### PR TITLE
fix(workflow): block embedded IPv4 egress literals

### DIFF
--- a/docs/development/workflow-bpmn-egress-guard-slice1-dev-verification-20260701.md
+++ b/docs/development/workflow-bpmn-egress-guard-slice1-dev-verification-20260701.md
@@ -22,6 +22,9 @@ workflow behavior.
 - The existing `send_webhook` SSRF guard was reviewed and left untouched. It is a product-specific
   resolve-and-pin path; this slice adds the BPMN policy primitive under `src/guards` and keeps
   dispatcher reuse/wiring for later slices.
+- Callers must use the returned `decision.normalizedUrl` when a URL is allowed. It is the WHATWG
+  canonicalized URL that this guard evaluated; a later caller that fetches the raw input string could
+  reintroduce parser-split ambiguity outside this module.
 
 ## Explicitly not shipped
 
@@ -42,4 +45,5 @@ Those are the next R1 slices.
   - wildcard/CIDR non-support;
   - local/internal hostname rejection;
   - unsafe IPv4/IPv6 classes, IPv4-mapped IPv6, NAT64, 6to4, and Teredo;
+  - deprecated IPv4-compatible IPv6 and ISATAP-wrapped IPv4;
   - URL canonicalization of decimal/hex/short IPv4 forms before IP blocking.

--- a/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
@@ -33,8 +33,12 @@ describe('R1-A egress guard — IP deny-list', () => {
     '2001:db8::1',
     '::ffff:127.0.0.1',
     '::ffff:10.1.2.3',
+    '::7f00:1',
+    '::a00:1',
     '64:ff9b::7f00:1',
     '2002:7f00:1::',
+    '2000::5efe:169.254.169.254',
+    '2000::200:5efe:a9fe:a9fe',
     '2001:0:4136:e378:8000:63bf:3fff:fdd2',
   ])('blocks unsafe IP literal %s', (ip) => {
     expect(isBlockedEgressIp(ip)).toBe(true)
@@ -111,7 +115,10 @@ describe('R1-A egress guard — URL policy', () => {
       'https://0x7f000001/',
       'https://127.1/',
       'https://[::ffff:127.0.0.1]/',
+      'https://[::7f00:1]/',
       'https://[64:ff9b::7f00:1]/',
+      'https://[2000::5efe:169.254.169.254]/',
+      'https://[2000::200:5efe:a9fe:a9fe]/',
     ]) {
       expect(validateEgressUrl(url, defaultEgressPolicy())).toEqual({
         allowed: false,

--- a/packages/core-backend/src/guards/egress-guard.ts
+++ b/packages/core-backend/src/guards/egress-guard.ts
@@ -85,6 +85,14 @@ function ipv4FromBytes(bytes: readonly number[]): ipaddr.IPv4 {
   return ipaddr.parse(bytes.join('.')) as ipaddr.IPv4
 }
 
+function lastFourBytesAsBlockedIpv4(bytes: readonly number[]): boolean {
+  return isBlockedIpv4(ipv4FromBytes(bytes.slice(12, 16)))
+}
+
+function isIsatapAddress(bytes: readonly number[]): boolean {
+  return (bytes[8] & 0xfd) === 0x00 && bytes[9] === 0x00 && bytes[10] === 0x5e && bytes[11] === 0xfe
+}
+
 function isBlockedIpv4(address: ipaddr.IPv4): boolean {
   return address.range() !== 'unicast'
 }
@@ -95,6 +103,12 @@ function isBlockedIpv6(address: ipaddr.IPv6, nat64Prefixes: readonly string[]): 
   }
 
   const bytes = address.toByteArray()
+  if (address.match(ipaddr.parseCIDR('::/96'))) {
+    return lastFourBytesAsBlockedIpv4(bytes)
+  }
+  if (isIsatapAddress(bytes)) {
+    return lastFourBytesAsBlockedIpv4(bytes)
+  }
   // NAT64 (well-known + any operator-configured /96 prefix) -> classify the embedded v4.
   for (const prefix of nat64Prefixes) {
     let cidr: [ipaddr.IPv4 | ipaddr.IPv6, number]
@@ -105,7 +119,7 @@ function isBlockedIpv6(address: ipaddr.IPv6, nat64Prefixes: readonly string[]): 
     }
     if (cidr[0].kind() !== 'ipv6' || cidr[1] !== 96) continue
     if (address.match(cidr)) {
-      return isBlockedIpv4(ipv4FromBytes(bytes.slice(12, 16)))
+      return lastFourBytesAsBlockedIpv4(bytes)
     }
   }
   if (address.match(ipaddr.parseCIDR('2002::/16'))) {


### PR DESCRIPTION
## Summary

Follow-up to #3432 / R1-A review P3 before R1-B consumes `isBlockedEgressIp` for resolved DNS answers.

This PR:
- decodes deprecated IPv4-compatible IPv6 (`::a.b.c.d` / `::7f00:1`) through the existing IPv4 deny classifier
- decodes ISATAP-style embedded IPv4 (`...:0000:5efe:a.b.c.d` and `...:0200:5efe:a.b.c.d`) through the same IPv4 deny classifier
- adds URL-level tests for both forms, not only helper-level tests
- preserves the mainline configurable NAT64 `/96` prefix handling while routing it through the same embedded-IPv4 classifier
- records the R1-B caller contract: fetch/use `decision.normalizedUrl`, not the raw input string

No BPMN engine wiring, no dispatcher, no fetch behavior change.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run src/guards/__tests__/egress-guard.test.ts --reporter=dot` — 49/49
- `pnpm --filter @metasheet/core-backend exec vitest run src/guards --reporter=dot` — 65/65
- `pnpm --filter @metasheet/core-backend run build` — pass
- `pnpm --filter @metasheet/core-backend exec eslint src/guards/egress-guard.ts src/guards/__tests__/egress-guard.test.ts` — 0 errors; test file ignored by existing ESLint ignore pattern
