### PR TITLE
docs(approval): as-built reconcile — second-batch T1-2 #3489 + T2-1+2 #3490 shipped

### DIFF
--- a/docs/development/approval-automation-parallel-development-plan-20260701.md
+++ b/docs/development/approval-automation-parallel-development-plan-20260701.md
@@ -1,7 +1,9 @@
 # Approval & Process-Automation — un-completed items, parallel-development plan & verification (2026-07-01)
 
 > **As-built coordination plan** (updated to main after `#3451`/`#3452`/`#3450`/`#3453`, the A3-a/b slices
-> `#3455`/`#3457`/`#3460`, and the first-batch runtime `#3467`/`#3468`/`#3474`/`#3477` merged). Deep review of what
+> `#3455`/`#3457`/`#3460`, the first-batch runtime `#3467`/`#3468`/`#3474`/`#3477`, the second-batch
+> runtime `#3489` T1-2 inbound webhook + `#3490` T2-1+2 scoped-admin handover, and UI exposure
+> `#3495` merged). Deep review of what
 > remains on the line, classified by gating and **sequenced into parallel lanes** so work distributes across
 > sessions without hot-file collision. **Shipped since the first cut:** T2-4 re-entry quorum-bypass (`#3446`,
 > `to_version >= cutoff`) + same-version cascade regression (`#3453`), R1-A/R1-B egress closure (`#3437`/`#3443`/
@@ -31,6 +33,12 @@
 - **First-batch runtime — SHIPPED:** `approval.completed` automation trigger (`#3467`), T1-1 slice-2 timeout
   transfer/jump effects (`#3468`), W7 non-approved result writeback (`#3474`), and safe delete_record editor
   exposure (`#3477`) are all on main on the ballot defaults.
+- **Second-batch runtime (partial) — SHIPPED:** T1-2 signed inbound webhook trigger (`#3489`) and T2-1+2
+  scoped approval admins + handover/bulk reassign (`#3490`, incl. the `reassign` action CHECK migration +
+  admin-scope permission codes). The second-batch ballot's remaining rungs (T3-5, T1-4) are still open.
+- **Automation rule-editor UI exposure — SHIPPED (`#3495`):** `approval.completed` and `webhook.received`
+  are visible in the rule editor with the UI type/label/config surface. This is a UI exposure close-out for
+  already-shipped triggers, not a new ballot rung.
 
 ## 2. Un-completed items — gating
 
@@ -42,12 +50,12 @@
 | ~~R1-B DNS-pinned dispatcher + wiring + redirect re-validation~~ | BPMN/workflow | **SHIPPED (#3447/#3451)** | done — raw BPMN HTTP-task fetch path replaced; default policy deny-all |
 | **R1-A3** configured destination enablement | BPMN/workflow | **runtime SHIPPED** (#3455/#3457/#3460), destinations not yet authorized | governance-only remainder: `#3460` injects the server-owned `BPMN_HTTP_TASK_EGRESS_POLICY` env policy at both BPMN route construction points; `#3455` normalizer + `#3457` route-provenance locks are in. **No core runtime code left** — what remains is authorizing/configuring the first live destination (ops/governance per `#3452`), default stays deny-all |
 | ~~T1-1 slice-2 transfer/jump timeout effects~~ | approval engine | **SHIPPED (#3468)** | done — transfer/jump wired; auto_* terminal effects remain env-gated/inert |
-| T2-1+2 scoped admins + handover | approval engine | unshipped | owner-gated (permission model + migration) |
+| ~~T2-1+2 scoped admins + handover~~ | approval engine | **SHIPPED (#3490)** | done — admin-scope capability codes + `reassign` bulk handover + CHECK/grant migration |
 | T1-4 node field-perms runtime | approval engine | unshipped | owner-gated (edit-form-at-node prerequisite) |
 | ~~T3-4 W7 rejection backwrite~~ | automation/approval | **SHIPPED (#3474)** | done — opt-in non-approved writeback, write-back-then-fail |
 | T3-5 W7 cross-base backwrite | automation/approval | unshipped | owner-gated (cross-base write-gate re-lock) |
 | ~~T0-3 delete_record editor~~ | automation engine | **SHIPPED (#3477)** | done — same-base trigger-record only, ack-gated editor, save-gate hardening |
-| T1-2 inbound webhook | automation engine | unshipped | owner-gated (signature/replay/audit, 9 decisions) |
+| ~~T1-2 inbound webhook~~ | automation engine | **SHIPPED (#3489)** | done — signed (HMAC + timestamp window) inbound trigger, fail-closed secret, uniform reject oracle |
 | ~~T1-3 approval.* trigger~~ | automation engine | **SHIPPED (#3467)** | done — template-routed, record-less v1, T2-6 ledger reuse, permission recheck |
 | ~~T2-6 event-driven dedup ledger~~ | automation engine | **SHIPPED (#3450)** | done — database-backed event fire ledger, sweep, real-DB CI wiring |
 | T3-2 business-calendar SLA · T3-3 signature · T3-1 mobile · T3-6 S-band | product/heavy | unshipped | owner-gated, L (T3-2 dep T1-1) |
@@ -65,12 +73,14 @@ edits to `ApprovalProductService.ts` / `automation-service.ts` collide).
   is **destination authorization** — a config/ops governance act per `#3452`, not code. Default stays deny-all
   until a first named destination is explicitly authorized.
 - **Lane B — approval engine** (`ApprovalProductService.ts` — HOT, so sequential): ~~`T2-4 fix`~~ **done (#3446)**
-  + cascade regression **done (#3453)** + `T1-1 slice-2` **done (#3468)** → next `T2-1+2` → `T1-4`. (`T3-5`
-  W7 cross-base backwrite touches
+  + cascade regression **done (#3453)** + `T1-1 slice-2` **done (#3468)** + `T2-1+2` **done (#3490)** →
+  next `T1-4` field-permissions authoring (awaiting its ballot votes). (`T3-5` W7 cross-base backwrite touches
   `automation-service.ts`, see Lane C.)
 - **Lane C — automation engine** (`automation-service.ts` — HOT, so sequential): ~~`T2-6 dedup`~~ **done (#3450)** →
   `T1-3 approval-trigger` **done (#3467)** → `T3-4` **done (#3474)** → `T0-3 delete_record` **done (#3477)** →
-  next `T1-2 inbound webhook` / `T3-5` W7 cross-base backwrite.
+  `T1-2 inbound webhook` **done (#3489)** → next `T3-5` W7 cross-base backwrite — **owner steer 2026-07-02:
+  design-lock-first as its own slice** (permission/lock/audit surface is heavy; do NOT fold it into the
+  fast demo layer).
 - **Lane D — product/heavy** (separate surfaces): `T3-1 mobile`, `T3-6 S-band`, `T3-2 business-calendar`
   (dep T1-1), `T3-3 signature`.
 
@@ -82,14 +92,18 @@ double-editing.
 ## 4. What's ready to build vs needs a decision
 - **Shipped:** T2-4 fix (#3446) + same-version cascade regression (#3453) · R1-A/R1-B default-closed egress closure
   (#3437/#3443/#3447/#3451) · T2-6 event dedup ledger (#3450) · approval.completed trigger (#3467) ·
-  T1-1 timeout transfer/jump effects (#3468) · W7 non-approved writeback (#3474) · delete_record editor (#3477).
-- **Owner-gated:** the remaining rungs — including A3 configured destination enablement, T1-2 inbound webhook,
-  T3-5 W7 cross-base, T2-1+2 scoped admins/handover, T1-4 field-perms, and product/heavy items. The register (#3385) and the
-  follow-up design-locks hold each rung's open decisions + proposed defaults.
-  **Approve per lane/rung, not blanket** — the remainder mixes distinct risk surfaces (SSRF wiring, destructive
-  delete, permission migration, cross-base write-back), so a single blanket "build on defaults" is unsafe.
+  T1-1 timeout transfer/jump effects (#3468) · W7 non-approved writeback (#3474) · delete_record editor (#3477) ·
+  T1-2 signed inbound webhook (#3489) · T2-1+2 scoped admins + handover (#3490) · rule-editor exposure for
+  `approval.completed` + `webhook.received` (#3495).
+- **Owner-gated:** the remaining rungs — A3 configured destination enablement (governance-only),
+  T3-5 W7 cross-base (**design-lock-first per owner steer 2026-07-02**), T1-4 field-perms authoring, and the
+  product/heavy items. The register (#3385) and the follow-up design-locks hold each rung's open decisions +
+  proposed defaults.
+  **Approve per lane/rung, not blanket** — the remainder mixes distinct risk surfaces (permission migration,
+  cross-base write-back, product semantics), so a single blanket "build on defaults" is unsafe.
   The next executable implementation decision surface is `approval-automation-second-batch-ballot-20260702.md`
-  (T1-2, T3-5, T2-1+2, T1-4). The product/governance-heavy tail is separated into
+  — now **partially executed** (T1-2 `#3489` + T2-1+2 `#3490` shipped; T3-5 + T1-4 still awaiting votes).
+  The product/governance-heavy tail is separated into
   `approval-automation-third-batch-ballot-20260702.md` (A3 destination authorization, T3-2, T3-3,
   T3-1, T3-6) so strategic decisions do not get mistaken for ready implementation queue.
 
@@ -138,13 +152,16 @@ coverage wired into `plugin-tests.yml`, plus regression updates for record-servi
 
 ## 7. Recommendation
 1. **Done:** T2-4 fix + cascade regression (#3446/#3453) · R1-A/R1-B default-closed egress closure
-   (#3437/#3443/#3447/#3451) · T2-6 dedup ledger (#3450) · first-batch runtime (#3467/#3468/#3474/#3477).
+   (#3437/#3443/#3447/#3451) · T2-6 dedup ledger (#3450) · first-batch runtime (#3467/#3468/#3474/#3477) ·
+   second-batch runtime partial (#3489 T1-2 · #3490 T2-1+2).
 2. **A3 is now governance-only:** the egress policy runtime is fully shipped (`#3452` design-lock +
    `#3455`/`#3457`/`#3460` normalizer / provenance locks / server-owned env injection). Default remains deny-all;
    the remaining act is **authorizing the first live destination** (config/ops), which happens when a named
    integration needs it — no code slice to schedule.
-3. **Next feature lanes after owner ratification:** Lane C `T1-2 inbound webhook` or `T3-5` W7 cross-base
-   writeback; Lane B `T2-1+2` scoped admins/handover or `T1-4` field-perms. Continue to ratify
+3. **Next feature lanes after owner ratification:** Lane C `T3-5` W7 cross-base writeback
+   (design-lock-first per owner steer 2026-07-02); Lane B `T1-4` field-perms authoring. The **UI-exposure
+   close-out is done** (`#3495`: approval.completed + webhook.received in the automation rule editor), so it
+   is no longer a next-lane item. Continue to ratify
    register defaults **per lane/rung**, not blanket — the first-batch per-rung ballot now lives as the shipped
    decision record in `approval-automation-first-batch-ballot-20260701.md`; the second-batch ballot is
    `approval-automation-second-batch-ballot-20260702.md`; the third-batch strategic/governance ballot is

--- a/docs/development/approval-automation-second-batch-ballot-20260702.md
+++ b/docs/development/approval-automation-second-batch-ballot-20260702.md
@@ -1,10 +1,12 @@
 # Approval & Process-Automation — second-batch per-rung decision ballot (2026-07-02)
 
-> **Status: PROPOSED — awaiting per-rung owner votes.** This ballot authorizes nothing by itself. It exists
-> to turn the remaining owner-gated queue into explicit, reviewable decisions after the first batch shipped
-> (`#3467`/`#3468`/`#3474`/`#3477`). Vote per line: ✅ adopt default · ✏️ override (state the change) ·
-> ⏸ hold. A rung with every line ✅/✏️ becomes GO for design-lock-first implementation; an unvoted rung
-> remains gated.
+> **Status: PARTIALLY EXECUTED (as-built reconcile 2026-07-02).** T1-2 and T2-1+2 were voted GO on the
+> proposed defaults and are **SHIPPED**: T1-2 signed inbound webhook `#3489` (`fadf1695e`), T2-1+2 scoped
+> admins + handover `#3490` (`2ebb8dd81`) — their tables below are the closed decision record. **Still
+> awaiting per-rung owner votes: T3-5 and T1-4.** For those, vote per line: ✅ adopt default · ✏️ override
+> (state the change) · ⏸ hold; a rung with every line ✅/✏️ becomes GO for design-lock-first implementation;
+> an unvoted rung remains gated. Owner steer 2026-07-02: **T3-5 runs design-lock-first as its own slice**
+> (permission/lock/audit surface is heavy — not part of the fast demo layer).
 >
 > Source of truth for the defaults is `approval-automation-decision-register-20260629.md`, with reviewer
 > notes folded into the "build contract" blocks below so implementation does not repeat known blind spots.
@@ -19,22 +21,24 @@
 
 | Lane | Order | Why |
 |---|---|---|
-| C — automation engine (`automation-service.ts`) | `T1-2 inbound webhook` → `T3-5 W7 cross-base backwrite` | Both touch automation runtime and security gates; keep sequential to avoid hot-file collisions. |
-| B — approval engine / authoring | `T2-1+2 scoped admins + handover` → `T1-4 field permissions` | Permission/handover is the larger admin model slice; field-permission authoring stays bounded and does not unlock edit-form-at-node. |
+| C — automation engine (`automation-service.ts`) | ~~`T1-2 inbound webhook`~~ **done #3489** → `T3-5 W7 cross-base backwrite` (design-lock-first) | Both touch automation runtime and security gates; keep sequential to avoid hot-file collisions. |
+| B — approval engine / authoring | ~~`T2-1+2 scoped admins + handover`~~ **done #3490** → `T1-4 field permissions` | Permission/handover is the larger admin model slice; field-permission authoring stays bounded and does not unlock edit-form-at-node. |
 
 ## T1-2 — inbound webhook endpoint (signed, audited) · M · Lane C first
 
+> **SHIPPED `#3489` (`fadf1695e`)** on the defaults below — closed decision record, not an open vote.
+
 | # | Decision | Proposed default | Vote |
 |---|---|---|---|
-| Q1 | Signature scheme | HMAC-SHA256 over `"${unixSeconds}.${rawBody}"`; header `X-MS-Webhook-Signature: sha256=<hex>` plus `X-MS-Webhook-Timestamp`; compare with `timingSafeEqual`. This intentionally differs from outbound body-only signing so timestamp replay is bound. | ⬜ |
-| Q2 | Secret-less rules | Fail-closed: unsigned / secret-less inbound rules are not ingestable; enforce non-empty secret at create/update for `webhook.received`. Existing secret-less rules are blocked on edit and return uniform reject at ingest. | ⬜ |
-| Q3 | Reject oracle | Uniform `401 { ok: false }` for unknown rule, wrong trigger type, disabled rule, missing secret, stale timestamp, and bad signature. No existence/enabled-state oracle. | ⬜ |
-| Q4 | Replay defense | Signed timestamp with ±300s freshness window. No nonce/dedup table in v1; residual in-window replay risk documented. | ⬜ |
-| Q5 | Dispatch authority | Execute userless under `rule.created_by`, same as scheduled triggers. The rule author's authority is the authority for side effects. | ⬜ |
-| Q6 | Secret at rest | Plaintext parity with outbound webhook secret in `trigger_config` for v1; any read API that exposes trigger config must redact the secret. Encryption-at-rest deferred. | ⬜ |
-| Q7 | Rejected-attempt observability | Accepted requests use existing redacted `AutomationExecution`; rejected attempts get structured security logs + `automation_webhook_rejected_total{reason}` metric. No new audit table. | ⬜ |
-| Q8 | Dispatch timing | Synchronous inline dispatch, returning 202 after executor completion. No queue in v1. | ⬜ |
-| Q9 | Rate/body limits | Per-rule rate limit via existing `RateLimitStore` (default 60/min/rule) and 1 MB body cap on the inbound path. | ⬜ |
+| Q1 | Signature scheme | HMAC-SHA256 over `"${unixSeconds}.${rawBody}"`; header `X-MS-Webhook-Signature: sha256=<hex>` plus `X-MS-Webhook-Timestamp`; compare with `timingSafeEqual`. This intentionally differs from outbound body-only signing so timestamp replay is bound. | ✅ SHIPPED #3489 |
+| Q2 | Secret-less rules | Fail-closed: unsigned / secret-less inbound rules are not ingestable; enforce non-empty secret at create/update for `webhook.received`. Existing secret-less rules are blocked on edit and return uniform reject at ingest. | ✅ SHIPPED #3489 |
+| Q3 | Reject oracle | Uniform `401 { ok: false }` for unknown rule, wrong trigger type, disabled rule, missing secret, stale timestamp, and bad signature. No existence/enabled-state oracle. | ✅ SHIPPED #3489 |
+| Q4 | Replay defense | Signed timestamp with ±300s freshness window. No nonce/dedup table in v1; residual in-window replay risk documented. | ✅ SHIPPED #3489 |
+| Q5 | Dispatch authority | Execute userless under `rule.created_by`, same as scheduled triggers. The rule author's authority is the authority for side effects. | ✅ SHIPPED #3489 |
+| Q6 | Secret at rest | Plaintext parity with outbound webhook secret in `trigger_config` for v1; any read API that exposes trigger config must redact the secret. Encryption-at-rest deferred. | ✅ SHIPPED #3489 |
+| Q7 | Rejected-attempt observability | Accepted requests use existing redacted `AutomationExecution`; rejected attempts get structured security logs + `automation_webhook_rejected_total{reason}` metric. No new audit table. | ✅ SHIPPED #3489 |
+| Q8 | Dispatch timing | Synchronous inline dispatch, returning 202 after executor completion. No queue in v1. | ✅ SHIPPED #3489 |
+| Q9 | Rate/body limits | Per-rule rate limit via existing `RateLimitStore` (default 60/min/rule) and 1 MB body cap on the inbound path. | ✅ SHIPPED #3489 |
 
 **Build contract / reviewer-note must-fixes**
 
@@ -65,18 +69,20 @@
 
 ## T2-1+2 — scoped approval admins + handover/bulk reassign · L · Lane B first
 
+> **SHIPPED `#3490` (`2ebb8dd81`)** on the defaults below — closed decision record, not an open vote.
+
 | # | Decision | Proposed default | Vote |
 |---|---|---|---|
-| Q1 | Meaning of "scoped" | Capability split only. Add global capability codes for template admin, process/recovery admin, and data-recovery admin. Department/category/template-set data scoping is deferred. | ⬜ |
-| Q2 | Who may reassign and to whom | Process/recovery scope (`approvals:admin`) may reassign active user-typed assignments. Target must not be requester and must not already be an active assignee at the node. Full audit required. | ⬜ |
-| Q3 | Permission-code naming | Keep codes under non-namespaced `approvals`: `approvals:admin`, `approvals:admin-templates`, `approvals:admin-data`. Accept `approvals:*` wildcard granting all three. Fix `APPROVAL_PRODUCT_PERMISSIONS` drift in the same change. | ⬜ |
-| Q4 | Batch atomicity | Per-instance transactions, best-effort manifest `{ succeeded, skipped }`. Re-run skips no-longer-assigned instances; no batch dedup table. | ⬜ |
-| Q5 | Source set and cap | Caller may pass explicit `instanceIds`; if omitted, enumerate active user assignments for `fromUserId`, tenant/platform-scoped, excluding role-typed assignments, capped at 200. | ⬜ |
-| Q6 | Audit action + version | Add new `reassign` audit action via CHECK migration; bump `approval_instances.version` per affected instance. Do not reuse `transfer` because revoke-window semantics count transfer as handled. | ⬜ |
-| Q7 | Multi-node / parallel handling | Reassign all active user-typed assignments for the source user across every node/branch in each selected instance; one audit row per `(instance,node)`. | ⬜ |
-| Q8 | Literal swap vs re-resolution | Literal swap to a static user assignment. Drop dynamic/delegation metadata intentionally; stamp `metadata.reassignedFrom` and `metadata.adminReassign=true`. | ⬜ |
-| Q9 | Notifications/events | Refresh counts for source user, target user, and affected requesters; emit `approval.bulk_reassigned` with the manifest. | ⬜ |
-| Q10 | Grants and down migration | Grant new codes to `admin` role in `up()`. `down()` removes role grants/permissions and restores the action CHECK using the established NOT VALID pattern. | ⬜ |
+| Q1 | Meaning of "scoped" | Capability split only. Add global capability codes for template admin, process/recovery admin, and data-recovery admin. Department/category/template-set data scoping is deferred. | ✅ SHIPPED #3490 |
+| Q2 | Who may reassign and to whom | Process/recovery scope (`approvals:admin`) may reassign active user-typed assignments. Target must not be requester and must not already be an active assignee at the node. Full audit required. | ✅ SHIPPED #3490 |
+| Q3 | Permission-code naming | Keep codes under non-namespaced `approvals`: `approvals:admin`, `approvals:admin-templates`, `approvals:admin-data`. Accept `approvals:*` wildcard granting all three. Fix `APPROVAL_PRODUCT_PERMISSIONS` drift in the same change. | ✅ SHIPPED #3490 |
+| Q4 | Batch atomicity | Per-instance transactions, best-effort manifest `{ succeeded, skipped }`. Re-run skips no-longer-assigned instances; no batch dedup table. | ✅ SHIPPED #3490 |
+| Q5 | Source set and cap | Caller may pass explicit `instanceIds`; if omitted, enumerate active user assignments for `fromUserId`, tenant/platform-scoped, excluding role-typed assignments, capped at 200. | ✅ SHIPPED #3490 |
+| Q6 | Audit action + version | Add new `reassign` audit action via CHECK migration; bump `approval_instances.version` per affected instance. Do not reuse `transfer` because revoke-window semantics count transfer as handled. | ✅ SHIPPED #3490 |
+| Q7 | Multi-node / parallel handling | Reassign all active user-typed assignments for the source user across every node/branch in each selected instance; one audit row per `(instance,node)`. | ✅ SHIPPED #3490 |
+| Q8 | Literal swap vs re-resolution | Literal swap to a static user assignment. Drop dynamic/delegation metadata intentionally; stamp `metadata.reassignedFrom` and `metadata.adminReassign=true`. | ✅ SHIPPED #3490 |
+| Q9 | Notifications/events | Refresh counts for source user, target user, and affected requesters; emit `approval.bulk_reassigned` with the manifest. | ✅ SHIPPED #3490 |
+| Q10 | Grants and down migration | Grant new codes to `admin` role in `up()`. `down()` removes role grants/permissions and restores the action CHECK using the established NOT VALID pattern. | ✅ SHIPPED #3490 |
 
 **Build contract / reviewer-note must-fixes**
 
@@ -86,6 +92,11 @@
 - Route guards must prove the split has an enforcement surface, not just new permission rows.
 
 ## T1-4 — node field-permissions authoring · M · Lane B after T2-1+2
+
+> **OPEN — awaiting votes.** Owner steer 2026-07-02: start with the hidden/readonly *configurable authoring
+> surface* and do NOT take on the full runtime semantics in one slice — reconcile this with Q2's
+> hidden-only-exposure default at vote time (either ✏️ Q2 to include a readonly control, or ✅ keep
+> hidden-only UI with readonly persisted-but-unexposed).
 
 | # | Decision | Proposed default | Vote |
 |---|---|---|---|


### PR DESCRIPTION
Step 1 of the owner-reviewed next batch: fix the map before new plans depart from it.

- **Plan doc**: header/§1/§2/§3/§4/§7 now record T1-2 (`#3489`) and T2-1+2 (`#3490`) as SHIPPED; Lane B next = T1-4 (awaiting votes), Lane C next = T3-5 (**design-lock-first per owner steer 2026-07-02**). It also records the now-shipped UI exposure slice (`#3495`) for `approval.completed` + `webhook.received` in the rule editor, so those triggers are no longer documented as API-only.
- **Second ballot**: header → **PARTIALLY EXECUTED**; the two shipped rungs' 19 vote cells closed as decision record (`✅ SHIPPED #PR`), SHIPPED banners under both rung headings; **only T3-5 + T1-4 remain open votes** (9 cells). T1-4 carries the owner-steer note (hidden/readonly configurable authoring surface first; reconcile with Q2's hidden-only default at vote time).

Docs-only; no runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)