### PR TITLE
feat(automation): write back non-approved approval outcomes

### DIFF
--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -213,6 +213,10 @@ function validateStartApprovalConfig(config: Record<string, unknown>, path: stri
   // resume-time action-fingerprint drift guard (cannot be swapped after the approval suspends).
   if (config.resultWriteback !== undefined) {
     if (!isRecord(config.resultWriteback)) return `${path}.resultWriteback must be an object`
+    const onNonApproved = config.resultWriteback.onNonApproved
+    if (onNonApproved !== undefined && typeof onNonApproved !== 'boolean') {
+      return `${path}.resultWriteback.onNonApproved must be a boolean`
+    }
     let mapped = 0
     for (const field of RESULT_WRITEBACK_FIELDS) {
       const value = config.resultWriteback[field]
@@ -2077,6 +2081,7 @@ export class AutomationService {
 
     const result = this.approvalCompletionStepResult(event)
     if (event.transition.toStatus !== 'approved') {
+      await this.tryWriteApprovalResultBack(bridge, execRule.actions[bridge.stepIndex]?.config ?? {}, event, result)
       await this.failApprovalBridgeExecution(execution, bridge, result.error ?? `Approval completed with ${event.transition.toStatus}`, result)
       return
     }
@@ -2098,21 +2103,10 @@ export class AutomationService {
     // W7-1: declared approval-result backwrite to the SOURCE record (fixed mapping, values from the
     // event, through the lock guard). Best-effort — a locked/missing record logs + skips rather than
     // crashing the resume, so the automation's remaining actions still run.
-    try {
-      const backwritten = await this.writeApprovalResultBack(bridge, execRule.actions[bridge.stepIndex]?.config ?? {}, event)
-      // W7-1a: merge the backwrite into the resume snapshot so the TAIL actions (send_webhook /
-      // update_record / ...) see the just-written result, not the pre-approval record.
-      if (backwritten) recordData = { ...recordData, ...backwritten }
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err)
-      logger.warn(`approval-result backwrite skipped for bridge ${bridge.id}: ${reason}`)
-      // W7-obs: surface the skip on the start_approval step result so it shows in the run history —
-      // an admin shouldn't need log access to see a misconfigured/blocked backwrite.
-      ;(result as { output?: Record<string, unknown> }).output = {
-        ...((result as { output?: Record<string, unknown> }).output ?? {}),
-        backwriteSkipped: reason,
-      }
-    }
+    const backwritten = await this.tryWriteApprovalResultBack(bridge, execRule.actions[bridge.stepIndex]?.config ?? {}, event, result)
+    // W7-1a: merge the backwrite into the resume snapshot so the TAIL actions (send_webhook /
+    // update_record / ...) see the just-written result, not the pre-approval record.
+    if (backwritten) recordData = { ...recordData, ...backwritten }
 
     const triggerEvent = bridge.triggerEvent ?? {}
     const context: ExecutionContext = {
@@ -2158,6 +2152,27 @@ export class AutomationService {
       output,
       error: `Approval completed with ${event.transition.toStatus}`,
       durationMs: 0,
+    }
+  }
+
+  private async tryWriteApprovalResultBack(
+    bridge: AutomationApprovalBridgeRow,
+    startApprovalConfig: Record<string, unknown>,
+    event: ApprovalCompletionEventV1,
+    result: AutomationStepResult,
+  ): Promise<Record<string, unknown> | null> {
+    try {
+      return await this.writeApprovalResultBack(bridge, startApprovalConfig, event)
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      logger.warn(`approval-result backwrite skipped for bridge ${bridge.id}: ${reason}`)
+      // W7-obs: surface the skip on the start_approval step result so it shows in the run history —
+      // an admin shouldn't need log access to see a misconfigured/blocked backwrite.
+      result.output = {
+        ...(isRecord(result.output) ? result.output : {}),
+        backwriteSkipped: reason,
+      }
+      return null
     }
   }
 
@@ -2260,8 +2275,9 @@ export class AutomationService {
    * event ONLY (never user-templated strings — that keeps the write path values-constrained, the whole
    * reason this was gated). Goes through the record lock guard (B1: an automation does not implicitly own
    * a lock). Null-safe: `approver` is null on auto/system approval (the field is written null, not
-   * crashed). Same-base only (the source record that started the approval). Approval-only is enforced by
-   * the caller (runs in the approved branch); rejection backwrite is a named follow-up.
+   * crashed). Same-base only (the source record that started the approval). The approved branch always
+   * writes when configured; non-approved terminal outcomes require the explicit `onNonApproved` opt-in so
+   * existing saved rules keep the former approved-only contract.
    */
   private async writeApprovalResultBack(
     bridge: AutomationApprovalBridgeRow,
@@ -2270,6 +2286,7 @@ export class AutomationService {
   ): Promise<Record<string, unknown> | null> {
     const writeback = isRecord(startApprovalConfig.resultWriteback) ? startApprovalConfig.resultWriteback : null
     if (!writeback || !bridge.recordId || !bridge.sheetId) return null
+    if (event.transition.toStatus !== 'approved' && writeback.onNonApproved !== true) return null
     await this.assertResultWritebackFields(bridge.sheetId, writeback, event.transition.toStatus)
     const patch: Record<string, unknown> = {}
     const statusField = resultWritebackFieldId(writeback, 'statusField')

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -151,7 +151,7 @@ async function createPublishedTemplate(
   return template.id
 }
 
-async function createStartApprovalRule(svc: AutomationService, templateId: string, resultWriteback?: Record<string, string>): Promise<string> {
+async function createStartApprovalRule(svc: AutomationService, templateId: string, resultWriteback?: Record<string, string | boolean>): Promise<string> {
   const startApproval = {
     type: 'start_approval',
     config: {
@@ -242,7 +242,7 @@ async function waitForExecutionStatus(svc: AutomationService, id: string, status
 
 async function executeAndApprove(
   svc: AutomationService,
-  resultWriteback: Record<string, string>,
+  resultWriteback: Record<string, string | boolean>,
   title = 'Q4 plan',
 ): Promise<{ executionId: string; approvalInstanceId: string }> {
   const templateId = await createPublishedTemplate()
@@ -673,6 +673,193 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       expect(jobs[0]).toMatchObject({ status: 'failed', error: 'Approval completed with rejected' })
       expect(jobs[1]).toMatchObject({ status: 'skipped' })
       jobs.forEach((job) => expect(() => normalizeWorkflowJob(job)).not.toThrow())
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('T3-4: rejected approval does not write existing resultWriteback mapping without explicit opt-in', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      await seedDefaultWritebackFields()
+      const RW = {
+        statusField: 'approval_status',
+        approverField: 'approved_by',
+        completedAtField: 'approved_at',
+      }
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId, RW)
+      await seedSheetRecord('Rejected approved-only writeback path')
+      const execRule = {
+        id: ruleId,
+        name: 'W7 rejected approved-only writeback',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+              resultWriteback: RW,
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w7-rejected-approved-only-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Rejected approved-only writeback path' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+      const bridge = await q(
+        `SELECT approval_instance_id
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const approvals = new ApprovalProductService()
+      const approvalAfterAction = await approvals.dispatchAction(
+        bridge.rows[0].approval_instance_id,
+        { action: 'reject', comment: 'no' },
+        { userId: APPROVER, userName: APPROVER },
+      )
+      expect(approvalAfterAction.status).toBe('rejected')
+
+      const failed = await waitForExecutionStatus(svc, execution.id, 'failed')
+      expect(failed.steps[0]).toMatchObject({
+        actionType: 'start_approval',
+        status: 'failed',
+        error: 'Approval completed with rejected',
+      })
+      expect(failed.steps[1]).toMatchObject({
+        actionType: 'send_webhook',
+        status: 'skipped',
+      })
+      expect(calls).toEqual([])
+
+      const rec = await q<{ data: Record<string, unknown> }>(
+        'SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        [RECORD, SHEET],
+      )
+      const data = rec.rows[0].data
+      expect(data).not.toHaveProperty('approval_status')
+      expect(data).not.toHaveProperty('approved_by')
+      expect(data).not.toHaveProperty('approved_at')
+
+      const finalBridge = await q(
+        'SELECT status, outcome FROM multitable_automation_approval_bridges WHERE execution_id = $1',
+        [execution.id],
+      )
+      expect(finalBridge.rows[0]).toMatchObject({ status: 'resumed', outcome: 'rejected' })
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('T3-4: rejected approval writes resultWriteback when explicitly opted in, then still fails without running the tail', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      await seedDefaultWritebackFields()
+      const RW = {
+        statusField: 'approval_status',
+        approverField: 'approved_by',
+        completedAtField: 'approved_at',
+        onNonApproved: true,
+      }
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId, RW)
+      await seedSheetRecord('Rejected writeback path')
+      const execRule = {
+        id: ruleId,
+        name: 'W7 rejected writeback',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+              resultWriteback: RW,
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w7-rejected-writeback-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Rejected writeback path' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+      const bridge = await q(
+        `SELECT approval_instance_id
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const approvals = new ApprovalProductService()
+      const approvalAfterAction = await approvals.dispatchAction(
+        bridge.rows[0].approval_instance_id,
+        { action: 'reject', comment: 'no' },
+        { userId: APPROVER, userName: APPROVER },
+      )
+      expect(approvalAfterAction.status).toBe('rejected')
+
+      const failed = await waitForExecutionStatus(svc, execution.id, 'failed')
+      expect(failed.steps[0]).toMatchObject({
+        actionType: 'start_approval',
+        status: 'failed',
+        error: 'Approval completed with rejected',
+      })
+      expect(failed.steps[1]).toMatchObject({
+        actionType: 'send_webhook',
+        status: 'skipped',
+      })
+      expect(calls).toEqual([])
+
+      const rec = await q<{ data: Record<string, unknown> }>(
+        'SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        [RECORD, SHEET],
+      )
+      const data = rec.rows[0].data
+      expect(data.approval_status).toBe('rejected')
+      expect(data.approved_by).toBe(APPROVER)
+      expect(typeof data.approved_at).toBe('string')
+
+      const finalBridge = await q(
+        'SELECT status, outcome FROM multitable_automation_approval_bridges WHERE execution_id = $1',
+        [execution.id],
+      )
+      expect(finalBridge.rows[0]).toMatchObject({ status: 'resumed', outcome: 'rejected' })
     } finally {
       svc.shutdown()
     }

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2599,13 +2599,14 @@ describe('AutomationService — Rule CRUD', () => {
     const base = { templateId: 'tpl_1', formDataMapping: { amount: '{{record.amount}}' } }
     const withRW = (rw: unknown) => ({ ...base, resultWriteback: rw })
 
-    // valid: a fixed outcome→field mapping (≥1 field, all non-empty strings)
+    // valid: a fixed outcome→field mapping (≥1 field, all non-empty strings) plus the explicit
+    // non-approved opt-in flag used by T3-4.
     dbExecuteResults.push([])
     const ok = await service.createRule('sheet_1', {
       name: 'Backwrite rule', triggerType: 'record.created', triggerConfig: {},
       actionType: 'start_approval',
-      actionConfig: withRW({ statusField: 'approval_status', approverField: 'approved_by' }),
-      actions: [{ type: 'start_approval', config: withRW({ statusField: 'approval_status', approverField: 'approved_by' }) }],
+      actionConfig: withRW({ statusField: 'approval_status', approverField: 'approved_by', onNonApproved: true }),
+      actions: [{ type: 'start_approval', config: withRW({ statusField: 'approval_status', approverField: 'approved_by', onNonApproved: true }) }],
       executionMode: 'workflow_job_v1', createdBy: 'user_1',
     })
     expect(ok.action_type).toBe('start_approval')
@@ -2625,6 +2626,14 @@ describe('AutomationService — Rule CRUD', () => {
       actions: [{ type: 'start_approval', config: withRW({ statusField: 123 }) }],
       executionMode: 'workflow_job_v1', createdBy: 'user_1',
     })).rejects.toThrow(/resultWriteback\.statusField must be a non-empty string/)
+
+    // invalid: the non-approved path is opt-in by an actual boolean, not a truthy string.
+    await expect(service.createRule('sheet_1', {
+      name: 'Bad non-approved backwrite flag', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'start_approval', actionConfig: withRW({ statusField: 'approval_status', onNonApproved: 'true' }),
+      actions: [{ type: 'start_approval', config: withRW({ statusField: 'approval_status', onNonApproved: 'true' }) }],
+      executionMode: 'workflow_job_v1', createdBy: 'user_1',
+    })).rejects.toThrow(/resultWriteback\.onNonApproved must be a boolean/)
   })
 
   it('A6-3-1: createRule accepts condition_branch only with workflow_job_v1', async () => {


### PR DESCRIPTION
## Summary
- Add explicit `resultWriteback.onNonApproved` support for `start_approval` actions.
- Keep existing mappings approved-only by default; rejected/cancelled/revoked outcomes write back only when the flag is `true`.
- Preserve write-back-then-fail semantics: non-approved outcomes may write configured fields, then the automation still fails and skips the tail.

## Why
T3-4 closes the W7 rejection-path writeback slice without changing existing saved rule behavior. The approved path remains unchanged; non-approved terminal outcomes are opt-in and continue to stop the workflow tail.

## Verification
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false` (211/211)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-automation-start-approval.test.ts --watch=false` (local env has no `DATABASE_URL`, so this real-DB file skipped as expected)

## CI note
`tests/integration/multitable-automation-start-approval.test.ts` is wired into `.github/workflows/plugin-tests.yml`, so the two new real-DB paths are verified by CI:
- existing resultWriteback mapping + rejected outcome without `onNonApproved` does not write back
- `onNonApproved: true` writes status/actor/completedAt, then still fails the workflow tail
