### PR TITLE
test(attendance): cover result edit edge cases

### DIFF
--- a/packages/core-backend/tests/integration/attendance-result-edit.test.ts
+++ b/packages/core-backend/tests/integration/attendance-result-edit.test.ts
@@ -150,6 +150,52 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
       [org, start, end, status],
     )).rows[0].id as string
   }
+  async function withDefaultRule(input: {
+    timezone: string
+    workStartTime?: string
+    workEndTime?: string
+    lateGraceMinutes?: number
+    earlyGraceMinutes?: number
+    severeLateThresholdMinutes?: number
+    absenceLateThresholdMinutes?: number
+    roundingMinutes?: number
+    workingDays?: number[]
+  }, run: () => Promise<void>): Promise<void> {
+    const ruleId = randomUUID()
+    const previousDefaultIds = (await pool.query(
+      `SELECT id FROM attendance_rules WHERE org_id = $1 AND is_default = true`,
+      [ORG],
+    )).rows.map((row) => String(row.id))
+    try {
+      await pool.query(`UPDATE attendance_rules SET is_default = false, updated_at = now() WHERE org_id = $1 AND is_default = true`, [ORG])
+      await pool.query(
+        `INSERT INTO attendance_rules
+         (id, org_id, name, timezone, work_start_time, work_end_time, late_grace_minutes, early_grace_minutes,
+          severe_late_threshold_minutes, absence_late_threshold_minutes, rounding_minutes, working_days, is_default)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, true)`,
+        [
+          ruleId,
+          ORG,
+          `ae1-rule-${ruleId}`,
+          input.timezone,
+          input.workStartTime ?? '09:00',
+          input.workEndTime ?? '18:00',
+          input.lateGraceMinutes ?? 5,
+          input.earlyGraceMinutes ?? 5,
+          input.severeLateThresholdMinutes ?? 30,
+          input.absenceLateThresholdMinutes ?? 60,
+          input.roundingMinutes ?? 5,
+          JSON.stringify(input.workingDays ?? [0, 1, 2, 3, 4, 5, 6]),
+        ],
+      )
+      await run()
+    } finally {
+      await pool.query(`DELETE FROM attendance_rules WHERE id = $1`, [ruleId]).catch(() => undefined)
+      if (previousDefaultIds.length > 0) {
+        await pool.query(`UPDATE attendance_rules SET is_default = true, updated_at = now() WHERE id = ANY($1::uuid[])`, [previousDefaultIds]).catch(() => undefined)
+      }
+    }
+  }
 
   beforeAll(async () => {
     const canListen: boolean = await new Promise((resolve) => {
@@ -270,14 +316,30 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     // default: no override → work stays 0, no fabricated punches
     const u1 = `u-abs-${RUN}`
     const wd1 = ymd(3)
-    const r1 = await seedRecord({ userId: u1, workDate: wd1, status: 'absent', workMinutes: 0, lateMinutes: 0, earlyLeaveMinutes: 0, firstInAt: null, lastOutAt: null })
+    const r1 = await seedRecord({
+      userId: u1,
+      workDate: wd1,
+      status: 'absent',
+      workMinutes: 0,
+      lateMinutes: 90,
+      earlyLeaveMinutes: 15,
+      firstInAt: null,
+      lastOutAt: null,
+      meta: { severe_late_count: 1, severe_late_minutes: 90, absence_late_count: 1, warnings: ['manual-review'] },
+    })
     const e1 = await postEdit({ orgId: ORG, recordId: r1, targetStatus: 'normal', reason: '线下值班，核验后更正为正常', idempotencyKey: `k-abs1-${RUN}` })
     expect(e1.status).toBe(200)
     const rec1 = await recordById(r1)
     expect(rec1.status).toBe('normal')
     expect(Number(rec1.work_minutes)).toBe(0)
+    expect(Number(rec1.late_minutes)).toBe(0)
+    expect(Number(rec1.early_leave_minutes)).toBe(0)
     expect(rec1.first_in_at).toBeNull()
     expect(rec1.last_out_at).toBeNull()
+    expect(Number(rec1.meta?.severe_late_count ?? -1)).toBe(0)
+    expect(Number(rec1.meta?.severe_late_minutes ?? -1)).toBe(0)
+    expect(Number(rec1.meta?.absence_late_count ?? -1)).toBe(0)
+    expect(rec1.meta?.warnings).toEqual(['manual-review'])
 
     // override: admin supplies the payroll work minutes
     const u2 = `u-abs2-${RUN}`
@@ -311,6 +373,24 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     expect(replay.status).toBe(200)
     expect(dataOf(replay).alreadyApplied).toBe(true)
     expect(await auditByKey(ORG, key)).toHaveLength(1)
+
+    // v1 decision: overrideMetrics is intentionally not part of the idempotency identity.
+    // A deliberate same-key replay with different metrics returns the first edit and does not mutate again.
+    const metricsReplay = await postEdit({
+      orgId: ORG,
+      recordId,
+      targetStatus: 'normal',
+      reason: 'verified offline',
+      overrideMetrics: { workMinutes: 1, lateMinutes: 99, earlyLeaveMinutes: 88 },
+      idempotencyKey: key,
+    })
+    expect(metricsReplay.status).toBe(200)
+    expect(dataOf(metricsReplay).alreadyApplied).toBe(true)
+    expect(await auditByKey(ORG, key)).toHaveLength(1)
+    const recAfterReplay = await recordById(recordId)
+    expect(Number(recAfterReplay.work_minutes)).toBe(480)
+    expect(Number(recAfterReplay.late_minutes)).toBe(0)
+    expect(Number(recAfterReplay.early_leave_minutes)).toBe(0)
 
     // same key, different payload (target) → 409
     const conflict = await postEdit({ orgId: ORG, recordId, targetStatus: 'absent', reason: 'verified offline', idempotencyKey: key })
@@ -394,7 +474,30 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     expect(await auditRowsForRecord(recordId)).toHaveLength(0)
   })
 
-  it('cross-org: a record from another org → 404, no audit row, no cross-org leak', async () => {
+  it('edit-window: invalid resolved rule timezone fails closed before writing audit or mutating the record', async () => {
+    await withDefaultRule({ timezone: 'Not/AZone' }, async () => {
+      const wd = ymd(2)
+      const recordId = await seedRecord({
+        userId: `u-badtz-${RUN}`,
+        workDate: wd,
+        status: 'late',
+        lateMinutes: 30,
+        workMinutes: 480,
+        firstInAt: `${wd}T01:30:00Z`,
+        lastOutAt: `${wd}T10:00:00Z`,
+      })
+      const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'bad timezone', idempotencyKey: `k-badtz-${RUN}` })
+      expect(res.status).toBe(422)
+      expect(codeOf(res)).toBe('ATTENDANCE_RESULT_EDIT_WINDOW_EXPIRED')
+      expect(await auditRowsForRecord(recordId)).toHaveLength(0)
+
+      const rec = await recordById(recordId)
+      expect(rec.status).toBe('late')
+      expect(Number(rec.late_minutes)).toBe(30)
+    })
+  })
+
+  it('partition filter: caller orgId mismatch for a record in another org → 404, no audit row', async () => {
     const wd = ymd(2)
     const otherRecord = await seedRecord({ userId: `u-x-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, org: ORG_OTHER, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
     const key = `k-xorg-${RUN}`


### PR DESCRIPTION
## Summary\n- cover the documented v1 idempotency behavior where same-key/different overrideMetrics replays return alreadyApplied and do not mutate again\n- assert absent -> normal clears lateness tier metadata while preserving unrelated meta and null punches\n- add an invalid resolved rule timezone fail-closed edit-window test\n- relabel the org mismatch test as a partition-filter assertion instead of an auth-boundary proof\n\n## Not covered in this slice\n- 503 payroll table unavailable fail-closed: simulating that requires temporarily breaking a shared migrated table, which is unsafe for parallel CI.\n\n## Verification\n- git diff --check\n- pnpm --filter @metasheet/core-backend type-check\n- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-result-edit.test.ts --reporter=dot (skipped locally: no DB)\n\nCloses part of #3317