### PR TITLE
docs(attendance): staging window bundle — AE-4 + RD-4/5 + OT-bank v1-8 (runbooks + helpers + unified plan)

### DIFF
--- a/docs/development/attendance-overtime-bank-v18-staging-smoke-runbook-20260702.md
+++ b/docs/development/attendance-overtime-bank-v18-staging-smoke-runbook-20260702.md
@@ -1,0 +1,614 @@
+# Attendance OT-bank v1-8 staging smoke runbook (三例验收 + settlement snapshot)
+
+**Date:** 2026-07-02
+
+**Status:** PREPARED. This runbook does **not** claim a staging PASS. It is the
+operator checklist for closing overtime-bank v1-8 after the v1-1..v1-6 chain
+(plus the #3255 must-pay e2e and the #3303 settings-restore hygiene fix) is
+deployed to staging.
+
+Do not mark the overtime-bank v1 arc complete from this document alone. The
+closeout happens only after a real run records the PASS stamp in the section
+below **and** the operator-decision blocks in this document are resolved.
+
+**Scope:** v1-8 closes the overtime-bank v1 arc end to end on staging:
+
+- 账1 accrual: overtime approval grants per-source comp-time lots when the bank
+  is enabled, and keeps the legacy NULL-source single lot when dormant;
+- 账2 offset: a rule-driven leave approval deducts the comp-time pool FIFO,
+  with `partial_unpaid_absence` shortfall behavior;
+- 账3 result: the full-attendance flag breaks on any raw leave, even when the
+  pool offset it;
+- 账4 settlement: cycle close writes the immutable settlement snapshot rows
+  (convertible from close-time balance, must-pay from period facts, statutory
+  overtime never poolable/convertible), replay-idempotent, period-frozen;
+- cleanup residue `0`.
+
+It does not add runtime code, a payout producer (v1-7), a settlement read API
+(v1-5d), cross-pool deduction order (v2), or any payroll amount computation.
+
+## What This Proves
+
+The smoke must prove the deployed staging build runs the full
+accrual → offset → settlement money path with the ratified invariants:
+
+1. With `overtimeBankPolicy` dormant, an approved overtime request grants the
+   legacy single NULL-source `comp_time` lot keyed
+   `overtime_conversion:<requestId>` (byte-identical legacy path).
+2. `PUT /api/attendance/settings` rejects
+   `overtimeBankPolicy.pooledSources=['statutory_holiday']` with `400`
+   (compliance floor: statutory-holiday overtime is never poolable).
+3. With the bank enabled (`pooledSources=['workday']`), an approved workday
+   overtime request grants exactly one per-source lot keyed
+   `overtime_conversion:<requestId>:workday` with `overtime_source='workday'`.
+4. Replaying the approval is rejected (`400 INVALID_STATUS`) and never
+   double-credits a lot or a grant ledger event.
+5. The three owner acceptance cases hold (compressed, minutes-based — see the
+   operator-decision block OQ-1): with +600 pool per user, leave of
+   600 / 300 / 900 minutes deducts 600 / 300 / 600, leaves remaining
+   0 / 300 / 0, and produces a real-absence shortfall of 0 / 0 / 300
+   (`insufficient='partial_unpaid_absence'`), with ledger conservation
+   `granted = remaining + exhausted + expired` on the read API.
+6. The full-attendance flag is `false` for all three case users (any leave
+   breaks it, even pool-offset leave) and `true` for the overtime-only control
+   user.
+7. Statutory-holiday overtime with the bank enabled banks NOTHING (fail-closed
+   must-pay), and at cycle close the statutory settlement row carries
+   `must_pay_minutes` from the PERIOD facts (480), `convertible_minutes=0` —
+   an injected poison 9999-minute statutory balance lot never surfaces.
+8. Cycle close (open→closed) writes the settlement snapshot in the same
+   transaction: case2 gets one `workday` row `convertible=300 / must_pay=0`
+   with frozen `period_start_date` / `period_end_date` / `closed_at` and the
+   snapshotted policy; case1/case3 get no row (zero-zero skipped); the dormant
+   user's NULL-source balance settles as `legacy_unsourced` convertible.
+9. Replay close returns `200` and changes nothing (`ON CONFLICT DO NOTHING`);
+   a period change on the closed cycle returns
+   `409 CYCLE_CLOSED_PERIOD_FROZEN`; DELETE returns
+   `409 CYCLE_CLOSED_NOT_DELETABLE`.
+10. Cleanup removes synthetic users, memberships, requests, records, events,
+    lots (ledger events cascade), fixtures (leave type / overtime rule /
+    holiday), approval-engine rows, settlement rows, and the payroll cycle,
+    restores settings, and the residue check is `0` in every category.
+
+## Operator-Decision Blocks (resolve before the final stamp)
+
+### OQ-1 — 三例验收 mapping (owner call)
+
+The owner acceptance table is framed as a 176h monthly schedule with hours
+(+10h overtime; 10h / 5h / 15h leave; effective hours 176/176/171). This smoke
+replays the **pool arithmetic** of those three cases in minutes
+(600 / 300 / 900 vs a 600-minute pool) and asserts pool remaining, deduction,
+shortfall (real absence), full-attendance flag, and cycle-end convertible —
+it does **not** rebuild a full month of 176 scheduled hours, and it does not
+assert the schedule-level effective-hours aggregate (amounts and payroll
+aggregation stay out of scope by design). **OPEN QUESTION:** confirm the
+compressed replay satisfies 三例验收, or require a full-month schedule replay
+before stamping. Record the decision next to the PASS stamp.
+
+### OQ-2 — shared org vs dedicated smoke org (population scope)
+
+The settlement population at cycle close is org-wide: users with period facts
+UNION users with **any active comp-time balance** (period-independent). On a
+shared org (`ORG_ID=default`), closing the smoke cycle would enumerate real
+balance-holders into the smoke cycle's settlement rows (all rows are deleted
+by `cycle_id` in cleanup, but real user ids would transit through a synthetic
+snapshot). The helper fails closed when it detects non-synthetic population
+and only proceeds with `ALLOW_NON_SYNTHETIC_SETTLEMENT_POPULATION=1`
+(dangerous). **OPEN QUESTION:** either accept the override explicitly on a
+quiet window, or run with a dedicated smoke `ORG_ID` — note that issuing
+tokens and route behavior for a non-default org id has not been verified in
+this repo; verify on the staging host before choosing that path.
+
+### OQ-3 — token minting path
+
+The staging environment sets a production node-env, under which
+`GET /api/auth/dev-token` returns `404`. Two candidate mint paths exist in the
+repo (`scripts/gen-staging-token.js` signing with the host's staging JWT
+secret; `scripts/ops/resolve-attendance-smoke-token.sh` minting inside the
+backend container) but neither is named as the approved smoke-token path by
+the AE-4 family docs. **OPEN QUESTION:** the operator picks the mint path and
+provides `ADMIN_TOKEN` plus the five per-user tokens (`CASE1_TOKEN`,
+`CASE2_TOKEN`, `CASE3_TOKEN`, `MUSTPAY_TOKEN`, `DORMANT_TOKEN`) whose subjects
+equal the synthetic user ids — business requests are created AS the token
+subject, so a mismatched subject would attribute rows to a user the cleanup
+does not cover. The helper refuses mismatched subjects.
+
+Note: on non-staging rehearsal runs where `GET /api/auth/dev-token` IS
+available, each dev-token mint inserts a `user_sessions` row for the stamped
+synthetic users; those session rows are expected out-of-ledger (not counted in
+the residue gate, harmless — no FK to `users`) and do not occur on staging,
+where the dev-token route returns `404`.
+
+### OQ-4 — settlement assertions are SQL-only
+
+`attendance_payroll_cycle_settlements` has no API read surface (the v1-5d read
+exit is designed but not built), and the leave-balances read API omits
+`overtime_source` / `source_key` from its lot projection. Per-source lot
+tagging and every settlement-row assertion in this smoke therefore go through
+`DATABASE_URL` directly, following the AE-4 family split (HTTP for business
+writes, SQL for exact assertions). **OPEN QUESTION:** confirm SQL-assert is an
+acceptable channel for the v1-8 stamp, or gate v1-8 behind landing v1-5d
+first.
+
+### OQ-5 — expiry reaper interference
+
+Grants stamped with an expiry are reaped by the attendance expiry service.
+This smoke sets `compTimeFromOvertime.expiresInDays=null` (no expiry) so no
+scheduler can mutate smoke lots mid-run; whether staging currently runs the
+expiry scheduler was not verified from the repo. Keep `expiresInDays` null.
+
+### OQ-6 — real segmentation engine instead of snapshot injection
+
+The CI must-pay e2e injects the overtime-segmentation snapshot into request
+metadata via SQL after approval. This smoke instead drives the REAL engine:
+`overtimeSegmentation.enabled=true`, same-day overtime on a weekday (workday
+bucket) and on a seeded holiday row (holiday bucket → statutory must-pay).
+This is closer to production truth; the arithmetic (rule `minMinutes=0`,
+`roundingMinutes=1`) is chosen so the rule-normalized total equals the raw
+minutes and the owner-case numbers stay exact.
+
+## Prerequisites
+
+1. Deploy a main build that includes:
+   - v1-1a/b `overtimeBankPolicy` config + per-source grant lots;
+   - v1-2a/b `leaveBalanceDeductionPolicy` config + rule-driven FIFO offset;
+   - v1-3a/b `attendanceBonusPolicy` + full-attendance flag on the summary;
+   - v1-5a/b settlement table, compute, close hooks, freeze guards;
+   - v1-6 policy admin UI (for the optional UI probe);
+   - the #3255 must-pay e2e and the #3303 unconditional-settings-restore fix.
+2. Staging migrations are current through:
+   - `attendance_leave_balances` (+ `overtime_source` column) and
+     `attendance_leave_balance_events`;
+   - `attendance_payroll_cycles` and `attendance_payroll_cycle_settlements`
+     (settlement FK is `ON DELETE RESTRICT`);
+   - the shared approval-engine tables (`approval_instances`,
+     `approval_assignments`, `approval_records`).
+3. `BASE_URL` points at the staging API.
+4. `DATABASE_URL` points at the same staging database. The operator must run a
+   quick API/DB coherence probe before mutating business rows.
+5. Authentication per OQ-3: admin token with `attendance:read`,
+   `attendance:write`, `attendance:admin`, `attendance:approve`; five per-user
+   tokens with `attendance:read`, `attendance:write` whose subjects equal the
+   synthetic user ids.
+6. Use only synthetic ids with an `otbank-v18-smoke-*` prefix. Do not point
+   cleanup at real employees. Business text fields (reasons, rule/leave-type/
+   holiday/cycle names) must carry the stamp; the SQL-seeded poison lot key
+   must begin `otbank-v18-smoke:<STAMP>:`.
+7. Run inside the bundled staging window
+   (`docs/development/attendance-staging-window-bundle-20260702.md`), after the
+   previous smoke restored its settings.
+
+## Suggested Environment
+
+```bash
+BASE_URL=http://127.0.0.1:8082            # staging root via your tunnel
+DATABASE_URL=postgresql://<redacted>@127.0.0.1:5432/metasheet
+DEPLOY_SHA=<deployed-main-sha>
+ORG_ID=default                            # see OQ-2 before accepting this
+STAMP=otbank-v18-smoke-$(date +%s)
+ADMIN_TOKEN='<admin bearer token>'
+CASE1_TOKEN='<bearer, subject = <STAMP>-case1>'
+CASE2_TOKEN='<bearer, subject = <STAMP>-case2>'
+CASE3_TOKEN='<bearer, subject = <STAMP>-case3>'
+MUSTPAY_TOKEN='<bearer, subject = <STAMP>-mustpay>'
+DORMANT_TOKEN='<bearer, subject = <STAMP>-dormant>'
+```
+
+The PASS stamp must include `DEPLOY_SHA`, `STAMP`, and residue `0`. Do not use
+a local branch SHA as the deploy SHA.
+
+## API/DB Helper
+
+Use the helper to execute the backend portions of this runbook:
+
+```bash
+BASE_URL="$BASE_URL" \
+DATABASE_URL="$DATABASE_URL" \
+DEPLOY_SHA="$DEPLOY_SHA" \
+ORG_ID="${ORG_ID:-default}" \
+STAMP="$STAMP" \
+ADMIN_TOKEN="$ADMIN_TOKEN" \
+CASE1_TOKEN="$CASE1_TOKEN" CASE2_TOKEN="$CASE2_TOKEN" CASE3_TOKEN="$CASE3_TOKEN" \
+MUSTPAY_TOKEN="$MUSTPAY_TOKEN" DORMANT_TOKEN="$DORMANT_TOKEN" \
+node scripts/ops/staging-attendance-overtime-bank-v18-smoke.mjs
+```
+
+The helper drives the real staging API for settings, fixtures, requests,
+approvals, and the cycle create/close; it uses SQL only for synthetic user
+seed, the poison lot, exact lot/ledger/settlement assertions, and cleanup. A
+successful run prints:
+
+```text
+OTBANK_V18_API_DB_SMOKE_PASS deploy=<sha> stamp=<otbank-v18-smoke-...> org=<org> cycle=<uuid> residue=0
+```
+
+This is **not** the final v1-8 PASS stamp. The final closeout requires the
+operator to (a) verify the deployed build (`/api/health` `build.commit` equals
+`DEPLOY_SHA`), (b) resolve the operator-decision blocks above (OQ-1 and OQ-2
+at minimum), and (c) optionally run the UI probe below — only then record
+`OTBANK_V18_STAGING_SMOKE_PASS`.
+
+## Preflight
+
+Run these checks before creating any business rows:
+
+1. API health returns success for the deployed build and `build.commit`
+   equals `DEPLOY_SHA`.
+2. Admin token can call `GET /api/attendance/settings` (a `401` means a
+   wrong-realm token — re-mint; a `503 DB_NOT_READY` means staging is not
+   migrated — STOP and run the migration-alignment SOP first).
+3. DB has the required tables:
+
+```sql
+SELECT to_regclass('attendance_leave_balances') IS NOT NULL AS lots_ok,
+       to_regclass('attendance_leave_balance_events') IS NOT NULL AS ledger_ok,
+       to_regclass('attendance_payroll_cycles') IS NOT NULL AS cycles_ok,
+       to_regclass('attendance_payroll_cycle_settlements') IS NOT NULL AS settlements_ok,
+       to_regclass('approval_instances') IS NOT NULL AS approvals_ok;
+```
+
+4. API/DB coherence probe: after the first settings PUT, confirm the
+   `overtimeBankPolicy` key is visible through `DATABASE_URL` in
+   `system_configs` under key `attendance.settings`. Abort if API and DB are
+   not the same staging instance.
+5. Save current attendance settings so the smoke can restore them:
+
+```bash
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$BASE_URL/api/attendance/settings" > /tmp/otbank-v18-settings-before.json
+```
+
+6. Verify zero pre-existing residue for this `STAMP` (fresh stamp per run).
+
+## Window and Seed
+
+The smoke uses a far-future, conflict-free settlement window (one full month,
+default: October of a helper-chosen year ≥2041; `SMOKE_YEAR` overridable, but
+only values in **2030–2099** are honored — an out-of-range override silently
+falls back to the hash-seeded default year, so re-check the helper's printed
+window if you override) so that:
+
+- no real records/requests exist inside the period (the period arm of the
+  settlement population stays synthetic by construction);
+- no synced holiday rows shift the day-type of the smoke dates;
+- no existing payroll cycle overlaps the period (an exact-period duplicate
+  returns `409 ALREADY_EXISTS` on create).
+
+Within the window: overtime accrual on the first Monday (workday), leave
+offset on the Tuesday, seeded statutory holiday + holiday overtime on the
+Wednesday.
+
+Seed five disposable users and active org memberships (SQL, upsert):
+
+- `otbank-v18-smoke-<stamp>-case1|case2|case3` (owner cases)
+- `otbank-v18-smoke-<stamp>-mustpay` (statutory boundary)
+- `otbank-v18-smoke-<stamp>-dormant` (dormant-bank regression + no-leave
+  full-attendance control)
+
+Fixtures (via API, all stamped): one overtime rule
+(`minMinutes=0, roundingMinutes=1`), one offset leave type (code
+`<STAMP>-offset`), one holiday row (`isWorkingDay=false`) on the Wednesday.
+
+The smoke may use direct SQL for seed/assert/cleanup, but every accrual,
+offset, approval, and cycle transition must go through the deployed API.
+
+## Step 1 — dormant-bank grant regression
+
+Set the policy baseline (segmentation + grant on, bank OFF):
+
+```bash
+curl -sS -X PUT "$BASE_URL/api/attendance/settings" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  --data '{
+    "overtimeSegmentation": { "enabled": true },
+    "compTimeFromOvertime": { "enabled": true, "expiresInDays": null },
+    "overtimeBankPolicy": { "enabled": false, "pooledSources": [] }
+  }'
+```
+
+As the dormant user: `POST /api/attendance/requests`
+`{workDate:<Monday>, requestType:'overtime', overtimeRuleId, minutes:120, reason:'OTBANK v1-8 smoke <STAMP> dormant regression'}`,
+then approve as admin via `POST /api/attendance/requests/:id/approve`.
+
+Backend assertions:
+
+```sql
+SELECT source_key, overtime_source, amount_minutes, remaining_minutes, expires_at
+FROM attendance_leave_balances
+WHERE org_id = :org_id AND source_type = 'overtime_conversion' AND source_id = :dormant_request_id;
+```
+
+Expected:
+
+- exactly one lot; `source_key = 'overtime_conversion:<requestId>'` (no
+  per-source suffix); `overtime_source` is NULL; amount = remaining = 120;
+  `expires_at` is NULL;
+- exactly one `grant` ledger event of +120 for that request.
+
+## Step 2 — enable the bank + offset rule + full-attendance flag
+
+First probe the compliance floor: `PUT /api/attendance/settings` with
+`{"overtimeBankPolicy":{"enabled":true,"pooledSources":["statutory_holiday"]}}`
+must return `400` (the pooled-sources enum excludes statutory holidays).
+
+Then enable the real matrix:
+
+```bash
+curl -sS -X PUT "$BASE_URL/api/attendance/settings" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  --data '{
+    "overtimeBankPolicy": { "enabled": true, "pooledSources": ["workday"] },
+    "leaveBalanceDeductionPolicy": {
+      "enabled": true,
+      "rules": [{ "requestLeaveType": "<STAMP>-offset", "deductFrom": ["comp_time"], "insufficient": "partial_unpaid_absence" }]
+    },
+    "attendanceBonusPolicy": { "enabled": true, "anyLeaveBreaksFullAttendance": true, "lateBeyondThresholdBreaksFullAttendance": true }
+  }'
+```
+
+Note: `PUT /api/attendance/settings` merges per policy key — this PUT does not
+disturb sibling policies, and the restore in Step 8 must therefore explicitly
+re-assert every key this smoke touched (never PUT an empty snapshot).
+
+## Step 3 — the three owner cases (accrual + offset)
+
+For each case user (`case1`, `case2`, `case3`):
+
+1. As the case user: create workday overtime on the Monday
+   (`minutes=600`, stamped reason), approve as admin.
+2. Assert (SQL) exactly one lot `overtime_conversion:<requestId>:workday`,
+   `overtime_source='workday'`, amount 600.
+3. Replay the approve: expect `400 INVALID_STATUS`, and no second lot or
+   grant event.
+4. Assert (API) `GET /api/attendance/leave-balances?userId=<user>&leaveTypeCode=comp_time`
+   shows granted=600, remaining=600.
+5. As the case user: create the offset leave on the Tuesday with
+   `leaveTypeCode=<STAMP>-offset` and minutes 600 / 300 / 900 respectively,
+   stamped reason; approve as admin (case3 approves too —
+   `partial_unpaid_absence` mode).
+6. Assert (SQL) the `leave_offset` deduct events for that leave request sum to
+   600 / 300 / 600.
+7. Assert (API) the balance read shows remaining 0 / 300 / 0, exhausted
+   600 / 300 / 600, expired 0, and conservation
+   `granted = remaining + exhausted + expired`.
+8. Compute shortfall = requested − deducted = 0 / 0 / 300 (case3's 300 = the
+   real absence of the owner table).
+
+The `insufficient='block'` variant (422 + rollback) is covered by the CI
+real-DB matrix and is not re-proven here.
+
+## Step 4 — statutory must-pay boundary + poison lot
+
+1. As admin: `POST /api/attendance/holidays`
+   `{date:<Wednesday>, name:'<STAMP> statutory holiday', isWorkingDay:false}` → `201`.
+2. As the mustpay user: create overtime on the Wednesday (`minutes=480`),
+   approve as admin.
+3. Assert (SQL) ZERO lots exist for that request — holiday overtime is mapped
+   to the statutory source, which is never poolable; with the bank enabled the
+   grant fails closed to must-pay.
+4. Seed the poison lot (SQL, stamped key):
+
+```sql
+INSERT INTO attendance_leave_balances
+  (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes,
+   source_type, source_key, status, granted_at, overtime_source)
+VALUES
+  (:org_id, :mustpay_user, 'comp_time', 9999, 9999,
+   'overtime_conversion', 'otbank-v18-smoke:<STAMP>:poison-statutory-lot', 'active', now(), 'statutory_holiday');
+```
+
+The poison lot must never surface in Step 7's settlement rows: must-pay reads
+period facts only, and the statutory source is never convertible.
+
+## Step 5 — full-attendance flags (账3)
+
+`GET /api/attendance/summary?userId=<user>&from=<periodStart>&to=<periodEnd>`
+as admin:
+
+- case1/case2/case3: `data.fullAttendanceEligible === false` (any leave breaks
+  it, even when the pool offset the leave);
+- dormant (overtime-only): `data.fullAttendanceEligible === true`.
+
+## Step 6 — settlement population guard (OQ-2)
+
+Before closing the cycle, count the would-be settlement population that is NOT
+stamped by this smoke:
+
+```sql
+SELECT count(*) AS non_synthetic FROM (
+  SELECT user_id FROM attendance_records
+    WHERE org_id = :org_id AND work_date BETWEEN :period_start AND :period_end
+  UNION
+  SELECT user_id FROM attendance_requests
+    WHERE org_id = :org_id AND status = 'approved' AND work_date BETWEEN :period_start AND :period_end
+  UNION
+  SELECT user_id FROM attendance_leave_balances
+    WHERE org_id = :org_id AND leave_type_code = 'comp_time' AND status = 'active' AND remaining_minutes > 0
+) pop WHERE user_id IS NULL OR left(user_id, length(:user_prefix)) <> :user_prefix;
+```
+
+If `non_synthetic > 0`, stop and resolve OQ-2 (dedicated org, or an explicit,
+recorded acceptance via `ALLOW_NON_SYNTHETIC_SETTLEMENT_POPULATION=1`).
+
+## Step 7 — cycle close, settlement snapshot, replay, freeze guards
+
+1. As admin: `POST /api/attendance/payroll-cycles`
+   `{name:'<STAMP>-cycle', startDate:<periodStart>, endDate:<periodEnd>, status:'open', metadata:{smokeStamp:'<STAMP>'}}` → `201`.
+2. Assert (SQL) zero settlement rows exist for the cycle before close.
+3. `PUT /api/attendance/payroll-cycles/:id {"status":"closed"}` → `200`.
+
+Backend assertions:
+
+```sql
+SELECT user_id, source, convertible_minutes, must_pay_minutes,
+       period_start_date, period_end_date, closed_at, snapshot
+FROM attendance_payroll_cycle_settlements
+WHERE org_id = :org_id AND cycle_id = :cycle_id
+ORDER BY user_id, source;
+```
+
+Expected:
+
+- case1: no rows (pool fully consumed, workday pooled → zero-zero skipped);
+- case2: exactly one row `source='workday'`, `convertible_minutes=300`,
+  `must_pay_minutes=0`, `period_start_date`/`period_end_date` equal the cycle
+  period, `closed_at` non-null, and `snapshot.overtimeBankPolicy.pooledSources`
+  contains `workday`;
+- case3: no rows (partial offset exhausted the pool);
+- mustpay: exactly one row `source='statutory_holiday'`,
+  `must_pay_minutes=480` (period facts), `convertible_minutes=0` — NOT the
+  9999 poison;
+- dormant: exactly one row `source='legacy_unsourced'`,
+  `convertible_minutes=120`, `must_pay_minutes=0`;
+- when the population guard reported synthetic-only: exactly 3 rows total.
+
+Then:
+
+4. Replay `PUT {"status":"closed"}` → `200`, and the settlement rows are
+   byte-for-byte unchanged (count and values).
+5. `PUT {"startDate":<periodStart+1>,"endDate":<periodEnd>}` →
+   `409 CYCLE_CLOSED_PERIOD_FROZEN`.
+6. `DELETE /api/attendance/payroll-cycles/:id` →
+   `409 CYCLE_CLOSED_NOT_DELETABLE` (cleanup therefore uses scoped SQL:
+   settlements first — the FK is `ON DELETE RESTRICT` — then the cycle).
+
+## Optional UI probe (v1-6, non-blocking)
+
+In a browser as the admin, open the attendance admin settings surface and
+verify the three policy cards (overtime bank / leave offset / full attendance)
+render the state this smoke configured, and that the pooled-sources selector
+never offers the statutory-holiday source. This probe strengthens the arc but
+is not part of the stamped assertion set.
+
+## Step 8 — cleanup and EXPLICIT settings restore
+
+Settings restore first, and never by PUT-ing an empty or partial snapshot:
+`PUT /api/attendance/settings` merges per policy key, so an empty-body restore
+is a NO-OP that leaks the smoke's policies (the #3303 lesson). Restore with
+every touched key explicitly re-asserted:
+
+```json
+{
+  "...": "<the full pre-smoke settings snapshot spread first>",
+  "overtimeSegmentation": { "enabled": false, "...": "<pre-smoke overtimeSegmentation if any>" },
+  "compTimeFromOvertime": { "enabled": false, "...": "<pre-smoke compTimeFromOvertime if any>" },
+  "overtimeBankPolicy": { "enabled": false, "pooledSources": [], "...": "<pre-smoke overtimeBankPolicy if any>" },
+  "leaveBalanceDeductionPolicy": { "enabled": false, "rules": [], "...": "<pre-smoke leaveBalanceDeductionPolicy if any>" },
+  "attendanceBonusPolicy": { "enabled": false, "...": "<pre-smoke attendanceBonusPolicy if any>" }
+}
+```
+
+Then re-GET and verify all five policy keys compare equal (stable JSON) to the
+pre-smoke snapshot. A restore that silently leaves `overtimeBankPolicy`
+enabled fails the smoke.
+
+Cleanup deletes only stamped/captured rows, in FK-safe order: approval
+records/assignments → adjustment events (by captured request ids) → records
+(by user prefix) → requests → lots (ledger events cascade) → approval
+instances → settlement rows (by cycle id) → cycles → holiday / overtime rule /
+leave type fixtures → user_orgs → users.
+
+## Step 9 — residue check
+
+After cleanup, every category must be zero. Use the literal `:stamp` matching
+`/^otbank-v18-smoke-[A-Za-z0-9-]+$/`, `:user_prefix = :stamp || '-'`, the
+captured `:request_ids` / `:approval_ids` / `:cycle_ids` / fixture ids, and
+the exact poison-lot key; do not use an unescaped wildcard stamp for cleanup.
+
+```sql
+SELECT
+  (SELECT count(*) FROM attendance_requests
+    WHERE org_id = :org_id AND (id = ANY(:request_ids::uuid[]) OR left(user_id, length(:user_prefix)) = :user_prefix)) AS requests,
+  (SELECT count(*) FROM attendance_records
+    WHERE org_id = :org_id AND left(user_id, length(:user_prefix)) = :user_prefix) AS records,
+  (SELECT count(*) FROM attendance_events
+    WHERE org_id = :org_id AND meta->>'requestId' = ANY(:request_ids::text[])) AS events,
+  (SELECT count(*) FROM attendance_leave_balances
+    WHERE org_id = :org_id AND (left(user_id, length(:user_prefix)) = :user_prefix OR source_key = :poison_lot_key)) AS leave_balances,
+  (SELECT count(*) FROM attendance_leave_balance_events
+    WHERE org_id = :org_id AND left(user_id, length(:user_prefix)) = :user_prefix) AS balance_events,
+  (SELECT count(*) FROM attendance_leave_types
+    WHERE org_id = :org_id AND (id = ANY(:leave_type_ids::uuid[]) OR code = :leave_type_code)) AS leave_types,
+  (SELECT count(*) FROM attendance_overtime_rules
+    WHERE org_id = :org_id AND (id = ANY(:overtime_rule_ids::uuid[]) OR name = :overtime_rule_name)) AS overtime_rules,
+  (SELECT count(*) FROM attendance_holidays
+    WHERE org_id = :org_id AND (id = ANY(:holiday_ids::uuid[]) OR name = :holiday_name)) AS holidays,
+  (SELECT count(*) FROM attendance_payroll_cycle_settlements
+    WHERE org_id = :org_id AND cycle_id = ANY(:cycle_ids::uuid[])) AS settlements,
+  (SELECT count(*) FROM attendance_payroll_cycles
+    WHERE org_id = :org_id AND (id = ANY(:cycle_ids::uuid[]) OR metadata->>'smokeStamp' = :stamp)) AS cycles,
+  (SELECT count(*) FROM approval_instances WHERE id = ANY(:approval_ids::text[])) AS approval_instances,
+  (SELECT count(*) FROM approval_assignments WHERE instance_id = ANY(:approval_ids::text[])) AS approval_assignments,
+  (SELECT count(*) FROM approval_records WHERE instance_id = ANY(:approval_ids::text[])) AS approval_records,
+  (SELECT count(*) FROM attendance_notification_deliveries
+    WHERE org_id = :org_id AND left(recipient_user_id, length(:user_prefix)) = :user_prefix) AS deliveries,
+  (SELECT count(*) FROM user_orgs
+    WHERE org_id = :org_id AND left(user_id, length(:user_prefix)) = :user_prefix) AS user_orgs,
+  (SELECT count(*) FROM users WHERE left(id, length(:user_prefix)) = :user_prefix) AS users;
+```
+
+The approval-engine categories are counted on purpose: the request
+create/approve chain writes `approval_instances` / `approval_assignments` /
+`approval_records`, and leaving them behind is a failed smoke, not a harmless
+warning. The deliveries category must be zero because this smoke never writes
+notification deliveries — a non-zero count means cross-smoke interference in
+the bundled window. Do not narrow residue to only the rows that are easy to
+delete.
+
+## Expected PASS Stamp
+
+Use this exact shape after all steps pass and the operator-decision blocks are
+resolved:
+
+```text
+OTBANK_V18_STAGING_SMOKE_PASS deploy=<sha> stamp=<otbank-v18-smoke-...> org=<org> cycle=<uuid> residue=0
+```
+
+Backfill text:
+
+> **回填（YYYY-MM-DD OT-bank v1-8 staging closeout）**：staging smoke
+> `OTBANK_V18_STAGING_SMOKE_PASS` on deploy `<sha>`（stamp `<stamp>`）：dormant
+> bank kept the legacy NULL-source grant; enabled bank granted per-source
+> workday lots; owner 三例（600/300/900 leave vs 600 pool）deducted
+> 600/300/600 with remaining 0/300/0、real-absence shortfall 0/0/300、满勤
+> flag false×3（overtime-only control true）; statutory-holiday OT banked
+> nothing and settled as must-pay 480 from period facts（poison 9999 lot never
+> surfaced）; cycle close snapshotted convertible 0/300/0 with frozen period
+> columns; replay close idempotent; period-change/DELETE 409-frozen; settings
+> restored and verified; cleanup residue=0。OQ-1/OQ-2 decisions recorded:
+> `<...>`。v1-8 closed ✅（v1-7 payout producer remains gated）。
+
+## On FAIL
+
+- Dormant path grants a per-source lot or an enabled-bank grant appears with
+  no segmentation snapshot: the accrual gating regressed; do not pass.
+- `pooledSources=['statutory_holiday']` is accepted by PUT: the compliance
+  floor regressed; do not pass.
+- Replay approve credits a second lot/event: grant idempotency regressed; do
+  not pass.
+- case3 approve returns `422` instead of approving with a 300 shortfall: the
+  `partial_unpaid_absence` mode is not wired; do not pass.
+- Full-attendance flag is true for a case user: 账3 reads net-after-offset
+  instead of raw leave; do not pass.
+- A statutory settlement row shows 9999 or a convertible amount: must-pay is
+  being derived from balance lots; do not pass — this is the poison-lot
+  invariant.
+- Settlement rows change on replay close, or the frozen-period/DELETE guards
+  do not return `409`: settlement immutability regressed; do not pass.
+- Settings do not compare equal after restore: the #3303 hygiene regressed —
+  fix the restore before re-running anything else in the window.
+- Residue is nonzero: inspect the stamped rows before re-running.
+
+## Safety
+
+- Uses only synthetic `otbank-v18-smoke-*` users, fixtures, and a far-future
+  settlement period chosen to contain zero real facts.
+- Saves and restores attendance settings, with an explicit re-assert of every
+  touched policy key and a verified compare (never PUTs an empty snapshot).
+- Fails closed before cycle close if the settlement population would include
+  any non-synthetic user (override is explicit and must be recorded).
+- Does not change scheduler flags, worker flags, notification channel
+  configuration, or production payroll cycles; never touches deliveries.
+- Does not delete by broad source/type text; cleanup is stamped and keyed by
+  captured ids; the closed smoke cycle is removed via scoped SQL only
+  (settlements first, then the cycle).

