### PR TITLE
fix(k3): split list read envelope diagnostics

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5718,7 +5718,7 @@ async function testReadSmokeRoute() {
   const failSvc = createMockServices({
     externalSystemRegistry: { async getExternalSystemForAdapter(input) { return { id: input.id, kind: 'erp:k3-wise-webapi', credentials: {} } } },
     adapterRegistry: { createAdapter() { return {
-      async read() { const e = new Error('material M-001 secret 42'); e.name = 'K3WiseWebApiAdapterError'; e.details = { code: 'K3_WISE_READ_BUSINESS_ERROR' }; throw e },
+      async read() { const e = new Error('material M-001 secret 42'); e.name = 'K3WiseWebApiAdapterError'; e.details = { code: 'K3_WISE_READ_LIST_REJECTED', dataDataPresent: true }; throw e },
       async upsert(b) { failWrite.push(b); return {} },
     } } },
   })
@@ -5728,8 +5728,9 @@ async function testReadSmokeRoute() {
   })
   assertOkResponse(fail, 200)
   assert.equal(fail.body.data.ok, false)
-  assert.equal(fail.body.data.errorCode, 'K3_WISE_READ_BUSINESS_ERROR')
+  assert.equal(fail.body.data.errorCode, 'K3_WISE_READ_LIST_REJECTED')
   assert.equal(fail.body.data.errorType, 'K3WiseWebApiAdapterError')
+  assert.equal(fail.body.data.dataDataPresent, true)
   const failStr = JSON.stringify(fail.body.data)
   assert.ok(!failStr.includes('M-001') && !failStr.includes('42'), 'read failure evidence is values-free')
   assert.equal(failWrite.length, 0, 'no write attempted on read failure')

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -962,6 +962,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.equal(read.metadata.readOnly, true)
   assert.equal(read.metadata.requestedLimit, 2)
   assert.equal(read.metadata.returnedRecordCount, 2)
+  assert.equal(read.metadata.dataDataPresent, true)
   assert.equal(read.metadata.readPath, '/K3API/Material/GetList')
 
   const listCalls = calls.filter((call) => call.pathname === '/K3API/Material/GetList')
@@ -1011,7 +1012,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.ok(tooLarge instanceof AdapterValidationError, 'LIST smoke rejects limits above the preset bound')
   assert.equal(tooLarge.details.code, 'K3_WISE_READ_LIST_LIMIT_EXCEEDED')
 
