### PR TITLE
test(attendance): fix shift-compliance-cap suite flake (reset plugin settings cache between tests)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -16,6 +16,8 @@ type AttendancePluginTestModule = {
     AUTO_SHIFT_AUTO_WRITE_SYSTEM_ROLE_TAG: string
     runAttendanceAutoShiftAutoWriteOnce(db: unknown, options?: Record<string, unknown>): Promise<any>
   }
+  // Resets the plugin's module-level settings cache (60s TTL). Exposed by the plugin for test isolation.
+  resetAttendanceSettingsCacheForTests?: () => void
 }
 
 function getAttendancePluginForTest(): AttendancePluginTestModule {
@@ -391,6 +393,11 @@ attendanceIntegrationDescribe(
     if (!baseUrl) {
       throw new Error('Attendance integration server was not started; inspect beforeAll setup output.')
     }
+    // Isolate the plugin's module-level settings cache (60s TTL) between tests. Without this, a prior test's
+    // shiftCompliance settings leak through getSettings() for up to 60s and silently disable enforcement —
+    // the root cause of the flaky `shift-compliance cap` 201-vs-422 when this file runs in the shared 10-file
+    // attendance suite process. The plugin exposes resetAttendanceSettingsCacheForTests for exactly this.
+    getAttendancePluginForTest().resetAttendanceSettingsCacheForTests?.()
   })
 
   afterAll(async () => {


### PR DESCRIPTION
## Problem
The `test (18.x/20.x)` CI lane intermittently fails the attendance integration suite at `enforces the daily shift-compliance cap (block)` with `expected 201 to be 422`. The test **passes in isolation** but flakes in the full 10-file attendance suite.

## Root cause
The attendance plugin caches org settings in a **module-level `settingsCache` with a 60s TTL** — `getSettings(db)` returns the cached value without re-reading the DB within the TTL. The 10 attendance files run in **one shared server process**, so a prior test's `shiftCompliance` settings leak through `getSettings` for up to 60s. The cap enforcement does `if (settings.shiftCompliance.enforcement !== 'block') return` — so a stale non-`block` cache makes it **silently skip enforcement → 201 instead of 422**.

The plugin already exports `resetAttendanceSettingsCacheForTests` *for exactly this* ("the 60s TTL would otherwise leak settings across tests") — but **no test called it**.

## Fix
Call `resetAttendanceSettingsCacheForTests()` in `attendance-plugin.test.ts`'s `beforeEach`, so every test reads fresh DB-backed settings. **Scope: this test file only** — no production, plugin, or unrelated change.

## Verification
The full 10-file attendance lane, **3× on fresh DBs with `TZ=UTC` (CI's environment) → 230/230** each. Before the fix the cap test fails `422 vs 201` in the full suite. `tsc` clean.

(Unblocks #3347, whose own date-reminder lane is green and whose CI red was solely this flake.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)