### PR TITLE
docs(agents): PR-body rule — no bare closing keywords for issues that outlive the PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 ## Commit & Pull Request Guidelines
 - Follow conventional commit prefixes seen in history (e.g., `feat(data-adapters): ...`, `perf(phase11): ...`, `chore(deps): ...`, `docs: ...`); include a scope when possible.
 - PRs should state what changed, why, and how to verify (commands run, coverage snippets). Link relevant issues or Phase docs; attach UI screenshots/GIFs for frontend changes and note migration/rollback steps for backend DB updates.
+- In PR bodies, avoid bare GitHub closing keywords such as `closes #NNN` or `fixes #NNN` for issues that must outlive the PR, including umbrellas and staged follow-ups. Break keyword adjacency instead, such as `close umbrella #NNN` or `#NNN is then closed`; #3317 was accidentally auto-closed by #3491 this way and reopened on 2026-07-02.
 - Keep branches small and single-purpose; update checklists in `trigger-checks.md` when relevant.
 
 ## Security & Configuration Tips


### PR DESCRIPTION
## Why

Umbrella #3317 was accidentally auto-closed one second after the #3491 merge: the PR body's after-merge notes contained a bare `close #3317`, which GitHub parses as a closing reference. It was reopened on 2026-07-02 with a root-cause comment. The owner authored a cross-agent prevention rule in the canonical checkout's `AGENTS.md`, but both agent lanes (Codex and Claude) read `AGENTS.md` from fresh `origin/main` worktrees at session start — the rule only takes effect once it lands on main. This PR lifts the owner's line verbatim (one insertion in the Commit & Pull Request Guidelines section).

## What

`AGENTS.md` +1: avoid bare GitHub closing keywords (`closes #NNN` / `fixes #NNN`) in PR bodies for issues that must outlive the PR (umbrellas, staged follow-ups); break keyword adjacency instead (`close umbrella #NNN`, `#NNN is then closed`); records the #3317/#3491 incident and the 2026-07-02 reopen.

Docs-only, one line, no code/CI changes. (This PR body itself follows the rule — the incident references above carry no keyword-adjacent closing forms.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)