### PR TITLE
fix(workflow): close NAT64 NSP SSRF gap in the R1-A egress guard (guard-only)

### DIFF
--- a/docs/development/workflow-bpmn-egress-guard-nat64-nsp-hardening-20260701.md
+++ b/docs/development/workflow-bpmn-egress-guard-nat64-nsp-hardening-20260701.md
@@ -1,0 +1,42 @@
+# R1-A egress guard — NAT64 Network-Specific-Prefix hardening (2026-07-01)
+
+Follow-up to the R1-A egress guard (`3915c1ca4`), from the ratified BPMN SSRF design-lock
+(`#3428`). Guard-only; **no BPMN engine wiring**.
+
+## Finding
+
+An independent adversarial probe of the egress IP classifier surfaced one real bypass class the
+R1-A guard missed: **NAT64 on a Network-Specific Prefix (NSP)**. `isBlockedIpv6` decoded the
+embedded IPv4 only for the well-known NAT64 prefix `64:ff9b::/96`. A deployment whose NAT64
+gateway uses any other (globally-routable) `/96` prefix — e.g. the real public service
+`2a00:1098:2c::/96` — wraps an **internal** v4 (RFC-1918 / CGNAT / metadata) in the low 32 bits;
+the outer address classifies as `unicast`, so `isBlockedEgressIp` returned `false` and the
+internal target could be reached through the translator.
+
+## Fix
+
+`EgressPolicy.nat64Prefixes?: readonly string[]` — extra `/96` NAT64 prefixes this deployment
+translates. The well-known `64:ff9b::/96` is always decoded; `validateEgressUrl` passes
+`[well-known, ...policy.nat64Prefixes]` to the classifier, which decodes the embedded v4 for any
+matching `/96` prefix and classifies it (an internal inner v4 → blocked; a public inner v4 →
+decoded and allowed). Existing callers are unchanged (`isBlockedEgressIp(host)` defaults to the
+well-known prefix), so the R1-A behaviour and tests are preserved.
+
+## Residual (documented, not a silent gap)
+
+- A NAT64 gateway on an NSP **must be declared** in `nat64Prefixes`; an unconfigured NSP literal
+  is treated as ordinary global-unicast. It remains gated by the L3 **allowlist** (an attacker's
+  NAT64 literal must be explicitly allowlisted to pass `validateEgressUrl`), which is the backstop.
+- NAT64 with a non-`/96` RFC 6052 prefix length is not decoded.
+- Full hostname L2 (resolve every A/AAAA, classify, and pin atomically to defeat DNS rebinding)
+  remains the slice-2 dispatcher's job; this guard classifies IP-literal hosts only.
+
+## Verification
+
+- `pnpm --filter @metasheet/core-backend exec vitest run src/guards/__tests__/egress-guard.test.ts`
+  — **45 tests pass** (R1-A suite + new NSP cases: well-known default, configured NSP →
+  internal/metadata blocked, configured NSP → public decoded, unconfigured residual, and the
+  end-to-end `IP_BLOCKED`).
+- `pnpm --filter @metasheet/core-backend run type-check` (`tsc --noEmit`) — clean.
+
+No new dependency; no runtime is wired to `executeHttpTask`.

--- a/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
@@ -145,3 +145,28 @@ describe('R1-A egress guard — URL policy', () => {
     })
   })
 })
+
+describe('R1-A egress guard — NAT64 Network-Specific Prefix (configurable)', () => {
+  test('well-known 64:ff9b::/96 embedding an internal v4 is blocked by default', () => {
+    expect(isBlockedEgressIp('64:ff9b::a00:1')).toBe(true) // 10.0.0.1
+  })
+  test('a configured NSP NAT64 embedding an internal v4 is blocked', () => {
+    expect(isBlockedEgressIp('2a00:1098:2c::a00:1', ['2a00:1098:2c::/96'])).toBe(true) // 10.0.0.1
+  })
+  test('a configured NSP NAT64 embedding cloud metadata is blocked', () => {
+    expect(isBlockedEgressIp('2a00:1098:2c::a9fe:a9fe', ['2a00:1098:2c::/96'])).toBe(true) // 169.254.169.254
+  })
+  test('a configured NSP NAT64 embedding a public v4 decodes and is not blocked', () => {
+    expect(isBlockedEgressIp('2a00:1098:2c::808:808', ['2a00:1098:2c::/96'])).toBe(false) // 8.8.8.8
+  })
+  test('RESIDUAL: an unconfigured NSP NAT64 is not decoded (L3 allowlist is the backstop)', () => {
+    expect(isBlockedEgressIp('2a00:1098:2c::a00:1')).toBe(false)
+  })
+  test('end-to-end: a configured NSP NAT64 pointing at an internal v4 is IP_BLOCKED', () => {
+    const p: EgressPolicy = { allowedHosts: [], nat64Prefixes: ['2a00:1098:2c::/96'] }
+    expect(validateEgressUrl('https://[2a00:1098:2c::a00:1]/', p)).toEqual({
+      allowed: false,
+      reason: 'IP_BLOCKED',
+    })
+  })
+})

--- a/packages/core-backend/src/guards/egress-guard.ts
+++ b/packages/core-backend/src/guards/egress-guard.ts
@@ -6,7 +6,17 @@ export interface EgressPolicy {
    * hosts only: no wildcard, suffix, CIDR, or scheme-bearing entries.
    */
   allowedHosts?: readonly string[]
+  /**
+   * Extra `/96` NAT64 prefixes this deployment translates, in addition to the
+   * well-known `64:ff9b::/96`. Required when a NAT64 gateway on a Network-Specific
+   * Prefix sits on the egress path, so an embedded internal IPv4 cannot be smuggled
+   * past the classifier. Non-`/96` prefixes are ignored.
+   */
+  nat64Prefixes?: readonly string[]
 }
