### PR TITLE
fix(approval,automation): cycle decision-clean hardenings + audit/verification MD

### DIFF
--- a/docs/development/approval-automation-cycle-completion-and-verification-20260630.md
+++ b/docs/development/approval-automation-cycle-completion-and-verification-20260630.md
@@ -1,0 +1,105 @@
+# Approval & Process-Automation — cycle audit, completion & verification (2026-06-30)
+
+> A code-grounded re-audit of the line against current `main` (HEAD `f14be042e`), the decision-clean work
+> completed this cycle (with verification), one newly-found latent defect surfaced for a decision, and the
+> remaining backlog with a recommended GO order. **Honest headline:** the *ratified-buildable* feature set is
+> exhausted — every remaining rung is owner-gated by an open security/permission/destructive/product/migration
+> decision (re-confirmed against code, not just docs). So this cycle completes the **decision-clean hardenings**
+> (which need no owner decision) and teees up the gated rungs for a one-word GO.
+
+## 1. Where the line stands (code-verified, not doc-trusted)
+
+A 4-reader audit verified each capability against the actual code (greps + file:line), not the planning docs.
+
+**Shipped + verified on `main`:**
+
+| Capability | PR | Evidence |
+|---|---|---|
+| T2-3 person/team analytics | #3387 | `routes/approval-metrics.ts` /people (`approvals:analytics`) + /teams (`approvals:admin`); migration `…090000` |
+| T1-1 node-SLA **slice-1 (remind only)** | #3404 | `NODE_TIMEOUT_SUPPORTED_EFFECTS = {'remind'}` (ApprovalProductService:311); deadline cols on `approval_metrics`; leader scanner |
+| T2-4 N-of-M threshold | #3406 | `'threshold'` mode + `approvalThreshold`; dual fail-closed N>M (executor 422 + runtime backstop) |
+| T2-5 timezone scheduling | #3401 | `automation-timezone.ts` (IANA fail-closed, DST fire-once/skip); UTC byte-identical |
+| date_field floating-day fix | #3417 | `floatingCalendarDay` literal-day; date-only widened SQL bounds (HEAD is this commit) |
+| T0-2 W7 resultWriteback **backend** | #3384 | approved-path backwrite + `statusField/approverField/completedAtField` validation (automation-service.ts) |
+| R2 redaction (public path) / R3 editor | #3382 | bridge `redactHiddenFormFields`; `webhook.received` removed from the editor selectable set |
+
+**Partial-by-design / latent (verified):** T1-1 slice-2 (transfer/jump/auto_* still publish-rejected); R2 is a
+*latent* gap — `toUnifiedApprovalDTO` returns `form_snapshot` verbatim, redaction lives only on the public
+bridge path; `webhook.received` remains a runtime-inert trigger enum entry (kept until T1-2).
+
+## 2. Completed this cycle (decision-clean — no owner decision required)
+
+All three are pure correctness/robustness on shipped code, built + verified, merge-ready on branch
+`claude/approval-automation-audit-20260630`:
+
+- **(1a) `offsetDays` save cap** (`5f5253049`). The save validator accepted any non-negative integer, so an
+  absurd value (1e12) overflowed the candidate-range `new Date(ms).toISOString()` with a `RangeError` and
+  aborted the **whole scan** for the rule. Added `MAX_DATE_REMINDER_OFFSET_DAYS = 36500` (~100y) fail-closed
+  at save. *Verify:* unit (range OK at cap) + real-DB `DR-VAL` (createRule rejects 1e12).
+- **(1b) Runtime degrade-not-throw** (`54655c0f1`). The save cap only guards the API path; a **persisted**
+  out-of-range offset (direct-DB / pre-cap) still threw at scan. Added a magnitude clamp in the pure functions
+  (mirrors the junk-tz "degrade, never throw" posture) → bounded output, never an aborting `RangeError`.
+  *Verify:* unit golden updated — 1e12 now degrades (no throw), clamped result equals the at-cap bounds.
+- **(2) Deterministic analytics Top-N** (`54655c0f1`). `byTemplate` / `byPeople` / `byTeams` used
+  `ORDER BY COUNT(*) DESC LIMIT 100` with no tie-break → nondeterministic which buckets survive the cut. Added
+  the group key as a secondary ASC sort. *Verify:* 16 approval-metrics unit + 3 people/teams real-DB green.
+
+**Cycle verification total:** tsc 0 · 39 date-reminder unit · 16 approval-metrics unit · 19 + 3 real-DB green.
+
+## 3. Newly-found latent defect — surfaced for a decision (NOT auto-fixed)
+
+**T2-4 threshold re-entry quorum bypass** *(reachability self-verified, not reader-trusted).* The threshold
+tally `COUNT(DISTINCT actor_id) … WHERE instance_id=$1 AND action='approve' AND metadata->>'nodeKey'=$2`
+(ApprovalProductService ~4178) is **not scoped to the current node-entry round**. The **return (退回) path**
+(`~3996`) admits any *previously-visited* approval node as a target — which an already-resolved `threshold`
+node is — and on return `deactivateAllActiveAssignments` + `resolveReturnToNode` re-activate it while the prior
+`approve` records stay (records are append-only; nothing clears them). So a 2-of-3 node where A+B approved,
+then someone 退回s back to it, is re-satisfied by a **single** fresh approval on the 2 stale votes (the tally
+reads `priorDistinct(A,B)=2 + 1`). *(Admin-jump can't trigger this — `isReachableDownstream` only goes
+forward; the return path is the reachable vector.)* A quorum bypass in a voting mechanism — security-relevant.
+
+This is **owner-gated** because the fix is a vote-scoping *semantic* choice, not a one-liner. **Proposed
+default:** scope the tally to approvals at/after the node's latest activation (`node_breakdown[].activatedAt`
+is already recorded), and reconcile with add-sign/reduce-sign. I can land it as a fail-first real-DB test
+(RED on current code) + the fix in one PR on your GO. *(Analogous to the date-field P2 you caught — a real
+bug found by review, held for a ratified fix rather than guessed.)*
+
+## 4. The remaining backlog is entirely owner-gated — recommended GO order
+
+All 13 un-shipped rungs were re-validated against code: each still carries a live open decision (none entered
+the ratify→ship pipeline). Recommended order for your next GO, each one design-lock-first:
+
+1. **R1 — BPMN governance + SSRF containment** *(LIVE EXPOSURE — do first).* `/api/workflow` is mounted
+   `authenticate`-only (no RBAC) and `BPMNWorkflowEngine` runs a process-supplied `fetch()` (authenticated
+   SSRF). This is an exposure, not a feature gap. **Recommend GO #1.**
+2. **T0-3 — expose `delete_record` in the editor** *(cheapest, S).* Executor exists; needs confirm + permission
+   + anti-misdelete + same-base-only + the `validateCrossBaseWriteConfig` delete/lock extension.
+3. **T2-6 — event-driven dedup ledger** *(substrate).* `record.*`/`form.submitted` rules re-run side effects on
+   redelivery; this is the idempotency substrate several later rungs lean on. Do just before T1-3.
+4. **T1-3 — `approval.*` automation trigger** *(unblocks the most).* Exposes the completion event as a
+   first-class rule trigger; carries the routing-key / templateId-null / loop-depth / cross-tenant decisions.
+5. **T1-1 slice-2 — transfer/jump timeout effects** — the transfer + direct-jump core is decision-clean against
+   the ratified T1-1 defaults (config `transferToUserId`/`jumpToNodeKey`, actor `system:approval-timeout`,
+   `metadata.timeoutEffect`, reuse `buildTransferAssignments`/`resolveReturnToNode`; parallel-region already
+   rejected; direct jump-to-terminal already blocked). **One open carve-out:** an *indirect* jump to an
+   approval node that then auto-completes (e.g. `mergeWithRequester`) cascades to terminal — effectively a
+   timeout auto-approve. Proposed default: treat that cascade as a terminal effect → keep it behind the same
+   `auto_approve`/`auto_reject` env gate. Design-lock that carve-out, then it's GO-ready.
+6. Then **T1-4** (node field-perms authoring + readonly/editable runtime; dep: edit-form-at-node) ·
+   **T3-4** (W7 rejection backwrite; product call: write-then-fail vs write-then-continue) ·
+   **T3-5** (W7 cross-base; security arc through the cross-base write gate) ·
+   **T1-2** (inbound webhook; signature/replay/audit contract) ·
+   **T2-1+2** (scoped admins + handover; permission model + migration) ·
+   **T3-2** (business-calendar SLA; cross-domain wiring, dep T1-1) · **T3-3** (signature) ·
+   **T3-1** (mobile; blocked on a notification hub) · **T3-6** (S-band approval-as-records; product-model).
+
+Design-locks for all of these already exist in the design-lock pack (#3385) + decision register (#3385); each
+is one ratification (approve-defaults or override) away from a build.
+
+## 5. Verdict
+
+The authorized, decision-clean work is **done and verified** (three hardenings, merge-ready). The line is at a
+clean gate: no ratified-buildable feature remains un-built, one real defect is surfaced for your decision, and
+the gated backlog is prioritized with R1 flagged as a live exposure to triage first. Nothing here was
+auto-built past an owner decision — the state-mutating and security/permission/destructive rungs stay
+design-lock-first, awaiting your GO.

--- a/docs/development/approval-automation-cycle-completion-and-verification-20260630.md
+++ b/docs/development/approval-automation-cycle-completion-and-verification-20260630.md
@@ -1,6 +1,7 @@
 # Approval & Process-Automation — cycle audit, completion & verification (2026-06-30)
 
-> A code-grounded re-audit of the line against current `main` (HEAD `f14be042e`), the decision-clean work
+> A code-grounded re-audit of the line against the approval-line baseline `f14be042e` (origin/main may have
+> advanced with unrelated commits since — that does not affect these conclusions), the decision-clean work
 > completed this cycle (with verification), one newly-found latent defect surfaced for a decision, and the
 > remaining backlog with a recommended GO order. **Honest headline:** the *ratified-buildable* feature set is
 > exhausted — every remaining rung is owner-gated by an open security/permission/destructive/product/migration

--- a/packages/core-backend/src/multitable/automation-date-reminder.test.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.test.ts
@@ -351,17 +351,24 @@ describe('dateReminderCandidateDateRange — SQL pre-filter brackets the product
     expect(bareOnLoDay >= oldFullIsoLo).toBe(false)
   })
 
