### PR TITLE
feat(integration): resolver_lookup R0 — contract + evidence + error-code allowlist + UI mirror (#1709)

### DIFF
--- a/apps/web/src/services/integration/readSourceConfigs.ts
+++ b/apps/web/src/services/integration/readSourceConfigs.ts
@@ -105,9 +105,15 @@ export interface ReadSourceProbeEvidence {
   boundedSmokeExecuted?: boolean
   timeoutReached?: boolean
   capReached?: boolean
+  // R0 (#1709 resolver): values-free resolver evidence surface.
+  ambiguous?: boolean
+  resolved?: boolean
   recordCount?: number
   rowCount?: number
   sampleCount?: number
+  candidateCount?: number
+  matchedCount?: number
+  rule?: string
   errorCode?: string
   errorType?: string
 }
@@ -320,8 +326,10 @@ export function buildReadSourceConfigPayload(draft: ReadSourceConfigDraft): Read
 
 const EVIDENCE_CONTAINER_ALIASES = ['primary', 'header', 'lines'] as const
 const EVIDENCE_SHAPE_TYPES = new Set(['array', 'null', 'object', 'string', 'number', 'boolean', 'missing', 'other'])
-const EVIDENCE_BOOLEAN_KEYS = ['containerLocated', 'boundedSmokeExecuted', 'timeoutReached', 'capReached'] as const
-const EVIDENCE_COUNT_KEYS = ['recordCount', 'rowCount', 'sampleCount'] as const
+const EVIDENCE_BOOLEAN_KEYS = ['containerLocated', 'boundedSmokeExecuted', 'timeoutReached', 'capReached', 'ambiguous', 'resolved'] as const
+const EVIDENCE_COUNT_KEYS = ['recordCount', 'rowCount', 'sampleCount', 'candidateCount', 'matchedCount'] as const
+// R0: resolver evidence `rule` closed vocabulary (mirrors read-source-config RESOLVER_RULES).
+const EVIDENCE_RESOLVER_RULES = new Set(['exactly_one', 'first_when_sorted', 'field_equals'])
 
 // Client-side mirrors of the FROZEN S2-a vocabularies — source of truth:
 // plugins/plugin-integration-core/lib/read-source-probe-contract.cjs
@@ -339,6 +347,17 @@ const READ_SOURCE_PROBE_ERROR_CODES = new Set([
   'READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED',
   'READ_SOURCE_PROBE_SHAPE_MISMATCH',
   'READ_SOURCE_PROBE_TIMEOUT',
+  // R0 (#1709 resolver): the 9 exact resolver coarse codes (no prefix match — unknown resolver-looking
+  // codes still fall back to READ_SOURCE_PROBE_FAILED).
+  'READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND',
+  'READ_SOURCE_RESOLVER_SHAPE_MISMATCH',
+  'READ_SOURCE_RESOLVER_NO_MATCH',
+  'READ_SOURCE_RESOLVER_AMBIGUOUS',
+  'READ_SOURCE_RESOLVER_CAP_REACHED',
+  'READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED',
+  'READ_SOURCE_RESOLVER_RULE_INVALID',
+  'READ_SOURCE_RESOLVER_FIELD_MISSING',
+  'READ_SOURCE_RESOLVER_FAILED',
 ])
 const READ_SOURCE_PROBE_ERROR_TYPES = new Set([
   'Error',
@@ -347,6 +366,7 @@ const READ_SOURCE_PROBE_ERROR_TYPES = new Set([
   'K3WiseWebApiAdapterError',
   'ReadSourceProbeContractError',
   'ReadSourceProbeRuntimeError',
+  'ReadSourceResolverError',
   'TimeoutError',
   'TypeError',
 ])
@@ -396,6 +416,8 @@ export function normalizeReadSourceProbeEvidence(value: unknown): ReadSourceProb
     const count = safeCount(value[key])
     if (count !== null) evidence[key] = count
   }
+  // R0: resolver `rule` closed-vocabulary only — a raw/unknown rule string is dropped, never rendered.
+  if (typeof value.rule === 'string' && EVIDENCE_RESOLVER_RULES.has(value.rule)) evidence.rule = value.rule
   if (!evidence.ok) {
     evidence.errorCode = typeof value.errorCode === 'string' && READ_SOURCE_PROBE_ERROR_CODES.has(value.errorCode)
       ? value.errorCode

--- a/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
@@ -230,6 +230,44 @@ describe('readSourceConfigs pure helpers', () => {
       expect(text.includes(errorCode)).toBe(false)
       expect(text.includes(errorType)).toBe(false)
     }
+
+    // R0 (#1709): the 9 resolver codes + resolver evidence keys render; non-vocabulary codes/rule drop.
+    const resolver = normalizeReadSourceProbeEvidence({
+      ok: false,
+      object: 'material',
+      mode: 'resolver_lookup',
+      boundedSmoke: false,
+      errorCode: 'READ_SOURCE_RESOLVER_AMBIGUOUS',
+      errorType: 'ReadSourceResolverError',
+      candidateCount: 2,
+      matchedCount: 2,
+      ambiguous: true,
+      resolved: false,
+      rule: 'field_equals',
+    })
+    expect(resolver).toMatchObject({
+      errorCode: 'READ_SOURCE_RESOLVER_AMBIGUOUS',
+      errorType: 'ReadSourceResolverError',
+      candidateCount: 2,
+      matchedCount: 2,
+      ambiguous: true,
+      resolved: false,
+      rule: 'field_equals',
+    })
+    // a resolver-looking-but-unregistered code + a raw rule string fall back / drop (no prefix match).
+    const bogusResolver = normalizeReadSourceProbeEvidence({
+      ok: false,
+      object: 'material',
+      mode: 'resolver_lookup',
+      boundedSmoke: false,
+      errorCode: 'READ_SOURCE_RESOLVER_SECRET_MAT-001',
+      rule: 'take_the_first_row',
+    })
+    expect(bogusResolver?.errorCode).toBe('READ_SOURCE_PROBE_FAILED')
+    expect('rule' in (bogusResolver ?? {})).toBe(false)
+    const bogusText = JSON.stringify(bogusResolver)
+    expect(bogusText.includes('MAT-001')).toBe(false)
+    expect(bogusText.includes('take_the_first_row')).toBe(false)
   })
 
   it('payload assembly normalizes readPath to carry the leading slash (server byte-normalization mirror)', () => {

--- a/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
@@ -26,7 +26,7 @@ function baseValid(mode) {
   if (mode === 'single_record') { cfg.keyField = 'FNumber'; cfg.keyEncoding = 'structured_json_field'; cfg.containerPaths = ['Data'] }
   if (mode === 'list_page') { cfg.containerPaths = ['Data.Data', 'Data.DATA'] }
   if (mode === 'detail_with_lines') { cfg.keyField = 'FBillNo'; cfg.headerContainerPaths = ['Data.Page1']; cfg.lineContainerPaths = ['Data.Page2'] }
-  if (mode === 'resolver_lookup') { cfg.keyField = 'FMaterialId'; cfg.containerPaths = ['Data.Rows']; cfg.multiplicityRuleField = 'FIsCurrent' }
+  if (mode === 'resolver_lookup') { cfg.keyField = 'FMaterialId'; cfg.containerPaths = ['Data.Rows']; cfg.resolverRule = 'exactly_one'; cfg.fieldMap = [{ source: 'FItemID', target: 'item_id' }] }
   return cfg
 }
 function codes(result) { return (result.errors || []).map((e) => e.code) }
@@ -107,10 +107,44 @@ assert.ok(codes(validateReadSourceConfig({ ...baseValid('list_page'), nefariousK
   const cfg = baseValid('detail_with_lines'); delete cfg.lineContainerPaths
   assert.ok(codes(validateReadSourceConfig(cfg)).includes('READ_SOURCE_MODE_FIELD_REQUIRED'))
 }
+
+// --- 6b. R0 resolver_lookup contract (rule-specific fields, values-free) ---
+const resolver = (over) => ({ ...baseValid('resolver_lookup'), ...over })
+// pre-R0 fail-closed: an old resolver row (no resolverRule, multiplicityRuleField-only) is INVALID now.
 {
-  const cfg = baseValid('resolver_lookup'); delete cfg.multiplicityRuleField
-  assert.ok(codes(validateReadSourceConfig(cfg)).includes('READ_SOURCE_MODE_FIELD_REQUIRED'))
+  const old = baseValid('resolver_lookup'); delete old.resolverRule; delete old.fieldMap; old.multiplicityRuleField = 'FIsCurrent'
+  const c = codes(validateReadSourceConfig(old))
+  assert.ok(c.includes('READ_SOURCE_MODE_FIELD_REQUIRED'), 'pre-R0 resolver without resolverRule is fail-closed')
 }
+// exactly_one: valid with no rule fields; INVALID if a rule-specific field is present.
+assert.equal(validateReadSourceConfig(resolver({ resolverRule: 'exactly_one' })).valid, true)
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'exactly_one', multiplicityRuleField: 'X' }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'exactly_one', resolverSortDirection: 'asc' }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+// first_when_sorted: needs multiplicityRuleField(sort) + resolverSortDirection; discriminator forbidden.
+assert.equal(validateReadSourceConfig(resolver({ resolverRule: 'first_when_sorted', multiplicityRuleField: 'FDate', resolverSortDirection: 'desc' })).valid, true)
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'first_when_sorted', multiplicityRuleField: 'FDate' }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'first_when_sorted', resolverSortDirection: 'desc' }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'first_when_sorted', multiplicityRuleField: 'FDate', resolverSortDirection: 'sideways' }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+// field_equals: needs multiplicityRuleField(discriminator) + resolverDiscriminatorValue; sort forbidden.
+assert.equal(validateReadSourceConfig(resolver({ resolverRule: 'field_equals', multiplicityRuleField: 'FIsCurrent', resolverDiscriminatorValue: 'true' })).valid, true)
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'field_equals', multiplicityRuleField: 'FIsCurrent' }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'field_equals', resolverDiscriminatorValue: 'true' }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+// resolverRule not in the set → RULE_NOT_SUPPORTED.
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'take_the_first' }))).includes('READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED'))
+// discriminator value must be a bounded enum-like token, never a free/secret/host-shaped value.
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'field_equals', multiplicityRuleField: 'FIsCurrent', resolverDiscriminatorValue: 'https://evil/x?a=b c' }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+// fieldMap must be exactly ONE resolver output target.
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'exactly_one', fieldMap: [{ source: 'A', target: 'a' }, { source: 'B', target: 'b' }] }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+assert.ok(codes(validateReadSourceConfig(resolver({ resolverRule: 'exactly_one', fieldMap: undefined }))).includes('READ_SOURCE_RESOLVER_RULE_INVALID'))
+// resolver-only keys are rejected on a NON-resolver mode.
+assert.ok(codes(validateReadSourceConfig({ ...baseValid('list_page'), resolverRule: 'exactly_one' })).includes('READ_SOURCE_RESOLVER_KEY_NOT_ALLOWED'))
+// normalized output carries the resolver fields (field_equals sample).
+{
+  const n = validateReadSourceConfig(resolver({ resolverRule: 'field_equals', multiplicityRuleField: 'FIsCurrent', resolverDiscriminatorValue: 'current' })).normalized
+  assert.equal(n.resolverRule, 'field_equals'); assert.equal(n.multiplicityRuleField, 'FIsCurrent'); assert.equal(n.resolverDiscriminatorValue, 'current')
+  assert.ok(Object.isFrozen(n))
+}
+
 assert.deepEqual(validateReadSourceConfig({ valid: false }).errors[0].code, 'READ_SOURCE_UNEXPECTED_FIELD')
 assert.equal(validateReadSourceConfig(null).errors[0].code, 'READ_SOURCE_CONFIG_NOT_OBJECT')
 

