### PR TITLE
feat(multitable): C2 cross-base editable-mirror write-through op — asymmetric authority + no-oracle (default-off) (#3440/#3441)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -168,7 +168,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope + mirror-read-only enumeration hardening)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope + mirror-read-only enumeration hardening + cross-base editable-mirror write-through op)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -203,6 +203,7 @@ jobs:
             tests/integration/multitable-oapi-scope-guard-realdb.test.ts \
             tests/integration/multitable-oapi-token-create-scope.api.test.ts \
             tests/integration/multitable-mirror-readonly-enumeration-realdb.test.ts \
+            tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts \
             tests/integration/multitable-fieldperm-write-gate-patch-realdb.test.ts \
             tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -735,6 +735,46 @@ function defaultCrossBaseWriteQuota(): { limit: number; windowMs: number } {
 // silently defeat the guardrail). `unref`'d cleanup timer prunes expired windows.
 const defaultCrossBaseWriteQuotaStore = new MemoryRateLimitStore(DEFAULT_CROSS_BASE_WRITE_QUOTA_WINDOW_MS)
 
+/**
+ * Shared per-target-base cross-base write quota — the SAME discipline (increment-then-check, keyed by the
+ * resolved target base, env-tunable via CROSS_BASE_WRITE_QUOTA_*) and the SAME default counter store as the
+ * automation executor's gate, exposed for the C2 mirror write-through op's base-A leg (#3440 Lock B: quota
+ * is caller-composed, keyed to base A, never applied to the base-B leg). Sharing the store means automation
+ * writes and mirror-op writes draw from ONE per-base budget in-process, which is the point of the guardrail
+ * (protect the target base), not an accident. Returns true when the write is within quota. Fail-open ONLY on
+ * a counter-store error (store failure, not actor failure — mirrors checkCrossBaseWriteQuota).
+ */
+/**
+ * Test-only: clear the shared cross-base write quota counters (the `_map` getter exists for exactly this).
+ * Lets a real-DB golden assert an absolute limit boundary without prior-test accumulation on the process-
+ * global singleton. Never called by runtime code.
+ */
+export function __resetSharedCrossBaseWriteQuotaForTest(): void {
+  defaultCrossBaseWriteQuotaStore._map.clear()
+}
+
+export async function consumeSharedCrossBaseWriteQuota(
+  targetBaseId: string,
+  override?: { limit?: number; windowMs?: number; store?: RateLimitStore },
+): Promise<boolean> {
+  const def = defaultCrossBaseWriteQuota()
+  const limit = override?.limit ?? def.limit
+  const windowMs = override?.windowMs ?? def.windowMs
+  const store = override?.store ?? defaultCrossBaseWriteQuotaStore
+  const key = `crossbase-write-quota:${targetBaseId}`
+  let count: number
+  try {
+    count = (await store.increment(key, windowMs)).count
+  } catch (err) {
+    logger.warn('Cross-base write quota store error; allowing this write', {
+      targetBaseId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return true
+  }
+  return count <= limit
+}
+
 export interface AutomationDeps {
   eventBus: EventBus
   queryFn: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>

--- a/packages/core-backend/src/multitable/post-commit-hooks.ts
+++ b/packages/core-backend/src/multitable/post-commit-hooks.ts
@@ -1,7 +1,7 @@
 // 'restore' is a record-level version restore (Layer 1). It is NOT bridge-origin,
 // so the invalidator below (skips only 'yjs-bridge') correctly fires for it — a
 // restore writes meta_records.data and any live Y.Doc must re-seed from the DB.
-export type RecordWriteSource = 'rest' | 'yjs-bridge' | 'restore'
+export type RecordWriteSource = 'rest' | 'yjs-bridge' | 'restore' | 'crossbase-mirror-write'
 
 export type YjsInvalidator = (recordIds: string[]) => Promise<void> | void
 

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -261,6 +261,18 @@ export interface RecordPatchInput {
    * Absent for session writes → strict no-op (the session write path is unchanged).
    */
   oapiAudit?: OapiWriteAuditContext
+  /**
+   * C2 cross-base mirror write-through (#3440 §3/§4): an authority/no-oracle guard the dedicated mirror op
+   * injects so its Lock-B (asymmetric two-leg authority) + Lock-C (per-record no-oracle mask on the named
+   * forward record) checks run INSIDE this patch's mutation transaction — the guard takes FOR UPDATE on its
+   * gating rows first, so authorization cannot drift between check and edge write (TOCTOU, permission-revert
+   * lesson). Runs as the FIRST statement of the transaction, before any record row is read or mutated; a
+   * throw aborts the whole patch. The guard MAY finalize the pending link change values it computed under
+   * those locks (the link set-diff and target validation read `changes` later, inside this same
+   * transaction). Never set by the general PATCH / bulk / Yjs / restore paths — the mirror stays read-only
+   * on every existing path (C2/I-1); this seam carries authorization for the ONE gated op only.
+   */
+  preWriteGuard?: (query: QueryFn) => Promise<void>
 }
 
 export interface RecordPatchResult {
@@ -693,6 +705,8 @@ export class RecordWriteService {
       mirrorInvalidationBySheet.set(mirrorSheetId, group)
     }
     const updates = await this.pool.transaction(async ({ query }) => {
+      // C2 mirror write-through: in-transaction authority/no-oracle guard (see RecordPatchInput.preWriteGuard).
+      if (input.preWriteGuard) await input.preWriteGuard(query)
       const updated: Array<{ recordId: string; version: number }> = []
 
       // Native person (人员): resolve the sheet member set ONCE per patch op (lazily, only when a

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -273,6 +273,19 @@ export interface RecordPatchInput {
    * on every existing path (C2/I-1); this seam carries authorization for the ONE gated op only.
    */
   preWriteGuard?: (query: QueryFn) => Promise<void>
+  /**
+   * C2 cross-base mirror write-through (#3440 Lock A/B): when true, skip the SHEET-LEVEL
+   * `ensureRecordWriteAllowed` record-write gate for the records this patch mutates — the mirror op's
+   * `preWriteGuard` has ALREADY established the full authorization the design-lock specifies (Lock B base-A
+   * C1 base-level write authority + quota, base-B rec_B record-edit leg, Lock C per-record read+write mask on
+   * the named forward record). The service's own `ensureRecordWriteAllowed(capsA)` is `multitable:write`
+   * (a DISJOINT permission axis from C1's `resolveBaseWritable`), so applying it here would wrongly re-gate —
+   * and over-deny — the feature's target actor (a base-B actor authorized purely via C1, without global
+   * `multitable:write` or a sheet-A grant). ONLY the dedicated, guard-protected mirror op may set this; every
+   * other patchRecords protection (FOR UPDATE lock, ensureRecordNotLocked, link-target-exists validation,
+   * dedup, revision, mirror-invalidation, field validation) still runs. Never set by any general path.
+   */
+  authorizationPreValidated?: boolean
 }
 
 export interface RecordPatchResult {
@@ -610,6 +623,7 @@ export class RecordWriteService {
       sheetScope,
       access,
       source,
+      authorizationPreValidated,
     } = input
 
     const h = this.helpers
@@ -751,7 +765,13 @@ export class RecordWriteService {
         }
         const recordRow: any = (recordRes.rows as any[])[0]
 
+        // authorizationPreValidated: the C2 mirror op's preWriteGuard already carries the design-lock's
+        // full authority (base-A C1 base-level write + quota + base-B rec_B edit + Lock-C per-record
+        // read+write mask). The sheet-level ensureRecordWriteAllowed axis (multitable:write) is disjoint
+        // from C1 and would over-deny the target actor, so it is skipped for that op ONLY. All other
+        // guards below (lock, link-target, dedup, validation) still run.
         if (
+          !authorizationPreValidated &&
           !h.ensureRecordWriteAllowed(
             capabilities,
             sheetScope,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -198,6 +198,8 @@ import {
   RecordPatchFieldValidationError as RecordServicePatchFieldValidationError,
 } from '../multitable/record-service'
 import { canUnlock, ensureRecordNotLocked, mapRecordLockState } from '../multitable/record-lock'
+import { resolveCrossBaseWriteAuthority } from '../multitable/cross-base-write-authority'
+import { consumeSharedCrossBaseWriteQuota } from '../multitable/automation-executor'
 import {
   acquireAutoNumberSheetWriteLock,
   allocateAutoNumberValues,
@@ -15221,6 +15223,236 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] lock record failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update record lock state' } })
+    }
+  })
+
+
+  // ── C2 cross-base editable-mirror write-through (#3440 design-lock / #3441 build spec) ────────────────
+  // The ONE deliberately-gated path that lets a base-B actor edit a cross-base mirror field M_B by mutating
+  // the single canonical FORWARD edge (F_A, rec_A, rec_B) THROUGH RecordWriteService.patchRecords (Lock A:
+  // the forward service supplies dedup / link-target-exists / revision / mirror-invalidation — never a
+  // hand-rolled meta_links INSERT/DELETE, and never a row keyed by M_B). Authorization runs INSIDE the
+  // patch transaction via preWriteGuard (Lock B asymmetric two-leg authority + Lock C per-record no-oracle
+  // mask), after FOR UPDATE on the gating rows (sheets + both records) so base/permission cannot drift
+  // between check and edge write (§4; permission-revert lesson). Default-off behind
+  // MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE — and NOT enable-ready until the Decision-F concurrency gate
+  // (forward link-edit ↔ this op) is proven closed by its own golden (build spec §6).
+  //
+  // Same-base mirrors stay read-only on every path incl. this one (Decision D): the op REFUSES a same-base
+  // pairing. The general PATCH / bulk / create / form / import / plugin-SDK / Yjs / snapshot paths are
+  // untouched — the mirror read-only floor (C2/I-1, isFieldAlwaysReadOnly) is never widened.
+  router.post('/crossbase/mirror-link', async (req: Request, res: Response) => {
+    // W-flag: unset → the op does not exist as a write path (mirror read-only exactly as today).
+    if (String(process.env.MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE ?? '').trim().toLowerCase() !== 'true') {
+      return res.status(403).json({ ok: false, error: { code: 'MIRROR_WRITE_DISABLED', message: 'Cross-base mirror editing is not enabled' } })
+    }
+    const schema = z.object({
+      sheetId: z.string().min(1), // base-B sheet — where the mirror field lives
+      recordId: z.string().min(1), // rec_B — the record whose mirror cell is being edited
+      fieldId: z.string().min(1), // M_B — the mirror field id
+      action: z.enum(['add', 'remove']),
+      foreignRecordId: z.string().min(1), // rec_A — the base-A record to link/unlink
+      // Lock B base-A leg: the explicit declared base-A opt-in (claim == truth via the C1 primitive).
+      targetBaseId: z.string().min(1),
+    })
+    const parsed = schema.safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+    // Lock C uniform fail-closed deny (no-oracle): masked ≡ missing ≡ row-denied ≡ locked ≡ record-scope-
+    // denied on the named rec_A — ONE byte-identical status+body for every per-record rec_A outcome, on
+    // BOTH verbs, thrown from the guard and emitted from exactly one site below. No response byte (and no
+    // success/noop split) may distinguish "exists but unreadable" from "does not exist", nor "was linked"
+    // from "never existed" (the REMOVE-side linkage oracle).
+    class MirrorLinkTargetUnavailableError extends Error {}
+    // Coarse actor-side denials (base-B leg / base-A leg) — these are about the ACTOR's own authority, not
+    // about rec_A, so they may be distinguishable from each other (but carry no rec_A information).
+    class MirrorOpDeniedError extends Error {
+      constructor(public readonly denyCode: 'RECORD_EDIT_DENIED' | 'FIELD_POLICY_DENIED' | 'CLAIM_MISMATCH' | 'BASE_NOT_WRITABLE') { super(denyCode) }
+    }
+    class MirrorOpQuotaError extends Error {}
+    class MirrorOpRecordMissingError extends Error {}
+    try {
+      const pool = poolManager.get()
+      const q = pool.query.bind(pool)
+      const { sheetId: sheetB, recordId: recB, fieldId: mirrorFieldId, action, foreignRecordId: recA, targetBaseId: declaredBaseClaim } = parsed.data
+
+      const { access, capabilities: capsB, sheetScope: scopeB } = await resolveSheetCapabilities(req, q, sheetB)
+      if (!access.userId) {
+        return res.status(401).json({ error: 'Authentication required' })
+      }
+      const actorId = getRequestActorId(req)
+      const actorUserId = access.userId
+
+      // Resolve the mirror pairing M_B → F_A. Config-shape failures are plain validation responses — they
+      // describe the actor's OWN sheet-B field config, never rec_A.
+      const mirrorFieldRes = await q('SELECT id, type, property FROM meta_fields WHERE id = $1 AND sheet_id = $2', [mirrorFieldId, sheetB])
+      const mirrorFieldRow = mirrorFieldRes.rows[0] as { id?: unknown; type?: unknown; property?: unknown } | undefined
+      if (!mirrorFieldRow || String(mirrorFieldRow.type) !== 'link') {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Mirror field not found: ${mirrorFieldId}` } })
+      }
+      const mirrorProperty = normalizeJson(mirrorFieldRow.property)
+      const mirrorCfg = parseLinkFieldConfig(mirrorFieldRow.property)
+      const forwardFieldId = typeof mirrorProperty.mirrorOf === 'string' && mirrorProperty.mirrorOf.trim().length > 0 ? mirrorProperty.mirrorOf.trim() : ''
+      const sheetA = mirrorCfg?.foreignSheetId ?? ''
+      if (!forwardFieldId || !sheetA) {
+        return res.status(422).json({ ok: false, error: { code: 'NOT_A_MIRROR_FIELD', message: 'Field is not a mirror-side twoWay link' } })
+      }
+      const forwardFieldRes = await q('SELECT id, type, property FROM meta_fields WHERE id = $1 AND sheet_id = $2', [forwardFieldId, sheetA])
+      const forwardFieldRow = forwardFieldRes.rows[0] as { id?: unknown; type?: unknown; property?: unknown } | undefined
+      const forwardCfg = forwardFieldRow && String(forwardFieldRow.type) === 'link' ? parseLinkFieldConfig(forwardFieldRow.property) : null
+      if (!forwardCfg || forwardCfg.twoWay !== true || forwardCfg.mirrorFieldId !== mirrorFieldId || forwardCfg.foreignSheetId !== sheetB) {
+        return res.status(422).json({ ok: false, error: { code: 'MIRROR_PAIRING_INVALID', message: 'Mirror field is not paired to a matching forward link' } })
+      }
+      const basesRes = await q('SELECT id, base_id FROM meta_sheets WHERE id = ANY($1::text[])', [[sheetA, sheetB]])
+      const baseBySheet = new Map<string, string | null>()
+      for (const r of basesRes.rows as Array<{ id: unknown; base_id: unknown }>) {
+        baseBySheet.set(String(r.id), typeof r.base_id === 'string' ? r.base_id : null)
+      }
+      if (!baseBySheet.has(sheetA) || !baseBySheet.has(sheetB)) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Sheet not found for mirror pairing' } })
+      }
+      const baseA = baseBySheet.get(sheetA) ?? null
+      const baseB = baseBySheet.get(sheetB) ?? null
+      // Decision D: the SAME-base mirror stays read-only — this op exists for the cross-base pairing only
+      // (null-aware, same comparison as the read path's cross-base resolution).
+      if (baseA === baseB) {
+        return res.status(403).json({ ok: false, error: { code: 'MIRROR_WRITE_CROSSBASE_ONLY', message: 'Same-base mirror fields are read-only' } })
+      }
+
+      // Sheet-A write context (schema/echo-mask/guards) — config-level, resolved pre-transaction; the
+      // per-row gating happens under FOR UPDATE inside the guard below.
+      const { capabilities: capsA, sheetScope: scopeA } = await resolveSheetCapabilities(req, q, sheetA)
+      const patchContext = await buildRecordPatchContext(req, q, sheetA, access, capsA)
+      if (!patchContext) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetA}` } })
+      }
+
+      // The single forward change. Its value is FINALIZED inside the guard (under the gating locks, in the
+      // same transaction the set-diff + link-target validation read it), so the resolved edge set cannot
+      // drift between resolve and write (§4).
+      const forwardChange: { fieldId: string; value: unknown } = { fieldId: forwardFieldId, value: [] }
+
+      const preWriteGuard = async (query: QueryFn): Promise<void> => {
+        // Gating-row locks FIRST, deterministic order (sheets sorted, then records): serializes against
+        // permission grant/revoke (which take the sheet FOR UPDATE) and against concurrent instances of
+        // this op. The forward writer re-locks rec_A later in this same transaction (no-op).
+        await query('SELECT id FROM meta_sheets WHERE id = ANY($1::text[]) FOR UPDATE', [[sheetA, sheetB].sort()])
+        const recBRes = await query('SELECT id, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE', [recB, sheetB])
+        const recBRow = recBRes.rows[0] as { created_by?: unknown; locked?: unknown; locked_by?: unknown } | undefined
+        if (!recBRow) throw new MirrorOpRecordMissingError() // the actor's OWN record — a plain 404, no rec_A info
+
+        // ── Lock B, base-B acting-side leg — RECORD-level edit eligibility on rec_B (owner-ratified:
+        // record-edit / row-level-deny / mirror-op field policy). NO C1 primitive, NO claim, NO quota —
+        // base-B is the acting side, not a cross-base canonical-edge target.
+        if (!capsB.canEditRecord) throw new MirrorOpDeniedError('RECORD_EDIT_DENIED')
+        const recBScopeMap = await loadRecordPermissionScopeMap(query, sheetB, [recB], actorUserId)
+        const recBCreatedBy = typeof recBRow.created_by === 'string' ? recBRow.created_by : null
+        if (!ensureRecordWriteAllowed(capsB, scopeB, access, recBCreatedBy, 'edit', recBScopeMap, recB)) {
+          throw new MirrorOpDeniedError('RECORD_EDIT_DENIED')
+        }
+        if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(query, sheetB)) && (await loadDeniedRecordIds(query, sheetB, actorUserId)).has(recB)) {
+          throw new MirrorOpDeniedError('RECORD_EDIT_DENIED')
+        }
+        // Editing rec_B.M_B is semantically a rec_B edit even though the physical mutation lands on
+        // rec_A.F_A — a locked rec_B blocks the op like any other rec_B edit.
+        ensureRecordNotLocked(actorId, recBRow, () => new MirrorOpDeniedError('RECORD_EDIT_DENIED'))
+        // Mirror-op field policy: a per-subject hide / explicit per-subject read-only on M_B for THIS actor
+        // denies the op. (The DERIVED mirrorOf read-only is what this dedicated op is gated to bypass; the
+        // per-subject field_permissions scope is not.)
+        const mirrorFieldScope = (await loadFieldPermissionScopeMap(query, sheetB, actorUserId)).get(mirrorFieldId)
+        if (mirrorFieldScope && (mirrorFieldScope.visible === false || mirrorFieldScope.readOnly === true)) {
+          throw new MirrorOpDeniedError('FIELD_POLICY_DENIED')
+        }
+
+        // ── Lock B, base-A canonical-owner leg — the C1 primitive (claim==truth BEFORE base-writable,
+        // fail-closed), then the caller-composed base-A-keyed quota as the LAST authority gate (same
+        // discipline + same shared per-base budget as automation cross-base writes). base-B consumed no
+        // claim and no quota above.
+        const authority = await resolveCrossBaseWriteAuthority({ actorId: actorUserId, targetBaseId: baseA, declaredBaseClaim, queryFn: query })
+        if ('reason' in authority) {
+          throw new MirrorOpDeniedError(authority.reason === 'claim_mismatch' ? 'CLAIM_MISMATCH' : 'BASE_NOT_WRITABLE')
+        }
+        if (!(await consumeSharedCrossBaseWriteQuota(baseA as string))) {
+          throw new MirrorOpQuotaError()
+        }
+
+        // ── Lock C — per-record no-oracle mask on the NAMED rec_A, BEFORE any edge-existence read (the
+        // REMOVE-side linkage oracle): base-read + foreign-field readability (canonical read-path helper),
+        // sheet-A read gate, existence, row-level read deny, record-scope deny, record lock — every one of
+        // them the SAME MirrorLinkTargetUnavailableError, so masked ≡ missing ≡ denied, byte-identical.
+        const readability = await resolveForeignFieldReadability(req, query, baseB, [sheetA])
+        const readEntry = readability.get(sheetA)
+        if (!readEntry || readEntry.readableFieldIds.size === 0) throw new MirrorLinkTargetUnavailableError()
+        const readableSheets = await resolveReadableSheetIds(req, query, [sheetA])
+        if (!readableSheets.has(sheetA)) throw new MirrorLinkTargetUnavailableError()
+        const recARes = await query('SELECT id, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE', [recA, sheetA])
+        const recARow = recARes.rows[0] as { created_by?: unknown; locked?: unknown; locked_by?: unknown } | undefined
+        if (!recARow) throw new MirrorLinkTargetUnavailableError()
+        if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(query, sheetA)) && (await loadDeniedRecordIds(query, sheetA, actorUserId)).has(recA)) {
+          throw new MirrorLinkTargetUnavailableError()
+        }
+        const recAScope = (await loadRecordPermissionScopeMap(query, sheetA, [recA], actorUserId)).get(recA)
+        if (recAScope && recAScope.accessLevel === 'none') throw new MirrorLinkTargetUnavailableError()
+        ensureRecordNotLocked(actorId, recARow, () => new MirrorLinkTargetUnavailableError())
+
+        // ── Only now may edge existence be read: finalize the forward set under the held locks. The
+        // forward writer's own set-diff + ON CONFLICT dedup make a re-add a no-op (never a duplicate
+        // canonical row) and a remove-nonlinked a no-op.
+        const currentRes = await query('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2', [forwardFieldId, recA])
+        const currentIds = (currentRes.rows as Array<{ foreign_record_id: unknown }>).map((r) => String(r.foreign_record_id))
+        forwardChange.value = action === 'add'
+          ? (currentIds.includes(recB) ? currentIds : [...currentIds, recB])
+          : currentIds.filter((id) => id !== recB)
+      }
+
+      const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+      if (yjsInvalidator) {
+        recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      }
+      const result = await recordWriteService.patchRecords({
+        sheetId: sheetA,
+        changesByRecord: new Map([[recA, [forwardChange]]]) as Map<string, Array<{ fieldId: string; value: unknown; expectedVersion?: number }>>,
+        actorId,
+        fields: patchContext.fields,
+        visiblePropertyFields: patchContext.readableEchoFields,
+        visiblePropertyFieldIds: patchContext.readableEchoFieldIds,
+        attachmentFields: patchContext.attachmentFields,
+        fieldById: patchContext.fieldById,
+        capabilities: capsA,
+        sheetScope: scopeA,
+        access,
+        source: 'crossbase-mirror-write',
+        preWriteGuard,
+      })
+      return res.json({
+        ok: true,
+        data: {
+          action,
+          recordId: recB,
+          fieldId: mirrorFieldId,
+          forward: { sheetId: sheetA, recordId: recA, fieldId: forwardFieldId, version: result.updated[0]?.version ?? null },
+        },
+      })
+    } catch (err) {
+      if (err instanceof MirrorLinkTargetUnavailableError) {
+        // The ONE uniform fail-closed body (Lock C). Do not add fields, vary the message, or branch here.
+        return res.status(403).json({ ok: false, error: { code: 'MIRROR_LINK_TARGET_UNAVAILABLE', message: 'Link target is not available' } })
+      }
+      if (err instanceof MirrorOpRecordMissingError) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${parsed.data.recordId}` } })
+      }
+      if (err instanceof MirrorOpDeniedError) {
+        return res.status(403).json({ ok: false, error: { code: err.denyCode, message: 'Cross-base mirror edit denied' } })
+      }
+      if (err instanceof MirrorOpQuotaError) {
+        return res.status(429).json({ ok: false, error: { code: 'CROSS_BASE_WRITE_QUOTA_EXCEEDED', message: 'Cross-base write quota exceeded for the target base' } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] crossbase mirror-link failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to apply mirror link edit' } })
     }
   })
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -15277,7 +15277,9 @@ export function univerMetaRouter(): Router {
       const q = pool.query.bind(pool)
       const { sheetId: sheetB, recordId: recB, fieldId: mirrorFieldId, action, foreignRecordId: recA, targetBaseId: declaredBaseClaim } = parsed.data
 
-      const { access, capabilities: capsB, sheetScope: scopeB } = await resolveSheetCapabilities(req, q, sheetB)
+      // base-B sheet resolution: only `access` is taken here — the base-B capability is re-derived UNDER the
+      // guard's sheet lock (§4, below) so it cannot drift between this resolve and the edge write.
+      const { access } = await resolveSheetCapabilities(req, q, sheetB)
       if (!access.userId) {
         return res.status(401).json({ error: 'Authentication required' })
       }
@@ -15338,17 +15340,25 @@ export function univerMetaRouter(): Router {
         // permission grant/revoke (which take the sheet FOR UPDATE) and against concurrent instances of
         // this op. The forward writer re-locks rec_A later in this same transaction (no-op).
         await query('SELECT id FROM meta_sheets WHERE id = ANY($1::text[]) FOR UPDATE', [[sheetA, sheetB].sort()])
+        // §4: re-derive the base-B sheet capability UNDER the lock so a concurrent sheet-B grant revoke
+        // cannot be missed. capsB/scopeB above were resolved PRE-transaction; because a sheet-B write grant
+        // LIFTS the capability (applyContextSheetSchemaWriteGrant), a revoke committing between that resolve
+        // and this lock would leave the base-B leg checking STALE (still-writable) caps. Mirror exactly what
+        // resolveSheetCapabilities does, but with the transaction query holding the sheet FOR UPDATE.
+        const freshScopeB = (await loadSheetPermissionScopeMap(query, [sheetB], actorUserId)).get(sheetB)
+        const freshCapsB = applyContextSheetSchemaWriteGrant(deriveCapabilities(access.permissions, access.isAdminRole), freshScopeB, access.isAdminRole)
         const recBRes = await query('SELECT id, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE', [recB, sheetB])
         const recBRow = recBRes.rows[0] as { created_by?: unknown; locked?: unknown; locked_by?: unknown } | undefined
         if (!recBRow) throw new MirrorOpRecordMissingError() // the actor's OWN record — a plain 404, no rec_A info
 
         // ── Lock B, base-B acting-side leg — RECORD-level edit eligibility on rec_B (owner-ratified:
         // record-edit / row-level-deny / mirror-op field policy). NO C1 primitive, NO claim, NO quota —
-        // base-B is the acting side, not a cross-base canonical-edge target.
-        if (!capsB.canEditRecord) throw new MirrorOpDeniedError('RECORD_EDIT_DENIED')
+        // base-B is the acting side, not a cross-base canonical-edge target. Uses the freshly re-derived
+        // (under-lock) base-B capability so authorization cannot drift between check and edge write (§4).
+        if (!freshCapsB.canEditRecord) throw new MirrorOpDeniedError('RECORD_EDIT_DENIED')
         const recBScopeMap = await loadRecordPermissionScopeMap(query, sheetB, [recB], actorUserId)
         const recBCreatedBy = typeof recBRow.created_by === 'string' ? recBRow.created_by : null
-        if (!ensureRecordWriteAllowed(capsB, scopeB, access, recBCreatedBy, 'edit', recBScopeMap, recB)) {
+        if (!ensureRecordWriteAllowed(freshCapsB, freshScopeB, access, recBCreatedBy, 'edit', recBScopeMap, recB)) {
           throw new MirrorOpDeniedError('RECORD_EDIT_DENIED')
         }
         if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(query, sheetB)) && (await loadDeniedRecordIds(query, sheetB, actorUserId)).has(recB)) {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -15472,6 +15472,27 @@ export function univerMetaRouter(): Router {
       if (err instanceof MirrorOpQuotaError) {
         return res.status(429).json({ ok: false, error: { code: 'CROSS_BASE_WRITE_QUOTA_EXCEEDED', message: 'Cross-base write quota exceeded for the target base' } })
       }
+      // Generic RecordWriteService errors from the forward-write MECHANICS (field validation, version).
+      // These surface only AFTER the guard's Lock-C uniform mask has already established rec_A's
+      // existence + readability + writability under the FOR UPDATE lock, so they carry no rec_A
+      // existence/linkage signal the guard did not already settle — mapping them off the generic 500 to
+      // their proper statuses (parity with the /patch template) adds no new oracle. Messages stay coarse
+      // (values-free), NOT the raw service message, since this is a no-oracle-sensitive route.
+      if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) {
+        return res.status(409).json({ ok: false, error: { code: 'VERSION_CONFLICT', message: 'Cross-base mirror edit conflicted with a concurrent write' } })
+      }
+      if (err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) {
+        return res.status(403).json({ ok: false, error: { code: 'FIELD_FORBIDDEN', message: 'Cross-base mirror edit forbidden' } })
+      }
+      if (err instanceof ServiceValidationError || err instanceof RecordServiceValidationError) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Cross-base mirror edit is invalid' } })
+      }
+      // A post-guard record-not-found can only concern the named rec_A (rec_B is 404'd in the guard) and
+      // is impossible under its held FOR UPDATE lock — but if it ever surfaces it MUST collapse into the
+      // ONE uniform Lock-C body, never a distinguishable 404 (no rec_A existence oracle).
+      if (err instanceof ServiceNotFoundError || err instanceof RecordServiceNotFoundError) {
+        return res.status(403).json({ ok: false, error: { code: 'MIRROR_LINK_TARGET_UNAVAILABLE', message: 'Link target is not available' } })
+      }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] crossbase mirror-link failed:', err)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -15392,8 +15392,16 @@ export function univerMetaRouter(): Router {
         if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(query, sheetA)) && (await loadDeniedRecordIds(query, sheetA, actorUserId)).has(recA)) {
           throw new MirrorLinkTargetUnavailableError()
         }
+        // Lock C per-record READ+WRITE mask on rec_A (#3440 Lock C: masked ≡ missing ≡ NOT-WRITABLE, all
+        // uniform). base-A authority (Lock B) is BASE-level; a per-record record_permissions scope that
+        // limits this actor to read-deny ('none') OR read-only ('read') on rec_A must fail closed on the
+        // WRITE — folded into the SAME MirrorLinkTargetUnavailableError so read-only is byte-identical to
+        // masked/missing (no linkage/existence oracle). No scope entry ⇒ the base-level write authority
+        // already proven by the C1 leg governs (allowed) — do NOT re-impose a sheet-level write requirement.
         const recAScope = (await loadRecordPermissionScopeMap(query, sheetA, [recA], actorUserId)).get(recA)
-        if (recAScope && recAScope.accessLevel === 'none') throw new MirrorLinkTargetUnavailableError()
+        if (recAScope && (recAScope.accessLevel === 'none' || recAScope.accessLevel === 'read')) {
+          throw new MirrorLinkTargetUnavailableError()
+        }
         ensureRecordNotLocked(actorId, recARow, () => new MirrorLinkTargetUnavailableError())
 
         // ── Only now may edge existence be read: finalize the forward set under the held locks. The
@@ -15425,6 +15433,11 @@ export function univerMetaRouter(): Router {
         access,
         source: 'crossbase-mirror-write',
         preWriteGuard,
+        // The preWriteGuard above has already established the design-lock's full authority (base-A C1
+        // base-level write + quota + base-B rec_B edit + Lock-C per-record read+write mask). Skip the
+        // service's sheet-level ensureRecordWriteAllowed (multitable:write) gate — a disjoint permission
+        // axis from C1 that would over-deny the C1-only target actor (#3440 Lock A/B).
+        authorizationPreValidated: true,
       })
       return res.json({
         ok: true,

--- a/packages/core-backend/tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts
@@ -1,0 +1,325 @@
+/**
+ * C2 cross-base editable-mirror write-through — real-DB goldens (#3440 design-lock §6 / #3441 build spec §5).
+ *
+ * The ONE flag-gated op (`POST /crossbase/mirror-link`, MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE) that lets a
+ * base-B actor edit a cross-base mirror M_B by mutating the single canonical FORWARD edge (F_A, rec_A, rec_B)
+ * through the forward link-write service. Matrix:
+ *
+ *   W-flag  — flag unset ⇒ op refused, no write (mirror read-only exactly as today).
+ *   W-A     — spine + dedup: happy add ⇒ exactly one (F_A, rec_A, rec_B) row and count(M_B rows) === 0;
+ *             re-add of an edge that already exists from base-A's side ⇒ no-op, still exactly one row;
+ *             remove ⇒ edge gone. Floor regression: a mirror write via the general /patch is still rejected.
+ *             Fail-first (instrument proof): a directly-seeded M_B row IS detected by the spine probe.
+ *   W-B     — asymmetric authority: happy path needs base-A C1 (claim==truth + base-writable) AND base-B
+ *             record-level rec_B eligibility. Denials, each with NO edge: wrong claim; absent claim (400);
+ *             base-A not writable; base-B rec_B row-denied (record-level, NOT base-level); read-only actor;
+ *             quota N+1 (base-A-keyed). Asymmetry: a base-B-only denial consumes NO base-A quota slot, and
+ *             an actor WITHOUT base-B base-write authority still passes (C1 is invoked for base-A only).
+ *   W-C     — no-oracle (LOAD-BEARING): with base-A write authority but row-denied read on the named rec_A,
+ *             ADD is byte-identical (status + body) to ADD of a non-existent rec_A′, and REMOVE of the
+ *             masked-but-actually-linked rec_A is byte-identical to REMOVE of non-existent rec_A′ — with the
+ *             edge still present afterwards (no success/no-op signal distinguishes "was linked" from "never
+ *             existed"). These byte-identity assertions are themselves the fail-first detector for the
+ *             mask-after-edge-existence regression: moving the mask after the existence branch makes the two
+ *             responses diverge and turns these goldens RED.
+ *
+ * The spine assertion (count(meta_links WHERE field_id = M_B) === 0) runs after EVERY case.
+ * Decision-F (forward link-edit ↔ this op concurrency) is a SEPARATE enablement-gate golden — flag stays
+ * default-off; this suite sets the flag per-request-window explicitly and restores it.
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml real-DB runner list.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { __resetSharedCrossBaseWriteQuotaForTest } from '../../src/multitable/automation-executor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_A = `base_c2w_a_${TS}` // canonical-edge owner base (forward field's base)
+const BASE_B = `base_c2w_b_${TS}` // acting base (mirror field's base)
+const SA = `sheet_c2w_a_${TS}`
+const SB = `sheet_c2w_b_${TS}`
+const F_A = `fld_c2w_fwd_${TS}` // forward twoWay link A→B (the canonical edge key)
+const M_B = `fld_c2w_mir_${TS}` // mirror twoWay link B→A, mirrorOf=F_A (read-only on all non-op paths)
+const F_B_NAME = `fld_c2w_bname_${TS}`
+const REC_A1 = `rec_c2w_a1_${TS}`
+const REC_A2 = `rec_c2w_a2_${TS}` // the masked target (W-C)
+const REC_B1 = `rec_c2w_b1_${TS}`
+const REC_A_MISSING = `rec_c2w_missing_${TS}` // never inserted
+
+const OWNER = `u_c2w_owner_${TS}` // owns BASE_A (base-A writable) + full multitable perms
+const READONLY = `u_c2w_ro_${TS}` // multitable:read only (base-B leg: canEditRecord=false)
+const NOBASEA = `u_c2w_nba_${TS}` // full sheet perms but NOT base-A writable (no ownership, no base codes)
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = {
+  id: OWNER,
+  roles: ['member'],
+  perms: ['multitable:read', 'multitable:write'],
+}
+const asUser = (id: string, perms: string[]) => { currentUser = { id, roles: ['member'], perms } }
+const asOwner = () => asUser(OWNER, ['multitable:read', 'multitable:write'])
+
+/** Spine assertion: the mirror field must NEVER own a meta_links row. */
+const mirrorRows = async (): Promise<number> =>
+  Number(((await q('SELECT count(*)::int AS n FROM meta_links WHERE field_id = $1', [M_B])).rows[0] as { n: number }).n)
+/** Canonical forward edge count for (F_A, recA, recB). */
+const forwardEdgeCount = async (recA: string, recB: string): Promise<number> =>
+  Number(((await q('SELECT count(*)::int AS n FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = $3', [F_A, recA, recB])).rows[0] as { n: number }).n)
+
+type MirrorOpBody = {
+  sheetId?: string
+  recordId?: string
+  fieldId?: string
+  action?: 'add' | 'remove'
+  foreignRecordId?: string
+  targetBaseId?: string
+}
+const mirrorOp = (overrides: MirrorOpBody = {}) =>
+  request(app).post('/api/multitable/crossbase/mirror-link').send({
+    sheetId: SB,
+    recordId: REC_B1,
+    fieldId: M_B,
+    action: 'add',
+    foreignRecordId: REC_A1,
+    targetBaseId: BASE_A,
+    ...overrides,
+  })
+
+describeIfDatabase('C2 cross-base mirror write-through — op runtime goldens (real DB)', () => {
+  beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE = 'true'
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as express.Request & { user?: unknown }).user = currentUser; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    for (const u of [OWNER, READONLY, NOBASEA]) {
+      await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
+    }
+    // OWNER owns BASE_A ⇒ resolveBaseWritable(BASE_A) true for OWNER; nobody owns BASE_B and no actor holds
+    // base codes for it ⇒ an op success ALSO proves C1 is not invoked for the base-B leg (it would fail).
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE_A, 'C2W A', OWNER])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_B, 'C2W B'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3),($4,$5,$6)', [SA, BASE_A, 'A', SB, BASE_B, 'B'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_A, SA, 'Fwd', 'link', JSON.stringify({ foreignSheetId: SB, foreignBaseId: BASE_B, twoWay: true, mirrorFieldId: M_B }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [M_B, SB, 'Mir', 'link', JSON.stringify({ foreignSheetId: SA, foreignBaseId: BASE_A, twoWay: true, mirrorFieldId: F_A, mirrorOf: F_A }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_B_NAME, SB, 'BName', 'string', '{}', 2])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1),($4,$5,$6::jsonb,1),($7,$8,$9::jsonb,1)',
+      [REC_A1, SA, '{}', REC_A2, SA, '{}', REC_B1, SB, JSON.stringify({ [F_B_NAME]: 'b1' })])
+  })
+
+  afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE
+    delete process.env.CROSS_BASE_WRITE_QUOTA_LIMIT
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[F_A, M_B]]).catch(() => {})
+    await q('DELETE FROM record_permissions WHERE sheet_id = ANY($1::text[])', [[SA, SB]]).catch(() => {})
+    for (const t of ['meta_record_revisions', 'meta_records']) await q(`DELETE FROM ${t} WHERE sheet_id = ANY($1::text[])`, [[SA, SB]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SA, SB]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SA, SB]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[OWNER, READONLY, NOBASEA]]).catch(() => {})
+    await poolManager.get().end?.()
+  })
+
+  afterEach(async () => {
+    // The spine invariant holds after EVERY case, whatever the outcome (allow / deny / error).
+    expect(await mirrorRows()).toBe(0)
+    asOwner()
+  })
+
+  // ── W-flag ────────────────────────────────────────────────────────────────
+  test('W-flag: flag unset ⇒ op refused, no edge written', async () => {
+    process.env.MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE = 'false'
+    try {
+      const res = await mirrorOp()
+      expect(res.status).toBe(403)
+      expect(res.body?.error?.code).toBe('MIRROR_WRITE_DISABLED')
+      expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+    } finally {
+      process.env.MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE = 'true'
+    }
+  })
+
+  // ── W-A: spine + dedup + floor ───────────────────────────────────────────
+  test('W-A: happy add writes exactly ONE canonical forward edge; mirror owns no row', async () => {
+    const res = await mirrorOp()
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.forward?.fieldId).toBe(F_A)
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(1)
+    expect(await mirrorRows()).toBe(0)
+  })
+
+  test('W-A: re-add of an edge that already exists is a NO-OP — still exactly one (F_A,…) row', async () => {
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(1) // seeded by the previous golden via the op itself
+    const res = await mirrorOp()
+    expect(res.status).toBe(200)
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(1) // dedup via the forward service, no duplicate row
+  })
+
+  test('W-A: remove deletes the canonical edge', async () => {
+    const res = await mirrorOp({ action: 'remove' })
+    expect(res.status).toBe(200)
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+  })
+
+  test('W-A floor regression: a mirror write via the general /patch is STILL rejected (C2/I-1 intact)', async () => {
+    const res = await request(app).post('/api/multitable/patch').send({
+      sheetId: SB,
+      changes: [{ recordId: REC_B1, fieldId: M_B, value: [REC_A1] }],
+    })
+    expect(res.status).toBe(403)
+    expect(await mirrorRows()).toBe(0)
+  })
+
+  test('W-A fail-first instrument proof: a directly-seeded M_B row IS detected by the spine probe', async () => {
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [M_B, REC_B1, REC_A1])
+    expect(await mirrorRows()).toBe(1) // the probe that guards every other golden really can go red
+    await q('DELETE FROM meta_links WHERE field_id = $1', [M_B])
+  })
+
+  // ── W-B: asymmetric two-leg authority ────────────────────────────────────
+  test('W-B: wrong base-A claim ⇒ deny, no edge (claim==truth is load-bearing)', async () => {
+    const res = await mirrorOp({ targetBaseId: BASE_B }) // truthful-looking but WRONG (must equal F_A's base)
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('CLAIM_MISMATCH')
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+  })
+
+  test('W-B: absent claim ⇒ fail-closed 400, no edge', async () => {
+    const res = await mirrorOp({ targetBaseId: undefined })
+    expect(res.status).toBe(400)
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+  })
+
+  test('W-B: base-A not writable ⇒ deny, no edge — while base-B base-write is NEVER required (asymmetry)', async () => {
+    asUser(NOBASEA, ['multitable:read', 'multitable:write'])
+    const res = await mirrorOp()
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('BASE_NOT_WRITABLE')
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+    // Asymmetry positive proof: OWNER holds NO base-write authority on BASE_B (not owner, no base codes) —
+    // if the C1 primitive were (wrongly) invoked for the base-B leg the happy path could never pass; it
+    // passes in W-A above purely on record-level rec_B eligibility.
+  })
+
+  test('W-B: read-only actor fails the base-B record-edit leg ⇒ deny, no edge', async () => {
+    asUser(READONLY, ['multitable:read'])
+    const res = await mirrorOp()
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('RECORD_EDIT_DENIED')
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+  })
+
+  test('W-B: rec_B row-denied actor cannot use the mirror op as a bypass (RECORD-level, not base-level) — and the denial consumes NO base-A quota', async () => {
+    // Row-level read deny on rec_B for OWNER: record-edit eligibility on the SPECIFIC rec_B fails even
+    // though OWNER's sheet/base-level authority is intact — the record-level upgrade the lock ratified.
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = true WHERE id = $1', [SB])
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)',
+      [SB, REC_B1, 'user', OWNER, 'none'])
+    __resetSharedCrossBaseWriteQuotaForTest() // absolute boundary: ignore prior tests' accumulation on the shared singleton
+    process.env.CROSS_BASE_WRITE_QUOTA_LIMIT = '1' // ONE slot in the window for BASE_A
+    try {
+      const denied = await mirrorOp()
+      expect(denied.status).toBe(403)
+      expect(denied.body?.error?.code).toBe('RECORD_EDIT_DENIED')
+      expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+
+      // The base-B-only denial above must NOT have consumed the single base-A quota slot: after lifting
+      // the rec_B deny, the very next authorized write still fits the limit-1 budget.
+      await q('DELETE FROM record_permissions WHERE sheet_id = $1 AND record_id = $2', [SB, REC_B1])
+      await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SB])
+      const allowed = await mirrorOp()
+      expect(allowed.status).toBe(200)
+      expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(1)
+
+      // Quota N+1 (base-A-keyed): the SECOND authorized attempt in the same window exceeds limit 1.
+      const overQuota = await mirrorOp({ action: 'remove' })
+      expect(overQuota.status).toBe(429)
+      expect(overQuota.body?.error?.code).toBe('CROSS_BASE_WRITE_QUOTA_EXCEEDED')
+      expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(1) // denied attempt wrote/removed nothing
+    } finally {
+      delete process.env.CROSS_BASE_WRITE_QUOTA_LIMIT
+      await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SB]).catch(() => {})
+      await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SB])
+      // leave state clean for W-C: remove the edge minted above (fresh window after env delete)
+      const cleanup = await mirrorOp({ action: 'remove' })
+      expect(cleanup.status).toBe(200)
+      expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+    }
+  })
+
+  // ── W-C: per-record no-oracle on rec_A (LOAD-BEARING) ────────────────────
+  test('W-C ADD: masked rec_A is BYTE-IDENTICAL to missing rec_A′ — uniform deny, no edge either way', async () => {
+    // OWNER has base-A write (owner) but is row-denied READ on the specific REC_A2.
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = true WHERE id = $1', [SA])
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)',
+      [SA, REC_A2, 'user', OWNER, 'none'])
+    try {
+      const masked = await mirrorOp({ foreignRecordId: REC_A2 })
+      const missing = await mirrorOp({ foreignRecordId: REC_A_MISSING })
+      expect(masked.status).toBe(missing.status)
+      expect(masked.body).toEqual(missing.body) // byte-identity: same status, same body, no divergence
+      expect(masked.status).toBe(403)
+      expect(await forwardEdgeCount(REC_A2, REC_B1)).toBe(0)
+      expect(await forwardEdgeCount(REC_A_MISSING, REC_B1)).toBe(0)
+    } finally {
+      await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SA]).catch(() => {})
+      await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SA])
+    }
+  })
+
+  test('W-C REMOVE: removing a masked-but-LINKED rec_A is BYTE-IDENTICAL to removing a missing rec_A′ — the edge survives (no linkage oracle)', async () => {
+    // Seed the canonical edge from base-A's side (the forward field's own write path is out of band here;
+    // direct seed keeps this golden independent of the ADD goldens).
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [F_A, REC_A2, REC_B1])
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = true WHERE id = $1', [SA])
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)',
+      [SA, REC_A2, 'user', OWNER, 'none'])
+    try {
+      const maskedLinked = await mirrorOp({ action: 'remove', foreignRecordId: REC_A2 })
+      const missing = await mirrorOp({ action: 'remove', foreignRecordId: REC_A_MISSING })
+      expect(maskedLinked.status).toBe(missing.status)
+      expect(maskedLinked.body).toEqual(missing.body) // "was linked" is indistinguishable from "never existed"
+      expect(maskedLinked.status).toBe(403)
+      expect(await forwardEdgeCount(REC_A2, REC_B1)).toBe(1) // the masked remove removed NOTHING
+    } finally {
+      await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SA]).catch(() => {})
+      await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SA])
+      await q('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [F_A, REC_A2])
+    }
+  })
+
+  test('W-C: authorized-and-readable rec_A still flows normally after the mask goldens (no over-deny)', async () => {
+    const add = await mirrorOp({ foreignRecordId: REC_A2 })
+    expect(add.status).toBe(200)
+    expect(await forwardEdgeCount(REC_A2, REC_B1)).toBe(1)
+    const remove = await mirrorOp({ action: 'remove', foreignRecordId: REC_A2 })
+    expect(remove.status).toBe(200)
+    expect(await forwardEdgeCount(REC_A2, REC_B1)).toBe(0)
+  })
+
+  // ── Decision D guard: the op refuses a SAME-base pairing ─────────────────
+  test('same-base pairing is refused (same-base mirror stays read-only, Decision D)', async () => {
+    // Re-point sheet B into BASE_A temporarily: pairing becomes same-base.
+    await q('UPDATE meta_sheets SET base_id = $2 WHERE id = $1', [SB, BASE_A])
+    try {
+      const res = await mirrorOp()
+      expect(res.status).toBe(403)
+      expect(res.body?.error?.code).toBe('MIRROR_WRITE_CROSSBASE_ONLY')
+      expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+    } finally {
+      await q('UPDATE meta_sheets SET base_id = $2 WHERE id = $1', [SB, BASE_B])
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts
@@ -239,6 +239,25 @@ describeIfDatabase('C2 cross-base mirror write-through — op runtime goldens (r
     expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
   })
 
+  test('W-B: per-subject field policy (M_B read-only/hidden) denies the op ⇒ FIELD_POLICY_DENIED, no edge', async () => {
+    // build-spec §5 W-A base-B denial: "the relevant mirror-op field policy on rec_B". The DERIVED mirrorOf
+    // read-only is exactly what this dedicated op is gated to bypass — but an EXPLICIT per-subject
+    // field_permissions hide/read-only on M_B for the acting user is NOT bypassed. OWNER passes every other
+    // leg, so this isolates the field-policy denial (thrown in the base-B leg, before base-A quota).
+    await q("INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,true,true)",
+      [SB, M_B, OWNER])
+    try {
+      const res = await mirrorOp()
+      expect(res.status).toBe(403)
+      expect(res.body?.error?.code).toBe('FIELD_POLICY_DENIED')
+      expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+      // Fail-first: deleting the guard's field-policy check (op ~lines 145-148) lets the op reach the write
+      // ⇒ 200 with no FIELD_POLICY_DENIED code → this golden goes RED.
+    } finally {
+      await q('DELETE FROM field_permissions WHERE sheet_id = $1 AND field_id = $2', [SB, M_B]).catch(() => {})
+    }
+  })
+
   test('W-B: rec_B row-denied actor cannot use the mirror op as a bypass (RECORD-level, not base-level) — and the denial consumes NO base-A quota', async () => {
     // Row-level read deny on rec_B for OWNER: record-edit eligibility on the SPECIFIC rec_B fails even
     // though OWNER's sheet/base-level authority is intact — the record-level upgrade the lock ratified.

--- a/packages/core-backend/tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts
@@ -55,6 +55,12 @@ const REC_A_MISSING = `rec_c2w_missing_${TS}` // never inserted
 const OWNER = `u_c2w_owner_${TS}` // owns BASE_A (base-A writable) + full multitable perms
 const READONLY = `u_c2w_ro_${TS}` // multitable:read only (base-B leg: canEditRecord=false)
 const NOBASEA = `u_c2w_nba_${TS}` // full sheet perms but NOT base-A writable (no ownership, no base codes)
+// The FEATURE'S ACTUAL TARGET USER: authorized purely via the cross-base C1 leg (a DB `multitable:base:write`
+// code → resolveBaseWritable(BASE_A)=true) + a sheet-B write grant (spreadsheet_permissions → capsB
+// record-edit for the base-B leg), but with NO global `multitable:write` and NO sheet-A grant → capsA
+// (sheet-A) record-write is FALSE. Proves the op authorizes the forward write from the guard's C1/quota/
+// Lock-C authority, not the disjoint sheet-level `multitable:write` axis patchRecords would otherwise impose.
+const TARGET = `u_c2w_tgt_${TS}`
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
@@ -101,14 +107,24 @@ describeIfDatabase('C2 cross-base mirror write-through — op runtime goldens (r
     app.use((req, _res, next) => { ;(req as express.Request & { user?: unknown }).user = currentUser; next() })
     app.use('/api/multitable', univerMetaRouter())
 
-    for (const u of [OWNER, READONLY, NOBASEA]) {
+    for (const u of [OWNER, READONLY, NOBASEA, TARGET]) {
       await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
     }
+    // TARGET base-A leg (C1): a DB base-write code → resolveBaseWritable(BASE_A)=true (reads
+    // user_permissions, NOT req.user.perms — disjoint from capsA). (The sheet-B grant for the base-B leg is
+    // inserted after the sheets exist, below.)
+    await q("INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'multitable:base:write') ON CONFLICT DO NOTHING", [TARGET])
     // OWNER owns BASE_A ⇒ resolveBaseWritable(BASE_A) true for OWNER; nobody owns BASE_B and no actor holds
     // base codes for it ⇒ an op success ALSO proves C1 is not invoked for the base-B leg (it would fail).
     await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE_A, 'C2W A', OWNER])
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_B, 'C2W B'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3),($4,$5,$6)', [SA, BASE_A, 'A', SB, BASE_B, 'B'])
+    // TARGET base-B leg: a sheet-B FULL write grant (spreadsheet:write ⇒ canRead+canWrite) → capsB
+    // .canEditRecord lifted for sheet B ONLY; sheet A stays ungranted so capsA.canEditRecord=false. TARGET's
+    // Lock-C READ access to base-A/sheet-A comes from its req.user.perms (multitable:read + multitable:base:read,
+    // set per-test) — base:read satisfies the cross-base resolveBaseReadable(BASE_A) gate WITHOUT lifting any
+    // WRITE capability, keeping the forward write authorized solely by the guard's C1/quota/Lock-C authority.
+    await q("INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,'spreadsheet:write')", [SB, TARGET])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [F_A, SA, 'Fwd', 'link', JSON.stringify({ foreignSheetId: SB, foreignBaseId: BASE_B, twoWay: true, mirrorFieldId: M_B }), 1])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
@@ -128,7 +144,9 @@ describeIfDatabase('C2 cross-base mirror write-through — op runtime goldens (r
     await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SA, SB]]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SA, SB]]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
-    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[OWNER, READONLY, NOBASEA]]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[SA, SB]]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = $1', [TARGET]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[OWNER, READONLY, NOBASEA, TARGET]]).catch(() => {})
     await poolManager.get().end?.()
   })
 
@@ -307,6 +325,48 @@ describeIfDatabase('C2 cross-base mirror write-through — op runtime goldens (r
     const remove = await mirrorOp({ action: 'remove', foreignRecordId: REC_A2 })
     expect(remove.status).toBe(200)
     expect(await forwardEdgeCount(REC_A2, REC_B1)).toBe(0)
+  })
+
+  // ── W-Target: the C1-only actor (the feature's actual target user) — authority from the guard, NOT
+  //    the disjoint sheet-level multitable:write axis. Fail-first for the over-deny fix: WITHOUT
+  //    authorizationPreValidated, patchRecords' ensureRecordWriteAllowed(capsA) throws (capsA.canEditRecord
+  //    =false here) and the route degrades to 500 — this golden goes RED.
+  test('W-Target: C1-authorized actor with NO global multitable:write (sheet-B grant only) succeeds — add+remove one canonical edge', async () => {
+    __resetSharedCrossBaseWriteQuotaForTest()
+    // NO multitable:write ⇒ capsA.canEditRecord=false. base-A WRITE via the DB base:write code (C1);
+    // base:read satisfies Lock-C cross-base read of BASE_A; base-B via the sheet-B write grant.
+    asUser(TARGET, ['multitable:read', 'multitable:base:read'])
+    const add = await mirrorOp()
+    expect(add.status).toBe(200)
+    expect(add.body?.data?.forward?.fieldId).toBe(F_A)
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(1)
+    expect(await mirrorRows()).toBe(0)
+    const remove = await mirrorOp({ action: 'remove' })
+    expect(remove.status).toBe(200)
+    expect(await forwardEdgeCount(REC_A1, REC_B1)).toBe(0)
+  })
+
+  // ── W-C write-mask: rec_A READABLE but a per-record record_permissions 'read' (read-only) scope denies
+  //    the WRITE — uniform, byte-identical to missing (masked ≡ missing ≡ NOT-WRITABLE, no oracle). Fail-
+  //    first for the Lock-C write-mask: without the `accessLevel==='read'` branch the read-only actor would
+  //    reach the edge write and the two responses diverge.
+  test('W-C write-mask: read-only record scope on rec_A ⇒ uniform MIRROR_LINK_TARGET_UNAVAILABLE, byte-identical to missing, no edge', async () => {
+    __resetSharedCrossBaseWriteQuotaForTest()
+    // TARGET can READ REC_A2 (multitable:read + a record 'read' grant) but the 'read' scope forbids WRITE.
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)',
+      [SA, REC_A2, 'user', TARGET, 'read'])
+    asUser(TARGET, ['multitable:read', 'multitable:base:read'])
+    try {
+      const readOnly = await mirrorOp({ foreignRecordId: REC_A2 })
+      const missing = await mirrorOp({ foreignRecordId: REC_A_MISSING })
+      expect(readOnly.status).toBe(missing.status)
+      expect(readOnly.body).toEqual(missing.body) // read-only ≡ missing: no write-vs-nonexistent oracle
+      expect(readOnly.status).toBe(403)
+      expect(readOnly.body?.error?.code).toBe('MIRROR_LINK_TARGET_UNAVAILABLE')
+      expect(await forwardEdgeCount(REC_A2, REC_B1)).toBe(0)
+    } finally {
+      await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SA]).catch(() => {})
+    }
   })
 
   // ── Decision D guard: the op refuses a SAME-base pairing ─────────────────

--- a/packages/core-backend/tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts
@@ -113,6 +113,11 @@ describeIfDatabase('C2 cross-base mirror write-through — op runtime goldens (r
     // TARGET base-A leg (C1): a DB base-write code → resolveBaseWritable(BASE_A)=true (reads
     // user_permissions, NOT req.user.perms — disjoint from capsA). (The sheet-B grant for the base-B leg is
     // inserted after the sheets exist, below.)
+    // Seed the permission-catalog parent row FIRST: user_permissions.permission_code FKs to
+    // permissions(code), and this suite must not depend on a sibling test seeding it earlier in the CI
+    // ordering (it stably FK-violated on the 20.x real-DB run when nothing had). Matches the pattern in
+    // multitable-base-writable-resolver.test.ts.
+    await q("INSERT INTO permissions (code, name, description) VALUES ('multitable:base:write', 'Base Write', 'C2 mirror write-through tests') ON CONFLICT (code) DO NOTHING")
     await q("INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'multitable:base:write') ON CONFLICT DO NOTHING", [TARGET])
     // OWNER owns BASE_A ⇒ resolveBaseWritable(BASE_A) true for OWNER; nobody owns BASE_B and no actor holds
     // base codes for it ⇒ an op success ALSO proves C1 is not invoked for the base-B leg (it would fail).


### PR DESCRIPTION
## What

Cross-base Slice-1 **C2 PR-B**: the ONE deliberately-gated op that lets a base-B actor edit a cross-base mirror field `M_B` (add/remove a link to a base-A record `rec_A`) by writing the single canonical **forward** edge `(F_A, rec_A, rec_B)` through the existing forward link-write service. Implements the RATIFIED design-lock #3440 (Locks A/B/C, §3/§4) + build spec #3441.

**Default-off behind `MULTITABLE_ENABLE_CROSSBASE_MIRROR_WRITE`. NOT enable-ready** — the Decision-F concurrency gate (forward link-edit ↔ this op TOCTOU/lock closure) is a separate follow-up golden and is the precondition for any flag-on. This PR must not be read as enablement.

## The three locks

- **Lock A — spine preserved, write-through only.** New dedicated route `POST /crossbase/mirror-link` (never a branch in general PATCH — the mirror read-only floor `isFieldAlwaysReadOnly` is unchanged). Effects the change as an authority-gated patch of `rec_A.F_A` through `RecordWriteService.patchRecords`, which supplies dedup/ON-CONFLICT, link-target-exists validation, revision recording, mirror-invalidation. Never a hand-rolled `meta_links` INSERT/DELETE; never a row keyed by `M_B`. Golden asserts `count(meta_links WHERE field_id = M_B) === 0` after every outcome; re-add is a no-op (no duplicate canonical row).
- **Lock B — asymmetric two-leg authority.** base-A (canonical-owner) leg = C1 primitive `resolveCrossBaseWriteAuthority` (claim==truth before base-writable) + caller-composed base-A-keyed quota (same shared per-base budget as automation). base-B (acting) leg = **record-level** edit eligibility on `rec_B` (record-edit / row-level-deny / record-lock / per-subject mirror-field policy) — NO C1 primitive, NO claim, NO quota. Either leg fails ⇒ deny.
- **Lock C — per-record no-oracle mask on `rec_A`.** Every per-record `rec_A` outcome (foreign-field-unreadable / sheet-unreadable / missing / row-read-denied / record-scope read-only / locked) throws ONE uniform `MIRROR_LINK_TARGET_UNAVAILABLE` (403), on BOTH verbs, BEFORE any edge-existence read — masked ≡ missing ≡ not-writable, byte-identical (closes the REMOVE-side linkage oracle).

Runs in ONE `pool.transaction` with `FOR UPDATE` on the gating rows (sheets + both records) taken first (§4). All authority — base-A C1, base-B sheet capability, record/field/row scopes — is re-read under the lock.

## Adversarial review (this PR was reviewed before merge)

Multi-lens adversarial review with independent verification. Findings, all resolved:
- **BLOCKER (fixed c3aac7a4d):** routing through `patchRecords` with `capsA` re-gated the forward write on the actor's sheet-level `multitable:write` — a permission axis disjoint from C1 — silently over-denying the feature's target user (a base-B actor authorized purely via C1) to a 500. Fixed with a scoped `authorizationPreValidated` seam that skips ONLY that one sheet-level gate (every other patchRecords protection still runs); the guard's Lock-B/C already carry the full authority. Also closed the Lock-C per-record **write** mask (deny a read-only record scope on `rec_A`, folded into the uniform deny).
- **MINOR (fixed 3a82b7898):** base-B sheet capability was captured pre-transaction; now re-derived under the guard's lock so a concurrent sheet-B grant revoke can't be missed (§4).
- **ADVISORY (fixed 3a82b7898):** added the missing FIELD_POLICY_DENIED fail-first golden.
- no-oracle byte-identity, spine/dedup, base-B asymmetry (no claim/quota), and quota parity with automation: verified clean.

## Tests

`multitable-crossbase-mirror-writethrough-realdb.test.ts` — **18/18 real-DB goldens**, each security case fail-first-proven (reverting the fix turns its golden RED), spine assertion after every case, wired into the `plugin-tests.yml` real-DB job. Covers W-flag, W-A (spine+dedup+floor-regression+instrument), W-B (asymmetric authority incl. C1-only target actor succeeds + base-B consumes no quota), W-C (ADD+REMOVE byte-identity incl. read-only-record-scope), FIELD_POLICY_DENIED, same-base refusal (Decision D).

## Out of scope (unchanged, each a separate gate)

Flag enablement (Decision-F concurrency golden precondition); same-base editable mirror (D); live realtime push (E); cross-base triggers; cascade; FE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)