### PR TITLE
fix(multitable): legacy permission grant/revoke routes take the sheet FOR UPDATE lock (#3402 follow-up)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -230,6 +230,7 @@ jobs:
             tests/integration/multitable-uncreate-config-realdb.test.ts \
             tests/integration/multitable-undelete-config-realdb.test.ts \
             tests/integration/multitable-permission-revert-realdb.test.ts \
+            tests/integration/multitable-legacy-permission-route-lock-realdb.test.ts \
             tests/integration/multitable-revert-pit-realdb.test.ts \
             tests/integration/multitable-undelete-pit-realdb.test.ts \
             tests/integration/multitable-reset-pit-realdb.test.ts \

--- a/docs/development/multitable-legacy-permission-route-lock-dev-verification-20260630.md
+++ b/docs/development/multitable-legacy-permission-route-lock-dev-verification-20260630.md
@@ -1,0 +1,67 @@
+# Legacy permission grant/revoke routes — sheet FOR UPDATE lock (dev + verification)
+
+**Date:** 2026-06-30  **Grounding:** `origin/main @ 352cac267`
+**Branch:** `claude/legacy-perm-route-lock-20260630`
+**Follow-up to:** #3402 (forward-route lock), which closed the three multitable forward permission routes and **explicitly deferred** the legacy `routes/spreadsheet-permissions.ts` grant/revoke routes as the *"remaining un-serialized writer."* This closes that residual the **same way** (one lock model — no second locking strategy).
+
+> Flag status: `MULTITABLE_ENABLE_PERMISSION_REVERT` stays **default-off**. This change enables nothing; it completes the writer-set serialization that makes a future, separately-signed-off enablement safe.
+
+---
+
+## 1. Context
+
+The permission-revert **execute** path reads the live grant and re-checks de-escalation **inside a txn under `meta_sheets … FOR UPDATE`**. #3402 made the three multitable forward grant/revoke routes take that **same** lock so they serialize against a concurrent revert. It left the legacy `routes/spreadsheet-permissions.ts` `POST …/permissions/grant` and `…/revoke` routes taking **no explicit sheet lock** — they wrote `spreadsheet_permissions` via **single auto-commit `pool.query` statements** (no transaction, so no row lock could be held across the write). #3402 flagged these collectively as the *"remaining un-serialized writer"*; §2 refines that characterization — grant was *incidentally* FK-serialized against the revert, so only revoke was actually un-serialized.
+
+## 2. The grant vs revoke asymmetry (stated precisely — not overclaimed)
+
+`spreadsheet_permissions.sheet_id REFERENCES meta_sheets(id)`. This FK changes the two routes' pre-existing exposure differently, and the guarantee must be stated exactly:
+
+- **Grant (`INSERT`)** — an INSERT into the child implicitly takes **`FOR KEY SHARE`** on the parent `meta_sheets` row (FK enforcement). The revert holds **`FOR UPDATE`** on that row, and **`FOR UPDATE` conflicts with `FOR KEY SHARE`**, so a concurrent grant INSERT **was already serialized** against the revert (it blocks until the revert commits). Adding the explicit lock to grant is **uniformity** (one lock model, matching #3402) — **not** a new closure.
+- **Revoke (`DELETE`)** — deleting the child row takes **no lock on the parent** `meta_sheets` row. So revoke was **not** FK-serialized against the revert and could interleave the revert's live-grant re-check and its apply. **Revoke is the genuine residual** this PR closes.
+
+Both are locked (full writer-set uniformity, per #3402's all-routes approach), but only revoke was a real gap.
+
+## 3. Fix
+
+`packages/core-backend/src/routes/spreadsheet-permissions.ts`. Each DB write path (the `if (pool)` branch of grant and of revoke) is wrapped in a transaction that locks the owning sheet row **first**, then writes:
+
+```
+await transaction(async ({ query }) => {
+  await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE', [req.params.id])
+  await query(/* the existing INSERT … ON CONFLICT DO NOTHING  /  DELETE … */)
+})
+```
+
+Lock-acquisition order is `meta_sheets → spreadsheet_permissions`, **identical** to the revert and to #3402's forward routes (see §5). The in-memory fallback (`else` branch, no `pool`) is unchanged (dev-only, no DB, nothing to serialize). The rbac guard, request validation, audit call, and the post-write re-`SELECT` for the response are unchanged.
+
+## 4. Verification
+
+### 4.1 Real-DB golden (new) — `tests/integration/multitable-legacy-permission-route-lock-realdb.test.ts`
+
+Added to the `plugin-tests.yml` real-DB allowlist. Two concurrency goldens using the **FK-aware discriminator** from #3402's `(m)`: an external txn HOLDS **`FOR KEY SHARE`** (not `FOR UPDATE`) on the sheet row, then the route is fired.
+
+- **(a) grant parks** — the fixed grant requests `FOR UPDATE` (conflicts with the held `FOR KEY SHARE`) → it parks (not settled, no grant row) while held, then applies after release.
+- **(b) revoke parks** — same, for the DELETE.
+
+Why `FOR KEY SHARE` (not `FOR UPDATE`) is the correct discriminator: it is **compatible** with the FK key-share an unfixed grant INSERT needs (and a plain revoke DELETE takes no meta_sheets lock at all), so an **unfixed** route sails → the assertion fails (RED). It **conflicts** with the `FOR UPDATE` the **fixed** route now requests → the route parks (GREEN). Assertions are two-sided (state unchanged while held **and** applied after release), so a slow CI run cannot mask a missing lock.
+
+### 4.2 Results (local, real Postgres)
+
+- **With the fix:** `Tests 3 passed (3)` (sentinel + grant parks + revoke parks).
+- **RED-pre-fix proof (non-negotiable):** reverting *only* the runtime change and re-running → **`2 failed | 1 passed`** — both concurrency goldens fail against the unfixed route (the grant/revoke sail under the held `FOR KEY SHARE`). The goldens therefore have teeth; they are not green-regardless.
+- `tsc --noEmit` clean.
+
+## 5. Deadlock analysis
+
+The new locks take `meta_sheets … FOR UPDATE` **before** writing `spreadsheet_permissions` — the same `meta_sheets → permission-row` order as the revert (which locks `meta_sheets` first, then the grant rows) and #3402's forward routes. No code path locks a permission table and **then** `meta_sheets` (re-verified on current main). With a single consistent lock-acquisition order across every actor, there is no lock-order cycle → deadlock-free. (The sheet-delete FK cascade also locks `meta_sheets` first, same direction.)
+
+## 6. Scope / non-goals
+
+- Only the **user-subject** grant/revoke — the legacy route handles `subject_type='user'` exclusively (unchanged).
+- The **in-memory fallback** path (no `pool`) is dev-only and takes no lock (there is no DB to serialize against); unchanged.
+- Does **not** enable the flag, change rbac/validation, add a sheet-existence check, or alter the response shape — minimal, lock-only.
+- Forward-vs-forward last-write-wins between two authorized permission writes is pre-existing and out of scope (as in #3402).
+
+## 7. Outcome
+
+With this change, **every** writer of `spreadsheet_permissions` — the multitable forward route (#3402), the permission-revert apply (under its own lock), and now the legacy grant/revoke route — serializes against the permission-revert under the same `meta_sheets FOR UPDATE`. The writer-set serialization #3402 began is complete; revoke's genuine residual is closed.

--- a/packages/core-backend/src/routes/spreadsheet-permissions.ts
+++ b/packages/core-backend/src/routes/spreadsheet-permissions.ts
@@ -2,7 +2,7 @@ import type { Request, Response} from 'express';
 import { Router } from 'express'
 import { rbacGuard } from '../rbac/rbac'
 import { auditLog } from '../audit/audit'
-import { pool } from '../db/pg'
+import { pool, transaction } from '../db/pg'
 
 // Use the global Express.Request type which already includes user property
 type AuthenticatedRequest = Request
@@ -47,12 +47,20 @@ export function spreadsheetPermissionsRouter(): Router {
     const perm = req.body?.permission
     if (!userId || !perm) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId and permission required' } })
     if (pool) {
-      await pool.query(
-        `INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code)
-         VALUES ($1, $2, 'user', $2, $3)
-         ON CONFLICT DO NOTHING`,
-        [req.params.id, userId, perm],
-      )
+      // Never-escalate-under-concurrency (#3389 / #3402 follow-up): take the SAME meta_sheets row lock the
+      // permission-revert execute path (and the multitable forward grant/revoke routes, #3402) hold, so this legacy
+      // grant write serializes against a concurrent revert under ONE lock model. A grant INSERT already blocks on the
+      // revert via the FK's implicit FOR KEY SHARE on meta_sheets vs the revert's FOR UPDATE; the explicit lock makes
+      // the legacy route UNIFORM with #3402 rather than relying on that implicit FK lock (it does not close a new hole).
+      await transaction(async ({ query }) => {
+        await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE', [req.params.id])
+        await query(
+          `INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code)
+           VALUES ($1, $2, 'user', $2, $3)
+           ON CONFLICT DO NOTHING`,
+          [req.params.id, userId, perm],
+        )
+      })
     } else {
       const map = sheetPerms.get(req.params.id) || new Map<string, Set<string>>()
       const set = map.get(userId) || new Set<string>()
@@ -82,14 +90,22 @@ export function spreadsheetPermissionsRouter(): Router {
     const perm = req.body?.permission
     if (!userId || !perm) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId and permission required' } })
     if (pool) {
-      await pool.query(
-        `DELETE FROM spreadsheet_permissions
-         WHERE sheet_id = $1
-           AND subject_type = 'user'
-           AND user_id = $2
-           AND perm_code = $3`,
-        [req.params.id, userId, perm],
-      )
+      // Never-escalate-under-concurrency (#3389 / #3402 follow-up): the legacy revoke is the GENUINE residual
+      // un-serialized writer #3402 deferred — a child-row DELETE takes NO lock on the parent meta_sheets row, so
+      // (unlike a grant INSERT) it is NOT FK-serialized against a concurrent permission-revert and could interleave
+      // the revert's live-grant re-check and its apply. Take the SAME meta_sheets FOR UPDATE the revert holds so it
+      // cannot. (#3402-style: lock the sheet row first, then write.)
+      await transaction(async ({ query }) => {
+        await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE', [req.params.id])
+        await query(
+          `DELETE FROM spreadsheet_permissions
+           WHERE sheet_id = $1
+             AND subject_type = 'user'
+             AND user_id = $2
+             AND perm_code = $3`,
+          [req.params.id, userId, perm],
+        )
+      })
     } else {
       const map = sheetPerms.get(req.params.id) || new Map<string, Set<string>>()
       const set = map.get(userId) || new Set<string>()

--- a/packages/core-backend/tests/integration/multitable-legacy-permission-route-lock-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-legacy-permission-route-lock-realdb.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Legacy spreadsheet-permissions grant/revoke routes — concurrency lock (#3389 / #3402 follow-up) — real DB.
+ *
+ * #3402 made the three multitable forward permission routes take the same `meta_sheets … FOR UPDATE` the
+ * permission-revert execute path holds, but explicitly DEFERRED the legacy `routes/spreadsheet-permissions.ts`
+ * grant/revoke routes as the "remaining un-serialized writer". This closes that residual the SAME way (one lock
+ * model): each write now runs in a txn that locks the owning sheet row first.
+ *
+ * The grant vs revoke asymmetry (stated precisely so the guarantee isn't overclaimed):
+ *   - `spreadsheet_permissions.sheet_id REFERENCES meta_sheets(id)`, so a grant INSERT implicitly takes
+ *     `FOR KEY SHARE` on the parent meta_sheets row. The revert holds `FOR UPDATE`, which CONFLICTS with
+ *     FOR KEY SHARE — so a concurrent grant INSERT was ALREADY serialized against the revert. Locking grant is
+ *     UNIFORMITY (one lock model), not a new closure.
+ *   - A revoke DELETEs the CHILD row, which takes NO lock on the parent meta_sheets row → it was NOT FK-serialized
+ *     against the revert and could interleave the revert's live-grant re-check and its apply. Revoke is the
+ *     GENUINE residual closure.
+ *
+ * Discriminator (FK-aware, same as #3402's (m)): HOLD `FOR KEY SHARE` (NOT `FOR UPDATE`) on the sheet row in an
+ * external txn, then fire the route. FOR KEY SHARE is COMPATIBLE with the FK key-share an unfixed grant INSERT needs
+ * (and a plain revoke DELETE takes no meta_sheets lock at all) → the UNFIXED route sails (test RED). It CONFLICTS with
+ * the `FOR UPDATE` the FIXED route now requests → the route parks until release (test GREEN). A plain `FOR UPDATE`
+ * holder could not discriminate the grant case (the FK key-share alone would block the unfixed INSERT). Assertions are
+ * two-sided (state unchanged WHILE held AND applied AFTER release), so a slow CI run cannot mask a missing lock.
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { spreadsheetPermissionsRouter } from '../../src/routes/spreadsheet-permissions'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_legacy_lock_${TS}`
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+
+let app: Express
+const CREATED_SHEETS: string[] = []
+let seq = 0
+const mkSubject = (tag: string) => `subj_legacy_${tag}_${TS}_${seq++}`
+
+async function freshSheet(tag: string): Promise<string> {
+  const id = `sheet_legacy_${tag}_${TS}`
+  await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [id, BASE, id])
+  CREATED_SHEETS.push(id)
+  return id
+}
+
+const grant = (s: string, userId: string, permission: string) =>
+  request(app).post(`/api/spreadsheets/${s}/permissions/grant`).send({ userId, permission })
+const revoke = (s: string, userId: string, permission: string) =>
+  request(app).post(`/api/spreadsheets/${s}/permissions/revoke`).send({ userId, permission })
+
+const codesFor = async (s: string, userId: string): Promise<string[]> =>
+  ((await q(`SELECT perm_code FROM spreadsheet_permissions WHERE sheet_id=$1 AND subject_type='user' AND user_id=$2 ORDER BY perm_code`, [s, userId])).rows as Array<{ perm_code: string }>).map((r) => r.perm_code)
+
+describeIfDatabase('legacy spreadsheet-permissions grant/revoke — meta_sheets FOR UPDATE lock (#3402 follow-up, real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as unknown as { user?: unknown }).user = { id: `admin_legacy_${TS}`, role: 'admin' }; next() }) // rbacGuard global-admin bypass
+    app.use(spreadsheetPermissionsRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'Legacy Lock Base'])
+  })
+  afterAll(async () => {
+    for (const s of CREATED_SHEETS) {
+      await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = $1', [s]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [s]).catch(() => {})
+    }
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('(a) grant parks under a held FOR KEY SHARE on the sheet (proves the grant route now takes meta_sheets FOR UPDATE)', async () => {
+    const s = await freshSheet('grant')
+    const subj = mkSubject('grant')
+    // hold FOR KEY SHARE, fire grant
+    let releaseHold: () => void = () => {}
+    const holdReleased = new Promise<void>((resolve) => { releaseHold = () => resolve() })
+    let acquired: () => void = () => {}
+    const lockAcquired = new Promise<void>((resolve) => { acquired = () => resolve() })
+    const holder = poolManager.get().transaction(async ({ query }) => {
+      await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR KEY SHARE', [s])
+      acquired()
+      await holdReleased
+    })
+    try {
+      await lockAcquired
+      let settled = false
+      const fired = Promise.resolve(grant(s, subj, 'spreadsheet:admin').then((r) => { settled = true; return r }))
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      // FIXED: parked on meta_sheets FOR UPDATE (conflicts with held FOR KEY SHARE) → not settled, no grant row.
+      expect(settled).toBe(false)
+      expect(await codesFor(s, subj)).toEqual([])
+      releaseHold()
+      await holder
+      const res = await fired
+      expect(res.status).toBe(200)
+      expect(settled).toBe(true)
+      expect(await codesFor(s, subj)).toEqual(['spreadsheet:admin']) // applied after release
+    } finally {
+      releaseHold()
+      await holder.catch(() => {})
+    }
+  })
+
+  test('(b) revoke parks under a held FOR KEY SHARE on the sheet (the GENUINE residual — a child DELETE has no parent lock)', async () => {
+    const s = await freshSheet('revoke')
+    const subj = mkSubject('revoke')
+    await q(`INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code) VALUES ($1,$2,'user',$2,$3)`, [s, subj, 'spreadsheet:read'])
+    let releaseHold: () => void = () => {}
+    const holdReleased = new Promise<void>((resolve) => { releaseHold = () => resolve() })
+    let acquired: () => void = () => {}
+    const lockAcquired = new Promise<void>((resolve) => { acquired = () => resolve() })
+    const holder = poolManager.get().transaction(async ({ query }) => {
+      await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR KEY SHARE', [s])
+      acquired()
+      await holdReleased
+    })
+    try {
+      await lockAcquired
+      let settled = false
+      const fired = Promise.resolve(revoke(s, subj, 'spreadsheet:read').then((r) => { settled = true; return r }))
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      // FIXED: parked → not settled, grant row STILL present (a plain DELETE would have removed it by now → RED pre-fix).
+      expect(settled).toBe(false)
+      expect(await codesFor(s, subj)).toEqual(['spreadsheet:read'])
+      releaseHold()
+      await holder
+      const res = await fired
+      expect(res.status).toBe(200)
+      expect(settled).toBe(true)
+      expect(await codesFor(s, subj)).toEqual([]) // revoked after release
+    } finally {
+      releaseHold()
+      await holder.catch(() => {})
+    }
+  })
+})


### PR DESCRIPTION
## What

#3402 locked the three multitable forward permission routes against a concurrent permission-revert but **explicitly deferred** the legacy `routes/spreadsheet-permissions.ts` grant/revoke routes as the *"remaining un-serialized writer."* This closes that residual the **same way** — one lock model, no second strategy.

The legacy routes wrote `spreadsheet_permissions` via **single auto-commit `pool.query` statements**, so no row lock could be held across the write. Each DB write path (grant `INSERT`, revoke `DELETE`) now runs in a transaction that takes the **same** `meta_sheets … FOR UPDATE` the revert holds, **sheet-row-first**.

## Grant vs revoke — stated precisely (not overclaimed)

`spreadsheet_permissions.sheet_id REFERENCES meta_sheets(id)`:
- **Grant (`INSERT`)** implicitly takes `FOR KEY SHARE` on the parent `meta_sheets` row, which **conflicts** with the revert's `FOR UPDATE` — so a concurrent grant was **already serialized** against the revert. Locking it is **uniformity** (one lock model), **not** a new closure.
- **Revoke (`DELETE` of the child)** takes **no** parent lock → it was **not** serialized and could interleave the revert's check→apply. **Revoke is the genuine residual** this PR closes.

Both are locked for full writer-set uniformity; only revoke was a real gap.

## Verification

- **New real-DB golden** `multitable-legacy-permission-route-lock-realdb.test.ts` (added to the `plugin-tests.yml` allowlist), using #3402's **FK-aware `FOR KEY SHARE` discriminator** for both grant **(a)** and revoke **(b)**: a held `FOR KEY SHARE` parks the *fixed* route (which now requests `FOR UPDATE`) but would **not** park the *unfixed* route.
- **3/3 green with the fix; 2/3 RED with the runtime reverted** — proving the goldens genuinely discriminate (not green-regardless). `tsc --noEmit` clean.
- **Adversarial audit (3 independent reviewers), all PASS**: regression/scope (clean), golden-teeth+doc-framing (FK persistent, discriminator sound, two-sided assertions, flake/false-green vectors closed), and **deadlock/lock-order** (uniform `meta_sheets`-first across every writer; field/view permission tables have no FK so no second-lock inversion; spreadsheet_permissions' FK key-share is on the same row already held `FOR UPDATE`).

## Deadlock analysis

Lock order is `meta_sheets → permission-row` everywhere — the new legacy routes, #3402's forward routes, and the revert. No path locks a permission table then `meta_sheets`. Deadlock-free.

## Scope / non-goals

- Only the **user-subject** grant/revoke (the route handles `subject_type='user'` exclusively).
- The **in-memory fallback** (no `pool`) is dev-only and takes no lock; unchanged.
- Does **not** enable the flag (`MULTITABLE_ENABLE_PERMISSION_REVERT` stays default-off), change rbac/validation, add a sheet-existence check, or alter the response shape — minimal, lock-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)