### PR TITLE
feat(approval-center): batch approve/reject + list-level urge (操作台 enhancement)

### DIFF
--- a/apps/web/src/approvals/useApprovalBatchActions.ts
+++ b/apps/web/src/approvals/useApprovalBatchActions.ts
@@ -1,0 +1,60 @@
+import type { ApprovalActionRequest } from '../types/approval'
+
+/**
+ * Batch approval-action orchestration (approval-center 操作台). The backend exposes only single-instance
+ * `POST /api/approvals/:id/actions`; "batch approve/reject" is therefore a FRONTEND fan-out over the same
+ * authoritative per-instance endpoint (every row still runs the full server-side guard/transition). This
+ * module is the pure, Element-Plus-free orchestration core so the concurrency + partial-failure manifest is
+ * unit-testable independently of the view.
+ *
+ * Semantics:
+ * - Bounded concurrency (default 4) so a large selection can't open hundreds of simultaneous requests.
+ * - Per-row isolation: one row's rejection/throw NEVER aborts the batch; it lands in `failed` with its
+ *   message and the rest continue (mirrors the server's per-instance transaction boundary).
+ * - Order-independent; the manifest is keyed by id so the caller can map results back to rows.
+ */
+export interface ApprovalBatchActionResult {
+  succeeded: string[]
+  failed: Array<{ id: string; message: string }>
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  if (err && typeof err === 'object' && 'message' in err && typeof (err as { message: unknown }).message === 'string') {
+    return (err as { message: string }).message
+  }
+  return 'Unknown error'
+}
+
+export async function runApprovalBatchAction(
+  ids: readonly string[],
+  makeRequest: (id: string) => ApprovalActionRequest,
+  dispatch: (id: string, req: ApprovalActionRequest) => Promise<unknown>,
+  options: { concurrency?: number } = {},
+): Promise<ApprovalBatchActionResult> {
+  const result: ApprovalBatchActionResult = { succeeded: [], failed: [] }
+  const uniqueIds = [...new Set(ids.filter((id) => typeof id === 'string' && id.length > 0))]
+  if (uniqueIds.length === 0) return result
+
+  const concurrency = Math.max(1, Math.min(options.concurrency ?? 4, uniqueIds.length))
+  let cursor = 0
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor
+      cursor += 1
+      if (index >= uniqueIds.length) return
+      const id = uniqueIds[index]
+      try {
+        await dispatch(id, makeRequest(id))
+        result.succeeded.push(id)
+      } catch (err) {
+        result.failed.push({ id, message: errorMessage(err) })
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()))
+  return result
+}

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -92,6 +92,33 @@
              reports at least one unread row for the current filter so clicking
              never issues a no-op round-trip. -->
         <div class="approval-center__tab-toolbar">
+          <!-- 操作台: batch approve/reject over the current selection. Each row still runs the
+               authoritative single-instance server transition (frontend fan-out, not a bulk endpoint). -->
+          <span
+            v-if="selectedPending.length > 0"
+            class="approval-center__selection-count"
+            data-testid="approval-selection-count"
+          >已选 {{ selectedPending.length }} 项</span>
+          <el-button
+            type="success"
+            plain
+            :disabled="selectedPending.length === 0 || batchRunning"
+            :loading="batchRunning && batchAction === 'approve'"
+            data-testid="approval-batch-approve"
+            @click="handleBatchApprove"
+          >
+            批量通过
+          </el-button>
+          <el-button
+            type="danger"
+            plain
+            :disabled="selectedPending.length === 0 || batchRunning"
+            :loading="batchRunning && batchAction === 'reject'"
+            data-testid="approval-batch-reject"
+            @click="openBatchReject"
+          >
+            批量驳回
+          </el-button>
           <el-button
             type="primary"
             plain
@@ -118,14 +145,22 @@
           </el-button>
         </div>
         <el-table
+          ref="pendingTableRef"
           v-loading="store.loading"
           :data="store.pendingApprovals"
           style="width: 100%"
           max-height="560"
           stripe
           highlight-current-row
