### PR TITLE
feat(automation): add signed inbound webhook trigger

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -298,6 +298,7 @@ jobs:
             tests/integration/multitable-automation-start-approval-http.test.ts \
             tests/integration/multitable-form-submit-trigger.test.ts \
             tests/integration/multitable-event-dedup-trigger.test.ts \
+            tests/integration/multitable-inbound-webhook-trigger.test.ts \
             tests/integration/multitable-form-submit-start-approval-smoke.test.ts \
             tests/integration/automation-approval-completed-trigger.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \

--- a/docs/development/approval-automation-t1-2-inbound-webhook-dev-verification-20260702.md
+++ b/docs/development/approval-automation-t1-2-inbound-webhook-dev-verification-20260702.md
@@ -1,0 +1,68 @@
+# Approval & Process-Automation T1-2 Inbound Webhook — Development & Verification
+
+Date: 2026-07-02
+Status: built for review
+
+## Scope
+
+Implements the second-batch default for T1-2: make the existing `webhook.received` automation trigger real through a signed inbound HTTP endpoint.
+
+This is backend/API-first. The rule-editor selector can be exposed in a later UI slice; the runtime no longer remains inert.
+
+## Shipped Behavior
+
+- Endpoint: `POST /api/multitable/automation/webhooks/:ruleId`.
+- Signature: `X-MS-Webhook-Signature: sha256=<hex>` over `"${unixSeconds}.${rawBody}"`, with `X-MS-Webhook-Timestamp`.
+- Replay window: timestamp must be within +/-300 seconds.
+- Secret policy: `webhook.received` rules require a non-empty `trigger_config.secret` at create/update; legacy/direct-DB secret-less rules are blocked on any edit and rejected at ingest.
+- Reject posture: unknown rule, wrong trigger type, disabled rule, missing secret, stale timestamp, bad signature, missing body, and invalid top-level JSON all return `401 { ok:false }`.
+- Observability: rejected attempts increment `automation_webhook_rejected_total{reason}` and write structured security logs; accepted attempts use the existing redacted automation execution log.
+- Dispatch: synchronous inline execution; successful verification returns `202` after execution completes.
+- Limits: 1 MB JSON body parser on the inbound path; per-rule rate limit 60/minute using the existing rate-limiter store.
+- Secret redaction: HTTP rule serialization redacts `triggerConfig.secret`.
+
+## Trust Boundary
+
+The webhook caller is anonymous. Possession of the per-rule secret authorizes delivery, but the caller does not become a platform actor.
+
+The request body is exposed as `recordData` for conditions/templates, but the actual executor context is synthetic:
+
+- `recordId = ''`
+- `sheetId = rule.sheet_id`
+- `actorId = null`
+
+Therefore body fields named `recordId`, `sheetId`, `actorId`, or similar are data only; they cannot retarget records or impersonate users.
+
+## Verification
+
+- Unit: `tests/unit/automation-inbound-webhook.test.ts`
+  - strips `sha256=` before constant-time comparison,
+  - rejects stale timestamps and bad signatures,
+  - enforces save-boundary secret requirement,
+  - redacts webhook secrets on HTTP serialization.
+- Real DB / mounted route: `tests/integration/multitable-inbound-webhook-trigger.test.ts`
+  - create/update secret gate,
+  - mounted route rejects arrays, primitives, and empty body,
+  - uniform 401 for unknown/wrong-trigger/disabled/bad-signature/stale/missing-secret,
+  - accepted signed request writes a durable execution row,
+  - malicious body `recordId` / `sheetId` / `actorId` stays inside `data` and cannot become execution context.
+- CI wiring:
+  - excluded from the no-DB Vitest run,
+  - wired as a whole file into `.github/workflows/plugin-tests.yml` multitable real-DB lane.
+
+Commands run locally:
+
+```bash
+pnpm install --frozen-lockfile --prefer-offline
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/automation-inbound-webhook.test.ts tests/unit/automation-routes-wiring.test.ts --reporter=dot
+DATABASE_URL=${DATABASE_URL:-postgresql://postgres@localhost:5432/metasheet_test} pnpm --filter @metasheet/core-backend migrate
+DATABASE_URL=${DATABASE_URL:-postgresql://postgres@localhost:5432/metasheet_test} pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-inbound-webhook-trigger.test.ts tests/integration/multitable-event-dedup-trigger.test.ts tests/integration/multitable-form-submit-trigger.test.ts tests/integration/automation-approval-completed-trigger.test.ts --reporter=dot
+```
+
+## Deferred
+
+- Nonce/dedup for in-window replay. Timestamp freshness is v1; residual replay inside the 300 second window is known.
+- Secret encryption at rest. V1 keeps plaintext parity with outbound webhook secrets and relies on response/log redaction.
+- Rule-editor trigger exposure. This PR makes the backend trigger real; UI affordance can follow.
+- Record-target mapping from webhook body. V1 does not let request payload fields retarget records or impersonate actors.

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -158,7 +158,7 @@ import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
 import { isOapiAllowlistRequest } from './multitable/oapi-read-allowlist'
 import { dashboardRouter } from './routes/dashboard'
-import { createAutomationRoutes } from './routes/automation'
+import { automationWebhookJsonParser, createAutomationRoutes } from './routes/automation'
 import { createMultitableAiRoutes } from './routes/multitable-ai'
 import { QueueServiceImpl } from './services/QueueService'
 import { createMultitableButtonRoutes } from './routes/multitable-button'
@@ -967,6 +967,10 @@ export class MetaSheetServer {
       next()
     })
     this.app.use('/api/attendance/import', express.json({ limit: attendanceImportJsonLimit }))
+
+    // T1-2 inbound automation webhooks need the exact raw JSON bytes for HMAC verification and a
+    // narrower body limit than the general API. Parse this prefix before the global JSON parser.
+    this.app.use('/api/multitable/automation/webhooks', automationWebhookJsonParser)
 
     // Body parsing
     this.app.use(express.json({ limit: '10mb' }))

--- a/packages/core-backend/src/metrics/metrics.ts
+++ b/packages/core-backend/src/metrics/metrics.ts
@@ -1,268 +1,289 @@
 import type { Application, Request, Response, NextFunction } from 'express'
-import client from 'prom-client'
+import client, {
+  type CounterConfiguration,
+  type GaugeConfiguration,
+  type HistogramConfiguration,
+  type SummaryConfiguration,
+} from 'prom-client'
 
 export const registry = new client.Registry()
 client.collectDefaultMetrics({ register: registry })
 
