### PR TITLE
docs(multitable): add Global History flag operator checklist

### DIFF
--- a/docs/development/multitable-global-history-staging-flag-operator-checklist-20260701.md
+++ b/docs/development/multitable-global-history-staging-flag-operator-checklist-20260701.md
@@ -1,0 +1,183 @@
+# Global History — staging flag enablement operator checklist (2026-07-01)
+
+This is an operator checklist for staging/sandbox flag enablement. Canonical source remains current main plus the
+existing `multitable-global-history-*` docs; this note does not create a new design authority and does not authorize
+production enablement.
+
+## Scope
+
+This checklist covers staging/sandbox operation for the four Global History flags already smoke-verified in
+`multitable-global-history-staging-flag-smoke-20260701.md`:
+
+- `MULTITABLE_ENABLE_SHEET_CONFIG_REVERT=true`
+- `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT=true`
+- `MULTITABLE_ENABLE_PIT_RESET=true`
+- `MULTITABLE_ENABLE_PIT_UNDELETE=true`
+
+It also records the safety guard for `MULTITABLE_META_REVISION_RETENTION_ENABLED`: keep it absent/off while
+`MULTITABLE_ENABLE_PIT_RESET=true` unless the owner explicitly accepts that revert-undo becomes time-windowed.
+
+Production flags, product rollout scope, and the history-anchored Reset T-source upgrade remain separate owner
+decisions.
+
+## Preconditions
+
+Before enabling or re-enabling the flags on staging:
+
+1. Confirm the backend and web containers are on the intended Global History-capable image. The 2026-07-01 smoke used:
+   - `ghcr.io/zensgit/metasheet2-backend:925932837965c7e95fa2974dcdbc3a539581bf9b`
+   - `ghcr.io/zensgit/metasheet2-web:925932837965c7e95fa2974dcdbc3a539581bf9b`
+2. Confirm health is `status=ok` for the running backend.
+3. Confirm `MULTITABLE_META_REVISION_RETENTION_ENABLED` is absent/off before enabling `MULTITABLE_ENABLE_PIT_RESET`.
+4. Confirm the target is staging/sandbox, not production.
+5. Keep rollback ready: either a backup of the staging override file or a known-good edit that removes the four flags.
+
+## Read-only status helper
+
+Use the helper to inspect the running containers and the allowed flag set without dumping secrets:
+
+```bash
+METASHEET_STATUS_SSH_HOST=mainuser@<staging-host> \
+  node scripts/ops/multitable-global-history-flag-status.mjs
+```
+
+Optional health check, if a local tunnel is already open:
+
+```bash
+METASHEET_STATUS_SSH_HOST=mainuser@<staging-host> \
+METASHEET_STATUS_HEALTH_URL=http://127.0.0.1:18900/health \
+  node scripts/ops/multitable-global-history-flag-status.mjs --strict
+```
+
+The helper returns non-zero for stop conditions such as:
+
+- backend or web container not running;
+- health check not OK;
+- `MULTITABLE_ENABLE_PIT_RESET=true` together with `MULTITABLE_META_REVISION_RETENTION_ENABLED=true`;
+- backend/web image mismatch when `--strict` is used.
+
+It prints only these keys from the backend container environment:
+
+- `MULTITABLE_ENABLE_SHEET_CONFIG_REVERT`
+- `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT`
+- `MULTITABLE_ENABLE_PIT_RESET`
+- `MULTITABLE_ENABLE_PIT_UNDELETE`
+- `MULTITABLE_META_REVISION_RETENTION_ENABLED`
+
+## Enablement procedure
+
+On staging, keep the compose chain explicit:
+
+```text
+/home/mainuser/metasheet2-dingtalk-staging/docker-compose.app.staging.yml
+/home/mainuser/docker-compose.v12-hotpatch.override.yml
+/home/mainuser/metasheet2-staging-t9w.override.yml
+```
+
+The override should pin both images and carry only the intended staging flags:
+
+```yaml
+services:
+  backend:
+    image: ghcr.io/zensgit/metasheet2-backend:<verified-image-tag>
+    environment:
+      MULTITABLE_ENABLE_SHEET_CONFIG_REVERT: "true"
+      MULTITABLE_ENABLE_FIELD_RETYPE_REVERT: "true"
+      MULTITABLE_ENABLE_PIT_RESET: "true"
+      MULTITABLE_ENABLE_PIT_UNDELETE: "true"
+  web:
+    image: ghcr.io/zensgit/metasheet2-web:<verified-image-tag>
+```
+
+Then restart the affected services with the same compose chain:
+
+```bash
+docker compose \
+  -f /home/mainuser/metasheet2-dingtalk-staging/docker-compose.app.staging.yml \
+  -f /home/mainuser/docker-compose.v12-hotpatch.override.yml \
+  -f /home/mainuser/metasheet2-staging-t9w.override.yml \
+  up -d backend web
+```
+
+Run the status helper after restart. Stop if any stop condition appears.
+
+## Smoke checks
+
+### T9-W low-risk flags
+
+Browser smoke:
+
+1. Open a throwaway multitable sheet.
+2. Change a supported sheet config value.
+3. Open the config-history modal.
+4. Preview and confirm the supported revert.
+5. Confirm the current config value returned to the target value.
+6. Confirm a `meta_config_revisions` row exists with `source='restore'` and `restored_from_id` pointing to the reverted
+   revision.
+
+This checks the product path. It does not expand the supported revert set.
+
+### PIT_RESET
+
+Use the committed harness:
+
+```bash
+BASE_URL=http://127.0.0.1:18082 \
+ADMIN_TOKEN=<sheet-admin-jwt> \
+EDITOR_TOKEN=<record-editor-jwt> \
+  node packages/core-backend/scripts/reset-acceptance.mjs
+```
+
+Expected flag-on result with the default ceiling:
+
+```text
+summary: 10 passed, 0 failed, 1 skipped
+```
+
+The skipped case is the optional 413 ceiling check unless `RESET_MAX_RECORDS=<small>` matches the environment ceiling.
+After the happy path, manually confirm once that post-T records landed in `meta_records_trash` rather than being hard
+deleted. The 2026-07-01 evidence confirmed this for the staging run.
+
+### PIT_UNDELETE
+
+There is no committed operator harness equivalent to `reset-acceptance.mjs` yet. Until one exists, use a throwaway
+fixture equivalent to the 2026-07-01 evidence:
+
+1. Create a deleted record `U` with create/delete revisions and no live row.
+2. Create a live record `L`.
+3. Ensure `U`'s T-snapshot links outbound to `L`.
+4. Run `revert-preview` at T and verify `visibleUndeleteCount=1`, `undeleteSupported=true`, and an executable identity.
+5. Run execute without confirm and expect `400 CONFIRM_REQUIRED`.
+6. Run execute with `confirm:"undelete"` and expect resurrection.
+7. Confirm the live row data, outbound `meta_links` rebuild, and `meta_record_revisions.source='restore'`.
+
+Clean the throwaway base/sheet/records/revisions/links immediately after the check.
+
+## Rollback
+
+1. Remove the four Global History flags from the staging override, or set them to anything other than `"true"`.
+2. Restart the backend. Restart web too if the rollback also changes the image.
+3. Run the status helper and confirm the four flags are absent/off.
+4. Re-run a minimal flag-off probe for the affected route. For example, `reset-preview` should return
+   `403 RESET_DISABLED` when `MULTITABLE_ENABLE_PIT_RESET` is off.
+
+No data migration is required for rollback.
+
+## Stop conditions
+
+Stop and do not broaden rollout if any of these occurs:
+
+- target host or compose chain is not staging/sandbox;
+- backend or web image is not the intended verified image;
+- health is not OK after restart;
+- `MULTITABLE_ENABLE_PIT_RESET=true` and `MULTITABLE_META_REVISION_RETENTION_ENABLED=true`;
+- reset acceptance has any failure;
+- T9-W browser smoke cannot find the config-history entry on a verified web image;
+- PIT_UNDELETE smoke lacks `CONFIRM_REQUIRED`, `source='restore'`, or outbound link rebuild evidence;
+- cleanup cannot isolate the throwaway fixture from real user data.
+
+## Cleanup notes
+
+Use unique prefixes for smoke fixtures and delete only those prefixes. The 2026-07-01 pass cleaned the latest
+PIT_RESET/T9-W/PIT_UNDELETE fixtures and observed older `RESET-ACCEPT ...` residue from previous runs; do not bulk-delete
+unreviewed historical residues unless they are explicitly tied to a smoke prefix and owner-approved.

