### PR TITLE
feat(approval): T3-2 business-calendar SLA runtime (WorkdayCalendarPort, implements design-lock)

### DIFF
--- a/packages/core-backend/src/core/workday-calendar-port.ts
+++ b/packages/core-backend/src/core/workday-calendar-port.ts
@@ -1,0 +1,244 @@
+/**
+ * T3-2 — Business/work-day calendar wired to approval SLA.
+ *
+ * A hexagonal PORT that lets the approval SLA path refine a deadline against a
+ * working-day / business-time calendar WITHOUT ever reading `attendance_*` tables
+ * or taking a compile-time dependency on the attendance plugin. The attendance
+ * plugin registers a PROVIDER (adapter) wrapping its `resolveEffectiveCalendar`.
+ *
+ * When no provider is bound (attendance absent / unregistered) the SLA path
+ * FAILS OPEN to natural elapsed arithmetic (see ApprovalMetricsService).
+ *
+ * See docs/development/t3-2-business-calendar-sla-design-lock-20260703.md.
+ */
+
+/**
+ * A recurring intra-day non-counting window (Q6, v1: recurring windows / day masks,
+ * NOT absolute date ranges). Minutes-of-day `[startMinuteOfDay, endMinuteOfDay)` in the
+ * calendar timezone. When `daysOfWeek` is present it restricts the window to those
+ * weekdays (0 = Sunday … 6 = Saturday); absent → applies to every working day.
+ */
+export interface RecurringWindow {
+  startMinuteOfDay: number
+  endMinuteOfDay: number
+  daysOfWeek?: number[]
+}
+
+/**
+ * A resolved, snapshot working-time calendar for one org. `isWorkingDay` is a pure
+ * day-mask lookup (holidays / rest days baked in at resolve time); `nonCountingWindows`
+ * are recurring intra-day windows that do not count toward the SLA even on a working day.
+ */
+export interface WorkdayCalendar {
+  timezone: string
+  isWorkingDay(dayIso: string): boolean
+  nonCountingWindows: RecurringWindow[]
+}
+
+/**
+ * The port. `resolve` returns the working-time context for `orgId` as of the `asOf`
+ * snapshot instant, or `null` when the provider owns no calendar for that org (a
+ * foreign / unauthorized org is the provider's decision — approval passes the resolved
+ * org, never a raw attendance id). A throw is treated as fail-open by the caller.
+ */
+export interface WorkdayCalendarPort {
+  resolve(orgId: string, asOf: Date): Promise<WorkdayCalendar | null>
+}
+
+/**
+ * Single-provider registry. Unlike the view registries (keyed by view type) there is
+ * exactly one working-day calendar provider process-wide; binding a second one replaces
+ * the first (logged). Unbound → `get()` returns `undefined` → the SLA path fails open.
+ */
+class WorkdayCalendarRegistryImpl {
+  private provider: WorkdayCalendarPort | undefined
+  private static instance: WorkdayCalendarRegistryImpl
+
+  private constructor() {}
+
+  static getInstance(): WorkdayCalendarRegistryImpl {
+    if (!WorkdayCalendarRegistryImpl.instance) {
+      WorkdayCalendarRegistryImpl.instance = new WorkdayCalendarRegistryImpl()
+    }
+    return WorkdayCalendarRegistryImpl.instance
+  }
+
+  register(provider: WorkdayCalendarPort): void {
+    if (this.provider) {
+      console.warn('WorkdayCalendarPort provider is being replaced')
+    }
+    this.provider = provider
+  }
+
+  unregister(): void {
+    this.provider = undefined
+  }
+
+  get(): WorkdayCalendarPort | undefined {
+    return this.provider
+  }
+
+  has(): boolean {
+    return this.provider !== undefined
+  }
+
+  /** Clear the bound provider (test isolation). */
+  clear(): void {
+    this.provider = undefined
+  }
+}
+
+export function getWorkdayCalendarRegistry(): WorkdayCalendarRegistryImpl {
+  return WorkdayCalendarRegistryImpl.getInstance()
+}
+
+/** Register the process-wide working-day calendar provider (convenience). */
+export function registerWorkdayCalendarProvider(provider: WorkdayCalendarPort): void {
+  getWorkdayCalendarRegistry().register(provider)
+}
+
+/** Unregister the working-day calendar provider (convenience / test teardown). */
+export function unregisterWorkdayCalendarProvider(): void {
+  getWorkdayCalendarRegistry().unregister()
+}
+
+export { WorkdayCalendarRegistryImpl }
+
+// ---------------------------------------------------------------------------
+// Pure business-time deadline arithmetic (no DB, no port — fully unit-testable).
+// ---------------------------------------------------------------------------
+
+const MINUTES_PER_DAY = 1440
+const MS_PER_MINUTE = 60_000
+
+/** Default forward-search horizon (Q10): if no deadline is found inside this many days, clamp + flag. */
+export const WORKDAY_SEARCH_CAP_DAYS = 366
+
+export interface WorkdayDeadlineResult {
+  /** The computed business-time due instant (or the clamped horizon end when exhausted). */
+  dueAt: Date
+  /** True when the forward search hit the day cap without consuming the full SLA budget. */
+  clamped: boolean
+}
+
+/**
+ * Read the calendar-timezone wall-clock day (`YYYY-MM-DD`) and minute-of-day (0..1439)
+ * of an instant. Uses `Intl` (DST-correct) with an h23 hour cycle. Throws if the
+ * timezone is invalid — the caller treats that as fail-open.
+ */
+function tzParts(instant: Date, timeZone: string): { dayIso: string; minuteOfDay: number } {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+  const parts = fmt.formatToParts(instant)
+  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? '00'
+  const year = get('year')
+  const month = get('month')
+  const day = get('day')
+  const hour = Number(get('hour')) % 24
+  const minute = Number(get('minute'))
+  return { dayIso: `${year}-${month}-${day}`, minuteOfDay: hour * 60 + minute }
+}
+
+/** Weekday (0 = Sunday … 6 = Saturday) of a `YYYY-MM-DD` calendar date (tz-independent). */
+function weekdayOf(dayIso: string): number {
+  return new Date(`${dayIso}T00:00:00Z`).getUTCDay()
+}
+
+/**
+ * The non-counting minute intervals `[a, b)` (minutes-of-day) that apply on `dayIso`,
+ * merged and clamped to `[0, 1440)`. Windows whose `daysOfWeek` excludes the day are ignored.
+ */
+function nonCountingIntervalsForDay(dayIso: string, windows: RecurringWindow[]): Array<[number, number]> {
+  if (!windows.length) return []
+  const weekday = weekdayOf(dayIso)
+  const raw: Array<[number, number]> = []
+  for (const w of windows) {
+    if (Array.isArray(w.daysOfWeek) && !w.daysOfWeek.includes(weekday)) continue
+    const a = Math.max(0, Math.min(MINUTES_PER_DAY, Math.floor(w.startMinuteOfDay)))
+    const b = Math.max(0, Math.min(MINUTES_PER_DAY, Math.floor(w.endMinuteOfDay)))
+    if (b > a) raw.push([a, b])
+  }
+  if (!raw.length) return []
+  raw.sort((x, y) => x[0] - y[0])
+  const merged: Array<[number, number]> = [raw[0]]
+  for (let i = 1; i < raw.length; i++) {
+    const last = merged[merged.length - 1]
+    if (raw[i][0] <= last[1]) last[1] = Math.max(last[1], raw[i][1])
+    else merged.push(raw[i])
+  }
+  return merged
+}
+
+/**
+ * The counting sub-segments `[a, b)` (minutes-of-day) inside `[fromMinute, toMinute)` on
+ * `dayIso` — i.e. the requested range minus the non-counting windows.
+ */
+function countingSegments(
+  dayIso: string,
+  fromMinute: number,
+  toMinute: number,
+  windows: RecurringWindow[],
+): Array<[number, number]> {
+  const intervals = nonCountingIntervalsForDay(dayIso, windows)
+  const segments: Array<[number, number]> = []
+  let cursor = fromMinute
+  for (const [a, b] of intervals) {
+    if (b <= cursor || a >= toMinute) continue
+    if (a > cursor) segments.push([cursor, Math.min(a, toMinute)])
+    cursor = Math.max(cursor, b)
+    if (cursor >= toMinute) break
+  }
+  if (cursor < toMinute) segments.push([cursor, toMinute])
+  return segments.filter(([a, b]) => b > a)
+}
+
+/**
+ * Walk forward from `start`, counting ONLY minutes that fall on a working day AND outside every
+ * non-counting window (in the calendar's timezone), until `durationMinutes` have been consumed.
+ *
+ * Pure and DB-free. Real-millisecond arithmetic is used within a day and to hop to the next local
+ * midnight; on a DST-transition day this can be off by the transition amount (accepted v1 imprecision,
+ * documented). Caps the search at `capDays` days (Q10): if the budget is not consumed inside the
+ * horizon the result is clamped to the horizon end and `clamped` is true.
+ */
+export function computeWorkdayDeadline(
+  start: Date,
+  durationMinutes: number,
+  calendar: WorkdayCalendar,
+  capDays: number = WORKDAY_SEARCH_CAP_DAYS,
+): WorkdayDeadlineResult {
+  const tz = calendar.timezone
+  let remaining = Math.max(0, durationMinutes)
+  let cursorMs = start.getTime()
+
+  if (remaining === 0) return { dueAt: new Date(cursorMs), clamped: false }
+
+  for (let day = 0; day <= capDays; day++) {
+    const { dayIso, minuteOfDay } = tzParts(new Date(cursorMs), tz)
+    if (calendar.isWorkingDay(dayIso)) {
+      const segments = countingSegments(dayIso, minuteOfDay, MINUTES_PER_DAY, calendar.nonCountingWindows)
+      for (const [a, b] of segments) {
+        const segMinutes = b - a
+        if (remaining <= segMinutes) {
+          // The budget exhausts `remaining` minutes into this counting segment. `a` is the
+          // segment's starting minute-of-day; `cursorMs` is at `minuteOfDay`, so the real
+          // offset from the cursor is (a - minuteOfDay) + remaining.
+          const offsetMinutes = a - minuteOfDay + remaining
+          return { dueAt: new Date(cursorMs + offsetMinutes * MS_PER_MINUTE), clamped: false }
+        }
+        remaining -= segMinutes
+      }
+    }
+    // Hop to the next local midnight (minutes left in this tz-day).
+    cursorMs += (MINUTES_PER_DAY - minuteOfDay) * MS_PER_MINUTE
+  }
+  // Horizon exhausted without consuming the budget → clamp + flag (caller logs).
+  return { dueAt: new Date(cursorMs), clamped: true }
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260703140000_add_calendar_sla_to_approval_metrics.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260703140000_add_calendar_sla_to_approval_metrics.ts
@@ -1,0 +1,56 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+/**
+ * T3-2 — business/work-day calendar wired to approval SLA.
+ *
+ * Additive, nullable columns on approval_metrics for the calendar-typed SLA path, plus a NEW partial
+ * index for the calendar overdue scan. The legacy `sla_hours` branch and its scan index
+ * (`idx_approval_metrics_sla_scan`) are LEFT UNTOUCHED — a template carrying only `sla_hours` stays
+ * byte-identical to today's UTC wall-clock SLA (opt-in; §8). No backfill for historical rows (§5/Q7).
+ *
+ *   - sla_calendar_org_id : the calendar org resolved from the requester/org snapshot at instance start.
+ *   - sla_timezone        : the resolved timezone the deadline was computed in (audit; provider tz →
+ *                           APP_TIMEZONE → UTC).
+ *   - sla_due_at          : the absolute business-time due instant computed at node activation.
+ *   - sla_unit            : SLA-unit discriminator — 'wall_clock' (legacy elapsed) or 'business' (calendar).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'approval_metrics')
+  if (!exists) return
+
+  await sql`ALTER TABLE approval_metrics ADD COLUMN IF NOT EXISTS sla_calendar_org_id TEXT`.execute(db)
+  await sql`ALTER TABLE approval_metrics ADD COLUMN IF NOT EXISTS sla_timezone TEXT`.execute(db)
+  await sql`ALTER TABLE approval_metrics ADD COLUMN IF NOT EXISTS sla_due_at TIMESTAMPTZ`.execute(db)
+  await sql`ALTER TABLE approval_metrics ADD COLUMN IF NOT EXISTS sla_unit TEXT`.execute(db)
+
+  await sql`
+    ALTER TABLE approval_metrics
+      DROP CONSTRAINT IF EXISTS approval_metrics_sla_unit_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE approval_metrics
+      ADD CONSTRAINT approval_metrics_sla_unit_check
+      CHECK (sla_unit IS NULL OR sla_unit IN ('wall_clock', 'business'))
+  `.execute(db)
+
+  // New partial index for the calendar overdue scan. Mirrors the shape of idx_approval_metrics_sla_scan
+  // (kept as-is for the legacy path) but keys on the absolute due instant.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_due_scan
+      ON approval_metrics(sla_due_at)
+      WHERE terminal_at IS NULL AND sla_due_at IS NOT NULL AND sla_breached = FALSE
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'approval_metrics')
+  if (!exists) return
+  await sql`DROP INDEX IF EXISTS idx_approval_metrics_sla_due_scan`.execute(db)
+  await sql`ALTER TABLE approval_metrics DROP CONSTRAINT IF EXISTS approval_metrics_sla_unit_check`.execute(db)
+  await sql`ALTER TABLE approval_metrics DROP COLUMN IF EXISTS sla_unit`.execute(db)
+  await sql`ALTER TABLE approval_metrics DROP COLUMN IF EXISTS sla_due_at`.execute(db)
+  await sql`ALTER TABLE approval_metrics DROP COLUMN IF EXISTS sla_timezone`.execute(db)
+  await sql`ALTER TABLE approval_metrics DROP COLUMN IF EXISTS sla_calendar_org_id`.execute(db)
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -16,6 +16,10 @@ import { createContainer } from './di/container'
 import { IConfigService, ILogger, ICollabService, ICoreAPI, IPluginLoader, ICollectionManager, IPLMAdapter, IAthenaAdapter, IDedupCADAdapter, ICADMLAdapter, IVisionAdapter, IFormulaService } from './di/identifiers'
 import { PluginLoader, type LoadedPlugin } from './core/plugin-loader'
 import { Logger, setLogContext } from './core/logger'
+import {
+  getWorkdayCalendarRegistry,
+  type WorkdayCalendarPort,
+} from './core/workday-calendar-port'
 import type {
   CoreAPI,
   UserInfo,
@@ -227,6 +231,9 @@ export class MetaSheetServer {
   private pluginCommunicationNamespacesByPlugin = new Map<string, Set<string>>()
   private pluginCommunicationNamespaceOwners = new Map<string, string>()
   private pluginAttendanceSchedulerUnregistersByPlugin = new Map<string, Set<() => void>>()
+  // T3-2: the plugin (if any) that currently owns the bound WorkdayCalendarPort provider, so a
+  // reload/deactivate of that plugin unbinds it and the SLA path fails open again.
+  private workdayCalendarProviderOwner: string | null = null
   private port: number
   private host?: string
   private portLocked: boolean
@@ -909,8 +916,26 @@ export class MetaSheetServer {
     return wrappedUnregister
   }
 
+  private registerPluginWorkdayCalendarProvider(pluginName: string, provider: WorkdayCalendarPort): (() => void) {
+    getWorkdayCalendarRegistry().register(provider)
+    this.workdayCalendarProviderOwner = pluginName
+    this.logger.info(`WorkdayCalendarPort provider bound by plugin: ${pluginName}`)
+    return () => {
+      if (this.workdayCalendarProviderOwner === pluginName) {
+        getWorkdayCalendarRegistry().unregister()
+        this.workdayCalendarProviderOwner = null
+      }
+    }
+  }
+
   private cleanupPluginRuntimeRegistrations(pluginName: string): void {
     this.removePluginRoutes(pluginName)
+
+    // T3-2: unbind this plugin's working-day calendar provider so the SLA path fails open again.
+    if (this.workdayCalendarProviderOwner === pluginName) {
+      getWorkdayCalendarRegistry().unregister()
+      this.workdayCalendarProviderOwner = null
+    }
 
     const namespaces = this.pluginCommunicationNamespacesByPlugin.get(pluginName)
     if (namespaces) {
@@ -1662,6 +1687,11 @@ export class MetaSheetServer {
         notification: notificationService,
         attendanceScheduler: {
           registerJob: (job: { name?: string; run(): Promise<unknown> }) => this.registerPluginAttendanceSchedulerJob(pluginName, job),
+        },
+        // T3-2: let a plugin bind the working-day calendar provider the approval SLA path consults.
+        // Registration is tracked per-plugin so a plugin reload/deactivate unbinds it (fail-open again).
+        workdayCalendar: {
+          register: (provider: WorkdayCalendarPort) => this.registerPluginWorkdayCalendarProvider(pluginName, provider),
         },
         automationRegistry,
         rbacProvisioning,
@@ -2596,6 +2626,21 @@ if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
 // ============================================================
 // View Provider System Exports
 // ============================================================
+
+// T3-2 WorkdayCalendarPort exports — the approval SLA business-calendar port + registry.
+export {
+  getWorkdayCalendarRegistry,
+  registerWorkdayCalendarProvider,
+  unregisterWorkdayCalendarProvider,
+  computeWorkdayDeadline,
+  WORKDAY_SEARCH_CAP_DAYS,
+} from './core/workday-calendar-port'
+export type {
+  WorkdayCalendarPort,
+  WorkdayCalendar,
+  RecurringWindow,
+  WorkdayDeadlineResult,
+} from './core/workday-calendar-port'
 
 // View Config Provider exports
 export { getViewConfigRegistry, registerViewConfigProvider, unregisterViewConfigProvider } from './core/view-config-registry'

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -581,7 +581,7 @@ export class ApprovalMetricsService {
          PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_seconds)
            FILTER (WHERE duration_seconds IS NOT NULL)::text AS p95_duration,
          COUNT(*) FILTER (WHERE sla_breached = TRUE)::text AS sla_breach_count,
-         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL)::text AS sla_candidate_count
+         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL OR sla_due_at IS NOT NULL)::text AS sla_candidate_count
        FROM approval_metrics
        ${where}`,
       params,
@@ -614,7 +614,7 @@ export class ApprovalMetricsService {
          COUNT(*) FILTER (WHERE terminal_state = 'revoked')::text AS revoked,
          AVG(duration_seconds) FILTER (WHERE duration_seconds IS NOT NULL)::text AS avg_duration,
          COUNT(*) FILTER (WHERE sla_breached = TRUE)::text AS sla_breach_count,
-         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL)::text AS sla_candidate_count
+         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL OR sla_due_at IS NOT NULL)::text AS sla_candidate_count
        FROM approval_metrics
        ${where}
        GROUP BY template_id
@@ -708,7 +708,7 @@ export class ApprovalMetricsService {
          COUNT(*) FILTER (WHERE m.terminal_state = 'revoked')::text AS revoked,
          AVG(m.duration_seconds) FILTER (WHERE m.duration_seconds IS NOT NULL)::text AS avg_duration,
          COUNT(*) FILTER (WHERE m.sla_breached = TRUE)::text AS sla_breach_count,
-         COUNT(*) FILTER (WHERE m.sla_hours IS NOT NULL)::text AS sla_candidate_count
+         COUNT(*) FILTER (WHERE m.sla_hours IS NOT NULL OR m.sla_due_at IS NOT NULL)::text AS sla_candidate_count
        FROM approval_metrics m
        LEFT JOIN approval_instances i ON i.id = m.instance_id
        ${where}
@@ -803,7 +803,7 @@ export class ApprovalMetricsService {
       `SELECT
          template_id,
          COUNT(*)::text AS total,
-         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL)::text AS sla_candidate_count,
+         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL OR sla_due_at IS NOT NULL)::text AS sla_candidate_count,
          COUNT(*) FILTER (WHERE sla_breached = TRUE)::text AS sla_breach_count,
          AVG(duration_seconds) FILTER (WHERE duration_seconds IS NOT NULL)::text AS avg_duration,
          PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_seconds)
@@ -811,10 +811,10 @@ export class ApprovalMetricsService {
        FROM approval_metrics
        ${where}
        GROUP BY template_id
-       HAVING COUNT(*) FILTER (WHERE sla_hours IS NOT NULL) > 0
+       HAVING COUNT(*) FILTER (WHERE sla_hours IS NOT NULL OR sla_due_at IS NOT NULL) > 0
        ORDER BY
          (COUNT(*) FILTER (WHERE sla_breached = TRUE))::float
-           / NULLIF(COUNT(*) FILTER (WHERE sla_hours IS NOT NULL), 0) DESC,
+           / NULLIF(COUNT(*) FILTER (WHERE sla_hours IS NOT NULL OR sla_due_at IS NOT NULL), 0) DESC,
          COUNT(*) FILTER (WHERE sla_breached = TRUE) DESC,
          COUNT(*) DESC
        LIMIT $${templateLimitParam.length}`,

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -10,6 +10,35 @@
  */
 
 import { pool } from '../db/pg'
+import { Logger } from '../core/logger'
+import {
+  getWorkdayCalendarRegistry,
+  computeWorkdayDeadline,
+  WORKDAY_SEARCH_CAP_DAYS,
+} from '../core/workday-calendar-port'
+
+const calendarSlaLogger = new Logger('ApprovalCalendarSla')
+
+/**
+ * T3-2 calendar SLA descriptor threaded from the caller into a node-activation stamp. Present ONLY when
+ * the activating node opted into a business-time SLA (`NodeTimeoutConfig.unit === 'business'`). `orgId`
+ * is the calendar org resolved from the requester/org snapshot at instance start (falls back to 'default').
+ */
+export interface CalendarSlaInput {
+  afterMinutes: number
+  orgId: string
+}
+
+/**
+ * The armed calendar deadline: the absolute business-time due instant and the resolved timezone it was
+ * computed in (persisted for audit). Fully snapshotted at the activation instant — a later calendar edit
+ * never moves an already-armed deadline.
+ */
+interface ResolvedCalendarDeadline {
+  dueAt: Date
+  timezone: string
+  orgId: string
+}
 
 export type Query = <T = unknown>(
   sql: string,
@@ -43,6 +72,11 @@ export interface ApprovalMetricsRow {
   sla_breached: boolean
   sla_breached_at: string | null
   node_breakdown: NodeBreakdownEntry[]
+  // T3-2 calendar SLA (nullable / absent on legacy + non-calendar rows).
+  sla_calendar_org_id?: string | null
+  sla_timezone?: string | null
+  sla_due_at?: string | null
+  sla_unit?: 'wall_clock' | 'business' | null
   created_at: string
   updated_at: string
 }
@@ -188,6 +222,10 @@ export class ApprovalMetricsService {
     // instance start — this is the one activation path that does NOT flow through recordNodeActivation.
     timeoutDeadline?: Date | null
     timeoutEffect?: string | null
+    // T3-2: present when the initial node opted into a business-time SLA. Computes sla_due_at via the
+    // WorkdayCalendarPort (snapshot asOf startedAt; fail-open to wall-clock); its due instant also drives
+    // current_node_deadline_at so the node-timeout effect fires at the business deadline.
+    calendarSla?: CalendarSlaInput | null
   }): Promise<void> {
     const tenantId = resolveTenantId(input.tenantId)
     const initialBreakdown: NodeBreakdownEntry[] = input.initialNodeKey
@@ -199,11 +237,16 @@ export class ApprovalMetricsService {
         approverIds: [],
       }]
       : []
+    const calendar = input.calendarSla
+      ? await this.resolveCalendarDeadline(input.calendarSla, input.startedAt, input.instanceId)
+      : null
+    const deadline = calendar ? calendar.dueAt : (input.timeoutDeadline ?? null)
     await this.query(
       `INSERT INTO approval_metrics
          (instance_id, template_id, tenant_id, started_at, sla_hours, node_breakdown,
-          current_node_deadline_at, current_node_timeout_effect)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
+          current_node_deadline_at, current_node_timeout_effect,
+          sla_due_at, sla_timezone, sla_calendar_org_id, sla_unit)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11, $12)
        ON CONFLICT (instance_id) DO NOTHING`,
       [
         input.instanceId,
@@ -212,8 +255,12 @@ export class ApprovalMetricsService {
         input.startedAt.toISOString(),
         input.slaHours ?? null,
         JSON.stringify(initialBreakdown),
-        input.timeoutDeadline ? input.timeoutDeadline.toISOString() : null,
+        deadline ? deadline.toISOString() : null,
         input.timeoutEffect ?? null,
+        calendar ? calendar.dueAt.toISOString() : null,
+        calendar ? calendar.timezone : null,
+        calendar ? calendar.orgId : null,
+        calendar ? 'business' : null,
       ],
     )
   }
@@ -231,6 +278,10 @@ export class ApprovalMetricsService {
     // columns are cleared so the previous node's deadline can never linger on the new node.
     timeoutDeadline?: Date | null
     timeoutEffect?: string | null
+    // T3-2: present when the activating node opted into a business-time SLA. sla_due_at is computed via
+    // the WorkdayCalendarPort (snapshot asOf activatedAt; fail-open to wall-clock) and also drives
+    // current_node_deadline_at. Absent → the calendar columns are cleared (like the T1-1 deadline).
+    calendarSla?: CalendarSlaInput | null
   }): Promise<void> {
     let added = false
     await this.mutateBreakdown(input.instanceId, (breakdown) => {
@@ -252,18 +303,84 @@ export class ApprovalMetricsService {
     // to the new node's deadline if it has a timeout, else NULL (clearing the prior node's). A
     // retry / re-emit (an open entry already exists → `added` stays false) is a strict no-op, so it
     // can never push out or clear an existing deadline. Best-effort, like every metrics write.
+    //
+    // T3-2: on a business-time node the calendar due instant replaces the naive deadline (so the effect
+    // fires at the business time) and populates the sla_* columns; a wall-clock / no-timeout node clears
+    // them, so a prior node's calendar deadline can never linger on the new node.
     if (added) {
+      const calendar = input.calendarSla
+        ? await this.resolveCalendarDeadline(input.calendarSla, input.activatedAt, input.instanceId)
+        : null
+      const deadline = calendar ? calendar.dueAt : (input.timeoutDeadline ?? null)
       await this.query(
         `UPDATE approval_metrics
            SET current_node_deadline_at = $2,
-               current_node_timeout_effect = $3
+               current_node_timeout_effect = $3,
+               sla_due_at = $4,
+               sla_timezone = $5,
+               sla_calendar_org_id = $6,
+               sla_unit = $7
          WHERE instance_id = $1`,
         [
           input.instanceId,
-          input.timeoutDeadline ? input.timeoutDeadline.toISOString() : null,
+          deadline ? deadline.toISOString() : null,
           input.timeoutEffect ?? null,
+          calendar ? calendar.dueAt.toISOString() : null,
+          calendar ? calendar.timezone : null,
+          calendar ? calendar.orgId : null,
+          calendar ? 'business' : null,
         ],
       )
+    }
+  }
+
+  /**
+   * T3-2 — resolve the business-time due instant for a calendar-typed node SLA, fully snapshotted at
+   * the activation instant. Consults the WorkdayCalendarPort registry:
+   *   - provider bound + calendar for org → walk `afterMinutes` of counting time forward (Q3/Q6);
+   *   - provider UNBOUND, provider THROWS, or org UNRESOLVED (`resolve` → null) → FAIL OPEN to natural
+   *     elapsed arithmetic (activatedAt + afterMinutes, wall-clock), timezone APP_TIMEZONE → UTC, log (Q4);
+   *   - forward search capped at 366 days (Q10) — an all-non-working calendar clamps + logs.
+   * NEVER throws — a calendar failure must not block approval creation or disable SLA tracking.
+   */
+  private async resolveCalendarDeadline(
+    input: CalendarSlaInput,
+    activatedAt: Date,
+    instanceId: string,
+  ): Promise<ResolvedCalendarDeadline> {
+    const orgId = input.orgId
+    const fallbackTimezone = process.env.APP_TIMEZONE || 'UTC'
+    const naiveDueAt = new Date(activatedAt.getTime() + input.afterMinutes * 60_000)
+    const provider = getWorkdayCalendarRegistry().get()
+    if (!provider) {
+      calendarSlaLogger.warn(
+        `Calendar SLA fail-open for ${instanceId}: no WorkdayCalendarPort provider bound — using wall-clock elapsed`,
+      )
+      return { dueAt: naiveDueAt, timezone: fallbackTimezone, orgId }
+    }
+    try {
+      const calendar = await provider.resolve(orgId, activatedAt)
+      if (!calendar) {
+        calendarSlaLogger.warn(
+          `Calendar SLA fail-open for ${instanceId}: provider returned no calendar for org '${orgId}' — using wall-clock elapsed`,
+        )
+        return { dueAt: naiveDueAt, timezone: fallbackTimezone, orgId }
+      }
+      const timezone = typeof calendar.timezone === 'string' && calendar.timezone.trim().length > 0
+        ? calendar.timezone
+        : fallbackTimezone
+      const { dueAt, clamped } = computeWorkdayDeadline(activatedAt, input.afterMinutes, calendar)
+      if (clamped) {
+        calendarSlaLogger.warn(
+          `Calendar SLA search cap for ${instanceId}: no working time found within ${WORKDAY_SEARCH_CAP_DAYS} days for org '${orgId}' — clamped to horizon`,
+        )
+      }
+      return { dueAt, timezone, orgId }
+    } catch (error) {
+      calendarSlaLogger.warn(
+        `Calendar SLA fail-open for ${instanceId}: provider threw (${error instanceof Error ? error.message : String(error)}) — using wall-clock elapsed`,
+      )
+      return { dueAt: naiveDueAt, timezone: fallbackTimezone, orgId }
     }
   }
 
@@ -316,9 +433,12 @@ export class ApprovalMetricsService {
     // `approval_instances.current_node_key` to the NEXT node inside the committed transaction, so once the
     // flow has advanced this clear is a safe no-op and the activation write is the sole owner of the
     // deadline. On a terminal outcome `recordTerminal` clears unconditionally, so nothing is missed.
+    // T3-2: the calendar SLA columns are cleared alongside the T1-1 deadline (same scoped guard) so a
+    // decided node's business due can never linger; the next node's activation is the sole owner of them.
     await this.query(
       `UPDATE approval_metrics
-         SET current_node_deadline_at = NULL, current_node_timeout_effect = NULL
+         SET current_node_deadline_at = NULL, current_node_timeout_effect = NULL,
+             sla_due_at = NULL, sla_timezone = NULL, sla_calendar_org_id = NULL, sla_unit = NULL
        WHERE instance_id = $1
          AND EXISTS (
            SELECT 1 FROM approval_instances i
@@ -385,6 +505,8 @@ export class ApprovalMetricsService {
    * caller can emit audit events / notifications.
    */
   async checkSlaBreaches(now: Date): Promise<string[]> {
+    // LEGACY path (unchanged, byte-identical): `sla_hours` elapsed since started_at. Served by the
+    // preserved partial index idx_approval_metrics_sla_scan — do NOT modify this predicate.
     const result = await this.query<{ instance_id: string }>(
       `UPDATE approval_metrics
          SET sla_breached = TRUE,
@@ -396,7 +518,24 @@ export class ApprovalMetricsService {
        RETURNING instance_id`,
       [now.toISOString()],
     )
-    return result.rows.map((row) => row.instance_id)
+    // T3-2 CALENDAR path (§6): rebase overdue detection on the actual business-time `sla_due_at`. A
+    // separate UPDATE keeps the legacy predicate untouched and lets Postgres use the NEW partial index
+    // idx_approval_metrics_sla_due_scan. Rows with sla_due_at NULL (legacy / non-calendar) are untouched.
+    const calendar = await this.query<{ instance_id: string }>(
+      `UPDATE approval_metrics
+         SET sla_breached = TRUE,
+             sla_breached_at = $1
+       WHERE terminal_at IS NULL
+         AND sla_due_at IS NOT NULL
+         AND sla_breached = FALSE
+         AND sla_due_at < $1
+       RETURNING instance_id`,
+      [now.toISOString()],
+    )
+    const ids = new Set<string>()
+    for (const row of result.rows) ids.add(row.instance_id)
+    for (const row of calendar.rows) ids.add(row.instance_id)
+    return [...ids]
   }
 
   async getMetricsSummary(input: MetricsSummaryQuery = {}): Promise<MetricsSummary> {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1031,11 +1031,17 @@ function normalizeNodeTimeout(
   // validateNodeTimeoutConfigs so all entry points raise the same APPROVAL_NODE_TIMEOUT_* codes.
   const transferToUserId = typeof value.transferToUserId === 'string' ? value.transferToUserId.trim() : undefined
   const jumpToNodeKey = typeof value.jumpToNodeKey === 'string' ? value.jumpToNodeKey.trim() : undefined
+  // T3-2 SLA-unit discriminator rides along; the strict value gate lives in validateNodeTimeoutConfigs.
+  // 'wall_clock' is the default → omit it so a wall-clock timeout stays byte-identical to T1-1's shape.
+  const unit = value.unit === 'business' ? 'business' as const
+    : value.unit === 'wall_clock' ? 'wall_clock' as const
+    : undefined
   return {
     afterMinutes: value.afterMinutes as number,
     effect: value.effect as NodeTimeoutEffect,
     ...(transferToUserId ? { transferToUserId } : {}),
     ...(jumpToNodeKey ? { jumpToNodeKey } : {}),
+    ...(unit === 'business' ? { unit } : {}),
   }
 }
 
@@ -1170,6 +1176,16 @@ function validateNodeTimeoutConfigs(approvalGraph: ApprovalGraph): void {
         `approvalGraph node ${node.key} timeout.effect '${effect}' is not supported yet`,
         400,
         'APPROVAL_NODE_TIMEOUT_EFFECT_UNSUPPORTED',
+      )
+    }
+    // T3-2: the SLA-unit discriminator, when present, must be one of the two known units — an unknown
+    // value is rejected (never silently coerced to the wall-clock default).
+    const unit = (timeout as { unit?: unknown }).unit
+    if (unit !== undefined && unit !== 'wall_clock' && unit !== 'business') {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} timeout.unit must be 'wall_clock' or 'business'`,
+        400,
+        'APPROVAL_NODE_TIMEOUT_INVALID',
       )
     }
     if (parallelRegionNodeKeys.has(node.key)) {
@@ -2096,6 +2112,19 @@ function getApprovalNodeConfig(runtimeGraph: RuntimeGraph, nodeKey: string): App
 function nodeTimeoutForKey(runtimeGraph: RuntimeGraph, nodeKey: string): NodeTimeoutConfig | undefined {
   const config = getApprovalNodeConfig(runtimeGraph, nodeKey) as { timeout?: NodeTimeoutConfig } | null
   return config?.timeout ?? undefined
+}
+
+/**
+ * T3-2 (Q2): the calendar org for a business-time node SLA, resolved from the FROZEN requester/org
+ * snapshot. Deterministic per instance (the snapshot never changes) so every node of an instance
+ * resolves the same org. Falls back to the literal `default` org when no explicit org mapping exists.
+ * Approval passes this resolved org to the port — never a raw attendance id.
+ */
+function resolveCalendarSlaOrgId(requesterSnapshot: Record<string, unknown> | null | undefined): string {
+  const org = requesterSnapshot && typeof requesterSnapshot.orgId === 'string'
+    ? requesterSnapshot.orgId.trim()
+    : ''
+  return org.length > 0 ? org : 'default'
 }
 
 /**
@@ -3525,6 +3554,14 @@ export class ApprovalProductService {
       const initialTimeout = initial.currentNodeKey
         ? nodeTimeoutForKey(runtimeGraph, initial.currentNodeKey)
         : undefined
+      // T3-2: a business-unit initial node arms its deadline through the calendar (org resolved from the
+      // frozen requester snapshot, §2); otherwise the wall-clock deadline is stamped exactly as T1-1.
+      const initialCalendarSla = initialTimeout?.unit === 'business'
+        ? {
+            afterMinutes: initialTimeout.afterMinutes,
+            orgId: resolveCalendarSlaOrgId(requesterSnapshot as unknown as Record<string, unknown>),
+          }
+        : undefined
       await this.metrics.recordInstanceStart({
       instanceId,
       templateId: bundle.template.id,
@@ -3534,8 +3571,10 @@ export class ApprovalProductService {
       initialNodeKey: initial.currentNodeKey,
       ...(initialTimeout?.effect
         ? {
-            timeoutDeadline: new Date(startedAt.getTime() + initialTimeout.afterMinutes * 60000),
             timeoutEffect: initialTimeout.effect,
+            ...(initialCalendarSla
+              ? { calendarSla: initialCalendarSla }
+              : { timeoutDeadline: new Date(startedAt.getTime() + initialTimeout.afterMinutes * 60000) }),
           }
         : {}),
       })
@@ -3788,7 +3827,7 @@ export class ApprovalProductService {
       }
 
       if (resolution.currentNodeKey) {
-        this.emitNodeActivationMetric(id, resolution.currentNodeKey, nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
+        this.emitNodeActivationMetric(id, resolution.currentNodeKey, resolveCalendarSlaOrgId(toNullableRecord(instance.requester_snapshot)), nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
       }
     } catch (error) {
       await rollbackQuietly(client)
@@ -4276,7 +4315,7 @@ export class ApprovalProductService {
       // breakdown entry, then re-entry activation re-stamps the target node (incl. its own timeout).
       this.emitNodeDecisionMetric(id, currentNodeKey, APPROVAL_TIMEOUT_SYSTEM_ACTOR)
       if (resolution.status === 'pending' && resolution.currentNodeKey) {
-        this.emitNodeActivationMetric(id, resolution.currentNodeKey, nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
+        this.emitNodeActivationMetric(id, resolution.currentNodeKey, resolveCalendarSlaOrgId(toNullableRecord(instance.requester_snapshot)), nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
       }
       if (completionEvent) {
         emitApprovalCompletionEvent(completionEvent)
@@ -4722,7 +4761,7 @@ export class ApprovalProductService {
         await client.query('COMMIT')
         this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
         if (resolution.currentNodeKey) {
-          this.emitNodeActivationMetric(id, resolution.currentNodeKey, nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
+          this.emitNodeActivationMetric(id, resolution.currentNodeKey, resolveCalendarSlaOrgId(toNullableRecord(instance.requester_snapshot)), nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
         }
         return (await this.getApproval(id))!
       }
@@ -5215,7 +5254,7 @@ export class ApprovalProductService {
         emitApprovalCompletionEvent(completionEvent)
         this.emitTerminalMetric(id, 'approved')
       } else if (resolution.currentNodeKey && resolution.currentNodeKey !== currentNodeKey) {
-        this.emitNodeActivationMetric(id, resolution.currentNodeKey, nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
+        this.emitNodeActivationMetric(id, resolution.currentNodeKey, resolveCalendarSlaOrgId(toNullableRecord(instance.requester_snapshot)), nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
       }
     } catch (error) {
       await rollbackQuietly(client)
@@ -5246,11 +5285,22 @@ export class ApprovalProductService {
     )
   }
 
-  private emitNodeActivationMetric(instanceId: string, nodeKey: string, timeout?: NodeTimeoutConfig): void {
+  private emitNodeActivationMetric(
+    instanceId: string,
+    nodeKey: string,
+    calendarOrgId: string,
+    timeout?: NodeTimeoutConfig,
+  ): void {
     const activatedAt = new Date()
     // T1-1: when the activating node declares a timeout, stamp its absolute deadline + effect so the
     // SLA scanner can fire on it. No timeout → recordNodeActivation clears the columns (so the prior
     // node's deadline can never linger). Still inside safeMetricsCall — a best-effort write.
+    //
+    // T3-2: a business-unit timeout passes `calendarSla` instead of a naive `timeoutDeadline` — the
+    // metrics service computes the business-time deadline via the WorkdayCalendarPort (fail-open safe).
+    const calendarSla = timeout?.unit === 'business'
+      ? { afterMinutes: timeout.afterMinutes, orgId: calendarOrgId }
+      : undefined
     safeMetricsCall(`recordNodeActivation(${instanceId}/${nodeKey})`, () =>
       this.metrics.recordNodeActivation({
         instanceId,
@@ -5258,8 +5308,10 @@ export class ApprovalProductService {
         activatedAt,
         ...(timeout?.effect
           ? {
-              timeoutDeadline: new Date(activatedAt.getTime() + timeout.afterMinutes * 60000),
               timeoutEffect: timeout.effect,
+              ...(calendarSla
+                ? { calendarSla }
+                : { timeoutDeadline: new Date(activatedAt.getTime() + timeout.afterMinutes * 60000) }),
             }
           : {}),
       }),

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -92,6 +92,13 @@ export interface NodeTimeoutConfig {
   transferToUserId?: string
   /** effect='jump': approval-node key the instance is sent to (re-entry semantics) when the deadline fires. */
   jumpToNodeKey?: string
+  /**
+   * T3-2 SLA-unit discriminator. Default/absent === 'wall_clock' — `afterMinutes` elapses as UTC
+   * wall-clock (byte-identical to T1-1). When 'business', the deadline is computed against a
+   * working-day calendar (WorkdayCalendarPort): only minutes on a working day and outside every
+   * non-counting window count. Provider-absent → fail-open to wall-clock.
+   */
+  unit?: 'wall_clock' | 'business'
 }
 
 export interface ApprovalNodeConfig {

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -963,6 +963,21 @@ export interface PluginServices {
   attendanceScheduler?: {
     registerJob(job: { name?: string; run(): Promise<unknown> }): (() => void) | null
   }
+  /**
+   * T3-2 — host→plugin surface for binding the process-wide working-day calendar provider that the
+   * approval SLA path consults through the WorkdayCalendarPort. `register` returns an unbind function.
+   * A provider whose `resolve` returns null (foreign / unmapped org) or throws is treated as fail-open
+   * by approval. The registered provider MAY read `attendance_*`; approval never does.
+   */
+  workdayCalendar?: {
+    register(provider: {
+      resolve(orgId: string, asOf: Date): Promise<{
+        timezone: string
+        isWorkingDay(dayIso: string): boolean
+        nonCountingWindows: Array<{ startMinuteOfDay: number; endMinuteOfDay: number; daysOfWeek?: number[] }>
+      } | null>
+    }): (() => void)
+  }
   notification: NotificationService // Notification service instance
   automationRegistry: PluginAutomationRegistryService
   rbacProvisioning: PluginRbacProvisioningService

--- a/packages/core-backend/tests/integration/approval-calendar-sla.test.ts
+++ b/packages/core-backend/tests/integration/approval-calendar-sla.test.ts
@@ -416,6 +416,29 @@ describeIfDatabase('Approval T3-2 business-calendar SLA — real DB', () => {
     expect(row.rows[0]?.sla_breached_at).not.toBeNull()
   })
 
+  it('analytics denominator (review P2): a business-calendar breached row (sla_hours NULL) counts as an SLA CANDIDATE, not just a breach', async () => {
+    // Before the fix, the candidate denominators counted only `sla_hours IS NOT NULL`, so a calendar row
+    // (sla_hours NULL, sla_due_at set, sla_breached TRUE) inflated the breach numerator while the candidate
+    // denominator stayed 0 → a >100% (or divide-by-near-zero) breach rate. The predicate now counts
+    // `sla_hours IS NOT NULL OR sla_due_at IS NOT NULL`. Isolated by a unique tenant.
+    const metrics = new ApprovalMetricsService(rawQuery)
+    const tenantId = `t32-denom-${Date.now()}`
+    const instanceId = `${tenantId}-i1`
+    await seedInstance(instanceId, 'approval_1')
+    await rawQuery(
+      `INSERT INTO approval_metrics
+         (instance_id, template_id, tenant_id, started_at, sla_hours, sla_due_at, sla_unit,
+          sla_breached, sla_breached_at, node_breakdown)
+       VALUES ($1, NULL, $2, now() - INTERVAL '2 hours', NULL, now() - INTERVAL '1 minute', 'business',
+               TRUE, now(), '[]'::jsonb)`,
+      [instanceId, tenantId],
+    )
+    const summary = await metrics.getMetricsSummary({ tenantId })
+    expect(summary.slaBreachCount).toBe(1)
+    // The calendar row IS a candidate — denominator includes it (was 0 before the fix → inflated rate).
+    expect(summary.slaCandidateCount).toBe(1)
+  })
+
   it('legacy sla_hours path is byte-identical (no calendar columns) and still index-served', async () => {
     const metrics = new ApprovalMetricsService(rawQuery)
     const instanceId = `t32-legacy-${Date.now()}`

--- a/packages/core-backend/tests/integration/approval-calendar-sla.test.ts
+++ b/packages/core-backend/tests/integration/approval-calendar-sla.test.ts
@@ -1,0 +1,469 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+import { ApprovalMetricsService } from '../../src/services/ApprovalMetricsService'
+import {
+  registerWorkdayCalendarProvider,
+  unregisterWorkdayCalendarProvider,
+  type WorkdayCalendarPort,
+  type WorkdayCalendar,
+} from '../../src/core/workday-calendar-port'
+
+/**
+ * T3-2 — business/work-day calendar wired to approval SLA (real DB, real approval-start + metrics SQL).
+ *
+ * The deadline is asserted THROUGH the real approval start + recordNodeActivation metrics path with a
+ * registered FAKE WorkdayCalendarPort provider — never a hand-built deadline. Fail-first contrast:
+ *   RED-before (no provider bound) → sla_due_at is the naive elapsed instant;
+ *   GREEN (weekend-non-working provider) → sla_due_at is pushed strictly past the naive instant.
+ * Plus fail-open (absent / throwing / null-org), snapshot (calendar edit after activation), the 366-day
+ * cap, and the legacy sla_hours path staying byte-identical + index-served.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const AFTER_MINUTES = 6 * 1440 // 6 business days — a run of 6 working days always crosses ≥1 weekend.
+const DAY_MS = 86_400_000
+
+type MetricsRow = {
+  started_at: string
+  current_node_deadline_at: string | null
+  sla_due_at: string | null
+  sla_timezone: string | null
+  sla_calendar_org_id: string | null
+  sla_unit: string | null
+  sla_hours: number | null
+}
+
+function weekendCalendar(tz = 'UTC'): WorkdayCalendar {
+  return {
+    timezone: tz,
+    isWorkingDay: (dayIso: string) => ![0, 6].includes(new Date(`${dayIso}T00:00:00Z`).getUTCDay()),
+    nonCountingWindows: [],
+  }
+}
+
+function allNonWorkingCalendar(tz = 'UTC'): WorkdayCalendar {
+  return { timezone: tz, isWorkingDay: () => false, nonCountingWindows: [] }
+}
+
+const weekendProvider: WorkdayCalendarPort = { resolve: async () => weekendCalendar() }
+const throwingProvider: WorkdayCalendarPort = { resolve: async () => { throw new Error('provider boom') } }
+const nullProvider: WorkdayCalendarPort = { resolve: async () => null }
+const allNonWorkingProvider: WorkdayCalendarPort = { resolve: async () => allNonWorkingCalendar() }
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+function buildFormSchema() {
+  return { fields: [{ id: 'reason', type: 'text', label: '事由', required: true }] }
+}
+
+// Single business-unit approval node — the INITIAL node, activated through recordInstanceStart.
+function buildBusinessSlaGraph(unit: 'business' | 'wall_clock') {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'node_a',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['approver-a'],
+          approvalMode: 'single',
+          timeout: { afterMinutes: AFTER_MINUTES, effect: 'remind', unit },
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-a', source: 'start', target: 'node_a' },
+      { key: 'edge-a-end', source: 'node_a', target: 'end' },
+    ],
+  }
+}
+
+describeIfDatabase('Approval T3-2 business-calendar SLA — real DB', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+
+  function rawQuery<T extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<{ rows: T[]; rowCount?: number | null }> {
+    return poolManager.get().query<T>(sql, params) as unknown as Promise<{ rows: T[]; rowCount?: number | null }>
+  }
+
+  async function fetchMetrics(instanceId: string): Promise<MetricsRow | null> {
+    const result = await rawQuery<MetricsRow>(
+      `SELECT started_at, current_node_deadline_at, sla_due_at, sla_timezone,
+              sla_calendar_org_id, sla_unit, sla_hours
+         FROM approval_metrics WHERE instance_id = $1`,
+      [instanceId],
+    )
+    return result.rows[0] ?? null
+  }
+
+  // recordInstanceStart is a post-commit best-effort write — poll until the metrics row satisfies `ready`.
+  async function waitForMetrics(instanceId: string, ready: (row: MetricsRow) => boolean): Promise<MetricsRow> {
+    for (let attempt = 0; attempt < 80; attempt++) {
+      const row = await fetchMetrics(instanceId)
+      if (row && ready(row)) return row
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    const row = await fetchMetrics(instanceId)
+    throw new Error(`metrics row not ready for ${instanceId}: ${JSON.stringify(row)}`)
+  }
+
+  async function createTemplate(adminToken: string, approvalGraph: object): Promise<Response> {
+    const templateKey = `approval-t32-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    return jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'T3-2 Business Calendar SLA Template',
+        description: 'T3-2 business-calendar SLA integration',
+        formSchema: buildFormSchema(),
+        approvalGraph,
+      },
+    })
+  }
+
+  async function publishGraphTemplate(adminToken: string, approvalGraph: object): Promise<string> {
+    const templateResponse = await createTemplate(adminToken, approvalGraph)
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status).toBe(200)
+    return template.id
+  }
+
+  async function startApproval(requesterToken: string, templateId: string): Promise<string> {
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 'business calendar sla' } },
+    })
+    expect(createResponse.status).toBe(201)
+    const created = await createResponse.json() as { id: string }
+    createdApprovalIds.add(created.id)
+    return created.id
+  }
+
+  async function seedInstance(id: string, currentNodeKey: string): Promise<void> {
+    await rawQuery(
+      `INSERT INTO approval_instances (id, status, current_node_key)
+       VALUES ($1, 'pending', $2) ON CONFLICT (id) DO NOTHING`,
+      [id, currentNodeKey],
+    )
+    createdApprovalIds.add(id)
+  }
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterEach(() => {
+    unregisterWorkdayCalendarProvider()
+  })
+
+  afterAll(async () => {
+    unregisterWorkdayCalendarProvider()
+    const pool = poolManager.get()
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool.query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+    } catch {
+      // best-effort cleanup
+    }
+    if (server) await server.stop()
+  })
+
+  it('has DATABASE_URL configured (sentinel — never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('GREEN: a weekend-non-working provider pushes sla_due_at strictly past the naive elapsed instant', async () => {
+    registerWorkdayCalendarProvider(weekendProvider)
+    const admin = await authToken(baseUrl, 't32-admin')
+    const templateId = await publishGraphTemplate(admin, buildBusinessSlaGraph('business'))
+    const requester = await authToken(baseUrl, 't32-requester')
+    const instanceId = await startApproval(requester, templateId)
+
+    const row = await waitForMetrics(instanceId, (r) => r.sla_due_at !== null)
+    expect(row.sla_unit).toBe('business')
+    expect(row.sla_timezone).toBe('UTC')
+    expect(row.sla_calendar_org_id).toBe('default')
+
+    const startedMs = new Date(row.started_at).getTime()
+    const naiveMs = startedMs + AFTER_MINUTES * 60_000
+    const dueMs = new Date(row.sla_due_at as string).getTime()
+    // Business time skips at least one weekend → strictly later than the naive elapsed instant.
+    expect(dueMs).toBeGreaterThan(naiveMs)
+    expect(dueMs - naiveMs).toBeGreaterThanOrEqual(DAY_MS) // ≥1 full skipped day
+    // The node-timeout effect deadline tracks the business due instant (so `remind` fires at business time).
+    expect(new Date(row.current_node_deadline_at as string).getTime()).toBe(dueMs)
+  })
+
+  it('RED / fail-open: with NO provider bound, sla_due_at is the naive elapsed instant (creation still succeeds)', async () => {
+    // No provider registered (afterEach unbinds). This is the RED-before contrast to the GREEN case.
+    const admin = await authToken(baseUrl, 't32-admin')
+    const templateId = await publishGraphTemplate(admin, buildBusinessSlaGraph('business'))
+    const requester = await authToken(baseUrl, 't32-requester')
+    const instanceId = await startApproval(requester, templateId)
+
+    const row = await waitForMetrics(instanceId, (r) => r.sla_due_at !== null)
+    expect(row.sla_unit).toBe('business')
+    expect(row.sla_timezone).toBe('UTC') // APP_TIMEZONE unset → UTC fallback
+    expect(row.sla_calendar_org_id).toBe('default')
+
+    const startedMs = new Date(row.started_at).getTime()
+    const naiveMs = startedMs + AFTER_MINUTES * 60_000
+    const dueMs = new Date(row.sla_due_at as string).getTime()
+    // Fail-open = natural elapsed arithmetic (activatedAt + afterMinutes) — no weekend push.
+    expect(Math.abs(dueMs - naiveMs)).toBeLessThan(2_000)
+  })
+
+  it('fail-open: a throwing provider falls back to elapsed arithmetic; approval creation is not blocked', async () => {
+    registerWorkdayCalendarProvider(throwingProvider)
+    const admin = await authToken(baseUrl, 't32-admin')
+    const templateId = await publishGraphTemplate(admin, buildBusinessSlaGraph('business'))
+    const requester = await authToken(baseUrl, 't32-requester')
+    const instanceId = await startApproval(requester, templateId)
+
+    const row = await waitForMetrics(instanceId, (r) => r.sla_due_at !== null)
+    expect(row.sla_unit).toBe('business')
+    const naiveMs = new Date(row.started_at).getTime() + AFTER_MINUTES * 60_000
+    expect(Math.abs(new Date(row.sla_due_at as string).getTime() - naiveMs)).toBeLessThan(2_000)
+  })
+
+  it('fail-open: a provider that resolves null (unmapped / foreign org) falls back to elapsed arithmetic', async () => {
+    registerWorkdayCalendarProvider(nullProvider)
+    const admin = await authToken(baseUrl, 't32-admin')
+    const templateId = await publishGraphTemplate(admin, buildBusinessSlaGraph('business'))
+    const requester = await authToken(baseUrl, 't32-requester')
+    const instanceId = await startApproval(requester, templateId)
+
+    const row = await waitForMetrics(instanceId, (r) => r.sla_due_at !== null)
+    const naiveMs = new Date(row.started_at).getTime() + AFTER_MINUTES * 60_000
+    expect(Math.abs(new Date(row.sla_due_at as string).getTime() - naiveMs)).toBeLessThan(2_000)
+  })
+
+  it('366-day cap: an all-non-working calendar clamps sla_due_at to the horizon (creation succeeds)', async () => {
+    registerWorkdayCalendarProvider(allNonWorkingProvider)
+    const admin = await authToken(baseUrl, 't32-admin')
+    const templateId = await publishGraphTemplate(admin, buildBusinessSlaGraph('business'))
+    const requester = await authToken(baseUrl, 't32-requester')
+    const instanceId = await startApproval(requester, templateId)
+
+    const row = await waitForMetrics(instanceId, (r) => r.sla_due_at !== null)
+    expect(row.sla_unit).toBe('business')
+    const startedMs = new Date(row.started_at).getTime()
+    const dueMs = new Date(row.sla_due_at as string).getTime()
+    // Clamped to ~366 days out (no working time ever found).
+    expect(dueMs - startedMs).toBeGreaterThan(365 * DAY_MS)
+  })
+
+  it('snapshot: a calendar edit AFTER activation does not move an already-armed sla_due_at', async () => {
+    // A mutable provider — instance A arms under the weekend calendar; then we flip the provider to
+    // all-non-working. Instance A's armed deadline must NOT move (resolved asOf activation), while a
+    // NEW instance B armed after the edit reflects the change (proving the mutation actually took effect).
+    let working = true
+    const mutableProvider: WorkdayCalendarPort = {
+      resolve: async () => (working ? weekendCalendar() : allNonWorkingCalendar()),
+    }
+    registerWorkdayCalendarProvider(mutableProvider)
+    const admin = await authToken(baseUrl, 't32-admin')
+    const templateId = await publishGraphTemplate(admin, buildBusinessSlaGraph('business'))
+    const requester = await authToken(baseUrl, 't32-requester')
+
+    const instanceA = await startApproval(requester, templateId)
+    const armedA = await waitForMetrics(instanceA, (r) => r.sla_due_at !== null)
+    const armedDueA = new Date(armedA.sla_due_at as string).getTime()
+
+    // Edit the calendar after A is armed.
+    working = false
+
+    // Re-read A repeatedly — its armed deadline is a snapshot and must be stable.
+    for (let i = 0; i < 5; i++) {
+      const again = await fetchMetrics(instanceA)
+      expect(new Date(again!.sla_due_at as string).getTime()).toBe(armedDueA)
+      await new Promise((r) => setTimeout(r, 30))
+    }
+
+    // A fresh instance armed AFTER the edit sees the new (all-non-working → clamped) calendar.
+    const instanceB = await startApproval(requester, templateId)
+    const armedB = await waitForMetrics(instanceB, (r) => r.sla_due_at !== null)
+    const startedB = new Date(armedB.started_at).getTime()
+    expect(new Date(armedB.sla_due_at as string).getTime() - startedB).toBeGreaterThan(365 * DAY_MS)
+  })
+
+  it('recordNodeActivation SQL path: a business calendarSla arms sla_due_at past naive; foreign org fails open', async () => {
+    registerWorkdayCalendarProvider(weekendProvider)
+    const metrics = new ApprovalMetricsService(rawQuery)
+    const instanceId = `t32-activation-${Date.now()}`
+    await seedInstance(instanceId, 'approval_2')
+    await metrics.recordInstanceStart({ instanceId, templateId: null, startedAt: new Date(), slaHours: null, initialNodeKey: null })
+
+    const activatedAt = new Date()
+    await metrics.recordNodeActivation({
+      instanceId,
+      nodeKey: 'approval_2',
+      activatedAt,
+      timeoutEffect: 'remind',
+      calendarSla: { afterMinutes: AFTER_MINUTES, orgId: 'default' },
+    })
+    const row = await fetchMetrics(instanceId)
+    expect(row?.sla_unit).toBe('business')
+    expect(row?.sla_calendar_org_id).toBe('default')
+    const naiveMs = activatedAt.getTime() + AFTER_MINUTES * 60_000
+    expect(new Date(row!.sla_due_at as string).getTime()).toBeGreaterThan(naiveMs)
+    // current_node_deadline_at tracks the business due (effect fires at business time).
+    expect(new Date(row!.current_node_deadline_at as string).getTime())
+      .toBe(new Date(row!.sla_due_at as string).getTime())
+
+    // Foreign org: a provider that owns no calendar for that org → null → fail-open naive.
+    registerWorkdayCalendarProvider({ resolve: async (orgId) => (orgId === 'home' ? weekendCalendar() : null) })
+    const foreignId = `t32-foreign-${Date.now()}`
+    await seedInstance(foreignId, 'approval_2')
+    await metrics.recordInstanceStart({ instanceId: foreignId, templateId: null, startedAt: new Date(), slaHours: null, initialNodeKey: null })
+    const foreignActivatedAt = new Date()
+    await metrics.recordNodeActivation({
+      instanceId: foreignId,
+      nodeKey: 'approval_2',
+      activatedAt: foreignActivatedAt,
+      timeoutEffect: 'remind',
+      calendarSla: { afterMinutes: AFTER_MINUTES, orgId: 'foreign' },
+    })
+    const foreignRow = await fetchMetrics(foreignId)
+    const foreignNaive = foreignActivatedAt.getTime() + AFTER_MINUTES * 60_000
+    expect(Math.abs(new Date(foreignRow!.sla_due_at as string).getTime() - foreignNaive)).toBeLessThan(2_000)
+  })
+
+  it('breach scan (§6): a past sla_due_at row is marked breached through the real checkSlaBreaches UPDATE', async () => {
+    // Real-DB proof of the calendar branch (not just the mock unit test): a calendar row whose
+    // business-time sla_due_at is in the past — and NO sla_hours (so the legacy branch cannot match it) —
+    // must be flagged by the sla_due_at UPDATE.
+    const metrics = new ApprovalMetricsService(rawQuery)
+    const instanceId = `t32-breach-${Date.now()}`
+    await seedInstance(instanceId, 'approval_1')
+    await rawQuery(
+      `INSERT INTO approval_metrics
+         (instance_id, template_id, tenant_id, started_at, sla_hours, sla_due_at, sla_unit, node_breakdown)
+       VALUES ($1, NULL, 'default', now() - INTERVAL '2 hours', NULL,
+               now() - INTERVAL '1 minute', 'business', '[]'::jsonb)`,
+      [instanceId],
+    )
+    const breached = await metrics.checkSlaBreaches(new Date())
+    expect(breached).toContain(instanceId)
+    const row = await rawQuery<{ sla_breached: boolean; sla_breached_at: string | null }>(
+      `SELECT sla_breached, sla_breached_at FROM approval_metrics WHERE instance_id = $1`,
+      [instanceId],
+    )
+    expect(row.rows[0]?.sla_breached).toBe(true)
+    expect(row.rows[0]?.sla_breached_at).not.toBeNull()
+  })
+
+  it('legacy sla_hours path is byte-identical (no calendar columns) and still index-served', async () => {
+    const metrics = new ApprovalMetricsService(rawQuery)
+    const instanceId = `t32-legacy-${Date.now()}`
+    await seedInstance(instanceId, 'approval_1')
+    // A legacy row: sla_hours set, NO calendar SLA → sla_due_at / sla_unit stay NULL.
+    await rawQuery(
+      `INSERT INTO approval_metrics (instance_id, template_id, tenant_id, started_at, sla_hours, node_breakdown)
+       VALUES ($1, NULL, 'default', now() - INTERVAL '10 hours', 1, '[]'::jsonb)`,
+      [instanceId],
+    )
+    const seeded = await fetchMetrics(instanceId)
+    expect(seeded?.sla_hours).toBe(1)
+    expect(seeded?.sla_due_at).toBeNull()
+    expect(seeded?.sla_unit).toBeNull()
+
+    // Legacy breach scan flags it (started_at + 1h elapsed) — unchanged behavior.
+    const breached = await metrics.checkSlaBreaches(new Date())
+    expect(breached).toContain(instanceId)
+
+    // The LEGACY fallback predicate must stay INDEX-SERVED (task: "assert the fallback predicate uses an
+    // index; do not drop the current scan index"). On a pinned session with seqscan disabled the planner
+    // picks idx_approval_metrics_sla_scan for the legacy predicate.
+    const client = await poolManager.get().getInternalPool().connect()
+    let legacyText = ''
+    try {
+      await client.query('BEGIN')
+      await client.query('SET LOCAL enable_seqscan = off')
+      const legacyPlan = await client.query(
+        `EXPLAIN SELECT instance_id FROM approval_metrics
+          WHERE terminal_at IS NULL AND sla_hours IS NOT NULL AND sla_breached = FALSE
+            AND started_at + (sla_hours * interval '1 hour') < now()`,
+      )
+      await client.query('COMMIT')
+      legacyText = legacyPlan.rows.map((r) => r['QUERY PLAN']).join('\n')
+    } finally {
+      client.release()
+    }
+    expect(legacyText).toContain('idx_approval_metrics_sla_scan')
+
+    // Both partial indexes exist: the preserved legacy scan index AND the new calendar-scan index for
+    // sla_due_at. (Exact plan choice for the calendar predicate varies with table stats on a tiny test
+    // table, so servability is proven by the legacy plan above + the index's existence here.)
+    const idx = await rawQuery<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes WHERE tablename = 'approval_metrics'
+        AND indexname IN ('idx_approval_metrics_sla_scan', 'idx_approval_metrics_sla_due_scan')`,
+    )
+    const idxNames = idx.rows.map((r) => r.indexname)
+    expect(idxNames).toContain('idx_approval_metrics_sla_scan')
+    expect(idxNames).toContain('idx_approval_metrics_sla_due_scan')
+  })
+})

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -93,7 +93,12 @@ describe('ApprovalMetricsService', () => {
       expect(normalize(deadlineSql)).toContain('UPDATE approval_metrics')
       expect(normalize(deadlineSql)).toContain('SET current_node_deadline_at = $2')
       expect(normalize(deadlineSql)).toContain('current_node_timeout_effect = $3')
-      expect(deadlineParams).toEqual(['apr-1', null, null])
+      // T3-2: the same clearing UPDATE now also NULLs the calendar SLA columns (no calendarSla on this
+      // activation → sla_due_at/sla_timezone/sla_calendar_org_id/sla_unit all cleared). Legacy behavior
+      // (both T1-1 deadline columns cleared) is unchanged.
+      expect(normalize(deadlineSql)).toContain('sla_due_at = $4')
+      expect(normalize(deadlineSql)).toContain('sla_unit = $7')
+      expect(deadlineParams).toEqual(['apr-1', null, null, null, null, null, null])
 
       // Re-emit with an existing open entry → mutate returns null, `added` stays
       // false → NO breakdown UPDATE and crucially NO deadline UPDATE (this is the
@@ -133,7 +138,9 @@ describe('ApprovalMetricsService', () => {
       expect(normalize(deadlineSql)).toContain('UPDATE approval_metrics')
       expect(normalize(deadlineSql)).toContain('SET current_node_deadline_at = $2')
       expect(normalize(deadlineSql)).toContain('current_node_timeout_effect = $3')
-      expect(deadlineParams).toEqual(['apr-1', '2026-04-25T15:00:00.000Z', 'auto_reject'])
+      // T3-2: a wall-clock timeout (no calendarSla) stamps the naive deadline and leaves the calendar
+      // columns NULL — byte-identical SLA behavior, additive columns only.
+      expect(deadlineParams).toEqual(['apr-1', '2026-04-25T15:00:00.000Z', 'auto_reject', null, null, null, null])
     })
 
     it('returns silently when the instance has no metrics row', async () => {
@@ -268,21 +275,29 @@ describe('ApprovalMetricsService', () => {
   })
 
   describe('checkSlaBreaches', () => {
-    it('returns breached instance ids from the update', async () => {
-      queryMock.mockResolvedValueOnce({
-        rows: [{ instance_id: 'apr-1' }, { instance_id: 'apr-9' }],
-        rowCount: 2,
-      })
+    it('unions breached ids from the legacy (sla_hours) and calendar (sla_due_at) scans', async () => {
+      // T3-2: two UPDATEs run — the byte-identical legacy sla_hours predicate, then the calendar
+      // sla_due_at predicate — and their returned ids are merged (deduped).
+      queryMock
+        .mockResolvedValueOnce({ rows: [{ instance_id: 'apr-1' }, { instance_id: 'apr-9' }], rowCount: 2 })
+        .mockResolvedValueOnce({ rows: [{ instance_id: 'apr-9' }, { instance_id: 'apr-cal' }], rowCount: 2 })
 
       const now = new Date('2026-04-25T12:00:00Z')
       const breached = await service.checkSlaBreaches(now)
 
-      expect(breached).toEqual(['apr-1', 'apr-9'])
-      const [sql, params] = queryMock.mock.calls[0]
-      expect(normalize(sql)).toContain(`sla_breached = TRUE`)
-      expect(normalize(sql)).toContain(`started_at + (sla_hours * interval '1 hour') < $1`)
-      expect(normalize(sql)).toContain(`RETURNING instance_id`)
-      expect(params[0]).toBe('2026-04-25T12:00:00.000Z')
+      expect(breached).toEqual(['apr-1', 'apr-9', 'apr-cal'])
+      expect(queryMock).toHaveBeenCalledTimes(2)
+      // Legacy predicate is preserved byte-identical (still served by idx_approval_metrics_sla_scan).
+      const [legacySql, legacyParams] = queryMock.mock.calls[0]
+      expect(normalize(legacySql)).toContain(`sla_breached = TRUE`)
+      expect(normalize(legacySql)).toContain(`started_at + (sla_hours * interval '1 hour') < $1`)
+      expect(normalize(legacySql)).toContain(`RETURNING instance_id`)
+      expect(legacyParams[0]).toBe('2026-04-25T12:00:00.000Z')
+      // Calendar predicate keys on the absolute sla_due_at (new partial index).
+      const [calendarSql, calendarParams] = queryMock.mock.calls[1]
+      expect(normalize(calendarSql)).toContain(`sla_due_at IS NOT NULL`)
+      expect(normalize(calendarSql)).toContain(`sla_due_at < $1`)
+      expect(calendarParams[0]).toBe('2026-04-25T12:00:00.000Z')
     })
   })
 

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -497,7 +497,7 @@ describe('ApprovalMetricsService', () => {
       ])
 
       const templatesSql = normalize(queryMock.mock.calls[3][0])
-      expect(templatesSql).toContain('HAVING COUNT(*) FILTER (WHERE sla_hours IS NOT NULL) > 0')
+      expect(templatesSql).toContain('HAVING COUNT(*) FILTER (WHERE sla_hours IS NOT NULL OR sla_due_at IS NOT NULL) > 0')
       expect(templatesSql).toContain('sla_breached = TRUE')
       expect(templatesSql).toContain('LIMIT $4')
     })

--- a/packages/core-backend/tests/unit/workday-calendar-port.test.ts
+++ b/packages/core-backend/tests/unit/workday-calendar-port.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  computeWorkdayDeadline,
+  getWorkdayCalendarRegistry,
+  registerWorkdayCalendarProvider,
+  unregisterWorkdayCalendarProvider,
+  WORKDAY_SEARCH_CAP_DAYS,
+  type WorkdayCalendar,
+  type RecurringWindow,
+} from '../../src/core/workday-calendar-port'
+
+/**
+ * T3-2 — pure business-time deadline arithmetic + the WorkdayCalendarPort registry. No DB, no port
+ * resolution: computeWorkdayDeadline is a pure function over a snapshot WorkdayCalendar.
+ */
+
+function calendar(opts: {
+  tz?: string
+  workingWeekdays?: number[] // 0=Sun..6=Sat; default Mon-Fri
+  windows?: RecurringWindow[]
+  allNonWorking?: boolean
+}): WorkdayCalendar {
+  const working = opts.workingWeekdays ?? [1, 2, 3, 4, 5]
+  return {
+    timezone: opts.tz ?? 'UTC',
+    isWorkingDay: (dayIso: string) => {
+      if (opts.allNonWorking) return false
+      const wd = new Date(`${dayIso}T00:00:00Z`).getUTCDay()
+      return working.includes(wd)
+    },
+    nonCountingWindows: opts.windows ?? [],
+  }
+}
+
+describe('computeWorkdayDeadline (T3-2 pure)', () => {
+  it('counts plain wall-clock when the whole span is within one working day', () => {
+    // Mon 2026-01-05 is a working day; 120 min from 00:00 → 02:00, no skips.
+    const start = new Date('2026-01-05T00:00:00Z')
+    expect(start.getUTCDay()).toBe(1)
+    const { dueAt, clamped } = computeWorkdayDeadline(start, 120, calendar({}))
+    expect(clamped).toBe(false)
+    expect(dueAt.toISOString()).toBe('2026-01-05T02:00:00.000Z')
+  })
+
+  it('skips the weekend — business due lands strictly past the naive elapsed instant', () => {
+    // Fri 2026-01-02 23:00Z + 120 business minutes: 60 min left Fri, Sat/Sun skipped, 60 min Mon.
+    const start = new Date('2026-01-02T23:00:00Z')
+    expect(start.getUTCDay()).toBe(5) // Friday
+    const naive = new Date(start.getTime() + 120 * 60_000) // Sat 2026-01-03 01:00Z
+    const { dueAt, clamped } = computeWorkdayDeadline(start, 120, calendar({}))
+    expect(clamped).toBe(false)
+    expect(dueAt.toISOString()).toBe('2026-01-05T01:00:00.000Z') // Monday 01:00Z
+    expect(dueAt.getTime()).toBeGreaterThan(naive.getTime())
+  })
+
+  it('excludes a recurring intra-day non-counting window', () => {
+    // Working every day; the first hour [00:00,01:00) does not count. 30 min budget → 01:30.
+    const start = new Date('2026-01-05T00:00:00Z')
+    const windows: RecurringWindow[] = [{ startMinuteOfDay: 0, endMinuteOfDay: 60 }]
+    const { dueAt } = computeWorkdayDeadline(start, 30, calendar({ workingWeekdays: [0, 1, 2, 3, 4, 5, 6], windows }))
+    expect(dueAt.toISOString()).toBe('2026-01-05T01:30:00.000Z')
+  })
+
+  it('clamps + flags when no working time is found within the 366-day cap', () => {
+    const start = new Date('2026-01-05T00:00:00Z')
+    const { dueAt, clamped } = computeWorkdayDeadline(start, 60, calendar({ allNonWorking: true }))
+    expect(clamped).toBe(true)
+    // Horizon-clamped roughly to start + cap days (day-granularity hops to local midnight).
+    const minExpected = start.getTime() + (WORKDAY_SEARCH_CAP_DAYS - 1) * 86_400_000
+    expect(dueAt.getTime()).toBeGreaterThan(minExpected)
+  })
+
+  it('zero-duration returns the start instant unchanged', () => {
+    const start = new Date('2026-01-05T09:30:00Z')
+    const { dueAt, clamped } = computeWorkdayDeadline(start, 0, calendar({}))
+    expect(clamped).toBe(false)
+    expect(dueAt.toISOString()).toBe(start.toISOString())
+  })
+})
+
+describe('WorkdayCalendarRegistry (T3-2)', () => {
+  afterEach(() => {
+    unregisterWorkdayCalendarProvider()
+  })
+
+  it('binds, resolves, and unbinds a single provider (fail-open when unbound)', async () => {
+    expect(getWorkdayCalendarRegistry().has()).toBe(false)
+    expect(getWorkdayCalendarRegistry().get()).toBeUndefined()
+
+    const provider = { resolve: async () => calendar({}) }
+    registerWorkdayCalendarProvider(provider)
+    expect(getWorkdayCalendarRegistry().has()).toBe(true)
+    expect(getWorkdayCalendarRegistry().get()).toBe(provider)
+
+    unregisterWorkdayCalendarProvider()
+    expect(getWorkdayCalendarRegistry().has()).toBe(false)
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -20452,6 +20452,49 @@ module.exports = {
         context.api.events.emit(type, data)
       }
     }
+
+    // T3-2: register the working-day calendar provider (adapter) the approval SLA path consults through
+    // the WorkdayCalendarPort. This is the ONLY approval↔attendance coupling — approval never reads
+    // attendance_* tables; it calls resolve(orgId, asOf) and receives a snapshot day-mask. The adapter
+    // wraps resolveEffectiveCalendar over a bounded horizon (asOf .. asOf+368d, with a 1-day margin so
+    // every tz-day the 366-day forward walk can touch is covered) and returns an in-memory working-day set.
+    if (context?.services?.workdayCalendar?.register) {
+      try {
+        const DAY_MS = 86400000
+        context.services.workdayCalendar.register({
+          async resolve(orgId, asOf) {
+            const anchor = asOf instanceof Date ? asOf : new Date(asOf)
+            if (Number.isNaN(anchor.getTime())) return null
+            const from = new Date(anchor.getTime() - DAY_MS).toISOString().slice(0, 10)
+            const to = new Date(anchor.getTime() + 368 * DAY_MS).toISOString().slice(0, 10)
+            // A foreign / unmapped org is the provider's call — resolveEffectiveCalendar throws on
+            // invalid input, which the approval side treats as fail-open (never blocks creation).
+            const resolved = await resolveEffectiveCalendar(db, {
+              orgId: orgId || DEFAULT_ORG_ID,
+              from,
+              to,
+              orgOnly: true,
+            })
+            const working = new Set()
+            for (const item of resolved?.items || []) {
+              if (item?.effective?.isWorkingDay && typeof item.date === 'string') {
+                working.add(item.date)
+              }
+            }
+            return {
+              timezone: typeof resolved?.timezone === 'string' && resolved.timezone ? resolved.timezone : 'UTC',
+              isWorkingDay: (dayIso) => working.has(dayIso),
+              // v1: intra-day non-counting windows are not derived from attendance shifts yet — day-mask only.
+              nonCountingWindows: [],
+            }
+          },
+        })
+        logger.info('Attendance registered WorkdayCalendarPort provider for approval SLA')
+      } catch (err) {
+        logger.warn(`Attendance WorkdayCalendarPort registration failed: ${err && err.message ? err.message : err}`)
+      }
+    }
+
     async function userManagesAttendanceGroup(orgId, groupId, userId) {
       const rows = await db.query(
         `SELECT 1


### PR DESCRIPTION
Implements T3-2 per its ratified design-lock (#3513) — business/work-day calendar wired to approval SLA through a **port**, so approval never reads `attendance_*`.

## What ships
- **`WorkdayCalendarPort` (§1):** new `core/workday-calendar-port.ts` — the port interfaces + single-provider registry (unbound ⇒ fail-open) + the pure, DB-free `computeWorkdayDeadline` (tz-aware via `Intl`, counts only working-day minutes outside non-counting windows, 366-day cap). The **attendance plugin registers a provider** wrapping `resolveEffectiveCalendar`; the host injects/tracks the surface and unbinds on reload.
- **Port boundary proven:** grep confirms the approval SLA path (`ApprovalMetricsService`, `workday-calendar-port.ts`) has **zero** `attendance_*` reads and no `plugin-attendance` import — attendance table access lives solely in the plugin adapter; approval passes only the resolved org string.
- **Deadline (§3):** `recordNodeActivation`/`recordInstanceStart` compute `sla_due_at` via the port, **snapshotted `asOf` activation** (later calendar edits don't move an armed deadline). Opt-in is `NodeTimeoutConfig.unit: 'business'` (default `wall_clock` = byte-identical); `normalizeNodeTimeout` round-trips it, unknown units rejected.
- **Fail-open (§4):** provider absent / throws / null → fall back to elapsed arithmetic (`APP_TIMEZONE`→UTC), log, **never block** creation or silently disable SLA. Cap clamp logs.
- **Migration (§5):** additive nullable `sla_calendar_org_id`/`sla_timezone`/`sla_due_at`/`sla_unit` + a new partial index; **legacy `sla_hours` + its scan index untouched, no backfill**.

## Verification
tsc 0 · new real-DB `approval-calendar-sla` **10/10** (weekend calendar pushes `sla_due_at` strictly past naive via the **real approval-start + `recordNodeActivation` SQL path** with a fake port; **RED-before** no-provider→naive; fail-open absent/throwing/null-org; 366-cap; **snapshot**; foreign-org; calendar-branch breach; **legacy byte-identical + `idx_approval_metrics_sla_scan` index-served via EXPLAIN**) · port unit 6/6 · regressions node-sla 5/5, timeout-effects 13/13, full unit 4169/4169, attendance plugin 149/149.

## Reviewer decisions (honest, flagged)
- **Org mapping is degenerate today:** `ApprovalRequesterSnapshot` has no `orgId`, so `resolveCalendarSlaOrgId` always returns `'default'` — the Q2 plumbing is forward-compatible but effectively single-org. I deliberately did NOT fall back to `tenant_id` (approval-tenant vs attendance-org may be different namespaces → wrong-calendar risk). Multi-org needs a real requester→calendar-org mapping.
- **A business node emits two signals at `sla_due_at`:** the node-timeout effect (`current_node_deadline_at`) AND an instance `sla_breached` (`checkSlaBreaches` calendar branch). §6 reads as either-or; I implemented both. If only breach detection was intended, decoupling `current_node_deadline_at` removes a potential double-notify — your call.

> **Merge note:** touches `index.ts` + `ApprovalProductService.ts` alongside T3-6 (#3519). Merge the two backend PRs sequentially (rebase the second) — no logical conflict, just adjacent init/normalizer edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)