### PR TITLE
feat(multitable): support wall-clock cron scheduling

### DIFF
--- a/docs/development/multitable-automation-cron-parser-dev-verification-20260628.md
+++ b/docs/development/multitable-automation-cron-parser-dev-verification-20260628.md
@@ -1,0 +1,42 @@
+# Multitable automation cron parser — dev & verification (2026-06-28)
+
+> Status: built + locally verified. Slice: post-light-up automation maturity follow-up after
+> `schedule.date_field`, `form.submitted`, and `start_approval` landed on main.
+
+## Scope
+
+The previous automation scheduler treated `schedule.cron` as a small set of fixed intervals. That meant common
+wall-clock cron expressions either drifted (`15 9 * * *` approximated as a cadence) or were rejected outright
+(`0 12 1 */2 *`). This slice changes only the scheduler substrate:
+
+- cron triggers now compute the next matching UTC minute and use a one-shot timeout that reschedules after firing;
+- interval triggers and date-field scans continue using fixed `setInterval` cadences;
+- both backend `triggerConfig.expression` and editor-emitted `triggerConfig.cron` are accepted as the expression source;
+- no action execution, permissions, webhook ingress, destructive actions, or UI behavior changed.
+
+## Supported v1 cron shape
+
+Five-field UTC cron:
+
+- minute, hour, day-of-month, month, day-of-week;
+- `*`, `*/N`, `A-B`, `A,B`, and `A-B/N`;
+- numeric fields only; day-of-week accepts `0` or `7` for Sunday;
+- when both day-of-month and day-of-week are restricted, either can match (standard cron behavior).
+
+Deferred: time-zone-aware scheduling, seconds field, named months/weekdays, `L`, `W`, `#`, and Quartz syntax.
+
+## Verification
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --reporter=dot`
+  - 194/194 passed.
+  - Added goldens:
+    - complex cron (`0 12 1 */2 *`) registers instead of being treated as unsupported;
+    - editor-emitted `triggerConfig.cron` registers;
+    - `15 9 * * *` fires exactly at the next matching UTC wall-clock minute under fake timers;
+    - list/range/step fields compute the expected next occurrence;
+    - day-of-week `7` is treated as Sunday inside ranges;
+    - invalid syntax still fail-closes to `null`.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-scheduler-leader.test.ts tests/unit/automation-scheduler-metrics.test.ts --reporter=dot`
+  - 10/10 passed.
+- `pnpm --filter @metasheet/core-backend build`
+  - TypeScript clean.

--- a/packages/core-backend/src/multitable/automation-scheduler.ts
+++ b/packages/core-backend/src/multitable/automation-scheduler.ts
@@ -1,7 +1,8 @@
 /**
  * Automation Scheduler — V1
  * Manages cron and interval triggers.
- * V1 supports setInterval-based scheduling and simplified cron patterns.
+ * Cron triggers use UTC minute-resolution next-occurrence scheduling; interval
+ * and date-field scans use fixed setInterval cadences.
  */
 
 import { Logger } from '../core/logger'
@@ -59,15 +60,114 @@ export interface AutomationSchedulerRuntimeOptions {
   leaderStateGauge?: AutomationSchedulerLeaderGauge
 }
 
