### PR TITLE
docs(integration): lock K3 BOM material resolver gate

### DIFF
--- a/docs/development/data-factory-k3-read-list-development-verification-20260626.md
+++ b/docs/development/data-factory-k3-read-list-development-verification-20260626.md
@@ -1,10 +1,10 @@
 # K3 read/list + external-system read onboarding — development & verification (2026-06-26)
 
-> Status: **buildable development COMPLETE + verified; remaining surfaces GATED (not unfinished)**. This MD records the full development + verification of the K3 read/list/BOM line and its read-onboarding standardization. Per the line's own plan (the C0–C5 ladder + GATEs), every authorized non-gated slice is shipped. C3 LIST-only and C4 single-level BOM read are now shipped after their customer/operator GATEs; C5 resolver, recursive BOM, and writes remain deliberately frozen behind their own customer/owner GATEs.
+> Status: **buildable development COMPLETE + verified; remaining surfaces GATED (not unfinished)**. This MD records the full development + verification of the K3 read/list/BOM line and its read-onboarding standardization. Per the line's own plan (the C0–C5 ladder + GATEs), every authorized non-gated slice is shipped. C3 LIST-only and C4 single-level BOM read are now shipped after their customer/operator GATEs; material→FBillNo resolver now has a GATE-front contract only, while resolver runtime/composition, recursive BOM, and writes remain deliberately frozen behind their own customer/owner GATEs.
 
 ## 0. Honest scope
 
-The line's plan gates the broader surfaces on purpose. So "complete the unfinished development" resolves to: **finish everything buildable without crossing a GATE (done), and document the gated remainder with its gate reasons.** No customer/owner GATE was crossed to manufacture "completion." C3 LIST-only was opened only after #1709 customer/operator evidence explicitly requested WebAPI LIST; C4 BOM single-level read was opened only after #3399's shape-first GATE-front and a separate owner runtime opt-in. C5 resolver, recursive BOM, and writes remain locked.
+The line's plan gates the broader surfaces on purpose. So "complete the unfinished development" resolves to: **finish everything buildable without crossing a GATE (done), and document the gated remainder with its gate reasons.** No customer/owner GATE was crossed to manufacture "completion." C3 LIST-only was opened only after #1709 customer/operator evidence explicitly requested WebAPI LIST; C4 BOM single-level read was opened only after #3399's shape-first GATE-front and a separate owner runtime opt-in. The material→FBillNo resolver is now opened only to GATE-front contract/shape intake; resolver runtime/composition, recursive BOM, and writes remain locked.
 
 ## 1. Development delivered (merged, with SHAs)
 
@@ -22,6 +22,7 @@ The line's plan gates the broader surfaces on purpose. So "complete the unfinish
 - `#3330` — **C3 LIST-only**: explicit `k3wise.material-list.v1` preset + bounded Material/GetList route/adapter wiring. Single page, preset-owned `Top/PageSize/PageIndex`, rows parsed from `response.Data.DATA`, optional key mapped only to the internal `FNumber` prefix filter, route-only internal marker required before adapter LIST execution, no request-supplied raw filters/cursor/watermark/limit/path/method/payload, values-free evidence, no BOM/resolver/write.
 - `#3399` (`c499abe83`) — **C4 BOM GATE-front**: docs-only, redacted live shape intake for BOM read; explicitly no runtime/no BOM call.
 - `#3405` (`efa832a08`) — **C4 BOM single-level read runtime**: explicit `k3wise.material-bom.v1` preset + `POST /K3API/BOM/GetDetail`; request body `Data.FBillNo` as a bound JSON value (not `k3_freeform` / not raw Filter); extracts `Data.Page1` header count + `Data.Page2` line rows; one call, no recursion, no material-to-FBillNo resolver, no Save/Submit/Audit/write.
