### PR TITLE
feat(multitable): OAPI-4a per-base/sheet scoped-token runtime (records slice)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -168,7 +168,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -200,6 +200,7 @@ jobs:
             tests/integration/multitable-oapi2a-token-write-realdb.test.ts \
             tests/integration/multitable-oapi2a-comments-write-realdb.test.ts \
             tests/integration/multitable-oapi2a-ratelimit-realdb.test.ts \
+            tests/integration/multitable-oapi-scope-guard-realdb.test.ts \
             tests/integration/multitable-fieldperm-write-gate-patch-realdb.test.ts \
             tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -168,7 +168,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -201,6 +201,7 @@ jobs:
             tests/integration/multitable-oapi2a-comments-write-realdb.test.ts \
             tests/integration/multitable-oapi2a-ratelimit-realdb.test.ts \
             tests/integration/multitable-oapi-scope-guard-realdb.test.ts \
+            tests/integration/multitable-oapi-token-create-scope.api.test.ts \
             tests/integration/multitable-fieldperm-write-gate-patch-realdb.test.ts \
             tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \

--- a/docs/development/multitable-oapi4a-scoped-token-runtime-dev-verification-20260629.md
+++ b/docs/development/multitable-oapi4a-scoped-token-runtime-dev-verification-20260629.md
@@ -19,8 +19,9 @@ creator RBAC)` — enforced by one shared guard on every records route (read + w
 | **Guard** | `middleware/oapi-scope-guard.ts` (NEW) | the shared `oapiScopeGuard` (§2–§4). |
 | Audit | `multitable/oapi-write-audit.ts` | the `res.on('finish')` boundary threads `req.oapiAuditReason` → `recordOapiWriteAttempt` → value-scrubbed `detail.reason`. |
 | Routes | `routes/univer-meta.ts` | `oapiScopeGuard` mounted on all **10** reachable records routes at the locked positions (§2). |
-| Golden | `tests/integration/multitable-oapi-scope-guard-realdb.test.ts` (NEW, 14 tests) | §5. |
-| CI | `.github/workflows/plugin-tests.yml` | golden added to the real-DB file list + step name (§5). |
+| **REST mint** | `routes/api-tokens.ts` | `CreateTokenSchema` + the create route now accept/persist `baseIds`/`sheetIds` (review fix — Zod's unknown-key strip previously dropped them, so the supported minting API could only produce unscoped creator-wide tokens). |
+| Golden | `multitable-oapi-scope-guard-realdb.test.ts` (NEW, 15 tests) + `multitable-oapi-token-create-scope.api.test.ts` (NEW, 6 tests) | §5. |
+| CI | `.github/workflows/plugin-tests.yml` | both goldens added to the real-DB file list + step name (§5). |
 
 ## 2. Enforcement seam + route wiring (locked order)
 `oapiScopeGuard` is a strict no-op unless `req.apiTokenId` is set, and a no-op (allow) for an unscoped token.
@@ -52,12 +53,17 @@ client-supplied baseId.
   (T-f NO-ORACLE: `missing.body` deep-equals `outOfScope.body`).
 
 ## 5. Verification (real DB) — `metasheet_oapi4a_test`, all migrations applied
-**`multitable-oapi-scope-guard-realdb.test.ts` → 14/14 passed.** Coverage: in-scope allow (base / sheet / both
+**`multitable-oapi-scope-guard-realdb.test.ts` → 15/15 passed.** Coverage: in-scope allow (base / sheet / both
 narrowest / read) · out-of-base 403 + **denied audit row with `detail.reason='out_of_base_sheet_scope'`** + no
-mutation · out-of-sheet 403 · legacy-unscoped unchanged (writes any base, reads any sheet) · session no-op
-(writes a sheet no scoped token could reach) · record-addressed allow/deny + **no-oracle byte-identical 403** ·
-DELETE out-of-scope 403 + record present · **3-way min** (in-base but no write capability → 403
-`INSUFFICIENT_SCOPE`) · **rotateToken preserves scope** · **/patch defense-in-depth** (below).
+mutation · out-of-sheet 403 · **out-of-scope READ 403** (uniform read+write, review add) · legacy-unscoped
+unchanged (writes any base, reads any sheet) · session no-op (writes a sheet no scoped token could reach) ·
+record-addressed allow/deny + **no-oracle byte-identical 403** · DELETE out-of-scope 403 + record present ·
+**3-way min** (in-base but no write capability → 403 `INSUFFICIENT_SCOPE`) · **rotateToken preserves scope** ·
+**/patch defense-in-depth** (below).
+**`multitable-oapi-token-create-scope.api.test.ts` → 6/6 passed (review fix).** Proves the supported REST
+minting surface: create with `baseIds`/`sheetIds` → persisted (DB row asserted) + returned + listed · the
+REST-minted token is **enforced** (denied out-of-scope 403 `OUT_OF_SCOPE`) and allowed in-scope · `sheetIds`
+accepted. Regression for the Zod-strip footgun (a "scoped" create silently minting an unscoped token).
 **Adjacent OAPI suites (regression):** oapi1-token-read + oapi2a-token-write + oapi2a-ratelimit → all green
 (**36/36 across the 4 suites**). **Typecheck:** `tsc --noEmit` exit 0, clean.
 

--- a/docs/development/multitable-oapi4a-scoped-token-runtime-dev-verification-20260629.md
+++ b/docs/development/multitable-oapi4a-scoped-token-runtime-dev-verification-20260629.md
@@ -1,0 +1,98 @@
+# OAPI-4a — per-base/sheet scoped-token runtime (records slice) — dev & verification (2026-06-29)
+
+> Status: built + verified (real-DB, fail-first proven). Grounding: `origin/main` @ `8bb4a7573`. Builds to the
+> RATIFIED design-lock `docs/development/multitable-oapi4-scoped-tokens-designlock-20260629.md` (#3370). Scope =
+> **records routes only** (OAPI-4b comments / OAPI-4c UI are OUT). Default behavior unchanged on deploy
+> (additive nullable migration, no backfill → legacy tokens stay creator-wide).
+
+## 1. What shipped
+A third authorization dimension on `mst_` tokens — `effective access = min(capability scope, base/sheet scope,
+creator RBAC)` — enforced by one shared guard on every records route (read + write).
+
+| Layer | File | Change |
+|---|---|---|
+| Migration | `db/migrations/zzzz20260629120000_add_api_token_base_sheet_scope.ts` | `ALTER TABLE multitable_api_tokens ADD COLUMN base_ids text[]` + `sheet_ids text[]` — **nullable, no default, no backfill**. `down()` drops both. |
+| DB type | `db/types.ts` | `MultitableApiTokensTable` gains `base_ids: string[] \| null` + `sheet_ids: string[] \| null`. |
+| Types | `multitable/api-tokens.ts` | `ApiToken` + `ApiTokenCreateInput` gain optional `baseIds` / `sheetIds`. |
+| Service | `multitable/api-token-service.ts` | `normalizeScopeArray` (trim/dedupe/empty→NULL) + `readScopeArray` (NULL/empty→undefined); `createToken` persists; `rowToToken` maps back (so `validateToken` carries them); **`rotateToken` copies scope forward** (no silent widen). |
+| Auth mw | `middleware/api-token-auth.ts` | `apiTokenAuth` attaches `req.apiTokenBaseIds`/`apiTokenSheetIds`; `Express.Request` gains those + `oapiAuditReason`; `requireScope` sets `req.oapiAuditReason='insufficient_scope'` before its 403. |
+| **Guard** | `middleware/oapi-scope-guard.ts` (NEW) | the shared `oapiScopeGuard` (§2–§4). |
+| Audit | `multitable/oapi-write-audit.ts` | the `res.on('finish')` boundary threads `req.oapiAuditReason` → `recordOapiWriteAttempt` → value-scrubbed `detail.reason`. |
+| Routes | `routes/univer-meta.ts` | `oapiScopeGuard` mounted on all **10** reachable records routes at the locked positions (§2). |
+| Golden | `tests/integration/multitable-oapi-scope-guard-realdb.test.ts` (NEW, 14 tests) | §5. |
+| CI | `.github/workflows/plugin-tests.yml` | golden added to the real-DB file list + step name (§5). |
+
+## 2. Enforcement seam + route wiring (locked order)
+`oapiScopeGuard` is a strict no-op unless `req.apiTokenId` is set, and a no-op (allow) for an unscoped token.
+Mounted on all **10** mst_-reachable records routes (the read allowlist regex covers `/records` AND
+`/records/:recordId`):
+- **Writes** (4): `POST /records`, `PATCH /records/:recordId`, `DELETE /records/:recordId`, `POST /patch` —
+  `apiTokenAuth → oapiWriteAuditBoundary → apiTokenWriteRateLimit → oapiScopeGuard → requireScope → handler`.
+  Guard **after** the rate-limiter (out-of-scope attempts are themselves rate-limited) and **before**
+  `requireScope`; the audit boundary's finish-listener captures the 403.
+- **Reads** (6): `GET /records`, `/records/:recordId`, `/view`, `/sheets/:sheetId/view-aggregate`,
+  `/records-summary`, `/fields` — `apiTokenAuth → oapiScopeGuard → requireScope`.
+
+## 3. Scope composition (§3 of the lock)
+Per resolved target sheet `S` in base `B`: in-scope iff `(base_ids empty OR B ∈ base_ids) AND
+(sheet_ids empty OR S ∈ sheet_ids)`. **Every** touched sheet must resolve AND pass (fail-closed). The target
+base is resolved **server-side** (`SELECT id, base_id FROM meta_sheets WHERE id = ANY(...)`) — never a
+client-supplied baseId.
+
+## 4. Two load-bearing decisions
+- **recordId-authoritative resolution (no spoof):** for `:recordId` routes the guard resolves the sheet from
+  the **record** (`SELECT sheet_id FROM meta_records WHERE id = $1`), NOT a body `sheetId`. A scoped token
+  cannot declare an out-of-scope record into an in-scope sheet. (Soft-delete moves rows out of `meta_records`
+  into a trash table — there is no `deleted_at` column — so a deleted/absent record resolves to no sheet → []
+  → uniform 403; the no-oracle property holds. This was a build fix: an initial `AND deleted_at IS NULL` threw
+  on the missing column and the fail-closed `catch` masked it on the out-of-scope cases — caught by the
+  in-scope T-f assertion, then corrected.)
+- **No-oracle uniform 403:** unresolvable target (missing record / no sheet id / unknown sheet) and out-of-scope
+  return the **same** `403 OUT_OF_SCOPE` body — a scoped token cannot probe existence. Verified byte-identical
+  (T-f NO-ORACLE: `missing.body` deep-equals `outOfScope.body`).
+
+## 5. Verification (real DB) — `metasheet_oapi4a_test`, all migrations applied
+**`multitable-oapi-scope-guard-realdb.test.ts` → 14/14 passed.** Coverage: in-scope allow (base / sheet / both
+narrowest / read) · out-of-base 403 + **denied audit row with `detail.reason='out_of_base_sheet_scope'`** + no
+mutation · out-of-sheet 403 · legacy-unscoped unchanged (writes any base, reads any sheet) · session no-op
+(writes a sheet no scoped token could reach) · record-addressed allow/deny + **no-oracle byte-identical 403** ·
+DELETE out-of-scope 403 + record present · **3-way min** (in-base but no write capability → 403
+`INSUFFICIENT_SCOPE`) · **rotateToken preserves scope** · **/patch defense-in-depth** (below).
+**Adjacent OAPI suites (regression):** oapi1-token-read + oapi2a-token-write + oapi2a-ratelimit → all green
+(**36/36 across the 4 suites**). **Typecheck:** `tsc --noEmit` exit 0, clean.
+
+**Fail-first (the guard is load-bearing):** neutralizing `oapiScopeGuard` (early `next()`) turns exactly the 6
+scope-enforcement tests RED — T-b (out-of-base), T-c (out-of-sheet), T-f PATCH / NO-ORACLE / DELETE, T-h
+(rotated scope) — while the 8 non-scope tests (in-scope allow, legacy-unscoped, session, capability-min) stay
+green. The enforcement is necessary for precisely the right assertions.
+
+**CI wiring (test-infra invariant):** added to `.github/workflows/plugin-tests.yml`:
+`tests/integration/multitable-oapi-scope-guard-realdb.test.ts \` in the "Run multitable real-DB integration"
+file list (+ the step name). Acceptance = the file appears in the step output with passing counts (a
+`describeIfDatabase` golden silently skips green if omitted).
+
+## 6. /patch defense-in-depth (coordinator addendum — verified)
+`/patch` is single-sheet (the body carries ONE `sheetId`; `changes[]` are `{recordId, fieldId, value}` with no
+per-change sheet), so the guard's one resolved sheet IS the full target set. A scoped token could still pass an
+in-scope `sheetId` yet name a `recordId` living in another sheet — but `RecordWriteService.patchRecords`
+**confines every write to the declared sheet**: the UPDATE is `WHERE sheet_id = $2 AND id = $3`
+(`record-write-service.ts:892–904`) and the load/existence SELECTs are all `WHERE sheet_id = $1 AND id …`
+(731 / 855 / 1067). An out-of-sheet `recordId` matches zero rows → untouched. **Not a cross-sheet hole.**
+Golden **T-patch confinement** asserts: in-scope `sheetId=A`, `changes[].recordId` = a SHEET-B record → that
+record is unchanged. (No fix to `patchRecords` was needed or made.)
+
+## 7. Security invariants (§8 of the lock) → evidence
+- *A scoped token can NEVER act outside its base_ids/sheet_ids, any route, read or write* → T-a..T-c, T-f, the
+  read tests, fail-first.
+- *Scoping only tightens (AND-constraint, never OR-widen)* → 3-way min T-g (capability still required) +
+  legacy-unscoped T-d (no new grant).
+- *Target base resolved server-side from sheet→base* → guard resolves via `meta_sheets`, never a client baseId
+  (recordId-authoritative resolution T-f).
+- *Revoking/scoping takes effect next request* → `validateToken` reads scope per request; `rotateToken`
+  preserves scope (T-h).
+
+## 8. Out of scope / follow-ups
+OAPI-4b (comments through the same guard, with server-side comment→container→sheet→base resolution + the
+uniform 404/403 shape) and OAPI-4c (token-create UI base/sheet pickers) are separate opt-ins. `/patch` is
+single-sheet today; if a multi-sheet batch is ever added, the guard's `resolveTargetSheetIds` must enumerate
+the full set (it already iterates a set and fails closed on any unresolved/out-of-scope member).

--- a/packages/core-backend/src/db/migrations/zzzz20260629120000_add_api_token_base_sheet_scope.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260629120000_add_api_token_base_sheet_scope.ts
@@ -1,0 +1,21 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * OAPI-4a — per-base/sheet scoped API tokens (design-lock
+ * `docs/development/multitable-oapi4-scoped-tokens-designlock-20260629.md`, RATIFIED).
+ *
+ * Additive, nullable, NO backfill: existing tokens keep `base_ids = sheet_ids = NULL` →
+ * **unscoped → creator-wide**, exactly today's OAPI-2 behavior. Scoping is opt-in per token; no
+ * token's behavior changes on deploy. `text[]` whitelists; the §3 AND-composition is applied in the
+ * request-time `oapiScopeGuard`, not in SQL.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE multitable_api_tokens ADD COLUMN IF NOT EXISTS base_ids text[]`.execute(db)
+  await sql`ALTER TABLE multitable_api_tokens ADD COLUMN IF NOT EXISTS sheet_ids text[]`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE multitable_api_tokens DROP COLUMN IF EXISTS sheet_ids`.execute(db)
+  await sql`ALTER TABLE multitable_api_tokens DROP COLUMN IF EXISTS base_ids`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1464,6 +1464,9 @@ export interface MultitableApiTokensTable {
   expires_at: NullableTimestamp
   revoked: boolean
   revoked_at: NullableTimestamp
+  // OAPI-4a per-base/sheet scope whitelists (nullable text[]; NULL/empty = unscoped = creator-wide).
+  base_ids: string[] | null
+  sheet_ids: string[] | null
 }
 
 export interface MultitableWebhooksTable {

--- a/packages/core-backend/src/middleware/api-token-auth.ts
+++ b/packages/core-backend/src/middleware/api-token-auth.ts
@@ -17,6 +17,11 @@ declare global {
       apiTokenUserId?: string
       /** The API token's own id (NOT the creator's). Used to key the per-token rate limiter. */
       apiTokenId?: string
+      /** OAPI-4a per-base/sheet scope whitelists (undefined/empty = unscoped = creator-wide). */
+      apiTokenBaseIds?: string[]
+      apiTokenSheetIds?: string[]
+      /** OAPI-4a: a scrubbed reason a 403-issuing guard sets so the write-audit boundary records it. */
+      oapiAuditReason?: string
     }
   }
 }
@@ -67,6 +72,9 @@ export async function apiTokenAuth(
   req.apiTokenUserId = result.token.createdBy
   // The token's own id — keys the per-token rate limiter (OAPI-2a). NOT the creator id.
   req.apiTokenId = result.token.id
+  // OAPI-4a per-base/sheet scope — read by `oapiScopeGuard` (undefined = unscoped = creator-wide).
+  req.apiTokenBaseIds = result.token.baseIds
+  req.apiTokenSheetIds = result.token.sheetIds
 
   // Set a minimal user object so downstream route guards work
   req.user = {
@@ -91,6 +99,9 @@ export function requireScope(scope: ApiTokenScope) {
     }
 
     if (!req.apiTokenScopes.includes(scope)) {
+      // OAPI-4a: record the capability-scope denial reason for the write-audit boundary (distinct from
+      // the base/sheet `out_of_base_sheet_scope` reason set by oapiScopeGuard).
+      req.oapiAuditReason = 'insufficient_scope'
       res.status(403).json({
         ok: false,
         error: {

--- a/packages/core-backend/src/middleware/oapi-scope-guard.ts
+++ b/packages/core-backend/src/middleware/oapi-scope-guard.ts
@@ -1,0 +1,136 @@
+/**
+ * OAPI-4a — per-base/sheet scoped-token guard (design-lock
+ * `docs/development/multitable-oapi4-scoped-tokens-designlock-20260629.md`, RATIFIED).
+ *
+ * One shared guard, mounted on every token-accepting records route (read AND write), AFTER `apiTokenAuth`
+ * (and, on writes, AFTER `apiTokenWriteRateLimit` so out-of-scope attempts are themselves rate-limited) and
+ * BEFORE the handler. It resolves the request's target sheet(s) → base server-side and rejects a scoped token
+ * whose whitelist does not cover them.
+ *
+ * Invariants:
+ *  - STRICT NO-OP for session/JWT requests (no `req.apiTokenId`) — ordinary edits/reads are byte-for-byte unchanged.
+ *  - NO-OP (allow) for an UNSCOPED token (both whitelists empty) — legacy creator-wide back-compat.
+ *  - §3 AND-composition; **every** touched target must be in-scope (fail-closed on cross-/multi-target).
+ *  - The target base is resolved from the sheet→base map server-side — never a client-supplied baseId.
+ *  - For a record-addressed route (`:recordId`), the authoritative sheet is the RECORD'S sheet (a body
+ *    `sheetId` is NOT trusted), so a token cannot mis-declare a record into an in-scope sheet.
+ *  - NO-ORACLE: an unresolvable target (missing record / no sheet id / unknown sheet) and an out-of-scope
+ *    target both return the SAME uniform 403 `OUT_OF_SCOPE` — a scoped token cannot probe existence.
+ */
+import type { Request, Response, NextFunction } from 'express'
+import { poolManager } from '../integration/db/connection-pool'
+
+/** Uniform out-of-scope rejection — identical body for not-found and out-of-scope (no existence oracle). */
+function denyOutOfScope(req: Request, res: Response): void {
+  // Scrubbed reason for the write-audit boundary (reads carry no audit). MUST be set before the response
+  // is sent, so the `res.on('finish')` listener observes it.
+  req.oapiAuditReason = 'out_of_base_sheet_scope'
+  res.status(403).json({
+    ok: false,
+    error: { code: 'OUT_OF_SCOPE', message: 'API token is not scoped to the requested base/sheet' },
+  })
+}
+
+/**
+ * Resolve the FULL set of target sheet ids this request touches, server-side.
+ * Returns `[]` when the target cannot be resolved (→ the caller fails closed with a uniform 403).
+ */
+async function resolveTargetSheetIds(req: Request): Promise<string[]> {
+  const pool = poolManager.get()
+  const params = (req.params ?? {}) as Record<string, unknown>
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const query = (req.query ?? {}) as Record<string, unknown>
+
+  // Record-addressed routes (PATCH / DELETE / GET /records/:recordId): the authoritative sheet is the
+  // record's own sheet — do NOT trust a body/query sheetId here. (Soft-delete moves rows OUT of meta_records
+  // into a trash table — there is no `deleted_at` column — so a deleted/absent record simply resolves to no
+  // sheet → [] → uniform 403, preserving the no-oracle property.)
+  const recordId = typeof params.recordId === 'string' ? params.recordId : null
+  if (recordId) {
+    const r = await pool.query('SELECT sheet_id FROM meta_records WHERE id = $1', [recordId])
+    const row = (r.rows as Array<{ sheet_id?: unknown }>)[0]
+    const sid = row && typeof row.sheet_id === 'string' ? row.sheet_id : null
+    return sid ? [sid] : []
+  }
+
+  // Direct sheet id: path param (`/sheets/:sheetId/...`), else body, else query.
+  const directSheetId =
+    (typeof params.sheetId === 'string' && params.sheetId) ||
+    (typeof body.sheetId === 'string' && body.sheetId) ||
+    (typeof query.sheetId === 'string' && query.sheetId) ||
+    null
+  if (directSheetId) return [directSheetId]
+
+  // View id → its sheet.
+  const viewId =
+    (typeof body.viewId === 'string' && body.viewId) ||
+    (typeof query.viewId === 'string' && query.viewId) ||
+    null
+  if (viewId) {
+    const r = await pool.query('SELECT sheet_id FROM meta_views WHERE id = $1', [viewId])
+    const row = (r.rows as Array<{ sheet_id?: unknown }>)[0]
+    const sid = row && typeof row.sheet_id === 'string' ? row.sheet_id : null
+    return sid ? [sid] : []
+  }
+
+  return []
+}
+
+export async function oapiScopeGuard(req: Request, res: Response, next: NextFunction): Promise<void> {
+  // No-op for session/JWT requests.
+  if (!req.apiTokenId) {
+    next()
+    return
+  }
+
+  const baseIds = req.apiTokenBaseIds
+  const sheetIds = req.apiTokenSheetIds
+  const baseScoped = Array.isArray(baseIds) && baseIds.length > 0
+  const sheetScoped = Array.isArray(sheetIds) && sheetIds.length > 0
+
+  // Unscoped token → legacy creator-wide → allow (the capability scope + creator RBAC still apply downstream).
+  if (!baseScoped && !sheetScoped) {
+    next()
+    return
+  }
+
+  try {
+    const targetSheetIds = await resolveTargetSheetIds(req)
+    if (targetSheetIds.length === 0) {
+      // Unresolvable target — fail closed, uniform with out-of-scope (no oracle).
+      denyOutOfScope(req, res)
+      return
+    }
+
+    const pool = poolManager.get()
+    const baseRes = await pool.query(
+      'SELECT id, base_id FROM meta_sheets WHERE id = ANY($1::text[])',
+      [targetSheetIds],
+    )
+    const baseBySheet = new Map<string, string | null>()
+    for (const row of baseRes.rows as Array<{ id: unknown; base_id: unknown }>) {
+      baseBySheet.set(String(row.id), typeof row.base_id === 'string' ? row.base_id : null)
+    }
+
+    // EVERY touched sheet must resolve AND satisfy the §3 AND-composition (fail-closed).
+    for (const sid of targetSheetIds) {
+      if (!baseBySheet.has(sid)) {
+        // Target sheet does not exist (or is unreadable at the catalog) — uniform deny.
+        denyOutOfScope(req, res)
+        return
+      }
+      const baseId = baseBySheet.get(sid) ?? null
+      const baseOk = !baseScoped || (baseId !== null && (baseIds as string[]).includes(baseId))
+      const sheetOk = !sheetScoped || (sheetIds as string[]).includes(sid)
+      if (!baseOk || !sheetOk) {
+        denyOutOfScope(req, res)
+        return
+      }
+    }
+
+    next()
+  } catch {
+    // Any resolution error → fail closed with the SAME uniform 403 (never a 500 that leaks, never an allow).
+    denyOutOfScope(req, res)
+  }
+}

--- a/packages/core-backend/src/multitable/api-token-service.ts
+++ b/packages/core-backend/src/multitable/api-token-service.ts
@@ -32,6 +32,21 @@ function hashToken(plainText: string): string {
   return createHash('sha256').update(plainText).digest('hex')
 }
 
+/**
+ * OAPI-4a — normalize an optional per-base/sheet scope list for PERSISTENCE: trim, drop empties, dedupe;
+ * an empty/absent list → `null` so "unscoped" (creator-wide) is unambiguous in the column (never `[]`).
+ */
+function normalizeScopeArray(v: readonly string[] | undefined | null): string[] | null {
+  if (!v || v.length === 0) return null
+  const cleaned = [...new Set(v.map((s) => s.trim()).filter((s) => s.length > 0))]
+  return cleaned.length > 0 ? cleaned : null
+}
+
+/** Read a Postgres `text[]` scope column back to the optional domain shape (NULL/empty → undefined). */
+function readScopeArray(v: string[] | null | undefined): string[] | undefined {
+  return v && v.length > 0 ? v : undefined
+}
+
 /** Map a DB row to the domain ApiToken. */
 function rowToToken(row: {
   id: string
@@ -45,6 +60,8 @@ function rowToToken(row: {
   expires_at?: string | Date | null
   revoked: boolean
   revoked_at?: string | Date | null
+  base_ids?: string[] | null
+  sheet_ids?: string[] | null
 }): ApiToken {
   const scopes =
     typeof row.scopes === 'string'
@@ -56,6 +73,8 @@ function rowToToken(row: {
     tokenHash: row.token_hash,
     tokenPrefix: row.token_prefix,
     scopes,
+    baseIds: readScopeArray(row.base_ids),
+    sheetIds: readScopeArray(row.sheet_ids),
     createdBy: row.created_by,
     createdAt:
       row.created_at instanceof Date
@@ -107,6 +126,9 @@ export class ApiTokenService {
     const id = generateTokenId()
     const now = new Date().toISOString()
 
+    const baseIds = normalizeScopeArray(input.baseIds)
+    const sheetIds = normalizeScopeArray(input.sheetIds)
+
     await this.db
       .insertInto('multitable_api_tokens')
       .values({
@@ -119,6 +141,8 @@ export class ApiTokenService {
         created_at: now,
         expires_at: input.expiresAt ?? undefined,
         revoked: false,
+        base_ids: baseIds,
+        sheet_ids: sheetIds,
       })
       .execute()
 
@@ -128,6 +152,8 @@ export class ApiTokenService {
       tokenHash: tokenHashValue,
       tokenPrefix,
       scopes: [...input.scopes],
+      baseIds: baseIds ?? undefined,
+      sheetIds: sheetIds ?? undefined,
       createdBy: userId,
       createdAt: now,
       expiresAt: input.expiresAt,
@@ -269,6 +295,10 @@ export class ApiTokenService {
       const id = generateTokenId()
       const now = new Date().toISOString()
 
+      // A rotated token KEEPS its per-base/sheet scope — never silently widen to creator-wide.
+      const baseIds = normalizeScopeArray(token.baseIds)
+      const sheetIds = normalizeScopeArray(token.sheetIds)
+
       await trx
         .insertInto('multitable_api_tokens')
         .values({
@@ -281,6 +311,8 @@ export class ApiTokenService {
           created_at: now,
           expires_at: token.expiresAt ?? undefined,
           revoked: false,
+          base_ids: baseIds,
+          sheet_ids: sheetIds,
         })
         .execute()
 
@@ -290,6 +322,8 @@ export class ApiTokenService {
         tokenHash: tokenHashValue,
         tokenPrefix,
         scopes: [...token.scopes],
+        baseIds: baseIds ?? undefined,
+        sheetIds: sheetIds ?? undefined,
         createdBy: userId,
         createdAt: now,
         expiresAt: token.expiresAt,

--- a/packages/core-backend/src/multitable/api-tokens.ts
+++ b/packages/core-backend/src/multitable/api-tokens.ts
@@ -15,6 +15,10 @@ export interface ApiToken {
   expiresAt?: string       // optional expiry
   revoked: boolean
   revokedAt?: string
+  // OAPI-4a per-base/sheet scope whitelists. Both absent/empty = unscoped (creator-wide, legacy).
+  // The §3 AND-composition is enforced at request time by `oapiScopeGuard`.
+  baseIds?: string[]
+  sheetIds?: string[]
 }
 
 export type ApiTokenScope =
@@ -38,6 +42,10 @@ export interface ApiTokenCreateInput {
   name: string
   scopes: ApiTokenScope[]
   expiresAt?: string
+  // OAPI-4a optional per-base/sheet scope. Empty/absent → unscoped (creator-wide). Normalized
+  // (trim/dedupe/empty→NULL) by ApiTokenService.createToken.
+  baseIds?: string[]
+  sheetIds?: string[]
 }
 
 export interface ApiTokenCreateResult {

--- a/packages/core-backend/src/multitable/oapi-write-audit.ts
+++ b/packages/core-backend/src/multitable/oapi-write-audit.ts
@@ -120,10 +120,12 @@ export async function recordOapiWriteAttempt(
   ctx: OapiWriteAuditContext,
   outcome: Exclude<OapiWriteOutcome, 'committed'>,
   statusCode: number,
-  detailText?: string,
+  reason?: string,
 ): Promise<void> {
   try {
-    const detail = detailText ? JSON.stringify({ message: redactString(detailText) }) : null
+    // OAPI-4a: a 403-issuing guard (oapiScopeGuard / requireScope) sets a fixed, enum-like reason
+    // (`out_of_base_sheet_scope` / `insufficient_scope`); persist it value-scrubbed as `detail.reason`.
+    const detail = reason ? JSON.stringify({ reason: redactString(reason) }) : null
     await sql`
       INSERT INTO oapi_write_audit
         (token_id, actor_id, operation, scope, sheet_id, record_ids, batch_count, outcome, status_code, request_id, detail)
