### PR TITLE
feat(plm): consumer pact for PATCH bom/multitable line write-back (P3, thin success-only)

### DIFF
--- a/docs/development/plm-collab-bom-multitable-line-write-pact-design-lock-20260627.md
+++ b/docs/development/plm-collab-bom-multitable-line-write-pact-design-lock-20260627.md
@@ -1,0 +1,114 @@
+# Design-Lock — PLM-COLLAB P3 BOM Multitable Line Write-Back Consumer Pact (方案1)
+
+Date: 2026-06-27
+Status: LOCKED (consumer contract) — provider endpoint NOT yet built (downstream obligation, see below)
+Consumer: `Metasheet2`  ·  Provider: `YuantusPLM`
+Branch: `claude/plm-bom-multitable-line-write-pact-20260627`
+
+## 1. Decision
+
+Owner selected **方案1 — the thinnest consumer contract**: a single line-addressed PATCH that
+locks only the minimal SUCCESS shape of a BOM multi-table cell edit. Nothing beyond that minimal
+surface is added to the broker artifact in this slice.
+
+The P3 multi-table surface was read-only until now (`getBomMultitableContext` →
+`GET /api/v1/bom/multitable/{partId}/context`). This adds the **first write-back method** on that
+surface, as a consumer Pact only.
+
+## 2. Locked contract
+
+**Path (line-addressed):**
+```
+PATCH /api/v1/bom/multitable/{part_id}/lines/{bom_line_id}
+```
+- `bom_line_id` selects the specific line; `part_id` is the **context boundary** only.
+- The provider must (in a future slice) validate that the line belongs to the part. This consumer
+  pact does NOT lock that validation — it locks the minimal success contract only.
+
+**Request body — whitelist of exactly four editable business cells, all optional:**
+```
+{ "quantity", "uom", "find_num", "refdes" }
+```
+- These are exactly the editable cells of `BomMultitableLine` (`quantity` numeric in the read model;
+  `uom` / `find_num` / `refdes` strings). The consumer patch type accepts `number | string | null`
+  for `quantity` (editor hands a string pre-coercion); `null` is a legitimate "clear this cell" edit.
+- The local adapter **rejects an empty body** (a PATCH that changes nothing) BEFORE issuing any
+  request, and **strips any key outside the whitelist** so it can never reach the provider.
+
+**Response — thinnest envelope:**
+```
+{ "ok": true, "bom_line_id": "..." }
+```
+- `eco_id` / `source_version` / `applied` are **DEFERRED** to the real provider endpoint design and
+  are deliberately NOT part of this consumer contract.
+
+**Scope: SUCCESS interaction ONLY.**
+- No 403 / unauthorized / error interaction is added. Rationale: a 403 interaction would widen the
+  YuantusPLM provider-verifier surface, and the consumer does not yet depend on that error shape.
+  Permission / unauthorized handling waits until the provider endpoint or the UI write path truly
+  arrives.
+
+## 3. Implementation
+
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts`
+  - New consumer types `BomMultitableLinePatch` and `BomMultitableLineUpdateResult`.
+  - New method `updateBomMultitableLine(partId, bomLineId, patch)`:
+    1. builds payload from ONLY the four whitelisted keys that are `!== undefined`;
+    2. if payload has 0 keys → returns `{ data: [], error }` with the fixed message
+       `updateBomMultitableLine requires at least one of quantity, uom, find_num, refdes`,
+       BEFORE any mock/network branch;
+    3. mockMode → `{ data: [{ ok: true, bom_line_id }], metadata: { totalCount: 1 } }`;
+    4. `apiMode !== 'yuantus'` guard (legacy/mock-non-yuantus unsupported affordance, no request);
+    5. `this.select<...>(`/api/v1/bom/multitable/${partId}/lines/${bomLineId}`, { method: 'PATCH', data: payload })`.
+  - The method body contains the exact path template literal so the pact drift-guard passes.
+- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json`
+  - New success interaction INSERTED between `.../context` and `.../embed-token` (so JSON order ==
+    concatenated `PACT_PATHS` order). Fresh part/line ids `01H000000000000000000000P4` /
+    `01H000000000000000000000R8`. Headers mirror context/embed-token (Authorization Bearer + regex
+    matcher, `x-tenant-id: tenant-1`, plus `Content-Type: application/json` on the request body).
+    `type` matchers on the four request cells and on response `$.ok` / `$.bom_line_id`.
+- `packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts`
+  - PATCH appended to END of `PLM_ADAPTER_PACT_PATHS`; callsite template added to `endpointsToFind`;
+    one new `it()` locking method=PATCH, provider-state present, request keys exactly
+    `['find_num','quantity','refdes','uom']`, response exactly `{ ok:true, bom_line_id:'…R8' }`
+    (asserts NO `eco_id`/`source_version`/`applied`), and EXACTLY ONE interaction for this path with
+    status 200 (success-only).
+- `packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts`
+  - Load-bearing runtime verification (the pact test only does string `.includes` on the source).
+    New cases: empty / only-undefined patch → error + `select` NOT called; unknown-key stripped
+    (only whitelisted keys reach `select`); valid yuantus patch → `select` called once with
+    method `PATCH`, the `/api/v1/bom/multitable/P4/lines/R8` path, and only whitelisted keys; `null`
+    cell kept (real clear edit); mock + legacy affordances issue no request.
+
+## 4. Deferrals / downstream obligations
+
+- **Provider verifier expectation for an endpoint that does not exist yet.** Landing this consumer
+  pact adds a YuantusPLM provider-verifier expectation for `PATCH .../lines/{bom_line_id}`. This is
+  consciously **minimized to success-only** so the provider surface stays as small as possible until
+  the real endpoint is designed. The provider side must implement the route and satisfy this state.
+- Provider must validate `line ∈ part` (NOT in this consumer contract).
+- `eco_id` / `source_version` / `applied` left to the provider endpoint design.
+- The HTTP route and the UI write path are NOT built in this slice.
+- Capability-manifest gating for the write is DEFERRED.
+- 403 / unauthorized contract DEFERRED (success-only by design).
+
+## 5. Verification (local, `/tmp/ms2-bompact`)
+
+- Pact contract test: `vitest run tests/contract/plm-adapter-yuantus.pact.test.ts` → 16/16 pass
+  (order oracle + provider-state + drift-guard + new success-only it() all green).
+- Adapter unit test: `vitest run tests/unit/plm-adapter-bom-multitable.test.ts` → 17/17 pass
+  (10 existing read cases + 7 new runtime write cases).
+- Typecheck: `pnpm --filter @metasheet/core-backend run type-check` (`tsc --noEmit`) → exit 0.
+
+## 6. CI (`.github/workflows/yuantus-pact-consumer.yml`) — observed, NOT modified
+
+- Triggers on PR-to-main (both `PLMAdapter.ts` and `tests/contract/**` paths are touched).
+- Does NOT hard-fail when broker secrets are absent: the publish step runs only on `push` to
+  `refs/heads/main` (never on PR), is `continue-on-error: true`, and shell-guards `exit 0` when
+  `PACT_BROKER_BASE_URL` is unset — it no-ops/skips as designed. The only failure path is
+  base-url-set-but-token-empty (misconfiguration, not absence).
+- Not a required check (repo branch protection requires `contracts (strict/dashboard/openapi)`,
+  `pr-validate`, `test (20.x)`; `yuantus-pact-consumer` is not among them).
+- Note: this workflow's PR run executes `test:contract` (covers the new pact test) but for unit only
+  runs `plm-adapter-yuantus.test.ts` — it does NOT run `plm-adapter-bom-multitable.test.ts`; those
+  new runtime cases are exercised by the required `test (20.x)` job instead.

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -722,6 +722,26 @@ export interface BomMultitableContextResult {
   context: BomMultitableContext | null;
 }
 
