### PR TITLE
docs(workflow): refresh R1 egress ledger after A3-a/b

### DIFF
--- a/docs/development/workflow-bpmn-ssrf-egress-line-dev-and-verification-20260701.md
+++ b/docs/development/workflow-bpmn-ssrf-egress-line-dev-and-verification-20260701.md
@@ -2,7 +2,7 @@
 
 Survey of the BPMN HTTP-task SSRF boundary line (design-lock `#3428` plus A3
 rollout lock `#3452`): what is landed, what is verified, and what remains
-gated. Grounded against `origin/main` after `#3452` / `#3454`.
+gated. Grounded against `origin/main` after `#3457`.
 
 ## 1. Baseline
 
@@ -27,6 +27,8 @@ gated. Grounded against `origin/main` after `#3452` / `#3454`.
 | A1 IP-pinned dispatcher | `#3447` / `be35eec6` | Adds `dispatchPinnedEgressRequest`: resolve-all DNS, deny if any resolved IP is unsafe, pin the chosen validated IP, revalidate redirects, cap redirects, and require manual redirect handling. No engine wiring in that slice. |
 | A2 engine wiring | `#3451` / `5193432a8` | Replaces the raw `fetch` path in `executeHttpTask` with the pinned dispatcher plus HTTPS JSON transport; preserves Host/SNI while connecting to the pinned IP; enforces GET/POST only; rejects `Authorization`, `Cookie`, `Host`, `Proxy-*`, `Forwarded`, and `X-Forwarded-*`; caps headers, redirects, timeout, and response size; default policy remains fail-closed. |
 | A3 rollout policy design-lock | `#3452` / `771871e05` | Locks the next governance gate: server-owned policy source only, exact DNS host policy entries, NAT64 prefixes as classifier metadata only, fail-closed malformed/absent config, both engine construction sites sharing one loader path, route provenance negative controls, and values-free evidence. No runtime/config loader or live destination enablement. |
+| A3-a policy normalizer | `#3455` / `cead5a84d` | Adds `normalizeBpmnHttpTaskEgressPolicyConfig`: server-owned policy config parsing, exact ASCII DNS host validation, `/96` deployment NAT64 prefix normalization, duplicate rejection, order-independent fingerprinting, and values-free metadata/errors. No route/runtime/config loader, DNS lookup, transport, persistence, or live allowlist enablement. |
+| A3-b route provenance negative controls | `#3457` / `4bd15aca3` | Locks that workflow deploy/start/designer payloads, start variables, and BPMN extension XML cannot smuggle egress policy into `BPMNWorkflowEngine`. Adds route and engine negative controls while keeping A3-c runtime policy injection gated. |
 
 ## 3. Current Runtime State
 
@@ -64,28 +66,41 @@ by a future rollout/configuration slice.
 - `#3452` fresh CI passed `test (18.x)`, `test (20.x)`, coverage, K3 WISE,
   after-sales, and the contract gates; the A3 design-lock is docs-only and
   does not enable a destination.
+- `#3455` shipped the pure A3-a policy normalizer with focused tests for
+  fail-closed missing/malformed config, exact-host validation, NAT64 prefix
+  validation, duplicate handling, order-independent fingerprints, and
+  values-free error metadata. The slice has no route/runtime consumer.
+- `#3457` local focused verification recorded route + engine provenance tests:
+  2 files / 10 tests PASS; core backend build PASS; the combined R1
+  guard/dispatcher/transport/policy-normalizer/engine/route-provenance suite:
+  6 files / 112 tests PASS; `git diff --check` PASS.
+- `#3457` fresh CI passed `test (18.x)`, `test (20.x)`, coverage, K3 WISE,
+  after-sales, and the contract gates after rebasing to the current main.
 
 ## 5. Remaining Gate
 
-The R1 code path is closed by default, and `#3452` now locks the rollout policy
-shape. The rollout/configuration runtime is still a separate gate. This is
-intentional: the design-lock treated fail-closed rollout as a behavior change
-and required the policy-enablement path to be its own step.
+The R1 code path is closed by default. `#3452` locks the rollout policy shape,
+`#3455` implements the pure policy normalizer, and `#3457` locks route
+provenance negative controls. The runtime injection/configuration path is still
+a separate gate. This is intentional: the design-lock treated fail-closed
+rollout as a behavior change and required the policy-enablement path to be its
+own step.
 
 | Remaining item | State | Why it remains separate |
 |---|---|---|
-| A3 rollout / configured policy enablement | **DESIGN-LOCK SHIPPED; RUNTIME GATED** | `#3452` defines the server-owned policy model and route-provenance/values-free evidence gates. No product/admin configuration surface, config loader, route injection, or live allowlist rollout has been opened. Enabling real destinations remains an owner/governance decision, not an automatic continuation. |
+| A3-c runtime policy injection / configured policy enablement | **A3-a/A3-b SHIPPED; RUNTIME GATED** | `#3452` defines the server-owned policy model, `#3455` validates the policy shape, and `#3457` proves route/user/BPMN inputs cannot supply policy. No product/admin configuration surface, config loader, engine construction injection, or live allowlist rollout has been opened. Enabling real destinations remains an owner/governance decision, not an automatic continuation. |
 
 ## 6. Outcome
 
-- R1 design-lock, guard, IP classifier hardening, dispatcher, and engine wiring
-  are all merged on `main`.
+- R1 design-lock, guard, IP classifier hardening, dispatcher, engine wiring,
+  A3-a policy normalizer, and A3-b route provenance negative controls are all
+  merged on `main`.
 - The original live SSRF hole is closed by default: no configured allowlist means
   no outbound HTTP-task request is dispatched.
-- The remaining work is not another blind SSRF patch; it is the explicit A3
-  policy/rollout runtime. `#3452` already defines the server-owned policy source,
-  route-level provenance controls, and evidence boundaries; implementation still
-  requires per-slice owner opt-in.
+- The remaining work is not another blind SSRF patch; it is the explicit A3-c
+  policy/rollout runtime. `#3452` defines the server-owned policy source,
+  `#3455` validates the policy contract, and `#3457` locks route-level
+  provenance controls; runtime injection still requires per-slice owner opt-in.
 
 ## Invariants Held
 


### PR DESCRIPTION
## Summary
- refresh the R1 BPMN SSRF egress development/verification ledger through #3455 and #3457
- record A3-a policy normalizer and A3-b route provenance negative controls as shipped
- keep A3-c runtime policy injection / configured enablement explicitly gated

## Verification
- git diff --check
- rg check for A3-a/A3-b/A3-c gate wording

## Boundary
Docs-only. No runtime, route, config loader, engine injection, DNS/transport, or live allowlist enablement.