### PR TITLE
docs(approval): reconcile automation plan as-built state

### DIFF
--- a/docs/development/approval-automation-parallel-development-plan-20260701.md
+++ b/docs/development/approval-automation-parallel-development-plan-20260701.md
@@ -1,10 +1,11 @@
 # Approval & Process-Automation — un-completed items, parallel-development plan & verification (2026-07-01)
 
-> **As-built coordination plan** (updated to main after `#3437`/`#3443`/`#3446` merged). Deep review of what
+> **As-built coordination plan** (updated to main after `#3451`/`#3452`/`#3450`/`#3453` merged). Deep review of what
 > remains on the line, classified by gating and **sequenced into parallel lanes** so work distributes across
 > sessions without hot-file collision. **Shipped since the first cut:** T2-4 re-entry quorum-bypass (`#3446`,
-> `to_version >= cutoff`) + the R1-A egress guard/classifier (`#3437`/`#3443`). **Honest framing:** the
-> remainder is owner-gated (design-lock-first) or in flight (R1-B) — so "complete all development" is realized by
+> `to_version >= cutoff`) + same-version cascade regression (`#3453`), R1-A/R1-B egress closure (`#3437`/`#3443`/
+> `#3447`/`#3451`), A3 rollout design-lock (`#3452`), and T2-6 event dedup ledger (`#3450`). **Honest framing:** the
+> remainder is owner-gated (design-lock-first) — so "complete all development" is realized by
 > *ratifying defaults **per lane/rung** (not blanket — it mixes SSRF / destructive-delete / permission-migration
 > / cross-base-writeback risk) + distributing the lanes*, not one session building everything.
 
@@ -12,20 +13,27 @@
 - **Tier-1:** T2-3 analytics, T1-1 node-SLA slice-1 (remind-only), T2-4 threshold mode, T2-5 timezone,
   date_field floating-day fix. **Cycle hardenings:** offsetDays save-cap + runtime clamp, analytics Top-N
   tie-break. **W7** approved-path resultWriteback (backend).
-- **R1-A (SSRF) — COMPLETE:** `validateEgressUrl` egress guard + `isBlockedEgressIp` classifier
+- **R1-A/R1-B (SSRF) — DEFAULT-CLOSED COMPLETE:** `validateEgressUrl` egress guard + `isBlockedEgressIp` classifier
   (mapped / NAT64 / 6to4 / Teredo / **ISATAP both u/l forms `0000:5efe`+`0200:5efe` via `(bytes[8] & 0xfd)`** /
-  IPv4-compatible `::/96`). `#3437` (embedded-IPv4 literals) and `#3443` (well-known NAT64 fold) **merged**. The
-  guard is **not wired** to `BPMNWorkflowEngine.ts:550` yet — that call-site wiring is **R1-B** (the remaining slice).
+  IPv4-compatible `::/96`), the IP-pinned dispatcher, and `BPMNWorkflowEngine.executeHttpTask` wiring are merged.
+  Default policy remains deny-all, so the original raw `fetch(url)` full-read SSRF path is closed by default; live
+  destination enablement remains the separate A3 rollout/governance gate.
 - **T2-4 threshold re-entry quorum-bypass — FIXED (`#3446`):** the tally is scoped to the current node-entry
