### PR TITLE
[codex] add R1 pinned egress dispatcher

### DIFF
--- a/packages/core-backend/src/guards/__tests__/egress-dispatcher.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-dispatcher.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  dispatchPinnedEgressRequest,
+  type EgressAddressResolver,
+  type PinnedEgressRequest,
+  type PinnedEgressTransport,
+} from '../egress-dispatcher'
+import type { EgressPolicy } from '../egress-guard'
+
+const policy = (hosts: readonly string[], extra: Partial<EgressPolicy> = {}): EgressPolicy => ({
+  allowedHosts: hosts,
+  ...extra,
+})
+
+const resolver = (addresses: readonly { address: string; family?: 4 | 6 }[]): EgressAddressResolver => {
+  return async () => addresses
+}
+
+const recordingTransport = (
+  responses: readonly { status: number; headers?: Record<string, string>; body?: unknown }[],
+): { calls: PinnedEgressRequest[]; transport: PinnedEgressTransport } => {
+  const calls: PinnedEgressRequest[] = []
+  return {
+    calls,
+    transport: async (request) => {
+      calls.push(request)
+      return responses[Math.min(calls.length - 1, responses.length - 1)] ?? { status: 204 }
+    },
+  }
+}
+
+describe('R1-A egress pinned dispatcher', () => {
+  test('validates allowlist, resolves once, and passes only the pinned public address to transport', async () => {
+    const { calls, transport } = recordingTransport([{ status: 200, body: { ok: true } }])
+    const resolvedHosts: string[] = []
+
+    const decision = await dispatchPinnedEgressRequest(
+      {
+        url: 'https://API.Example.com/hook',
+        method: 'POST',
+        headers: { Accept: 'application/json' },
+        body: { hello: 'world' },
+      },
+      {
+        policy: policy(['api.example.com']),
+        resolveAddresses: async (hostname) => {
+          resolvedHosts.push(hostname)
+          return [{ address: '8.8.8.8', family: 4 }]
+        },
+        transport,
+      },
+    )
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      finalUrl: 'https://api.example.com/hook',
+      redirectCount: 0,
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      normalizedUrl: 'https://api.example.com/hook',
+      hostname: 'api.example.com',
+      pinnedAddress: '8.8.8.8',
+      family: 4,
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+      body: { hello: 'world' },
+      redirect: 'manual',
+      redirectCount: 0,
+    })
+    expect(resolvedHosts).toEqual(['api.example.com'])
+  })
+
+  test('rejects caller-supplied Host headers before DNS or transport', async () => {
+    let resolved = false
+    let transported = false
+
+    for (const headers of [{ Host: 'evil.example.com' }, { host: 'evil.example.com' }]) {
+      const decision = await dispatchPinnedEgressRequest(
+        { url: 'https://api.example.com/hook', headers },
+        {
+          policy: policy(['api.example.com']),
+          resolveAddresses: async () => {
+            resolved = true
+            return [{ address: '8.8.8.8', family: 4 }]
+          },
+          transport: async () => {
+            transported = true
+            return { status: 200 }
+          },
+        },
+      )
+
+      expect(decision).toEqual({ allowed: false, reason: 'HOST_HEADER_NOT_ALLOWED' })
+    }
+    expect(resolved).toBe(false)
+    expect(transported).toBe(false)
+  })
+
+  test('fails closed before DNS or transport when URL policy denies the target', async () => {
+    let resolved = false
+    let transported = false
+
+    const decision = await dispatchPinnedEgressRequest(
+      { url: 'https://api.example.com/hook' },
+      {
+        policy: policy([]),
+        resolveAddresses: async () => {
+          resolved = true
+          return [{ address: '8.8.8.8', family: 4 }]
+        },
+        transport: async () => {
+          transported = true
+          return { status: 200 }
+        },
+      },
+    )
+
+    expect(decision).toEqual({ allowed: false, reason: 'ALLOWLIST_REQUIRED' })
+    expect(resolved).toBe(false)
+    expect(transported).toBe(false)
+  })
+
+  test('denies the whole dispatch if any resolved address is unsafe', async () => {
+    let transported = false
+
+    const decision = await dispatchPinnedEgressRequest(
+      { url: 'https://api.example.com/hook' },
+      {
+        policy: policy(['api.example.com']),
+        resolveAddresses: resolver([
+          { address: '8.8.8.8', family: 4 },
+          { address: '169.254.169.254', family: 4 },
+        ]),
+        transport: async () => {
+          transported = true
+          return { status: 200 }
+        },
+      },
+    )
+
+    expect(decision).toEqual({ allowed: false, reason: 'DNS_IP_BLOCKED' })
+    expect(transported).toBe(false)
+  })
+
+  test('blocks resolved NAT64 addresses that embed an internal IPv4', async () => {
+    const decision = await dispatchPinnedEgressRequest(
+      { url: 'https://api.example.com/hook' },
+      {
+        policy: policy(['api.example.com'], { nat64Prefixes: ['2a00:1098:2c::/96'] }),
+        resolveAddresses: resolver([{ address: '2a00:1098:2c::a9fe:a9fe', family: 6 }]),
+        transport: async () => ({ status: 200 }),
+      },
+    )
+
+    expect(decision).toEqual({ allowed: false, reason: 'DNS_IP_BLOCKED' })
+  })
+
+  test('fails closed on DNS uncertainty and invalid resolver output', async () => {
+    await expect(
+      dispatchPinnedEgressRequest(
+        { url: 'https://api.example.com/hook' },
+        {
+          policy: policy(['api.example.com']),
+          resolveAddresses: async () => {
+            throw new Error('lookup failed')
+          },
+          transport: async () => ({ status: 200 }),
+        },
+      ),
+    ).resolves.toEqual({ allowed: false, reason: 'DNS_LOOKUP_FAILED' })
+
+    await expect(
+      dispatchPinnedEgressRequest(
+        { url: 'https://api.example.com/hook' },
+        {
+          policy: policy(['api.example.com']),
+          resolveAddresses: resolver([]),
+          transport: async () => ({ status: 200 }),
+        },
+      ),
+    ).resolves.toEqual({ allowed: false, reason: 'DNS_NO_ADDRESSES' })
+
+    await expect(
+      dispatchPinnedEgressRequest(
+        { url: 'https://api.example.com/hook' },
+        {
+          policy: policy(['api.example.com']),
+          resolveAddresses: resolver([{ address: 'not-an-ip' }]),
+          transport: async () => ({ status: 200 }),
+        },
+      ),
+    ).resolves.toEqual({ allowed: false, reason: 'DNS_INVALID_ADDRESS' })
+  })
+
+  test('uses an allowlisted public IP literal as its own pinned address without DNS lookup', async () => {
+    let resolved = false
+    const { calls, transport } = recordingTransport([{ status: 204 }])
+
+    const decision = await dispatchPinnedEgressRequest(
+      { url: 'https://8.8.8.8/dns-query' },
+      {
+        policy: policy(['8.8.8.8']),
+        resolveAddresses: async () => {
+          resolved = true
+          return [{ address: '10.0.0.1', family: 4 }]
+        },
+        transport,
+      },
+    )
+
+    expect(decision).toMatchObject({ allowed: true })
+    expect(resolved).toBe(false)
+    expect(calls[0]).toMatchObject({
+      hostname: '8.8.8.8',
+      pinnedAddress: '8.8.8.8',
+      family: 4,
+    })
+  })
+
+  test('revalidates redirects and rejects a redirect target outside the allowlist before transport', async () => {
+    const { calls, transport } = recordingTransport([
+      { status: 302, headers: { Location: 'https://evil.example.com/next' } },
+      { status: 200 },
+    ])
+
+    const decision = await dispatchPinnedEgressRequest(
+      { url: 'https://api.example.com/start' },
+      {
+        policy: policy(['api.example.com']),
+        resolveAddresses: resolver([{ address: '8.8.8.8', family: 4 }]),
+        transport,
+      },
+    )
+
+    expect(decision).toEqual({ allowed: false, reason: 'HOST_NOT_ALLOWLISTED' })
+    expect(calls).toHaveLength(1)
+  })
+
+  test('revalidates redirect DNS and rejects a redirect that resolves to a private IP', async () => {
+    const { calls, transport } = recordingTransport([
+      { status: 302, headers: { Location: 'https://safe.example.com/next' } },
+      { status: 200 },
+    ])
+    const addressesByHost: Record<string, readonly { address: string; family: 4 | 6 }[]> = {
+      'api.example.com': [{ address: '8.8.8.8', family: 4 }],
+      'safe.example.com': [{ address: '10.0.0.8', family: 4 }],
+    }
+
+    const decision = await dispatchPinnedEgressRequest(
+      { url: 'https://api.example.com/start' },
+      {
+        policy: policy(['api.example.com', 'safe.example.com']),
+        resolveAddresses: async (hostname) => addressesByHost[hostname] ?? [],
+        transport,
+      },
+    )
+
+    expect(decision).toEqual({ allowed: false, reason: 'DNS_IP_BLOCKED' })
+    expect(calls).toHaveLength(1)
+  })
+
+  test('follows a revalidated redirect with a freshly pinned public address', async () => {
+    const { calls, transport } = recordingTransport([
+      { status: 302, headers: { Location: 'https://safe.example.com/next' } },
+      { status: 200, body: { ok: true } },
+    ])
+    const addressesByHost: Record<string, readonly { address: string; family: 4 | 6 }[]> = {
+      'api.example.com': [{ address: '8.8.8.8', family: 4 }],
+      'safe.example.com': [{ address: '1.1.1.1', family: 4 }],
+    }
+
+    const decision = await dispatchPinnedEgressRequest(
+      { url: 'https://api.example.com/start' },
+      {
+        policy: policy(['api.example.com', 'safe.example.com']),
+        resolveAddresses: async (hostname) => addressesByHost[hostname] ?? [],
+        transport,
+      },
+    )
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      finalUrl: 'https://safe.example.com/next',
+      redirectCount: 1,
+    })
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).toMatchObject({ hostname: 'api.example.com', pinnedAddress: '8.8.8.8' })
+    expect(calls[0]?.redirect).toBe('manual')
+    expect(calls[1]).toMatchObject({
+      hostname: 'safe.example.com',
+      pinnedAddress: '1.1.1.1',
+      redirect: 'manual',
+      redirectCount: 1,
+    })
+  })
+
+  test('caps redirect chains fail-closed', async () => {
+    const decision = await dispatchPinnedEgressRequest(
+      { url: 'https://api.example.com/start' },
+      {
+        policy: policy(['api.example.com']),
+        resolveAddresses: resolver([{ address: '8.8.8.8', family: 4 }]),
+        maxRedirects: 0,
+        transport: async () => ({ status: 302, headers: { Location: 'https://api.example.com/again' } }),
+      },
+    )
+
+    expect(decision).toEqual({ allowed: false, reason: 'REDIRECT_LIMIT_EXCEEDED' })
+  })
+})

