### PR TITLE
feat(integration-web): S3 consultant self-service UI — read-source config panel (#1709)

### DIFF
--- a/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
@@ -314,7 +314,10 @@ const keyFieldRequired = computed(() => draft.mode === 'single_record' || draft.
 // The S2-b runtime requires inputs.key exactly when the config declares a keyField.
 const probeNeedsKey = computed(() => showKeyField.value && draft.keyField.trim().length > 0)
 
-watch(() => draft.mode, () => {
+// Probe evidence / save result describe the config that was probed/saved — ANY draft change
+// (system switch, mode, path, containers, fieldMap, …) makes them stale, so clear both. watch on a
+// reactive object is implicitly deep.
+watch(draft, () => {
   probeEvidence.value = null
   saveResult.value = null
 })

--- a/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
@@ -1,0 +1,549 @@
+<template>
+  <div class="integration-read-source" data-testid="read-source-panel">
+    <p class="integration-read-source__hint">
+      顾问/管理员在这里配置第三方 API 的只读读取源：填写 S1 结构 → 定位容器探测(values-free)→ 保存版本(内容寻址,幂等)→ 审批后运行时才可选用。
+      终端用户只能选择已审批的读取源并提供业务 key,永远不能提交原始端点 / 过滤器 / 响应路径。本面板不含任何写入 / 删除能力。
+    </p>
+
+    <div class="integration-read-source__columns">
+      <div class="integration-read-source__form" data-testid="read-source-form">
+        <h3>新建 / 试配读取源</h3>
+
+        <label class="integration-read-source__field">
+          <span>外部系统(systemId)</span>
+          <select v-model="draft.systemId" data-testid="rsc-system" @change="onSystemChange">
+            <option value="">请选择已配置系统</option>
+            <option v-for="system in systems" :key="system.id" :value="system.id">
+              {{ system.name }} ({{ system.kind }})
+            </option>
+          </select>
+        </label>
+
+        <label class="integration-read-source__field">
+          <span>requiredKind(随所选系统)</span>
+          <input :value="draft.requiredKind" data-testid="rsc-required-kind" readonly placeholder="选择系统后自动填充" />
+        </label>
+
+        <label class="integration-read-source__field">
+          <span>object(读取对象名)</span>
+          <input v-model="draft.object" data-testid="rsc-object" placeholder="material" />
+        </label>
+
+        <label class="integration-read-source__field">
+          <span>mode(四种已验证读取模式)</span>
+          <select v-model="draft.mode" data-testid="rsc-mode">
+            <option v-for="mode in READ_SOURCE_MODES" :key="mode" :value="mode">{{ mode }}</option>
+          </select>
+        </label>
+
+        <label class="integration-read-source__field">
+          <span>readPath(仅相对路径;绝对 URL、%、\、.. 会被拒绝)</span>
+          <input v-model="draft.readPath" data-testid="rsc-read-path" placeholder="/K3API/Material/GetDetail" />
+        </label>
+
+        <label class="integration-read-source__field">
+          <span>readMethod</span>
+          <select v-model="draft.readMethod" data-testid="rsc-read-method">
+            <option v-for="method in READ_SOURCE_METHODS" :key="method" :value="method">{{ method }}</option>
+          </select>
+        </label>
+
+        <label class="integration-read-source__field">
+          <span>operations(本线只读,不可编辑)</span>
+          <input value="read" data-testid="rsc-operations" readonly disabled />
+        </label>
+
+        <label class="integration-read-source__field">
+          <span>version(正整数)</span>
+          <input v-model.number="draft.version" type="number" min="1" data-testid="rsc-version" />
+        </label>
+
+        <template v-if="showKeyField">
+          <label class="integration-read-source__field">
+            <span>keyField{{ keyFieldRequired ? '(必填)' : '(可选)' }}</span>
+            <input v-model="draft.keyField" data-testid="rsc-key-field" placeholder="FNumber" />
+          </label>
+          <label class="integration-read-source__field">
+            <span>keyEncoding(可选)</span>
+            <select v-model="draft.keyEncoding" data-testid="rsc-key-encoding">
+              <option value="">(不指定)</option>
+              <option v-for="encoding in READ_SOURCE_KEY_ENCODINGS" :key="encoding" :value="encoding">{{ encoding }}</option>
+            </select>
+          </label>
+        </template>
+
+        <label v-if="draft.mode === 'resolver_lookup'" class="integration-read-source__field">
+          <span>multiplicityRuleField(必填)</span>
+          <input v-model="draft.multiplicityRuleField" data-testid="rsc-multiplicity-field" placeholder="FIsCurrent" />
+        </label>
+
+        <label v-if="draft.mode !== 'detail_with_lines'" class="integration-read-source__field">
+          <span>containerPaths(逗号/换行分隔的点号路径,必填)</span>
+          <input v-model="draft.containerPaths" data-testid="rsc-container-paths" placeholder="Data.Data, Data.DATA" />
+        </label>
+
+        <template v-if="draft.mode === 'detail_with_lines'">
+          <label class="integration-read-source__field">
+            <span>headerContainerPaths(必填)</span>
+            <input v-model="draft.headerContainerPaths" data-testid="rsc-header-container-paths" placeholder="Data.Page1" />
+          </label>
+          <label class="integration-read-source__field">
+            <span>lineContainerPaths(必填)</span>
+            <input v-model="draft.lineContainerPaths" data-testid="rsc-line-container-paths" placeholder="Data.Page2" />
+          </label>
+        </template>
+
+        <div class="integration-read-source__field-map">
+          <div class="integration-read-source__field-map-head">
+            <span>fieldMap(数据面字段映射,可选;source=响应字段路径,target=清洗列)</span>
+            <button type="button" class="integration-workbench__button" data-testid="rsc-field-map-add" @click="addFieldMapRow">
+              添加映射行
+            </button>
+          </div>
+          <div
+            v-for="(entry, index) in draft.fieldMap"
+            :key="index"
+            class="integration-read-source__field-map-row"
+          >
+            <input v-model="entry.source" :data-testid="`rsc-field-map-source-${index}`" placeholder="FName" />
+            <span>→</span>
+            <input v-model="entry.target" :data-testid="`rsc-field-map-target-${index}`" placeholder="material_name" />
+            <button type="button" class="integration-workbench__button" :data-testid="`rsc-field-map-remove-${index}`" @click="removeFieldMapRow(index)">
+              删除
+            </button>
+          </div>
+        </div>
+
+        <ul v-if="validationProblems.length > 0" class="integration-read-source__problems" data-testid="rsc-validation">
+          <li v-for="problem in validationProblems" :key="problem">{{ problem }}</li>
+        </ul>
+
+        <div class="integration-read-source__probe-controls">
+          <label class="integration-read-source__inline">
+            <input v-model="boundedSmoke" type="checkbox" data-testid="rsc-bounded-smoke" />
+            <span>bounded smoke(受平台上限约束的试读计数)</span>
+          </label>
+          <label v-if="probeNeedsKey" class="integration-read-source__inline">
+            <span>探测 key(业务键值,仅用于本次探测,不会保存)</span>
+            <input v-model="probeKey" data-testid="rsc-probe-key" placeholder="MAT-001" />
+          </label>
+        </div>
+
+        <div class="integration-read-source__actions">
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rsc-probe"
+            :disabled="probing || validationProblems.length > 0"
+            @click="runProbe"
+          >{{ probing ? '探测中…' : '定位容器探测' }}</button>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rsc-save"
+            :disabled="saving || validationProblems.length > 0"
+            @click="saveVersion"
+          >{{ saving ? '保存中…' : '保存版本' }}</button>
+        </div>
+
+        <p v-if="actionError" class="integration-read-source__error" data-testid="rsc-error">{{ actionError }}</p>
+
+        <div v-if="probeEvidence" class="integration-read-source__evidence" data-testid="rsc-probe-evidence">
+          <h4>探测证据(values-free)</h4>
+          <ul>
+            <li data-testid="rsc-evidence-ok">ok: {{ probeEvidence.ok ? 'true' : 'false' }}</li>
+            <li v-if="probeEvidence.containerLocated !== undefined" data-testid="rsc-evidence-located">
+              containerLocated: {{ probeEvidence.containerLocated ? 'true' : 'false' }}
+            </li>
+            <li
+              v-for="entry in evidenceContainers"
+              :key="entry.alias"
+              :data-testid="`rsc-evidence-container-${entry.alias}`"
+            >
+              {{ entry.alias }}: type={{ entry.shape.type }}<template v-if="entry.shape.arrayLength !== undefined">, arrayLength={{ entry.shape.arrayLength === null ? 'null' : entry.shape.arrayLength }}</template>
+            </li>
+            <li v-if="probeEvidence.boundedSmokeExecuted !== undefined" data-testid="rsc-evidence-smoke">
+              boundedSmokeExecuted: {{ probeEvidence.boundedSmokeExecuted ? 'true' : 'false' }}
+            </li>
+            <li v-if="probeEvidence.recordCount !== undefined" data-testid="rsc-evidence-record-count">
+              recordCount: {{ probeEvidence.recordCount }}
+            </li>
+            <li v-if="probeEvidence.capReached !== undefined" data-testid="rsc-evidence-cap">
+              capReached: {{ probeEvidence.capReached ? 'true' : 'false' }}
+            </li>
+            <li v-if="probeEvidence.timeoutReached !== undefined" data-testid="rsc-evidence-timeout">
+              timeoutReached: {{ probeEvidence.timeoutReached ? 'true' : 'false' }}
+            </li>
+            <li v-if="probeEvidence.errorCode" data-testid="rsc-evidence-error-code">errorCode: {{ probeEvidence.errorCode }}</li>
+            <li v-if="probeEvidence.errorType" data-testid="rsc-evidence-error-type">errorType: {{ probeEvidence.errorType }}</li>
+          </ul>
+        </div>
+
+        <p v-if="saveResult" class="integration-read-source__save-result" data-testid="rsc-save-result">
+          {{ saveResult.reused ? `已复用现有版本 v${saveResult.version}` : `已保存新版本 v${saveResult.version}` }}(status: {{ saveResult.status }})
+        </p>
+      </div>
+
+      <div class="integration-read-source__list" data-testid="read-source-list">
+        <div class="integration-read-source__list-head">
+          <h3>已保存读取源</h3>
+          <button type="button" class="integration-workbench__button" data-testid="rsc-refresh" :disabled="loading" @click="refresh">
+            {{ loading ? '加载中…' : '刷新' }}
+          </button>
+        </div>
+        <p v-if="listError" class="integration-read-source__error" data-testid="rsc-list-error">{{ listError }}</p>
+        <p v-if="!loading && configs.length === 0" class="integration-read-source__empty" data-testid="rsc-empty">
+          暂无读取源配置。
+        </p>
+        <table v-if="configs.length > 0" class="integration-read-source__table">
+          <thead>
+            <tr>
+              <th>system</th><th>object</th><th>mode</th><th>版本</th><th>状态</th><th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <template v-for="row in configs" :key="row.id">
+              <tr :data-testid="`rsc-row-${row.id}`">
+                <td>{{ row.systemId }}</td>
+                <td>{{ row.object }}</td>
+                <td>{{ row.mode }}</td>
+                <td>v{{ row.version }}</td>
+                <td>
+                  <span class="integration-read-source__status" :data-status="row.status" :data-testid="`rsc-status-${row.id}`">
+                    {{ statusLabel(row.status) }}
+                  </span>
+                </td>
+                <td class="integration-read-source__row-actions">
+                  <button
+                    v-if="row.status === 'draft'"
+                    type="button"
+                    class="integration-workbench__button"
+                    :data-testid="`rsc-approve-${row.id}`"
+                    @click="approve(row)"
+                  >审批</button>
+                  <button
+                    v-if="row.status === 'approved'"
+                    type="button"
+                    class="integration-workbench__button"
+                    :data-testid="`rsc-retire-${row.id}`"
+                    @click="retire(row)"
+                  >停用</button>
+                  <button
+                    type="button"
+                    class="integration-workbench__button"
+                    :data-testid="`rsc-audit-toggle-${row.id}`"
+                    @click="toggleAudit(row)"
+                  >{{ auditConfigId === row.id ? '收起审计' : '审计' }}</button>
+                </td>
+              </tr>
+              <tr v-if="auditConfigId === row.id" :data-testid="`rsc-audit-${row.id}`">
+                <td colspan="6">
+                  <ul class="integration-read-source__audit" data-testid="rsc-audit-list">
+                    <li v-if="auditRows.length === 0">暂无审计记录。</li>
+                    <li v-for="(entry, index) in auditRows" :key="index">
+                      {{ auditActionLabel(entry.action) }} · {{ entry.actor || '(unknown)' }} · {{ entry.createdAt || '' }}
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// External-API read self-service (#1709) — S3 consultant self-service panel.
+// Consultant/config tier only; probe + save + approve/retire + values-free audit.
+// The probe evidence path is allowlist-normalized in the service layer, so row values or
+// field keys can never reach this template even from a malformed response.
+import { computed, reactive, ref, watch } from 'vue'
+import type { IntegrationScope, WorkbenchExternalSystem } from '../../services/integration/workbench'
+import {
+  READ_SOURCE_KEY_ENCODINGS,
+  READ_SOURCE_METHODS,
+  READ_SOURCE_MODES,
+  approveReadSourceConfig,
+  buildReadSourceConfigPayload,
+  createReadSourceConfigDraft,
+  listReadSourceConfigAudit,
+  listReadSourceConfigs,
+  probeReadSourceConfig,
+  retireReadSourceConfig,
+  saveReadSourceConfigVersion,
+  validateReadSourceDraft,
+  type ReadSourceAuditRow,
+  type ReadSourceConfigRow,
+  type ReadSourceProbeEvidence,
+  type ReadSourceSaveResult,
+  type ReadSourceStatus,
+} from '../../services/integration/readSourceConfigs'
+
+const props = defineProps<{
+  scope: IntegrationScope
+  systems: WorkbenchExternalSystem[]
+}>()
+
+const draft = reactive(createReadSourceConfigDraft())
+const boundedSmoke = ref(false)
+const probeKey = ref('')
+const probing = ref(false)
+const saving = ref(false)
+const loading = ref(false)
+const actionError = ref('')
+const listError = ref('')
+const probeEvidence = ref<ReadSourceProbeEvidence | null>(null)
+const saveResult = ref<ReadSourceSaveResult | null>(null)
+const configs = ref<ReadSourceConfigRow[]>([])
+const auditConfigId = ref('')
+const auditRows = ref<ReadSourceAuditRow[]>([])
+
+const validationProblems = computed(() => validateReadSourceDraft(draft))
+const evidenceContainers = computed(() => {
+  const containers = probeEvidence.value?.containers
+  if (!containers) return []
+  return (['primary', 'header', 'lines'] as const).flatMap((alias) => {
+    const shape = containers[alias]
+    return shape ? [{ alias, shape }] : []
+  })
+})
+const showKeyField = computed(() => draft.mode !== 'list_page')
+const keyFieldRequired = computed(() => draft.mode === 'single_record' || draft.mode === 'resolver_lookup')
+// The S2-b runtime requires inputs.key exactly when the config declares a keyField.
+const probeNeedsKey = computed(() => showKeyField.value && draft.keyField.trim().length > 0)
+
+watch(() => draft.mode, () => {
+  probeEvidence.value = null
+  saveResult.value = null
+})
+
+function onSystemChange(): void {
+  const system = props.systems.find((item) => item.id === draft.systemId)
+  draft.requiredKind = system ? system.kind : ''
+}
+
+function addFieldMapRow(): void {
+  draft.fieldMap.push({ source: '', target: '' })
+}
+
+function removeFieldMapRow(index: number): void {
+  draft.fieldMap.splice(index, 1)
+}
+
+function statusLabel(status: ReadSourceStatus): string {
+  if (status === 'approved') return '已审批'
+  if (status === 'retired') return '已停用'
+  return '草稿'
+}
+
+function auditActionLabel(action: ReadSourceAuditRow['action']): string {
+  if (action === 'save_version') return '保存新版本'
+  if (action === 'reuse_version') return '复用已有版本'
+  return '状态变更'
+}
+
+function coarseErrorMessage(error: unknown): string {
+  // Coarse only: code/reason enums, never submitted values.
+  if (error instanceof Error) return error.message
+  return '读取源接口请求失败'
+}
+
+async function refresh(): Promise<void> {
+  loading.value = true
+  listError.value = ''
+  try {
+    configs.value = await listReadSourceConfigs(props.scope)
+  } catch (error) {
+    listError.value = coarseErrorMessage(error)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function runProbe(): Promise<void> {
+  actionError.value = ''
+  probeEvidence.value = null
+  if (probeNeedsKey.value && !probeKey.value.trim()) {
+    actionError.value = '该配置声明了 keyField,探测需要提供业务 key'
+    return
+  }
+  probing.value = true
+  try {
+    probeEvidence.value = await probeReadSourceConfig(draft.systemId.trim(), {
+      config: buildReadSourceConfigPayload(draft),
+      boundedSmoke: boundedSmoke.value,
+      key: probeNeedsKey.value ? probeKey.value : undefined,
+    }, props.scope)
+  } catch (error) {
+    actionError.value = coarseErrorMessage(error)
+  } finally {
+    probing.value = false
+  }
+}
+
+async function saveVersion(): Promise<void> {
+  actionError.value = ''
+  saveResult.value = null
+  saving.value = true
+  try {
+    saveResult.value = await saveReadSourceConfigVersion(buildReadSourceConfigPayload(draft), props.scope)
+    await refresh()
+  } catch (error) {
+    actionError.value = coarseErrorMessage(error)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function approve(row: ReadSourceConfigRow): Promise<void> {
+  if (!window.confirm(`审批后运行时即可选用该读取源(${row.object} v${row.version})。确认审批?`)) return
+  actionError.value = ''
+  try {
+    await approveReadSourceConfig(row.id, props.scope)
+    await refresh()
+  } catch (error) {
+    actionError.value = coarseErrorMessage(error)
+  }
+}
+
+async function retire(row: ReadSourceConfigRow): Promise<void> {
+  actionError.value = ''
+  try {
+    await retireReadSourceConfig(row.id, props.scope)
+    await refresh()
+  } catch (error) {
+    actionError.value = coarseErrorMessage(error)
+  }
+}
+
+async function toggleAudit(row: ReadSourceConfigRow): Promise<void> {
+  if (auditConfigId.value === row.id) {
+    auditConfigId.value = ''
+    auditRows.value = []
+    return
+  }
+  actionError.value = ''
+  try {
+    auditRows.value = await listReadSourceConfigAudit(row.id, props.scope)
+    auditConfigId.value = row.id
+  } catch (error) {
+    actionError.value = coarseErrorMessage(error)
+  }
+}
+
+void refresh()
+</script>
+
+<style scoped>
+.integration-read-source__hint {
+  color: #666;
+  font-size: 13px;
+  margin: 0 0 12px;
+}
+.integration-read-source__columns {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(360px, 1.2fr);
+  gap: 20px;
+}
+.integration-read-source__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+.integration-read-source__field input,
+.integration-read-source__field select {
+  padding: 6px 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+}
+.integration-read-source__field-map-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 6px 0;
+}
+.integration-read-source__inline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  margin: 6px 0;
+}
+.integration-read-source__actions {
+  display: flex;
+  gap: 8px;
+  margin: 10px 0;
+}
+.integration-read-source__problems {
+  color: #b45309;
+  font-size: 12px;
+  padding-left: 18px;
+}
+.integration-read-source__error {
+  color: #b91c1c;
+  font-size: 13px;
+}
+.integration-read-source__evidence {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-top: 10px;
+  font-size: 13px;
+}
+.integration-read-source__evidence ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+.integration-read-source__save-result {
+  color: #15803d;
+  font-size: 13px;
+}
+.integration-read-source__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.integration-read-source__table th,
+.integration-read-source__table td {
+  border-bottom: 1px solid #eee;
+  padding: 6px 8px;
+  text-align: left;
+}
+.integration-read-source__status[data-status='approved'] {
+  color: #15803d;
+}
+.integration-read-source__status[data-status='draft'] {
+  color: #b45309;
+}
+.integration-read-source__status[data-status='retired'] {
+  color: #6b7280;
+}
+.integration-read-source__row-actions {
+  display: flex;
+  gap: 6px;
+}
+.integration-read-source__list-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.integration-read-source__empty {
+  color: #888;
+  font-size: 13px;
+}
+.integration-read-source__audit {
+  margin: 4px 0;
+  padding-left: 18px;
+  font-size: 12px;
+  color: #555;
+}
+@media (max-width: 960px) {
+  .integration-read-source__columns {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/apps/web/src/services/integration/readSourceConfigs.ts
+++ b/apps/web/src/services/integration/readSourceConfigs.ts
@@ -1,0 +1,460 @@
+import { apiFetch } from '../../utils/api'
+import type { IntegrationScope } from './workbench'
+
+// External-API read self-service (#1709) — S3 consultant UI service layer.
+//
+// Scope fence: consultant/admin tier ONLY (config-time). The runtime/end-user tier never reaches
+// these calls. Read-only line: operations is pinned to ['read'] at payload assembly and is not
+// editable in any form. Evidence handling is values-free by construction — the probe evidence
+// normalizer below copies ONLY allowlisted booleans / bounded counts / coarse enum codes /
+// container {type, arrayLength}; any other field a response might carry is dropped, never rendered.
+
+export const READ_SOURCE_MODES = ['single_record', 'list_page', 'detail_with_lines', 'resolver_lookup'] as const
+export type ReadSourceMode = typeof READ_SOURCE_MODES[number]
+
+export const READ_SOURCE_METHODS = ['GET', 'POST'] as const
+export type ReadSourceMethod = typeof READ_SOURCE_METHODS[number]
+
+export const READ_SOURCE_KEY_ENCODINGS = ['structured_json_field', 'filter_expression', 'numeric_id'] as const
+export type ReadSourceKeyEncoding = typeof READ_SOURCE_KEY_ENCODINGS[number]
+
+export const READ_SOURCE_STATUSES = ['draft', 'approved', 'retired'] as const
+export type ReadSourceStatus = typeof READ_SOURCE_STATUSES[number]
+
+export interface ReadSourceFieldMapEntry {
+  source: string
+  target: string
+}
+
+// The S1 config shape (server-authoritative validator: plugins read-source-config.cjs).
+export interface ReadSourceConfigPayload {
+  version: number
+  systemId: string
+  requiredKind: string
+  object: string
+  mode: ReadSourceMode
+  readPath: string
+  readMethod: ReadSourceMethod
+  operations: ['read']
+  keyField?: string
+  keyEncoding?: ReadSourceKeyEncoding
+  multiplicityRuleField?: string
+  containerPaths?: string[]
+  headerContainerPaths?: string[]
+  lineContainerPaths?: string[]
+  fieldMap?: ReadSourceFieldMapEntry[]
+}
+
+// Form draft: list fields are edited as separated text; assembly parses them.
+export interface ReadSourceConfigDraft {
+  version: number
+  systemId: string
+  requiredKind: string
+  object: string
+  mode: ReadSourceMode
+  readPath: string
+  readMethod: ReadSourceMethod
+  keyField: string
+  keyEncoding: '' | ReadSourceKeyEncoding
+  multiplicityRuleField: string
+  containerPaths: string
+  headerContainerPaths: string
+  lineContainerPaths: string
+  fieldMap: ReadSourceFieldMapEntry[]
+}
+
+export interface ReadSourceConfigRow {
+  id: string
+  systemId: string
+  object: string
+  mode: string
+  version: number
+  status: ReadSourceStatus
+  contentKey: string
+  createdBy: string | null
+  updatedAt: string | null
+}
+
+export interface ReadSourceSaveResult {
+  id: string
+  version: number
+  status: ReadSourceStatus
+  reused: boolean
+  contentKey: string
+}
+
+export interface ReadSourceAuditRow {
+  action: 'save_version' | 'reuse_version' | 'status_change'
+  actor: string | null
+  detail: Record<string, unknown>
+  createdAt: string | null
+}
+
+export interface ReadSourceProbeContainerShape {
+  type: 'array' | 'null' | 'object' | 'string' | 'number' | 'boolean' | 'missing' | 'other'
+  arrayLength?: number | null
+}
+
+export interface ReadSourceProbeEvidence {
+  ok: boolean
+  object: string
+  mode: string
+  boundedSmoke: boolean
+  containers?: Partial<Record<'primary' | 'header' | 'lines', ReadSourceProbeContainerShape>>
+  containerLocated?: boolean
+  boundedSmokeExecuted?: boolean
+  timeoutReached?: boolean
+  capReached?: boolean
+  recordCount?: number
+  rowCount?: number
+  sampleCount?: number
+  errorCode?: string
+  errorType?: string
+}
+
+// Coarse, values-free API error: code + reason enums only — submitted values never enter error text.
+export class ReadSourceApiError extends Error {
+  code: string
+  reason: string
+  status: number
+
+  constructor(status: number, code: string, reason: string) {
+    super(`读取源接口请求失败(${code}${reason ? `/${reason}` : ''})`)
+    this.name = 'ReadSourceApiError'
+    this.status = status
+    this.code = code
+    this.reason = reason
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+async function parseReadSourceResponse<T>(response: Response): Promise<T> {
+  let payload: Record<string, unknown> | null = null
+  try {
+    payload = await response.json() as Record<string, unknown>
+  } catch {
+    payload = null
+  }
+  if (!response.ok || payload?.ok === false) {
+    const error = isPlainObject(payload?.error) ? payload.error : {}
+    const details = isPlainObject(error.details) ? error.details : {}
+    const code = typeof error.code === 'string' && error.code ? error.code : 'READ_SOURCE_REQUEST_FAILED'
+    const reason = typeof details.reason === 'string' ? details.reason : ''
+    throw new ReadSourceApiError(response.status, code, reason)
+  }
+  return payload?.data as T
+}
+
+function buildQuery(input: Record<string, unknown>): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null || value === '') continue
+    params.set(key, String(value))
+  }
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}
+
+// --- pure helpers (unit-testable, DOM-free) --------------------------------
+
+export const READ_SOURCE_MODE_REQUIRED_FIELDS: Record<ReadSourceMode, string[]> = {
+  single_record: ['keyField', 'containerPaths'],
+  list_page: ['containerPaths'],
+  detail_with_lines: ['headerContainerPaths', 'lineContainerPaths'],
+  resolver_lookup: ['keyField', 'containerPaths', 'multiplicityRuleField'],
+}
+
+export function createReadSourceConfigDraft(): ReadSourceConfigDraft {
+  return {
+    version: 1,
+    systemId: '',
+    requiredKind: '',
+    object: '',
+    mode: 'single_record',
+    readPath: '',
+    readMethod: 'POST',
+    keyField: '',
+    keyEncoding: '',
+    multiplicityRuleField: '',
+    containerPaths: '',
+    headerContainerPaths: '',
+    lineContainerPaths: '',
+    fieldMap: [],
+  }
+}
+
+export function parseContainerPathList(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+// Client-side mirror of the crown-jewel relative-path guard — COARSE only, the server is
+// authoritative. Rejects the classes the server rejects so consultants get instant feedback.
+export function isCoarseSafeRelativeReadPath(value: string): boolean {
+  const raw = value.trim()
+  if (!raw) return false
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(raw)) return false
+  if (raw.startsWith('//')) return false
+  if (raw.includes('\\')) return false
+  if (raw.includes('%')) return false
+  const path = raw.startsWith('/') ? raw : `/${raw}`
+  if (path.split('/').some((segment) => segment === '..')) return false
+  return /^\/[A-Za-z0-9\-._~/]*$/.test(path)
+}
+
+// Coarse client validation: field-name-keyed messages only (values are never echoed).
+export function validateReadSourceDraft(draft: ReadSourceConfigDraft): string[] {
+  const problems: string[] = []
+  if (!Number.isInteger(draft.version) || draft.version < 1) problems.push('version 需为正整数')
+  if (!draft.systemId.trim()) problems.push('systemId 必填(选择外部系统)')
+  if (!draft.requiredKind.trim()) problems.push('requiredKind 必填')
+  if (!draft.object.trim()) problems.push('object 必填')
+  if (!READ_SOURCE_MODES.includes(draft.mode)) problems.push('mode 不在允许列表')
+  if (!READ_SOURCE_METHODS.includes(draft.readMethod)) problems.push('readMethod 不在允许列表')
+  if (!isCoarseSafeRelativeReadPath(draft.readPath)) {
+    problems.push('readPath 必须是相对路径(不接受绝对 URL、%、\\、..)')
+  }
+  for (const field of READ_SOURCE_MODE_REQUIRED_FIELDS[draft.mode] ?? []) {
+    if (field === 'keyField' && !draft.keyField.trim()) problems.push(`keyField 为 ${draft.mode} 模式必填`)
+    if (field === 'multiplicityRuleField' && !draft.multiplicityRuleField.trim()) {
+      problems.push(`multiplicityRuleField 为 ${draft.mode} 模式必填`)
+    }
+    if (field === 'containerPaths' && parseContainerPathList(draft.containerPaths).length === 0) {
+      problems.push(`containerPaths 为 ${draft.mode} 模式必填`)
+    }
+    if (field === 'headerContainerPaths' && parseContainerPathList(draft.headerContainerPaths).length === 0) {
+      problems.push(`headerContainerPaths 为 ${draft.mode} 模式必填`)
+    }
+    if (field === 'lineContainerPaths' && parseContainerPathList(draft.lineContainerPaths).length === 0) {
+      problems.push(`lineContainerPaths 为 ${draft.mode} 模式必填`)
+    }
+  }
+  for (const entry of draft.fieldMap) {
+    const hasSource = entry.source.trim().length > 0
+    const hasTarget = entry.target.trim().length > 0
+    if (hasSource !== hasTarget) {
+      problems.push('fieldMap 行需同时填写 source 与 target(或整行留空)')
+      break
+    }
+  }
+  return problems
+}
+
+// Assemble the exact S1 payload: operations pinned to ['read']; only mode-relevant optional
+// fields ride along; empty optionals are dropped, never sent as ''.
+export function buildReadSourceConfigPayload(draft: ReadSourceConfigDraft): ReadSourceConfigPayload {
+  const payload: ReadSourceConfigPayload = {
+    version: draft.version,
+    systemId: draft.systemId.trim(),
+    requiredKind: draft.requiredKind.trim(),
+    object: draft.object.trim(),
+    mode: draft.mode,
+    readPath: draft.readPath.trim(),
+    readMethod: draft.readMethod,
+    operations: ['read'],
+  }
+  const wantsKeyField = draft.mode === 'single_record' || draft.mode === 'resolver_lookup' || draft.mode === 'detail_with_lines'
+  if (wantsKeyField && draft.keyField.trim()) payload.keyField = draft.keyField.trim()
+  if (wantsKeyField && draft.keyEncoding) payload.keyEncoding = draft.keyEncoding
+  if (draft.mode === 'resolver_lookup' && draft.multiplicityRuleField.trim()) {
+    payload.multiplicityRuleField = draft.multiplicityRuleField.trim()
+  }
+  if (draft.mode === 'detail_with_lines') {
+    const header = parseContainerPathList(draft.headerContainerPaths)
+    const lines = parseContainerPathList(draft.lineContainerPaths)
+    if (header.length > 0) payload.headerContainerPaths = header
+    if (lines.length > 0) payload.lineContainerPaths = lines
+  } else {
+    const containers = parseContainerPathList(draft.containerPaths)
+    if (containers.length > 0) payload.containerPaths = containers
+  }
+  const fieldMap = draft.fieldMap
+    .map((entry) => ({ source: entry.source.trim(), target: entry.target.trim() }))
+    .filter((entry) => entry.source.length > 0 && entry.target.length > 0)
+  if (fieldMap.length > 0) payload.fieldMap = fieldMap
+  return payload
+}
+
+const EVIDENCE_CONTAINER_ALIASES = ['primary', 'header', 'lines'] as const
+const EVIDENCE_SHAPE_TYPES = new Set(['array', 'null', 'object', 'string', 'number', 'boolean', 'missing', 'other'])
+const EVIDENCE_BOOLEAN_KEYS = ['containerLocated', 'boundedSmokeExecuted', 'timeoutReached', 'capReached'] as const
+const EVIDENCE_COUNT_KEYS = ['recordCount', 'rowCount', 'sampleCount'] as const
+
+function safeCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null
+}
+
+function safeContainerShape(value: unknown): ReadSourceProbeContainerShape | null {
+  if (!isPlainObject(value)) return null
+  const type = typeof value.type === 'string' && EVIDENCE_SHAPE_TYPES.has(value.type)
+    ? value.type as ReadSourceProbeContainerShape['type']
+    : null
+  if (!type) return null
+  const shape: ReadSourceProbeContainerShape = { type }
+  if (value.arrayLength === null) shape.arrayLength = null
+  else {
+    const count = safeCount(value.arrayLength)
+    if (count !== null) shape.arrayLength = count
+  }
+  return shape
+}
+
+// THE render-side leak guard: rebuild the evidence from an explicit allowlist. Unknown fields —
+// including any row values or field keys a hostile/malformed response might carry — are dropped
+// before anything reaches a template.
+export function normalizeReadSourceProbeEvidence(value: unknown): ReadSourceProbeEvidence | null {
+  if (!isPlainObject(value)) return null
+  const evidence: ReadSourceProbeEvidence = {
+    ok: value.ok === true,
+    object: typeof value.object === 'string' ? value.object : 'unknown',
+    mode: typeof value.mode === 'string' ? value.mode : 'unknown',
+    boundedSmoke: value.boundedSmoke === true,
+  }
+  if (isPlainObject(value.containers)) {
+    const containers: ReadSourceProbeEvidence['containers'] = {}
+    for (const alias of EVIDENCE_CONTAINER_ALIASES) {
+      const shape = safeContainerShape(value.containers[alias])
+      if (shape) containers[alias] = shape
+    }
+    if (Object.keys(containers).length > 0) evidence.containers = containers
+  }
+  for (const key of EVIDENCE_BOOLEAN_KEYS) {
+    if (typeof value[key] === 'boolean') evidence[key] = value[key] as boolean
+  }
+  for (const key of EVIDENCE_COUNT_KEYS) {
+    const count = safeCount(value[key])
+    if (count !== null) evidence[key] = count
+  }
+  if (!evidence.ok) {
+    if (typeof value.errorCode === 'string' && /^[A-Z0-9_]{1,80}$/.test(value.errorCode)) {
+      evidence.errorCode = value.errorCode
+    }
+    if (typeof value.errorType === 'string' && /^[A-Za-z]{1,64}$/.test(value.errorType)) {
+      evidence.errorType = value.errorType
+    }
+  }
+  return evidence
+}
+
+export function normalizeReadSourceConfigRow(value: unknown): ReadSourceConfigRow | null {
+  if (!isPlainObject(value)) return null
+  if (typeof value.id !== 'string' || !value.id) return null
+  const status = typeof value.status === 'string' && (READ_SOURCE_STATUSES as readonly string[]).includes(value.status)
+    ? value.status as ReadSourceStatus
+    : 'draft'
+  return {
+    id: value.id,
+    systemId: typeof value.systemId === 'string' ? value.systemId : '',
+    object: typeof value.object === 'string' ? value.object : '',
+    mode: typeof value.mode === 'string' ? value.mode : '',
+    version: safeCount(value.version) ?? 0,
+    status,
+    contentKey: typeof value.contentKey === 'string' ? value.contentKey : '',
+    createdBy: typeof value.createdBy === 'string' ? value.createdBy : null,
+    updatedAt: typeof value.updatedAt === 'string' ? value.updatedAt : null,
+  }
+}
+
+// --- API calls (consultant tier) --------------------------------------------
+
+export async function listReadSourceConfigs(
+  scope: IntegrationScope,
+  filters: { systemId?: string; status?: string } = {},
+): Promise<ReadSourceConfigRow[]> {
+  const query = buildQuery({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    systemId: filters.systemId,
+    status: filters.status,
+  })
+  const response = await apiFetch(`/api/integration/read-source-configs${query}`)
+  const data = await parseReadSourceResponse<unknown[]>(response)
+  return (Array.isArray(data) ? data : [])
+    .map(normalizeReadSourceConfigRow)
+    .filter((row): row is ReadSourceConfigRow => row !== null)
+}
+
+export async function saveReadSourceConfigVersion(
+  config: ReadSourceConfigPayload,
+  scope: IntegrationScope,
+): Promise<ReadSourceSaveResult> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-configs${query}`, {
+    method: 'POST',
+    body: JSON.stringify({ config }),
+  })
+  const data = await parseReadSourceResponse<Record<string, unknown>>(response)
+  return {
+    id: typeof data?.id === 'string' ? data.id : '',
+    version: safeCount(data?.version) ?? 0,
+    status: typeof data?.status === 'string' && (READ_SOURCE_STATUSES as readonly string[]).includes(data.status)
+      ? data.status as ReadSourceStatus
+      : 'draft',
+    reused: data?.reused === true,
+    contentKey: typeof data?.contentKey === 'string' ? data.contentKey : '',
+  }
+}
+
+export async function approveReadSourceConfig(id: string, scope: IntegrationScope): Promise<ReadSourceConfigRow | null> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-configs/${encodeURIComponent(id)}/approve${query}`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+  return normalizeReadSourceConfigRow(await parseReadSourceResponse<unknown>(response))
+}
+
+export async function retireReadSourceConfig(id: string, scope: IntegrationScope): Promise<ReadSourceConfigRow | null> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-configs/${encodeURIComponent(id)}/retire${query}`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+  return normalizeReadSourceConfigRow(await parseReadSourceResponse<unknown>(response))
+}
+
+export async function listReadSourceConfigAudit(id: string, scope: IntegrationScope): Promise<ReadSourceAuditRow[]> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-configs/${encodeURIComponent(id)}/audit${query}`)
+  const data = await parseReadSourceResponse<unknown[]>(response)
+  return (Array.isArray(data) ? data : []).flatMap((row) => {
+    if (!isPlainObject(row)) return []
+    const action = row.action === 'save_version' || row.action === 'reuse_version' || row.action === 'status_change'
+      ? row.action
+      : null
+    if (!action) return []
+    return [{
+      action,
+      actor: typeof row.actor === 'string' ? row.actor : null,
+      detail: isPlainObject(row.detail) ? row.detail : {},
+      createdAt: typeof row.createdAt === 'string' ? row.createdAt : null,
+    }]
+  })
+}
+
+export async function probeReadSourceConfig(
+  systemId: string,
+  input: { config: ReadSourceConfigPayload; boundedSmoke: boolean; key?: string },
+  scope: IntegrationScope,
+): Promise<ReadSourceProbeEvidence | null> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const body: Record<string, unknown> = {
+    config: input.config,
+    boundedSmoke: input.boundedSmoke,
+  }
+  // inputs.key rides BESIDE the contract only when the config declares a keyField (the
+  // runtime fail-closes both a missing required key and a key supplied to a keyless plan).
+  if (input.key !== undefined && input.key.trim() !== '') {
+    body.inputs = { key: input.key.trim() }
+  }
+  const response = await apiFetch(`/api/integration/external-systems/${encodeURIComponent(systemId)}/read-source-probe${query}`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+  return normalizeReadSourceProbeEvidence(await parseReadSourceResponse<unknown>(response))
+}

--- a/apps/web/src/services/integration/readSourceConfigs.ts
+++ b/apps/web/src/services/integration/readSourceConfigs.ts
@@ -112,23 +112,54 @@ export interface ReadSourceProbeEvidence {
   errorType?: string
 }
 
-// Coarse, values-free API error: code + reason enums only — submitted values never enter error text.
+export interface ReadSourceFieldError {
+  code: string
+  field: string
+  reason: string
+}
+
+// Everything lifted from a response body into error text is CLAMPED to enum-shaped patterns first —
+// a value-carrying string under code/reason/field can never reach the DOM through Error.message.
+const ERROR_CODE_PATTERN = /^[A-Z0-9_]{1,80}$/
+const ERROR_REASON_PATTERN = /^[a-z0-9_:-]{1,80}$/
+const ERROR_FIELD_PATTERN = /^[A-Za-z0-9_.()-]{1,64}$/
+
+// Coarse, values-free API error: clamped code + reason enums only — submitted values never enter error text.
 export class ReadSourceApiError extends Error {
   code: string
   reason: string
   status: number
+  fieldErrors: ReadSourceFieldError[]
 
-  constructor(status: number, code: string, reason: string) {
-    super(`读取源接口请求失败(${code}${reason ? `/${reason}` : ''})`)
+  constructor(status: number, code: string, reason: string, fieldErrors: ReadSourceFieldError[] = []) {
+    const fieldSummary = fieldErrors.length > 0
+      ? `:${fieldErrors.map((entry) => ` ${entry.field}: ${entry.reason}`).join(';')}`
+      : ''
+    super(`读取源接口请求失败(${code}${reason ? `/${reason}` : ''})${fieldSummary}`)
     this.name = 'ReadSourceApiError'
     this.status = status
     this.code = code
     this.reason = reason
+    this.fieldErrors = fieldErrors
   }
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+// Save-time validator errors ride as details.errors = [{code, field, reason}]; keep only tuples where
+// every part matches its enum-shaped pattern (a hostile/value-carrying part drops the whole tuple).
+function clampFieldErrors(value: unknown): ReadSourceFieldError[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((entry) => {
+    if (!isPlainObject(entry)) return []
+    const { code, field, reason } = entry
+    if (typeof code !== 'string' || !ERROR_CODE_PATTERN.test(code)) return []
+    if (typeof field !== 'string' || !ERROR_FIELD_PATTERN.test(field)) return []
+    if (typeof reason !== 'string' || !ERROR_REASON_PATTERN.test(reason)) return []
+    return [{ code, field, reason }]
+  })
 }
 
 async function parseReadSourceResponse<T>(response: Response): Promise<T> {
@@ -141,9 +172,13 @@ async function parseReadSourceResponse<T>(response: Response): Promise<T> {
   if (!response.ok || payload?.ok === false) {
     const error = isPlainObject(payload?.error) ? payload.error : {}
     const details = isPlainObject(error.details) ? error.details : {}
-    const code = typeof error.code === 'string' && error.code ? error.code : 'READ_SOURCE_REQUEST_FAILED'
-    const reason = typeof details.reason === 'string' ? details.reason : ''
-    throw new ReadSourceApiError(response.status, code, reason)
+    const code = typeof error.code === 'string' && ERROR_CODE_PATTERN.test(error.code)
+      ? error.code
+      : 'READ_SOURCE_REQUEST_FAILED'
+    const reason = typeof details.reason === 'string' && ERROR_REASON_PATTERN.test(details.reason)
+      ? details.reason
+      : ''
+    throw new ReadSourceApiError(response.status, code, reason, clampFieldErrors(details.errors))
   }
   return payload?.data as T
 }
@@ -248,13 +283,16 @@ export function validateReadSourceDraft(draft: ReadSourceConfigDraft): string[] 
 // Assemble the exact S1 payload: operations pinned to ['read']; only mode-relevant optional
 // fields ride along; empty optionals are dropped, never sent as ''.
 export function buildReadSourceConfigPayload(draft: ReadSourceConfigDraft): ReadSourceConfigPayload {
+  // Mirror the server's normalizeReadSourceConfig leading-slash rule so the probe route (which
+  // requires a byte-normalized config) accepts the same payload the save route would normalize.
+  const trimmedReadPath = draft.readPath.trim()
   const payload: ReadSourceConfigPayload = {
     version: draft.version,
     systemId: draft.systemId.trim(),
     requiredKind: draft.requiredKind.trim(),
     object: draft.object.trim(),
     mode: draft.mode,
-    readPath: draft.readPath.trim(),
+    readPath: trimmedReadPath.startsWith('/') || trimmedReadPath === '' ? trimmedReadPath : `/${trimmedReadPath}`,
     readMethod: draft.readMethod,
     operations: ['read'],
   }
@@ -284,6 +322,34 @@ const EVIDENCE_CONTAINER_ALIASES = ['primary', 'header', 'lines'] as const
 const EVIDENCE_SHAPE_TYPES = new Set(['array', 'null', 'object', 'string', 'number', 'boolean', 'missing', 'other'])
 const EVIDENCE_BOOLEAN_KEYS = ['containerLocated', 'boundedSmokeExecuted', 'timeoutReached', 'capReached'] as const
 const EVIDENCE_COUNT_KEYS = ['recordCount', 'rowCount', 'sampleCount'] as const
+
+// Client-side mirrors of the FROZEN S2-a vocabularies — source of truth:
+// plugins/plugin-integration-core/lib/read-source-probe-contract.cjs
+// (READ_SOURCE_PROBE_ERROR_CODES / READ_SOURCE_PROBE_ERROR_TYPES). Anything outside these closed
+// sets — even an enum-SHAPED string — is replaced by the coarse fallback, never rendered verbatim.
+const READ_SOURCE_PROBE_ERROR_CODES = new Set([
+  'READ_SOURCE_PROBE_CONTRACT_INVALID',
+  'READ_SOURCE_PROBE_FAILED',
+  'READ_SOURCE_PROBE_AUTH_FAILED',
+  'READ_SOURCE_PROBE_CAP_REACHED',
+  'READ_SOURCE_PROBE_CONFIG_INVALID',
+  'READ_SOURCE_PROBE_CONTAINER_NOT_FOUND',
+  'READ_SOURCE_PROBE_NETWORK_FAILED',
+  'READ_SOURCE_PROBE_REJECTED',
+  'READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED',
+  'READ_SOURCE_PROBE_SHAPE_MISMATCH',
+  'READ_SOURCE_PROBE_TIMEOUT',
+])
+const READ_SOURCE_PROBE_ERROR_TYPES = new Set([
+  'Error',
+  'AbortError',
+  'FetchError',
+  'K3WiseWebApiAdapterError',
+  'ReadSourceProbeContractError',
+  'ReadSourceProbeRuntimeError',
+  'TimeoutError',
+  'TypeError',
+])
 
 function safeCount(value: unknown): number | null {
   return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null
@@ -331,12 +397,12 @@ export function normalizeReadSourceProbeEvidence(value: unknown): ReadSourceProb
     if (count !== null) evidence[key] = count
   }
   if (!evidence.ok) {
-    if (typeof value.errorCode === 'string' && /^[A-Z0-9_]{1,80}$/.test(value.errorCode)) {
-      evidence.errorCode = value.errorCode
-    }
-    if (typeof value.errorType === 'string' && /^[A-Za-z]{1,64}$/.test(value.errorType)) {
-      evidence.errorType = value.errorType
-    }
+    evidence.errorCode = typeof value.errorCode === 'string' && READ_SOURCE_PROBE_ERROR_CODES.has(value.errorCode)
+      ? value.errorCode
+      : 'READ_SOURCE_PROBE_FAILED'
+    evidence.errorType = typeof value.errorType === 'string' && READ_SOURCE_PROBE_ERROR_TYPES.has(value.errorType)
+      ? value.errorType
+      : 'Error'
   }
   return evidence
 }

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -249,6 +249,16 @@
     <section class="integration-workbench__panel">
       <div class="integration-workbench__panel-head">
         <div>
+          <h2>读取源配置(顾问自助)</h2>
+          <p>标准化第三方 API 只读读取源:S1 结构校验 → 定位容器探测 → 内容寻址保存版本 → 审批。运行时只消费已审批版本;本面板不含写入 / 删除。</p>
+        </div>
+      </div>
+      <IntegrationReadSourceConfigPanel :scope="currentScope()" :systems="systems" />
+    </section>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__panel-head">
+        <div>
           <h2>选择系统与数据集</h2>
           <p>来源对象决定从哪里取数，目标模板决定写到哪里。先选系统，再加载可选数据集或模板。</p>
         </div>
@@ -1400,6 +1410,7 @@ import {
   type WorkbenchExternalSystem,
 } from '../services/integration/workbench'
 import MetaIntegrationFieldRuleAuthoring from '../components/integration/MetaIntegrationFieldRuleAuthoring.vue'
+import IntegrationReadSourceConfigPanel from '../components/integration/IntegrationReadSourceConfigPanel.vue'
 import PlmBomReviewPanel from '../components/plm/PlmBomReviewPanel.vue'
 
 type WorkbenchSide = 'source' | 'target'

--- a/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
@@ -1,0 +1,565 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App as VueApp } from 'vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: vi.fn(),
+}))
+
+import IntegrationReadSourceConfigPanel from '../src/components/integration/IntegrationReadSourceConfigPanel.vue'
+import {
+  buildReadSourceConfigPayload,
+  createReadSourceConfigDraft,
+  isCoarseSafeRelativeReadPath,
+  normalizeReadSourceProbeEvidence,
+  validateReadSourceDraft,
+  type ReadSourceConfigDraft,
+} from '../src/services/integration/readSourceConfigs'
+import type { WorkbenchExternalSystem } from '../src/services/integration/workbench'
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function errorResponse(status: number, code: string, reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: { code, message: 'coarse', details: { reason } } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function waitUntil(condition: () => boolean, label: string, attempts = 50): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+  throw new Error(`waitUntil timed out: ${label}`)
+}
+
+// --- pure helper tests (DOM-free) -------------------------------------------
+
+describe('readSourceConfigs pure helpers', () => {
+  function validDraft(mode: ReadSourceConfigDraft['mode'] = 'single_record'): ReadSourceConfigDraft {
+    const draft = createReadSourceConfigDraft()
+    draft.systemId = 'sys_1'
+    draft.requiredKind = 'erp:k3-wise-webapi'
+    draft.object = 'material'
+    draft.mode = mode
+    draft.readPath = '/K3API/Material/GetDetail'
+    draft.readMethod = 'POST'
+    if (mode === 'single_record' || mode === 'resolver_lookup') {
+      draft.keyField = 'FNumber'
+      draft.containerPaths = 'Data'
+    }
+    if (mode === 'resolver_lookup') draft.multiplicityRuleField = 'FIsCurrent'
+    if (mode === 'list_page') draft.containerPaths = 'Data.Data, Data.DATA'
+    if (mode === 'detail_with_lines') {
+      draft.headerContainerPaths = 'Data.Page1'
+      draft.lineContainerPaths = 'Data.Page2'
+    }
+    return draft
+  }
+
+  it('per-mode required fields gate validation', () => {
+    expect(validateReadSourceDraft(validDraft('single_record'))).toEqual([])
+    expect(validateReadSourceDraft(validDraft('list_page'))).toEqual([])
+    expect(validateReadSourceDraft(validDraft('detail_with_lines'))).toEqual([])
+    expect(validateReadSourceDraft(validDraft('resolver_lookup'))).toEqual([])
+
+    const missingKey = validDraft('single_record')
+    missingKey.keyField = ''
+    expect(validateReadSourceDraft(missingKey).some((p) => p.includes('keyField'))).toBe(true)
+
+    const missingContainers = validDraft('list_page')
+    missingContainers.containerPaths = ' '
+    expect(validateReadSourceDraft(missingContainers).some((p) => p.includes('containerPaths'))).toBe(true)
+
+    const missingLines = validDraft('detail_with_lines')
+    missingLines.lineContainerPaths = ''
+    expect(validateReadSourceDraft(missingLines).some((p) => p.includes('lineContainerPaths'))).toBe(true)
+
+    const missingMultiplicity = validDraft('resolver_lookup')
+    missingMultiplicity.multiplicityRuleField = ''
+    expect(validateReadSourceDraft(missingMultiplicity).some((p) => p.includes('multiplicityRuleField'))).toBe(true)
+
+    const halfFieldMap = validDraft('single_record')
+    halfFieldMap.fieldMap = [{ source: 'FName', target: '' }]
+    expect(validateReadSourceDraft(halfFieldMap).some((p) => p.includes('fieldMap'))).toBe(true)
+  })
+
+  it('coarse relative-path guard mirrors the server reject classes', () => {
+    expect(isCoarseSafeRelativeReadPath('/K3API/Material/GetDetail')).toBe(true)
+    expect(isCoarseSafeRelativeReadPath('K3API/Material/GetList')).toBe(true)
+    for (const bad of ['https://evil.example.com/x', '//evil.example.com/x', '/a/%2e%2e/x', '/a/../x', '\\\\host\\share', '', '   ', 'javascript:alert(1)']) {
+      expect(isCoarseSafeRelativeReadPath(bad), bad).toBe(false)
+    }
+  })
+
+  it('payload assembly pins operations to [read], keeps only mode-relevant fields, drops empties', () => {
+    const single = buildReadSourceConfigPayload(validDraft('single_record'))
+    expect(single).toEqual({
+      version: 1,
+      systemId: 'sys_1',
+      requiredKind: 'erp:k3-wise-webapi',
+      object: 'material',
+      mode: 'single_record',
+      readPath: '/K3API/Material/GetDetail',
+      readMethod: 'POST',
+      operations: ['read'],
+      keyField: 'FNumber',
+      containerPaths: ['Data'],
+    })
+
+    const detail = validDraft('detail_with_lines')
+    detail.containerPaths = 'ShouldBe.Dropped'
+    detail.keyField = 'FBillNo'
+    const detailPayload = buildReadSourceConfigPayload(detail)
+    expect(detailPayload.containerPaths).toBeUndefined()
+    expect(detailPayload.headerContainerPaths).toEqual(['Data.Page1'])
+    expect(detailPayload.lineContainerPaths).toEqual(['Data.Page2'])
+    expect(detailPayload.keyField).toBe('FBillNo')
+
+    const list = validDraft('list_page')
+    list.keyField = 'ShouldBeDropped'
+    list.multiplicityRuleField = 'AlsoDropped'
+    const listPayload = buildReadSourceConfigPayload(list)
+    expect(listPayload.keyField).toBeUndefined()
+    expect(listPayload.multiplicityRuleField).toBeUndefined()
+    expect(listPayload.containerPaths).toEqual(['Data.Data', 'Data.DATA'])
+
+    const mapped = validDraft('single_record')
+    mapped.fieldMap = [
+      { source: ' FName ', target: ' material_name ' },
+      { source: '', target: '' },
+    ]
+    expect(buildReadSourceConfigPayload(mapped).fieldMap).toEqual([{ source: 'FName', target: 'material_name' }])
+    const emptyMap = validDraft('single_record')
+    emptyMap.fieldMap = [{ source: '', target: '' }]
+    expect(buildReadSourceConfigPayload(emptyMap).fieldMap).toBeUndefined()
+  })
+
+  it('evidence normalizer is an allowlist: illegal fields (row values) are dropped', () => {
+    const evidence = normalizeReadSourceProbeEvidence({
+      ok: true,
+      object: 'material',
+      mode: 'single_record',
+      boundedSmoke: true,
+      containers: {
+        primary: { type: 'array', arrayLength: 3, firstRowValue: 'LEAKY-VALUE' },
+        header: { type: 'nonsense' },
+        bogusAlias: { type: 'array', arrayLength: 1 },
+      },
+      containerLocated: true,
+      boundedSmokeExecuted: true,
+      recordCount: 3,
+      capReached: false,
+      rows: [{ FName: 'SECRET-ROW-VALUE' }],
+      firstRowValue: 'LEAKY-VALUE',
+      message: 'secret M-001 at https://k3host',
+    })
+    expect(evidence).toEqual({
+      ok: true,
+      object: 'material',
+      mode: 'single_record',
+      boundedSmoke: true,
+      containers: { primary: { type: 'array', arrayLength: 3 } },
+      containerLocated: true,
+      boundedSmokeExecuted: true,
+      recordCount: 3,
+      capReached: false,
+    })
+    const text = JSON.stringify(evidence)
+    for (const leak of ['SECRET-ROW-VALUE', 'LEAKY-VALUE', 'M-001', 'k3host', 'bogusAlias', 'nonsense']) {
+      expect(text.includes(leak), leak).toBe(false)
+    }
+  })
+
+  it('evidence normalizer keeps only enum-shaped error codes/types and only when not ok', () => {
+    const failed = normalizeReadSourceProbeEvidence({
+      ok: false,
+      object: 'material',
+      mode: 'list_page',
+      boundedSmoke: false,
+      errorCode: 'READ_SOURCE_PROBE_TIMEOUT',
+      errorType: 'TimeoutError',
+      timeoutReached: true,
+    })
+    expect(failed).toMatchObject({ ok: false, errorCode: 'READ_SOURCE_PROBE_TIMEOUT', errorType: 'TimeoutError', timeoutReached: true })
+
+    const hostile = normalizeReadSourceProbeEvidence({
+      ok: false,
+      object: 'material',
+      mode: 'list_page',
+      boundedSmoke: false,
+      errorCode: 'FAILED M-001 https://k3host',
+      errorType: 'Error<script>',
+    })
+    expect(hostile?.errorCode).toBeUndefined()
+    expect(hostile?.errorType).toBeUndefined()
+  })
+})
+
+// --- component tests ---------------------------------------------------------
+
+const SYSTEMS: WorkbenchExternalSystem[] = [
+  { id: 'sys_1', tenantId: 'default', workspaceId: null, name: 'K3 WISE', kind: 'erp:k3-wise-webapi', role: 'target', status: 'active' },
+  { id: 'sys_http', tenantId: 'default', workspaceId: null, name: 'Generic HTTP', kind: 'http', role: 'source', status: 'active' },
+]
+
+describe('IntegrationReadSourceConfigPanel', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+  let originalConfirm: typeof window.confirm | undefined
+  let confirmMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    originalConfirm = window.confirm
+    confirmMock = vi.fn(() => true)
+    Object.defineProperty(window, 'confirm', { configurable: true, value: confirmMock })
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    Object.defineProperty(window, 'confirm', { configurable: true, value: originalConfirm })
+    app = null
+    container = null
+  })
+
+  function mountPanel(): HTMLDivElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () => h(IntegrationReadSourceConfigPanel, {
+        scope: { tenantId: 'default', workspaceId: null },
+        systems: SYSTEMS,
+      }),
+    })
+    app.mount(container)
+    return container
+  }
+
+  function q<T extends HTMLElement>(root: HTMLElement, testid: string): T {
+    const el = root.querySelector<T>(`[data-testid="${testid}"]`)
+    if (!el) throw new Error(`missing [data-testid=${testid}]`)
+    return el
+  }
+
+  function setInput(root: HTMLElement, testid: string, value: string): void {
+    const input = q<HTMLInputElement>(root, testid)
+    input.value = value
+    input.dispatchEvent(new Event('input'))
+  }
+
+  function setSelect(root: HTMLElement, testid: string, value: string): void {
+    const select = q<HTMLSelectElement>(root, testid)
+    select.value = value
+    select.dispatchEvent(new Event('change'))
+  }
+
+  function mockListOnly(rows: unknown[] = []): void {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.startsWith('/api/integration/read-source-configs')) {
+        return jsonResponse(rows)
+      }
+      return jsonResponse(null)
+    })
+  }
+
+  async function fillValidSingleRecordDraft(root: HTMLElement): Promise<void> {
+    setSelect(root, 'rsc-system', 'sys_1')
+    await flushUi()
+    setInput(root, 'rsc-object', 'material')
+    setInput(root, 'rsc-read-path', '/K3API/Material/GetDetail')
+    setInput(root, 'rsc-key-field', 'FNumber')
+    setInput(root, 'rsc-container-paths', 'Data')
+    await flushUi()
+  }
+
+  it('renders list rows with status badges; approve only on draft, retire only on approved', async () => {
+    mockListOnly([
+      { id: 'cfg_draft', systemId: 'sys_1', object: 'material', mode: 'single_record', version: 1, status: 'draft', contentKey: 'ck1', createdBy: 'op', updatedAt: '2026-07-01' },
+      { id: 'cfg_appr', systemId: 'sys_1', object: 'material', mode: 'list_page', version: 2, status: 'approved', contentKey: 'ck2', createdBy: 'op', updatedAt: '2026-07-01' },
+      { id: 'cfg_ret', systemId: 'sys_http', object: 'order', mode: 'list_page', version: 1, status: 'retired', contentKey: 'ck3', createdBy: 'op', updatedAt: '2026-07-01' },
+    ])
+    const root = mountPanel()
+    await flushUi()
+
+    expect(q(root, 'rsc-status-cfg_draft').textContent).toContain('草稿')
+    expect(q(root, 'rsc-status-cfg_appr').textContent).toContain('已审批')
+    expect(q(root, 'rsc-status-cfg_ret').textContent).toContain('已停用')
+    expect(root.querySelector('[data-testid="rsc-approve-cfg_draft"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-retire-cfg_draft"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-approve-cfg_appr"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-retire-cfg_appr"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-approve-cfg_ret"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-retire-cfg_ret"]')).toBeNull()
+  })
+
+  it('gates fields per mode and blocks probe/save until required fields are present', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+
+    // single_record (default): keyField + containerPaths visible; probe disabled while invalid
+    expect(root.querySelector('[data-testid="rsc-key-field"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-container-paths"]')).not.toBeNull()
+    expect(q<HTMLButtonElement>(root, 'rsc-probe').disabled).toBe(true)
+    expect(q<HTMLButtonElement>(root, 'rsc-save').disabled).toBe(true)
+    expect(q(root, 'rsc-validation').textContent).toContain('keyField')
+
+    // list_page: keyField hidden
+    setSelect(root, 'rsc-mode', 'list_page')
+    await flushUi()
+    expect(root.querySelector('[data-testid="rsc-key-field"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-container-paths"]')).not.toBeNull()
+
+    // detail_with_lines: header/line inputs replace containerPaths
+    setSelect(root, 'rsc-mode', 'detail_with_lines')
+    await flushUi()
+    expect(root.querySelector('[data-testid="rsc-container-paths"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-header-container-paths"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-line-container-paths"]')).not.toBeNull()
+
+    // resolver_lookup: multiplicity field appears
+    setSelect(root, 'rsc-mode', 'resolver_lookup')
+    await flushUi()
+    expect(root.querySelector('[data-testid="rsc-multiplicity-field"]')).not.toBeNull()
+
+    // valid single_record enables the buttons
+    setSelect(root, 'rsc-mode', 'single_record')
+    await fillValidSingleRecordDraft(root)
+    expect(q(root, 'rsc-required-kind').getAttribute('value') ?? q<HTMLInputElement>(root, 'rsc-required-kind').value).toContain('erp:k3-wise-webapi')
+    expect(root.querySelector('[data-testid="rsc-validation"]')).toBeNull()
+    expect(q<HTMLButtonElement>(root, 'rsc-probe').disabled).toBe(false)
+    expect(q<HTMLButtonElement>(root, 'rsc-save').disabled).toBe(false)
+  })
+
+  it('probe posts the exact contract body (config + boundedSmoke + inputs.key) and renders values-free evidence', async () => {
+    const probeBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems/sys_1/read-source-probe')) {
+        probeBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({
+          ok: true,
+          object: 'material',
+          mode: 'single_record',
+          boundedSmoke: true,
+          containers: { primary: { type: 'object', arrayLength: null } },
+          containerLocated: true,
+          boundedSmokeExecuted: true,
+          recordCount: 1,
+          capReached: false,
+          timeoutReached: false,
+          rows: [{ FName: 'SECRET-ROW-VALUE' }],
+          firstRowValue: 'LEAKY-VALUE',
+        })
+      }
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await fillValidSingleRecordDraft(root)
+
+    const smoke = q<HTMLInputElement>(root, 'rsc-bounded-smoke')
+    smoke.checked = true
+    smoke.dispatchEvent(new Event('change'))
+    await flushUi()
+    setInput(root, 'rsc-probe-key', ' M-001 ')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rsc-probe').click()
+    await flushUi()
+
+    expect(probeBodies).toHaveLength(1)
+    expect(probeBodies[0]).toEqual({
+      config: {
+        version: 1,
+        systemId: 'sys_1',
+        requiredKind: 'erp:k3-wise-webapi',
+        object: 'material',
+        mode: 'single_record',
+        readPath: '/K3API/Material/GetDetail',
+        readMethod: 'POST',
+        operations: ['read'],
+        keyField: 'FNumber',
+        containerPaths: ['Data'],
+      },
+      boundedSmoke: true,
+      inputs: { key: 'M-001' },
+    })
+
+    const evidence = q(root, 'rsc-probe-evidence')
+    expect(evidence.textContent).toContain('ok: true')
+    expect(q(root, 'rsc-evidence-container-primary').textContent).toContain('type=object')
+    expect(q(root, 'rsc-evidence-record-count').textContent).toContain('recordCount: 1')
+
+    // leak guard: illegal fields in the response never reach the DOM
+    for (const leak of ['SECRET-ROW-VALUE', 'LEAKY-VALUE']) {
+      expect(root.innerHTML.includes(leak), leak).toBe(false)
+    }
+  })
+
+  it('probe with declared keyField but empty key fail-closes client-side (no fetch)', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+    await fillValidSingleRecordDraft(root)
+    apiFetchMock.mockClear()
+
+    q<HTMLButtonElement>(root, 'rsc-probe').click()
+    await flushUi()
+
+    expect(apiFetchMock).not.toHaveBeenCalled()
+    expect(q(root, 'rsc-error').textContent).toContain('keyField')
+  })
+
+  it('renders coarse failure evidence codes', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      if (url.includes('/read-source-probe')) {
+        return jsonResponse({
+          ok: false,
+          object: 'material',
+          mode: 'single_record',
+          boundedSmoke: false,
+          errorCode: 'READ_SOURCE_PROBE_CONTAINER_NOT_FOUND',
+          errorType: 'ReadSourceProbeRuntimeError',
+          containers: { primary: { type: 'missing', arrayLength: null } },
+          containerLocated: false,
+        })
+      }
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await fillValidSingleRecordDraft(root)
+    setInput(root, 'rsc-probe-key', 'M-001')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rsc-probe').click()
+    await flushUi()
+
+    expect(q(root, 'rsc-evidence-error-code').textContent).toContain('READ_SOURCE_PROBE_CONTAINER_NOT_FOUND')
+    expect(q(root, 'rsc-evidence-error-type').textContent).toContain('ReadSourceProbeRuntimeError')
+    expect(q(root, 'rsc-evidence-located').textContent).toContain('false')
+  })
+
+  it('surfaces contract 400 as coarse code/reason without echoing values', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      if (url.includes('/read-source-probe')) {
+        return errorResponse(400, 'READ_SOURCE_PROBE_CONTRACT_INVALID', 'unexpected_field')
+      }
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await fillValidSingleRecordDraft(root)
+    setInput(root, 'rsc-probe-key', 'M-001')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rsc-probe').click()
+    await flushUi()
+
+    const message = q(root, 'rsc-error').textContent ?? ''
+    expect(message).toContain('READ_SOURCE_PROBE_CONTRACT_INVALID')
+    expect(message).toContain('unexpected_field')
+    expect(message.includes('M-001')).toBe(false)
+  })
+
+  it('save renders 已保存新版本 vs 已复用现有版本 and refreshes the list', async () => {
+    let saved = false
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/integration/read-source-configs') && init?.method === 'POST') {
+        const reused = saved
+        saved = true
+        return jsonResponse({ id: 'cfg_1', version: 3, status: 'draft', reused, contentKey: 'ck' })
+      }
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await fillValidSingleRecordDraft(root)
+
+    q<HTMLButtonElement>(root, 'rsc-save').click()
+    await waitUntil(() => (root.querySelector('[data-testid="rsc-save-result"]')?.textContent ?? '').includes('已保存新版本'), 'first save settles')
+    expect(q(root, 'rsc-save-result').textContent).toContain('已保存新版本 v3')
+
+    q<HTMLButtonElement>(root, 'rsc-save').click()
+    await waitUntil(() => (root.querySelector('[data-testid="rsc-save-result"]')?.textContent ?? '').includes('已复用'), 'second save settles')
+    expect(q(root, 'rsc-save-result').textContent).toContain('已复用现有版本 v3')
+  })
+
+  it('approve requires confirm; cancel means no API call', async () => {
+    const approveCalls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/approve') && init?.method === 'POST') {
+        approveCalls.push(url)
+        return jsonResponse({ id: 'cfg_draft', systemId: 'sys_1', object: 'material', mode: 'single_record', version: 1, status: 'approved', contentKey: 'ck1' })
+      }
+      if (url.startsWith('/api/integration/read-source-configs')) {
+        return jsonResponse([
+          { id: 'cfg_draft', systemId: 'sys_1', object: 'material', mode: 'single_record', version: 1, status: 'draft', contentKey: 'ck1' },
+        ])
+      }
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+
+    confirmMock.mockReturnValueOnce(false)
+    q<HTMLButtonElement>(root, 'rsc-approve-cfg_draft').click()
+    await flushUi()
+    expect(approveCalls).toHaveLength(0)
+
+    confirmMock.mockReturnValueOnce(true)
+    q<HTMLButtonElement>(root, 'rsc-approve-cfg_draft').click()
+    await flushUi()
+    expect(approveCalls).toHaveLength(1)
+    expect(approveCalls[0]).toContain('/api/integration/read-source-configs/cfg_draft/approve')
+  })
+
+  it('audit toggle loads values-free audit rows', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/audit')) {
+        return jsonResponse([
+          { action: 'save_version', actor: 'consultant_1', detail: { status: 'draft' }, createdAt: '2026-07-01T00:00:00Z' },
+          { action: 'status_change', actor: 'admin_1', detail: { from: 'draft', to: 'approved' }, createdAt: '2026-07-02T00:00:00Z' },
+        ])
+      }
+      if (url.startsWith('/api/integration/read-source-configs')) {
+        return jsonResponse([
+          { id: 'cfg_1', systemId: 'sys_1', object: 'material', mode: 'single_record', version: 1, status: 'approved', contentKey: 'ck1' },
+        ])
+      }
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rsc-audit-toggle-cfg_1').click()
+    await flushUi()
+
+    const audit = q(root, 'rsc-audit-list')
+    expect(audit.textContent).toContain('保存新版本')
+    expect(audit.textContent).toContain('状态变更')
+    expect(audit.textContent).toContain('consultant_1')
+  })
+})

