### PR TITLE
[codex] add K3 LIST values-free shape probe

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5542,7 +5542,19 @@ async function testReadSmokeRoute() {
             if (req.options && req.options.k3ReadMode === 'list') {
               return {
                 records: [{ FName: 'SECRET-LIST-NAME', FNumber: 'M-LIST-001' }, { FName: 'SECRET-LIST-NAME-2', FNumber: 'M-LIST-002' }],
-                metadata: { readPath: 'https://k3host/K3API/Material/GetList' },
+                metadata: {
+                  readPath: 'https://k3host/K3API/Material/GetList',
+                  listShapeProbe: {
+                    dataData: false,
+                    dataLowerData: false,
+                    dataRows: false,
+                    resultData: false,
+                    resultRows: true,
+                    rows: false,
+                    topLevelArray: false,
+                    materialNumber: 'M-LIST-001',
+                  },
+                },
               }
             }
             return {
@@ -5613,6 +5625,15 @@ async function testReadSmokeRoute() {
   assert.equal(okList.body.data.object, 'material')
   assert.equal(okList.body.data.mode, 'list')
   assert.equal(okList.body.data.recordCount, 2)
+  assert.deepEqual(okList.body.data.listShapeProbe, {
+    dataData: false,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: true,
+    rows: false,
+    topLevelArray: false,
+  })
   const listReadArg = readArgs[readArgs.length - 1]
   assert.equal(listReadArg.object, 'material')
   assert.equal(listReadArg.limit, 10)
@@ -5637,7 +5658,7 @@ async function testReadSmokeRoute() {
     maxListLimit: 10,
   }, 'LIST applies the non-persisted Material/GetList overlay before adapter creation')
   const okListStr = JSON.stringify(okList.body.data)
-  for (const leak of ['M-LIST-001', 'SECRET-LIST-NAME', 'k3host', 'readPath']) {
+  for (const leak of ['M-LIST-001', 'SECRET-LIST-NAME', 'k3host', 'readPath', 'materialNumber']) {
     assert.ok(!okListStr.includes(leak), `LIST read-smoke response must not leak ${leak}`)
   }
 
@@ -5718,7 +5739,25 @@ async function testReadSmokeRoute() {
   const failSvc = createMockServices({
     externalSystemRegistry: { async getExternalSystemForAdapter(input) { return { id: input.id, kind: 'erp:k3-wise-webapi', credentials: {} } } },
     adapterRegistry: { createAdapter() { return {
-      async read() { const e = new Error('material M-001 secret 42'); e.name = 'K3WiseWebApiAdapterError'; e.details = { code: 'K3_WISE_READ_LIST_REJECTED', dataDataPresent: true }; throw e },
+      async read() {
+        const e = new Error('material M-001 secret 42')
+        e.name = 'K3WiseWebApiAdapterError'
+        e.details = {
+          code: 'K3_WISE_READ_LIST_REJECTED',
+          dataDataPresent: true,
+          listShapeProbe: {
+            dataData: true,
+            dataLowerData: false,
+            dataRows: false,
+            resultData: false,
+            resultRows: false,
+            rows: false,
+            topLevelArray: false,
+            materialNumber: 'M-001',
+          },
+        }
+        throw e
+      },
       async upsert(b) { failWrite.push(b); return {} },
     } } },
   })
@@ -5731,8 +5770,17 @@ async function testReadSmokeRoute() {
   assert.equal(fail.body.data.errorCode, 'K3_WISE_READ_LIST_REJECTED')
   assert.equal(fail.body.data.errorType, 'K3WiseWebApiAdapterError')
   assert.equal(fail.body.data.dataDataPresent, true)
+  assert.deepEqual(fail.body.data.listShapeProbe, {
+    dataData: true,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: false,
+    rows: false,
+    topLevelArray: false,
+  })
   const failStr = JSON.stringify(fail.body.data)
-  assert.ok(!failStr.includes('M-001') && !failStr.includes('42'), 'read failure evidence is values-free')
+  assert.ok(!failStr.includes('M-001') && !failStr.includes('42') && !failStr.includes('materialNumber'), 'read failure evidence is values-free')
   assert.equal(failWrite.length, 0, 'no write attempted on read failure')
 
   console.log('  testReadSmokeRoute OK')

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -963,6 +963,15 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.equal(read.metadata.requestedLimit, 2)
   assert.equal(read.metadata.returnedRecordCount, 2)
   assert.equal(read.metadata.dataDataPresent, true)
+  assert.deepEqual(read.metadata.listShapeProbe, {
+    dataData: true,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: false,
+    rows: false,
+    topLevelArray: false,
+  })
   assert.equal(read.metadata.readPath, '/K3API/Material/GetList')
 
   const listCalls = calls.filter((call) => call.pathname === '/K3API/Material/GetList')
@@ -1046,6 +1055,59 @@ async function testK3WebApiMaterialListReadSmoke() {
   const missingRows = await missingRowsAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2))
   assert.equal(missingRows.records.length, 0, 'LIST success envelope without Data.DATA remains an empty bounded page')
   assert.equal(missingRows.metadata.dataDataPresent, false, 'LIST success evidence carries a values-free rows-shape diagnostic')
+  assert.deepEqual(missingRows.metadata.listShapeProbe, {
+    dataData: false,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: false,
+    rows: false,
+    topLevelArray: false,
+  })
+
+  const alternateRowsFetchImpl = async (url, options) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === '/K3API/Material/GetList') {
+      return jsonResponse(200, {
+        StatusCode: 200,
+        Message: 'Material list succeeded',
+        Result: { Rows: [{ FNumber: 'SECRET-MAT' }] },
+      })
+    }
+    return fetchImpl(url, options)
+  }
+  const alternateRowsAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        objects: {
+          material: {
+            operations: ['read'],
+            readPath: '/K3API/Material/GetList',
+            readMethod: 'POST',
+            readMode: 'list',
+            readListBodyTemplate: { Data: { Top: 10, PageIndex: 1 } },
+            pageIndexField: 'PageIndex',
+            pageSizeField: 'PageSize',
+            maxListLimit: 3,
+          },
+        },
+      },
+    }),
+    fetchImpl: alternateRowsFetchImpl,
+  })
+  const alternateRows = await alternateRowsAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2))
+  assert.equal(alternateRows.records.length, 0, 'shape probe does not silently widen the extractor')
+  assert.equal(alternateRows.metadata.dataDataPresent, false)
+  assert.deepEqual(alternateRows.metadata.listShapeProbe, {
+    dataData: false,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: true,
+    rows: false,
+    topLevelArray: false,
+  }, 'LIST shape probe localizes rows under a fixed allowlisted alternate container')
 
   const rejectedFetchImpl = async (url, options) => {
     const parsed = new URL(url)
@@ -1082,6 +1144,15 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.ok(rejected instanceof K3WiseWebApiAdapterError, 'LIST explicit failure marker is rejected before row extraction')
   assert.equal(rejected.details.code, 'K3_WISE_READ_LIST_REJECTED')
   assert.equal(rejected.details.dataDataPresent, true)
+  assert.deepEqual(rejected.details.listShapeProbe, {
+    dataData: true,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: false,
+    rows: false,
+    topLevelArray: false,
+  })
 
   const unrecognizedFetchImpl = async (url, options) => {
     const parsed = new URL(url)
@@ -1117,6 +1188,15 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.ok(unrecognized instanceof K3WiseWebApiAdapterError, 'LIST rows under Data.DATA with an unrecognized envelope gets a response-shape diagnostic')
   assert.equal(unrecognized.details.code, 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED')
   assert.equal(unrecognized.details.dataDataPresent, true)
+  assert.deepEqual(unrecognized.details.listShapeProbe, {
+    dataData: true,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: false,
+    rows: false,
+    topLevelArray: false,
+  })
 
   const modeMismatch = await adapter.read({
     object: 'material',

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -179,9 +179,38 @@ assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, { records: [{ FNumber: 'M
 assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, {
   records: [],
   raw: { Data: { SECRET: 'never leak' } },
-  metadata: { dataDataPresent: false, readPath: 'https://k3host/K3API/Material/GetList' },
+  metadata: {
+    dataDataPresent: false,
+    listShapeProbe: {
+      dataData: false,
+      dataLowerData: false,
+      dataRows: true,
+      resultData: false,
+      resultRows: false,
+      rows: false,
+      topLevelArray: false,
+      SECRET: true,
+    },
+    readPath: 'https://k3host/K3API/Material/GetList',
+  },
 }, { object: 'material', mode: 'list' }), {
-  ok: true, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', recordPresent: false, recordCount: 0, referenceObjectCount: 0, dataDataPresent: false,
+  ok: true,
+  presetId: 'k3wise.material-list.v1',
+  object: 'material',
+  mode: 'list',
+  recordPresent: false,
+  recordCount: 0,
+  referenceObjectCount: 0,
+  dataDataPresent: false,
+  listShapeProbe: {
+    dataData: false,
+    dataLowerData: false,
+    dataRows: true,
+    resultData: false,
+    resultRows: false,
+    rows: false,
+    topLevelArray: false,
+  },
 })
 
 // --- error evidence: coarse code + type ONLY (never the message, which may carry the key/values) ---
@@ -203,11 +232,39 @@ for (const leak of ['M-001', '42', 'failed with secret']) {
 }
 const listError = new Error('material M-001 rejected with secret value 42')
 listError.name = 'K3WiseWebApiAdapterError'
-listError.details = { code: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED', dataDataPresent: true }
+listError.details = {
+  code: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED',
+  dataDataPresent: true,
+  listShapeProbe: {
+    dataData: true,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: false,
+    rows: false,
+    topLevelArray: false,
+    materialNumber: 'M-001',
+  },
+}
 assert.deepEqual(readSmokeErrorEvidence(LIST_PRESET, listError, { object: 'material', mode: 'list' }), {
   ok: false, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list',
-  errorCode: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED', errorType: 'K3WiseWebApiAdapterError', dataDataPresent: true,
+  errorCode: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED',
+  errorType: 'K3WiseWebApiAdapterError',
+  dataDataPresent: true,
+  listShapeProbe: {
+    dataData: true,
+    dataLowerData: false,
+    dataRows: false,
+    resultData: false,
+    resultRows: false,
+    rows: false,
+    topLevelArray: false,
+  },
 })
+const listErrorStr = JSON.stringify(readSmokeErrorEvidence(LIST_PRESET, listError, { object: 'material', mode: 'list' }))
+for (const leak of ['M-001', '42', 'materialNumber']) {
+  assert.ok(!listErrorStr.includes(leak), `LIST error evidence must not leak ${leak}`)
+}
 const unsafeDetails = new Error('material M-001 failed with secret value 42')
 unsafeDetails.name = 'K3WiseWebApiAdapterError'
 unsafeDetails.details = { code: 'M-001 failed with secret value 42' }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -787,8 +787,21 @@ function materialListRowsCandidate(data) {
   return null
 }
 
+function materialListShapeProbe(data) {
+  return {
+    dataData: Array.isArray(getPath(data, 'Data.DATA')),
+    dataLowerData: Array.isArray(getPath(data, 'Data.data')),
+    dataRows: Array.isArray(getPath(data, 'Data.Rows')),
+    resultData: Array.isArray(getPath(data, 'Result.Data')),
+    resultRows: Array.isArray(getPath(data, 'Result.Rows')),
+    rows: Array.isArray(getPath(data, 'Rows')),
+    topLevelArray: Array.isArray(data),
+  }
+}
+
 function materialListDataDataPresent(data) {
-  return Array.isArray(getPath(data, 'Data.DATA')) || Array.isArray(getPath(data, 'Data.data'))
+  const probe = materialListShapeProbe(data)
+  return probe.dataData || probe.dataLowerData
 }
 
 function materialListBusinessSuccess(data, config) {
@@ -1312,7 +1325,8 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
         })
       }
 
-      const dataDataPresent = materialListDataDataPresent(readResponse.data)
+      const listShapeProbe = materialListShapeProbe(readResponse.data)
+      const dataDataPresent = listShapeProbe.dataData || listShapeProbe.dataLowerData
       if (!materialListBusinessSuccess(readResponse.data, config)) {
         const failureCode = materialListBusinessFailureCode(readResponse.data)
         throw new K3WiseWebApiAdapterError(String(responseMessage(readResponse.data, config, 'K3 WISE list read business response failed')), {
@@ -1320,6 +1334,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           object: request.object,
           responseCode: responseFailureCode(readResponse.data, config, failureCode),
           dataDataPresent,
+          listShapeProbe,
         })
       }
 
@@ -1333,6 +1348,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           requestedLimit: request.limit,
           returnedRecordCount: records.length,
           dataDataPresent,
+          listShapeProbe,
           readPath,
           readOnly: true,
         },

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -74,6 +74,28 @@ function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
 
+const READ_SMOKE_LIST_SHAPE_PROBE_KEYS = Object.freeze([
+  'dataData',
+  'dataLowerData',
+  'dataRows',
+  'resultData',
+  'resultRows',
+  'rows',
+  'topLevelArray',
+])
+
+function readSmokeListShapeProbeEvidence(value) {
+  if (!isPlainObject(value)) return null
+  const evidence = {}
+  let hasEvidence = false
+  for (const key of READ_SMOKE_LIST_SHAPE_PROBE_KEYS) {
+    if (typeof value[key] !== 'boolean') continue
+    evidence[key] = value[key]
+    hasEvidence = true
+  }
+  return hasEvidence ? evidence : null
+}
+
 function mergeOperations(existing, required) {
   const values = []
   for (const source of [existing, required]) {
@@ -175,6 +197,8 @@ function readSmokeSuccessEvidence(preset, result, contract = {}) {
   if (result && result.metadata && typeof result.metadata.dataDataPresent === 'boolean') {
     evidence.dataDataPresent = result.metadata.dataDataPresent
   }
+  const listShapeProbe = readSmokeListShapeProbeEvidence(result && result.metadata && result.metadata.listShapeProbe)
+  if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
   return evidence
 }
 
@@ -199,6 +223,8 @@ function readSmokeErrorEvidence(preset, error, contract = {}) {
   if (error && error.details && typeof error.details.dataDataPresent === 'boolean') {
     evidence.dataDataPresent = error.details.dataDataPresent
   }
+  const listShapeProbe = readSmokeListShapeProbeEvidence(error && error.details && error.details.listShapeProbe)
+  if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
   return evidence
 }
 


### PR DESCRIPTION
## Summary

Adds a values-free fixed-allowlist response-shape probe to the K3 WISE Material/GetList read-smoke path.

This follows the #1709 keyed entity-machine rerun: the owner-approved sample key reached the internal LIST prefix filter, but the smoke still returned `recordPresent=false` and `dataDataPresent=false`. The next useful signal is to localize whether live K3 returns rows under a known alternate response container before changing the GetList body or widening the extractor.

## What changed

- Adds `listShapeProbe` booleans on the adapter metadata/error details for fixed candidate containers only:
  - `dataData`
  - `dataLowerData`
  - `dataRows`
  - `resultData`
  - `resultRows`
  - `rows`
  - `topLevelArray`
- Projects only those fixed boolean keys into read-smoke evidence.
- Keeps existing `dataDataPresent` for compatibility.
- Adds tests for success evidence, error evidence, HTTP route projection, values-free filtering, and alternate-container localization.

## Boundaries

- Diagnostic-only.
- Does not change the GetList endpoint, body, filter, pagination, or request contract.
- Does not widen `materialListRowsCandidate`; alternate containers are detected but not read yet.
- Does not open BOM, resolver, Save, Submit, Audit, production write, or any write path.
- Values-free: no raw payload, rows, keys, material codes/names, credentials, host/system ids, dynamic paths, messages, or customer values are surfaced.

## Verification

- `node plugins/plugin-integration-core/__tests__/read-smoke.test.cjs`
- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `pnpm --filter plugin-integration-core test:k3-wise-adapters`
- `pnpm --filter plugin-integration-core test:http-routes`
- `pnpm --filter plugin-integration-core test`
