### PR TITLE
feat(workflow): wire BPMN HTTP tasks through pinned egress

### DIFF
--- a/packages/core-backend/src/guards/__tests__/egress-pinned-transport.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-pinned-transport.test.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, test } from 'vitest'
+
+import {
+  pinnedHttpsJsonRequest,
+  type HttpsRequestFn,
+} from '../egress-pinned-transport'
+
+function makeFakeRequest(
+  status: number,
+  responseBody: string,
+  mode: { timeout?: boolean; error?: Error } = {},
+) {
+  let captured: { address: string; family: number } | null = null
+  let capturedHeaders: Record<string, string> = {}
+  const writes: string[] = []
+
+  const request = ((_url: unknown, options: any, cb: any) => {
+    capturedHeaders = options.headers ?? {}
+    const req: any = new EventEmitter()
+    req.write = (chunk: string) => { writes.push(String(chunk)) }
+    req.destroy = () => {}
+    req.end = () => {
+      options.lookup('rebind.attacker.example', {}, (_e: unknown, address: string, family: number) => {
+        captured = { address, family }
+      })
+      if (mode.error) { setImmediate(() => req.emit('error', mode.error)); return }
+      if (mode.timeout) { setImmediate(() => req.emit('timeout')); return }
+      const res: any = new EventEmitter()
+      res.statusCode = status
+      res.headers = { 'content-type': 'application/json', location: '/next' }
+      res.destroy = () => {}
+      setImmediate(() => {
+        cb(res)
+        res.emit('data', Buffer.from(responseBody))
+        res.emit('end')
+      })
+    }
+    return req
+  }) as unknown as HttpsRequestFn
+
+  return { request, captured: () => captured, headers: () => capturedHeaders, writes: () => writes }
+}
+
+describe('pinned HTTPS JSON transport', () => {
+  test('connects to the pinned address, preserves Host/SNI identity, and parses bounded JSON', async () => {
+    const fake = makeFakeRequest(200, '{"ok":true}')
+
+    const response = await pinnedHttpsJsonRequest(
+      {
+        normalizedUrl: 'https://api.example.com/hook',
+        hostname: 'api.example.com',
+        pinnedAddress: '8.8.8.8',
+        family: 4,
+        method: 'POST',
+        headers: { Host: 'evil.example.com', 'X-Keep': 'yes' },
+        body: '{"hello":"world"}',
+        redirect: 'manual',
+        redirectCount: 0,
+      },
+      { timeoutMs: 1000, maxResponseBytes: 1024, requestImpl: fake.request },
+    )
+
+    expect(response).toMatchObject({
+      status: 200,
+      body: { ok: true },
+      headers: { location: '/next' },
+    })
+    expect(fake.captured()).toEqual({ address: '8.8.8.8', family: 4 })
+    expect(fake.headers()).toMatchObject({ host: 'api.example.com', 'X-Keep': 'yes' })
+    expect(fake.headers().Host).toBeUndefined()
+    expect(fake.writes()).toEqual(['{"hello":"world"}'])
+  })
+
+  test('rejects oversized responses before surfacing a body', async () => {
+    const fake = makeFakeRequest(200, '{"too":"large"}')
+
+    await expect(pinnedHttpsJsonRequest(
+      {
+        normalizedUrl: 'https://api.example.com/hook',
+        hostname: 'api.example.com',
+        pinnedAddress: '8.8.8.8',
+        family: 4,
+        method: 'GET',
+        headers: {},
+        redirect: 'manual',
+        redirectCount: 0,
+      },
+      { timeoutMs: 1000, maxResponseBytes: 4, requestImpl: fake.request },
+    )).rejects.toThrow('pinned egress response exceeded size limit')
+  })
+})

