### PR TITLE
feat(approval): T1-1 slice-2 transfer/jump node-timeout effects (terminal gate CLOSED)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -343,6 +343,7 @@ jobs:
             tests/integration/approval-bridge-redaction-regression.test.ts \
             tests/integration/approval-metrics-people-teams.test.ts \
             tests/integration/approval-node-sla-remind.test.ts \
+            tests/integration/approval-node-timeout-effects.test.ts \
             tests/integration/approval-nofm-threshold.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -95,6 +95,7 @@ import {
   startApprovalSlaScheduler,
   stopApprovalSlaScheduler,
 } from './services/ApprovalSlaScheduler'
+import { ApprovalProductService } from './services/ApprovalProductService'
 import {
   resolveAttendanceSchedulerIntervalMs,
   resolveAttendanceSchedulerLeaderOptions,
@@ -2101,6 +2102,10 @@ export class MetaSheetServer {
             )
           }
         },
+        // T1-1 slice-2: apply due transfer/jump timeout effects (system actor, single-shot inside the
+        // service transaction). Throws propagate to the scheduler's per-row catch → retried next tick.
+        onNodeEffect: async ({ instanceId, effect }) =>
+          new ApprovalProductService().applyNodeTimeoutEffect(instanceId, effect),
       })
       this.logger.info('Approval SLA scheduler initialized')
     } catch (e) {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -76,6 +76,7 @@ import { Logger } from '../core/logger'
 import { eventBus } from '../integration/events/event-bus'
 
 const metricsLogger = new Logger('ApprovalMetricsHook')
+const nodeTimeoutLogger = new Logger('ApprovalNodeTimeout')
 
 function safeMetricsCall(label: string, fn: () => Promise<void>): void {
   Promise.resolve()
@@ -306,9 +307,26 @@ const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-app
 const AUTO_APPROVAL_ACTOR_MODES = new Set<AutoApprovalActorMode>(['system', 'original_approver'])
 const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(['editable', 'readonly', 'hidden'])
 // T1-1 node-level SLA. The full effect enum is declared so an off-enum value is a hard reject; slice 1
-// only WIRES `remind` (a notification) — transfer/jump/auto_* are rejected at publish until their slice.
+// wired `remind` (a notification), slice 2 wires `transfer` + `jump` (state mutations) — auto_* remain
+// rejected at publish and runtime-inert (terminal effects stay behind the closed gate below).
 const NODE_TIMEOUT_EFFECTS = new Set<NodeTimeoutEffect>(['remind', 'transfer', 'jump', 'auto_approve', 'auto_reject'])
-const NODE_TIMEOUT_SUPPORTED_EFFECTS = new Set<NodeTimeoutEffect>(['remind'])
+const NODE_TIMEOUT_SUPPORTED_EFFECTS = new Set<NodeTimeoutEffect>(['remind', 'transfer', 'jump'])
+// T1-1 slice-2 QS-b: a timeout-jump whose auto-approval cascade would land the instance in a TERMINAL
+// state is a de-facto auto_approve. That terminal outcome is gated behind this env flag, which the
+// owner keeps CLOSED — when off (default), the effect is skipped entirely (no state mutation).
+const NODE_TIMEOUT_TERMINAL_EFFECTS_ENV = 'APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS'
+function nodeTimeoutTerminalEffectsEnabled(): boolean {
+  return process.env[NODE_TIMEOUT_TERMINAL_EFFECTS_ENV] === 'true'
+}
+// T1-1 slice-2 Q7: system sentinel recorded as the actor of a scanner-fired transfer/jump.
+const APPROVAL_TIMEOUT_SYSTEM_ACTOR = 'system:approval-timeout'
+/** Outcome of a scanner-invoked transfer/jump timeout effect (see applyNodeTimeoutEffect). */
+export type ApprovalNodeTimeoutEffectOutcome =
+  | 'applied'
+  | 'skipped_stale'
+  | 'skipped_invalid_config'
+  | 'skipped_terminal_gated'
+  | 'skipped_parallel_state'
 // Upper bound (~69.4 days) guards against an overflowing deadline; lower bound forbids 0/negative.
 const NODE_TIMEOUT_MAX_AFTER_MINUTES = 100000
 const APPROVAL_MAX_AUTO_STEPS = 50
@@ -945,9 +963,15 @@ function normalizeNodeTimeout(
   if (!isRecord(value)) {
     failValidation(context, `${path} must be an object`)
   }
+  // Slice-2 effect targets ride along (trimmed); required/cross-field rules live in
+  // validateNodeTimeoutConfigs so all entry points raise the same APPROVAL_NODE_TIMEOUT_* codes.
+  const transferToUserId = typeof value.transferToUserId === 'string' ? value.transferToUserId.trim() : undefined
+  const jumpToNodeKey = typeof value.jumpToNodeKey === 'string' ? value.jumpToNodeKey.trim() : undefined
   return {
     afterMinutes: value.afterMinutes as number,
     effect: value.effect as NodeTimeoutEffect,
+    ...(transferToUserId ? { transferToUserId } : {}),
+    ...(jumpToNodeKey ? { jumpToNodeKey } : {}),
   }
 }
 
@@ -1035,9 +1059,13 @@ function collectParallelRegionNodeKeys(approvalGraph: ApprovalGraph): Set<string
 /**
  * T1-1 node-level SLA publish/author gate. For every node carrying a `config.timeout`:
  *   - `afterMinutes` must be a whole integer in (0, NODE_TIMEOUT_MAX_AFTER_MINUTES].
- *   - `effect` must be in the declared enum AND supported by slice 1 (`remind` only) — transfer / jump
- *     / auto_* are reserved (APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED).
+ *   - `effect` must be in the declared enum AND wired (`remind` | `transfer` | `jump`) — auto_* stay
+ *     reserved (APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED).
  *   - the node must NOT be inside a parallel region (APPROVAL_NODE_TIMEOUT_PARALLEL_UNSUPPORTED).
+ *   - slice-2 target rules (APPROVAL_NODE_TIMEOUT_TARGET_INVALID): transfer requires
+ *     `transferToUserId`; jump requires `jumpToNodeKey` referencing an EXISTING approval node that is
+ *     not the node itself and not inside a parallel region; targets are strictly effect-matched
+ *     (a stray target field on any other effect is rejected); transfer/jump only on approval nodes.
  * Raises the specific codes directly (status 400) so create / update / publish surface the same error
  * regardless of the surrounding validation context.
  */
@@ -1086,6 +1114,52 @@ function validateNodeTimeoutConfigs(approvalGraph: ApprovalGraph): void {
         400,
         'APPROVAL_NODE_TIMEOUT_PARALLEL_UNSUPPORTED',
       )
+    }
+    // T1-1 slice-2 QS-a: per-effect target rules. Strict cross-field — a target that does not belong
+    // to the configured effect is rejected rather than silently ignored, so a saved graph can never
+    // carry a misleading target.
+    const transferToUserId = (timeout as { transferToUserId?: unknown }).transferToUserId
+    const jumpToNodeKey = (timeout as { jumpToNodeKey?: unknown }).jumpToNodeKey
+    const failTarget = (message: string): never => {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} ${message}`,
+        400,
+        'APPROVAL_NODE_TIMEOUT_TARGET_INVALID',
+      )
+    }
+    if (effect === 'transfer' || effect === 'jump') {
+      if (node.type !== 'approval') {
+        failTarget(`timeout.effect '${effect}' is only supported on approval nodes`)
+      }
+    }
+    if (effect === 'transfer') {
+      if (typeof transferToUserId !== 'string' || transferToUserId.trim().length === 0) {
+        failTarget('timeout.transferToUserId is required for the transfer effect')
+      }
+      if (jumpToNodeKey !== undefined) {
+        failTarget('timeout.jumpToNodeKey is not allowed on a transfer effect')
+      }
+    } else if (effect === 'jump') {
+      if (transferToUserId !== undefined) {
+        failTarget('timeout.transferToUserId is not allowed on a jump effect')
+      }
+      const targetKey = typeof jumpToNodeKey === 'string' ? jumpToNodeKey.trim() : ''
+      if (targetKey.length === 0) {
+        failTarget('timeout.jumpToNodeKey is required for the jump effect')
+      }
+      if (targetKey === node.key) {
+        failTarget('timeout.jumpToNodeKey must not target the node itself')
+      }
+      const target = approvalGraph.nodes.find((candidate) => candidate.key === targetKey)
+      if (!target) {
+        failTarget(`timeout.jumpToNodeKey references unknown node ${targetKey}`)
+      } else if (target.type !== 'approval') {
+        failTarget('timeout.jumpToNodeKey must target an approval node')
+      } else if (parallelRegionNodeKeys.has(targetKey)) {
+        failTarget('timeout.jumpToNodeKey must not target a node inside a parallel region')
+      }
+    } else if (transferToUserId !== undefined || jumpToNodeKey !== undefined) {
+      failTarget(`timeout target fields are not allowed on the '${effect}' effect`)
     }
   }
 }
@@ -3636,6 +3710,258 @@ export class ApprovalProductService {
       throw new ServiceError('Approval not found after jump', 404, APPROVAL_ERROR_CODES.APPROVAL_NOT_FOUND)
     }
     return approval
+  }
+
+  /**
+   * T1-1 slice-2 — apply a scanner-fired node-timeout effect (`transfer` | `jump`) with the
+   * `system:approval-timeout` actor. Invoked by ApprovalSlaScheduler for due non-remind rows.
+   *
+   * Contract:
+   * - Single-shot: on any outcome that can never self-heal for this activation (applied, invalid
+   *   config, gated terminal cascade, lingering deadline on a terminal instance, in-flight parallel
+   *   state) the armed deadline is consumed INSIDE this transaction — the scheduler must NOT call
+   *   markNodeTimeoutFired for effect rows.
+   * - Race guard: the instance row is locked FOR UPDATE and the armed deadline is re-verified in-txn
+   *   (present, overdue, effect matches the scan); a mismatch is a stale skip that consumes nothing.
+   * - QS-b terminal gate (ships CLOSED): a jump resolution that cascades to a TERMINAL state is
+   *   resolved FIRST and inspected — when APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS is not enabled, the
+   *   effect is skipped with zero approval-state mutation (only the timeout is consumed).
+   */
+  async applyNodeTimeoutEffect(id: string, scannedEffect: 'transfer' | 'jump'): Promise<ApprovalNodeTimeoutEffectOutcome> {
+    if (!pool) throw new Error('Database not available')
+
+    let client: ApprovalDbClient | null = null
+    try {
+      client = await pool.connect()
+      await client.query('BEGIN')
+
+      const consumeTimeout = async (): Promise<void> => {
+        await client!.query(
+          `UPDATE approval_metrics
+             SET current_node_deadline_at = NULL, current_node_timeout_effect = NULL
+           WHERE instance_id = $1`,
+          [id],
+        )
+      }
+      const consumeAndSkip = async (outcome: ApprovalNodeTimeoutEffectOutcome, reason: string): Promise<ApprovalNodeTimeoutEffectOutcome> => {
+        await consumeTimeout()
+        await client!.query('COMMIT')
+        nodeTimeoutLogger.warn(
+          `node-timeout ${scannedEffect} skipped: ${JSON.stringify({ instanceId: id, effect: scannedEffect, reason })}`,
+        )
+        return outcome
+      }
+
+      const instanceResult = await client.query<ApprovalInstanceRow>(
+        `SELECT * FROM approval_instances WHERE id = $1 AND COALESCE(source_system, 'platform') = 'platform' FOR UPDATE`,
+        [id],
+      )
+      const instance = instanceResult.rows[0]
+      if (!instance) {
+        await client.query('ROLLBACK')
+        return 'skipped_stale'
+      }
+      if (instance.status !== 'pending') {
+        // A lingering deadline on a decided instance (the best-effort terminal metrics cleanup was
+        // missed) — consume it so the scanner stops re-returning the row every tick.
+        await consumeTimeout()
+        await client.query('COMMIT')
+        return 'skipped_stale'
+      }
+
+      // Scan→fire race guard: re-verify the armed deadline inside the transaction.
+      const armedResult = await client.query<{ current_node_deadline_at: string | Date | null; current_node_timeout_effect: string | null }>(
+        `SELECT current_node_deadline_at, current_node_timeout_effect FROM approval_metrics WHERE instance_id = $1 FOR UPDATE`,
+        [id],
+      )
+      const armed = armedResult.rows[0]
+      const deadlineMs = armed?.current_node_deadline_at ? new Date(armed.current_node_deadline_at as string | Date).getTime() : Number.NaN
+      if (!armed || Number.isNaN(deadlineMs) || deadlineMs > Date.now() || armed.current_node_timeout_effect !== scannedEffect) {
+        await client.query('ROLLBACK')
+        return 'skipped_stale'
+      }
+
+      if (!instance.published_definition_id || !instance.current_node_key) {
+        return await consumeAndSkip('skipped_invalid_config', 'instance_not_runtime_managed')
+      }
+      if (readParallelBranchStates(instance.metadata)) {
+        // Timeout effects can't safely mutate an in-flight parallel region (publish rejects these
+        // configs; this is runtime defense-in-depth against a stale published definition).
+        return await consumeAndSkip('skipped_parallel_state', 'parallel_state_in_flight')
+      }
+
+      const runtimeResult = await client.query<PublishedDefinitionRow>(
+        `SELECT * FROM approval_published_definitions WHERE id = $1`,
+        [instance.published_definition_id],
+      )
+      const runtime = runtimeResult.rows[0]
+      if (!runtime) {
+        return await consumeAndSkip('skipped_invalid_config', 'published_definition_missing')
+      }
+      const runtimeGraph = asRuntimeGraph(runtime.runtime_graph)
+      const currentNodeKey = instance.current_node_key
+      const timeoutConfig = nodeTimeoutForKey(runtimeGraph, currentNodeKey)
+      if (!timeoutConfig || timeoutConfig.effect !== scannedEffect) {
+        // The armed deadline no longer matches the current node's configured effect (e.g. the
+        // instance advanced and the best-effort re-stamp has not landed yet). Not ours to consume —
+        // the activation re-stamp owns these columns; next tick sees fresh state.
+        await client.query('ROLLBACK')
+        return 'skipped_stale'
+      }
+
+      const formSnapshot = toNullableRecord(instance.form_snapshot) || {}
+      const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
+      const executor = new ApprovalGraphExecutor(runtimeGraph, formSnapshot, {
+        assignmentResolver: buildApprovalAssignmentResolver({
+          formSnapshot,
+          requesterSnapshot,
+        }),
+        requesterContext: ((d, t, r) => ({
+          department: typeof d === 'string' && d ? d : null,
+          title: typeof t === 'string' && t ? t : null,
+          roles: Array.isArray(r) ? r.filter((role): role is string => typeof role === 'string') : [],
+        }))(requesterSnapshot?.directoryDepartment, requesterSnapshot?.directoryTitle, requesterSnapshot?.directoryRoles),
+      })
+
+      if (scannedEffect === 'transfer') {
+        const targetUserId = timeoutConfig.transferToUserId?.trim()
+        if (!targetUserId) {
+          return await consumeAndSkip('skipped_invalid_config', 'transfer_target_missing')
+        }
+        // Hand the WHOLE node over: every active assignment at the node is deactivated and the
+        // static target takes it (mode semantics reset to the single handed-over approver).
+        await client.query(
+          `UPDATE approval_assignments
+             SET is_active = FALSE, updated_at = now()
+           WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE`,
+          [id, currentNodeKey],
+        )
+        await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, targetUserId))
+        // Parity with the dispatch transfer: an in-place handover does not bump the instance version.
+        await this.insertApprovalRecord(client, id, {
+          action: 'transfer',
+          actorId: APPROVAL_TIMEOUT_SYSTEM_ACTOR,
+          actorName: APPROVAL_TIMEOUT_SYSTEM_ACTOR,
+          comment: null,
+          fromStatus: instance.status,
+          toStatus: instance.status,
+          fromVersion: instance.version,
+          toVersion: instance.version,
+          metadata: { nodeKey: currentNodeKey, timeoutEffect: true, targetUserId },
+          targetUserId,
+        })
+        await consumeTimeout()
+        await client.query('COMMIT')
+        return 'applied'
+      }
+
+      const targetNodeKey = timeoutConfig.jumpToNodeKey?.trim()
+      const targetNode = targetNodeKey ? findRuntimeGraphNode(runtimeGraph, targetNodeKey) : null
+      if (!targetNodeKey || !targetNode || targetNode.type !== 'approval' || targetNodeKey === currentNodeKey) {
+        return await consumeAndSkip('skipped_invalid_config', 'jump_target_invalid')
+      }
+
+      const jumpResolution = executor.resolveReturnToNode(targetNodeKey)
+      const requesterId = requesterSnapshot?.id
+      const resolution = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
+        ? this.applyAutoApprovalCascade(
+            id,
+            runtimeGraph,
+            executor,
+            jumpResolution,
+            typeof requesterId === 'string' ? requesterId : null,
+            await this.loadApprovalHistory(client, id),
+          )
+        : jumpResolution
+      if (resolution.status !== 'pending' && !nodeTimeoutTerminalEffectsEnabled()) {
+        // QS-b: the jump's auto-approval cascade would land TERMINAL — a de-facto auto_approve. The
+        // terminal gate ships CLOSED, so skip with zero approval-state mutation (resolution was
+        // computed in memory only; nothing has been written yet).
+        return await consumeAndSkip('skipped_terminal_gated', 'terminal_cascade_gated')
+      }
+
+      const nextVersion = instance.version + 1
+      const activeAssignments = await client.query<ApprovalAssignmentRow>(
+        `SELECT * FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY created_at ASC`,
+        [id],
+      )
+      const oldAssignees = assignmentRowsForAudit(activeAssignments.rows)
+      const newAssignees = graphAssignmentsForAudit(resolution.assignments)
+      let completionEvent: ApprovalCompletionEventV1 | null = null
+
+      await this.deactivateAllActiveAssignments(client, id)
+      await client.query(
+        `UPDATE approval_instances
+         SET status = $2,
+             version = $3,
+             current_node_key = $4,
+             current_step = $5,
+             total_steps = $6,
+             updated_at = now()
+         WHERE id = $1`,
+        [
+          id,
+          resolution.status,
+          nextVersion,
+          resolution.currentNodeKey,
+          resolution.currentStep ?? instance.total_steps,
+          resolution.totalSteps,
+        ],
+      )
+      await this.insertAssignments(client, id, resolution.assignments)
+      await this.insertApprovalRecord(client, id, {
+        action: 'jump',
+        actorId: APPROVAL_TIMEOUT_SYSTEM_ACTOR,
+        actorName: APPROVAL_TIMEOUT_SYSTEM_ACTOR,
+        comment: null,
+        fromStatus: instance.status,
+        toStatus: resolution.status,
+        fromVersion: instance.version,
+        toVersion: nextVersion,
+        metadata: {
+          timeoutEffect: true,
+          fromNodeKey: currentNodeKey,
+          toNodeKey: targetNodeKey,
+          nextNodeKey: resolution.currentNodeKey,
+          oldAssignees,
+          newAssignees,
+        },
+      })
+      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
+      await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
+      if (resolution.status === 'approved') {
+        completionEvent = this.buildCompletionEvent(
+          instance,
+          {
+            action: 'jump',
+            fromStatus: instance.status,
+            toStatus: 'approved',
+            fromVersion: instance.version,
+            toVersion: nextVersion,
+            nodeKey: currentNodeKey,
+          },
+          { id: APPROVAL_TIMEOUT_SYSTEM_ACTOR, name: APPROVAL_TIMEOUT_SYSTEM_ACTOR },
+        )
+      }
+      await consumeTimeout()
+      await client.query('COMMIT')
+
+      // Post-commit best-effort metrics, mirroring the return path: close the timed-out node's open
+      // breakdown entry, then re-entry activation re-stamps the target node (incl. its own timeout).
+      this.emitNodeDecisionMetric(id, currentNodeKey, APPROVAL_TIMEOUT_SYSTEM_ACTOR)
+      if (resolution.status === 'pending' && resolution.currentNodeKey) {
+        this.emitNodeActivationMetric(id, resolution.currentNodeKey, nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
+      }
+      if (completionEvent) {
+        emitApprovalCompletionEvent(completionEvent)
+      }
+      return 'applied'
+    } catch (error) {
+      await rollbackQuietly(client)
+      throw error
+    } finally {
+      client?.release()
+    }
   }
 
   async dispatchAction(

--- a/packages/core-backend/src/services/ApprovalSlaScheduler.ts
+++ b/packages/core-backend/src/services/ApprovalSlaScheduler.ts
@@ -41,7 +41,19 @@ export interface ApprovalSlaSchedulerOptions {
    * timeout is still single-shot via `markNodeTimeoutFired`).
    */
   onNodeReminder?: (reminder: ApprovalNodeTimeoutReminder) => Promise<void> | void
+  /**
+   * T1-1 slice-2: apply a due state-mutating timeout effect (`transfer` | `jump`). Wired in index.ts
+   * to `ApprovalProductService.applyNodeTimeoutEffect`, which owns the single-shot consumption inside
+   * its own transaction — the scheduler must NOT call `markNodeTimeoutFired` for effect rows. Returns
+   * the outcome string for logging. Absent → effect rows are left un-fired (slice-1 posture).
+   */
+  onNodeEffect?: (request: ApprovalNodeTimeoutEffectRequest) => Promise<string> | string
   logger?: Logger
+}
+
+export interface ApprovalNodeTimeoutEffectRequest {
+  instanceId: string
+  effect: 'transfer' | 'jump'
 }
 
 /** Minimal DB surface the scheduler needs for node-timeout assignee resolution (pg Pool satisfies it). */
@@ -90,6 +102,7 @@ export class ApprovalSlaScheduler {
   private readonly onBreach: ApprovalSlaSchedulerOptions['onBreach']
   private readonly pool: ApprovalSlaSchedulerPool | null
   private readonly onNodeReminder: ApprovalSlaSchedulerOptions['onNodeReminder']
+  private readonly onNodeEffect: ApprovalSlaSchedulerOptions['onNodeEffect']
   private timer: NodeJS.Timeout | null = null
   private renewalTimer: NodeJS.Timeout | null = null
   private acquisitionTimer: NodeJS.Timeout | null = null
@@ -111,6 +124,7 @@ export class ApprovalSlaScheduler {
     // `undefined` (option omitted) → shared pool; explicit `null` → no assignee lookup.
     this.pool = options.pool === undefined ? defaultPool : options.pool
     this.onNodeReminder = options.onNodeReminder
+    this.onNodeEffect = options.onNodeEffect
     this.logger = options.logger ?? new Logger('ApprovalSlaScheduler')
     if (this.leaderOptions) {
       this.setLeaderGauge('follower')
@@ -203,10 +217,10 @@ export class ApprovalSlaScheduler {
 
   /**
    * T1-1 node-level SLA scan. For each metrics row whose current node has passed its deadline:
-   * resolve the node's active assignees and dispatch a node-overdue reminder (slice 1 wires `remind`
-   * only), then mark the timeout fired so it is strictly single-shot. Per-row isolation: a single
-   * failure (no assignees, dispatch error) leaves that row un-fired (retried next tick, at-least-once)
-   * and never breaks the rest of the batch or the tick.
+   * `remind` → resolve active assignees, dispatch the reminder, then markNodeTimeoutFired (single-shot
+   * here); `transfer`/`jump` (slice 2) → delegate to onNodeEffect, which consumes the timeout inside
+   * its own transaction (never marked here). Per-row isolation: a single failure leaves that row
+   * un-fired (retried next tick, at-least-once) and never breaks the rest of the batch or the tick.
    */
   private async fireNodeTimeouts(now: Date): Promise<void> {
     let due: Array<{ instanceId: string; effect: string }> = []
@@ -218,17 +232,26 @@ export class ApprovalSlaScheduler {
     }
     for (const row of due) {
       try {
-        // Slice 1 wires `remind` only. Other effects can't be published yet (publish gate), so leave
-        // an unexpected row un-fired rather than silently consuming an effect we don't handle.
-        if (row.effect !== 'remind') continue
-        const assigneeIds = await this.resolveActiveAssignees(row.instanceId)
-        if (this.onNodeReminder) {
-          await this.onNodeReminder({ instanceId: row.instanceId, effect: row.effect, assigneeIds })
+        if (row.effect === 'remind') {
+          const assigneeIds = await this.resolveActiveAssignees(row.instanceId)
+          if (this.onNodeReminder) {
+            await this.onNodeReminder({ instanceId: row.instanceId, effect: row.effect, assigneeIds })
+          }
+          await this.metrics.markNodeTimeoutFired(row.instanceId)
+        } else if ((row.effect === 'transfer' || row.effect === 'jump') && this.onNodeEffect) {
+          // Slice-2 state-mutating effects: the service call owns the single-shot consumption inside
+          // its transaction — no markNodeTimeoutFired here. A throw leaves the row un-fired (nothing
+          // mutated) and it retries next tick.
+          const outcome = await this.onNodeEffect({ instanceId: row.instanceId, effect: row.effect })
+          this.logger.info(`Node-timeout ${row.effect} for ${row.instanceId}: ${outcome}`)
+        } else {
+          // auto_* (runtime-inert) or an unwired effect hook — leave the row un-fired rather than
+          // silently consuming an effect we don't handle.
+          continue
         }
-        await this.metrics.markNodeTimeoutFired(row.instanceId)
       } catch (error) {
         this.logger.warn(
-          `Node-timeout remind failed for ${row.instanceId}: ${error instanceof Error ? error.message : String(error)}`,
+          `Node-timeout ${row.effect} failed for ${row.instanceId}: ${error instanceof Error ? error.message : String(error)}`,
         )
       }
     }

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -75,13 +75,20 @@ export interface ApprovalNode {
     | Record<string, never>
 }
 
-// T1-1 node-level SLA + timeout. The effect enum declares the full set; slice 1 wires `remind`
-// only (a notification, no state mutation) — transfer/jump/auto_* are rejected at publish until
-// their slice. `afterMinutes` = whole wall-clock minutes from the node's activation.
+// T1-1 node-level SLA + timeout. The effect enum declares the full set; slice 1 wired `remind`
+// (a notification, no state mutation) and slice 2 wires `transfer` + `jump` (state mutations executed
+// by the scanner with a system actor). auto_approve/auto_reject remain rejected at publish and
+// runtime-inert — a jump whose auto-approval cascade would land TERMINAL is likewise skipped unless
+// the APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS gate is explicitly enabled (it ships CLOSED).
+// `afterMinutes` = whole wall-clock minutes from the node's activation.
 export type NodeTimeoutEffect = 'remind' | 'transfer' | 'jump' | 'auto_approve' | 'auto_reject'
 export interface NodeTimeoutConfig {
   afterMinutes: number
   effect: NodeTimeoutEffect
+  /** effect='transfer': static user the node's active assignments are handed to when the deadline fires. */
+  transferToUserId?: string
+  /** effect='jump': approval-node key the instance is sent to (re-entry semantics) when the deadline fires. */
+  jumpToNodeKey?: string
 }
 
 export interface ApprovalNodeConfig {

--- a/packages/core-backend/tests/integration/approval-node-timeout-effects.test.ts
+++ b/packages/core-backend/tests/integration/approval-node-timeout-effects.test.ts
@@ -1,0 +1,575 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import { ApprovalMetricsService } from '../../src/services/ApprovalMetricsService'
+import {
+  ApprovalSlaScheduler,
+  type ApprovalNodeTimeoutReminder,
+} from '../../src/services/ApprovalSlaScheduler'
+
+/**
+ * T1-1 slice-2 — transfer/jump node-timeout effects (real DB, real HTTP publish/create path).
+ *
+ * Ballot decisions locked here:
+ *  - Q1: transfer + jump wired; auto_* still publish-rejected (terminal gate CLOSED — no env set).
+ *  - QS-a: timeout.transferToUserId / timeout.jumpToNodeKey publish validation (target-specific 400s).
+ *  - QS-b: a jump whose resolution cascades to a TERMINAL state is SKIPPED (no state mutation) while
+ *    APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS is unset, and the timeout is consumed (single-shot).
+ *  - Q3: audit reuses actions 'transfer'/'jump' with metadata.timeoutEffect=true.
+ *  - Q7: system actor 'system:approval-timeout'.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+type JsonRecord = Record<string, unknown>
+
+type ApprovalRecordRow = {
+  action: string
+  actor_id: string | null
+  to_status: string
+  metadata: JsonRecord
+}
+
+type ApprovalAssignmentRow = {
+  assignee_id: string
+  is_active: boolean
+}
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+  return response
+}
+
+function buildFormSchema() {
+  return {
+    fields: [
+      { id: 'reason', type: 'text', label: '事由', required: true },
+    ],
+  }
+}
+
+type TimeoutConfig = Record<string, unknown>
+
+// Single approval node carrying a timeout config — publish-validation fixtures.
+function buildSingleNodeGraph(timeout: TimeoutConfig | undefined) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'node_a',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a'],
+          approvalMode: 'single',
+          ...(timeout !== undefined ? { timeout } : {}),
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-a', source: 'start', target: 'node_a' },
+      { key: 'edge-a-end', source: 'node_a', target: 'end' },
+    ],
+  }
+}
+
+// A(approver-a) -> B(approver-b, timeout) -> end. Fire the timeout while pending at B.
+function buildTwoNodeGraph(timeoutOnB: TimeoutConfig) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'node_a',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-a'], approvalMode: 'single' },
+      },
+      {
+        key: 'node_b',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-b'], approvalMode: 'single', timeout: timeoutOnB },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-a', source: 'start', target: 'node_a' },
+      { key: 'edge-a-b', source: 'node_a', target: 'node_b' },
+      { key: 'edge-b-end', source: 'node_b', target: 'end' },
+    ],
+  }
+}
+
+// A -> B(timeout jump -> C) -> C(requester-merged auto-approval) -> end: the timeout jump's
+// cascade lands TERMINAL (approved) — must be gated-skipped while the terminal gate is closed.
+function buildTerminalCascadeGraph(requesterId: string) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'node_a',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-a'], approvalMode: 'single' },
+      },
+      {
+        key: 'node_b',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-b'],
+          approvalMode: 'single',
+          timeout: { afterMinutes: 1, effect: 'jump', jumpToNodeKey: 'node_c' },
+        },
+      },
+      {
+        key: 'node_c',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: [requesterId],
+          approvalMode: 'single',
+          autoApprovalPolicy: { mergeWithRequester: true },
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-a', source: 'start', target: 'node_a' },
+      { key: 'edge-a-b', source: 'node_a', target: 'node_b' },
+      { key: 'edge-b-c', source: 'node_b', target: 'node_c' },
+      { key: 'edge-c-end', source: 'node_c', target: 'end' },
+    ],
+  }
+}
+
+describeIfDatabase('Approval T1-1 slice-2 node-timeout transfer/jump effects — real DB', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+
+  function rawQuery<T extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<{ rows: T[] }> {
+    return poolManager.get().query<T>(sql, params) as unknown as Promise<{ rows: T[] }>
+  }
+
+  beforeAll(async () => {
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool.query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+    } catch {
+      // Ignore cleanup failures — the top-level describe restart clears everything on rerun.
+    }
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  async function createTemplate(adminToken: string, approvalGraph: object): Promise<Response> {
+    const templateKey = `approval-t11s2-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    return jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Node Timeout Effects Template',
+        description: 'T1-1 slice-2 transfer/jump timeout effects integration',
+        formSchema: buildFormSchema(),
+        approvalGraph,
+      },
+    })
+  }
+
+  async function publishGraphTemplate(adminToken: string, approvalGraph: object): Promise<string> {
+    const templateResponse = await createTemplate(adminToken, approvalGraph)
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status).toBe(200)
+    return template.id
+  }
+
+  async function startApproval(requesterToken: string, templateId: string): Promise<{ id: string; currentNodeKey: string | null }> {
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 'node timeout effects' } },
+    })
+    expect(createResponse.status).toBe(201)
+    const created = await createResponse.json() as { id: string; currentNodeKey: string | null }
+    createdApprovalIds.add(created.id)
+    return created
+  }
+
+  // The decision(old node) + activation(new node) metrics writes after an approve are two CONCURRENT
+  // unawaited best-effort calls, and recordNodeDecision clears the deadline columns — a late decision
+  // write can wipe the fresh activation stamp (pre-existing slice-1 race, register reviewer note (3)).
+  // Deterministic test arming: wait until the columns are STABLE across consecutive reads (in-flight
+  // writers settled), then force-arm BOTH columns overdue (mirrors the slice-1 remind test seeding
+  // metrics directly). The service re-validates the effect against the published graph config anyway.
+  async function forceDeadlineOverdue(instanceId: string, effect: string): Promise<void> {
+    let prev = ''
+    let stable = 0
+    for (let attempt = 0; attempt < 60 && stable < 3; attempt++) {
+      const row = await rawQuery<{ current_node_deadline_at: unknown; current_node_timeout_effect: string | null }>(
+        `SELECT current_node_deadline_at, current_node_timeout_effect FROM approval_metrics WHERE instance_id = $1`,
+        [instanceId],
+      )
+      const sig = `${row.rows[0]?.current_node_timeout_effect ?? 'null'}|${row.rows[0]?.current_node_deadline_at ? 'set' : 'null'}`
+      stable = sig === prev ? stable + 1 : 0
+      prev = sig
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+    expect(stable).toBeGreaterThanOrEqual(3)
+    const updated = await rawQuery(
+      `UPDATE approval_metrics
+         SET current_node_deadline_at = now() - INTERVAL '1 minute',
+             current_node_timeout_effect = $2
+       WHERE instance_id = $1
+       RETURNING instance_id`,
+      [instanceId, effect],
+    )
+    expect(updated.rows).toHaveLength(1)
+  }
+
+  async function fetchRecords(instanceId: string): Promise<ApprovalRecordRow[]> {
+    const result = await rawQuery<ApprovalRecordRow>(
+      `SELECT action, actor_id, to_status, metadata FROM approval_records WHERE instance_id = $1 ORDER BY created_at ASC`,
+      [instanceId],
+    )
+    return result.rows
+  }
+
+  async function fetchActiveAssignees(instanceId: string): Promise<string[]> {
+    const result = await rawQuery<ApprovalAssignmentRow>(
+      `SELECT assignee_id, is_active FROM approval_assignments WHERE instance_id = $1`,
+      [instanceId],
+    )
+    return result.rows.filter((row) => row.is_active).map((row) => row.assignee_id).sort()
+  }
+
+  async function fetchInstance(instanceId: string): Promise<{ status: string; current_node_key: string | null; version: number }> {
+    const result = await rawQuery<{ status: string; current_node_key: string | null; version: number }>(
+      `SELECT status, current_node_key, version FROM approval_instances WHERE id = $1`,
+      [instanceId],
+    )
+    expect(result.rows).toHaveLength(1)
+    return result.rows[0]
+  }
+
+  function buildScheduler(reminders?: ApprovalNodeTimeoutReminder[]): ApprovalSlaScheduler {
+    const service = new ApprovalProductService()
+    return new ApprovalSlaScheduler({
+      metrics: new ApprovalMetricsService(rawQuery),
+      pool: { query: rawQuery },
+      onNodeReminder: reminders
+        ? async (reminder) => { reminders.push(reminder) }
+        : undefined,
+      onNodeEffect: async ({ instanceId, effect }) => service.applyNodeTimeoutEffect(instanceId, effect),
+    })
+  }
+
+  it('has DATABASE_URL configured (sentinel — never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('terminal gate is CLOSED in this suite (owner amendment — no env enablement)', () => {
+    expect(process.env.APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS).toBeUndefined()
+  })
+
+  it('publish REJECTS a transfer timeout without transferToUserId (QS-a)', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const response = await createTemplate(adminToken, buildSingleNodeGraph({ afterMinutes: 1, effect: 'transfer' }))
+    expect(response.status).toBe(400)
+    const body = await response.json() as { code?: string; error?: { code?: string } }
+    expect(JSON.stringify(body)).toContain('APPROVAL_NODE_TIMEOUT_TARGET_INVALID')
+  })
+
+  it('publish REJECTS a jump timeout to a nonexistent node (QS-a)', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const response = await createTemplate(
+      adminToken,
+      buildSingleNodeGraph({ afterMinutes: 1, effect: 'jump', jumpToNodeKey: 'no_such_node' }),
+    )
+    expect(response.status).toBe(400)
+    expect(JSON.stringify(await response.json())).toContain('APPROVAL_NODE_TIMEOUT_TARGET_INVALID')
+  })
+
+  it('publish REJECTS a jump timeout targeting a non-approval node (QS-a)', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const response = await createTemplate(
+      adminToken,
+      buildSingleNodeGraph({ afterMinutes: 1, effect: 'jump', jumpToNodeKey: 'end' }),
+    )
+    expect(response.status).toBe(400)
+    expect(JSON.stringify(await response.json())).toContain('APPROVAL_NODE_TIMEOUT_TARGET_INVALID')
+  })
+
+  it('publish REJECTS a self-jump timeout (QS-a)', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const response = await createTemplate(
+      adminToken,
+      buildSingleNodeGraph({ afterMinutes: 1, effect: 'jump', jumpToNodeKey: 'node_a' }),
+    )
+    expect(response.status).toBe(400)
+    expect(JSON.stringify(await response.json())).toContain('APPROVAL_NODE_TIMEOUT_TARGET_INVALID')
+  })
+
+  it('publish REJECTS a remind timeout carrying a stray target field (strict cross-field)', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const response = await createTemplate(
+      adminToken,
+      buildSingleNodeGraph({ afterMinutes: 1, effect: 'remind', transferToUserId: 'someone' }),
+    )
+    expect(response.status).toBe(400)
+    expect(JSON.stringify(await response.json())).toContain('APPROVAL_NODE_TIMEOUT_TARGET_INVALID')
+  })
+
+  it('publish still REJECTS auto_approve / auto_reject (terminal effects stay unwired)', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    for (const effect of ['auto_approve', 'auto_reject']) {
+      const response = await createTemplate(adminToken, buildSingleNodeGraph({ afterMinutes: 1, effect }))
+      expect(response.status).toBe(400)
+      expect(JSON.stringify(await response.json())).toContain('APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED')
+    }
+  })
+
+  it('TRANSFER: an overdue transfer timeout hands the node to the target once (single-shot) and the node still completes', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const requesterToken = await authToken(baseUrl, 'timeout-requester')
+    const targetToken = await authToken(baseUrl, 'timeout-target')
+
+    const templateId = await publishGraphTemplate(
+      adminToken,
+      buildSingleNodeGraph({ afterMinutes: 1, effect: 'transfer', transferToUserId: 'timeout-target' }),
+    )
+    const inst = await startApproval(requesterToken, templateId)
+    expect(inst.currentNodeKey).toBe('node_a')
+    expect(await fetchActiveAssignees(inst.id)).toEqual(['approver-a'])
+
+    await forceDeadlineOverdue(inst.id, 'transfer')
+    const scheduler = buildScheduler()
+    await scheduler.tick(new Date())
+
+    // Node handed over: original approver inactive, target active; instance unchanged otherwise.
+    expect(await fetchActiveAssignees(inst.id)).toEqual(['timeout-target'])
+    const afterTransfer = await fetchInstance(inst.id)
+    expect(afterTransfer.status).toBe('pending')
+    expect(afterTransfer.current_node_key).toBe('node_a')
+
+    // Audit: action='transfer', system actor, timeoutEffect discriminator (Q3/Q7).
+    const records = await fetchRecords(inst.id)
+    const transferRecords = records.filter((row) => row.action === 'transfer')
+    expect(transferRecords).toHaveLength(1)
+    expect(transferRecords[0].actor_id).toBe('system:approval-timeout')
+    expect(transferRecords[0].metadata.timeoutEffect).toBe(true)
+    expect(transferRecords[0].metadata.targetUserId).toBe('timeout-target')
+
+    // Single-shot: deadline consumed inside the effect transaction; a second tick adds nothing.
+    const deadline = await rawQuery<{ current_node_deadline_at: unknown }>(
+      `SELECT current_node_deadline_at FROM approval_metrics WHERE instance_id = $1`,
+      [inst.id],
+    )
+    expect(deadline.rows[0]?.current_node_deadline_at).toBeNull()
+    await scheduler.tick(new Date())
+    expect((await fetchRecords(inst.id)).filter((row) => row.action === 'transfer')).toHaveLength(1)
+
+    // The handed-over node still functions: the target approves and the instance completes.
+    const approve = await jsonRequest(baseUrl, `/api/approvals/${inst.id}/actions`, targetToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'approved after timeout handover' },
+    })
+    expect(approve.status).toBe(200)
+    expect((await fetchInstance(inst.id)).status).toBe('approved')
+  })
+
+  it('JUMP: an overdue jump timeout sends the instance to the target node with re-entry semantics', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const requesterToken = await authToken(baseUrl, 'timeout-requester')
+    const approverAToken = await authToken(baseUrl, 'approver-a')
+
+    const templateId = await publishGraphTemplate(
+      adminToken,
+      buildTwoNodeGraph({ afterMinutes: 1, effect: 'jump', jumpToNodeKey: 'node_a' }),
+    )
+    const inst = await startApproval(requesterToken, templateId)
+    expect(inst.currentNodeKey).toBe('node_a')
+
+    const firstApprove = await jsonRequest(baseUrl, `/api/approvals/${inst.id}/actions`, approverAToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'advance to node_b' },
+    })
+    expect(firstApprove.status).toBe(200)
+    const atB = await fetchInstance(inst.id)
+    expect(atB.current_node_key).toBe('node_b')
+
+    await forceDeadlineOverdue(inst.id, 'jump')
+    const scheduler = buildScheduler()
+    await scheduler.tick(new Date())
+
+    // Jumped back to node_a: re-entry re-resolves node_a's assignment; version bumped.
+    const afterJump = await fetchInstance(inst.id)
+    expect(afterJump.status).toBe('pending')
+    expect(afterJump.current_node_key).toBe('node_a')
+    expect(afterJump.version).toBe(atB.version + 1)
+    expect(await fetchActiveAssignees(inst.id)).toEqual(['approver-a'])
+
+    const records = await fetchRecords(inst.id)
+    const jumpRecords = records.filter((row) => row.action === 'jump')
+    expect(jumpRecords).toHaveLength(1)
+    expect(jumpRecords[0].actor_id).toBe('system:approval-timeout')
+    expect(jumpRecords[0].metadata.timeoutEffect).toBe(true)
+    expect(jumpRecords[0].metadata.toNodeKey).toBe('node_a')
+
+    // node_a carries no timeout → the re-entry activation leaves no armed deadline.
+    const deadline = await rawQuery<{ current_node_deadline_at: unknown }>(
+      `SELECT current_node_deadline_at FROM approval_metrics WHERE instance_id = $1`,
+      [inst.id],
+    )
+    expect(deadline.rows[0]?.current_node_deadline_at).toBeNull()
+
+    // Single-shot: a second tick adds no further jump.
+    await scheduler.tick(new Date())
+    expect((await fetchRecords(inst.id)).filter((row) => row.action === 'jump')).toHaveLength(1)
+  })
+
+  it('QS-b GATED SKIP: a jump whose cascade lands TERMINAL is skipped with NO state mutation and the timeout is consumed', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const requesterToken = await authToken(baseUrl, 'timeout-requester-cascade')
+    const approverAToken = await authToken(baseUrl, 'approver-a')
+
+    const templateId = await publishGraphTemplate(adminToken, buildTerminalCascadeGraph('timeout-requester-cascade'))
+    const inst = await startApproval(requesterToken, templateId)
+    const firstApprove = await jsonRequest(baseUrl, `/api/approvals/${inst.id}/actions`, approverAToken, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'advance to node_b' },
+    })
+    expect(firstApprove.status).toBe(200)
+    const atB = await fetchInstance(inst.id)
+    expect(atB.current_node_key).toBe('node_b')
+
+    await forceDeadlineOverdue(inst.id, 'jump')
+    const service = new ApprovalProductService()
+    const outcome = await service.applyNodeTimeoutEffect(inst.id, 'jump')
+    expect(outcome).toBe('skipped_terminal_gated')
+
+    // No state mutation: still pending at node_b, same version, approver-b still active, no jump record.
+    const after = await fetchInstance(inst.id)
+    expect(after.status).toBe('pending')
+    expect(after.current_node_key).toBe('node_b')
+    expect(after.version).toBe(atB.version)
+    expect(await fetchActiveAssignees(inst.id)).toEqual(['approver-b'])
+    expect((await fetchRecords(inst.id)).filter((row) => row.action === 'jump')).toHaveLength(0)
+
+    // Timeout consumed (single-shot for this activation) so the gated skip cannot warn-loop every tick.
+    const deadline = await rawQuery<{ current_node_deadline_at: unknown }>(
+      `SELECT current_node_deadline_at FROM approval_metrics WHERE instance_id = $1`,
+      [inst.id],
+    )
+    expect(deadline.rows[0]?.current_node_deadline_at).toBeNull()
+  })
+
+  it('RACE GUARD: a future (not yet due) deadline is skipped stale with nothing consumed or mutated', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const requesterToken = await authToken(baseUrl, 'timeout-requester')
+
+    const templateId = await publishGraphTemplate(
+      adminToken,
+      buildSingleNodeGraph({ afterMinutes: 60, effect: 'transfer', transferToUserId: 'timeout-target' }),
+    )
+    const inst = await startApproval(requesterToken, templateId)
+
+    const service = new ApprovalProductService()
+    const outcome = await service.applyNodeTimeoutEffect(inst.id, 'transfer')
+    expect(outcome).toBe('skipped_stale')
+
+    // Untouched: original assignee still active, deadline still armed (future), no transfer record.
+    expect(await fetchActiveAssignees(inst.id)).toEqual(['approver-a'])
+    expect((await fetchRecords(inst.id)).filter((row) => row.action === 'transfer')).toHaveLength(0)
+    const deadline = await rawQuery<{ current_node_deadline_at: unknown }>(
+      `SELECT current_node_deadline_at FROM approval_metrics WHERE instance_id = $1`,
+      [inst.id],
+    )
+    expect(deadline.rows[0]?.current_node_deadline_at).not.toBeNull()
+  })
+
+  it('REMIND regression: a remind timeout still notifies and never invokes the effect path', async () => {
+    const adminToken = await authToken(baseUrl, 'timeout-admin')
+    const requesterToken = await authToken(baseUrl, 'timeout-requester')
+
+    const templateId = await publishGraphTemplate(
+      adminToken,
+      buildSingleNodeGraph({ afterMinutes: 1, effect: 'remind' }),
+    )
+    const inst = await startApproval(requesterToken, templateId)
+    await forceDeadlineOverdue(inst.id, 'remind')
+
+    const reminders: ApprovalNodeTimeoutReminder[] = []
+    const scheduler = buildScheduler(reminders)
+    await scheduler.tick(new Date())
+
+    const mine = reminders.filter((r) => r.instanceId === inst.id)
+    expect(mine).toHaveLength(1)
+    expect(mine[0].effect).toBe('remind')
+    expect(mine[0].assigneeIds).toContain('approver-a')
+    // No state mutation from the remind path.
+    expect(await fetchActiveAssignees(inst.id)).toEqual(['approver-a'])
+    expect((await fetchInstance(inst.id)).status).toBe('pending')
+  })
+})

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2021,14 +2021,25 @@ describe('ApprovalProductService', () => {
       )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_INVALID' })
     })
 
