### PR TITLE
feat(workflow): add R1-A BPMN egress URL guard

### DIFF
--- a/docs/development/workflow-bpmn-egress-guard-slice1-dev-verification-20260701.md
+++ b/docs/development/workflow-bpmn-egress-guard-slice1-dev-verification-20260701.md
@@ -1,0 +1,45 @@
+# R1-A BPMN egress guard slice 1 — development + verification (2026-07-01)
+
+**Status: REVIEWABLE — NOT WIRED.** This slice implements the pure egress URL/policy guard
+authorized by `workflow-bpmn-http-task-ssrf-boundary-design-lock-20260630.md` after `R1 GO`.
+It does not modify `BPMNWorkflowEngine.executeHttpTask`, does not fetch, and does not change live
+workflow behavior.
+
+## What this slice adds
+
+- `validateEgressUrl(url, policy)` in `packages/core-backend/src/guards/egress-guard.ts`.
+- `defaultEgressPolicy()` is fail-closed: an empty/missing allowlist denies every URL.
+- V1 policy follows the ratified §0 decisions:
+  - `https:` only; `http:` remains denied even if the host is allowlisted.
+  - exact-host allowlist only, case-normalized.
+  - no suffix wildcard, bare wildcard, or CIDR allowlist in this runtime slice.
+  - credentials in the URL are rejected.
+  - unsafe hostnames such as `localhost`, `.localhost`, `.local`, and `.internal` are rejected
+    even if accidentally allowlisted.
+  - IP literals are classified before allow, including canonicalized decimal/hex/short IPv4 forms.
+- `ipaddr.js` is now a direct backend dependency because this security boundary needs robust IPv6
+  classification for mapped IPv4, NAT64, 6to4, Teredo, CGNAT, multicast, and reserved ranges.
+- The existing `send_webhook` SSRF guard was reviewed and left untouched. It is a product-specific
+  resolve-and-pin path; this slice adds the BPMN policy primitive under `src/guards` and keeps
+  dispatcher reuse/wiring for later slices.
+
+## Explicitly not shipped
+
+- DNS resolution and post-resolution IP validation.
+- IP-pinned dispatcher and redirect validation.
+- Header/method filtering.
+- Any wiring into BPMN HTTP service tasks.
+
+Those are the next R1 slices.
+
+## Verification
+
+- Unit coverage: `packages/core-backend/src/guards/__tests__/egress-guard.test.ts`
+  - scheme rejection matrix;
+  - credential rejection;
+  - default fail-closed policy;
+  - exact-host allowlist;
+  - wildcard/CIDR non-support;
+  - local/internal hostname rejection;
+  - unsafe IPv4/IPv6 classes, IPv4-mapped IPv6, NAT64, 6to4, and Teredo;
+  - URL canonicalization of decimal/hex/short IPv4 forms before IP blocking.

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -47,6 +47,7 @@
     "geoip-lite": "^1.4.10",
     "glob": "^10.3.10",
     "ioredis": "^5.3.0",
+    "ipaddr.js": "^2.4.0",
     "joi": "^18.0.2",
     "jsonwebtoken": "^9.0.2",
     "kysely": "^0.28.8",

