### PR TITLE
fix(core-backend): always fold well-known NAT64 into isBlockedEgressIp (guard API hardening)

### DIFF
--- a/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-guard.test.ts
@@ -170,3 +170,35 @@ describe('R1-A egress guard — NAT64 Network-Specific Prefix (configurable)', (
     })
   })
 })
+
+describe('R1-A egress guard — isBlockedEgressIp always folds in well-known NAT64 (P3 API hardening)', () => {
+  // REGRESSION-CATCHER (red before the fix, green after). A direct caller passing ONLY a custom
+  // prefix must still decode the well-known 64:ff9b::/96. Pre-fix the custom prefix REPLACED the
+  // default, so 64:ff9b:: skipped the decode loop and fell through to ipaddr.js's rfc6052 range
+  // → range() !== 'unicast' → conservatively (and here wrongly) blocked. Post-fix well-known is
+  // always merged, so the inner PUBLIC v4 (8.8.8.8) is decoded and correctly allowed. This is the
+  // single assertion whose result differs between old and new code.
+  test('REGRESSION: well-known NAT64 embedding a PUBLIC v4 is decoded even when only a custom prefix is passed', () => {
+    expect(isBlockedEgressIp('64:ff9b::808:808', ['2a00:1098:2c::/96'])).toBe(false) // 8.8.8.8
+  })
+
+  // GUARDS: true on both old and new code (the rfc6052 fallback already blocks these). They assert
+  // the security direction is never weakened by the change — not that they catch the P3 regression.
+  test('GUARD: well-known NAT64 embedding cloud metadata stays blocked with a custom-only prefix', () => {
+    expect(isBlockedEgressIp('64:ff9b::a9fe:a9fe', ['2a00:1098:2c::/96'])).toBe(true) // 169.254.169.254
+  })
+  test('GUARD: a single custom-prefix call keeps BOTH the custom NSP and well-known active', () => {
+    expect(isBlockedEgressIp('2a00:1098:2c::a00:1', ['2a00:1098:2c::/96'])).toBe(true) // custom NSP → 10.0.0.1
+    expect(isBlockedEgressIp('64:ff9b::a00:1', ['2a00:1098:2c::/96'])).toBe(true) // well-known → 10.0.0.1
+  })
+
+  // ZERO-DRIFT: validateEgressUrl source is untouched; its existing explicit [...WELL_KNOWN, ...policy]
+  // merge is byte-identical after the helper's Set-dedup, so the main path is unchanged.
+  test('ZERO-DRIFT: validateEgressUrl still blocks well-known NAT64 metadata under a configured-NSP policy', () => {
+    const p: EgressPolicy = { allowedHosts: [], nat64Prefixes: ['2a00:1098:2c::/96'] }
+    expect(validateEgressUrl('https://[64:ff9b::a9fe:a9fe]/', p)).toEqual({
+      allowed: false,
+      reason: 'IP_BLOCKED',
+    })
+  })
+})

--- a/packages/core-backend/src/guards/egress-guard.ts
+++ b/packages/core-backend/src/guards/egress-guard.ts
@@ -117,14 +117,19 @@ function isBlockedIpv6(address: ipaddr.IPv6, nat64Prefixes: readonly string[]): 
 
 export function isBlockedEgressIp(
   hostname: string,
-  nat64Prefixes: readonly string[] = WELL_KNOWN_NAT64_PREFIXES,
+  nat64Prefixes: readonly string[] = [],
 ): boolean {
   const address = parseIp(hostname)
   if (!address) return false
   if (address.kind() === 'ipv4') {
     return isBlockedIpv4(address as ipaddr.IPv4)
   }
-  return isBlockedIpv6(address as ipaddr.IPv6, nat64Prefixes)
+  // Always fold in the well-known NAT64 NSP (64:ff9b::/96) rather than letting a caller's prefixes
+  // REPLACE it. A direct caller passing only its own operator prefix must never silently drop the
+  // default, or the well-known NSP's inner v4 stops being decoded. De-duped so validateEgressUrl's
+  // existing explicit [...WELL_KNOWN, ...policy] merge stays byte-for-byte equivalent (zero-drift).
+  const mergedNat64Prefixes = [...new Set([...WELL_KNOWN_NAT64_PREFIXES, ...nat64Prefixes])]
+  return isBlockedIpv6(address as ipaddr.IPv6, mergedNat64Prefixes)
 }
 
 export function validateEgressUrl(rawUrl: unknown, policy: EgressPolicy = defaultEgressPolicy()): EgressUrlDecision {


### PR DESCRIPTION
Guard API hardening on the R1-A egress guard (follow-up to #3438, per review). **Scope: `isBlockedEgressIp` + tests only** — no policy schema, no runtime route, no self-service S2.

## What
`isBlockedEgressIp(host, prefixes)`'s second arg defaulted to `WELL_KNOWN_NAT64_PREFIXES`, so a caller passing custom prefixes **replaced** the well-known `64:ff9b::/96` instead of adding to it. The helper now **always Set-merges** the well-known prefix internally (default arg → `[]`), so a direct caller can never drop the default NAT64 decode.

## Not a live SSRF hole (honest framing)
`validateEgressUrl` already merges explicitly (`[...WELL_KNOWN, ...policy]`), so the **main path was always safe**. And ipaddr.js classifies `64:ff9b::/96` as its own `rfc6052` range, so even a dropped-well-known **internal** NAT64 was already conservatively blocked by the `range() !== 'unicast'` fallback. The observable pre-fix defect was narrower — a **public** well-known NAT64 false-positive-**blocked** under a custom-only prefix, plus contract fragility for future direct callers. API robustness, not closing a hole.

## Zero-drift
`validateEgressUrl` source is **untouched**; the Set-dedup makes its existing explicit merge byte-identical, so the entire pre-existing suite passes unchanged — that unchanged suite *is* the zero-drift proof.

## Tests (red-before-green)
- **REGRESSION** (the one discriminator): `isBlockedEgressIp('64:ff9b::808:808', ['2a00:1098:2c::/96'])` → `false`. Verified **true pre-fix** (rfc6052 fallback) → **false post-fix** (decode → 8.8.8.8 public → allowed) against the real source in an isolated vitest run (48→49 passing).
- **GUARDs** (pass on both old/new — assert the security direction never weakens): well-known metadata stays blocked; both custom + well-known active in one call.
- **ZERO-DRIFT**: `validateEgressUrl` still IP_BLOCKs well-known metadata under a configured-NSP policy.

Ref #3438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)