### PR TITLE
feat(approval): T2-4 N-of-M threshold voting node mode (backend)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -338,6 +338,7 @@ jobs:
             tests/integration/approval-bridge-redaction-regression.test.ts \
             tests/integration/approval-metrics-people-teams.test.ts \
             tests/integration/approval-node-sla-remind.test.ts \
+            tests/integration/approval-nofm-threshold.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -1231,14 +1231,51 @@ export class ApprovalGraphExecutor {
     approvalConfig: ApprovalNodeConfig,
     sourceStep: number,
   ): ApprovalGraphAssignment[] {
-    if (this.options.assignmentResolver) {
-      return this.options.assignmentResolver({ nodeKey, sourceStep, config: approvalConfig })
+    const assignments: ApprovalGraphAssignment[] = this.options.assignmentResolver
+      ? this.options.assignmentResolver({ nodeKey, sourceStep, config: approvalConfig })
+      : (approvalConfig.assigneeIds ?? []).map((assigneeId) => ({
+          assignmentType: approvalConfig.assigneeType === 'role' ? 'role' : 'user',
+          assigneeId,
+          nodeKey,
+          sourceStep,
+        }))
+    this.assertThresholdReachable(nodeKey, approvalConfig, assignments)
+    return assignments
+  }
+
+  /**
+   * T2-4 N-of-M (门槛会签) fail-closed reachability check, run at the SAME concrete-assignment
+   * point where the empty-assignee policy fails closed (see `resolveAssignmentsForApprovalNode`
+   * callers). Publish-time validation only bounds `N <= M` for fully-static USER lists, where the
+   * distinct count is author-known; DYNAMIC / ROLE / manager sources resolve M at runtime, so the
+   * resolved set is re-checked here.
+   *
+   * A threshold node resolves APPROVED once N DISTINCT approver identities approve. Each resolved
+   * assignment slot is consumed by at most one approval (`deactivateActorAssignmentsAtNode`), so
+   * the distinct resolvable slots are an upper bound on the reachable distinct-approver count. If
+   * `N > distinct slots` the node could NEVER reach APPROVED: it would exhaust its assignments with
+   * the threshold still unmet and silently fall through to the completion path (a 3-of-2). Fail
+   * closed at resolution instead. Empty sets are intentionally skipped — the caller's
+   * `emptyAssigneePolicy` (auto-approve / reject) owns that case.
+   */
+  private assertThresholdReachable(
+    nodeKey: string,
+    approvalConfig: ApprovalNodeConfig,
+    assignments: ApprovalGraphAssignment[],
+  ): void {
+    if (normalizeApprovalMode(approvalConfig.approvalMode) !== 'threshold') return
+    if (assignments.length === 0) return
+    const threshold = this.getApprovalThreshold(nodeKey)
+    const distinctSlots = new Set(
+      assignments.map((assignment) => `${assignment.assignmentType}:${assignment.assigneeId}`),
+    ).size
+    if (threshold > distinctSlots) {
+      throw new ServiceError(
+        `Approval node ${nodeKey} requires ${threshold} distinct approver(s) but only ${distinctSlots} resolvable approver slot(s) were produced`,
+        422,
+        'APPROVAL_THRESHOLD_UNREACHABLE',
+        { nodeKey, threshold, resolvedApproverCount: distinctSlots },
+      )
     }
-    return (approvalConfig.assigneeIds ?? []).map((assigneeId) => ({
-      assignmentType: approvalConfig.assigneeType === 'role' ? 'role' : 'user',
-      assigneeId,
-      nodeKey,
-      sourceStep,
-    }))
   }
 }

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -103,7 +103,7 @@ export interface ApprovalGraphResolution {
    * Any-mode resolution carries `'any'`; all-mode carries `'all'` only when aggregation is complete
    * (the route short-circuits incomplete all-mode before calling `resolveAfterApprove`).
    */
-  aggregateMode: 'single' | 'all' | 'any' | null
+  aggregateMode: 'single' | 'all' | 'any' | 'threshold' | null
   /**
    * Indicates that the previous node's aggregation requirement is satisfied and resolution advanced.
    * Always `true` when `resolveAfterApprove` returns (incomplete aggregation never reaches here).
@@ -283,7 +283,7 @@ export function pruneHiddenFormData(
 }
 
 function normalizeApprovalMode(value: unknown): ApprovalMode {
-  return value === 'all' || value === 'any' || value === 'single' ? value : 'single'
+  return value === 'all' || value === 'any' || value === 'single' || value === 'threshold' ? value : 'single'
 }
 
 function evaluateRule(rule: ConditionRule, formData: Record<string, unknown>): boolean {
@@ -690,6 +690,17 @@ export class ApprovalGraphExecutor {
     return normalizeApprovalMode(this.getApprovalNodeConfig(nodeKey).approvalMode)
   }
 
+  /**
+   * T2-4 N-of-M threshold for a `'threshold'`-mode node: the number of DISTINCT approver
+   * identities required to resolve the node APPROVED. Defaults to 1 if absent/invalid — a
+   * published threshold graph always carries a publish-validated positive integer, so the
+   * fallback only guards against a hand-malformed runtime graph (never resolves on zero).
+   */
+  getApprovalThreshold(nodeKey: string): number {
+    const threshold = this.getApprovalNodeConfig(nodeKey).approvalThreshold
+    return typeof threshold === 'number' && Number.isInteger(threshold) && threshold >= 1 ? threshold : 1
+  }
+
   getApprovalNodeAssigneeIds(nodeKey: string): string[] {
     return [...(this.getApprovalNodeConfig(nodeKey).assigneeIds ?? [])]
   }
@@ -817,7 +828,7 @@ export class ApprovalGraphExecutor {
 
   private resolveFromNode(
     nodeKey: string,
-    context: { aggregateMode: 'single' | 'all' | 'any' | null; aggregateComplete: boolean },
+    context: { aggregateMode: 'single' | 'all' | 'any' | 'threshold' | null; aggregateComplete: boolean },
   ): ApprovalGraphResolution {
     const ccEvents: ApprovalCcEvent[] = []
     const autoApprovalEvents: ApprovalGraphAutoApprovalEvent[] = []

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1142,6 +1142,35 @@ function normalizeApprovalGraph(
             context,
             `approvalGraph.nodes[${index}].config.approvalMode`,
           )
+          // T2-4 N-of-M threshold (门槛会签). A 'threshold'-mode node requires a positive-integer
+          // approvalThreshold; when every approver is a static user id the distinct count M is known
+          // at author time, so bound 1 <= N <= M. Distinct ServiceError codes (not failValidation,
+          // which collapses to the shared graph-invalid code) so callers can branch on the cause.
+          let approvalThreshold: number | undefined
+          if (approvalMode === 'threshold') {
+            const rawThreshold = node.config.approvalThreshold
+            if (typeof rawThreshold !== 'number' || !Number.isInteger(rawThreshold) || rawThreshold < 1) {
+              throw new ServiceError(
+                `approvalGraph.nodes[${index}].config.approvalThreshold must be an integer >= 1 when approvalMode is 'threshold'`,
+                400,
+                'APPROVAL_THRESHOLD_INVALID',
+              )
+            }
+            approvalThreshold = rawThreshold
+            const staticUsersOnly = !assigneeSources && hasLegacyAssignees && node.config.assigneeType === 'user'
+            if (staticUsersOnly) {
+              const distinctAssignees = new Set(
+                (node.config.assigneeIds as string[]).map((entry) => entry.trim()),
+              ).size
+              if (approvalThreshold > distinctAssignees) {
+                throw new ServiceError(
+                  `approvalGraph.nodes[${index}].config.approvalThreshold (${approvalThreshold}) must not exceed the ${distinctAssignees} distinct static approver(s)`,
+                  400,
+                  'APPROVAL_THRESHOLD_OUT_OF_RANGE',
+                )
+              }
+            }
+          }
           const emptyAssigneePolicy = normalizeEmptyAssigneePolicy(
             node.config.emptyAssigneePolicy,
             context,
@@ -1171,6 +1200,7 @@ function normalizeApprovalGraph(
               : {}),
             ...(assigneeSources ? { assigneeSources } : {}),
             ...(approvalMode ? { approvalMode } : {}),
+            ...(approvalThreshold !== undefined ? { approvalThreshold } : {}),
             ...(emptyAssigneePolicy ? { emptyAssigneePolicy } : {}),
             ...(autoApprovalPolicy ? { autoApprovalPolicy } : {}),
             ...(fieldPermissions ? { fieldPermissions } : {}),
@@ -1393,7 +1423,20 @@ function collectBranchAssignees(
       )
     }
     if (node.type === 'approval') {
-      const approvalConfig = node.config as { assigneeIds?: string[]; assigneeSources?: ApprovalAssigneeSource[] }
+      const approvalConfig = node.config as {
+        assigneeIds?: string[]
+        assigneeSources?: ApprovalAssigneeSource[]
+        approvalMode?: ApprovalMode
+      }
+      // T2-4: threshold mode is linear-only in v1 — reject a 'threshold' approval node nested
+      // inside a parallel region (distinct ServiceError code, mirrors the nested-parallel guard).
+      if (approvalConfig.approvalMode === 'threshold') {
+        throw new ServiceError(
+          `approvalGraph node ${node.key} uses approvalMode 'threshold' inside a parallel region — threshold mode is linear-only in v1`,
+          400,
+          'APPROVAL_THRESHOLD_IN_PARALLEL',
+        )
+      }
       for (const assignee of approvalConfig.assigneeIds ?? []) {
         assignees.add(assignee)
       }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4188,6 +4188,19 @@ export class ApprovalProductService {
         // Deactivate the actor's own assignment first (whether or not the threshold is met).
         await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
         const remainingAssignments = currentNodeAssignments.length - actorAssignments.length
+        if (distinctApproverCount < threshold && remainingAssignments === 0) {
+          // Defensive fail-closed (should be unreachable — `assertThresholdReachable` rejects
+          // N > resolved-M at resolution time): the threshold is unmet but no pending siblings
+          // remain, so completing here would silently approve an N-of-M whose N exceeds the
+          // resolved M (a 3-of-2). NEVER silent-approve an unmet threshold — throw so the outer
+          // transaction handler rolls back the actor's just-deactivated assignment.
+          throw new ServiceError(
+            `Approval node ${currentNodeKey} threshold ${threshold} cannot be met — ${distinctApproverCount} distinct approval(s) recorded with no remaining approvers`,
+            422,
+            'APPROVAL_THRESHOLD_UNREACHABLE',
+            { instanceId: id, nodeKey: currentNodeKey, threshold, approvedCount: distinctApproverCount },
+          )
+        }
         if (distinctApproverCount < threshold && remainingAssignments > 0) {
           // Threshold not yet reached and still-pending siblings remain — record this partial
           // approval and keep the node pending (mirrors 'all' short-circuit; siblings stay active).

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -300,7 +300,7 @@ const DETAIL_LEAF_FIELD_TYPES = new Set(
 
 const APPROVAL_NODE_TYPES = new Set(['start', 'approval', 'cc', 'condition', 'parallel', 'end'])
 const CONDITION_OPERATORS = new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'isEmpty'])
-const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any'])
+const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any', 'threshold'])
 const PARALLEL_JOIN_MODES = new Set(['all', 'any'])
 const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve'])
 const AUTO_APPROVAL_ACTOR_MODES = new Set<AutoApprovalActorMode>(['system', 'original_approver'])
@@ -330,7 +330,7 @@ function isNonEmptyString(value: unknown): value is string {
 function normalizeApprovalMode(value: unknown, context: ValidationContext, path: string): ApprovalMode | undefined {
   if (value === undefined) return undefined
   if (typeof value !== 'string' || !APPROVAL_MODES.has(value as ApprovalMode)) {
-    failValidation(context, `${path} must be single, all, or any`)
+    failValidation(context, `${path} must be single, all, any, or threshold`)
   }
   return value as ApprovalMode
 }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2315,6 +2315,19 @@ export class ApprovalProductService {
           assignments: remainingAssignments,
         }
       }
+      // T2-4 threshold: dispatch-time auto-approvals count toward N (Q5). Hold the node pending
+      // with the still-manual assignees until the distinct auto-approver count reaches the
+      // threshold; only then fall through to resolveAfterApprove and advance past the node.
+      if (approvalMode === 'threshold' && remainingAssignments.length > 0) {
+        const threshold = executor.getApprovalThreshold(nodeKey)
+        const distinctAutoApprovers = new Set(evaluations.map((entry) => entry.assignment.assigneeId)).size
+        if (distinctAutoApprovers < threshold) {
+          return {
+            ...resolution,
+            assignments: remainingAssignments,
+          }
+        }
+      }
 
       const nextResolution = executor.resolveAfterApprove(nodeKey)
       autoSteps += nextResolution.autoApprovalEvents.length
@@ -4111,6 +4124,83 @@ export class ApprovalProductService {
             [id, currentNodeKey, actor.userId, siblingAssignments.map((assignment) => assignment.id)],
           )
         }
+      } else if (approvalMode === 'threshold') {
+        // T2-4 N-of-M (门槛会签): the node resolves APPROVED once `threshold` DISTINCT
+        // approver identities have approved. Count the approvers who have ALREADY recorded
+        // an approve at this node (excludes the current actor — their assignment is still
+        // active and no record exists yet), then add this one. DISTINCT actor_id dedupes
+        // across role rows / re-dispatch, and auto-approvals are included because they too
+        // write an action='approve' record carrying metadata.nodeKey (Q5).
+        const threshold = executor.getApprovalThreshold(currentNodeKey)
+        const priorApproversResult = await client.query<{ count: string }>(
+          `SELECT COUNT(DISTINCT actor_id) AS count
+             FROM approval_records
+             WHERE instance_id = $1
+               AND action = 'approve'
+               AND metadata->>'nodeKey' = $2`,
+          [id, currentNodeKey],
+        )
+        const priorDistinctApprovers = Number.parseInt(priorApproversResult.rows[0]?.count || '0', 10)
+        const distinctApproverCount = priorDistinctApprovers + 1
+        // Deactivate the actor's own assignment first (whether or not the threshold is met).
+        await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
+        const remainingAssignments = currentNodeAssignments.length - actorAssignments.length
+        if (distinctApproverCount < threshold && remainingAssignments > 0) {
+          // Threshold not yet reached and still-pending siblings remain — record this partial
+          // approval and keep the node pending (mirrors 'all' short-circuit; siblings stay active).
+          await client.query(
+            `UPDATE approval_instances
+             SET version = $2,
+                 updated_at = now()
+             WHERE id = $1`,
+            [id, nextVersion],
+          )
+          await this.insertApprovalRecord(client, id, {
+            action: 'approve',
+            actorId: actor.userId,
+            actorName,
+            comment: request.comment || null,
+            fromStatus: instance.status,
+            toStatus: instance.status,
+            fromVersion: instance.version,
+            toVersion: nextVersion,
+            metadata: {
+              nodeKey: currentNodeKey,
+              nextNodeKey: currentNodeKey,
+              approvalMode,
+              aggregateComplete: false,
+              approvalThreshold: threshold,
+              approvedCount: distinctApproverCount,
+              remainingAssignments,
+            },
+          }, actor)
+          await client.query('COMMIT')
+          return (await this.getApproval(id))!
+        }
+        // Threshold reached on THIS approval (first-N-wins) — cancel the remaining pending
+        // siblings, reusing the 'any' first-wins sibling-cancel path + audit metadata.
+        const siblingAssignments = currentNodeAssignments.filter((assignment) =>
+          !assignmentMatchesActor(assignment, actor.userId, actorRoles))
+        aggregateCancelledAssigneeIds = Array.from(
+          new Set(siblingAssignments.map((assignment) => assignment.assignee_id)),
+        )
+        if (siblingAssignments.length > 0) {
+          await client.query(
+            `UPDATE approval_assignments
+             SET is_active = FALSE,
+                 metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+                   'aggregateCancelledBy', $3::text,
+                   'aggregateCancelledAt', now()::text,
+                   'aggregateMode', 'threshold'
+                 ),
+                 updated_at = now()
+             WHERE instance_id = $1
+               AND node_key = $2
+               AND is_active = TRUE
+               AND id = ANY($4::uuid[])`,
+            [id, currentNodeKey, actor.userId, siblingAssignments.map((assignment) => assignment.id)],
+          )
+        }
       } else {
         // Single-approver mode. In parallel state the blanket
         // `deactivateAllActiveAssignments` would cancel sibling branches'
@@ -4247,7 +4337,10 @@ export class ApprovalProductService {
           approveRecordMetadata.parallelCancelledAssignees = parallelCancelledAssigneeIds
         }
       }
-      if (approvalMode === 'any' && aggregateCancelledAssigneeIds.length > 0) {
+      if (approvalMode === 'threshold') {
+        approveRecordMetadata.approvalThreshold = executor.getApprovalThreshold(currentNodeKey)
+      }
+      if ((approvalMode === 'any' || approvalMode === 'threshold') && aggregateCancelledAssigneeIds.length > 0) {
         approveRecordMetadata.aggregateCancelled = aggregateCancelledAssigneeIds
       }
       await this.insertApprovalRecord(client, id, {
@@ -4261,7 +4354,7 @@ export class ApprovalProductService {
         toVersion: nextVersion,
         metadata: approveRecordMetadata,
       }, actor)
-      if (approvalMode === 'any' && aggregateCancelledAssigneeIds.length > 0) {
+      if ((approvalMode === 'any' || approvalMode === 'threshold') && aggregateCancelledAssigneeIds.length > 0) {
         // One 'sign' audit row describing the aggregation cancellation — lets the timeline UI
         // render a muted "已被 {approver} 的决定覆盖" line without mining assignment metadata.
         await this.insertApprovalRecord(client, id, {
@@ -4276,7 +4369,7 @@ export class ApprovalProductService {
           metadata: {
             nodeKey: currentNodeKey,
             autoCancelled: true,
-            aggregateMode: 'any',
+            aggregateMode: approvalMode,
             aggregateCancelledBy: actor.userId,
             cancelledAssignees: aggregateCancelledAssigneeIds,
           },

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -10,7 +10,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
 export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level'
-export type ApprovalMode = 'single' | 'all' | 'any'
+export type ApprovalMode = 'single' | 'all' | 'any' | 'threshold'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
 export type ApprovalActionType =
@@ -89,6 +89,15 @@ export interface ApprovalNodeConfig {
   assigneeIds?: string[]
   assigneeSources?: ApprovalAssigneeSource[]
   approvalMode?: ApprovalMode
+  /**
+   * T2-4 N-of-M threshold (门槛会签). Only meaningful when `approvalMode === 'threshold'`:
+   * the node resolves APPROVED once `approvalThreshold` DISTINCT approver identities have
+   * approved (M = the baked assignee count). Validated at publish as a positive integer and,
+   * when every approver is a static user id, bounded `1 <= approvalThreshold <= distinct(assigneeIds)`.
+   * Threshold mode is linear-only in v1 (rejected inside a parallel region). Lives in node-config
+   * JSON — no SQL migration.
+   */
+  approvalThreshold?: number
   emptyAssigneePolicy?: EmptyAssigneePolicy
   autoApprovalPolicy?: AutoApprovalPolicy
   // P1-C node-level field permissions. Default-absent === editable === current

--- a/packages/core-backend/tests/integration/approval-nofm-threshold.test.ts
+++ b/packages/core-backend/tests/integration/approval-nofm-threshold.test.ts
@@ -1,0 +1,362 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+type JsonRecord = Record<string, unknown>
+
+type ApprovalRecordRow = {
+  action: string
+  actor_id: string | null
+  to_status: string
+  metadata: JsonRecord
+}
+
+type ApprovalAssignmentRow = {
+  assignee_id: string
+  is_active: boolean
+  metadata: JsonRecord | null
+}
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: {
+    method?: string
+    body?: unknown
+  } = {},
+) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+  return response
+}
+
+function buildFormSchema() {
+  return {
+    fields: [
+      {
+        id: 'reason',
+        type: 'text',
+        label: '事由',
+        required: true,
+      },
+    ],
+  }
+}
+
+// T2-4: a single approval node with three baked assignees (M=3) and threshold N=2.
+// The node resolves APPROVED on the 2nd distinct approval; the 3rd assignee is cancelled.
+function buildThresholdGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_threshold',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a', 'approver-b', 'approver-c'],
+          approvalMode: 'threshold',
+          approvalThreshold: 2,
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-threshold', source: 'start', target: 'approval_threshold' },
+      { key: 'edge-threshold-end', source: 'approval_threshold', target: 'end' },
+    ],
+  }
+}
+
+describeIfDatabase('Approval T2-4 N-of-M threshold (门槛会签) API', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+
+  beforeAll(async () => {
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+
+    await ensureApprovalSchemaReady()
+
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [],
+    })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool.query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+    } catch {
+      // Ignore cleanup failures — the top-level describe restart clears everything on rerun.
+    }
+
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  async function publishThresholdTemplate(adminToken: string): Promise<string> {
+    const templateKey = `approval-t24-threshold-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Threshold Mode Template',
+        description: 'approvalMode=threshold (N-of-M) integration',
+        formSchema: buildFormSchema(),
+        approvalGraph: buildThresholdGraph(),
+      },
+    })
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status).toBe(200)
+    return template.id
+  }
+
+  it('resolves a threshold (2-of-3) node on the SECOND distinct approval and cancels the third assignee', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-threshold')
+    const requesterToken = await authToken(baseUrl, 'requester-threshold')
+    const approverAToken = await authToken(baseUrl, 'approver-a')
+    const approverBToken = await authToken(baseUrl, 'approver-b')
+    const approverCToken = await authToken(baseUrl, 'approver-c')
+
+    const templateId = await publishThresholdTemplate(adminToken)
+
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: {
+        templateId,
+        formData: { reason: 'threshold request' },
+      },
+    })
+    expect(createResponse.status).toBe(201)
+    const createdApproval = await createResponse.json() as {
+      id: string
+      status: string
+      currentNodeKey: string | null
+      assignments: Array<{ assigneeId: string; isActive: boolean; nodeKey?: string | null }>
+    }
+    createdApprovalIds.add(createdApproval.id)
+    expect(createdApproval.status).toBe('pending')
+    expect(createdApproval.currentNodeKey).toBe('approval_threshold')
+    expect(
+      createdApproval.assignments
+        .filter((assignment) => assignment.isActive)
+        .map((assignment) => assignment.assigneeId)
+        .sort(),
+    ).toEqual(['approver-a', 'approver-b', 'approver-c'])
+
+    // FIRST approval (approver-a): threshold (2) not yet met → node stays pending, siblings active.
+    const firstApprove = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, approverAToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'approver-a (1 of 2)' },
+    })
+    expect(firstApprove.status).toBe(200)
+    const afterFirst = await firstApprove.json() as {
+      status: string
+      currentNodeKey: string | null
+      assignments: Array<{ assigneeId: string; isActive: boolean }>
+    }
+    expect(afterFirst.status).toBe('pending')
+    expect(afterFirst.currentNodeKey).toBe('approval_threshold')
+    expect(
+      afterFirst.assignments
+        .filter((assignment) => assignment.isActive)
+        .map((assignment) => assignment.assigneeId)
+        .sort(),
+    ).toEqual(['approver-b', 'approver-c'])
+
+    // SECOND distinct approval (approver-b): threshold met → APPROVED, approver-c cancelled.
+    const secondApprove = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, approverBToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'approver-b (2 of 2)' },
+    })
+    expect(secondApprove.status).toBe(200)
+    const afterSecond = await secondApprove.json() as {
+      status: string
+      currentNodeKey: string | null
+      assignments: Array<{ assigneeId: string; isActive: boolean }>
+    }
+    expect(afterSecond.status).toBe('approved')
+    expect(afterSecond.currentNodeKey).toBeNull()
+    expect(afterSecond.assignments.filter((assignment) => assignment.isActive)).toHaveLength(0)
+
+    const pool = poolManager.get()
+    const assignmentResult = await pool.query<ApprovalAssignmentRow>(
+      `SELECT assignee_id, is_active, metadata
+       FROM approval_assignments
+       WHERE instance_id = $1
+       ORDER BY assignee_id ASC`,
+      [createdApproval.id],
+    )
+    // approver-c's still-pending assignment is cancelled the moment the Nth (2nd) approval lands.
+    const approverCRow = assignmentResult.rows.find((row) => row.assignee_id === 'approver-c')
+    expect(approverCRow).toBeTruthy()
+    expect(approverCRow?.is_active).toBe(false)
+    expect(approverCRow?.metadata).toMatchObject({
+      aggregateCancelledBy: 'approver-b',
+      aggregateMode: 'threshold',
+    })
+    expect(typeof (approverCRow?.metadata as JsonRecord | undefined)?.aggregateCancelledAt).toBe('string')
+
+    // The two approvers' own rows are deactivated WITHOUT the sibling-cancel metadata.
+    const approverARow = assignmentResult.rows.find((row) => row.assignee_id === 'approver-a')
+    expect(approverARow?.is_active).toBe(false)
+    expect((approverARow?.metadata as JsonRecord | undefined)?.aggregateCancelledBy).toBeUndefined()
+    const approverBRow = assignmentResult.rows.find((row) => row.assignee_id === 'approver-b')
+    expect(approverBRow?.is_active).toBe(false)
+    expect((approverBRow?.metadata as JsonRecord | undefined)?.aggregateCancelledBy).toBeUndefined()
+
+    // Two approve records: approver-a partial (aggregateComplete false) + approver-b complete.
+    const approveRecordsResult = await pool.query<ApprovalRecordRow>(
+      `SELECT action, actor_id, to_status, metadata
+       FROM approval_records
+       WHERE instance_id = $1 AND action = 'approve'
+       ORDER BY to_version ASC, created_at ASC`,
+      [createdApproval.id],
+    )
+    expect(approveRecordsResult.rows).toHaveLength(2)
+    expect(approveRecordsResult.rows[0]?.actor_id).toBe('approver-a')
+    expect(approveRecordsResult.rows[0]?.to_status).toBe('pending')
+    expect(approveRecordsResult.rows[0]?.metadata).toMatchObject({
+      nodeKey: 'approval_threshold',
+      approvalMode: 'threshold',
+      aggregateComplete: false,
+      approvalThreshold: 2,
+      approvedCount: 1,
+    })
+    expect(approveRecordsResult.rows[1]?.actor_id).toBe('approver-b')
+    expect(approveRecordsResult.rows[1]?.to_status).toBe('approved')
+    expect(approveRecordsResult.rows[1]?.metadata).toMatchObject({
+      nodeKey: 'approval_threshold',
+      nextNodeKey: null,
+      approvalMode: 'threshold',
+      aggregateComplete: true,
+      approvalThreshold: 2,
+      aggregateCancelled: ['approver-c'],
+    })
+
+    // One system 'sign' audit row records the threshold-driven sibling cancellation.
+    const signRecordsResult = await pool.query<ApprovalRecordRow>(
+      `SELECT action, actor_id, to_status, metadata
+       FROM approval_records
+       WHERE instance_id = $1 AND action = 'sign'
+       ORDER BY created_at ASC`,
+      [createdApproval.id],
+    )
+    expect(signRecordsResult.rows).toHaveLength(1)
+    expect(signRecordsResult.rows[0]?.actor_id).toBe('system')
+    expect(signRecordsResult.rows[0]?.metadata).toMatchObject({
+      nodeKey: 'approval_threshold',
+      autoCancelled: true,
+      aggregateMode: 'threshold',
+      aggregateCancelledBy: 'approver-b',
+      cancelledAssignees: ['approver-c'],
+    })
+
+    // approver-c attempting to approve afterward is rejected — their active assignment is gone.
+    const lateApprove = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, approverCToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'too late' },
+    })
+    expect(lateApprove.status).toBe(403)
+    const errorPayload = await lateApprove.json() as { error?: { code?: string } }
+    expect(errorPayload.error?.code).toBe('APPROVAL_ASSIGNMENT_REQUIRED')
+  })
+
+  it('still REJECTS the whole instance on a single reject (destructive path unchanged)', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-threshold-rej')
+    const requesterToken = await authToken(baseUrl, 'requester-threshold-rej')
+    const approverAToken = await authToken(baseUrl, 'approver-a')
+
+    const templateId = await publishThresholdTemplate(adminToken)
+
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: {
+        templateId,
+        formData: { reason: 'threshold reject request' },
+      },
+    })
+    expect(createResponse.status).toBe(201)
+    const createdApproval = await createResponse.json() as { id: string; status: string }
+    createdApprovalIds.add(createdApproval.id)
+    expect(createdApproval.status).toBe('pending')
+
+    // A single reject terminates the instance — no N-of-M counting on the destructive path.
+    const rejectResponse = await jsonRequest(baseUrl, `/api/approvals/${createdApproval.id}/actions`, approverAToken, {
+      method: 'POST',
+      body: { action: 'reject', comment: 'one reject ends it' },
+    })
+    expect(rejectResponse.status).toBe(200)
+    const rejected = await rejectResponse.json() as {
+      status: string
+      currentNodeKey: string | null
+      assignments: Array<{ assigneeId: string; isActive: boolean }>
+    }
+    expect(rejected.status).toBe('rejected')
+    expect(rejected.currentNodeKey).toBeNull()
+    expect(rejected.assignments.filter((assignment) => assignment.isActive)).toHaveLength(0)
+
+    const pool = poolManager.get()
+    const activeAfterReject = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`,
+      [createdApproval.id],
+    )
+    expect(Number.parseInt(activeAfterReject.rows[0]?.count || '0', 10)).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/integration/approval-nofm-threshold.test.ts
+++ b/packages/core-backend/tests/integration/approval-nofm-threshold.test.ts
@@ -96,6 +96,34 @@ function buildThresholdGraph() {
   }
 }
 
+// T2-4 P1 semantic-hole regression: a ROLE source resolves only M=2 distinct approver slots
+// but the node config demands N=3. Publish-time validation only bounds N <= M for the fully-
+// static USER case, so this graph publishes; the N > M must be caught FAIL-CLOSED when the
+// assignments are RESOLVED at create — never silently approved once the 2 slots are exhausted
+// with the 3rd approval impossible.
+function buildUnreachableThresholdGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_threshold',
+        type: 'approval',
+        config: {
+          assigneeType: 'role',
+          assigneeIds: ['role-reviewers', 'role-leads'], // M = 2 distinct role slots
+          approvalMode: 'threshold',
+          approvalThreshold: 3, // N = 3 > M = 2
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-threshold', source: 'start', target: 'approval_threshold' },
+      { key: 'edge-threshold-end', source: 'approval_threshold', target: 'end' },
+    ],
+  }
+}
+
 describeIfDatabase('Approval T2-4 N-of-M threshold (门槛会签) API', () => {
   let server: MetaSheetServer | undefined
   let baseUrl = ''
@@ -143,7 +171,7 @@ describeIfDatabase('Approval T2-4 N-of-M threshold (门槛会签) API', () => {
     }
   })
 
-  async function publishThresholdTemplate(adminToken: string): Promise<string> {
+  async function publishGraphTemplate(adminToken: string, approvalGraph: object): Promise<string> {
     const templateKey = `approval-t24-threshold-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
     const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
       method: 'POST',
@@ -152,7 +180,7 @@ describeIfDatabase('Approval T2-4 N-of-M threshold (门槛会签) API', () => {
         name: 'Threshold Mode Template',
         description: 'approvalMode=threshold (N-of-M) integration',
         formSchema: buildFormSchema(),
-        approvalGraph: buildThresholdGraph(),
+        approvalGraph,
       },
     })
     expect(templateResponse.status).toBe(201)
@@ -165,6 +193,10 @@ describeIfDatabase('Approval T2-4 N-of-M threshold (门槛会签) API', () => {
     })
     expect(publishResponse.status).toBe(200)
     return template.id
+  }
+
+  async function publishThresholdTemplate(adminToken: string): Promise<string> {
+    return publishGraphTemplate(adminToken, buildThresholdGraph())
   }
 
   it('resolves a threshold (2-of-3) node on the SECOND distinct approval and cancels the third assignee', async () => {
@@ -358,5 +390,42 @@ describeIfDatabase('Approval T2-4 N-of-M threshold (门槛会签) API', () => {
       [createdApproval.id],
     )
     expect(Number.parseInt(activeAfterReject.rows[0]?.count || '0', 10)).toBe(0)
+  })
+
+  it('FAILS CLOSED at resolution when threshold N exceeds the resolved approver count (N > M)', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-threshold-nm')
+    const requesterToken = await authToken(baseUrl, 'requester-threshold-nm')
+
+    // Publish SUCCEEDS: publish-time N <= M validation only covers fully-static USER lists, so a
+    // 2-role / threshold-3 node passes authoring. This is exactly the P1 semantic hole — a
+    // DYNAMIC/ROLE source whose resolved M is never re-checked against N.
+    const templateId = await publishGraphTemplate(adminToken, buildUnreachableThresholdGraph())
+
+    // createApproval resolves the role source to M=2 distinct slots < threshold N=3. It MUST fail
+    // closed at resolution rather than create a node that silently approves once its 2 assignments
+    // are exhausted (the 3rd distinct approval being impossible). Against the pre-fix code this
+    // returns 201 and creates a node that would silent-approve a 3-of-2 — the assertion goes RED.
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: {
+        templateId,
+        formData: { reason: 'unreachable threshold request' },
+      },
+    })
+    expect(createResponse.status).toBe(422)
+    const errorPayload = await createResponse.json() as { id?: string; error?: { code?: string } }
+    if (errorPayload.id) {
+      createdApprovalIds.add(errorPayload.id)
+    }
+    expect(errorPayload.error?.code).toBe('APPROVAL_THRESHOLD_UNREACHABLE')
+
+    // Fail-closed-at-resolution means no instance was ever inserted (the throw fires before the
+    // create transaction begins) — so the unmet threshold can never be silently approved later.
+    const pool = poolManager.get()
+    const leakedInstances = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM approval_instances WHERE template_id = $1`,
+      [templateId],
+    )
+    expect(Number.parseInt(leakedInstances.rows[0]?.count || '0', 10)).toBe(0)
   })
 })

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -5216,4 +5216,135 @@ describe('ApprovalProductService', () => {
       statement.startsWith("UPDATE approval_templates SET status = 'published'"))).toBe(false)
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
+
+  describe('T2-4 threshold (N-of-M) mode publish validation', () => {
+    const createTemplate = async (request: unknown) => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      return new ApprovalProductService().createTemplate(request as never)
+    }
+
+    const thresholdGraph = (approvalConfig: Record<string, unknown>) => ({
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_threshold', type: 'approval', config: approvalConfig },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-threshold', source: 'start', target: 'approval_threshold' },
+        { key: 'edge-threshold-end', source: 'approval_threshold', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    })
+
+    const baseRequest = (graph: Record<string, unknown>) => ({
+      key: 'threshold-tpl',
+      name: 'Threshold Tpl',
+      visibilityScope: { type: 'all', ids: [] },
+      formSchema: { fields: [{ id: 'reason', type: 'text', label: '事由', required: true }] },
+      approvalGraph: graph,
+    })
+
+    it('rejects a threshold node whose N exceeds the distinct static approver count', async () => {
+      // N=4 against 3 distinct static users → out of range.
+      await expect(createTemplate(baseRequest(thresholdGraph({
+        assigneeType: 'user',
+        assigneeIds: ['u-a', 'u-b', 'u-c'],
+        approvalMode: 'threshold',
+        approvalThreshold: 4,
+      })))).rejects.toMatchObject({
+        code: 'APPROVAL_THRESHOLD_OUT_OF_RANGE',
+        statusCode: 400,
+      })
+    })
+
+    it('rejects a threshold node with a non-positive / non-integer threshold', async () => {
+      await expect(createTemplate(baseRequest(thresholdGraph({
+        assigneeType: 'user',
+        assigneeIds: ['u-a', 'u-b'],
+        approvalMode: 'threshold',
+        approvalThreshold: 0,
+      })))).rejects.toMatchObject({
+        code: 'APPROVAL_THRESHOLD_INVALID',
+        statusCode: 400,
+      })
+
+      await expect(createTemplate(baseRequest(thresholdGraph({
+        assigneeType: 'user',
+        assigneeIds: ['u-a', 'u-b'],
+        approvalMode: 'threshold',
+        approvalThreshold: 1.5,
+      })))).rejects.toMatchObject({
+        code: 'APPROVAL_THRESHOLD_INVALID',
+        statusCode: 400,
+      })
+
+      // 'threshold' mode with no approvalThreshold at all is also rejected.
+      await expect(createTemplate(baseRequest(thresholdGraph({
+        assigneeType: 'user',
+        assigneeIds: ['u-a', 'u-b'],
+        approvalMode: 'threshold',
+      })))).rejects.toMatchObject({
+        code: 'APPROVAL_THRESHOLD_INVALID',
+        statusCode: 400,
+      })
+    })
+
+    it('rejects a threshold node nested inside a parallel region (linear-only in v1)', async () => {
+      const parallelGraph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['edge-fork-a', 'edge-fork-b'], joinNodeKey: 'join', joinMode: 'all' } },
+          // A VALID threshold (2 of 2) so the per-node range check passes and the dedicated
+          // parallel-region guard is the failure that fires.
+          { key: 'branch_a', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['p-a1', 'p-a2'], approvalMode: 'threshold', approvalThreshold: 2 } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['p-b1'] } },
+          { key: 'join', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-fork', source: 'start', target: 'fork' },
+          { key: 'edge-fork-a', source: 'fork', target: 'branch_a' },
+          { key: 'edge-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'edge-a-join', source: 'branch_a', target: 'join' },
+          { key: 'edge-b-join', source: 'branch_b', target: 'join' },
+        ],
+        policy: { allowRevoke: true },
+      }
+      await expect(createTemplate(baseRequest(parallelGraph))).rejects.toMatchObject({
+        code: 'APPROVAL_THRESHOLD_IN_PARALLEL',
+        statusCode: 400,
+      })
+    })
+
+    it('accepts a valid linear threshold (2-of-3) node and round-trips approvalThreshold', async () => {
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const s = normalize(sql)
+        if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (s.startsWith('INSERT INTO approval_templates')) {
+          return { rows: [{ id: 'tpl-t', key: String(params?.[0]), name: String(params?.[1]), description: null, category: null, visibility_scope: JSON.parse(String(params?.[4])), sla_hours: null, status: 'draft', active_version_id: null, latest_version_id: null, created_at: new Date('2026-06-30T00:00:00.000Z'), updated_at: new Date('2026-06-30T00:00:00.000Z') }], rowCount: 1 }
+        }
+        if (s.startsWith('INSERT INTO approval_template_versions')) {
+          return { rows: [{ id: 'ver-t', template_id: 'tpl-t', version: 1, status: 'draft', form_schema: JSON.parse(String(params?.[1])), approval_graph: JSON.parse(String(params?.[2])), created_at: new Date('2026-06-30T00:00:00.000Z'), updated_at: new Date('2026-06-30T00:00:00.000Z') }], rowCount: 1 }
+        }
+        if (s.startsWith('UPDATE approval_templates')) {
+          return { rows: [{ id: 'tpl-t', key: 'threshold-tpl', name: 'Threshold Tpl', description: null, category: null, visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft', active_version_id: null, latest_version_id: 'ver-t', created_at: new Date('2026-06-30T00:00:00.000Z'), updated_at: new Date('2026-06-30T00:00:00.000Z') }], rowCount: 1 }
+        }
+        throw new Error(`Unhandled query: ${s}`)
+      })
+
+      const result = await createTemplate(baseRequest(thresholdGraph({
+        assigneeType: 'user',
+        assigneeIds: ['u-a', 'u-b', 'u-c'],
+        approvalMode: 'threshold',
+        approvalThreshold: 2,
+      })))
+      const node = result.approvalGraph.nodes.find((n) => n.key === 'approval_threshold')
+      expect((node?.config as { approvalMode?: string }).approvalMode).toBe('threshold')
+      expect((node?.config as { approvalThreshold?: number }).approvalThreshold).toBe(2)
+
+      const insertVersionCall = pgState.client.query.mock.calls.find(([sql]) =>
+        normalize(sql as string).startsWith('INSERT INTO approval_template_versions'))
+      const persistedGraph = JSON.parse(String(insertVersionCall?.[1]?.[2]))
+      expect(persistedGraph.nodes[1].config.approvalThreshold).toBe(2)
+    })
+  })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
       // no-DB default job so it doesn't skip-green, and wired as a WHOLE FILE into the `Run approval
       // real-DB integration` step in plugin-tests.yml where it runs against real Postgres every PR.
       'tests/integration/approval-node-sla-remind.test.ts',