-  const malformedFetchImpl = async (url, options) => {
+  const missingRowsFetchImpl = async (url, options) => {
     const parsed = new URL(url)
     if (parsed.pathname === '/K3API/Material/GetList') {
       return jsonResponse(200, {
@@ -1022,7 +1023,7 @@ async function testK3WebApiMaterialListReadSmoke() {
     }
     return fetchImpl(url, options)
   }
-  const malformedAdapter = createK3WiseWebApiAdapter({
+  const missingRowsAdapter = createK3WiseWebApiAdapter({
     system: createK3WebApiSystem({
       config: {
         baseUrl: 'https://k3.example.test',
@@ -1040,11 +1041,82 @@ async function testK3WebApiMaterialListReadSmoke() {
         },
       },
     }),
-    fetchImpl: malformedFetchImpl,
+    fetchImpl: missingRowsFetchImpl,
   })
-  const malformed = await malformedAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2)).catch((error) => error)
-  assert.ok(malformed instanceof K3WiseWebApiAdapterError, 'LIST success envelope without Data.DATA fails closed')
-  assert.equal(malformed.details.code, 'K3_WISE_READ_BUSINESS_ERROR')
+  const missingRows = await missingRowsAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2))
+  assert.equal(missingRows.records.length, 0, 'LIST success envelope without Data.DATA remains an empty bounded page')
+  assert.equal(missingRows.metadata.dataDataPresent, false, 'LIST success evidence carries a values-free rows-shape diagnostic')
+
+  const rejectedFetchImpl = async (url, options) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === '/K3API/Material/GetList') {
+      return jsonResponse(200, {
+        StatusCode: 200,
+        Message: 'Material list rejected',
+        Data: { Code: 'N', DATA: [{ FNumber: 'SECRET-MAT' }] },
+      })
+    }
+    return fetchImpl(url, options)
+  }
+  const rejectedAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        objects: {
+          material: {
+            operations: ['read'],
+            readPath: '/K3API/Material/GetList',
+            readMethod: 'POST',
+            readMode: 'list',
+            readListBodyTemplate: { Data: { Top: 10, PageIndex: 1 } },
+            pageIndexField: 'PageIndex',
+            pageSizeField: 'PageSize',
+            maxListLimit: 3,
+          },
+        },
+      },
+    }),
+    fetchImpl: rejectedFetchImpl,
+  })
+  const rejected = await rejectedAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2)).catch((error) => error)
+  assert.ok(rejected instanceof K3WiseWebApiAdapterError, 'LIST explicit failure marker is rejected before row extraction')
+  assert.equal(rejected.details.code, 'K3_WISE_READ_LIST_REJECTED')
+  assert.equal(rejected.details.dataDataPresent, true)
+
+  const unrecognizedFetchImpl = async (url, options) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === '/K3API/Material/GetList') {
+      return jsonResponse(200, {
+        Message: 'Material list payload with no success marker',
+        Data: { DATA: [{ FNumber: 'SECRET-MAT' }] },
+      })
+    }
+    return fetchImpl(url, options)
+  }
+  const unrecognizedAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        objects: {
+          material: {
+            operations: ['read'],
+            readPath: '/K3API/Material/GetList',
+            readMethod: 'POST',
+            readMode: 'list',
+            readListBodyTemplate: { Data: { Top: 10, PageIndex: 1 } },
+            pageIndexField: 'PageIndex',
+            pageSizeField: 'PageSize',
+            maxListLimit: 3,
+          },
+        },
+      },
+    }),
+    fetchImpl: unrecognizedFetchImpl,
+  })
+  const unrecognized = await unrecognizedAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2)).catch((error) => error)
+  assert.ok(unrecognized instanceof K3WiseWebApiAdapterError, 'LIST rows under Data.DATA with an unrecognized envelope gets a response-shape diagnostic')
+  assert.equal(unrecognized.details.code, 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED')
+  assert.equal(unrecognized.details.dataDataPresent, true)
 
   const modeMismatch = await adapter.read({
     object: 'material',

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -176,6 +176,13 @@ assert.deepEqual(readSmokeSuccessEvidence(PRESET, {}, { object: 'material', mode
 assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, { records: [{ FNumber: 'M-001' }, { FNumber: 'M-002' }] }, { object: 'material', mode: 'list' }), {
   ok: true, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', recordPresent: true, recordCount: 2, referenceObjectCount: 0,
 })
+assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, {
+  records: [],
+  raw: { Data: { SECRET: 'never leak' } },
+  metadata: { dataDataPresent: false, readPath: 'https://k3host/K3API/Material/GetList' },
+}, { object: 'material', mode: 'list' }), {
+  ok: true, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', recordPresent: false, recordCount: 0, referenceObjectCount: 0, dataDataPresent: false,
+})
 
 // --- error evidence: coarse code + type ONLY (never the message, which may carry the key/values) ---
 class FakeAdapterError extends Error {
@@ -194,6 +201,13 @@ const errStr = JSON.stringify(errEv)
 for (const leak of ['M-001', '42', 'failed with secret']) {
   assert.ok(!errStr.includes(leak), `error evidence must not leak ${leak}`)
 }
+const listError = new Error('material M-001 rejected with secret value 42')
+listError.name = 'K3WiseWebApiAdapterError'
+listError.details = { code: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED', dataDataPresent: true }
+assert.deepEqual(readSmokeErrorEvidence(LIST_PRESET, listError, { object: 'material', mode: 'list' }), {
+  ok: false, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list',
+  errorCode: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED', errorType: 'K3WiseWebApiAdapterError', dataDataPresent: true,
+})
 const unsafeDetails = new Error('material M-001 failed with secret value 42')
 unsafeDetails.name = 'K3WiseWebApiAdapterError'
 unsafeDetails.details = { code: 'M-001 failed with secret value 42' }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -787,9 +787,23 @@ function materialListRowsCandidate(data) {
   return null
 }
 
+function materialListDataDataPresent(data) {
+  return Array.isArray(getPath(data, 'Data.DATA')) || Array.isArray(getPath(data, 'Data.data'))
+}
+
 function materialListBusinessSuccess(data, config) {
-  if (hasExplicitBusinessFailure(data)) return false
-  return businessSuccess(data, config) && materialListRowsCandidate(data) !== null
+  return businessSuccess(data, config)
+}
+
+function materialListBusinessFailureCode(data) {
+  const statusCode = getStatusCode(data)
+  if (
+    hasExplicitBusinessFailure(data) ||
+    (statusCode !== null && (statusCode < 200 || statusCode >= 300))
+  ) {
+    return 'K3_WISE_READ_LIST_REJECTED'
+  }
+  return 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED'
 }
 
 function buildMaterialReadRecord(detail, request, objectConfig) {
@@ -1298,11 +1312,14 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
         })
       }
 
+      const dataDataPresent = materialListDataDataPresent(readResponse.data)
       if (!materialListBusinessSuccess(readResponse.data, config)) {
+        const failureCode = materialListBusinessFailureCode(readResponse.data)
         throw new K3WiseWebApiAdapterError(String(responseMessage(readResponse.data, config, 'K3 WISE list read business response failed')), {
-          code: 'K3_WISE_READ_BUSINESS_ERROR',
+          code: failureCode,
           object: request.object,
-          responseCode: responseFailureCode(readResponse.data, config, 'K3_WISE_READ_BUSINESS_ERROR'),
+          responseCode: responseFailureCode(readResponse.data, config, failureCode),
+          dataDataPresent,
         })
       }
 
@@ -1315,6 +1332,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           mode: 'material-list-smoke',
           requestedLimit: request.limit,
           returnedRecordCount: records.length,
+          dataDataPresent,
           readPath,
           readOnly: true,
         },

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -151,9 +151,8 @@ function applyReadSmokePresetOverlay(system, preset) {
   }
 }
 