--- a/scripts/ops/multitable-global-history-flag-status.mjs
+++ b/scripts/ops/multitable-global-history-flag-status.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * Read-only Global History staging flag status helper.
+ *
+ * The script intentionally prints only the flags in FLAG_KEYS. It never dumps
+ * the full container environment, tokens, or connection strings.
+ */
+
+import { execFileSync } from 'node:child_process'
+
+const FLAG_KEYS = Object.freeze([
+  'MULTITABLE_ENABLE_SHEET_CONFIG_REVERT',
+  'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT',
+  'MULTITABLE_ENABLE_PIT_RESET',
+  'MULTITABLE_ENABLE_PIT_UNDELETE',
+  'MULTITABLE_META_REVISION_RETENTION_ENABLED',
+])
+
+const TRUE_VALUES = new Set(['1', 'true', 'TRUE', 'yes', 'YES', 'on', 'ON'])
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    strict: false,
+    help: false,
+    backendContainer: process.env.METASHEET_STATUS_BACKEND_CONTAINER || 'metasheet-staging-backend',
+    webContainer: process.env.METASHEET_STATUS_WEB_CONTAINER || 'metasheet-staging-web',
+    sshHost: process.env.METASHEET_STATUS_SSH_HOST || '',
+    healthUrl: process.env.METASHEET_STATUS_HEALTH_URL || '',
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--json') options.json = true
+    else if (arg === '--strict') options.strict = true
+    else if (arg === '--help' || arg === '-h') options.help = true
+    else if (arg === '--backend-container') options.backendContainer = argv[++i] || ''
+    else if (arg === '--web-container') options.webContainer = argv[++i] || ''
+    else if (arg === '--ssh-host') options.sshHost = argv[++i] || ''
+    else if (arg === '--health-url') options.healthUrl = argv[++i] || ''
+    else throw new Error(`unknown argument: ${arg}`)
+  }
+
+  return options
+}
+
+function usage() {
+  return `Usage:
+  node scripts/ops/multitable-global-history-flag-status.mjs [--json] [--strict]
+
+Environment / options:
+  METASHEET_STATUS_SSH_HOST       SSH target for remote docker reads, e.g. mainuser@staging-host
+  METASHEET_STATUS_BACKEND_CONTAINER  backend container name (default: metasheet-staging-backend)
+  METASHEET_STATUS_WEB_CONTAINER      web container name (default: metasheet-staging-web)
+  METASHEET_STATUS_HEALTH_URL         optional local/tunneled health URL to fetch
+
+Examples:
+  METASHEET_STATUS_SSH_HOST=mainuser@staging-host \\
+    node scripts/ops/multitable-global-history-flag-status.mjs
+
+  METASHEET_STATUS_HEALTH_URL=http://127.0.0.1:18900/health \\
+    node scripts/ops/multitable-global-history-flag-status.mjs --json
+`
+}
+
+function runCommand(command, args) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function runShell(command, sshHost = '') {
+  if (sshHost) {
+    return runCommand('ssh', [
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ConnectTimeout=10',
+      sshHost,
+      command,
+    ])
+  }
+  return runCommand('sh', ['-lc', command])
+}
+
+function parseContainerInspect(text) {
+  const [image = '', status = ''] = String(text).trim().split('\t')
+  return { image: image.trim(), status: status.trim() }
+}
+
+function imageTag(image) {
+  const value = String(image || '')
+  if (!value || value.includes('@sha256:')) return ''
+  const slash = value.lastIndexOf('/')
+  const colon = value.lastIndexOf(':')
+  return colon > slash ? value.slice(colon + 1) : ''
+}
+
+function collectFlagMapFromEnvText(text) {
+  const allowed = new Set(FLAG_KEYS)
+  const flags = Object.fromEntries(FLAG_KEYS.map((key) => [key, null]))
+  for (const line of String(text || '').split(/\r?\n/)) {
+    const eq = line.indexOf('=')
+    if (eq <= 0) continue
+    const key = line.slice(0, eq)
+    if (!allowed.has(key)) continue
+    flags[key] = line.slice(eq + 1)
+  }
+  return flags
+}
+
+function flagEnabled(flags, key) {
+  return TRUE_VALUES.has(String(flags[key] ?? ''))
+}
+
+async function fetchHealth(healthUrl) {
+  if (!healthUrl) return null
+  const res = await fetch(healthUrl, { headers: { accept: 'application/json' } })
+  let body = null
+  try {
+    body = await res.json()
+  } catch {
+    body = await res.text()
+  }
+  return { status: res.status, ok: res.ok, body }
+}
+
+function inspectContainer(sshHost, container) {
+  const command = `docker inspect ${shellQuote(container)} --format ${shellQuote('{{.Config.Image}}\t{{.State.Status}}')}`
+  return parseContainerInspect(runShell(command, sshHost))
+}
+
+function readBackendFlags(sshHost, container) {
+  const command = `docker exec ${shellQuote(container)} sh -lc ${shellQuote('env')}`
+  return collectFlagMapFromEnvText(runShell(command, sshHost))
+}
+
+function buildAssessment(input, { strict = false } = {}) {
+  const warnings = []
+  const stops = []
+  const backendTag = imageTag(input.backend.image)
+  const webTag = imageTag(input.web.image)
+
+  if (input.backend.status && input.backend.status !== 'running') {
+    stops.push(`backend container is ${input.backend.status}`)
+  }
+  if (input.web.status && input.web.status !== 'running') {
+    stops.push(`web container is ${input.web.status}`)
+  }
+  if (backendTag && webTag && backendTag !== webTag) {
+    warnings.push(`backend/web image tags differ: backend=${backendTag} web=${webTag}`)
+  }
+  if (strict && warnings.length > 0) {
+    stops.push(...warnings.map((warning) => `strict: ${warning}`))
+  }
+  if (input.health && !input.health.ok) {
+    stops.push(`health check returned ${input.health.status}`)
+  }
+  if (
+    flagEnabled(input.flags, 'MULTITABLE_ENABLE_PIT_RESET') &&
+    flagEnabled(input.flags, 'MULTITABLE_META_REVISION_RETENTION_ENABLED')
+  ) {
+    stops.push('PIT_RESET is enabled while MULTITABLE_META_REVISION_RETENTION_ENABLED is true')
+  }
+
+  return {
+    ok: stops.length === 0,
+    warnings,
+    stops,
+    backendTag,
+    webTag,
+  }
+}
+
+function renderText(snapshot, assessment) {
+  const lines = []
+  lines.push('Global History staging flag status')
+  lines.push('')
+  lines.push(`backend: ${snapshot.backend.image || '(unknown)'} [${snapshot.backend.status || 'unknown'}]`)
+  lines.push(`web:     ${snapshot.web.image || '(unknown)'} [${snapshot.web.status || 'unknown'}]`)
+  if (snapshot.health) {
+    const body = snapshot.health.body && typeof snapshot.health.body === 'object' ? snapshot.health.body : {}
+    lines.push(`health:  ${snapshot.health.status} ${snapshot.health.ok ? 'ok' : 'not ok'}${body.commit ? ` commit=${body.commit}` : ''}${body.created ? ` created=${body.created}` : ''}`)
+  }
+  lines.push('')
+  lines.push('flags:')
+  for (const key of FLAG_KEYS) {
+    lines.push(`  ${key}=${snapshot.flags[key] ?? '(absent)'}`)
+  }
+  lines.push('')
+  lines.push('checks:')
+  if (assessment.stops.length === 0) lines.push('  PASS no stop conditions detected')
+  for (const stop of assessment.stops) lines.push(`  STOP ${stop}`)
+  for (const warning of assessment.warnings) lines.push(`  WARN ${warning}`)
+  return lines.join('\n')
+}
+
+async function collectStatus(options) {
+  const backend = inspectContainer(options.sshHost, options.backendContainer)
+  const web = inspectContainer(options.sshHost, options.webContainer)
+  const flags = readBackendFlags(options.sshHost, options.backendContainer)
+  const health = await fetchHealth(options.healthUrl)
+  return { backend, web, flags, health, checkedAt: new Date().toISOString() }
+}
+
+async function main() {
+  let options
+  try {
+    options = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(`ERROR: ${error.message}`)
+    console.error(usage())
+    process.exit(2)
+  }
+  if (options.help) {
+    console.log(usage())
+    return
+  }
+
+  let snapshot
+  try {
+    snapshot = await collectStatus(options)
+  } catch (error) {
+    console.error(`ERROR: failed to collect status: ${error.message}`)
+    process.exit(2)
+  }
+
+  const assessment = buildAssessment(snapshot, { strict: options.strict })
+  if (options.json) {
+    console.log(JSON.stringify({ snapshot, assessment }, null, 2))
+  } else {
+    console.log(renderText(snapshot, assessment))
+  }
+  if (!assessment.ok) process.exit(1)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}
+
+export {
+  FLAG_KEYS,
+  buildAssessment,
+  collectFlagMapFromEnvText,
+  flagEnabled,
+  imageTag,
+  parseArgs,
+  parseContainerInspect,
+  renderText,
+}