--- a/packages/core-backend/src/guards/egress-dispatcher.ts
+++ b/packages/core-backend/src/guards/egress-dispatcher.ts
@@ -1,0 +1,240 @@
+import * as ipaddr from 'ipaddr.js'
+
+import {
+  defaultEgressPolicy,
+  isBlockedEgressIp,
+  validateEgressUrl,
+  type EgressPolicy,
+  type EgressUrlDenyReason,
+} from './egress-guard'
+
+export type EgressResolvedAddress = {
+  address: string
+  family?: 4 | 6
+}
+
+export type EgressAddressResolver = (hostname: string) => Promise<readonly EgressResolvedAddress[]>
+
+export type PinnedEgressTarget = {
+  normalizedUrl: string
+  hostname: string
+  pinnedAddress: string
+  family: 4 | 6
+}
+
+export type PinnedEgressRequest = PinnedEgressTarget & {
+  method: string
+  headers: Readonly<Record<string, string>>
+  body?: unknown
+  redirect: 'manual'
+  redirectCount: number
+}
+
+export type PinnedEgressResponse = {
+  status: number
+  headers?: Readonly<Record<string, string | readonly string[] | undefined>>
+  body?: unknown
+}
+
+/**
+ * Transport implementations must connect to pinnedAddress while preserving hostname for Host/SNI.
+ * This module deliberately injects the transport so A1 stays testable without live outbound I/O.
+ */
+export type PinnedEgressTransport = (request: PinnedEgressRequest) => Promise<PinnedEgressResponse>
+
+export type PinnedEgressDenyReason =
+  | EgressUrlDenyReason
+  | 'DNS_LOOKUP_FAILED'
+  | 'DNS_NO_ADDRESSES'
+  | 'DNS_INVALID_ADDRESS'
+  | 'DNS_IP_BLOCKED'
+  | 'HOST_HEADER_NOT_ALLOWED'
+  | 'REDIRECT_LOCATION_MALFORMED'
+  | 'REDIRECT_LIMIT_EXCEEDED'
+
+export type PinnedEgressDecision =
+  | {
+      allowed: true
+      response: PinnedEgressResponse
+      finalUrl: string
+      redirectCount: number
+    }
+  | {
+      allowed: false
+      reason: PinnedEgressDenyReason
+    }
+
+export type DispatchPinnedEgressOptions = {
+  policy?: EgressPolicy
+  resolveAddresses: EgressAddressResolver
+  transport: PinnedEgressTransport
+  maxRedirects?: number
+}
+
+export type DispatchPinnedEgressInput = {
+  url: unknown
+  method?: string
+  headers?: Readonly<Record<string, string>>
+  body?: unknown
+}
+
+const DEFAULT_MAX_REDIRECTS = 3
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+
+function parseAddress(address: string): { canonicalAddress: string; family: 4 | 6 } | null {
+  const raw = address.trim()
+  if (!raw || raw.includes('%') || !ipaddr.isValid(raw)) return null
+  const parsed = ipaddr.parse(raw)
+  return {
+    canonicalAddress: parsed.toString(),
+    family: parsed.kind() === 'ipv4' ? 4 : 6,
+  }
+}
+
+function responseHeader(
+  headers: PinnedEgressResponse['headers'],
+  name: string,
+): string | null {
+  if (!headers) return null
+  const wanted = name.toLowerCase()
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== wanted) continue
+    if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : null
+    return typeof value === 'string' ? value : null
+  }
+  return null
+}
+
+function hasCallerHostHeader(headers: Readonly<Record<string, string>> | undefined): boolean {
+  return Object.keys(headers ?? {}).some((key) => key.toLowerCase() === 'host')
+}
+
+async function resolvePinnedTarget(
+  normalizedUrl: string,
+  hostname: string,
+  policy: EgressPolicy,
+  resolveAddresses: EgressAddressResolver,
+): Promise<{ allowed: true; target: PinnedEgressTarget } | { allowed: false; reason: PinnedEgressDenyReason }> {
+  const literal = parseAddress(hostname)
+  if (literal) {
+    if (isBlockedEgressIp(literal.canonicalAddress, policy.nat64Prefixes)) {
+      return { allowed: false, reason: 'DNS_IP_BLOCKED' }
+    }
+    return {
+      allowed: true,
+      target: {
+        normalizedUrl,
+        hostname,
+        pinnedAddress: literal.canonicalAddress,
+        family: literal.family,
+      },
+    }
+  }
+
+  let addresses: readonly EgressResolvedAddress[]
+  try {
+    addresses = await resolveAddresses(hostname)
+  } catch {
+    return { allowed: false, reason: 'DNS_LOOKUP_FAILED' }
+  }
+
+  if (addresses.length === 0) return { allowed: false, reason: 'DNS_NO_ADDRESSES' }
+
+  const parsedAddresses: Array<{ canonicalAddress: string; family: 4 | 6 }> = []
+  for (const resolved of addresses) {
+    const parsed = parseAddress(resolved.address)
+    if (!parsed) return { allowed: false, reason: 'DNS_INVALID_ADDRESS' }
+    if (resolved.family !== undefined && resolved.family !== parsed.family) {
+      return { allowed: false, reason: 'DNS_INVALID_ADDRESS' }
+    }
+    if (isBlockedEgressIp(parsed.canonicalAddress, policy.nat64Prefixes)) {
+      return { allowed: false, reason: 'DNS_IP_BLOCKED' }
+    }
+    parsedAddresses.push(parsed)
+  }
+
+  const first = parsedAddresses[0]
+  if (!first) return { allowed: false, reason: 'DNS_NO_ADDRESSES' }
+  return {
+    allowed: true,
+    target: {
+      normalizedUrl,
+      hostname,
+      pinnedAddress: first.canonicalAddress,
+      family: first.family,
+    },
+  }
+}
+
+export async function dispatchPinnedEgressRequest(
+  input: DispatchPinnedEgressInput,
+  options: DispatchPinnedEgressOptions,
+): Promise<PinnedEgressDecision> {
+  const policy = options.policy ?? defaultEgressPolicy()
+  if (hasCallerHostHeader(input.headers)) {
+    return { allowed: false, reason: 'HOST_HEADER_NOT_ALLOWED' }
+  }
+  const maxRedirects = Number.isInteger(options.maxRedirects) && options.maxRedirects !== undefined
+    ? Math.max(0, options.maxRedirects)
+    : DEFAULT_MAX_REDIRECTS
+  let currentUrl = input.url
+  let method = input.method || 'GET'
+  let body = input.body
+
+  for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
+    const urlDecision = validateEgressUrl(currentUrl, policy)
+    if (urlDecision.allowed === false) return { allowed: false, reason: urlDecision.reason }
+
+    const targetDecision = await resolvePinnedTarget(
+      urlDecision.normalizedUrl,
+      urlDecision.hostname,
+      policy,
+      options.resolveAddresses,
+    )
+    if (targetDecision.allowed === false) return { allowed: false, reason: targetDecision.reason }
+
+    const response = await options.transport({
+      ...targetDecision.target,
+      method,
+      headers: Object.freeze({ ...(input.headers ?? {}) }),
+      body,
+      redirect: 'manual',
+      redirectCount,
+    })
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return {
+        allowed: true,
+        response,
+        finalUrl: targetDecision.target.normalizedUrl,
+        redirectCount,
+      }
+    }
+
+    const location = responseHeader(response.headers, 'location')
+    if (!location) {
+      return {
+        allowed: true,
+        response,
+        finalUrl: targetDecision.target.normalizedUrl,
+        redirectCount,
+      }
+    }
+    if (redirectCount >= maxRedirects) {
+      return { allowed: false, reason: 'REDIRECT_LIMIT_EXCEEDED' }
+    }
+
+    try {
+      currentUrl = new URL(location, targetDecision.target.normalizedUrl).toString()
+    } catch {
+      return { allowed: false, reason: 'REDIRECT_LOCATION_MALFORMED' }
+    }
+
+    if (response.status === 303) {
+      method = 'GET'
+      body = undefined
+    }
+  }
+
+  return { allowed: false, reason: 'REDIRECT_LIMIT_EXCEEDED' }
+}

