### PR TITLE
fix(approval): T2-4 threshold re-entry quorum-bypass — scope tally to current node-entry round

### DIFF
--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4175,14 +4175,52 @@ export class ApprovalProductService {
         // across role rows / re-dispatch, and auto-approvals are included because they too
         // write an action='approve' record carrying metadata.nodeKey (Q5).
         const threshold = executor.getApprovalThreshold(currentNodeKey)
-        const priorApproversResult = await client.query<{ count: string }>(
-          `SELECT COUNT(DISTINCT actor_id) AS count
+        // T2-4 RE-ENTRY quorum fix: scope the DISTINCT-approver tally to the CURRENT node-entry round. A
+        // `threshold` node can be RETURNED/JUMPED back to after it already resolved (the 退回/return path admits
+        // any previously-visited approval node), and `approval_records` are append-only — so without scoping,
+        // approve records from a PRIOR entry still count toward N and re-satisfy the node on stale votes (a
+        // quorum bypass: a 2-of-3 that A+B already approved would resolve on a single fresh vote). The current
+        // round begins at the `to_version` of the most recent return/jump that re-entered THIS node; approve
+        // records are stamped `to_version = <bumped version>`, so those recorded AT-OR-AFTER the re-entry
+        // (`to_version >= cutoff`) belong to the current round. `>=` (not `>`) is deliberate: a return/jump can
+        // trigger an auto-approval cascade AT the re-entered node in the SAME transaction (insertAutoApprovalEvents
+        // writes those approve records at `to_version = <re-entry version> = cutoff`) — legitimate current-round
+        // votes that must count. Prior-round approves are strictly `< cutoff` (they predate the version bump), so
+        // `>=` admits the cascade without re-admitting stale votes. With NO re-entry (cutoff null) the tally is
+        // the whole-node count — byte-identical to the pre-fix behaviour (zero regression). The graph is validated
+        // ACYCLIC (executor cycle guards), so a threshold node is only re-enterable via a return/jump — this
+        // marker is complete (no forward-loop re-entry path).
+        const reentryCutoffResult = await client.query<{ cutoff: number | string | null }>(
+          `SELECT MAX(to_version) AS cutoff
              FROM approval_records
              WHERE instance_id = $1
-               AND action = 'approve'
-               AND metadata->>'nodeKey' = $2`,
+               AND action IN ('return', 'jump')
+               AND ( metadata->>'nextNodeKey' = $2
+                  OR metadata->>'targetNodeKey' = $2
+                  OR metadata->>'toNodeKey' = $2 )`,
           [id, currentNodeKey],
         )
+        const rawCutoff = reentryCutoffResult.rows[0]?.cutoff
+        const reentryCutoff = rawCutoff === null || rawCutoff === undefined ? null : Number(rawCutoff)
+        const priorApproversResult =
+          reentryCutoff === null
+            ? await client.query<{ count: string }>(
+                `SELECT COUNT(DISTINCT actor_id) AS count
+                   FROM approval_records
+                   WHERE instance_id = $1
+                     AND action = 'approve'
+                     AND metadata->>'nodeKey' = $2`,
+                [id, currentNodeKey],
+              )
+            : await client.query<{ count: string }>(
+                `SELECT COUNT(DISTINCT actor_id) AS count
+                   FROM approval_records
+                   WHERE instance_id = $1
+                     AND action = 'approve'
+                     AND metadata->>'nodeKey' = $2
+                     AND to_version >= $3`,
+                [id, currentNodeKey, reentryCutoff],
+              )
         const priorDistinctApprovers = Number.parseInt(priorApproversResult.rows[0]?.count || '0', 10)
         const distinctApproverCount = priorDistinctApprovers + 1
         // Deactivate the actor's own assignment first (whether or not the threshold is met).

--- a/packages/core-backend/tests/integration/approval-nofm-threshold.test.ts
+++ b/packages/core-backend/tests/integration/approval-nofm-threshold.test.ts
@@ -96,6 +96,39 @@ function buildThresholdGraph() {
   }
 }
 
+// T2-4 RE-ENTRY: a threshold (2-of-3) node followed by a SECOND approval node, so after the threshold
+// resolves the instance sits at the second node — from which an approver can RETURN (退回) to the already-
+// resolved threshold node, re-activating it while its prior-round approve records remain (append-only). Used
+// to prove the quorum tally is scoped to the current node-entry round (stale votes must NOT re-satisfy N).
+function buildThresholdReentryGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_threshold',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a', 'approver-b', 'approver-c'],
+          approvalMode: 'threshold',
+          approvalThreshold: 2,
+        },
+      },
+      {
+        key: 'approval_second',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-a'], approvalMode: 'single' },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-threshold', source: 'start', target: 'approval_threshold' },
+      { key: 'edge-threshold-second', source: 'approval_threshold', target: 'approval_second' },
+      { key: 'edge-second-end', source: 'approval_second', target: 'end' },
+    ],
+  }
+}
+
 // T2-4 P1 semantic-hole regression: a ROLE source resolves only M=2 distinct approver slots
 // but the node config demands N=3. Publish-time validation only bounds N <= M for the fully-
 // static USER case, so this graph publishes; the N > M must be caught FAIL-CLOSED when the
