### PR TITLE
feat(integration): C4 K3 BOM read runtime slice — k3wise.material-bom.v1 (#1709)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5572,6 +5572,36 @@ async function testReadSmokeRoute() {
                 },
               }
             }
+            if (req.options && req.options.k3ReadMode === 'bom') {
+              return {
+                records: [{ FNumber: 'M-BOM-CHILD-1' }, { FNumber: 'M-BOM-CHILD-2' }, { FNumber: 'M-BOM-CHILD-3' }],
+                metadata: {
+                  readPath: 'https://k3host/K3API/BOM/GetDetail',
+                  mode: 'material-bom-smoke',
+                  bomHeaderPresent: true,
+                  bomLinePresent: true,
+                  bomHeaderCount: 1,
+                  bomLineCount: 3,
+                  bomShapeProbe: {
+                    dataPage1: true,
+                    dataPage2: true,
+                    dataLowerPage1: false,
+                    dataLowerPage2: false,
+                    materialNumber: 'M-BOM-SECRET',
+                  },
+                  bomResponseShapeProbe: {
+                    dataObjectPresent: true,
+                    headerPresent: true,
+                    linePresent: true,
+                    fixedContainers: {
+                      dataPage1: { type: 'array', arrayLength: 1, materialNumber: 'M-BOM-HEADER-SECRET' },
+                      dataPage2: { type: 'array', arrayLength: 3, materialNumber: 'M-BOM-LINE-SECRET' },
+                      arbitraryContainer: { type: 'array', arrayLength: 9 },
+                    },
+                  },
+                },
+              }
+            }
             return {
               records: [{ _k3ReferenceObjects: { unit: {} }, FName: 'SECRET-NAME', FNumber: req.filters.FNumber }],
               metadata: { requestedNumber: req.filters.FNumber, readPath: 'https://k3host/x' },
@@ -5706,6 +5736,40 @@ async function testReadSmokeRoute() {
   assert.equal(keyedListReadArg.options[READ_SMOKE_LIST_REQUEST_MARKER], true, 'keyed LIST route supplies the internal route-only marker')
   assert.ok(!JSON.stringify(okListKey.body.data).includes('M-004'), 'LIST key is not echoed in values-free evidence')
 
+  // C4 BOM read (#1709): the route preserves values-free BOM evidence (header/line counts + Page1/Page2
+  // container types) end-to-end and drops leak-bait; the parent bill key is plumbed to the adapter as
+  // options.bomKey (bound value), never echoed in the evidence.
+  const okBom = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' }, query: { workspaceId: 'workspace_1' },
+    body: { presetId: 'k3wise.material-bom.v1', intent: { object: 'material-bom', mode: 'bom', key: 'BILL-001' } },
+  })
+  assertOkResponse(okBom, 200)
+  assert.equal(okBom.body.data.ok, true)
+  assert.equal(okBom.body.data.presetId, 'k3wise.material-bom.v1')
+  assert.equal(okBom.body.data.object, 'material-bom')
+  assert.equal(okBom.body.data.mode, 'bom')
+  assert.equal(okBom.body.data.recordCount, 3)
+  assert.equal(okBom.body.data.bomHeaderCount, 1)
+  assert.equal(okBom.body.data.bomLineCount, 3)
+  assert.deepEqual(okBom.body.data.bomShapeProbe, {
+    dataPage1: true,
+    dataPage2: true,
+    dataLowerPage1: false,
+    dataLowerPage2: false,
+  })
+  assert.deepEqual(okBom.body.data.bomResponseShapeProbe.fixedContainers, {
+    dataPage1: { type: 'array', arrayLength: 1 },
+    dataPage2: { type: 'array', arrayLength: 3 },
+  }, 'route preserves the BOM Page1/Page2 container types/counts and drops arbitrary containers + leak-bait')
+  const bomReadArg = readArgs[readArgs.length - 1]
+  assert.equal(bomReadArg.object, 'material-bom')
+  assert.equal(bomReadArg.options.k3ReadMode, 'bom')
+  assert.equal(bomReadArg.options.bomKey, 'BILL-001', 'route plumbs the parent bill key to the adapter as options.bomKey')
+  const okBomStr = JSON.stringify(okBom.body.data)
+  for (const leak of ['M-BOM-CHILD-1', 'M-BOM-SECRET', 'M-BOM-HEADER-SECRET', 'M-BOM-LINE-SECRET', 'BILL-001', 'materialNumber', 'arbitraryContainer', 'k3host', 'readPath']) {
+    assert.ok(!okBomStr.includes(leak), `BOM read-smoke response must not leak ${leak}`)
+  }
+
   // C2/C3: unauthorized LIST/BOM/raw fields fail closed before any system load.
   const systemLoadCountBeforeInvalid = findCalls(calls, 'getExternalSystemForAdapter').length
   const intentBom = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
@@ -5730,6 +5794,15 @@ async function testReadSmokeRoute() {
     body: { presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', key: '   ' } },
   })
   assert.equal(listBlankKey.statusCode, 400, 'blank LIST key is fail-closed')
+  // C4: BOM key is REQUIRED (unlike LIST). A no-key BOM intent fails closed at the contract layer with a 400,
+  // before any system load or adapter creation — values-free, no BOM call.
+  const bomNoKey = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-bom.v1', intent: { object: 'material-bom', mode: 'bom' } },
+  })
+  assert.equal(bomNoKey.statusCode, 400, 'BOM read without a parent bill key is fail-closed (key required)')
+  assert.equal(bomNoKey.body.error.code, 'READ_SMOKE_CONTRACT_INVALID', 'no-key BOM maps to the coarse contract-invalid code')
+  assert.equal(findCalls(calls, 'getExternalSystemForAdapter').length, systemLoadCountBeforeInvalid, 'no-key BOM fails before system load')
 
   // write-gated: a read-only integration user cannot trigger the credentialed probe (existence-oracle risk)
   const denied = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -2041,10 +2041,105 @@ async function testK3WebApiAutoFlagCoercion() {
   }
 }
 