--- a/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  defaultEgressPolicy,
+  isBlockedEgressIp,
+  validateEgressUrl,
+  type EgressPolicy,
+} from '../egress-guard'
+
+const policy = (hosts: readonly string[]): EgressPolicy => ({ allowedHosts: hosts })
+
+describe('R1-A egress guard — IP deny-list', () => {
+  test.each([
+    '127.0.0.1',
+    '0.0.0.0',
+    '255.255.255.255',
+    '10.0.0.1',
+    '172.16.0.1',
+    '172.31.255.255',
+    '192.168.1.10',
+    '169.254.169.254',
+    '100.64.0.1',
+    '198.18.0.1',
+    '224.0.0.1',
+    '240.0.0.1',
+    '192.0.2.1',
+    '::1',
+    '::',
+    'fe80::1',
+    'fc00::1',
+    'fd00::1',
+    'ff02::1',
+    '2001:db8::1',
+    '::ffff:127.0.0.1',
+    '::ffff:10.1.2.3',
+    '64:ff9b::7f00:1',
+    '2002:7f00:1::',
+    '2001:0:4136:e378:8000:63bf:3fff:fdd2',
+  ])('blocks unsafe IP literal %s', (ip) => {
+    expect(isBlockedEgressIp(ip)).toBe(true)
+  })
+
+  test.each(['8.8.8.8', '1.1.1.1', '2606:4700:4700::1111', '::ffff:8.8.8.8'])(
+    'allows globally-routable IP literal %s at the deny-list layer',
+    (ip) => {
+      expect(isBlockedEgressIp(ip)).toBe(false)
+    },
+  )
+})
+
+describe('R1-A egress guard — URL policy', () => {
+  test('fails closed when no allowlist is configured', () => {
+    expect(validateEgressUrl('https://api.example.com/hook', defaultEgressPolicy())).toEqual({
+      allowed: false,
+      reason: 'ALLOWLIST_REQUIRED',
+    })
+  })
+
+  test('allows an exact allowlisted https host and normalizes host case', () => {
+    expect(validateEgressUrl('https://API.Example.com/hook?a=1', policy(['api.example.com']))).toMatchObject({
+      allowed: true,
+      protocol: 'https:',
+      hostname: 'api.example.com',
+    })
+  })
+
+  test('rejects non-https schemes, including otherwise-allowlisted http', () => {
+    expect(validateEgressUrl('http://api.example.com/hook', policy(['api.example.com']))).toEqual({
+      allowed: false,
+      reason: 'SCHEME_NOT_ALLOWED',
+    })
+    for (const scheme of ['file', 'ftp', 'gopher', 'data', 'ws', 'wss', 'mailto']) {
+      expect(validateEgressUrl(`${scheme}:example`, policy(['api.example.com']))).toMatchObject({
+        allowed: false,
+        reason: 'SCHEME_NOT_ALLOWED',
+      })
+    }
+  })
+
+  test('rejects credentials in URL even for an allowlisted host', () => {
+    expect(validateEgressUrl('https://user:pass@api.example.com/hook', policy(['api.example.com']))).toEqual({
+      allowed: false,
+      reason: 'URL_CREDENTIALS_NOT_ALLOWED',
+    })
+  })
+
+  test('requires exact host allowlisting; suffixes and wildcards do not match', () => {
+    expect(validateEgressUrl('https://evil.api.example.com/hook', policy(['api.example.com']))).toEqual({
+      allowed: false,
+      reason: 'HOST_NOT_ALLOWLISTED',
+    })
+    expect(validateEgressUrl('https://api.example.com/hook', policy(['*.example.com', 'example.com/24']))).toEqual({
+      allowed: false,
+      reason: 'ALLOWLIST_REQUIRED',
+    })
+  })
+
+  test('rejects local/internal hostnames even if accidentally allowlisted', () => {
+    for (const host of ['localhost', 'service.localhost', 'service.local', 'service.internal']) {
+      expect(validateEgressUrl(`https://${host}/`, policy([host]))).toEqual({
+        allowed: false,
+        reason: 'HOST_INTERNAL_NAME',
+      })
+    }
+  })
+
+  test('checks IP literals after URL canonicalization, including decimal/hex/short IPv4 forms', () => {
+    for (const url of [
+      'https://127.0.0.1/',
+      'https://2130706433/',
+      'https://0x7f000001/',
+      'https://127.1/',
+      'https://[::ffff:127.0.0.1]/',
+      'https://[64:ff9b::7f00:1]/',
+    ]) {
+      expect(validateEgressUrl(url, defaultEgressPolicy())).toEqual({
+        allowed: false,
+        reason: 'IP_BLOCKED',
+      })
+    }
+  })
+
+  test('allows a public IP literal only when the exact IP host is allowlisted', () => {
+    expect(validateEgressUrl('https://8.8.8.8/dns-query', policy(['8.8.8.8']))).toMatchObject({
+      allowed: true,
+      hostname: '8.8.8.8',
+    })
+    expect(validateEgressUrl('https://8.8.8.8/dns-query', policy(['dns.google']))).toEqual({
+      allowed: false,
+      reason: 'HOST_NOT_ALLOWLISTED',
+    })
+  })
+
+  test('allows a public IPv6 literal only when the exact IP host is allowlisted', () => {
+    expect(validateEgressUrl('https://[2606:4700:4700::1111]/', policy(['2606:4700:4700::1111']))).toMatchObject({
+      allowed: true,
+      hostname: '2606:4700:4700::1111',
+    })
+  })
+
+  test('treats CIDR-like allowlist entries as invalid in v1, never as a widened allow', () => {
+    expect(validateEgressUrl('https://8.8.8.8/dns-query', policy(['8.8.8.0/24']))).toEqual({
+      allowed: false,
+      reason: 'ALLOWLIST_REQUIRED',
+    })
+  })
+})

