### PR TITLE
fix(multitable,approval): drop inert webhook.received trigger from editor + lock hidden-field redaction (R3/R2)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -335,6 +335,7 @@ jobs:
             tests/integration/approval-common-template-presets.api.test.ts \
             tests/integration/approval-amount-total-check.api.test.ts \
             tests/integration/approval-wp1-parallel-gateway.api.test.ts \
+            tests/integration/approval-bridge-redaction-regression.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -38,7 +38,13 @@
             <option value="schedule.cron">{{ automationTriggerTypeLabel('schedule.cron', isZh) }}</option>
             <option value="schedule.interval">{{ automationTriggerTypeLabel('schedule.interval', isZh) }}</option>
             <option value="schedule.date_field">{{ automationTriggerTypeLabel('schedule.date_field', isZh) }}</option>
-            <option value="webhook.received">{{ automationTriggerTypeLabel('webhook.received', isZh) }}</option>
+            <!--
+              `webhook.received` is intentionally NOT offered here: it is runtime-inert today
+              (no inbound ingestion route exists, the scheduler skips it, and it has no
+              TRIGGER_TYPE_BY_EVENT entry), so a saved rule would silently never fire. This is a
+              UI-only removal — the backend trigger-type enum is deliberately left intact pending a
+              real inbound webhook endpoint, at which point this option can be re-exposed.
+            -->
           </select>
 
           <!-- field.value_changed config -->

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -218,8 +218,11 @@ describe('MetaAutomationRuleEditor', () => {
     const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
     expect(triggerSelect).toBeTruthy()
     // record.created/updated/deleted + field.value_changed + form.submitted + schedule.cron/interval/date_field
-    // + webhook.received
-    expect(triggerSelect.options.length).toBe(9)
+    // `webhook.received` is intentionally NOT selectable: it is runtime-inert (no inbound ingestion
+    // route, scheduler skips it, no TRIGGER_TYPE_BY_EVENT entry) so a saved rule would never fire.
+    expect(triggerSelect.options.length).toBe(8)
+    const triggerValues = Array.from(triggerSelect.options).map((option) => option.value)
+    expect(triggerValues).not.toContain('webhook.received')
   })
 
   it('localizes core rule editor chrome in zh-CN while keeping raw select values', async () => {

--- a/packages/core-backend/tests/integration/approval-bridge-redaction-regression.test.ts
+++ b/packages/core-backend/tests/integration/approval-bridge-redaction-regression.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApprovalBridgeService } from '../../src/services/ApprovalBridgeService'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+// Real-DB regression spec: runs only with a Postgres DATABASE_URL. Excluded from
+// the no-DB default test job → skipped here (the `sentinel` test below makes a
+// silent skip impossible to mistake for a pass).
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+/**
+ * R2 regression guard for hidden-field redaction on the PUBLIC read seam.
+ *
+ * `GET /api/approvals/:id` resolves through `ApprovalBridgeService.getApproval`,
+ * whose `toUnifiedDTO` mapper runs `redactHiddenFormFields` — so a field a node
+ * marks `hidden` is stripped from the echoed `formSnapshot`. The SIBLING method
+ * `ApprovalProductService.getApproval` returns the snapshot UN-redacted; the
+ * route is wired to the bridge precisely because of that asymmetry. (This test
+ * deliberately does NOT assert on the un-redacted ProductService path — that
+ * would lock a wart and block a future hardening of ProductService.)
+ *
+ * The existing HTTP test (`approval-p1c-field-permissions.api.test.ts`) covers
+ * the end-to-end route. This guard is a faster, server-less assertion on the
+ * exact service method the route depends on, exercising the real
+ * `loadApprovalInstance → loadRuntimeGraphs → toUnifiedDTO →
+ * redactHiddenFormFields / collectActiveNodeKeys` chain over real rows (NOT a
+ * hand-built fixture handed straight to the pure function). It catches a future
+ * read path that swaps the bridge for an un-redacting method.
+ */
+describeIfDatabase('ApprovalBridgeService.getApproval hidden-field redaction (R2 regression)', () => {
+  const pool = poolManager.get()
+  const seeded = { instanceId: '', templateId: '' }
+
+  beforeAll(async () => {
+    await ensureApprovalSchemaReady()
+
+    // template → version → published_definition (runtime graph hides `secret` at
+    // approval_1) → instance pinned AT approval_1 with both fields in the snapshot.
+    const template = await pool.query<{ id: string }>(
+      `INSERT INTO approval_templates (key, name, status) VALUES ($1, $2, 'published') RETURNING id`,
+      [`r2-redact-${Date.now()}`, 'R2 redaction regression'],
+    )
+    seeded.templateId = template.rows[0].id
+
+    const version = await pool.query<{ id: string }>(
+      `INSERT INTO approval_template_versions (template_id, version, form_schema, approval_graph)
+       VALUES ($1, 1, $2, '{}'::jsonb) RETURNING id`,
+      [
+        seeded.templateId,
+        JSON.stringify({
+          fields: [
+            { id: 'reason', type: 'text', label: 'Reason' },
+            { id: 'secret', type: 'text', label: 'Secret' },
+          ],
+        }),
+      ],
+    )
+
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: { fieldPermissions: [{ fieldId: 'secret', access: 'hidden' }] },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+    }
+    const published = await pool.query<{ id: string }>(
+      `INSERT INTO approval_published_definitions (template_id, template_version_id, runtime_graph)
+       VALUES ($1, $2, $3) RETURNING id`,
+      [seeded.templateId, version.rows[0].id, JSON.stringify(runtimeGraph)],
+    )
+
+    // Non-PLM id (isPlmId only matches the `plm:` prefix) so getApproval takes
+    // the local read path. template_version_id left NULL so the form_schema
+    // lookup branch is skipped — only redaction is under test here.
+    seeded.instanceId = `r2-redact-instance-${Date.now()}`
+    await pool.query(
+      `INSERT INTO approval_instances (id, status, source_system, current_node_key, form_snapshot, published_definition_id)
+       VALUES ($1, 'pending', 'platform', 'approval_1', $2, $3)`,
+      [seeded.instanceId, JSON.stringify({ reason: 'trip', secret: 'classified' }), published.rows[0].id],
+    )
+  })
+
+  afterAll(async () => {
+    try {
+      if (seeded.instanceId) {
+        await pool.query('DELETE FROM approval_instances WHERE id = $1', [seeded.instanceId])
+      }
+      if (seeded.templateId) {
+        // template delete cascades versions + published_definitions (FK ON DELETE CASCADE).
+        await pool.query('DELETE FROM approval_templates WHERE id = $1', [seeded.templateId])
+      }
+    } catch {
+      // ignore cleanup failures
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('strips the hidden field from the formSnapshot while keeping non-hidden fields', async () => {
+    const dto = await new ApprovalBridgeService().getApproval(seeded.instanceId)
+    expect(dto).not.toBeNull()
+    // The redacting public seam: `secret` (hidden at approval_1) is gone, `reason` stays.
+    expect(dto?.formSnapshot).not.toHaveProperty('secret')
+    expect(dto?.formSnapshot).toHaveProperty('reason', 'trip')
+
+    // Redaction is an echo-only transform — the stored snapshot is untouched.
+    const stored = await pool.query<{ form_snapshot: Record<string, unknown> }>(
+      'SELECT form_snapshot FROM approval_instances WHERE id = $1',
+      [seeded.instanceId],
+    )
+    expect(stored.rows[0]?.form_snapshot).toMatchObject({ reason: 'trip', secret: 'classified' })
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -35,6 +35,10 @@ export default defineConfig({
       'tests/integration/approval-detail-subform.db.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/approval-common-template-presets.api.test.ts',
+      // R2 hidden-field redaction guard: DATABASE_URL-gated (describeIfDatabase). Excluded from the
+      // default no-DB job so it doesn't skip-green, and wired as a WHOLE FILE into the dedicated
+      // `Run approval real-DB integration` step in plugin-tests.yml where it runs against real Postgres.
+      'tests/integration/approval-bridge-redaction-regression.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
Two contained risk-triage fixes from the approval-automation dev-plan (#3379, Track R). **No new capability — a UI-only removal + a regression test.**

**R3 — remove the inert `webhook.received` trigger from the editor's selectable set.** It was editor-selectable but runtime-inert (no inbound ingestion route, scheduler skips it, no `TRIGGER_TYPE_BY_EVENT` entry) → a saved rule silently never fired. Removed from the dropdown with an explanatory comment; **backend trigger-type enum left intact** pending a real inbound endpoint (the design-locked T1-2). Editor spec updated (option count 9→8 + asserts `webhook.received` not selectable). Known behavior: a previously-saved `webhook.received` rule now shows a blank trigger select — consistent with "stop advertising a trigger that never fired."

**R2 — hidden-field redaction regression guard.** `GET /api/approvals/:id` resolves through `ApprovalBridgeService.getApproval`, whose `toUnifiedDTO` runs `redactHiddenFormFields`; the sibling `ApprovalProductService.getApproval` returns the snapshot un-redacted (the route is wired to the bridge precisely for that). New DB-backed test seeds template→version→published-definition (graph hides `secret` at `approval_1`)→instance, then asserts the bridge strips `secret` / keeps `reason` and that the stored snapshot is untouched (echo-only) — exercising the real `loadApprovalInstance → loadRuntimeGraphs → toUnifiedDTO → redactHiddenFormFields` chain, not a hand-built fixture. Sentinel test guards against a silent DB-less skip. Deliberately does **not** assert the un-redacted ProductService path (would lock a wart + block future hardening — documented in a comment).

Verified green locally: `vue-tsc -b` clean · backend `tsc --noEmit` clean · R3 editor spec 100/100 · R2 regression 2/2 (DB-backed, sentinel ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)