### PR TITLE
feat(automation): add date reminder ledger retention

### DIFF
--- a/docs/design/multitable-date-reminder-ledger-retention-design-lock-20260629.md
+++ b/docs/design/multitable-date-reminder-ledger-retention-design-lock-20260629.md
@@ -1,0 +1,35 @@
+# Multitable date-reminder ledger retention — design lock (2026-06-29)
+
+> Status: RATIFIED + BUILT in this slice. Owner chose the 365-day retention default for the
+> `schedule.date_field` idempotency ledger.
+
+## 1. Problem
+
+`meta_automation_date_reminder_fires` is the claim ledger that gives date reminders their at-most-once
+property. Each fired occurrence writes `(rule_id, record_id, occurrence_ts)` before executing the automation,
+and later scans skip duplicates by the primary key. Rule deletion cascades ledger rows, but a long-lived active
+rule can accumulate rows forever.
+
+## 2. Decision
+
+- Keep ledger rows for **365 days**.
+- Age by `fired_at`, not `occurrence_ts`. Retention answers "how long do we keep the claim/audit row after it
+  was written"; `occurrence_ts` is the record-relative reminder instant and can differ from actual firing time
+  after catch-up.
+- Retention is best-effort and must never block reminder delivery.
+- No new global scheduler. An active date-reminder scan opportunistically sweeps at most once per process per
+  day; explicit `sweepDateReminderLedger()` remains available as an ops/test seam.
+- Rule deletion remains immediate through the existing FK cascade.
+
+## 3. Non-goals
+
+- Configurable retention (`180` vs `365`) is not built. The owner selected 365 days for v1.
+- Archival/export of old ledger rows is not built.
+- Changing the dedup key or delivery semantic is out of scope. At-most-once remains unchanged.
+
+## 4. Verification gates
+
+- Pure helper pins the 365-day cutoff.
+- Real-DB test inserts old and recent ledger rows, runs the sweep, and proves only the old `fired_at` row is
+  removed.
+- Existing date-reminder scan/claim/fire tests remain green.

--- a/docs/design/multitable-date-reminder-ledger-retention-design-lock-20260629.md
+++ b/docs/design/multitable-date-reminder-ledger-retention-design-lock-20260629.md
@@ -19,6 +19,7 @@ rule can accumulate rows forever.
 - Retention is best-effort and must never block reminder delivery.
 - No new global scheduler. An active date-reminder scan opportunistically sweeps at most once per process per
   day; explicit `sweepDateReminderLedger()` remains available as an ops/test seam.
+- Add a dedicated `fired_at` index in a new migration so the daily sweep is not a growing full-table scan.
 - Rule deletion remains immediate through the existing FK cascade.
 
 ## 3. Non-goals

