### PR TITLE
docs(multitable): flag-enablement readiness — permission-revert + T9-W + PIT (smoke, runbooks, STOP-SHIP determination)

### DIFF
--- a/docs/development/multitable-permission-revert-flagon-smoke-runbook-20260630.md
+++ b/docs/development/multitable-permission-revert-flagon-smoke-runbook-20260630.md
@@ -1,0 +1,55 @@
+# Permission-revert flag-on smoke — runbook + verification
+
+**Date:** 2026-06-30  **Grounding:** `origin/main @ f14be042e` (includes #3402 forward-route lock + #3414 legacy-route lock)
+**Flag:** `MULTITABLE_ENABLE_PERMISSION_REVERT`
+**Scope:** staging/sandbox enablement only. **Prod flag is NOT changed by this work.** This document is a runbook + verification evidence; the staging flip itself is an operator action gated on owner sign-off.
+
+> What enabling this flag turns on: reverting a `permission` config-revision via `POST /sheets/:id/config-restore-preview` + `…/config-restore-execute`. It is **de-escalation-only**, on top of the `canManageSheetAccess` capability floor, a typed `revert-permission` confirm, a server-minted preview-identity token, and (now) two-sided concurrency serialization across all `spreadsheet_permissions` writers.
+
+---
+
+## 1. Pre-enable state (what the gate protects)
+
+With the flag **off** (default), both routes return `403 PERMISSION_REVERT_DISABLED`. The flag is the *outermost* gate; underneath it the path is constrained by, in order:
+
+1. **Capability floor** — `canManageSheetAccess` (admin or `multitable:share`); precedes the flag check, so a non-privileged actor 403s even with the flag on.
+2. **Typed confirm** — body must carry `confirm: "revert-permission"`, else `400 CONFIRM_REQUIRED`.
+3. **Preview identity** — execute requires a server-minted `previewToken` binding the live grant hash; a changed grant → `409 GRANT_DRIFT`, an expired token → `410`.
+4. **De-escalation-only** — the apply re-checks `permissionRevertDirection(before, LIVE)` against the **current** live grant; escalation/no-op → `422 RESTORE_NOT_SUPPORTED`.
+5. **Concurrency serialization** — the execute path holds `meta_sheets … FOR UPDATE`; **all** forward writers of the grant tables now take the same lock (multitable forward routes #3402, legacy grant/revoke #3414), so no concurrent write can interleave a re-checked de-escalation into a net escalation.
+
+## 2. Verification (the 5 smoke points) — evidence
+
+Run on a fresh real Postgres at current main; the goldens self-set the flag per test, so one run exercises both flag-on and flag-off contracts. **Three-PR combined integration** (`multitable-permission-revert-realdb.test.ts` which contains #3402's `(m)`, plus `multitable-legacy-permission-route-lock-realdb.test.ts` = #3414) — **17/17 passed** in a single invocation (the first time the three PRs are verified together post-#3414-merge).
+
+| # | Smoke requirement | Verified by | Result |
+|---|---|---|---|
+| 1 | de-escalation **executable** | (c) sheet admin→read, (d) revoke (before=null), (i) field read-write→read-only, (j) view admin→read | 200 + grant lowered/removed |
+| 2 | escalation / noop **still 422** | (e) escalation, (f) noop, (g) live-recheck (deceptively-high recorded `after`) | 422 `RESTORE_NOT_SUPPORTED`, grant unchanged |
+| 3 | typed confirm **effective** | (k) missing/wrong confirm → 400 `CONFIRM_REQUIRED`; `revert-permission` → 200 applied | pass |
+| 4 | audit / `source=restore` **correct** | (c) asserts a `source='restore'` permission revision back-referencing the reverted revision (`restored_from_id`) | `restoreRevCount = 1` |
+| 5 | **concurrency gate does not regress** | (h) `GRANT_DRIFT` on drift; (m) #3402 forward grant parks under a held `FOR KEY SHARE`; #3414 legacy (a) grant + (b) revoke park | pass |
+| — | flag-**OFF** contract still holds | (a) flag-off → 403 both routes; (b) capability floor 403 even with flag on | pass |
+
+The concurrency row is the load-bearing addition: it confirms the three independently-merged locking PRs **coexist** and the never-escalate-under-concurrency property holds end-to-end on current main, not just per-PR at merge time.
+
+## 3. Operator runbook — enable in staging/sandbox
+
+**Enablement detail that changes restart assumptions:** the flag is read **per-request directly from `process.env`** (`univer-meta.ts:8084` preview, `:8297` execute) — there is **no in-app config cache**. So:
+
+1. **Enable:** set `MULTITABLE_ENABLE_PERMISSION_REVERT=true` in the staging service's environment/deployment config and **restart/redeploy** the service (the value is captured at process launch; a running process won't pick up a newly-set env var without restart). No cache-bust step is needed beyond the restart.
+2. **Smoke (post-enable, against the running staging instance):** as a `canManageSheetAccess` actor, on a throwaway sheet —
+   - preview + execute a **de-escalation** (e.g. admin→read) → expect 200 + the grant lowered;
+   - attempt an **escalation** revert → expect 422 `RESTORE_NOT_SUPPORTED`, grant unchanged;
+   - execute **without** the typed confirm → expect 400 `CONFIRM_REQUIRED`;
+   - confirm a `source='restore'` permission revision was recorded for the de-escalation;
+   - re-preview then change the grant out-of-band before execute → expect 409 `GRANT_DRIFT`.
+3. **Rollback:** unset `MULTITABLE_ENABLE_PERMISSION_REVERT` (or set to anything other than `true`) and restart → both routes return to `403 PERMISSION_REVERT_DISABLED`. The flag toggles behavior only; it persists no state, so rollback is clean and immediate (no data migration, no cleanup).
+
+## 4. Scope / guards / recommendation
+
+- **Staging/sandbox only.** Do **not** change the prod flag as part of this; prod enablement is a separate, later owner decision.
+- Enabling exposes a **narrow, de-escalation-only** capability (it can only *reduce* a subject's access, never raise it), behind four independent gates + the capability floor — not a broad new surface.
+- No schema change, no migration, no default change. The flag is the only lever; rollback is unset+restart.
+
+**Recommendation:** the runtime, the four gates, and the cross-PR concurrency serialization are verified; the flag is **ready for staging/sandbox enablement on the operator's go**. Prod remains a separate decision. No code change ships with this runbook — it is verification + procedure only.

--- a/docs/development/multitable-pit-reset-undelete-stopship-finding-runbook-20260630.md
+++ b/docs/development/multitable-pit-reset-undelete-stopship-finding-runbook-20260630.md
@@ -1,0 +1,65 @@
+# PIT Reset / Undelete — STOP-SHIP determination, T-source decision, flag-on smoke, runbook
+
+**Date:** 2026-06-30  **Grounding:** `origin/main @ f14be042e`
+**Flags:** `MULTITABLE_ENABLE_PIT_RESET`, `MULTITABLE_ENABLE_PIT_UNDELETE`
+**Scope:** staging/sandbox; **prod flags NOT changed.** Phase 3 of the flag-enablement sequence — the highest-risk tier, gated on a data-loss STOP-SHIP determination *before* any smoke is treated as "ready."
+
+> The directive was to **determine** whether trash-retention is a genuine STOP-SHIP for PIT_RESET before producing a reassuring smoke. This is a finding-gate, not a checklist tick. The determination below was adversarially refuted (an independent agent tried to find a data-loss path and could not).
+
+---
+
+## 1. STOP-SHIP determination — NOT a data-loss stop-ship today (with a sharpened, conditional future-gate)
+
+**PIT_RESET is recoverable on today's default config; it is NOT a data-loss stop-ship.** A reset-to-T does two things, both recoverable:
+
+- **Records created after T → soft-deleted to the recycle bin.** `reset-execute` (`univer-meta.ts:9701-9733`), in one transaction, writes a `delete` revision *with the full data snapshot*, **inserts the record into `meta_records_trash` with its full snapshot**, then removes it from the live table. The trash INSERT is **fail-closed** (not error-swallowed, surrogate-uuid PK, no `ON CONFLICT`), so a live delete without a trash row is unreachable — if the trash write fails, the whole txn rolls back. A working restore route (`POST /records/:recordId/restore`) brings trashed records back.
+- **Records modified after T → reverted (UPDATE) to their at-T values**, recording a `source='restore'` revision.
+
+**No trash purge exists.** Exhaustively confirmed: the only `DELETE FROM meta_records_trash` in production is the per-record restore op (`record-service.ts:1029`, inside the restore txn, after a successful re-insert). The three retention starters wired in `src/index.ts` (operation-audit, attachment-orphan, meta-revision) **none** touch `meta_records_trash`; the create migration states explicitly "rows live here until an explicit purge; no automatic aging." So reset-deleted records persist **indefinitely**.
+
+### The recoverability asymmetry (the load-bearing nuance)
+
+| Reset effect | Recovery source | Recoverable today? | Future-gate |
+|---|---|---|---|
+| **delete** (created-after-T) | `meta_records_trash` snapshot (+ delete-revision snapshot as a 2nd copy) | **Yes, unconditionally** | None — no sweep ever touches trash |
+| **revert** (modified-after-T) | the **prior** `meta_record_revisions` row (the post-T edit's revision, now at rn≥2 after the revert) | Yes (revision retention is **off** by default) | **Conditional** — becomes purgeable if `MULTITABLE_META_REVISION_RETENTION_ENABLED` is enabled |
+
+The revert's *own* `source='restore'` revision stores the *reverted-to* (at-T) value, not the pre-reset value it overwrote. So **undo of a revert** relies on the prior revision, which the retention sweep's "never delete the latest per record" invariant does **not** protect (it sits at rn≥2). Today both retention flags default off, so it persists.
+
+**Refinement of the "trash-retention STOP-SHIP" framing:** the future stop-ship is **`MULTITABLE_META_REVISION_RETENTION_ENABLED`** (it can age out the revision a *revert-undo* needs), **not** trash-retention — `meta_records_trash` is unconditionally safe (no purge exists). The conditional rule for enablement is therefore: **do not enable revision-retention purging while PIT_RESET is enabled** (or accept that revert-undo gains a finite window), whereas delete-recovery is safe regardless.
+
+### Operational residuals (real, but not data-loss stop-ships)
+
+1. **No atomic "undo reset."** Undoing a reset is piecemeal: restore each trashed record + revert each value-change via record history. No single button. Worth a follow-up if resets become routine.
+2. **Orphan trash if a sheet is later hard-deleted** — the trash row persists but is un-restorable (sheet gone). Independent of reset; pre-existing.
+3. **Unbounded trash growth.** No purge means large/repeated resets bloat `meta_records_trash` indefinitely (storage/operational). The `idx_meta_records_trash(sheet_id, deleted_at DESC)` index suggests a retention purge is anticipated — *that* is the moment delete-recoverability would also gain a window, and must be re-evaluated against PIT_RESET then.
+
+## 2. Reset T-source — product decision (owner's call, not made here)
+
+The current T-source is a **free `datetime-local` picker** (`ResetToPointPicker.vue`): the operator picks any past instant T. `reconstructRecordsAtT` resolves state at T = the **latest revision with `created_at ≤ T`** — so picking "3:47pm" when the last change was 2:00pm silently yields the **2:00pm** state.
+
+| Option | Pros | Cons |
+|---|---|---|
+| **datetime-local** (shipped) | Minimal, flexible (any instant), already works | The resulting state isn't self-evident — T snaps to the last revision ≤ T; for a *destructive* op the operator may not realize which state they'll get |
+| **history-anchored picker** (deferred) | Operator selects an actual, visible change-point (HistoryCenter batch timestamps) → predictable, self-documenting, safer for a destructive op | More UI; surface + wire the history timestamps |
+
+The `asOf` derivation is explicitly the **single swappable seam**, so the upgrade is a localized change. **Recommendation (for the owner to decide):** upgrade to the history-anchored picker before broad enablement — for a destructive reset, picking a real visible historical point is materially safer than an arbitrary instant that snaps. It is **not a hard blocker** (datetime-local is correct, just less self-documenting). This is a product decision and is left to the owner.
+
+## 3. Flag-on smoke — evidence
+
+PIT goldens run flag-on against a fresh real Postgres at current main (`multitable-reset-pit-realdb`, `multitable-revert-pit-realdb`, `multitable-undelete-pit-realdb`, `multitable-pit-view-realdb`) → **41/41 passed**. (The "rs injected" / "rv injected" / "forced … insert failure" lines are *intentional* injected-failure atomicity goldens — they assert reset/undelete roll back cleanly mid-apply — inside passing tests.) Coverage includes: flag-off 403; reset preview→typed-`confirm:"reset"`→execute (reverts + soft-deletes to trash); too-large refusal (record ceiling); all-or-nothing block on a forbidden/locked target; preview-identity drift (409/410); and apply-atomicity rollback.
+
+## 4. Operator runbook (gated on §1 + §2)
+
+Both PIT flags are read **per-request from `process.env`** (`PIT_RESET_ENABLED()` `:9516`, `PIT_UNDELETE_ENABLED()` `:9359`) — no in-app cache.
+
+- **Pre-enable condition (from §1):** keep `MULTITABLE_META_REVISION_RETENTION_ENABLED` **off** while PIT_RESET is on (so revert-undo stays recoverable); delete-recovery is safe regardless. If revision-retention is ever enabled alongside, document that revert-undo gains a finite window.
+- **Enable:** set `MULTITABLE_ENABLE_PIT_RESET=true` / `MULTITABLE_ENABLE_PIT_UNDELETE=true` in staging env + **restart/redeploy**.
+- **Smoke (live):** on a throwaway sheet, make post-T edits + a post-T record, then reset-preview→`confirm:"reset"`→execute → at-T edits reverted, post-T record gone from live; verify it sits in `GET /sheets/:id/trash`; restore it via `POST /records/:id/restore` → back on live. Verify a too-large sheet 413s and a drifted preview 409s.
+- **Rollback:** unset (or ≠ `true`) + restart → 403. No persisted flag state.
+
+## 5. Recommendation
+
+- **PIT_RESET / PIT_UNDELETE are flag-on-smoke-verified and recoverable today** (adversarially confirmed) — **enable-able in staging/sandbox on the operator's go, under the §1 condition** (revision-retention stays off ↔ revert-undo recoverable). Prod is a separate, later decision.
+- **The T-source datetime-local→history-anchored upgrade is a product decision left to the owner** (recommended before broad enablement, not a hard blocker).
+- **Follow-ups (not blockers):** an atomic "undo reset"; a trash-retention purge policy (which, when added, re-opens the delete-recoverability question and must be re-evaluated against PIT_RESET). No code ships with this doc.

--- a/docs/development/multitable-t9w-lowrisk-flags-smoke-runbook-20260630.md
+++ b/docs/development/multitable-t9w-lowrisk-flags-smoke-runbook-20260630.md
@@ -1,0 +1,46 @@
+# T9-W low-risk flags (sheet-config-revert + field-retype-revert) — lossless envelope + flag-on smoke + runbook
+
+**Date:** 2026-06-30  **Grounding:** `origin/main @ f14be042e`
+**Flags:** `MULTITABLE_ENABLE_SHEET_CONFIG_REVERT`, `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT`
+**Scope:** staging/sandbox enablement only; **prod flags NOT changed.** Phase 2 of the flag-enablement sequence (lower risk than uncreate / undelete / permission per owner's prioritization).
+
+> Per the directive, this **verifies** the "option I = schema-only / lossless" interpretation for field-retype rather than asserting it, and establishes the exact safety envelope (what's supported, what stays gated, and why).
+
+---
+
+## 1. SHEET_CONFIG_REVERT — supported envelope
+
+`classifyRevert` returns `gated` for **every** `sheet_config` revision; the route opens only the keys in `SUPPORTED_SHEET_CONFIG_REVERT_KEYS = {conditionalReadRules, rowLevelReadPermissionsEnabled}` (the conditional-read rules + the row-level-read-deny toggle), via `isSupportedSheetConfigRevert`. A sheet_config revert touching any other key stays gated (fail-closed).
+
+**Lossless by nature:** these are **configuration settings**, not data. Reverting them restores a prior config value; no cell values, schema, or records are touched. There is nothing to lose — it is a setting flip, fully reversible.
+
+## 2. FIELD_RETYPE_REVERT — the lossless claim, verified
+
+**Claim ("option I"):** a field `type`/`property` revert is *schema-only / lossless*. **Verified, with a bounded envelope:**
+
+- **Why it's lossless (symmetry argument, from primary source):** the forward `PATCH /fields` retype changes `type`/`property` with **NO cell-value migration** — stored values are kept raw and the read path tolerates type-mismatched values (`config-restore.ts` U-2 comment). A schema-only revert is therefore *symmetric with the forward op*: it does a raw `meta_fields` UPDATE of the type back, coercing/dropping **nothing**. Neither direction touches values, so the round-trip loses nothing.
+- **Empirical proof (golden (c)):** revert toward a numeric type while a cell holds `'hello'` → after execute, `recValue() === 'hello'` — the non-fitting value is **KEPT, not coerced or dropped**. That is the lossless property demonstrated on real data.
+- **The safety envelope (why `FIELD_RETYPE_EXCLUDED_TYPES` exists):** `applyConfigRevert` does a *raw* UPDATE, but the forward route also runs **type-transition side effects** (autoNumber sequence, formula dependency graph, link join-table) that a raw UPDATE skips. So both endpoints must be **plain scalars**; the excluded set — `formula, lookup, rollup, link, attachment, button, autoNumber, createdTime, modifiedTime, createdBy, modifiedBy` — is exactly the **side-effecting / computed / system** types, which stay **gated even flag-on**. v1 also requires an actual `type` change (property-only deferred).
+- **Empirical gating proof (golden (d)):** a non-scalar endpoint (`link`) → preview not confirmable, execute **422** `RESTORE_NOT_SUPPORTED`, **no write** — even with the flag on. So "lossless" is *scoped*: in-envelope (scalar↔scalar) is lossless; out-of-envelope is refused, not silently mis-reverted.
+
+So "option I = schema-only / lossless" holds **for the scalar↔scalar envelope**, and the envelope is enforced fail-closed. It is **not** a blanket "all retypes are lossless" claim — value-transforming/dropping retypes are explicitly a separate, destructive, not-this-slice decision.
+
+## 3. Flag-on smoke — evidence
+
+Run flag-on against a fresh real Postgres at current main: `multitable-sheet-config-revert-realdb`, `multitable-field-retype-revert-realdb`, `multitable-config-restore-realdb` → **26/26 passed**. (The "forced restore-revision insert failure" / "t9w injected" lines are *intentional* injected-failure atomicity goldens — they assert the execute rolls back cleanly on a mid-apply failure — and sit inside passing tests.)
+
+Coverage includes, per flag: flag-off 403; happy in-envelope revert (200 + `source='restore'` forward revision); out-of-envelope gated (422, no write); drift (409); and apply-atomicity (injected failure → rollback, no partial write).
+
+## 4. Operator runbook
+
+Both flags are read **per-request directly from `process.env`** (field-retype: `univer-meta.ts:8097/8178`; sheet-config: `:8102/8183`) — no in-app config cache, same as permission-revert.
+
+- **Enable:** set `MULTITABLE_ENABLE_SHEET_CONFIG_REVERT=true` and/or `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT=true` in the staging env + **restart/redeploy** (value captured at launch).
+- **Smoke (post-enable, live):** revert a `conditionalReadRules` / `rowLevelReadPermissionsEnabled` change → 200; revert a scalar↔scalar field retype → 200 + values intact; attempt a non-scalar (e.g. link) retype revert → 422; verify a `source='restore'` revision is recorded.
+- **Rollback:** unset (or ≠ `true`) + restart → routes return to 403. No persisted state; rollback is clean/immediate.
+
+## 5. Scope / recommendation
+
+- **Staging/sandbox only; prod unchanged.** These two are independent flags — enable either/both.
+- Both expose only their **supported envelope** (config-toggle keys / scalar retypes); everything else stays gated fail-closed.
+- **Recommendation:** both are **verified and ready for staging/sandbox enablement on the operator's go**, and are genuinely lower-risk than the uncreate/undelete/permission tiers — sheet-config is a setting flip; field-retype is provably lossless in-envelope with destructive types gated. Prod remains a separate decision. No code ships with this doc.


### PR DESCRIPTION
Docs-only. Verification + operator runbooks for the flag-enablement sequence (owner's order). **No code, no flag changes, no prod touch** — each "enable in staging" / product / prod decision remains the owner's. One MD per phase.

## Phase 1 — permission-revert flag-on smoke (`MULTITABLE_ENABLE_PERMISSION_REVERT`)
The additive check is the **three-PR combined flag-on run on current main** (permission-revert + #3402 forward-route `(m)` + #3414 legacy-route) — **17/17**, first time the three locking PRs are verified together post-#3414-merge. All 5 smoke points + the flag-OFF contract map to passing goldens. Runbook notes the flag is a **per-request `process.env` read** (set env + restart, no cache-bust).

## Phase 2 — T9-W low-risk flags (`SHEET_CONFIG_REVERT`, `FIELD_RETYPE_REVERT`)
"Option I = schema-only / lossless" is **verified, not asserted**: the forward retype does no cell-value migration, so a schema-only revert is symmetric/lossless — golden (c) proves a non-fitting value is **KEPT** on revert; (d) proves non-scalar endpoints stay **gated 422** even flag-on (`FIELD_RETYPE_EXCLUDED_TYPES` = the side-effecting types). SHEET_CONFIG is config-toggle reverts (non-lossy by nature). **26/26** goldens flag-on.

## Phase 3 — PIT reset/undelete — STOP-SHIP determination (the gated tier)
**Determination: NOT a data-loss stop-ship today** (adversarially refuted — an independent agent could not find a data-loss/purge/unrecoverable path):
- reset **deletes** → soft-deleted to `meta_records_trash` with snapshot (fail-closed atomic) + a delete-revision; **no purge exists anywhere** → unconditionally recoverable; restore route works.
- reset **reverts** → recoverable via the **prior** revision, which is purgeable **only if** `MULTITABLE_META_REVISION_RETENTION_ENABLED` is enabled.
- **Refines the framing:** the conditional future-gate is **revision-retention** (for revert-undo), **not** trash-retention (trash is unconditionally safe). Enablement condition: keep revision-retention off while PIT_RESET is on.
- **41/41** PIT goldens flag-on. The **T-source datetime-local→history-anchored** upgrade is framed as a **product decision left to the owner** (recommended for a destructive op, not a hard blocker).

## Owner-decision gates (unchanged, not made here)
Every staging enablement, the T-source product choice, any prod flag. Recommendations + runbooks are provided; the flips are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)