--- a/packages/core-backend/src/guards/egress-guard.ts
+++ b/packages/core-backend/src/guards/egress-guard.ts
@@ -1,0 +1,144 @@
+import * as ipaddr from 'ipaddr.js'
+
+export interface EgressPolicy {
+  /**
+   * Exact destination hosts allowed by policy. V1 intentionally supports exact
+   * hosts only: no wildcard, suffix, CIDR, or scheme-bearing entries.
+   */
+  allowedHosts?: readonly string[]
+}
+
+export type EgressUrlDenyReason =
+  | 'URL_REQUIRED'
+  | 'URL_MALFORMED'
+  | 'SCHEME_NOT_ALLOWED'
+  | 'URL_CREDENTIALS_NOT_ALLOWED'
+  | 'HOST_REQUIRED'
+  | 'HOST_INTERNAL_NAME'
+  | 'ALLOWLIST_REQUIRED'
+  | 'HOST_NOT_ALLOWLISTED'
+  | 'IP_BLOCKED'
+
+export type EgressUrlDecision =
+  | {
+      allowed: true
+      normalizedUrl: string
+      protocol: 'https:'
+      hostname: string
+    }
+  | {
+      allowed: false
+      reason: EgressUrlDenyReason
+    }
+
+export function defaultEgressPolicy(): EgressPolicy {
+  return { allowedHosts: [] }
+}
+
+function stripIpv6Brackets(hostname: string): string {
+  return hostname.replace(/^\[/, '').replace(/\]$/, '')
+}
+
+function normalizeHost(hostname: string): string {
+  const withoutBrackets = stripIpv6Brackets(hostname.trim().toLowerCase())
+  return withoutBrackets.endsWith('.') ? withoutBrackets.slice(0, -1) : withoutBrackets
+}
+
+function normalizeAllowedHost(value: string): string | null {
+  const raw = value.trim()
+  if (!raw) return null
+  if (raw.includes('*') || raw.includes('/') || raw.includes('@') || raw.includes('://')) return null
+  return normalizeHost(raw)
+}
+
+function normalizedAllowedHosts(policy: EgressPolicy): Set<string> {
+  const hosts = new Set<string>()
+  for (const host of policy.allowedHosts ?? []) {
+    const normalized = normalizeAllowedHost(host)
+    if (normalized) hosts.add(normalized)
+  }
+  return hosts
+}
+
+function isInternalHostname(hostname: string): boolean {
+  const h = normalizeHost(hostname)
+  return h === 'localhost' || h.endsWith('.localhost') || h.endsWith('.local') || h.endsWith('.internal')
+}
+
+function parseIp(hostname: string): ipaddr.IPv4 | ipaddr.IPv6 | null {
+  const host = stripIpv6Brackets(hostname.trim())
+  if (!host || host.includes('%') || !ipaddr.isValid(host)) return null
+  return ipaddr.parse(host)
+}
+
+function ipv4FromBytes(bytes: readonly number[]): ipaddr.IPv4 {
+  return ipaddr.parse(bytes.join('.')) as ipaddr.IPv4
+}
+
+function isBlockedIpv4(address: ipaddr.IPv4): boolean {
+  return address.range() !== 'unicast'
+}
+
+function isBlockedIpv6(address: ipaddr.IPv6): boolean {
+  if (address.isIPv4MappedAddress()) {
+    return isBlockedIpv4(address.toIPv4Address())
+  }
+
+  const bytes = address.toByteArray()
+  if (address.match(ipaddr.parseCIDR('64:ff9b::/96'))) {
+    return isBlockedIpv4(ipv4FromBytes(bytes.slice(12, 16)))
+  }
+  if (address.match(ipaddr.parseCIDR('2002::/16'))) {
+    return isBlockedIpv4(ipv4FromBytes(bytes.slice(2, 6)))
+  }
+
+  return address.range() !== 'unicast'
+}
+
+export function isBlockedEgressIp(hostname: string): boolean {
+  const address = parseIp(hostname)
+  if (!address) return false
+  if (address.kind() === 'ipv4') {
+    return isBlockedIpv4(address as ipaddr.IPv4)
+  }
+  return isBlockedIpv6(address as ipaddr.IPv6)
+}
+
+export function validateEgressUrl(rawUrl: unknown, policy: EgressPolicy = defaultEgressPolicy()): EgressUrlDecision {
+  if (typeof rawUrl !== 'string' || rawUrl.trim().length === 0) {
+    return { allowed: false, reason: 'URL_REQUIRED' }
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return { allowed: false, reason: 'URL_MALFORMED' }
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { allowed: false, reason: 'SCHEME_NOT_ALLOWED' }
+  }
+  if (parsed.username || parsed.password) {
+    return { allowed: false, reason: 'URL_CREDENTIALS_NOT_ALLOWED' }
+  }
+
+  const hostname = normalizeHost(parsed.hostname)
+  if (!hostname) return { allowed: false, reason: 'HOST_REQUIRED' }
+  if (isInternalHostname(hostname)) return { allowed: false, reason: 'HOST_INTERNAL_NAME' }
+
+  if (isBlockedEgressIp(hostname)) {
+    return { allowed: false, reason: 'IP_BLOCKED' }
+  }
+
+  const allowedHosts = normalizedAllowedHosts(policy)
+  if (allowedHosts.size === 0) return { allowed: false, reason: 'ALLOWLIST_REQUIRED' }
+  if (!allowedHosts.has(hostname)) return { allowed: false, reason: 'HOST_NOT_ALLOWLISTED' }
+
+  return {
+    allowed: true,
+    normalizedUrl: parsed.toString(),
+    protocol: 'https:',
+    hostname,
+  }
+}

