### PR TITLE
feat(approval): RA-1b curated role vocabulary — publish+dry-run hard gate, dedicated formula-roles picker, curated freeze

### DIFF
--- a/apps/web/src/approvals/useApprovalDirectory.ts
+++ b/apps/web/src/approvals/useApprovalDirectory.ts
@@ -113,6 +113,10 @@ export function useApprovalDirectory({ apiFetch = defaultApiFetch }: UseApproval
     }
   }
 
+  // TODO(RA-1b FE): this loads ALL roles for the SHARED static_role approver picker (correct — static_role is
+  // NOT curated). When a DEDICATED formula `requester.role` picker is added, point it at the curated endpoint
+  // `GET /api/approval-templates/directory/formula-roles` (approval_usable=true only). The BE publish + dry-run
+  // HARD GATE already enforces curation regardless, so this is convenience, not the security boundary.
   async function loadRoles(): Promise<void> {
     rolesLoading.value = true
     statusMessage.value = ''

--- a/docs/design/approval-requester-role-ra1b-design-lock-20260627.md
+++ b/docs/design/approval-requester-role-ra1b-design-lock-20260627.md
@@ -1,6 +1,6 @@
 # RA-1b requester.role membership — Design Lock
 
-> Status: **RATIFIED — RUNTIME NOT BUILT** (build after `requester.title`). Provenance + vocabulary decided (owner 2026-06-27); the runtime is the next gated slice. Schema verified on `origin/main`.
+> Status: **RATIFIED — RUNTIME SHIPPED + CURATED-VOCABULARY ENFORCED**. Provenance + vocabulary decided (owner 2026-06-27); the `in`-grammar runtime + role resolver shipped (merged on `origin/main`); the curated-vocabulary enforcement (this slice, 2026-06-27) closes D-role-vocabulary. Schema verified on `origin/main`.
 
 ## Facts
 - `directory_accounts` has **NO** first-class role/position column. A DingTalk `role_list` may sit unextracted in `directory_accounts.raw` — **NOT a v1 source**.
@@ -19,4 +19,53 @@
 4. **Guard + tests**: wedge guard for `requester.role`; evaluator + resolver + round-trip + `in`-grammar unit tests.
 
 ## Sequence
-`requester.title` first (cheaper, no grammar) → then RA-1b role.
+`requester.title` first (cheaper, no grammar) → then RA-1b role → **then RA-1b CURATED-VOCABULARY enforcement (below)**.
+
+---
+
+## CURATED-VOCABULARY ENFORCEMENT (owner SHARP boundary correction, 2026-06-27) — SHIPPED
+
+The shipped role runtime exposed **every** RBAC role to `requester.role in [...]`, so an author could route on
+`admin`/system roles — violating ratified **D-role-vocabulary** ("approval-curated subset", §Decisions). The
+following enforcement closes that gap. Each piece is fail-closed and independent of any picker.
+
+### Curated source (the ONE source of truth)
+- **`roles.approval_usable boolean NOT NULL DEFAULT false`** (migration `zzzz20260627150000_add_approval_usable_to_roles`,
+  idempotent/`checkColumnExists`-guarded). **Secure-by-default**: every existing role — including `admin`/system —
+  is excluded until an administrator explicitly opts it in.
+- **Curated set = `SELECT id FROM roles WHERE approval_usable = true`** (`fetchCuratedApprovalRoleIds`).
+
+### The HARD GATE — publish + dry-run (independent of any picker)
+- **Publish** (`ApprovalProductService.publishTemplate` → `validateApprovalConditionFormulasAgainstFormSchema`):
+  AFTER schema validation, `extractRequesterRoleLiterals(expression)` is checked against the curated set; any
+  uncurated literal throws `ServiceError(400, 'APPROVAL_REQUESTER_ROLE_NOT_CURATED')`. The curated set is fetched
+  ONCE per publish (transaction client), only when the graph routes on `requester.role`. This is THE security
+  boundary — drafts may be authored, but a graph routing on an uncurated role can never be PUBLISHED.
+- **Dry-run** (`POST /api/approval-templates/formula-condition/dry-run`) runs the SAME curated check (same code,
+  `success:false`) so preview and publish never diverge.
+- **`extractRequesterRoleLiterals`** walks the AST for `membership` nodes (attr `role`), incl. nesting inside
+  `AND`/`OR`/`NOT`; returns the unique union, `[]` on parse error / non-role formulas.
+
+### Formula `requester.role` vs `static_role` — distinct pickers
+- Curation scopes **ONLY** the formula `requester.role` vocabulary, **NOT** `static_role` approver selection.
+- `listDirectoryRoles` (`GET …/directory/roles`) is the SHARED author picker — it ALSO backs `static_role` —
+  and is **UNCHANGED** (returns ALL roles).
+- A **DEDICATED** `listFormulaConditionRoles` (`GET …/directory/formula-roles`) returns ONLY `approval_usable=true`.
+  *(FE follow-up: wire the formula-condition role picker to the new endpoint; the BE endpoint + publish gate are
+  the security must-haves and are shipped.)*
+
+### Curated-freeze (resolver)
+- `resolveApprovalRequesterRoleIds` INNER-JOINs `roles` and keeps ONLY `approval_usable = true`
+  (`JOIN roles r ON r.id = ur.role_id … AND r.approval_usable = true`), so a SYSTEM role the requester holds can
+  never enter `requester_snapshot.directoryRoles`. Dedup / trim / order preserved; still THROWS on read failure.
+
+### Genuine-empty → DEFAULT (role is a PREDICATE, not a routing key)
+- A requester with **zero curated roles** must route to the condition's **DEFAULT edge** (membership = false),
+  **NOT** be 422-rejected. Consequences:
+  - `directoryRoles` is **ALWAYS frozen as an array, including `[]`** (never omitted) at create, and threaded as
+    `[]` (not `null`) at create + both dispatch sites — so dispatch evaluates membership to `false`, not fail-closed.
+  - The create-time role wedge guard rejects **only** a TRANSIENT read failure
+    (`roleReadFailed → 503 APPROVAL_REQUESTER_ROLE_UNRESOLVED`); the genuine-empty **422 is REMOVED**.
+  - `evaluateRequesterMembership` keeps: `null`/`undefined` context → fail (truly unthreaded); `[]` → `false`.
+  - **Department / title are UNCHANGED** — they are routing KEYS and keep their reject-on-absence (422/503).
+

--- a/docs/development/approval-ra1b-curated-vocabulary-dev-verification-20260627.md
+++ b/docs/development/approval-ra1b-curated-vocabulary-dev-verification-20260627.md
@@ -1,0 +1,58 @@
+# RA-1b curated-vocabulary enforcement — development & verification (2026-06-27)
+
+> Follow-up to #3309 (RA-1b `requester.role` grammar + fresh `user_roles` provenance, on `main`). Closes the **open** P1: the ratified **D-role-vocabulary** ("approval-curated subset of RBAC roles") was decided but **not enforced** — an author could route `requester.role in ["admin"]` on a system role. Branch `claude/approval-ra1b-curated-vocab-20260627`. Design lock: `docs/design/approval-requester-role-ra1b-design-lock-20260627.md` (status → RUNTIME SHIPPED + CURATED-VOCABULARY ENFORCED).
+
+## 1. Problem
+The shipped `requester.role in [...]` runtime exposed **every** RBAC role: the resolver froze all `user_roles`, the author picker listed all roles, and publish did **zero** literal validation. An author could therefore route on `admin`/system roles — contradicting the owner decision *"do not expose system/admin roles to approval-formula authors."*
+
+## 2. Design (owner-corrected — the SHARP boundary correction)
+- **Curated source** — new `roles.approval_usable boolean NOT NULL DEFAULT false` (secure-by-default; every role, incl. admin, excluded until an admin opts it in).
+- **PUBLISH is the hard gate** — `requester.role in [uncurated literal]` is rejected at graph-validation (`APPROVAL_REQUESTER_ROLE_NOT_CURATED`, 400), **independent of any picker**. An author-side picker may filter, but must not be the only gate.
+- **DRY-RUN shares the same check** — no "preview-passes / publish-fails" divergence.
+- **Boundary precision (owner P1)** — do **NOT** narrow the shared `listDirectoryRoles` picker: it also serves **`static_role` approver selection** (`useApprovalDirectory.loadRoles()`). Curation scopes **only** the formula `requester.role`, not static-role assignee nodes. → a **dedicated** `formula-roles` endpoint returns curated-only; `static_role` keeps the full catalog.
+- **Curated-freeze** — the resolver returns only the requester's curated roles, so system roles never enter `requester_snapshot.directoryRoles`.
+- **Genuine-empty → DEFAULT** — `role` is a routing *predicate*, not a *key*: a requester with zero curated roles routes to the condition's default edge (membership = false), **not** a 422 reject; only a transient `user_roles` read failure → 503. (Department/title remain routing keys and keep reject-on-absence.)
+
+## 3. Implementation
+- **Migration** `zzzz20260627150000_add_approval_usable_to_roles.ts` — `roles.approval_usable boolean NOT NULL DEFAULT false`; idempotent (`checkTableExists` + `checkColumnExists`), reversible `down`.
+- **Curated source** (`approval-directory.ts`) — `fetchCuratedApprovalRoleIds(queryFn?)` = `SELECT id FROM roles WHERE approval_usable = true` (trim/blank-strip → `Set`). Accepts a transaction-scoped query fn (publish) or defaults to the pooled `query` (dry-run).
+- **Literal extraction** (`ApprovalConditionFormula.ts`) — `extractRequesterRoleLiterals(expression)` parses to the AST and walks `membership`/`unary`/`binary`/`compare` nodes, collecting the unique role-id literals of every `requester.role in [...]` (incl. nested in AND/OR/NOT). `[]` on parse error / non-role formulas. *(There is no `paren`/`group` AST node — parens flatten during parsing; `aggregate` is a leaf — so no membership-containing node is unreachable: the walk cannot be bypassed by parenthesising or nesting.)*
+- **Publish hard gate** (`ApprovalProductService.publishTemplate` → `validateApprovalConditionFormulasAgainstFormSchema`) — accepts an optional `curatedRoleIds: ReadonlySet<string> | null`; fetched **once per publish** on the transaction client, and only when `runtimeGraphUsesRequesterAttribute(graph, 'role')`. For each condition branch, any `extractRequesterRoleLiterals` literal **not** in the curated set throws `ServiceError(400, 'APPROVAL_REQUESTER_ROLE_NOT_CURATED')` — placed **outside** the schema-validation try/catch so the 400 is not re-wrapped as a 500 graph-invalid. `createTemplate`/`updateTemplate` pass `null` (drafts are not the gate).
+- **Dry-run** (`routes/approvals.ts`) — runs the identical curated check before evaluation; uncurated literal → `success:false / APPROVAL_REQUESTER_ROLE_NOT_CURATED`. Skips the DB read entirely when the formula has no role literals.
+- **Dedicated picker endpoint** — `GET /api/approval-templates/directory/formula-roles` → `listFormulaConditionRoles()` (curated-only), gated `authenticate` + `rbacGuard('approval-templates:manage')`. **`listDirectoryRoles` / `GET …/directory/roles` is untouched** (still ALL roles, for static_role).
+- **Curated-freeze resolver** (`ApprovalRequesterRoles.ts`) — `resolveApprovalRequesterRoleIds` now `INNER JOIN roles r ON r.id = ur.role_id … AND r.approval_usable = true`; a system role the requester holds can never enter the snapshot. Still throws on read failure (for the 503).
+- **Genuine-empty semantics** (`ApprovalProductService.ts`) — `directoryRoles` is **always** frozen as an array including `[]` (never omitted); `requesterContext.roles` threads `[]` (not `null`) at create + both dispatch sites; the create-time role wedge guard now rejects **only** a transient read failure (503), the genuine-empty **422 is removed**.
+- **Frontend** (`useApprovalDirectory.ts`) — `loadRoles()` is **byte-unchanged** (still `/directory/roles`, all roles, for the static_role picker); only a TODO documents that a future dedicated formula-condition picker should point at `/directory/formula-roles`, and that the BE gate is the security boundary regardless. *(The dedicated FE picker is a non-security UX follow-up; the BE endpoint + publish/dry-run gate are the must-haves and are shipped.)*
+
+## 4. Verification (independent, on the real dev DB)
+**Three boundary properties — all proven, not just inspected:**
+1. **No publish bypass.** Real-DB test *"FAILS publish when a requester.role literal is UNCURATED (APPROVAL_REQUESTER_ROLE_NOT_CURATED)"* ✓. Static analysis: `publishTemplate` is the **sole** producer of the published/active definition (`SET status='published', active_version_id=$1` — the only `'published'` writes in the service); instance creation requires `status==='published'`; `createTemplate`/`updateTemplate` only mutate drafts. The AST extractor reaches every membership node (parens flatten, `aggregate` is a leaf). So an uncurated literal cannot reach runtime by any path.
+2. **`static_role` picker intact.** Real-DB tests *"/directory/formula-roles returns ONLY approval_usable roles"* ✓ **and** *"/directory/roles is UNCHANGED — still returns ALL roles"* ✓. BE diff appends new functions (no edit to `listDirectoryRoles`); FE `loadRoles()` byte-unchanged.
+3. **Genuine-empty → DEFAULT.** Real-DB test *"a requester with ZERO curated roles routes to the DEFAULT edge (NOT a 422 reject)"* ✓ (a requester holding only an uncurated role → curated set `[]` → membership false → default).
+
+**Suites (worktree, run by me):**
+- **Unit 175/175** — `approval-condition-formula` + `approval-product-service` + `approval-rbac-boundary` (incl. *dry-run rejects an UNCURATED requester.role literal — preview matches publish*) + `approval-requester-roles` + `approval-graph-executor`.
+- **Real-DB / API 19/19, 0 skipped** — `approval-requester-role.db.test.ts` (4: sentinel + freeze-from-user_roles round-trip + uncurated-publish-fails + zero-curated→default) and `approval-directory-endpoints.api.test.ts` (incl. formula-roles curated / roles-unchanged / 403 non-manager / least-privilege). The **`DATABASE_URL`-set sentinel** guards against the silent-skip trap — the suites executed against the migrated dev DB, they did not skip.
+- **tsc** clean (0 errors) — incl. the `runtimeGraphUsesRequesterAttribute` param widening (`RuntimeGraph` → `ApprovalGraph`) and the transaction-client `client.query.bind(client)`.
+- **Migration exercised independently** — the DB suites get the column from their own `ADD COLUMN IF NOT EXISTS` bootstrap, so the migration file itself was proven separately: ran the real runner (`tsx src/db/migrate.ts`) against a scratch DB → `zzzz20260627150000` applied last in the chain (correct ordering) yielding `approval_usable | NOT NULL | DEFAULT false`; `rollback` then dropped it cleanly (`down()` proven).
+
+## 5. Invariants — CONFIRMED
+- An uncurated/admin `requester.role` literal can **never** be published or pass dry-run (proven; secure-by-default column). ✓
+- `static_role` approver selection is **unaffected** — `/directory/roles` + `loadRoles()` still return all roles. ✓
+- A system role the requester holds **never** enters `requester_snapshot.directoryRoles` (INNER-JOIN curated freeze). ✓
+- Zero curated roles routes to **default**, not a 422; only a transient read failure fails closed (503). Department/title (routing keys) keep reject-on-absence. ✓
+- New `roles.approval_usable` is secure-by-default (`NOT NULL DEFAULT false`); migration idempotent + reversible. ✓
+
+## 6. Deploy preflight — secure-by-default is a behavior change (REQUIRED before prod deploy)
+`approval_usable` defaults to **false** for every existing role. So any **already-published** template that routes on `requester.role` will, for **new** instances created after deploy, freeze a curated set of `[]` and route those branches to **DEFAULT** until an admin sets `approval_usable = true` on the intended roles. (In-flight instances keep their already-frozen roles — not retroactively re-curated.) RA-1b role-routing is only days old (#3309), so the expected count is ~0, but **verify on prod before deploy**:
+
+```sql
+SELECT count(*) AS active_defs_routing_on_role
+FROM approval_published_definitions
+WHERE is_active = true AND runtime_graph::text LIKE '%requester.role%';
+```
+If > 0: in the **same deploy**, set `approval_usable = true` on the roles those templates route on, or routing flips to DEFAULT under them. (Illustrative run on the dev test DB returned 0.) Fail-safe direction either way: an unset/uncurated role degrades to DEFAULT, never to a wrong-but-confident route.
+
+## 7. Deliberately deferred (NOT silently dropped)
+- **FE dedicated formula-condition role picker** — wire a curated picker to `/directory/formula-roles`. Non-security UX (BE gate already enforces); documented TODO in `useApprovalDirectory.ts`.
+- Decision-gated remainder (unchanged from #3309 MD): `requester.level`, W7 rejection/cross-base backwrite, amount enhancements, canvas polish — each needs an owner call.

--- a/packages/core-backend/src/db/migrations/zzzz20260627150000_add_approval_usable_to_roles.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260627150000_add_approval_usable_to_roles.ts
@@ -1,0 +1,40 @@
+import type { Kysely } from 'kysely'
+import { checkColumnExists, checkTableExists } from './_patterns'
+
+/**
+ * RA-1b CURATED-VOCABULARY: the curated source for `requester.role in [...]` approval routing.
+ *
+ * `roles.approval_usable` is the SINGLE source of truth for which RBAC roles an author may route on in a
+ * formula condition. Secure-by-default: `NOT NULL DEFAULT false`, so EVERY existing role (incl. admin /
+ * system roles) is excluded until an administrator explicitly opts it in. The curated set is
+ * `SELECT id FROM roles WHERE approval_usable = true`, enforced at publish + dry-run and used to freeze
+ * only curated roles into the requester snapshot.
+ *
+ * Idempotent: guarded by checkTableExists + checkColumnExists so re-runs (and environments where `roles`
+ * has not yet been created) are no-ops.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const rolesExists = await checkTableExists(db, 'roles')
+  if (!rolesExists) return
+
+  const hasApprovalUsable = await checkColumnExists(db, 'roles', 'approval_usable')
+  if (!hasApprovalUsable) {
+    await db.schema
+      .alterTable('roles')
+      .addColumn('approval_usable', 'boolean', (col) => col.notNull().defaultTo(false))
+      .execute()
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const rolesExists = await checkTableExists(db, 'roles')
+  if (!rolesExists) return
+
+  const hasApprovalUsable = await checkColumnExists(db, 'roles', 'approval_usable')
+  if (hasApprovalUsable) {
+    await db.schema
+      .alterTable('roles')
+      .dropColumn('approval_usable')
+      .execute()
+  }
+}

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -24,13 +24,19 @@ import {
   ApprovalConditionFormulaError,
   assertApprovalConditionFormulaValidForSchema,
   evaluateApprovalConditionFormula,
+  extractRequesterRoleLiterals,
 } from '../services/ApprovalConditionFormula'
 import {
   APPROVAL_ERROR_CODES,
   type ApprovalBridgePlmAdapter,
 } from '../services/approval-bridge-types'
 import { publishApprovalCountsUpdate } from '../services/approval-realtime'
-import { searchDirectoryUsers, listDirectoryRoles } from '../services/approval-directory'
+import {
+  searchDirectoryUsers,
+  listDirectoryRoles,
+  listFormulaConditionRoles,
+  fetchCuratedApprovalRoleIds,
+} from '../services/approval-directory'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 import { createDelegation, listDelegations, disableDelegation, updateDelegation } from '../services/ApprovalDelegationConfig'
 import type { FormSchema } from '../types/approval-product'
@@ -371,6 +377,19 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
+  // RA-1b CURATED-VOCABULARY — DEDICATED formula-condition role picker. Returns ONLY roles with
+  // approval_usable=true (the curated set the publish/dry-run HARD GATE enforces). Distinct from
+  // /directory/roles, which is the shared author picker that ALSO serves static_role approver selection and
+  // intentionally returns ALL roles. Curating only requester.role (NOT static_role) is the ratified scope.
+  r.get('/api/approval-templates/directory/formula-roles', authenticate, rbacGuard('approval-templates:manage'), async (_req: Request, res: Response) => {
+    try {
+      const roles = await listFormulaConditionRoles()
+      res.json({ roles })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DIRECTORY_FORMULA_ROLES_FAILED', 'Failed to list formula-condition roles')
+    }
+  })
+
   // FC-4 — approval-specific formula-condition dry-run. This intentionally uses the
   // exact approval evaluator from publish/execution and stays separate from the
   // sheet-scoped multitable formula dry-run API.
@@ -395,6 +414,27 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         return res.status(400).json(
           approvalErrorResponse('APPROVAL_FORMULA_DRY_RUN_INVALID_REQUEST', 'formData object is required'),
         )
+      }
+
+      // RA-1b CURATED-VOCABULARY — run the SAME curated gate as publish so preview and publish never
+      // diverge: any `requester.role in [...]` literal not in the curated set (roles.approval_usable=true)
+      // is rejected as success:false / APPROVAL_REQUESTER_ROLE_NOT_CURATED. Skip the DB read entirely when
+      // the formula has no role literals. A curated-set read failure surfaces via the outer catch (500).
+      const roleLiterals = extractRequesterRoleLiterals(expression)
+      if (roleLiterals.length > 0) {
+        const curated = await fetchCuratedApprovalRoleIds()
+        const uncurated = roleLiterals.filter((roleId) => !curated.has(roleId))
+        if (uncurated.length > 0) {
+          return res.json({
+            data: {
+              success: false,
+              error: {
+                code: 'APPROVAL_REQUESTER_ROLE_NOT_CURATED',
+                message: `requester.role routes on role(s) not approved for approval routing: ${uncurated.join(', ')}`,
+              },
+            },
+          })
+        }
       }
 
       try {

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -554,6 +554,53 @@ export function formulaReferencesRequesterAttribute(expression: string, attr: st
   return astReferencesRequesterAttribute(ast, attr)
 }
 
+/** Collect every role-id string literal used by a `requester.role in [...]` membership node anywhere in
+ *  the formula (including nested inside AND/OR/NOT). Walks the parsed AST, so a string literal like
+ *  "admin" appearing as a comparison operand — not inside a role membership array — is NOT collected.
+ *  Mirrors `formulaReferencesRequesterAttribute`: returns `[]` on a parse error or when there is no role
+ *  membership. The returned list is the UNIQUE union of all role literals (order-preserving). */
+function astRequesterRoleLiterals(ast: FormulaAst, out: string[], seen: Set<string>): void {
+  switch (ast.kind) {
+    case 'membership':
+      if (ast.attr in ROLE_REQUESTER_ATTRS) {
+        for (const element of ast.elements) {
+          if (!seen.has(element)) {
+            seen.add(element)
+            out.push(element)
+          }
+        }
+      }
+      return
+    case 'unary':
+      astRequesterRoleLiterals(ast.expr, out, seen)
+      return
+    case 'binary':
+    case 'compare':
+      astRequesterRoleLiterals(ast.left, out, seen)
+      astRequesterRoleLiterals(ast.right, out, seen)
+      return
+    default:
+      return
+  }
+}
+
+/** RA-1b CURATED-VOCABULARY: extract the unique role-id literals an expression routes on via
+ *  `requester.role in [...]`. The HARD GATE (publish + dry-run) feeds these into the curated-set check so
+ *  an author can never route on an uncurated (e.g. admin/system) role. `[]` for non-role formulas and for
+ *  a parse error (callers either re-validate elsewhere or treat an unparseable formula as routing on
+ *  nothing). */
+export function extractRequesterRoleLiterals(expression: string): string[] {
+  let ast: FormulaAst
+  try {
+    ast = parseFormula(expression)
+  } catch {
+    return []
+  }
+  const out: string[] = []
+  astRequesterRoleLiterals(ast, out, new Set<string>())
+  return out
+}
+
 function formFieldTypeToFormulaType(field: FormField): FormulaType | 'unsupported' {
   switch (field.type) {
     case 'number':

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -47,11 +47,13 @@ import { validateAmountTotalConsistency } from './amount-total-check'
 import {
   ApprovalConditionFormulaError,
   assertApprovalConditionFormulaValidForSchema,
+  extractRequesterRoleLiterals,
   formulaReferencesRequesterAttribute,
   parseApprovalConditionFormula,
 } from './ApprovalConditionFormula'
 import { resolveApprovalRequesterOrgRelations, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
 import { resolveApprovalRequesterRoleIds } from './ApprovalRequesterRoles'
+import { fetchCuratedApprovalRoleIds } from './approval-directory'
 import { resolveActiveDelegationMap } from './ApprovalDelegations'
 import type {
   ApprovalAssignmentDTO,
@@ -494,6 +496,11 @@ function validateApprovalConditionFormulasAgainstFormSchema(
   approvalGraph: ApprovalGraph,
   formSchema: FormSchema,
   context: ValidationContext,
+  // RA-1b CURATED-VOCABULARY: when supplied (publish HARD GATE), every `requester.role in [...]` literal
+  // MUST be in this curated set (roles.approval_usable=true). `null` (create/update draft authoring) skips
+  // the curated check — publish is the hard gate, not draft-save. The curated set is fetched ONCE per
+  // publish by the caller.
+  curatedRoleIds: ReadonlySet<string> | null = null,
 ): void {
   for (const node of approvalGraph.nodes) {
     if (node.type !== 'condition') continue
@@ -502,14 +509,27 @@ function validateApprovalConditionFormulasAgainstFormSchema(
 
     config.branches.forEach((branch, branchIndex) => {
       if (!isRecord(branch) || !isRecord(branch.formula) || typeof branch.formula.expression !== 'string') return
+      const expression = branch.formula.expression
       try {
-        assertApprovalConditionFormulaValidForSchema(branch.formula.expression, formSchema)
+        assertApprovalConditionFormulaValidForSchema(expression, formSchema)
       } catch (error) {
         const message = error instanceof ApprovalConditionFormulaError ? error.message : String(error)
         failValidation(
           context,
           `approvalGraph node ${node.key} condition formula branch ${branchIndex + 1} is invalid: ${message}`,
         )
+      }
+      // OUTSIDE the try/catch above: a NOT_CURATED rejection must keep its own 400 code, not be
+      // re-wrapped by failValidation's context (e.g. 500 GRAPH_INVALID at publish). Throws directly.
+      if (curatedRoleIds) {
+        const uncurated = extractRequesterRoleLiterals(expression).filter((roleId) => !curatedRoleIds.has(roleId))
+        if (uncurated.length > 0) {
+          throw new ServiceError(
+            `approvalGraph node ${node.key} condition formula branch ${branchIndex + 1} routes on role(s) not approved for approval routing: ${uncurated.join(', ')}`,
+            400,
+            'APPROVAL_REQUESTER_ROLE_NOT_CURATED',
+          )
+        }
       }
     })
   }
@@ -1775,7 +1795,7 @@ export function runtimeGraphUsesManagerChain(runtimeGraph: RuntimeGraph): boolea
  * such a condition exists, rather than freezing an absent attribute that would wedge every later approval
  * at the condition (the snapshot is frozen; admin-cancel only).
  */
-export function runtimeGraphUsesRequesterAttribute(runtimeGraph: RuntimeGraph, attr: string): boolean {
+export function runtimeGraphUsesRequesterAttribute(runtimeGraph: ApprovalGraph, attr: string): boolean {
   return runtimeGraph.nodes.some((node) => {
     if (node.type !== 'condition') return false
     const config: unknown = node.config
@@ -2619,7 +2639,13 @@ export class ApprovalProductService {
       const approvalGraph = asApprovalGraph(version.approval_graph)
       validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
-      validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
+      // RA-1b CURATED-VOCABULARY — THE HARD GATE. Only when the graph actually routes on requester.role do
+      // we fetch the curated set (one read, on this transaction client) and reject any uncurated literal at
+      // publish. Independent of any picker, so an author can never publish a route on an admin/system role.
+      const curatedRoleIds = runtimeGraphUsesRequesterAttribute(approvalGraph, 'role')
+        ? await fetchCuratedApprovalRoleIds(client.query.bind(client))
+        : null
+      validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT, curatedRoleIds)
       // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
       // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
       // placeholder role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.
@@ -2975,23 +3001,16 @@ export class ApprovalProductService {
       )
     }
 
-    // Same wedge guard for `requester.role` (membership routing). An unresolved role set on a role-routed
-    // condition downstream of an approval node would otherwise freeze an empty set into the snapshot and
-    // wedge every later approval at the condition; reject at create instead. Distinguish a thrown read
-    // (transient/infra -> 503, retryable) from a successful empty read (genuine row-level absence — the
-    // requester holds no roles -> 422). Only fires when the graph actually routes on requester.role.
-    if (needsRequesterRoles && requesterRoleIds.length === 0) {
-      if (roleReadFailed) {
-        throw new ServiceError(
-          'Could not resolve the requester roles required by this approval template. Please retry.',
-          503,
-          'APPROVAL_REQUESTER_ROLE_UNRESOLVED',
-        )
-      }
+    // RA-1b CURATED-VOCABULARY — role is a PREDICATE, not a routing key. Unlike department/title (above),
+    // a GENUINE-EMPTY curated role set is NOT rejected: it freezes `[]`, intersects nothing, and routes to
+    // the condition's DEFAULT edge (membership = false). The ONLY fail-closed cause here is a TRANSIENT read
+    // FAILURE — which would otherwise freeze a phantom-empty set under a real-but-unreadable membership and
+    // silently mis-route to default. Reject that (503, retryable); never the genuine-empty case.
+    if (needsRequesterRoles && roleReadFailed) {
       throw new ServiceError(
-        'This approval template routes on the requester roles, which are not set for you. Contact an administrator.',
-        422,
-        'APPROVAL_REQUESTER_ROLE_REQUIRED',
+        'Could not resolve the requester roles required by this approval template. Please retry.',
+        503,
+        'APPROVAL_REQUESTER_ROLE_UNRESOLVED',
       )
     }
 
@@ -3021,7 +3040,10 @@ export class ApprovalProductService {
       department: actor.department,
       ...(orgRelations.primaryDepartmentName ? { directoryDepartment: orgRelations.primaryDepartmentName } : {}),
       ...(orgRelations.primaryTitle ? { directoryTitle: orgRelations.primaryTitle } : {}),
-      ...(requesterRoleIds.length > 0 ? { directoryRoles: requesterRoleIds } : {}),
+      // RA-1b CURATED-VOCABULARY — FREEZE directoryRoles ALWAYS as an array, INCLUDING `[]`. Genuine-empty is
+      // a valid predicate state (routes to DEFAULT), so it must NOT be omitted: an omitted field would thread
+      // null at dispatch and fail-closed at eval instead of evaluating membership to false.
+      directoryRoles: requesterRoleIds,
       roles: actor.roles || [],
       permissions: actor.permissions || [],
       ...(orgRelations.managerId ? { managerId: orgRelations.managerId } : {}),
@@ -3038,7 +3060,8 @@ export class ApprovalProductService {
       requesterContext: {
         department: requesterSnapshot.directoryDepartment ?? null,
         title: requesterSnapshot.directoryTitle ?? null,
-        roles: requesterSnapshot.directoryRoles ?? null,
+        // RA-1b: thread `[]` (not null) — genuine-empty curated roles → membership false → DEFAULT route.
+        roles: requesterSnapshot.directoryRoles ?? [],
       },
     })
     const instanceId = crypto.randomUUID()
@@ -3281,7 +3304,7 @@ export class ApprovalProductService {
         requesterContext: ((d, t, r) => ({
           department: typeof d === 'string' && d ? d : null,
           title: typeof t === 'string' && t ? t : null,
-          roles: Array.isArray(r) ? r.filter((role): role is string => typeof role === 'string') : null,
+          roles: Array.isArray(r) ? r.filter((role): role is string => typeof role === 'string') : [],
         }))(requesterSnapshot?.directoryDepartment, requesterSnapshot?.directoryTitle, requesterSnapshot?.directoryRoles),
       })
       const jumpResolution = executor.resolveReturnToNode(targetNodeKey)
@@ -3451,7 +3474,7 @@ export class ApprovalProductService {
         requesterContext: ((d, t, r) => ({
           department: typeof d === 'string' && d ? d : null,
           title: typeof t === 'string' && t ? t : null,
-          roles: Array.isArray(r) ? r.filter((role): role is string => typeof role === 'string') : null,
+          roles: Array.isArray(r) ? r.filter((role): role is string => typeof role === 'string') : [],
         }))(requesterSnapshot?.directoryDepartment, requesterSnapshot?.directoryTitle, requesterSnapshot?.directoryRoles),
       })
       const storedCurrentNodeKey = instance.current_node_key

--- a/packages/core-backend/src/services/ApprovalRequesterRoles.ts
+++ b/packages/core-backend/src/services/ApprovalRequesterRoles.ts
@@ -1,5 +1,5 @@
 /**
- * Approval ↔ requester ROLE resolution (READ-ONLY) — RA-1b.
+ * Approval ↔ requester ROLE resolution (READ-ONLY) — RA-1b CURATED-VOCABULARY.
  *
  * `requester.role in [...]` routes on the requester's CURRENT role membership, resolved by a FRESH
  * `user_roles` SELECT at create time — deliberately NOT the login-time token-claim `roles` carried on the
@@ -7,25 +7,36 @@
  * `requester_snapshot.directoryRoles` at create and reloaded at dispatch, exactly like the directory
  * department/title snapshot fields, so routing is deterministic and tamper-resistant.
  *
- * BOUNDARY: this is a single read-only `SELECT role_id FROM user_roles` — it lives OUTSIDE
+ * CURATED-ONLY (RA-1b vocabulary lock): the resolver INNER-JOINs `roles` and keeps ONLY roles with
+ * `approval_usable = true`, so a SYSTEM/admin role the requester happens to hold can NEVER enter
+ * `directoryRoles`. `role` is a routing PREDICATE, not a key: a requester with zero CURATED roles freezes
+ * `[]`, intersects nothing, and routes to the condition's DEFAULT edge (membership = false) — it is NOT
+ * rejected. Only a transient read FAILURE fails the create closed (503).
+ *
+ * BOUNDARY: this is a single read-only `SELECT … FROM user_roles JOIN roles` — it lives OUTSIDE
  * `ApprovalDirectoryOrg` (which is CI-boundary-locked to `directory_*` SELECTs) precisely because
- * `user_roles` is an RBAC table, not a directory table. It writes nothing and touches no `approval_*`
- * table.
+ * `user_roles` / `roles` are RBAC tables, not directory tables. It writes nothing and touches no
+ * `approval_*` table.
  */
 
 type QueryFn = <Row>(text: string, params?: unknown[]) => Promise<{ rows: Row[] }>
 
 /**
- * Resolve the requester's role-id set from `user_roles` (deduped, blank-stripped, order-preserving).
- * Returns `[]` for a blank user id or a user with no roles. THROWS on a read failure — the caller
- * distinguishes a thrown read (transient → 503) from a successful empty read (genuine absence → 422) in
- * the create-time wedge guard, mirroring the directory department/title split.
+ * Resolve the requester's CURATED role-id set from `user_roles` JOIN `roles` where `approval_usable = true`
+ * (deduped, blank-stripped, order-preserving). Returns `[]` for a blank user id, a user with no roles, or a
+ * user whose roles are all uncurated. THROWS on a read failure — the caller treats a thrown read as
+ * transient (→ 503) while a successful empty read is a GENUINE-EMPTY predicate (→ DEFAULT route), mirroring
+ * the directory department/title read but NOT their reject-on-absence (those are routing keys; role is a
+ * predicate).
  */
 export async function resolveApprovalRequesterRoleIds(localUserId: string, query: QueryFn): Promise<string[]> {
   const userId = localUserId.trim()
   if (!userId) return []
   const rows = await query<{ role_id: string | null }>(
-    `SELECT role_id FROM user_roles WHERE user_id = $1`,
+    `SELECT ur.role_id
+       FROM user_roles ur
+       JOIN roles r ON r.id = ur.role_id
+      WHERE ur.user_id = $1 AND r.approval_usable = true`,
     [userId],
   )
   const roles: string[] = []

--- a/packages/core-backend/src/services/approval-directory.ts
+++ b/packages/core-backend/src/services/approval-directory.ts
@@ -61,3 +61,38 @@ export async function listDirectoryRoles(): Promise<DirectoryRoleOption[]> {
   )
   return result.rows.map((row) => ({ id: row.id, name: row.name ?? '' }))
 }
+
+/**
+ * RA-1b CURATED-VOCABULARY: list ONLY the roles an author may route on in a formula `requester.role in
+ * [...]` condition — i.e. `approval_usable = true`. This is the DEDICATED formula-condition role picker,
+ * distinct from `listDirectoryRoles` (which serves static_role approver selection and returns ALL roles).
+ * The publish/dry-run HARD GATE re-validates against the same curated set, so the picker is convenience,
+ * not the security boundary.
+ */
+export async function listFormulaConditionRoles(): Promise<DirectoryRoleOption[]> {
+  const result = await query<{ id: string; name: string }>(
+    `SELECT r.id, r.name FROM roles r WHERE r.approval_usable = true ORDER BY r.id ASC`,
+  )
+  return result.rows.map((row) => ({ id: row.id, name: row.name ?? '' }))
+}
+
+/** QueryFn shape so the publish HARD GATE can fetch the curated set on its OWN transaction client (one read
+ *  per publish), while the dry-run route uses the default pooled `query`. */
+type CuratedQueryFn = <Row>(text: string, params?: unknown[]) => Promise<{ rows: Row[] }>
+
+/**
+ * RA-1b CURATED-VOCABULARY: the curated set of role ids approved for formula `requester.role` routing —
+ * `SELECT id FROM roles WHERE approval_usable = true`. This is THE source of truth for the publish + dry-run
+ * HARD GATE (independent of any picker). Pass a transaction-scoped query fn at publish; defaults to the
+ * pooled `query` for the dry-run route.
+ */
+export async function fetchCuratedApprovalRoleIds(queryFn?: CuratedQueryFn): Promise<Set<string>> {
+  const run: CuratedQueryFn = queryFn ?? (query as unknown as CuratedQueryFn)
+  const result = await run<{ id: string }>(`SELECT id FROM roles WHERE approval_usable = true`, [])
+  const curated = new Set<string>()
+  for (const row of result.rows) {
+    const id = typeof row.id === 'string' ? row.id.trim() : ''
+    if (id) curated.add(id)
+  }
+  return curated
+}

--- a/packages/core-backend/tests/integration/approval-directory-endpoints.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-directory-endpoints.api.test.ts
@@ -32,7 +32,8 @@ const NON = `${PREFIX}-non`
 const ALICE = `${PREFIX}-alice`
 const BOB = `${PREFIX}-bob`
 const CAROL = `${PREFIX}-carol`
-const ROLE = `${PREFIX}-role`
+const ROLE = `${PREFIX}-role` // UNCURATED (approval_usable defaults false)
+const ROLE_CURATED = `${PREFIX}-role-curated` // RA-1b: approval_usable=true
 
 async function canListenOnEphemeralPort(): Promise<boolean> {
   return await new Promise((resolve) => {
@@ -78,7 +79,15 @@ describeIfDatabase('approval directory endpoints (P1-static-picker backend, real
     await seedUser(BOB, 'ZmarkerQ Bob')
     await seedUser(CAROL, 'Zzz Other Person')
     try {
+      // RA-1b: defensively ensure the curated column exists (whether or not the migration ran in this lane),
+      // then seed an UNCURATED role (ROLE, default approval_usable=false) and a CURATED role (approval_usable=true).
+      await pool.query(`ALTER TABLE roles ADD COLUMN IF NOT EXISTS approval_usable boolean NOT NULL DEFAULT false`)
       await pool.query(`INSERT INTO roles (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`, [ROLE, 'Dirpick Role'])
+      await pool.query(
+        `INSERT INTO roles (id, name, approval_usable) VALUES ($1, $2, true)
+         ON CONFLICT (id) DO UPDATE SET approval_usable = true`,
+        [ROLE_CURATED, 'Dirpick Curated Role'],
+      )
       roleSeeded = true
     } catch {
       roleSeeded = false
@@ -99,7 +108,7 @@ describeIfDatabase('approval directory endpoints (P1-static-picker backend, real
     const pool = poolManager.get()
     try {
       await pool.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [[ADMIN, NON, ALICE, BOB, CAROL]])
-      if (roleSeeded) await pool.query(`DELETE FROM roles WHERE id = $1`, [ROLE])
+      if (roleSeeded) await pool.query(`DELETE FROM roles WHERE id = ANY($1::text[])`, [[ROLE, ROLE_CURATED]])
     } catch {
       // ignore cleanup failures
     }
@@ -166,16 +175,50 @@ describeIfDatabase('approval directory endpoints (P1-static-picker backend, real
     }
   })
 
+  it('RA-1b: /directory/formula-roles returns ONLY approval_usable roles (curated vocabulary)', async () => {
+    const res = await get(baseUrl, '/api/approval-templates/directory/formula-roles', adminToken)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { roles: Array<{ id: string; name: string }> }
+    expect(Array.isArray(body.roles)).toBe(true)
+    if (roleSeeded) {
+      const ids = body.roles.map((r) => r.id)
+      expect(ids).toContain(ROLE_CURATED) // approval_usable=true → curated
+      expect(ids).not.toContain(ROLE) // approval_usable=false → excluded (secure-by-default)
+    }
+  })
+
+  it('RA-1b: /directory/roles is UNCHANGED — the shared author/static_role picker still returns ALL roles', async () => {
+    // The curated lock scopes ONLY formula requester.role; static_role approver selection (which shares this
+    // endpoint) must still see uncurated roles, otherwise the owner boundary would over-reach.
+    const res = await get(baseUrl, '/api/approval-templates/directory/roles', adminToken)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { roles: Array<{ id: string }> }
+    if (roleSeeded) {
+      const ids = body.roles.map((r) => r.id)
+      expect(ids).toContain(ROLE) // uncurated role STILL visible to the shared picker
+      expect(ids).toContain(ROLE_CURATED)
+    }
+  })
+
+  it('rejects a non-manager on /directory/formula-roles (403)', async () => {
+    const res = await get(baseUrl, '/api/approval-templates/directory/formula-roles', nonMgrToken)
+    expect(res.status).toBe(403)
+  })
+
   it('routes are gated by least-privilege approval-templates:manage, NOT ensurePlatformAdmin', () => {
     const src = readFileSync(path.resolve(__dirname, '../../src/routes/approvals.ts'), 'utf8')
     const lines = src.split('\n')
     const usersLine = lines.find((l) => l.includes("'/api/approval-templates/directory/users'"))
     const rolesLine = lines.find((l) => l.includes("'/api/approval-templates/directory/roles'"))
+    const formulaRolesLine = lines.find((l) => l.includes("'/api/approval-templates/directory/formula-roles'"))
     expect(usersLine).toBeTruthy()
     expect(rolesLine).toBeTruthy()
+    expect(formulaRolesLine).toBeTruthy()
     expect(usersLine).toContain("rbacGuard('approval-templates:manage')")
     expect(rolesLine).toContain("rbacGuard('approval-templates:manage')")
+    expect(formulaRolesLine).toContain("rbacGuard('approval-templates:manage')")
     expect(usersLine).not.toContain('ensurePlatformAdmin')
     expect(rolesLine).not.toContain('ensurePlatformAdmin')
+    expect(formulaRolesLine).not.toContain('ensurePlatformAdmin')
   })
 })

--- a/packages/core-backend/tests/integration/approval-requester-role.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-requester-role.db.test.ts
@@ -21,10 +21,12 @@ import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
 const REQ = `rrole-req-${TS}`
+const REQ_UNCURATED = `rrole-req-unc-${TS}` // holds ONLY an uncurated role → curated set is genuine-empty
 const APPROVER = `rrole-appr-${TS}`
 const FIN = `rrole-fin-${TS}`
 const OTHER = `rrole-oth-${TS}`
-const ROLE = `finance_approver-${TS}` // seeded into user_roles; MUST match the membership literal below
+const ROLE = `finance_approver-${TS}` // CURATED (approval_usable=true); MUST match the membership literal below
+const UNCURATED_ROLE = `system_admin-${TS}` // approval_usable=false — an author must NOT be able to route on it
 
 async function canListen(): Promise<boolean> {
   return await new Promise((r) => {
@@ -73,22 +75,34 @@ describeIfDatabase('requester.role — real-DB create->reload->dispatch round-tr
   let base = ''
   let reqTok = ''
   let apprTok = ''
+  let reqUncuratedTok = ''
 
   beforeAll(async () => {
     expect(await canListen()).toBe(true)
     await ensureApprovalSchemaReady()
     const pool = poolManager.get()
-    // RBAC table guard (defensive — present via migrations in the CI lane; matches the real schema).
+    // RBAC table guards (defensive — present via migrations in the CI lane; matches the real schema).
     await pool.query(`CREATE TABLE IF NOT EXISTS user_roles (user_id varchar(255) NOT NULL, role_id varchar(255) NOT NULL, created_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL)`)
+    await pool.query(`CREATE TABLE IF NOT EXISTS roles (id text PRIMARY KEY, name text NOT NULL, created_at timestamptz DEFAULT now() NOT NULL, updated_at timestamptz DEFAULT now() NOT NULL)`)
+    // RA-1b CURATED-VOCABULARY: ensure the curated column exists (whether or not the migration ran in this
+    // lane), then seed a CURATED role (approval_usable=true) and an UNCURATED role (false). The resolver
+    // JOINs `roles` on approval_usable, and the publish HARD GATE enforces the same curated set.
+    await pool.query(`ALTER TABLE roles ADD COLUMN IF NOT EXISTS approval_usable boolean NOT NULL DEFAULT false`)
+    await pool.query(`INSERT INTO roles (id, name, approval_usable) VALUES ($1, $2, true) ON CONFLICT (id) DO UPDATE SET approval_usable = true`, [ROLE, ROLE])
+    await pool.query(`INSERT INTO roles (id, name, approval_usable) VALUES ($1, $2, false) ON CONFLICT (id) DO UPDATE SET approval_usable = false`, [UNCURATED_ROLE, UNCURATED_ROLE])
     // Seed: the requester user + a single user_roles row. NO directory account needed — requester.role reads
     // straight off user_roles, independent of the directory snapshot.
     await pool.query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`, [REQ, `${REQ}@x.test`])
     await pool.query(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`, [REQ, ROLE])
+    // A second requester holding ONLY an UNCURATED role → curated set resolves to [] (genuine-empty).
+    await pool.query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`, [REQ_UNCURATED, `${REQ_UNCURATED}@x.test`])
+    await pool.query(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`, [REQ_UNCURATED, UNCURATED_ROLE])
     server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
     await server.start()
     base = `http://127.0.0.1:${server.getAddress()!.port}`
     reqTok = await tok(base, REQ)
     apprTok = await tok(base, APPROVER)
+    reqUncuratedTok = await tok(base, REQ_UNCURATED)
   })
 
   afterAll(async () => {
@@ -105,8 +119,9 @@ describeIfDatabase('requester.role — real-DB create->reload->dispatch round-tr
         await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
         await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
       }
-      await pool.query(`DELETE FROM user_roles WHERE user_id = $1`, [REQ])
-      await pool.query(`DELETE FROM users WHERE id = $1`, [REQ])
+      await pool.query(`DELETE FROM user_roles WHERE user_id = ANY($1::varchar[])`, [[REQ, REQ_UNCURATED]])
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::varchar[])`, [[REQ, REQ_UNCURATED]])
+      await pool.query(`DELETE FROM roles WHERE id = ANY($1::text[])`, [[ROLE, UNCURATED_ROLE]])
     } catch {
       /* best effort */
     }
@@ -162,5 +177,68 @@ describeIfDatabase('requester.role — real-DB create->reload->dispatch round-tr
     )).rows.map((r) => r.assignee_id)
     expect(assignees).toContain(FIN)
     expect(assignees).not.toContain(OTHER)
+  })
+
+  // RA-1b CURATED-VOCABULARY: a graph whose membership literal references an UNCURATED role must FAIL at
+  // publish (the HARD GATE), even though create-time draft authoring accepts it.
+  it('FAILS publish when a requester.role literal is UNCURATED (APPROVAL_REQUESTER_ROLE_NOT_CURATED)', async () => {
+    const key = `rrole-${TS}-uncurated`
+    const graph = JSON.parse(JSON.stringify(GRAPH)) as typeof GRAPH
+    const condition = graph.nodes.find((n) => n.key === 'condition_1')!
+    ;(condition.config as { branches: Array<{ formula: { expression: string } }> }).branches[0].formula.expression =
+      `requester.role in ["${UNCURATED_ROLE}"]`
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201) // draft authoring accepts it
+    const tid = ((await created.json()) as { id: string }).id
+
+    const publishRes = await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })
+    expect(publishRes.status, await publishRes.clone().text()).toBe(400)
+    const body = (await publishRes.json()) as { code?: string; error?: { code?: string } }
+    expect(body.code ?? body.error?.code).toBe('APPROVAL_REQUESTER_ROLE_NOT_CURATED')
+  })
+
+  // RA-1b GENUINE-EMPTY SEMANTICS: role is a PREDICATE, not a routing key. A requester whose CURATED role
+  // set is empty (holds only an uncurated role) must NOT be 422-rejected at create — it routes to DEFAULT.
+  it('a requester with ZERO curated roles routes to the DEFAULT edge (NOT a 422 reject)', async () => {
+    const key = `rrole-${TS}-genuine-empty`
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: GRAPH },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+
+    // REQ_UNCURATED holds only the UNCURATED role → curated set []. createApproval MUST succeed (no 422).
+    const started = await req(base, '/api/approvals', reqUncuratedTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status, await started.clone().text()).toBeLessThan(300)
+    const startBody = (await started.json()) as { id?: string; data?: { id: string } }
+    const iid = startBody.id ?? startBody.data!.id
+
+    const pool = poolManager.get()
+    // directoryRoles frozen as [] (genuine-empty), not omitted — so dispatch threads [] → membership false.
+    const snap = (await pool.query<{ requester_snapshot: { directoryRoles?: string[] } | null }>(
+      `SELECT requester_snapshot FROM approval_instances WHERE id = $1`,
+      [iid],
+    )).rows[0]
+    expect(snap.requester_snapshot?.directoryRoles).toEqual([])
+
+    // approve approval_1 → condition evaluates membership(["finance"], []) = false → DEFAULT edge (other).
+    const approved = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+    expect(approved.status, await approved.clone().text()).toBeLessThan(300)
+    const after = (await pool.query<{ current_node_key: string | null }>(
+      `SELECT current_node_key FROM approval_instances WHERE id = $1`,
+      [iid],
+    )).rows[0]
+    expect(after.current_node_key).toBe('approval_other')
+    const assignees = (await pool.query<{ assignee_id: string }>(
+      `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND assignment_type = 'user' AND is_active = TRUE`,
+      [iid],
+    )).rows.map((r) => r.assignee_id)
+    expect(assignees).toContain(OTHER)
+    expect(assignees).not.toContain(FIN)
   })
 })

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -3,6 +3,7 @@ import {
   APPROVAL_CONDITION_FORMULA_LIMITS,
   assertApprovalConditionFormulaValidForSchema,
   evaluateApprovalConditionFormula,
+  extractRequesterRoleLiterals,
   parseApprovalConditionFormula,
 } from '../../src/services/ApprovalConditionFormula'
 import type { FormSchema } from '../../src/types/approval-product'
@@ -197,8 +198,9 @@ describe('requester namespace (requester.role — membership via `in [...]`)', (
     expect(evaluateApprovalConditionFormula('requester.role in ["a","b"]', {}, { roles: ['x', 'y'] })).toBe(false)
     // genuinely-empty held set -> false (no match; create-time guard prevents this on a role-routed graph)
     expect(evaluateApprovalConditionFormula('requester.role in ["a","b"]', {}, { roles: [] })).toBe(false)
-    // single-element literal
-    expect(evaluateApprovalConditionFormula('requester.role in ["admin"]', {}, { roles: ['admin'] })).toBe(true)
+    // single-element literal (use a NON-system curated-style id — `admin` would be uncurated and is a
+    // misleading sample now that requester.role is a curated vocabulary, RA-1b)
+    expect(evaluateApprovalConditionFormula('requester.role in ["finance_approver"]', {}, { roles: ['finance_approver'] })).toBe(true)
   })
 
   it('combines with form fields + AND/OR/NOT (membership yields boolean)', () => {
@@ -257,5 +259,28 @@ describe('requester namespace (requester.role — membership via `in [...]`)', (
     expect(() => parseApprovalConditionFormula('"requester.role" in ["a"]')).toThrow(/only supported for requester.role/)
     // and a bare quoted literal evaluates as a plain string (no context read, no formData spoof).
     expect(evaluateApprovalConditionFormula('"requester.role" == "requester.role"', {}, { roles: ['a'] })).toBe(true)
+  })
+})
+
+describe('extractRequesterRoleLiterals (RA-1b CURATED-VOCABULARY — publish/dry-run hard gate input)', () => {
+  it('returns the unique union of role literals, including membership nested in AND/OR/NOT', () => {
+    expect(extractRequesterRoleLiterals('requester.role in ["a","b"]')).toEqual(['a', 'b'])
+    // nested inside AND/OR/NOT — KEYSTONE: a curated gate that only checked top-level would miss these
+    expect(extractRequesterRoleLiterals('requester.role in ["a"] AND {amount} >= 5')).toEqual(['a'])
+    expect(extractRequesterRoleLiterals('NOT (requester.role in ["a"])')).toEqual(['a'])
+    expect(
+      extractRequesterRoleLiterals('(requester.role in ["a","b"]) OR (requester.role in ["b","c"])'),
+    ).toEqual(['a', 'b', 'c']) // deduped union across two membership nodes
+  })
+
+  it('returns [] for a non-role formula and for a parse error', () => {
+    expect(extractRequesterRoleLiterals('{amount} >= 5')).toEqual([])
+    expect(extractRequesterRoleLiterals('requester.department == "财务"')).toEqual([])
+    // a quoted "admin" used as a plain comparison operand is NOT a role literal
+    expect(extractRequesterRoleLiterals('requester.title == "admin"')).toEqual([])
+    // parse error -> [] (never throws)
+    expect(extractRequesterRoleLiterals('requester.role in [')).toEqual([])
+    expect(extractRequesterRoleLiterals('this is (not valid')).toEqual([])
+    expect(extractRequesterRoleLiterals('')).toEqual([])
   })
 })

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2347,10 +2347,10 @@ describe('ApprovalProductService', () => {
     await expect(service.createApproval({ templateId: 'tpl-1', formData: {} }, { userId: 'requester-1' })).resolves.toBeTruthy()
   })
 
-  // requester.role wedge guard — same error-vs-empty split as department/title. A role-routed condition
-  // downstream of an approval node would otherwise freeze an empty role set into the snapshot and wedge
-  // every later approval; reject at create instead, distinguishing transient-read (503) from genuine
-  // row-level absence (422). The role-id set is resolved by the SEPARATE user_roles resolver (mocked here).
+  // requester.role wedge guard — RA-1b CURATED-VOCABULARY makes role a PREDICATE, not a routing key, so it
+  // DIVERGES from department/title: only a TRANSIENT read failure fails create closed (503). A successful
+  // GENUINE-EMPTY curated set is NOT rejected — it freezes [] and routes to DEFAULT (membership = false).
+  // The role-id set is resolved by the SEPARATE user_roles resolver (mocked here).
   const roleWedgeGraph = {
     nodes: [
       { key: 'start', type: 'start', config: {} },
@@ -2388,14 +2388,16 @@ describe('ApprovalProductService', () => {
       .rejects.toMatchObject({ statusCode: 503, code: 'APPROVAL_REQUESTER_ROLE_UNRESOLVED' })
   })
 
-  it('role wedge guard: a SUCCESSFUL read with NO roles also rejects AT CREATE (422) — genuine absence is fail-closed at create', async () => {
-    roleResolverState.resolveApprovalRequesterRoleIds.mockResolvedValue([]) // success, but no roles
+  it('role GENUINE-EMPTY: a SUCCESSFUL read with NO curated roles does NOT 422 — create succeeds (routes to DEFAULT)', async () => {
+    // RA-1b: role is a predicate. Empty curated set must NOT reject at create (unlike department/title); it
+    // freezes [] and the condition takes its default edge. Only a thrown read fails closed (503, above).
+    roleResolverState.resolveApprovalRequesterRoleIds.mockResolvedValue([]) // success, but no curated roles
     mountWedgeSql(roleWedgeGraph)
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService(buildNoopMetrics() as never)
     vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({ templateVersionId: 'ver-2', publishedDefinitionId: 'pub-2' }))
     await expect(service.createApproval({ templateId: 'tpl-1', formData: {} }, { userId: 'requester-1' }))
-      .rejects.toMatchObject({ statusCode: 422, code: 'APPROVAL_REQUESTER_ROLE_REQUIRED' })
+      .resolves.toBeTruthy()
   })
 
   it('role guard detection is token-aware — a quoted "requester.role" is not a requester reference', () => {
@@ -4667,6 +4669,87 @@ describe('ApprovalProductService', () => {
     const condition = result.runtimeGraph?.nodes.find((node) => node.key === 'route')
     expect((condition?.config as { branches: Array<{ formula?: { expression: string } }> }).branches[0].formula)
       .toEqual({ expression: 'SUM({items.amount}) >= 20000' })
+  })
+
+  // RA-1b CURATED-VOCABULARY — publish HARD GATE. A role-routed condition must publish ONLY when every
+  // requester.role literal is curated (roles.approval_usable=true); an uncurated literal fails closed.
+  describe('publish curated requester.role vocabulary gate (RA-1b)', () => {
+    const roleFormSchema = { fields: [] as unknown[] }
+    function roleRoutedGraph(expression: string) {
+      return {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          {
+            key: 'route',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression } }],
+              defaultEdgeKey: 'edge-low',
+            },
+          },
+          { key: 'high', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+          { key: 'low', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-route', source: 'start', target: 'route' },
+          { key: 'edge-high', source: 'route', target: 'high' },
+          { key: 'edge-low', source: 'route', target: 'low' },
+          { key: 'edge-high-end', source: 'high', target: 'end' },
+          { key: 'edge-low-end', source: 'low', target: 'end' },
+        ],
+      }
+    }
+    const template = {
+      id: 'tpl-1', key: 'role-formula', name: 'Role Formula', description: null, category: null,
+      visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+      active_version_id: null, latest_version_id: 'ver-2', created_at: new Date(), updated_at: new Date(),
+    }
+    function mockPublish(expression: string, curatedRoleIds: string[]) {
+      const version = {
+        id: 'ver-2', template_id: 'tpl-1', version: 2, status: 'draft',
+        form_schema: roleFormSchema, approval_graph: roleRoutedGraph(expression),
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [template], rowCount: 1 }
+        if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+        if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) return { rows: [], rowCount: 0 }
+        // RA-1b curated-set read — fetched on the transaction client, once per publish, only when role-routed.
+        if (statement.startsWith('SELECT id FROM roles WHERE approval_usable')) {
+          return { rows: curatedRoleIds.map((id) => ({ id })), rowCount: curatedRoleIds.length }
+        }
+        if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+          const runtimeGraph = JSON.parse(String(params?.[2]))
+          return { rows: [{ id: 'pub-2', template_id: 'tpl-1', template_version_id: 'ver-2', runtime_graph: runtimeGraph, is_active: true, published_at: new Date() }], rowCount: 1 }
+        }
+        if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
+        if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) return { rows: [], rowCount: 1 }
+        throw new Error(`Unhandled query: ${statement}`)
+      })
+    }
+
+    it('publishes a CURATED requester.role literal', async () => {
+      mockPublish('requester.role in ["finance_approver"]', ['finance_approver', 'expense_lead'])
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().publishTemplate('tpl-1', { policy: { allowRevoke: true } } as never)
+      expect(result.publishedDefinitionId).toBe('pub-2')
+    })
+
+    it('rejects an UNCURATED requester.role literal at publish (APPROVAL_REQUESTER_ROLE_NOT_CURATED, 400)', async () => {
+      // "admin" is a SYSTEM role NOT in the curated set — the boundary the owner sharpened.
+      mockPublish('requester.role in ["admin"]', ['finance_approver'])
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-1', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject({
+        code: 'APPROVAL_REQUESTER_ROLE_NOT_CURATED',
+        statusCode: 400,
+        message: expect.stringContaining('admin'),
+      })
+    })
   })
 
   it('snapshots publish-time auto-approval policy into runtime_graph without a migration column', async () => {

--- a/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
+++ b/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
@@ -290,6 +290,9 @@ describe('Approval RBAC boundary verification', () => {
 
     it('POST .../dry-run previews a requester.role in [...] condition when sample roles are supplied (RA-1b)', async () => {
       authState.user = templateManager()
+      // RA-1b: dry-run runs the SAME curated gate as publish — the curated set (roles.approval_usable=true)
+      // must include the literal for the preview to proceed.
+      pgState.pool.query.mockResolvedValue({ rows: [{ id: 'finance_approver' }], rowCount: 1 })
       const res = await request(app)
         .post('/api/approval-templates/formula-condition/dry-run')
         .send({
@@ -301,6 +304,26 @@ describe('Approval RBAC boundary verification', () => {
 
       expect(res.status).toBe(200)
       expect(res.body).toEqual({ data: { success: true, result: true } })
+    })
+
+    it('POST .../dry-run rejects an UNCURATED requester.role literal with NOT_CURATED (preview matches publish)', async () => {
+      authState.user = templateManager()
+      // curated set = ONLY finance_approver; "admin" is NOT approval_usable → must be rejected, fail-closed,
+      // so preview cannot greenlight a route that publish would reject.
+      pgState.pool.query.mockResolvedValue({ rows: [{ id: 'finance_approver' }], rowCount: 1 })
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send({
+          expression: 'requester.role in ["admin"]',
+          formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+          formData: {},
+          requester: { roles: ['admin'] },
+        })
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.success).toBe(false)
+      expect(res.body.data.error.code).toBe('APPROVAL_REQUESTER_ROLE_NOT_CURATED')
+      expect(res.body.data.error.message).toContain('admin')
     })
 
     it('POST .../dry-run: a requester.* condition without a sample requester is unpreviewable (success:false, not a phantom true)', async () => {

--- a/packages/core-backend/tests/unit/approval-requester-roles.test.ts
+++ b/packages/core-backend/tests/unit/approval-requester-roles.test.ts
@@ -19,4 +19,18 @@ describe('resolveApprovalRequesterRoleIds (RA-1b fresh user_roles resolver)', ()
       Promise.reject(new Error('user_roles read failed'))
     await expect(resolveApprovalRequesterRoleIds('u-1', boom)).rejects.toThrow('user_roles read failed')
   })
+
+  it('RA-1b CURATED-VOCABULARY: filters to approval_usable roles via a JOIN on `roles` (SQL lock)', async () => {
+    // The stub ignores the SQL text (real curation lives in the DB), so assert the SQL itself JOINs `roles`
+    // and filters approval_usable — the real-DB test proves the runtime behaviour. Without the JOIN, a
+    // SYSTEM role the requester holds would leak into directoryRoles.
+    let capturedSql = ''
+    const q = <Row>(text: string, _params?: unknown[]): Promise<{ rows: Row[] }> => {
+      capturedSql = text
+      return Promise.resolve({ rows: [{ role_id: 'finance_approver' }] as unknown as Row[] })
+    }
+    expect(await resolveApprovalRequesterRoleIds('u-1', q)).toEqual(['finance_approver'])
+    expect(capturedSql).toMatch(/JOIN\s+roles/i)
+    expect(capturedSql).toMatch(/approval_usable\s*=\s*true/i)
+  })
 })


### PR DESCRIPTION
## What & why
Follow-up to #3309. The ratified **D-role-vocabulary** ("approval-curated subset of RBAC roles") was *decided but not enforced* — an author could route `requester.role in ["admin"]` on a system role. This closes that open P1.

## Design (owner-corrected boundary)
- **Curated source** — new `roles.approval_usable boolean NOT NULL DEFAULT false` (secure-by-default; every role, incl. admin, excluded until an admin opts it in).
- **PUBLISH = the hard gate** — uncurated `requester.role` literal → `400 APPROVAL_REQUESTER_ROLE_NOT_CURATED`. `publishTemplate` is the **sole** producer of the runtime (published/active) definition; `createTemplate`/`updateTemplate` drafts pass `null`. The AST extractor walks every membership-bearing node (parens flatten, `aggregate` is a leaf) → **no bypass**.
- **DRY-RUN** runs the identical check (preview == publish).
- **Boundary precision (owner P1)** — `listDirectoryRoles` (`/directory/roles`) is **UNCHANGED** (still ALL roles; it also backs `static_role` approver selection). Curation scopes **only** the formula `requester.role` via a **dedicated** `GET /directory/formula-roles` (curated-only). FE `loadRoles()` is **byte-unchanged**.
- **Curated freeze** — the resolver INNER-JOINs `approval_usable = true`, so a system role the requester holds never enters `requester_snapshot.directoryRoles`.
- **Genuine-empty → DEFAULT** — `role` is a predicate, not a routing key: zero curated roles → membership false → default edge, **not** a 422. Only a transient `user_roles` read failure fails closed (503). Department/title (routing keys) unchanged.

## Verification (independent, real dev DB)
All three boundary properties **proven**, not just inspected:
1. **No publish bypass** — DB test *FAILS publish when a requester.role literal is UNCURATED*.
2. **static_role intact** — DB tests */directory/formula-roles curated-only* **and** */directory/roles UNCHANGED (ALL roles)*.
3. **empty→DEFAULT** — DB test *a requester with ZERO curated roles routes to the DEFAULT edge (NOT a 422)*.

- Unit **175/175** (incl. *dry-run rejects UNCURATED literal — preview matches publish*), real-DB/API **19/19, 0 skipped** (DATABASE_URL sentinel guards the silent-skip trap), **tsc clean**.
- **Migration exercised independently** — real runner against a scratch DB: `zzzz20260627150000` applies last-in-chain → `approval_usable | NOT NULL | DEFAULT false`; `rollback` drops it (down proven).
- `.api` + both `.db` files are in the `plugin-tests.yml` Postgres lane.

## ⚠️ Deploy preflight (secure-by-default = behavior change)
Any already-published template routing on `requester.role` will, for new instances, route to DEFAULT until an admin curates those roles. RA-1b is days old (~0 expected) — verify on prod (query in the dev/verification MD §6) and curate in the same deploy if any exist. Fail-safe direction: uncurated → DEFAULT, never a wrong-but-confident route.

## Docs
- Design lock: `approval-requester-role-ra1b-design-lock-20260627.md` → **RUNTIME SHIPPED + CURATED-VOCABULARY ENFORCED**
- Dev/verification: `docs/development/approval-ra1b-curated-vocabulary-dev-verification-20260627.md`

## Deferred (stated, not dropped)
FE dedicated formula-condition role picker (non-security UX — BE gate already enforces; documented TODO). `requester.level` / W7 backwrite / amount / canvas remain owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)