### PR TITLE
feat(attendance): AE-2 notify corrected employee

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -27,7 +27,7 @@
     "test:unit": "vitest run tests/unit --reporter=dot",
     "test:integration": "vitest --config vitest.integration.config.ts run tests/integration --reporter=dot",
     "test:integration:after-sales": "vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot",
-    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts tests/integration/attendance-comp-time-expiry-reminder.test.ts tests/integration/attendance-shift-swap.test.ts tests/integration/attendance-schedule-dispatch.test.ts --reporter=dot",
+    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts tests/integration/attendance-comp-time-expiry-reminder.test.ts tests/integration/attendance-shift-swap.test.ts tests/integration/attendance-schedule-dispatch.test.ts tests/integration/attendance-result-edit.test.ts --reporter=dot",
     "test:contract": "vitest run tests/contract --reporter=dot",
     "test:e2e:handoff": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:cache": "npm run build:cache && TEST_USE_DIST=true vitest --config vitest.cache.config.ts run --reporter=dot",

--- a/packages/core-backend/tests/integration/attendance-result-edit.test.ts
+++ b/packages/core-backend/tests/integration/attendance-result-edit.test.ts
@@ -5,6 +5,11 @@ import net from 'net'
 import http from 'http'
 import { randomUUID } from 'crypto'
 import { Pool } from 'pg'
+import {
+  AttendanceNotificationDeliveryWorker,
+  DeterministicFakeAttendanceDeliveryChannel,
+  type AttendanceNotificationDeliveryQuery,
+} from '../../src/services/AttendanceNotificationDeliveryWorker'
 
 // AE-1 — audited admin correction of a confirmed attendance anomaly result (design-lock
 // attendance-anomaly-result-edit-guard-design-lock-20260626, RATIFIED 2026-06-27). Route-level real-DB tests
@@ -75,6 +80,7 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   let baseUrl = ''
   let pool: Pool
   let adminToken = ''
+  let previousDefaultNotificationChannel: string | undefined
 
   const authHeaders = (token: string) => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' })
 
@@ -162,6 +168,16 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   async function auditByKey(orgId: string, key: string) {
     return (await pool.query(`SELECT * FROM attendance_record_result_edits WHERE org_id = $1 AND idempotency_key = $2`, [orgId, key])).rows as any[]
   }
