### PR TITLE
feat(plm): surface governed BOM writeback in workbench

### DIFF
--- a/apps/web/src/components/plm/PlmBomReviewPanel.vue
+++ b/apps/web/src/components/plm/PlmBomReviewPanel.vue
@@ -1,8 +1,8 @@
 <template>
   <section class="bom-review" data-testid="plm-bom-review-panel">
     <header class="bom-review__head">
-      <strong>BOM Review（只读）</strong>
-      <small>来自 PLM 的受治理只读快照；不可在此编辑/写回。</small>
+      <strong>BOM Review</strong>
+      <small>来自 PLM 的受治理快照；此工作台可写回已授权的 BOM 单元格。</small>
     </header>
 
     <div class="bom-review__query">
@@ -44,7 +44,14 @@
         未找到该 Part 的 BOM 数据。
       </p>
 
-      <PlmBomReviewTable v-else-if="reviewState === 'table' && context" :context="context" />
+      <PlmBomReviewTable
+        v-else-if="reviewState === 'table' && context"
+        :context="context"
+        editable
+        :submitting-line-id="submittingLineId"
+        :line-messages="lineMessages"
+        @submit-line="submitLinePatch"
+      />
     </div>
   </section>
 </template>
@@ -53,6 +60,9 @@
 import { computed, ref } from 'vue'
 import {
   getPlmBomMultitableContext,
+  updatePlmBomMultitableLine,
+  type PlmBomMultitableLine,
+  type PlmBomMultitableLinePatch,
   type PlmBomMultitableResult,
 } from '../../services/integration/workbench'
 import PlmBomReviewTable from './PlmBomReviewTable.vue'
@@ -62,6 +72,9 @@ const props = defineProps<{ dataSourceId: string }>()
 const partId = ref('')
 const loading = ref(false)
 const result = ref<PlmBomMultitableResult | null>(null)
