### PR TITLE
docs(approval): fix A3 as-built drift (P2) + first-batch per-rung decision ballot

### DIFF
--- a/docs/development/approval-automation-first-batch-ballot-20260701.md
+++ b/docs/development/approval-automation-first-batch-ballot-20260701.md
@@ -1,0 +1,64 @@
+# Approval & Process-Automation — first-batch per-rung decision ballot (2026-07-01)
+
+> **Per-rung ballot** (NOT blanket approval) for the four first-batch rungs picked by unblock-value:
+> T1-3 · T3-4 · T0-3 (Lane C, sequential — same hot file) ∥ T1-1 slice-2 (Lane B). Each line = one open
+> decision + the proposed default. **Vote per item:** ✅ adopt default · ✏️ override (state the change) ·
+> ⏸ hold. A rung with all items ✅/✏️ is GO — build starts on the ratified defaults, fail-first + real-DB,
+> PR-for-review. An un-voted rung stays gated. Full decision text + code anchors live in
+> `approval-automation-decision-register-20260629.md`; this ballot **amends 3 defaults** with
+> post-register facts (marked **AMENDED**, with the reason). Sizing figures are optimistic build-effort,
+> **not calendar commitments** — review rounds on security/permission surfaces may dominate.
+
+## T1-3 — `approval.*` automation trigger · M (~2–3pd) · Lane C first
+
+| # | 决策 | 建议默认 | 票 |
+|---|---|---|---|
+| Q1 | 路由/范围键 | `config.templateId` **REQUIRED**;`loadEnabledApprovalRules(templateId)` 跨 sheet 查询,v1 无迁移/索引。**AMENDED:** register 原 default 声称 templateId 恒非空 —— 已被 register 自己的 reviewer note 证伪(`ApprovalInstanceRow.template_id` 是 `string\|null`,经 `nullableString()` → null)。修正:templateId 仍为唯一路由键;**null-template completion 显式声明 v1 out-of-contract**(永不匹配任何规则;fire 时若存在 enabled approval 规则则记 debug 日志),真实 null-template 消费者出现时立具名 follow-up | ⬜ |
+| Q2 | 跨租户授权 | create/update 时要求规则 createdBy 对配置的 templateId 持 `approvals:read`/模板可见性,fire 时复查;否则 deny+skip(复用 bridge 的 permission-code 查询) | ⬜ |
+| Q3 | record-less + action 白名单 | v1 无记录上下文(synthetic payload,`recordId=''`,审批事件挂 `triggerEvent`);action 仅允许 send_notification / send_webhook / send_email / send_dingtalk_*;含 record-targeting 或 start_approval 的规则在保存时拒绝 | ⬜ |
+| Q4 | 循环/深度防护 | (a) 结构性断环:禁 start_approval + record-writing(随 Q3);(b) synthetic 执行播种 `_automationDepth = (bridge 深度 ?? 0)+1`;(c) eventId 硬去重(见 Q5) | ⬜ |
+| Q5 | 幂等/重投递 | **AMENDED:** register 原 default 是"新建小 ledger"——T2-6 已落(#3450),改为**复用 `meta_automation_event_fires` claim-before-execute**,dedupKey = `approval.completed:{event.eventId}`(eventId 已含 `instanceId:toVersion:eventType`,天然唯一);**无新迁移**(同时消解 register 里 no-migration non-goal 与 Q5 的内部矛盾) | ⬜ |
+| Q6 | 触发器形状 | 单一 trigger type `approval.completed` + 可选 `config.outcomes?: ('approved'\|'rejected'\|'revoked'\|'cancelled')[]`(默认 approved-only) | ⬜ |
+| Q7 | 与 W6 bridge 的关系 | 互不抑制:bridge resume 与 fresh trigger 是不同消费者,所有 completion 事件都 fire fresh 规则(文档写明 X 启动的审批可触发自动化 Y) | ⬜ |
+| Q8 | conditions | v1 非目标:该触发器带非空 ConditionGroup 的规则保存时拒绝;审批字段条件词表是具名 follow-up | ⬜ |
+
+## T3-4 — W7 rejection backwrite · S-M (~1–2pd) · Lane C after T1-3
+
+| # | 决策 | 建议默认 | 票 |
+|---|---|---|---|
+| D1 | 尾部语义 | **WRITE-BACK-THEN-FAIL**:非 approved 终态时先回写记录,run 仍按今日契约 terminal-failed、tail 跳过("拒绝时通知"的诉求由 T1-3 承接更干净) | ⬜ |
+| D2 | 存量规则 | **OPT-IN**:新增 `resultWriteback.onNonApproved`(默认 false);已保存规则行为不变,作者显式开启 | ⬜ |
+| D3 | 覆盖终态 | `toStatus !== 'approved'` 三态统一(rejected/revoked/cancelled) | ⬜ |
+| D4 | approverField 语义 | 写终态操作者(null-safe:`event.actor?.id ?? null`);文档写明非 approved 路径该字段含义是"完成者" *(注:keystone 测试与本项耦合 —— 若改此项,测试断言随之改)* | ⬜ |
+| D5 | select 校验强度 | LENIENT:保存端仍只校验 'approved' option;缺 option 的终态运行时 skip + `backwriteSkipped` 可观测,不新拒存量规则 | ⬜ |
+| D6 | 下游扇出 | 与 approved 路径对等:深度防护的 `multitable.record.updated` + realtime 照发(复用 `writeApprovalResultBack` 免费获得) | ⬜ |
+
+## T0-3 — delete_record 编辑器安全露出 · S (~1–2pd) · Lane C after T3-4
+
+| # | 决策 | 建议默认 | 票 |
+|---|---|---|---|
+| Q1 | 跨 base 露出 | v1 **仅 same-base**(trigger-record delete);跨 base 保持 runtime-capable 但编辑器不露出,单独 gated slice | ⬜ |
+| Q2 | 防误删确认 | 必选 acknowledgement checkbox 阻塞 Save(文案:永久不可撤销);ack 存 authoring state,**不进 action.config**(serialize 显式 delete_record 分支输出干净 `{}`)。**建 build 契约补充:** 已保存规则编辑时 ack 预勾选、新加 delete action 必须重新勾;ack/hint 文案走 i18n 模块 | ⬜ |
+| Q3 | 爆炸半径 | trigger-record-only:same-base delete 只删触发记录(空 config),v1 无 id/字段路径选择器 | ⬜ |
+| Q4 | 保存端校验 | 扩展 `validateCrossBaseWriteConfig` 到 delete_record(和 lock_record)—— 与编辑器露出无关的 fail-closed-at-save 补防(该 action 本就 API 可存) | ⬜ |
+| Q5 | Test Run 语义 | 保持现状 + 编辑器非阻塞提示(Test Run 用合成记录、不会删真实记录);不为破坏性 action 特判 | ⬜ |
+| Q6 | 作者权限 | 与其它记录变更 action 对齐 `canManageAutomation`,本 rung 不加新 capability | ⬜ |
+| Q7 | 审计 | 复用既有 execution-log + `multitable.record.deleted`;独立破坏性审计/retention 仅在 owner 要求时再立项 | ⬜ |
+
+## T1-1 slice-2 — transfer/jump 超时效果 · M (~2–3pd) · Lane B(与 Lane C 并行)
+
+*slice-1 已定且已上线(不投票):存储=approval_metrics 标量列 · remind 单发 · wall-clock 分钟 + 重入重置 deadline · afterMinutes 粒度。*
+
+| # | 决策 | 建议默认 | 票 |
+|---|---|---|---|
+| Q1 | 本 slice 接通哪些效果 | **transfer + jump**;auto_approve/auto_reject 保留在枚举但 runtime-INERT,置于 `APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS` env gate + 模板发布时确认之后(declared-but-do-not-wire 先例) | ⬜ |
+| QS-a | target 配置 schema(register 未单列,slice-2 必须定) | `timeout.transferToUserId`(静态单用户,publish 校验非空;role/chain 升级不在本 slice)· `timeout.jumpToNodeKey`(publish 校验:节点存在、approval 类型、非 parallel-region;直达 terminal 已有校验阻挡) | ⬜ |
+| QS-b | 间接级联 carve-out | timeout-jump 落点若自动完成(如 mergeWithRequester)并级联到 terminal = 事实 auto-approve → **归入 Q1 同一 terminal gate**:gate 未开则 fire 时 skip effect + 结构化日志(不 fallback 成 remind);gate 开启才允许级联 | ⬜ |
+| Q3 | 审计判别 | 复用既有 record actions(transfer/jump)+ `metadata.timeoutEffect=true`(adminJump 先例);不动 CHECK 约束 | ⬜ |
+| Q6 | parallel region | 区内 remind-only;parallel-branch 节点上的 transfer/jump/auto_* 超时配置 publish-reject | ⬜ |
+| Q7 | 执行者身份 | 保留系统 actor `system:approval-timeout` 记入 actorId+metadata;auto_reject(将来启用)合成 system comment 以满足 rejectCommentRequired | ⬜ |
+
+## 投票方式
+- 直接在对话里逐项回复(如 "T1-3 全✅,Q1 ✏️ 改成 …"),或编辑本文件把 ⬜ 改 ✅/✏️/⏸。
+- 每个 rung 独立 GO;GO 后按 lane 顺序开建(Lane C: T1-3 → T3-4 → T0-3;Lane B: T1-1-s2 可并行)。
+- 第二批候选(本批消化后再出 ballot):T1-2 inbound webhook · T3-5 cross-base backwrite · T2-1+2 · T1-4。

--- a/docs/development/approval-automation-parallel-development-plan-20260701.md
+++ b/docs/development/approval-automation-parallel-development-plan-20260701.md
@@ -24,7 +24,8 @@
   round via `to_version >= <re-entry cutoff>` (schema-free, uses existing data); no re-entry -> exact old query.
   The `#3453` follow-up locks the same-version requester auto-approval cascade boundary that requires `>=`.
 - **T2-6 event dedup ledger — SHIPPED (`#3450`):** automation record-change/form-submit dispatch now has a
-  database-backed event-fire ledger, TTL/count sweep, real-DB coverage, and CI wiring. This removes the substrate
+  database-backed event-fire ledger (7-day TTL retention sweep only — no count cap), real-DB coverage, and CI
+  wiring. This removes the substrate
   blocker for approval-trigger and inbound-webhook work, but those feature rungs remain owner-gated.
 
 ## 2. Un-completed items — gating
@@ -109,10 +110,16 @@ so a future `>` change fails).
 a database-backed fire ledger, redelivery/replay can execute side effects more than once. T1-2 inbound webhook and
 T1-3 approval-trigger both need the same substrate before they can safely expose higher-frequency event sources.
 
