### PR TITLE
docs(multitable): time-machine masterplan + TODO (PROPOSED)

### DIFF
--- a/docs/development/multitable-time-machine-plus-design-lock-20260619.md
+++ b/docs/development/multitable-time-machine-plus-design-lock-20260619.md
@@ -1,0 +1,301 @@
+# Multitable Time Machine+ Design Lock
+
+Status: DESIGN / OWNER-RATIFY BEFORE RUNTIME. No code changes are authorized by this document. The first implementation PR must start from T1/T4 in the companion TODO only after this design is accepted.
+
+Grounding: drafted on 2026-06-19 against the completed multitable history / restore / trash line on `origin/main` (record history, per-field restore, readable trash titles, actor display names, and rule-deny-aware trash/restore are already shipped). This design intentionally starts a new product arc: a global history center and restore workflow that goes beyond per-record history.
+
+## 0. Goal
+
+Build a global multitable history and recovery center that surpasses the baseline "Time Machine" feature set by combining:
+
+- global timeline and filtering across sheets / records / actors / sources;
+- batch-level change understanding, not only raw revision rows;
+- permission-safe search, totals, and details;
+- field-level diff drilldown;
+- restore preview before mutation;
+- scoped restore of selected records / fields / changes;
+- restore-as-forward-revision auditability;
+- point-in-time read-only view before any point-in-time rollback.
+
+The north-star user promise:
+
+> A user can understand who changed what, why it changed, how much would be affected by restore, and which parts cannot be restored because of permission, schema, deletion, or conflict rules before any data is changed.
+
+## 1. Baseline And Differentiation
+
+Baseline capability to match:
+
+- filter history by time;
+- filter history by operator;
+- filter history by data;
+- view history details;
+- restore a specified historical version.
+
+Time Machine+ acceptance bar:
+
+- batch-level operation grouping;
+- actor / source explanation (`manual`, `api`, `automation`, `import`, `ai`, `restore`, `system`);
+- visible-only history with no hidden-record, hidden-field, or total-count leak;
+- restore preview before mutation;
+- selected-record and selected-field restore;
+- restore as a forward change that is itself visible in history;
+- point-in-time read-only reconstruction before point-in-time restore;
+- conflict report for schema drift, deleted records, stale versions, and field write gates.
+
+## 2. Non-Goals For The First Program
+
+- No database engine rewrite.
+- No row-capacity target in this arc.
+- No formula-engine performance target in this arc.
+- No permanent purge UI unless separately approved.
+- No silent full-base rollback.
+- No config/schema restore in the first runtime slice.
+- No direct exposure of raw revision tables as the public API.
+- No restore endpoint that bypasses preview for multi-record or multi-field actions.
+
+## 3. Locked Principles
+
+### LOCK-1: History Is A Read Model, Not The Source Of Truth
+
+The canonical sources remain the existing record revisions, trash records, field metadata, permission rules, and operation provenance. Time Machine+ may build a queryable projection over those sources, but it must not introduce a parallel write primitive or bypass the existing restore/write gates.
+
+### LOCK-2: Batch Is The Primary UX Unit
+
+The global timeline shows operation batches first, not individual field cells. A batch groups changes produced by one user/API/automation/import/AI/restore/system action.
+
+A batch can contain:
+
+- record creates;
+- record updates;
+- record deletes;
+- record restores / undeletes;
+- field-level value sets / unsets;
+- link sync changes;
+- later slices: config/view/permission changes.
+
+### LOCK-3: Permission Filtering Applies Before Counts, Search, And Detail
+
+A user must not infer denied records or hidden fields from:
+
+- event count;
+- total count;
+- search result count;
+- filter option presence;
+- field names;
+- diff payloads;
+- restore preview conflicts;
+- missing-vs-forbidden response shape.
+
+Rule-denied records are invisible unless the route has an explicit admin-bypass contract. Field-hidden / field-read-denied values never appear in history detail or restore preview.
+
+### LOCK-4: Restore Is Always Forward-Writing
+
+Restore never rewinds storage in place. It creates new revisions / changes that appear in the history center and can themselves be understood and, where applicable, undone by a later restore.
+
+### LOCK-5: Multi-Record Or Multi-Field Restore Requires Preview
+
+Batch restore and point-in-time restore require a dry-run preview first. The preview must be permission-filtered and must report:
+
+- affected records;
+- affected fields;
+- denied records / fields;
+- missing or deleted targets;
+- schema drift;
+- field write conflicts;
+- expected-version conflicts;
+- link / formula side effects that will be recomputed or rejected.
+
+Runtime restore must require a preview token or equivalent server-verifiable preview identity. A client must not be able to skip preview for the high-risk restore modes.
+
+### LOCK-6: Point-In-Time View Comes Before Point-In-Time Restore
+
+The first point-in-time feature is a read-only reconstruction: "show the table as of time T" for visible data. Full restore-to-time is deferred until read-only reconstruction is proven under permissions, pagination, deleted records, and schema drift.
+
+### LOCK-7: Config History Is Separate From Data History
+
+Record data history ships first. Field/schema/view/permission history may be captured and displayed later, but restore of config changes is a separate product decision and must not be mixed with data restore in the first runtime slices.
+
+### LOCK-8: Source Attribution Is Part Of The Product Contract
+
+Every batch should carry enough provenance to answer "why did this happen?":
+
+- actor id and display name snapshot when available;
+- source kind;
+- request / trace id when available;
+- automation / import / AI action id when available;
+- source batch id for restore-created batches.
+
+Missing provenance must degrade gracefully, not block history display.
+
+## 4. Proposed Read Model
+
+The exact migration shape is a later implementation decision, but the design assumes an append-only projection with two logical layers.
+
+### `history_batches`
+
+- `id`
+- `base_id`
+- `sheet_id` nullable
+- `actor_id` nullable
+- `actor_name_snapshot` nullable
+- `source`: `manual | api | automation | import | ai | restore | system`
+- `action`: `create | update | delete | restore | bulk_update | config_change`
+- `created_at`
+- `affected_record_count`
+- `affected_field_count`
+- `trace_id` nullable
+- `request_id` nullable
+- `metadata jsonb`
+
+### `history_changes`
+
+- `id`
+- `batch_id`
+- `sheet_id`
+- `record_id`
+- `field_id` nullable
+- `change_kind`: `value_set | value_unset | record_create | record_delete | record_restore | link_sync | config_change`
+- `before jsonb` nullable
+- `after jsonb` nullable
+- `before_version` nullable
+- `after_version` nullable
+- `field_type_snapshot` nullable
+- `created_at`
+
+The public API must return permission-filtered projections of these rows, not raw internal rows.
+
+## 5. API Shape
+
+### `GET /api/multitable/bases/:baseId/history/events`
+
+Query:
+
+- `sheetId?`
+- `actorId?`
+- `source?`
+- `action?`
+- `from?`
+- `to?`
+- `recordQuery?`
+- `fieldIds?`
+- `limit`
+- `cursor`
+
+Returns permission-filtered batch summaries. Totals and cursors must be computed after permission filtering.
+
+### `GET /api/multitable/history/events/:batchId`
+
+Returns:
+
+- batch summary;
+- grouped records;
+- grouped field diffs;
+- visible-only detail;
+- source explanation when available.
+
+Denied and missing batches must share the same not-found shape unless an admin-bypass contract explicitly applies.
+
+### `POST /api/multitable/history/restore-preview`
+
+Body:
+
+- `batchId?`
+- `targetTime?`
+- `sheetId?`
+- `recordIds?`
+- `fieldIds?`
+- `changeIds?`
+- `mode: batch | point_in_time | selected_changes`
+
+Returns:
+
+- allowed changes;
+- denied changes;
+- conflicts;
+- schema drift;
+- expected effects;
+- preview token / identity.
+
+### `POST /api/multitable/history/restore`
+
+Requires a preview token or equivalent server-verifiable preview identity. Creates forward revisions only. Restore-created batches must link back to the source batch / target time where applicable.
+
+## 6. UI Shape
+
+### Global History Center
+
+Entry point: multitable toolbar / more menu. The first screen is a timeline of batches with dense filters:
+
+- time range;
+- actor;
+- source;
+- action;
+- sheet;
+- visible record title / data search;
+- field.
+
+### Batch Detail
+
+Batch detail shows:
+
+- action summary;
+- actor and source;
+- affected record count;
+- affected field count;
+- grouped record list;
+- field-level before/after diffs;
+- hidden/denied items summarized only when doing so does not leak existence.
+
+### Restore Flow
+
+Restore is a three-step flow for multi-record or multi-field actions:
+
+1. choose scope;
+2. preview effects and conflicts;
+3. confirm and execute.
+
+The confirm screen must name the scope in human terms and must not rely on raw record ids when a visible title exists.
+
+## 7. Verification Strategy
+
+Every runtime slice must include real-DB security goldens for:
+
+- hidden record is absent from list and total;
+- hidden field is absent from filters, detail, and preview;
+- denied vs missing batch detail has the same external shape;
+- admin-bypass works only where explicitly allowed;
+- restore preview writes nothing;
+- restore execution requires preview identity;
+- restore creates a forward batch / revision;
+- restore event is visible as `source=restore`.
+
+Frontend tests are not sufficient for permission claims. UI slices need component tests for behavior and at least one route/integration proof for API contract and masking.
+
+## 8. Open Decisions Before Runtime
+
+These decisions must be ratified before the first runtime slice:
+
+1. Is `history_batches` materialized at write time, backfilled from revisions, or initially projected from revisions on read?
+2. Is the first MVP scoped to one base, one sheet, or all sheets inside a base?
+3. Which sources are in the first source enum: manual/API/import/automation/AI/restore/system, or a smaller subset?
+4. What is the retention promise for the global history read model?
+5. Should restore preview tokens be persisted rows, signed payloads, or short-lived cache entries?
+6. What is the maximum batch restore size before requiring async execution?
+7. Are config/view changes captured in the first projection but hidden from UI, or fully deferred?
+
+## 9. First Program Recommendation
+
+Start with read-only confidence before mutation:
+
+1. T0 design-lock ratification.
+2. T1 batch projection.
+3. T4 permission-safe query hardening.
+4. T2 global history center read-only UI.
+5. T3 batch detail.
+6. T5 restore preview.
+7. T6 scoped restore.
+8. T7 point-in-time read-only view.
+9. T8 point-in-time restore.
+10. T9 config history.
+
+The smallest useful release is T1 + T4 + T2 + T3: a read-only, permission-safe global history center with batch detail. Restore should not ship until preview exists.

