### PR TITLE
fix(automation): date_field treats a date-type field as a FLOATING calendar day (Option 1)

### DIFF
--- a/docs/development/automation-date-field-floating-day-design-lock-20260630.md
+++ b/docs/development/automation-date-field-floating-day-design-lock-20260630.md
@@ -1,0 +1,143 @@
+# Design-lock — `date_field` reminders treat a `date`-type field as a FLOATING calendar day (Option 1)
+
+> Small, self-contained correctness arc. **Not** mixed with R1 (BPMN/SSRF). Fixes the owner-ratified P2:
+> a `date`-type trigger field + a negative-offset (Western-hemisphere) timezone fires the reminder **one
+> calendar day early**. Surfaced from the T2-5 (#3401) DST work; the underlying facts predate T2-5 but #3401
+> is the change that made the negative-offset path reachable. Owner ratified **Option 1** on 2026-06-30.
+
+## 1. The defect (locked by the finding, re-stated for the record)
+
+`schedule.date_field` rule, trigger field is a **`date`-type** field (date-picker writes a bare `YYYY-MM-DD`),
+configured with a **negative-offset IANA tz** (`America/*`) → reminder fires one day early. Empirical, on the
+merged T2-5 code, "3 days before `2026-03-08`, 09:00":
+
+| timezone | occurrence (UTC) | local | verdict |
+|---|---|---|---|
+| `America/New_York` | `2026-03-04T14:00:00.000Z` | **Mar 4** 09:00 | ❌ should be Mar 5 |
+| `UTC` | `2026-03-05T09:00:00.000Z` | Mar 5 | ✅ |
+| `Asia/Shanghai` (+8) | `2026-03-05T01:00:00.000Z` | Mar 5 09:00 | ✅ |
+
+**Root cause (two pre-existing facts that interact only once a non-UTC tz is honored):**
+1. `field-codecs.ts:1096-1097` — the value codec normalizes `dateTime` → full UTC ISO (`toISOString()`), but
+   **`date` has no case** and falls through to `return value` verbatim → a `date` field stores a bare
+   `YYYY-MM-DD`.
+2. `automation-date-reminder.ts:216` — the zoned day-bucket does `getZonedParts(t, tz)` where `t` is
+   `new Date('2026-03-08')` = UTC midnight. In a negative-offset zone, UTC-midnight's **local** day is the
+   PREVIOUS day → the entire offset/timeOfDay computation is anchored one civil day early.
+3. `validateDateFieldTriggerAtSave` accepts **both** `date` and `dateTime` trigger fields.
+
+## 2. Decision — Option 1: a `date` value is a FLOATING calendar day
+
+A date-only field has **no instant**. `2026-03-08` means "the calendar day the user picked", and its day must
+**not** move with timezone. So:
+
+- **`date`-type field (floating):** derive the anchor calendar day from the **literal `YYYY-MM-DD`** (not by
+  parsing to a UTC instant and re-zoning). Shift by ±`offsetDays` civil days, then place `timeOfDay` as the
+  **local** wall-clock in `config.timezone` and convert that to a UTC instant.
+- **`dateTime`-type field (instant):** UNCHANGED — `getZonedParts(instant, tz)` → local day → shift → local
+  `timeOfDay`. A real instant legitimately belongs to different civil days in different zones; that is correct.
+- **UTC / no-tz path:** UNCHANGED for both (literal UTC parts already equal the floating day).
+
+**Rejected alternatives (owner-confirmed):** Option 2 (codec-normalize `date` → local-noon) touches global
+storage semantics — far larger blast radius. Option 3 (forbid non-UTC tz on `date` fields) is too conservative
+— it removes the most common date-reminder configuration (a localized day reminder).
+
+## 3. Implementation (the small arc — 5 points)
+
+**P1 — `computeDateReminderOccurrence` gains floating semantics.** Add a 3rd param
+`opts: { floating?: boolean } = {}` (NOT a new persisted config key — the flag is derived from the field type
+at scan time, not stored). When `floating`:
+  - Resolve the anchor day from the bare value: regex `^(\d{4})-(\d{2})-(\d{2})` → `{year, month, day}`; if the
+    value is a `Date` or a non-matching string, fall back to the parsed instant's **UTC** parts (a `date`
+    stored as full-ISO-midnight still yields the right civil day). Absent/unparseable → `null` (unchanged).
+  - Use that day in BOTH the UTC branch and the zoned branch **in place of** `getZonedParts(t, tz)`. Everything
+    downstream (civil-day shift, `zonedWallClockToUtcMs(timeOfDay)`, junk-tz→UTC catch) is unchanged.
+  - Default (`floating` absent/false) = today's instant semantics → **byte-identical** for every existing
+    caller and golden.
+
+**P2 — `evaluateDateReminders` plumbs the field type.** After the config validation (automation-service.ts
+~1223), do ONE `SELECT type FROM meta_fields WHERE sheet_id = $1 AND id = $2` for `dateFieldId` (mirrors
+`validateDateFieldTriggerAtSave`; one query per scan, not per record). `floating = fieldType === 'date'`,
+passed to `computeDateReminderOccurrence(data[dateFieldId], config, { floating })`. **Fail-closed on the field
+type:** if the row is MISSING (deleted) or NO LONGER `date`/`dateTime` (retyped to string/etc.), **skip the
+scan** (`return` + warn) — do NOT fall through to instant. The record JSONB can retain the stale `dateFieldId`
+key after a delete/retype, so `data ->> dateFieldId` may still match; relying on "candidates matches nothing"
+would fire reminders for a field that is no longer a date trigger (and for a former `date` field, at the
+day-early value). Locked by real-DB `DR-GONE` (retype→string AND field-delete, both RED-before).
+
+**P3 — SQL pre-filter boundary, made exact for bare dates.** `dateReminderCandidateDateRange` returns full-ISO
+bounds; the candidates query compares `data->>field BETWEEN lo AND hi` lexicographically. A bare `YYYY-MM-DD`
+that equals the `lo` **date** sorts BEFORE a full-ISO `lo` (the bare string is a prefix) → it can be wrongly
+excluded at the exact boundary day. Fix: return **date-only, widened** bounds — `loBound = dateOnly(lo)` (start
+of the lo civil day) and `hiBound = dateOnly(hi + 1 day)` (start of the day after hi). Both bare `YYYY-MM-DD`
+and full-ISO stored values then fall inside by lexicographic compare; the result is a strict **superset** of
+today's window (the exact gate stays the JS `isDateReminderDue`). Update the `dateReminderCandidateDateRange`
+unit assertions to the new bounds.
+
+**P4 — Goldens.**
+  - *Pure unit* (`automation-date-reminder.test.ts`): floating `2026-03-08` + `America/New_York` + 3-before +
+    09:00 → `2026-03-05T14:00:00.000Z` (Mar 5 09:00 EST). The SAME inputs with `floating:false` →
+    `2026-03-04T14:00:00.000Z` (documents that the day-early value is *correct* for a true instant). Plus:
+    floating `Asia/Shanghai` (positive offset, no shift either way) and floating UTC-path unchanged.
+  - *Real-DB* (`tests/integration/multitable-date-reminder-trigger.test.ts`): a `date`-type record storing a
+    **bare `YYYY-MM-DD`** (as the date-picker writes — the existing fixtures store full ISO and so never
+    exercised this path) + `America/New_York` rule fires once through the **real SQL pre-filter**, and the
+    ledger `occurrence_ts` equals the corrected floating-day instant (the buggy value would be one civil day
+    earlier). This single test covers both the bare-date SQL fetch (P3) and the occurrence correctness (P1+P2).
+    The file is already in `plugin-tests.yml:298` → CI-covered.
+
+**P5 — Fix the DST golden comment.** The block added in #3401
+(`automation-scheduler-date-reminder.test.ts`) currently describes the bare-date day-bucketing **neutrally as
+"how it works"**. Update the comment so it no longer reads as blessing the day-early behavior, and note that
+the floating fix changes the `date`-type day-derivation while the DST gap/overlap clock behavior it tests is
+unaffected (it uses `dateTime`-style instant inputs).
+
+## 4. Compatibility / re-fire note
+
+For an affected rule (floating field + negative-offset tz) with a due occurrence in the 48h window at deploy,
+the corrected `occurrence_ts` is a NEW dedup key → a **bounded one-time re-fire** is possible — identical to
+the already-accepted "editing a rule's timezone re-buckets `occurrence_ts`" semantic (Q5, the module header).
+It self-corrects to the right day thereafter; historical ledger rows are never rewritten. CN/positive-offset
+and UTC tenants, and all `dateTime`-field rules, see **no change**.
+
+## 5. Verification gate
+
+tsc 0 · `automation-date-reminder.test.ts` + `automation-scheduler-date-reminder.test.ts` green · the new
+real-DB golden green against local Postgres · `dateReminderCandidateDateRange` unit assertions updated · the
+full automation-v1 suite unchanged on the UTC/`dateTime` paths · adversarial verification pass over the diff
+(boundary dates, month/year rollover, leap day, DST-gap-on-floating-date, dedup-key stability). Then PR →
+rebase → CI green → merge, per the standing gate. **R1 follows after this lands.**
+
+## 6. Adversarial verification outcome (5-skeptic panel over the built diff)
+
+All five dimensions returned **solid**: occurrence-edges (month/year/leap/junk rollover all identical between
+floating and instant — divergence is ONLY the intended literal-day source), **SQL superset** (brute-forced
+thousands of due records across date-line / DST / leap zones — **zero false-negatives**), dateTime-unchanged
+(byte-identical for `floating=false`, line-by-line), scanner-plumbing, and re-fire/dedup (re-fire stays bounded
+to at-most-once). Two `isReal` **P3** edge findings were folded in (both adjacent to the new scan block):
+
+- **Transient `meta_fields` read failure → day-early spurious fire.** The catch originally defaulted
+  `floating=false`, which for a `date`-field in a negative-offset tz emits the *buggy* day-early occurrence as
+  its one allowed re-fire. Changed to **skip the scan tick** (`return`) — the grace window + next tick recover
+  it with no wrong-day fire. Locked by real-DB `DR-SKIP-ON-READ-FAIL` (RED-before: it fired the day-early one).
+- **`dateFieldId` trim parity (pre-existing).** The save validator trims before its lookup but the scan read
+  the id un-trimmed, so a whitespace-padded id passed save then silently no-op'd at scan. The scan now trims
+  once (aligns both the new type read and the existing `data ->> dateFieldId` candidates key). Locked by
+  real-DB `DR-TRIM` (RED-before: the padded rule fired nothing).
+
+Out-of-scope note (NOT fixed here — flagged for a separate item): `validateDateFieldTriggerAtSave` doesn't cap
+`offsetDays` magnitude, so an absurd value (e.g. 1e12) makes `dateReminderCandidateDateRange` throw `RangeError`
+and aborts that rule's scan. Pre-existing, orthogonal to floating, and a total-skip (not a per-record
+false-negative); left for a follow-up so this arc stays small.
+
+## 7. Owner review (PR #3417) — P2 fix
+
+The owner caught a **P2** the adversarial panel rated only P3: the original scan block set
+`floating = ft === 'date'` and **fell through** for a missing/retyped field — the docstring *claimed* skip but
+the code did not, and the "candidates matches nothing" assumption is unsafe because a record's JSONB keeps the
+stale `dateFieldId` key after a field delete/retype. So a `date_field` rule whose trigger field was deleted or
+retyped to `string` would keep firing reminders off the stale key (and a former `date` field would fire the
+day-early value). Fixed with a fail-closed guard: proceed only when the field is `date`/`dateTime`, else skip
+the scan. Locked by `DR-GONE`. (Non-blocking confirmations accepted: relative real-DB golden is correct;
+`dateFieldId.trim()` stays in this arc, not peeled; skip-whole-tick on a read throw is the right posture; the
+`offsetDays` `RangeError` is a fine separate follow-up.)

