### PR TITLE
feat(approval): T3-1 v0 mobile approval surface (responsive web, flag-gated default-off)

### DIFF
--- a/apps/web/src/composables/useMobileViewport.ts
+++ b/apps/web/src/composables/useMobileViewport.ts
@@ -1,0 +1,52 @@
+import { onBeforeUnmount, onMounted, readonly, ref } from 'vue'
+
+/**
+ * T3-1 v0 — shared mobile-viewport detection for the approval surface.
+ *
+ * Pure viewport width test (no touch/UA runtime gating): the mobile approval
+ * surface is already opt-in behind the `approvalMobile` feature flag, so the
+ * only remaining question is "is this a narrow viewport?". Keeping it width-only
+ * makes the layout deterministic and testable — a caller composes it with the
+ * flag as `flag && isMobile`.
+ *
+ * `window.matchMedia` is undefined under jsdom / SSR, so every access is
+ * guarded; when it is unavailable the viewport is treated as non-mobile (the
+ * desktop path stays the safe default). The resize listener is registered on
+ * mount and torn down on unmount so no global listener leaks.
+ */
+const DEFAULT_MOBILE_QUERY = '(max-width: 768px)'
+
+function matchesMediaQuery(query: string): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return Boolean(window.matchMedia?.(query)?.matches)
+  } catch {
+    return false
+  }
+}
+
+export function useMobileViewport(query: string = DEFAULT_MOBILE_QUERY) {
+  const isMobile = ref(matchesMediaQuery(query))
+
+  function updateMobileState(): void {
+    isMobile.value = matchesMediaQuery(query)
+  }
+
+  onMounted(() => {
+    updateMobileState()
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', updateMobileState)
+    }
+  })
+
+  onBeforeUnmount(() => {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('resize', updateMobileState)
+    }
+  })
+
+  return {
+    isMobile: readonly(isMobile),
+    updateMobileState,
+  }
+}

--- a/apps/web/src/stores/featureFlags.ts
+++ b/apps/web/src/stores/featureFlags.ts
@@ -10,6 +10,15 @@ export interface ProductFeatures {
   attendanceAdmin: boolean
   attendanceImport: boolean
   plm: boolean
+  /**
+   * T3-1 v0 — mobile approval surface (responsive web) rollout gate (ballot Q11).
+   * Tenant/user-scoped, DEFAULT OFF: the flag is only true when the backend
+   * session payload (or an authorized dev override) explicitly enables it.
+   * There is intentionally NO plugin/admin inference — an admin does not get
+   * the mobile surface for free — so the desktop approval center/detail stay
+   * byte-identical for every tenant that has not opted in.
+   */
+  approvalMobile: boolean
   mode: ProductMode
 }
 
@@ -40,6 +49,7 @@ const DEFAULT_FEATURES: ProductFeatures = {
   attendanceAdmin: false,
   attendanceImport: false,
   plm: false,
+  approvalMobile: false,
   mode: 'platform',
 }
 