@@ -157,7 +159,9 @@ export function oapiWriteAuditBoundary(operation: OapiWriteOperation, scope: str
       if (sc >= 200 && sc < 300) return // committed — audited in-txn
       const outcome: Exclude<OapiWriteOutcome, 'committed'> =
         sc === 429 ? 'rate_limited' : sc === 403 ? 'denied' : 'error'
-      void recordOapiWriteAttempt(ctx, outcome, sc)
+      // `req.oapiAuditReason` is set synchronously by the guard before the 403 is sent, so it is
+      // observable here at finish-time (undefined for rate_limited/error — bare outcome row, as before).
+      void recordOapiWriteAttempt(ctx, outcome, sc, req.oapiAuditReason)
     })
     next()
   }

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -41,6 +41,11 @@ const CreateTokenSchema = z.object({
   name: z.string().min(1).max(100),
   scopes: z.array(z.enum(ALL_API_TOKEN_SCOPES as [string, ...string[]])).min(1),
   expiresAt: z.string().datetime().optional(),
+  // OAPI-4a per-base/sheet least-privilege scope (opt-in). Omitted/empty → unscoped (creator-wide).
+  // Scoping only TIGHTENS (the guard ANDs it with capability scope + creator RBAC), so accepting
+  // arbitrary ids cannot widen access beyond what the creator's RBAC already allows.
+  baseIds: z.array(z.string().min(1)).optional(),
+  sheetIds: z.array(z.string().min(1)).optional(),
 })
 
 const CreateDingTalkGroupSchema = z.object({
@@ -238,6 +243,8 @@ export function apiTokensRouter(): Router {
         name: input.name,
         scopes: input.scopes as import('../multitable/api-tokens').ApiTokenScope[],
         expiresAt: input.expiresAt,
+        baseIds: input.baseIds,
+        sheetIds: input.sheetIds,
       })
       res.status(201).json({
         ok: true,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -158,6 +158,7 @@ import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value,
 import { apiTokenWriteRateLimit, conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import { buildOapiAuditContext, oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
 import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
+import { oapiScopeGuard } from '../middleware/oapi-scope-guard'
 import {
   AutomationRuleValidationError,
   getAutomationServiceInstance,
@@ -10041,7 +10042,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.get('/fields', apiTokenAuth, requireScope('fields:read'), async (req: Request, res: Response) => {
+  router.get('/fields', apiTokenAuth, oapiScopeGuard, requireScope('fields:read'), async (req: Request, res: Response) => {
     const sheetId = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : ''
     if (!sheetId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
@@ -12040,7 +12041,7 @@ export function univerMetaRouter(): Router {
   // Aggregation footer (benchmark v2 #4-3b-1): aggregate the full (unpaginated) PERSISTED-view-filtered
   // record set. view-config-driven (view.config.aggregations), no ad-hoc params. Field visibility uses
   // the D3c export composite (hidden fields' aggregates OMITTED — leak guard). Max-rows hard-fails (413).
-  router.get('/sheets/:sheetId/view-aggregate', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
+  router.get('/sheets/:sheetId/view-aggregate', apiTokenAuth, oapiScopeGuard, requireScope('records:read'), async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const viewId = typeof req.query.viewId === 'string' ? req.query.viewId.trim() : ''
     const search = normalizeSearchTerm(req.query.search) // same normalization as /view (trim+lowercase) → search parity
@@ -12394,7 +12395,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.get('/view', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
+  router.get('/view', apiTokenAuth, oapiScopeGuard, requireScope('records:read'), async (req: Request, res: Response) => {
     const sheetIdParam = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : undefined
     const viewIdParam = typeof req.query.viewId === 'string' ? req.query.viewId.trim() : undefined
     const seed = req.query.seed === 'true'
@@ -13611,7 +13612,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.patch('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('update', 'records:write'), apiTokenWriteRateLimit, requireScope('records:write'), async (req: Request, res: Response) => {
+  router.patch('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('update', 'records:write'), apiTokenWriteRateLimit, oapiScopeGuard, requireScope('records:write'), async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
     if (!recordId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
@@ -13807,7 +13808,7 @@ export function univerMetaRouter(): Router {
    * When `cursor` is absent the first page is returned.
    * When `cursor` is present, offset-based params are ignored.
    */
-  router.get('/records', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
+  router.get('/records', apiTokenAuth, oapiScopeGuard, requireScope('records:read'), async (req: Request, res: Response) => {
     const sheetId = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : ''
     if (!sheetId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
@@ -13936,7 +13937,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.get('/records/:recordId', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
+  router.get('/records/:recordId', apiTokenAuth, oapiScopeGuard, requireScope('records:read'), async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
     const sheetIdParam = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : undefined
     const viewIdParam = typeof req.query.viewId === 'string' ? req.query.viewId.trim() : undefined
@@ -14124,7 +14125,7 @@ export function univerMetaRouter(): Router {
    *
    * Returns: { ok: true, data: { records: [{id, display}], page: {offset, limit, total, hasMore} } }
    */
-  router.get('/records-summary', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
+  router.get('/records-summary', apiTokenAuth, oapiScopeGuard, requireScope('records:read'), async (req: Request, res: Response) => {
     const sheetId = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : ''
     const displayFieldId = typeof req.query.displayFieldId === 'string' ? req.query.displayFieldId.trim() : null
     const search = typeof req.query.search === 'string' ? req.query.search.trim().toLowerCase() : ''
@@ -14624,7 +14625,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.post('/records', apiTokenAuth, oapiWriteAuditBoundary('create', 'records:write'), apiTokenWriteRateLimit, requireScope('records:write'), async (req: Request, res: Response) => {
+  router.post('/records', apiTokenAuth, oapiWriteAuditBoundary('create', 'records:write'), apiTokenWriteRateLimit, oapiScopeGuard, requireScope('records:write'), async (req: Request, res: Response) => {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),
@@ -14886,7 +14887,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.delete('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('delete', 'records:write'), apiTokenWriteRateLimit, requireScope('records:write'), async (req: Request, res: Response) => {
+  router.delete('/records/:recordId', apiTokenAuth, oapiWriteAuditBoundary('delete', 'records:write'), apiTokenWriteRateLimit, oapiScopeGuard, requireScope('records:write'), async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId : ''
     if (!recordId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
@@ -15167,7 +15168,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.post('/patch', apiTokenAuth, oapiWriteAuditBoundary('upsert', 'records:write'), apiTokenWriteRateLimit, requireScope('records:write'), async (req: Request, res: Response) => {
+  router.post('/patch', apiTokenAuth, oapiWriteAuditBoundary('upsert', 'records:write'), apiTokenWriteRateLimit, oapiScopeGuard, requireScope('records:write'), async (req: Request, res: Response) => {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),

--- a/packages/core-backend/tests/integration/multitable-oapi-scope-guard-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi-scope-guard-realdb.test.ts
@@ -1,0 +1,222 @@
+/**
+ * OAPI-4a — per-base/sheet scoped-token guard (real DB).
+ * Design-lock: docs/development/multitable-oapi4-scoped-tokens-designlock-20260629.md (RATIFIED).
+ *
+ * Proves the shared `oapiScopeGuard` confines an `mst_` token to its base_ids/sheet_ids whitelist on every
+ * records route (read + write), with the §3 AND-composition, fail-closed cross-/multi-target, a uniform
+ * no-oracle 403, the 3-way min (capability ∩ base/sheet ∩ creator RBAC), legacy-unscoped + session passthrough,
+ * the denied write-audit row carrying detail.reason, rotateToken scope preservation, and the /patch
+ * defense-in-depth (patchRecords confines to the declared sheet_id so an out-of-sheet recordId is untouched).
+ *
+ * FAIL-FIRST: with `oapiScopeGuard` removed from the route chains, the out-of-base/out-of-sheet writes (T-b/T-c)
+ * SUCCEED creator-wide → those assertions (403 + no-mutation + denied-reason audit) go RED. Verified manually
+ * (see dev-verification MD §4). Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { db } from '../../src/db/db'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApiTokenService } from '../../src/multitable/api-token-service'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_A = `base_sg_a_${TS}`
+const BASE_B = `base_sg_b_${TS}`
+const SHEET_A1 = `sheet_sg_a1_${TS}`
+const SHEET_A2 = `sheet_sg_a2_${TS}`
+const SHEET_B1 = `sheet_sg_b1_${TS}`
+const FLD_A1 = `fld_sg_a1_${TS}`
+const FLD_A2 = `fld_sg_a2_${TS}`
+const FLD_B1 = `fld_sg_b1_${TS}`
+const REC_A1 = `rec_sg_a1_${TS}`
+const REC_B1 = `rec_sg_b1_${TS}`
+const WRITER = `user_sg_writer_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let sessionApp: Express
+// tokens (all created by WRITER, who holds multitable:write so the min-spine passes for in-scope writes)
+let tUnscoped = '', tUnscopedId = ''
+let tBaseA = '', tBaseAId = ''
+let tSheetA1 = '', tSheetA1Id = ''
+let tBoth = ''
+let tBaseAReadOnly = ''
+
+const recData = async (recordId: string): Promise<Record<string, unknown> | null> => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+  return r.rows.length ? (r.rows[0] as { data: Record<string, unknown> }).data : null
+}
+const auditRows = async (tokenId: string): Promise<Array<{ outcome: string; status_code: number | null; detail: unknown }>> => {
+  const r = await q('SELECT outcome, status_code, detail FROM oapi_write_audit WHERE token_id = $1 ORDER BY id', [tokenId])
+  return r.rows as Array<{ outcome: string; status_code: number | null; detail: unknown }>
+}
+const post = (path: string, token: string, body: unknown) =>
+  request(app).post(path).set('Authorization', `Bearer ${token}`).send(body)
+const patch = (recordId: string, token: string, body: unknown) =>
+  request(app).patch(`/api/multitable/records/${recordId}`).set('Authorization', `Bearer ${token}`).send(body)
+const del = (recordId: string, token: string) =>
+  request(app).delete(`/api/multitable/records/${recordId}`).set('Authorization', `Bearer ${token}`)
+const getRec = (path: string, token: string) =>
+  request(app).get(path).set('Authorization', `Bearer ${token}`)
+const flush = () => new Promise((r) => setTimeout(r, 80)) // let the res.on('finish') audit listener flush
+
+describeIfDatabase('OAPI-4a scoped-token guard (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use('/api/multitable', univerMetaRouter())
+    // A SESSION app: inject a logged-in user (no token) to prove the guard is a strict no-op for session reqs.
+    sessionApp = express()
+    sessionApp.use(express.json())
+    sessionApp.use((req, _res, next) => { ;(req as express.Request & { user?: unknown }).user = { id: WRITER }; next() })
+    sessionApp.use('/api/multitable', univerMetaRouter())
+
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1,$2,$3,'x','member',$4::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET permissions = EXCLUDED.permissions`,
+      [WRITER, `${WRITER}@t.local`, WRITER, JSON.stringify(['multitable:read', 'multitable:write'])],
+    )
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2),($3,$4)', [BASE_A, 'SG Base A', BASE_B, 'SG Base B'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3),($4,$5,$6),($7,$8,$9)', [
+      SHEET_A1, BASE_A, 'A1', SHEET_A2, BASE_A, 'A2', SHEET_B1, BASE_B, 'B1',
+    ])
+    await q(
+      `INSERT INTO meta_fields (id, sheet_id, name, type, property, "order")
+       VALUES ($1,$2,'F','text','{}'::jsonb,1),($3,$4,'F','text','{}'::jsonb,1),($5,$6,'F','text','{}'::jsonb,1)`,
+      [FLD_A1, SHEET_A1, FLD_A2, SHEET_A2, FLD_B1, SHEET_B1],
+    )
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1),($4,$5,$6::jsonb,1)', [
+      REC_A1, SHEET_A1, JSON.stringify({ [FLD_A1]: 'a1-seed' }),
+      REC_B1, SHEET_B1, JSON.stringify({ [FLD_B1]: 'b1-seed' }),
+    ])
+
+    const svc = new ApiTokenService(db)
+    const rw = ['records:write', 'records:read', 'fields:read'] as const
+    const u = await svc.createToken(WRITER, { name: 'unscoped', scopes: [...rw] })
+    tUnscoped = u.plainTextToken; tUnscopedId = u.token.id
+    const ba = await svc.createToken(WRITER, { name: 'baseA', scopes: [...rw], baseIds: [BASE_A] })
+    tBaseA = ba.plainTextToken; tBaseAId = ba.token.id
+    const sa = await svc.createToken(WRITER, { name: 'sheetA1', scopes: [...rw], sheetIds: [SHEET_A1] })
+    tSheetA1 = sa.plainTextToken; tSheetA1Id = sa.token.id
+    const bo = await svc.createToken(WRITER, { name: 'both', scopes: [...rw], baseIds: [BASE_A], sheetIds: [SHEET_A1] })
+    tBoth = bo.plainTextToken
+    const bro = await svc.createToken(WRITER, { name: 'baseA-ro', scopes: ['records:read'], baseIds: [BASE_A] })
+    tBaseAReadOnly = bro.plainTextToken
+  })
+
+  afterAll(async () => {
+    await db.deleteFrom('multitable_api_tokens').where('created_by', '=', WRITER).execute().catch(() => {})
+    await q('DELETE FROM oapi_write_audit WHERE actor_id = $1', [WRITER]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A1, SHEET_A2, SHEET_B1]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_A1, SHEET_A2, SHEET_B1]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A1, SHEET_A2, SHEET_B1]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [WRITER]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── (a) in-scope ALLOW ────────────────────────────────────────────────────
+  test('T-a base-scoped token writes into an in-scope sheet (POST /records)', async () => {
+    const res = await post('/api/multitable/records', tBaseA, { sheetId: SHEET_A1, data: { [FLD_A1]: 'by-baseA' } })
+    expect([200, 201]).toContain(res.status)
+  })
+  test('T-a sheet-scoped + both-scoped tokens allowed on their exact sheet', async () => {
+    expect([200, 201]).toContain((await post('/api/multitable/records', tSheetA1, { sheetId: SHEET_A1, data: { [FLD_A1]: 'by-sheetA1' } })).status)
+    expect([200, 201]).toContain((await post('/api/multitable/records', tBoth, { sheetId: SHEET_A1, data: { [FLD_A1]: 'by-both' } })).status)
+  })
+  test('T-a read: base-scoped token reads an in-scope sheet (GET /records)', async () => {
+    expect((await getRec(`/api/multitable/records?sheetId=${SHEET_A1}`, tBaseA)).status).toBe(200)
+  })
+
+  // ── (b) out-of-BASE → 403 OUT_OF_SCOPE + denied audit w/ reason + NO mutation ─
+  test('T-b out-of-base write → 403 OUT_OF_SCOPE, no mutation, denied audit row with detail.reason', async () => {
+    const before = await recData(REC_B1)
+    const res = await post('/api/multitable/records', tBaseA, { sheetId: SHEET_B1, data: { [FLD_B1]: 'should-not-write' } })
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('OUT_OF_SCOPE')
+    const after = await q('SELECT COUNT(*)::int AS n FROM meta_records WHERE sheet_id = $1', [SHEET_B1])
+    expect((after.rows[0] as { n: number }).n).toBe(1) // only the seed — nothing created
+    expect(await recData(REC_B1)).toEqual(before)
+    await flush()
+    const denied = (await auditRows(tBaseAId)).filter((r) => r.outcome === 'denied' && r.status_code === 403)
+    expect(denied.length).toBeGreaterThanOrEqual(1)
+    expect(denied.some((r) => (r.detail as { reason?: string } | null)?.reason === 'out_of_base_sheet_scope')).toBe(true)
+  })
+
+  // ── (c) out-of-SHEET (same base) → 403 ────────────────────────────────────
+  test('T-c sheet-scoped token denied on a sibling sheet in the SAME base (out-of-sheet)', async () => {
+    const res = await post('/api/multitable/records', tSheetA1, { sheetId: SHEET_A2, data: { [FLD_A2]: 'wrong-sheet' } })
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('OUT_OF_SCOPE')
+  })
+
+  // ── (d) legacy UNSCOPED token → unchanged (creator-wide) ──────────────────
+  test('T-d unscoped token writes ANY base + reads ANY sheet (legacy creator-wide, unchanged)', async () => {
+    expect([200, 201]).toContain((await post('/api/multitable/records', tUnscoped, { sheetId: SHEET_B1, data: { [FLD_B1]: 'unscoped-ok' } })).status)
+    expect((await getRec(`/api/multitable/records?sheetId=${SHEET_B1}`, tUnscoped)).status).toBe(200)
+  })
+
+  // ── (e) SESSION request → unaffected (guard strict no-op) ─────────────────
+  test('T-e session request (no token) writes a sheet no scoped token could reach → guard no-op', async () => {
+    const res = await request(sessionApp).post('/api/multitable/records').send({ sheetId: SHEET_B1, data: { [FLD_B1]: 'by-session' } })
+    expect([200, 201]).toContain(res.status)
+  })
+
+  // ── (f) record-addressed routes + NO-ORACLE ───────────────────────────────
+  test('T-f PATCH in-scope record allowed; out-of-scope record 403 + untouched', async () => {
+    expect((await patch(REC_A1, tBaseA, { sheetId: SHEET_A1, data: { [FLD_A1]: 'patched-in-scope' } })).status).toBe(200)
+    const before = await recData(REC_B1)
+    const res = await patch(REC_B1, tBaseA, { sheetId: SHEET_B1, data: { [FLD_B1]: 'patched-out' } })
+    expect(res.status).toBe(403)
+    expect(await recData(REC_B1)).toEqual(before) // untouched
+  })
+  test('T-f NO-ORACLE: out-of-scope record and MISSING record return byte-identical 403', async () => {
+    const outOfScope = await patch(REC_B1, tBaseA, { sheetId: SHEET_B1, data: { [FLD_B1]: 'x' } })
+    const missing = await patch(`rec_sg_does_not_exist_${TS}`, tBaseA, { sheetId: SHEET_A1, data: { x: 'y' } })
+    expect(outOfScope.status).toBe(403)
+    expect(missing.status).toBe(403)
+    expect(missing.body).toEqual(outOfScope.body) // no existence oracle
+    expect(missing.body?.error?.code).toBe('OUT_OF_SCOPE')
+  })
+  test('T-f DELETE out-of-scope record → 403, record still present (authoritative sheet = record sheet)', async () => {
+    const res = await del(REC_B1, tBaseA)
+    expect(res.status).toBe(403)
+    expect((await q('SELECT 1 FROM meta_records WHERE id = $1', [REC_B1])).rows.length).toBe(1)
+  })
+
+  // ── (g) 3-way MIN (capability ∩ base/sheet ∩ creator RBAC) ────────────────
+  test('T-g token in-scope by base but missing the WRITE capability → 403 INSUFFICIENT_SCOPE', async () => {
+    const res = await post('/api/multitable/records', tBaseAReadOnly, { sheetId: SHEET_A1, data: { [FLD_A1]: 'no-write-cap' } })
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('INSUFFICIENT_SCOPE') // capability gate, not the base/sheet gate
+  })
+
+  // ── (h) rotateToken PRESERVES scope ───────────────────────────────────────
+  test('T-h rotated token keeps its base scope (not widened to creator-wide)', async () => {
+    const svc = new ApiTokenService(db)
+    const rotated = await svc.rotateToken(tBaseAId, WRITER)
+    expect(rotated.token.baseIds).toEqual([BASE_A])
+    const tok = rotated.plainTextToken
+    // still bounded: in-scope allowed, out-of-scope denied
+    expect([200, 201]).toContain((await post('/api/multitable/records', tok, { sheetId: SHEET_A1, data: { [FLD_A1]: 'rotated-ok' } })).status)
+    expect((await post('/api/multitable/records', tok, { sheetId: SHEET_B1, data: { [FLD_B1]: 'rotated-out' } })).status).toBe(403)
+  })
+
+  // ── (+) /patch DEFENSE-IN-DEPTH: declared sheet in-scope, but a change names an out-of-sheet record ──
+  test('T-patch confinement: in-scope declared sheet, change.recordId in another sheet → that record untouched', async () => {
+    const before = await recData(REC_B1) // belongs to SHEET_B1
+    // tSheetA1 is in-scope for SHEET_A1; declare sheetId=SHEET_A1 (guard passes) but target REC_B1 (sheet B1).
+    const res = await post('/api/multitable/patch', tSheetA1, {
+      sheetId: SHEET_A1,
+      changes: [{ recordId: REC_B1, fieldId: FLD_B1, value: 'cross-sheet-attempt' }],
+    })
+    // patchRecords confines to WHERE sheet_id = $declaredSheet AND id = $recordId → the B1 record matches 0 rows.
+    // The request may 200 (no-op for the unmatched change) or error, but REC_B1 MUST be unchanged either way.
+    expect(await recData(REC_B1)).toEqual(before)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-oapi-scope-guard-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi-scope-guard-realdb.test.ts
@@ -155,6 +155,13 @@ describeIfDatabase('OAPI-4a scoped-token guard (real DB)', () => {
     expect(res.body?.error?.code).toBe('OUT_OF_SCOPE')
   })
 
+  // ── (c-read) out-of-scope READ → 403 (the lock requires uniform read AND write) ──
+  test('T-c read: base-scoped token reading an out-of-scope sheet → 403 OUT_OF_SCOPE', async () => {
+    const res = await getRec(`/api/multitable/records?sheetId=${SHEET_B1}`, tBaseA)
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('OUT_OF_SCOPE')
+  })
+
   // ── (d) legacy UNSCOPED token → unchanged (creator-wide) ──────────────────
   test('T-d unscoped token writes ANY base + reads ANY sheet (legacy creator-wide, unchanged)', async () => {
     expect([200, 201]).toContain((await post('/api/multitable/records', tUnscoped, { sheetId: SHEET_B1, data: { [FLD_B1]: 'unscoped-ok' } })).status)

--- a/packages/core-backend/tests/integration/multitable-oapi-token-create-scope.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi-token-create-scope.api.test.ts
@@ -1,0 +1,125 @@
+/**
+ * OAPI-4a — REST token-create scope plumbing (real DB).
+ *
+ * Regression for a review finding: the supported minting surface POST /api/multitable/api-tokens had a
+ * `CreateTokenSchema` of only {name,scopes,expiresAt}, so Zod's default unknown-key STRIP silently dropped a
+ * caller's `baseIds`/`sheetIds` → a "scoped" create produced an UNSCOPED creator-wide token (a least-privilege
+ * footgun: scoped tokens could not be minted through the API at all).
+ *
+ * Proves the supported surface now: (1) REST create accepts + persists baseIds/sheetIds and returns them;
+ * (2) the list reflects the persisted scope; (3) the REST-minted token is genuinely ENFORCED by oapiScopeGuard
+ * (denied out-of-scope) — i.e. the scope is real end-to-end, not just echoed back. Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+
+// Stub ONLY the session-auth middleware (inject the logged-in creator) — the REAL db is kept, so the token is
+// genuinely persisted and the guard enforces against real meta_sheets. The factory cannot close over outer
+// vars (vi.mock is hoisted), so the creator id is a fixed literal, mirrored by WRITER below.
+vi.mock('../../src/middleware/auth', () => {
+  const authenticate = (req: { user?: unknown }, _res: unknown, next: () => void) => {
+    ;(req as { user?: unknown }).user = { id: 'user_tc_oapi4a_fixed' }
+    next()
+  }
+  return { authenticate, authMiddleware: authenticate, default: authenticate }
+})
+
+import { apiTokensRouter } from '../../src/routes/api-tokens'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const WRITER = 'user_tc_oapi4a_fixed' // MUST equal the id injected by the auth mock above
+const BASE_X = `base_tc_x_${TS}`
+const BASE_Y = `base_tc_y_${TS}`
+const SHEET_X = `sheet_tc_x_${TS}`
+const SHEET_Y = `sheet_tc_y_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let mintedPlaintext = ''
+
+describeIfDatabase('OAPI-4a REST token-create scope plumbing (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use(apiTokensRouter()) // absolute paths: /api/multitable/api-tokens (session create/list)
+    app.use('/api/multitable', univerMetaRouter()) // the mst_ guard path: /api/multitable/records
+    // Clean any residue from a prior run (the creator id is fixed).
+    await db.deleteFrom('multitable_api_tokens').where('created_by', '=', WRITER).execute().catch(() => {})
+    // The creator holds global multitable perms so the 3-way min's CREATOR-RBAC leg passes for an in-scope op
+    // (the guard is the base/sheet leg; an in-scope op must clear BOTH to succeed).
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1,$2,$3,'x','member',$4::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET permissions = EXCLUDED.permissions`,
+      [WRITER, `${WRITER}@t.local`, WRITER, JSON.stringify(['multitable:read', 'multitable:write'])],
+    )
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2),($3,$4)', [BASE_X, 'TC X', BASE_Y, 'TC Y'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3),($4,$5,$6)', [
+      SHEET_X, BASE_X, 'X', SHEET_Y, BASE_Y, 'Y',
+    ])
+    // A field + record on SHEET_X (mirrors the scope-guard golden) so the in-scope read is a faithful 200.
+    await q(`INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,'F','text','{}'::jsonb,1)`, [`fld_tc_x_${TS}`, SHEET_X])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_tc_x_${TS}`, SHEET_X, JSON.stringify({})])
+  })
+
+  afterAll(async () => {
+    await db.deleteFrom('multitable_api_tokens').where('created_by', '=', WRITER).execute().catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_X, SHEET_Y]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_X, SHEET_Y]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_X, SHEET_Y]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_X, BASE_Y]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [WRITER]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('REST create accepts + persists baseIds (NOT stripped) and returns them', async () => {
+    const res = await request(app)
+      .post('/api/multitable/api-tokens')
+      .send({ name: 'scoped-x', scopes: ['records:write', 'records:read'], baseIds: [BASE_X] })
+    expect(res.status).toBe(201)
+    expect(res.body?.data?.token?.baseIds).toEqual([BASE_X])
+    expect(typeof res.body?.data?.plaintext).toBe('string')
+    expect(res.body.data.plaintext).toMatch(/^mst_/)
+    mintedPlaintext = res.body.data.plaintext
+    // persisted, not merely echoed
+    const row = await q('SELECT base_ids FROM multitable_api_tokens WHERE id = $1', [res.body.data.token.id])
+    expect((row.rows[0] as { base_ids: string[] }).base_ids).toEqual([BASE_X])
+  })
+
+  test('list reflects the persisted scope', async () => {
+    const res = await request(app).get('/api/multitable/api-tokens')
+    expect(res.status).toBe(200)
+    const tok = (res.body?.data?.tokens ?? []).find((t: { name?: string }) => t.name === 'scoped-x')
+    expect(tok?.baseIds).toEqual([BASE_X])
+  })
+
+  test('the REST-minted scoped token is ENFORCED — denied out-of-scope (base Y) 403 OUT_OF_SCOPE', async () => {
+    const res = await request(app)
+      .post('/api/multitable/records')
+      .set('Authorization', `Bearer ${mintedPlaintext}`)
+      .send({ sheetId: SHEET_Y, data: {} })
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('OUT_OF_SCOPE')
+  })
+
+  test('the REST-minted scoped token is allowed IN-scope (base X) — proves the scope is the gate, not a blanket block', async () => {
+    const res = await request(app)
+      .get(`/api/multitable/records?sheetId=${SHEET_X}`)
+      .set('Authorization', `Bearer ${mintedPlaintext}`)
+    expect(res.status).toBe(200)
+  })
+
+  test('REST create accepts sheetIds too (not stripped)', async () => {
+    const res = await request(app)
+      .post('/api/multitable/api-tokens')
+      .send({ name: 'scoped-sheet', scopes: ['records:read'], sheetIds: [SHEET_X] })
+    expect(res.status).toBe(201)
+    expect(res.body?.data?.token?.sheetIds).toEqual([SHEET_X])
+  })
+})


### PR DESCRIPTION
Runtime for the ratified scoped-tokens lock **#3370** — records slice (comments=4b, UI=4c stay out). Adds a third authorization dimension to `mst_` tokens: **effective access = min(capability scope, base/sheet scope, creator RBAC)**, enforced by one shared `oapiScopeGuard` on every records route (read + write).

**Security model**
- **Default-off by construction:** additive nullable `base_ids[]`/`sheet_ids[]`, **no backfill** → legacy tokens stay `NULL` = unscoped = creator-wide, unchanged on deploy. Opt-in per token.
- **§3 AND-composition**, fail-closed: every touched base/sheet must be in-scope.
- **Record-authoritative resolution:** PATCH/DELETE/GET `:recordId` resolve the sheet from the *record* server-side, never a body `sheetId` (no spoof).
- **No-oracle:** missing / unknown / out-of-scope all return a **byte-identical 403 `OUT_OF_SCOPE`** — a scoped token can't probe existence. Fail-closed `catch` (deny over leak).
- **Locked middleware order:** `apiTokenAuth → oapiWriteAuditBoundary → apiTokenWriteRateLimit → oapiScopeGuard → requireScope` (out-of-scope 403 is both rate-limited and recorded with a scrubbed `detail.reason`). Session = strict no-op.
- **/patch defense-in-depth:** `patchRecords` confines writes to `WHERE sheet_id AND id`, golden-proven against a cross-sheet `recordId`.

**Verification:** real-DB golden **15/15** (in-scope allow · out-of-base/sheet 403 + denied audit w/ reason + no mutation · **out-of-scope read 403** · legacy-unscoped + session passthrough · no-oracle byte-identical · DELETE authoritative-sheet · 3-way min · rotateToken keeps scope · /patch confinement); **fail-first** (6 RED when guard neutralized); **36/36** across the 4 OAPI suites; `tsc` clean; golden registered in `plugin-tests.yml` and confirmed RAN. Reviewed line-by-line + advisor pass (the `GET /records/:recordId` mount confirmed a **pre-existing-route middleware insertion**, body untouched — not a new read surface).

Dev/verification MD: `docs/development/multitable-oapi4a-scoped-token-runtime-dev-verification-20260629.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)