### PR TITLE
feat(integration): C3 K3 WebAPI Material LIST read-only smoke (#1709, bounded, gated)

### DIFF
--- a/docs/development/data-source-system-integration-c3-k3-webapi-list-readonly-dev-verification-20260627.md
+++ b/docs/development/data-source-system-integration-c3-k3-webapi-list-readonly-dev-verification-20260627.md
@@ -1,0 +1,74 @@
+# K3 WebAPI read/list — C3 LIST-only — development & verification (2026-06-27)
+
+> Status: **implemented + offline-verified; live entity-machine smoke = operator's gated next step.** This slice
+> opens a bounded, read-only Material LIST path. It does NOT open BOM, resolver/composition, Save/Submit/Audit,
+> production write, broad/unbounded scans, or cursor pagination. No real K3 was called here (no credentials); the
+> fixtures are synthetic. The values-free live entity-machine smoke is the operator's gated step, as with every
+> prior slice (e.g. #3241 detail retest).
+
+## Authorization
+
+#1709 owner/customer GATE (2026-06-27): `customerAdminAccepted=true`, `authorizedSlice=C3 LIST only`, read-only;
+BOM / resolver / Save / Submit / Audit / production write remain locked. The owner published the values-free wire
+contract (below), explicitly replacing the previously **inferred** shape (closed draft PR #3324).
+
+## Approved wire contract (O1–O6, values-free, from #1709)
+
+```text
+O1  POST /K3API/Material/GetList
+O2  body.Data.{Top,PageSize,PageIndex}; PageIndex starts at 1; PageSize<=10; Top<=10; no cursor token
+O3  body.Data.{Filter,OrderBy,Fields}; v1 filter = FNumber only, internally composed; no raw caller filter
+O4  response.Data.DATA rows → FNumber/FName/FModel/FUnitID
+O6  success = StatusCode 200 + success Message + parseable Data.DATA; else read-only error evidence
+```
+
+## What was built (one coherent diff, fresh from origin/main)
+
+- **Contract** (`lib/read-smoke.cjs`): new built-in preset `k3wise.material-list.v1` (PRESET-OWNED endpoint/method/
+  pagination/fields; `allowedModes:['list']`; key-OPTIONAL). `normalizeReadSmokeContract` now allows a key-optional
+  list intent (absent key → first page/no filter); `buildReadSmokeRequest` dispatches on the normalized
+  `contract.object/mode` (the #3247 C3 acceptance lock — now demanded) and never reuses the GetDetail shape;
+  `readSmokeSuccessEvidence` adds values-free `recordCount` + list `pageBounded` flag.
+- **Adapter** (`lib/adapters/k3-wise-webapi-adapter.cjs`): the single-record `K3_WISE_READ_LIST_UNSUPPORTED`
+  deny-guard is **preserved**; a separate `assertMaterialListReadOnlyScope` + bounded `Material/GetList` execution
+  is added in front, opened ONLY when the preset-owned `objectConfig.readMode === 'list'`. Pagination is hard-capped
+  at 10 (PageIndex=1, no cursor) regardless of config; the FNumber filter is internally composed exact-match,
+  pattern-validated against injection; rows are projected to the allowlisted fields only.
+- **Route** (`lib/http-routes.cjs`): passes the whole normalized `contract` to the builder (#3247 lock); write-gated
+  (`requireAccess('write')`), backend credential context, values-free evidence — unchanged wiring, now list-aware.
+
+## Verification (offline, 2026-06-27, clean origin/main worktree + pnpm install)
+
+Full `plugin-integration-core` CJS suite: **55/55 files pass, 0 failures.** Focused C3 coverage:
+
+- `read-smoke.test.cjs` — list preset/catalog, list builder (keyed → FNumber filter; no-key → first page), list
+  evidence values-free (no FNumber/FName/FModel/FUnitID).
+- `read-smoke-contract.test.cjs` — list intent normalizes (key-optional); fail-closed: detail mode / BOM object /
+  raw pagination/filter/path in intent all rejected.
+- `k3-wise-adapters.test.cjs` — bounded GetList success (rows projected, FExtra dropped); issued body =
+  `{Data:{Top:10,PageSize:10,PageIndex:1,Filter:'',OrderBy:'FNumber',Fields:'FNumber,FName,FModel,FUnitID'}}`;
+  key → `FNumber='…'`; **hard cap** (listMaxRows:999 → Top/PageSize still 10); **adversarial deny-guard still
+  fires**: cursor / watermark / request-pagination → `K3_WISE_READ_LIST_UNSUPPORTED`, injection-shaped FNumber /
+  raw `Filter` → `K3_WISE_READ_FILTER_UNSUPPORTED`; business failure → `K3_WISE_READ_BUSINESS_ERROR`; never
+  Save/Submit/Audit/GetDetail; **BOM not unlocked**.
+- `http-routes.test.cjs` — list intent → bounded read, evidence `{mode:'list',recordCount,pageBounded}`,
+  values-free; preset-owned GetList overlay applied without mutating the stored system; request-supplied list
+  pagination → 400.
+
+## Boundaries verified
+
+read-only; write-gated (operator-only, 403 for read users); values-free on success/failure (counts/flags only);
+single bounded page (Top/PageSize≤10, PageIndex=1, no cursor); endpoint/method/pagination/fields preset-owned (no
+request-supplied raw path/method/payload/config/pagination); FNumber-only internally-composed filter, injection
+fail-closed; BOM / resolver / Save / Submit / Audit / production write unreachable (negative controls).
+
+## Gated / not built (unchanged)
+
+C4 BOM read, C5 resolver/composition, any K3 Save/Submit/Audit/production write, broad/unbounded scans, cursor
+pagination — all still locked; each needs its own owner/customer GATE.
+
+## Next step (gated, operator-run)
+
+Values-free **live entity-machine smoke** against real K3 WebAPI `Material/GetList` (operator supplies credentials/
+endpoint at deploy): confirm 200 + `Data.DATA` parses, bounded page, values-free evidence, no write/BOM/LIST-cursor.
+This MD records the buildable+offline-verified state; it does not assert a live run.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5537,6 +5537,15 @@ async function testReadSmokeRoute() {
         return {
           async read(req) {
             readArgs.push(req)
+            if (req.options && req.options.readMode === 'list') {
+              return {
+                records: [
+                  { FNumber: 'M-LIST-1', FName: 'SECRET-LIST-NAME', FModel: 'SECRET-MODEL', FUnitID: 'SECRET-UNIT' },
+                  { FNumber: 'M-LIST-2', FName: 'SECRET-LIST-NAME-2', FModel: 'SECRET-MODEL-2', FUnitID: 'SECRET-UNIT-2' },
+                ],
+                metadata: { mode: 'material-list-bounded-smoke', pageBounded: true, readPath: 'https://k3host/x' },
+              }
+            }
             return {
               records: [{ _k3ReferenceObjects: { unit: {} }, FName: 'SECRET-NAME', FNumber: req.filters.FNumber }],
               metadata: { requestedNumber: req.filters.FNumber, readPath: 'https://k3host/x' },
@@ -5592,6 +5601,36 @@ async function testReadSmokeRoute() {
   assert.equal(okIntent.body.data.recordPresent, true)
   assert.deepEqual(readArgs[readArgs.length - 1], { object: 'material', filters: { FNumber: 'M-002' } }, 'intent shape drives the same single FNumber read')
   assert.ok(!JSON.stringify(okIntent.body.data).includes('M-002'), 'intent-shape response is values-free')
+
+  // C3 LIST-only: the material-list preset drives a bounded list read; evidence is values-free (counts/flags only)
+  const okList = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list' } },
+  })
+  assertOkResponse(okList, 200)
+  assert.equal(okList.body.data.ok, true)
+  assert.equal(okList.body.data.presetId, 'k3wise.material-list.v1')
+  assert.equal(okList.body.data.mode, 'list')
+  assert.equal(okList.body.data.recordCount, 2)
+  assert.equal(okList.body.data.pageBounded, true)
+  // route consumed contract.object/mode and signaled list mode (no key → empty filter, no request pagination)
+  assert.deepEqual(readArgs[readArgs.length - 1], { object: 'material', filters: {}, options: { readMode: 'list' } }, 'list intent drives a bounded list read signal')
+  // the non-persisted overlay applied the preset-owned GetList endpoint + list config
+  const listAdapterSystem = findCalls(calls, 'createAdapter').at(-1)[1]
+  assert.equal(listAdapterSystem.config.objects.material.readPath, '/K3API/Material/GetList')
+  assert.equal(listAdapterSystem.config.objects.material.readMode, 'list')
+  assert.deepEqual(storedK3System, storedK3SystemBefore, 'list read-smoke does not mutate the stored system')
+  // values-free: no row VALUES (FNumber/FName/FModel/FUnitID) leak into the evidence
+  const okListStr = JSON.stringify(okList.body.data)
+  for (const leak of ['M-LIST-1', 'SECRET-LIST-NAME', 'SECRET-MODEL', 'SECRET-UNIT', 'k3host']) {
+    assert.ok(!okListStr.includes(leak), `list read-smoke response must not leak ${leak}`)
+  }
+  // request-supplied pagination in a list intent is fail-closed at the contract (400)
+  const listRawPagination = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', limit: 500 } },
+  })
+  assert.equal(listRawPagination.statusCode, 400, 'request-supplied list pagination is fail-closed')
 
   // C2: LIST/BOM cannot enter via intent — fail-closed before any system load
   const intentBom = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -166,6 +166,27 @@ function createK3FetchMock() {
       response.Data[0].Data.FNumber = materialNumber
       return jsonResponse(200, response)
     }
+    if (parsed.pathname === '/K3API/Material/GetList') {
+      const data = (body && body.Data) || {}
+      if (typeof data.Filter === 'string' && data.Filter.includes('LISTFAIL')) {
+        return jsonResponse(200, { StatusCode: 500, Message: 'list query failed', Data: { DATA: [] } })
+      }
+      if (typeof data.Filter === 'string' && data.Filter.includes('EMPTY')) {
+        return jsonResponse(200, { StatusCode: 200, Message: 'OK', Data: { DATA: [] } })
+      }
+      // Bounded list response: rows live under response.Data.DATA (O4). FExtra is an unknown field the adapter
+      // MUST project away — only FNumber/FName/FModel/FUnitID survive downstream.
+      return jsonResponse(200, {
+        StatusCode: 200,
+        Message: 'OK',
+        Data: {
+          DATA: [
+            { FNumber: 'M-LIST-001', FName: 'SECRET-NAME-1', FModel: 'MODEL-1', FUnitID: 'UNIT-1', FExtra: 'IGNORED' },
+            { FNumber: 'M-LIST-002', FName: 'SECRET-NAME-2', FModel: 'MODEL-2', FUnitID: 'UNIT-2', FExtra: 'IGNORED' },
+          ],
+        },
+      })
+    }
     if (parsed.pathname === '/K3API/Material/Submit') {
       return jsonResponse(200, { success: true, submitted: body.Number })
     }
@@ -879,6 +900,96 @@ async function testK3WebApiMaterialDetailReadSmoke() {
   assert.ok(bomRead instanceof UnsupportedAdapterOperationError, 'read-only smoke does not unlock BOM reads')
 }
 
+// C3 LIST-only (#1709): bounded Material/GetList. Endpoint/pagination/fields are preset-owned; the deny-guard
+// still blocks cursor/watermark/request-pagination/BOM; evidence-bearing rows are projected to allowlisted fields.
+async function testK3WebApiMaterialListReadSmoke() {
+  const listConfig = (overrides = {}) => ({
+    baseUrl: 'https://k3.example.test',
+    autoSubmit: false,
+    autoAudit: false,
+    objects: {
+      material: {
+        operations: ['read'],
+        readPath: '/K3API/Material/GetList',
+        readMethod: 'POST',
+        readMode: 'list',
+        listMaxRows: 10,
+        listFields: ['FNumber', 'FName', 'FModel', 'FUnitID'],
+        ...overrides,
+      },
+    },
+  })
+  const { calls, fetchImpl } = createK3FetchMock()
+  const adapter = createK3WiseWebApiAdapter({ system: createK3WebApiSystem({ config: listConfig() }), fetchImpl })
+
+  // ----- happy path: bounded single page; no key → no filter -----
+  const list = await adapter.read({ object: 'material', options: { readMode: 'list' } })
+  assert.equal(list.records.length, 2, 'bounded list returns the mocked rows')
+  assert.equal(list.metadata.mode, 'material-list-bounded-smoke')
+  assert.equal(list.metadata.readOnly, true)
+  assert.equal(list.metadata.pageBounded, true)
+  assert.equal(list.metadata.readPath, '/K3API/Material/GetList')
+  // rows projected to the allowlisted fields ONLY (FExtra dropped)
+  assert.deepEqual(Object.keys(list.records[0]).sort(), ['FModel', 'FName', 'FNumber', 'FUnitID'])
+  assert.equal(list.records[0].FExtra, undefined, 'unknown response fields are projected away')
+  // issued GetList body: preset-owned bounded pagination + fields; empty filter with no key
+  const listCalls = calls.filter((call) => call.pathname === '/K3API/Material/GetList')
+  assert.equal(listCalls.length, 1, 'list read calls Material/GetList once')
+  assert.equal(listCalls[0].options.method, 'POST')
+  assert.deepEqual(listCalls[0].body, {
+    Data: { Top: 10, PageSize: 10, PageIndex: 1, Filter: '', OrderBy: 'FNumber', Fields: 'FNumber,FName,FModel,FUnitID' },
+  })
+  // read-only: never Save/Submit/Audit/GetDetail
+  for (const banned of ['/K3API/Material/Save', '/K3API/Material/Submit', '/K3API/Material/Audit', '/K3API/Material/GetDetail']) {
+    assert.equal(calls.some((call) => call.pathname === banned), false, `list read must not call ${banned}`)
+  }
+
+  // ----- key → internally composed EXACT FNumber filter (never a raw caller expression) -----
+  const keyed = createK3FetchMock()
+  const keyedAdapter = createK3WiseWebApiAdapter({ system: createK3WebApiSystem({ config: listConfig() }), fetchImpl: keyed.fetchImpl })
+  await keyedAdapter.read({ object: 'material', filters: { FNumber: 'M-001' }, options: { readMode: 'list' } })
+  assert.equal(keyed.calls.find((c) => c.pathname === '/K3API/Material/GetList').body.Data.Filter, "FNumber='M-001'", 'caller key maps to an exact internal FNumber filter')
+
+  // ----- empty page: empty Data.DATA is a valid empty result (recordPresent false), not an error -----
+  const empty = createK3FetchMock()
+  const emptyAdapter = createK3WiseWebApiAdapter({ system: createK3WebApiSystem({ config: listConfig() }), fetchImpl: empty.fetchImpl })
+  const emptyRead = await emptyAdapter.read({ object: 'material', filters: { FNumber: 'EMPTY' }, options: { readMode: 'list' } })
+  assert.equal(emptyRead.records.length, 0, 'empty Data.DATA is a valid empty page, not an error')
+  assert.equal(emptyRead.metadata.mode, 'material-list-bounded-smoke')
+
+  // ----- HARD CAP: a preset asking for 999 rows is still capped at 10, PageIndex pinned to 1 -----
+  const capped = createK3FetchMock()
+  const cappedAdapter = createK3WiseWebApiAdapter({ system: createK3WebApiSystem({ config: listConfig({ listMaxRows: 999 }) }), fetchImpl: capped.fetchImpl })
+  await cappedAdapter.read({ object: 'material', options: { readMode: 'list' } })
+  const cappedBody = capped.calls.find((c) => c.pathname === '/K3API/Material/GetList').body
+  assert.equal(cappedBody.Data.Top, 10, 'Top hard-capped at 10 regardless of preset value')
+  assert.equal(cappedBody.Data.PageSize, 10, 'PageSize hard-capped at 10 regardless of preset value')
+  assert.equal(cappedBody.Data.PageIndex, 1, 'PageIndex pinned to 1 (single page)')
+
+  // ----- ADVERSARIAL negative controls: the deny-guard still fires on the list path -----
+  const cursorList = await adapter.read({ object: 'material', cursor: 'next', options: { readMode: 'list' } }).catch((e) => e)
+  assert.equal((cursorList.details || {}).code, 'K3_WISE_READ_LIST_UNSUPPORTED', 'cursor rejected on list path')
+  const watermarkList = await adapter.read({ object: 'material', watermark: { FModifyDate: 'x' }, options: { readMode: 'list' } }).catch((e) => e)
+  assert.equal((watermarkList.details || {}).code, 'K3_WISE_READ_LIST_UNSUPPORTED', 'watermark rejected on list path')
+  const reqPagination = await adapter.read({ object: 'material', options: { readMode: 'list', limit: 500 } }).catch((e) => e)
+  assert.equal((reqPagination.details || {}).code, 'K3_WISE_READ_LIST_UNSUPPORTED', 'request-supplied pagination rejected (preset-owned)')
+  const injection = await adapter.read({ object: 'material', filters: { FNumber: "M' OR '1'='1" }, options: { readMode: 'list' } }).catch((e) => e)
+  assert.equal((injection.details || {}).code, 'K3_WISE_READ_FILTER_UNSUPPORTED', 'filter-injection-shaped FNumber rejected')
+  const rawFilter = await adapter.read({ object: 'material', filters: { Filter: '1=1' }, options: { readMode: 'list' } }).catch((e) => e)
+  assert.equal((rawFilter.details || {}).code, 'K3_WISE_READ_FILTER_UNSUPPORTED', 'raw caller filter expression rejected')
+
+  // ----- business failure surfaces as a read error (not a write path) -----
+  const fail = createK3FetchMock()
+  const failAdapter = createK3WiseWebApiAdapter({ system: createK3WebApiSystem({ config: listConfig() }), fetchImpl: fail.fetchImpl })
+  const failed = await failAdapter.read({ object: 'material', filters: { FNumber: 'LISTFAIL' }, options: { readMode: 'list' } }).catch((e) => e)
+  assert.ok(failed instanceof K3WiseWebApiAdapterError, 'list business failure is a read error')
+  assert.equal(failed.details.code, 'K3_WISE_READ_BUSINESS_ERROR')
+
+  // ----- BOM stays locked: a material list preset does NOT unlock bom -----
+  const bomList = await adapter.read({ object: 'bom', options: { readMode: 'list' } }).catch((e) => e)
+  assert.ok(bomList instanceof UnsupportedAdapterOperationError, 'bom is not unlocked by the material list preset')
+}
+
 async function testK3WebApiAuthorityCodeToken() {
   const { calls, fetchImpl } = createK3FetchMock()
   const adapter = createK3WiseWebApiAdapter({
@@ -1534,6 +1645,7 @@ async function testK3WebApiAutoFlagCoercion() {
 async function main() {
   await testK3WebApiAdapter()
   await testK3WebApiMaterialDetailReadSmoke()
+  await testK3WebApiMaterialListReadSmoke()
   await testK3WebApiAuthorityCodeToken()
   await testK3WebApiSaveBusinessEvidence()
   await testK3WebApiNestedDataSaveParse()

--- a/plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs
@@ -70,4 +70,35 @@ try {
   assert.ok(!String(e.message).includes('bom') || true) // object name is a coarse allowlist token, not a value
 }
 
+// --- C3 LIST preset (#1709): list mode + key-optional normalization, still fail-closed on raw/injection ---
+const LIST = getReadSmokePreset('k3wise.material-list.v1')
+assert.deepEqual(LIST.allowedModes, ['list'])
+assert.equal(LIST.keyOptional, true)
+// list intent with a key → normalized; key preserved (mapped to an exact FNumber filter downstream)
+assert.deepEqual(
+  normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', key: 'M-001' } }),
+  { presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', key: 'M-001' },
+)
+// list WITHOUT a key → key-optional → key:null (first page, no filter)
+assert.deepEqual(
+  normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list' } }),
+  { presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', key: null },
+)
+// shipped subset { presetId } (no key) also normalizes (key-optional preset)
+assert.deepEqual(
+  normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1' }),
+  { presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', key: null },
+)
+// list preset stays fail-closed: detail mode not allowed, BOM object not allowed
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'single_record_detail' } }), isErr('mode_not_allowed'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'bom', mode: 'list' } }), isErr('object_not_allowed'))
+// no raw pagination/filter/path can ride into a list intent (strict intent keys: object/mode/key only)
+for (const bad of ['limit', 'top', 'pageSize', 'pageIndex', 'cursor', 'filter', 'Filter', 'readPath', 'fields']) {
+  assert.throws(
+    () => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', [bad]: 1 } }),
+    isErr('unexpected_field'),
+    `list intent raw field '${bad}' must be rejected`,
+  )
+}
+
 console.log('read-smoke-contract.test.cjs OK')

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -39,13 +39,30 @@ assert.equal(getReadSmokePreset('__proto__'), undefined)
 // catalog frozen — no user/runtime mutation
 assert.throws(() => { READ_SMOKE_PRESETS['x.v1'] = { requiredKind: 'http' } }, TypeError, 'catalog is frozen')
 
-// --- forced single-record read request: FNumber filter only, no list/pagination/cursor/watermark/BOM ---
-const reqObj = buildReadSmokeRequest(PRESET, 'M-001')
+// --- detail read request builder: consumes the normalized contract.object/mode (#3247); FNumber filter only ---
+const reqObj = buildReadSmokeRequest(PRESET, { presetId: PRESET.presetId, object: 'material', mode: 'single_record_detail', key: 'M-001' })
 assert.deepEqual(reqObj, { object: 'material', filters: { FNumber: 'M-001' } })
 assert.equal(reqObj.cursor, undefined)
 assert.equal(reqObj.limit, undefined)
 assert.equal(reqObj.watermark, undefined)
 assert.equal(reqObj.pagination, undefined)
+
+// --- C3 LIST builder: dispatches on contract.mode='list'; signals list mode + optional FNumber filter only ---
+const LIST_PRESET = getReadSmokePreset('k3wise.material-list.v1')
+assert.ok(LIST_PRESET, 'list preset is registered')
+assert.deepEqual(LIST_PRESET.allowedModes, ['list'])
+assert.equal(LIST_PRESET.keyOptional, true)
+assert.equal(LIST_PRESET.readConfigOverlay.objects.material.readPath, '/K3API/Material/GetList')
+assert.equal(LIST_PRESET.readConfigOverlay.objects.material.readMode, 'list')
+// list with an explicit key → exact FNumber filter signal; pagination/path NOT in the request (preset-owned)
+const listReqKeyed = buildReadSmokeRequest(LIST_PRESET, { presetId: LIST_PRESET.presetId, object: 'material', mode: 'list', key: 'M-001' })
+assert.deepEqual(listReqKeyed, { object: 'material', filters: { FNumber: 'M-001' }, options: { readMode: 'list' } })
+assert.equal(listReqKeyed.cursor, undefined)
+assert.equal(listReqKeyed.limit, undefined)
+assert.equal(listReqKeyed.pagination, undefined)
+// list with no key → first page, no filter
+const listReqNoKey = buildReadSmokeRequest(LIST_PRESET, { presetId: LIST_PRESET.presetId, object: 'material', mode: 'list', key: null })
+assert.deepEqual(listReqNoKey, { object: 'material', filters: {}, options: { readMode: 'list' } })
 
 // --- non-persisted read config overlay: target-side Save config is preserved, read config is in-memory only ---
 const storedSystem = {
@@ -87,7 +104,7 @@ const okResult = {
 }
 const ev = readSmokeSuccessEvidence(PRESET, okResult)
 assert.deepEqual(ev, {
-  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: true, referenceObjectCount: 2,
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: true, referenceObjectCount: 2, recordCount: 1,
 })
 // nothing sensitive leaks (key / material values / raw / metadata / host)
 const evStr = JSON.stringify(ev)
@@ -99,11 +116,28 @@ assert.equal(ev.raw, undefined)
 assert.equal(ev.metadata, undefined)
 // empty / missing records → recordPresent false, count 0
 assert.deepEqual(readSmokeSuccessEvidence(PRESET, { records: [] }), {
-  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: false, referenceObjectCount: 0,
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: false, referenceObjectCount: 0, recordCount: 0,
 })
 assert.deepEqual(readSmokeSuccessEvidence(PRESET, {}), {
-  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: false, referenceObjectCount: 0,
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: false, referenceObjectCount: 0, recordCount: 0,
 })
+
+// --- C3 LIST evidence: values-free counts/flags only; row VALUES (FNumber/FName/FModel/FUnitID) never surface ---
+const listResult = {
+  records: [
+    { FNumber: 'M-LIST-1', FName: 'SECRET-LIST-NAME', FModel: 'SECRET-MODEL', FUnitID: 'SECRET-UNIT' },
+    { FNumber: 'M-LIST-2', FName: 'SECRET-LIST-NAME-2', FModel: 'SECRET-MODEL-2', FUnitID: 'SECRET-UNIT-2' },
+  ],
+  metadata: { mode: 'material-list-bounded-smoke', pageBounded: true },
+}
+const listEv = readSmokeSuccessEvidence(LIST_PRESET, listResult)
+assert.deepEqual(listEv, {
+  ok: true, presetId: 'k3wise.material-list.v1', object: 'material', recordPresent: true, referenceObjectCount: 0, recordCount: 2, mode: 'list', pageBounded: true,
+})
+const listEvStr = JSON.stringify(listEv)
+for (const leak of ['M-LIST-1', 'SECRET-LIST-NAME', 'SECRET-MODEL', 'SECRET-UNIT', 'FName', 'FModel', 'FUnitID']) {
+  assert.ok(!listEvStr.includes(leak), `list evidence must not leak ${leak}`)
+}
 
 // --- error evidence: coarse code + type ONLY (never the message, which may carry the key/values) ---
 class FakeAdapterError extends Error {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -598,6 +598,110 @@ function assertMaterialDetailReadOnlyScope(request) {
   }
 }
 
+// C3 LIST-only scope guard (#1709). The single-record deny-guard above stays intact for detail reads; this is the
+// sibling guard for the ONE authorized bounded list path. It keeps cursor, watermark, request-supplied pagination,
+// BOM, and any non-material object BLOCKED — only an optional FNumber filter rides in. Pagination/endpoint/fields
+// are preset-owned and applied by the caller, never from the request.
+const LIST_HARD_CAP = 10
+const MATERIAL_NUMBER_PATTERN = /^[A-Za-z0-9._-]{1,64}$/
+function assertMaterialListReadOnlyScope(request) {
+  if (request.object !== 'material') {
+    throw new UnsupportedAdapterOperationError('K3 WISE WebAPI bounded list supports only material', {
+      kind: 'erp:k3-wise-webapi',
+      object: request.object,
+      operation: 'read',
+    })
+  }
+  if (request.cursor) {
+    throw new AdapterValidationError('K3 WISE Material bounded list does not support cursor pagination', {
+      code: 'K3_WISE_READ_LIST_UNSUPPORTED',
+      object: request.object,
+      field: 'cursor',
+    })
+  }
+  if (Object.keys(request.watermark || {}).length > 0) {
+    throw new AdapterValidationError('K3 WISE Material bounded list does not support watermark reads', {
+      code: 'K3_WISE_READ_LIST_UNSUPPORTED',
+      object: request.object,
+      field: 'watermark',
+    })
+  }
+  // Pagination is preset-owned — a request-supplied limit/top/pageSize/pageIndex is rejected (defense in depth;
+  // the contract normalizer already strips these before the adapter is reached).
+  const options = isPlainObject(request.options) ? request.options : {}
+  for (const field of ['limit', 'top', 'pageSize', 'pageIndex', 'page']) {
+    if (options[field] !== undefined) {
+      throw new AdapterValidationError('K3 WISE Material bounded list pagination is preset-owned', {
+        code: 'K3_WISE_READ_LIST_UNSUPPORTED',
+        object: request.object,
+        field,
+      })
+    }
+  }
+  // Only an FNumber filter may ride in (optional). No raw caller filter expression.
+  const allowedFilterKeys = new Set(['FNumber', 'number', 'materialNumber', 'templateMaterialNumber', 'referenceFields'])
+  const unknownFilters = Object.keys(request.filters || {}).filter((key) => !allowedFilterKeys.has(key))
+  if (unknownFilters.length > 0) {
+    throw new AdapterValidationError('K3 WISE Material bounded list supports only an FNumber filter', {
+      code: 'K3_WISE_READ_FILTER_UNSUPPORTED',
+      object: request.object,
+      fields: unknownFilters,
+    })
+  }
+}
+
+// Internally compose the FNumber filter (O3): exact match, FNumber only, never a raw caller expression. The caller
+// key is validated against a strict material-number charset to prevent K3 filter injection; anything else fails
+// closed. Returns '' (no filter → first page) when no key is supplied.
+function composeBoundedFNumberFilter(request) {
+  const filters = isPlainObject(request.filters) ? request.filters : {}
+  const raw = firstDefined(filters.FNumber, filters.number, filters.materialNumber, filters.templateMaterialNumber)
+  if (isBlankValue(raw)) return ''
+  const value = String(raw).trim()
+  if (!MATERIAL_NUMBER_PATTERN.test(value)) {
+    throw new AdapterValidationError('K3 WISE Material bounded list FNumber filter is not a valid material number', {
+      code: 'K3_WISE_READ_FILTER_UNSUPPORTED',
+      object: request.object,
+      field: 'FNumber',
+    })
+  }
+  return `FNumber='${value}'`
+}
+
+// Bounded single-page list body (O2): Top/PageSize hard-capped at 10, PageIndex fixed at 1, no cursor. Fields and
+// page size are preset-owned; the hard cap applies regardless of what the preset config requests.
+function buildMaterialListBody(objectConfig, filter) {
+  const maxRows = Math.min(Number(objectConfig.listMaxRows) || LIST_HARD_CAP, LIST_HARD_CAP)
+  const fields = Array.isArray(objectConfig.listFields) && objectConfig.listFields.length > 0
+    ? objectConfig.listFields.filter((field) => typeof field === 'string' && field.trim())
+    : ['FNumber', 'FName', 'FModel', 'FUnitID']
+  return {
+    Data: {
+      Top: maxRows,
+      PageSize: maxRows,
+      PageIndex: 1,
+      Filter: filter,
+      OrderBy: 'FNumber',
+      Fields: fields.join(','),
+    },
+  }
+}
+
+// Extract bounded list rows from response.Data.DATA (O4), projecting ONLY the allowlisted fields so unknown
+// response fields never carry downstream.
+function extractMaterialListRows(data, fields) {
+  const dataNode = isPlainObject(data) && isPlainObject(data.Data) ? data.Data : null
+  const rows = dataNode && Array.isArray(dataNode.DATA) ? dataNode.DATA : []
+  const projectFields = Array.isArray(fields) && fields.length > 0 ? fields : ['FNumber', 'FName', 'FModel', 'FUnitID']
+  return rows.filter(isPlainObject).map((row) => {
+    const projected = {}
+    for (const field of projectFields) {
+      if (row[field] !== undefined) projected[field] = row[field]
+    }
+    return projected
+  })
+}
+
 function defaultMaterialReferenceFields(objectConfig) {
   return Array.isArray(objectConfig.schema)
     ? objectConfig.schema
@@ -1117,6 +1221,60 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       throw new AdapterValidationError(`K3 WISE object is not configured: ${request.object}`, { object: request.object })
     }
     ensureOperation(normalizedSystem.kind, request.object, objectConfig, 'read')
+    // C3 LIST-only (#1709): open the bounded single-page list read ONLY when the PRESET-OWNED objectConfig declares
+    // readMode 'list' (never request-supplied). Everything else falls through to the single-record detail path,
+    // whose deny-guard still blocks list/cursor/watermark/BOM.
+    if (objectConfig.readMode === 'list') {
+      assertMaterialListReadOnlyScope(request)
+      const listReadPath = objectConfig.readPath
+        ? assertRelativePath(objectConfig.readPath, 'object.readPath')
+        : null
+      if (!listReadPath) {
+        throw new K3WiseWebApiAdapterError('K3 WISE list read endpoint is not configured for material', {
+          code: 'K3_WISE_READ_NOT_CONFIGURED',
+          object: request.object,
+        })
+      }
+      const listFilter = composeBoundedFNumberFilter(request)
+      const listBody = buildMaterialListBody(objectConfig, listFilter)
+      const listAuth = await login()
+      let listResponse
+      try {
+        listResponse = await requestJson(listReadPath, {
+          method: objectConfig.readMethod || 'POST',
+          query: listAuth.query,
+          headers: listAuth.headers,
+          body: listBody,
+        })
+      } catch (error) {
+        throw new K3WiseWebApiAdapterError(`K3 WISE WebAPI list read failed: ${error && error.message ? error.message : String(error)}`, {
+          code: 'K3_WISE_READ_FAILED',
+          object: request.object,
+          status: error && error.status,
+          path: listReadPath,
+        })
+      }
+      if (!businessSuccess(listResponse.data, config)) {
+        throw new K3WiseWebApiAdapterError(String(responseMessage(listResponse.data, config, 'K3 WISE list read business response failed')), {
+          code: 'K3_WISE_READ_BUSINESS_ERROR',
+          object: request.object,
+          responseCode: responseFailureCode(listResponse.data, config, 'K3_WISE_READ_BUSINESS_ERROR'),
+        })
+      }
+      const listRows = extractMaterialListRows(listResponse.data, objectConfig.listFields)
+      return createReadResult({
+        records: listRows,
+        raw: listResponse.data,
+        metadata: {
+          object: request.object,
+          mode: 'material-list-bounded-smoke',
+          readPath: listReadPath,
+          readOnly: true,
+          pageBounded: true,
+          maxRows: Math.min(Number(objectConfig.listMaxRows) || LIST_HARD_CAP, LIST_HARD_CAP),
+        },
+      })
+    }
     assertMaterialDetailReadOnlyScope(request)
 
     const readPath = objectConfig.readPath

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1604,10 +1604,11 @@ function createHandlers(services, options = {}) {
       })
     },
 
-    // #1709 follow-up: generic read-smoke preset route (v1: K3 Material/GetDetail preset only). Built-in
-    // preset catalog ONLY — no user/request-supplied preset. Read-only: forced single read, no list/
-    // pagination/cursor/watermark/BOM, no Save/Submit/Audit, no production write. Loads credentials via the
-    // backend getExternalSystemForAdapter context (never the public, credential-stripped response) and never
+    // #1709 follow-up: generic read-smoke preset route. v1 presets: K3 Material/GetDetail single-record AND the
+    // C3 bounded Material/GetList (LIST-only, owner/customer GATE 2026-06-27). Built-in preset catalog ONLY — no
+    // user/request-supplied preset, path, method, payload, or pagination. Read-only: a single record read OR one
+    // bounded list page (no cursor/watermark/BOM), no Save/Submit/Audit, no production write. Loads credentials via
+    // the backend getExternalSystemForAdapter context (never the public, credential-stripped response) and never
     // modifies the system's role/config. Evidence is values-free.
     async externalSystemReadSmoke(req, res) {
       // Requires WRITE access: although the operation is read-only, this is an active credentialed outbound
@@ -1639,7 +1640,7 @@ function createHandlers(services, options = {}) {
       const adapter = adapterRegistry.createAdapter(adapterSystem, { principal: requestPrincipal(req) })
       // Forced single read only; values-free evidence on success or failure (never key/raw/values/credentials).
       try {
-        const result = await adapter.read(buildReadSmokeRequest(preset, contract.key))
+        const result = await adapter.read(buildReadSmokeRequest(preset, contract))
         return sendOk(res, readSmokeSuccessEvidence(preset, result))
       } catch (error) {
         return sendOk(res, readSmokeErrorEvidence(preset, error))

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -29,6 +29,35 @@ const READ_SMOKE_PRESETS = Object.freeze({
       }),
     }),
   }),
+  // C3 LIST-only (#1709, owner/customer GATE 2026-06-27; approved values-free wire contract). Bounded,
+  // single-page Material list. Endpoint/method/pagination/fields are PRESET-OWNED (never request-supplied):
+  // POST /K3API/Material/GetList, body.Data.{Top,PageSize,PageIndex} hard-capped (PageIndex=1, no cursor),
+  // body.Data.Fields = FNumber/FName/FModel/FUnitID. Read-only; no BOM/resolver/Save/Submit/Audit/write.
+  'k3wise.material-list.v1': Object.freeze({
+    presetId: 'k3wise.material-list.v1',
+    requiredKind: 'erp:k3-wise-webapi',
+    object: 'material',
+    allowedObjects: Object.freeze(['material']),
+    allowedModes: Object.freeze(['list']),
+    defaultObject: 'material',
+    defaultMode: 'list',
+    // LIST is key-OPTIONAL: an explicit key maps ONLY to an internally-composed exact FNumber filter (O3);
+    // absent → first page, no filter. A raw caller filter expression can never ride in (strict contract keys).
+    keyOptional: true,
+    readConfigOverlay: Object.freeze({
+      objects: Object.freeze({
+        material: Object.freeze({
+          operations: Object.freeze(['read']),
+          readPath: '/K3API/Material/GetList',
+          readMethod: 'POST',
+          readMode: 'list',
+          // Bounded pagination is preset-owned; the adapter additionally hard-caps at 10 regardless of this value.
+          listMaxRows: 10,
+          listFields: Object.freeze(['FNumber', 'FName', 'FModel', 'FUnitID']),
+        }),
+      }),
+    }),
+  }),
 })
 
 function isPlainObject(value) {
@@ -55,9 +84,19 @@ function getReadSmokePreset(presetId) {
   return Object.prototype.hasOwnProperty.call(READ_SMOKE_PRESETS, presetId) ? READ_SMOKE_PRESETS[presetId] : undefined
 }
 
-// Forced single-record read request. Single explicit key only — no list/pagination/cursor/watermark/BOM.
-function buildReadSmokeRequest(preset, key) {
-  return { object: preset.object, filters: { FNumber: key } }
+// Read request builder — dispatches on the NORMALIZED contract.object/mode (C3 acceptance lock #3247). It never
+// silently reuses the single-record GetDetail shape for a list read. The adapter derives the endpoint + bounded
+// pagination + fields from the preset-owned objectConfig; this builder only signals object + mode (+ optional key).
+function buildReadSmokeRequest(preset, contract) {
+  const object = contract && typeof contract.object === 'string' ? contract.object : preset.object
+  if (contract && contract.mode === 'list') {
+    // LIST: bounded single page; endpoint/pagination are preset-owned (adapter-side). An optional key maps ONLY
+    // to an internally-composed exact FNumber filter; absent → first page, no filter. No request-supplied paging.
+    const filters = contract.key ? { FNumber: contract.key } : {}
+    return { object, filters, options: { readMode: 'list' } }
+  }
+  // single_record_detail (default): forced single explicit key; no list/pagination/cursor/watermark/BOM.
+  return { object, filters: { FNumber: contract ? contract.key : undefined } }
 }
 
 // Non-persisted preset overlay for the credentialed read-smoke route. Entity-machine validation
@@ -101,13 +140,22 @@ function readSmokeSuccessEvidence(preset, result) {
     const refs = records[0] && records[0]._k3ReferenceObjects
     referenceObjectCount = refs && typeof refs === 'object' ? Object.keys(refs).length : 0
   }
-  return {
+  const meta = result && typeof result.metadata === 'object' && result.metadata ? result.metadata : {}
+  const evidence = {
     ok: true,
     presetId: preset.presetId,
     object: preset.object,
     recordPresent,
     referenceObjectCount,
+    // Count only — never the row VALUES (FNumber/FName/FModel/FUnitID stay out of evidence).
+    recordCount: records.length,
   }
+  // LIST mode: surface the bounded-page flag (values-free) so callers can confirm paging stayed capped.
+  if (meta.mode === 'material-list-bounded-smoke') {
+    evidence.mode = 'list'
+    evidence.pageBounded = meta.pageBounded === true
+  }
+  return evidence
 }
 
 // Values-free error evidence. Returns ONLY a coarse code + type — never the error message, which may carry
@@ -185,11 +233,12 @@ function normalizeReadSmokeContract(input) {
   if (!Array.isArray(preset.allowedModes) || !preset.allowedModes.includes(mode)) {
     throw new ReadSmokeContractError('mode_not_allowed', 'mode is not allowlisted for this preset')
   }
-  // Key is runtime-only and never echoed; require a non-empty string.
+  // Key is runtime-only and never echoed. Required for single-record reads; OPTIONAL for key-optional presets
+  // (LIST: absent key → first-page/no-filter; present key → internally-composed exact FNumber filter).
   const key = typeof rawKey === 'string' ? rawKey.trim() : ''
-  if (!key) throw new ReadSmokeContractError('key_required', 'a non-empty key is required')
+  if (!key && !preset.keyOptional) throw new ReadSmokeContractError('key_required', 'a non-empty key is required')
 
-  return { presetId: preset.presetId, object, mode, key }
+  return { presetId: preset.presetId, object, mode, key: key || null }
 }
 
 module.exports = {


### PR DESCRIPTION
## What

Opens the **C3 LIST-only** slice of #1709 — a bounded, read-only K3 WISE WebAPI `Material/GetList` path — under the owner/customer GATE granted on the issue (2026-06-27, `customerAdminAccepted=true`, `authorizedSlice=C3 LIST only`). Built against the owner's **published values-free wire contract** (O1–O6), explicitly replacing the previously **inferred** shape (closed draft #3324).

## Wire contract (O1–O6, from #1709)

```text
O1  POST /K3API/Material/GetList
O2  body.Data.{Top,PageSize,PageIndex}; PageIndex=1; PageSize<=10; Top<=10; no cursor
O3  body.Data.{Filter,OrderBy,Fields}; v1 filter = FNumber only, internally composed; no raw caller filter
O4  response.Data.DATA rows -> FNumber/FName/FModel/FUnitID
O6  success = 200 + success Message + parseable Data.DATA; else read-only error evidence
```

## Changes (one coherent diff, fresh from origin/main)

- **Contract** (`read-smoke.cjs`): new built-in preset `k3wise.material-list.v1` (preset-owned endpoint/method/pagination/fields; `allowedModes:['list']`; key-optional). `buildReadSmokeRequest` now consumes the normalized `contract.object/mode` (the **#3247 acceptance lock**, now demanded) and never reuses the GetDetail shape. Values-free evidence gains `recordCount` + list `pageBounded`.
- **Adapter** (`k3-wise-webapi-adapter.cjs`): the single-record `K3_WISE_READ_LIST_UNSUPPORTED` deny-guard is **preserved**; a separate bounded list path is added in front, opened **only** when the preset-owned `objectConfig.readMode==='list'`. Pagination hard-capped at 10 (PageIndex=1, no cursor) regardless of config; FNumber filter is internally composed exact-match, injection-validated; rows projected to allowlisted fields only.
- **Route** (`http-routes.cjs`): passes the whole normalized contract to the builder; stays write-gated + values-free.

## Verification — **offline only** (not yet run against real K3)

Full `plugin-integration-core` CJS suite **55/55 green** locally, driving a **synthetic `fetchImpl`** (mocks). This proves the contract / guard / projection / values-free logic — **not** that real K3 accepts the body or that envelope parsing matches production. Adversarial negative controls prove the deny-guard **still fires**: cursor / watermark / request-pagination → `K3_WISE_READ_LIST_UNSUPPORTED`; injection-shaped FNumber / raw `Filter` → `K3_WISE_READ_FILTER_UNSUPPORTED`; business failure → `K3_WISE_READ_BUSINESS_ERROR`; never Save/Submit/Audit/GetDetail; BOM not unlocked; empty `Data.DATA` = valid empty page; hard cap holds (listMaxRows:999 → Top/PageSize still 10).

## Boundaries / still gated

Read-only, write-gated (403 for read users), values-free. **C4 BOM, C5 resolver, any Save/Submit/Audit/production write, broad/unbounded scans, cursor pagination remain locked** — each needs its own GATE.

## Disclosures for review

- Replaces the **closed** inferred-shape #3324; the `codex/k3-c3-list-only-20260627` branch/worktree should be cleaned up so it isn't re-pushed.
- v1 FNumber filter is **exact-match** with a conservative charset (`[A-Za-z0-9._-]`); a material number outside that set fails closed. Prefix/`like` semantics, if wanted, are a tracked follow-up.
- **Live values-free entity-machine smoke against real K3 `Material/GetList` is the operator's gated next step** (credentials/endpoint supplied at deploy) — same pattern as #3241. This PR does not assert a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