+async function testK3WebApiMaterialBomReadSmoke() {
+  const { calls, fetchImpl } = createK3FetchMock()
+  const bomPreset = getReadSmokePreset('k3wise.material-bom.v1')
+  // Operator-confirmed live BOM/GetDetail shape (#1709): Data is an object with a header array Data.Page1
+  // and a sub-item line array Data.Page2 (no paging). Rows carry leak-bait VALUES to prove the route layer
+  // (read-smoke.test / http-routes.test) scrubs them; the adapter surfaces only counts/types/flags.
+  const bomCalls = []
+  const bomFetchImpl = async (url, options) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === '/K3API/BOM/GetDetail') {
+      bomCalls.push({ method: options.method, body: options.body ? JSON.parse(options.body) : undefined })
+      return jsonResponse(200, {
+        StatusCode: 200,
+        Message: 'BOM detail succeeded',
+        Data: {
+          Page1: [
+            { FBOMNumber: 'BOM-SECRET-001', FNumber: 'MAT-SECRET-PARENT', FVersion: 'V1' },
+          ],
+          Page2: [
+            { FNumber: 'MAT-SECRET-CHILD-1', FItemName: 'secret-name-1', FQty: 2 },
+            { FNumber: 'MAT-SECRET-CHILD-2', FItemName: 'secret-name-2', FQty: 5 },
+            { FNumber: 'MAT-SECRET-CHILD-3', FItemName: 'secret-name-3', FQty: 1 },
+          ],
+        },
+      })
+    }
+    return fetchImpl(url, options)
+  }
+  const adapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        objects: {
+          'material-bom': {
+            operations: ['read'],
+            readPath: '/K3API/BOM/GetDetail',
+            readMethod: 'POST',
+            readMode: 'bom',
+            readBomBodyTemplate: { Data: {} },
+            readBomBodyKey: 'Data',
+            readBomParentKeyField: 'FBillNo',
+          },
+        },
+      },
+    }),
+    fetchImpl: bomFetchImpl,
+  })
+
+  // Route-marker gating: a BOM read without the internal read-smoke marker is rejected before any K3 call.
+  const unmarked = await adapter.read({
+    object: 'material-bom',
+    options: { k3ReadMode: 'bom', bomKey: 'BOM-1' },
+  }).catch((error) => error)
+  assert.ok(unmarked instanceof AdapterValidationError, 'BOM read cannot be triggered outside the read-smoke route')
+  assert.equal(unmarked.details.code, 'K3_WISE_BOM_READ_ROUTE_UNSUPPORTED')
+  assert.equal(bomCalls.length, 0, 'unmarked BOM read fails before the K3 GetDetail call')
+
+  // O2 bound-value lock: feed a parent key containing a quote; it must reach the body verbatim, NOT escaped.
+  const read = await adapter.read(buildReadSmokeRequest(bomPreset, { object: 'material-bom', mode: 'bom', key: "BOM'1" }))
+
+  assert.equal(read.records.length, 3, 'BOM smoke returns the Data.Page2 line rows')
+  assert.equal(read.metadata.mode, 'material-bom-smoke')
+  assert.equal(read.metadata.readOnly, true)
+  assert.equal(read.metadata.returnedRecordCount, 3)
+  assert.equal(read.metadata.bomHeaderPresent, true)
+  assert.equal(read.metadata.bomLinePresent, true)
+  assert.equal(read.metadata.bomHeaderCount, 1, 'Data.Page1 header count surfaced (values-free)')
+  assert.equal(read.metadata.bomLineCount, 3, 'Data.Page2 line count surfaced (values-free)')
+  assert.equal(read.metadata.readPath, '/K3API/BOM/GetDetail')
+  assert.deepEqual(read.metadata.bomShapeProbe, {
+    dataPage1: true,
+    dataPage2: true,
+    dataLowerPage1: false,
+    dataLowerPage2: false,
+  })
+  assert.equal(read.metadata.bomResponseShapeProbe.dataObjectPresent, true)
+  assert.equal(read.metadata.bomResponseShapeProbe.headerPresent, true)
+  assert.equal(read.metadata.bomResponseShapeProbe.linePresent, true)
+  assert.deepEqual(read.metadata.bomResponseShapeProbe.fixedContainers, {
+    dataPage1: { type: 'array', arrayLength: 1 },
+    dataPage2: { type: 'array', arrayLength: 3 },
+    dataLowerPage1: { type: 'missing', arrayLength: null },
+    dataLowerPage2: { type: 'missing', arrayLength: null },
+    topLevel: { type: 'object', arrayLength: null },
+  }, 'BOM response-shape probe surfaces fixed container types/counts only')
+
+  assert.equal(bomCalls.length, 1, 'BOM smoke calls BOM/GetDetail exactly once (no recursion, no resolver fan-out)')
+  assert.equal(bomCalls[0].method, 'POST')
+  // THE O2 fix, locked: the parent bill key is a bound JSON value — quote preserved (not "BOM''1"), and the
+  // body carries nothing else (requiredFlags=[]; no Filter/Fields/escaping). A refactor that re-routes FBillNo
+  // through k3_freeform or adds flags fails here.
+  assert.deepEqual(bomCalls[0].body, { Data: { FBillNo: "BOM'1" } })
+}
+
 async function main() {
   await testK3WebApiAdapter()
   await testK3WebApiMaterialDetailReadSmoke()
   await testK3WebApiMaterialListReadSmoke()
+  await testK3WebApiMaterialBomReadSmoke()
   await testK3WebApiAuthorityCodeToken()
   await testK3WebApiSaveBusinessEvidence()
   await testK3WebApiNestedDataSaveParse()

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -18,6 +18,7 @@ const { READ_SMOKE_LIST_REQUEST_MARKER } = require(path.join(__dirname, '..', 'l
 
 const PRESET = getReadSmokePreset('k3wise.material-detail.v1')
 const LIST_PRESET = getReadSmokePreset('k3wise.material-list.v1')
+const BOM_PRESET = getReadSmokePreset('k3wise.material-bom.v1')
 
 // --- catalog (built-in only) ---
 assert.ok(PRESET, 'k3wise.material-detail.v1 is registered')
@@ -380,5 +381,132 @@ for (const leak of ['M-001', '42', 'failed with secret']) {
 const bare = readSmokeErrorEvidence(PRESET, {}, { object: 'material', mode: 'single_record_detail' })
 assert.equal(bare.errorCode, 'READ_SMOKE_READ_FAILED')
 assert.equal(bare.errorType, 'Error')
+
+// --- C4 BOM read (#1709): values-free BOM evidence sanitizer. Feed bomShapeProbe + bomResponseShapeProbe with
+// leak-bait values (material numbers, nested row payloads, arbitrary keys); the surfaced evidence must contain
+// ONLY allowlisted booleans/counts + per-container {type, arrayLength}, dropping every value.
+assert.ok(BOM_PRESET, 'k3wise.material-bom.v1 is registered')
+const bomEvidence = readSmokeSuccessEvidence(BOM_PRESET, {
+  records: [{ FNumber: 'SECRET-CHILD-1' }, { FNumber: 'SECRET-CHILD-2' }, { FNumber: 'SECRET-CHILD-3' }],
+  metadata: {
+    mode: 'material-bom-smoke',
+    bomHeaderPresent: true,
+    bomLinePresent: true,
+    bomHeaderCount: 1,
+    bomLineCount: 3,
+    bomShapeProbe: {
+      dataPage1: true,
+      dataPage2: true,
+      dataLowerPage1: false,
+      dataLowerPage2: false,
+      materialNumber: 'SECRET-BOM-001',
+    },
+    bomResponseShapeProbe: {
+      dataObjectPresent: true,
+      headerPresent: true,
+      linePresent: true,
+      arbitraryKeyName: 'SECRET-BOM-KEY',
+      fixedContainers: {
+        dataPage1: { type: 'array', arrayLength: 1, materialNumber: 'SECRET-BOM-002' },
+        dataPage2: { type: 'array', arrayLength: 3, rows: [{ materialNumber: 'SECRET-BOM-003' }] },
+        arbitraryContainer: { type: 'array', arrayLength: 99 },
+      },
+    },
+  },
+}, { object: 'material-bom', mode: 'bom' })
+assert.deepEqual(bomEvidence, {
+  ok: true,
+  presetId: 'k3wise.material-bom.v1',
+  object: 'material-bom',
+  mode: 'bom',
+  recordPresent: true,
+  recordCount: 3,
+  referenceObjectCount: 0,
+  bomHeaderPresent: true,
+  bomLinePresent: true,
+  bomHeaderCount: 1,
+  bomLineCount: 3,
+  bomShapeProbe: {
+    dataPage1: true,
+    dataPage2: true,
+    dataLowerPage1: false,
+    dataLowerPage2: false,
+  },
+  bomResponseShapeProbe: {
+    dataObjectPresent: true,
+    headerPresent: true,
+    linePresent: true,
+    fixedContainers: {
+      dataPage1: { type: 'array', arrayLength: 1 },
+      dataPage2: { type: 'array', arrayLength: 3 },
+    },
+  },
+})
+const bomEvidenceStr = JSON.stringify(bomEvidence)
+for (const leak of ['SECRET-CHILD-1', 'SECRET-CHILD-2', 'SECRET-CHILD-3', 'SECRET-BOM-001', 'SECRET-BOM-002', 'SECRET-BOM-003', 'SECRET-BOM-KEY', 'materialNumber', 'arbitraryKeyName', 'arbitraryContainer', 'rows']) {
+  assert.ok(!bomEvidenceStr.includes(leak), `BOM evidence must not leak ${leak}`)
+}
+
+// C4 BOM read (#1709): values-free BOM ERROR evidence — symmetric to the LIST error path. A failed BOM read
+// surfaces the coarse BOM code + presence/counts/shape from error.details, dropping every leak-bait value.
+const bomError = {
+  name: 'K3WiseWebApiAdapterError',
+  details: {
+    code: 'K3_WISE_BOM_READ_REJECTED',
+    bomHeaderPresent: true,
+    bomLinePresent: false,
+    bomHeaderCount: 1,
+    bomLineCount: 0,
+    bomShapeProbe: {
+      dataPage1: true,
+      dataPage2: false,
+      dataLowerPage1: false,
+      dataLowerPage2: false,
+      materialNumber: 'SECRET-BOM-ERR-001',
+    },
+    bomResponseShapeProbe: {
+      dataObjectPresent: true,
+      headerPresent: true,
+      linePresent: false,
+      arbitraryKeyName: 'SECRET-BOM-ERR-KEY',
+      fixedContainers: {
+        dataPage1: { type: 'array', arrayLength: 1, materialNumber: 'SECRET-BOM-ERR-002' },
+        dataPage2: { type: 'null', arrayLength: null },
+        arbitraryContainer: { type: 'array', arrayLength: 9 },
+      },
+    },
+  },
+}
+assert.deepEqual(readSmokeErrorEvidence(BOM_PRESET, bomError, { object: 'material-bom', mode: 'bom' }), {
+  ok: false,
+  presetId: 'k3wise.material-bom.v1',
+  object: 'material-bom',
+  mode: 'bom',
+  errorCode: 'K3_WISE_BOM_READ_REJECTED',
+  errorType: 'K3WiseWebApiAdapterError',
+  bomHeaderPresent: true,
+  bomLinePresent: false,
+  bomHeaderCount: 1,
+  bomLineCount: 0,
+  bomShapeProbe: {
+    dataPage1: true,
+    dataPage2: false,
+    dataLowerPage1: false,
+    dataLowerPage2: false,
+  },
+  bomResponseShapeProbe: {
+    dataObjectPresent: true,
+    headerPresent: true,
+    linePresent: false,
+    fixedContainers: {
+      dataPage1: { type: 'array', arrayLength: 1 },
+      dataPage2: { type: 'null', arrayLength: null },
+    },
+  },
+})
+const bomErrorStr = JSON.stringify(readSmokeErrorEvidence(BOM_PRESET, bomError, { object: 'material-bom', mode: 'bom' }))
+for (const leak of ['SECRET-BOM-ERR-001', 'SECRET-BOM-ERR-002', 'SECRET-BOM-ERR-KEY', 'materialNumber', 'arbitraryKeyName', 'arbitraryContainer']) {
+  assert.ok(!bomErrorStr.includes(leak), `BOM error evidence must not leak ${leak}`)
+}
 
 console.log('read-smoke.test.cjs OK')

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
@@ -252,8 +252,11 @@ function assertRelativeEndpoint(value, field) {
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
 }
 
-function normalizeSchema(schema, field) {
+function normalizeSchema(schema, field, allowEmpty = false) {
   if (!Array.isArray(schema) || schema.length === 0) {
+    // A write-capable object needs a schema to compose the Save body. A read-only object (C4 BOM read #1709)
+    // does not project to a schema (it returns raw rows), so an empty/missing schema is allowed for it.
+    if (allowEmpty) return []
     throw new Error(`${field}.schema must be a non-empty array`)
   }
   return schema.map((item, index) => {
@@ -267,18 +270,26 @@ function normalizeSchema(schema, field) {
 
 function normalizeTemplate(template, field) {
   if (!isPlainObject(template)) throw new Error(`${field} must be an object`)
-  const savePath = assertRelativeEndpoint(template.savePath || template.path, `${field}.savePath`)
+  const operations = Array.isArray(template.operations) && template.operations.length > 0
+    ? [...template.operations]
+    : ['upsert']
+  // A write-capable object (upsert) requires a Save endpoint. A read-only object (e.g. the C4 BOM read
+  // overlay #1709, operations:['read']) legitimately has none — and must NOT be given one, so it can never
+  // reach the Save path. Any savePath that IS supplied is still validated.
+  const rawSavePath = template.savePath || template.path
+  const savePath = operations.includes('upsert')
+    ? assertRelativeEndpoint(rawSavePath, `${field}.savePath`)
+    : (rawSavePath ? assertRelativeEndpoint(rawSavePath, `${field}.savePath`) : null)
   const normalized = {
     ...cloneJson(template),
-    savePath,
     bodyKey: typeof template.bodyKey === 'string' && template.bodyKey.trim()
       ? template.bodyKey.trim()
       : 'Data',
-    schema: normalizeSchema(template.schema, field),
-    operations: Array.isArray(template.operations) && template.operations.length > 0
-      ? [...template.operations]
-      : ['upsert'],
+    schema: normalizeSchema(template.schema, field, !operations.includes('upsert')),
+    operations,
   }
+  if (savePath !== null) normalized.savePath = savePath
+  else delete normalized.savePath
   if (template.submitPath) normalized.submitPath = assertRelativeEndpoint(template.submitPath, `${field}.submitPath`)
   if (template.auditPath) normalized.auditPath = assertRelativeEndpoint(template.auditPath, `${field}.auditPath`)
   if (template.readPath) normalized.readPath = assertRelativeEndpoint(template.readPath, `${field}.readPath`)

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -26,7 +26,7 @@ const {
   normalizeTemplate,
 } = require('./k3-wise-document-templates.cjs')
 const crypto = require('node:crypto')
-const { READ_SMOKE_LIST_REQUEST_MARKER } = require('../read-smoke-marker.cjs')
+const { READ_SMOKE_LIST_REQUEST_MARKER, READ_SMOKE_BOM_REQUEST_MARKER } = require('../read-smoke-marker.cjs')
 const { scrubSecretStringValue } = require('../payload-redaction.cjs')
 // DF-T1-0: single source of truth for Save-body composition, shared with the no-write
 // preview (http-routes.cjs). Placeholder detection (findUnfilledPlaceholders) is shared; the
@@ -44,6 +44,9 @@ class K3WiseWebApiAdapterError extends Error {
 
 const DEFAULT_OBJECTS = getK3WiseDocumentObjectDefaults()
 const DEFAULT_MATERIAL_LIST_MAX_LIMIT = 10
+// C4 BOM read (#1709): GetDetail has no paging, so a large bill returns every line. Bound the records we
+// retain and the line count we report so a values-free read-smoke stays bounded regardless of bill size.
+const DEFAULT_MATERIAL_BOM_MAX_LINES = 1000
 
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
@@ -626,6 +629,21 @@ function resolveMaterialReadMode(request, objectConfig) {
     }
     return mode
   }
+  if (mode === 'bom') {
+    if (request.options[READ_SMOKE_BOM_REQUEST_MARKER] !== true) {
+      throw new AdapterValidationError('K3 WISE BOM read is only available through the read-smoke route', {
+        code: 'K3_WISE_BOM_READ_ROUTE_UNSUPPORTED',
+        object: request.object,
+      })
+    }
+    if (configMode !== 'bom') {
+      throw new AdapterValidationError('K3 WISE BOM read requires a bom-mode object config', {
+        code: 'K3_WISE_BOM_READ_NOT_CONFIGURED',
+        object: request.object,
+      })
+    }
+    return mode
+  }
   throw new AdapterValidationError('K3 WISE Material read mode is not supported', {
     code: 'K3_WISE_READ_MODE_UNSUPPORTED',
     object: request.object,
@@ -677,6 +695,57 @@ function assertMaterialListReadOnlyScope(request, objectConfig) {
       object: request.object,
       limit: request.limit,
       maxLimit,
+    })
+  }
+}
+
+// C4 BOM read (#1709): read-only, single GetDetail call, preset-mediated parent bill key only. No
+// request-supplied filters/cursor/watermark/options, no resolver (the caller names the bill directly),
+// no recursion (one call). Mirrors the LIST scope guard but for the material-bom object.
+function assertMaterialBomReadOnlyScope(request) {
+  if (request.object !== 'material-bom') {
+    throw new UnsupportedAdapterOperationError('K3 WISE WebAPI read-only BOM supports only material-bom reads', {
+      kind: 'erp:k3-wise-webapi',
+      object: request.object,
+      operation: 'read',
+    })
+  }
+  if (request.cursor) {
+    throw new AdapterValidationError('K3 WISE BOM read does not support cursor pagination', {
+      code: 'K3_WISE_BOM_READ_CURSOR_UNSUPPORTED',
+      object: request.object,
+      field: 'cursor',
+    })
+  }
+  if (Object.keys(request.watermark || {}).length > 0) {
+    throw new AdapterValidationError('K3 WISE BOM read does not support watermark reads', {
+      code: 'K3_WISE_BOM_READ_WATERMARK_UNSUPPORTED',
+      object: request.object,
+      field: 'watermark',
+    })
+  }
+  if (Object.keys(request.filters || {}).length > 0) {
+    throw new AdapterValidationError('K3 WISE BOM read does not accept request-supplied filters', {
+      code: 'K3_WISE_BOM_READ_FILTER_UNSUPPORTED',
+      object: request.object,
+      fields: Object.keys(request.filters),
+    })
+  }
+  const allowedOptionKeys = new Set(['k3ReadMode', 'bomKey'])
+  const unknownOptions = Object.keys(request.options || {}).filter((key) => !allowedOptionKeys.has(key))
+  if (unknownOptions.length > 0) {
+    throw new AdapterValidationError('K3 WISE BOM read does not accept request-supplied options', {
+      code: 'K3_WISE_BOM_READ_OPTION_UNSUPPORTED',
+      object: request.object,
+      fields: unknownOptions,
+    })
+  }
+  const bomKey = typeof request.options.bomKey === 'string' ? request.options.bomKey.trim() : ''
+  if (!bomKey) {
+    throw new AdapterValidationError('K3 WISE BOM read requires a parent bill key', {
+      code: 'K3_WISE_BOM_READ_PARENT_KEY_INVALID',
+      object: request.object,
+      field: 'bomKey',
     })
   }
 }
@@ -921,6 +990,97 @@ function materialListBusinessFailureCode(data) {
     return 'K3_WISE_READ_LIST_REJECTED'
   }
   return 'K3_WISE_READ_LIST_ENVELOPE_UNRECOGNIZED'
+}
+
+// --- C4 BOM read (#1709). Operator-confirmed live shape: BOM/GetDetail POST returns a single object `Data`
+// with a header array `Data.Page1` and a sub-item line array `Data.Page2` (no paging). Case-aware candidates
+// from day one (the Data.Data vs Data.DATA lesson): confirmed PascalCase Page1/Page2 first, lowercase variants
+// as defensive fallbacks. Line/row VALUES are never surfaced — only counts/types/presence flags.
+
+function buildBomReadBody(request, objectConfig) {
+  const template = isPlainObject(objectConfig.readBomBodyTemplate)
+    ? cloneJson(objectConfig.readBomBodyTemplate)
+    : {}
+  const bodyKey = typeof objectConfig.readBomBodyKey === 'string' && objectConfig.readBomBodyKey.trim()
+    ? objectConfig.readBomBodyKey.trim()
+    : 'Data'
+  const parentKeyField = typeof objectConfig.readBomParentKeyField === 'string' && objectConfig.readBomParentKeyField.trim()
+    ? objectConfig.readBomParentKeyField.trim()
+    : 'FBillNo'
+  const container = isPlainObject(template[bodyKey]) ? template[bodyKey] : {}
+  // O2 (operator-confirmed): the parent bill key is a STRUCTURED JSON FIELD — a bound value, NOT embedded in a
+  // filter-expression string. It is assigned directly with NO k3_freeform / LIKE escaping: escaping a value
+  // that is not inside an expression would corrupt it. This is the validated O2-contingent encoding (#3399).
+  template[bodyKey] = {
+    ...container,
+    [parentKeyField]: String(request.options.bomKey),
+  }
+  return template
+}
+
+function bomHeaderRowsCandidate(data) {
+  const candidates = [getPath(data, 'Data.Page1'), getPath(data, 'Data.page1')]
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate.filter(isPlainObject).map((row) => cloneJson(row))
+  }
+  return null
+}
+
+function bomLineRowsCandidate(data) {
+  const candidates = [getPath(data, 'Data.Page2'), getPath(data, 'Data.page2')]
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate.filter(isPlainObject).map((row) => cloneJson(row))
+  }
+  return null
+}
+
+function bomShapeProbe(data) {
+  return {
+    dataPage1: Array.isArray(getPath(data, 'Data.Page1')),
+    dataPage2: Array.isArray(getPath(data, 'Data.Page2')),
+    dataLowerPage1: Array.isArray(getPath(data, 'Data.page1')),
+    dataLowerPage2: Array.isArray(getPath(data, 'Data.page2')),
+  }
+}
+
+const MATERIAL_BOM_RESPONSE_SHAPE_CONTAINER_PATHS = Object.freeze([
+  ['dataPage1', 'Data.Page1'],
+  ['dataPage2', 'Data.Page2'],
+  ['dataLowerPage1', 'Data.page1'],
+  ['dataLowerPage2', 'Data.page2'],
+  ['topLevel', ''],
+])
+
+function bomResponseShapeProbe(data) {
+  const fixedContainers = {}
+  for (const [key, path] of MATERIAL_BOM_RESPONSE_SHAPE_CONTAINER_PATHS) {
+    fixedContainers[key] = materialListShapeValueEvidence(path ? getPath(data, path) : data)
+  }
+  return {
+    dataObjectPresent: isPlainObject(getPath(data, 'Data')),
+    headerPresent: Array.isArray(getPath(data, 'Data.Page1')) || Array.isArray(getPath(data, 'Data.page1')),
+    linePresent: Array.isArray(getPath(data, 'Data.Page2')) || Array.isArray(getPath(data, 'Data.page2')),
+    fixedContainers,
+  }
+}
+
+function bomHeaderCount(data) {
+  return materialListArrayLength(bomHeaderRowsCandidate(data) || undefined)
+}
+
+function bomLineCount(data) {
+  return materialListArrayLength(bomLineRowsCandidate(data) || undefined)
+}
+
+function bomBusinessFailureCode(data) {
+  const statusCode = getStatusCode(data)
+  if (
+    hasExplicitBusinessFailure(data) ||
+    (statusCode !== null && (statusCode < 200 || statusCode >= 300))
+  ) {
+    return 'K3_WISE_BOM_READ_REJECTED'
+  }
+  return 'K3_WISE_BOM_READ_ENVELOPE_UNRECOGNIZED'
 }
 
 function buildMaterialReadRecord(detail, request, objectConfig) {
@@ -1471,6 +1631,79 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           dataPageIndex,
           listShapeProbe,
           responseShapeProbe,
+          readPath,
+          readOnly: true,
+        },
+      })
+    }
+
+    if (readMode === 'bom') {
+      assertMaterialBomReadOnlyScope(request)
+      const readPath = objectConfig.readPath
+        ? assertRelativePath(objectConfig.readPath, 'object.readPath')
+        : null
+      if (!readPath) {
+        throw new K3WiseWebApiAdapterError('K3 WISE BOM read endpoint is not configured for material-bom', {
+          code: 'K3_WISE_BOM_READ_NOT_CONFIGURED',
+          object: request.object,
+        })
+      }
+
+      const authContext = await login()
+      let readResponse
+      try {
+        readResponse = await requestJson(readPath, {
+          method: objectConfig.readMethod || 'POST',
+          query: authContext.query,
+          headers: authContext.headers,
+          body: buildBomReadBody(request, objectConfig),
+        })
+      } catch (error) {
+        throw new K3WiseWebApiAdapterError(`K3 WISE WebAPI BOM read failed: ${error && error.message ? error.message : String(error)}`, {
+          code: 'K3_WISE_BOM_READ_FAILED',
+          object: request.object,
+          status: error && error.status,
+          path: readPath,
+        })
+      }
+
+      const bomShape = bomShapeProbe(readResponse.data)
+      const bomHeaderPresent = bomShape.dataPage1 || bomShape.dataLowerPage1
+      const bomLinePresent = bomShape.dataPage2 || bomShape.dataLowerPage2
+      const headerCount = bomHeaderCount(readResponse.data)
+      const lineCount = bomLineCount(readResponse.data)
+      const bomResponseShape = bomResponseShapeProbe(readResponse.data)
+      if (!businessSuccess(readResponse.data, config)) {
+        const failureCode = bomBusinessFailureCode(readResponse.data)
+        throw new K3WiseWebApiAdapterError(String(responseMessage(readResponse.data, config, 'K3 WISE BOM read business response failed')), {
+          code: failureCode,
+          object: request.object,
+          responseCode: responseFailureCode(readResponse.data, config, failureCode),
+          bomHeaderPresent,
+          bomLinePresent,
+          bomHeaderCount: headerCount,
+          bomLineCount: lineCount,
+          bomShapeProbe: bomShape,
+          bomResponseShapeProbe: bomResponseShape,
+        })
+      }
+
+      // LIST records style (cloneJson rows, NO buildMaterialReadRecord / reference resolution) — keeps the
+      // no-resolver red line. Single GetDetail call above — no recursion. Records bounded by the line cap.
+      const records = (bomLineRowsCandidate(readResponse.data) || []).slice(0, DEFAULT_MATERIAL_BOM_MAX_LINES)
+      return createReadResult({
+        records,
+        raw: readResponse.data,
+        metadata: {
+          object: request.object,
+          mode: 'material-bom-smoke',
+          returnedRecordCount: records.length,
+          bomHeaderPresent,
+          bomLinePresent,
+          bomHeaderCount: headerCount,
+          bomLineCount: lineCount,
+          bomShapeProbe: bomShape,
+          bomResponseShapeProbe: bomResponseShape,
           readPath,
           readOnly: true,
         },

--- a/plugins/plugin-integration-core/lib/read-smoke-marker.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke-marker.cjs
@@ -4,6 +4,12 @@
 // request bodies, persisted adapter config, and source-action config cannot manufacture it.
 const READ_SMOKE_LIST_REQUEST_MARKER = Symbol('plugin-integration-core.read-smoke-list-request')
 
+// Internal-only marker for the C4 K3 BOM read-smoke route (#1709). Same Symbol discipline as the
+// LIST marker: BOM read is reachable ONLY through the credentialed read-smoke route, never from a
+// JSON request body, persisted adapter config, or source-action config.
+const READ_SMOKE_BOM_REQUEST_MARKER = Symbol('plugin-integration-core.read-smoke-bom-request')
+
 module.exports = {
   READ_SMOKE_LIST_REQUEST_MARKER,
+  READ_SMOKE_BOM_REQUEST_MARKER,
 }

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const { READ_SMOKE_LIST_REQUEST_MARKER } = require('./read-smoke-marker.cjs')
+const { READ_SMOKE_LIST_REQUEST_MARKER, READ_SMOKE_BOM_REQUEST_MARKER } = require('./read-smoke-marker.cjs')
 
 // #1709 follow-up: generic read-smoke preset catalog + values-free evidence helpers.
 // Registers ONLY built-in presets — there is no user/request-supplied preset path. The preset
@@ -66,6 +66,34 @@ const READ_SMOKE_PRESETS = Object.freeze({
           pageIndexField: 'PageIndex',
           pageSizeField: 'PageSize',
           maxListLimit: 10,
+        }),
+      }),
+    }),
+  }),
+  'k3wise.material-bom.v1': Object.freeze({
+    presetId: 'k3wise.material-bom.v1',
+    requiredKind: 'erp:k3-wise-webapi',
+    object: 'material-bom',
+    // C4 BOM read (#1709): explicit preset + explicit intent shape only. The parent bill key is the ONLY
+    // caller-supplied datum — a bound JSON value, never a filter expression (operator-confirmed O2). No
+    // recursion, no resolver, no write: the overlay creates a clean read-only `material-bom` object so
+    // ensureOperation gates it to read and it can never reach the existing write-only `bom` Save object.
+    allowedObjects: Object.freeze(['material-bom']),
+    allowedModes: Object.freeze(['bom']),
+    defaultObject: 'material-bom',
+    defaultMode: 'bom',
+    readConfigOverlay: Object.freeze({
+      objects: Object.freeze({
+        'material-bom': Object.freeze({
+          operations: Object.freeze(['read']),
+          readPath: '/K3API/BOM/GetDetail',
+          readMethod: 'POST',
+          readMode: 'bom',
+          readBomBodyTemplate: Object.freeze({
+            Data: Object.freeze({}),
+          }),
+          readBomBodyKey: 'Data',
+          readBomParentKeyField: 'FBillNo',
         }),
       }),
     }),
@@ -172,6 +200,59 @@ function readSmokeResponseShapeProbeEvidence(value) {
   return hasEvidence ? evidence : null
 }
 
+// C4 BOM read (#1709): values-free BOM shape evidence under DISTINCT keys (dataPage1/dataPage2 header+line
+// containers), so LIST/detail sanitization is untouched. Like LIST, surfaces only allowlisted booleans and
+// per-container {type, arrayLength} — never Page1/Page2 field keys or row values.
+const READ_SMOKE_BOM_SHAPE_PROBE_KEYS = Object.freeze([
+  'dataPage1',
+  'dataPage2',
+  'dataLowerPage1',
+  'dataLowerPage2',
+])
+
+function readSmokeBomShapeProbeEvidence(value) {
+  if (!isPlainObject(value)) return null
+  const evidence = {}
+  let hasEvidence = false
+  for (const key of READ_SMOKE_BOM_SHAPE_PROBE_KEYS) {
+    if (typeof value[key] !== 'boolean') continue
+    evidence[key] = value[key]
+    hasEvidence = true
+  }
+  return hasEvidence ? evidence : null
+}
+
+const READ_SMOKE_BOM_RESPONSE_SHAPE_CONTAINER_KEYS = Object.freeze([
+  'dataPage1',
+  'dataPage2',
+  'dataLowerPage1',
+  'dataLowerPage2',
+  'topLevel',
+])
+
+function readSmokeBomResponseShapeProbeEvidence(value) {
+  if (!isPlainObject(value)) return null
+  const evidence = {}
+  let hasEvidence = false
+  for (const key of ['dataObjectPresent', 'headerPresent', 'linePresent']) {
+    if (typeof value[key] !== 'boolean') continue
+    evidence[key] = value[key]
+    hasEvidence = true
+  }
+  if (isPlainObject(value.fixedContainers)) {
+    const fixedContainers = {}
+    for (const key of READ_SMOKE_BOM_RESPONSE_SHAPE_CONTAINER_KEYS) {
+      const container = readSmokeResponseShapeContainerEvidence(value.fixedContainers[key])
+      if (container) fixedContainers[key] = container
+    }
+    if (Object.keys(fixedContainers).length > 0) {
+      evidence.fixedContainers = fixedContainers
+      hasEvidence = true
+    }
+  }
+  return hasEvidence ? evidence : null
+}
+
 // C3 LIST paging echo (#1709): copy ONLY the allowlisted values-free count fields (K3-echoed page size/index +
 // our requested paging) from a metadata/details source onto the evidence. Non-negative integers only.
 const READ_SMOKE_LIST_PAGING_COUNT_KEYS = Object.freeze(['dataPageSize', 'dataPageIndex', 'requestedLimit', 'requestedPageIndex'])
@@ -225,6 +306,22 @@ function buildReadSmokeRequest(preset, contractOrKey) {
       enumerable: true,
     })
     if (contract.key !== undefined) request.options.listKey = contract.key
+    return request
+  }
+  if (mode === 'bom') {
+    // BOM read REQUIRES a parent bill key (you must name the bill). It is a bound value carried via the
+    // internal route marker + options.bomKey; the adapter assigns it to Data.FBillNo with no escaping.
+    if (contract.key === undefined || contract.key === null || String(contract.key).trim() === '') {
+      throw new ReadSmokeContractError('bom_key_required', 'BOM read requires a parent bill key')
+    }
+    const request = {
+      object,
+      options: { k3ReadMode: 'bom', bomKey: contract.key },
+    }
+    Object.defineProperty(request.options, READ_SMOKE_BOM_REQUEST_MARKER, {
+      value: true,
+      enumerable: true,
+    })
     return request
   }
   throw new ReadSmokeContractError('mode_not_allowed', 'mode is not allowlisted for this preset')