--- a/packages/core-backend/src/multitable/automation-date-reminder.test.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.test.ts
@@ -124,6 +124,82 @@ describe('computeDateReminderOccurrence — timezone-aware (T2-5)', () => {
   })
 })
 
+describe('computeDateReminderOccurrence — FLOATING date-only field (Option 1: date vs dateTime)', () => {
+  const NY = 'America/New_York' // EST = UTC-5 in March (before DST), EDT = UTC-4 in summer
+
+  // THE regression lock. A `date`-type field stores a bare 'YYYY-MM-DD' (the date-picker output). A date-only
+  // value has NO instant, so its calendar day must NOT move with timezone. "3 days before 2026-03-08, 09:00"
+  // in New York must be Mar 5 09:00 EST (= 14:00Z), NOT Mar 4. Before the fix the bare date was parsed to UTC
+  // midnight then re-zoned to the PREVIOUS NY day, firing a civil day early.
+  test('floating + negative-offset tz: the bare calendar day does NOT shift (Mar 8 → Mar 5 09:00 EST)', () => {
+    expect(
+      computeDateReminderOccurrence(
+        '2026-03-08',
+        { offsetDays: 3, direction: 'before', timeOfDay: '09:00', timezone: NY },
+        { floating: true },
+      ),
+    ).toBe('2026-03-05T14:00:00.000Z')
+  })
+
+  // The SAME shape WITHOUT floating (a real dateTime instant at UTC-midnight) keeps instant→local-day
+  // semantics: 2026-03-08T00:00Z is locally Mar 7 in NY, so 3-before lands Mar 4. This is CORRECT for an
+  // instant and documents exactly why the two field types must diverge — the floating fix must not touch it.
+  test('instant (dateTime) default is UNCHANGED: a UTC-midnight instant re-zones to the previous NY day', () => {
+    const cfg = { offsetDays: 3, direction: 'before' as const, timeOfDay: '09:00', timezone: NY }
+    expect(computeDateReminderOccurrence('2026-03-08T00:00:00.000Z', cfg)).toBe('2026-03-04T14:00:00.000Z')
+    // floating:false is identical to omitting opts.
+    expect(computeDateReminderOccurrence('2026-03-08T00:00:00.000Z', cfg, { floating: false })).toBe(
+      '2026-03-04T14:00:00.000Z',
+    )
+  })
+
+  test('floating + positive-offset tz (Asia/Shanghai +8): no shift either way (Mar 5 09:00 CST = Mar 5 01:00Z)', () => {
+    expect(
+      computeDateReminderOccurrence(
+        '2026-03-08',
+        { offsetDays: 3, direction: 'before', timeOfDay: '09:00', timezone: 'Asia/Shanghai' },
+        { floating: true },
+      ),
+    ).toBe('2026-03-05T01:00:00.000Z')
+  })
+
+  test('floating UTC path is byte-identical (no tz): the bare date buckets in UTC exactly as before', () => {
+    expect(
+      computeDateReminderOccurrence('2026-03-08', { offsetDays: 3, direction: 'before', timeOfDay: '09:00' }, { floating: true }),
+    ).toBe('2026-03-05T09:00:00.000Z')
+  })
+
+  test('floating + DST spring-forward gap: a non-existent local timeOfDay resolves FORWARD (not skipped)', () => {
+    // floating Mar 8, 0-before, 02:30 NY — 02:30 does not exist on the spring-forward day → 03:30 EDT = 07:30Z.
+    expect(
+      computeDateReminderOccurrence(
+        '2026-03-08',
+        { offsetDays: 0, direction: 'before', timeOfDay: '02:30', timezone: NY },
+        { floating: true },
+      ),
+    ).toBe('2026-03-08T07:30:00.000Z')
+  })
+
+  test('floating with a full-ISO-midnight value (legacy date stored as ISO): still the literal civil day', () => {
+    // A date-only field whose value was persisted as full-ISO-midnight must STILL take the literal day, so the
+    // floating fallback (UTC parts) gives Mar 8 → Mar 5 09:00 EST, not the re-zoned Mar 7.
+    expect(
+      computeDateReminderOccurrence(
+        '2026-03-08T00:00:00.000Z',
+        { offsetDays: 3, direction: 'before', timeOfDay: '09:00', timezone: NY },
+        { floating: true },
+      ),
+    ).toBe('2026-03-05T14:00:00.000Z')
+  })
+
+  test('floating null/empty/unparseable ⇒ null (unchanged)', () => {
+    const cfg = { offsetDays: 1, direction: 'before' as const, timezone: NY }
+    expect(computeDateReminderOccurrence(null, cfg, { floating: true })).toBeNull()
+    expect(computeDateReminderOccurrence('', cfg, { floating: true })).toBeNull()
+    expect(computeDateReminderOccurrence('not-a-date', cfg, { floating: true })).toBeNull()
+  })
+})
+
 describe('date-reminder timer boundary — timezone-aware (T2-5)', () => {
   const NY = 'America/New_York'
 
@@ -253,5 +329,24 @@ describe('dateReminderCandidateDateRange — SQL pre-filter brackets the product
     expect(dateValue >= loIso && dateValue <= hiIso).toBe(true)
     // a far-future date (occurrence well beyond now) is OUTSIDE the range.
     expect('2026-09-01T00:00:00.000Z' <= hiIso).toBe(false)
+  })
+
+  test('DATE-ONLY bounds: a bare YYYY-MM-DD on the boundary day is INCLUDED (full-ISO bounds would drop it)', () => {
+    const now = Date.parse('2026-06-25T12:00:00.000Z')
+    const window = DATE_REMINDER_GRACE_WINDOW_MS
+    const cfg = { offsetDays: 3, direction: 'before' as const }
+    const { loIso, hiIso } = dateReminderCandidateDateRange(now, cfg, window)
+    // Bounds are date-only ('YYYY-MM-DD') so the lexicographic SQL BETWEEN is exact for a bare date value.
+    expect(loIso).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(hiIso).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    // The productive bare date (occurrence ≈ now ⇒ dateDay ≈ 06-28) is inside the range.
+    expect('2026-06-28' >= loIso && '2026-06-28' <= hiIso).toBe(true)
+    // A bare date sitting exactly on the lo boundary day is INCLUDED now…
+    const bareOnLoDay = loIso // loIso is itself a bare date on the lo civil day
+    expect(bareOnLoDay >= loIso).toBe(true)
+    // …whereas the OLD full-ISO lower bound (a time-suffixed instant on the same day) would have EXCLUDED it,
+    // because the bare string is a prefix of the timestamp and sorts BEFORE it. This is the boundary-luck fix.
+    const oldFullIsoLo = `${loIso}T12:00:00.000Z`
+    expect(bareOnLoDay >= oldFullIsoLo).toBe(false)
   })
 })