--- a/docs/development/multitable-time-machine-plus-todo-20260619.md
+++ b/docs/development/multitable-time-machine-plus-todo-20260619.md
@@ -1,0 +1,348 @@
+# Multitable Time Machine+ TODO
+
+Status: PLANNED / GATED. This TODO depends on `multitable-time-machine-plus-design-lock-20260619.md`. Runtime work is not authorized until the design-lock open decisions are ratified.
+
+Grounding: created on 2026-06-19 after the multitable history / restore / trash line reached product-grade UX. This document is the implementation queue for the next arc: a global, permission-safe Time Machine+ history center.
+
+## 0. Success Definition
+
+The arc is complete when users can:
+
+- open a global multitable history center;
+- filter changes by time, actor, source, action, sheet, field, and visible record data;
+- inspect a batch-level summary and field-level diff detail;
+- trust that denied records and hidden fields do not leak through list, count, filters, detail, or preview;
+- preview multi-record / multi-field restore before any mutation;
+- restore a selected batch / record / field scope as a forward change;
+- view a table as of time T in read-only mode before any point-in-time rollback feature is opened.
+
+## 1. Slice Plan
+
+### T0 - Design Lock Ratification
+
+Status: TODO.
+
+Deliverables:
+
+- ratified design-lock;
+- resolved open decisions from section 8 of the design doc;
+- first-slice data model decision;
+- explicit MVP boundary.
+
+Verification:
+
+- review only;
+- no runtime diff;
+- grep that no feature flag / API route / migration was introduced in T0.
+
+### T1 - History Batch Projection
+
+Status: TODO, blocked on T0.
+
+Goal: create a queryable batch/change projection from existing write and revision paths.
+
+Scope:
+
+- record create;
+- record update;
+- record delete;
+- record restore / undelete;
+- per-field value set / unset;
+- actor id and actor display name snapshot when available;
+- source kind;
+- source batch id for restore-created batches.
+
+Out of scope:
+
+- config history;
+- restore UI;
+- point-in-time reconstruction;
+- purge / retention UI.
+
+Tests:
+
+- real-DB create creates one batch and one or more changes;
+- real-DB update creates one batch with changed field ids;
+- real-DB delete creates a delete batch;
+- real-DB restore creates a restore batch linked to the source;
+- bulk update creates one batch with many changes, not many unrelated batches;
+- actor/source metadata preserved;
+- tsc clean.
+
+### T2 - Global History Center Read-Only UI
+
+Status: TODO, blocked on T1 + T4 route contract.
+
+Goal: add a global history center entry and timeline UI.
+
+Scope:
+
+- toolbar / more-menu entry;
+- timeline list of batches;
+- filters for time, actor, action, source, sheet, field;
+- search by visible record title / data;
+- cursor pagination;
+- empty, loading, error states.
+
+Out of scope:
+
+- restore;
+- point-in-time view;
+- config history restore.
+
+Tests:
+
+- component render for list, filters, empty, error;
+- client contract test for query params;
+- no raw record ids when a visible title exists;
+- actor display name fallback;
+- vue-tsc clean;
+- browser Path A screenshot for dense timeline layout.
+
+### T3 - Batch Detail And Diff Drilldown
+
+Status: TODO, blocked on T1 + T4.
+
+Goal: users can understand what one batch changed.
+
+Scope:
+
+- open batch detail from timeline;
+- show actor/source/time;
+- show affected record count and field count;
+- group changes by record;
+- show before/after field diffs;
+- link to visible record drawer;
+- show restore-created batch back-reference.
+
+Tests:
+
+- hidden fields are not rendered;
+- denied records are not rendered;
+- totals match visible records only;
+- deleted-record changes show readable title when available;
+- no raw JSON dumps for common scalar/link/person values;
+- FE component tests + real-route API tests.
+
+### T4 - Permission-Safe Query Hardening
+
+Status: TODO, should land before or together with T2/T3.
+
+Goal: history queries cannot become a side channel.
+
+Required locks:
+
+- denied records absent from list;
+- denied records absent from total;
+- hidden fields absent from filters;
+- hidden fields absent from detail;
+- hidden fields absent from preview;
+- missing and denied batch detail share not-found shape;
+- admin bypass is explicit and tested;
+- flag-off behavior is inert.
+
+Tests:
+
+- real-DB rule-denied record invisible from list and total;
+- real-DB hidden field changed but not visible in field filters or detail;
+- real-DB hidden-field-only batch does not leak through counts;
+- same external response for missing vs denied detail;
+- admin can see a rule-denied batch only where bypass is intentionally supported;
+- real-DB allowlist / CI step confirms the file actually runs.
+
+### T5 - Restore Preview
+
+Status: TODO, blocked on T3 + T4.
+
+Goal: dry-run restore without mutation.
+
+Scope:
+
+- preview a batch restore;
+- preview selected records;
+- preview selected fields;
+- preview selected changes;
+- report denied changes;
+- report schema drift;
+- report missing/deleted targets;
+- report expected-version conflicts;
+- report link/formula side effects where applicable;
+- return preview token / identity.
+
+Tests:
+
+- preview writes nothing;
+- preview excludes denied records from allowed changes;
+- preview excludes hidden fields;
+- preview reports field write conflicts;
+- preview reports schema drift;
+- preview token cannot be forged trivially;
+- same-shape missing/denied where required.
+
+### T6 - Scoped Restore
+
+Status: TODO, blocked on T5.
+
+Goal: execute restore for a selected safe scope.
+
+Modes:
+
+- restore selected record changes from a batch;
+- restore selected fields;
+- restore selected change ids;
+- restore a permission-filtered batch subset.
+
+Rules:
+
+- preview identity required;
+- restore writes forward revisions;
+- restore creates a `source=restore` batch;
+- per-field write gates apply;
+- current rule-deny gates apply;
+- restore event links back to source batch.
+
+Tests:
+
+- selected-field restore;
+- partial-batch restore;
+- hidden field cannot be restored;
+- denied record cannot be restored;
+- restore event appears in history;
+- restore itself is inspectable in batch detail;
+- restore can be followed by another restore without corrupting history.
+
+### T7 - Point-In-Time Read-Only View
+
+Status: TODO, blocked on T1/T4/T3 maturity.
+
+Goal: open the table as of time T in read-only mode.
+
+Scope:
+
+- reconstruct visible records as of T;
+- page large results;
+- field masks apply;
+- rule-denied records invisible;
+- deleted records handled according to the ratified policy;
+- no editing.
+
+Out of scope:
+
+- one-click full table rollback;
+- config/schema reconstruction unless T9 has landed.
+
+Tests:
+
+- record value at T reconstructed;
+- later changes absent;
+- hidden field masked;
+- rule-denied record invisible;
+- total count does not leak denied records;
+- deleted-record policy tested;
+- large-table pagination contract.
+
+### T8 - Point-In-Time Restore
+
+Status: OWNER-GATED, blocked on T7 and a new restore-specific ratification.
+
+Goal: restore a sheet or subset to time T.
+
+Prerequisites:
+
+- point-in-time read-only view proven;
+- restore preview proven;
+- async limit / max size decided;
+- owner ratifies rollback semantics.
+
+Tests:
+
+- full-sheet dry-run;
+- subset dry-run;
+- conflict handling;
+- forward revisions created;
+- restore batch created;
+- no count/existence leaks;
+- rollback can itself be understood in history.
+
+### T9 - Config History
+
+Status: OWNER-GATED, separate program after data history.
+
+Goal: track and display schema/view/config changes.
+
+Potential scope:
+
+- field create/delete/rename/type-change;
+- view filter/sort/group changes;
+- permission rule changes;
+- automation config changes later.
+
+Restore:
+
+- config restore is separate from data restore;
+- no mixed config+data restore until explicitly designed.
+
+Tests:
+
+- schema change capture;
+- view change capture;
+- permission change capture;
+- config detail visible to authorized users only;
+- no restore until separate restore design exists.
+
+## 2. Recommended MVP
+
+MVP should be read-only:
+
+1. T0 design-lock.
+2. T1 batch projection.
+3. T4 permission-safe query hardening.
+4. T2 global timeline UI.
+5. T3 batch detail.
+
+Do not ship T6 restore before T5 preview exists.
+Do not ship T8 point-in-time restore as part of the MVP. The first release must prove list/detail/query safety before any global rollback surface opens.
+
+## 3. CI And Verification Rules
+
+- Permission claims require real-DB tests, not only service mocks.
+- API route contracts require route-level tests.
+- Frontend-only tests may verify rendering, filters, and event wiring, but not permission safety.
+- Any new real-DB test file must be added to the explicit multitable CI allowlist if the workflow uses one.
+- Browser evidence is required for the global history center timeline before calling the UI slice complete.
+- Each slice must include a "what is not covered" note in its PR.
+
+## 4. Product Gates
+
+The following require explicit owner opt-in:
+
+- enabling batch restore beyond selected record/field restore;
+- point-in-time restore;
+- config restore;
+- permanent purge UI;
+- retention policy UI;
+- async restore execution limits;
+- exposing history to non-editors;
+- cross-base history search.
+
+## 5. Risks To Re-Review On Every Slice
+
+- Count leaks through totals, filters, or pagination.
+- Hidden field names leak through filter facets.
+- Denied records leak through batch-level affected counts.
+- Restore preview reveals more than the actor can write.
+- Restore writes around current field permissions.
+- Batch grouping accidentally splits one user action into misleading many actions.
+- Backfill makes old revisions look like current-source events without marking provenance quality.
+- Point-in-time view silently reconstructs config with today's schema.
+
+## 6. Done Definition
+
+The full Time Machine+ arc is done only when:
+
+- read-only global history is shipped and browser-verified;
+- batch detail is permission-safe and real-DB-verified;
+- restore preview is mandatory for scoped restore;
+- scoped restore writes forward revisions and creates history batches;
+- point-in-time read-only view works under permissions;
+- docs distinguish shipped runtime from owner-gated point-in-time/config restore tails.

