### PR TITLE
feat(attendance): add AE-3 result edit admin modal

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1100,6 +1100,31 @@
                     >
                       {{ item.state === 'pending' ? tr('Pending request', '申请处理中') : tr('Create request', '创建申请') }}
                     </button>
+                    <button
+                      v-if="attendanceResultEditCapabilityUnknown"
+                      class="attendance__btn"
+                      data-attendance-result-edit-probe
+                      @click="openResultEditModal(item)"
+                    >
+                      {{ tr('Check edit access', '检查更正权限') }}
+                    </button>
+                    <button
+                      v-else
+                      class="attendance__btn"
+                      :disabled="Boolean(attendanceResultEditDisabledReason(item))"
+                      :title="attendanceResultEditDisabledReason(item) || undefined"
+                      data-attendance-result-edit-open
+                      @click="openResultEditModal(item)"
+                    >
+                      {{ tr('Edit result', '修改结果') }}
+                    </button>
+                    <small
+                      v-if="attendanceResultEditCapabilityUnknown || attendanceResultEditDisabledReason(item)"
+                      class="attendance__field-hint"
+                      data-attendance-result-edit-disabled-reason
+                    >
+                      {{ attendanceResultEditCapabilityUnknown ? tr('Check admin permission before editing.', '更正前需先检查管理员权限。') : attendanceResultEditDisabledReason(item) }}
+                    </small>
                   </td>
                 </tr>
               </tbody>
@@ -8729,6 +8754,125 @@
         </div>
       </section>
     </template>
