### PR TITLE
feat(workflow): egress-guard module for BPMN SSRF boundary (R1 slice 1, not wired)

### DIFF
--- a/docs/development/workflow-bpmn-http-task-ssrf-D-ratification-and-slice1-20260630.md
+++ b/docs/development/workflow-bpmn-http-task-ssrf-D-ratification-and-slice1-20260630.md
@@ -1,0 +1,74 @@
+# R1 SSRF — D0–D5 ratification + slice 1 (egress-guard module), 2026-06-30
+
+Companion to the design-lock
+`docs/development/workflow-bpmn-http-task-ssrf-boundary-design-lock-20260630.md` (`#3428`).
+This record (1) ratifies the D0–D5 decisions and (2) records slice 1 — the standalone
+egress-guard module. **No runtime is wired to `executeHttpTask`;** the module resolves no DNS and
+opens no sockets.
+
+## 1. D0–D5 ratification
+
+Ratified per the design-lock recommendations. The two decisions that shape slice 1 (D1, D2) are
+encoded as **`EgressPolicy` config**, not hard-coded; the rest bind at their *wiring* slices and
+remain owner-amendable — so slice 1 does **not** silently settle the genuinely owner-scoped calls
+(D3 rollout especially).
+
+| # | Decision | Ratified | Binds at |
+|---|---|---|---|
+| D0 | Deploy provenance / who sets http-task fields | Workflow authors are untrusted for network egress; the boundary holds regardless of deploy authz. | (assumption; no code input) |
+| D1 | `http` vs `https`-only | `https`-only **default**; `http` allowed only when explicitly configured. Encoded as `EgressPolicy.allowedSchemes` (default `['https']`). | slice 1 (config) |
+| D2 | Allowlist granularity | Exact host **and** CIDR; no bare suffix wildcards. Encoded as `allowedHosts` (exact) + `allowedCidrs`. | slice 1 (config) |
+| D3 | **Rollout for existing http-tasks** | fail-closed (L7) is a behavior change — **still an owner call** (hard fail-closed / warn-then-enforce / per-tenant). Not decided here. | **slice 3/4 (wiring)** — owner ratifies before enforcement reaches live workflows |
+| D4 | Outbound header/method policy (L8) | forbid caller-set `Authorization`/`Cookie`/`Host`; configured method set. | slice 3 (wiring) |
+| D5 | in-process IP-pinned dispatcher vs egress proxy | in-process pinned-IP dispatcher unless a central egress proxy is adopted. | slice 2 (dispatcher) |
+
+Slice 1 is safe to build now because it needs only D1 + D2 (both config); D3/D4/D5 do not gate it
+(the module is not wired, so no live workflow is affected and no rollout call is forced).
+
+## 2. Slice 1 — egress-guard module (this PR)
+
+`packages/core-backend/src/guards/egress-guard.ts` + `__tests__/egress-guard.test.ts`, exported
+from `guards/index.ts`. Adds the runtime dep **`ipaddr.js`** (vetted IP/CIDR parsing on a security
+path — chosen over hand-rolling IPv6/mapped/CIDR logic).
+
+Exports:
+- **`isBlockedIp(ip, nat64Prefixes?)` (L2 core, reusable by slice 2):** blocks loopback, link-local
+  (incl. cloud metadata `169.254.169.254`), private, CGNAT, IPv6 ULA, multicast, reserved,
+  unspecified/broadcast — and **decomposes embedded-IPv4 tunnel forms** (IPv4-mapped, 6to4
+  `2002::/16`; Teredo blocked outright; NAT64 for the well-known `64:ff9b::/96` **and any
+  operator-configured `/96` prefix**) so those wrappers cannot smuggle a blocked v4. Unparseable →
+  fail-closed. **Residual:** a NAT64 gateway on a Network-Specific Prefix must be declared via
+  `EgressPolicy.nat64Prefixes`, else an IP-literal in that prefix is treated as global-unicast
+  (still gated by the L3 allowlist); non-`/96` NAT64 lengths are not decoded.
+- **`validateEgressUrl(url, policy)` (synchronous — L1 + L3 + L2-for-IP-literals):** canonicalizes
+  with WHATWG `URL` and classifies `url.hostname` (so decimal/octal/hex/short IPv4 forms normalize
+  before classification); enforces scheme allowlist, rejects credentials-in-URL, requires allowlist
+  membership, and applies `isBlockedIp` to IP-literal hosts. **L2 overrides L3** (an allowlisted
+  internal IP is still blocked).
+- **`defaultEgressPolicy()`:** `https`-only + empty allowlist ⇒ **deny all** (fail-closed).
+
+**Explicitly NOT in slice 1:** DNS resolution + the atomic resolve-and-pin dispatcher (slice 2,
+where `isBlockedIp` runs on each resolved IP then pins it — keeping resolve-and-pin atomic so no
+rebinding hole opens between slices); wiring into `BPMNWorkflowEngine.executeHttpTask` + header/
+method hardening (slice 3, L8); rollout (slice 3/4, D3).
+
+## 3. Verification
+
+- `pnpm --filter @metasheet/core-backend exec vitest run src/guards/__tests__/egress-guard.test.ts`
+  — **59 tests pass** (scheme/creds; the IP-literal zoo incl. IPv4-mapped/NAT64/6to4/Teredo metadata
+  + loopback, and decimal/hex/short-form normalization; allowlist; L2-overrides-L3; fail-closed).
+- `pnpm --filter @metasheet/core-backend run type-check` (`tsc --noEmit`) — **clean**.
+- An independent adversarial probe (IP-representation + URL-parsing corpus) was run over both
+  functions. The URL probe found **no** bypass. The IP probe surfaced one real gap — NAT64 on a
+  Network-Specific Prefix (only the well-known prefix was decoded) — now closed by the configurable
+  `nat64Prefixes` above and pinned by new tests.
+
+## 4. Next slices (not started — each takes its own opt-in)
+
+2. IP-pinned egress dispatcher (L4 redirect re-validation + L5 rebinding/TOCTOU defeat) — calls
+   `isBlockedIp` on every resolved IP and pins.
+3. Wire `executeHttpTask` to the dispatcher; apply L6 limits + L8 header/method policy (D4); D3
+   rollout.
+4. Rebinding/redirect/rollout integration tests; enable behind the configured policy.
+
+This record authorizes no runtime wiring. `executeHttpTask` is unchanged.

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -47,6 +47,7 @@
     "geoip-lite": "^1.4.10",
     "glob": "^10.3.10",
     "ioredis": "^5.3.0",
