### PR TITLE
feat(plm): support multi-kid embed public keys

### DIFF
--- a/docs/operations/plm-bom-multitable-production-readiness-runbook-20260609.md
+++ b/docs/operations/plm-bom-multitable-production-readiness-runbook-20260609.md
@@ -39,8 +39,8 @@ Set these in the MetaSheet2 deployment that hosts the embedded BOM review UI.
 | `PLM_EMBED_ALLOWED_ORIGINS` | Yes | Single source for allowed PLM parent origins, backend `embed_origin` check, frontend parent-origin allowlist, and edge CSP value. | Explicit origins only. Never use `*`. |
 | `PLM_EMBED_DATA_SOURCE_ID` | Yes | Server-bound PLM data source used by `/api/plm-embed/bom-review/context`. | Must identify the Yuantus PLM source for this deployment. Never accept source id from the iframe. |
 | `PLM_EMBED_AUDIENCE` | Yes | Expected JWT `aud`. | Must match Yuantus token minting. Default is `metasheet2.embed`. |
-| `YUANTUS_EMBED_PUBLIC_KEY` | Yes | Base64 raw Ed25519 public key for offline verification. | Public key only. Never configure a Yuantus private key in MetaSheet2. |
-| `YUANTUS_EMBED_KEY_ID` | Yes | Expected key id for the configured public key. | Must match Yuantus minting key id. Default is `embed-1`. |
+| `YUANTUS_EMBED_PUBLIC_KEYS` | Yes, preferred | JSON object of `kid -> base64 raw Ed25519 public key` for offline verification. | Public keys only. Keep both old and new `kid` entries during rotation windows; never configure a Yuantus private key in MetaSheet2. |
+| `YUANTUS_EMBED_PUBLIC_KEY` / `YUANTUS_EMBED_KEY_ID` | Compatibility fallback | Legacy single-key form used only when `YUANTUS_EMBED_PUBLIC_KEYS` is unset. | Public key only; `YUANTUS_EMBED_KEY_ID` must match Yuantus minting key id. Default is `embed-1`. |
 | `REDIS_URL` | Yes | Shared single-use `jti` consume store. | Required. No in-memory fallback is allowed. |
 
 Current tenant configuration caveat:
@@ -187,12 +187,12 @@ Run these before customer UAT.
 | Iframe shows `not-configured` | Allowlist is empty after fail-closed filtering. | Fix `PLM_EMBED_ALLOWED_ORIGINS`. |
 | Iframe shows transient error after token was accepted | The single-use token was already consumed before a provider degradation. | Reopen or reload from PLM so the parent mints and posts a new token. Do not retry the old token. |
 | API returns 401 `EMBED_TOKEN_REQUIRED` | Embed token header missing. | Ensure the parent posts a token and the iframe sends it on embed API calls. |
-| API returns 401 `INVALID_EMBED_TOKEN` | Malformed, expired, wrong audience, wrong type, missing `jti`, or bad signature. | Re-mint token. Check public key, key id, audience, clocks, and JWT claims. |
+| API returns 401 `INVALID_EMBED_TOKEN` | Malformed, expired, wrong audience, wrong type, missing `jti`, unknown `kid`, or bad signature. | Re-mint token. Check public-key map, key id, audience, clocks, and JWT claims. |
 | API returns 401 `EMBED_TOKEN_REPLAYED` | Same token reused. | Re-mint token from PLM. |
 | API returns 403 `EMBED_FEATURE_MISMATCH` | Token is for a different feature. | Mint with `feature_key = "bom_multitable"`. |
 | API returns 403 `EMBED_ORIGIN_NOT_ALLOWED` | Token `embed_origin` is not in `PLM_EMBED_ALLOWED_ORIGINS`. | Align Yuantus mint config and MetaSheet2 allowlist. |
 | API returns 403 `EMBED_TENANT_MISMATCH` | Token tenant differs from the tenant actually served by `PLM_EMBED_DATA_SOURCE_ID`. | Fix token tenant or data-source tenant. Do not bypass this check. |
