### PR TITLE
feat(approval): T1-1 node-level SLA + remind (slice 1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -337,6 +337,7 @@ jobs:
             tests/integration/approval-wp1-parallel-gateway.api.test.ts \
             tests/integration/approval-bridge-redaction-regression.test.ts \
             tests/integration/approval-metrics-people-teams.test.ts \
+            tests/integration/approval-node-sla-remind.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/src/db/migrations/zzzz20260630100000_add_node_timeout_to_approval_metrics.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260630100000_add_node_timeout_to_approval_metrics.ts
@@ -1,0 +1,33 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+/**
+ * T1-1 node-level SLA — per-node timeout deadline + effect, read by the node-timeout scanner.
+ *
+ * Two nullable scalar columns on the existing approval_metrics row: the deadline for the
+ * CURRENT node (NULL = no node timeout / already fired) and the configured effect. Maintained
+ * at node activation/decision; cleared (set NULL) when the timeout fires (single-shot) or the
+ * node is decided / the instance terminates. A partial index keeps the scan cheap, mirroring
+ * idx_approval_metrics_sla_scan.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'approval_metrics')
+  if (!exists) return
+
+  await sql`ALTER TABLE approval_metrics ADD COLUMN IF NOT EXISTS current_node_deadline_at TIMESTAMPTZ`.execute(db)
+  await sql`ALTER TABLE approval_metrics ADD COLUMN IF NOT EXISTS current_node_timeout_effect TEXT`.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_metrics_node_timeout
+      ON approval_metrics(current_node_deadline_at)
+      WHERE current_node_deadline_at IS NOT NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'approval_metrics')
+  if (!exists) return
+  await sql`DROP INDEX IF EXISTS idx_approval_metrics_node_timeout`.execute(db)
+  await sql`ALTER TABLE approval_metrics DROP COLUMN IF EXISTS current_node_timeout_effect`.execute(db)
+  await sql`ALTER TABLE approval_metrics DROP COLUMN IF EXISTS current_node_deadline_at`.execute(db)
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2090,6 +2090,16 @@ export class MetaSheetServer {
             )
           }
         },
+        // T1-1 node-level SLA: dispatch per-node overdue reminders to the node's active assignees.
+        onNodeReminder: async ({ instanceId, assigneeIds }) => {
+          try {
+            await breachNotifier.notifyNodeReminder(instanceId, assigneeIds)
+          } catch (notifyError) {
+            this.logger.warn(
+              `ApprovalBreachNotifier node-reminder dispatch failed: ${notifyError instanceof Error ? notifyError.message : String(notifyError)}`,
+            )
+          }
+        },
       })
       this.logger.info('Approval SLA scheduler initialized')
     } catch (e) {

--- a/packages/core-backend/src/services/ApprovalBreachNotifier.ts
+++ b/packages/core-backend/src/services/ApprovalBreachNotifier.ts
@@ -176,6 +176,48 @@ export class ApprovalBreachNotifier {
     }
   }
 
+  /**
+   * T1-1 node-level SLA: dispatch a single instance's node-overdue reminder to all channels. Unlike
+   * `notifyBreaches` this NEVER touches `breach_notified_at` — node timeouts are single-shot via
+   * `approval_metrics.current_node_deadline_at`, which the scheduler clears with `markNodeTimeoutFired`.
+   * Never throws — channel failures are isolated/logged exactly like `notifyBreaches`.
+   */
+  async notifyNodeReminder(instanceId: string, assigneeIds: string[] = []): Promise<NotifyResult> {
+    const empty: NotifyResult = { requested: 0, notified: 0, skipped: 0, sent: 0, failed: 0, perChannel: [] }
+    const id = typeof instanceId === 'string' ? instanceId.trim() : ''
+    if (!id) return empty
+    if (this.channels.length === 0) {
+      this.logger.warn('ApprovalBreachNotifier.notifyNodeReminder invoked with zero channels; skipping')
+      return { ...empty, requested: 1, skipped: 1 }
+    }
+
+    let ctx: ApprovalBreachContext | undefined
+    try {
+      const contexts = await this.metrics.listBreachContextByIds([id])
+      ctx = contexts[0]
+    } catch (error) {
+      this.logger.warn(`Node reminder context fetch failed for ${id}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+
+    const message = this.composeNodeReminderMessage(id, ctx, assigneeIds)
+    const perChannel: NotifyResultPerChannel[] = []
+    let sent = 0
+    let failed = 0
+    const settlements = await Promise.all(
+      this.channels.map(async (channel) => ({ channel, result: await this.dispatch(channel, message) })),
+    )
+    for (const { channel, result } of settlements) {
+      if (result.ok) {
+        sent += 1
+        perChannel.push({ channel: channel.name, sent: 1, failed: 0, errors: [] })
+      } else {
+        failed += 1
+        perChannel.push({ channel: channel.name, sent: 0, failed: 1, errors: result.error ? [result.error] : [] })
+      }
+    }
+    return { requested: 1, notified: sent > 0 ? 1 : 0, skipped: 0, sent, failed, perChannel }
+  }
+
   private async dispatch(
     channel: BreachNotificationChannel,
     message: BreachMessage,
@@ -208,6 +250,25 @@ export class ApprovalBreachNotifier {
       `- 启动时间：${startedAt}`,
       `- SLA 阈值：${slaHours}`,
       `- 超时时长：${overdue}`,
+      `- 当前节点：${node}`,
+      `- 详情链接：${link || '(未配置 PUBLIC_APP_URL)'}`,
+    ].join('\n')
+    return { instanceId, title, body, link, severity: 'warning' }
+  }
+
+  private composeNodeReminderMessage(
+    instanceId: string,
+    ctx: ApprovalBreachContext | undefined,
+    assigneeIds: string[],
+  ): BreachMessage {
+    const templateName = ctx?.templateName?.trim() || '未命名模板'
+    const node = ctx?.currentNodeKey?.trim() || '未知节点'
+    const approvers = Array.isArray(assigneeIds) && assigneeIds.length > 0 ? assigneeIds.join('、') : '当前审批人'
+    const shortId = abbreviateId(instanceId)
+    const link = this.buildLink(instanceId)
+    const title = `审批节点超时提醒 | ${templateName} | 实例 #${shortId}`
+    const body = [
+      `- 待处理审批人：${approvers}`,
       `- 当前节点：${node}`,
       `- 详情链接：${link || '(未配置 PUBLIC_APP_URL)'}`,
     ].join('\n')

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -220,12 +220,18 @@ export class ApprovalMetricsService {
     instanceId: string
     nodeKey: string
     activatedAt: Date
+    // T1-1: when the activating node has a timeout, stamp its deadline + effect; otherwise the
+    // columns are cleared so the previous node's deadline can never linger on the new node.
+    timeoutDeadline?: Date | null
+    timeoutEffect?: string | null
   }): Promise<void> {
+    let added = false
     await this.mutateBreakdown(input.instanceId, (breakdown) => {
       const hasOpen = breakdown.some(
         (entry) => entry.nodeKey === input.nodeKey && !entry.decidedAt,
       )
       if (hasOpen) return null
+      added = true
       breakdown.push({
         nodeKey: input.nodeKey,
         activatedAt: input.activatedAt.toISOString(),
@@ -235,6 +241,23 @@ export class ApprovalMetricsService {
       })
       return breakdown
     })
+    // T1-1 node-timeout: (re)set the deadline columns ONLY when a NEW node was actually activated —
+    // to the new node's deadline if it has a timeout, else NULL (clearing the prior node's). A
+    // retry / re-emit (an open entry already exists → `added` stays false) is a strict no-op, so it
+    // can never push out or clear an existing deadline. Best-effort, like every metrics write.
+    if (added) {
+      await this.query(
+        `UPDATE approval_metrics
+           SET current_node_deadline_at = $2,
+               current_node_timeout_effect = $3
+         WHERE instance_id = $1`,
+        [
+          input.instanceId,
+          input.timeoutDeadline ? input.timeoutDeadline.toISOString() : null,
+          input.timeoutEffect ?? null,
+        ],
+      )
+    }
   }
 
   /**
@@ -276,6 +299,13 @@ export class ApprovalMetricsService {
       }
       return breakdown
     })
+    // T1-1: the node is decided — clear its timeout deadline so the scanner won't fire for it.
+    await this.query(
+      `UPDATE approval_metrics
+         SET current_node_deadline_at = NULL, current_node_timeout_effect = NULL
+       WHERE instance_id = $1`,
+      [input.instanceId],
+    )
   }
 
   /**
@@ -294,9 +324,38 @@ export class ApprovalMetricsService {
       `UPDATE approval_metrics
          SET terminal_at = $2,
              terminal_state = $3,
-             duration_seconds = GREATEST(0, EXTRACT(EPOCH FROM ($2::timestamptz - started_at))::INTEGER)
+             duration_seconds = GREATEST(0, EXTRACT(EPOCH FROM ($2::timestamptz - started_at))::INTEGER),
+             current_node_deadline_at = NULL,
+             current_node_timeout_effect = NULL
        WHERE instance_id = $1`,
       [input.instanceId, input.terminalAt.toISOString(), input.terminalState],
+    )
+  }
+
+  /**
+   * T1-1 node-timeout scan: rows whose current node has passed its deadline and not yet fired
+   * (deadline NULL after firing/decision => excluded by the partial index). Single-shot is
+   * enforced by `markNodeTimeoutFired` clearing the deadline.
+   */
+  async scanNodeTimeouts(now: Date): Promise<Array<{ instanceId: string; effect: string }>> {
+    const result = await this.query<{ instance_id: string; current_node_timeout_effect: string | null }>(
+      `SELECT instance_id, current_node_timeout_effect
+         FROM approval_metrics
+        WHERE terminal_at IS NULL
+          AND current_node_deadline_at IS NOT NULL
+          AND current_node_deadline_at < $1`,
+      [now.toISOString()],
+    )
+    return result.rows.map((r) => ({ instanceId: r.instance_id, effect: r.current_node_timeout_effect ?? 'remind' }))
+  }
+
+  /** Mark a node-timeout as fired (clear deadline + effect) so it can never re-fire for this activation. */
+  async markNodeTimeoutFired(instanceId: string): Promise<void> {
+    await this.query(
+      `UPDATE approval_metrics
+         SET current_node_deadline_at = NULL, current_node_timeout_effect = NULL
+       WHERE instance_id = $1`,
+      [instanceId],
     )
   }
 

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -184,6 +184,10 @@ export class ApprovalMetricsService {
     startedAt: Date
     slaHours?: number | null
     initialNodeKey?: string | null
+    // T1-1: when the FIRST (initial) node declares a timeout, stamp its deadline + effect right at
+    // instance start — this is the one activation path that does NOT flow through recordNodeActivation.
+    timeoutDeadline?: Date | null
+    timeoutEffect?: string | null
   }): Promise<void> {
     const tenantId = resolveTenantId(input.tenantId)
     const initialBreakdown: NodeBreakdownEntry[] = input.initialNodeKey
@@ -197,8 +201,9 @@ export class ApprovalMetricsService {
       : []
     await this.query(
       `INSERT INTO approval_metrics
-         (instance_id, template_id, tenant_id, started_at, sla_hours, node_breakdown)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+         (instance_id, template_id, tenant_id, started_at, sla_hours, node_breakdown,
+          current_node_deadline_at, current_node_timeout_effect)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
        ON CONFLICT (instance_id) DO NOTHING`,
       [
         input.instanceId,
@@ -207,6 +212,8 @@ export class ApprovalMetricsService {
         input.startedAt.toISOString(),
         input.slaHours ?? null,
         JSON.stringify(initialBreakdown),
+        input.timeoutDeadline ? input.timeoutDeadline.toISOString() : null,
+        input.timeoutEffect ?? null,
       ],
     )
   }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3310,13 +3310,26 @@ export class ApprovalProductService {
     // Wave 2 WP5 slice 1 — metrics start row is written after commit and
     // guarded so a metrics failure cannot roll back the approval instance.
     safeMetricsCall(`recordInstanceStart(${instanceId})`, async () => {
+      // T1-1: the FIRST node is activated here (not via emitNodeActivationMetric), so its timeout
+      // deadline must be stamped at instance start — otherwise a `remind` on the initial node never
+      // fires. Mirror emitNodeActivationMetric: read the node's timeout off the runtime graph in scope.
+      const startedAt = new Date()
+      const initialTimeout = initial.currentNodeKey
+        ? nodeTimeoutForKey(runtimeGraph, initial.currentNodeKey)
+        : undefined
       await this.metrics.recordInstanceStart({
       instanceId,
       templateId: bundle.template.id,
       tenantId: actor.tenantId ?? null,
-      startedAt: new Date(),
+      startedAt,
       slaHours: bundle.template.sla_hours ?? null,
       initialNodeKey: initial.currentNodeKey,
+      ...(initialTimeout?.effect
+        ? {
+            timeoutDeadline: new Date(startedAt.getTime() + initialTimeout.afterMinutes * 60000),
+            timeoutEffect: initialTimeout.effect,
+          }
+        : {}),
       })
       if (initial.status === 'approved') {
         await this.metrics.recordTerminal({

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -26,6 +26,8 @@ import type {
   FormFieldVisibilityRule,
   NodeFieldAccess,
   NodeFieldPermission,
+  NodeTimeoutConfig,
+  NodeTimeoutEffect,
   PublishApprovalTemplateRequest,
   RuntimeGraph,
   RuntimePolicy,
@@ -303,6 +305,12 @@ const PARALLEL_JOIN_MODES = new Set(['all', 'any'])
 const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve'])
 const AUTO_APPROVAL_ACTOR_MODES = new Set<AutoApprovalActorMode>(['system', 'original_approver'])
 const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(['editable', 'readonly', 'hidden'])
+// T1-1 node-level SLA. The full effect enum is declared so an off-enum value is a hard reject; slice 1
+// only WIRES `remind` (a notification) — transfer/jump/auto_* are rejected at publish until their slice.
+const NODE_TIMEOUT_EFFECTS = new Set<NodeTimeoutEffect>(['remind', 'transfer', 'jump', 'auto_approve', 'auto_reject'])
+const NODE_TIMEOUT_SUPPORTED_EFFECTS = new Set<NodeTimeoutEffect>(['remind'])
+// Upper bound (~69.4 days) guards against an overflowing deadline; lower bound forbids 0/negative.
+const NODE_TIMEOUT_MAX_AFTER_MINUTES = 100000
 const APPROVAL_MAX_AUTO_STEPS = 50
 
 function toNullableRecord(value: unknown): Record<string, unknown> | null {
@@ -921,6 +929,28 @@ function normalizeNodeFieldPermissions(
   return normalized
 }
 
+/**
+ * T1-1: preserve a node's `timeout` config through normalization so it survives into the stored /
+ * runtime graph (the surrounding `normalizedNode.config` is a strict whitelist — an un-copied field is
+ * silently dropped). Shape-only here; the strict semantic gate (integer range, supported effect, no
+ * parallel region) runs in `validateNodeTimeoutConfigs` so it can raise the specific
+ * APPROVAL_NODE_TIMEOUT_* codes consistently at create / update / publish.
+ */
+function normalizeNodeTimeout(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): NodeTimeoutConfig | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) {
+    failValidation(context, `${path} must be an object`)
+  }
+  return {
+    afterMinutes: value.afterMinutes as number,
+    effect: value.effect as NodeTimeoutEffect,
+  }
+}
+
 function normalizeConditionFormulaPredicate(
   value: unknown,
   context: ValidationContext,
@@ -965,6 +995,99 @@ function validateNodeFieldPermissionsAgainstFormSchema(
       }
     }
   })
+}
+
+/**
+ * T1-1: every node key that lives INSIDE a parallel region — i.e. is reachable from a `parallel`
+ * node's branch edge target before the region's join node. Computed from the stored graph structure
+ * (not runtime instance state), mirroring `collectParallelBranchNodeKeys`. Used to reject node-level
+ * timeouts inside a parallel region (the scanner's single-cursor deadline model can't track a
+ * per-branch node, so it's deferred to a later slice).
+ */
+function collectParallelRegionNodeKeys(approvalGraph: ApprovalGraph): Set<string> {
+  const regionNodeKeys = new Set<string>()
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'parallel') continue
+    const config = node.config as { branches?: unknown; joinNodeKey?: unknown }
+    const joinNodeKey = typeof config.joinNodeKey === 'string' ? config.joinNodeKey : null
+    const branchEdgeKeys = Array.isArray(config.branches)
+      ? config.branches.filter((entry): entry is string => typeof entry === 'string')
+      : []
+    for (const branchEdgeKey of branchEdgeKeys) {
+      const edge = approvalGraph.edges.find((candidate) => candidate.key === branchEdgeKey)
+      if (!edge) continue
+      const queue = [edge.target]
+      const visited = new Set<string>()
+      while (queue.length > 0) {
+        const nodeKey = queue.shift()!
+        if (nodeKey === joinNodeKey || visited.has(nodeKey)) continue
+        visited.add(nodeKey)
+        regionNodeKeys.add(nodeKey)
+        for (const outgoing of approvalGraph.edges.filter((candidate) => candidate.source === nodeKey)) {
+          queue.push(outgoing.target)
+        }
+      }
+    }
+  }
+  return regionNodeKeys
+}
+
+/**
+ * T1-1 node-level SLA publish/author gate. For every node carrying a `config.timeout`:
+ *   - `afterMinutes` must be a whole integer in (0, NODE_TIMEOUT_MAX_AFTER_MINUTES].
+ *   - `effect` must be in the declared enum AND supported by slice 1 (`remind` only) — transfer / jump
+ *     / auto_* are reserved (APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED).
+ *   - the node must NOT be inside a parallel region (APPROVAL_NODE_TIMEOUT_PARALLEL_UNSUPPORTED).
+ * Raises the specific codes directly (status 400) so create / update / publish surface the same error
+ * regardless of the surrounding validation context.
+ */
+function validateNodeTimeoutConfigs(approvalGraph: ApprovalGraph): void {
+  const parallelRegionNodeKeys = collectParallelRegionNodeKeys(approvalGraph)
+  for (const node of approvalGraph.nodes) {
+    const timeout = (node.config as { timeout?: unknown }).timeout
+    if (timeout === undefined || timeout === null) continue
+    if (!isRecord(timeout)) {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} timeout must be an object`,
+        400,
+        'APPROVAL_NODE_TIMEOUT_INVALID',
+      )
+    }
+    const afterMinutes = (timeout as { afterMinutes?: unknown }).afterMinutes
+    if (
+      !Number.isInteger(afterMinutes)
+      || (afterMinutes as number) <= 0
+      || (afterMinutes as number) > NODE_TIMEOUT_MAX_AFTER_MINUTES
+    ) {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} timeout.afterMinutes must be an integer in (0, ${NODE_TIMEOUT_MAX_AFTER_MINUTES}]`,
+        400,
+        'APPROVAL_NODE_TIMEOUT_INVALID',
+      )
+    }
+    const effect = (timeout as { effect?: unknown }).effect
+    if (typeof effect !== 'string' || !NODE_TIMEOUT_EFFECTS.has(effect as NodeTimeoutEffect)) {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} timeout.effect is invalid`,
+        400,
+        'APPROVAL_NODE_TIMEOUT_INVALID',
+      )
+    }
+    if (!NODE_TIMEOUT_SUPPORTED_EFFECTS.has(effect as NodeTimeoutEffect)) {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} timeout.effect '${effect}' is not supported yet`,
+        400,
+        'APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED',
+      )
+    }
+    if (parallelRegionNodeKeys.has(node.key)) {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} timeout is not supported inside a parallel region`,
+        400,
+        'APPROVAL_NODE_TIMEOUT_PARALLEL_UNSUPPORTED',
+      )
+    }
+  }
 }
 
 function normalizeApprovalGraph(
@@ -1034,6 +1157,11 @@ function normalizeApprovalGraph(
             context,
             `approvalGraph.nodes[${index}].config.fieldPermissions`,
           )
+          const timeout = normalizeNodeTimeout(
+            node.config.timeout,
+            context,
+            `approvalGraph.nodes[${index}].config.timeout`,
+          )
           normalizedNode.config = {
             ...(hasLegacyAssignees
               ? {
@@ -1046,6 +1174,7 @@ function normalizeApprovalGraph(
             ...(emptyAssigneePolicy ? { emptyAssigneePolicy } : {}),
             ...(autoApprovalPolicy ? { autoApprovalPolicy } : {}),
             ...(fieldPermissions ? { fieldPermissions } : {}),
+            ...(timeout ? { timeout } : {}),
           }
         }
         break
@@ -2397,6 +2526,7 @@ export class ApprovalProductService {
     validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
+    validateNodeTimeoutConfigs(approvalGraph)
 
     let client: ApprovalDbClient | null = null
     try {
@@ -2552,6 +2682,7 @@ export class ApprovalProductService {
         validateApprovalAssigneeSourcesAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateNodeFieldPermissionsAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateApprovalConditionFormulasAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
+        validateNodeTimeoutConfigs(nextApprovalGraph)
 
         const versionResult = await client.query<TemplateVersionRow>(
           `INSERT INTO approval_template_versions (template_id, version, status, form_schema, approval_graph)
@@ -2646,6 +2777,7 @@ export class ApprovalProductService {
         ? await fetchCuratedApprovalRoleIds(client.query.bind(client))
         : null
       validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT, curatedRoleIds)
+      validateNodeTimeoutConfigs(approvalGraph)
       // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
       // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
       // placeholder role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1899,6 +1899,16 @@ function getApprovalNodeConfig(runtimeGraph: RuntimeGraph, nodeKey: string): App
 }
 
 /**
+ * T1-1: the node-level timeout (if any) declared on the approval node being activated. Read from the
+ * runtime graph in scope so the activation site can stamp the deadline. `undefined` for nodes without
+ * a timeout (or non-approval nodes) — the activation site then clears the deadline columns.
+ */
+function nodeTimeoutForKey(runtimeGraph: RuntimeGraph, nodeKey: string): NodeTimeoutConfig | undefined {
+  const config = getApprovalNodeConfig(runtimeGraph, nodeKey) as { timeout?: NodeTimeoutConfig } | null
+  return config?.timeout ?? undefined
+}
+
+/**
  * True when any approval node's assignee sources include a management-chain source
  * (`continuous_managers` or `manager_at_level`). Used at create time to decide
  * whether to walk the (more expensive) management chain into the requester snapshot
@@ -3534,7 +3544,7 @@ export class ApprovalProductService {
       }
 
       if (resolution.currentNodeKey) {
-        this.emitNodeActivationMetric(id, resolution.currentNodeKey)
+        this.emitNodeActivationMetric(id, resolution.currentNodeKey, nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
       }
     } catch (error) {
       await rollbackQuietly(client)
@@ -3975,7 +3985,7 @@ export class ApprovalProductService {
         await client.query('COMMIT')
         this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
         if (resolution.currentNodeKey) {
-          this.emitNodeActivationMetric(id, resolution.currentNodeKey)
+          this.emitNodeActivationMetric(id, resolution.currentNodeKey, nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
         }
         return (await this.getApproval(id))!
       }
@@ -4305,7 +4315,7 @@ export class ApprovalProductService {
         emitApprovalCompletionEvent(completionEvent)
         this.emitTerminalMetric(id, 'approved')
       } else if (resolution.currentNodeKey && resolution.currentNodeKey !== currentNodeKey) {
-        this.emitNodeActivationMetric(id, resolution.currentNodeKey)
+        this.emitNodeActivationMetric(id, resolution.currentNodeKey, nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
       }
     } catch (error) {
       await rollbackQuietly(client)
@@ -4336,12 +4346,22 @@ export class ApprovalProductService {
     )
   }
 
-  private emitNodeActivationMetric(instanceId: string, nodeKey: string): void {
+  private emitNodeActivationMetric(instanceId: string, nodeKey: string, timeout?: NodeTimeoutConfig): void {
+    const activatedAt = new Date()
+    // T1-1: when the activating node declares a timeout, stamp its absolute deadline + effect so the
+    // SLA scanner can fire on it. No timeout → recordNodeActivation clears the columns (so the prior
+    // node's deadline can never linger). Still inside safeMetricsCall — a best-effort write.
     safeMetricsCall(`recordNodeActivation(${instanceId}/${nodeKey})`, () =>
       this.metrics.recordNodeActivation({
         instanceId,
         nodeKey,
-        activatedAt: new Date(),
+        activatedAt,
+        ...(timeout?.effect
+          ? {
+              timeoutDeadline: new Date(activatedAt.getTime() + timeout.afterMinutes * 60000),
+              timeoutEffect: timeout.effect,
+            }
+          : {}),
       }),
     )
   }

--- a/packages/core-backend/src/services/ApprovalSlaScheduler.ts
+++ b/packages/core-backend/src/services/ApprovalSlaScheduler.ts
@@ -9,6 +9,7 @@
 
 import { randomBytes } from 'crypto'
 import { Logger } from '../core/logger'
+import { pool as defaultPool } from '../db/pg'
 import { getRedisClient } from '../db/redis'
 import { RedisLeaderLock, type RedisLeaderLockClient } from '../multitable/redis-leader-lock'
 import { getApprovalMetricsService, type ApprovalMetricsService } from './ApprovalMetricsService'
@@ -28,7 +29,33 @@ export interface ApprovalSlaSchedulerOptions {
    * (notifications only); audit-event emission on breach is not yet wired.
    */
   onBreach?: (instanceIds: string[]) => Promise<void> | void
+  /**
+   * T1-1 node-level SLA: DB handle used to resolve a metrics row's active assignees for node-timeout
+   * reminders. Defaults to the shared internal pool; inject a fake in tests. `null` disables the
+   * assignee lookup (reminders fire with an empty recipient set).
+   */
+  pool?: ApprovalSlaSchedulerPool | null
+  /**
+   * T1-1 node-level SLA: dispatch a node-overdue reminder to the resolved active assignees. Wired in
+   * index.ts to `ApprovalBreachNotifier.notifyNodeReminder`. Absent → reminders are skipped (the
+   * timeout is still single-shot via `markNodeTimeoutFired`).
+   */
+  onNodeReminder?: (reminder: ApprovalNodeTimeoutReminder) => Promise<void> | void
   logger?: Logger
+}
+
+/** Minimal DB surface the scheduler needs for node-timeout assignee resolution (pg Pool satisfies it). */
+export interface ApprovalSlaSchedulerPool {
+  query<T extends Record<string, unknown> = { assignee_id: string }>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<{ rows: T[] }>
+}
+
+export interface ApprovalNodeTimeoutReminder {
+  instanceId: string
+  effect: string
+  assigneeIds: string[]
 }
 
 export interface ApprovalSlaSchedulerLeaderOptions {
@@ -61,6 +88,8 @@ export class ApprovalSlaScheduler {
   private readonly retryIntervalMs: number
   private readonly leaderStateGauge: ApprovalSlaSchedulerLeaderGauge | null
   private readonly onBreach: ApprovalSlaSchedulerOptions['onBreach']
+  private readonly pool: ApprovalSlaSchedulerPool | null
+  private readonly onNodeReminder: ApprovalSlaSchedulerOptions['onNodeReminder']
   private timer: NodeJS.Timeout | null = null
   private renewalTimer: NodeJS.Timeout | null = null
   private acquisitionTimer: NodeJS.Timeout | null = null
@@ -79,6 +108,9 @@ export class ApprovalSlaScheduler {
     this.retryIntervalMs = this.leaderOptions?.retryIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
     this.leaderStateGauge = options.runtime?.leaderStateGauge ?? null
     this.onBreach = options.onBreach
+    // `undefined` (option omitted) → shared pool; explicit `null` → no assignee lookup.
+    this.pool = options.pool === undefined ? defaultPool : options.pool
+    this.onNodeReminder = options.onNodeReminder
     this.logger = options.logger ?? new Logger('ApprovalSlaScheduler')
     if (this.leaderOptions) {
       this.setLeaderGauge('follower')
@@ -157,6 +189,9 @@ export class ApprovalSlaScheduler {
           }
         }
       }
+      // T1-1 node-level SLA: fire per-node timeout effects (slice 1: `remind` only). Isolated from the
+      // breach scan above so a node-timeout failure can never break the breach pipeline or the tick.
+      await this.fireNodeTimeouts(now)
       return breached
     } catch (error) {
       this.logger.error(`SLA tick failed: ${error instanceof Error ? error.message : String(error)}`)
@@ -164,6 +199,50 @@ export class ApprovalSlaScheduler {
     } finally {
       this.running = false
     }
+  }
+
+  /**
+   * T1-1 node-level SLA scan. For each metrics row whose current node has passed its deadline:
+   * resolve the node's active assignees and dispatch a node-overdue reminder (slice 1 wires `remind`
+   * only), then mark the timeout fired so it is strictly single-shot. Per-row isolation: a single
+   * failure (no assignees, dispatch error) leaves that row un-fired (retried next tick, at-least-once)
+   * and never breaks the rest of the batch or the tick.
+   */
+  private async fireNodeTimeouts(now: Date): Promise<void> {
+    let due: Array<{ instanceId: string; effect: string }> = []
+    try {
+      due = await this.metrics.scanNodeTimeouts(now)
+    } catch (error) {
+      this.logger.warn(`Node-timeout scan failed: ${error instanceof Error ? error.message : String(error)}`)
+      return
+    }
+    for (const row of due) {
+      try {
+        // Slice 1 wires `remind` only. Other effects can't be published yet (publish gate), so leave
+        // an unexpected row un-fired rather than silently consuming an effect we don't handle.
+        if (row.effect !== 'remind') continue
+        const assigneeIds = await this.resolveActiveAssignees(row.instanceId)
+        if (this.onNodeReminder) {
+          await this.onNodeReminder({ instanceId: row.instanceId, effect: row.effect, assigneeIds })
+        }
+        await this.metrics.markNodeTimeoutFired(row.instanceId)
+      } catch (error) {
+        this.logger.warn(
+          `Node-timeout remind failed for ${row.instanceId}: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
+    }
+  }
+
+  private async resolveActiveAssignees(instanceId: string): Promise<string[]> {
+    if (!this.pool) return []
+    const result = await this.pool.query<{ assignee_id: string }>(
+      `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND is_active = true`,
+      [instanceId],
+    )
+    return result.rows
+      .map((row) => row.assignee_id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0)
   }
 
   get leader(): boolean {

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -75,6 +75,15 @@ export interface ApprovalNode {
     | Record<string, never>
 }
 
+// T1-1 node-level SLA + timeout. The effect enum declares the full set; slice 1 wires `remind`
+// only (a notification, no state mutation) — transfer/jump/auto_* are rejected at publish until
+// their slice. `afterMinutes` = whole wall-clock minutes from the node's activation.
+export type NodeTimeoutEffect = 'remind' | 'transfer' | 'jump' | 'auto_approve' | 'auto_reject'
+export interface NodeTimeoutConfig {
+  afterMinutes: number
+  effect: NodeTimeoutEffect
+}
+
 export interface ApprovalNodeConfig {
   assigneeType?: ApprovalAssigneeType
   assigneeIds?: string[]
@@ -87,6 +96,8 @@ export interface ApprovalNodeConfig {
   // are inert (forward-stable contract only). Orthogonal to FormFieldVisibilityRule
   // (data-value-keyed); fieldPermissions is node-keyed.
   fieldPermissions?: NodeFieldPermission[]
+  // T1-1 node-level SLA: optional per-node timeout + effect (slice 1: remind only).
+  timeout?: NodeTimeoutConfig
 }
 
 export type ApprovalAssigneeSource =

--- a/packages/core-backend/tests/integration/approval-node-sla-remind.test.ts
+++ b/packages/core-backend/tests/integration/approval-node-sla-remind.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+import { ApprovalMetricsService } from '../../src/services/ApprovalMetricsService'
+import {
+  ApprovalSlaScheduler,
+  type ApprovalNodeTimeoutReminder,
+} from '../../src/services/ApprovalSlaScheduler'
+
+/**
+ * T1-1 node-level SLA (slice 1: `remind`) — real-DB proof of the scanner remind path and the
+ * activation-stamp idempotency invariant (P1a). The unit suite hand-feeds metrics; this asserts the
+ * real SQL wire: an overdue `current_node_deadline_at` row → resolve active assignees → reminder
+ * dispatched ONCE → `markNodeTimeoutFired` clears the deadline so the next scan is empty.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const SHOT_INSTANCE = `node-sla-shot-${TS}`
+const SHOT_ASSIGNEE = `node-sla-approver-${TS}`
+const IDEM_INSTANCE = `node-sla-idem-${TS}`
+
+function rawQuery<T extends Record<string, unknown> = Record<string, unknown>>(
+  sql: string,
+  params?: unknown[],
+): Promise<{ rows: T[]; rowCount?: number | null }> {
+  return poolManager.get().query<T>(sql, params) as unknown as Promise<{ rows: T[]; rowCount?: number | null }>
+}
+
+async function seedInstance(id: string, currentNodeKey: string | null): Promise<void> {
+  await rawQuery(
+    `INSERT INTO approval_instances (id, status, current_node_key)
+     VALUES ($1, 'pending', $2)
+     ON CONFLICT (id) DO NOTHING`,
+    [id, currentNodeKey],
+  )
+}
+
+describeIfDatabase('approval node-level SLA remind (T1-1 slice 1) — real DB', () => {
+  beforeAll(async () => {
+    await ensureApprovalSchemaReady()
+  })
+
+  afterAll(async () => {
+    // CASCADE from approval_instances clears approval_metrics + approval_assignments.
+    await rawQuery(`DELETE FROM approval_instances WHERE id = ANY($1)`, [[SHOT_INSTANCE, IDEM_INSTANCE]])
+  })
+
+  it('has DATABASE_URL configured (sentinel — never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('(a) single-shot: an overdue remind row notifies active assignees once, then the scan is empty', async () => {
+    const metrics = new ApprovalMetricsService(rawQuery)
+
+    await seedInstance(SHOT_INSTANCE, 'approval_1')
+    // An open node_breakdown entry + an overdue deadline (1 min in the past), effect remind, no SLA so
+    // the breach scan in tick() leaves this row alone.
+    await rawQuery(
+      `INSERT INTO approval_metrics
+         (instance_id, template_id, tenant_id, started_at, sla_hours, node_breakdown,
+          current_node_deadline_at, current_node_timeout_effect)
+       VALUES ($1, NULL, 'default', now() - INTERVAL '10 minutes', NULL, $2::jsonb,
+               now() - INTERVAL '1 minute', 'remind')`,
+      [
+        SHOT_INSTANCE,
+        JSON.stringify([
+          { nodeKey: 'approval_1', activatedAt: new Date(Date.now() - 600_000).toISOString(), decidedAt: null, durationSeconds: null, approverIds: [] },
+        ]),
+      ],
+    )
+    await rawQuery(
+      `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, is_active)
+       VALUES ($1, 'user', $2, TRUE)`,
+      [SHOT_INSTANCE, SHOT_ASSIGNEE],
+    )
+
+    const reminders: ApprovalNodeTimeoutReminder[] = []
+    const scheduler = new ApprovalSlaScheduler({
+      metrics,
+      pool: { query: rawQuery },
+      onNodeReminder: async (reminder) => {
+        reminders.push(reminder)
+      },
+    })
+
+    await scheduler.tick(new Date())
+
+    const forThisInstance = reminders.filter((r) => r.instanceId === SHOT_INSTANCE)
+    expect(forThisInstance).toHaveLength(1)
+    expect(forThisInstance[0].effect).toBe('remind')
+    expect(forThisInstance[0].assigneeIds).toContain(SHOT_ASSIGNEE)
+
+    // markNodeTimeoutFired cleared the deadline → a second scan must not return this instance.
+    const due2 = await metrics.scanNodeTimeouts(new Date())
+    expect(due2.find((d) => d.instanceId === SHOT_INSTANCE)).toBeUndefined()
+
+    const deadlineRow = await rawQuery<{ current_node_deadline_at: unknown }>(
+      `SELECT current_node_deadline_at FROM approval_metrics WHERE instance_id = $1`,
+      [SHOT_INSTANCE],
+    )
+    expect(deadlineRow.rows[0]?.current_node_deadline_at).toBeNull()
+
+    // A second tick fires no further reminder for this instance.
+    await scheduler.tick(new Date())
+    expect(reminders.filter((r) => r.instanceId === SHOT_INSTANCE)).toHaveLength(1)
+  })
+
+  it('(b) idempotency (P1a): re-activating an open node never overwrites the stamped deadline', async () => {
+    const metrics = new ApprovalMetricsService(rawQuery)
+    const D1 = new Date('2030-01-01T00:00:00.000Z')
+    const D2 = new Date('2030-06-01T00:00:00.000Z')
+
+    await seedInstance(IDEM_INSTANCE, 'approval_1')
+    await metrics.recordInstanceStart({
+      instanceId: IDEM_INSTANCE,
+      templateId: null,
+      startedAt: new Date(),
+      slaHours: null,
+      initialNodeKey: null,
+    })
+
+    // First activation of approval_1 → stamps D1 (no open entry yet → added).
+    await metrics.recordNodeActivation({
+      instanceId: IDEM_INSTANCE,
+      nodeKey: 'approval_1',
+      activatedAt: new Date(),
+      timeoutDeadline: D1,
+      timeoutEffect: 'remind',
+    })
+    // Re-activation of the SAME still-open node with a LATER deadline → no-op (open entry exists).
+    await metrics.recordNodeActivation({
+      instanceId: IDEM_INSTANCE,
+      nodeKey: 'approval_1',
+      activatedAt: new Date(),
+      timeoutDeadline: D2,
+      timeoutEffect: 'remind',
+    })
+    // Re-activation with NO timeout → must NOT clear the existing deadline (still an open entry).
+    await metrics.recordNodeActivation({
+      instanceId: IDEM_INSTANCE,
+      nodeKey: 'approval_1',
+      activatedAt: new Date(),
+    })
+
+    const row = await rawQuery<{ current_node_deadline_at: string | Date | null; current_node_timeout_effect: string | null }>(
+      `SELECT current_node_deadline_at, current_node_timeout_effect FROM approval_metrics WHERE instance_id = $1`,
+      [IDEM_INSTANCE],
+    )
+    const stored = row.rows[0]?.current_node_deadline_at
+    expect(stored).not.toBeNull()
+    expect(new Date(stored as string | Date).getTime()).toBe(D1.getTime())
+    expect(row.rows[0]?.current_node_timeout_effect).toBe('remind')
+  })
+})

--- a/packages/core-backend/tests/integration/approval-node-sla-remind.test.ts
+++ b/packages/core-backend/tests/integration/approval-node-sla-remind.test.ts
@@ -18,6 +18,8 @@ const TS = Date.now()
 const SHOT_INSTANCE = `node-sla-shot-${TS}`
 const SHOT_ASSIGNEE = `node-sla-approver-${TS}`
 const IDEM_INSTANCE = `node-sla-idem-${TS}`
+const FIRST_INSTANCE = `node-sla-first-${TS}`
+const FIRST_ASSIGNEE = `node-sla-first-approver-${TS}`
 
 function rawQuery<T extends Record<string, unknown> = Record<string, unknown>>(
   sql: string,
@@ -42,7 +44,7 @@ describeIfDatabase('approval node-level SLA remind (T1-1 slice 1) — real DB', 
 
   afterAll(async () => {
     // CASCADE from approval_instances clears approval_metrics + approval_assignments.
-    await rawQuery(`DELETE FROM approval_instances WHERE id = ANY($1)`, [[SHOT_INSTANCE, IDEM_INSTANCE]])
+    await rawQuery(`DELETE FROM approval_instances WHERE id = ANY($1)`, [[SHOT_INSTANCE, IDEM_INSTANCE, FIRST_INSTANCE]])
   })
 
   it('has DATABASE_URL configured (sentinel — never skip-green)', () => {
@@ -150,5 +152,57 @@ describeIfDatabase('approval node-level SLA remind (T1-1 slice 1) — real DB', 
     expect(stored).not.toBeNull()
     expect(new Date(stored as string | Date).getTime()).toBe(D1.getTime())
     expect(row.rows[0]?.current_node_timeout_effect).toBe('remind')
+  })
+
+  it('(c) first node: a `remind` timeout stamped at instance start (recordInstanceStart) fires once', async () => {
+    const metrics = new ApprovalMetricsService(rawQuery)
+
+    await seedInstance(FIRST_INSTANCE, 'approval_1')
+    // The FIRST node is activated through recordInstanceStart — NOT recordNodeActivation — so before
+    // T1-1 its deadline was never stamped and a first-node `remind` could never fire. Stamp it 1 min
+    // in the past via the changed method and prove the new instance-start columns are written + scanned.
+    await metrics.recordInstanceStart({
+      instanceId: FIRST_INSTANCE,
+      templateId: null,
+      startedAt: new Date(),
+      slaHours: null,
+      initialNodeKey: 'approval_1',
+      timeoutDeadline: new Date(Date.now() - 60_000),
+      timeoutEffect: 'remind',
+    })
+
+    // recordInstanceStart must persist the deadline columns at INSERT time (the fix).
+    const stamped = await rawQuery<{ current_node_deadline_at: unknown; current_node_timeout_effect: string | null }>(
+      `SELECT current_node_deadline_at, current_node_timeout_effect FROM approval_metrics WHERE instance_id = $1`,
+      [FIRST_INSTANCE],
+    )
+    expect(stamped.rows[0]?.current_node_deadline_at).not.toBeNull()
+    expect(stamped.rows[0]?.current_node_timeout_effect).toBe('remind')
+
+    await rawQuery(
+      `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, is_active)
+       VALUES ($1, 'user', $2, TRUE)`,
+      [FIRST_INSTANCE, FIRST_ASSIGNEE],
+    )
+
+    const reminders: ApprovalNodeTimeoutReminder[] = []
+    const scheduler = new ApprovalSlaScheduler({
+      metrics,
+      pool: { query: rawQuery },
+      onNodeReminder: async (reminder) => {
+        reminders.push(reminder)
+      },
+    })
+
+    await scheduler.tick(new Date())
+
+    const forThisInstance = reminders.filter((r) => r.instanceId === FIRST_INSTANCE)
+    expect(forThisInstance).toHaveLength(1)
+    expect(forThisInstance[0].effect).toBe('remind')
+    expect(forThisInstance[0].assigneeIds).toContain(FIRST_ASSIGNEE)
+
+    // Single-shot: markNodeTimeoutFired cleared the first-node deadline → a second tick fires nothing.
+    await scheduler.tick(new Date())
+    expect(reminders.filter((r) => r.instanceId === FIRST_INSTANCE)).toHaveLength(1)
   })
 })

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -67,10 +67,13 @@ describe('ApprovalMetricsService', () => {
   })
 
   describe('recordNodeActivation', () => {
-    it('appends a new open entry and skips when one already exists', async () => {
-      // First call: select current breakdown, then update.
+    it('appends a new open entry (plus a separate deadline write) and re-emit is a no-op', async () => {
+      // A NEW activation now issues three calls: SELECT current breakdown, the
+      // breakdown UPDATE, then the T1-1 best-effort deadline UPDATE — the last
+      // ONLY because a brand-new entry was added.
       queryMock
         .mockResolvedValueOnce({ rows: [{ node_breakdown: [] }] as Row[] })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
         .mockResolvedValueOnce({ rows: [], rowCount: 1 })
 
       await service.recordNodeActivation({
@@ -79,11 +82,22 @@ describe('ApprovalMetricsService', () => {
         activatedAt: new Date('2026-04-25T11:00:00Z'),
       })
 
-      expect(queryMock).toHaveBeenCalledTimes(2)
+      expect(queryMock).toHaveBeenCalledTimes(3)
       const updatePayload = JSON.parse(queryMock.mock.calls[1][1][1])
       expect(updatePayload).toHaveLength(1)
       expect(updatePayload[0]).toMatchObject({ nodeKey: 'approval_2', decidedAt: null })
+      // The deadline UPDATE is a SEPARATE best-effort write (NOT folded into the
+      // breakdown transaction). With no timeout on this activation it CLEARS both
+      // columns so the prior node's deadline can never linger on the new node.
+      const [deadlineSql, deadlineParams] = queryMock.mock.calls[2]
+      expect(normalize(deadlineSql)).toContain('UPDATE approval_metrics')
+      expect(normalize(deadlineSql)).toContain('SET current_node_deadline_at = $2')
+      expect(normalize(deadlineSql)).toContain('current_node_timeout_effect = $3')
+      expect(deadlineParams).toEqual(['apr-1', null, null])
 
+      // Re-emit with an existing open entry → mutate returns null, `added` stays
+      // false → NO breakdown UPDATE and crucially NO deadline UPDATE (this is the
+      // foundation's P1a idempotency guard locked at the unit level).
       queryMock.mockClear()
       queryMock.mockResolvedValueOnce({
         rows: [{ node_breakdown: [{ nodeKey: 'approval_2', activatedAt: 'x', decidedAt: null, durationSeconds: null, approverIds: [] }] }] as Row[],
@@ -93,7 +107,33 @@ describe('ApprovalMetricsService', () => {
         nodeKey: 'approval_2',
         activatedAt: new Date('2026-04-25T11:05:00Z'),
       })
+      // Only the SELECT (FOR UPDATE) ran — no deadline write was emitted.
       expect(queryMock).toHaveBeenCalledTimes(1)
+      expect(normalize(queryMock.mock.calls[0][0])).toContain('FOR UPDATE')
+    })
+
+    it('stamps the new node deadline + effect when the activation carries a timeout (T1-1 lock)', async () => {
+      queryMock
+        .mockResolvedValueOnce({ rows: [{ node_breakdown: [] }] as Row[] })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+
+      const deadline = new Date('2026-04-25T15:00:00Z')
+      await service.recordNodeActivation({
+        instanceId: 'apr-1',
+        nodeKey: 'approval_2',
+        activatedAt: new Date('2026-04-25T11:00:00Z'),
+        timeoutDeadline: deadline,
+        timeoutEffect: 'auto_reject',
+      })
+
+      // SELECT + breakdown UPDATE + the separate deadline UPDATE.
+      expect(queryMock).toHaveBeenCalledTimes(3)
+      const [deadlineSql, deadlineParams] = queryMock.mock.calls[2]
+      expect(normalize(deadlineSql)).toContain('UPDATE approval_metrics')
+      expect(normalize(deadlineSql)).toContain('SET current_node_deadline_at = $2')
+      expect(normalize(deadlineSql)).toContain('current_node_timeout_effect = $3')
+      expect(deadlineParams).toEqual(['apr-1', '2026-04-25T15:00:00.000Z', 'auto_reject'])
     })
 
     it('returns silently when the instance has no metrics row', async () => {
@@ -119,6 +159,8 @@ describe('ApprovalMetricsService', () => {
             ],
           }] as Row[],
         })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+        // T1-1: the separate deadline-clear UPDATE that follows the breakdown write.
         .mockResolvedValueOnce({ rows: [], rowCount: 1 })
 
       await service.recordNodeDecision({
@@ -170,14 +212,24 @@ describe('ApprovalMetricsService', () => {
       })
 
       expect(transaction).toHaveBeenCalledTimes(1)
-      expect(queryMock).not.toHaveBeenCalled()
+      // The breakdown read-modify-write stays fully inside the transaction…
       expect(calls).toEqual(['begin', 'select', 'update', 'commit'])
       expect(normalize(String(txQuery.mock.calls[0][0]))).toContain('FOR UPDATE')
+      // …while the T1-1 deadline-clear is a SEPARATE best-effort write issued via
+      // the plain (non-transactional) query runner — and it clears BOTH columns.
+      expect(queryMock).toHaveBeenCalledTimes(1)
+      const [clearSql, clearParams] = queryMock.mock.calls[0]
+      expect(normalize(clearSql)).toContain('UPDATE approval_metrics')
+      expect(normalize(clearSql)).toContain('current_node_deadline_at = NULL')
+      expect(normalize(clearSql)).toContain('current_node_timeout_effect = NULL')
+      expect(clearParams).toEqual(['apr-1'])
     })
 
     it('synthesizes a zero-duration entry when no matching open entry exists', async () => {
       queryMock
         .mockResolvedValueOnce({ rows: [{ node_breakdown: [] }] as Row[] })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+        // T1-1: the separate deadline-clear UPDATE that follows the breakdown write.
         .mockResolvedValueOnce({ rows: [], rowCount: 1 })
 
       await service.recordNodeDecision({
@@ -206,6 +258,9 @@ describe('ApprovalMetricsService', () => {
       const [sql, params] = queryMock.mock.calls[0]
       expect(normalize(sql)).toContain('UPDATE approval_metrics')
       expect(normalize(sql)).toContain('EXTRACT(EPOCH FROM ($2::timestamptz - started_at))')
+      // T1-1: terminal also clears the node-timeout deadline columns in the SAME update.
+      expect(normalize(sql)).toContain('current_node_deadline_at = NULL')
+      expect(normalize(sql)).toContain('current_node_timeout_effect = NULL')
       expect(params[2]).toBe('approved')
     })
   })

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1869,6 +1869,189 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  describe('T1-1 node-level SLA timeout (author / publish validation)', () => {
+    function timeoutRequest(timeout: unknown) {
+      return {
+        key: 'node-timeout-tpl',
+        name: 'Node Timeout Template',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'approval_1',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['manager-1'], timeout },
+            },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+            { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+          ],
+        },
+      }
+    }
+
+    function parallelTimeoutRequest(timeout: unknown) {
+      return {
+        key: 'node-timeout-parallel-tpl',
+        name: 'Node Timeout Parallel Template',
+        formSchema: { fields: [] },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'parallel_fork',
+              type: 'parallel',
+              config: { branches: ['edge-fork-a', 'edge-fork-b'], joinMode: 'all', joinNodeKey: 'end' },
+            },
+            {
+              key: 'branch_a',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['user-a'], timeout },
+            },
+            { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+            { key: 'edge-fork-a', source: 'parallel_fork', target: 'branch_a' },
+            { key: 'edge-fork-b', source: 'parallel_fork', target: 'branch_b' },
+            { key: 'edge-a-end', source: 'branch_a', target: 'end' },
+            { key: 'edge-b-end', source: 'branch_b', target: 'end' },
+          ],
+        },
+      }
+    }
+
+    function mockTemplateInsert() {
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 }
+        }
+        if (statement.startsWith('INSERT INTO approval_templates')) {
+          return {
+            rows: [{
+              id: 'tpl-node-timeout',
+              key: String(params?.[0]),
+              name: String(params?.[1]),
+              description: null,
+              category: null,
+              visibility_scope: JSON.parse(String(params?.[4])),
+              sla_hours: null,
+              status: 'draft',
+              active_version_id: null,
+              latest_version_id: null,
+              created_at: new Date('2026-06-29T00:00:00.000Z'),
+              updated_at: new Date('2026-06-29T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        if (statement.startsWith('INSERT INTO approval_template_versions')) {
+          return {
+            rows: [{
+              id: 'ver-node-timeout',
+              template_id: 'tpl-node-timeout',
+              version: 1,
+              status: 'draft',
+              form_schema: JSON.parse(String(params?.[1])),
+              approval_graph: JSON.parse(String(params?.[2])),
+              created_at: new Date('2026-06-29T00:00:00.000Z'),
+              updated_at: new Date('2026-06-29T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        if (statement.startsWith('UPDATE approval_templates')) {
+          return {
+            rows: [{
+              id: 'tpl-node-timeout',
+              key: 'node-timeout-tpl',
+              name: 'Node Timeout Template',
+              description: null,
+              category: null,
+              visibility_scope: { type: 'all', ids: [] },
+              sla_hours: null,
+              status: 'draft',
+              active_version_id: null,
+              latest_version_id: 'ver-node-timeout',
+              created_at: new Date('2026-06-29T00:00:00.000Z'),
+              updated_at: new Date('2026-06-29T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        throw new Error(`Unhandled query: ${statement}`)
+      })
+    }
+
+    it('rejects a non-integer afterMinutes before hitting the database', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        timeoutRequest({ afterMinutes: 1.5, effect: 'remind' }) as never,
+      )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_INVALID' })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('rejects a zero / negative afterMinutes', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        timeoutRequest({ afterMinutes: 0, effect: 'remind' }) as never,
+      )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_INVALID' })
+    })
+
+    it('rejects an afterMinutes above the cap', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        timeoutRequest({ afterMinutes: 100001, effect: 'remind' }) as never,
+      )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_INVALID' })
+    })
+
+    it('rejects an off-enum effect', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        timeoutRequest({ afterMinutes: 30, effect: 'escalate' }) as never,
+      )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_INVALID' })
+    })
+
+    it.each(['transfer', 'jump', 'auto_approve', 'auto_reject'])(
+      'rejects the unsupported (slice-1) effect %s',
+      async (effect) => {
+        const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+        const service = new ApprovalProductService()
+        await expect(service.createTemplate(
+          timeoutRequest({ afterMinutes: 30, effect }) as never,
+        )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED' })
+      },
+    )
+
+    it('rejects a timeout on a node inside a parallel region', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        parallelTimeoutRequest({ afterMinutes: 30, effect: 'remind' }) as never,
+      )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_PARALLEL_UNSUPPORTED' })
+    })
+
+    it('accepts a valid remind timeout and preserves it through normalization', async () => {
+      mockTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const result = await service.createTemplate(
+        timeoutRequest({ afterMinutes: 30, effect: 'remind' }) as never,
+      )
+      const node = result.approvalGraph.nodes.find((n) => n.key === 'approval_1')
+      expect((node?.config as Record<string, unknown>).timeout).toEqual({ afterMinutes: 30, effect: 'remind' })
+    })
+  })
+
   it('rejects empty assigneeSources and invalid form field sources before hitting the database', async () => {
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService()

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -43,6 +43,10 @@ export default defineConfig({
       // doesn't skip-green, and wired as a WHOLE FILE into the `Run approval real-DB integration`
       // step in plugin-tests.yml where it runs against real Postgres every PR.
       'tests/integration/approval-metrics-people-teams.test.ts',
+      // T1-1 node-level SLA remind (slice 1): DATABASE_URL-gated (describeIfDatabase). Excluded from the
+      // no-DB default job so it doesn't skip-green, and wired as a WHOLE FILE into the `Run approval
+      // real-DB integration` step in plugin-tests.yml where it runs against real Postgres every PR.
+      'tests/integration/approval-node-sla-remind.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
Ratified **Tier-1 T1-1, slice 1** — per-approval-node timeout deadline + a single-shot `remind` effect (notify the node's active assignees when their step is overdue). Built to the ratified defaults + your foundation-review fixes. Additive + best-effort (every metrics write is `safeMetricsCall` — a bug degrades gracefully, never breaks an approval flow).

## What (4 committed parts)
- **A** publish validation: `timeout` config validated at create/update/publish — `APPROVAL_NODE_TIMEOUT_INVALID` (bounds/off-enum), `APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED` (transfer/jump/auto_* — remind only this slice), **`APPROVAL_NODE_TIMEOUT_PARALLEL_UNSUPPORTED`** (your P1b — single scalar can't hold parallel deadlines, so v1 forbids node timeouts inside a parallel region; BFS-detected). **Also fixed a latent bug:** the node normalizer's strict whitelist was silently dropping `timeout` before publish/runtime — now carried.
- **B** stamp deadline at the 3 transition-activation sites (only on a *new* activation entry — your P1a).
- **C** scanner remind: `ApprovalSlaScheduler.tick` → `scanNodeTimeouts` → notify active assignees via a new dedicated `notifyNodeReminder` (does NOT touch breach idempotency) → `markNodeTimeoutFired`. Threaded via an `onNodeReminder` hook (mirrors `onBreach`).
- **D** real-DB test + CI-wiring (both `vitest.config.ts` exclude + the approval real-DB whole-file list).

## Review fixes folded in
P1a idempotency (re-emit no-op) · P1b parallel-forbid · P2 mark clears deadline+effect.

## Verification (real, post-rebase)
`tsc` 0 · validation unit **10 passed** · real-DB integration **3/3** (sentinel + single-shot + **idempotency-P1a**) · approval-product-service 87 · scheduler+notifier 23.

## ⚠️ One known limitation (your call — fix in this slice or a fast follow)
A `remind` on the **first** approval node won't fire: that node is activated via `recordInstanceStart` (instance creation), which isn't one of the 3 transition-activation stamping sites, so its deadline isn't stamped. Transition-reached nodes work. Covering the first node = extend `recordInstanceStart` to stamp the deadline (a focused follow-up). Flagged rather than rushed at depth; I'll add it on your word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)