### PR TITLE
feat(approval): RA-1b FE formula-roles picker — guide authors to curated requester.role values (take-or-drop)

### DIFF
--- a/apps/web/src/approvals/useApprovalDirectory.ts
+++ b/apps/web/src/approvals/useApprovalDirectory.ts
@@ -39,6 +39,7 @@ export interface UseApprovalDirectoryOptions {
 const FORBIDDEN_MESSAGE = '需要 approval-templates:manage 权限'
 const USERS_FAILED_MESSAGE = '加载用户目录失败'
 const ROLES_FAILED_MESSAGE = '加载角色目录失败'
+const FORMULA_ROLES_FAILED_MESSAGE = '加载审批可用角色失败'
 
 async function readJson(response: Response): Promise<Record<string, unknown> | null> {
   try {
@@ -81,8 +82,13 @@ function asRoleOptions(value: unknown): DirectoryRoleOption[] {
 export function useApprovalDirectory({ apiFetch = defaultApiFetch }: UseApprovalDirectoryOptions = {}) {
   const users = ref<DirectoryUserOption[]>([])
   const roles = ref<DirectoryRoleOption[]>([])
+  // CURATED-VOCABULARY (RA-1b): the roles an author may route on in a formula `requester.role in [...]`
+  // condition — i.e. `approval_usable = true`. SEPARATE from `roles` (the static_role approver picker,
+  // which intentionally lists ALL roles). Never merge the two — that boundary is the ratified scope.
+  const formulaRoles = ref<DirectoryRoleOption[]>([])
   const usersLoading = ref(false)
   const rolesLoading = ref(false)
+  const formulaRolesLoading = ref(false)
   const statusMessage = ref('')
 
   async function searchUsers(q: string): Promise<void> {
@@ -113,10 +119,8 @@ export function useApprovalDirectory({ apiFetch = defaultApiFetch }: UseApproval
     }
   }
 
-  // TODO(RA-1b FE): this loads ALL roles for the SHARED static_role approver picker (correct — static_role is
-  // NOT curated). When a DEDICATED formula `requester.role` picker is added, point it at the curated endpoint
-  // `GET /api/approval-templates/directory/formula-roles` (approval_usable=true only). The BE publish + dry-run
-  // HARD GATE already enforces curation regardless, so this is convenience, not the security boundary.
+  // Loads ALL roles for the SHARED static_role approver picker (correct — static_role assignee selection is
+  // NOT curated). The DEDICATED formula `requester.role` picker uses `loadFormulaRoles()` below instead.
   async function loadRoles(): Promise<void> {
     rolesLoading.value = true
     statusMessage.value = ''
@@ -136,6 +140,33 @@ export function useApprovalDirectory({ apiFetch = defaultApiFetch }: UseApproval
       statusMessage.value = error instanceof Error && error.message ? error.message : ROLES_FAILED_MESSAGE
     } finally {
       rolesLoading.value = false
+    }
+  }
+
+  // CURATED-VOCABULARY (RA-1b): the DEDICATED formula `requester.role` picker. Hits the curated endpoint
+  // `GET /api/approval-templates/directory/formula-roles` (approval_usable=true only), so an author is GUIDED
+  // to insert only curated roles into `requester.role in [...]` — matching the publish + dry-run HARD GATE
+  // (which is the actual security boundary; this picker is authoring convenience). Mirrors `loadRoles` exactly
+  // but MUST stay separate from it / `roles` (static_role): never merge the curated and full role sets.
+  async function loadFormulaRoles(): Promise<void> {
+    formulaRolesLoading.value = true
+    statusMessage.value = ''
+    try {
+      const response = await apiFetch('/api/approval-templates/directory/formula-roles')
+      if (response.status === 403) {
+        formulaRoles.value = []
+        statusMessage.value = FORBIDDEN_MESSAGE
+        return
+      }
+      const data = await readJson(response)
+      if (!response.ok || !data) {
+        throw new Error(FORMULA_ROLES_FAILED_MESSAGE)
+      }
+      formulaRoles.value = asRoleOptions(data.roles)
+    } catch (error: unknown) {
+      statusMessage.value = error instanceof Error && error.message ? error.message : FORMULA_ROLES_FAILED_MESSAGE
+    } finally {
+      formulaRolesLoading.value = false
     }
   }
 
@@ -168,11 +199,14 @@ export function useApprovalDirectory({ apiFetch = defaultApiFetch }: UseApproval
   return {
     users,
     roles,
+    formulaRoles,
     usersLoading,
     rolesLoading,
+    formulaRolesLoading,
     statusMessage,
     searchUsers,
     loadRoles,
+    loadFormulaRoles,
     ensureUserOptionVisible,
     ensureRoleOptionVisible,
     formatUserLabel,

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -681,6 +681,21 @@
                       data-testid="approval-condition-formula-insert-max"
                       @click="insertConditionFormulaFunction(branch, 'MAX')"
                     >MAX()</el-button>
+                    <template v-if="directory.formulaRoles.value.length > 0">
+                      <span
+                        class="template-authoring__condition-formula-role-hint"
+                        data-testid="approval-condition-formula-role-hint"
+                      >requester.role（审批可用角色）：</span>
+                      <el-button
+                        v-for="role in directory.formulaRoles.value"
+                        :key="role.id"
+                        size="small"
+                        :disabled="readOnly"
+                        :title="`插入 requester.role in [&quot;${role.id}&quot;]`"
+                        :data-testid="`approval-condition-formula-insert-role-${role.id}`"
+                        @click="insertConditionFormulaRoleMembership(branch, role.id)"
+                      >{{ directory.formatRoleLabel(role) }}</el-button>
+                    </template>
                   </div>
                   <div class="template-authoring__condition-formula-dryrun">
                     <el-input
@@ -1286,6 +1301,12 @@ function insertConditionFormulaToken(branch: ConditionBranchEdit, token: string)
 function insertConditionFormulaFunction(branch: ConditionBranchEdit, fn: 'SUM' | 'COUNT' | 'MIN' | 'MAX'): void {
   appendFormulaText(branch, `${fn}()`)
 }
+// CURATED-VOCABULARY (RA-1b): insert a ready `requester.role in ["<id>"]` membership for a CURATED role
+// (from the formula-roles picker). JSON.stringify quotes/escapes the id so the inserted snippet always
+// parses. Single-role is the common case; for multiple roles the author edits the array by hand.
+function insertConditionFormulaRoleMembership(branch: ConditionBranchEdit, roleId: string): void {
+  appendFormulaText(branch, `requester.role in [${JSON.stringify(roleId)}]`)
+}
 
 function conditionFormulaDryRunKey(nodeKey: string, edgeKey: string): string {
   return `${nodeKey}:${edgeKey}`
@@ -1809,6 +1830,7 @@ async function handlePublish() {
 onMounted(() => {
   if (!canManageTemplates.value) return
   void directory.loadRoles()
+  void directory.loadFormulaRoles()
   void loadTemplateForEdit()
 })
 </script>
@@ -2008,6 +2030,13 @@ onMounted(() => {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  align-items: center;
+}
+
+.template-authoring__condition-formula-role-hint {
+  margin-left: 4px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
 }
 
 .template-authoring__condition-formula-dryrun {

--- a/apps/web/tests/useApprovalDirectory.spec.ts
+++ b/apps/web/tests/useApprovalDirectory.spec.ts
@@ -90,6 +90,50 @@ describe('useApprovalDirectory', () => {
     expect(dir.statusMessage.value).toContain('approval-templates:manage')
   })
 
+  // RA-1b CURATED-VOCABULARY: the dedicated formula-role picker hits the CURATED endpoint and is kept
+  // strictly separate from loadRoles / `roles` (the static_role approver picker, which lists ALL roles).
+  it('loadFormulaRoles hits the CURATED /formula-roles endpoint and parses the bare {roles} shape', async () => {
+    const apiFetch = vi.fn().mockResolvedValue(
+      jsonResponse({ roles: [{ id: 'finance_approver', name: '财务审批' }, { id: 'r2', name: '' }] }),
+    )
+    const dir = useApprovalDirectory({ apiFetch })
+
+    await dir.loadFormulaRoles()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/approval-templates/directory/formula-roles')
+    expect(dir.formulaRoles.value).toEqual([{ id: 'finance_approver', name: '财务审批' }, { id: 'r2', name: '' }])
+    expect(dir.formulaRolesLoading.value).toBe(false)
+  })
+
+  it('loadFormulaRoles and loadRoles hit DIFFERENT endpoints and fill SEPARATE refs (curated vs static_role)', async () => {
+    const apiFetch = vi.fn().mockImplementation((path: string) =>
+      Promise.resolve(
+        path.endsWith('/formula-roles')
+          ? jsonResponse({ roles: [{ id: 'finance_approver', name: '财务审批' }] })
+          : jsonResponse({ roles: [{ id: 'finance_approver', name: '财务审批' }, { id: 'admin', name: '系统管理员' }] }),
+      ),
+    )
+    const dir = useApprovalDirectory({ apiFetch })
+
+    await dir.loadRoles()
+    await dir.loadFormulaRoles()
+
+    // static_role picker keeps ALL roles (incl. admin); the curated formula picker excludes it.
+    expect(dir.roles.value.map((r) => r.id)).toEqual(['finance_approver', 'admin'])
+    expect(dir.formulaRoles.value.map((r) => r.id)).toEqual(['finance_approver'])
+  })
+
+  it('403 on loadFormulaRoles sets a permission status message and clears the curated array', async () => {
+    const apiFetch = vi.fn().mockResolvedValue(jsonResponse({}, { status: 403, ok: false }))
+    const dir = useApprovalDirectory({ apiFetch })
+    dir.formulaRoles.value = [{ id: 'stale', name: 'x' }]
+
+    await dir.loadFormulaRoles()
+
+    expect(dir.formulaRoles.value).toEqual([])
+    expect(dir.statusMessage.value).toContain('approval-templates:manage')
+  })
+
   it('ensureUserOptionVisible prepends a synthetic option for an id missing from the page, no-op when present', () => {
     const apiFetch = vi.fn()
     const dir = useApprovalDirectory({ apiFetch })

--- a/docs/development/approval-ra1b-fe-formula-roles-picker-dev-verification-20260628.md
+++ b/docs/development/approval-ra1b-fe-formula-roles-picker-dev-verification-20260628.md
@@ -1,0 +1,30 @@
+# RA-1b FE formula-roles picker — development & verification (2026-06-28)
+
+> Completes the curated-vocabulary feature end-to-end. The BE hard gate shipped in #3327 (`34a8f6d46`, on `main`) rejects an uncurated `requester.role` literal at publish/dry-run; this slice adds the **authoring-side convenience**: an author is now *guided* to insert only curated roles, instead of discovering the curated set by hitting a publish rejection. Branch `claude/approval-ra1b-fe-formula-roles-picker-20260628`, off `main` @ `34a8f6d46`.
+
+## Scope (deliberately minimal, non-gated)
+This is the one item the #3327 advisor flagged as deferred-but-defensible. It needs **no product/security decision** (the curated endpoint + the security boundary already exist BE-side), so it's buildable now. It does **not** touch any owner-gated item (`requester.level`, W7 backwrite, amount rules, canvas) — those remain owner-gated.
+
+## Implementation
+- **Composable** (`useApprovalDirectory.ts`) — added a **dedicated** curated path, mirroring `loadRoles()` exactly but separate from it:
+  - `formulaRoles` ref + `formulaRolesLoading` + `loadFormulaRoles()` → `GET /api/approval-templates/directory/formula-roles` (curated, `approval_usable=true`; bare `{ roles }` shape; same 403/error handling).
+  - The pre-existing `loadRoles()` / `roles` (the SHARED `static_role` approver picker, which lists ALL roles) is **unchanged** — the prior `TODO(RA-1b FE)` is retired and replaced by a doc note. The curated and full role sets are never merged (the ratified boundary).
+- **View** (`TemplateAuthoringView.vue`):
+  - In the condition-formula tools row (formula mode only — inside the `predicateMode === 'formula'` `v-else` block, after the SUM/COUNT/MIN/MAX inserts), a curated-role affordance: a `requester.role（审批可用角色）` hint + one button per curated role (label = `formatRoleLabel`), rendered only when `directory.formulaRoles.value.length > 0`.
+  - `insertConditionFormulaRoleMembership(branch, roleId)` appends a ready `requester.role in [${JSON.stringify(roleId)}]` snippet (JSON.stringify quotes/escapes the id → always parses). Single-role is the common case; multi-role is a manual array edit. Uses the same append-only `appendFormulaText` model as the existing field/aggregate inserts.
+  - `directory.loadFormulaRoles()` called at `onMounted` alongside `loadRoles()` (behind the same `canManageTemplates` guard).
+  - Hint CSS (muted, small) added next to the existing formula-tools styles.
+
+## Verification
+- **`useApprovalDirectory.spec.ts` 12/12** (3 new): `loadFormulaRoles` hits the **curated** `/formula-roles` endpoint + parses `{ roles }`; **separation** — `loadRoles` vs `loadFormulaRoles` hit different endpoints and fill separate refs (static_role keeps `admin`, the curated picker excludes it); 403 clears `formulaRoles` + sets the permission message.
+- **`vue-tsc -b` clean** (0 errors) — template binding (`directory.formulaRoles.value`, consistent with the existing `directory.roles.value` access in this file) + the new method typecheck.
+- **Boundary preserved** — `static_role` picker (`directory.roles`, line 992) and `loadRoles()` are byte-unchanged; the curated affordance is additive and formula-mode-scoped.
+- **Insert correctness** — the emitted `requester.role in ["<id>"]` is exactly the membership grammar the BE parser + curated publish gate accept (proven by #3327's grammar + DB tests); JSON.stringify guarantees a parseable literal.
+
+## Invariants
+- `static_role` approver selection is unaffected; the curated picker is a separate, additive surface. ✓
+- The picker fetches only curated roles; it is authoring convenience, NOT the security boundary (the BE publish/dry-run gate from #3327 remains the enforcement). ✓
+- The affordance renders only in condition **formula** mode and only when curated roles are present. ✓
+
+## Still owner-gated (unchanged)
+`requester.level` (title→rank mapping decision), W7 rejection/cross-base/person-writer backwrite (named scenario + security), amount rules (product+security), canvas polish (deprioritized UX). Each is a separate opt-in.


### PR DESCRIPTION
## ⚠️ This is a fork for your call — take it or close it
I built this as the natural completion of the curated-vocabulary loop, but it's a **new authoring UX surface** whose design I chose myself, and I'd previously filed it as a *deferred* follow-up. So treat this PR as a surfaced fork, **not** something to auto-merge: take it if you want the convenience, close it if you'd rather leave authoring as-is (the feature is fully secure without it). It's additive and cheap to drop.

## What it does
The BE hard gate (#3327, on `main`) already rejects an uncurated `requester.role` literal at publish/dry-run — that's the security boundary and it's complete. This adds the **authoring convenience**: in the condition-formula editor, an author is *guided* to insert only curated roles, instead of discovering the curated set by hitting a publish rejection.

- `useApprovalDirectory`: dedicated `loadFormulaRoles()` + `formulaRoles` ref → `GET /directory/formula-roles` (curated, `approval_usable=true`). **Separate** from `loadRoles()`/`roles` (the shared `static_role` approver picker — byte-unchanged, still ALL roles).
- `TemplateAuthoringView`: in the formula tools (formula mode only), one button per curated role inserting a ready `requester.role in ["<id>"]` snippet (JSON.stringify-escaped). Loaded at mount behind the same `approval-templates:manage` guard.

## Verification
- `useApprovalDirectory.spec` **12/12** (3 new): curated endpoint; **curated-vs-static_role separation** (static_role keeps `admin`, curated excludes it); 403 handling.
- `vue-tsc -b` clean. `static_role` picker untouched.

## Boundary
Touches **no** owner-gated item. `requester.level`, W7 backwrite, amount rules, canvas polish stay gated — each a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)