### PR TITLE
feat(multitable): date-reminder automation trigger (schedule.date_field)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -286,6 +286,7 @@ jobs:
             tests/integration/multitable-automation-start-approval.test.ts \
             tests/integration/multitable-automation-start-approval-http.test.ts \
             tests/integration/multitable-form-submit-trigger.test.ts \
+            tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \
             tests/integration/multitable-ai-shortcut-run.test.ts \

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -36,6 +36,7 @@
             <option value="field.value_changed">{{ automationTriggerTypeLabel('field.value_changed', isZh) }}</option>
             <option value="schedule.cron">{{ automationTriggerTypeLabel('schedule.cron', isZh) }}</option>
             <option value="schedule.interval">{{ automationTriggerTypeLabel('schedule.interval', isZh) }}</option>
+            <option value="schedule.date_field">{{ automationTriggerTypeLabel('schedule.date_field', isZh) }}</option>
             <option value="webhook.received">{{ automationTriggerTypeLabel('webhook.received', isZh) }}</option>
           </select>
 
@@ -78,6 +79,24 @@
           <template v-if="draft.triggerType === 'schedule.interval'">
             <label class="meta-rule-editor__label">{{ automationLabel('trigger.intervalMinutes', isZh) }}</label>
             <input v-model.number="draft.triggerConfig.intervalMinutes" class="meta-rule-editor__input" type="number" min="1" placeholder="5" data-field="intervalMinutes" />
+          </template>
+
+          <!-- schedule.date_field (date reminder) config -->
+          <template v-if="draft.triggerType === 'schedule.date_field'">
+            <label class="meta-rule-editor__label">{{ isZh ? '日期字段' : 'Date field' }}</label>
+            <select v-model="draft.triggerConfig.dateFieldId" class="meta-rule-editor__select" data-field="dateFieldId">
+              <option value="">{{ isZh ? '请选择日期字段' : 'Select a date field' }}</option>
+              <option v-for="field in dateReminderCandidateFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+            </select>
+            <label class="meta-rule-editor__label">{{ isZh ? '提前 / 延后天数' : 'Days offset' }}</label>
+            <input v-model.number="draft.triggerConfig.offsetDays" class="meta-rule-editor__input" type="number" min="0" placeholder="3" data-field="offsetDays" />
+            <label class="meta-rule-editor__label">{{ isZh ? '方向' : 'Direction' }}</label>
+            <select v-model="draft.triggerConfig.direction" class="meta-rule-editor__select" data-field="direction">
+              <option value="before">{{ isZh ? '日期之前' : 'Before the date' }}</option>
+              <option value="after">{{ isZh ? '日期之后' : 'After the date' }}</option>
+            </select>
+            <label class="meta-rule-editor__label">{{ isZh ? '触发时间（UTC，可选）' : 'Time of day (UTC, optional)' }}</label>
+            <input v-model="draft.triggerConfig.timeOfDay" class="meta-rule-editor__input" type="time" placeholder="09:00" data-field="timeOfDay" />
           </template>
         </section>
 
