### PR TITLE
fix(approval): close T2-4 threshold re-entry-THROUGH quorum bypass (second bypass)

### DIFF
--- a/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
+++ b/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
@@ -80,12 +80,28 @@ _(Additional decision-clean items surfaced by the review workflow are appended i
   fire-and-forget via `safeMetricsCall`), the single per-instance deadline column → last-writer-wins race, and
   the recommended fix = **exactly** the conditional node-scoped clear shipped in #3497. My fix is validated by
   an independent adversarial pass.
-- **Additional decision-clean candidates:** _(from the focused hunt — appended below; if none beyond the race,
-  that is the finding)._
+- **Additional decision-clean bug FOUND + FIXED (#3499): a SECOND T2-4 threshold quorum bypass.** The
+  focused adversarial hunt found that my earlier re-entry fix (#3446) was incomplete: the cutoff only matched
+  return/jump records that *named* the threshold node X, missing re-entry *through* X (a return/jump to an
+  upstream ancestor, then forward approval back down to X — the forward step is an `approve` at the upstream
+  node with `nextNodeKey=X`, which the cutoff never inspected → `cutoff=NULL` → whole-node fallback → stale
+  votes re-counted → single-vote quorum bypass). Fixed by keying the cutoff off the entry *transition* into X
+  (`nextNodeKey=X AND nodeKey<>X` OR `targetNodeKey/toNodeKey=X`). **Verify:** real-DB 6/6 incl. a new
+  fail-first `N1→X(2-of-3)→N3` through-re-entry test, RED-before confirmed; prior re-entry + cascade `>=`
+  regression + timeout-effects 13/13 green. Decision-clean (the round-scoped semantics were already the chosen
+  intent).
+- **Other surfaces verified CLEAN by the hunt:** inbound webhook (HMAC/timestamp-window/uniform-reject/secret
+  redaction incl. redacted-placeholder round-trip rejection, per-ruleId rate limiter), T1-3 approval.completed
+  (dual authz re-checked at fire, fail-closed, ledger-idempotent), W7 non-approved backwrite (opt-in,
+  lock-fail-closed), SLA scheduler (per-row isolation, single-shot, in-txn deadline re-verify), T2-1+2 bulk
+  reassign (`FOR UPDATE`, skips, ≤200 cap, N>M fail-closed). No other decision-clean defect surfaced.
 
 ## 7. Bottom line
 
-The buildable-without-a-vote surface is completed + verified (#3497). The heavy remainder is owner-gated;
+The buildable-without-a-vote surface is completed + verified — **two decision-clean bugs found + fixed this
+batch: the node-timeout deadline-clear race (#3497, merged) and a second T2-4 threshold quorum bypass (#3499)**
+— plus a broader-surface hunt that verified the rest of the recently-shipped runtime clean. The heavy remainder
+is owner-gated;
 it is now one vote from build in three genuinely-parallel lanes (B / C / D), with the two nearest rungs
 (T3-5, T1-4) design-locked. Recommended fastest path: vote T3-5 + T1-4 to start B/C, and open Lane D on
 T3-6 (the differentiation move) in parallel. Sizing figures are optimistic build-effort, NOT calendar

--- a/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
+++ b/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
@@ -95,6 +95,24 @@ _(Additional decision-clean items surfaced by the review workflow are appended i
   (dual authz re-checked at fire, fail-closed, ledger-idempotent), W7 non-approved backwrite (opt-in,
   lock-fail-closed), SLA scheduler (per-row isolation, single-shot, in-txn deadline re-verify), T2-1+2 bulk
   reassign (`FOR UPDATE`, skips, ≤200 cap, N>M fail-closed). No other decision-clean defect surfaced.
+- **OPEN VERIFY-ITEM (potential 4th vector, NOT yet fixed):** the `#3499` cutoff keys off an `approve` record
+  whose `nextNodeKey` literally equals X. If an **intermediate condition/cc node sits between the upstream
+  return target and X** (`N1 → condition → X`, a linear flow), the upstream approve's `nextNodeKey` may be the
+  *condition* node (immediate successor), not X — in which case `cutoff=NULL` → whole-node fallback → the
+  through-X bypass could survive for that graph shape. **Not spiraled into a 4th reactive fix this turn**
+  (advisor guidance); logged as a verify-item feeding the structural decision below.
+
+## 6b. STRUCTURAL owner-decision — durable round-scoping vs reactive patching
+
+This is the **3rd patch to the same cutoff heuristic** (#3446 name-X · #3453 same-version cascade · #3499
+through-X), and the verify-item above may be a 4th. Reconstructing "which round am I in" by pattern-matching
+`nextNodeKey`/`targetNodeKey`/`toNodeKey` across append-only records is inherently whack-a-mole. The register's
+originally-proposed **Option B (`nodeEntryEpoch`)** — a per-node-entry epoch stamped at activation and carried
+on each approve record, so the tally filters `metadata.nodeEntryEpoch = <current>` — makes round-scoping
+**provably complete** regardless of entry vector, at the cost of one schema/stamping change (#3446 deferred it
+as "simpler without it"). **Owner decision:** keep patching the cutoff heuristic reactively, OR do the one
+`nodeEntryEpoch` migration that closes the class. Recommend the epoch; it retires this whole bug family
+(and the verify-item) in one ratified change.
 
 ## 7. Bottom line
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4735,26 +4735,33 @@ export class ApprovalProductService {
         // write an action='approve' record carrying metadata.nodeKey (Q5).
         const threshold = executor.getApprovalThreshold(currentNodeKey)
         // T2-4 RE-ENTRY quorum fix: scope the DISTINCT-approver tally to the CURRENT node-entry round. A
-        // `threshold` node can be RETURNED/JUMPED back to after it already resolved (the 退回/return path admits
-        // any previously-visited approval node), and `approval_records` are append-only — so without scoping,
-        // approve records from a PRIOR entry still count toward N and re-satisfy the node on stale votes (a
-        // quorum bypass: a 2-of-3 that A+B already approved would resolve on a single fresh vote). The current
-        // round begins at the `to_version` of the most recent return/jump that re-entered THIS node; approve
-        // records are stamped `to_version = <bumped version>`, so those recorded AT-OR-AFTER the re-entry
-        // (`to_version >= cutoff`) belong to the current round. `>=` (not `>`) is deliberate: a return/jump can
-        // trigger an auto-approval cascade AT the re-entered node in the SAME transaction (insertAutoApprovalEvents
-        // writes those approve records at `to_version = <re-entry version> = cutoff`) — legitimate current-round
-        // votes that must count. Prior-round approves are strictly `< cutoff` (they predate the version bump), so
-        // `>=` admits the cascade without re-admitting stale votes. With NO re-entry (cutoff null) the tally is
-        // the whole-node count — byte-identical to the pre-fix behaviour (zero regression). The graph is validated
-        // ACYCLIC (executor cycle guards), so a threshold node is only re-enterable via a return/jump — this
-        // marker is complete (no forward-loop re-entry path).
+        // `threshold` node round-scoping. A threshold node X can be RE-ENTERED after it already resolved —
+        // either DIRECTLY (a return/jump targeting X) OR THROUGH X (a return/jump to an UPSTREAM node, then
+        // normal forward approval progressing back down to X). `approval_records` are append-only, so without
+        // round-scoping the prior round's approves at X still count toward N and re-satisfy the node on stale
+        // votes (a quorum bypass: a 2-of-3 that A+B already approved would resolve on a single fresh vote).
+        //
+        // The current round begins at the `to_version` of the most recent ENTRY into X — captured as ANY
+        // record that lands the instance on X:
+        //   • an upstream approve advancing into X: metadata.nextNodeKey = X AND metadata.nodeKey <> X.
+        //     The `<> X` guard EXCLUDES X's OWN partial-approve records (which carry nodeKey=X/nextNodeKey=X
+        //     and must not bump the cutoff mid-round), so only a transition FROM another node counts.
+        //   • a return/jump naming X explicitly: metadata.targetNodeKey = X OR metadata.toNodeKey = X.
+        // (The earlier fix only matched return/jump records that NAMED X, missing re-entry THROUGH X from an
+        // upstream return target — a real second bypass. Keying off the entry transition closes both.)
+        //
+        // Approve records are stamped `to_version = <bumped version>`; those AT-OR-AFTER the entry
+        // (`to_version >= cutoff`) belong to the current round. `>=` (not `>`) is deliberate: an entry can
+        // trigger an auto-approval cascade AT X in the SAME transaction (insertAutoApprovalEvents writes those
+        // at `to_version = entry version = cutoff`) — current-round votes that must count; prior-round approves
+        // are strictly `< cutoff`. cutoff is NULL only when X was never entered by a recorded transition (e.g.
+        // an immediately-active first node) AND never re-entered → the whole-node count, which for such a
+        // first-round-only node is exactly the current round.
         const reentryCutoffResult = await client.query<{ cutoff: number | string | null }>(
           `SELECT MAX(to_version) AS cutoff
              FROM approval_records
              WHERE instance_id = $1
-               AND action IN ('return', 'jump')
-               AND ( metadata->>'nextNodeKey' = $2
+               AND ( ( metadata->>'nextNodeKey' = $2 AND COALESCE(metadata->>'nodeKey', '') <> $2 )
                   OR metadata->>'targetNodeKey' = $2
                   OR metadata->>'toNodeKey' = $2 )`,
           [id, currentNodeKey],

--- a/packages/core-backend/tests/integration/approval-nofm-threshold.test.ts
+++ b/packages/core-backend/tests/integration/approval-nofm-threshold.test.ts
@@ -129,6 +129,46 @@ function buildThresholdReentryGraph() {
   }
 }
 
+// Re-entry THROUGH the threshold node (not TO it): an upstream approval node precedes X, and the RETURN
+// targets that UPSTREAM node. The return record names the upstream node, NOT X — so a cutoff that only
+// matched return/jump records naming X missed this vector. Forward approval then progresses upstream→X,
+// re-entering X while its prior-round approves persist. This is a distinct second bypass from the direct
+// return-to-X case above.
+function buildThresholdThroughReentryGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_upstream',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-p'], approvalMode: 'single' },
+      },
+      {
+        key: 'approval_threshold',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a', 'approver-b', 'approver-c'],
+          approvalMode: 'threshold',
+          approvalThreshold: 2,
+        },
+      },
+      {
+        key: 'approval_second',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-a'], approvalMode: 'single' },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-upstream', source: 'start', target: 'approval_upstream' },
+      { key: 'edge-upstream-threshold', source: 'approval_upstream', target: 'approval_threshold' },
+      { key: 'edge-threshold-second', source: 'approval_threshold', target: 'approval_second' },
+      { key: 'edge-second-end', source: 'approval_second', target: 'end' },
+    ],
+  }
+}
+
 // Same re-entry shape as above, but the threshold node includes the requester and enables
 // merge-with-requester auto approval. On RETURN, the auto-approval audit row is inserted
 // at the SAME to_version as the return record. That legitimate current-round vote must