-**Shipped implementation:** `meta_automation_event_fires` stores `(rule_id, base_id, event_key)` first-write-wins
-claims, with a bounded retention sweep (TTL + per-rule cap). The executor checks/claims before side effects and
-skips duplicate deliveries without treating them as rule failures. Record-service/write-service integrations feed
-stable event identities for the currently shipped sources.
+**Shipped implementation (exact shape):** `meta_automation_event_fires(rule_id, dedup_key, fired_at)` with
+**PRIMARY KEY `(rule_id, dedup_key)`** (+ `fired_at` index; `rule_id` FK → `automation_rules` ON DELETE CASCADE).
+`dedup_key = ${eventType}:${_eventId}` — a transport `_eventId` is stamped at every emit site for the shipped
+sources (record.created/updated/deleted, form.submitted, field.value_changed via record.updated); a missing
+`_eventId` stays **fail-open during rollout** (the ledger only gates stamped events). Claim-then-fire:
+`INSERT … ON CONFLICT DO NOTHING RETURNING` — the rule executes only if it won the insert (at-most-once), and a
+lost claim is a skipped duplicate, not a rule failure. Retention: **7-day TTL sweep only** (`fired_at < cutoff`,
+kicked at most once per 24h, best-effort) — there is NO `base_id` column, NO `event_key` column, and NO per-rule
+count cap. T1-3 will reuse this ledger with `dedup_key = approval.completed:${event.eventId}` (the approval
+completion event's own unique id — no `_eventId` stamping needed) and **no new migration** (ballot Q5).
 
 **Verification:** pure dedup-key tests, automation-service unit coverage, real-DB `multitable-event-dedup-trigger`
 coverage wired into `plugin-tests.yml`, plus regression updates for record-service/write-service callers.

--- a/docs/development/approval-automation-parallel-development-plan-20260701.md
+++ b/docs/development/approval-automation-parallel-development-plan-20260701.md
@@ -1,10 +1,12 @@
 # Approval & Process-Automation — un-completed items, parallel-development plan & verification (2026-07-01)
 
-> **As-built coordination plan** (updated to main after `#3451`/`#3452`/`#3450`/`#3453` merged). Deep review of what
+> **As-built coordination plan** (updated to main after `#3451`/`#3452`/`#3450`/`#3453` and the A3-a/b slices
+> `#3455`/`#3457`/`#3460` merged). Deep review of what
 > remains on the line, classified by gating and **sequenced into parallel lanes** so work distributes across
 > sessions without hot-file collision. **Shipped since the first cut:** T2-4 re-entry quorum-bypass (`#3446`,
 > `to_version >= cutoff`) + same-version cascade regression (`#3453`), R1-A/R1-B egress closure (`#3437`/`#3443`/
-> `#3447`/`#3451`), A3 rollout design-lock (`#3452`), and T2-6 event dedup ledger (`#3450`). **Honest framing:** the
+> `#3447`/`#3451`), A3 rollout design-lock + **runtime policy plumbing** (`#3452` + `#3455`/`#3457`/`#3460`),
+> and T2-6 event dedup ledger (`#3450`). **Honest framing:** the
 > remainder is owner-gated (design-lock-first) — so "complete all development" is realized by
 > *ratifying defaults **per lane/rung** (not blanket — it mixes SSRF / destructive-delete / permission-migration
 > / cross-base-writeback risk) + distributing the lanes*, not one session building everything.
