### PR TITLE
feat(automation): expose safe delete-record editor action

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1864,6 +1864,7 @@ function describeActionType(actionType: AutomationActionType, actionConfig: Reco
     case 'update_record':
     case 'create_record':
     case 'send_webhook':
+    case 'delete_record':
     case 'lock_record':
       return automationCardActionSummary(actionType, '', isZh.value)
     case 'send_dingtalk_group_message':

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -256,7 +256,7 @@
           <div class="meta-rule-editor__section-title">{{ automationLabel('editor.actions', isZh) }} <span class="meta-rule-editor__hint">{{ automationLabel('editor.actionStepHint', isZh) }}</span></div>
           <div
             v-for="(action, idx) in draft.actions"
-            :key="idx"
+            :key="action.draftId"
             class="meta-rule-editor__action-row"
             :data-action-index="idx"
           >
@@ -958,6 +958,22 @@
               </label>
             </div>
 
+            <!-- delete_record config (T0-3): same-base trigger-record only; acknowledgement is UI-only. -->
+            <div v-if="action.type === 'delete_record'" class="meta-rule-editor__action-config" data-action-config="delete_record">
+              <div class="meta-rule-editor__hint meta-rule-editor__hint--warning" data-field="deleteRecordWarning">
+                {{ automationLabel('actionConfig.deleteRecordWarning', isZh) }}
+              </div>
+              <label class="meta-rule-editor__toggle-label">
+                <input
+                  type="checkbox"
+                  data-field="deleteRecordAck"
+                  :checked="isDeleteRecordAcknowledged(action)"
+                  @change="setDeleteRecordAcknowledged(action, ($event.target as HTMLInputElement).checked)"
+                />
+                {{ automationLabel('actionConfig.deleteRecordAck', isZh) }}
+              </label>
+            </div>
+
             <!-- wait_for_callback config (A6-2: info-only, ZERO params — the suspend point; no
                  webhook-URL / timer / manual-task fields. An admin resumes from the runs detail.) -->
             <div v-if="action.type === 'wait_for_callback'" class="meta-rule-editor__action-config" data-action-config="wait_for_callback">
@@ -1117,6 +1133,9 @@
           <div v-if="savedRuleHasDingTalkActions" class="meta-rule-editor__hint meta-rule-editor__hint--warning" data-field="dingtalkTestRunWarning">
             {{ automationLabel('testRun.warning', isZh) }}
           </div>
+          <div v-if="hasDeleteRecordAction" class="meta-rule-editor__hint meta-rule-editor__hint--warning" data-field="deleteRecordTestRunHint">
+            {{ automationLabel('actionConfig.deleteRecordTestRunHint', isZh) }}
+          </div>
           <div v-if="!props.rule?.id" class="meta-rule-editor__hint" data-field="testRunUnsavedHint">
             {{ automationLabel('testRun.unsavedHint', isZh) }}
           </div>
@@ -1269,8 +1288,10 @@ type DraftActionConfig = Record<string, unknown> & {
 }
 
 interface DraftAction {
+  draftId: string
   type: AutomationActionType
   config: DraftActionConfig
+  persisted?: boolean
 }
 
 interface Draft {
@@ -1345,6 +1366,9 @@ const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
   'send_email',
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
+  // T0-3: expose only the safe authoring shape — same-base trigger-record delete, config: {}.
+  // Cross-base delete remains backend/runtime-only and is not surfaced in this editor.
+  'delete_record',
   'wait_for_callback',
   'condition_branch',
   'parallel_branch',
@@ -1778,9 +1802,19 @@ function emptyDraft(): Draft {
     triggerType: 'record.created',
     triggerConfig: {},
     conditions: { conjunction: 'AND', conditions: [] },
-    actions: [{ type: 'update_record', config: defaultConfigForActionType('update_record') }],
+    actions: [createDraftAction('update_record')],
     executionMode: null,
   }
+}
+
+let draftActionIdSequence = 0
+function createDraftAction(
+  type: AutomationActionType,
+  config: DraftActionConfig = defaultConfigForActionType(type),
+  persisted = false,
+): DraftAction {
+  draftActionIdSequence += 1
+  return { draftId: `draft-action-${draftActionIdSequence}`, type, config, persisted }
 }
 
 function draftConfigFromAction(type: AutomationActionType, config: Record<string, unknown>): DraftActionConfig {
@@ -1909,13 +1943,14 @@ function draftFromRule(rule: AutomationRule): Draft {
     triggerConfig: { ...rule.triggerConfig, ...(rule.trigger?.config ?? {}) },
     conditions: conditionGroupFromRule(rule.conditions),
     actions: rule.actions && rule.actions.length
-      ? rule.actions.map((a) => ({ type: a.type, config: draftConfigFromAction(a.type, a.config) }))
-      : [{ type: rule.actionType, config: draftConfigFromAction(rule.actionType, rule.actionConfig) }],
+      ? rule.actions.map((a) => createDraftAction(a.type, draftConfigFromAction(a.type, a.config), true))
+      : [createDraftAction(rule.actionType, draftConfigFromAction(rule.actionType, rule.actionConfig), true)],
     executionMode: rule.executionMode ?? null,
   }
 }
 
 const draft = ref<Draft>(emptyDraft())
+const deleteRecordAcknowledgements = ref<Record<string, boolean>>({})
 const conditionEditorEntries = computed(() => collectConditionEditorEntries(draft.value.conditions.conditions))
 
 // A6-2b/A6-3-2a/A6-3-4 + start_approval (W6-1): wait_for_callback, condition_branch, parallel_branch, AND
@@ -1928,6 +1963,7 @@ const JOB_MODE_REQUIRING_ACTION_TYPES: AutomationActionType[] = ['wait_for_callb
 const requiresJobMode = computed(() =>
   draft.value.actions.some((a) => JOB_MODE_REQUIRING_ACTION_TYPES.includes(a.type)),
 )
+const hasDeleteRecordAction = computed(() => draft.value.actions.some((a) => a.type === 'delete_record'))
 
 // A6-3-2a: empty drafts for a fresh condition_branch action.
 function createEmptyBranchActionDraft(): BranchActionDraft {
@@ -2137,6 +2173,7 @@ watch(
   async (v) => {
     if (v) {
       draft.value = props.rule ? draftFromRule(props.rule) : emptyDraft()
+      resetDeleteRecordAcknowledgements()
       error.value = ''
       saving.value = false
       dingTalkDestinationsError.value = ''
@@ -2165,6 +2202,25 @@ watch(
   },
   { immediate: true },
 )
+
+function resetDeleteRecordAcknowledgements(): void {
+  const next: Record<string, boolean> = {}
+  for (const action of draft.value.actions) {
+    if (action.type === 'delete_record') next[action.draftId] = action.persisted === true
+  }
+  deleteRecordAcknowledgements.value = next
+}
+
+function isDeleteRecordAcknowledged(action: DraftAction): boolean {
+  return deleteRecordAcknowledgements.value[action.draftId] === true
+}
+
+function setDeleteRecordAcknowledged(action: DraftAction, checked: boolean): void {
+  deleteRecordAcknowledgements.value = {
+    ...deleteRecordAcknowledgements.value,
+    [action.draftId]: checked,
+  }
+}
 
 const canSave = computed(() => {
   if (!draft.value.name.trim()) return false
@@ -2202,6 +2258,7 @@ const canSave = computed(() => {
       const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
       if (!recipients.length || !subjectTemplate || !bodyTemplate) return false
     }
+    if (action.type === 'delete_record' && !isDeleteRecordAcknowledged(action)) return false
   }
   return true
 })
@@ -2231,7 +2288,7 @@ function removeConditionNode(path: ConditionPath) {
 
 function addAction() {
   if (draft.value.actions.length >= 3) return
-  draft.value.actions.push({ type: 'update_record', config: defaultConfigForActionType('update_record') })
+  draft.value.actions.push(createDraftAction('update_record'))
 }
 
 function parseUserIdsText(value: unknown): string[] {
@@ -2811,6 +2868,8 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
         publicFormViewId: '',
         internalViewId: '',
       }
+    case 'delete_record':
+      return {}
     case 'lock_record':
       return { locked: true }
     case 'wait_for_callback':
@@ -2822,11 +2881,24 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
 
 function onDraftActionTypeChange(action: DraftAction) {
   action.config = defaultConfigForActionType(action.type)
+  action.persisted = false
+  if (action.type === 'delete_record') {
+    setDeleteRecordAcknowledged(action, false)
+  } else if (deleteRecordAcknowledgements.value[action.draftId] !== undefined) {
+    const next = { ...deleteRecordAcknowledgements.value }
+    delete next[action.draftId]
+    deleteRecordAcknowledgements.value = next
+  }
   if (JOB_MODE_REQUIRING_ACTION_TYPES.includes(action.type)) draft.value.executionMode = 'workflow_job_v1'
 }
 
 function removeAction(idx: number) {
-  draft.value.actions.splice(idx, 1)
+  const [removed] = draft.value.actions.splice(idx, 1)
+  if (removed?.draftId && deleteRecordAcknowledgements.value[removed.draftId] !== undefined) {
+    const next = { ...deleteRecordAcknowledgements.value }
+    delete next[removed.draftId]
+    deleteRecordAcknowledgements.value = next
+  }
 }
 
 function moveAction(idx: number, dir: number) {
@@ -2935,6 +3007,9 @@ function buildPayload(): Partial<AutomationRule> {
           fields: fieldPairsToRecord(action.config.fieldUpdates),
         },
       }
+    }
+    if (action.type === 'delete_record') {
+      return { type: action.type, config: {} }
     }
     if (action.type === 'start_approval') {
       // Assemble the {key: value} formDataMapping the backend requires from the editable rows. templateId +

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -1012,6 +1012,7 @@ export type AutomationActionType =
   | 'send_email'
   | 'send_dingtalk_group_message'
   | 'send_dingtalk_person_message'
+  | 'delete_record'
   | 'lock_record'
   | 'wait_for_callback'
   | 'condition_branch'

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -128,6 +128,9 @@ export type AutomationLabelKey =
   | 'actionConfig.emailSubjectPlaceholder'
   | 'actionConfig.bodyTemplate'
   | 'actionConfig.emailBodyPlaceholder'
+  | 'actionConfig.deleteRecordWarning'
+  | 'actionConfig.deleteRecordAck'
+  | 'actionConfig.deleteRecordTestRunHint'
   | 'actionConfig.lockRecord'
   | 'actionConfig.waitForCallbackHint'
   | 'conditionBranch.readOnly'
@@ -666,6 +669,18 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'conditionBranch.addBranch': { en: '+ Branch', zh: '+ 分支' },
   'conditionBranch.default': { en: 'Default branch (no condition)', zh: '默认分支（无条件）' },
   'conditionBranch.addDefault': { en: '+ Default branch', zh: '+ 默认分支' },
+  'actionConfig.deleteRecordWarning': {
+    en: 'Deletes the trigger record in this table. This is permanent and cannot be undone.',
+    zh: '将删除本表中的触发记录。该操作是永久性的，无法撤销。',
+  },
+  'actionConfig.deleteRecordAck': {
+    en: 'I understand this permanently deletes the trigger record.',
+    zh: '我确认此动作会永久删除触发记录。',
+  },
+  'actionConfig.deleteRecordTestRunHint': {
+    en: 'Test Run uses a synthetic record and will not delete a real record.',
+    zh: '测试运行使用合成记录，不会删除真实记录。',
+  },
   'parallelBranch.readOnly': {
     en: 'This parallel branch rule uses constructs not editable in this version — read-only (save is disabled to avoid flattening it).',
     zh: '该并行分支规则包含本版本不可编辑的结构 —— 只读（已禁用保存以避免压扁丢失）。',
@@ -879,6 +894,8 @@ export function automationActionTypeLabel(type: AutomationActionType | UnknownAu
       return isZh ? '发送钉钉群消息' : 'Send DingTalk group message'
     case 'send_dingtalk_person_message':
       return isZh ? '发送钉钉个人消息' : 'Send DingTalk person message'
+    case 'delete_record':
+      return isZh ? '删除记录' : 'Delete record'
     case 'lock_record':
       return isZh ? '锁定记录' : 'Lock record'
     case 'wait_for_callback':

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -58,9 +58,20 @@ describe('meta-automation-labels', () => {
     expect(automationActionTypeLabel('send_dingtalk_group_message', true)).toBe('发送钉钉群消息')
     expect(automationActionTypeLabel('parallel_branch', false)).toBe('Parallel branch')
     expect(automationActionTypeLabel('parallel_branch', true)).toBe('并行分支')
+    expect(automationActionTypeLabel('delete_record', false)).toBe('Delete record')
+    expect(automationActionTypeLabel('delete_record', true)).toBe('删除记录')
     expect(automationActionTypeLabel('notify', true)).toBe('发送通知')
     expect(automationActionTypeLabel('update_field', true)).toBe('更新字段值')
     expect(automationActionTypeLabel('future_action', true)).toBe('future_action')
+  })
+
+  it('localizes destructive delete_record authoring warnings', () => {
+    expect(automationLabel('actionConfig.deleteRecordWarning', false)).toContain('permanent')
+    expect(automationLabel('actionConfig.deleteRecordAck', false)).toContain('permanently deletes')
+    expect(automationLabel('actionConfig.deleteRecordTestRunHint', false)).toContain('will not delete a real record')
+    expect(automationLabel('actionConfig.deleteRecordWarning', true)).toContain('永久')
+    expect(automationLabel('actionConfig.deleteRecordAck', true)).toContain('永久删除')
+    expect(automationLabel('actionConfig.deleteRecordTestRunHint', true)).toContain('不会删除真实记录')
   })
 
   it('explains required WorkflowJob mode for wait and branch actions', () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -333,6 +333,76 @@ describe('MetaAutomationRuleEditor', () => {
     expect(lockOption?.disabled).toBe(false)
   })
 
+  it('offers delete_record as a first-class action but requires an explicit destructive acknowledgement', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    ;(container.querySelector('[data-field="name"]') as HTMLInputElement).value = 'Delete trigger record'
+    ;(container.querySelector('[data-field="name"]') as HTMLInputElement).dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    const deleteOption = Array.from(actionSelect.options).find((option) => option.value === 'delete_record')
+    expect(deleteOption).toBeTruthy()
+    expect(deleteOption?.disabled).toBe(false)
+
+    actionSelect.value = 'delete_record'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.querySelector('[data-action-config="delete_record"]')).toBeTruthy()
+    expect(container.querySelector('[data-field="deleteRecordTestRunHint"]')?.textContent)
+      .toContain('will not delete a real record')
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    expect(saved).not.toHaveBeenCalled()
+
+    const ack = container.querySelector('[data-field="deleteRecordAck"]') as HTMLInputElement
+    expect(ack.checked).toBe(false)
+    ack.checked = true
+    ack.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].actions).toEqual([{ type: 'delete_record', config: {} }])
+    expect(saved.mock.calls[0][0].actionConfig).toEqual({})
+  })
+
+  it('pre-checks the destructive acknowledgement for an existing delete_record rule and preserves empty config', async () => {
+    const saved = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      rule: fakeRule({
+        name: 'Existing delete',
+        actionType: 'delete_record',
+        actionConfig: {},
+        actions: [{ type: 'delete_record', config: {} }],
+      }),
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    const ack = container.querySelector('[data-field="deleteRecordAck"]') as HTMLInputElement
+    expect(actionSelect.value).toBe('delete_record')
+    expect(ack.checked).toBe(true)
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].actions).toEqual([{ type: 'delete_record', config: {} }])
+    expect(saved.mock.calls[0][0].actions[0].config).not.toHaveProperty('deleteRecordAck')
+    expect(saved.mock.calls[0][0].actions[0].config).not.toHaveProperty('targetBaseId')
+  })
+
   it('keeps existing lock_record actions selectable and enabled', async () => {
     const { container } = mount({
       visible: true,

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -323,19 +323,20 @@ function resultWritebackFieldTypeError(
  * ADDRESSING SHAPE only — the actual base-write AUTHORITY + claim==truth are re-checked per run in the
  * executor write-gate (`evaluateCrossBaseWrite`). When a record-mutating action declares a non-empty
  * `targetBaseId` (opting into cross-base):
- *  - `update_record` MUST also carry a non-empty `targetSheetId` AND `targetRecordId` (the trigger
- *    record is not in the target base, so the update has no record to address otherwise — §2.4).
+ *  - `update_record` / `delete_record` / `lock_record` MUST also carry a non-empty `targetSheetId`
+ *    AND `targetRecordId` (the trigger record is not in the target base, so the mutation has no
+ *    record to address otherwise — §2.4).
  *  - `create_record` needs nothing more (its `sheetId` is the target sheet).
  * A malformed cross-base config → rejected at save. (Same-base actions — no `targetBaseId` — pass.)
  */
 function validateCrossBaseWriteConfig(config: Record<string, unknown>, actionType: string, path: string): string | null {
-  if (actionType !== 'update_record') return null
+  if (!['update_record', 'delete_record', 'lock_record'].includes(actionType)) return null
   const targetBaseId = typeof config.targetBaseId === 'string' ? config.targetBaseId.trim() : ''
   if (!targetBaseId) return null // same-base (or no opt-in) — nothing to validate
   const targetSheetId = typeof config.targetSheetId === 'string' ? config.targetSheetId.trim() : ''
   const targetRecordId = typeof config.targetRecordId === 'string' ? config.targetRecordId.trim() : ''
   if (!targetSheetId || !targetRecordId) {
-    return `${path}: cross-base update_record requires targetSheetId and targetRecordId when targetBaseId is set`
+    return `${path}: cross-base ${actionType} requires targetSheetId and targetRecordId when targetBaseId is set`
   }
   return null
 }

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2636,6 +2636,26 @@ describe('AutomationService — Rule CRUD', () => {
     })).rejects.toThrow(/resultWriteback\.onNonApproved must be a boolean/)
   })
 
+  it('T0-3: createRule rejects malformed cross-base delete_record and lock_record target triples', async () => {
+    await expect(service.createRule('sheet_1', {
+      name: 'Half-addressed delete', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'delete_record',
+      actionConfig: { targetBaseId: 'base_b', targetSheetId: 'sheet_b' },
+      actions: [{ type: 'delete_record', config: { targetBaseId: 'base_b', targetSheetId: 'sheet_b' } }],
+      createdBy: 'user_1',
+    })).rejects.toThrow(/actionConfig: cross-base delete_record requires targetSheetId and targetRecordId/)
+
+    await expect(service.createRule('sheet_1', {
+      name: 'Half-addressed lock', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'update_record',
+      actionConfig: { fields: { status: 'ok' } },
+      actions: [{ type: 'lock_record', config: { locked: true, targetBaseId: 'base_b', targetRecordId: 'rec_b' } }],
+      createdBy: 'user_1',
+    })).rejects.toThrow(/actions\[0\]\.config: cross-base lock_record requires targetSheetId and targetRecordId/)
+
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
   it('A6-3-1: createRule accepts condition_branch only with workflow_job_v1', async () => {
     const action = {
       type: 'condition_branch',
@@ -3245,6 +3265,23 @@ describe('AutomationService — Rule CRUD', () => {
     const promise = service.updateRule('atr_1', 'sheet_1', { executionMode: null })
 
     await expect(promise).rejects.toThrow('condition_branch/start_approval/parallel_branch requires execution_mode workflow_job_v1')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('T0-3: updateRule rejects merged malformed cross-base delete_record config before update', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'update_record',
+      action_config: { fields: { status: 'before' } },
+      actions: [{ type: 'update_record', config: { fields: { status: 'before' } } }],
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', {
+      actionType: 'delete_record',
+      actionConfig: { targetBaseId: 'base_b', targetSheetId: 'sheet_b' },
+      actions: [{ type: 'delete_record', config: { targetBaseId: 'base_b', targetSheetId: 'sheet_b' } }],
+    })
+
+    await expect(promise).rejects.toThrow(/actionConfig: cross-base delete_record requires targetSheetId and targetRecordId/)
     expect(dbExecuteResults).toHaveLength(0)
   })
 


### PR DESCRIPTION
## Summary

T0-3 exposes the existing `delete_record` automation action in the rule editor, but only in the safe v1 authoring shape:

- UI can select `delete_record` as a first-class action.
- New/changed delete actions require an explicit destructive acknowledgement before Save.
- Existing saved `delete_record` rules load with the acknowledgement pre-checked so an unedited save is not wedged.
- Saved payload is always `{ type: 'delete_record', config: {} }`; the acknowledgement is UI-only and no cross-base target fields are surfaced.
- Test Run shows a non-blocking hint that it uses a synthetic record and will not delete a real record.

Backend save validation is also tightened: malformed cross-base target triples now fail closed for `delete_record` and `lock_record`, matching the runtime gate instead of allowing a rule that only fails later.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false` → 213/213
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/meta-automation-labels.spec.ts tests/multitable-automation-manager.spec.ts --watch=false` → 198/198
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm lint`
- targeted ESLint over the modified rule-editor/type/label/test files
- `git diff --check`

## Notes

No runtime delete semantics changed. Cross-base `delete_record` remains backend/runtime-only and is not exposed by the editor in this slice.
