### PR TITLE
ci(attendance): wire AE-3 request-center parity spec into web guard

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -6,11 +6,13 @@
 # through green CI (e.g. the overview admin-only-preload guard going red unnoticed).
 #
 # Scope (deliberately TARGETED): run the green attendance admin-surface guard specs —
-# attendance-admin-regressions.spec.ts (overview admin-only-preload guard) and
-# attendance-admin-anchor-nav.spec.ts (member resolve / nav guards). The full
-# `@metasheet/web` vitest suite still has historical/flaky failures, so wiring the whole
-# suite as a required gate now would be red on arrival. Keep expanding the `vitest run`
-# filter (or move to the full web suite) as more web specs are cleaned up.
+# attendance-admin-regressions.spec.ts (overview admin-only-preload guard + AE-3
+# result-edit modal matrix), attendance-admin-anchor-nav.spec.ts (member resolve / nav
+# guards), and AttendanceRequestCenterSection.result-edit.spec.ts (request-center parity
+# for the shared AE-3 result-edit callback). The full `@metasheet/web` vitest suite still
+# has historical/flaky failures, so wiring the whole suite as a required gate now would
+# be red on arrival. Keep expanding the `vitest run` filter (or move to the full web
+# suite) as more web specs are cleaned up.
 name: Attendance Web Guard
 
 on:
@@ -20,6 +22,7 @@ on:
       - 'apps/web/src/views/attendance/**'
       - 'apps/web/tests/attendance-admin-regressions.spec.ts'
       - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
+      - 'apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
@@ -28,6 +31,7 @@ on:
       - 'apps/web/src/views/attendance/**'
       - 'apps/web/tests/attendance-admin-regressions.spec.ts'
       - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
+      - 'apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -70,4 +74,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav AttendanceRequestCenterSection.result-edit --reporter=dot


### PR DESCRIPTION
## Why

`AttendanceRequestCenterSection.result-edit.spec.ts` (the AE-3 request-center parity spec, +135 lines from #3461) currently executes in **no CI gate**: the broad `@metasheet/web` vitest suite is deliberately un-gated (historical/flaky), and `attendance-web-guard.yml` (last expanded in #2086) runs only `attendance-admin-regressions` + `attendance-admin-anchor-nav`. A green-but-never-run spec is the "wire-vs-fixture" false-green class — flagged as F1 in the post-merge AE-3 review (`/tmp/pr3461-review-claude-20260702.md`).

The +215 main-surface AE-3 tests in `attendance-admin-regressions.spec.ts` already run in this guard (green on #3461); this PR closes the gap for the parity spec only.

## What

One file, `.github/workflows/attendance-web-guard.yml`:

- add `AttendanceRequestCenterSection.result-edit` to the targeted `vitest run` filter;
- add `apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts` to both `on.pull_request.paths` and `on.push.paths`;
- refresh the header comment to list all three gated specs.

No runtime/product change. Follows the workflow header's own instruction: "Keep expanding the `vitest run` filter … as more web specs are cleaned up."

## Verification

- Local run with the exact CI command: `pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav AttendanceRequestCenterSection.result-edit --reporter=dot` → **3 files, 132 tests passed** (3 + 30 + 99), confirming the filter substring matches the new spec and it is green before gating.
- This PR touches the guard workflow itself (listed in its own path filters), so the expanded 3-spec run executes in CI on this PR.
- All 5 required checks (`contracts ×3`, `pr-validate`, `test (20.x)`) trigger on `pull_request` without path filters — verified, no stuck-pending risk for a workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)