### PR TITLE
feat(multitable): expose start_approval as a configurable action in the editor (form submit → start approval)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1352,6 +1352,16 @@ export class MultitableApiClient {
     return this.parseJson(res)
   }
 
+  /**
+   * List APPROVAL templates (distinct from the multitable templates above) for the start_approval action's
+   * template picker. Guarded server-side by `approvals:read` — an automation author lacking that permission
+   * gets 401/403, which the editor degrades to a free-text template-id input (never a hard dependency).
+   */
+  async listApprovalTemplates(): Promise<{ data: Array<{ id: string; name?: string }>; total: number }> {
+    const res = await this.fetch('/api/approval-templates')
+    return this.parseJson(res)
+  }
+
   async installTemplate(templateId: string, input: InstallTemplateInput = {}): Promise<InstallTemplateResult> {
     const res = await this.fetch(`/api/multitable/templates/${encodeURIComponent(templateId)}/install`, {
       method: 'POST',

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -317,6 +317,26 @@
               <textarea v-model="action.config.message" class="meta-rule-editor__textarea" :placeholder="automationLabel('actionConfig.notificationMessagePlaceholder', isZh)" rows="3"></textarea>
             </div>
 
+            <!-- start_approval config -->
+            <div v-if="action.type === 'start_approval'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__label">{{ isZh ? '审批模板' : 'Approval template' }}</label>
+              <select v-if="approvalTemplates.length > 0" v-model="action.config.templateId" class="meta-rule-editor__select" data-field="approvalTemplateId">
+                <option value="">{{ isZh ? '请选择审批模板' : 'Select an approval template' }}</option>
+                <option v-for="t in approvalTemplates" :key="t.id" :value="t.id">{{ t.name || t.id }}</option>
+              </select>
+              <input v-else v-model="action.config.templateId" class="meta-rule-editor__input" type="text" :placeholder="isZh ? '审批模板 ID' : 'Approval template ID'" data-field="approvalTemplateId" />
+              <label class="meta-rule-editor__label">{{ isZh ? '表单字段映射（审批字段 → 记录字段）' : 'Form-data mapping (approval field → record field)' }}</label>
+              <div v-for="(pair, pidx) in (action.config.formDataMappingPairs as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
+                <input v-model="pair.fieldId" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" :placeholder="isZh ? '审批字段' : 'Approval field'" data-field="approvalMappingKey" />
+                <select v-model="pair.value" class="meta-rule-editor__select meta-rule-editor__select--sm" data-field="approvalMappingValue">
+                  <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
+                  <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+                </select>
+                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeApprovalMapping(action, pidx)">&times;</button>
+              </div>
+              <button class="meta-rule-editor__btn" type="button" @click="addApprovalMapping(action)">{{ automationLabel('editor.addField', isZh) }}</button>
+            </div>
+
             <!-- send_email config -->
             <div v-if="action.type === 'send_email'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.recipients', isZh) }}</label>
@@ -1264,6 +1284,9 @@ const saving = ref(false)
 const cronPreset = ref('0 * * * *')
 const dingTalkDestinations = ref<DingTalkGroupDestination[]>([])
 const dingTalkDestinationsError = ref('')
+// start_approval template picker. Empty (incl. on a 401/403 for an author lacking `approvals:read`) →
+// the config block degrades to a free-text template-id input; the select is never a hard dependency.
+const approvalTemplates = ref<Array<{ id: string; name?: string }>>([])
 const personRecipientSuggestions = ref<Record<number, MetaSheetPermissionCandidate[]>>({})
 const personRecipientLoading = ref<Record<number, boolean>>({})
 const personRecipientErrors = ref<Record<number, string>>({})
@@ -1287,6 +1310,7 @@ const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
   'create_record',
   'send_webhook',
   'send_notification',
+  'start_approval',
   'send_email',
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
@@ -1784,6 +1808,19 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
       message: typeof config.message === 'string' ? config.message : '',
     }
   }
+  if (type === 'start_approval') {
+    // Backfill: disassemble the persisted formDataMapping object into editable {fieldId, value} rows
+    // (inverse of buildActionPayload's fieldPairsToRecord). templateId loads as-is.
+    const mapping = isPlainRecord(config.formDataMapping) ? config.formDataMapping : {}
+    const formDataMappingPairs = Array.isArray(config.formDataMappingPairs)
+      ? config.formDataMappingPairs
+      : Object.entries(mapping).map(([fieldId, value]) => ({ fieldId, value: String(value ?? '') }))
+    return {
+      ...config,
+      templateId: typeof config.templateId === 'string' ? config.templateId : '',
+      formDataMappingPairs,
+    }
+  }
   if (type === 'send_dingtalk_group_message') {
     return {
       ...config,
@@ -2075,8 +2112,16 @@ watch(
           dingTalkDestinations.value = []
           dingTalkDestinationsError.value = err instanceof Error ? err.message : 'Failed to load DingTalk groups'
         }
+        try {
+          // Best-effort: a 401/403 (author lacks approvals:read) or any error → empty → text-input fallback.
+          const res = await props.client.listApprovalTemplates()
+          approvalTemplates.value = Array.isArray(res?.data) ? res.data : []
+        } catch {
+          approvalTemplates.value = []
+        }
       } else {
         dingTalkDestinations.value = []
+        approvalTemplates.value = []
       }
     }
   },
