### PR TITLE
test(multitable): in-process operator smoke for form.submitted → start_approval (W6 #1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -298,6 +298,7 @@ jobs:
             tests/integration/multitable-automation-start-approval-http.test.ts \
             tests/integration/multitable-form-submit-trigger.test.ts \
             tests/integration/multitable-event-dedup-trigger.test.ts \
+            tests/integration/multitable-form-submit-start-approval-smoke.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/docs/development/w6-form-submit-start-approval-operator-smoke-acceptance-record-20260629.md
+++ b/docs/development/w6-form-submit-start-approval-operator-smoke-acceptance-record-20260629.md
@@ -1,0 +1,126 @@
+# W6 operator-smoke — `form.submitted → start_approval` acceptance record (2026-06-29)
+
+> **Scope of the PASS below: the IN-PROCESS automatable seam only.** This record delivers
+> a CI-wired harness + a runbook + an in-process ✅ PASS + a fillable deployed-record
+> template. It does **not** constitute a deployed/staging operator run — that leg
+> (`/api` co-tenancy on the live host, a real operator browser session, cross-process
+> resume) remains **owner-gated** (§5). Read "✅ PASS" as scoped to §4, not as "the
+> deployed smoke is done."
+
+This is the operator-entry counterpart to
+`w6-operator-smoke-acceptance-record-20260622.md`. That record proved the
+`record.created → start_approval → approve → resume` seam (#2974). **The gap this closes:**
+the operator's actual entry point is a **form submit** (#3336 `form.submitted` trigger +
+#3339 `start_approval` action, editor-exposed) — and no single test chained
+`form submit → a real approval instance → the approver's todo` end-to-end. This record
+captures that chain's acceptance state so the gate is explicit.
+
+## 1. Implementation state (on `main`)
+- **`form.submitted` trigger** (#3336) and **`start_approval` action** (#3339, editor-exposed)
+  are on `main`; `start_approval` opens the suspend/resume approval bridge
+  (`multitable_automation_approval_bridges`), completion driven by the approval terminal
+  event (the same bridge runtime the 06-22 record accepts).
+- **New in-process seam test** —
+  `tests/integration/multitable-form-submit-start-approval-smoke.test.ts`, wired into the
+  `Run multitable real-DB integration` Postgres lane in `plugin-tests.yml` (runs every PR
+  with `DATABASE_URL` set), so it is automated debt-free, not a one-off.
+
+## 2. Acceptance criteria
+An operator-equivalent flow proves: **submit a form → the `form.submitted` rule fires →
+`start_approval` creates a real approval instance → the approver has a pending todo**, over
+the real HTTP submit boundary against real Postgres.
+
+## 3. Real event chain exercised
+```
+POST /api/multitable/views/:id/submit            (real HTTP boundary)
+  → eventBus 'multitable.form.submitted'
+    → AutomationService subscription → matchesTrigger('form.submitted')
+      → executeRule(start_approval)  [executionMode workflow_job_v1 → suspended job]
+        → multitable_automation_approval_bridges row (status='pending', approval_instance_id)
+          → approval_instances row (non-terminal)
+            → approval_assignments row for the approver (is_active=true)  ← the "待办出现"
+```
+
+## 4. Evidence — IN-PROCESS seam: ✅ PASS
+
+`multitable-form-submit-start-approval-smoke.test.ts` — **2/2 green** (real DB, `TS=…`):
+- the submit returns `200`;
+- a `start_approval` execution + a **pending** bridge with a non-null `approval_instance_id`
+  appear from the `form.submitted` rule;
+- the `approval_instances` row exists and is **non-terminal**;
+- the approver has an **active** `approval_assignments` row (the todo).
+
+Representative captured run (local `metasheet_test`; the test cleans up after itself, so
+these IDs are an illustrative sample, not a persisted fixture — re-run with `SMOKE_KEEP=1`
+to retain rows for inspection):
+
+| Field | Value |
+|---|---|
+| **env** | in-process Express mounting `univerMetaRouter()` → real Postgres (`metasheet_test`; CI: `:5432`, local: `:5435`). **Not** the deployed host. |
+| **rule** | `atr_84409637-2f8b-4e90-8282-5e3886d8dd5a` — trigger `form.submitted`, action `start_approval`, `execution_mode=workflow_job_v1` |
+| **template** | `5099703b-75c1-46c2-b35e-004d9e24e12f` (published; `formSchema.summary` required; graph `start → approval_1{mode:any, static_user:approver} → end`) |
+| **trigger input** | `POST /api/multitable/views/:id/submit` body `{ data: { <number field>: 5 } }` |
+| **automation run (execution)** | `axe_9e9c58fb-5b13-4084-bea8-8d896ab7806b` status `running` (job **suspended**, awaiting the approval terminal event — resume is the 06-22 record's scope) |
+| **bridge** | `aab_7759d9ba-f9ed-47d7-9807-598ea10f494a` status `pending` |
+| **approval instance** | `14291efe-57ae-49e8-a7c8-d842247f70a0` status `pending` |
+| **approver todo (active assignment)** | `49badfdc-dcc8-4396-b172-99974cc4f284` (`is_active=true`) |
+
+This proves the trigger → action → bridge → instance → assignment wiring is correct
+**in process**. The resume tail (approver approves → suspended job resumes exactly once,
+incl. the unauth-approve negative boundary) is already covered by #2974 and accepted in the
+06-22 record; this record deliberately stops at "the approver has a todo".
+
+## 5. Deployed operator smoke: ⬜ owner sign-off (gated)
+What §4 does **not** cover: the **deployed** path — `/api` co-tenancy with the SPA, a real
+operator's browser session, and cross-process behaviour on the deployed host. That is the
+`automation-start-approval-operator-smoke-runbook-20260613.md` operator runbook (`#2480`
+family), and it requires a human operator on the live environment (staging `:8082` has a
+distinct `JWT_SECRET` and its deploy lane does not auto-mirror `main` — preflight the bundle
+fingerprint + auth round-trip first). To be filled by the operator:
+
+| Field | Value (operator fills) |
+|---|---|
+| env / host | ______ |
+| rule id | ______ |
+| template id | ______ |
+| trigger input (form view + payload) | ______ |
+| approval instance id | ______ |
+| automation run (execution) id | ______ |
+| approver todo visible? | ______ |
+| result | ⬜ PASS / ⬜ FAIL |
+
+## 6. Acceptance decision (owner)
+The in-process seam (§4) is green + durable + re-run every PR. The open question is whether
+to **accept on that evidence** or **require the deployed smoke (§5)** first:
+
+- [ ] **Accept on the in-process seam** — the `form.submitted → start_approval → todo` chain
+  is sign-off-ready; the deployed `#2480` smoke is recommended-but-not-blocking, tracked
+  separately.
+- [ ] **Require the deployed operator smoke (§5)** — run the runbook on the deployed host and
+  fill its PASS before sign-off.
+
+**Owner sign-off:** ______________  **Date:** ____________  **Decision:** ____________
+
+## 7. W7 state after this record
+This record no longer gates the already-shipped W7 approved-path result writeback. Since the
+original W6/W7 planning text, main has shipped the approved-path `resultWriteback` runtime and
+editor UI (`statusField` / `approverField` / `completedAtField`) as separate, verified slices.
+
+What this record still does: it closes the missing **form-submit entry** proof for W6's in-process
+operator seam, and leaves the deployed/staging smoke as an owner sign-off decision (§5/§6).
+
+What it does **not** authorize or close: W7 rejection backwrite, cross-base backwrite, or a
+person-shaped approver writer. Those remain independent owner-gated follow-ups with their own
+business/security semantics.
+
+## 8. Notes
+- **`formDataMapping` interpolation gotcha (operator trap).** Mapping values are rendered by
+  `renderMappedValue` and **only emit interpolated content** — a bare literal renders
+  **empty**, which fails required-field validation (`Approval form data is invalid`, the
+  bridge stays instance-less). Use a `{{…}}` expression, e.g.
+  `{ summary: 'Approval for form submission {{recordId}}' }`, not a bare string. The seam test
+  encodes this.
+- Brand-neutral (benchmarked against mainstream OA / approval platforms; states MetaSheet
+  principles, no external brand names in the contract).
+- The in-process evidence is automated + re-run every PR; only the deployed-host check (§5)
+  requires a human operator on the live environment.

--- a/packages/core-backend/tests/integration/multitable-form-submit-start-approval-smoke.test.ts
+++ b/packages/core-backend/tests/integration/multitable-form-submit-start-approval-smoke.test.ts
@@ -1,0 +1,201 @@
+/**
+ * W6 operator-smoke — IN-PROCESS seam for the `form.submitted → start_approval` chain (#1, 2026-06-29).
+ *
+ * The existing W6 seam (#2974, `multitable-automation-start-approval-http.test.ts`) proves
+ * `record.created → start_approval → approval → HTTP approve → resume`. THE GAP this closes: the operator's
+ * actual entry point is a FORM SUBMIT (#3336 `form.submitted` trigger + #3339 `start_approval` action,
+ * editor-exposed), which no single test chains end-to-end to a real approval + the approver's todo.
+ *
+ * Real event chain over the real HTTP submit boundary + real Postgres:
+ *   POST /api/multitable/views/:id/submit  →  eventBus 'multitable.form.submitted'
+ *     →  AutomationService subscription  →  matchesTrigger('form.submitted')  →  executeRule(start_approval)
+ *       →  a pending approval instance + the bridge linkage  →  the approver's ACTIVE assignment (the todo).
+ *
+ * Asserts the operator scenario: submit a form → an approval instance is created → the approver has a
+ * pending todo. The DEPLOYED browser/operator path (cross-process, /api co-tenancy) stays the #2480 runbook;
+ * this is the automatable, CI-wired in-process proof that backs the operator-smoke acceptance record.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_fsa_${TS}`
+const SHEET_ID = `sheet_fsa_${TS}`
+const VIEW_ID = `view_fsa_${TS}`
+const FLD_VALUE = `fld_fsa_value_${TS}`
+const REQUESTER = `u_fsa_req_${TS}`
+const APPROVER = `u_fsa_appr_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const queryFn = ((sql: string, params?: unknown[]) => poolManager.get().query(sql, params)) as never
+
+let app: Express
+let svc: AutomationService
+let ruleId = ''
+let templateId = ''
+
+function approvalTemplateRequest() {
+  return {
+    key: `fsa-${TS}`,
+    name: 'Form-submit Start-approval Smoke',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'Approver',
+          config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+async function bridgeFor(rid: string): Promise<{ status: string; approval_instance_id: string } | undefined> {
+  const r = await q(
+    `SELECT b.status, b.approval_instance_id
+       FROM multitable_automation_approval_bridges b
+       JOIN multitable_automation_executions e ON e.id = b.execution_id
+      WHERE e.rule_id = $1
+      ORDER BY b.created_at DESC LIMIT 1`,
+    [rid],
+  )
+  return (r.rows as Array<{ status: string; approval_instance_id: string }>)[0]
+}
+
+describeIfDatabase('W6 form.submitted → start_approval → approval instance → approver todo (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as unknown as { user: unknown }).user = { id: REQUESTER, roles: ['member'], perms: ['multitable:write'] }
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'FSA Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'FSA Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VALUE, SHEET_ID, 'Value', 'number', '{}', 1])
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, config) VALUES ($1,$2,$3,$4,$5::jsonb)', [VIEW_ID, SHEET_ID, 'Form', 'form', JSON.stringify({})])
+
+    // start_approval resolves the requester (trigger actor) + the static approver against the users table —
+    // both must be real + active; the requester also needs `approvals:write` to start, the approver
+    // `approvals:act` (mirrors the W6 seam #2974). Else: "requester user not found" / "lacks approvals:write".
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('approvals:write', 'Approvals Write', 'FSA smoke'), ('approvals:act', 'Approvals Act', 'FSA smoke')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    for (const uid of [REQUESTER, APPROVER]) {
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+        [uid, `${uid}@fsa.test`],
+      )
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+
+    const approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate(approvalTemplateRequest() as never)
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+
+    svc = new AutomationService(integrationEventBus, db as never, queryFn)
+    svc.init()
+    // Editor-exposed shape: form.submitted trigger → start_approval action (#3336 + #3339).
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'on form submit start approval',
+      triggerType: 'form.submitted',
+      triggerConfig: {},
+      actionType: 'start_approval',
+      actionConfig: {
+        templateId,
+        formDataMapping: { summary: 'Approval for form submission {{recordId}}' },
+        requester: { mode: 'trigger_actor' },
+      },
+      // start_approval is a suspend/resume job action — requires the job runtime (same as #2974).
+      executionMode: 'workflow_job_v1',
+    } as never)
+    ruleId = (rule as { id: string }).id
+  })
+
+  afterAll(async () => {
+    try { svc?.shutdown() } catch { /* noop */ }
+    // Operators capturing acceptance evidence can set SMOKE_KEEP=1 to leave the seeded
+    // rule/template/instance/bridge in place for inspection (IDs are otherwise ephemeral).
+    if (process.env.SMOKE_KEEP) return
+    const inst = await bridgeFor(ruleId)
+    if (inst?.approval_instance_id) {
+      await q('DELETE FROM approval_assignments WHERE instance_id = $1', [inst.approval_instance_id]).catch(() => {})
+      await q('DELETE FROM approval_records WHERE instance_id = $1', [inst.approval_instance_id]).catch(() => {})
+      await q('DELETE FROM approval_instances WHERE id = $1', [inst.approval_instance_id]).catch(() => {})
+    }
+    await q('DELETE FROM multitable_automation_approval_bridges WHERE execution_id IN (SELECT id FROM multitable_automation_executions WHERE rule_id = $1)', [ruleId]).catch(() => {})
+    await q('DELETE FROM multitable_automation_executions WHERE rule_id = $1', [ruleId]).catch(() => {})
+    await q('DELETE FROM automation_rules WHERE id = $1', [ruleId]).catch(() => {})
+    if (templateId) await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE id = $1', [VIEW_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[REQUESTER, APPROVER]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[REQUESTER, APPROVER]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('operator scenario: form submit → start_approval → a pending approval instance + the approver todo', async () => {
+    // 1) Submit the form over the real HTTP boundary → emits form.submitted.
+    const res = await request(app)
+      .post(`/api/multitable/views/${VIEW_ID}/submit`)
+      .send({ data: { [FLD_VALUE]: 5 } })
+    expect(res.status).toBe(200)
+
+    // 2) The form.submitted rule fired → an execution row, and start_approval opened a PENDING bridge.
+    let bridge: { status: string; approval_instance_id: string } | undefined
+    await (async () => {
+      const deadline = Date.now() + 6000
+      for (;;) {
+        bridge = await bridgeFor(ruleId)
+        if (bridge?.approval_instance_id) return
+        if (Date.now() > deadline) return
+        await new Promise((r) => setTimeout(r, 50))
+      }
+    })()
+    expect(bridge, 'start_approval should have created an approval bridge from the form.submitted rule').toBeTruthy()
+    expect(bridge!.status).toBe('pending')
+
+    // 3) A real approval INSTANCE was created and is non-terminal (the operator's "approval instance generated").
+    const instId = bridge!.approval_instance_id
+    const inst = await q('SELECT status FROM approval_instances WHERE id = $1', [instId])
+    expect((inst.rows as Array<{ status: string }>).length).toBe(1)
+    expect(['pending', 'running', 'in_progress', 'active']).toContain((inst.rows[0] as { status: string }).status)
+
+    // 4) The approver has an ACTIVE assignment for this instance — the "待办出现" (todo appears).
+    const todo = await q(
+      `SELECT 1 FROM approval_assignments WHERE instance_id = $1 AND assignee_id = $2 AND is_active = true`,
+      [instId, APPROVER],
+    )
+    expect((todo.rows as unknown[]).length, 'the approver should have an active pending todo').toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
       // ephemeral port against real Postgres, so it is excluded from the default run and wired
       // into the dedicated `Run multitable real-DB integration` job in plugin-tests.yml.
       'tests/integration/multitable-automation-start-approval-http.test.ts',
+      // W6 form-submit -> start_approval operator-smoke seam: DATABASE_URL-gated and
+      // wired as a WHOLE FILE into the `Run multitable real-DB integration` job in
+      // plugin-tests.yml, so it runs against real Postgres instead of skip-greening here.
+      'tests/integration/multitable-form-submit-start-approval-smoke.test.ts',
       // T2-6 event-driven dedup ledger: DATABASE_URL-gated. Excluded from the no-DB default job so it
       // does not skip-green, and wired as a WHOLE FILE into the `Run multitable real-DB integration`
       // job in plugin-tests.yml where it runs against real Postgres every PR.


### PR DESCRIPTION
## What & why

W6 = the automation → approval bridge. The operator-smoke gate for the **form-submit entry point** was the one un-covered seam: the 06-22 acceptance record proves `record.created → start_approval → approve → resume` (#2974), but no single test chained the operator's *actual* entry — a **form submit** (#3336 `form.submitted` trigger + #3339 editor-exposed `start_approval` action) — end-to-end to a real approval instance + the approver's todo.

This is **#1 of the approval-&-automation line**: not new capability, just walking the already-landed `form.submitted → start_approval` path over a real boundary and giving it an operator sign-off record. **No runtime change — test + CI wiring + docs only.**

## Real event chain proven (in-process seam)

```
POST /api/multitable/views/:id/submit            (real HTTP boundary, real Postgres)
  → eventBus 'multitable.form.submitted'
    → AutomationService → matchesTrigger('form.submitted')
      → executeRule(start_approval)  [workflow_job_v1 → suspended job]
        → multitable_automation_approval_bridges (status='pending', approval_instance_id)
          → approval_instances (non-terminal)
            → approval_assignments for the approver (is_active=true)  ← the todo
```

`multitable-form-submit-start-approval-smoke.test.ts` — **2/2 green** on real DB; tsc clean. Also excluded from the default no-DB Vitest config so it cannot skip-green there. Wired into the `Run multitable real-DB integration` Postgres lane in `plugin-tests.yml` (DATABASE_URL-gated, runs every PR), next to its start-approval / form-submit siblings — so it is automated, not invisible debt. `SMOKE_KEEP=1` retains rows for operator inspection.

## Scope of the PASS

**In-process seam only.** The deployed/staging operator leg (`/api` co-tenancy, real browser session, cross-process) stays **owner-gated** — see §5 of the acceptance record (`docs/development/w6-form-submit-start-approval-operator-smoke-acceptance-record-20260629.md`), which mirrors the 06-22 two-tier structure: in-process ✅ / deployed ⬜ / owner accept-vs-require decision.

## W7 state

This record no longer gates the already-shipped W7 approved-path resultWriteback runtime and editor UI. It closes the missing W6 form-submit entry proof only. W7 rejection backwrite, cross-base backwrite, and person-shaped approver writes remain separate owner-gated follow-ups.

## Operator trap recorded

`formDataMapping` values render via `renderMappedValue`, which **only emits interpolated content** — a bare literal renders empty and fails required-field validation. Use `{{…}}` (e.g. `{ summary: '… {{recordId}}' }`). The test encodes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