+// The consumer-side write-back patch for a single governed BOM multi-table line. Only the four
+// editable business cells of BomMultitableLine are whitelisted; all are optional (a PATCH carries
+// only the cells the user actually changed). `quantity` is numeric in the read model but the editor
+// may hand us a string before coercion, so the consumer type accepts number|string|null. Anything
+// outside this whitelist is stripped before the request is issued (see updateBomMultitableLine).
+export interface BomMultitableLinePatch {
+  quantity?: number | string | null;
+  uom?: string | null;
+  find_num?: string | null;
+  refdes?: string | null;
+}
+
+// The thinnest success envelope the provider write-back must return. Deliberately minimal:
+// eco_id / source_version / applied are DEFERRED to the real provider endpoint design and are
+// NOT part of this consumer contract.
+export interface BomMultitableLineUpdateResult {
+  ok: boolean;
+  bom_line_id: string;
+}
+
 // Field guard for the governed BOM multi-table context. Validates EVERY field declared on
 // BomMultitableLine / BomMultitablePart / BomMultitableContext — both the structural keys
 // (bom_line_id, part_id, level, path, ...) AND the displayed cells (item_number, name, state,
@@ -2171,6 +2191,52 @@ export class PLMAdapter extends HTTPAdapter {
     }
     // legacy / non-yuantus PLM has no multitable review surface
     return { feature_key: 'bom_multitable', entitled: false, upgrade: { available: true }, context: null }