+    "ipaddr.js": "^2.4.0",
     "joi": "^18.0.2",
     "jsonwebtoken": "^9.0.2",
     "kysely": "^0.28.8",

--- a/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  defaultEgressPolicy,
+  isBlockedIp,
+  validateEgressUrl,
+  type EgressPolicy,
+} from '../egress-guard'
+
+function policy(over: Partial<EgressPolicy> = {}): EgressPolicy {
+  return { allowedSchemes: ['https'], allowedHosts: [], allowedCidrs: [], ...over }
+}
+
+describe('isBlockedIp — L2 classifier', () => {
+  const blocked = [
+    // IPv4 non-global-unicast
+    '127.0.0.1', '127.5.5.5', '0.0.0.0', '255.255.255.255',
+    '169.254.169.254', // cloud metadata
+    '10.0.0.1', '172.16.0.1', '192.168.1.1',
+    '100.64.0.1', // CGNAT
+    '224.0.0.1', '240.0.0.1',
+    // IPv6 non-global
+    '::1', 'fe80::1', 'fc00::1', 'fd12:3456::1', 'ff02::1', '::',
+    // embedded-IPv4 tunnel forms whose inner v4 is blocked (the top SSRF bypasses)
+    '::ffff:169.254.169.254', // IPv4-mapped metadata
+    '::ffff:127.0.0.1', // IPv4-mapped loopback
+    '64:ff9b::7f00:1', // NAT64 well-known → 127.0.0.1
+    '2002:7f00:1::', // 6to4 → 127.0.0.1
+    '2001:0000:4136:e378:8000:63bf:3fff:fdd2', // Teredo → blocked outright
+  ]
+  for (const ip of blocked) {
+    it(`blocks ${ip}`, () => expect(isBlockedIp(ip)).toBe(true))
+  }
+
+  const allowed = ['8.8.8.8', '1.1.1.1', '2606:4700:4700::1111', '::ffff:8.8.8.8']
+  for (const ip of allowed) {
+    it(`allows global-unicast ${ip}`, () => expect(isBlockedIp(ip)).toBe(false))
+  }
+
+  it('fail-closes on an unparseable value', () => expect(isBlockedIp('not-an-ip')).toBe(true))
+})
+
+describe('validateEgressUrl — scheme + creds (L1)', () => {
+  const p = policy({ allowedHosts: ['example.com', '8.8.8.8'] })
+  for (const bad of [
+    'file:///etc/passwd', 'ftp://example.com/', 'gopher://example.com/',
+    'data:text/plain,hello', 'ws://example.com/', 'mailto:a@example.com',
+  ]) {
+    it(`rejects scheme: ${bad}`, () => expect(validateEgressUrl(bad, p).allowed).toBe(false))
+  }
+  it('rejects http when policy is https-only', () =>
+    expect(validateEgressUrl('http://example.com/', p).allowed).toBe(false))
+  it('accepts https to an allowlisted host', () =>
+    expect(validateEgressUrl('https://example.com/', p).allowed).toBe(true))
+  it('rejects credentials in the URL', () =>
+    expect(validateEgressUrl('https://user:pass@example.com/', p).allowed).toBe(false))
+  it('allows http only when explicitly configured (D1)', () =>
+    expect(validateEgressUrl('http://example.com/',
+      policy({ allowedSchemes: ['https', 'http'], allowedHosts: ['example.com'] })).allowed).toBe(true))
+})
+
+describe('validateEgressUrl — IP-literal + host normalization (L2)', () => {
+  // Allow every address by CIDR so ONLY the L2 classifier can block — isolates L2.
+  const p = policy({ allowedCidrs: ['0.0.0.0/0', '::/0'] })
+  const blockedUrls = [
+    'https://127.0.0.1/',
+    'https://169.254.169.254/', // metadata
+    'https://[::1]/',
+    'https://10.0.0.1/',
+    'https://[::ffff:169.254.169.254]/', // IPv4-mapped metadata
+    'https://2130706433/', // decimal 127.0.0.1 — canonicalized by new URL()
+    'https://0x7f000001/', // hex 127.0.0.1
+    'https://127.1/', // short form 127.0.0.1
+  ]
+  for (const u of blockedUrls) {
+    it(`blocks ${u}`, () => expect(validateEgressUrl(u, p).allowed).toBe(false))
+  }
+  it('allows a public IP that is allowlisted', () =>
+    expect(validateEgressUrl('https://8.8.8.8/', policy({ allowedHosts: ['8.8.8.8'] })).allowed).toBe(true))
+})
+
+describe('validateEgressUrl — allowlist (L3) + fail-closed (L7)', () => {
+  it('denies a public IP not on the allowlist (empty default)', () =>
+    expect(validateEgressUrl('https://8.8.8.8/', defaultEgressPolicy()).allowed).toBe(false))
+  it('denies a public DNS host not on the allowlist', () =>
+    expect(validateEgressUrl('https://evil.example/', defaultEgressPolicy()).allowed).toBe(false))
+  it('allows an allowlisted DNS host', () =>
+    expect(validateEgressUrl('https://api.example.com/', policy({ allowedHosts: ['api.example.com'] })).allowed).toBe(true))
+  it('allows a public IP via CIDR', () =>
+    expect(validateEgressUrl('https://8.8.8.8/', policy({ allowedCidrs: ['8.8.8.0/24'] })).allowed).toBe(true))
+  it('L2 overrides L3 — an allowlisted internal IP is still blocked', () =>
+    expect(validateEgressUrl('https://127.0.0.1/',
+      policy({ allowedHosts: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'] })).allowed).toBe(false))
+  it('denies a malformed URL', () =>
+    expect(validateEgressUrl('http://', defaultEgressPolicy()).allowed).toBe(false))
+  it('a malformed allowlist CIDR never widens access', () =>
+    expect(validateEgressUrl('https://8.8.8.8/', policy({ allowedCidrs: ['not-a-cidr'] })).allowed).toBe(false))
+})
+
+describe('isBlockedIp — NAT64 Network-Specific Prefix (configurable)', () => {
+  it('well-known 64:ff9b::/96 with an embedded internal v4 is blocked by default', () =>
+    expect(isBlockedIp('64:ff9b::a00:1')).toBe(true)) // 10.0.0.1
+  it('a configured NSP NAT64 embedding an internal v4 is blocked', () =>
+    expect(isBlockedIp('2a00:1098:2c::a00:1', ['2a00:1098:2c::/96'])).toBe(true)) // 10.0.0.1
+  it('a configured NSP NAT64 embedding cloud metadata is blocked', () =>
+    expect(isBlockedIp('2a00:1098:2c::a9fe:a9fe', ['2a00:1098:2c::/96'])).toBe(true)) // 169.254.169.254
+  it('a configured NSP NAT64 embedding a PUBLIC v4 decodes and is allowed', () =>
+    expect(isBlockedIp('2a00:1098:2c::808:808', ['2a00:1098:2c::/96'])).toBe(false)) // 8.8.8.8
+  it('RESIDUAL: an UNCONFIGURED NSP NAT64 is not decoded (documented; L3 allowlist is the backstop)', () =>
+    expect(isBlockedIp('2a00:1098:2c::a00:1')).toBe(false))
+})
+
+describe('validateEgressUrl — NAT64 NSP via policy (L2 over L3)', () => {
+  it('a configured NSP NAT64 pointing at an internal v4 is denied even if the /64 is allowlisted', () =>
+    expect(validateEgressUrl('https://[2a00:1098:2c::a00:1]/',
+      policy({ nat64Prefixes: ['2a00:1098:2c::/96'], allowedCidrs: ['2a00:1098:2c::/64'] })).allowed).toBe(false))
+})

--- a/packages/core-backend/src/guards/egress-guard.ts
+++ b/packages/core-backend/src/guards/egress-guard.ts
@@ -1,0 +1,219 @@
+/**
+ * Egress guard — BPMN HTTP service-task SSRF boundary (R1, slice 1).
+ *
+ * Design-lock: docs/development/workflow-bpmn-http-task-ssrf-boundary-design-lock-20260630.md.
+ *
+ * SCOPE (slice 1): the standalone, synchronous validator + policy config + the reusable IP
+ * classifier. It performs **no DNS resolution and opens no sockets**, and it is **not wired to**
+ * `BPMNWorkflowEngine.executeHttpTask`. The atomic resolve-and-pin dispatcher (slice 2) and the
+ * engine wiring / header-method hardening (slice 3, L8) are separate, later, opt-in slices.
+ *
+ * Why synchronous: DNS resolution must be *atomic* with the pinned connection to defeat DNS
+ * rebinding (TOCTOU). Resolving here and re-resolving in the dispatcher would reopen that hole,
+ * so full hostname L2 lives entirely in slice 2 — which calls `isBlockedIp` (below) on each
+ * resolved address and then pins it. Slice 1 classifies only IP-literal hosts.
+ *
+ * NAT64 note (residual): the classifier decodes the embedded IPv4 for the well-known NAT64 prefix
+ * `64:ff9b::/96` and any operator-configured `nat64Prefixes`. A deployment that runs a NAT64
+ * gateway on its egress path using a Network-Specific Prefix MUST list that prefix in
+ * `EgressPolicy.nat64Prefixes`, otherwise an IP-literal in that prefix is treated as ordinary
+ * global-unicast (it is still gated by the L3 allowlist — an attacker's NAT64 literal must be
+ * explicitly allowlisted to pass). NAT64 with a non-`/96` RFC 6052 prefix length is not decoded.
+ */
+import ipaddr from 'ipaddr.js'
+
+/** NAT64 prefixes whose embedded IPv4 is always decoded (RFC 6052 well-known). */
+const WELL_KNOWN_NAT64_PREFIXES = ['64:ff9b::/96'] as const
+
+/** Egress policy. Fail-closed: an empty allowlist denies every destination. */
+export interface EgressPolicy {
+  /** Allowed URL schemes without the trailing ':'. Fail-closed default: `['https']` (D1). */
+  allowedSchemes: string[]
+  /** Exact hostnames permitted — DNS names or IP literals (D2). */
+  allowedHosts: string[]
+  /** CIDR ranges permitted for IP-literal hosts, e.g. a known public integration range (D2). */
+  allowedCidrs: string[]
+  /**
+   * Extra `/96` NAT64 prefixes this deployment translates (in addition to the well-known
+   * `64:ff9b::/96`). Required when a NAT64 gateway using a Network-Specific Prefix sits on the
+   * egress path, so an embedded internal IPv4 cannot be smuggled past the classifier.
+   */
+  nat64Prefixes?: string[]
+}
+
+export interface EgressDecision {
+  allowed: boolean
+  /** Populated only when `allowed === false`. */
+  blockedReason?: string
+}
+
+/**
+ * The fail-closed default policy (L7): `https`-only, and an **empty allowlist that denies every
+ * destination** until an operator explicitly configures one.
+ */
+export function defaultEgressPolicy(): EgressPolicy {
+  return { allowedSchemes: ['https'], allowedHosts: [], allowedCidrs: [] }
+}
+
+const block = (blockedReason: string): EgressDecision => ({ allowed: false, blockedReason })
+const ALLOW: EgressDecision = { allowed: true }
+
+/** A plain IPv4 is a candidate target only when it is globally-routable unicast. */
+function isGlobalUnicastV4(addr: ipaddr.IPv4): boolean {
+  // ipaddr.js IPv4 range() ∈ {unicast, unspecified, broadcast, multicast, linkLocal, loopback,
+  // carrierGradeNat, private, reserved}. Only 'unicast' is a public destination.
+  return addr.range() === 'unicast'
+}
+
+function embeddedIpv4At96(v6: ipaddr.IPv6): ipaddr.IPv4 {
+  const p = v6.parts // eight 16-bit groups; low 32 bits are the embedded v4 for a /96 prefix
+  return ipaddr.fromByteArray([p[6] >> 8, p[6] & 0xff, p[7] >> 8, p[7] & 0xff]) as ipaddr.IPv4
+}
+
+/** If `v6` sits in a configured `/96` NAT64 prefix, return its embedded IPv4; else null. */
+function nat64EmbeddedIpv4(v6: ipaddr.IPv6, nat64Prefixes: readonly string[]): ipaddr.IPv4 | null {
+  for (const cidr of nat64Prefixes) {
+    let range: ipaddr.IPv4 | ipaddr.IPv6
+    let bits: number
+    try {
+      ;[range, bits] = ipaddr.parseCIDR(cidr)
+    } catch {
+      continue
+    }
+    if (range.kind() !== 'ipv6' || bits !== 96) continue // slice 1 handles /96 NAT64
+    if (v6.match(range, 96)) return embeddedIpv4At96(v6)
+  }
+  return null
+}
+
+function isTeredo(v6: ipaddr.IPv6): boolean {
+  return v6.parts[0] === 0x2001 && v6.parts[1] === 0x0000
+}
+
+/**
+ * `true` when the IP literal must never be an outbound target (L2). Blocks loopback, link-local
+ * (incl. cloud metadata `169.254.169.254`), private, CGNAT, IPv6 ULA, multicast, reserved,
+ * unspecified/broadcast — and **decomposes embedded-IPv4 tunnel forms** (IPv4-mapped, 6to4, and
+ * NAT64 in the well-known or any configured `/96` prefix) so those wrappers cannot smuggle a
+ * blocked v4. Teredo is blocked outright. Unparseable → fail-closed. See the NAT64 residual note
+ * in the file header for the non-configured-NSP / non-`/96` limits.
+ */
+export function isBlockedIp(
+  ip: string,
+  nat64Prefixes: readonly string[] = WELL_KNOWN_NAT64_PREFIXES,
+): boolean {
+  let addr: ipaddr.IPv4 | ipaddr.IPv6
+  try {
+    addr = ipaddr.parse(ip)
+  } catch {
+    return true // unparseable → fail closed
+  }
+
+  if (addr.kind() === 'ipv4') {
+    return !isGlobalUnicastV4(addr as ipaddr.IPv4)
+  }
+
+  const v6 = addr as ipaddr.IPv6
+
+  // IPv4-mapped (::ffff:a.b.c.d) → classify the embedded v4.
+  if (v6.isIPv4MappedAddress()) {
+    return !isGlobalUnicastV4(v6.toIPv4Address())
+  }
+
+  // NAT64 (well-known + configured /96 prefixes) → classify the embedded v4.
+  const nat64Inner = nat64EmbeddedIpv4(v6, nat64Prefixes)
+  if (nat64Inner) {
+    return !isGlobalUnicastV4(nat64Inner)
+  }
+
+  // 6to4 (2002::/16) → the v4 gateway is bits 16..47.
+  if (v6.parts[0] === 0x2002) {
+    const p = v6.parts
+    const inner = ipaddr.fromByteArray([p[1] >> 8, p[1] & 0xff, p[2] >> 8, p[2] & 0xff]) as ipaddr.IPv4
+    return !isGlobalUnicastV4(inner)
+  }
+
+  // Teredo (2001:0::/32) — deprecated tunnel, never a legitimate target.
+  if (isTeredo(v6)) {
+    return true
+  }
+
+  // Plain IPv6: only global unicast is a candidate target.
+  return v6.range() !== 'unicast'
+}
+
+/** Strip the brackets WHATWG `URL` keeps on IPv6 hostnames (`[::1]` → `::1`). */
+function unbracket(host: string): string {
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+}
+
+function ipMatchesCidrs(ip: ipaddr.IPv4 | ipaddr.IPv6, cidrs: string[]): boolean {
+  for (const cidr of cidrs) {
+    let range: ipaddr.IPv4 | ipaddr.IPv6
+    let bits: number
+    try {
+      ;[range, bits] = ipaddr.parseCIDR(cidr)
+    } catch {
+      continue // a malformed allowlist entry never *widens* access
+    }
+    if (range.kind() !== ip.kind()) continue
+    if (ip.match(range, bits)) return true
+  }
+  return false
+}
+
+function hostInAllowedHosts(host: string, allowedHosts: string[]): boolean {
+  const h = host.toLowerCase()
+  return allowedHosts.some((a) => a.toLowerCase() === h)
+}
+
+/**
+ * Synchronous SSRF egress validation for a single URL (L1 scheme+creds, L3 allowlist, and L2 for
+ * IP-literal hosts). **Does not resolve DNS.** A DNS hostname is allowlist-checked only; its
+ * resolved addresses are classified with `isBlockedIp` and pinned by the slice-2 dispatcher.
+ * Every failure path — including a malformed URL or an empty allowlist — denies (fail-closed).
+ */
+export function validateEgressUrl(rawUrl: string, policy: EgressPolicy): EgressDecision {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return block('malformed URL')
+  }
+
+  // L1 — scheme allowlist (URL canonicalization already lower-cased the scheme).
+  const scheme = url.protocol.replace(/:$/, '')
+  if (!policy.allowedSchemes.some((s) => s.toLowerCase() === scheme)) {
+    return block(`scheme not allowed: ${scheme}`)
+  }
+
+  // L1 — reject credentials in the URL (userinfo).
+  if (url.username !== '' || url.password !== '') {
+    return block('credentials in URL are not allowed')
+  }
+
+  const host = unbracket(url.hostname)
+  if (host === '') {
+    return block('empty host')
+  }
+
+  const nat64Prefixes = [...WELL_KNOWN_NAT64_PREFIXES, ...(policy.nat64Prefixes ?? [])]
+
+  if (ipaddr.isValid(host)) {
+    // IP-literal host — classify (L2) then require allowlist membership (L3).
+    if (isBlockedIp(host, nat64Prefixes)) {
+      return block('destination IP is in a blocked range')
+    }
+    const ip = ipaddr.parse(host)
+    if (hostInAllowedHosts(host, policy.allowedHosts) || ipMatchesCidrs(ip, policy.allowedCidrs)) {
+      return ALLOW
+    }
+    return block('destination IP is not in the egress allowlist')
+  }
+
+  // DNS hostname — slice 1 does not resolve; exact-host allowlist only (CIDR is IP-only).
+  if (hostInAllowedHosts(host, policy.allowedHosts)) {
+    return ALLOW
+  }
+  return block('destination host is not in the egress allowlist')
+}

--- a/packages/core-backend/src/guards/index.ts
+++ b/packages/core-backend/src/guards/index.ts
@@ -8,3 +8,4 @@ export * from './safety-metrics';
 export * from './middleware';
 export * from './audit-integration';
 export * from './idempotency';
+export * from './egress-guard';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       ioredis:
         specifier: ^5.3.0
         version: 5.8.2
+      ipaddr.js:
+        specifier: ^2.4.0
+        version: 2.4.0
       joi:
         specifier: ^18.0.2
         version: 18.0.2
@@ -2941,6 +2944,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -7435,6 +7442,8 @@ snapshots:
       sprintf-js: 1.1.2
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.4.0: {}
 
   is-array-buffer@3.0.5:
     dependencies:


### PR DESCRIPTION
## R1 slice 1 — the egress-guard module (per your `拍 D0–D5` + slice-1 go)

Implements the first slice of the design-locked BPMN HTTP-task SSRF boundary (**#3428**): a **standalone** validator + reusable IP classifier + fail-closed policy config. It **resolves no DNS, opens no sockets, and is NOT wired to `executeHttpTask`** — exactly the scope you specified.

### Exports
- **`isBlockedIp(ip, nat64Prefixes?)`** — the L2 core (reused by slice 2 on resolved IPs). Blocks loopback / link-local (incl. cloud metadata `169.254.169.254`) / private / CGNAT / IPv6 ULA / multicast / reserved / unspecified, and **decomposes embedded-IPv4 tunnel forms** (IPv4-mapped, 6to4, NAT64) so a v6 wrapper can't smuggle a blocked v4. Unparseable → fail-closed.
- **`validateEgressUrl(url, policy)`** — synchronous L1 (scheme + creds) + L3 (allowlist) + L2 for IP-literal hosts. Canonicalizes via WHATWG `URL` so decimal/octal/hex/short IPv4 forms normalize before classification; **L2 overrides L3** (an allowlisted internal IP is still blocked).
- **`defaultEgressPolicy()`** — `https`-only + empty allowlist ⇒ **deny all** (fail-closed).

### New runtime dependency (security path)
Adds **`ipaddr.js@^2.4.0`** for vetted IP/CIDR parsing — chosen over hand-rolling IPv6/mapped/CIDR classification (`package.json` + lockfile; lockfile delta is only this package).

### Adversarial verification (and a real fix)
Two independent adversarial probes wrote + ran scratch tests against the actual functions:
- URL-parsing probe → **no bypass** (the guard reads the same WHATWG `url.hostname` a downstream fetch would).
- IP-representation probe → surfaced **one real gap**: NAT64 on a **Network-Specific Prefix** (only the well-known `64:ff9b::/96` was decoded). **Fixed** by making `EgressPolicy.nat64Prefixes` configurable (well-known always decoded; operators running NAT64 declare their prefix), with the residual documented (unconfigured NSP / non-`/96` lengths; L3 allowlist is the backstop). New tests pin it.

### D0–D5 ratification (companion doc)
D1/D2 encoded as `EgressPolicy` config; **D3 (rollout)/D4 (header-method)/D5 (dispatcher) explicitly bind at their wiring slices and remain owner-amendable** — slice 1 does not settle them.

### Verification
`vitest` — **59 pass**; `tsc --noEmit` — **clean**.

Slices 2–4 (IP-pinned dispatcher, `executeHttpTask` wiring + L8, rollout) are **not started** and each takes its own opt-in. 🤖 Review PR — metasheet2, not for self-merge.