### PR TITLE
feat(approval): T3-5 W7 cross-base resultWriteback (implements design-lock)

### DIFF
--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1793,8 +1793,11 @@ export class AutomationExecutor {
    * record-create guard at record-service.ts). The state is unreachable today (sheets are hard-deleted)
    * but this hardens against a future sheet-soft-delete feature.
    */
-  private async resolveSheetBaseId(sheetId: string): Promise<string | null | undefined> {
-    const res = await this.deps.queryFn('SELECT base_id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL', [sheetId])
+  private async resolveSheetBaseId(
+    sheetId: string,
+    queryFn: AutomationDeps['queryFn'],
+  ): Promise<string | null | undefined> {
+    const res = await queryFn('SELECT base_id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL', [sheetId])
     const row = (res.rows as Array<{ base_id?: unknown }>)[0]
     if (!row) return undefined
     return typeof row.base_id === 'string' ? row.base_id : null
@@ -1821,6 +1824,31 @@ export class AutomationExecutor {
     declaredTargetBaseId: string | undefined,
     context: ExecutionContext,
   ): Promise<CrossBaseWriteGate> {
+    // Thin adapter: unpack the automation `ExecutionContext` (trigger sheet + trigger actor) and delegate to
+    // the context-agnostic gate below. Record-mutating actions (update/create/delete/lock) route here.
+    return this.evaluateCrossBaseWriteGate(
+      this.deps.queryFn,
+      context.actorId ?? null,
+      context.sheetId,
+      targetSheetId,
+      declaredTargetBaseId,
+    )
+  }
+
+  /**
+   * ②b write-gate, CONTEXT-AGNOSTIC "new shape" (queryFn, actorId, triggerSheetId, targetSheetId,
+   * declaredTargetBaseId). The record-mutating executors delegate here via `evaluateCrossBaseWrite`, and the
+   * T3-5 approval cross-base resultWriteback backwrite calls it directly on the SAME executor instance so it
+   * shares the per-target-base write QUOTA (Q5) with update/create/delete/lock. Behaviour is unchanged from
+   * the pre-T3-5 method; only the trigger sheet/actor + queryFn are now explicit params instead of `context`.
+   */
+  async evaluateCrossBaseWriteGate(
+    queryFn: AutomationDeps['queryFn'],
+    actorId: string | null,
+    triggerSheetId: string,
+    targetSheetId: string,
+    declaredTargetBaseId: string | undefined,
+  ): Promise<CrossBaseWriteGate> {
     // Fast-path: a write to the SAME sheet as the trigger, with no explicit cross-base `targetBaseId`,
     // is DEFINITIONALLY same-base — a sheet cannot exist in two bases — so skip the base lookups
     // entirely. This keeps a legitimate same-sheet write from fail-closing when the sheet row is
@@ -1830,7 +1858,7 @@ export class AutomationExecutor {
     const declaredBaseClaim = typeof declaredTargetBaseId === 'string' && declaredTargetBaseId.trim()
       ? declaredTargetBaseId.trim()
       : null
-    if (targetSheetId === context.sheetId && declaredBaseClaim === null) {
+    if (targetSheetId === triggerSheetId && declaredBaseClaim === null) {
       return { crossBase: false }
     }
 
@@ -1840,7 +1868,7 @@ export class AutomationExecutor {
     // a soft-deleted target (undefined → null) would collapse against a legacy-null trigger base
     // (null === null → same-base) and silently SKIP the gate. Treating it as a cross-base rejection keeps
     // legitimate legacy-null-base SAME-BASE writes (both sides null, both rows present) unaffected.
-    const rawTargetBaseId = await this.resolveSheetBaseId(targetSheetId)
+    const rawTargetBaseId = await this.resolveSheetBaseId(targetSheetId, queryFn)
     if (rawTargetBaseId === undefined) {
       return {
         crossBase: true,
@@ -1849,7 +1877,7 @@ export class AutomationExecutor {
       }
     }
 
-    const triggerBaseId = (await this.resolveSheetBaseId(context.sheetId)) ?? null
+    const triggerBaseId = (await this.resolveSheetBaseId(triggerSheetId, queryFn)) ?? null
     const targetBaseId = rawTargetBaseId ?? null
 
     // Same-base (null-aware, mirrors `baseIdsAreCrossBase` = strict `!==`): null-vs-null and
@@ -1863,10 +1891,10 @@ export class AutomationExecutor {
     // computed at the top, reused here.)
     const claimed = declaredBaseClaim
     const authority = await resolveCrossBaseWriteAuthority({
-      actorId: context.actorId ?? null,
+      actorId,
       targetBaseId,
       declaredBaseClaim: claimed,
-      queryFn: this.deps.queryFn,
+      queryFn,
     })
     if ('reason' in authority) {
       if (authority.reason === 'claim_mismatch') {

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -2610,6 +2610,8 @@ export class AutomationService {
       return false // record gone — the caller's missing-record path already handled it
     }
     ensureRecordNotLocked(opts.lockActorId, lockRow, () => new Error(opts.lockedMessage))
+    // lock-guarded: resultWriteback patch — ensureRecordNotLocked (opts.lockActorId = the trigger actor for a
+    // cross-base target) is enforced immediately above, so a locked target record throws → backwriteSkipped.
     await this.queryFn(
       `UPDATE meta_records
        SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -144,6 +144,9 @@ const MAX_PARALLEL_BRANCHES = 10
 const MAX_PARALLEL_BRANCH_ACTIONS = 20
 const RESULT_WRITEBACK_FIELDS = ['statusField', 'approverField', 'completedAtField'] as const
 type ResultWritebackField = typeof RESULT_WRITEBACK_FIELDS[number]
+// T3-5: optional cross-base target on a resultWriteback — a LITERAL triple (no expression templating).
+// When any is set the save gate requires all three; runtime routes the backwrite to the target record.
+const RESULT_WRITEBACK_TARGET_KEYS = ['targetBaseId', 'targetSheetId', 'targetRecordId'] as const
 const TEXT_RESULT_WRITEBACK_TYPES = new Set(['string', 'longText'])
 const STATUS_RESULT_WRITEBACK_TYPES = new Set([...TEXT_RESULT_WRITEBACK_TYPES, 'select'])
 const COMPLETED_AT_RESULT_WRITEBACK_TYPES = new Set([...TEXT_RESULT_WRITEBACK_TYPES, 'dateTime'])
@@ -237,6 +240,20 @@ function validateStartApprovalConfig(config: Record<string, unknown>, path: stri
       mapped += 1
     }
     if (mapped === 0) return `${path}.resultWriteback must map at least one of statusField/approverField/completedAtField`
+    // T3-5 cross-base target: an OPTIONAL literal triple. If ANY of the three target ids is present, require
+    // the FULL triple as non-empty strings (Q4). No expression templating — literal ids only. Target
+    // field-type/read validation AND the author's target-base write authority are DEFERRED to runtime (the
+    // executor cross-base gate re-checks the TRIGGER actor's authority every run).
+    const writeback = config.resultWriteback
+    const anyTargetPresent = RESULT_WRITEBACK_TARGET_KEYS.some((key) => writeback[key] !== undefined)
+    if (anyTargetPresent) {
+      for (const key of RESULT_WRITEBACK_TARGET_KEYS) {
+        const value = writeback[key]
+        if (typeof value !== 'string' || value.trim().length === 0) {
+          return `${path}.resultWriteback cross-base target requires ${RESULT_WRITEBACK_TARGET_KEYS.join(' + ')} (all non-empty) when any is set`
+        }
+      }
+    }
   }
   return null
 }
@@ -278,6 +295,53 @@ function resultWritebackFieldId(writeback: Record<string, unknown>, field: Resul
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : null
+}
+
+// T3-5: read one cross-base target id (trimmed non-empty string, else null).
+function resultWritebackTargetId(
+  writeback: Record<string, unknown>,
+  key: typeof RESULT_WRITEBACK_TARGET_KEYS[number],
+): string | null {
+  const value = writeback[key]
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+// T3-5: does this resultWriteback opt into a cross-base target? (Any of the triple present as a non-empty
+// string. The save gate has already enforced the FULL triple when any is set, so runtime can read all three.)
+function isCrossBaseWriteback(writeback: Record<string, unknown>): boolean {
+  return RESULT_WRITEBACK_TARGET_KEYS.some((key) => resultWritebackTargetId(writeback, key) !== null)
+}
+
+// Discriminated result of a backwrite: same-base returns the `patch` (merged into the resume tail context);
+// cross-base returns only the target triple (its patch is NOT merged into the tail — §3.3).
+type ApprovalBackwriteOutcome =
+  | { kind: 'same-base'; patch: Record<string, unknown> }
+  | { kind: 'cross-base'; target: { targetBaseId: string; targetSheetId: string; targetRecordId: string } }
+
+// The backwrite patch: DECLARED fixed field→value mapping, VALUES sourced from the completion EVENT only
+// (status = outcome, approver = the approval actor, completedAt = the event time). Never the trigger actor.
+function buildResultWritebackPatch(
+  writeback: Record<string, unknown>,
+  event: ApprovalCompletionEventV1,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {}
+  const statusField = resultWritebackFieldId(writeback, 'statusField')
+  const approverField = resultWritebackFieldId(writeback, 'approverField')
+  const completedAtField = resultWritebackFieldId(writeback, 'completedAtField')
+  if (statusField) patch[statusField] = event.transition.toStatus
+  if (approverField) patch[approverField] = event.actor?.id ?? null
+  if (completedAtField) patch[completedAtField] = event.occurredAt
+  return patch
+}
+
+// T3-5: the EFFECTIVE actor for a cross-base backwrite is the TRIGGER actor stamped on the stored trigger
+// event (NOT the resume/request actor). Trimmed non-empty string, else null → fail-closed at the gate.
+function readTriggerActorId(triggerEvent: unknown): string | null {
+  if (!triggerEvent || typeof triggerEvent !== 'object' || Array.isArray(triggerEvent)) return null
+  const value = (triggerEvent as Record<string, unknown>).actorId
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
 }
 
 type ResultWritebackTargetField = {
@@ -2273,7 +2337,19 @@ export class AutomationService {
     result: AutomationStepResult,
   ): Promise<Record<string, unknown> | null> {
     try {
-      return await this.writeApprovalResultBack(bridge, startApprovalConfig, event)
+      const outcome = await this.writeApprovalResultBack(bridge, startApprovalConfig, event)
+      if (!outcome) return null
+      if (outcome.kind === 'cross-base') {
+        // Q3 audit: extend the start_approval step output with the target triple. §3.3: the cross-base
+        // patch is NOT merged into the resume `recordData` the tail actions see (unlike the same-base
+        // W7-1a merge) — return null so the caller's `if (backwritten)` merge is skipped.
+        result.output = {
+          ...(isRecord(result.output) ? result.output : {}),
+          crossBaseBackwrite: { ...outcome.target },
+        }
+        return null
+      }
+      return outcome.patch
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err)
       logger.warn(`approval-result backwrite skipped for bridge ${bridge.id}: ${reason}`)
@@ -2394,61 +2470,171 @@ export class AutomationService {
     bridge: AutomationApprovalBridgeRow,
     startApprovalConfig: Record<string, unknown>,
     event: ApprovalCompletionEventV1,
-  ): Promise<Record<string, unknown> | null> {
+  ): Promise<ApprovalBackwriteOutcome | null> {
     const writeback = isRecord(startApprovalConfig.resultWriteback) ? startApprovalConfig.resultWriteback : null
     if (!writeback || !bridge.recordId || !bridge.sheetId) return null
     if (event.transition.toStatus !== 'approved' && writeback.onNonApproved !== true) return null
+
+    // T3-5: a configured cross-base target routes the backwrite to the TARGET record in another base
+    // (gated by the shared executor cross-base write gate). The SOURCE record is NOT mutated.
+    if (isCrossBaseWriteback(writeback)) {
+      return this.writeApprovalResultBackCrossBase(bridge, writeback, event)
+    }
+
+    // ── same-base (W7-1): write onto the SOURCE record that started the approval ──
     await this.assertResultWritebackFields(bridge.sheetId, writeback, event.transition.toStatus)
-    const patch: Record<string, unknown> = {}
-    const statusField = resultWritebackFieldId(writeback, 'statusField')
-    const approverField = resultWritebackFieldId(writeback, 'approverField')
-    const completedAtField = resultWritebackFieldId(writeback, 'completedAtField')
-    if (statusField) patch[statusField] = event.transition.toStatus
-    if (approverField) patch[approverField] = event.actor?.id ?? null
-    if (completedAtField) patch[completedAtField] = event.occurredAt
+    const patch = buildResultWritebackPatch(writeback, event)
     if (Object.keys(patch).length === 0) return null
 
+    // W7-1a parity: the shared tail lock-checks the SOURCE record (actor = the approval actor), writes the
+    // patch, and emits the chaining event + realtime fan-out (actor passed through) so UI / subscribers /
+    // downstream record.updated automations see the backwrite live. onMissing: 'skip' — a gone record
+    // returns null (the resume's own missing-record path already handled it), NOT an error.
+    const actorId = event.actor?.id ?? null
+    const wrote = await this.applyResultWritebackPatch(bridge.sheetId, bridge.recordId, patch, {
+      lockActorId: actorId,
+      chainActorId: actorId,
+      realtimeActorId: actorId ?? undefined,
+      automationDepth: this.backwriteAutomationDepth(bridge),
+      lockedMessage: 'source record is locked',
+      onMissing: 'skip',
+    })
+    if (!wrote) return null
+    return { kind: 'same-base', patch }
+  }
+
+  /**
+   * T3-5 cross-base approval-result backwrite: write the outcome onto a record in ANOTHER base, gated by the
+   * SAME executor cross-base write gate as update/create/delete/lock (`evaluateCrossBaseWriteGate` on the
+   * shared executor instance → shared per-target-base quota, claim==truth, base-write authority). Q1: the
+   * EFFECTIVE actor is the TRIGGER actor (from `bridge.triggerEvent`), NOT the resume/request actor; a
+   * null/system trigger actor fails CLOSED (no owner/requester fallback) and the SAME actor governs the
+   * target-record lock. VALUES still come from the completion EVENT (approver = the approval actor), never
+   * the trigger actor. Anti-misroute: the write targets `targetRecordId` only — the SOURCE record is never
+   * mutated. Any gate reject / missing target / lock throws → surfaced as `backwriteSkipped`, no write.
+   *
+   * Quota note (§3.5 limitation): a resume RETRY re-consumes a per-target-base quota slot — there is no
+   * idempotent cross-base-backwrite ledger in v1. Out of scope; recorded here so it is not mistaken for a bug.
+   */
+  private async writeApprovalResultBackCrossBase(
+    bridge: AutomationApprovalBridgeRow,
+    writeback: Record<string, unknown>,
+    event: ApprovalCompletionEventV1,
+  ): Promise<Extract<ApprovalBackwriteOutcome, { kind: 'cross-base' }> | null> {
+    const targetBaseId = resultWritebackTargetId(writeback, 'targetBaseId')
+    const targetSheetId = resultWritebackTargetId(writeback, 'targetSheetId')
+    const targetRecordId = resultWritebackTargetId(writeback, 'targetRecordId')
+    // The save gate requires the full triple when any target id is set; defend regardless (executor-parity:
+    // last line of defense even if save validation were bypassed).
+    if (!targetBaseId || !targetSheetId || !targetRecordId || !bridge.sheetId) {
+      throw new Error('cross-base resultWriteback requires targetBaseId + targetSheetId + targetRecordId')
+    }
+
+    // Q1 effective actor = the TRIGGER actor. Null → fail-closed via the gate (resolveBaseWritable false).
+    const triggerActorId = readTriggerActorId(bridge.triggerEvent)
+
+    // Cross-base write gate (shared per-target-base quota — Q5). A reject (unauthorized / null actor / claim
+    // mismatch / quota) throws → `backwriteSkipped`, NO write. NOTE: an authorized gate eval CONSUMES a quota
+    // slot before the record-level checks below, so a blocked-by-lock / not-found target still spends a slot.
+    const gate = await this.executor.evaluateCrossBaseWriteGate(
+      this.queryFn,
+      triggerActorId,
+      bridge.sheetId,
+      targetSheetId,
+      targetBaseId,
+    )
+    if (gate.crossBase && gate.ok === false) throw new Error(gate.error)
+    // gate.crossBase === false means the declared target resolved to the SAME base as the source — a same-base
+    // DIFFERENT-record write; no authority gate applies (consistent with same-base update_record). The write
+    // still targets targetRecordId, so §3.1 (source not mutated) holds regardless.
+
+    // Target field-type/read validation runs against the TARGET sheet (deferred from save per Q4).
+    await this.assertResultWritebackFields(targetSheetId, writeback, event.transition.toStatus)
+    const patch = buildResultWritebackPatch(writeback, event)
+    if (Object.keys(patch).length === 0) return null
+
+    // Shared tail, TARGET-retargeted: lock-check governed by the SAME (trigger) actor; the realtime publish
+    // OMITS the actor (cross-base privacy posture — realtimeActorId undefined), while the chaining event
+    // carries the trigger actor (matching executeUpdateRecord cross-base). onMissing: 'throw' — a missing
+    // target record fails closed (never a silent no-op), mirroring the executor "target record not found".
+    const wrote = await this.applyResultWritebackPatch(targetSheetId, targetRecordId, patch, {
+      lockActorId: triggerActorId,
+      chainActorId: triggerActorId,
+      realtimeActorId: undefined,
+      automationDepth: this.backwriteAutomationDepth(bridge),
+      lockedMessage: 'target record is locked',
+      onMissing: 'throw',
+      missingMessage: `cross-base resultWriteback target record not found: ${targetRecordId} ∉ ${targetSheetId}`,
+    })
+    if (!wrote) return null // unreachable with onMissing:'throw'; keeps the boolean contract total
+    return { kind: 'cross-base', target: { targetBaseId, targetSheetId, targetRecordId } }
+  }
+
+  // Depth guard shared by both backwrite paths: inherit the trigger's `_automationDepth` + 1 so a
+  // backwrite-driven cascade can't run away.
+  private backwriteAutomationDepth(bridge: AutomationApprovalBridgeRow): number {
+    return (((bridge.triggerEvent as Record<string, unknown> | null)?._automationDepth as number) ?? 0) + 1
+  }
+
+  /**
+   * Shared tail for BOTH W7 backwrite paths: lock-check the target record (governed by `lockActorId`,
+   * B1), write the patch via the bare `|| $1::jsonb` UPDATE, then emit the chaining event + realtime
+   * fan-out. Returns true when the row was written, false when the record is gone AND `onMissing` is
+   * 'skip' (a gone record with 'throw' raises `missingMessage` instead). `realtimeActorId` is the actor
+   * surfaced on the realtime publish — `undefined` OMITS it (the cross-base privacy posture).
+   *
+   * rich-longText SAFE: the patch carries ONLY system outcome values (status enum / approver id / ISO
+   * timestamp), never user-supplied longText — classified SAFE in the rich-longText write-sink guard.
+   */
+  private async applyResultWritebackPatch(
+    sheetId: string,
+    recordId: string,
+    patch: Record<string, unknown>,
+    opts: {
+      lockActorId: string | null
+      chainActorId: string | null
+      realtimeActorId: string | undefined
+      automationDepth: number
+      lockedMessage: string
+      onMissing: 'skip' | 'throw'
+      missingMessage?: string
+    },
+  ): Promise<boolean> {
     const lockRes = await this.queryFn(
       'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
-      [bridge.recordId, bridge.sheetId],
+      [recordId, sheetId],
     )
     const lockRow = lockRes.rows[0] as { locked?: unknown; locked_by?: unknown; created_by?: unknown } | undefined
-    if (!lockRow) return null // record gone — the resume's own missing-record path already handled it
-    ensureRecordNotLocked(event.actor?.id ?? null, lockRow, () => new Error('source record is locked'))
-    // rich-longText SAFE: patch carries ONLY system outcome values (status enum / approver id / ISO
-    // timestamp), never user-supplied longText — classified SAFE in the rich-longText write-sink guard.
-    // lock-guarded: the backwrite respects the source record lock via ensureRecordNotLocked just above (B1).
+    if (!lockRow) {
+      if (opts.onMissing === 'throw') throw new Error(opts.missingMessage ?? `resultWriteback target record not found: ${recordId} ∉ ${sheetId}`)
+      return false // record gone — the caller's missing-record path already handled it
+    }
+    ensureRecordNotLocked(opts.lockActorId, lockRow, () => new Error(opts.lockedMessage))
     await this.queryFn(
       `UPDATE meta_records
        SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb, version = version + 1, updated_at = NOW()
        WHERE id = $2 AND sheet_id = $3`,
-      [JSON.stringify(patch), bridge.recordId, bridge.sheetId],
+      [JSON.stringify(patch), recordId, sheetId],
     )
-
-    // W7-1a parity: emit the chaining event + realtime fan-out, matching update_record, so UI /
-    // subscribers / downstream record.updated automations see the backwrite live. Depth-guarded
-    // (inherits the trigger's _automationDepth + 1) so a backwrite-driven cascade can't run away.
-    const actorId = event.actor?.id ?? null
-    const automationDepth = (((bridge.triggerEvent as Record<string, unknown> | null)?._automationDepth as number) ?? 0) + 1
     this.eventBus.emit('multitable.record.updated', withAutomationEventId({
-      sheetId: bridge.sheetId,
-      recordId: bridge.recordId,
+      sheetId,
+      recordId,
       changes: patch,
-      actorId,
-      _automationDepth: automationDepth,
+      actorId: opts.chainActorId,
+      _automationDepth: opts.automationDepth,
     }))
     try {
       publishMultitableSheetRealtime({
-        spreadsheetId: bridge.sheetId,
+        spreadsheetId: sheetId,
         source: 'multitable',
         kind: 'record-updated',
-        recordId: bridge.recordId,
-        actorId: actorId ?? undefined,
+        recordId,
+        actorId: opts.realtimeActorId,
       })
     } catch {
       // publishMultitableSheetRealtime swallows its own errors; belt-and-suspenders.
     }
-    return patch
+    return true
   }
 
   private async assertResultWritebackFields(
@@ -2495,6 +2681,9 @@ export class AutomationService {
       if (action.type !== 'start_approval' || !isRecord(action.config)) continue
       const writeback = isRecord(action.config.resultWriteback) ? action.config.resultWriteback : null
       if (!writeback) continue
+      // T3-5: a cross-base target's fields live in the TARGET sheet, not this rule's source sheet — the
+      // source-sheet field-type check does not apply, so defer it to the runtime cross-base check (Q4).
+      if (isCrossBaseWriteback(writeback)) continue
       const mapped = RESULT_WRITEBACK_FIELDS
         .map((field) => ({ field, id: resultWritebackFieldId(writeback, field) }))
         .filter((entry): entry is { field: ResultWritebackField; id: string } => !!entry.id)

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -2543,10 +2543,10 @@ export class AutomationService {
       targetSheetId,
       targetBaseId,
     )
-    if (gate.crossBase && gate.ok === false) throw new Error(gate.error)
-    // gate.crossBase === false means the declared target resolved to the SAME base as the source — a same-base
-    // DIFFERENT-record write; no authority gate applies (consistent with same-base update_record). The write
-    // still targets targetRecordId, so §3.1 (source not mutated) holds regardless.
+    if (!gate.crossBase) {
+      throw new Error('cross-base resultWriteback target must resolve to a different base')
+    }
+    if (gate.ok === false) throw new Error(gate.error)
 
     // Target field-type/read validation runs against the TARGET sheet (deferred from save per Q4).
     await this.assertResultWritebackFields(targetSheetId, writeback, event.transition.toStatus)

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -29,6 +29,19 @@ const RECORD = `rec_w6_${TS}`
 const REQUESTER = `w6_requester_${TS}`
 const APPROVER = `w6_approver_${TS}`
 const NO_APPROVAL_PERMISSION = `w6_no_approval_${TS}`
+
+// T3-5 cross-base resultWriteback fixtures. The target sheets live in DIFFERENT bases from the source
+// (BASE/SHEET), so a resultWriteback aimed at them is a genuine cross-base write governed by the shared
+// executor gate. XB_BASE_OK is OWNED BY REQUESTER (the trigger actor) → base-write via ownership;
+// XB_BASE_DENY is owned by APPROVER → REQUESTER has NO base-write on it.
+const XB_BASE_OK = `base_w6_xbok_${TS}`
+const XB_SHEET_OK = `sheet_w6_xbok_${TS}`
+const XB_REC_OK = `rec_w6_xbok_${TS}`
+const XB_REC_NULL = `rec_w6_xbnull_${TS}` // second target record for the null-actor canary
+const XB_BASE_DENY = `base_w6_xbdeny_${TS}`
+const XB_SHEET_DENY = `sheet_w6_xbdeny_${TS}`
+const XB_REC_DENY = `rec_w6_xbdeny_${TS}`
+
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
 const executionIds: string[] = []
@@ -232,6 +245,24 @@ async function seedDefaultWritebackFields(): Promise<void> {
   ])
 }
 
+// T3-5: seed the cross-base target bases/sheets/records + the OK target's writeback fields. Field ids are
+// GLOBALLY UNIQUE (meta_fields PK is `id`), so the target sheet cannot reuse the source's `approval_status`
+// etc — it gets its own `xb_*` ids. Idempotent upserts so a re-run stays clean.
+async function seedCrossBaseTargets(): Promise<void> {
+  await q(`INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3) ON CONFLICT (id) DO UPDATE SET owner_id = EXCLUDED.owner_id`, [XB_BASE_OK, 'W6 XB Target OK', REQUESTER])
+  await q(`INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3) ON CONFLICT (id) DO UPDATE SET owner_id = EXCLUDED.owner_id`, [XB_BASE_DENY, 'W6 XB Target Deny', APPROVER])
+  await q(`INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3) ON CONFLICT (id) DO NOTHING`, [XB_SHEET_OK, XB_BASE_OK, 'W6 XB Target Sheet OK'])
+  await q(`INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3) ON CONFLICT (id) DO NOTHING`, [XB_SHEET_DENY, XB_BASE_DENY, 'W6 XB Target Sheet Deny'])
+  for (const [rec, sheet] of [[XB_REC_OK, XB_SHEET_OK], [XB_REC_NULL, XB_SHEET_OK], [XB_REC_DENY, XB_SHEET_DENY]] as const) {
+    await q(`INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,'{}'::jsonb,1) ON CONFLICT (id) DO UPDATE SET data='{}'::jsonb, version=1`, [rec, sheet])
+  }
+  const seedField = (id: string, name: string, type: string, property: Record<string, unknown>, order: number) =>
+    q(`INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING`, [id, XB_SHEET_OK, name, type, JSON.stringify(property), order])
+  await seedField('xb_status', 'XB Status', 'select', { options: [{ value: 'approved' }, { value: 'rejected' }] }, 10)
+  await seedField('xb_by', 'XB By', 'string', {}, 11)
+  await seedField('xb_at', 'XB At', 'dateTime', {}, 12)
+}
+
 async function waitForExecutionStatus(svc: AutomationService, id: string, status: string) {
   await vi.waitFor(async () => {
     const execution = await svc.logs.getById(id)
@@ -293,6 +324,71 @@ async function executeAndApprove(
   return { executionId: execution.id, approvalInstanceId }
 }
 
+// T3-5: run a start_approval whose resultWriteback carries a cross-base target triple, then approve it.
+// The persisted rule (createStartApprovalRule) and the inline execRule share the SAME action config so the
+// resume-time fingerprint guard passes. `triggerActorId` is the actor stamped on the TRIGGER event (the
+// governing identity for the cross-base gate); null models a system/scheduled trigger with no actor.
+async function runCrossBaseBackwrite(
+  svc: AutomationService,
+  resultWriteback: Record<string, string>,
+  opts: { title: string; triggerActorId: string | null },
+): Promise<string> {
+  const templateId = await createPublishedTemplate()
+  const ruleId = await createStartApprovalRule(svc, templateId, resultWriteback)
+  await seedSheetRecord(opts.title)
+  await seedDefaultWritebackFields() // source fields (exercised by the §3.1 source-resident-field canary)
+  const execRule = {
+    id: ruleId,
+    name: 'W6 start approval',
+    sheetId: SHEET,
+    trigger: { type: 'record.created', config: {} },
+    actions: [
+      { type: 'start_approval', config: { templateId, formDataMapping: { summary: 'Record {{record.title}} needs approval' }, requester: { mode: 'trigger_actor' }, resultWriteback } },
+      { type: 'send_webhook', config: { url: 'https://example.test/w6-tail' } },
+    ],
+    enabled: true,
+    createdBy: REQUESTER,
+    createdAt: new Date(TS).toISOString(),
+    executionMode: 'workflow_job_v1',
+  }
+  const execution = await svc.executeRule(execRule as never, {
+    sheetId: SHEET,
+    recordId: RECORD,
+    data: { title: opts.title },
+    ...(opts.triggerActorId !== null ? { actorId: opts.triggerActorId } : {}),
+  })
+  executionIds.push(execution.id)
+  const bridge = await q(
+    `SELECT approval_instance_id FROM multitable_automation_approval_bridges WHERE execution_id = $1`,
+    [execution.id],
+  )
+  approvalIds.push(bridge.rows[0].approval_instance_id)
+  const approvals = new ApprovalProductService()
+  await approvals.dispatchAction(
+    bridge.rows[0].approval_instance_id,
+    { action: 'approve', comment: 'go' },
+    { userId: APPROVER, userName: APPROVER },
+  )
+  await waitForExecutionStatus(svc, execution.id, 'success')
+  return execution.id
+}
+
+// T3-5 save-gate helper: persist a start_approval rule with the given resultWriteback shape. A fake
+// templateId is fine — createRule validates the config SHAPE, not template existence.
+function createSaveGateRule(svc: AutomationService, resultWriteback: Record<string, string>) {
+  const config = { templateId: 'tpl-fake', formDataMapping: { summary: 'x' }, resultWriteback }
+  return svc.createRule(SHEET, {
+    name: 'T3-5 save gate',
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'start_approval',
+    actionConfig: config,
+    actions: [{ type: 'start_approval', config }] as never,
+    executionMode: 'workflow_job_v1',
+    createdBy: REQUESTER,
+  })
+}
+
 describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)', () => {
   beforeAll(async () => {
     await ensureApprovalSchemaReady()
@@ -318,6 +414,12 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET])
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET])
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE])
+    // T3-5 cross-base target fixtures.
+    const xbSheets = [XB_SHEET_OK, XB_SHEET_DENY]
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [xbSheets]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [xbSheets]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [xbSheets]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[XB_BASE_OK, XB_BASE_DENY]]).catch(() => {})
     for (const id of templateIds) {
       await q('DELETE FROM approval_published_definitions WHERE template_id = $1::uuid', [id])
       await q('DELETE FROM approval_template_versions WHERE template_id = $1::uuid', [id])
@@ -589,6 +691,140 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       const rec = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])
       const data = rec.rows[0].data as Record<string, unknown>
       expect(data).not.toHaveProperty('approval_status_number')
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  // ── T3-5: cross-base resultWriteback ─────────────────────────────────────────
+  // The approval outcome is written back onto a record in ANOTHER base, gated by the SAME executor
+  // cross-base write gate as update/create/delete/lock (trigger-actor base-write, claim==truth, shared
+  // per-target-base quota). RED before T3-5: the target triple is ignored — the backwrite validates/writes
+  // against the SOURCE sheet, so a target-only field id skips (field-not-found) and the target is untouched.
+
+  test('T3-5: approved cross-base resultWriteback writes onto the TARGET record; source untouched; step output carries the triple', async () => {
+    const webhookBodies: string[] = []
+    const updatedEvents: Array<Record<string, unknown>> = []
+    const subId = eventBus.subscribe('multitable.record.updated', (p: unknown) => { updatedEvents.push(p as Record<string, unknown>) })
+    const svc = makeAutomationService((async (_url: string, o?: { body?: string }) => {
+      if (o?.body) webhookBodies.push(o.body)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      await seedCrossBaseTargets()
+      const RW = { statusField: 'xb_status', approverField: 'xb_by', completedAtField: 'xb_at', targetBaseId: XB_BASE_OK, targetSheetId: XB_SHEET_OK, targetRecordId: XB_REC_OK }
+      const executionId = await runCrossBaseBackwrite(svc, RW, { title: 'Q4 plan', triggerActorId: REQUESTER })
+
+      // Target record carries the outcome — values from the completion EVENT (approver = APPROVER), even
+      // though the trigger actor that AUTHORIZED the cross-base write is REQUESTER (two distinct identities).
+      const tgt = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [XB_REC_OK, XB_SHEET_OK])).rows[0].data as Record<string, unknown>
+      // Exact body: ONLY the three mapped keys land on the target — no extra/leaked key from the patch builder.
+      expect(tgt).toEqual({ xb_status: 'approved', xb_by: APPROVER, xb_at: expect.any(String) })
+      // §3.1 anti-misroute: the SOURCE record is NOT mutated by the cross-base backwrite.
+      const src = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])).rows[0].data as Record<string, unknown>
+      expect(src).toEqual({ title: 'Q4 plan' })
+      // §3.3 non-merge: the tail send_webhook's recordData snapshot does NOT see the cross-base patch.
+      expect(webhookBodies.length).toBeGreaterThan(0)
+      const body = JSON.parse(webhookBodies[webhookBodies.length - 1]) as { data?: Record<string, unknown> }
+      expect(body.data).not.toHaveProperty('xb_status')
+      expect(body.data?.title).toBe('Q4 plan')
+      // Q3 audit: the start_approval step output carries the target triple, with no skip.
+      const resumed = (await svc.logs.getById(executionId))!
+      const startStep = resumed.steps.find((s) => s.actionType === 'start_approval')
+      expect(startStep?.output).toMatchObject({ crossBaseBackwrite: { targetBaseId: XB_BASE_OK, targetSheetId: XB_SHEET_OK, targetRecordId: XB_REC_OK } })
+      expect(startStep?.output).not.toHaveProperty('backwriteSkipped')
+      // Q3 fan-out: the cross-base backwrite emits multitable.record.updated for the TARGET sheet/record
+      // (not the source), so the target base's subscribers see it live. (Actor-omission on the realtime
+      // publish is a separate privacy channel; this asserts the chaining emit fired for the right record.)
+      expect(updatedEvents.some((e) => e.recordId === XB_REC_OK && e.sheetId === XB_SHEET_OK
+        && (e.changes as Record<string, unknown> | undefined)?.xb_status === 'approved')).toBe(true)
+      expect(updatedEvents.some((e) => e.recordId === RECORD)).toBe(false) // source never emitted
+    } finally {
+      eventBus.unsubscribe(subId)
+      svc.shutdown()
+    }
+  })
+
+  test('T3-5: cross-base backwrite where the TRIGGER actor lacks target base-write → skip (backwriteSkipped); target + source unchanged', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
+    try {
+      await seedCrossBaseTargets()
+      // XB_BASE_DENY is owned by APPROVER; the trigger actor REQUESTER has NO base-write there.
+      const RW = { statusField: 'xb_status', targetBaseId: XB_BASE_DENY, targetSheetId: XB_SHEET_DENY, targetRecordId: XB_REC_DENY }
+      const executionId = await runCrossBaseBackwrite(svc, RW, { title: 'Q4 plan', triggerActorId: REQUESTER })
+
+      const tgt = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [XB_REC_DENY, XB_SHEET_DENY])).rows[0].data as Record<string, unknown>
+      expect(tgt).toEqual({}) // unchanged — fail-closed, no partial write
+      const src = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])).rows[0].data as Record<string, unknown>
+      expect(src).toEqual({ title: 'Q4 plan' })
+      const resumed = (await svc.logs.getById(executionId))!
+      const startStep = resumed.steps.find((s) => s.actionType === 'start_approval')
+      expect(startStep?.output).toMatchObject({ backwriteSkipped: expect.stringContaining('base-write') })
+      expect(startStep?.output).not.toHaveProperty('crossBaseBackwrite')
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('T3-5: null trigger actor → cross-base backwrite skipped even though the rule creator owns the target base (no requester fallback)', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
+    try {
+      await seedCrossBaseTargets()
+      // XB_BASE_OK is owned by REQUESTER (the rule creator / approval requester). The TRIGGER actor is null;
+      // the gate uses the TRIGGER actor (NOT event.requester which resolves to REQUESTER) → fail-closed.
+      const RW = { statusField: 'xb_status', targetBaseId: XB_BASE_OK, targetSheetId: XB_SHEET_OK, targetRecordId: XB_REC_NULL }
+      const executionId = await runCrossBaseBackwrite(svc, RW, { title: 'Q4 plan', triggerActorId: null })
+
+      const tgt = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [XB_REC_NULL, XB_SHEET_OK])).rows[0].data as Record<string, unknown>
+      expect(tgt).toEqual({}) // unchanged
+      const resumed = (await svc.logs.getById(executionId))!
+      const startStep = resumed.steps.find((s) => s.actionType === 'start_approval')
+      expect(startStep?.output).toMatchObject({ backwriteSkipped: expect.stringContaining('base-write') })
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('T3-5: a cross-base target with a SOURCE-resident field id does NOT mutate the source record (anti-misroute)', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
+    try {
+      await seedCrossBaseTargets()
+      // 'approval_status' EXISTS in the SOURCE sheet but NOT in the target sheet. Pre-T3-5 the backwrite
+      // ignored the target triple and wrote 'approval_status' onto the SOURCE record (the misroute). With
+      // T3-5 the write is routed to the cross-base target, where the field is absent → the backwrite skips
+      // → the source record stays untouched. This is the sharpest proof of §3.1 (source not mutated).
+      const RW = { statusField: 'approval_status', targetBaseId: XB_BASE_OK, targetSheetId: XB_SHEET_OK, targetRecordId: XB_REC_OK }
+      const executionId = await runCrossBaseBackwrite(svc, RW, { title: 'Q4 plan', triggerActorId: REQUESTER })
+
+      const src = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])).rows[0].data as Record<string, unknown>
+      expect(src).toEqual({ title: 'Q4 plan' }) // NOT mutated — no approval_status on the source
+      const resumed = (await svc.logs.getById(executionId))!
+      const startStep = resumed.steps.find((s) => s.actionType === 'start_approval')
+      expect(startStep?.output).toMatchObject({ backwriteSkipped: expect.stringContaining('target field not found') })
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('T3-5 save gate: a PARTIAL cross-base target triple is rejected at rule-save', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
+    try {
+      await seedSheetRecord('save gate')
+      await expect(
+        createSaveGateRule(svc, { statusField: 'xb_status', targetSheetId: XB_SHEET_OK }),
+      ).rejects.toThrow(/cross-base target requires/)
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('T3-5 save gate: the FULL cross-base target triple is accepted at rule-save', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
+    try {
+      await seedSheetRecord('save gate')
+      const rule = await createSaveGateRule(svc, { statusField: 'xb_status', targetBaseId: XB_BASE_OK, targetSheetId: XB_SHEET_OK, targetRecordId: XB_REC_OK })
+      ruleIds.push(rule.id)
+      expect(rule.id).toBeTruthy()
     } finally {
       svc.shutdown()
     }

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -26,6 +26,7 @@ const TS = Date.now()
 const BASE = `base_w6_start_${TS}`
 const SHEET = `sheet_w6_start_${TS}`
 const RECORD = `rec_w6_${TS}`
+const SAME_BASE_TARGET_RECORD = `rec_w6_same_target_${TS}`
 const REQUESTER = `w6_requester_${TS}`
 const APPROVER = `w6_approver_${TS}`
 const NO_APPROVAL_PERMISSION = `w6_no_approval_${TS}`
@@ -331,7 +332,7 @@ async function executeAndApprove(
 async function runCrossBaseBackwrite(
   svc: AutomationService,
   resultWriteback: Record<string, string>,
-  opts: { title: string; triggerActorId: string | null },
+  opts: { title: string; triggerActorId: string | null; beforeApprove?: () => Promise<void> },
 ): Promise<string> {
   const templateId = await createPublishedTemplate()
   const ruleId = await createStartApprovalRule(svc, templateId, resultWriteback)
@@ -363,6 +364,7 @@ async function runCrossBaseBackwrite(
     [execution.id],
   )
   approvalIds.push(bridge.rows[0].approval_instance_id)
+  await opts.beforeApprove?.()
   const approvals = new ApprovalProductService()
   await approvals.dispatchAction(
     bridge.rows[0].approval_instance_id,
@@ -741,6 +743,43 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       expect(updatedEvents.some((e) => e.recordId === RECORD)).toBe(false) // source never emitted
     } finally {
       eventBus.unsubscribe(subId)
+      svc.shutdown()
+    }
+  })
+
+  test('T3-5: target triple resolving to the SOURCE base is rejected (no same-base arbitrary target write)', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
+    try {
+      const RW = {
+        statusField: 'approval_status',
+        targetBaseId: BASE,
+        targetSheetId: SHEET,
+        targetRecordId: SAME_BASE_TARGET_RECORD,
+      }
+      const executionId = await runCrossBaseBackwrite(svc, RW, {
+        title: 'Same-base target plan',
+        triggerActorId: REQUESTER,
+        beforeApprove: async () => {
+          await q(
+            `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
+             VALUES ($1, $2, $3::jsonb, 1, $4)
+             ON CONFLICT (id) DO UPDATE
+                SET data = EXCLUDED.data,
+                    version = 1`,
+            [SAME_BASE_TARGET_RECORD, SHEET, JSON.stringify({ title: 'same-base target' }), REQUESTER],
+          )
+        },
+      })
+
+      const src = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])).rows[0].data as Record<string, unknown>
+      expect(src).toEqual({ title: 'Same-base target plan' })
+      const sameBaseTarget = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [SAME_BASE_TARGET_RECORD, SHEET])).rows[0].data as Record<string, unknown>
+      expect(sameBaseTarget).toEqual({ title: 'same-base target' })
+      const resumed = (await svc.logs.getById(executionId))!
+      const startStep = resumed.steps.find((s) => s.actionType === 'start_approval')
+      expect(startStep?.output).toMatchObject({ backwriteSkipped: expect.stringContaining('different base') })
+      expect(startStep?.output).not.toHaveProperty('crossBaseBackwrite')
+    } finally {
       svc.shutdown()
     }
   })

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -785,6 +785,31 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
     }
   })
 
+  test('T3-5: a cross-base target record LOCKED by ANOTHER actor → backwrite skipped (trigger actor governs the target lock); target + source unchanged', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
+    try {
+      await seedCrossBaseTargets()
+      // XB_BASE_OK is owned by the trigger actor REQUESTER (base-write authorized), but the TARGET record is
+      // locked by ANOTHER actor (APPROVER). ensureRecordNotLocked is evaluated with the TRIGGER actor, so the
+      // lock holds → the cross-base backwrite skips, no partial write.
+      await q('UPDATE meta_records SET locked = TRUE, locked_by = $1 WHERE id = $2 AND sheet_id = $3', [APPROVER, XB_REC_NULL, XB_SHEET_OK])
+      const RW = { statusField: 'xb_status', targetBaseId: XB_BASE_OK, targetSheetId: XB_SHEET_OK, targetRecordId: XB_REC_NULL }
+      const executionId = await runCrossBaseBackwrite(svc, RW, { title: 'Locked plan', triggerActorId: REQUESTER })
+
+      const tgt = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [XB_REC_NULL, XB_SHEET_OK])).rows[0].data as Record<string, unknown>
+      expect(tgt).toEqual({}) // unchanged — locked, no partial write
+      const src = (await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])).rows[0].data as Record<string, unknown>
+      expect(src).toEqual({ title: 'Locked plan' })
+      const resumed = (await svc.logs.getById(executionId))!
+      const startStep = resumed.steps.find((s) => s.actionType === 'start_approval')
+      expect(startStep?.output).toHaveProperty('backwriteSkipped')
+      expect(startStep?.output).not.toHaveProperty('crossBaseBackwrite')
+    } finally {
+      await q('UPDATE meta_records SET locked = FALSE, locked_by = NULL WHERE id = $1 AND sheet_id = $2', [XB_REC_NULL, XB_SHEET_OK]).catch(() => {})
+      svc.shutdown()
+    }
+  })
+
   test('T3-5: a cross-base target with a SOURCE-resident field id does NOT mutate the source record (anti-misroute)', async () => {
     const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
     try {

--- a/packages/core-backend/tests/integration/multitable-cross-base-write-quota.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-write-quota.test.ts
@@ -203,4 +203,22 @@ describeIfDatabase('cross-base write QUOTA guardrail (real DB)', () => {
     expect(over.steps[0]?.error ?? '').toMatch(/quota/i)
     expect(await countRecords(SHEET_D)).toBe(before + 2) // only the 2 under-limit writes landed
   })
+
+  // ── Q-6: T3-5 cross-base backwrite gate shares the per-target-base counter with create_record (Q5) ──
+  // `evaluateCrossBaseWriteGate` is the reusable "new shape" gate the approval resultWriteback cross-base
+  // backwrite calls. Filling BASE_B via a real create_record must make a subsequent backwrite-gate
+  // evaluation for BASE_B reject on quota — proving the SHARED per-target-base bucket AND that an
+  // authorized gate evaluation consumes a slot (the backwrite's "blocked/not-found still consumes" posture).
+  test('Q-6: the cross-base backwrite gate shares the per-target-base quota with create_record', async () => {
+    const { executor } = makeExecutor({ limit: 2, windowMs: 60_000, store: new MemoryRateLimitStore() })
+    // Slot 1 via a real create_record cross-base write.
+    expect((await executor.execute(crossBaseCreate(SHEET_B, BASE_B, 'q6-c1'), trigger)).steps[0]?.status).toBe('success')
+    // Slot 2 via the backwrite gate directly (authorized: OWNER owns BASE_B) → ok, consumes the 2nd slot.
+    const gate2 = await executor.evaluateCrossBaseWriteGate(q, OWNER, SHEET_A, SHEET_B, BASE_B)
+    expect(gate2).toEqual({ crossBase: true, ok: true })
+    // 3rd attempt now exceeds limit=2 → quota reject via the SHARED BASE_B counter.
+    const gate3 = await executor.evaluateCrossBaseWriteGate(q, OWNER, SHEET_A, SHEET_B, BASE_B)
+    expect(gate3).toMatchObject({ crossBase: true, ok: false })
+    if (gate3.crossBase && gate3.ok === false) expect(gate3.error).toMatch(/quota/i)
+  })
 })


### PR DESCRIPTION
Implements T3-5 per its ratified design-lock — extends W7 `resultWriteback` to a **literal cross-base target**, reusing the executor's ratified cross-base write gate.

## What ships (design-lock §2)
- **Config (Q2):** `resultWriteback` gains optional literal `targetBaseId`+`targetSheetId`+`targetRecordId` (no templating). Save gate: all-three-or-none required when any is set (create + update).
- **Effective actor (Q1):** the **trigger actor** (`readTriggerActorId(bridge.triggerEvent)` → `triggerEvent.actorId`), NOT the resume actor. Null/system approvals **fail closed** at the gate (no owner/requester fallback). Same actor governs the target-record lock. VALUES still come from the event (approver = `event.actor?.id`).
- **Gate reuse (§3.4):** extracted the executor gate to a public context-agnostic `evaluateCrossBaseWriteGate(queryFn, actorId, triggerSheetId, targetSheetId, declaredTargetBaseId)`; the 4 record-action call sites keep the old adapter signature; the service calls it on the **same executor instance** → **shares the singleton per-target-base quota** with update/create/delete/lock (Q5).
- **Audit (Q3):** no new table; step output carries the target triple; actor omitted from the target-base realtime fan-out.

## Verification (independently re-run)
tsc 0 · **start-approval 22/22** (16 existing W7 + 6 new T3-5) · cross-base gate suites **30/30** incl. a new **Q-6 quota-sharing** test. **RED-before confirmed** — incl. the sharpest **anti-misroute** (a source-resident field id + cross-base triple mutated the SOURCE record pre-change; untouched post-change). Proven: authorized target write · unauthorized fail-closed · null-actor fail-closed (no requester fallback) · **source untouched** · **non-merge into resume tail** (tail webhook lacks the cross-base patch) · step-output triple · target-sheet fan-out. Self-reviewed (2 finder agents: correctness clean; 4 cleanup items applied) + advisor.

## Named follow-ups (honest, disclosed)
- **`onNonApproved` + cross-base** is reachable (a non-approved terminal with `onNonApproved:true` + a cross-base triple routes through the same cross-base branch) but **not pinned by a test** — by-construction covered by T3-4's `onNonApproved` gating × T3-5's cross-base branch (both independently tested); the reject-flow test needs custom plumbing. Worth a follow-up test.
- Realtime **actor-omission** is implemented but asserted only via the eventBus emit, not a publish spy.
- **Resume-retry quota double-spend** documented as a v1 limitation in-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)