### PR TITLE
feat(multitable): W7 resultWriteback UI in the start_approval action editor (T0-2)

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -336,6 +336,26 @@
                 <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeApprovalMapping(action, pidx)">&times;</button>
               </div>
               <button class="meta-rule-editor__btn" type="button" @click="addApprovalMapping(action)">{{ automationLabel('editor.addField', isZh) }}</button>
+
+              <!-- W7 approval-result writeback (optional): three source-field pickers. Type compat is a hint; the
+                   currently-configured value is always preserved as a marked option (see resultWritebackFieldOptions). -->
+              <label class="meta-rule-editor__label">{{ automationLabel('resultWriteback.title', isZh) }}</label>
+              <div class="meta-rule-editor__hint">{{ automationLabel('resultWriteback.hint', isZh) }}</div>
+              <label class="meta-rule-editor__label meta-rule-editor__label--sub">{{ automationLabel('resultWriteback.statusField', isZh) }}</label>
+              <select v-model="action.config.resultWritebackStatusField" class="meta-rule-editor__select" data-field="resultWritebackStatusField">
+                <option value="">{{ automationLabel('resultWriteback.none', isZh) }}</option>
+                <option v-for="opt in resultWritebackFieldOptions('status', action.config.resultWritebackStatusField)" :key="opt.id" :value="opt.id" :data-marked="opt.marked || undefined">{{ opt.label }}</option>
+              </select>
+              <label class="meta-rule-editor__label meta-rule-editor__label--sub">{{ automationLabel('resultWriteback.approverField', isZh) }}</label>
+              <select v-model="action.config.resultWritebackApproverField" class="meta-rule-editor__select" data-field="resultWritebackApproverField">
+                <option value="">{{ automationLabel('resultWriteback.none', isZh) }}</option>
+                <option v-for="opt in resultWritebackFieldOptions('approver', action.config.resultWritebackApproverField)" :key="opt.id" :value="opt.id" :data-marked="opt.marked || undefined">{{ opt.label }}</option>
+              </select>
+              <label class="meta-rule-editor__label meta-rule-editor__label--sub">{{ automationLabel('resultWriteback.completedAtField', isZh) }}</label>
+              <select v-model="action.config.resultWritebackCompletedAtField" class="meta-rule-editor__select" data-field="resultWritebackCompletedAtField">
+                <option value="">{{ automationLabel('resultWriteback.none', isZh) }}</option>
+                <option v-for="opt in resultWritebackFieldOptions('completedAt', action.config.resultWritebackCompletedAtField)" :key="opt.id" :value="opt.id" :data-marked="opt.marked || undefined">{{ opt.label }}</option>
+              </select>
             </div>
 
             <!-- send_email config -->
