### PR TITLE
feat(approval): T1-4 node field-permissions authoring (linear editor, hidden+readonly)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -14,6 +14,8 @@ import type {
   FormFieldVisibilityRule,
   FormOption,
   FormSchema,
+  NodeFieldAccess,
+  NodeFieldPermission,
   CreateApprovalTemplateRequest,
   UpdateApprovalTemplateRequest,
 } from '../types/approval'
@@ -138,6 +140,13 @@ export interface ApprovalStepDraft {
   // mirroring `FieldAuthoringDraft.original`.
   mergeWithRequester: boolean
   originalAutoApprovalPolicy?: AutoApprovalPolicy
+  // T1-4 node-level field permissions (linear editor). One entry per NON-editable form field
+  // (`editable` is the absent default, so a field left editable carries no entry). Hydrated from
+  // `config.fieldPermissions` and re-emitted by `buildStepConfig`, which prunes entries whose field
+  // was deleted (backend cross-ref safety) and drops any `editable` entry. `hidden` is enforced at
+  // runtime (server echo-redaction, shipped #2799); `readonly` round-trips but is runtime-inert
+  // (enforcement deferred to T1-4b).
+  fieldPermissions: NodeFieldPermission[]
 }
 
 export interface TemplateAuthoringDraft {
@@ -260,6 +269,7 @@ export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
     approvalMode: 'single',
     emptyAssigneePolicy: 'error',
     mergeWithRequester: false,
+    fieldPermissions: [],
   }
 }
 