--- a/docs/development/multitable-timemachine-masterplan-todo-20260629.md
+++ b/docs/development/multitable-timemachine-masterplan-todo-20260629.md
@@ -1,0 +1,79 @@
+# 多维表 历史 / 时光机能力 — 总体开发计划 + 门控 TODO (PROPOSED)
+
+> Status: **PROPOSED 2026-06-29.** 把三条线（记录级收尾 / 全局时光机弧 / schema·快照纵深）合并成一张可跟踪的门控清单。
+> 计划文档，**不改任何代码**；每个 🔒 项需单独 owner opt-in，每个 📄 项需 design-lock 先行 + ratify。
+> 依赖：`multitable-time-machine-plus-design-lock-20260619.md`（同 PR 一并提交，T0 ratify）、
+> `multitable-time-machine-plus-todo-20260619.md`（全局弧逐切片 scope/测试细则）、已 on main 的
+> `multitable-record-restore-layer1-design-20260615.md`。外部产品对标基线见内部 research 基准（不在本文展开）。
+> 标记：✅ 已完成(on main) · 🟡 部分 · ⬜ 待开发(未门控) · 🔒 owner-gated · 📄 design-lock 先行。
+
+## 0. 目标能力集 与 基线
+**目标能力**（完整「时光机」对外能力面）：统一操作历史时间线（**配置 + 数据**，改前/改后 diff）· 时间点只读查看（看成 T 时刻）
+· **时间点（整表 / 范围）恢复** · 回收站 / 恢复被删记录 · 可配留存窗口 · 还原回滚数据/配置但**不回滚权限**。
+
+**基线（现状）**：**记录级**修订捕获 + 单记录历史读 + 单记录恢复已扎实落地并 on main（约覆盖目标的 ~40%）；
+**整表时光机本体（时间点查看/恢复）尚未建**。`multitable-time-machine-plus-*` 两份为**本地草稿、未提交/未 ratify**——
+故 **T0 = 提交并 ratify 这两份**。
+
+## 1. Track R — 记录级收尾（底座已在，低风险，可与 TM 并行）
+| ID | 项 | 状态 | 依赖 | 解锁能力 |
+|---|---|---|---|---|
+| R0 | 记录级修订捕获（create/update/delete 全写路径，snapshot+patch+actor）+ 单记录历史读 + 单记录恢复(Lock A–D, 错误码, Yjs) | ✅ | — | 查看记录历史 / 单条还原到版本 |
+| R1 | **Slice 3 FE 收尾**：workbench `onRestoreRecordVersion` 接 API client + 抽屉刷新；**列级(单字段)恢复** UI | ⬜ | R0 | 记录历史抽屉闭环 |
+| R2 | **Slice 2 undelete + link 恢复**：记录**软删**(`deleted_at`/trash) + 恢复被删记录并重建 `meta_links`+mirror 扇出；link 字段值恢复 | 🔒📄 | 软删设计锁 | 回收站 / 恢复被删记录 / link 还原 |
+| R3 | **留存上线**：开启 `MULTITABLE_META_REVISION_RETENTION_ENABLED` + 选 keep-last-n/keep-days + 接线 `VERSION_EXPIRED` + revision 唯一性加固(partial unique index) | ⬜ | R0 | 可配留存窗口 |
+
+## 2. Track TM — 全局时光机弧（整表时间点查看/恢复本体；逐切片细则见 `...-todo-20260619.md`）
+| ID | 项 | 状态 | 依赖 | 解锁能力 |
+|---|---|---|---|---|
+| T0 | **Design-lock ratify**（提交两份草稿 + 决 open decisions + 数据模型/MVP 边界）；零 runtime diff | 🔒📄 | — | 解锁后续全部 |
+| T1 | **历史批次投影** `history_batches`/`history_changes`（从 revisions 物化：增删改/restore/字段 set·unset/actor/source/batch 关联） | ⬜ | T0 | 统一历史**数据底座** |
+| T4 | **权限安全查询加固**（denied 记录不进 list/total；hidden 字段不进 filter/detail/preview；missing≡denied 形状；admin 旁路显式；flag-off 惰性） | ⬜ | T0（与 T2/T3 同落或更早） | 历史不成 side-channel（硬底线） |
+| T2 | **全局历史中心 UI**（入口 + 时间线 + 时间/人/动作/sheet/字段 筛选 + 标题搜索 + 游标分页 + 空/载/错态） | ⬜ | T1 + T4 | 统一操作历史时间线 |
+| T3 | **批次详情 / diff 钻取**（改前/改后、受影响记录·字段数、按记录分组、回链记录抽屉、restore 批次回链） | ⬜ | T1 + T4 | 改前改后对比 / 单元格级变更(派生) |
+| T5 | **恢复预览 dry-run**（批/记录/字段/变更级；报 denied/schema-drift/missing/版本冲突/link·formula 副作用；preview token） | ⬜ | T3 + T4 | 还原前预演 |
+| T6 | **范围化恢复**（按预览身份：选中记录/字段/变更/权限过滤子集；写 forward revision + `source=restore` 批次 + 回链） | 🔒 | T5 | 选择性还原 |
+| T7 | **时间点只读视图**（重建为 T 时刻、只读；字段掩码 + rule-deny + 删除策略 + 大表分页） | 🔒 | T1/T3/T4 成熟 | 看成 T 时刻 |
+| T8 | **时间点恢复（核心）**：把 sheet/子集回滚到 T 时刻 | 🔒📄 | T7 + 回滚语义单独 ratify | **整表一键还原到历史版本** |
+| T9 | **配置/Schema 历史**：加/删字段、改类型、视图/筛选/权限/自动化 变更 捕获+展示（恢复另设计） | 🔒📄 | 数据历史后单独立项 | 配置维度历史（完整对齐的最后一块） |
+
+## 3. Track S — schema-inclusive 快照（Layer 2，可选纵深）
+| ID | 项 | 状态 | 依赖 | 备注 |
+|---|---|---|---|---|
+| S1 | **MetaSnapshotService**：base/sheet 级、含 schema(字段/视图/link) 的检查点 + 治理面(锁/保护级/过期/标签/审计) | 🔒📄 | 单独立项 | 比点恢复更重；纵深，非对外能力必需 |
+| S2 | **type-changed schema-drift 检测**：revision 时存 schema-at-capture，使 Layer 2 识别类型漂移（当前仅靠值校验兜底） | ⬜ | S1 或独立 | 关闭 Layer 1 已知残缺 |
+
+## 4. 能力 → 关闭项 矩阵
+| 目标能力 | 现状 | 关闭于 |
+|---|---|---|
+| 统一操作历史时间线（配置+数据，改前改后） | 仅单记录历史 | **T1+T2+T3**（数据）、**T9**（配置） |
+| **整表一键还原到任意历史版本** | 仅单记录恢复 | **T7→T8** |
+| 时间点查看 | 无 | **T7** |
+| 单元格编辑历史 | 记录级(含字段 diff) | **T3** 派生呈现 |
+| 回收站 / 恢复被删记录 | 记录硬删 | **R2** |
+| 可配留存窗口 | 机制有、默认关 | **R3** |
+| 还原不回滚权限 | 表级恢复尚无 | **T8 设计需显式采纳** |
+| 配置/schema 历史 | 无 | **T9** |
+
+## 5. 推荐顺序 + MVP
+1. **read-only 优先 MVP（可见度最大、零回滚风险）**：`T0 → T1 → T4 → T2 → T3 → T5`
+   = 历史中心主界面 + 改前改后 + 还原**预演**，全程不改数据。
+2. **门控回滚（各自 owner GO，风险递增）**：`T6 → T7 → T8`。
+3. **并行低风险**：Track R（R1 收尾、R3 留存）随时可推；R2(undelete) 需软删设计锁先行。
+4. **最后/独立**：T9 配置历史、S1 快照。
+> 红线：T6 不在 T5 之前；T8 不进 MVP（先证 list/detail/query 安全，再开任何全局回滚面）。
+
+## 6. 验收纪律（每切片必带）
+- **real-DB golden 必须进 `plugin-tests.yml` 的 real-DB allowlist，并核到日志「文件真的跑了」**（不是只看 CI 绿——此前已两次踩 describeIfDatabase 静默 skip）。
+- 权限断言用 **real-DB**（service mock 不算）；路由契约要 route-level 测试。
+- UI 切片要**浏览器证据**（密集时间线截图）。
+- session/非 token 路径无回归；每 PR 附「未覆盖」说明。
+- 每个 🔒 项 = **单独 owner opt-in**；📄 项 = **design-lock 先行 + ratify**。
+
+## 7. 常驻风险（每切片复审）
+count/filter/分页 泄漏 denied 计数 · filter facet 泄漏 hidden 字段名 · 批次 affected 数泄漏 denied 记录 · preview 暴露超出可写范围 · restore 绕过当前字段权限 · 批次分组把一次操作误拆成多次 · 回填 revision 冒充 current-source（provenance 质量未标） · 时间点视图用「今天的 schema」静默重建。
+
+## 8. 结论
+能形成完整时光机能力面——但「完成」须指 **Track R（收尾 + undelete + 留存） + TM 的 T0–T8**；配置维度完整对齐再加 **T9**。
+底座（不可变全量 snapshot 修订 + 已硬化恢复引擎）是对的，是 **build-out 不是重构**。建议先 ratify **T0**、按 read-only MVP
+(`T1/T4/T2/T3/T5`) 落地，回滚面(T6/T7/T8)逐个门控开。**本文与两份草稿一并 PROPOSED；不改代码。**


