### PR TITLE
fix(multitable): row-lock the permission-revert live-grant load (never-escalate-under-concurrency)

### DIFF
--- a/docs/development/multitable-permission-revert-concurrency-rowlock-dev-verification-20260629.md
+++ b/docs/development/multitable-permission-revert-concurrency-rowlock-dev-verification-20260629.md
@@ -1,0 +1,109 @@
+# Permission-revert concurrency hardening — row-lock the live-grant load (dev + verification)
+
+**Date:** 2026-06-29  **Grounding:** `origin/main @ 57fd06962`  **PR:** #3400
+**Branch:** `claude/permrevert-concurrency-rowlock-20260629`
+**Status of the flag:** `MULTITABLE_ENABLE_PERMISSION_REVERT` stays **default-off**. This change enables nothing; it is the engineering prerequisite that makes a future, separately-signed-off enablement safe.
+
+> Positioning: this is a focused engineering hardening of one already-shipped, flag-gated path. It does **not** advance the gated Global History remainder (PIT/T9-W flag enablement, Reset-UI product entry, value-level undelete) — those remain owner-gated per-item decisions, re-listed in §7 for sign-off.
+
+---
+
+## 1. Context — what permission-revert is, and the gap
+
+The Global History line includes a **config-history → config-restore** capability. One restorable kind is a `permission` revision: reverting it re-applies the revision's `before` grant, but **only when restoring `before` reduces** the subject's access on the entity's single total-order access rank (field `hidden < read-only < read-write`; view `none < read < write < admin`; sheet `none < read < write-own < write < admin`). Escalation / no-op is refused fail-closed (422). The path sits behind the default-off flag `MULTITABLE_ENABLE_PERMISSION_REVERT`, on top of the `canManageSheetAccess` capability floor and a typed `revert-permission` confirm.
+
+The load-bearing safety property is **never-escalate**: the execute path re-checks `permissionRevertDirection(before, LIVE)` against the **current live grant** (not the recorded `after`), inside its transaction. A server-minted preview token binds the live grant via an HMAC `currentGrantHash`, so a grant changed between preview and execute → 409 `GRANT_DRIFT`.
+
+**The gap (concurrency):** the execute path serialized via `SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE` as a coarse mutex, then read the live grant with a **plain `SELECT`**. The forward grant/revoke routes do **not** take that `meta_sheets` lock — they write the permission row directly. So a forward write that **lowered** the grant could commit *between* the revert's direction check and its apply, turning a checked de-escalation into a **net escalation**:
+
+```
+preview:  live = admin            (revert target `before` = read; admin→read is a de-escalation)
+forward:  admin → none           (a concurrent authorized revoke commits)
+revert:   applies "admin→read"   → but live is now none, so the net is none→read = ESCALATION
+```
+
+The original code documented this honestly: the `meta_sheets FOR UPDATE` carried a comment that "the forward grant/revoke routes must take the same lock for full coverage — tracked in the dev-verification honest gaps." This PR closes it — but via a **better mechanism** than making the forward routes take that lock.
+
+---
+
+## 2. Decision — row-lock the execute-path live-grant load (not a value-CAS, not a forward-route change)
+
+A primary-source fact determined the mechanism: `loadLivePermissionGrant` returns **`null` for a no-row entity**, and `permissionAccessRank(null) = 0`. Therefore **a de-escalation always reads a non-null live grant** (de-escalation requires live rank ≥ 1, and rank ≥ 1 ⇒ non-null ⇒ a row exists) — for all three scopes. The "field rank-2 read-write = no-row default" subtlety that would have forced `INSERT … ON CONFLICT … WHERE` CAS gymnastics **does not arise**.
+
+Given that, **pessimistic row-locking is strictly simpler and equally correct**: the execute-path live-grant load takes `FOR UPDATE` on the actual permission row(s). Because the locked row always exists, and a concurrent forward write on the same subject **writes that same row** (and so contends on the lock), the revert's drift re-check → direction re-check → apply become **atomic** against forward writes — with **no forward-route change** and **no new error branch** (it reuses the existing `GRANT_DRIFT` verdict).
+
+| Option considered | Verdict |
+|---|---|
+| (a) Forward routes take `meta_sheets FOR UPDATE` (the original comment's plan) | Correct but touches **live** security routes; needs deadlock analysis; broader blast radius. Rejected. |
+| (b) Per-scope value-CAS in the revert (`… ON CONFLICT … WHERE`, rowCount==0 → drift) | Confined, but intricate (NULL normalization; delete-then-insert atomicity across 3 scopes). Rejected once (2) below held. |
+| **(c) `FOR UPDATE` on the execute-path live-grant load** | **Chosen.** Confined to the gated path; reuses the existing drift check verbatim; no forward-route change; no per-scope CAS fiddliness. |
+
+### Change (the whole runtime diff)
+
+`loadLivePermissionGrant` gains `forUpdate = false`; when true it appends ` FOR UPDATE` to the field, view, **and** sheet SELECTs. The execute path (the single `pool.transaction` caller) passes `forUpdate = true`; the **preview** path (a read-only GET on the pool, no txn) keeps the default `false`. The pre-existing `meta_sheets FOR UPDATE` is **kept** (see §5). Lock order is always `meta_sheets → permission-row`.
+
+---
+
+## 3. Correctness argument
+
+- **Atomicity of the never-escalate check.** With `FOR UPDATE` held from the live-grant load through commit, no forward write can move the locked row in between. So `hashPermissionGrant(live)` (drift check) and `permissionRevertDirection(before, live)` (direction check) both see the same row state the apply writes against.
+- **The two orderings.** (A) Revert acquires the row lock first → a concurrent lowering forward write **blocks** until the revert commits; the revert de-escalates against the value it checked; the forward then applies (authorized last-write-wins). No revert-blessed escalation. (B) Forward write holds the row first → the revert's `FOR UPDATE` **blocks**, then (READ COMMITTED) re-reads the **committed** lowered value; the drift check `hash(new) ≠ hash(preview)` → **409**, no apply. No escalation.
+- **ABA is benign.** If a forward write moves the grant and then back to exactly the preview value before the execute-load, the drift check passes and the row is locked at that value; the apply de-escalates from the *current* value atomically — still correct.
+- **Isolation dependency, verified.** The re-read semantics require **READ COMMITTED**. The connection pool issues a plain `BEGIN` with no `ISOLATION LEVEL`, and there is **no `default_transaction_isolation` override** anywhere in the package → READ COMMITTED (Postgres default) confirmed. (Under REPEATABLE READ/SERIALIZABLE a concurrent-modify would surface as a 40001 to map; that case does not apply here.)
+
+---
+
+## 4. Verification
+
+### 4.1 Real-DB goldens (15/15 pass)
+
+File `tests/integration/multitable-permission-revert-realdb.test.ts` — **already in the `plugin-tests.yml` real-DB allowlist** (so the new cases ride along in CI). Existing (a)–(l) plus **two new concurrency goldens**:
+
+- **(m) CONCURRENCY sheet** — a forward **REVOKE** (`admin→none`) committed **while** the revert executes ⇒ revert re-reads `none` and **409 `GRANT_DRIFT`**; grant stays revoked (never raised to read).
+- **(n) CONCURRENCY field** — a forward **HIDE** (`read-write→hidden`) committed **while** the revert executes ⇒ revert re-reads rank-0 and **409 `GRANT_DRIFT`**; field stays hidden (never restored to read-only).
+
+Both stage the interleave **deterministically**, not via timing: a separate uncommitted txn holds the forward write's **row lock**; the revert execute is fired and (post-fix) blocks on that lock at its `FOR UPDATE` load; the holder then commits the lowered grant, the execute unblocks, re-reads, and 409s. The serial drift case (h) does **not** exercise the lock — it never overlaps two transactions. Pre-fix (plain SELECT) the load would read the stale pre-commit grant, pass drift, and raise the subject above the committed-forward grant; the assertions (`409` + grant unchanged at the lowered value) fail pre-fix and pass post-fix.
+
+Local run against a fresh real Postgres (`metasheet_pr_test`, migrated to latest): **`Tests 15 passed (15)`**.
+
+### 4.2 Type-check
+
+`tsc --noEmit` on `@metasheet/core-backend`: clean.
+
+### 4.3 Forward-path serialization audit (independent)
+
+An independent sweep of every write path to `field_permissions`, `meta_view_permissions`, `spreadsheet_permissions`:
+
+1. **Every forward path that lowers/removes a grant** (the sheet/view/field `PUT …/permissions/…` routes, and the legacy `spreadsheet-permissions` revoke route) does so via `DELETE`/upsert on the **exact lock key** → all **contend** on the revert's `FOR UPDATE`. There is **no** `UPDATE`-by-non-key, no `TRUNCATE`, and no dynamic `DELETE FROM ${table}` resolving to a permission table.
+2. **One non-contending path:** the legacy `POST /api/spreadsheets/:id/permissions/grant` does `INSERT … ON CONFLICT DO NOTHING` of a single managed `perm_code` **without** deleting existing managed rows, so a brand-new managed row isn't covered by the row lock (sheet scope only — it inserts a *different* `perm_code`, a new row the revert's lock doesn't cover). **Benign for never-escalate** — and the precise claim matters: the **revert's own writes never raise the subject above the live grant it direction-checked** (it only `DELETE`s managed rows and inserts the lower target). It does **not** follow that the subject's final derived level always equals the target: if a concurrent §2 grant of a higher `perm_code` commits *after* the revert's apply-`DELETE`, that new row survives and the final derived level can be higher. But that higher level is set by an **independent authorized grant**, not by the revert — forward-vs-forward last-write-wins, which would occur with or without the revert and is explicitly out of scope. (Field/view grants are single-PK, so the row lock fully serializes — no new-row escape there; this is a sheet-scope-only nuance.) Optional future owner-gated hardening if grant/revert mutual exclusion is ever wanted.
+3. **Deadlock check:** the revert is the **only** explicit `meta_sheets FOR UPDATE` holder, always taken **before** the permission-row lock. The sheet-delete cascade locks `meta_sheets` then cascades into `spreadsheet_permissions` (same `meta_sheets → permission` direction). The forward permission routes never lock `meta_sheets` at all. **No `permission-row → meta_sheets` order exists → deadlock-free.**
+
+---
+
+## 5. Why the `meta_sheets FOR UPDATE` is kept
+
+It is not redundant. It (a) serializes **concurrent reverts** on the same sheet as a coarse mutex, and (b) is **load-bearing** for the sheet-delete FK cascade: `spreadsheet_permissions.sheet_id REFERENCES meta_sheets(id) ON DELETE CASCADE`, so a sheet delete bulk-removes permission rows by `sheet_id` (not the per-subject key) — the row lock alone would not serialize that, but the kept `meta_sheets FOR UPDATE` does (the delete needs the conflicting `meta_sheets` row lock). `field_permissions` / `meta_view_permissions` have no FKs, so only the exact-key forward routes touch them (covered by the row lock).
+
+---
+
+## 6. Not covered (honest gaps)
+
+- The legacy `/permissions/grant` insert-only path (§4.3.2) — benign for never-escalate as analyzed; mutual exclusion with revert is an optional future owner-gated item, not required for safe enablement.
+- Forward-vs-forward last-write-wins between two authorized permission writes — pre-existing, unchanged, out of scope.
+- This PR does not add a UI surface or change any flag default.
+
+---
+
+## 7. Owner-gated remainder — unchanged, per-item sign-off (re-listed for clarity)
+
+This PR settles the **one** autonomously-buildable engineering prerequisite. Everything below remains an explicit, separate owner decision (not a `/goal` sweep):
+
+| Item | State after this PR | What enabling/building requires |
+|---|---|---|
+| **`MULTITABLE_ENABLE_PERMISSION_REVERT`** enablement | Engineering prerequisite (concurrency) **satisfied** by this PR + two-writer goldens (m)/(n) | Owner **GO** to enable in an environment (a prod-enablement decision; the runbook concurrency item is now backed by a passing golden, not a hand-waved gap). |
+| `MULTITABLE_ENABLE_SHEET_CONFIG_REVERT` / `…_FIELD_RETYPE_REVERT` / `…_CONFIG_UNCREATE` / `…_CONFIG_UNDELETE` | Built, default-off | Owner per-tier enablement decision (operational, reversible). |
+| `MULTITABLE_ENABLE_PIT_RESET` / `…_PIT_UNDELETE` | Built, default-off | Owner ops decision to enable. |
+| Reset-to-T **product entry** (UI surface) | Minimal datetime-local product entry **shipped** (#3301); `ResetToPointPicker` wired into `MultitableWorkbench.vue` | Remaining owner decision is whether to **upgrade** to a history-anchored T-source picker + rollout (not a product-entry block). |
+| Value-level field **undelete** of already-destroyed data | **Not possible** for data already destroyed | Only a forward-capture (going-forward) design is buildable, and that is a separate gated opt-in. |
+
+Canonical source for the remainder remains current `main` + the existing Global History docs and the 2026-06-29 readiness refresh (`multitable-global-history-gated-remainder-readiness-refresh-20260629.md`).

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6106,21 +6106,27 @@ async function recreateViewFromConfig(query: TxnQuery, opts: {
 type PermGrant = Record<string, unknown> | null
 
 /** Read the subject's CURRENT live grant for a permission entity (field/view/sheet); null = no grant. */
-async function loadLivePermissionGrant(query: TxnQuery, scope: PermissionScope, parts: string[], sheetId: string): Promise<PermGrant> {
+// `forUpdate` (execute path ONLY) appends `FOR UPDATE` so the live-grant read row-locks the permission row(s) for the
+// rest of the surrounding txn. Because a de-escalation always reads a non-null live grant (no-row ⇒ null ⇒ rank 0, and
+// de-escalation requires live rank ≥ 1), the locked row always exists; the drift re-check + apply then cannot interleave
+// with a concurrent forward grant write on the same subject (never-escalate-under-concurrency, READ COMMITTED re-read).
+// Preview path passes false — it is a read-only GET on the pool (no txn), where a row lock would be wrong.
+async function loadLivePermissionGrant(query: TxnQuery, scope: PermissionScope, parts: string[], sheetId: string, forUpdate = false): Promise<PermGrant> {
+  const lock = forUpdate ? ' FOR UPDATE' : ''
   if (scope === 'field') {
     const [fieldId, subjectType, subjectId] = parts
-    const r = (await query('SELECT visible, read_only FROM field_permissions WHERE sheet_id = $1 AND field_id = $2 AND subject_type = $3 AND subject_id = $4', [sheetId, fieldId, subjectType, subjectId])) as any
+    const r = (await query('SELECT visible, read_only FROM field_permissions WHERE sheet_id = $1 AND field_id = $2 AND subject_type = $3 AND subject_id = $4' + lock, [sheetId, fieldId, subjectType, subjectId])) as any
     const row = r.rows[0] as { visible?: boolean; read_only?: boolean } | undefined
     return row ? { fieldId, subjectType, subjectId, visible: row.visible !== false, readOnly: row.read_only === true } : null
   }
   if (scope === 'view') {
     const [viewId, subjectType, subjectId] = parts
-    const r = (await query('SELECT permission FROM meta_view_permissions WHERE view_id = $1 AND subject_type = $2 AND subject_id = $3', [viewId, subjectType, subjectId])) as any
+    const r = (await query('SELECT permission FROM meta_view_permissions WHERE view_id = $1 AND subject_type = $2 AND subject_id = $3' + lock, [viewId, subjectType, subjectId])) as any
     const row = r.rows[0] as { permission?: string } | undefined
     return row && typeof row.permission === 'string' ? { viewId, subjectType, subjectId, permission: row.permission } : null
   }
   const [subjectType, subjectId] = parts
-  const r = (await query('SELECT perm_code FROM spreadsheet_permissions WHERE sheet_id = $1 AND subject_type = $2 AND subject_id = $3 AND perm_code = ANY($4::text[])', [sheetId, subjectType, subjectId, MANAGED_SHEET_PERMISSION_CODES])) as any
+  const r = (await query('SELECT perm_code FROM spreadsheet_permissions WHERE sheet_id = $1 AND subject_type = $2 AND subject_id = $3 AND perm_code = ANY($4::text[])' + lock, [sheetId, subjectType, subjectId, MANAGED_SHEET_PERMISSION_CODES])) as any
   const accessLevel = deriveSheetAccessLevel((r.rows as Array<{ perm_code: string }>).map((x) => String(x.perm_code)))
   return accessLevel ? { subjectType, subjectId, accessLevel } : null
 }
@@ -8295,11 +8301,15 @@ export function univerMetaRouter(): Router {
           return res.status(400).json({ ok: false, error: { code: 'INVALID_REVISION', message: 'Permission revision before-snapshot does not match its entity id.' } })
         }
         const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {
-          // Never-escalate-under-concurrency: lock the sheet row so the live-grant read → direction re-check → apply
-          // cannot interleave with another grant write on this sheet. (Enablement gate: the forward grant/revoke routes
-          // must take the same lock for full coverage — tracked in the dev-verification honest gaps.)
+          // Never-escalate-under-concurrency: the live-grant load below takes `FOR UPDATE` (forUpdate=true), row-locking
+          // the actual permission row for this subject until commit — so the drift re-check → direction re-check → apply
+          // cannot interleave with a concurrent forward grant/revoke write on the SAME subject (which contends on that
+          // same row; no forward-route change needed). A de-escalation always reads an existing row (no-row ⇒ null ⇒
+          // rank 0, and de-escalation requires live rank ≥ 1), so the FOR UPDATE always locks a real row. The meta_sheets
+          // FOR UPDATE is kept as the coarse per-sheet mutex that also serializes concurrent reverts; lock order is
+          // always meta_sheets → permission-row, so concurrent reverts can't deadlock.
           await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE', [sheetId])
-          const live = await loadLivePermissionGrant(query, parsedPerm.scope, parsedPerm.parts, sheetId)
+          const live = await loadLivePermissionGrant(query, parsedPerm.scope, parsedPerm.parts, sheetId, /* forUpdate */ true)
           const verdict = verifyConfigPermissionRevertPreviewIdentity(previewToken, { sheetId, revisionId, entityId: rev.entity_id, currentGrantHash: hashPermissionGrant(live), actorId: access.userId })
           if (!verdict.valid) {
             if (verdict.reason === 'grant_drift') return { status: 409, code: 'GRANT_DRIFT', message: 'The grant changed since preview; re-preview before reverting.' }

--- a/packages/core-backend/tests/integration/multitable-permission-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-permission-revert-realdb.test.ts
@@ -13,11 +13,22 @@
  * BEFORE the direction re-check). Apply mirrors the forward grant write (target=null ⇒ revoke) and records a
  * source='restore' permission revision (live → target).
  *
- * Goldens (a)-(l): (a) flag-off 403 (preview+execute) · (b) canManageSheetAccess floor 403 · (c) happy SHEET
+ * Goldens (a)-(n): (a) flag-off 403 (preview+execute) · (b) canManageSheetAccess floor 403 · (c) happy SHEET
  * de-escalation (admin→read + restore revision) · (d) happy REVOKE (revert a `create`, before=null) · (e) escalation
  * refused 422 · (f) noop refused 422 · (g) LIVE re-check load-bearing 422 (uses live, not recorded after) · (h) grant
  * drift 409 · (i) FIELD de-escalation (read-write→read-only) · (j) VIEW de-escalation (admin→read) · (k) typed-confirm
- * 400/200 · (l) no-oracle preview shape. Runs only with DATABASE_URL.
+ * 400/200 · (l) no-oracle preview shape · (m)/(n) CONCURRENCY: a forward write that LOWERS the grant, committed WHILE
+ * the revert executes, must not let the revert escalate the subject above the committed-forward grant. Runs only with
+ * DATABASE_URL.
+ *
+ * NEVER-ESCALATE-UNDER-CONCURRENCY (cases m/n): the execute-path live-grant load takes `FOR UPDATE`, row-locking the
+ * subject's permission row for the rest of the txn. A concurrent forward grant write contends on that SAME row, so it
+ * cannot interleave between the revert's drift/direction re-check and its apply. Staged deterministically here by
+ * holding the forward write's row lock in a SEPARATE uncommitted txn while the revert executes: post-fix the execute
+ * BLOCKS on the lock, and once the forward write commits a LOWER grant, the load re-reads the new live value and the
+ * drift verdict fires (409) — instead of applying a now-escalating de-escalation. Pre-fix (plain SELECT, no FOR UPDATE)
+ * the load would read the stale pre-commit grant, pass drift, and raise the subject ABOVE the committed-forward grant
+ * (none→read / hidden→read-only). The serial drift case (h) does NOT exercise the lock — it never overlaps two txns.
  *
  * NOTE on case (g): the design's "lower the live grant after preview → 422" is UNREACHABLE in the runtime — lowering
  * live changes its derived grant ⇒ changes `hashPermissionGrant(live)` ⇒ the drift verdict (→409) fires BEFORE the
@@ -30,6 +41,7 @@
  * NOTE on the flag: MULTITABLE_ENABLE_PERMISSION_REVERT is read PER-REQUEST inside the handlers, so — exactly like the
  * sibling config-undelete golden — ONE app + a per-test env toggle + an afterEach delete is correct and sufficient.
  */
+import type { PoolClient } from 'pg'
 import express, { type Express } from 'express'
 import request from 'supertest'
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
@@ -345,5 +357,75 @@ describeIfDatabase('multitable permission-revert — T9-W de-escalation-only (re
     expect(String(pr.note)).not.toMatch(/\d/) // the consequence text names no count
     // the OTHER subject's id (and thus its grant) never appears in the response (token is HMAC/base64 over subj only).
     expect(JSON.stringify(p.body)).not.toContain(other)
+  })
+
+  // Stage a deterministic concurrent interleave: hold the forward (grant-lowering) write's row lock in a SEPARATE
+  // uncommitted txn, FIRE the revert execute (which — post-fix — blocks on that lock at its `FOR UPDATE` live-load),
+  // settle so the execute reaches the lock-wait, then COMMIT the forward write so the execute unblocks and re-reads the
+  // now-lower live grant. `forward` performs the uncommitted lowering write on the held client; `makeExec` builds the
+  // supertest execute call (fired immediately via Promise.resolve, NOT deferred until after the commit).
+  async function raceForwardLowerThenExecute(
+    forward: (client: PoolClient) => Promise<unknown>,
+    makeExec: () => PromiseLike<request.Response>,
+  ): Promise<request.Response> {
+    const pool = poolManager.get().getInternalPool()
+    expect(pool).toBeTruthy()
+    const client = await pool!.connect()
+    try {
+      await client.query('BEGIN')
+      await forward(client) // forward lowering write — uncommitted ⇒ holds the row lock
+      const pending = Promise.resolve(makeExec()) // fire the revert execute now (blocks on the held lock, post-fix)
+      await new Promise((r) => setTimeout(r, 200)) // let the execute reach its FOR UPDATE lock-wait
+      await client.query('COMMIT') // forward lowering commits ⇒ execute unblocks, re-reads the lower grant
+      return await pending
+    } finally {
+      await client.query('ROLLBACK').catch(() => {}) // no-op if already committed; releases on error paths
+      client.release()
+    }
+  }
+
+  test('(m) CONCURRENCY sheet: forward REVOKE (admin→none) commits while revert executes → revert re-reads & 409s (never escalates none→read)', async () => {
+    process.env[FLAG] = 'true'
+    const s = await freshSheet('m')
+    const subj = mkSubject('m')
+    await seedSheetGrant(s, subj, 'admin') // LIVE = admin at preview
+    const eid = sheetEntityId(subj)
+    const rev = await insertPermissionRev(s, eid, { action: 'update', before: sheetSnap(subj, 'read'), after: sheetSnap(subj, 'admin'), changedKeys: SHEET_KEYS })
+    const p = await preview(s, rev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.permissionRevert).toMatchObject({ direction: 'de-escalation', supported: true }) // read < admin, by value
+    const token: string = p.body.data.previewToken
+    const x = await raceForwardLowerThenExecute(
+      // forward REVOKE: delete the subject's grant row(s) (admin → none), held uncommitted to lock the row.
+      (c) => c.query(`DELETE FROM spreadsheet_permissions WHERE sheet_id=$1 AND subject_type='user' AND subject_id=$2`, [s, subj]),
+      () => execute(s, { revisionId: rev, previewToken: token, confirm: 'revert-permission' }),
+    )
+    // the execute re-read the COMMITTED revoke (live=none) ⇒ grant-hash drift vs the admin-bound token ⇒ 409, no apply.
+    expect(x.status).toBe(409)
+    expect(x.body?.error?.code).toBe('GRANT_DRIFT')
+    expect(await sheetCodes(s, subj)).toEqual([]) // stays REVOKED — never raised back to read (the escalation this lock closes)
+  })
+
+  test('(n) CONCURRENCY field: forward HIDE (read-write→hidden) commits while revert executes → revert re-reads & 409s (never escalates hidden→read-only)', async () => {
+    process.env[FLAG] = 'true'
+    const s = await freshSheet('n')
+    const subj = mkSubject('n')
+    const fld = mkFieldId()
+    await seedFieldGrant(s, fld, subj, true, false) // LIVE = visible + read-write (rank 2) at preview
+    const eid = fieldEntityId(fld, subj)
+    const rev = await insertPermissionRev(s, eid, { action: 'update', before: fieldSnap(fld, subj, true, true), after: fieldSnap(fld, subj, true, false), changedKeys: FIELD_KEYS })
+    const p = await preview(s, rev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.permissionRevert).toMatchObject({ scope: 'field', direction: 'de-escalation', supported: true }) // read-only(1) < read-write(2)
+    const token: string = p.body.data.previewToken
+    const x = await raceForwardLowerThenExecute(
+      // forward HIDE: lower the field grant to hidden (visible=false, rank 0), held uncommitted to lock the row.
+      (c) => c.query(`UPDATE field_permissions SET visible=false WHERE sheet_id=$1 AND field_id=$2 AND subject_type='user' AND subject_id=$3`, [s, fld, subj]),
+      () => execute(s, { revisionId: rev, previewToken: token, confirm: 'revert-permission' }),
+    )
+    // the execute re-read the COMMITTED hide (live rank 0) ⇒ drift vs the read-write-bound token ⇒ 409, no apply.
+    expect(x.status).toBe(409)
+    expect(x.body?.error?.code).toBe('GRANT_DRIFT')
+    expect(await fieldGrantRow(s, fld, subj)).toMatchObject({ visible: false }) // stays HIDDEN — never restored to read-only
   })
 })


### PR DESCRIPTION
## What

Closes the documented concurrency gap in the **flag-gated** multitable permission-revert execute path (`MULTITABLE_ENABLE_PERMISSION_REVERT`, **default off**). The execute path re-checks the de-escalation direction against the **LIVE** grant inside its txn, but the live-grant load was a plain `SELECT`. A concurrent forward grant/revoke write that **lowered** the grant between the revert's direction check and its apply could turn a checked de-escalation into a **net escalation** (e.g. forward revokes `admin→none`, then the revert "de-escalates" `admin→read` = `none→read`, raising the subject).

The original code even documented this: the `meta_sheets FOR UPDATE` carried a comment that "the forward grant/revoke routes must take the same lock for full coverage — tracked in the dev-verification honest gaps."

## Fix (confined to the gated path, no forward-route change)

The execute-path live-grant load now takes **`FOR UPDATE`** (`loadLivePermissionGrant` gains a `forUpdate` flag, set `true` **only** on the execute path; preview stays unlocked). A de-escalation always reads a **non-null** live grant (no-row ⇒ `null` ⇒ rank 0, and de-escalation requires live rank ≥ 1), so the `FOR UPDATE` always locks a **real row**; a concurrent forward write on the same subject contends on that row, so the drift re-check → direction re-check → apply are **atomic** against it. The existing `meta_sheets FOR UPDATE` is **kept** (coarse per-sheet mutex; also serializes the sheet-delete FK cascade — see below); lock order is always `meta_sheets → permission-row`, so concurrent reverts can't deadlock. Under **READ COMMITTED** (verified the pool sets no isolation override), a blocked `FOR UPDATE` re-reads the committed-forward value → drift → **409**.

## Why row-lock over CAS

`FOR UPDATE` reuses the existing `GRANT_DRIFT` check verbatim (no new `rowCount==0` branch), avoids per-scope NULL-normalization/delete-then-insert CAS fiddliness, and needs zero forward-route change. The "field rank-2 = no-row" subtlety that would have forced CAS gymnastics **doesn't arise**: the loader returns `null` for no-row, and de-escalation never reads `null`.

## Verification

- **15/15** `multitable-permission-revert-realdb` goldens pass against a real Postgres, including **new (m)/(n)**: a forward **REVOKE** (sheet) / **HIDE** (field) committed **WHILE** the revert executes — staged deterministically via a held row lock — makes the revert **re-read the lowered grant and 409 `GRANT_DRIFT`** instead of escalating. (The serial drift case (h) does *not* exercise the lock; (m)/(n) overlap two txns.)
- File is already in the `plugin-tests.yml` real-DB allowlist (line ~232) → (m)/(n) ride along.
- `tsc --noEmit` clean.
- **Forward-path serialization audit** (independent): every forward path that *lowers/removes* a field/view/sheet grant does so via UPDATE/DELETE on the **same lock key** → all contend. Sheet-delete FK cascade is serialized by the kept `meta_sheets FOR UPDATE`. **No** `permission-row → meta_sheets` lock order anywhere → deadlock-free.

## Scope / non-goals

- **Does NOT enable the flag.** This is the engineering prerequisite that makes a future *owner-gated* enablement safe.
- The legacy `/permissions/grant` INSERT-without-DELETE path (sheet scope) is non-contending but **benign** for never-escalate: the **revert's own writes never raise the subject above the live it direction-checked**. The final *derived* level isn't guaranteed to equal the target — a concurrent grant of a higher `perm_code` that commits after the revert's apply-`DELETE` survives — but that higher value is an **independent authorized grant** (forward-vs-forward last-write-wins), not a revert-blessed escalation. Field/view are single-PK (fully serialized; no new-row escape). Optional future owner-gated hardening if grant/revert mutual exclusion is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)