### PR TITLE
feat(plm-collab): Phase 7 governed write-back — consumer-only pact-first slice

### DIFF
--- a/docs/development/plm-collaboration-phase7-writeback-pact-first-consumer-slice-dev-and-verification-20260627.md
+++ b/docs/development/plm-collaboration-phase7-writeback-pact-first-consumer-slice-dev-and-verification-20260627.md
@@ -1,0 +1,64 @@
+# PLM Collaboration Phase 7 — Governed Write-Back, Pact-First Slice (consumer-only) — Development & Verification
+
+- Date: 2026-06-27
+- Repo: **metasheet2 (consumer) ONLY.** YuantusPLM (provider) is **not touched** in this slice.
+- Line: Phase 7 governed BOM write-back — **Slice 1 = the consumer-first write pact** (the contract before the code).
+- Scope decision: **Option A (consumer-only pact preparation)**, owner-ratified. Build the consumer write contract; do **not** sync to Yuantus, do **not** publish to the broker, do **not** implement provider mutation.
+
+## 0. Why consumer-only (the load-bearing CI constraint)
+
+A consumer-first pact normally relies on the broker's **pending-pacts** feature so a new consumer interaction does not break the provider until the provider implements it. **Yuantus deliberately disabled pending** — its provider verifier (`pytest test_pact_provider_yuantus_plm.py`) is a non-`continue-on-error` CI gate with **no pending/WIP/allowlist mechanism**, and an anti-defang meta-gate (`test_ci_contracts_pact_provider_gate.py`) pins the broker selectors to `mainBranch` with no pending flags. So **syncing a not-yet-implemented write-back interaction into Yuantus would turn its always-on CI red**, and the endpoint that would satisfy it is explicitly out of scope. Therefore this slice ships the contract **consumer-side only**; the Yuantus sync + broker publish + provider verifier are deferred to the (separately authorized) provider-endpoint slice. metasheet2's own consumer CI (`yuantus-pact-consumer.yml`) runs a **static** `test:contract` and does **not** publish to a broker, so this lands green on both sides.
+
+## 1. Decision surface (from the Phase 7 design `#884`)
+
+- **Fork 1 — governed seam:** **(A) route through ECO change control** (owner: "go ECO"). The consumer expresses *intent*; the provider routes it through ECO governance in the deferred endpoint slice.
+- **Fork 2 — write authorization (ratified):** permission `"Part BOM"` / `AMLAction.update`; write `feature_key` `bom_multitable_writeback` (app/SKU `plm.bom_multitable_writeback`). A **write-scoped** authorization — never the read embed token.
+- **Fork 3 — the write pact:** required, sequenced first = **this slice**.
+
+## 2. What was built (metasheet2 consumer, code-grounded)
+
+All under `packages/core-backend/`:
+- **`PLMAdapter.writeBackBomMultitableLine(partId, bomLineId, changes)`** (`src/data-adapters/PLMAdapter.ts`) — relays a governed BOM line-field write-back intent as `PATCH /api/v1/bom/multitable/{partId}/lines/{bomLineId}` via `this.select(..., { method: 'PATCH', data: changes })`, addressed by the stable `bomLineId`. `mockMode` returns `{ ok, bom_line_id }`; non-yuantus → an error without a call. New return type `BomMultitableWriteBackResponse { ok, bom_line_id }` (thin — provider detail like a governed ECO id is the deferred provider slice's to define).
+- **Pact interaction** (`tests/contract/pacts/metasheet2-yuantus-plm.json`) — one **success** PATCH interaction: request body `{ quantity: 2, uom: "EA" }` (type-matched), provider-state names a `plm.bom_multitable_writeback` **write-scoped** authorization, `Authorization: Bearer …` (regex-matched) + `x-tenant-id`; response `200 { ok: true, bom_line_id }` (type-matched).
+- **Guard updates** (`tests/contract/plm-adapter-yuantus.pact.test.ts`) — added the PATCH entry to `PLM_ADAPTER_PACT_PATHS` (correct order, composed into `PACT_PATHS`) + the path to `endpointsToFind`.
+- **Focused unit test** (`tests/unit/plm-adapter-yuantus.test.ts`) — locks the write-back API shape (PATCH to the `/lines/` path, body = the change intent) and that it carries **no read embed-token header**; plus a non-yuantus refusal.
+
+## 3. The four implementation guards — honored
+
+1. **Path/method:** `PATCH /api/v1/bom/multitable/{part_id}/lines/{bom_line_id}` — same namespace as the read `…/context`, consistent with the existing `updateCadProperties` / `updateCadViewState` PATCH writes. ✅
+2. **Non-empty success fixture:** the success body carries `{ quantity: 2, uom: "EA" }` (fields all optional in the type, but the fixture is non-empty) so "empty PATCH success" is **not** written into a future provider obligation. ✅
+3. **`feature_key` not in body:** `bom_multitable_writeback` is expressed as a **write-scoped authorization** via the provider-state name + the `Authorization` fixture; the body carries **only** the BOM line change intent. ✅
+4. **Real symbol:** updated the actual `PACT_PATHS` (via `PLM_ADAPTER_PACT_PATHS`) + `endpointsToFind`. ✅
+
+Negatives (read-token-rejected / unentitled / unpermitted / lifecycle / cross-tenant / replay) are **deliberately NOT in the committed pact** — they are the provider-endpoint slice's verifier responsibility, and adding them now would redden Yuantus's strict always-on gate. The "read token ≠ write token" invariant is enforced **consumer-internally** (the relay), not on the pact wire, and is locked here by the unit test asserting no embed-token header on the write.
+
+## 4. Verification (reproducible)
+
+Worktree off `origin/main` (`342c7160b`); `node_modules` reused from the main checkout via symlink.
+
+```bash
+cd packages/core-backend
+npx tsc --noEmit                                                   # 0 errors
+npm run test:contract                                              # 19/19 green (pact guard: count/order/endpointsToFind)
+npx vitest run tests/unit/plm-adapter-yuantus.test.ts             # 25/25 green (23 existing + 2 new write-back)
+```
+- **Typecheck:** clean (0 TS errors).
+- **`test:contract`:** 19/19 — interaction count == `PACT_PATHS.length`, order matches, every path appears in `PLMAdapter.ts`, embed-token doc test intact.
+- **Unit:** 25/25 — the 2 new tests lock the write-back shape + no-embed-token-header guard.
+- Pact JSON validated (`JSON.parse`).
+- Baseline (pre-change) `test:contract` was 19/19 green before the slice (the new interaction + its PACT_PATHS entry keep the count balanced).
+
+## 5. Boundaries / out of scope (deferred, each separately authorized)
+
+- **No Yuantus change** — its committed pact, provider verifier, and broker publication are **untouched** (kept green; no pending-gate fight).
+- **No provider mutation** — the governed write endpoint (Fork 1 ECO seam + lifecycle guard + write-token scope/provider-side single-use + audit/idempotency) is the next slice.
+- **No broker publish** of this consumer pact until the provider endpoint exists (otherwise Yuantus broker-verify, when active, would pull it and fail).
+- **No negatives in the committed pact**; **Phase 6 SSO** remains deferred.
+
+## 6. Re-entry (the next authorized slice)
+
+Provider-endpoint slice: build the Yuantus governed write endpoint routing through ECO (Fork 1), enforcing `is_entitled(bom_multitable_writeback)` + `check_permission("Part BOM", update)` + lifecycle guard + write-token scope + provider-side single-use + audit/idempotency; then **sync** this consumer pact into Yuantus + the provider verifier interaction (+ negatives), and only then publish to the broker. That is the slice that turns this contract into an end-to-end-verified write seam.
+
+## 7. Conclusion
+
+The Phase 7 governed write-back **contract** now exists, consumer-first, in metasheet2 — a thin, owner-ratified success PATCH interaction + the `PLMAdapter` relay method + guard/unit coverage — verified green (`test:contract` 19/19, unit 25/25, tsc clean) **without touching Yuantus, without publishing to the broker, and without implementing provider mutation**. The provider seam, the broker publish, and the negative-path coverage are the deferred, separately-authorized provider-endpoint slice.

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -259,6 +259,17 @@ export interface BOMSubstituteMutationResponse {
   substitute_item_id?: string
 }
 
+/**
+ * PLM-COLLAB Phase 7 (pact-first slice, consumer-only): the governed BOM multitable write-back
+ * response shape the consumer expects from the (future, separately-authorized) provider seam.
+ * Thin by design — provider-side detail (e.g. the governed ECO id) is the deferred provider-endpoint
+ * slice's to define. This slice ships the CONTRACT only; no provider mutation exists yet.
+ */
+export interface BomMultitableWriteBackResponse {
+  ok: boolean
+  bom_line_id: string
+}
+
 export interface PLMDocument {
   id: string
   name: string
@@ -2171,6 +2182,36 @@ export class PLMAdapter extends HTTPAdapter {
     }
     // legacy / non-yuantus PLM has no multitable review surface
     return { feature_key: 'bom_multitable', entitled: false, upgrade: { available: true }, context: null }
+  }
+
+  /**
+   * PLM-COLLAB Phase 7 (pact-first slice, consumer-only): relay a governed BOM multitable
+   * line-field write-back INTENT to the provider's governed write seam, addressed by the stable
+   * `bomLineId`. The write is a SEPARATELY-AUTHORIZED, write-scoped operation — never the read
+   * embed token; the provider enforces is_entitled(bom_multitable_writeback) + permission +
+   * lifecycle guard and routes it through ECO change control. This consumer slice defines the
+   * CONTRACT only (see tests/contract/pacts) — the provider write endpoint is a deferred,
+   * separately-authorized slice and does NOT exist yet.
+   */
+  async writeBackBomMultitableLine(
+    partId: string,
+    bomLineId: string,
+    changes: { quantity?: number; uom?: string; find_num?: string; refdes?: string }
+  ): Promise<QueryResult<BomMultitableWriteBackResponse>> {
+    if (this.mockMode) {
+      return {
+        data: [{ ok: true, bom_line_id: bomLineId }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('BOM multitable write-back is not supported for this PLM API mode') }
+    }
+
+    return this.select<BomMultitableWriteBackResponse>(`/api/v1/bom/multitable/${partId}/lines/${bomLineId}`, {
+      method: 'PATCH',
+      data: changes,
+    })
   }
 
   async getApprovals(options?: ApprovalQueryOptions): Promise<QueryResult<ApprovalRequest>> {

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3803,6 +3803,83 @@
       }
     },
     {
+      "description": "write back BOM multitable line field changes for an entitled part with a write-scoped token",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_multitable_writeback authorization and BOM line 01H000000000000000000000R1 on part 01H000000000000000000000P1 accepts a write-scoped field update"
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000P1/lines/01H000000000000000000000R1",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.write-scoped.example",
+          "x-tenant-id": "tenant-1",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.quantity": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.uom": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "body": {
+          "quantity": 2,
+          "uom": "EA"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "ok": true,
+          "bom_line_id": "01H000000000000000000000R1"
+        },
+        "matchingRules": {
+          "body": {
+            "$.ok": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.bom_line_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "mint a MetaSheet BOM review embed token for the Yuantus parent host",
       "providerStates": [
         {

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -116,6 +116,8 @@ const PLM_ADAPTER_PACT_PATHS = [
   // PLM-COLLAB V1.1: the two modern Path-A surfaces (advisory manifest + governed BOM context).
   { method: 'GET', path: '/api/v1/integrations/capabilities' },
   { method: 'GET', path: '/api/v1/bom/multitable/01H000000000000000000000P1/context' },
+  // PLM-COLLAB Phase 7 (pact-first, consumer-only): governed BOM line-field write-back intent.
+  { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000P1/lines/01H000000000000000000000R1' },
 ] as const
 
 const PARENT_HOST_PACT_PATHS = [
@@ -199,6 +201,7 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       'fetchYuantusFileMetadata',
       '/api/v1/integrations/capabilities',
       '/api/v1/bom/multitable/${partId}/context',
+      '/api/v1/bom/multitable/${partId}/lines/${bomLineId}',
     ]
     for (const ep of endpointsToFind) {
       expect(

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -1146,3 +1146,37 @@ describe('PLMAdapter Yuantus documents single-side failure + sources metadata', 
     expect(sources[1]).toMatchObject({ name: 'related_documents', ok: true, count: 1 })
   })
 })
+
+describe('PLMAdapter Yuantus BOM multitable write-back (Phase 7 pact-first slice)', () => {
+  it('relays as PATCH /bom/multitable/{partId}/lines/{bomLineId} with the change body and no read embed-token header', async () => {
+    const adapter = createAdapter()
+    const selectMock = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R1' }], metadata: { totalCount: 1 } })
+    ;(adapter as any).select = selectMock
+
+    const changes = { quantity: 2, uom: 'EA' }
+    const result = await adapter.writeBackBomMultitableLine('P1', 'R1', changes)
+
+    // write-back API shape: a PATCH to the line resource carrying ONLY the BOM line change intent
+    expect(selectMock).toHaveBeenCalledTimes(1)
+    expect(selectMock).toHaveBeenCalledWith('/api/v1/bom/multitable/P1/lines/R1', {
+      method: 'PATCH',
+      data: changes,
+    })
+    // the write must NOT ride the read embed token: this method injects no headers / embed-token at all
+    const [, opts] = selectMock.mock.calls[0]
+    expect(opts).not.toHaveProperty('headers')
+    expect(JSON.stringify(opts)).not.toContain('embed')
+    expect(result.data?.[0]).toMatchObject({ ok: true, bom_line_id: 'R1' })
+  })
+
+  it('refuses on a non-yuantus PLM without attempting the write', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).apiMode = 'legacy'
+    const selectMock = vi.fn()
+    ;(adapter as any).select = selectMock
+
+    const result = await adapter.writeBackBomMultitableLine('P1', 'R1', { quantity: 2 })
+    expect(selectMock).not.toHaveBeenCalled()
+    expect(result.error).toBeInstanceOf(Error)
+  })
+})


### PR DESCRIPTION
## Summary
**Slice 1** of the Phase 7 governed BOM write-back (design `#884`): the **consumer-first write contract**, metasheet2-side **only**. Per owner-ratified **Option A** — Yuantus **not touched**, broker **not published**, **no provider mutation** (each a separately authorized provider-endpoint slice).

## Forks
- **Fork 1 — seam:** route through **ECO** change-control (owner: "go ECO"); consumer expresses *intent*, provider routes via ECO in the deferred slice.
- **Fork 2 — write auth (ratified):** permission `"Part BOM"`/`AMLAction.update`; write `feature_key` `bom_multitable_writeback` → `plm.bom_multitable_writeback` — write-scoped, never the read embed token.
- **Fork 3 — the pact:** first = this slice.

## In this PR (`packages/core-backend`)
- `PLMAdapter.writeBackBomMultitableLine(partId, bomLineId, changes)` → `PATCH /api/v1/bom/multitable/{partId}/lines/{bomLineId}` (stable `bomLineId`) via `this.select` PATCH; thin `BomMultitableWriteBackResponse { ok, bom_line_id }`.
- One **success** PATCH pact interaction (body `{ quantity: 2, uom: "EA" }` type-matched; write-scoped token via providerState + `Authorization` fixture, **not** in body) + `PACT_PATHS`/`endpointsToFind` guard updates.
- Focused unit test: locks the write-back shape + **no read embed-token header**.

## Why consumer-only (CI-safety)
Yuantus's provider verifier is a strict **no-pending** CI gate (+ anti-defang meta-gate); syncing a not-yet-implemented interaction would redden its always-on CI, and the satisfying endpoint is out of scope. metasheet2's consumer CI runs a **static** `test:contract` and does **not** publish to a broker → green both sides.

## Verification
- `npx tsc --noEmit` → **0 errors**
- `npm run test:contract` → **19/19**
- `npx vitest run tests/unit/plm-adapter-yuantus.test.ts` → **25/25** (23 + 2 new)

## Deferred (separately authorized)
Provider governed write endpoint (ECO seam + lifecycle guard + write-token scope/single-use + audit/idempotency); the Yuantus pact sync + verifier interaction + **negatives**; the broker publish; **Phase 6 SSO**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