--- a/packages/core-backend/src/multitable/automation-date-reminder.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.ts
@@ -185,13 +185,42 @@ export function dateReminderTimeOfDayPassed(
 }
 
 /**
+ * The literal calendar day of a FLOATING (date-only) value. A `date`-type field stores a bare 'YYYY-MM-DD'
+ * (the date-picker output — field-codecs passes `date` values through un-normalized, only `dateTime` is
+ * toISOString-normalized), so a date-only field has NO instant and its day must be read straight from the
+ * string, NOT re-derived by parsing to a UTC instant and re-zoning (which shifts back a civil day in a
+ * negative-offset zone). Falls back to the parsed instant's UTC parts for a Date object or a non-bare string
+ * (a date-only value persisted as full-ISO-midnight still yields the right civil day). Month is 1-based to
+ * match `getZonedParts`. PURE.
+ */
+function floatingCalendarDay(value: unknown, parsed: Date): { year: number; month: number; day: number } {
+  if (typeof value === 'string') {
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(value.trim())
+    if (m) {
+      // Normalize through Date.UTC so any out-of-range component rolls over EXACTLY as the instant path would —
+      // floating and instant never diverge on junk input (and unparseable values were already rejected above).
+      const norm = new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])))
+      return { year: norm.getUTCFullYear(), month: norm.getUTCMonth() + 1, day: norm.getUTCDate() }
+    }
+  }
+  return { year: parsed.getUTCFullYear(), month: parsed.getUTCMonth() + 1, day: parsed.getUTCDate() }
+}
+
+/**
  * PURE occurrence: the instant a record's reminder should fire, day-bucketed in `config.timezone` (UTC when
  * absent/'UTC'/invalid). Returns an ISO string, or null if the date value is absent/unparseable. NEVER reads
  * NOW. The UTC path is byte-identical to pre-T2-5; the zoned path day-buckets in LOCAL time and converts back.
+ *
+ * `opts.floating` (a `date`-type field): the value is a FLOATING calendar day with no instant, so the anchor
+ * day is the LITERAL 'YYYY-MM-DD' (it does NOT move with timezone); `timeOfDay` is still placed as the LOCAL
+ * wall-clock in `config.timezone`. Default (absent/false, a `dateTime` field) keeps the instant→local-day
+ * semantics → BYTE-IDENTICAL for every existing caller. The day-source is the only difference; the civil-day
+ * shift + timeOfDay conversion + junk-tz→UTC defense are shared.
  */
 export function computeDateReminderOccurrence(
   dateValue: unknown,
   config: { offsetDays?: number; direction?: 'before' | 'after'; timeOfDay?: string; timezone?: string },
+  opts: { floating?: boolean } = {},
 ): string | null {
   if (dateValue === null || dateValue === undefined || dateValue === '') return null
   const d = dateValue instanceof Date ? dateValue : new Date(String(dateValue))
@@ -202,18 +231,25 @@ export function computeDateReminderOccurrence(
   const signedDays = config.direction === 'after' ? offset : -offset
   const tz = resolveReminderTimeZone(config.timezone)
 
+  // FLOATING (date-only) → the literal calendar day; otherwise the day is derived from the instant per-path.
+  const floatingDay = opts.floating ? floatingCalendarDay(dateValue, d) : null
+  const utcDay = () =>
+    floatingDay ?? { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() }
+
   if (!tz) {
-    // Day-bucket: strip the source time-of-day to UTC midnight, then shift by whole days. (UNCHANGED.)
-    const dayUtcMidnight = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+    // Day-bucket: strip the source time-of-day to UTC midnight, then shift by whole days. (UNCHANGED for
+    // instant; for floating the literal day equals the UTC-midnight day, so this stays byte-identical too.)
+    const base = utcDay()
+    const dayUtcMidnight = Date.UTC(base.year, base.month - 1, base.day)
     const reminderDay = dayUtcMidnight + signedDays * DAY_MS
     const occurrenceMs = reminderDay + parseTimeOfDayMinutes(config.timeOfDay) * 60 * 1000
     return new Date(occurrenceMs).toISOString()
   }
 
   try {
-    // Zoned day-bucket: take the source date's LOCAL calendar day, shift by whole CIVIL days, then set the
-    // LOCAL `timeOfDay` and convert that local wall-clock back to a UTC instant.
-    const p = getZonedParts(t, tz)
+    // Zoned day-bucket: the anchor day is the FLOATING literal day (date-only) or the instant's LOCAL calendar
+    // day (dateTime); shift by whole CIVIL days, then set the LOCAL `timeOfDay` and convert back to a UTC instant.
+    const p = floatingDay ?? getZonedParts(t, tz)
     const shifted = new Date(Date.UTC(p.year, p.month - 1, p.day + signedDays))
     const mins = parseTimeOfDayMinutes(config.timeOfDay)
     const occurrenceMs = zonedWallClockToUtcMs(
@@ -229,8 +265,9 @@ export function computeDateReminderOccurrence(
     )
     return new Date(occurrenceMs).toISOString()
   } catch {
-    // Runtime defense (Q6): a persisted-junk tz must never throw — degrade to UTC bucketing.
-    const dayUtcMidnight = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+    // Runtime defense (Q6): a persisted-junk tz must never throw — degrade to UTC bucketing (floating-aware).
+    const base = utcDay()
+    const dayUtcMidnight = Date.UTC(base.year, base.month - 1, base.day)
     const reminderDay = dayUtcMidnight + signedDays * DAY_MS
     const occurrenceMs = reminderDay + parseTimeOfDayMinutes(config.timeOfDay) * 60 * 1000
     return new Date(occurrenceMs).toISOString()
@@ -280,10 +317,17 @@ export function dateReminderFloorMs(ruleCreatedAtMs: number, effectiveAt: string
 
 /**
  * PURE coarse date-VALUE range for the SQL pre-filter. Only records whose date field falls in this window
- * can possibly produce an occurrence in the firing window, so SQL fetches just those (ISO strings sort
+ * can possibly produce an occurrence in the firing window, so SQL fetches just those (ISO date strings sort
  * chronologically → a plain string BETWEEN works, no cast that could throw on legacy junk). Deliberately
  * GENEROUS (±2 day slack for day-bucketing + timeOfDay); the JS predicate (`isDateReminderDue`) is the exact
- * gate. Returns inclusive ISO bounds.
+ * gate. Returns inclusive bounds.
+ *
+ * Bounds are DATE-ONLY and widened a day on each end so the lexicographic `data->>field BETWEEN lo AND hi` is
+ * exact for BOTH a bare 'YYYY-MM-DD' (date-type, the date-picker output) AND a full-ISO
+ * 'YYYY-MM-DDTHH:mm:ss.sssZ' (dateTime). A bare date equal to a full-ISO bound's day sorts BEFORE it (the bare
+ * string is a prefix) and would be wrongly EXCLUDED at the exact boundary day; truncating lo to its civil day
+ * (start) and extending hi to the day AFTER makes the range a strict SUPERSET of the old window on both ends,
+ * so no record that should fire is ever dropped by the pre-filter, regardless of how its date value is stored.
  */
 export function dateReminderCandidateDateRange(
   nowMs: number,
@@ -299,5 +343,7 @@ export function dateReminderCandidateDateRange(
   const occHi = nowMs
   const lo = occLo - signedDays * DAY_MS - SLACK
   const hi = occHi - signedDays * DAY_MS + SLACK
-  return { loIso: new Date(lo).toISOString(), hiIso: new Date(hi).toISOString() }
+  const dateOnly = (ms: number) => new Date(ms).toISOString().slice(0, 10)
+  // lo → start of its civil day (≤ a bare date that day); hi → the day AFTER (≥ any time component that day).
+  return { loIso: dateOnly(lo), hiIso: dateOnly(hi + DAY_MS) }
 }

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1212,7 +1212,10 @@ export class AutomationService {
    */
   private async evaluateDateReminders(rule: ExecutorRule): Promise<void> {
     const config = rule.trigger.config as Partial<ScheduleDateFieldConfig>
-    const dateFieldId = typeof config.dateFieldId === 'string' ? config.dateFieldId : ''
+    // TRIM to match validateDateFieldTriggerAtSave (which trims before its field lookup): otherwise a rule
+    // saved via direct API with a whitespace-padded dateFieldId passes save but silently no-ops at scan (the
+    // type read + the `data ->> dateFieldId` candidates key both miss). Parity keeps "saved ⇒ scans".
+    const dateFieldId = typeof config.dateFieldId === 'string' ? config.dateFieldId.trim() : ''
     if (
       !dateFieldId ||
       typeof config.offsetDays !== 'number' ||
@@ -1247,6 +1250,33 @@ export class AutomationService {
     const ruleFloorMs = dateReminderFloorMs(ruleCreatedAtMs, config.effectiveAt)
     const { loIso, hiIso } = dateReminderCandidateDateRange(nowMs, config, scanWindowMs)
 
+    // FLOATING-DAY semantics: a `date`-type field stores a bare 'YYYY-MM-DD' (date-only, no instant), so its
+    // calendar day must NOT be re-zoned (that fires a civil day early in a negative-offset tz). A `dateTime`
+    // field is a real instant and keeps instant→local-day semantics. Read the field's type ONCE per scan
+    // (mirrors validateDateFieldTriggerAtSave) — not per record.
+    //   • Field GONE (no row) or NO LONGER date/dateTime (retyped to string/etc.) → SKIP. The record JSONB can
+    //     retain the stale key after a field delete/retype, so `data ->> dateFieldId` may still match — we must
+    //     NOT rely on "candidates matches nothing" and fire reminders for what is no longer a date trigger.
+    //   • THROWN read (transient DB fault) → SKIP this tick too: degrading to instant would, for a date-type
+    //     field in a negative-offset tz, emit the day-EARLY occurrence as a spurious wrong-day reminder. The
+    //     fixed grace window + next tick re-scan recover it with no wrong-day fire.
+    let floating = false
+    try {
+      const ftRes = await this.queryFn('SELECT type FROM meta_fields WHERE sheet_id = $1 AND id = $2', [
+        rule.sheetId,
+        dateFieldId,
+      ])
+      const ft = (ftRes.rows as Array<{ type?: unknown }>)[0]?.type
+      if (ft !== 'date' && ft !== 'dateTime') {
+        logger.warn(`Rule ${rule.id}: date field ${dateFieldId} is missing or no longer date/dateTime — skipping scan`)
+        return
+      }
+      floating = ft === 'date'
+    } catch (err) {
+      logger.warn(`Rule ${rule.id}: date-field type read failed — skipping this scan tick (no wrong-day fire): ${String(err)}`)
+      return
+    }
+
     // Coarse SQL pre-filter: only records whose date field falls in the window can produce a due occurrence.
     const candidates = await sql<{ id: string; data: Record<string, unknown> | string | null }>`
       SELECT id, data
@@ -1260,7 +1290,7 @@ export class AutomationService {
     for (const rec of candidates.rows) {
       const data: Record<string, unknown> =
         typeof rec.data === 'string' ? (JSON.parse(rec.data) as Record<string, unknown>) : (rec.data ?? {})
-      const occurrence = computeDateReminderOccurrence(data[dateFieldId], config)
+      const occurrence = computeDateReminderOccurrence(data[dateFieldId], config, { floating })
       if (!occurrence) continue
       if (!isDateReminderDue(occurrence, nowMs, scanWindowMs, ruleFloorMs)) continue
 

--- a/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
@@ -24,6 +24,7 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 import { AutomationService } from '../../src/multitable/automation-service'
 import { EventBus } from '../../src/integration/events/event-bus'
 import { db } from '../../src/db/db'
+import { getZonedParts, zonedWallClockToUtcMs } from '../../src/multitable/automation-timezone'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -278,5 +279,169 @@ describeIfDatabase('multitable date-reminder trigger — scan/claim/fire (real D
     await q('UPDATE automation_rules SET created_at = $1 WHERE id = $2', [iso(TS - 10 * DAY), disabled.id])
     await svc.runDateReminderScanNow(disabled.id)
     expect(await claimCount(disabled.id)).toBe(0)
+  })
+
+  // DR-FLOAT (Option 1): the date-picker writes a BARE 'YYYY-MM-DD' into a `date`-type field (the existing
+  // fixtures above store a full ISO instant, so they never exercised this path). A date-only value is a
+  // FLOATING calendar day: in a negative-offset tz it must fire on the literal day, NOT one civil day early.
+  // This drives the value through the REAL SQL pre-filter (date-only bounds) AND the floating occurrence math.
+  test('DR-FLOAT: a bare YYYY-MM-DD in a date-type field fires at the FLOATING day under a negative-offset tz', async () => {
+    const NY = 'America/New_York'
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const addCivilDays = (d: { year: number; month: number; day: number }, n: number) => {
+      const t = new Date(Date.UTC(d.year, d.month - 1, d.day + n))
+      return { year: t.getUTCFullYear(), month: t.getUTCMonth() + 1, day: t.getUTCDate() }
+    }
+    // Anchor on TODAY's NY-local civil day. Record date = today+2 (bare), 3-before ⇒ occurrence = YESTERDAY
+    // 12:00 NY — solidly in (now-48h, now], independent of the wall-clock time CI runs at.
+    const todayNY = getZonedParts(Date.now(), NY)
+    const recDay = addCivilDays(todayNY, 2)
+    const recDate = `${recDay.year}-${pad(recDay.month)}-${pad(recDay.day)}` // BARE 'YYYY-MM-DD', as a picker writes
+    const REC_FLOAT = `rec_dr_float_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+      REC_FLOAT,
+      SHEET,
+      JSON.stringify({ [FLD_DATE]: recDate }),
+    ])
+
+    const rule = await svc.createRule(
+      SHEET,
+      mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timeOfDay: '12:00', timezone: NY }),
+    )
+    // Backdate floor (created_at + effectiveAt) so the past occurrence is allowed to fire (mirrors RULE_BACKDATED).
+    await q(
+      `UPDATE automation_rules SET created_at = $1::timestamptz,
+         trigger_config = jsonb_set(trigger_config, '{effectiveAt}', to_jsonb($2::text)) WHERE id = $3`,
+      [iso(TS - 10 * DAY), iso(TS - 10 * DAY), rule.id],
+    )
+
+    await svc.runDateReminderScanNow(rule.id)
+
+    // REC_FLOAT fired exactly once → the real SQL pre-filter fetched the bare-date record (date-only bounds
+    // work). Scope to REC_FLOAT: the shared sheet holds other fixtures whose own occurrences also fire this rule.
+    const led = await q(
+      'SELECT occurrence_ts FROM meta_automation_date_reminder_fires WHERE rule_id = $1 AND record_id = $2',
+      [rule.id, REC_FLOAT],
+    )
+    expect(led.rows.length).toBe(1)
+    // …at the CORRECT floating day: YESTERDAY 12:00 NY. The pre-fix re-zoning would have produced a day earlier.
+    const yNY = addCivilDays(todayNY, -1)
+    const expectedOccMs = zonedWallClockToUtcMs(
+      { year: yNY.year, month: yNY.month, day: yNY.day, hour: 12, minute: 0, second: 0 },
+      NY,
+    )
+    const occTs = new Date((led.rows[0] as { occurrence_ts: string | Date }).occurrence_ts).getTime()
+    expect(occTs).toBe(expectedOccMs)
+  })
+
+  // DR-TRIM: validateDateFieldTriggerAtSave trims dateFieldId before its lookup, so a whitespace-padded id
+  // PASSES save (persisted raw); the scan must trim too or the type read + `data ->> dateFieldId` both miss and
+  // the rule silently no-ops forever. Locks the save↔scan parity.
+  test('DR-TRIM: a whitespace-padded dateFieldId still scans (scan trims to match the save validator)', async () => {
+    const padded = await svc.createRule(
+      SHEET,
+      mkDateRule({ dateFieldId: ` ${FLD_DATE} `, offsetDays: 3, direction: 'before', timeOfDay: '00:00' }),
+    )
+    // Persisted RAW (padded) — so it is the scan-side trim, not the saved value, that makes this fire.
+    expect((padded.trigger_config as { dateFieldId: string }).dateFieldId).toBe(` ${FLD_DATE} `)
+    await q(
+      `UPDATE automation_rules SET created_at = $1::timestamptz,
+         trigger_config = jsonb_set(trigger_config, '{effectiveAt}', to_jsonb($2::text)) WHERE id = $3`,
+      [iso(TS - 10 * DAY), iso(TS - 10 * DAY), padded.id],
+    )
+    await svc.runDateReminderScanNow(padded.id)
+    // REC_DUE (date = now+3) is due under 3-before/00:00 → the padded-id rule fires for it (trim parity).
+    // Without the scan-side trim the candidates key `data ->> ' fld '` matches nothing → zero fires.
+    const led = await q(
+      'SELECT 1 FROM meta_automation_date_reminder_fires WHERE rule_id = $1 AND record_id = $2',
+      [padded.id, REC_DUE],
+    )
+    expect(led.rows.length).toBe(1)
+  })
+
+  // DR-SKIP-ON-READ-FAIL: a TRANSIENT field-type read error must NOT degrade to instant bucketing (that would
+  // emit the day-EARLY occurrence as a spurious wrong-day reminder for a date-type field in a negative-offset
+  // tz). The scan skips this tick instead — recovered on the next tick, no wrong-day fire.
+  test('DR-SKIP-ON-READ-FAIL: a thrown meta_fields type read skips the scan tick (no fire), then recovers', async () => {
+    const REC_SKIP = `rec_dr_skip_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+      REC_SKIP,
+      SHEET,
+      JSON.stringify({ [FLD_DATE]: iso(TS + 3 * DAY) }),
+    ])
+    const rule = await svc.createRule(
+      SHEET,
+      mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timeOfDay: '00:00' }),
+    )
+    await q(
+      `UPDATE automation_rules SET created_at = $1::timestamptz,
+         trigger_config = jsonb_set(trigger_config, '{effectiveAt}', to_jsonb($2::text)) WHERE id = $3`,
+      [iso(TS - 10 * DAY), iso(TS - 10 * DAY), rule.id],
+    )
+    const cnt = async (rid: string) =>
+      ((await q('SELECT count(*)::int AS n FROM meta_automation_date_reminder_fires WHERE rule_id = $1 AND record_id = $2', [rid, REC_SKIP])).rows[0] as { n: number }).n
+
+    // A service whose ONLY failure is the meta_fields type read (everything else hits real PG).
+    const throwingQ = ((text: string, params?: unknown[]) =>
+      /SELECT type FROM meta_fields/i.test(text)
+        ? Promise.reject(new Error('transient meta_fields read'))
+        : q(text, params)) as never
+    const svc2 = new AutomationService(new EventBus(), db as never, throwingQ)
+    try {
+      await svc2.runDateReminderScanNow(rule.id) // type read throws → skip tick → no fire
+      expect(await cnt(rule.id)).toBe(0)
+      // Control: the SAME rule fires once under the healthy service → proves the SKIP (not another gate) blocked it.
+      await svc.runDateReminderScanNow(rule.id)
+      expect(await cnt(rule.id)).toBe(1)
+    } finally {
+      svc2.shutdown()
+    }
+  })
+
+  // DR-GONE: the trigger field is valid at save, then RETYPED away from date/dateTime (or DELETED). The record
+  // JSONB keeps the stale key, so `data ->> dateFieldId` still matches — the scan must SKIP on the type read,
+  // not fire a reminder for a field that is no longer a date trigger. (Fail-first: the pre-fix floating=false
+  // fall-through would fire for the stale key.)
+  test('DR-GONE: a retyped-away or DELETED trigger field skips the scan — stale record key never fires', async () => {
+    const FLD_TMP = `fld_dr_gone_${TS}`
+    const REC_TMP = `rec_dr_gone_${TS}`
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+      FLD_TMP,
+      SHEET,
+      'Tmp',
+      'date',
+      '{}',
+      9,
+    ])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+      REC_TMP,
+      SHEET,
+      JSON.stringify({ [FLD_TMP]: iso(TS + 3 * DAY) }), // due under 3-before/00:00 if it WERE still scanned
+    ])
+    const rule = await svc.createRule(
+      SHEET,
+      mkDateRule({ dateFieldId: FLD_TMP, offsetDays: 3, direction: 'before', timeOfDay: '00:00' }),
+    )
+    await q(
+      `UPDATE automation_rules SET created_at = $1::timestamptz,
+         trigger_config = jsonb_set(trigger_config, '{effectiveAt}', to_jsonb($2::text)) WHERE id = $3`,
+      [iso(TS - 10 * DAY), iso(TS - 10 * DAY), rule.id],
+    )
+    const claims = async () =>
+      ((await q('SELECT count(*)::int AS n FROM meta_automation_date_reminder_fires WHERE rule_id = $1', [rule.id])).rows[0] as { n: number }).n
+    const execs = async () =>
+      ((await q('SELECT count(*)::int AS n FROM multitable_automation_executions WHERE rule_id = $1', [rule.id])).rows[0] as { n: number }).n
+
+    // (a) RETYPED date → string (row present, wrong type): the stale REC_TMP key remains in data.
+    await q('UPDATE meta_fields SET type = $1 WHERE id = $2', ['string', FLD_TMP])
+    await svc.runDateReminderScanNow(rule.id)
+    expect(await claims()).toBe(0)
+    expect(await execs()).toBe(0)
+
+    // (b) field row DELETED entirely (type read returns no row): still skip.
+    await q('DELETE FROM meta_fields WHERE id = $1', [FLD_TMP])
+    await svc.runDateReminderScanNow(rule.id)
+    expect(await claims()).toBe(0)
+    expect(await execs()).toBe(0)
   })
 })

--- a/packages/core-backend/tests/unit/automation-scheduler-date-reminder.test.ts
+++ b/packages/core-backend/tests/unit/automation-scheduler-date-reminder.test.ts
@@ -115,9 +115,12 @@ describe('AutomationScheduler — schedule.date_field timeOfDay alignment (DR-A/
 // it behaves like cron's skip.
 describe('date_field DST gap/overlap — lands on a representable instant (NOT cron-style skip)', () => {
   // US spring-forward 2026: Mar 8, 02:00 EST → 03:00 EDT. Local 02:30 does NOT exist.
-  // Note: the date VALUE is noon-UTC so its NY-LOCAL calendar day is genuinely Mar 8 (a bare 'YYYY-MM-DD'
-  // parses to UTC midnight, whose local day in a negative-offset zone is the PREVIOUS day — the day-bucket
-  // is keyed off the local day, not the UTC day).
+  // These cases exercise the INSTANT (dateTime) path: the date VALUE is a full-ISO noon-UTC instant whose
+  // NY-LOCAL day is Mar 8, so they pin the DST gap/overlap CLOCK behavior — NOT day-derivation. A date-ONLY
+  // ('date'-type) field is a FLOATING calendar day whose civil day does not move with timezone (see the
+  // floating goldens in automation-date-reminder.test.ts); that fix changes how the day is derived but leaves
+  // this gap/overlap resolution unchanged. (Do NOT read the noon-UTC choice as blessing the old bare-date
+  // day-shift — it is here only to make the LOCAL day land on the transition day for the instant path.)
   it('spring-forward GAP: a non-existent local timeOfDay resolves FORWARD to 03:30 (not skipped, unlike cron)', () => {
     const occ = computeDateReminderOccurrence('2026-03-08T12:00:00Z', { timeOfDay: '02:30', timezone: 'America/New_York' })
     expect(occ).not.toBeNull()


### PR DESCRIPTION
## What & why

Closes the owner-ratified **P2**: a `schedule.date_field` reminder on a **`date`-type** trigger field configured with a **negative-offset** IANA timezone (`America/*`) fired **one calendar day early**. Surfaced from the T2-5 (#3401) DST work — the underlying facts predate T2-5, but #3401 is the change that made the non-UTC path reachable.

**Root cause:** a `date`-type field stores a bare `YYYY-MM-DD` (field-codecs passes `date` through un-normalized; only `dateTime` is `toISOString`-normalized). The zoned day-bucket parsed it to UTC midnight then re-zoned (`getZonedParts`); in a negative-offset zone UTC-midnight's *local* day is the previous day → the whole shift anchored a civil day early.

## Option 1 (owner-ratified): a date-only value is a FLOATING calendar day

A date-only field has no instant, so its day must not move with timezone.

1. **`computeDateReminderOccurrence`** gains `opts.floating`: the anchor day is read from the literal `YYYY-MM-DD` (regex, with a UTC-parts fallback for `Date`/legacy full-ISO) instead of re-zoning. `dateTime` (default) keeps instant→local-day — **byte-identical** for every existing caller; UTC path unchanged for both.
2. **`evaluateDateReminders`** reads the field type **once per scan** (mirrors `validateDateFieldTriggerAtSave`) → `{ floating: type === 'date' }`.
3. **`dateReminderCandidateDateRange`** now returns **date-only, day-widened** bounds so the lexicographic SQL `BETWEEN` is exact for both bare `YYYY-MM-DD` and full-ISO values (strict superset — no firing record dropped; the boundary-day was the "luck" case).
4. **Goldens:** pure (floating Mar 8 NY → **Mar 5 09:00 EST**; instant unchanged → Mar 4; Shanghai/UTC/DST-gap/legacy-ISO) + bare-date SQL boundary lock + **real-DB `DR-FLOAT`** firing through the live pre-filter.
5. **P5:** the #3401 DST-golden comment no longer reads as blessing the day-shift.

Rejected (owner-confirmed): Option 2 (codec normalize → global storage blast radius), Option 3 (forbid non-UTC on date fields → kills the most common config).

## Adversarial verification (5-skeptic panel)

All five dimensions **solid**; the SQL superset was brute-forced across date-line / DST / leap zones with **zero false-negatives**; `dateTime`/UTC byte-identical confirmed line-by-line. Two **P3** edges folded in:
- **Transient `meta_fields` read failure** now **skips the scan tick** (was: default to instant → a day-early spurious fire). Locked by `DR-SKIP-ON-READ-FAIL`.
- **`dateFieldId` trim parity** (pre-existing): the scan now trims to match the save validator. Locked by `DR-TRIM`.

Out-of-scope (flagged, not fixed here): `offsetDays` magnitude isn't capped at save → a huge value makes the range builder throw `RangeError` (total skip, pre-existing, orthogonal). Left for a follow-up to keep this arc small.

## Verification
tsc 0 · **38 unit + 17 real-DB green** · RED-before confirmed for DR-FLOAT (buggy path exactly 24h early), DR-TRIM, DR-SKIP · UTC/`dateTime` paths unchanged.

## Compatibility
Bounded **one-time re-fire** possible for affected rules at deploy (corrected `occurrence_ts` = new dedup key) — same accepted semantic as editing a rule's timezone. CN/positive-offset, UTC, and all `dateTime` fields see no change.

Design-lock: `docs/development/automation-date-field-floating-day-design-lock-20260630.md`. **R1 follows after this lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)