@@ -157,6 +167,12 @@ function extractFeaturesFromPayload(payload: any): Partial<ProductFeatures> {
           : typeof featuresNode.plm_workbench === 'boolean'
             ? featuresNode.plm_workbench
             : undefined,
+    approvalMobile:
+      typeof featuresNode.approvalMobile === 'boolean'
+        ? featuresNode.approvalMobile
+        : typeof featuresNode.approval_mobile === 'boolean'
+          ? featuresNode.approval_mobile
+          : undefined,
     mode: normalizeMode(
       featuresNode.mode ??
       featuresNode.productMode ??
@@ -251,12 +267,21 @@ function resolveFeatures(
     mode = 'platform'
   }
 
+  // T3-1 v0 rollout gate: default OFF. Only an explicit backend/override boolean
+  // flips it on — no inference from admin role or product mode. `boolOrDefault`
+  // returns false when neither source supplies a boolean.
+  const approvalMobile = boolOrDefault(
+    override.approvalMobile,
+    backend.approvalMobile,
+  )
+
   return {
     attendance,
     workflow,
     attendanceAdmin,
     attendanceImport,
     plm,
+    approvalMobile,
     mode,
   }
 }

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -90,8 +90,11 @@
         </template>
         <!-- Wave 2 WP3 slice 2 — bulk 全部标记已读. Disabled until the server
              reports at least one unread row for the current filter so clicking
-             never issues a no-op round-trip. -->
-        <div class="approval-center__tab-toolbar">
+             never issues a no-op round-trip.
+             T3-1 v0: batch multi-select is desktop-only — checkbox fan-out over
+             an el-table selection is not a touch gesture, and the mobile action
+             set (ballot Q8) is approve/reject/comment/initiate only. -->
+        <div v-if="!isMobileLayout" class="approval-center__tab-toolbar">
           <!-- 操作台: batch approve/reject over the current selection. Each row still runs the
                authoritative single-instance server transition (frontend fan-out, not a bulk endpoint). -->
           <span
@@ -144,7 +147,15 @@
             待处理考勤审批
           </el-button>
         </div>
+        <ApprovalMobileList
+          v-if="isMobileLayout"
+          :approvals="store.pendingApprovals"
+          :loading="store.loading"
+          :empty-text="searchText ? '未找到匹配的审批' : '暂无待处理审批'"
+          @select="handleRowClick"
+        />
         <el-table
+          v-else
           ref="pendingTableRef"
           v-loading="store.loading"
           :data="store.pendingApprovals"
@@ -199,7 +210,15 @@
       </el-tab-pane>
 
       <el-tab-pane label="我发起的" name="mine">
+        <ApprovalMobileList
+          v-if="isMobileLayout"
+          :approvals="store.myApprovals"
+          :loading="store.loading"
+          :empty-text="searchText ? '未找到匹配的审批' : '暂无我发起的审批'"
+          @select="handleRowClick"
+        />
         <el-table
+          v-else
           v-loading="store.loading"
           :data="store.myApprovals"
           style="width: 100%"
@@ -263,7 +282,15 @@
       </el-tab-pane>
 
       <el-tab-pane label="抄送我的" name="cc">
+        <ApprovalMobileList
+          v-if="isMobileLayout"
+          :approvals="store.ccApprovals"
+          :loading="store.loading"
+          :empty-text="searchText ? '未找到匹配的审批' : '暂无抄送我的审批'"
+          @select="handleRowClick"
+        />
         <el-table
+          v-else
           v-loading="store.loading"
           :data="store.ccApprovals"
           style="width: 100%"
@@ -310,7 +337,15 @@
       </el-tab-pane>
 
       <el-tab-pane label="已完成" name="completed">
+        <ApprovalMobileList
+          v-if="isMobileLayout"
+          :approvals="store.completedApprovals"
+          :loading="store.loading"
+          :empty-text="searchText ? '未找到匹配的审批' : '暂无已完成审批'"
+          @select="handleRowClick"
+        />
         <el-table
+          v-else
           v-loading="store.loading"
           :data="store.completedApprovals"
           style="width: 100%"
@@ -391,7 +426,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { Search } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
@@ -401,10 +436,23 @@ import { useApprovalPermissions } from '../../approvals/permissions'
 import { dispatchAction, getPendingCount, markAllApprovalsRead, remindApproval } from '../../approvals/api'
 import { runApprovalBatchAction } from '../../approvals/useApprovalBatchActions'
 import { useApprovalCountsRealtime, type ApprovalCountsUpdatedPayload } from '../../approvals/useApprovalCountsRealtime'
+import { useFeatureFlags } from '../../stores/featureFlags'
+import { useMobileViewport } from '../../composables/useMobileViewport'
+import ApprovalMobileList from './ApprovalMobileList.vue'
 
 const router = useRouter()
 const store = useApprovalStore()
 const { canWrite } = useApprovalPermissions()
+
+// T3-1 v0 — mobile approval surface (ballot Q10/Q11). The layout switches to the
+// touch-first card list ONLY when the tenant/user has opted in via the
+// `approvalMobile` feature flag AND the viewport is narrow. The flag is loaded
+// once by the app shell (main.ts / App.vue); this view reads it reactively and
+// never triggers a load, so with the flag OFF the desktop table path is
+// unchanged for every viewport.
+const { hasFeature } = useFeatureFlags()
+const { isMobile } = useMobileViewport()
+const isMobileLayout = computed(() => hasFeature('approvalMobile') && isMobile.value)
 
 // ── 操作台: batch approve/reject over the pending selection ────────────────
 const pendingTableRef = ref<{ clearSelection: () => void } | null>(null)
@@ -788,6 +836,42 @@ onMounted(() => {
   .approval-center__attendance-entry {
     align-items: flex-start;
     flex-direction: column;
+  }
+}
+
+/* T3-1 v0 — responsive chrome. The center is only rendered as the touch-first
+   card list when the `approvalMobile` flag is on, but the header/toolbar chrome
+   should reflow on any narrow viewport so the search + filters never overflow
+   horizontally. */
+@media (max-width: 768px) {
+  .approval-center {
+    padding: 16px 12px;
+  }
+
+  .approval-center__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .approval-center__toolbar {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .approval-center__toolbar :deep(.el-input),
+  .approval-center__toolbar :deep(.el-select) {
+    width: 100% !important;
+    margin-left: 0 !important;
+  }
+
+  .approval-center__toolbar :deep(.el-button) {
+    margin-left: 0 !important;
+    width: 100%;
+  }
+
+  .approval-center__pagination {
+    justify-content: center;
   }
 }
 </style>

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -240,8 +240,13 @@
             </el-button>
           </div>
           <div class="approval-detail__actions-secondary">
+            <!-- T3-1 v0 (ballot Q8): the deferred action set —
+                 退回/转交/加签/减签/催办/撤回 — is desktop-only. The mobile
+                 surface exposes approve/reject/comment only, so each deferred
+                 control is additionally gated on `!isMobileLayout`. 评论 stays
+                 visible on both surfaces. -->
             <el-button
-              v-if="canAct && returnableNodes.length > 0"
+              v-if="canAct && !isMobileLayout && returnableNodes.length > 0"
               type="warning"
               :loading="store.loading"
               @click="openReturnDialog"
@@ -249,7 +254,7 @@
               退回
             </el-button>
             <el-button
-              v-if="canAct"
+              v-if="canAct && !isMobileLayout"
               type="warning"
               :loading="store.loading"
               @click="openTransferDialog"
@@ -258,7 +263,7 @@
             </el-button>
             <!-- P1-B 加签: pull additional co-signer(s) into the current node. -->
             <el-button
-              v-if="canAct"
+              v-if="canAct && !isMobileLayout"
               type="primary"
               plain
               :loading="store.loading"
@@ -270,7 +275,7 @@
             <!-- P1-B 减签: remove a previously add-signed co-signer at the
                  current node. Only shown when at least one such row exists. -->
             <el-button
-              v-if="canAct && reducibleAssignees.length > 0"
+              v-if="canAct && !isMobileLayout && reducibleAssignees.length > 0"
               type="primary"
               plain
               :loading="store.loading"
@@ -283,7 +288,7 @@
                  a pending instance; server-side rate-limits to once per hour
                  per user per instance (429 → surfaced as a friendly toast). -->
             <el-button
-              v-if="isRequester"
+              v-if="isRequester && !isMobileLayout"
               type="primary"
               plain
               :loading="remindLoading"
@@ -293,7 +298,7 @@
               <el-icon style="margin-right: 4px"><Bell /></el-icon>催一下
             </el-button>
             <el-popconfirm
-              v-if="isRequester"
+              v-if="isRequester && !isMobileLayout"
               title="确认撤回此审批？"
               confirm-button-text="确认"
               cancel-button-text="取消"
@@ -556,6 +561,8 @@ import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { markApprovalRead, remindApproval } from '../../approvals/api'
+import { useFeatureFlags } from '../../stores/featureFlags'
+import { useMobileViewport } from '../../composables/useMobileViewport'
 import {
   buildDetailRowsForDisplay,
   findDetailFieldInSchema,
@@ -567,6 +574,17 @@ const router = useRouter()
 const store = useApprovalStore()
 const templateStore = useApprovalTemplateStore()
 const { canAct } = useApprovalPermissions()
+
+// T3-1 v0 — mobile approval surface (ballot Q8/Q11). When the tenant/user has
+// opted into `approvalMobile` AND the viewport is narrow, the action bar is
+// restricted to the v0 mobile action set — approve / reject / comment — and the
+// deferred actions (transfer / return / add-sign / reduce-sign / revoke /
+// remind) are hidden. The flag is loaded by the app shell; this view only reads
+// it, so with the flag OFF the desktop action bar is unchanged for every
+// viewport.
+const { hasFeature } = useFeatureFlags()
+const { isMobile } = useMobileViewport()
+const isMobileLayout = computed(() => hasFeature('approvalMobile') && isMobile.value)
 
 const approval = computed(() => store.activeApproval)
 
@@ -853,6 +871,26 @@ function openCommentDialog() {
   commentDialogVisible.value = true
 }
 
+// T3-1 v0 (ballot Q7): the mobile surface reuses the SAME version-less unified
+// `/api/approvals/:id/actions` endpoint as desktop (via `store.executeAction`).
+// Its only concurrency guard is refresh-on-4xx: when the action is rejected with
+// a 4xx (the instance advanced under the approver — a stale action), re-pull the
+// detail + history so the mobile action bar reflects live state instead of a
+// stale one. Scoped to the mobile layout so desktop behavior is unchanged.
+function is4xxConflict(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  const match = /API error:\s*(\d{3})/.exec(message)
+  if (!match) return false
+  const status = Number(match[1])
+  return status >= 400 && status < 500
+}
+
+async function refreshAfterStaleMobileAction(id: string, error: unknown): Promise<void> {
+  if (!isMobileLayout.value) return
+  if (!is4xxConflict(error)) return
+  await Promise.all([store.loadDetail(id), store.loadHistory(id)]).catch(() => undefined)
+}
+
 async function submitAction() {
   const id = route.params.id as string
   try {
@@ -863,8 +901,9 @@ async function submitAction() {
     ElMessage.success(currentAction.value === 'approve' ? '审批已通过' : '审批已驳回')
     actionDialogVisible.value = false
     await store.loadHistory(id)
-  } catch {
+  } catch (error) {
     ElMessage.error('操作失败，请重试')
+    await refreshAfterStaleMobileAction(id, error)
   }
 }
 
@@ -944,8 +983,9 @@ async function submitComment() {
     ElMessage.success('评论已提交')
     commentDialogVisible.value = false
     await store.loadHistory(id)
-  } catch {
+  } catch (error) {
     ElMessage.error('评论提交失败，请重试')
+    await refreshAfterStaleMobileAction(id, error)
   }
 }
 
@@ -1220,9 +1260,20 @@ onMounted(async () => {
   gap: 12px;
 }
 
-/* Responsive: stack on small screens */
+/* Responsive: stack on small screens.
+   T3-1 v0: on the mobile approval surface the action set is restricted to
+   approve/reject/comment (deferred actions hidden), so the remaining controls
+   are laid out as full-width, comfortably tappable rows. */
 @media (max-width: 768px) {
+  .approval-detail {
+    padding: 16px 12px;
+  }
+
   .approval-detail__body {
+    grid-template-columns: 1fr;
+  }
+
+  .approval-detail__meta {
     grid-template-columns: 1fr;
   }
 
@@ -1233,7 +1284,15 @@ onMounted(async () => {
 
   .approval-detail__actions-primary,
   .approval-detail__actions-secondary {
+    flex-direction: column;
+    align-items: stretch;
     justify-content: center;
+  }
+
+  .approval-detail__actions-primary :deep(.el-button),
+  .approval-detail__actions-secondary :deep(.el-button) {
+    width: 100%;
+    margin-left: 0;
   }
 }
 </style>

--- a/apps/web/src/views/approval/ApprovalMobileList.vue
+++ b/apps/web/src/views/approval/ApprovalMobileList.vue
@@ -1,0 +1,183 @@
+<template>
+  <div class="approval-mobile-list" data-testid="approval-mobile-list">
+    <div
+      v-if="loading"
+      class="approval-mobile-list__loading"
+      data-testid="approval-mobile-loading"
+    >
+      加载中…
+    </div>
+    <div
+      v-else-if="approvals.length === 0"
+      class="approval-mobile-list__empty"
+      data-testid="approval-mobile-empty"
+    >
+      {{ emptyText }}
+    </div>
+    <button
+      v-for="row in approvals"
+      v-else
+      :key="row.id"
+      type="button"
+      class="approval-mobile-list__card"
+      data-testid="approval-mobile-card"
+      :data-approval-id="row.id"
+      @click="$emit('select', row)"
+    >
+      <div class="approval-mobile-list__card-top">
+        <span class="approval-mobile-list__title">{{ row.title ?? '审批申请' }}</span>
+        <span
+          class="approval-mobile-list__status"
+          :class="`approval-mobile-list__status--${statusTagType(row.status)}`"
+          :data-status="row.status"
+        >
+          {{ statusLabel(row.status) }}
+        </span>
+      </div>
+      <div class="approval-mobile-list__meta">
+        <span class="approval-mobile-list__request-no">{{ row.requestNo ?? '-' }}</span>
+        <span class="approval-mobile-list__requester">{{ row.requester?.name ?? '-' }}</span>
+      </div>
+      <div class="approval-mobile-list__date">{{ formatDate(row.createdAt) }}</div>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { UnifiedApprovalDTO } from '../../types/approval'
+
+// T3-1 v0 — dedicated touch-first list card (ballot Q10). Replaces the desktop
+// `el-table` (fixed column widths + horizontal scroll + tiny row-click targets)
+// with full-width tappable cards. Kept free of Element Plus so it stays touch
+// sized and trivially mountable in tests. Labels reuse the module's existing
+// Chinese status/format vocabulary verbatim — no new user-facing copy.
+withDefaults(
+  defineProps<{
+    approvals: UnifiedApprovalDTO[]
+    loading?: boolean
+    emptyText?: string
+  }>(),
+  {
+    loading: false,
+    emptyText: '暂无审批',
+  },
+)
+
+defineEmits<{
+  (event: 'select', row: UnifiedApprovalDTO): void
+}>()
+
+function statusTagType(status: string): string {
+  const map: Record<string, string> = {
+    pending: 'warning',
+    approved: 'success',
+    rejected: 'danger',
+    revoked: 'info',
+    cancelled: 'info',
+  }
+  return map[status] ?? 'info'
+}
+
+function statusLabel(status: string): string {
+  const map: Record<string, string> = {
+    pending: '待处理',
+    approved: '已通过',
+    rejected: '已驳回',
+    revoked: '已撤回',
+    cancelled: '已取消',
+  }
+  return map[status] ?? status
+}
+
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '-'
+  return new Date(dateStr).toLocaleString('zh-CN')
+}
+</script>
+
+<style scoped>
+.approval-mobile-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.approval-mobile-list__loading,
+.approval-mobile-list__empty {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--el-text-color-secondary, #909399);
+  font-size: 14px;
+}
+
+.approval-mobile-list__card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  background: #fff;
+  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border-radius: 10px;
+  padding: 14px 16px;
+  cursor: pointer;
+  /* Touch target floor — comfortably above the 44px accessibility minimum. */
+  min-height: 72px;
+}
+
+.approval-mobile-list__card:active {
+  background: var(--el-fill-color-light, #f5f7fa);
+}
+
+.approval-mobile-list__card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.approval-mobile-list__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--el-text-color-primary, #303133);
+  line-height: 1.4;
+}
+
+.approval-mobile-list__status {
+  flex-shrink: 0;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--el-fill-color-light, #f5f7fa);
+  color: var(--el-text-color-secondary, #909399);
+}
+
+.approval-mobile-list__status--warning {
+  background: #fdf6ec;
+  color: #e6a23c;
+}
+
+.approval-mobile-list__status--success {
+  background: #f0f9eb;
+  color: #67c23a;
+}
+
+.approval-mobile-list__status--danger {
+  background: #fef0f0;
+  color: #f56c6c;
+}
+
+.approval-mobile-list__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--el-text-color-regular, #606266);
+}
+
+.approval-mobile-list__date {
+  font-size: 12px;
+  color: var(--el-text-color-secondary, #909399);
+}
+</style>

--- a/apps/web/tests/approvalMobileDetailActions.spec.ts
+++ b/apps/web/tests/approvalMobileDetailActions.spec.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+
+// ---------------------------------------------------------------------------
+// T3-1 v0 — mobile approval DETAIL action-set restriction + concurrency (Q7/Q8).
+//
+//   - flag ON + narrow → action bar shows approve/reject/comment ONLY; the
+//     deferred set (transfer/return/add-sign/reduce-sign/revoke/remind) is
+//     hidden; approve dispatches via the SAME unified /actions endpoint (the
+//     mocked store.executeAction); a 4xx failure triggers refresh-on-4xx.
+//   - flag OFF → the full desktop action bar is unchanged.
+//
+// The store is mocked so no action touches the api mock-mode fixtures.
+// ---------------------------------------------------------------------------
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: pushSpy, back: vi.fn() }),
+    useRoute: () => ({ params: { id: 'apv_1' }, query: {}, path: '/approvals/apv_1', meta: {} }),
+  }
+})
+
+const mockApprovalMobileFlag = ref(false)
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({
+    hasFeature: (feature: string) =>
+      feature === 'approvalMobile' ? mockApprovalMobileFlag.value : false,
+  }),
+}))
+
+// The approver can act (canAct = true) so approve/reject are enabled.
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({ canAct: { value: true } }),
+}))
+
+vi.mock('../src/approvals/api', () => ({
+  markApprovalRead: vi.fn().mockResolvedValue({ ok: true }),
+  remindApproval: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+}))
+
+vi.mock('../src/approvals/templateStore', () => ({
+  useApprovalTemplateStore: () => ({
+    activeTemplate: null,
+    loadTemplate: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+const mockActiveApproval = ref<any>(null)
+const mockHistory = ref<any[]>([])
+const mockLoading = ref(false)
+const executeActionSpy = vi.fn()
+const loadDetailSpy = vi.fn().mockResolvedValue(undefined)
+const loadHistorySpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../src/approvals/store', () => ({
+  useApprovalStore: () => ({
+    get activeApproval() { return mockActiveApproval.value },
+    get history() { return mockHistory.value },
+    get loading() { return mockLoading.value },
+    get error() { return null },
+    set error(_v: unknown) { /* noop */ },
+    loadDetail: loadDetailSpy,
+    loadHistory: loadHistorySpy,
+    executeAction: executeActionSpy,
+  }),
+}))
+
+function stub(name: string, tag = 'div', extraProps: Record<string, unknown> = {}) {
+  return defineComponent({
+    name,
+    props: { modelValue: {}, type: String, label: String, title: String, ...extraProps },
+    emits: ['update:modelValue', 'click', 'confirm', 'change'],
+    render() {
+      return h(tag, { 'data-stub': name }, this.$slots.default?.())
+    },
+  })
+}
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, loading: Boolean, disabled: Boolean, text: Boolean, plain: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      'data-el-button': this.type || 'default',
+      onClick: (e: Event) => this.$emit('click', e),
+    }, this.$slots.default?.())
+  },
+})
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String },
+  render() {
+    // Respect `v-model` like the real dialog: a CLOSED dialog renders nothing,
+    // so a hidden dialog's confirm button (e.g. "确认转交") never leaks into the
+    // action-set assertions.
+    if (!this.modelValue) return null
+    return h('div', { 'data-el-dialog': this.title }, [this.$slots.default?.(), this.$slots.footer?.()])
+  },
+})
+// el-table-column's `#default="{ row }"` needs a { row } context the real table
+// supplies; render an inert placeholder instead of invoking the scoped slot.
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String },
+  render() { return h('div', { 'data-column': this.prop || this.label }) },
+})
+const ElPopconfirm = defineComponent({
+  name: 'ElPopconfirm',
+  props: { title: String },
+  render() { return h('div', { 'data-el-popconfirm': this.title }, this.$slots.reference?.()) },
+})
+
+const stubDirective = { mounted() {}, updated() {} }
+
+function setViewport(mobile: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: mobile && query.includes('max-width'),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}
+
+async function flushUi(cycles = 5): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function pendingInstance(): any {
+  return {
+    id: 'apv_1',
+    title: '出差报销',
+    status: 'pending',
+    requester: { id: 'user_99', name: '张三' },
+    requestNo: 'AP-100001',
+    currentStep: 1,
+    totalSteps: 2,
+    currentNodeKey: 'approval_1',
+    formSnapshot: { fld_reason: '出差报销' },
+    assignments: [
+      { id: 'a1', type: 'user', assigneeId: 'user_add', sourceStep: 1, nodeKey: 'approval_1', isActive: true, metadata: { addSign: true } },
+    ],
+  }
+}
+
+function buttonTexts(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('button')).map((b) => b.textContent?.trim() ?? '')
+}
+
+describe('ApprovalDetailView — T3-1 mobile action-set restriction', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    mockApprovalMobileFlag.value = false
+    mockActiveApproval.value = pendingInstance()
+    mockHistory.value = []
+    mockLoading.value = false
+    executeActionSpy.mockReset()
+    executeActionSpy.mockResolvedValue({})
+    loadDetailSpy.mockClear()
+    loadHistorySpy.mockClear()
+    pushSpy.mockClear()
+    setViewport(false)
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalDetailView } = await import('../src/views/approval/ApprovalDetailView.vue')
+    const Host = defineComponent({ setup() { return () => h(ApprovalDetailView as any) } })
+    app = createApp(Host)
+    // Broad Element Plus stubs; the action buttons are the assertion surface.
+    for (const name of ['ElTag', 'ElAlert', 'ElDivider', 'ElEmpty', 'ElTable', 'ElTimeline', 'ElTimelineItem', 'ElForm', 'ElFormItem', 'ElInput', 'ElSelect', 'ElOption', 'ElRadioGroup', 'ElRadio', 'ElIcon']) {
+      app.component(name, stub(name))
+    }
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElButton', ElButton)
+    app.component('ElDialog', ElDialog)
+    app.component('ElPopconfirm', ElPopconfirm)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  it('flag OFF → desktop action bar keeps the full deferred action set', async () => {
+    mockApprovalMobileFlag.value = false
+    setViewport(true) // narrow viewport alone must NOT restrict when flag is off
+    await mountView()
+
+    const texts = buttonTexts(container!).join('|')
+    expect(texts).toContain('通过')
+    expect(texts).toContain('驳回')
+    expect(texts).toContain('评论')
+    // Deferred set present on desktop:
+    expect(texts).toContain('转交')
+    expect(container!.querySelector('[data-testid="approval-add-sign-button"]')).toBeTruthy()
+    expect(container!.querySelector('[data-testid="approval-reduce-sign-button"]')).toBeTruthy()
+  })
+
+  it('flag ON + narrow → exposes approve/reject/comment ONLY, hides the deferred set', async () => {
+    mockApprovalMobileFlag.value = true
+    setViewport(true)
+    await mountView()
+
+    const texts = buttonTexts(container!).join('|')
+    // v0 mobile action set:
+    expect(texts).toContain('通过')
+    expect(texts).toContain('驳回')
+    expect(texts).toContain('评论')
+    // Deferred set hidden:
+    expect(texts).not.toContain('转交')
+    expect(texts).not.toContain('撤回')
+    expect(container!.querySelector('[data-testid="approval-add-sign-button"]')).toBeNull()
+    expect(container!.querySelector('[data-testid="approval-reduce-sign-button"]')).toBeNull()
+    expect(container!.querySelector('[data-testid="approval-remind-button"]')).toBeNull()
+  })
+
+  it('flag ON + narrow → approve dispatches via the unified /actions endpoint (store.executeAction)', async () => {
+    mockApprovalMobileFlag.value = true
+    setViewport(true)
+    await mountView()
+
+    const approveBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('通过'))
+    expect(approveBtn).toBeTruthy()
+    approveBtn!.click()
+    await flushUi()
+
+    // Dialog confirm ("确认") submits the action.
+    const confirmBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.trim() === '确认')
+    expect(confirmBtn).toBeTruthy()
+    confirmBtn!.click()
+    await flushUi()
+
+    expect(executeActionSpy).toHaveBeenCalledWith('apv_1', expect.objectContaining({ action: 'approve' }))
+  })
+
+  it('flag ON + narrow → a 4xx conflict re-pulls detail + history (refresh-on-4xx)', async () => {
+    mockApprovalMobileFlag.value = true
+    setViewport(true)
+    executeActionSpy.mockRejectedValueOnce(new Error('API error: 409 Conflict'))
+    await mountView()
+    loadDetailSpy.mockClear()
+    loadHistorySpy.mockClear()
+
+    const approveBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('通过'))
+    approveBtn!.click()
+    await flushUi()
+    const confirmBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.trim() === '确认')
+    confirmBtn!.click()
+    await flushUi()
+
+    expect(executeActionSpy).toHaveBeenCalled()
+    expect(loadDetailSpy).toHaveBeenCalledWith('apv_1')
+    expect(loadHistorySpy).toHaveBeenCalledWith('apv_1')
+  })
+})

