### PR TITLE
test(workflow): lock A3 route egress provenance

### DIFF
--- a/docs/development/workflow-bpmn-http-task-egress-a3b-route-provenance-dev-verification-20260701.md
+++ b/docs/development/workflow-bpmn-http-task-egress-a3b-route-provenance-dev-verification-20260701.md
@@ -1,0 +1,61 @@
+# Workflow BPMN HTTP-task egress A3-b route provenance — development and verification (2026-07-01)
+
+## Scope
+
+This is the A3-b negative-control slice from
+`docs/development/workflow-bpmn-http-task-egress-a3-rollout-policy-design-lock-20260701.md`.
+
+It does not enable any live HTTP-task destination, load runtime egress config, alter DNS/transport pinning, or change the
+workflow engine wiring. The slice only locks route provenance: workflow route inputs, start variables, designer deploy
+payloads, and BPMN XML must not become egress policy.
+
+## Changes
+
+- Added `packages/core-backend/tests/unit/workflow-egress-route-provenance.test.ts`.
+  - `POST /api/workflow/deploy`, `POST /api/workflow/start/:key`, and
+    `POST /api/workflow-designer/workflows/:id/deploy` remain authenticated
+    before any engine deploy/start call.
+  - Deploy body fields such as `allowedHosts`, `nat64Prefixes`, `egressPolicy`, and `httpTaskEgress` are not lifted into
+    the engine constructor or deploy definition.
+  - `POST /api/workflow/start/:key` treats policy-like keys as workflow variables only, not policy constructor input.
+  - `POST /api/workflow-designer/workflows/:id/deploy` forwards the stored BPMN XML only, not request-supplied policy.
+  - Policy-like BPMN XML extension elements do not construct route-supplied engine policy.
+- Extended `packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts` with an engine-level
+  variable-smuggling negative control: workflow variables cannot satisfy the egress allowlist.
+
+## Verification
+
+Commands run from the repository root:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/workflow-egress-route-provenance.test.ts \
+  src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend build
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  src/guards/__tests__/egress-guard.test.ts \
+  src/guards/__tests__/egress-dispatcher.test.ts \
+  src/guards/__tests__/egress-pinned-transport.test.ts \
+  src/guards/__tests__/egress-policy-normalizer.test.ts \
+  src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts \
+  tests/unit/workflow-egress-route-provenance.test.ts \
+  --reporter=dot
+
+git diff --check
+```
+
+Observed result:
+
+- Focused route + engine provenance tests: 2 files / 10 tests PASS.
+- Core backend build: PASS.
+- R1 egress guard/dispatcher/transport/policy-normalizer/engine/route-provenance suite: 6 files / 112 tests PASS.
+- `git diff --check`: PASS.
+
+## Remaining gated work
+
+A3-c remains the first slice that can inject a real runtime egress policy into `BPMNWorkflowEngine`. It is still
+owner/governance gated because it decides the actual allowlist source and rollout behavior. This A3-b slice deliberately
+keeps the fail-closed/no-destination-enabled boundary intact.

--- a/packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts
+++ b/packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts
@@ -111,6 +111,31 @@ describe('BPMN HTTP task egress wiring', () => {
     expect(instance.variables.httpResult).toBeUndefined()
   })
 
+  test('does not treat workflow variables as egress policy configuration', async () => {
+    const { engine, resolved, transported } = makeEngine()
+    const instance = testInstance()
+    instance.variables = {
+      allowedHosts: ['api.example.com'],
+      nat64Prefixes: ['2a00:1098:2c::/96'],
+      httpTaskEgress: {
+        policy: {
+          allowedHosts: ['api.example.com'],
+          nat64Prefixes: ['2a00:1098:2c::/96'],
+        },
+      },
+    }
+    installInstance(engine, instance)
+
+    await expect(executeHttpTask(engine, instance.id, {
+      url: 'https://api.example.com/hook',
+      responseVariable: 'httpResult',
+    })).rejects.toThrow('BPMN_HTTP_EGRESS_DENIED: ALLOWLIST_REQUIRED')
+
+    expect(resolved()).toBe(false)
+    expect(transported()).toBe(false)
+    expect(instance.variables.httpResult).toBeUndefined()
+  })
+
   test('blocks private DNS answers before transport', async () => {
     const { engine, transported } = makeEngine({
       policy: { allowedHosts: ['api.example.com'] },

--- a/packages/core-backend/tests/unit/workflow-egress-route-provenance.test.ts
+++ b/packages/core-backend/tests/unit/workflow-egress-route-provenance.test.ts
@@ -1,0 +1,259 @@
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const routeState = vi.hoisted(() => ({
+  user: { id: 'owner-1', tenantId: 'tenant-1' } as Record<string, unknown> | null,
+  engineOptions: [] as unknown[],
+  initialize: vi.fn().mockResolvedValue(undefined),
+  shutdown: vi.fn().mockResolvedValue(undefined),
+  deployProcess: vi.fn().mockResolvedValue('definition-1'),
+  startProcess: vi.fn().mockResolvedValue('instance-1'),
+  loadWorkflowDraft: vi.fn(),
+  deployWorkflow: vi.fn().mockResolvedValue('visual-deployment-1'),
+  dbExecute: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (!routeState.user) {
+      res.status(401).json({ success: false, error: 'Unauthorized' })
+      return
+    }
+    req.user = routeState.user as never
+    next()
+  },
+}))
+
+vi.mock('../../src/db/db', () => {
+  const execute = () => routeState.dbExecute()
+  return {
+    db: {
+      insertInto: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({ execute }),
+      }),
+      updateTable: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ execute }),
+        }),
+      }),
+      selectFrom: vi.fn().mockReturnValue({
+        selectAll: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        execute,
+      }),
+      deleteFrom: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../../src/workflow/WorkflowDesigner', () => ({
+  WorkflowDesigner: vi.fn().mockImplementation(() => ({
+    getTemplates: vi.fn().mockReturnValue([]),
+    loadWorkflow: vi.fn(),
+    loadWorkflowDraft: routeState.loadWorkflowDraft,
+    saveWorkflow: vi.fn(),
+    saveBpmnDraft: vi.fn(),
+    validateWorkflow: vi.fn().mockReturnValue({ valid: true, errors: [] }),
+    deployWorkflow: routeState.deployWorkflow,
+  })),
+}))
+
+vi.mock('../../src/workflow/BPMNWorkflowEngine', () => ({
+  BPMNWorkflowEngine: vi.fn().mockImplementation((options?: unknown) => {
+    routeState.engineOptions.push(options)
+    return {
+      initialize: routeState.initialize,
+      shutdown: routeState.shutdown,
+      deployProcess: routeState.deployProcess,
+      startProcess: routeState.startProcess,
+    }
+  }),
+}))
+
+const POLICY_LIKE_PAYLOAD = {
+  allowedHosts: ['metadata.google.internal'],
+  nat64Prefixes: ['2a00:1098:2c::/96'],
+  httpTaskEgress: { policy: { allowedHosts: ['metadata.google.internal'] } },
+  egressPolicy: { allowedHosts: ['metadata.google.internal'] },
+}
+
+function suspiciousBpmnXml() {
+  return [
+    '<definitions>',
+    '<process id="policy_smuggle">',
+    '<serviceTask id="http_task" name="HTTP">',
+    '<extensionElements>',
+    '<allowedHosts>metadata.google.internal</allowedHosts>',
+    '<nat64Prefixes>2a00:1098:2c::/96</nat64Prefixes>',
+    '<httpTaskEgress>{"allowedHosts":["metadata.google.internal"]}</httpTaskEgress>',
+    '</extensionElements>',
+    '</serviceTask>',
+    '</process>',
+    '</definitions>',
+  ].join('')
+}
+
+function draft(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wf_1',
+    name: 'Policy smuggle draft',
+    description: '',
+    version: 1,
+    status: 'draft',
+    createdBy: 'owner-1',
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+    category: 'automation',
+    tags: [],
+    bpmnXml: suspiciousBpmnXml(),
+    sourceMode: 'bpmn_xml',
+    visual: null,
+    shares: [],
+    executions: [],
+    ...overrides,
+  }
+}
+
+async function buildWorkflowApp() {
+  delete process.env.DISABLE_WORKFLOW
+  const router = (await import('../../src/routes/workflow')).default
+  const app = express()
+  app.use(express.json())
+  app.use('/api/workflow', router)
+  return app
+}
+
+async function buildWorkflowDesignerApp() {
+  delete process.env.DISABLE_WORKFLOW
+  const router = (await import('../../src/routes/workflow-designer')).default
+  const app = express()
+  app.use(express.json())
+  app.use('/api/workflow-designer', router)
+  return app
+}
+
+function expectNoInjectedEgressPolicy(value: unknown) {
+  expect(value).not.toHaveProperty('allowedHosts')
+  expect(value).not.toHaveProperty('nat64Prefixes')
+  expect(value).not.toHaveProperty('httpTaskEgress')
+  expect(value).not.toHaveProperty('egressPolicy')
+  expect(value).not.toHaveProperty('policy')
+}
+
+function expectNoPolicyLeak(responseBody: unknown) {
+  const serialized = JSON.stringify(responseBody)
+  expect(serialized).not.toContain('metadata.google.internal')
+  expect(serialized).not.toContain('2a00:1098:2c::/96')
+  expect(serialized).not.toContain('httpTaskEgress')
+  expect(serialized).not.toContain('allowedHosts')
+  expect(serialized).not.toContain('nat64Prefixes')
+}
+
+function expectNoInjectedEnginePolicy() {
+  expect(routeState.engineOptions.length).toBeGreaterThan(0)
+  expect(routeState.engineOptions).toEqual(routeState.engineOptions.map(() => undefined))
+}
+
+describe('R1-A3-b BPMN HTTP-task route provenance', () => {
+  beforeEach(() => {
+    routeState.user = { id: 'owner-1', tenantId: 'tenant-1' }
+    routeState.initialize.mockClear()
+    routeState.shutdown.mockClear()
+    routeState.deployProcess.mockClear()
+    routeState.startProcess.mockClear()
+    routeState.loadWorkflowDraft.mockReset()
+    routeState.deployWorkflow.mockClear()
+    routeState.dbExecute.mockClear()
+  })
+
+  test('workflow deploy/start and designer deploy remain authenticated route surfaces', async () => {
+    routeState.user = null
+
+    const workflowApp = await buildWorkflowApp()
+    expect((await request(workflowApp).post('/api/workflow/deploy').send({
+      name: 'Blocked deploy',
+      bpmnXml: suspiciousBpmnXml(),
+    })).status).toBe(401)
+    expect((await request(workflowApp).post('/api/workflow/start/policy_smuggle').send({
+      variables: { allowedHosts: ['metadata.google.internal'] },
+    })).status).toBe(401)
+
+    const designerApp = await buildWorkflowDesignerApp()
+    expect((await request(designerApp).post('/api/workflow-designer/workflows/wf_1/deploy').send({})).status).toBe(401)
+    expect(routeState.deployProcess).not.toHaveBeenCalled()
+    expect(routeState.startProcess).not.toHaveBeenCalled()
+  })
+
+  test('workflow deploy ignores policy-like request fields and constructs the engine without injected policy', async () => {
+    const app = await buildWorkflowApp()
+
+    const response = await request(app).post('/api/workflow/deploy').send({
+      name: 'Suspicious deploy',
+      bpmnXml: suspiciousBpmnXml(),
+      ...POLICY_LIKE_PAYLOAD,
+    })
+
+    expect(response.status).toBe(201)
+    expectNoPolicyLeak(response.body)
+    expectNoInjectedEnginePolicy()
+    expect(routeState.deployProcess).toHaveBeenCalledTimes(1)
+    const [definition] = routeState.deployProcess.mock.calls[0]
+    expect(definition).toMatchObject({
+      name: 'Suspicious deploy',
+      bpmnXml: suspiciousBpmnXml(),
+      tenantId: 'tenant-1',
+    })
+    expectNoInjectedEgressPolicy(definition)
+  })
+
+  test('workflow start treats policy-like variables as variables, not egress policy', async () => {
+    const app = await buildWorkflowApp()
+
+    const response = await request(app).post('/api/workflow/start/policy_smuggle').send({
+      businessKey: 'bk-1',
+      variables: {
+        ...POLICY_LIKE_PAYLOAD,
+      },
+      allowedHosts: ['ignored.example.com'],
+    })
+
+    expect(response.status).toBe(201)
+    expectNoPolicyLeak(response.body)
+    expectNoInjectedEnginePolicy()
+    expect(routeState.startProcess).toHaveBeenCalledTimes(1)
+    expect(routeState.startProcess).toHaveBeenCalledWith(
+      'policy_smuggle',
+      {
+        ...POLICY_LIKE_PAYLOAD,
+        _startUserId: 'owner-1',
+      },
+      'bk-1',
+      'tenant-1',
+    )
+  })
+
+  test('workflow-designer deploy forwards stored BPMN XML only and never request-supplied policy', async () => {
+    routeState.loadWorkflowDraft.mockResolvedValue(draft())
+    const app = await buildWorkflowDesignerApp()
+
+    const response = await request(app)
+      .post('/api/workflow-designer/workflows/wf_1/deploy')
+      .send(POLICY_LIKE_PAYLOAD)
+
+    expect(response.status).toBe(200)
+    expectNoPolicyLeak(response.body)
+    expectNoInjectedEnginePolicy()
+    expect(routeState.deployProcess).toHaveBeenCalledTimes(1)
+    const [definition] = routeState.deployProcess.mock.calls[0]
+    expect(definition).toMatchObject({
+      key: '',
+      name: 'Policy smuggle draft',
+      bpmnXml: suspiciousBpmnXml(),
+      tenantId: 'tenant-1',
+    })
+    expectNoInjectedEgressPolicy(definition)
+    expect(routeState.deployWorkflow).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

A3-b route provenance / policy-smuggling negative controls for the BPMN HTTP-task SSRF line.

This slice is intentionally test + verification record only. It does **not** enable live HTTP-task destinations, load runtime egress config, change DNS/transport pinning, or wire A3-c policy injection.

## What changed

- Add route-level negative controls for:
  - `POST /api/workflow/deploy`
  - `POST /api/workflow/start/:key`
  - `POST /api/workflow-designer/workflows/:id/deploy`
- Assert auth gates still run before engine deploy/start calls.
- Assert policy-like request fields / workflow variables / BPMN XML extension elements do not become engine egress policy.
- Add an engine-level variable-smuggling negative control: workflow variables cannot satisfy the egress allowlist.
- Add `docs/development/workflow-bpmn-http-task-egress-a3b-route-provenance-dev-verification-20260701.md` with the verification record and remaining A3-c gate.

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/workflow-egress-route-provenance.test.ts \
  src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts \
  --reporter=dot
# 2 files / 10 tests PASS

pnpm --filter @metasheet/core-backend build
# PASS

pnpm --filter @metasheet/core-backend exec vitest run \
  src/guards/__tests__/egress-guard.test.ts \
  src/guards/__tests__/egress-dispatcher.test.ts \
  src/guards/__tests__/egress-pinned-transport.test.ts \
  src/guards/__tests__/egress-policy-normalizer.test.ts \
  src/workflow/__tests__/BPMNWorkflowEngine.egress.test.ts \
  tests/unit/workflow-egress-route-provenance.test.ts \
  --reporter=dot
# 6 files / 112 tests PASS

git diff --check
# PASS
```

## Remaining gate

A3-c remains owner/governance gated: it is the first slice that can inject a real runtime egress policy into `BPMNWorkflowEngine` and decide the actual allowlist source / rollout behavior.
