### PR TITLE
fix(attendance): enforce shift cap on explicit schedules

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -4537,6 +4537,14 @@ attendanceIntegrationDescribe(
     let smallShiftId: string | undefined
     let rotationRuleId: string | undefined
     let smallRotationRuleId: string | undefined
+    let complianceHolidayTouched = false
+    let complianceHolidayRows: Array<{
+      id: string
+      holiday_date: string
+      name: string | null
+      is_working_day: boolean
+      origin: string | null
+    }> = []
     try {
       // Compliance enforcement is orthogonal to RBAC (it runs after the dispatch check, inside the
       // txn). Bypass RBAC so each save path reaches the guard without per-route permission plumbing.
@@ -4555,6 +4563,30 @@ attendanceIntegrationDescribe(
       const rtCompliance = (rt.body as { data?: { shiftCompliance?: { dailyMaxMinutes?: number; enforcement?: string } } } | undefined)?.data?.shiftCompliance
       expect(rtCompliance?.dailyMaxMinutes).toBe(60)
       expect(rtCompliance?.enforcement).toBe('block')
+
+      // Regression fixture: shift-compliance caps count explicit assignment load, not effective
+      // calendar minutes. A rest holiday on the target date must not turn a 9h explicit assignment
+      // into a 0-minute projection and let the save through.
+      const priorHolidayRows = await pool.query<{
+        id: string
+        holiday_date: string
+        name: string | null
+        is_working_day: boolean
+        origin: string | null
+      }>(
+        `SELECT id, to_char(holiday_date, 'YYYY-MM-DD') AS holiday_date, name, is_working_day, origin
+         FROM attendance_holidays
+         WHERE org_id = $1 AND holiday_date = $2::date`,
+        ['default', startA],
+      )
+      complianceHolidayRows = priorHolidayRows.rows
+      await pool.query('DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date = $2::date', ['default', startA])
+      await pool.query(
+        `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin)
+         VALUES ($1, 'default', $2, $3, false, 'manual')`,
+        [randomUuidV4(), startA, `Compliance Rest ${runSuffix}`],
+      )
+      complianceHolidayTouched = true
 
       // A 9h shift (540 min planned every day, > 60) and a 30-min shift (< 60).
       const bigShiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, { method: 'POST', headers, body: JSON.stringify({ name: `compliance-big-${runSuffix}`, timezone: 'UTC', workStartTime: '09:00', workEndTime: '18:00', workingDays: [0, 1, 2, 3, 4, 5, 6] }) })
@@ -4643,6 +4675,20 @@ attendanceIntegrationDescribe(
       }
       await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = ANY($1::text[])', [[targetUserId, memberUserId]]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_rotation_assignments WHERE user_id = $1', [targetUserId]).catch(() => undefined)
+      if (complianceHolidayTouched) {
+        await pool.query('DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date = $2::date', ['default', startA]).catch(() => undefined)
+        for (const row of complianceHolidayRows) {
+          await pool.query(
+            `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin)
+             VALUES ($1, 'default', $2, $3, $4, $5)
+             ON CONFLICT (org_id, holiday_date) DO UPDATE SET
+               name = EXCLUDED.name,
+               is_working_day = EXCLUDED.is_working_day,
+               origin = EXCLUDED.origin`,
+            [row.id, row.holiday_date, row.name, row.is_working_day, row.origin],
+          ).catch(() => undefined)
+        }
+      }
       if (rotationRuleId) await pool.query('DELETE FROM attendance_rotation_rules WHERE id = $1', [rotationRuleId]).catch(() => undefined)
       if (smallRotationRuleId) await pool.query('DELETE FROM attendance_rotation_rules WHERE id = $1', [smallRotationRuleId]).catch(() => undefined)
       if (groupId) {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -16831,9 +16831,10 @@ function attendanceDistinctPeriodStarts(from, to, startFn) {
 // assignment covers (fixed-apply writes shift assignments too) and SKIPS default-rule fallback days
 // (no explicit assignment ref). Otherwise the org default (e.g. Mon–Fri 09:00–18:00) would consume the
 // whole cap and block every save — so caps must measure scheduled load the admin added, not the baseline.
-// Reuses the SAME resolver primitives as comprehensiveHours (buildWorkContextPrefetch +
-// resolveWorkContextFromPrefetch + calculateAttendanceComprehensiveShiftPlannedMinutes) — no hand-rolled
-// two-table union. Pass the transaction as `db` so it sees the uncommitted post-write state.
+// Reuses the same assignment/rotation prefetch primitives as comprehensiveHours, but deliberately
+// does NOT reuse resolveWorkContextFromPrefetch/calculateAttendancePlannedMinutesFromWorkContext:
+// those are effective-calendar primitives and may zero an explicit assignment on a holiday/policy
+// rest day. This cap measures the explicit load the admin is trying to save.
 async function projectExplicitScheduledMinutesByUser(db, orgId, userId, from, to) {
   const workDates = enumerateAttendanceCalendarDateRange(from, to)
   const defaultRule = await loadDefaultRule(db, orgId)
@@ -16841,12 +16842,33 @@ async function projectExplicitScheduledMinutesByUser(db, orgId, userId, from, to
   const items = []
   let total = 0
   for (const date of workDates) {
-    const context = resolveWorkContextFromPrefetch({ orgId, userId, workDate: date, defaultRule, prefetched })
-    // Only days an explicit shift OR rotation assignment covers count toward the cap (fixed-apply writes
-    // shift assignments too). Use the raw assignment refs — not `context.source` — so the calendarPolicy
-    // override layer (which runs after `source` is set) can't flip the classification.
-    if (!context || (!context.assignment && !context.rotationAssignment)) continue
-    const minutes = calculateAttendancePlannedMinutesFromWorkContext(context, defaultRule)
+    const rotationInfo = resolveRotationInfoFromPrefetch(
+      prefetched.rotationAssignmentsByUser?.get(userId),
+      date,
+      prefetched.rotationShiftsById,
+    )
+    let minutes = 0
+    let hasExplicitAssignment = false
+    if (rotationInfo?.assignment && rotationInfo.shift) {
+      hasExplicitAssignment = true
+      minutes = isAttendanceProfileWorkingOnDate(rotationInfo.shift, date)
+        ? calculateAttendanceComprehensiveShiftPlannedMinutes(rotationInfo.shift)
+        : 0
+    } else {
+      const assignmentSlots = resolveShiftAssignmentsFromPrefetch(
+        prefetched.shiftAssignmentsByUser?.get(userId),
+        date,
+        { multiShiftDay: prefetched.multiShiftDay },
+      )
+      if (assignmentSlots.length > 0) {
+        hasExplicitAssignment = true
+        minutes = assignmentSlots.reduce((sum, entry) => {
+          if (!isShiftAssignmentEntryWorkingOnDate(entry, date)) return sum
+          return sum + calculateAttendanceComprehensiveShiftPlannedMinutes(entry.shift)
+        }, 0)
+      }
+    }
+    if (!hasExplicitAssignment) continue
     items.push({ date, plannedMinutes: minutes })
     total += minutes
   }


### PR DESCRIPTION
## Summary
- Fix shift-compliance cap projection to count explicit shift/rotation assignment load instead of effective-calendar minutes
- Preserve default-rule fallback skip behavior and assignment/rotation precedence
- Add a regression fixture proving a rest holiday cannot zero an explicit 9h assignment and let the save through

## Why
The main queue is red on `attendance-plugin.test.ts` because the daily cap test expects the assignment save to block, but the projection could reuse effective-calendar semantics. A holiday/calendar-policy rest day can reduce explicit assignment minutes to 0, producing `201` instead of `422`.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend run --if-present type-check`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --testNamePattern "enforces the daily shift-compliance cap" --watch=false` (local env skipped: no integration server/DB)
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --watch=false` (local env skipped: no integration server/DB)

## Boundary
- Attendance cap enforcement only
- No settings/schema/route changes
- Does not touch #3355 K3/read-smoke code
