### PR TITLE
test(attendance): make NS-3 zonedUtcIso helper server-timezone-independent (host-tz robustness; NOT the CI red)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -6264,9 +6264,21 @@ attendanceIntegrationDescribe(
     let overtimeRuleId: string | undefined
     // UTC ISO for a local wall-clock in tz (DST-safe here because the dates avoid transitions).
     const zonedUtcIso = (dateStr: string, timeStr: string, tz: string): string => {
-      const guess = new Date(`${dateStr}T${timeStr}:00.000Z`)
-      const local = new Date(guess.toLocaleString('en-US', { timeZone: tz }))
-      return new Date(guess.getTime() + (guess.getTime() - local.getTime())).toISOString()
+      // The UTC instant whose wall-clock time in `tz` equals dateStr+timeStr. Uses Intl.formatToParts with an
+      // explicit timeZone so the result is INDEPENDENT of the server's default timezone. (The previous
+      // toLocaleString → `new Date(str)` round-trip parsed the tz wall-clock string back in the SERVER's tz, so a
+      // non-UTC runner — e.g. TZ unset → America/Los_Angeles — mis-shifted the instant and collapsed the intended
+      // 23:00→01:00 cross-midnight window into a same-day 16:00→18:00 window, dropping crossesMidnight, making NS-3
+      // fail on non-UTC hosts (e.g. local dev on a non-UTC machine). This is a host-tz determinism fix — NOT the
+      // intermittent CI attendance red, which is a different test ("multi-shift slot conflicts …").)
+      const naive = new Date(`${dateStr}T${timeStr}:00.000Z`).getTime()
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+      }).formatToParts(new Date(naive))
+      const p = (t: string) => Number(parts.find((x) => x.type === t)!.value)
+      const shownAsUtc = Date.UTC(p('year'), p('month') - 1, p('day'), p('hour') % 24, p('minute'), p('second'))
+      return new Date(naive - (shownAsUtc - naive)).toISOString()
     }
     try {
       process.env.RBAC_BYPASS = 'true'


### PR DESCRIPTION
Test-only. A host-timezone determinism fix for one attendance integration test.

## What

`attendance-plugin.test.ts`'s NS-3 (overtime cross-midnight) test builds its window with a `zonedUtcIso` helper whose `toLocaleString → new Date(str)` round-trip parsed the tz wall-clock string back in the **server's default timezone**. On a non-UTC host (e.g. `TZ` unset → `America/Los_Angeles`) it mis-shifted the instant, collapsing the intended **23:00→01:00 cross-midnight** window into a same-day **16:00→18:00** window — so `crossesMidnight` dropped and NS-3 failed. Recompute the UTC instant via `Intl.formatToParts` with an explicit `timeZone` (server-tz-independent).

## Verification

- NS-3 passes under `TZ=America/Los_Angeles`, `America/New_York`, and `UTC`.
- Full attendance integration suite **221/221** on a fresh DB (TZ unset).
- `tsc --noEmit` clean. Diff is one helper in one test file.

## Explicitly NOT the CI attendance red

This does **not** fix the current intermittent CI attendance failure. That red is a **different** test — `enforces multi-shift slot conflicts on manual assignment create and update` (1 fail / 238 pass on CI) — which passes on CI's UTC and did **not** reproduce in 6 local fresh-DB UTC runs. NS-3 passes on CI's UTC; it only failed on non-UTC hosts (local dev). That intermittent flake is being routed/diagnosed separately.

This PR's value is host-tz robustness: NS-3 would otherwise fail on any non-UTC CI runner or developer machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)