--- a/packages/core-backend/src/guards/egress-pinned-transport.ts
+++ b/packages/core-backend/src/guards/egress-pinned-transport.ts
@@ -1,0 +1,129 @@
+import https from 'node:https'
+import type { IncomingMessage } from 'node:http'
+
+import type {
+  PinnedEgressRequest,
+  PinnedEgressResponse,
+  PinnedEgressTransport,
+} from './egress-dispatcher'
+
+export type HttpsRequestFn = typeof https.request
+
+export interface PinnedHttpsJsonTransportOptions {
+  timeoutMs?: number
+  maxResponseBytes?: number
+  requestImpl?: HttpsRequestFn
+}
+
+export const DEFAULT_PINNED_HTTPS_JSON_TIMEOUT_MS = 5_000
+export const DEFAULT_PINNED_HTTPS_JSON_MAX_RESPONSE_BYTES = 1024 * 1024
+
+function stripCallerHost(headers: Readonly<Record<string, string>>): Record<string, string> {
+  const safeHeaders: Record<string, string> = {}
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === 'host') continue
+    safeHeaders[key] = value
+  }
+  return safeHeaders
+}
+
+function responseHeaders(res: IncomingMessage): PinnedEgressResponse['headers'] {
+  const headers: Record<string, string | readonly string[] | undefined> = {}
+  for (const [key, value] of Object.entries(res.headers)) {
+    if (typeof value === 'number') {
+      headers[key] = String(value)
+    } else {
+      headers[key] = value
+    }
+  }
+  return headers
+}
+
+function parseJsonResponse(raw: string): unknown {
+  if (raw.length === 0) return null
+  return JSON.parse(raw) as unknown
+}
+
+export function createPinnedHttpsJsonTransport(
+  options: PinnedHttpsJsonTransportOptions = {},
+): PinnedEgressTransport {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PINNED_HTTPS_JSON_TIMEOUT_MS
+  const maxResponseBytes = options.maxResponseBytes ?? DEFAULT_PINNED_HTTPS_JSON_MAX_RESPONSE_BYTES
+  const requestImpl = options.requestImpl ?? https.request
+
+  return async (request) => pinnedHttpsJsonRequest(request, { timeoutMs, maxResponseBytes, requestImpl })
+}
+
+export async function pinnedHttpsJsonRequest(
+  request: PinnedEgressRequest,
+  options: Required<PinnedHttpsJsonTransportOptions>,
+): Promise<PinnedEgressResponse> {
+  return await new Promise<PinnedEgressResponse>((resolve, reject) => {
+    let settled = false
+    const finish = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      fn()
+    }
+
+    const url = new URL(request.normalizedUrl)
+    const safeHeaders = stripCallerHost(request.headers)
+    safeHeaders.host = url.host
+
+    const req = options.requestImpl(
+      request.normalizedUrl,
+      {
+        method: request.method,
+        headers: safeHeaders,
+        timeout: options.timeoutMs,
+        servername: request.hostname,
+        lookup: (_hostname: string, _options: unknown, cb: (err: Error | null, address: string, family: number) => void) => {
+          cb(null, request.pinnedAddress, request.family)
+        },
+      } as https.RequestOptions,
+      (res: IncomingMessage) => {
+        const status = res.statusCode ?? 0
+        const chunks: Buffer[] = []
+        let totalBytes = 0
+
+        res.on('data', (chunk: Buffer | string) => {
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+          totalBytes += buffer.length
+          if (totalBytes > options.maxResponseBytes) {
+            const error = new Error('pinned egress response exceeded size limit')
+            res.destroy(error)
+            finish(() => reject(error))
+            return
+          }
+          chunks.push(buffer)
+        })
+
+        res.on('end', () => {
+          finish(() => {
+            try {
+              resolve({
+                status,
+                headers: responseHeaders(res),
+                body: parseJsonResponse(Buffer.concat(chunks).toString('utf8')),
+              })
+            } catch {
+              reject(new Error('pinned egress response JSON parse failed'))
+            }
+          })
+        })
+
+        res.on('error', (error: Error) => finish(() => reject(error)))
+      },
+    )
+
+    req.on('error', (error: Error) => finish(() => reject(error)))
+    req.on('timeout', () => {
+      const error = new Error('pinned egress request timed out')
+      req.destroy(error)
+      finish(() => reject(error))
+    })
+
+    if (typeof request.body === 'string' && request.body.length > 0) req.write(request.body)
+    req.end()
+  })
+}

--- a/packages/core-backend/src/workflow/BPMNWorkflowEngine.ts
+++ b/packages/core-backend/src/workflow/BPMNWorkflowEngine.ts
@@ -4,11 +4,19 @@
  */
 
 import { EventEmitter } from 'events'
+import { lookup } from 'node:dns/promises'
 import { db } from '../db/db'
 import { sql } from 'kysely'
 import { Logger } from '../core/logger'
 import { v4 as uuidv4 } from 'uuid'
 import { metrics } from '../metrics/metrics'
+import {
+  dispatchPinnedEgressRequest,
+  type EgressAddressResolver,
+  type PinnedEgressTransport,
+} from '../guards/egress-dispatcher'
+import { defaultEgressPolicy, type EgressPolicy } from '../guards/egress-guard'
+import { createPinnedHttpsJsonTransport } from '../guards/egress-pinned-transport'
 
 // Types for optional dependencies
 type ScheduledTaskType = { start: () => void; stop: () => void }