+- `integration-core-k3wise-bom-material-resolver-gate-contract-design-20260630.md` — **material→FBillNo resolver GATE-front**: docs-only, redacted live shape intake for read-only material→BOM bill lookup; explicitly no runtime/no resolver call/no BOM call/no composition.
 
 **Standardization:**
 - `#3257` (`2f7f82323`) — K3 read/list **GATE v2** + reusable values-free evidence checklist.
@@ -58,7 +59,8 @@ A separate adversarial pass re-verified the C0–C2 baseline on fresh `origin/ma
 | C3 — WebAPI LIST | shipped (LIST-only) | opened by #1709 customer/operator GATE; bounded Material/GetList only, values-free |
 | C4 — BOM read | shipped (single-level read only) | opened by #3399 shape-first GATE-front + owner runtime opt-in; one `BOM/GetDetail` call only, values-free |
 | BOM recursive multi-level expansion | frozen (locked) | separate fan-out/request-amplification gate; single-level C4 PASS does not authorize recursion |
-| material→FBillNo resolver / server-side composition | frozen (locked) | explicit owner unlock + named demand; not inferred from BOM read-smoke |
+| material→FBillNo resolver | GATE-front contract only; runtime frozen | shape-first contract opened; runtime requires redacted live lookup shape + separate owner opt-in; not inferred from BOM read-smoke |
+| material→FBillNo -> BOM server-side composition | frozen (locked) | separate opt-in after resolver runtime; first resolver slice must not auto-call `BOM/GetDetail` |
 | C5 — resolver / server-side composition | frozen (locked) | explicit owner unlock + named demand |
 | Save / Submit / Audit / production / external write | frozen | separate owner authorization (FOS-P4-style write gate); a read GATE never authorizes a write |
 | Live K3 beyond the verified read-smokes | gated | customer GATE packet / owner opt-in for each new surface; C3 LIST and C4 single-level BOM read are the only live read-smokes recorded here |

--- a/docs/development/data-source-system-integration-line-closeout-20260630.md
+++ b/docs/development/data-source-system-integration-line-closeout-20260630.md
@@ -1,10 +1,12 @@
 # 数据库及系统对接 — 交付线收口 (line close-out) — 2026-06-30
 
-> 状态：**线收口 (CLOSED at scoped deliverable)。** 只读数据库源 + K3 `Material/GetDetail` 单条读 + **SQL 批量物料读** + **C3 K3 WebAPI-LIST 列表页读（no-key + keyed）** + **C4 K3 WebAPI-BOM 单层读** + C6 **sandbox** 外部写均已交付并验证。production/batch 写、BOM 递归展开、material→FBillNo resolver、C5 resolver 仍为各自独立 gate，不在本次收口范围。
+> 状态：**线收口 (CLOSED at scoped deliverable)。** 只读数据库源 + K3 `Material/GetDetail` 单条读 + **SQL 批量物料读** + **C3 K3 WebAPI-LIST 列表页读（no-key + keyed）** + **C4 K3 WebAPI-BOM 单层读** + C6 **sandbox** 外部写均已交付并验证。production/batch 写、BOM 递归展开、material→FBillNo resolver runtime / composition、C5 resolver 仍为各自独立 gate，不在本次收口范围；material→FBillNo resolver 本次仅打开 GATE-front contract / shape intake。
 >
 > 更新 2026-06-30：C3 K3 WebAPI-LIST 由 **deferred** 翻为 **done** —— 客户/operator 侧 redacted live 样本确认行容器为 `Data.Data`(PascalCase)，窄 preset-owned slice **#3390**（`e1766a629`）修复 response-side extractor，实体机 **no-key rerun PASS**；keyed `FNumber` Filter 经 **keyed rerun 亦 PASS**（**无需新代码** —— 能力已含于 #3390，preset 自带 filter shape `FNumber like '%<escaped>%'`，owner 直接以已部署包验证、`sampleKeyEchoed=false`）。
 >
-> 更新 2026-06-30：C4 K3 WebAPI-BOM **单层读** 由 GATE-front + runtime + 实体机 smoke 闭合 —— #3399 (`c499abe83`) 先锁 redacted live shape，#3405 (`efa832a08`) 实现 `k3wise.material-bom.v1`，on-prem release `multitable-onprem-k3-c4-bom-read-20260630-efa832a08` 实体机 rerun **PASS**（`recordCount=3`、`bomHeaderCount=1`、`bomLineCount=3`、`bomShapeProbe.dataPage1=true`、`bomShapeProbe.dataPage2=true`、`bomKeyEchoed=false`）。递归 BOM 展开、material→FBillNo resolver、Save/Submit/Audit/write 仍为独立 gate。
+> 更新 2026-06-30：C4 K3 WebAPI-BOM **单层读** 由 GATE-front + runtime + 实体机 smoke 闭合 —— #3399 (`c499abe83`) 先锁 redacted live shape，#3405 (`efa832a08`) 实现 `k3wise.material-bom.v1`，on-prem release `multitable-onprem-k3-c4-bom-read-20260630-efa832a08` 实体机 rerun **PASS**（`recordCount=3`、`bomHeaderCount=1`、`bomLineCount=3`、`bomShapeProbe.dataPage1=true`、`bomShapeProbe.dataPage2=true`、`bomKeyEchoed=false`）。递归 BOM 展开、material→FBillNo resolver runtime / composition、Save/Submit/Audit/write 仍为独立 gate。
+>
+> 更新 2026-06-30：material→FBillNo resolver **仅打开 GATE-front contract** —— `integration-core-k3wise-bom-material-resolver-gate-contract-design-20260630.md` 记录 read-only lookup 合同、operator redacted live shape ask、R1→R8 unknowns。无 runtime、无 resolver call、无 BOM call、无 composition、无 recursion、无 write。
 >
 > 引用（非重复推导）：#1709（read/list 线 + 诊断 ledger）、`data-source-system-integration-delivery-todo-20260614.md`（子线状态）、`data-factory-k3-read-list-development-verification-20260626.md`（#3263）。
 
@@ -52,7 +54,7 @@
 
 **实体机 C4 BOM read-smoke（values-free）PASS**：release `multitable-onprem-k3-c4-bom-read-20260630-efa832a08`（package provenance `gitCommit=efa832a08d560e3ddd983da0096ce89cf4c213ae`）部署后，operator 使用 owner-approved private `FBillNo` 运行 exactly one read-smoke：`httpStatus=200`、`responseOk=true`、`apiOk=true`、`presetId=k3wise.material-bom.v1`、`mode=bom`、`bomKeyEchoed=false`、`recordPresent=true`、`recordCount=3`、`bomHeaderPresent=true`、`bomLinePresent=true`、`bomHeaderCount=1`、`bomLineCount=3`、`bomShapeProbe.dataPage1=true`、`bomShapeProbe.dataPage2=true`、`bomResponseShapeProbe.fixedContainers.dataPage1.type=array length=1`、`bomResponseShapeProbe.fixedContainers.dataPage2.type=array length=3`、`errorCode=null`、`errorType=null`。边界守住：no raw payload / no row values / no material or BOM key echo / no messages / no credentials / no resolver / no Save / Submit / Audit / production write。
 
-**C4 BOM 单层读闭合**：能力仅为 one-call single-level BOM read。递归多层展开、material→FBillNo resolver、以及任何写路径均未打开，仍为独立 gate（见下）。
+**C4 BOM 单层读闭合**：能力仅为 one-call single-level BOM read。递归多层展开、material→FBillNo resolver runtime / composition、以及任何写路径均未打开，仍为独立 gate（见下）；material→FBillNo resolver 本次仅进入 GATE-front contract / shape-intake 状态。
 
 ## 仍为独立 gate（不在本次收口范围、不计为本线开发量）
 
@@ -60,7 +62,8 @@
 | --- | --- | --- |
 | production / batch 外部写 | frozen | 独立 owner 授权（最大风险刀；sandbox 已验证、production 始终单独 gate）|
 | K3 BOM 递归多层展开 | frozen | 单层 read-smoke PASS 不自动解锁；递归 fan-out / request amplification / values-free-at-scale 需独立设计与 owner opt-in |
-| material→FBillNo resolver / server-side composition | frozen | 显式 owner 解锁 + 具名 demand；不能从 BOM read-smoke 推导 |
+| material→FBillNo resolver | GATE-front contract only; runtime frozen | 本次只锁 read-only lookup 形状索取；runtime 需 redacted live lookup shape + owner 单独 opt-in；不能从 BOM read-smoke 推导 |
+| material→FBillNo -> BOM server-side composition | frozen | resolver runtime 之后的独立 opt-in；第一刀 resolver 不自动调用 `BOM/GetDetail` |
 | C5 resolver / server-side composition | frozen | 显式 owner 解锁 + 具名 demand |
 | Windows 默认 temp path 部署 caveat | tracked | #2642（不阻塞 runtime gate）|
 
@@ -70,4 +73,4 @@
 
 ## 一句话
 
-数据库及系统对接能力在 **scoped 层面收口并验证**：只读 DB 源 + K3 单条读 + SQL 批量读 + **WebAPI-LIST C3 列表页读（no-key + keyed）** + **WebAPI-BOM C4 单层读** + sandbox 外部写。WebAPI-LIST C3 由客户 redacted live 样本确认行容器（`Data.Data` PascalCase）→ #3390 修复 → 实体机 no-key rerun PASS；keyed `FNumber` Filter 因 preset 自带 filter shape **无需新代码**、keyed rerun 亦 PASS；C4 BOM 由 #3399 shape-first → #3405 runtime → 实体机 `Data.Page1/Page2` rerun PASS。production 写 / BOM 递归 / material→FBillNo resolver 为独立未来 gate。
+数据库及系统对接能力在 **scoped 层面收口并验证**：只读 DB 源 + K3 单条读 + SQL 批量读 + **WebAPI-LIST C3 列表页读（no-key + keyed）** + **WebAPI-BOM C4 单层读** + sandbox 外部写。WebAPI-LIST C3 由客户 redacted live 样本确认行容器（`Data.Data` PascalCase）→ #3390 修复 → 实体机 no-key rerun PASS；keyed `FNumber` Filter 因 preset 自带 filter shape **无需新代码**、keyed rerun 亦 PASS；C4 BOM 由 #3399 shape-first → #3405 runtime → 实体机 `Data.Page1/Page2` rerun PASS。production 写 / BOM 递归 / material→FBillNo resolver runtime / composition 为独立未来 gate；material→FBillNo resolver 目前仅 GATE-front contract 已打开。

--- a/docs/development/integration-core-k3wise-bom-material-resolver-gate-contract-design-20260630.md
+++ b/docs/development/integration-core-k3wise-bom-material-resolver-gate-contract-design-20260630.md
@@ -1,0 +1,243 @@
+# K3 WISE BOM material to FBillNo resolver - GATE-front contract & design-lock - 2026-06-30
+
+## Status
+
+**GATE-front design only. No runtime implemented in this PR. No K3 call is made.**
+
+Owner-authorized 2026-06-30 as the GATE-front for the next #1709 slice after C4
+single-level BOM read. This PR is docs-only and exists to lock the contract and
+operator shape intake for a **read-only material -> FBillNo resolver** before any
+runtime is built.
+
+Scope fence for this PR:
+
+- no runtime; no preset; no route; no adapter change.
+- no resolver call; no BOM read call; no recursive BOM expansion.
+- no Save / Submit / Audit; no K3 write; no production write.
+- values-free throughout: keys, types, counts, booleans, and structural paths only.
+
+The resolver runtime remains frozen until both are true:
+
+1. the operator/customer provides the redacted live lookup shape described below, and
+2. the owner gives a separate resolver runtime opt-in.
+
+This document does not authorize that runtime.
+
+## Why now
+
+C4 BOM single-level read is shipped and entity-verified:
+
+- #3399 (`c499abe83`) locked the shape-first BOM GATE-front.
+- #3405 (`efa832a08`) shipped `k3wise.material-bom.v1`.
+- The entity-machine read-smoke PASSed with one owner-approved private `FBillNo`:
+  `recordCount=3`, `bomHeaderCount=1`, `bomLineCount=3`, `Data.Page1` header,
+  `Data.Page2` lines, and `bomKeyEchoed=false`.
+
+That capability deliberately reads by **BOM bill number**. It does not answer the
+next operator question: given a material, which BOM bill number should be used?
+
+The next useful bridge is therefore not recursion and not write. It is a narrow,
+read-only resolver:
+
+```text
+material key -> FBillNo candidate(s)
+```
+
+This is still a separate gate. A BOM read-smoke PASS proves `BOM/GetDetail` works for
+an already-known `FBillNo`; it does **not** prove how a live K3 instance maps a material
+to a default/current/active BOM bill.
+
+## Current verified baseline
+
+| Surface | State | Boundary |
+| --- | --- | --- |
+| `k3wise.material-list.v1` | shipped + entity-verified | bounded Material/GetList page read; optional keyed filter; no resolver/write |
+| `k3wise.material-bom.v1` | shipped + entity-verified | one `BOM/GetDetail` call by bound `Data.FBillNo`; single-level; no resolver/recursion/write |
+| material -> FBillNo resolver | **not built** | this design-lock only |
+| recursive BOM expansion | frozen | separate fan-out/request-amplification gate |
+| Save / Submit / Audit / write | frozen | separate owner authorization |
+
+## Proposed contract (post-GATE only)
+
+A future resolver slice may add a built-in resolver preset such as
+`k3wise.material-bom-resolver.v1`. The exact name is not important; the invariants are.
+
+The resolver is a read-only lookup. It may return values internally for the next server
+step, but public evidence must remain values-free.
+
+Allowed post-GATE shape:
+
+```jsonc
+{
+  "presetId": "k3wise.material-bom-resolver.v1",
+  "intent": {
+    "object": "material-bom-resolver",
+    "mode": "resolve_bom_bill",
+    "key": "<owner-approved material key supplied at runtime>"
+  }
+}
+```
+
+Rules:
+
+- `presetId` must be built-in and allowlisted.
+- The request may supply only the runtime material key. It must never supply a raw
+  endpoint, path, method, filter, field list, body, response path, credential, token, or
+  adapter config.
+- The preset owns endpoint/path/body/filter/field selection.
+- Material key encoding is contingent on the operator-confirmed request shape. It must
+  not be copied from C3 LIST or C4 BOM by habit:
+  - expression string -> use the confirmed K3 filter escaping strategy;
+  - structured JSON field -> bound JSON value, no expression escaping;
+  - numeric/internal id -> type-check and bind as the confirmed type.
+- The runtime must fail closed on no match, multiple matches without a deterministic
+  rule, inactive/non-current candidates, unsupported version semantics, or missing
+  required operator inputs.
+- The resolver must not automatically execute `BOM/GetDetail` in the first slice. It
+  proves lookup only. A later server-side composition slice may chain resolver -> BOM
+  read only after a separate owner opt-in.
+
+## Resolver-specific unknowns - blockers for runtime
+
+These must be answered by the redacted live shape before any implementation.
+
+| ID | Question | Why it blocks |
+| --- | --- | --- |
+| R1 | Exact lookup endpoint path + HTTP method | adapter cannot issue the lookup |
+| R2 | Request shape: which field carries the material key; is it a structured body field, filter-expression value, material number, material id, or internal K3 id | safe request builder and key typing cannot be built |
+| R3 | Response container path + case for BOM bill candidate rows | extractor cannot locate candidates |
+| R4 | Candidate row field keys: FBillNo key, material key/id echo field, active/current/default flag, version/effective-date fields, status fields | runtime cannot choose safely or prove why it held |
+| R5 | Multiplicity rule: when multiple BOM bills exist for one material, which one is selected (active/current/default/latest/effective-date/org-specific) | prevents silent wrong-BOM selection |
+| R6 | Organization/scope/version inputs: whether org id, use-org, BOM category, version, or effective date is required | prevents cross-org or stale-version lookup |
+| R7 | No-match / inactive / ambiguous / invalid-material error envelope | distinct fail-closed evidence and stop rules |
+| R8 | Whether the lookup returns just header rows or also line rows | keeps resolver from accidentally becoming BOM read or recursion |
+
+## Operator intake manifest
+
+Requested once from operator/customer, values-free. This can come from a live working K3
+lookup or official K3 WebAPI documentation **for this instance**. Prefer a live shape.
+
+Please provide structure only:
+
+1. **Endpoint** - material-to-BOM lookup path + HTTP method.
+2. **Request skeleton** - body keys / filter keys; mark the material-key field; mark
+   whether it is a structured JSON value, filter expression, internal id, or other typed
+   value. Redact the value.
+3. **Required scope fields** - org id, use-org, BOM category, version/effective date, or
+   other flags if required. Redact values.
+4. **Response skeleton** - top-level keys + types; candidate row container path + case +
+   type + arrayLength.
+5. **Candidate row field keys + types** - especially the FBillNo field, active/current
+   flag, version/effective-date fields, material key/id echo field, status, and org/scope
+   fields. No values.
+6. **Multiplicity examples** - values-free counts only:
+   - one material -> zero candidate rows;
+   - one material -> exactly one current/active candidate;
+   - one material -> multiple candidates, with the field that determines the selected
+     one.
+7. **Error envelope** - keys/codes for invalid material, no BOM, inactive BOM, and
+   ambiguous version.
+
+Redaction rules:
+
+- Do not include material numbers/names/ids, BOM bill numbers, row values, messages, raw
+  payloads, credentials, tokens, cookies, authority codes, connection strings,
+  host/system/tenant ids, or arbitrary response keys beyond the requested skeleton.
+- Allowed evidence is structural: field names, types, booleans, counts, container paths,
+  enum-like error codes, and array lengths.
+
+Ready-to-post operator request:
+
+```text
+Next operator/customer step: material→FBillNo resolver GATE-front.
+Please provide one redacted live material-to-BOM lookup request/response SHAPE.
+
+Structure only, no values:
+- endpoint path + HTTP method
+- request skeleton; mark the material-key field and whether it is a structured JSON
+  value, filter-expression value, material number/id, or internal K3 id
+- required scope fields: org/use-org/BOM category/version/effective date/etc.
+- response skeleton: top-level keys+types; candidate row container path+case+type+
+  arrayLength
+- candidate row field keys+types: FBillNo, active/current/default/status, version/
+  effective-date, org/scope, material echo field if present
+- multiplicity rule: zero/one/multiple candidate row counts and which field selects the
+  default/current bill
+- error envelope keys/codes for invalid material, no BOM, inactive BOM, ambiguous version
+
+Redact all material numbers/names/ids, FBillNo values, row values, raw payloads, messages,
+credentials/tokens/cookies/authority codes, connection strings, host/system/tenant ids.
+Boundary: shape request only. No resolver runtime, no BOM call, no recursion, no
+Save/Submit/Audit/write.
+```
+
+## Error taxonomy (post-GATE)
+
+A distinct prefix keeps resolver evidence separate from BOM read and write paths.
+
+| Condition | Code |
+| --- | --- |
+| resolver endpoint not configured | `K3_WISE_BOM_RESOLVER_NOT_CONFIGURED` |
+| material key missing / invalid | `K3_WISE_BOM_RESOLVER_KEY_INVALID` |
+| transport / HTTP error | `K3_WISE_BOM_RESOLVER_FAILED` |
+| candidate container not located | `K3_WISE_BOM_RESOLVER_CONTAINER_UNLOCATED` |
+| no BOM candidate for material | `K3_WISE_BOM_RESOLVER_NOT_FOUND` |
+| multiple candidates, no deterministic rule | `K3_WISE_BOM_RESOLVER_AMBIGUOUS` |
+| K3 business error in response | `K3_WISE_BOM_RESOLVER_BUSINESS_ERROR` |
+
+Resolver errors must not fall through to `K3_WISE_BOM_READ_*` or Save / Submit / Audit
+paths.
+
+## Boundary and non-goals
+
+- No runtime in this PR.
+- No K3 call in this PR.
+- No automatic resolver -> BOM read composition in the first resolver slice.
+- No recursive BOM expansion.
+- No material master search beyond the specific resolver shape.
+- No Save / Submit / Audit; no K3 write; no external/production write.
+- No UI.
+- No migration.
+- No credential or external-system config mutation.
+- No values in docs, fixtures, logs, PR text, comments, or issue evidence.
+
+## Post-GATE implementation ladder
+
+Each row is a separate opt-in.
+
+| Slice | Scope | Runtime opened |
+| --- | --- | --- |
+| R0 | This design-lock + operator shape ask | None |
+| R1 | Resolver contract normalizer + preset metadata tests | None |
+| R2 | Resolver read-smoke runtime for material -> FBillNo lookup only | One allowlisted read-only lookup |
+| R3 | Optional composition: resolver output feeds `k3wise.material-bom.v1` in one server action | Separate opt-in; still read-only |
+| R4 | Recursive BOM expansion | Separate fan-out gate |
+| R5 | Any write path | Separate owner authorization |
+
+No slice may combine resolver contract + runtime + composition in one PR. No slice may
+include Save, Submit, Audit, K3 write, production write, or recursive fan-out.
+
+## Acceptance locks for the first runtime slice
+
+When R2 is opened, it must prove:
+
+- request cannot supply raw endpoint/path/method/body/filter/response path;
+- unknown preset/object/mode fails closed before adapter creation;
+- missing material key fails closed before K3 is called;
+- no-match and ambiguous-match outcomes hold, not guess;
+- values-free success evidence: `candidateCount`, `resolved=true|false`,
+  `ambiguous=true|false`, `selectedRule=<enum>`, `keyEchoed=false`;
+- values-free failure evidence: enum-like error code/type only, no message or raw payload;
+- resolver does not call `BOM/GetDetail`;
+- resolver does not call Save / Submit / Audit or any write;
+- persisted external-system config is not mutated;
+- route remains operator-gated (`integration:write`) if exposed via read-smoke.
+
+## Disposition
+
+This document opens only the **GATE-front**. The actual resolver remains frozen until the
+operator shape arrives and the owner explicitly opts into the runtime slice.
+
+The already verified C4 BOM read remains what it is: one-call single-level read by known
+`FBillNo`. It is not a material-to-BOM resolver and it does not authorize server-side
+composition.


### PR DESCRIPTION
## Summary

Docs-only GATE-front for the next #1709 slice: a read-only material -> FBillNo resolver contract before any runtime.

This adds a design-lock that:
- keeps the current C4 BOM read boundary intact: `k3wise.material-bom.v1` remains one-call single-level read by known `FBillNo`;
- defines a future resolver as lookup-only (`material key -> FBillNo candidate(s)`), not automatic BOM read composition;
- front-loads the operator/customer redacted live shape ask for endpoint/request/container/multiplicity/error envelope;
- records the R0 -> R5 ladder so resolver runtime, composition, recursion, and write each stay separate opt-ins.

I also updated the two current ledgers so they say the precise new state: material->FBillNo resolver has a GATE-front contract only; runtime/composition are still frozen.

## Boundary

No runtime, no preset, no route, no adapter change, no K3 call, no resolver call, no BOM call, no composition, no recursion, no Save/Submit/Audit/write.

## Validation

- `git diff --check`
- values-free scan over the touched docs for obvious sample-value/secret bait

## Operator ask

The new design-lock includes a ready-to-post values-free operator/customer request for the material-to-BOM lookup shape. Runtime remains blocked until that shape arrives and the owner gives a separate opt-in.
