### PR TITLE
fix(attendance): stop shared-org holiday pollution breaking the multi-shift slot test (main-wide gate)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -613,7 +613,13 @@ attendanceIntegrationDescribe(
     const assignmentId = (assignmentRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
     expect(assignmentId).toBeTruthy()
 
-    const holidayDate = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString().slice(0, 10)
+    // Fixed far-future date, NOT `Date.now() + 7 days`. Holidays here live in the shared 'default' org and
+    // are not cleaned up, so a near-term relative date can collide with another test's fixed workDate: on
+    // 2026-07-01, `today + 7` == the multi-shift test's fixed `2026-07-08`, and that stray holiday made the
+    // day non-working → `plannedMinutes` read [0,0] instead of [240,240]. A far-future fixed date (matching
+    // the other throwaway-holiday tests in this file, e.g. 2036/3000/2029) can never collide with a
+    // near-term test date.
+    const holidayDate = '2099-07-08'
     const holidayRes = await requestJson(`${baseUrl}/api/attendance/holidays`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Why the whole `test (18.x)`/`test (20.x)` gate went red on main

`attendance-plugin.test.ts > enforces multi-shift slot conflicts …` asserts `plannedMinutes [240,240]` but got `[0,0]`, on **every** PR (docs-only #3424 inherited it), starting exactly at the **UTC July-1 rollover**, with **no code change** (the only commit since the last green run, #3419, is notification-only).

## Root cause — test isolation, not a product regression

The big "create every attendance entity" smoke test creates a holiday at **`Date.now() + 7 days`** in the shared **`'default'` org** and never cleans it up (it's verified at creation, then abandoned). Holidays are org-global, so on **2026-07-01**, `today + 7` == the multi-shift test's **fixed** `workDate = '2026-07-08'`. The effective calendar then *correctly* treats that day as a non-working holiday → `plannedMinutes` = 0.

- On 2026-06-30, `today+7` = July 7 (no collision) → green.
- On 2026-07-01, `today+7` = July 8 → collision → red.

A holiday zeroing planned minutes is **correct** behavior; the fault is a stray relative-date holiday leaking across tests on a shared org.

## Fix (test-only)

Match the file's own convention — its other throwaway-holiday tests use far-future **fixed** dates (`2036-10-01`, year-3000, `2029-03-15`) or `DELETE` their rows. This one now uses a far-future fixed date (`'2099-07-08'`) that can never collide with a near-term test date. No product code touched.

## Verification

This PR's own `test (18.x)`/`test (20.x)` running green on July 1 confirms the mechanism. After it lands, #3424 (and every other PR) rebases onto a green gate.