### PR TITLE
feat(workflow): add R1 A3 egress policy normalizer

### DIFF
--- a/packages/core-backend/src/guards/__tests__/egress-policy-normalizer.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-policy-normalizer.test.ts
@@ -113,6 +113,8 @@ describe('R1-A3-a BPMN HTTP-task egress policy normalizer', () => {
 
   test.each([
     '2a00:1098:2c::/64',
+    '2a00:1098:2c::1/96',
+    '64:ff9b::c000:0201/96',
     '8.8.8.0/24',
     'not-a-prefix',
     '2a00:1098:2c::',

--- a/packages/core-backend/src/guards/__tests__/egress-policy-normalizer.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-policy-normalizer.test.ts
@@ -142,6 +142,16 @@ describe('R1-A3-a BPMN HTTP-task egress policy normalizer', () => {
     })
   })
 
+  test('rejects the built-in well-known NAT64 prefix as redundant policy config', () => {
+    expect(normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['api.example.com'],
+      nat64Prefixes: ['64:ff9b::/96'],
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'EGRESS_POLICY_DUPLICATE_NAT64_PREFIX', field: 'nat64Prefixes[]' },
+    })
+  })
+
   test('sorts normalized sets so policy fingerprint is order-independent', () => {
     const first = normalizeBpmnHttpTaskEgressPolicyConfig({
       allowedHosts: ['z.example.com', 'a.example.com'],

--- a/packages/core-backend/src/guards/__tests__/egress-policy-normalizer.test.ts
+++ b/packages/core-backend/src/guards/__tests__/egress-policy-normalizer.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'vitest'
+
+import { normalizeBpmnHttpTaskEgressPolicyConfig } from '../egress-policy-normalizer'
+
+describe('R1-A3-a BPMN HTTP-task egress policy normalizer', () => {
+  test('fails closed when config is missing, empty, or malformed', () => {
+    for (const raw of [undefined, null, '', '   ']) {
+      const result = normalizeBpmnHttpTaskEgressPolicyConfig(raw)
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: 'EGRESS_POLICY_MISSING', field: 'config' },
+        policy: { allowedHosts: [] },
+        metadata: {
+          policyPresent: false,
+          allowedHostCount: 0,
+          nat64PrefixCount: 0,
+          policyFingerprint: null,
+        },
+      })
+    }
+    for (const raw of ['{bad-json', '[]', [], true, 42]) {
+      expect(normalizeBpmnHttpTaskEgressPolicyConfig(raw)).toMatchObject({
+        ok: false,
+        error: { code: 'EGRESS_POLICY_MALFORMED', field: 'config' },
+      })
+    }
+  })
+
+  test('normalizes exact ASCII DNS hosts and values-free metadata', () => {
+    const result = normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['API.Example.com.', 'xn--bcher-kva.example'],
+      nat64Prefixes: ['2A00:1098:2C::/96'],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected policy config to normalize')
+    expect(result.policy).toEqual({
+      allowedHosts: ['api.example.com', 'xn--bcher-kva.example'],
+      nat64Prefixes: ['2a00:1098:2c:0:0:0:0:0/96'],
+    })
+    expect(result.metadata).toMatchObject({
+      policyPresent: true,
+      allowedHostCount: 2,
+      nat64PrefixCount: 1,
+    })
+    expect(result.metadata.policyFingerprint).toMatch(/^[a-f0-9]{16}$/)
+    expect(JSON.stringify(result.metadata)).not.toContain('api.example.com')
+    expect(JSON.stringify(result.metadata)).not.toContain('xn--bcher-kva')
+  })
+
+  test('accepts server-owned JSON config input without echoing config in evidence', () => {
+    const result = normalizeBpmnHttpTaskEgressPolicyConfig(JSON.stringify({
+      allowedHosts: ['Webhook.Example.com'],
+      nat64Prefixes: [],
+    }))
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected JSON policy config to normalize')
+    expect(result.policy.allowedHosts).toEqual(['webhook.example.com'])
+    expect(JSON.stringify(result.metadata)).not.toContain('Webhook')
+  })
+
+  test('rejects empty allowlists and unknown top-level config keys', () => {
+    expect(normalizeBpmnHttpTaskEgressPolicyConfig({ allowedHosts: [] })).toMatchObject({
+      ok: false,
+      error: { code: 'EGRESS_POLICY_EMPTY_ALLOWLIST', field: 'allowedHosts' },
+    })
+    expect(normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['api.example.com'],
+      timeoutMs: 5000,
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'EGRESS_POLICY_UNKNOWN_KEY', field: 'config' },
+    })
+  })
+
+  test.each([
+    'https://api.example.com',
+    'api.example.com/path',
+    'api.example.com?x=1',
+    'api.example.com#frag',
+    'user@api.example.com',
+    'api.example.com:443',
+    '*.example.com',
+    '.example.com',
+    'example.com/24',
+    '8.8.8.8',
+    '2606:4700:4700::1111',
+    'localhost',
+    'service.localhost',
+    'service.local',
+    'service.internal',
+    'api',
+    'bücher.example',
+    'api..example.com',
+    '-api.example.com',
+    'api-.example.com',
+  ])('rejects non-exact-host policy entry %s', (host) => {
+    expect(normalizeBpmnHttpTaskEgressPolicyConfig({ allowedHosts: [host] })).toMatchObject({
+      ok: false,
+      error: { code: 'EGRESS_POLICY_INVALID_HOST', field: 'allowedHosts[]' },
+    })
+  })
+
+  test('rejects duplicate hosts after canonicalization', () => {
+    expect(normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['API.Example.com', 'api.example.com.'],
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'EGRESS_POLICY_DUPLICATE_HOST', field: 'allowedHosts[]' },
+    })
+  })
+
+  test.each([
+    '2a00:1098:2c::/64',
+    '8.8.8.0/24',
+    'not-a-prefix',
+    '2a00:1098:2c::',
+    '64:ff9b::/６',
+  ])('rejects malformed or non-/96 NAT64 prefix %s', (prefix) => {
+    expect(normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['api.example.com'],
+      nat64Prefixes: [prefix],
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'EGRESS_POLICY_INVALID_NAT64_PREFIX', field: 'nat64Prefixes[]' },
+    })
+  })
+
+  test('rejects duplicate NAT64 prefixes after normalization', () => {
+    expect(normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['api.example.com'],
+      nat64Prefixes: [
+        '2A00:1098:2C::/96',
+        '2a00:1098:002c:0000:0000:0000:0000:0000/96',
+      ],
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'EGRESS_POLICY_DUPLICATE_NAT64_PREFIX', field: 'nat64Prefixes[]' },
+    })
+  })
+
+  test('sorts normalized sets so policy fingerprint is order-independent', () => {
+    const first = normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['z.example.com', 'a.example.com'],
+      nat64Prefixes: ['2a00:1098:2c::/96', '2a01:1098:2c::/96'],
+    })
+    const second = normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['A.Example.com.', 'z.example.com'],
+      nat64Prefixes: ['2A01:1098:002C:0000:0000:0000:0000:0000/96', '2a00:1098:2c::/96'],
+    })
+
+    expect(first.ok).toBe(true)
+    expect(second.ok).toBe(true)
+    if (!first.ok || !second.ok) throw new Error('expected both policies to normalize')
+    expect(first.policy).toEqual(second.policy)
+    expect(first.metadata.policyFingerprint).toBe(second.metadata.policyFingerprint)
+    expect(first.policy.allowedHosts).toEqual(['a.example.com', 'z.example.com'])
+    expect(first.policy.nat64Prefixes).toEqual([
+      '2a00:1098:2c:0:0:0:0:0/96',
+      '2a01:1098:2c:0:0:0:0:0/96',
+    ])
+  })
+
+  test('error result is values-free and never echoes rejected host or secret-shaped config', () => {
+    const result = normalizeBpmnHttpTaskEgressPolicyConfig({
+      allowedHosts: ['secret-customer-host.example.com/path'],
+      bearerToken: 'SECRET-TOKEN-NEVER-ECHO',
+    })
+
+    expect(result.ok).toBe(false)
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('secret-customer-host')
+    expect(serialized).not.toContain('SECRET-TOKEN')
+    expect(serialized).not.toContain('/path')
+  })
+})