-| API returns 503 `embed verification not configured` | `YUANTUS_EMBED_PUBLIC_KEY` missing or invalid. | Set the public key and matching `YUANTUS_EMBED_KEY_ID`, then redeploy. |
+| API returns 503 `embed verification not configured` | No usable `YUANTUS_EMBED_PUBLIC_KEYS` map, malformed JSON map, or no legacy `YUANTUS_EMBED_PUBLIC_KEY`. | Set a valid JSON public-key map, or the legacy public key plus matching `YUANTUS_EMBED_KEY_ID`, then redeploy. |
 | API returns 503 `embed replay store unavailable` | Redis unavailable or first Redis connection failed and was memoized null. | Restore Redis and restart MetaSheet2 if first connect failed. |
 | API returns 503 `embed data source not configured` | `PLM_EMBED_DATA_SOURCE_ID` missing. | Set data source id and redeploy. |
 | API returns 503 `embed data source unsupported` | `PLM_EMBED_DATA_SOURCE_ID` points at a source kind that cannot serve Yuantus PLM embed reads. | Point `PLM_EMBED_DATA_SOURCE_ID` at the Yuantus PLM source. |
@@ -222,7 +222,7 @@ Record the evidence before go-live:
 - [ ] `PLM_EMBED_DATA_SOURCE_ID` points to the intended Yuantus source.
 - [ ] Served tenant equals Yuantus token `tenant_id`.
 - [ ] `PLM_EMBED_AUDIENCE` matches Yuantus minting.
-- [ ] `YUANTUS_EMBED_PUBLIC_KEY` and `YUANTUS_EMBED_KEY_ID` match Yuantus signing config.
+- [ ] `YUANTUS_EMBED_PUBLIC_KEYS` contains the active Yuantus signing `kid` and, during rotation, the previous `kid`; or the legacy single-key env matches Yuantus signing config.
 - [ ] Redis `PING` succeeds from the runtime environment.
 - [ ] Valid first-use token renders a BOM review.
 - [ ] Reusing the same token returns 401 `EMBED_TOKEN_REPLAYED`.

--- a/packages/core-backend/src/auth/embed-config.ts
+++ b/packages/core-backend/src/auth/embed-config.ts
@@ -18,8 +18,31 @@ export function frameAncestorsValue(): string {
   return origins.length ? `frame-ancestors ${origins.join(' ')}` : "frame-ancestors 'none'"
 }
 
-/** kid -> base64 raw Ed25519 PUBLIC key (Yuantus distributes the public key by deploy config). */
+function parsePublicKeysMap(raw: string): Record<string, string> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(parsed)
+      .map(([kid, pub]) => [kid.trim(), typeof pub === 'string' ? pub.trim() : ''] as const)
+      .filter(([kid, pub]) => kid && pub),
+  )
+}
+
+/** kid -> base64 raw Ed25519 PUBLIC key (Yuantus distributes public keys by deploy config). */
 export function embedPublicKeysByKid(): Record<string, string> {
+  const map = (process.env.YUANTUS_EMBED_PUBLIC_KEYS || '').trim()
+  if (map) {
+    return parsePublicKeysMap(map)
+  }
+
   const pub = (process.env.YUANTUS_EMBED_PUBLIC_KEY || '').trim()
   const kid = (process.env.YUANTUS_EMBED_KEY_ID || 'embed-1').trim()
   return pub ? { [kid]: pub } : {}

--- a/packages/core-backend/tests/unit/embed-config.test.ts
+++ b/packages/core-backend/tests/unit/embed-config.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { embedPublicKeysByKid } from '../../src/auth/embed-config'
+
+const ENV_KEYS = ['YUANTUS_EMBED_PUBLIC_KEYS', 'YUANTUS_EMBED_PUBLIC_KEY', 'YUANTUS_EMBED_KEY_ID']
+
+describe('embedPublicKeysByKid', () => {
+  afterEach(() => {
+    for (const key of ENV_KEYS) delete process.env[key]
+  })
+
+  it('keeps the legacy single-key env shape working', () => {
+    process.env.YUANTUS_EMBED_PUBLIC_KEY = 'pub-1'
+    process.env.YUANTUS_EMBED_KEY_ID = 'kid-1'
+
+    expect(embedPublicKeysByKid()).toEqual({ 'kid-1': 'pub-1' })
+  })
+
+  it('defaults the legacy key id when only the public key is configured', () => {
+    process.env.YUANTUS_EMBED_PUBLIC_KEY = 'pub-1'
+
+    expect(embedPublicKeysByKid()).toEqual({ 'embed-1': 'pub-1' })
+  })
+
+  it('accepts a JSON kid-to-public-key map for rotation windows', () => {
+    process.env.YUANTUS_EMBED_PUBLIC_KEYS = JSON.stringify({
+      'embed-old': 'old-pub',
+      'embed-new': 'new-pub',
+    })
+
+    expect(embedPublicKeysByKid()).toEqual({
+      'embed-old': 'old-pub',
+      'embed-new': 'new-pub',
+    })
+  })
+
+  it('trims and drops empty or non-string JSON map entries', () => {
+    process.env.YUANTUS_EMBED_PUBLIC_KEYS = JSON.stringify({
+      ' embed-old ': ' old-pub ',
+      'embed-empty': '  ',
+      'embed-number': 123,
+      '  ': 'blank-kid',
+    })
+
+    expect(embedPublicKeysByKid()).toEqual({ 'embed-old': 'old-pub' })
+  })
+
+  it('prefers the JSON map over the legacy single-key env when both are set', () => {
+    process.env.YUANTUS_EMBED_PUBLIC_KEYS = JSON.stringify({ 'embed-new': 'new-pub' })
+    process.env.YUANTUS_EMBED_PUBLIC_KEY = 'legacy-pub'
+    process.env.YUANTUS_EMBED_KEY_ID = 'legacy-kid'
+
+    expect(embedPublicKeysByKid()).toEqual({ 'embed-new': 'new-pub' })
+  })
+
+  it('fails closed on malformed JSON instead of falling back to an old key', () => {
+    process.env.YUANTUS_EMBED_PUBLIC_KEYS = '{not-json'
+    process.env.YUANTUS_EMBED_PUBLIC_KEY = 'legacy-pub'
+    process.env.YUANTUS_EMBED_KEY_ID = 'legacy-kid'
+
+    expect(embedPublicKeysByKid()).toEqual({})
+  })
+})

--- a/packages/core-backend/tests/unit/plm-embed-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-routes.test.ts
@@ -96,7 +96,7 @@ describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
     process.env.PLM_EMBED_DATA_SOURCE_ID = DS_ID
   })
   afterEach(() => {
-    for (const k of ['YUANTUS_EMBED_PUBLIC_KEY', 'YUANTUS_EMBED_KEY_ID', 'PLM_EMBED_AUDIENCE', 'PLM_EMBED_ALLOWED_ORIGINS', 'PLM_EMBED_DATA_SOURCE_ID']) delete process.env[k]
+    for (const k of ['YUANTUS_EMBED_PUBLIC_KEYS', 'YUANTUS_EMBED_PUBLIC_KEY', 'YUANTUS_EMBED_KEY_ID', 'PLM_EMBED_AUDIENCE', 'PLM_EMBED_ALLOWED_ORIGINS', 'PLM_EMBED_DATA_SOURCE_ID']) delete process.env[k]
   })
 
   it('the embed path is whitelisted from the global session gate (else it would 401 before embedTokenAuth)', () => {
@@ -117,6 +117,22 @@ describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
     expect(getBomMultitableContext).toHaveBeenCalledWith('P1')
   })
 