+      // T2-4 N-of-M threshold (门槛会签): DATABASE_URL-gated (describeIfDatabase). Excluded from the
+      // no-DB default job so it doesn't skip-green, and wired as a WHOLE FILE into the
+      // `Run approval real-DB integration` step in plugin-tests.yml where it runs against real Postgres.
+      'tests/integration/approval-nofm-threshold.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
Ratified **Tier-1 T2-4** — adds a `threshold` approval-node mode (N-of-M / 门槛会签) alongside `single`/`all`/`any`. Backend-only (contract + publish-validation + dispatch runtime; authored via template JSON/API, exactly as `all`/`any` shipped backend-first). **No SQL migration** (mode lives in node-config JSON).

## Built to the ratified defaults
- **N = distinct approver identities** (deduped across role rows / re-dispatch); M = baked assignee count.
- **First-N-wins**: the node resolves approved the moment the Nth distinct approval lands; remaining pending assignees are cancelled (reuses the existing `'any'` sibling-cancel path).
- **Single reject still rejects** the whole instance — the destructive path is **unchanged** (no new counting on reject).
- **Auto-approvals count** toward N (they write an approve record / deactivate an assignment).
- **Linear-only in v1** — `threshold` rejected at publish inside a parallel region (deferred like the other parallel restrictions).
- Config: `'threshold'` added to `ApprovalMode` + aggregate-mode unions + `APPROVAL_MODES` + a numeric `approvalThreshold` on the node config.

## Verification (real)
`tsc` 0 · publish-validation unit tests **4 new** (N>distinct → reject, non-positive/non-integer → reject, parallel-region → reject, valid 2-of-3 round-trips) within 81 passing · **real-DB integration 2/2**: a 2-of-3 node resolves approved on the **2nd** distinct approval and **cancels the 3rd assignee**; a **single reject still rejects** the instance. CI-wired into both `vitest.config.ts` exclude + the approval real-DB whole-file list.

This is the 4th and final ratified Tier-1 rung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)