--- a/scripts/ops/multitable-global-history-flag-status.test.mjs
+++ b/scripts/ops/multitable-global-history-flag-status.test.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildAssessment,
+  collectFlagMapFromEnvText,
+  flagEnabled,
+  imageTag,
+  parseContainerInspect,
+  renderText,
+} from './multitable-global-history-flag-status.mjs'
+
+test('collectFlagMapFromEnvText returns only Global History flags', () => {
+  const flags = collectFlagMapFromEnvText([
+    'MULTITABLE_ENABLE_PIT_RESET=true',
+    'DATABASE_URL=postgres://secret',
+    'TOKEN=secret',
+    'MULTITABLE_ENABLE_PIT_UNDELETE=false',
+    'MULTITABLE_META_REVISION_RETENTION_ENABLED=1',
+  ].join('\n'))
+
+  assert.equal(flags.MULTITABLE_ENABLE_PIT_RESET, 'true')
+  assert.equal(flags.MULTITABLE_ENABLE_PIT_UNDELETE, 'false')
+  assert.equal(flags.MULTITABLE_META_REVISION_RETENTION_ENABLED, '1')
+  assert.equal(Object.hasOwn(flags, 'DATABASE_URL'), false)
+  assert.equal(Object.hasOwn(flags, 'TOKEN'), false)
+})
+
+test('flagEnabled accepts common true values only', () => {
+  assert.equal(flagEnabled({ A: 'true' }, 'A'), true)
+  assert.equal(flagEnabled({ A: '1' }, 'A'), true)
+  assert.equal(flagEnabled({ A: 'false' }, 'A'), false)
+  assert.equal(flagEnabled({ A: null }, 'A'), false)
+})
+
+test('buildAssessment stops on PIT_RESET plus meta revision retention', () => {
+  const assessment = buildAssessment({
+    backend: { image: 'ghcr.io/zensgit/metasheet2-backend:abc', status: 'running' },
+    web: { image: 'ghcr.io/zensgit/metasheet2-web:abc', status: 'running' },
+    flags: collectFlagMapFromEnvText([
+      'MULTITABLE_ENABLE_PIT_RESET=true',
+      'MULTITABLE_META_REVISION_RETENTION_ENABLED=true',
+    ].join('\n')),
+    health: { ok: true, status: 200, body: { status: 'ok' } },
+  })
+
+  assert.equal(assessment.ok, false)
+  assert.match(assessment.stops.join('\n'), /PIT_RESET/)
+})
+
+test('buildAssessment warns on image tag mismatch and strict turns it into a stop', () => {
+  const snapshot = {
+    backend: { image: 'ghcr.io/zensgit/metasheet2-backend:abc', status: 'running' },
+    web: { image: 'ghcr.io/zensgit/metasheet2-web:def', status: 'running' },
+    flags: collectFlagMapFromEnvText('MULTITABLE_ENABLE_PIT_RESET=false'),
+    health: { ok: true, status: 200, body: { status: 'ok' } },
+  }
+
+  const loose = buildAssessment(snapshot)
+  assert.equal(loose.ok, true)
+  assert.equal(loose.warnings.length, 1)
+
+  const strict = buildAssessment(snapshot, { strict: true })
+  assert.equal(strict.ok, false)
+  assert.match(strict.stops.join('\n'), /strict:/)
+})
+
+test('parseContainerInspect and imageTag parse docker inspect output', () => {
+  const inspect = parseContainerInspect('ghcr.io/zensgit/metasheet2-backend:925932\t running')
+  assert.equal(inspect.image, 'ghcr.io/zensgit/metasheet2-backend:925932')
+  assert.equal(inspect.status, 'running')
+  assert.equal(imageTag(inspect.image), '925932')
+})
+
+test('renderText does not print non-allowlisted env values', () => {
+  const flags = collectFlagMapFromEnvText([
+    'MULTITABLE_ENABLE_SHEET_CONFIG_REVERT=true',
+    'SECRET_TOKEN=do-not-print',
+  ].join('\n'))
+  const snapshot = {
+    backend: { image: 'backend:abc', status: 'running' },
+    web: { image: 'web:abc', status: 'running' },
+    flags,
+    health: null,
+  }
+  const output = renderText(snapshot, buildAssessment(snapshot))
+  assert.match(output, /MULTITABLE_ENABLE_SHEET_CONFIG_REVERT=true/)
+  assert.doesNotMatch(output, /do-not-print/)
+  assert.doesNotMatch(output, /SECRET_TOKEN/)
+})