-  round via `to_version >= <re-entry cutoff>` (schema-free, uses existing data); no re-entry → exact old query.
+  round via `to_version >= <re-entry cutoff>` (schema-free, uses existing data); no re-entry -> exact old query.
+  The `#3453` follow-up locks the same-version requester auto-approval cascade boundary that requires `>=`.
+- **T2-6 event dedup ledger — SHIPPED (`#3450`):** automation record-change/form-submit dispatch now has a
+  database-backed event-fire ledger, TTL/count sweep, real-DB coverage, and CI wiring. This removes the substrate
+  blocker for approval-trigger and inbound-webhook work, but those feature rungs remain owner-gated.
 
 ## 2. Un-completed items — gating
 
 | Item | Subsystem | Status | Gating |
 |---|---|---|---|
 | ~~T2-4 threshold re-entry quorum-bypass~~ | approval engine | **SHIPPED (#3446)** | done — `to_version >= re-entry cutoff`, schema-free; CI green |
+| ~~T2-4 same-version cascade regression~~ | approval engine | **SHIPPED (#3453)** | done — locks that same-version auto-approval at re-entry counts under `>=` |
 | ~~ISATAP `0200:5efe` u/l-bit + IPv4-compat~~ | BPMN (guard) | **SHIPPED (#3437/#3443)** | done — classifier folds both ISATAP u/l forms + `::/96` |
-| **R1-B** DNS-pinned dispatcher + wiring + redirect re-validation | BPMN/workflow | unshipped | **ratified-buildable** (D0-D5 ratified, #3437 precondition met) — the remaining R1 slice |
+| ~~R1-B DNS-pinned dispatcher + wiring + redirect re-validation~~ | BPMN/workflow | **SHIPPED (#3447/#3451)** | done — raw BPMN HTTP-task fetch path replaced; default policy deny-all |
+| **R1-A3** policy rollout / configured destination enablement | BPMN/workflow | design-lock shipped, runtime unshipped | owner/governance-gated; `#3452` records server-owned policy source and no live destination authorization |
 | T1-1 slice-2 transfer/jump timeout effects | approval engine | unshipped | owner-gated (transfer/jump **target-config schema** + indirect jump→terminal carve-out; auto_* env-gated) |
 | T2-1+2 scoped admins + handover | approval engine | unshipped | owner-gated (permission model + migration) |
 | T1-4 node field-perms runtime | approval engine | unshipped | owner-gated (edit-form-at-node prerequisite) |
@@ -34,7 +42,7 @@
 | T0-3 delete_record editor | automation engine | unshipped | owner-gated (destructive, 7 decisions) |
 | T1-2 inbound webhook | automation engine | unshipped | owner-gated (signature/replay/audit, 9 decisions) |
 | T1-3 approval.* trigger | automation engine | unshipped | owner-gated (routing/loop/cross-tenant, 8 decisions) |
-| T2-6 event-driven dedup ledger | automation engine | unshipped | owner-gated (substrate for T1-2/T1-3) |
+| ~~T2-6 event-driven dedup ledger~~ | automation engine | **SHIPPED (#3450)** | done — database-backed event fire ledger, sweep, real-DB CI wiring |
 | T3-2 business-calendar SLA · T3-3 signature · T3-1 mobile · T3-6 S-band | product/heavy | unshipped | owner-gated, L (T3-2 dep T1-1) |
 
 ## 3. Parallel-development lanes (the sequencing)
@@ -44,25 +52,28 @@ The constraint is **hot files**: items sharing one runtime file must be **sequen
 edits to `ApprovalProductService.ts` / `automation-service.ts` collide).
 
 - **Lane A — BPMN/workflow** (`BPMNWorkflowEngine.ts`, `routes/workflow*`, `guards/egress-guard.ts`):
-  R1-A guard/classifier **done** (#3437/#3443); **`R1-B`** (DNS-pinned dispatcher + wiring) is the remaining
-  slice. *R1 line active in a parallel session (#3442) — one session owns this; do not fork it.*
+  R1-A guard/classifier **done** (#3437/#3443), dispatcher **done** (#3447), engine wiring **done** (#3451).
+  The remaining BPMN egress work is **A3 policy rollout/configured enablement**, which is a governance gate:
+  server-owned policy source, route-provenance negative controls, and explicit destination enablement. No live
+  destination is authorized by the default-closed R1-B runtime.
 - **Lane B — approval engine** (`ApprovalProductService.ts` — HOT, so sequential): ~~`T2-4 fix`~~ **done (#3446)**
-  → next `T1-1 slice-2` → `T2-1+2` → `T1-4`. (`T3-4/T3-5` W7-backwrite touch `automation-service.ts`, see Lane C.)
-- **Lane C — automation engine** (`automation-service.ts` — HOT, so sequential): `T2-6 dedup` (substrate) →
+  + cascade regression **done (#3453)** → next `T1-1 slice-2` → `T2-1+2` → `T1-4`. (`T3-4/T3-5` W7-backwrite touch
+  `automation-service.ts`, see Lane C.)
+- **Lane C — automation engine** (`automation-service.ts` — HOT, so sequential): ~~`T2-6 dedup`~~ **done (#3450)** →
   `T1-3 approval-trigger` / `T1-2 webhook` → `T0-3 delete_record` → `T3-4`/`T3-5` W7-backwrite.
 - **Lane D — product/heavy** (separate surfaces): `T3-1 mobile`, `T3-6 S-band`, `T3-2 business-calendar`
   (dep T1-1), `T3-3 signature`.
 
-**Hard deps:** R1-B→#3437 (met) · T2-2→T2-1 (permission model) · T3-2→T1-1 (node-SLA) · T1-2/T1-3 lean on
-T2-6 (dedup substrate). **Cross-lane collision risk:** Lane B and the W7 items in Lane C both eventually touch
+**Hard deps:** R1-B→#3437 (met and shipped) · A3→R1-B (met, but A3 remains governance-gated) · T2-2→T2-1
+(permission model) · T3-2→T1-1 (node-SLA) · T1-2/T1-3→T2-6 (met and shipped). **Cross-lane collision risk:** Lane B and the W7 items in Lane C both eventually touch
 approval-completion code — keep W7-backwrite in Lane C to avoid `ApprovalProductService`/`automation-service`
 double-editing.
 
 ## 4. What's ready to build vs needs a decision
-- **Shipped:** T2-4 fix (#3446) · R1-A guard/classifier (#3437/#3443).
-- **Ready now (ratified):** **R1-B** — the remaining R1 slice (D0-D5 ratified, #3437 precondition met); active in
-  a parallel session (#3442).
-- **Owner-gated:** everything else — the register (#3385) holds each rung's open decisions + proposed defaults.
+- **Shipped:** T2-4 fix (#3446) + same-version cascade regression (#3453) · R1-A/R1-B default-closed egress closure
+  (#3437/#3443/#3447/#3451) · T2-6 event dedup ledger (#3450).
+- **Owner-gated:** everything else — including A3 configured destination enablement. The register (#3385) and the
+  follow-up design-locks hold each rung's open decisions + proposed defaults.
   **Approve per lane/rung, not blanket** — the remainder mixes distinct risk surfaces (SSRF wiring, destructive
   delete, permission migration, cross-base write-back), so a single blanket "build on defaults" is unsafe.
 
@@ -84,17 +95,31 @@ exact old whole-node query (zero regression).** The graph is validated acyclic, 
 re-entry path (marker complete). This is **simpler than the epoch proposal** — no new metadata field, no per-node
 counter, no migration.
 
-**Verification (real-DB):** `approval-nofm-threshold` **4/4** incl. a fail-first re-entry test (2-of-3 → A+B
-approve → advance → RETURN → one fresh vote must NOT re-resolve; RED-before confirmed) · N>M fail-closed +
-single-reject unchanged. **Open follow-up:** a dedicated regression for the same-version-cascade `>=` boundary
-(reasoned + cascade write-site confirmed, not yet test-locked).
+**Verification (real-DB):** `approval-nofm-threshold` **5/5** incl. a fail-first re-entry test (2-of-3 -> A+B
+approve -> advance -> RETURN -> one fresh vote must NOT re-resolve; RED-before confirmed) · N>M fail-closed +
+single-reject unchanged · `#3453` same-version requester auto-approval cascade regression (locks the `>=` boundary
+so a future `>` change fails).
 
-## 6. Recommendation
-1. **Done:** T2-4 fix (#3446) · R1-A guard/classifier (#3437/#3443).
-2. **Lane A (R1-B)** — open the DNS-pinned dispatcher + wiring next (closes the live SSRF); active in a parallel
-   session (#3442).
-3. **Ratify register defaults PER LANE/RUNG** (not blanket — the remainder mixes SSRF, destructive delete,
-   permission migration, and cross-base write-back risk surfaces). A good parallel next lane is **T2-6 (dedup
-   ledger)** — an independent Lane C substrate that then unblocks T1-3/T1-2. Within each lane, items sharing a
-   hot file (`ApprovalProductService.ts` / `automation-service.ts`) stay sequential.
+## 6. T2-6 event dedup ledger — AS-BUILT (`#3450`, shipped)
 
+**Bug class / substrate gap:** record-change and form-submit automation events are at-least-once sources; without
+a database-backed fire ledger, redelivery/replay can execute side effects more than once. T1-2 inbound webhook and
+T1-3 approval-trigger both need the same substrate before they can safely expose higher-frequency event sources.
+
+**Shipped implementation:** `meta_automation_event_fires` stores `(rule_id, base_id, event_key)` first-write-wins
+claims, with a bounded retention sweep (TTL + per-rule cap). The executor checks/claims before side effects and
+skips duplicate deliveries without treating them as rule failures. Record-service/write-service integrations feed
+stable event identities for the currently shipped sources.
+
+**Verification:** pure dedup-key tests, automation-service unit coverage, real-DB `multitable-event-dedup-trigger`
+coverage wired into `plugin-tests.yml`, plus regression updates for record-service/write-service callers.
+
+## 7. Recommendation
+1. **Done:** T2-4 fix + cascade regression (#3446/#3453) · R1-A/R1-B default-closed egress closure
+   (#3437/#3443/#3447/#3451) · T2-6 dedup ledger (#3450).
+2. **Next security gate:** A3 egress policy rollout/configured enablement — design-lock shipped in `#3452`, but
+   runtime still requires per-slice owner opt-in. Default runtime remains deny-all until a server-owned policy is
+   explicitly configured.
+3. **Next feature lanes after owner ratification:** Lane C `T1-3 approval-trigger` / `T1-2 inbound webhook`
+   (dedup dependency now met), or Lane B `T1-1 slice-2` (transfer/jump timeout effects). Continue to ratify
+   register defaults **per lane/rung**, not blanket.


### PR DESCRIPTION
## Summary

Docs-only as-built reconciliation for `approval-automation-parallel-development-plan-20260701.md`.

Updates the plan after the latest merged work:
- R1-B is shipped via #3447/#3451; the BPMN HTTP-task raw fetch path is default-closed, with A3 configured destination enablement still owner/governance-gated.
- R1-A3 design-lock is shipped via #3452, but A3 runtime/configured destination enablement remains unshipped and requires per-slice owner opt-in.
- T2-6 event dedup ledger is shipped via #3450, so T1-2/T1-3 no longer have that substrate blocker.
- T2-4 same-version cascade regression is shipped via #3453, so the previous open follow-up is no longer open.

## Boundary

No runtime, migration, workflow route, approval service, or automation engine changes. This PR does not authorize A3 destination enablement, destructive delete, inbound webhook, approval triggers, W7 cross-base, or other owner-gated rungs.

## Verification

- `git diff --check`
- residual-state scan for stale `R1-B remaining`, `T2-6 unshipped`, `open follow-up`, `#3452 in review`, and `active in parallel` wording
