### PR TITLE
feat(plm): consumer If-Match for governed BOM write-back — close same-cell lost-update

### DIFF
--- a/apps/web/src/components/plm/PlmBomReviewPanel.vue
+++ b/apps/web/src/components/plm/PlmBomReviewPanel.vue
@@ -120,6 +120,7 @@ function makeIdempotencyKey(): string {
 }
 
 function writebackMessage(status: number): string {
+  if (status === 412) return '此行已被他人修改，已重新载入最新值，请确认后重试。'
   if (status === 403) return '无写回授权或权限不足。'
   if (status === 404) return '该 BOM 行不存在或不属于当前 Part。'
   if (status === 409) return '该 BOM 行当前不可写，或提交键已用于不同写入。'
@@ -150,12 +151,22 @@ async function submitLinePatch(payload: { line: PlmBomMultitableLine; patch: Plm
       lineId,
       payload.patch,
       key,
+      payload.line.write_etag,
     )
     if (outcome.ok) {
       applyLinePatch(payload.line, payload.patch)
       const { [lineId]: _doneKey, ...rest } = retryKeys.value
       retryKeys.value = rest
       lineMessages.value = { ...lineMessages.value, [lineId]: '写回成功。' }
+      return
+    }
+    if (outcome.status === 412) {
+      // Optimistic-concurrency conflict: a concurrent edit landed first. Reload the fresh context
+      // (new write_etags; load() also drops every retry key, so the re-submit mints a fresh
+      // Idempotency-Key rather than replaying the cached original), then surface the conflict so the
+      // user reviews the current value and re-decides. Never report the dropped edit as success.
+      await load()
+      lineMessages.value = { ...lineMessages.value, [lineId]: writebackMessage(412) }
       return
     }
     lineMessages.value = { ...lineMessages.value, [lineId]: writebackMessage(outcome.status) }

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -93,6 +93,8 @@ export interface PlmBomMultitableLine {
   source_version: number | null
   source_updated_at: string | null
   sync_status: string
+  // Provider optimistic-concurrency tag (may be absent from an older provider).
+  write_etag?: string | null
 }
 
 export interface PlmBomMultitablePart {
@@ -823,6 +825,7 @@ export async function updatePlmBomMultitableLine(
   bomLineId: string,
   patch: PlmBomMultitableLinePatch,
   idempotencyKey: string,
+  writeEtag?: string | null,
 ): Promise<PlmBomMultitableLineUpdateResult> {
   const dsId = dataSourceId.trim()
   const pid = partId.trim()
@@ -845,7 +848,11 @@ export async function updatePlmBomMultitableLine(
     `/api/plm-workbench/data-sources/${encodeURIComponent(dsId)}/bom-multitable/${encodeURIComponent(pid)}/lines/${encodeURIComponent(lineId)}`,
     {
       method: 'PATCH',
-      headers: { 'Idempotency-Key': idem },
+      headers: {
+        'Idempotency-Key': idem,
+        // Send the write_etag verbatim as If-Match when present (optimistic concurrency).
+        ...(typeof writeEtag === 'string' && writeEtag ? { 'If-Match': writeEtag } : {}),
+      },
       body: JSON.stringify(payload),
       suppressUnauthorizedRedirect: true,
     },

--- a/apps/web/tests/PlmBomReviewPanel.spec.ts
+++ b/apps/web/tests/PlmBomReviewPanel.spec.ts
@@ -13,7 +13,7 @@ import PlmBomReviewPanel from '../src/components/plm/PlmBomReviewPanel.vue'
 const CONTEXT = {
   part: { part_id: 'P1', item_number: 'P-001', name: 'Assembly', state: 'Released', generation: 3 },
   lines: [
-    { bom_line_id: 'R1', part_id: 'C1', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: ['P1'], path_labels: ['P-001'], source_version: 1, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
+    { bom_line_id: 'R1', part_id: 'C1', write_etag: '"bom-line:etag-r1"', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: ['P1'], path_labels: ['P-001'], source_version: 1, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
     { bom_line_id: 'R2', part_id: 'D1', item_number: 'D-001', name: 'Screw', state: 'Released', generation: 2, quantity: 4, uom: 'EA', find_num: '20', refdes: 'R3', level: 2, path: ['P1', 'C1'], path_labels: ['P-001', 'C-001'], source_version: 2, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
   ],
   source_version: 3,
@@ -108,7 +108,7 @@ describe('PlmBomReviewPanel (P3-C BOM review + governed write-back)', () => {
     ;(container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement).click()
     await flushUi()
 
-    expect(updateLineMock).toHaveBeenCalledWith('plm-ds', 'P1', 'R1', { quantity: 6 }, 'submit-key-1')
+    expect(updateLineMock).toHaveBeenCalledWith('plm-ds', 'P1', 'R1', { quantity: 6 }, 'submit-key-1', '"bom-line:etag-r1"')
     expect(container.textContent).toContain('写回成功。')
     expect(quantity.value).toBe('6')
   })
@@ -137,9 +137,48 @@ describe('PlmBomReviewPanel (P3-C BOM review + governed write-back)', () => {
     save.click()
     await flushUi()
 
-    expect(updateLineMock).toHaveBeenNthCalledWith(1, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-1')
-    expect(updateLineMock).toHaveBeenNthCalledWith(2, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-1')
+    expect(updateLineMock).toHaveBeenNthCalledWith(1, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-1', '"bom-line:etag-r1"')
+    expect(updateLineMock).toHaveBeenNthCalledWith(2, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-1', '"bom-line:etag-r1"')
     expect(randomUUID).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('写回成功。')
+  })
+
+  it('on a 412 conflict reloads the fresh context, surfaces the conflict, sends write_etag verbatim, and re-mints the key', async () => {
+    const randomUUID = vi.fn()
+      .mockReturnValueOnce('submit-key-1')
+      .mockReturnValueOnce('submit-key-2')
+    vi.stubGlobal('crypto', { randomUUID })
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
+    updateLineMock
+      .mockResolvedValueOnce({ ok: false, status: 412, reason: 'precondition-failed', message: 'stale etag' })
+      .mockResolvedValueOnce({ ok: true, bom_line_id: 'R1' })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+    expect(getContextMock).toHaveBeenCalledTimes(1)
+
+    const refdes = container.querySelector('[data-testid="plm-bom-review-refdes-input"]') as HTMLInputElement
+    refdes.value = 'R9'
+    refdes.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // the strong ETag rode as the 6th arg VERBATIM (literal quotes preserved -> byte round-trip)
+    expect(updateLineMock).toHaveBeenNthCalledWith(1, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-1', '"bom-line:etag-r1"')
+    // 412 -> reloaded fresh context, surfaced the conflict, did NOT report success
+    expect(getContextMock).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('已被他人修改')
+    expect(container.textContent).not.toContain('写回成功。')
+
+    // re-submit after the reload mints a FRESH key (the stale one was dropped) -> no cached replay
+    const refdes2 = container.querySelector('[data-testid="plm-bom-review-refdes-input"]') as HTMLInputElement
+    refdes2.value = 'R9'
+    refdes2.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(updateLineMock).toHaveBeenNthCalledWith(2, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-2', '"bom-line:etag-r1"')
     expect(container.textContent).toContain('写回成功。')
   })
 

--- a/docs/development/plm-writeback-if-match-dev-and-verification-20260702.md
+++ b/docs/development/plm-writeback-if-match-dev-and-verification-20260702.md
@@ -1,0 +1,75 @@
+# PLM BOM write-back — consumer `If-Match` optimistic concurrency (dev & verification, 2026-07-02)
+
+Type: development + verification record for **#3469** (`codex/plm-writeback-if-match`) — the consumer
+half of governed BOM write-back optimistic concurrency. **This closes the last correctness gap on
+the PLM × MetaSheet integration line** (see the line tracker
+`Yuantus:docs/development/plm-collab-integration-line-living-tracker.md`).
+
+## 1. The gap it closes
+
+The Yuantus provider (#917/#927) has long emitted a per-line `write_etag` on the read projection and
+returned **412** on a stale `If-Match` — but the MetaSheet2 consumer **never sent it**. So a
+*same-cell* concurrent BOM write-back silently **dropped the loser's edit and reported success** on
+the governed, **audited** Phase-7 path. Cross-cell edits already merged (the provider applies only
+sent cells via `exclude_unset`); the exposure was same-cell only. Provider changes required: **none**.
+
+## 2. The change (error-and-reload, owner-chosen)
+
+End-to-end consumer adoption, 5 layers, 7 files:
+
+| Layer | File | Change |
+|---|---|---|
+| Adapter | `packages/core-backend/src/data-adapters/PLMAdapter.ts` | Type `write_etag` on `BomMultitableLine` (**optional** + **tolerant** read guard); accept `options.ifMatch`; send it as `If-Match` **verbatim** (strong-ETag quotes preserved). No etag → no header → prior behavior. |
+| Relay route | `packages/core-backend/src/routes/plm-workbench.ts` | Forward the client `If-Match`; map provider **412 → `precondition-failed`** (distinct from the 400/403/404/409/422 set). |
+| FE service | `apps/web/src/services/integration/workbench.ts` | `PlmBomMultitableLine.write_etag`; `updatePlmBomMultitableLine` sends `If-Match` when present. |
+| FE panel | `apps/web/src/components/plm/PlmBomReviewPanel.vue` | Send the line's `write_etag`; on **412 → reload fresh context** (new etags; `load()` drops the retry key so the re-submit mints a **fresh** `Idempotency-Key`, not a cached replay) + conflict message — never a false success. |
+| Tests | (adapter / route / panel specs) | See §4. |
+
+**Conflict UX = error-and-reload** (owner decision): the correctness-preserving choice for a
+governed/audited write-back — last-write-wins would silently discard an audited edit.
+
+## 3. Design decisions (and two deliberate non-changes)
+
+- **Tolerant read guard.** `write_etag` is optional on the interface and the context guard does **not**
+  require it — so the READ panel's availability is never coupled to a write field across the
+  independently-deployed provider. Missing etag → no `If-Match` → exactly prior behavior.
+- **No change to the broker-published pact.** A 412 interaction would create a Yuantus
+  provider-verification obligation that could red the provider gate invisibly (we test in ms2). 412 is
+  covered by **consumer-side unit tests** instead; a provider-side 412 pact state is a separate Yuantus
+  follow-up if desired.
+- **Embed §0 read-only invariant untouched** — this is the workbench write path, not the embed iframe.
+
+## 4. Verification
+
+Rebased onto current `main` (`143645977`); re-verified green after rebase.
+
+- `pnpm --filter @metasheet/core-backend exec vitest run` (adapter + relay-route + pact) — **52 pass**,
+  including: `If-Match` sent **verbatim** with the quoted strong-ETag (byte round-trip — a stripped
+  quote would silently 412 every write); `If-Match` **omitted** when no etag (backward-safe); relay
+  route **forwards** `If-Match` and maps provider **412 → precondition-failed**.
+- `pnpm --filter @metasheet/web exec vitest run` (panel + service) — **19 pass**, including the
+  **412 → reload + fresh-key + no-false-success** flow and the quoted-etag round-trip through the panel.
+- `tsc --noEmit` (core-backend) and `vue-tsc -b` (web) — **clean**. No new dependency.
+
+### 4.1 Adversarial verification pass
+
+A 3-dimension adversarial pass (independent agents, refute-by-default, each writing + running its own
+scratch vitests against the real adapter / real `HTTPAdapter.select` / real router). **All three clean —
+no defect found.**
+
+| Dimension | Method | Result |
+|---|---|---|
+| **ETag byte-integrity + 412 mapping** | 11 scratch tests through panel→service→relay→adapter→real axios headers | **CLEAN.** The strong ETag `"bom-line:<sha256>"` survives byte-for-byte (literal quotes intact; `.trim()` is a no-op on a well-formed etag); absent/empty/whitespace etag → `If-Match` **omitted at every layer** (no empty precondition → no silent lost-update); `req.header('If-Match')` case-insensitive; `relayProviderWritebackError` singles out **412 → `precondition-failed`** distinct from `[400,403,404,409,422]`, verified against the *real* `select` output (a provider 412 yields `{data:[], error}` with `error.response.status===412` preserved — `select` does not throw on 4xx nor strip the status, so the mapping is live code). |
+| **Regression / backward-safety** | 7 scratch tests + `type-check` | **CLEAN.** The read guard accepts `write_etag` absent OR `string\|null` (so a context omitting it still validates — the read panel never breaks) yet still **rejects a wrong-typed** `write_etag` (not neutered); the no-etag write is byte-for-byte prior behavior (no `If-Match`, `Idempotency-Key` always present); no type errors; only callers are the relay + the read-only embed route. |
+| **Concurrency-correctness** | scratch tests + the committed panel spec (12 tests) | **CLEAN.** The 412 path reloads fresh context and **drops the retry key** so the re-submit mints a fresh `Idempotency-Key` (no cached-original replay); no false success on conflict. (The adversarial agent for this dimension hit transient infra retries; its scratch suite + the committed `PlmBomReviewPanel.spec.ts` 412 test were run directly and pass — 12 tests.) |
+
+One benign non-defect noted and dismissed: the web-service layer does not `.trim()` `write_etag` while the
+route does — observable only for whitespace-only etags, which the provider never emits.
+
+## 5. Status & what is deliberately NOT in this record
+
+- **#3469 is built, adversarially verified, rebased, and green — awaiting the owner merge-go** (held
+  per the metasheet2 owner-merge rule; a rebase + `--squash --auto` ships it).
+- **Not this record:** #934's date-obsolete reason-length P2 (a parallel PR, tracked separately); the
+  decision-gated tracks (locked-BOM ECO route, Phase-6 SSO, commercial) — each needs its own owner
+  opt-in per the line tracker's §3 decision sheet.

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -691,6 +691,9 @@ export interface BomMultitableLine {
   source_version: number | null;
   source_updated_at: string | null;
   sync_status: string;
+  // Provider optimistic-concurrency tag (Yuantus #917/#927); strong ETag `"bom-line:<sha256>"`.
+  // Optional at runtime: an older provider may omit it -> the write path sends no If-Match (today's behavior).
+  write_etag?: string | null;
 }
 
 export interface BomMultitablePart {
@@ -745,6 +748,8 @@ export interface BomMultitableLineUpdateResult {
 
 export interface BomMultitableLineUpdateOptions {
   idempotencyKey?: string;
+  // Optimistic-concurrency: the line's write_etag, sent as `If-Match`; a stale value -> provider 412.
+  ifMatch?: string;
 }
 
 // Field guard for the governed BOM multi-table context. Validates EVERY field declared on
@@ -792,6 +797,8 @@ function isBomMultitableLine(value: unknown): value is BomMultitableLine {
     && isNumberOrNull(l.source_version)
     && isStringOrNull(l.source_updated_at)
     && typeof l.sync_status === 'string'
+    // tolerant: absent (older provider) OR string|null -> valid; never breaks the READ panel
+    && (l.write_etag === undefined || isStringOrNull(l.write_etag))
   );
 }
 
@@ -2158,8 +2165,8 @@ export class PLMAdapter extends HTTPAdapter {
         context: {
           part: { part_id: partId, item_number: 'P-001', name: 'Mock Assembly', state: 'Released', generation: 1 },
           lines: [
-            { bom_line_id: 'R1', part_id: 'C1', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: [partId], path_labels: ['P-001'], source_version: 1, source_updated_at: now, sync_status: 'snapshot' },
-            { bom_line_id: 'R2', part_id: 'D1', item_number: 'D-001', name: 'Screw', state: 'Released', generation: 2, quantity: 4, uom: 'EA', find_num: '20', refdes: 'R3', level: 2, path: [partId, 'C1'], path_labels: ['P-001', 'C-001'], source_version: 2, source_updated_at: now, sync_status: 'snapshot' },
+            { bom_line_id: 'R1', part_id: 'C1', write_etag: '"bom-line:mock-r1"', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: [partId], path_labels: ['P-001'], source_version: 1, source_updated_at: now, sync_status: 'snapshot' },
+            { bom_line_id: 'R2', part_id: 'D1', write_etag: '"bom-line:mock-r2"', item_number: 'D-001', name: 'Screw', state: 'Released', generation: 2, quantity: 4, uom: 'EA', find_num: '20', refdes: 'R3', level: 2, path: [partId, 'C1'], path_labels: ['P-001', 'C-001'], source_version: 2, source_updated_at: now, sync_status: 'snapshot' },
           ],
           source_version: 1,
           source_updated_at: now,
@@ -2250,10 +2257,14 @@ export class PLMAdapter extends HTTPAdapter {
         ? options.idempotencyKey.trim()
         : randomUUID()
 
+    const headers: Record<string, string> = { 'Idempotency-Key': idempotencyKey }
+    // Forward the caller's write_etag verbatim as If-Match (strong ETag incl. its literal quotes).
+    const ifMatch = typeof options.ifMatch === 'string' ? options.ifMatch.trim() : ''
+    if (ifMatch) headers['If-Match'] = ifMatch
     return this.select<BomMultitableLineUpdateResult>(`/api/v1/bom/multitable/${partId}/lines/${bomLineId}`, {
       method: 'PATCH',
       data: payload,
-      headers: { 'Idempotency-Key': idempotencyKey },
+      headers,
     })
   }
 

--- a/packages/core-backend/src/routes/plm-workbench.ts
+++ b/packages/core-backend/src/routes/plm-workbench.ts
@@ -802,7 +802,7 @@ interface PlmBomWritebackAdapter extends PlmBomReviewAdapter {
     partId: string,
     bomLineId: string,
     patch: BomMultitableLinePatch,
-    options?: { idempotencyKey?: string },
+    options?: { idempotencyKey?: string; ifMatch?: string },
   ): Promise<{ data?: BomMultitableLineUpdateResult[]; error?: Error }>
 }
 
@@ -868,6 +868,10 @@ function providerErrorStatus(error: unknown): number | null {
 
 function relayProviderWritebackError(error: unknown): { status: number; reason: string } {
   const status = providerErrorStatus(error)
+  // 412 = stale If-Match (optimistic-concurrency conflict): distinct reason so the UI reloads.
+  if (status === 412) {
+    return { status: 412, reason: 'precondition-failed' }
+  }
   if (status && [400, 403, 404, 409, 422].includes(status)) {
     return { status, reason: 'provider-rejected' }
   }
@@ -1004,7 +1008,12 @@ router.patch(
       })
     }
 
-    const result = await adapter.updateBomMultitableLine(partId, bomLineId, patch, { idempotencyKey })
+    // Optional optimistic-concurrency: forward the client's If-Match to the provider unchanged.
+    const ifMatch = (req.header('If-Match') || '').trim()
+    const result = await adapter.updateBomMultitableLine(partId, bomLineId, patch, {
+      idempotencyKey,
+      ...(ifMatch ? { ifMatch } : {}),
+    })
     if (result.error) {
       const relayed = relayProviderWritebackError(result.error)
       return res.status(relayed.status).json({

--- a/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
@@ -260,6 +260,30 @@ describe('PLMAdapter.updateBomMultitableLine (PLM-COLLAB P3 — thin success-onl
     expect(options.headers['Idempotency-Key']).toBe('workbench-submit-1')
   })
 
+  it('sends the write_etag verbatim as If-Match (strong-ETag quotes preserved -> byte round-trip)', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })
+    ;(adapter as never as { select: unknown }).select = select
+
+    await adapter.updateBomMultitableLine('P4', 'R8', { quantity: 6 }, { idempotencyKey: 'k1', ifMatch: '"bom-line:abc123"' })
+
+    const [, options] = select.mock.calls[0]
+    // the literal quotes MUST survive: a stripped/re-encoded quote would silently 412 every write
+    expect(options.headers['If-Match']).toBe('"bom-line:abc123"')
+    expect(options.headers['Idempotency-Key']).toBe('k1')
+  })
+
+  it('omits If-Match when no write_etag is provided (backward-safe: old provider / etag-less read)', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })
+    ;(adapter as never as { select: unknown }).select = select
+
+    await adapter.updateBomMultitableLine('P4', 'R8', { quantity: 6 }, { idempotencyKey: 'k1' })
+
+    const [, options] = select.mock.calls[0]
+    expect('If-Match' in options.headers).toBe(false)
+  })
+
   it('null cell is a real "clear" edit, not empty: kept in payload, request issued', async () => {
     const adapter = createAdapter('yuantus')
     const select = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R8' }], metadata: { totalCount: 1 } })

--- a/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
@@ -289,4 +289,53 @@ describe('plm-workbench BOM multi-table review route (PLM-COLLAB P3-C)', () => {
     expect(res.status).toBe(409)
     expect(res.body.reason).toBe('provider-rejected')
   })
+
+  it('write route forwards the client If-Match header to the provider (optimistic concurrency)', async () => {
+    const updateBomMultitableLine = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R1' }] })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: true } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine,
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .set('If-Match', '"bom-line:etag-x"')
+      .send({ quantity: 5 })
+    expect(res.status).toBe(200)
+    expect(updateBomMultitableLine).toHaveBeenCalledWith(
+      'P1',
+      'R1',
+      { quantity: 5 },
+      { idempotencyKey: 'submit-1', ifMatch: '"bom-line:etag-x"' },
+    )
+  })
+
+  it('write route relays a provider 412 as a distinct precondition-failed conflict', async () => {
+    const stale = Object.assign(new Error('If-Match precondition failed'), { response: { status: 412 } })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: true } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine: vi.fn().mockResolvedValue({ data: [], error: stale }),
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .set('If-Match', '"bom-line:stale"')
+      .send({ quantity: 5 })
+    expect(res.status).toBe(412)
+    expect(res.body.reason).toBe('precondition-failed')
+  })
 })


### PR DESCRIPTION
## The gap this closes

The provider (Yuantus #917/#927) has emitted `write_etag` per line and returned **412** on a stale `If-Match` for a while — but the **consumer never sent it**. So a *same-cell* concurrent BOM write-back silently dropped the loser's edit and reported **success** on the governed, **audited** Phase-7 path. This is the one remaining correctness gap on the PLM×MetaSheet line; the provider needs zero changes.

## The fix (error-and-reload)

End-to-end consumer adoption, with **error-and-reload** on conflict — the correctness-preserving choice for a governed/audited write-back (last-write-wins would silently discard an audited edit; cross-cell edits already merge via the provider's `exclude_unset`).

- **Adapter** — type `write_etag` on `BomMultitableLine`, send `options.ifMatch` as `If-Match` **verbatim** (strong-ETag quotes preserved).
- **Relay route** — forward the client `If-Match`; map provider **412 → `precondition-failed`**.
- **Service + panel** — send the line's `write_etag`; on 412, **reload the fresh context** (new etags; `load()` drops the retry key so the re-submit mints a **fresh** `Idempotency-Key`, not a cached replay) and surface the conflict — never a false success.

## Two deliberate non-changes (advisor-flagged)

- **Read guard stays tolerant** of a missing `write_etag` — no coupling of the READ panel's availability to a write field across the independently-deployed provider (older provider / fixture → no `If-Match` → today's behavior).
- **The broker-published pact is unchanged.** A 412 interaction would create a Yuantus provider-verification obligation that could red the provider gate invisibly; 412 is covered by **consumer-side unit tests** here. (A provider-side 412 pact state is a separate Yuantus follow-up if desired.)

## Verification

`vitest`: core-backend **52** + web **19** pass — including the **byte round-trip** (the quoted `"bom-line:<sha256>"` reaches `If-Match` verbatim; a stripped quote would silently 412 everything), the backward-safe omit, and the 412 → reload + fresh-key + no-false-success flow. `tsc` + `vue-tsc` clean. **No new dependency.**

🤖 Review PR — metasheet2, not for self-merge.