### PR TITLE
feat(multitable): expose form.submitted in the automation rule editor (light up BACKEND-ONLY trigger)

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -34,6 +34,7 @@
             <option value="record.updated">{{ automationTriggerTypeLabel('record.updated', isZh) }}</option>
             <option value="record.deleted">{{ automationTriggerTypeLabel('record.deleted', isZh) }}</option>
             <option value="field.value_changed">{{ automationTriggerTypeLabel('field.value_changed', isZh) }}</option>
+            <option value="form.submitted">{{ automationTriggerTypeLabel('form.submitted', isZh) }}</option>
             <option value="schedule.cron">{{ automationTriggerTypeLabel('schedule.cron', isZh) }}</option>
             <option value="schedule.interval">{{ automationTriggerTypeLabel('schedule.interval', isZh) }}</option>
             <option value="schedule.date_field">{{ automationTriggerTypeLabel('schedule.date_field', isZh) }}</option>

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -217,8 +217,9 @@ describe('MetaAutomationRuleEditor', () => {
 
     const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
     expect(triggerSelect).toBeTruthy()
-    // record.created/updated/deleted + field.value_changed + schedule.cron/interval/date_field + webhook.received
-    expect(triggerSelect.options.length).toBe(8)
+    // record.created/updated/deleted + field.value_changed + form.submitted + schedule.cron/interval/date_field
+    // + webhook.received
+    expect(triggerSelect.options.length).toBe(9)
   })
 
   it('localizes core rule editor chrome in zh-CN while keeping raw select values', async () => {
@@ -486,6 +487,42 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.querySelector('[data-field="dateFieldId"]')).toBeTruthy()
     expect(container.querySelector('[data-field="offsetDays"]')).toBeTruthy()
     expect(container.querySelector('[data-field="direction"]')).toBeTruthy()
+  })
+
+  it('exposes form.submitted as a config-less trigger and saves it (light up the BACKEND-ONLY trigger)', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'On form submit'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    triggerSelect.value = 'form.submitted'
+    triggerSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // form.submitted is config-less — none of the type-specific config sub-forms render for it.
+    expect(container.querySelector('[data-field="dateFieldId"]')).toBeNull()
+    expect(container.querySelector('[data-field="cronPreset"]')).toBeNull()
+    expect(container.querySelector('[data-field="intervalMinutes"]')).toBeNull()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].triggerType).toBe('form.submitted')
+  })
+
+  it('backfills an existing form.submitted rule into the trigger selector (round-trip)', async () => {
+    const rule: AutomationRule = {
+      id: 'atr_fs', sheetId: 'sheet_1', name: 'fs', triggerType: 'form.submitted',
+      triggerConfig: {}, actionType: 'notify', actionConfig: {}, enabled: true,
+    } as AutomationRule
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule })
+    await flushPromises()
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    expect(triggerSelect.value).toBe('form.submitted')
   })
 
   it('can add and remove conditions', async () => {

--- a/docs/development/multitable-form-submitted-trigger-ui-dev-verification-20260628.md
+++ b/docs/development/multitable-form-submitted-trigger-ui-dev-verification-20260628.md
@@ -1,0 +1,44 @@
+# `form.submitted` automation trigger — editor "light-up" — dev & verification (2026-06-28)
+
+> Status: built + verified. Grounding: `origin/main` @ `c5eb20d99`. Candidate-B "light up a BACKEND-ONLY
+> trigger" slice, owner-authorized as the next fork after date-reminder. Small by design — no design-lock; the
+> intent lives here + in the PR.
+
+## 1. The gap (design intent)
+
+`form.submitted` was a fully-wired backend trigger (in `ALL_TRIGGER_TYPES` / `VALID_TRIGGER_TYPES`, mapped
+`multitable.form.submitted → form.submitted`, real-event-chain proven by `multitable-form-submit-trigger.test.ts`)
+**but it had no entry in the automation rule editor's trigger dropdown** — a "built but not exposed" item from
+the benchmark audit. So "automate on public form submit" (→ notify / update_record / start_approval) was
+reachable only via direct API, not the UI. This lights it up.
+
+## 2. What changed (minimal)
+
+`form.submitted` is **config-less** — it fires for any form submission on the sheet (no per-form binding;
+`matchesTrigger` falls through to the default `type === eventType`), so the only gap was exposure:
+- `MetaAutomationRuleEditor.vue`: one `<option value="form.submitted">` in the trigger select (grouped with the
+  record/form event triggers). No config sub-form (it has none). The frontend `AutomationTriggerType` union and
+  the `automationTriggerTypeLabel` case ("当表单提交时" / "When form submitted") already existed.
+- Submit/round-trip needs nothing new — `buildPayload` only special-cases cron/date_field config; for
+  `form.submitted` the trigger persists as `{ type: 'form.submitted', config: {} }` and reloads as-is.
+
+No backend change: the capability already exists and is enforced server-side (`VALID_TRIGGER_TYPES`).
+
+## 3. Verification
+
+- **Editor + labels specs — 108/108** (`apps/web`): trigger-option count 8→9 (updated in place); new
+  `form.submitted` is config-less (no `dateFieldId`/`cronPreset`/`intervalMinutes` sub-form renders) and **saves**
+  (onSave payload `triggerType === 'form.submitted'`); an existing `form.submitted` rule **backfills** into the
+  selector (round-trip). `vue-tsc -b` exit 0.
+- **Backend capability re-check — 3/3** (`multitable-form-submit-trigger.test.ts`, real DB): a real form submit
+  emits `multitable.form.submitted` → `AutomationService` → `matchesTrigger('form.submitted')` → durable
+  execution row; a plain `POST /records` (record.created, not form.submitted) produces no execution. The
+  capability the UI now exposes works end-to-end.
+
+## 4. Out of scope (named)
+
+- **`start_approval` action UI** — the natural next pairing ("form submit → start approval"); higher value but
+  touches approval templates / field mapping. Separate slice, after this.
+- **`delete_record` action UI** — destructive; needs permission + confirm-copy + execution-log + anti-misdelete
+  before it's a "cheap" light-up. Deferred.
+- DARK rollout / API write-back / realtime co-edit / template / mobile — independent arcs, not light-ups.


### PR DESCRIPTION
## Light up the `form.submitted` automation trigger in the editor

Owner-authorized Candidate-B "light up a built-but-unexposed trigger" slice (the next fork after date-reminder).

`form.submitted` was a fully-wired **backend** trigger (in `VALID_TRIGGER_TYPES`, mapped from `multitable.form.submitted`, real-event-chain proven by `multitable-form-submit-trigger.test.ts`) **with no entry in the rule editor's trigger dropdown** — authorable only via direct API. This adds the option so "automate on public form submit" (→ notify / update_record / start_approval) is authorable in the UI.

### Minimal by design
`form.submitted` is **config-less** — it fires for any form submission on the sheet (`matchesTrigger` → default `type === eventType`, no per-form binding). So the only gap was exposure: one `<option>` in the trigger select. No config sub-form, no `buildPayload` special-case (the trigger persists as `{type:'form.submitted', config:{}}` and reloads as-is). **No backend change** — the capability is already enforced server-side.

### Verification
- **Editor + labels specs 108/108** (`apps/web`): option count 8→9 (in place); `form.submitted` renders config-less (no `dateFieldId`/`cronPreset`/`intervalMinutes`) + **saves** (`triggerType==='form.submitted'`) + an existing rule **backfills** into the selector (round-trip). `vue-tsc -b` clean.
- **Backend capability re-check 3/3** (`multitable-form-submit-trigger`, real DB): real form submit → `AutomationService` → durable execution; plain `POST /records` does not.

### Out of scope (named)
`start_approval` action UI (next pairing: "form submit → start approval") · `delete_record` (destructive — deferred, needs perm/confirm/log/anti-misdelete) · DARK rollout / API write-back / realtime / template / mobile (independent arcs).

Dev/verification doc: `docs/development/multitable-form-submitted-trigger-ui-dev-verification-20260628.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)