### PR TITLE
[codex] Align K3 list read filter dialect

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5544,6 +5544,7 @@ async function testReadSmokeRoute() {
                 records: [{ FName: 'SECRET-LIST-NAME', FNumber: 'M-LIST-001' }, { FName: 'SECRET-LIST-NAME-2', FNumber: 'M-LIST-002' }],
                 metadata: {
                   readPath: 'https://k3host/K3API/Material/GetList',
+                  dataRowCount: 2,
                   listShapeProbe: {
                     dataData: false,
                     dataLowerData: false,
@@ -5625,6 +5626,7 @@ async function testReadSmokeRoute() {
   assert.equal(okList.body.data.object, 'material')
   assert.equal(okList.body.data.mode, 'list')
   assert.equal(okList.body.data.recordCount, 2)
+  assert.equal(okList.body.data.dataRowCount, 2)
   assert.deepEqual(okList.body.data.listShapeProbe, {
     dataData: false,
     dataLowerData: false,
@@ -5652,6 +5654,8 @@ async function testReadSmokeRoute() {
     readListFields: ['FNumber', 'FName', 'FModel', 'FUnitID'],
     readListOrderBy: 'FNumber',
     readListFilterField: 'FNumber',
+    readListFilterMode: 'contains_like',
+    readListFilterEscape: 'k3_freeform',
     topField: 'Top',
     pageIndexField: 'PageIndex',
     pageSizeField: 'PageSize',
@@ -5671,7 +5675,7 @@ async function testReadSmokeRoute() {
   assert.equal(keyedListReadArg.object, 'material')
   assert.equal(keyedListReadArg.limit, 10)
   assert.equal(keyedListReadArg.options.k3ReadMode, 'list')
-  assert.equal(keyedListReadArg.options.listKey, 'M-004', 'LIST key maps only to the internal FNumber prefix input')
+  assert.equal(keyedListReadArg.options.listKey, 'M-004', 'LIST key maps only to the internal preset-owned LIST filter input')
   assert.equal(keyedListReadArg.options[READ_SMOKE_LIST_REQUEST_MARKER], true, 'keyed LIST route supplies the internal route-only marker')
   assert.ok(!JSON.stringify(okListKey.body.data).includes('M-004'), 'LIST key is not echoed in values-free evidence')
 
@@ -5745,6 +5749,7 @@ async function testReadSmokeRoute() {
         e.details = {
           code: 'K3_WISE_READ_LIST_REJECTED',
           dataDataPresent: true,
+          dataRowCount: 1,
           listShapeProbe: {
             dataData: true,
             dataLowerData: false,
@@ -5770,6 +5775,7 @@ async function testReadSmokeRoute() {
   assert.equal(fail.body.data.errorCode, 'K3_WISE_READ_LIST_REJECTED')
   assert.equal(fail.body.data.errorType, 'K3WiseWebApiAdapterError')
   assert.equal(fail.body.data.dataDataPresent, true)
+  assert.equal(fail.body.data.dataRowCount, 1)
   assert.deepEqual(fail.body.data.listShapeProbe, {
     dataData: true,
     dataLowerData: false,

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -933,6 +933,8 @@ async function testK3WebApiMaterialListReadSmoke() {
             readListFields: ['FNumber', 'FName', 'FModel', 'FUnitID'],
             readListOrderBy: 'FNumber',
             readListFilterField: 'FNumber',
+            readListFilterMode: 'contains_like',
+            readListFilterEscape: 'k3_freeform',
             topField: 'Top',
             pageIndexField: 'PageIndex',
             pageSizeField: 'PageSize',
@@ -963,6 +965,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.equal(read.metadata.requestedLimit, 2)
   assert.equal(read.metadata.returnedRecordCount, 2)
   assert.equal(read.metadata.dataDataPresent, true)
+  assert.equal(read.metadata.dataRowCount, 3)
   assert.deepEqual(read.metadata.listShapeProbe, {
     dataData: true,
     dataLowerData: false,
@@ -988,13 +991,13 @@ async function testK3WebApiMaterialListReadSmoke() {
     },
   })
   const filteredByKey = await adapter.read(buildMarkedListRequest({ object: 'material', mode: 'list', key: "MAT-'A" }))
-  assert.equal(filteredByKey.records.length, 2, 'LIST key is an internal bounded-prefix input, not a caller raw filter')
+  assert.equal(filteredByKey.records.length, 2, 'LIST key is an internal bounded filter input, not a caller raw filter')
   const filteredCall = calls.filter((call) => call.pathname === '/K3API/Material/GetList').at(-1)
-  assert.equal(filteredCall.body.Data.Filter, "FNumber LIKE 'MAT-''A%'", 'LIST key is mapped to an escaped FNumber prefix filter')
-  const wildcardKey = await adapter.read(buildMarkedListRequest({ object: 'material', mode: 'list', key: 'MAT%_[' }))
-  assert.equal(wildcardKey.records.length, 2, 'LIST wildcard key still runs as a bounded internal prefix input')
+  assert.equal(filteredCall.body.Data.Filter, "FNumber like '%MAT-''A%'", 'LIST key is mapped to the documented K3 contains-like filter')
+  const wildcardKey = await adapter.read(buildMarkedListRequest({ object: 'material', mode: 'list', key: 'MAT_001' }))
+  assert.equal(wildcardKey.records.length, 2, 'LIST wildcard-shaped key still runs as a bounded internal input')
   const wildcardCall = calls.filter((call) => call.pathname === '/K3API/Material/GetList').at(-1)
-  assert.equal(wildcardCall.body.Data.Filter, "FNumber LIKE 'MAT[%][_][[]%'", 'LIST key escapes LIKE wildcards before appending the prefix wildcard')
+  assert.equal(wildcardCall.body.Data.Filter, "FNumber like '%MAT_001%'", 'LIST key uses K3 freeform quoting instead of T-SQL bracket escaping')
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Save'), false, 'LIST smoke must not Save')
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Submit'), false, 'LIST smoke must not Submit')
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Audit'), false, 'LIST smoke must not Audit')
@@ -1027,7 +1030,7 @@ async function testK3WebApiMaterialListReadSmoke() {
       return jsonResponse(200, {
         StatusCode: 200,
         Message: 'Material list succeeded',
-        Data: {},
+        Data: { ROWCOUNT: 0, DATA: null },
       })
     }
     return fetchImpl(url, options)
@@ -1053,8 +1056,9 @@ async function testK3WebApiMaterialListReadSmoke() {
     fetchImpl: missingRowsFetchImpl,
   })
   const missingRows = await missingRowsAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2))
-  assert.equal(missingRows.records.length, 0, 'LIST success envelope without Data.DATA remains an empty bounded page')
+  assert.equal(missingRows.records.length, 0, 'LIST success envelope with ROWCOUNT=0 and DATA=null remains an empty bounded page')
   assert.equal(missingRows.metadata.dataDataPresent, false, 'LIST success evidence carries a values-free rows-shape diagnostic')
+  assert.equal(missingRows.metadata.dataRowCount, 0, 'LIST success evidence carries values-free Data.ROWCOUNT')
   assert.deepEqual(missingRows.metadata.listShapeProbe, {
     dataData: false,
     dataLowerData: false,
@@ -1099,6 +1103,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   const alternateRows = await alternateRowsAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2))
   assert.equal(alternateRows.records.length, 0, 'shape probe does not silently widen the extractor')
   assert.equal(alternateRows.metadata.dataDataPresent, false)
+  assert.equal(alternateRows.metadata.dataRowCount, null)
   assert.deepEqual(alternateRows.metadata.listShapeProbe, {
     dataData: false,
     dataLowerData: false,
@@ -1144,6 +1149,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.ok(rejected instanceof K3WiseWebApiAdapterError, 'LIST explicit failure marker is rejected before row extraction')
   assert.equal(rejected.details.code, 'K3_WISE_READ_LIST_REJECTED')
   assert.equal(rejected.details.dataDataPresent, true)
+  assert.equal(rejected.details.dataRowCount, null)
   assert.deepEqual(rejected.details.listShapeProbe, {
     dataData: true,
     dataLowerData: false,
@@ -1188,6 +1194,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.ok(unrecognized instanceof K3WiseWebApiAdapterError, 'LIST rows under Data.DATA with an unrecognized envelope gets a response-shape diagnostic')
   assert.equal(unrecognized.details.code, 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED')
   assert.equal(unrecognized.details.dataDataPresent, true)
+  assert.equal(unrecognized.details.dataRowCount, null)
   assert.deepEqual(unrecognized.details.listShapeProbe, {
     dataData: true,
     dataLowerData: false,

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -45,6 +45,8 @@ assert.deepEqual(LIST_PRESET.readConfigOverlay, {
       readListFields: ['FNumber', 'FName', 'FModel', 'FUnitID'],
       readListOrderBy: 'FNumber',
       readListFilterField: 'FNumber',
+      readListFilterMode: 'contains_like',
+      readListFilterEscape: 'k3_freeform',
       topField: 'Top',
       pageIndexField: 'PageIndex',
       pageSizeField: 'PageSize',
@@ -129,6 +131,8 @@ assert.deepEqual(listOverlayedSystem.config.objects.material, {
   readListFields: ['FNumber', 'FName', 'FModel', 'FUnitID'],
   readListOrderBy: 'FNumber',
   readListFilterField: 'FNumber',
+  readListFilterMode: 'contains_like',
+  readListFilterEscape: 'k3_freeform',
   topField: 'Top',
   pageIndexField: 'PageIndex',
   pageSizeField: 'PageSize',
@@ -181,6 +185,7 @@ assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, {
   raw: { Data: { SECRET: 'never leak' } },
   metadata: {
     dataDataPresent: false,
+    dataRowCount: 0,
     listShapeProbe: {
       dataData: false,
       dataLowerData: false,
@@ -202,6 +207,7 @@ assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, {
   recordCount: 0,
   referenceObjectCount: 0,
   dataDataPresent: false,
+  dataRowCount: 0,
   listShapeProbe: {
     dataData: false,
     dataLowerData: false,
@@ -235,6 +241,7 @@ listError.name = 'K3WiseWebApiAdapterError'
 listError.details = {
   code: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED',
   dataDataPresent: true,
+  dataRowCount: 1,
   listShapeProbe: {
     dataData: true,
     dataLowerData: false,
@@ -251,6 +258,7 @@ assert.deepEqual(readSmokeErrorEvidence(LIST_PRESET, listError, { object: 'mater
   errorCode: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED',
   errorType: 'K3WiseWebApiAdapterError',
   dataDataPresent: true,
+  dataRowCount: 1,
   listShapeProbe: {
     dataData: true,
     dataLowerData: false,

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -762,10 +762,32 @@ function buildListReadBody(request, objectConfig) {
     const filterField = typeof objectConfig.readListFilterField === 'string' && objectConfig.readListFilterField.trim()
       ? objectConfig.readListFilterField.trim()
       : 'FNumber'
-    const escaped = escapeK3LikePrefix(listKey)
-    template[bodyKey].Filter = `${filterField} LIKE '${escaped}%'`
+    template[bodyKey].Filter = buildListFilterExpression(filterField, listKey, objectConfig)
   }
   return template
+}
+
+function buildListFilterExpression(filterField, listKey, objectConfig) {
+  const filterMode = typeof objectConfig.readListFilterMode === 'string' && objectConfig.readListFilterMode.trim()
+    ? objectConfig.readListFilterMode.trim()
+    : 'prefix_like'
+  const escapeMode = typeof objectConfig.readListFilterEscape === 'string' && objectConfig.readListFilterEscape.trim()
+    ? objectConfig.readListFilterEscape.trim()
+    : 'tsql_like'
+  if (filterMode === 'contains_like') {
+    const escaped = escapeMode === 'k3_freeform'
+      ? escapeK3FilterStringLiteral(listKey)
+      : escapeK3LikePrefix(listKey)
+    return `${filterField} like '%${escaped}%'`
+  }
+  const escaped = escapeMode === 'k3_freeform'
+    ? escapeK3FilterStringLiteral(listKey)
+    : escapeK3LikePrefix(listKey)
+  return `${filterField} LIKE '${escaped}%'`
+}
+
+function escapeK3FilterStringLiteral(value) {
+  return String(value).replace(/'/g, "''")
 }
 
 function escapeK3LikePrefix(value) {
@@ -802,6 +824,20 @@ function materialListShapeProbe(data) {
 function materialListDataDataPresent(data) {
   const probe = materialListShapeProbe(data)
   return probe.dataData || probe.dataLowerData
+}
+
+function materialListRowCount(data) {
+  const value = firstDefined(
+    getPath(data, 'Data.ROWCOUNT'),
+    getPath(data, 'Data.rowCount'),
+    getPath(data, 'Data.RowCount'),
+  )
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value.trim())
+    if (Number.isInteger(parsed) && parsed >= 0) return parsed
+  }
+  return null
 }
 
 function materialListBusinessSuccess(data, config) {
@@ -1327,6 +1363,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
 
       const listShapeProbe = materialListShapeProbe(readResponse.data)
       const dataDataPresent = listShapeProbe.dataData || listShapeProbe.dataLowerData
+      const dataRowCount = materialListRowCount(readResponse.data)
       if (!materialListBusinessSuccess(readResponse.data, config)) {
         const failureCode = materialListBusinessFailureCode(readResponse.data)
         throw new K3WiseWebApiAdapterError(String(responseMessage(readResponse.data, config, 'K3 WISE list read business response failed')), {
@@ -1334,6 +1371,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           object: request.object,
           responseCode: responseFailureCode(readResponse.data, config, failureCode),
           dataDataPresent,
+          dataRowCount,
           listShapeProbe,
         })
       }
@@ -1348,6 +1386,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           requestedLimit: request.limit,
           returnedRecordCount: records.length,
           dataDataPresent,
+          dataRowCount,
           listShapeProbe,
           readPath,
           readOnly: true,

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -60,6 +60,8 @@ const READ_SMOKE_PRESETS = Object.freeze({
           readListFields: Object.freeze(['FNumber', 'FName', 'FModel', 'FUnitID']),
           readListOrderBy: 'FNumber',
           readListFilterField: 'FNumber',
+          readListFilterMode: 'contains_like',
+          readListFilterEscape: 'k3_freeform',
           topField: 'Top',
           pageIndexField: 'PageIndex',
           pageSizeField: 'PageSize',
@@ -94,6 +96,11 @@ function readSmokeListShapeProbeEvidence(value) {
     hasEvidence = true
   }
   return hasEvidence ? evidence : null
+}
+
+function readSmokeSafeCount(value) {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value
+  return null
 }
 
 function mergeOperations(existing, required) {
@@ -197,6 +204,8 @@ function readSmokeSuccessEvidence(preset, result, contract = {}) {
   if (result && result.metadata && typeof result.metadata.dataDataPresent === 'boolean') {
     evidence.dataDataPresent = result.metadata.dataDataPresent
   }
+  const dataRowCount = readSmokeSafeCount(result && result.metadata && result.metadata.dataRowCount)
+  if (dataRowCount !== null) evidence.dataRowCount = dataRowCount
   const listShapeProbe = readSmokeListShapeProbeEvidence(result && result.metadata && result.metadata.listShapeProbe)
   if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
   return evidence
@@ -223,6 +232,8 @@ function readSmokeErrorEvidence(preset, error, contract = {}) {
   if (error && error.details && typeof error.details.dataDataPresent === 'boolean') {
     evidence.dataDataPresent = error.details.dataDataPresent
   }
+  const dataRowCount = readSmokeSafeCount(error && error.details && error.details.dataRowCount)
+  if (dataRowCount !== null) evidence.dataRowCount = dataRowCount
   const listShapeProbe = readSmokeListShapeProbeEvidence(error && error.details && error.details.listShapeProbe)
   if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
   return evidence
@@ -239,7 +250,7 @@ function readSmokeSafeErrorCode(value) {
 // { presetId, intent:{ object, mode, key } } shape with the shipped read-smoke { presetId, key } subset by
 // normalizing BOTH detail shapes to one output { presetId, object, mode, key }. C3 LIST uses the explicit
 // intent shape and returns { presetId, object, mode } or an optional key that maps only to the preset-owned
-// internal FNumber prefix filter. Fail-closed + values-free: a raw
+// internal preset-owned LIST filter. Fail-closed + values-free: a raw
 // path/method/headers/
 // body/response/credential/config can never ride in (strict key allowlist); unknown preset/object/mode → a
 // coarse reason; the key is never echoed in an error.


### PR DESCRIPTION
## Summary

Align the bounded K3 Material/GetList read-smoke filter with the per-instance documentation sample from #1709.

- Switch the built-in `k3wise.material-list.v1` preset to a preset-owned contains-like filter shape: `FNumber like '%<value>%'`.
- Use K3 freeform string-literal quoting for this preset instead of the prior T-SQL bracket escaping, so material keys containing `_` are no longer rewritten as `[_]`.
- Surface `Data.ROWCOUNT` as values-free `dataRowCount` evidence on LIST success/error evidence.

## Why

The entity-machine C3 LIST smoke now proves route/auth/deploy work, and `Material/GetDetail` confirms the owner-approved sample exists. The per-instance K3 docs show the broad GetList contract matches our adapter, but the documented filter sample is contains-like (`FNumber like '%<value>%'`) while the adapter emitted prefix-like (`FNumber LIKE '<value>%'`) with T-SQL-style bracket escaping.

This PR keeps the change narrow and preset-owned. It does not expose raw request-supplied `Filter`, does not change the endpoint/body/container, and does not widen the row extractor.

## Boundary

C3 LIST-only diagnostic/read-smoke only:

- no BOM/resolver
- no Save/Submit/Audit
- no production/external write
- no request-supplied raw Filter
- values-free evidence only

This is still documentation/sample-derived. Live PASS still requires a new on-prem package and entity-machine rerun.

## Verification

- `node plugins/plugin-integration-core/__tests__/read-smoke.test.cjs`
- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `pnpm --filter plugin-integration-core test`
