### PR TITLE
feat(approval): T3-6 approvals-as-multitable-records projection runtime (implements design-lock)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260703130000_create_approval_record_projection.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260703130000_create_approval_record_projection.ts
@@ -1,0 +1,39 @@
+/**
+ * Migration: `approval_record_projection` — T3-6 approval read-model side mapping table.
+ *
+ * T3-6 materializes each approval instance as ONE row in a system-managed multitable sheet so
+ * 飞书-grade reporting / dashboards / views / formulas come for free over the existing multitable
+ * analytics. This side table is the instance↔record link (design-lock §4): keyed on the approval
+ * instance id, it maps to the provisioned base/sheet/record and carries the monotonic
+ * `projected_version` used to make the projection idempotent under at-least-once event redelivery
+ * (a re-projection whose source version is not newer is a no-op — never a duplicate row).
+ *
+ * We deliberately do NOT add a column to every `meta_records` row (design-lock §4, Q5) — the mapping
+ * lives here, off the hot record table. `last_projected_at` / `last_error` make a best-effort lost
+ * write observable so the §6b reconcile sweep can self-heal it. No FK to `meta_sheets`/`meta_records`:
+ * a dropped projected record (simulating a lost write) must leave the mapping healable by reconcile,
+ * not cascade-deleted out from under it.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS approval_record_projection (
+      instance_id text PRIMARY KEY,
+      base_id text NOT NULL,
+      sheet_id text NOT NULL,
+      record_id text NOT NULL,
+      projected_version integer NOT NULL,
+      last_projected_at timestamptz NOT NULL DEFAULT now(),
+      last_error text
+    )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_record_projection_sheet
+    ON approval_record_projection (sheet_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS approval_record_projection`.execute(db)
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2062,6 +2062,29 @@ export class MetaSheetServer {
       this.logger.error('AutomationService initialization failed; continuing in degraded mode', e as Error)
     }
 
+    // T3-6: approval read-model projection. Subscribe the terminal projection trigger to the approval
+    // completion bus (the create-hook path lives inside ApprovalProductService.createApproval), then
+    // start the leader-gated §6b reconcile sweep that self-heals any best-effort lost write.
+    try {
+      const { getApprovalRecordProjectionService } = await import(
+        './multitable/approval-record-projection-service'
+      )
+      const {
+        startApprovalProjectionSweepScheduler,
+        resolveApprovalProjectionSweepLeaderOptions,
+        resolveApprovalProjectionSweepIntervalMs,
+      } = await import('./services/ApprovalProjectionSweepScheduler')
+      getApprovalRecordProjectionService().subscribe(eventBus)
+      const projectionSweepLeaderOptions = await resolveApprovalProjectionSweepLeaderOptions()
+      startApprovalProjectionSweepScheduler({
+        leaderOptions: projectionSweepLeaderOptions,
+        intervalMs: resolveApprovalProjectionSweepIntervalMs(),
+      })
+      this.logger.info('Approval record projection initialized')
+    } catch (e) {
+      this.logger.error('Approval record projection initialization failed; continuing in degraded mode', e as Error)
+    }
+
     // Bind external data-source manager to DB and load persisted sources (A0)
     try {
       const { db: kyselyDbDataSources } = await import('./db/db')

--- a/packages/core-backend/src/multitable/approval-record-projection-service.ts
+++ b/packages/core-backend/src/multitable/approval-record-projection-service.ts
@@ -1,0 +1,443 @@
+/**
+ * T3-6 — Approval data as first-class multitable records (read-model projection).
+ *
+ * Design-lock: docs/development/t3-6-approvals-as-multitable-records-design-lock-20260703.md
+ *
+ * The approval engine stays the system of record. This service materializes each approval instance
+ * as ONE row in a system-managed multitable sheet so 飞书-grade reporting / dashboards / views /
+ * formulas come for free over the existing multitable analytics — a one-way projection, never a
+ * write-back (editing the projected record never mutates the approval).
+ *
+ * Load-bearing invariants (all enforced by `reconcile`, the single materialization core shared by the
+ * create hook, the terminal completion-event subscription, the leader-gated sweep, and the on-demand
+ * reconcile):
+ *
+ *  §6a EVENT-SILENT — the projected write is a direct SQL materialization on `meta_records`. It does
+ *  NOT go through the automation event bus, so it emits NO `record.created`/`record.updated` and can
+ *  never fire a `record.*` automation rule on the system sheet (no projection→automation loop). This
+ *  is why we do not reuse `RecordService.createRecord` (which emits): the strongest event-silence
+ *  guarantee is a path that never touches `eventBus`.
+ *
+ *  §4 IDEMPOTENT — every path re-reads the AUTHORITATIVE state from `approval_instances` (+
+ *  `approval_records`) and upserts guarded by `projected_version` = `approval_instances.version`
+ *  (monotonic; `transition.toVersion === instance.version` post-transition). A redelivered create/
+ *  terminal event whose source version is not strictly newer is a no-op — never a duplicate row.
+ *
+ *  §6b DETERMINISTIC RECONCILE / never-clobber — a per-instance advisory lock serializes concurrent
+ *  reconciles (the auto-approve create-hook↔completion-event race, and sweep↔live-terminal). Under the
+ *  lock we re-check the stored version and write BOTH `meta_records` and the mapping row only when the
+ *  source is strictly newer; a stale reconcile writes NEITHER table (so it cannot clobber a live
+ *  terminal record body while the mapping refuses the version downgrade). `projected_version` /
+ *  `last_projected_at` / `last_error` make a lost write observable and healable on the next sweep.
+ *
+ *  BEST-EFFORT — a projection failure never fails the parent approval flow (the create hook and the
+ *  event subscription both swallow errors; only the observability columns record them).
+ *
+ *  §5 SYSTEM SHEET — one system-owned base + one sheet per template family, provisioned lazily and
+ *  idempotently (ON CONFLICT) on first projection, with a fixed system-authored §3 column set. The
+ *  base carries a reserved system owner and no per-sheet share is minted, so it is governed by the
+ *  standard multitable capability gate (per-row visibility_scope inheritance is a separate slice).
+ */
+
+import type { PoolClient } from 'pg'
+
+import { Logger } from '../core/logger'
+import { pool } from '../db/pg'
+import type { EventBus } from '../integration/events/event-bus'
+import type { ApprovalCompletionEventV1 } from '../services/ApprovalCompletionEvent'
+
+const logger = new Logger('ApprovalRecordProjection')
+
+/** The system-owned base that holds every per-template-family projection sheet (§5). */
+export const APPROVAL_PROJECTION_BASE_ID = 'base_apr_projection'
+/** Reserved owner/actor for the system-managed base + record rows (not a real user). */
+export const APPROVAL_PROJECTION_SYSTEM_OWNER = 'system:approval-projection'
+
+/** Terminal approval outcomes projected to the neutral read-model (Q9). */
+const TERMINAL_STATUSES = new Set(['approved', 'rejected', 'revoked', 'cancelled'])
+
+/** Approval-record actions that represent a decider (so `approverId` excludes the auto-approve create row). */
+const DECISION_ACTIONS = ['approve', 'reject', 'revoke', 'sign']
+
+/** Completion event types this service subscribes to for the terminal projection trigger. */
+export const APPROVAL_COMPLETION_EVENT_TYPES = [
+  'approval.approved',
+  'approval.rejected',
+  'approval.revoked',
+  'approval.cancelled',
+] as const
+
+/**
+ * The §3 allowlist — value-constrained system columns only, NEVER `form_snapshot` (a separate
+ * PII-redaction review gates any form projection). Order is the sheet's field order.
+ */
+interface ProjectionColumn {
+  key: string
+  name: string
+  type: 'text' | 'dateTime'
+}
+
+const PROJECTION_COLUMNS: readonly ProjectionColumn[] = [
+  { key: 'requestNo', name: 'Request No', type: 'text' },
+  { key: 'templateId', name: 'Template Id', type: 'text' },
+  { key: 'templateName', name: 'Template Name', type: 'text' },
+  { key: 'status', name: 'Status', type: 'text' },
+  { key: 'outcome', name: 'Outcome', type: 'text' },
+  { key: 'requesterId', name: 'Requester Id', type: 'text' },
+  { key: 'approverId', name: 'Approver Id', type: 'text' },
+  { key: 'createdAt', name: 'Created At', type: 'dateTime' },
+  { key: 'completedAt', name: 'Completed At', type: 'dateTime' },
+  { key: 'currentNodeKey', name: 'Current Node Key', type: 'text' },
+]
+
+export function deriveProjectionSheetId(templateId: string): string {
+  return `sht_apr_proj_${templateId}`
+}
+
+export function deriveProjectionFieldId(sheetId: string, columnKey: string): string {
+  return `${sheetId}__${columnKey}`
+}
+
+export function deriveProjectionRecordId(instanceId: string): string {
+  return `rec_apr_${instanceId}`
+}
+
+export type ProjectionOutcome =
+  | { status: 'projected'; version: number }
+  | { status: 'noop'; version: number; storedVersion: number }
+  | { status: 'absent' }
+  | { status: 'skipped'; reason: 'no-pool' | 'no-template' }
+
+interface AuthoritativeInstance {
+  id: string
+  status: string
+  version: number
+  requestNo: string | null
+  templateId: string | null
+  templateName: string | null
+  requesterId: string | null
+  currentNodeKey: string | null
+  createdAt: Date | null
+  updatedAt: Date | null
+}
+
+interface TerminalDecision {
+  approverId: string | null
+  completedAt: Date | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function toNullableString(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim().length > 0 ? value : null
+  return null
+}
+
+function toNullableDate(value: unknown): Date | null {
+  if (value instanceof Date) return value
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = new Date(value)
+    return Number.isFinite(parsed.getTime()) ? parsed : null
+  }
+  return null
+}
+
+function toIsoOrEmpty(value: Date | null): string {
+  return value ? value.toISOString() : ''
+}
+
+/**
+ * The projection service. All state lives in Postgres, so a fresh instance behaves identically to the
+ * shared singleton (integration tests can construct their own against the same pool).
+ */
+export class ApprovalRecordProjectionService {
+  private readonly subscriptionIds: string[] = []
+
+  /** Subscribe the terminal projection trigger to the completion bus (best-effort per event). */
+  subscribe(eventBus: EventBus): void {
+    for (const eventType of APPROVAL_COMPLETION_EVENT_TYPES) {
+      const id = eventBus.subscribe<ApprovalCompletionEventV1>(eventType, (payload) => {
+        const instanceId = payload?.approval?.instanceId
+        if (typeof instanceId !== 'string' || instanceId.length === 0) return
+        this.reconcile(instanceId).catch((error) => {
+          logger.warn(
+            `terminal projection for ${instanceId} failed: ${error instanceof Error ? error.message : String(error)}`,
+          )
+        })
+      })
+      this.subscriptionIds.push(id)
+    }
+    logger.info('ApprovalRecordProjectionService subscribed to approval completion bus')
+  }
+
+  unsubscribe(eventBus: EventBus): void {
+    for (const id of this.subscriptionIds.splice(0)) eventBus.unsubscribe(id)
+  }
+
+  /**
+   * Reconcile ONE instance: re-derive the §3 columns from authoritative state and idempotently upsert
+   * the projected record + mapping row, guarded by `projected_version`. The single core shared by the
+   * create hook, the completion-event subscription, the sweep, and the on-demand path.
+   */
+  async reconcile(instanceId: string): Promise<ProjectionOutcome> {
+    if (!pool) return { status: 'skipped', reason: 'no-pool' }
+
+    const instance = await this.loadAuthoritativeInstance(instanceId)
+    if (!instance) return { status: 'absent' }
+    if (!instance.templateId) return { status: 'skipped', reason: 'no-template' }
+
+    const terminal = TERMINAL_STATUSES.has(instance.status)
+    const decision = terminal ? await this.loadTerminalDecision(instanceId, instance.status) : null
+    const sheetId = deriveProjectionSheetId(instance.templateId)
+    const recordId = deriveProjectionRecordId(instanceId)
+    const data = this.buildRecordData(sheetId, instance, terminal, decision)
+
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      // Serialize every reconcile for THIS instance (auto-approve create-hook↔event, sweep↔terminal).
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`approval-projection:${instanceId}`])
+
+      const existing = await client.query<{ projected_version: number }>(
+        'SELECT projected_version FROM approval_record_projection WHERE instance_id = $1',
+        [instanceId],
+      )
+      const storedVersion = existing.rows[0]?.projected_version
+      if (storedVersion !== undefined && instance.version <= storedVersion) {
+        // Stale/redelivered — never clobber a newer live projection (§6b). Write NEITHER table.
+        await client.query('COMMIT')
+        return { status: 'noop', version: instance.version, storedVersion }
+      }
+
+      // Provision base→sheet→fields (idempotent) BEFORE the record upsert so the meta_records→meta_sheets
+      // FK is satisfied even for a concurrent first-projection of a brand-new template family.
+      await this.ensureSystemBase(client)
+      await this.ensureFamilySheet(client, sheetId, instance.templateId, instance.templateName)
+
+      await client.query(
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
+         VALUES ($1, $2, $3::jsonb, 1, $4, $4)
+         ON CONFLICT (id) DO UPDATE
+           SET data = EXCLUDED.data,
+               version = meta_records.version + 1,
+               modified_by = EXCLUDED.modified_by,
+               updated_at = now()`,
+        [recordId, sheetId, JSON.stringify(data), APPROVAL_PROJECTION_SYSTEM_OWNER],
+      )
+
+      await client.query(
+        `INSERT INTO approval_record_projection
+           (instance_id, base_id, sheet_id, record_id, projected_version, last_projected_at, last_error)
+         VALUES ($1, $2, $3, $4, $5, now(), NULL)
+         ON CONFLICT (instance_id) DO UPDATE
+           SET base_id = EXCLUDED.base_id,
+               sheet_id = EXCLUDED.sheet_id,
+               record_id = EXCLUDED.record_id,
+               projected_version = EXCLUDED.projected_version,
+               last_projected_at = now(),
+               last_error = NULL`,
+        [instanceId, APPROVAL_PROJECTION_BASE_ID, sheetId, recordId, instance.version],
+      )
+
+      await client.query('COMMIT')
+      return { status: 'projected', version: instance.version }
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined)
+      await this.recordLastError(instanceId, error)
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  /** On-demand: reconcile every instance of a template family (best-effort per instance). */
+  async reconcileTemplateFamily(templateId: string): Promise<{ scanned: number; reconciled: number }> {
+    if (!pool) return { scanned: 0, reconciled: 0 }
+    const rows = await pool.query<{ id: string }>(
+      'SELECT id FROM approval_instances WHERE template_id = $1 ORDER BY updated_at ASC',
+      [templateId],
+    )
+    return this.reconcileEach(rows.rows.map((row) => row.id))
+  }
+
+  /**
+   * Leader-gated sweep: find instances whose authoritative version is ahead of their projection (or
+   * that have no mapping row at all — a lost create write) and reconcile them. Bounded by `limit`.
+   */
+  async sweep(options: { limit?: number } = {}): Promise<{ scanned: number; reconciled: number }> {
+    if (!pool) return { scanned: 0, reconciled: 0 }
+    const limit = Math.max(1, Math.min(options.limit ?? 200, 1000))
+    const rows = await pool.query<{ id: string }>(
+      `SELECT i.id
+         FROM approval_instances i
+         LEFT JOIN approval_record_projection pr ON pr.instance_id = i.id
+        WHERE i.template_id IS NOT NULL
+          AND (pr.instance_id IS NULL OR i.version > pr.projected_version)
+        ORDER BY i.updated_at ASC
+        LIMIT $1`,
+      [limit],
+    )
+    return this.reconcileEach(rows.rows.map((row) => row.id))
+  }
+
+  private async reconcileEach(instanceIds: string[]): Promise<{ scanned: number; reconciled: number }> {
+    let reconciled = 0
+    for (const instanceId of instanceIds) {
+      try {
+        const outcome = await this.reconcile(instanceId)
+        if (outcome.status === 'projected') reconciled += 1
+      } catch (error) {
+        logger.warn(
+          `sweep/reconcile for ${instanceId} failed: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
+    }
+    return { scanned: instanceIds.length, reconciled }
+  }
+
+  private async loadAuthoritativeInstance(instanceId: string): Promise<AuthoritativeInstance | null> {
+    if (!pool) return null
+    const result = await pool.query<Record<string, unknown>>(
+      `SELECT i.id, i.status, i.version, i.request_no, i.template_id, i.current_node_key,
+              i.requester_snapshot, i.created_at, i.updated_at, t.name AS template_name
+         FROM approval_instances i
+         LEFT JOIN approval_templates t ON t.id = i.template_id
+        WHERE i.id = $1`,
+      [instanceId],
+    )
+    const row = result.rows[0]
+    if (!row) return null
+    const requesterSnapshot = isRecord(row.requester_snapshot) ? row.requester_snapshot : {}
+    return {
+      id: String(row.id),
+      status: String(row.status),
+      version: Number(row.version ?? 0),
+      requestNo: toNullableString(row.request_no),
+      templateId: toNullableString(row.template_id),
+      templateName: toNullableString(row.template_name),
+      requesterId: toNullableString(requesterSnapshot.id),
+      currentNodeKey: toNullableString(row.current_node_key),
+      createdAt: toNullableDate(row.created_at),
+      updatedAt: toNullableDate(row.updated_at),
+    }
+  }
+
+  /**
+   * The approver + completion time of a TERMINAL instance: the most recent decider record matching the
+   * terminal status. The auto-approve-at-create row is action `created` (not a decision), so it is
+   * excluded — `approverId` stays null for auto-approve, matching the completion event's `actor: null`.
+   */
+  private async loadTerminalDecision(instanceId: string, terminalStatus: string): Promise<TerminalDecision> {
+    if (!pool) return { approverId: null, completedAt: null }
+    const result = await pool.query<Record<string, unknown>>(
+      `SELECT actor_id, occurred_at
+         FROM approval_records
+        WHERE instance_id = $1
+          AND action = ANY($2::text[])
+          AND to_status = $3
+        ORDER BY occurred_at DESC, id DESC
+        LIMIT 1`,
+      [instanceId, DECISION_ACTIONS, terminalStatus],
+    )
+    const row = result.rows[0]
+    if (!row) return { approverId: null, completedAt: null }
+    return {
+      approverId: toNullableString(row.actor_id),
+      completedAt: toNullableDate(row.occurred_at),
+    }
+  }
+
+  private buildRecordData(
+    sheetId: string,
+    instance: AuthoritativeInstance,
+    terminal: boolean,
+    decision: TerminalDecision | null,
+  ): Record<string, string> {
+    const values: Record<string, string> = {
+      requestNo: instance.requestNo ?? '',
+      templateId: instance.templateId ?? '',
+      templateName: instance.templateName ?? '',
+      status: instance.status,
+      outcome: terminal ? instance.status : '',
+      requesterId: instance.requesterId ?? '',
+      approverId: terminal ? (decision?.approverId ?? '') : '',
+      createdAt: toIsoOrEmpty(instance.createdAt),
+      completedAt: terminal ? toIsoOrEmpty(decision?.completedAt ?? instance.updatedAt) : '',
+      currentNodeKey: instance.currentNodeKey ?? '',
+    }
+    const data: Record<string, string> = {}
+    for (const column of PROJECTION_COLUMNS) {
+      data[deriveProjectionFieldId(sheetId, column.key)] = values[column.key] ?? ''
+    }
+    return data
+  }
+
+  private async ensureSystemBase(client: PoolClient): Promise<void> {
+    await client.query(
+      `INSERT INTO meta_bases (id, name, icon, color, owner_id, workspace_id)
+       VALUES ($1, $2, 'table', '#5b8def', $3, NULL)
+       ON CONFLICT (id) DO NOTHING`,
+      [APPROVAL_PROJECTION_BASE_ID, 'Approval Records (system)', APPROVAL_PROJECTION_SYSTEM_OWNER],
+    )
+  }
+
+  private async ensureFamilySheet(
+    client: PoolClient,
+    sheetId: string,
+    templateId: string,
+    templateName: string | null,
+  ): Promise<void> {
+    await client.query(
+      `INSERT INTO meta_sheets (id, base_id, name, description)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        sheetId,
+        APPROVAL_PROJECTION_BASE_ID,
+        `Approval · ${templateName ?? templateId}`,
+        'System-managed approval read-model projection (T3-6)',
+      ],
+    )
+    for (let order = 0; order < PROJECTION_COLUMNS.length; order += 1) {
+      const column = PROJECTION_COLUMNS[order]
+      await client.query(
+        `INSERT INTO meta_fields (id, sheet_id, name, type, property, "order")
+         VALUES ($1, $2, $3, $4, '{}'::jsonb, $5)
+         ON CONFLICT (id) DO NOTHING`,
+        [deriveProjectionFieldId(sheetId, column.key), sheetId, column.name, column.type, order],
+      )
+    }
+  }
+
+  /** Best-effort observability: stamp the failure onto the mapping row when one already exists. */
+  private async recordLastError(instanceId: string, error: unknown): Promise<void> {
+    if (!pool) return
+    const message = (error instanceof Error ? error.message : String(error)).slice(0, 500)
+    try {
+      await pool.query(
+        `UPDATE approval_record_projection
+            SET last_error = $2, last_projected_at = now()
+          WHERE instance_id = $1`,
+        [instanceId, message],
+      )
+    } catch {
+      // Observability is best-effort — never mask the original failure.
+    }
+  }
+}
+
+let sharedProjectionService: ApprovalRecordProjectionService | null = null
+
+export function getApprovalRecordProjectionService(): ApprovalRecordProjectionService {
+  if (!sharedProjectionService) sharedProjectionService = new ApprovalRecordProjectionService()
+  return sharedProjectionService
+}
+
+/** Test seam — override or clear the shared singleton. */
+export function setApprovalRecordProjectionServiceForTests(
+  service: ApprovalRecordProjectionService | null,
+): void {
+  sharedProjectionService = service
+}

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -73,6 +73,7 @@ import {
   type ApprovalCompletionEventV1,
   type ApprovalCompletionTransitionSnapshot,
 } from './ApprovalCompletionEvent'
+import { getApprovalRecordProjectionService } from '../multitable/approval-record-projection-service'
 import { Logger } from '../core/logger'
 import { eventBus } from '../integration/events/event-bus'
 
@@ -3546,6 +3547,14 @@ export class ApprovalProductService {
         })
       }
     })
+    // T3-6 create hook (design-lock §2): project the pending (or auto-approve terminal) row NOW.
+    // Completion events only fire on TERMINAL, so a create-only pending instance would never project
+    // without this explicit hook — this DOES add an approval-side create coupling (named, not hidden).
+    // Awaited + best-effort: a projection failure NEVER fails the approval flow, and awaiting BEFORE
+    // the emit makes auto-approve-at-create deterministic — the create hook writes the ONE terminal row
+    // and the subsequent completion-event reconcile is a version-guarded no-op (not a second row).
+    await this.projectApprovalOnCreate(instanceId)
+
     if (completionEvent) {
       emitApprovalCompletionEvent(completionEvent)
     }
@@ -3555,6 +3564,19 @@ export class ApprovalProductService {
       throw new ServiceError('Approval not found after creation', 500, 'APPROVAL_CREATE_FAILED')
     }
     return approval
+  }
+
+  /** T3-6: best-effort read-model projection at create — never throws into the approval flow. */
+  private async projectApprovalOnCreate(instanceId: string): Promise<void> {
+    try {
+      await getApprovalRecordProjectionService().reconcile(instanceId)
+    } catch (error) {
+      approvalProductLogger.warn(
+        `approval record projection (create hook) failed for ${instanceId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
+    }
   }
 
   async adminJump(

--- a/packages/core-backend/src/services/ApprovalProjectionSweepScheduler.ts
+++ b/packages/core-backend/src/services/ApprovalProjectionSweepScheduler.ts
@@ -1,0 +1,297 @@
+/**
+ * T3-6 approval read-model projection sweep scheduler (design-lock §6b).
+ *
+ * Runs a periodic tick that calls the projection service `sweep()` — a bounded scan for instances
+ * whose authoritative `approval_instances.version` is ahead of their projection (or that have no
+ * mapping row at all, i.e. a lost create write) — and reconciles them idempotently. This is the
+ * self-heal that keeps the read-model consistent after a best-effort projection failure.
+ *
+ * Mirrors LedgerRetentionScheduler exactly: a single-process interval with a one-run guard;
+ * multi-instance fleets opt into a Redis leader lock via ENABLE_APPROVAL_PROJECTION_SWEEP_LEADER_LOCK.
+ * The sweep is idempotent + convergent (a later tick reconciles whatever a missed/duplicate tick
+ * left, and the per-instance advisory lock + projected_version guard make it clobber-safe), so the
+ * leader lock is a LOAD optimisation only, never load-bearing for correctness.
+ *
+ * Enabled by default; disable with APPROVAL_PROJECTION_SWEEP_DISABLED=1. Interval defaults to 5min
+ * (APPROVAL_PROJECTION_SWEEP_INTERVAL_MS), clamped to a 30s floor.
+ */
+
+import { randomBytes } from 'crypto'
+import { Logger } from '../core/logger'
+import { getRedisClient } from '../db/redis'
+import { RedisLeaderLock, type RedisLeaderLockClient } from '../multitable/redis-leader-lock'
+import {
+  ApprovalRecordProjectionService,
+  getApprovalRecordProjectionService,
+} from '../multitable/approval-record-projection-service'
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000
+const MIN_INTERVAL_MS = 30_000
+const DEFAULT_LOCK_TTL_MS = 30_000
+const DEFAULT_SWEEP_LIMIT = 200
+
+export interface ApprovalProjectionSweepSchedulerLeaderOptions {
+  leaderLock: RedisLeaderLock
+  lockKey?: string
+  ownerId: string
+  ttlMs?: number
+  renewIntervalMs?: number
+  retryIntervalMs?: number
+}
+
+export interface ApprovalProjectionSweepSchedulerLeaderGauge {
+  labels(labels: { state: 'leader' | 'follower' | 'relinquished' }): { set(value: number): void }
+}
+
+export interface ApprovalProjectionSweepSchedulerRuntimeOptions {
+  leaderStateGauge?: ApprovalProjectionSweepSchedulerLeaderGauge
+}
+
+export interface ApprovalProjectionSweepSchedulerOptions {
+  service?: ApprovalRecordProjectionService
+  intervalMs?: number
+  sweepLimit?: number
+  leaderOptions?: ApprovalProjectionSweepSchedulerLeaderOptions | null
+  runtime?: ApprovalProjectionSweepSchedulerRuntimeOptions
+  logger?: Logger
+}
+
+export class ApprovalProjectionSweepScheduler {
+  private readonly logger: Logger
+  private readonly service: ApprovalRecordProjectionService
+  private readonly intervalMs: number
+  private readonly sweepLimit: number
+  private readonly leaderOptions: ApprovalProjectionSweepSchedulerLeaderOptions | null
+  private readonly lockKey: string
+  private readonly ttlMs: number
+  private readonly renewIntervalMs: number
+  private readonly retryIntervalMs: number
+  private readonly leaderStateGauge: ApprovalProjectionSweepSchedulerLeaderGauge | null
+  private timer: NodeJS.Timeout | null = null
+  private renewalTimer: NodeJS.Timeout | null = null
+  private acquisitionTimer: NodeJS.Timeout | null = null
+  private running = false
+  private started = false
+  private isLeader = false
+  public readonly ready: Promise<void>
+
+  constructor(options: ApprovalProjectionSweepSchedulerOptions = {}) {
+    this.service = options.service ?? getApprovalRecordProjectionService()
+    this.intervalMs = Math.max(MIN_INTERVAL_MS, options.intervalMs ?? DEFAULT_INTERVAL_MS)
+    this.sweepLimit = Math.max(1, options.sweepLimit ?? DEFAULT_SWEEP_LIMIT)
+    this.leaderOptions = options.leaderOptions ?? null
+    this.lockKey = this.leaderOptions?.lockKey ?? 'approval-projection-sweep:leader'
+    this.ttlMs = this.leaderOptions?.ttlMs ?? DEFAULT_LOCK_TTL_MS
+    this.renewIntervalMs = this.leaderOptions?.renewIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
+    this.retryIntervalMs = this.leaderOptions?.retryIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
+    this.leaderStateGauge = options.runtime?.leaderStateGauge ?? null
+    this.logger = options.logger ?? new Logger('ApprovalProjectionSweepScheduler')
+    if (this.leaderOptions) {
+      this.setLeaderGauge('follower')
+      this.ready = this.attemptLeadership().catch((error) => {
+        this.isLeader = false
+        this.setLeaderGauge('follower')
+        this.logger.warn(`Approval projection sweep leader-lock acquisition failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    } else {
+      this.isLeader = true
+      this.setLeaderGauge('leader')
+      this.ready = Promise.resolve()
+    }
+  }
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+    this.ready.then(() => {
+      if (!this.started) return
+      if (this.isLeader) {
+        this.startTickLoop()
+      } else {
+        this.startAcquisitionRetryLoop()
+      }
+    }).catch((error) => {
+      this.logger.warn(`Approval projection sweep scheduler start skipped after leader-lock error: ${error instanceof Error ? error.message : String(error)}`)
+    })
+  }
+
+  stop(): void {
+    this.started = false
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer)
+      this.renewalTimer = null
+    }
+    if (this.acquisitionTimer) {
+      clearInterval(this.acquisitionTimer)
+      this.acquisitionTimer = null
+    }
+    if (this.leaderOptions && this.isLeader) {
+      const { leaderLock, ownerId } = this.leaderOptions
+      leaderLock.release(this.lockKey, ownerId).catch(() => {})
+      this.isLeader = false
+    }
+    this.setLeaderGauge('relinquished')
+    this.logger.info('Approval projection sweep scheduler stopped')
+  }
+
+  /** Run one sweep pass. Returns rows reconciled. The one-run guard prevents overlapping passes. */
+  async tick(): Promise<number> {
+    if (!this.isLeader) return 0
+    if (this.running) return 0
+    this.running = true
+    try {
+      const { scanned, reconciled } = await this.service.sweep({ limit: this.sweepLimit })
+      if (reconciled > 0) {
+        this.logger.info(`Approval projection sweep reconciled ${reconciled}/${scanned} drifted instance(s)`)
+      }
+      return reconciled
+    } catch (error) {
+      this.logger.error(`Approval projection sweep tick failed: ${error instanceof Error ? error.message : String(error)}`)
+      return 0
+    } finally {
+      this.running = false
+    }
+  }
+
+  get leader(): boolean {
+    return this.isLeader
+  }
+
+  private async attemptLeadership(): Promise<void> {
+    if (!this.leaderOptions) return
+    const { leaderLock, ownerId } = this.leaderOptions
+    const won = await leaderLock.acquire(this.lockKey, ownerId, this.ttlMs)
+    this.isLeader = won
+    if (won) {
+      this.logger.info(`Acquired approval projection sweep leader lock ${this.lockKey} (owner=${ownerId}, ttl=${this.ttlMs}ms)`)
+      this.setLeaderGauge('leader')
+      this.stopAcquisitionRetryLoop()
+      this.startRenewalLoop()
+      if (this.started) this.startTickLoop()
+    } else {
+      this.logger.info(`Did not acquire approval projection sweep leader lock ${this.lockKey}; operating as non-leader (owner=${ownerId})`)
+      this.setLeaderGauge('follower')
+    }
+  }
+
+  private setLeaderGauge(state: 'leader' | 'follower' | 'relinquished'): void {
+    if (!this.leaderStateGauge) return
+    try {
+      for (const candidate of ['leader', 'follower', 'relinquished'] as const) {
+        this.leaderStateGauge.labels({ state: candidate }).set(candidate === state ? 1 : 0)
+      }
+    } catch {
+      // Metrics failures must not break the scheduler.
+    }
+  }
+
+  private startTickLoop(): void {
+    if (!this.started || !this.isLeader || this.timer) return
+    this.logger.info(`Approval projection sweep scheduler starting with interval ${this.intervalMs}ms`)
+    this.timer = setInterval(() => { void this.tick() }, this.intervalMs)
+    if (typeof this.timer.unref === 'function') this.timer.unref()
+  }
+
+  private startAcquisitionRetryLoop(): void {
+    if (!this.leaderOptions || this.acquisitionTimer || this.isLeader) return
+    this.acquisitionTimer = setInterval(() => {
+      this.attemptLeadership().catch((error) => {
+        this.isLeader = false
+        this.setLeaderGauge('follower')
+        this.logger.warn(`Approval projection sweep leader-lock retry failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    }, this.retryIntervalMs)
+    if (typeof this.acquisitionTimer.unref === 'function') this.acquisitionTimer.unref()
+  }
+
+  private stopAcquisitionRetryLoop(): void {
+    if (!this.acquisitionTimer) return
+    clearInterval(this.acquisitionTimer)
+    this.acquisitionTimer = null
+  }
+
+  private startRenewalLoop(): void {
+    if (!this.leaderOptions) return
+    if (this.renewalTimer) clearInterval(this.renewalTimer)
+    const { leaderLock, ownerId } = this.leaderOptions
+    this.renewalTimer = setInterval(() => {
+      leaderLock.renew(this.lockKey, ownerId, this.ttlMs).then(
+        (ok) => {
+          if (!ok) this.relinquishLeadership('renewal rejected')
+        },
+        (error) => {
+          this.logger.warn(`Approval projection sweep leader renewal error for ${this.lockKey}: ${error instanceof Error ? error.message : String(error)}`)
+          this.relinquishLeadership('renewal error')
+        },
+      )
+    }, this.renewIntervalMs)
+    if (typeof this.renewalTimer.unref === 'function') this.renewalTimer.unref()
+  }
+
+  private relinquishLeadership(reason: string): void {
+    if (!this.isLeader) return
+    this.logger.warn(`Relinquishing approval projection sweep leadership (${reason})`)
+    this.isLeader = false
+    this.setLeaderGauge('relinquished')
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer)
+      this.renewalTimer = null
+    }
+    if (this.started) this.startAcquisitionRetryLoop()
+  }
+}
+
+let sharedScheduler: ApprovalProjectionSweepScheduler | null = null
+
+/** Enabled by default; opt OUT with APPROVAL_PROJECTION_SWEEP_DISABLED=1. Returns null when disabled/started. */
+export function startApprovalProjectionSweepScheduler(
+  options: ApprovalProjectionSweepSchedulerOptions = {},
+): ApprovalProjectionSweepScheduler | null {
+  if (process.env.APPROVAL_PROJECTION_SWEEP_DISABLED === '1') return null
+  if (sharedScheduler) return sharedScheduler
+  sharedScheduler = new ApprovalProjectionSweepScheduler(options)
+  sharedScheduler.start()
+  return sharedScheduler
+}
+
+export function getSharedApprovalProjectionSweepScheduler(): ApprovalProjectionSweepScheduler | null {
+  return sharedScheduler
+}
+
+export function stopApprovalProjectionSweepScheduler(): void {
+  if (sharedScheduler) {
+    sharedScheduler.stop()
+    sharedScheduler = null
+  }
+}
+
+export function resolveApprovalProjectionSweepIntervalMs(): number | undefined {
+  const raw = Number(process.env.APPROVAL_PROJECTION_SWEEP_INTERVAL_MS)
+  return Number.isFinite(raw) && raw > 0 ? raw : undefined
+}
+
+export async function resolveApprovalProjectionSweepLeaderOptions(): Promise<ApprovalProjectionSweepSchedulerLeaderOptions | null> {
+  if (process.env.ENABLE_APPROVAL_PROJECTION_SWEEP_LEADER_LOCK !== 'true') return null
+  const redis = await getRedisClient()
+  if (!redis) return null
+  const ttlMs = Number(process.env.APPROVAL_PROJECTION_SWEEP_LEADER_LOCK_TTL_MS) > 0
+    ? Number(process.env.APPROVAL_PROJECTION_SWEEP_LEADER_LOCK_TTL_MS)
+    : DEFAULT_LOCK_TTL_MS
+  const retryIntervalMs = Number(process.env.APPROVAL_PROJECTION_SWEEP_LEADER_LOCK_RETRY_MS) > 0
+    ? Number(process.env.APPROVAL_PROJECTION_SWEEP_LEADER_LOCK_RETRY_MS)
+    : undefined
+  return {
+    leaderLock: new RedisLeaderLock({ client: redis as unknown as RedisLeaderLockClient }),
+    ownerId: `approval-projection-sweep:${process.pid}:${randomBytes(4).toString('hex')}`,
+    ttlMs,
+    retryIntervalMs,
+  }
+}

--- a/packages/core-backend/tests/integration/approval-record-projection.test.ts
+++ b/packages/core-backend/tests/integration/approval-record-projection.test.ts
@@ -1,0 +1,503 @@
+/**
+ * T3-6 — Approval data as first-class multitable records (read-model projection) · real-DB integration.
+ *
+ * Design-lock: docs/development/t3-6-approvals-as-multitable-records-design-lock-20260703.md (§7 plan).
+ *
+ * Real chain over real Postgres + the real in-process eventBus:
+ *   ApprovalProductService.createApproval → awaited create hook → ApprovalRecordProjectionService.reconcile
+ *     (direct SQL, EVENT-SILENT materialization on meta_records + the approval_record_projection mapping);
+ *   ApprovalProductService.dispatchAction(approve/reject/revoke) → emitApprovalCompletionEvent
+ *     → projection subscription → reconcile (SAME row, version-guarded, idempotent).
+ *
+ * Covers §7: create→pending row · each terminal outcome→same row (no 2nd) · auto-approve→one row ·
+ * redelivery idempotent · §6a event-silence (no record.* automation fires) · §6b reconcile+sweep after a
+ * dropped/stale row · no write-back · visibility (admin/owner-scoped) · best-effort (failure never fails
+ * the approval flow).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { withAutomationEventId } from '../../src/multitable/automation-event-dedup'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { resolveSheetCapabilitiesForUser } from '../../src/multitable/sheet-capabilities'
+import {
+  ApprovalRecordProjectionService,
+  APPROVAL_PROJECTION_BASE_ID,
+  deriveProjectionFieldId,
+  deriveProjectionRecordId,
+  deriveProjectionSheetId,
+  getApprovalRecordProjectionService,
+  setApprovalRecordProjectionServiceForTests,
+} from '../../src/multitable/approval-record-projection-service'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const REQUESTER = `u_prj_req_${TS}`
+const APPROVER = `u_prj_appr_${TS}`
+const ADMIN = `u_prj_admin_${TS}`
+const NONADMIN = `u_prj_none_${TS}`
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+const queryFn = ((sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)) as never
+
+let approvals: ApprovalProductService
+let projection: ApprovalRecordProjectionService
+let automation: AutomationService | undefined
+let normalTemplateId = ''
+let autoTemplateId = ''
+const ruleIds: string[] = []
+const notifications: Array<{ message: string; sheetId: string }> = []
+const recordEventSheetIds: string[] = []
+
+function normalTemplateRequest() {
+  return {
+    key: `prj-normal-${TS}`,
+    name: 'Projection Normal Template',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'Approver',
+          config: { assigneeType: 'user', assigneeIds: [APPROVER], approvalMode: 'single' },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-a', source: 'start', target: 'approval_1' },
+        { key: 'e-a-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+function autoTemplateRequest() {
+  return {
+    key: `prj-auto-${TS}`,
+    name: 'Projection Auto-Approve Template',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_empty',
+          type: 'approval',
+          name: 'Auto',
+          config: { assigneeType: 'user', assigneeIds: [], approvalMode: 'single', emptyAssigneePolicy: 'auto-approve' },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-a', source: 'start', target: 'approval_empty' },
+        { key: 'e-a-end', source: 'approval_empty', target: 'end' },
+      ],
+    },
+  }
+}
+
+const requesterActor = () => ({ userId: REQUESTER, userName: REQUESTER })
+const approverActor = () => ({ userId: APPROVER, userName: APPROVER })
+
+async function createNormal(): Promise<string> {
+  const dto = await approvals.createApproval({ templateId: normalTemplateId, formData: { summary: 's' } }, requesterActor())
+  return (dto as { id: string }).id
+}
+
+interface ProjectionRow {
+  instance_id: string
+  base_id: string
+  sheet_id: string
+  record_id: string
+  projected_version: number
+  last_error: string | null
+}
+
+async function getMapping(instanceId: string): Promise<ProjectionRow | null> {
+  const r = await q('SELECT * FROM approval_record_projection WHERE instance_id = $1', [instanceId])
+  return (r.rows[0] as ProjectionRow | undefined) ?? null
+}
+
+async function getProjectedRecord(instanceId: string): Promise<{ data: Record<string, unknown>; version: number } | null> {
+  const r = await q('SELECT data, version FROM meta_records WHERE id = $1', [deriveProjectionRecordId(instanceId)])
+  const row = r.rows[0] as { data: Record<string, unknown>; version: number } | undefined
+  return row ? { data: row.data, version: Number(row.version) } : null
+}
+
+function col(data: Record<string, unknown>, sheetId: string, key: string): string {
+  const value = data[deriveProjectionFieldId(sheetId, key)]
+  return typeof value === 'string' ? value : ''
+}
+
+async function countRecordsForSheet(sheetId: string): Promise<number> {
+  const r = await q('SELECT COUNT(*)::int AS count FROM meta_records WHERE sheet_id = $1', [sheetId])
+  return (r.rows[0] as { count: number }).count
+}
+
+async function waitForProjectedStatus(instanceId: string, expected: string, timeoutMs = 6000): Promise<Record<string, unknown>> {
+  const sheetId = deriveProjectionSheetId(normalTemplateId)
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const rec = await getProjectedRecord(instanceId)
+    if (rec && col(rec.data, sheetId, 'status') === expected) return rec.data
+    if (Date.now() > deadline) return rec?.data ?? {}
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+async function executionCount(ruleId: string): Promise<number> {
+  const r = await q('SELECT COUNT(*)::int AS count FROM multitable_automation_executions WHERE rule_id = $1', [ruleId])
+  return (r.rows[0] as { count: number }).count
+}
+
+async function waitForExecutionCount(ruleId: string, expected: number, timeoutMs = 6000): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const count = await executionCount(ruleId)
+    if (count >= expected || Date.now() > deadline) return count
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+describeIfDatabase('T3-6 approval record projection (real DB)', () => {
+  beforeAll(async () => {
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('approvals:read','Approvals Read','prj'),('approvals:write','Approvals Write','prj'),('approvals:act','Approvals Act','prj')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    for (const uid of [REQUESTER, APPROVER, ADMIN, NONADMIN]) {
+      const isAdminFlag = uid === ADMIN
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1, $2, $1, 'x', $3, '[]'::jsonb, TRUE, $4)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE, is_admin = EXCLUDED.is_admin, role = EXCLUDED.role`,
+        [uid, `${uid}@prj.test`, isAdminFlag ? 'admin' : 'user', isAdminFlag],
+      )
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+    // isAdmin() is resolved from user_roles (not users.is_admin), so make ADMIN a real admin there.
+    await q(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, 'admin') ON CONFLICT DO NOTHING`, [ADMIN])
+
+    approvals = new ApprovalProductService()
+    const normal = await approvals.createTemplate(normalTemplateRequest() as never)
+    normalTemplateId = (normal as { id: string }).id
+    await approvals.publishTemplate(normalTemplateId, { policy: { allowRevoke: true } } as never)
+    const auto = await approvals.createTemplate(autoTemplateRequest() as never)
+    autoTemplateId = (auto as { id: string }).id
+    await approvals.publishTemplate(autoTemplateId, { policy: { allowRevoke: true } } as never)
+
+    // The projection service is the module singleton (the create hook inside createApproval uses it) —
+    // wire the SAME instance to the completion bus for the terminal projection trigger.
+    projection = new ApprovalRecordProjectionService()
+    setApprovalRecordProjectionServiceForTests(projection)
+    projection.subscribe(integrationEventBus)
+
+    integrationEventBus.subscribe('automation.notification', (payload) => {
+      notifications.push(payload as (typeof notifications)[number])
+    })
+    integrationEventBus.subscribe('multitable.record.created', (payload) => {
+      const sheetId = (payload as { sheetId?: string }).sheetId
+      if (sheetId) recordEventSheetIds.push(sheetId)
+    })
+    integrationEventBus.subscribe('multitable.record.updated', (payload) => {
+      const sheetId = (payload as { sheetId?: string }).sheetId
+      if (sheetId) recordEventSheetIds.push(sheetId)
+    })
+  })
+
+  afterAll(async () => {
+    try { projection?.unsubscribe(integrationEventBus) } catch { /* noop */ }
+    try { automation?.shutdown() } catch { /* noop */ }
+    setApprovalRecordProjectionServiceForTests(null)
+    const templateIds = [normalTemplateId, autoTemplateId].filter(Boolean)
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])', [templateIds]).catch(() => ({ rows: [] as unknown[] }))
+    for (const row of instances.rows as Array<{ id: string }>) {
+      await q('DELETE FROM approval_record_projection WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
+    }
+    if (ruleIds.length > 0) {
+      await q('DELETE FROM meta_automation_event_fires WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    }
+    // System sheets (deterministic per family) + their records/fields cascade; then the shared base.
+    await q('DELETE FROM meta_sheets WHERE base_id = $1', [APPROVAL_PROJECTION_BASE_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [APPROVAL_PROJECTION_BASE_ID]).catch(() => {})
+    for (const tid of templateIds) {
+      await q('DELETE FROM approval_templates WHERE id = $1', [tid]).catch(() => {})
+    }
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[REQUESTER, APPROVER, ADMIN, NONADMIN]]).catch(() => {})
+    await q('DELETE FROM user_roles WHERE user_id = ANY($1::text[])', [[REQUESTER, APPROVER, ADMIN, NONADMIN]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[REQUESTER, APPROVER, ADMIN, NONADMIN]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('create → one projected PENDING row with the §3 columns + a mapping row', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const instanceId = await createNormal()
+
+    const mapping = await getMapping(instanceId)
+    expect(mapping, 'mapping row links instance→record').toBeTruthy()
+    expect(mapping!.base_id).toBe(APPROVAL_PROJECTION_BASE_ID)
+    expect(mapping!.sheet_id).toBe(sheetId)
+    expect(mapping!.record_id).toBe(deriveProjectionRecordId(instanceId))
+    expect(mapping!.projected_version).toBe(0)
+    expect(mapping!.last_error).toBeNull()
+
+    const rec = await getProjectedRecord(instanceId)
+    expect(rec, 'projected record exists after the awaited create hook').toBeTruthy()
+    expect(col(rec!.data, sheetId, 'status')).toBe('pending')
+    expect(col(rec!.data, sheetId, 'outcome')).toBe('')
+    expect(col(rec!.data, sheetId, 'requesterId')).toBe(REQUESTER)
+    expect(col(rec!.data, sheetId, 'approverId')).toBe('')
+    expect(col(rec!.data, sheetId, 'templateId')).toBe(normalTemplateId)
+    expect(col(rec!.data, sheetId, 'templateName')).toBe('Projection Normal Template')
+    expect(col(rec!.data, sheetId, 'requestNo').length).toBeGreaterThan(0)
+    expect(col(rec!.data, sheetId, 'createdAt').length).toBeGreaterThan(0)
+    expect(col(rec!.data, sheetId, 'completedAt')).toBe('')
+    // NO form_snapshot column is projected (§3 allowlist).
+    expect(Object.keys(rec!.data)).not.toContain(deriveProjectionFieldId(sheetId, 'form_snapshot'))
+  })
+
+  test('terminal APPROVED → SAME row updated (no 2nd row), approverId + completedAt set', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const instanceId = await createNormal()
+    const before = await countRecordsForSheet(sheetId)
+
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, approverActor())
+    const data = await waitForProjectedStatus(instanceId, 'approved')
+
+    expect(col(data, sheetId, 'status')).toBe('approved')
+    expect(col(data, sheetId, 'outcome')).toBe('approved')
+    expect(col(data, sheetId, 'approverId')).toBe(APPROVER)
+    expect(col(data, sheetId, 'completedAt').length).toBeGreaterThan(0)
+    // Same row: sheet record count did not grow for this instance's update.
+    expect(await countRecordsForSheet(sheetId)).toBe(before)
+    const mapping = await getMapping(instanceId)
+    expect(mapping!.projected_version).toBeGreaterThan(0)
+  })
+
+  test('terminal REJECTED → same row, outcome rejected', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const instanceId = await createNormal()
+    await approvals.dispatchAction(instanceId, { action: 'reject', comment: 'no' } as never, approverActor())
+    const data = await waitForProjectedStatus(instanceId, 'rejected')
+    expect(col(data, sheetId, 'status')).toBe('rejected')
+    expect(col(data, sheetId, 'outcome')).toBe('rejected')
+    expect(col(data, sheetId, 'approverId')).toBe(APPROVER)
+  })
+
+  test('terminal REVOKED → same row, outcome revoked', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const instanceId = await createNormal()
+    await approvals.dispatchAction(instanceId, { action: 'revoke', comment: 'recall' } as never, requesterActor())
+    const data = await waitForProjectedStatus(instanceId, 'revoked')
+    expect(col(data, sheetId, 'status')).toBe('revoked')
+    expect(col(data, sheetId, 'outcome')).toBe('revoked')
+  })
+
+  test('terminal CANCELLED derivation → same row via reconcile (product API has no cancel path in this slice)', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const instanceId = await createNormal()
+    const before = await countRecordsForSheet(sheetId)
+    // Simulate the authoritative cancel + a monotonic version bump, then reconcile (the SAME core the
+    // completion-event subscription runs). cancelled has no decider record → approverId stays ''.
+    await q(`UPDATE approval_instances SET status = 'cancelled', version = version + 1, updated_at = now() WHERE id = $1`, [instanceId])
+    const outcome = await projection.reconcile(instanceId)
+    expect(outcome.status).toBe('projected')
+    const rec = await getProjectedRecord(instanceId)
+    expect(col(rec!.data, sheetId, 'status')).toBe('cancelled')
+    expect(col(rec!.data, sheetId, 'outcome')).toBe('cancelled')
+    expect(col(rec!.data, sheetId, 'approverId')).toBe('')
+    expect(await countRecordsForSheet(sheetId)).toBe(before)
+  })
+
+  test('auto-approve-at-create → exactly ONE row, terminal', async () => {
+    const sheetId = deriveProjectionSheetId(autoTemplateId)
+    const dto = await approvals.createApproval({ templateId: autoTemplateId, formData: { summary: 'auto' } }, requesterActor())
+    const instanceId = (dto as { id: string; status: string }).id
+    expect((dto as { status: string }).status).toBe('approved')
+
+    // Give the completion-event reconcile a chance to (no-op) run — must NOT create a second row.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    const recs = await q('SELECT id FROM meta_records WHERE sheet_id = $1', [sheetId])
+    const forInstance = (recs.rows as Array<{ id: string }>).filter((r) => r.id === deriveProjectionRecordId(instanceId))
+    expect(forInstance.length, 'auto-approve maps to exactly one row').toBe(1)
+    const rec = await getProjectedRecord(instanceId)
+    expect(col(rec!.data, sheetId, 'status')).toBe('approved')
+    expect(col(rec!.data, sheetId, 'outcome')).toBe('approved')
+    // approverId reflects the AUTHORITATIVE decider record. An empty-assignee auto-approve writes a
+    // `system:auto-approval` decision record, so the read-model records the system as the approver
+    // (richer + reconcile-consistent — sweep and live derive it identically from approval_records).
+    expect(col(rec!.data, sheetId, 'approverId')).toBe('system:auto-approval')
+    const mapping = await getMapping(instanceId)
+    expect(mapping!.projected_version).toBe(0)
+  })
+
+  test('redelivery of create + terminal is idempotent (no dup row, no double-update)', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const instanceId = await createNormal()
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, approverActor())
+    await waitForProjectedStatus(instanceId, 'approved')
+
+    const recBefore = await getProjectedRecord(instanceId)
+    const mappingBefore = await getMapping(instanceId)
+    const countBefore = await countRecordsForSheet(sheetId)
+
+    // Re-run reconcile several times (models create + terminal event redelivery). All must be no-ops.
+    for (let i = 0; i < 3; i += 1) {
+      const outcome = await projection.reconcile(instanceId)
+      expect(outcome.status).toBe('noop')
+    }
+
+    const recAfter = await getProjectedRecord(instanceId)
+    const mappingAfter = await getMapping(instanceId)
+    expect(await countRecordsForSheet(sheetId)).toBe(countBefore)
+    expect(recAfter!.version, 'record version unchanged (no double-write)').toBe(recBefore!.version)
+    expect(mappingAfter!.projected_version).toBe(mappingBefore!.projected_version)
+  })
+
+  test('§6a event-silence: a record.created rule on the system sheet does NOT fire on a projection write', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    // Ensure the system sheet exists (a prior create already provisioned it).
+    expect(await countRecordsForSheet(sheetId)).toBeGreaterThan(0)
+
+    automation = new AutomationService(integrationEventBus, db as never, queryFn)
+    automation.init()
+    const rule = await automation.createRule(sheetId, {
+      name: 'silence probe',
+      triggerType: 'record.created',
+      actionType: 'send_notification',
+      actionConfig: { userIds: [APPROVER], message: 'SILENCE_PROBE' },
+      createdBy: ADMIN,
+    } as never)
+    const ruleId = (rule as { id: string }).id
+    ruleIds.push(ruleId)
+
+    recordEventSheetIds.length = 0
+    const notifBefore = notifications.filter((n) => n.message === 'SILENCE_PROBE').length
+
+    // Projection write (create → pending, then terminal → update) targeting the SAME system sheet.
+    const instanceId = await createNormal()
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, approverActor())
+    await waitForProjectedStatus(instanceId, 'approved')
+    await new Promise((resolve) => setTimeout(resolve, 400))
+
+    expect(await executionCount(ruleId), 'projection write must not execute the system-sheet rule').toBe(0)
+    expect(notifications.filter((n) => n.message === 'SILENCE_PROBE').length).toBe(notifBefore)
+    expect(recordEventSheetIds.filter((s) => s === sheetId), 'projection emits NO record.* bus event for the system sheet').toEqual([])
+
+    // Positive control: a GENUINE record.created bus event for the same sheet DOES fire the rule — so the
+    // zero above is event-silence, not a dead rule.
+    integrationEventBus.emit('multitable.record.created', withAutomationEventId({
+      sheetId,
+      recordId: deriveProjectionRecordId(instanceId),
+      data: {},
+      actorId: 'sys-control',
+    }))
+    expect(await waitForExecutionCount(ruleId, 1), 'the rule IS live on a real bus event').toBe(1)
+  })
+
+  test('§6b reconcile: a dropped projected row is restored idempotently; a newer live projection is never clobbered', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const instanceId = await createNormal()
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, approverActor())
+    await waitForProjectedStatus(instanceId, 'approved')
+    const liveVersion = (await getMapping(instanceId))!.projected_version
+
+    // Simulate a lost write: drop BOTH the projected record and the mapping row.
+    await q('DELETE FROM approval_record_projection WHERE instance_id = $1', [instanceId])
+    await q('DELETE FROM meta_records WHERE id = $1', [deriveProjectionRecordId(instanceId)])
+    expect(await getProjectedRecord(instanceId)).toBeNull()
+
+    // Reconcile restores it to the authoritative §3 columns.
+    const restored = await projection.reconcile(instanceId)
+    expect(restored.status).toBe('projected')
+    const rec = await getProjectedRecord(instanceId)
+    expect(col(rec!.data, sheetId, 'status')).toBe('approved')
+    expect((await getMapping(instanceId))!.projected_version).toBe(liveVersion)
+
+    // Re-run → idempotent no-op (guarded by projected_version).
+    expect((await projection.reconcile(instanceId)).status).toBe('noop')
+
+    // Never-clobber: stale the mapping to a LOWER version, keep the newer live record; reconcile must NOT
+    // overwrite the newer record body (source version is not strictly newer than the live projection).
+    await createNormal() // unrelated, keeps the sweep predicate exercised below
+    const recVersionBefore = (await getProjectedRecord(instanceId))!.version
+    await q('UPDATE approval_record_projection SET projected_version = projected_version + 5 WHERE instance_id = $1', [instanceId])
+    const clobberAttempt = await projection.reconcile(instanceId)
+    expect(clobberAttempt.status).toBe('noop')
+    expect((await getProjectedRecord(instanceId))!.version, 'record body not clobbered by a stale reconcile').toBe(recVersionBefore)
+  })
+
+  test('§6b sweep: an instance ahead of its projection is found + reconciled', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const instanceId = await createNormal() // projected pending at v0
+    // Advance authoritative state past the projection WITHOUT going through the event (models a missed event).
+    await q(`UPDATE approval_instances SET status = 'approved', version = version + 1, updated_at = now() WHERE id = $1`, [instanceId])
+    await q(
+      `INSERT INTO approval_records (instance_id, action, actor_id, actor_name, from_status, to_status, to_version, occurred_at)
+       VALUES ($1, 'approve', $2, $2, 'pending', 'approved', (SELECT version FROM approval_instances WHERE id = $1), now())`,
+      [instanceId, APPROVER],
+    )
+
+    const result = await projection.sweep({ limit: 500 })
+    expect(result.reconciled).toBeGreaterThanOrEqual(1)
+    const rec = await getProjectedRecord(instanceId)
+    expect(col(rec!.data, sheetId, 'status')).toBe('approved')
+    expect(col(rec!.data, sheetId, 'approverId')).toBe(APPROVER)
+  })
+
+  test('no write-back: editing the projected record does not mutate the approval instance', async () => {
+    const instanceId = await createNormal()
+    const before = await q('SELECT status, version FROM approval_instances WHERE id = $1', [instanceId])
+    const beforeRow = before.rows[0] as { status: string; version: number }
+
+    const recordId = deriveProjectionRecordId(instanceId)
+    await q(`UPDATE meta_records SET data = data || '{"tampered":"yes"}'::jsonb WHERE id = $1`, [recordId])
+
+    const after = await q('SELECT status, version FROM approval_instances WHERE id = $1', [instanceId])
+    const afterRow = after.rows[0] as { status: string; version: number }
+    expect(afterRow.status).toBe(beforeRow.status)
+    expect(Number(afterRow.version)).toBe(Number(beforeRow.version))
+  })
+
+  test('visibility: system sheet is admin/owner-scoped (admin canRead; a non-privileged non-admin cannot)', async () => {
+    const sheetId = deriveProjectionSheetId(normalTemplateId)
+    const adminCaps = await resolveSheetCapabilitiesForUser(queryFn, sheetId, ADMIN)
+    expect(adminCaps.capabilities.canRead, 'admin can read the system sheet').toBe(true)
+
+    const nonAdminCaps = await resolveSheetCapabilitiesForUser(queryFn, sheetId, NONADMIN)
+    expect(nonAdminCaps.isAdminRole).toBe(false)
+    expect(nonAdminCaps.capabilities.canRead, 'a non-privileged non-admin cannot read the system sheet').toBe(false)
+  })
+
+  test('best-effort: a projection failure at the create hook never fails the approval flow', async () => {
+    class ThrowingProjection extends ApprovalRecordProjectionService {
+      override async reconcile(): Promise<never> {
+        throw new Error('forced projection failure')
+      }
+    }
+    setApprovalRecordProjectionServiceForTests(new ThrowingProjection())
+    try {
+      const dto = await approvals.createApproval({ templateId: normalTemplateId, formData: { summary: 'be' } }, requesterActor())
+      const instanceId = (dto as { id: string }).id
+      expect(instanceId, 'createApproval succeeds despite a throwing projection').toBeTruthy()
+      const exists = await q('SELECT 1 FROM approval_instances WHERE id = $1', [instanceId])
+      expect(exists.rows.length).toBe(1)
+    } finally {
+      setApprovalRecordProjectionServiceForTests(projection)
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
@@ -88,6 +88,10 @@ const ALLOWLIST: Record<string, { disposition: 'CHOKEPOINT' | 'SAFE'; reason: st
     disposition: 'SAFE',
     reason: 'writes ONLY auto-number columns (numeric sequence values) — never a user-supplied longText carrier',
   },
+  'multitable/approval-record-projection-service.ts': {
+    disposition: 'SAFE',
+    reason: 'T3-6 read-model projection writes ONLY the fixed system columns (requestNo/templateId/name/status/outcome/requesterId/approverId/timestamps/currentNodeKey) derived from approval_instances+approval_records — never form_snapshot or a user-supplied rich-longText carrier',
+  },
   'multitable/formula-engine.ts': {
     disposition: 'SAFE',
     reason: 'writes ONLY computed formula-result keys — derived server-side, never raw user HTML',


### PR DESCRIPTION
Implements T3-6 (approval data as a first-class multitable read-model) per its ratified design-lock (#3504). One-way projection; the approval engine stays authoritative; editing a projected row never mutates the approval.

## Architecture
One `reconcile(instanceId)` core re-reads authoritative state from `approval_instances` (+ `approval_records`) and upserts — shared by the **create hook**, the **completion-event subscription**, the **sweep**, and the on-demand path, so every path agrees.

- **Create hook (§2):** `createApproval` calls `projectApprovalOnCreate` (awaited, best-effort — a projection failure never fails the approval) → the pending row; **auto-approve-at-create lands on the SAME one row** (completion reconcile is a version-guarded no-op).
- **Event-silent (§6a — the P1 decision):** the projected write is **direct SQL** on `meta_records`, never touching `eventBus` → emits no `record.*` and no system-sheet automation can fire. **Proven** by (a) a rule on the system sheet has `executionCount===0` after a projection write **with a positive control** (a real `multitable.record.created` DOES fire it → 1), and (b) a bus spy captures zero `record.*` for the system sheet.
- **Reconcile/idempotency (§4/§6b — the P2 decision):** `projected_version = instance.version` (monotonic); a per-instance `pg_advisory_xact_lock` serializes; a stale/redelivered reconcile (`version <= stored`) writes **neither** table → never clobbers a newer live projection. Sweep predicate catches drift + a lost create; `reconcile` / `reconcileTemplateFamily` callable.
- **Columns (§3):** system allowlist only (requestNo/template/status/outcome/requester/approver/timestamps/currentNodeKey) — never `form_snapshot`. Mapping via `approval_record_projection (instance_id PK, …)` — no `meta_records` column.

## Verification
tsc 0 · new real-DB suite **14/14** · **fail-first proven** (reconcile neutralized → 10/14 fail; the 4 that pass are projection-independent) · regressions green: approval unit 91/91, T1-3 7/7, T2-6 7/7, pack1a lifecycle 3/3.

## Reviewer decisions (honest, flagged)
- **Visibility is the standard capability gate, NOT a hard admin-only DENY.** Grounded finding: the multitable read model is global-permission-driven with **no per-sheet DENY** — a user already holding global `multitable:read` could read the system sheet. Delivered: system ownership + no per-sheet share minted (test proves admin reads, non-privileged non-admin cannot). Stricter per-sheet admin-only enforcement needs new read-route surface — out of this slice (design-lock §5 scopes per-row `visibility_scope` to a later slice anyway). **Your call whether that's sufficient for v1.**
- **Deferred:** the on-demand HTTP admin endpoint (callable core delivered, no route), the `approval_projection_stale_total` prom counter (per-row `projected_version`/`last_projected_at`/`last_error` + sweep logging delivered), `reconcileTemplateFamily` test (thin wrapper). `approverId='system:auto-approval'` on auto-approve is a deliberate reporting-richer derivation from `approval_records`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)