--- a/packages/core-backend/src/guards/egress-policy-normalizer.ts
+++ b/packages/core-backend/src/guards/egress-policy-normalizer.ts
@@ -46,6 +46,9 @@ export type EgressPolicyNormalizationResult =
     }
 
 const ALLOWED_CONFIG_KEYS = new Set(['allowedHosts', 'nat64Prefixes'])
+// The guard always decodes RFC 6052's well-known NAT64 prefix; server policy
+// config only carries extra deployment-specific prefixes.
+const BUILT_IN_NAT64_PREFIXES = new Set(['64:ff9b:0:0:0:0:0:0/96'])
 
 function disabledMetadata(): Readonly<EgressPolicyMetadata> {
   return Object.freeze({
@@ -171,6 +174,7 @@ export function normalizeBpmnHttpTaskEgressPolicyConfig(rawConfig: unknown): Egr
   for (const entry of rawNat64Prefixes) {
     const prefix = normalizeNat64Prefix(entry)
     if (!prefix) return fail('EGRESS_POLICY_INVALID_NAT64_PREFIX', 'nat64Prefixes[]')
+    if (BUILT_IN_NAT64_PREFIXES.has(prefix)) return fail('EGRESS_POLICY_DUPLICATE_NAT64_PREFIX', 'nat64Prefixes[]')
     if (seenPrefixes.has(prefix)) return fail('EGRESS_POLICY_DUPLICATE_NAT64_PREFIX', 'nat64Prefixes[]')
     seenPrefixes.add(prefix)
     nat64Prefixes.push(prefix)

--- a/packages/core-backend/src/guards/egress-policy-normalizer.ts
+++ b/packages/core-backend/src/guards/egress-policy-normalizer.ts
@@ -128,6 +128,7 @@ function normalizeNat64Prefix(value: unknown): string | null {
   try {
     const cidr = ipaddr.parseCIDR(raw)
     if (cidr[0].kind() !== 'ipv6' || cidr[1] !== 96) return null
+    if (cidr[0].toByteArray().slice(12).some((byte) => byte !== 0)) return null
     return `${cidr[0].toNormalizedString()}/96`
   } catch {
     return null

--- a/packages/core-backend/src/guards/egress-policy-normalizer.ts
+++ b/packages/core-backend/src/guards/egress-policy-normalizer.ts
@@ -1,0 +1,190 @@
+import { createHash } from 'crypto'
+import * as ipaddr from 'ipaddr.js'
+
+import { defaultEgressPolicy, type EgressPolicy } from './egress-guard'
+
+export type EgressPolicyConfigErrorCode =
+  | 'EGRESS_POLICY_MISSING'
+  | 'EGRESS_POLICY_MALFORMED'
+  | 'EGRESS_POLICY_UNKNOWN_KEY'
+  | 'EGRESS_POLICY_EMPTY_ALLOWLIST'
+  | 'EGRESS_POLICY_INVALID_HOST'
+  | 'EGRESS_POLICY_DUPLICATE_HOST'
+  | 'EGRESS_POLICY_INVALID_NAT64_PREFIX'
+  | 'EGRESS_POLICY_DUPLICATE_NAT64_PREFIX'
+
+export type EgressPolicyConfigField =
+  | 'config'
+  | 'allowedHosts'
+  | 'allowedHosts[]'
+  | 'nat64Prefixes'
+  | 'nat64Prefixes[]'
+
+export interface EgressPolicyMetadata {
+  policyPresent: boolean
+  allowedHostCount: number
+  nat64PrefixCount: number
+  policyFingerprint: string | null
+}
+
+export interface EgressPolicyConfigError {
+  code: EgressPolicyConfigErrorCode
+  field: EgressPolicyConfigField
+}
+
+export type EgressPolicyNormalizationResult =
+  | {
+      ok: true
+      policy: Readonly<EgressPolicy>
+      metadata: Readonly<EgressPolicyMetadata>
+    }
+  | {
+      ok: false
+      policy: Readonly<EgressPolicy>
+      metadata: Readonly<EgressPolicyMetadata>
+      error: Readonly<EgressPolicyConfigError>
+    }
+
+const ALLOWED_CONFIG_KEYS = new Set(['allowedHosts', 'nat64Prefixes'])
+
+function disabledMetadata(): Readonly<EgressPolicyMetadata> {
+  return Object.freeze({
+    policyPresent: false,
+    allowedHostCount: 0,
+    nat64PrefixCount: 0,
+    policyFingerprint: null,
+  })
+}
+
+function fail(
+  code: EgressPolicyConfigErrorCode,
+  field: EgressPolicyConfigField,
+): EgressPolicyNormalizationResult {
+  return {
+    ok: false,
+    policy: Object.freeze({
+      allowedHosts: Object.freeze([...(defaultEgressPolicy().allowedHosts ?? [])]),
+      nat64Prefixes: Object.freeze([]),
+    }),
+    metadata: disabledMetadata(),
+    error: Object.freeze({ code, field }),
+  }
+}
+
+type ParsedConfig =
+  | { kind: 'ok'; config: Record<string, unknown> }
+  | { kind: 'missing' }
+  | { kind: 'malformed' }
+
+function parseConfig(rawConfig: unknown): ParsedConfig {
+  if (rawConfig === null || rawConfig === undefined) return { kind: 'missing' }
+  if (typeof rawConfig === 'string') {
+    const trimmed = rawConfig.trim()
+    if (!trimmed) return { kind: 'missing' }
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? { kind: 'ok', config: parsed as Record<string, unknown> }
+        : { kind: 'malformed' }
+    } catch {
+      return { kind: 'malformed' }
+    }
+  }
+  return rawConfig && typeof rawConfig === 'object' && !Array.isArray(rawConfig)
+    ? { kind: 'ok', config: rawConfig as Record<string, unknown> }
+    : { kind: 'malformed' }
+}
+
+function hasOnlyAllowedConfigKeys(config: Record<string, unknown>): boolean {
+  return Object.keys(config).every((key) => ALLOWED_CONFIG_KEYS.has(key))
+}
+
+function normalizeHostEntry(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const raw = value.trim()
+  if (!raw || /[^\x00-\x7F]/.test(raw)) return null
+  if (raw.includes('*') || raw.includes('/') || raw.includes('@') || raw.includes('://')) return null
+  if (raw.includes(':') || raw.includes('?') || raw.includes('#') || raw.includes('\\')) return null
+
+  const host = raw.toLowerCase().replace(/\.$/, '')
+  if (!host || host.length > 253 || !host.includes('.')) return null
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local') || host.endsWith('.internal')) {
+    return null
+  }
+  if (ipaddr.isValid(host)) return null
+
+  const labels = host.split('.')
+  if (labels.some((label) => label.length === 0 || label.length > 63)) return null
+  for (const label of labels) {
+    if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)) return null
+  }
+  return host
+}
+
+function normalizeNat64Prefix(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const raw = value.trim().toLowerCase()
+  if (!raw || /[^\x00-\x7F]/.test(raw)) return null
+  try {
+    const cidr = ipaddr.parseCIDR(raw)
+    if (cidr[0].kind() !== 'ipv6' || cidr[1] !== 96) return null
+    return `${cidr[0].toNormalizedString()}/96`
+  } catch {
+    return null
+  }
+}
+
+function fingerprintPolicy(allowedHosts: readonly string[], nat64Prefixes: readonly string[]): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ allowedHosts, nat64Prefixes }))
+    .digest('hex')
+    .slice(0, 16)
+}
+
+export function normalizeBpmnHttpTaskEgressPolicyConfig(rawConfig: unknown): EgressPolicyNormalizationResult {
+  const parsed = parseConfig(rawConfig)
+  if (parsed.kind === 'missing') return fail('EGRESS_POLICY_MISSING', 'config')
+  if (parsed.kind === 'malformed') return fail('EGRESS_POLICY_MALFORMED', 'config')
+  const { config } = parsed
+  if (!hasOnlyAllowedConfigKeys(config)) return fail('EGRESS_POLICY_UNKNOWN_KEY', 'config')
+
+  if (!Array.isArray(config.allowedHosts)) return fail('EGRESS_POLICY_MALFORMED', 'allowedHosts')
+  if (config.allowedHosts.length === 0) return fail('EGRESS_POLICY_EMPTY_ALLOWLIST', 'allowedHosts')
+
+  const allowedHosts: string[] = []
+  const seenHosts = new Set<string>()
+  for (const entry of config.allowedHosts) {
+    const host = normalizeHostEntry(entry)
+    if (!host) return fail('EGRESS_POLICY_INVALID_HOST', 'allowedHosts[]')
+    if (seenHosts.has(host)) return fail('EGRESS_POLICY_DUPLICATE_HOST', 'allowedHosts[]')
+    seenHosts.add(host)
+    allowedHosts.push(host)
+  }
+  allowedHosts.sort()
+
+  const rawNat64Prefixes = config.nat64Prefixes ?? []
+  if (!Array.isArray(rawNat64Prefixes)) return fail('EGRESS_POLICY_MALFORMED', 'nat64Prefixes')
+
+  const nat64Prefixes: string[] = []
+  const seenPrefixes = new Set<string>()
+  for (const entry of rawNat64Prefixes) {
+    const prefix = normalizeNat64Prefix(entry)
+    if (!prefix) return fail('EGRESS_POLICY_INVALID_NAT64_PREFIX', 'nat64Prefixes[]')
+    if (seenPrefixes.has(prefix)) return fail('EGRESS_POLICY_DUPLICATE_NAT64_PREFIX', 'nat64Prefixes[]')
+    seenPrefixes.add(prefix)
+    nat64Prefixes.push(prefix)
+  }
+  nat64Prefixes.sort()
+
+  const policy = Object.freeze({
+    allowedHosts: Object.freeze([...allowedHosts]),
+    nat64Prefixes: Object.freeze([...nat64Prefixes]),
+  })
+  const metadata = Object.freeze({
+    policyPresent: true,
+    allowedHostCount: allowedHosts.length,
+    nat64PrefixCount: nat64Prefixes.length,
+    policyFingerprint: fingerprintPolicy(allowedHosts, nat64Prefixes),
+  })
+  return { ok: true, policy, metadata }
+}