--- a/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
@@ -199,6 +199,7 @@ describe('readSourceConfigs pure helpers', () => {
     })
     expect(failed).toMatchObject({ ok: false, errorCode: 'READ_SOURCE_PROBE_TIMEOUT', errorType: 'TimeoutError', timeoutReached: true })
 
+    // value-carrying strings fall back to the coarse defaults
     const hostile = normalizeReadSourceProbeEvidence({
       ok: false,
       object: 'material',
@@ -207,8 +208,36 @@ describe('readSourceConfigs pure helpers', () => {
       errorCode: 'FAILED M-001 https://k3host',
       errorType: 'Error<script>',
     })
-    expect(hostile?.errorCode).toBeUndefined()
-    expect(hostile?.errorType).toBeUndefined()
+    expect(hostile?.errorCode).toBe('READ_SOURCE_PROBE_FAILED')
+    expect(hostile?.errorType).toBe('Error')
+
+    // enum-SHAPED but outside the frozen S2-a vocabularies → fallback, never rendered verbatim
+    for (const [errorCode, errorType] of [
+      ['MATERIAL_2024_SECRET', 'AdapterValidationError'],
+      ['READ_SOURCE_PROBE_BOGUS', 'SecretLeakError'],
+    ]) {
+      const nonVocabulary = normalizeReadSourceProbeEvidence({
+        ok: false,
+        object: 'material',
+        mode: 'list_page',
+        boundedSmoke: false,
+        errorCode,
+        errorType,
+      })
+      expect(nonVocabulary?.errorCode).toBe('READ_SOURCE_PROBE_FAILED')
+      expect(nonVocabulary?.errorType).toBe('Error')
+      const text = JSON.stringify(nonVocabulary)
+      expect(text.includes(errorCode)).toBe(false)
+      expect(text.includes(errorType)).toBe(false)
+    }
+  })
+
+  it('payload assembly normalizes readPath to carry the leading slash (server byte-normalization mirror)', () => {
+    const draft = validDraft('list_page')
+    draft.readPath = 'K3API/Material/GetList'
+    expect(buildReadSourceConfigPayload(draft).readPath).toBe('/K3API/Material/GetList')
+    draft.readPath = '/K3API/Material/GetList'
+    expect(buildReadSourceConfigPayload(draft).readPath).toBe('/K3API/Material/GetList')
   })
 })
 