@@ -542,6 +582,57 @@ describeIfDatabase('Approval T2-4 N-of-M threshold (门槛会签) API', () => {
     expect(afterFresh.currentNodeKey).toBe('approval_threshold')
 
     // A SECOND fresh distinct approval resolves the current round → advances again (fresh quorum still works).
+    const afterFresh2 = await act(bTok, { action: 'approve', comment: 'B r2 (2 of 2)' })
+    expect(afterFresh2.currentNodeKey).toBe('approval_second')
+  })
+
+  it('does NOT re-satisfy a threshold node RE-ENTERED THROUGH an upstream return target (second bypass)', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-threshold')
+    const requesterToken = await authToken(baseUrl, 'requester-threshold')
+    const pTok = await authToken(baseUrl, 'approver-p')
+    const aTok = await authToken(baseUrl, 'approver-a')
+    const bTok = await authToken(baseUrl, 'approver-b')
+
+    const templateId = await publishGraphTemplate(adminToken, buildThresholdThroughReentryGraph())
+    const create = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 'through re-entry quorum' } },
+    })
+    expect(create.status).toBe(201)
+    const inst = (await create.json()) as { id: string; currentNodeKey: string | null }
+    createdApprovalIds.add(inst.id)
+    expect(inst.currentNodeKey).toBe('approval_upstream')
+
+    const act = async (token: string, body: object) =>
+      (await jsonRequest(baseUrl, `/api/approvals/${inst.id}/actions`, token, { method: 'POST', body })).json() as Promise<{
+        status: string
+        currentNodeKey: string | null
+      }>
+
+    // Round 1: P approves upstream → advances to threshold; A + B approve the 2-of-3 → advances to second.
+    const afterP = await act(pTok, { action: 'approve', comment: 'P r1' })
+    expect(afterP.currentNodeKey).toBe('approval_threshold')
+    await act(aTok, { action: 'approve', comment: 'A r1' })
+    const afterB = await act(bTok, { action: 'approve', comment: 'B r1' })
+    expect(afterB.currentNodeKey).toBe('approval_second')
+
+    // RETURN to the UPSTREAM node — the return record names approval_upstream, NOT approval_threshold.
+    // This is the vector the earlier (name-X-only) cutoff missed.
+    const afterReturn = await act(aTok, { action: 'return', targetNodeKey: 'approval_upstream', comment: 'send back upstream' })
+    expect(afterReturn.currentNodeKey).toBe('approval_upstream')
+
+    // Round 2: P re-approves upstream → forward INTO the threshold node (re-entry THROUGH X).
+    const afterP2 = await act(pTok, { action: 'approve', comment: 'P r2' })
+    expect(afterP2.currentNodeKey).toBe('approval_threshold')
+
+    // ONE fresh approval must NOT re-satisfy the 2-of-3 on the stale round-1 A+B votes.
+    // (Pre-fix: cutoff query finds no return/jump NAMING approval_threshold → cutoff NULL → whole-node tally
+    // counts round-1 A+B → single vote resolves and the instance would already be at approval_second.)
+    const afterFresh = await act(aTok, { action: 'approve', comment: 'A r2 (1 of 2)' })
+    expect(afterFresh.status).toBe('pending')
+    expect(afterFresh.currentNodeKey).toBe('approval_threshold')
+
+    // A second fresh distinct approval resolves the current round → advances.
     const afterFresh2 = await act(bTok, { action: 'approve', comment: 'B r2 (2 of 2)' })
     expect(afterFresh2.currentNodeKey).toBe('approval_second')
   })


