### PR TITLE
docs(automation): close first-batch approval automation ledger

### DIFF
--- a/docs/development/approval-automation-cycle-completion-and-verification-20260630.md
+++ b/docs/development/approval-automation-cycle-completion-and-verification-20260630.md
@@ -3,10 +3,16 @@
 > A code-grounded re-audit of the line against the approval-line baseline `f14be042e` (origin/main may have
 > advanced with unrelated commits since — that does not affect these conclusions), the decision-clean work
 > completed this cycle (with verification), one newly-found latent defect surfaced for a decision, and the
-> remaining backlog with a recommended GO order. **Honest headline:** the *ratified-buildable* feature set is
-> exhausted — every remaining rung is owner-gated by an open security/permission/destructive/product/migration
+> remaining backlog with a recommended GO order. **Historical headline at that baseline:** the *ratified-buildable*
+> feature set was exhausted — every then-remaining rung was owner-gated by an open security/permission/destructive/product/migration
 > decision (re-confirmed against code, not just docs). So this cycle completes the **decision-clean hardenings**
 > (which need no owner decision) and teees up the gated rungs for a one-word GO.
+>
+> **As-built update after follow-on rungs shipped.** This 2026-06-30 audit is historical for its cycle, but the
+> open items it surfaced have since moved: T2-4 re-entry quorum bypass shipped in `#3446` (+ cascade regression
+> lock `#3453`), R1 default-closed egress containment shipped through `#3437`/`#3443`/`#3447`/`#3451`, T2-6
+> shipped in `#3450`, and the first-batch runtime shipped in `#3467`/`#3468`/`#3474`/`#3477`. The current queue
+> is the later lane plan, not the original 13-rung list below.
 
 ## 1. Where the line stands (code-verified, not doc-trusted)
 
@@ -24,9 +30,10 @@ A 4-reader audit verified each capability against the actual code (greps + file:
 | T0-2 W7 resultWriteback **backend** | #3384 | approved-path backwrite + `statusField/approverField/completedAtField` validation (automation-service.ts) |
 | R2 redaction (public path) / R3 editor | #3382 | bridge `redactHiddenFormFields`; `webhook.received` removed from the editor selectable set |
 
-**Partial-by-design / latent (verified):** T1-1 slice-2 (transfer/jump/auto_* still publish-rejected); R2 is a
-*latent* gap — `toUnifiedApprovalDTO` returns `form_snapshot` verbatim, redaction lives only on the public
-bridge path; `webhook.received` remains a runtime-inert trigger enum entry (kept until T1-2).
+**Partial-by-design / latent at the time (verified then, updated now):** T1-1 slice-2 transfer/jump has since
+shipped (`#3468`) while `auto_approve`/`auto_reject` remain env-gated/inert terminal effects. R2 was a *latent*
+gap — `toUnifiedApprovalDTO` returns `form_snapshot` verbatim, redaction lives only on the public bridge path;
+`webhook.received` remains a runtime-inert trigger enum entry (kept until T1-2).
 
 ## 2. Completed this cycle (decision-clean — no owner decision required)
 
@@ -47,7 +54,7 @@ All three are pure correctness/robustness on shipped code, built + verified, mer
 
 **Cycle verification total:** tsc 0 · 39 date-reminder unit · 16 approval-metrics unit · 19 + 3 real-DB green.
 
-## 3. Newly-found latent defect — surfaced for a decision (NOT auto-fixed)
+## 3. Newly-found latent defect — later fixed
 
 **T2-4 threshold re-entry quorum bypass** *(reachability self-verified, not reader-trusted).* The threshold
 tally `COUNT(DISTINCT actor_id) … WHERE instance_id=$1 AND action='approve' AND metadata->>'nodeKey'=$2`
@@ -59,35 +66,35 @@ then someone 退回s back to it, is re-satisfied by a **single** fresh approval 
 reads `priorDistinct(A,B)=2 + 1`). *(Admin-jump can't trigger this — `isReachableDownstream` only goes
 forward; the return path is the reachable vector.)* A quorum bypass in a voting mechanism — security-relevant.
 
-This is **owner-gated** because the fix is a vote-scoping *semantic* choice, not a one-liner. **Proposed
-default:** scope the tally to approvals at/after the node's latest activation (`node_breakdown[].activatedAt`
-is already recorded), and reconcile with add-sign/reduce-sign. I can land it as a fail-first real-DB test
-(RED on current code) + the fix in one PR on your GO. *(Analogous to the date-field P2 you caught — a real
-bug found by review, held for a ratified fix rather than guessed.)*
+**As-built:** fixed in `#3446` by scoping the tally to the current node-entry round with
+`to_version >= <re-entry cutoff>`; `#3453` added the same-version cascade regression lock that preserves the
+required `>=` boundary. The earlier proposed `node_breakdown[].activatedAt` direction was not what shipped.
 
-## 4. The remaining backlog is entirely owner-gated — recommended GO order
+## 4. Original recommended GO order — superseded by later shipped slices
 
-All 13 un-shipped rungs were re-validated against code: each still carries a live open decision (none entered
-the ratify→ship pipeline). Recommended order for your next GO, each one design-lock-first:
+At the time, all 13 un-shipped rungs were re-validated against code. Several have since shipped; the list below
+is retained as historical decision context, not current queue state.
 