--- a/packages/core-backend/src/guards/index.ts
+++ b/packages/core-backend/src/guards/index.ts
@@ -9,3 +9,4 @@ export * from './middleware';
 export * from './audit-integration';
 export * from './idempotency';
 export * from './egress-guard';
+export * from './egress-dispatcher';


### PR DESCRIPTION
## Summary

Implements R1 egress closure A1: a pure, injectable IP-pinned egress dispatcher module for BPMN HTTP-task SSRF hardening.

This adds:
- `dispatchPinnedEgressRequest` under `packages/core-backend/src/guards/egress-dispatcher.ts`
- URL policy reuse via `validateEgressUrl`
- injected DNS resolver + injected transport, so this slice has no live outbound I/O
- deny-if-any-resolved-IP-is-unsafe behavior, including NAT64 NSP coverage
- redirect re-validation and redirect cap
- pinned transport contract: connect to `pinnedAddress` while preserving original `hostname` for Host/SNI
- `redirect: 'manual'` on the transport request so A2 cannot silently rely on auto-following redirects
- fail-closed rejection of caller-supplied `Host` headers before DNS/transport, avoiding Host/SNI split at the pinned transport boundary
- focused tests for fail-closed URL policy, Host header rejection, DNS uncertainty, mixed public/private DNS, NAT64, IP literals, redirect re-validation, and redirect cap

## Boundary

This is A1 only.

It deliberately does **not** modify `BPMNWorkflowEngine.executeHttpTask`, does not import or call `fetch`, and does not enable live BPMN HTTP egress. The current live callpoint remains unchanged until A2 wiring.

## Verification

- `pnpm install` in the isolated worktree
- `pnpm --filter @metasheet/core-backend exec vitest run src/guards/__tests__/egress-guard.test.ts src/guards/__tests__/egress-dispatcher.test.ts --reporter=dot`
  - 2 files / 64 tests passed
- `pnpm --filter @metasheet/core-backend type-check`
- `rg` confirmed `executeHttpTask` still has the existing `fetch(url, ...)` and the new dispatcher is only exported/tested, not wired into runtime