### PR DESCRIPTION
A **second** T2-4 threshold quorum bypass, found by an adversarial hunt in the `/goal` batch — it extends my earlier re-entry fix (#3446) and is decision-clean (the round-scoped semantics were already the chosen intent; the implementation was incomplete). Follows #3497 (the node-timeout deadline race), which merged.

## Bug
The re-entry cutoff only matched return/jump records that **named** the threshold node X (`nextNodeKey`/`targetNodeKey`/`toNodeKey` = X). But an acyclic graph re-enters X whenever a return/jump targets an **upstream ancestor Y** and normal forward approval then progresses Y→…→X — that return/jump names **Y, not X**, and the forward step is an `approve` at Y with `nextNodeKey=X` (never inspected). So `cutoff=NULL` → the tally fell back to the whole-node distinct count → append-only prior-round approves at X were re-counted → **a single fresh vote re-satisfied the quorum**.

Concrete: `N1 → X(2-of-3) → N3`. A+B approve X (resolves → N3); return N3→**N1**; re-approve N1 → forward into X; then **one** approver re-resolves the 2-of-3.

## Fix
Key the cutoff off the **entry transition** into X, not just records naming X: `MAX(to_version)` over records where `metadata.nextNodeKey = X AND metadata.nodeKey <> X` (an upstream approve/return landing on X; the `<> X` guard excludes X's own partial-approve records so a mid-round partial can't bump the cutoff) OR `targetNodeKey = X` OR `toNodeKey = X`. `>= cutoff` unchanged (same-transaction entry cascades still count). Documented consequence: cutoff is now non-NULL on the first round too — correct, because all round-1 approves at X are `>=` the advance version; the stale "byte-identical / marker-complete" comments are corrected.

## Verification
tsc 0 · real-DB `approval-nofm-threshold` **6/6** incl. a **new fail-first test** (N1→X(2-of-3)→N3; A+B approve → return to the **upstream** node → re-approve forward into X → one fresh vote must NOT re-resolve). **RED-before confirmed** (name-X-only cutoff reverted → the single vote resolves → instance at `approval_second`). The prior direct-re-entry test + the same-version-cascade `>=` regression + timeout-effects 13/13 all still green.

Part of the `/goal` batch; the plan + T3-5 design-lock + T1-4 build-spec + dev/verification MD landed in #3497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)