### PR TITLE
feat(multitable): OAPI-2a/2b token write runtime (records:write + comments:write)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -197,6 +197,9 @@ jobs:
             tests/integration/multitable-conditional-rule-trash-realdb.test.ts \
             tests/integration/multitable-oapi1-token-read-realdb.test.ts \
             tests/integration/multitable-oapi1-comments-read-realdb.test.ts \
+            tests/integration/multitable-oapi2a-token-write-realdb.test.ts \
+            tests/integration/multitable-oapi2a-comments-write-realdb.test.ts \
+            tests/integration/multitable-oapi2a-ratelimit-realdb.test.ts \
             tests/integration/multitable-fieldperm-write-gate-patch-realdb.test.ts \
             tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260628130000_create_oapi_write_audit.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260628130000_create_oapi_write_audit.ts
@@ -1,0 +1,44 @@
+/**
+ * Migration: `oapi_write_audit` — the OAPI-2a token-write audit ledger.
+ *
+ * Design-lock `docs/development/multitable-oapi2-write-designlock-20260628.md` §6 / §10.7 (RATIFIED).
+ * Every token-authenticated write attempt is audited with its final outcome:
+ *   - `committed` rows are inserted **inside the mutation transaction** (RecordService / RecordWriteService /
+ *     CommentService), so an audit-insert failure rolls the write back (fail-closed). They carry the real
+ *     written result (`record_ids` / `batch_count`).
+ *   - `denied` / `error` / `rate_limited` rows are written best-effort at the route boundary (no mutation txn
+ *     to join) with mandatory alerting on write failure.
+ *
+ * Purpose-built + UNPARTITIONED on purpose: the general `audit_logs` table is range-partitioned by month, so a
+ * missing partition would make the same-txn committed INSERT fail and roll back EVERY token write — an
+ * unacceptable coupling for a fail-closed path. It also types `user_id` as INTEGER, while our actor ids are
+ * strings. Value-scrub (F1) is applied to `detail` by the caller before persisting. Pure DDL; idempotent.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS oapi_write_audit (
+      id bigserial PRIMARY KEY,
+      token_id text NOT NULL,
+      actor_id text NOT NULL,
+      operation text NOT NULL CHECK (operation IN ('create', 'update', 'upsert', 'delete')),
+      scope text NOT NULL,
+      sheet_id text,
+      record_ids text[],
+      batch_count integer,
+      outcome text NOT NULL CHECK (outcome IN ('committed', 'denied', 'error', 'rate_limited')),
+      status_code integer,
+      request_id text,
+      detail jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_oapi_write_audit_token ON oapi_write_audit (token_id, created_at DESC)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_oapi_write_audit_actor ON oapi_write_audit (actor_id, created_at DESC)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_oapi_write_audit_outcome ON oapi_write_audit (outcome, created_at DESC)`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS oapi_write_audit`.execute(db)
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -154,7 +154,7 @@ import plmEmbedRouter from './routes/plm-embed'
 import { createHostPluginStorage } from './plugins/plugin-durable-storage'
 import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
-import { isOapiReadAllowlistRequest } from './multitable/oapi-read-allowlist'
+import { isOapiAllowlistRequest } from './multitable/oapi-read-allowlist'
 import { dashboardRouter } from './routes/dashboard'
 import { createAutomationRoutes } from './routes/automation'
 import { createMultitableAiRoutes } from './routes/multitable-ai'
@@ -995,10 +995,11 @@ export class MetaSheetServer {
     this.app.use((req: Request, res: Response, next: NextFunction) => {
       if (isWhitelisted(req.path)) return next()
       if (isPublicFormAuthBypass(req)) return optionalJwtAuthMiddleware(req, res, next)
-      // OAPI-1: let an `mst_` API token reach the per-route apiTokenAuth + requireScope guards on the
-      // read allowlist ONLY (fail-closed). An `mst_` bearer on any non-allowlisted path falls through to
-      // jwtAuthMiddleware → 401, so tokens can never reach write/side-effecting or non-gating routes.
-      if (isOapiReadAllowlistRequest(req.method, req.path, req.headers.authorization)) return next()
+      // OAPI-1/2a: let an `mst_` API token reach the per-route apiTokenAuth + requireScope guards on the
+      // method-bound allowlist (read GETs ∪ the 4 OAPI-2a write routes), fail-closed. An `mst_` bearer on
+      // any non-allowlisted (method, path) falls through to jwtAuthMiddleware → 401, so a token can never
+      // reach a write/side-effecting route outside the allowlist (kept in lockstep with the mounted guards).
+      if (isOapiAllowlistRequest(req.method, req.path, req.headers.authorization)) return next()
       if (req.path.startsWith('/api/')) return jwtAuthMiddleware(req, res, next)
       return next()
     })

--- a/packages/core-backend/src/middleware/api-token-auth.ts
+++ b/packages/core-backend/src/middleware/api-token-auth.ts
@@ -15,6 +15,8 @@ declare global {
     interface Request {
       apiTokenScopes?: ApiTokenScope[]
       apiTokenUserId?: string
+      /** The API token's own id (NOT the creator's). Used to key the per-token rate limiter. */
+      apiTokenId?: string
     }
   }
 }
@@ -63,6 +65,8 @@ export async function apiTokenAuth(
   // Attach scopes and synthetic user context
   req.apiTokenScopes = result.token.scopes
   req.apiTokenUserId = result.token.createdBy
+  // The token's own id — keys the per-token rate limiter (OAPI-2a). NOT the creator id.
+  req.apiTokenId = result.token.id
 
   // Set a minimal user object so downstream route guards work
   req.user = {

--- a/packages/core-backend/src/middleware/rate-limiter.ts
+++ b/packages/core-backend/src/middleware/rate-limiter.ts
@@ -274,7 +274,9 @@ export function conditionalPublicRateLimiter(
  */
 const oapiTokenWriteLimiter = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 600,
+  // Default 600/min/token (design-lock §7). Env-overridable so a low-cap golden can prove that even
+  // wrong-scope write attempts are rate-limited (the limiter runs BEFORE requireScope on every route).
+  maxRequests: Number(process.env.OAPI_WRITE_RATE_LIMIT_MAX) || 600,
   keyPrefix: 'oapi-token-write',
   keyFn: (req: Request) => req.apiTokenId,
 })

--- a/packages/core-backend/src/middleware/rate-limiter.ts
+++ b/packages/core-backend/src/middleware/rate-limiter.ts
@@ -267,3 +267,29 @@ export function conditionalPublicRateLimiter(
     }
   }
 }
+
+/**
+ * OAPI-2a per-token write limiter — 600 req/min keyed by the API token's OWN id (`req.apiTokenId`, set by
+ * `apiTokenAuth`); 429 on exceed (design-lock §7 / §2.4 "600/min/token").
+ */
+const oapiTokenWriteLimiter = createRateLimiter({
+  windowMs: 60 * 1000,
+  maxRequests: 600,
+  keyPrefix: 'oapi-token-write',
+  keyFn: (req: Request) => req.apiTokenId,
+})
+
+/**
+ * Apply the per-token write limiter ONLY to token-authenticated requests. This is a **strict no-op for
+ * session (non-token) requests**: `createRateLimiter` falls back to `userId`/`req.ip` when `keyFn` returns
+ * undefined (see the `rawKey` line above), which on these SESSION-SHARED write routes would wrongly throttle
+ * ordinary user edits. Short-circuiting on a missing `apiTokenId` keeps session writes unthrottled by this
+ * limiter while every `mst_` token write is capped per-token.
+ */
+export function apiTokenWriteRateLimit(req: Request, res: Response, next: NextFunction): void {
+  if (!req.apiTokenId) {
+    next()
+    return
+  }
+  oapiTokenWriteLimiter(req, res, next)
+}

