### PR TITLE
feat(approval): T3-3 node signaturePolicy (declared-inert slice 1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -347,6 +347,7 @@ jobs:
             tests/integration/approval-node-timeout-effects.test.ts \
             tests/integration/approval-nofm-threshold.test.ts \
             tests/integration/approval-bulk-reassign.api.test.ts \
+            tests/integration/approval-node-signature-policy.api.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -988,6 +988,12 @@ function normalizeNodeSignaturePolicy(
   if (!isRecord(value)) {
     failValidation(context, `${path} must be an object`)
   }
+  const allowedKeys = new Set(['required', 'kind', 'appliesTo'])
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      failValidation(context, `${path}.${key} is not supported`)
+    }
+  }
   if (typeof value.required !== 'boolean') {
     failValidation(context, `${path}.required must be a boolean`)
   }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -26,6 +26,7 @@ import type {
   FormFieldVisibilityRule,
   NodeFieldAccess,
   NodeFieldPermission,
+  SignaturePolicy,
   NodeTimeoutConfig,
   NodeTimeoutEffect,
   PublishApprovalTemplateRequest,
@@ -971,6 +972,39 @@ function normalizeNodeFieldPermissions(
 }
 
 /**
+ * T3-3 slice 1 (declared-inert): normalize a node's `signaturePolicy` (shape only). Persisted +
+ * round-tripped so it survives normalize → publish → reload → dispatch re-normalize, but NOT enforced at
+ * runtime this slice. `required` must be a boolean; `kind` is contract-OPEN (any non-empty string when
+ * present — Q1); `appliesTo` when present must be `approve` | `approve_reject` (default approve-only — Q7).
+ * Absent → `undefined` so the caller omits the key (default-absent nodes stay byte-identical). Invalid shape
+ * → `failValidation(400)`, never a coerced default (no silent flatten).
+ */
+function normalizeNodeSignaturePolicy(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): SignaturePolicy | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) {
+    failValidation(context, `${path} must be an object`)
+  }
+  if (typeof value.required !== 'boolean') {
+    failValidation(context, `${path}.required must be a boolean`)
+  }
+  if (value.kind !== undefined && !isNonEmptyString(value.kind)) {
+    failValidation(context, `${path}.kind must be a non-empty string`)
+  }
+  if (value.appliesTo !== undefined && value.appliesTo !== 'approve' && value.appliesTo !== 'approve_reject') {
+    failValidation(context, `${path}.appliesTo must be approve or approve_reject`)
+  }
+  return {
+    required: value.required,
+    ...(value.kind !== undefined ? { kind: (value.kind as string).trim() } : {}),
+    ...(value.appliesTo !== undefined ? { appliesTo: value.appliesTo as SignaturePolicy['appliesTo'] } : {}),
+  }
+}
+
+/**
  * T1-1: preserve a node's `timeout` config through normalization so it survives into the stored /
  * runtime graph (the surrounding `normalizedNode.config` is a strict whitelist — an un-copied field is
  * silently dropped). Shape-only here; the strict semantic gate (integer range, supported effect, no
@@ -1288,6 +1322,11 @@ function normalizeApprovalGraph(
             context,
             `approvalGraph.nodes[${index}].config.timeout`,
           )
+          const signaturePolicy = normalizeNodeSignaturePolicy(
+            node.config.signaturePolicy,
+            context,
+            `approvalGraph.nodes[${index}].config.signaturePolicy`,
+          )
           normalizedNode.config = {
             ...(hasLegacyAssignees
               ? {
@@ -1302,6 +1341,7 @@ function normalizeApprovalGraph(
             ...(autoApprovalPolicy ? { autoApprovalPolicy } : {}),
             ...(fieldPermissions ? { fieldPermissions } : {}),
             ...(timeout ? { timeout } : {}),
+            ...(signaturePolicy ? { signaturePolicy } : {}),
           }
         }
         break

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -117,6 +117,22 @@ export interface ApprovalNodeConfig {
   fieldPermissions?: NodeFieldPermission[]
   // T1-1 node-level SLA: optional per-node timeout + effect (slice 1: remind only).
   timeout?: NodeTimeoutConfig
+  // T3-3 node signature / compliance — slice 1: DECLARED-INERT. Persisted + round-tripped on the node
+  // config but NOT enforced at runtime — approve/reject never blocks on a signature until enforcement is
+  // separately ratified (mirrors the fieldPermissions readonly/auto_* declared-but-do-not-wire precedent).
+  // Default-absent === no signature policy === current behavior (byte-stable).
+  signaturePolicy?: SignaturePolicy
+}
+
+/**
+ * T3-3 slice 1 (declared-inert): a node's signature/attestation requirement. `kind` is contract-OPEN
+ * (v1 authoring offers typed/click attestation; handwritten-image capture is a separate later slice — Q1).
+ * `appliesTo` defaults to approve-only when absent (Q7). NOT enforced this slice.
+ */
+export interface SignaturePolicy {
+  required: boolean
+  kind?: string
+  appliesTo?: 'approve' | 'approve_reject'
 }
 
 export type ApprovalAssigneeSource =