+          :row-key="rowKey"
           @row-click="handleRowClick"
+          @selection-change="handlePendingSelectionChange"
         >
+          <el-table-column
+            type="selection"
+            width="44"
+            :selectable="isRowBatchSelectable"
+          />
           <el-table-column prop="requestNo" label="审批编号" width="180" />
           <el-table-column prop="title" label="标题" min-width="200" />
           <el-table-column label="发起人" width="120">
@@ -190,6 +225,23 @@
           <el-table-column label="发起时间" width="180">
             <template #default="{ row }">
               {{ formatDate(row.createdAt) }}
+            </template>
+          </el-table-column>
+          <!-- 催办: a requester nudge to the current approver, only meaningful while the instance is
+               still pending. Server-side rate-limited (1/instance/user/hour); 429 surfaces gracefully. -->
+          <el-table-column label="操作" width="100" fixed="right">
+            <template #default="{ row }">
+              <el-button
+                v-if="row.status === 'pending'"
+                type="primary"
+                link
+                :loading="remindingId === row.id"
+                :disabled="remindingId !== null"
+                :data-testid="`approval-urge-${row.id}`"
+                @click.stop="handleUrge(row)"
+              >
+                催办
+              </el-button>
             </template>
           </el-table-column>
           <template #empty>
@@ -304,6 +356,37 @@
         />
       </el-tab-pane>
     </el-tabs>
+
+    <!-- Batch reject: a comment is offered (some templates require one; a per-row failure is captured
+         in the manifest rather than aborting the batch). -->
+    <el-dialog
+      v-model="batchRejectDialogVisible"
+      title="批量驳回"
+      width="440px"
+      data-testid="approval-batch-reject-dialog"
+    >
+      <p class="approval-center__batch-reject-summary">
+        将驳回所选的 {{ selectedPending.length }} 项审批。
+      </p>
+      <el-input
+        v-model="batchRejectComment"
+        type="textarea"
+        :rows="3"
+        placeholder="驳回意见（部分审批模板要求必填）"
+        data-testid="approval-batch-reject-comment"
+      />
+      <template #footer>
+        <el-button data-testid="approval-batch-reject-cancel" @click="batchRejectDialogVisible = false">取消</el-button>
+        <el-button
+          type="danger"
+          :loading="batchRunning"
+          data-testid="approval-batch-reject-confirm"
+          @click="handleBatchReject"
+        >
+          确认驳回
+        </el-button>
+      </template>
+    </el-dialog>
   </section>
 </template>
 
@@ -315,12 +398,108 @@ import { ElMessage } from 'element-plus'
 import type { UnifiedApprovalDTO, ApprovalStatus } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
-import { getPendingCount, markAllApprovalsRead } from '../../approvals/api'
+import { dispatchAction, getPendingCount, markAllApprovalsRead, remindApproval } from '../../approvals/api'
+import { runApprovalBatchAction } from '../../approvals/useApprovalBatchActions'
 import { useApprovalCountsRealtime, type ApprovalCountsUpdatedPayload } from '../../approvals/useApprovalCountsRealtime'
 
 const router = useRouter()
 const store = useApprovalStore()
 const { canWrite } = useApprovalPermissions()