### PR DESCRIPTION
**PROPOSED docs-only** — consolidates the multitable history / version-recovery → time-machine roadmap into one trackable, gated plan, and lands the previously-**untracked** Time Machine+ design-lock + TODO drafts so the arc is reviewable on main. **No code; no runtime authorized until T0 ratifies.**

### Files
- **`multitable-timemachine-masterplan-todo-20260629.md`** (NEW) — the master plan: three tracks in one gated checklist (✅/🟡/⬜/🔒/📄), each row mapped to the capability it unlocks.
  - **Track R** (record-level finish): R1 FE wiring + column-level restore · R2 🔒 undelete + recycle-bin + link restore · R3 retention enablement.
  - **Track TM** (global time machine): T0🔒 ratify → T1 history projection → T4 query-hardening → T2 history-center UI → T3 diff drilldown → T5 restore *preview* → T6/T7/**T8** point-in-time rollback (owner-gated) → T9 config history.
  - **Track S**: schema-inclusive snapshots / type-drift detection.
- **`multitable-time-machine-plus-design-lock-20260619.md`** + **`-todo-20260619.md`** — the existing local drafts, now committed (brand-clean) so **T0** can ratify them.

### Shape of the plan
- **Read-only MVP first** (`T0→T1→T4→T2→T3→T5`): history timeline + before/after diffs + restore **preview**, zero mutation risk — before any rollback surface opens.
- Every 🔒 item is a **separate owner GO**; every 📄 item is **design-lock-first**.
- Acceptance discipline carried forward: **real-DB goldens wired into `plugin-tests.yml`'s allowlist and verified they actually RAN** (the OAPI-2a silent-skip lesson), permission-safe via real-DB (no count/field/existence leaks), browser evidence for UI, session no-regression.

De-branded per convention — committed docs state our own capability goals; the external-product benchmark stays an internal research artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)