--- a/apps/web/tests/approvalMobileResponsive.spec.ts
+++ b/apps/web/tests/approvalMobileResponsive.spec.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+
+// ---------------------------------------------------------------------------
+// T3-1 v0 — mobile approval CENTER responsive adaptation (ballot Q10/Q11).
+//
+// Proves the full rollout-gate matrix:
+//   - flag OFF (any viewport)        → desktop el-table, NO mobile card list
+//   - flag ON  + narrow viewport     → dedicated ApprovalMobileList card list,
+//                                       batch toolbar hidden, tap → detail route
+//   - flag ON  + wide viewport       → desktop el-table (enabling the tenant
+//                                       gate must not force mobile chrome onto
+//                                       desktop users)
+//
+// The store is mocked (list data never touches the api mock-mode fixtures), and
+// the `approvalMobile` flag is controlled by mocking the featureFlags module —
+// the view only READS the flag, so no loader runs in the test.
+// ---------------------------------------------------------------------------
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: pushSpy, back: vi.fn() }),
+    useRoute: () => ({ params: {}, query: {}, path: '/approvals', meta: {} }),
+  }
+})
+
+// Feature-flag gate — a module-level ref toggled per test.
+const mockApprovalMobileFlag = ref(false)
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({
+    hasFeature: (feature: string) =>
+      feature === 'approvalMobile' ? mockApprovalMobileFlag.value : false,
+  }),
+}))
+
+// Keep the on-mount badge/realtime side-effects off the real wire.
+vi.mock('../src/approvals/api', () => ({
+  dispatchAction: vi.fn().mockResolvedValue({}),
+  getPendingCount: vi.fn().mockResolvedValue({ count: 0, unreadCount: 0 }),
+  markAllApprovalsRead: vi.fn().mockResolvedValue({ markedCount: 0 }),
+  remindApproval: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+}))
+vi.mock('../src/approvals/useApprovalCountsRealtime', () => ({
+  useApprovalCountsRealtime: () => undefined,
+}))
+
+const mockPendingApprovals = ref<any[]>([])
+const mockMyApprovals = ref<any[]>([])
+const mockCcApprovals = ref<any[]>([])
+const mockCompletedApprovals = ref<any[]>([])
+const mockLoading = ref(false)
+const loadPendingSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../src/approvals/store', () => ({
+  useApprovalStore: () => ({
+    get approvals() { return [] },
+    get pendingApprovals() { return mockPendingApprovals.value },
+    get myApprovals() { return mockMyApprovals.value },
+    get ccApprovals() { return mockCcApprovals.value },
+    get completedApprovals() { return mockCompletedApprovals.value },
+    get activeApproval() { return null },
+    get history() { return [] },
+    get loading() { return mockLoading.value },
+    get error() { return null },
+    get totalPending() { return mockPendingApprovals.value.length },
+    get totalMine() { return mockMyApprovals.value.length },
+    get totalCc() { return mockCcApprovals.value.length },
+    get totalCompleted() { return mockCompletedApprovals.value.length },
+    get pendingCount() { return mockPendingApprovals.value.length },
+    approvalById: () => undefined,
+    loadPending: loadPendingSpy,
+    loadMine: vi.fn(),
+    loadCc: vi.fn(),
+    loadCompleted: vi.fn(),
+    loadDetail: vi.fn(),
+    loadHistory: vi.fn(),
+    submitApproval: vi.fn(),
+    executeAction: vi.fn(),
+  }),
+}))
+
+// Element Plus stubs — the mobile card list is a real child (no Element Plus),
+// so it renders for real when the mobile path is active.
+function stub(name: string, tag = 'div', extraProps: Record<string, unknown> = {}) {
+  return defineComponent({
+    name,
+    props: { modelValue: {}, type: String, label: String, name: String, ...extraProps },
+    emits: ['update:modelValue', 'tab-change', 'row-click', 'change', 'clear', 'click'],
+    render() {
+      return h(tag, { 'data-stub': name }, [this.$slots.label?.(), this.$slots.default?.()])
+    },
+  })
+}
+
+const ElTabs = stub('ElTabs')
+const ElTabPane = defineComponent({
+  name: 'ElTabPane',
+  props: { label: String, name: String },
+  render() {
+    return h('div', { 'data-tab-pane': this.name, 'data-tab-label': this.label }, [
+      this.$slots.label?.(),
+      this.$slots.default?.(),
+    ])
+  },
+})
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: Array },
+  render() {
+    return h('div', { 'data-el-table': 'true' }, this.$slots.default?.())
+  },
+})
+// Do NOT invoke scoped slots — el-table-column's `#default="{ row }"` expects a
+// { row } context that only the real el-table supplies.
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number], minWidth: [String, Number] },
+  render() {
+    return h('div', { 'data-column': this.prop || this.label })
+  },
+})
+const ElTag = stub('ElTag', 'span')
+const ElInput = defineComponent({ name: 'ElInput', render() { return h('input', { 'data-el-input': 'true' }) } })
+const ElSelect = defineComponent({ name: 'ElSelect', render() { return h('select', { 'data-el-select': 'true' }, this.$slots.default?.()) } })
+const ElOption = stub('ElOption', 'option')
+const ElPagination = defineComponent({ name: 'ElPagination', render() { return h('div', { 'data-el-pagination': 'true' }) } })
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, loading: Boolean, disabled: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      'data-el-button': this.type || 'default',
+      onClick: (e: Event) => this.$emit('click', e),
+    }, this.$slots.default?.())
+  },
+})
+const ElAlert = stub('ElAlert')
+const ElEmpty = defineComponent({ name: 'ElEmpty', props: { description: String }, render() { return h('div', { 'data-el-empty': 'true' }, this.description) } })
+const ElDialog = stub('ElDialog')
+const ElBadge = stub('ElBadge', 'span')
+const ElTooltip = stub('ElTooltip')
+const ElIcon = stub('ElIcon', 'i')
+
+const stubDirective = { mounted() {}, updated() {} }
+
+function setViewport(mobile: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: mobile && query.includes('max-width'),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function pendingRow(id: string, title: string): any {
+  return {
+    id,
+    requestNo: `AP-${id}`,
+    title,
+    status: 'pending',
+    requester: { name: '张三' },
+    createdAt: '2026-04-10T08:00:00Z',
+    assignments: [],
+  }
+}
+
+describe('ApprovalCenterView — T3-1 mobile responsive gate', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    mockApprovalMobileFlag.value = false
+    mockPendingApprovals.value = []
+    mockMyApprovals.value = []
+    mockCcApprovals.value = []
+    mockCompletedApprovals.value = []
+    mockLoading.value = false
+    loadPendingSpy.mockClear()
+    pushSpy.mockClear()
+    setViewport(false)
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalCenterView } = await import('../src/views/approval/ApprovalCenterView.vue')
+    const Host = defineComponent({ setup() { return () => h(ApprovalCenterView as any) } })
+    app = createApp(Host)
+    app.component('ElTabs', ElTabs)
+    app.component('ElTabPane', ElTabPane)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElInput', ElInput)
+    app.component('ElSelect', ElSelect)
+    app.component('ElOption', ElOption)
+    app.component('ElPagination', ElPagination)
+    app.component('ElButton', ElButton)
+    app.component('ElAlert', ElAlert)
+    app.component('ElEmpty', ElEmpty)
+    app.component('ElDialog', ElDialog)
+    app.component('ElBadge', ElBadge)
+    app.component('ElTooltip', ElTooltip)
+    app.component('ElIcon', ElIcon)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  it('flag OFF + narrow viewport → keeps the desktop table, no mobile list', async () => {
+    mockApprovalMobileFlag.value = false
+    setViewport(true)
+    mockPendingApprovals.value = [pendingRow('1', '出差报销')]
+    await mountView()
+
+    expect(container!.querySelector('[data-testid="approval-mobile-list"]')).toBeNull()
+    expect(container!.querySelector('[data-el-table]')).toBeTruthy()
+  })
+
+  it('flag ON + narrow viewport → renders the mobile card list, hides the desktop table + batch toolbar', async () => {
+    mockApprovalMobileFlag.value = true
+    setViewport(true)
+    mockPendingApprovals.value = [pendingRow('1', '出差报销'), pendingRow('2', '采购申请')]
+    await mountView()
+
+    const list = container!.querySelector('[data-testid="approval-mobile-list"]')
+    expect(list).toBeTruthy()
+    const cards = container!.querySelectorAll('[data-testid="approval-mobile-card"]')
+    expect(cards.length).toBe(2)
+    expect(cards[0].textContent).toContain('出差报销')
+    expect(cards[0].textContent).toContain('待处理')
+
+    // Desktop widgets are gone on the mobile surface.
+    expect(container!.querySelector('[data-el-table]')).toBeNull()
+    expect(container!.querySelector('[data-testid="approval-batch-approve"]')).toBeNull()
+  })
+
+  it('flag ON + WIDE viewport → stays on the desktop table (gate does not force mobile chrome)', async () => {
+    mockApprovalMobileFlag.value = true
+    setViewport(false)
+    mockPendingApprovals.value = [pendingRow('1', '出差报销')]
+    await mountView()
+
+    expect(container!.querySelector('[data-testid="approval-mobile-list"]')).toBeNull()
+    expect(container!.querySelector('[data-el-table]')).toBeTruthy()
+  })
+
+  it('flag ON + narrow → tapping a card routes to the approval detail', async () => {
+    mockApprovalMobileFlag.value = true
+    setViewport(true)
+    mockPendingApprovals.value = [pendingRow('42', '报销单')]
+    await mountView()
+
+    const card = container!.querySelector<HTMLButtonElement>('[data-testid="approval-mobile-card"]')
+    expect(card).toBeTruthy()
+    card!.click()
+    await flushUi()
+
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-detail', params: { id: '42' } })
+  })
+})

