### PR TITLE
fix(approval): node-timeout deadline-clear race (decision-clean)

### DIFF
--- a/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
+++ b/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
@@ -5,7 +5,7 @@
 > runtime is NOT blind-built on presumed votes; instead every remaining rung is made **one vote from build**
 > (design-lock / build-spec), and the decision-clean work is completed + verified this batch.
 
-## 1. Shipped on main (code-verified, as of `d1578808c`)
+## 1. Shipped / queued in this batch (code-verified, base through #3441 `a206a5bb` + this PR)
 
 Engine parity with 钉钉/飞书 approval is ~85% — the recent burst closed most of it:
 - **Correctness/security:** T2-4 re-entry quorum fix + cascade regression (#3446/#3453) · R1 SSRF egress

--- a/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
+++ b/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
@@ -1,0 +1,83 @@
+# Approval & Process-Automation — remaining-items plan, development & verification (2026-07-03)
+
+> `/goal` deliverable: deep-review the line, sequence the remaining items for **parallel development**,
+> complete everything genuinely buildable, and record dev + verification. **Discipline honored:** gated
+> runtime is NOT blind-built on presumed votes; instead every remaining rung is made **one vote from build**
+> (design-lock / build-spec), and the decision-clean work is completed + verified this batch.
+
+## 1. Shipped on main (code-verified, as of `d1578808c`)
+
+Engine parity with 钉钉/飞书 approval is ~85% — the recent burst closed most of it:
+- **Correctness/security:** T2-4 re-entry quorum fix + cascade regression (#3446/#3453) · R1 SSRF egress
+  default-closed complete (#3437/#3443/#3447/#3451/#3460) · **node-timeout deadline-clear race fix (#3497,
+  this batch)**.
+- **Automation triggers/actions:** T2-6 dedup ledger (#3450) · T1-3 approval.completed trigger (#3467) ·
+  T1-2 signed inbound webhook (#3489) · T3-4 W7 rejection backwrite (#3474) · T0-3 delete_record editor
+  (#3477).
+- **Approval engine:** T1-1 slice-2 transfer/jump timeout effects (#3468) · T2-1+2 scoped admins + handover
+  (#3490).
+- **UX:** rule editor exposes approval.completed + webhook.received (#3495) · **approval-center batch
+  approve/reject + list-level urge (#3496, open)**.
+
+## 2. Remaining items — gating (authoritative)
+
+| Item | Subsystem | Size | Gating | Made-ready this batch |
+|---|---|---|---|---|
+| **node-timeout deadline-clear race** | approval metrics | S | **decision-clean → BUILT (#3497)** | ✅ shipped-for-review |
+| **T3-5** W7 cross-base backwrite | automation (Lane C) | L | design-lock-first (owner) | **design-lock #3-5 doc** |
+| **T1-4** node field-perms authoring | approval (Lane B) | M | owner-vote-needed | **build-spec doc** |
+| **T3-2** business-calendar SLA | product | L | owner-vote-needed (3rd ballot) | reuse-attendance note |
+| **T3-3** node signature/compliance | approval | M-L | owner-vote-needed (declared-inert first) | 3rd ballot |
+| **T3-1** mobile approval | product | L | owner-vote-needed (blocked on notif hub) | 3rd ballot |
+| **T3-6** approvals-as-multitable-records | product | L | owner-vote-needed (**the 超越 move**) | 3rd ballot |
+| **A3** egress destination authorization | BPMN | S | governance-only (config/ops, not code) | — |
+
+## 3. Parallel-development plan (lanes — concurrent, hot-file-sequential within a lane)
+
+- **Lane B — approval engine** (`ApprovalProductService.ts` hot): T1-4 field-perms authoring (on vote) →
+  T3-3 signature (declared-inert first).
+- **Lane C — automation engine** (`automation-service.ts` hot): T3-5 cross-base backwrite (on vote,
+  design-lock ready).
+- **Lane D — product/heavy** (separate surfaces, fully parallel): T3-6 approvals-as-records (highest
+  differentiation — unlocks 飞书-grade reporting + re-automation for free), T3-2 calendar-SLA (reuse the
+  attendance effective-calendar substrate → L drops toward M), T3-1 mobile (responsive pass; native blocked
+  on a notification hub).
+- **Lane A — BPMN:** A3 is governance-only — no code slice; authorize a destination when a named integration
+  needs it.
+
+Dependency notes: T3-2 → T1-1 node-SLA (met) · T3-5/T3-3 sit on their hot files so stay sequential within
+their lanes · Lane D items share no runtime hot file → genuinely parallel.
+
+## 4. Completed this batch (decision-clean — no owner vote) + verification
+
+**node-timeout deadline-clear race (#3497)** — `recordNodeDecision`'s unconditional instance-wide deadline
+clear raced the next node's activation write (both unawaited post-commit best-effort), silently losing the
+new node's timeout. Fixed by scoping the clear to `approval_instances.current_node_key` (= the next node
+post-commit → the clear is a safe no-op once advanced). **Verify:** tsc 0 · real-DB `approval-node-sla-remind`
+5/5 incl. a new fail-first race-guard test; **RED-before confirmed** (unconditional clear reverted → the
+advanced node's fresh deadline is wiped → test fails).
+
+_(Additional decision-clean items surfaced by the review workflow are appended in §6.)_
+
+## 5. Made one-vote-from-build this batch (authorized design, no runtime)
+
+- **T3-5 design-lock** (`w7-cross-base-resultwriteback-design-lock-20260703.md`) — register Q1–Q5 + the 5
+  reviewer must-fixes turned into a build contract + fail-first verification plan. Reuses the ratified
+  executor cross-base gate; literal target triple; trigger-actor authority fail-closed. **On T3-5 vote → build
+  Lane C.**
+- **T1-4 build-spec** (`t1-4-node-field-permissions-authoring-build-spec-20260703.md`) — folds the owner
+  hidden/readonly steer + reconciles it with the register Q2 hidden-only default (the one vote to settle);
+  hidden enforced (echo-redaction), readonly persisted-but-runtime-inert (T1-4b later). **On T1-4 vote →
+  build Lane B.**
+
+## 6. Review-workflow findings (appended after synthesis)
+
+_(Confirmed shipped-state + any additional verified decision-clean candidates + gating corrections.)_
+
+## 7. Bottom line
+
+The buildable-without-a-vote surface is completed + verified (#3497). The heavy remainder is owner-gated;
+it is now one vote from build in three genuinely-parallel lanes (B / C / D), with the two nearest rungs
+(T3-5, T1-4) design-locked. Recommended fastest path: vote T3-5 + T1-4 to start B/C, and open Lane D on
+T3-6 (the differentiation move) in parallel. Sizing figures are optimistic build-effort, NOT calendar
+commitments — the security/permission/product rungs' review rounds can dominate.

--- a/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
+++ b/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
@@ -55,7 +55,8 @@ clear raced the next node's activation write (both unawaited post-commit best-ef
 new node's timeout. Fixed by scoping the clear to `approval_instances.current_node_key` (= the next node
 post-commit → the clear is a safe no-op once advanced). **Verify:** tsc 0 · real-DB `approval-node-sla-remind`
 5/5 incl. a new fail-first race-guard test; **RED-before confirmed** (unconditional clear reverted → the
-advanced node's fresh deadline is wiped → test fails).
+advanced node's fresh deadline is wiped → test fails). **Broader regression:** `approval-node-timeout-effects`
+13/13 + `approval-nofm-threshold` 5/5 green (the shared metrics path is unaffected).
 
 _(Additional decision-clean items surfaced by the review workflow are appended in §6.)_
 
@@ -70,9 +71,17 @@ _(Additional decision-clean items surfaced by the review workflow are appended i
   hidden enforced (echo-redaction), readonly persisted-but-runtime-inert (T1-4b later). **On T1-4 vote →
   build Lane B.**
 
-## 6. Review-workflow findings (appended after synthesis)
+## 6. Review findings (adversarial workflow + focused hunt)
 
-_(Confirmed shipped-state + any additional verified decision-clean candidates + gating corrections.)_
+- **Shipped-state: CONFIRMED.** All 11 recently-shipped items are genuinely present on origin/main with live
+  `file:symbol` anchors (verified against git objects, not merge-commit ancestry).
+- **The node-timeout deadline race: INDEPENDENTLY CONFIRMED** as live, with the same call-site evidence
+  (`ApprovalProductService.ts` 5072/5077 approve, 4614/4616 reject/return, 4181/4183 timeout-jump; both emits
+  fire-and-forget via `safeMetricsCall`), the single per-instance deadline column → last-writer-wins race, and
+  the recommended fix = **exactly** the conditional node-scoped clear shipped in #3497. My fix is validated by
+  an independent adversarial pass.
+- **Additional decision-clean candidates:** _(from the focused hunt — appended below; if none beyond the race,
+  that is the finding)._
 
 ## 7. Bottom line
 

--- a/docs/development/t1-4-node-field-permissions-authoring-build-spec-20260703.md
+++ b/docs/development/t1-4-node-field-permissions-authoring-build-spec-20260703.md
@@ -1,0 +1,63 @@
+# T1-4 — Node field-permissions authoring · BUILD-SPEC (vote-ready) · 2026-07-03
+
+> **Status: awaiting the T1-4 per-rung votes** in `approval-automation-second-batch-ballot-20260702.md`.
+> This spec folds the owner steer (2026-07-02): **start from the hidden/readonly configurable authoring
+> surface; do NOT take on the full mid-flow runtime semantics in one slice.** It reconciles that steer with
+> the register's Q2 hidden-only default (below) so the rung is one vote from build. **No runtime until voted.**
+
+## 1. What's already shipped (contract layer, P1-C)
+
+`NodeFieldAccess = 'editable' | 'readonly' | 'hidden'` and `NodeFieldPermission { fieldId, access }` exist
+(`types/approval-product.ts:51`); a node's `fieldPermissions` array is normalized shape-only
+(`ApprovalProductService.ts:921`) and cross-referenced — every `fieldPermissions[].fieldId` must exist on the
+form (`:1021`). So the **data model + validation is done**; the gaps are (a) an authoring UI to set it and
+(b) runtime enforcement.
+
+## 2. The reconcile the vote must settle (Q1/Q2 + owner steer)
+
+- **Register Q1 default:** defer edit-form-at-node — readonly/editable stay **runtime-inert** this rung; a
+  later **T1-4b** builds mid-flow form editing + readonly/editable enforcement.
+- **Register Q2 default:** expose **only `hidden`** in the authoring UI (don't offer readonly/editable while
+  they have no runtime effect).
+- **Owner steer (2026-07-02):** start from the **hidden/readonly configurable** authoring surface.
+- **The one vote decision (Q2):** ✏️ **expose hidden + readonly (persisted, readonly runtime-inert with a
+  "takes effect in a later slice" hint)**, OR ✅ **hidden-only UI** (readonly stays persist-able via API but
+  unexposed). Recommend the ✏️ path per the steer — it makes the config authorable now without shipping the
+  heavy runtime — provided the UI clearly marks readonly as not-yet-enforced.
+
+## 3. Scope (on the ✏️ reconcile)
+
+- **Authoring UI** (linear-steps editor only — Q3; complex-graph `fieldPermissions` stay preserved/read-only):
+  per approval node, a per-form-field access selector offering `hidden` + `readonly` (+ implicit default
+  `editable`). Persists `node.config.fieldPermissions`. Readonly carries a non-blocking "enforced in a later
+  slice" hint.
+- **Runtime — `hidden` ONLY this rung:** a hidden field is **echo-redacted** from the node's form view
+  (Q4: redaction is echo-only — it does NOT affect assignee resolution or condition routing; show a
+  non-blocking hint when a hidden field also drives routing). Readonly/editable = **runtime-inert** (deferred
+  to T1-4b).
+- **Do NOT build:** mid-flow form editing, write-back to `form_snapshot`, readonly/editable enforcement,
+  complex-graph authoring.
+
+## 4. Build contract (reviewer-note guards)
+
+- Authoring UI **never flattens** an unsupported/complex loaded shape — preserve + re-emit verbatim (mirror
+  the condition_branch/parallel_branch read-only-never-flatten precedent).
+- Hidden redaction is applied at the **read/echo boundary** only; a real-wire test asserts a hidden field is
+  absent from the node form echo AND that assignee resolution / condition routing still see the value.
+- Hiding a routing-driver field is **allowed** (Q4) with a visible authoring hint; a test asserts routing is
+  unchanged when the driver is hidden.
+- readonly persisted round-trips through save/load unchanged while producing **no runtime effect** (a test
+  asserts a readonly field is still editable/echoed at runtime this rung).
+
+## 5. Verification plan (fail-first)
+
+RED-before: a hidden `fieldPermission` does not redact the node form echo. Green-after: hidden field absent
+from the echo; assignee/condition paths still read it; readonly is persisted but runtime-inert; complex-graph
+fieldPermissions preserved on round-trip. FE: authoring selector renders per node/field, offers hidden +
+readonly, blocks nothing, and round-trips.
+
+## 6. Status / next step
+
+Vote-ready. On the T1-4 rung voted GO (with the Q2 reconcile decided), build in **Lane B**
+(`ApprovalProductService.ts` authoring/validation + the template-authoring FE), fail-first + real-DB/vue-tsc,
+PR-for-review. Until then, no runtime.

--- a/docs/development/w7-cross-base-resultwriteback-design-lock-20260703.md
+++ b/docs/development/w7-cross-base-resultwriteback-design-lock-20260703.md
@@ -1,0 +1,72 @@
+# T3-5 — W7 cross-base resultWriteback · DESIGN-LOCK (PROPOSED) · 2026-07-03
+
+> **Status: PROPOSED design-lock — awaiting the T3-5 per-rung votes in
+> `approval-automation-second-batch-ballot-20260702.md`.** Per the owner steer (2026-07-02) T3-5 runs
+> **design-lock-first as its own slice** — its permission/lock/audit surface is heavy, so it is NOT part of
+> the fast demo layer. This doc turns the register's Q1–Q5 + reviewer notes into a buildable contract so the
+> rung is one ratification from implementation. **No runtime is written until the ballot rung is voted GO.**
+
+## 1. What ships today vs the gap
+
+W7 `resultWriteback` (backend #3384, non-approved extension #3474) writes the approval outcome
+(`statusField` / `approverField` / `completedAtField`, plus `onNonApproved` opt-in) back onto the **source
+record only** — `writeApprovalResultBack` (automation-service.ts) resolves fields against the trigger sheet and
+writes through `ensureRecordNotLocked(event.actor?.id)` with NO cross-base authority check. Record-mutating
+automation actions (`update_record` etc.) already cross bases through the executor's ratified gate
+`evaluateCrossBaseWrite` (automation-executor.ts:1819): an explicit `targetBaseId` must equal the target
+sheet's real `base_id`, the **effective (trigger) actor** must pass `resolveBaseWritable(actorId, …)`
+(fail-closed on no userId — no fallback to the rule owner), and a per-target-base quota is consumed.
+
+**Gap:** `resultWriteback` cannot target another base. T3-5 extends it to a **literal cross-base target**,
+reusing the same gate — not a new write path.
+
+## 2. Locked decisions (register Q1–Q5, defaults adopted unless the ballot overrides)
+
+- **Q1 — effective actor:** the **trigger actor** read from `bridge.triggerEvent`, matching the executor
+  cross-base gate's ratified "effective actor = trigger actor". Null/system approvals (`event.actor` null) and
+  null-actor triggers **fail closed** for cross-base backwrite (`resolveBaseWritable` is fail-closed on no
+  userId). The same actor governs the **target-record lock** check. *(Stated limitation, not a bug:
+  auto/system approvals cannot cross-base backwrite.)*
+- **Q2 — target addressing:** **literal triple only** — `resultWriteback.targetBaseId` +
+  `targetSheetId` + `targetRecordId`. No expression templating (W7-1 was gated to avoid it). Dynamic
+  single-link-field target resolution is a **named follow-up**, not v1.
+- **Q3 — audit/provenance:** no new audit table in v1. Extend the `start_approval` step output with the
+  target base/sheet/record ids; **omit actor from the target-base realtime fan-out** (cross-base privacy
+  posture, matching the executor's cross-base emit).
+- **Q4 — save validation:** if ANY target id is present, require the **full triple** at save. Defer target
+  field-type/read validation to runtime; do **not** block save on the author's target-base write authority
+  (runtime re-checks the trigger actor's authority every run).
+- **Q5 — quota:** share the **singleton per-target-base cross-base write quota** with update/create/delete/
+  lock. A blocked/not-found attempt still consumes a slot (matches existing executor posture).
+
+## 3. Build contract (reviewer-note must-fixes — fold in at implementation)
+
+1. **Anti-misroute:** the same-base source record is **not** mutated when a cross-base target is configured
+   (the write goes to the target, not the trigger record). Real-DB test asserts the source row is unchanged.
+2. **Authority fail-closed** test uses the real DB and the **trigger actor** (not the request actor, not the
+   approval/resume actor which collapses to `event.actor?.id ?? event.requester.id`). A trigger actor lacking
+   target-base write → skip + observable `backwriteSkipped`, source untouched, no partial write.
+3. **Non-merge into tail context:** the cross-base patch is **NOT** merged into the source `recordData` that
+   the resume tail actions see (unlike the same-base W7-1a merge). Add a test asserting the tail context does
+   not see the cross-base patch.
+4. **Gate reuse, re-pinned:** extract/reuse the executor's cross-base gate helper (its call signature is
+   `(queryFn, actorId, triggerSheetId, …)`, not `(context)`), and **re-run the existing cross-base
+   write-gate suites** against the new shape so they stay pinned.
+5. **Resume-retry quota note:** document that quota may be re-consumed on a resume retry unless a separate
+   idempotent cross-base-backwrite ledger is introduced (out of v1 scope; note it).
+
+## 4. Verification plan (fail-first, real-DB)
+
+- **RED-before:** a cross-base `resultWriteback` target is ignored / errors before the change.
+- **Green-after:** authorized trigger actor → target record row carries status/approver/completedAt;
+  source row untouched; quota decremented; step output carries the target triple.
+- **Fail-closed:** unauthorized trigger actor / null-actor system approval → skip + `backwriteSkipped`,
+  target and source both unchanged.
+- **Save gate:** partial target triple rejected at rule save; full triple accepted; same-base path unchanged.
+- **Regression:** the 12/12 same-base W7 backwrite suite + the executor cross-base write-gate suites stay green.
+
+## 5. Status / next step
+
+Design-lock **PROPOSED**. On the owner voting the T3-5 rung GO (ballot), implement on the above contract in
+**Lane C** (`automation-service.ts` — sequential with other automation-runtime work), fail-first + real-DB,
+PR-for-review. Until then, no runtime.

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -306,12 +306,25 @@ export class ApprovalMetricsService {
       }
       return breakdown
     })
-    // T1-1: the node is decided — clear its timeout deadline so the scanner won't fire for it.
+    // T1-1: the node is decided — clear ITS timeout deadline so the scanner won't fire for it.
+    //
+    // RACE FIX: this clear and the following node's `recordNodeActivation` deadline-set are separate,
+    // unawaited best-effort metrics calls (both fire post-commit via safeMetricsCall). An UNCONDITIONAL
+    // instance-wide clear here can therefore land AFTER the new node's activation write and WIPE the fresh
+    // deadline — silently losing the new node's timeout (affects remind + transfer/jump alike). Scope the
+    // clear to "the instance is still at the decided node": the forward transition already updated
+    // `approval_instances.current_node_key` to the NEXT node inside the committed transaction, so once the
+    // flow has advanced this clear is a safe no-op and the activation write is the sole owner of the
+    // deadline. On a terminal outcome `recordTerminal` clears unconditionally, so nothing is missed.
     await this.query(
       `UPDATE approval_metrics
          SET current_node_deadline_at = NULL, current_node_timeout_effect = NULL
-       WHERE instance_id = $1`,
-      [input.instanceId],
+       WHERE instance_id = $1
+         AND EXISTS (
+           SELECT 1 FROM approval_instances i
+            WHERE i.id = $1 AND i.current_node_key = $2
+         )`,
+      [input.instanceId, input.nodeKey],
     )
   }
 

--- a/packages/core-backend/tests/integration/approval-node-sla-remind.test.ts
+++ b/packages/core-backend/tests/integration/approval-node-sla-remind.test.ts
@@ -20,6 +20,7 @@ const SHOT_ASSIGNEE = `node-sla-approver-${TS}`
 const IDEM_INSTANCE = `node-sla-idem-${TS}`
 const FIRST_INSTANCE = `node-sla-first-${TS}`
 const FIRST_ASSIGNEE = `node-sla-first-approver-${TS}`
+const RACE_INSTANCE = `node-sla-race-${TS}`
 
 function rawQuery<T extends Record<string, unknown> = Record<string, unknown>>(
   sql: string,
@@ -44,7 +45,7 @@ describeIfDatabase('approval node-level SLA remind (T1-1 slice 1) — real DB', 
 
   afterAll(async () => {
     // CASCADE from approval_instances clears approval_metrics + approval_assignments.
-    await rawQuery(`DELETE FROM approval_instances WHERE id = ANY($1)`, [[SHOT_INSTANCE, IDEM_INSTANCE, FIRST_INSTANCE]])
+    await rawQuery(`DELETE FROM approval_instances WHERE id = ANY($1)`, [[SHOT_INSTANCE, IDEM_INSTANCE, FIRST_INSTANCE, RACE_INSTANCE]])
   })
 
   it('has DATABASE_URL configured (sentinel — never skip-green)', () => {
@@ -204,5 +205,47 @@ describeIfDatabase('approval node-level SLA remind (T1-1 slice 1) — real DB', 
     // Single-shot: markNodeTimeoutFired cleared the first-node deadline → a second tick fires nothing.
     await scheduler.tick(new Date())
     expect(reminders.filter((r) => r.instanceId === FIRST_INSTANCE)).toHaveLength(1)
+  })
+
+  it('(d) race guard: a LATE prior-node decision must NOT wipe the already-advanced node\'s fresh deadline', async () => {
+    const metrics = new ApprovalMetricsService(rawQuery)
+
+    // The instance has ALREADY advanced to approval_2 (committed current_node_key) with approval_2's
+    // timeout deadline freshly armed 30 min out. The post-commit metrics writes for the prior node's
+    // decision and the new node's activation are unordered best-effort — this exercises the decision
+    // write LANDING LATE.
+    await seedInstance(RACE_INSTANCE, 'approval_2')
+    await rawQuery(
+      `INSERT INTO approval_metrics
+         (instance_id, template_id, tenant_id, started_at, sla_hours, node_breakdown,
+          current_node_deadline_at, current_node_timeout_effect)
+       VALUES ($1, NULL, 'default', now() - INTERVAL '5 minutes', NULL, $2::jsonb,
+               now() + INTERVAL '30 minutes', 'remind')`,
+      [
+        RACE_INSTANCE,
+        JSON.stringify([
+          { nodeKey: 'approval_1', activatedAt: new Date(Date.now() - 300_000).toISOString(), decidedAt: null, durationSeconds: null, approverIds: [] },
+          { nodeKey: 'approval_2', activatedAt: new Date(Date.now() - 60_000).toISOString(), decidedAt: null, durationSeconds: null, approverIds: [] },
+        ]),
+      ],
+    )
+
+    // A late-landing decision write for the PRIOR node (approval_1) — the instance is at approval_2, so
+    // this must NOT clear approval_2's deadline (pre-fix: the unconditional instance-wide clear wiped it).
+    await metrics.recordNodeDecision({ instanceId: RACE_INSTANCE, nodeKey: 'approval_1', decidedAt: new Date(), approverIds: ['approver-x'] })
+    const survived = await rawQuery<{ current_node_deadline_at: string | null; current_node_timeout_effect: string | null }>(
+      `SELECT current_node_deadline_at, current_node_timeout_effect FROM approval_metrics WHERE instance_id = $1`,
+      [RACE_INSTANCE],
+    )
+    expect(survived.rows[0]?.current_node_deadline_at, 'the advanced node\'s deadline must survive a late prior-node decision').not.toBeNull()
+    expect(survived.rows[0]?.current_node_timeout_effect).toBe('remind')
+
+    // Companion: a decision for the CURRENT node (approval_2) DOES clear it — the normal single-shot path.
+    await metrics.recordNodeDecision({ instanceId: RACE_INSTANCE, nodeKey: 'approval_2', decidedAt: new Date(), approverIds: ['approver-x'] })
+    const cleared = await rawQuery<{ current_node_deadline_at: string | null }>(
+      `SELECT current_node_deadline_at FROM approval_metrics WHERE instance_id = $1`,
+      [RACE_INSTANCE],
+    )
+    expect(cleared.rows[0]?.current_node_deadline_at, 'deciding the current node clears its own deadline').toBeNull()
   })
 })

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -222,7 +222,9 @@ describe('ApprovalMetricsService', () => {
       expect(normalize(clearSql)).toContain('UPDATE approval_metrics')
       expect(normalize(clearSql)).toContain('current_node_deadline_at = NULL')
       expect(normalize(clearSql)).toContain('current_node_timeout_effect = NULL')
-      expect(clearParams).toEqual(['apr-1'])
+      expect(normalize(clearSql)).toContain('approval_instances')
+      expect(normalize(clearSql)).toContain('current_node_key = $2')
+      expect(clearParams).toEqual(['apr-1', 'approval_1'])
     })
 
     it('synthesizes a zero-duration entry when no matching open entry exists', async () => {


### PR DESCRIPTION
Decision-clean bug fix surfaced by the #3468 T1-1 slice-2 build (no owner decision needed).

## Bug
`recordNodeDecision(old node)` and `recordNodeActivation(new node)` are separate unawaited best-effort metrics writes (both post-commit via `safeMetricsCall`) → they race. `recordNodeDecision` cleared the node-timeout deadline with an **unconditional instance-wide** `SET current_node_deadline_at = NULL`, so a decision write landing **after** the next node's activation **wiped the fresh deadline** — the new node's timeout (remind/transfer/jump) is silently lost.

## Fix
Scope the clear to "instance still at the decided node" via `approval_instances.current_node_key` (set to the NEXT node inside the committed transaction, so once the flow advanced the clear is a safe no-op and the activation write is the sole deadline owner). Terminal outcomes still clear via `recordTerminal`. No schema change.

## Verification
tsc 0 · real-DB `approval-node-sla-remind` **5/5** incl. a new **fail-first race-guard** test · **RED-before confirmed** (unconditional clear reverted → the advanced node's deadline is wiped → test fails).

This is part of the `/goal` batch; the parallel-development plan + T3-5 design-lock + T1-4 build-spec + the dev/verification MD land alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)