### PR TITLE
feat(approval): durable T2-4 threshold round-scoping via per-node-entry epoch (implements #3501)

### DIFF
--- a/docs/development/node-entry-epoch-implementation-dev-verification-20260703.md
+++ b/docs/development/node-entry-epoch-implementation-dev-verification-20260703.md
@@ -1,0 +1,66 @@
+# nodeEntryEpoch implementation — dev & verification (2026-07-03)
+
+> Implements the ratified design-lock (#3501) — the **structural close** for the T2-4 threshold round-scoping
+> bug family. Replaces the append-only cutoff heuristic (#3446/#3453/#3499) with a per-node-entry epoch
+> recorded at *activation*. **Honest framing:** this is a **completeness-by-construction / heuristic-retirement**
+> change, not a live-bug fix — the previously-feared condition/cc "4th vector" turns out **not** to be reachable
+> (the executor transparently skips condition/cc nodes, so a forward re-entry still threads `nextNodeKey=X` and
+> #3499's clause already scopes it). The epoch's value is that round-scoping stops depending on transition
+> inference at all.
+
+## What shipped
+
+- **Migration** (`zzzz20260703120000_add_node_entry_epoch.ts`): `approval_instances.node_activation_seq
+  INTEGER NOT NULL DEFAULT 0` + `approval_assignments.entry_epoch INTEGER` (nullable). Idempotent; reversible
+  (up→2 cols, down→0, verified).
+- **Helpers:** `bumpNodeActivationSeq` (`UPDATE … +1 RETURNING`) and `currentNodeEntryEpoch`
+  (`SELECT DISTINCT entry_epoch … is_active=TRUE`; **fails closed** — 409 on empty, 500
+  `APPROVAL_NODE_ENTRY_EPOCH_MIXED` on multiple distinct epochs). `insertAssignments` gains an explicit
+  `entryEpoch: number|null` argument stamped on every inserted row.
+- **9 `insertAssignments` call-sites classified** (§4 two-semantics split):
+
+  | Site | class | epoch source |
+  |---|---|---|
+  | initial start (`created`) · admin `jump` · timeout-`jump` · `return` · forward advance (`resolveAfterApprove`) | **ACTIVATION** | `bumpNodeActivationSeq` (mint) |
+  | admin `reassign`/handover · timeout `transfer` · manual `transfer` · `add_sign` | **MUTATION** | preserve current epoch (read before deactivate; never bump) |
+
+  Admin reassign inserts **grouped-by-source-epoch** (strictly more correct for a multi-node parallel
+  handover — never manufactures a mixed-epoch node).
+- **Approve-record stamping:** the current node's epoch is resolved once at the top of the approve handler
+  while the actor's assignment is still active, and stamped as `metadata.nodeEntryEpoch` on every current-node
+  approve (partial / threshold / resolving). `insertAutoApprovalEvents` carries the activation epoch so a
+  same-transaction requester-merge/auto-vote counts in-round.
+- **Tally (§5/§6, dual-read):** resolve the current epoch from active assignments (fail-closed above); `null`
+  (legacy pre-migration activation) → the **retained** cutoff heuristic (#3446/#3499/#3453 — not deleted);
+  non-null → `COUNT(DISTINCT actor_id) … metadata->>'nodeKey'=X AND (metadata->>'nodeEntryEpoch')::int = epoch`.
+  In-flight instances switch transparently to the epoch path on their next re-activation. No backfill.
+- **No API leak:** the two columns are internal (read explicitly; DTO mappers use explicit camelCase fields,
+  no raw-row spread) — verified they don't reach approval responses.
+
+## Verification (independently re-run)
+
+- **New suite `approval-node-entry-epoch.test.ts` — 5/5:** condition/cc-in-the-middle (forward-looking
+  regression lock); mid-round **manual-transfer** epoch preservation; mid-round **admin-reassign** epoch
+  preservation (both assert `node_activation_seq` unchanged across the mutation); **mixed-epoch fail-closed**
+  (500, instance untouched); **migration dual-read** + re-activation takeover.
+- **Existing `approval-nofm-threshold.test.ts` — 6/6** (incl. #3446 direct re-entry, #3499 through-X, #3453
+  same-tx cascade) now pass **via the epoch tally** (instances are post-migration → epoch-stamped), proving
+  the epoch mechanism correctly scopes every prior re-entry scenario.
+- **Regression:** `approval-node-timeout-effects` 13/13 · `approval-node-sla-remind` 5/5 · modified mock-DB
+  unit suites `approval-product-service` + `approval-admin-jump-service` 100/100. `tsc --noEmit` 0.
+
+## Honest caveats
+
+- **No RED-before for the condition/cc vector** — it is not a currently-reproducible bug (see framing above);
+  the test is a green completeness lock, not a fail-first bug reproduction.
+- **Two pre-existing, unrelated type errors** in excluded test files (`approval-admin-jump-service.test.ts:683`
+  stray `version`; `approval-product-service.test.ts:2649` resolver-stub signature) surface only under a
+  tests-included typecheck; they predate this change, are outside the diff, and are not CI-gated
+  (`tsc --noEmit` excludes `**/*.test.ts`). Left as-is.
+
+## What it retires
+
+The cutoff heuristic (#3446/#3453/#3499) becomes a **dormant legacy fallback** for pre-migration in-flight
+instances only. New/re-activated threshold rounds are scoped by the epoch — provably complete, no
+transition-metadata inference. The cutoff code can be deleted after a deprecation window once no NULL-epoch
+instances remain.

--- a/packages/core-backend/src/db/migrations/zzzz20260703120000_add_node_entry_epoch.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260703120000_add_node_entry_epoch.ts
@@ -1,0 +1,45 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+/**
+ * nodeEntryEpoch — durable T2-4 threshold (门槛会签) round-scoping.
+ *
+ * Replaces the append-only cutoff heuristic (#3446 / #3453 / #3499) that inferred
+ * "which round am I in" from transition metadata with a per-node-entry epoch recorded
+ * AT activation. Two additive columns (see design-lock
+ * docs/development/node-entry-epoch-threshold-round-scoping-design-lock-20260703.md §3/§6):
+ *
+ *   - approval_instances.node_activation_seq: a per-instance monotonic counter bumped by 1
+ *     each time a node is activated. The post-increment value is that activation's epoch.
+ *     NOT NULL DEFAULT 0 so legacy rows read a stable baseline.
+ *   - approval_assignments.entry_epoch: the instance's post-increment node_activation_seq
+ *     stamped on every assignment row created in that activation. NULLABLE — pre-migration
+ *     (legacy) assignments carry NULL, which the tally treats as "use the cutoff fallback"
+ *     (dual-read, §6) so in-flight instances are never mis-counted.
+ *
+ * Additive + idempotent; no backfill (the dual-read fallback removes backfill risk).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const hasInstances = await checkTableExists(db, 'approval_instances')
+  if (hasInstances) {
+    await sql`ALTER TABLE approval_instances ADD COLUMN IF NOT EXISTS node_activation_seq INTEGER NOT NULL DEFAULT 0`.execute(db)
+  }
+
+  const hasAssignments = await checkTableExists(db, 'approval_assignments')
+  if (hasAssignments) {
+    await sql`ALTER TABLE approval_assignments ADD COLUMN IF NOT EXISTS entry_epoch INTEGER`.execute(db)
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const hasAssignments = await checkTableExists(db, 'approval_assignments')
+  if (hasAssignments) {
+    await sql`ALTER TABLE approval_assignments DROP COLUMN IF EXISTS entry_epoch`.execute(db)
+  }
+
+  const hasInstances = await checkTableExists(db, 'approval_instances')
+  if (hasInstances) {
+    await sql`ALTER TABLE approval_instances DROP COLUMN IF EXISTS node_activation_seq`.execute(db)
+  }
+}

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3415,8 +3415,11 @@ export class ApprovalProductService {
         ],
       )
 
-      await this.insertAssignments(client, instanceId, initial.assignments)
-      await this.insertAutoApprovalEvents(client, instanceId, 0, initial.status, initial.autoApprovalEvents)
+      // ACTIVATION (nodeEntryEpoch §4·A): initial node activation mints a fresh epoch. The
+      // same-transaction auto-approval cascade at this node carries that same epoch (§7).
+      const initialEntryEpoch = await this.bumpNodeActivationSeq(client, instanceId)
+      await this.insertAssignments(client, instanceId, initial.assignments, initialEntryEpoch)
+      await this.insertAutoApprovalEvents(client, instanceId, 0, initial.status, initial.autoApprovalEvents, initialEntryEpoch)
       await this.insertCcEvents(client, instanceId, 0, initial.status, initial.ccEvents)
       await this.insertApprovalRecord(client, instanceId, {
         action: 'created',
@@ -3659,7 +3662,9 @@ export class ApprovalProductService {
           resolution.totalSteps,
         ],
       )
-      await this.insertAssignments(client, id, resolution.assignments)
+      // ACTIVATION (nodeEntryEpoch §4·A): admin jump lands the instance on a (re)activated node.
+      const jumpEntryEpoch = await this.bumpNodeActivationSeq(client, id)
+      await this.insertAssignments(client, id, resolution.assignments, jumpEntryEpoch)
       await this.insertApprovalRecord(client, id, {
         action: 'jump',
         actorId: actor.userId,
@@ -3682,7 +3687,7 @@ export class ApprovalProductService {
           parallelStateCleared: Boolean(parallelState),
         },
       }, actor)
-      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
+      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents, jumpEntryEpoch)
       await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
       if (resolution.status === 'approved') {
         completionEvent = this.buildCompletionEvent(
@@ -3863,17 +3868,32 @@ export class ApprovalProductService {
 
         const nextVersion = instance.version + 1
         const actorName = actor.userName || actor.userId
-        const reassignments = sourceAssignments.rows.map((assignment) => ({
-          assignmentType: 'user' as const,
-          assigneeId: toUserId,
-          sourceStep: assignment.source_step ?? 0,
-          nodeKey: assignment.node_key || '',
-          metadata: {
-            reassignedFrom: fromUserId,
-            adminReassign: true,
-            previousAssignmentId: assignment.id,
-          },
-        }))
+        // MUTATION (nodeEntryEpoch §4·B): admin reassign / handover keeps the SAME round — the
+        // reassigned-in approver's approve must count toward the current quorum, so the handed seat
+        // PRESERVES its epoch (NEVER bump node_activation_seq). Read each seat's epoch off its
+        // STILL-ACTIVE source row (queried above, before the deactivate below). A user's seats are
+        // normally at one node/epoch; a parallel handover can span nodes, so insert grouped by epoch
+        // to never create a mixed-epoch node.
+        const reassignmentsByEpoch = new Map<
+          number | null,
+          Array<{ assignmentType: 'user'; assigneeId: string; sourceStep: number; nodeKey: string; metadata: Record<string, unknown> }>
+        >()
+        for (const assignment of sourceAssignments.rows) {
+          const epoch = assignment.entry_epoch ?? null
+          const bucket = reassignmentsByEpoch.get(epoch) ?? []
+          bucket.push({
+            assignmentType: 'user' as const,
+            assigneeId: toUserId,
+            sourceStep: assignment.source_step ?? 0,
+            nodeKey: assignment.node_key || '',
+            metadata: {
+              reassignedFrom: fromUserId,
+              adminReassign: true,
+              previousAssignmentId: assignment.id,
+            },
+          })
+          reassignmentsByEpoch.set(epoch, bucket)
+        }
 
         await client.query(
           `UPDATE approval_assignments
@@ -3884,7 +3904,9 @@ export class ApprovalProductService {
               AND is_active = TRUE`,
           [instanceId, fromUserId],
         )
-        await this.insertAssignments(client, instanceId, reassignments)
+        for (const [epoch, bucket] of reassignmentsByEpoch) {
+          await this.insertAssignments(client, instanceId, bucket, epoch)
+        }
         await client.query(
           `UPDATE approval_instances
               SET version = $2, updated_at = now()
@@ -4058,6 +4080,10 @@ export class ApprovalProductService {
         if (!targetUserId) {
           return await consumeAndSkip('skipped_invalid_config', 'transfer_target_missing')
         }
+        // MUTATION (nodeEntryEpoch §4·B): timeout transfer hands the node over WITHIN the same round.
+        // Read the current epoch BEFORE the node-wide deactivate below (afterwards the node is empty)
+        // and stamp the handed-to assignee with it; NEVER bump node_activation_seq.
+        const timeoutTransferEntryEpoch = await this.currentNodeEntryEpoch(client, id, currentNodeKey)
         // Hand the WHOLE node over: every active assignment at the node is deactivated and the
         // static target takes it (mode semantics reset to the single handed-over approver).
         await client.query(
@@ -4066,7 +4092,7 @@ export class ApprovalProductService {
            WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE`,
           [id, currentNodeKey],
         )
-        await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, targetUserId))
+        await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, targetUserId), timeoutTransferEntryEpoch)
         // Parity with the dispatch transfer: an in-place handover does not bump the instance version.
         await this.insertApprovalRecord(client, id, {
           action: 'transfer',
@@ -4138,7 +4164,9 @@ export class ApprovalProductService {
           resolution.totalSteps,
         ],
       )
-      await this.insertAssignments(client, id, resolution.assignments)
+      // ACTIVATION (nodeEntryEpoch §4·A): timeout-jump re-activates the jump target node.
+      const timeoutJumpEntryEpoch = await this.bumpNodeActivationSeq(client, id)
+      await this.insertAssignments(client, id, resolution.assignments, timeoutJumpEntryEpoch)
       await this.insertApprovalRecord(client, id, {
         action: 'jump',
         actorId: APPROVAL_TIMEOUT_SYSTEM_ACTOR,
@@ -4157,7 +4185,7 @@ export class ApprovalProductService {
           newAssignees,
         },
       })
-      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
+      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents, timeoutJumpEntryEpoch)
       await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
       if (resolution.status === 'approved') {
         completionEvent = this.buildCompletionEvent(
@@ -4311,8 +4339,12 @@ export class ApprovalProductService {
         if (!currentNodeKey) {
           throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
         }
+        // MUTATION (nodeEntryEpoch §4·B): manual transfer keeps the SAME round. Read the node's
+        // current epoch BEFORE deactivating the actor's seat (a single-approver node would be EMPTY at
+        // the read otherwise) and stamp the handed-to assignee with it; NEVER bump node_activation_seq.
+        const transferEntryEpoch = await this.currentNodeEntryEpoch(client, id, currentNodeKey)
         await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
-        await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, request.targetUserId))
+        await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, request.targetUserId), transferEntryEpoch)
         await this.insertApprovalRecord(client, id, {
           action: 'transfer',
           actorId: actor.userId,
@@ -4356,10 +4388,15 @@ export class ApprovalProductService {
             'APPROVAL_ADD_SIGN_IN_PARALLEL_UNSUPPORTED',
           )
         }
+        // MUTATION (nodeEntryEpoch §4·B): add-sign extends the CURRENT round — the added co-signer's
+        // approve must count toward the same quorum, so preserve the node's current epoch (its active
+        // siblings still hold it here — no deactivation precedes this insert); NEVER bump the seq.
+        const addSignEntryEpoch = await this.currentNodeEntryEpoch(client, id, currentNodeKey)
         await this.insertAssignments(
           client,
           id,
           executor.buildAddSignAssignments(currentNodeKey, targetUserIds, actor.userId),
+          addSignEntryEpoch,
         )
         await client.query(
           `UPDATE approval_instances SET version = $2, updated_at = now() WHERE id = $1`,
@@ -4592,7 +4629,11 @@ export class ApprovalProductService {
             resolution.totalSteps,
           ],
         )
-        await this.insertAssignments(client, id, resolution.assignments)
+        // ACTIVATION (nodeEntryEpoch §4·A): a return re-activates the target node — a FRESH round.
+        // Its same-transaction auto-approval cascade (e.g. requester merge) carries this new epoch,
+        // so the re-entered threshold node's stale prior-round votes (a different epoch) never count.
+        const returnEntryEpoch = await this.bumpNodeActivationSeq(client, id)
+        await this.insertAssignments(client, id, resolution.assignments, returnEntryEpoch)
         await this.insertApprovalRecord(client, id, {
           action: 'return',
           actorId: actor.userId,
@@ -4608,7 +4649,7 @@ export class ApprovalProductService {
             nextNodeKey: resolution.currentNodeKey,
           },
         }, actor)
-        await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
+        await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents, returnEntryEpoch)
         await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
         await client.query('COMMIT')
         this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
@@ -4662,6 +4703,14 @@ export class ApprovalProductService {
       }
 
       const approvalMode = executor.getApprovalMode(currentNodeKey)
+      // nodeEntryEpoch (§5): capture the current node's entry epoch NOW — while the resolving
+      // actor's assignment is still active (every mode below deactivates it) so the DISTINCT read
+      // is authoritative and fails closed on empty/mixed. Reused by the threshold tally (null =>
+      // legacy cutoff fallback; a single epoch => epoch tally) AND stamped onto this node's approve
+      // records so a later re-entry (a new epoch) never re-counts them.
+      const currentNodeEpoch = currentNodeKey
+        ? await this.currentNodeEntryEpoch(client, id, currentNodeKey)
+        : null
       // Approval aggregation semantics:
       //   'all'    (会签): deactivate only the actor's assignment, short-circuit if siblings remain.
       //   'any'    (或签): first approver wins — deactivate siblings with an audit trail
@@ -4695,6 +4744,8 @@ export class ApprovalProductService {
               approvalMode,
               aggregateComplete: false,
               remainingAssignments,
+              // nodeEntryEpoch (§4): every approve at this node carries its current round's epoch.
+              ...(currentNodeEpoch !== null ? { nodeEntryEpoch: currentNodeEpoch } : {}),
             },
           }, actor)
           await client.query('COMMIT')
@@ -4734,60 +4785,66 @@ export class ApprovalProductService {
         // across role rows / re-dispatch, and auto-approvals are included because they too
         // write an action='approve' record carrying metadata.nodeKey (Q5).
         const threshold = executor.getApprovalThreshold(currentNodeKey)
-        // T2-4 RE-ENTRY quorum fix: scope the DISTINCT-approver tally to the CURRENT node-entry round. A
-        // `threshold` node round-scoping. A threshold node X can be RE-ENTERED after it already resolved —
-        // either DIRECTLY (a return/jump targeting X) OR THROUGH X (a return/jump to an UPSTREAM node, then
-        // normal forward approval progressing back down to X). `approval_records` are append-only, so without
-        // round-scoping the prior round's approves at X still count toward N and re-satisfy the node on stale
-        // votes (a quorum bypass: a 2-of-3 that A+B already approved would resolve on a single fresh vote).
-        //
-        // The current round begins at the `to_version` of the most recent ENTRY into X — captured as ANY
-        // record that lands the instance on X:
-        //   • an upstream approve advancing into X: metadata.nextNodeKey = X AND metadata.nodeKey <> X.
-        //     The `<> X` guard EXCLUDES X's OWN partial-approve records (which carry nodeKey=X/nextNodeKey=X
-        //     and must not bump the cutoff mid-round), so only a transition FROM another node counts.
-        //   • a return/jump naming X explicitly: metadata.targetNodeKey = X OR metadata.toNodeKey = X.
-        // (The earlier fix only matched return/jump records that NAMED X, missing re-entry THROUGH X from an
-        // upstream return target — a real second bypass. Keying off the entry transition closes both.)
-        //
-        // Approve records are stamped `to_version = <bumped version>`; those AT-OR-AFTER the entry
-        // (`to_version >= cutoff`) belong to the current round. `>=` (not `>`) is deliberate: an entry can
-        // trigger an auto-approval cascade AT X in the SAME transaction (insertAutoApprovalEvents writes those
-        // at `to_version = entry version = cutoff`) — current-round votes that must count; prior-round approves
-        // are strictly `< cutoff`. cutoff is NULL only when X was never entered by a recorded transition (e.g.
-        // an immediately-active first node) AND never re-entered → the whole-node count, which for such a
-        // first-round-only node is exactly the current round.
-        const reentryCutoffResult = await client.query<{ cutoff: number | string | null }>(
-          `SELECT MAX(to_version) AS cutoff
-             FROM approval_records
-             WHERE instance_id = $1
-               AND ( ( metadata->>'nextNodeKey' = $2 AND COALESCE(metadata->>'nodeKey', '') <> $2 )
-                  OR metadata->>'targetNodeKey' = $2
-                  OR metadata->>'toNodeKey' = $2 )`,
-          [id, currentNodeKey],
-        )
-        const rawCutoff = reentryCutoffResult.rows[0]?.cutoff
-        const reentryCutoff = rawCutoff === null || rawCutoff === undefined ? null : Number(rawCutoff)
-        const priorApproversResult =
-          reentryCutoff === null
-            ? await client.query<{ count: string }>(
-                `SELECT COUNT(DISTINCT actor_id) AS count
-                   FROM approval_records
-                   WHERE instance_id = $1
-                     AND action = 'approve'
-                     AND metadata->>'nodeKey' = $2`,
-                [id, currentNodeKey],
-              )
-            : await client.query<{ count: string }>(
-                `SELECT COUNT(DISTINCT actor_id) AS count
-                   FROM approval_records
-                   WHERE instance_id = $1
-                     AND action = 'approve'
-                     AND metadata->>'nodeKey' = $2
-                     AND to_version >= $3`,
-                [id, currentNodeKey, reentryCutoff],
-              )
-        const priorDistinctApprovers = Number.parseInt(priorApproversResult.rows[0]?.count || '0', 10)
+        // T2-4 quorum tally scoped to the CURRENT node-entry round (nodeEntryEpoch, design-lock
+        // 2026-07-03 §5). `currentNodeEpoch` was resolved above from the node's ACTIVE assignments and
+        // already failed closed on an empty/mixed set. A threshold node X can be RE-ENTERED after it
+        // resolved — direct return/jump to X, forward re-entry THROUGH X from an upstream target,
+        // timeout-jump, OR forward through a condition/cc node in between. Each re-entry mints a FRESH
+        // epoch at activation, so the prior round's append-only approves carry a DIFFERENT epoch and can
+        // never re-satisfy N on stale votes. Complete for every entry vector by construction — no
+        // transition-metadata (nextNodeKey/targetNodeKey/toNodeKey/to_version) inference.
+        let priorDistinctApprovers: number
+        if (currentNodeEpoch === null) {
+          // Dual-read fallback (§6): a legacy pre-migration activation — the active assignments carry a
+          // NULL epoch and this round's approves have no metadata.nodeEntryEpoch. Keep the RETAINED
+          // cutoff heuristic (#3446/#3499 entry-transition cutoff + #3453 `>=` same-tx cascade) until the
+          // node next re-activates and stamps an epoch, at which point the instance transparently switches
+          // to the epoch path. Dormant legacy fallback — NOT deleted.
+          const reentryCutoffResult = await client.query<{ cutoff: number | string | null }>(
+            `SELECT MAX(to_version) AS cutoff
+               FROM approval_records
+               WHERE instance_id = $1
+                 AND ( ( metadata->>'nextNodeKey' = $2 AND COALESCE(metadata->>'nodeKey', '') <> $2 )
+                    OR metadata->>'targetNodeKey' = $2
+                    OR metadata->>'toNodeKey' = $2 )`,
+            [id, currentNodeKey],
+          )
+          const rawCutoff = reentryCutoffResult.rows[0]?.cutoff
+          const reentryCutoff = rawCutoff === null || rawCutoff === undefined ? null : Number(rawCutoff)
+          const priorApproversResult =
+            reentryCutoff === null
+              ? await client.query<{ count: string }>(
+                  `SELECT COUNT(DISTINCT actor_id) AS count
+                     FROM approval_records
+                     WHERE instance_id = $1
+                       AND action = 'approve'
+                       AND metadata->>'nodeKey' = $2`,
+                  [id, currentNodeKey],
+                )
+              : await client.query<{ count: string }>(
+                  `SELECT COUNT(DISTINCT actor_id) AS count
+                     FROM approval_records
+                     WHERE instance_id = $1
+                       AND action = 'approve'
+                       AND metadata->>'nodeKey' = $2
+                       AND to_version >= $3`,
+                  [id, currentNodeKey, reentryCutoff],
+                )
+          priorDistinctApprovers = Number.parseInt(priorApproversResult.rows[0]?.count || '0', 10)
+        } else {
+          // Epoch tally (§5): count DISTINCT approvers whose approve carries THIS node's current epoch.
+          // A plain indexed filter on the self-contained epoch — no join to the mutable assignment table.
+          const epochApproversResult = await client.query<{ count: string }>(
+            `SELECT COUNT(DISTINCT actor_id) AS count
+               FROM approval_records
+               WHERE instance_id = $1
+                 AND action = 'approve'
+                 AND metadata->>'nodeKey' = $2
+                 AND (metadata->>'nodeEntryEpoch')::int = $3`,
+            [id, currentNodeKey, currentNodeEpoch],
+          )
+          priorDistinctApprovers = Number.parseInt(epochApproversResult.rows[0]?.count || '0', 10)
+        }
         const distinctApproverCount = priorDistinctApprovers + 1
         // Deactivate the actor's own assignment first (whether or not the threshold is met).
         await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
@@ -4832,6 +4889,9 @@ export class ApprovalProductService {
               approvalThreshold: threshold,
               approvedCount: distinctApproverCount,
               remainingAssignments,
+              // nodeEntryEpoch (§4): this partial vote is a PRIOR approver the next round-mate's
+              // tally counts — it MUST carry the current round's epoch to be included.
+              ...(currentNodeEpoch !== null ? { nodeEntryEpoch: currentNodeEpoch } : {}),
             },
           }, actor)
           await client.query('COMMIT')
@@ -4981,12 +5041,18 @@ export class ApprovalProductService {
           resolution.totalSteps,
         ],
       )
-      await this.insertAssignments(client, id, resolution.assignments)
+      // ACTIVATION (nodeEntryEpoch §4·A): forward advance activates the NEXT node — a new epoch.
+      // The resolving approve record below stays on the CURRENT node's epoch (`currentNodeEpoch`,
+      // captured before any deactivation); only the newly-inserted assignments + the cascade at the
+      // next node carry `advanceEntryEpoch`.
+      const advanceEntryEpoch = await this.bumpNodeActivationSeq(client, id)
+      await this.insertAssignments(client, id, resolution.assignments, advanceEntryEpoch)
       const approveRecordMetadata: Record<string, unknown> = {
         nodeKey: currentNodeKey,
         nextNodeKey: resolution.currentNodeKey,
         approvalMode,
         aggregateComplete: true,
+        ...(currentNodeEpoch !== null ? { nodeEntryEpoch: currentNodeEpoch } : {}),
       }
       if (isInParallelRegion) {
         approveRecordMetadata.parallelNodeKey = parallelState?.parallelNodeKey
@@ -5055,7 +5121,7 @@ export class ApprovalProductService {
           },
         })
       }
-      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
+      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents, advanceEntryEpoch)
       await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
       const completionEvent = resolution.status === 'approved'
         ? this.buildCompletionEvent(
@@ -5313,27 +5379,107 @@ export class ApprovalProductService {
     )
   }
 
+  // nodeEntryEpoch (design-lock 2026-07-03 §4): `insertAssignments` is SHARED by node
+  // activations AND same-round assignee mutations, so the epoch is decided by the CALLER,
+  // never by "an insert happened". `entryEpoch` is stamped on `entry_epoch` for every row:
+  //   - ACTIVATION call-sites pass the freshly-bumped `bumpNodeActivationSeq` value (a new epoch).
+  //   - SAME-ROUND MUTATION call-sites pass the node's PRESERVED current epoch
+  //     (`currentNodeEntryEpoch`, read BEFORE the old rows are deactivated) — NEVER bumped.
+  // `null` is only passed by a mutation preserving a legacy (pre-migration) NULL epoch; it
+  // stamps SQL NULL so the dual-read fallback (§6) keeps scoping that round by the cutoff.
   private async insertAssignments(
     client: { query: typeof pool.query },
     instanceId: string,
     assignments: Array<{ assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string; sourceStep: number; metadata?: unknown }>,
+    entryEpoch: number | null,
   ): Promise<void> {
     await this.assertNoActiveAssignmentConflicts(client, instanceId, assignments)
     for (const assignment of assignments) {
       await client.query(
         `INSERT INTO approval_assignments
-         (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, metadata, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, TRUE, $6::jsonb, now(), now())`,
+         (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch, metadata, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, TRUE, $6, $7::jsonb, now(), now())`,
         [
           instanceId,
           assignment.assignmentType,
           assignment.assigneeId,
           assignment.sourceStep,
           assignment.nodeKey,
+          entryEpoch,
           JSON.stringify(assignment.metadata ?? {}),
         ],
       )
     }
+  }
+
+  // nodeEntryEpoch source (§3): a per-instance monotonic activation sequence. Bumped by 1
+  // at each node ACTIVATION; the post-increment value is that activation's epoch, stamped on
+  // the rows `insertAssignments` inserts for it. Same-round mutations MUST NOT call this.
+  private async bumpNodeActivationSeq(
+    client: { query: typeof pool.query },
+    instanceId: string,
+  ): Promise<number> {
+    const result = await client.query<{ node_activation_seq: number | string }>(
+      `UPDATE approval_instances
+          SET node_activation_seq = node_activation_seq + 1
+        WHERE id = $1
+      RETURNING node_activation_seq`,
+      [instanceId],
+    )
+    const raw = result.rows[0]?.node_activation_seq
+    if (raw === undefined || raw === null) {
+      throw new ServiceError(
+        'Failed to bump node activation sequence — approval instance not found',
+        500,
+        'APPROVAL_NODE_ACTIVATION_SEQ_MISSING',
+        { instanceId },
+      )
+    }
+    return Number(raw)
+  }
+
+  // nodeEntryEpoch resolution (§5): the CURRENT epoch of a node = the DISTINCT `entry_epoch`
+  // of its ACTIVE assignments (the authoritative current round). Fail closed rather than let
+  // a MAX() paper over an inconsistency:
+  //   - EMPTY (no active assignments) → structural error. The resolving actor's own assignment
+  //     is still active at the tally/read point, so a node being resolved/mutated must have ≥1.
+  //   - a single NULL epoch (legacy pre-migration activation) → return null → cutoff fallback (§6).
+  //   - exactly one non-NULL epoch → return it → epoch tally.
+  //   - mixed NULL/non-NULL, or >1 distinct non-NULL → a STRUCTURAL invariant violation (a single
+  //     round must never span epochs) → fail closed. Never MAX()-collapse.
+  private async currentNodeEntryEpoch(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    nodeKey: string,
+  ): Promise<number | null> {
+    const result = await client.query<{ entry_epoch: number | string | null }>(
+      `SELECT DISTINCT entry_epoch
+         FROM approval_assignments
+        WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE`,
+      [instanceId, nodeKey],
+    )
+    if (result.rows.length === 0) {
+      throw new ServiceError(
+        `Approval node ${nodeKey} has no active assignments to resolve the current entry epoch`,
+        409,
+        'APPROVAL_NODE_ENTRY_EPOCH_EMPTY',
+        { instanceId, nodeKey },
+      )
+    }
+    if (result.rows.length > 1) {
+      throw new ServiceError(
+        `Approval node ${nodeKey} active assignments span multiple entry epochs (structural invariant violated)`,
+        500,
+        'APPROVAL_NODE_ENTRY_EPOCH_MIXED',
+        {
+          instanceId,
+          nodeKey,
+          epochs: result.rows.map((row) => (row.entry_epoch === null ? null : Number(row.entry_epoch))),
+        },
+      )
+    }
+    const only = result.rows[0]?.entry_epoch
+    return only === null || only === undefined ? null : Number(only)
   }
 
   // Dynamic-source discriminator. `metadata.resolvedFrom` is written ONLY by
@@ -5412,12 +5558,19 @@ export class ApprovalProductService {
     }
   }
 
+  // nodeEntryEpoch (§4/§7): a same-transaction auto-approval cascade at a node's ENTRY carries
+  // the SAME epoch as the assignments that activation created — so a requester merge / auto-vote
+  // at a threshold node counts toward the round the tally scopes to. Callers pass the freshly
+  // bumped activation epoch; `null` (legacy activation) stamps nothing so the round stays on the
+  // cutoff fallback. Applied to the 'approve' rows the tally reads AND the 'sign' skip rows
+  // (harmless — the tally filters action='approve').
   private async insertAutoApprovalEvents(
     client: { query: typeof pool.query },
     instanceId: string,
     version: number,
     status: string,
     autoApprovalEvents: ApprovalGraphAutoApprovalEvent[],
+    entryEpoch: number | null,
   ): Promise<void> {
     for (const event of autoApprovalEvents) {
       const skipped = event.metadata?.skipped === true
@@ -5439,6 +5592,7 @@ export class ApprovalProductService {
           autoApproved: true,
           reason: event.reason,
           ...(event.metadata ?? {}),
+          ...(entryEpoch !== null ? { nodeEntryEpoch: entryEpoch } : {}),
         },
       })
     }

--- a/packages/core-backend/src/services/approval-bridge-types.ts
+++ b/packages/core-backend/src/services/approval-bridge-types.ts
@@ -180,6 +180,9 @@ export interface ApprovalAssignmentRow {
   node_key: string | null
   is_active: boolean
   metadata: Record<string, unknown>
+  // nodeEntryEpoch (design-lock 2026-07-03): the instance's node_activation_seq at the
+  // activation that created this assignment. NULL for pre-migration (legacy) rows.
+  entry_epoch?: number | null
   created_at: Date
   updated_at: Date
 }

--- a/packages/core-backend/tests/integration/approval-node-entry-epoch.test.ts
+++ b/packages/core-backend/tests/integration/approval-node-entry-epoch.test.ts
@@ -1,0 +1,537 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+// nodeEntryEpoch (design-lock 2026-07-03) — durable T2-4 threshold round-scoping.
+// These tests exercise the epoch mechanism itself (§9): the condition/cc-in-the-middle 4th
+// vector, mid-round assignee mutations that PRESERVE the epoch, the mixed-epoch fail-closed
+// belt, and the migration dual-read fallback. The pre-existing behavioural regressions
+// (#3446 / #3499 / #3453) live in approval-nofm-threshold.test.ts and must stay green there.
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+type JsonRecord = Record<string, unknown>
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = (await response.json()) as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+) {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+function buildFormSchema() {
+  return { fields: [{ id: 'reason', type: 'text', label: '事由', required: true }] }
+}
+
+// A bare threshold (2-of-3) node → end. Used for the mid-round mutation + mixed-epoch cases.
+function buildThresholdGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_threshold',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a', 'approver-b', 'approver-c'],
+          approvalMode: 'threshold',
+          approvalThreshold: 2,
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-threshold', source: 'start', target: 'approval_threshold' },
+      { key: 'edge-threshold-end', source: 'approval_threshold', target: 'end' },
+    ],
+  }
+}
+
+// Threshold (2-of-3) → a second single node, so an approver can RETURN to the resolved
+// threshold node and re-activate it (the dual-read migration test drives this).
+function buildThresholdReentryGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_threshold',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a', 'approver-b', 'approver-c'],
+          approvalMode: 'threshold',
+          approvalThreshold: 2,
+        },
+      },
+      {
+        key: 'approval_second',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-a'], approvalMode: 'single' },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-threshold', source: 'start', target: 'approval_threshold' },
+      { key: 'edge-threshold-second', source: 'approval_threshold', target: 'approval_second' },
+      { key: 'edge-second-end', source: 'approval_second', target: 'end' },
+    ],
+  }
+}
+
+// The design-lock's headline 4th vector: a CONDITION node sits between the upstream approval node
+// and the threshold node X. N1(approval) → condition → X(2-of-3) → N3. The executor traverses the
+// condition transparently, so forward re-entry lands the instance on X. The epoch is minted when X
+// is ACTIVATED (entry vector irrelevant), so a re-entered round never re-counts the prior round.
+function buildConditionInMiddleGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_upstream',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-p'], approvalMode: 'single' },
+      },
+      {
+        key: 'condition_route',
+        type: 'condition',
+        config: {
+          // Deterministic route to X: the branch matches reason='route', and the default also
+          // points at X, so the instance always forwards into the threshold node.
+          branches: [{ edgeKey: 'edge-cond-threshold', rules: [{ fieldId: 'reason', operator: 'eq', value: 'route' }] }],
+          defaultEdgeKey: 'edge-cond-threshold',
+        },
+      },
+      {
+        key: 'approval_threshold',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a', 'approver-b', 'approver-c'],
+          approvalMode: 'threshold',
+          approvalThreshold: 2,
+        },
+      },
+      {
+        key: 'approval_second',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['approver-a'], approvalMode: 'single' },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-upstream', source: 'start', target: 'approval_upstream' },
+      { key: 'edge-upstream-cond', source: 'approval_upstream', target: 'condition_route' },
+      { key: 'edge-cond-threshold', source: 'condition_route', target: 'approval_threshold' },
+      { key: 'edge-threshold-second', source: 'approval_threshold', target: 'approval_second' },
+      { key: 'edge-second-end', source: 'approval_second', target: 'end' },
+    ],
+  }
+}
+
+describeIfDatabase('Approval nodeEntryEpoch — durable threshold round-scoping', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+  const createdUserIds = new Set<string>()
+
+  const pool = () => poolManager.get()
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    const port = address && typeof address === 'object' ? address.port : undefined
+    expect(port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterAll(async () => {
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool().query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_metrics WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool().query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+      if (createdUserIds.size > 0) {
+        await pool().query('DELETE FROM users WHERE id = ANY($1::text[])', [[...createdUserIds]])
+      }
+    } finally {
+      await server?.stop()
+    }
+  })
+
+  async function ensureUsers(...ids: string[]): Promise<void> {
+    for (const id of ids) {
+      createdUserIds.add(id)
+      await pool().query(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active)
+         VALUES ($1, $2, $3, 'test', 'user', '[]'::jsonb, TRUE)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE, updated_at = now()`,
+        [id, `${id}@example.test`, id],
+      )
+    }
+  }
+
+  async function publishGraphTemplate(adminToken: string, approvalGraph: object): Promise<string> {
+    const templateKey = `epoch-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'nodeEntryEpoch Template',
+        description: 'nodeEntryEpoch integration',
+        formSchema: buildFormSchema(),
+        approvalGraph,
+      },
+    })
+    expect(templateResponse.status, await templateResponse.clone().text()).toBe(201)
+    const template = (await templateResponse.json()) as { id: string }
+    createdTemplateIds.add(template.id)
+
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status, await publishResponse.clone().text()).toBe(200)
+    return template.id
+  }
+
+  async function createApproval(requesterToken: string, templateId: string, reason: string): Promise<{
+    id: string
+    currentNodeKey: string | null
+  }> {
+    const create = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason } },
+    })
+    expect(create.status, await create.clone().text()).toBe(201)
+    const inst = (await create.json()) as { id: string; currentNodeKey: string | null }
+    createdApprovalIds.add(inst.id)
+    return inst
+  }
+
+  type ActResult = {
+    status: string
+    currentNodeKey: string | null
+    assignments: Array<{ assigneeId: string; isActive: boolean }>
+  }
+
+  function actor(token: string, instanceId: string) {
+    return async (body: object): Promise<ActResult> => {
+      const response = await jsonRequest(baseUrl, `/api/approvals/${instanceId}/actions`, token, {
+        method: 'POST',
+        body,
+      })
+      return (await response.json()) as ActResult
+    }
+  }
+
+  async function nodeActivationSeq(instanceId: string): Promise<number> {
+    const result = await pool().query<{ node_activation_seq: number }>(
+      `SELECT node_activation_seq FROM approval_instances WHERE id = $1`,
+      [instanceId],
+    )
+    expect(result.rows).toHaveLength(1)
+    return Number(result.rows[0].node_activation_seq)
+  }
+
+  async function activeAssigneeIds(instanceId: string): Promise<string[]> {
+    const result = await pool().query<{ assignee_id: string }>(
+      `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY assignee_id`,
+      [instanceId],
+    )
+    return result.rows.map((row) => row.assignee_id)
+  }
+
+  it('condition-in-the-middle: a re-entered threshold node does NOT re-resolve on stale prior-round votes (4th vector)', async () => {
+    const adminToken = await authToken(baseUrl, 'epoch-admin-condition')
+    const requesterToken = await authToken(baseUrl, 'epoch-requester-condition')
+    const pTok = await authToken(baseUrl, 'approver-p')
+    const aTok = await authToken(baseUrl, 'approver-a')
+    const bTok = await authToken(baseUrl, 'approver-b')
+
+    const templateId = await publishGraphTemplate(adminToken, buildConditionInMiddleGraph())
+    // reason='route' drives the condition branch to the threshold node.
+    const inst = await createApproval(requesterToken, templateId, 'route')
+    expect(inst.currentNodeKey).toBe('approval_upstream')
+
+    const act = { p: actor(pTok, inst.id), a: actor(aTok, inst.id), b: actor(bTok, inst.id) }
+
+    // ROUND 1: P approves the upstream node → forwards THROUGH the condition into X. A + B resolve the
+    // 2-of-3 → advances to the second node.
+    const afterP1 = await act.p({ action: 'approve', comment: 'P r1' })
+    expect(afterP1.currentNodeKey).toBe('approval_threshold')
+    await act.a({ action: 'approve', comment: 'A r1' })
+    const afterB1 = await act.b({ action: 'approve', comment: 'B r1' })
+    expect(afterB1.currentNodeKey).toBe('approval_second')
+
+    // Return to the UPSTREAM node (approver-a is the second node's approver). The return names the
+    // upstream node — the forward path back into X crosses the transparently-skipped condition node.
+    const afterReturn = await act.a({ action: 'return', targetNodeKey: 'approval_upstream', comment: 'send back' })
+    expect(afterReturn.currentNodeKey).toBe('approval_upstream')
+
+    // ROUND 2: P re-approves upstream → forward through the condition, re-activating X (a FRESH epoch).
+    const afterP2 = await act.p({ action: 'approve', comment: 'P r2' })
+    expect(afterP2.currentNodeKey).toBe('approval_threshold')
+
+    // ONE fresh vote must NOT re-satisfy the 2-of-3 on the stale round-1 A+B approves (which carry the
+    // prior epoch). The epoch keys off X's ACTIVATION, so the condition-in-the-middle entry vector is
+    // irrelevant — round 2 starts at 0 prior votes.
+    const afterA2 = await act.a({ action: 'approve', comment: 'A r2 (1 of 2)' })
+    expect(afterA2.status).toBe('pending')
+    expect(afterA2.currentNodeKey).toBe('approval_threshold')
+
+    // A second distinct fresh vote resolves the fresh round → advances.
+    const afterB2 = await act.b({ action: 'approve', comment: 'B r2 (2 of 2)' })
+    expect(afterB2.currentNodeKey).toBe('approval_second')
+  })
+
+  it('mid-round MANUAL TRANSFER preserves the node epoch — the transferred-in approver counts in the same round', async () => {
+    const adminToken = await authToken(baseUrl, 'epoch-admin-transfer')
+    const requesterToken = await authToken(baseUrl, 'epoch-requester-transfer')
+    const aTok = await authToken(baseUrl, 'approver-a')
+    const bTok = await authToken(baseUrl, 'approver-b')
+    const dTok = await authToken(baseUrl, 'approver-d')
+
+    const templateId = await publishGraphTemplate(adminToken, buildThresholdGraph())
+    const inst = await createApproval(requesterToken, templateId, 'manual transfer preserves epoch')
+    expect(inst.currentNodeKey).toBe('approval_threshold')
+    const seqAtActivation = await nodeActivationSeq(inst.id)
+
+    const act = { a: actor(aTok, inst.id), b: actor(bTok, inst.id), d: actor(dTok, inst.id) }
+
+    // approver-a casts the first (partial) vote of the round.
+    const afterA = await act.a({ action: 'approve', comment: 'A partial (1 of 2)' })
+    expect(afterA.status).toBe('pending')
+    expect(afterA.currentNodeKey).toBe('approval_threshold')
+    expect(await nodeActivationSeq(inst.id)).toBe(seqAtActivation)
+
+    // approver-b hands their still-pending seat to approver-d MID-ROUND (manual transfer).
+    const seqBeforeTransfer = await nodeActivationSeq(inst.id)
+    const transfer = await jsonRequest(baseUrl, `/api/approvals/${inst.id}/actions`, bTok, {
+      method: 'POST',
+      body: { action: 'transfer', targetUserId: 'approver-d', comment: 'hand my seat to D' },
+    })
+    expect(transfer.status, await transfer.clone().text()).toBe(200)
+    // §4·B invariant: a same-round mutation must NOT bump node_activation_seq.
+    expect(await nodeActivationSeq(inst.id)).toBe(seqBeforeTransfer)
+    expect(await activeAssigneeIds(inst.id)).toEqual(['approver-c', 'approver-d'])
+
+    // The transferred-in D carries the SAME entry_epoch as the round; so A + D = 2 distinct → resolves.
+    const afterD = await act.d({ action: 'approve', comment: 'D (2 of 2, same round as A)' })
+    expect(afterD.status).toBe('approved')
+    expect(afterD.currentNodeKey).toBeNull()
+
+    // D's approve carries the current round's epoch and A + D were tallied together.
+    const epochRows = await pool().query<{ entry_epoch: number | null }>(
+      `SELECT DISTINCT entry_epoch FROM approval_assignments
+        WHERE instance_id = $1 AND node_key = 'approval_threshold' AND assignee_id IN ('approver-a', 'approver-d')`,
+      [inst.id],
+    )
+    expect(epochRows.rows).toHaveLength(1)
+    expect(epochRows.rows[0].entry_epoch).not.toBeNull()
+  })
+
+  it('mid-round ADMIN REASSIGN / handover preserves the node epoch — the reassigned-in approver counts in the same round', async () => {
+    await ensureUsers('approver-a', 'approver-b', 'approver-c', 'epoch-handover-to')
+    const adminToken = await authToken(baseUrl, 'epoch-admin-reassign')
+    const requesterToken = await authToken(baseUrl, 'epoch-requester-reassign')
+    const aTok = await authToken(baseUrl, 'approver-a')
+    const eTok = await authToken(baseUrl, 'epoch-handover-to')
+    // Process-admin (bulk reassign) surface.
+    const processAdmin = await authToken(baseUrl, 'epoch-process-admin')
+
+    const templateId = await publishGraphTemplate(adminToken, buildThresholdGraph())
+    const inst = await createApproval(requesterToken, templateId, 'admin reassign preserves epoch')
+    expect(inst.currentNodeKey).toBe('approval_threshold')
+
+    const act = { a: actor(aTok, inst.id), e: actor(eTok, inst.id) }
+
+    // approver-a casts the first (partial) vote of the round.
+    const afterA = await act.a({ action: 'approve', comment: 'A partial (1 of 2)' })
+    expect(afterA.status).toBe('pending')
+    expect(afterA.currentNodeKey).toBe('approval_threshold')
+
+    // Admin reassigns approver-b's still-pending seat to epoch-handover-to MID-ROUND.
+    const seqBeforeReassign = await nodeActivationSeq(inst.id)
+    const reassign = await jsonRequest(baseUrl, '/api/approvals/admin/reassign', processAdmin, {
+      method: 'POST',
+      body: {
+        fromUserId: 'approver-b',
+        toUserId: 'epoch-handover-to',
+        instanceIds: [inst.id],
+        reason: 'B unavailable mid-round',
+      },
+    })
+    expect(reassign.status, await reassign.clone().text()).toBe(200)
+    const reassignBody = (await reassign.json()) as { data: { succeeded: string[]; skipped: unknown[] } }
+    expect(reassignBody.data.succeeded).toEqual([inst.id])
+    // §4·B invariant: reassign is a same-round mutation → node_activation_seq unchanged.
+    expect(await nodeActivationSeq(inst.id)).toBe(seqBeforeReassign)
+    expect(await activeAssigneeIds(inst.id)).toEqual(['approver-c', 'epoch-handover-to'])
+
+    // The reassigned-in approver carries the round's epoch → A + handover-to = 2 distinct → resolves.
+    const afterE = await act.e({ action: 'approve', comment: 'handover-to (2 of 2, same round as A)' })
+    expect(afterE.status).toBe('approved')
+    expect(afterE.currentNodeKey).toBeNull()
+
+    const epochRows = await pool().query<{ entry_epoch: number | null }>(
+      `SELECT DISTINCT entry_epoch FROM approval_assignments
+        WHERE instance_id = $1 AND node_key = 'approval_threshold' AND assignee_id IN ('approver-a', 'epoch-handover-to')`,
+      [inst.id],
+    )
+    expect(epochRows.rows).toHaveLength(1)
+    expect(epochRows.rows[0].entry_epoch).not.toBeNull()
+  })
+
+  it('FAILS CLOSED when a threshold node active assignments span two distinct non-NULL epochs (§5 belt)', async () => {
+    const adminToken = await authToken(baseUrl, 'epoch-admin-mixed')
+    const requesterToken = await authToken(baseUrl, 'epoch-requester-mixed')
+    const aTok = await authToken(baseUrl, 'approver-a')
+
+    const templateId = await publishGraphTemplate(adminToken, buildThresholdGraph())
+    const inst = await createApproval(requesterToken, templateId, 'mixed epoch fail-closed')
+    expect(inst.currentNodeKey).toBe('approval_threshold')
+
+    // Deliberately corrupt the invariant: force approver-c's active seat onto a DIFFERENT non-NULL
+    // epoch so the node's active assignments span {n, n+9999} — a mis-classified insert would look
+    // like this. currentNodeEntryEpoch must fail closed rather than MAX()-collapse the tally.
+    const bump = await pool().query<{ count: string }>(
+      `UPDATE approval_assignments
+          SET entry_epoch = entry_epoch + 9999
+        WHERE instance_id = $1 AND node_key = 'approval_threshold' AND assignee_id = 'approver-c' AND is_active = TRUE`,
+      [inst.id],
+    )
+    expect(Number(bump.rowCount)).toBe(1)
+
+    const distinct = await pool().query<{ entry_epoch: number | null }>(
+      `SELECT DISTINCT entry_epoch FROM approval_assignments
+        WHERE instance_id = $1 AND node_key = 'approval_threshold' AND is_active = TRUE`,
+      [inst.id],
+    )
+    expect(distinct.rows.length).toBeGreaterThan(1)
+
+    const response = await jsonRequest(baseUrl, `/api/approvals/${inst.id}/actions`, aTok, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'A against a mixed-epoch node' },
+    })
+    expect(response.status).toBe(500)
+    const payload = (await response.json()) as { error?: { code?: string } }
+    expect(payload.error?.code).toBe('APPROVAL_NODE_ENTRY_EPOCH_MIXED')
+
+    // Fail-closed: the instance is untouched — still pending on the threshold node, no approve landed.
+    const state = await pool().query<{ status: string; current_node_key: string | null }>(
+      `SELECT status, current_node_key FROM approval_instances WHERE id = $1`,
+      [inst.id],
+    )
+    expect(state.rows[0].status).toBe('pending')
+    expect(state.rows[0].current_node_key).toBe('approval_threshold')
+    const approves = await pool().query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM approval_records WHERE instance_id = $1 AND action = 'approve'`,
+      [inst.id],
+    )
+    expect(Number.parseInt(approves.rows[0].count, 10)).toBe(0)
+  })
+
+  it('MIGRATION dual-read: a legacy NULL-epoch round scopes via the cutoff fallback, then the epoch path takes over on re-activation', async () => {
+    const adminToken = await authToken(baseUrl, 'epoch-admin-dualread')
+    const requesterToken = await authToken(baseUrl, 'epoch-requester-dualread')
+    const aTok = await authToken(baseUrl, 'approver-a')
+    const bTok = await authToken(baseUrl, 'approver-b')
+
+    const templateId = await publishGraphTemplate(adminToken, buildThresholdReentryGraph())
+    const inst = await createApproval(requesterToken, templateId, 'dual-read migration')
+    expect(inst.currentNodeKey).toBe('approval_threshold')
+
+    // Simulate a threshold instance that was pending mid-round AT DEPLOY: its active assignments
+    // carry entry_epoch = NULL (pre-migration activation). The instance counter is left intact so
+    // subsequent activations still mint fresh epochs.
+    const nulled = await pool().query(
+      `UPDATE approval_assignments SET entry_epoch = NULL WHERE instance_id = $1`,
+      [inst.id],
+    )
+    expect(Number(nulled.rowCount)).toBeGreaterThan(0)
+
+    const act = { a: actor(aTok, inst.id), b: actor(bTok, inst.id) }
+
+    // ROUND 1 runs entirely on the legacy (NULL-epoch) cutoff fallback: A partial keeps it pending,
+    // B resolves the 2-of-3 and advances. The two approves are written epoch-less.
+    const afterA1 = await act.a({ action: 'approve', comment: 'A r1 (legacy cutoff)' })
+    expect(afterA1.status).toBe('pending')
+    expect(afterA1.currentNodeKey).toBe('approval_threshold')
+    const afterB1 = await act.b({ action: 'approve', comment: 'B r1 (legacy cutoff resolves)' })
+    expect(afterB1.currentNodeKey).toBe('approval_second')
+
+    // The round-1 approves are epoch-less (dual-read wrote no nodeEntryEpoch for the NULL round).
+    const legacyApproves = await pool().query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM approval_records
+        WHERE instance_id = $1 AND action = 'approve'
+          AND metadata->>'nodeKey' = 'approval_threshold'
+          AND metadata ? 'nodeEntryEpoch'`,
+      [inst.id],
+    )
+    expect(Number.parseInt(legacyApproves.rows[0].count, 10)).toBe(0)
+
+    // RE-ACTIVATION: approver-a (at the second node) returns to the threshold node. The return path
+    // mints a FRESH epoch and stamps it on the re-activated seats — the instance switches to the
+    // epoch path.
+    const afterReturn = await act.a({ action: 'return', targetNodeKey: 'approval_threshold', comment: 'send back' })
+    expect(afterReturn.currentNodeKey).toBe('approval_threshold')
+    const reactivatedEpoch = await pool().query<{ entry_epoch: number | null }>(
+      `SELECT DISTINCT entry_epoch FROM approval_assignments
+        WHERE instance_id = $1 AND node_key = 'approval_threshold' AND is_active = TRUE`,
+      [inst.id],
+    )
+    expect(reactivatedEpoch.rows).toHaveLength(1)
+    expect(reactivatedEpoch.rows[0].entry_epoch).not.toBeNull()
+
+    // ROUND 2 is scoped by the epoch, which EXCLUDES the epoch-less round-1 votes: ONE fresh vote must
+    // NOT re-resolve on the stale legacy A+B approves.
+    const afterA2 = await act.a({ action: 'approve', comment: 'A r2 (1 of 2, epoch path)' })
+    expect(afterA2.status).toBe('pending')
+    expect(afterA2.currentNodeKey).toBe('approval_threshold')
+
+    // A second distinct fresh vote resolves the fresh round → advances again.
+    const afterB2 = await act.b({ action: 'approve', comment: 'B r2 (2 of 2, epoch path)' })
+    expect(afterB2.currentNodeKey).toBe('approval_second')
+  })
+})

--- a/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
@@ -273,6 +273,11 @@ function mockAdminJumpQueries(options: {
     if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
       return { rows: [], rowCount: assignments.length }
     }
+    // nodeEntryEpoch (2026-07-03): the admin jump is an ACTIVATION — it bumps node_activation_seq
+    // and stamps the new epoch. Answer the bump with a value BEFORE the broad UPDATE handler below.
+    if (statement.startsWith('UPDATE approval_instances SET node_activation_seq = node_activation_seq + 1')) {
+      return { rows: [{ node_activation_seq: 1 }], rowCount: 1 }
+    }
     if (statement.startsWith('UPDATE approval_instances')) {
       return { rows: [], rowCount: 1 }
     }
@@ -417,6 +422,7 @@ describe('ApprovalProductService adminJump', () => {
       'finance-1',
       2,
       'finance_review',
+      1, // entry_epoch (nodeEntryEpoch): the jump activation's bumped node_activation_seq
       '{}',
     ])
 
@@ -483,6 +489,7 @@ describe('ApprovalProductService adminJump', () => {
       'director-1',
       3,
       'director_review',
+      1, // entry_epoch (nodeEntryEpoch): the jump activation's bumped node_activation_seq
       '{}',
     ])
 
@@ -543,6 +550,7 @@ describe('ApprovalProductService adminJump', () => {
       'requester-1',
       2,
       'finance_review',
+      1, // entry_epoch (nodeEntryEpoch): the jump activation's bumped node_activation_seq
       JSON.stringify({ resolvedFrom: { kind: 'requester', sourceIndex: 0 } }),
     ])
 
@@ -593,6 +601,7 @@ describe('ApprovalProductService adminJump', () => {
       'director-1',
       3,
       'director_review',
+      1, // entry_epoch (nodeEntryEpoch): the jump activation's bumped node_activation_seq
       '{}',
     ])
 

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -235,8 +235,24 @@ function mockInsertOnlyClient() {
     if (statement.startsWith('INSERT INTO approval_records')) {
       return { rows: [], rowCount: 1 }
     }
-    throw new Error(`Unhandled client query: ${statement}`)
+    { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
   })
+}
+
+// nodeEntryEpoch (2026-07-03): the per-test mock routers predate the epoch columns, but the two
+// epoch queries flow through EVERY create/approve/return/mutation path. Answer them uniformly here
+// (checked right before each router's "Unhandled" throw) so no router needs to enumerate them:
+//   - the activation-seq bump returns a stable value callers only thread onward as the epoch;
+//   - currentNodeEntryEpoch returns a single NULL row, which keeps mock instances on the legacy
+//     cutoff fallback (§6) so every pre-existing round-scoping / metadata assertion is unaffected.
+function epochMockResult(statement: string): { rows: unknown[]; rowCount: number } | null {
+  if (statement.startsWith('UPDATE approval_instances SET node_activation_seq = node_activation_seq + 1')) {
+    return { rows: [{ node_activation_seq: 1 }], rowCount: 1 }
+  }
+  if (statement.startsWith('SELECT DISTINCT entry_epoch FROM approval_assignments')) {
+    return { rows: [{ entry_epoch: null }], rowCount: 1 }
+  }
+  return null
 }
 
 describe('ApprovalProductService', () => {
@@ -310,7 +326,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
         return { rows: [], rowCount: 0 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -384,7 +400,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
         return { rows: [], rowCount: 0 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -450,7 +466,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -508,7 +524,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -592,7 +608,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -688,7 +704,7 @@ describe('ApprovalProductService', () => {
           rowCount: 1,
         }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -784,7 +800,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -929,7 +945,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -1070,7 +1086,7 @@ describe('ApprovalProductService', () => {
           rowCount: 1,
         }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -1185,7 +1201,7 @@ describe('ApprovalProductService', () => {
           rowCount: 1,
         }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -1376,7 +1392,7 @@ describe('ApprovalProductService', () => {
         if (statement.startsWith('UPDATE approval_templates')) {
           return { rows: [{ id: 'tpl-formula', key: 'formula-template', name: 'Formula Template', description: null, category: null, visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft', active_version_id: null, latest_version_id: 'ver-formula', created_at: new Date('2026-06-25T00:00:00.000Z'), updated_at: new Date('2026-06-25T00:00:00.000Z') }], rowCount: 1 }
         }
-        throw new Error(`Unhandled query: ${statement}`)
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
       })
 
       const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -1534,7 +1550,7 @@ describe('ApprovalProductService', () => {
           rowCount: 1,
         }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -1783,7 +1799,7 @@ describe('ApprovalProductService', () => {
             rowCount: 1,
           }
         }
-        throw new Error(`Unhandled query: ${statement}`)
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
       })
     }
 
@@ -1984,7 +2000,7 @@ describe('ApprovalProductService', () => {
             rowCount: 1,
           }
         }
-        throw new Error(`Unhandled query: ${statement}`)
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
       })
     }
 
@@ -2222,7 +2238,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -2340,7 +2356,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -2412,7 +2428,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_instances')) return { rows: [], rowCount: 1 }
       if (statement.startsWith('INSERT INTO approval_assignments')) return { rows: [], rowCount: 1 }
       if (statement.startsWith('INSERT INTO approval_records')) return { rows: [], rowCount: 1 }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
   }
 
@@ -2705,7 +2721,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_instances')) return { rows: [], rowCount: 1 }
       if (statement.startsWith('INSERT INTO approval_assignments')) return { rows: [], rowCount: 1 }
       if (statement.startsWith('INSERT INTO approval_records')) return { rows: [], rowCount: 1 }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -2811,7 +2827,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -2943,7 +2959,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -3060,7 +3076,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -3245,7 +3261,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -3276,6 +3292,7 @@ describe('ApprovalProductService', () => {
       'requester-1',
       1,
       'approval_1',
+      1, // entry_epoch (nodeEntryEpoch): the initial activation's bumped node_activation_seq
       JSON.stringify({ resolvedFrom: { kind: 'requester', sourceIndex: 0 } }),
     ])
   })
@@ -3424,7 +3441,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -3475,6 +3492,7 @@ describe('ApprovalProductService', () => {
       'approver-42',
       1,
       'approval_1',
+      1, // entry_epoch (nodeEntryEpoch): the initial activation's bumped node_activation_seq
       JSON.stringify({ resolvedFrom: { kind: 'form_field_user', sourceIndex: 0, fieldId: 'reviewer' } }),
     ])
   })
@@ -3515,7 +3533,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_instances')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled client query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled client query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -3592,7 +3610,7 @@ describe('ApprovalProductService', () => {
     const assignmentInserts = pgState.client.query.mock.calls.filter(([sql]) =>
       normalize(sql as string).startsWith('INSERT INTO approval_assignments'))
     expect(assignmentInserts).toHaveLength(1)
-    expect(assignmentInserts[0]?.[1]).toEqual([expect.any(String), 'user', 'manager-2', 1, 'approval_1', '{}'])
+    expect(assignmentInserts[0]?.[1]).toEqual([expect.any(String), 'user', 'manager-2', 1, 'approval_1', 1, '{}'])
 
     const autoRecordCall = pgState.client.query.mock.calls.find(([sql, params]) =>
       normalize(sql as string).startsWith('INSERT INTO approval_records') &&
@@ -3692,7 +3710,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -3846,7 +3864,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -3972,7 +3990,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -4099,7 +4117,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -4210,7 +4228,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -4248,6 +4266,7 @@ describe('ApprovalProductService', () => {
       'requester-1',
       2,
       'requester-review',
+      1, // entry_epoch (nodeEntryEpoch): the forward-advance activation's bumped node_activation_seq
       JSON.stringify({ resolvedFrom: { kind: 'requester', sourceIndex: 0 } }),
     ])
   })
@@ -4336,7 +4355,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -4460,7 +4479,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -4490,7 +4509,7 @@ describe('ApprovalProductService', () => {
     const assignmentInserts = pgState.client.query.mock.calls.filter(([sql]) =>
       normalize(sql as string).startsWith('INSERT INTO approval_assignments'))
     expect(assignmentInserts).toHaveLength(1)
-    expect(assignmentInserts[0]?.[1]).toEqual(['apr-1', 'user', 'manager-1', 3, 'compliance-review', '{}'])
+    expect(assignmentInserts[0]?.[1]).toEqual(['apr-1', 'user', 'manager-1', 3, 'compliance-review', 1, '{}'])
 
     const skippedRecord = pgState.client.query.mock.calls.find(([sql, params]) =>
       normalize(sql as string).startsWith('INSERT INTO approval_records') &&
@@ -4606,13 +4625,13 @@ describe('ApprovalProductService', () => {
         return { rows: [], rowCount: 1 }
       }
       if (statement.startsWith('INSERT INTO approval_assignments')) {
-        expect(params).toEqual(['apr-1', 'user', 'legacy-manager', 2, 'approval_old_high', '{}'])
+        expect(params).toEqual(['apr-1', 'user', 'legacy-manager', 2, 'approval_old_high', 1, '{}'])
         return { rows: [], rowCount: 1 }
       }
       if (statement.startsWith('INSERT INTO approval_records')) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -4762,7 +4781,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -4854,7 +4873,7 @@ describe('ApprovalProductService', () => {
         return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
       }
       if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) return { rows: [], rowCount: 1 }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -4921,7 +4940,7 @@ describe('ApprovalProductService', () => {
         }
         if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
         if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) return { rows: [], rowCount: 1 }
-        throw new Error(`Unhandled query: ${statement}`)
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
       })
     }
 
@@ -5012,7 +5031,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) {
         return { rows: [], rowCount: 1 }
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
@@ -5139,7 +5158,7 @@ describe('ApprovalProductService', () => {
           template.active_version_id = 'ver-2'
           return { rows: [], rowCount: 1 }
         }
-        throw new Error(`Unhandled query: ${statement}`)
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
       })
       return client
     }
@@ -5211,7 +5230,7 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('INSERT INTO approval_published_definitions')) {
         throw new Error('insert failed')
       }
-      throw new Error(`Unhandled query: ${statement}`)
+      { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
     })
 
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')


### PR DESCRIPTION
Implements the ratified `nodeEntryEpoch` design-lock (#3501) — the **structural close** for the T2-4 threshold round-scoping bug family. Round-scoping stops inferring "which round" from append-only transition metadata (the cutoff heuristic that needed 3 patches: #3446/#3453/#3499) and instead **records the round at activation**.

**Honest framing:** this is **completeness-by-construction / heuristic-retirement**, not a live-bug fix. The previously-feared condition/cc "4th vector" turns out **not reachable** — the executor transparently skips condition/cc nodes, so a forward re-entry still threads `nextNodeKey=X` and #3499's clause already scopes it. The epoch's value is that scoping no longer depends on transition inference at all.

## What shipped
- **Migration:** `approval_instances.node_activation_seq` + `approval_assignments.entry_epoch` (nullable). Idempotent, reversible.
- **Helpers:** `bumpNodeActivationSeq`; `currentNodeEntryEpoch` (active-only DISTINCT read, **fails closed** — 409 empty / 500 mixed). `insertAssignments(entryEpoch)`.
- **9 call-sites classified (§4):** ACTIVATION (mint) = created / jump×2 / return / forward-advance; MUTATION (preserve, never bump) = admin-reassign / timeout-transfer / manual-transfer / add_sign (read epoch **before** deactivate). Admin reassign inserts grouped-by-source-epoch (correct for multi-node handover).
- **Approve stamping:** `metadata.nodeEntryEpoch` resolved once while the actor's assignment is active; cascade approves carry the activation epoch.
- **Tally (§5/§6 dual-read):** null epoch → **retained** cutoff heuristic (legacy in-flight, not deleted); non-null → epoch filter. Transparent switchover on next re-activation, no backfill.
- No API leak of the new columns (explicit-field DTO mappers).

## Verification (independently re-run by the reviewing session)
- **New `approval-node-entry-epoch` 5/5:** condition/cc lock · mid-round manual-transfer + admin-reassign preserve epoch (`node_activation_seq` unchanged) · mixed-epoch fail-closed · migration dual-read + takeover.
- **Existing `approval-nofm-threshold` 6/6** (incl. #3446/#3499/#3453) now pass **via the epoch tally** — proving the epoch scopes every prior re-entry scenario.
- Regression: timeout-effects 13/13 · node-sla 5/5 · modified mock-DB unit suites 100/100 · `tsc --noEmit` 0.

## Caveats (honest)
- No RED-before for the condition/cc vector (not a reproducible bug — see framing); it's a green completeness lock.
- Two pre-existing unrelated type errors in excluded test files (predate this change, outside the diff, not CI-gated). Left as-is.

Dev/verification MD: `docs/development/node-entry-epoch-implementation-dev-verification-20260703.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)