### PR TITLE
test(attendance): cover self-service rules locale labels

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -20951,7 +20951,7 @@ const selfRulesPunchPolicySummary = computed(() => {
   return `${mode} · ${outdoor} · ${merge}`
 })
 
-const SELF_RULES_WEEKDAY_LABELS = [
+const selfRulesWeekdayLabels = computed(() => [
   tr('Sun', '周日'),
   tr('Mon', '周一'),
   tr('Tue', '周二'),
@@ -20959,7 +20959,7 @@ const SELF_RULES_WEEKDAY_LABELS = [
   tr('Thu', '周四'),
   tr('Fri', '周五'),
   tr('Sat', '周六'),
-]
+])
 
 function formatSelfRulesMinutes(value: unknown): string {
   const minutes = Number(value)
@@ -20971,7 +20971,8 @@ const selfRulesWorkingDaysSummary = computed(() => {
   if (!Array.isArray(days) || days.length === 0) return tr('Not configured', '未配置')
   const uniqueDays = Array.from(new Set(days.map(day => Number(day)).filter(day => Number.isInteger(day) && day >= 0 && day <= 6))).sort((a, b) => a - b)
   if (uniqueDays.length === 7) return tr('Every day', '每天')
-  return uniqueDays.map(day => SELF_RULES_WEEKDAY_LABELS[day]).join(', ') || tr('Not configured', '未配置')
+  const labels = selfRulesWeekdayLabels.value
+  return uniqueDays.map(day => labels[day]).join(', ') || tr('Not configured', '未配置')
 })
 
 const selfRulesGraceSummary = computed(() => {

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -263,7 +263,7 @@ function installOverviewMock(): void {
             workEndTime: '18:00',
             workingDays: [1, 2, 3, 4, 5],
             lateGraceMinutes: 5,
-            earlyLeaveGraceMinutes: 5,
+            earlyGraceMinutes: 5,
             severeLateThresholdMinutes: 30,
             absenceLateThresholdMinutes: 60,
             geofence: 'raw-geofence-secret',
@@ -607,6 +607,22 @@ describe('Attendance self-service dashboard', () => {
     expect(container?.querySelector('[data-selfservice-primary-action]')?.textContent).toContain('Resolve anomaly reminders')
     expect(container?.querySelector('[data-selfservice-card="guide"]')?.textContent).toContain('Adjusted')
     expect(container?.querySelector('[data-selfservice-card="guide"]')?.textContent).toContain('manual correction')
+  })
+
+  it('updates self-service rules weekday labels when the locale changes', async () => {
+    useLocale().setLocale('en')
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const rulesCard = () => container?.querySelector('[data-selfservice-card="rules"]')?.textContent ?? ''
+    expect(rulesCard()).toContain('Mon, Tue, Wed, Thu, Fri')
+
+    useLocale().setLocale('zh-CN')
+    await flushUi(4)
+
+    expect(rulesCard()).toContain('周一, 周二, 周三, 周四, 周五')
+    expect(rulesCard()).not.toContain('Mon, Tue, Wed, Thu, Fri')
   })
 
   it('clears stale self-service rules while a reload is in flight', async () => {


### PR DESCRIPTION
## Summary
- make self-service rules weekday labels recompute when the locale changes
- align the self-service rules fixture with the runtime earlyGraceMinutes field
- add a dashboard regression test for English -> Chinese locale switching

Issue: #3302

## Verification
- git diff --check origin/main...HEAD
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web exec vitest run tests/attendance-selfservice-dashboard.spec.ts --watch=false