+
+// ── 操作台: batch approve/reject over the pending selection ────────────────
+const pendingTableRef = ref<{ clearSelection: () => void } | null>(null)
+const selectedPending = ref<UnifiedApprovalDTO[]>([])
+const batchRunning = ref(false)
+const batchAction = ref<'approve' | 'reject' | null>(null)
+const batchRejectDialogVisible = ref(false)
+const batchRejectComment = ref('')
+const remindingId = ref<string | null>(null)
+
+function rowKey(row: UnifiedApprovalDTO): string {
+  return row.id
+}
+
+// Only platform-native pending rows are batch-actionable here; attendance-backed approvals live in the
+// attendance module (their row-click routes away), so excluding them keeps the batch honest.
+function isRowBatchSelectable(row: UnifiedApprovalDTO): boolean {
+  return row.status === 'pending' && !isAttendanceApproval(row)
+}
+
+function handlePendingSelectionChange(rows: UnifiedApprovalDTO[]): void {
+  selectedPending.value = rows.filter(isRowBatchSelectable)
+}
+
+function clearPendingSelection(): void {
+  selectedPending.value = []
+  // Guard the child API: the ref may be null (tab not rendered) or, under test stubs, a component
+  // without ElTable's imperative methods — never let a missing clearSelection abort navigation.
+  if (typeof pendingTableRef.value?.clearSelection === 'function') {
+    pendingTableRef.value.clearSelection()
+  }
+}
+
+async function runBatch(action: 'approve' | 'reject', comment: string): Promise<void> {
+  const ids = selectedPending.value.map((row) => row.id)
+  if (ids.length === 0 || batchRunning.value) return
+  batchRunning.value = true
+  batchAction.value = action
+  try {
+    const trimmed = comment.trim()
+    const result = await runApprovalBatchAction(
+      ids,
+      () => (trimmed ? { action, comment: trimmed } : { action }),
+      (id, req) => dispatchAction(id, req),
+    )
+    if (result.failed.length === 0) {
+      ElMessage.success(`已${action === 'approve' ? '通过' : '驳回'} ${result.succeeded.length} 项`)
+    } else if (result.succeeded.length === 0) {
+      ElMessage.error(`全部 ${result.failed.length} 项处理失败：${result.failed[0]?.message ?? ''}`)
+    } else {
+      ElMessage.warning(`成功 ${result.succeeded.length} 项，失败 ${result.failed.length} 项（失败项仍在列表中）`)
+    }
+    clearPendingSelection()
+    loadCurrentTab()
+    void refreshPendingBadgeCount()
+  } finally {
+    batchRunning.value = false
+    batchAction.value = null
+  }
+}
+
+async function handleBatchApprove(): Promise<void> {
+  await runBatch('approve', '')
+}
+
+function openBatchReject(): void {
+  if (selectedPending.value.length === 0) return
+  batchRejectComment.value = ''
+  batchRejectDialogVisible.value = true
+}
+
+async function handleBatchReject(): Promise<void> {
+  await runBatch('reject', batchRejectComment.value)
+  batchRejectDialogVisible.value = false
+}
+
+async function handleUrge(row: UnifiedApprovalDTO): Promise<void> {
+  if (remindingId.value) return
+  remindingId.value = row.id
+  try {
+    const result = await remindApproval(row.id)
+    if (result.ok) {
+      ElMessage.success('已发送催办提醒')
+    } else if (result.status === 429) {
+      const retry = result.error.retryAfterSeconds
+      ElMessage.warning(retry ? `催办过于频繁，请 ${Math.ceil(retry / 60)} 分钟后再试` : '催办过于频繁，请稍后再试')
+    } else {
+      ElMessage.error(result.error.message || '催办失败，请重试')
+    }
+  } catch {
+    ElMessage.error('催办失败，请重试')
+  } finally {
+    remindingId.value = null
+  }
+}
 
 // Wave 2 WP3 slice 1/2: server-owned pending badge. Slice 1 drove the count
 // off active assignments; slice 2 flips the primary semantic to `unreadCount`