@@ -60,6 +68,72 @@ interface BPMNTimerJob {
   activity_id: string
   retries: number
   [key: string]: unknown
+}
+
+export interface BPMNHttpTaskEgressOptions {
+  policy?: EgressPolicy
+  resolveAddresses?: EgressAddressResolver
+  transport?: PinnedEgressTransport
+  maxRedirects?: number
+}
+
+export interface BPMNWorkflowEngineOptions {
+  httpTaskEgress?: BPMNHttpTaskEgressOptions
+}
+
+type HttpTaskHeaderDecision =
+  | { allowed: true; headers: Record<string, string> }
+  | { allowed: false; reason: 'HEADER_NOT_ALLOWED' }
+
+const HTTP_TASK_ALLOWED_METHODS = new Set(['GET', 'POST'])
+const HTTP_TASK_FORBIDDEN_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'forwarded',
+  'host',
+  'proxy-authenticate',
+  'proxy-authorization',
+])
+const HTTP_TASK_MAX_HEADER_COUNT = 32
+const HTTP_TASK_MAX_HEADER_BYTES = 8 * 1024
+const DEFAULT_HTTP_TASK_MAX_REDIRECTS = 3
+
+const resolveDnsAddresses: EgressAddressResolver = async (hostname) => {
+  const records = await lookup(hostname, { all: true, verbatim: true })
+  return records.map((record) => ({
+    address: record.address,
+    family: record.family === 6 ? 6 : 4,
+  }))
+}
+
+function isForbiddenHttpTaskHeader(name: string): boolean {
+  const lower = name.trim().toLowerCase()
+  return HTTP_TASK_FORBIDDEN_HEADERS.has(lower)
+    || lower.startsWith('proxy-')
+    || lower.startsWith('x-forwarded-')
+}
+
+function normalizeHttpTaskHeaders(raw: unknown): HttpTaskHeaderDecision {
+  if (raw === undefined || raw === null) return { allowed: true, headers: {} }
+  if (typeof raw !== 'object' || Array.isArray(raw)) return { allowed: false, reason: 'HEADER_NOT_ALLOWED' }
+
+  const headers: Record<string, string> = {}
+  let totalBytes = 0
+  const entries = Object.entries(raw as Record<string, unknown>)
+  if (entries.length > HTTP_TASK_MAX_HEADER_COUNT) return { allowed: false, reason: 'HEADER_NOT_ALLOWED' }
+  for (const [key, value] of entries) {
+    if (!key || isForbiddenHttpTaskHeader(key) || typeof value !== 'string') {
+      return { allowed: false, reason: 'HEADER_NOT_ALLOWED' }
+    }
+    totalBytes += Buffer.byteLength(key, 'utf8') + Buffer.byteLength(value, 'utf8')
+    if (totalBytes > HTTP_TASK_MAX_HEADER_BYTES) return { allowed: false, reason: 'HEADER_NOT_ALLOWED' }
+    headers[key] = value
+  }
+  return { allowed: true, headers }
+}
+
+function httpTaskError(reason: string): Error {
+  return new Error(`BPMN_HTTP_EGRESS_DENIED: ${reason}`)
 }
 
 // Dynamic imports for optional dependencies
