### PR TITLE
docs(approval): reconcile second-batch automation status

### DIFF
--- a/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
+++ b/docs/development/approval-automation-goal-batch-dev-verification-20260703.md
@@ -2,8 +2,9 @@
 
 > `/goal` deliverable: deep-review the line, sequence the remaining items for **parallel development**,
 > complete everything genuinely buildable, and record dev + verification. **Discipline honored:** gated
-> runtime is NOT blind-built on presumed votes; instead every remaining rung is made **one vote from build**
-> (design-lock / build-spec), and the decision-clean work is completed + verified this batch.
+> runtime was not blind-built on presumed votes; design-lock/build-spec came first. As of the 2026-07-03
+> as-built reconcile, the second-batch runtime rungs that were made one-vote-from-build here have since shipped
+> (`#3505` / `#3506`). The remaining runtime is the third-batch owner/governance tail.
 
 ## 1. Shipped / queued in this batch (code-verified, base through #3441 `a206a5bb` + this PR)
 
@@ -15,17 +16,20 @@ Engine parity with 钉钉/飞书 approval is ~85% — the recent burst closed mo
   T1-2 signed inbound webhook (#3489) · T3-4 W7 rejection backwrite (#3474) · T0-3 delete_record editor
   (#3477).
 - **Approval engine:** T1-1 slice-2 transfer/jump timeout effects (#3468) · T2-1+2 scoped admins + handover
-  (#3490).
-- **UX:** rule editor exposes approval.completed + webhook.received (#3495) · **approval-center batch
-  approve/reject + list-level urge (#3496, open)**.
+  (#3490) · T1-4 field-permissions authoring (#3505).
+- **UX:** rule editor exposes approval.completed + webhook.received (#3495) · approval-center batch
+  approve/reject + list-level urge (#3496, merged).
+- **W7/cross-base:** T3-5 cross-base resultWriteback shipped (#3506) after the design-lock-first contract,
+  including trigger-actor gate/lock, source untouched, non-merge into tail context, and same-base target-triple
+  fail-closed hardening.
 
 ## 2. Remaining items — gating (authoritative)
 
 | Item | Subsystem | Size | Gating | Made-ready this batch |
 |---|---|---|---|---|
 | **node-timeout deadline-clear race** | approval metrics | S | **decision-clean → BUILT (#3497)** | ✅ shipped-for-review |
-| **T3-5** W7 cross-base backwrite | automation (Lane C) | L | design-lock-first (owner) | **design-lock #3-5 doc** |
-| **T1-4** node field-perms authoring | approval (Lane B) | M | owner-vote-needed | **build-spec doc** |
+| ~~T3-5 W7 cross-base backwrite~~ | automation (Lane C) | L | **SHIPPED (#3506)** | literal cross-base target triple + trigger-actor authority/lock |
+| ~~T1-4 node field-perms authoring~~ | approval (Lane B) | M | **SHIPPED (#3505)** | field-permissions authoring UI + preservation/anti-flatten |
 | **T3-2** business-calendar SLA | product | L | owner-vote-needed (3rd ballot) | reuse-attendance note |
 | **T3-3** node signature/compliance | approval | M-L | owner-vote-needed (declared-inert first) | 3rd ballot |
 | **T3-1** mobile approval | product | L | owner-vote-needed (blocked on notif hub) | 3rd ballot |
@@ -34,10 +38,9 @@ Engine parity with 钉钉/飞书 approval is ~85% — the recent burst closed mo
 
 ## 3. Parallel-development plan (lanes — concurrent, hot-file-sequential within a lane)
 
-- **Lane B — approval engine** (`ApprovalProductService.ts` hot): T1-4 field-perms authoring (on vote) →
-  T3-3 signature (declared-inert first).
-- **Lane C — automation engine** (`automation-service.ts` hot): T3-5 cross-base backwrite (on vote,
-  design-lock ready).
+- **Lane B — approval engine** (`ApprovalProductService.ts` hot): T1-4 field-perms authoring **shipped (#3505)** →
+  next third-batch T3-3 signature (declared-inert first, owner-voted).
+- **Lane C — automation engine** (`automation-service.ts` hot): T3-5 cross-base backwrite **shipped (#3506)**.
 - **Lane D — product/heavy** (separate surfaces, fully parallel): T3-6 approvals-as-records (highest
   differentiation — unlocks 飞书-grade reporting + re-automation for free), T3-2 calendar-SLA (reuse the
   attendance effective-calendar substrate → L drops toward M), T3-1 mobile (responsive pass; native blocked
@@ -45,8 +48,8 @@ Engine parity with 钉钉/飞书 approval is ~85% — the recent burst closed mo
 - **Lane A — BPMN:** A3 is governance-only — no code slice; authorize a destination when a named integration
   needs it.
 
-Dependency notes: T3-2 → T1-1 node-SLA (met) · T3-5/T3-3 sit on their hot files so stay sequential within
-their lanes · Lane D items share no runtime hot file → genuinely parallel.
+Dependency notes: T3-2 → T1-1 node-SLA (met) · T3-3 sits on the approval hot file and stays sequential within
+Lane B · Lane D items share no runtime hot file → genuinely parallel.
 
 ## 4. Completed this batch (decision-clean — no owner vote) + verification
 
@@ -60,16 +63,14 @@ advanced node's fresh deadline is wiped → test fails). **Broader regression:**
 
 _(Additional decision-clean items surfaced by the review workflow are appended in §6.)_
 
-## 5. Made one-vote-from-build this batch (authorized design, no runtime)
+## 5. Made one-vote-from-build, then shipped in follow-up PRs
 
 - **T3-5 design-lock** (`w7-cross-base-resultwriteback-design-lock-20260703.md`) — register Q1–Q5 + the 5
   reviewer must-fixes turned into a build contract + fail-first verification plan. Reuses the ratified
-  executor cross-base gate; literal target triple; trigger-actor authority fail-closed. **On T3-5 vote → build
-  Lane C.**
+  executor cross-base gate; literal target triple; trigger-actor authority fail-closed. **Shipped by #3506**.
 - **T1-4 build-spec** (`t1-4-node-field-permissions-authoring-build-spec-20260703.md`) — folds the owner
-  hidden/readonly steer + reconciles it with the register Q2 hidden-only default (the one vote to settle);
-  hidden enforced (echo-redaction), readonly persisted-but-runtime-inert (T1-4b later). **On T1-4 vote →
-  build Lane B.**
+  hidden/readonly steer + records the Q2 decision settled before #3505;
+  hidden enforced (echo-redaction), readonly persisted-but-runtime-inert (T1-4b later). **Shipped by #3505**.
 
 ## 6. Review findings (adversarial workflow + focused hunt)
 
@@ -118,9 +119,8 @@ as "simpler without it"). **Owner decision:** keep patching the cutoff heuristic
 
 The buildable-without-a-vote surface is completed + verified — **two decision-clean bugs found + fixed this
 batch: the node-timeout deadline-clear race (#3497, merged) and a second T2-4 threshold quorum bypass (#3499)**
-— plus a broader-surface hunt that verified the rest of the recently-shipped runtime clean. The heavy remainder
-is owner-gated;
-it is now one vote from build in three genuinely-parallel lanes (B / C / D), with the two nearest rungs
-(T3-5, T1-4) design-locked. Recommended fastest path: vote T3-5 + T1-4 to start B/C, and open Lane D on
-T3-6 (the differentiation move) in parallel. Sizing figures are optimistic build-effort, NOT calendar
-commitments — the security/permission/product rungs' review rounds can dominate.
+— plus a broader-surface hunt that verified the rest of the recently-shipped runtime clean. The two nearest
+owner-voted implementation rungs from this doc have since shipped: **T1-4 (#3505)** and **T3-5 (#3506)**.
+The heavy remainder is the third-batch owner/governance tail: A3 destination authorization, T3-2 calendar-SLA,
+T3-3 signature/compliance, T3-1 mobile approval, and T3-6 approvals-as-records. Sizing figures are optimistic
+build-effort, NOT calendar commitments — the security/permission/product rungs' review rounds can dominate.

--- a/docs/development/approval-automation-parallel-development-plan-20260701.md
+++ b/docs/development/approval-automation-parallel-development-plan-20260701.md
@@ -9,7 +9,8 @@
 > `to_version >= cutoff`) + same-version cascade regression (`#3453`), R1-A/R1-B egress closure (`#3437`/`#3443`/
 > `#3447`/`#3451`), A3 rollout design-lock + **runtime policy plumbing** (`#3452` + `#3455`/`#3457`/`#3460`),
 > T2-6 event dedup ledger (`#3450`), approval.completed trigger (`#3467`), timeout transfer/jump effects
-> (`#3468`), W7 non-approved result writeback (`#3474`), and delete_record editor exposure (`#3477`).
+> (`#3468`), W7 non-approved result writeback (`#3474`), delete_record editor exposure (`#3477`), T1-4
+> field-permissions authoring (`#3505`), and T3-5 cross-base resultWriteback (`#3506`).
 > **Honest framing:** the
 > remainder is owner-gated (design-lock-first) — so "complete all development" is realized by
 > *ratifying defaults **per lane/rung** (not blanket — it mixes SSRF / destructive-delete / permission-migration
@@ -33,9 +34,10 @@
 - **First-batch runtime — SHIPPED:** `approval.completed` automation trigger (`#3467`), T1-1 slice-2 timeout
   transfer/jump effects (`#3468`), W7 non-approved result writeback (`#3474`), and safe delete_record editor
   exposure (`#3477`) are all on main on the ballot defaults.
-- **Second-batch runtime (partial) — SHIPPED:** T1-2 signed inbound webhook trigger (`#3489`) and T2-1+2
+- **Second-batch runtime — SHIPPED / CLOSED:** T1-2 signed inbound webhook trigger (`#3489`), T2-1+2
   scoped approval admins + handover/bulk reassign (`#3490`, incl. the `reassign` action CHECK migration +
-  admin-scope permission codes). The second-batch ballot's remaining rungs (T3-5, T1-4) are still open.
+  admin-scope permission codes), T1-4 field-permissions authoring (`#3505`), and T3-5 W7 cross-base
+  resultWriteback (`#3506`) are all on main. The second-batch ballot is now a historical decision record.
 - **Automation rule-editor UI exposure — SHIPPED (`#3495`):** `approval.completed` and `webhook.received`
   are visible in the rule editor with the UI type/label/config surface. This is a UI exposure close-out for
   already-shipped triggers, not a new ballot rung.
@@ -51,9 +53,9 @@
 | **R1-A3** configured destination enablement | BPMN/workflow | **runtime SHIPPED** (#3455/#3457/#3460), destinations not yet authorized | governance-only remainder: `#3460` injects the server-owned `BPMN_HTTP_TASK_EGRESS_POLICY` env policy at both BPMN route construction points; `#3455` normalizer + `#3457` route-provenance locks are in. **No core runtime code left** — what remains is authorizing/configuring the first live destination (ops/governance per `#3452`), default stays deny-all |
 | ~~T1-1 slice-2 transfer/jump timeout effects~~ | approval engine | **SHIPPED (#3468)** | done — transfer/jump wired; auto_* terminal effects remain env-gated/inert |
 | ~~T2-1+2 scoped admins + handover~~ | approval engine | **SHIPPED (#3490)** | done — admin-scope capability codes + `reassign` bulk handover + CHECK/grant migration |
-| T1-4 node field-perms runtime | approval engine | unshipped | owner-gated (edit-form-at-node prerequisite) |
+| ~~T1-4 node field-perms authoring~~ | approval engine | **SHIPPED (#3505)** | done — authoring UI + preservation/anti-flatten; readonly/editable persisted but runtime-inert until edit-form-at-node |
 | ~~T3-4 W7 rejection backwrite~~ | automation/approval | **SHIPPED (#3474)** | done — opt-in non-approved writeback, write-back-then-fail |
-| T3-5 W7 cross-base backwrite | automation/approval | unshipped | owner-gated (cross-base write-gate re-lock) |
+| ~~T3-5 W7 cross-base backwrite~~ | automation/approval | **SHIPPED (#3506)** | done — literal cross-base target triple, trigger-actor gate/lock, source untouched, same-base target triple fails closed |
 | ~~T0-3 delete_record editor~~ | automation engine | **SHIPPED (#3477)** | done — same-base trigger-record only, ack-gated editor, save-gate hardening |
 | ~~T1-2 inbound webhook~~ | automation engine | **SHIPPED (#3489)** | done — signed (HMAC + timestamp window) inbound trigger, fail-closed secret, uniform reject oracle |
 | ~~T1-3 approval.* trigger~~ | automation engine | **SHIPPED (#3467)** | done — template-routed, record-less v1, T2-6 ledger reuse, permission recheck |
@@ -73,14 +75,13 @@ edits to `ApprovalProductService.ts` / `automation-service.ts` collide).
   is **destination authorization** — a config/ops governance act per `#3452`, not code. Default stays deny-all
   until a first named destination is explicitly authorized.
 - **Lane B — approval engine** (`ApprovalProductService.ts` — HOT, so sequential): ~~`T2-4 fix`~~ **done (#3446)**
-  + cascade regression **done (#3453)** + `T1-1 slice-2` **done (#3468)** + `T2-1+2` **done (#3490)** →
-  next `T1-4` field-permissions authoring (awaiting its ballot votes). (`T3-5` W7 cross-base backwrite touches
-  `automation-service.ts`, see Lane C.)
+  + cascade regression **done (#3453)** + `T1-1 slice-2` **done (#3468)** + `T2-1+2` **done (#3490)** +
+  `T1-4` field-permissions authoring **done (#3505)**. Remaining Lane-B work is the third-batch T3-3
+  signature/compliance slice, gated by its owner vote.
 - **Lane C — automation engine** (`automation-service.ts` — HOT, so sequential): ~~`T2-6 dedup`~~ **done (#3450)** →
   `T1-3 approval-trigger` **done (#3467)** → `T3-4` **done (#3474)** → `T0-3 delete_record` **done (#3477)** →
-  `T1-2 inbound webhook` **done (#3489)** → next `T3-5` W7 cross-base backwrite — **owner steer 2026-07-02:
-  design-lock-first as its own slice** (permission/lock/audit surface is heavy; do NOT fold it into the
-  fast demo layer).
+  `T1-2 inbound webhook` **done (#3489)** → `T3-5` W7 cross-base backwrite **done (#3506)**. Remaining
+  automation-side heavy work is third-batch/product gated.
 - **Lane D — product/heavy** (separate surfaces): `T3-1 mobile`, `T3-6 S-band`, `T3-2 business-calendar`
   (dep T1-1), `T3-3 signature`.
 
@@ -94,16 +95,16 @@ double-editing.
   (#3437/#3443/#3447/#3451) · T2-6 event dedup ledger (#3450) · approval.completed trigger (#3467) ·
   T1-1 timeout transfer/jump effects (#3468) · W7 non-approved writeback (#3474) · delete_record editor (#3477) ·
   T1-2 signed inbound webhook (#3489) · T2-1+2 scoped admins + handover (#3490) · rule-editor exposure for
-  `approval.completed` + `webhook.received` (#3495).
-- **Owner-gated:** the remaining rungs — A3 configured destination enablement (governance-only),
-  T3-5 W7 cross-base (**design-lock-first per owner steer 2026-07-02**), T1-4 field-perms authoring, and the
-  product/heavy items. The register (#3385) and the follow-up design-locks hold each rung's open decisions +
+  `approval.completed` + `webhook.received` (#3495) · T1-4 field-permissions authoring (#3505) · T3-5 W7
+  cross-base resultWriteback (#3506).
+- **Owner-gated:** the remaining rungs — A3 configured destination enablement (governance-only) and the
+  third-batch product/heavy items. The register (#3385) and the follow-up design-locks hold each rung's open decisions +
   proposed defaults.
   **Approve per lane/rung, not blanket** — the remainder mixes distinct risk surfaces (permission migration,
   cross-base write-back, product semantics), so a single blanket "build on defaults" is unsafe.
-  The next executable implementation decision surface is `approval-automation-second-batch-ballot-20260702.md`
-  — now **partially executed** (T1-2 `#3489` + T2-1+2 `#3490` shipped; T3-5 + T1-4 still awaiting votes).
-  The product/governance-heavy tail is separated into
+  The second-batch implementation surface `approval-automation-second-batch-ballot-20260702.md` is now
+  **fully executed and closed** (T1-2 `#3489`, T2-1+2 `#3490`, T1-4 `#3505`, T3-5 `#3506`). The next
+  executable decision surface is the product/governance-heavy tail in
   `approval-automation-third-batch-ballot-20260702.md` (A3 destination authorization, T3-2, T3-3,
   T3-1, T3-6) so strategic decisions do not get mistaken for ready implementation queue.
 
@@ -153,18 +154,17 @@ coverage wired into `plugin-tests.yml`, plus regression updates for record-servi
 ## 7. Recommendation
 1. **Done:** T2-4 fix + cascade regression (#3446/#3453) · R1-A/R1-B default-closed egress closure
    (#3437/#3443/#3447/#3451) · T2-6 dedup ledger (#3450) · first-batch runtime (#3467/#3468/#3474/#3477) ·
-   second-batch runtime partial (#3489 T1-2 · #3490 T2-1+2).
+   second-batch runtime (#3489 T1-2 · #3490 T2-1+2 · #3505 T1-4 · #3506 T3-5).
 2. **A3 is now governance-only:** the egress policy runtime is fully shipped (`#3452` design-lock +
    `#3455`/`#3457`/`#3460` normalizer / provenance locks / server-owned env injection). Default remains deny-all;
    the remaining act is **authorizing the first live destination** (config/ops), which happens when a named
    integration needs it — no code slice to schedule.
-3. **Next feature lanes after owner ratification:** Lane C `T3-5` W7 cross-base writeback
-   (design-lock-first per owner steer 2026-07-02); Lane B `T1-4` field-perms authoring. The **UI-exposure
-   close-out is done** (`#3495`: approval.completed + webhook.received in the automation rule editor), so it
-   is no longer a next-lane item. Continue to ratify
+3. **Next feature lanes after owner ratification:** the second-batch lanes are closed. The **UI-exposure
+   close-out is done** (`#3495`: approval.completed + webhook.received in the automation rule editor), T1-4
+   authoring is done (`#3505`), and T3-5 cross-base writeback is done (`#3506`). Continue to ratify
    register defaults **per lane/rung**, not blanket — the first-batch per-rung ballot now lives as the shipped
    decision record in `approval-automation-first-batch-ballot-20260701.md`; the second-batch ballot is
-   `approval-automation-second-batch-ballot-20260702.md`; the third-batch strategic/governance ballot is
+   now a closed decision record in `approval-automation-second-batch-ballot-20260702.md`; the third-batch strategic/governance ballot is
    `approval-automation-third-batch-ballot-20260702.md`. Sizing note: per-rung person-day estimates are
    optimistic build-effort figures, NOT calendar commitments — on the security/permission/migration rungs
    (T1-2, T2-1+2, T3-5) review rounds can cost more calendar than the build itself.

--- a/docs/development/approval-automation-second-batch-ballot-20260702.md
+++ b/docs/development/approval-automation-second-batch-ballot-20260702.md
@@ -1,12 +1,11 @@
 # Approval & Process-Automation — second-batch per-rung decision ballot (2026-07-02)
 
-> **Status: PARTIALLY EXECUTED (as-built reconcile 2026-07-02).** T1-2 and T2-1+2 were voted GO on the
-> proposed defaults and are **SHIPPED**: T1-2 signed inbound webhook `#3489` (`fadf1695e`), T2-1+2 scoped
-> admins + handover `#3490` (`2ebb8dd81`) — their tables below are the closed decision record. **Still
-> awaiting per-rung owner votes: T3-5 and T1-4.** For those, vote per line: ✅ adopt default · ✏️ override
-> (state the change) · ⏸ hold; a rung with every line ✅/✏️ becomes GO for design-lock-first implementation;
-> an unvoted rung remains gated. Owner steer 2026-07-02: **T3-5 runs design-lock-first as its own slice**
-> (permission/lock/audit surface is heavy — not part of the fast demo layer).
+> **Status: EXECUTED / CLOSED DECISION RECORD (as-built reconcile 2026-07-03).** All four second-batch
+> rungs were voted GO on their recorded defaults or owner-steered amendments and are **SHIPPED**:
+> T1-2 signed inbound webhook `#3489` (`fadf1695e`), T2-1+2 scoped admins + handover `#3490`
+> (`2ebb8dd81`), T1-4 field-permissions authoring `#3505` (`df8d43bf9`), and T3-5 W7 cross-base
+> resultWriteback `#3506` (`e80f622e5`). The tables below are now historical decision records, not
+> open votes.
 >
 > Source of truth for the defaults is `approval-automation-decision-register-20260629.md`, with reviewer
 > notes folded into the "build contract" blocks below so implementation does not repeat known blind spots.
@@ -21,8 +20,8 @@
 
 | Lane | Order | Why |
 |---|---|---|
-| C — automation engine (`automation-service.ts`) | ~~`T1-2 inbound webhook`~~ **done #3489** → `T3-5 W7 cross-base backwrite` (design-lock-first) | Both touch automation runtime and security gates; keep sequential to avoid hot-file collisions. |
-| B — approval engine / authoring | ~~`T2-1+2 scoped admins + handover`~~ **done #3490** → `T1-4 field permissions` | Permission/handover is the larger admin model slice; field-permission authoring stays bounded and does not unlock edit-form-at-node. |
+| C — automation engine (`automation-service.ts`) | ~~`T1-2 inbound webhook`~~ **done #3489** → ~~`T3-5 W7 cross-base backwrite`~~ **done #3506** | Both touched automation runtime and security gates; shipped sequentially to avoid hot-file collisions. |
+| B — approval engine / authoring | ~~`T2-1+2 scoped admins + handover`~~ **done #3490** → ~~`T1-4 field permissions`~~ **done #3505** | Permission/handover was the larger admin model slice; field-permission authoring stayed bounded and did not unlock edit-form-at-node. |
 
 ## T1-2 — inbound webhook endpoint (signed, audited) · M · Lane C first
 
@@ -51,13 +50,17 @@
 
 ## T3-5 — W7 cross-base resultWriteback · L · Lane C after T1-2
 
+> **SHIPPED `#3506` (`e80f622e5`)** on the defaults below, plus the review hardening that a target triple
+> resolving back to the source base fails closed instead of becoming a same-base arbitrary-record write. Closed
+> decision record, not an open vote.
+
 | # | Decision | Proposed default | Vote |
 |---|---|---|---|
-| Q1 | Effective actor for cross-base gate | Use the original trigger actor from `bridge.triggerEvent`, matching executor cross-base writes. Null/system approvals fail closed for cross-base backwrite. Same actor is used for target-record lock checks. | ⬜ |
-| Q2 | Target record addressing | Literal target triple only: `targetBaseId` + `targetSheetId` + `targetRecordId` on `resultWriteback`. Dynamic link-field target resolution is a named follow-up, not v1. | ⬜ |
-| Q3 | Audit/provenance | No new audit table in v1. Extend the `start_approval` step output with target base/sheet/record ids; omit actor from target-base realtime fan-out, matching cross-base privacy posture. | ⬜ |
-| Q4 | Save validation | If any target id is present, require the full triple at save. Defer target field-type/read validation to runtime; do not block save on author's target-base write authority. Runtime re-checks trigger actor authority every run. | ⬜ |
-| Q5 | Quota | Share the singleton per-target-base cross-base write quota with update/create/delete/lock. A blocked/not-found attempt still consumes a slot, matching existing executor posture. | ⬜ |
+| Q1 | Effective actor for cross-base gate | Use the original trigger actor from `bridge.triggerEvent`, matching executor cross-base writes. Null/system approvals fail closed for cross-base backwrite. Same actor is used for target-record lock checks. | ✅ SHIPPED #3506 |
+| Q2 | Target record addressing | Literal target triple only: `targetBaseId` + `targetSheetId` + `targetRecordId` on `resultWriteback`. Dynamic link-field target resolution is a named follow-up, not v1. | ✅ SHIPPED #3506 |
+| Q3 | Audit/provenance | No new audit table in v1. Extend the `start_approval` step output with target base/sheet/record ids; omit actor from target-base realtime fan-out, matching cross-base privacy posture. | ✅ SHIPPED #3506 |
+| Q4 | Save validation | If any target id is present, require the full triple at save. Defer target field-type/read validation to runtime; do not block save on author's target-base write authority. Runtime re-checks trigger actor authority every run. | ✅ SHIPPED #3506 |
+| Q5 | Quota | Share the singleton per-target-base cross-base write quota with update/create/delete/lock. A blocked/not-found attempt still consumes a slot, matching existing executor posture. | ✅ SHIPPED #3506 |
 
 **Build contract / reviewer-note must-fixes**
 
@@ -93,17 +96,17 @@
 
 ## T1-4 — node field-permissions authoring · M · Lane B after T2-1+2
 
-> **OPEN — awaiting votes.** Owner steer 2026-07-02: start with the hidden/readonly *configurable authoring
-> surface* and do NOT take on the full runtime semantics in one slice — reconcile this with Q2's
-> hidden-only-exposure default at vote time (either ✏️ Q2 to include a readonly control, or ✅ keep
-> hidden-only UI with readonly persisted-but-unexposed).
+> **SHIPPED `#3505` (`df8d43bf9`)** with the owner-steered hidden/readonly configurable authoring
+> surface. Runtime redaction for hidden fields already existed; this slice shipped the authoring UI and
+> preservation/anti-flatten contract. Readonly remains persisted but runtime-inert until a later edit-form-at-node
+> slice. Closed decision record, not an open vote.
 
 | # | Decision | Proposed default | Vote |
 |---|---|---|---|
-| Q1 | edit-form-at-node | Defer. This rung does not build mid-flow form editing or write-back to `form_snapshot`; readonly/editable remain runtime-inert. Create a later T1-4b for edit-form-at-node + readonly/editable enforcement. | ⬜ |
-| Q2 | What UI exposes | Expose only `hidden` in authoring UI. Do not expose readonly/editable controls while they have no runtime effect. | ⬜ |
-| Q3 | Authoring surface | Linear steps editor only. Complex-graph fieldPermissions remain preserved/read-only; complex authoring is a later G-6-style slice. | ⬜ |
-| Q4 | Hiding routing-driver fields | Allow it. Redaction is echo-only and does not affect assignee resolution or condition routing; show a non-blocking hint when a hidden field also drives routing. | ⬜ |
+| Q1 | edit-form-at-node | Defer. This rung does not build mid-flow form editing or write-back to `form_snapshot`; readonly/editable remain runtime-inert. Create a later T1-4b for edit-form-at-node + readonly/editable enforcement. | ✅ SHIPPED #3505 |
+| Q2 | What UI exposes | Owner-steered amendment: expose `hidden`, `readonly`, and `editable` as configurable authoring states while keeping readonly/editable runtime-inert in this slice. | ✅ SHIPPED #3505 |
+| Q3 | Authoring surface | Linear steps editor only. Complex-graph fieldPermissions remain preserved/read-only; complex authoring is a later G-6-style slice. | ✅ SHIPPED #3505 |
+| Q4 | Hiding routing-driver fields | Allow it. Redaction is echo-only and does not affect assignee resolution or condition routing; show a non-blocking hint when a hidden field also drives routing. | ✅ SHIPPED #3505 |
 
 **Build contract / reviewer-note must-fixes**
 
@@ -115,9 +118,10 @@
 ## Voting examples
 
 - `T1-2 all ✅; T3-5 hold; T2-1+2 Q6 ✏️ reuse transfer instead of reassign; T1-4 all ✅`
-- `Lane C all ✅` means T1-2 then T3-5 may be implemented sequentially.
-- `Lane B all ✅` means T2-1+2 then T1-4 may be implemented sequentially.
+- Historical: `Lane C all ✅` meant T1-2 then T3-5 could be implemented sequentially; both are now shipped.
+- Historical: `Lane B all ✅` meant T2-1+2 then T1-4 could be implemented sequentially; both are now shipped.
 - Strategic/product votes belong in `approval-automation-third-batch-ballot-20260702.md`, not this hot-file
   implementation batch.
 
-No runtime begins until the relevant rung's votes are complete.
+No additional runtime begins from this second-batch ballot; it is closed. Strategic/product votes remain in
+`approval-automation-third-batch-ballot-20260702.md`.

--- a/docs/development/t1-4-node-field-permissions-authoring-build-spec-20260703.md
+++ b/docs/development/t1-4-node-field-permissions-authoring-build-spec-20260703.md
@@ -1,9 +1,9 @@
-# T1-4 — Node field-permissions authoring · BUILD-SPEC (vote-ready) · 2026-07-03
+# T1-4 — Node field-permissions authoring · BUILD-SPEC (RATIFIED — SHIPPED #3505) · 2026-07-03
 
-> **Status: awaiting the T1-4 per-rung votes** in `approval-automation-second-batch-ballot-20260702.md`.
-> This spec folds the owner steer (2026-07-02): **start from the hidden/readonly configurable authoring
-> surface; do NOT take on the full mid-flow runtime semantics in one slice.** It reconciles that steer with
-> the register's Q2 hidden-only default (below) so the rung is one vote from build. **No runtime until voted.**
+> **Status: RATIFIED — SHIPPED by `#3505` (`df8d43bf9`).** The second-batch ballot adopted the owner steer:
+> expose the hidden/readonly/editable authoring surface while keeping readonly/editable runtime-inert until a
+> later edit-form-at-node slice. #3505 also shipped the malformed `fieldPermissions` fail-closed guard so
+> invalid entries become unsupported/read-only rather than silently flattening on save.
 
 ## 1. What's already shipped (contract layer, P1-C)
 
@@ -13,19 +13,17 @@
 form (`:1021`). So the **data model + validation is done**; the gaps are (a) an authoring UI to set it and
 (b) runtime enforcement.
 
-## 2. The reconcile the vote must settle (Q1/Q2 + owner steer)
+## 2. Shipped reconcile (Q1/Q2 + owner steer)
 
 - **Register Q1 default:** defer edit-form-at-node — readonly/editable stay **runtime-inert** this rung; a
   later **T1-4b** builds mid-flow form editing + readonly/editable enforcement.
 - **Register Q2 default:** expose **only `hidden`** in the authoring UI (don't offer readonly/editable while
   they have no runtime effect).
 - **Owner steer (2026-07-02):** start from the **hidden/readonly configurable** authoring surface.
-- **The one vote decision (Q2):** ✏️ **expose hidden + readonly (persisted, readonly runtime-inert with a
-  "takes effect in a later slice" hint)**, OR ✅ **hidden-only UI** (readonly stays persist-able via API but
-  unexposed). Recommend the ✏️ path per the steer — it makes the config authorable now without shipping the
-  heavy runtime — provided the UI clearly marks readonly as not-yet-enforced.
+- **Shipped Q2 decision:** expose hidden + readonly + editable as configurable authoring states. Readonly is
+  persisted but runtime-inert in this slice and remains explicitly deferred to T1-4b.
 
-## 3. Scope (on the ✏️ reconcile)
+## 3. Shipped scope
 
 - **Authoring UI** (linear-steps editor only — Q3; complex-graph `fieldPermissions` stay preserved/read-only):
   per approval node, a per-form-field access selector offering `hidden` + `readonly` (+ implicit default
@@ -58,6 +56,5 @@ readonly, blocks nothing, and round-trips.
 
 ## 6. Status / next step
 
-Vote-ready. On the T1-4 rung voted GO (with the Q2 reconcile decided), build in **Lane B**
-(`ApprovalProductService.ts` authoring/validation + the template-authoring FE), fail-first + real-DB/vue-tsc,
-PR-for-review. Until then, no runtime.
+Build-spec **RATIFIED — SHIPPED** by #3505. The second-batch ballot entry is now a closed decision record.
+T1-4b remains a separate future slice for edit-form-at-node plus readonly/editable runtime enforcement.

--- a/docs/development/w7-cross-base-resultwriteback-design-lock-20260703.md
+++ b/docs/development/w7-cross-base-resultwriteback-design-lock-20260703.md
@@ -1,14 +1,14 @@
-# T3-5 — W7 cross-base resultWriteback · DESIGN-LOCK (PROPOSED) · 2026-07-03
+# T3-5 — W7 cross-base resultWriteback · DESIGN-LOCK (RATIFIED — SHIPPED #3506) · 2026-07-03
 
-> **Status: PROPOSED design-lock — awaiting the T3-5 per-rung votes in
-> `approval-automation-second-batch-ballot-20260702.md`.** Per the owner steer (2026-07-02) T3-5 runs
-> **design-lock-first as its own slice** — its permission/lock/audit surface is heavy, so it is NOT part of
-> the fast demo layer. This doc turns the register's Q1–Q5 + reviewer notes into a buildable contract so the
-> rung is one ratification from implementation. **No runtime is written until the ballot rung is voted GO.**
+> **Status: RATIFIED — SHIPPED by `#3506` (`e80f622e5`).** The T3-5 per-rung votes in
+> `approval-automation-second-batch-ballot-20260702.md` were executed as recorded: literal target triple,
+> trigger-actor cross-base authority, shared cross-base quota, source-record untouched, no merge into the
+> source tail context. Review hardening also landed: a target triple resolving back to the source base fails
+> closed instead of becoming a same-base arbitrary-record write.
 
-## 1. What ships today vs the gap
+## 1. What shipped vs the gap
 
-W7 `resultWriteback` (backend #3384, non-approved extension #3474) writes the approval outcome
+Before #3506, W7 `resultWriteback` (backend #3384, non-approved extension #3474) wrote the approval outcome
 (`statusField` / `approverField` / `completedAtField`, plus `onNonApproved` opt-in) back onto the **source
 record only** — `writeApprovalResultBack` (automation-service.ts) resolves fields against the trigger sheet and
 writes through `ensureRecordNotLocked(event.actor?.id)` with NO cross-base authority check. Record-mutating
@@ -17,10 +17,11 @@ automation actions (`update_record` etc.) already cross bases through the execut
 sheet's real `base_id`, the **effective (trigger) actor** must pass `resolveBaseWritable(actorId, …)`
 (fail-closed on no userId — no fallback to the rule owner), and a per-target-base quota is consumed.
 
-**Gap:** `resultWriteback` cannot target another base. T3-5 extends it to a **literal cross-base target**,
-reusing the same gate — not a new write path.
+**Shipped by #3506:** `resultWriteback` can target another base through a **literal cross-base target**,
+reusing the same gate — not a new write path. The source-base path remains separate, and a same-base target
+triple is rejected rather than silently treated as a cross-base write.
 
-## 2. Locked decisions (register Q1–Q5, defaults adopted unless the ballot overrides)
+## 2. Locked decisions (register Q1–Q5, shipped defaults)
 
 - **Q1 — effective actor:** the **trigger actor** read from `bridge.triggerEvent`, matching the executor
   cross-base gate's ratified "effective actor = trigger actor". Null/system approvals (`event.actor` null) and
@@ -39,7 +40,7 @@ reusing the same gate — not a new write path.
 - **Q5 — quota:** share the **singleton per-target-base cross-base write quota** with update/create/delete/
   lock. A blocked/not-found attempt still consumes a slot (matches existing executor posture).
 
-## 3. Build contract (reviewer-note must-fixes — fold in at implementation)
+## 3. Build contract (reviewer-note must-fixes — shipped)
 
 1. **Anti-misroute:** the same-base source record is **not** mutated when a cross-base target is configured
    (the write goes to the target, not the trigger record). Real-DB test asserts the source row is unchanged.
@@ -67,6 +68,6 @@ reusing the same gate — not a new write path.
 
 ## 5. Status / next step
 
-Design-lock **PROPOSED**. On the owner voting the T3-5 rung GO (ballot), implement on the above contract in
-**Lane C** (`automation-service.ts` — sequential with other automation-runtime work), fail-first + real-DB,
-PR-for-review. Until then, no runtime.
+Design-lock **RATIFIED — SHIPPED** by #3506. The second-batch ballot entry is now a closed decision record.
+Named follow-ups remain separate decisions: dynamic link-field target resolution and an idempotent
+cross-base-backwrite ledger for resume retries.


### PR DESCRIPTION
## Summary
- reconcile the second-batch automation ballot after T1-4 (#3505) and T3-5 (#3506) shipped
- flip the T1-4 build-spec and T3-5 design-lock from vote-ready/proposed to RATIFIED — SHIPPED
- update the parallel plan and goal dev/verification MD so the remaining queue points at the third-batch owner/governance tail, not already-shipped second-batch rungs
- correct the approval-center batch/urge status now that #3496 is merged

## Verification
- `git diff --check`
- stale-status grep for T1-4/T3-5 vote-ready/proposed/unshipped wording across the touched docs
- checked current PR state for #3496 and #3504 with `gh pr view`

Docs-only; no runtime changes.