@@ -318,6 +328,39 @@ function formatIds(ids?: string[]): string {
 
 function isAuthorableFieldType(value: FormFieldType): value is AuthorableFieldType {
   return AUTHORABLE_FIELD_TYPES.includes(value as AuthorableFieldType)
+}
+
+function isNodeFieldAccess(value: unknown): value is NodeFieldAccess {
+  return value === 'editable' || value === 'readonly' || value === 'hidden'
+}
+
+/**
+ * T1-4: the access a step assigns to a form field — the matching `fieldPermissions` entry's access,
+ * or `editable` (the absent default) when the field has no entry. Pure; used by the authoring UI.
+ */
+export function stepFieldAccess(step: ApprovalStepDraft, fieldId: string): NodeFieldAccess {
+  const entry = step.fieldPermissions.find((permission) => permission.fieldId === fieldId)
+  return entry ? entry.access : 'editable'
+}
+
+/**
+ * T1-4: return a NEW `fieldPermissions` array with `fieldId` set to `access`. `editable` removes the
+ * entry (absent === editable === the byte-stable default); a non-editable access updates the entry
+ * IN PLACE (position-stable, so an untouched load→save keeps the hydrated order) or appends a new one.
+ * Pure — the caller assigns the result back so Vue reactivity fires.
+ */
+export function setStepFieldPermission(
+  permissions: NodeFieldPermission[],
+  fieldId: string,
+  access: NodeFieldAccess,
+): NodeFieldPermission[] {
+  if (access === 'editable') {
+    return permissions.filter((permission) => permission.fieldId !== fieldId)
+  }
+  if (permissions.some((permission) => permission.fieldId === fieldId)) {
+    return permissions.map((permission) => (permission.fieldId === fieldId ? { fieldId, access } : permission))
+  }
+  return [...permissions, { fieldId, access }]
 }
 
 function fieldDraftFromField(field: FormField): FieldAuthoringDraft | null {
@@ -391,6 +434,16 @@ function stepDraftFromApprovalNode(
   const autoApprovalPolicy = config.autoApprovalPolicy as AutoApprovalPolicy | undefined
   const mergeWithRequester = autoApprovalPolicy?.mergeWithRequester === true
 
+  // T1-4: hydrate node-level field permissions. Only well-formed { fieldId, access-in-enum } entries
+  // are carried; a malformed entry is separately caught by `unsupportedTemplateAuthoringReason`
+  // (fail-closed read-only) so it is never silently re-saved.
+  const fieldPermissions = Array.isArray(config.fieldPermissions)
+    ? config.fieldPermissions
+        .filter((entry): entry is NodeFieldPermission =>
+          isPlainRecord(entry) && typeof entry.fieldId === 'string' && isNodeFieldAccess(entry.access))
+        .map((entry) => ({ fieldId: entry.fieldId, access: entry.access }))
+    : []
+
   return {
     localId: nextLocalId('step'),
     name: node.name ?? `审批人 ${index}`,
@@ -403,6 +456,7 @@ function stepDraftFromApprovalNode(
     emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
     mergeWithRequester,
     ...(autoApprovalPolicy ? { originalAutoApprovalPolicy: autoApprovalPolicy } : {}),
+    fieldPermissions,
   }
 }
 
@@ -484,8 +538,9 @@ const RECOGNISED_GRAPH_NODE_TYPES = new Set([
 // The approval-node config keys the BACKEND `normalizeApprovalGraph` re-emits for a COMPLEX graph
 // (ApprovalProductService.ts:899-911). Any other key — TOP-LEVEL or NESTED — is silently dropped on
 // save. NB: this is the COMPLEX path's allowlist ONLY — the linear path reconstructs via
-// `buildStepConfig`, which does NOT preserve `fieldPermissions`, so the two allowlists must stay
-// SEPARATE (sharing would let a linear node's `fieldPermissions` through, then flatten it).
+// `buildStepConfig`, which authors + re-emits `fieldPermissions` (T1-4) but NOT `timeout` /
+// `approvalThreshold`, so the two allowlists must stay SEPARATE (sharing would let a linear node's
+// unrepresented key through, then flatten it).
 const BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS = [
   'assigneeType',
   'assigneeIds',
@@ -651,6 +706,9 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
       'approvalMode',
       'emptyAssigneePolicy',
       'autoApprovalPolicy',
+      // T1-4: `fieldPermissions` is now authored + preserved by the linear path (buildStepConfig),
+      // so it is no longer an unknown config key that would force the whole template read-only.
+      'fieldPermissions',
     ]
     if (Object.keys(config).some((key) => !allowedConfigKeys.includes(key))) return true
     const sources = config.assigneeSources
@@ -658,6 +716,17 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
       if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level'].includes(source?.kind)) return true
+    }
+    // T1-4: `buildStepConfig` re-emits only { fieldId, access } per entry (the backend allowlist),
+    // so a linear node carrying an ARRAY-shaped fieldPermissions with an extra key or non-object
+    // entry would be silently flattened on save — fail-closed to read-only instead (mirrors the
+    // complex path's `complexApprovalConfigHasBackendDrop`).
+    const perms = config.fieldPermissions
+    if (perms !== undefined) {
+      if (!Array.isArray(perms)) return true
+      for (const perm of perms) {
+        if (!isPlainRecord(perm) || hasKeyOutside(perm, BACKEND_FIELD_PERMISSION_KEYS)) return true
+      }
     }
     return false
   })
@@ -822,7 +891,7 @@ function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
  * mirroring `buildFormSchema`'s `delete next.visibilityRule` omit-empty discipline so a
  * bare `{}` is never persisted.
  */
-function buildStepConfig(step: ApprovalStepDraft): ApprovalNodeConfig {
+function buildStepConfig(step: ApprovalStepDraft, fieldIds: Set<string>): ApprovalNodeConfig {
   const autoApprovalPolicy: AutoApprovalPolicy = {
     ...step.originalAutoApprovalPolicy,
     ...(step.mergeWithRequester ? { mergeWithRequester: true } : {}),
@@ -832,11 +901,20 @@ function buildStepConfig(step: ApprovalStepDraft): ApprovalNodeConfig {
   if (!step.mergeWithRequester) {
     delete autoApprovalPolicy.mergeWithRequester
   }
+  // T1-4: emit only NON-editable entries (editable === absent default) whose field still exists —
+  // pruning an entry for a deleted field keeps the backend cross-reference
+  // (`validateNodeFieldPermissionsAgainstFormSchema`) satisfied. Omit the key entirely when empty
+  // (mirrors the autoApprovalPolicy omit-empty discipline so a bare `[]` is never persisted). Fresh
+  // objects so the emitted graph never aliases the reactive draft.
+  const fieldPermissions = step.fieldPermissions
+    .filter((permission) => permission.access !== 'editable' && fieldIds.has(permission.fieldId))
+    .map((permission) => ({ fieldId: permission.fieldId, access: permission.access }))
   return {
     assigneeSources: [sourceFromStep(step)],
     approvalMode: step.approvalMode,
     emptyAssigneePolicy: step.emptyAssigneePolicy,
     ...(Object.keys(autoApprovalPolicy).length > 0 ? { autoApprovalPolicy } : {}),
+    ...(fieldPermissions.length > 0 ? { fieldPermissions } : {}),
   }
 }
 
@@ -857,11 +935,14 @@ export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph
     // emptyAssigneePolicy / autoApprovalPolicy + every other node + ALL edges stay byte-identical.
     return applyApprovalNodeEditsToGraph(withCcEdits, draft.approvalNodeEdits ?? {})
   }
+  // T1-4: the set of live top-level form-field ids — `buildStepConfig` prunes any fieldPermission
+  // whose field was deleted so a dangling fieldId can never reach the backend cross-reference.
+  const fieldIds = new Set(draft.fields.map((field) => field.id.trim()).filter(Boolean))
   const approvalNodes = draft.steps.map((step, index) => ({
     key: `approval_${index + 1}`,
     type: 'approval' as const,
     name: step.name.trim() || `审批人 ${index + 1}`,
-    config: buildStepConfig(step),
+    config: buildStepConfig(step, fieldIds),
   }))
   const nodes: ApprovalGraph['nodes'] = [
     { key: 'start', type: 'start', name: '发起', config: {} },

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -439,8 +439,7 @@ function stepDraftFromApprovalNode(
   // (fail-closed read-only) so it is never silently re-saved.
   const fieldPermissions = Array.isArray(config.fieldPermissions)
     ? config.fieldPermissions
-        .filter((entry): entry is NodeFieldPermission =>
-          isPlainRecord(entry) && typeof entry.fieldId === 'string' && isNodeFieldAccess(entry.access))
+        .filter((entry): entry is NodeFieldPermission => !isBackendDroppedFieldPermission(entry))
         .map((entry) => ({ fieldId: entry.fieldId, access: entry.access }))
     : []
 
@@ -576,6 +575,19 @@ function hasKeyOutside(value: unknown, allowed: string[]): boolean {
   return isPlainRecord(value) && Object.keys(value).some((key) => !allowed.includes(key))
 }
 
+// T1-4: a `fieldPermissions[]` entry the backend `normalizeApprovalGraph` re-emits verbatim is EXACTLY
+// `{ fieldId: <non-empty string>, access: 'editable'|'readonly'|'hidden' }`. Anything else — an extra key,
+// a non-string/empty fieldId, OR an out-of-enum access value — is dropped/normalized away on save. Both the
+// linear authoring guard and the complex-drop check must treat such an entry as a backend-drop (fail-closed
+// to read-only) so hydrate/buildStepConfig never SILENTLY flattens it. Single source of truth for both.
+function isBackendDroppedFieldPermission(perm: unknown): boolean {
+  return !isPlainRecord(perm)
+    || hasKeyOutside(perm, BACKEND_FIELD_PERMISSION_KEYS)
+    || typeof perm.fieldId !== 'string'
+    || perm.fieldId.length === 0
+    || !isNodeFieldAccess(perm.access)
+}
+
 /**
  * True when a COMPLEX approval node's config carries a key — TOP-LEVEL or NESTED in assigneeSources[]
  * / autoApprovalPolicy / fieldPermissions[] — that the backend `normalizeApprovalGraph` does NOT
@@ -596,7 +608,7 @@ function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): b
   const perms = config.fieldPermissions
   if (Array.isArray(perms)) {
     for (const perm of perms) {
-      if (!isPlainRecord(perm) || hasKeyOutside(perm, BACKEND_FIELD_PERMISSION_KEYS)) return true
+      if (isBackendDroppedFieldPermission(perm)) return true
     }
   }
   return false
@@ -725,7 +737,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (perms !== undefined) {
       if (!Array.isArray(perms)) return true
       for (const perm of perms) {
-        if (!isPlainRecord(perm) || hasKeyOutside(perm, BACKEND_FIELD_PERMISSION_KEYS)) return true
+        if (isBackendDroppedFieldPermission(perm)) return true
       }
     }
     return false

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -56,6 +56,17 @@ export interface ApprovalNode {
     | Record<string, never>
 }
 
+// Byte-mirrors backend packages/core-backend/src/types/approval-product.ts:51-56 (P1-C node-level
+// field permissions). `editable` (the absent default) === current behavior. Only `hidden` is
+// enforced at runtime (server-side echo-redaction — already shipped in #2799); `readonly`/`editable`
+// are contract-stable but runtime-inert (readonly enforcement is deferred to T1-4b). The authoring
+// editor may set `hidden`/`readonly`; both round-trip, `readonly` carries a "not-yet-enforced" hint.
+export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden'
+export interface NodeFieldPermission {
+  fieldId: string
+  access: NodeFieldAccess
+}
+
 export interface ApprovalNodeConfig {
   assigneeType?: ApprovalAssigneeType
   assigneeIds?: string[]
@@ -63,6 +74,9 @@ export interface ApprovalNodeConfig {
   approvalMode?: ApprovalMode
   emptyAssigneePolicy?: EmptyAssigneePolicy
   autoApprovalPolicy?: AutoApprovalPolicy
+  // P1-C node-level field permissions. Default-absent === editable === current behavior. `hidden`
+  // entries are enforced server-side (echo-redaction); `readonly`/`editable` are runtime-inert.
+  fieldPermissions?: NodeFieldPermission[]
 }
 
 // Byte-mirrors backend packages/core-backend/src/types/approval-product.ts:121-128.

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1047,6 +1047,50 @@
               </el-checkbox>
             </el-form-item>
           </div>
+          <!-- T1-4 node field permissions: per-form-field access at this approval node. `隐藏` is
+               enforced at runtime (server echo-redaction); `只读` round-trips but is not yet enforced
+               (T1-4b). A field left `可编辑` carries no persisted entry (absent === editable). -->
+          <div class="template-authoring__field-perms" data-testid="approval-step-field-permissions">
+            <div class="template-authoring__field-perms-head">
+              <strong>字段权限</strong>
+              <span class="template-authoring__hint">
+                「隐藏」在审批到该节点时对所有查看者隐藏该字段（仅回显隐藏，不影响审批人解析与条件路由）；「只读」将在后续版本生效。字段默认为「可编辑」。
+              </span>
+            </div>
+            <div v-if="fieldPermissionFields.length === 0" class="template-authoring__hint">
+              请先在上方添加表单字段，即可为本步骤设置字段权限。
+            </div>
+            <div
+              v-for="field in fieldPermissionFields"
+              :key="field.id"
+              class="template-authoring__field-perm-row"
+              data-testid="approval-step-field-permission-row"
+            >
+              <span class="template-authoring__field-perm-label">{{ field.label || field.id }}（{{ field.id }}）</span>
+              <el-select
+                :model-value="stepFieldAccess(step, field.id)"
+                :disabled="readOnly"
+                size="small"
+                style="width: 130px"
+                :data-testid="`approval-step-field-access-${field.id}`"
+                @update:model-value="(access: NodeFieldAccess) => onStepFieldAccessChange(step, field.id, access)"
+              >
+                <el-option label="可编辑" value="editable" />
+                <el-option label="只读" value="readonly" />
+                <el-option label="隐藏" value="hidden" />
+              </el-select>
+              <span
+                v-if="stepFieldAccess(step, field.id) === 'readonly'"
+                class="template-authoring__hint"
+                data-testid="approval-step-field-readonly-hint"
+              >只读将在后续版本（T1-4b）生效，当前保存但暂不强制</span>
+              <span
+                v-else-if="stepFieldAccess(step, field.id) === 'hidden' && routingDriverFieldIds.has(field.id)"
+                class="template-authoring__hint template-authoring__hint--warn"
+                data-testid="approval-step-field-routing-hint"
+              >该字段被审批人来源引用；隐藏仅影响回显，不影响审批人解析</span>
+            </div>
+          </div>
         </div>
       </el-card>
 
@@ -1093,6 +1137,8 @@ import {
   draftFromTemplate,
   graphReadOnlyReason,
   parseIdsText,
+  stepFieldAccess,
+  setStepFieldPermission,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
   approvalFormulaInsertOptions,
@@ -1133,6 +1179,7 @@ import type {
   ApprovalNode,
   CcNodeConfig,
   ConditionNodeConfig,
+  NodeFieldAccess,
   ParallelJoinMode,
   ParallelNodeConfig,
 } from '../../types/approval'
@@ -1592,6 +1639,23 @@ function setApprovalSourceLevel(nodeKey: string, value: number): void {
 }
 
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))
+
+// T1-4 node field permissions: every top-level form field is a candidate for a per-node access
+// override (the linear editor shows the same field list for every approval step).
+const fieldPermissionFields = computed(() => draft.value.fields.filter((field) => field.id.trim()))
+// Form fields that DRIVE routing (a form_field_user assignee source references them). Hiding one is
+// allowed — redaction is echo-only, so resolution is unaffected — but the UI surfaces a hint.
+const routingDriverFieldIds = computed(() => {
+  const ids = new Set<string>()
+  for (const step of draft.value.steps) {
+    if (step.sourceKind === 'form_field_user' && step.fieldId.trim()) ids.add(step.fieldId.trim())
+  }
+  return ids
+})
+function onStepFieldAccessChange(step: ApprovalStepDraft, fieldId: string, access: NodeFieldAccess): void {
+  step.fieldPermissions = setStepFieldPermission(step.fieldPermissions, fieldId, access)
+}
+
 const formSchemaPreview = computed(() => JSON.stringify(buildFormSchema(draft.value), null, 2))
 const approvalGraphPreview = computed(() => JSON.stringify(buildApprovalGraph(draft.value), null, 2))
 

--- a/apps/web/tests/approval-template-authoring-field-permissions.test.ts
+++ b/apps/web/tests/approval-template-authoring-field-permissions.test.ts
@@ -120,6 +120,22 @@ describe('T1-4 linear field-permissions authoring', () => {
     expect(unsupportedTemplateAuthoringReason(template)).not.toBeNull()
   })
 
+  it('treats a fieldPermission entry with an OUT-OF-ENUM access as unsupported (fail-closed, never silent flatten)', () => {
+    // `access: 'bogus'` would pass hydrate's filter-then-drop → silently deleted on save. It must instead
+    // fail the linear guard to read-only. (Review P2.)
+    const template = buildTemplate(linearGraph([
+      { fieldId: 'secret', access: 'bogus' } as unknown as NodeFieldPermission,
+    ]))
+    expect(unsupportedTemplateAuthoringReason(template)).not.toBeNull()
+  })
+
+  it('treats a fieldPermission entry with a NON-STRING fieldId as unsupported (fail-closed)', () => {
+    const template = buildTemplate(linearGraph([
+      { fieldId: 123, access: 'hidden' } as unknown as NodeFieldPermission,
+    ]))
+    expect(unsupportedTemplateAuthoringReason(template)).not.toBeNull()
+  })
+
   it('hydrates the step draft with the node fieldPermissions', () => {
     const template = buildTemplate(linearGraph([
       { fieldId: 'secret', access: 'hidden' },

--- a/apps/web/tests/approval-template-authoring-field-permissions.test.ts
+++ b/apps/web/tests/approval-template-authoring-field-permissions.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO, NodeFieldPermission } from '../src/types/approval'
+import {
+  buildApprovalGraph,
+  draftFromTemplate,
+  setStepFieldPermission,
+  stepFieldAccess,
+  unsupportedTemplateAuthoringReason,
+  validateTemplateDraft,
+  type ApprovalStepDraft,
+} from '../src/approvals/templateAuthoring'
+
+// T1-4 — LINEAR-editor authoring of node-level field permissions (hidden + readonly). PURE-LOGIC
+// tests (no .vue) so they run under approval-web-guard. The GATE: a linear approval node's
+// `fieldPermissions` must (a) NOT force the template read-only, (b) round-trip through
+// hydrate→build (never flattened), (c) prune entries for deleted fields (backend cross-ref safety),
+// (d) omit itself when every field is `editable`, and (e) add NO blocking validation error for a
+// hidden routing-driver or a readonly field (non-blocking hint only). Runtime enforcement of
+// `hidden` (server echo-redaction) already shipped in #2799 and is covered by the backend suite.
+
+const FIELDS = [
+  { id: 'reason', type: 'text' as const, label: '事由', required: true },
+  { id: 'secret', type: 'text' as const, label: '机密', required: false },
+  { id: 'note', type: 'text' as const, label: '备注', required: false },
+  { id: 'approver', type: 'user' as const, label: '审批人', required: false },
+]
+
+// Linear start→approval_1→end. `approval_1` hides `secret`, marks `note` readonly, and resolves its
+// approver from the `approver` form field (so `approver` is a routing driver).
+function linearGraph(fieldPermissions: NodeFieldPermission[]): ApprovalGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      {
+        key: 'approval_1',
+        type: 'approval',
+        name: '主管',
+        config: {
+          assigneeSources: [{ kind: 'form_field_user', fieldId: 'approver' }],
+          approvalMode: 'single',
+          emptyAssigneePolicy: 'error',
+          fieldPermissions,
+        },
+      },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+    ],
+  }
+}
+
+function buildTemplate(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1', key: 'expense', name: '费用审批', description: null, category: null,
+    visibilityScope: { type: 'all', ids: [] }, slaHours: null, status: 'draft',
+    activeVersionId: null, latestVersionId: 'ver_1',
+    createdAt: '2026-07-02T00:00:00Z', updatedAt: '2026-07-02T00:00:00Z',
+    formSchema: { fields: FIELDS }, approvalGraph,
+  }
+}
+
+function approvalNodeConfig(graph: ApprovalGraph) {
+  const node = graph.nodes.find((candidate) => candidate.key === 'approval_1')
+  expect(node).toBeTruthy()
+  return node!.config as { fieldPermissions?: NodeFieldPermission[] }
+}
+
+describe('T1-4 linear field-permissions authoring', () => {
+  it('does NOT lock a linear template with fieldPermissions read-only (fieldPermissions is an allowed linear config key)', () => {
+    const template = buildTemplate(linearGraph([{ fieldId: 'secret', access: 'hidden' }]))
+    expect(unsupportedTemplateAuthoringReason(template)).toBeNull()
+  })
+
+  it('round-trips hidden + readonly fieldPermissions through hydrate→build (never flattened)', () => {
+    const template = buildTemplate(linearGraph([
+      { fieldId: 'secret', access: 'hidden' },
+      { fieldId: 'note', access: 'readonly' },
+    ]))
+    const draft = draftFromTemplate(template)
+    const rebuilt = buildApprovalGraph(draft)
+    const config = approvalNodeConfig(rebuilt)
+    expect(config.fieldPermissions).toEqual([
+      { fieldId: 'secret', access: 'hidden' },
+      { fieldId: 'note', access: 'readonly' },
+    ])
+  })
+
+  it('omits fieldPermissions entirely when every entry is the editable default', () => {
+    const template = buildTemplate(linearGraph([{ fieldId: 'secret', access: 'editable' }]))
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(approvalNodeConfig(rebuilt).fieldPermissions).toBeUndefined()
+  })
+
+  it('prunes a fieldPermission whose field was deleted (no dangling fieldId → backend cross-ref safe)', () => {
+    const template = buildTemplate(linearGraph([{ fieldId: 'secret', access: 'hidden' }]))
+    const draft = draftFromTemplate(template)
+    // Author deletes the `secret` field.
+    draft.fields = draft.fields.filter((field) => field.id !== 'secret')
+    const config = approvalNodeConfig(buildApprovalGraph(draft))
+    expect(config.fieldPermissions).toBeUndefined()
+  })
+
+  it('adds NO blocking validation error for a hidden routing-driver field or a readonly field', () => {
+    // `approver` is BOTH the form_field_user routing driver AND hidden; `note` is readonly.
+    const template = buildTemplate(linearGraph([
+      { fieldId: 'approver', access: 'hidden' },
+      { fieldId: 'note', access: 'readonly' },
+    ]))
+    const draft = draftFromTemplate(template)
+    const errors = validateTemplateDraft(draft, unsupportedTemplateAuthoringReason(template))
+    expect(errors).toEqual([])
+  })
+
+  it('treats a fieldPermission entry with an unknown key as unsupported (fail-closed, never silent flatten)', () => {
+    const template = buildTemplate(linearGraph([
+      { fieldId: 'secret', access: 'hidden', extra: 'x' } as unknown as NodeFieldPermission,
+    ]))
+    expect(unsupportedTemplateAuthoringReason(template)).not.toBeNull()
+  })
+
+  it('hydrates the step draft with the node fieldPermissions', () => {
+    const template = buildTemplate(linearGraph([
+      { fieldId: 'secret', access: 'hidden' },
+      { fieldId: 'note', access: 'readonly' },
+    ]))
+    const step = draftFromTemplate(template).steps[0]
+    expect(stepFieldAccess(step, 'secret')).toBe('hidden')
+    expect(stepFieldAccess(step, 'note')).toBe('readonly')
+    expect(stepFieldAccess(step, 'reason')).toBe('editable') // no entry === editable default
+  })
+})
+
+describe('T1-4 setStepFieldPermission (pure)', () => {
+  const base: NodeFieldPermission[] = [{ fieldId: 'secret', access: 'hidden' }]
+
+  it('appends a new non-editable entry', () => {
+    expect(setStepFieldPermission(base, 'note', 'readonly')).toEqual([
+      { fieldId: 'secret', access: 'hidden' },
+      { fieldId: 'note', access: 'readonly' },
+    ])
+  })
+
+  it('updates an existing entry IN PLACE (position-stable)', () => {
+    const perms: NodeFieldPermission[] = [
+      { fieldId: 'a', access: 'hidden' },
+      { fieldId: 'b', access: 'readonly' },
+    ]
+    expect(setStepFieldPermission(perms, 'a', 'readonly')).toEqual([
+      { fieldId: 'a', access: 'readonly' },
+      { fieldId: 'b', access: 'readonly' },
+    ])
+  })
+
+  it('removes the entry when set back to editable (absent === editable)', () => {
+    expect(setStepFieldPermission(base, 'secret', 'editable')).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const perms: NodeFieldPermission[] = [{ fieldId: 'secret', access: 'hidden' }]
+    setStepFieldPermission(perms, 'note', 'hidden')
+    expect(perms).toEqual([{ fieldId: 'secret', access: 'hidden' }])
+  })
+})
+
+// Type-only guard: the step draft exposes a fieldPermissions array (mirrors the node config).
+const _stepShape: Pick<ApprovalStepDraft, 'fieldPermissions'> = { fieldPermissions: [] }
+void _stepShape

--- a/apps/web/tests/approval-template-authoring-graph-preserve.test.ts
+++ b/apps/web/tests/approval-template-authoring-graph-preserve.test.ts
@@ -292,8 +292,10 @@ describe('G-1 unsupportedTemplateAuthoringReason — complex graphs are save-abl
   })
 
   it('still returns a reason for a LINEAR approval node carrying an unsupported config key', () => {
-    // fieldPermissions on a LINEAR approval node is outside the editor allowlist → fail-closed
-    // (the linear-path config check still runs; a complex graph would skip it and preserve).
+    // A node-level `timeout` on a LINEAR approval node is outside the editor allowlist → fail-closed
+    // (the linear-path config check still runs; a complex graph would skip it and preserve). NOTE:
+    // `fieldPermissions` is NO LONGER an example here — T1-4 added it to the linear allowlist and the
+    // editor authors it; this guard covers the config keys the linear editor still can't represent.
     const template = buildTemplate({
       nodes: [
         { key: 'start', type: 'start', name: '发起', config: {} },
@@ -305,7 +307,7 @@ describe('G-1 unsupportedTemplateAuthoringReason — complex graphs are save-abl
             assigneeSources: [{ kind: 'requester' }],
             approvalMode: 'single',
             emptyAssigneePolicy: 'error',
-            fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+            timeout: { afterMinutes: 60, effect: 'remind' },
           } as never,
         },
         { key: 'end', type: 'end', name: '结束', config: {} },

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -336,12 +336,11 @@ describe('approval template authoring helpers', () => {
     expect(rebuilt.nodes.some((node) => node.type === 'parallel')).toBe(true)
   })
 
-  it('fails closed on a node carrying fieldPermissions (no node-field editor yet)', () => {
-    // P1-C: fieldPermissions is NOT in the FE allowlist until a node-field
-    // permission editor ships. A template carrying it must render read-only in
-    // the MVP editor (never silently flattened) so the hidden-field config is
-    // preserved on the round-trip.
-    const reason = unsupportedTemplateAuthoringReason(buildTemplate({
+  it('authors + round-trips fieldPermissions on a linear node (T1-4 — no longer fail-closed)', () => {
+    // T1-4: the linear editor now AUTHORS node-level field permissions, so a linear approval node
+    // carrying `fieldPermissions` is supported (not read-only) and its hidden/readonly config
+    // round-trips through hydrate→build unchanged (never flattened).
+    const template = buildTemplate({
       approvalGraph: {
         nodes: [
           { key: 'start', type: 'start', name: '发起', config: {} },
@@ -363,9 +362,12 @@ describe('approval template authoring helpers', () => {
           { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
         ],
       },
-    }))
+    })
 
-    expect(reason).toContain('暂不支持的配置')
+    expect(unsupportedTemplateAuthoringReason(template)).toBeNull()
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    const node = rebuilt.nodes.find((candidate) => candidate.key === 'approval_1')!
+    expect((node.config as ApprovalNodeConfig).fieldPermissions).toEqual([{ fieldId: 'amount', access: 'hidden' }])
   })
 
   it('blocks existing attachment fields because the MVP has no upload runtime', () => {
@@ -686,7 +688,8 @@ describe('TemplateAuthoringView', () => {
   })
 
   // POST-GATE combined-view acceptance (runbook Stage A1/A2): A picker + E self-approver
-  // coexist editable on one template; the same shape carrying B fieldPermissions is fail-closed.
+  // coexist editable on one template; the same shape carrying B fieldPermissions is now ALSO
+  // editable (T1-4 ships the node field-permissions editor) and renders the per-field access selector.
   function buildComboGraph(node1Config: Record<string, unknown>) {
     return {
       nodes: [
@@ -715,16 +718,68 @@ describe('TemplateAuthoringView', () => {
     expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false)
   })
 
-  it('combined view A2: the same template carrying fieldPermissions opens fail-closed (B) — unsupported alert + save disabled', async () => {
+  it('combined view A2: the same template carrying fieldPermissions is editable (T1-4) — no unsupported alert, save enabled, per-field access selector renders the hidden value', async () => {
     routeParams = { id: 'tpl_combo_fp' }
     getTemplateSpy.mockResolvedValue(buildTemplate({
-      approvalGraph: buildComboGraph({ assigneeSources: [{ kind: 'static_user', userIds: ['u1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error', autoApprovalPolicy: { mergeWithRequester: true }, fieldPermissions: [{ fieldId: 'secret', access: 'hidden' }] }),
+      approvalGraph: buildComboGraph({ assigneeSources: [{ kind: 'static_user', userIds: ['u1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error', autoApprovalPolicy: { mergeWithRequester: true }, fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }] }),
     }))
     await mountView()
     await flushUi()
 
-    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).not.toBeNull() // B fail-closed
-    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(true) // save disabled
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // B now editable, not fail-closed
+    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // save enabled
+    expect(container!.querySelector('[data-testid="approval-step-field-permissions"]')).not.toBeNull() // the per-field access editor renders
+    const amountAccess = container!.querySelector('[data-testid="approval-step-field-access-amount"]') as HTMLSelectElement
+    expect(amountAccess).not.toBeNull()
+    expect(amountAccess.value).toBe('hidden') // hydrated from the stored fieldPermission
+  })
+
+  it('T1-4 write wire: selecting readonly through the SFC control writes {fieldId,access:readonly} to the save payload AND renders the readonly hint', async () => {
+    // The default template is LINEAR (fields amount + reviewer) so the field-permissions editor is
+    // live. This drives the @update:model-value → onStepFieldAccessChange → setStepFieldPermission →
+    // save-payload wire that a pure-helper test can't see (wire-vs-fixture discipline).
+    routeParams = { id: 'tpl_t14_write' }
+    getTemplateSpy.mockResolvedValue(buildTemplate())
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-step-field-readonly-hint"]')).toBeNull() // no hint yet
+
+    const amountAccess = container!.querySelector('[data-testid="approval-step-field-access-amount"]') as HTMLSelectElement
+    expect(amountAccess).not.toBeNull()
+    amountAccess.value = 'readonly'
+    amountAccess.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-step-field-readonly-hint"]')).not.toBeNull() // hint now renders
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    const node = payload.approvalGraph.nodes.find((candidate: any) => candidate.key === 'approval_1')
+    expect(node.config.fieldPermissions).toEqual([{ fieldId: 'amount', access: 'readonly' }]) // WRITTEN via the control
+  })
+
+  it('T1-4 routing hint: hiding a form_field_user routing-driver field renders the routing hint and does NOT block save (non-blocking)', async () => {
+    // The default template's approval step resolves its approver from the `reviewer` form field
+    // (form_field_user), so `reviewer` is a routing driver.
+    routeParams = { id: 'tpl_t14_routing' }
+    getTemplateSpy.mockResolvedValue(buildTemplate())
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-step-field-routing-hint"]')).toBeNull() // reviewer editable → no hint
+
+    const reviewerAccess = container!.querySelector('[data-testid="approval-step-field-access-reviewer"]') as HTMLSelectElement
+    expect(reviewerAccess).not.toBeNull()
+    reviewerAccess.value = 'hidden'
+    reviewerAccess.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-step-field-routing-hint"]')).not.toBeNull() // driver hidden → hint
+    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // non-blocking
   })
 
   it('direct_manager reads back editable: a saved direct_manager template is NOT fail-closed (no unsupported alert, save enabled, sourceKind hydrated)', async () => {

--- a/packages/core-backend/tests/integration/approval-p1c-field-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-p1c-field-permissions.api.test.ts
@@ -323,4 +323,189 @@ describeIfDatabase('Approval P1-C node field permissions (hidden subset) API', (
     expect(body.formSnapshot).not.toHaveProperty('secret')
     expect(body.formSnapshot).toHaveProperty('reason', 'present')
   })
+
+  // T1-4 §4 build contract — echo-ONLY redaction. These lock behavior that #2799 already ships
+  // correctly (no RED-before): a hidden field that ALSO drives routing must still route, and a
+  // `readonly` entry must persist + round-trip while producing NO runtime redaction.
+
+  it('resolves a form_field_user assignee from a hidden driver field while redacting it from the echo (routing unaffected)', async () => {
+    const adminToken = await authToken(baseUrl, 'p1c-admin')
+    const requesterToken = await authToken(baseUrl, 'p1c-requester')
+
+    const formSchema = {
+      fields: [
+        { id: 'reason', type: 'text', label: '事由', required: true },
+        { id: 'approver', type: 'user', label: '审批人' },
+      ],
+    }
+    // approval_1 resolves its approver FROM `approver` AND hides `approver`. The assignee is resolved
+    // at create from the STORED snapshot; the echo redaction is read-time only.
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: {
+            assigneeSources: [{ kind: 'form_field_user', fieldId: 'approver' }],
+            fieldPermissions: [{ fieldId: 'approver', access: 'hidden' }],
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-1-end', source: 'approval_1', target: 'end' },
+      ],
+    }
+
+    const created = await authorPublishStart(
+      baseUrl,
+      adminToken,
+      requesterToken,
+      `p1c-driver-${Date.now()}`,
+      formSchema,
+      graph,
+      { reason: 'trip', approver: 'p1c-manager-driven' },
+      bookkeeping,
+    )
+    expect(created.currentNodeKey).toBe('approval_1')
+
+    const detail = await jsonRequest(baseUrl, `/api/approvals/${created.id}`, requesterToken)
+    expect(detail.status).toBe(200)
+    const body = await detail.json() as {
+      formSnapshot: JsonRecord | null
+      assignments: Array<{ assigneeId: string; isActive: boolean }>
+    }
+    // Echo hides the routing driver...
+    expect(body.formSnapshot).not.toHaveProperty('approver')
+    expect(body.formSnapshot).toHaveProperty('reason', 'trip')
+    // ...but the assignee was resolved from its stored value (routing unaffected).
+    expect(body.assignments.some((assignment) => assignment.assigneeId === 'p1c-manager-driven' && assignment.isActive)).toBe(true)
+  })
+
+  it('routes a downstream condition on a hidden driver field unchanged while redacting it at the hiding node', async () => {
+    const adminToken = await authToken(baseUrl, 'p1c-admin')
+    const requesterToken = await authToken(baseUrl, 'p1c-requester')
+    const manager1Token = await authToken(baseUrl, 'p1c-manager-1')
+
+    const formSchema = {
+      fields: [
+        { id: 'reason', type: 'text', label: '事由', required: true },
+        { id: 'amount', type: 'text', label: '金额' },
+      ],
+    }
+    // approval_1 hides `amount`; the DOWNSTREAM condition routes on `amount`. Approving approval_1
+    // dispatches to the condition, which reads the STORED (un-redacted) `amount` → the `high` branch.
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['p1c-manager-1'], fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }] },
+        },
+        {
+          key: 'cond_1',
+          type: 'condition',
+          config: { branches: [{ edgeKey: 'to-high', rules: [{ fieldId: 'amount', operator: 'eq', value: 'big' }] }], defaultEdgeKey: 'to-low' },
+        },
+        { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['p1c-high'] } },
+        { key: 'approval_low', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['p1c-low'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-1-c', source: 'approval_1', target: 'cond_1' },
+        { key: 'to-high', source: 'cond_1', target: 'approval_high' },
+        { key: 'to-low', source: 'cond_1', target: 'approval_low' },
+        { key: 'edge-high-end', source: 'approval_high', target: 'end' },
+        { key: 'edge-low-end', source: 'approval_low', target: 'end' },
+      ],
+    }
+
+    const created = await authorPublishStart(
+      baseUrl,
+      adminToken,
+      requesterToken,
+      `p1c-cond-${Date.now()}`,
+      formSchema,
+      graph,
+      { reason: 'trip', amount: 'big' },
+      bookkeeping,
+    )
+    expect(created.currentNodeKey).toBe('approval_1')
+
+    // While AT approval_1, `amount` is redacted from the echo...
+    const detail = await jsonRequest(baseUrl, `/api/approvals/${created.id}`, requesterToken)
+    const body = await detail.json() as { formSnapshot: JsonRecord | null }
+    expect(body.formSnapshot).not.toHaveProperty('amount')
+    expect(body.formSnapshot).toHaveProperty('reason', 'trip')
+
+    // ...and approving approval_1 routes the condition on the STORED `amount` → the high branch.
+    const approve = await jsonRequest(baseUrl, `/api/approvals/${created.id}/actions`, manager1Token, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'ok' },
+    })
+    expect(approve.status).toBe(200)
+    const advanced = await approve.json() as { currentNodeKey: string | null }
+    expect(advanced.currentNodeKey).toBe('approval_high')
+  })
+
+  it('persists a readonly fieldPermission that round-trips through save/load and stays runtime-inert (still echoed)', async () => {
+    const adminToken = await authToken(baseUrl, 'p1c-admin')
+    const requesterToken = await authToken(baseUrl, 'p1c-requester')
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: ['p1c-manager-1'], fieldPermissions: [{ fieldId: 'secret', access: 'readonly' }] },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-1-end', source: 'approval_1', target: 'end' },
+      ],
+    }
+
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: { key: `p1c-ro-${Date.now()}`, name: 'p1c-readonly', formSchema: buildFormSchema(), approvalGraph: graph },
+    })
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    bookkeeping.templates.add(template.id)
+
+    // Round-trip: GET the saved template → the readonly fieldPermission survived normalize/save/load.
+    const getTemplate = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}`, adminToken)
+    expect(getTemplate.status).toBe(200)
+    const templateDetail = await getTemplate.json() as {
+      approvalGraph: { nodes: Array<{ key: string; config: { fieldPermissions?: Array<{ fieldId: string; access: string }> } }> }
+    }
+    const savedNode = templateDetail.approvalGraph.nodes.find((node) => node.key === 'approval_1')
+    expect(savedNode?.config.fieldPermissions).toEqual([{ fieldId: 'secret', access: 'readonly' }])
+
+    // Runtime-inert: publish + create → `secret` is STILL echoed (readonly is not redacted).
+    const publish = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publish.status).toBe(200)
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId: template.id, formData: { reason: 'trip', secret: 'shown' } },
+    })
+    expect(createResponse.status).toBe(201)
+    const created = await createResponse.json() as { id: string }
+    bookkeeping.approvals.add(created.id)
+
+    const detail = await jsonRequest(baseUrl, `/api/approvals/${created.id}`, requesterToken)
+    const body = await detail.json() as { formSnapshot: JsonRecord | null }
+    expect(body.formSnapshot).toHaveProperty('secret', 'shown')
+    expect(body.formSnapshot).toHaveProperty('reason', 'trip')
+  })
 })


### PR DESCRIPTION
Implements T1-4 per its build-spec + your hidden/readonly steer. **Scope correction (honest):** the runtime `hidden` echo-redaction was **already shipped in #2799** (`redactHiddenFormFields` wired in `ApprovalBridgeService.toUnifiedDTO`) — so this PR builds only the genuinely-missing **authoring UI** + the **§4 contract tests**, not a duplicate.

## What ships
- **Authoring UI** (linear step editor, `TemplateAuthoringView.vue`): per-step, per-form-field access selector (可编辑/只读/隐藏) → persists `node.config.fieldPermissions`. `editable` is the absent default (untouched linear templates stay byte-stable). `readonly` carries a non-blocking "enforced in a later slice (T1-4b)" hint.
- **Owner reconcile settled ✏️:** hidden AND readonly are authorable; **only `hidden` is runtime-enforced** this rung (via the pre-shipped redaction); `readonly` persists + round-trips but is **runtime-inert**.
- **Never-flatten / fail-closed:** `fieldPermissions` added to the linear `allowedConfigKeys`; `buildStepConfig` prunes deleted fields; a malformed entry fails **closed** to read-only (never silently re-saved); complex graphs preserve `fieldPermissions` verbatim (deep-clone path). A routing-driver-hidden authoring hint (form_field_user).

## Verification (independently re-run)
- **FE `vue-tsc -b` 0** · authoring tests **77/77** (field-permissions **11 new** — hydrate/emit/allowlist/never-flatten; `approvalTemplateAuthoring` 46 incl. 2 new mounted write-wire + routing-hint; graph-preserve 20). **RED-before (genuine, FE):** pre-change round-trip drops `fieldPermissions` / locks read-only / routing-driver template errors → GREEN after.
- **Backend `tsc` 0** · `approval-p1c-field-permissions` **7/7** real-DB (4 existing + **3 new §4 locks**): hidden field redacted from the node echo while assignee resolution (form_field_user) + condition routing still read the stored snapshot (echo-only proof); readonly round-trips runtime-inert.

## Caveats (honest)
- The 3 backend contract tests are **regression locks** (no RED-before — they lock behavior #2799 already ships correctly).
- 17 pre-existing FE suite failures (featureFlags/multitable/attendance/etc., `auth.getToken` fixtures) — proven pre-existing by stash-and-rerun; **not caused by this change**; touched areas fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)