### PR TITLE
docs(multitable): DESIGN-LOCK (RATIFIED) — cross-base editable-mirror write-through (C2 runtime)

### DIFF
--- a/docs/development/multitable-crossbase-c2-editable-mirror-writethrough-designlock-20260701.md
+++ b/docs/development/multitable-crossbase-c2-editable-mirror-writethrough-designlock-20260701.md
@@ -1,10 +1,11 @@
-# Cross-base Slice 1 — C2: editable-mirror write-through — DESIGN-LOCK (proposed) — 2026-07-01
+# Cross-base Slice 1 — C2: editable-mirror write-through — DESIGN-LOCK (RATIFIED) — 2026-07-01
 
 > The runtime that opens **one** gated cross-base mirror-edit path onto the floor guarded by C1
 > (`resolveCrossBaseWriteAuthority`) + C2/I-1 (mirror read-only on every `meta_links`-writing path). Builds on the
 > RATIFIED Slice-1 lock (`multitable-crossbase-twoway-editable-mirror-slice1-designlock-20260629.md`, §7 A–F, §10
-> I-1/I-2/I-3). Grounding: `origin/main` @ `032e063af` (C1 `e10c80dc5` + C2/I-1 `c452eb403` landed). **Proposed —
-> NOT ratified, NO code.** Owner-directed to lock three things sharply (§2). Default-off
+> I-1/I-2/I-3). Grounding: `origin/main` @ `032e063af` (C1 `e10c80dc5` + C2/I-1 `c452eb403` landed). **RATIFIED
+> 2026-07-01 (owner-signed; Locks A/B/C + the §6 golden matrix settled — base-B = record-level). NO code until the
+> separate contract-first runtime PR.** Owner-directed to lock three things sharply (§2). Default-off
 > `MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE`.
 
 ## 1. Scope — one path, nothing else
@@ -118,10 +119,11 @@ New `multitable-crossbase-mirror-writethrough-realdb.test.ts`:
 Each security golden fail-first-proven; the spine assertion runs after every case; wired into `plugin-tests.yml`.
 
 ## 7. Pre-runtime gates (before any code)
-1. **Owner ratification** of §2 Locks A/B/C (+ §3/§4).
+1. **Owner ratification** of §2 Locks A/B/C (+ §3/§4) — ✅ **DONE (RATIFIED 2026-07-01).** The base-B granularity
+   decision is **resolved = record-level** (§2 Lock B); no open ratification items remain.
 2. **Adversarial advisor pass** — ✅ run on this draft (2026-07-01); folded in: Lock A → route through the forward
    link-write service (dedup/validation/revision/mirror-invalidation inherited, no duplicate `(F_A,…)` row), Lock C →
-   the REMOVE-side linkage-oracle (mask before edge-existence branch). Open item = the base-B granularity ratification
-   question (Lock B ⚠). A final pass on the ratified design before runtime is still advisable.
+   the REMOVE-side linkage-oracle (mask before edge-existence branch). A final pass on the ratified design before
+   runtime is still advisable.
 3. Only then: runtime, contract-first — the dedicated op + the three locks, goldens fail-first, default-off; the
    Decision-F co-lock is the enablement gate, not part of the runtime PR.

--- a/docs/development/multitable-crossbase-c2-editable-mirror-writethrough-designlock-20260701.md
+++ b/docs/development/multitable-crossbase-c2-editable-mirror-writethrough-designlock-20260701.md
@@ -46,23 +46,21 @@ Both endpoints must pass; the two legs are **not** symmetric:
   = **claim==truth** (the op's declared base-A opt-in must equal `F_A`'s actual base) **+** `resolveBaseWritable(actor,
   baseA)` **+** the per-target-base **quota keyed to base A** (the same quota discipline as automation cross-base
   writes; composed by this caller, base-A-keyed, exactly as C1/§10-I-3 specifies — NOT inside the primitive).