-  test('offsetDays at the cap does NOT overflow toISOString; far above the cap WOULD (why the save cap exists)', () => {
+  test('offsetDays defense-in-depth: bounded at the cap, and a PERSISTED out-of-range value DEGRADES (no throw)', () => {
     const now = Date.parse('2026-06-25T12:00:00.000Z')
     const window = DATE_REMINDER_GRACE_WINDOW_MS
-    // At the sanity cap the range math stays inside the JS Date range — no throw, valid date-only bounds.
+    // At the sanity cap the range math stays inside the JS Date range — valid date-only bounds.
+    const atCap = dateReminderCandidateDateRange(now, { offsetDays: MAX_DATE_REMINDER_OFFSET_DAYS, direction: 'after' }, window)
+    expect(atCap.loIso).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(atCap.hiIso).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    // The save cap (validateDateFieldTriggerAtSave) rejects new out-of-range rules; for a PERSISTED junk value
+    // (direct-DB / pre-cap) the runtime clamp degrades to bounded output instead of throwing a RangeError that
+    // would abort the whole scan. The clamped 1e12 produces the SAME bounds as the cap (magnitude clamp).
+    let degraded: { loIso: string; hiIso: string } | null = null
     expect(() => {
-      const r = dateReminderCandidateDateRange(now, { offsetDays: MAX_DATE_REMINDER_OFFSET_DAYS, direction: 'after' }, window)
-      expect(r.loIso).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-      expect(r.hiIso).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      degraded = dateReminderCandidateDateRange(now, { offsetDays: 1e12, direction: 'after' }, window)
     }).not.toThrow()
-    // An uncapped absurd value overflows new Date(ms).toISOString() with a RangeError — exactly what the
-    // save-time cap (validateDateFieldTriggerAtSave) fail-closes so the scan never aborts on it.
-    expect(() => dateReminderCandidateDateRange(now, { offsetDays: 1e12, direction: 'after' }, window)).toThrow(RangeError)
+    expect(degraded!).toEqual(atCap)
+    // The occurrence path degrades too (no throw) for a persisted huge offset.
+    expect(() =>
+      computeDateReminderOccurrence('2026-06-28', { offsetDays: 1e12, direction: 'after', timeOfDay: '09:00' }),
+    ).not.toThrow()
   })
 })

