### PR TITLE
fix(attendance): honor result-edit notification toggle

### DIFF
--- a/packages/core-backend/tests/integration/attendance-result-edit.test.ts
+++ b/packages/core-backend/tests/integration/attendance-result-edit.test.ts
@@ -123,6 +123,11 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     }
   }
 
+  function resultEditPolicyWithNotifyAffectedEmployee(policy: unknown, notifyAffectedEmployee: boolean) {
+    const base = resultEditPolicyWithEnabled(policy, true)
+    return { ...base, notifyAffectedEmployee }
+  }
+
   async function seedRecord(input: {
     userId: string
     workDate: string
@@ -342,11 +347,14 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     expect(Number(audit[0].after_snapshot.lateMinutes)).toBe(0)
     expect(audit[0].reason).toContain('核验后更正')
     expect(audit[0].actor_user_id).toBe(`ae1-admin-${RUN}`)
-    expect(audit[0].notification_delivery_id).toBeNull()
+    expect(audit[0].notification_delivery_id).toEqual(expect.any(String))
     expect(audit[0].notification_skipped_reason).toBeNull()
 
     const deliveries = await deliveryRowsForRecord(recordId)
     expect(deliveries).toHaveLength(1)
+    expect(audit[0].notification_delivery_id).toBe(deliveries[0].id)
+    expect(dataOf(res).edit.notificationDeliveryId).toBe(deliveries[0].id)
+    expect(dataOf(res).edit.notificationSkippedReason).toBeNull()
     expect(deliveries[0]).toMatchObject({
       source_type: 'attendance_result_edit',
       source_id: audit[0].id,
@@ -370,6 +378,48 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     expect(deliveries[0].payload.overrideMetrics).toBeUndefined()
     expect(deliveries[0].payload.evidence).toBeUndefined()
     expect(deliveries.filter(row => row.recipient_user_id !== userId)).toHaveLength(0)
+  })
+
+  it('AE-2.1 notifyAffectedEmployee=false: correction succeeds but records a skipped notification and writes no outbox row', async () => {
+    const settings = await getSettings()
+    expect(settings.status).toBe(200)
+    const originalPolicy = dataOf(settings)?.attendanceResultEditPolicy
+    const disabledNotify = await putSettings({
+      attendanceResultEditPolicy: resultEditPolicyWithNotifyAffectedEmployee(originalPolicy, false),
+    })
+    expect(disabledNotify.status).toBe(200)
+
+    try {
+      const userId = `u-ae2-off-${RUN}`
+      const workDate = ymd(2)
+      const recordId = await seedRecord({
+        userId, workDate, status: 'late', workMinutes: 480, lateMinutes: 25, earlyLeaveMinutes: 0,
+        firstInAt: `${workDate}T01:25:00Z`, lastOutAt: `${workDate}T10:00:00Z`,
+      })
+      const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: '通知关闭但仍允许更正', idempotencyKey: `k-ae2-off-${RUN}` })
+      expect(res.status).toBe(200)
+      expect(dataOf(res).alreadyApplied).toBe(false)
+      expect(dataOf(res).edit.notificationDeliveryId).toBeNull()
+      expect(dataOf(res).edit.notificationSkippedReason).toBe('policy_disabled')
+
+      const rec = await recordById(recordId)
+      expect(rec.status).toBe('normal')
+      expect(Number(rec.late_minutes)).toBe(0)
+      expect(rec.meta?.manual_result_edit?.auditId).toEqual(expect.any(String))
+
+      const audit = await auditRowsForRecord(recordId)
+      expect(audit).toHaveLength(1)
+      expect(audit[0].notification_delivery_id).toBeNull()
+      expect(audit[0].notification_skipped_reason).toBe('policy_disabled')
+      expect(await deliveryRowsForRecord(recordId)).toHaveLength(0)
+    } finally {
+      await putSettings({
+        attendanceResultEditPolicy: resultEditPolicyWithEnabled(
+          originalPolicy,
+          isResultEditPolicySetting(originalPolicy) ? originalPolicy.enabled !== false : true,
+        ),
+      }).catch(() => undefined)
+    }
   })
 
   it('AE-1b durability: same-facts import recompute preserves the corrected result without a review flag', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -308,8 +308,8 @@ const DEFAULT_SETTINGS = {
   // attendance:admin POST /api/attendance/anomaly-result-edits write action. enabled = master switch (default
   // ON; the route 403s when explicitly false). editWindowDays bounds how far back a work_date may be corrected
   // (org-tz today − work_date), default 180, range 1..366. requireReason default true (a blank reason 400s).
-  // notifyAffectedEmployee remains reserved for a follow-up gate; AE-2 v1 always enqueues after a successful
-  // correction and leaves the audit row's notification_delivery_id / notification_skipped_reason columns NULL.
+  // notifyAffectedEmployee controls the AE-2 employee notification producer: true enqueues one employee-only
+  // delivery and back-links notification_delivery_id; false writes no outbox row and records the skipped reason.
   attendanceResultEditPolicy: {
     enabled: true,
     editWindowDays: 180,
@@ -18364,7 +18364,27 @@ async function enqueueAttendanceResultEditNotification(trx, { orgId, record, aud
       JSON.stringify(payload),
     ]
   )
-  return inserted[0] ?? null
+  if (inserted[0]) return inserted[0]
+  const existing = await trx.query(
+    `SELECT * FROM attendance_notification_deliveries
+      WHERE org_id = $1 AND source_key = $2
+      LIMIT 1`,
+    [orgId, sourceKey]
+  )
+  return existing[0] ?? null
+}
+
+async function markAttendanceResultEditNotificationStatus(trx, { orgId, auditRow, deliveryId = null, skippedReason = null }) {
+  if (!auditRow?.id) return auditRow
+  const rows = await trx.query(
+    `UPDATE attendance_record_result_edits
+      SET notification_delivery_id = $3,
+          notification_skipped_reason = $4
+      WHERE id = $1 AND org_id = $2
+      RETURNING *`,
+    [auditRow.id, orgId, deliveryId, skippedReason]
+  )
+  return rows[0] ?? auditRow
 }
 
 // §4.1 idempotency compare: a replayed (org_id, idempotency_key) is "already applied" only when its key
@@ -18419,6 +18439,7 @@ async function applyAttendanceResultEdit(trx, options) {
     actorUserId,
     idempotencyKey,
     editWindowDays,
+    notifyAffectedEmployee = true,
   } = options
 
   const normalizedEvidence = Array.isArray(evidence) ? evidence : []
@@ -18568,18 +18589,33 @@ async function applyAttendanceResultEdit(trx, options) {
   const marker = buildManualResultEditMarker(auditRow, updated)
   const markedRecord = await attachManualResultEditMarkerToRecord(trx, updated, marker)
   afterSnapshot = buildResultEditSnapshot(markedRecord)
-  await enqueueAttendanceResultEditNotification(trx, {
-    orgId,
-    record: markedRecord,
-    auditRow,
-    beforeStatus,
-    targetStatus,
-    reason,
-  })
+  let finalAuditRow = auditRow
+  if (notifyAffectedEmployee === false) {
+    finalAuditRow = await markAttendanceResultEditNotificationStatus(trx, {
+      orgId,
+      auditRow,
+      skippedReason: 'policy_disabled',
+    })
+  } else {
+    const delivery = await enqueueAttendanceResultEditNotification(trx, {
+      orgId,
+      record: markedRecord,
+      auditRow,
+      beforeStatus,
+      targetStatus,
+      reason,
+    })
+    finalAuditRow = await markAttendanceResultEditNotificationStatus(trx, {
+      orgId,
+      auditRow,
+      deliveryId: delivery?.id ?? null,
+      skippedReason: null,
+    })
+  }
 
   return {
     alreadyApplied: false,
-    edit: mapResultEditRow(auditRow),
+    edit: mapResultEditRow(finalAuditRow),
     record: markedRecord,
     beforeSnapshot,
     afterSnapshot,
@@ -25241,6 +25277,7 @@ module.exports = {
 	            actorUserId,
 	            idempotencyKey,
 	            editWindowDays: policy.editWindowDays,
+	            notifyAffectedEmployee: policy.notifyAffectedEmployee !== false,
 	          }))
 	          res.json({
 	            ok: true,


### PR DESCRIPTION
## Summary
- honor attendanceResultEditPolicy.notifyAffectedEmployee in the AE-2 result-edit notification producer
- when enabled, enqueue the employee-only delivery and back-link notification_delivery_id to the immutable audit row
- when disabled, skip the outbox row and persist notification_skipped_reason='policy_disabled'
- add a real-DB route regression for the disabled-notify path and tighten the default path to assert the audit delivery backlink

## Verification
- node -c plugins/plugin-attendance/index.cjs
- git diff --check origin/main...HEAD
- pnpm --filter @metasheet/core-backend type-check
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-result-edit.test.ts --reporter=dot (local no-DB path: 19 skipped; CI runs this against real Postgres)
- subagent review found P2 skipped-reason literal drift; fixed to the design/migration contract value policy_disabled

Refs #3317