+  }
+
+  /**
+   * Write back a single governed BOM multi-table line (方案1 — line-addressed PATCH; `partId` is the
+   * context boundary, `bomLineId` selects the row). THIN consumer contract: the payload is restricted
+   * to the four editable business cells (quantity / uom / find_num / refdes), an empty patch (nothing
+   * changed) is REJECTED before any mock/network branch, any non-whitelisted key is stripped, and the
+   * success envelope is the minimal { ok, bom_line_id }. Permission/unauthorized (403) and the
+   * provider's line∈part validation are intentionally OUT of this consumer contract; success-only.
+   */
+  async updateBomMultitableLine(
+    partId: string,
+    bomLineId: string,
+    patch: BomMultitableLinePatch,
+  ): Promise<QueryResult<BomMultitableLineUpdateResult>> {
+    // Build the request payload from ONLY the four whitelisted, defined keys. `null` is a real value
+    // (a "clear this cell" edit) and is preserved; `undefined` (untouched) and any unknown key are
+    // dropped. Copying the four keys individually makes the unknown-key strip structural.
+    const payload: BomMultitableLinePatch = {}
+    if (patch.quantity !== undefined) payload.quantity = patch.quantity
+    if (patch.uom !== undefined) payload.uom = patch.uom
+    if (patch.find_num !== undefined) payload.find_num = patch.find_num
+    if (patch.refdes !== undefined) payload.refdes = patch.refdes
+
+    // Reject an empty body (a PATCH that changes nothing) BEFORE any mock/network branch.
+    if (Object.keys(payload).length === 0) {
+      return {
+        data: [],
+        error: new Error('updateBomMultitableLine requires at least one of quantity, uom, find_num, refdes'),
+      }
+    }
+
+    if (this.mockMode) {
+      return {
+        data: [{ ok: true, bom_line_id: bomLineId }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('BOM multitable line write-back is not supported for this PLM API mode') }
+    }
+
+    return this.select<BomMultitableLineUpdateResult>(`/api/v1/bom/multitable/${partId}/lines/${bomLineId}`, {
+      method: 'PATCH',
+      data: payload,
+    })
   }
 
   async getApprovals(options?: ApprovalQueryOptions): Promise<QueryResult<ApprovalRequest>> {

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3803,6 +3803,99 @@
       }
     },
     {
+      "description": "write back the editable cells of a single governed BOM multitable line",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_multitable license and BOM line 01H000000000000000000000R8 under part 01H000000000000000000000P4 is editable via the multi-table write-back surface"
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000P4/lines/01H000000000000000000000R8",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "quantity": 6,
+          "uom": "ea",
+          "find_num": "20",
+          "refdes": "B2"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.quantity": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.uom": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.find_num": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.refdes": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "ok": true,
+          "bom_line_id": "01H000000000000000000000R8"
+        },
+        "matchingRules": {
+          "body": {
+            "$.ok": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.bom_line_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "mint a MetaSheet BOM review embed token for the Yuantus parent host",
       "providerStates": [
         {

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -116,6 +116,8 @@ const PLM_ADAPTER_PACT_PATHS = [
   // PLM-COLLAB V1.1: the two modern Path-A surfaces (advisory manifest + governed BOM context).
   { method: 'GET', path: '/api/v1/integrations/capabilities' },
   { method: 'GET', path: '/api/v1/bom/multitable/01H000000000000000000000P1/context' },
+  // PLM-COLLAB P3 (方案1): the line-addressed, thin success-only BOM multitable write-back.
+  { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000P4/lines/01H000000000000000000000R8' },
 ] as const
 
 const PARENT_HOST_PACT_PATHS = [
@@ -199,6 +201,7 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       'fetchYuantusFileMetadata',
       '/api/v1/integrations/capabilities',
       '/api/v1/bom/multitable/${partId}/context',
+      '/api/v1/bom/multitable/${partId}/lines/${bomLineId}',
     ]
     for (const ep of endpointsToFind) {
       expect(
@@ -226,6 +229,36 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(rules).toHaveProperty('$.embed_token')
     expect(rules).toHaveProperty('$.jti')
     expect(rules).toHaveProperty('$.expires_in')
+  })
+
+  it('documents the P3 thin success-only BOM multitable line write-back contract (方案1)', () => {
+    const pact = loadPact()
+    const PATH = '/api/v1/bom/multitable/01H000000000000000000000P4/lines/01H000000000000000000000R8'
+    const matches = pact.interactions.filter(i => i.request.path === PATH)
+    // success-only: EXACTLY ONE interaction for this path, status 200, no 403/error twin
+    expect(matches).toHaveLength(1)
+    const interaction = matches[0]
+    expect(interaction.request.method).toBe('PATCH')
+    expect(interaction.response.status).toBe(200)
+
+    // a non-empty provider state is declared
+    expect(interaction.providerStates).toBeDefined()
+    expect(interaction.providerStates!.length).toBeGreaterThan(0)
+    expect(interaction.providerStates![0].name).toBeTruthy()
+
+    // request body is whitelisted to EXACTLY the four editable cells — no extras
+    const reqBody = interaction.request.body as Record<string, unknown>
+    expect(Object.keys(reqBody).sort()).toEqual(['find_num', 'quantity', 'refdes', 'uom'])
+
+    // response is the thinnest envelope: { ok, bom_line_id } only — eco_id/source_version/applied DEFERRED
+    expect(interaction.response.body).toEqual({
+      ok: true,
+      bom_line_id: '01H000000000000000000000R8',
+    })
+    const resBody = interaction.response.body as Record<string, unknown>
+    expect(resBody).not.toHaveProperty('eco_id')
+    expect(resBody).not.toHaveProperty('source_version')
+    expect(resBody).not.toHaveProperty('applied')
   })
 
   it('aml/apply request body documents the RPC envelope shape used by PLMAdapter', () => {

--- a/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
@@ -158,3 +158,104 @@ describe('PLMAdapter.getBomMultitableContext (PLM-COLLAB P3-C)', () => {
     expect(result.context).toEqual(withNulls)
   })
 })
+
+describe('PLMAdapter.updateBomMultitableLine (PLM-COLLAB P3 — thin success-only write-back)', () => {
+  it('empty patch ({}): returns an error AND issues NO request (rejected before any network/mock branch)', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn()
+    ;(adapter as never as { select: unknown }).select = select
+
+    const result = await adapter.updateBomMultitableLine('P4', 'R8', {})
+
+    expect(result.data).toEqual([])
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error?.message).toBe('updateBomMultitableLine requires at least one of quantity, uom, find_num, refdes')
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('only-undefined patch: same as empty — error, no request', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn()
+    ;(adapter as never as { select: unknown }).select = select
+
+    const result = await adapter.updateBomMultitableLine('P4', 'R8', { quantity: undefined, uom: undefined })
+
+    expect(result.error).toBeInstanceOf(Error)
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('unknown keys are stripped: only whitelisted cells reach select', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })
+    ;(adapter as never as { select: unknown }).select = select
+
+    await adapter.updateBomMultitableLine('P4', 'R8', {
+      quantity: 6,
+      // a non-whitelisted key the caller should never be able to write
+      eco_id: 'E9',
+      applied: true,
+    } as never)
+
+    expect(select).toHaveBeenCalledTimes(1)
+    const [, options] = select.mock.calls[0]
+    expect(options.method).toBe('PATCH')
+    // only the whitelisted, defined keys survive — eco_id/applied are gone
+    expect(Object.keys(options.data).sort()).toEqual(['quantity'])
+    expect(options.data).toEqual({ quantity: 6 })
+  })
+
+  it('valid patch in yuantus mode: select called once with PATCH + the line path + only whitelisted keys', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })
+    ;(adapter as never as { select: unknown }).select = select
+
+    const result = await adapter.updateBomMultitableLine('P4', 'R8', {
+      quantity: 6,
+      uom: 'ea',
+      find_num: '20',
+      refdes: 'B2',
+    })
+
+    expect(select).toHaveBeenCalledTimes(1)
+    const [path, options] = select.mock.calls[0]
+    expect(path).toBe('/api/v1/bom/multitable/P4/lines/R8')
+    expect(options.method).toBe('PATCH')
+    expect(options.data).toEqual({ quantity: 6, uom: 'ea', find_num: '20', refdes: 'B2' })
+    expect(result.data?.[0]).toEqual({ ok: true, bom_line_id: 'R8' })
+  })
+
+  it('null cell is a real "clear" edit, not empty: kept in payload, request issued', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })
+    ;(adapter as never as { select: unknown }).select = select
+
+    await adapter.updateBomMultitableLine('P4', 'R8', { refdes: null })
+
+    expect(select).toHaveBeenCalledTimes(1)
+    const [, options] = select.mock.calls[0]
+    expect(options.data).toEqual({ refdes: null })
+  })
+
+  it('mock mode: returns a demoable { ok, bom_line_id } without a network call', async () => {
+    const adapter = createAdapter('mock')
+    const select = vi.fn()
+    ;(adapter as never as { select: unknown }).select = select
+
+    const result = await adapter.updateBomMultitableLine('P4', 'R8', { quantity: 6 })
+
+    expect(select).not.toHaveBeenCalled()
+    expect(result.data?.[0]).toEqual({ ok: true, bom_line_id: 'R8' })
+  })
+
+  it('legacy mode: unsupported affordance WITHOUT a request', async () => {
+    const adapter = createAdapter('legacy')
+    const select = vi.fn()
+    ;(adapter as never as { select: unknown }).select = select
+
+    const result = await adapter.updateBomMultitableLine('P4', 'R8', { quantity: 6 })
+
+    expect(result.data).toEqual([])
+    expect(result.error).toBeInstanceOf(Error)
+    expect(select).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

Locks the **thinnest consumer Pact** (方案1, owner-selected) for the first BOM multi-table **write-back**:

```
PATCH /api/v1/bom/multitable/{part_id}/lines/{bom_line_id}
```

The P3 surface had only the read side (`GET …/context`, read-only). This adds the consumer-side contract for editing a line, addressed by `bom_line_id` with `part_id` as the context boundary.

## Scope (deliberately minimal)

- **Body whitelist** — only `quantity / uom / find_num / refdes` (exactly `BomMultitableLine`'s editable business fields); all optional. The adapter **rejects an empty body before issuing any request** and **strips non-whitelisted keys**.
- **Thin response** — `{ ok, bom_line_id }` only; `eco_id / source_version / applied` deferred to the real provider-endpoint design.
- **Success interaction ONLY** — no 403/unauthorized twin, to avoid widening the YuantusPLM provider-verifier surface before the consumer depends on that error shape.

## Changes

- `PLMAdapter.updateBomMultitableLine(partId, bomLineId, patch)` — the consumer declaration (whitelist + empty-body rejection + mock/apiMode guards + thin result).
- New success interaction inserted between `…/context` and `…/embed-token` in the hand-authored Pact v3 artifact (consumer `Metasheet2` → provider `YuantusPLM`), ids `…P4` / `…R8`.
- Pact test: appended to `PLM_ADAPTER_PACT_PATHS` + `endpointsToFind`; a new `it()` locks whitelist / thin-response / exactly-one-success.
- **Load-bearing runtime tests** in `tests/unit/plm-adapter-bom-multitable.test.ts` (the pact test only string-greps the source): empty-body → error + **no request**, unknown-key stripped, valid → `select` PATCH once with the path + whitelisted keys only.
- Design-lock + verification MD recording 方案1, the deferrals, and the downstream provider-verifier obligation.

## Verification

- Pact contract test: 16/16 · adapter unit test: 17/17 (10 read + 7 new write) · `tsc --noEmit`: clean. Independently re-run by an adversarial reviewer (APPROVE).

## Deferred (each a separate owner-gated slice)

Provider-side `line ∈ part` validation · `eco_id/source_version/applied` envelope · the HTTP route + UI write path · capability-manifest gating for the write · the 403/unauthorized interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)