--- a/docs/design/multitable-date-reminder-timeofday-alignment-design-lock-20260628.md
+++ b/docs/design/multitable-date-reminder-timeofday-alignment-design-lock-20260628.md
@@ -41,7 +41,7 @@ Locks DR-A/DR-B/DR-C with `vi.useFakeTimers()` (no real DB needed for the timing
 Plus: the existing 16 pure unit + 11 real-DB tests stay green; add/extend a real-DB case asserting the aligned path (not just `runDateReminderScanNow`) fires once.
 
 ## 5. Scope / non-goals (unchanged from #3329)
-UTC-only day bucketing (tz-aware boundary deferred); whole-day offsets only; ledger retention/aging deferred; at-most-once delivery. This lock touches **only** *when the scan runs* + the `scanIntervalMs`/window decoupling — not the occurrence math, the dedup ledger, or the UTC semantic.
+UTC-only day bucketing (tz-aware boundary deferred); whole-day offsets only; at-most-once delivery. Ledger retention/aging was deferred by this lock and closed by the fixed 365-day `fired_at` sweep follow-up. This lock touches **only** *when the scan runs* + the `scanIntervalMs`/window decoupling — not the occurrence math, the dedup ledger, or the UTC semantic.
 
 ## 6. Build sequence (post-ratify only)
 design-lock ratified → DR-A/DR-B scheduler rewrite + DR-D core decouple + DR-E text → DR-4 fake-timer golden + real-DB aligned-path case → backend `tsc` + frontend `vue-tsc` + editor specs → dev/verification MD → PR (held for review, not auto-merged).

--- a/docs/development/multitable-date-reminder-ledger-retention-dev-verification-20260629.md
+++ b/docs/development/multitable-date-reminder-ledger-retention-dev-verification-20260629.md
@@ -14,6 +14,8 @@ The date-reminder claim ledger now has bounded retention:
   count.
 - `evaluateDateReminders` calls a best-effort once-per-day guard before scanning candidates, so any active
   date-reminder rule keeps the ledger aged without adding another scheduler.
+- `zzzz20260628120200_add_date_reminder_fires_fired_at_index` adds an index on `fired_at`, so the retention
+  sweep's only predicate is indexed on existing deployments too.
 
 ## 2. Safety properties
 
@@ -21,6 +23,7 @@ The date-reminder claim ledger now has bounded retention:
 - At-most-once delivery is unchanged.
 - Rule deletion still cascades immediately through the existing FK.
 - Retention is based on `fired_at`, not occurrence time.
+- The retention predicate is indexed by a new migration, not by editing the already-shipped table migration.
 - Cleanup failure logs a warning and does not block reminder delivery.
 
 ## 3. Verification

--- a/docs/development/multitable-date-reminder-ledger-retention-dev-verification-20260629.md
+++ b/docs/development/multitable-date-reminder-ledger-retention-dev-verification-20260629.md
@@ -1,0 +1,40 @@
+# Date-reminder ledger retention — dev & verification (2026-06-29)
+
+> Status: built; local pure/typecheck verification complete, real-DB verification wired for CI. Design lock:
+> `docs/design/multitable-date-reminder-ledger-retention-design-lock-20260629.md`.
+
+## 1. What changed
+
+The date-reminder claim ledger now has bounded retention:
+
+- `DATE_REMINDER_LEDGER_RETENTION_DAYS = 365`.
+- `dateReminderLedgerRetentionCutoffIso(nowMs)` computes the fixed cutoff.
+- `AutomationService.sweepDateReminderLedger(nowMs)` deletes
+  `meta_automation_date_reminder_fires` rows whose `fired_at` is older than the cutoff and returns the deleted
+  count.
+- `evaluateDateReminders` calls a best-effort once-per-day guard before scanning candidates, so any active
+  date-reminder rule keeps the ledger aged without adding another scheduler.
+
+## 2. Safety properties
+
+- The dedup key remains `(rule_id, record_id, occurrence_ts)`.
+- At-most-once delivery is unchanged.
+- Rule deletion still cascades immediately through the existing FK.
+- Retention is based on `fired_at`, not occurrence time.
+- Cleanup failure logs a warning and does not block reminder delivery.
+
+## 3. Verification
+
+- Pure unit: `automation-date-reminder.test.ts` 23/23. New cases pin exactly 365 days and deterministic cutoff.
+- Backend typecheck: `pnpm --filter @metasheet/core-backend type-check` clean.
+- Real-DB integration is wired in `multitable-date-reminder-trigger.test.ts`: DR-RET inserts an old and recent
+  ledger row, runs `sweepDateReminderLedger`, and proves only the old `fired_at` row is removed. Local execution
+  could not complete because the local dev Postgres schema is not migrated to `meta_bases`; CI's DB lane is the
+  required proof for this case.
+
+## 4. Still deferred
+
+- Configurable retention.
+- Archival before deletion.
+- Timezone-aware day bucketing and sub-day offsets remain the separate date-reminder forks named in the prior
+  design records.

--- a/docs/development/multitable-date-reminder-timeofday-alignment-dev-verification-20260628.md
+++ b/docs/development/multitable-date-reminder-timeofday-alignment-dev-verification-20260628.md
@@ -34,9 +34,11 @@
 - `timeOfDay` drives the actual fire time (UTC), bounded catch-up on restart, never a backfill-blast. ✓
 - The dedup/backfill window is a fixed 48h constant — a per-rule/script `scanIntervalMs` can no longer distort it. ✓
 - Claim ledger + at-most-once unchanged; cron/interval scheduling unchanged. ✓
-- Scope unchanged from #3329: UTC-only bucketing, whole-day offsets, ledger retention deferred. ✓
+- Scope unchanged from #3329: UTC-only bucketing and whole-day offsets stay deferred. Ledger retention was
+  closed by the 365-day `fired_at` sweep follow-up. ✓
 
 ## 6. Boundary / deferred (named)
 - **Boot-scan burst (behavior delta vs the old `setInterval`):** DR-B runs one `evaluateDateReminders` per `date_field` rule on register, so a leader boot/failover *after* `timeOfDay` with N such rules kicks off ~N near-simultaneous catch-up scans (the old boot-anchored `setInterval` deferred the first scan instead). Each scan is bounded + idempotent, so it's correct; at scale a future slice could stagger/coalesce the catch-up. Non-blocking at current rule counts.
 - **Re-enable-after-48h catch-up (named, not a backfill surprise):** disable a `date_field` rule for >48h then re-enable it after `timeOfDay` → the register-time catch-up fires the trailing-48h occurrences that were never claimed (the floor is the *preserved* `effectiveAt`, which is genuinely old — re-enable is not a re-activation). This is within the accepted recent window + at-most-once, and re-enable is an explicit operator action, so it's the intended semantic; flagged so it isn't re-filed as a backfill bug.
-- Unchanged deferred from #3329: tz-aware day boundaries, sub-day offsets, `date_reminder_fires` retention/aging.
+- Unchanged deferred from #3329: tz-aware day boundaries and sub-day offsets. `date_reminder_fires`
+  retention/aging is closed by the fixed 365-day `fired_at` sweep follow-up.

--- a/docs/development/multitable-date-reminder-trigger-dev-verification-20260628.md
+++ b/docs/development/multitable-date-reminder-trigger-dev-verification-20260628.md
@@ -93,9 +93,10 @@ ON DELETE CASCADE). Frontend: `types.ts` · `meta-automation-labels.ts` · `Meta
 
 ## 6. Boundaries / deferred (named, not silent)
 
-- **Retention/aging** of `meta_automation_date_reminder_fires` is NOT built — rows are reaped on rule delete
-  (FK CASCADE) but long-lived rules grow the ledger. Deferred debt (the NiFi provenance benchmark flagged
-  retention as the bounded gap); a separate aging slice.
+- **Retention/aging** of `meta_automation_date_reminder_fires` was NOT built in this initial slice — rows were
+  reaped on rule delete (FK CASCADE), but long-lived rules could grow the ledger. Follow-up shipped a fixed
+  365-day `fired_at` retention sweep; see
+  `docs/development/multitable-date-reminder-ledger-retention-dev-verification-20260629.md`.
 - **Timezone:** v1 buckets in UTC (date fields are stored UTC). `timezone` is persisted but only `'UTC'` is
   honored; tz-aware day boundaries need an IANA tz library — deferred.
 - **Sub-day offsets:** day-bucketing assumes whole-day `offsetDays`; hour-level offsets would revisit the key

--- a/packages/core-backend/src/db/migrations/zzzz20260628120100_create_date_reminder_fires.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260628120100_create_date_reminder_fires.ts
@@ -8,9 +8,9 @@
  * day-bucketed reminder instant (NOT the wall-clock fire time — `fired_at` records that), so editing a
  * deadline to a NEW day produces a NEW occurrence (fires once) while same-day edits stay deduped.
  *
- * FK → automation_rules(id) ON DELETE CASCADE: deleting a rule reaps its ledger rows (the common churn).
- * Retention/aging of long-lived rows is intentionally NOT built here — deferred debt (see the dev doc; the
- * NiFi provenance benchmark flagged retention as the bounded gap). Pure DDL; idempotent.
+ * FK → automation_rules(id) ON DELETE CASCADE: deleting a rule reaps its ledger rows (the common churn). Long
+ * lived active rules are aged by the service's fixed 365-day `fired_at` retention sweep. Pure DDL;
+ * idempotent.
  */
 import { sql, type Kysely } from 'kysely'
 

--- a/packages/core-backend/src/db/migrations/zzzz20260628120200_add_date_reminder_fires_fired_at_index.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260628120200_add_date_reminder_fires_fired_at_index.ts
@@ -1,0 +1,19 @@
+/**
+ * Add the retention-sweep index for the date-reminder idempotency ledger.
+ *
+ * The daily 365-day aging path deletes rows by `fired_at < cutoff`; existing deployments already have the
+ * table from `zzzz20260628120100_create_date_reminder_fires`, so this must be a new migration rather than an
+ * edit to the shipped table migration.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_date_reminder_fires_fired_at
+    ON meta_automation_date_reminder_fires (fired_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_date_reminder_fires_fired_at`.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-date-reminder.test.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.test.ts
@@ -10,9 +10,12 @@ import {
   isDateReminderDue,
   dateReminderFloorMs,
   DATE_REMINDER_GRACE_WINDOW_MS,
+  DATE_REMINDER_LEDGER_RETENTION_DAYS,
+  DATE_REMINDER_LEDGER_RETENTION_MS,
   nextDateReminderTimerDelayMs,
   dateReminderTimeOfDayPassed,
   dateReminderCandidateDateRange,
+  dateReminderLedgerRetentionCutoffIso,
 } from './automation-date-reminder'
 
 const DAY = 24 * 60 * 60 * 1000
