### PR TITLE
feat(integration): S3-2 runtime read route — approved-config, key-only, data/evidence split (#1709)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -517,6 +517,7 @@ function createHarness() {
         async approve() { return {} },
         async retire() { return {} },
         async listAudit() { return [] },
+        async getForRuntime() { return {} },
       },
     },
     logger: {

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -9,7 +9,7 @@ const { MAX_LIST_LIMIT } = httpRoutes
 const { PLM_STOCK_PREPARATION_ACTION_ID } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-table-actions.cjs'))
 const { STOCK_PREPARATION_MAIN_TABLE_TEMPLATE } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
 const { READ_SMOKE_LIST_REQUEST_MARKER } = require(path.join(__dirname, '..', 'lib', 'read-smoke-marker.cjs'))
-const { createReadSourceConfigStore } = require(path.join(__dirname, '..', 'lib', 'read-source-config-store.cjs'))
+const { createReadSourceConfigStore, ReadSourceConfigNotApprovedError } = require(path.join(__dirname, '..', 'lib', 'read-source-config-store.cjs'))
 // S4: adapter self-described metadata — the mock registry serves the REAL per-module metadata
 // so the /adapters route assertions verify the actual shipped values (no duplicated literal).
 const ADAPTER_METADATA_BY_KIND = {
@@ -272,6 +272,10 @@ function createMockServices(overrides = {}) {
       async get(input) {
         calls.push(['readSourceConfigGet', input])
         return { id: input.id, status: 'draft' }
+      },
+      async getForRuntime(input) {
+        calls.push(['readSourceConfigGetForRuntime', input])
+        return { id: input.id, status: 'approved', systemId: 'sys_1', config: {} }
       },
       async approve(input) {
         calls.push(['readSourceConfigApprove', input])
@@ -6290,6 +6294,140 @@ async function testReadSourceConfigRoutes() {
   console.log('  testReadSourceConfigRoutes OK')
 }
 
+// S3-2 (#1709 self-service): runtime-tier configured read route. Approved-config-only, key-only body,
+// data-plane values to the caller, values-free evidence, read tier by design (S0 two-tier model).
+async function testReadSourceConfiguredReadRoute() {
+  const readArgs = []
+  const writeCalls = []
+  const approvedConfig = {
+    version: 3,
+    systemId: 'sys_1',
+    requiredKind: 'erp:k3-wise-webapi',
+    object: 'material',
+    mode: 'single_record',
+    readPath: '/K3API/Material/GetDetail',
+    readMethod: 'POST',
+    operations: ['read'],
+    keyField: 'FNumber',
+    containerPaths: ['Data'],
+    fieldMap: [
+      { source: 'FName', target: 'col_name' },
+      { source: 'FModel', target: 'col_model' },
+    ],
+  }
+  const storeCalls = []
+  const services = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        return { id: input.id, kind: 'erp:k3-wise-webapi', credentials: { bearerToken: 'secret-token' }, config: { objects: {} } }
+      },
+    },
+    readSourceConfigStore: {
+      async saveVersion() { return {} },
+      async list() { return [] },
+      async get() { return {} },
+      async approve() { return {} },
+      async retire() { return {} },
+      async listAudit() { return [] },
+      async getForRuntime(input) {
+        storeCalls.push(['getForRuntime', input])
+        if (input.id === 'rsc_draft') {
+          const error = new Error('read-source config version is not approved')
+          error.name = 'ReadSourceConfigNotApprovedError'
+          Object.setPrototypeOf(error, ReadSourceConfigNotApprovedError.prototype)
+          error.details = { id: input.id, status: 'draft' }
+          throw error
+        }
+        return { id: input.id, systemId: 'sys_1', object: 'material', mode: 'single_record', version: 3, status: 'approved', config: approvedConfig }
+      },
+    },
+    adapterRegistry: {
+      createAdapter() {
+        return {
+          async read(req) {
+            readArgs.push(req)
+            return {
+              records: [],
+              raw: { Data: { FName: 'SECRET-NAME', FModel: 'MX-9', FNumber: req.filters.FNumber, FUnclassified: 'DROP-ME' } },
+            }
+          },
+          async upsert(b) { writeCalls.push(['upsert', b]); return {} },
+          async save(b) { writeCalls.push(['save', b]); return {} },
+        }
+      },
+    },
+  }).services
+  const { routes } = mountRoutes(services)
+
+  // success: read tier is ALLOWED (the designed runtime tier), data plane carries ONLY mapped targets,
+  // evidence stays values-free.
+  const ok = await invoke(routes, 'POST', '/api/integration/read-source-configs/:id/read', {
+    user: READ_USER, params: { id: 'rsc_ok' }, query: { workspaceId: 'workspace_1' },
+    body: { inputs: { key: 'M-001' } },
+  })
+  assertOkResponse(ok, 200)
+  assert.equal(ok.body.data.evidence.ok, true)
+  assert.deepEqual(ok.body.data.data.containers.primary.records, [{ col_name: 'SECRET-NAME', col_model: 'MX-9' }])
+  assert.equal(ok.body.data.data.recordCount, 1)
+  assert.equal(readArgs.length, 1, 'adapter.read called exactly once')
+  assert.deepEqual(readArgs[0], { object: 'material', filters: { FNumber: 'M-001' } })
+  assert.equal(writeCalls.length, 0, 'no write surface touched')
+  const evidenceStr = JSON.stringify(ok.body.data.evidence)
+  for (const leak of ['M-001', 'SECRET-NAME', 'MX-9', 'col_name', 'FName', 'DROP-ME', 'secret-token', '/K3API']) {
+    assert.ok(!evidenceStr.includes(leak), `evidence must not leak ${leak}`)
+  }
+  const dataStr = JSON.stringify(ok.body.data.data)
+  assert.ok(!dataStr.includes('DROP-ME') && !dataStr.includes('FUnclassified'), 'unmapped raw fields never reach the data plane')
+
+  // approved-only: draft/retired → 409 coarse
+  const draft = await invoke(routes, 'POST', '/api/integration/read-source-configs/:id/read', {
+    user: READ_USER, params: { id: 'rsc_draft' }, body: { inputs: { key: 'M-001' } },
+  })
+  assert.equal(draft.statusCode, 409, 'non-approved config is fail-closed')
+  assert.equal(draft.body.error.code, 'READ_SOURCE_CONFIG_NOT_APPROVED')
+
+  // strict body allowlist: a config (or any extra key) can never ride in from the runtime request
+  const smuggle = await invoke(routes, 'POST', '/api/integration/read-source-configs/:id/read', {
+    user: READ_USER, params: { id: 'rsc_ok' }, body: { inputs: { key: 'M-001' }, config: { readPath: 'https://evil.example.com' } },
+  })
+  assert.equal(smuggle.statusCode, 400, 'extra body keys are fail-closed')
+  assert.ok(!JSON.stringify(smuggle.body).includes('evil.example.com'), 'error is values-free')
+
+  // unauthenticated rejected
+  const anon = await invoke(routes, 'POST', '/api/integration/read-source-configs/:id/read', {
+    params: { id: 'rsc_ok' }, body: { inputs: { key: 'M-001' } },
+  })
+  assert.equal(anon.statusCode, 401, 'unauthenticated caller rejected')
+
+  // approved config whose registered system kind has drifted → 409 fail-closed, no adapter read
+  const readsBefore = readArgs.length
+  const wrongKind = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) { return { id: input.id, kind: 'http' } },
+    },
+    readSourceConfigStore: {
+      async saveVersion() { return {} },
+      async list() { return [] },
+      async get() { return {} },
+      async approve() { return {} },
+      async retire() { return {} },
+      async listAudit() { return [] },
+      async getForRuntime(input) {
+        return { id: input.id, systemId: 'sys_1', object: 'material', mode: 'single_record', version: 3, status: 'approved', config: approvedConfig }
+      },
+    },
+  }).services
+  const { routes: wkRoutes } = mountRoutes(wrongKind)
+  const wk = await invoke(wkRoutes, 'POST', '/api/integration/read-source-configs/:id/read', {
+    user: READ_USER, params: { id: 'rsc_ok' }, body: { inputs: { key: 'M-001' } },
+  })
+  assert.equal(wk.statusCode, 409, 'kind drift is fail-closed')
+  assert.equal(wk.body.error.code, 'READ_SOURCE_READ_KIND_MISMATCH')
+  assert.equal(readArgs.length, readsBefore, 'no outbound read on kind mismatch')
+
+  console.log('  testReadSourceConfiguredReadRoute OK')
+}
+
 async function main() {
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
@@ -6313,6 +6451,7 @@ async function main() {
   await testReadSmokeRoute()
   await testReadSourceProbeRoute()
   await testReadSourceConfigRoutes()
+  await testReadSourceConfiguredReadRoute()
   await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testExternalSystemTestClearsErrorToActiveOnSuccess()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -24,6 +24,7 @@ const ROUTES = [
   ['GET', '/api/integration/read-source-configs/:id/audit', 'readSourceConfigsAudit'],
   ['POST', '/api/integration/read-source-configs/:id/approve', 'readSourceConfigsApprove'],
   ['POST', '/api/integration/read-source-configs/:id/retire', 'readSourceConfigsRetire'],
+  ['POST', '/api/integration/read-source-configs/:id/read', 'readSourceConfigsRead'],
   ['GET', '/api/integration/external-systems/:id/objects', 'externalSystemObjects'],
   ['GET', '/api/integration/external-systems/:id/schema', 'externalSystemSchema'],
   ['GET', '/api/integration/pipelines', 'pipelinesList'],
@@ -106,7 +107,14 @@ const {
   ReadSourceConfigValidationError,
   ReadSourceConfigNotFoundError,
   ReadSourceConfigConflictError,
+  ReadSourceConfigNotApprovedError,
 } = require('./read-source-config-store.cjs')
+// S3-2 (#1709 self-service): runtime-tier configured read — consumes an APPROVED stored config version;
+// data plane (mapped values) flows to the authorized caller, evidence stays values-free.
+const {
+  prepareConfiguredRead,
+  executeConfiguredRead,
+} = require('./read-source-read-runtime.cjs')
 const { K3_REFERENCE_MAPPING_TEMPLATES } = require('./reference-mapping-templates.cjs')
 const { listReferenceIntegrationTemplates } = require('./reference-integration-templates.cjs')
 // DF-T2c: read-only derive route reuses the DF-T2a helper (no duplication; pure compute, no write).
@@ -1474,6 +1482,10 @@ function mapReadSourceConfigError(error) {
   if (error instanceof ReadSourceConfigNotFoundError) {
     return new HttpRouteError(404, 'READ_SOURCE_CONFIG_NOT_FOUND', 'read-source config not found')
   }
+  if (error instanceof ReadSourceConfigNotApprovedError) {
+    // Fail-closed runtime gate: draft/retired versions are not consumable. Coarse status enum only.
+    return new HttpRouteError(409, 'READ_SOURCE_CONFIG_NOT_APPROVED', 'read-source config version is not approved', { status: error.details && error.details.status })
+  }
   if (error instanceof ReadSourceConfigConflictError) {
     return new HttpRouteError(409, 'READ_SOURCE_CONFIG_STATUS_CONFLICT', 'read-source config status transition is not allowed', error.details)
   }
@@ -1499,7 +1511,7 @@ function createHandlers(services, options = {}) {
   const deadLetters = requireService('deadLetterStore', ['listDeadLetters'])
   const stagingInstaller = requireService('stagingInstaller', ['installStaging', 'listStagingDescriptors'])
   const templateRegistry = requireService('templateRegistry', ['upsertTemplate', 'getTemplate', 'listTemplates', 'deleteTemplate', 'instantiateTemplate'])
-  const readSourceConfigs = requireService('readSourceConfigStore', ['saveVersion', 'list', 'get', 'approve', 'retire', 'listAudit'])
+  const readSourceConfigs = requireService('readSourceConfigStore', ['saveVersion', 'list', 'get', 'approve', 'retire', 'listAudit', 'getForRuntime'])
   const context = options.context || {}
   const configuredTableActions = context && context.config
     ? (context.config.stockPreparationTableActions || context.config.tableActions)
@@ -1819,6 +1831,63 @@ function createHandlers(services, options = {}) {
         })))
       } catch (error) {
         throw mapReadSourceConfigError(error)
+      }
+    },
+
+    // S3-2 (#1709 self-service): runtime-tier configured read — the end-user/cleansing tier consumes an
+    // ALREADY-APPROVED read-source config version and supplies ONLY the preset-declared named key input.
+    // No raw endpoint/filter/body/response-path can enter: the stored config is S1-normalized and the
+    // request body is a strict {inputs} allowlist. The data plane (fieldMap-mapped values) flows to the
+    // authorized caller under the S0 two-tier model; evidence stays values-free. requireAccess('read') IS
+    // the designed runtime tier: config-time surfaces (save/approve/probe) stay write-tier, and an
+    // approved preset + key-only body is exactly the end-user surface S0 defines.
+    async readSourceConfigsRead(req, res) {
+      requireAccess(req, 'read')
+      const body = requestBody(req)
+      // Strict body allowlist BEFORE anything else: only { inputs } may ride in from the runtime request.
+      if (body !== undefined && body !== null) {
+        if (typeof body !== 'object' || Array.isArray(body)) {
+          throw new HttpRouteError(400, 'READ_SOURCE_READ_CONTRACT_INVALID', 'configured read request is invalid', { reason: 'not_object' })
+        }
+        const unexpected = Object.keys(body).filter((key) => key !== 'inputs')
+        if (unexpected.length > 0) {
+          throw new HttpRouteError(400, 'READ_SOURCE_READ_CONTRACT_INVALID', 'configured read request is invalid', { reason: 'unexpected_field' })
+        }
+      }
+      let row
+      try {
+        row = await readSourceConfigs.getForRuntime(scopedInput(req, { id: requestParams(req).id }))
+      } catch (error) {
+        throw mapReadSourceConfigError(error)
+      }
+      let prepared
+      try {
+        prepared = prepareConfiguredRead({ config: row.config, inputs: body ? body.inputs : undefined })
+      } catch (error) {
+        // Coarse, values-free reason only (never the stored config, key, or values).
+        throw new HttpRouteError(400, 'READ_SOURCE_READ_CONTRACT_INVALID', 'configured read request is invalid', { reason: error && typeof error.reason === 'string' ? error.reason : 'invalid' })
+      }
+      // Backend credential context via the stored systemId reference — resolution stays dynamic (lock 5).
+      const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
+        ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
+        : externalSystems.getExternalSystem.bind(externalSystems)
+      const system = await loadSystem(scopedInput(req, { id: row.systemId }))
+      if (!system || system.kind !== prepared.plan.requiredKind) {
+        throw new HttpRouteError(409, 'READ_SOURCE_READ_KIND_MISMATCH', 'external system kind does not match the approved config')
+      }
+      try {
+        const { evidence, data } = await executeConfiguredRead(prepared, {
+          system,
+          createAdapter: (adapterSystem) => adapterRegistry.createAdapter(adapterSystem, { principal: requestPrincipal(req) }),
+        })
+        return sendOk(res, { evidence, data })
+      } catch (error) {
+        // Defense-in-depth only: the route pre-checks kind above, so the executor's own kind re-check
+        // (same guard, second layer) is unreachable here unless the runtime module changes.
+        if (error instanceof ReadSourceProbeRuntimeError) {
+          throw new HttpRouteError(409, 'READ_SOURCE_READ_KIND_MISMATCH', 'external system kind does not match the approved config')
+        }
+        throw error
       }
     },
 