@@ -291,6 +388,18 @@ function readSmokeSuccessEvidence(preset, result, contract = {}) {
   if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
   const responseShapeProbe = readSmokeResponseShapeProbeEvidence(result && result.metadata && result.metadata.responseShapeProbe)
   if (responseShapeProbe) evidence.responseShapeProbe = responseShapeProbe
+  // C4 BOM read (#1709): values-free BOM evidence, guarded by presence so LIST/detail results are unchanged.
+  const metadata = result && result.metadata
+  if (metadata && typeof metadata.bomHeaderPresent === 'boolean') evidence.bomHeaderPresent = metadata.bomHeaderPresent
+  if (metadata && typeof metadata.bomLinePresent === 'boolean') evidence.bomLinePresent = metadata.bomLinePresent
+  const bomHeaderCount = readSmokeSafeCount(metadata && metadata.bomHeaderCount)
+  if (bomHeaderCount !== null) evidence.bomHeaderCount = bomHeaderCount
+  const bomLineCount = readSmokeSafeCount(metadata && metadata.bomLineCount)
+  if (bomLineCount !== null) evidence.bomLineCount = bomLineCount
+  const bomShapeProbe = readSmokeBomShapeProbeEvidence(metadata && metadata.bomShapeProbe)
+  if (bomShapeProbe) evidence.bomShapeProbe = bomShapeProbe
+  const bomResponseShapeProbe = readSmokeBomResponseShapeProbeEvidence(metadata && metadata.bomResponseShapeProbe)
+  if (bomResponseShapeProbe) evidence.bomResponseShapeProbe = bomResponseShapeProbe
   return evidence
 }
 