-const httpHistogram = new client.Histogram({
+function counter<T extends string>(configuration: CounterConfiguration<T>) {
+  return new client.Counter<T>({ ...configuration, registers: [] })
+}
+
+function gauge<T extends string>(configuration: GaugeConfiguration<T>) {
+  return new client.Gauge<T>({ ...configuration, registers: [] })
+}
+
+function histogram<T extends string>(configuration: HistogramConfiguration<T>) {
+  return new client.Histogram<T>({ ...configuration, registers: [] })
+}
+
+function summary<T extends string>(configuration: SummaryConfiguration<T>) {
+  return new client.Summary<T>({ ...configuration, registers: [] })
+}
+
+const httpHistogram = histogram({
   name: 'http_server_requests_seconds',
   help: 'HTTP server request duration in seconds',
   labelNames: ['route', 'method', 'status'] as const,
   buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5]
 })
 
-const httpSummary = new client.Summary({
+const httpSummary = summary({
   name: 'http_server_requests_seconds_summary',
   help: 'HTTP request duration summary',
   labelNames: ['route', 'method', 'status'] as const,
   percentiles: [0.5, 0.9, 0.99]
 })
 
-const httpRequestsTotal = new client.Counter({
+const httpRequestsTotal = counter({
   name: 'http_requests_total',
   help: 'Total HTTP requests by method and status',
   labelNames: ['method', 'status'] as const
 })
 
-const jwtAuthFail = new client.Counter({
+const jwtAuthFail = counter({
   name: 'jwt_auth_fail_total',
   help: 'Total JWT auth failures',
   labelNames: ['reason'] as const
 })
 
-const approvalActions = new client.Counter({
+const approvalActions = counter({
   name: 'metasheet_approval_actions_total',
   help: 'Approval actions count',
   labelNames: ['action', 'result'] as const
 })
 
-const approvalConflict = new client.Counter({
+const approvalConflict = counter({
   name: 'metasheet_approval_conflict_total',
   help: 'Approval version conflicts',
   labelNames: ['action'] as const
 })
 
-const automationWebhookRejectedTotal = new client.Counter({
+const automationWebhookRejectedTotal = counter({
   name: 'automation_webhook_rejected_total',
   help: 'Inbound automation webhook attempts rejected before execution',
   labelNames: ['reason'] as const
 })
 
-const rbacPermCacheHits = new client.Counter({
+const rbacPermCacheHits = counter({
   name: 'rbac_perm_cache_hits_total',
   help: 'RBAC permission cache hits',
   labelNames: [] as const
 })
 
-const rbacPermCacheMiss = new client.Counter({
+const rbacPermCacheMiss = counter({
   name: 'rbac_perm_cache_miss_total',
   help: 'RBAC permission cache misses',
   labelNames: [] as const
 })
 
 // Alias (plural) for compatibility with external scripts
-const rbacPermCacheMisses = new client.Counter({
+const rbacPermCacheMisses = counter({
   name: 'rbac_perm_cache_misses_total',
   help: 'RBAC permission cache misses (alias)',
   labelNames: [] as const
 })
 
 // RBAC denials and auth failures (compatibility names)
-const rbacDenials = new client.Counter({
+const rbacDenials = counter({
   name: 'metasheet_rbac_denials_total',
   help: 'Total RBAC permission denials',
   labelNames: [] as const
 })
 
-const authFailures = new client.Counter({
+const authFailures = counter({
   name: 'metasheet_auth_failures_total',
   help: 'Total authentication failures (alias)',
   labelNames: [] as const
 })
 
 // V2 Integration metrics
-const eventsEmittedTotal = new client.Counter({
+const eventsEmittedTotal = counter({
   name: 'metasheet_events_emitted_total',
   help: 'Total events emitted via EventBus',
   labelNames: [] as const
 })
 
-const messagesProcessedTotal = new client.Counter({
+const messagesProcessedTotal = counter({
   name: 'metasheet_messages_processed_total',
   help: 'Total messages processed via MessageBus',
   labelNames: [] as const
 })
 
-const messagesRetriedTotal = new client.Counter({
+const messagesRetriedTotal = counter({
   name: 'metasheet_messages_retried_total',
   help: 'Total message retries',
   labelNames: [] as const
 })
 
-const messagesExpiredTotal = new client.Counter({
+const messagesExpiredTotal = counter({
   name: 'metasheet_messages_expired_total',
   help: 'Total messages expired (dropped before processing)',
   labelNames: [] as const
 })
 
-const permissionDeniedTotal = new client.Counter({
+const permissionDeniedTotal = counter({
   name: 'metasheet_permission_denied_total',
   help: 'Total permission denied (sandbox) occurrences',
   labelNames: [] as const
 })
 
-const rpcTimeoutsTotal = new client.Counter({
+const rpcTimeoutsTotal = counter({
   name: 'metasheet_rpc_timeouts_total',
   help: 'Total RPC timeouts',
   labelNames: [] as const
 })
 
 // Config reload metrics
-const configReloadTotal = new client.Counter({
+const configReloadTotal = counter({
   name: 'metasheet_config_reload_total',
   help: 'Total config reload operations',
   labelNames: ['result', 'telemetry_restart'] as const
 })
 
-const configVersionGauge = new client.Gauge({
+const configVersionGauge = gauge({
   name: 'metasheet_config_version',
   help: 'Current config version (monotonic counter)',
   labelNames: [] as const
 })
 
-const configSamplingRate = new client.Gauge({
+const configSamplingRate = gauge({
   name: 'metasheet_config_sampling_rate',
   help: 'Current telemetry sampling rate',
   labelNames: [] as const
 })
 
 // Plugin reload metrics (Phase 8)
-const pluginReloadTotal = new client.Counter({
+const pluginReloadTotal = counter({
   name: 'metasheet_plugin_reload_total',
   help: 'Total plugin reload operations',
   labelNames: ['plugin_name', 'result'] as const
 })
 
-const pluginReloadDuration = new client.Histogram({
+const pluginReloadDuration = histogram({
   name: 'metasheet_plugin_reload_duration_seconds',
   help: 'Plugin reload duration in seconds',
   labelNames: ['plugin_name'] as const,
   buckets: [0.1, 0.5, 1, 2, 5, 10]
 })
 
-const pluginStatus = new client.Gauge({
+const pluginStatus = gauge({
   name: 'metasheet_plugin_status',
   help: 'Plugin status indicator (1=current status)',
   labelNames: ['plugin_name', 'status'] as const
 })
 
 // Snapshot metrics (Phase 9)
-const snapshotCreateTotal = new client.Counter({
+const snapshotCreateTotal = counter({
   name: 'metasheet_snapshot_create_total',
   help: 'Total snapshot create operations',
   labelNames: ['result'] as const
 })
 
-const snapshotRestoreTotal = new client.Counter({
+const snapshotRestoreTotal = counter({
   name: 'metasheet_snapshot_restore_total',
   help: 'Total snapshot restore operations',
   labelNames: ['result'] as const
 })
 
-const snapshotOperationDuration = new client.Histogram({
+const snapshotOperationDuration = histogram({
   name: 'metasheet_snapshot_operation_duration_seconds',
   help: 'Snapshot operation duration in seconds',
   labelNames: ['operation'] as const,
   buckets: [0.1, 0.5, 1, 2, 5, 10, 30]
 })
 
-const snapshotCleanupTotal = new client.Counter({
+const snapshotCleanupTotal = counter({
   name: 'metasheet_snapshot_cleanup_total',
   help: 'Total snapshot cleanup operations',
   labelNames: ['result'] as const
 })
 
 // Sprint 2: Snapshot Protection Metrics
-const snapshotTagsTotal = new client.Counter({
+const snapshotTagsTotal = counter({
   name: 'metasheet_snapshot_tags_total',
   help: 'Total count of snapshot tags usage',
   labelNames: ['tag'] as const
 })
 
-const snapshotProtectionLevel = new client.Gauge({
+const snapshotProtectionLevel = gauge({
   name: 'metasheet_snapshot_protection_level',
   help: 'Snapshot protection level distribution',
   labelNames: ['level'] as const
 })
 
-const snapshotReleaseChannel = new client.Gauge({
+const snapshotReleaseChannel = gauge({
   name: 'metasheet_snapshot_release_channel',
   help: 'Snapshot release channel distribution',
   labelNames: ['channel'] as const
 })
 
-const protectionRuleEvaluationsTotal = new client.Counter({
+const protectionRuleEvaluationsTotal = counter({
   name: 'metasheet_protection_rule_evaluations_total',
   help: 'Total protection rule evaluations',
   labelNames: ['rule', 'result'] as const
 })
 
-const protectionRuleBlocksTotal = new client.Counter({
+const protectionRuleBlocksTotal = counter({
   name: 'metasheet_protection_rule_blocks_total',
   help: 'Total operations blocked by protection rules',
   labelNames: ['rule', 'operation'] as const
 })
 
-const snapshotProtectedSkippedTotal = new client.Counter({
+const snapshotProtectedSkippedTotal = counter({
   name: 'metasheet_snapshot_protected_skipped_total',
   help: 'Total protected snapshots skipped during cleanup',
   labelNames: [] as const
 })
 
 // Cache metrics (Phase 1)
-const cache_hits_total = new client.Counter({
+const cache_hits_total = counter({
   name: 'cache_hits_total',
   help: 'Total cache hits',
   labelNames: ['impl', 'key_pattern'] as const
 })
 
-const cache_miss_total = new client.Counter({
+const cache_miss_total = counter({
   name: 'cache_miss_total',
   help: 'Total cache misses',
   labelNames: ['impl', 'key_pattern'] as const
 })
 
-const cache_set_total = new client.Counter({
+const cache_set_total = counter({
   name: 'cache_set_total',
   help: 'Total cache sets',
   labelNames: ['impl', 'key_pattern'] as const
 })
 
-const cache_del_total = new client.Counter({
+const cache_del_total = counter({
   name: 'cache_del_total',
   help: 'Total cache deletions',
   labelNames: ['impl', 'key_pattern'] as const
 })
 
-const cache_errors_total = new client.Counter({
+const cache_errors_total = counter({
   name: 'cache_errors_total',
   help: 'Total cache errors',
   labelNames: ['impl', 'error_type'] as const
 })
 
-const cache_invalidate_total = new client.Counter({
+const cache_invalidate_total = counter({
   name: 'cache_invalidate_total',
   help: 'Total cache invalidations',
   labelNames: ['impl', 'tag'] as const
 })
 
-const cache_enabled = new client.Gauge({
+const cache_enabled = gauge({
   name: 'cache_enabled',
   help: 'Whether cache is enabled (1=enabled, 0=disabled)',
   labelNames: ['impl'] as const
 })
 
-const cache_candidate_requests = new client.Counter({
+const cache_candidate_requests = counter({
   name: 'cache_candidate_requests',
   help: 'Requests that could benefit from caching',
   labelNames: ['route', 'method'] as const
@@ -270,20 +291,20 @@ const cache_candidate_requests = new client.Counter({
 
 // Redis metrics (Phase 5 extension)
 // Redis histogram; ensure creation even if Redis client not used yet
-const redisOperationDuration = new client.Histogram({
+const redisOperationDuration = histogram({
   name: 'redis_operation_duration_seconds',
   help: 'Redis cache operation duration in seconds',
   labelNames: ['op'] as const,
   buckets: [0.0005, 0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2]
 })
 
-const redisRecoveryAttemptsTotal = new client.Counter({
+const redisRecoveryAttemptsTotal = counter({
   name: 'redis_recovery_attempts_total',
   help: 'Redis recovery attempts after failure',
   labelNames: ['result'] as const
 })
 
-const redisLastFailureTimestamp = new client.Gauge({
+const redisLastFailureTimestamp = gauge({
   name: 'redis_last_failure_timestamp',
   help: 'Unix timestamp of last Redis failure',
   labelNames: [] as const
@@ -292,26 +313,26 @@ const redisLastFailureTimestamp = new client.Gauge({
 // Fallback metrics (Phase 5)
 // Tracks degraded responses for SLO validation
 // Reasons: http_error, http_timeout, message_error, message_timeout, cache_miss, circuit_breaker
-const fallbackRawTotal = new client.Counter({
+const fallbackRawTotal = counter({
   name: 'metasheet_fallback_total',
   help: 'Total degraded fallback responses (raw count)',
   labelNames: ['reason'] as const
 })
 
-const fallbackEffectiveTotal = new client.Counter({
+const fallbackEffectiveTotal = counter({
   name: 'metasheet_fallback_effective_total',
   help: 'Effective degraded fallback responses (excludes benign causes like cache_miss when COUNT_CACHE_MISS_AS_FALLBACK=false)',
   labelNames: ['reason'] as const
 })
 
 // RBAC table permission check metrics
-const rbacPermissionChecksTotal = new client.Counter({
+const rbacPermissionChecksTotal = counter({
   name: 'rbac_permission_checks_total',
   help: 'Total RBAC permission checks by operation and result',
   labelNames: ['operation', 'result'] as const
 })
 
-const rbacCheckLatencySeconds = new client.Histogram({
+const rbacCheckLatencySeconds = histogram({
   name: 'rbac_check_latency_seconds',
   help: 'RBAC permission check latency in seconds',
   labelNames: ['operation'] as const,
@@ -319,97 +340,97 @@ const rbacCheckLatencySeconds = new client.Histogram({
 })
 
 // View data metrics (view-service)
-const viewDataLatencySeconds = new client.Histogram({
+const viewDataLatencySeconds = histogram({
   name: 'metasheet_view_data_latency_seconds',
   help: 'View data query latency in seconds',
   labelNames: ['type', 'status'] as const,
   buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5]
 })
 
-const viewDataRequestsTotal = new client.Counter({
+const viewDataRequestsTotal = counter({
   name: 'metasheet_view_data_requests_total',
   help: 'Total view data requests',
   labelNames: ['type', 'result'] as const
 })
 
 // Sprint 4: Advanced Messaging Metrics
-const dlqMessagesTotal = new client.Counter({
+const dlqMessagesTotal = counter({
   name: 'metasheet_dlq_messages_total',
   help: 'Total messages sent to DLQ',
   labelNames: ['topic'] as const
 })
 
-const delayedMessagesTotal = new client.Counter({
+const delayedMessagesTotal = counter({
   name: 'metasheet_delayed_messages_total',
   help: 'Total delayed messages scheduled',
   labelNames: ['topic'] as const
 })
 
 // BPMN Workflow Engine Metrics
-const bpmnProcessInstancesTotal = new client.Counter({
+const bpmnProcessInstancesTotal = counter({
   name: 'bpmn_process_instances_total',
   help: 'Total BPMN process instances started',
   labelNames: ['definition_key', 'result'] as const
 })
 
-const bpmnProcessInstancesActive = new client.Gauge({
+const bpmnProcessInstancesActive = gauge({
   name: 'bpmn_process_instances_active',
   help: 'Current number of active BPMN process instances',
   labelNames: [] as const
 })
 
-const bpmnActivityExecutionsTotal = new client.Counter({
+const bpmnActivityExecutionsTotal = counter({
   name: 'bpmn_activity_executions_total',
   help: 'Total BPMN activity executions',
   labelNames: ['activity_type', 'result'] as const
 })
 
-const bpmnActivityDurationSeconds = new client.Histogram({
+const bpmnActivityDurationSeconds = histogram({
   name: 'bpmn_activity_duration_seconds',
   help: 'BPMN activity execution duration in seconds',
   labelNames: ['activity_type'] as const,
   buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30, 60]
 })
 
-const bpmnProcessDurationSeconds = new client.Histogram({
+const bpmnProcessDurationSeconds = histogram({
   name: 'bpmn_process_duration_seconds',
   help: 'BPMN process instance duration in seconds',
   labelNames: ['definition_key'] as const,
   buckets: [1, 5, 10, 30, 60, 300, 600, 1800, 3600]
 })
 
-const bpmnTimerJobsTotal = new client.Counter({
+const bpmnTimerJobsTotal = counter({
   name: 'bpmn_timer_jobs_total',
   help: 'Total BPMN timer jobs processed',
   labelNames: ['result'] as const
 })
 
-const bpmnSignalEventsTotal = new client.Counter({
+const bpmnSignalEventsTotal = counter({
   name: 'bpmn_signal_events_total',
   help: 'Total BPMN signal events processed',
   labelNames: ['signal_name'] as const
 })
 
-const bpmnMessageEventsTotal = new client.Counter({
+const bpmnMessageEventsTotal = counter({
   name: 'bpmn_message_events_total',
   help: 'Total BPMN message events processed',
   labelNames: ['message_name'] as const
 })
 
-const bpmnProcessErrorsTotal = new client.Counter({
+const bpmnProcessErrorsTotal = counter({
   name: 'bpmn_process_errors_total',
   help: 'Total BPMN process errors',
   labelNames: ['error_type'] as const
 })
 
-const bpmnStuckInstancesGauge = new client.Gauge({
+const bpmnStuckInstancesGauge = gauge({
   name: 'bpmn_stuck_instances',
   help: 'Number of potentially stuck BPMN process instances',
   labelNames: [] as const
 })
 
 // RPC Latency Histogram
-const rpcLatencySeconds = new client.Histogram({
+const rpcLatencySeconds = histogram({
   name: 'metasheet_rpc_latency_seconds',
   help: 'RPC call latency in seconds',
   labelNames: ['method', 'plugin', 'status'] as const,
@@ -417,19 +438,19 @@ const rpcLatencySeconds = new client.Histogram({
 })
 
 // Metrics Stream (real-time WebSocket streaming)
-const metricsStreamClients = new client.Gauge({
+const metricsStreamClients = gauge({
   name: 'metasheet_metrics_stream_clients',
   help: 'Active metrics streaming clients',
   labelNames: [] as const
 })
 
-const metricsStreamPushesTotal = new client.Counter({
+const metricsStreamPushesTotal = counter({
   name: 'metasheet_metrics_stream_pushes_total',
   help: 'Total push events sent via metrics stream',
   labelNames: [] as const
 })
 
-const metricsStreamErrorsTotal = new client.Counter({
+const metricsStreamErrorsTotal = counter({
   name: 'metasheet_metrics_stream_errors_total',
   help: 'Total metrics stream push errors',
   labelNames: [] as const
@@ -438,25 +459,25 @@ const metricsStreamErrorsTotal = new client.Counter({
 // API Gateway + CircuitBreaker observability (Lane 3 / collab-infra rollout).
 // These are exposed via the shared registry so operators can query the
 // same `/metrics/prom` endpoint; no new endpoint is introduced.
-const apigwCbStoreUsedTotal = new client.Counter({
+const apigwCbStoreUsedTotal = counter({
   name: 'apigw_cb_store_used_total',
   help: 'CircuitBreaker store operations by backing implementation',
   labelNames: ['store'] as const
 })
 
-const apigwCbInitTotal = new client.Counter({
+const apigwCbInitTotal = counter({
   name: 'apigw_cb_init_total',
   help: 'APIGateway.initRedisCircuitBreakerStore outcome counts',
   labelNames: ['outcome'] as const
 })
 
-const automationSchedulerLeaderGauge = new client.Gauge({
+const automationSchedulerLeaderGauge = gauge({
   name: 'automation_scheduler_leader',
   help: 'AutomationScheduler leader-lock state (1=current state, 0=other)',
   labelNames: ['state'] as const
 })
 
-const approvalSlaSchedulerLeaderGauge = new client.Gauge({
+const approvalSlaSchedulerLeaderGauge = gauge({
   name: 'approval_sla_scheduler_leader',
   help: 'ApprovalSlaScheduler leader-lock state (1=current state, 0=other)',
   labelNames: ['state'] as const

--- a/packages/core-backend/src/metrics/metrics.ts
+++ b/packages/core-backend/src/metrics/metrics.ts
@@ -42,6 +42,12 @@ const approvalConflict = new client.Counter({
   labelNames: ['action'] as const
 })
 
+const automationWebhookRejectedTotal = new client.Counter({
+  name: 'automation_webhook_rejected_total',
+  help: 'Inbound automation webhook attempts rejected before execution',
+  labelNames: ['reason'] as const
+})
+
 const rbacPermCacheHits = new client.Counter({
   name: 'rbac_perm_cache_hits_total',
   help: 'RBAC permission cache hits',
@@ -462,6 +468,7 @@ registry.registerMetric(httpRequestsTotal)
 registry.registerMetric(jwtAuthFail)
 registry.registerMetric(approvalActions)
 registry.registerMetric(approvalConflict)
+registry.registerMetric(automationWebhookRejectedTotal)
 registry.registerMetric(rbacPermCacheHits)
 registry.registerMetric(rbacPermCacheMiss)
 registry.registerMetric(rbacPermCacheMisses)
@@ -604,6 +611,7 @@ export const metrics = {
   jwtAuthFail,
   approvalActions,
   approvalConflict,
+  automationWebhookRejectedTotal,
   rbacPermCacheHits,
   rbacPermCacheMiss,
   rbacPermCacheMisses,

--- a/packages/core-backend/src/multitable/automation-inbound-webhook.ts
+++ b/packages/core-backend/src/multitable/automation-inbound-webhook.ts
@@ -1,0 +1,96 @@
+import { createHmac, timingSafeEqual } from 'crypto'
+
+export const WEBHOOK_RECEIVED_TRIGGER = 'webhook.received'
+export const INBOUND_WEBHOOK_SIGNATURE_HEADER = 'x-ms-webhook-signature'
+export const INBOUND_WEBHOOK_TIMESTAMP_HEADER = 'x-ms-webhook-timestamp'
+export const INBOUND_WEBHOOK_SIGNATURE_PREFIX = 'sha256='
+export const INBOUND_WEBHOOK_REPLAY_WINDOW_SECONDS = 300
+export const INBOUND_WEBHOOK_BODY_LIMIT = '1mb'
+export const INBOUND_WEBHOOK_RATE_LIMIT_PER_MINUTE = 60
+export const INBOUND_WEBHOOK_RATE_LIMIT_WINDOW_MS = 60_000
+
+export type InboundWebhookRejectReason =
+  | 'unknown_rule'
+  | 'wrong_trigger'
+  | 'disabled'
+  | 'missing_secret'
+  | 'missing_body'
+  | 'invalid_body'
+  | 'missing_timestamp'
+  | 'stale_timestamp'
+  | 'missing_signature'
+  | 'bad_signature'
+
+export function inboundWebhookSecret(triggerConfig: Record<string, unknown> | null | undefined): string {
+  const secret = triggerConfig && typeof triggerConfig.secret === 'string' ? triggerConfig.secret.trim() : ''
+  return secret
+}
+
+export function validateInboundWebhookTriggerAtSave(
+  triggerType: string,
+  triggerConfig: Record<string, unknown> | null | undefined,
+): string | null {
+  if (triggerType !== WEBHOOK_RECEIVED_TRIGGER) return null
+  if (!inboundWebhookSecret(triggerConfig)) {
+    return 'webhook.received requires trigger_config.secret'
+  }
+  return null
+}
+
+export function signInboundWebhookBody(rawBody: Buffer | string, secret: string, unixSeconds: number | string): string {
+  const timestamp = String(unixSeconds)
+  const body = Buffer.isBuffer(rawBody) ? rawBody.toString('utf8') : rawBody
+  const digest = createHmac('sha256', secret)
+    .update(`${timestamp}.${body}`)
+    .digest('hex')
+  return `${INBOUND_WEBHOOK_SIGNATURE_PREFIX}${digest}`
+}
+
+function normalizeSignatureHeader(value: unknown): string {
+  const raw = Array.isArray(value) ? value[0] : value
+  const sig = typeof raw === 'string' ? raw.trim() : ''
+  return sig.startsWith(INBOUND_WEBHOOK_SIGNATURE_PREFIX)
+    ? sig.slice(INBOUND_WEBHOOK_SIGNATURE_PREFIX.length)
+    : sig
+}
+
+export function verifyInboundWebhookSignature(input: {
+  rawBody: Buffer
+  secret: string
+  timestampHeader: unknown
+  signatureHeader: unknown
+  nowMs?: number
+}): { ok: true } | { ok: false; reason: InboundWebhookRejectReason } {
+  const timestampRaw = Array.isArray(input.timestampHeader) ? input.timestampHeader[0] : input.timestampHeader
+  const timestamp = typeof timestampRaw === 'string' ? timestampRaw.trim() : ''
+  if (!timestamp) return { ok: false, reason: 'missing_timestamp' }
+  if (!/^\d+$/.test(timestamp)) return { ok: false, reason: 'stale_timestamp' }
+
+  const tsSeconds = Number(timestamp)
+  const nowSeconds = Math.floor((input.nowMs ?? Date.now()) / 1000)
+  if (!Number.isFinite(tsSeconds) || Math.abs(nowSeconds - tsSeconds) > INBOUND_WEBHOOK_REPLAY_WINDOW_SECONDS) {
+    return { ok: false, reason: 'stale_timestamp' }
+  }
+
+  const providedHex = normalizeSignatureHeader(input.signatureHeader)
+  if (!providedHex) return { ok: false, reason: 'missing_signature' }
+  if (!/^[a-f0-9]{64}$/i.test(providedHex)) return { ok: false, reason: 'bad_signature' }
+
+  const expected = signInboundWebhookBody(input.rawBody, input.secret, timestamp)
+    .slice(INBOUND_WEBHOOK_SIGNATURE_PREFIX.length)
+  const expectedBuffer = Buffer.from(expected, 'hex')
+  const providedBuffer = Buffer.from(providedHex, 'hex')
+  if (expectedBuffer.length !== providedBuffer.length || !timingSafeEqual(expectedBuffer, providedBuffer)) {
+    return { ok: false, reason: 'bad_signature' }
+  }
+  return { ok: true }
+}
+
+export function isTopLevelWebhookJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function redactInboundWebhookTriggerConfig(config: Record<string, unknown>): Record<string, unknown> {
+  if (!Object.prototype.hasOwnProperty.call(config, 'secret')) return config
+  return { ...config, secret: '<redacted>' }
+}

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -20,6 +20,17 @@ import {
   EVENT_DEDUP_LEDGER_SWEEP_INTERVAL_MS,
   withAutomationEventId,
 } from './automation-event-dedup'
+import {
+  INBOUND_WEBHOOK_SIGNATURE_HEADER,
+  INBOUND_WEBHOOK_TIMESTAMP_HEADER,
+  WEBHOOK_RECEIVED_TRIGGER,
+  inboundWebhookSecret,
+  isTopLevelWebhookJsonObject,
+  redactInboundWebhookTriggerConfig,
+  validateInboundWebhookTriggerAtSave,
+  verifyInboundWebhookSignature,
+  type InboundWebhookRejectReason,
+} from './automation-inbound-webhook'
 import { isValidIanaTimeZone } from './automation-timezone'
 import { ensureRecordNotLocked } from './record-lock'
 import { publishMultitableSheetRealtime } from './realtime-publish'
@@ -53,6 +64,7 @@ import {
 } from './automation-approval-bridge-service'
 import type { ApprovalCompletionEventV1 } from '../services/ApprovalCompletionEvent'
 import { applyTemplateVisibilityFilter, type ApprovalTemplateVisibilityActor } from '../services/ApprovalProductService'
+import { metrics } from '../metrics/metrics'
 import {
   normalizeDingTalkAutomationActionInputs,
   validateDingTalkAutomationActionConfigs,
@@ -577,6 +589,10 @@ export type AutomationEventPayload = {
   _triggeredBy?: string
 }
 
+export type InboundWebhookDispatchResult =
+  | { accepted: true; execution: AutomationExecution }
+  | { accepted: false; reason: InboundWebhookRejectReason }
+
 function serializeAutomationConditionFieldRows(rows: unknown[]): AutomationConditionField[] {
   return rows
     .map((row) => {
@@ -859,6 +875,9 @@ export class AutomationService {
     const cronTriggerError = this.validateCronTriggerAtSave(input.triggerType, input.triggerConfig ?? null)
     if (cronTriggerError) throw new AutomationRuleValidationError(cronTriggerError)
 
+    const inboundWebhookError = validateInboundWebhookTriggerAtSave(input.triggerType, input.triggerConfig ?? null)
+    if (inboundWebhookError) throw new AutomationRuleValidationError(inboundWebhookError)
+
     // T1-3: approval.completed rules validate templateId/outcomes/actions/conditions + creator permission.
     const approvalCompletedError = await this.validateApprovalCompletedRuleAtSave(
       input.triggerType,
@@ -1065,6 +1084,12 @@ export class AutomationService {
       )
       if (cronTriggerError) throw new AutomationRuleValidationError(cronTriggerError)
 
+      const inboundWebhookError = validateInboundWebhookTriggerAtSave(
+        nextTriggerType,
+        nextTriggerConfig as Record<string, unknown> | null,
+      )
+      if (inboundWebhookError) throw new AutomationRuleValidationError(inboundWebhookError)
+
       // SERVER-SET activation floor: when the RESULT is a date_field rule, persist `effectiveAt`. Converting
       // INTO date_field (prev type differs) activates NOW; staying date_field (config edit) PRESERVES the
       // existing activation (fall back to created_at for pre-fix rules) so an edit never re-opens backfill.
@@ -1085,6 +1110,31 @@ export class AutomationService {
         updates.trigger_config = JSON.stringify(baseConfig)
         if (updates.trigger_type === undefined) updates.trigger_type = nextTriggerType
       }
+    }
+
+    // T1-2: a legacy/direct-DB secret-less webhook.received rule must be blocked on ANY edit, not only
+    // trigger edits. Otherwise an action-only patch would keep an ingestable-looking rule whose inbound path
+    // later has to fail at runtime. Validate the resulting trigger config for every write shape.
+    if (
+      input.triggerType !== undefined
+      || input.triggerConfig !== undefined
+      || input.actionType !== undefined
+      || input.actionConfig !== undefined
+      || input.actions !== undefined
+      || input.executionMode !== undefined
+      || input.conditions !== undefined
+      || input.name !== undefined
+      || input.enabled !== undefined
+    ) {
+      const existingForWebhook = existingRuleSnapshot !== undefined ? existingRuleSnapshot : await this.getRule(ruleId)
+      existingRuleSnapshot = existingForWebhook
+      if (!existingForWebhook || existingForWebhook.sheet_id !== sheetId) return null
+      const nextTriggerType = input.triggerType ?? existingForWebhook.trigger_type
+      const nextTriggerConfig = (
+        input.triggerConfig !== undefined ? input.triggerConfig : existingForWebhook.trigger_config
+      ) as Record<string, unknown> | null
+      const inboundWebhookError = validateInboundWebhookTriggerAtSave(nextTriggerType, nextTriggerConfig)
+      if (inboundWebhookError) throw new AutomationRuleValidationError(inboundWebhookError)
     }
 
     // T1-3: when the RESULTING rule is approval.completed, validate the full resulting shape (trigger config
@@ -1718,6 +1768,66 @@ export class AutomationService {
       logger.warn('approval.completed template visibility check failed; denying (fail-closed)', err instanceof Error ? err : undefined)
       return false
     }
+  }
+
+  private rejectInboundWebhook(ruleId: string, reason: InboundWebhookRejectReason): InboundWebhookDispatchResult {
+    try {
+      metrics.automationWebhookRejectedTotal.labels(reason).inc()
+    } catch {
+      // Metrics must never change the webhook security outcome.
+    }
+    logger.warn(`webhook.received rejected rule=${ruleId || '<missing>'} reason=${reason}`)
+    return { accepted: false, reason }
+  }
+
+  /**
+   * T1-2 inbound webhook dispatch.
+   *
+   * The caller is anonymous; only possession of the per-rule secret authorizes delivery. The request body is
+   * exposed as `recordData`, but record context is intentionally synthetic (`recordId=''`, `actorId=null`):
+   * caller-supplied `recordId` / `sheetId` / actor-shaped fields are data only and cannot retarget actions
+   * or impersonate a user. Side effects run under the stored rule author, matching scheduled triggers.
+   */
+  async handleInboundWebhook(
+    ruleId: string,
+    rawBody: Buffer,
+    parsedBody: unknown,
+    headers: Record<string, unknown>,
+    nowMs = Date.now(),
+  ): Promise<InboundWebhookDispatchResult> {
+    if (!ruleId) return this.rejectInboundWebhook(ruleId, 'unknown_rule')
+    if (rawBody.length === 0) return this.rejectInboundWebhook(ruleId, 'missing_body')
+    if (!isTopLevelWebhookJsonObject(parsedBody)) return this.rejectInboundWebhook(ruleId, 'invalid_body')
+
+    const rule = await this.getRule(ruleId)
+    if (!rule) return this.rejectInboundWebhook(ruleId, 'unknown_rule')
+    if (rule.trigger_type !== WEBHOOK_RECEIVED_TRIGGER) return this.rejectInboundWebhook(ruleId, 'wrong_trigger')
+    if (!rule.enabled) return this.rejectInboundWebhook(ruleId, 'disabled')
+
+    const secret = inboundWebhookSecret(rule.trigger_config)
+    if (!secret) return this.rejectInboundWebhook(ruleId, 'missing_secret')
+
+    const verified = verifyInboundWebhookSignature({
+      rawBody,
+      secret,
+      timestampHeader: headers[INBOUND_WEBHOOK_TIMESTAMP_HEADER],
+      signatureHeader: headers[INBOUND_WEBHOOK_SIGNATURE_HEADER],
+      nowMs,
+    })
+    if (verified.ok === false) return this.rejectInboundWebhook(ruleId, verified.reason)
+
+    const triggerEvent: AutomationEventPayload & Record<string, unknown> = {
+      sheetId: rule.sheet_id,
+      recordId: '',
+      data: parsedBody,
+      actorId: null,
+      _triggeredBy: WEBHOOK_RECEIVED_TRIGGER,
+      webhook: {
+        body: parsedBody,
+      },
+    }
+    const execution = await this.executeRule(toExecutorRule(rule), triggerEvent)
+    return { accepted: true, execution }
   }
 
   async handleEvent(eventType: string, payload: AutomationEventPayload): Promise<void> {
@@ -2551,7 +2661,10 @@ export type SerializedAutomationRule = {
  * Shape preserved verbatim from the legacy `univer-meta.ts` route.
  */
 export function serializeAutomationRule(rule: AutomationRule): SerializedAutomationRule {
-  const triggerConfig = rule.trigger_config ?? {}
+  const rawTriggerConfig = rule.trigger_config ?? {}
+  const triggerConfig = rule.trigger_type === WEBHOOK_RECEIVED_TRIGGER
+    ? redactInboundWebhookTriggerConfig(rawTriggerConfig)
+    : rawTriggerConfig
   const actionConfig = rule.action_config ?? {}
   return {
     id: rule.id,

--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -17,12 +17,18 @@
  *   stats → AutomationStats (flat object)
  */
 
-import { Router, type Request, type Response } from 'express'
+import express, { Router, type Request, type Response } from 'express'
 import type { AutomationService } from '../multitable/automation-service'
 import { redactAutomationExecutionForResponse } from '../multitable/automation-log-service'
 import type { AutomationExecution, AutomationStepResult } from '../multitable/automation-executor'
 import { legacyAutomationStatusToJobStatus } from '../multitable/workflow-job-contract'
 import { requireAdminRole } from '../guards/audit-integration'
+import { createRateLimiter } from '../middleware/rate-limiter'
+import {
+  INBOUND_WEBHOOK_BODY_LIMIT,
+  INBOUND_WEBHOOK_RATE_LIMIT_PER_MINUTE,
+  INBOUND_WEBHOOK_RATE_LIMIT_WINDOW_MS,
+} from '../multitable/automation-inbound-webhook'
 
 // ── A2 run-governance read mappers (boundary only — no storage change) ───────
 
@@ -36,6 +42,26 @@ const C1_TO_LEGACY: Record<string, string> = {
 }
 // C1 future states no stored row can match yet → legal filter, empty result (no contract churn at A6).
 const C1_FUTURE_STATUSES = new Set(['queued', 'suspended', 'rejected', 'errored'])
+
+type RawBodyRequest = Request & { rawBody?: Buffer }
+
+export const automationWebhookJsonParser = express.json({
+  limit: INBOUND_WEBHOOK_BODY_LIMIT,
+  strict: false,
+  verify: (req, _res, buf) => {
+    (req as RawBodyRequest).rawBody = Buffer.from(buf)
+  },
+})
+
+const inboundWebhookRateLimiter = createRateLimiter({
+  windowMs: INBOUND_WEBHOOK_RATE_LIMIT_WINDOW_MS,
+  maxRequests: INBOUND_WEBHOOK_RATE_LIMIT_PER_MINUTE,
+  keyPrefix: 'automation-inbound-webhook',
+  keyFn: (req) => (typeof req.params.ruleId === 'string' && req.params.ruleId ? req.params.ruleId : undefined),
+  onLimited: (_req, res, retryAfterSeconds) => {
+    res.status(429).json({ ok: false, error: { code: 'RATE_LIMITED', retryAfter: retryAfterSeconds } })
+  },
+})
 
 type StatusFilter =
   | { kind: 'none' }
@@ -164,6 +190,26 @@ export function createAutomationRoutes(
     }
     return svc
   }
+
+  // ── T1-2 inbound webhook trigger ───────────────────────────────────────
+
+  router.post(
+    '/automation/webhooks/:ruleId',
+    inboundWebhookRateLimiter,
+    automationWebhookJsonParser,
+    async (req: Request, res: Response) => {
+      const ruleId = typeof req.params.ruleId === 'string' ? req.params.ruleId : ''
+      const svc = getService(res)
+      if (!svc) return undefined
+
+      const rawBody = (req as RawBodyRequest).rawBody
+      const result = await svc.handleInboundWebhook(ruleId, rawBody ?? Buffer.alloc(0), req.body, req.headers as Record<string, unknown>)
+      if (!result.accepted) {
+        return res.status(401).json({ ok: false })
+      }
+      return res.status(202).json({ ok: true, executionId: result.execution.id, status: result.execution.status })
+    },
+  )
 
   // ── Test run ────────────────────────────────────────────────────────────
 

--- a/packages/core-backend/tests/integration/multitable-inbound-webhook-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-inbound-webhook-trigger.test.ts
@@ -1,0 +1,245 @@
+/**
+ * T1-2 inbound webhook trigger — real mounted route + real DB.
+ *
+ * Drives the public unauthenticated route end to end:
+ *   POST /api/multitable/automation/webhooks/:ruleId
+ *     → raw-body HMAC verification
+ *     → AutomationService.handleInboundWebhook
+ *     → executeRule
+ *     → durable multitable_automation_executions row.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { AutomationService, type AutomationRule } from '../../src/multitable/automation-service'
+import { automationWebhookJsonParser, createAutomationRoutes } from '../../src/routes/automation'
+import { signInboundWebhookBody } from '../../src/multitable/automation-inbound-webhook'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE = `base_iwh_${TS}`
+const SHEET = `sheet_iwh_${TS}`
+const CREATOR = `u_iwh_${TS}`
+const SECRET = 'inbound-secret'
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const queryFn = ((sql: string, params?: unknown[]) => poolManager.get().query(sql, params)) as never
+
+let app: Express
+let svc: AutomationService
+const ruleIds: string[] = []
+const notifications: Array<Record<string, unknown>> = []
+
+function bodyBuffer(value: unknown): Buffer {
+  return Buffer.from(JSON.stringify(value))
+}
+
+function signedHeaders(rawBody: Buffer, secret = SECRET, timestamp = Math.floor(Date.now() / 1000)): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'X-MS-Webhook-Timestamp': String(timestamp),
+    'X-MS-Webhook-Signature': signInboundWebhookBody(rawBody, secret, timestamp),
+  }
+}
+
+async function createWebhookRule(name: string, overrides: Partial<Parameters<AutomationService['createRule']>[1]> = {}): Promise<AutomationRule> {
+  const rule = await svc.createRule(SHEET, {
+    name,
+    triggerType: 'webhook.received',
+    triggerConfig: { secret: SECRET },
+    actionType: 'send_notification',
+    actionConfig: { userIds: [CREATOR], message: name },
+    createdBy: CREATOR,
+    ...overrides,
+  })
+  ruleIds.push(rule.id)
+  return rule
+}
+
+async function executionRows(ruleId: string): Promise<Array<Record<string, unknown>>> {
+  const res = await q(
+    `SELECT id, status, trigger_event
+       FROM multitable_automation_executions
+      WHERE rule_id = $1
+      ORDER BY created_at ASC`,
+    [ruleId],
+  )
+  return res.rows as Array<Record<string, unknown>>
+}
+
+describeIfDatabase('T1-2 inbound webhook trigger (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'Inbound Webhook Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'Inbound Webhook Sheet'])
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+      [CREATOR, `${CREATOR}@iwh.test`],
+    )
+
+    const bus = new EventBus()
+    bus.subscribe('automation.notification', (payload) => notifications.push(payload as Record<string, unknown>))
+    svc = new AutomationService(bus, db as never, queryFn)
+
+    app = express()
+    // Mirrors production: this prefix captures raw bytes before the general JSON parser.
+    app.use('/api/multitable/automation/webhooks', automationWebhookJsonParser)
+    app.use(express.json())
+    app.use('/api/multitable', createAutomationRoutes(svc))
+  })
+
+  afterAll(async () => {
+    try { svc?.shutdown() } catch { /* noop */ }
+    if (ruleIds.length > 0) {
+      await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    }
+    await q('DELETE FROM users WHERE id = $1', [CREATOR]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('save gate rejects webhook.received rules without a secret on create and any later edit', async () => {
+    await expect(svc.createRule(SHEET, {
+      name: 'missing secret',
+      triggerType: 'webhook.received',
+      triggerConfig: {},
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'x' },
+      createdBy: CREATOR,
+    })).rejects.toThrow(/webhook\.received requires trigger_config\.secret/)
+
+    const dirtyId = `atr_iwh_dirty_${TS}`
+    ruleIds.push(dirtyId)
+    await q(
+      `INSERT INTO automation_rules
+        (id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_by)
+       VALUES ($1,$2,$3,'webhook.received',$4::jsonb,'send_notification',$5::jsonb,TRUE,$6)`,
+      [dirtyId, SHEET, 'dirty', '{}', JSON.stringify({ userIds: [CREATOR], message: 'dirty' }), CREATOR],
+    )
+
+    await expect(svc.updateRule(dirtyId, SHEET, { name: 'dirty edited' }))
+      .rejects.toThrow(/webhook\.received requires trigger_config\.secret/)
+  })
+
+  test('mounted route rejects arrays, primitives, and empty body', async () => {
+    for (const value of [[1], 'x', 42, true]) {
+      const raw = bodyBuffer(value)
+      const res = await request(app)
+        .post('/api/multitable/automation/webhooks/atr_missing')
+        .set(signedHeaders(raw))
+        .send(raw.toString('utf8'))
+      expect(res.status).toBe(401)
+      expect(res.body).toEqual({ ok: false })
+    }
+
+    const empty = await request(app)
+      .post('/api/multitable/automation/webhooks/atr_missing')
+      .set('Content-Type', 'application/json')
+      .send('')
+    expect(empty.status).toBe(401)
+    expect(empty.body).toEqual({ ok: false })
+  })
+
+  test('uniform 401 rejects unknown rule, wrong trigger, disabled, bad signature, stale timestamp, and missing secret', async () => {
+    const raw = bodyBuffer({ event: 'x' })
+    await request(app)
+      .post('/api/multitable/automation/webhooks/atr_unknown')
+      .set(signedHeaders(raw))
+      .send(raw.toString('utf8'))
+      .expect(401, { ok: false })
+
+    const wrong = await svc.createRule(SHEET, {
+      name: 'wrong trigger',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'wrong' },
+      createdBy: CREATOR,
+    })
+    ruleIds.push(wrong.id)
+    await request(app)
+      .post(`/api/multitable/automation/webhooks/${wrong.id}`)
+      .set(signedHeaders(raw))
+      .send(raw.toString('utf8'))
+      .expect(401, { ok: false })
+
+    const disabled = await createWebhookRule('disabled', { enabled: false })
+    await request(app)
+      .post(`/api/multitable/automation/webhooks/${disabled.id}`)
+      .set(signedHeaders(raw))
+      .send(raw.toString('utf8'))
+      .expect(401, { ok: false })
+
+    const ok = await createWebhookRule('reject matrix')
+    await request(app)
+      .post(`/api/multitable/automation/webhooks/${ok.id}`)
+      .set({ ...signedHeaders(raw), 'X-MS-Webhook-Signature': 'sha256='.padEnd(71, '0') })
+      .send(raw.toString('utf8'))
+      .expect(401, { ok: false })
+
+    const staleTs = Math.floor(Date.now() / 1000) - 301
+    await request(app)
+      .post(`/api/multitable/automation/webhooks/${ok.id}`)
+      .set(signedHeaders(raw, SECRET, staleTs))
+      .send(raw.toString('utf8'))
+      .expect(401, { ok: false })
+
+    const secretlessId = `atr_iwh_secretless_${TS}`
+    ruleIds.push(secretlessId)
+    await q(
+      `INSERT INTO automation_rules
+        (id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_by)
+       VALUES ($1,$2,$3,'webhook.received',$4::jsonb,'send_notification',$5::jsonb,TRUE,$6)`,
+      [secretlessId, SHEET, 'secretless', '{}', JSON.stringify({ userIds: [CREATOR], message: 'secretless' }), CREATOR],
+    )
+    await request(app)
+      .post(`/api/multitable/automation/webhooks/${secretlessId}`)
+      .set(signedHeaders(raw))
+      .send(raw.toString('utf8'))
+      .expect(401, { ok: false })
+  })
+
+  test('accepted signed request executes once and cannot spoof record, sheet, or actor context from body', async () => {
+    const rule = await createWebhookRule('accepted')
+    const raw = bodyBuffer({
+      event: 'external.created',
+      recordId: 'rec_attacker',
+      sheetId: 'sheet_attacker',
+      actorId: 'u_attacker',
+      value: 123,
+    })
+
+    const res = await request(app)
+      .post(`/api/multitable/automation/webhooks/${rule.id}`)
+      .set(signedHeaders(raw))
+      .send(raw.toString('utf8'))
+      .expect(202)
+    expect(res.body).toMatchObject({ ok: true, status: 'success' })
+
+    const rows = await executionRows(rule.id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe('success')
+    const event = rows[0].trigger_event as Record<string, unknown>
+    expect(event.sheetId).toBe(SHEET)
+    expect(event.recordId).toBe('')
+    expect(event.actorId).toBeNull()
+    expect(event.data).toMatchObject({
+      recordId: 'rec_attacker',
+      sheetId: 'sheet_attacker',
+      actorId: 'u_attacker',
+      value: 123,
+    })
+    expect(notifications.some((n) => n.message === 'accepted')).toBe(true)
+  })
+})

--- a/packages/core-backend/tests/unit/automation-inbound-webhook.test.ts
+++ b/packages/core-backend/tests/unit/automation-inbound-webhook.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  signInboundWebhookBody,
+  validateInboundWebhookTriggerAtSave,
+  verifyInboundWebhookSignature,
+  redactInboundWebhookTriggerConfig,
+} from '../../src/multitable/automation-inbound-webhook'
+
+describe('automation inbound webhook helpers', () => {
+  test('verifies HMAC-SHA256 over timestamp.rawBody and strips sha256= before constant-time compare', () => {
+    const rawBody = Buffer.from(JSON.stringify({ event: 'ok' }))
+    const timestamp = '1782900000'
+    const signature = signInboundWebhookBody(rawBody, 'secret-1', timestamp)
+
+    expect(verifyInboundWebhookSignature({
+      rawBody,
+      secret: 'secret-1',
+      timestampHeader: timestamp,
+      signatureHeader: signature,
+      nowMs: Number(timestamp) * 1000,
+    })).toEqual({ ok: true })
+  })
+
+  test('rejects stale timestamps and bad signatures', () => {
+    const rawBody = Buffer.from('{"x":1}')
+    const timestamp = '1782900000'
+    const signature = signInboundWebhookBody(rawBody, 'secret-1', timestamp)
+    const badSignature = `${signature.slice(0, -1)}${signature.endsWith('0') ? '1' : '0'}`
+
+    expect(verifyInboundWebhookSignature({
+      rawBody,
+      secret: 'secret-1',
+      timestampHeader: timestamp,
+      signatureHeader: signature,
+      nowMs: (Number(timestamp) + 301) * 1000,
+    })).toEqual({ ok: false, reason: 'stale_timestamp' })
+
+    expect(verifyInboundWebhookSignature({
+      rawBody,
+      secret: 'secret-1',
+      timestampHeader: timestamp,
+      signatureHeader: badSignature,
+      nowMs: Number(timestamp) * 1000,
+    })).toEqual({ ok: false, reason: 'bad_signature' })
+  })
+
+  test('save gate requires a non-empty secret for webhook.received', () => {
+    expect(validateInboundWebhookTriggerAtSave('webhook.received', {})).toBe('webhook.received requires trigger_config.secret')
+    expect(validateInboundWebhookTriggerAtSave('webhook.received', { secret: '  ' })).toBe('webhook.received requires trigger_config.secret')
+    expect(validateInboundWebhookTriggerAtSave('webhook.received', { secret: 's' })).toBeNull()
+    expect(validateInboundWebhookTriggerAtSave('record.created', {})).toBeNull()
+  })
+
+  test('HTTP rule serialization redacts webhook trigger secrets', () => {
+    expect(redactInboundWebhookTriggerConfig({ secret: 'live-secret', label: 'ingress' }))
+      .toEqual({ secret: '<redacted>', label: 'ingress' })
+  })
+})

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -3183,6 +3183,9 @@ describe('AutomationService — Rule CRUD', () => {
 
   it('updateRule returns updated rule', async () => {
     const updatedRow = makeRuleRow({ name: 'Updated' })
+    // T1-2 webhook save gate reads the existing trigger even for name-only edits so a legacy/direct-DB
+    // secret-less webhook.received rule cannot be edited forward.
+    dbExecuteTakeFirstResults.push(makeRuleRow())
     dbExecuteResults.push([updatedRow])
     const rule = await service.updateRule('atr_1', 'sheet_1', { name: 'Updated' })
     expect(rule).not.toBeNull()

--- a/packages/core-backend/tests/unit/metrics-auth.test.ts
+++ b/packages/core-backend/tests/unit/metrics-auth.test.ts
@@ -1,6 +1,7 @@
 import express from 'express'
+import client from 'prom-client'
 import request from 'supertest'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createMetricsAuthMiddleware, resolveMetricsScrapeToken } from '../../src/metrics/metrics'
 
@@ -72,5 +73,17 @@ describe('metrics auth middleware', () => {
 
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ ok: true })
+  })
+
+  it('keeps custom metrics out of the prom-client default registry across module reloads', async () => {
+    client.register.clear()
+
+    vi.resetModules()
+    await import('../../src/metrics/metrics')
+    vi.resetModules()
+    await import('../../src/metrics/metrics')
+
+    expect(client.register.getSingleMetric('http_server_requests_seconds')).toBeUndefined()
+    expect(client.register.getSingleMetric('automation_webhook_rejected_total')).toBeUndefined()
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -79,6 +79,9 @@ export default defineConfig({
       // does not skip-green, and wired as a WHOLE FILE into the `Run multitable real-DB integration`
       // job in plugin-tests.yml where it runs against real Postgres every PR.
       'tests/integration/multitable-event-dedup-trigger.test.ts',
+      // T1-2 inbound webhook trigger: mounted-route + real-DB execution row. Excluded from the no-DB
+      // default job so it does not skip-green, and wired as a WHOLE FILE into the multitable real-DB lane.
+      'tests/integration/multitable-inbound-webhook-trigger.test.ts',
       // comments.api.test.ts needs setup.integration.ts + a live DB. It stays
       // CI-excluded (NOT wired) because 8 of its tests have a pre-existing real-wire
       // failure (CommentService.mapRowToComment drops containerId/targetId/


### PR DESCRIPTION
## Summary
- add signed `POST /api/multitable/automation/webhooks/:ruleId` delivery for `webhook.received` rules
- require non-empty per-rule secrets at create/update, reject legacy secret-less rules on edit/ingest, and redact secrets on rule reads
- verify HMAC over `timestamp.rawBody`, enforce 5-minute replay window, 1MB JSON limit, 60/min/rule rate limit, uniform 401 rejects, and rejection metrics
- wire the real-DB integration file into CI and document the T1-2 dev/verification record

## Security boundary
- caller-supplied `recordId` / `sheetId` / actor-shaped fields remain body data only; the execution context is synthetic record-less with `actorId=null`
- accepted webhooks execute under the stored automation rule author, same as scheduled/event triggers
- malformed / stale / unsigned / wrong-trigger / disabled / missing-secret paths all fail closed

## Not included
- editor UI exposure for configuring webhook secrets
- secret rotation history / dual-secret windows
- source IP allowlists

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/automation-inbound-webhook.test.ts tests/unit/automation-routes-wiring.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/automation-v1.test.ts tests/unit/multitable-automation-service.test.ts tests/unit/automation-inbound-webhook.test.ts tests/unit/automation-routes-wiring.test.ts --reporter=dot`
- `DATABASE_URL=${DATABASE_URL:-postgresql://postgres@localhost:5432/metasheet_test} pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-inbound-webhook-trigger.test.ts tests/integration/multitable-event-dedup-trigger.test.ts tests/integration/multitable-form-submit-trigger.test.ts tests/integration/automation-approval-completed-trigger.test.ts --reporter=dot`
