### PR TITLE
feat(automation): timezone-aware cron + date-reminder scheduling (T2-5)

### DIFF
--- a/packages/core-backend/src/multitable/automation-date-reminder.test.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.test.ts
@@ -73,6 +73,84 @@ describe('computeDateReminderOccurrence — pure, day-bucketed', () => {
   })
 })
 
+describe('computeDateReminderOccurrence — timezone-aware (T2-5)', () => {
+  const NY = 'America/New_York'
+
+  test('UTC default path is unchanged when timezone is absent / "UTC"', () => {
+    const cfg = { offsetDays: 3, direction: 'before' as const, timeOfDay: '09:00' }
+    expect(computeDateReminderOccurrence('2026-06-28T14:30:00.000Z', cfg)).toBe('2026-06-25T09:00:00.000Z')
+    expect(computeDateReminderOccurrence('2026-06-28T14:30:00.000Z', { ...cfg, timezone: 'UTC' })).toBe(
+      '2026-06-25T09:00:00.000Z',
+    )
+  })
+
+  test('non-UTC zone: timeOfDay is LOCAL wall-clock, converted to UTC (EDT = UTC-4)', () => {
+    // 0 days before, fire 09:00 America/New_York on 2026-06-15 (EDT) = 13:00 UTC.
+    expect(
+      computeDateReminderOccurrence('2026-06-15T20:00:00.000Z', {
+        offsetDays: 0,
+        direction: 'before',
+        timeOfDay: '09:00',
+        timezone: NY,
+      }),
+    ).toBe('2026-06-15T13:00:00.000Z')
+  })
+
+  test('non-UTC zone: day-bucket uses the LOCAL calendar day of the source date', () => {
+    // 2026-06-16T02:00:00Z is still 2026-06-15 22:00 LOCAL (EDT). So the local day is the 15th, and a
+    // 0-offset 09:00 reminder fires 2026-06-15 09:00 EDT = 13:00 UTC (NOT the 16th).
+    expect(
+      computeDateReminderOccurrence('2026-06-16T02:00:00.000Z', {
+        offsetDays: 0,
+        direction: 'before',
+        timeOfDay: '09:00',
+        timezone: NY,
+      }),
+    ).toBe('2026-06-15T13:00:00.000Z')
+  })
+
+  test('runtime defense: an invalid IANA tz degrades to UTC bucketing (never throws, no null)', () => {
+    let occ: string | null = null
+    expect(() => {
+      occ = computeDateReminderOccurrence('2026-06-28T14:30:00.000Z', {
+        offsetDays: 3,
+        direction: 'before',
+        timeOfDay: '09:00',
+        timezone: 'Not/AZone',
+      })
+    }).not.toThrow()
+    // Identical to the UTC path.
+    expect(occ).toBe('2026-06-25T09:00:00.000Z')
+  })
+})
+
+describe('date-reminder timer boundary — timezone-aware (T2-5)', () => {
+  const NY = 'America/New_York'
+
+  test('UTC default path unchanged: delay lands on the UTC timeOfDay boundary', () => {
+    // 2026-06-15T06:00:00Z, timeOfDay 09:00 UTC → fire at 09:00 UTC, 3h out.
+    const now = Date.parse('2026-06-15T06:00:00.000Z')
+    expect(nextDateReminderTimerDelayMs('09:00', now)).toBe(3 * 60 * 60 * 1000)
+    expect(dateReminderTimeOfDayPassed('09:00', now)).toBe(false)
+  })
+
+  test('non-UTC zone: the timer fires at the LOCAL timeOfDay, not the UTC one', () => {
+    // 2026-06-15T06:00:00Z. 09:00 America/New_York (EDT) = 13:00 UTC → still ahead, delay = 7h.
+    const now = Date.parse('2026-06-15T06:00:00.000Z')
+    const delay = nextDateReminderTimerDelayMs('09:00', now, NY)
+    expect(now + delay).toBe(Date.parse('2026-06-15T13:00:00.000Z'))
+    expect(dateReminderTimeOfDayPassed('09:00', now, NY)).toBe(false)
+  })
+
+  test('non-UTC zone: when today’s local boundary has passed, advance to the next LOCAL day', () => {
+    // 2026-06-15T16:00:00Z = 12:00 EDT, past 09:00 local → next is 2026-06-16 09:00 EDT = 2026-06-16 13:00 UTC.
+    const now = Date.parse('2026-06-15T16:00:00.000Z')
+    const delay = nextDateReminderTimerDelayMs('09:00', now, NY)
+    expect(now + delay).toBe(Date.parse('2026-06-16T13:00:00.000Z'))
+    expect(dateReminderTimeOfDayPassed('09:00', now, NY)).toBe(true)
+  })
+})
+
 describe('isDateReminderDue — firing window (backfill bound)', () => {
   const now = Date.parse('2026-06-25T12:00:00.000Z')
   const window = DATE_REMINDER_GRACE_WINDOW_MS // 2 days

--- a/packages/core-backend/src/multitable/automation-date-reminder.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.ts
@@ -16,12 +16,30 @@
  *      time within the same reminder day does not change the occurrence → no re-spam. (Day-bucketing assumes
  *      offsetDays granularity; sub-day offsets are a future revisit — out of v1.)
  *
- * Timezone: v1 buckets in UTC (date fields are stored as `toISOString()` = UTC). A tz-aware day boundary
- * needs an IANA tz library and is deferred; `config.timezone` is accepted+persisted but only `'UTC'` is
- * honored in v1 (documented limitation).
+ * Timezone (T2-5): the day-bucket honors `config.timezone`. With timezone absent / 'UTC' / 'Etc/UTC' the
+ * occurrence is bucketed in UTC EXACTLY as before (no behaviour change). With a valid non-UTC IANA zone the
+ * source date's LOCAL calendar day is taken, shifted by ±offsetDays as civil days, then `timeOfDay` is the
+ * LOCAL wall-clock on the reminder day, converted back to a UTC instant. A persisted-junk tz never throws —
+ * it falls back to UTC bucketing. Editing a rule's timezone re-buckets `occurrence_ts`, so a bounded one-time
+ * re-fire is possible (Q5, accepted); historical ledger rows are never rewritten.
  */
 
+import { getZonedParts, isValidIanaTimeZone, zonedWallClockToUtcMs } from './automation-timezone'
+
 const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Resolve a date-reminder timezone: a valid non-UTC IANA zone → that zone; absent / 'UTC' / 'Etc/UTC' /
+ * invalid → `null` = the UTC path. PURE; never throws (invalid is filtered here, so the zoned helpers below
+ * only ever run with a known-good zone, and a junk persisted tz degrades to UTC instead of mis-firing).
+ */
+function resolveReminderTimeZone(raw: string | undefined): string | null {
+  if (typeof raw !== 'string') return null
+  const tz = raw.trim()
+  if (!tz || tz === 'UTC' || tz === 'Etc/UTC') return null
+  if (!isValidIanaTimeZone(tz)) return null
+  return tz
+}
 
 export interface ScheduleDateFieldConfig {
   /** The DATE/dateTime field whose value anchors the reminder. */
@@ -30,9 +48,9 @@ export interface ScheduleDateFieldConfig {
   offsetDays: number
   /** Fire this many days BEFORE the date, or AFTER it. */
   direction: 'before' | 'after'
-  /** When on the reminder day to fire, 'HH:mm' (UTC, v1). Default '09:00'. */
+  /** When on the reminder day to fire, 'HH:mm' in `timezone` (LOCAL wall-clock). Default '09:00'. */
   timeOfDay?: string
-  /** Persisted but v1 honors only 'UTC' (documented limitation). */
+  /** IANA timezone for the day-bucket + timeOfDay (T2-5). Absent/'UTC' = UTC bucketing. Invalid → UTC. */
   timezone?: string
   /**
    * SERVER-SET activation instant (ISO): when this rule BECAME a date-reminder (create-as-date_field or a
@@ -89,45 +107,134 @@ function utcTimeOfDayBoundaryMs(nowMs: number, timeOfDay: string | undefined): n
 }
 
 /**
- * DR-A: ms from `nowMs` until the NEXT UTC `timeOfDay` boundary (today's if still ahead, else tomorrow's).
- * The scheduler arms a `setTimeout` to this instant and re-arms each day, so the scan runs at ~the configured
- * time rather than anchored to server-boot time. PURE.
+ * The `timeOfDay` boundary (ms epoch) on the LOCAL calendar day containing `nowMs`, expressed as a UTC instant.
+ * tz must be a resolved, valid non-UTC zone. PURE; throws only on an invalid tz (caller guards/catches).
  */
-export function nextDateReminderTimerDelayMs(timeOfDay: string | undefined, nowMs: number): number {
-  const today = utcTimeOfDayBoundaryMs(nowMs, timeOfDay)
-  const target = today > nowMs ? today : today + DAY_MS
-  return target - nowMs
+function zonedTimeOfDayBoundaryMs(nowMs: number, timeOfDay: string | undefined, tz: string): number {
+  const p = getZonedParts(nowMs, tz)
+  const mins = parseTimeOfDayMinutes(timeOfDay)
+  return zonedWallClockToUtcMs(
+    { year: p.year, month: p.month, day: p.day, hour: Math.floor(mins / 60), minute: mins % 60, second: 0 },
+    tz,
+  )
 }
 
 /**
- * DR-B: has today's UTC `timeOfDay` boundary already passed at `nowMs`? When true at register/restart the
+ * DR-A: ms from `nowMs` until the NEXT `timeOfDay` boundary (today's if still ahead, else tomorrow's). The
+ * scheduler arms a `setTimeout` to this instant and re-arms each day, so the scan runs at ~the configured
+ * LOCAL time rather than anchored to server-boot time. With no/UTC tz the math is UTC (UNCHANGED). With a
+ * non-UTC zone "tomorrow" is the next LOCAL civil day (NOT today+24h — DST-safe), and a junk tz falls back to
+ * the UTC math (never throws). PURE.
+ */
+export function nextDateReminderTimerDelayMs(
+  timeOfDay: string | undefined,
+  nowMs: number,
+  timezone?: string,
+): number {
+  const tz = resolveReminderTimeZone(timezone)
+  if (!tz) {
+    const today = utcTimeOfDayBoundaryMs(nowMs, timeOfDay)
+    const target = today > nowMs ? today : today + DAY_MS
+    return target - nowMs
+  }
+  try {
+    const today = zonedTimeOfDayBoundaryMs(nowMs, timeOfDay, tz)
+    if (today > nowMs) return today - nowMs
+    // Next LOCAL civil day's boundary (handles month/DST rollover; +DAY_MS on the UTC instant could drift).
+    const p = getZonedParts(nowMs, tz)
+    const nextCivil = new Date(Date.UTC(p.year, p.month - 1, p.day + 1))
+    const mins = parseTimeOfDayMinutes(timeOfDay)
+    const target = zonedWallClockToUtcMs(
+      {
+        year: nextCivil.getUTCFullYear(),
+        month: nextCivil.getUTCMonth() + 1,
+        day: nextCivil.getUTCDate(),
+        hour: Math.floor(mins / 60),
+        minute: mins % 60,
+        second: 0,
+      },
+      tz,
+    )
+    return target - nowMs
+  } catch {
+    const today = utcTimeOfDayBoundaryMs(nowMs, timeOfDay)
+    const target = today > nowMs ? today : today + DAY_MS
+    return target - nowMs
+  }
+}
+
+/**
+ * DR-B: has today's `timeOfDay` boundary already passed at `nowMs`? When true at register/restart the
  * scheduler runs ONE immediate catch-up scan — still gated by the firing window + `ruleCreatedAt`, so it can
- * never backfill-blast — so a deploy after the configured time still delivers today's reminders. PURE.
+ * never backfill-blast — so a deploy after the configured time still delivers today's reminders. With no/UTC
+ * tz the boundary is UTC (UNCHANGED); a non-UTC zone uses the LOCAL boundary; a junk tz falls back to UTC
+ * (never throws). PURE.
  */
-export function dateReminderTimeOfDayPassed(timeOfDay: string | undefined, nowMs: number): boolean {
-  return utcTimeOfDayBoundaryMs(nowMs, timeOfDay) <= nowMs
+export function dateReminderTimeOfDayPassed(
+  timeOfDay: string | undefined,
+  nowMs: number,
+  timezone?: string,
+): boolean {
+  const tz = resolveReminderTimeZone(timezone)
+  if (!tz) return utcTimeOfDayBoundaryMs(nowMs, timeOfDay) <= nowMs
+  try {
+    return zonedTimeOfDayBoundaryMs(nowMs, timeOfDay, tz) <= nowMs
+  } catch {
+    return utcTimeOfDayBoundaryMs(nowMs, timeOfDay) <= nowMs
+  }
 }
 
 /**
- * PURE occurrence: the instant a record's reminder should fire, day-bucketed in UTC. Returns an ISO string,
- * or null if the date value is absent/unparseable. NEVER reads NOW.
+ * PURE occurrence: the instant a record's reminder should fire, day-bucketed in `config.timezone` (UTC when
+ * absent/'UTC'/invalid). Returns an ISO string, or null if the date value is absent/unparseable. NEVER reads
+ * NOW. The UTC path is byte-identical to pre-T2-5; the zoned path day-buckets in LOCAL time and converts back.
  */
 export function computeDateReminderOccurrence(
   dateValue: unknown,
-  config: { offsetDays?: number; direction?: 'before' | 'after'; timeOfDay?: string },
+  config: { offsetDays?: number; direction?: 'before' | 'after'; timeOfDay?: string; timezone?: string },
 ): string | null {
   if (dateValue === null || dateValue === undefined || dateValue === '') return null
   const d = dateValue instanceof Date ? dateValue : new Date(String(dateValue))
   const t = d.getTime()
   if (Number.isNaN(t)) return null
 
-  // Day-bucket: strip the source time-of-day to UTC midnight, then shift by whole days.
-  const dayUtcMidnight = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
   const offset = Number.isFinite(config.offsetDays) ? Math.trunc(config.offsetDays) : 0
   const signedDays = config.direction === 'after' ? offset : -offset
-  const reminderDay = dayUtcMidnight + signedDays * DAY_MS
-  const occurrenceMs = reminderDay + parseTimeOfDayMinutes(config.timeOfDay) * 60 * 1000
-  return new Date(occurrenceMs).toISOString()
+  const tz = resolveReminderTimeZone(config.timezone)
+
+  if (!tz) {
+    // Day-bucket: strip the source time-of-day to UTC midnight, then shift by whole days. (UNCHANGED.)
+    const dayUtcMidnight = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+    const reminderDay = dayUtcMidnight + signedDays * DAY_MS
+    const occurrenceMs = reminderDay + parseTimeOfDayMinutes(config.timeOfDay) * 60 * 1000
+    return new Date(occurrenceMs).toISOString()
+  }
+
+  try {
+    // Zoned day-bucket: take the source date's LOCAL calendar day, shift by whole CIVIL days, then set the
+    // LOCAL `timeOfDay` and convert that local wall-clock back to a UTC instant.
+    const p = getZonedParts(t, tz)
+    const shifted = new Date(Date.UTC(p.year, p.month - 1, p.day + signedDays))
+    const mins = parseTimeOfDayMinutes(config.timeOfDay)
+    const occurrenceMs = zonedWallClockToUtcMs(
+      {
+        year: shifted.getUTCFullYear(),
+        month: shifted.getUTCMonth() + 1,
+        day: shifted.getUTCDate(),
+        hour: Math.floor(mins / 60),
+        minute: mins % 60,
+        second: 0,
+      },
+      tz,
+    )
+    return new Date(occurrenceMs).toISOString()
+  } catch {
+    // Runtime defense (Q6): a persisted-junk tz must never throw — degrade to UTC bucketing.
+    const dayUtcMidnight = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+    const reminderDay = dayUtcMidnight + signedDays * DAY_MS
+    const occurrenceMs = reminderDay + parseTimeOfDayMinutes(config.timeOfDay) * 60 * 1000
+    return new Date(occurrenceMs).toISOString()
+  }
 }
 
 /**

--- a/packages/core-backend/src/multitable/automation-scheduler.ts
+++ b/packages/core-backend/src/multitable/automation-scheduler.ts
@@ -11,6 +11,12 @@ import {
   dateReminderTimeOfDayPassed,
   type ScheduleDateFieldConfig,
 } from './automation-date-reminder'
+import {
+  getZonedParts,
+  isValidIanaTimeZone,
+  zonedMinuteKey,
+  type ZonedParts,
+} from './automation-timezone'
 import type { AutomationRule } from './automation-executor'
 import type { RedisLeaderLock } from './redis-leader-lock'
 
@@ -155,6 +161,74 @@ function cronMatches(parsed: ParsedCronExpression, date: Date): boolean {
   return domMatches || dowMatches
 }
 
+/**
+ * T2-5: cron-field match against a candidate UTC instant's LOCAL wall-clock in a timezone. Identical
+ * OR-semantics to {@link cronMatches}, only the field source differs — `parts` are the zoned year/month/day/
+ * hour/minute (day-of-week is derived from the civil date so it is locale-independent and never reads a
+ * formatter weekday string).
+ */
+function cronMatchesZoned(parsed: ParsedCronExpression, parts: ZonedParts): boolean {
+  if (!parsed.minute.has(parts.minute)) return false
+  if (!parsed.hour.has(parts.hour)) return false
+  if (!parsed.month.has(parts.month)) return false
+
+  const dow = new Date(Date.UTC(parts.year, parts.month - 1, parts.day)).getUTCDay()
+  const domMatches = parsed.dayOfMonth.has(parts.day)
+  const dowMatches = parsed.dayOfWeek.has(dow)
+  if (parsed.dayOfMonthWildcard && parsed.dayOfWeekWildcard) return true
+  if (parsed.dayOfMonthWildcard) return dowMatches
+  if (parsed.dayOfWeekWildcard) return domMatches
+  return domMatches || dowMatches
+}
+
+/**
+ * Look-back bound for DST fall-back dedup. A wall-clock minute repeats across at most the DST shift, which is
+ * ≤ 1h for every modern IANA zone; 3h gives comfortable margin. The cost (≤180 cheap zoned-minute lookups) is
+ * paid ONLY when a candidate already matched the cron — i.e. once per fired occurrence, not per scanned minute.
+ */
+const MAX_DST_FALLBACK_LOOKBACK_MS = 3 * 60 * 60 * 1000
+
+/**
+ * Resolve a cron schedule's timezone. Absent / 'UTC' / 'Etc/UTC' → `null` = the UTC fast path (behaviour
+ * UNCHANGED from pre-T2-5). A persisted-junk tz must NOT throw in the scan loop (Q6 runtime defense): warn and
+ * fall back to UTC.
+ */
+function resolveCronTimeZone(raw: string | undefined): string | null {
+  if (typeof raw !== 'string') return null
+  const tz = raw.trim()
+  if (!tz || tz === 'UTC' || tz === 'Etc/UTC') return null
+  if (!isValidIanaTimeZone(tz)) {
+    logger.warn(`Invalid IANA timezone '${tz}' on a cron schedule — falling back to UTC`)
+    return null
+  }
+  return tz
+}
+
+/**
+ * Q1 (DST fall-back): a wall-clock minute that occurs TWICE (clock-back day) must fire ONCE. We always emit
+ * the FIRST instant and suppress the SECOND. A candidate is the suppressed repeat iff some EARLIER UTC minute
+ * within {@link MAX_DST_FALLBACK_LOOKBACK_MS} maps to the SAME local Y-M-D-H-m. Identical local-date-hour-
+ * minute can only arise during a fall-back overlap, so this is false-positive-free for ordinary days/crons.
+ * Defensive: any zoned-formatter throw is treated as "not a repeat" (never throws in the scan).
+ */
+function isZonedFallbackRepeat(candidateMs: number, timeZone: string): boolean {
+  let key: string
+  try {
+    key = zonedMinuteKey(candidateMs, timeZone)
+  } catch {
+    return false
+  }
+  const minuteMs = 60 * 1000
+  for (let back = candidateMs - minuteMs; back >= candidateMs - MAX_DST_FALLBACK_LOOKBACK_MS; back -= minuteMs) {
+    try {
+      if (zonedMinuteKey(back, timeZone) === key) return true
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
 /** Leap-safe maximum day each month (1..12) can host (February = 29). */
 const MONTH_MAX_DAYS: Readonly<Record<number, number>> = {
   1: 31, 2: 29, 3: 31, 4: 30, 5: 31, 6: 30,
@@ -199,17 +273,38 @@ export function cronHasNoMatchingDay(expression: string): boolean {
   return dayUnreachable(parsed)
 }
 
-export function nextCronOccurrenceMs(expression: string, fromMs: number = Date.now()): number | null {
+export function nextCronOccurrenceMs(
+  expression: string,
+  fromMs: number = Date.now(),
+  timeZone?: string,
+): number | null {
   const parsed = parseCronExpression(expression)
   if (!parsed) return null
   // Fast path: a day-impossible cron (e.g. Feb 30) would otherwise scan the full
   // ~5-year window before returning null. Short-circuit it up front.
   if (dayUnreachable(parsed)) return null
+  // T2-5: resolve the schedule timezone. `null` = UTC fast path (UNCHANGED from pre-T2-5); a non-UTC IANA zone
+  // interprets each candidate minute's LOCAL wall-clock. Invalid/junk tz already fell back to UTC via the
+  // resolver. Spring-forward (Q2) is emergent: a non-existent local minute maps to NO UTC instant, so the
+  // minute-scan simply never matches it and that day is skipped — no special case needed.
+  const tz = resolveCronTimeZone(timeZone)
   const minuteMs = 60 * 1000
   let candidate = Math.floor(fromMs / minuteMs) * minuteMs + minuteMs
   const max = candidate + 5 * 366 * 24 * 60 * minuteMs
   while (candidate <= max) {
-    if (cronMatches(parsed, new Date(candidate))) return candidate
+    if (tz) {
+      let matched = false
+      try {
+        matched = cronMatchesZoned(parsed, getZonedParts(candidate, tz))
+      } catch {
+        // Defensive: a zoned-formatter failure mid-scan must never throw out of the loop (Q6).
+        matched = false
+      }
+      // Q1: emit the FIRST instant of a wall-clock minute; suppress the DST fall-back repeat.
+      if (matched && !isZonedFallbackRepeat(candidate, tz)) return candidate
+    } else if (cronMatches(parsed, new Date(candidate))) {
+      return candidate
+    }
     candidate += minuteMs
   }
   return null
@@ -434,8 +529,8 @@ export class AutomationScheduler {
     clearTimeout(timer)
   }
 
-  private registerCron(rule: AutomationRule, expression: string): void {
-    const nextMs = nextCronOccurrenceMs(expression)
+  private registerCron(rule: AutomationRule, expression: string, timeZone?: string): void {
+    const nextMs = nextCronOccurrenceMs(expression, Date.now(), timeZone)
     if (!nextMs) {
       logger.warn(`Rule ${rule.id}: unsupported cron expression: ${expression}`)
       return
@@ -445,13 +540,17 @@ export class AutomationScheduler {
       if (!this.timers.has(rule.id)) return
       this.runScheduledRule(rule)
       this.timers.delete(rule.id)
-      if (this.isLeader) this.registerCron(rule, expression)
+      // Re-arm from NOW (no catch-up — Q3 at-most-once). On a DST fall-back day the next-occurrence scan
+      // suppresses the repeated wall-clock minute, so the timer advances past the overlap (fire-once).
+      if (this.isLeader) this.registerCron(rule, expression, timeZone)
     }, delayMs)
     if (typeof timer.unref === 'function') {
       timer.unref()
     }
     this.timers.set(rule.id, timer)
-    logger.info(`Registered cron schedule for rule ${rule.id} (next: ${new Date(nextMs).toISOString()})`)
+    logger.info(
+      `Registered cron schedule for rule ${rule.id} (next: ${new Date(nextMs).toISOString()}${timeZone ? `, tz=${timeZone}` : ''})`,
+    )
   }
 
   /**
@@ -480,7 +579,7 @@ export class AutomationScheduler {
         return
       }
       const config = trigger.config as Partial<ScheduleDateFieldConfig>
-      if (dateReminderTimeOfDayPassed(config.timeOfDay, Date.now())) {
+      if (dateReminderTimeOfDayPassed(config.timeOfDay, Date.now(), config.timezone)) {
         this.runScheduledRule(rule)
       }
       this.armDateFieldTimer(rule, config)
@@ -489,6 +588,7 @@ export class AutomationScheduler {
 
     let intervalMs: number | null = null
     let cronExpression: string | null = null
+    let cronTimezone: string | undefined
     if (trigger.type === 'schedule.interval') {
       intervalMs = typeof trigger.config.intervalMs === 'number' ? trigger.config.intervalMs : null
       if (!intervalMs || intervalMs < 1000) {
@@ -501,7 +601,8 @@ export class AutomationScheduler {
         : typeof trigger.config.cron === 'string'
           ? trigger.config.cron
           : ''
-      if (!nextCronOccurrenceMs(cronExpression)) {
+      cronTimezone = typeof trigger.config.timezone === 'string' ? trigger.config.timezone : undefined
+      if (!nextCronOccurrenceMs(cronExpression, Date.now(), cronTimezone)) {
         logger.warn(`Rule ${rule.id}: unsupported cron expression: ${cronExpression}`)
         return
       }
@@ -517,7 +618,7 @@ export class AutomationScheduler {
     }
 
     if (cronExpression) {
-      this.registerCron(rule, cronExpression)
+      this.registerCron(rule, cronExpression, cronTimezone)
       return
     }
 
@@ -539,7 +640,7 @@ export class AutomationScheduler {
    * lives in `this.timers`, so `unregister`'s clear cancels a pending fire.
    */
   private armDateFieldTimer(rule: AutomationRule, config: Partial<ScheduleDateFieldConfig>): void {
-    const delay = nextDateReminderTimerDelayMs(config.timeOfDay, Date.now())
+    const delay = nextDateReminderTimerDelayMs(config.timeOfDay, Date.now(), config.timezone)
     const timer = setTimeout(() => {
       this.runScheduledRule(rule)
       if (this.timers.get(rule.id) === timer) {
@@ -550,7 +651,8 @@ export class AutomationScheduler {
       timer.unref()
     }
     this.timers.set(rule.id, timer)
-    logger.info(`Registered date-reminder schedule for rule ${rule.id} (next scan in ${delay}ms, timeOfDay=${config.timeOfDay ?? '09:00'} UTC)`)
+    const tzLabel = config.timezone && config.timezone !== 'UTC' ? config.timezone : 'UTC'
+    logger.info(`Registered date-reminder schedule for rule ${rule.id} (next scan in ${delay}ms, timeOfDay=${config.timeOfDay ?? '09:00'} ${tzLabel})`)
   }
 
   /**

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -13,6 +13,7 @@ import {
   dateReminderLedgerRetentionCutoffIso,
   type ScheduleDateFieldConfig,
 } from './automation-date-reminder'
+import { isValidIanaTimeZone } from './automation-timezone'
 import { ensureRecordNotLocked } from './record-lock'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { extractSelectOptions } from './field-codecs'
@@ -800,6 +801,9 @@ export class AutomationService {
     const dateTriggerError = await this.validateDateFieldTriggerAtSave(sheetId, input.triggerType, input.triggerConfig ?? null)
     if (dateTriggerError) throw new AutomationRuleValidationError(dateTriggerError)
 
+    const cronTriggerError = this.validateCronTriggerAtSave(input.triggerType, input.triggerConfig ?? null)
+    if (cronTriggerError) throw new AutomationRuleValidationError(cronTriggerError)
+
     // date_field rules carry a SERVER-SET activation `effectiveAt` (= now) so the firing floor is the rule's
     // activation, not its row createdAt. Spread-then-set overwrites any client-supplied effectiveAt (no backfill bypass).
     const persistedTriggerConfig: Record<string, unknown> =
@@ -982,6 +986,12 @@ export class AutomationService {
       )
       if (dateTriggerError) throw new AutomationRuleValidationError(dateTriggerError)
 
+      const cronTriggerError = this.validateCronTriggerAtSave(
+        nextTriggerType,
+        nextTriggerConfig as Record<string, unknown> | null,
+      )
+      if (cronTriggerError) throw new AutomationRuleValidationError(cronTriggerError)
+
       // SERVER-SET activation floor: when the RESULT is a date_field rule, persist `effectiveAt`. Converting
       // INTO date_field (prev type differs) activates NOW; staying date_field (config edit) PRESERVES the
       // existing activation (fall back to created_at for pre-fix rules) so an edit never re-opens backfill.
@@ -1105,13 +1115,34 @@ export class AutomationService {
       .where('trigger_type', 'in', ['schedule.cron', 'schedule.interval', 'schedule.date_field'])
       .execute()
 
+    // Q4 (T2-5 migration risk A): now that the persisted cron timezone is HONORED, a non-UTC rule that
+    // previously fired in UTC will shift its firing time. Collect those rules so operators get a one-time
+    // startup audit naming exactly which rules change (sheetId, ruleId, tz) — emitted after registration.
+    const nonUtcCronAudit: Array<{ sheetId: string; ruleId: string; timezone: string }> = []
+
     for (const row of rows) {
       const rule = this.mapRow(row)
       this.scheduler.register(toExecutorRule(rule))
+      if (rule.trigger_type === 'schedule.cron') {
+        const cfg = (rule.trigger_config ?? null) as Record<string, unknown> | null
+        const tzRaw = cfg && typeof cfg.timezone === 'string' ? cfg.timezone.trim() : ''
+        if (tzRaw && tzRaw !== 'UTC' && tzRaw !== 'Etc/UTC') {
+          nonUtcCronAudit.push({ sheetId: rule.sheet_id, ruleId: rule.id, timezone: tzRaw })
+        }
+      }
     }
 
     if (rows.length > 0) {
       logger.info(`Registered ${rows.length} scheduled automation rule(s) on startup`)
+    }
+
+    if (nonUtcCronAudit.length > 0) {
+      logger.warn(
+        `T2-5 timezone audit: ${nonUtcCronAudit.length} enabled non-UTC cron rule(s) now honor their persisted timezone (firing time shifts from UTC):`,
+      )
+      for (const a of nonUtcCronAudit) {
+        logger.warn(`  cron rule ${a.ruleId} (sheet ${a.sheetId}) timezone=${a.timezone}`)
+      }
     }
   }
 
@@ -1189,6 +1220,19 @@ export class AutomationService {
     ) {
       logger.warn(`Rule ${rule.id}: invalid schedule.date_field config — skipping scan`)
       return
+    }
+
+    // Q6 runtime defense: a persisted-junk timezone (e.g. a direct-DB write that bypassed the save validator)
+    // must NOT throw in the scan loop — the pure occurrence math degrades to UTC bucketing. Surface it once so
+    // operators notice the mis-config, then proceed (the rule still fires, just in UTC).
+    if (
+      typeof config.timezone === 'string' &&
+      config.timezone.trim() &&
+      config.timezone.trim() !== 'UTC' &&
+      config.timezone.trim() !== 'Etc/UTC' &&
+      !isValidIanaTimeZone(config.timezone.trim())
+    ) {
+      logger.warn(`Rule ${rule.id}: invalid date-reminder timezone '${config.timezone}' — falling back to UTC bucketing`)
     }
 
     const nowMs = Date.now()
@@ -1303,8 +1347,13 @@ export class AutomationService {
       }
     }
 
-    if (cfg.timezone !== undefined && cfg.timezone !== null && cfg.timezone !== '' && cfg.timezone !== 'UTC') {
-      return `schedule.date_field timezone v1 supports only 'UTC' (got ${String(cfg.timezone)})`
+    // T2-5: timezone is now honored (was UTC-only). Accept any VALID IANA zone; reject invalid (fail-closed,
+    // 400 at save) so a saved rule's behavior matches its config. Absent/empty/'UTC' = UTC bucketing.
+    if (cfg.timezone !== undefined && cfg.timezone !== null && cfg.timezone !== '') {
+      const tzStr = typeof cfg.timezone === 'string' ? cfg.timezone.trim() : ''
+      if (!tzStr || !isValidIanaTimeZone(tzStr)) {
+        return `schedule.date_field timezone must be a valid IANA timezone (got ${String(cfg.timezone)})`
+      }
     }
 
     const res = await this.queryFn('SELECT type FROM meta_fields WHERE sheet_id = $1 AND id = $2', [sheetId, dateFieldId])
@@ -1315,6 +1364,28 @@ export class AutomationService {
       return `schedule.date_field dateFieldId must be a date/dateTime field (got ${fieldType || 'unknown'})`
     }
 
+    return null
+  }
+
+  /**
+   * T2-5 cron SAVE-boundary validator. `schedule.cron` is now timezone-aware, so a junk timezone must be
+   * rejected at save (400, fail-closed — mirrors the date_field tz gate) rather than silently mis-firing or
+   * being caught-and-UTC'd only at runtime. Accepts absent / '' / 'UTC' / 'Etc/UTC' / any valid IANA zone;
+   * rejects only an invalid zone. No DB access (pure Intl validity check). No-op for any other trigger type.
+   */
+  private validateCronTriggerAtSave(
+    triggerType: string,
+    triggerConfig: Record<string, unknown> | null | undefined,
+  ): string | null {
+    if (triggerType !== 'schedule.cron') return null
+    const cfg = isRecord(triggerConfig) ? triggerConfig : {}
+    if (cfg.timezone !== undefined && cfg.timezone !== null && cfg.timezone !== '') {
+      const tzStr = typeof cfg.timezone === 'string' ? cfg.timezone.trim() : ''
+      if (!tzStr || tzStr === 'UTC' || tzStr === 'Etc/UTC') return null
+      if (!isValidIanaTimeZone(tzStr)) {
+        return `schedule.cron timezone must be a valid IANA timezone (got ${String(cfg.timezone)})`
+      }
+    }
     return null
   }
 

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1311,8 +1311,10 @@ export class AutomationService {
    *
    * Enforces: dateFieldId EXISTS on this sheet AND is a `date`/`dateTime` field (not an arbitrary string
    * field that happens to parse); offsetDays is a finite non-negative integer; direction ∈ {before, after};
-   * timeOfDay (if given) is HH:mm; timezone is rejected unless 'UTC' (v1 honors only UTC — reject, don't
-   * accept-and-ignore, so the saved rule's behavior matches its config).
+   * timeOfDay (if given) is HH:mm; timezone (if given) must be a valid IANA zone — T2-5 made date_field
+   * timezone-aware, so a non-UTC tz is now HONORED (local-date bucketing), no longer rejected. Invalid
+   * IANA strings are rejected at save; a persisted-junk tz reaching the scanner falls back to UTC + warn
+   * (never throws), so the saved rule's behavior still matches its config.
    */
   private async validateDateFieldTriggerAtSave(
     sheetId: string,

--- a/packages/core-backend/src/multitable/automation-timezone.ts
+++ b/packages/core-backend/src/multitable/automation-timezone.ts
@@ -1,0 +1,146 @@
+/**
+ * Timezone helpers for automation scheduling (T2-5) — PURE, dependency-free.
+ *
+ * Wall-clock ↔ UTC conversion via `Intl.DateTimeFormat` with a per-tz formatter cache. Mirrors the proven
+ * pattern in `plugins/plugin-attendance` (getZonedParts / timeZoneOffset / zonedTimeToUtc) so the codebase
+ * has ONE shape for zoned-time math rather than a second hand-rolled variant.
+ *
+ * IMPORTANT: the UTC default scheduling path NEVER calls into this module — callers branch on
+ * "timezone absent / 'UTC' / 'Etc/UTC'" and only enter the zoned path for an explicit non-UTC IANA zone. That
+ * branch is what keeps the pre-T2-5 UTC behaviour byte-identical (no regression).
+ *
+ * No new runtime dependency: IANA validity + conversion ride entirely on the platform `Intl` API.
+ */
+
+export interface ZonedParts {
+  year: number
+  /** 1-12. */
+  month: number
+  /** 1-31. */
+  day: number
+  /** 0-23. */
+  hour: number
+  minute: number
+  second: number
+}
+
+/**
+ * Per-tz `Intl.DateTimeFormat` cache. Constructing a formatter is the expensive part; the minute-scan in
+ * `nextCronOccurrenceMs` calls `getZonedParts` up to ~1440×/day so the cache matters. `hourCycle: 'h23'` keeps
+ * midnight as hour `0` (some V8 builds otherwise render it as `24` under `hour12: false`, which would make a
+ * midnight cron silently never match — see the defensive `24 → 0` normalize below).
+ */
+const formatterCache = new Map<string, Intl.DateTimeFormat>()
+
+function getFormatter(timeZone: string): Intl.DateTimeFormat {
+  let fmt = formatterCache.get(timeZone)
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      hourCycle: 'h23',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    formatterCache.set(timeZone, fmt)
+  }
+  return fmt
+}
+
+/** True iff `timeZone` is a valid IANA zone (the platform `Intl` accepts it). PURE; never throws. */
+export function isValidIanaTimeZone(timeZone: string): boolean {
+  if (typeof timeZone !== 'string' || !timeZone.trim()) return false
+  try {
+    // Constructing with an unknown timeZone throws RangeError; a known zone does not.
+    new Intl.DateTimeFormat('en-US', { timeZone: timeZone.trim() }).format(0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Wall-clock fields of a UTC instant in `timeZone`. This UTC→local direction is EXACT and unambiguous.
+ * Throws only when `timeZone` is invalid — callers validate/guard first (the scheduler/date-reminder loops
+ * wrap this in try/catch so a persisted-junk tz can never throw mid-scan).
+ */
+export function getZonedParts(utcMs: number, timeZone: string): ZonedParts {
+  const parts = getFormatter(timeZone).formatToParts(utcMs)
+  let year = 0
+  let month = 0
+  let day = 0
+  let hour = 0
+  let minute = 0
+  let second = 0
+  for (const part of parts) {
+    switch (part.type) {
+      case 'year':
+        year = Number(part.value)
+        break
+      case 'month':
+        month = Number(part.value)
+        break
+      case 'day':
+        day = Number(part.value)
+        break
+      case 'hour':
+        hour = Number(part.value)
+        break
+      case 'minute':
+        minute = Number(part.value)
+        break
+      case 'second':
+        second = Number(part.value)
+        break
+      default:
+        break
+    }
+  }
+  // Defensive: portable across V8 builds that render local midnight as "24" rather than "00".
+  if (hour === 24) hour = 0
+  return { year, month, day, hour, minute, second }
+}
+
+/** Offset (minutes) of `timeZone` at the given UTC instant: (localWallClock-as-UTC) − utc. */
+function timeZoneOffsetMinutes(utcMs: number, timeZone: string): number {
+  const p = getZonedParts(utcMs, timeZone)
+  const asUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second)
+  return (asUtc - utcMs) / 60000
+}
+
+/**
+ * Convert a LOCAL wall-clock (civil Y-M-D h:m in `timeZone`) to a UTC epoch-ms — the hard local→UTC direction.
+ * Single-pass guess+correct, matching the plugin-attendance precedent. Exact for times away from DST edges
+ * (the date-reminder default 09:00 is far from typical 02:00–03:00 transitions). At an exact spring-forward
+ * gap the result lands on the post-transition instant; at a fall-back overlap it resolves to one offset —
+ * both acceptable bounded edges (Q5 documents the bounded one-time re-bucket tolerance). Throws only on an
+ * invalid tz (callers guard).
+ */
+export function zonedWallClockToUtcMs(
+  parts: { year: number; month: number; day: number; hour: number; minute: number; second?: number },
+  timeZone: string,
+): number {
+  const utcGuess = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second ?? 0,
+  )
+  const offset = timeZoneOffsetMinutes(utcGuess, timeZone)
+  return utcGuess - offset * 60000
+}
+
+/**
+ * Stable LOCAL minute key `"Y-M-D-H-m"` of a UTC instant in `timeZone` (seconds dropped). Used by the cron
+ * scan to dedup a DST fall-back: two distinct UTC instants share the SAME key only during a fall-back overlap,
+ * so an exact key match against an earlier instant uniquely identifies the repeated wall-clock minute.
+ */
+export function zonedMinuteKey(utcMs: number, timeZone: string): string {
+  const p = getZonedParts(utcMs, timeZone)
+  return `${p.year}-${p.month}-${p.day}-${p.hour}-${p.minute}`
+}

--- a/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
@@ -248,9 +248,15 @@ describeIfDatabase('multitable date-reminder trigger — scan/claim/fire (real D
       .rejects.toThrow(/offsetDays must be a non-negative integer/i)
   })
 
-  test('DR-VAL: rejects a non-UTC timezone at save (v1 honors only UTC — reject, not accept-and-ignore)', async () => {
-    await expect(svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timezone: 'America/New_York' })))
-      .rejects.toThrow(/timezone v1 supports only 'UTC'/i)
+  test('DR-VAL (T2-5): accepts a valid non-UTC IANA timezone at save (now honored, not UTC-only)', async () => {
+    const ok = await svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timezone: 'America/New_York' }))
+    expect(ok.id).toBeTruthy()
+    expect((ok.trigger_config as { timezone?: string }).timezone).toBe('America/New_York')
+  })
+
+  test('DR-VAL (T2-5): rejects an INVALID IANA timezone at save (400, fail-closed)', async () => {
+    await expect(svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timezone: 'Not/AZone' })))
+      .rejects.toThrow(/timezone must be a valid IANA timezone/i)
   })
 
   test('DR-VAL: a valid date field + config saves successfully', async () => {

--- a/packages/core-backend/tests/unit/automation-scheduler-date-reminder.test.ts
+++ b/packages/core-backend/tests/unit/automation-scheduler-date-reminder.test.ts
@@ -17,6 +17,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AutomationScheduler } from '../../src/multitable/automation-scheduler'
 import type { AutomationRule } from '../../src/multitable/automation-executor'
+import { computeDateReminderOccurrence } from '../../src/multitable/automation-date-reminder'
+import { getZonedParts } from '../../src/multitable/automation-timezone'
 
 const H = 60 * 60 * 1000
 
@@ -104,5 +106,30 @@ describe('AutomationScheduler — schedule.date_field timeOfDay alignment (DR-A/
     vi.advanceTimersByTime(24 * H)
     expect(cb).not.toHaveBeenCalled() // no armed timer
     s.destroy()
+  })
+})
+
+// Review note (T2-5): date_field DST semantics differ DELIBERATELY from cron. cron skips a non-existent
+// local minute (no UTC instant maps to it). date_field is a single point-in-time occurrence, so it lands
+// on the nearest REPRESENTABLE instant instead of skipping — documented + locked here so nobody assumes
+// it behaves like cron's skip.
+describe('date_field DST gap/overlap — lands on a representable instant (NOT cron-style skip)', () => {
+  // US spring-forward 2026: Mar 8, 02:00 EST → 03:00 EDT. Local 02:30 does NOT exist.
+  // Note: the date VALUE is noon-UTC so its NY-LOCAL calendar day is genuinely Mar 8 (a bare 'YYYY-MM-DD'
+  // parses to UTC midnight, whose local day in a negative-offset zone is the PREVIOUS day — the day-bucket
+  // is keyed off the local day, not the UTC day).
+  it('spring-forward GAP: a non-existent local timeOfDay resolves FORWARD to 03:30 (not skipped, unlike cron)', () => {
+    const occ = computeDateReminderOccurrence('2026-03-08T12:00:00Z', { timeOfDay: '02:30', timezone: 'America/New_York' })
+    expect(occ).not.toBeNull()
+    const p = getZonedParts(Date.parse(occ!), 'America/New_York')
+    expect({ day: p.day, hour: p.hour, minute: p.minute }).toEqual({ day: 8, hour: 3, minute: 30 }) // pushed past the gap, NOT dropped
+  })
+
+  // US fall-back 2026: Nov 1, 02:00 EDT → 01:00 EST. Local 01:30 occurs TWICE.
+  it('fall-back OVERLAP: a repeated local timeOfDay resolves to a single deterministic instant', () => {
+    const occ = computeDateReminderOccurrence('2026-11-01T12:00:00Z', { timeOfDay: '01:30', timezone: 'America/New_York' })
+    expect(occ).not.toBeNull()
+    const p = getZonedParts(Date.parse(occ!), 'America/New_York')
+    expect({ day: p.day, hour: p.hour, minute: p.minute }).toEqual({ day: 1, hour: 1, minute: 30 }) // one ISO instant — no double-fire
   })
 })

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2109,6 +2109,67 @@ describe('nextCronOccurrenceMs', () => {
   })
 })
 
+describe('nextCronOccurrenceMs — timezone (T2-5)', () => {
+  const NY = 'America/New_York'
+
+  it('UTC default path is unchanged when no timezone / "UTC" is supplied', () => {
+    const from = Date.parse('2026-06-28T09:14:30.000Z')
+    // Identical to the UTC golden above — proves the tz param does not perturb the default path.
+    expect(new Date(nextCronOccurrenceMs('15 9 * * *', from)!).toISOString()).toBe('2026-06-28T09:15:00.000Z')
+    expect(new Date(nextCronOccurrenceMs('15 9 * * *', from, 'UTC')!).toISOString()).toBe('2026-06-28T09:15:00.000Z')
+    expect(new Date(nextCronOccurrenceMs('15 9 * * *', from, 'Etc/UTC')!).toISOString()).toBe('2026-06-28T09:15:00.000Z')
+  })
+
+  it('maps a wall-clock cron to the correct UTC instant on a normal day (EDT = UTC-4)', () => {
+    // 09:30 America/New_York on 2026-06-15 (EDT) = 13:30 UTC.
+    const from = Date.parse('2026-06-15T00:00:00.000Z')
+    expect(new Date(nextCronOccurrenceMs('30 9 * * *', from, NY)!).toISOString()).toBe('2026-06-15T13:30:00.000Z')
+  })
+
+  it('handles a midnight tz cron (guards the hour-"24" formatter gotcha)', () => {
+    // 00:00 America/New_York on 2026-06-15 (EDT, UTC-4) = 04:00 UTC. A naive formatter rendering midnight as
+    // hour "24" would never match the 0-hour set → this pins the 24→0 normalize.
+    const from = Date.parse('2026-06-14T12:00:00.000Z')
+    expect(new Date(nextCronOccurrenceMs('0 0 * * *', from, NY)!).toISOString()).toBe('2026-06-15T04:00:00.000Z')
+  })
+
+  it('DST fall-back: a wall-clock time occurring twice fires ONCE (first instant, then skips the repeat)', () => {
+    // 2026-11-01 America/New_York clocks go 02:00 EDT → 01:00 EST, so local 01:30 happens twice:
+    //   first  = 01:30 EDT = 05:30 UTC
+    //   second = 01:30 EST = 06:30 UTC   ← must be SUPPRESSED
+    const before = Date.parse('2026-10-31T12:00:00.000Z')
+    const firstFire = nextCronOccurrenceMs('30 1 * * *', before, NY)!
+    expect(new Date(firstFire).toISOString()).toBe('2026-11-01T05:30:00.000Z')
+
+    // Re-arm from the first fire: the next occurrence must NOT be the repeated 01:30 EST (06:30 UTC) —
+    // it must advance past the overlap to the NEXT day's 01:30 EST (2026-11-02 06:30 UTC).
+    const nextFire = nextCronOccurrenceMs('30 1 * * *', firstFire, NY)!
+    expect(nextFire).not.toBe(Date.parse('2026-11-01T06:30:00.000Z')) // the suppressed duplicate
+    expect(new Date(nextFire).toISOString()).toBe('2026-11-02T06:30:00.000Z')
+  })
+
+  it('DST spring-forward: a wall-clock time that does not exist skips that day', () => {
+    // 2026-03-08 America/New_York clocks go 02:00 EST → 03:00 EDT, so local 02:30 NEVER occurs that day.
+    // The minute-scan finds no UTC instant mapping to 02:30 on Mar 8 → it skips to 2026-03-09 02:30 EDT
+    // (= 06:30 UTC).
+    const from = Date.parse('2026-03-08T00:00:00.000Z')
+    const fire = nextCronOccurrenceMs('30 2 * * *', from, NY)!
+    expect(new Date(fire).toISOString()).not.toBe('2026-03-08T07:30:00.000Z')
+    expect(new Date(fire).getUTCDate()).not.toBe(8) // skipped the spring-forward day entirely
+    expect(new Date(fire).toISOString()).toBe('2026-03-09T06:30:00.000Z')
+  })
+
+  it('runtime defense: an invalid IANA tz is CAUGHT (not thrown) and falls back to UTC', () => {
+    const from = Date.parse('2026-06-15T00:00:00.000Z')
+    let result: number | null = null
+    expect(() => {
+      result = nextCronOccurrenceMs('30 1 * * *', from, 'Not/AZone')
+    }).not.toThrow()
+    // UTC fallback: 01:30 UTC, not 01:30 in some zone.
+    expect(new Date(result!).toISOString()).toBe('2026-06-15T01:30:00.000Z')
+  })
+})
+
 describe('cronHasNoMatchingDay', () => {
   it('flags day-of-month values no restricted month can host', () => {
     expect(cronHasNoMatchingDay('0 0 30 2 *')).toBe(true) // February tops out at 29
@@ -2423,6 +2484,44 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule.name).toBe('My Rule')
     expect(rule.trigger_type).toBe('record.created')
     expect(rule.enabled).toBe(true)
+  })
+
+  it('T2-5: createRule REJECTS an invalid IANA timezone on a cron trigger (400 at save)', async () => {
+    await expect(
+      service.createRule('sheet_1', {
+        name: 'cron bad tz',
+        triggerType: 'schedule.cron',
+        triggerConfig: { expression: '30 1 * * *', timezone: 'Not/AZone' },
+        actionType: 'update_record',
+        actionConfig: { fields: { status: 'x' } },
+      }),
+    ).rejects.toThrow(/cron timezone must be a valid IANA timezone/i)
+  })
+
+  it('T2-5: createRule ACCEPTS a valid non-UTC IANA timezone on a cron trigger', async () => {
+    dbExecuteResults.push([]) // insertInto().execute()
+    const rule = await service.createRule('sheet_1', {
+      name: 'cron good tz',
+      triggerType: 'schedule.cron',
+      triggerConfig: { expression: '30 1 * * *', timezone: 'America/New_York' },
+      actionType: 'update_record',
+      actionConfig: { fields: { status: 'x' } },
+    })
+    expect(rule.trigger_type).toBe('schedule.cron')
+    expect((rule.trigger_config as { timezone?: string }).timezone).toBe('America/New_York')
+  })
+
+  it('T2-5: createRule REJECTS an invalid IANA timezone on a date_field trigger (400, tz gate before DB lookup)', async () => {
+    // The tz gate fires before the meta_fields lookup, so an invalid tz rejects even with the empty-rows mock.
+    await expect(
+      service.createRule('sheet_1', {
+        name: 'date_field bad tz',
+        triggerType: 'schedule.date_field',
+        triggerConfig: { dateFieldId: 'fld_d', offsetDays: 3, direction: 'before', timezone: 'Bogus/Zone' },
+        actionType: 'update_record',
+        actionConfig: { fields: { status: 'x' } },
+      }),
+    ).rejects.toThrow(/date_field timezone must be a valid IANA timezone/i)
   })
 
   it('A6-2: createRule accepts wait_for_callback with workflow_job_v1', async () => {


### PR DESCRIPTION
Ratified **Tier-1 T2-5** — makes both `schedule.cron` and `schedule.date_field` timezone-aware (the `timezone` config was accepted but ignored / UTC-only). Built to the approved defaults.

## What
- **New `automation-timezone.ts`** — IANA validation + wall-clock↔UTC via cached `Intl.DateTimeFormat`, **no new dependency** (mirrors the proven `plugin-attendance` pattern).
- **Cron** (`automation-scheduler.ts`) — `nextCronOccurrenceMs(expr, fromMs, timeZone?)` matches each candidate's *local* wall-clock; **DST fall-back fires ONCE** (suppress the repeated window), **spring-forward skips** the missing hour; at-most-once / no-catch-up preserved.
- **Date-reminder** (`automation-date-reminder.ts`) — occurrence + timer day-bucket in the configured tz.
- **Validation** (`automation-service.ts`) — date_field validator relaxed UTC-only → accept-valid-IANA / **reject-invalid 400**; new fail-closed cron-tz gate (create+update); **one-time startup audit** of enabled non-UTC cron rules; runtime junk-tz → catch→UTC + warn (never throws mid-scan).

## Defaults (ratified)
fall-back fire-once · spring-forward skip · no catch-up · startup audit · bounded re-bucket documented (ledger untouched) · reject-at-save-400 + runtime fallback · both cron + date_field.

## Verification
`tsc` 0 · **DST goldens pass** (fall-back-once, spring-forward-skip) · `automation-v1` **211** · `automation-date-reminder` **30** · scheduler-leader/metrics **16** · **UTC default path byte-identical** (pinned by "UTC unchanged" goldens — no regression). DB-gated paths (valid-IANA save *acceptance* + full tz firing) run in the existing `multitable-date-reminder-trigger` CI integration test (updated), not locally.

Built to ratified defaults + verified; **held reviewable** for your merge. Single-pass offset is exact for normal times; exact DST-instant wall-clock times fall under the documented Q5 bounded tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)