+  it('REAL CHAIN: accepts a rotated kid from YUANTUS_EMBED_PUBLIC_KEYS', async () => {
+    process.env.YUANTUS_EMBED_PUBLIC_KEYS = JSON.stringify({
+      'embed-old': 'unused-old-public-key',
+      'embed-new': PUB_B64,
+    })
+    delete process.env.YUANTUS_EMBED_PUBLIC_KEY
+    delete process.env.YUANTUS_EMBED_KEY_ID
+    const getBomMultitableContext = vi.fn().mockResolvedValue({ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: CONTEXT })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext }))
+
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({}, 'embed-new'))
+
+    expect(res.status).toBe(200)
+    expect(getBomMultitableContext).toHaveBeenCalledWith('P1')
+  })
+
   it('a non-whitelisted /api/* path with no session is 401 (proves the stand-in gate is real)', async () => {
     const res = await request(buildApp()).get('/api/other/thing')
     expect(res.status).toBe(401)
@@ -134,6 +150,12 @@ describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
 
   it('no Yuantus public key configured -> 503 fail-closed (not 401)', async () => {
     delete process.env.YUANTUS_EMBED_PUBLIC_KEY
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(503)
+  })
+
+  it('malformed YUANTUS_EMBED_PUBLIC_KEYS -> 503 fail-closed (not a server error)', async () => {
+    process.env.YUANTUS_EMBED_PUBLIC_KEYS = '{not-json'
     const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
     expect(res.status).toBe(503)
   })


### PR DESCRIPTION
## Summary
- add YUANTUS_EMBED_PUBLIC_KEYS as a JSON kid-to-public-key map for PLM embed-token verification
- keep the existing YUANTUS_EMBED_PUBLIC_KEY / YUANTUS_EMBED_KEY_ID fallback for compatibility
- fail closed on malformed maps and update the production readiness runbook for rotation windows

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/embed-config.test.ts tests/unit/embed-token-verify.test.ts tests/unit/plm-embed-routes.test.ts
- pnpm --filter @metasheet/core-backend run type-check
- git diff --check