@@ -434,6 +613,7 @@ function loadCurrentTab() {
 
 function handleTabChange() {
   currentPage.value = 1
+  clearPendingSelection()
   loadCurrentTab()
   // Refresh badge whenever the user re-enters the 待办 tab so recent actions
   // reflect immediately.
@@ -442,17 +622,20 @@ function handleTabChange() {
 
 function handleSearch() {
   currentPage.value = 1
+  clearPendingSelection()
   loadCurrentTab()
 }
 
 function handleSourceSystemChange() {
   currentPage.value = 1
+  clearPendingSelection()
   loadCurrentTab()
   void refreshPendingBadgeCount()
 }
 
 function handlePageChange(page: number) {
   currentPage.value = page
+  clearPendingSelection()
   loadCurrentTab()
 }
 
@@ -555,7 +738,21 @@ onMounted(() => {
 .approval-center__tab-toolbar {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
   margin-bottom: 12px;
+}
+
+.approval-center__selection-count {
+  margin-right: auto;
+  color: #4b5563;
+  font-size: 13px;
+}
+
+.approval-center__batch-reject-summary {
+  margin: 0 0 12px;
+  color: #4b5563;
+  font-size: 14px;
 }
 
 .approval-center__attendance-entry {

--- a/apps/web/tests/approvalCenterRemindBadge.spec.ts
+++ b/apps/web/tests/approvalCenterRemindBadge.spec.ts
@@ -109,6 +109,7 @@ vi.mock('../src/approvals/templateStore', () => ({
 }))
 
 vi.mock('../src/approvals/api', () => ({
+  dispatchAction: vi.fn().mockResolvedValue({}),
   getPendingCount: (sourceSystem?: 'all' | 'platform' | 'plm') => getPendingCountSpy(sourceSystem),
   remindApproval: (...args: unknown[]) => remindApprovalSpy(...args),
   markApprovalRead: (...args: unknown[]) => markApprovalReadSpy(...args),

--- a/apps/web/tests/approvalCenterUnreadBadge.spec.ts
+++ b/apps/web/tests/approvalCenterUnreadBadge.spec.ts
@@ -108,6 +108,7 @@ vi.mock('../src/approvals/templateStore', () => ({
 }))
 
 vi.mock('../src/approvals/api', () => ({
+  dispatchAction: vi.fn().mockResolvedValue({}),
   getPendingCount: (sourceSystem?: 'all' | 'platform' | 'plm') => getPendingCountSpy(sourceSystem),
   markAllApprovalsRead: (sourceSystem?: 'all' | 'platform' | 'plm') => markAllApprovalsReadSpy(sourceSystem),
   markApprovalRead: (id: string) => markApprovalReadSpy(id),

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -4065,6 +4065,31 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].triggerConfig).toEqual({ secret: 's3cret-1' })
   })
 
+  it('approval.completed: an existing rule carrying conditions disables save with the no-conditions reason', async () => {
+    // Deferred from the #3495 review: the block-reason mirror must specifically catch a conditions-bearing
+    // approval.completed rule (record-less v1 has no record context to evaluate conditions against).
+    const saved = vi.fn()
+    const rule = fakeRule({
+      id: 'rule_ac',
+      name: 'Approval done + condition',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId: 'tpl-1' },
+      actionType: 'send_notification',
+      actionConfig: { userId: 'user_1', message: 'done' },
+      actions: [{ type: 'send_notification', config: { userId: 'user_1', message: 'done' } }],
+      conditions: { conjunction: 'AND', conditions: [{ fieldId: 'fld_score', operator: 'equals', value: 1 }] },
+    })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    expect(container.querySelector('[data-field="approvalCompletedBlockReason"]')?.textContent)
+      .toContain('does not support conditions')
+    saveBtn.click()
+    expect(saved).not.toHaveBeenCalled()
+  })
+
   it('webhook.received: an existing rule with a redacted secret keeps the stored secret by omitting triggerConfig', async () => {
     const saved = vi.fn()
     const rule = fakeRule({

--- a/apps/web/tests/useApprovalBatchActions.spec.ts
+++ b/apps/web/tests/useApprovalBatchActions.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runApprovalBatchAction } from '../src/approvals/useApprovalBatchActions'
+import type { ApprovalActionRequest } from '../src/types/approval'
+
+describe('runApprovalBatchAction', () => {
+  it('returns an empty manifest and never dispatches for an empty selection', async () => {
+    const dispatch = vi.fn()
+    const result = await runApprovalBatchAction([], () => ({ action: 'approve' }), dispatch)
+    expect(result).toEqual({ succeeded: [], failed: [] })
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('dispatches the per-id request for every unique id and reports all succeeded', async () => {
+    const seen: Array<{ id: string; req: ApprovalActionRequest }> = []
+    const dispatch = vi.fn(async (id: string, req: ApprovalActionRequest) => { seen.push({ id, req }) })
+    const result = await runApprovalBatchAction(
+      ['a', 'b', 'a', 'c'], // duplicate 'a' is de-duped
+      (id) => ({ action: 'reject', comment: `no-${id}` }),
+      dispatch,
+    )
+    expect(result.succeeded.sort()).toEqual(['a', 'b', 'c'])
+    expect(result.failed).toEqual([])
+    expect(dispatch).toHaveBeenCalledTimes(3)
+    expect(seen.find((s) => s.id === 'b')?.req).toEqual({ action: 'reject', comment: 'no-b' })
+  })
+
+  it('isolates per-row failures: one rejection does NOT abort the batch and lands in the manifest', async () => {
+    const dispatch = vi.fn(async (id: string) => {
+      if (id === 'bad') throw new Error('APPROVAL_THRESHOLD_UNREACHABLE')
+      if (id === 'bad2') throw 'plain string failure'
+    })
+    const result = await runApprovalBatchAction(
+      ['ok1', 'bad', 'ok2', 'bad2', 'ok3'],
+      () => ({ action: 'approve' }),
+      dispatch,
+    )
+    expect(result.succeeded.sort()).toEqual(['ok1', 'ok2', 'ok3'])
+    expect(result.failed).toContainEqual({ id: 'bad', message: 'APPROVAL_THRESHOLD_UNREACHABLE' })
+    expect(result.failed).toContainEqual({ id: 'bad2', message: 'plain string failure' })
+    expect(dispatch).toHaveBeenCalledTimes(5)
+  })
+
+  it('bounds concurrency: never more than `concurrency` dispatches are in flight at once', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const dispatch = vi.fn(async () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise<void>((resolve) => setTimeout(resolve, 5))
+      inFlight -= 1
+    })
+    await runApprovalBatchAction(
+      ['1', '2', '3', '4', '5', '6'],
+      () => ({ action: 'approve' }),
+      dispatch,
+      { concurrency: 2 },
+    )
+    expect(maxInFlight).toBe(2)
+    expect(dispatch).toHaveBeenCalledTimes(6)
+  })
+})


### PR DESCRIPTION
Owner-ordered **step ④ — approval-center experience.** The center already had search / status / source / pagination / unread; this adds the operator-console actions (batch + urge) that 钉钉/飞书 have. Enhancement, not from-zero.

## What ships
- **待我处理**: selection column (attendance-backed + non-pending rows non-selectable) + batch toolbar **批量通过 / 批量驳回** (reject opens a comment dialog). Selection clears on every tab/page/filter change and after a batch.
- **我发起的**: per-row **催办** (requester → approver nudge), pending-only, reusing the rate-limited `POST /api/approvals/:id/remind`; 429 → "try again in N min".
- **Frontend fan-out, not a bulk endpoint**: batch runs over the authoritative single-instance `POST /api/approvals/:id/actions` — every row still runs the full server guard/transition. The orchestration is a pure, Element-Plus-free composable `runApprovalBatchAction`: bounded concurrency (4), per-row isolation (one failure never aborts the batch), `{succeeded, failed}` manifest → success / partial (failures stay listed) / all-failed message.

## Verification
`vue-tsc -b` 0 · **new composable spec 4/4** (empty guard · all-succeed + de-dupe · per-row failure isolation incl. non-Error throw · concurrency-bound) · **all 4 existing center specs green (25)** — the `clearSelection` child-API guard keeps the stubbed-ElTable specs passing · **rule-editor spec 112/112** including the **deferred-from-#3495** test (approval.completed + conditions → save disabled with the no-conditions reason). Element Plus row-selection can't be driven through the spec's component stub, so batch correctness is locked at the composable unit level by design.

## Not in this slice
Center filter additions (already cover search/status/source) · mobile-responsive pass · print/export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)