--- a/apps/web/tests/featureFlagsApprovalMobile.spec.ts
+++ b/apps/web/tests/featureFlagsApprovalMobile.spec.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// T3-1 v0 rollout gate (ballot Q11) — locks the REAL featureFlags store logic
+// (DEFAULT_FEATURES + boolOrDefault + no-inference), which the mounted view
+// specs deliberately mock out. Proves `approvalMobile` is default OFF and only
+// an explicit backend flag or authorized dev override flips it on.
+// ---------------------------------------------------------------------------
+
+function meResponse(features: Record<string, unknown>) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ data: { user: { role: 'user', features } } }),
+  }
+}
+
+describe('featureFlags — approvalMobile rollout gate (T3-1)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  it('defaults approvalMobile OFF when the backend does not enable it (no admin/mode inference)', async () => {
+    localStorage.setItem('auth_token', 'session-token')
+    // attendance + workflow booleans present → no /api/plugins inference fetch.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/api/auth/me')) {
+        return meResponse({ attendance: true, workflow: false, mode: 'platform' })
+      }
+      throw new Error(`Unexpected fetch URL: ${String(input)}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { useFeatureFlags } = await import('../src/stores/featureFlags')
+    const flags = useFeatureFlags()
+    const features = await flags.loadProductFeatures(true)
+
+    expect(features.approvalMobile).toBe(false)
+    expect(flags.hasFeature('approvalMobile')).toBe(false)
+  })
+
+  it('honors an explicit backend enable (snake_case alias)', async () => {
+    localStorage.setItem('auth_token', 'session-token')
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/api/auth/me')) {
+        return meResponse({ attendance: true, workflow: false, approval_mobile: true, mode: 'platform' })
+      }
+      throw new Error(`Unexpected fetch URL: ${String(input)}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { useFeatureFlags } = await import('../src/stores/featureFlags')
+    const flags = useFeatureFlags()
+    const features = await flags.loadProductFeatures(true)
+
+    expect(features.approvalMobile).toBe(true)
+    expect(flags.hasFeature('approvalMobile')).toBe(true)
+  })
+
+  it('honors an authorized dev override even when the backend omits the flag', async () => {
+    vi.stubEnv('VITE_ALLOW_FEATURE_OVERRIDE', 'true')
+    localStorage.setItem('auth_token', 'session-token')
+    localStorage.setItem('metasheet_features', JSON.stringify({ approvalMobile: true }))
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/api/auth/me')) {
+        return meResponse({ attendance: true, workflow: false, mode: 'platform' })
+      }
+      throw new Error(`Unexpected fetch URL: ${String(input)}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { useFeatureFlags } = await import('../src/stores/featureFlags')
+    const flags = useFeatureFlags()
+    const features = await flags.loadProductFeatures(true)
+
+    expect(features.approvalMobile).toBe(true)
+  })
+})


### PR DESCRIPTION
Implements T3-1 **v0** per its ballot: **responsive web, flag-gated, default OFF** — no native, no PWA, no out-of-app push (push waits for a Notification Hub that doesn't exist; explicitly out of scope). Backend untouched.

## What ships
- **Flag gate (Q11):** `approvalMobile` added to `ProductFeatures`, `DEFAULT_FEATURES.approvalMobile = false`, resolved with **no admin/plugin/mode inference** — false unless the backend session payload or an authorized dev override explicitly enables it. **Flag OFF ⇒ desktop path byte-identical for every viewport** (views read `hasFeature` reactively; layout switches only when `hasFeature('approvalMobile') && isMobile`).
- **Responsive (Q10):** a dedicated touch-first `ApprovalMobileList.vue` (no Element Plus; ≥72px targets) replaces the `el-table` across all 4 center tabs; detail action bar reflows to stacked full-width. `/m/*` route tree deferred (adapted in place, as the ballot prefers).
- **Action set (Q8):** mobile exposes **approve / reject / comment + initiate entry** only; transfer/return/add-sign/reduce-sign/revoke/remind hidden on mobile. **Concurrency (Q7):** reuses the same version-less `/api/approvals/:id/actions` + **refresh-on-4xx** (scoped to mobile). Offline (Q6): read-only cached list, no queued mutations.

## Verification
`vue-tsc -b` 0 · **11 new specs** (center gate matrix: off / on+narrow / on+wide / tap-routing · detail: action-set restriction / unified-endpoint dispatch / refresh-on-4xx / desktop-full-set · store: default-off / backend-enable / dev-override). **RED-before demonstrated** (revert views → the 4 flag-ON tests fail, desktop/OFF stay green; store default-off was `undefined` pre-change). Existing `approval-center*` + detail/e2e/field-visibility/inbox-guard + feature-shape consumers all green.

## Reviewer decisions / deferred (honest)
- **i18n tension:** the approval module has **no i18n infra** (100% hardcoded 中文, no `useLocale`). I matched the module's convention + reused its status/date helpers; genuinely new strings are `加载中…` / `暂无审批` / `审批申请`. Retrofitting half-i18n into one module would be worse — flagging for your call.
- **Q9 initiate form** (`ApprovalNewView` + pickers) is **not** mobile-adapted yet (the entry is present) — a separate slice.
- Pre-existing FE failures (`featureFlags.spec` / `multitable-workbench-1672-1673`) are **not mine** (verified against origin/main with my change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)