@@ -2762,6 +2807,18 @@ function removeFieldUpdate(action: DraftAction, idx: number) {
   ;(action.config.fieldUpdates as FieldPair[]).splice(idx, 1)
 }
 
+// start_approval: formDataMapping rows reuse the FieldPair shape (fieldId = the approval-form field key,
+// value = the source record field id). buildActionPayload assembles them into the {key: value} object the
+// backend's validateStartApprovalConfig requires.
+function addApprovalMapping(action: DraftAction) {
+  if (!Array.isArray(action.config.formDataMappingPairs)) action.config.formDataMappingPairs = []
+  ;(action.config.formDataMappingPairs as FieldPair[]).push({ fieldId: '', value: '' })
+}
+
+function removeApprovalMapping(action: DraftAction, idx: number) {
+  ;(action.config.formDataMappingPairs as FieldPair[]).splice(idx, 1)
+}
+
 function addCreateFieldValue(action: DraftAction) {
   if (!Array.isArray(action.config.fieldValues)) action.config.fieldValues = []
   ;(action.config.fieldValues as FieldPair[]).push({ fieldId: '', value: '' })
@@ -2802,6 +2859,18 @@ function buildPayload(): Partial<AutomationRule> {
         type: action.type,
         config: {
           fields: fieldPairsToRecord(action.config.fieldUpdates),
+        },
+      }
+    }
+    if (action.type === 'start_approval') {
+      // Assemble the {key: value} formDataMapping the backend requires from the editable rows. templateId +
+      // mapping non-emptiness are enforced server-side (validateStartApprovalConfig) — the UI is authoring,
+      // not the validation gate.
+      return {
+        type: action.type,
+        config: {
+          templateId: typeof action.config.templateId === 'string' ? action.config.templateId.trim() : '',
+          formDataMapping: fieldPairsToRecord(action.config.formDataMappingPairs),
         },
       }
     }

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1882,11 +1882,13 @@ function draftFromRule(rule: AutomationRule): Draft {
 const draft = ref<Draft>(emptyDraft())
 const conditionEditorEntries = computed(() => collectConditionEditorEntries(draft.value.conditions.conditions))
 
-// A6-2b/A6-3-2a/A6-3-4: wait_for_callback, condition_branch, and parallel_branch all REQUIRE execution_mode
-// 'workflow_job_v1' — the backend fail-closes a legacy rule that contains either. So whenever such
-// an action is present the job-mode toggle is forced on (and disabled), and buildPayload enforces it
-// regardless of toggle/loaded state.
-const JOB_MODE_REQUIRING_ACTION_TYPES: AutomationActionType[] = ['wait_for_callback', 'condition_branch', 'parallel_branch']
+// A6-2b/A6-3-2a/A6-3-4 + start_approval (W6-1): wait_for_callback, condition_branch, parallel_branch, AND
+// start_approval all REQUIRE execution_mode 'workflow_job_v1' — the backend (collectNestedAutomationActions /
+// validateStartApprovalActionConfigs) fail-closes a legacy rule that contains any of them. So whenever such an
+// action is present the job-mode toggle is forced on (and disabled), and buildPayload enforces it regardless
+// of toggle/loaded state. (start_approval MUST be here, else the editor would save executionMode:null and the
+// server would reject the rule — breaking the "form.submitted → start_approval" authoring path.)
+const JOB_MODE_REQUIRING_ACTION_TYPES: AutomationActionType[] = ['wait_for_callback', 'condition_branch', 'parallel_branch', 'start_approval']
 const requiresJobMode = computed(() =>
   draft.value.actions.some((a) => JOB_MODE_REQUIRING_ACTION_TYPES.includes(a.type)),
 )

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -1008,6 +1008,7 @@ export type AutomationActionType =
   | 'create_record'
   | 'send_webhook'
   | 'send_notification'
+  | 'start_approval'
   | 'send_email'
   | 'send_dingtalk_group_message'
   | 'send_dingtalk_person_message'

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -843,6 +843,8 @@ export function automationActionTypeLabel(type: AutomationActionType | UnknownAu
     case 'send_notification':
     case 'notify':
       return isZh ? '发送通知' : 'Send notification'
+    case 'start_approval':
+      return isZh ? '发起审批' : 'Start approval'
     case 'send_email':
       return isZh ? '发送邮件' : 'Send email'
     case 'send_dingtalk_group_message':

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -525,6 +525,64 @@ describe('MetaAutomationRuleEditor', () => {
     expect(triggerSelect.value).toBe('form.submitted')
   })
 
+  it('exposes start_approval as a selectable action with template + form-data mapping, and saves it', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'start approval'; nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(Array.from(actionSelect.options).map((o) => o.value)).toContain('start_approval')
+    actionSelect.value = 'start_approval'; actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // No client injected → the template picker degrades to a free-text input (the rbac/empty fallback).
+    const tmpl = container.querySelector('[data-field="approvalTemplateId"]') as HTMLInputElement
+    expect(tmpl).not.toBeNull()
+    tmpl.value = 'tmpl_1'; tmpl.dispatchEvent(new Event('input'))
+
+    const cfg = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-config') as HTMLElement
+    const addBtn = Array.from(cfg.querySelectorAll('button')).find((b) => !b.classList.contains('meta-rule-editor__btn--icon')) as HTMLButtonElement
+    addBtn.click()
+    await flushPromises()
+    const keyInput = cfg.querySelector('[data-field="approvalMappingKey"]') as HTMLInputElement
+    const valSelect = cfg.querySelector('[data-field="approvalMappingValue"]') as HTMLSelectElement
+    keyInput.value = 'amount'; keyInput.dispatchEvent(new Event('input'))
+    valSelect.value = 'fld_2'; valSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].actions).toEqual([
+      { type: 'start_approval', config: { templateId: 'tmpl_1', formDataMapping: { amount: 'fld_2' } } },
+    ])
+  })
+
+  it('backfills + round-trips a form.submitted → start_approval rule (the combo, both directions)', async () => {
+    const saved = vi.fn()
+    const rule: AutomationRule = {
+      id: 'atr_sa', sheetId: 'sheet_1', name: 'sa', triggerType: 'form.submitted',
+      triggerConfig: {}, actionType: 'start_approval',
+      actionConfig: { templateId: 'tmpl_9', formDataMapping: { amount: 'fld_2' } }, enabled: true,
+    } as AutomationRule
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
+    await flushPromises()
+    // form.submitted trigger + start_approval action coexist; the mapping disassembled into an editable row.
+    expect((container.querySelector('[data-field="triggerType"]') as HTMLSelectElement).value).toBe('form.submitted')
+    expect((container.querySelector('[data-field="approvalTemplateId"]') as HTMLInputElement).value).toBe('tmpl_9')
+    expect((container.querySelector('[data-field="approvalMappingKey"]') as HTMLInputElement).value).toBe('amount')
+    expect((container.querySelector('[data-field="approvalMappingValue"]') as HTMLSelectElement).value).toBe('fld_2')
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+    expect(saved.mock.calls[0][0].triggerType).toBe('form.submitted')
+    expect(saved.mock.calls[0][0].actions).toEqual([
+      { type: 'start_approval', config: { templateId: 'tmpl_9', formDataMapping: { amount: 'fld_2' } } },
+    ])
+  })
+
   it('can add and remove conditions', async () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -558,6 +558,9 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].actions).toEqual([
       { type: 'start_approval', config: { templateId: 'tmpl_1', formDataMapping: { amount: 'fld_2' } } },
     ])
