### PR TITLE
fix(multitable): parse generated formula field ids

### DIFF
--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -11,8 +11,8 @@ import { Logger } from '../core/logger'
 
 const logger = new Logger('MultitableFormulaEngine')
 
-/** Regex matching multitable field references like {fld_abc123} */
-const FIELD_REF_PATTERN = /\{(fld_[a-zA-Z0-9_]+)\}/g
+/** Regex matching multitable field references like {fld_abc123} or API-generated {fld_<uuid-with-dashes>}. */
+const FIELD_REF_PATTERN = /\{(fld_[a-zA-Z0-9_-]+)\}/g
 
 /** Dry-run (#5a / design #1860): diagnostics + result for an UNSAVED formula expression. */
 export type DryRunDiagnosticKind = 'unknown_field' | 'unsupported' | 'runtime' | 'type_mismatch' | 'missing_sample'

--- a/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
@@ -183,6 +183,13 @@ describe('MultitableFormulaEngine', () => {
       expect(refs).toEqual(['fld_a'])
     })
 
+    it('extracts API-generated UUID field IDs containing hyphens', () => {
+      const refs = mtEngine.extractFieldReferences(
+        '={fld_01234567-89ab-cdef-0123-456789abcdef}+{fld_price}',
+      )
+      expect(refs).toEqual(['fld_01234567-89ab-cdef-0123-456789abcdef', 'fld_price'])
+    })
+
     it('returns empty array for no references', () => {
       const refs = mtEngine.extractFieldReferences('=1+2')
       expect(refs).toEqual([])
@@ -197,6 +204,19 @@ describe('MultitableFormulaEngine', () => {
         sampleFields,
       )
       expect(result).toBe(50)
+    })
+
+    it('resolves API-generated UUID field IDs containing hyphens', async () => {
+      const uuidFieldId = 'fld_01234567-89ab-cdef-0123-456789abcdef'
+      const result = await mtEngine.evaluateField(
+        `={${uuidFieldId}}+{fld_qty}`,
+        { [uuidFieldId]: 20, fld_qty: 5 },
+        [
+          { id: uuidFieldId, name: 'Generated A', type: 'number' },
+          { id: 'fld_qty', name: 'Quantity', type: 'number' },
+        ],
+      )
+      expect(result).toBe(25)
     })
 
     it('evaluates parenthesized field reference groups', async () => {


### PR DESCRIPTION
## Summary
- allow multitable formula field references to include hyphens in `fld_<uuid>` IDs generated by the API
- add parser/evaluator regression coverage for API-generated field IDs in formulas

## Root Cause
The formula engine only matched `{fld_[A-Za-z0-9_]}` references. Fields created through the API use `buildId('fld')`, producing IDs like `fld_<uuid-with-dashes>`. Formulas authored against those fields therefore produced no extracted dependencies and could not be evaluated/recomputed on PATCH.

This matches the #3408/#3426 symptom: source-field PATCH succeeds, but the dependent formula is not surfaced in `data.records` and a later record read has no materialized formula value.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-formula-engine.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `git diff --check`

## Notes
This is parser-only and preserves the existing `{fld_*}` contract. It does not change permissions, formula evaluation semantics, or write routing.