@@ -427,5 +460,55 @@ describeIfDatabase('Approval T2-4 N-of-M threshold (门槛会签) API', () => {
       [templateId],
     )
     expect(Number.parseInt(leakedInstances.rows[0]?.count || '0', 10)).toBe(0)
+  })
+
+  it('does NOT re-satisfy a RETURNED-to threshold node on stale prior-round votes (re-entry quorum scope)', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-threshold')
+    const requesterToken = await authToken(baseUrl, 'requester-threshold')
+    const aTok = await authToken(baseUrl, 'approver-a')
+    const bTok = await authToken(baseUrl, 'approver-b')
+
+    const templateId = await publishGraphTemplate(adminToken, buildThresholdReentryGraph())
+    const create = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 're-entry quorum' } },
+    })
+    expect(create.status).toBe(201)
+    const inst = (await create.json()) as { id: string; currentNodeKey: string | null }
+    createdApprovalIds.add(inst.id)
+    expect(inst.currentNodeKey).toBe('approval_threshold')
+
+    const act = async (token: string, body: object) =>
+      (await jsonRequest(baseUrl, `/api/approvals/${inst.id}/actions`, token, { method: 'POST', body })).json() as Promise<{
+        status: string
+        currentNodeKey: string | null
+        assignments: Array<{ assigneeId: string; isActive: boolean }>
+      }>
+
+    // Round 1: A + B approve the 2-of-3 → node resolves → instance advances to approval_second.
+    await act(aTok, { action: 'approve', comment: 'A r1' })
+    const afterB = await act(bTok, { action: 'approve', comment: 'B r1' })
+    expect(afterB.status).toBe('pending')
+    expect(afterB.currentNodeKey).toBe('approval_second')
+
+    // approver-a (the second node's approver) RETURNS to the already-resolved threshold node.
+    const afterReturn = await act(aTok, { action: 'return', targetNodeKey: 'approval_threshold', comment: 'send back' })
+    expect(afterReturn.currentNodeKey).toBe('approval_threshold')
+    expect(afterReturn.assignments.filter((x) => x.isActive).map((x) => x.assigneeId).sort()).toEqual([
+      'approver-a',
+      'approver-b',
+      'approver-c',
+    ])
+
+    // Round 2, ONE fresh approval. THE FIX: the stale round-1 A+B votes must NOT count → node stays pending on
+    // 1-of-2. (Pre-fix bug: prior-round A+B still count → 2+1=3 ≥ 2 → the node re-resolves on a single vote and
+    // the instance would already be at approval_second here.)
+    const afterFresh = await act(aTok, { action: 'approve', comment: 'A r2 (1 of 2)' })
+    expect(afterFresh.status).toBe('pending')
+    expect(afterFresh.currentNodeKey).toBe('approval_threshold')
+
+    // A SECOND fresh distinct approval resolves the current round → advances again (fresh quorum still works).
+    const afterFresh2 = await act(bTok, { action: 'approve', comment: 'B r2 (2 of 2)' })
+    expect(afterFresh2.currentNodeKey).toBe('approval_second')
   })
 })


### PR DESCRIPTION
Closes the **T2-4 threshold re-entry quorum-bypass** (confirmed real bug; Lane B / approval engine, independent of the in-flight R1 lane).

## Bug
The threshold quorum tally counts `COUNT(DISTINCT actor_id) … action='approve' AND metadata->>'nodeKey'=$2` with **no round scoping**. The 退回/return path admits any previously-visited approval node — including an already-resolved `threshold` node — and `approval_records` are append-only. So on re-entry the prior-round approve records still count toward N: **a 2-of-3 that A+B already approved re-resolves on a single fresh vote.** Self-verified reachable.

## Fix (schema-free — uses existing data)
The current round begins at the `to_version` of the most recent return/jump that re-entered the node; approve records carry `to_version` (bumped), so scope the tally to **`to_version >= cutoff`**. `>=` (not `>`) is deliberate: a return/jump can fire an auto-approval cascade AT the re-entered node in the **same transaction** (`insertAutoApprovalEvents` writes those approve records at `to_version = re-entry version = cutoff`) — legitimate current-round votes that must count; prior-round approves are strictly `< cutoff`, so `>=` admits the cascade without re-admitting stale votes. **No re-entry → cutoff null → falls back to the exact old whole-node query (zero regression for the normal path).** The graph is validated **acyclic**, so a threshold node is only re-enterable via return/jump (marker complete — no forward-loop bypass). Only the `threshold` branch changes.

## Verification
tsc 0 · real-DB `approval-nofm-threshold` **4/4** incl. a **new fail-first re-entry test** (2-of-3 → A+B approve → advance → RETURN → one fresh vote must NOT re-resolve; a 2nd fresh vote still resolves). **RED-before confirmed.** N>M fail-closed + single-reject paths unchanged.

Open follow-up (flagged): a dedicated regression for the same-version-cascade `>=` boundary — the `>=` correctness is reasoned + the cascade write-site confirmed, but not yet locked by its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)