-- **base-B leg (where the edit originates — `M_B`'s base):** a **plain `resolveBaseWritable(actor, baseB)`** — **no
-  claim, no quota** (the actor is acting on their own base's record `rec_B`, not a cross-base *target*; base-B is not
-  a canonical-edge owner and must not be double-charged or claim-gated).
-- The primitive is called for the **base-A leg only**; base-B is a bare write-authority check. Any single-leg failure
-  → deny. (Locks the §10/I-3 asymmetry so a future impl can't collapse it into a symmetric double-primitive call or
-  double quota.)
-- **⚠ Ratification question (owner) — base-B granularity.** You specified base-B = plain `resolveBaseWritable(actor,
-  baseB)`, which is **base-level**: it authorizes *any* record in base B, so a **row-level-deny or record-edit
-  restriction on the specific `rec_B`** would be bypassed — an asymmetry vs Lock C's *per-record* guard on `rec_A`.
-  This may be exactly what you want (base-B is the actor's own base; the mutation of record is `rec_A`, and `rec_B`
-  only re-projects). **Two options — your call:** **(B-level)** keep plain `resolveBaseWritable(baseB)` as ratified;
-  or **(rec-level)** additionally honor `rec_B`'s record-level permissions (row-deny / field). Not silently upgraded,
-  not silently shipped as a gap.
+- **base-B leg (where the edit originates — `M_B`'s base): RECORD-level (owner-ratified 2026-07-01).** **No claim, no
+  quota, NO C1 primitive** (base-B is not a cross-base *target* / canonical-edge owner — never claim-gated or
+  double-charged), **but** the op requires the actor's **local edit eligibility on the specific `rec_B`** —
+  record-edit / row-level-deny / the relevant mirror-op field policy on `rec_B`. Editing `rec_B.M_B` is semantically a
+  record edit of `rec_B` even though the physical mutation lands on `rec_A.F_A`, so a **row-denied / record-edit-denied
+  base-B actor must NOT be able to use the mirror op as a bypass**. (A plain base-*level* `resolveBaseWritable(baseB)`
+  was considered and **rejected** as too coarse — it would authorize *any* record in base B.)
+- The C1 primitive is called for the **base-A leg only**; base-B is a **local `rec_B` record-edit check** (no
+  primitive / no claim / no quota). Any single-leg failure → deny. (Locks the §10/I-3 asymmetry — a future impl can't
+  collapse it into a symmetric double-primitive / double-quota call, and can't drop base-B to a coarse base-level
+  check.)
 
 ### Lock C — I-2 per-record no-oracle mask on `rec_A`
-Authority (Lock B) is **base-level**; it does NOT cover per-record visibility. The op names a specific base-A record
-`rec_A`, so:
+Lock B's **base-A** authority is base-level (it authorizes writing base A, not *reading a specific record*); it does
+NOT cover per-record visibility of the named base-A record `rec_A`, so:
 - The op enforces the **same per-record foreign read+write mask the read path uses** — parity with
   `resolveForeignFieldReadability` / `shouldMaskForeignField` (univer-meta.ts:~1411) — on the named `rec_A`.
 - **No-oracle on ADD (hard):** adding `rec_A` that is **masked** (actor lacks read) / **missing** / **not writable**
@@ -81,9 +79,11 @@ Authority (Lock B) is **base-level**; it does NOT cover per-record visibility. T
 ## 3. Architecture (write-through, single-DB, atomic)
 Bases share one Postgres; `meta_links` is one global edge table. The op resolves `F_A` (the forward field paired to
 `M_B` via `mirrorOf`/`mirrorFieldId`) and its base A, then in **one `pool.transaction`**: Lock B (base-A primitive +
-base-B writable) → Lock C (rec_A read+write mask, uniform-deny) → `INSERT/DELETE` the canonical forward edge. The
-mirror side (`M_B` on `rec_B`) is **not** written — it re-projects on next read (Decision E: no live cross-base push;
-base-A's forward field fans out normally on its own sheet). All-or-nothing.
+base-B **local `rec_B` record-edit check**) → Lock C (`rec_A` read+write mask, uniform-deny) → **invoke the
+transaction-aware forward link-write helper for `rec_A.F_A`** (per Lock A — the helper supplies `ON CONFLICT`/dedup,
+link-target-exists, revision recording, and mirror-invalidation; the op **never** hand-rolls a `meta_links`
+INSERT/DELETE). The mirror side (`M_B` on `rec_B`) is **not** written — it re-projects on next read (Decision E: no
+live cross-base push; base-A's forward field fans out normally on its own sheet). All-or-nothing.
 
 ## 4. Consistency / TOCTOU (Decision F launch gate)
 Resolve-then-write is one txn; the txn takes `FOR UPDATE` on the gating row(s) so base/permission can't drift between
@@ -103,9 +103,12 @@ New `multitable-crossbase-mirror-writethrough-realdb.test.ts`:
   edge deleted. **Fail-first:** a variant that wrote an `M_B` row **or a duplicate `(F_A,…)` row** is RED.
 - **W-A floor regression:** a mirror write through the general PATCH / bulk `/patch` is **still rejected** (C2/I-1
   intact — the op didn't loosen the floor).
-- **W-B authority:** base-A-writable but not base-B-writable → deny; base-B-writable but not base-A-writable → deny;
-  wrong/absent base-A claim → deny; quota N+1 on base A → deny; **and** a base-B leg golden asserting base-B is a
-  plain writable check (no claim/quota consumed on base B — quota counter untouched for base B).
+- **W-B authority (asymmetric, record-level base-B):** happy path (base-A primitive passes **and** actor can edit
+  `rec_B`) ⇒ the one forward edge. Denials, each with **no edge**: base-A NOT base-writable; wrong/absent base-A
+  claim; base-A quota N+1; **base-B `rec_B` record-edit-denied or row-denied** (the record-level upgrade — a base-B
+  actor who cannot edit `rec_B` cannot use the mirror op as a bypass). **base-B asymmetry assertions:** base-B is a
+  *local record-edit* check only — it consumes **no claim and no quota** (the base-A quota counter is unchanged after
+  a base-B-only denial, and there is **no base-B quota counter**), and the C1 primitive is invoked for base-A only.
 - **W-C no-oracle (ADD + REMOVE):** ADD — has-base-A-write-but-no-`rec_A`-read → uniform deny **byte-identical** to
   missing-`rec_A`, no edge. REMOVE — removing a **masked/unreadable-but-actually-linked** `rec_A` → **byte-identical**
   to remove-nonexistent-`rec_A`, no edge removed and no success/noop linkage signal. Fail-first: disable the

--- a/docs/development/multitable-crossbase-c2-editable-mirror-writethrough-designlock-20260701.md
+++ b/docs/development/multitable-crossbase-c2-editable-mirror-writethrough-designlock-20260701.md
@@ -1,0 +1,124 @@
+# Cross-base Slice 1 — C2: editable-mirror write-through — DESIGN-LOCK (proposed) — 2026-07-01
+
+> The runtime that opens **one** gated cross-base mirror-edit path onto the floor guarded by C1
+> (`resolveCrossBaseWriteAuthority`) + C2/I-1 (mirror read-only on every `meta_links`-writing path). Builds on the
+> RATIFIED Slice-1 lock (`multitable-crossbase-twoway-editable-mirror-slice1-designlock-20260629.md`, §7 A–F, §10
+> I-1/I-2/I-3). Grounding: `origin/main` @ `032e063af` (C1 `e10c80dc5` + C2/I-1 `c452eb403` landed). **Proposed —
+> NOT ratified, NO code.** Owner-directed to lock three things sharply (§2). Default-off
+> `MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE`.
+
+## 1. Scope — one path, nothing else
+Add **one** deliberately-gated operation that lets an actor on base **B** edit a cross-base **mirror** field `M_B`
+on record `rec_B` to add/remove a link to a base-**A** record `rec_A`, by writing the **single canonical forward
+edge** `(F_A, rec_A, rec_B)`. Everything else stays exactly as C1/C2-I-1 left it. **OUT** (each a separate later
+slice, unchanged by this): same-base editable mirror (Decision D — same-base mirror stays read-only), live realtime
+push (Decision E — base-B read-recomputes), cross-base triggers, cascade. No new capability beyond this one op.
+
+## 2. The three locks (sharp)
+
+### Lock A — the single write-through path does NOT bypass the spine invariant
+- The mirror stays **read-only on every existing path**: `isFieldAlwaysReadOnly` (permission-derivation.ts:66,
+  `mirrorOf ⇒ true`) is **unchanged**; the general record-write paths (PATCH / bulk `/patch` / create / form /
+  import / plugin-SDK / Yjs / snapshot rebuilds) continue to **reject** a mirror write (C2/I-1). This op does **not**
+  loosen that guard.
+- Editing the mirror is a **distinct, dedicated operation** (a new flag-gated route/op — NOT a branch inside the
+  general PATCH), so the read-only floor is never widened. It effects the change as an **authority-gated patch of
+  `rec_A.F_A`** (the forward field) — i.e. Lock B/C supply the *authorization*, and the **existing forward link-write
+  service** supplies the *mechanics*. It does **not** hand-roll a bare `INSERT/DELETE meta_links`. Routing through the
+  forward writer is load-bearing, not stylistic: a raw INSERT preserves the *no-`M_B`-row* spine but silently drops
+  the forward path's own invariants, two of them spine-relevant — **`ON CONFLICT`/dedup** (a base-B "add" of an edge
+  that already exists from base-A's side must be a **no-op, never a duplicate `(F_A, rec_A, rec_B)` row** — a
+  second-canonical-row break keyed by `F_A` instead of `M_B`) and **link-target-exists validation**; plus revision
+  recording and the same-base mirror-invalidation collection. Routing through the service inherits all of these for
+  free and is consistent with Decision E (base-A's forward field fans out normally; base-B re-projects on read). The
+  op writes **only** the one canonical forward edge — **never** a row keyed by the mirror field id `M_B`. *(If a
+  future impl ever bypasses the service, the doc/contract must enumerate every forward invariant it replicates — dedup
+  first.)*
+- **Enumeration re-proof (acceptance):** re-run the C2/I-1 write-path enumeration — after this op lands, the set of
+  paths able to write a `meta_links` edge for a mirror field id is still **exactly {∅}** (the mirror field id never
+  gets a row); the ONLY new writer is this op, and it writes the **forward** field id. A golden asserts
+  `count(meta_links WHERE field_id = M_B) === 0` after every op outcome (allow, deny, error).
+
+### Lock B — I-3 both-endpoints authority, implemented ASYMMETRICALLY
+Both endpoints must pass; the two legs are **not** symmetric:
+- **base-A leg (the canonical-edge owner — `F_A`'s base):** the write mutates base-A's relational space, so it goes
+  through the C1 primitive `resolveCrossBaseWriteAuthority({ actorId, targetBaseId: baseA, declaredBaseClaim, queryFn })`
+  = **claim==truth** (the op's declared base-A opt-in must equal `F_A`'s actual base) **+** `resolveBaseWritable(actor,
+  baseA)` **+** the per-target-base **quota keyed to base A** (the same quota discipline as automation cross-base
+  writes; composed by this caller, base-A-keyed, exactly as C1/§10-I-3 specifies — NOT inside the primitive).
+- **base-B leg (where the edit originates — `M_B`'s base):** a **plain `resolveBaseWritable(actor, baseB)`** — **no
+  claim, no quota** (the actor is acting on their own base's record `rec_B`, not a cross-base *target*; base-B is not
+  a canonical-edge owner and must not be double-charged or claim-gated).
+- The primitive is called for the **base-A leg only**; base-B is a bare write-authority check. Any single-leg failure
+  → deny. (Locks the §10/I-3 asymmetry so a future impl can't collapse it into a symmetric double-primitive call or
+  double quota.)
+- **⚠ Ratification question (owner) — base-B granularity.** You specified base-B = plain `resolveBaseWritable(actor,
+  baseB)`, which is **base-level**: it authorizes *any* record in base B, so a **row-level-deny or record-edit
+  restriction on the specific `rec_B`** would be bypassed — an asymmetry vs Lock C's *per-record* guard on `rec_A`.
+  This may be exactly what you want (base-B is the actor's own base; the mutation of record is `rec_A`, and `rec_B`
+  only re-projects). **Two options — your call:** **(B-level)** keep plain `resolveBaseWritable(baseB)` as ratified;
+  or **(rec-level)** additionally honor `rec_B`'s record-level permissions (row-deny / field). Not silently upgraded,
+  not silently shipped as a gap.
+
+### Lock C — I-2 per-record no-oracle mask on `rec_A`
+Authority (Lock B) is **base-level**; it does NOT cover per-record visibility. The op names a specific base-A record
+`rec_A`, so:
+- The op enforces the **same per-record foreign read+write mask the read path uses** — parity with
+  `resolveForeignFieldReadability` / `shouldMaskForeignField` (univer-meta.ts:~1411) — on the named `rec_A`.
+- **No-oracle on ADD (hard):** adding `rec_A` that is **masked** (actor lacks read) / **missing** / **not writable**
+  all return the **same uniform fail-closed** response (identical status + body); a base-B actor must NOT probe base-A
+  record existence or permission via a mirror add. Masked ≡ missing ≡ denied, indistinguishable.
+- **No-oracle on REMOVE (hard — the sharper leak):** the mask already empties masked foreign records from the mirror
+  projection, so removing one requires guessing its id — and a remove that returns **success-iff-the-edge-existed**
+  would confirm a masked record was linked (a *linkage* oracle, worse than existence). Therefore the per-record
+  mask/authority check on `rec_A` runs **BEFORE any edge-existence branch**, and **remove-a-masked-(or-unreadable)-`rec_A`
+  is byte-identical to remove-a-nonexistent-`rec_A`** — no success/noop signal distinguishes "was linked" from "never
+  existed" on either verb.
+- The §6 goldens prove the load-bearing cases specifically: **has base-A write (Lock B passes) but NO read on the
+  specific `rec_A`** → uniform deny on ADD (byte-identical to missing-`rec_A`) **and** on REMOVE (byte-identical to
+  remove-nonexistent), with no edge written/removed either way.
+
+## 3. Architecture (write-through, single-DB, atomic)
+Bases share one Postgres; `meta_links` is one global edge table. The op resolves `F_A` (the forward field paired to
+`M_B` via `mirrorOf`/`mirrorFieldId`) and its base A, then in **one `pool.transaction`**: Lock B (base-A primitive +
+base-B writable) → Lock C (rec_A read+write mask, uniform-deny) → `INSERT/DELETE` the canonical forward edge. The
+mirror side (`M_B` on `rec_B`) is **not** written — it re-projects on next read (Decision E: no live cross-base push;
+base-A's forward field fans out normally on its own sheet). All-or-nothing.
+
+## 4. Consistency / TOCTOU (Decision F launch gate)
+Resolve-then-write is one txn; the txn takes `FOR UPDATE` on the gating row(s) so base/permission can't drift between
+the Lock-B/C checks and the edge write (permission-revert lesson). **Decision F stands as the launch gate:** the flag
+is NOT enabled until the forward grant/revoke routes **and** the forward link-edit co-lock with this op (same sheet
+lock) **or** use a conditional/versioned write. Runtime can land default-off before that gate closes; enabling can't.
+
+## 5. Non-goals (unchanged)
+Same-base editable mirror (D); live realtime push (E, read-recompute only); cross-base triggers; cascade. `M_B`
+read-only by codec on all non-op paths.
+
+## 6. Test plan — real-DB goldens, fail-first (CI real-DB job)
+New `multitable-crossbase-mirror-writethrough-realdb.test.ts`:
+- **W-A spine + dedup:** happy add via the op ⇒ exactly one forward edge `(F_A, rec_A, rec_B)`; `count(meta_links
+  WHERE field_id = M_B) === 0`. A base-B **add of an edge that already exists from base-A's side ⇒ no-op, still
+  exactly one `(F_A, rec_A, rec_B)` row** (dedup via the forward service, not a duplicate canonical row). Remove ⇒
+  edge deleted. **Fail-first:** a variant that wrote an `M_B` row **or a duplicate `(F_A,…)` row** is RED.
+- **W-A floor regression:** a mirror write through the general PATCH / bulk `/patch` is **still rejected** (C2/I-1
+  intact — the op didn't loosen the floor).
+- **W-B authority:** base-A-writable but not base-B-writable → deny; base-B-writable but not base-A-writable → deny;
+  wrong/absent base-A claim → deny; quota N+1 on base A → deny; **and** a base-B leg golden asserting base-B is a
+  plain writable check (no claim/quota consumed on base B — quota counter untouched for base B).
+- **W-C no-oracle (ADD + REMOVE):** ADD — has-base-A-write-but-no-`rec_A`-read → uniform deny **byte-identical** to
+  missing-`rec_A`, no edge. REMOVE — removing a **masked/unreadable-but-actually-linked** `rec_A` → **byte-identical**
+  to remove-nonexistent-`rec_A`, no edge removed and no success/noop linkage signal. Fail-first: disable the
+  per-record mask, **or move it AFTER the edge-existence branch** → the two responses diverge (a linkage oracle) / a
+  row appears or is removed.
+- **W-flag:** flag unset → op refused (mirror read-only as today), no write.
+Each security golden fail-first-proven; the spine assertion runs after every case; wired into `plugin-tests.yml`.
+
+## 7. Pre-runtime gates (before any code)
+1. **Owner ratification** of §2 Locks A/B/C (+ §3/§4).
+2. **Adversarial advisor pass** — ✅ run on this draft (2026-07-01); folded in: Lock A → route through the forward
+   link-write service (dedup/validation/revision/mirror-invalidation inherited, no duplicate `(F_A,…)` row), Lock C →
+   the REMOVE-side linkage-oracle (mask before edge-existence branch). Open item = the base-B granularity ratification
+   question (Lock B ⚠). A final pass on the ratified design before runtime is still advisable.
+3. Only then: runtime, contract-first — the dedicated op + the three locks, goldens fail-first, default-off; the
+   Decision-F co-lock is the enablement gate, not part of the runtime PR.


### PR DESCRIPTION
**Design-lock only — RATIFIED, NO code.** The C2 runtime: one gated cross-base mirror-edit path onto the floor guarded by C1 (`resolveCrossBaseWriteAuthority`) + C2/I-1 (mirror read-only everywhere). Locks three surfaces:

- **Lock A — spine non-bypass:** a dedicated flag-gated op effects the change as an authority-gated patch of `rec_A.F_A` routed through the existing forward link-write service (not a hand-rolled INSERT) — so it inherits `ON CONFLICT` dedup, link-target-exists, revision, and mirror-invalidation. Never an `M_B` row; `isFieldAlwaysReadOnly` unchanged; enumeration re-proof.
- **Lock B — I-3 asymmetric both-endpoints:** base-A leg via the C1 primitive (claim==truth + `resolveBaseWritable` + base-A-keyed quota); base-B leg is **record-level local edit eligibility on `rec_B`** (no C1 primitive, no claim, no quota). Base-B coarse base-level was considered and rejected; row/record denied actors cannot use the mirror op as a bypass.
- **Lock C — I-2 no-oracle (ADD + REMOVE):** per-record `rec_A` mask checked before any edge-existence branch; masked/missing/denied byte-identical on both add and remove (closes the sharper remove-side linkage oracle).

Default-off `MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE`; Decision-F forward-route co-lock remains an enablement gate; realtime push deferred; same-base out. Advisor pass folded in. Docs-only.