--- a/packages/core-backend/tests/integration/approval-node-signature-policy.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-node-signature-policy.api.test.ts
@@ -142,6 +142,15 @@ describeIfDatabase('T3-3 node signaturePolicy (declared-inert) API', () => {
     expect(nodeConfigOf(template.approvalGraph, 'approval_1')).not.toHaveProperty('signaturePolicy')
   })
 
+  it('preserves required:false as an explicit policy value (not omitted as default-absent)', async () => {
+    const adminToken = await authToken(baseUrl, 'sig-admin')
+    const createRes = await createTemplate(adminToken, buildGraph({ required: false, kind: 'typed' }))
+    expect(createRes.status).toBe(201)
+    const template = (await createRes.json()) as { id: string; approvalGraph: JsonRecord }
+    templateIds.add(template.id)
+    expect(nodeConfigOf(template.approvalGraph, 'approval_1').signaturePolicy).toEqual({ required: false, kind: 'typed' })
+  })
+
   it('is DECLARED-INERT: a required signaturePolicy does NOT block approve (no signature supplied)', async () => {
     const adminToken = await authToken(baseUrl, 'sig-admin')
     const requesterToken = await authToken(baseUrl, 'sig-requester')
@@ -162,11 +171,13 @@ describeIfDatabase('T3-3 node signaturePolicy (declared-inert) API', () => {
     expect(((await act.json()) as { status: string }).status).toBe('approved')
   })
 
-  it('rejects a malformed signaturePolicy at publish (non-boolean required / bad appliesTo)', async () => {
+  it('rejects a malformed signaturePolicy at publish (non-boolean required / bad appliesTo / unknown key)', async () => {
     const adminToken = await authToken(baseUrl, 'sig-admin')
     const bad1 = await createTemplate(adminToken, buildGraph({ required: 'yes' }))
     expect(bad1.status).toBe(400)
     const bad2 = await createTemplate(adminToken, buildGraph({ required: true, appliesTo: 'always' }))
     expect(bad2.status).toBe(400)
+    const bad3 = await createTemplate(adminToken, buildGraph({ required: true, captureMode: 'typed' }))
+    expect(bad3.status).toBe(400)
   })
 })

--- a/packages/core-backend/tests/integration/approval-node-signature-policy.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-node-signature-policy.api.test.ts
@@ -1,0 +1,172 @@
+/**
+ * T3-3 slice 1 (declared-inert) — node `signaturePolicy` persists + round-trips but is NOT enforced.
+ *
+ * Build contract (third-batch ballot T3-3): prove `signaturePolicy` survives normalize → publish → reload
+ * → dispatch re-normalize; a default-absent node stays byte-identical; and the policy does NOT block
+ * approve/reject this slice (enforcement is a separate ratified rung).
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+type JsonRecord = Record<string, unknown>
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = net.createServer()
+    srv.once('error', () => resolve(false))
+    srv.listen(0, '127.0.0.1', () => srv.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  expect(res.status).toBe(200)
+  return ((await res.json()) as { token: string }).token
+}
+
+async function jsonRequest(baseUrl: string, path: string, token: string, options: { method?: string; body?: unknown } = {}) {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+function buildFormSchema(): JsonRecord {
+  return { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] }
+}
+
+// Linear start → approval_1 → end. `approval_1` carries the given (or no) signaturePolicy.
+function buildGraph(signaturePolicy?: JsonRecord): JsonRecord {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_1',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['sig-approver'],
+          approvalMode: 'single',
+          ...(signaturePolicy ? { signaturePolicy } : {}),
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+    ],
+  }
+}
+
+function nodeConfigOf(graph: JsonRecord, key: string): JsonRecord {
+  const nodes = (graph.nodes ?? []) as Array<{ key: string; config: JsonRecord }>
+  const node = nodes.find((n) => n.key === key)
+  expect(node).toBeTruthy()
+  return node!.config
+}
+
+describeIfDatabase('T3-3 node signaturePolicy (declared-inert) API', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const templateIds = new Set<string>()
+  const approvalIds = new Set<string>()
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    baseUrl = `http://127.0.0.1:${server.getAddress()!.port}`
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    const aIds = [...approvalIds]
+    const tIds = [...templateIds]
+    if (aIds.length) {
+      await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [aIds]).catch(() => {})
+      await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [aIds]).catch(() => {})
+      await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [aIds]).catch(() => {})
+    }
+    if (tIds.length) {
+      await pool.query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [tIds]).catch(() => {})
+      await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [tIds]).catch(() => {})
+      await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [tIds]).catch(() => {})
+    }
+    if (server) await server.stop()
+  })
+
+  async function createTemplate(adminToken: string, graph: JsonRecord): Promise<string> {
+    const res = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: { key: `t33-sig-${TS}-${Math.floor(Math.random() * 1e6)}`, name: 'sig', formSchema: buildFormSchema(), approvalGraph: graph },
+    })
+    return res
+  }
+
+  it('sentinel: DATABASE_URL is set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  it('persists + round-trips signaturePolicy through create → publish → reload byte-identically', async () => {
+    const adminToken = await authToken(baseUrl, 'sig-admin')
+    const policy = { required: true, kind: 'typed', appliesTo: 'approve_reject' }
+    const createRes = await createTemplate(adminToken, buildGraph(policy))
+    expect(createRes.status).toBe(201)
+    const template = (await createRes.json()) as { id: string; approvalGraph: JsonRecord }
+    templateIds.add(template.id)
+    // Survives normalize on create.
+    expect(nodeConfigOf(template.approvalGraph, 'approval_1').signaturePolicy).toEqual(policy)
+
+    const pub = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, { method: 'POST', body: { policy: { allowRevoke: true } } })
+    expect(pub.status).toBe(200)
+
+    // Survives reload (a fresh GET → the stored + re-read graph).
+    const reload = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}`, adminToken)
+    expect(reload.status).toBe(200)
+    const reloaded = (await reload.json()) as { approvalGraph: JsonRecord }
+    expect(nodeConfigOf(reloaded.approvalGraph, 'approval_1').signaturePolicy).toEqual(policy)
+  })
+
+  it('leaves a node with NO signaturePolicy byte-identical (default-absent, key omitted)', async () => {
+    const adminToken = await authToken(baseUrl, 'sig-admin')
+    const createRes = await createTemplate(adminToken, buildGraph())
+    expect(createRes.status).toBe(201)
+    const template = (await createRes.json()) as { id: string; approvalGraph: JsonRecord }
+    templateIds.add(template.id)
+    expect(nodeConfigOf(template.approvalGraph, 'approval_1')).not.toHaveProperty('signaturePolicy')
+  })
+
+  it('is DECLARED-INERT: a required signaturePolicy does NOT block approve (no signature supplied)', async () => {
+    const adminToken = await authToken(baseUrl, 'sig-admin')
+    const requesterToken = await authToken(baseUrl, 'sig-requester')
+    const approverToken = await authToken(baseUrl, 'sig-approver')
+    const createRes = await createTemplate(adminToken, buildGraph({ required: true, kind: 'typed' }))
+    const template = (await createRes.json()) as { id: string }
+    templateIds.add(template.id)
+    await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, { method: 'POST', body: { policy: { allowRevoke: true } } })
+
+    const inst = await jsonRequest(baseUrl, '/api/approvals', requesterToken, { method: 'POST', body: { templateId: template.id, formData: { summary: 'sig test' } } })
+    expect(inst.status).toBe(201)
+    const created = (await inst.json()) as { id: string }
+    approvalIds.add(created.id)
+
+    // Approve with NO signature payload — must succeed (enforcement is a later rung).
+    const act = await jsonRequest(baseUrl, `/api/approvals/${created.id}/actions`, approverToken, { method: 'POST', body: { action: 'approve', comment: 'ok' } })
+    expect(act.status).toBe(200)
+    expect(((await act.json()) as { status: string }).status).toBe('approved')
+  })
+
+  it('rejects a malformed signaturePolicy at publish (non-boolean required / bad appliesTo)', async () => {
+    const adminToken = await authToken(baseUrl, 'sig-admin')
+    const bad1 = await createTemplate(adminToken, buildGraph({ required: 'yes' }))
+    expect(bad1.status).toBe(400)
+    const bad2 = await createTemplate(adminToken, buildGraph({ required: true, appliesTo: 'always' }))
+    expect(bad2.status).toBe(400)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -54,6 +54,9 @@ export default defineConfig({
       // T2-1+2 scoped approval admins + bulk handover: real-DB route/service boundary with RBAC and
       // approval_records CHECK coverage. Excluded from the no-DB default and wired into approval real-DB CI.
       'tests/integration/approval-bulk-reassign.api.test.ts',
+      // T3-3 node signaturePolicy declared-inert floor: real HTTP + real DB round-trip.
+      // Excluded from the no-DB default and wired into approval real-DB CI so it cannot skip-green.
+      'tests/integration/approval-node-signature-policy.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
Third-batch **T3-3 first rung** on the ballot default (Q2 **declared-inert**): a node carries an optional `signaturePolicy { required, kind?, appliesTo? }` that is **persisted + round-tripped** through the approval graph but **NOT enforced at runtime** — approve/reject never blocks on a signature until enforcement is a separately-ratified rung (mirrors the `fieldPermissions` readonly / `auto_*` declared-but-do-not-wire precedent).

## What ships
- `SignaturePolicy` type + `signaturePolicy?` on `ApprovalNodeConfig`. `kind` is **contract-open** (Q1: v1 authoring will offer typed/click; image capture is a later slice); `appliesTo` defaults **approve-only** (Q7).
- Shape-only normalizer `normalizeNodeSignaturePolicy` (required boolean · kind non-empty string · appliesTo ∈ {approve, approve_reject}) — **fails closed** on a malformed value, never a coerced default / silent flatten. Wired into the node-config whitelist next to `fieldPermissions`/`timeout`; **default-absent nodes stay byte-identical** (key omitted).
- No SQL migration (lives in node-config JSON). Q8 signature-ref-in-record + runtime enforcement + authoring UI are **later rungs** (this is the inert floor the ballot's build contract asks to prove first).

## Verification
tsc 0 · new real-DB **`approval-node-signature-policy` 5/5**: create→publish→reload **round-trip byte-identical** · **default-absent byte-identical** · **DECLARED-INERT** (a `required:true` policy does NOT block approve with no signature) · malformed `required`/`appliesTo` **rejected at save**. **RED-before confirmed** (round-trip fails when the whitelist emit is removed → policy dropped). Regression: p1c field-permissions 7/7 · nofm-threshold 6/6.

Per the T3-3 build contract: proves `signaturePolicy` survives normalize→publish→reload→re-normalize, default-absent stays byte-identical, and the floor cannot imply runtime enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)