### PR TITLE
feat(multitable): C1 — extract shared cross-base write-authority primitive

### DIFF
--- a/docs/development/multitable-crossbase-c1-authority-primitive-dev-verification-20260630.md
+++ b/docs/development/multitable-crossbase-c1-authority-primitive-dev-verification-20260630.md
@@ -8,11 +8,16 @@
 ## 1. What was extracted
 A new context-agnostic module **`packages/core-backend/src/multitable/cross-base-write-authority.ts`** owns the
 two-part cross-base write-authority decision on a write into a canonical-owner base:
+0. **null target base** — a sheet's `base_id` can be null at runtime (legacy/unresolved) even where the call site
+   narrows to `string`, so `targetBaseId` is typed `string | null` and a null base — which can neither be claimed nor
+   written — is rejected **up front** as `{ ok:false, reason:'claim_mismatch' }`, before `resolveBaseWritable` is
+   consulted. Behaviour-identical to the extracted source (there a null target made `claimed !== targetBaseId` fire →
+   same reason); now explicit so no caller can treat the target as guaranteed-non-null.
 1. **claim == truth** — `declaredBaseClaim === targetBaseId` (explicit opt-in), else `{ ok:false, reason:'claim_mismatch' }`.
 2. **base-write authority** — `resolveBaseWritable(actorId, queryFn, targetBaseId)`, else `{ ok:false, reason:'not_writable' }`.
 
