### PR TITLE
test(multitable): cover multi-resurrect rollback

### DIFF
--- a/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
@@ -221,4 +221,32 @@ describeIfDatabase('multitable T8-1 PIT undelete-execute (real DB)', () => {
       await q(`DROP FUNCTION IF EXISTS ${FN}()`, []).catch(() => {})
     }
   })
+
+  test('(m) multi-resurrect forced failure is all-or-nothing — no earlier resurrect survives a later insert failure', async () => {
+    process.env[FLAG] = 'true'
+    const U2 = `rec_un_zmulti_${TS}`
+    await rev(U2, 1, 'create', { [NAME]: 'u2-at-T1', [LINK]: [L] }, T0)
+    const pv = await preview(T1)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.undeleteRecordIds).toHaveLength(2)
+    expect(pv.body?.data?.undeleteRecordIds).toEqual(expect.arrayContaining([U, U2]))
+
+    const FN = `un_multi_fail_${TS}`, TRG = `un_multi_fail_trg_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${FN}() RETURNS trigger LANGUAGE plpgsql AS $fn$ BEGIN RAISE EXCEPTION 'forced multi undelete insert failure'; END; $fn$`, [])
+    await q(`DROP TRIGGER IF EXISTS ${TRG} ON meta_records`, [])
+    await q(`CREATE TRIGGER ${TRG} BEFORE INSERT ON meta_records FOR EACH ROW WHEN (NEW.id = '${U2}') EXECUTE FUNCTION ${FN}()`, [])
+    try {
+      const x = await execute(T1, pv.body?.data?.previewIdentity, 'undelete')
+      expect(x.status).toBeGreaterThanOrEqual(409)
+      expect(await liveRow(U)).toBeUndefined()
+      expect(await liveRow(U2)).toBeUndefined()
+      expect(await outboundEdges(U)).toBe(0)
+      expect(await outboundEdges(U2)).toBe(0)
+      expect(await revCount(U)).toBe(2) // create + delete only; no rolled-forward resurrect revision survived
+      expect(await revCount(U2)).toBe(1) // create only; no rolled-forward resurrect revision survived
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${TRG} ON meta_records`, []).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${FN}()`, []).catch(() => {})
+    }
+  })
 })


### PR DESCRIPTION
## Summary\n- add a T8-1 real-DB golden for multi-resurrect atomicity\n- force the second resurrect insert to fail and assert neither resurrect row, link edge, nor restore revision survives\n- keep the assertion order-insensitive over the undelete record id set\n\n## Still gated outside this PR\n- The flag-on live smoke remains a non-prod environment gate before MULTITABLE_ENABLE_PIT_UNDELETE=true. This PR only covers the missing golden in #3321.\n\n## Verification\n- git diff --check\n- pnpm --filter @metasheet/core-backend type-check\n- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-undelete-pit-realdb.test.ts --reporter=dot (skipped locally: no DB)\n\nRefs #3321