-1. **R1 — BPMN governance + SSRF containment** *(LIVE EXPOSURE — do first).* `/api/workflow` is mounted
+1. ~~**R1 — BPMN governance + SSRF containment** *(LIVE EXPOSURE — do first).* `/api/workflow` is mounted
    `authenticate`-only (no RBAC) and `BPMNWorkflowEngine` runs a process-supplied `fetch()` (authenticated
-   SSRF). This is an exposure, not a feature gap. **Recommend GO #1.**
-2. **T0-3 — expose `delete_record` in the editor** *(cheapest, S).* Executor exists; needs confirm + permission
-   + anti-misdelete + same-base-only + the `validateCrossBaseWriteConfig` delete/lock extension.
-3. **T2-6 — event-driven dedup ledger** *(substrate).* `record.*`/`form.submitted` rules re-run side effects on
-   redelivery; this is the idempotency substrate several later rungs lean on. Do just before T1-3.
-4. **T1-3 — `approval.*` automation trigger** *(unblocks the most).* Exposes the completion event as a
-   first-class rule trigger; carries the routing-key / templateId-null / loop-depth / cross-tenant decisions.
-5. **T1-1 slice-2 — transfer/jump timeout effects** — the transfer + direct-jump core is decision-clean against
+   SSRF). This is an exposure, not a feature gap.~~ **Shipped default-closed** through `#3437`/`#3443`/`#3447`/`#3451`;
+   live destination authorization remains governance-only.
+2. ~~**T0-3 — expose `delete_record` in the editor** *(cheapest, S).* Executor exists; needs confirm + permission
+   + anti-misdelete + same-base-only + the `validateCrossBaseWriteConfig` delete/lock extension.~~ **Shipped `#3477`.**
+3. ~~**T2-6 — event-driven dedup ledger** *(substrate).* `record.*`/`form.submitted` rules re-run side effects on
+   redelivery; this is the idempotency substrate several later rungs lean on. Do just before T1-3.~~ **Shipped `#3450`.**
+4. ~~**T1-3 — `approval.*` automation trigger** *(unblocks the most).* Exposes the completion event as a
+   first-class rule trigger; carries the routing-key / templateId-null / loop-depth / cross-tenant decisions.~~
+   **Shipped `#3467`.**
+5. ~~**T1-1 slice-2 — transfer/jump timeout effects** — the transfer + direct-jump core is decision-clean against
    the ratified T1-1 defaults (config `transferToUserId`/`jumpToNodeKey`, actor `system:approval-timeout`,
    `metadata.timeoutEffect`, reuse `buildTransferAssignments`/`resolveReturnToNode`; parallel-region already
    rejected; direct jump-to-terminal already blocked). **One open carve-out:** an *indirect* jump to an
    approval node that then auto-completes (e.g. `mergeWithRequester`) cascades to terminal — effectively a
    timeout auto-approve. Proposed default: treat that cascade as a terminal effect → keep it behind the same
-   `auto_approve`/`auto_reject` env gate. Design-lock that carve-out, then it's GO-ready.
+   `auto_approve`/`auto_reject` env gate.~~ **Transfer/jump shipped `#3468`; terminal auto_* remains gated.**
 6. Then **T1-4** (node field-perms authoring + readonly/editable runtime; dep: edit-form-at-node) ·
-   **T3-4** (W7 rejection backwrite; product call: write-then-fail vs write-then-continue) ·
+   ~~**T3-4** (W7 rejection backwrite; product call: write-then-fail vs write-then-continue)~~ **shipped `#3474`** ·
    **T3-5** (W7 cross-base; security arc through the cross-base write gate) ·
    **T1-2** (inbound webhook; signature/replay/audit contract) ·
    **T2-1+2** (scoped admins + handover; permission model + migration) ·

--- a/docs/development/approval-automation-decision-register-20260629.md
+++ b/docs/development/approval-automation-decision-register-20260629.md
@@ -1,28 +1,33 @@
 # Approval & Process-Automation — decision register (2026-06-29)
 