+type CronField = ReadonlySet<number>
+
+interface ParsedCronExpression {
+  minute: CronField
+  hour: CronField
+  dayOfMonth: CronField
+  month: CronField
+  dayOfWeek: CronField
+  dayOfMonthWildcard: boolean
+  dayOfWeekWildcard: boolean
+}
+
+function parseCronField(
+  raw: string,
+  min: number,
+  max: number,
+  options: { sundaySeven?: boolean } = {},
+): { values: Set<number>; wildcard: boolean } | null {
+  if (!raw) return null
+  const values = new Set<number>()
+  const wildcard = raw === '*'
+
+  for (const piece of raw.split(',')) {
+    if (!piece) return null
+    const [rangePart, stepPart] = piece.split('/')
+    if (piece.split('/').length > 2) return null
+    const step = stepPart === undefined ? 1 : Number(stepPart)
+    if (!Number.isInteger(step) || step < 1) return null
+
+    let start: number
+    let end: number
+    if (rangePart === '*') {
+      start = min
+      end = max
+    } else if (rangePart.includes('-')) {
+      const [a, b] = rangePart.split('-')
+      if (!a || !b || rangePart.split('-').length !== 2) return null
+      start = Number(a)
+      end = Number(b)
+    } else {
+      start = Number(rangePart)
+      end = start
+    }
+
+    if (!Number.isInteger(start) || !Number.isInteger(end)) return null
+    if (start < min || start > max || end < min || end > max) return null
+    if (start > end) return null
+    for (let v = start; v <= end; v += step) {
+      values.add(options.sundaySeven && v === 7 ? 0 : v)
+    }
+  }
+
+  if (values.size === 0) return null
+  return { values, wildcard }
+}
+
+export function parseCronExpression(expression: string): ParsedCronExpression | null {
+  const parts = expression.trim().split(/\s+/)
+  if (parts.length !== 5) return null
+  const [minuteRaw, hourRaw, domRaw, monthRaw, dowRaw] = parts
+  const minute = parseCronField(minuteRaw, 0, 59)
+  const hour = parseCronField(hourRaw, 0, 23)
+  const dayOfMonth = parseCronField(domRaw, 1, 31)
+  const month = parseCronField(monthRaw, 1, 12)
+  const dayOfWeek = parseCronField(dowRaw, 0, 7, { sundaySeven: true })
+  if (!minute || !hour || !dayOfMonth || !month || !dayOfWeek) return null
+  return {
+    minute: minute.values,
+    hour: hour.values,
+    dayOfMonth: dayOfMonth.values,
+    month: month.values,
+    dayOfWeek: dayOfWeek.values,
+    dayOfMonthWildcard: dayOfMonth.wildcard,
+    dayOfWeekWildcard: dayOfWeek.wildcard,
+  }
+}
+
+function cronMatches(parsed: ParsedCronExpression, date: Date): boolean {
+  if (!parsed.minute.has(date.getUTCMinutes())) return false
+  if (!parsed.hour.has(date.getUTCHours())) return false
+  if (!parsed.month.has(date.getUTCMonth() + 1)) return false
+
+  const domMatches = parsed.dayOfMonth.has(date.getUTCDate())
+  const dowMatches = parsed.dayOfWeek.has(date.getUTCDay())
+  if (parsed.dayOfMonthWildcard && parsed.dayOfWeekWildcard) return true
+  if (parsed.dayOfMonthWildcard) return dowMatches
+  if (parsed.dayOfWeekWildcard) return domMatches
+  // Standard cron semantics: when both DOM and DOW are restricted, either can match.
+  return domMatches || dowMatches
+}
+
+export function nextCronOccurrenceMs(expression: string, fromMs: number = Date.now()): number | null {
+  const parsed = parseCronExpression(expression)
+  if (!parsed) return null
+  const minuteMs = 60 * 1000
+  let candidate = Math.floor(fromMs / minuteMs) * minuteMs + minuteMs
+  const max = candidate + 5 * 366 * 24 * 60 * minuteMs
+  while (candidate <= max) {
+    if (cronMatches(parsed, new Date(candidate))) return candidate
+    candidate += minuteMs
+  }
+  return null
+}
+
 /**
- * Simplified cron parser for V1.
- * Supports common patterns:
- *   - * / N * * * *  (every N minutes)
- *   - 0 * * * *      (hourly at :00)
- *   - 0 0 * * *      (daily at midnight)
- *   - 0 0 * * 1      (weekly on Monday at midnight)
- *
- * Returns interval in milliseconds, or null if unsupported.
+ * Legacy helper kept for callers/tests that need the old fixed-interval
+ * approximation. The scheduler itself uses `nextCronOccurrenceMs` so custom
+ * wall-clock expressions such as `15 9 * * *` fire at the requested time.
  */
 export function parseCronToIntervalMs(expression: string): number | null {
   const parts = expression.trim().split(/\s+/)
@@ -242,7 +342,7 @@ export class AutomationScheduler {
     this.isLeader = false
     this.setLeaderGauge('relinquished')
     for (const [ruleId, timer] of this.timers.entries()) {
-      clearInterval(timer)
+      clearTimeout(timer)
       logger.info(`Cleared schedule for rule ${ruleId} after leader loss`)
     }
     this.timers.clear()
@@ -255,6 +355,39 @@ export class AutomationScheduler {
   /** Test / diagnostics hook. */
   get leader(): boolean {
     return this.isLeader
+  }
+
+  private runScheduledRule(rule: AutomationRule): void {
+    try {
+      const result = this.callback(rule)
+      if (result && typeof (result as Promise<void>).catch === 'function') {
+        (result as Promise<void>).catch((err) => {
+          logger.error(`Scheduled rule ${rule.id} execution failed`, err instanceof Error ? err : undefined)
+        })
+      }
+    } catch (err) {
+      logger.error(`Scheduled rule ${rule.id} execution failed`, err instanceof Error ? err : undefined)
+    }
+  }
+
+  private registerCron(rule: AutomationRule, expression: string): void {
+    const nextMs = nextCronOccurrenceMs(expression)
+    if (!nextMs) {
+      logger.warn(`Rule ${rule.id}: unsupported cron expression: ${expression}`)
+      return
+    }
+    const delayMs = Math.max(1_000, nextMs - Date.now())
+    const timer = setTimeout(() => {
+      if (!this.timers.has(rule.id)) return
+      this.runScheduledRule(rule)
+      this.timers.delete(rule.id)
+      if (this.isLeader) this.registerCron(rule, expression)
+    }, delayMs)
+    if (typeof timer.unref === 'function') {
+      timer.unref()
+    }
+    this.timers.set(rule.id, timer)
+    logger.info(`Registered cron schedule for rule ${rule.id} (next: ${new Date(nextMs).toISOString()})`)
   }
 
   /**
@@ -272,6 +405,7 @@ export class AutomationScheduler {
 
     const trigger = rule.trigger
     let intervalMs: number | null = null
+    let cronExpression: string | null = null
 
     if (trigger.type === 'schedule.interval') {
       intervalMs = typeof trigger.config.intervalMs === 'number' ? trigger.config.intervalMs : null
@@ -280,10 +414,13 @@ export class AutomationScheduler {
         return
       }
     } else if (trigger.type === 'schedule.cron') {
-      const expression = typeof trigger.config.expression === 'string' ? trigger.config.expression : ''
-      intervalMs = parseCronToIntervalMs(expression)
-      if (!intervalMs) {
-        logger.warn(`Rule ${rule.id}: unsupported cron expression: ${expression}`)
+      cronExpression = typeof trigger.config.expression === 'string'
+        ? trigger.config.expression
+        : typeof trigger.config.cron === 'string'
+          ? trigger.config.cron
+          : ''
+      if (!nextCronOccurrenceMs(cronExpression)) {
+        logger.warn(`Rule ${rule.id}: unsupported cron expression: ${cronExpression}`)
         return
       }
     } else if (trigger.type === 'schedule.date_field') {
@@ -302,17 +439,13 @@ export class AutomationScheduler {
       return
     }
 
+    if (cronExpression) {
+      this.registerCron(rule, cronExpression)
+      return
+    }
+
     const timer = setInterval(() => {
-      try {
-        const result = this.callback(rule)
-        if (result && typeof (result as Promise<void>).catch === 'function') {
-          (result as Promise<void>).catch((err) => {
-            logger.error(`Scheduled rule ${rule.id} execution failed`, err instanceof Error ? err : undefined)
-          })
-        }
-      } catch (err) {
-        logger.error(`Scheduled rule ${rule.id} execution failed`, err instanceof Error ? err : undefined)
-      }
+      this.runScheduledRule(rule)
     }, intervalMs)
 
     // Prevent timer from keeping the process alive in tests
@@ -330,7 +463,7 @@ export class AutomationScheduler {
   unregister(ruleId: string): void {
     const timer = this.timers.get(ruleId)
     if (timer) {
-      clearInterval(timer)
+      clearTimeout(timer)
       this.timers.delete(ruleId)
       logger.info(`Unregistered schedule for rule ${ruleId}`)
     }
@@ -355,7 +488,7 @@ export class AutomationScheduler {
    */
   destroy(): void {
     for (const [ruleId, timer] of this.timers.entries()) {
-      clearInterval(timer)
+      clearTimeout(timer)
       logger.info(`Destroyed schedule for rule ${ruleId}`)
     }
     this.timers.clear()

--- a/packages/core-backend/src/multitable/automation-scheduler.ts
+++ b/packages/core-backend/src/multitable/automation-scheduler.ts
@@ -151,9 +151,56 @@ function cronMatches(parsed: ParsedCronExpression, date: Date): boolean {
   return domMatches || dowMatches
 }
 
+/** Leap-safe maximum day each month (1..12) can host (February = 29). */
+const MONTH_MAX_DAYS: Readonly<Record<number, number>> = {
+  1: 31, 2: 29, 3: 31, 4: 30, 5: 31, 6: 30,
+  7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31,
+}
+
+/**
+ * True when a PARSED cron's day fields can never select a real calendar day.
+ * Provably safe — only reports "impossible" when day-of-week is a wildcard
+ * (otherwise the DOM/DOW OR-semantics could still match via a weekday, so the
+ * day is reachable), day-of-month is restricted, and the smallest requested
+ * day-of-month exceeds the largest day ANY restricted month can host.
+ */
+function dayUnreachable(parsed: ParsedCronExpression): boolean {
+  // DOW restricted → a matching weekday can occur regardless of DOM (OR-semantics).
+  if (!parsed.dayOfWeekWildcard) return false
+  // DOM wildcard → every day is allowed.
+  if (parsed.dayOfMonthWildcard) return false
+
+  let maxHostableDay = 0
+  for (const m of parsed.month) {
+    const d = MONTH_MAX_DAYS[m] ?? 31
+    if (d > maxHostableDay) maxHostableDay = d
+  }
+  let minRequestedDay = Infinity
+  for (const d of parsed.dayOfMonth) {
+    if (d < minRequestedDay) minRequestedDay = d
+  }
+  return minRequestedDay > maxHostableDay
+}
+
+/**
+ * Cheap pre-check exposing {@link dayUnreachable} for a raw cron string so
+ * `nextCronOccurrenceMs` (and tests) can prune day-impossible expressions —
+ * e.g. `0 0 30 2 *` (February 30th) — instead of scanning ~5 years of minutes.
+ * Returns `false` for unparseable input (that null path is handled by the
+ * caller's own parse). February uses 29 so `0 0 29 2 *` is NOT pruned.
+ */
+export function cronHasNoMatchingDay(expression: string): boolean {
+  const parsed = parseCronExpression(expression)
+  if (!parsed) return false
+  return dayUnreachable(parsed)
+}
+
 export function nextCronOccurrenceMs(expression: string, fromMs: number = Date.now()): number | null {
   const parsed = parseCronExpression(expression)
   if (!parsed) return null
+  // Fast path: a day-impossible cron (e.g. Feb 30) would otherwise scan the full
+  // ~5-year window before returning null. Short-circuit it up front.
+  if (dayUnreachable(parsed)) return null
   const minuteMs = 60 * 1000
   let candidate = Math.floor(fromMs / minuteMs) * minuteMs + minuteMs
   const max = candidate + 5 * 366 * 24 * 60 * minuteMs
@@ -342,7 +389,7 @@ export class AutomationScheduler {
     this.isLeader = false
     this.setLeaderGauge('relinquished')
     for (const [ruleId, timer] of this.timers.entries()) {
-      clearTimeout(timer)
+      this.clearTimer(timer)
       logger.info(`Cleared schedule for rule ${ruleId} after leader loss`)
     }
     this.timers.clear()
@@ -368,6 +415,19 @@ export class AutomationScheduler {
     } catch (err) {
       logger.error(`Scheduled rule ${rule.id} execution failed`, err instanceof Error ? err : undefined)
     }
+  }
+
+  /**
+   * Cancel a rule timer. The `timers` map mixes setTimeout handles (cron,
+   * which re-arm) and setInterval handles (interval / date_field scans).
+   * Node's `clearTimeout` cancels both kinds — they share one `Timeout`
+   * object — so routing every rule-timer teardown through this one helper
+   * keeps the call sites consistent without tracking each handle's kind. The
+   * renewal loop is cleared separately with `clearInterval`; it is not a rule
+   * timer and never enters this map.
+   */
+  private clearTimer(timer: NodeJS.Timeout): void {
+    clearTimeout(timer)
   }
 
   private registerCron(rule: AutomationRule, expression: string): void {
@@ -463,7 +523,7 @@ export class AutomationScheduler {
   unregister(ruleId: string): void {
     const timer = this.timers.get(ruleId)
     if (timer) {
-      clearTimeout(timer)
+      this.clearTimer(timer)
       this.timers.delete(ruleId)
       logger.info(`Unregistered schedule for rule ${ruleId}`)
     }
@@ -488,7 +548,7 @@ export class AutomationScheduler {
    */
   destroy(): void {
     for (const [ruleId, timer] of this.timers.entries()) {
-      clearTimeout(timer)
+      this.clearTimer(timer)
       logger.info(`Destroyed schedule for rule ${ruleId}`)
     }
     this.timers.clear()

--- a/packages/core-backend/tests/unit/automation-scheduler-leader.test.ts
+++ b/packages/core-backend/tests/unit/automation-scheduler-leader.test.ts
@@ -118,6 +118,42 @@ describe('AutomationScheduler — leader lock', () => {
     scheduler.destroy()
   })
 
+  it('non-leader scheduler does not schedule a cron timer (cron-isolated)', async () => {
+    // Sharper sibling of the combined "any schedule trigger" test above: this
+    // registers ONLY a cron rule on a non-leader, so the cron branch is pinned
+    // in isolation. A regression that scheduled cron-on-non-leader while leaving
+    // the interval path correct could otherwise hide behind the combined test's
+    // aggregate activeCount assertion. This locks the cross-replica
+    // double-fire guard specifically for the cron path.
+    const shared = sharedStore
+    shared.set('automation-scheduler:leader', {
+      value: 'external-owner',
+      expireAt: Date.now() + 10_000,
+    })
+
+    const client = new MemoryLeaderLockClient(shared)
+    const lock = new RedisLeaderLock({ client })
+
+    const scheduler = new AutomationScheduler(vi.fn(), {
+      leaderLock: lock,
+      ownerId: 'loser',
+      ttlMs: 10_000,
+      renewIntervalMs: 10_000,
+    })
+    await scheduler.ready
+    expect(scheduler.leader).toBe(false)
+
+    scheduler.register({
+      ...makeIntervalRule('rule_cron_only'),
+      trigger: { type: 'schedule.cron', config: { expression: '15 9 * * *' } },
+    })
+
+    expect(scheduler.isRegistered('rule_cron_only')).toBe(false)
+    expect(scheduler.activeCount).toBe(0)
+
+    scheduler.destroy()
+  })
+
   it('legacy constructor (no leader options) always acts as leader and preserves old behaviour', async () => {
     const scheduler = new AutomationScheduler(vi.fn())
     await scheduler.ready

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { evaluateCondition, evaluateConditions, type AutomationCondition, type ConditionGroup } from '../../src/multitable/automation-conditions'
 import { AutomationExecutor, type AutomationRule, type AutomationDeps, type AutomationExecution } from '../../src/multitable/automation-executor'
-import { AutomationScheduler, nextCronOccurrenceMs, parseCronToIntervalMs } from '../../src/multitable/automation-scheduler'
+import { AutomationScheduler, cronHasNoMatchingDay, nextCronOccurrenceMs, parseCronToIntervalMs } from '../../src/multitable/automation-scheduler'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, ALL_TRIGGER_TYPES } from '../../src/multitable/automation-triggers'
 import type { AutomationTrigger, AutomationTriggerType } from '../../src/multitable/automation-triggers'
 import { EventBus } from '../../src/integration/events/event-bus'
@@ -1982,6 +1982,48 @@ describe('AutomationScheduler', () => {
     }
   })
 
+  it('re-arms a cron rule after each fire (fires at consecutive occurrences)', async () => {
+    scheduler.destroy()
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-06-28T09:14:30.000Z'))
+      const cb = vi.fn()
+      const cronScheduler = new AutomationScheduler(cb)
+      cronScheduler.register(createMockRule({
+        trigger: { type: 'schedule.cron', config: { expression: '15 9 * * *' } },
+      }))
+      // First occurrence: 2026-06-28T09:15:00Z.
+      await vi.advanceTimersByTimeAsync(46_000)
+      expect(cb).toHaveBeenCalledTimes(1)
+      // After firing, the rule must re-arm itself (still registered).
+      expect(cronScheduler.isRegistered('rule_1')).toBe(true)
+      // Second occurrence: next day 2026-06-29T09:15:00Z (~24h later).
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000)
+      expect(cb).toHaveBeenCalledTimes(2)
+      expect(cronScheduler.isRegistered('rule_1')).toBe(true)
+      cronScheduler.destroy()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('unregister and destroy clear a cron (setTimeout-backed) timer', () => {
+    scheduler.register(createMockRule({
+      trigger: { type: 'schedule.cron', config: { expression: '15 9 * * *' } },
+    }))
+    expect(scheduler.isRegistered('rule_1')).toBe(true)
+    scheduler.unregister('rule_1')
+    expect(scheduler.isRegistered('rule_1')).toBe(false)
+    expect(scheduler.activeCount).toBe(0)
+
+    scheduler.register(createMockRule({
+      trigger: { type: 'schedule.cron', config: { expression: '15 9 * * *' } },
+    }))
+    expect(scheduler.activeCount).toBe(1)
+    scheduler.destroy()
+    expect(scheduler.activeCount).toBe(0)
+  })
+
   it('destroy clears all timers', () => {
     scheduler.register(createMockRule({ id: 'a', trigger: { type: 'schedule.interval', config: { intervalMs: 60000 } } }))
     scheduler.register(createMockRule({ id: 'b', trigger: { type: 'schedule.interval', config: { intervalMs: 60000 } } }))
@@ -2044,6 +2086,49 @@ describe('nextCronOccurrenceMs', () => {
   it('rejects invalid cron syntax', () => {
     expect(nextCronOccurrenceMs('0 25 * * *', Date.parse('2026-06-28T00:00:00.000Z'))).toBeNull()
     expect(nextCronOccurrenceMs('* * *', Date.parse('2026-06-28T00:00:00.000Z'))).toBeNull()
+  })
+
+  it('returns null for a parseable but never-matching cron (February 30th)', () => {
+    expect(nextCronOccurrenceMs('0 0 30 2 *', Date.parse('2026-06-28T00:00:00.000Z'))).toBeNull()
+  })
+
+  it('does not over-prune a valid leap-year February 29th cron', () => {
+    // Guards the N4 short-circuit: Feb 29 IS reachable on leap years, so it must
+    // resolve, not get nulled. Next leap Feb 29 after 2026-06-28 is 2028.
+    expect(
+      new Date(nextCronOccurrenceMs('0 0 29 2 *', Date.parse('2026-06-28T00:00:00.000Z'))!).toISOString(),
+    ).toBe('2028-02-29T00:00:00.000Z')
+  })
+
+  it('does not over-prune a DOW-restricted cron whose day-of-month is calendar-impossible', () => {
+    // `0 0 30 2 1`: Feb 30 never exists, but DOW=Monday is restricted, so the
+    // DOM/DOW OR-semantics still match February Mondays — must NOT be nulled.
+    expect(
+      nextCronOccurrenceMs('0 0 30 2 1', Date.parse('2026-06-28T00:00:00.000Z')),
+    ).not.toBeNull()
+  })
+})
+
+describe('cronHasNoMatchingDay', () => {
+  it('flags day-of-month values no restricted month can host', () => {
+    expect(cronHasNoMatchingDay('0 0 30 2 *')).toBe(true) // February tops out at 29
+    expect(cronHasNoMatchingDay('0 0 31 4 *')).toBe(true) // April has 30 days
+    expect(cronHasNoMatchingDay('0 0 31 4,6,9,11 *')).toBe(true) // all 30-day months
+  })
+
+  it('does not flag reachable days (leap Feb 29, DOW-restricted, 31-day months, wildcards)', () => {
+    expect(cronHasNoMatchingDay('0 0 29 2 *')).toBe(false) // Feb 29 exists on leap years
+    expect(cronHasNoMatchingDay('0 0 30 2 1')).toBe(false) // DOW restricted → OR-match a Monday
+    expect(cronHasNoMatchingDay('0 0 31 5 *')).toBe(false) // May has 31 days
+    expect(cronHasNoMatchingDay('0 0 31 4,5 *')).toBe(false) // May (31) can host it
+    expect(cronHasNoMatchingDay('0 0 15 * *')).toBe(false) // month wildcard
+    expect(cronHasNoMatchingDay('0 0 * * *')).toBe(false) // day-of-month wildcard
+    expect(cronHasNoMatchingDay('* * * * *')).toBe(false) // all wildcard
+  })
+
+  it('returns false for unparseable input (null parse is handled by the caller)', () => {
+    expect(cronHasNoMatchingDay('0 25 * * *')).toBe(false)
+    expect(cronHasNoMatchingDay('* * *')).toBe(false)
   })
 })
 

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { evaluateCondition, evaluateConditions, type AutomationCondition, type ConditionGroup } from '../../src/multitable/automation-conditions'
 import { AutomationExecutor, type AutomationRule, type AutomationDeps, type AutomationExecution } from '../../src/multitable/automation-executor'
-import { AutomationScheduler, parseCronToIntervalMs } from '../../src/multitable/automation-scheduler'
+import { AutomationScheduler, nextCronOccurrenceMs, parseCronToIntervalMs } from '../../src/multitable/automation-scheduler'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, ALL_TRIGGER_TYPES } from '../../src/multitable/automation-triggers'
 import type { AutomationTrigger, AutomationTriggerType } from '../../src/multitable/automation-triggers'
 import { EventBus } from '../../src/integration/events/event-bus'
@@ -1945,12 +1945,41 @@ describe('AutomationScheduler', () => {
     expect(scheduler.isRegistered('rule_1')).toBe(true)
   })
 
-  it('rejects unsupported cron expression', () => {
+  it('registers complex cron expressions instead of treating them as unsupported intervals', () => {
     const rule = createMockRule({
       trigger: { type: 'schedule.cron', config: { expression: '0 12 1 */2 *' } },
     })
     scheduler.register(rule)
-    expect(scheduler.isRegistered('rule_1')).toBe(false)
+    expect(scheduler.isRegistered('rule_1')).toBe(true)
+  })
+
+  it('accepts the editor-emitted triggerConfig.cron key as the cron expression source', () => {
+    const rule = createMockRule({
+      trigger: { type: 'schedule.cron', config: { cron: '15 9 * * *' } },
+    })
+    scheduler.register(rule)
+    expect(scheduler.isRegistered('rule_1')).toBe(true)
+  })
+
+  it('fires cron rules at the next matching UTC wall-clock minute', async () => {
+    scheduler.destroy()
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-06-28T09:14:30.000Z'))
+      const callback = vi.fn()
+      const cronScheduler = new AutomationScheduler(callback)
+      const rule = createMockRule({
+        trigger: { type: 'schedule.cron', config: { expression: '15 9 * * *' } },
+      })
+      cronScheduler.register(rule)
+      await vi.advanceTimersByTimeAsync(29_999)
+      expect(callback).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
+      expect(callback).toHaveBeenCalledTimes(1)
+      cronScheduler.destroy()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('destroy clears all timers', () => {
@@ -1983,6 +2012,38 @@ describe('parseCronToIntervalMs', () => {
   })
   it('too few parts returns null', () => {
     expect(parseCronToIntervalMs('* * *')).toBe(null)
+  })
+})
+
+describe('nextCronOccurrenceMs', () => {
+  it('aligns daily wall-clock cron to the requested UTC minute', () => {
+    const from = Date.parse('2026-06-28T09:14:30.000Z')
+    expect(new Date(nextCronOccurrenceMs('15 9 * * *', from)!).toISOString()).toBe('2026-06-28T09:15:00.000Z')
+  })
+
+  it('supports list/range/step fields for month-scoped cron', () => {
+    const from = Date.parse('2026-01-31T12:00:00.000Z')
+    expect(new Date(nextCronOccurrenceMs('0 12 1 */2 *', from)!).toISOString()).toBe('2026-03-01T12:00:00.000Z')
+  })
+
+  it('treats stepped day-of-month as restricted, not as an every-day wildcard', () => {
+    const from = Date.parse('2026-01-01T10:00:00.000Z')
+    expect(new Date(nextCronOccurrenceMs('0 9 */2 * *', from)!).toISOString()).toBe('2026-01-03T09:00:00.000Z')
+  })
+
+  it('uses either day-of-month or day-of-week when both are restricted', () => {
+    const from = Date.parse('2026-06-28T00:00:00.000Z') // Sunday
+    expect(new Date(nextCronOccurrenceMs('0 9 15 * 1', from)!).toISOString()).toBe('2026-06-29T09:00:00.000Z')
+  })
+
+  it('treats day-of-week 7 as Sunday inside ranges', () => {
+    const from = Date.parse('2026-06-27T09:00:00.000Z') // Saturday
+    expect(new Date(nextCronOccurrenceMs('0 9 * * 1-7', from)!).toISOString()).toBe('2026-06-28T09:00:00.000Z')
+  })
+
+  it('rejects invalid cron syntax', () => {
+    expect(nextCronOccurrenceMs('0 25 * * *', Date.parse('2026-06-28T00:00:00.000Z'))).toBeNull()
+    expect(nextCronOccurrenceMs('* * *', Date.parse('2026-06-28T00:00:00.000Z'))).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

Adds real UTC wall-clock scheduling for `schedule.cron` automation triggers.

- Parses five-field numeric cron expressions with `*`, `*/N`, ranges, lists, and range steps.
- Computes the next matching UTC minute and uses one-shot timeouts that reschedule after firing.
- Keeps `schedule.interval` and `schedule.date_field` on their existing fixed-cadence paths.
- Accepts both backend `triggerConfig.expression` and editor-emitted `triggerConfig.cron`.
- Leaves action execution, permissions, webhook ingress, destructive actions, and UI behavior unchanged.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --reporter=dot` — 194/194
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-scheduler-leader.test.ts tests/unit/automation-scheduler-metrics.test.ts --reporter=dot` — 10/10
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

## Deferred

- Time-zone-aware scheduling.
- Seconds field, named months/weekdays, `L`, `W`, `#`, and Quartz syntax.
- Any destructive automation action or inbound webhook expansion.
