### PR TITLE
fix(integration): classify CREDENTIAL-coded adapter errors as AUTH_FAILED (#1709)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/read-source-probe-runtime.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-probe-runtime.test.cjs
@@ -297,6 +297,7 @@ async function testErrorClassificationIsCoarseAndValuesFree() {
   const cases = [
     [Object.assign(new Error('401 from https://k3host M-001'), { name: 'K3WiseWebApiAdapterError', status: 401 }), 'READ_SOURCE_PROBE_AUTH_FAILED', 'K3WiseWebApiAdapterError'],
     [Object.assign(new Error('login failed'), { name: 'K3WiseWebApiAdapterError', details: { code: 'K3_WISE_LOGIN_FAILED' } }), 'READ_SOURCE_PROBE_AUTH_FAILED', 'K3WiseWebApiAdapterError'],
+    [Object.assign(new Error('credentials are not stored'), { name: 'K3WiseWebApiAdapterError', details: { code: 'K3_WISE_CREDENTIALS_MISSING' } }), 'READ_SOURCE_PROBE_AUTH_FAILED', 'K3WiseWebApiAdapterError'],
     [Object.assign(new Error('business response failed'), { name: 'K3WiseWebApiAdapterError', details: { code: 'K3_WISE_READ_BUSINESS_ERROR' } }), 'READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED', 'K3WiseWebApiAdapterError'],
     [Object.assign(new Error('filter not allowed'), { name: 'AdapterValidationError' }), 'READ_SOURCE_PROBE_REJECTED', 'Error'],
     [Object.assign(new TypeError('fetch failed'), { code: 'ECONNREFUSED' }), 'READ_SOURCE_PROBE_NETWORK_FAILED', 'TypeError'],

--- a/plugins/plugin-integration-core/lib/read-source-probe-runtime.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-probe-runtime.cjs
@@ -181,7 +181,7 @@ function classifyProbeErrorCode(error) {
   const code = typeof error?.code === 'string'
     ? error.code
     : (typeof error?.details?.code === 'string' ? error.details.code : '')
-  if (/LOGIN|TOKEN|AUTH/.test(code)) return 'READ_SOURCE_PROBE_AUTH_FAILED'
+  if (/LOGIN|TOKEN|AUTH|CREDENTIAL/.test(code)) return 'READ_SOURCE_PROBE_AUTH_FAILED'
   if (/BUSINESS/.test(code)) return 'READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED'
   if (name === 'AdapterValidationError' || name === 'UnsupportedAdapterOperationError') return 'READ_SOURCE_PROBE_REJECTED'
   if (/NOT_CONFIGURED|UNSUPPORTED|REJECTED/.test(code)) return 'READ_SOURCE_PROBE_REJECTED'


### PR DESCRIPTION
实体机冒烟发现 `K3_WISE_CREDENTIALS_MISSING` 落入 `READ_SOURCE_PROBE_FAILED` 兜底(分类正则缺 CREDENTIAL 模式),操作者无法区分「凭证问题」与「未知失败」。归入 AUTH_FAILED 粗类;values-free 纪律不变(仅模式比较)。测试补一条用例。

🤖 Generated with [Claude Code](https://claude.com/claude-code)