### PR TITLE
fix(k3): surface read-smoke adapter error codes

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5718,7 +5718,7 @@ async function testReadSmokeRoute() {
   const failSvc = createMockServices({
     externalSystemRegistry: { async getExternalSystemForAdapter(input) { return { id: input.id, kind: 'erp:k3-wise-webapi', credentials: {} } } },
     adapterRegistry: { createAdapter() { return {
-      async read() { const e = new Error('material M-001 secret 42'); e.name = 'K3WiseWebApiAdapterError'; e.code = 'K3_WISE_READ_BUSINESS_ERROR'; throw e },
+      async read() { const e = new Error('material M-001 secret 42'); e.name = 'K3WiseWebApiAdapterError'; e.details = { code: 'K3_WISE_READ_BUSINESS_ERROR' }; throw e },
       async upsert(b) { failWrite.push(b); return {} },
     } } },
   })

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -179,7 +179,11 @@ assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, { records: [{ FNumber: 'M
 
 // --- error evidence: coarse code + type ONLY (never the message, which may carry the key/values) ---
 class FakeAdapterError extends Error {
-  constructor() { super('material M-001 failed with secret value 42'); this.name = 'K3WiseWebApiAdapterError'; this.code = 'K3_WISE_READ_BUSINESS_ERROR' }
+  constructor() {
+    super('material M-001 failed with secret value 42')
+    this.name = 'K3WiseWebApiAdapterError'
+    this.details = { code: 'K3_WISE_READ_BUSINESS_ERROR' }
+  }
 }
 const errEv = readSmokeErrorEvidence(PRESET, new FakeAdapterError(), { object: 'material', mode: 'single_record_detail' })
 assert.deepEqual(errEv, {
@@ -189,6 +193,15 @@ assert.deepEqual(errEv, {
 const errStr = JSON.stringify(errEv)
 for (const leak of ['M-001', '42', 'failed with secret']) {
   assert.ok(!errStr.includes(leak), `error evidence must not leak ${leak}`)
+}
+const unsafeDetails = new Error('material M-001 failed with secret value 42')
+unsafeDetails.name = 'K3WiseWebApiAdapterError'
+unsafeDetails.details = { code: 'M-001 failed with secret value 42' }
+const unsafeEv = readSmokeErrorEvidence(PRESET, unsafeDetails, { object: 'material', mode: 'single_record_detail' })
+assert.equal(unsafeEv.errorCode, 'READ_SMOKE_READ_FAILED', 'non-enum details.code is not surfaced')
+const unsafeStr = JSON.stringify(unsafeEv)
+for (const leak of ['M-001', '42', 'failed with secret']) {
+  assert.ok(!unsafeStr.includes(leak), `unsafe details.code must not leak ${leak}`)
 }
 // error without code/name → safe defaults
 const bare = readSmokeErrorEvidence(PRESET, {}, { object: 'material', mode: 'single_record_detail' })

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -180,7 +180,8 @@ function readSmokeSuccessEvidence(preset, result, contract = {}) {
 function readSmokeErrorEvidence(preset, error, contract = {}) {
   // Use the error's own enum-like code + name only (both values-free). Never fall back to constructor.name
   // (a plain thrown object would surface 'Object', which is noise) and never read the message.
-  const code = error && typeof error.code === 'string' && error.code ? error.code : null
+  const code = readSmokeSafeErrorCode(error && error.code) ||
+    readSmokeSafeErrorCode(error && error.details && error.details.code)
   const name = error && typeof error.name === 'string' && error.name ? error.name : null
   const object = typeof contract.object === 'string' && contract.object ? contract.object : preset.object
   const mode = typeof contract.mode === 'string' && contract.mode ? contract.mode : preset.defaultMode
@@ -192,6 +193,13 @@ function readSmokeErrorEvidence(preset, error, contract = {}) {
     errorCode: code || 'READ_SMOKE_READ_FAILED',
     errorType: name || 'Error',
   }
+}
+
+function readSmokeSafeErrorCode(value) {
+  if (typeof value !== 'string') return null
+  const code = value.trim()
+  if (!code || code.length > 80) return null
+  return /^[A-Z0-9_:-]+$/.test(code) ? code : null
 }
 
 // C1 contract normalizer (#1709 / C0 #3242). Reconciles the forward-looking


### PR DESCRIPTION
## Summary

Follow-up to the #1709 C3 LIST-only live entity-machine smoke: the route was reachable and values-free, but a real K3 `Material/GetList` failure collapsed to generic `READ_SMOKE_READ_FAILED` because read-smoke evidence only considered `error.code` while `K3WiseWebApiAdapterError` stores its coarse enum under `error.details.code`.

This PR surfaces `error.details.code` when it is safe enum-like evidence.

## Boundary

- C3 LIST-only diagnostic evidence only.
- No endpoint/body/pagination/filter behavior change.
- No BOM, resolver, Save, Submit, Audit, production write, or broad scan.
- Values-free: never reads `error.message`, raw K3 payload, rows, host, credentials, key, or material values.

## What changed

- `readSmokeErrorEvidence` now accepts `error.code` or `error.details.code` only if the value is enum-like (`[A-Z0-9_:-]`, max 80 chars).
- Added unit coverage for real `K3WiseWebApiAdapterError` shape (`details.code`) and a negative control where a non-enum `details.code` contains secret-looking content and must be suppressed.
- Route test now mocks the real adapter shape (`details.code`) instead of the previous synthetic `error.code`.

## Verification

```text
node plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
pnpm --filter plugin-integration-core test:http-routes
pnpm --filter plugin-integration-core test:k3-wise-adapters
pnpm --filter plugin-integration-core test
```

All passed locally after `pnpm install --frozen-lockfile` in the isolated worktree.