-// Values-free evidence from a successful read. Extracts ONLY recordPresent (boolean) + referenceObjectCount
-// (count) from the result's records — never the record values, metadata (which carries the key as
-// requestedNumber + a readPath), or raw payload.
+// Values-free evidence from a successful read. Extracts ONLY booleans/counts from the result — never
+// record values, raw payload, or metadata that may carry a key/readPath.
 function readSmokeSuccessEvidence(preset, result, contract = {}) {
   const records = result && Array.isArray(result.records) ? result.records : []
   const recordPresent = records.length > 0
@@ -164,7 +163,7 @@ function readSmokeSuccessEvidence(preset, result, contract = {}) {
     const refs = records[0] && records[0]._k3ReferenceObjects
     referenceObjectCount = refs && typeof refs === 'object' ? Object.keys(refs).length : 0
   }
-  return {
+  const evidence = {
     ok: true,
     presetId: preset.presetId,
     object,
@@ -173,6 +172,10 @@ function readSmokeSuccessEvidence(preset, result, contract = {}) {
     recordCount: records.length,
     referenceObjectCount,
   }
+  if (result && result.metadata && typeof result.metadata.dataDataPresent === 'boolean') {
+    evidence.dataDataPresent = result.metadata.dataDataPresent
+  }
+  return evidence
 }
 
 // Values-free error evidence. Returns ONLY a coarse code + type — never the error message, which may carry
@@ -185,7 +188,7 @@ function readSmokeErrorEvidence(preset, error, contract = {}) {
   const name = error && typeof error.name === 'string' && error.name ? error.name : null
   const object = typeof contract.object === 'string' && contract.object ? contract.object : preset.object
   const mode = typeof contract.mode === 'string' && contract.mode ? contract.mode : preset.defaultMode
-  return {
+  const evidence = {
     ok: false,
     presetId: preset.presetId,
     object,
@@ -193,6 +196,10 @@ function readSmokeErrorEvidence(preset, error, contract = {}) {
     errorCode: code || 'READ_SMOKE_READ_FAILED',
     errorType: name || 'Error',
   }
+  if (error && error.details && typeof error.details.dataDataPresent === 'boolean') {
+    evidence.dataDataPresent = error.details.dataDataPresent
+  }
+  return evidence
 }
 
 function readSmokeSafeErrorCode(value) {


### PR DESCRIPTION
## Summary
- split K3 Material/GetList envelope failures into values-free `K3_WISE_READ_LIST_REJECTED` vs `K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED`
- add values-free `dataDataPresent` evidence on LIST success and failure paths
- preserve empty-page semantics: a successful envelope with no `Data.DATA` / `Data.data` returns `recordPresent=false` instead of a business-error throw

## Why
The entity-machine C3 LIST smoke now reaches K3 but returns `K3_WISE_READ_BUSINESS_ERROR`. The previous code collapsed three different states into one bucket: K3 rejection, unrecognized LIST envelope, and missing row container. This PR adds enough values-free signal for the next run to distinguish request/contract rejection from response-shape interpretation without guessing the GetList body.

## Boundary
- diagnostic-only for C3 Material/GetList read-smoke
- no request body/endpoint change
- no LIST widening beyond the existing bounded read-smoke
- no BOM/resolver/Save/Submit/Audit/write path changes
- evidence remains values-free: booleans/counts/coarse enum codes only; no key, row, payload, message, host, credentials

## Verification
- `node plugins/plugin-integration-core/__tests__/read-smoke.test.cjs`
- `pnpm --filter plugin-integration-core test:http-routes`
- `pnpm --filter plugin-integration-core test:k3-wise-adapters`
- `pnpm --filter plugin-integration-core test`
