### PR TITLE
feat(automation): add T2-6 event dedup ledger

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -297,6 +297,7 @@ jobs:
             tests/integration/multitable-automation-start-approval.test.ts \
             tests/integration/multitable-automation-start-approval-http.test.ts \
             tests/integration/multitable-form-submit-trigger.test.ts \
+            tests/integration/multitable-event-dedup-trigger.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260701120000_create_automation_event_fires.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260701120000_create_automation_event_fires.ts
@@ -1,0 +1,29 @@
+/**
+ * Migration: `meta_automation_event_fires` — event-driven automation idempotency ledger.
+ *
+ * Event-driven triggers (record.created/updated/deleted, form.submitted, and field.value_changed via
+ * record.updated) receive a transport `_eventId` at every emit site. Each matching rule claims
+ * (rule_id, dedup_key) before executing, where dedup_key = `${eventType}:${_eventId}`. The primary key
+ * gives at-most-once side effects for redelivered events without hashing record contents or reading a
+ * deleted record. Missing `_eventId` stays fail-open during rollout; this table only gates stamped events.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_automation_event_fires (
+      rule_id text NOT NULL REFERENCES automation_rules(id) ON DELETE CASCADE,
+      dedup_key text NOT NULL,
+      fired_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (rule_id, dedup_key)
+    )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_event_fires_fired_at
+    ON meta_automation_event_fires (fired_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_automation_event_fires`.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-event-dedup.ts
+++ b/packages/core-backend/src/multitable/automation-event-dedup.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from 'crypto'
+
+export const EVENT_DEDUP_RETENTION_DAYS = 7
+export const EVENT_DEDUP_LEDGER_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+export function newAutomationEventId(): string {
+  return randomUUID()
+}
+
+export function withAutomationEventId<T extends Record<string, unknown>>(payload: T): T & { _eventId: string } {
+  return {
+    ...payload,
+    _eventId: newAutomationEventId(),
+  }
+}
+
+export function buildAutomationEventDedupKey(
+  eventType: string,
+  payload: unknown,
+): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+  const record = payload as Record<string, unknown>
+  const eventId = typeof record._eventId === 'string' ? record._eventId.trim() : ''
+  if (!eventId) return null
+  return `${eventType}:${eventId}`
+}
+
+export function eventDedupRetentionCutoffIso(nowMs = Date.now()): string {
+  return new Date(nowMs - EVENT_DEDUP_RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString()
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -5,6 +5,7 @@
 
 import { randomUUID } from 'crypto'
 import { Logger } from '../core/logger'
+import { withAutomationEventId } from './automation-event-dedup'
 import { redactString } from './automation-log-redact'
 import { computeActionFingerprint } from './automation-suspension-service'
 import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
@@ -2084,13 +2085,13 @@ export class AutomationExecutor {
       )
 
       // Emit event for chaining
-      this.deps.eventBus.emit('multitable.record.updated', {
+      this.deps.eventBus.emit('multitable.record.updated', withAutomationEventId({
         sheetId: effectiveSheetId,
         recordId: effectiveRecordId,
         changes: fields,
         actorId: context.actorId,
         _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
-      })
+      }))
 
       // C1 real-time fan-out: invalidate the EFFECTIVE sheet's room (target for cross-base, trigger for
       // same-base) so its gated subscribers see the change live — automation writes were previously
@@ -2190,12 +2191,12 @@ export class AutomationExecutor {
       // Emit event for chaining (mirrors the updated/created emits + the same-base delete sink's
       // `multitable.record.deleted` shape). C1 real-time invalidation fan-out to the target base's room
       // is OUT of this lock — this only emits the domain event; no cross-room publish is wired here.
-      this.deps.eventBus.emit('multitable.record.deleted', {
+      this.deps.eventBus.emit('multitable.record.deleted', withAutomationEventId({
         sheetId: effectiveSheetId,
         recordId: effectiveRecordId,
         actorId: context.actorId,
         _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
-      })
+      }))
 
       // C1 real-time fan-out (see executeUpdateRecord) — invalidate the effective sheet's room.
       this.publishRecordRealtime('record-deleted', effectiveSheetId, effectiveRecordId, gate.crossBase, context)
@@ -2239,13 +2240,13 @@ export class AutomationExecutor {
         [recordId, targetSheetId, JSON.stringify(data)],
       )
 
-      this.deps.eventBus.emit('multitable.record.created', {
+      this.deps.eventBus.emit('multitable.record.created', withAutomationEventId({
         sheetId: targetSheetId,
         recordId,
         data,
         actorId: context.actorId,
         _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
-      })
+      }))
 
       // C1 real-time fan-out (see executeUpdateRecord) — invalidate the target sheet's room.
       this.publishRecordRealtime('record-created', targetSheetId, recordId, gate.crossBase, context)

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -14,6 +14,12 @@ import {
   dateReminderLedgerRetentionCutoffIso,
   type ScheduleDateFieldConfig,
 } from './automation-date-reminder'
+import {
+  buildAutomationEventDedupKey,
+  eventDedupRetentionCutoffIso,
+  EVENT_DEDUP_LEDGER_SWEEP_INTERVAL_MS,
+  withAutomationEventId,
+} from './automation-event-dedup'
 import { isValidIanaTimeZone } from './automation-timezone'
 import { ensureRecordNotLocked } from './record-lock'
 import { publishMultitableSheetRealtime } from './realtime-publish'
@@ -525,6 +531,7 @@ export type AutomationEventPayload = {
   data?: Record<string, unknown>
   changes?: Record<string, unknown>
   actorId?: string | null
+  _eventId?: string
   _automationDepth?: number
   _triggeredBy?: string
 }
@@ -658,6 +665,7 @@ export class AutomationService {
   private suspensionService: AutomationSuspensionService
   private approvalBridgeService: AutomationApprovalBridgeService
   private lastDateReminderLedgerSweepMs = 0
+  private lastEventDedupLedgerSweepMs = 0
   /** Kept for backward-compat with raw SQL in executor actions */
   private queryFn: AutomationQueryFn
 