--- a/packages/core-backend/src/middleware/rate-limiter.ts
+++ b/packages/core-backend/src/middleware/rate-limiter.ts
@@ -131,8 +131,9 @@ export class RedisRateLimitStore implements RateLimitStore {
 export interface RateLimiterOptions {
   /** Time window in milliseconds */
   windowMs: number
-  /** Maximum number of requests allowed within the window */
-  maxRequests: number
+  /** Maximum number of requests allowed within the window. A function is evaluated PER-REQUEST (runtime cap),
+   *  so an env-driven cap is honored regardless of when the limiter module was first imported. */
+  maxRequests: number | (() => number)
   /** Prefix used to namespace keys (e.g. 'public-form-submit') */
   keyPrefix: string
   /** Optional Redis client — enables distributed rate limiting.
@@ -181,7 +182,8 @@ export function createRateLimiter(options: RateLimiterOptions) {
     const key = `ratelimit:${keyPrefix}:${rawKey}`
 
     const handleResult = (result: { count: number; ttlMs: number }) => {
-      if (result.count > maxRequests) {
+      const max = typeof maxRequests === 'function' ? maxRequests() : maxRequests
+      if (result.count > max) {
         const retryAfterSeconds = Math.ceil(result.ttlMs / 1000)
         res.set('Retry-After', String(retryAfterSeconds))
         if (onLimited) {
@@ -276,7 +278,7 @@ const oapiTokenWriteLimiter = createRateLimiter({
   windowMs: 60 * 1000,
   // Default 600/min/token (design-lock §7). Env-overridable so a low-cap golden can prove that even
   // wrong-scope write attempts are rate-limited (the limiter runs BEFORE requireScope on every route).
-  maxRequests: Number(process.env.OAPI_WRITE_RATE_LIMIT_MAX) || 600,
+  maxRequests: () => Number(process.env.OAPI_WRITE_RATE_LIMIT_MAX) || 600,
   keyPrefix: 'oapi-token-write',
   keyFn: (req: Request) => req.apiTokenId,
 })

--- a/packages/core-backend/src/multitable/oapi-read-allowlist.ts
+++ b/packages/core-backend/src/multitable/oapi-read-allowlist.ts
@@ -61,3 +61,54 @@ export function isOapiReadAllowlistRequest(method: string, path: string, authHea
   if (method !== 'GET') return false
   return OAPI_READ_PATHS.some((pattern) => pattern.test(path))
 }
+
+/**
+ * OAPI-2a write routes — **method-bound** (design-lock
+ * `docs/development/multitable-oapi2-write-designlock-20260628.md` §2, RATIFIED 2026-06-28).
+ *
+ * Unlike the read allowlist (GET-only), a write route is opened ONLY for its specific write method: a write
+ * path is never opened for GET, and a read path is never opened for a write method. Each entry is an anchored
+ * `^…$` `(method, path)` pair in **exact lockstep** with a route that mounts BOTH `apiTokenAuth` +
+ * `requireScope` (univer-meta.ts / comments.ts) — the same over-match hazard as the read list: an entry
+ * without a mounted `requireScope` is a silent no-auth bypass (`requireScope` fail-opens with no scopes).
+ *
+ * `DELETE /records/:id` is intentionally **absent** — it is OAPI-2b, gated after 2a (design-lock §4). So are
+ * `/records/:id/lock`, `/records/:id/restore`, comment edit/delete (`PATCH`/`DELETE /api/comments/:id`), and
+ * the public-form submit path `POST /api/multitable/views/:id/submit` (its own `publicToken` gate, disjoint).
+ */
+const OAPI_WRITE_ROUTES: readonly { method: string; pattern: RegExp }[] = [
+  // records:write — POST /records (create). Exactly /records: not /records/:id, not /records/:id/lock.
+  { method: 'POST', pattern: /^\/api\/multitable\/records$/ },
+  // records:write — PATCH /records/:recordId (update). Exactly one id segment: not /records/:id/lock.
+  { method: 'PATCH', pattern: /^\/api\/multitable\/records\/[^/]+$/ },
+  // records:write — POST /patch (batch upsert).
+  { method: 'POST', pattern: /^\/api\/multitable\/patch$/ },
+  // comments:write — POST /api/comments (comment CREATE only). NOT PATCH/DELETE /api/comments/:id (edit/delete).
+  { method: 'POST', pattern: /^\/api\/comments$/ },
+]
+
+/**
+ * True only for an `mst_`-token request whose `(method, path)` matches an OAPI-2a write route. Fail-closed:
+ * a wrong method on a write path, any read path, a non-token bearer, `DELETE` (2b), or any unlisted path →
+ * false → the normal JWT gate (401 for an `mst_` bearer).
+ */
+export function isOapiWriteAllowlistRequest(
+  method: string,
+  path: string,
+  authHeader: string | undefined,
+): boolean {
+  if (!isApiTokenBearer(authHeader)) return false
+  return OAPI_WRITE_ROUTES.some((route) => route.method === method && route.pattern.test(path))
+}
+
+/**
+ * THE single switch the global JWT gate (index.ts) consults: true for any allowlisted OAPI request, read
+ * (GET, OAPI-1) or write (method-bound, OAPI-2a). A match lets an `mst_` bearer skip the JWT gate to reach
+ * the per-route `apiTokenAuth` + `requireScope`; everything else falls through to a 401.
+ */
+export function isOapiAllowlistRequest(method: string, path: string, authHeader: string | undefined): boolean {
+  return (
+    isOapiReadAllowlistRequest(method, path, authHeader) ||
+    isOapiWriteAllowlistRequest(method, path, authHeader)
+  )
+}

--- a/packages/core-backend/src/multitable/oapi-read-allowlist.ts
+++ b/packages/core-backend/src/multitable/oapi-read-allowlist.ts
@@ -91,9 +91,10 @@ const OAPI_WRITE_ROUTES: readonly { method: string; pattern: RegExp }[] = [
 ]
 
 /**
- * True only for an `mst_`-token request whose `(method, path)` matches an OAPI-2a write route. Fail-closed:
- * a wrong method on a write path, any read path, a non-token bearer, `DELETE` (2b), or any unlisted path →
- * false → the normal JWT gate (401 for an `mst_` bearer).
+ * True only for an `mst_`-token request whose `(method, path)` matches an OAPI-2a/2b write route — including
+ * single-record `DELETE /records/:id` (OAPI-2b). Fail-closed: a wrong method on a write path, any read path,
+ * a non-token bearer, an unlisted destructive sibling (`/records/:id/lock`, `/restore`, comment edit/delete),
+ * or any other unlisted path → false → the normal JWT gate (401 for an `mst_` bearer).
  */
 export function isOapiWriteAllowlistRequest(
   method: string,

--- a/packages/core-backend/src/multitable/oapi-read-allowlist.ts
+++ b/packages/core-backend/src/multitable/oapi-read-allowlist.ts
@@ -72,7 +72,7 @@ export function isOapiReadAllowlistRequest(method: string, path: string, authHea
  * `requireScope` (univer-meta.ts / comments.ts) — the same over-match hazard as the read list: an entry
  * without a mounted `requireScope` is a silent no-auth bypass (`requireScope` fail-opens with no scopes).
  *
- * `DELETE /records/:id` is intentionally **absent** — it is OAPI-2b, gated after 2a (design-lock §4). So are
+ * `DELETE /records/:id` is included as OAPI-2b (single-record SOFT delete; design-lock §4). Still **absent**:
  * `/records/:id/lock`, `/records/:id/restore`, comment edit/delete (`PATCH`/`DELETE /api/comments/:id`), and
  * the public-form submit path `POST /api/multitable/views/:id/submit` (its own `publicToken` gate, disjoint).
  */
@@ -81,6 +81,9 @@ const OAPI_WRITE_ROUTES: readonly { method: string; pattern: RegExp }[] = [
   { method: 'POST', pattern: /^\/api\/multitable\/records$/ },
   // records:write — PATCH /records/:recordId (update). Exactly one id segment: not /records/:id/lock.
   { method: 'PATCH', pattern: /^\/api\/multitable\/records\/[^/]+$/ },
+  // records:write — DELETE /records/:recordId (OAPI-2b: single-record SOFT delete only). Exactly one id
+  // segment: not /records/:id/lock. No bulk-by-filter endpoint exists; hard purge stays session/admin-only.
+  { method: 'DELETE', pattern: /^\/api\/multitable\/records\/[^/]+$/ },
   // records:write — POST /patch (batch upsert).
   { method: 'POST', pattern: /^\/api\/multitable\/patch$/ },
   // comments:write — POST /api/comments (comment CREATE only). NOT PATCH/DELETE /api/comments/:id (edit/delete).

--- a/packages/core-backend/src/multitable/oapi-write-audit.ts
+++ b/packages/core-backend/src/multitable/oapi-write-audit.ts
@@ -1,0 +1,164 @@
+/**
+ * OAPI-2a token-write audit — the two-layer model (design-lock
+ * `docs/development/multitable-oapi2-write-designlock-20260628.md` §6 / §10.7, RATIFIED).
+ *
+ * Because a denial never commits, a single post-commit hook cannot capture it. So:
+ *   - COMMITTED writes are audited by an INSERT **inside the mutation transaction** (the record/comment
+ *     services), via {@link insertCommittedAuditInTxn} / {@link insertCommittedAuditKysely}. If that INSERT
+ *     throws, the surrounding transaction rolls back → the write fails closed. The committed row IS the
+ *     audit (no separate route-boundary "committed" row → no double-audit).
+ *   - DENIED / ERROR / RATE_LIMITED attempts are audited best-effort at the route boundary via
+ *     {@link oapiWriteAuditBoundary} (a `res.on('finish')` listener that fires after the response). A failed
+ *     write here ALERTS (never silently drops) — there is no mutation txn to roll back.
+ *
+ * Every control here is a STRICT NO-OP for session (non-token) requests: the boundary skips when there is no
+ * `req.apiTokenId`, and the in-txn insert fires only when the service receives an `OapiWriteAuditContext`.
+ */
+import { sql } from 'kysely'
+import type { Request, Response, NextFunction } from 'express'
+import { Logger } from '../core/logger'
+import { db } from '../db/db'
+import { redactString } from './automation-log-redact'
+
+const logger = new Logger('OapiWriteAudit')
+
+export type OapiWriteOperation = 'create' | 'update' | 'upsert' | 'delete'
+export type OapiWriteOutcome = 'committed' | 'denied' | 'error' | 'rate_limited'
+
+/** Fixed context for a token write, resolved at the route boundary before the mutation runs. */
+export interface OapiWriteAuditContext {
+  tokenId: string
+  actorId: string
+  operation: OapiWriteOperation
+  scope: string
+  sheetId?: string | null
+  requestId?: string | null
+}
+
+/** Result detail available only for a committed write (already inside the txn). */
+export interface OapiWriteCommittedResult {
+  recordIds?: string[] | null
+  batchCount?: number | null
+  detail?: Record<string, unknown> | null
+}
+
+/** A raw parameterized query fn — matches the `query` handle from `pool.transaction({ query })`. */
+export type TxnQuery = (text: string, params?: readonly unknown[]) => Promise<unknown>
+
+/**
+ * Build a committed-write audit context from the request. Returns `null` for non-token (session) requests,
+ * which is the signal for callers to skip the in-txn audit entirely (no-op for session writes).
+ */
+export function buildOapiAuditContext(
+  req: Request,
+  operation: OapiWriteOperation,
+  scope: string,
+): OapiWriteAuditContext | null {
+  if (!req.apiTokenId || !req.apiTokenUserId) return null
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const params = (req.params ?? {}) as Record<string, unknown>
+  const sheetId =
+    (typeof body.sheetId === 'string' && body.sheetId) ||
+    (typeof params.sheetId === 'string' && params.sheetId) ||
+    null
+  const requestId = typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : null
+  return { tokenId: req.apiTokenId, actorId: req.apiTokenUserId, operation, scope, sheetId, requestId }
+}
+
+/**
+ * Insert the COMMITTED audit row using a raw txn `query` handle (record services). MUST be called inside the
+ * mutation transaction, after the mutation succeeds: if it throws, the transaction rolls back (fail-closed).
+ */
+export async function insertCommittedAuditInTxn(
+  query: TxnQuery,
+  ctx: OapiWriteAuditContext,
+  result: OapiWriteCommittedResult,
+): Promise<void> {
+  await query(
+    `INSERT INTO oapi_write_audit
+       (token_id, actor_id, operation, scope, sheet_id, record_ids, batch_count, outcome, status_code, request_id, detail)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'committed', NULL, $8, $9::jsonb)`,
+    [
+      ctx.tokenId,
+      ctx.actorId,
+      ctx.operation,
+      ctx.scope,
+      ctx.sheetId ?? null,
+      result.recordIds && result.recordIds.length ? result.recordIds : null,
+      result.batchCount ?? null,
+      ctx.requestId ?? null,
+      result.detail ? JSON.stringify(result.detail) : null,
+    ],
+  )
+}
+
+/**
+ * Insert the COMMITTED audit row using a Kysely transaction handle (CommentService). Same fail-closed
+ * contract: a throw rolls back the comment-create transaction.
+ */
+export async function insertCommittedAuditKysely(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  trx: any,
+  ctx: OapiWriteAuditContext,
+  result: OapiWriteCommittedResult,
+): Promise<void> {
+  const detail = result.detail ? JSON.stringify(result.detail) : null
+  await sql`
+    INSERT INTO oapi_write_audit
+      (token_id, actor_id, operation, scope, sheet_id, record_ids, batch_count, outcome, status_code, request_id, detail)
+    VALUES (${ctx.tokenId}, ${ctx.actorId}, ${ctx.operation}, ${ctx.scope}, ${ctx.sheetId ?? null},
+            NULL, ${result.batchCount ?? null}, 'committed', NULL, ${ctx.requestId ?? null}, ${detail}::jsonb)
+  `.execute(trx)
+}
+
+/**
+ * Best-effort route-boundary writer for a NON-committed attempt (denied / error / rate_limited), via the
+ * global Kysely `db`. Never throws into the request path; a write failure ALERTS (the lost abuse-signal must
+ * not be silent).
+ */
+export async function recordOapiWriteAttempt(
+  ctx: OapiWriteAuditContext,
+  outcome: Exclude<OapiWriteOutcome, 'committed'>,
+  statusCode: number,
+  detailText?: string,
+): Promise<void> {
+  try {
+    const detail = detailText ? JSON.stringify({ message: redactString(detailText) }) : null
+    await sql`
+      INSERT INTO oapi_write_audit
+        (token_id, actor_id, operation, scope, sheet_id, record_ids, batch_count, outcome, status_code, request_id, detail)
+      VALUES (${ctx.tokenId}, ${ctx.actorId}, ${ctx.operation}, ${ctx.scope}, ${ctx.sheetId ?? null},
+              NULL, NULL, ${outcome}, ${statusCode}, ${ctx.requestId ?? null}, ${detail}::jsonb)
+    `.execute(db)
+  } catch (err) {
+    logger.error(
+      `[ALERT] failed to persist ${outcome} OAPI write attempt (token=${ctx.tokenId} op=${ctx.operation} status=${statusCode}); abuse-signal lost`,
+      err instanceof Error ? err : undefined,
+    )
+  }
+}
+
+/**
+ * Outermost route middleware: registers a `res.on('finish')` listener that audits a NON-2xx token-write
+ * outcome (denied 403 / rate_limited 429 / error 5xx) at the boundary. A 2xx is skipped — that committed
+ * write was already audited in-txn by the service (mutual exclusivity → no double-audit). No-op for session
+ * (non-token) requests. Mount AFTER `apiTokenAuth` (so `apiTokenId` is set) and BEFORE `requireScope` /
+ * the limiter (so their 403/429 are observed).
+ */
+export function oapiWriteAuditBoundary(operation: OapiWriteOperation, scope: string) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const ctx = buildOapiAuditContext(req, operation, scope)
+    if (!ctx) {
+      next()
+      return
+    }
+    res.on('finish', () => {
+      const sc = res.statusCode
+      if (sc >= 200 && sc < 300) return // committed — audited in-txn
+      const outcome: Exclude<OapiWriteOutcome, 'committed'> =
+        sc === 429 ? 'rate_limited' : sc === 403 ? 'denied' : 'error'
+      void recordOapiWriteAttempt(ctx, outcome, sc)
+    })
+    next()
+  }
+}

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -204,6 +204,8 @@ export type RecordDeleteInput = {
   resolveSheetAccess: (
     sheetId: string,
   ) => Promise<{ capabilities: MultitableCapabilities; sheetScope?: SheetPermissionScope }>
+  /** OAPI-2b (§6): present only for a token delete → committed audit row inserted IN-TXN (fail-closed). No-op for session. */
+  oapiAudit?: OapiWriteAuditContext
 }
 
 export type RecordDeleteResult = {
@@ -841,6 +843,11 @@ export class RecordService {
 
       // lock-guarded: single DELETE — ensureRecordNotLocked enforced above (rejects before this txn).
       await query('DELETE FROM meta_records WHERE id = $1', [recordId])
+
+      // OAPI-2b §6: committed token-delete audit INSIDE the (soft-)delete txn (fail-closed). No-op for session.
+      if (input.oapiAudit) {
+        await insertCommittedAuditInTxn(query, input.oapiAudit, { recordIds: [recordId] })
+      }
     })
 
     publishMultitableSheetRealtime({

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -19,6 +19,7 @@ import {
   type MultitableField,
 } from './field-codecs'
 import { createPersonMemberResolver, personRestrictGroupIds } from './person-field-restriction'
+import { insertCommittedAuditInTxn, type OapiWriteAuditContext } from './oapi-write-audit'
 import {
   HierarchyCycleError,
   assertNoHierarchyParentCycle,
@@ -185,6 +186,8 @@ export type RecordCreateInput = {
   data: Record<string, unknown>
   actorId: string | null
   capabilities: MultitableCapabilities
+  /** OAPI-2a (§6): present only for a token write → committed audit row inserted IN-TXN (fail-closed). No-op for session. */
+  oapiAudit?: OapiWriteAuditContext
 }
 
 export type RecordCreateResult = {
@@ -217,6 +220,8 @@ export type RecordPatchInput = {
   access: AccessInfo
   capabilities: MultitableCapabilities
   sheetScope?: SheetPermissionScope
+  /** OAPI-2a (§6): present only for a token write → committed audit row inserted IN-TXN (fail-closed). No-op for session. */
+  oapiAudit?: OapiWriteAuditContext
 }
 
 export type RecordPatchResult = {
@@ -690,6 +695,11 @@ export class RecordService {
         patch,
         snapshot: patch,
       })
+
+      // OAPI-2a §6: committed token-write audit INSIDE the create txn (fail-closed). No-op for session.
+      if (input.oapiAudit) {
+        await insertCommittedAuditInTxn(query, input.oapiAudit, { recordIds: [recordId] })
+      }
 
       return inserted
     })
@@ -1318,6 +1328,12 @@ export class RecordService {
         if (ids.length === 0) {
           await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [fieldId, recordId])
         }
+      }
+
+      // OAPI-2a §6: committed token-write audit INSIDE the patch txn (fail-closed); fires on a successful
+      // PATCH whether or not fields changed. No-op for session (no oapiAudit).
+      if (input.oapiAudit) {
+        await insertCommittedAuditInTxn(query, input.oapiAudit, { recordIds: [recordId] })
       }
     })
 

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -38,6 +38,7 @@ import {
   type NotifyRecordSubscribersInput,
 } from './record-subscription-service'
 import { ensureRecordNotLocked } from './record-lock'
+import { insertCommittedAuditInTxn, type OapiWriteAuditContext } from './oapi-write-audit'
 
 // ---------------------------------------------------------------------------
 // Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
@@ -253,6 +254,12 @@ export interface RecordPatchInput {
    * that doc immediately after would tear out a live editor's state.
    */
   source?: RecordPostCommitContext['source']
+  /**
+   * OAPI-2a (§6): present only for an `mst_` token write. When set, a `committed` audit row is inserted
+   * INSIDE this patch's mutation transaction, so a failed audit insert rolls the write back (fail-closed).
+   * Absent for session writes → strict no-op (the session write path is unchanged).
+   */
+  oapiAudit?: OapiWriteAuditContext
 }
 
 export interface RecordPatchResult {
@@ -997,6 +1004,15 @@ export class RecordWriteService {
         }
 
         updated.push({ recordId, version: nextVersion })
+      }
+
+      // OAPI-2a §6: committed token-write audit, INSIDE the mutation txn → a failed insert rolls back the
+      // write (fail-closed). No-op for session writes (no oapiAudit context).
+      if (input.oapiAudit) {
+        await insertCommittedAuditInTxn(query, input.oapiAudit, {
+          recordIds: updated.map((u) => u.recordId),
+          batchCount: updated.length,
+        })
       }
 
       return updated

--- a/packages/core-backend/src/routes/comments.ts
+++ b/packages/core-backend/src/routes/comments.ts
@@ -7,7 +7,7 @@ import { Logger } from '../core/logger'
 import { rbacGuard } from '../rbac/rbac'
 import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
 import { apiTokenWriteRateLimit } from '../middleware/rate-limiter'
-import { oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
+import { buildOapiAuditContext, oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
 import {
   CommentAccessError,
   CommentConflictError,
@@ -334,6 +334,7 @@ export function commentsRouter(injector?: Injector): Router {
         parentId: parsed.data.parentId,
         mentions: parsed.data.mentions,
         authorId: getUserId(req),
+        oapiAudit: buildOapiAuditContext(req, 'create', 'comments:write'),
       })
       return res.status(201).json({ ok: true, data: { comment } })
     } catch (error) {

--- a/packages/core-backend/src/routes/comments.ts
+++ b/packages/core-backend/src/routes/comments.ts
@@ -6,6 +6,7 @@ import { ICommentService, type CommentQueryOptions } from '../di/identifiers'
 import { Logger } from '../core/logger'
 import { rbacGuard } from '../rbac/rbac'
 import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
+import { apiTokenWriteRateLimit } from '../middleware/rate-limiter'
 import {
   CommentAccessError,
   CommentConflictError,
@@ -294,7 +295,7 @@ export function commentsRouter(injector?: Injector): Router {
     }
   })
 
-  router.post('/api/comments', rbacGuard('comments', 'write'), async (req: Request, res: Response) => {
+  router.post('/api/comments', apiTokenAuth, requireScope('comments:write'), apiTokenWriteRateLimit, rbacGuard('comments', 'write'), async (req: Request, res: Response) => {
     const schema = z.object({
       spreadsheetId: z.string().min(1).optional(),
       containerId: z.string().min(1).optional(),

--- a/packages/core-backend/src/routes/comments.ts
+++ b/packages/core-backend/src/routes/comments.ts
@@ -7,6 +7,7 @@ import { Logger } from '../core/logger'
 import { rbacGuard } from '../rbac/rbac'
 import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
 import { apiTokenWriteRateLimit } from '../middleware/rate-limiter'
+import { oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
 import {
   CommentAccessError,
   CommentConflictError,
@@ -295,7 +296,7 @@ export function commentsRouter(injector?: Injector): Router {
     }
   })
 
-  router.post('/api/comments', apiTokenAuth, requireScope('comments:write'), apiTokenWriteRateLimit, rbacGuard('comments', 'write'), async (req: Request, res: Response) => {
+  router.post('/api/comments', apiTokenAuth, oapiWriteAuditBoundary('create', 'comments:write'), requireScope('comments:write'), apiTokenWriteRateLimit, rbacGuard('comments', 'write'), async (req: Request, res: Response) => {
     const schema = z.object({
       spreadsheetId: z.string().min(1).optional(),
       containerId: z.string().min(1).optional(),

--- a/packages/core-backend/src/routes/comments.ts
+++ b/packages/core-backend/src/routes/comments.ts
@@ -296,7 +296,7 @@ export function commentsRouter(injector?: Injector): Router {
     }
   })
 
-  router.post('/api/comments', apiTokenAuth, oapiWriteAuditBoundary('create', 'comments:write'), requireScope('comments:write'), apiTokenWriteRateLimit, rbacGuard('comments', 'write'), async (req: Request, res: Response) => {
+  router.post('/api/comments', apiTokenAuth, oapiWriteAuditBoundary('create', 'comments:write'), apiTokenWriteRateLimit, requireScope('comments:write'), rbacGuard('comments', 'write'), async (req: Request, res: Response) => {
     const schema = z.object({
       spreadsheetId: z.string().min(1).optional(),
       containerId: z.string().min(1).optional(),

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -13611,7 +13611,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.patch('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('update', 'records:write'), requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
+  router.patch('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('update', 'records:write'), apiTokenWriteRateLimit, requireScope('records:write'), async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
     if (!recordId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
@@ -14624,7 +14624,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.post('/records', apiTokenAuth, oapiWriteAuditBoundary('create', 'records:write'), requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
+  router.post('/records', apiTokenAuth, oapiWriteAuditBoundary('create', 'records:write'), apiTokenWriteRateLimit, requireScope('records:write'), async (req: Request, res: Response) => {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),
@@ -14886,7 +14886,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.delete('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('delete', 'records:write'), requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
+  router.delete('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('delete', 'records:write'), apiTokenWriteRateLimit, requireScope('records:write'), async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId : ''
     if (!recordId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
@@ -15167,7 +15167,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.post('/patch', apiTokenAuth, oapiWriteAuditBoundary('upsert', 'records:write'), requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
+  router.post('/patch', apiTokenAuth, oapiWriteAuditBoundary('upsert', 'records:write'), apiTokenWriteRateLimit, requireScope('records:write'), async (req: Request, res: Response) => {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -156,7 +156,7 @@ import { validateRecord, getDefaultValidationRules } from '../multitable/field-v
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value, isPersonSingleRecord, isRichLongTextProperty, normalizeMultiSelectValue, richLongTextToPlainText, validateLongTextValue, validatePersonValue } from '../multitable/field-codecs'
 import { apiTokenWriteRateLimit, conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
-import { oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
+import { buildOapiAuditContext, oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
 import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
 import {
   AutomationRuleValidationError,
@@ -13671,6 +13671,7 @@ export function univerMetaRouter(): Router {
         access,
         capabilities,
         sheetScope,
+        oapiAudit: buildOapiAuditContext(req, 'update', 'records:write'),
       })
       const fields = patchResult.fields
       const nextVersion = patchResult.version
@@ -14657,6 +14658,7 @@ export function univerMetaRouter(): Router {
         capabilities,
         actorId: getRequestActorId(req),
         data,
+        oapiAudit: buildOapiAuditContext(req, 'create', 'records:write'),
       })
 
       // F4 (#2106 §3 F4): the create echo previously returned result.data UNMASKED, so a field_permissions-
@@ -15260,6 +15262,7 @@ export function univerMetaRouter(): Router {
               capabilities,
               sheetScope,
               access,
+              oapiAudit: buildOapiAuditContext(req, 'upsert', 'records:write'),
             })
             updated.push(...result.updated)
             if (result.records) records.push(...(result.records as Array<{ recordId: string; data: Record<string, unknown> }>))
@@ -15302,6 +15305,7 @@ export function univerMetaRouter(): Router {
         capabilities,
         sheetScope,
         access,
+        oapiAudit: buildOapiAuditContext(req, 'upsert', 'records:write'),
       })
 
       return res.json({

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -14886,7 +14886,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.delete('/records/:recordId', async (req: Request, res: Response) => {
+  router.delete('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('delete', 'records:write'), requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId : ''
     if (!recordId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
@@ -14911,6 +14911,7 @@ export function univerMetaRouter(): Router {
           const { capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
           return { capabilities, ...(sheetScope ? { sheetScope } : {}) }
         },
+        oapiAudit: buildOapiAuditContext(req, 'delete', 'records:write'),
       })
 
       return res.json({ ok: true, data: { deleted: recordId } })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -155,7 +155,7 @@ import { FormulaEngine } from '../formula/engine'
 import { validateRecord, getDefaultValidationRules } from '../multitable/field-validation-engine'
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value, isPersonSingleRecord, isRichLongTextProperty, normalizeMultiSelectValue, richLongTextToPlainText, validateLongTextValue, validatePersonValue } from '../multitable/field-codecs'
-import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
+import { apiTokenWriteRateLimit, conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
 import {
   AutomationRuleValidationError,
@@ -13610,7 +13610,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.patch('/records/:recordId', async (req: Request, res: Response) => {
+  router.patch('/records/:recordId', apiTokenAuth, requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
     if (!recordId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
@@ -14622,7 +14622,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.post('/records', async (req: Request, res: Response) => {
+  router.post('/records', apiTokenAuth, requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),
@@ -15163,7 +15163,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.post('/patch', async (req: Request, res: Response) => {
+  router.post('/patch', apiTokenAuth, requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -156,6 +156,7 @@ import { validateRecord, getDefaultValidationRules } from '../multitable/field-v
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value, isPersonSingleRecord, isRichLongTextProperty, normalizeMultiSelectValue, richLongTextToPlainText, validateLongTextValue, validatePersonValue } from '../multitable/field-codecs'
 import { apiTokenWriteRateLimit, conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
+import { oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
 import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
 import {
   AutomationRuleValidationError,
@@ -13610,7 +13611,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.patch('/records/:recordId', apiTokenAuth, requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
+  router.patch('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('update', 'records:write'), requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
     if (!recordId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
@@ -14622,7 +14623,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.post('/records', apiTokenAuth, requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
+  router.post('/records', apiTokenAuth, oapiWriteAuditBoundary('create', 'records:write'), requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),
@@ -15163,7 +15164,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.post('/patch', apiTokenAuth, requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
+  router.post('/patch', apiTokenAuth, oapiWriteAuditBoundary('upsert', 'records:write'), requireScope('records:write'), apiTokenWriteRateLimit, async (req: Request, res: Response) => {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -14,6 +14,7 @@ import type { CollabService } from './CollabService'
 import { db } from '../db/db'
 import { nowTimestamp } from '../db/type-helpers'
 import { buildCommentInboxRoom, buildCommentRecordRoom, buildCommentSheetRoom } from './commentRooms'
+import { insertCommittedAuditKysely, type OapiWriteAuditContext } from '../multitable/oapi-write-audit'
 import { notifyRecordSubscribersWithKysely } from '../multitable/record-subscription-service'
 
 /**
@@ -265,6 +266,8 @@ export class CommentService {
     authorId: string
     parentId?: string
     mentions?: string[]
+    /** OAPI-2a (§6): present only for a token comment-create → committed audit row inserted atomically with the comment (fail-closed). No-op for session. */
+    oapiAudit?: OapiWriteAuditContext
   }): Promise<Comment> {
     const id = `cmt_${randomUUID()}`
     const mentions = this.normalizeMentions(data.mentions ?? this.parseMentions(data.content))
@@ -298,25 +301,33 @@ export class CommentService {
       }
     }
 
-    await db
-      .insertInto('meta_comments')
-      .values({
-        id,
-        spreadsheet_id: data.spreadsheetId,
-        row_id: data.rowId,
-        field_id: effectiveFieldId ?? null,
-        target_type: 'meta_record',
-        target_id: data.rowId,
-        target_field_id: effectiveFieldId ?? null,
-        container_type: 'meta_sheet',
-        container_id: data.spreadsheetId,
-        content: data.content,
-        author_id: data.authorId,
-        parent_id: data.parentId ?? null,
-        resolved: false,
-        mentions: JSON.stringify(mentions),
+    const commentValues = {
+      id,
+      spreadsheet_id: data.spreadsheetId,
+      row_id: data.rowId,
+      field_id: effectiveFieldId ?? null,
+      target_type: 'meta_record',
+      target_id: data.rowId,
+      target_field_id: effectiveFieldId ?? null,
+      container_type: 'meta_sheet',
+      container_id: data.spreadsheetId,
+      content: data.content,
+      author_id: data.authorId,
+      parent_id: data.parentId ?? null,
+      resolved: false,
+      mentions: JSON.stringify(mentions),
+    }
+    if (data.oapiAudit) {
+      // OAPI-2a §6: a token comment-create + its committed audit row are atomic (fail-closed) — a failed
+      // audit insert rolls back the comment. Session creates take the unchanged bare insert below.
+      const auditCtx = data.oapiAudit
+      await db.transaction().execute(async (trx) => {
+        await trx.insertInto('meta_comments').values(commentValues).execute()
+        await insertCommittedAuditKysely(trx, auditCtx, { detail: { commentId: id } })
       })
-      .execute()
+    } else {
+      await db.insertInto('meta_comments').values(commentValues).execute()
+    }
 
     const comment = await this.getComment(id)
     if (!comment) {

--- a/packages/core-backend/tests/integration/multitable-oapi1-token-read-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi1-token-read-realdb.test.ts
@@ -122,11 +122,15 @@ describeIfDatabase('OAPI-1 read-only API-token routes (real DB)', () => {
     expect(ids).not.toContain(REC_SECRET) // creator (non-admin) is denied this row → token is too
   })
 
-  test('READ-ONLY — the same token on a write route (POST /patch) is rejected', async () => {
+  test('READ-ONLY SCOPE — a records:read token on a write route (POST /patch) is rejected with 403 (OAPI-2a)', async () => {
+    // OAPI-2a mounts apiTokenAuth + requireScope('records:write') on POST /patch, so a records:read token now
+    // reaches requireScope and is rejected for INSUFFICIENT_SCOPE (403) — previously 401 (no auth mounted).
+    // The intent is unchanged: a read-scoped token still cannot mutate.
     const res = await request(app).post('/api/multitable/patch')
       .set('Authorization', `Bearer ${tokReadOk}`)
       .send({ sheetId: SHEET_ID, changes: [{ recordId: REC_OPEN, fieldId: STATUS, value: 'hacked' }] })
-    expect(res.status).toBe(401) // no apiTokenAuth on write → actor unset → rejected
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(res.body)).toContain('INSUFFICIENT_SCOPE')
     const check = await q('SELECT data FROM meta_records WHERE id = $1', [REC_OPEN])
     expect((check.rows[0] as { data?: Record<string, unknown> })?.data?.[STATUS]).toBe('open') // unchanged
   })

--- a/packages/core-backend/tests/integration/multitable-oapi2a-comments-write-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi2a-comments-write-realdb.test.ts
@@ -1,0 +1,125 @@
+/**
+ * OAPI-2a — comments:write token comment-create (real DB, full server).
+ *
+ * The comment path is a SEPARATE write surface from records (its own router + CommentService + Kysely
+ * transaction), so it needs its own golden. Proves, through the full MetaSheetServer (the global gate +
+ * the route's apiTokenAuth → rate-limit → requireScope → rbacGuard chain):
+ *   - comments:write token → POST /api/comments → 2xx + a COMMITTED audit row (operation=create,
+ *     scope=comments:write, actor=creator) — the Kysely in-txn audit path;
+ *   - wrong scope (records:read) → 403 INSUFFICIENT_SCOPE + a DENIED audit row + NO comment;
+ *   - revoked → 401, no comment.
+ * Runs only with DATABASE_URL.
+ */
+import net from 'net'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { ApiTokenService } from '../../src/multitable/api-token-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const CREATOR = `user_oapi2cw_${TS}`
+const SHEET = `sheet_oapi2cw_${TS}`
+const ROW = `rec_oapi2cw_${TS}`
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+
+describeIfDatabase('OAPI-2a comments:write token comment-create (real DB, full server)', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let tokWrite = ''
+  let tokWriteId = ''
+  let tokWrongScope = ''
+  let tokWrongScopeId = ''
+  let tokRevoked = ''
+
+  const postComment = (token: string, body: unknown) =>
+    fetch(`${base}/api/comments`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  const commentCount = async (): Promise<number> =>
+    Number(((await q('SELECT COUNT(*)::int AS n FROM meta_comments WHERE spreadsheet_id = $1', [SHEET])).rows[0] as { n: number }).n)
+  const auditRows = async (
+    tokenId: string,
+  ): Promise<Array<{ operation: string; outcome: string; status_code: number | null; scope: string; actor_id: string }>> =>
+    (await q('SELECT operation, outcome, status_code, scope, actor_id FROM oapi_write_audit WHERE token_id = $1', [tokenId]))
+      .rows as Array<{ operation: string; outcome: string; status_code: number | null; scope: string; actor_id: string }>
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    // Admin creator so rbacGuard('comments','write') passes for the success path; the comments-RBAC min-spine
+    // is already covered by the OAPI-1 comments golden. (rbacGuard runs AFTER requireScope for the 403 case.)
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1,$2,$3,'x','member',$4::jsonb, TRUE, TRUE)
+       ON CONFLICT (id) DO UPDATE SET is_admin = TRUE`,
+      [CREATOR, `${CREATOR}@t.local`, 'CmtWriter', JSON.stringify(['comments:write'])],
+    )
+
+    const svc = new ApiTokenService(db)
+    const w = await svc.createToken(CREATOR, { name: 'cw', scopes: ['comments:write'] })
+    tokWrite = w.plainTextToken
+    tokWriteId = w.token.id
+    const ws = await svc.createToken(CREATOR, { name: 'rr', scopes: ['records:read'] })
+    tokWrongScope = ws.plainTextToken
+    tokWrongScopeId = ws.token.id
+    const rv = await svc.createToken(CREATOR, { name: 'rv', scopes: ['comments:write'] })
+    tokRevoked = rv.plainTextToken
+    await svc.revokeToken(rv.token.id, CREATOR)
+
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+  })
+
+  afterAll(async () => {
+    await db.deleteFrom('multitable_api_tokens').where('created_by', '=', CREATOR).execute().catch(() => {})
+    await q('DELETE FROM oapi_write_audit WHERE token_id = ANY($1::text[])', [[tokWriteId, tokWrongScopeId]]).catch(() => {})
+    await q('DELETE FROM meta_comments WHERE spreadsheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [CREATOR]).catch(() => {})
+    if (server) await server.stop()
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('comments:write → POST /api/comments 2xx + committed audit (operation=create, scope=comments:write)', async () => {
+    const before = await commentCount()
+    const res = await postComment(tokWrite, { spreadsheetId: SHEET, rowId: ROW, content: 'hello from token' })
+    expect([200, 201]).toContain(res.status)
+    expect(await commentCount()).toBe(before + 1)
+    const committed = (await auditRows(tokWriteId)).filter(
+      (r) => r.outcome === 'committed' && r.operation === 'create' && r.scope === 'comments:write',
+    )
+    expect(committed.length).toBeGreaterThanOrEqual(1)
+    expect(committed[0].actor_id).toBe(CREATOR) // acts-as-creator
+  })
+
+  test('wrong scope (records:read) → 403 INSUFFICIENT_SCOPE + denied audit + no comment', async () => {
+    const before = await commentCount()
+    const res = await postComment(tokWrongScope, { spreadsheetId: SHEET, rowId: ROW, content: 'should not exist' })
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(await res.json())).toContain('INSUFFICIENT_SCOPE')
+    expect(await commentCount()).toBe(before)
+    await new Promise((r) => setTimeout(r, 100)) // boundary finish-listener flush
+    expect((await auditRows(tokWrongScopeId)).some((r) => r.outcome === 'denied' && r.status_code === 403)).toBe(true)
+  })
+
+  test('revoked token → 401, no comment', async () => {
+    const before = await commentCount()
+    expect((await postComment(tokRevoked, { spreadsheetId: SHEET, rowId: ROW, content: 'x' })).status).toBe(401)
+    expect(await commentCount()).toBe(before)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-oapi2a-ratelimit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi2a-ratelimit-realdb.test.ts
@@ -1,0 +1,85 @@
+/**
+ * OAPI-2a — wrong-scope write attempts ARE rate-limited (real DB).
+ *
+ * Regression guard for the review P1: the per-token limiter runs BEFORE `requireScope`, so a `records:read`
+ * token cannot hammer a write route unbounded. Within the per-token cap each attempt 403s (denied audit);
+ * beyond the cap it is 429 (rate_limited audit) — proving rate-limiting covers ALL token write attempts, not
+ * only scope-correct ones.
+ *
+ * The 600/min cap is lowered via `OAPI_WRITE_RATE_LIMIT_MAX` (read when the rate-limiter module loads), set
+ * BEFORE the dynamic `univerMetaRouter` import so the limiter constructs with the low cap. Runs only with
+ * DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { db } from '../../src/db/db'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApiTokenService } from '../../src/multitable/api-token-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_oapi2rl_${TS}`
+const SHEET_ID = `sheet_oapi2rl_${TS}`
+const CREATOR = `user_oapi2rl_${TS}`
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let tokRead = ''
+let tokReadId = ''
+
+describeIfDatabase('OAPI-2a wrong-scope writes are rate-limited (real DB)', () => {
+  beforeAll(async () => {
+    process.env.OAPI_WRITE_RATE_LIMIT_MAX = '2' // low cap; read when the rate-limiter module loads below
+    const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+    app = express()
+    app.use(express.json())
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1,$2,$3,'x','member',$4::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET permissions = EXCLUDED.permissions`,
+      [CREATOR, `${CREATOR}@t.local`, CREATOR, JSON.stringify(['multitable:write'])],
+    )
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'rl'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'rl'])
+
+    const svc = new ApiTokenService(db)
+    const r = await svc.createToken(CREATOR, { name: 'read', scopes: ['records:read'] })
+    tokRead = r.plainTextToken
+    tokReadId = r.token.id
+  })
+
+  afterAll(async () => {
+    delete process.env.OAPI_WRITE_RATE_LIMIT_MAX
+    await db.deleteFrom('multitable_api_tokens').where('created_by', '=', CREATOR).execute().catch(() => {})
+    await q('DELETE FROM oapi_write_audit WHERE token_id = $1', [tokReadId]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [CREATOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('records:read token hammering POST /records is capped per-token (403 within cap, 429 beyond)', async () => {
+    const hit = () =>
+      request(app)
+        .post('/api/multitable/records')
+        .set('Authorization', `Bearer ${tokRead}`)
+        .send({ sheetId: SHEET_ID, data: {} })
+    const r1 = await hit()
+    const r2 = await hit()
+    const r3 = await hit()
+    expect(r1.status).toBe(403) // within cap (2): limiter passes → requireScope → 403 (denied)
+    expect(r2.status).toBe(403)
+    expect(r3.status).toBe(429) // 3rd exceeds the cap → rate-limited BEFORE requireScope
+    await new Promise((res) => setTimeout(res, 100)) // let the boundary res.on('finish') listeners flush
+    const rows = (await q('SELECT outcome, status_code FROM oapi_write_audit WHERE token_id = $1', [tokReadId]))
+      .rows as Array<{ outcome: string; status_code: number }>
+    expect(rows.some((x) => x.outcome === 'denied' && x.status_code === 403)).toBe(true)
+    expect(rows.some((x) => x.outcome === 'rate_limited' && x.status_code === 429)).toBe(true)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-oapi2a-ratelimit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi2a-ratelimit-realdb.test.ts
@@ -6,9 +6,9 @@
  * beyond the cap it is 429 (rate_limited audit) — proving rate-limiting covers ALL token write attempts, not
  * only scope-correct ones.
  *
- * The 600/min cap is lowered via `OAPI_WRITE_RATE_LIMIT_MAX` (read when the rate-limiter module loads), set
- * BEFORE the dynamic `univerMetaRouter` import so the limiter constructs with the low cap. Runs only with
- * DATABASE_URL.
+ * The 600/min cap is lowered via `OAPI_WRITE_RATE_LIMIT_MAX`, which the limiter reads PER-REQUEST (runtime
+ * cap) — so it is honored regardless of when the rate-limiter module was first imported in this batched
+ * Vitest invocation (the module-load-time read was unreliable across files). Runs only with DATABASE_URL.
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
@@ -17,6 +17,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { db } from '../../src/db/db'
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { ApiTokenService } from '../../src/multitable/api-token-service'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -30,8 +31,7 @@ let tokReadId = ''
 
 describeIfDatabase('OAPI-2a wrong-scope writes are rate-limited (real DB)', () => {
   beforeAll(async () => {
-    process.env.OAPI_WRITE_RATE_LIMIT_MAX = '2' // low cap; read when the rate-limiter module loads below
-    const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+    process.env.OAPI_WRITE_RATE_LIMIT_MAX = '2' // runtime cap (read per-request) — independent of import timing
     app = express()
     app.use(express.json())
     app.use('/api/multitable', univerMetaRouter())

--- a/packages/core-backend/tests/integration/multitable-oapi2a-token-write-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi2a-token-write-realdb.test.ts
@@ -144,6 +144,19 @@ describeIfDatabase('OAPI-2a token WRITE routes (real DB)', () => {
     expect((await auditRows(tokWriteId)).some((r) => r.outcome === 'committed' && r.operation === 'upsert')).toBe(true)
   })
 
+  test('OAPI-2b: records:write → DELETE /records/:id soft-deletes + committed audit (operation=delete); wrong-scope 403', async () => {
+    const REC_DEL = `rec_oapi2b_del_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_DEL, SHEET_ID, JSON.stringify({ [STATUS]: 'to-delete' })])
+    // wrong scope → 403, record still present (no destructive action without records:write)
+    expect((await request(app).delete(`/api/multitable/records/${REC_DEL}`).set('Authorization', `Bearer ${tokWrongScope}`)).status).toBe(403)
+    expect((await q('SELECT 1 FROM meta_records WHERE id = $1', [REC_DEL])).rows.length).toBe(1)
+    // records:write → soft delete (removed from the live table → trash; not a hard purge)
+    const res = await request(app).delete(`/api/multitable/records/${REC_DEL}`).set('Authorization', `Bearer ${tokWrite}`)
+    expect([200, 204]).toContain(res.status)
+    expect((await q('SELECT 1 FROM meta_records WHERE id = $1', [REC_DEL])).rows.length).toBe(0)
+    expect((await auditRows(tokWriteId)).some((r) => r.outcome === 'committed' && r.operation === 'delete')).toBe(true)
+  })
+
   test('wrong scope (records:read) → POST /records 403 + NO create + a denied audit row', async () => {
     const before = await recordCount()
     const res = await post('/api/multitable/records', tokWrongScope, { sheetId: SHEET_ID, data: { [STATUS]: 'should-not-exist' } })

--- a/packages/core-backend/tests/integration/multitable-oapi2a-token-write-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi2a-token-write-realdb.test.ts
@@ -1,0 +1,188 @@
+/**
+ * OAPI-2a — token WRITE routes (real DB).
+ * Design-lock: docs/development/multitable-oapi2-write-designlock-20260628.md (RATIFIED).
+ *
+ * Proves an `mst_` records:write token mutates AS ITS CREATOR (Option A) through the full write stack, with
+ * deny-by-default scope, revoke, the min(token, creator-RBAC) spine, and the two-layer audit:
+ *   - valid records:write → POST /records / PATCH /records/:id / POST /patch succeed + a COMMITTED audit row
+ *     (operation create/update/upsert; actor_id = creator — acts-as-creator provenance);
+ *   - records:read token (wrong scope) → 403 INSUFFICIENT_SCOPE, NO mutation, + a DENIED audit row (§6 Layer-1);
+ *   - revoked → 401; no token → 401;
+ *   - min spine — creator lacks multitable:write → 403 even WITH records:write scope, NO mutation;
+ *   - fail-closed — when the in-txn committed audit insert fails, the write ROLLS BACK (no record created).
+ *
+ * Rate-limit (600/min/token) and cross-base mirror write-gate are exercised at the unit/design level and by
+ * the shared RecordWriteService gates; a full 600-request loop / cross-base fixture is deferred from this golden.
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { db } from '../../src/db/db'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApiTokenService } from '../../src/multitable/api-token-service'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_oapi2a_${TS}`
+const SHEET_ID = `sheet_oapi2a_${TS}`
+const STATUS = `fld_oapi2a_status_${TS}`
+const REC_SEED = `rec_oapi2a_seed_${TS}`
+const WRITER = `user_oapi2a_writer_${TS}`
+const RO = `user_oapi2a_ro_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let tokWrite = '', tokWriteId = '' // records:write, creator = WRITER (can write)
+let tokWrongScope = '', tokWrongScopeId = '' // records:read only
+let tokRevoked = '' // records:write, then revoked
+let tokRoWrite = '' // records:write, creator = RO (cannot write)
+
+const recordCount = async (): Promise<number> => {
+  const r = await q('SELECT COUNT(*)::int AS n FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
+  return (r.rows[0] as { n: number }).n
+}
+const auditRows = async (
+  tokenId: string,
+): Promise<Array<{ operation: string; outcome: string; status_code: number | null; actor_id: string }>> => {
+  const r = await q(
+    'SELECT operation, outcome, status_code, actor_id FROM oapi_write_audit WHERE token_id = $1 ORDER BY id',
+    [tokenId],
+  )
+  return r.rows as Array<{ operation: string; outcome: string; status_code: number | null; actor_id: string }>
+}
+const post = (path: string, token: string, body: unknown) =>
+  request(app).post(path).set('Authorization', `Bearer ${token}`).send(body)
+
+describeIfDatabase('OAPI-2a token WRITE routes (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    // No fake-user middleware: each route's apiTokenAuth must set the actor from the token itself.
+    app.use('/api/multitable', univerMetaRouter())
+
+    for (const [id, perms] of [
+      [WRITER, ['multitable:write']],
+      [RO, ['multitable:read']],
+    ] as const) {
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1,$2,$3,'x','member',$4::jsonb, TRUE, FALSE)
+         ON CONFLICT (id) DO UPDATE SET permissions = EXCLUDED.permissions`,
+        [id, `${id}@t.local`, id, JSON.stringify(perms)],
+      )
+    }
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'OAPI2a Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'OAPI2a Sheet'])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [STATUS, SHEET_ID, 'Status', 'text', '{}', 1],
+    )
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+      REC_SEED,
+      SHEET_ID,
+      JSON.stringify({ [STATUS]: 'seed' }),
+    ])
+
+    const svc = new ApiTokenService(db)
+    const w = await svc.createToken(WRITER, { name: 'w', scopes: ['records:write'] })
+    tokWrite = w.plainTextToken
+    tokWriteId = w.token.id
+    const ws = await svc.createToken(WRITER, { name: 'ws', scopes: ['records:read'] })
+    tokWrongScope = ws.plainTextToken
+    tokWrongScopeId = ws.token.id
+    const rv = await svc.createToken(WRITER, { name: 'rv', scopes: ['records:write'] })
+    tokRevoked = rv.plainTextToken
+    await svc.revokeToken(rv.token.id, WRITER)
+    const ro = await svc.createToken(RO, { name: 'ro', scopes: ['records:write'] })
+    tokRoWrite = ro.plainTextToken
+  })
+
+  afterAll(async () => {
+    await db.deleteFrom('multitable_api_tokens').where('created_by', 'in', [WRITER, RO]).execute().catch(() => {})
+    await q('DELETE FROM oapi_write_audit WHERE token_id = ANY($1::text[])', [[tokWriteId, tokWrongScopeId]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[WRITER, RO]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('records:write → POST /records creates + a committed audit row (operation=create, actor=creator)', async () => {
+    const before = await recordCount()
+    const res = await post('/api/multitable/records', tokWrite, { sheetId: SHEET_ID, data: { [STATUS]: 'created-by-token' } })
+    expect([200, 201]).toContain(res.status)
+    expect(await recordCount()).toBe(before + 1)
+    const committed = (await auditRows(tokWriteId)).filter((r) => r.outcome === 'committed' && r.operation === 'create')
+    expect(committed.length).toBeGreaterThanOrEqual(1)
+    expect(committed[0].actor_id).toBe(WRITER) // acts-as-creator provenance (Option A)
+  })
+
+  test('records:write → PATCH /records/:id updates + committed audit (operation=update)', async () => {
+    const res = await request(app)
+      .patch(`/api/multitable/records/${REC_SEED}`)
+      .set('Authorization', `Bearer ${tokWrite}`)
+      .send({ sheetId: SHEET_ID, data: { [STATUS]: 'patched' } })
+    expect(res.status).toBe(200)
+    const chk = await q('SELECT data FROM meta_records WHERE id = $1', [REC_SEED])
+    expect((chk.rows[0] as { data: Record<string, unknown> }).data[STATUS]).toBe('patched')
+    expect((await auditRows(tokWriteId)).some((r) => r.outcome === 'committed' && r.operation === 'update')).toBe(true)
+  })
+
+  test('records:write → POST /patch upserts + committed audit (operation=upsert)', async () => {
+    const res = await post('/api/multitable/patch', tokWrite, {
+      sheetId: SHEET_ID,
+      changes: [{ recordId: REC_SEED, fieldId: STATUS, value: 'upserted' }],
+    })
+    expect(res.status).toBe(200)
+    expect((await auditRows(tokWriteId)).some((r) => r.outcome === 'committed' && r.operation === 'upsert')).toBe(true)
+  })
+
+  test('wrong scope (records:read) → POST /records 403 + NO create + a denied audit row', async () => {
+    const before = await recordCount()
+    const res = await post('/api/multitable/records', tokWrongScope, { sheetId: SHEET_ID, data: { [STATUS]: 'should-not-exist' } })
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(res.body)).toContain('INSUFFICIENT_SCOPE')
+    expect(await recordCount()).toBe(before) // no mutation
+    await new Promise((r) => setTimeout(r, 75)) // let the res.on('finish') boundary listener flush
+    expect((await auditRows(tokWrongScopeId)).some((r) => r.outcome === 'denied' && r.status_code === 403)).toBe(true)
+  })
+
+  test('revoked token → POST /records 401, no create', async () => {
+    const before = await recordCount()
+    expect((await post('/api/multitable/records', tokRevoked, { sheetId: SHEET_ID, data: {} })).status).toBe(401)
+    expect(await recordCount()).toBe(before)
+  })
+
+  test('no token → POST /records 401 (auth required)', async () => {
+    const before = await recordCount()
+    expect((await request(app).post('/api/multitable/records').send({ sheetId: SHEET_ID, data: {} })).status).toBe(401)
+    expect(await recordCount()).toBe(before)
+  })
+
+  test('min spine — creator lacks multitable:write → 403 even WITH records:write scope, no create', async () => {
+    const before = await recordCount()
+    const res = await post('/api/multitable/records', tokRoWrite, { sheetId: SHEET_ID, data: { [STATUS]: 'ro-denied' } })
+    expect(res.status).toBe(403) // token scope OK, but the creator's live capability denies → min(token, creator-RBAC)
+    expect(await recordCount()).toBe(before)
+  })
+
+  test('fail-closed — an in-txn committed-audit failure ROLLS BACK the write (no record created)', async () => {
+    const before = await recordCount()
+    // Rename the audit table so the in-txn INSERT throws → the create transaction must roll back.
+    await q('ALTER TABLE oapi_write_audit RENAME TO oapi_write_audit_tmp', [])
+    try {
+      const res = await post('/api/multitable/records', tokWrite, { sheetId: SHEET_ID, data: { [STATUS]: 'should-rollback' } })
+      expect(res.status).toBeGreaterThanOrEqual(500) // audit insert failed inside the txn → 5xx
+      expect(await recordCount()).toBe(before) // fail-closed: NO record persisted
+    } finally {
+      await q('ALTER TABLE oapi_write_audit_tmp RENAME TO oapi_write_audit', [])
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-oapi-read-allowlist.test.ts
+++ b/packages/core-backend/tests/unit/multitable-oapi-read-allowlist.test.ts
@@ -85,6 +85,7 @@ describe('OAPI-2a write-allowlist gate matcher (method-bound)', () => {
   test('ALLOWS: mst_ + the exact write (method, path) pairs', () => {
     expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/records', MST)).toBe(true)
     expect(isOapiWriteAllowlistRequest('PATCH', '/api/multitable/records/rec_1', MST)).toBe(true)
+    expect(isOapiWriteAllowlistRequest('DELETE', '/api/multitable/records/rec_1', MST)).toBe(true) // OAPI-2b
     expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/patch', MST)).toBe(true)
     expect(isOapiWriteAllowlistRequest('POST', '/api/comments', MST)).toBe(true)
   })
@@ -109,8 +110,8 @@ describe('OAPI-2a write-allowlist gate matcher (method-bound)', () => {
   })
 
   test('DENIES: destructive + adjacent + out-of-scope write traps (fail-closed)', () => {
-    // DELETE is OAPI-2b — NOT yet token-exposed
-    expect(isOapiWriteAllowlistRequest('DELETE', '/api/multitable/records/rec_1', MST)).toBe(false)
+    // DELETE /records/:id is now OAPI-2b (allowed above); but DELETE on the collection (no id) is not a route
+    expect(isOapiWriteAllowlistRequest('DELETE', '/api/multitable/records', MST)).toBe(false)
     // collaboration / undelete primitives — not in the matrix
     expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/records/rec_1/lock', MST)).toBe(false)
     expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/sheets/s1/records/rec_1/restore', MST)).toBe(false)
@@ -131,12 +132,13 @@ describe('isOapiAllowlistRequest — union of read (GET) + write (method-bound)'
     expect(isOapiAllowlistRequest('GET', '/api/comments', MST)).toBe(true)
     expect(isOapiAllowlistRequest('POST', '/api/multitable/records', MST)).toBe(true)
     expect(isOapiAllowlistRequest('PATCH', '/api/multitable/records/rec_1', MST)).toBe(true)
+    expect(isOapiAllowlistRequest('DELETE', '/api/multitable/records/rec_1', MST)).toBe(true)
     expect(isOapiAllowlistRequest('POST', '/api/multitable/patch', MST)).toBe(true)
     expect(isOapiAllowlistRequest('POST', '/api/comments', MST)).toBe(true)
   })
 
   test('DENIES the traps in the union (no read/write cross-leak)', () => {
-    expect(isOapiAllowlistRequest('DELETE', '/api/multitable/records/rec_1', MST)).toBe(false)
+    expect(isOapiAllowlistRequest('DELETE', '/api/multitable/records', MST)).toBe(false) // no id → not the 2b delete route
     expect(isOapiAllowlistRequest('POST', '/api/multitable/views/v1/submit', MST)).toBe(false)
     expect(isOapiAllowlistRequest('POST', '/api/multitable/records/rec_1/lock', MST)).toBe(false)
     expect(isOapiAllowlistRequest('PATCH', '/api/comments/cmt_1', MST)).toBe(false)

--- a/packages/core-backend/tests/unit/multitable-oapi-read-allowlist.test.ts
+++ b/packages/core-backend/tests/unit/multitable-oapi-read-allowlist.test.ts
@@ -5,7 +5,12 @@
  */
 import { describe, expect, test } from 'vitest'
 
-import { isApiTokenBearer, isOapiReadAllowlistRequest } from '../../src/multitable/oapi-read-allowlist'
+import {
+  isApiTokenBearer,
+  isOapiAllowlistRequest,
+  isOapiReadAllowlistRequest,
+  isOapiWriteAllowlistRequest,
+} from '../../src/multitable/oapi-read-allowlist'
 
 const MST = 'Bearer mst_abc123'
 const JWT = 'Bearer eyJhbGciOi.x.y'
@@ -73,5 +78,70 @@ describe('OAPI-1 read-allowlist gate matcher', () => {
     expect(isOapiReadAllowlistRequest('GET', '/api/multitable/sheet_1/mention-candidates', MST)).toBe(false)
     // presence is GET-only; a write to it (or any non-GET) is excluded by the method check anyway
     expect(isOapiReadAllowlistRequest('POST', '/api/comments', MST)).toBe(false)
+  })
+})
+
+describe('OAPI-2a write-allowlist gate matcher (method-bound)', () => {
+  test('ALLOWS: mst_ + the exact write (method, path) pairs', () => {
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/records', MST)).toBe(true)
+    expect(isOapiWriteAllowlistRequest('PATCH', '/api/multitable/records/rec_1', MST)).toBe(true)
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/patch', MST)).toBe(true)
+    expect(isOapiWriteAllowlistRequest('POST', '/api/comments', MST)).toBe(true)
+  })
+
+  test('DENIES: non-mst_ bearer → false (normal JWT gate runs)', () => {
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/records', JWT)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/records', undefined)).toBe(false)
+  })
+
+  test('DENIES: GET on a write path (writes are method-bound, never opened for GET)', () => {
+    expect(isOapiWriteAllowlistRequest('GET', '/api/multitable/records', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('GET', '/api/multitable/patch', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('GET', '/api/comments', MST)).toBe(false)
+  })
+
+  test('DENIES: a write method on a READ path (no cross-method over-match)', () => {
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/records-summary', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/view', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('PATCH', '/api/multitable/view', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/sheets/s1/view-aggregate', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/fields', MST)).toBe(false)
+  })
+
+  test('DENIES: destructive + adjacent + out-of-scope write traps (fail-closed)', () => {
+    // DELETE is OAPI-2b — NOT yet token-exposed
+    expect(isOapiWriteAllowlistRequest('DELETE', '/api/multitable/records/rec_1', MST)).toBe(false)
+    // collaboration / undelete primitives — not in the matrix
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/records/rec_1/lock', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/sheets/s1/records/rec_1/restore', MST)).toBe(false)
+    // comment EDIT/DELETE — the matrix is comment-create only
+    expect(isOapiWriteAllowlistRequest('PATCH', '/api/comments/cmt_1', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('DELETE', '/api/comments/cmt_1', MST)).toBe(false)
+    // public-form submit — its own publicToken gate, disjoint (must NEVER be a records:write entry)
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/views/v1/submit', MST)).toBe(false)
+    // POST on a single-record path is not a create route; PATCH on the collection is not an update route
+    expect(isOapiWriteAllowlistRequest('POST', '/api/multitable/records/rec_1', MST)).toBe(false)
+    expect(isOapiWriteAllowlistRequest('PATCH', '/api/multitable/records', MST)).toBe(false)
+  })
+})
+
+describe('isOapiAllowlistRequest — union of read (GET) + write (method-bound)', () => {
+  test('ALLOWS reads and writes', () => {
+    expect(isOapiAllowlistRequest('GET', '/api/multitable/records', MST)).toBe(true)
+    expect(isOapiAllowlistRequest('GET', '/api/comments', MST)).toBe(true)
+    expect(isOapiAllowlistRequest('POST', '/api/multitable/records', MST)).toBe(true)
+    expect(isOapiAllowlistRequest('PATCH', '/api/multitable/records/rec_1', MST)).toBe(true)
+    expect(isOapiAllowlistRequest('POST', '/api/multitable/patch', MST)).toBe(true)
+    expect(isOapiAllowlistRequest('POST', '/api/comments', MST)).toBe(true)
+  })
+
+  test('DENIES the traps in the union (no read/write cross-leak)', () => {
+    expect(isOapiAllowlistRequest('DELETE', '/api/multitable/records/rec_1', MST)).toBe(false)
+    expect(isOapiAllowlistRequest('POST', '/api/multitable/views/v1/submit', MST)).toBe(false)
+    expect(isOapiAllowlistRequest('POST', '/api/multitable/records/rec_1/lock', MST)).toBe(false)
+    expect(isOapiAllowlistRequest('PATCH', '/api/comments/cmt_1', MST)).toBe(false)
+    expect(isOapiAllowlistRequest('POST', '/api/multitable/records-summary', MST)).toBe(false)
+    expect(isOapiAllowlistRequest('GET', '/api/multitable/patch', MST)).toBe(false)
+    expect(isOapiAllowlistRequest('POST', '/api/multitable/records', JWT)).toBe(false)
   })
 })


### PR DESCRIPTION
Implements the **OAPI-2a runtime** + **OAPI-2b DELETE** per the RATIFIED design-lock `docs/development/multitable-oapi2-write-designlock-20260628.md` (#3358) and the owner's `/goal` spec. Exposes 4 write routes (+DELETE) to `mst_` API tokens.

### Scope (token-exposed writes)
`POST /records` · `PATCH /records/:id` · `POST /patch` · `POST /api/comments` (2a) · `DELETE /records/:id` (2b, soft-delete). Each `records:write` / `comments:write`, method-bound.

### The 6 must-do items
- **Method-bound allowlist** — `OAPI_WRITE_ROUTES` (anchored `(method,path)`); the index.ts gate now consults `isOapiAllowlistRequest` (read GET ∪ write). GET-on-write / write-on-read / `/lock` / `/restore` / `/views/:id/submit` / comment-edit all still 401. **+15 unit tests (allowlist 14/14).**
- **Guards** — every route mounts `apiTokenAuth → requireScope(...)` in lockstep with the allowlist; comments keeps `rbacGuard` (min composition).
- **`req.apiTokenId`** plumbed for per-token keying.
- **Per-token rate limit** — 600/min/token, 429; **strict no-op for session** (short-circuits when no `apiTokenId`, avoiding the `userId`/IP fallback).
- **Two-layer audit** (`oapi_write_audit`, purpose-built/unpartitioned) — committed rows inserted **IN-TXN** in the 4 write services (fail-closed: a failed audit insert rolls back the write); denied/error/rate_limited via a `res.on('finish')` route-boundary writer (best-effort + alert). Value-scrubbed (reused `redactString`). Provenance = creator; token shown only in audit.
- **Real-DB goldens** — `multitable-oapi2a-token-write-realdb.test.ts`: create/update/upsert/**delete** → committed audit; wrong-scope→403+denied audit+no-mutation; revoked→401; no-token→401; **min-spine creator-lacks-write→403**; **fail-closed rollback**.

### Safety (blast-radius)
The 4 services are **shared with the session write path**; every control is a **no-op for session writes** (in-txn audit fires only when an `oapiAudit` context is threaded from a token route; limiter skips without `apiTokenId`; `requireScope` fail-opens for non-token). Full core-backend **unit suite 4081 passed / 309 files, tsc clean** — zero regression. Also fixes the OAPI-1 golden (read token on POST /patch now 403 via the new requireScope, not 401).

### Deferred (noted)
Rate-limit 600-loop golden + cross-base mirror-gate golden (the gate is inherited via the shared RecordWriteService). OAPI-3 (`webhooks:manage`), OAPI-4 (per-base scoping) remain separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)