@@ -33,7 +35,7 @@
 | ~~T2-4 same-version cascade regression~~ | approval engine | **SHIPPED (#3453)** | done — locks that same-version auto-approval at re-entry counts under `>=` |
 | ~~ISATAP `0200:5efe` u/l-bit + IPv4-compat~~ | BPMN (guard) | **SHIPPED (#3437/#3443)** | done — classifier folds both ISATAP u/l forms + `::/96` |
 | ~~R1-B DNS-pinned dispatcher + wiring + redirect re-validation~~ | BPMN/workflow | **SHIPPED (#3447/#3451)** | done — raw BPMN HTTP-task fetch path replaced; default policy deny-all |
-| **R1-A3** policy rollout / configured destination enablement | BPMN/workflow | design-lock shipped, runtime unshipped | owner/governance-gated; `#3452` records server-owned policy source and no live destination authorization |
+| **R1-A3** configured destination enablement | BPMN/workflow | **runtime SHIPPED** (#3455/#3457/#3460), destinations not yet authorized | governance-only remainder: `#3460` injects the server-owned `BPMN_HTTP_TASK_EGRESS_POLICY` env policy at both BPMN route construction points; `#3455` normalizer + `#3457` route-provenance locks are in. **No core runtime code left** — what remains is authorizing/configuring the first live destination (ops/governance per `#3452`), default stays deny-all |
 | T1-1 slice-2 transfer/jump timeout effects | approval engine | unshipped | owner-gated (transfer/jump **target-config schema** + indirect jump→terminal carve-out; auto_* env-gated) |
 | T2-1+2 scoped admins + handover | approval engine | unshipped | owner-gated (permission model + migration) |
 | T1-4 node field-perms runtime | approval engine | unshipped | owner-gated (edit-form-at-node prerequisite) |
@@ -52,10 +54,11 @@ The constraint is **hot files**: items sharing one runtime file must be **sequen
 edits to `ApprovalProductService.ts` / `automation-service.ts` collide).
 
 - **Lane A — BPMN/workflow** (`BPMNWorkflowEngine.ts`, `routes/workflow*`, `guards/egress-guard.ts`):
-  R1-A guard/classifier **done** (#3437/#3443), dispatcher **done** (#3447), engine wiring **done** (#3451).
-  The remaining BPMN egress work is **A3 policy rollout/configured enablement**, which is a governance gate:
-  server-owned policy source, route-provenance negative controls, and explicit destination enablement. No live
-  destination is authorized by the default-closed R1-B runtime.
+  R1-A guard/classifier **done** (#3437/#3443), dispatcher **done** (#3447), engine wiring **done** (#3451),
+  **A3 policy plumbing done** (#3455 normalizer / #3457 route-provenance locks / #3460 server-owned
+  `BPMN_HTTP_TASK_EGRESS_POLICY` env injection at both route construction points). The ONLY remaining egress work
+  is **destination authorization** — a config/ops governance act per `#3452`, not code. Default stays deny-all
+  until a first named destination is explicitly authorized.
 - **Lane B — approval engine** (`ApprovalProductService.ts` — HOT, so sequential): ~~`T2-4 fix`~~ **done (#3446)**
   + cascade regression **done (#3453)** → next `T1-1 slice-2` → `T2-1+2` → `T1-4`. (`T3-4/T3-5` W7-backwrite touch
   `automation-service.ts`, see Lane C.)
@@ -117,9 +120,13 @@ coverage wired into `plugin-tests.yml`, plus regression updates for record-servi
 ## 7. Recommendation
 1. **Done:** T2-4 fix + cascade regression (#3446/#3453) · R1-A/R1-B default-closed egress closure
    (#3437/#3443/#3447/#3451) · T2-6 dedup ledger (#3450).
-2. **Next security gate:** A3 egress policy rollout/configured enablement — design-lock shipped in `#3452`, but
-   runtime still requires per-slice owner opt-in. Default runtime remains deny-all until a server-owned policy is
-   explicitly configured.
+2. **A3 is now governance-only:** the egress policy runtime is fully shipped (`#3452` design-lock +
+   `#3455`/`#3457`/`#3460` normalizer / provenance locks / server-owned env injection). Default remains deny-all;
+   the remaining act is **authorizing the first live destination** (config/ops), which happens when a named
+   integration needs it — no code slice to schedule.
 3. **Next feature lanes after owner ratification:** Lane C `T1-3 approval-trigger` / `T1-2 inbound webhook`
    (dedup dependency now met), or Lane B `T1-1 slice-2` (transfer/jump timeout effects). Continue to ratify
-   register defaults **per lane/rung**, not blanket.
+   register defaults **per lane/rung**, not blanket — the first-batch per-rung ballot lives in
+   `approval-automation-first-batch-ballot-20260701.md`. Sizing note: per-rung person-day estimates are
+   optimistic build-effort figures, NOT calendar commitments — on the security/permission/migration rungs
+   (T1-2, T2-1+2, T3-5) review rounds can cost more calendar than the build itself.


### PR DESCRIPTION
Two docs changes per the review of the line assessment:

## 1. P2 doc-drift fix — A3 is runtime-shipped, governance-remaining
The plan doc still said R1-A3 "design-lock shipped, **runtime unshipped**". Verified as-built: `#3455` normalizer + `#3457` route-provenance locks + `#3460` server-owned `BPMN_HTTP_TASK_EGRESS_POLICY` env policy injected at **both** BPMN route construction points (`BPMNWorkflowEngine.ts:234` constructor, `:655` dispatch). Remaining = **authorizing/configuring the first live destination** (ops/governance per `#3452`), not code. Reworded header/§2/§3/§7 accordingly + added the sizing caveat (estimates ≠ calendar commitments).

## 2. First-batch **per-rung** ballot (not blanket)
`approval-automation-first-batch-ballot-20260701.md` — T1-3 / T3-4 / T0-3 (Lane C, sequential) ∥ T1-1 slice-2 (Lane B). Every open register decision is one voteable line (✅ default / ✏️ override / ⏸ hold). Three defaults **AMENDED** with post-register facts, each with the reason:
- **T1-3 Q1:** templateId routing kept, but null-template completions declared v1 out-of-contract (the register's own reviewer note disproved the "templateId reliably non-null" anchor).
- **T1-3 Q5:** reuse the now-shipped T2-6 `meta_automation_event_fires` claim ledger (`approval.completed:{event.eventId}`), no new migration.
- **T1-1-s2:** explicit target-config schema (`transferToUserId`/`jumpToNodeKey` publish validation) + the indirect jump→terminal cascade folded under the `APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS` gate.

Voting a rung GO starts its build on the ratified defaults (fail-first + real-DB, PR-for-review). Un-voted rungs stay gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)