-    it.each(['transfer', 'jump', 'auto_approve', 'auto_reject'])(
-      'rejects the unsupported (slice-1) effect %s',
+    it.each(['auto_approve', 'auto_reject'])(
+      'rejects the still-unwired terminal effect %s',
       async (effect) => {
         const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
         const service = new ApprovalProductService()
         await expect(service.createTemplate(
           timeoutRequest({ afterMinutes: 30, effect }) as never,
         )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED' })
+      },
+    )
+
+    it.each(['transfer', 'jump'])(
+      'rejects the slice-2 effect %s without its required target',
+      async (effect) => {
+        const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+        const service = new ApprovalProductService()
+        await expect(service.createTemplate(
+          timeoutRequest({ afterMinutes: 30, effect }) as never,
+        )).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_NODE_TIMEOUT_TARGET_INVALID' })
       },
     )
 


### PR DESCRIPTION
**First-batch ballot GO (T1-1 slice-2, owner amendment: terminal gate stays CLOSED).** Node timeouts can now transfer the node to a static target or jump the instance to another approval node — `auto_approve`/`auto_reject` remain publish-rejected and runtime-inert; the `APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS` env exists ONLY as the QS-b cascade guard's gate (no enablement path built).

## Ballot decisions → code
- **Q1:** `NODE_TIMEOUT_SUPPORTED_EFFECTS` grows `transfer`+`jump`; auto_* unchanged (publish-rejected).
- **QS-a:** `NodeTimeoutConfig.transferToUserId / jumpToNodeKey` + publish validation under new `APPROVAL_NODE_TIMEOUT_TARGET_INVALID` (transfer needs a target user; jump needs an existing approval-node target, not self, not in a parallel region; strict cross-field — stray targets rejected).
- **Runtime:** `applyNodeTimeoutEffect` — instance FOR UPDATE + **in-transaction armed-deadline re-verification** (present + overdue + effect match; scan→fire race guard); transfer = whole-node handover via `buildTransferAssignments`, no version bump (dispatch-transfer parity); jump mirrors adminJump/return (resolveReturnToNode + auto-approval cascade + version bump + auto-approval/cc events + post-commit decision/activation metrics so the target node's own timeout re-arms).
- **QS-b (gate CLOSED):** the jump resolution is computed FIRST; a cascade landing terminal → **skip with zero approval-state mutation**, consume the timeout, structured warn (`terminal_cascade_gated`).
- **Single-shot:** the service consumes the deadline in-txn on applied/invalid-config/gated outcomes; stale mismatches consume NOTHING (activation re-stamp owns those columns); the scheduler never marks effect rows.
- **Q3:** audit reuses `transfer`/`jump` actions + `metadata.timeoutEffect: true` (adminJump precedent, no migration). **Q7:** actor `system:approval-timeout`. **Q6:** parallel-region publish rules preserved + runtime consume-and-skip defense.
- **Composes with #3446:** the timeout-jump record carries `toNodeKey`/`nextNodeKey`, so a timeout-jump back into a threshold node correctly resets the T2-4 quorum round.

## Verification (independently re-run by the reviewing session)
Fail-first RED **9 failed / 4 passed** before impl → **13/13 green** (×3 by builder, re-verified once more) on an isolated migrated DB · regressions: node-sla-remind + nofm-threshold **9/9**, sla-scheduler unit **11/11** · `tsc --noEmit` 0 · CI: suite wired into plugin-tests.yml.

## Surfaced pre-existing defect (NOT fixed here — proposed small follow-up)
The post-approve `recordNodeDecision`(old node) / `recordNodeActivation`(new node) metrics writes are concurrent unawaited best-effort calls, and decision **clears the deadline columns** — a late decision write can wipe a fresh activation stamp (lost node-timeout for that activation; affects slice-1 remind equally). Worth its own small fix (order/await the two calls or make the decision-clear node-scoped).

## Not in this slice
Notification to the transfer target (not in ballot) · editor exposure of the new config fields · any auto_* enablement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)