### PR TITLE
fix(integration): C3 LIST read PascalCase Data.Data row container (#1709)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5553,6 +5553,7 @@ async function testReadSmokeRoute() {
                     dataDataType: 'missing',
                     dataDataArrayLength: null,
                     fixedContainers: {
+                      dataPascalData: { type: 'array', arrayLength: 2, materialNumber: 'M-LIST-002' },
                       resultRows: { type: 'array', arrayLength: 2, materialNumber: 'M-LIST-001' },
                       topLevel: { type: 'object', arrayLength: null },
                       arbitraryContainer: { type: 'array', arrayLength: 1 },
@@ -5657,6 +5658,7 @@ async function testReadSmokeRoute() {
     dataDataType: 'missing',
     dataDataArrayLength: null,
     fixedContainers: {
+      dataPascalData: { type: 'array', arrayLength: 2 },
       resultRows: { type: 'array', arrayLength: 2 },
       topLevel: { type: 'object', arrayLength: null },
     },
@@ -5687,7 +5689,7 @@ async function testReadSmokeRoute() {
     maxListLimit: 10,
   }, 'LIST applies the non-persisted Material/GetList overlay before adapter creation')
   const okListStr = JSON.stringify(okList.body.data)
-  for (const leak of ['M-LIST-001', 'SECRET-LIST-NAME', 'k3host', 'readPath', 'materialNumber']) {
+  for (const leak of ['M-LIST-001', 'M-LIST-002', 'SECRET-LIST-NAME', 'k3host', 'readPath', 'materialNumber']) {
     assert.ok(!okListStr.includes(leak), `LIST read-smoke response must not leak ${leak}`)
   }
 

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -974,6 +974,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.deepEqual(read.metadata.listShapeProbe, {
     dataData: true,
     dataLowerData: false,
+    dataPascalData: false,
     dataRows: false,
     resultData: false,
     resultRows: false,
@@ -990,6 +991,7 @@ async function testK3WebApiMaterialListReadSmoke() {
     fixedContainers: {
       dataData: { type: 'array', arrayLength: 3 },
       dataLowerData: { type: 'missing', arrayLength: null },
+      dataPascalData: { type: 'missing', arrayLength: null },
       dataRows: { type: 'missing', arrayLength: null },
       dataList: { type: 'missing', arrayLength: null },
       dataItems: { type: 'missing', arrayLength: null },
@@ -1099,6 +1101,7 @@ async function testK3WebApiMaterialListReadSmoke() {
     fixedContainers: {
       dataData: { type: 'null', arrayLength: null },
       dataLowerData: { type: 'missing', arrayLength: null },
+      dataPascalData: { type: 'missing', arrayLength: null },
       dataRows: { type: 'missing', arrayLength: null },
       dataList: { type: 'missing', arrayLength: null },
       dataItems: { type: 'missing', arrayLength: null },
@@ -1108,6 +1111,61 @@ async function testK3WebApiMaterialListReadSmoke() {
       topLevel: { type: 'object', arrayLength: null },
     },
   }, 'paging-echo response-shape probe makes DATA=null explicit without changing extraction')
+
+  // C3 LIST PascalCase row container (#1709): the live K3 instance returns rows at Data.Data (PascalCase) with
+  // PascalCase RowCount/PageSize/PageIndex. Confirm extraction + that dataDataPresent reflects Data.Data (no
+  // recordPresent=true with dataDataPresent=false), without removing the Data.DATA / Data.data compat paths.
+  const pascalFetchImpl = async (url, options) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === '/K3API/Material/GetList') {
+      return jsonResponse(200, {
+        StatusCode: 200,
+        Message: 'Material list succeeded',
+        Data: {
+          RowCount: 30134,
+          PageSize: 10,
+          PageIndex: 1,
+          Top: 10,
+          Data: [
+            { FNumber: 'MAT-PASCAL-001', FName: 'P1' },
+            { FNumber: 'MAT-PASCAL-002', FName: 'P2' },
+          ],
+        },
+      })
+    }
+    return fetchImpl(url, options)
+  }
+  const pascalAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        objects: {
+          material: {
+            operations: ['read'],
+            readPath: '/K3API/Material/GetList',
+            readMethod: 'POST',
+            readMode: 'list',
+            readListBodyTemplate: { Data: { Top: 10, PageIndex: 1 } },
+            pageIndexField: 'PageIndex',
+            pageSizeField: 'PageSize',
+            maxListLimit: 3,
+          },
+        },
+      },
+    }),
+    fetchImpl: pascalFetchImpl,
+  })
+  const pascal = await pascalAdapter.read(buildMarkedListRequest({ object: 'material', mode: 'list' }, 2))
+  assert.equal(pascal.records.length, 2, 'rows extracted from the PascalCase Data.Data container (bounded to limit)')
+  assert.equal(pascal.records[0].FNumber, 'MAT-PASCAL-001', 'PascalCase Data.Data rows are returned')
+  assert.equal(pascal.metadata.dataDataPresent, true, 'dataDataPresent reflects Data.Data (no recordPresent-true / dataDataPresent-false split)')
+  assert.equal(pascal.metadata.dataRowCount, 30134, 'PascalCase Data.RowCount surfaced')
+  assert.equal(pascal.metadata.dataPageSize, 10, 'PascalCase Data.PageSize surfaced')
+  assert.equal(pascal.metadata.dataPageIndex, 1, 'PascalCase Data.PageIndex surfaced')
+  assert.equal(pascal.metadata.listShapeProbe.dataPascalData, true, 'shape probe flags the PascalCase container')
+  assert.equal(pascal.metadata.listShapeProbe.dataData, false, 'all-caps Data.DATA absent in the PascalCase response')
+  assert.equal(pascal.metadata.responseShapeProbe.fixedContainers.dataPascalData.type, 'array', 'response-shape probe localizes Data.Data as an array')
+  assert.equal(pascal.metadata.responseShapeProbe.fixedContainers.dataPascalData.arrayLength, 2)
 
   const missingRowsFetchImpl = async (url, options) => {
     const parsed = new URL(url)
@@ -1147,6 +1205,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.deepEqual(missingRows.metadata.listShapeProbe, {
     dataData: false,
     dataLowerData: false,
+    dataPascalData: false,
     dataRows: false,
     resultData: false,
     resultRows: false,
@@ -1195,6 +1254,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.deepEqual(alternateRows.metadata.listShapeProbe, {
     dataData: false,
     dataLowerData: false,
+    dataPascalData: false,
     dataRows: false,
     resultData: false,
     resultRows: true,
@@ -1244,6 +1304,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.deepEqual(rejected.details.listShapeProbe, {
     dataData: true,
     dataLowerData: false,
+    dataPascalData: false,
     dataRows: false,
     resultData: false,
     resultRows: false,
@@ -1291,6 +1352,7 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.deepEqual(unrecognized.details.listShapeProbe, {
     dataData: true,
     dataLowerData: false,
+    dataPascalData: false,
     dataRows: false,
     resultData: false,
     resultRows: false,

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -211,6 +211,7 @@ const responseShapeEvidence = readSmokeSuccessEvidence(LIST_PRESET, {
       arbitraryKeyName: 'SECRET-KEY',
       fixedContainers: {
         dataData: { type: 'null', arrayLength: null, materialNumber: 'SECRET-MAT-002' },
+        dataPascalData: { type: 'array', arrayLength: 2, materialNumber: 'SECRET-MAT-004' },
         dataList: { type: 'array', arrayLength: 2, rows: [{ materialNumber: 'SECRET-MAT-003' }] },
         resultRows: { type: 'invalid-type', arrayLength: 1 },
         arbitraryContainer: { type: 'array', arrayLength: 99 },
@@ -235,12 +236,13 @@ assert.deepEqual(responseShapeEvidence, {
     dataDataArrayLength: null,
     fixedContainers: {
       dataData: { type: 'null', arrayLength: null },
+      dataPascalData: { type: 'array', arrayLength: 2 },
       dataList: { type: 'array', arrayLength: 2 },
     },
   },
 })
 const responseShapeEvidenceStr = JSON.stringify(responseShapeEvidence)
-for (const leak of ['SECRET-MAT-002', 'SECRET-MAT-003', 'SECRET-KEY', 'materialNumber', 'arbitraryKeyName', 'arbitraryContainer']) {
+for (const leak of ['SECRET-MAT-002', 'SECRET-MAT-003', 'SECRET-MAT-004', 'SECRET-KEY', 'materialNumber', 'arbitraryKeyName', 'arbitraryContainer']) {
   assert.ok(!responseShapeEvidenceStr.includes(leak), `response-shape evidence must not leak ${leak}`)
 }
 

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -802,6 +802,9 @@ function materialListRowsCandidate(data) {
   const candidates = [
     getPath(data, 'Data.DATA'),
     getPath(data, 'Data.data'),
+    // PascalCase row container observed on the live K3 instance (#1709): rows are at Data.Data, while the
+    // doc sample used Data.DATA. Compat order keeps the prior all-caps/lowercase paths first.
+    getPath(data, 'Data.Data'),
   ]
   for (const candidate of candidates) {
     if (Array.isArray(candidate)) return candidate.filter(isPlainObject).map((row) => cloneJson(row))
@@ -813,6 +816,7 @@ function materialListShapeProbe(data) {
   return {
     dataData: Array.isArray(getPath(data, 'Data.DATA')),
     dataLowerData: Array.isArray(getPath(data, 'Data.data')),
+    dataPascalData: Array.isArray(getPath(data, 'Data.Data')),
     dataRows: Array.isArray(getPath(data, 'Data.Rows')),
     resultData: Array.isArray(getPath(data, 'Result.Data')),
     resultRows: Array.isArray(getPath(data, 'Result.Rows')),
@@ -824,6 +828,7 @@ function materialListShapeProbe(data) {
 const MATERIAL_LIST_RESPONSE_SHAPE_CONTAINER_PATHS = Object.freeze([
   ['dataData', 'Data.DATA'],
   ['dataLowerData', 'Data.data'],
+  ['dataPascalData', 'Data.Data'],
   ['dataRows', 'Data.Rows'],
   ['dataList', 'Data.List'],
   ['dataItems', 'Data.Items'],
@@ -1425,7 +1430,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       }
 
       const listShapeProbe = materialListShapeProbe(readResponse.data)
-      const dataDataPresent = listShapeProbe.dataData || listShapeProbe.dataLowerData
+      const dataDataPresent = listShapeProbe.dataData || listShapeProbe.dataLowerData || listShapeProbe.dataPascalData
       const dataRowCount = materialListRowCount(readResponse.data)
       // Paging echo: what K3 reports it applied, vs what we requested (Top=PageSize=request.limit, PageIndex=1).
       const dataPageSize = materialListPageSize(readResponse.data)

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -79,6 +79,7 @@ function isPlainObject(value) {
 const READ_SMOKE_LIST_SHAPE_PROBE_KEYS = Object.freeze([
   'dataData',
   'dataLowerData',
+  'dataPascalData',
   'dataRows',
   'resultData',
   'resultRows',
@@ -101,6 +102,7 @@ function readSmokeListShapeProbeEvidence(value) {
 const READ_SMOKE_RESPONSE_SHAPE_CONTAINER_KEYS = Object.freeze([
   'dataData',
   'dataLowerData',
+  'dataPascalData',
   'dataRows',
   'dataList',
   'dataItems',


### PR DESCRIPTION
## What

The live K3 instance returns the `Material/GetList` row array at **`Data.Data` (PascalCase)**, while the adapter/probes only checked `Data.DATA` (all-caps) and `Data.data` — a one-case path gap. The count/page helpers already handled PascalCase `RowCount`/`PageSize`/`PageIndex` (which is exactly why those extracted fine but the row container didn't). Confirmed values-free from the live response structure (#1709): `actualRowContainer=Data.Data`, array length 10.

## Changes (response-side only)

- `materialListRowsCandidate`: add `Data.Data` (compat order keeps `Data.DATA` / `Data.data` first).
- `materialListShapeProbe` + the `responseShapeProbe` container-path allowlist + **both** read-smoke sanitizer allowlists (`READ_SMOKE_LIST_SHAPE_PROBE_KEYS` for `listShapeProbe`, `READ_SMOKE_RESPONSE_SHAPE_CONTAINER_KEYS` for `responseShapeProbe.fixedContainers`): add **`dataPascalData`** — so it is dropped at neither the evidence nor the wire layer.
- `dataDataPresent` folds in `Data.Data` — so we never get the inconsistent `recordPresent=true` + `dataDataPresent=false` evidence.

## Tests

- **Adapter keystone:** `Data.Data` array + PascalCase `RowCount/PageSize/PageIndex` → rows extracted, `dataDataPresent=true`, `dataRowCount=30134`, both probes localize `Data.Data`.
- **read-smoke sanitizer:** a `fixedContainers.dataPascalData` leak-bait `materialNumber` is surfaced as clean `{type,arrayLength}` only (proves the new allowlist key still scrubs values).
- **http-routes wire test:** the route preserves `responseShapeProbe.fixedContainers.dataPascalData` end-to-end and drops the leak-bait — this is the test that would have failed on the original P1 gap.

## Boundary

- **No** request body / filter / endpoint / paging change; `Data.DATA` / `Data.data` compat preserved (purely additive).
- No BOM/resolver/Save/Submit/Audit/production write. Values-free (counts/flags/types only).
- Full `plugin-integration-core` CJS suite **55/55**.

## Next

Package + **no-key rerun** → expected `recordPresent=true` / `recordCount=10` / `dataRowCount=30134` = **first real C3 LIST no-key PASS**. That flips the close-out (#3388) from "WebAPI-LIST deferred" to "done (no-key page)" via a small docs follow-up. The keyed `FNumber` filter remains a separate optional refinement (doesn't block the no-key PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