@@ -143,8 +217,12 @@ export class BPMNWorkflowEngine extends EventEmitter {
   private timerJobs: Map<string, ScheduledTaskType>
   private messageSubscriptions: Map<string, Set<string>>
   private signalSubscriptions: Map<string, Set<string>>
+  private httpTaskEgressPolicy: EgressPolicy
+  private httpTaskResolveAddresses: EgressAddressResolver
+  private httpTaskTransport: PinnedEgressTransport
+  private httpTaskMaxRedirects: number
 
-  constructor() {
+  constructor(options: BPMNWorkflowEngineOptions = {}) {
     super()
     this.logger = new Logger('BPMNWorkflowEngine')
     this.processDefinitions = new Map()
@@ -152,6 +230,11 @@ export class BPMNWorkflowEngine extends EventEmitter {
     this.timerJobs = new Map()
     this.messageSubscriptions = new Map()
     this.signalSubscriptions = new Map()
+    const httpTaskEgress = options.httpTaskEgress ?? {}
+    this.httpTaskEgressPolicy = httpTaskEgress.policy ?? defaultEgressPolicy()
+    this.httpTaskResolveAddresses = httpTaskEgress.resolveAddresses ?? resolveDnsAddresses
+    this.httpTaskTransport = httpTaskEgress.transport ?? createPinnedHttpsJsonTransport()
+    this.httpTaskMaxRedirects = httpTaskEgress.maxRedirects ?? DEFAULT_HTTP_TASK_MAX_REDIRECTS
   }
 
   /**
@@ -542,30 +625,51 @@ export class BPMNWorkflowEngine extends EventEmitter {
   ): Promise<void> {
     const instance = this.runningInstances.get(instanceId)
     const url = this.resolveExpression(props.url, instance?.variables) as string
-    const method = (props.method as string | undefined) || 'GET'
-    const headers = (this.resolveExpression(props.headers, instance?.variables) as Record<string, string> | undefined) || {}
+    const method = typeof props.method === 'string' && props.method.trim()
+      ? props.method.trim().toUpperCase()
+      : 'GET'
+    if (!HTTP_TASK_ALLOWED_METHODS.has(method)) {
+      throw httpTaskError('METHOD_NOT_ALLOWED')
+    }
+
+    const headerDecision = normalizeHttpTaskHeaders(this.resolveExpression(props.headers, instance?.variables))
+    if (headerDecision.allowed === false) {
+      throw httpTaskError(headerDecision.reason)
+    }
+    const headers = { ...headerDecision.headers }
     const body = this.resolveExpression(props.body, instance?.variables)
+    const requestBody = method === 'GET' || body === undefined ? undefined : JSON.stringify(body)
+    if (requestBody !== undefined && !Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')) {
+      headers['Content-Type'] = 'application/json'
+    }
 
     try {
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-          ...headers
+      const decision = await dispatchPinnedEgressRequest(
+        {
+          url,
+          method,
+          headers,
+          body: requestBody,
         },
-        body: body ? JSON.stringify(body) : undefined
-      })
-
-      const responseData = await response.json() as unknown
+        {
+          policy: this.httpTaskEgressPolicy,
+          resolveAddresses: this.httpTaskResolveAddresses,
+          transport: this.httpTaskTransport,
+          maxRedirects: this.httpTaskMaxRedirects,
+        },
+      )
+      if (decision.allowed === false) {
+        throw httpTaskError(decision.reason)
+      }
 
       // Store response if variable specified
       if (props.responseVariable) {
         await this.updateProcessVariables(instanceId, {
-          [props.responseVariable as string]: responseData
+          [props.responseVariable as string]: decision.response.body
         })
       }
 
-      this.logger.info(`HTTP task completed: ${method} ${url}`)
+      this.logger.info(`HTTP task completed: ${method} ${new URL(decision.finalUrl).hostname}`)
     } catch (error: unknown) {
       this.logger.error(`HTTP task failed: ${error}`)
       throw error

--- a/packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts
+++ b/packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  BPMNWorkflowEngine,
+  type ProcessInstance,
+} from '../BPMNWorkflowEngine'
+import type { PinnedEgressRequest, PinnedEgressTransport } from '../../guards/egress-dispatcher'
+import type { EgressPolicy } from '../../guards/egress-guard'
+
+function testInstance(id = 'inst_1'): ProcessInstance {
+  return {
+    id,
+    processDefinitionId: 'proc_def_1',
+    processDefinitionKey: 'test_process',
+    state: 'ACTIVE',
+    variables: {},
+    startTime: new Date('2026-07-01T00:00:00Z'),
+  }
+}
+
+function makeEngine(options: {
+  policy?: EgressPolicy
+  resolvedAddress?: string
+  transport?: PinnedEgressTransport
+} = {}) {
+  const calls: PinnedEgressRequest[] = []
+  let resolved = false
+  let transported = false
+  const transport = options.transport ?? (async (request: PinnedEgressRequest) => {
+    transported = true
+    calls.push(request)
+    return { status: 200, body: { ok: true } }
+  })
+  const engine = new BPMNWorkflowEngine({
+    httpTaskEgress: {
+      policy: options.policy,
+      resolveAddresses: async () => {
+        resolved = true
+        return [{ address: options.resolvedAddress ?? '8.8.8.8', family: 4 }]
+      },
+      transport,
+    },
+  })
+  return {
+    engine,
+    calls,
+    resolved: () => resolved,
+    transported: () => transported,
+  }
+}
+
+function installInstance(engine: BPMNWorkflowEngine, instance: ProcessInstance) {
+  const anyEngine = engine as any
+  anyEngine.runningInstances.set(instance.id, instance)
+  anyEngine.updateProcessVariables = async (_instanceId: string, variables: Record<string, unknown>) => {
+    instance.variables = { ...instance.variables, ...variables }
+  }
+}
+
+async function executeHttpTask(
+  engine: BPMNWorkflowEngine,
+  instanceId: string,
+  props: Record<string, unknown>,
+) {
+  await (engine as any).executeHttpTask(instanceId, props)
+}
+
+describe('BPMN HTTP task egress wiring', () => {
+  test('routes HTTP tasks through the pinned egress dispatcher and stores the JSON body', async () => {
+    const { engine, calls } = makeEngine({ policy: { allowedHosts: ['api.example.com'] } })
+    const instance = testInstance()
+    installInstance(engine, instance)
+
+    await executeHttpTask(engine, instance.id, {
+      url: 'https://api.example.com/hook',
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+      body: { hello: 'world' },
+      responseVariable: 'httpResult',
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      normalizedUrl: 'https://api.example.com/hook',
+      hostname: 'api.example.com',
+      pinnedAddress: '8.8.8.8',
+      family: 4,
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: '{"hello":"world"}',
+      redirect: 'manual',
+    })
+    expect(instance.variables.httpResult).toEqual({ ok: true })
+  })
+
+  test('fails closed by default before DNS or transport when no allowlist policy is configured', async () => {
+    const { engine, resolved, transported } = makeEngine()
+    const instance = testInstance()
+    installInstance(engine, instance)
+
+    await expect(executeHttpTask(engine, instance.id, {
+      url: 'https://api.example.com/hook',
+      responseVariable: 'httpResult',
+    })).rejects.toThrow('BPMN_HTTP_EGRESS_DENIED: ALLOWLIST_REQUIRED')
+
+    expect(resolved()).toBe(false)
+    expect(transported()).toBe(false)
+    expect(instance.variables.httpResult).toBeUndefined()
+  })
+
+  test('blocks private DNS answers before transport', async () => {
+    const { engine, transported } = makeEngine({
+      policy: { allowedHosts: ['api.example.com'] },
+      resolvedAddress: '169.254.169.254',
+    })
+    const instance = testInstance()
+    installInstance(engine, instance)
+
+    await expect(executeHttpTask(engine, instance.id, {
+      url: 'https://api.example.com/hook',
+      responseVariable: 'httpResult',
+    })).rejects.toThrow('BPMN_HTTP_EGRESS_DENIED: DNS_IP_BLOCKED')
+
+    expect(transported()).toBe(false)
+    expect(instance.variables.httpResult).toBeUndefined()
+  })
+
+  test('rejects unsafe methods and credential/forwarding headers before dispatch', async () => {
+    const { engine, resolved, transported } = makeEngine({ policy: { allowedHosts: ['api.example.com'] } })
+    const instance = testInstance()
+    installInstance(engine, instance)
+
+    await expect(executeHttpTask(engine, instance.id, {
+      url: 'https://api.example.com/hook',
+      method: 'DELETE',
+    })).rejects.toThrow('BPMN_HTTP_EGRESS_DENIED: METHOD_NOT_ALLOWED')
+
+    for (const headers of [
+      { Host: 'evil.example.com' },
+      { Authorization: 'Bearer SECRET_TOKEN' },
+      { Cookie: 'session=SECRET' },
+      { Forwarded: 'for=127.0.0.1' },
+      { 'X-Forwarded-Host': 'internal.local' },
+      { 'Proxy-Authorization': 'Basic SECRET' },
+    ]) {
+      await expect(executeHttpTask(engine, instance.id, {
+        url: 'https://api.example.com/hook',
+        headers,
+      })).rejects.toThrow('BPMN_HTTP_EGRESS_DENIED: HEADER_NOT_ALLOWED')
+    }
+
+    expect(resolved()).toBe(false)
+    expect(transported()).toBe(false)
+  })
+
+  test('rejects oversized header sets before dispatch', async () => {
+    const { engine, resolved, transported } = makeEngine({ policy: { allowedHosts: ['api.example.com'] } })
+    const instance = testInstance()
+    installInstance(engine, instance)
+
+    await expect(executeHttpTask(engine, instance.id, {
+      url: 'https://api.example.com/hook',
+      headers: Object.fromEntries(Array.from({ length: 33 }, (_, index) => [`X-Test-${index}`, 'ok'])),
+    })).rejects.toThrow('BPMN_HTTP_EGRESS_DENIED: HEADER_NOT_ALLOWED')
+
+    await expect(executeHttpTask(engine, instance.id, {
+      url: 'https://api.example.com/hook',
+      headers: { 'X-Large': 'x'.repeat(8 * 1024) },
+    })).rejects.toThrow('BPMN_HTTP_EGRESS_DENIED: HEADER_NOT_ALLOWED')
+
+    expect(resolved()).toBe(false)
+    expect(transported()).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/unit/workflow-approval-automation-convergence.guard.test.ts
+++ b/packages/core-backend/tests/unit/workflow-approval-automation-convergence.guard.test.ts
@@ -87,11 +87,13 @@ function tableWriteSites(src: string, tablePattern: string): string[] {
  *                    product dependencies (doctrine §5).
  *   PREVIEW        — Workflow Designer compile-preview / gap-report. Read-only,
  *                    no live execution (doctrine §3.3).
+ *   TEST           — structural/security regression tests only. Not a runtime
+ *                    consumer and not a reason to expand product dependencies.
  *
  * Adding a file here is a deliberate, reviewable act. Approval and automation
  * runtime code must NEVER appear in this list (see the dedicated test below).
  */
-const BPMN_IMPORT_ALLOWLIST: Array<{ file: string; disposition: 'LEGACY-RUNTIME' | 'PREVIEW'; reason: string }> = [
+const BPMN_IMPORT_ALLOWLIST: Array<{ file: string; disposition: 'LEGACY-RUNTIME' | 'PREVIEW' | 'TEST'; reason: string }> = [
   {
     file: 'routes/workflow.ts',
     disposition: 'LEGACY-RUNTIME',
@@ -101,6 +103,11 @@ const BPMN_IMPORT_ALLOWLIST: Array<{ file: string; disposition: 'LEGACY-RUNTIME'
     file: 'routes/workflow-designer.ts',
     disposition: 'PREVIEW',
     reason: 'Workflow Designer compile-preview / gap-report only — no live execution (doctrine §3.3).',
+  },
+  {
+    file: 'workflow/__tests__/BPMNWorkflowEngine.egress.test.ts',
+    disposition: 'TEST',
+    reason: 'R1 BPMN HTTP-task SSRF closure regression tests only — not a product runtime consumer.',
   },
 ]
 


### PR DESCRIPTION
## Summary

Closes the live R1 BPMN HTTP-task SSRF execution path by replacing `BPMNWorkflowEngine.executeHttpTask`'s raw `fetch(url, ...)` with the ratified pinned-egress dispatcher.

This builds on the already-landed R1-A guard and dispatcher primitives:

- `validateEgressUrl` / IP classifier / allowlist policy.
- `dispatchPinnedEgressRequest` with DNS resolution, post-resolution IP checks, redirect re-validation, and pinned target handoff.

## What changed

- Adds `egress-pinned-transport.ts`, an HTTPS JSON transport that:
  - connects through a pinned IP via custom `lookup`;
  - preserves the original hostname for Host/SNI;
  - disables caller Host override;
  - bounds timeout and response body size;
  - parses JSON response bodies for the existing `responseVariable` contract.
- Wires `BPMNWorkflowEngine.executeHttpTask` to `dispatchPinnedEgressRequest`.
- Enforces the ratified D4 policy at the engine boundary:
  - `GET` / `POST` only;
  - rejects caller-set `Authorization`, `Cookie`, `Host`, `Proxy-*`, `Forwarded`, and `X-Forwarded-*`;
  - caps header count and total header bytes.
- Keeps default runtime fail-closed: no configured allowlist means no outbound HTTP task is dispatched.
- Classifies the new engine egress regression test in the convergence guard allowlist as TEST only, so the legacy BPMN runtime fence remains explicit.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/workflow-approval-automation-convergence.guard.test.ts src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts src/guards/__tests__/egress-pinned-transport.test.ts src/guards/__tests__/egress-dispatcher.test.ts src/guards/__tests__/egress-guard.test.ts --reporter=dot` — 75/75
- `pnpm --filter @metasheet/core-backend type-check`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend exec eslint src/workflow/BPMNWorkflowEngine.ts src/guards/egress-pinned-transport.ts --max-warnings=0`
- `git diff --check`

## Review focus

- The raw `fetch` in `BPMNWorkflowEngine.executeHttpTask` is gone.
- Denied URL / DNS / header / method paths fail before transport.
- Allowed path uses the dispatcher-normalized URL and the pinned address handoff.
- Default empty allowlist is intentionally fail-closed per R1 D3.