@@ -322,6 +431,20 @@ function readSmokeErrorEvidence(preset, error, contract = {}) {
   if (listShapeProbe) evidence.listShapeProbe = listShapeProbe
   const responseShapeProbe = readSmokeResponseShapeProbeEvidence(error && error.details && error.details.responseShapeProbe)
   if (responseShapeProbe) evidence.responseShapeProbe = responseShapeProbe
+  // C4 BOM read (#1709): surface values-free BOM presence/counts/shape from the error details too (symmetric
+  // to the LIST error path), so a failed keyed BOM rerun still shows where the read got to. Guarded by
+  // presence → LIST/detail error evidence is unchanged.
+  const details = error && error.details
+  if (details && typeof details.bomHeaderPresent === 'boolean') evidence.bomHeaderPresent = details.bomHeaderPresent
+  if (details && typeof details.bomLinePresent === 'boolean') evidence.bomLinePresent = details.bomLinePresent
+  const bomHeaderCount = readSmokeSafeCount(details && details.bomHeaderCount)
+  if (bomHeaderCount !== null) evidence.bomHeaderCount = bomHeaderCount
+  const bomLineCount = readSmokeSafeCount(details && details.bomLineCount)
+  if (bomLineCount !== null) evidence.bomLineCount = bomLineCount
+  const bomShapeProbe = readSmokeBomShapeProbeEvidence(details && details.bomShapeProbe)
+  if (bomShapeProbe) evidence.bomShapeProbe = bomShapeProbe
+  const bomResponseShapeProbe = readSmokeBomResponseShapeProbeEvidence(details && details.bomResponseShapeProbe)
+  if (bomResponseShapeProbe) evidence.bomResponseShapeProbe = bomResponseShapeProbe
   return evidence
 }
 