--- a/packages/core-backend/src/multitable/automation-date-reminder.test.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.test.ts
@@ -16,6 +16,7 @@ import {
   dateReminderTimeOfDayPassed,
   dateReminderCandidateDateRange,
   dateReminderLedgerRetentionCutoffIso,
+  MAX_DATE_REMINDER_OFFSET_DAYS,
 } from './automation-date-reminder'
 
 const DAY = 24 * 60 * 60 * 1000
@@ -348,5 +349,19 @@ describe('dateReminderCandidateDateRange — SQL pre-filter brackets the product
     // because the bare string is a prefix of the timestamp and sorts BEFORE it. This is the boundary-luck fix.
     const oldFullIsoLo = `${loIso}T12:00:00.000Z`
     expect(bareOnLoDay >= oldFullIsoLo).toBe(false)
+  })
+
+  test('offsetDays at the cap does NOT overflow toISOString; far above the cap WOULD (why the save cap exists)', () => {
+    const now = Date.parse('2026-06-25T12:00:00.000Z')
+    const window = DATE_REMINDER_GRACE_WINDOW_MS
+    // At the sanity cap the range math stays inside the JS Date range — no throw, valid date-only bounds.
+    expect(() => {
+      const r = dateReminderCandidateDateRange(now, { offsetDays: MAX_DATE_REMINDER_OFFSET_DAYS, direction: 'after' }, window)
+      expect(r.loIso).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(r.hiIso).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    }).not.toThrow()
+    // An uncapped absurd value overflows new Date(ms).toISOString() with a RangeError — exactly what the
+    // save-time cap (validateDateFieldTriggerAtSave) fail-closes so the scan never aborts on it.
+    expect(() => dateReminderCandidateDateRange(now, { offsetDays: 1e12, direction: 'after' }, window)).toThrow(RangeError)
   })
 })