### PR DESCRIPTION
## Summary

Adds a staging/sandbox operator checklist for Global History flag enablement and a read-only status helper.

- documents preconditions, enablement, rollback, stop conditions, and smoke expectations for the four staging flags
- adds `scripts/ops/multitable-global-history-flag-status.mjs` to inspect backend/web images and the allowlisted flag set without dumping secrets
- adds `node:test` coverage for flag parsing, stop-condition detection, image mismatch handling, and secret-safe rendering

## Safety posture

- docs-only + read-only helper; no runtime behavior changes
- no production flag enablement
- status helper prints only the five allowlisted Global History keys
- PIT_RESET + `MULTITABLE_META_REVISION_RETENTION_ENABLED=true` is a stop condition

## Verification

- `node --test scripts/ops/multitable-global-history-flag-status.test.mjs`
- `node scripts/ops/multitable-global-history-flag-status.mjs --help`
- `METASHEET_STATUS_SSH_HOST=metasheet-main node scripts/ops/multitable-global-history-flag-status.mjs`
  - backend/web both on `925932837965c7e95fa2974dcdbc3a539581bf9b`
  - four staging flags true
  - `MULTITABLE_META_REVISION_RETENTION_ENABLED=(absent)`
  - no stop conditions detected
- `git diff --check`