+const submittingLineId = ref<string | null>(null)
+const lineMessages = ref<Record<string, string>>({})
+const retryKeys = ref<Record<string, string>>({})
 
 const context = computed(() =>
   result.value && result.value.available ? result.value.context : null,
@@ -89,12 +102,67 @@ async function load(): Promise<void> {
   const pid = partId.value.trim()
   if (!pid || loading.value) return
   loading.value = true
+  lineMessages.value = {}
+  retryKeys.value = {}
   try {
     result.value = await getPlmBomMultitableContext(props.dataSourceId, pid)
   } catch {
     result.value = { data_source_id: props.dataSourceId, available: false, reason: 'unavailable' }
   } finally {
     loading.value = false
+  }
+}
+
+function makeIdempotencyKey(): string {
+  const cryptoApi = globalThis.crypto as { randomUUID?: () => string } | undefined
+  if (typeof cryptoApi?.randomUUID === 'function') return cryptoApi.randomUUID()
+  return `bom-write-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function writebackMessage(status: number): string {
+  if (status === 403) return '无写回授权或权限不足。'
+  if (status === 404) return '该 BOM 行不存在或不属于当前 Part。'
+  if (status === 409) return '该 BOM 行当前不可写，或提交键已用于不同写入。'
+  if (status === 422 || status === 400) return '写回内容无效，请检查单元格。'
+  return '写回暂时失败，请稍后重试。'
+}
+
+function applyLinePatch(line: PlmBomMultitableLine, patch: PlmBomMultitableLinePatch): void {
+  if ('quantity' in patch) {
+    line.quantity = typeof patch.quantity === 'number' || patch.quantity === null ? patch.quantity : Number(patch.quantity)
+  }
+  if ('uom' in patch) line.uom = patch.uom ?? null
+  if ('find_num' in patch) line.find_num = patch.find_num ?? null
+  if ('refdes' in patch) line.refdes = patch.refdes ?? null
+}
+
+async function submitLinePatch(payload: { line: PlmBomMultitableLine; patch: PlmBomMultitableLinePatch }): Promise<void> {
+  const lineId = payload.line.bom_line_id
+  if (!context.value || submittingLineId.value) return
+  const key = retryKeys.value[lineId] || makeIdempotencyKey()
+  retryKeys.value = { ...retryKeys.value, [lineId]: key }
+  submittingLineId.value = lineId
+  lineMessages.value = { ...lineMessages.value, [lineId]: '正在写回…' }
+  try {
+    const outcome = await updatePlmBomMultitableLine(
+      props.dataSourceId,
+      context.value.part.part_id,
+      lineId,
+      payload.patch,
+      key,
+    )
+    if (outcome.ok) {
+      applyLinePatch(payload.line, payload.patch)
+      const { [lineId]: _doneKey, ...rest } = retryKeys.value
+      retryKeys.value = rest
+      lineMessages.value = { ...lineMessages.value, [lineId]: '写回成功。' }
+      return
+    }
+    lineMessages.value = { ...lineMessages.value, [lineId]: writebackMessage(outcome.status) }
+  } catch {
+    lineMessages.value = { ...lineMessages.value, [lineId]: '写回暂时失败，请稍后重试。' }
+  } finally {
+    submittingLineId.value = null
   }
 }
 </script>

--- a/apps/web/src/components/plm/PlmBomReviewTable.vue
+++ b/apps/web/src/components/plm/PlmBomReviewTable.vue
@@ -19,15 +19,20 @@
           <th>名称</th>
           <th>状态</th>
           <th>数量</th>
+          <th>单位</th>
+          <th>查找号</th>
           <th>位号</th>
           <th>来源版本</th>
           <th>来源更新时间</th>
+          <th v-if="editable">写回</th>
         </tr>
       </thead>
       <tbody>
-        <tr
+        <template
           v-for="line in context.lines"
           :key="line.bom_line_id"
+        >
+        <tr
           data-testid="plm-bom-review-row"
           :data-bom-line-id="line.bom_line_id"
           :data-level="line.level"
@@ -40,11 +45,74 @@
           </td>
           <td>{{ line.name }}</td>
           <td>{{ line.state || '—' }}</td>
-          <td>{{ formatQuantity(line) }}</td>
-          <td>{{ line.refdes || '—' }}</td>
+          <td>
+            <input
+              v-if="editable"
+              class="bom-review__cell-input"
+              type="number"
+              :value="draftFor(line).quantity"
+              :disabled="submittingLineId === line.bom_line_id"
+              data-testid="plm-bom-review-quantity-input"
+              @input="updateDraft(line, 'quantity', ($event.target as HTMLInputElement).value)"
+            />
+            <template v-else>{{ formatQuantity(line) }}</template>
+          </td>
+          <td>
+            <input
+              v-if="editable"
+              class="bom-review__cell-input"
+              :value="draftFor(line).uom"
+              :disabled="submittingLineId === line.bom_line_id"
+              data-testid="plm-bom-review-uom-input"
+              @input="updateDraft(line, 'uom', ($event.target as HTMLInputElement).value)"
+            />
+            <template v-else>{{ line.uom || '—' }}</template>
+          </td>
+          <td>
+            <input
+              v-if="editable"
+              class="bom-review__cell-input"
+              :value="draftFor(line).find_num"
+              :disabled="submittingLineId === line.bom_line_id"
+              data-testid="plm-bom-review-find-num-input"
+              @input="updateDraft(line, 'find_num', ($event.target as HTMLInputElement).value)"
+            />
+            <template v-else>{{ line.find_num || '—' }}</template>
+          </td>
+          <td>
+            <input
+              v-if="editable"
+              class="bom-review__cell-input"
+              :value="draftFor(line).refdes"
+              :disabled="submittingLineId === line.bom_line_id"
+              data-testid="plm-bom-review-refdes-input"
+              @input="updateDraft(line, 'refdes', ($event.target as HTMLInputElement).value)"
+            />
+            <template v-else>{{ line.refdes || '—' }}</template>
+          </td>
           <td>{{ line.source_version ?? '—' }}</td>
           <td>{{ line.source_updated_at || '—' }}</td>
+          <td v-if="editable">
+            <button
+              type="button"
+              class="bom-review__save"
+              data-testid="plm-bom-review-save"
+              :data-bom-line-id="line.bom_line_id"
+              :disabled="submittingLineId === line.bom_line_id || !isLineChanged(line)"
+              @click="submitLine(line)"
+            >
+              {{ submittingLineId === line.bom_line_id ? '写回中…' : '保存' }}
+            </button>
+            <small
+              v-if="lineMessages[line.bom_line_id]"
+              class="bom-review__line-message"
+              data-testid="plm-bom-review-line-message"
+            >
+              {{ lineMessages[line.bom_line_id] }}
+            </small>
+          </td>
         </tr>
+        </template>
       </tbody>
     </table>
   </div>
@@ -53,15 +121,101 @@
 <script setup lang="ts">
 // P3-D2: the read-only BOM review table, extracted from PlmBomReviewPanel so BOTH the standalone
 // panel (P3-C) and the embedded view (P3-D2) render the identical table.
-import { type PlmBomMultitableContext, type PlmBomMultitableLine } from '../../services/integration/workbench'
+import { reactive, watch } from 'vue'
+import {
+  type PlmBomMultitableContext,
+  type PlmBomMultitableLine,
+  type PlmBomMultitableLinePatch,
+} from '../../services/integration/workbench'
+
+interface LineDraft {
+  quantity: string
+  uom: string
+  find_num: string
+  refdes: string
+}
 
 // nullable so both call sites (panel + embed) can bind their `context | null` computed without a
 // non-null assertion; the root v-if guards the render and narrows context for the subtree.
-defineProps<{ context: PlmBomMultitableContext | null }>()
+const props = withDefaults(defineProps<{
+  context: PlmBomMultitableContext | null
+  editable?: boolean
+  submittingLineId?: string | null
+  lineMessages?: Record<string, string>
+}>(), {
+  editable: false,
+  submittingLineId: null,
+  lineMessages: () => ({}),
+})
+
+const emit = defineEmits<{
+  (event: 'submit-line', payload: {
+    line: PlmBomMultitableLine
+    patch: PlmBomMultitableLinePatch
+  }): void
+}>()
+
+const drafts = reactive<Record<string, LineDraft>>({})
+
+function draftFromLine(line: PlmBomMultitableLine): LineDraft {
+  return {
+    quantity: line.quantity === null || line.quantity === undefined ? '' : String(line.quantity),
+    uom: line.uom ?? '',
+    find_num: line.find_num ?? '',
+    refdes: line.refdes ?? '',
+  }
+}
+
+watch(
+  () => props.context,
+  (context) => {
+    for (const key of Object.keys(drafts)) delete drafts[key]
+    for (const line of context?.lines ?? []) drafts[line.bom_line_id] = draftFromLine(line)
+  },
+  { immediate: true },
+)
+
+function draftFor(line: PlmBomMultitableLine): LineDraft {
+  if (!drafts[line.bom_line_id]) drafts[line.bom_line_id] = draftFromLine(line)
+  return drafts[line.bom_line_id]
+}
+
+function updateDraft(line: PlmBomMultitableLine, field: keyof LineDraft, value: string): void {
+  draftFor(line)[field] = value
+}
 
 function formatQuantity(line: PlmBomMultitableLine): string {
   if (line.quantity === null || line.quantity === undefined) return '—'
   return line.uom ? `${line.quantity} ${line.uom}` : String(line.quantity)
+}
+
+function nullableText(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+function buildPatch(line: PlmBomMultitableLine): PlmBomMultitableLinePatch {
+  const draft = draftFor(line)
+  const patch: PlmBomMultitableLinePatch = {}
+  const quantity = draft.quantity.trim() ? Number(draft.quantity) : null
+  if (quantity !== line.quantity) patch.quantity = quantity
+  const uom = nullableText(draft.uom)
+  if (uom !== line.uom) patch.uom = uom
+  const findNum = nullableText(draft.find_num)
+  if (findNum !== line.find_num) patch.find_num = findNum
+  const refdes = nullableText(draft.refdes)
+  if (refdes !== line.refdes) patch.refdes = refdes
+  return patch
+}
+
+function isLineChanged(line: PlmBomMultitableLine): boolean {
+  return Object.keys(buildPatch(line)).length > 0
+}
+
+function submitLine(line: PlmBomMultitableLine): void {
+  const patch = buildPatch(line)
+  if (Object.keys(patch).length === 0) return
+  emit('submit-line', { line, patch })
 }
 </script>
 
@@ -71,4 +225,7 @@ function formatQuantity(line: PlmBomMultitableLine): string {
 .bom-review__table { width: 100%; border-collapse: collapse; }
 .bom-review__table th, .bom-review__table td { text-align: left; padding: 4px 8px; border-bottom: 1px solid rgba(0,0,0,0.08); }
 .bom-review__hint { opacity: 0.8; }
+.bom-review__cell-input { width: 80px; max-width: 100%; box-sizing: border-box; }
+.bom-review__save { white-space: nowrap; }
+.bom-review__line-message { display: block; margin-top: 2px; max-width: 160px; }
 </style>

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -128,6 +128,25 @@ export type PlmBomMultitableResult =
     reason?: string
   }
 
+export interface PlmBomMultitableLinePatch {
+  quantity?: number | string | null
+  uom?: string | null
+  find_num?: string | null
+  refdes?: string | null
+}
+
+export type PlmBomMultitableLineUpdateResult =
+  | {
+    ok: true
+    bom_line_id: string
+  }
+  | {
+    ok: false
+    status: number
+    reason: string
+    message: string
+  }
+
 export interface WorkbenchExternalSystemUpsertRequest extends IntegrationScope {
   id?: string
   projectId?: string | null
@@ -796,6 +815,59 @@ export async function getPlmBomMultitableContext(
     return { data_source_id: dsId, available: false, reason: 'unavailable' }
   }
   return normalizePlmBomMultitableResult(dsId, payload)
+}
+
+export async function updatePlmBomMultitableLine(
+  dataSourceId: string,
+  partId: string,
+  bomLineId: string,
+  patch: PlmBomMultitableLinePatch,
+  idempotencyKey: string,
+): Promise<PlmBomMultitableLineUpdateResult> {
+  const dsId = dataSourceId.trim()
+  const pid = partId.trim()
+  const lineId = bomLineId.trim()
+  const idem = idempotencyKey.trim()
+  if (!dsId || !pid || !lineId || !idem) {
+    return { ok: false, status: 400, reason: 'invalid-request', message: 'BOM write-back request is incomplete' }
+  }
+
+  const payload: PlmBomMultitableLinePatch = {}
+  if (patch.quantity !== undefined) payload.quantity = patch.quantity
+  if (patch.uom !== undefined) payload.uom = patch.uom
+  if (patch.find_num !== undefined) payload.find_num = patch.find_num
+  if (patch.refdes !== undefined) payload.refdes = patch.refdes
+  if (Object.keys(payload).length === 0) {
+    return { ok: false, status: 400, reason: 'empty-patch', message: 'No changed BOM cells to submit' }
+  }
+
+  const response = await apiFetch(
+    `/api/plm-workbench/data-sources/${encodeURIComponent(dsId)}/bom-multitable/${encodeURIComponent(pid)}/lines/${encodeURIComponent(lineId)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Idempotency-Key': idem },
+      body: JSON.stringify(payload),
+      suppressUnauthorizedRedirect: true,
+    },
+  )
+  const body = await response.json().catch(() => null) as Record<string, unknown> | null
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      reason: typeof body?.reason === 'string' && body.reason.trim() ? body.reason.trim() : 'writeback-failed',
+      message: typeof body?.error === 'string' && body.error.trim() ? body.error.trim() : `BOM write-back failed (${response.status})`,
+    }
+  }
+  if (body?.ok === true && typeof body.bom_line_id === 'string' && body.bom_line_id.trim()) {
+    return { ok: true, bom_line_id: body.bom_line_id.trim() }
+  }
+  return {
+    ok: false,
+    status: 502,
+    reason: 'malformed-response',
+    message: 'BOM write-back returned a malformed response',
+  }
 }
 
 export async function upsertWorkbenchExternalSystem(

--- a/apps/web/tests/PlmBomReviewPanel.spec.ts
+++ b/apps/web/tests/PlmBomReviewPanel.spec.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App as VueApp } from 'vue'
 
 const getContextMock = vi.fn()