--- a/packages/core-backend/src/multitable/automation-date-reminder.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.ts
@@ -77,6 +77,14 @@ export interface ScheduleDateFieldConfig {
 export const DATE_REMINDER_GRACE_WINDOW_MS = 2 * DAY_MS
 
 /**
+ * Sanity cap for `offsetDays` (whole days before/after the date value). 100 years is far beyond any real
+ * reminder and keeps the candidate-range math (`nowMs ± signedDays*DAY ± slack`) safely inside the JS Date
+ * range — an uncapped value (e.g. 1e12) overflows `new Date(ms).toISOString()` with a RangeError and aborts
+ * the whole scan for that rule. Enforced fail-closed at save (validateDateFieldTriggerAtSave).
+ */
+export const MAX_DATE_REMINDER_OFFSET_DAYS = 36500
+
+/**
  * Retain the date-reminder idempotency ledger for one year. The ledger is a dedupe/audit record, not user
  * content; rule deletion still cascades immediately, while long-lived active rules age by actual `fired_at`.
  */

--- a/packages/core-backend/src/multitable/automation-date-reminder.ts
+++ b/packages/core-backend/src/multitable/automation-date-reminder.ts
@@ -85,6 +85,19 @@ export const DATE_REMINDER_GRACE_WINDOW_MS = 2 * DAY_MS
 export const MAX_DATE_REMINDER_OFFSET_DAYS = 36500
 
 /**
+ * Runtime defense (mirrors the junk-tz "degrade, never throw" posture): the save cap only guards the API
+ * path, so a PERSISTED out-of-range `offsetDays` (direct-DB write, or a rule saved before the cap existed)
+ * would still overflow the occurrence/range math's `new Date(ms).toISOString()` and abort the WHOLE scan
+ * for the rule. Clamp the magnitude here so a junk value degrades to a bounded (if meaningless) occurrence
+ * instead of throwing. Junk/non-finite → 0.
+ */
+function clampOffsetDays(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return 0
+  const t = Math.trunc(raw)
+  return Math.max(-MAX_DATE_REMINDER_OFFSET_DAYS, Math.min(MAX_DATE_REMINDER_OFFSET_DAYS, t))
+}
+
+/**
  * Retain the date-reminder idempotency ledger for one year. The ledger is a dedupe/audit record, not user
  * content; rule deletion still cascades immediately, while long-lived active rules age by actual `fired_at`.
  */
@@ -235,7 +248,7 @@ export function computeDateReminderOccurrence(
   const t = d.getTime()
   if (Number.isNaN(t)) return null
 
-  const offset = Number.isFinite(config.offsetDays) ? Math.trunc(config.offsetDays) : 0
+  const offset = clampOffsetDays(config.offsetDays)
   const signedDays = config.direction === 'after' ? offset : -offset
   const tz = resolveReminderTimeZone(config.timezone)
 
@@ -342,7 +355,7 @@ export function dateReminderCandidateDateRange(
   config: { offsetDays?: number; direction?: 'before' | 'after' },
   scanWindowMs: number,
 ): { loIso: string; hiIso: string } {
-  const offset = Number.isFinite(config.offsetDays) ? Math.trunc(config.offsetDays) : 0
+  const offset = clampOffsetDays(config.offsetDays)
   const signedDays = config.direction === 'after' ? offset : -offset
   // occurrence = dateDay + signedDays*DAY (+timeOfDay). Inverting: dateDay = occurrence - signedDays*DAY.
   // occurrence ∈ (now - window, now]  ⇒  dateDay ∈ (now - window, now] - signedDays*DAY. Add ±2d slack.

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -9,6 +9,7 @@ import {
   dateReminderFloorMs,
   DATE_REMINDER_GRACE_WINDOW_MS,
   DATE_REMINDER_LEDGER_SWEEP_INTERVAL_MS,
+  MAX_DATE_REMINDER_OFFSET_DAYS,
   dateReminderCandidateDateRange,
   dateReminderLedgerRetentionCutoffIso,
   type ScheduleDateFieldConfig,
@@ -1369,6 +1370,11 @@ export class AutomationService {
       offsetDays < 0
     ) {
       return 'schedule.date_field offsetDays must be a non-negative integer'
+    }
+    // Magnitude cap (fail-closed): an absurd offset (e.g. 1e12) overflows the candidate-range math's
+    // `new Date(ms).toISOString()` with a RangeError and aborts the whole scan for the rule. Bound it at save.
+    if (offsetDays > MAX_DATE_REMINDER_OFFSET_DAYS) {
+      return `schedule.date_field offsetDays must be at most ${MAX_DATE_REMINDER_OFFSET_DAYS} days`
     }
 
     if (cfg.timeOfDay !== undefined && cfg.timeOfDay !== null && cfg.timeOfDay !== '') {

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -466,7 +466,7 @@ export class ApprovalMetricsService {
        FROM approval_metrics
        ${where}
        GROUP BY template_id
-       ORDER BY COUNT(*) DESC
+       ORDER BY COUNT(*) DESC, template_id ASC
        LIMIT 100`,
       params,
     )
@@ -561,7 +561,7 @@ export class ApprovalMetricsService {
        LEFT JOIN approval_instances i ON i.id = m.instance_id
        ${where}
        GROUP BY ${keyExpr}
-       ORDER BY COUNT(*) DESC
+       ORDER BY COUNT(*) DESC, ${keyExpr} ASC
        LIMIT 100`,
       params,
     )

--- a/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-date-reminder-trigger.test.ts
@@ -249,6 +249,13 @@ describeIfDatabase('multitable date-reminder trigger — scan/claim/fire (real D
       .rejects.toThrow(/offsetDays must be a non-negative integer/i)
   })
 
+  test('DR-VAL: rejects an offsetDays above the sanity cap at save (no scan-aborting RangeError)', async () => {
+    // 1e12 is a valid non-negative integer, so it passes the old check; the magnitude cap fail-closes it at
+    // save, otherwise the candidate-range math would throw a RangeError and abort the whole scan for the rule.
+    await expect(svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 1e12, direction: 'before' })))
+      .rejects.toThrow(/offsetDays must be at most/i)
+  })
+
   test('DR-VAL (T2-5): accepts a valid non-UTC IANA timezone at save (now honored, not UTC-only)', async () => {
     const ok = await svc.createRule(SHEET, mkDateRule({ dateFieldId: FLD_DATE, offsetDays: 3, direction: 'before', timezone: 'America/New_York' }))
     expect(ok.id).toBeTruthy()

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -360,6 +360,31 @@ describe('ApprovalMetricsService', () => {
     })
   })
 
+  // Top-N determinism: without a tie-break, `ORDER BY COUNT(*) DESC LIMIT 100` returns ties in unspecified
+  // order, so which buckets survive the cut is nondeterministic across executions. Each dimension query must
+  // carry the group key as a secondary ASC sort. (SQL-string asserts on the mocked query — cheap + exact.)
+  describe('Top-N truncation is deterministic (tie-break on the group key)', () => {
+    const emptySummary = { rows: [{ total: '0', approved: '0', rejected: '0', revoked: '0', returned: '0', running: '0', avg_duration: null, p50_duration: null, p95_duration: null, sla_breach_count: '0', sla_candidate_count: '0' }] }
+
+    it('byTemplate breaks COUNT ties on template_id', async () => {
+      queryMock.mockResolvedValueOnce(emptySummary).mockResolvedValueOnce({ rows: [] })
+      await service.getMetricsSummary({ tenantId: 't' })
+      expect(normalize(queryMock.mock.calls[1][0])).toMatch(/ORDER BY COUNT\(\*\) DESC,\s*template_id ASC/)
+    })
+
+    it('getMetricsByRequester breaks COUNT ties on the group key', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] })
+      await service.getMetricsByRequester({ tenantId: 't' })
+      expect(normalize(queryMock.mock.calls[0][0])).toMatch(/ORDER BY COUNT\(\*\) DESC,\s*.+ ASC/)
+    })
+
+    it('getMetricsByDepartment breaks COUNT ties on the group key', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] })
+      await service.getMetricsByDepartment({ tenantId: 't' })
+      expect(normalize(queryMock.mock.calls[0][0])).toMatch(/ORDER BY COUNT\(\*\) DESC,\s*.+ ASC/)
+    })
+  })
+
   describe('getMetricsReport', () => {
     it('returns summary plus slowest instances and riskiest SLA templates', async () => {
       queryMock


### PR DESCRIPTION
## Summary

A code-grounded re-audit of the approval & process-automation line against current `main`, plus the **decision-clean hardenings** completable this cycle without an owner decision. The ratified-buildable feature set is exhausted — every remaining rung is owner-gated — so this PR ships the safe correctness work and the audit/verification MD that prioritizes the gated backlog.

## Decision-clean hardenings (this PR)

1. **`offsetDays` save cap** (`5f5253049`) — reject `offsetDays > 36500` (~100y) at save; an absurd value overflowed the candidate-range `toISOString()` with a `RangeError` and aborted the whole scan.
2. **Runtime degrade-not-throw** (`54655c0f1`) — the save cap only guards the API path; a *persisted* out-of-range offset still threw at scan. Clamp the magnitude in the pure functions (junk-tz "degrade, never throw" posture).
3. **Deterministic analytics Top-N** (`54655c0f1`) — `byTemplate`/`byPeople`/`byTeams` `ORDER BY COUNT(*) DESC LIMIT 100` had no tie-break → nondeterministic truncation. Added the group key as a secondary ASC sort.

**Verification:** tsc 0 · 39 date-reminder unit · 16 approval-metrics unit · 19 + 3 real-DB green.

## Surfaced for a decision (NOT fixed here)

**T2-4 threshold re-entry quorum bypass** — the threshold tally `COUNT(DISTINCT actor_id) … action='approve'` is unscoped to the node-entry round, so a returned-to/re-entered `threshold` node can be satisfied by stale votes from a prior entry. Owner-gated (vote-scoping is a semantic choice). Proposed fix in the MD; I can land it fail-first on your GO.

## Audit / verification MD

`docs/development/approval-automation-cycle-completion-and-verification-20260630.md` — code-verified shipped ledger, the completed hardenings, the surfaced defect, and the **owner-gated backlog with a recommended GO order**: R1 (live SSRF exposure) → T0-3 (cheapest) → T2-6 (substrate) → T1-3 (unblocks most) → T1-1 slice-2 → … Each is design-lock-first; nothing was auto-built past an owner decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)