### PR DESCRIPTION
## What

外部 API 读取自助化(#1709)**S3-2 切片**:运行层配置驱动读取路由——两层模型(S0)的**运行层面**正式接通,S3-1 执行器(#3473)+ S2-c 存储(#3470)的最后接线。

- `POST /api/integration/read-source-configs/:id/read`,`requireAccess('read')` = S0 设计的终端用户/清洗流档(配置面 save/approve/probe 保持 write 档)
- **approved-only**:经 `getForRuntime`(draft/retired → 409 `READ_SOURCE_CONFIG_NOT_APPROVED` 粗粒度状态);请求体严格 `{inputs}` allowlist——运行请求永远带不进 config/raw 形状(多余键 → 400 values-free)
- 凭证解析走存储的 systemId 引用 + 后端 `getExternalSystemForAdapter` 上下文(锁 5 动态解析);kind 漂移 → 409 且**不发起外呼**(测试锁定)
- 响应 `{evidence, data}`:数据面只含 fieldMap 目标列(未映射原始字段永不出现,泄漏扫描);证据面 values-free(对 key/值/host/字段名/凭证逐一扫描)
- 测试:成功数据面精确断言、draft 409、走私 config 400、401、kind 漂移 409 零外呼、双 harness mock 对齐

## 审查说明

S2-c/S3-1/UI 三个前置 PR 均已过 5/5/3 视角对抗审查并修复确认项。本接线 commit 的 3 视角 workflow 审查因订阅额度触顶未能执行,改为人工对照三个视角完成:tier(租户 scope 姿态与全部 sibling 路由一致)、wiring(错误类均为 Error 平级无 instanceof 遮蔽;防御性 catch 已标注)、test(补路由级 kind-mismatch 用例)。

## 验证

插件全套件 exit 0(rebase 到 ba1a636bd 后)· http-routes / PoC harness 双套通过 · lint/type-check 前次全绿(本次仅 .cjs 与测试文件变化)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)