--- a/packages/core-backend/src/guards/index.ts
+++ b/packages/core-backend/src/guards/index.ts
@@ -10,3 +10,4 @@ export * from './audit-integration';
 export * from './idempotency';
 export * from './egress-guard';
 export * from './egress-dispatcher';
+export * from './egress-policy-normalizer';


### PR DESCRIPTION
## What

Implements R1 A3-a from #3452: a pure BPMN HTTP-task egress policy config normalizer.

- Adds `normalizeBpmnHttpTaskEgressPolicyConfig(rawConfig)` for server-owned policy input.
- Returns either a frozen normalized `EgressPolicy` plus values-free metadata, or a fail-closed disabled policy plus coarse error code/field.
- Locks exact ASCII DNS host normalization, explicit punycode acceptance, Unicode IDN rejection, public IP literal rejection, wildcard/suffix/path/scheme/port/userinfo/CIDR rejection, duplicate host rejection, and `/96` IPv6 NAT64 prefix validation.
- Requires NAT64 policy prefixes to be true network roots (host bits zero), so semantically-duplicate `/96` prefixes cannot drift counts/fingerprints.
- Keeps evidence values-free: counts + fingerprint only, no raw host/config/token echo.

## Boundary

A3-a only. No route, engine, transport, DNS, database, server config loader, workflow deployment path, or outbound call is touched. No destination is enabled; runtime remains fail-closed by default.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run src/guards/__tests__/egress-policy-normalizer.test.ts src/guards/__tests__/egress-guard.test.ts src/guards/__tests__/egress-dispatcher.test.ts --reporter=dot` — 100/100
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