-Signature: `resolveCrossBaseWriteAuthority({ actorId, targetBaseId, declaredBaseClaim, queryFn }) → { ok:true } | { ok:false, reason }`.
-Order is load-bearing (claim before authority) — identical to the extracted source.
+Signature: `resolveCrossBaseWriteAuthority({ actorId, targetBaseId: string | null, declaredBaseClaim, queryFn }) → { ok:true } | { ok:false, reason }`.
+Order is load-bearing (null-target → claim → authority) — identical to the extracted source.
 
 `AutomationExecutor.evaluateCrossBaseWrite` is now a **thin adapter**: it keeps its automation-flavoured parts
 (ExecutionContext unpack, same-sheet/no-claim fast-path, `resolveSheetBaseId` soft-deleted-target check, same-base
@@ -36,11 +41,12 @@ The same-base / fast-path / soft-deleted-target / quota returns are untouched. N
   `…-delete-lock`, `…-write-quota`. Includes the claim/authority-path assertions (XW-2e, LK-1f "claim==truth → step
   failed") and the quota cap. **46/46.** That the unedited tests still pass — same error strings, same quota keying,
   same claim==truth semantics — is the behavior-preserving proof.
-- **New primitive unit test** `tests/unit/cross-base-write-authority.test.ts` — **5/5**: claim_mismatch (null claim
-  AND claim≠target, each proving authority is NOT consulted — claim checked first), not_writable, ok, null-actor
-  pass-through. `resolveBaseWritable` mocked directly (cleaner isolation than a mock queryFn; lets the test assert
-  the claim-before-authority order).
-- **Combined run: 51/51.** **`tsc --noEmit`: exit 0, clean.**
+- **New primitive unit test** `tests/unit/cross-base-write-authority.test.ts` — **6/6**: claim_mismatch (null claim
+  AND claim≠target, each proving authority is NOT consulted — claim checked first), **null target base (claim null AND
+  claim string → claim_mismatch, authority NOT consulted)**, not_writable, ok, null-actor pass-through.
+  `resolveBaseWritable` mocked directly (cleaner isolation than a mock queryFn; lets the test assert the
+  claim-before-authority order).
+- **Combined run: 52/52** (46 automation goldens unchanged + 6 primitive unit). **`tsc --noEmit`: exit 0, clean.**
 - **Context-agnostic proof:** the new module's only `import` is `from './permission-service'` (`resolveBaseWritable`
   + the `QueryFn` type). It imports NO automation-executor / `ExecutionContext` / quota store / automation type — so
   C2's mirror-write can consume it without dragging automation semantics.

--- a/docs/development/multitable-crossbase-c1-authority-primitive-dev-verification-20260630.md
+++ b/docs/development/multitable-crossbase-c1-authority-primitive-dev-verification-20260630.md
@@ -1,0 +1,58 @@
+# Cross-base Slice 1 — C1: shared write-authority primitive extraction — dev & verification (2026-06-30)
+
+> Status: built + verified (regression byte-identical, tsc clean). Branch `claude/multitable-crossbase-c1-authority-primitive-20260630`
+> off current main. First runtime slice of the **RATIFIED** design-lock
+> `multitable-crossbase-twoway-editable-mirror-slice1-designlock-20260629.md` (§3 + §10/I-3). **Pure
+> refactor-extraction — NO new behavior, NO mirror-write.**
+
+## 1. What was extracted
+A new context-agnostic module **`packages/core-backend/src/multitable/cross-base-write-authority.ts`** owns the
+two-part cross-base write-authority decision on a write into a canonical-owner base:
+1. **claim == truth** — `declaredBaseClaim === targetBaseId` (explicit opt-in), else `{ ok:false, reason:'claim_mismatch' }`.
+2. **base-write authority** — `resolveBaseWritable(actorId, queryFn, targetBaseId)`, else `{ ok:false, reason:'not_writable' }`.
+
+Signature: `resolveCrossBaseWriteAuthority({ actorId, targetBaseId, declaredBaseClaim, queryFn }) → { ok:true } | { ok:false, reason }`.
+Order is load-bearing (claim before authority) — identical to the extracted source.
+
+`AutomationExecutor.evaluateCrossBaseWrite` is now a **thin adapter**: it keeps its automation-flavoured parts
+(ExecutionContext unpack, same-sheet/no-claim fast-path, `resolveSheetBaseId` soft-deleted-target check, same-base
+short-circuit, and the per-target-base **quota** step) and delegates ONLY the claim+authority decision to the
+primitive, mapping the structured `reason` back to the **exact, unchanged** `CrossBaseWriteGate` error strings.
+
+## 2. Byte-identical mapping (reason → preserved error string)
+| primitive result | adapter `CrossBaseWriteGate` (verbatim, unchanged) |
+|---|---|
+| `claim_mismatch` | `Cross-base write requires an explicit targetBaseId equal to the target sheet's base: target sheet ${targetSheetId} base=${targetBaseId ?? 'null'}, declared=${claimed ?? 'null'}` |
+| `not_writable` | `Cross-base write denied: trigger actor lacks base-write on ${targetBaseId}` |
+| `ok` | falls through to the unchanged quota step → `{ crossBase:true, ok:true }` (or the quota rejection) |
+
+The same-base / fast-path / soft-deleted-target / quota returns are untouched. No signature change to
+`evaluateCrossBaseWrite` or `CrossBaseWriteGate`. The only import change in the adapter: `resolveBaseWritable` →
+`resolveCrossBaseWriteAuthority` (the direct `resolveBaseWritable` call moved into the primitive).
+
+## 3. Verification
+- **Regression-lock — BYTE-IDENTICAL automation (real DB):** the 4 existing cross-base-write goldens, **unchanged**,
+  pass against the refactored adapter — `multitable-cross-base-automation-write`, `…-write-rule`,
+  `…-delete-lock`, `…-write-quota`. Includes the claim/authority-path assertions (XW-2e, LK-1f "claim==truth → step
+  failed") and the quota cap. **46/46.** That the unedited tests still pass — same error strings, same quota keying,
+  same claim==truth semantics — is the behavior-preserving proof.
+- **New primitive unit test** `tests/unit/cross-base-write-authority.test.ts` — **5/5**: claim_mismatch (null claim
+  AND claim≠target, each proving authority is NOT consulted — claim checked first), not_writable, ok, null-actor
+  pass-through. `resolveBaseWritable` mocked directly (cleaner isolation than a mock queryFn; lets the test assert
+  the claim-before-authority order).
+- **Combined run: 51/51.** **`tsc --noEmit`: exit 0, clean.**
+- **Context-agnostic proof:** the new module's only `import` is `from './permission-service'` (`resolveBaseWritable`
+  + the `QueryFn` type). It imports NO automation-executor / `ExecutionContext` / quota store / automation type — so
+  C2's mirror-write can consume it without dragging automation semantics.
+
+## 4. Boundaries honored (per §10/I-3)
+- **Quota stays adapter-composed** — NOT moved into the primitive. The automation adapter keeps
+  `checkCrossBaseWriteQuota(targetBaseId)`. For C2: the **base-A leg** = primitive + base-A-keyed quota; the
+  **base-B leg** = a plain `resolveBaseWritable` (no claim, no quota — the actor's own base, not a cross-base target).
+- **No mirror-write, no flag, no new write path** is introduced in C1. `isFieldAlwaysReadOnly` is untouched (the
+  mirror stays read-only everywhere). C2 builds the gated write-through on top of this primitive (lead deliverable:
+  the §10/I-1 write-path enumeration).
+
+## 5. tsc narrowing note (non-behavioral)
+The adapter branches on the primitive result via `if ('reason' in authority)` (rather than `if (!authority.ok)`) —
+the `in`-operator narrows the union member robustly; behavior is identical (reason present ⟺ not-ok).

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -10,7 +10,7 @@ import { computeActionFingerprint } from './automation-suspension-service'
 import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
 import { isRichLongTextProperty, sanitizeRichLongText } from './field-codecs'
 import { ensureRecordNotLocked } from './record-lock'
-import { resolveBaseWritable } from './permission-service'
+import { resolveCrossBaseWriteAuthority } from './cross-base-write-authority'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { MemoryRateLimitStore, type RateLimitStore } from '../middleware/rate-limiter'
 import {
@@ -1855,21 +1855,27 @@ export class AutomationExecutor {
     // same-set are same-base; a null/legacy base vs a set base is cross-base.
     if (triggerBaseId === targetBaseId) return { crossBase: false }
 
-    // Cross-base: require an explicit, consistent opt-in (claim == truth). A non-null `targetBaseId`
-    // claim that equals the target sheet's ACTUAL base passes; absent or mismatched (incl. a claim vs a
-    // null actual base) rejects. (`declaredBaseClaim` computed at the top, reused here.)
+    // Cross-base AUTHORITY decision — claim==truth then base-write — via the shared, context-agnostic primitive
+    // (C1: `resolveCrossBaseWriteAuthority`, the SAME primitive the cross-base mirror write-through consumes; see
+    // the design-lock §3/§10). The primitive returns a structured reason; this adapter maps it back to the EXACT,
+    // unchanged `CrossBaseWriteGate` error strings (order preserved: claim before writable). (`declaredBaseClaim`
+    // computed at the top, reused here.)
     const claimed = declaredBaseClaim
-    if (claimed === null || claimed !== targetBaseId) {
-      return {
-        crossBase: true,
-        ok: false,
-        error: `Cross-base write requires an explicit targetBaseId equal to the target sheet's base: target sheet ${targetSheetId} base=${targetBaseId ?? 'null'}, declared=${claimed ?? 'null'}`,
+    const authority = await resolveCrossBaseWriteAuthority({
+      actorId: context.actorId ?? null,
+      targetBaseId,
+      declaredBaseClaim: claimed,
+      queryFn: this.deps.queryFn,
+    })
+    if ('reason' in authority) {
+      if (authority.reason === 'claim_mismatch') {
+        return {
+          crossBase: true,
+          ok: false,
+          error: `Cross-base write requires an explicit targetBaseId equal to the target sheet's base: target sheet ${targetSheetId} base=${targetBaseId ?? 'null'}, declared=${claimed ?? 'null'}`,
+        }
       }
-    }
-
-    // Trigger-actor base-write authority (fail-closed: null actor → false).
-    const writable = await resolveBaseWritable(context.actorId ?? null, this.deps.queryFn, targetBaseId)
-    if (!writable) {
+      // reason === 'not_writable' — trigger-actor lacks base-write (fail-closed: null actor → false).
       return {
         crossBase: true,
         ok: false,

--- a/packages/core-backend/src/multitable/cross-base-write-authority.ts
+++ b/packages/core-backend/src/multitable/cross-base-write-authority.ts
@@ -1,0 +1,57 @@
+/**
+ * Cross-base write authority — the shared, CONTEXT-AGNOSTIC authority primitive.
+ *
+ * Extracted from `AutomationExecutor.evaluateCrossBaseWrite` (C1 of the ratified cross-base Slice 1 design-lock,
+ * `docs/development/multitable-crossbase-twoway-editable-mirror-slice1-designlock-20260629.md` §3/§10). It is the
+ * single source of truth for the two-part authority decision on a cross-base write into a canonical-owner base:
+ *
+ *   1. claim == truth  — the caller's declared target base must equal the resolved target base (an explicit opt-in).
+ *   2. base-write authority — the actor must hold base-write on that target base (`resolveBaseWritable`, fail-closed).
+ *
+ * Both the automation executor (today) and the cross-base mirror write-through (C2, later) consume THIS — neither
+ * lifts the automation-flavoured `evaluateCrossBaseWrite` wholesale (§3). To stay context-agnostic this module
+ * imports ONLY `resolveBaseWritable` + the `QueryFn` type — NOT the automation executor, `ExecutionContext`, the
+ * quota store, or any automation type.
+ *
+ * Scope boundaries this primitive deliberately does NOT own (the CALLER composes them, per §10/I-3):
+ *   - Base resolution + the same-base short-circuit + soft-deleted-target handling (caller resolves bases first and
+ *     only calls this for a genuine cross-base write).
+ *   - The per-target-base write QUOTA (adapter-composed: the automation adapter and the C2 base-A leg each apply
+ *     their quota keyed to the target/base-A; the C2 base-B leg uses a plain `resolveBaseWritable` with no claim
+ *     and no quota — it is the actor's own base, not a cross-base target).
+ *   - Caller-specific error wording (this returns a structured `reason`; the caller maps it to its own message).
+ */
+import { resolveBaseWritable, type QueryFn } from './permission-service'
+
+export type CrossBaseWriteAuthorityReason = 'claim_mismatch' | 'not_writable'
+
+export type CrossBaseWriteAuthorityResult =
+  | { ok: true }
+  | { ok: false; reason: CrossBaseWriteAuthorityReason }
+
+/**
+ * Resolve the cross-base write authority decision for a write INTO `targetBaseId`.
+ * Order is load-bearing (claim before authority) and matches the extracted source exactly.
+ *
+ * @param actorId           the acting user id (null/empty → fail-closed via `resolveBaseWritable`)
+ * @param targetBaseId      the resolved canonical-owner base being written into (caller resolves + same-base-short-circuits first)
+ * @param declaredBaseClaim the caller's explicit target-base opt-in (null when absent)
+ * @param queryFn           DB access for `resolveBaseWritable`
+ */
+export async function resolveCrossBaseWriteAuthority(input: {
+  actorId: string | null
+  targetBaseId: string
+  declaredBaseClaim: string | null
+  queryFn: QueryFn
+}): Promise<CrossBaseWriteAuthorityResult> {
+  // (1) claim == truth — an explicit, consistent opt-in. Absent or mismatched → reject.
+  if (input.declaredBaseClaim === null || input.declaredBaseClaim !== input.targetBaseId) {
+    return { ok: false, reason: 'claim_mismatch' }
+  }
+  // (2) base-write authority (fail-closed: null/empty actor → false).
+  const writable = await resolveBaseWritable(input.actorId, input.queryFn, input.targetBaseId)
+  if (!writable) {
+    return { ok: false, reason: 'not_writable' }
+  }
+  return { ok: true }
+}

--- a/packages/core-backend/src/multitable/cross-base-write-authority.ts
+++ b/packages/core-backend/src/multitable/cross-base-write-authority.ts
@@ -34,16 +34,28 @@ export type CrossBaseWriteAuthorityResult =
  * Order is load-bearing (claim before authority) and matches the extracted source exactly.
  *
  * @param actorId           the acting user id (null/empty → fail-closed via `resolveBaseWritable`)
- * @param targetBaseId      the resolved canonical-owner base being written into (caller resolves + same-base-short-circuits first)
+ * @param targetBaseId      the resolved canonical-owner base being written into. **`string | null` ON PURPOSE:** a
+ *                          sheet's `base_id` can be null at runtime (legacy/unresolved) even where the call site's
+ *                          type narrows to `string`, so this primitive does NOT assume a non-null target. A null
+ *                          base is not a writable cross-base target and admits no valid claim==truth opt-in → it is
+ *                          rejected up front. (Callers should still resolve + reject a null base themselves; this
+ *                          defends regardless, so no caller can treat the target as guaranteed-non-null.)
  * @param declaredBaseClaim the caller's explicit target-base opt-in (null when absent)
  * @param queryFn           DB access for `resolveBaseWritable`
  */
 export async function resolveCrossBaseWriteAuthority(input: {
   actorId: string | null
-  targetBaseId: string
+  targetBaseId: string | null
   declaredBaseClaim: string | null
   queryFn: QueryFn
 }): Promise<CrossBaseWriteAuthorityResult> {
+  // (0) A null/legacy/unresolved target base can NEITHER be claimed NOR written — reject up front. Behaviour-identical
+  // to the extracted source (a null target made `claimed !== targetBaseId` fire → claim_mismatch), now made EXPLICIT
+  // so a `string`-typed call site can't slip a runtime-null through as a writable target. Also narrows the operand of
+  // the claim check + `resolveBaseWritable` below to a non-null base.
+  if (input.targetBaseId === null) {
+    return { ok: false, reason: 'claim_mismatch' }
+  }
   // (1) claim == truth — an explicit, consistent opt-in. Absent or mismatched → reject.
   if (input.declaredBaseClaim === null || input.declaredBaseClaim !== input.targetBaseId) {
     return { ok: false, reason: 'claim_mismatch' }

--- a/packages/core-backend/tests/unit/cross-base-write-authority.test.ts
+++ b/packages/core-backend/tests/unit/cross-base-write-authority.test.ts
@@ -34,6 +34,15 @@ describe('resolveCrossBaseWriteAuthority (C1 shared primitive)', () => {
     expect(mockWritable).not.toHaveBeenCalled()
   })
 
+  it('null target base → claim_mismatch up front, authority NOT consulted (a null base is never writable)', async () => {
+    // Even with a claim that "matches" a null target, a null base admits no valid opt-in and is not writable.
+    const rClaimNull = await resolveCrossBaseWriteAuthority({ actorId: 'u1', targetBaseId: null, declaredBaseClaim: null, queryFn: qf })
+    const rClaimStr = await resolveCrossBaseWriteAuthority({ actorId: 'u1', targetBaseId: null, declaredBaseClaim: 'baseA', queryFn: qf })
+    expect(rClaimNull).toEqual({ ok: false, reason: 'claim_mismatch' })
+    expect(rClaimStr).toEqual({ ok: false, reason: 'claim_mismatch' })
+    expect(mockWritable).not.toHaveBeenCalled()
+  })
+
   it('not_writable when claim==target but base-write is denied', async () => {
     mockWritable.mockResolvedValue(false)
     const r = await resolveCrossBaseWriteAuthority({ actorId: 'u1', targetBaseId: 'baseA', declaredBaseClaim: 'baseA', queryFn: qf })

--- a/packages/core-backend/tests/unit/cross-base-write-authority.test.ts
+++ b/packages/core-backend/tests/unit/cross-base-write-authority.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit test for the C1 shared authority primitive `resolveCrossBaseWriteAuthority`.
+ *
+ * Proves the context-agnostic two-part decision (claim==truth → base-write) and its ORDER (claim is checked
+ * before authority, so a bad claim never reaches `resolveBaseWritable`). `resolveBaseWritable` is mocked directly
+ * (not driven through a mock queryFn) so the test isolates the primitive's own logic + reason mapping with no DB.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/multitable/permission-service', () => ({
+  resolveBaseWritable: vi.fn(),
+}))
+
+import { resolveCrossBaseWriteAuthority } from '../../src/multitable/cross-base-write-authority'
+import { resolveBaseWritable } from '../../src/multitable/permission-service'
+import type { QueryFn } from '../../src/multitable/permission-service'
+
+const mockWritable = resolveBaseWritable as unknown as ReturnType<typeof vi.fn>
+// A stand-in queryFn; it is only ever forwarded to (the mocked) resolveBaseWritable, never executed here.
+const qf = (async () => ({ rows: [] })) as unknown as QueryFn
+
+describe('resolveCrossBaseWriteAuthority (C1 shared primitive)', () => {
+  beforeEach(() => mockWritable.mockReset())
+
+  it('claim_mismatch when the claim is null — authority NOT consulted (claim checked first)', async () => {
+    const r = await resolveCrossBaseWriteAuthority({ actorId: 'u1', targetBaseId: 'baseA', declaredBaseClaim: null, queryFn: qf })
+    expect(r).toEqual({ ok: false, reason: 'claim_mismatch' })
+    expect(mockWritable).not.toHaveBeenCalled()
+  })
+
+  it('claim_mismatch when the claim != target base — authority NOT consulted', async () => {
+    const r = await resolveCrossBaseWriteAuthority({ actorId: 'u1', targetBaseId: 'baseA', declaredBaseClaim: 'baseB', queryFn: qf })
+    expect(r).toEqual({ ok: false, reason: 'claim_mismatch' })
+    expect(mockWritable).not.toHaveBeenCalled()
+  })
+
+  it('not_writable when claim==target but base-write is denied', async () => {
+    mockWritable.mockResolvedValue(false)
+    const r = await resolveCrossBaseWriteAuthority({ actorId: 'u1', targetBaseId: 'baseA', declaredBaseClaim: 'baseA', queryFn: qf })
+    expect(r).toEqual({ ok: false, reason: 'not_writable' })
+    expect(mockWritable).toHaveBeenCalledWith('u1', qf, 'baseA')
+  })
+
+  it('ok when claim==target and base-write is granted', async () => {
+    mockWritable.mockResolvedValue(true)
+    const r = await resolveCrossBaseWriteAuthority({ actorId: 'u1', targetBaseId: 'baseA', declaredBaseClaim: 'baseA', queryFn: qf })
+    expect(r).toEqual({ ok: true })
+  })
+
+  it('forwards a null actorId through to resolveBaseWritable (fail-closed handled downstream)', async () => {
+    mockWritable.mockResolvedValue(false)
+    await resolveCrossBaseWriteAuthority({ actorId: null, targetBaseId: 'baseA', declaredBaseClaim: 'baseA', queryFn: qf })
+    expect(mockWritable).toHaveBeenCalledWith(null, qf, 'baseA')
+  })
+})


### PR DESCRIPTION
**C1 of the RATIFIED cross-base Slice 1 design-lock** (#3376, §3 + §10/I-3). Pure refactor-extraction — **no new behavior, no mirror-write, no flag, no new write path.**

Extracts the cross-base write **authority** decision (claim==truth → base-write) into a new **context-agnostic** primitive that both the automation executor (today) and the C2 mirror write-through (later) will share — so C2 does **not** lift the automation-flavoured `evaluateCrossBaseWrite` wholesale (the §3 anti-pattern your guidance flagged).

- **NEW `cross-base-write-authority.ts`** — `resolveCrossBaseWriteAuthority({actorId, targetBaseId, declaredBaseClaim, queryFn}) → {ok} | {ok:false, reason:'claim_mismatch'|'not_writable'}`. Claim-before-authority order. Imports **only** `resolveBaseWritable` + `QueryFn` — no automation/`ExecutionContext`/quota (context-agnostic, verified by grep).
- **`evaluateCrossBaseWrite` → thin adapter** — delegates the claim+authority decision to the primitive and maps the structured reason back to the **exact, unchanged** `CrossBaseWriteGate` error strings; the fast-path, soft-deleted check, same-base short-circuit, and **quota step stay in the adapter** (quota is caller-composed, base-A-keyed, per §10/I-3 — *not* moved into the primitive).
- **NEW primitive unit test** (5/5, incl. claim-checked-before-authority ordering).

**Verification (independently re-run):** the **4 existing automation cross-base-write goldens pass UNCHANGED** — `multitable-cross-base-automation-write` / `-write-rule` / `-delete-lock` / `-write-quota` (incl. the claim==truth paths + the quota cap) → **51/51** with the unit test = byte-identical behavior proof. `tsc --noEmit` exit 0.

Next: **C2** (the gated mirror write-through) consumes this primitive — led by the §10/I-1 write-path enumeration, with the per-record no-oracle mask (I-2) and asymmetric both-endpoints (I-3). Default-off `MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE`; not in this PR.

Dev/verification MD: `docs/development/multitable-crossbase-c1-authority-primitive-dev-verification-20260630.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)