### PR TITLE
feat(multitable): PLMAdapter sends Idempotency-Key + re-add amended BOM write-back pact interaction

### DIFF
--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -1,4 +1,5 @@
 import { Optional } from '@wendellhu/redi'
+import { randomUUID } from 'node:crypto'
 import { IConfigService, ILogger } from '../di/identifiers'
 import { HTTPAdapter } from './HTTPAdapter'
 import type { QueryResult, DataSourceConfig } from './BaseAdapter'
@@ -2198,7 +2199,9 @@ export class PLMAdapter extends HTTPAdapter {
    * context boundary, `bomLineId` selects the row). THIN consumer contract: the payload is restricted
    * to the four editable business cells (quantity / uom / find_num / refdes), an empty patch (nothing
    * changed) is REJECTED before any mock/network branch, any non-whitelisted key is stripped, and the
-   * success envelope is the minimal { ok, bom_line_id }. Permission/unauthorized (403) and the
+   * success envelope is the minimal { ok, bom_line_id }. Each governed write mints a FRESH per-edit
+   * Idempotency-Key (randomUUID) sent as a request header, so the GOVERNED provider (Yuantus #905) can
+   * dedupe a retried write without applying it twice. Permission/unauthorized (403) and the
    * provider's line∈part validation are intentionally OUT of this consumer contract; success-only.
    */
   async updateBomMultitableLine(
@@ -2233,9 +2236,15 @@ export class PLMAdapter extends HTTPAdapter {
       return { data: [], error: new Error('BOM multitable line write-back is not supported for this PLM API mode') }
     }
 
+    // Mint a fresh per-edit Idempotency-Key so the governed provider (Yuantus #905) can dedupe a
+    // retried write without applying it twice. It rides as a request header alongside the axios
+    // instance's auth/tenant defaults, which HTTPAdapter.select merges in.
+    const idempotencyKey = randomUUID()
+
     return this.select<BomMultitableLineUpdateResult>(`/api/v1/bom/multitable/${partId}/lines/${bomLineId}`, {
       method: 'PATCH',
       data: payload,
+      headers: { 'Idempotency-Key': idempotencyKey },
     })
   }
 

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3803,6 +3803,107 @@
       }
     },
     {
+      "description": "write back a governed BOM multi-table line's editable cells in an editable (Draft) state",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_multitable_writeback license and part 01H000000000000000000000W1 has an editable Part-BOM line 01H000000000000000000000W3"
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000W1/lines/01H000000000000000000000W3",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1",
+          "Content-Type": "application/json",
+          "Idempotency-Key": "pact-writeback-key-0001"
+        },
+        "body": {
+          "quantity": 7,
+          "uom": "ea",
+          "find_num": "15",
+          "refdes": "WB1,WB2"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            },
+            "$.Idempotency-Key": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.quantity": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.uom": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.find_num": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.refdes": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "ok": true,
+          "bom_line_id": "01H000000000000000000000W3"
+        },
+        "matchingRules": {
+          "body": {
+            "$.ok": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.bom_line_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "mint a MetaSheet BOM review embed token for the Yuantus parent host",
       "providerStates": [
         {

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -116,10 +116,12 @@ const PLM_ADAPTER_PACT_PATHS = [
   // PLM-COLLAB V1.1: the two modern Path-A surfaces (advisory manifest + governed BOM context).
   { method: 'GET', path: '/api/v1/integrations/capabilities' },
   { method: 'GET', path: '/api/v1/bom/multitable/01H000000000000000000000P1/context' },
-  // PLM-COLLAB P3 (方案1) BOM multitable write-back: depublished from the main pact — the provider
-  // endpoint is Phase 7 (Yuantus #884), owner-gated/unbuilt, so a main pact for it false-fails the
-  // provider's blocking broker gate (consumer-ahead). Re-add this interaction only when the Yuantus
-  // provider build is ratified. PLMAdapter.ts keeps the client method (see endpointsToFind below).
+  // PLM-COLLAB P3 (方案1) governed BOM multitable write-back: re-added in its AMENDED form now that
+  // the Yuantus provider (#905) honors a GOVERNED, Idempotency-Key-gated write-back (entitlement
+  // plm.bom_multitable_writeback). It MUST sit at the END of the adapter-owned list — immediately
+  // before the V1.2 parent-host embed-token — so the concatenated PACT_PATHS order matches the
+  // corresponding placement of the interaction in the pact JSON. PLMAdapter.ts owns the callsite.
+  { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000W1/lines/01H000000000000000000000W3' },
 ] as const
 
 const PARENT_HOST_PACT_PATHS = [
@@ -233,12 +235,44 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(rules).toHaveProperty('$.expires_in')
   })
 
-  // PLM-COLLAB P3 (方案1) BOM multitable write-back contract: DEPUBLISHED from the main pact.
-  // Its provider endpoint (PATCH /bom/multitable/{part}/lines/{line}) is Phase 7 (Yuantus #884),
-  // owner-gated and unbuilt, so publishing it on the consumer main pact false-fails Yuantus's
-  // blocking broker provider-verify gate (consumer-ahead-of-provider). The interaction (and this
-  // `it` documenting it) is removed until the provider build is ratified; PLMAdapter.ts retains
-  // the client method, which `endpointsToFind` above still asserts.
+  // PLM-COLLAB P3 (方案1) governed BOM multitable write-back contract: RE-ADDED in its AMENDED form
+  // now that the Yuantus provider (#905) honors the governed, Idempotency-Key-gated write-back. The
+  // W1/W3 ids and request/response shape mirror the Yuantus provider fixture exactly, so the broker
+  // provider-verify gate stays green. PLMAdapter.updateBomMultitableLine is the live consumer callsite.
+  it('governed BOM multitable write-back interaction locks the amended PATCH contract (Idempotency-Key + entitlement state, success-only)', () => {
+    const pact = loadPact()
+    const path = '/api/v1/bom/multitable/01H000000000000000000000W1/lines/01H000000000000000000000W3'
+    const matches = pact.interactions.filter(i => i.request.path === path)
+    // success-only: exactly ONE interaction for this line-addressed write-back path
+    expect(matches).toHaveLength(1)
+    const writeback = matches[0]
+
+    expect(writeback.request.method).toBe('PATCH')
+
+    // the governed provider state is present AND names the write entitlement it gates on
+    expect(writeback.providerStates).toBeDefined()
+    expect(writeback.providerStates!.length).toBeGreaterThan(0)
+    expect(writeback.providerStates![0].name).toContain('plm.bom_multitable_writeback')
+
+    // the request carries a per-edit Idempotency-Key header (the governed-write seam)
+    expect(writeback.request.headers).toBeDefined()
+    expect(writeback.request.headers).toHaveProperty('Idempotency-Key')
+
+    // request body is restricted to EXACTLY the four editable business cells
+    expect(Object.keys(writeback.request.body as Record<string, unknown>).sort()).toEqual([
+      'find_num',
+      'quantity',
+      'refdes',
+      'uom',
+    ])
+
+    // response is the minimal success envelope — no eco_id / source_version / applied leakage
+    expect(writeback.response.status).toBe(200)
+    expect(writeback.response.body).toEqual({
+      ok: true,
+      bom_line_id: '01H000000000000000000000W3',
+    })
+  })
 
   it('aml/apply request body documents the RPC envelope shape used by PLMAdapter', () => {
     const pact = loadPact()

--- a/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
@@ -224,6 +224,30 @@ describe('PLMAdapter.updateBomMultitableLine (PLM-COLLAB P3 — thin success-onl
     expect(result.data?.[0]).toEqual({ ok: true, bom_line_id: 'R8' })
   })
 
+  it('mints a FRESH per-edit Idempotency-Key header on each governed write (two successive writes generate DIFFERENT keys)', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })
+    ;(adapter as never as { select: unknown }).select = select
+
+    await adapter.updateBomMultitableLine('P4', 'R8', { quantity: 6 })
+    await adapter.updateBomMultitableLine('P4', 'R8', { quantity: 7 })
+
+    expect(select).toHaveBeenCalledTimes(2)
+    const [, firstOptions] = select.mock.calls[0]
+    const [, secondOptions] = select.mock.calls[1]
+    const firstKey = firstOptions.headers['Idempotency-Key']
+    const secondKey = secondOptions.headers['Idempotency-Key']
+
+    // present and NON-EMPTY on each call (the per-edit governed-write seam)
+    expect(typeof firstKey).toBe('string')
+    expect(firstKey.length).toBeGreaterThan(0)
+    expect(typeof secondKey).toBe('string')
+    expect(secondKey.length).toBeGreaterThan(0)
+
+    // per-edit generation: a retried/second write must NOT reuse the same key
+    expect(firstKey).not.toBe(secondKey)
+  })
+
   it('null cell is a real "clear" edit, not empty: kept in payload, request issued', async () => {
     const adapter = createAdapter('yuantus')
     const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })


### PR DESCRIPTION
Closes the cross-repo loop now that the Yuantus governed write-back provider has landed (Yuantus #905).

## What
- `PLMAdapter.updateBomMultitableLine` mints a fresh per-edit **`Idempotency-Key`** (`randomUUID()`, after the apiMode guard so only the network path mints it) and sends it as a request header — the governed provider requires it.
- **Re-adds** the PATCH write-back interaction to the pact (33→34) in its **amended form** — depublished by #3337 while the provider was unbuilt, now restored. ids `…W1/lines/…W3` (matching the provider's seeded fixture, **not** the original P4/R8), `Idempotency-Key` header, `plm.bom_multitable_writeback` providerState.
- Pact `it()` + a new adapter unit test lock it (incl. successive calls minting **different** keys).

## Broker-gate safety
The re-added interaction is **byte-for-byte DEEP EQUAL** to the Yuantus #905 provider's vendored fixture (independently verified), so on `push:main` the republished pact verifies green against the now-honoring provider.

## Verification
Contract suite + adapter unit: 34 passed; full contract dir: 20 passed; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)