--- a/plugins/plugin-integration-core/__tests__/read-source-probe-contract.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-probe-contract.test.cjs
@@ -10,10 +10,14 @@ const { validateReadSourceConfig } = require(path.join(__dirname, '..', 'lib', '
 const {
   READ_SOURCE_PROBE_TIMEOUT_MS,
   READ_SOURCE_PROBE_ROW_CAP,
+  READ_SOURCE_PROBE_ERROR_CODES,
+  READ_SOURCE_RESOLVER_ERROR_CODES,
+  READ_SOURCE_RESOLVER_RULES,
   ReadSourceProbeContractError,
   normalizeReadSourceProbeContract,
   readSourceProbeContractErrorEvidence,
   readSourceProbeEvidence,
+  safeResolverRule,
 } = require(path.join(__dirname, '..', 'lib', 'read-source-probe-contract.cjs'))
 
 function normalizedConfig(mode) {
@@ -46,7 +50,11 @@ function normalizedConfig(mode) {
     cfg.keyField = 'FMaterialId'
     cfg.keyEncoding = 'structured_json_field'
     cfg.containerPaths = ['Data.Rows']
+    // R0 contract: field_equals rule (discriminator field + value) + exactly one output target.
+    cfg.resolverRule = 'field_equals'
     cfg.multiplicityRuleField = 'FIsCurrent'
+    cfg.resolverDiscriminatorValue = 'current'
+    cfg.fieldMap = [{ source: 'FItemID', target: 'item_id' }]
   }
   const result = validateReadSourceConfig(cfg)
   assert.equal(result.valid, true, `${mode} fixture must validate: ${JSON.stringify(result.errors)}`)
@@ -274,6 +282,47 @@ assertContractReason({ config: null }, 'config_required')
       assert.ok(!text.includes(leak), `unsafe error evidence must not leak ${leak}`)
     }
   }
+}
+
+// --- R0 resolver evidence surface (#1709) ---
+{
+  // All 9 resolver codes are registered as EXACT members of the probe error-code set.
+  const nine = [
+    'READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND', 'READ_SOURCE_RESOLVER_SHAPE_MISMATCH',
+    'READ_SOURCE_RESOLVER_NO_MATCH', 'READ_SOURCE_RESOLVER_AMBIGUOUS', 'READ_SOURCE_RESOLVER_CAP_REACHED',
+    'READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED', 'READ_SOURCE_RESOLVER_RULE_INVALID',
+    'READ_SOURCE_RESOLVER_FIELD_MISSING', 'READ_SOURCE_RESOLVER_FAILED',
+  ]
+  assert.deepEqual([...READ_SOURCE_RESOLVER_ERROR_CODES], nine)
+  for (const code of nine) assert.ok(READ_SOURCE_PROBE_ERROR_CODES.includes(code), `${code} registered`)
+
+  const plan = normalizeReadSourceProbeContract({ config: normalizedConfig('list_page') })
+  // A resolver failure code passes through exactly; resolver counts/booleans/rule are permitted values-free.
+  const ev = readSourceProbeEvidence(plan, {
+    ok: false, errorCode: 'READ_SOURCE_RESOLVER_AMBIGUOUS', errorType: 'ReadSourceResolverError',
+    candidateCount: 2, matchedCount: 2, ambiguous: true, resolved: false, rule: 'field_equals',
+  })
+  assert.equal(ev.errorCode, 'READ_SOURCE_RESOLVER_AMBIGUOUS')
+  assert.equal(ev.errorType, 'ReadSourceResolverError')
+  assert.equal(ev.candidateCount, 2)
+  assert.equal(ev.matchedCount, 2)
+  assert.equal(ev.ambiguous, true)
+  assert.equal(ev.resolved, false)
+  assert.equal(ev.rule, 'field_equals')
+
+  // NO prefix matching: a resolver-looking-but-unregistered code + a raw rule string fall back / drop.
+  const bogus = readSourceProbeEvidence(plan, {
+    ok: false, errorCode: 'READ_SOURCE_RESOLVER_SECRET_MAT-001', rule: 'take_the_first',
+    candidateCount: 'lots', matchedCount: -1,
+  })
+  assert.equal(bogus.errorCode, 'READ_SOURCE_PROBE_FAILED', 'unregistered resolver-looking code falls back')
+  assert.ok(!('rule' in bogus), 'non-vocabulary rule is dropped')
+  assert.ok(!('candidateCount' in bogus) && !('matchedCount' in bogus), 'non-count values are dropped')
+  assert.ok(!JSON.stringify(bogus).includes('MAT-001') && !JSON.stringify(bogus).includes('take_the_first'))
+
+  assert.deepEqual([...READ_SOURCE_RESOLVER_RULES], ['exactly_one', 'first_when_sorted', 'field_equals'])
+  assert.equal(safeResolverRule('exactly_one'), 'exactly_one')
+  assert.equal(safeResolverRule('take_the_first'), null)
 }
 
 console.log('read-source-probe-contract.test.cjs OK')