-> The **actionable gate** to completing the dev-plan (#3379). A code-grounded design-lock workflow
-> authored + adversarially reviewed all 17 heavy/decision rungs; **every one came back owner-gated**
+> The **original actionable gate** to completing the dev-plan (#3379). In the 2026-06-29 pass, a code-grounded
+> design-lock workflow authored + adversarially reviewed all 17 heavy/decision rungs; **every one came back owner-gated**
 > (zero decision-clean), surfacing the open product/security/migration decisions below — each with a
 > **proposed default**. To unblock a rung: approve its defaults (or override), then it can be built
 > design-lock-first. Full design-lock sections: `approval-automation-design-lock-pack-20260629.md`.
 > Three rungs (T1-3, T2-4, T3-6) carry an anchor caveat — verify cited code before building.
+>
+> **As-built update:** this register is the original decision record, not the current open queue. Several rows
+> have since been ratified and shipped: R1 default-closed egress containment (`#3437`/`#3443`/`#3447`/`#3451`),
+> T2-6 (`#3450`), T1-3 (`#3467`), T1-1 slice-2 transfer/jump (`#3468`), T3-4 (`#3474`), and T0-3 (`#3477`).
+> Remaining owner-gated rows still use this register as their decision source.
 
 ## Classification
 
 | Rung | Title | Size | Open decisions | Anchors confirmed |
 |---|---|---|---|---|
-| T0-3 | Expose delete_record in the rule editor (safely) | S | 7 | yes |
-| T1-1 | Node-level SLA + timeout actions | M | 8 | yes |
+| T0-3 | Expose delete_record in the rule editor (safely) | S | 0 — shipped #3477 | yes |
+| T1-1 | Node-level SLA + timeout actions | M | slice-1/slice-2 shipped; terminal auto_* still gated | yes |
 | T1-2 | Inbound webhook endpoint (signed, audited) | M | 9 | yes |
-| T1-3 | approval.* automation trigger | M | 8 | ⚠️ partial |
+| T1-3 | approval.* automation trigger | M | 0 — shipped #3467 | ⚠️ partial, then verified in build |
 | T1-4 | Node field-permissions readonly/editable + authoring UI | M | 4 | yes |
 | T2-1+2 | Scoped approval administrators + handover (bulk reassign) | L | 10 | yes |
 | T2-3 | Person/team process analytics | M | 8 | yes |
-| T2-4 | N-of-M threshold voting node mode | M | 8 | ⚠️ partial |
+| T2-4 | N-of-M threshold voting node mode | M | 0 — shipped + re-entry fix #3406/#3446 | ⚠️ partial, then verified in build |
 | T2-5 | Timezone-aware scheduling | M | 7 | yes |
-| T2-6 | Event-driven dedup ledger | M | 8 | yes |
-| R1 | BPMN runtime governance + SSRF containment | M | 7 | yes |
-| T3-4 | W7 rejection backwrite | M | 6 | yes |
+| T2-6 | Event-driven dedup ledger | M | 0 — shipped #3450 | yes |
+| R1 | BPMN runtime governance + SSRF containment | M | default-closed runtime shipped; destination authorization remains governance-only | yes |
+| T3-4 | W7 rejection backwrite | M | 0 — shipped #3474 | yes |
 | T3-5 | W7 cross-base backwrite | L | 5 | yes |
 | T3-2 | Business/work-day calendar wired to approval SLA | L | 10 | yes |
 | T3-3 | Handwritten signature / compliance | M | 9 | yes |
@@ -385,4 +390,3 @@
   - **proposed default:** Project ALL terminal outcomes into the neutral read-model (rejected/revoked/cancelled included). Leave the legacy W7 source-record write-back approved-only until the separate #3 product decision lands.
 - **Q10.** Base placement / multi-tenancy: which base owns the managed approval-object sheet — one global system sheet, one per template family, or per source base? Is cross-base projection in or out?
   - **proposed default:** One system-owned base/sheet per template family, provisioned lazily on first projection. Cross-base projection is a non-goal for this rung.
-

--- a/docs/development/approval-automation-design-lock-pack-20260629.md
+++ b/docs/development/approval-automation-design-lock-pack-20260629.md
@@ -6,6 +6,13 @@
 > register (`approval-automation-decision-register-20260629.md`) for the open decisions + proposed
 > defaults that unblock it. Anchor caveat: T1-3 / T2-4 / T3-6 had cited anchors the reviewer could not
 > fully confirm — verify against code before implementing.
+>
+> **As-built update:** this pack remains the historical design-lock source. Some sections are now shipped
+> implementations rather than open proposals: R1 default-closed egress containment, T2-6 dedup, T1-3
+> approval.completed trigger, T1-1 slice-2 transfer/jump, T3-4 non-approved W7 writeback, and T0-3
+> delete_record editor exposure. The shipped status and current queue are summarized in
+> `approval-automation-parallel-development-plan-20260701.md` and
+> `approval-automation-first-batch-ballot-20260701.md`.
 
 ---
 
@@ -1334,4 +1341,3 @@ GO and only after D1–D10 are answered. Brand-neutral: states MetaSheet capabil
 benchmarked internally, no external product names in the contract.
 
 ---
-

--- a/docs/development/approval-automation-dev-plan-todo-20260629.md
+++ b/docs/development/approval-automation-dev-plan-todo-20260629.md
@@ -10,11 +10,18 @@
 > approved before any runtime/UI code). Status markers:
 > **🔒** gated — needs an explicit owner GO · **⬜** GO'd, not started · **🟡** in progress / partial · **✅** shipped.
 > Sizes: **S** ≈ ≤1–2 PRs contained · **M** ≈ a small arc · **L** ≈ a multi-PR arc with its own design-lock.
+>
+> **Historical snapshot notice (updated after first-batch runtime landed).** This 2026-06-29 TODO is retained as
+> the original ladder, not the current queue. Current as-built status moved forward through R1 default-closed
+> egress containment, T2-6 dedup, T1-3 approval.completed trigger, T1-1 slice-2 timeout transfer/jump, T3-4
+> non-approved W7 writeback, and T0-3 delete_record editor exposure. For the current queue and lane ordering,
+> use `docs/development/approval-automation-parallel-development-plan-20260701.md`; for the first-batch
+> decisions, use `docs/development/approval-automation-first-batch-ballot-20260701.md`.
 
-## Where we are (one line)
-Core is **done**: baseline 9/9, P1 3✅+1🟡, automation engine mature (8/9 triggers live, 12+2 actions,
+## Historical "where we were" snapshot (one line)
+At the time, core was **done**: baseline 9/9, P1 3✅+1🟡, automation engine mature (8/9 triggers live, 12+2 actions,
 full scheduler/jobs/suspend-resume/conditions/retry/depth/idempotency), W6 + W7 approved-path shipped.
-Frontier = P2 (0✅/3🟡/3⬜), P3 (1✅/2🟡/2⬜), the S-band, a short parity list, and a risk-triage track.
+Frontier then = P2 (0✅/3🟡/3⬜), P3 (1✅/2🟡/2⬜), the S-band, a short parity list, and a risk-triage track.
 
 ---
 
@@ -46,25 +53,23 @@ These are not "build-next" features — they are exposures/decisions the audit s
 
 - [ ] **🔒 T0-1 — W6 deployed operator sign-off.** Owner decision on PR #3373: accept the in-process seam
   as ship evidence, or require the deployed staging smoke first. **No dev** — a governance close-out.
-- [ ] **🔒 T0-2 — W7 `resultWriteback` UI implementation.** The design-lock (#3375) is **merged**; implement
+- [x] **✅ T0-2 — W7 `resultWriteback` UI implementation.** Shipped after this snapshot; the design-lock (#3375) drove
   per it: three optional source-field pickers writing the backend config keys `statusField` /
   `approverField` / `completedAtField` (UI labels are separate), omit-when-empty, **preserve the current
   configured value in each picker** (P2 fix), explicit-carry in `buildActionPayload` (+ pass `requester`
-  through), two fail-first round-trip tests. **Size S–M · design-lock done → ready on GO.**
-- [ ] **🔒 T0-3 — Expose `delete_record` in the rule editor.** Full guarded executor support exists but it
-  is backend-only. Add to the selectable set behind confirm + permission + anti-misdelete. **Size S.**
+  through), two fail-first round-trip tests.
+- [x] **✅ T0-3 — Expose `delete_record` in the rule editor.** Shipped as first-batch runtime (#3477):
+  same-base trigger-record only, acknowledgement-gated editor, save-gate hardening.
 
 ## Track 1 — High-frequency parity (contained)
 
-- [ ] **🔒 T1-1 — Node-level SLA + timeout actions.** Per-node timeout with a defined effect set
-  (remind / transfer / jump / auto-approve / auto-reject). Today SLA is template-level + remind only.
-  **Highest parity value, no hard deps — recommended first feature arc after the finish-lines.**
-  **Size M · design-lock-first** (timeout-effect + invalidation semantics).
+- [x] **✅ T1-1 — Node-level SLA + timeout actions.** Slice-1 remind and slice-2 transfer/jump are shipped
+  (#3404/#3468). `auto_approve`/`auto_reject` remain env-gated/inert terminal effects, and business-calendar
+  SLA is still a separate gated rung.
 - [ ] **🔒 T1-2 — Inbound webhook endpoint** (signed, audited) — makes `webhook.received` real (closes R3).
   **Size M · design-lock-first** (signature + trigger-audit contract).
-- [ ] **🔒 T1-3 — `approval.*` automation trigger.** "On approval terminal (approved/rejected/…) → run an
-  automation rule." The completion event already drives W6 resume; this exposes it as a first-class rule
-  trigger. **Size M · design-lock-first** (trigger contract + loop/depth guard).
+- [x] **✅ T1-3 — `approval.*` automation trigger.** Shipped as `approval.completed` first-class trigger
+  (#3467): template-routed, record-less v1, T2-6 ledger reuse, permission recheck.
 - [ ] **🔒 T1-4 — Finish P1-C node field-permissions.** `readonly`/`editable` runtime (today only `hidden`
   works) + authoring UI. **Size S–M · dep:** edit-form-at-node direction (snapshots are write-once at create).
 
@@ -89,8 +94,8 @@ These are not "build-next" features — they are exposures/decisions the audit s
 - [ ] **🔒 T3-2 — Business/work-day calendar wired to SLA** (multi-time-dimension, non-counting windows).
   The calendar exists (attendance) but is unwired. **Size L · dep:** T1-1 node-SLA.
 - [ ] **🔒 T3-3 — Handwritten signature / compliance.** Absent. **Size M–L.**
-- [ ] **🔒 T3-4 — W7 rejection backwrite.** **Size M · design-lock-first** — the open product call:
-  rejected/cancelled/revoked → write-back-then-continue-tail vs write-back-then-fail.
+- [x] **✅ T3-4 — W7 rejection backwrite.** Shipped as opt-in non-approved resultWriteback (#3474):
+  write-back-then-fail, three non-approved terminal states.
 - [ ] **🔒 T3-5 — W7 cross-base backwrite.** **Size M–L · design-lock-first** — security arc
   (perm / lock / audit / target-resolution re-lock); routes through the existing cross-base write gate.
 - [ ] **🔒 T3-6 — S-band: approval data as first-class multitable records.** Strategic; broader than the

--- a/docs/development/approval-automation-development-verification-20260629.md
+++ b/docs/development/approval-automation-development-verification-20260629.md
@@ -6,6 +6,13 @@
 > rest. Companion artifacts: the **decision register** (`approval-automation-decision-register-20260629.md`),
 > the **design-lock pack** (`approval-automation-design-lock-pack-20260629.md`), and the evidence base —
 > the **refresh audit** (`docs/research/approval-automation-refresh-audit-20260629.md`).
+>
+> **As-built update after later rungs shipped.** This report remains the 2026-06-29 decision-register
+> closeout, but several rungs it listed as owner-gated have since been ratified and shipped: R1 default-closed
+> egress containment, T2-6 dedup, T1-3 approval.completed trigger, T1-1 slice-2 timeout transfer/jump, T3-4
+> non-approved W7 writeback, and T0-3 delete_record editor exposure. Treat the register/pack below as the
+> historical decision record plus remaining-gate reference, not as a current claim that all 17 rungs are still
+> open.
 
 ## 1. The honest finding (why "complete all 20 rungs, merged" was not the deliverable)
 
@@ -44,16 +51,16 @@ asserts as fail-first, **plus** the save Guarantee (holds via binding-persistenc
 
 ## 3. The gate to everything else — the decision register
 
-All 17 remaining rungs are catalogued in the **decision register** with their open decisions + proposed
-defaults. The fastest path to building any of them: **approve its proposed defaults (or override), and it
-becomes design-lock-first buildable.** A few high-signal examples (full list in the register):
+The original 17 rungs were catalogued in the **decision register** with their open decisions + proposed
+defaults. Several of those decisions have since been approved and shipped; the remaining rungs still follow the
+same path: **approve its proposed defaults (or override), and it becomes design-lock-first buildable.** A few
+high-signal examples from the original register (full list in the register):
 
-- **T0-3 expose `delete_record`** (7 decisions) — default: same-base trigger-record delete only, required
-  anti-misdelete acknowledgement kept out of persisted config, no cross-base UI in v1.
+- **T0-3 expose `delete_record`** — shipped later on the same-base trigger-record default (#3477).
 - **T1-1 node-level SLA + timeout** (8) — the open call is the timeout effect set + invalidation semantics.
 - **R1 BPMN governance + SSRF** (7) — the security containment approach (gate the route / allowlist
   service-task fetch); this is the discovered-risk ticket, recommend triaging first.
-- **T3-4 W7 rejection backwrite** (6) — the product call: write-back-then-continue-tail vs -then-fail.
+- **T3-4 W7 rejection backwrite** — shipped later as opt-in write-back-then-fail (#3474).
 
 Caveat: **T1-3, T2-4, T3-6** had cited anchors the adversarial reviewer could not fully confirm — verify
 the code references before building those three.
@@ -71,12 +78,12 @@ status is: **a complete, decision-ready plan to parity, with the decision-clean 
 
 ## 5. Recommended completion sequence (each a separate opt-in after its decisions land)
 
-1. **Land the shipped increment:** confirm the T0-2 §5 deviation (#3384), merge #3384 + #3382.
-2. **Triage the risk ticket R1** (BPMN governance/SSRF) — security, independent of features.
-3. **First parity arc — T1-1 node-level SLA + timeout actions** (highest benchmark value, no hard deps)
-   once its timeout-effect decisions are approved.
-4. Then T1-2 inbound webhook · T1-3 `approval.*` trigger · T1-4 field-perms — per their registers.
-5. Ops/admin (T2-*) and strategic L arcs (T3-*) as scoped, decision-led arcs.
+1. **Landed:** #3384 + #3382, R1 default-closed egress containment, T2-6, T1-3, T1-1 slice-2, T3-4,
+   and T0-3 have all shipped in later PRs.
+2. **Remaining feature/security lanes:** T1-2 inbound webhook, T3-5 W7 cross-base, T2-1+2 scoped
+   admins/handover, T1-4 field-perms, and the strategic L arcs remain decision-led.
+3. **Governance-only remainder:** R1 destination authorization remains deny-all until a named destination is
+   explicitly approved/configured.
 
 Nothing in §5 is started by this report. Approve a rung's register entries and I'll produce its
 design-lock then implementation, verified the same way as §2.

--- a/docs/development/approval-automation-first-batch-ballot-20260701.md
+++ b/docs/development/approval-automation-first-batch-ballot-20260701.md
@@ -1,5 +1,12 @@
 # Approval & Process-Automation — first-batch per-rung decision ballot (2026-07-01)
 
+> **Status: RATIFIED + SHIPPED as first-batch runtime.** The ballot is no longer awaiting votes. All four
+> rungs were built and merged on the proposed defaults: T1-3 approval.completed trigger `#3467`
+> (`f4451c945`), T1-1 slice-2 timeout transfer/jump `#3468` (`593df00e3`), T3-4 W7 non-approved
+> resultWriteback `#3474` (`bceb9ab11`), and T0-3 delete_record editor exposure `#3477`
+> (`264cac7fb`). The tables below are retained as the decision record; the `票` column now records the
+> shipped disposition, not an open request for approval.
+
 > **Per-rung ballot** (NOT blanket approval) for the four first-batch rungs picked by unblock-value:
 > T1-3 · T3-4 · T0-3 (Lane C, sequential — same hot file) ∥ T1-1 slice-2 (Lane B). Each line = one open
 > decision + the proposed default. **Vote per item:** ✅ adopt default · ✏️ override (state the change) ·
@@ -13,37 +20,37 @@
 
 | # | 决策 | 建议默认 | 票 |
 |---|---|---|---|
-| Q1 | 路由/范围键 | `config.templateId` **REQUIRED**;`loadEnabledApprovalRules(templateId)` 跨 sheet 查询,v1 无迁移/索引。**AMENDED:** register 原 default 声称 templateId 恒非空 —— 已被 register 自己的 reviewer note 证伪(`ApprovalInstanceRow.template_id` 是 `string\|null`,经 `nullableString()` → null)。修正:templateId 仍为唯一路由键;**null-template completion 显式声明 v1 out-of-contract**(永不匹配任何规则;fire 时若存在 enabled approval 规则则记 debug 日志),真实 null-template 消费者出现时立具名 follow-up | ⬜ |
-| Q2 | 跨租户授权 | create/update 时要求规则 createdBy 对配置的 templateId 持 `approvals:read`/模板可见性,fire 时复查;否则 deny+skip(复用 bridge 的 permission-code 查询) | ⬜ |
-| Q3 | record-less + action 白名单 | v1 无记录上下文(synthetic payload,`recordId=''`,审批事件挂 `triggerEvent`);action 仅允许 send_notification / send_webhook / send_email / send_dingtalk_*;含 record-targeting 或 start_approval 的规则在保存时拒绝 | ⬜ |
-| Q4 | 循环/深度防护 | (a) 结构性断环:禁 start_approval + record-writing(随 Q3);(b) synthetic 执行播种 `_automationDepth = (bridge 深度 ?? 0)+1`;(c) eventId 硬去重(见 Q5) | ⬜ |
-| Q5 | 幂等/重投递 | **AMENDED:** register 原 default 是"新建小 ledger"——T2-6 已落(#3450),改为**复用 `meta_automation_event_fires` claim-before-execute**,dedupKey = `approval.completed:{event.eventId}`(eventId 已含 `instanceId:toVersion:eventType`,天然唯一);**无新迁移**(同时消解 register 里 no-migration non-goal 与 Q5 的内部矛盾) | ⬜ |
-| Q6 | 触发器形状 | 单一 trigger type `approval.completed` + 可选 `config.outcomes?: ('approved'\|'rejected'\|'revoked'\|'cancelled')[]`(默认 approved-only) | ⬜ |
-| Q7 | 与 W6 bridge 的关系 | 互不抑制:bridge resume 与 fresh trigger 是不同消费者,所有 completion 事件都 fire fresh 规则(文档写明 X 启动的审批可触发自动化 Y) | ⬜ |
-| Q8 | conditions | v1 非目标:该触发器带非空 ConditionGroup 的规则保存时拒绝;审批字段条件词表是具名 follow-up | ⬜ |
+| Q1 | 路由/范围键 | `config.templateId` **REQUIRED**;`loadEnabledApprovalRules(templateId)` 跨 sheet 查询,v1 无迁移/索引。**AMENDED:** register 原 default 声称 templateId 恒非空 —— 已被 register 自己的 reviewer note 证伪(`ApprovalInstanceRow.template_id` 是 `string\|null`,经 `nullableString()` → null)。修正:templateId 仍为唯一路由键;**null-template completion 显式声明 v1 out-of-contract**(永不匹配任何规则;fire 时若存在 enabled approval 规则则记 debug 日志),真实 null-template 消费者出现时立具名 follow-up | ✅ SHIPPED #3467 |
+| Q2 | 跨租户授权 | create/update 时要求规则 createdBy 对配置的 templateId 持 `approvals:read`/模板可见性,fire 时复查;否则 deny+skip(复用 bridge 的 permission-code 查询) | ✅ SHIPPED #3467 |
+| Q3 | record-less + action 白名单 | v1 无记录上下文(synthetic payload,`recordId=''`,审批事件挂 `triggerEvent`);action 仅允许 send_notification / send_webhook / send_email / send_dingtalk_*;含 record-targeting 或 start_approval 的规则在保存时拒绝 | ✅ SHIPPED #3467 |
+| Q4 | 循环/深度防护 | (a) 结构性断环:禁 start_approval + record-writing(随 Q3);(b) synthetic 执行播种 `_automationDepth = (bridge 深度 ?? 0)+1`;(c) eventId 硬去重(见 Q5) | ✅ SHIPPED #3467 |
+| Q5 | 幂等/重投递 | **AMENDED:** register 原 default 是"新建小 ledger"——T2-6 已落(#3450),改为**复用 `meta_automation_event_fires` claim-before-execute**,dedupKey = `approval.completed:{event.eventId}`(eventId 已含 `instanceId:toVersion:eventType`,天然唯一);**无新迁移**(同时消解 register 里 no-migration non-goal 与 Q5 的内部矛盾) | ✅ SHIPPED #3467 |
+| Q6 | 触发器形状 | 单一 trigger type `approval.completed` + 可选 `config.outcomes?: ('approved'\|'rejected'\|'revoked'\|'cancelled')[]`(默认 approved-only) | ✅ SHIPPED #3467 |
+| Q7 | 与 W6 bridge 的关系 | 互不抑制:bridge resume 与 fresh trigger 是不同消费者,所有 completion 事件都 fire fresh 规则(文档写明 X 启动的审批可触发自动化 Y) | ✅ SHIPPED #3467 |
+| Q8 | conditions | v1 非目标:该触发器带非空 ConditionGroup 的规则保存时拒绝;审批字段条件词表是具名 follow-up | ✅ SHIPPED #3467 |
 
 ## T3-4 — W7 rejection backwrite · S-M (~1–2pd) · Lane C after T1-3
 
 | # | 决策 | 建议默认 | 票 |
 |---|---|---|---|
-| D1 | 尾部语义 | **WRITE-BACK-THEN-FAIL**:非 approved 终态时先回写记录,run 仍按今日契约 terminal-failed、tail 跳过("拒绝时通知"的诉求由 T1-3 承接更干净) | ⬜ |
-| D2 | 存量规则 | **OPT-IN**:新增 `resultWriteback.onNonApproved`(默认 false);已保存规则行为不变,作者显式开启 | ⬜ |
-| D3 | 覆盖终态 | `toStatus !== 'approved'` 三态统一(rejected/revoked/cancelled) | ⬜ |
-| D4 | approverField 语义 | 写终态操作者(null-safe:`event.actor?.id ?? null`);文档写明非 approved 路径该字段含义是"完成者" *(注:keystone 测试与本项耦合 —— 若改此项,测试断言随之改)* | ⬜ |
-| D5 | select 校验强度 | LENIENT:保存端仍只校验 'approved' option;缺 option 的终态运行时 skip + `backwriteSkipped` 可观测,不新拒存量规则 | ⬜ |
-| D6 | 下游扇出 | 与 approved 路径对等:深度防护的 `multitable.record.updated` + realtime 照发(复用 `writeApprovalResultBack` 免费获得) | ⬜ |
+| D1 | 尾部语义 | **WRITE-BACK-THEN-FAIL**:非 approved 终态时先回写记录,run 仍按今日契约 terminal-failed、tail 跳过("拒绝时通知"的诉求由 T1-3 承接更干净) | ✅ SHIPPED #3474 |
+| D2 | 存量规则 | **OPT-IN**:新增 `resultWriteback.onNonApproved`(默认 false);已保存规则行为不变,作者显式开启 | ✅ SHIPPED #3474 |
+| D3 | 覆盖终态 | `toStatus !== 'approved'` 三态统一(rejected/revoked/cancelled) | ✅ SHIPPED #3474 |
+| D4 | approverField 语义 | 写终态操作者(null-safe:`event.actor?.id ?? null`);文档写明非 approved 路径该字段含义是"完成者" *(注:keystone 测试与本项耦合 —— 若改此项,测试断言随之改)* | ✅ SHIPPED #3474 |
+| D5 | select 校验强度 | LENIENT:保存端仍只校验 'approved' option;缺 option 的终态运行时 skip + `backwriteSkipped` 可观测,不新拒存量规则 | ✅ SHIPPED #3474 |
+| D6 | 下游扇出 | 与 approved 路径对等:深度防护的 `multitable.record.updated` + realtime 照发(复用 `writeApprovalResultBack` 免费获得) | ✅ SHIPPED #3474 |
 
 ## T0-3 — delete_record 编辑器安全露出 · S (~1–2pd) · Lane C after T3-4
 
 | # | 决策 | 建议默认 | 票 |
 |---|---|---|---|
-| Q1 | 跨 base 露出 | v1 **仅 same-base**(trigger-record delete);跨 base 保持 runtime-capable 但编辑器不露出,单独 gated slice | ⬜ |
-| Q2 | 防误删确认 | 必选 acknowledgement checkbox 阻塞 Save(文案:永久不可撤销);ack 存 authoring state,**不进 action.config**(serialize 显式 delete_record 分支输出干净 `{}`)。**建 build 契约补充:** 已保存规则编辑时 ack 预勾选、新加 delete action 必须重新勾;ack/hint 文案走 i18n 模块 | ⬜ |
-| Q3 | 爆炸半径 | trigger-record-only:same-base delete 只删触发记录(空 config),v1 无 id/字段路径选择器 | ⬜ |
-| Q4 | 保存端校验 | 扩展 `validateCrossBaseWriteConfig` 到 delete_record(和 lock_record)—— 与编辑器露出无关的 fail-closed-at-save 补防(该 action 本就 API 可存) | ⬜ |
-| Q5 | Test Run 语义 | 保持现状 + 编辑器非阻塞提示(Test Run 用合成记录、不会删真实记录);不为破坏性 action 特判 | ⬜ |
-| Q6 | 作者权限 | 与其它记录变更 action 对齐 `canManageAutomation`,本 rung 不加新 capability | ⬜ |
-| Q7 | 审计 | 复用既有 execution-log + `multitable.record.deleted`;独立破坏性审计/retention 仅在 owner 要求时再立项 | ⬜ |
+| Q1 | 跨 base 露出 | v1 **仅 same-base**(trigger-record delete);跨 base 保持 runtime-capable 但编辑器不露出,单独 gated slice | ✅ SHIPPED #3477 |
+| Q2 | 防误删确认 | 必选 acknowledgement checkbox 阻塞 Save(文案:永久不可撤销);ack 存 authoring state,**不进 action.config**(serialize 显式 delete_record 分支输出干净 `{}`)。**建 build 契约补充:** 已保存规则编辑时 ack 预勾选、新加 delete action 必须重新勾;ack/hint 文案走 i18n 模块 | ✅ SHIPPED #3477 |
+| Q3 | 爆炸半径 | trigger-record-only:same-base delete 只删触发记录(空 config),v1 无 id/字段路径选择器 | ✅ SHIPPED #3477 |
+| Q4 | 保存端校验 | 扩展 `validateCrossBaseWriteConfig` 到 delete_record(和 lock_record)—— 与编辑器露出无关的 fail-closed-at-save 补防(该 action 本就 API 可存) | ✅ SHIPPED #3477 |
+| Q5 | Test Run 语义 | 保持现状 + 编辑器非阻塞提示(Test Run 用合成记录、不会删真实记录);不为破坏性 action 特判 | ✅ SHIPPED #3477 |
+| Q6 | 作者权限 | 与其它记录变更 action 对齐 `canManageAutomation`,本 rung 不加新 capability | ✅ SHIPPED #3477 |
+| Q7 | 审计 | 复用既有 execution-log + `multitable.record.deleted`;独立破坏性审计/retention 仅在 owner 要求时再立项 | ✅ SHIPPED #3477 |
 
 ## T1-1 slice-2 — transfer/jump 超时效果 · M (~2–3pd) · Lane B(与 Lane C 并行)
 
@@ -51,14 +58,14 @@
 
 | # | 决策 | 建议默认 | 票 |
 |---|---|---|---|
-| Q1 | 本 slice 接通哪些效果 | **transfer + jump**;auto_approve/auto_reject 保留在枚举但 runtime-INERT,置于 `APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS` env gate + 模板发布时确认之后(declared-but-do-not-wire 先例) | ⬜ |
-| QS-a | target 配置 schema(register 未单列,slice-2 必须定) | `timeout.transferToUserId`(静态单用户,publish 校验非空;role/chain 升级不在本 slice)· `timeout.jumpToNodeKey`(publish 校验:节点存在、approval 类型、非 parallel-region;直达 terminal 已有校验阻挡) | ⬜ |
-| QS-b | 间接级联 carve-out | timeout-jump 落点若自动完成(如 mergeWithRequester)并级联到 terminal = 事实 auto-approve → **归入 Q1 同一 terminal gate**:gate 未开则 fire 时 skip effect + 结构化日志(不 fallback 成 remind);gate 开启才允许级联 | ⬜ |
-| Q3 | 审计判别 | 复用既有 record actions(transfer/jump)+ `metadata.timeoutEffect=true`(adminJump 先例);不动 CHECK 约束 | ⬜ |
-| Q6 | parallel region | 区内 remind-only;parallel-branch 节点上的 transfer/jump/auto_* 超时配置 publish-reject | ⬜ |
-| Q7 | 执行者身份 | 保留系统 actor `system:approval-timeout` 记入 actorId+metadata;auto_reject(将来启用)合成 system comment 以满足 rejectCommentRequired | ⬜ |
+| Q1 | 本 slice 接通哪些效果 | **transfer + jump**;auto_approve/auto_reject 保留在枚举但 runtime-INERT,置于 `APPROVAL_NODE_TIMEOUT_TERMINAL_EFFECTS` env gate + 模板发布时确认之后(declared-but-do-not-wire 先例) | ✅ SHIPPED #3468 |
+| QS-a | target 配置 schema(register 未单列,slice-2 必须定) | `timeout.transferToUserId`(静态单用户,publish 校验非空;role/chain 升级不在本 slice)· `timeout.jumpToNodeKey`(publish 校验:节点存在、approval 类型、非 parallel-region;直达 terminal 已有校验阻挡) | ✅ SHIPPED #3468 |
+| QS-b | 间接级联 carve-out | timeout-jump 落点若自动完成(如 mergeWithRequester)并级联到 terminal = 事实 auto-approve → **归入 Q1 同一 terminal gate**:gate 未开则 fire 时 skip effect + 结构化日志(不 fallback 成 remind);gate 开启才允许级联 | ✅ SHIPPED #3468 |
+| Q3 | 审计判别 | 复用既有 record actions(transfer/jump)+ `metadata.timeoutEffect=true`(adminJump 先例);不动 CHECK 约束 | ✅ SHIPPED #3468 |
+| Q6 | parallel region | 区内 remind-only;parallel-branch 节点上的 transfer/jump/auto_* 超时配置 publish-reject | ✅ SHIPPED #3468 |
+| Q7 | 执行者身份 | 保留系统 actor `system:approval-timeout` 记入 actorId+metadata;auto_reject(将来启用)合成 system comment 以满足 rejectCommentRequired | ✅ SHIPPED #3468 |
 
 ## 投票方式
-- 直接在对话里逐项回复(如 "T1-3 全✅,Q1 ✏️ 改成 …"),或编辑本文件把 ⬜ 改 ✅/✏️/⏸。
-- 每个 rung 独立 GO;GO 后按 lane 顺序开建(Lane C: T1-3 → T3-4 → T0-3;Lane B: T1-1-s2 可并行)。
-- 第二批候选(本批消化后再出 ballot):T1-2 inbound webhook · T3-5 cross-base backwrite · T2-1+2 · T1-4。
+- Historical voting instruction: direct chat replies or file edits were accepted while this ballot was open.
+- Current as-built: all first-batch rungs are shipped; do not treat this file as an open authorization request.
+- 第二批候选(仍需 per-rung GO):T1-2 inbound webhook · T3-5 cross-base backwrite · T2-1+2 · T1-4。

--- a/docs/development/approval-automation-parallel-development-plan-20260701.md
+++ b/docs/development/approval-automation-parallel-development-plan-20260701.md
@@ -1,12 +1,14 @@
 # Approval & Process-Automation — un-completed items, parallel-development plan & verification (2026-07-01)
 
-> **As-built coordination plan** (updated to main after `#3451`/`#3452`/`#3450`/`#3453` and the A3-a/b slices
-> `#3455`/`#3457`/`#3460` merged). Deep review of what
+> **As-built coordination plan** (updated to main after `#3451`/`#3452`/`#3450`/`#3453`, the A3-a/b slices
+> `#3455`/`#3457`/`#3460`, and the first-batch runtime `#3467`/`#3468`/`#3474`/`#3477` merged). Deep review of what
 > remains on the line, classified by gating and **sequenced into parallel lanes** so work distributes across
 > sessions without hot-file collision. **Shipped since the first cut:** T2-4 re-entry quorum-bypass (`#3446`,
 > `to_version >= cutoff`) + same-version cascade regression (`#3453`), R1-A/R1-B egress closure (`#3437`/`#3443`/
 > `#3447`/`#3451`), A3 rollout design-lock + **runtime policy plumbing** (`#3452` + `#3455`/`#3457`/`#3460`),
-> and T2-6 event dedup ledger (`#3450`). **Honest framing:** the
+> T2-6 event dedup ledger (`#3450`), approval.completed trigger (`#3467`), timeout transfer/jump effects
+> (`#3468`), W7 non-approved result writeback (`#3474`), and delete_record editor exposure (`#3477`).
+> **Honest framing:** the
 > remainder is owner-gated (design-lock-first) — so "complete all development" is realized by
 > *ratifying defaults **per lane/rung** (not blanket — it mixes SSRF / destructive-delete / permission-migration
 > / cross-base-writeback risk) + distributing the lanes*, not one session building everything.
@@ -25,8 +27,10 @@
   The `#3453` follow-up locks the same-version requester auto-approval cascade boundary that requires `>=`.
 - **T2-6 event dedup ledger — SHIPPED (`#3450`):** automation record-change/form-submit dispatch now has a
   database-backed event-fire ledger (7-day TTL retention sweep only — no count cap), real-DB coverage, and CI
-  wiring. This removes the substrate
-  blocker for approval-trigger and inbound-webhook work, but those feature rungs remain owner-gated.
+  wiring. This removed the substrate blocker for approval-trigger and inbound-webhook work.
+- **First-batch runtime — SHIPPED:** `approval.completed` automation trigger (`#3467`), T1-1 slice-2 timeout
+  transfer/jump effects (`#3468`), W7 non-approved result writeback (`#3474`), and safe delete_record editor
+  exposure (`#3477`) are all on main on the ballot defaults.
 
 ## 2. Un-completed items — gating
 
@@ -37,14 +41,14 @@
 | ~~ISATAP `0200:5efe` u/l-bit + IPv4-compat~~ | BPMN (guard) | **SHIPPED (#3437/#3443)** | done — classifier folds both ISATAP u/l forms + `::/96` |
 | ~~R1-B DNS-pinned dispatcher + wiring + redirect re-validation~~ | BPMN/workflow | **SHIPPED (#3447/#3451)** | done — raw BPMN HTTP-task fetch path replaced; default policy deny-all |
 | **R1-A3** configured destination enablement | BPMN/workflow | **runtime SHIPPED** (#3455/#3457/#3460), destinations not yet authorized | governance-only remainder: `#3460` injects the server-owned `BPMN_HTTP_TASK_EGRESS_POLICY` env policy at both BPMN route construction points; `#3455` normalizer + `#3457` route-provenance locks are in. **No core runtime code left** — what remains is authorizing/configuring the first live destination (ops/governance per `#3452`), default stays deny-all |
-| T1-1 slice-2 transfer/jump timeout effects | approval engine | unshipped | owner-gated (transfer/jump **target-config schema** + indirect jump→terminal carve-out; auto_* env-gated) |
+| ~~T1-1 slice-2 transfer/jump timeout effects~~ | approval engine | **SHIPPED (#3468)** | done — transfer/jump wired; auto_* terminal effects remain env-gated/inert |
 | T2-1+2 scoped admins + handover | approval engine | unshipped | owner-gated (permission model + migration) |
 | T1-4 node field-perms runtime | approval engine | unshipped | owner-gated (edit-form-at-node prerequisite) |
-| T3-4 W7 rejection backwrite | automation/approval | unshipped | owner-gated (write-then-fail vs continue-tail; opt-in) |
+| ~~T3-4 W7 rejection backwrite~~ | automation/approval | **SHIPPED (#3474)** | done — opt-in non-approved writeback, write-back-then-fail |
 | T3-5 W7 cross-base backwrite | automation/approval | unshipped | owner-gated (cross-base write-gate re-lock) |
-| T0-3 delete_record editor | automation engine | unshipped | owner-gated (destructive, 7 decisions) |
+| ~~T0-3 delete_record editor~~ | automation engine | **SHIPPED (#3477)** | done — same-base trigger-record only, ack-gated editor, save-gate hardening |
 | T1-2 inbound webhook | automation engine | unshipped | owner-gated (signature/replay/audit, 9 decisions) |
-| T1-3 approval.* trigger | automation engine | unshipped | owner-gated (routing/loop/cross-tenant, 8 decisions) |
+| ~~T1-3 approval.* trigger~~ | automation engine | **SHIPPED (#3467)** | done — template-routed, record-less v1, T2-6 ledger reuse, permission recheck |
 | ~~T2-6 event-driven dedup ledger~~ | automation engine | **SHIPPED (#3450)** | done — database-backed event fire ledger, sweep, real-DB CI wiring |
 | T3-2 business-calendar SLA · T3-3 signature · T3-1 mobile · T3-6 S-band | product/heavy | unshipped | owner-gated, L (T3-2 dep T1-1) |
 
@@ -61,10 +65,12 @@ edits to `ApprovalProductService.ts` / `automation-service.ts` collide).
   is **destination authorization** — a config/ops governance act per `#3452`, not code. Default stays deny-all
   until a first named destination is explicitly authorized.
 - **Lane B — approval engine** (`ApprovalProductService.ts` — HOT, so sequential): ~~`T2-4 fix`~~ **done (#3446)**
-  + cascade regression **done (#3453)** → next `T1-1 slice-2` → `T2-1+2` → `T1-4`. (`T3-4/T3-5` W7-backwrite touch
+  + cascade regression **done (#3453)** + `T1-1 slice-2` **done (#3468)** → next `T2-1+2` → `T1-4`. (`T3-5`
+  W7 cross-base backwrite touches
   `automation-service.ts`, see Lane C.)
 - **Lane C — automation engine** (`automation-service.ts` — HOT, so sequential): ~~`T2-6 dedup`~~ **done (#3450)** →
-  `T1-3 approval-trigger` / `T1-2 webhook` → `T0-3 delete_record` → `T3-4`/`T3-5` W7-backwrite.
+  `T1-3 approval-trigger` **done (#3467)** → `T3-4` **done (#3474)** → `T0-3 delete_record` **done (#3477)** →
+  next `T1-2 inbound webhook` / `T3-5` W7 cross-base backwrite.
 - **Lane D — product/heavy** (separate surfaces): `T3-1 mobile`, `T3-6 S-band`, `T3-2 business-calendar`
   (dep T1-1), `T3-3 signature`.
 
@@ -75,8 +81,10 @@ double-editing.
 
 ## 4. What's ready to build vs needs a decision
 - **Shipped:** T2-4 fix (#3446) + same-version cascade regression (#3453) · R1-A/R1-B default-closed egress closure
-  (#3437/#3443/#3447/#3451) · T2-6 event dedup ledger (#3450).
-- **Owner-gated:** everything else — including A3 configured destination enablement. The register (#3385) and the
+  (#3437/#3443/#3447/#3451) · T2-6 event dedup ledger (#3450) · approval.completed trigger (#3467) ·
+  T1-1 timeout transfer/jump effects (#3468) · W7 non-approved writeback (#3474) · delete_record editor (#3477).
+- **Owner-gated:** the remaining rungs — including A3 configured destination enablement, T1-2 inbound webhook,
+  T3-5 W7 cross-base, T2-1+2 scoped admins/handover, T1-4 field-perms, and product/heavy items. The register (#3385) and the
   follow-up design-locks hold each rung's open decisions + proposed defaults.
   **Approve per lane/rung, not blanket** — the remainder mixes distinct risk surfaces (SSRF wiring, destructive
   delete, permission migration, cross-base write-back), so a single blanket "build on defaults" is unsafe.
@@ -126,14 +134,14 @@ coverage wired into `plugin-tests.yml`, plus regression updates for record-servi
 
 ## 7. Recommendation
 1. **Done:** T2-4 fix + cascade regression (#3446/#3453) · R1-A/R1-B default-closed egress closure
-   (#3437/#3443/#3447/#3451) · T2-6 dedup ledger (#3450).
+   (#3437/#3443/#3447/#3451) · T2-6 dedup ledger (#3450) · first-batch runtime (#3467/#3468/#3474/#3477).
 2. **A3 is now governance-only:** the egress policy runtime is fully shipped (`#3452` design-lock +
    `#3455`/`#3457`/`#3460` normalizer / provenance locks / server-owned env injection). Default remains deny-all;
    the remaining act is **authorizing the first live destination** (config/ops), which happens when a named
    integration needs it — no code slice to schedule.
-3. **Next feature lanes after owner ratification:** Lane C `T1-3 approval-trigger` / `T1-2 inbound webhook`
-   (dedup dependency now met), or Lane B `T1-1 slice-2` (transfer/jump timeout effects). Continue to ratify
-   register defaults **per lane/rung**, not blanket — the first-batch per-rung ballot lives in
-   `approval-automation-first-batch-ballot-20260701.md`. Sizing note: per-rung person-day estimates are
+3. **Next feature lanes after owner ratification:** Lane C `T1-2 inbound webhook` or `T3-5` W7 cross-base
+   writeback; Lane B `T2-1+2` scoped admins/handover or `T1-4` field-perms. Continue to ratify
+   register defaults **per lane/rung**, not blanket — the first-batch per-rung ballot now lives as the shipped
+   decision record in `approval-automation-first-batch-ballot-20260701.md`. Sizing note: per-rung person-day estimates are
    optimistic build-effort figures, NOT calendar commitments — on the security/permission/migration rungs
    (T1-2, T2-1+2, T3-5) review rounds can cost more calendar than the build itself.


### PR DESCRIPTION
## Summary
- mark the first-batch approval/automation runtime as shipped across the ballot, lane plan, register, design-lock pack, and older TODO/audit docs
- record shipped references for T1-3 (#3467), T1-1 slice-2 (#3468), T3-4 (#3474), and T0-3 (#3477)
- narrow older docs to historical snapshots so they no longer read as the current open queue

## Verification
- git diff --check
- git merge-base --is-ancestor f4451c945 origin/main
- git merge-base --is-ancestor 593df00e3 origin/main
- git merge-base --is-ancestor bceb9ab11 origin/main
- git merge-base --is-ancestor 264cac7fb origin/main

Docs-only. No runtime behavior changes.