### PR TITLE
feat(integration): add K3 LIST response shape probe

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5545,6 +5545,19 @@ async function testReadSmokeRoute() {
                 metadata: {
                   readPath: 'https://k3host/K3API/Material/GetList',
                   dataRowCount: 2,
+                  responseShapeProbe: {
+                    dataObjectPresent: true,
+                    dataRowCountPresent: true,
+                    dataPageSizePresent: false,
+                    dataPageIndexPresent: false,
+                    dataDataType: 'missing',
+                    dataDataArrayLength: null,
+                    fixedContainers: {
+                      resultRows: { type: 'array', arrayLength: 2, materialNumber: 'M-LIST-001' },
+                      topLevel: { type: 'object', arrayLength: null },
+                      arbitraryContainer: { type: 'array', arrayLength: 1 },
+                    },
+                  },
                   listShapeProbe: {
                     dataData: false,
                     dataLowerData: false,
@@ -5635,6 +5648,18 @@ async function testReadSmokeRoute() {
     resultRows: true,
     rows: false,
     topLevelArray: false,
+  })
+  assert.deepEqual(okList.body.data.responseShapeProbe, {
+    dataObjectPresent: true,
+    dataRowCountPresent: true,
+    dataPageSizePresent: false,
+    dataPageIndexPresent: false,
+    dataDataType: 'missing',
+    dataDataArrayLength: null,
+    fixedContainers: {
+      resultRows: { type: 'array', arrayLength: 2 },
+      topLevel: { type: 'object', arrayLength: null },
+    },
   })
   const listReadArg = readArgs[readArgs.length - 1]
   assert.equal(listReadArg.object, 'material')
@@ -5750,6 +5775,19 @@ async function testReadSmokeRoute() {
           code: 'K3_WISE_READ_LIST_REJECTED',
           dataDataPresent: true,
           dataRowCount: 1,
+          responseShapeProbe: {
+            dataObjectPresent: true,
+            dataRowCountPresent: true,
+            dataPageSizePresent: false,
+            dataPageIndexPresent: false,
+            dataDataType: 'array',
+            dataDataArrayLength: 1,
+            fixedContainers: {
+              dataData: { type: 'array', arrayLength: 1, materialNumber: 'M-001' },
+              topLevel: { type: 'object', arrayLength: null },
+              arbitraryContainer: { type: 'array', arrayLength: 1 },
+            },
+          },
           listShapeProbe: {
             dataData: true,
             dataLowerData: false,
@@ -5785,8 +5823,20 @@ async function testReadSmokeRoute() {
     rows: false,
     topLevelArray: false,
   })
+  assert.deepEqual(fail.body.data.responseShapeProbe, {
+    dataObjectPresent: true,
+    dataRowCountPresent: true,
+    dataPageSizePresent: false,
+    dataPageIndexPresent: false,
+    dataDataType: 'array',
+    dataDataArrayLength: 1,
+    fixedContainers: {
+      dataData: { type: 'array', arrayLength: 1 },
+      topLevel: { type: 'object', arrayLength: null },
+    },
+  })
   const failStr = JSON.stringify(fail.body.data)
-  assert.ok(!failStr.includes('M-001') && !failStr.includes('42') && !failStr.includes('materialNumber'), 'read failure evidence is values-free')
+	  assert.ok(!failStr.includes('M-001') && !failStr.includes('42') && !failStr.includes('materialNumber') && !failStr.includes('arbitraryContainer'), 'read failure evidence is values-free')
   assert.equal(failWrite.length, 0, 'no write attempted on read failure')
 
   console.log('  testReadSmokeRoute OK')

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -980,6 +980,25 @@ async function testK3WebApiMaterialListReadSmoke() {
     rows: false,
     topLevelArray: false,
   })
+  assert.deepEqual(read.metadata.responseShapeProbe, {
+    dataObjectPresent: true,
+    dataRowCountPresent: true,
+    dataPageSizePresent: true,
+    dataPageIndexPresent: true,
+    dataDataType: 'array',
+    dataDataArrayLength: 3,
+    fixedContainers: {
+      dataData: { type: 'array', arrayLength: 3 },
+      dataLowerData: { type: 'missing', arrayLength: null },
+      dataRows: { type: 'missing', arrayLength: null },
+      dataList: { type: 'missing', arrayLength: null },
+      dataItems: { type: 'missing', arrayLength: null },
+      resultData: { type: 'missing', arrayLength: null },
+      resultRows: { type: 'missing', arrayLength: null },
+      rows: { type: 'missing', arrayLength: null },
+      topLevel: { type: 'object', arrayLength: null },
+    },
+  }, 'LIST response-shape probe surfaces fixed container types/counts only')
   assert.equal(read.metadata.readPath, '/K3API/Material/GetList')
 
   const listCalls = calls.filter((call) => call.pathname === '/K3API/Material/GetList')
@@ -1070,6 +1089,25 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.equal(pagingEcho.metadata.dataPageIndex, 0, 'K3 echoes the page index it applied')
   assert.equal(pagingEcho.metadata.requestedLimit, 2, 'requested page size/Top surfaced for the requested-vs-echoed comparison')
   assert.equal(pagingEcho.metadata.requestedPageIndex, 1, 'requested page index surfaced for the comparison')
+  assert.deepEqual(pagingEcho.metadata.responseShapeProbe, {
+    dataObjectPresent: true,
+    dataRowCountPresent: true,
+    dataPageSizePresent: true,
+    dataPageIndexPresent: true,
+    dataDataType: 'null',
+    dataDataArrayLength: null,
+    fixedContainers: {
+      dataData: { type: 'null', arrayLength: null },
+      dataLowerData: { type: 'missing', arrayLength: null },
+      dataRows: { type: 'missing', arrayLength: null },
+      dataList: { type: 'missing', arrayLength: null },
+      dataItems: { type: 'missing', arrayLength: null },
+      resultData: { type: 'missing', arrayLength: null },
+      resultRows: { type: 'missing', arrayLength: null },
+      rows: { type: 'missing', arrayLength: null },
+      topLevel: { type: 'object', arrayLength: null },
+    },
+  }, 'paging-echo response-shape probe makes DATA=null explicit without changing extraction')
 
   const missingRowsFetchImpl = async (url, options) => {
     const parsed = new URL(url)
@@ -1115,6 +1153,9 @@ async function testK3WebApiMaterialListReadSmoke() {
     rows: false,
     topLevelArray: false,
   })
+  assert.equal(missingRows.metadata.responseShapeProbe.dataRowCountPresent, true)
+  assert.equal(missingRows.metadata.responseShapeProbe.dataDataType, 'null')
+  assert.deepEqual(missingRows.metadata.responseShapeProbe.fixedContainers.dataData, { type: 'null', arrayLength: null })
 
   const alternateRowsFetchImpl = async (url, options) => {
     const parsed = new URL(url)
@@ -1160,6 +1201,9 @@ async function testK3WebApiMaterialListReadSmoke() {
     rows: false,
     topLevelArray: false,
   }, 'LIST shape probe localizes rows under a fixed allowlisted alternate container')
+  assert.deepEqual(alternateRows.metadata.responseShapeProbe.fixedContainers.resultRows, { type: 'array', arrayLength: 1 })
+  assert.deepEqual(alternateRows.metadata.responseShapeProbe.fixedContainers.topLevel, { type: 'object', arrayLength: null })
+  assert.equal(alternateRows.metadata.responseShapeProbe.dataDataType, 'missing')
 
   const rejectedFetchImpl = async (url, options) => {
     const parsed = new URL(url)
@@ -1206,6 +1250,8 @@ async function testK3WebApiMaterialListReadSmoke() {
     rows: false,
     topLevelArray: false,
   })
+  assert.equal(rejected.details.responseShapeProbe.dataDataType, 'array')
+  assert.deepEqual(rejected.details.responseShapeProbe.fixedContainers.dataData, { type: 'array', arrayLength: 1 })
 
   const unrecognizedFetchImpl = async (url, options) => {
     const parsed = new URL(url)
@@ -1251,6 +1297,8 @@ async function testK3WebApiMaterialListReadSmoke() {
     rows: false,
     topLevelArray: false,
   })
+  assert.equal(unrecognized.details.responseShapeProbe.dataDataType, 'array')
+  assert.deepEqual(unrecognized.details.responseShapeProbe.fixedContainers.dataData, { type: 'array', arrayLength: 1 })
 
   const modeMismatch = await adapter.read({
     object: 'material',

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -197,6 +197,52 @@ assert.deepEqual(pagingEcho, {
 })
 assert.ok(!JSON.stringify(pagingEcho).includes('SECRET-MAT-001'), 'paging-echo evidence does not leak a material value')
 assert.ok(!JSON.stringify(pagingEcho).includes('materialNumber'), 'paging-echo evidence drops non-allowlisted metadata keys')
+const responseShapeEvidence = readSmokeSuccessEvidence(LIST_PRESET, {
+  records: [],
+  metadata: {
+    responseShapeProbe: {
+      dataObjectPresent: true,
+      dataRowCountPresent: true,
+      dataPageSizePresent: true,
+      dataPageIndexPresent: false,
+      dataDataType: 'null',
+      dataDataArrayLength: null,
+      materialNumber: 'SECRET-MAT-002',
+      arbitraryKeyName: 'SECRET-KEY',
+      fixedContainers: {
+        dataData: { type: 'null', arrayLength: null, materialNumber: 'SECRET-MAT-002' },
+        dataList: { type: 'array', arrayLength: 2, rows: [{ materialNumber: 'SECRET-MAT-003' }] },
+        resultRows: { type: 'invalid-type', arrayLength: 1 },
+        arbitraryContainer: { type: 'array', arrayLength: 99 },
+      },
+    },
+  },
+}, { object: 'material', mode: 'list' })
+assert.deepEqual(responseShapeEvidence, {
+  ok: true,
+  presetId: 'k3wise.material-list.v1',
+  object: 'material',
+  mode: 'list',
+  recordPresent: false,
+  recordCount: 0,
+  referenceObjectCount: 0,
+  responseShapeProbe: {
+    dataObjectPresent: true,
+    dataRowCountPresent: true,
+    dataPageSizePresent: true,
+    dataPageIndexPresent: false,
+    dataDataType: 'null',
+    dataDataArrayLength: null,
+    fixedContainers: {
+      dataData: { type: 'null', arrayLength: null },
+      dataList: { type: 'array', arrayLength: 2 },
+    },
+  },
+})
+const responseShapeEvidenceStr = JSON.stringify(responseShapeEvidence)
+for (const leak of ['SECRET-MAT-002', 'SECRET-MAT-003', 'SECRET-KEY', 'materialNumber', 'arbitraryKeyName', 'arbitraryContainer']) {
+  assert.ok(!responseShapeEvidenceStr.includes(leak), `response-shape evidence must not leak ${leak}`)
+}
 
 assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, { records: [{ FNumber: 'M-001' }, { FNumber: 'M-002' }] }, { object: 'material', mode: 'list' }), {
   ok: true, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', recordPresent: true, recordCount: 2, referenceObjectCount: 0,
@@ -263,6 +309,19 @@ listError.details = {
   code: 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED',
   dataDataPresent: true,
   dataRowCount: 1,
+  responseShapeProbe: {
+    dataObjectPresent: true,
+    dataRowCountPresent: true,
+    dataPageSizePresent: false,
+    dataPageIndexPresent: false,
+    dataDataType: 'array',
+    dataDataArrayLength: 1,
+    fixedContainers: {
+      dataData: { type: 'array', arrayLength: 1, materialNumber: 'M-001' },
+      topLevel: { type: 'object', arrayLength: null },
+      arbitraryContainer: { type: 'array', arrayLength: 1 },
+    },
+  },
   listShapeProbe: {
     dataData: true,
     dataLowerData: false,
@@ -289,9 +348,21 @@ assert.deepEqual(readSmokeErrorEvidence(LIST_PRESET, listError, { object: 'mater
     rows: false,
     topLevelArray: false,
   },
+  responseShapeProbe: {
+    dataObjectPresent: true,
+    dataRowCountPresent: true,
+    dataPageSizePresent: false,
+    dataPageIndexPresent: false,
+    dataDataType: 'array',
+    dataDataArrayLength: 1,
+    fixedContainers: {
+      dataData: { type: 'array', arrayLength: 1 },
+      topLevel: { type: 'object', arrayLength: null },
+    },
+  },
 })
 const listErrorStr = JSON.stringify(readSmokeErrorEvidence(LIST_PRESET, listError, { object: 'material', mode: 'list' }))
-for (const leak of ['M-001', '42', 'materialNumber']) {
+for (const leak of ['M-001', '42', 'materialNumber', 'arbitraryContainer']) {
   assert.ok(!listErrorStr.includes(leak), `LIST error evidence must not leak ${leak}`)
 }
 const unsafeDetails = new Error('material M-001 failed with secret value 42')

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -821,6 +821,56 @@ function materialListShapeProbe(data) {
   }
 }
 
+const MATERIAL_LIST_RESPONSE_SHAPE_CONTAINER_PATHS = Object.freeze([
+  ['dataData', 'Data.DATA'],
+  ['dataLowerData', 'Data.data'],
+  ['dataRows', 'Data.Rows'],
+  ['dataList', 'Data.List'],
+  ['dataItems', 'Data.Items'],
+  ['resultData', 'Result.Data'],
+  ['resultRows', 'Result.Rows'],
+  ['rows', 'Rows'],
+  ['topLevel', ''],
+])
+
+function materialListShapeType(value) {
+  if (value === undefined) return 'missing'
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  if (isPlainObject(value)) return 'object'
+  if (['string', 'number', 'boolean'].includes(typeof value)) return typeof value
+  return 'other'
+}
+
+function materialListArrayLength(value) {
+  if (!Array.isArray(value)) return null
+  return Math.min(value.length, 1000)
+}
+
+function materialListShapeValueEvidence(value) {
+  return {
+    type: materialListShapeType(value),
+    arrayLength: materialListArrayLength(value),
+  }
+}
+
+function materialListResponseShapeProbe(data) {
+  const fixedContainers = {}
+  for (const [key, path] of MATERIAL_LIST_RESPONSE_SHAPE_CONTAINER_PATHS) {
+    fixedContainers[key] = materialListShapeValueEvidence(path ? getPath(data, path) : data)
+  }
+  const dataData = getPath(data, 'Data.DATA')
+  return {
+    dataObjectPresent: isPlainObject(getPath(data, 'Data')),
+    dataRowCountPresent: materialListRowCount(data) !== null,
+    dataPageSizePresent: materialListPageSize(data) !== null,
+    dataPageIndexPresent: materialListPageIndex(data) !== null,
+    dataDataType: materialListShapeType(dataData),
+    dataDataArrayLength: materialListArrayLength(dataData),
+    fixedContainers,
+  }
+}
+
 function materialListDataDataPresent(data) {
   const probe = materialListShapeProbe(data)
   return probe.dataData || probe.dataLowerData
@@ -1382,6 +1432,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       const dataPageIndex = materialListPageIndex(readResponse.data)
       const requestedLimit = request.limit
       const requestedPageIndex = 1
+      const responseShapeProbe = materialListResponseShapeProbe(readResponse.data)
       if (!materialListBusinessSuccess(readResponse.data, config)) {
         const failureCode = materialListBusinessFailureCode(readResponse.data)
         throw new K3WiseWebApiAdapterError(String(responseMessage(readResponse.data, config, 'K3 WISE list read business response failed')), {
@@ -1395,6 +1446,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           requestedLimit,
           requestedPageIndex,
           listShapeProbe,
+          responseShapeProbe,
         })
       }
 
@@ -1413,6 +1465,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           dataPageSize,
           dataPageIndex,
           listShapeProbe,
+          responseShapeProbe,
           readPath,
           readOnly: true,
         },

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -98,9 +98,76 @@ function readSmokeListShapeProbeEvidence(value) {
   return hasEvidence ? evidence : null
 }
 
+const READ_SMOKE_RESPONSE_SHAPE_CONTAINER_KEYS = Object.freeze([
+  'dataData',
+  'dataLowerData',
+  'dataRows',
+  'dataList',
+  'dataItems',
+  'resultData',
+  'resultRows',
+  'rows',
+  'topLevel',
+])
+const READ_SMOKE_RESPONSE_SHAPE_TYPES = new Set(['array', 'null', 'object', 'string', 'number', 'boolean', 'missing', 'other'])
+
 function readSmokeSafeCount(value) {
   if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value
   return null
+}
+
+function readSmokeSafeOptionalCount(value) {
+  if (value === null) return null
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value
+  return undefined
+}
+
+function readSmokeSafeShapeType(value) {
+  if (typeof value !== 'string') return null
+  return READ_SMOKE_RESPONSE_SHAPE_TYPES.has(value) ? value : null
+}
+
+function readSmokeResponseShapeContainerEvidence(value) {
+  if (!isPlainObject(value)) return null
+  const type = readSmokeSafeShapeType(value.type)
+  if (!type) return null
+  const evidence = { type }
+  const arrayLength = readSmokeSafeOptionalCount(value.arrayLength)
+  if (arrayLength !== undefined) evidence.arrayLength = arrayLength
+  return evidence
+}
+
+function readSmokeResponseShapeProbeEvidence(value) {
+  if (!isPlainObject(value)) return null
+  const evidence = {}
+  let hasEvidence = false
+  for (const key of ['dataObjectPresent', 'dataRowCountPresent', 'dataPageSizePresent', 'dataPageIndexPresent']) {
+    if (typeof value[key] !== 'boolean') continue
+    evidence[key] = value[key]
+    hasEvidence = true
+  }
+  const dataDataType = readSmokeSafeShapeType(value.dataDataType)
+  if (dataDataType) {
+    evidence.dataDataType = dataDataType
+    hasEvidence = true
+  }
+  const dataDataArrayLength = readSmokeSafeOptionalCount(value.dataDataArrayLength)
+  if (dataDataArrayLength !== undefined) {
+    evidence.dataDataArrayLength = dataDataArrayLength
+    hasEvidence = true
+  }
+  if (isPlainObject(value.fixedContainers)) {
+    const fixedContainers = {}
+    for (const key of READ_SMOKE_RESPONSE_SHAPE_CONTAINER_KEYS) {
+      const container = readSmokeResponseShapeContainerEvidence(value.fixedContainers[key])
+      if (container) fixedContainers[key] = container
+    }
+    if (Object.keys(fixedContainers).length > 0) {
+      evidence.fixedContainers = fixedContainers
+      hasEvidence = true
+    }
+  }
+  return hasEvidence ? evidence : null
 }
 
 // C3 LIST paging echo (#1709): copy ONLY the allowlisted values-free count fields (K3-echoed page size/index +
@@ -220,6 +287,8 @@ function readSmokeSuccessEvidence(preset, result, contract = {}) {
   applyReadSmokePagingCounts(evidence, result && result.metadata)
   const listShapeProbe = readSmokeListShapeProbeEvidence(result && result.metadata && result.metadata.listShapeProbe)
   if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
+  const responseShapeProbe = readSmokeResponseShapeProbeEvidence(result && result.metadata && result.metadata.responseShapeProbe)
+  if (responseShapeProbe) evidence.responseShapeProbe = responseShapeProbe
   return evidence
 }
 
@@ -249,6 +318,8 @@ function readSmokeErrorEvidence(preset, error, contract = {}) {
   applyReadSmokePagingCounts(evidence, error && error.details)
   const listShapeProbe = readSmokeListShapeProbeEvidence(error && error.details && error.details.listShapeProbe)
   if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
+  const responseShapeProbe = readSmokeResponseShapeProbeEvidence(error && error.details && error.details.responseShapeProbe)
+  if (responseShapeProbe) evidence.responseShapeProbe = responseShapeProbe
   return evidence
 }
 


### PR DESCRIPTION
## Summary
- add a values-free C3 LIST responseShapeProbe for fixed K3 response containers
- surface only structural booleans/types/counts through read-smoke success and error evidence
- keep the current GetList request, filter, paging, and extractor behavior unchanged

## Boundary
- no raw payload, arbitrary response keys, row values, material numbers, host, credentials, or messages are surfaced
- no BOM/resolver/Save/Submit/Audit/write path changes
- no request-supplied raw Filter, endpoint, body, paging, or extractor widening in this slice

## Why
The latest #1709 rerun has route/auth/200 and K3 ROWCOUNT evidence, but recordCount remains 0 and all previous fixed array booleans are false. This probe localizes the live response page shape in one values-free package cycle before changing the extractor.

## Validation
- node plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
- node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
- node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- pnpm --filter plugin-integration-core test