--- a/plugins/plugin-integration-core/__tests__/read-source-read-runtime.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-read-runtime.test.cjs
@@ -52,7 +52,10 @@ function normalizedConfig(mode, overrides = {}) {
   if (mode === 'resolver_lookup') {
     cfg.keyField = 'FMaterialId'
     cfg.containerPaths = ['Data.Rows']
-    cfg.multiplicityRuleField = 'FIsCurrent'
+    // R0 contract shape (a valid resolver_lookup config); S3-1 still fail-closes it as mode_not_supported
+    // until R2 wires the evaluator — the executor rejects the MODE, not the contract.
+    cfg.resolverRule = 'exactly_one'
+    cfg.fieldMap = [{ source: 'FItemID', target: 'item_id' }]
   }
   Object.assign(cfg, overrides)
   const result = validateReadSourceConfig(cfg)

--- a/plugins/plugin-integration-core/lib/read-source-config.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-config.cjs
@@ -20,14 +20,25 @@ const READ_SOURCE_MODES = Object.freeze(['single_record', 'list_page', 'detail_w
 const READ_SOURCE_METHODS = Object.freeze(['GET', 'POST'])
 const READ_SOURCE_KEY_ENCODINGS = Object.freeze(['structured_json_field', 'filter_expression', 'numeric_id'])
 
+// resolver_lookup multiplicity rules (R0 contract extension, #1709 / resolver design-lock 2026-07-02).
+// The default MUST NOT be "take the first row" — resolverRule is REQUIRED for resolver_lookup (below), so an
+// old/pre-R0 resolver config that never declared it is fail-closed invalid (never silently reinterpreted).
+const RESOLVER_RULES = Object.freeze(['exactly_one', 'first_when_sorted', 'field_equals'])
+const RESOLVER_SORT_DIRECTIONS = Object.freeze(['asc', 'desc'])
+
 // Per-mode REQUIRED fields — hardcoded for the four modes (NOT a generic schema engine; per the design-lock,
-// "the four read modes" means "knows each mode's shape").
+// "the four read modes" means "knows each mode's shape"). resolver_lookup: multiplicityRuleField is no longer
+// unconditionally required — it is RULE-specific (validateResolverContract below), so the base requirement is
+// only keyField + containerPaths + resolverRule.
 const MODE_REQUIRED_FIELDS = Object.freeze({
   single_record: Object.freeze(['keyField', 'containerPaths']),
   list_page: Object.freeze(['containerPaths']),
   detail_with_lines: Object.freeze(['headerContainerPaths', 'lineContainerPaths']),
-  resolver_lookup: Object.freeze(['keyField', 'containerPaths', 'multiplicityRuleField']),
+  resolver_lookup: Object.freeze(['keyField', 'containerPaths', 'resolverRule']),
 })
+
+// Keys that only make sense for resolver_lookup — must NOT ride in under any other mode.
+const RESOLVER_ONLY_KEYS = Object.freeze(['resolverRule', 'resolverSortDirection', 'resolverDiscriminatorValue'])
 
 // Keys that would carry a write surface (fail-closed: read-only line).
 const WRITE_SHAPED_KEYS = Object.freeze(['savePath', 'submitPath', 'auditPath', 'deletePath', 'writePath'])
@@ -42,6 +53,8 @@ const ALLOWED_CONFIG_KEYS = Object.freeze(new Set([
   'version', 'systemId', 'requiredKind', 'object', 'mode', 'readPath', 'readMethod', 'operations',
   'keyField', 'keyEncoding', 'containerPaths', 'headerContainerPaths', 'lineContainerPaths',
   'multiplicityRuleField', 'fieldMap',
+  // R0: resolver_lookup contract keys (rule-gated below; rejected on non-resolver modes).
+  'resolverRule', 'resolverSortDirection', 'resolverDiscriminatorValue',
 ]))
 
 function isNonEmptyString(value) {
@@ -181,6 +194,53 @@ function validateReadSourceConfig(config) {
     push('READ_SOURCE_FIELD_MAP_INVALID', 'fieldMap', 'invalid_field_map')
   }
 
+  // R0 resolver_lookup contract (rule-gated multiplicity; #1709 / resolver design-lock). The resolver keys
+  // are rejected on any other mode; for resolver_lookup, resolverRule selects which rule-specific fields are
+  // required vs forbidden. Values-free: reasons are coarse enums, no config value is echoed.
+  if (config.mode !== 'resolver_lookup') {
+    for (const key of RESOLVER_ONLY_KEYS) {
+      if (config[key] !== undefined) push('READ_SOURCE_RESOLVER_KEY_NOT_ALLOWED', key, 'resolver_only_key')
+    }
+  } else {
+    const rule = config.resolverRule
+    const has = (k) => config[k] !== undefined
+    // resolverRule presence is enforced by MODE_REQUIRED_FIELDS; validate the VALUE here (a pre-R0 config
+    // with no resolverRule is already fail-closed via the required-field check — never reinterpreted).
+    if (rule !== undefined && !RESOLVER_RULES.includes(rule)) {
+      push('READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED', 'resolverRule', 'not_allowlisted')
+    }
+    if (config.resolverSortDirection !== undefined && !RESOLVER_SORT_DIRECTIONS.includes(config.resolverSortDirection)) {
+      push('READ_SOURCE_RESOLVER_RULE_INVALID', 'resolverSortDirection', 'not_allowlisted')
+    }
+    // resolverDiscriminatorValue is config METADATA (a short enum-like token), never runtime data — reject a
+    // host/path/secret/value-shaped string (bounded identifier + the global secret-shape scan below).
+    if (config.resolverDiscriminatorValue !== undefined && !isBoundedIdentifier(config.resolverDiscriminatorValue)) {
+      push('READ_SOURCE_RESOLVER_RULE_INVALID', 'resolverDiscriminatorValue', 'invalid_token')
+    }
+    // Rule-specific required / forbidden fields (only when the rule itself is a known value).
+    if (RESOLVER_RULES.includes(rule)) {
+      if (rule === 'exactly_one') {
+        for (const k of ['multiplicityRuleField', 'resolverSortDirection', 'resolverDiscriminatorValue']) {
+          if (has(k)) push('READ_SOURCE_RESOLVER_RULE_INVALID', k, 'not_allowed_for_exactly_one')
+        }
+      } else if (rule === 'first_when_sorted') {
+        if (!has('multiplicityRuleField')) push('READ_SOURCE_RESOLVER_RULE_INVALID', 'multiplicityRuleField', 'required_sort_field_for_first_when_sorted')
+        if (!has('resolverSortDirection')) push('READ_SOURCE_RESOLVER_RULE_INVALID', 'resolverSortDirection', 'required_for_first_when_sorted')
+        if (has('resolverDiscriminatorValue')) push('READ_SOURCE_RESOLVER_RULE_INVALID', 'resolverDiscriminatorValue', 'not_allowed_for_first_when_sorted')
+      } else if (rule === 'field_equals') {
+        if (!has('multiplicityRuleField')) push('READ_SOURCE_RESOLVER_RULE_INVALID', 'multiplicityRuleField', 'required_discriminator_field_for_field_equals')
+        if (!has('resolverDiscriminatorValue')) push('READ_SOURCE_RESOLVER_RULE_INVALID', 'resolverDiscriminatorValue', 'required_for_field_equals')
+        if (has('resolverSortDirection')) push('READ_SOURCE_RESOLVER_RULE_INVALID', 'resolverSortDirection', 'not_allowed_for_field_equals')
+      }
+    }
+    // fieldMap: REQUIRED and exactly ONE resolver output target for v1.
+    if (config.fieldMap === undefined) {
+      push('READ_SOURCE_RESOLVER_RULE_INVALID', 'fieldMap', 'resolver_requires_one_target')
+    } else if (Array.isArray(config.fieldMap) && config.fieldMap.length !== 1) {
+      push('READ_SOURCE_RESOLVER_RULE_INVALID', 'fieldMap', 'resolver_requires_exactly_one_target')
+    }
+  }
+
   // version — positive integer (audit/versioning surface; store is a later cut).
   if (!Number.isInteger(config.version) || config.version < 1) {
     push('READ_SOURCE_VERSION_INVALID', 'version', 'must_be_positive_integer')
@@ -212,6 +272,10 @@ function normalizeReadSourceConfig(config) {
   if (config.keyField !== undefined) out.keyField = config.keyField.trim()
   if (config.keyEncoding !== undefined) out.keyEncoding = config.keyEncoding
   if (config.multiplicityRuleField !== undefined) out.multiplicityRuleField = config.multiplicityRuleField.trim()
+  // R0 resolver_lookup contract fields (already validated; enum values are not trimmed as they are exact).
+  if (config.resolverRule !== undefined) out.resolverRule = config.resolverRule
+  if (config.resolverSortDirection !== undefined) out.resolverSortDirection = config.resolverSortDirection
+  if (config.resolverDiscriminatorValue !== undefined) out.resolverDiscriminatorValue = config.resolverDiscriminatorValue.trim()
   const trimList = (field) => {
     if (Array.isArray(config[field])) out[field] = Object.freeze(config[field].map((p) => p.trim()))
   }
@@ -228,6 +292,8 @@ module.exports = {
   READ_SOURCE_MODES,
   READ_SOURCE_METHODS,
   READ_SOURCE_KEY_ENCODINGS,
+  RESOLVER_RULES,
+  RESOLVER_SORT_DIRECTIONS,
   isSafeRelativeReadPath,
   validateReadSourceConfig,
   normalizeReadSourceConfig,

--- a/plugins/plugin-integration-core/lib/read-source-probe-contract.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-probe-contract.cjs
@@ -16,6 +16,25 @@ const READ_SOURCE_PROBE_CONTRACT_TOP_KEYS = Object.freeze(['config', 'boundedSmo
 const READ_SOURCE_PROBE_CONTAINER_ALIASES = Object.freeze(['primary', 'header', 'lines'])
 const READ_SOURCE_PROBE_ERROR_CODE = 'READ_SOURCE_PROBE_CONTRACT_INVALID'
 const READ_SOURCE_PROBE_DEFAULT_ERROR = 'READ_SOURCE_PROBE_FAILED'
+// R0 (#1709 / resolver design-lock): the exact resolver coarse-code allowlist. Registered as EXACT values in
+// the probe error-code set below so safeErrorCode accepts them — PREFIX MATCHING IS NOT ALLOWED, an unknown
+// resolver-looking code still degrades to the generic safe fallback. R1's evaluator produces these; R0 only
+// registers the surface so a producer object is not silently clamped into a generic failure.
+const READ_SOURCE_RESOLVER_ERROR_CODES = Object.freeze([
+  'READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND',
+  'READ_SOURCE_RESOLVER_SHAPE_MISMATCH',
+  'READ_SOURCE_RESOLVER_NO_MATCH',
+  'READ_SOURCE_RESOLVER_AMBIGUOUS',
+  'READ_SOURCE_RESOLVER_CAP_REACHED',
+  'READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED',
+  'READ_SOURCE_RESOLVER_RULE_INVALID',
+  'READ_SOURCE_RESOLVER_FIELD_MISSING',
+  'READ_SOURCE_RESOLVER_FAILED',
+])
+// The resolver evidence `rule` value is a closed vocabulary (mirrors read-source-config RESOLVER_RULES).
+const READ_SOURCE_RESOLVER_RULES = Object.freeze(['exactly_one', 'first_when_sorted', 'field_equals'])
+const READ_SOURCE_RESOLVER_RULE_SET = new Set(READ_SOURCE_RESOLVER_RULES)
+
 const READ_SOURCE_PROBE_ERROR_CODES = Object.freeze([
   READ_SOURCE_PROBE_ERROR_CODE,
   READ_SOURCE_PROBE_DEFAULT_ERROR,
@@ -28,6 +47,7 @@ const READ_SOURCE_PROBE_ERROR_CODES = Object.freeze([
   'READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED',
   'READ_SOURCE_PROBE_SHAPE_MISMATCH',
   'READ_SOURCE_PROBE_TIMEOUT',
+  ...READ_SOURCE_RESOLVER_ERROR_CODES,
 ])
 const READ_SOURCE_PROBE_ERROR_CODE_SET = new Set(READ_SOURCE_PROBE_ERROR_CODES)
 const READ_SOURCE_PROBE_ERROR_TYPES = Object.freeze([
@@ -37,16 +57,21 @@ const READ_SOURCE_PROBE_ERROR_TYPES = Object.freeze([
   'K3WiseWebApiAdapterError',
   'ReadSourceProbeContractError',
   'ReadSourceProbeRuntimeError',
+  'ReadSourceResolverError',
   'TimeoutError',
   'TypeError',
 ])
 const READ_SOURCE_PROBE_ERROR_TYPE_SET = new Set(READ_SOURCE_PROBE_ERROR_TYPES)
-const READ_SOURCE_PROBE_EVIDENCE_COUNT_KEYS = Object.freeze(['recordCount', 'rowCount', 'sampleCount'])
+// R0: resolver evidence counts (candidateCount/matchedCount) join the values-free count allowlist.
+const READ_SOURCE_PROBE_EVIDENCE_COUNT_KEYS = Object.freeze(['recordCount', 'rowCount', 'sampleCount', 'candidateCount', 'matchedCount'])
 const READ_SOURCE_PROBE_EVIDENCE_BOOLEAN_KEYS = Object.freeze([
   'containerLocated',
   'boundedSmokeExecuted',
   'timeoutReached',
   'capReached',
+  // R0: resolver evidence booleans.
+  'ambiguous',
+  'resolved',
 ])
 
 class ReadSourceProbeContractError extends Error {
@@ -157,6 +182,12 @@ function safeCount(value) {
   return null
 }
 
+// R0: the resolver evidence `rule` field is a closed vocabulary — exact membership, never a producer-supplied
+// free string (values-free: a raw/unknown rule string is dropped, not echoed).
+function safeResolverRule(value) {
+  return typeof value === 'string' && READ_SOURCE_RESOLVER_RULE_SET.has(value) ? value : null
+}
+
 function safeErrorCode(value) {
   if (typeof value !== 'string') return null
   const code = value.trim()
@@ -215,6 +246,10 @@ function readSourceProbeEvidence(plan, result) {
     if (typeof source[key] === 'boolean') evidence[key] = source[key]
   }
 
+  // R0: the resolver `rule` field, closed-vocabulary only (absent for non-resolver probes).
+  const rule = safeResolverRule(source.rule)
+  if (rule !== null) evidence.rule = rule
+
   if (!evidence.ok) {
     evidence.errorCode = safeErrorCode(source.errorCode) || READ_SOURCE_PROBE_DEFAULT_ERROR
     evidence.errorType = safeErrorType(source.errorType) || 'Error'
@@ -230,8 +265,11 @@ module.exports = {
   READ_SOURCE_PROBE_CONTAINER_ALIASES,
   READ_SOURCE_PROBE_ERROR_CODES,
   READ_SOURCE_PROBE_ERROR_TYPES,
+  READ_SOURCE_RESOLVER_ERROR_CODES,
+  READ_SOURCE_RESOLVER_RULES,
   ReadSourceProbeContractError,
   normalizeReadSourceProbeContract,
   readSourceProbeContractErrorEvidence,
   readSourceProbeEvidence,
+  safeResolverRule,
 }


### PR DESCRIPTION
## What

**R0** of the resolver_lookup runtime (owner-authorized on #1709 today, alongside R1). Implements the design-lock #3479 R0 slice: the **contract + evidence surface extension** only — no runtime execution, no route change, no evaluator (that's R1).

## Scope (contract/config/evidence surface)

- **S1 validator** (`read-source-config.cjs`): `resolverRule` ∈ {exactly_one, first_when_sorted, field_equals} (now in MODE_REQUIRED_FIELDS for resolver_lookup); `resolverSortDirection` ∈ {asc, desc}; `resolverDiscriminatorValue` = bounded enum-like token (isBoundedIdentifier + the global secret-shape scan reject host/path/secret/value-shaped strings). Resolver keys rejected on non-resolver modes (`READ_SOURCE_RESOLVER_KEY_NOT_ALLOWED`).
- **multiplicityRuleField made rule-specific**: removed from the unconditional required set → required as the SORT field for first_when_sorted, the DISCRIMINATOR field for field_equals, and FORBIDDEN for exactly_one (per-rule validation).
- **S2-a evidence** (`read-source-probe-contract.cjs`): the **9 exact `READ_SOURCE_RESOLVER_*` coarse codes** registered as exact members (no prefix match — unknown resolver-looking codes still fall back). Evidence allowlist extended: candidateCount/matchedCount (counts), ambiguous/resolved (booleans), `rule` (closed vocabulary via safeResolverRule).
- **S3-UI mirror** (`readSourceConfigs.ts`): the same closed code set + rule vocabulary + count/boolean keys mirrored client-side; non-vocabulary codes/rules drop to the coarse fallback. Leak/DOM tests extended.
- **Pre-R0 fail-closed proof**: an old resolver config (multiplicityRuleField-only, no resolverRule) → invalid (`READ_SOURCE_MODE_FIELD_REQUIRED`); never silently reinterpreted. No migration, no auto-approve.

## Boundary (owner-listed, held)

No resolver runtime EXECUTION (R1), no route change, no S3-1 executor change, no material→FBillNo composition, no recursive BOM, no Save/Submit/Audit, no external/production write. Values-free everything.

## Verification

Plugin suites (read-source-config / probe-contract / probe-runtime / read-runtime / config-store / http-routes) OK; UI panel spec 18/18; backend + web type-check clean; web lint clean. Reviewed for closed-vocabulary integrity (evidence code set vs validator code set separated; UI mirror exactly matches backend), per-rule required/forbidden validation, discriminator-value bounding + secret-shape rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)