@@ -1226,6 +1246,10 @@ type DraftActionConfig = Record<string, unknown> & {
   bodyTemplate?: string
   publicFormViewId?: string
   internalViewId?: string
+  // W7 start_approval result-writeback pickers (UI-only bindings; assembled into config.resultWriteback on save).
+  resultWritebackStatusField?: string
+  resultWritebackApproverField?: string
+  resultWritebackCompletedAtField?: string
   locked?: boolean
   // A6-3-2a condition_branch authoring (supported → editable draft; unsupported → read-only + original preserved)
   branches?: BranchDraft[]
@@ -1816,10 +1840,15 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
     const formDataMappingPairs = Array.isArray(config.formDataMappingPairs)
       ? config.formDataMappingPairs
       : Object.entries(mapping).map(([fieldId, value]) => ({ fieldId, value: String(value ?? '') }))
+    // W7: backfill the optional result-writeback pickers from config.resultWriteback (empty string when absent).
+    const writeback = isPlainRecord(config.resultWriteback) ? config.resultWriteback : {}
     return {
       ...config,
       templateId: typeof config.templateId === 'string' ? config.templateId : '',
       formDataMappingPairs,
+      resultWritebackStatusField: typeof writeback.statusField === 'string' ? writeback.statusField : '',
+      resultWritebackApproverField: typeof writeback.approverField === 'string' ? writeback.approverField : '',
+      resultWritebackCompletedAtField: typeof writeback.completedAtField === 'string' ? writeback.completedAtField : '',
     }
   }
   if (type === 'send_dingtalk_group_message') {
@@ -2822,6 +2851,42 @@ function removeApprovalMapping(action: DraftAction, idx: number) {
   ;(action.config.formDataMappingPairs as FieldPair[]).splice(idx, 1)
 }
 
+// W7 result-writeback picker options. Type compatibility is a HINT, never a GATE: the option set is the
+// type-compatible source fields PLUS the currently-configured field id, which is ALWAYS present (and thus
+// selectable + selected) even when it has been deleted, retyped, or is otherwise absent from `fields`.
+// Preserving the current value is what makes the omit-when-empty save rule safe — an empty picker then means
+// "the author cleared it," never "a configured value couldn't be displayed" (design-lock §3 P2 / §4). The
+// backend's assertResultWritebackFields remains the authority; the marker is a visible hint, not a rejection.
+type ResultWritebackFieldKind = 'status' | 'approver' | 'completedAt'
+const RESULT_WRITEBACK_COMPAT: Record<ResultWritebackFieldKind, readonly string[]> = {
+  status: ['string', 'longText', 'select'],
+  approver: ['string', 'longText'],
+  completedAt: ['string', 'longText', 'dateTime'],
+}
+
+function resultWritebackFieldOptions(
+  kind: ResultWritebackFieldKind,
+  currentValue: unknown,
+): Array<{ id: string; label: string; marked: boolean }> {
+  const compat = RESULT_WRITEBACK_COMPAT[kind]
+  const options = props.fields
+    .filter((field) => compat.includes(field.type))
+    .map((field) => ({ id: field.id, label: field.name, marked: false }))
+  const current = typeof currentValue === 'string' ? currentValue.trim() : ''
+  if (current && !options.some((option) => option.id === current)) {
+    // P2 must-fix: the stale/incompatible/missing configured value is appended as a marked option so the
+    // <select> never silently renders empty and an unedited save carries it back verbatim for the backend.
+    const existing = props.fields.find((field) => field.id === current)
+    const marker = existing
+      ? automationLabel('resultWriteback.markIncompatible', isZh.value)
+      : automationLabel('resultWriteback.markUnknown', isZh.value)
+    const baseName = existing ? existing.name : current
+    const label = isZh.value ? `${baseName}（${marker}）` : `${baseName} (${marker})`
+    options.push({ id: current, label, marked: true })
+  }
+  return options
+}
+
 function addCreateFieldValue(action: DraftAction) {
   if (!Array.isArray(action.config.fieldValues)) action.config.fieldValues = []
   ;(action.config.fieldValues as FieldPair[]).push({ fieldId: '', value: '' })
@@ -2869,13 +2934,28 @@ function buildPayload(): Partial<AutomationRule> {
       // Assemble the {key: value} formDataMapping the backend requires from the editable rows. templateId +
       // mapping non-emptiness are enforced server-side (validateStartApprovalConfig) — the UI is authoring,
       // not the validation gate.
-      return {
-        type: action.type,
-        config: {
-          templateId: typeof action.config.templateId === 'string' ? action.config.templateId.trim() : '',
-          formDataMapping: fieldPairsToRecord(action.config.formDataMappingPairs),
-        },
+      //
+      // W7: this branch rebuilds config from scratch (NOT a `...action.config` spread — that would leak the
+      // UI-only formDataMappingPairs draft rows). So result-writeback must be carried EXPLICITLY or an unedited
+      // load→save silently drops it (the lossy round-trip the W7 lock exists to fix). Assemble resultWriteback
+      // from the three pickers, emit only non-empty trimmed fields, and OMIT the key entirely when all three are
+      // empty — the backend rejects an empty `{}` mapping, so "nothing configured" must round-trip to ABSENCE.
+      const resultWriteback: Record<string, string> = {}
+      const statusField = typeof action.config.resultWritebackStatusField === 'string' ? action.config.resultWritebackStatusField.trim() : ''
+      const approverField = typeof action.config.resultWritebackApproverField === 'string' ? action.config.resultWritebackApproverField.trim() : ''
+      const completedAtField = typeof action.config.resultWritebackCompletedAtField === 'string' ? action.config.resultWritebackCompletedAtField.trim() : ''
+      if (statusField) resultWriteback.statusField = statusField
+      if (approverField) resultWriteback.approverField = approverField
+      if (completedAtField) resultWriteback.completedAtField = completedAtField
+      const config: Record<string, unknown> = {
+        templateId: typeof action.config.templateId === 'string' ? action.config.templateId.trim() : '',
+        formDataMapping: fieldPairsToRecord(action.config.formDataMappingPairs),
       }
+      if (Object.keys(resultWriteback).length > 0) config.resultWriteback = resultWriteback
+      // W7 §6: no `requester` UI in this slice, but carry a backend-valid hand-authored `requester` through so
+      // the from-scratch rebuild stays lossless for any valid config (not just the keys this slice surfaces).
+      if (action.config.requester !== undefined) config.requester = action.config.requester
+      return { type: action.type, config }
     }
     if (action.type === 'parallel_branch') {
       if (action.config.parallelBranchUnsupportedReason && action.config.parallelBranchOriginal) {

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -294,6 +294,15 @@ export type AutomationLabelKey =
   | 'runs.resumeError.ruleMissingOrDisabled'
   | 'runs.resumeError.recordGone'
   | 'runs.resumeError.generic'
+  // W7 start_approval approval-result writeback pickers.
+  | 'resultWriteback.title'
+  | 'resultWriteback.hint'
+  | 'resultWriteback.statusField'
+  | 'resultWriteback.approverField'
+  | 'resultWriteback.completedAtField'
+  | 'resultWriteback.none'
+  | 'resultWriteback.markUnknown'
+  | 'resultWriteback.markIncompatible'
 
 export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'log.title',
@@ -538,6 +547,14 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'runs.resumeError.ruleMissingOrDisabled',
   'runs.resumeError.recordGone',
   'runs.resumeError.generic',
+  'resultWriteback.title',
+  'resultWriteback.hint',
+  'resultWriteback.statusField',
+  'resultWriteback.approverField',
+  'resultWriteback.completedAtField',
+  'resultWriteback.none',
+  'resultWriteback.markUnknown',
+  'resultWriteback.markIncompatible',
 ]
 
 const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
@@ -810,6 +827,17 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'runs.resumeError.ruleMissingOrDisabled': { en: 'The rule is missing or disabled; cannot resume.', zh: '规则缺失或已停用，无法恢复。' },
   'runs.resumeError.recordGone': { en: 'The record no longer exists; cannot resume.', zh: '记录已不存在，无法恢复。' },
   'runs.resumeError.generic': { en: 'Resume failed.', zh: '恢复失败。' },
+  'resultWriteback.title': { en: 'Approval-result writeback (optional)', zh: '审批结果写回（可选）' },
+  'resultWriteback.hint': {
+    en: 'On approval, write the outcome back onto the source record. Each field is optional.',
+    zh: '审批通过后，将审批结果写回到来源记录。每个字段均为可选。',
+  },
+  'resultWriteback.statusField': { en: 'Status field', zh: '状态字段' },
+  'resultWriteback.approverField': { en: 'Approver field', zh: '审批人字段' },
+  'resultWriteback.completedAtField': { en: 'Completed-at field', zh: '完成时间字段' },
+  'resultWriteback.none': { en: '(not written)', zh: '（不写回）' },
+  'resultWriteback.markUnknown': { en: 'unknown field', zh: '未知字段' },
+  'resultWriteback.markIncompatible': { en: 'incompatible', zh: '不兼容' },
 }
 
 type UnknownAutomationString = string & Record<never, never>

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -604,6 +604,130 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1')
   })
 
+  async function selectStartApproval(container: HTMLElement) {
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'start approval'; nameInput.dispatchEvent(new Event('input'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'start_approval'; actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    const tmpl = container.querySelector('[data-field="approvalTemplateId"]') as HTMLInputElement
+    tmpl.value = 'tmpl_1'; tmpl.dispatchEvent(new Event('input'))
+    await flushPromises()
+  }
+
+  it('W7: renders the optional approval-result writeback pickers over type-compatible source fields', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+    await selectStartApproval(container)
+
+    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLSelectElement
+    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLSelectElement
+    const completedSel = container.querySelector('[data-field="resultWritebackCompletedAtField"]') as HTMLSelectElement
+    expect(statusSel).not.toBeNull()
+    expect(approverSel).not.toBeNull()
+    expect(completedSel).not.toBeNull()
+
+    // status hint = string / longText / select → Status(select), Name(string), Priority(select); plus "(not written)".
+    const statusVals = Array.from(statusSel.options).map((o) => o.value)
+    expect(statusVals).toContain('')
+    expect(statusVals).toEqual(expect.arrayContaining(['fld_1', 'fld_2', 'fld_priority']))
+    expect(statusVals).not.toContain('fld_score') // number is not a status-compatible hint
+    // approver hint = string / longText → only Name(string).
+    expect(Array.from(approverSel.options).map((o) => o.value)).toEqual(expect.arrayContaining(['', 'fld_2']))
+    expect(Array.from(approverSel.options).map((o) => o.value)).not.toContain('fld_1')
+  })
+
+  it('W7: OMITS config.resultWriteback when no writeback picker is set (omit-when-empty, not an invalid {})', async () => {
+    // The backend rejects an empty `{}` mapping, so "nothing configured" must round-trip to ABSENCE.
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+    await selectStartApproval(container)
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+    expect(saved.mock.calls[0][0].actions[0].config).not.toHaveProperty('resultWriteback')
+  })
+
+  it('W7: saves config.resultWriteback with exactly the chosen pickers (an untouched completedAt stays out)', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+    await selectStartApproval(container)
+    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLSelectElement
+    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLSelectElement
+    statusSel.value = 'fld_1'; statusSel.dispatchEvent(new Event('change'))
+    approverSel.value = 'fld_2'; approverSel.dispatchEvent(new Event('change'))
+    await flushPromises()
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+    expect(saved.mock.calls[0][0].actions[0].config.resultWriteback).toEqual({ statusField: 'fld_1', approverField: 'fld_2' })
+  })
+
+  it('W7: round-trips a loaded resultWriteback unchanged on an unedited save (lossy-drop FAIL-FIRST vs buildPayload)', async () => {
+    const saved = vi.fn()
+    const rule = {
+      id: 'atr_w7', sheetId: 'sheet_1', name: 'w7', triggerType: 'form.submitted',
+      triggerConfig: {}, actionType: 'start_approval',
+      actionConfig: {
+        templateId: 'tmpl_9',
+        formDataMapping: { amount: 'fld_2' },
+        resultWriteback: { statusField: 'fld_1', approverField: 'fld_2', completedAtField: 'fld_2' },
+        // §6: `requester` has no UI in this slice but rides the SAME from-scratch rebuild — it must survive too.
+        requester: { mode: 'form_field_user', fieldId: 'reviewerUserId' },
+      },
+      enabled: true,
+    } as unknown as AutomationRule
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
+    await flushPromises()
+    // draftConfigFromAction backfilled the pickers from the loaded config.
+    expect((container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLSelectElement).value).toBe('fld_1')
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+    const cfg = saved.mock.calls[0][0].actions[0].config
+    // FAIL-FIRST: buildPayload rebuilds start_approval config from scratch; without the explicit-carry it drops
+    // resultWriteback entirely → this deep-equals goes RED (the latent lossy round-trip the W7 lock fixes).
+    expect(cfg.resultWriteback).toEqual({ statusField: 'fld_1', approverField: 'fld_2', completedAtField: 'fld_2' })
+    // Same bug-class: the whitelist rebuild must carry a hand-authored `requester` through, not silently drop it.
+    expect(cfg.requester).toEqual({ mode: 'form_field_user', fieldId: 'reviewerUserId' })
+  })
+
+  it('W7: preserves a stale / incompatible / missing resultWriteback target across an unedited save (P2 FAIL-FIRST)', async () => {
+    const saved = vi.fn()
+    const rule = {
+      id: 'atr_w7_stale', sheetId: 'sheet_1', name: 'w7 stale', triggerType: 'form.submitted',
+      triggerConfig: {}, actionType: 'start_approval',
+      actionConfig: {
+        templateId: 'tmpl_9',
+        formDataMapping: { amount: 'fld_2' },
+        // fld_score is type=number → INCOMPATIBLE for statusField; fld_gone is ABSENT from `fields` → missing.
+        resultWriteback: { statusField: 'fld_score', approverField: 'fld_gone' },
+      },
+      enabled: true,
+    } as unknown as AutomationRule
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
+    await flushPromises()
+
+    // P2 FAIL-FIRST LEVER (DOM): the picker must keep the stale/missing value as a present + selected <option>.
+    // Without resultWritebackFieldOptions appending the current value, the type filter drops it → no matching
+    // option → select.value falls back to '' → these go RED. (The save assertion below passes via Vue v-model
+    // binding-persistence regardless of P2 — Vue never clears a bound value just because it left the options —
+    // so the DOM is the genuine P2 regression lever; see the design-lock §3 P2 / §4 reconciliation.)
+    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLSelectElement
+    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLSelectElement
+    expect(statusSel.value).toBe('fld_score')
+    const statusOpt = Array.from(statusSel.options).find((o) => o.value === 'fld_score')
+    expect(statusOpt).toBeTruthy()
+    expect(statusOpt?.getAttribute('data-marked')).toBe('true') // appended as the marked current-value option
+    expect(approverSel.value).toBe('fld_gone')
+    expect(Array.from(approverSel.options).some((o) => o.value === 'fld_gone')).toBe(true)
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+    // §4 Guarantee: the original (stale) ids reach the backend verbatim for assertResultWritebackFields fail-fast
+    // — never silently UI-dropped/omitted.
+    expect(saved.mock.calls[0][0].actions[0].config.resultWriteback).toEqual({ statusField: 'fld_score', approverField: 'fld_gone' })
+  })
+
   it('can add and remove conditions', async () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()


### PR DESCRIPTION
Implements the **W7 `resultWriteback` UI** per the merged design-lock (`docs/development/w7-resultwriteback-ui-design-lock-20260629.md`, #3375). Exposes the already-shipped approved-path backwrite config in the `start_approval` action editor. Frontend-only.

## What
- **D1** — optional "审批结果写回 / Approval-result writeback" block (after formDataMapping): three `<select>` pickers (`statusField`/`approverField`/`completedAtField`) over source `fields`, `data-field` hooks, empty = "(not written)".
- **D4 (P2)** — `resultWritebackFieldOptions(kind, current)`: type-compatible fields (status→string/longText/select, approver→string/longText, completedAt→string/longText/dateTime) **plus the currently-configured id always appended as a marked option** (incompatible/unknown), never excluded.
- **D2** — `buildPayload`: assemble `resultWriteback` by **explicit-carry** (no `...config` spread), emit only non-empty trimmed fields, **omit the key when all empty** (backend rejects `{}`), pass `requester` through if present.
- **D3** — `draftConfigFromAction`: backfill `config.resultWriteback` into the pickers.
- **D5** — 8 `resultWriteback.*` i18n keys in `meta-automation-labels`.

## ⚠️ Honest deviation from the design-lock §5 (please confirm)
The lock's §5 framed the P2 test as fail-first at **save** ("value renders empty → save omits it"). Empirically, Vue's `<select v-model>` **never clears the bound value** when it leaves the options — `buildPayload` reads the *binding*, not the DOM, so a stale value is carried regardless. That binding-persistence is what makes §4's round-trip Guarantee hold; reading the DOM at save would *re-create* the lossy drop this PR fixes. So P2's genuine, testable lever is at the **DOM** (the stale value stays a present+marked option), which the test asserts as fail-first — **plus** the save Guarantee (passes via binding-persistence). Net: the implementation is *more* correct than the lock's test framing, documented in a test comment + here. The core lossy-drop fix (explicit-carry) remains save-level fail-first.

## Verification (real)
- `vue-tsc -b` clean · `multitable-automation-rule-editor.spec.ts` + `meta-automation-labels.spec.ts` = **116 passed**, incl. 5 new W7 specs.
- Fail-first verified by revert: lossy-drop → RED without the carry; P2 marked-option → RED without the current-value append; `requester` round-trip → RED without the pass-through.

Held reviewable (not auto-merged) pending your nod on the §5 deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)