+
+    <div
+      v-if="attendanceResultEditModal.open && attendanceResultEditModal.snapshot"
+      class="attendance__modal"
+      role="dialog"
+      aria-modal="true"
+      data-attendance-result-edit-modal
+    >
+      <div class="attendance__modal-body attendance__result-edit-modal">
+        <div class="attendance__admin-section-header">
+          <div>
+            <h4>{{ tr('Edit attendance result', '更正考勤结果') }}</h4>
+            <small class="attendance__field-hint">
+              {{ attendanceResultEditModal.snapshot.workDate }}
+              <template v-if="attendanceResultEditModal.snapshot.userId">
+                · {{ attendanceResultEditModal.snapshot.userId }}
+              </template>
+            </small>
+          </div>
+          <button class="attendance__btn" type="button" @click="closeResultEditModal">
+            {{ tr('Close', '关闭') }}
+          </button>
+        </div>
+
+        <div class="attendance__result-edit-summary">
+          <span>
+            {{ tr('Current status', '当前状态') }}:
+            <strong>{{ formatStatus(attendanceResultEditModal.snapshot.sourceStatus) }}</strong>
+          </span>
+          <span v-if="attendanceResultEditModal.snapshot.request">
+            {{ tr('Linked request', '关联申请') }}:
+            {{ formatRequestType(attendanceResultEditModal.snapshot.request.requestType) }}
+            · {{ formatStatus(attendanceResultEditModal.snapshot.request.status) }}
+          </span>
+          <span v-if="attendanceResultEditModal.snapshot.warnings.length">
+            {{ tr('Warnings', '警告') }}: {{ formatWarningsShort(attendanceResultEditModal.snapshot.warnings) }}
+          </span>
+        </div>
+
+        <div class="attendance__request-form attendance__result-edit-form">
+          <label class="attendance__field" for="attendance-result-edit-target">
+            <span>{{ tr('Target status', '目标状态') }}</span>
+            <select
+              id="attendance-result-edit-target"
+              v-model="attendanceResultEditModal.targetStatus"
+              name="resultEditTargetStatus"
+              data-attendance-result-edit-target
+            >
+              <option
+                v-for="status in ATTENDANCE_RESULT_EDIT_TARGET_STATUSES"
+                :key="status"
+                :value="status"
+              >
+                {{ attendanceResultEditTargetLabel(status) }}
+              </option>
+            </select>
+          </label>
+          <label class="attendance__field attendance__field--full" for="attendance-result-edit-reason">
+            <span>{{ tr('Reason', '原因') }}</span>
+            <textarea
+              id="attendance-result-edit-reason"
+              v-model="attendanceResultEditModal.reason"
+              maxlength="500"
+              name="resultEditReason"
+              rows="3"
+              data-attendance-result-edit-reason
+            />
+            <small class="attendance__field-hint">
+              {{
+                attendanceResultEditReasonRequired
+                  ? tr('Required by policy.', '策略要求填写。')
+                  : tr('Optional by policy.', '策略未强制要求。')
+              }}
+            </small>
+          </label>
+          <label class="attendance__field" for="attendance-result-edit-evidence-label">
+            <span>{{ tr('Evidence label', '证据标签') }}</span>
+            <input
+              id="attendance-result-edit-evidence-label"
+              v-model="attendanceResultEditModal.evidenceLabel"
+              maxlength="240"
+              name="resultEditEvidenceLabel"
+              type="text"
+              data-attendance-result-edit-evidence-label
+            />
+          </label>
+          <label class="attendance__field" for="attendance-result-edit-evidence-url">
+            <span>{{ tr('Evidence URL', '证据链接') }}</span>
+            <input
+              id="attendance-result-edit-evidence-url"
+              v-model="attendanceResultEditModal.evidenceUrl"
+              name="resultEditEvidenceUrl"
+              placeholder="https://"
+              type="url"
+              data-attendance-result-edit-evidence-url
+            />
+          </label>
+        </div>
+
+        <p v-if="attendanceResultEditModal.error" class="attendance__error" data-attendance-result-edit-error>
+          {{ attendanceResultEditModal.error }}
+        </p>
+
+        <div class="attendance__admin-actions">
+          <button class="attendance__btn" type="button" @click="closeResultEditModal">
+            {{ tr('Cancel', '取消') }}
+          </button>
+          <button
+            class="attendance__btn attendance__btn--primary"
+            :disabled="attendanceResultEditSubmitDisabled"
+            type="button"
+            data-attendance-result-edit-submit
+            @click="submitResultEditModal"
+          >
+            {{ attendanceResultEditModal.submitting ? tr('Submitting...', '提交中...') : tr('Submit edit', '提交更正') }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -9061,6 +9205,30 @@ interface AttendanceAnomaly {
   suggestedRequestType: string | null
 }
 
+const ATTENDANCE_RESULT_EDIT_SOURCE_STATUSES = new Set(['late', 'early_leave', 'late_early', 'partial', 'absent'])
+const ATTENDANCE_RESULT_EDIT_TARGET_STATUSES = ['normal', 'late', 'early_leave', 'late_early', 'partial', 'absent', 'adjusted'] as const
+type AttendanceResultEditTargetStatus = typeof ATTENDANCE_RESULT_EDIT_TARGET_STATUSES[number]
+type AttendanceResultEditAdminCapability = 'unknown' | 'checking' | 'allowed' | 'forbidden'
+
+interface AttendanceResultEditSnapshot {
+  recordId: string
+  userId: string
+  workDate: string
+  sourceStatus: string
+  warnings: string[]
+  request: AttendanceAnomaly['request']
+  idempotencyKey: string
+}
+
+interface AttendanceResultEditResult {
+  id: string
+  beforeStatus: string
+  afterStatus: string
+  notificationDeliveryId: string | null
+  notificationSkippedReason: string | null
+  alreadyApplied: boolean
+}
+
 interface MissedPunchReminderResult {
   channel: string
   created: number
@@ -9341,6 +9509,12 @@ interface AttendanceSettings {
       weekly?: { enabled?: boolean; weekday?: number; sendAt?: string; recipients?: string[] }
       monthly?: { enabled?: boolean; dayOfMonth?: number; sendAt?: string; recipients?: string[] }
     }
+  }
+  attendanceResultEditPolicy?: {
+    enabled?: boolean
+    editWindowDays?: number
+    requireReason?: boolean
+    notifyAffectedEmployee?: boolean
   }
   autoShiftMatching?: {
     enabled?: boolean
@@ -10276,6 +10450,18 @@ const scheduleDispatchSaving = ref(false)
 const focusedAttendanceRequestId = computed(() => props.initialRequestId.trim())
 const anomalies = ref<AttendanceAnomaly[]>([])
 const anomaliesLoading = ref(false)
+const attendanceResultEditAdminCapability = ref<AttendanceResultEditAdminCapability>('unknown')
+const attendanceResultEditModal = reactive({
+  open: false,
+  snapshot: null as AttendanceResultEditSnapshot | null,
+  targetStatus: 'normal' as AttendanceResultEditTargetStatus,
+  reason: '',
+  evidenceLabel: '',
+  evidenceUrl: '',
+  submitting: false,
+  error: '',
+  result: null as AttendanceResultEditResult | null,
+})
 const missedPunchReminderCandidates = ref<MissedPunchReminderCandidate[]>([])
 const missedPunchReminderLoading = ref(false)
 const missedPunchReminderDefaultTo = new Date()
@@ -14618,6 +14804,234 @@ function normalizedUserId(): string | undefined {
   return value.length > 0 ? value : undefined
 }
 
+const attendanceResultEditPolicy = computed(() => attendanceSettings.value?.attendanceResultEditPolicy ?? {})
+const attendanceResultEditPolicyEnabled = computed(() => attendanceResultEditPolicy.value.enabled !== false)
+const attendanceResultEditReasonRequired = computed(() => attendanceResultEditPolicy.value.requireReason !== false)
+const attendanceResultEditCapabilityUnknown = computed(() => attendanceResultEditAdminCapability.value === 'unknown')
+const canEditAttendanceAnomalyResult = computed(() =>
+  attendancePluginActive.value && attendanceResultEditAdminCapability.value === 'allowed',
+)
+const attendanceResultEditSubmitDisabled = computed(() =>
+  attendanceResultEditModal.submitting
+  || !attendanceResultEditModal.snapshot
+  || !attendanceResultEditPolicyEnabled.value
+  || (attendanceResultEditReasonRequired.value && attendanceResultEditModal.reason.trim().length === 0),
+)
+
+function resetAttendanceResultEditCapability(): void {
+  attendanceResultEditAdminCapability.value = 'unknown'
+}
+
+async function ensureAttendanceResultEditCapability(): Promise<boolean> {
+  if (attendanceResultEditAdminCapability.value === 'allowed') return true
+  if (attendanceResultEditAdminCapability.value === 'forbidden') return false
+  if (attendanceResultEditAdminCapability.value === 'checking') return false
+
+  attendanceResultEditAdminCapability.value = 'checking'
+  await loadSettings()
+  if (adminForbidden.value) {
+    attendanceResultEditAdminCapability.value = 'forbidden'
+    return false
+  }
+  if (attendanceSettings.value) {
+    attendanceResultEditAdminCapability.value = 'allowed'
+    return true
+  }
+  attendanceResultEditAdminCapability.value = 'unknown'
+  return false
+}
+
+function attendanceResultEditIdempotencyKey(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+  } catch { /* fall through */ }
+  return `attendance-result-edit-${Date.now()}-${Math.floor(Math.random() * 1e9)}`
+}
+
+function normalizeAttendanceResultStatus(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase()
+}
+
+function isAttendanceResultEditSourceEditable(item: AttendanceAnomaly): boolean {
+  return ATTENDANCE_RESULT_EDIT_SOURCE_STATUSES.has(normalizeAttendanceResultStatus(item.status))
+}
+
+function computeAttendanceResultEditDisabledReason(item: AttendanceAnomaly): string {
+  if (attendanceResultEditAdminCapability.value === 'checking') {
+    return tr('Checking admin permission...', '正在检查管理员权限...')
+  }
+  if (attendanceResultEditAdminCapability.value === 'forbidden') {
+    return tr('Admin permission required.', '需要管理员权限。')
+  }
+  if (attendanceResultEditAdminCapability.value === 'allowed' && !canEditAttendanceAnomalyResult.value) {
+    return tr('Admin permission required.', '需要管理员权限。')
+  }
+  if (attendanceResultEditAdminCapability.value === 'allowed' && attendanceResultEditPolicyEnabled.value === false) {
+    return tr('Result editing is disabled by policy.', '考勤结果更正已被策略关闭。')
+  }
+  if (item.state === 'pending') {
+    return tr('Pending request exists.', '已有待处理申请。')
+  }
+  if (!isAttendanceResultEditSourceEditable(item)) {
+    return tr('This result is not editable.', '该结果不可更正。')
+  }
+  return ''
+}
+
+const attendanceResultEditDisabledReasons = computed(() => {
+  const reasons = new Map<string, string>()
+  for (const item of anomalies.value) {
+    reasons.set(item.recordId, computeAttendanceResultEditDisabledReason(item))
+  }
+  return reasons
+})
+
+function attendanceResultEditDisabledReason(item: AttendanceAnomaly): string {
+  return attendanceResultEditDisabledReasons.value.get(item.recordId)
+    ?? computeAttendanceResultEditDisabledReason(item)
+}
+
+function attendanceResultEditTargetLabel(status: AttendanceResultEditTargetStatus | string): string {
+  return formatStatus(status)
+}
+
+function attendanceResultEditErrorMessage(error: unknown, fallback = tr('Result edit failed', '考勤结果更正失败')): string {
+  const code = normalizeErrorCode((error as AttendanceApiError)?.code ?? '')
+  if (code === 'ATTENDANCE_RESULT_EDIT_DISABLED') return tr('Result editing is disabled by policy.', '考勤结果更正已被策略关闭。')
+  if (code === 'ATTENDANCE_RECORD_NOT_FOUND') return tr('The anomaly row is stale; reload anomalies.', '该异常记录已过期，请重载异常。')
+  if (code === 'ATTENDANCE_RESULT_EDIT_SOURCE_NOT_EDITABLE') return tr('The current source status is no longer editable.', '当前来源状态已不可更正。')
+  if (code === 'ATTENDANCE_RESULT_EDIT_NORMAL_TO_ABNORMAL_UNSUPPORTED') return tr('Normal results cannot be changed into abnormal results in this version.', '当前版本不支持将正常结果改为异常。')
+  if (code === 'ATTENDANCE_RESULT_EDIT_WINDOW_EXPIRED') return tr('The edit window has expired.', '更正窗口已过期。')
+  if (code === 'ATTENDANCE_RESULT_EDIT_CYCLE_CLOSED') return tr('The payroll cycle is closed or archived.', '该周期已关闭或归档。')
+  if (code === 'ATTENDANCE_RESULT_EDIT_IDEMPOTENCY_CONFLICT') return tr('This modal retry key was already used for a different edit. Close and reopen the modal.', '该弹窗重试键已用于另一笔更正，请关闭后重新打开。')
+  if (code === 'DB_NOT_READY') return tr('Attendance tables are not ready; the edit was not applied.', '考勤表尚未就绪，更正未应用。')
+  if (code === 'VALIDATION_ERROR') return (error as Error)?.message || tr('Check the required fields.', '请检查必填字段。')
+  return (error as Error)?.message || fallback
+}
+
+function resetAttendanceResultEditModal(): void {
+  attendanceResultEditModal.open = false
+  attendanceResultEditModal.snapshot = null
+  attendanceResultEditModal.targetStatus = 'normal'
+  attendanceResultEditModal.reason = ''
+  attendanceResultEditModal.evidenceLabel = ''
+  attendanceResultEditModal.evidenceUrl = ''
+  attendanceResultEditModal.submitting = false
+  attendanceResultEditModal.error = ''
+  attendanceResultEditModal.result = null
+}
+
+function clearAttendanceResultEditTransientState(): void {
+  resetAttendanceResultEditModal()
+}
+
+async function openResultEditModal(item: AttendanceAnomaly): Promise<void> {
+  const capabilityVerified = await ensureAttendanceResultEditCapability()
+  if (!capabilityVerified) {
+    const message = attendanceResultEditAdminCapability.value === 'forbidden'
+      ? tr('Admin permission required.', '需要管理员权限。')
+      : tr('Unable to verify admin permission.', '无法确认管理员权限。')
+    setStatus(appendStatusContext(message, anomaliesTimezoneContextHint.value), 'error')
+    return
+  }
+  const disabledReason = attendanceResultEditDisabledReason(item)
+  if (disabledReason) {
+    setStatus(appendStatusContext(disabledReason, anomaliesTimezoneContextHint.value), 'error')
+    return
+  }
+  attendanceResultEditModal.open = true
+  attendanceResultEditModal.snapshot = {
+    recordId: item.recordId,
+    userId: normalizedUserId() ?? currentUserId.value ?? '',
+    workDate: item.workDate,
+    sourceStatus: normalizeAttendanceResultStatus(item.status),
+    warnings: [...(Array.isArray(item.warnings) ? item.warnings : [])],
+    request: item.request ? { ...item.request } : null,
+    idempotencyKey: attendanceResultEditIdempotencyKey(),
+  }
+  attendanceResultEditModal.targetStatus = 'normal'
+  attendanceResultEditModal.reason = ''
+  attendanceResultEditModal.evidenceLabel = ''
+  attendanceResultEditModal.evidenceUrl = ''
+  attendanceResultEditModal.submitting = false
+  attendanceResultEditModal.error = ''
+  attendanceResultEditModal.result = null
+}
+
+function closeResultEditModal(): void {
+  resetAttendanceResultEditModal()
+}
+
+function buildAttendanceResultEditEvidence(): Array<Record<string, string>> {
+  const label = attendanceResultEditModal.evidenceLabel.trim()
+  const url = attendanceResultEditModal.evidenceUrl.trim()
+  if (!label && !url) return []
+  const item: Record<string, string> = {}
+  if (label) item.label = label
+  if (url) item.url = url
+  return [item]
+}
+
+function normalizeAttendanceResultEditResult(data: any): AttendanceResultEditResult {
+  const edit = data?.edit ?? {}
+  return {
+    id: String(edit.id ?? ''),
+    beforeStatus: String(edit.beforeStatus ?? ''),
+    afterStatus: String(edit.afterStatus ?? ''),
+    notificationDeliveryId: edit.notificationDeliveryId ? String(edit.notificationDeliveryId) : null,
+    notificationSkippedReason: edit.notificationSkippedReason ? String(edit.notificationSkippedReason) : null,
+    alreadyApplied: data?.alreadyApplied === true,
+  }
+}
+
+async function submitResultEditModal(): Promise<void> {
+  const snapshot = attendanceResultEditModal.snapshot
+  if (!snapshot) return
+  if (attendanceResultEditSubmitDisabled.value) return
+
+  attendanceResultEditModal.submitting = true
+  attendanceResultEditModal.error = ''
+  attendanceResultEditModal.result = null
+  try {
+    const body = {
+      orgId: normalizedOrgId(),
+      recordId: snapshot.recordId,
+      targetStatus: attendanceResultEditModal.targetStatus,
+      reason: attendanceResultEditModal.reason.trim() || undefined,
+      evidence: buildAttendanceResultEditEvidence(),
+      idempotencyKey: snapshot.idempotencyKey,
+    }
+    const response = await apiFetch('/api/attendance/anomaly-result-edits', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    const data = await response.json().catch(() => null)
+    if (!response.ok || !data?.ok) {
+      throw createApiError(response, data, tr('Result edit failed', '考勤结果更正失败'))
+    }
+    const result = normalizeAttendanceResultEditResult(data.data)
+    attendanceResultEditModal.result = result
+    attendanceResultEditModal.open = false
+    const notifyLine = result.notificationDeliveryId
+      ? tr('Employee notification enqueued.', '员工通知已入队。')
+      : result.notificationSkippedReason
+        ? tr(`Notification skipped: ${result.notificationSkippedReason}.`, `通知已跳过：${result.notificationSkippedReason}。`)
+        : tr('Notification outcome not returned.', '未返回通知结果。')
+    const statusLine = result.id
+      ? tr(`Result edit ${result.id}: ${formatStatus(result.beforeStatus)} → ${formatStatus(result.afterStatus)}.`, `结果更正 ${result.id}：${formatStatus(result.beforeStatus)} → ${formatStatus(result.afterStatus)}。`)
+      : tr(`Result edit applied: ${formatStatus(result.beforeStatus)} → ${formatStatus(result.afterStatus)}.`, `结果更正已应用：${formatStatus(result.beforeStatus)} → ${formatStatus(result.afterStatus)}。`)
+    setStatus(appendStatusContext(`${statusLine} ${notifyLine}`, anomaliesTimezoneContextHint.value))
+    await Promise.all([loadAnomalies(), loadRecords(), loadSummary()])
+    if (showAdmin.value && adminActiveSectionId.value === ATTENDANCE_ADMIN_SECTION_IDS.notificationDeliveries) {
+      void loadAttendanceNotificationDeliveries()
+    }
+  } catch (error) {
+    attendanceResultEditModal.error = attendanceResultEditErrorMessage(error)
+  } finally {
+    attendanceResultEditModal.submitting = false
+  }
+}
+
 function parseWorkingDaysInput(value: string): number[] {
   const days = value
     .split(',')
@@ -18772,6 +19186,7 @@ async function confirmMissedPunchReminder(): Promise<void> {
 }
 
 async function loadAnomalies() {
+  clearAttendanceResultEditTransientState()
   anomaliesLoading.value = true
   try {
     const query = buildQuery({
@@ -19487,6 +19902,7 @@ async function loadSettings() {
     const response = await apiFetchWithTimeout('/api/attendance/settings', {}, ATTENDANCE_ADMIN_REQUEST_TIMEOUT_MS)
     if (response.status === 403) {
       adminForbidden.value = true
+      attendanceResultEditAdminCapability.value = 'forbidden'
       attendanceSettings.value = null
       return
     }
@@ -19495,6 +19911,7 @@ async function loadSettings() {
       throw new Error(readErrorMessage(data, tr('Failed to load settings', '加载设置失败')))
     }
     adminForbidden.value = false
+    attendanceResultEditAdminCapability.value = 'allowed'
     attendanceSettings.value = (data.data as AttendanceSettings | null) ?? null
     applySettingsToForm(data.data || {})
     applyShiftComplianceToForm(data.data || {})
@@ -19510,6 +19927,7 @@ async function loadSettings() {
     applyAnnualPolicyToForm(data.data || {})
   } catch (error: any) {
     attendanceSettings.value = null
+    attendanceResultEditAdminCapability.value = 'unknown'
     setStatusFromError(error, tr('Failed to load settings', '加载设置失败'), 'admin')
   } finally {
     settingsLoading.value = false
@@ -25038,12 +25456,18 @@ onMounted(() => {
 })
 
 watch(orgId, () => {
+  resetAttendanceResultEditCapability()
+  clearAttendanceResultEditTransientState()
   if (attendancePluginActive.value) {
     refreshAll()
     if (showAdmin.value) {
       loadAdminData()
     }
   }
+})
+
+watch([fromDate, toDate, targetUserId], () => {
+  clearAttendanceResultEditTransientState()
 })
 
 watch(requestReportStatusBreakdown, (items) => {
@@ -27776,6 +28200,21 @@ const holidaySectionBindings = {
   max-height: calc(100% - 32px);
   overflow: auto;
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+}
+.attendance__result-edit-modal {
+  max-width: 640px;
+}
+.attendance__result-edit-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 12px 0;
+  font-size: 13px;
+  color: #4b5563;
+}
+.attendance__result-edit-form textarea {
+  min-height: 72px;
+  resize: vertical;
 }
 .attendance__admin-subsection {
   border-top: 1px solid var(--border, #e5e7eb);

--- a/apps/web/src/views/attendance/AttendanceRequestCenterSection.vue
+++ b/apps/web/src/views/attendance/AttendanceRequestCenterSection.vue
@@ -200,6 +200,31 @@
               >
                 {{ item.state === 'pending' ? tr('Pending request', '申请处理中') : tr('Create request', '创建申请') }}
               </button>
+              <button
+                v-if="resultEditCapabilityUnknown"
+                class="attendance__btn"
+                data-attendance-result-edit-probe
+                @click="openResultEditModal(item)"
+              >
+                {{ tr('Check edit access', '检查更正权限') }}
+              </button>
+              <button
+                v-else
+                class="attendance__btn"
+                :disabled="Boolean(resultEditDisabledReason(item))"
+                :title="resultEditDisabledReason(item) || undefined"
+                data-attendance-result-edit-open
+                @click="openResultEditModal(item)"
+              >
+                {{ tr('Edit result', '修改结果') }}
+              </button>
+              <small
+                v-if="resultEditCapabilityUnknown || resultEditDisabledReason(item)"
+                class="attendance__field-hint"
+                data-attendance-result-edit-disabled-reason
+              >
+                {{ resultEditCapabilityUnknown ? tr('Check admin permission before editing.', '更正前需先检查管理员权限。') : resultEditDisabledReason(item) }}
+              </small>
             </td>
           </tr>
         </tbody>
@@ -348,6 +373,9 @@ interface RequestCenterBindings {
   resolveRequest: (id: string, action: RequestResolutionAction) => MaybePromise<void>
   loadAnomalies: () => MaybePromise<void>
   prefillRequestFromAnomaly: (item: AttendanceAnomalyItem) => MaybePromise<void>
+  resultEditCapabilityUnknown: Ref<boolean>
+  openResultEditModal: (item: AttendanceAnomalyItem) => MaybePromise<void>
+  resultEditDisabledReason: (item: AttendanceAnomalyItem) => string
   loadRequestReport: () => MaybePromise<void>
   focusCalendarMonth: (value: string | null | undefined) => MaybePromise<void>
   shiftMonth: (delta: number) => MaybePromise<void>
@@ -392,6 +420,9 @@ const cancelRequest = (id: string) => props.requestCenter.cancelRequest(id)
 const resolveRequest = (id: string, action: RequestResolutionAction) => props.requestCenter.resolveRequest(id, action)
 const loadAnomalies = () => props.requestCenter.loadAnomalies()
 const prefillRequestFromAnomaly = (item: AttendanceAnomalyItem) => props.requestCenter.prefillRequestFromAnomaly(item)
+const resultEditCapabilityUnknown = props.requestCenter.resultEditCapabilityUnknown
+const openResultEditModal = (item: AttendanceAnomalyItem) => props.requestCenter.openResultEditModal(item)
+const resultEditDisabledReason = (item: AttendanceAnomalyItem) => props.requestCenter.resultEditDisabledReason(item)
 const loadRequestReport = () => props.requestCenter.loadRequestReport()
 const focusCalendarMonth = (value: string | null | undefined) => props.requestCenter.focusCalendarMonth(value)
 const shiftMonth = (delta: number) => props.requestCenter.shiftMonth(delta)
@@ -557,7 +588,15 @@ function formatLeaveTypeLabel(item: { name?: string | null; paid?: boolean | nul
 }
 
 .attendance__table-actions {
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.attendance__field-hint {
+  color: #777;
+  font-size: 11px;
 }
 
 .attendance__empty {

--- a/apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts
+++ b/apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, reactive, ref, type App } from 'vue'
+import AttendanceRequestCenterSection from '../src/views/attendance/AttendanceRequestCenterSection.vue'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+const anomaly = {
+  recordId: 'rec-1',
+  workDate: '2026-06-30',
+  status: 'late',
+  firstInAt: '2026-06-30T09:12:00.000Z',
+  lastOutAt: '2026-06-30T18:00:00.000Z',
+  workMinutes: 480,
+  lateMinutes: 12,
+  earlyLeaveMinutes: 0,
+  warnings: ['late'],
+  state: 'open' as const,
+  request: null,
+  suggestedRequestType: 'time_correction',
+}
+
+function tr(en: string): string {
+  return en
+}
+
+function mountSection(overrides: Partial<{
+  resultEditCapabilityUnknown: boolean
+  resultEditDisabledReason: (item: typeof anomaly) => string
+  openResultEditModal: (item: typeof anomaly) => void
+}> = {}) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const openResultEditModal = overrides.openResultEditModal ?? vi.fn()
+  const resultEditDisabledReason = overrides.resultEditDisabledReason ?? vi.fn(() => '')
+  const requestCenter = {
+    requestForm: reactive({
+      workDate: '2026-06-30',
+      requestType: 'time_correction',
+      requestedInAt: '',
+      requestedOutAt: '',
+      reason: '',
+      leaveTypeId: '',
+      overtimeRuleId: '',
+      minutes: '',
+      attachmentUrl: '',
+    }),
+    requestSubmitting: ref(false),
+    loading: ref(false),
+    requests: ref([]),
+    anomalies: ref([anomaly]),
+    anomaliesLoading: ref(false),
+    requestReport: ref([]),
+    reportLoading: ref(false),
+    leaveTypes: ref([]),
+    overtimeRules: ref([]),
+    isLeaveRequest: ref(false),
+    isOvertimeRequest: ref(false),
+    isLeaveOrOvertimeRequest: ref(false),
+    submitRequest: vi.fn(),
+    loadRequests: vi.fn(),
+    cancelRequest: vi.fn(),
+    resolveRequest: vi.fn(),
+    loadAnomalies: vi.fn(),
+    prefillRequestFromAnomaly: vi.fn(),
+    resultEditCapabilityUnknown: ref(overrides.resultEditCapabilityUnknown ?? false),
+    openResultEditModal,
+    resultEditDisabledReason,
+    loadRequestReport: vi.fn(),
+    focusCalendarMonth: vi.fn(),
+    shiftMonth: vi.fn(),
+  }
+  app = createApp(AttendanceRequestCenterSection, {
+    requestCenter,
+    calendarDays: [],
+    calendarLabel: 'June 2026',
+    weekDays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    formatDate: (value: string) => value,
+    formatDateTime: (value: string) => value,
+    formatRequestType: (value: string) => value,
+    formatStatus: (value: string) => value,
+    formatWarningsShort: (warnings: string[]) => warnings.join(', '),
+    tr,
+  })
+  app.mount(container)
+  return { openResultEditModal, resultEditDisabledReason }
+}
+
+afterEach(() => {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+})
+
+describe('AttendanceRequestCenterSection result edit action', () => {
+  it('calls the shared result-edit modal callback from anomaly rows', async () => {
+    const { openResultEditModal } = mountSection()
+    await nextTick()
+    const button = container?.querySelector('[data-attendance-result-edit-open]') as HTMLButtonElement
+    expect(button).toBeTruthy()
+    expect(button.disabled).toBe(false)
+    button.click()
+    expect(openResultEditModal).toHaveBeenCalledWith(anomaly)
+  })
+
+  it('renders the parent-provided disabled reason without calling the callback', async () => {
+    const openResultEditModal = vi.fn()
+    mountSection({
+      openResultEditModal,
+      resultEditDisabledReason: () => 'Admin permission required.',
+    })
+    await nextTick()
+    const button = container?.querySelector('[data-attendance-result-edit-open]') as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+    expect(container?.querySelector('[data-attendance-result-edit-disabled-reason]')?.textContent).toContain('Admin permission required.')
+    button.click()
+    expect(openResultEditModal).not.toHaveBeenCalled()
+  })
+
+  it('renders a probe-only action before capability is known', async () => {
+    const openResultEditModal = vi.fn()
+    mountSection({
+      resultEditCapabilityUnknown: true,
+      openResultEditModal,
+    })
+    await nextTick()
+    expect(container?.querySelector('[data-attendance-result-edit-open]')).toBeNull()
+    const probe = container?.querySelector('[data-attendance-result-edit-probe]') as HTMLButtonElement
+    expect(probe).toBeTruthy()
+    expect(container?.querySelector('[data-attendance-result-edit-disabled-reason]')?.textContent).toContain('Check admin permission')
+    probe.click()
+    expect(openResultEditModal).toHaveBeenCalledWith(anomaly)
+  })
+})

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -119,6 +119,8 @@ describe('Attendance admin regressions', () => {
   let scheduleGroupsData: unknown[] | null = null
   let scheduleDispatchRequestsData: Record<string, unknown> | null = null
   let attendanceRequestsData: unknown[] | null = null
+  let attendanceAnomaliesData: unknown[] | null = null
+  let attendanceResultEditPosts: Array<Record<string, unknown>> = []
   let autoShiftPreviewStatus = 200
   let autoShiftPreviewData: Record<string, unknown> | null = null
   let autoShiftApplyStatus = 200
@@ -136,6 +138,8 @@ describe('Attendance admin regressions', () => {
     scheduleGroupsData = null
     scheduleDispatchRequestsData = null
     attendanceRequestsData = null
+    attendanceAnomaliesData = null
+    attendanceResultEditPosts = []
     autoShiftPreviewStatus = 200
     autoShiftPreviewData = null
     autoShiftApplyStatus = 200
@@ -685,6 +689,35 @@ describe('Attendance admin regressions', () => {
           },
         })
       }
+      if (url.includes('/api/attendance/anomalies')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: attendanceAnomaliesData ?? [],
+            total: attendanceAnomaliesData?.length ?? 0,
+            page: 1,
+            pageSize: 50,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/anomaly-result-edits')) {
+        const body = JSON.parse(String((init as { body?: string } | undefined)?.body || '{}')) as Record<string, unknown>
+        attendanceResultEditPosts.push(body)
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            alreadyApplied: false,
+            edit: {
+              id: 'edit-1',
+              beforeStatus: 'late',
+              afterStatus: body.targetStatus,
+              notificationDeliveryId: 'delivery-1',
+              notificationSkippedReason: null,
+            },
+            record: { id: body.recordId, status: body.targetStatus },
+          },
+        })
+      }
       if (url.includes('/api/attendance/auto-shift-matching/apply')) {
         if (autoShiftApplyStatus >= 400) {
           return jsonResponse(autoShiftApplyStatus, {
@@ -833,6 +866,188 @@ describe('Attendance admin regressions', () => {
     ).toEqual([])
     expect(container!.querySelector('[data-missed-punch-reminder-admin]')).toBeNull()
     expect(container!.querySelector('[data-missed-punch-reminder-toolbar]')).toBeNull()
+  })
+
+  it('overview result-edit rows stay probe-only until admin capability is checked', async () => {
+    attendanceAnomaliesData = [
+      {
+        recordId: 'record-a',
+        workDate: '2026-05-13',
+        status: 'late',
+        firstInAt: '2026-05-13T09:12:00.000Z',
+        lastOutAt: '2026-05-13T18:00:00.000Z',
+        workMinutes: 480,
+        lateMinutes: 12,
+        earlyLeaveMinutes: 0,
+        warnings: ['late'],
+        state: 'open',
+        request: null,
+        suggestedRequestType: 'time_correction',
+      },
+    ]
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(12)
+
+    expect(container!.querySelector('[data-attendance-result-edit-open]')).toBeNull()
+    const probe = container!.querySelector<HTMLButtonElement>('[data-attendance-result-edit-probe]')
+    expect(probe).toBeTruthy()
+    expect(container!.querySelector('[data-attendance-result-edit-disabled-reason]')?.textContent).toContain('Check admin permission')
+    expect(
+      vi.mocked(apiFetch).mock.calls.some(([url]) => String(url).includes('/api/attendance/settings')),
+    ).toBe(false)
+
+    probe!.click()
+    await flushUi(12)
+
+    expect(
+      vi.mocked(apiFetch).mock.calls.some(([url]) => String(url).includes('/api/attendance/settings')),
+    ).toBe(true)
+    expect(container!.querySelector('[data-attendance-result-edit-modal]')).toBeTruthy()
+  })
+
+  it('overview result-edit probe fails closed when admin capability cannot be verified', async () => {
+    attendanceSettingsFail = true
+    attendanceAnomaliesData = [
+      {
+        recordId: 'record-a',
+        workDate: '2026-05-13',
+        status: 'late',
+        firstInAt: '2026-05-13T09:12:00.000Z',
+        lastOutAt: '2026-05-13T18:00:00.000Z',
+        workMinutes: 480,
+        lateMinutes: 12,
+        earlyLeaveMinutes: 0,
+        warnings: ['late'],
+        state: 'open',
+        request: null,
+        suggestedRequestType: 'time_correction',
+      },
+    ]
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(12)
+
+    const probe = container!.querySelector<HTMLButtonElement>('[data-attendance-result-edit-probe]')
+    expect(probe).toBeTruthy()
+    probe!.click()
+    await flushUi(12)
+
+    expect(
+      vi.mocked(apiFetch).mock.calls.some(([url]) => String(url).includes('/api/attendance/settings')),
+    ).toBe(true)
+    expect(container!.querySelector('[data-attendance-result-edit-modal]')).toBeNull()
+    expect(attendanceResultEditPosts).toHaveLength(0)
+  })
+
+  it('overview result-edit submit uses the modal snapshot and does not refresh admin deliveries', async () => {
+    attendanceSettingsData = {
+      attendanceResultEditPolicy: {
+        enabled: true,
+        requireReason: true,
+        notifyAffectedEmployee: true,
+      },
+    }
+    attendanceAnomaliesData = [
+      {
+        recordId: 'record-a',
+        workDate: '2026-05-13',
+        status: 'late',
+        firstInAt: '2026-05-13T09:12:00.000Z',
+        lastOutAt: '2026-05-13T18:00:00.000Z',
+        workMinutes: 480,
+        lateMinutes: 12,
+        earlyLeaveMinutes: 0,
+        warnings: ['late'],
+        state: 'open',
+        request: null,
+        suggestedRequestType: 'time_correction',
+      },
+    ]
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(12)
+
+    container!.querySelector<HTMLButtonElement>('[data-attendance-result-edit-probe]')!.click()
+    await flushUi(12)
+    expect(container!.querySelector('[data-attendance-result-edit-modal]')).toBeTruthy()
+
+    attendanceAnomaliesData = [
+      {
+        recordId: 'record-b',
+        workDate: '2026-05-14',
+        status: 'absent',
+        firstInAt: null,
+        lastOutAt: null,
+        workMinutes: 0,
+        lateMinutes: 0,
+        earlyLeaveMinutes: 0,
+        warnings: ['absent'],
+        state: 'open',
+        request: null,
+        suggestedRequestType: 'time_correction',
+      },
+    ]
+    setInput(container!, '[data-attendance-result-edit-reason]', 'corrected from manager review')
+    await flushUi(2)
+    container!.querySelector<HTMLButtonElement>('[data-attendance-result-edit-submit]')!.click()
+    await flushUi(16)
+
+    expect(attendanceResultEditPosts).toHaveLength(1)
+    expect(attendanceResultEditPosts[0]).toMatchObject({
+      recordId: 'record-a',
+      targetStatus: 'normal',
+      reason: 'corrected from manager review',
+      idempotencyKey: expect.any(String),
+    })
+    expect(attendanceResultEditPosts[0]).not.toHaveProperty('overrideMetrics')
+    expect(
+      vi.mocked(apiFetch).mock.calls.some(([url]) => String(url).includes('/api/attendance/notification-deliveries')),
+    ).toBe(false)
+  })
+
+  it('overview result-edit modal clears when anomalies reload starts', async () => {
+    attendanceSettingsData = {
+      attendanceResultEditPolicy: {
+        enabled: true,
+        requireReason: false,
+      },
+    }
+    attendanceAnomaliesData = [
+      {
+        recordId: 'record-a',
+        workDate: '2026-05-13',
+        status: 'late',
+        firstInAt: '2026-05-13T09:12:00.000Z',
+        lastOutAt: '2026-05-13T18:00:00.000Z',
+        workMinutes: 480,
+        lateMinutes: 12,
+        earlyLeaveMinutes: 0,
+        warnings: ['late'],
+        state: 'open',
+        request: null,
+        suggestedRequestType: 'time_correction',
+      },
+    ]
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(12)
+
+    container!.querySelector<HTMLButtonElement>('[data-attendance-result-edit-probe]')!.click()
+    await flushUi(12)
+    expect(container!.querySelector('[data-attendance-result-edit-modal]')).toBeTruthy()
+
+    const reloadButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Reload anomalies'))
+    expect(reloadButton).toBeTruthy()
+    reloadButton!.click()
+    await flushUi(2)
+
+    expect(container!.querySelector('[data-attendance-result-edit-modal]')).toBeNull()
   })
 
   it('overview self-service — the annual leave card reads the token-locked /me balance (no userId param)', async () => {


### PR DESCRIPTION
## Summary
- add the AE-3 attendance result-edit modal and shared row action for both anomaly surfaces
- keep overview safe with a probe-only admin capability check before exposing the write action
- fail closed if admin capability cannot be verified, and submit a modal-open snapshot with idempotency key, reason/evidence, and no overrideMetrics
- refresh admin notification deliveries only when the admin deliveries section is active

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/AttendanceRequestCenterSection.result-edit.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-surface-modes.spec.ts tests/attendance-selfservice-dashboard.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- git diff --check

## Review notes
- independent reviewer re-checked the prior P1/P2 risks: unknown capability is probe-only, settings probe failure fails closed without opening the modal, overview does not preload settings until probe, success does not refresh admin-only deliveries outside the active admin section, and real mount tests cover the path.
- addressed Gemini's non-blocking nits by caching disabled-reason computation and replacing source-grep assertions with real mount coverage.