+const updateLineMock = vi.fn()
 vi.mock('../src/services/integration/workbench', () => ({
   getPlmBomMultitableContext: (...args: unknown[]) => getContextMock(...args),
+  updatePlmBomMultitableLine: (...args: unknown[]) => updateLineMock(...args),
 }))
 
 import PlmBomReviewPanel from '../src/components/plm/PlmBomReviewPanel.vue'
@@ -55,9 +57,15 @@ afterEach(() => {
   app = null
   container?.remove()
   getContextMock.mockReset()
+  updateLineMock.mockReset()
+  vi.unstubAllGlobals()
 })
 
-describe('PlmBomReviewPanel (P3-C read-only BOM review)', () => {
+function cloneContext() {
+  return JSON.parse(JSON.stringify(CONTEXT))
+}
+
+describe('PlmBomReviewPanel (P3-C BOM review + governed write-back)', () => {
   it('is idle and does NOT call the service on mount', async () => {
     mountPanel()
     await flushUi()
@@ -66,7 +74,7 @@ describe('PlmBomReviewPanel (P3-C read-only BOM review)', () => {
   })
 
   it('loads + renders the read-only table with stable row keys, hierarchy, qty + provenance', async () => {
-    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: CONTEXT })
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
     mountPanel()
     await flushUi()
     await setPartAndLoad('P1')
@@ -79,9 +87,56 @@ describe('PlmBomReviewPanel (P3-C read-only BOM review)', () => {
     expect((rows[0] as HTMLElement).dataset.bomLineId).toBe('R1')
     expect((rows[1] as HTMLElement).dataset.bomLineId).toBe('R2')
     expect((rows[1] as HTMLElement).dataset.level).toBe('2')
-    // quantity + uom and the source provenance timestamp render
-    expect(container.textContent).toContain('2 EA')
+    // quantity + uom are editable in the standalone workbench panel
+    expect((container.querySelector('[data-testid="plm-bom-review-quantity-input"]') as HTMLInputElement).value).toBe('2')
+    expect((container.querySelector('[data-testid="plm-bom-review-uom-input"]') as HTMLInputElement).value).toBe('EA')
     expect(container.textContent).toContain('2026-06-05T00:00:00')
+  })
+
+  it('submits editable cells with a UI-owned Idempotency-Key and updates the row on success', async () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'submit-key-1' })
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
+    updateLineMock.mockResolvedValue({ ok: true, bom_line_id: 'R1' })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+
+    const quantity = container.querySelector('[data-testid="plm-bom-review-quantity-input"]') as HTMLInputElement
+    quantity.value = '6'
+    quantity.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateLineMock).toHaveBeenCalledWith('plm-ds', 'P1', 'R1', { quantity: 6 }, 'submit-key-1')
+    expect(container.textContent).toContain('写回成功。')
+    expect(quantity.value).toBe('6')
+  })
+
+  it('keeps a failed submit actionable so the user can retry the same logical edit', async () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'submit-key-1' })
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
+    updateLineMock
+      .mockResolvedValueOnce({ ok: false, status: 409, reason: 'provider-rejected', message: 'locked' })
+      .mockResolvedValueOnce({ ok: true, bom_line_id: 'R1' })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+
+    const refdes = container.querySelector('[data-testid="plm-bom-review-refdes-input"]') as HTMLInputElement
+    refdes.value = 'R9'
+    refdes.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    const save = container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement
+    save.click()
+    await flushUi()
+    expect(container.textContent).toContain('不可写')
+    save.click()
+    await flushUi()
+
+    expect(updateLineMock).toHaveBeenNthCalledWith(1, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-1')
+    expect(updateLineMock).toHaveBeenNthCalledWith(2, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-1')
+    expect(container.textContent).toContain('写回成功。')
   })
 
   it('shows the upgrade affordance (no table) when supported but not entitled', async () => {

--- a/apps/web/tests/plm-bom-review-service.spec.ts
+++ b/apps/web/tests/plm-bom-review-service.spec.ts
@@ -6,7 +6,10 @@ vi.mock('../src/utils/api', () => ({
   apiGet: (...args: unknown[]) => apiFetchMock(...args),
 }))
 
-import { getPlmBomMultitableContext } from '../src/services/integration/workbench'
+import {
+  getPlmBomMultitableContext,
+  updatePlmBomMultitableLine,
+} from '../src/services/integration/workbench'
 
 // The relay returns a BARE object (NOT the {ok,data} integration envelope).
 function rawJsonResponse(data: unknown, status = 200): Response {
@@ -68,5 +71,48 @@ describe('getPlmBomMultitableContext (P3-C consumer service)', () => {
     apiFetchMock.mockResolvedValue(rawJsonResponse({ data_source_id: 'ds-1', available: true, entitled: true, context: null, reason: 'unavailable' }))
     const r = await getPlmBomMultitableContext('ds-1', 'P1')
     expect(r).toEqual({ data_source_id: 'ds-1', available: true, entitled: true, context: null, reason: 'unavailable' })
+  })
+})
+
+describe('updatePlmBomMultitableLine (Phase 7 consumer write-back service)', () => {
+  beforeEach(() => apiFetchMock.mockReset())
+
+  it('sends the caller-owned Idempotency-Key and whitelisted patch body', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true, bom_line_id: 'R1' }))
+    const r = await updatePlmBomMultitableLine(
+      'ds-1',
+      'P1',
+      'R1',
+      { quantity: 6, refdes: null },
+      'submit-1',
+    )
+    expect(r).toEqual({ ok: true, bom_line_id: 'R1' })
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/plm-workbench/data-sources/ds-1/bom-multitable/P1/lines/R1',
+      {
+        method: 'PATCH',
+        headers: { 'Idempotency-Key': 'submit-1' },
+        body: JSON.stringify({ quantity: 6, refdes: null }),
+        suppressUnauthorizedRedirect: true,
+      },
+    )
+  })
+
+  it('returns actionable provider errors instead of throwing', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ error: 'locked', reason: 'provider-rejected' }, 409))
+    const r = await updatePlmBomMultitableLine(
+      'ds-1',
+      'P1',
+      'R1',
+      { quantity: 6 },
+      'submit-1',
+    )
+    expect(r).toEqual({ ok: false, status: 409, reason: 'provider-rejected', message: 'locked' })
+  })
+
+  it('refuses incomplete requests before fetching', async () => {
+    const r = await updatePlmBomMultitableLine('ds-1', 'P1', 'R1', {}, 'submit-1')
+    expect(r.ok).toBe(false)
+    expect(apiFetchMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -743,6 +743,10 @@ export interface BomMultitableLineUpdateResult {
   bom_line_id: string;
 }
 
+export interface BomMultitableLineUpdateOptions {
+  idempotencyKey?: string;
+}
+
 // Field guard for the governed BOM multi-table context. Validates EVERY field declared on
 // BomMultitableLine / BomMultitablePart / BomMultitableContext — both the structural keys
 // (bom_line_id, part_id, level, path, ...) AND the displayed cells (item_number, name, state,
@@ -2199,15 +2203,17 @@ export class PLMAdapter extends HTTPAdapter {
    * context boundary, `bomLineId` selects the row). THIN consumer contract: the payload is restricted
    * to the four editable business cells (quantity / uom / find_num / refdes), an empty patch (nothing
    * changed) is REJECTED before any mock/network branch, any non-whitelisted key is stripped, and the
-   * success envelope is the minimal { ok, bom_line_id }. Each governed write mints a FRESH per-edit
-   * Idempotency-Key (randomUUID) sent as a request header, so the GOVERNED provider (Yuantus #905) can
-   * dedupe a retried write without applying it twice. Permission/unauthorized (403) and the
-   * provider's line∈part validation are intentionally OUT of this consumer contract; success-only.
+   * success envelope is the minimal { ok, bom_line_id }. The workbench UI may pass the logical
+   * submit's Idempotency-Key so a retry dedupes at the governed provider (Yuantus #905); direct
+   * callers that omit it keep the old fallback behavior and mint a fresh per-call key. Permission/
+   * unauthorized (403) and the provider's line∈part validation are intentionally OUT of this
+   * consumer contract; success-only.
    */
   async updateBomMultitableLine(
     partId: string,
     bomLineId: string,
     patch: BomMultitableLinePatch,
+    options: BomMultitableLineUpdateOptions = {},
   ): Promise<QueryResult<BomMultitableLineUpdateResult>> {
     // Build the request payload from ONLY the four whitelisted, defined keys. `null` is a real value
     // (a "clear this cell" edit) and is preserved; `undefined` (untouched) and any unknown key are
@@ -2236,10 +2242,13 @@ export class PLMAdapter extends HTTPAdapter {
       return { data: [], error: new Error('BOM multitable line write-back is not supported for this PLM API mode') }
     }
 
-    // Mint a fresh per-edit Idempotency-Key so the governed provider (Yuantus #905) can dedupe a
-    // retried write without applying it twice. It rides as a request header alongside the axios
+    // Prefer the caller-owned logical-submit key; fall back to a fresh per-call key so older direct
+    // callers keep the pre-existing behavior. It rides as a request header alongside the axios
     // instance's auth/tenant defaults, which HTTPAdapter.select merges in.
-    const idempotencyKey = randomUUID()
+    const idempotencyKey =
+      typeof options.idempotencyKey === 'string' && options.idempotencyKey.trim()
+        ? options.idempotencyKey.trim()
+        : randomUUID()
 
     return this.select<BomMultitableLineUpdateResult>(`/api/v1/bom/multitable/${partId}/lines/${bomLineId}`, {
       method: 'PATCH',

--- a/packages/core-backend/src/routes/plm-workbench.ts
+++ b/packages/core-backend/src/routes/plm-workbench.ts
@@ -27,7 +27,12 @@ import {
 import { loadValidators } from '../types/validator'
 import { parsePagination } from '../util/response'
 import { getDataSourceManager } from './data-sources'
-import type { IntegrationCapabilitiesResult, BomMultitableContextResult } from '../data-adapters/PLMAdapter'
+import type {
+  IntegrationCapabilitiesResult,
+  BomMultitableContextResult,
+  BomMultitableLinePatch,
+  BomMultitableLineUpdateResult,
+} from '../data-adapters/PLMAdapter'
 
 // Typed wrapper for temporary tables not yet in main Database interface
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -792,12 +797,81 @@ interface PlmBomReviewAdapter {
   getBomMultitableContext(partId: string): Promise<BomMultitableContextResult>
 }
 
+interface PlmBomWritebackAdapter extends PlmBomReviewAdapter {
+  updateBomMultitableLine(
+    partId: string,
+    bomLineId: string,
+    patch: BomMultitableLinePatch,
+    options?: { idempotencyKey?: string },
+  ): Promise<{ data?: BomMultitableLineUpdateResult[]; error?: Error }>
+}
+
 function isPlmBomReviewAdapter(adapter: unknown): adapter is PlmBomReviewAdapter {
   const candidate = adapter as PlmBomReviewAdapter | null
   return (
     typeof candidate?.getIntegrationCapabilities === 'function'
     && typeof candidate?.getBomMultitableContext === 'function'
   )
+}
+
+function isPlmBomWritebackAdapter(adapter: unknown): adapter is PlmBomWritebackAdapter {
+  const candidate = adapter as PlmBomWritebackAdapter | null
+  return (
+    isPlmBomReviewAdapter(adapter)
+    && typeof candidate?.updateBomMultitableLine === 'function'
+  )
+}
+
+function normalizeBomLineWritebackPatch(value: unknown): BomMultitableLinePatch | null {
+  const record = value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+  const patch: BomMultitableLinePatch = {}
+  if ('quantity' in record) {
+    const quantity = record.quantity
+    if (
+      quantity !== null
+      && typeof quantity !== 'number'
+      && typeof quantity !== 'string'
+    ) {
+      return null
+    }
+    patch.quantity = quantity as number | string | null
+  }
+  if ('uom' in record) {
+    const uom = record.uom
+    if (uom !== null && typeof uom !== 'string') return null
+    patch.uom = uom as string | null
+  }
+  if ('find_num' in record) {
+    const findNum = record.find_num
+    if (findNum !== null && typeof findNum !== 'string') return null
+    patch.find_num = findNum as string | null
+  }
+  if ('refdes' in record) {
+    const refdes = record.refdes
+    if (refdes !== null && typeof refdes !== 'string') return null
+    patch.refdes = refdes as string | null
+  }
+  return Object.keys(patch).length > 0 ? patch : null
+}
+
+function providerErrorStatus(error: unknown): number | null {
+  const candidate = error as {
+    response?: { status?: unknown }
+    status?: unknown
+    statusCode?: unknown
+  } | null
+  const status = candidate?.response?.status ?? candidate?.status ?? candidate?.statusCode
+  return typeof status === 'number' ? status : null
+}
+
+function relayProviderWritebackError(error: unknown): { status: number; reason: string } {
+  const status = providerErrorStatus(error)
+  if (status && [400, 403, 404, 409, 422].includes(status)) {
+    return { status, reason: 'provider-rejected' }
+  }
+  return { status: 502, reason: 'provider-unavailable' }
 }
 
 router.get(
@@ -857,6 +931,97 @@ router.get(
       entitled,
       context: entitled ? result.context : null,
     })
+  },
+)
+
+router.patch(
+  '/api/plm-workbench/data-sources/:id/bom-multitable/:partId/lines/:bomLineId',
+  authenticate,
+  param('id').isString(),
+  param('partId').isString(),
+  param('bomLineId').isString(),
+  validate,
+  async (req: Request, res: Response) => {
+    const dataSourceId = req.params.id
+    const partId = req.params.partId
+    const bomLineId = req.params.bomLineId
+    let adapter: unknown
+    try {
+      adapter = getDataSourceManager().getDataSource(dataSourceId)
+    } catch {
+      return res
+        .status(404)
+        .json({ error: 'Data source not found', data_source_id: dataSourceId })
+    }
+    if (!isPlmBomWritebackAdapter(adapter)) {
+      return res.status(404).json({
+        error: 'BOM write-back is not supported for this data source',
+        data_source_id: dataSourceId,
+      })
+    }
+
+    let capabilities: IntegrationCapabilitiesResult
+    try {
+      capabilities = await adapter.getIntegrationCapabilities()
+    } catch {
+      return res.status(503).json({
+        error: 'PLM capabilities unavailable',
+        data_source_id: dataSourceId,
+        reason: 'unavailable',
+      })
+    }
+    const feature = capabilities.available ? capabilities.manifest.features.bom_multitable_writeback : undefined
+    if (!feature || feature.supported !== true) {
+      return res.status(404).json({
+        error: 'BOM write-back is not supported',
+        data_source_id: dataSourceId,
+        reason: 'unsupported',
+      })
+    }
+    if (feature.entitled !== true) {
+      return res.status(403).json({
+        error: 'BOM write-back is not entitled',
+        data_source_id: dataSourceId,
+        reason: 'not-entitled',
+      })
+    }
+
+    const idempotencyKey = (req.header('Idempotency-Key') || '').trim()
+    if (!idempotencyKey) {
+      return res.status(400).json({
+        error: 'Idempotency-Key header is required',
+        data_source_id: dataSourceId,
+        reason: 'missing-idempotency-key',
+      })
+    }
+
+    const patch = normalizeBomLineWritebackPatch(req.body)
+    if (!patch) {
+      return res.status(400).json({
+        error: 'BOM write-back patch must include quantity, uom, find_num, or refdes',
+        data_source_id: dataSourceId,
+        reason: 'invalid-patch',
+      })
+    }
+
+    const result = await adapter.updateBomMultitableLine(partId, bomLineId, patch, { idempotencyKey })
+    if (result.error) {
+      const relayed = relayProviderWritebackError(result.error)
+      return res.status(relayed.status).json({
+        error: result.error.message || 'BOM write-back failed',
+        data_source_id: dataSourceId,
+        reason: relayed.reason,
+      })
+    }
+    const payload = result.data?.[0]
+    if (!payload || payload.ok !== true || typeof payload.bom_line_id !== 'string') {
+      return res.status(502).json({
+        error: 'BOM write-back returned a malformed response',
+        data_source_id: dataSourceId,
+        reason: 'malformed-response',
+      })
+    }
+    return res.json(payload)
   },
 )
 

--- a/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
@@ -248,6 +248,18 @@ describe('PLMAdapter.updateBomMultitableLine (PLM-COLLAB P3 — thin success-onl
     expect(firstKey).not.toBe(secondKey)
   })
 
+  it('uses the caller-owned Idempotency-Key when the workbench retries the same logical submit', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })
+    ;(adapter as never as { select: unknown }).select = select
+
+    await adapter.updateBomMultitableLine('P4', 'R8', { quantity: 6 }, { idempotencyKey: 'workbench-submit-1' })
+
+    expect(select).toHaveBeenCalledTimes(1)
+    const [, options] = select.mock.calls[0]
+    expect(options.headers['Idempotency-Key']).toBe('workbench-submit-1')
+  })
+
   it('null cell is a real "clear" edit, not empty: kept in payload, request issued', async () => {
     const adapter = createAdapter('yuantus')
     const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })

--- a/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
@@ -53,17 +53,22 @@ const CONTEXT = {
   template_key: 'bom_review',
 }
 
-const manifest = (bom: Record<string, unknown> | undefined) => ({
+const manifest = (
+  bom: Record<string, unknown> | undefined,
+  extraFeatures: Record<string, Record<string, unknown>> = {},
+) => ({
   schema_version: 'v1',
   provider: 'yuantus-plm',
   advisory: true,
   features: {
     approval_automation: { supported: true, api_version: 'v1', entitled: true },
     ...(bom ? { bom_multitable: bom } : {}),
+    ...extraFeatures,
   },
 })
 
 const URL = '/api/plm-workbench/data-sources/ds-1/bom-multitable/P1/context'
+const WRITE_URL = '/api/plm-workbench/data-sources/ds-1/bom-multitable/P1/lines/R1'
 
 describe('plm-workbench BOM multi-table review route (PLM-COLLAB P3-C)', () => {
   const app = express()
@@ -177,5 +182,111 @@ describe('plm-workbench BOM multi-table review route (PLM-COLLAB P3-C)', () => {
     const res = await request(app).get(URL)
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ data_source_id: 'ds-1', available: true, entitled: true, context: null, reason: 'unavailable' })
+  })
+
+  it('write route requires a write-capable adapter', async () => {
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn(),
+      getBomMultitableContext: vi.fn(),
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .send({ quantity: 5 })
+    expect(res.status).toBe(404)
+    expect(res.body.reason).toBeUndefined()
+  })
+
+  it('write route pre-checks bom_multitable_writeback entitlement and does not call the provider when unentitled', async () => {
+    const updateBomMultitableLine = vi.fn()
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: false } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine,
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .send({ quantity: 5 })
+    expect(res.status).toBe(403)
+    expect(res.body.reason).toBe('not-entitled')
+    expect(updateBomMultitableLine).not.toHaveBeenCalled()
+  })
+
+  it('write route rejects a missing Idempotency-Key before calling the provider', async () => {
+    const updateBomMultitableLine = vi.fn()
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: true } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine,
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .send({ quantity: 5 })
+    expect(res.status).toBe(400)
+    expect(res.body.reason).toBe('missing-idempotency-key')
+    expect(updateBomMultitableLine).not.toHaveBeenCalled()
+  })
+
+  it('write route forwards whitelisted patch cells with the caller-owned Idempotency-Key', async () => {
+    const updateBomMultitableLine = vi.fn().mockResolvedValue({
+      data: [{ ok: true, bom_line_id: 'R1' }],
+    })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: true } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine,
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .send({ quantity: 5, refdes: null, applied: true })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true, bom_line_id: 'R1' })
+    expect(updateBomMultitableLine).toHaveBeenCalledWith(
+      'P1',
+      'R1',
+      { quantity: 5, refdes: null },
+      { idempotencyKey: 'submit-1' },
+    )
+  })
+
+  it('write route relays provider 409 conflicts as actionable failures', async () => {
+    const conflict = Object.assign(new Error('locked'), { response: { status: 409 } })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: true } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine: vi.fn().mockResolvedValue({ data: [], error: conflict }),
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .send({ quantity: 5 })
+    expect(res.status).toBe(409)
+    expect(res.body.reason).toBe('provider-rejected')
   })
 })


### PR DESCRIPTION
## Summary

Completes the Phase 7 consumer surface for governed BOM write-back in the PLM workbench:

- extends `PLMAdapter.updateBomMultitableLine` to accept a caller-owned `idempotencyKey`, while preserving the old fresh-key fallback
- adds the `plm-workbench` PATCH relay for `bom_multitable_writeback`, gated by the advisory capability manifest and forwarding actionable provider failures
- adds editable quantity/uom/find_num/refdes controls to the standalone BOM Review panel only; the embed view remains read-only by default
- keeps one idempotency key per logical failed submit so a retry dedupes at the provider

## Validation

- `pnpm --filter @metasheet/core-backend type-check`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-bom-multitable.test.ts tests/unit/plm-workbench-bom-multitable-routes.test.ts`
- `pnpm --filter @metasheet/web exec vitest run tests/plm-bom-review-service.spec.ts tests/PlmBomReviewPanel.spec.ts`

## Notes

- This does not change the frozen pact shape; it uses the existing governed PATCH interaction.
- The read-only embed page does not pass `editable`, so it stays read-only.
