### PR TITLE
feat(automation): approval.completed trigger — template-routed, record-less v1 (T1-3)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -299,6 +299,7 @@ jobs:
             tests/integration/multitable-form-submit-trigger.test.ts \
             tests/integration/multitable-event-dedup-trigger.test.ts \
             tests/integration/multitable-form-submit-start-approval-smoke.test.ts \
+            tests/integration/automation-approval-completed-trigger.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260702090000_add_approval_completed_trigger_type.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260702090000_add_approval_completed_trigger_type.ts
@@ -1,0 +1,40 @@
+/**
+ * Migration: `approval.completed` automation trigger (T1-3) — widen the trigger_type CHECK constraint.
+ *
+ * The approval-completion trigger (first-batch ballot 2026-07-01) is added to the application's
+ * VALID_TRIGGER_TYPES (automation-service + automation-triggers). The DB CHECK constraint
+ * `chk_automation_trigger_type` on `automation_rules` predates it, so persisting a rule with
+ * trigger_type='approval.completed' would be rejected (23514). This widens the allowed set, preserving
+ * every existing value (base = the latest constraint from the schedule.date_field migration). Pure DDL;
+ * idempotent via DROP CONSTRAINT IF EXISTS. (Caught by the real-DB approval-completed-trigger integration
+ * test — unit-level validation does not hit the constraint.)
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval', 'schedule.date_field',
+      'webhook.received', 'form.submitted', 'approval.completed'
+    ))
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval', 'schedule.date_field',
+      'webhook.received', 'form.submitted'
+    ))
+  `.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
+++ b/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
@@ -90,13 +90,13 @@ function normalizeStartApprovalConfig(config: Record<string, unknown>): StartApp
   }
 }
 
-function hasPermissionCode(permissionCodes: string[], permissionCode: string): boolean {
+export function hasPermissionCode(permissionCodes: string[], permissionCode: string): boolean {
   if (permissionCodes.includes(permissionCode) || permissionCodes.includes('*:*')) return true
   const resource = permissionCode.split(':')[0]
   return resource ? permissionCodes.includes(`${resource}:*`) : false
 }
 
-async function listRbacPermissionCodes(userId: string): Promise<string[]> {
+export async function listRbacPermissionCodes(userId: string): Promise<string[]> {
   const result = await query<{ code: string }>(
     `SELECT DISTINCT permission_code AS code FROM (
        SELECT up.permission_code

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -52,6 +52,7 @@ import {
   type AutomationApprovalBridgeRow,
 } from './automation-approval-bridge-service'
 import type { ApprovalCompletionEventV1 } from '../services/ApprovalCompletionEvent'
+import { applyTemplateVisibilityFilter, type ApprovalTemplateVisibilityActor } from '../services/ApprovalProductService'
 import {
   normalizeDingTalkAutomationActionInputs,
   validateDingTalkAutomationActionConfigs,
@@ -959,9 +960,15 @@ export class AutomationService {
     let normalizedActionConfigForUpdate: Record<string, unknown> | undefined
     let normalizedActionsForUpdate: AutomationAction[] | null | undefined
     let normalizedExecutionModeForUpdate: string | null | undefined
+    // T1-3: reuse the rule row already fetched by the action/trigger validation blocks below so the
+    // approval.completed resulting-shape check does NOT add a getRule call for those input shapes
+    // (unit tests mock getRule as a strict response queue — an extra fetch drains it and regresses
+    // existing workflow-action updates). Only a conditions-only edit fetches here on its own.
+    let existingRuleSnapshot: AutomationRule | null | undefined
 
     if (shouldValidateActions) {
       const existing = await this.getRule(ruleId)
+      existingRuleSnapshot = existing
       if (!existing || existing.sheet_id !== sheetId) return null
 
       const nextActionType = input.actionType ?? existing.action_type
@@ -1036,6 +1043,7 @@ export class AutomationService {
     // change on an existing date_field rule). Mirrors createRule's gate so the API can't bypass the UI contract.
     if (input.triggerType !== undefined || input.triggerConfig !== undefined) {
       const existingForTrigger = await this.getRule(ruleId)
+      existingRuleSnapshot = existingForTrigger
       if (!existingForTrigger || existingForTrigger.sheet_id !== sheetId) return null
       const nextTriggerType = input.triggerType ?? existingForTrigger.trigger_type
       const nextTriggerConfig = input.triggerConfig !== undefined ? input.triggerConfig : existingForTrigger.trigger_config
@@ -1086,7 +1094,7 @@ export class AutomationService {
       || input.executionMode !== undefined
       || input.conditions !== undefined
     ) {
-      const existingForApproval = await this.getRule(ruleId)
+      const existingForApproval = existingRuleSnapshot !== undefined ? existingRuleSnapshot : await this.getRule(ruleId)
       if (!existingForApproval || existingForApproval.sheet_id !== sheetId) return null
       const nextTriggerType = input.triggerType ?? existingForApproval.trigger_type
       if (nextTriggerType === APPROVAL_COMPLETED_TRIGGER) {
@@ -1636,10 +1644,13 @@ export class AutomationService {
     if (!(await this.approvalCompletedCreatorAuthorized(createdBy))) {
       return 'approval.completed rules require the creator to hold approvals:read for the configured template'
     }
+    if (!(await this.approvalTemplateVisibleToCreator(templateId, createdBy))) {
+      return 'trigger_config.templateId must reference an approval template visible to the rule creator'
+    }
     return null
   }
 
-  /** T1-3 Q2: the creator must hold `approvals:read` — checked at save AND re-checked at fire (fail-closed). */
+  /** T1-3 Q2 leg 1: the creator must hold `approvals:read` — checked at save AND re-checked at fire (fail-closed). */
   private async approvalCompletedCreatorAuthorized(createdBy: string | null): Promise<boolean> {
     if (!createdBy) return false
     try {
@@ -1647,6 +1658,59 @@ export class AutomationService {
       return hasPermissionCode(codes, 'approvals:read')
     } catch (err) {
       logger.warn('approval.completed creator permission check failed; denying (fail-closed)', err instanceof Error ? err : undefined)
+      return false
+    }
+  }
+
+  /**
+   * T1-3 Q2 leg 2: the creator must SEE the template per approval_templates.visibility_scope — otherwise a
+   * user with automation + approvals:read could bind a hidden template's completions and exfiltrate outcome
+   * data via webhook/notification. Checked at save AND re-checked at fire. There is no request token at
+   * either point, so the visibility actor is REBUILT FROM TRUSTED DB STATE (users.role/department/is_admin
+   * + user_roles ids/names + RBAC permission codes) and evaluated through the SAME
+   * applyTemplateVisibilityFilter predicate the template list/detail routes enforce. Fail-closed on any
+   * lookup error and on a missing/inactive creator.
+   */
+  private async approvalTemplateVisibleToCreator(templateId: string, createdBy: string | null): Promise<boolean> {
+    if (!createdBy) return false
+    try {
+      const userResult = await this.queryFn(
+        `SELECT role, department, is_admin FROM users WHERE id = $1 AND is_active = TRUE`,
+        [createdBy],
+      )
+      const user = userResult.rows[0] as { role?: string | null; department?: string | null; is_admin?: boolean | null } | undefined
+      if (!user) return false
+      const roleRows = await this.queryFn(
+        `SELECT ur.role_id, r.name FROM user_roles ur LEFT JOIN roles r ON r.id = ur.role_id WHERE ur.user_id = $1`,
+        [createdBy],
+      )
+      const roles = new Set<string>()
+      if (typeof user.role === 'string' && user.role.trim()) roles.add(user.role.trim())
+      for (const row of roleRows.rows as Array<{ role_id?: string | null; name?: string | null }>) {
+        if (typeof row.role_id === 'string' && row.role_id.trim()) roles.add(row.role_id.trim())
+        if (typeof row.name === 'string' && row.name.trim()) roles.add(row.name.trim())
+      }
+      const codes = await listRbacPermissionCodes(createdBy)
+      const actor: ApprovalTemplateVisibilityActor = {
+        userId: createdBy,
+        departmentIds: typeof user.department === 'string' && user.department.trim() ? [user.department.trim()] : [],
+        roles: [...roles],
+        permissions: codes,
+        isTemplateManager:
+          hasPermissionCode(codes, 'approval-templates:manage')
+          || user.is_admin === true
+          || roles.has('admin'),
+      }
+      const conditions: string[] = ['id = $1']
+      const params: unknown[] = [templateId]
+      applyTemplateVisibilityFilter(conditions, params, 2, actor)
+      const visible = await this.queryFn(
+        `SELECT 1 FROM approval_templates WHERE ${conditions.join(' AND ')} LIMIT 1`,
+        params,
+      )
+      return visible.rows.length > 0
+    } catch (err) {
+      logger.warn('approval.completed template visibility check failed; denying (fail-closed)', err instanceof Error ? err : undefined)
       return false
     }
   }
@@ -2130,9 +2194,14 @@ export class AutomationService {
     const outcome = event.transition.toStatus
     for (const rule of rules) {
       if (!approvalCompletedConfiguredOutcomes(rule.trigger_config).has(outcome)) continue
-      // Q2 fire-time re-check: deny + skip when the creator no longer holds approvals:read.
+      // Q2 fire-time re-check (both legs): deny + skip when the creator no longer holds approvals:read OR
+      // can no longer see the template per visibility_scope — completion data must not leak past either.
       if (!(await this.approvalCompletedCreatorAuthorized(rule.created_by))) {
         logger.warn(`approval.completed rule ${rule.id} skipped: creator lacks approvals:read at fire time`)
+        continue
+      }
+      if (!(await this.approvalTemplateVisibleToCreator(templateId, rule.created_by))) {
+        logger.warn(`approval.completed rule ${rule.id} skipped: template ${templateId} not visible to creator at fire time`)
         continue
       }
       try {

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -45,7 +45,12 @@ import { randomBytes } from 'crypto'
 import { AutomationLogService } from './automation-log-service'
 import { AutomationJobService } from './automation-job-service'
 import { AutomationSuspensionService, computeActionFingerprint } from './automation-suspension-service'
-import { AutomationApprovalBridgeService, type AutomationApprovalBridgeRow } from './automation-approval-bridge-service'
+import {
+  AutomationApprovalBridgeService,
+  hasPermissionCode,
+  listRbacPermissionCodes,
+  type AutomationApprovalBridgeRow,
+} from './automation-approval-bridge-service'
 import type { ApprovalCompletionEventV1 } from '../services/ApprovalCompletionEvent'
 import {
   normalizeDingTalkAutomationActionInputs,
@@ -78,7 +83,37 @@ const VALID_TRIGGER_TYPES = new Set([
   'schedule.date_field',
   'webhook.received',
   'form.submitted',
+  'approval.completed',
 ])
+
+// ── T1-3 approval.completed trigger (first-batch ballot 2026-07-01) ────────
+// Routed by REQUIRED trigger_config.templateId (cross-sheet — completion events carry no sheet/record).
+// Record-less v1: only non-record-targeting side effects may run (Q3), which also structurally breaks the
+// start_approval → approval.completed → start_approval loop (Q4a).
+const APPROVAL_COMPLETED_TRIGGER = 'approval.completed'
+const APPROVAL_COMPLETED_OUTCOMES: ReadonlySet<string> = new Set(['approved', 'rejected', 'revoked', 'cancelled'])
+const APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES: ReadonlySet<string> = new Set([
+  'send_notification',
+  'send_webhook',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+])
+const APPROVAL_COMPLETION_TRIGGER_EVENT_TYPES: readonly string[] = [
+  'approval.approved',
+  'approval.rejected',
+  'approval.revoked',
+  'approval.cancelled',
+]
+const APPROVAL_TEMPLATE_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Q6: outcomes filter — omitted/invalid persisted config degrades to approved-only (fail-closed default). */
+function approvalCompletedConfiguredOutcomes(triggerConfig: Record<string, unknown>): Set<string> {
+  const raw = triggerConfig?.outcomes
+  if (!Array.isArray(raw)) return new Set(['approved'])
+  const valid = raw.filter((entry): entry is string => typeof entry === 'string' && APPROVAL_COMPLETED_OUTCOMES.has(entry))
+  return valid.length > 0 ? new Set(valid) : new Set(['approved'])
+}
 
 const LEGACY_ACTION_TYPES = [
   'notify',
@@ -748,6 +783,11 @@ export class AutomationService {
           this.handleApprovalCompletionEvent(payload).catch((err) => {
             logger.error(`Automation approval bridge handler error for ${eventType}`, err instanceof Error ? err : undefined)
           })
+          // T1-3 (Q7): fresh approval.completed rules fire for EVERY completion, independently of the
+          // bridge resume above — the two consumers share no state (a bridged approval also fires rules).
+          this.handleApprovalCompletionTrigger(payload).catch((err) => {
+            logger.error(`Automation approval.completed trigger error for ${eventType}`, err instanceof Error ? err : undefined)
+          })
         },
       )
       this.subscriptionIds.push(id)
@@ -812,6 +852,17 @@ export class AutomationService {
 
     const cronTriggerError = this.validateCronTriggerAtSave(input.triggerType, input.triggerConfig ?? null)
     if (cronTriggerError) throw new AutomationRuleValidationError(cronTriggerError)
+
+    // T1-3: approval.completed rules validate templateId/outcomes/actions/conditions + creator permission.
+    const approvalCompletedError = await this.validateApprovalCompletedRuleAtSave(
+      input.triggerType,
+      (input.triggerConfig ?? null) as Record<string, unknown> | null,
+      input.actionType,
+      actionsForValidation,
+      input.conditions ?? null,
+      input.createdBy ?? null,
+    )
+    if (approvalCompletedError) throw new AutomationRuleValidationError(approvalCompletedError)
 
     // date_field rules carry a SERVER-SET activation `effectiveAt` (= now) so the firing floor is the rule's
     // activation, not its row createdAt. Spread-then-set overwrites any client-supplied effectiveAt (no backfill bypass).
@@ -1020,6 +1071,45 @@ export class AutomationService {
         }
         updates.trigger_config = JSON.stringify(baseConfig)
         if (updates.trigger_type === undefined) updates.trigger_type = nextTriggerType
+      }
+    }
+
+    // T1-3: when the RESULTING rule is approval.completed, validate the full resulting shape (trigger config
+    // + actions + conditions + creator permission) whatever subset of fields is edited — an action-only or
+    // conditions-only edit must not smuggle a disallowed shape past the save gate.
+    if (
+      input.triggerType !== undefined
+      || input.triggerConfig !== undefined
+      || input.actionType !== undefined
+      || input.actionConfig !== undefined
+      || input.actions !== undefined
+      || input.executionMode !== undefined
+      || input.conditions !== undefined
+    ) {
+      const existingForApproval = await this.getRule(ruleId)
+      if (!existingForApproval || existingForApproval.sheet_id !== sheetId) return null
+      const nextTriggerType = input.triggerType ?? existingForApproval.trigger_type
+      if (nextTriggerType === APPROVAL_COMPLETED_TRIGGER) {
+        const nextTriggerConfig = (
+          input.triggerConfig !== undefined ? input.triggerConfig : existingForApproval.trigger_config
+        ) as Record<string, unknown> | null
+        const nextActionType = input.actionType ?? existingForApproval.action_type
+        const nextActionConfig = (input.actionConfig ?? existingForApproval.action_config) as Record<string, unknown>
+        const nextActions = input.actions !== undefined ? input.actions : existingForApproval.actions ?? null
+        const nextExecutionMode = input.executionMode !== undefined
+          ? normalizeExecutionMode(input.executionMode)
+          : existingForApproval.execution_mode ?? null
+        const nextConditions = input.conditions !== undefined ? input.conditions : existingForApproval.conditions ?? null
+        const approvalActions = collectNestedAutomationActions(nextActionType, nextActionConfig, nextActions, nextExecutionMode)
+        const approvalCompletedError = await this.validateApprovalCompletedRuleAtSave(
+          nextTriggerType,
+          nextTriggerConfig,
+          nextActionType,
+          approvalActions,
+          nextConditions,
+          existingForApproval.created_by,
+        )
+        if (approvalCompletedError) throw new AutomationRuleValidationError(approvalCompletedError)
       }
     }
 
@@ -1492,6 +1582,75 @@ export class AutomationService {
     logger.info('AutomationService shut down')
   }
 
+  /**
+   * T1-3 save-time validation for `approval.completed` rules. Returns an error string or null.
+   * Ballot decisions: Q1 templateId REQUIRED + must reference an existing approval template (null-template
+   * completions are v1 out-of-contract); Q2 the creator must hold `approvals:read` (re-checked at fire time);
+   * Q3 record-less v1 — every action (top-level AND nested) must be a non-record-targeting side effect;
+   * Q6 optional outcomes filter; Q8 conditions evaluate record data this trigger lacks — reject non-empty.
+   */
+  private async validateApprovalCompletedRuleAtSave(
+    triggerType: string,
+    triggerConfig: Record<string, unknown> | null,
+    actionType: string,
+    nestedActions: AutomationAction[],
+    conditions: ConditionGroup | null | undefined,
+    createdBy: string | null,
+  ): Promise<string | null> {
+    if (triggerType !== APPROVAL_COMPLETED_TRIGGER) return null
+    const config = triggerConfig ?? {}
+    const templateIdRaw = config.templateId
+    const templateId = typeof templateIdRaw === 'string' ? templateIdRaw.trim() : ''
+    if (!templateId) return 'trigger_config.templateId is required for approval.completed rules'
+    if (!APPROVAL_TEMPLATE_UUID_RE.test(templateId)) {
+      return 'trigger_config.templateId must reference an existing approval template'
+    }
+    const template = await this.queryFn('SELECT id FROM approval_templates WHERE id = $1', [templateId])
+    if (template.rows.length === 0) {
+      return 'trigger_config.templateId must reference an existing approval template'
+    }
+    const outcomesRaw = config.outcomes
+    if (outcomesRaw !== undefined) {
+      if (!Array.isArray(outcomesRaw) || outcomesRaw.length === 0) {
+        return 'trigger_config.outcomes must be a non-empty array when present'
+      }
+      for (const outcome of outcomesRaw) {
+        if (typeof outcome !== 'string' || !APPROVAL_COMPLETED_OUTCOMES.has(outcome)) {
+          return `trigger_config.outcomes contains an invalid outcome: ${String(outcome)}`
+        }
+      }
+    }
+    if (conditions) {
+      const nodes = Array.isArray(conditions.conditions) ? conditions.conditions : null
+      if (!nodes || nodes.length > 0) {
+        return 'approval.completed rules cannot carry conditions (no record context in v1)'
+      }
+    }
+    const actionTypes = new Set<string>([actionType, ...nestedActions.map((action) => action.type)])
+    for (const type of actionTypes) {
+      if (!APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES.has(type)) {
+        return `action ${type} is not allowed on approval.completed rules (record-less v1 allows: ${[...APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES].join(', ')})`
+      }
+    }
+    if (!createdBy) return 'approval.completed rules require an authenticated creator'
+    if (!(await this.approvalCompletedCreatorAuthorized(createdBy))) {
+      return 'approval.completed rules require the creator to hold approvals:read for the configured template'
+    }
+    return null
+  }
+
+  /** T1-3 Q2: the creator must hold `approvals:read` — checked at save AND re-checked at fire (fail-closed). */
+  private async approvalCompletedCreatorAuthorized(createdBy: string | null): Promise<boolean> {
+    if (!createdBy) return false
+    try {
+      const codes = await listRbacPermissionCodes(createdBy)
+      return hasPermissionCode(codes, 'approvals:read')
+    } catch (err) {
+      logger.warn('approval.completed creator permission check failed; denying (fail-closed)', err instanceof Error ? err : undefined)
+      return false
+    }
+  }
+
   async handleEvent(eventType: string, payload: AutomationEventPayload): Promise<void> {
     const depth = typeof payload._automationDepth === 'number' ? payload._automationDepth : 0
     if (depth >= MAX_AUTOMATION_DEPTH) {
@@ -1939,6 +2098,94 @@ export class AutomationService {
   }
 
   /**
+   * T1-3: fresh `approval.completed` rule dispatch — independent of the W6/W7 bridge resume (Q7: a bridged
+   * approval ALSO fires fresh rules; the two consumers share no state). Routed by the event's templateId
+   * (Q1 — a templateId-null completion is v1 out-of-contract: it can never match a rule; log + return).
+   * Idempotent via the T2-6 event-fire ledger keyed `approval.completed:{event.eventId}` (Q5 — eventId is
+   * already unique per instance+version+type, so no transport _eventId stamping is needed).
+   */
+  async handleApprovalCompletionTrigger(event: ApprovalCompletionEventV1): Promise<void> {
+    if (event.version !== 1 || event.source !== 'approval-product') return
+    if (!APPROVAL_COMPLETION_TRIGGER_EVENT_TYPES.includes(event.eventType)) return
+    const templateId = event.approval.templateId
+    if (!templateId) {
+      logger.debug(`approval completion ${event.eventId} carries no templateId; approval.completed rules cannot match (v1 out-of-contract)`)
+      return
+    }
+    const rules = await this.loadEnabledApprovalCompletedRules(templateId)
+    if (rules.length === 0) return
+
+    // Q4(b): thread the automation chain depth — a bridge-originated approval (started by start_approval)
+    // continues its parent chain at depth+1; a human-started approval begins a fresh chain at depth 0.
+    // (Loops are ALSO structurally broken: Q3 save-rejects start_approval and every record-writing action
+    // on approval.completed rules, so this guard is defense-in-depth, not the only stop.)
+    const parentDepth = await this.approvalBridgeAutomationDepth(event.approval.instanceId)
+    const depth = parentDepth === null ? 0 : parentDepth + 1
+    if (depth >= MAX_AUTOMATION_DEPTH) {
+      logger.warn(`Automation recursion guard triggered (depth=${depth}) for approval.completed on template ${templateId}`)
+      return
+    }
+
+    this.kickEventDedupLedgerSweepIfDue(Date.now())
+    const outcome = event.transition.toStatus
+    for (const rule of rules) {
+      if (!approvalCompletedConfiguredOutcomes(rule.trigger_config).has(outcome)) continue
+      // Q2 fire-time re-check: deny + skip when the creator no longer holds approvals:read.
+      if (!(await this.approvalCompletedCreatorAuthorized(rule.created_by))) {
+        logger.warn(`approval.completed rule ${rule.id} skipped: creator lacks approvals:read at fire time`)
+        continue
+      }
+      try {
+        const claimed = await this.claimEventDelivery(rule.id, `approval.completed:${event.eventId}`)
+        if (!claimed) continue
+        // Q3 record-less payload: the approval event rides along as the trigger event; actions are
+        // save-restricted to non-record-targeting side effects, so the empty record context is never read.
+        const payload: AutomationEventPayload & Record<string, unknown> = {
+          sheetId: rule.sheet_id,
+          recordId: '',
+          data: {},
+          actorId: event.actor?.id ?? null,
+          _automationDepth: depth,
+          eventId: event.eventId,
+          eventType: event.eventType,
+          occurredAt: event.occurredAt,
+          approval: event.approval,
+          transition: event.transition,
+          requester: event.requester,
+        }
+        await this.executeRule(toExecutorRule(rule), payload)
+      } catch (err) {
+        logger.error(`approval.completed rule ${rule.id} failed`, err instanceof Error ? err : undefined)
+      }
+    }
+  }
+
+  /**
+   * Q4(b) helper: the parent automation depth for a bridge-originated approval instance, or null when no
+   * bridge exists (human/API-started approval — a fresh chain). A bridge whose trigger_event carries no
+   * depth counts as depth 0 (chain start). Lookup errors degrade to null — safe because approval.completed
+   * rules structurally cannot start approvals or write records (Q3), so no loop can form either way.
+   */
+  private async approvalBridgeAutomationDepth(instanceId: string): Promise<number | null> {
+    try {
+      const result = await this.queryFn(
+        `SELECT trigger_event FROM multitable_automation_approval_bridges
+          WHERE approval_instance_id = $1
+          ORDER BY created_at DESC LIMIT 1`,
+        [instanceId],
+      )
+      if (result.rows.length === 0) return null
+      const triggerEvent = (result.rows[0] as { trigger_event?: unknown }).trigger_event
+      if (!triggerEvent || typeof triggerEvent !== 'object' || Array.isArray(triggerEvent)) return 0
+      const rawDepth = (triggerEvent as Record<string, unknown>)._automationDepth
+      return typeof rawDepth === 'number' && Number.isFinite(rawDepth) ? rawDepth : 0
+    } catch (err) {
+      logger.warn('approval.completed bridge depth lookup failed; treating as a fresh chain', err instanceof Error ? err : undefined)
+      return null
+    }
+  }
+
+  /**
    * W7-1 approval-result backwrite: write the DECLARED fixed outcome→field mapping (from the
    * start_approval action's `resultWriteback`) onto the SOURCE record, using values from the completion
    * event ONLY (never user-templated strings — that keeps the write path values-constrained, the whole
@@ -2150,6 +2397,22 @@ export class AutomationService {
       .orderBy('created_at', 'asc')
       .execute()
 
+    return rows.map((r) => this.mapRow(r))
+  }
+
+  /**
+   * T1-3 Q1: cross-sheet routing for approval.completed rules by REQUIRED trigger_config.templateId.
+   * JSONB expression filter with no index in v1 by design (small table); revisit only on a perf signal.
+   */
+  async loadEnabledApprovalCompletedRules(templateId: string): Promise<AutomationRule[]> {
+    const rows = await this.db
+      .selectFrom('automation_rules')
+      .selectAll()
+      .where('trigger_type', '=', APPROVAL_COMPLETED_TRIGGER)
+      .where('enabled', '=', true)
+      .where(sql<string>`trigger_config->>'templateId'`, '=', templateId)
+      .orderBy('created_at', 'asc')
+      .execute()
     return rows.map((r) => this.mapRow(r))
   }
 

--- a/packages/core-backend/src/multitable/automation-triggers.ts
+++ b/packages/core-backend/src/multitable/automation-triggers.ts
@@ -13,6 +13,7 @@ export type AutomationTriggerType =
   | 'schedule.date_field'
   | 'webhook.received'
   | 'form.submitted'
+  | 'approval.completed'
 
 export const ALL_TRIGGER_TYPES: AutomationTriggerType[] = [
   'record.created',
@@ -24,6 +25,7 @@ export const ALL_TRIGGER_TYPES: AutomationTriggerType[] = [
   'schedule.date_field',
   'webhook.received',
   'form.submitted',
+  'approval.completed',
 ]
 
 /** Config shape for field.value_changed */
@@ -48,6 +50,18 @@ export interface ScheduleIntervalConfig {
 /** Config shape for webhook.received */
 export interface WebhookReceivedConfig {
   secret?: string
+}
+
+/**
+ * Config shape for approval.completed (T1-3).
+ * Routing is by REQUIRED approval templateId (cross-sheet; the completion event carries no sheet/record).
+ * `outcomes` filters which terminal outcomes fire the rule; omitted = approved only. Dispatch does NOT go
+ * through matchesTrigger/TRIGGER_TYPE_BY_EVENT — approval completions are routed by a dedicated
+ * template-keyed path in AutomationService (they are not multitable record events).
+ */
+export interface ApprovalCompletedConfig {
+  templateId: string
+  outcomes?: Array<'approved' | 'rejected' | 'revoked' | 'cancelled'>
 }
 
 export interface AutomationTrigger {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1704,7 +1704,10 @@ function readTemplateVisibilityScope(value: unknown): ApprovalTemplateVisibility
   return { type: value.type, ids } as ApprovalTemplateVisibilityScope
 }
 
-function applyTemplateVisibilityFilter(
+// Exported for reuse by consumers that must enforce single-template visibility for a DB-rebuilt actor
+// (e.g. the automation approval.completed trigger checks the RULE CREATOR's template visibility at save
+// AND at fire time, where no request token exists) — one authoritative scope predicate, not a re-derivation.
+export function applyTemplateVisibilityFilter(
   conditions: string[],
   params: unknown[],
   index: number,

--- a/packages/core-backend/tests/integration/automation-approval-completed-trigger.test.ts
+++ b/packages/core-backend/tests/integration/automation-approval-completed-trigger.test.ts
@@ -36,6 +36,7 @@ const queryFn = ((sqlText: string, params?: unknown[]) => poolManager.get().quer
 let svc: AutomationService
 let approvals: ApprovalProductService
 let templateId = ''
+const extraTemplateIds: string[] = []
 const ruleIds: string[] = []
 const notifications: Array<{ userIds: string[]; message: string; sheetId: string; recordId: string }> = []
 
@@ -127,7 +128,8 @@ describeIfDatabase('T1-3 approval.completed automation trigger (real DB)', () =>
 
   afterAll(async () => {
     try { svc?.shutdown() } catch { /* noop */ }
-    const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [templateId]).catch(() => ({ rows: [] as unknown[] }))
+    const allTemplateIds = [templateId, ...extraTemplateIds].filter(Boolean)
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])', [allTemplateIds]).catch(() => ({ rows: [] as unknown[] }))
     for (const row of instances.rows as Array<{ id: string }>) {
       await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
       await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
@@ -138,7 +140,9 @@ describeIfDatabase('T1-3 approval.completed automation trigger (real DB)', () =>
       await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
       await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [ruleIds]).catch(() => {})
     }
-    if (templateId) await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
+    for (const tid of allTemplateIds) {
+      await q('DELETE FROM approval_templates WHERE id = $1', [tid]).catch(() => {})
+    }
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
     await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER, OUTSIDER]]).catch(() => {})
@@ -292,6 +296,58 @@ describeIfDatabase('T1-3 approval.completed automation trigger (real DB)', () =>
     } finally {
       await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:read') ON CONFLICT DO NOTHING`, [CREATOR])
     }
+  })
+
+  test('Q2 visibility leg: hidden template rejected at save; visibility revoked after save → fire-skip', async () => {
+    // Save gate: a template whose visibility_scope excludes CREATOR must be rejected even though the
+    // template EXISTS and CREATOR holds approvals:read — otherwise its completions could be exfiltrated.
+    const hidden = await approvals.createTemplate({
+      ...approvalTemplateRequest(),
+      key: `act-hidden-${TS}`,
+      visibilityScope: { type: 'user', ids: [OUTSIDER] },
+    } as never)
+    const hiddenId = (hidden as { id: string }).id
+    extraTemplateIds.push(hiddenId)
+    await approvals.publishTemplate(hiddenId, { policy: { allowRevoke: true } } as never)
+    await expect(svc.createRule(SHEET_ID, {
+      name: 'hidden template probe',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId: hiddenId },
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'leak' },
+      createdBy: CREATOR,
+    } as never)).rejects.toThrow(/visible to the rule creator/)
+
+    // Visible-scoped template (CREATOR in scope) saves fine; then the scope flips to exclude CREATOR
+    // BEFORE the approval completes → the fire-time visibility re-check must deny + skip.
+    const scoped = await approvals.createTemplate({
+      ...approvalTemplateRequest(),
+      key: `act-scoped-${TS}`,
+      visibilityScope: { type: 'user', ids: [CREATOR, REQUESTER, APPROVER] },
+    } as never)
+    const scopedId = (scoped as { id: string }).id
+    extraTemplateIds.push(scopedId)
+    await approvals.publishTemplate(scopedId, { policy: { allowRevoke: true } } as never)
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'scoped template rule',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId: scopedId },
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'scoped fire' },
+      createdBy: CREATOR,
+    } as never)
+    const ruleId = (rule as { id: string }).id
+    ruleIds.push(ruleId)
+
+    const dto = await approvals.createApproval({ templateId: scopedId, formData: { summary: 'scoped' } }, requesterActor())
+    const instanceId = (dto as { id: string }).id
+    await q(
+      `UPDATE approval_templates SET visibility_scope = $2::jsonb WHERE id = $1`,
+      [scopedId, JSON.stringify({ type: 'user', ids: [OUTSIDER] })],
+    )
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, approverActor())
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(await executionCount(ruleId), 'creator lost template visibility → fire must skip').toBe(0)
   })
 
   test('Q1: a templateId-null completion is out-of-contract — no crash, no execution', async () => {

--- a/packages/core-backend/tests/integration/automation-approval-completed-trigger.test.ts
+++ b/packages/core-backend/tests/integration/automation-approval-completed-trigger.test.ts
@@ -1,0 +1,322 @@
+/**
+ * T1-3 `approval.completed` automation trigger — real-DB integration (first-batch ballot 2026-07-01).
+ *
+ * Real event chain over real Postgres + the real in-process eventBus:
+ *   ApprovalProductService.dispatchAction(approve/reject) → emitApprovalCompletionEvent
+ *     → AutomationService subscription → handleApprovalCompletionTrigger (template-routed, cross-sheet)
+ *       → T2-6 ledger claim (`approval.completed:{eventId}`) → executeRule (record-less)
+ *         → send_notification → eventBus 'automation.notification' (the fixture-free oracle).
+ *
+ * Ballot coverage: Q1 templateId routing + null-template out-of-contract · Q2 creator approvals:read at
+ * save AND fire (deny+skip) · Q3 record-less action allowlist (save-reject) · Q5 eventId dedup via the
+ * T2-6 ledger (redelivery = no-op) · Q6 outcomes filter (default approved-only) · Q8 conditions rejected.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import type { ApprovalCompletionEventV1 } from '../../src/services/ApprovalCompletionEvent'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_act_${TS}`
+const SHEET_ID = `sheet_act_${TS}`
+const CREATOR = `u_act_creator_${TS}`
+const REQUESTER = `u_act_req_${TS}`
+const APPROVER = `u_act_appr_${TS}`
+const OUTSIDER = `u_act_out_${TS}`
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+const queryFn = ((sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)) as never
+
+let svc: AutomationService
+let approvals: ApprovalProductService
+let templateId = ''
+const ruleIds: string[] = []
+const notifications: Array<{ userIds: string[]; message: string; sheetId: string; recordId: string }> = []
+
+function approvalTemplateRequest() {
+  return {
+    key: `act-${TS}`,
+    name: 'approval.completed Trigger Template',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'Approver',
+          config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+const requesterActor = () => ({ userId: REQUESTER, userName: REQUESTER })
+const approverActor = () => ({ userId: APPROVER, userName: APPROVER })
+
+async function startApprovalInstance(): Promise<string> {
+  const dto = await approvals.createApproval(
+    { templateId, formData: { summary: 'trigger test' } },
+    requesterActor(),
+  )
+  return (dto as { id: string }).id
+}
+
+async function executionCount(ruleId: string): Promise<number> {
+  const r = await q('SELECT COUNT(*)::int AS count FROM multitable_automation_executions WHERE rule_id = $1', [ruleId])
+  return (r.rows[0] as { count: number }).count
+}
+
+async function waitForExecutionCount(ruleId: string, expected: number, timeoutMs = 6000): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const count = await executionCount(ruleId)
+    if (count >= expected || Date.now() > deadline) return count
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+describeIfDatabase('T1-3 approval.completed automation trigger (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'ACT Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'ACT Sheet'])
+
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('approvals:read', 'Approvals Read', 'ACT test'),
+              ('approvals:write', 'Approvals Write', 'ACT test'),
+              ('approvals:act', 'Approvals Act', 'ACT test')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    for (const uid of [CREATOR, REQUESTER, APPROVER, OUTSIDER]) {
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+        [uid, `${uid}@act.test`],
+      )
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:read') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+
+    approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate(approvalTemplateRequest() as never)
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+
+    integrationEventBus.subscribe('automation.notification', (payload) => {
+      notifications.push(payload as (typeof notifications)[number])
+    })
+
+    svc = new AutomationService(integrationEventBus, db as never, queryFn)
+    svc.init()
+  })
+
+  afterAll(async () => {
+    try { svc?.shutdown() } catch { /* noop */ }
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [templateId]).catch(() => ({ rows: [] as unknown[] }))
+    for (const row of instances.rows as Array<{ id: string }>) {
+      await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
+    }
+    if (ruleIds.length > 0) {
+      await q('DELETE FROM meta_automation_event_fires WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    }
+    if (templateId) await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER, OUTSIDER]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER, OUTSIDER]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('save gate: templateId / outcomes / actions / conditions / creator permission all fail-closed', async () => {
+    const base = {
+      name: 'approval completed rule',
+      triggerType: 'approval.completed',
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'done' },
+      createdBy: CREATOR,
+    }
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: {} } as never))
+      .rejects.toThrow(/templateId is required/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId: '00000000-0000-4000-8000-000000000000' } } as never))
+      .rejects.toThrow(/must reference an existing approval template/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId, outcomes: ['maybe'] } } as never))
+      .rejects.toThrow(/invalid outcome/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId, outcomes: [] } } as never))
+      .rejects.toThrow(/non-empty array/)
+    await expect(svc.createRule(SHEET_ID, {
+      ...base,
+      triggerConfig: { templateId },
+      actionType: 'update_record',
+      actionConfig: { fieldId: 'x', value: 1 },
+    } as never)).rejects.toThrow(/not allowed on approval.completed rules/)
+    await expect(svc.createRule(SHEET_ID, {
+      ...base,
+      triggerConfig: { templateId },
+      conditions: { logic: 'and', conditions: [{ fieldId: 'x', operator: 'equals', value: 1 }] },
+    } as never)).rejects.toThrow(/cannot carry conditions/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId }, createdBy: OUTSIDER } as never))
+      .rejects.toThrow(/approvals:read/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId }, createdBy: null } as never))
+      .rejects.toThrow(/authenticated creator/)
+  })
+
+  test('fires on approval completion: template-routed, record-less, notification delivered, exactly once', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'notify on approval completed',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId },
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'approval finished' },
+      createdBy: CREATOR,
+    } as never)
+    const ruleId = (rule as { id: string }).id
+    ruleIds.push(ruleId)
+
+    const instanceId = await startApprovalInstance()
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, approverActor())
+
+    const count = await waitForExecutionCount(ruleId, 1)
+    expect(count, 'the approval.completed rule should have executed exactly once').toBe(1)
+
+    const exec = await q(
+      `SELECT status FROM multitable_automation_executions WHERE rule_id = $1 ORDER BY created_at DESC LIMIT 1`,
+      [ruleId],
+    )
+    expect((exec.rows[0] as { status: string }).status).toBe('success')
+
+    const notified = notifications.find((n) => n.message === 'approval finished')
+    expect(notified, 'send_notification should have emitted the oracle event').toBeTruthy()
+    expect(notified!.userIds).toEqual([CREATOR])
+    expect(notified!.sheetId).toBe(SHEET_ID)
+    expect(notified!.recordId, 'record-less v1 executes with an empty recordId').toBe('')
+
+    // Q5: the T2-6 ledger row exists under the approval.completed:{eventId} key shape.
+    const ledger = await q(
+      `SELECT dedup_key FROM meta_automation_event_fires WHERE rule_id = $1`,
+      [ruleId],
+    )
+    expect((ledger.rows as Array<{ dedup_key: string }>).some((r) =>
+      r.dedup_key.startsWith(`approval.completed:approval:${instanceId}:`))).toBe(true)
+
+    // Q5 redelivery: re-deliver the SAME completion event → ledger claim loses → still exactly 1 execution.
+    const eventsRow = await q(
+      `SELECT dedup_key FROM meta_automation_event_fires WHERE rule_id = $1 LIMIT 1`,
+      [ruleId],
+    )
+    const dedupKey = (eventsRow.rows[0] as { dedup_key: string }).dedup_key
+    const eventId = dedupKey.replace(/^approval\.completed:/, '')
+    const replay: ApprovalCompletionEventV1 = {
+      version: 1,
+      eventId,
+      eventType: 'approval.approved',
+      occurredAt: new Date().toISOString(),
+      source: 'approval-product',
+      approval: {
+        instanceId,
+        requestNo: null,
+        templateId,
+        templateVersionId: null,
+        publishedDefinitionId: null,
+        businessKey: null,
+        workflowKey: null,
+      },
+      transition: { action: 'approve', fromStatus: 'pending', toStatus: 'approved', fromVersion: 1, toVersion: 2, nodeKey: 'approval_1' },
+      actor: { id: APPROVER, name: APPROVER },
+      requester: { id: REQUESTER },
+    }
+    await svc.handleApprovalCompletionTrigger(replay)
+    expect(await executionCount(ruleId)).toBe(1)
+  })
+
+  test('Q6 outcomes filter: a rejected-only rule ignores approvals and fires on rejection', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'notify on rejection',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId, outcomes: ['rejected'] },
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'approval rejected' },
+      createdBy: CREATOR,
+    } as never)
+    const ruleId = (rule as { id: string }).id
+    ruleIds.push(ruleId)
+
+    const approvedId = await startApprovalInstance()
+    await approvals.dispatchAction(approvedId, { action: 'approve', comment: 'ok' } as never, approverActor())
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(await executionCount(ruleId), 'rejected-only rule must not fire on approve').toBe(0)
+
+    const rejectedId = await startApprovalInstance()
+    await approvals.dispatchAction(rejectedId, { action: 'reject', comment: 'no' } as never, approverActor())
+    const count = await waitForExecutionCount(ruleId, 1)
+    expect(count, 'rejected-only rule should fire once on rejection').toBe(1)
+  })
+
+  test('Q2 fire-time re-check: creator who lost approvals:read is denied + skipped', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'authz revoke probe',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId },
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'should not fire' },
+      createdBy: CREATOR,
+    } as never)
+    const ruleId = (rule as { id: string }).id
+    ruleIds.push(ruleId)
+
+    await q(`DELETE FROM user_permissions WHERE user_id = $1 AND permission_code = 'approvals:read'`, [CREATOR])
+    try {
+      const instanceId = await startApprovalInstance()
+      await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, approverActor())
+      await new Promise((resolve) => setTimeout(resolve, 600))
+      expect(await executionCount(ruleId), 'revoked creator must be denied at fire time').toBe(0)
+    } finally {
+      await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:read') ON CONFLICT DO NOTHING`, [CREATOR])
+    }
+  })
+
+  test('Q1: a templateId-null completion is out-of-contract — no crash, no execution', async () => {
+    const before = await q('SELECT COUNT(*)::int AS count FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds])
+    const nullTemplateEvent: ApprovalCompletionEventV1 = {
+      version: 1,
+      eventId: `approval:null-template-${TS}:1:approval.approved`,
+      eventType: 'approval.approved',
+      occurredAt: new Date().toISOString(),
+      source: 'approval-product',
+      approval: {
+        instanceId: `inst-null-${TS}`,
+        requestNo: null,
+        templateId: null,
+        templateVersionId: null,
+        publishedDefinitionId: null,
+        businessKey: null,
+        workflowKey: null,
+      },
+      transition: { action: 'approve', fromStatus: 'pending', toStatus: 'approved', fromVersion: 1, toVersion: 2, nodeKey: 'approval_1' },
+      actor: { id: APPROVER, name: APPROVER },
+      requester: { id: REQUESTER },
+    }
+    await svc.handleApprovalCompletionTrigger(nullTemplateEvent)
+    const after = await q('SELECT COUNT(*)::int AS count FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds])
+    expect((after.rows[0] as { count: number }).count).toBe((before.rows[0] as { count: number }).count)
+  })
+})


