### PR TITLE
feat(integration): C3 LIST paging echo diagnostic (#1709, values-free)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -966,6 +966,11 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.equal(read.metadata.returnedRecordCount, 2)
   assert.equal(read.metadata.dataDataPresent, true)
   assert.equal(read.metadata.dataRowCount, 3)
+  // Paging echo (#1709): K3 echoes the page size/index it applied; we surface requested-vs-echoed (values-free).
+  assert.equal(read.metadata.dataPageSize, 2, 'LIST surfaces K3-echoed Data.PAGESIZE')
+  assert.equal(read.metadata.dataPageIndex, 1, 'LIST surfaces K3-echoed Data.PAGEINDEX')
+  assert.equal(read.metadata.requestedLimit, 2, 'LIST surfaces requested page size/Top')
+  assert.equal(read.metadata.requestedPageIndex, 1, 'LIST surfaces requested PageIndex')
   assert.deepEqual(read.metadata.listShapeProbe, {
     dataData: true,
     dataLowerData: false,
@@ -1023,6 +1028,48 @@ async function testK3WebApiMaterialListReadSmoke() {
   const tooLarge = await adapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 4)).catch((error) => error)
   assert.ok(tooLarge instanceof AdapterValidationError, 'LIST smoke rejects limits above the preset bound')
   assert.equal(tooLarge.details.code, 'K3_WISE_READ_LIST_LIMIT_EXCEEDED')
+
+  // C3 LIST paging-echo diagnostic (#1709): the live no-key signature — K3 reports rows exist (ROWCOUNT>0) but
+  // returns a null DATA page and echoes a page size/index that does NOT match what we requested. Surfacing
+  // requested-vs-echoed paging (values-free counts) localizes a paging-param mismatch with no customer round-trip.
+  const pagingEchoFetchImpl = async (url, options) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === '/K3API/Material/GetList') {
+      return jsonResponse(200, {
+        StatusCode: 200,
+        Message: 'Material list succeeded',
+        Data: { ROWCOUNT: 30134, PAGESIZE: 0, PAGEINDEX: 0, DATA: null },
+      })
+    }
+    return fetchImpl(url, options)
+  }
+  const pagingEchoAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        objects: {
+          material: {
+            operations: ['read'],
+            readPath: '/K3API/Material/GetList',
+            readMethod: 'POST',
+            readMode: 'list',
+            readListBodyTemplate: { Data: { Top: 10, PageIndex: 1 } },
+            pageIndexField: 'PageIndex',
+            pageSizeField: 'PageSize',
+            maxListLimit: 3,
+          },
+        },
+      },
+    }),
+    fetchImpl: pagingEchoFetchImpl,
+  })
+  const pagingEcho = await pagingEchoAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2))
+  assert.equal(pagingEcho.records.length, 0, 'paging-echo list returns an empty bounded page, not a crash')
+  assert.equal(pagingEcho.metadata.dataRowCount, 30134, 'K3 reports rows exist via Data.ROWCOUNT')
+  assert.equal(pagingEcho.metadata.dataPageSize, 0, 'K3 echoes the page size it applied (0 here = did not accept requested page)')
+  assert.equal(pagingEcho.metadata.dataPageIndex, 0, 'K3 echoes the page index it applied')
+  assert.equal(pagingEcho.metadata.requestedLimit, 2, 'requested page size/Top surfaced for the requested-vs-echoed comparison')
+  assert.equal(pagingEcho.metadata.requestedPageIndex, 1, 'requested page index surfaced for the comparison')
 
   const missingRowsFetchImpl = async (url, options) => {
     const parsed = new URL(url)

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -177,6 +177,27 @@ assert.deepEqual(readSmokeSuccessEvidence(PRESET, { records: [] }, { object: 'ma
 assert.deepEqual(readSmokeSuccessEvidence(PRESET, {}, { object: 'material', mode: 'single_record_detail' }), {
   ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', mode: 'single_record_detail', recordPresent: false, recordCount: 0, referenceObjectCount: 0,
 })
+// C3 LIST paging echo (#1709): surfaces ONLY allowlisted values-free paging counts (K3-echoed page size/index +
+// requested paging); a non-count value under the same metadata (materialNumber) is never surfaced.
+const pagingEcho = readSmokeSuccessEvidence(LIST_PRESET, {
+  records: [],
+  metadata: {
+    dataRowCount: 30134,
+    dataPageSize: 0,
+    dataPageIndex: 0,
+    requestedLimit: 10,
+    requestedPageIndex: 1,
+    materialNumber: 'SECRET-MAT-001',
+  },
+}, { object: 'material', mode: 'list' })
+assert.deepEqual(pagingEcho, {
+  ok: true, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list',
+  recordPresent: false, recordCount: 0, referenceObjectCount: 0,
+  dataRowCount: 30134, dataPageSize: 0, dataPageIndex: 0, requestedLimit: 10, requestedPageIndex: 1,
+})
+assert.ok(!JSON.stringify(pagingEcho).includes('SECRET-MAT-001'), 'paging-echo evidence does not leak a material value')
+assert.ok(!JSON.stringify(pagingEcho).includes('materialNumber'), 'paging-echo evidence drops non-allowlisted metadata keys')
+
 assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, { records: [{ FNumber: 'M-001' }, { FNumber: 'M-002' }] }, { object: 'material', mode: 'list' }), {
   ok: true, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', recordPresent: true, recordCount: 2, referenceObjectCount: 0,
 })

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -826,18 +826,31 @@ function materialListDataDataPresent(data) {
   return probe.dataData || probe.dataLowerData
 }
 
-function materialListRowCount(data) {
-  const value = firstDefined(
-    getPath(data, 'Data.ROWCOUNT'),
-    getPath(data, 'Data.rowCount'),
-    getPath(data, 'Data.RowCount'),
-  )
+// Values-free non-negative-integer extraction from a fixed allowlist of K3 envelope count fields. Returns a
+// count or null; never a value/string passthrough beyond a parseable integer.
+function materialListCountField(data, paths) {
+  const value = firstDefined(...paths.map((path) => getPath(data, path)))
   if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value
   if (typeof value === 'string' && value.trim()) {
     const parsed = Number(value.trim())
     if (Number.isInteger(parsed) && parsed >= 0) return parsed
   }
   return null
+}
+
+function materialListRowCount(data) {
+  return materialListCountField(data, ['Data.ROWCOUNT', 'Data.rowCount', 'Data.RowCount'])
+}
+
+// C3 LIST paging echo (#1709): K3 echoes the accepted page size/index back in the envelope. Surfacing these
+// (values-free counts) lets a no-key rerun show whether K3 accepted our requested paging — the prime suspect
+// when ROWCOUNT>0 but DATA is null/non-array.
+function materialListPageSize(data) {
+  return materialListCountField(data, ['Data.PAGESIZE', 'Data.pageSize', 'Data.PageSize'])
+}
+
+function materialListPageIndex(data) {
+  return materialListCountField(data, ['Data.PAGEINDEX', 'Data.pageIndex', 'Data.PageIndex'])
 }
 
 function materialListBusinessSuccess(data, config) {
@@ -1364,6 +1377,11 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       const listShapeProbe = materialListShapeProbe(readResponse.data)
       const dataDataPresent = listShapeProbe.dataData || listShapeProbe.dataLowerData
       const dataRowCount = materialListRowCount(readResponse.data)
+      // Paging echo: what K3 reports it applied, vs what we requested (Top=PageSize=request.limit, PageIndex=1).
+      const dataPageSize = materialListPageSize(readResponse.data)
+      const dataPageIndex = materialListPageIndex(readResponse.data)
+      const requestedLimit = request.limit
+      const requestedPageIndex = 1
       if (!materialListBusinessSuccess(readResponse.data, config)) {
         const failureCode = materialListBusinessFailureCode(readResponse.data)
         throw new K3WiseWebApiAdapterError(String(responseMessage(readResponse.data, config, 'K3 WISE list read business response failed')), {
@@ -1372,6 +1390,10 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           responseCode: responseFailureCode(readResponse.data, config, failureCode),
           dataDataPresent,
           dataRowCount,
+          dataPageSize,
+          dataPageIndex,
+          requestedLimit,
+          requestedPageIndex,
           listShapeProbe,
         })
       }
@@ -1383,10 +1405,13 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
         metadata: {
           object: request.object,
           mode: 'material-list-smoke',
-          requestedLimit: request.limit,
+          requestedLimit,
+          requestedPageIndex,
           returnedRecordCount: records.length,
           dataDataPresent,
           dataRowCount,
+          dataPageSize,
+          dataPageIndex,
           listShapeProbe,
           readPath,
           readOnly: true,

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -103,6 +103,17 @@ function readSmokeSafeCount(value) {
   return null
 }
 
+// C3 LIST paging echo (#1709): copy ONLY the allowlisted values-free count fields (K3-echoed page size/index +
+// our requested paging) from a metadata/details source onto the evidence. Non-negative integers only.
+const READ_SMOKE_LIST_PAGING_COUNT_KEYS = Object.freeze(['dataPageSize', 'dataPageIndex', 'requestedLimit', 'requestedPageIndex'])
+function applyReadSmokePagingCounts(evidence, source) {
+  if (!source || typeof source !== 'object') return
+  for (const key of READ_SMOKE_LIST_PAGING_COUNT_KEYS) {
+    const count = readSmokeSafeCount(source[key])
+    if (count !== null) evidence[key] = count
+  }
+}
+
 function mergeOperations(existing, required) {
   const values = []
   for (const source of [existing, required]) {
@@ -206,6 +217,7 @@ function readSmokeSuccessEvidence(preset, result, contract = {}) {
   }
   const dataRowCount = readSmokeSafeCount(result && result.metadata && result.metadata.dataRowCount)
   if (dataRowCount !== null) evidence.dataRowCount = dataRowCount
+  applyReadSmokePagingCounts(evidence, result && result.metadata)
   const listShapeProbe = readSmokeListShapeProbeEvidence(result && result.metadata && result.metadata.listShapeProbe)
   if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
   return evidence
@@ -234,6 +246,7 @@ function readSmokeErrorEvidence(preset, error, contract = {}) {
   }
   const dataRowCount = readSmokeSafeCount(error && error.details && error.details.dataRowCount)
   if (dataRowCount !== null) evidence.dataRowCount = dataRowCount
+  applyReadSmokePagingCounts(evidence, error && error.details)
   const listShapeProbe = readSmokeListShapeProbeEvidence(error && error.details && error.details.listShapeProbe)
   if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
   return evidence


### PR DESCRIPTION
## What

Values-free **diagnostic** slice for the #1709 C3 LIST no-key result. The no-key smoke on #3369 showed K3 `Data.ROWCOUNT=30134` but a **null DATA page** and all fixed row-container probes `false` — i.e. the GetList request *reaches* the live Material list, but we don't get the page. The prime suspect is a **paging-param mismatch** (the `pagingFieldsMostlyMatch` "mostly" from the doc comparison).

This surfaces the **K3-echoed page size/index vs. our requested paging** (values-free counts) so a no-key rerun localizes the mismatch **without a customer round-trip**.

## Changes

- **adapter** (`k3-wise-webapi-adapter.cjs`): `materialListPageSize` / `materialListPageIndex` (allowlisted `Data.PAGESIZE`/`PAGEINDEX`, non-negative int or null, via a DRY `materialListCountField`); surface `dataPageSize` / `dataPageIndex` + `requestedLimit` / `requestedPageIndex` on **both** the list success metadata and the failure details.
- **read-smoke** (`read-smoke.cjs`): `applyReadSmokePagingCounts` copies only the 4 allowlisted counts (`readSmokeSafeCount`-sanitized) onto success + error evidence.

## Boundary / discipline

- **Diagnostic only** — *no* paging-value change, *no* filter/endpoint/body-shape change, no BOM/resolver/Save/Submit/Audit/production write.
- **Values-free** — counts only (frozen allowlist); a non-count value under the same metadata is dropped (test-locked).
- Don't guess the paging fix: the doc gave field names, not working values. This slice lets K3's echo reveal exactly what it accepted; the targeted one-line paging fix is the *next* slice.

## Tests

- Keystone live-signature case: `ROWCOUNT=30134 + DATA=null + mismatched PAGESIZE/PAGEINDEX echo` → empty bounded page (no crash), requested-vs-echoed surfaced.
- Happy-path echo (K3 echoes the requested page) + values-free evidence (material value / non-allowlisted key never surfaced).
- Full `plugin-integration-core` CJS suite **55/55**.

## Next

Package + **no-key rerun** → compare `requestedLimit`/`requestedPageIndex` vs `dataPageSize`/`dataPageIndex`:
- echo ≠ requested → paging-param mismatch → one-line targeted paging fix → rerun → `recordPresent=true` = first real C3 LIST PASS (unfiltered page; decoupled from the keyed-filter loop).
- echo == requested but DATA still null → container shape (less likely given 30134 + doc says `Data.DATA`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