--- a/docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md
+++ b/docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md
@@ -1,0 +1,484 @@
+# Attendance RD-4/5 report-digest staging smoke runbook
+
+**Date:** 2026-07-02
+
+**Status:** PREPARED. This runbook does **not** claim a staging PASS. It is the
+operator checklist for closing RD-4/RD-5 (report-digest config card + producer /
+worker send proof) inside the staging window coordinated by
+`docs/development/attendance-staging-window-bundle-20260702.md` (smoke #2 of 3).
+
+Do not mark the report-digest arc complete from this document alone. The
+closeout happens only after a real run records the PASS stamp in the section
+below.
+
+**Scope** (per the report-digest design lock
+`docs/development/attendance-report-digest-subscription-design-lock-20260626.md`
+§9, RD-4 + RD-5 rows):
+
+- RD-4: admin config card hydrates from settings, saves through the real PUT,
+  rejects invalid input, preserves sibling settings;
+- RD-5: producer writes per-subject delivery rows (proven separately from
+  sending), the delivery worker visibly sends or visibly fails those rows, and
+  cleanup residue is `0`.
+
+It does not add runtime code, a manual bulk-send button, a new channel, or new
+recipients vocabulary.
+
+## Known family deviation — deterministic source_keys (READ FIRST)
+
+Every other smoke in this family stamps its business keys
+(`ae4-smoke:<STAMP>:…`, `otbank-v18-smoke:<STAMP>:…`). **The digest producer
+cannot be stamped**: its `source_key` is deterministic by design —
+
+```text
+attendance_report_digest:{orgId}:{cadence}:{periodKey}:subject:{subjectUserId}:{recipientRole}:{recipientUserId}:channel:{channel}
+```
+
+— that determinism IS the idempotency mechanism (`ON CONFLICT (org_id,
+source_key) DO NOTHING` against the unique `(org_id, source_key)` index). The
+window plan's business-key prefix `rd45-smoke:<STAMP>:` therefore has **no
+occupant** in this smoke; only the row-id prefix `rd45-smoke-<suffix>-…`
+(users, memberships, the disposable org id) is stamp-carrying. Consequences:
+
+1. **Residue discipline tracks the deterministic keys explicitly.** The helper
+   prints a `RUN LOG — deterministic digest keys` block (periodKey, the exact
+   source_key prefix, every full key). Copy it into the worksheet below; the
+   residue SQL is anchored on `org_id + source_type + left(source_key, …)`,
+   never on a stamp.
+2. **Same-day reruns collide with themselves.** A rerun on the same UTC day
+   against the same org regenerates the SAME keys; the helper aborts at
+   preflight if rows already exist under the run's prefix (clean first, then
+   rerun).
+3. The design-lock §4 key template omits the `:subject:{subjectUserId}:`
+   segment; **the shipped implementation (with the segment) supersedes the
+   doc** — the helper's parser rejects the drifted shape.
+
+## Track structure (resolves bundle §9.4)
+
+The backend scheduler job registers the producer with **no orgId** — the
+scheduled producer is hardwired to the `default` org. The window plan's rule
+that "RD-4/5 MUST use a disposable **single-member** smoke org" is therefore
+only achievable through the shipped in-process test seam
+(`__attendanceReportDigestForTests.runAttendanceReportDigestOnce`, same
+pattern the C5-5 delivery smoke used for in-process services against
+`DATABASE_URL`).
+
+| Track | What | Org | Required for the PASS stamp? |
+|---|---|---|---|
+| **A — seam (PRIMARY, helper default)** | in-process seam invocation with `{orgId, now, todayKey}` pinned | disposable single-member `rd45-smoke-…-org` | **Yes** |
+| **B — real scheduler tick (VARIANT)** | backend scheduler produces on its own tick | `default` (forced by the wiring) | No — optional, owner-gated at run time |
+
+**Track B risk statement (read before opting in):** it writes pending digest
+rows naming **every active default-org member** (deterministic keys, cleaned
+afterwards by prefix), and if the backend env drifts worker-on, those rows
+would be **sent to real staging users**. Track B therefore hard-requires the
+delivery worker gate unset/false and `ACK_DEFAULT_ORG_FANOUT=1`. It
+strengthens the closeout (proves the registration → tick → producer chain on
+the deployed process) but is **not** required for
+`RD45_REPORT_DIGEST_STAGING_SMOKE_PASS`.
+
+## The three env gate layers — and an amendment to bundle §3.4
+
+Three DISTINCT gates, one per layer (do not conflate them):
+
+| Env | Layer | Track A (primary) | Track B (variant) |
+|---|---|---|---|
+| `ATTENDANCE_SCHEDULER_ENABLED` | process gate — must be exactly `'true'` or the shared scheduler never starts and no job (producer OR worker) ever runs | backend `true` (the delivery worker rides the same tick) | backend `true` |
+| `ATTENDANCE_REPORT_DIGEST_ENABLED` | producer gate — read by whichever **process** runs the producer | backend **UNSET/false (MUST)**; the helper sets it `true` inside its own process around the seam call only | backend `true` |
+| `ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED` | send gate — registers the delivery worker job on the same tick | backend `true` (window state; sends are contained to the smoke org's synthetic member and double as the RD-5 send proof) | backend **UNSET/false (MUST)** — rows must stay `pending` |
+| `ATTENDANCE_SCHEDULER_INTERVAL_MS` | tick period — default hourly, min-clamp 5000 ms; there is **no immediate first run**: the first tick fires **one FULL interval** after process start | shrink (e.g. `15000`) so the worker resolves rows quickly | shrink (e.g. `15000`) |
+| channel envs | `ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED=true` registers the deterministic fake sender under the work-notification channel name; the real-channel env or the SMTP env registers real senders | fake recommended (see send-posture table) | irrelevant (worker off) |
+
+**Amendment to the window bundle §3.4:** the bundle lists
+`ATTENDANCE_REPORT_DIGEST_ENABLED=true` among the set-once-at-window-start
+flags. Under Track A that is **wrong and unsafe**: the digest policy lives in
+the single GLOBAL settings row, so the policy this smoke enables is visible to
+the backend too — if the backend's producer gate were on, its scheduler would
+fan out one row per active **default-org** member and the window's live worker
+would send them. Under Track A the backend producer gate **stays off for the
+whole window**; the helper asserts a **no-default-org-leakage** guard and its
+residue block includes the default-org digest delta. Only a Track B opt-in
+sets the backend producer gate (and then the worker gate must be off —
+mutually exclusive states, each requiring a container recreate).
+
+Settings-visibility latency: the backend caches the settings row in-process
+for up to 60 s, and a first tick fires only one FULL interval after boot — all
+Track B waits (and the helper's built-in timeouts) budget `interval × 2 + 60 s
++ margin`.
+
+## What this proves
+
+1. **Producer grain** — the producer writes exactly one `pending` row per
+   resolved active subject (active membership AND active user; the seeded
+   inactive membership is excluded), with `source_type=
+   'attendance_report_digest'`, per-subject `source_key` (the `:subject:`
+   segment), `recipient_role='subject'` in the column vocab and `self` in the
+   key's config vocab, one consistent allowlisted channel
+   (`dingtalk_work_notification` | `email_smtp`), deterministic `source_id`,
+   and a digest payload (`kind`/`cadence`/`period.periodKey`).
+2. **Recipient containment** — zero rows name a recipient outside the resolved
+   subject set.
+3. **Replay idempotency** — a second producer invocation creates zero new rows;
+   TOTAL row count for the period is unchanged (`ON CONFLICT` dedup).
+4. **Disabled paths** — producer-gate off and policy off each produce zero new
+   rows (both are proven deterministically on the seam track).
+5. **RD-5 send split** — separately from (1), the live delivery worker visibly
+   resolves every smoke-org row: `sent`, or `failed` with a recognized
+   visible reason (send-posture table below).
+6. **No default-org leakage** — enabling the GLOBAL policy for the smoke did
+   not produce any default-org rows (Track A).
+7. **RD-4 config card** — browser probe of the admin card (hydrate / save /
+   reject invalid / preserve siblings).
+8. **Restore + residue** — settings restored byte-identical for the digest
+   policy; residue `0` across every touched surface, deterministic keys
+   included.
+9. The deliveries GET route has **no source filter param** (status +
+   pagination only) — the smoke proves the documented client-side
+   `source_key`-prefix filtering works against the real route.
+
+## Prerequisites
+
+1. Deploy ONE main build (the window's `DEPLOY_SHA`) that includes the RD-1
+   config contract, the RD-2/RD-3 producer chain, and the RD-4 admin config
+   card (bundle §2).
+2. Staging migrations current through `attendance_notification_deliveries`
+   (the `zzzz20260611120000` migration with the unique `(org_id, source_key)`
+   index).
+3. `BASE_URL` → staging API; `DATABASE_URL` → the SAME staging database (the
+   helper runs an API↔DB coherence probe and aborts on mismatch).
+4. Auth: preferred is the environment's approved smoke-token path
+   (`ADMIN_TOKEN` with `attendance:read`, `attendance:write`,
+   `attendance:admin`); the helper's dev-token fallback exists for
+   non-production stacks only and is expected to 404 on staging (bundle §9.5 /
+   OQ-4).
+5. Track A runs the seam **in-process**: execute the helper from a prepared
+   metasheet2 checkout at the deployed SHA with dependencies installed (`pg` +
+   `plugins/plugin-attendance/index.cjs` requireable — see OQ-2 for the
+   pnpm-layout `NODE_PATH` caveat), on a host that can
+   reach `DATABASE_URL` — the same execution locus the C5-5 delivery smoke
+   used (OQ-2).
+6. Backend container env verified for the chosen track per the layer table
+   above — read the live container env first (bundle §9.3 / OQ-3); env changes
+   require a container recreate, never mid-smoke.
+7. Use only synthetic ids with the `rd45-smoke-` prefix. The disposable org id
+   itself is stamped (`<STAMP>-org`).
+
+## Suggested environment
+
+```bash
+BASE_URL=http://127.0.0.1:8082
+DATABASE_URL=postgresql://<redacted>@<staging-db>/metasheet
+DEPLOY_SHA=<deployed-main-sha>          # never a local branch SHA
+STAMP=rd45-smoke-$(date +%s)            # /^rd45-smoke-[A-Za-z0-9-]+$/
+TRIGGER_MODE=seam                       # primary track
+SCHEDULER_INTERVAL_MS=15000             # MUST equal the backend's ATTENDANCE_SCHEDULER_INTERVAL_MS
+ADMIN_TOKEN='<staging admin bearer token>'
+# ORG_ID defaults to ${STAMP}-org on the seam track — do not point it at a real org.
+```
+
+## Helper
+
+```bash
+BASE_URL="$BASE_URL" DATABASE_URL="$DATABASE_URL" DEPLOY_SHA="$DEPLOY_SHA" \
+STAMP="$STAMP" TRIGGER_MODE=seam SCHEDULER_INTERVAL_MS="$SCHEDULER_INTERVAL_MS" \
+ADMIN_TOKEN="$ADMIN_TOKEN" \
+node scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs | tee /tmp/rd45-smoke-run-$STAMP.log
+```
+
+The helper drives the real staging HTTP API for settings writes and the
+deliveries read route, uses direct PG for exact assertions and stamped/
+prefix-scoped cleanup, and invokes the producer through the shipped seam. A
+successful run prints:
+
+```text
+RD45_REPORT_DIGEST_API_DB_SMOKE_PASS deploy=<sha> stamp=<rd45-smoke-...> org=<org> produced=<n> dedupOk=1 residue=0
+```
+
+This is **not** the final RD-4/5 PASS stamp: it does not operate the RD-4
+config card in a browser, and the send-posture decision below must be recorded
+by the operator. Keep the `tee`'d log — its RUN LOG block is the deterministic
+-key residue record.
+
+Helper phases (all assertions also listed as manual SQL below): preflight
+(tables via `to_regclass`, deterministic-key collision guard, digest-row
+baselines, UTC-midnight guard for Track B) → settings snapshot → seed → enable
+policy (`daily`, `sendAt='00:00'`, `timezone='UTC'`, `recipients=['self']` —
+due on every producer run all day, since due-ness is anchor-day + local time ≥
+sendAt, not minute-equality) → produce → grain/containment/API-visibility →
+replay → disabled paths → send posture → leakage guard → strict settings
+restore → cleanup → residue.
+
+## Steps
+
+### Step 0 — window preflight
+
+Covered by the bundle (§3): health + `build.commit == DEPLOY_SHA`, migration
+alignment, auth round-trip, env flags per the layer table, settings baseline
+snapshot.
+
+### Step 1 — seed (helper-automated)
+
+One disposable org `<STAMP>-org` with exactly **one active member**
+(`<STAMP>-member`) — the window plan's single-member rule — plus one user with
+an **inactive membership** (`<STAMP>-inactive`) to prove active-only subject
+resolution. No attendance records/requests are seeded: a zero-activity digest
+payload is a valid producer proof (row production, not report content, is
+under test).
+
+### Step 2 — produce and assert grain (helper-automated)
+
+Track A: the helper requires the plugin CJS, builds the harness-shaped db
+adapter over `DATABASE_URL`, sets the producer gate in its OWN process, and
+calls the seam once with pinned `{orgId, now, todayKey}`. Expected result:
+`ran=true`, daily cadence `rowsCreated=1`, `rowsExisting=0`.
+
+Manual verification SQL (also the worksheet source):
+
+```sql
+SELECT source_key, source_id, recipient_user_id, recipient_role, channel, status,
+       payload->>'kind' AS kind, payload->'period'->>'periodKey' AS period_key
+FROM attendance_notification_deliveries
+WHERE org_id = :smoke_org
+  AND source_type = 'attendance_report_digest'
+  AND left(source_key, length(:source_key_prefix)) = :source_key_prefix
+ORDER BY source_key;
+```
+
+Expected: exactly one row per active subject; `:subject:` segment present in
+every key; `recipient_role='subject'`; key role segment `self`; channel equal
+across rows and ∈ {`dingtalk_work_notification`, `email_smtp`} (the value is
+resolved from the **producing process's** default-channel env — leave
+`ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL` unset in the helper env, or set it
+identically to the backend, so the stamped channel matches what the worker's
+registry can serve); zero rows with a recipient outside the subject set.
+
+Because the deliveries GET route has no source filter, the helper additionally
+pages `GET /api/attendance/notification-deliveries?status=all&page=…&pageSize=200`
+and filters client-side by the source_key prefix — the count must equal the DB
+count.
+
+### Step 3 — replay idempotency (helper-automated)
+
+Second seam invocation (same pinned todayKey): `rowsCreated=0`,
+`rowsExisting=<n>`, and the **total** row count for the period unchanged. The
+count is status-tolerant on purpose — the window's live worker may already
+have moved rows `pending→sending→sent` between steps; dedup is proven by
+count, not by status.
+
+### Step 4 — disabled paths (helper-automated)
+
+- Producer gate off (env deleted in the seam process) → `{ran:false,
+  reason:'disabled'}`.
+- Policy off (`PUT {"attendanceReportDigestPolicy":{"enabled":false}}`) → the
+  helper waits out the plugin module's 60 s in-process settings cache, then
+  the seam returns `{ran:false, reason:'disabled'}` with the env gate ON.
+- Row count unchanged after both.
+
+### Step 5 — RD-5 send posture (helper-automated; operator records the posture)
+
+The window keeps the delivery worker ON (bundle §3.4); under the disposable
+smoke org its fan-out is contained to the synthetic member, so the send doubles
+as the RD-5 proof. The helper polls until every smoke-org row reaches a
+terminal, explainable state:
+
+| Backend channel env | Expected terminal state | Posture |
+|---|---|---|
+| `ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED=true` (recommended) | `status='sent'`, `delivered_at` set | **default / strongest** — a visible send through the real worker state machine |
+| real work-notification channel env enabled | `status='failed'`, `last_error='dingtalk_recipient_not_bound'` (synthetic users have no directory binding) | acceptable — a visible, attributable failure (the design lock demands "sends **or fails** visibly") |
+| no channel env registered | `status='failed'`, `last_error='attendance_delivery_channel_not_configured'` | weakest — visible but proves only the claim/fail path; prefer the fake channel |
+
+Anything else — rows stuck `pending`/`retrying`, or `failed` with an
+unrecognized error — is a smoke FAIL, not a posture. Record the observed
+posture in the worksheet; it becomes the `sendProof=` field of the final
+stamp. (`WORKER_EXPECTED=0` runs assert rows REMAIN `pending` instead — a
+producer-only proof that is NOT sufficient for the final stamp on its own.)
+
+### Step 6 — default-org leakage guard (helper-automated)
+
+Default-org digest-row count must equal its preflight baseline (normally 0).
+A delta means the backend has the producer gate set — a broken Track A
+precondition: disable it, then clean the leaked rows by the deterministic
+prefix on org `default` (never org-wide), and treat the run as FAILED.
+
+### Step 7 — RD-4 config card browser probe (manual — required for the final stamp)
+
+As the staging admin, open the attendance admin surface, report-digest section
+(the card's controls carry `data-report-digest*` selectors; the admin rail has
+a dedicated report-digest anchor):
+
+1. The card hydrates from the live settings (with the smoke policy restored,
+   it must show the PRE-smoke values — proving it reads, not caches).
+2. Enable the daily cadence, set a valid `sendAt`, save → re-GET settings shows
+   the change; unrelated policy keys are untouched (deep-merge preserved).
+3. Enter an invalid `sendAt` (e.g. `25:00`) → save is blocked or the PUT
+   returns 400 VALIDATION_ERROR; no partial write.
+4. Empty recipients on an enabled cadence → rejected.
+5. Restore the card to the pre-smoke values; verify via GET.
+
+No send is triggered by any of this (the producer gate stays off on the
+backend), so the probe is safe after cleanup.
+
+### Step 8 — cleanup + residue (helper-automated; re-run SQL manually at window close)
+
+Cleanup order is load-bearing: **restore/disable the policy BEFORE deleting
+rows** — while the policy and a producer gate are both live, the still-open
+period is re-inserted by the next producer run (deleted rows resurrect). The
+helper restores settings strictly (re-GET + byte-compare of
+`attendanceReportDigestPolicy`; the restore body explicitly re-asserts the
+policy because PUT deep-merges — an empty-snapshot PUT is a NO-OP), then
+deletes: smoke-org digest rows (org-scoped `source_type` delete is safe only
+because the org is disposable and stamped), stamped memberships, stamped
+users.
+
+## Residue worksheet + SQL
+
+Record from the helper RUN LOG: `STAMP`, `ORG_ID`, `periodKey`,
+`sourceKeyPrefix`, all `source_key` values, observed send posture.
+
+```sql
+-- deterministic-key surface (the family deviation: anchored on recorded keys, not a stamp)
+SELECT count(*) AS prefix_deliveries FROM attendance_notification_deliveries
+ WHERE org_id = :smoke_org AND source_type = 'attendance_report_digest'
+   AND left(source_key, length(:source_key_prefix)) = :source_key_prefix;
+SELECT count(*) AS org_digest_deliveries FROM attendance_notification_deliveries
+ WHERE org_id = :smoke_org AND source_type = 'attendance_report_digest';       -- bundle §7 shape
+SELECT count(*) AS default_org_digest_deliveries FROM attendance_notification_deliveries
+ WHERE org_id = 'default' AND source_type = 'attendance_report_digest';        -- leakage: must equal preflight baseline (normally 0)
+
+-- stamped surfaces (bundle §7 shape)
+SELECT count(*) AS stray_deliveries_to_smoke_users FROM attendance_notification_deliveries
+ WHERE left(recipient_user_id, 11) = 'rd45-smoke-';
+SELECT count(*) AS user_orgs FROM user_orgs WHERE left(user_id, 11) = 'rd45-smoke-';
+SELECT count(*) AS users FROM users WHERE left(id, 11) = 'rd45-smoke-';
+
+-- settings: GET /api/attendance/settings attendanceReportDigestPolicy equals the pre-smoke snapshot
+```
+
+Every count `0` (deltas `0` where a nonzero baseline was explicitly accepted at
+preflight). A stray row anywhere is a failed smoke, not a harmless warning.
+
+## Track B — optional default-org real-scheduler variant (owner-gated)
+
+Run ONLY after the risk statement above is accepted, and never with the
+delivery worker gate on.
+
+1. Backend env (container recreate): `ATTENDANCE_SCHEDULER_ENABLED=true`,
+   `ATTENDANCE_REPORT_DIGEST_ENABLED=true`, `ATTENDANCE_SCHEDULER_INTERVAL_MS=15000`,
+   delivery worker gate **unset/false**. Remember: the first tick fires one
+   FULL interval after process start, and a settings PUT may be invisible to
+   the backend for up to 60 s (in-process cache).
+2. Helper: `TRIGGER_MODE=scheduler ACK_DEFAULT_ORG_FANOUT=1 ORG_ID=default` +
+   the common env. The helper refuses to start within 30 minutes of UTC
+   midnight (the due periodKey would flip mid-run) unless explicitly
+   overridden.
+3. The helper polls for rows under the deterministic prefix (timeout
+   `2×interval + 60 s + margin`), asserts one row per active default-org
+   member, **pending-only** throughout (the worker-off proof), replay dedup by
+   waiting two further ticks, disabled path by policy-off + cache/tick wait,
+   then cleans by deterministic prefix only.
+4. Roll the env back (recreate) before resuming the window plan's flag state.
+
+## Expected PASS stamp
+
+Use this exact shape after the helper PASS, the RD-4 browser probe, the send
+posture record, and the residue block all succeed:
+
+```text
+RD45_REPORT_DIGEST_STAGING_SMOKE_PASS deploy=<sha> stamp=<rd45-smoke-...> org=<rd45-smoke-...-org> produced=<n> dedupOk=1 sendProof=<sent|failed_recipient_not_bound|failed_channel_not_configured> residue=0
+```
+
+Backfill text:
+
+> **回填（YYYY-MM-DD RD-4/5 report-digest staging closeout）**：staging smoke
+> `RD45_REPORT_DIGEST_STAGING_SMOKE_PASS` on deploy `<sha>`（stamp `<stamp>`，
+> disposable single-member org）：producer wrote per-subject pending rows with
+> the `:subject:` grain through the shipped seam; inactive membership excluded;
+> replay created zero new rows (ON CONFLICT dedup); producer-gate-off and
+> policy-off both produced nothing; the live delivery worker visibly resolved
+> every row（posture `<sendProof>`）; no default-org leakage; RD-4 config card
+> hydrated/saved/rejected-invalid in the browser; settings restored
+> byte-identical; deterministic keys recorded and cleaned; residue=0. RD-4/RD-5
+> closed ✅.
+
+## On FAIL
+
+- Helper aborts at the deterministic-key collision guard: a same-day run left
+  rows; clean via the residue SQL, then rerun (fresh STAMP still required).
+- `produced` ≠ active subject count, or a row without the `:subject:` segment:
+  producer grain regressed — do not pass.
+- Any row's recipient outside the resolved subject set: recipient containment
+  broken — do not pass; do NOT let the worker send.
+- Replay increases the count: idempotency regressed (unique index or ON
+  CONFLICT path) — do not pass.
+- Disabled path still produces: gate layering regressed — do not pass.
+- Rows stuck `pending`/`retrying` with the worker expected on: send gate or
+  channel env not effective on the deployed process — fix env, rerun.
+- `failed` with an unrecognized `last_error`: not a posture; investigate before
+  any rerun.
+- Default-org digest delta ≠ 0: backend producer gate was on — disable it,
+  clean by deterministic prefix on org `default` only, run FAILED.
+- Settings restore mismatch: **blocks the whole window** (bundle §4) until
+  settings are verified restored.
+
+## Safety
+
+- Only synthetic `rd45-smoke-*` users/org; the primary track never writes a
+  row naming a real user.
+- The globally-shared settings row is snapshotted and strictly restored; the
+  policy default is all-off.
+- The helper never mutates backend env; it never touches the send gate; the
+  producer gate is set only inside the helper's own process for the seam call.
+- Cleanup is org/prefix-scoped; never delete by `source_type` alone on the
+  default org.
+- Track B (the only mode that touches the default org) is fail-closed behind
+  `ACK_DEFAULT_ORG_FANOUT=1` + worker-off + UTC-midnight guard.
+- Enabling the shared scheduler also runs its other registered jobs each tick
+  (e.g. the comp-time expiry sweep) — see OQ-3 before flipping it on.
+
+## Open questions (resolve on the host before the window)
+
+**OQ-1 — RESOLVED: admin tokens are org-independent.** Verified against the
+code: `withPermission`/`withAnyPermission` (index.cjs:19841-19913) check only
+DB-level grants (`isAdmin` via `user_roles`, `userHasPermission` via
+`user_permissions`/`role_permissions`) with no org binding, and `getOrgId`
+(index.cjs:5823-5831) takes `body.orgId ?? query.orgId ?? user.orgId ??
+x-org-id` — so the helper's `?orgId=<rd45-smoke-…-org>` is honored by any
+staging token whose user passes the admin check; no smoke-org-minted token is
+needed. The only residual risk is host-side gateway/proxy middleware outside
+this repo; the read-only preflight GET stays as belt-and-braces, and the
+helper fails loudly (not skips) if the route answers non-200.
+
+**OQ-2 — seam execution locus (narrowed).** The backend image DOES ship the
+plugin (`Dockerfile.backend:44` COPYs `plugins/` into the runner stage), so
+the in-container option is repo-derivable; the remaining unknowns are only
+whether `pg` resolves from the helper's location in-image and whether the
+staging stack runs this Dockerfile. The safe default remains a prepared
+checkout at the deployed SHA on a host with `DATABASE_URL` access (the C5-5
+precedent) — with one concrete caveat: in a standard pnpm checkout `pg` is a
+dependency of `packages/core-backend` only (strict layout, no hoist), so
+`import('pg')` from `scripts/ops/` fails with `ERR_MODULE_NOT_FOUND` unless
+you run with `NODE_PATH=packages/core-backend/node_modules` (or from a cwd
+where `pg` resolves). The helper fails loudly at exit 2 either way.
+`PLUGIN_INDEX_PATH` overrides the default relative path if the locus differs.
+
+**OQ-3 — live env-flag state and co-registered scheduler jobs.** The current
+values of the scheduler/producer/worker/channel envs on the staging host, and
+which OTHER env-gated jobs would begin running once
+`ATTENDANCE_SCHEDULER_ENABLED=true` ticks (comp-time expiry runs every cycle;
+reminder jobs register under their own gates), must be read from the live
+container before the window (bundle §9.3). Only add what is missing; plan the
+rollback.
+
+**OQ-4 — token mint path.** Which mint path counts as the approved staging
+smoke-token path is unstated in the family docs (bundle §9.5); the operator
+picks one and uses it for all three window smokes. Note: on non-staging
+rehearsal runs where `GET /api/auth/dev-token` IS available, each mint
+persists a `user_sessions` row for the stamped synthetic admin; those session
+rows are expected out-of-ledger (not in the residue gate, no FK to `users`)
+and do not occur on staging, where the dev-token route returns `404`.
+
+**OQ-5 — backend instance topology (Track B only).** Whether the staging stack
+runs a single backend instance, and whether the scheduler leader lock is
+enabled, is host state: with multiple instances or a leader lock, tick timing
+and the 60 s settings-cache staleness apply per instance and the Track B wait
+math must be re-derived on the host.

--- a/docs/development/attendance-staging-window-bundle-20260702.md
+++ b/docs/development/attendance-staging-window-bundle-20260702.md
@@ -1,0 +1,322 @@
+# Attendance staging window bundle — AE-4 + RD-4/5 + OT-bank v1-8
+
+**Date:** 2026-07-02
+
+**Status:** PREPARED. This plan does **not** claim any staging PASS. It is the
+single operating plan for one staging window that runs three independent
+attendance smokes back-to-back on ONE deployed SHA. Each smoke's PASS is
+recorded in its own runbook; this document coordinates deploy, ordering,
+isolation, and the consolidated closeout.
+
+**Precedent:** the bundled-window format follows
+`docs/development/attendance-staging-smoke-ns4-ta4-20260624.md` (one doc, two
+self-contained smokes, per-smoke deployed-code gates, per-smoke stamps,
+zero-residue discipline). Its recorded lesson binds this window: the two
+precedent smokes did NOT land on one SHA and one stamp lost its exact deploy
+SHA — so in this window, **capture the exact deploy SHA into every stamp at
+run time**, never from memory.
+
+## 1. The three smokes
+
+| # | Smoke | Runbook | Helper | Final stamp shape |
+|---|---|---|---|---|
+| 1 | **AE-4** anomaly-result-edit closeout | `docs/development/attendance-ae4-anomaly-result-edit-staging-smoke-runbook-20260701.md` | `scripts/ops/staging-attendance-ae4-result-edit-smoke.mjs` (`AE4_RESULT_EDIT_API_DB_SMOKE_PASS`) | `AE4_RESULT_EDIT_STAGING_SMOKE_PASS deploy=<sha> stamp=<ae4-smoke-...> org=<org> notifyRecord=<uuid> skipRecord=<uuid> residue=0` |
+| 2 | **RD-4/5** report-digest config card + producer/worker | `docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md` | `scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs` (`RD45_REPORT_DIGEST_API_DB_SMOKE_PASS`) | `RD45_REPORT_DIGEST_STAGING_SMOKE_PASS deploy=<sha> stamp=<rd45-smoke-...> org=<rd45-smoke-...-org> produced=<n> dedupOk=1 sendProof=<sent\|failed_recipient_not_bound\|failed_channel_not_configured> residue=0` |
+| 3 | **OT-bank v1-8** 三例验收 + settlement | `docs/development/attendance-overtime-bank-v18-staging-smoke-runbook-20260702.md` | `scripts/ops/staging-attendance-overtime-bank-v18-smoke.mjs` (`OTBANK_V18_API_DB_SMOKE_PASS`) | `OTBANK_V18_STAGING_SMOKE_PASS deploy=<sha> stamp=<otbank-v18-smoke-...> org=<org> cycle=<uuid> residue=0` |
+
+Each helper prints an `*_API_DB_SMOKE_PASS` line that is **not** the final
+stamp; the final `*_STAGING_SMOKE_PASS` stamps are recorded by the operator in
+the respective runbooks after the manual/decision steps there.
+
+## 2. One deploy SHA for the whole window
+
+Deploy ONE main build to the staging stack and run all three smokes against
+it. The single `DEPLOY_SHA` must include every per-smoke code gate:
+
+- **AE-4**: AE-1 result-edit route + audit table, AE-1b marker durability,
+  AE-2/2.1 affected-employee notification + toggle, AE-3 admin modal (per the
+  AE-4 runbook's prerequisites).
+- **RD-4/5**: RD-1 config contract, RD-2/RD-3 producer chain, RD-4 admin
+  config card (per the report-digest design lock,
+  `docs/development/attendance-report-digest-subscription-design-lock-20260626.md`).
+- **OT-bank v1-8**: v1-1..v1-6 plus the #3255 must-pay e2e and the #3303
+  unconditional-settings-restore fix (per
+  `docs/development/attendance-overtime-bank-design-verification-20260624.md`).
+
+Deploy-SHA verification (manual — no committed tool cross-checks the staging
+stack's build against an expected SHA, see §9):
+
+```bash
+# through the web port tunnel (bare /health is not proxied at the web port — use /api/health):
+curl -sS http://127.0.0.1:8082/api/health | jq -r .build.commit
+# or backend-direct through the tunnel:
+curl -sS http://127.0.0.1:18900/health | jq -r .build.commit
+```
+
+Both must equal the full `DEPLOY_SHA` you will write into every stamp. Do not
+use a local branch SHA.
+
+Staging deploys are operator-run over SSH (the CI deploy job targets the
+prod-track stack, not the staging stack, and does not auto-mirror main): pin
+the image tag to the full 40-char SHA in the staging stack's env/override,
+pull, recreate `backend`/`web` with `--no-deps`, per
+`docs/development/staging-deploy-d88ad587b-20260426.md` and the flag-pinning
+override pattern in
+`docs/development/multitable-global-history-staging-flag-operator-checklist-20260701.md`.
+
+## 3. Shared window preflight (run ONCE, before smoke #1)
+
+1. **Health + build**: API health OK on the deployed build; `build.commit`
+   equals `DEPLOY_SHA` (commands above).
+2. **Migration alignment** (deploy SOP discipline): list pending migrations
+   from the running backend and classify them READ-ONLY before anything else:
+
+   ```bash
+   docker compose -f docker-compose.app.staging.yml exec -T backend \
+     node packages/core-backend/dist/src/db/migrate.js --list > /tmp/staging-migrate-list.txt
+   node scripts/ops/staging-migration-alignment-report.mjs \
+     --migrate-list-file /tmp/staging-migrate-list.txt --out-dir /tmp/staging-migration-report
+   ```
+
+   If the report says do-not-run-full-migrate, STOP and follow
+   `docs/development/staging-migration-alignment-runbook-verification-20260519.md`;
+   do not improvise DDL. The window needs (at minimum) the AE audit table,
+   `attendance_notification_deliveries` (shared by AE-4 and RD — the digest
+   producer has no tables of its own; it writes the existing deliveries table
+   and persists policy in the shared settings row), and the OT-bank
+   `attendance_payroll_cycle_settlements` + `overtime_source` migrations.
+3. **Auth round-trip**: with the staging-realm admin token,
+   `GET /api/attendance/settings` must return `200`. A `401 Invalid token`
+   means a wrong-realm token (staging signs with its own secret — re-mint,
+   don't debug the route); a `503 DB_NOT_READY` means the schema gap above —
+   STOP.
+4. **Environment flags — set once, at window start**: only RD needs env gates
+   (`ATTENDANCE_SCHEDULER_ENABLED=true`,
+   `ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED=true`, plus a routable
+   notification channel per the RD runbook). **The backend's
+   `ATTENDANCE_REPORT_DIGEST_ENABLED` stays UNSET/false for the whole window**
+   (RD runbook amendment): the digest policy is a single GLOBAL settings row,
+   so once the RD smoke enables it, a backend with the digest gate on would
+   fan the next real scheduler tick out to real default-org members — the
+   RD helper instead enables the gate process-locally around its seam call
+   and asserts a no-default-org-leakage guard. Only the RD runbook's
+   owner-gated Track B variant sets the backend gate, under its own guards.
+   Env changes require a backend container recreate, so flip them together
+   with the deploy (never mid-smoke), verify them in the running container
+   env, and plan the rollback (remove flags + restart) for the window close.
+   This is safe for the whole window: with the backend digest gate off, the
+   producer never runs in the backend regardless of policy state, and AE-4 /
+   v1-8 are settings-gated only.
+5. **Settings snapshot**: save `GET /api/attendance/settings` to
+   `/tmp/window-settings-before.json` as the window-level baseline, in
+   addition to each smoke's own snapshot/restore.
+6. **DB channel**: confirm `DATABASE_URL` reaches the SAME staging database as
+   `BASE_URL` (each helper also runs its own API↔DB coherence probe and
+   aborts on mismatch).
+
+## 4. Execution order and rationale
+
+Run strictly sequentially, never in parallel:
+
+1. **AE-4 first.** It is the only smoke with a mandatory manual browser step
+   (the AE-3 modal probe), so it runs while the operator's attention and the
+   freshly-verified deploy are at their best. Its settings key
+   (`attendanceResultEditPolicy`) is disjoint from the other two smokes.
+2. **RD-4/5 second.** It is the only smoke that depends on the window's env
+   flags (scheduler / delivery worker / digest producer) and on a disposable
+   org; running it in the middle keeps the flag-dependent assertions well
+   inside the window, after AE-4 has already restored its settings.
+3. **OT-bank v1-8 last.** It touches the most settings keys
+   (`overtimeSegmentation`, `compTimeFromOvertime`, `overtimeBankPolicy`,
+   `leaveBalanceDeductionPolicy`, `attendanceBonusPolicy`) and closes a
+   payroll cycle whose settlement population is org-wide — running it last
+   means the other smokes never execute under partially-flipped money-path
+   policies, and its population guard sees the quietest possible org state.
+
+Settings mutations across the three smokes are key-disjoint, and each smoke
+snapshots + restores its own keys before the next starts — but ordering still
+matters for blast-radius: a mid-run abort leaves that smoke's policies live
+until its cleanup is completed, so finish (or fully clean up) one smoke before
+starting the next. **A failed settings restore in any smoke blocks starting
+the next smoke** until settings are verified restored.
+
+## 5. Per-smoke isolation rules
+
+**Stamps.** Every business row a smoke creates is stamped, and every cleanup /
+residue query is anchored on the stamp — never on broad text or types:
+
+| Smoke | User/stamp prefix | Business-key prefix |
+|---|---|---|
+| AE-4 | `ae4-smoke-<suffix>-…` | `ae4-smoke:<STAMP>:…` |
+| RD-4/5 | `rd45-smoke-<suffix>-…` | `rd45-smoke:<STAMP>:…` (no occupant — digest source keys are deterministic; see the RD runbook's known-family-deviation section) |
+| OT-bank v1-8 | `otbank-v18-smoke-<suffix>-…` | `otbank-v18-smoke:<STAMP>:…` |
+
+The three prefixes are mutually exclusive by construction, so residue queries
+cannot collide. Helpers regex-lock their stamps and refuse unstamped ids.
+
+**Settings.** `PUT /api/attendance/settings` merges per policy key, so each
+smoke PUTs ONLY its own keys and siblings survive: AE-4 owns
+`attendanceResultEditPolicy`; RD-4/5 owns `attendanceReportDigestPolicy`;
+v1-8 owns the five overtime-bank keys listed in §4. Because of the merge
+semantics, restores must explicitly re-assert every touched key (PUT-ing an
+empty snapshot is a NO-OP — the #3303 lesson); each smoke restores and
+VERIFIES (re-GET + compare) before the next smoke begins.
+
+**The shared deliveries table.** Two of three smokes write
+`attendance_notification_deliveries`: AE-4 with
+`source_type='attendance_result_edit'` (source keys
+`attendance_result_edit:<org>:<recordId>:%`), RD-4/5 with
+`source_type='attendance_report_digest'` (unique idempotent source keys per
+org/cadence/period/recipient/channel). The OT-bank smoke writes none and
+asserts zero. Rules:
+
+- every delivery query (assert, residue, cleanup) is scoped
+  `org + source_type + stamped source key` — never delete by `source_type`
+  alone;
+- the delivery worker is live for the WHOLE window (env flags, §3). During
+  AE-4 either assert on delivery-row existence and audit back-link (not on
+  send status), or park claimable rows first with the established pattern —
+  bump `next_attempt_at` into the future for pre-existing pending rows and
+  make only the row under test claimable;
+- RD-5 must prove "producer writes row" and "worker sends/fails" as separate
+  assertions (its design lock requires the split).
+
+**Org scope.** AE-4 runs on the default org with stamped synthetic users.
+RD-4/5 MUST use a disposable single-member smoke org, because the digest
+producer fans out per active org member. OT-bank v1-8 defaults to the shared
+org but fails closed if the settlement population would include any
+non-synthetic user (its runbook OQ-2 records the operator decision; the
+override env is explicit and dangerous).
+
+**Payroll cycles.** Only v1-8 creates/closes a cycle, on a far-future period
+chosen to overlap nothing; AE-4 SQL-seeds a stamped closed cycle only for its
+409 guard. Neither touches production cycles.
+
+## 6. Per-smoke independence
+
+Each smoke is independently PASS/FAIL:
+
+- a FAIL in one smoke does **not** void another smoke's recorded PASS (the
+  precedent window closed one smoke on an earlier deploy than the other —
+  legitimate, as long as every stamp names its exact deploy SHA);
+- a FAILed smoke is cleaned up (helpers attempt best-effort cleanup and print
+  the residue), its settings restore is verified, and the window may continue
+  with the next smoke;
+- what a FAIL does block: re-running THAT smoke requires a fresh STAMP, and a
+  failed settings restore blocks the whole window (§4);
+- if the window must be re-run on a newer deploy, previously-recorded PASS
+  stamps stay valid for their SHA; re-stamp only what re-ran.
+
+## 7. Consolidated final residue sweep (window close)
+
+After all three smokes (and before rolling back env flags), run each
+runbook's own residue block once more, then this cross-smoke sweep. Every
+count must be `0`. Substitute the three run stamps; the per-run captured id
+lists (request/approval/cycle/import ids) come from each helper's output and
+runbook worksheet.
+
+```sql
+-- synthetic users and memberships, all three families
+SELECT count(*) AS users FROM users
+ WHERE left(id, 10) = 'ae4-smoke-' OR left(id, 11) = 'rd45-smoke-' OR left(id, 17) = 'otbank-v18-smoke-';
+SELECT count(*) AS user_orgs FROM user_orgs
+ WHERE left(user_id, 10) = 'ae4-smoke-' OR left(user_id, 11) = 'rd45-smoke-' OR left(user_id, 17) = 'otbank-v18-smoke-';
+
+-- attendance business rows by stamped meta/user
+SELECT count(*) AS records FROM attendance_records
+ WHERE meta->>'smokeStamp' IN (:ae4_stamp, :rd45_stamp, :otbank_stamp)
+    OR left(user_id, 10) = 'ae4-smoke-' OR left(user_id, 11) = 'rd45-smoke-' OR left(user_id, 17) = 'otbank-v18-smoke-';
+SELECT count(*) AS requests FROM attendance_requests
+ WHERE metadata->>'smokeStamp' IN (:ae4_stamp, :rd45_stamp, :otbank_stamp)
+    OR left(user_id, 10) = 'ae4-smoke-' OR left(user_id, 11) = 'rd45-smoke-' OR left(user_id, 17) = 'otbank-v18-smoke-';
+
+-- the shared deliveries table, per source_type + stamped scoping (never source_type alone)
+SELECT count(*) AS ae4_deliveries FROM attendance_notification_deliveries d
+  JOIN attendance_record_result_edits e ON d.source_id = e.id::text AND e.org_id = d.org_id
+ WHERE d.source_type = 'attendance_result_edit'
+   AND left(e.idempotency_key, length('ae4-smoke:' || :ae4_stamp || ':')) = 'ae4-smoke:' || :ae4_stamp || ':';
+SELECT count(*) AS rd45_deliveries FROM attendance_notification_deliveries
+ WHERE source_type = 'attendance_report_digest' AND org_id = :rd45_smoke_org;
+SELECT count(*) AS stray_deliveries_to_smoke_users FROM attendance_notification_deliveries
+ WHERE left(recipient_user_id, 10) = 'ae4-smoke-' OR left(recipient_user_id, 11) = 'rd45-smoke-'
+    OR left(recipient_user_id, 17) = 'otbank-v18-smoke-';
+
+-- OT-bank money-path tables (cycle ids captured from the v1-8 run)
+SELECT count(*) AS settlements FROM attendance_payroll_cycle_settlements WHERE cycle_id = ANY(:otbank_cycle_ids::uuid[]);
+SELECT count(*) AS cycles FROM attendance_payroll_cycles
+ WHERE metadata->>'smokeStamp' IN (:ae4_stamp, :otbank_stamp);
+SELECT count(*) AS lots FROM attendance_leave_balances
+ WHERE left(user_id, 17) = 'otbank-v18-smoke-' OR source_key = :otbank_poison_lot_key;
+SELECT count(*) AS fixtures FROM attendance_overtime_rules WHERE name = :otbank_rule_name;
+SELECT count(*) AS leave_types FROM attendance_leave_types WHERE code = :otbank_leave_type_code;
+SELECT count(*) AS holidays FROM attendance_holidays WHERE name = :otbank_holiday_name;
+
+-- approval-engine rows written by the v1-8 request chain (ids captured by the helper)
+SELECT count(*) AS approval_instances FROM approval_instances WHERE id = ANY(:otbank_approval_ids::text[]);
+
+-- settings: compare the live document to the window baseline
+-- (GET /api/attendance/settings vs /tmp/window-settings-before.json — policy keys equal)
+```
+
+The RD-4/5 runbook's own residue block (its digest/org tables) is part of this
+sweep by reference. A stray row anywhere is a failed window close, not a
+harmless warning — inspect before deleting anything by hand, and only delete
+via the owning runbook's stamped cleanup.
+
+Finally, roll back the RD env flags per §3 (remove flags + recreate the
+backend container, verify health), and confirm the settings document equals
+the window baseline.
+
+## 8. Closure checklist
+
+- [ ] Window preflight recorded (deploy SHA, migration report, auth
+      round-trip, env flags) — once, in this doc's run notes or the first
+      runbook's worksheet.
+- [ ] AE-4: helper `AE4_RESULT_EDIT_API_DB_SMOKE_PASS` + manual AE-3 modal
+      step done; final `AE4_RESULT_EDIT_STAGING_SMOKE_PASS` recorded in the
+      AE-4 runbook with deploy SHA + residue 0; **close the AE umbrella issue
+      #3317 with the stamp in the close note**.
+- [ ] RD-4/5: producer-writes-row and worker-sends assertions both recorded;
+      final stamp recorded in the RD-4/5 runbook with deploy SHA + residue 0;
+      disposable org torn down.
+- [ ] OT-bank v1-8: helper `OTBANK_V18_API_DB_SMOKE_PASS`; OQ-1 (三例 mapping)
+      and OQ-2 (org/population) decisions recorded; final
+      `OTBANK_V18_STAGING_SMOKE_PASS` recorded in the v1-8 runbook with deploy
+      SHA + residue 0; the v1-8 row in the overtime-bank design-verification
+      doc flips to done in a follow-up docs PR (not from this plan alone).
+- [ ] Consolidated residue sweep (§7) all-zero; env flags rolled back;
+      settings equal the window baseline.
+- [ ] Each stamp names the exact deployed SHA (the precedent window's missing
+      SHA lesson).
+
+## 9. Open questions / verify on the host before the window
+
+1. **Staging DB reachability**: the staging compose file publishes no host
+   port for the database; the working `DATABASE_URL` (published port or
+   tunnel endpoint) lives in the host-local override files — verify on the
+   host before the window.
+2. **Compose tooling**: the older deploy postmortem used v1 syntax with the
+   stop/rm/up-no-deps workaround; the newer operator checklist uses v2
+   (`docker compose`) — confirm which the host has before scripting.
+3. **Current env-flag state**: whether the scheduler / delivery-worker /
+   channel envs are already set on the host env file is not knowable from the
+   repo — read the live container env first; only add what is missing.
+4. **RD-5 tick mechanism — resolved in the RD runbook**: the primary track is
+   a deterministic in-process invocation of the digest-producer seam from a
+   prepared checkout at the deployed SHA on a host with `DATABASE_URL` access
+   (or in-container if the RD runbook's OQ-2 resolves on the host), scoped to
+   the disposable smoke org (no force-tick HTTP route exists); the
+   real-scheduler tick on the default org is an explicitly owner-gated
+   optional variant. See the RD-4/5 runbook for the exact commands and guards.
+5. **Token mint path**: dev-token is expected to 404 on staging
+   (production node-env); which mint path (host-side token generator script vs
+   in-container mint script) counts as the approved smoke-token path is
+   unstated in the family docs — operator picks one and uses it for all three
+   smokes (see the v1-8 runbook OQ-3).
+6. **Deploy-SHA cross-check tooling**: no committed helper asserts
+   `/health build.commit == DEPLOY_SHA` for the staging stack; §2's manual
+   curl check is mandatory in this window and the per-helper `DEPLOY_SHA` env
+   only names the stamp — it does not verify the build.
+7. **RD-4/5 runbook filename — resolved**: the RD-4/5 runbook + helper landed
+   in this bundle at the exact paths named in §1's table (this plan
+   intentionally does not restate their content).

--- a/scripts/ops/staging-attendance-overtime-bank-v18-smoke.mjs
+++ b/scripts/ops/staging-attendance-overtime-bank-v18-smoke.mjs
@@ -1,0 +1,992 @@
+#!/usr/bin/env node
+// OT-bank v1-8 staging smoke helper — overtime-bank accrual / leave-offset / cycle-close settlement API/DB chain.
+//
+// This helper drives the real staging HTTP API for every business write (settings PUT,
+// overtime-rule / leave-type / holiday / request create, approve, payroll-cycle create/close),
+// and uses SQL only for synthetic seed (users, the poison balance lot), exact assertions
+// (per-source lot tagging and attendance_payroll_cycle_settlements have NO API read surface
+// until the v1-5d read exit lands), and stamped cleanup. It intentionally does NOT claim the
+// final v1-8 staging closeout; the operator-decision blocks and the final stamp live in
+// docs/development/attendance-overtime-bank-v18-staging-smoke-runbook-20260702.md.
+//
+// Cases (compressed replay of the owner's three settlement acceptance cases, in minutes):
+//   case1: OT +600 pooled, leave 600 → deduct 600, remaining 0, shortfall 0, convertible 0
+//   case2: OT +600 pooled, leave 300 → deduct 300, remaining 300, shortfall 0, convertible 300
+//   case3: OT +600 pooled, leave 900 → deduct 600 (partial), remaining 0, shortfall 300, convertible 0
+// plus: dormant-bank NULL-source grant regression, statutory-holiday must-pay boundary with a
+// poison 9999 statutory balance lot, replay idempotency (approve replay + close replay), frozen
+// cycle guards, full-attendance flag, ledger conservation, settings restore, residue=0.
+
+import { randomUUID } from 'node:crypto'
+import { pathToFileURL } from 'node:url'
+
+// --- pure helpers (exported for the companion .test.mjs) -----------------------------------
+
+export const STAMP_PATTERN = /^otbank-v18-smoke-[A-Za-z0-9-]+$/
+
+export const RESTORED_POLICY_KEYS = [
+  'overtimeSegmentation',
+  'compTimeFromOvertime',
+  'overtimeBankPolicy',
+  'leaveBalanceDeductionPolicy',
+  'attendanceBonusPolicy',
+]
+
+// Compressed three-case plan (owner acceptance table, hours → minutes).
+export const CASE_PLAN = [
+  { key: 'case1', otMinutes: 600, leaveMinutes: 600, expectDeductMinutes: 600, expectRemainingMinutes: 0, expectShortfallMinutes: 0, expectConvertibleMinutes: 0 },
+  { key: 'case2', otMinutes: 600, leaveMinutes: 300, expectDeductMinutes: 300, expectRemainingMinutes: 300, expectShortfallMinutes: 0, expectConvertibleMinutes: 300 },
+  { key: 'case3', otMinutes: 600, leaveMinutes: 900, expectDeductMinutes: 600, expectRemainingMinutes: 0, expectShortfallMinutes: 300, expectConvertibleMinutes: 0 },
+]
+
+export function stableJson(value) {
+  return JSON.stringify(value ?? null)
+}
+
+export function jwtSubject(jwt) {
+  try {
+    const seg = String(jwt).split('.')[1]
+    if (!seg) return null
+    const payload = JSON.parse(Buffer.from(seg, 'base64url').toString('utf8'))
+    return payload.id ?? payload.sub ?? payload.userId ?? null
+  } catch {
+    return null
+  }
+}
+
+export function addDays(date, days) {
+  const next = new Date(`${date}T00:00:00.000Z`)
+  next.setUTCDate(next.getUTCDate() + days)
+  return next.toISOString().slice(0, 10)
+}
+
+export function isWeekend(ymd) {
+  const dow = new Date(`${ymd}T00:00:00.000Z`).getUTCDay()
+  return dow === 0 || dow === 6
+}
+
+export function firstMondayOfMonth(year, monthIndex) {
+  const d = new Date(Date.UTC(year, monthIndex, 1))
+  while (d.getUTCDay() !== 1) d.setUTCDate(d.getUTCDate() + 1)
+  return d.toISOString().slice(0, 10)
+}
+
+export function lastDayOfMonth(year, monthIndex) {
+  return new Date(Date.UTC(year, monthIndex + 1, 0)).toISOString().slice(0, 10)
+}
+
+// Far-future year so the settlement period contains no real staging records/requests and no
+// synced holiday rows (same isolation trick as the O6 segmentation smoke's 2040+ seed years).
+export function pickSmokeYear(suffix, override) {
+  const parsedOverride = Number.parseInt(String(override ?? ''), 10)
+  if (Number.isInteger(parsedOverride) && parsedOverride >= 2030 && parsedOverride <= 2099) return parsedOverride
+  const seed = Number.parseInt(String(suffix).slice(-3), 36)
+  return 2041 + ((Number.isFinite(seed) ? seed : 0) % 30)
+}
+
+// One month = one settlement window: OT on the first Monday (workday), leave offset on the
+// Tuesday, seeded statutory holiday + holiday OT on the Wednesday; cycle spans the full month.
+export function buildSmokeWindow(year) {
+  const monthIndex = 9 // October
+  const otDate = firstMondayOfMonth(year, monthIndex)
+  return {
+    year,
+    periodStart: `${year}-10-01`,
+    periodEnd: lastDayOfMonth(year, monthIndex),
+    otDate,
+    leaveDate: addDays(otDate, 1),
+    holidayDate: addDays(otDate, 2),
+  }
+}
+
+// PUT /api/attendance/settings deep-merges per policy key (mergeSettings), so restoring by
+// PUT-ing an empty snapshot is a NO-OP that leaks this smoke's policies (#3303 lesson). The
+// restore body must explicitly re-assert every toggled policy key, defaulting to disabled when
+// the pre-smoke settings never carried it.
+export function buildRestoreSettingsBody(originalSettings) {
+  const original = originalSettings && typeof originalSettings === 'object' ? originalSettings : {}
+  return {
+    ...original,
+    overtimeSegmentation: { enabled: false, ...(original.overtimeSegmentation ?? {}) },
+    compTimeFromOvertime: { enabled: false, ...(original.compTimeFromOvertime ?? {}) },
+    overtimeBankPolicy: { enabled: false, pooledSources: [], ...(original.overtimeBankPolicy ?? {}) },
+    leaveBalanceDeductionPolicy: { enabled: false, rules: [], ...(original.leaveBalanceDeductionPolicy ?? {}) },
+    attendanceBonusPolicy: { enabled: false, ...(original.attendanceBonusPolicy ?? {}) },
+  }
+}
+
+export function isStampedId(value, prefix) {
+  return typeof value === 'string' && value.startsWith(prefix) && value.length > prefix.length
+}
+
+export function parseJson(value) {
+  if (value == null || typeof value === 'object') return value
+  try { return JSON.parse(value) } catch { return null }
+}
+
+// Env-only contract (no CLI args), mirroring the AE-4 helper: BASE_URL/DATABASE_URL required,
+// DEPLOY_SHA mandatory (the PASS stamp must name the staging build actually smoked), STAMP
+// regex-locked so cleanup remains visibly synthetic and LIKE-free.
+export function resolveEnvConfig(env = {}) {
+  const errors = []
+  const baseUrl = String(env.BASE_URL || env.BASE || '').replace(/\/$/, '')
+  const databaseUrl = String(env.DATABASE_URL || '')
+  const orgId = String(env.ORG_ID || 'default')
+  const deploySha = String(env.DEPLOY_SHA || env.EXPECTED_DEPLOY_SHA || '')
+  if (!baseUrl || !databaseUrl) {
+    errors.push('BASE_URL and DATABASE_URL are required.')
+  }
+  if (!deploySha || deploySha === '<fill-from-staging-build>') {
+    errors.push('DEPLOY_SHA is required so the PASS stamp names the staging build that was actually smoked.')
+  }
+  const suffix = Date.now().toString(36)
+  const stamp = String(env.STAMP || `otbank-v18-smoke-${suffix}`)
+  if (!STAMP_PATTERN.test(stamp)) {
+    errors.push('STAMP must match /^otbank-v18-smoke-[A-Za-z0-9-]+$/ so cleanup remains visibly synthetic and LIKE-free.')
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    config: {
+      baseUrl,
+      databaseUrl,
+      orgId,
+      deploySha,
+      stamp,
+      suffix,
+      year: pickSmokeYear(suffix, env.SMOKE_YEAR),
+      allowNonSyntheticPopulation: env.ALLOW_NON_SYNTHETIC_SETTLEMENT_POPULATION === '1',
+    },
+  }
+}
+
+// --- runtime wiring -------------------------------------------------------------------------
+
+const IS_MAIN = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false
+const ENTRY = resolveEnvConfig(process.env)
+if (IS_MAIN && !ENTRY.ok) {
+  for (const message of ENTRY.errors) console.error(`FAIL: ${message}`)
+  console.error('  e.g. BASE_URL=http://127.0.0.1:8082 DATABASE_URL=postgresql://USER@127.0.0.1:5432/metasheet DEPLOY_SHA=<deployed-sha> ADMIN_TOKEN=<jwt> node scripts/ops/staging-attendance-overtime-bank-v18-smoke.mjs')
+  process.exit(2)
+}
+
+const { baseUrl: BASE_URL, databaseUrl: DATABASE_URL, orgId: ORG_ID, deploySha: DEPLOY_SHA, stamp: STAMP } = ENTRY.config
+const USER_PREFIX = `${STAMP}-`
+const KEY_PREFIX = `otbank-v18-smoke:${STAMP}:`
+
+const USERS = {
+  admin: process.env.ADMIN_USER_ID || `${USER_PREFIX}admin`,
+  case1: process.env.CASE1_USER_ID || `${USER_PREFIX}case1`,
+  case2: process.env.CASE2_USER_ID || `${USER_PREFIX}case2`,
+  case3: process.env.CASE3_USER_ID || `${USER_PREFIX}case3`,
+  mustpay: process.env.MUSTPAY_USER_ID || `${USER_PREFIX}mustpay`,
+  dormant: process.env.DORMANT_USER_ID || `${USER_PREFIX}dormant`,
+}
+const BUSINESS_USER_KEYS = ['case1', 'case2', 'case3', 'mustpay', 'dormant']
+const USER_TOKEN_ENVS = {
+  case1: 'CASE1_TOKEN',
+  case2: 'CASE2_TOKEN',
+  case3: 'CASE3_TOKEN',
+  mustpay: 'MUSTPAY_TOKEN',
+  dormant: 'DORMANT_TOKEN',
+}
+
+let adminToken = process.env.ADMIN_TOKEN || process.env.SMOKE_TOKEN || process.env.TOKEN || ''
+const userTokens = {}
+let originalSettings = null
+let cleanupAllowed = false
+let populationSyntheticOnly = false
+let smokeWindow = null
+let pass = 0
+const failures = []
+
+const created = {
+  overtimeRuleId: null,
+  leaveTypeId: null,
+  leaveTypeCode: `${STAMP}-offset`,
+  overtimeRuleName: `${STAMP}-ot-rule`,
+  holidayName: `${STAMP} statutory holiday`,
+  cycleName: `${STAMP}-cycle`,
+  poisonLotKey: `${KEY_PREFIX}poison-statutory-lot`,
+  holidayIds: [],
+  cycleIds: [],
+  requestIds: [],
+  approvalInstanceIds: new Set(),
+}
+
+let pool = null
+const q = (text, params = []) => pool.query(text, params).then(result => result.rows)
+
+function ok(condition, label, detail) {
+  if (condition) {
+    pass += 1
+    console.log(`  PASS  ${label}`)
+    return
+  }
+  failures.push(label)
+  const suffix = detail === undefined ? '' : ` - ${JSON.stringify(detail)}`
+  console.error(`  FAIL  ${label}${suffix}`)
+}
+
+function assertSyntheticUser(userId, label) {
+  if (isStampedId(userId, USER_PREFIX)) return
+  throw new Error(`refusing to run: ${label} "${userId}" is not stamped with ${USER_PREFIX}. This smoke deletes its synthetic users during cleanup.`)
+}
+
+function authHeaders(token) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'x-org-id': ORG_ID,
+  }
+  if (token) headers.Authorization = `Bearer ${token}`
+  return headers
+}
+
+async function api(token, pathname, { method = 'GET', body } = {}) {
+  const url = new URL(`${BASE_URL}${pathname}`)
+  if (!url.searchParams.has('orgId')) url.searchParams.set('orgId', ORG_ID)
+  const res = await fetch(url, {
+    method,
+    headers: authHeaders(token),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  let json = null
+  try { json = await res.json() } catch { /* non-json */ }
+  return { status: res.status, body: json }
+}
+
+async function mintToken(userId, { roles = 'user', perms }) {
+  const res = await api('', `/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`)
+  const token = res.body?.token || ''
+  if (!token) {
+    throw new Error(`could not mint dev-token for ${userId} (status ${res.status}); provide explicit ADMIN_TOKEN/CASE1_TOKEN/... for staging environments that disable dev-token`)
+  }
+  return token
+}
+
+async function resolveTokens() {
+  assertSyntheticUser(USERS.admin, 'ADMIN_USER_ID')
+  for (const key of BUSINESS_USER_KEYS) assertSyntheticUser(USERS[key], `${key} user id`)
+  if (!adminToken) {
+    adminToken = await mintToken(USERS.admin, {
+      roles: 'admin',
+      perms: 'attendance:read,attendance:write,attendance:admin,attendance:approve',
+    })
+    console.log('  minted admin dev-token')
+  } else {
+    const subject = jwtSubject(adminToken)
+    if (subject != null) console.log(`  using supplied admin token (subject ${subject})`)
+  }
+  for (const key of BUSINESS_USER_KEYS) {
+    const supplied = process.env[USER_TOKEN_ENVS[key]] || ''
+    if (supplied) {
+      // Requests are created AS the token subject; a mismatched supplied token would attribute
+      // business rows to a user this smoke does not clean up.
+      const subject = jwtSubject(supplied)
+      if (subject !== USERS[key]) {
+        throw new Error(`${USER_TOKEN_ENVS[key]} subject "${subject}" does not equal ${key} user id "${USERS[key]}"`)
+      }
+      userTokens[key] = supplied
+      console.log(`  using supplied ${key} token (subject ${subject})`)
+    } else {
+      userTokens[key] = await mintToken(USERS[key], { roles: 'user', perms: 'attendance:read,attendance:write' })
+      console.log(`  minted ${key} dev-token`)
+    }
+  }
+}
+
+async function preflightDatabase() {
+  const row = (await q(
+    `SELECT
+       to_regclass('public.users') IS NOT NULL AS users_ok,
+       to_regclass('public.user_orgs') IS NOT NULL AS user_orgs_ok,
+       to_regclass('public.attendance_requests') IS NOT NULL AS requests_ok,
+       to_regclass('public.attendance_records') IS NOT NULL AS records_ok,
+       to_regclass('public.attendance_events') IS NOT NULL AS events_ok,
+       to_regclass('public.attendance_leave_types') IS NOT NULL AS leave_types_ok,
+       to_regclass('public.attendance_overtime_rules') IS NOT NULL AS overtime_rules_ok,
+       to_regclass('public.attendance_holidays') IS NOT NULL AS holidays_ok,
+       to_regclass('public.attendance_leave_balances') IS NOT NULL AS leave_balances_ok,
+       to_regclass('public.attendance_leave_balance_events') IS NOT NULL AS balance_events_ok,
+       to_regclass('public.attendance_payroll_cycles') IS NOT NULL AS cycles_ok,
+       to_regclass('public.attendance_payroll_cycle_settlements') IS NOT NULL AS settlements_ok,
+       to_regclass('public.attendance_notification_deliveries') IS NOT NULL AS deliveries_ok,
+       to_regclass('public.approval_instances') IS NOT NULL AS approval_instances_ok,
+       to_regclass('public.approval_assignments') IS NOT NULL AS approval_assignments_ok,
+       to_regclass('public.approval_records') IS NOT NULL AS approval_records_ok,
+       to_regclass('public.system_configs') IS NOT NULL AS settings_ok`,
+  ))[0] || {}
+  const ready = Object.values(row).every(value => value === true)
+  ok(ready, 'DB assertion channel reachable and OT-bank v1-8 tables exist (incl attendance_payroll_cycle_settlements)', row)
+  if (!ready) throw new Error('staging DB missing OT-bank v1-8 tables (is the v1-5a settlement migration applied?) or DATABASE_URL points at the wrong database')
+}
+
+async function preflightNoExistingResidue() {
+  const row = (await q(
+    `SELECT
+       (SELECT count(*)::int FROM users WHERE left(id, $2) = $3) AS users,
+       (SELECT count(*)::int FROM user_orgs WHERE org_id = $1 AND left(user_id, $2) = $3) AS user_orgs,
+       (SELECT count(*)::int FROM attendance_requests WHERE org_id = $1 AND left(user_id, $2) = $3) AS requests,
+       (SELECT count(*)::int FROM attendance_records WHERE org_id = $1 AND left(user_id, $2) = $3) AS records,
+       (SELECT count(*)::int FROM attendance_leave_balances
+         WHERE org_id = $1 AND (left(user_id, $2) = $3 OR source_key = $4)) AS leave_balances,
+       (SELECT count(*)::int FROM attendance_leave_types WHERE org_id = $1 AND code = $5) AS leave_types,
+       (SELECT count(*)::int FROM attendance_overtime_rules WHERE org_id = $1 AND name = $6) AS overtime_rules,
+       (SELECT count(*)::int FROM attendance_holidays WHERE org_id = $1 AND name = $7) AS holidays,
+       (SELECT count(*)::int FROM attendance_payroll_cycles WHERE org_id = $1 AND metadata->>'smokeStamp' = $8) AS cycles,
+       (SELECT count(*)::int FROM attendance_payroll_cycle_settlements s
+         JOIN attendance_payroll_cycles c ON c.id = s.cycle_id AND c.org_id = s.org_id
+         WHERE s.org_id = $1 AND c.metadata->>'smokeStamp' = $8) AS settlements`,
+    [ORG_ID, USER_PREFIX.length, USER_PREFIX, created.poisonLotKey, created.leaveTypeCode, created.overtimeRuleName, created.holidayName, STAMP],
+  ))[0] || {}
+  const clean = Object.values(row).every(value => Number(value) === 0)
+  ok(clean, 'no pre-existing residue for this OT-bank smoke stamp', row)
+  if (!clean) throw new Error(`pre-existing residue found for ${STAMP}; use a fresh STAMP or inspect before running`)
+}
+
+async function getSettings() {
+  const res = await api(adminToken, '/api/attendance/settings')
+  ok(res.status === 200, `GET settings through staging API (status ${res.status})`, res.body)
+  if (res.status !== 200) throw new Error('cannot read attendance settings')
+  return res.body?.data ?? {}
+}
+
+async function putSettings(update, label) {
+  const res = await api(adminToken, '/api/attendance/settings', { method: 'PUT', body: update })
+  ok(res.status === 200, `${label} (status ${res.status})`, res.body)
+  if (res.status !== 200) throw new Error(`settings update failed: ${label}`)
+  return res.body?.data ?? {}
+}
+
+async function verifySettingsCoherence() {
+  const row = (await q(
+    `SELECT value::jsonb #> '{overtimeBankPolicy}' AS policy
+     FROM system_configs
+     WHERE key = 'attendance.settings'
+     LIMIT 1`,
+  ))[0]
+  const policy = row?.policy ?? null
+  const coherent = policy && typeof policy === 'object'
+  ok(Boolean(coherent), 'API settings write is visible through DATABASE_URL', policy)
+  if (!coherent) throw new Error('BASE_URL and DATABASE_URL do not appear coherent for attendance settings')
+}
+
+// Far-future window with ZERO pre-existing facts: no overlapping payroll cycle, no holiday rows
+// on the smoke dates, and no records/requests from ANY user inside the period — this keeps the
+// section-8a settlement population's period arm synthetic-only by construction.
+async function chooseWindow() {
+  let year = ENTRY.config.year
+  for (let i = 0; i < 12; i += 1) {
+    const candidate = buildSmokeWindow(year)
+    const row = (await q(
+      `SELECT
+         (SELECT count(*)::int FROM attendance_payroll_cycles
+           WHERE org_id = $1 AND start_date <= $3::date AND end_date >= $2::date) AS overlapping_cycles,
+         (SELECT count(*)::int FROM attendance_holidays
+           WHERE org_id = $1 AND holiday_date IN ($4::date, $5::date, $6::date)) AS holiday_rows,
+         (SELECT count(*)::int FROM attendance_records
+           WHERE org_id = $1 AND work_date BETWEEN $2 AND $3) AS period_records,
+         (SELECT count(*)::int FROM attendance_requests
+           WHERE org_id = $1 AND work_date BETWEEN $2 AND $3) AS period_requests`,
+      [ORG_ID, candidate.periodStart, candidate.periodEnd, candidate.otDate, candidate.leaveDate, candidate.holidayDate],
+    ))[0] || {}
+    const clean = Object.values(row).every(value => Number(value) === 0)
+    if (clean) {
+      ok(true, `chose conflict-free far-future settlement window ${candidate.periodStart}..${candidate.periodEnd}`, candidate)
+      return candidate
+    }
+    year += 1
+  }
+  throw new Error('could not find a conflict-free far-future settlement window; pass SMOKE_YEAR explicitly')
+}
+
+async function seedUsers() {
+  for (const key of BUSINESS_USER_KEYS) {
+    const userId = USERS[key]
+    assertSyntheticUser(userId, 'smoke user')
+    await pool.query(
+      `INSERT INTO users (id, email, password_hash, name, role, is_active)
+       VALUES ($1, $2, 'no-login', $3, 'user', true)
+       ON CONFLICT (id) DO UPDATE SET is_active = true, email = EXCLUDED.email, name = EXCLUDED.name`,
+      [userId, `${userId}@example.test`, userId],
+    )
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, true)
+       ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = true`,
+      [userId, ORG_ID],
+    )
+  }
+  cleanupAllowed = true
+  ok(true, 'seeded synthetic case/mustpay/dormant users', { stamp: STAMP })
+}
+
+async function captureApprovalInstanceId(requestId) {
+  const rows = await q('SELECT approval_instance_id FROM attendance_requests WHERE id = $1 AND org_id = $2', [requestId, ORG_ID])
+  const approvalId = rows[0]?.approval_instance_id
+  if (approvalId) created.approvalInstanceIds.add(String(approvalId))
+}
+
+async function postRequest(userKey, body) {
+  const res = await api(userTokens[userKey], '/api/attendance/requests', { method: 'POST', body: { orgId: ORG_ID, ...body } })
+  const id = res.body?.data?.request?.id ?? null
+  if (id) {
+    created.requestIds.push(String(id))
+    await captureApprovalInstanceId(id)
+  }
+  return { res, id }
+}
+
+async function approveRequest(requestId) {
+  return api(adminToken, `/api/attendance/requests/${requestId}/approve`, {
+    method: 'POST',
+    body: { comment: `OTBANK v1-8 smoke ${STAMP} approve` },
+  })
+}
+
+async function lotsByRequest(requestId) {
+  return q(
+    `SELECT source_key, overtime_source, amount_minutes, remaining_minutes, status, expires_at
+     FROM attendance_leave_balances
+     WHERE org_id = $1 AND source_type = 'overtime_conversion' AND source_id = $2
+     ORDER BY source_key ASC`,
+    [ORG_ID, requestId],
+  )
+}
+
+async function grantEventsByRequest(requestId) {
+  return q(
+    `SELECT delta_minutes FROM attendance_leave_balance_events
+     WHERE org_id = $1 AND event_type = 'grant' AND source_type = 'overtime_conversion' AND source_id = $2`,
+    [ORG_ID, requestId],
+  )
+}
+
+async function deductedMinutesForLeave(userId, leaveRequestId) {
+  const rows = await q(
+    `SELECT COALESCE(SUM(-delta_minutes), 0)::int AS deducted
+     FROM attendance_leave_balance_events
+     WHERE org_id = $1 AND user_id = $2 AND event_type = 'deduct' AND source_type = 'leave_offset' AND source_id = $3`,
+    [ORG_ID, userId, leaveRequestId],
+  )
+  return Number(rows[0]?.deducted ?? 0)
+}
+
+async function leaveBalanceSummary(userId) {
+  const res = await api(adminToken, `/api/attendance/leave-balances?userId=${encodeURIComponent(userId)}&leaveTypeCode=comp_time`)
+  if (res.status !== 200) return { status: res.status }
+  const summary = res.body?.data?.summary ?? {}
+  return {
+    status: res.status,
+    grantedMinutes: Number(summary.grantedMinutes ?? -1),
+    remainingMinutes: Number(summary.remainingMinutes ?? -1),
+    exhaustedMinutes: Number(summary.exhaustedMinutes ?? -1),
+    expiredMinutes: Number(summary.expiredMinutes ?? -1),
+  }
+}
+
+async function settlementRows(cycleId) {
+  return q(
+    `SELECT user_id, source, convertible_minutes, must_pay_minutes,
+            period_start_date::text AS period_start_date, period_end_date::text AS period_end_date,
+            closed_at, snapshot
+     FROM attendance_payroll_cycle_settlements
+     WHERE org_id = $1 AND cycle_id = $2
+     ORDER BY user_id ASC, source ASC`,
+    [ORG_ID, cycleId],
+  )
+}
+
+function settlementProjection(rows) {
+  return rows.map(row => ({
+    user: row.user_id,
+    source: row.source,
+    convertible: Number(row.convertible_minutes),
+    mustPay: Number(row.must_pay_minutes),
+  }))
+}
+
+// --- phases ----------------------------------------------------------------------------------
+
+async function setupFixtures() {
+  const rule = await api(adminToken, '/api/attendance/overtime-rules', {
+    method: 'POST',
+    body: { name: created.overtimeRuleName, minMinutes: 0, roundingMinutes: 1 },
+  })
+  ok(rule.status === 201 && rule.body?.data?.id, 'created stamped overtime rule (minMinutes=0, roundingMinutes=1)', rule.body)
+  created.overtimeRuleId = rule.body?.data?.id ?? null
+  if (!created.overtimeRuleId) throw new Error('overtime rule creation failed')
+
+  const leaveType = await api(adminToken, '/api/attendance/leave-types', {
+    method: 'POST',
+    body: { code: created.leaveTypeCode, name: `${STAMP} offset leave`, paid: true, requiresApproval: true },
+  })
+  ok(leaveType.status === 201 && leaveType.body?.data?.id, 'created stamped offset leave type', leaveType.body)
+  created.leaveTypeId = leaveType.body?.data?.id ?? null
+  if (!created.leaveTypeId) throw new Error('leave type creation failed')
+}
+
+async function assertDormantGrantRegression() {
+  await putSettings({
+    overtimeSegmentation: { enabled: true },
+    compTimeFromOvertime: { enabled: true, expiresInDays: null },
+    overtimeBankPolicy: { enabled: false, pooledSources: [] },
+  }, 'enable segmentation + comp-time grant with overtimeBankPolicy DORMANT')
+  await verifySettingsCoherence()
+
+  const { res, id } = await postRequest('dormant', {
+    workDate: smokeWindow.otDate,
+    requestType: 'overtime',
+    overtimeRuleId: created.overtimeRuleId,
+    minutes: 120,
+    reason: `OTBANK v1-8 smoke ${STAMP} dormant regression`,
+  })
+  ok(res.status === 201 && id, `dormant: overtime request created (status ${res.status})`, res.body)
+  if (!id) throw new Error('dormant overtime request creation failed')
+  const approve = await approveRequest(id)
+  ok(approve.status === 200, 'dormant: overtime approved', approve.body)
+
+  const lots = await lotsByRequest(id)
+  ok(
+    lots.length === 1
+      && lots[0]?.source_key === `overtime_conversion:${id}`
+      && lots[0]?.overtime_source == null
+      && Number(lots[0]?.amount_minutes) === 120
+      && Number(lots[0]?.remaining_minutes) === 120
+      && lots[0]?.expires_at == null,
+    'dormant bank keeps the single NULL-source lot (legacy grant path, no expiry)',
+    lots,
+  )
+  const events = await grantEventsByRequest(id)
+  ok(events.length === 1 && Number(events[0]?.delta_minutes) === 120, 'dormant: exactly one +120 grant ledger event', events)
+}
+
+async function enableBankAndOffsetPolicies() {
+  const rejected = await api(adminToken, '/api/attendance/settings', {
+    method: 'PUT',
+    body: { overtimeBankPolicy: { enabled: true, pooledSources: ['statutory_holiday'] } },
+  })
+  ok(rejected.status === 400, 'PUT pooledSources=[statutory_holiday] is rejected with 400 (compliance floor)', rejected.body)
+
+  await putSettings({
+    overtimeBankPolicy: { enabled: true, pooledSources: ['workday'] },
+    leaveBalanceDeductionPolicy: {
+      enabled: true,
+      rules: [{ requestLeaveType: created.leaveTypeCode, deductFrom: ['comp_time'], insufficient: 'partial_unpaid_absence' }],
+    },
+    attendanceBonusPolicy: { enabled: true, anyLeaveBreaksFullAttendance: true, lateBeyondThresholdBreaksFullAttendance: true },
+  }, 'enable overtimeBankPolicy(workday) + leave-offset rule + full-attendance flag')
+}
+
+async function runOwnerCase(plan) {
+  const userId = USERS[plan.key]
+  const ot = await postRequest(plan.key, {
+    workDate: smokeWindow.otDate,
+    requestType: 'overtime',
+    overtimeRuleId: created.overtimeRuleId,
+    minutes: plan.otMinutes,
+    reason: `OTBANK v1-8 smoke ${STAMP} ${plan.key} overtime accrual`,
+  })
+  ok(ot.res.status === 201 && ot.id, `${plan.key}: overtime request created`, ot.res.body)
+  if (!ot.id) throw new Error(`${plan.key}: overtime request creation failed`)
+  const otApprove = await approveRequest(ot.id)
+  ok(otApprove.status === 200, `${plan.key}: overtime approved`, otApprove.body)
+
+  const lots = await lotsByRequest(ot.id)
+  ok(
+    lots.length === 1
+      && lots[0]?.source_key === `overtime_conversion:${ot.id}:workday`
+      && lots[0]?.overtime_source === 'workday'
+      && Number(lots[0]?.amount_minutes) === plan.otMinutes,
+    `${plan.key}: bank grant is one per-source workday lot of ${plan.otMinutes}`,
+    lots,
+  )
+
+  const replay = await approveRequest(ot.id)
+  ok(replay.status === 400 && replay.body?.error?.code === 'INVALID_STATUS', `${plan.key}: replay approve rejected with 400 INVALID_STATUS`, replay.body)
+  const lotsAfterReplay = await lotsByRequest(ot.id)
+  const grantEvents = await grantEventsByRequest(ot.id)
+  ok(lotsAfterReplay.length === 1 && grantEvents.length === 1, `${plan.key}: replay approve did not double-credit lot/event`)
+
+  const before = await leaveBalanceSummary(userId)
+  ok(
+    before.status === 200 && before.grantedMinutes === plan.otMinutes && before.remainingMinutes === plan.otMinutes,
+    `${plan.key}: comp_time balance reads granted=${plan.otMinutes}, remaining=${plan.otMinutes} before offset`,
+    before,
+  )
+
+  const leave = await postRequest(plan.key, {
+    workDate: smokeWindow.leaveDate,
+    requestType: 'leave',
+    leaveTypeCode: created.leaveTypeCode,
+    minutes: plan.leaveMinutes,
+    reason: `OTBANK v1-8 smoke ${STAMP} ${plan.key} leave offset ${plan.leaveMinutes}m`,
+  })
+  ok(leave.res.status === 201 && leave.id, `${plan.key}: leave request created (${plan.leaveMinutes}m)`, leave.res.body)
+  if (!leave.id) throw new Error(`${plan.key}: leave request creation failed`)
+  const leaveApprove = await approveRequest(leave.id)
+  ok(leaveApprove.status === 200, `${plan.key}: leave approved (offset rule, insufficient=partial_unpaid_absence)`, leaveApprove.body)
+
+  const deducted = await deductedMinutesForLeave(userId, leave.id)
+  ok(deducted === plan.expectDeductMinutes, `${plan.key}: FIFO offset deducted exactly ${plan.expectDeductMinutes}m from comp_time`, { deducted })
+  const shortfall = plan.leaveMinutes - deducted
+  ok(shortfall === plan.expectShortfallMinutes, `${plan.key}: real-absence shortfall is ${plan.expectShortfallMinutes}m (requested - deducted)`, { shortfall })
+
+  const after = await leaveBalanceSummary(userId)
+  ok(
+    after.status === 200
+      && after.remainingMinutes === plan.expectRemainingMinutes
+      && after.exhaustedMinutes === plan.expectDeductMinutes
+      && after.grantedMinutes === plan.otMinutes
+      && after.expiredMinutes === 0,
+    `${plan.key}: post-offset balance remaining=${plan.expectRemainingMinutes}, exhausted=${plan.expectDeductMinutes}`,
+    after,
+  )
+  ok(
+    after.grantedMinutes === after.remainingMinutes + after.exhaustedMinutes + after.expiredMinutes,
+    `${plan.key}: ledger conservation holds (granted = remaining + exhausted + expired)`,
+    after,
+  )
+}
+
+async function assertStatutoryMustPaySetup() {
+  const holiday = await api(adminToken, '/api/attendance/holidays', {
+    method: 'POST',
+    body: { date: smokeWindow.holidayDate, name: created.holidayName, isWorkingDay: false },
+  })
+  ok(holiday.status === 201 && holiday.body?.data?.id, 'created stamped statutory holiday for the must-pay boundary', holiday.body)
+  const holidayId = holiday.body?.data?.id
+  if (holidayId) created.holidayIds.push(String(holidayId))
+  if (!holidayId) throw new Error('holiday creation failed')
+
+  const ot = await postRequest('mustpay', {
+    workDate: smokeWindow.holidayDate,
+    requestType: 'overtime',
+    overtimeRuleId: created.overtimeRuleId,
+    minutes: 480,
+    reason: `OTBANK v1-8 smoke ${STAMP} mustpay statutory-holiday overtime`,
+  })
+  ok(ot.res.status === 201 && ot.id, 'mustpay: statutory-holiday overtime request created', ot.res.body)
+  if (!ot.id) throw new Error('mustpay overtime request creation failed')
+  const approve = await approveRequest(ot.id)
+  ok(approve.status === 200, 'mustpay: statutory-holiday overtime approved', approve.body)
+
+  const lots = await lotsByRequest(ot.id)
+  ok(lots.length === 0, 'mustpay: statutory-holiday OT banked NOTHING (never poolable; enabled bank fails closed to must-pay)', lots)
+
+  await pool.query(
+    `INSERT INTO attendance_leave_balances
+       (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at, overtime_source)
+     VALUES ($1, $2, 'comp_time', 9999, 9999, 'overtime_conversion', $3, 'active', now(), 'statutory_holiday')`,
+    [ORG_ID, USERS.mustpay, created.poisonLotKey],
+  )
+  ok(true, 'SQL-seeded poison statutory balance lot (9999m) — must never surface as must-pay or convertible', { poisonLotKey: created.poisonLotKey })
+}
+
+async function assertFullAttendanceFlags() {
+  for (const plan of CASE_PLAN) {
+    const res = await api(adminToken, `/api/attendance/summary?userId=${encodeURIComponent(USERS[plan.key])}&from=${smokeWindow.periodStart}&to=${smokeWindow.periodEnd}`)
+    ok(
+      res.status === 200 && res.body?.data?.fullAttendanceEligible === false,
+      `${plan.key}: fullAttendanceEligible=false (any leave breaks it, even when pool-offset)`,
+      { status: res.status, fullAttendanceEligible: res.body?.data?.fullAttendanceEligible },
+    )
+  }
+  const control = await api(adminToken, `/api/attendance/summary?userId=${encodeURIComponent(USERS.dormant)}&from=${smokeWindow.periodStart}&to=${smokeWindow.periodEnd}`)
+  ok(
+    control.status === 200 && control.body?.data?.fullAttendanceEligible === true,
+    'dormant (overtime-only, no leave) control: fullAttendanceEligible=true',
+    { status: control.status, fullAttendanceEligible: control.body?.data?.fullAttendanceEligible },
+  )
+}
+
+// Section-8a settlement population = period facts UNION active comp_time balance holders,
+// org-wide. The balance arm is period-independent, so on a shared org a real staging user with
+// an active comp_time balance would be enumerated into OUR smoke cycle's settlement snapshot.
+// Fail closed unless the operator explicitly accepted that in the runbook decision block.
+async function assertSettlementPopulationSynthetic() {
+  const rows = await q(
+    `SELECT count(*)::int AS non_synthetic FROM (
+       SELECT user_id FROM attendance_records WHERE org_id = $1 AND work_date BETWEEN $2 AND $3
+       UNION
+       SELECT user_id FROM attendance_requests WHERE org_id = $1 AND status = 'approved' AND work_date BETWEEN $2 AND $3
+       UNION
+       SELECT user_id FROM attendance_leave_balances WHERE org_id = $1 AND leave_type_code = 'comp_time' AND status = 'active' AND remaining_minutes > 0
+     ) pop WHERE user_id IS NULL OR left(user_id, $4) <> $5`,
+    [ORG_ID, smokeWindow.periodStart, smokeWindow.periodEnd, USER_PREFIX.length, USER_PREFIX],
+  )
+  const nonSynthetic = Number(rows[0]?.non_synthetic ?? -1)
+  populationSyntheticOnly = nonSynthetic === 0
+  if (nonSynthetic > 0 && !ENTRY.config.allowNonSyntheticPopulation) {
+    throw new Error(`cycle close would settle ${nonSynthetic} non-synthetic user(s) on org "${ORG_ID}" (active comp_time balance holders are enumerated period-independently). Use a dedicated smoke org per the runbook decision block, or set ALLOW_NON_SYNTHETIC_SETTLEMENT_POPULATION=1 (dangerous) after the operator explicitly accepts it.`)
+  }
+  ok(
+    populationSyntheticOnly || ENTRY.config.allowNonSyntheticPopulation,
+    `settlement population check (non-synthetic users: ${nonSynthetic}${populationSyntheticOnly ? '' : '; override accepted'})`,
+    { nonSynthetic },
+  )
+}
+
+async function assertCycleCloseSettlement() {
+  const createRes = await api(adminToken, '/api/attendance/payroll-cycles', {
+    method: 'POST',
+    body: {
+      name: created.cycleName,
+      startDate: smokeWindow.periodStart,
+      endDate: smokeWindow.periodEnd,
+      status: 'open',
+      metadata: { smokeStamp: STAMP },
+    },
+  })
+  const cycleId = createRes.body?.data?.id ?? null
+  ok(createRes.status === 201 && cycleId, 'created stamped OPEN payroll cycle over the smoke period', createRes.body)
+  if (!cycleId) throw new Error('payroll cycle creation failed (an exact-period collision returns 409 ALREADY_EXISTS — rerun with SMOKE_YEAR)')
+  created.cycleIds.push(String(cycleId))
+
+  const pre = await settlementRows(cycleId)
+  ok(pre.length === 0, 'no settlement rows exist before close', pre)
+
+  const close = await api(adminToken, `/api/attendance/payroll-cycles/${cycleId}`, { method: 'PUT', body: { status: 'closed' } })
+  ok(close.status === 200, 'cycle open→closed transition succeeded (snapshot in the same txn)', close.body)
+
+  const rows = await settlementRows(cycleId)
+  const forUser = (userId) => rows.filter(row => row.user_id === userId)
+
+  ok(forUser(USERS.case1).length === 0, 'case1: pool fully consumed → no settlement row (convertible 0, must-pay 0)', settlementProjection(forUser(USERS.case1)))
+
+  const c2 = forUser(USERS.case2)
+  ok(
+    c2.length === 1 && c2[0]?.source === 'workday' && Number(c2[0]?.convertible_minutes) === 300 && Number(c2[0]?.must_pay_minutes) === 0,
+    'case2: exactly one workday row with convertible=300, must_pay=0',
+    settlementProjection(c2),
+  )
+  ok(
+    c2[0] != null
+      && String(c2[0].period_start_date).slice(0, 10) === smokeWindow.periodStart
+      && String(c2[0].period_end_date).slice(0, 10) === smokeWindow.periodEnd
+      && c2[0].closed_at != null,
+    'case2: settlement row carries the frozen period columns + closed_at',
+    c2[0] && { period_start_date: c2[0].period_start_date, period_end_date: c2[0].period_end_date },
+  )
+  const snapshot = parseJson(c2[0]?.snapshot) ?? {}
+  ok(
+    Array.isArray(snapshot?.overtimeBankPolicy?.pooledSources) && snapshot.overtimeBankPolicy.pooledSources.includes('workday'),
+    'case2: snapshot froze the effective overtimeBankPolicy (pooledSources includes workday)',
+    snapshot?.overtimeBankPolicy,
+  )
+
+  ok(forUser(USERS.case3).length === 0, 'case3: partial offset exhausted the pool → no settlement row (convertible 0)', settlementProjection(forUser(USERS.case3)))
+
+  const mp = forUser(USERS.mustpay)
+  ok(
+    mp.length === 1 && mp[0]?.source === 'statutory_holiday' && Number(mp[0]?.must_pay_minutes) === 480 && Number(mp[0]?.convertible_minutes) === 0,
+    'mustpay: statutory must-pay=480 from PERIOD facts; poison 9999 balance lot did not surface',
+    settlementProjection(mp),
+  )
+
+  const dm = forUser(USERS.dormant)
+  ok(
+    dm.length === 1 && dm[0]?.source === 'legacy_unsourced' && Number(dm[0]?.convertible_minutes) === 120 && Number(dm[0]?.must_pay_minutes) === 0,
+    'dormant: NULL-source balance settles as legacy_unsourced convertible=120, must_pay=0',
+    settlementProjection(dm),
+  )
+
+  if (populationSyntheticOnly) {
+    ok(rows.length === 3, 'settlement rows are exactly the 3 expected (case2 + mustpay + dormant); zero-zero rows skipped', settlementProjection(rows))
+  }
+
+  const replay = await api(adminToken, `/api/attendance/payroll-cycles/${cycleId}`, { method: 'PUT', body: { status: 'closed' } })
+  ok(replay.status === 200, 'replay close returns 200', replay.body)
+  const replayRows = await settlementRows(cycleId)
+  ok(
+    replayRows.length === rows.length && stableJson(settlementProjection(replayRows)) === stableJson(settlementProjection(rows)),
+    'replay close is idempotent — settlement rows unchanged (ON CONFLICT DO NOTHING)',
+    settlementProjection(replayRows),
+  )
+
+  const frozen = await api(adminToken, `/api/attendance/payroll-cycles/${cycleId}`, {
+    method: 'PUT',
+    body: { startDate: addDays(smokeWindow.periodStart, 1), endDate: smokeWindow.periodEnd },
+  })
+  ok(frozen.status === 409 && frozen.body?.error?.code === 'CYCLE_CLOSED_PERIOD_FROZEN', 'closed cycle period change returns 409 CYCLE_CLOSED_PERIOD_FROZEN', frozen.body)
+
+  const del = await api(adminToken, `/api/attendance/payroll-cycles/${cycleId}`, { method: 'DELETE' })
+  ok(del.status === 409 && del.body?.error?.code === 'CYCLE_CLOSED_NOT_DELETABLE', 'closed cycle DELETE returns 409 CYCLE_CLOSED_NOT_DELETABLE (cleanup must use scoped SQL)', del.body)
+
+  return cycleId
+}
+
+// --- cleanup / residue -----------------------------------------------------------------------
+
+async function residueCounts() {
+  const requestIds = created.requestIds
+  const approvalIds = Array.from(created.approvalInstanceIds)
+  const cycleIds = created.cycleIds
+  const holidayIds = created.holidayIds
+  const row = (await q(
+    `SELECT
+       (SELECT count(*)::int FROM attendance_requests
+         WHERE org_id = $1 AND (id = ANY($4::uuid[]) OR left(user_id, $2) = $3)) AS requests,
+       (SELECT count(*)::int FROM attendance_records WHERE org_id = $1 AND left(user_id, $2) = $3) AS records,
+       (SELECT count(*)::int FROM attendance_events
+         WHERE org_id = $1 AND meta->>'requestId' = ANY($5::text[])) AS events,
+       (SELECT count(*)::int FROM attendance_leave_balances
+         WHERE org_id = $1 AND (left(user_id, $2) = $3 OR source_key = $6)) AS leave_balances,
+       (SELECT count(*)::int FROM attendance_leave_balance_events
+         WHERE org_id = $1 AND left(user_id, $2) = $3) AS balance_events,
+       (SELECT count(*)::int FROM attendance_leave_types
+         WHERE org_id = $1 AND (id = ANY($7::uuid[]) OR code = $8)) AS leave_types,
+       (SELECT count(*)::int FROM attendance_overtime_rules
+         WHERE org_id = $1 AND (id = ANY($9::uuid[]) OR name = $10)) AS overtime_rules,
+       (SELECT count(*)::int FROM attendance_holidays
+         WHERE org_id = $1 AND (id = ANY($11::uuid[]) OR name = $12)) AS holidays,
+       (SELECT count(*)::int FROM attendance_payroll_cycle_settlements
+         WHERE org_id = $1 AND cycle_id = ANY($13::uuid[])) AS settlements,
+       (SELECT count(*)::int FROM attendance_payroll_cycles
+         WHERE org_id = $1 AND (id = ANY($13::uuid[]) OR metadata->>'smokeStamp' = $14)) AS cycles,
+       (SELECT count(*)::int FROM approval_instances WHERE id = ANY($15::text[])) AS approval_instances,
+       (SELECT count(*)::int FROM approval_assignments WHERE instance_id = ANY($15::text[])) AS approval_assignments,
+       (SELECT count(*)::int FROM approval_records WHERE instance_id = ANY($15::text[])) AS approval_records,
+       (SELECT count(*)::int FROM attendance_notification_deliveries
+         WHERE org_id = $1 AND left(recipient_user_id, $2) = $3) AS deliveries,
+       (SELECT count(*)::int FROM user_orgs WHERE org_id = $1 AND left(user_id, $2) = $3) AS user_orgs,
+       (SELECT count(*)::int FROM users WHERE left(id, $2) = $3) AS users`,
+    [
+      ORG_ID,
+      USER_PREFIX.length,
+      USER_PREFIX,
+      requestIds,
+      requestIds,
+      created.poisonLotKey,
+      created.leaveTypeId ? [created.leaveTypeId] : [],
+      created.leaveTypeCode,
+      created.overtimeRuleId ? [created.overtimeRuleId] : [],
+      created.overtimeRuleName,
+      holidayIds,
+      created.holidayName,
+      cycleIds,
+      STAMP,
+      approvalIds,
+    ],
+  ))[0] || {}
+  return row
+}
+
+async function restoreSettings({ strict = false } = {}) {
+  if (!originalSettings) return
+  const res = await api(adminToken, '/api/attendance/settings', { method: 'PUT', body: buildRestoreSettingsBody(originalSettings) })
+  if (strict) {
+    ok(res.status === 200, `restore original attendance settings (status ${res.status})`, res.body)
+    if (res.status !== 200) throw new Error('failed to restore original attendance settings')
+    const restored = await getSettings()
+    for (const key of RESTORED_POLICY_KEYS) {
+      const restoredPolicy = restored[key] ?? null
+      const originalPolicy = originalSettings[key] ?? null
+      ok(stableJson(restoredPolicy) === stableJson(originalPolicy), `restored ${key} matches the pre-smoke value`, restoredPolicy)
+      if (stableJson(restoredPolicy) !== stableJson(originalPolicy)) {
+        throw new Error(`${key} did not restore to its pre-smoke value`)
+      }
+    }
+    return
+  }
+  if (res.status !== 200) {
+    console.error(`WARN: failed to restore attendance settings (status ${res.status})`)
+  }
+}
+
+async function cleanup({ strictSettingsRestore = false } = {}) {
+  if (!cleanupAllowed) return
+  await restoreSettings({ strict: strictSettingsRestore }).catch(error => {
+    if (strictSettingsRestore) throw error
+    console.error(`WARN: failed to restore attendance settings: ${error?.message || error}`)
+  })
+  const requestIds = created.requestIds
+  const approvalIds = Array.from(created.approvalInstanceIds)
+  const cycleIds = created.cycleIds
+  const holidayIds = created.holidayIds
+  // FK-safe order: approval children → events → records → requests → lots (balance events
+  // cascade) → approval instances → settlements (FK RESTRICT) → cycles → fixtures → users.
+  await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds]).catch(() => undefined)
+  await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds]).catch(() => undefined)
+  await pool.query(`DELETE FROM attendance_events WHERE org_id = $1 AND meta->>'requestId' = ANY($2::text[])`, [ORG_ID, requestIds]).catch(() => undefined)
+  await pool.query('DELETE FROM attendance_records WHERE org_id = $1 AND left(user_id, $2) = $3', [ORG_ID, USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+  await pool.query('DELETE FROM attendance_requests WHERE org_id = $1 AND (id = ANY($2::uuid[]) OR left(user_id, $3) = $4)', [ORG_ID, requestIds, USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+  await pool.query('DELETE FROM attendance_leave_balances WHERE org_id = $1 AND (left(user_id, $2) = $3 OR source_key = $4)', [ORG_ID, USER_PREFIX.length, USER_PREFIX, created.poisonLotKey]).catch(() => undefined)
+  await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds]).catch(() => undefined)
+  await pool.query('DELETE FROM attendance_payroll_cycle_settlements WHERE org_id = $1 AND cycle_id = ANY($2::uuid[])', [ORG_ID, cycleIds]).catch(() => undefined)
+  await pool.query(`DELETE FROM attendance_payroll_cycles WHERE org_id = $1 AND (id = ANY($2::uuid[]) OR metadata->>'smokeStamp' = $3)`, [ORG_ID, cycleIds, STAMP]).catch(() => undefined)
+  await pool.query('DELETE FROM attendance_holidays WHERE org_id = $1 AND (id = ANY($2::uuid[]) OR name = $3)', [ORG_ID, holidayIds, created.holidayName]).catch(() => undefined)
+  if (created.overtimeRuleId) {
+    await pool.query('DELETE FROM attendance_overtime_rules WHERE org_id = $1 AND id = $2', [ORG_ID, created.overtimeRuleId]).catch(() => undefined)
+  }
+  if (created.leaveTypeId) {
+    await pool.query('DELETE FROM attendance_leave_types WHERE org_id = $1 AND id = $2', [ORG_ID, created.leaveTypeId]).catch(() => undefined)
+  }
+  await pool.query('DELETE FROM user_orgs WHERE org_id = $1 AND left(user_id, $2) = $3', [ORG_ID, USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+  await pool.query('DELETE FROM users WHERE left(id, $1) = $2', [USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+}
+
+// --- main ------------------------------------------------------------------------------------
+
+async function main() {
+  console.log(`OT-bank v1-8 API/DB staging smoke helper @ ${BASE_URL}`)
+  console.log(`  deploy=${DEPLOY_SHA} org=${ORG_ID} stamp=${STAMP}`)
+  console.log('  NOTE: this helper does not close v1-8 by itself; record the final stamp only through the v1-8 runbook after its operator-decision blocks are resolved.')
+
+  await resolveTokens()
+  await preflightDatabase()
+  await preflightNoExistingResidue()
+  originalSettings = await getSettings()
+
+  smokeWindow = await chooseWindow()
+  await seedUsers()
+  await setupFixtures()
+
+  await assertDormantGrantRegression()
+  await enableBankAndOffsetPolicies()
+  for (const plan of CASE_PLAN) {
+    await runOwnerCase(plan)
+  }
+  await assertStatutoryMustPaySetup()
+  await assertFullAttendanceFlags()
+  await assertSettlementPopulationSynthetic()
+  const cycleId = await assertCycleCloseSettlement()
+
+  await cleanup({ strictSettingsRestore: true })
+  const residue = await residueCounts()
+  const residueOk = Object.values(residue).every(value => Number(value) === 0)
+  ok(residueOk, 'cleanup residue is zero', residue)
+  if (!residueOk) throw new Error(`residue not zero: ${JSON.stringify(residue)}`)
+  if (failures.length) {
+    throw new Error(`OT-bank v1-8 API/DB smoke had ${failures.length} failed assertion(s): ${failures.join('; ')}`)
+  }
+
+  console.log(`OTBANK_V18_API_DB_SMOKE_PASS deploy=${DEPLOY_SHA} stamp=${STAMP} org=${ORG_ID} cycle=${cycleId} residue=0`)
+  console.log(`Assertions passed: ${pass}`)
+}
+
+if (IS_MAIN) {
+  let pg
+  try {
+    pg = await import('pg')
+  } catch {
+    console.error('FAIL: package "pg" is required. Run this helper from a prepared metasheet2 checkout with dependencies installed.')
+    process.exit(2)
+  }
+  pool = new pg.default.Pool({ connectionString: DATABASE_URL })
+  main()
+    .catch(async (error) => {
+      console.error(`FAIL: ${error?.message || error}`)
+      try {
+        await cleanup()
+        const residue = await residueCounts()
+        console.error(`Residue after best-effort cleanup: ${JSON.stringify(residue)}`)
+      } catch (cleanupError) {
+        console.error(`WARN: cleanup failed: ${cleanupError?.message || cleanupError}`)
+      }
+      process.exitCode = 1
+    })
+    .finally(async () => {
+      await pool.end().catch(() => undefined)
+    })
+}

--- a/scripts/ops/staging-attendance-overtime-bank-v18-smoke.test.mjs
+++ b/scripts/ops/staging-attendance-overtime-bank-v18-smoke.test.mjs
@@ -1,0 +1,188 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import {
+  STAMP_PATTERN,
+  RESTORED_POLICY_KEYS,
+  CASE_PLAN,
+  addDays,
+  isWeekend,
+  firstMondayOfMonth,
+  lastDayOfMonth,
+  pickSmokeYear,
+  buildSmokeWindow,
+  buildRestoreSettingsBody,
+  isStampedId,
+  resolveEnvConfig,
+} from './staging-attendance-overtime-bank-v18-smoke.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const script = readFileSync(join(here, 'staging-attendance-overtime-bank-v18-smoke.mjs'), 'utf8')
+const runbook = readFileSync(join(here, '../../docs/development/attendance-overtime-bank-v18-staging-smoke-runbook-20260702.md'), 'utf8')
+
+test('v1-8 env contract: BASE_URL/DATABASE_URL/DEPLOY_SHA required, STAMP regex-locked, defaults applied', () => {
+  const missing = resolveEnvConfig({})
+  assert.equal(missing.ok, false)
+  assert.ok(missing.errors.some(msg => msg.includes('BASE_URL and DATABASE_URL')))
+  assert.ok(missing.errors.some(msg => msg.includes('DEPLOY_SHA is required')))
+
+  const placeholder = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: '<fill-from-staging-build>',
+  })
+  assert.equal(placeholder.ok, false)
+  assert.ok(placeholder.errors.some(msg => msg.includes('DEPLOY_SHA is required')))
+
+  const good = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082/',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: 'abc123def456',
+  })
+  assert.equal(good.ok, true)
+  assert.equal(good.config.baseUrl, 'http://127.0.0.1:8082', 'trailing slash stripped')
+  assert.equal(good.config.orgId, 'default')
+  assert.match(good.config.stamp, STAMP_PATTERN)
+  assert.ok(good.config.stamp.startsWith('otbank-v18-smoke-'))
+  assert.equal(good.config.allowNonSyntheticPopulation, false)
+
+  const badStamp = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: 'abc123def456',
+    STAMP: 'ae4-smoke-wrong-family',
+  })
+  assert.equal(badStamp.ok, false)
+  assert.ok(badStamp.errors.some(msg => msg.includes('otbank-v18-smoke')))
+
+  const override = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: 'abc123def456',
+    SMOKE_YEAR: '2055',
+    ALLOW_NON_SYNTHETIC_SETTLEMENT_POPULATION: '1',
+  })
+  assert.equal(override.config.year, 2055)
+  assert.equal(override.config.allowNonSyntheticPopulation, true)
+})
+
+test('v1-8 window builder: far-future month, weekday smoke dates inside the settlement period', () => {
+  assert.ok(pickSmokeYear('abc') >= 2041 && pickSmokeYear('abc') <= 2070, 'default year is far-future')
+  assert.equal(pickSmokeYear('abc', '2049'), 2049, 'SMOKE_YEAR override honored')
+  assert.notEqual(pickSmokeYear('abc', '1999'), 1999, 'implausible override rejected')
+
+  for (const year of [2043, 2051, 2067]) {
+    const window = buildSmokeWindow(year)
+    assert.equal(window.periodStart, `${year}-10-01`)
+    assert.equal(window.periodEnd, lastDayOfMonth(year, 9))
+    assert.equal(window.otDate, firstMondayOfMonth(year, 9))
+    assert.equal(new Date(`${window.otDate}T00:00:00.000Z`).getUTCDay(), 1, 'OT accrual date is a Monday (workday source)')
+    assert.equal(window.leaveDate, addDays(window.otDate, 1))
+    assert.equal(window.holidayDate, addDays(window.otDate, 2))
+    for (const date of [window.otDate, window.leaveDate, window.holidayDate]) {
+      assert.equal(isWeekend(date), false, `${date} must be a weekday`)
+      assert.ok(date >= window.periodStart && date <= window.periodEnd, `${date} inside settlement period`)
+    }
+  }
+})
+
+test('v1-8 settings restore body never PUTs an empty snapshot (deep-merge #3303 lesson)', () => {
+  const fromEmpty = buildRestoreSettingsBody({})
+  for (const key of RESTORED_POLICY_KEYS) {
+    assert.ok(fromEmpty[key] && typeof fromEmpty[key] === 'object', `${key} explicitly re-asserted`)
+    assert.equal(fromEmpty[key].enabled, false, `${key} defaults to disabled when the pre-smoke settings never carried it`)
+  }
+  assert.deepEqual(fromEmpty.overtimeBankPolicy.pooledSources, [])
+  assert.deepEqual(fromEmpty.leaveBalanceDeductionPolicy.rules, [])
+
+  const original = {
+    someSiblingPolicy: { enabled: true, keep: 'me' },
+    overtimeBankPolicy: { enabled: true, pooledSources: ['restday'], maxMinutesPerPeriod: 0, validityDays: null },
+  }
+  const restored = buildRestoreSettingsBody(original)
+  assert.deepEqual(restored.someSiblingPolicy, { enabled: true, keep: 'me' }, 'sibling policies pass through untouched')
+  assert.equal(restored.overtimeBankPolicy.enabled, true, 'a genuinely-enabled pre-smoke bank policy is restored enabled')
+  assert.deepEqual(restored.overtimeBankPolicy.pooledSources, ['restday'])
+  assert.equal(restored.compTimeFromOvertime.enabled, false, 'untouched-by-original keys still explicitly reset')
+})
+
+test('v1-8 case plan replays the owner acceptance arithmetic with conservation', () => {
+  assert.equal(CASE_PLAN.length, 3)
+  assert.deepEqual(CASE_PLAN.map(plan => plan.leaveMinutes), [600, 300, 900], 'leave 10h / 5h / 15h in minutes')
+  for (const plan of CASE_PLAN) {
+    assert.equal(plan.otMinutes, 600, 'every case accrues +10h overtime into the pool')
+    assert.equal(plan.expectDeductMinutes, Math.min(plan.otMinutes, plan.leaveMinutes), 'FIFO deducts at most the pool')
+    assert.equal(plan.expectRemainingMinutes, plan.otMinutes - plan.expectDeductMinutes, 'remaining = granted - deducted')
+    assert.equal(plan.expectShortfallMinutes, plan.leaveMinutes - plan.expectDeductMinutes, 'real absence = requested - deducted')
+    assert.equal(plan.expectConvertibleMinutes, plan.expectRemainingMinutes, 'cycle-end convertible = close-time remaining')
+  }
+  assert.deepEqual(CASE_PLAN.map(plan => plan.expectConvertibleMinutes), [0, 300, 0], 'owner table: convertible 0 / 5h / 0')
+  assert.deepEqual(CASE_PLAN.map(plan => plan.expectShortfallMinutes), [0, 0, 300], 'owner table: real absence 0 / 0 / 5h')
+})
+
+test('v1-8 synthetic-id predicate refuses unstamped ids', () => {
+  assert.equal(isStampedId('otbank-v18-smoke-abc-case1', 'otbank-v18-smoke-abc-'), true)
+  assert.equal(isStampedId('otbank-v18-smoke-abc-', 'otbank-v18-smoke-abc-'), false, 'bare prefix is not a user id')
+  assert.equal(isStampedId('real-employee-42', 'otbank-v18-smoke-abc-'), false)
+  assert.equal(isStampedId(null, 'otbank-v18-smoke-abc-'), false)
+})
+
+test('v1-8 helper does not claim the final staging pass', () => {
+  assert.match(script, /OTBANK_V18_API_DB_SMOKE_PASS/)
+  assert.doesNotMatch(script, /OTBANK_V18_STAGING_SMOKE_PASS/)
+  assert.match(runbook, /This is \*\*not\*\* the final v1-8 PASS stamp/)
+})
+
+test('v1-8 helper cleanup is stamped and LIKE-free, with settlements deleted before cycles (FK RESTRICT)', () => {
+  assert.match(script, /STAMP must match \/\^otbank-v18-smoke-\[A-Za-z0-9-\]\+\$\//)
+  assert.doesNotMatch(script, /LIKE '%/)
+  assert.doesNotMatch(script, /metadata::text LIKE/)
+  assert.doesNotMatch(script, /meta::text LIKE/)
+  assert.doesNotMatch(script, /source_key LIKE/)
+  const settlementsDelete = script.indexOf('DELETE FROM attendance_payroll_cycle_settlements')
+  const cyclesDelete = script.indexOf('DELETE FROM attendance_payroll_cycles')
+  assert.ok(settlementsDelete !== -1 && cyclesDelete !== -1 && settlementsDelete < cyclesDelete,
+    'settlement rows must be deleted before their cycle (ON DELETE RESTRICT; the API refuses with 409)')
+  assert.match(script, /cascade/i, 'balance-event cleanup relies on the documented lot→event cascade')
+})
+
+test('v1-8 helper residue categories cover every table the smoke can dirty (incl approval-engine rows)', () => {
+  for (const table of [
+    'attendance_requests',
+    'attendance_records',
+    'attendance_events',
+    'attendance_leave_balances',
+    'attendance_payroll_cycle_settlements',
+    'attendance_payroll_cycles',
+    'attendance_holidays',
+    'attendance_overtime_rules',
+    'attendance_leave_types',
+    'approval_instances',
+    'approval_assignments',
+    'approval_records',
+    'user_orgs',
+    'users',
+  ]) {
+    assert.match(script, new RegExp(`to_regclass\\('public\\.${table}'\\)`), `${table} is preflighted`)
+    assert.match(script, new RegExp(`FROM ${table}`), `${table} is counted`)
+    assert.match(script, new RegExp(`DELETE FROM ${table}`), `${table} is cleaned`)
+  }
+  // counted-only surfaces: balance events cascade from lots; deliveries must stay untouched (0).
+  for (const table of ['attendance_leave_balance_events', 'attendance_notification_deliveries']) {
+    assert.match(script, new RegExp(`to_regclass\\('public\\.${table}'\\)`), `${table} is preflighted`)
+    assert.match(script, new RegExp(`FROM ${table}`), `${table} is counted`)
+  }
+  assert.doesNotMatch(script, /DELETE FROM attendance_notification_deliveries/,
+    'the OT-bank smoke writes no deliveries and must not delete any (coexistence with the AE/report-digest smokes)')
+})
+
+test('v1-8 helper fails the run before printing PASS and gates the shared-org settlement population', () => {
+  assert.match(script, /if \(failures\.length\)/)
+  assert.match(script, /failed assertion\(s\)/)
+  assert.match(script, /ALLOW_NON_SYNTHETIC_SETTLEMENT_POPULATION=1 \(dangerous\)/)
+  assert.match(script, /poison/i)
+  assert.match(script, /9999/)
+})

--- a/scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs
+++ b/scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs
@@ -1,0 +1,945 @@
+#!/usr/bin/env node
+// RD-4/5 staging smoke helper — attendance report-digest producer / worker send chain.
+//
+// Two trigger tracks (see docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md):
+//   TRIGGER_MODE=seam      (PRIMARY, default) — in-process invocation of the shipped
+//     __attendanceReportDigestForTests.runAttendanceReportDigestOnce seam (C5-5 precedent) against a
+//     DISPOSABLE SINGLE-MEMBER smoke org. This is the only track that can honor the window plan's
+//     "RD-4/5 MUST use a disposable single-member smoke org" rule, because the backend scheduler job
+//     passes no orgId and is hardwired to the default org. Deterministic: no scheduler wait, todayKey
+//     pinned, and the producer env gate is set in THIS process only — the backend's
+//     ATTENDANCE_REPORT_DIGEST_ENABLED must stay unset/false so the globally-shared policy this smoke
+//     enables cannot fan out to real default-org members (the helper asserts no default-org leakage).
+//   TRIGGER_MODE=scheduler (OPTIONAL VARIANT, owner-gated) — real backend scheduler tick on org
+//     'default'. Requires ACK_DEFAULT_ORG_FANOUT=1 because it writes pending digest rows naming EVERY
+//     active default-org member, and requires the delivery worker env gate to be unset/false on the
+//     backend (rows must stay 'pending'; nothing may send to real staging users).
+//
+// KNOWN FAMILY DEVIATION (loud, not silent): digest source_keys are DETERMINISTIC
+// (org/cadence/period/subject/recipient/channel) and carry NO rd45 stamp. Residue discipline therefore
+// tracks the stamped users/org PLUS the deterministic key prefix + period keys recorded in this
+// helper's RUN LOG output. A same-day rerun regenerates the SAME deterministic keys.
+//
+// This helper drives the real staging HTTP API for settings writes and the deliveries read route
+// (which has NO source filter param — filtering is client-side by source_key prefix, plus direct PG
+// via DATABASE_URL for exact assertions). It intentionally does NOT claim the final RD-4/5 staging
+// PASS; the RD-4 config-card browser probe, the send-posture decision, and the final stamp live in
+// the runbook.
+
+import { createRequire } from 'node:module'
+import { pathToFileURL, fileURLToPath } from 'node:url'
+import { dirname, resolve as resolvePath } from 'node:path'
+
+// --- pure helpers (exported for the companion .test.mjs) -----------------------------------
+
+export const STAMP_PATTERN = /^rd45-smoke-[A-Za-z0-9-]+$/
+
+export const DIGEST_SOURCE_TYPE = 'attendance_report_digest'
+export const DIGEST_CADENCE = 'daily'
+export const DEFAULT_ORG_ID = 'default'
+export const SETTINGS_CACHE_TTL_MS = 60_000 // in-process settings cache in the plugin module
+
+export const DELIVERY_CHANNEL_ALLOWLIST = ['dingtalk_work_notification', 'email_smtp']
+
+// Terminal 'failed' reasons that still count as the design lock's "worker sends/FAILS visibly":
+// unbound recipient under the real work-notification channel env, or no channel registered at all.
+export const RECOGNIZED_TERMINAL_FAILURES = [
+  'dingtalk_recipient_not_bound',
+  'attendance_delivery_channel_not_configured',
+]
+
+// Every table this helper can dirty. system_configs is mutated via PUT /settings and restored —
+// never deleted — so it is preflighted but intentionally NOT in this delete/count triple-check list.
+export const RESIDUE_TABLES = ['attendance_notification_deliveries', 'user_orgs', 'users']
+
+// Mirrors DEFAULT_SETTINGS.attendanceReportDigestPolicy (all-off). Used only when the pre-smoke
+// settings never carried the policy key (GET normalizes, so normally it does).
+export const DISABLED_DIGEST_POLICY_DEFAULT = {
+  enabled: false,
+  timezone: 'Asia/Shanghai',
+  channel: 'work_notification',
+  cadences: {
+    daily: { enabled: false, sendAt: '18:30', recipients: ['self'] },
+    weekly: { enabled: false, weekday: 1, sendAt: '09:00', recipients: ['self'] },
+    monthly: { enabled: false, dayOfMonth: 1, sendAt: '09:00', recipients: ['self'] },
+  },
+}
+
+export function stableJson(value) {
+  return JSON.stringify(value ?? null)
+}
+
+export function parseJson(value) {
+  if (value == null || typeof value === 'object') return value
+  try { return JSON.parse(value) } catch { return null }
+}
+
+export function jwtSubject(jwt) {
+  try {
+    const seg = String(jwt).split('.')[1]
+    if (!seg) return null
+    const payload = JSON.parse(Buffer.from(seg, 'base64url').toString('utf8'))
+    return payload.id ?? payload.sub ?? payload.userId ?? null
+  } catch {
+    return null
+  }
+}
+
+export function utcDateKey(date) {
+  return date.toISOString().slice(0, 10)
+}
+
+export function addDaysUtc(dateKey, days) {
+  const next = new Date(`${dateKey}T00:00:00.000Z`)
+  next.setUTCDate(next.getUTCDate() + days)
+  return next.toISOString().slice(0, 10)
+}
+
+// daily cadence resolves to the previous COMPLETED calendar day in the policy timezone; this smoke
+// pins the policy timezone to UTC so the helper-side computation matches the producer exactly.
+export function computeCompletedDailyPeriod(todayKey) {
+  const day = addDaysUtc(todayKey, -1)
+  return { from: day, to: day, periodKey: `${DIGEST_CADENCE}:${day}` }
+}
+
+export function minutesUntilUtcMidnight(date) {
+  const next = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1))
+  return Math.floor((next.getTime() - date.getTime()) / 60_000)
+}
+
+// source_key template (implementation supersedes the design-lock §4 doc drift that omits the
+// ':subject:' segment):
+//   attendance_report_digest:{orgId}:{cadence}:{periodKey}:subject:{subjectUserId}:{recipientRole}:{recipientUserId}:channel:{channel}
+// periodKey itself starts with the cadence, so the cadence appears twice for a well-formed key.
+export function buildDigestSourceKeyPrefix(orgId, cadence, periodKey) {
+  return `${DIGEST_SOURCE_TYPE}:${orgId}:${cadence}:${periodKey}:subject:`
+}
+
+export function buildDigestSourceKey({ orgId, cadence, periodKey, subjectUserId, recipientRole, recipientUserId, channel }) {
+  return `${buildDigestSourceKeyPrefix(orgId, cadence, periodKey)}${subjectUserId}:${recipientRole}:${recipientUserId}:channel:${channel}`
+}
+
+export function parseDigestSourceKey(key) {
+  if (typeof key !== 'string' || !key.startsWith(`${DIGEST_SOURCE_TYPE}:`)) return null
+  const subjectSplit = key.split(':subject:')
+  if (subjectSplit.length !== 2) return null
+  const head = subjectSplit[0].slice(DIGEST_SOURCE_TYPE.length + 1) // {orgId}:{cadence}:{periodKey}
+  const headParts = head.split(':')
+  if (headParts.length < 3) return null
+  const orgId = headParts[0]
+  const cadence = headParts[1]
+  const periodKey = headParts.slice(2).join(':')
+  if (!orgId || !cadence || !periodKey.startsWith(`${cadence}:`)) return null
+  const tailSplit = subjectSplit[1].split(':channel:')
+  if (tailSplit.length !== 2) return null
+  const channel = tailSplit[1]
+  const recipientParts = tailSplit[0].split(':')
+  if (recipientParts.length !== 3) return null
+  const [subjectUserId, recipientRole, recipientUserId] = recipientParts
+  if (!subjectUserId || !recipientRole || !recipientUserId || !channel) return null
+  return { orgId, cadence, periodKey, subjectUserId, recipientRole, recipientUserId, channel }
+}
+
+// PUT /api/attendance/settings deep-merges per policy key (and per cadence), so restoring by
+// PUT-ing an empty snapshot is a NO-OP that leaks this smoke's policy. The restore body must
+// explicitly re-assert attendanceReportDigestPolicy, defaulting to the all-off shape when the
+// pre-smoke settings never carried it.
+export function buildRestoreDigestPolicyBody(originalSettings) {
+  const original = originalSettings && typeof originalSettings === 'object' ? originalSettings : {}
+  const policy = original.attendanceReportDigestPolicy
+  return {
+    ...original,
+    attendanceReportDigestPolicy: policy && typeof policy === 'object' ? policy : DISABLED_DIGEST_POLICY_DEFAULT,
+  }
+}
+
+// Classify worker outcomes for the RD-5 send proof. "Visibly proven" = every row reached a terminal,
+// explainable state: 'sent', or 'failed' with a recognized last_error (unbound recipient / channel
+// not configured). Anything else (stuck pending/retrying, unexplained failure) is NOT proof.
+export function classifySendOutcome(rows) {
+  const outcome = {
+    total: rows.length,
+    sent: 0,
+    pending: 0,
+    sending: 0,
+    retrying: 0,
+    failedRecognized: 0,
+    failedOther: [],
+    unknown: [],
+  }
+  for (const row of rows) {
+    const status = String(row.status ?? '')
+    if (status === 'sent') outcome.sent += 1
+    else if (status === 'pending') outcome.pending += 1
+    else if (status === 'sending') outcome.sending += 1
+    else if (status === 'retrying') outcome.retrying += 1
+    else if (status === 'failed') {
+      if (RECOGNIZED_TERMINAL_FAILURES.includes(String(row.last_error ?? ''))) outcome.failedRecognized += 1
+      else outcome.failedOther.push({ id: row.id ?? null, lastError: row.last_error ?? null })
+    } else outcome.unknown.push({ id: row.id ?? null, status })
+  }
+  outcome.terminal = outcome.sent + outcome.failedRecognized + outcome.failedOther.length
+  outcome.visiblyProven = rows.length > 0
+    && outcome.sent + outcome.failedRecognized === rows.length
+    && outcome.failedOther.length === 0
+    && outcome.unknown.length === 0
+  return outcome
+}
+
+// Env-only contract (no CLI args), mirroring the AE-4 / OT-bank v1-8 helpers: BASE_URL/DATABASE_URL
+// required, DEPLOY_SHA mandatory (the PASS stamp must name the staging build actually smoked), STAMP
+// regex-locked so cleanup remains visibly synthetic and LIKE-free.
+export function resolveEnvConfig(env = {}) {
+  const errors = []
+  const baseUrl = String(env.BASE_URL || env.BASE || '').replace(/\/$/, '')
+  const databaseUrl = String(env.DATABASE_URL || '')
+  const deploySha = String(env.DEPLOY_SHA || env.EXPECTED_DEPLOY_SHA || '')
+  if (!baseUrl || !databaseUrl) {
+    errors.push('BASE_URL and DATABASE_URL are required.')
+  }
+  if (!deploySha || deploySha === '<fill-from-staging-build>') {
+    errors.push('DEPLOY_SHA is required so the PASS stamp names the staging build that was actually smoked.')
+  }
+  const suffix = Date.now().toString(36)
+  const stamp = String(env.STAMP || `rd45-smoke-${suffix}`)
+  if (!STAMP_PATTERN.test(stamp)) {
+    errors.push('STAMP must match /^rd45-smoke-[A-Za-z0-9-]+$/ so cleanup remains visibly synthetic and LIKE-free.')
+  }
+  const triggerMode = String(env.TRIGGER_MODE || 'seam')
+  if (triggerMode !== 'seam' && triggerMode !== 'scheduler') {
+    errors.push('TRIGGER_MODE must be "seam" (primary: disposable smoke org via the in-process producer seam) or "scheduler" (optional owner-gated default-org variant).')
+  }
+  const orgId = String(env.ORG_ID || (triggerMode === 'scheduler' ? DEFAULT_ORG_ID : `${stamp}-org`))
+  if (triggerMode === 'seam' && !orgId.startsWith('rd45-smoke-')) {
+    errors.push('TRIGGER_MODE=seam requires a DISPOSABLE smoke org: ORG_ID must start with "rd45-smoke-" (default: <STAMP>-org). Never point the seam track at a real org.')
+  }
+  if (triggerMode === 'scheduler') {
+    if (orgId !== DEFAULT_ORG_ID) {
+      errors.push('TRIGGER_MODE=scheduler exercises the backend scheduler job, which passes no orgId and is hardwired to the default org; ORG_ID must be "default".')
+    }
+    if (env.ACK_DEFAULT_ORG_FANOUT !== '1') {
+      errors.push('TRIGGER_MODE=scheduler writes one pending digest row for EVERY active default-org member (deterministic keys, cleaned afterwards). Set ACK_DEFAULT_ORG_FANOUT=1 only after the runbook variant decision block is accepted.')
+    }
+    if (env.WORKER_EXPECTED === '1') {
+      errors.push('TRIGGER_MODE=scheduler requires the delivery worker env gate unset/false on the backend (rows must stay pending; no real sends). WORKER_EXPECTED=1 is not allowed in this mode.')
+    }
+  }
+  const intervalRaw = Number.parseInt(String(env.SCHEDULER_INTERVAL_MS ?? ''), 10)
+  const schedulerIntervalMs = Number.isInteger(intervalRaw) ? Math.max(intervalRaw, 5000) : 15000
+  return {
+    ok: errors.length === 0,
+    errors,
+    config: {
+      baseUrl,
+      databaseUrl,
+      deploySha,
+      stamp,
+      suffix,
+      orgId,
+      triggerMode,
+      schedulerIntervalMs,
+      workerExpected: triggerMode === 'scheduler' ? false : env.WORKER_EXPECTED !== '0',
+      allowPreexistingDigestRows: env.ALLOW_PREEXISTING_DIGEST_ROWS === '1',
+      allowUtcMidnightCrossing: env.ALLOW_UTC_MIDNIGHT_CROSSING === '1',
+      pluginIndexPath: String(env.PLUGIN_INDEX_PATH || ''),
+    },
+  }
+}
+
+// --- runtime wiring -------------------------------------------------------------------------
+
+const IS_MAIN = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false
+const ENTRY = resolveEnvConfig(process.env)
+if (IS_MAIN && !ENTRY.ok) {
+  for (const message of ENTRY.errors) console.error(`FAIL: ${message}`)
+  console.error('  e.g. BASE_URL=http://127.0.0.1:8082 DATABASE_URL=postgresql://USER@127.0.0.1:5432/metasheet DEPLOY_SHA=<deployed-sha> ADMIN_TOKEN=<jwt> node scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs')
+  process.exit(2)
+}
+
+const {
+  baseUrl: BASE_URL,
+  databaseUrl: DATABASE_URL,
+  deploySha: DEPLOY_SHA,
+  stamp: STAMP,
+  orgId: ORG_ID,
+  triggerMode: TRIGGER_MODE,
+  schedulerIntervalMs: SCHEDULER_INTERVAL_MS,
+  workerExpected: WORKER_EXPECTED,
+} = ENTRY.config
+
+const USER_PREFIX = `${STAMP}-`
+const MEMBER_USER = process.env.MEMBER_USER_ID || `${USER_PREFIX}member`
+const INACTIVE_USER = process.env.INACTIVE_USER_ID || `${USER_PREFIX}inactive`
+const ADMIN_USER = process.env.ADMIN_USER_ID || `${USER_PREFIX}admin`
+
+// The period is pinned once at process start (policy timezone is set to UTC by this smoke, so the
+// helper-side computation matches the producer). The seam track passes this todayKey explicitly and
+// is therefore midnight-safe; the scheduler variant guards against UTC-midnight crossings instead.
+const RUN_NOW = new Date()
+const RUN_TODAY_KEY = utcDateKey(RUN_NOW)
+const PERIOD = computeCompletedDailyPeriod(RUN_TODAY_KEY)
+const SOURCE_KEY_PREFIX = buildDigestSourceKeyPrefix(ORG_ID, DIGEST_CADENCE, PERIOD.periodKey)
+
+let adminToken = process.env.ADMIN_TOKEN || process.env.SMOKE_TOKEN || process.env.TOKEN || ''
+let originalSettings = null
+let cleanupAllowed = false
+let orgDigestBaseline = 0
+let defaultOrgDigestBaseline = 0
+let pass = 0
+const failures = []
+
+let pool = null
+const q = (text, params = []) => pool.query(text, params).then(result => result.rows)
+
+function ok(condition, label, detail) {
+  if (condition) {
+    pass += 1
+    console.log(`  PASS  ${label}`)
+    return
+  }
+  failures.push(label)
+  const suffix = detail === undefined ? '' : ` - ${JSON.stringify(detail)}`
+  console.error(`  FAIL  ${label}${suffix}`)
+}
+
+function assertSyntheticUser(userId, label) {
+  if (typeof userId === 'string' && userId.startsWith(USER_PREFIX) && userId.length > USER_PREFIX.length) return
+  throw new Error(`refusing to run: ${label} "${userId}" is not stamped with ${USER_PREFIX}. This smoke deletes its synthetic users during cleanup.`)
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function authHeaders(token) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'x-org-id': ORG_ID,
+  }
+  if (token) headers.Authorization = `Bearer ${token}`
+  return headers
+}
+
+async function api(token, pathname, { method = 'GET', body } = {}) {
+  const url = new URL(`${BASE_URL}${pathname}`)
+  if (!url.searchParams.has('orgId')) url.searchParams.set('orgId', ORG_ID)
+  const res = await fetch(url, {
+    method,
+    headers: authHeaders(token),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  let json = null
+  try { json = await res.json() } catch { /* non-json */ }
+  return { status: res.status, body: json }
+}
+
+async function mintToken(userId, { roles = 'admin', perms }) {
+  const res = await api('', `/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`)
+  const token = res.body?.token || ''
+  if (!token) {
+    throw new Error(`could not mint dev-token for ${userId} (status ${res.status}); provide explicit ADMIN_TOKEN for staging environments that disable dev-token`)
+  }
+  return token
+}
+
+async function resolveTokens() {
+  assertSyntheticUser(ADMIN_USER, 'ADMIN_USER_ID')
+  if (!adminToken) {
+    adminToken = await mintToken(ADMIN_USER, {
+      roles: 'admin',
+      perms: 'attendance:read,attendance:write,attendance:admin',
+    })
+    console.log('  minted admin dev-token')
+  } else {
+    const subject = jwtSubject(adminToken)
+    if (subject != null) console.log(`  using supplied admin token (subject ${subject})`)
+  }
+}
+
+// --- preflight -------------------------------------------------------------------------------
+
+async function preflightDatabase() {
+  const row = (await q(
+    `SELECT
+       to_regclass('public.attendance_notification_deliveries') IS NOT NULL AS deliveries_ok,
+       to_regclass('public.user_orgs') IS NOT NULL AS user_orgs_ok,
+       to_regclass('public.users') IS NOT NULL AS users_ok,
+       to_regclass('public.system_configs') IS NOT NULL AS settings_ok`,
+  ))[0] || {}
+  const ready = Object.values(row).every(value => value === true)
+  ok(ready, 'DB assertion channel reachable and RD-4/5 tables exist (attendance_notification_deliveries et al)', row)
+  if (!ready) throw new Error('staging DB missing the deliveries table (migration zzzz20260611120000) or DATABASE_URL points at the wrong database')
+}
+
+async function countOrgDigestRows(orgId) {
+  const rows = await q(
+    `SELECT count(*)::int AS n FROM attendance_notification_deliveries WHERE org_id = $1 AND source_type = $2`,
+    [orgId, DIGEST_SOURCE_TYPE],
+  )
+  return Number(rows[0]?.n ?? -1)
+}
+
+async function preflightDeliveriesBaseline() {
+  // Deterministic-key collision guard: a previous rd45 run of the SAME UTC day against the SAME org
+  // would have created rows under this exact prefix (the family deviation — keys carry no stamp).
+  const prefixCount = Number((await q(
+    `SELECT count(*)::int AS n FROM attendance_notification_deliveries
+     WHERE org_id = $1 AND source_type = $2 AND left(source_key, $3) = $4`,
+    [ORG_ID, DIGEST_SOURCE_TYPE, SOURCE_KEY_PREFIX.length, SOURCE_KEY_PREFIX],
+  ))[0]?.n ?? -1)
+  ok(prefixCount === 0, `no pre-existing rows under this run's deterministic source_key prefix (${SOURCE_KEY_PREFIX})`, { prefixCount })
+  if (prefixCount !== 0) {
+    throw new Error('deterministic-key collision: a previous rd45 run today left digest rows under the same prefix; clean them via the runbook residue block before rerunning')
+  }
+
+  orgDigestBaseline = await countOrgDigestRows(ORG_ID)
+  defaultOrgDigestBaseline = ORG_ID === DEFAULT_ORG_ID ? orgDigestBaseline : await countOrgDigestRows(DEFAULT_ORG_ID)
+  const baselinesClean = orgDigestBaseline === 0 && defaultOrgDigestBaseline === 0
+  ok(
+    baselinesClean || ENTRY.config.allowPreexistingDigestRows,
+    `digest-row baselines (run org: ${orgDigestBaseline}, default org: ${defaultOrgDigestBaseline}${baselinesClean ? '' : '; ALLOW_PREEXISTING_DIGEST_ROWS accepted — residue asserts DELTA=0'})`,
+    { orgDigestBaseline, defaultOrgDigestBaseline },
+  )
+  if (!baselinesClean && !ENTRY.config.allowPreexistingDigestRows) {
+    throw new Error('pre-existing attendance_report_digest rows found; inspect them (was the digest producer ever enabled on this stack?) or set ALLOW_PREEXISTING_DIGEST_ROWS=1 to assert baseline-delta instead of absolute zero')
+  }
+
+  if (WORKER_EXPECTED) {
+    // The delivery worker claims due rows GLOBALLY (C5-5 lesson). This smoke does not change what the
+    // already-running window worker does to foreign rows, so this is informational, not a gate.
+    const due = Number((await q(
+      `SELECT count(*)::int AS n FROM attendance_notification_deliveries
+       WHERE status IN ('pending', 'retrying') AND next_attempt_at <= now()`,
+    ))[0]?.n ?? -1)
+    if (due > 0) console.log(`  WARN: ${due} foreign due delivery row(s) are claimable by the window's live worker (global claim; unrelated to this smoke)`)
+  }
+}
+
+function guardUtcMidnight() {
+  if (TRIGGER_MODE !== 'scheduler') return // seam track pins todayKey explicitly — midnight-safe
+  const minutes = minutesUntilUtcMidnight(new Date())
+  if (minutes < 30 && !ENTRY.config.allowUtcMidnightCrossing) {
+    throw new Error(`only ${minutes} minute(s) until UTC midnight; the scheduler variant's waits would cross the day boundary and flip the due periodKey mid-run. Rerun after midnight or set ALLOW_UTC_MIDNIGHT_CROSSING=1.`)
+  }
+  ok(true, `UTC-midnight guard ok (${minutes} minutes remaining)`, { minutes })
+}
+
+// --- settings --------------------------------------------------------------------------------
+
+async function getSettings() {
+  const res = await api(adminToken, '/api/attendance/settings')
+  ok(res.status === 200, `GET settings through staging API (status ${res.status})`, res.body)
+  if (res.status !== 200) throw new Error('cannot read attendance settings')
+  return res.body?.data ?? {}
+}
+
+async function putSettings(update, label) {
+  const res = await api(adminToken, '/api/attendance/settings', { method: 'PUT', body: update })
+  ok(res.status === 200, `${label} (status ${res.status})`, res.body)
+  if (res.status !== 200) throw new Error(`settings update failed: ${label}`)
+  return res.body?.data ?? {}
+}
+
+async function verifySettingsCoherence() {
+  const row = (await q(
+    `SELECT value::jsonb #> '{attendanceReportDigestPolicy}' AS policy
+     FROM system_configs
+     WHERE key = 'attendance.settings'
+     LIMIT 1`,
+  ))[0]
+  const policy = parseJson(row?.policy) ?? null
+  const coherent = policy && typeof policy === 'object' && policy.enabled === true
+  ok(Boolean(coherent), 'API settings write (digest policy enabled) is visible through DATABASE_URL', policy)
+  if (!coherent) throw new Error('BASE_URL and DATABASE_URL do not appear coherent for attendance settings')
+}
+
+async function enableDigestPolicy() {
+  // Exact RD-3 integration-test shape: timezone UTC + daily sendAt 00:00 => due on every tick all
+  // day (due-ness is anchor-day + localHHmm >= sendAt, NOT minute-equality); recipients self-only.
+  await putSettings({
+    attendanceReportDigestPolicy: {
+      enabled: true,
+      timezone: 'UTC',
+      channel: 'work_notification',
+      cadences: {
+        daily: { enabled: true, sendAt: '00:00', recipients: ['self'] },
+      },
+    },
+  }, 'enable report-digest policy (daily, sendAt=00:00, timezone=UTC, recipients=[self])')
+  await verifySettingsCoherence()
+}
+
+// --- seed / subjects ---------------------------------------------------------------------------
+
+async function seedUsers() {
+  // One ACTIVE member (the window plan's single-member rule for the smoke org) plus one user whose
+  // MEMBERSHIP is inactive — proving the producer's active-only subject resolution has teeth.
+  for (const [userId, orgActive] of [[MEMBER_USER, true], [INACTIVE_USER, false]]) {
+    assertSyntheticUser(userId, 'smoke user')
+    await pool.query(
+      `INSERT INTO users (id, email, password_hash, name, role, is_active)
+       VALUES ($1, $2, 'no-login', $3, 'user', true)
+       ON CONFLICT (id) DO UPDATE SET is_active = true, email = EXCLUDED.email, name = EXCLUDED.name`,
+      [userId, `${userId}@example.test`, userId],
+    )
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = $3`,
+      [userId, ORG_ID, orgActive],
+    )
+  }
+  cleanupAllowed = true
+  ok(true, `seeded synthetic member (active) + inactive-membership user into org "${ORG_ID}"`, { stamp: STAMP })
+}
+
+async function resolveExpectedSubjects() {
+  // Same join discipline as the producer's subject loader: active membership AND active user.
+  const rows = await q(
+    `SELECT uo.user_id
+     FROM user_orgs uo
+     JOIN users u ON u.id = uo.user_id
+     WHERE uo.org_id = $1 AND uo.is_active = true AND u.is_active = true
+     ORDER BY uo.user_id`,
+    [ORG_ID],
+  )
+  const subjects = rows.map(row => String(row.user_id))
+  ok(subjects.includes(MEMBER_USER), 'stamped active member is a resolved digest subject', { subjects: subjects.length })
+  ok(!subjects.includes(INACTIVE_USER), 'inactive membership is excluded from digest subjects', { subjects: subjects.length })
+  if (TRIGGER_MODE === 'seam') {
+    ok(subjects.length === 1 && subjects[0] === MEMBER_USER, 'disposable smoke org has exactly ONE active member (window-plan single-member rule)', subjects)
+  } else {
+    ok(subjects.length >= 1, `default org resolves ${subjects.length} active digest subject(s) — one pending row per subject is expected`, { subjects: subjects.length })
+  }
+  return subjects
+}
+
+// --- trigger tracks ----------------------------------------------------------------------------
+
+function resolvePluginIndexPath() {
+  if (ENTRY.config.pluginIndexPath) return ENTRY.config.pluginIndexPath
+  const here = dirname(fileURLToPath(import.meta.url))
+  return resolvePath(here, '../../plugins/plugin-attendance/index.cjs')
+}
+
+function loadDigestSeam() {
+  const requireCjs = createRequire(import.meta.url)
+  const plugin = requireCjs(resolvePluginIndexPath())
+  const seam = plugin?.__attendanceReportDigestForTests
+  if (!seam?.runAttendanceReportDigestOnce) {
+    throw new Error(`plugin module at ${resolvePluginIndexPath()} does not export __attendanceReportDigestForTests.runAttendanceReportDigestOnce; set PLUGIN_INDEX_PATH or run from a prepared metasheet2 checkout at the deployed SHA`)
+  }
+  return seam
+}
+
+// Same db-adapter shape as the RD-3 integration harness: query -> rows[], transaction(fn) with a
+// same-shaped client under BEGIN/COMMIT/ROLLBACK.
+function createPluginDb() {
+  return {
+    async query(sql, params) {
+      const result = await pool.query(sql, params)
+      return result.rows
+    },
+    async transaction(handler) {
+      const client = await pool.connect()
+      const trx = {
+        async query(sql, params) {
+          const result = await client.query(sql, params)
+          return result.rows
+        },
+      }
+      try {
+        await client.query('BEGIN')
+        const value = await handler(trx)
+        await client.query('COMMIT')
+        return value
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => undefined)
+        throw error
+      } finally {
+        client.release()
+      }
+    },
+  }
+}
+
+// The producer env gate is process-local: setting it here affects ONLY this helper process, never
+// the backend. The backend's own gate must stay unset/false under the seam track (leakage guard).
+async function runSeamOnce({ envEnabled = true } = {}) {
+  const seam = loadDigestSeam()
+  const previous = process.env.ATTENDANCE_REPORT_DIGEST_ENABLED
+  if (envEnabled) process.env.ATTENDANCE_REPORT_DIGEST_ENABLED = 'true'
+  else delete process.env.ATTENDANCE_REPORT_DIGEST_ENABLED
+  try {
+    return await seam.runAttendanceReportDigestOnce(createPluginDb(), {
+      orgId: ORG_ID,
+      now: RUN_NOW,
+      todayKey: RUN_TODAY_KEY,
+      logger: { warn: () => undefined, error: () => undefined, info: () => undefined },
+      emitEvent: () => undefined,
+    })
+  } finally {
+    if (previous === undefined) delete process.env.ATTENDANCE_REPORT_DIGEST_ENABLED
+    else process.env.ATTENDANCE_REPORT_DIGEST_ENABLED = previous
+  }
+}
+
+async function fetchDigestRows() {
+  return q(
+    `SELECT id, org_id, source_type, source_id, source_key, recipient_user_id, recipient_role,
+            channel, status, last_error, payload
+     FROM attendance_notification_deliveries
+     WHERE org_id = $1 AND source_type = $2 AND left(source_key, $3) = $4
+     ORDER BY source_key ASC`,
+    [ORG_ID, DIGEST_SOURCE_TYPE, SOURCE_KEY_PREFIX.length, SOURCE_KEY_PREFIX],
+  )
+}
+
+async function produceViaSeam(subjects) {
+  const result = await runSeamOnce({ envEnabled: true })
+  const cadenceEntry = Array.isArray(result?.cadences) ? result.cadences.find(entry => entry?.cadence === DIGEST_CADENCE) : null
+  ok(result?.ran === true && cadenceEntry != null, 'seam invocation ran with the daily cadence due', result)
+  ok(
+    Number(cadenceEntry?.rowsCreated) === subjects.length && Number(cadenceEntry?.rowsExisting ?? 0) === 0,
+    `seam produced exactly ${subjects.length} new row(s), zero pre-existing`,
+    cadenceEntry,
+  )
+  return fetchDigestRows()
+}
+
+async function produceViaScheduler(subjects) {
+  const timeoutMs = 2 * SCHEDULER_INTERVAL_MS + SETTINGS_CACHE_TTL_MS + 30_000
+  console.log(`  waiting for the backend scheduler tick: interval=${SCHEDULER_INTERVAL_MS}ms (NO immediate first run — the first tick fires one FULL interval after process start), plus up to 60s in-process settings cache; timeout ${timeoutMs}ms`)
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const rows = await fetchDigestRows()
+    if (rows.length >= subjects.length) {
+      ok(true, `scheduler tick produced ${rows.length} digest row(s) under the deterministic prefix`, { rows: rows.length })
+      return rows
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`no digest rows appeared within ${timeoutMs}ms — verify on the backend: ATTENDANCE_SCHEDULER_ENABLED is exactly 'true', ATTENDANCE_REPORT_DIGEST_ENABLED is truthy, ATTENDANCE_SCHEDULER_INTERVAL_MS matches SCHEDULER_INTERVAL_MS=${SCHEDULER_INTERVAL_MS}, the leader lock (if enabled) is held, and the container was recreated after env changes`)
+    }
+    await sleep(5000)
+  }
+}
+
+// --- assertions --------------------------------------------------------------------------------
+
+const KNOWN_STATUSES = ['pending', 'sending', 'sent', 'retrying', 'failed']
+
+function assertProducedGrain(rows, subjects) {
+  ok(rows.length === subjects.length, `producer wrote exactly one row per active subject (expected ${subjects.length})`, { rows: rows.length })
+
+  const subjectSet = new Set(subjects)
+  const seenSubjects = new Set()
+  const badRows = []
+  for (const row of rows) {
+    const parsed = parseDigestSourceKey(String(row.source_key ?? ''))
+    const payload = parseJson(row.payload) ?? {}
+    const good = parsed != null
+      && parsed.orgId === ORG_ID
+      && parsed.cadence === DIGEST_CADENCE
+      && parsed.periodKey === PERIOD.periodKey
+      && parsed.recipientRole === 'self' // source_key segment uses the CONFIG vocab
+      && parsed.subjectUserId === parsed.recipientUserId // recipients=[self] => subject is recipient
+      && row.recipient_role === 'subject' // the COLUMN uses the row vocab for self-recipients
+      && row.recipient_user_id === parsed.recipientUserId
+      && subjectSet.has(parsed.subjectUserId)
+      && DELIVERY_CHANNEL_ALLOWLIST.includes(String(row.channel ?? ''))
+      && String(row.channel) === parsed.channel
+      && row.source_id === `${ORG_ID}:${DIGEST_CADENCE}:${PERIOD.periodKey}`
+      && KNOWN_STATUSES.includes(String(row.status ?? ''))
+      && payload.kind === DIGEST_SOURCE_TYPE
+      && payload.cadence === DIGEST_CADENCE
+      && payload?.period?.periodKey === PERIOD.periodKey
+    if (!good) badRows.push({ sourceKey: row.source_key, status: row.status, channel: row.channel, recipientRole: row.recipient_role })
+    if (parsed) seenSubjects.add(parsed.subjectUserId)
+  }
+  ok(badRows.length === 0, 'every row carries per-subject grain (":subject:" segment), self/subject role vocab, allowlisted channel, deterministic source_id and digest payload', badRows.slice(0, 3))
+  ok(
+    seenSubjects.size === subjects.length && subjects.every(subject => seenSubjects.has(subject)),
+    'per-subject coverage: every resolved subject appears exactly once in the produced keys',
+    { seen: seenSubjects.size, expected: subjects.length },
+  )
+
+  const channels = new Set(rows.map(row => String(row.channel ?? '')))
+  ok(channels.size === 1, 'all rows carry ONE consistent resolved delivery channel', Array.from(channels))
+}
+
+async function assertNoOutsideRecipients(subjects) {
+  const rows = await q(
+    `SELECT count(*)::int AS n FROM attendance_notification_deliveries
+     WHERE org_id = $1 AND source_type = $2 AND left(source_key, $3) = $4
+       AND NOT (recipient_user_id = ANY($5::text[]))`,
+    [ORG_ID, DIGEST_SOURCE_TYPE, SOURCE_KEY_PREFIX.length, SOURCE_KEY_PREFIX, subjects],
+  )
+  ok(Number(rows[0]?.n) === 0, 'zero digest rows name a recipient outside the resolved subject set', rows[0])
+}
+
+// The deliveries GET route has NO source_type/source_key filter param — only status + pagination.
+// Filtering is therefore CLIENT-SIDE by deterministic source_key prefix, paging through the org.
+async function assertApiVisibility(expectedCount) {
+  let page = 1
+  let seen = 0
+  let matched = 0
+  let total = 0
+  for (;;) {
+    const res = await api(adminToken, `/api/attendance/notification-deliveries?status=all&page=${page}&pageSize=200`)
+    if (res.status !== 200) {
+      ok(false, `deliveries GET route readable for org "${ORG_ID}" (status ${res.status}) — see runbook OQ-1 on admin-token org scoping`, res.body)
+      return
+    }
+    const data = res.body?.data ?? {}
+    const items = Array.isArray(data.items) ? data.items : []
+    total = Number(data.total ?? items.length)
+    for (const item of items) {
+      if (String(item.sourceKey ?? '').startsWith(SOURCE_KEY_PREFIX)) matched += 1
+    }
+    seen += items.length
+    if (items.length === 0 || seen >= total || page >= 200) break
+    page += 1
+  }
+  ok(matched === expectedCount, `deliveries GET route shows the produced rows via client-side source_key-prefix filtering (${matched}/${expectedCount}; route has no source filter param)`, { matched, expectedCount, total })
+}
+
+async function assertReplayIdempotency(subjects) {
+  if (TRIGGER_MODE === 'seam') {
+    const replay = await runSeamOnce({ envEnabled: true })
+    const cadenceEntry = Array.isArray(replay?.cadences) ? replay.cadences.find(entry => entry?.cadence === DIGEST_CADENCE) : null
+    ok(
+      replay?.ran === true && Number(cadenceEntry?.rowsCreated) === 0 && Number(cadenceEntry?.rowsExisting) === subjects.length,
+      'second seam invocation created zero new rows (ON CONFLICT (org_id, source_key) DO NOTHING) and reported all rows existing',
+      cadenceEntry ?? replay,
+    )
+  } else {
+    const waitMs = 2 * SCHEDULER_INTERVAL_MS + 10_000
+    console.log(`  waiting ${waitMs}ms (>= 2 scheduler ticks) to observe replay dedup on the still-due period...`)
+    await sleep(waitMs)
+  }
+  const rows = await fetchDigestRows()
+  const dedupOk = rows.length === subjects.length
+  ok(dedupOk, `replay idempotency: TOTAL row count for the period is unchanged (${rows.length}/${subjects.length})`, { rows: rows.length })
+  return dedupOk
+}
+
+async function assertDisabledPaths(subjects) {
+  if (TRIGGER_MODE === 'seam') {
+    const envOff = await runSeamOnce({ envEnabled: false })
+    ok(envOff?.ran === false && envOff?.reason === 'disabled', 'env-gate off (producer gate unset in the seam process) -> {ran:false, reason:"disabled"}', envOff)
+
+    await putSettings({ attendanceReportDigestPolicy: { enabled: false } }, 'disable report-digest policy (policy-off path)')
+    const cacheWaitMs = SETTINGS_CACHE_TTL_MS + 1000
+    console.log(`  waiting ${cacheWaitMs}ms for the plugin module's in-process settings cache (60s TTL) to expire before the policy-off seam call...`)
+    await sleep(cacheWaitMs)
+    const policyOff = await runSeamOnce({ envEnabled: true })
+    ok(policyOff?.ran === false && policyOff?.reason === 'disabled', 'policy off (enabled=false) -> {ran:false, reason:"disabled"} even with the env gate on', policyOff)
+  } else {
+    await putSettings({ attendanceReportDigestPolicy: { enabled: false } }, 'disable report-digest policy (policy-off path)')
+    const waitMs = SETTINGS_CACHE_TTL_MS + 2 * SCHEDULER_INTERVAL_MS + 10_000
+    console.log(`  waiting ${waitMs}ms (60s settings cache + 2 ticks) to prove the disabled policy stops production...`)
+    await sleep(waitMs)
+  }
+  const rows = await fetchDigestRows()
+  ok(rows.length === subjects.length, 'disabled paths produced zero new rows (count unchanged)', { rows: rows.length })
+}
+
+// RD-5 send proof. Window state keeps the delivery worker ON (bundle §3.4); under the disposable
+// smoke org the fan-out is contained to synthetic users, so sends are harmless and double as the
+// send-path proof: every row must reach a terminal, explainable state. Under WORKER_EXPECTED=0 or
+// the scheduler variant, the proof inverts: rows must REMAIN pending (nothing may send).
+async function assertSendPosture(subjects) {
+  if (!WORKER_EXPECTED) {
+    const waitMs = 2 * SCHEDULER_INTERVAL_MS + 10_000
+    console.log(`  waiting ${waitMs}ms to confirm rows stay pending with the delivery worker off...`)
+    await sleep(waitMs)
+    const rows = await fetchDigestRows()
+    const nonPending = rows.filter(row => String(row.status) !== 'pending')
+    ok(
+      rows.length === subjects.length && nonPending.length === 0,
+      'worker-off posture: every produced row is still status=pending (producer-only proof; no sends occurred)',
+      nonPending.slice(0, 3),
+    )
+    return 'worker-off:pending-only'
+  }
+
+  const timeoutMs = 3 * SCHEDULER_INTERVAL_MS + 90_000
+  console.log(`  polling for the delivery worker to visibly resolve the smoke-org rows (worker runs on the shared scheduler tick; timeout ${timeoutMs}ms)...`)
+  const deadline = Date.now() + timeoutMs
+  let outcome = classifySendOutcome(await fetchDigestRows())
+  while (outcome.terminal < outcome.total && Date.now() <= deadline) {
+    await sleep(5000)
+    outcome = classifySendOutcome(await fetchDigestRows())
+  }
+  ok(
+    outcome.visiblyProven,
+    `RD-5 send proof: worker visibly resolved every row (sent=${outcome.sent}, failedRecognized=${outcome.failedRecognized}, pending=${outcome.pending}, sending=${outcome.sending}, retrying=${outcome.retrying}, failedOther=${outcome.failedOther.length})`,
+    outcome,
+  )
+  if (!outcome.visiblyProven) {
+    throw new Error('delivery worker did not visibly resolve the digest rows — verify the worker env gate, channel envs, and the scheduler interval on the backend, then consult the runbook send-posture table')
+  }
+  return `worker-on:sent=${outcome.sent},failed_recognized=${outcome.failedRecognized}`
+}
+
+async function assertNoDefaultOrgLeakage() {
+  if (ORG_ID === DEFAULT_ORG_ID) return // scheduler variant runs ON the default org; residue handles it
+  const count = await countOrgDigestRows(DEFAULT_ORG_ID)
+  ok(
+    count === defaultOrgDigestBaseline,
+    'no default-org leakage: the backend producer gate stayed off while the GLOBAL digest policy was enabled for this smoke',
+    { count, baseline: defaultOrgDigestBaseline },
+  )
+  if (count !== defaultOrgDigestBaseline) {
+    throw new Error('default-org digest rows appeared during the smoke: the backend has ATTENDANCE_REPORT_DIGEST_ENABLED set. Disable it, then clean the leaked rows via the runbook (deterministic prefix on org default) — do NOT let the worker send them')
+  }
+}
+
+function printRunLog(rows) {
+  console.log('  RUN LOG — deterministic digest keys (record in the runbook worksheet; keys carry NO stamp):')
+  console.log(`    periodKey=${PERIOD.periodKey}`)
+  console.log(`    sourceKeyPrefix=${SOURCE_KEY_PREFIX}`)
+  for (const row of rows) console.log(`    source_key=${row.source_key}`)
+}
+
+// --- cleanup / residue -----------------------------------------------------------------------
+
+async function restoreSettings({ strict = false } = {}) {
+  if (!originalSettings) return
+  const res = await api(adminToken, '/api/attendance/settings', { method: 'PUT', body: buildRestoreDigestPolicyBody(originalSettings) })
+  if (strict) {
+    ok(res.status === 200, `restore original attendance settings (status ${res.status})`, res.body)
+    if (res.status !== 200) throw new Error('failed to restore original attendance settings')
+    const restored = await getSettings()
+    const restoredPolicy = restored.attendanceReportDigestPolicy ?? null
+    const expectedPolicy = originalSettings.attendanceReportDigestPolicy ?? DISABLED_DIGEST_POLICY_DEFAULT
+    ok(stableJson(restoredPolicy) === stableJson(expectedPolicy), 'restored attendanceReportDigestPolicy matches the pre-smoke value', restoredPolicy)
+    if (stableJson(restoredPolicy) !== stableJson(expectedPolicy)) {
+      throw new Error('attendanceReportDigestPolicy did not restore to its pre-smoke value')
+    }
+    return
+  }
+  if (res.status !== 200) {
+    console.error(`WARN: failed to restore attendance settings (status ${res.status})`)
+  }
+}
+
+async function cleanup({ strictSettingsRestore = false } = {}) {
+  if (!cleanupAllowed) return
+  // Cleanup-order trap: restore/disable the policy BEFORE deleting rows — while the policy and the
+  // producer gate are both live, the still-open period is re-inserted on the next producer run.
+  await restoreSettings({ strict: strictSettingsRestore }).catch(error => {
+    if (strictSettingsRestore) throw error
+    console.error(`WARN: failed to restore attendance settings: ${error?.message || error}`)
+  })
+  if (TRIGGER_MODE === 'seam') {
+    // The smoke org is disposable and stamped, so an org-scoped source_type delete is safe there.
+    await pool.query(
+      'DELETE FROM attendance_notification_deliveries WHERE org_id = $1 AND source_type = $2',
+      [ORG_ID, DIGEST_SOURCE_TYPE],
+    ).catch(() => undefined)
+  } else {
+    // NEVER org-wide on the default org: delete strictly by the deterministic source_key prefix.
+    await pool.query(
+      'DELETE FROM attendance_notification_deliveries WHERE org_id = $1 AND source_type = $2 AND left(source_key, $3) = $4',
+      [ORG_ID, DIGEST_SOURCE_TYPE, SOURCE_KEY_PREFIX.length, SOURCE_KEY_PREFIX],
+    ).catch(() => undefined)
+  }
+  await pool.query('DELETE FROM user_orgs WHERE org_id = $1 AND left(user_id, $2) = $3', [ORG_ID, USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+  await pool.query('DELETE FROM users WHERE left(id, $1) = $2', [USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+}
+
+async function residueCounts() {
+  const row = (await q(
+    `SELECT
+       (SELECT count(*)::int FROM attendance_notification_deliveries
+         WHERE org_id = $1 AND source_type = $2 AND left(source_key, $3) = $4) AS prefix_deliveries,
+       (SELECT count(*)::int FROM attendance_notification_deliveries
+         WHERE org_id = $1 AND source_type = $2) AS org_digest_deliveries,
+       (SELECT count(*)::int FROM attendance_notification_deliveries
+         WHERE left(recipient_user_id, $5) = $6) AS smoke_recipient_deliveries,
+       (SELECT count(*)::int FROM user_orgs WHERE org_id = $1 AND left(user_id, $5) = $6) AS user_orgs,
+       (SELECT count(*)::int FROM users WHERE left(id, $5) = $6) AS users`,
+    [ORG_ID, DIGEST_SOURCE_TYPE, SOURCE_KEY_PREFIX.length, SOURCE_KEY_PREFIX, USER_PREFIX.length, USER_PREFIX],
+  ))[0] || {}
+  const residue = {
+    prefix_deliveries: Number(row.prefix_deliveries ?? -1),
+    org_digest_delta: Number(row.org_digest_deliveries ?? -1) - orgDigestBaseline,
+    smoke_recipient_deliveries: Number(row.smoke_recipient_deliveries ?? -1),
+    user_orgs: Number(row.user_orgs ?? -1),
+    users: Number(row.users ?? -1),
+  }
+  if (ORG_ID !== DEFAULT_ORG_ID) {
+    residue.default_org_digest_delta = (await countOrgDigestRows(DEFAULT_ORG_ID)) - defaultOrgDigestBaseline
+  }
+  return residue
+}
+
+// --- main ------------------------------------------------------------------------------------
+
+async function main() {
+  console.log(`RD-4/5 report-digest API/DB staging smoke helper @ ${BASE_URL}`)
+  console.log(`  deploy=${DEPLOY_SHA} org=${ORG_ID} stamp=${STAMP} mode=${TRIGGER_MODE} workerExpected=${WORKER_EXPECTED ? 1 : 0}`)
+  console.log('  NOTE: this helper does not close RD-4/5 by itself; the RD-4 config-card browser probe and the final stamp live in docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md.')
+  console.log('  NOTE: digest source_keys are deterministic (family deviation) — the RUN LOG below is part of the residue record.')
+
+  await resolveTokens()
+  await preflightDatabase()
+  guardUtcMidnight()
+  await preflightDeliveriesBaseline()
+  originalSettings = await getSettings()
+
+  await seedUsers()
+  const subjects = await resolveExpectedSubjects()
+  await enableDigestPolicy()
+
+  const rows = TRIGGER_MODE === 'seam' ? await produceViaSeam(subjects) : await produceViaScheduler(subjects)
+  printRunLog(rows)
+  assertProducedGrain(rows, subjects)
+  await assertNoOutsideRecipients(subjects)
+  await assertApiVisibility(subjects.length)
+
+  const dedupOk = await assertReplayIdempotency(subjects)
+  await assertDisabledPaths(subjects)
+  const sendPosture = await assertSendPosture(subjects)
+  await assertNoDefaultOrgLeakage()
+
+  await cleanup({ strictSettingsRestore: true })
+  const residue = await residueCounts()
+  const residueOk = Object.values(residue).every(value => Number(value) === 0)
+  ok(residueOk, 'cleanup residue is zero (deterministic prefix + org deltas + stamped users)', residue)
+  if (!residueOk) throw new Error(`residue not zero: ${JSON.stringify(residue)}`)
+  if (failures.length) {
+    throw new Error(`RD-4/5 API/DB smoke had ${failures.length} failed assertion(s): ${failures.join('; ')}`)
+  }
+
+  console.log(`  sendPosture=${sendPosture} periodKey=${PERIOD.periodKey}`)
+  console.log(`RD45_REPORT_DIGEST_API_DB_SMOKE_PASS deploy=${DEPLOY_SHA} stamp=${STAMP} org=${ORG_ID} produced=${subjects.length} dedupOk=${dedupOk ? 1 : 0} residue=0`)
+  console.log(`Assertions passed: ${pass}`)
+}
+
+if (IS_MAIN) {
+  let pg
+  try {
+    pg = await import('pg')
+  } catch {
+    console.error('FAIL: package "pg" is required. Run this helper from a prepared metasheet2 checkout with dependencies installed.')
+    process.exit(2)
+  }
+  pool = new pg.default.Pool({ connectionString: DATABASE_URL })
+  main()
+    .catch(async (error) => {
+      console.error(`FAIL: ${error?.message || error}`)
+      try {
+        await cleanup()
+        const residue = await residueCounts()
+        console.error(`Residue after best-effort cleanup: ${JSON.stringify(residue)}`)
+      } catch (cleanupError) {
+        console.error(`WARN: cleanup failed: ${cleanupError?.message || cleanupError}`)
+      }
+      process.exitCode = 1
+    })
+    .finally(async () => {
+      await pool.end().catch(() => undefined)
+    })
+}

--- a/scripts/ops/staging-attendance-report-digest-rd45-smoke.test.mjs
+++ b/scripts/ops/staging-attendance-report-digest-rd45-smoke.test.mjs
@@ -1,0 +1,278 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import {
+  STAMP_PATTERN,
+  DIGEST_SOURCE_TYPE,
+  DIGEST_CADENCE,
+  DEFAULT_ORG_ID,
+  DELIVERY_CHANNEL_ALLOWLIST,
+  RECOGNIZED_TERMINAL_FAILURES,
+  RESIDUE_TABLES,
+  DISABLED_DIGEST_POLICY_DEFAULT,
+  utcDateKey,
+  addDaysUtc,
+  computeCompletedDailyPeriod,
+  minutesUntilUtcMidnight,
+  buildDigestSourceKeyPrefix,
+  buildDigestSourceKey,
+  parseDigestSourceKey,
+  buildRestoreDigestPolicyBody,
+  classifySendOutcome,
+  resolveEnvConfig,
+} from './staging-attendance-report-digest-rd45-smoke.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const script = readFileSync(join(here, 'staging-attendance-report-digest-rd45-smoke.mjs'), 'utf8')
+const runbook = readFileSync(join(here, '../../docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md'), 'utf8')
+const bundle = readFileSync(join(here, '../../docs/development/attendance-staging-window-bundle-20260702.md'), 'utf8')
+
+const GOOD_ENV = {
+  BASE_URL: 'http://127.0.0.1:8082/',
+  DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+  DEPLOY_SHA: 'abc123def456',
+}
+
+test('rd45 env contract: BASE_URL/DATABASE_URL/DEPLOY_SHA required, STAMP regex-locked, seam is the primary default', () => {
+  const missing = resolveEnvConfig({})
+  assert.equal(missing.ok, false)
+  assert.ok(missing.errors.some(msg => msg.includes('BASE_URL and DATABASE_URL')))
+  assert.ok(missing.errors.some(msg => msg.includes('DEPLOY_SHA is required')))
+
+  const placeholder = resolveEnvConfig({ ...GOOD_ENV, DEPLOY_SHA: '<fill-from-staging-build>' })
+  assert.equal(placeholder.ok, false)
+  assert.ok(placeholder.errors.some(msg => msg.includes('DEPLOY_SHA is required')))
+
+  const good = resolveEnvConfig(GOOD_ENV)
+  assert.equal(good.ok, true)
+  assert.equal(good.config.baseUrl, 'http://127.0.0.1:8082', 'trailing slash stripped')
+  assert.equal(good.config.triggerMode, 'seam', 'seam (disposable smoke org) is the PRIMARY default track')
+  assert.match(good.config.stamp, STAMP_PATTERN)
+  assert.equal(good.config.orgId, `${good.config.stamp}-org`, 'seam default org is derived from the stamp (disposable)')
+  assert.equal(good.config.workerExpected, true, 'window state keeps the delivery worker on; send proof expected by default')
+  assert.equal(good.config.allowPreexistingDigestRows, false)
+  assert.equal(good.config.allowUtcMidnightCrossing, false)
+
+  const workerOff = resolveEnvConfig({ ...GOOD_ENV, WORKER_EXPECTED: '0' })
+  assert.equal(workerOff.config.workerExpected, false)
+
+  const badStamp = resolveEnvConfig({ ...GOOD_ENV, STAMP: 'otbank-v18-smoke-wrong-family' })
+  assert.equal(badStamp.ok, false)
+  assert.ok(badStamp.errors.some(msg => msg.includes('rd45-smoke')))
+
+  const badMode = resolveEnvConfig({ ...GOOD_ENV, TRIGGER_MODE: 'cron' })
+  assert.equal(badMode.ok, false)
+  assert.ok(badMode.errors.some(msg => msg.includes('TRIGGER_MODE')))
+})
+
+test('rd45 env contract: org rules per track (seam=stamped disposable org; scheduler=default org + explicit fan-out ack + worker off)', () => {
+  const seamRealOrg = resolveEnvConfig({ ...GOOD_ENV, ORG_ID: 'default' })
+  assert.equal(seamRealOrg.ok, false, 'the seam track must never point at a real org')
+  assert.ok(seamRealOrg.errors.some(msg => msg.includes('rd45-smoke-')))
+
+  const seamCustom = resolveEnvConfig({ ...GOOD_ENV, ORG_ID: 'rd45-smoke-abc-org' })
+  assert.equal(seamCustom.ok, true)
+
+  const schedNoAck = resolveEnvConfig({ ...GOOD_ENV, TRIGGER_MODE: 'scheduler' })
+  assert.equal(schedNoAck.ok, false)
+  assert.ok(schedNoAck.errors.some(msg => msg.includes('ACK_DEFAULT_ORG_FANOUT=1')))
+  assert.equal(schedNoAck.config.orgId, DEFAULT_ORG_ID, 'scheduler variant defaults to the default org (the backend job is hardwired to it)')
+
+  const schedAck = resolveEnvConfig({ ...GOOD_ENV, TRIGGER_MODE: 'scheduler', ACK_DEFAULT_ORG_FANOUT: '1' })
+  assert.equal(schedAck.ok, true)
+  assert.equal(schedAck.config.workerExpected, false, 'scheduler variant must run with the delivery worker off (rows stay pending)')
+
+  const schedWorkerOn = resolveEnvConfig({ ...GOOD_ENV, TRIGGER_MODE: 'scheduler', ACK_DEFAULT_ORG_FANOUT: '1', WORKER_EXPECTED: '1' })
+  assert.equal(schedWorkerOn.ok, false, 'WORKER_EXPECTED=1 is rejected in scheduler mode')
+
+  const schedWrongOrg = resolveEnvConfig({ ...GOOD_ENV, TRIGGER_MODE: 'scheduler', ACK_DEFAULT_ORG_FANOUT: '1', ORG_ID: 'rd45-smoke-abc-org' })
+  assert.equal(schedWrongOrg.ok, false, 'the backend scheduler cannot serve a smoke org; ORG_ID must be default')
+
+  assert.equal(resolveEnvConfig({ ...GOOD_ENV, SCHEDULER_INTERVAL_MS: '3000' }).config.schedulerIntervalMs, 5000, 'mirrors the backend 5000ms floor clamp')
+  assert.equal(resolveEnvConfig({ ...GOOD_ENV, SCHEDULER_INTERVAL_MS: '20000' }).config.schedulerIntervalMs, 20000)
+  assert.equal(resolveEnvConfig({ ...GOOD_ENV, SCHEDULER_INTERVAL_MS: 'abc' }).config.schedulerIntervalMs, 15000, 'default interval when unset/garbage')
+})
+
+test('rd45 completed-daily-period computation: previous UTC calendar day incl month/year/leap boundaries', () => {
+  assert.deepEqual(computeCompletedDailyPeriod('2026-07-02'), { from: '2026-07-01', to: '2026-07-01', periodKey: 'daily:2026-07-01' })
+  assert.deepEqual(computeCompletedDailyPeriod('2026-03-01'), { from: '2026-02-28', to: '2026-02-28', periodKey: 'daily:2026-02-28' })
+  assert.deepEqual(computeCompletedDailyPeriod('2028-03-01'), { from: '2028-02-29', to: '2028-02-29', periodKey: 'daily:2028-02-29' }, 'leap-year boundary')
+  assert.deepEqual(computeCompletedDailyPeriod('2026-01-01'), { from: '2025-12-31', to: '2025-12-31', periodKey: 'daily:2025-12-31' }, 'year boundary')
+  assert.equal(addDaysUtc('2026-07-01', 1), '2026-07-02')
+  assert.equal(utcDateKey(new Date('2026-07-02T23:59:59.000Z')), '2026-07-02')
+})
+
+test('rd45 source_key builder/parser round-trip on the verified template (":subject:" segment; cadence appears twice)', () => {
+  // Literal example from the verified facts extract (implementation key shape).
+  const literal = 'attendance_report_digest:default:daily:daily:2026-07-01:subject:u1:self:u1:channel:dingtalk_work_notification'
+  const parts = {
+    orgId: 'default',
+    cadence: 'daily',
+    periodKey: 'daily:2026-07-01',
+    subjectUserId: 'u1',
+    recipientRole: 'self',
+    recipientUserId: 'u1',
+    channel: 'dingtalk_work_notification',
+  }
+  assert.equal(buildDigestSourceKey(parts), literal)
+  assert.deepEqual(parseDigestSourceKey(literal), parts)
+  assert.ok(literal.startsWith(buildDigestSourceKeyPrefix('default', 'daily', 'daily:2026-07-01')))
+  assert.ok(buildDigestSourceKeyPrefix('default', 'daily', 'daily:2026-07-01').endsWith(':subject:'), 'prefix pins the per-subject grain segment')
+
+  // Weekly period keys embed colons; owner-role recipient differs from the subject.
+  const weekly = buildDigestSourceKey({
+    orgId: 'default',
+    cadence: 'weekly',
+    periodKey: 'weekly:2026-06-22:2026-06-28',
+    subjectUserId: 'u1',
+    recipientRole: 'owner',
+    recipientUserId: 'mgr1',
+    channel: 'email_smtp',
+  })
+  assert.deepEqual(parseDigestSourceKey(weekly)?.periodKey, 'weekly:2026-06-22:2026-06-28')
+  assert.deepEqual(parseDigestSourceKey(weekly)?.recipientUserId, 'mgr1')
+})
+
+test('rd45 source_key parser rejects malformed keys, including the design-lock §4 doc-drift shape without ":subject:"', () => {
+  // The design-lock doc template omits the ':subject:' segment; the implementation supersedes it,
+  // and the parser must NOT accept the drifted shape.
+  assert.equal(parseDigestSourceKey('attendance_report_digest:default:daily:daily:2026-07-01:u1:self:u1:channel:dingtalk_work_notification'), null)
+  assert.equal(parseDigestSourceKey('attendance_result_edit:default:rec1:subject:u1:self:u1:channel:x'), null, 'wrong source_type prefix')
+  assert.equal(parseDigestSourceKey('attendance_report_digest:default:daily:weekly:2026-06-22:2026-06-28:subject:u1:self:u1:channel:x'), null, 'periodKey must start with the cadence (cadence appears twice)')
+  assert.equal(parseDigestSourceKey('attendance_report_digest:default:daily:daily:2026-07-01:subject:u1:self:u1:nochannel'), null, 'missing :channel: separator')
+  assert.equal(parseDigestSourceKey('attendance_report_digest:default:daily:daily:2026-07-01:subject:u1:self:u:1:channel:x'), null, 'recipient section must be exactly subject:role:recipient')
+  assert.equal(parseDigestSourceKey(null), null)
+})
+
+test('rd45 UTC-midnight guard math (scheduler variant only; the seam track pins todayKey)', () => {
+  assert.equal(minutesUntilUtcMidnight(new Date('2026-07-02T23:45:00.000Z')), 15)
+  assert.equal(minutesUntilUtcMidnight(new Date('2026-07-02T23:59:30.000Z')), 0)
+  assert.equal(minutesUntilUtcMidnight(new Date('2026-07-02T00:00:00.000Z')), 1440)
+})
+
+test('rd45 settings restore body never PUTs an empty snapshot (deep-merge lesson) and re-asserts the digest policy explicitly', () => {
+  const fromEmpty = buildRestoreDigestPolicyBody({})
+  assert.deepEqual(fromEmpty.attendanceReportDigestPolicy, DISABLED_DIGEST_POLICY_DEFAULT, 'defaults to the all-off policy when the pre-smoke settings never carried it')
+  assert.equal(fromEmpty.attendanceReportDigestPolicy.enabled, false)
+  for (const cadence of ['daily', 'weekly', 'monthly']) {
+    assert.equal(fromEmpty.attendanceReportDigestPolicy.cadences[cadence].enabled, false, `${cadence} cadence explicitly disabled`)
+  }
+  assert.equal(fromEmpty.attendanceReportDigestPolicy.cadences.daily.sendAt, '18:30', 'default daily sendAt matches DEFAULT_SETTINGS')
+
+  const original = {
+    someSiblingPolicy: { enabled: true, keep: 'me' },
+    attendanceReportDigestPolicy: {
+      enabled: true,
+      timezone: 'Asia/Shanghai',
+      channel: 'email_smtp',
+      cadences: {
+        daily: { enabled: true, sendAt: '19:00', recipients: ['self', 'owner'] },
+        weekly: { enabled: false, weekday: 1, sendAt: '09:00', recipients: ['self'] },
+        monthly: { enabled: false, dayOfMonth: 1, sendAt: '09:00', recipients: ['self'] },
+      },
+    },
+  }
+  const restored = buildRestoreDigestPolicyBody(original)
+  assert.deepEqual(restored.attendanceReportDigestPolicy, original.attendanceReportDigestPolicy, 'a genuinely-configured pre-smoke policy is restored verbatim')
+  assert.deepEqual(restored.someSiblingPolicy, { enabled: true, keep: 'me' }, 'sibling policies pass through untouched')
+
+  const fromNull = buildRestoreDigestPolicyBody(null)
+  assert.deepEqual(fromNull.attendanceReportDigestPolicy, DISABLED_DIGEST_POLICY_DEFAULT)
+})
+
+test('rd45 send-outcome classifier: sent / recognized visible failure = proven; stuck or unexplained = not proven', () => {
+  assert.deepEqual(RECOGNIZED_TERMINAL_FAILURES, ['dingtalk_recipient_not_bound', 'attendance_delivery_channel_not_configured'])
+
+  const allSent = classifySendOutcome([{ status: 'sent' }, { status: 'sent' }])
+  assert.equal(allSent.visiblyProven, true)
+  assert.equal(allSent.sent, 2)
+
+  const mixed = classifySendOutcome([{ status: 'sent' }, { status: 'failed', last_error: 'dingtalk_recipient_not_bound' }])
+  assert.equal(mixed.visiblyProven, true, 'unbound-recipient failure is a documented VISIBLE worker outcome')
+  assert.equal(mixed.failedRecognized, 1)
+
+  const channelMissing = classifySendOutcome([{ status: 'failed', last_error: 'attendance_delivery_channel_not_configured' }])
+  assert.equal(channelMissing.visiblyProven, true, 'channel-not-configured is terminal and visible (weakest posture; runbook prefers the deterministic fake channel)')
+
+  const unexplained = classifySendOutcome([{ status: 'failed', last_error: 'boom' }])
+  assert.equal(unexplained.visiblyProven, false)
+  assert.equal(unexplained.failedOther.length, 1)
+
+  const stuck = classifySendOutcome([{ status: 'sent' }, { status: 'pending' }])
+  assert.equal(stuck.visiblyProven, false, 'a stuck pending row is not a send proof')
+  assert.equal(stuck.terminal, 1)
+
+  assert.equal(classifySendOutcome([]).visiblyProven, false, 'zero rows prove nothing')
+})
+
+test('rd45 helper does not claim the final staging pass and prints the exact API/DB pass-line shape', () => {
+  assert.match(script, /RD45_REPORT_DIGEST_API_DB_SMOKE_PASS deploy=\$\{DEPLOY_SHA\} stamp=\$\{STAMP\} org=\$\{ORG_ID\} produced=\$\{subjects\.length\} dedupOk=\$\{dedupOk \? 1 : 0\} residue=0/)
+  assert.doesNotMatch(script, /RD45_REPORT_DIGEST_STAGING_SMOKE_PASS/)
+  assert.match(runbook, /RD45_REPORT_DIGEST_STAGING_SMOKE_PASS/)
+  assert.match(runbook, /\*\*Status:\*\* PREPARED/)
+  assert.match(runbook, /does \*\*not\*\* claim a staging PASS/)
+  assert.match(script, /if \(failures\.length\)/)
+  assert.match(script, /failed assertion\(s\)/)
+})
+
+test('rd45 deterministic-source_key family deviation is loud in both artifacts (keys carry no stamp; RUN LOG is part of the residue record)', () => {
+  assert.match(script, /KNOWN FAMILY DEVIATION/)
+  assert.match(script, /RUN LOG — deterministic digest keys/)
+  assert.match(runbook, /family deviation/i)
+  assert.match(runbook, /deterministic/i)
+  assert.match(script, /deterministic-key collision/i, 'same-day rerun collision is guarded at preflight')
+  assert.equal('rd45-smoke-'.length, 11, 'window-bundle §7 residue SQL slices left(...,11)')
+  assert.match(bundle, /left\(user_id, 11\) = 'rd45-smoke-'/)
+  assert.match(bundle, /org_id = :rd45_smoke_org/)
+})
+
+test('rd45 helper residue triple-check covers every table the smoke can dirty; settings row is restored, never deleted', () => {
+  assert.deepEqual(RESIDUE_TABLES, ['attendance_notification_deliveries', 'user_orgs', 'users'])
+  for (const table of RESIDUE_TABLES) {
+    assert.match(script, new RegExp(`to_regclass\\('public\\.${table}'\\)`), `${table} is preflighted`)
+    assert.match(script, new RegExp(`FROM ${table}`), `${table} is counted`)
+    assert.match(script, new RegExp(`DELETE FROM ${table}`), `${table} is cleaned`)
+  }
+  assert.match(script, /to_regclass\('public\.system_configs'\)/, 'settings storage is preflighted')
+  assert.doesNotMatch(script, /DELETE FROM system_configs/, 'settings are restored via PUT, never deleted')
+  // this smoke writes no other attendance business rows
+  assert.doesNotMatch(script, /DELETE FROM attendance_records/)
+  assert.doesNotMatch(script, /DELETE FROM attendance_requests/)
+})
+
+test('rd45 helper cleanup is stamped/prefix-scoped, LIKE-free, and restores settings BEFORE deleting rows (re-insert trap)', () => {
+  assert.match(script, /STAMP must match \/\^rd45-smoke-\[A-Za-z0-9-\]\+\$\//)
+  assert.doesNotMatch(script, /LIKE '%/)
+  assert.doesNotMatch(script, /source_key LIKE/)
+  const restoreCall = script.indexOf('await restoreSettings({ strict: strictSettingsRestore })')
+  const deliveriesDelete = script.indexOf('DELETE FROM attendance_notification_deliveries')
+  assert.ok(restoreCall !== -1 && deliveriesDelete !== -1 && restoreCall < deliveriesDelete,
+    'policy restore/disable must precede row deletion or the still-open period is re-inserted on the next producer run')
+  assert.match(script, /DELETE FROM attendance_notification_deliveries WHERE org_id = \$1 AND source_type = \$2 AND left\(source_key, \$3\) = \$4/,
+    'the default-org variant deletes ONLY by deterministic source_key prefix, never org-wide')
+})
+
+test('rd45 helper keeps the three env gate layers distinct: producer gate set process-locally for the seam, send gate never touched', () => {
+  assert.match(script, /process\.env\.ATTENDANCE_REPORT_DIGEST_ENABLED = 'true'/, 'seam track enables the producer gate in the helper process only')
+  assert.doesNotMatch(script, /ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED/, 'the helper never reads or writes the send gate (backend env is operator-owned)')
+  assert.doesNotMatch(script, /process\.env\.ATTENDANCE_SCHEDULER_ENABLED\s*=/, 'the helper never mutates the backend process gate')
+  assert.match(script, /default-org leakage/i, 'seam track asserts the globally-shared policy did not fan out on the backend')
+  for (const name of ['ATTENDANCE_REPORT_DIGEST_ENABLED', 'ATTENDANCE_SCHEDULER_ENABLED', 'ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED', 'ATTENDANCE_SCHEDULER_INTERVAL_MS']) {
+    assert.match(runbook, new RegExp(name), `runbook documents ${name}`)
+  }
+  assert.match(runbook, /one FULL interval/i, 'first-tick-after-boot timing is documented explicitly')
+  assert.match(runbook, /single-member/i, 'window-plan single-member smoke-org rule is stated')
+  assert.match(runbook, /OQ-/, 'open questions are explicit blocks, not silent gaps')
+})
+
+test('rd45 constants match the verified producer facts', () => {
+  assert.equal(DIGEST_SOURCE_TYPE, 'attendance_report_digest')
+  assert.equal(DIGEST_CADENCE, 'daily')
+  assert.equal(DEFAULT_ORG_ID, 'default')
+  assert.deepEqual(DELIVERY_CHANNEL_ALLOWLIST, ['dingtalk_work_notification', 'email_smtp'])
+  assert.match(script, /ON CONFLICT \(org_id, source_key\) DO NOTHING/, 'dedup mechanism named where the replay assertion is made')
+  assert.match(script, /status IN \('pending', 'retrying'\) AND next_attempt_at <= now\(\)/, 'global worker-claim visibility check uses the worker claim shape')
+})


### PR DESCRIPTION
## Why

The owner approved bundling the three prepared-but-unrun staging smokes — **AE-4** (anomaly-result-edit closeout, runbook already on main), **RD-4/5** (report-digest producer/worker), and **OT-bank v1-8** (三例验收 + settlement) — into ONE staging deploy window: one `DEPLOY_SHA`, one shared preflight, three independent PASS stamps. RD-4/5 and v1-8 had no runbooks or helpers; this PR authors them in the established `scripts/ops/staging-attendance-*-smoke.mjs` family style (NS4-TA4 is the bundled-window precedent) plus a unified window plan.

Docs + ops scripts only — no runtime/product code, no migrations, no CI changes.

## What (7 new files, +3823)

**Unified window plan** — `docs/development/attendance-staging-window-bundle-20260702.md`: order AE-4 → RD-4/5 → v1-8 with rationale; shared preflight once (health/deploy-SHA/migration alignment/auth round-trip); per-smoke stamp isolation (`ae4-smoke-` / `rd45-smoke-` / `otbank-v18-smoke-`, mutually exclusive by construction); deep-merge-aware settings restore verified before the next smoke; per-smoke PASS/FAIL independence; consolidated final residue sweep; closure checklist (incl. closing umbrella #3317 with the AE-4 stamp).

**RD-4/5 set** — runbook + `staging-attendance-report-digest-rd45-smoke.mjs` + contract tests (**14/14**):
- PRIMARY track = deterministic in-process invocation of the shipped `__attendanceReportDigestForTests.runAttendanceReportDigestOnce` seam (index.cjs:15026) on a **disposable single-member smoke org** — required because the real scheduler job is hardwired to the default org and fans out to ALL active members.
- Key safety finding encoded: the digest policy is a single GLOBAL settings row, so the backend's `ATTENDANCE_REPORT_DIGEST_ENABLED` **stays UNSET for the whole window** (the helper enables it process-locally around the seam call and asserts a no-default-org-leakage guard). The window plan §3.4 was amended to match.
- Owner-gated Track B variant (real scheduler tick on default org) boxed behind `ACK_DEFAULT_ORG_FANOUT=1` + hard worker-off; explicitly NOT required for the PASS stamp.
- The deterministic (non-stamped) digest source_key family deviation is loudly documented with worksheet-captured keys and collision guards.

**OT-bank v1-8 set** — runbook + `staging-attendance-overtime-bank-v18-smoke.mjs` + contract tests (**9/9**): replays the v1-5b-iii must-pay choreography (#3255/#3303 lineage) through the deployed API; settlement/lot assertions via SQL (no API read surface yet — recorded as an OQ/owner decision); fail-closed synthetic-population guard on cycle close (dangerous override env is explicit); strict settings restore re-asserting all five money-path keys; far-future collision-free window (SMOKE_YEAR bounds documented).

All runbooks carry `Status: PREPARED` and claim NO staging PASS; each records genuine host-side open questions (token mint path, seam locus `pg`/`NODE_PATH` caveat, live env-flag state, instance topology) instead of inventing answers.

## Verification

- Built via a Read→Build→Verify agent workflow with independent adversarial verification against origin/main: seam signature + db-adapter shape (byte-equivalent to the RD-3 harness), every route/env/settings-key/table/error-string claim checked at file:line, org-independence of admin tokens confirmed in code (withPermission has no org binding; getOrgId honors ?orgId), doc-parity between the window plan, both new runbooks, and the existing AE-4 runbook. Final verdict: PASS, no P1; all P2/P3 findings fixed in this PR.
- `node --check` both helpers: OK. `node --test`: RD 14/14, v18 9/9 (contract tests on pure functions — stamp regex locks, period math incl. leap boundary, deep-merge restore bodies, residue-table triple-check incl. `attendance_events`, LIKE-free stamped cleanup, FK-safe delete ordering, PASS-line shape).
- Note: `scripts/ops/*.test.mjs` are run manually per family convention (none are CI-registered, same as the AE-4 helper's tests) — flagged, not changed here.

## After merge

The window is turnkey pending operator scheduling: deploy one main SHA to staging, run the three runbooks in order (AE-4 includes the mandatory manual AE-3 modal browser step), record three PASS stamps + residue=0, close #3317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)