+    // [P1] start_approval REQUIRES execution_mode workflow_job_v1 — the editor must auto-enable it on save,
+    // else the server fail-closes the rule and the authoring path silently breaks.
+    expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1')
   })
 
   it('backfills + round-trips a form.submitted → start_approval rule (the combo, both directions)', async () => {
@@ -581,6 +584,24 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].actions).toEqual([
       { type: 'start_approval', config: { templateId: 'tmpl_9', formDataMapping: { amount: 'fld_2' } } },
     ])
+    expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1')
+  })
+
+  it('force-corrects a loaded LEGACY start_approval rule (executionMode: null) to workflow_job_v1 on save', async () => {
+    const saved = vi.fn()
+    const rule = {
+      id: 'atr_sa_legacy', sheetId: 'sheet_1', name: 'legacy sa', triggerType: 'form.submitted',
+      triggerConfig: {}, actionType: 'start_approval',
+      actionConfig: { templateId: 'tmpl_9', formDataMapping: { amount: 'fld_2' } },
+      enabled: true, executionMode: null,
+    } as unknown as AutomationRule
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
+    await flushPromises()
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+    // The backend fail-closes a legacy start_approval rule; the editor force-corrects on save — parity with
+    // wait_for_callback's A6-2b golden. (buildPayload enforces job-mode regardless of the loaded null.)
+    expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1')
   })
 
   it('can add and remove conditions', async () => {

--- a/docs/development/multitable-start-approval-action-ui-dev-verification-20260628.md
+++ b/docs/development/multitable-start-approval-action-ui-dev-verification-20260628.md
@@ -31,12 +31,27 @@ API. So "form submit → start approval" couldn't be built in the UI. This expos
 The UI is **authoring, not the validation gate** — `validateStartApprovalConfig` already fail-closes templateId
 + non-empty mapping at save (create/updateRule), so a bad/incomplete config is rejected server-side regardless.
 
+### [P1] start_approval requires `workflow_job_v1` — the editor must auto-enable it (review fix)
+The backend (`collectNestedAutomationActions` / `validateStartApprovalActionConfigs`) fail-closes any
+`start_approval` rule whose `execution_mode` isn't `workflow_job_v1`. Adding `start_approval` to the *selectable*
+actions alone was a **dead config**: the editor's `JOB_MODE_REQUIRING_ACTION_TYPES` was still
+`['wait_for_callback','condition_branch','parallel_branch']`, so save emitted `executionMode: null` and the server
+rejected the rule — breaking the very "form.submitted → start_approval from the UI" path this slice exists for.
+Fix: add `start_approval` to `JOB_MODE_REQUIRING_ACTION_TYPES` (selecting it now force-on-locks the job-mode
+toggle, and `buildPayload` enforces it regardless of toggle/loaded state — parity with `wait_for_callback`).
+
 ## 3. Verification
 
-- **Editor + labels specs — 110/110** (`apps/web`): `start_approval` is a selectable action; selecting it renders
-  the template + mapping config; a rule **saves** as `{type:'start_approval', config:{templateId, formDataMapping}}`;
-  and a **form.submitted → start_approval** rule **backfills** (templateId + mapping rows repopulate) and
-  **round-trips** on save (both directions, the combo the use-case needs). `vue-tsc -b` exit 0.
+- **Editor + labels specs — all green** (`apps/web`): `start_approval` is a selectable action; selecting it renders
+  the template + mapping config; a rule **saves** as `{type:'start_approval', config:{templateId, formDataMapping}}`
+  **with `executionMode: 'workflow_job_v1'`** ([P1] asserted in both save specs); a **form.submitted →
+  start_approval** rule **backfills** (templateId + mapping rows repopulate) and **round-trips** on save (both
+  directions); and a loaded **legacy** start_approval rule (`executionMode: null`) is **force-corrected** to
+  `workflow_job_v1` on save (parity with `wait_for_callback` A6-2b). `vue-tsc -b` exit 0.
+- **[P1] fail-first:** removing `start_approval` from `JOB_MODE_REQUIRING_ACTION_TYPES` → all 3 start_approval
+  executionMode goldens RED (`expected null to be 'workflow_job_v1'`) — the exact server-reject bug. Restored → green.
+- **No regression on shared action-type machinery:** broader automation web specs (manager, condition/parallel
+  branch editors, log viewer) stay green.
 - **Save-boundary validation — already covered** (no duplication): `automation-v1.test.ts` W6-1 "createRule rejects
   invalid start_approval config before persistence" → `actionConfig.templateId is required`. The UI relies on this.
 - **Backend capability re-check — 14/14** (`multitable-automation-start-approval`, real DB): `start_approval`

--- a/docs/development/multitable-start-approval-action-ui-dev-verification-20260628.md
+++ b/docs/development/multitable-start-approval-action-ui-dev-verification-20260628.md
@@ -1,0 +1,50 @@
+# `start_approval` automation action — editor "light-up" — dev & verification (2026-06-28)
+
+> Status: built + verified. Grounding: `origin/main` @ `262b52524` (the form.submitted merge). Candidate-B
+> "light up a BACKEND-ONLY action" slice; owner-authorized as the pairing after form.submitted
+> ("表单提交 → 发起审批"). Advisor-reviewed before implementation. Frontend-only (no backend change).
+
+## 1. The gap
+
+`start_approval` was a fully-wired backend action (execution proven by `multitable-automation-start-approval.test.ts`,
+save-validation enforced by `validateStartApprovalConfig` inside create/updateRule) **but absent from the editor's
+selectable action types** (`SUPPORTED_SELECTABLE_ACTION_TYPES`) with no config UI — authorable only via direct
+API. So "form submit → start approval" couldn't be built in the UI. This exposes it.
+
+## 2. What changed (frontend only)
+
+- **Selectable + label**: `start_approval` added to `SUPPORTED_SELECTABLE_ACTION_TYPES` + the frontend
+  `AutomationActionType` union + an `automationActionTypeLabel` case ("发起审批" / "Start approval").
+- **Config block** (`MetaAutomationRuleEditor.vue`): `templateId` + `formDataMapping`.
+  - **templateId** — a **fetched `<select>` over approval templates** (new `client.listApprovalTemplates()` →
+    `GET /api/approval-templates`) **with a free-text fallback**. That route is `rbacGuard('approvals:read')`;
+    an automation author may lack it, so a 401/403/empty fetch degrades to a text input — **the select is never a
+    hard dependency** (the design's single most important point).
+  - **formDataMapping** — a free-form key→value rows editor (approval field → record field picker), reusing the
+    `FieldPair` shape + `fieldPairsToRecord`, mirroring `update_record`.
+- **Two-direction wiring** (the real work vs the config-less form.submitted): `buildActionPayload` assembles
+  `{templateId, formDataMapping}`; `draftConfigFromAction` disassembles a saved mapping object back into editable
+  rows. Round-trip covered by a spec.
+- **Deferred (named)**: `requester` mode + `resultWriteback` — both **optional** in the backend; out of v1.
+  Schema-aware mapping labels (fetching each template's form schema) is a second integration — also v2.
+
+The UI is **authoring, not the validation gate** — `validateStartApprovalConfig` already fail-closes templateId
++ non-empty mapping at save (create/updateRule), so a bad/incomplete config is rejected server-side regardless.
+
+## 3. Verification
+
+- **Editor + labels specs — 110/110** (`apps/web`): `start_approval` is a selectable action; selecting it renders
+  the template + mapping config; a rule **saves** as `{type:'start_approval', config:{templateId, formDataMapping}}`;
+  and a **form.submitted → start_approval** rule **backfills** (templateId + mapping rows repopulate) and
+  **round-trips** on save (both directions, the combo the use-case needs). `vue-tsc -b` exit 0.
+- **Save-boundary validation — already covered** (no duplication): `automation-v1.test.ts` W6-1 "createRule rejects
+  invalid start_approval config before persistence" → `actionConfig.templateId is required`. The UI relies on this.
+- **Backend capability re-check — 14/14** (`multitable-automation-start-approval`, real DB): `start_approval`
+  executes (`AutomationService → ApprovalProductService.createApproval`). No backend change in this slice.
+
+## 4. Out of scope (named)
+
+- `requester` mode + `resultWriteback` UI (optional backend config) — v2.
+- Schema-aware mapping (per-template form-field labels) — a second integration; v2.
+- `delete_record` action UI (destructive — perm/confirm/log/anti-misdelete first) · DARK rollout · API
+  write-back · realtime · template · mobile — independent arcs.


### PR DESCRIPTION
## Light up the `start_approval` action in the editor — "表单提交 → 发起审批"

Owner-authorized Candidate-B pairing after form.submitted. `start_approval` was a fully-wired **backend** action (execution proven by `multitable-automation-start-approval`; save-validation enforced by `validateStartApprovalConfig` in create/updateRule) **absent from the editor's selectable actions** — authorable only via direct API. This exposes it as a configurable action.

### Config UI (frontend only)
- **templateId** — a fetched approval-templates `<select>` (new `client.listApprovalTemplates()` → `GET /api/approval-templates`) **with a free-text fallback**. That route is `rbacGuard('approvals:read')`; an automation author may lack it, so a 401/403/empty fetch **degrades to a text input** — the select is never a hard dependency.
- **formDataMapping** — a free-form key→value rows editor (approval field → record field picker), reusing `FieldPair` / `fieldPairsToRecord` (mirrors `update_record`).
- **Two-direction wiring**: `buildActionPayload` assembles `{templateId, formDataMapping}`; `draftConfigFromAction` disassembles it back into editable rows (backfill).
- **No backend change** — `validateStartApprovalConfig` already fail-closes `templateId` + non-empty mapping at save, so the UI is authoring, not the validation gate.

### Deferred (named)
`requester` mode + `resultWriteback` (both optional backend config) · schema-aware mapping labels (per-template form schema = a second integration) — all v2.

### Verification
- **Editor + labels specs 110/110**: selectable + template/mapping config renders + saves `{type:'start_approval', config:{templateId, formDataMapping}}` + a **form.submitted → start_approval** rule backfills + round-trips (both directions). `vue-tsc -b` clean.
- **Broader automation web specs 113/113** (manager, condition/parallel branch editors, log viewer) — no regression on the shared action-type union/labels machinery.
- **Backend start_approval execution re-check 14/14** (real DB); **save-rejection already covered** (`automation-v1` W6-1 "createRule rejects invalid start_approval config").

Dev/verification doc: `docs/development/multitable-start-approval-action-ui-dev-verification-20260628.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)