@@ -146,6 +149,18 @@ describe('DR-A/DR-B timeOfDay-aligned scheduling helpers (PURE)', () => {
     expect(dateReminderTimeOfDayPassed('09:00', noon)).toBe(true) // 12:00 > 09:00
     expect(dateReminderTimeOfDayPassed('18:00', noon)).toBe(false) // 12:00 < 18:00
     expect(dateReminderTimeOfDayPassed('12:00', noon)).toBe(true) // == now ⇒ passed
+  })
+})
+
+describe('date-reminder ledger retention helpers (PURE)', () => {
+  test('retention window is fixed at 365 days', () => {
+    expect(DATE_REMINDER_LEDGER_RETENTION_DAYS).toBe(365)
+    expect(DATE_REMINDER_LEDGER_RETENTION_MS).toBe(365 * DAY)
+  })
+
+  test('dateReminderLedgerRetentionCutoffIso: cutoff is based on fired_at age', () => {
+    const now = Date.parse('2026-06-29T12:00:00.000Z')
+    expect(dateReminderLedgerRetentionCutoffIso(now)).toBe('2025-06-29T12:00:00.000Z')
   })
 })
 

--- a/packages/core-backend/src/multitable/automation-date-reminder.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.ts
@@ -58,6 +58,19 @@ export interface ScheduleDateFieldConfig {
  */
 export const DATE_REMINDER_GRACE_WINDOW_MS = 2 * DAY_MS
 
+/**
+ * Retain the date-reminder idempotency ledger for one year. The ledger is a dedupe/audit record, not user
+ * content; rule deletion still cascades immediately, while long-lived active rules age by actual `fired_at`.
+ */
+export const DATE_REMINDER_LEDGER_RETENTION_DAYS = 365
+export const DATE_REMINDER_LEDGER_RETENTION_MS = DATE_REMINDER_LEDGER_RETENTION_DAYS * DAY_MS
+export const DATE_REMINDER_LEDGER_SWEEP_INTERVAL_MS = DAY_MS
+
+/** PURE cutoff for ledger aging. Rows with fired_at older than this can be deleted. */
+export function dateReminderLedgerRetentionCutoffIso(nowMs: number): string {
+  return new Date(nowMs - DATE_REMINDER_LEDGER_RETENTION_MS).toISOString()
+}
+
 /** Parse 'HH:mm' → minutes-since-midnight, or 540 (09:00) on junk. */
 function parseTimeOfDayMinutes(timeOfDay: string | undefined): number {
   if (typeof timeOfDay !== 'string') return 9 * 60

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -8,7 +8,9 @@ import {
   isDateReminderDue,
   dateReminderFloorMs,
   DATE_REMINDER_GRACE_WINDOW_MS,
+  DATE_REMINDER_LEDGER_SWEEP_INTERVAL_MS,
   dateReminderCandidateDateRange,
+  dateReminderLedgerRetentionCutoffIso,
   type ScheduleDateFieldConfig,
 } from './automation-date-reminder'
 import { ensureRecordNotLocked } from './record-lock'
@@ -653,6 +655,7 @@ export class AutomationService {
   private jobService: AutomationJobService
   private suspensionService: AutomationSuspensionService
   private approvalBridgeService: AutomationApprovalBridgeService
+  private lastDateReminderLedgerSweepMs = 0
   /** Kept for backward-compat with raw SQL in executor actions */
   private queryFn: AutomationQueryFn
 
@@ -1127,6 +1130,41 @@ export class AutomationService {
   }
 
   /**
+   * Delete old date-reminder claim rows. This is an ops/test seam and is intentionally keyed by `fired_at`
+   * (ledger age), not `occurrence_ts` (the record-relative reminder instant).
+   */
+  async sweepDateReminderLedger(nowMs = Date.now()): Promise<number> {
+    const cutoffIso = dateReminderLedgerRetentionCutoffIso(nowMs)
+    const deleted = await sql<{ count: number | string }>`
+      WITH deleted AS (
+        DELETE FROM meta_automation_date_reminder_fires
+         WHERE fired_at < ${cutoffIso}
+        RETURNING 1
+      )
+      SELECT count(*)::int AS count FROM deleted
+    `.execute(this.db)
+    return Number(deleted.rows[0]?.count ?? 0)
+  }
+
+  /**
+   * Opportunistic ledger aging: any active date-reminder scan sweeps at most once/day per process. This avoids
+   * a second scheduler while still bounding the long-lived dedupe ledger. Cleanup is best-effort; a retention
+   * failure must never block reminder delivery.
+   */
+  private async sweepDateReminderLedgerIfDue(nowMs: number): Promise<void> {
+    if (nowMs - this.lastDateReminderLedgerSweepMs < DATE_REMINDER_LEDGER_SWEEP_INTERVAL_MS) return
+    this.lastDateReminderLedgerSweepMs = nowMs
+    try {
+      const deleted = await this.sweepDateReminderLedger(nowMs)
+      if (deleted > 0) {
+        logger.info(`Date-reminder ledger retention swept ${deleted} old row(s)`)
+      }
+    } catch (err) {
+      logger.warn('Date-reminder ledger retention sweep failed; continuing reminder scan', err instanceof Error ? err : undefined)
+    }
+  }
+
+  /**
    * Date-reminder scan (`schedule.date_field`). For each record in the rule's sheet whose date field yields a
    * DUE occurrence, claim it in the idempotency ledger and fire the rule once with the record as context.
    *
@@ -1154,6 +1192,7 @@ export class AutomationService {
     }
 
     const nowMs = Date.now()
+    await this.sweepDateReminderLedgerIfDue(nowMs)
     // DR-D: fixed grace window (decoupled from any per-rule cadence) — bounds backfill + missed-tick catch-up.
     const scanWindowMs = DATE_REMINDER_GRACE_WINDOW_MS
     const createdAtMs = new Date(rule.createdAt).getTime()

--- a/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
@@ -140,6 +140,31 @@ describeIfDatabase('multitable date-reminder trigger — scan/claim/fire (real D
     expect(await execCount(RULE_BACKDATED)).toBe(execsBefore) // and therefore fired nothing
   })
 
+  test('DR-RET: 365d ledger retention deletes old fired_at rows and keeps recent dedupe rows', async () => {
+    const OLD_LEDGER_RECORD = `rec_dr_ledger_old_${TS}`
+    const RECENT_LEDGER_RECORD = `rec_dr_ledger_recent_${TS}`
+    await q(
+      `INSERT INTO meta_automation_date_reminder_fires (rule_id, record_id, occurrence_ts, fired_at)
+       VALUES ($1,$2,$3::timestamptz,$4::timestamptz)`,
+      [RULE_BACKDATED, OLD_LEDGER_RECORD, iso(TS - 400 * DAY), iso(TS - 366 * DAY)],
+    )
+    await q(
+      `INSERT INTO meta_automation_date_reminder_fires (rule_id, record_id, occurrence_ts, fired_at)
+       VALUES ($1,$2,$3::timestamptz,$4::timestamptz)`,
+      [RULE_BACKDATED, RECENT_LEDGER_RECORD, iso(TS - 20 * DAY), iso(TS - 364 * DAY)],
+    )
+
+    expect(await svc.sweepDateReminderLedger(TS)).toBeGreaterThanOrEqual(1)
+
+    const rows = await q(
+      `SELECT record_id FROM meta_automation_date_reminder_fires
+        WHERE rule_id = $1 AND record_id = ANY($2::text[])
+        ORDER BY record_id`,
+      [RULE_BACKDATED, [OLD_LEDGER_RECORD, RECENT_LEDGER_RECORD]],
+    )
+    expect((rows.rows as Array<{ record_id: string }>).map((r) => r.record_id)).toEqual([RECENT_LEDGER_RECORD])
+  })
+
   test('DR-3: BACKFILL bound — the SAME due record under a FRESH rule does NOT fire (occurrence < floor = effectiveAt ≈ created_at)', async () => {
     await svc.runDateReminderScanNow(RULE_FRESH)
     // REC_DUE is fetched by the SQL window, but its occurrence (today 00:00) predates the fresh rule's FLOOR


### PR DESCRIPTION
## Summary

Adds bounded retention for the `schedule.date_field` idempotency ledger:

- fixes the v1 retention choice at 365 days;
- ages `meta_automation_date_reminder_fires` by `fired_at` rather than `occurrence_ts`;
- exposes `AutomationService.sweepDateReminderLedger()` as an ops/test seam;
- runs a best-effort once-per-day opportunistic sweep from active date-reminder scans, without adding a new scheduler;
- updates the original date-reminder docs and migration comment so they no longer claim ledger retention is unbuilt.

At-most-once delivery and the `(rule_id, record_id, occurrence_ts)` dedupe key are unchanged.

## Verification

Local:

- `pnpm -C packages/core-backend exec vitest run src/multitable/automation-date-reminder.test.ts --reporter=dot` → 23/23
- `pnpm --filter @metasheet/core-backend type-check` → clean
- `git diff --check HEAD~1..HEAD` → clean

Real-DB:

- Added `DR-RET` to `tests/integration/multitable-date-reminder-trigger.test.ts`: inserts old and recent ledger rows, runs the sweep, and proves only the old `fired_at` row is removed.
- Local dev Postgres could not run the suite because this checkout's local 5435 DB is not migrated to `meta_bases` (the migration chain stops on an older approval migration). CI's DB lane is the required proof for this case.
