### PR TITLE
fix(multitable): tolerate missing member group table for record permissions

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7550,37 +7550,70 @@ export function univerMetaRouter(): Router {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
       }
 
-      const result = await pool.query(
-        `SELECT
-            rp.id,
-            rp.sheet_id,
-            rp.record_id,
-            rp.subject_type,
-            rp.subject_id,
-            rp.access_level,
-            rp.created_at,
-            rp.created_by,
-            u.name AS user_name,
-            u.email AS user_email,
-            u.is_active AS user_is_active,
-            r.name AS role_name,
-            r.description AS role_description,
-            g.name AS group_name,
-            g.description AS group_description
-         FROM record_permissions rp
-         LEFT JOIN users u
-           ON rp.subject_type = 'user'
-          AND u.id = rp.subject_id
-         LEFT JOIN roles r
-           ON rp.subject_type = 'role'
-          AND r.id::text = rp.subject_id
-         LEFT JOIN platform_member_groups g
-           ON rp.subject_type = 'member-group'
-          AND g.id::text = rp.subject_id
-         WHERE rp.sheet_id = $1 AND rp.record_id = $2
-         ORDER BY rp.created_at ASC`,
-        [sheetId, recordId],
-      )
+      let result: { rows: any[] }
+      try {
+        result = await pool.query(
+          `SELECT
+              rp.id,
+              rp.sheet_id,
+              rp.record_id,
+              rp.subject_type,
+              rp.subject_id,
+              rp.access_level,
+              rp.created_at,
+              rp.created_by,
+              u.name AS user_name,
+              u.email AS user_email,
+              u.is_active AS user_is_active,
+              r.name AS role_name,
+              r.description AS role_description,
+              g.name AS group_name,
+              g.description AS group_description
+           FROM record_permissions rp
+           LEFT JOIN users u
+             ON rp.subject_type = 'user'
+            AND u.id = rp.subject_id
+           LEFT JOIN roles r
+             ON rp.subject_type = 'role'
+            AND r.id::text = rp.subject_id
+           LEFT JOIN platform_member_groups g
+             ON rp.subject_type = 'member-group'
+            AND g.id::text = rp.subject_id
+           WHERE rp.sheet_id = $1 AND rp.record_id = $2
+           ORDER BY rp.created_at ASC`,
+          [sheetId, recordId],
+        )
+      } catch (err) {
+        if (!isUndefinedTableError(err, 'platform_member_groups')) throw err
+        result = await pool.query(
+          `SELECT
+              rp.id,
+              rp.sheet_id,
+              rp.record_id,
+              rp.subject_type,
+              rp.subject_id,
+              rp.access_level,
+              rp.created_at,
+              rp.created_by,
+              u.name AS user_name,
+              u.email AS user_email,
+              u.is_active AS user_is_active,
+              r.name AS role_name,
+              r.description AS role_description,
+              NULL::text AS group_name,
+              NULL::text AS group_description
+           FROM record_permissions rp
+           LEFT JOIN users u
+             ON rp.subject_type = 'user'
+            AND u.id = rp.subject_id
+           LEFT JOIN roles r
+             ON rp.subject_type = 'role'
+            AND r.id::text = rp.subject_id
+           WHERE rp.sheet_id = $1 AND rp.record_id = $2
+           ORDER BY rp.created_at ASC`,
+          [sheetId, recordId],
+        )
+      }
       const items = (result.rows as any[]).map((row) => ({
         id: String(row.id),
         sheetId: String(row.sheet_id),

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -3189,4 +3189,43 @@ describe('Multitable sheet-scoped permissions API', () => {
     expect(String(viewPermissionCalls[0]?.[0])).toContain('LEFT JOIN platform_member_groups g')
     expect(String(viewPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
   })
+
+  test('lists record permissions when the optional member-group directory table is absent', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('SELECT id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+          expect(params).toEqual(['record_1', 'sheet_ops'])
+          return { rows: [{ id: 'record_1' }] }
+        }
+        if (sql.includes('FROM record_permissions rp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          throw undefinedTableError('platform_member_groups')
+        }
+        if (sql.includes('FROM record_permissions rp') && !sql.includes('LEFT JOIN platform_member_groups g')) {
+          expect(params).toEqual(['sheet_ops', 'record_1'])
+          return { rows: [] }
+        }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/records/record_1/permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([])
+    const recordPermissionCalls = mockPool.query.mock.calls.filter(([sql]) => String(sql).includes('FROM record_permissions rp'))
+    expect(recordPermissionCalls).toHaveLength(2)
+    expect(String(recordPermissionCalls[0]?.[0])).toContain('LEFT JOIN platform_member_groups g')
+    expect(String(recordPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
+  })
 })


### PR DESCRIPTION
## Summary

- add the same optional `platform_member_groups` fallback to the record-permissions list endpoint that view/field permission lists already have
- keep member-group labels best-effort: if the optional directory table is absent, the endpoint still returns permission rows with null group label/subtitle instead of 500
- add a focused route test for the missing-table fallback path

## Why

#3408/#3426 continue to report permission-list 500s on the entity environment. Current main already has this fallback for view and field permission lists, but record permissions still joined `platform_member_groups` without the same retry path. This closes that asymmetric backend gap.

This PR does not claim to fix the formula echo/materialization failures in #3408/#3426; current main still needs separate deployment/evidence alignment for that path.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts -t "lists record permissions when the optional member-group directory table is absent" --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `git diff --check`

Note: the full `multitable-sheet-permissions.api.test.ts` file currently has unrelated mock-harness failures on existing tests after recent SQL additions; the new focused fallback case passes.
