### PR TITLE
feat(approval): add scoped admin handover

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -346,6 +346,7 @@ jobs:
             tests/integration/approval-node-sla-remind.test.ts \
             tests/integration/approval-node-timeout-effects.test.ts \
             tests/integration/approval-nofm-threshold.test.ts \
+            tests/integration/approval-bulk-reassign.api.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/docs/development/approval-scoped-admins-handover-dev-verification-20260702.md
+++ b/docs/development/approval-scoped-admins-handover-dev-verification-20260702.md
@@ -1,0 +1,77 @@
+# Approval scoped admins + bulk handover — dev and verification
+
+Date: 2026-07-02
+Status: REVIEWABLE
+PR: #3490
+
+## Scope
+
+This slice implements the T2-1+2 defaults from the second-batch ballot:
+
+- split approval administration capabilities:
+  - `approvals:admin` for process recovery operations,
+  - `approvals:admin-templates` for template/delegation authoring,
+  - `approvals:admin-data` reserved for data-recovery scoped work;
+- bulk handover for active platform approval instances from one user assignee to another;
+- per-instance best-effort manifest `{ succeeded, skipped }`;
+- `reassign` audit action and version bump on successful handover;
+- realtime/count refresh fan-out for actor, source user, target user, and affected requesters.
+
+Non-goals:
+
+- no data-scoped admin model;
+- no role/dynamic assignment rewrite;
+- no cross-base or source-system handover;
+- no version-conflict skip, because the API does not accept a version precondition.
+
+## Implementation
+
+- Added migration `zzzz20260702110000_add_approval_reassign_and_admin_scopes`.
+  - Extends `approval_records.action` CHECK with `reassign`.
+  - Registers the three scoped permission codes and grants them to the admin role.
+  - Restores the old CHECK as `NOT VALID` on down.
+  - Down removes only the two newly-introduced split codes (`approvals:admin-templates`, `approvals:admin-data`); it preserves the pre-existing `approvals:admin` seeded by the admin-jump migration.
+- Added `ApprovalProductService.bulkReassignApprovals`.
+  - Validates active target user.
+  - Enumerates active user assignments for `fromUserId` only when `instanceIds` is omitted.
+  - Treats an explicit empty `instanceIds: []` as an empty handover, never as "enumerate all".
+  - Locks each instance with `FOR UPDATE`.
+  - Skips non-pending, missing, not-assigned, target-is-requester, target-already-assignee, invalid-target, and unexpected per-instance errors.
+  - Deactivates source active user assignments and inserts static user assignments for the target with `metadata.reassignedFrom` and `metadata.adminReassign`.
+  - Writes a `reassign` audit record per affected node and bumps `approval_instances.version`.
+- Added `POST /api/approvals/admin/reassign`.
+  - Gated by `approvals:admin`.
+  - Does not admit `approvals:admin-templates`.
+- Replaced template/delegation authoring gates with the shared template-admin guard:
+  - `approval-templates:manage` or `approvals:admin-templates`.
+  - Visibility-manager checks also recognize `approvals:*` and `approvals:admin-templates`.
+- Updated the approval schema bootstrap marker so stale integration DBs rebuild the `approval_records_action_check` constraint.
+
+## Verification
+
+Local verification:
+
+- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` — PASS.
+- `DATABASE_URL=... pnpm --filter @metasheet/core-backend db:migrate` — PASS; migration executed.
+- `DATABASE_URL=... pnpm --filter @metasheet/core-backend db:rollback && DATABASE_URL=... pnpm --filter @metasheet/core-backend db:migrate` — PASS; down/up round-trip executed, with `approvals:admin` preserved after rollback and the two split codes restored after migrate.
+- DB readback: `approval_records_action_check` includes `reassign`.
+- `DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-bulk-reassign.api.test.ts --reporter=dot` — PASS, 3/3.
+- `DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-node-timeout-effects.test.ts tests/integration/approval-nofm-threshold.test.ts --reporter=dot` — PASS, 18/18.
+- `DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-directory-endpoints.api.test.ts tests/integration/approval-delegation-api.db.test.ts --reporter=dot` — PASS, 16/16.
+- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/approvals-routes.test.ts tests/unit/approval-rbac-boundary.test.ts --reporter=dot` — PASS, 45/45.
+- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/approval-rbac-boundary.test.ts tests/unit/automation-v1.test.ts --reporter=dot` — PASS, 246/246.
+
+New fail-first / boundary coverage:
+
+- `approvals:admin-templates` can create approval templates but receives 403 on process handover.
+- Successful user handover deactivates the source assignment, inserts the target assignment, bumps version, writes `reassign` audit, and reruns as `not-assigned`.
+- Explicit empty `instanceIds: []` is a no-op and does not enumerate all active assignments.
+- Invalid target user fails at request boundary.
+- Target requester is skipped fail-closed.
+- Role-typed source assignments are skipped; only active user assignments are rewritten.
+- The integration test is excluded from the no-DB Vitest config and included in the approval real-DB CI lane.
+
+## Follow-ups
+
+- `approvals:admin-data` is registered but has no runtime route yet; it is reserved for a future data-recovery scoped surface.
+- The current `approval_assignments` active-unique index is instance-wide, so a target already active elsewhere in the same instance is skipped to avoid violating the existing schema. A narrower per-node duplicate model would require a schema change and is out of scope.

--- a/packages/core-backend/src/db/migrations/zzzz20260702110000_add_approval_reassign_and_admin_scopes.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260702110000_add_approval_reassign_and_admin_scopes.ts
@@ -1,0 +1,100 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+const ADMIN_SCOPE_PERMISSIONS = [
+  {
+    code: 'approvals:admin',
+    name: 'Approvals Admin',
+    description: 'Perform administrative approval process recovery actions',
+  },
+  {
+    code: 'approvals:admin-templates',
+    name: 'Approval Template Admin',
+    description: 'Manage approval templates without approval process recovery privileges',
+  },
+  {
+    code: 'approvals:admin-data',
+    name: 'Approval Data Recovery Admin',
+    description: 'Perform approval data recovery operations without template administration privileges',
+  },
+] as const
+const NEW_ADMIN_SCOPE_PERMISSION_CODES = ADMIN_SCOPE_PERMISSIONS
+  .map((permission) => permission.code)
+  .filter((code) => code !== 'approvals:admin')
+
+const ACTIONS_WITH_REASSIGN = [
+  'created',
+  'approve',
+  'reject',
+  'return',
+  'revoke',
+  'transfer',
+  'sign',
+  'comment',
+  'cc',
+  'remind',
+  'jump',
+  'add_sign',
+  'reduce_sign',
+  'reassign',
+]
+const ACTIONS_WITHOUT_REASSIGN = ACTIONS_WITH_REASSIGN.filter((action) => action !== 'reassign')
+
+function actionCheck(actions: string[]): string {
+  return `action IN (${actions.map((action) => `'${action}'`).join(', ')})`
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql.raw(`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (${actionCheck(ACTIONS_WITH_REASSIGN)})`).execute(db)
+
+  const permissionsExists = await checkTableExists(db, 'permissions')
+  if (permissionsExists) {
+    for (const permission of ADMIN_SCOPE_PERMISSIONS) {
+      await sql`
+        INSERT INTO permissions (code, name, description)
+        VALUES (${permission.code}, ${permission.name}, ${permission.description})
+        ON CONFLICT (code) DO NOTHING
+      `.execute(db)
+    }
+  }
+
+  const rolePermissionsExists = await checkTableExists(db, 'role_permissions')
+  if (permissionsExists && rolePermissionsExists) {
+    for (const permission of ADMIN_SCOPE_PERMISSIONS) {
+      await sql`
+        INSERT INTO role_permissions (role_id, permission_code)
+        SELECT 'admin', p.code
+        FROM permissions p
+        WHERE p.code = ${permission.code}
+        ON CONFLICT DO NOTHING
+      `.execute(db)
+    }
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const rolePermissionsExists = await checkTableExists(db, 'role_permissions')
+  if (rolePermissionsExists) {
+    await sql`
+      DELETE FROM role_permissions
+      WHERE permission_code IN (${sql.join(NEW_ADMIN_SCOPE_PERMISSION_CODES)})
+    `.execute(db)
+  }
+
+  const permissionsExists = await checkTableExists(db, 'permissions')
+  if (permissionsExists) {
+    await sql`
+      DELETE FROM permissions
+      WHERE code IN (${sql.join(NEW_ADMIN_SCOPE_PERMISSION_CODES)})
+    `.execute(db)
+  }
+
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql.raw(`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (${actionCheck(ACTIONS_WITHOUT_REASSIGN)}) NOT VALID`).execute(db)
+}

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -12,7 +12,7 @@ import { Logger } from '../core/logger'
 import { IPLMAdapter } from '../di/identifiers'
 import { pool } from '../db/pg'
 import { authenticate } from '../middleware/auth'
-import { rbacGuard } from '../rbac/rbac'
+import { rbacGuard, rbacGuardAny } from '../rbac/rbac'
 import { REFUND_WORKFLOW_KEY, type AfterSalesApprovalBridgeService } from '../services/AfterSalesApprovalBridgeService'
 import { ApprovalBridgeService, ServiceError } from '../services/ApprovalBridgeService'
 import {
@@ -43,6 +43,7 @@ import type { FormSchema } from '../types/approval-product'
 
 const logger = new Logger('ApprovalsRouter')
 const MAX_APPROVAL_PAGE_SIZE = 200
+const approvalTemplateAdminGuard = rbacGuardAny(['approval-templates:manage', 'approvals:admin-templates'])
 
 let approvalsDegraded = false
 const allowDegradation = process.env.APPROVALS_OPTIONAL === '1'
@@ -167,6 +168,8 @@ function resolveApprovalTemplateVisibilityActor(req: Request): ApprovalTemplateV
     isTemplateManager: req.user?.role === 'admin'
       || roles.includes('admin')
       || permissions.includes('*:*')
+      || permissions.includes('approvals:*')
+      || permissions.includes('approvals:admin-templates')
       || permissions.includes('approval-templates:manage'),
   }
 }
@@ -356,8 +359,8 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
 
   // Directory lookups for the authoring assignee picker. Registered BEFORE
   // '/api/approval-templates/:id' so 'directory' is not matched as an :id.
-  // Gated by approval-templates:manage (same authoring permission as create/publish).
-  r.get('/api/approval-templates/directory/users', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  // Gated by approval-templates:manage OR the split template-admin capability (same authoring permission as create/publish).
+  r.get('/api/approval-templates/directory/users', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const q = String(req.query.q || '').trim()
       const limit = Number.parseInt(String(req.query.limit ?? '20'), 10)
@@ -368,7 +371,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.get('/api/approval-templates/directory/roles', authenticate, rbacGuard('approval-templates:manage'), async (_req: Request, res: Response) => {
+  r.get('/api/approval-templates/directory/roles', authenticate, approvalTemplateAdminGuard, async (_req: Request, res: Response) => {
     try {
       const roles = await listDirectoryRoles()
       res.json({ roles })
@@ -381,7 +384,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   // approval_usable=true (the curated set the publish/dry-run HARD GATE enforces). Distinct from
   // /directory/roles, which is the shared author picker that ALSO serves static_role approver selection and
   // intentionally returns ALL roles. Curating only requester.role (NOT static_role) is the ratified scope.
-  r.get('/api/approval-templates/directory/formula-roles', authenticate, rbacGuard('approval-templates:manage'), async (_req: Request, res: Response) => {
+  r.get('/api/approval-templates/directory/formula-roles', authenticate, approvalTemplateAdminGuard, async (_req: Request, res: Response) => {
     try {
       const roles = await listFormulaConditionRoles()
       res.json({ roles })
@@ -393,7 +396,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   // FC-4 — approval-specific formula-condition dry-run. This intentionally uses the
   // exact approval evaluator from publish/execution and stays separate from the
   // sheet-scoped multitable formula dry-run API.
-  r.post('/api/approval-templates/formula-condition/dry-run', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.post('/api/approval-templates/formula-condition/dry-run', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const body = isPlainRecord(req.body) ? req.body : {}
       const expression = typeof body.expression === 'string' ? body.expression : ''
@@ -477,7 +480,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.post('/api/approval-templates', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.post('/api/approval-templates', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const template = await productService.createTemplate({
         key: req.body?.key,
@@ -525,7 +528,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.patch('/api/approval-templates/:id', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.patch('/api/approval-templates/:id', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const template = await productService.updateTemplate(req.params.id, {
         key: req.body?.key,
@@ -556,7 +559,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   // the caller must publish the clone separately before it can initiate
   // instances. Mounted *before* the per-id publish route would not matter
   // (path is distinct), but we keep it adjacent to the other per-id routes.
-  r.post('/api/approval-templates/:id/clone', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.post('/api/approval-templates/:id/clone', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const template = await productService.cloneTemplate(req.params.id)
       res.status(201).json(template)
@@ -570,7 +573,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.post('/api/approval-templates/:id/publish', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.post('/api/approval-templates/:id/publish', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const version = await productService.publishTemplate(req.params.id, {
         policy: req.body?.policy,
@@ -586,7 +589,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.get('/api/approval-templates/:id/versions/:versionId', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.get('/api/approval-templates/:id/versions/:versionId', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const version = await productService.getTemplateVersion(req.params.id, req.params.versionId)
       if (!version) {
@@ -794,10 +797,10 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  // 委托设置 (delegation config) — ADMIN-managed (approval-templates:manage). An admin
+  // 委托设置 (delegation config) — template-admin managed. An admin
   // configures delegations for any user: the delegator is a chosen field and the list
   // shows 委托人 + 被委托人. v1: one active row per (delegator, scope target).
-  r.get('/api/approval-delegations', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.get('/api/approval-delegations', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const delegatorUserId = typeof req.query.delegatorUserId === 'string' ? req.query.delegatorUserId : undefined
       res.json({ data: await listDelegations(pool.query.bind(pool), { delegatorUserId }) })
@@ -806,7 +809,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.post('/api/approval-delegations', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.post('/api/approval-delegations', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const body = (req.body ?? {}) as Record<string, unknown>
       const created = await createDelegation(pool.query.bind(pool), {
@@ -823,7 +826,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.patch('/api/approval-delegations/:id', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.patch('/api/approval-delegations/:id', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const id = typeof req.params.id === 'string' ? req.params.id : ''
       const body = (req.body ?? {}) as Record<string, unknown>
@@ -842,7 +845,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.delete('/api/approval-delegations/:id', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.delete('/api/approval-delegations/:id', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const id = typeof req.params.id === 'string' ? req.params.id : ''
       const disabled = await disableDelegation(pool.query.bind(pool), id)
@@ -1421,6 +1424,72 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         error,
         'APPROVAL_ADMIN_JUMP_FAILED',
         'Failed to jump approval',
+      )
+    }
+  })
+
+  r.post('/api/approvals/admin/reassign', authenticate, rbacGuard('approvals:admin'), async (req: Request, res: Response) => {
+    try {
+      const productService = getProductService()
+      const userId = resolveApprovalActorId(req)
+      if (!userId) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
+
+      const fromUserId = normalizeApprovalText(req.body?.fromUserId)
+      const toUserId = normalizeApprovalText(req.body?.toUserId)
+      const reason = normalizeApprovalText(req.body?.reason)
+      if (!fromUserId) {
+        return res.status(400).json(approvalErrorResponse('VALIDATION_ERROR', 'fromUserId is required'))
+      }
+      if (!toUserId) {
+        return res.status(400).json(approvalErrorResponse('VALIDATION_ERROR', 'toUserId is required'))
+      }
+      if (!reason) {
+        return res.status(400).json(approvalErrorResponse('VALIDATION_ERROR', 'reason is required'))
+      }
+      const instanceIds = Array.isArray(req.body?.instanceIds)
+        ? req.body.instanceIds
+            .filter((value: unknown): value is string => typeof value === 'string')
+            .map((value: string) => value.trim())
+            .filter(Boolean)
+        : undefined
+
+      const actor = {
+        userId,
+        userName: resolveApprovalActorName(req, userId),
+        roles: resolveApprovalActorRoles(req),
+        permissions: resolveApprovalActorPermissions(req),
+        tenantId: resolveApprovalTenantId(req),
+        ip: req.ip || null,
+        userAgent: req.get('user-agent') || null,
+      }
+      const result = await productService.bulkReassignApprovals({
+        fromUserId,
+        toUserId,
+        reason,
+        ...(instanceIds !== undefined ? { instanceIds } : {}),
+      }, actor)
+
+      await publishApprovalCountsForUsers(
+        options,
+        [
+          { userId, roles: actor.roles },
+          { userId: fromUserId },
+          { userId: toUserId },
+          ...result.affectedRequesterIds.map((requesterId) => ({ userId: requesterId })),
+        ],
+        'bulk-reassign',
+      )
+      res.json({ ok: true, data: result })
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_BULK_REASSIGN_FAILED',
+        'Failed to bulk reassign approvals',
       )
     }
   })

--- a/packages/core-backend/src/services/ApprovalDelegationConfig.ts
+++ b/packages/core-backend/src/services/ApprovalDelegationConfig.ts
@@ -1,9 +1,9 @@
 /**
  * Approval delegation (委托) — config CRUD (WRITE path).
  *
- * Manages rows in `approval_delegations` for the 委托设置 surface — ADMIN-managed (via
- * approval-templates:manage at the route): an admin creates / lists / patches / disables
- * time-boxed delegations for any user (the delegator is a chosen field). Kept separate
+ * Manages rows in `approval_delegations` for the 委托设置 surface — template-admin managed
+ * at the route: an admin creates / lists / patches / disables time-boxed delegations
+ * for any user (the delegator is a chosen field). Kept separate
  * from the read-only resolve seam (ApprovalDelegations.ts) so the convergence-guarded
  * create-approval path stays write-free.
  */
@@ -131,7 +131,7 @@ export async function listDelegations(query: QueryFn, filter: { delegatorUserId?
 
 /**
  * Disable (soft-delete) a delegation by id. Admin-managed (gated by
- * approval-templates:manage at the route); returns false for an unknown/already-inactive id.
+ * the template-admin guard at the route); returns false for an unknown/already-inactive id.
  */
 export async function disableDelegation(query: QueryFn, id: string): Promise<boolean> {
   const res = await query<{ id: string }>(

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -77,6 +77,7 @@ import { eventBus } from '../integration/events/event-bus'
 
 const metricsLogger = new Logger('ApprovalMetricsHook')
 const nodeTimeoutLogger = new Logger('ApprovalNodeTimeout')
+const approvalProductLogger = new Logger('ApprovalProductService')
 
 function safeMetricsCall(label: string, fn: () => Promise<void>): void {
   Promise.resolve()
@@ -226,6 +227,28 @@ type ApprovalAdminJumpRequest = {
   version: number
   targetNodeKey: string
   reason: string
+}
+
+export type ApprovalBulkReassignSkipReason =
+  | 'not-found'
+  | 'not-pending'
+  | 'not-assigned'
+  | 'target-is-requester'
+  | 'target-already-assignee'
+  | 'target-user-invalid'
+  | 'error'
+
+export type ApprovalBulkReassignRequest = {
+  fromUserId: string
+  toUserId: string
+  instanceIds?: string[]
+  reason: string
+}
+
+export type ApprovalBulkReassignResult = {
+  succeeded: string[]
+  skipped: Array<{ id: string; reason: ApprovalBulkReassignSkipReason }>
+  affectedRequesterIds: string[]
 }
 
 type AdminJumpAuditAssignee = {
@@ -3048,7 +3071,7 @@ export class ApprovalProductService {
    *   - name:  `"{original} (副本)"`
    *   - key:   `"{original}_copy_<6 hex chars>"`     (guarantees uniqueness)
    *
-   * Permission: callers must already hold `approval-templates:manage`; this
+   * Permission: callers must already hold a template-admin capability; this
    * method treats the clone as an ordinary draft creation from the acting
    * admin's perspective.
    */
@@ -3153,6 +3176,8 @@ export class ApprovalProductService {
       roles: actor.roles ?? [],
       permissions: actor.permissions ?? [],
       isTemplateManager: (actor.permissions ?? []).includes('approval-templates:manage')
+        || (actor.permissions ?? []).includes('approvals:admin-templates')
+        || (actor.permissions ?? []).includes('approvals:*')
         || (actor.permissions ?? []).includes('*:*')
         || (actor.roles ?? []).includes('admin'),
     })
@@ -3710,6 +3735,211 @@ export class ApprovalProductService {
       throw new ServiceError('Approval not found after jump', 404, APPROVAL_ERROR_CODES.APPROVAL_NOT_FOUND)
     }
     return approval
+  }
+
+  async bulkReassignApprovals(
+    request: ApprovalBulkReassignRequest,
+    actor: CreateApprovalActor & { ip?: string | null; userAgent?: string | null },
+  ): Promise<ApprovalBulkReassignResult> {
+    if (!pool) throw new Error('Database not available')
+
+    const fromUserId = request.fromUserId.trim()
+    const toUserId = request.toUserId.trim()
+    const reason = request.reason.trim()
+    if (!fromUserId) throw new ServiceError('fromUserId is required', 400, 'VALIDATION_ERROR')
+    if (!toUserId) throw new ServiceError('toUserId is required', 400, 'VALIDATION_ERROR')
+    if (!reason) throw new ServiceError('reason is required', 400, 'VALIDATION_ERROR')
+    if (fromUserId === toUserId) {
+      throw new ServiceError('fromUserId and toUserId must be different', 400, 'VALIDATION_ERROR')
+    }
+
+    const targetUser = await pool.query<{ id: string }>(
+      `SELECT id FROM users WHERE id = $1 AND COALESCE(is_active, TRUE) = TRUE LIMIT 1`,
+      [toUserId],
+    )
+    if (targetUser.rows.length === 0) {
+      throw new ServiceError('Target user is not active', 400, 'APPROVAL_REASSIGN_TARGET_INVALID')
+    }
+
+    const hasExplicitInstanceIds = Array.isArray(request.instanceIds)
+    const explicitIds = hasExplicitInstanceIds
+      ? [...new Set(request.instanceIds.map((id) => id.trim()).filter(Boolean))]
+      : []
+    if (explicitIds.length > 200) {
+      throw new ServiceError('Bulk reassign supports at most 200 instances per request', 400, 'VALIDATION_ERROR')
+    }
+
+    let candidateIds = explicitIds
+    if (!hasExplicitInstanceIds) {
+      const candidates = await pool.query<{ instance_id: string }>(
+        `SELECT DISTINCT a.instance_id
+           FROM approval_assignments a
+           JOIN approval_instances i ON i.id = a.instance_id
+          WHERE a.assignment_type = 'user'
+            AND a.assignee_id = $1
+            AND a.is_active = TRUE
+            AND i.status = 'pending'
+            AND COALESCE(i.source_system, 'platform') = 'platform'
+          ORDER BY a.instance_id ASC
+          LIMIT 200`,
+        [fromUserId],
+      )
+      candidateIds = candidates.rows.map((row) => row.instance_id)
+    }
+
+    const result: ApprovalBulkReassignResult = {
+      succeeded: [],
+      skipped: [],
+      affectedRequesterIds: [],
+    }
+    const affectedRequesters = new Set<string>()
+
+    const skip = (id: string, reasonCode: ApprovalBulkReassignSkipReason): void => {
+      result.skipped.push({ id, reason: reasonCode })
+    }
+
+    for (const instanceId of candidateIds) {
+      let client: ApprovalDbClient | null = null
+      try {
+        client = await pool.connect()
+        await client.query('BEGIN')
+
+        const instanceResult = await client.query<ApprovalInstanceRow>(
+          `SELECT * FROM approval_instances WHERE id = $1 AND COALESCE(source_system, 'platform') = 'platform' FOR UPDATE`,
+          [instanceId],
+        )
+        const instance = instanceResult.rows[0]
+        if (!instance) {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'not-found')
+          continue
+        }
+        if (instance.status !== 'pending') {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'not-pending')
+          continue
+        }
+
+        const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
+        const requesterId = typeof requesterSnapshot?.id === 'string' ? requesterSnapshot.id : null
+        if (requesterId && requesterId === toUserId) {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'target-is-requester')
+          continue
+        }
+
+        const sourceAssignments = await client.query<ApprovalAssignmentRow>(
+          `SELECT *
+             FROM approval_assignments
+            WHERE instance_id = $1
+              AND assignment_type = 'user'
+              AND assignee_id = $2
+              AND is_active = TRUE
+            ORDER BY COALESCE(node_key, ''), created_at ASC
+            FOR UPDATE`,
+          [instanceId, fromUserId],
+        )
+        if (sourceAssignments.rows.length === 0) {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'not-assigned')
+          continue
+        }
+
+        const targetAssignments = await client.query<{ node_key: string | null }>(
+          `SELECT node_key
+             FROM approval_assignments
+            WHERE instance_id = $1
+              AND assignment_type = 'user'
+              AND assignee_id = $2
+              AND is_active = TRUE
+            LIMIT 1`,
+          [instanceId, toUserId],
+        )
+        if (targetAssignments.rows.length > 0) {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'target-already-assignee')
+          continue
+        }
+
+        const nextVersion = instance.version + 1
+        const actorName = actor.userName || actor.userId
+        const reassignments = sourceAssignments.rows.map((assignment) => ({
+          assignmentType: 'user' as const,
+          assigneeId: toUserId,
+          sourceStep: assignment.source_step ?? 0,
+          nodeKey: assignment.node_key || '',
+          metadata: {
+            reassignedFrom: fromUserId,
+            adminReassign: true,
+            previousAssignmentId: assignment.id,
+          },
+        }))
+
+        await client.query(
+          `UPDATE approval_assignments
+              SET is_active = FALSE, updated_at = now()
+            WHERE instance_id = $1
+              AND assignment_type = 'user'
+              AND assignee_id = $2
+              AND is_active = TRUE`,
+          [instanceId, fromUserId],
+        )
+        await this.insertAssignments(client, instanceId, reassignments)
+        await client.query(
+          `UPDATE approval_instances
+              SET version = $2, updated_at = now()
+            WHERE id = $1`,
+          [instanceId, nextVersion],
+        )
+
+        for (const assignment of sourceAssignments.rows) {
+          await this.insertApprovalRecord(client, instanceId, {
+            action: 'reassign',
+            actorId: actor.userId,
+            actorName,
+            comment: reason,
+            fromStatus: instance.status,
+            toStatus: instance.status,
+            fromVersion: instance.version,
+            toVersion: nextVersion,
+            metadata: {
+              adminReassign: true,
+              fromUserId,
+              toUserId,
+              nodeKey: assignment.node_key,
+              previousAssignmentId: assignment.id,
+              reason,
+            },
+            targetUserId: toUserId,
+          }, actor)
+        }
+
+        await client.query('COMMIT')
+        result.succeeded.push(instanceId)
+        if (requesterId) affectedRequesters.add(requesterId)
+      } catch (error) {
+        await rollbackQuietly(client)
+        approvalProductLogger.warn(
+          `bulk approval reassign skipped instance ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
+          error instanceof Error ? error : undefined,
+        )
+        skip(instanceId, 'error')
+      } finally {
+        client?.release()
+      }
+    }
+
+    result.affectedRequesterIds = [...affectedRequesters].sort()
+    eventBus.emit('approval.bulk_reassigned', {
+      actorId: actor.userId,
+      fromUserId,
+      toUserId,
+      reason,
+      succeeded: result.succeeded,
+      skipped: result.skipped,
+      affectedRequesterIds: result.affectedRequesterIds,
+    })
+    return result
   }
 
   /**

--- a/packages/core-backend/src/services/approval-directory.ts
+++ b/packages/core-backend/src/services/approval-directory.ts
@@ -6,9 +6,9 @@ import { query } from '../db/pg'
  * These deliberately return ONLY an identifier + label (and email for users) — far less
  * than admin-users' ADMIN_USER_PROFILE_SELECT / fetchRoleCatalog. The picker needs to turn
  * a free-text id into a human-pickable option, nothing more, and these endpoints are gated
- * upstream by rbacGuard('approval-templates:manage'). Keeping the shape minimal is the
- * least-privilege choice and avoids re-exposing the full admin user profile through a
- * template-authoring surface.
+ * upstream by the template-admin guard (`approval-templates:manage` or
+ * `approvals:admin-templates`). Keeping the shape minimal is the least-privilege choice
+ * and avoids re-exposing the full admin user profile through a template-authoring surface.
  */
 
 export interface DirectoryUserOption {

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -2,6 +2,9 @@ export const APPROVAL_PRODUCT_PERMISSIONS = [
   'approvals:read',
   'approvals:write',
   'approvals:act',
+  'approvals:admin',
+  'approvals:admin-templates',
+  'approvals:admin-data',
   'approval-templates:manage',
 ] as const
 

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -1,11 +1,11 @@
 import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
-// Bumped for P1-B 加签/减签: the action CHECK constraint now also permits
-// 'add_sign' / 'reduce_sign' (mirrors migration
-// zzzz20260616130000_add_add_reduce_sign_actions_to_approval_records.ts). The
-// version marker re-runs the DDL on an already-bootstrapped test DB.
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260622-delegations'
+// Bumped for T2-1+2 admin handover: the action CHECK constraint now also
+// permits 'reassign' (mirrors migration
+// zzzz20260702110000_add_approval_reassign_and_admin_scopes.ts). The version
+// marker re-runs the DDL on an already-bootstrapped test DB.
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260702-admin-reassign'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -181,7 +181,7 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`
       ALTER TABLE approval_records
       ADD CONSTRAINT approval_records_action_check
-      CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc', 'remind', 'jump', 'add_sign', 'reduce_sign'))
+      CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc', 'remind', 'jump', 'add_sign', 'reduce_sign', 'reassign'))
     `)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance ON approval_records(instance_id)`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance_action_time ON approval_records(instance_id, action, occurred_at DESC)`)

--- a/packages/core-backend/tests/integration/approval-bulk-reassign.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-bulk-reassign.api.test.ts
@@ -1,0 +1,331 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+type JsonRecord = Record<string, unknown>
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string, perms = '*:*', roles = 'admin'): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+) {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+function buildFormSchema() {
+  return {
+    fields: [{ id: 'reason', type: 'text', label: '事由', required: true }],
+  }
+}
+
+function buildUserGraph(assigneeId: string) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_a',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: [assigneeId], approvalMode: 'single' },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-a', source: 'start', target: 'approval_a' },
+      { key: 'edge-a-end', source: 'approval_a', target: 'end' },
+    ],
+  }
+}
+
+function buildRoleGraph(roleId: string) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_role',
+        type: 'approval',
+        config: { assigneeType: 'role', assigneeIds: [roleId], approvalMode: 'single' },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-role', source: 'start', target: 'approval_role' },
+      { key: 'edge-role-end', source: 'approval_role', target: 'end' },
+    ],
+  }
+}
+
+describeIfDatabase('Approval T2-1+2 scoped admins + bulk handover — real DB', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+  const createdUserIds = new Set<string>()
+
+  const pool = () => poolManager.get()
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterAll(async () => {
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool().query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_metrics WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool().query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+      if (createdUserIds.size > 0) {
+        await pool().query('DELETE FROM users WHERE id = ANY($1::text[])', [[...createdUserIds]])
+      }
+    } finally {
+      await server?.stop()
+    }
+  })
+
+  async function ensureUsers(...ids: string[]): Promise<void> {
+    for (const id of ids) {
+      createdUserIds.add(id)
+      await pool().query(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active)
+         VALUES ($1, $2, $3, 'test', 'user', '[]'::jsonb, TRUE)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE, updated_at = now()`,
+        [id, `${id}@example.test`, id],
+      )
+    }
+  }
+
+  async function publishTemplate(token: string, graph: object, name: string): Promise<string> {
+    const create = await jsonRequest(baseUrl, '/api/approval-templates', token, {
+      method: 'POST',
+      body: {
+        key: `bulk-reassign-${name}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+        name,
+        description: 'T2-1+2 bulk reassign integration',
+        formSchema: buildFormSchema(),
+        approvalGraph: graph,
+      },
+    })
+    expect(create.status, await create.clone().text()).toBe(201)
+    const template = await create.json() as { id: string }
+    createdTemplateIds.add(template.id)
+    const publish = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, token, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publish.status, await publish.clone().text()).toBe(200)
+    return template.id
+  }
+
+  async function startApproval(token: string, templateId: string): Promise<{ id: string; version: number }> {
+    const create = await jsonRequest(baseUrl, '/api/approvals', token, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 'handover' } },
+    })
+    expect(create.status, await create.clone().text()).toBe(201)
+    const approval = await create.json() as { id: string }
+    createdApprovalIds.add(approval.id)
+    const version = await pool().query<{ version: number }>(
+      `SELECT version FROM approval_instances WHERE id = $1`,
+      [approval.id],
+    )
+    expect(version.rows).toHaveLength(1)
+    return { id: approval.id, version: version.rows[0].version }
+  }
+
+  it('gives approvals:admin-templates a real template-management surface but not process handover', async () => {
+    const templateAdmin = await authToken(baseUrl, 'template-admin-only', 'approvals:admin-templates', 'user')
+    const create = await jsonRequest(baseUrl, '/api/approval-templates', templateAdmin, {
+      method: 'POST',
+      body: {
+        key: `template-admin-surface-${Date.now()}`,
+        name: 'Template admin surface',
+        formSchema: buildFormSchema(),
+        approvalGraph: buildUserGraph('surface-approver'),
+      },
+    })
+    expect(create.status, await create.clone().text()).toBe(201)
+    const template = await create.json() as { id: string }
+    createdTemplateIds.add(template.id)
+
+    const denied = await jsonRequest(baseUrl, '/api/approvals/admin/reassign', templateAdmin, {
+      method: 'POST',
+      body: { fromUserId: 'from-user', toUserId: 'to-user', reason: 'not process admin' },
+    })
+    expect(denied.status).toBe(403)
+  })
+
+  it('reassigns active user assignments, bumps version, audits reassign, and reruns as a no-op', async () => {
+    await ensureUsers('handover-from', 'handover-to')
+    const admin = await authToken(baseUrl, 'handover-admin', 'approvals:admin', 'user')
+    const author = await authToken(baseUrl, 'handover-author')
+    const requester = await authToken(baseUrl, 'handover-requester')
+    const templateId = await publishTemplate(author, buildUserGraph('handover-from'), 'handover-success')
+    const approval = await startApproval(requester, templateId)
+
+    const emptyExplicit = await jsonRequest(baseUrl, '/api/approvals/admin/reassign', admin, {
+      method: 'POST',
+      body: {
+        fromUserId: 'handover-from',
+        toUserId: 'handover-to',
+        instanceIds: [],
+        reason: 'empty explicit list must not enumerate everything',
+      },
+    })
+    expect(emptyExplicit.status, await emptyExplicit.clone().text()).toBe(200)
+    const emptyExplicitBody = await emptyExplicit.json() as { data: { succeeded: string[]; skipped: unknown[] } }
+    expect(emptyExplicitBody.data.succeeded).toEqual([])
+    expect(emptyExplicitBody.data.skipped).toEqual([])
+    const untouched = await pool().query<{ assignee_id: string; is_active: boolean }>(
+      `SELECT assignee_id, is_active
+         FROM approval_assignments
+        WHERE instance_id = $1
+        ORDER BY created_at ASC`,
+      [approval.id],
+    )
+    expect(untouched.rows).toContainEqual({ assignee_id: 'handover-from', is_active: true })
+
+    const first = await jsonRequest(baseUrl, '/api/approvals/admin/reassign', admin, {
+      method: 'POST',
+      body: {
+        fromUserId: 'handover-from',
+        toUserId: 'handover-to',
+        instanceIds: [approval.id],
+        reason: 'employee left',
+      },
+    })
+    expect(first.status, await first.clone().text()).toBe(200)
+    const firstBody = await first.json() as { data: { succeeded: string[]; skipped: unknown[] } }
+    expect(firstBody.data.succeeded, JSON.stringify(firstBody)).toEqual([approval.id])
+    expect(firstBody.data.skipped).toEqual([])
+
+    const state = await pool().query<{
+      version: number
+      assignee_id: string
+      is_active: boolean
+      metadata: JsonRecord | null
+    }>(
+      `SELECT i.version, a.assignee_id, a.is_active, a.metadata
+         FROM approval_instances i
+         JOIN approval_assignments a ON a.instance_id = i.id
+        WHERE i.id = $1
+        ORDER BY a.created_at ASC`,
+      [approval.id],
+    )
+    expect(state.rows.some((row) => row.assignee_id === 'handover-from' && row.is_active === false)).toBe(true)
+    const target = state.rows.find((row) => row.assignee_id === 'handover-to' && row.is_active === true)
+    expect(target?.metadata?.adminReassign).toBe(true)
+    expect(target?.metadata?.reassignedFrom).toBe('handover-from')
+    expect(state.rows[0].version).toBe(approval.version + 1)
+
+    const audit = await pool().query<{ action: string; actor_id: string; target_user_id: string | null; metadata: JsonRecord }>(
+      `SELECT action, actor_id, target_user_id, metadata
+         FROM approval_records
+        WHERE instance_id = $1 AND action = 'reassign'`,
+      [approval.id],
+    )
+    expect(audit.rows).toHaveLength(1)
+    expect(audit.rows[0].actor_id).toBe('handover-admin')
+    expect(audit.rows[0].target_user_id).toBe('handover-to')
+    expect(audit.rows[0].metadata.fromUserId).toBe('handover-from')
+
+    const rerun = await jsonRequest(baseUrl, '/api/approvals/admin/reassign', admin, {
+      method: 'POST',
+      body: {
+        fromUserId: 'handover-from',
+        toUserId: 'handover-to',
+        instanceIds: [approval.id],
+        reason: 'employee left',
+      },
+    })
+    expect(rerun.status, await rerun.clone().text()).toBe(200)
+    const rerunBody = await rerun.json() as { data: { succeeded: string[]; skipped: Array<{ id: string; reason: string }> } }
+    expect(rerunBody.data.succeeded).toEqual([])
+    expect(rerunBody.data.skipped).toEqual([{ id: approval.id, reason: 'not-assigned' }])
+  })
+
+  it('fails closed for invalid target, requester target, and role-typed source assignments', async () => {
+    await ensureUsers('guard-from', 'guard-target', 'role-target')
+    const admin = await authToken(baseUrl, 'guard-admin', 'approvals:admin', 'user')
+    const author = await authToken(baseUrl, 'guard-author')
+    const requesterAsTarget = await authToken(baseUrl, 'guard-target')
+
+    const invalid = await jsonRequest(baseUrl, '/api/approvals/admin/reassign', admin, {
+      method: 'POST',
+      body: { fromUserId: 'guard-from', toUserId: 'missing-target-user', reason: 'invalid target' },
+    })
+    expect(invalid.status).toBe(400)
+
+    const userTemplate = await publishTemplate(author, buildUserGraph('guard-from'), 'requester-target')
+    const requesterTargetApproval = await startApproval(requesterAsTarget, userTemplate)
+    const requesterGuard = await jsonRequest(baseUrl, '/api/approvals/admin/reassign', admin, {
+      method: 'POST',
+      body: {
+        fromUserId: 'guard-from',
+        toUserId: 'guard-target',
+        instanceIds: [requesterTargetApproval.id],
+        reason: 'segregation guard',
+      },
+    })
+    expect(requesterGuard.status, await requesterGuard.clone().text()).toBe(200)
+    const requesterGuardBody = await requesterGuard.json() as { data: { skipped: Array<{ id: string; reason: string }> } }
+    expect(requesterGuardBody.data.skipped).toEqual([{ id: requesterTargetApproval.id, reason: 'target-is-requester' }])
+
+    const roleTemplate = await publishTemplate(author, buildRoleGraph('role-reviewer'), 'role-not-user')
+    const roleApproval = await startApproval(await authToken(baseUrl, 'role-requester'), roleTemplate)
+    const roleGuard = await jsonRequest(baseUrl, '/api/approvals/admin/reassign', admin, {
+      method: 'POST',
+      body: {
+        fromUserId: 'role-reviewer',
+        toUserId: 'role-target',
+        instanceIds: [roleApproval.id],
+        reason: 'role should not handover',
+      },
+    })
+    expect(roleGuard.status, await roleGuard.clone().text()).toBe(200)
+    const roleGuardBody = await roleGuard.json() as { data: { skipped: Array<{ id: string; reason: string }> } }
+    expect(roleGuardBody.data.skipped).toEqual([{ id: roleApproval.id, reason: 'not-assigned' }])
+  })
+})

--- a/packages/core-backend/tests/integration/approval-directory-endpoints.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-directory-endpoints.api.test.ts
@@ -205,7 +205,7 @@ describeIfDatabase('approval directory endpoints (P1-static-picker backend, real
     expect(res.status).toBe(403)
   })
 
-  it('routes are gated by least-privilege approval-templates:manage, NOT ensurePlatformAdmin', () => {
+  it('routes are gated by the least-privilege template-admin guard, NOT ensurePlatformAdmin', () => {
     const src = readFileSync(path.resolve(__dirname, '../../src/routes/approvals.ts'), 'utf8')
     const lines = src.split('\n')
     const usersLine = lines.find((l) => l.includes("'/api/approval-templates/directory/users'"))
@@ -214,9 +214,10 @@ describeIfDatabase('approval directory endpoints (P1-static-picker backend, real
     expect(usersLine).toBeTruthy()
     expect(rolesLine).toBeTruthy()
     expect(formulaRolesLine).toBeTruthy()
-    expect(usersLine).toContain("rbacGuard('approval-templates:manage')")
-    expect(rolesLine).toContain("rbacGuard('approval-templates:manage')")
-    expect(formulaRolesLine).toContain("rbacGuard('approval-templates:manage')")
+    expect(src).toContain("rbacGuardAny(['approval-templates:manage', 'approvals:admin-templates'])")
+    expect(usersLine).toContain('approvalTemplateAdminGuard')
+    expect(rolesLine).toContain('approvalTemplateAdminGuard')
+    expect(formulaRolesLine).toContain('approvalTemplateAdminGuard')
     expect(usersLine).not.toContain('ensurePlatformAdmin')
     expect(rolesLine).not.toContain('ensurePlatformAdmin')
     expect(formulaRolesLine).not.toContain('ensurePlatformAdmin')

--- a/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
@@ -44,14 +44,13 @@ describe('approval admin jump migration and bootstrap sync', () => {
     expect(roleDeleteIndex).toBeLessThan(permissionDeleteIndex)
   })
 
-  it('T-bootstrap keeps approval_schema_bootstrap action check aligned with add_sign/reduce_sign (P1-B)', async () => {
+  it('T-bootstrap keeps approval_schema_bootstrap action check aligned with reassign (P1-B)', async () => {
     const source = await fs.readFile(BOOTSTRAP_PATH, 'utf8')
 
-    // The delegation runtime added approval_delegations to the bootstrap and bumped the
-    // version; the action CHECK still permits add_sign/reduce_sign (Lane D / migration
-    // zzzz20260616130000).
-    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260622-delegations'")
-    expect(source).toContain("'remind', 'jump', 'add_sign', 'reduce_sign'")
+    // The scoped-admin runtime added admin reassign to the bootstrap and bumped the
+    // version; the action CHECK still permits add_sign/reduce_sign plus reassign.
+    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260702-admin-reassign'")
+    expect(source).toContain("'remind', 'jump', 'add_sign', 'reduce_sign', 'reassign'")
   })
 
   it('does not mutate immutable historical approval action migrations', async () => {

--- a/packages/core-backend/tests/unit/approvals-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-routes.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../src/middleware/auth', () => ({
 
 vi.mock('../../src/rbac/rbac', () => ({
   rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  rbacGuardAny: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
 }))
 
 describe('approvals routes', () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -51,6 +51,9 @@ export default defineConfig({
       // no-DB default job so it doesn't skip-green, and wired as a WHOLE FILE into the
       // `Run approval real-DB integration` step in plugin-tests.yml where it runs against real Postgres.
       'tests/integration/approval-nofm-threshold.test.ts',
+      // T2-1+2 scoped approval admins + bulk handover: real-DB route/service boundary with RBAC and
+      // approval_records CHECK coverage. Excluded from the no-DB default and wired into approval real-DB CI.
+      'tests/integration/approval-bulk-reassign.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## Summary

Implements the T2-1+2 scoped approval-admin + bulk handover defaults from the second-batch ballot.

- Adds scoped approval admin permission codes: `approvals:admin`, `approvals:admin-templates`, `approvals:admin-data`.
- Adds `POST /api/approvals/admin/reassign`, gated by `approvals:admin`.
- Allows process admins to reassign active platform user assignments from one user to another with per-instance best-effort results.
- Adds `approval_records.action = 'reassign'`, version bump, per-node audit, count refresh fan-out, and `approval.bulk_reassigned` event.
- Splits template/delegation authoring onto a shared template-admin guard: `approval-templates:manage` or `approvals:admin-templates`.
- Wires the new real-DB test into the approval integration CI lane.
- Adds the dev/verification MD.

## Boundaries

- No data-scoped admin model in this slice.
- No role/dynamic assignment rewrite; only active user assignments are reassigned.
- No cross-base/source-system handover.
- No version-conflict skip, because the API does not accept a version precondition.
- `approvals:admin-data` is registered but has no runtime route yet.

## Review notes

Self-review caught and fixed two important edges:

- Stale approval test DBs did not rebuild `approval_records_action_check` unless the bootstrap marker changed, so the marker is bumped.
- Explicit `instanceIds: []` must not silently become enumerate-all; it is now a no-op and covered by a real-DB test.
- Migration down preserves the pre-existing `approvals:admin` permission seeded by the admin-jump migration and removes only the two new split codes.

## Verification

- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `DATABASE_URL=... pnpm --filter @metasheet/core-backend db:migrate`
- `DATABASE_URL=... pnpm --filter @metasheet/core-backend db:rollback && DATABASE_URL=... pnpm --filter @metasheet/core-backend db:migrate`
- DB readback: `approval_records_action_check` includes `reassign`; rollback preserves `approvals:admin`, migrate restores all three scoped codes.
- `DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-bulk-reassign.api.test.ts --reporter=dot` — 3/3.
- `DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-node-timeout-effects.test.ts tests/integration/approval-nofm-threshold.test.ts --reporter=dot` — 18/18.
- `DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-directory-endpoints.api.test.ts tests/integration/approval-delegation-api.db.test.ts --reporter=dot` — 16/16.
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/approval-rbac-boundary.test.ts tests/unit/automation-v1.test.ts --reporter=dot` — 246/246.