@@ -284,7 +313,7 @@ describe('IntegrationReadSourceConfigPanel', () => {
     setSelect(root, 'rsc-system', 'sys_1')
     await flushUi()
     setInput(root, 'rsc-object', 'material')
-    setInput(root, 'rsc-read-path', '/K3API/Material/GetDetail')
+    setInput(root, 'rsc-read-path', 'K3API/Material/GetDetail')
     setInput(root, 'rsc-key-field', 'FNumber')
     setInput(root, 'rsc-container-paths', 'Data')
     await flushUi()
@@ -534,6 +563,98 @@ describe('IntegrationReadSourceConfigPanel', () => {
     await flushUi()
     expect(approveCalls).toHaveLength(1)
     expect(approveCalls[0]).toContain('/api/integration/read-source-configs/cfg_draft/approve')
+  })
+
+  it('switching the external system clears stale probe evidence and save state', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      if (url.includes('/read-source-probe')) {
+        return jsonResponse({
+          ok: true,
+          object: 'material',
+          mode: 'single_record',
+          boundedSmoke: false,
+          containers: { primary: { type: 'object', arrayLength: null } },
+          containerLocated: true,
+        })
+      }
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await fillValidSingleRecordDraft(root)
+    setInput(root, 'rsc-probe-key', 'M-001')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rsc-probe').click()
+    await waitUntil(() => root.querySelector('[data-testid="rsc-probe-evidence"]') !== null, 'probe evidence appears')
+
+    setSelect(root, 'rsc-system', 'sys_http')
+    await flushUi()
+    expect(root.querySelector('[data-testid="rsc-probe-evidence"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-save-result"]')).toBeNull()
+  })
+
+  it('clamps hostile top-level error code/reason before they can reach the DOM', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      if (url.includes('/read-source-probe')) {
+        return errorResponse(400, 'FAILED M-001 https://k3host', 'Value M-001 leaked')
+      }
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await fillValidSingleRecordDraft(root)
+    setInput(root, 'rsc-probe-key', 'M-001')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rsc-probe').click()
+    await waitUntil(() => root.querySelector('[data-testid="rsc-error"]') !== null, 'error appears')
+
+    const message = q(root, 'rsc-error').textContent ?? ''
+    expect(message).toContain('READ_SOURCE_REQUEST_FAILED')
+    for (const leak of ['M-001', 'k3host', 'leaked']) {
+      expect(root.innerHTML.includes(leak), leak).toBe(false)
+    }
+  })
+
+  it('save 400 renders a coarse per-field list and drops hostile tuples', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/integration/read-source-configs') && init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          ok: false,
+          error: {
+            code: 'READ_SOURCE_CONFIG_INVALID',
+            message: 'coarse',
+            details: {
+              errors: [
+                { code: 'READ_SOURCE_ENDPOINT_NOT_RELATIVE', field: 'readPath', reason: 'not_safe_relative_path' },
+                { code: 'READ_SOURCE_KEY_FIELD_INVALID', field: 'keyField', reason: 'invalid_identifier' },
+                { code: 'READ_SOURCE_X', field: '<img src=x> M-001', reason: 'bad reason with spaces' },
+                { code: 'lower_case_code M-001', field: 'object', reason: 'ok_reason' },
+              ],
+            },
+          },
+        }), { status: 400, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await fillValidSingleRecordDraft(root)
+
+    q<HTMLButtonElement>(root, 'rsc-save').click()
+    await waitUntil(() => root.querySelector('[data-testid="rsc-error"]') !== null, 'save error appears')
+
+    const message = q(root, 'rsc-error').textContent ?? ''
+    expect(message).toContain('READ_SOURCE_CONFIG_INVALID')
+    expect(message).toContain('readPath: not_safe_relative_path')
+    expect(message).toContain('keyField: invalid_identifier')
+    for (const leak of ['<img', 'M-001', 'bad reason with spaces', 'lower_case_code']) {
+      expect(root.innerHTML.includes(leak), leak).toBe(false)
+    }
   })
 
   it('audit toggle loads values-free audit rows', async () => {


### PR DESCRIPTION
## What

外部 API 读取自助化(#1709)**S3 顾问自助 UI**:IntegrationWorkbenchView 新增「读取源配置」面板。

- 配置列表(状态徽标/版本)+ S1 形状创建表单(四模式逐模式必填门控,operations 锁死 ['read'],requiredKind 由所选系统自动带出防 409)
- **定位容器探测**按钮 → S2-b probe 路由(87e0695fb),证据渲染走**allowlist 归一化器**(镜像 S2-a 冻结词表:11 错误码/8 错误类型/8 容器形状类型;非法字段一律丢弃,DOM 泄漏测试锁定)
- **保存版本** → S2-c 路由(#3470),已复用 vs 新版本双态渲染;approve(确认门控,仅 draft)/retire(仅 approved)/values-free 审计视图
- 服务层错误解析全钳制:code/reason 模式钳制 + S1 errors 数组逐元组钳制后按字段粗粒度呈现;readPath 前导斜杠镜像服务端归一化(probe 字节一致性)

## 对抗审查

3 视角(渲染泄漏/后端契约对齐/表单安全)× 逐条反驳验证,确认 5 项缺陷全部修复并测试锁定(未钳制错误串入 DOM、词表 vs 形状匹配、切换系统残留证据、无斜杠 readPath 致 probe 400、errors 数组丢弃)。后端契约与 S2-c 实际实现逐点对账通过(camelCase 行/信封/200-201/scope 传参)。

## 验证

面板 spec 18/18 · 既有 workbench 双 spec 79/79 · pnpm lint · pnpm type-check 全绿。依赖后端 #3470 先行合并(仅逻辑顺序,文件零交集)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)