+  async function deliveryRowsForRecord(recordId: string, orgId = ORG) {
+    return (await pool.query(
+      `SELECT * FROM attendance_notification_deliveries
+        WHERE org_id = $1
+          AND source_type = 'attendance_result_edit'
+          AND source_key LIKE $2
+        ORDER BY created_at ASC`,
+      [orgId, `attendance_result_edit:${orgId}:${recordId}:%`],
+    )).rows as any[]
+  }
   async function seedClosedCycle(workDate: string, status: 'closed' | 'archived', org = ORG): Promise<string> {
     const start = new Date(new Date(`${workDate}T00:00:00Z`).getTime() - 5 * 86400000).toISOString().slice(0, 10)
     const end = new Date(new Date(`${workDate}T00:00:00Z`).getTime() + 5 * 86400000).toISOString().slice(0, 10)
@@ -228,6 +244,8 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     process.env.DATABASE_URL = dbUrl
     process.env.RBAC_BYPASS = 'true'
     process.env.SKIP_PLUGINS = 'false'
+    previousDefaultNotificationChannel = process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
+    delete process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
     const repoRoot = path.join(__dirname, '../../../../')
     const { MetaSheetServer } = await import('../../src/index')
     server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')] })
@@ -250,16 +268,25 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     for (const c of ['org_id', 'record_id', 'before_status', 'after_status', 'before_snapshot', 'after_snapshot', 'reason', 'evidence', 'idempotency_key', 'notification_delivery_id', 'notification_skipped_reason']) {
       expect(names.has(c)).toBe(true)
     }
+    const deliveryCols = (await pool.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'attendance_notification_deliveries'`,
+    )).rows as { column_name: string }[]
+    if (deliveryCols.length === 0) {
+      throw new Error('attendance_notification_deliveries is missing — the AE-2 delivery outbox migration was not applied (regression)')
+    }
   })
 
   afterAll(async () => {
     if (pool) {
+      await pool.query(`DELETE FROM attendance_notification_deliveries WHERE org_id = ANY($1)`, [[ORG, ORG_OTHER]]).catch(() => undefined)
       await pool.query(`DELETE FROM attendance_record_result_edits WHERE org_id = ANY($1)`, [[ORG, ORG_OTHER]]).catch(() => undefined)
       await pool.query(`DELETE FROM attendance_records WHERE org_id = ANY($1)`, [[ORG, ORG_OTHER]]).catch(() => undefined)
       await pool.query(`DELETE FROM attendance_payroll_cycles WHERE org_id = ANY($1)`, [[ORG, ORG_OTHER]]).catch(() => undefined)
     }
     if (server && (server as unknown as { stop?: () => Promise<void> }).stop) await (server as unknown as { stop: () => Promise<void> }).stop()
     await pool?.end().catch(() => undefined)
+    if (previousDefaultNotificationChannel === undefined) delete process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
+    else process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL = previousDefaultNotificationChannel
   })
 
   it('§3.5a late→normal: zeroes late/early, preserves work_minutes, recomputes meta tiers; writes audit before/after', async () => {
@@ -317,6 +344,32 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     expect(audit[0].actor_user_id).toBe(`ae1-admin-${RUN}`)
     expect(audit[0].notification_delivery_id).toBeNull()
     expect(audit[0].notification_skipped_reason).toBeNull()
+
+    const deliveries = await deliveryRowsForRecord(recordId)
+    expect(deliveries).toHaveLength(1)
+    expect(deliveries[0]).toMatchObject({
+      source_type: 'attendance_result_edit',
+      source_id: audit[0].id,
+      recipient_user_id: userId,
+      recipient_role: 'subject',
+      channel: 'dingtalk_work_notification',
+      status: 'pending',
+    })
+    expect(deliveries[0].source_key).toBe(`attendance_result_edit:${ORG}:${recordId}:${audit[0].id}:employee:${userId}:channel:dingtalk_work_notification`)
+    expect(deliveries[0].payload).toMatchObject({
+      kind: 'attendance_result_edit',
+      sourceType: 'attendance_result_edit',
+      recipientUserId: userId,
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      workDate,
+      beforeStatus: 'late',
+      afterStatus: 'normal',
+      reasonSummary: '员工提交线下签到凭证，核验后更正',
+    })
+    expect(deliveries[0].payload.overrideMetrics).toBeUndefined()
+    expect(deliveries[0].payload.evidence).toBeUndefined()
+    expect(deliveries.filter(row => row.recipient_user_id !== userId)).toHaveLength(0)
   })
 
   it('AE-1b durability: same-facts import recompute preserves the corrected result without a review flag', async () => {
@@ -352,6 +405,37 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     expect(Number(rec.early_leave_minutes)).toBe(0)
     expect(rec.meta?.manual_result_edit?.reviewConflict).toBeNull()
     expect(await auditRowsForRecord(recordId)).toHaveLength(1)
+  })
+
+  it('AE-2 notification: channel-unavailable path still enqueues pending and never sends synchronously', async () => {
+    const previousChannel = process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
+    process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL = 'email_smtp'
+    try {
+      const userId = `u-ae2-email-${RUN}`
+      const workDate = workdayYmd(3)
+      const recordId = await seedRecord({
+        userId, workDate, status: 'late', workMinutes: 480, lateMinutes: 20, earlyLeaveMinutes: 0,
+        firstInAt: `${workDate}T01:20:00Z`, lastOutAt: `${workDate}T10:00:00Z`,
+      })
+      const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'email channel configured but worker not running', idempotencyKey: `k-ae2-email-${RUN}` })
+      expect(res.status).toBe(200)
+
+      const deliveries = await deliveryRowsForRecord(recordId)
+      expect(deliveries).toHaveLength(1)
+      expect(deliveries[0]).toMatchObject({
+        recipient_user_id: userId,
+        recipient_role: 'subject',
+        channel: 'email_smtp',
+        status: 'pending',
+        attempt_count: 0,
+        delivered_at: null,
+        last_error: null,
+      })
+      expect(deliveries[0].source_key).toContain(':channel:email_smtp')
+    } finally {
+      if (previousChannel === undefined) delete process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
+      else process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL = previousChannel
+    }
   })
 
   it('AE-1b durability: a no-status import recompute preserves the corrected result and flags changed facts', async () => {
@@ -517,6 +601,7 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
       expect(res.status).toBe(403)
       expect(codeOf(res)).toBe('ATTENDANCE_RESULT_EDIT_DISABLED')
       expect(await auditRowsForRecord(recordId)).toHaveLength(0)
+      expect(await deliveryRowsForRecord(recordId)).toHaveLength(0)
 
       const rec = await recordById(recordId)
       expect(rec.status).toBe('late')
@@ -590,12 +675,15 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     const firstMarker = afterFirst.meta?.manual_result_edit
     expect(firstMarker?.idempotencyKey).toBe(key)
     expect(firstMarker?.auditId).toEqual(expect.any(String))
+    const afterFirstDeliveries = await deliveryRowsForRecord(recordId)
+    expect(afterFirstDeliveries).toHaveLength(1)
 
     // exact replay → alreadyApplied, no 2nd row
     const replay = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'verified offline', idempotencyKey: key })
     expect(replay.status).toBe(200)
     expect(dataOf(replay).alreadyApplied).toBe(true)
     expect(await auditByKey(ORG, key)).toHaveLength(1)
+    expect(await deliveryRowsForRecord(recordId)).toHaveLength(1)
     const afterReplay = await recordById(recordId)
     expect(afterReplay.meta?.manual_result_edit).toMatchObject({
       idempotencyKey: key,
@@ -628,6 +716,58 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     expect(conflict.status).toBe(409)
     expect(codeOf(conflict)).toBe('ATTENDANCE_RESULT_EDIT_IDEMPOTENCY_CONFLICT')
     expect(await auditByKey(ORG, key)).toHaveLength(1)
+    expect(await deliveryRowsForRecord(recordId)).toHaveLength(1)
+  })
+
+  it('AE-2 notification: worker failure is visible through the existing delivery status API', async () => {
+    await pool.query(
+      `UPDATE attendance_notification_deliveries
+          SET next_attempt_at = now() + interval '1 day'
+        WHERE org_id = $1 AND source_type = 'attendance_result_edit'`,
+      [ORG],
+    )
+    const userId = `u-ae2-worker-${RUN}`
+    const workDate = workdayYmd(3)
+    const recordId = await seedRecord({
+      userId, workDate, status: 'late', workMinutes: 480, lateMinutes: 22, earlyLeaveMinutes: 0,
+      firstInAt: `${workDate}T01:22:00Z`, lastOutAt: `${workDate}T10:00:00Z`,
+    })
+    const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'worker failure probe', idempotencyKey: `k-ae2-worker-${RUN}` })
+    expect(res.status).toBe(200)
+    const [delivery] = await deliveryRowsForRecord(recordId)
+    expect(delivery).toBeTruthy()
+    await pool.query(
+      `UPDATE attendance_notification_deliveries
+          SET payload = payload || $2::jsonb, next_attempt_at = '2000-01-01T00:00:00Z'::timestamptz
+        WHERE id = $1`,
+      [delivery.id, JSON.stringify({ fakeDelivery: 'fail' })],
+    )
+
+    const query: AttendanceNotificationDeliveryQuery = async (sqlText, params) => {
+      const r = await pool.query(sqlText, params as unknown[])
+      return { rows: r.rows, rowCount: r.rowCount }
+    }
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query,
+      channels: [new DeterministicFakeAttendanceDeliveryChannel()],
+      workerId: 'ae2-worker-test',
+      batchSize: 1,
+    })
+    await expect(worker.runBatch()).resolves.toMatchObject({ failed: 1 })
+
+    const failed = await requestJson(`${baseUrl}/api/attendance/notification-deliveries?orgId=${encodeURIComponent(ORG)}&status=failed&pageSize=50`, { headers: authHeaders(adminToken) })
+    expect(failed.status).toBe(200)
+    const items = dataOf(failed)?.items ?? []
+    const row = items.find((item: any) => item.id === delivery.id)
+    expect(row).toMatchObject({
+      sourceType: 'attendance_result_edit',
+      recipientUserId: userId,
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      status: 'failed',
+      lastError: 'fake_non_retryable_failure',
+    })
+    expect(Number(dataOf(failed)?.counters?.failed ?? 0)).toBeGreaterThanOrEqual(1)
   })
 
   it('editable-source: off/adjusted → 422 SOURCE_NOT_EDITABLE; normal→abnormal → 422 NORMAL_TO_ABNORMAL_UNSUPPORTED; normal→normal → 422 SOURCE_NOT_EDITABLE', async () => {
@@ -654,6 +794,8 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     // none of the rejected edits wrote an audit row or changed status
     expect(await auditRowsForRecord(off)).toHaveLength(0)
     expect(await auditRowsForRecord(norm)).toHaveLength(0)
+    expect(await deliveryRowsForRecord(off)).toHaveLength(0)
+    expect(await deliveryRowsForRecord(norm)).toHaveLength(0)
     expect((await recordById(norm)).status).toBe('normal')
   })
 
@@ -666,6 +808,7 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
       expect(e1.status).toBe(409)
       expect(codeOf(e1)).toBe('ATTENDANCE_RESULT_EDIT_CYCLE_CLOSED')
       expect(await auditRowsForRecord(r1)).toHaveLength(0)
+      expect(await deliveryRowsForRecord(r1)).toHaveLength(0)
       expect((await recordById(r1)).status).toBe('late') // unchanged
 
       // overlapping open cycle present too → the closed one still wins and rejects

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -120,6 +120,7 @@ const ATTENDANCE_SCHEDULER_SCOPE_ACTIONS = new Set(ATTENDANCE_SCHEDULER_SCOPE_AC
 const ATTENDANCE_DINGTALK_WORK_NOTIFICATION_CHANNEL = 'dingtalk_work_notification'
 const ATTENDANCE_ROUTABLE_DEFAULT_DELIVERY_CHANNELS = new Set([ATTENDANCE_DINGTALK_WORK_NOTIFICATION_CHANNEL, 'email_smtp'])
 const MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE = 'manual_missed_punch_reminder'
+const ATTENDANCE_RESULT_EDIT_NOTIFICATION_SOURCE_TYPE = 'attendance_result_edit'
 // RD-3 attendance report-digest producer (design-lock attendance-report-digest-subscription-design-lock-20260626 §4).
 // source_type stamped on every C5 outbox row this producer writes.
 const ATTENDANCE_REPORT_DIGEST_SOURCE_TYPE = 'attendance_report_digest'
@@ -307,8 +308,8 @@ const DEFAULT_SETTINGS = {
   // attendance:admin POST /api/attendance/anomaly-result-edits write action. enabled = master switch (default
   // ON; the route 403s when explicitly false). editWindowDays bounds how far back a work_date may be corrected
   // (org-tz today − work_date), default 180, range 1..366. requireReason default true (a blank reason 400s).
-  // notifyAffectedEmployee default true (AE-2 honours it; a disabled value is still recorded as a skipped
-  // reason on the audit row).
+  // notifyAffectedEmployee remains reserved for a follow-up gate; AE-2 v1 always enqueues after a successful
+  // correction and leaves the audit row's notification_delivery_id / notification_skipped_reason columns NULL.
   attendanceResultEditPolicy: {
     enabled: true,
     editWindowDays: 180,
@@ -18307,6 +18308,65 @@ async function attachManualResultEditMarkerToRecord(trx, record, marker) {
   return rows[0] ?? { ...record, meta }
 }
 
+function buildAttendanceResultEditNotificationReasonSummary(reason) {
+  const text = typeof reason === 'string' ? reason.trim() : ''
+  if (!text) return ''
+  return text.length > 240 ? `${text.slice(0, 240)}...` : text
+}
+
+function buildAttendanceResultEditNotificationPayload({ record, beforeStatus, targetStatus, reason, channel }) {
+  const workDate = normalizeDateOnly(record?.work_date)
+    ?? (record?.work_date != null ? String(record.work_date).slice(0, 10) : null)
+  const reasonSummary = buildAttendanceResultEditNotificationReasonSummary(reason)
+  const title = 'Attendance result corrected'
+  const body = reasonSummary
+    ? `Your attendance result for ${workDate ?? 'this date'} was corrected from ${beforeStatus} to ${targetStatus}. Reason: ${reasonSummary}`
+    : `Your attendance result for ${workDate ?? 'this date'} was corrected from ${beforeStatus} to ${targetStatus}.`
+  return {
+    kind: ATTENDANCE_RESULT_EDIT_NOTIFICATION_SOURCE_TYPE,
+    title,
+    body,
+    sourceType: ATTENDANCE_RESULT_EDIT_NOTIFICATION_SOURCE_TYPE,
+    recipientUserId: record?.user_id ?? null,
+    recipientRole: 'subject',
+    channel,
+    workDate,
+    beforeStatus,
+    afterStatus: targetStatus,
+    reasonSummary,
+  }
+}
+
+async function enqueueAttendanceResultEditNotification(trx, { orgId, record, auditRow, beforeStatus, targetStatus, reason }) {
+  if (!record?.id || !record?.user_id || !auditRow?.id) return null
+  const channel = resolveAttendanceDefaultDeliveryChannelForProducer()
+  const payload = buildAttendanceResultEditNotificationPayload({
+    record,
+    beforeStatus,
+    targetStatus,
+    reason,
+    channel,
+  })
+  const sourceKey = `${ATTENDANCE_RESULT_EDIT_NOTIFICATION_SOURCE_TYPE}:${orgId}:${record.id}:${auditRow.id}:employee:${record.user_id}:channel:${channel}`
+  const inserted = await trx.query(
+    `INSERT INTO attendance_notification_deliveries
+       (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, payload)
+     VALUES ($1, $2, $3, $4, $5, 'subject', $6, 'pending', $7::jsonb)
+     ON CONFLICT (org_id, source_key) DO NOTHING
+     RETURNING *`,
+    [
+      orgId,
+      ATTENDANCE_RESULT_EDIT_NOTIFICATION_SOURCE_TYPE,
+      auditRow.id,
+      sourceKey,
+      record.user_id,
+      channel,
+      JSON.stringify(payload),
+    ]
+  )
+  return inserted[0] ?? null
+}
+
 // §4.1 idempotency compare: a replayed (org_id, idempotency_key) is "already applied" only when its key
 // PAYLOAD fields match the prior audit row — compared in STORED form (trimmed reason, normalized evidence)
 // so a byte-identical replay never spuriously conflicts on whitespace/key-ordering. Any divergence → 409.
@@ -18508,6 +18568,14 @@ async function applyAttendanceResultEdit(trx, options) {
   const marker = buildManualResultEditMarker(auditRow, updated)
   const markedRecord = await attachManualResultEditMarkerToRecord(trx, updated, marker)
   afterSnapshot = buildResultEditSnapshot(markedRecord)
+  await enqueueAttendanceResultEditNotification(trx, {
+    orgId,
+    record: markedRecord,
+    auditRow,
+    beforeStatus,
+    targetStatus,
+    reason,
+  })
 
   return {
     alreadyApplied: false,


### PR DESCRIPTION
## Summary
- implements AE-2 runtime from #3407: enqueue one same-transaction attendance_result_edit notification outbox row after the audit + manual_result_edit marker write
- scopes the notification to the corrected employee only, with source_key including the resolved channel and a redacted payload (no overrideMetrics/evidence)
- extends the AE real-DB matrix for success, replay dedup, pending-without-send, no fanout, rejected-correction no-outbox, and worker-failure visibility through the existing delivery status API
- wires the matrix into `test:integration:attendance`, the existing Postgres-backed attendance integration gate

## Verification
- `node -c plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend type-check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-result-edit-durability.test.ts tests/unit/attendance-result-edit-helpers.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-result-edit.test.ts --reporter=dot` (local no-DB run skips 18/18; CI `test:integration:attendance` supplies Postgres and must execute it)

## Scope
- no synchronous send
- no new env/policy/channel/UI/staging work
- AE-3/AE-4 remain separate gated follow-ups

Refs #3317, #3407