@@ -1197,6 +1205,47 @@ export class AutomationService {
   }
 
   /**
+   * Delete old event-driven claim rows. These rows are not audit records; they only need to outlive the
+   * maximum expected redelivery window, so T2-6 keeps a short seven-day retention.
+   */
+  async sweepEventDedupLedger(nowMs = Date.now()): Promise<number> {
+    const cutoffIso = eventDedupRetentionCutoffIso(nowMs)
+    const deleted = await sql<{ count: number | string }>`
+      WITH deleted AS (
+        DELETE FROM meta_automation_event_fires
+         WHERE fired_at < ${cutoffIso}
+        RETURNING 1
+      )
+      SELECT count(*)::int AS count FROM deleted
+    `.execute(this.db)
+    return Number(deleted.rows[0]?.count ?? 0)
+  }
+
+  private kickEventDedupLedgerSweepIfDue(nowMs: number): void {
+    if (nowMs - this.lastEventDedupLedgerSweepMs < EVENT_DEDUP_LEDGER_SWEEP_INTERVAL_MS) return
+    this.lastEventDedupLedgerSweepMs = nowMs
+    void this.sweepEventDedupLedger(nowMs)
+      .then((deleted) => {
+        if (deleted > 0) {
+          logger.info(`Automation event dedup ledger retention swept ${deleted} old row(s)`)
+        }
+      })
+      .catch((err) => {
+        logger.warn('Automation event dedup ledger retention sweep failed; continuing event handling', err instanceof Error ? err : undefined)
+      })
+  }
+
+  private async claimEventDelivery(ruleId: string, dedupKey: string): Promise<boolean> {
+    const claim = await sql<{ dedup_key: string }>`
+      INSERT INTO meta_automation_event_fires (rule_id, dedup_key)
+      VALUES (${ruleId}, ${dedupKey})
+      ON CONFLICT DO NOTHING
+      RETURNING dedup_key
+    `.execute(this.db)
+    return claim.rows.length > 0
+  }
+
+  /**
    * Date-reminder scan (`schedule.date_field`). For each record in the rule's sheet whose date field yields a
    * DUE occurrence, claim it in the idempotency ledger and fire the rule once with the record as context.
    *
@@ -1459,12 +1508,21 @@ export class AutomationService {
     const triggerType = TRIGGER_TYPE_BY_EVENT[eventType]
     if (!triggerType) return
 
+    const dedupKey = buildAutomationEventDedupKey(eventType, payload)
+    if (dedupKey) {
+      this.kickEventDedupLedgerSweepIfDue(Date.now())
+    }
+
     for (const rule of rules) {
       const execRule = toExecutorRule(rule)
 
       if (!matchesTrigger(execRule.trigger, triggerType, payload)) continue
 
       try {
+        if (dedupKey) {
+          const claimed = await this.claimEventDelivery(rule.id, dedupKey)
+          if (!claimed) continue
+        }
         await this.executeRule(execRule, payload)
       } catch (err) {
         logger.error(
@@ -1928,13 +1986,13 @@ export class AutomationService {
     // (inherits the trigger's _automationDepth + 1) so a backwrite-driven cascade can't run away.
     const actorId = event.actor?.id ?? null
     const automationDepth = (((bridge.triggerEvent as Record<string, unknown> | null)?._automationDepth as number) ?? 0) + 1
-    this.eventBus.emit('multitable.record.updated', {
+    this.eventBus.emit('multitable.record.updated', withAutomationEventId({
       sheetId: bridge.sheetId,
       recordId: bridge.recordId,
       changes: patch,
       actorId,
       _automationDepth: automationDepth,
-    })
+    }))
     try {
       publishMultitableSheetRealtime({
         spreadsheetId: bridge.sheetId,

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 
 import type { EventBus } from '../integration/events/event-bus'
+import { withAutomationEventId } from './automation-event-dedup'
 import type { MultitableCapabilities } from './access'
 import {
   ensureAttachmentIdsExist as ensureAttachmentIdsExistShared,
@@ -238,7 +239,7 @@ function isUndefinedTableError(err: unknown, tableName: string): boolean {
   const code = typeof (err as { code?: unknown })?.code === 'string' ? (err as { code: string }).code : null
   const message = typeof (err as { message?: unknown })?.message === 'string' ? (err as { message: string }).message : ''
   if (code === '42P01') return message.includes(tableName)
-  return message.includes(`relation \"${tableName}\" does not exist`)
+  return message.includes(`relation "${tableName}" does not exist`)
 }
 
 // Postgres unique_violation (e.g. a primary-key collision from a TOCTOU race on restore).
@@ -740,12 +741,12 @@ export class RecordService {
         patch,
       }],
     })
-    this.eventBus.emit('multitable.record.created', {
+    this.eventBus.emit('multitable.record.created', withAutomationEventId({
       sheetId,
       recordId,
       data: patch,
       actorId,
-    })
+    }))
 
     return {
       recordId,
@@ -858,11 +859,11 @@ export class RecordService {
       recordId,
       recordIds: [recordId],
     })
-    this.eventBus.emit('multitable.record.deleted', {
+    this.eventBus.emit('multitable.record.deleted', withAutomationEventId({
       sheetId,
       recordId,
       actorId,
-    })
+    }))
 
     return {
       recordId,
@@ -1040,7 +1041,7 @@ export class RecordService {
       recordId,
       recordIds: [recordId],
     })
-    this.eventBus.emit('multitable.record.created', { sheetId, recordId, actorId })
+    this.eventBus.emit('multitable.record.created', withAutomationEventId({ sheetId, recordId, actorId }))
 
     return { recordId, sheetId }
   }
@@ -1389,12 +1390,12 @@ export class RecordService {
         patch,
       }],
     })
-    this.eventBus.emit('multitable.record.updated', {
+    this.eventBus.emit('multitable.record.updated', withAutomationEventId({
       sheetId,
       recordId,
       data: patch,
       actorId,
-    })
+    }))
 
     return {
       recordId,

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -16,6 +16,7 @@
 
 import { randomUUID } from 'crypto'
 import type { EventBus } from '../integration/events/event-bus'
+import { withAutomationEventId } from './automation-event-dedup'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import {
   createYjsInvalidationPostCommitHook,
@@ -1335,12 +1336,12 @@ export class RecordWriteService {
         const changes = Object.fromEntries(
           (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
         )
-        this.eventBus.emit('multitable.record.updated', {
+        this.eventBus.emit('multitable.record.updated', withAutomationEventId({
           sheetId,
           recordId: update.recordId,
           changes,
           actorId,
-        })
+        }))
       }
     }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -170,6 +170,7 @@ import {
   preflightDingTalkAutomationUpdate,
   serializeAutomationRule,
 } from '../multitable/automation-service'
+import { withAutomationEventId } from '../multitable/automation-event-dedup'
 import { listAutomationDingTalkGroupDeliveries } from '../multitable/dingtalk-group-delivery-service'
 import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
@@ -1969,7 +1970,7 @@ function isUndefinedTableError(err: unknown, tableName: string): boolean {
   const code = typeof (err as any)?.code === 'string' ? (err as any).code : null
   const msg = typeof (err as any)?.message === 'string' ? (err as any).message : ''
   if (code === '42P01') return msg.includes(tableName)
-  return msg.includes(`relation \"${tableName}\" does not exist`)
+  return msg.includes(`relation "${tableName}" does not exist`)
 }
 
 function mapFieldType(type: string): UniverMetaField['type'] {
@@ -3538,7 +3539,7 @@ async function computeDependentLookupRollupRecords(
   if (sheetIds.length === 0) return []
 
   const fieldRes = await query(
-    'SELECT id, sheet_id, name, type, property, \"order\" FROM meta_fields WHERE sheet_id = ANY($1::text[]) ORDER BY \"order\" ASC',
+    'SELECT id, sheet_id, name, type, property, "order" FROM meta_fields WHERE sheet_id = ANY($1::text[]) ORDER BY "order" ASC',
     [sheetIds],
   )
 
@@ -9472,7 +9473,7 @@ export function univerMetaRouter(): Router {
         }
         for (const recordId of resurrectedIds) { // post-commit realtime, mirrors restoreRecord
           publishMultitableSheetRealtime({ spreadsheetId: sheetId, actorId: undeleteActorId, source: 'multitable', kind: 'record-created', recordId, recordIds: [recordId] })
-          eventBus.emit('multitable.record.created', { sheetId, recordId, actorId: undeleteActorId })
+          eventBus.emit('multitable.record.created', withAutomationEventId({ sheetId, recordId, actorId: undeleteActorId }))
         }
       }
       const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
@@ -9760,7 +9761,7 @@ export function univerMetaRouter(): Router {
           recordPatches: updatedRows.map((r) => ({ recordId: r.recordId, version: r.version, patch: r.patch })),
         })
         for (const row of updatedRows) {
-          eventBus.emit('multitable.record.updated', { sheetId, recordId: row.recordId, changes: row.patch, actorId })
+          eventBus.emit('multitable.record.updated', withAutomationEventId({ sheetId, recordId: row.recordId, changes: row.patch, actorId }))
         }
       }
       if (deletedRecordIds.length > 0) {
@@ -9772,7 +9773,7 @@ export function univerMetaRouter(): Router {
           recordIds: deletedRecordIds,
         })
         for (const recordId of deletedRecordIds) {
-          eventBus.emit('multitable.record.deleted', { sheetId, recordId, actorId })
+          eventBus.emit('multitable.record.deleted', withAutomationEventId({ sheetId, recordId, actorId }))
         }
       }
       return res.json({ ok: true, data: { asOf: asOfIso, strategy: 'reset', revertedCount: updatedRows.length, deletedCount: deletedRecordIds.length, deletedRecordIds } })
@@ -13582,12 +13583,12 @@ export function univerMetaRouter(): Router {
       // unchanged.) Payload is sheetId/recordId only (matchesTrigger + handleEvent key off those, and
       // actions re-read the record) — no raw record.data egress. `mode` distinguishes a new submission
       // ('create') from a form-link edit ('update').
-      eventBus.emit('multitable.form.submitted', {
+      eventBus.emit('multitable.form.submitted', withAutomationEventId({
         sheetId: view.sheetId,
         recordId: record.id,
         actorId: getRequestActorId(req),
         mode: recordId ? 'update' : 'create',
-      })
+      }))
 
       return res.json({
         ok: true,

--- a/packages/core-backend/tests/integration/multitable-event-dedup-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-event-dedup-trigger.test.ts
@@ -1,0 +1,187 @@
+/**
+ * T2-6 event-driven dedup ledger — real DB.
+ *
+ * Runs the real AutomationService handleEvent path and the real update_record action. The event-id key is
+ * transport-scoped (`eventType:_eventId`) and claimed per rule before execution, so a redelivery of the same
+ * emitted event is at-most-once while legitimate later events still fire.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { AutomationService, type AutomationRule } from '../../src/multitable/automation-service'
+import { RecordService } from '../../src/multitable/record-service'
+import type { MultitableCapabilities } from '../../src/multitable/access'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE = `base_t26_${TS}`
+const SHEET = `sheet_t26_${TS}`
+const REC = `rec_t26_${TS}`
+const FLD_VALUE = `fld_t26_value_${TS}`
+const FLD_MARK = `fld_t26_mark_${TS}`
+const ACTOR = `u_t26_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const queryFn = ((sql: string, params?: unknown[]) => poolManager.get().query(sql, params)) as never
+
+const fullCapabilities: MultitableCapabilities = {
+  canRead: true,
+  canCreateRecord: true,
+  canEditRecord: true,
+  canDeleteRecord: true,
+  canManageFields: false,
+  canManageSheetAccess: false,
+  canManageViews: false,
+  canComment: true,
+  canManageAutomation: true,
+  canExport: true,
+}
+
+type TxClient = { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }> }
+
+function recordPoolAdapter() {
+  const pg = poolManager.get()
+  return {
+    query: (sql: string, params?: unknown[]) => pg.query(sql, params),
+    transaction: (handler: (client: TxClient) => Promise<unknown>) => pg.transaction(handler as never),
+  }
+}
+
+async function createRule(svc: AutomationService, name: string, triggerType = 'record.created', triggerConfig: Record<string, unknown> = {}): Promise<AutomationRule> {
+  return svc.createRule(SHEET, {
+    name,
+    triggerType,
+    triggerConfig,
+    actionType: 'update_record',
+    actionConfig: { fields: { [FLD_MARK]: name } },
+    createdBy: ACTOR,
+  })
+}
+
+async function executionCount(ruleId: string): Promise<number> {
+  const res = await q('SELECT count(*)::int AS n FROM multitable_automation_executions WHERE rule_id = $1', [ruleId])
+  return Number((res.rows[0] as { n?: number | string } | undefined)?.n ?? 0)
+}
+
+async function ledgerCount(ruleId: string): Promise<number> {
+  const res = await q('SELECT count(*)::int AS n FROM meta_automation_event_fires WHERE rule_id = $1', [ruleId])
+  return Number((res.rows[0] as { n?: number | string } | undefined)?.n ?? 0)
+}
+
+describeIfDatabase('T2-6 event-driven automation dedup ledger (real DB)', () => {
+  let eventBus: EventBus
+  let svc: AutomationService
+  const ruleIds: string[] = []
+
+  beforeAll(async () => {
+    eventBus = new EventBus()
+    svc = new AutomationService(eventBus, db as never, queryFn)
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'T2-6 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'T2-6 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VALUE, SHEET, 'Value', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_MARK, SHEET, 'Mark', 'string', '{}', 2])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC, SHEET, JSON.stringify({ [FLD_VALUE]: 'initial' })])
+  })
+
+  afterAll(async () => {
+    try { svc?.shutdown() } catch { /* noop */ }
+    await q('DELETE FROM meta_automation_event_fires WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    await q('DELETE FROM automation_rules WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('redelivery with the same _eventId claims once and executes once', async () => {
+    const rule = await createRule(svc, 'same-event')
+    ruleIds.push(rule.id)
+
+    const payload = { sheetId: SHEET, recordId: REC, data: { [FLD_VALUE]: 'x' }, actorId: ACTOR, _eventId: 'evt_same' }
+    await svc.handleEvent('multitable.record.created', payload)
+    await svc.handleEvent('multitable.record.created', payload)
+
+    expect(await ledgerCount(rule.id)).toBe(1)
+    expect(await executionCount(rule.id)).toBe(1)
+  })
+
+  test('different _eventId values are legitimate new deliveries', async () => {
+    const rule = await createRule(svc, 'different-event')
+    ruleIds.push(rule.id)
+
+    await svc.handleEvent('multitable.record.created', { sheetId: SHEET, recordId: REC, data: {}, actorId: ACTOR, _eventId: 'evt_a' })
+    await svc.handleEvent('multitable.record.created', { sheetId: SHEET, recordId: REC, data: {}, actorId: ACTOR, _eventId: 'evt_b' })
+
+    expect(await ledgerCount(rule.id)).toBe(2)
+    expect(await executionCount(rule.id)).toBe(2)
+  })
+
+  test('absent _eventId fails open during rollout', async () => {
+    const rule = await createRule(svc, 'absent-event-id')
+    ruleIds.push(rule.id)
+
+    await svc.handleEvent('multitable.record.created', { sheetId: SHEET, recordId: REC, data: {}, actorId: ACTOR })
+    await svc.handleEvent('multitable.record.created', { sheetId: SHEET, recordId: REC, data: {}, actorId: ACTOR })
+
+    expect(await ledgerCount(rule.id)).toBe(0)
+    expect(await executionCount(rule.id)).toBe(2)
+  })
+
+  test('field.value_changed rides record.updated and dedups on the underlying event id', async () => {
+    const rule = await createRule(svc, 'field-value', 'field.value_changed', { fieldId: FLD_VALUE, condition: 'any' })
+    ruleIds.push(rule.id)
+
+    const payload = { sheetId: SHEET, recordId: REC, changes: { [FLD_VALUE]: 'changed' }, actorId: ACTOR, _eventId: 'evt_field' }
+    await svc.handleEvent('multitable.record.updated', payload)
+    await svc.handleEvent('multitable.record.updated', payload)
+
+    expect(await ledgerCount(rule.id)).toBe(1)
+    expect(await executionCount(rule.id)).toBe(1)
+  })
+
+  test('the same event id claims independently per sibling rule', async () => {
+    const first = await createRule(svc, 'sibling-a')
+    const second = await createRule(svc, 'sibling-b')
+    ruleIds.push(first.id, second.id)
+
+    await svc.handleEvent('multitable.record.created', { sheetId: SHEET, recordId: REC, data: {}, actorId: ACTOR, _eventId: 'evt_sibling' })
+
+    expect(await ledgerCount(first.id)).toBe(1)
+    expect(await ledgerCount(second.id)).toBe(1)
+    expect(await executionCount(first.id)).toBe(1)
+    expect(await executionCount(second.id)).toBe(1)
+  })
+
+  test('real record-service emit site stamps _eventId', async () => {
+    const captured: unknown[] = []
+    const bus = new EventBus()
+    bus.subscribe('multitable.record.created', (payload) => captured.push(payload))
+
+    const service = new RecordService(recordPoolAdapter() as never, bus)
+    const result = await service.createRecord({
+      sheetId: SHEET,
+      data: { [FLD_VALUE]: 'wire' },
+      actorId: ACTOR,
+      capabilities: fullCapabilities,
+    })
+
+    expect(result.recordId).toEqual(expect.any(String))
+    expect(captured).toHaveLength(1)
+    expect(captured[0]).toMatchObject({
+      sheetId: SHEET,
+      recordId: result.recordId,
+      data: { [FLD_VALUE]: 'wire' },
+      actorId: ACTOR,
+      _eventId: expect.any(String),
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
@@ -180,6 +180,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
       recordId: 'rec_1',
       data: { fld_title: 'Updated title' },
       actorId: 'user_patch_1',
+      _eventId: expect.any(String),
     })
   })
 

--- a/packages/core-backend/tests/unit/automation-event-dedup.test.ts
+++ b/packages/core-backend/tests/unit/automation-event-dedup.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildAutomationEventDedupKey,
+  eventDedupRetentionCutoffIso,
+  EVENT_DEDUP_RETENTION_DAYS,
+  newAutomationEventId,
+  withAutomationEventId,
+} from '../../src/multitable/automation-event-dedup'
+
+describe('automation event dedup helpers', () => {
+  it('builds event-type scoped dedup keys from stamped event ids', () => {
+    expect(buildAutomationEventDedupKey('multitable.record.updated', { _eventId: 'evt_1' })).toBe(
+      'multitable.record.updated:evt_1',
+    )
+    expect(buildAutomationEventDedupKey('multitable.record.created', { _eventId: ' evt_2 ' })).toBe(
+      'multitable.record.created:evt_2',
+    )
+  })
+
+  it('fails open when the event id is absent or invalid', () => {
+    expect(buildAutomationEventDedupKey('multitable.record.updated', {})).toBeNull()
+    expect(buildAutomationEventDedupKey('multitable.record.updated', { _eventId: '' })).toBeNull()
+    expect(buildAutomationEventDedupKey('multitable.record.updated', { _eventId: 42 })).toBeNull()
+    expect(buildAutomationEventDedupKey('multitable.record.updated', null)).toBeNull()
+    expect(buildAutomationEventDedupKey('multitable.record.updated', undefined)).toBeNull()
+    expect(buildAutomationEventDedupKey('multitable.record.updated', [])).toBeNull()
+  })
+
+  it('stamps payloads with fresh event ids', () => {
+    const a = withAutomationEventId({ sheetId: 'sheet_1', recordId: 'rec_1' })
+    const b = withAutomationEventId({ sheetId: 'sheet_1', recordId: 'rec_1' })
+    expect(a).toMatchObject({ sheetId: 'sheet_1', recordId: 'rec_1', _eventId: expect.any(String) })
+    expect(a._eventId).not.toBe(b._eventId)
+    expect(newAutomationEventId()).toEqual(expect.any(String))
+  })
+
+  it('computes the seven-day ledger retention cutoff', () => {
+    const now = Date.parse('2026-07-01T12:00:00.000Z')
+    expect(EVENT_DEDUP_RETENTION_DAYS).toBe(7)
+    expect(eventDedupRetentionCutoffIso(now)).toBe('2026-06-24T12:00:00.000Z')
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -299,6 +299,42 @@ describe('AutomationService', () => {
     })
   })
 
+  describe('event dedup ledger', () => {
+    it('does not block event execution on the opportunistic retention sweep', async () => {
+      const rule = createMockRule({ action_type: 'send_notification' })
+      const query = createMockQuery([rule])
+      service = new AutomationService(bus, createMockDb([rule]) as never, query)
+      const emitSpy = vi.spyOn(bus, 'emit')
+      const sweep = vi.fn(() => new Promise<number>(() => {}))
+      const claim = vi.fn(async () => true)
+      const testHooks = service as unknown as {
+        sweepEventDedupLedger: (nowMs?: number) => Promise<number>
+        claimEventDelivery: (ruleId: string, dedupKey: string) => Promise<boolean>
+      }
+      testHooks.sweepEventDedupLedger = sweep
+      testHooks.claimEventDelivery = claim
+
+      const outcome = await Promise.race([
+        service.handleEvent('multitable.record.created', {
+          sheetId: 'sheet1',
+          recordId: 'rec1',
+          data: {},
+          actorId: 'user1',
+          _eventId: 'evt_nonblocking_sweep',
+        }).then(() => 'done'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 25)),
+      ])
+
+      expect(outcome).toBe('done')
+      expect(sweep).toHaveBeenCalledTimes(1)
+      expect(claim).toHaveBeenCalledWith(rule.id, 'multitable.record.created:evt_nonblocking_sweep')
+      expect(emitSpy).toHaveBeenCalledWith('automation.notification', expect.objectContaining({
+        recordId: 'rec1',
+        userIds: ['user_notify'],
+      }))
+    })
+  })
+
   describe('disabled rules', () => {
     it('skips disabled rules (query returns only enabled)', async () => {
       // The query only returns enabled rules, so we simulate empty result

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -183,6 +183,7 @@ describe('RecordService', () => {
       recordId: result.recordId,
       data: { fld_title: 'Alpha' },
       actorId: 'user_1',
+      _eventId: expect.any(String),
     })
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -470,6 +471,7 @@ describe('RecordService', () => {
       sheetId: 'sheet_ops',
       recordId: 'rec_existing',
       actorId: 'user_1',
+      _eventId: expect.any(String),
     })
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -206,6 +206,7 @@ describe('RecordWriteService', () => {
       recordId: 'rec1',
       changes: { fld_name: 'Alice' },
       actorId: 'user1',
+      _eventId: expect.any(String),
     })
   })
 

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
       // ephemeral port against real Postgres, so it is excluded from the default run and wired
       // into the dedicated `Run multitable real-DB integration` job in plugin-tests.yml.
       'tests/integration/multitable-automation-start-approval-http.test.ts',
+      // T2-6 event-driven dedup ledger: DATABASE_URL-gated. Excluded from the no-DB default job so it
+      // does not skip-green, and wired as a WHOLE FILE into the `Run multitable real-DB integration`
+      // job in plugin-tests.yml where it runs against real Postgres every PR.
+      'tests/integration/multitable-event-dedup-trigger.test.ts',
       // comments.api.test.ts needs setup.integration.ts + a live DB. It stays
       // CI-excluded (NOT wired) because 8 of its tests have a pre-existing real-wire
       // failure (CommentService.mapRowToComment drops containerId/targetId/


### PR DESCRIPTION
## Summary

Implements T2-6 on the ratified #3385 register defaults: event-driven automation triggers now carry a transport `_eventId`, and each matching rule claims `(rule_id, dedup_key)` before executing so redelivered events are at-most-once while legitimate later events still fire.

## Scope

- Adds `meta_automation_event_fires` with `PRIMARY KEY (rule_id, dedup_key)` and a `fired_at` retention index.
- Adds `automation-event-dedup.ts` helpers:
  - `_eventId` stamping for supported emit sites.
  - `dedupKey = ${eventType}:${_eventId}`.
  - absent/invalid `_eventId` fail-open during rollout.
  - 7-day retention cutoff.
- Wires `_eventId` onto `multitable.record.created`, `multitable.record.updated`, `multitable.record.deleted`, and `multitable.form.submitted` emit sites, including chained automation writes and W7 backwrite fan-out.
- `field.value_changed` rides `multitable.record.updated`, so it dedups on the underlying event id.
- Leaves `webhook.received` and `approval.*` out of scope, per the register.
- Wires the real-DB test file into the multitable integration lane and excludes it from the no-DB default run so it cannot skip-green.

## Verification

- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/automation-event-dedup.test.ts tests/unit/multitable-automation-service.test.ts tests/unit/record-service.test.ts tests/unit/record-write-service.test.ts --reporter=dot` — 121/121
- `DATABASE_URL=postgresql://postgres@localhost:5432/metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-event-dedup-trigger.test.ts tests/integration/multitable-form-submit-trigger.test.ts tests/integration/multitable-date-reminder-trigger.test.ts --reporter=dot` — 29/29
- `pnpm --filter @metasheet/core-backend exec eslint src/multitable/automation-event-dedup.ts --max-warnings=0`
- `git diff --check HEAD~1..HEAD`

## Notes

A full-file targeted ESLint run over the long touched legacy files still reports pre-existing lint debt unrelated to this PR (`record-write-service.ts`, `univer-meta.ts`). The new helper itself is lint-clean, and the behavior is covered by unit + real-DB integration tests.
