### PR TITLE
docs(multitable): retitle T9-W design-locks RATIFIED + runtime-shipped (close stale-audit drift)

### DIFF
--- a/docs/development/multitable-t9w-permission-revert-designlock-20260628.md
+++ b/docs/development/multitable-t9w-permission-revert-designlock-20260628.md
@@ -1,4 +1,4 @@
-# T9-W permission-revert — DESIGN-LOCK (PROPOSED)
+# T9-W permission-revert — DESIGN-LOCK (RATIFIED · runtime shipped #3361)
 
 **Date:** 2026-06-28 · **Type:** T9-W unsafe-restore write-slice design-lock, narrowed v1. Docs-only; locks scope + per-decision bars **before any runtime code**. The **last and highest-blast-radius** link on the config-restore line — it touches the access-control surface itself.
 

--- a/docs/development/multitable-t9w-tier3-uncreate-designlock-20260627.md
+++ b/docs/development/multitable-t9w-tier3-uncreate-designlock-20260627.md
@@ -1,4 +1,4 @@
-# T9-W Tier 3 (U-3) un-create — DESIGN-LOCK (PROPOSED)
+# T9-W Tier 3 (U-3) un-create — DESIGN-LOCK (RATIFIED · runtime shipped #3335)
 
 **Date:** 2026-06-27 · **Type:** T9-W unsafe-restore write-slice design-lock, narrowed v1. Locks scope + the per-decision bars **before any runtime code**. Docs-only. Unblocks the umbrella lock's `🔒 U-3 (HOLD) … until a separate destructive-delete sign-off` (`multitable-t9-w-unsafe-restore-design-lock-20260626.md`).
 

--- a/docs/development/multitable-t9w-tier4-undelete-designlock-20260628.md
+++ b/docs/development/multitable-t9w-tier4-undelete-designlock-20260628.md
@@ -1,4 +1,4 @@
-# T9-W Tier 4 (U-4) config-undelete — DESIGN-LOCK (PROPOSED)
+# T9-W Tier 4 (U-4) config-undelete — DESIGN-LOCK (RATIFIED · runtime shipped #3343)
 
 **Date:** 2026-06-28 · **Type:** T9-W unsafe-restore write-slice design-lock, narrowed v1. Docs-only; locks scope + per-decision bars **before any runtime code**. The inverse of Tier 3 (#3335): Tier 3 reverts a `create` (drop the entity); Tier 4 reverts a **`delete`** (recreate it).
 


### PR DESCRIPTION
Low-finding cleanup from the permission-revert review: the Tier 3 / Tier 4 / permission-revert design-lock titles still read `DESIGN-LOCK (PROPOSED)` though all three are owner-ratified and their runtimes are merged (#3335 / #3343 / #3361). Retitled to `RATIFIED · runtime shipped #<PR>` so a future stale-audit doesn't false-flag them. Bodies were already correct (owner-ratified). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)