### PR TITLE
feat(integration): resolver_lookup R2 — S3-1 runtime executor integration, standalone-only (#1709)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -6428,6 +6428,109 @@ async function testReadSourceConfiguredReadRoute() {
   console.log('  testReadSourceConfiguredReadRoute OK')
 }
 
+// R2 (#1709): resolver_lookup end-to-end through the S3-2 route — approved-only, key-only, read-tier,
+// standalone (data carries ONLY the resolver target+value), no write, values-free.
+async function testReadSourceResolverReadRoute() {
+  const readArgs = []
+  const writeCalls = []
+  const resolverConfig = {
+    version: 1,
+    systemId: 'sys_1',
+    requiredKind: 'erp:k3-wise-webapi',
+    object: 'material',
+    mode: 'resolver_lookup',
+    readPath: '/K3API/Material/GetList',
+    readMethod: 'POST',
+    operations: ['read'],
+    keyField: 'FNumber',
+    containerPaths: ['Data.Rows'],
+    resolverRule: 'exactly_one',
+    fieldMap: [{ source: 'FItemID', target: 'item_id' }],
+  }
+  const services = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        return { id: input.id, kind: 'erp:k3-wise-webapi', credentials: { bearerToken: 'secret-token' }, config: { objects: {} } }
+      },
+    },
+    readSourceConfigStore: {
+      async saveVersion() { return {} },
+      async list() { return [] },
+      async get() { return {} },
+      async approve() { return {} },
+      async retire() { return {} },
+      async listAudit() { return [] },
+      async getForRuntime(input) {
+        if (input.id === 'rsc_draft') {
+          const error = new Error('not approved')
+          error.name = 'ReadSourceConfigNotApprovedError'
+          Object.setPrototypeOf(error, ReadSourceConfigNotApprovedError.prototype)
+          error.details = { id: input.id, status: 'draft' }
+          throw error
+        }
+        return { id: input.id, systemId: 'sys_1', object: 'material', mode: 'resolver_lookup', version: 1, status: 'approved', config: resolverConfig }
+      },
+    },
+    adapterRegistry: {
+      createAdapter() {
+        return {
+          async read(req) {
+            readArgs.push(req)
+            return { records: [], raw: { Data: { Rows: [{ FItemID: 4242, FName: 'SECRET-NAME', FNumber: req.filters.FNumber }] } } }
+          },
+          async upsert(b) { writeCalls.push(['upsert', b]); return {} },
+          async save(b) { writeCalls.push(['save', b]); return {} },
+        }
+      },
+    },
+  }).services
+  const { routes } = mountRoutes(services)
+
+  // exactly_one resolves; read-tier; keyed outbound read once; standalone data; no write; values-free.
+  const ok = await invoke(routes, 'POST', '/api/integration/read-source-configs/:id/read', {
+    user: READ_USER, params: { id: 'rsc_resolver' }, body: { inputs: { key: 'M-001' } },
+  })
+  assertOkResponse(ok, 200)
+  assert.equal(ok.body.data.evidence.ok, true)
+  assert.equal(ok.body.data.evidence.rule, 'exactly_one')
+  assert.equal(ok.body.data.evidence.resolved, true)
+  assert.deepEqual(ok.body.data.data, { resolver: { target: 'item_id', value: 4242 } })
+  assert.equal(readArgs.length, 1, 'exactly one outbound keyed read — no composition/chaining')
+  assert.deepEqual(readArgs[0], { object: 'material', filters: { FNumber: 'M-001' } })
+  assert.equal(writeCalls.length, 0, 'resolver is read-only — no write surface touched')
+  const evStr = JSON.stringify(ok.body.data.evidence)
+  for (const leak of ['4242', 'FItemID', 'item_id', 'FNumber', 'SECRET-NAME', 'M-001', 'secret-token', '/K3API']) {
+    assert.ok(!evStr.includes(leak), `resolver evidence must not leak ${leak}`)
+  }
+
+  // >1 candidate → AMBIGUOUS coarse code, data null (still 200 — a resolved outcome, not a route error).
+  const many = createMockServices({
+    externalSystemRegistry: { async getExternalSystemForAdapter(input) { return { id: input.id, kind: 'erp:k3-wise-webapi', credentials: {}, config: { objects: {} } } } },
+    readSourceConfigStore: {
+      async saveVersion() { return {} }, async list() { return [] }, async get() { return {} },
+      async approve() { return {} }, async retire() { return {} }, async listAudit() { return [] },
+      async getForRuntime(input) { return { id: input.id, systemId: 'sys_1', object: 'material', mode: 'resolver_lookup', version: 1, status: 'approved', config: resolverConfig } },
+    },
+    adapterRegistry: { createAdapter() { return { async read() { return { records: [], raw: { Data: { Rows: [{ FItemID: 1 }, { FItemID: 2 }] } } } }, async upsert() { return {} }, async save() { return {} } } } },
+  }).services
+  const ambRes = await invoke(mountRoutes(many).routes, 'POST', '/api/integration/read-source-configs/:id/read', {
+    user: READ_USER, params: { id: 'rsc_resolver' }, body: { inputs: { key: 'M-001' } },
+  })
+  assertOkResponse(ambRes, 200)
+  assert.equal(ambRes.body.data.evidence.ok, false)
+  assert.equal(ambRes.body.data.evidence.errorCode, 'READ_SOURCE_RESOLVER_AMBIGUOUS')
+  assert.equal(ambRes.body.data.data, null)
+
+  // approved-only still holds for resolver configs.
+  const draft = await invoke(routes, 'POST', '/api/integration/read-source-configs/:id/read', {
+    user: READ_USER, params: { id: 'rsc_draft' }, body: { inputs: { key: 'M-001' } },
+  })
+  assert.equal(draft.statusCode, 409)
+  assert.equal(draft.body.error.code, 'READ_SOURCE_CONFIG_NOT_APPROVED')
+
+  console.log('  testReadSourceResolverReadRoute OK')
+}
+
 async function main() {
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
@@ -6452,6 +6555,7 @@ async function main() {
   await testReadSourceProbeRoute()
   await testReadSourceConfigRoutes()
   await testReadSourceConfiguredReadRoute()
+  await testReadSourceResolverReadRoute()
   await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testExternalSystemTestClearsErrorToActiveOnSuccess()

--- a/plugins/plugin-integration-core/__tests__/read-source-read-runtime.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-read-runtime.test.cjs
@@ -139,12 +139,59 @@ async function testPrepareFailClosed() {
     () => prepareConfiguredRead({ config }),
     (error) => error instanceof ReadSourceProbeContractError && error.reason === 'key_required',
   )
-  // resolver_lookup runtime is a later gated slice — its multiplicity selection semantics are undesigned,
-  // so the configured read rejects the mode outright rather than silently running a plain keyed read.
-  assert.throws(
-    () => prepareConfiguredRead({ config: normalizedConfig('resolver_lookup'), inputs: { key: 'M-001' } }),
-    (error) => error instanceof ReadSourceProbeContractError && error.reason === 'mode_not_supported',
-  )
+  // R2 (#1709): resolver_lookup is now a SUPPORTED runtime mode (wired to the R1 evaluator) — prepare no
+  // longer fail-closes it; the prepared object threads the normalized config for the evaluator.
+  const resolverPrepared = prepareConfiguredRead({ config: normalizedConfig('resolver_lookup'), inputs: { key: 'M-001' } })
+  assert.equal(resolverPrepared.plan.mode, 'resolver_lookup')
+  assert.equal(resolverPrepared.config.resolverRule, 'exactly_one')
+}
+
+// R2 (#1709): resolver_lookup runs through the R1 evaluator — standalone, values-free, no write, no
+// composition. The executor does the outbound keyed read and hands the raw response to evaluateResolver.
+async function testResolverLookupRuntime() {
+  const prepared = prepareConfiguredRead({ config: normalizedConfig('resolver_lookup'), inputs: { key: 'M-001' } })
+
+  // exactly_one PASS: one candidate → resolved to the single output target+value.
+  const one = mockDeps({
+    read: (req) => ({
+      records: [{}],
+      raw: { Data: { Rows: [{ FItemID: 4242, FName: 'SIGMA-VALUE', FMaterialId: req.filters.FMaterialId }] } },
+    }),
+  })
+  const ok = await executeConfiguredRead(prepared, one.deps)
+  assert.equal(ok.evidence.ok, true)
+  assert.equal(ok.evidence.rule, 'exactly_one')
+  assert.equal(ok.evidence.resolved, true)
+  assert.equal(ok.evidence.candidateCount, 1)
+  // Data plane: ONLY the one resolver target+value — never a full row, container map, or downstream read.
+  assert.deepEqual(ok.data, { resolver: { target: 'item_id', value: 4242 } })
+  // No composition: the resolved value is not fed anywhere — exactly one outbound read, nothing chained.
+  assert.equal(one.state.readArgs.length, 1)
+  assert.deepEqual(one.state.readArgs[0], { object: 'material', filters: { FMaterialId: 'M-001' } })
+  // No write: resolver is read-only.
+  assert.equal(one.state.writeCalls.length, 0)
+  // Values-free: the resolved value, candidate field names, and key never ride into evidence.
+  const evText = JSON.stringify(ok.evidence)
+  for (const leak of ['4242', 'FItemID', 'item_id', 'FMaterialId', 'SIGMA-VALUE', 'M-001']) {
+    assert.ok(!evText.includes(leak), `resolver evidence must not leak ${leak}`)
+  }
+
+  // >1 candidate → AMBIGUOUS, data null (exactly_one keeps its own fail-closed detail, not silently first).
+  const many = mockDeps({
+    read: () => ({ records: [{}], raw: { Data: { Rows: [{ FItemID: 1 }, { FItemID: 2 }] } } }),
+  })
+  const amb = await executeConfiguredRead(prepared, many.deps)
+  assert.equal(amb.evidence.ok, false)
+  assert.equal(amb.evidence.errorCode, 'READ_SOURCE_RESOLVER_AMBIGUOUS')
+  assert.equal(amb.evidence.ambiguous, true)
+  assert.equal(amb.data, null)
+  assert.equal(many.state.writeCalls.length, 0)
+
+  // container missing → resolver coarse code, data null (no generic-mode leakage into resolver outcomes).
+  const missing = mockDeps({ read: () => ({ records: [{}], raw: { Data: {} } }) })
+  const miss = await executeConfiguredRead(prepared, missing.deps)
+  assert.equal(miss.evidence.errorCode, 'READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND')
+  assert.equal(miss.data, null)
 }
 
 async function testSingleRecordDataPlane() {
@@ -318,6 +365,7 @@ async function testTimeoutInjectableAndPathReGuard() {
 
 async function main() {
   await testPrepareFailClosed()
+  await testResolverLookupRuntime()
   await testSingleRecordDataPlane()
   await testListPageCapAndProjection()
   await testDetailWithLinesBothContainersMapped()

--- a/plugins/plugin-integration-core/__tests__/read-source-read-runtime.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-read-runtime.test.cjs
@@ -52,8 +52,8 @@ function normalizedConfig(mode, overrides = {}) {
   if (mode === 'resolver_lookup') {
     cfg.keyField = 'FMaterialId'
     cfg.containerPaths = ['Data.Rows']
-    // R0 contract shape (a valid resolver_lookup config); S3-1 still fail-closes it as mode_not_supported
-    // until R2 wires the evaluator — the executor rejects the MODE, not the contract.
+    // R2-supported resolver_lookup config shape; the executor now accepts this mode and threads the
+    // normalized config into the R1 evaluator.
     cfg.resolverRule = 'exactly_one'
     cfg.fieldMap = [{ source: 'FItemID', target: 'item_id' }]
   }

--- a/plugins/plugin-integration-core/lib/read-source-read-runtime.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-read-runtime.cjs
@@ -28,15 +28,20 @@ const {
   classifyProbeErrorCode,
   normalizeReadSourceProbeInputs,
 } = require('./read-source-probe-runtime.cjs')
+// R2 (#1709): resolver_lookup runtime = the R1 pure evaluator, wired here (standalone only). The evaluator
+// owns all multiplicity-rule selection + values-free evidence; this executor only supplies the outbound
+// keyed read + the config, then returns the evaluator's { evidence, data } verbatim.
+const { evaluateResolver } = require('./read-source-resolver-evaluator.cjs')
 const { applyReadSmokePresetOverlay } = require('./read-smoke.cjs')
 
 const CONFIGURED_READ_BODY_KEYS = Object.freeze(['config', 'inputs'])
 
-// resolver_lookup runtime is a LATER gated slice: its selection semantics (how multiplicityRuleField picks
-// among candidate rows) are not designed anywhere on this line yet, so executing it as a plain keyed read
-// would silently drop the multiplicity rule. Fail-closed reject instead — flagged, not silently dropped
-// (same discipline as the S1 marker-gating deferral in read-source-config.cjs).
-const CONFIGURED_READ_SUPPORTED_MODES = Object.freeze(['single_record', 'list_page', 'detail_with_lines'])
+// R2 (#1709, owner-authorized 2026-07-03): resolver_lookup is now a supported runtime mode — its multiplicity
+// selection semantics were designed (resolver design-lock) and implemented as the R1 pure evaluator, which
+// this executor invokes. STANDALONE ONLY: the resolver resolves one key to one value and returns it; its
+// output is NEVER fed into a second read / BOM lookup / any chained call (no composition — a separate,
+// still-ungated slice). The other three modes keep the generic field-map data plane below.
+const CONFIGURED_READ_SUPPORTED_MODES = Object.freeze(['single_record', 'list_page', 'detail_with_lines', 'resolver_lookup'])
 
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
@@ -65,6 +70,11 @@ function prepareConfiguredRead(body) {
   return Object.freeze({
     plan,
     fieldMap,
+    // R2: the S1-normalized config (body.config is byte-equal to the validator's normalized output — the
+    // S2-a contract's assertS1NormalizedConfig guarantees it) is threaded through for resolver_lookup, whose
+    // evaluator consumes resolverRule / multiplicityRuleField / resolverSortDirection /
+    // resolverDiscriminatorValue / containerPaths / fieldMap. The other modes ignore it.
+    config: body.config,
     inputs: normalizeReadSourceProbeInputs(plan, body.inputs),
   })
 }
@@ -123,7 +133,7 @@ function failureOutcome(plan, errorCode, errorType, extra) {
 // values-free in the probe vocabulary, data null on any failure. `timeoutMs` is dependency injection for
 // tests only; the platform constants are never request-reachable.
 async function executeConfiguredRead(prepared, { system, createAdapter, timeoutMs = READ_SOURCE_PROBE_TIMEOUT_MS }) {
-  const { plan, fieldMap, inputs } = prepared
+  const { plan, fieldMap, config, inputs } = prepared
   // Execution-time defense-in-depth — same re-guard as the S2-b probe: no adapter, no outbound path for
   // a readPath that lost the config-time guarantee.
   if (!isSafeRelativeReadPath(plan.readPath)) {
@@ -161,6 +171,15 @@ async function executeConfiguredRead(prepared, { system, createAdapter, timeoutM
   const raw = raced && raced.raw
   if (!isPlainObject(raw)) {
     return failureOutcome(plan, 'READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED', 'ReadSourceProbeRuntimeError')
+  }
+
+  // R2 (#1709): resolver_lookup BYPASSES the generic field-map data plane below. The R1 evaluator locates the
+  // candidate container, applies the config's multiplicity rule (exactly_one / first_when_sorted /
+  // field_equals — each with its own fail-closed detail), and returns { evidence, data } where data carries
+  // ONLY the one resolver output target+value. STANDALONE: that value is returned to the caller and NEVER
+  // fed into a second read / BOM lookup / chained call (composition is a separate, still-ungated slice).
+  if (plan.mode === 'resolver_lookup') {
+    return evaluateResolver(config, raw, { rowCap: plan.rowCap })
   }
 
   const shapes = {}


### PR DESCRIPTION
## What

**R2** of resolver_lookup — the S3-1 runtime executor integration (owner-authorized 2026-07-03 with hard boundaries). Wires the merged R1 pure evaluator into `executeConfiguredRead` so an approved resolver_lookup config actually executes at runtime. **Backend only — ZERO frontend changes** (the resolver config-authoring form is R3, explicitly out of R2).

## How

- `read-source-read-runtime.cjs`: `resolver_lookup` added to `CONFIGURED_READ_SUPPORTED_MODES`; the S1-normalized `config` (byte-equal to the validator's normalized output per assertS1NormalizedConfig) threaded through `prepareConfiguredRead`; in `executeConfiguredRead`, after the outbound keyed read yields `raw`, resolver_lookup **returns `evaluateResolver(config, raw, {rowCap})` verbatim**, BYPASSING the generic field-map data plane (which stays for the other three modes).
- **Outbound read reuses the existing builder** — `buildReadSourceProbeRequest` already routes resolver_lookup down the single_record keyed branch (filter by keyField=inputs.key); the candidate ARRAY container is what the evaluator selects from. No new outbound path.

## Hard boundaries (owner-listed, enforced + seam-commented + tested)

- **No composition** — the resolver resolves one key to one value and returns it; its output is NEVER fed into a second read / BOM lookup / chained call. Test asserts **exactly ONE outbound read** (`readArgs.length === 1`).
- **No recursive BOM, no material→FBillNo chaining.**
- **No write** — read-only; test asserts `writeCalls.length === 0`.
- **No UI expansion** — zero frontend changes (config form is R3).
- **approved-only** (getForRuntime; draft/retired → 409), **key-only** ({inputs} strict allowlist), **values-free** (evidence leak-scanned: resolved value, field names, candidate values, key, credential, path all absent).

## Verification

Full plugin `pnpm test` exit 0 (all read-source / resolver / http-routes suites); type-check clean. Route test covers: exactly_one resolves → data:{resolver:{target,value}}; >1 → AMBIGUOUS + data:null (still 200 — a resolved outcome); container-missing coarse code; single outbound read (no chaining); zero write; values-free leak scan; approved-only 409. Reviewed the no-composition seam (immediate return, no downstream), no-write reachability, and config-threading safety directly.

Completes the owner-authorized resolver R0+R1+R2 (standalone). **R3 (route/config UI), composition, recursive BOM, and write remain separately gated.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)