@@ -1304,6 +1323,7 @@ const internalViews = computed(() => (props.views ?? []).filter((view) => !view.
 const groupDestinationCandidateFields = computed(() => props.fields)
 const recipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
 const memberGroupRecipientCandidateFields = computed(() => props.fields.filter(isDingTalkMemberGroupRecipientField))
+const dateReminderCandidateFields = computed(() => props.fields.filter((field) => field.type === 'date' || field.type === 'dateTime'))
 const savedRuleHasDingTalkActions = computed(() => ruleHasDingTalkActions(props.rule))
 function dingTalkTestRunConfirmMessage(): string {
   const separator = isZh.value ? '' : ' '
@@ -2755,6 +2775,11 @@ function buildPayload(): Partial<AutomationRule> {
   const triggerConfig = { ...d.triggerConfig }
   if (d.triggerType === 'schedule.cron' && cronPreset.value !== 'custom') {
     triggerConfig.cron = cronPreset.value
+  }
+  if (d.triggerType === 'schedule.date_field') {
+    // Normalize the date-reminder config so an unset/garbage direction or offset can't persist a no-op rule.
+    triggerConfig.direction = triggerConfig.direction === 'after' ? 'after' : 'before'
+    triggerConfig.offsetDays = Number(triggerConfig.offsetDays) || 0
   }
   const actions = d.actions.map((action) => {
     if (action.type === 'condition_branch') {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -969,6 +969,7 @@ export type AutomationTriggerType =
   | 'field.value_changed'
   | 'schedule.cron'
   | 'schedule.interval'
+  | 'schedule.date_field'
   | 'webhook.received'
   | 'form.submitted'
   // Legacy aliases

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -878,6 +878,8 @@ export function automationTriggerTypeLabel(type: AutomationTriggerType | Unknown
       return isZh ? '定时计划（cron）' : 'Schedule (cron)'
     case 'schedule.interval':
       return isZh ? '定时计划（间隔）' : 'Schedule (interval)'
+    case 'schedule.date_field':
+      return isZh ? '日期提醒（按日期字段）' : 'Date reminder (by date field)'
     case 'webhook.received':
       return isZh ? '收到 Webhook 时' : 'Webhook received'
     case 'form.submitted':

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -217,7 +217,8 @@ describe('MetaAutomationRuleEditor', () => {
 
     const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
     expect(triggerSelect).toBeTruthy()
-    expect(triggerSelect.options.length).toBe(7)
+    // record.created/updated/deleted + field.value_changed + schedule.cron/interval/date_field + webhook.received
+    expect(triggerSelect.options.length).toBe(8)
   })
 
   it('localizes core rule editor chrome in zh-CN while keeping raw select values', async () => {
@@ -471,6 +472,20 @@ describe('MetaAutomationRuleEditor', () => {
 
     const cronSelect = container.querySelector('[data-field="cronPreset"]')
     expect(cronSelect).toBeTruthy()
+  })
+
+  it('shows date-field config (field/offset/direction) for schedule.date_field trigger', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    triggerSelect.value = 'schedule.date_field'
+    triggerSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="dateFieldId"]')).toBeTruthy()
+    expect(container.querySelector('[data-field="offsetDays"]')).toBeTruthy()
+    expect(container.querySelector('[data-field="direction"]')).toBeTruthy()
   })
 
   it('can add and remove conditions', async () => {

--- a/docs/development/multitable-date-reminder-trigger-dev-verification-20260628.md
+++ b/docs/development/multitable-date-reminder-trigger-dev-verification-20260628.md
@@ -1,0 +1,84 @@
+# Date-reminder automation trigger (`schedule.date_field`) — dev & verification (2026-06-28)
+
+> Status: built + verified (real-DB, with two fail-first proofs). Grounding: `origin/main` @ `43ef71ed9`.
+> The lightweight Feishu-parity arc recommended by the post-cross-base frontier note
+> (`docs/research/multitable-post-crossbase-frontier-decision-20260628.md`) and authorized by the owner
+> ("按建议执行" = GO on the #1 recommendation). Advisor-reviewed before implementation.
+
+## 1. The gap
+
+Feishu Base has a "remind N days before a deadline" primitive; multitable had **no date-driven trigger** —
+its automation triggers were all event-driven (`record.*`, `form.submitted`, `comment.created`) or fixed
+wall-clock (`schedule.cron` / `schedule.interval`). There was no way to fire "N days before/after the value
+of a record's date field". This adds that primitive: `schedule.date_field`.
+
+## 2. What it is
+
+A new trigger type `schedule.date_field` with config `{ dateFieldId, offsetDays, direction: 'before'|'after',
+timeOfDay?, timezone?, scanIntervalMs? }`. It is **data-driven**: every record has its own occurrence derived
+from its date field. A daily scan (leader-only, like cron) finds records whose occurrence is due, claims each
+in an idempotency ledger, and fires the rule once per due record with the record as context — so downstream
+actions (`send_notification`, `update_record`, …) resolve the record's fields normally.
+
+## 3. Design — the two things that make it correct (advisor-shaped)
+
+### Idempotency: occurrence is a PURE, day-bucketed key + claim-then-fire
+- `computeDateReminderOccurrence(dateValue, config)` is a **pure function** — it never reads NOW. The dedup key
+  is `(rule, record, occurrence)`; if tick time leaked into the occurrence, every tick would re-fire.
+- The occurrence is **day-bucketed** (UTC): the source date's time-of-day is stripped before the ±offsetDays
+  shift, then `timeOfDay` sets when on the reminder day it fires. Editing the deadline's *time* within the same
+  reminder day does **not** change the occurrence → no re-spam.
+- **Claim-then-fire** = AT-MOST-ONCE: `INSERT … ON CONFLICT DO NOTHING RETURNING` into
+  `meta_automation_date_reminder_fires`, fire **only** when the insert won. A crash in the gap drops that one
+  reminder (the documented at-most-once semantic) — preferable to at-least-once double-reminders.
+
+### Firing window: bounded so a fresh rule never backfill-blasts
+`isDateReminderDue(occ, now, scanWindow, ruleCreatedAt)` fires iff **all** hold (each an explicit product
+semantic, golden-locked):
+- `occ <= now` — due;
+- `occ > now - scanWindow` — within the recent window (a replica down longer than the window skips missed
+  reminders rather than replaying history; `scanWindow = 2× cadence`);
+- `occ >= ruleCreatedAt` — a rule never reaches into the past relative to when it was authored.
+
+Without the lower bound, creating a rule on a sheet of 1,000 dated records would blast 1,000 reminders on the
+first scan. The combined bound makes the answer **zero**. (Advisor's day-one failure mode — the first thing a
+reviewer probes; locked by DR-3.)
+
+### Scan pushes the coarse filter into SQL
+Date fields are stored as `toISOString()` (UTC). ISO strings sort chronologically, so the candidate window is a
+plain string `BETWEEN` — no `::timestamptz` cast that could throw on legacy junk. The exact predicate
+(`isDateReminderDue`) runs in JS on the bounded candidate set.
+
+## 4. Files
+
+Backend: `automation-date-reminder.ts` (pure core, new) · `automation-triggers.ts` (type) ·
+`automation-scheduler.ts` (register the scan cadence) · `automation-service.ts` (`evaluateDateReminders`
+scan/claim/fire + `runDateReminderScanNow` ops/test seam + VALID_TRIGGER_TYPES + 3 registration points) ·
+migrations: `…_add_date_field_trigger_type` (widen CHECK) + `…_create_date_reminder_fires` (ledger, FK
+ON DELETE CASCADE). Frontend: `types.ts` · `meta-automation-labels.ts` · `MetaAutomationRuleEditor.vue`
+(trigger option + date-field/offset/direction/time config + submit normalization).
+
+## 5. Verification
+
+- **Pure unit (no DB) — 16/16:** occurrence purity + day-bucketing + before/after/offset/default-time +
+  null-safety; firing-window (due / future / out-of-window / before-creation); clamp; candidate range.
+- **Real-DB integration — 5/5** (`multitable-date-reminder-trigger.test.ts`, wired into `plugin-tests.yml`):
+  DR-1 due record fires once (claim row + `update_record` marker stamped via the record context) · DR-2
+  idempotent (no new claim, no new execution on re-scan) · **DR-3 backfill bound** (the same due record under a
+  FRESH rule does NOT fire — occurrence < created_at) · DR-6 date edited to a new reminder-day fires a new
+  occurrence, old stays deduped.
+- **Two fail-first proofs:** disabling the dedup guard → DR-2 RED (re-fire); disabling the `created_at`
+  predicate → DR-3 RED (fresh rule backfills `claimCount=1`). Both restored → green.
+- **Typecheck:** backend `tsc --noEmit` exit 0; frontend `vue-tsc -b` exit 0; editor + labels specs 106/106
+  (trigger-option count 7→8 updated in place; a new render test added).
+
+## 6. Boundaries / deferred (named, not silent)
+
+- **Retention/aging** of `meta_automation_date_reminder_fires` is NOT built — rows are reaped on rule delete
+  (FK CASCADE) but long-lived rules grow the ledger. Deferred debt (the NiFi provenance benchmark flagged
+  retention as the bounded gap); a separate aging slice.
+- **Timezone:** v1 buckets in UTC (date fields are stored UTC). `timezone` is persisted but only `'UTC'` is
+  honored; tz-aware day boundaries need an IANA tz library — deferred.
+- **Sub-day offsets:** day-bucketing assumes whole-day `offsetDays`; hour-level offsets would revisit the key
+  granularity — out of v1.
+- At-most-once (not at-least-once) is the chosen v1 delivery semantic (documented in code).

--- a/docs/development/multitable-date-reminder-trigger-dev-verification-20260628.md
+++ b/docs/development/multitable-date-reminder-trigger-dev-verification-20260628.md
@@ -49,11 +49,24 @@ Date fields are stored as `toISOString()` (UTC). ISO strings sort chronologicall
 plain string `BETWEEN` — no `::timestamptz` cast that could throw on legacy junk. The exact predicate
 (`isDateReminderDue`) runs in JS on the bounded candidate set.
 
+### Save-boundary validation — the UI contract sunk into the API ([P2] review fix)
+The editor only offers `date`/`dateTime` fields, but a direct API / import / script write could persist any
+`dateFieldId` (incl. a non-date field), a negative `offsetDays`, or a non-UTC `timezone` — the scan would then
+warn+skip or mis-fire on an arbitrary parseable-string field. The "date-field reminder" contract was locked in
+the UI only. `validateDateFieldTriggerAtSave` (called from both `createRule` and `updateRule`, after the next
+trigger is composed) **fail-closes** it: `dateFieldId` must EXIST on the sheet and be a `date`/`dateTime` field;
+`offsetDays` a finite non-negative integer; `direction ∈ {before, after}`; `timeOfDay` a valid `HH:mm`; and a
+non-UTC `timezone` is **rejected** (not accept-and-ignore — v1 honors only UTC, so the saved rule's behavior
+matches its config). Any violation → `AutomationRuleValidationError` → 400. Mirrors the existing
+`assertResultWritebackFieldsAtSave` save-time field check. Also: `runDateReminderScanNow` now honors the
+`enabled` gate (a disabled rule is a no-op via the deterministic seam, parity with the scheduler).
+
 ## 4. Files
 
 Backend: `automation-date-reminder.ts` (pure core, new) · `automation-triggers.ts` (type) ·
 `automation-scheduler.ts` (register the scan cadence) · `automation-service.ts` (`evaluateDateReminders`
-scan/claim/fire + `runDateReminderScanNow` ops/test seam + VALID_TRIGGER_TYPES + 3 registration points) ·
+scan/claim/fire + `runDateReminderScanNow` ops/test seam (enabled-gated) + `validateDateFieldTriggerAtSave`
+wired into create/updateRule + VALID_TRIGGER_TYPES + 3 registration points) ·
 migrations: `…_add_date_field_trigger_type` (widen CHECK) + `…_create_date_reminder_fires` (ledger, FK
 ON DELETE CASCADE). Frontend: `types.ts` · `meta-automation-labels.ts` · `MetaAutomationRuleEditor.vue`
 (trigger option + date-field/offset/direction/time config + submit normalization).
@@ -62,13 +75,19 @@ ON DELETE CASCADE). Frontend: `types.ts` · `meta-automation-labels.ts` · `Meta
 
 - **Pure unit (no DB) — 16/16:** occurrence purity + day-bucketing + before/after/offset/default-time +
   null-safety; firing-window (due / future / out-of-window / before-creation); clamp; candidate range.
-- **Real-DB integration — 5/5** (`multitable-date-reminder-trigger.test.ts`, wired into `plugin-tests.yml`):
+- **Real-DB integration — 11/11** (`multitable-date-reminder-trigger.test.ts`, wired into `plugin-tests.yml`):
   DR-1 due record fires once (claim row + `update_record` marker stamped via the record context) · DR-2
   idempotent (no new claim, no new execution on re-scan) · **DR-3 backfill bound** (the same due record under a
   FRESH rule does NOT fire — occurrence < created_at) · DR-6 date edited to a new reminder-day fires a new
-  occurrence, old stays deduped.
-- **Two fail-first proofs:** disabling the dedup guard → DR-2 RED (re-fire); disabling the `created_at`
-  predicate → DR-3 RED (fresh rule backfills `claimCount=1`). Both restored → green.
+  occurrence, old stays deduped · **DR-VAL ×4** (unknown field / non-date string field / negative offset /
+  non-UTC timezone all → validation error at save) + valid date config saves · **DR-DISABLED** (a disabled
+  rule is a no-op via the seam).
+- **Three fail-first proofs:** disabling the dedup guard → DR-2 RED (re-fire); disabling the `created_at`
+  predicate → DR-3 RED (fresh rule backfills `claimCount=1`); disabling the save-boundary validator → the 4
+  DR-VAL rejection tests RED (bad-config rules persist). All restored → green.
+- **No regression on shared paths:** `createRule`/`updateRule` are shared — the shared automation unit suites
+  (`multitable-automation-service`, `automation-v1`) stay green; the validator no-ops for every non-date_field
+  trigger.
 - **Typecheck:** backend `tsc --noEmit` exit 0; frontend `vue-tsc -b` exit 0; editor + labels specs 106/106
   (trigger-option count 7→8 updated in place; a new render test added).
 

--- a/packages/core-backend/src/db/migrations/zzzz20260628120000_add_date_field_trigger_type.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260628120000_add_date_field_trigger_type.ts
@@ -1,0 +1,39 @@
+/**
+ * Migration: `schedule.date_field` automation trigger — widen the trigger_type CHECK constraint.
+ *
+ * The date-reminder trigger (fire N days before/after a record's date field) is added to the application's
+ * VALID_TRIGGER_TYPES (automation-service + automation-triggers). The DB CHECK constraint
+ * `chk_automation_trigger_type` on `automation_rules` predates it, so persisting a rule with
+ * trigger_type='schedule.date_field' would be rejected (23514). This widens the allowed set, preserving every
+ * existing value (base = the latest constraint from #22 form.submitted, which carries both the legacy
+ * `field.changed` and `field.value_changed`). Pure DDL; idempotent via DROP CONSTRAINT IF EXISTS.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval', 'schedule.date_field',
+      'webhook.received', 'form.submitted'
+    ))
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval',
+      'webhook.received', 'form.submitted'
+    ))
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260628120100_create_date_reminder_fires.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260628120100_create_date_reminder_fires.ts
@@ -1,0 +1,35 @@
+/**
+ * Migration: `meta_automation_date_reminder_fires` — the date-reminder idempotency ledger.
+ *
+ * A date-reminder scan computes, per record, a day-bucketed `occurrence_ts` (pure function of the record's
+ * date value + the rule's offset/direction/timeOfDay). To fire AT-MOST-ONCE per (rule, record, occurrence)
+ * across ticks AND replicas, the scan claims the occurrence here FIRST (INSERT ... ON CONFLICT DO NOTHING)
+ * and only fires when the insert won. The composite PRIMARY KEY is the dedup key. occurrence_ts is the
+ * day-bucketed reminder instant (NOT the wall-clock fire time — `fired_at` records that), so editing a
+ * deadline to a NEW day produces a NEW occurrence (fires once) while same-day edits stay deduped.
+ *
+ * FK → automation_rules(id) ON DELETE CASCADE: deleting a rule reaps its ledger rows (the common churn).
+ * Retention/aging of long-lived rows is intentionally NOT built here — deferred debt (see the dev doc; the
+ * NiFi provenance benchmark flagged retention as the bounded gap). Pure DDL; idempotent.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_automation_date_reminder_fires (
+      rule_id text NOT NULL REFERENCES automation_rules(id) ON DELETE CASCADE,
+      record_id text NOT NULL,
+      occurrence_ts timestamptz NOT NULL,
+      fired_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (rule_id, record_id, occurrence_ts)
+    )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_date_reminder_fires_rule
+    ON meta_automation_date_reminder_fires (rule_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_automation_date_reminder_fires`.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-date-reminder.test.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure-core unit tests for the date-reminder trigger (`schedule.date_field`). No DB. These pin the two
+ * invariants that make idempotency work: occurrence is a PURE, day-bucketed function of (dateValue, config)
+ * — never NOW — and the firing window bounds the lower edge so a fresh rule never backfill-blasts history.
+ */
+import { describe, expect, test } from 'vitest'
+
+import {
+  computeDateReminderOccurrence,
+  isDateReminderDue,
+  dateReminderScanIntervalMs,
+  dateReminderScanWindowMs,
+  dateReminderCandidateDateRange,
+} from './automation-date-reminder'
+
+const DAY = 24 * 60 * 60 * 1000
+
+describe('computeDateReminderOccurrence — pure, day-bucketed', () => {
+  test('N days BEFORE at a time-of-day', () => {
+    expect(
+      computeDateReminderOccurrence('2026-06-28T14:30:00.000Z', { offsetDays: 3, direction: 'before', timeOfDay: '09:00' }),
+    ).toBe('2026-06-25T09:00:00.000Z')
+  })
+
+  test('N days AFTER', () => {
+    expect(
+      computeDateReminderOccurrence('2026-06-28T00:00:00.000Z', { offsetDays: 2, direction: 'after', timeOfDay: '00:00' }),
+    ).toBe('2026-06-30T00:00:00.000Z')
+  })
+
+  test('DAY-BUCKETED: the source time-of-day is stripped — same date, different time ⇒ same occurrence', () => {
+    const cfg = { offsetDays: 1, direction: 'before' as const, timeOfDay: '09:00' }
+    const a = computeDateReminderOccurrence('2026-06-28T00:00:01.000Z', cfg)
+    const b = computeDateReminderOccurrence('2026-06-28T23:59:59.000Z', cfg)
+    expect(a).toBe('2026-06-27T09:00:00.000Z')
+    expect(b).toBe(a) // editing the deadline's time within the same day must NOT change the occurrence
+  })
+
+  test('PURE: same inputs ⇒ same output, independent of when called (no NOW leak)', () => {
+    const cfg = { offsetDays: 5, direction: 'after' as const, timeOfDay: '12:30' }
+    const first = computeDateReminderOccurrence('2026-01-15T08:00:00.000Z', cfg)
+    const second = computeDateReminderOccurrence('2026-01-15T08:00:00.000Z', cfg)
+    expect(first).toBe(second)
+    expect(first).toBe('2026-01-20T12:30:00.000Z')
+  })
+
+  test('offset 0 before ⇒ the same day at the configured time', () => {
+    expect(
+      computeDateReminderOccurrence('2026-06-28T18:00:00.000Z', { offsetDays: 0, direction: 'before', timeOfDay: '09:00' }),
+    ).toBe('2026-06-28T09:00:00.000Z')
+  })
+
+  test('default time-of-day is 09:00 when omitted/garbage', () => {
+    expect(computeDateReminderOccurrence('2026-06-28T18:00:00.000Z', { offsetDays: 0, direction: 'before' })).toBe(
+      '2026-06-28T09:00:00.000Z',
+    )
+    expect(
+      computeDateReminderOccurrence('2026-06-28T18:00:00.000Z', { offsetDays: 0, direction: 'before', timeOfDay: 'nope' }),
+    ).toBe('2026-06-28T09:00:00.000Z')
+  })
+
+  test('null / empty / unparseable date ⇒ null', () => {
+    const cfg = { offsetDays: 1, direction: 'before' as const }
+    expect(computeDateReminderOccurrence(null, cfg)).toBeNull()
+    expect(computeDateReminderOccurrence(undefined, cfg)).toBeNull()
+    expect(computeDateReminderOccurrence('', cfg)).toBeNull()
+    expect(computeDateReminderOccurrence('not-a-date', cfg)).toBeNull()
+  })
+})
+
+describe('isDateReminderDue — firing window (backfill bound)', () => {
+  const now = Date.parse('2026-06-25T12:00:00.000Z')
+  const window = dateReminderScanWindowMs(DAY) // 2 days
+  const created = Date.parse('2026-06-01T00:00:00.000Z')
+
+  test('due + within window + after creation ⇒ true', () => {
+    expect(isDateReminderDue('2026-06-25T09:00:00.000Z', now, window, created)).toBe(true)
+  })
+
+  test('future occurrence ⇒ false (not yet due)', () => {
+    expect(isDateReminderDue('2026-06-25T18:00:00.000Z', now, window, created)).toBe(false)
+  })
+
+  test('older than the recent window ⇒ false (never backfill-blast)', () => {
+    // occurrence 3+ days ago, window is 2 days → outside the window.
+    expect(isDateReminderDue('2026-06-22T09:00:00.000Z', now, window, created)).toBe(false)
+  })
+
+  test('occurrence before the rule was created ⇒ false (no reach into the past)', () => {
+    const createdLate = Date.parse('2026-06-25T11:00:00.000Z')
+    expect(isDateReminderDue('2026-06-25T09:00:00.000Z', now, window, createdLate)).toBe(false)
+  })
+
+  test('unparseable occurrence ⇒ false', () => {
+    expect(isDateReminderDue('garbage', now, window, created)).toBe(false)
+  })
+})
+
+describe('dateReminderScanIntervalMs — clamp [1h, 7d], default daily', () => {
+  test('default = 24h', () => {
+    expect(dateReminderScanIntervalMs({})).toBe(DAY)
+  })
+  test('floor at 1h', () => {
+    expect(dateReminderScanIntervalMs({ scanIntervalMs: 1000 })).toBe(60 * 60 * 1000)
+  })
+  test('cap at 7d', () => {
+    expect(dateReminderScanIntervalMs({ scanIntervalMs: 999 * DAY })).toBe(7 * DAY)
+  })
+})
+
+describe('dateReminderCandidateDateRange — SQL pre-filter brackets the productive date value', () => {
+  test("a record whose occurrence lands at NOW has its date value inside the range", () => {
+    const now = Date.parse('2026-06-25T12:00:00.000Z')
+    const window = dateReminderScanWindowMs(DAY)
+    const cfg = { offsetDays: 3, direction: 'before' as const }
+    const { loIso, hiIso } = dateReminderCandidateDateRange(now, cfg, window)
+    // occurrence = dateDay - 3d. For occurrence ≈ now (06-25), dateDay ≈ 06-28.
+    const dateValue = '2026-06-28T10:00:00.000Z'
+    expect(dateValue >= loIso && dateValue <= hiIso).toBe(true)
+    // a far-future date (occurrence well beyond now) is OUTSIDE the range.
+    expect('2026-09-01T00:00:00.000Z' <= hiIso).toBe(false)
+  })
+})

--- a/packages/core-backend/src/multitable/automation-date-reminder.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.ts
@@ -1,0 +1,139 @@
+/**
+ * Date-reminder trigger (`schedule.date_field`) — PURE core logic (2026-06-28).
+ *
+ * A date-reminder fires relative to the value of a record's DATE field: "N days before/after the date in
+ * field X". Unlike `schedule.cron`/`schedule.interval` (fixed wall-clock cadence), the fire time is
+ * DATA-DRIVEN — every record has its own occurrence derived from its date value. This module holds the pure,
+ * NOW-free helpers (occurrence computation, the firing-window predicate, the SQL pre-filter range, cadence);
+ * the scan/dedupe/fire orchestration lives in AutomationService.evaluateDateReminders.
+ *
+ * Two invariants make idempotency work and MUST hold:
+ *   1. `computeDateReminderOccurrence` is a PURE function of (dateValue, config) — it NEVER reads NOW or tick
+ *      time. The dedup key is (rule, record, occurrence); if tick time leaked into the occurrence, the key
+ *      would change every tick and every tick would re-fire.
+ *   2. The occurrence is DAY-BUCKETED: the source date's time-of-day is stripped (UTC midnight) before the
+ *      ±offsetDays shift, then `timeOfDay` sets when on the reminder day it fires. So editing the deadline's
+ *      time within the same reminder day does not change the occurrence → no re-spam. (Day-bucketing assumes
+ *      offsetDays granularity; sub-day offsets are a future revisit — out of v1.)
+ *
+ * Timezone: v1 buckets in UTC (date fields are stored as `toISOString()` = UTC). A tz-aware day boundary
+ * needs an IANA tz library and is deferred; `config.timezone` is accepted+persisted but only `'UTC'` is
+ * honored in v1 (documented limitation).
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export interface ScheduleDateFieldConfig {
+  /** The DATE/dateTime field whose value anchors the reminder. */
+  dateFieldId: string
+  /** Whole days before/after the date value. >= 0. */
+  offsetDays: number
+  /** Fire this many days BEFORE the date, or AFTER it. */
+  direction: 'before' | 'after'
+  /** When on the reminder day to fire, 'HH:mm' (UTC, v1). Default '09:00'. */
+  timeOfDay?: string
+  /** Persisted but v1 honors only 'UTC' (documented limitation). */
+  timezone?: string
+  /** Scan cadence override in ms (default 24h). Not load-bearing for correctness — the window is. */
+  scanIntervalMs?: number
+}
+
+/** Default daily scan — matches the "N days before" semantic. */
+export const DEFAULT_DATE_REMINDER_SCAN_INTERVAL_MS = DAY_MS
+
+/** Clamp the scan cadence to [1h, 7d]; default daily. */
+export function dateReminderScanIntervalMs(config: Partial<ScheduleDateFieldConfig>): number {
+  const raw = typeof config.scanIntervalMs === 'number' ? config.scanIntervalMs : DEFAULT_DATE_REMINDER_SCAN_INTERVAL_MS
+  const MIN = 60 * 60 * 1000
+  const MAX = 7 * DAY_MS
+  if (!Number.isFinite(raw) || raw < MIN) return MIN
+  if (raw > MAX) return MAX
+  return Math.floor(raw)
+}
+
+/** Parse 'HH:mm' → minutes-since-midnight, or 540 (09:00) on junk. */
+function parseTimeOfDayMinutes(timeOfDay: string | undefined): number {
+  if (typeof timeOfDay !== 'string') return 9 * 60
+  const m = /^(\d{1,2}):(\d{2})$/.exec(timeOfDay.trim())
+  if (!m) return 9 * 60
+  const hh = Number(m[1])
+  const mm = Number(m[2])
+  if (hh < 0 || hh > 23 || mm < 0 || mm > 59) return 9 * 60
+  return hh * 60 + mm
+}
+
+/**
+ * PURE occurrence: the instant a record's reminder should fire, day-bucketed in UTC. Returns an ISO string,
+ * or null if the date value is absent/unparseable. NEVER reads NOW.
+ */
+export function computeDateReminderOccurrence(
+  dateValue: unknown,
+  config: { offsetDays?: number; direction?: 'before' | 'after'; timeOfDay?: string },
+): string | null {
+  if (dateValue === null || dateValue === undefined || dateValue === '') return null
+  const d = dateValue instanceof Date ? dateValue : new Date(String(dateValue))
+  const t = d.getTime()
+  if (Number.isNaN(t)) return null
+
+  // Day-bucket: strip the source time-of-day to UTC midnight, then shift by whole days.
+  const dayUtcMidnight = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+  const offset = Number.isFinite(config.offsetDays) ? Math.trunc(config.offsetDays) : 0
+  const signedDays = config.direction === 'after' ? offset : -offset
+  const reminderDay = dayUtcMidnight + signedDays * DAY_MS
+  const occurrenceMs = reminderDay + parseTimeOfDayMinutes(config.timeOfDay) * 60 * 1000
+  return new Date(occurrenceMs).toISOString()
+}
+
+/**
+ * PURE firing-window predicate. A record's occurrence fires iff:
+ *   - it is DUE (`occurrence <= now`), AND
+ *   - it is within the recent scan window (`occurrence > now - scanWindowMs`) — so a fresh rule on a sheet of
+ *     long-past records does NOT backfill-blast, and a replica that was down longer than the window skips
+ *     missed reminders rather than replaying history, AND
+ *   - it is at/after the rule's creation (`occurrence >= ruleCreatedAtMs`) — a rule never reaches into the
+ *     past relative to when it was authored.
+ * `scanWindowMs` should be the scan cadence plus grace (see `dateReminderScanWindowMs`). At-most-once by
+ * construction (paired with claim-then-fire). All bounds are explicit product semantics, locked by goldens.
+ */
+export function isDateReminderDue(
+  occurrenceIso: string,
+  nowMs: number,
+  scanWindowMs: number,
+  ruleCreatedAtMs: number,
+): boolean {
+  const occ = new Date(occurrenceIso).getTime()
+  if (Number.isNaN(occ)) return false
+  if (occ > nowMs) return false // not yet due
+  if (occ <= nowMs - scanWindowMs) return false // older than the recent window — never backfill
+  if (occ < ruleCreatedAtMs) return false // rule does not reach into the past
+  return true
+}
+
+/** The recent window = one scan cadence + a grace multiple, so a single missed tick still catches up. */
+export function dateReminderScanWindowMs(scanIntervalMs: number): number {
+  return scanIntervalMs * 2
+}
+
+/**
+ * PURE coarse date-VALUE range for the SQL pre-filter. Only records whose date field falls in this window
+ * can possibly produce an occurrence in the firing window, so SQL fetches just those (ISO strings sort
+ * chronologically → a plain string BETWEEN works, no cast that could throw on legacy junk). Deliberately
+ * GENEROUS (±2 day slack for day-bucketing + timeOfDay); the JS predicate (`isDateReminderDue`) is the exact
+ * gate. Returns inclusive ISO bounds.
+ */
+export function dateReminderCandidateDateRange(
+  nowMs: number,
+  config: { offsetDays?: number; direction?: 'before' | 'after' },
+  scanWindowMs: number,
+): { loIso: string; hiIso: string } {
+  const offset = Number.isFinite(config.offsetDays) ? Math.trunc(config.offsetDays) : 0
+  const signedDays = config.direction === 'after' ? offset : -offset
+  // occurrence = dateDay + signedDays*DAY (+timeOfDay). Inverting: dateDay = occurrence - signedDays*DAY.
+  // occurrence ∈ (now - window, now]  ⇒  dateDay ∈ (now - window, now] - signedDays*DAY. Add ±2d slack.
+  const SLACK = 2 * DAY_MS
+  const occLo = nowMs - scanWindowMs
+  const occHi = nowMs
+  const lo = occLo - signedDays * DAY_MS - SLACK
+  const hi = occHi - signedDays * DAY_MS + SLACK
+  return { loIso: new Date(lo).toISOString(), hiIso: new Date(hi).toISOString() }
+}

--- a/packages/core-backend/src/multitable/automation-scheduler.ts
+++ b/packages/core-backend/src/multitable/automation-scheduler.ts
@@ -5,6 +5,7 @@
  */
 
 import { Logger } from '../core/logger'
+import { dateReminderScanIntervalMs, type ScheduleDateFieldConfig } from './automation-date-reminder'
 import type { AutomationRule } from './automation-executor'
 import type { RedisLeaderLock } from './redis-leader-lock'
 
@@ -285,6 +286,11 @@ export class AutomationScheduler {
         logger.warn(`Rule ${rule.id}: unsupported cron expression: ${expression}`)
         return
       }
+    } else if (trigger.type === 'schedule.date_field') {
+      // Date-reminder: a fixed SCAN cadence (default daily). The timer fires the same callback as cron, but
+      // the service callback branches on the type and runs evaluateDateReminders (scan → claim → fire) rather
+      // than executing the rule once. Correctness lives in the firing-window predicate, not the cadence.
+      intervalMs = dateReminderScanIntervalMs(trigger.config as Partial<ScheduleDateFieldConfig>)
     } else {
       // Not a schedule trigger — skip
       return

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1,8 +1,16 @@
 import { randomUUID } from 'crypto'
-import type { Kysely } from 'kysely'
+import { sql, type Kysely } from 'kysely'
 import type { EventBus } from '../integration/events/event-bus'
 import { Logger } from '../core/logger'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, type AutomationTriggerType } from './automation-triggers'
+import {
+  computeDateReminderOccurrence,
+  isDateReminderDue,
+  dateReminderScanIntervalMs,
+  dateReminderScanWindowMs,
+  dateReminderCandidateDateRange,
+  type ScheduleDateFieldConfig,
+} from './automation-date-reminder'
 import { ensureRecordNotLocked } from './record-lock'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { extractSelectOptions } from './field-codecs'
@@ -57,6 +65,7 @@ const VALID_TRIGGER_TYPES = new Set([
   'field.value_changed',
   'schedule.cron',
   'schedule.interval',
+  'schedule.date_field',
   'webhook.received',
   'form.submitted',
 ])
@@ -673,7 +682,12 @@ export class AutomationService {
     this.approvalBridgeService = new AutomationApprovalBridgeService(this.jobService)
     this.scheduler = new AutomationScheduler(
       async (rule) => {
-        await this.executeRule(rule, { _triggeredBy: 'schedule' })
+        // Date-reminder rules scan → claim → fire per due record; other schedule rules execute once.
+        if (rule.trigger.type === 'schedule.date_field') {
+          await this.evaluateDateReminders(rule)
+        } else {
+          await this.executeRule(rule, { _triggeredBy: 'schedule' })
+        }
       },
       schedulerLeaderOptions,
       schedulerRuntime,
@@ -1013,7 +1027,11 @@ export class AutomationService {
   async registerScheduledRules(sheetId: string): Promise<void> {
     const rules = await this.loadEnabledRules(sheetId)
     for (const rule of rules) {
-      if (rule.trigger_type === 'schedule.cron' || rule.trigger_type === 'schedule.interval') {
+      if (
+        rule.trigger_type === 'schedule.cron' ||
+        rule.trigger_type === 'schedule.interval' ||
+        rule.trigger_type === 'schedule.date_field'
+      ) {
         this.scheduler.register(toExecutorRule(rule))
       }
     }
@@ -1034,7 +1052,7 @@ export class AutomationService {
       .selectFrom('automation_rules')
       .selectAll()
       .where('enabled', '=', true)
-      .where('trigger_type', 'in', ['schedule.cron', 'schedule.interval'])
+      .where('trigger_type', 'in', ['schedule.cron', 'schedule.interval', 'schedule.date_field'])
       .execute()
 
     for (const row of rows) {
@@ -1052,9 +1070,99 @@ export class AutomationService {
    */
   registerSchedule(rule: AutomationRule): void {
     const execRule = toExecutorRule(rule)
-    if (execRule.trigger.type === 'schedule.cron' || execRule.trigger.type === 'schedule.interval') {
+    if (
+      execRule.trigger.type === 'schedule.cron' ||
+      execRule.trigger.type === 'schedule.interval' ||
+      execRule.trigger.type === 'schedule.date_field'
+    ) {
       this.scheduler.register(execRule)
     }
+  }
+
+  /**
+   * Date-reminder scan (`schedule.date_field`). For each record in the rule's sheet whose date field yields a
+   * DUE occurrence, claim it in the idempotency ledger and fire the rule once with the record as context.
+   *
+   * Idempotency = claim-then-fire (AT-MOST-ONCE): INSERT the (rule, record, occurrence) row ON CONFLICT DO
+   * NOTHING and fire ONLY when the insert won. A crash between claim and fire drops that one reminder — the
+   * documented at-most-once semantic, preferable to at-least-once double-reminders. `isDateReminderDue`
+   * bounds the lower edge so a fresh rule over historical records never backfill-blasts, and `occurrence` is a
+   * pure, day-bucketed function of the record's date value + config (never NOW) → the dedup key is stable
+   * across ticks. The coarse date-value range pushes the scan into SQL (ISO date strings sort
+   * chronologically, so a string BETWEEN works without a cast that could throw on legacy data).
+   *
+   * The fire payload mirrors the record.* shape (`{ recordId, data }`) the executor maps to
+   * `context.recordData`, so downstream actions (e.g. send_notification) resolve record fields normally.
+   */
+  private async evaluateDateReminders(rule: ExecutorRule): Promise<void> {
+    const config = rule.trigger.config as Partial<ScheduleDateFieldConfig>
+    const dateFieldId = typeof config.dateFieldId === 'string' ? config.dateFieldId : ''
+    if (
+      !dateFieldId ||
+      typeof config.offsetDays !== 'number' ||
+      (config.direction !== 'before' && config.direction !== 'after')
+    ) {
+      logger.warn(`Rule ${rule.id}: invalid schedule.date_field config — skipping scan`)
+      return
+    }
+
+    const nowMs = Date.now()
+    const scanWindowMs = dateReminderScanWindowMs(dateReminderScanIntervalMs(config))
+    const createdAtMs = new Date(rule.createdAt).getTime()
+    const ruleCreatedAtMs = Number.isNaN(createdAtMs) ? 0 : createdAtMs
+    const { loIso, hiIso } = dateReminderCandidateDateRange(nowMs, config, scanWindowMs)
+
+    // Coarse SQL pre-filter: only records whose date field falls in the window can produce a due occurrence.
+    const candidates = await sql<{ id: string; data: Record<string, unknown> | string | null }>`
+      SELECT id, data
+        FROM meta_records
+       WHERE sheet_id = ${rule.sheetId}
+         AND data ->> ${dateFieldId} IS NOT NULL
+         AND data ->> ${dateFieldId} BETWEEN ${loIso} AND ${hiIso}
+    `.execute(this.db)
+
+    let fired = 0
+    for (const rec of candidates.rows) {
+      const data: Record<string, unknown> =
+        typeof rec.data === 'string' ? (JSON.parse(rec.data) as Record<string, unknown>) : (rec.data ?? {})
+      const occurrence = computeDateReminderOccurrence(data[dateFieldId], config)
+      if (!occurrence) continue
+      if (!isDateReminderDue(occurrence, nowMs, scanWindowMs, ruleCreatedAtMs)) continue
+
+      // Claim-then-fire: insert the dedup row; fire ONLY if WE won the insert (at-most-once).
+      const claim = await sql<{ record_id: string }>`
+        INSERT INTO meta_automation_date_reminder_fires (rule_id, record_id, occurrence_ts)
+        VALUES (${rule.id}, ${rec.id}, ${occurrence})
+        ON CONFLICT DO NOTHING
+        RETURNING record_id
+      `.execute(this.db)
+      if (claim.rows.length === 0) continue // a prior tick / replica already fired this occurrence
+
+      await this.executeRule(rule, {
+        recordId: rec.id,
+        data,
+        sheetId: rule.sheetId,
+        occurrenceTs: occurrence,
+        _triggeredBy: 'date_reminder',
+      })
+      fired += 1
+    }
+    if (fired > 0) {
+      logger.info(`Date-reminder rule ${rule.id}: fired ${fired} reminder(s)`)
+    }
+  }
+
+  /**
+   * Run ONE date-reminder scan for a single rule immediately — an ops "run now" / diagnostics hook (and the
+   * deterministic test seam, since the scheduler's setInterval cadence is not test-friendly). Loads the rule
+   * and, only if it is a `schedule.date_field` rule, runs the scan → claim → fire pass once. No-op otherwise.
+   */
+  async runDateReminderScanNow(ruleId: string): Promise<void> {
+    const rule = await this.getRule(ruleId)
+    if (!rule) return
+    const execRule = toExecutorRule(rule)
+    if (execRule.trigger.type !== 'schedule.date_field') return
+    await this.evaluateDateReminders(execRule)
   }
 
   /**

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -794,6 +794,9 @@ export class AutomationService {
     const writebackFieldError = await this.assertResultWritebackFieldsAtSave(sheetId, actionsForValidation)
     if (writebackFieldError) throw new AutomationRuleValidationError(writebackFieldError)
 
+    const dateTriggerError = await this.validateDateFieldTriggerAtSave(sheetId, input.triggerType, input.triggerConfig ?? null)
+    if (dateTriggerError) throw new AutomationRuleValidationError(dateTriggerError)
+
     const row = {
       id: ruleId,
       sheet_id: sheetId,
@@ -953,6 +956,22 @@ export class AutomationService {
     if (input.conditions !== undefined) updates.conditions = input.conditions ? JSON.stringify(input.conditions) : null
     if (input.actions !== undefined) updates.actions = normalizedActionsForUpdate ? JSON.stringify(normalizedActionsForUpdate) : null
     if (input.executionMode !== undefined) updates.execution_mode = normalizedExecutionModeForUpdate ?? normalizeExecutionMode(input.executionMode)
+
+    // W (date-reminder): validate a RESULTING schedule.date_field trigger at the SAVE boundary — fires when the
+    // trigger type/config is being changed and the result is a date_field rule (explicit type, or a config
+    // change on an existing date_field rule). Mirrors createRule's gate so the API can't bypass the UI contract.
+    if (input.triggerType !== undefined || input.triggerConfig !== undefined) {
+      const existingForTrigger = await this.getRule(ruleId)
+      if (!existingForTrigger || existingForTrigger.sheet_id !== sheetId) return null
+      const nextTriggerType = input.triggerType ?? existingForTrigger.trigger_type
+      const nextTriggerConfig = input.triggerConfig !== undefined ? input.triggerConfig : existingForTrigger.trigger_config
+      const dateTriggerError = await this.validateDateFieldTriggerAtSave(
+        sheetId,
+        nextTriggerType,
+        nextTriggerConfig as Record<string, unknown> | null,
+      )
+      if (dateTriggerError) throw new AutomationRuleValidationError(dateTriggerError)
+    }
 
     if (Object.keys(updates).length === 0) return this.getRule(ruleId)
 
@@ -1160,9 +1179,71 @@ export class AutomationService {
   async runDateReminderScanNow(ruleId: string): Promise<void> {
     const rule = await this.getRule(ruleId)
     if (!rule) return
+    // A DISABLED rule never fires via the scheduler (registerSchedule gates on enabled); the deterministic
+    // ops/test seam honors the same gate so a disabled rule can't be made to fire through this path.
+    if (!rule.enabled) return
     const execRule = toExecutorRule(rule)
     if (execRule.trigger.type !== 'schedule.date_field') return
     await this.evaluateDateReminders(execRule)
+  }
+
+  /**
+   * Date-reminder SAVE-boundary validator — sink the editor's date-field contract into createRule/updateRule
+   * so a direct API / import / script write cannot persist a `schedule.date_field` rule that looks saved but
+   * silently skips or mis-fires at scan. Returns a validation-error string (→ AutomationRuleValidationError →
+   * 400) or null. No-op for any other trigger type.
+   *
+   * Enforces: dateFieldId EXISTS on this sheet AND is a `date`/`dateTime` field (not an arbitrary string
+   * field that happens to parse); offsetDays is a finite non-negative integer; direction ∈ {before, after};
+   * timeOfDay (if given) is HH:mm; timezone is rejected unless 'UTC' (v1 honors only UTC — reject, don't
+   * accept-and-ignore, so the saved rule's behavior matches its config).
+   */
+  private async validateDateFieldTriggerAtSave(
+    sheetId: string,
+    triggerType: string,
+    triggerConfig: Record<string, unknown> | null | undefined,
+  ): Promise<string | null> {
+    if (triggerType !== 'schedule.date_field') return null
+    const cfg = isRecord(triggerConfig) ? triggerConfig : {}
+
+    const dateFieldId = typeof cfg.dateFieldId === 'string' ? cfg.dateFieldId.trim() : ''
+    if (!dateFieldId) return 'schedule.date_field requires a dateFieldId'
+
+    if (cfg.direction !== 'before' && cfg.direction !== 'after') {
+      return "schedule.date_field direction must be 'before' or 'after'"
+    }
+
+    const offsetDays = cfg.offsetDays
+    if (
+      typeof offsetDays !== 'number' ||
+      !Number.isFinite(offsetDays) ||
+      !Number.isInteger(offsetDays) ||
+      offsetDays < 0
+    ) {
+      return 'schedule.date_field offsetDays must be a non-negative integer'
+    }
+
+    if (cfg.timeOfDay !== undefined && cfg.timeOfDay !== null && cfg.timeOfDay !== '') {
+      const t = typeof cfg.timeOfDay === 'string' ? cfg.timeOfDay : ''
+      const m = /^(\d{1,2}):(\d{2})$/.exec(t)
+      if (!m || Number(m[1]) > 23 || Number(m[2]) > 59) {
+        return 'schedule.date_field timeOfDay must be HH:mm (00:00–23:59)'
+      }
+    }
+
+    if (cfg.timezone !== undefined && cfg.timezone !== null && cfg.timezone !== '' && cfg.timezone !== 'UTC') {
+      return `schedule.date_field timezone v1 supports only 'UTC' (got ${String(cfg.timezone)})`
+    }
+
+    const res = await this.queryFn('SELECT type FROM meta_fields WHERE sheet_id = $1 AND id = $2', [sheetId, dateFieldId])
+    const row = (res.rows as Array<{ type: unknown }>)[0]
+    if (!row) return `schedule.date_field dateFieldId not found on sheet: ${dateFieldId}`
+    const fieldType = typeof row.type === 'string' ? row.type : ''
+    if (fieldType !== 'date' && fieldType !== 'dateTime') {
+      return `schedule.date_field dateFieldId must be a date/dateTime field (got ${fieldType || 'unknown'})`
+    }
+
+    return null
   }
 
   /**

--- a/packages/core-backend/src/multitable/automation-triggers.ts
+++ b/packages/core-backend/src/multitable/automation-triggers.ts
@@ -10,6 +10,7 @@ export type AutomationTriggerType =
   | 'field.value_changed'
   | 'schedule.cron'
   | 'schedule.interval'
+  | 'schedule.date_field'
   | 'webhook.received'
   | 'form.submitted'
 
@@ -20,6 +21,7 @@ export const ALL_TRIGGER_TYPES: AutomationTriggerType[] = [
   'field.value_changed',
   'schedule.cron',
   'schedule.interval',
+  'schedule.date_field',
   'webhook.received',
   'form.submitted',
 ]

--- a/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Date-reminder trigger (`schedule.date_field`) — real-DB wire proof of scan → claim → fire (2026-06-28).
+ *
+ * The fire time is DATA-DRIVEN (per record's date field), so correctness hinges on idempotency + a bounded
+ * firing window, not a wall-clock cadence. This suite drives `runDateReminderScanNow` (the deterministic ops
+ * seam) against real Postgres and asserts the two day-one failure modes are closed:
+ *   DR-1  fires once for a DUE record (claim row + end-to-end update_record marker, via the record context).
+ *   DR-2  IDEMPOTENT — a second scan adds no claim row, logs no new execution, double-writes nothing.
+ *   DR-3  BACKFILL bound — the SAME due record under a FRESH rule (created_at = now) does NOT fire, because
+ *         its occurrence predates the rule's creation. This isolates the created_at predicate (the SQL window
+ *         still fetches the record; isDateReminderDue rejects it). The day-one blast a reviewer probes first.
+ *   DR-4  a far-FUTURE date does not fire.
+ *   DR-5  null / absent date is skipped.
+ *   DR-6  editing the date to a NEW reminder-day produces a NEW occurrence (fires again); the old occurrence
+ *         stays deduped (no re-spam of the original day).
+ *
+ * created_at is BACKDATED on the primary rule so a record's occurrence can legitimately fall in
+ * (created_at, now] — a just-created rule can only ever fire for occurrences at/after its creation (that IS
+ * the backfill guarantee), which is exactly what DR-3 pins. Runs only with DATABASE_URL.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { db } from '../../src/db/db'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE = `base_dr_${TS}`
+const SHEET = `sheet_dr_${TS}`
+const FLD_DATE = `fld_dr_date_${TS}`
+const FLD_MARK = `fld_dr_mark_${TS}`
+const REC_DUE = `rec_dr_due_${TS}`
+const REC_FUTURE = `rec_dr_future_${TS}`
+const REC_NULL = `rec_dr_null_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+// Real db + queryFn so the scan (this.db) AND the fired update_record action (queryFn) both hit live Postgres.
+const svc = new AutomationService(new EventBus(), db as never, q as never)
+
+const DAY = 24 * 60 * 60 * 1000
+const iso = (ms: number) => new Date(ms).toISOString()
+
+let RULE_BACKDATED = ''
+let RULE_FRESH = ''
+
+/** Count claim (fire) rows for a rule in the idempotency ledger. */
+const claimCount = async (ruleId: string): Promise<number> => {
+  const r = await q('SELECT count(*)::int AS n FROM meta_automation_date_reminder_fires WHERE rule_id = $1', [ruleId])
+  return (r.rows as Array<{ n: number }>)[0].n
+}
+/** Count logged executions for a rule (each fire records one). */
+const execCount = async (ruleId: string): Promise<number> => {
+  const r = await q('SELECT count(*)::int AS n FROM multitable_automation_executions WHERE rule_id = $1', [ruleId])
+  return (r.rows as Array<{ n: number }>)[0].n
+}
+const recordData = async (recordId: string): Promise<Record<string, unknown>> => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+  const d = (r.rows[0] as { data: unknown } | undefined)?.data
+  return (typeof d === 'string' ? JSON.parse(d) : (d as Record<string, unknown>)) ?? {}
+}
+
+describeIfDatabase('multitable date-reminder trigger — scan/claim/fire (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'DR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'DR Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_DATE, SHEET, 'Due', 'date', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_MARK, SHEET, 'Mark', 'string', '{}', 2])
+
+    // REC_DUE date = now + 3 days. With offset=3/before/timeOfDay=00:00 the occurrence day-buckets to TODAY
+    // 00:00 UTC, which is <= now (due) and within the recent window. REC_FUTURE is far out; REC_NULL has none.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_DUE, SHEET, JSON.stringify({ [FLD_DATE]: iso(TS + 3 * DAY) })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_FUTURE, SHEET, JSON.stringify({ [FLD_DATE]: iso(TS + 30 * DAY) })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_NULL, SHEET, JSON.stringify({ [FLD_MARK]: 'x' })])
+
+    const ruleConfig = {
+      name: `dr ${TS}`,
+      triggerType: 'schedule.date_field',
+      triggerConfig: { dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timeOfDay: '00:00' },
+      actionType: 'update_record',
+      actionConfig: { fields: { [FLD_MARK]: 'reminded' } },
+    } as never
+
+    const backdated = await svc.createRule(SHEET, ruleConfig)
+    RULE_BACKDATED = backdated.id
+    // Backdate creation so REC_DUE's occurrence (today 00:00) is >= created_at — the only way a freshly-made
+    // rule could fire for it. (DR-3 keeps a FRESH rule to prove the opposite.)
+    await q('UPDATE automation_rules SET created_at = $1 WHERE id = $2', [iso(TS - 10 * DAY), RULE_BACKDATED])
+
+    const fresh = await svc.createRule(SHEET, ruleConfig)
+    RULE_FRESH = fresh.id // created_at stays ~now → must NOT fire for the past-bucketed occurrence
+  })
+
+  afterAll(async () => {
+    svc.shutdown()
+    await q('DELETE FROM meta_automation_date_reminder_fires WHERE rule_id = ANY($1::text[])', [[RULE_BACKDATED, RULE_FRESH]]).catch(() => {})
+    await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [[RULE_BACKDATED, RULE_FRESH]]).catch(() => {})
+    await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [[RULE_BACKDATED, RULE_FRESH]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('DR-1: a DUE record fires once — claim row written + update_record marker stamped via record context', async () => {
+    await svc.runDateReminderScanNow(RULE_BACKDATED)
+    // exactly one claim (REC_DUE), and it is REC_DUE specifically.
+    expect(await claimCount(RULE_BACKDATED)).toBe(1)
+    const rows = await q('SELECT record_id FROM meta_automation_date_reminder_fires WHERE rule_id = $1', [RULE_BACKDATED])
+    expect((rows.rows as Array<{ record_id: string }>).map((r) => r.record_id)).toEqual([REC_DUE])
+    // end-to-end: the fire ran update_record against the triggered record (proves the record context flowed).
+    expect((await recordData(REC_DUE))[FLD_MARK]).toBe('reminded')
+    // FUTURE + NULL records did NOT fire.
+    expect((await recordData(REC_FUTURE))[FLD_MARK]).toBeUndefined()
+    expect((await recordData(REC_NULL))[FLD_MARK]).toBe('x')
+  })
+
+  test('DR-2: a second scan is IDEMPOTENT — no new claim, no new execution', async () => {
+    const claimsBefore = await claimCount(RULE_BACKDATED)
+    const execsBefore = await execCount(RULE_BACKDATED)
+    await svc.runDateReminderScanNow(RULE_BACKDATED)
+    expect(await claimCount(RULE_BACKDATED)).toBe(claimsBefore) // dedup blocked the re-claim
+    expect(await execCount(RULE_BACKDATED)).toBe(execsBefore) // and therefore fired nothing
+  })
+
+  test('DR-3: BACKFILL bound — the SAME due record under a FRESH rule does NOT fire (occurrence < created_at)', async () => {
+    await svc.runDateReminderScanNow(RULE_FRESH)
+    // REC_DUE is fetched by the SQL window, but its occurrence (today 00:00) predates the fresh rule's
+    // creation (~now) → isDateReminderDue rejects it → zero claims, zero fires. No day-one backfill blast.
+    expect(await claimCount(RULE_FRESH)).toBe(0)
+    expect(await execCount(RULE_FRESH)).toBe(0)
+  })
+
+  test('DR-6: editing the date to a NEW reminder-day fires a NEW occurrence; the old occurrence stays deduped', async () => {
+    const claimsBefore = await claimCount(RULE_BACKDATED) // 1 (today)
+    // Move the deadline one day earlier (now+2d) → occurrence buckets to YESTERDAY 00:00 — still due + in
+    // window, but a DIFFERENT occurrence_ts than today → a fresh claim + fire.
+    await q('UPDATE meta_records SET data = data || $1::jsonb WHERE id = $2', [JSON.stringify({ [FLD_DATE]: iso(TS + 2 * DAY) }), REC_DUE])
+    await svc.runDateReminderScanNow(RULE_BACKDATED)
+    expect(await claimCount(RULE_BACKDATED)).toBe(claimsBefore + 1) // one NEW occurrence claimed
+    // both occurrences (today + yesterday) are now in the ledger for REC_DUE.
+    const occRows = await q('SELECT count(*)::int AS n FROM meta_automation_date_reminder_fires WHERE rule_id = $1 AND record_id = $2', [RULE_BACKDATED, REC_DUE])
+    expect((occRows.rows as Array<{ n: number }>)[0].n).toBe(2)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
@@ -103,7 +103,8 @@ describeIfDatabase('multitable date-reminder trigger — scan/claim/fire (real D
     svc.shutdown()
     await q('DELETE FROM meta_automation_date_reminder_fires WHERE rule_id = ANY($1::text[])', [[RULE_BACKDATED, RULE_FRESH]]).catch(() => {})
     await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [[RULE_BACKDATED, RULE_FRESH]]).catch(() => {})
-    await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [[RULE_BACKDATED, RULE_FRESH]]).catch(() => {})
+    // Sheet-scoped so the save-validation goldens' throwaway rules are reaped too (FK cascades their ledger rows).
+    await q('DELETE FROM automation_rules WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
@@ -151,5 +152,56 @@ describeIfDatabase('multitable date-reminder trigger — scan/claim/fire (real D
     // both occurrences (today + yesterday) are now in the ledger for REC_DUE.
     const occRows = await q('SELECT count(*)::int AS n FROM meta_automation_date_reminder_fires WHERE rule_id = $1 AND record_id = $2', [RULE_BACKDATED, REC_DUE])
     expect((occRows.rows as Array<{ n: number }>)[0].n).toBe(2)
+  })
+
+  // ── P2: SAVE-boundary validation — the UI's date-field contract is enforced in createRule/updateRule, so a
+  // direct API / import / script write cannot persist a rule that looks saved but skips/mis-fires at scan. ──
+  const mkDateRule = (triggerConfig: Record<string, unknown>) => ({
+    name: `dr-val ${TS}`,
+    triggerType: 'schedule.date_field',
+    triggerConfig,
+    actionType: 'update_record',
+    actionConfig: { fields: { [FLD_MARK]: 'reminded' } },
+  }) as never
+
+  test('DR-VAL: rejects an unknown dateFieldId at save (not found on sheet)', async () => {
+    await expect(svc.createRule(SHEET, mkDateRule({ dateFieldId: `nope_${TS}`, offsetDays: 3, direction: 'before' })))
+      .rejects.toThrow(/dateFieldId not found/i)
+  })
+
+  test('DR-VAL: rejects a NON-date field (string) at save', async () => {
+    await expect(svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_MARK, offsetDays: 3, direction: 'before' })))
+      .rejects.toThrow(/must be a date\/dateTime field/i)
+  })
+
+  test('DR-VAL: rejects a negative offsetDays at save', async () => {
+    await expect(svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_DATE, offsetDays: -1, direction: 'before' })))
+      .rejects.toThrow(/offsetDays must be a non-negative integer/i)
+  })
+
+  test('DR-VAL: rejects a non-UTC timezone at save (v1 honors only UTC — reject, not accept-and-ignore)', async () => {
+    await expect(svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timezone: 'America/New_York' })))
+      .rejects.toThrow(/timezone v1 supports only 'UTC'/i)
+  })
+
+  test('DR-VAL: a valid date field + config saves successfully', async () => {
+    const ok = await svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 1, direction: 'after', timeOfDay: '08:30' }))
+    expect(ok.id).toBeTruthy()
+    expect(ok.trigger_type).toBe('schedule.date_field')
+  })
+
+  test('DR-DISABLED: a DISABLED date_field rule is a no-op via runDateReminderScanNow (enabled gate honored)', async () => {
+    const disabled = await svc.createRule(SHEET, {
+      name: `dr-disabled ${TS}`,
+      triggerType: 'schedule.date_field',
+      triggerConfig: { dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timeOfDay: '00:00' },
+      actionType: 'update_record',
+      actionConfig: { fields: { [FLD_MARK]: 'reminded' } },
+      enabled: false,
+    } as never)
+    // Backdate so an ENABLED rule WOULD fire for REC_DUE — isolating "disabled" as the only reason it doesn't.
+    await q('UPDATE automation_rules SET created_at = $1 WHERE id = $2', [iso(TS - 10 * DAY), disabled.id])
+    await svc.runDateReminderScanNow(disabled.id)
+    expect(await claimCount(disabled.id)).toBe(0)
   })
 })


### PR DESCRIPTION
## Date-reminder trigger — fire N days before/after a record's date field

The lightweight Feishu-parity arc the post-cross-base frontier note recommended, authorized by the owner ("按建议执行"). Adds the **date-driven** automation trigger multitable lacked — all prior triggers were event-driven (`record.*`/`form.submitted`) or fixed wall-clock (`schedule.cron`/`schedule.interval`).

### How it works
A daily leader-only scan computes a **pure, day-bucketed occurrence** per record, **claims** it in an idempotency ledger (`INSERT … ON CONFLICT DO NOTHING`), and fires the rule **once per due record** with the record as context (so `send_notification`/`update_record` resolve the record's fields).

### The two correctness invariants (advisor-shaped)
1. **Idempotency** — `occurrence` is a PURE function of `(dateValue, config)`, never NOW, day-bucketed in UTC. The dedup key `(rule, record, occurrence)` is stable across ticks; editing the deadline's *time* within the same day doesn't re-spam. **Claim-then-fire = at-most-once.**
2. **Bounded firing window** — fires iff `occ ∈ (now − 2×cadence, now] AND occ ≥ rule.created_at`. A fresh rule over 1,000 historical records fires **zero**, not 1,000 (the day-one blast).

### Files
Backend: new `automation-date-reminder.ts` pure core · trigger type · scheduler scan cadence · `evaluateDateReminders` (scan/claim/fire) + `runDateReminderScanNow` ops/test seam · 2 migrations (widen trigger_type CHECK + ledger with FK ON DELETE CASCADE). Frontend: minimal editor exposure (trigger option + date-field/offset/direction/time + submit normalization).

### Verification
- **Pure unit 16/16** (occurrence purity/day-bucketing, firing window, clamp, candidate range).
- **Real-DB integration 5/5** (wired into `plugin-tests.yml`): DR-1 fires-once + record context · DR-2 idempotent · **DR-3 backfill bound** · DR-6 date-edit → new occurrence.
- **Two fail-first proofs**: dedup guard disabled → DR-2 RED; `created_at` predicate disabled → DR-3 RED. Restored → green.
- Shared automation unit **227/227** + adjacent integration (form-submit-trigger, suspend-resume) **14/14** — shared trigger-type/scheduler/service paths unchanged. `tsc` + `vue-tsc` clean; editor/labels specs **106/106**.

### Deferred (named)
Ledger retention/aging (FK-reaped on rule delete; long-lived rules grow it) · tz-aware bucketing (v1 = UTC) · sub-day offsets.

Dev/verification doc: `docs/development/multitable-date-reminder-trigger-dev-verification-20260628.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)