### PR DESCRIPTION
## What

C4 K3 **BOM read** runtime slice — preset `k3wise.material-bom.v1`. Owner-authorized as a separate opt-in after the GATE-front (#3399). **For your explicit merge GO — not auto-merged** (runtime on a customer's live ERP path).

## ⚠️ Cross-cutting change — flagging first

`k3-wise-document-templates.cjs`: `normalizeTemplate` / `normalizeSchema` **no longer require `savePath`/`schema` for read-only objects** (operations without `upsert`). **Write objects are unchanged** (still require both). This lets the BOM read object exist as a clean read-only object — and means it has **no Save endpoint**, so it structurally cannot Save (enforces the no-write red line). Full plugin CJS suite stays green (55/55) → no existing object regressed.

## Scope (exactly as authorized)

`k3wise.material-bom.v1` → POST `/K3API/BOM/GetDetail` → body `Data.FBillNo=<parentKey>` → parse `Data.Page1` header + `Data.Page2` lines → values-free read-smoke evidence. Built on the operator-confirmed live shape (#1709): `Data` object with header array `Data.Page1` and line array `Data.Page2`, no paging.

## Red lines (test-locked, not just asserted)

- **No recursion** — exactly one upstream call.
- **No resolver** — caller names the bill (`FBillNo`); `cloneJson` rows, no reference resolution.
- **No Save/Submit/Audit/write** — read-only object, no `savePath`.
- **No raw payload / row-value exposure** — sanitizer drops all values (leak scans in sanitizer + wire tests).
- **Bound `FBillNo`, no escaping** (operator-confirmed O2) — proven by asserting the request body is exactly `{Data:{FBillNo:"BOM'1"}}` (quote preserved, not `BOM''1`).
- **Key required** (unlike LIST) — a no-key BOM intent fails closed with **400** before any system load.

## Tests

adapter keystone (records=3, bound-value, route-marker gating, one call) · read-smoke sanitizer (values-free, leak-bait dropped) · http-routes wire (route preserves BOM evidence, drops leak-bait, plumbs `bomKey` without echo) · no-key BOM 400 fail-closed. Full plugin CJS suite **55/55**.

## Boundary

BOM runtime is reachable only through the credentialed read-smoke route (internal Symbol marker). No recursion, no resolver, no Save/Submit/Audit, no production write, no raw payload/row values. Recursive multi-level explosion and material→bill resolver remain separate gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)