### PR DESCRIPTION
**First-batch ballot GO (T1-3 all-✅).** Approval completions become a first-class automation trigger: approve/reject/revoke/cancel → matching rules fire (notification/webhook/email/DingTalk) — the approval → automation product loop (拒绝通知、审批后 webhook、审批后消息 all land here).

## Ballot decisions → code
- **Q1 routing:** `trigger_config.templateId` REQUIRED + must reference an existing template; cross-sheet dispatch via `loadEnabledApprovalCompletedRules` (JSONB filter, no index v1). **templateId-null completions = v1 out-of-contract** (never match; debug-log + return).
- **Q2 authz:** creator must hold `approvals:read` — at SAVE **and re-checked at fire** (deny+skip, fail-closed on lookup errors). Principal = route-set server-side `createdBy`.
- **Q3 record-less v1:** payload `recordId:''` with the approval event riding along; actions save-restricted (top-level AND nested) to `send_notification / send_webhook / send_email / send_dingtalk_*`; record-targeting + `start_approval` rejected → the approval→approval loop is structurally broken (Q4a).
- **Q4 depth:** bridge-originated approvals continue the parent chain at depth+1 (read-only bridge lookup); human-started = depth 0; MAX_AUTOMATION_DEPTH retained.
- **Q5 idempotency:** reuses the **T2-6 ledger** with `dedup_key = approval.completed:{event.eventId}` — no new ledger, redelivery = no-op.
- **Q6:** single `approval.completed` type + optional `outcomes` filter (default approved-only; invalid persisted values degrade fail-closed).
- **Q7:** fresh rules fire for EVERY completion, independent of the W6/W7 bridge resume.
- **Q8:** non-empty conditions rejected at save.
- **DB:** `chk_automation_trigger_type` CHECK widened by migration (date_field-widening pattern). `updateRule` validates the full RESULTING shape (no smuggling via action-only edits).

## Verification
tsc 0 · **new real-DB suite 6/6**: save-gate fail-closed matrix · E2E approve→notification (record-less payload + ledger-key + same-eventId replay no-op) · rejected-only outcome filter both directions · fire-time permission-revoke deny+skip · templateId-null out-of-contract. **RED-before confirmed** (impl stashed → `Invalid trigger_type: approval.completed`). **Regressions green:** start-approval bridge 14/14 · HTTP seam 3/3 · W6 form-submit smoke 2/2 · date-reminder 19/19. CI: suite wired into plugin-tests.yml.

## Not in this slice (named follow-ups)
Rule-editor UI exposure (backend/API contract first — same pattern as W7 resultWriteback backend) · approval-field conditions vocabulary · source-record resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)