--- a/packages/core-backend/src/guards/index.ts
+++ b/packages/core-backend/src/guards/index.ts
@@ -8,3 +8,4 @@ export * from './safety-metrics';
 export * from './middleware';
 export * from './audit-integration';
 export * from './idempotency';
+export * from './egress-guard';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       ioredis:
         specifier: ^5.3.0
         version: 5.8.2
+      ipaddr.js:
+        specifier: ^2.4.0
+        version: 2.4.0
       joi:
         specifier: ^18.0.2
         version: 18.0.2
@@ -2941,6 +2944,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -7435,6 +7442,8 @@ snapshots:
       sprintf-js: 1.1.2
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.4.0: {}
 
   is-array-buffer@3.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

R1-A from the ratified BPMN HTTP-task SSRF design-lock (#3431): add the pure egress URL/policy guard only.

This PR adds:
- `validateEgressUrl(url, policy)` under `packages/core-backend/src/guards/egress-guard.ts`
- fail-closed default policy (`allowedHosts: []` denies all)
- v1 exact-host allowlist only, case-normalized
- `https:` only; plain `http:` remains denied even if allowlisted
- credentials-in-URL rejection
- unsafe hostname rejection (`localhost`, `.localhost`, `.local`, `.internal`)
- IP literal deny-list using a direct `ipaddr.js` dependency for robust IPv4/IPv6 classification, including mapped IPv4, NAT64, 6to4, Teredo, CGNAT, multicast, and reserved ranges
- dev/verification MD for the slice

## Explicit non-goals

No live behavior changes in this slice:
- no `BPMNWorkflowEngine.executeHttpTask` wiring
- no DNS resolution / post-resolution validation
- no IP-pinned dispatcher
- no redirect re-validation
- no header/method filtering
- no fetch

Those are the next R1 slices. The existing `send_webhook` SSRF guard was reviewed and left untouched; it is product-specific and already wired to its own pinned fetch path.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run src/guards/__tests__/egress-guard.test.ts --reporter=dot` — 39/39
- `pnpm --filter @metasheet/core-backend exec vitest run src/guards --reporter=dot` — 55/55
- `pnpm --filter @metasheet/core-backend run build` — pass
- `pnpm --filter @metasheet/core-backend exec eslint src/guards/egress-guard.ts src/guards/__tests__/egress-guard.test.ts` — 0 errors; test file is ignored by existing ESLint ignore pattern
