### PR TITLE
feat(plm): re-add Phase-7 BOM write-back pact interaction + Idempotency-Key (#3332 follow-up)

### DIFF
--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { Optional } from '@wendellhu/redi'
 import { IConfigService, ILogger } from '../di/identifiers'
 import { HTTPAdapter } from './HTTPAdapter'
@@ -2236,6 +2237,12 @@ export class PLMAdapter extends HTTPAdapter {
     return this.select<BomMultitableLineUpdateResult>(`/api/v1/bom/multitable/${partId}/lines/${bomLineId}`, {
       method: 'PATCH',
       data: payload,
+      // The governed write-back endpoint REQUIRES a per-edit Idempotency-Key (the provider 400s
+      // without it; it is the single-use/replay-guard key — design #901 §2). A fresh key per call
+      // means a transport retry of the SAME edit is idempotent (provider returns the cached result),
+      // while a genuinely new edit is a distinct key. Merged on top of the connection's auth/tenant
+      // headers by HTTPAdapter.select.
+      headers: { 'Idempotency-Key': randomUUID() },
     })
   }
 

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3803,6 +3803,107 @@
       }
     },
     {
+      "description": "write back a governed BOM multi-table line's editable cells in an editable (Draft) state",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_multitable_writeback license and part 01H000000000000000000000W1 has an editable Part-BOM line 01H000000000000000000000W3"
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000W1/lines/01H000000000000000000000W3",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1",
+          "Content-Type": "application/json",
+          "Idempotency-Key": "pact-writeback-key-0001"
+        },
+        "body": {
+          "quantity": 7,
+          "uom": "ea",
+          "find_num": "15",
+          "refdes": "WB1,WB2"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            },
+            "$.Idempotency-Key": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.quantity": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.uom": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.find_num": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.refdes": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "ok": true,
+          "bom_line_id": "01H000000000000000000000W3"
+        },
+        "matchingRules": {
+          "body": {
+            "$.ok": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.bom_line_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "mint a MetaSheet BOM review embed token for the Yuantus parent host",
       "providerStates": [
         {

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -116,10 +116,10 @@ const PLM_ADAPTER_PACT_PATHS = [
   // PLM-COLLAB V1.1: the two modern Path-A surfaces (advisory manifest + governed BOM context).
   { method: 'GET', path: '/api/v1/integrations/capabilities' },
   { method: 'GET', path: '/api/v1/bom/multitable/01H000000000000000000000P1/context' },
-  // PLM-COLLAB P3 (方案1) BOM multitable write-back: depublished from the main pact — the provider
-  // endpoint is Phase 7 (Yuantus #884), owner-gated/unbuilt, so a main pact for it false-fails the
-  // provider's blocking broker gate (consumer-ahead). Re-add this interaction only when the Yuantus
-  // provider build is ratified. PLMAdapter.ts keeps the client method (see endpointsToFind below).
+  // PLM-COLLAB P3 (方案1) BOM multitable write-back: RE-ADDED now that the Yuantus provider endpoint
+  // landed (#905, ratified design #901). Uses the provider's seeded W1/W3 fixture + the distinct
+  // write SKU providerState; the consumer sends an Idempotency-Key (provider 400s without it).
+  { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000W1/lines/01H000000000000000000000W3' },
 ] as const
 
 const PARENT_HOST_PACT_PATHS = [
@@ -233,12 +233,34 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(rules).toHaveProperty('$.expires_in')
   })
 
-  // PLM-COLLAB P3 (方案1) BOM multitable write-back contract: DEPUBLISHED from the main pact.
-  // Its provider endpoint (PATCH /bom/multitable/{part}/lines/{line}) is Phase 7 (Yuantus #884),
-  // owner-gated and unbuilt, so publishing it on the consumer main pact false-fails Yuantus's
-  // blocking broker provider-verify gate (consumer-ahead-of-provider). The interaction (and this
-  // `it` documenting it) is removed until the provider build is ratified; PLMAdapter.ts retains
-  // the client method, which `endpointsToFind` above still asserts.
+  // PLM-COLLAB P3 (方案1) BOM multitable write-back contract: RE-ADDED. The Yuantus provider
+  // endpoint landed (#905, ratified design #901), so the consumer pact re-publishes the governed
+  // PATCH interaction (it was temporarily depublished in #3337 while the provider was unbuilt).
+  it('documents the P3 governed BOM multitable line write-back contract (方案1, re-added post-#905)', () => {
+    const pact = loadPact()
+    const PATH = '/api/v1/bom/multitable/01H000000000000000000000W1/lines/01H000000000000000000000W3'
+    const matches = pact.interactions.filter(i => i.request.path === PATH)
+    // success-only: EXACTLY ONE interaction for this path, status 200, no 403/error twin
+    expect(matches).toHaveLength(1)
+    const interaction = matches[0]
+    expect(interaction.request.method).toBe('PATCH')
+    expect(interaction.response.status).toBe(200)
+
+    // provider state names the DISTINCT write SKU (not the read projection's plm.bom_multitable)
+    expect(interaction.providerStates).toBeDefined()
+    expect(interaction.providerStates![0].name).toContain('plm.bom_multitable_writeback')
+
+    // the provider REQUIRES a per-edit Idempotency-Key; the consumer declares + (PLMAdapter) sends it
+    expect(interaction.request.headers).toBeDefined()
+    expect(interaction.request.headers!['Idempotency-Key']).toBeTruthy()
+
+    // request body is whitelisted to the four editable cells; response is the thin {ok, bom_line_id}
+    const reqBody = interaction.request.body as Record<string, unknown>
+    expect(Object.keys(reqBody).sort()).toEqual(['find_num', 'quantity', 'refdes', 'uom'])
+    const resBody = interaction.response.body as Record<string, unknown>
+    expect(resBody.ok).toBe(true)
+    expect(resBody).toHaveProperty('bom_line_id')
+  })
 
   it('aml/apply request body documents the RPC envelope shape used by PLMAdapter', () => {
     const pact = loadPact()


### PR DESCRIPTION
**#3332 follow-up.** The Yuantus provider write-back endpoint **landed** (#905, ratified design #901), so this re-publishes the governed PATCH interaction that #3337 temporarily depublished while the provider was unbuilt.

## What
- **pact**: re-add `PATCH /api/v1/bom/multitable/{W1}/lines/{W3}` → `200 {ok, bom_line_id}`, providerState naming the **distinct write SKU** `plm.bom_multitable_writeback`, with an `Idempotency-Key` header. The interaction's request/response/providerStates **byte-match** the provider's checked-in (#905) interaction, so the broker provider-verify passes. `PACT_PATHS` + the documenting `it()` restored.
- **`PLMAdapter.updateBomMultitableLine`** now **sends a per-edit `Idempotency-Key`** (`crypto.randomUUID`) — the provider 400s without it (#901 §2); merged on top of the connection auth/tenant headers by `HTTPAdapter.select`.

## Effect / safety
On `push:main`, the Yuantus Pact Consumer republishes the main pact **with** this interaction; the Yuantus provider (already on main) then verifies it green — closing the #3332 → #3337 → #905 loop. The interaction is aligned exactly to the provider's seeded W1/W3 fixture, so it will **not** re-red the blocking broker Phase-B gate.

Verify: PACT_PATHS↔JSON exact ordered match (34); write-back request/response/providerStates equal the provider's verified shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)