+
+/** NAT64 prefixes whose embedded IPv4 is always decoded (RFC 6052 well-known). */
+const WELL_KNOWN_NAT64_PREFIXES = ['64:ff9b::/96'] as const
 
 export type EgressUrlDenyReason =
   | 'URL_REQUIRED'
@@ -79,14 +89,24 @@ function isBlockedIpv4(address: ipaddr.IPv4): boolean {
   return address.range() !== 'unicast'
 }
 
-function isBlockedIpv6(address: ipaddr.IPv6): boolean {
+function isBlockedIpv6(address: ipaddr.IPv6, nat64Prefixes: readonly string[]): boolean {
   if (address.isIPv4MappedAddress()) {
     return isBlockedIpv4(address.toIPv4Address())
   }
 
   const bytes = address.toByteArray()
-  if (address.match(ipaddr.parseCIDR('64:ff9b::/96'))) {
-    return isBlockedIpv4(ipv4FromBytes(bytes.slice(12, 16)))
+  // NAT64 (well-known + any operator-configured /96 prefix) -> classify the embedded v4.
+  for (const prefix of nat64Prefixes) {
+    let cidr: [ipaddr.IPv4 | ipaddr.IPv6, number]
+    try {
+      cidr = ipaddr.parseCIDR(prefix)
+    } catch {
+      continue
+    }
+    if (cidr[0].kind() !== 'ipv6' || cidr[1] !== 96) continue
+    if (address.match(cidr)) {
+      return isBlockedIpv4(ipv4FromBytes(bytes.slice(12, 16)))
+    }
   }
   if (address.match(ipaddr.parseCIDR('2002::/16'))) {
     return isBlockedIpv4(ipv4FromBytes(bytes.slice(2, 6)))
@@ -95,13 +115,16 @@ function isBlockedIpv6(address: ipaddr.IPv6): boolean {
   return address.range() !== 'unicast'
 }
 
-export function isBlockedEgressIp(hostname: string): boolean {
+export function isBlockedEgressIp(
+  hostname: string,
+  nat64Prefixes: readonly string[] = WELL_KNOWN_NAT64_PREFIXES,
+): boolean {
   const address = parseIp(hostname)
   if (!address) return false
   if (address.kind() === 'ipv4') {
     return isBlockedIpv4(address as ipaddr.IPv4)
   }
-  return isBlockedIpv6(address as ipaddr.IPv6)
+  return isBlockedIpv6(address as ipaddr.IPv6, nat64Prefixes)
 }
 
 export function validateEgressUrl(rawUrl: unknown, policy: EgressPolicy = defaultEgressPolicy()): EgressUrlDecision {
@@ -127,7 +150,8 @@ export function validateEgressUrl(rawUrl: unknown, policy: EgressPolicy = defaul
   if (!hostname) return { allowed: false, reason: 'HOST_REQUIRED' }
   if (isInternalHostname(hostname)) return { allowed: false, reason: 'HOST_INTERNAL_NAME' }
 
-  if (isBlockedEgressIp(hostname)) {
+  const nat64Prefixes = [...WELL_KNOWN_NAT64_PREFIXES, ...(policy.nat64Prefixes ?? [])]
+  if (isBlockedEgressIp(hostname, nat64Prefixes)) {
     return { allowed: false, reason: 'IP_BLOCKED' }
   }
 


### PR DESCRIPTION
## Follow-up to the R1-A egress guard (`3915c1ca4`) — one real SSRF gap

My parallel slice-1 PR (#3434) was closed as a duplicate of your landed R1-A guard. But it carried one gain the incumbent lacks, surfaced by an independent adversarial probe: a **NAT64 Network-Specific-Prefix bypass**. This ports just that fix onto your structure.

### The gap
`isBlockedIpv6` decoded the embedded IPv4 only for the well-known NAT64 prefix `64:ff9b::/96`. A deployment whose NAT64 gateway uses **any other `/96` prefix** (e.g. the real public `2a00:1098:2c::/96`) wraps an **internal** v4 in the low 32 bits; the outer address classifies as `unicast`, so `isBlockedEgressIp` returned `false` and the internal target was reachable through the translator.

### The fix (surgical, matches your API)
- `EgressPolicy.nat64Prefixes?: readonly string[]` — extra `/96` NAT64 prefixes this deployment translates.
- Well-known `64:ff9b::/96` is **always** decoded; `validateEgressUrl` passes `[well-known, ...policy.nat64Prefixes]`.
- **Existing callers unchanged** — `isBlockedEgressIp(host)` defaults to well-known, so your R1-A behaviour + all existing tests are preserved.

### Residual (documented)
Unconfigured NSP / non-`/96` lengths aren't decoded; the **L3 allowlist is the backstop** (a NAT64 literal must be explicitly allowlisted to pass). Full hostname L2 (resolve-all + pin, anti-rebinding) stays the slice-2 dispatcher's job.

### Verification
`vitest` **45 pass** (your suite + new NSP cases: configured → internal/metadata blocked, public decoded, unconfigured residual, end-to-end `IP_BLOCKED`); `tsc --noEmit` clean. **No new dependency, no engine wiring.**

🤖 Review PR — metasheet2, not for self-merge.