### PR TITLE
docs(attendance): MP-6 makeup-punch staging-smoke set (runbook + helper + bundle addendum)

### DIFF
--- a/docs/development/attendance-makeup-punch-mp6-staging-smoke-runbook-20260703.md
+++ b/docs/development/attendance-makeup-punch-mp6-staging-smoke-runbook-20260703.md
@@ -1,0 +1,472 @@
+# Attendance makeup-punch MP-6 staging smoke runbook (quota / window / type / anomaly-prefill / approval-adjusted-record)
+
+**Date:** 2026-07-03
+
+**Status:** PREPARED. This runbook does **not** claim a staging PASS. It is the
+operator checklist for closing the 补卡规则 (makeup-punch policy) MP arc on
+staging after MP-1..MP-5 are deployed. No staging run has been recorded here.
+
+Do not mark MP-6 complete from this document alone. The closeout happens only
+after a real run records the PASS stamp in the section below **and** the
+operator-decision blocks in this document are resolved.
+
+**Scope:** MP-6 proves the deployed staging build enforces the makeup-punch
+policy end to end on the existing self-service request + approval path (per the
+design lock `attendance-makeup-punch-policy-design-lock-20260626.md` §7, MP-6:
+quota / window / type / anomaly-prefill / approval-adjusted-record / residue=0).
+It adds no runtime code, no admin/delegated submit path, and no new record model
+— MP-1..MP-3 layer a configurable eligibility check plus an audit snapshot
+around the SAME `POST /api/attendance/requests` create and the SAME final
+approval that writes the adjusted record and adjustment event.
+
+## What This Proves
+
+The smoke drives the real staging API for every business write (enable the
+policy, create makeup requests, approve) and reads server truth via
+`DATABASE_URL`. It asserts, on the deployed build:
+
+1. **type / future / window / reason / attachment (fail-closed):** with
+   `makeupPunchPolicy` enabled (quota cap 1, `submitWindow.days=30`,
+   `requireReason` + `requireAttachment` on), the create path rejects, with the
+   ratified `422` codes and no persisted row:
+   - a future `workDate` → `MAKEUP_PUNCH_FUTURE_DATE_UNSUPPORTED`;
+   - a `workDate` older than the submit window → `MAKEUP_PUNCH_WINDOW_EXPIRED`;
+   - a `missed_check_in` against a server fact of `missing_check_out` →
+     `MAKEUP_PUNCH_TYPE_NOT_ALLOWED` (the type gate reads server-derived facts,
+     not client prefill);
+   - a valid fact with an empty reason → `MAKEUP_PUNCH_REASON_REQUIRED`;
+   - a valid fact with no attachment → `MAKEUP_PUNCH_ATTACHMENT_REQUIRED`.
+2. **anomaly-prefill (accepted):** a `missed_check_out` request whose SERVER
+   facts (`deriveMakeupAnomalyFacts` over a seeded `partial` record: first-in
+   present, last-out absent → `missing_check_out`) satisfy the type gate is
+   created `status='pending'` and carries a FRESH full
+   `metadata.makeupPunchPolicySnapshot` (version / enabled / timezone / cycle /
+   quota{maxRequestsPerCycle,countStatuses,principal} / submitWindow /
+   allowedAnomalyTypes / requestEvaluatedAt / matchedAnomalyTypes including
+   `missing_check_out`).
+3. **quota:** a second same-cycle valid makeup for the same subject is rejected
+   `MAKEUP_PUNCH_QUOTA_EXCEEDED` — the pending request from (2) already fills the
+   cap of 1. Quota is counted per `(org, subject user_id, calendar_month cycle)`,
+   anchored on `workDate`, not submit time; `pending` + `approved` count.
+4. **approval-adjusted-record:** approving the valid request finalizes it in one
+   admin approve — the request row becomes `status='approved'`, the
+   `attendance_records` row for the work date becomes `status='adjusted'`
+   (`upsertAttendanceRecord({ mode:'override', statusOverride:'adjusted' })`),
+   and exactly one `attendance_events` row `event_type='adjustment'` for the
+   request carries the REDUCED `meta.makeupPolicySnapshot` (gated on snapshot
+   PRESENCE, never the live policy; `quota` reduced to `{ maxRequestsPerCycle }`
+   only, `matchedAnomalyTypes` includes `missing_check_out`).
+5. **residue=0:** stamped cleanup over every table the smoke dirties
+   (`attendance_requests`, `attendance_records`, `attendance_events`, and the
+   approval-engine rows `approval_instances` / `approval_assignments` /
+   `approval_records`, plus `users` / `user_orgs`) leaves zero; the makeup smoke
+   writes NO `attendance_notification_deliveries` and asserts that category is
+   zero (coexistence with the AE / report-digest smokes).
+
+### Grounding (all on origin/main, `plugins/plugin-attendance/index.cjs`)
+
+- `DEFAULT_SETTINGS.makeupPunchPolicy` ~L284 (dormant default);
+- `MAKEUP_PUNCH_ALLOWED_REQUEST_TYPES` ~L12650 = `missed_check_in` /
+  `missed_check_out` / `time_correction`;
+- `MAKEUP_REQUEST_TYPE_ANOMALY_TABLE` ~L12727 (static type→anomaly table);
+- `deriveMakeupAnomalyFacts` ~L12739 (server-derived facts; `partial` +
+  first-in present + last-out absent → `missing_check_out`);
+- `buildMakeupPunchPolicySnapshot` ~L12812 (full snapshot);
+- `enforceMakeupPunchPolicy` ~L12843, check order future (~L12851) → window
+  (~L12857) → type (~L12862) → reason (~L12872) → attachment (~L12875) → quota
+  (~L12881); every violation is `HttpError(422, MAKEUP_PUNCH_*)`;
+- POST create enforce wiring ~L26736-26782 (settings read gated behind the
+  request-type check; enforce in-txn after the lock + duplicate guard; fresh
+  snapshot onto `draft.metadata.makeupPunchPolicySnapshot`);
+- final-approval adjusted record ~L28441-28459; adjustment event + reduced
+  `meta.makeupPolicySnapshot` ~L28546-28600 (snapshot PRESENCE gate ~L28561).
+
+## Operator-Decision Blocks (resolve before the final stamp)
+
+### OQ-1 — token mint path
+
+The staging environment sets a production node-env, under which
+`GET /api/auth/dev-token` returns `404`. Two candidate mint paths exist in the
+repo (`scripts/gen-staging-token.js` signing with the host's staging JWT secret;
+`scripts/ops/resolve-attendance-smoke-token.sh` minting inside the backend
+container) but neither is named as the approved smoke-token path by the family
+docs. **OPEN QUESTION:** the operator picks the mint path and provides
+`ADMIN_TOKEN` (`attendance:read,write,admin,approve`) plus `SUBJECT_TOKEN`
+(`attendance:read,write`) whose subject equals the synthetic subject user id —
+the makeup request is created AS the token subject, so a mismatched subject would
+attribute the row to a user this cleanup does not cover. The helper refuses a
+mismatched subject.
+
+Note: on non-staging rehearsal runs where `GET /api/auth/dev-token` IS
+available, each mint inserts a `user_sessions` row for the stamped synthetic
+users; those rows are expected out-of-ledger (no FK to `users`, not counted in
+the residue gate) and do not occur on staging where the route `404`s.
+
+### OQ-2 — `DATABASE_URL` reachability / API↔DB coherence
+
+The staging compose file publishes no host port for the database; the working
+`DATABASE_URL` (published port or tunnel endpoint) lives in host-local override
+files. **OPEN QUESTION:** verify on the host that `DATABASE_URL` reaches the SAME
+staging database as `BASE_URL` before mutating rows. The helper runs an API↔DB
+coherence probe (after the enable-PUT it confirms
+`makeupPunchPolicy.enabled=true` is visible in `system_configs` under key
+`attendance.settings`) and aborts on mismatch, but the reachable endpoint itself
+must be confirmed on the host.
+
+### OQ-3 — org scope: single-tenant posture is the real blast radius (population guard N/A)
+
+Unlike the OT-bank v1-8 settlement smoke, MP-6 has **no org-wide enumeration**:
+the quota count and the type-gate fact derivation both filter
+`user_id = <subject>`, so no non-synthetic user is read or written by the
+enforcement path. The v1-8-style settlement-population guard therefore does not
+apply here and is intentionally absent.
+
+The real MP-6 exposure is a **behavior blast radius, not data**: enabling
+`makeupPunchPolicy` flips a single GLOBAL settings row (the create path reads
+org-wide settings ~L26738), so for the duration of the window EVERY real user's
+makeup request in the org is subject to this smoke's policy. Per the MP-4 config
+lock §5 (RBAC single-tenant posture): `attendance:admin` is a **global**
+permission and `org_id` is a **partition key, not an auth boundary** — so this
+policy must be enabled only under a single-tenant / per-customer deployment
+posture. **OPEN QUESTION:** confirm the window is a single-tenant deployment (run
+on `ORG_ID=default` with a short window and a verified settings restore), OR run
+on a dedicated disposable org — noting that token issuance and route behavior for
+a non-default org id are not verified in this repo; verify on the host before
+choosing that path.
+
+### OQ-4 — approval finalization (single approve vs distinct approver / multi-step)
+
+The helper drives ONE admin approve (`POST /api/attendance/requests/:id/approve`)
+and asserts the request finalizes (`status='approved'` + adjusted record +
+adjustment event). This holds when the makeup request carries no
+`approvalFlow.steps` (`isFinalApproval` is true when `flowSteps.length === 0`,
+~L28145). **OPEN QUESTION:** confirm the staging host does not configure a
+multi-step approval flow (or a distinct-approver requirement) for makeup request
+types; if it does, provide the additional approver token(s) and drive the flow
+to final before the adjusted-record assertions. The approver is `ADMIN_TOKEN`
+(distinct from the subject); a self-approve constraint, if enforced on the host,
+is satisfied because subject ≠ admin.
+
+### OQ-5 — SQL-assert channel
+
+The request-metadata `makeupPunchPolicySnapshot` and the adjustment-event
+`meta.makeupPolicySnapshot` have no API read surface, and the `attendance_records`
+status transition is not exposed as a distinct read. Those assertions go through
+`DATABASE_URL` directly, following the attendance staging-smoke family split
+(HTTP for business writes, SQL for exact assertions). **OPEN QUESTION:** confirm
+SQL-assert is an acceptable channel for the MP-6 stamp.
+
+### OQ-6 — scheduler / expiry interference
+
+Makeup requests and adjusted records are not reaped by any scheduler, and the
+seeded `partial` records are synthetic-subject only. Whether staging runs the
+attendance scheduler / delivery worker is not knowable from the repo; MP-6 needs
+neither. **OPEN QUESTION:** none required, but note the seeded records are real
+`attendance_records` rows for the synthetic subject — the residue gate removes
+them by user prefix.
+
+## Prerequisites
+
+1. Deploy a main build that includes MP-1 (dormant `makeupPunchPolicy` config),
+   MP-2 (create/update enforcement helper), MP-3 (request metadata snapshot +
+   final approval audit meta); MP-4 (admin config UI) and MP-5 (Request Center
+   UX) are not exercised by this API/DB helper but should be on the same build
+   for the arc closeout.
+2. Staging migrations are current through the tables this smoke touches:
+   `attendance_requests`, `attendance_records`, `attendance_events`, and the
+   shared approval-engine tables (`approval_instances`, `approval_assignments`,
+   `approval_records`).
+3. `BASE_URL` points at the staging API.
+4. `DATABASE_URL` points at the same staging database (OQ-2).
+5. Authentication per OQ-1: `ADMIN_TOKEN` and a `SUBJECT_TOKEN` whose subject
+   equals the synthetic subject user id.
+6. Use only synthetic ids with an `mp6-smoke-*` prefix. Do not point cleanup at
+   real employees. Business text (reasons, seeded-record meta) carries the stamp;
+   the attachment key begins `mp6-smoke:<STAMP>:`.
+7. Run standalone, OR as the OPTIONAL 4th smoke on the same deploy SHA in the
+   bundled window (`docs/development/attendance-staging-window-bundle-20260702.md`),
+   after the previous smoke restored its settings.
+
+## Suggested Environment
+
+```bash
+BASE_URL=http://127.0.0.1:8082            # staging root via your tunnel
+DATABASE_URL=postgresql://<redacted>@127.0.0.1:5432/metasheet
+DEPLOY_SHA=<deployed-main-sha>
+ORG_ID=default                            # see OQ-3 (single-tenant posture) before accepting this
+STAMP=mp6-smoke-$(date +%s)
+ADMIN_TOKEN='<admin bearer token>'
+SUBJECT_TOKEN='<bearer, subject = <STAMP>-subject>'
+```
+
+The PASS stamp must include `DEPLOY_SHA`, `STAMP`, and residue `0`. Do not use a
+local branch SHA as the deploy SHA.
+
+## API/DB Helper
+
+Use the helper to execute the backend portions of this runbook:
+
+```bash
+BASE_URL="$BASE_URL" \
+DATABASE_URL="$DATABASE_URL" \
+DEPLOY_SHA="$DEPLOY_SHA" \
+ORG_ID="${ORG_ID:-default}" \
+STAMP="$STAMP" \
+ADMIN_TOKEN="$ADMIN_TOKEN" \
+SUBJECT_TOKEN="$SUBJECT_TOKEN" \
+node scripts/ops/staging-attendance-makeup-punch-mp6-smoke.mjs
+```
+
+The helper drives the real staging API for the settings enable, the request
+creates, and the approve; it uses SQL only for the synthetic user seed, the
+seeded `partial` records (server-fact materialization), the snapshot / record /
+event assertions, and stamped cleanup. A successful run prints:
+
+```text
+MP6_MAKEUP_PUNCH_API_DB_SMOKE_PASS deploy=<sha> stamp=<mp6-smoke-...> org=<org> quota=1 approvals=1 residue=0
+```
+
+This is **not** the final MP-6 PASS stamp. The final closeout requires the
+operator to (a) verify the deployed build (`/api/health` `build.commit` equals
+`DEPLOY_SHA`), (b) resolve the operator-decision blocks above (OQ-1 and OQ-3 at
+minimum), and (c) optionally run the MP-4/MP-5 UI probe — only then record
+`MP6_MAKEUP_PUNCH_STAGING_SMOKE_PASS`.
+
+## Preflight
+
+Run these checks before creating any business rows:
+
+1. API health returns success for the deployed build and `build.commit` equals
+   `DEPLOY_SHA`.
+2. Admin token can call `GET /api/attendance/settings` (a `401` means a
+   wrong-realm token — re-mint; a `503 DB_NOT_READY` means staging is not
+   migrated — STOP and run the migration-alignment SOP first).
+3. DB has the required tables:
+
+```sql
+SELECT to_regclass('attendance_requests') IS NOT NULL AS requests_ok,
+       to_regclass('attendance_records') IS NOT NULL AS records_ok,
+       to_regclass('attendance_events') IS NOT NULL AS events_ok,
+       to_regclass('approval_instances') IS NOT NULL AS approvals_ok;
+```
+
+4. API/DB coherence probe: after the enable-PUT, confirm
+   `makeupPunchPolicy.enabled=true` is visible through `DATABASE_URL` in
+   `system_configs` under key `attendance.settings`. Abort if API and DB are not
+   the same staging instance.
+5. Save current attendance settings so the smoke can restore them:
+
+```bash
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$BASE_URL/api/attendance/settings" > /tmp/mp6-settings-before.json
+```
+
+6. Verify zero pre-existing residue for this `STAMP` (fresh stamp per run).
+
+## Window and Seed
+
+MP-6 uses RECENT PAST work dates (the opposite of the OT-bank far-future window):
+the submit-window check requires `workDate` to be past and within
+`submitWindow.days`, and the future-date check rejects tomorrow. Because every
+enforcement read is anchored on the synthetic subject's own rows, recent dates do
+not collide with real staging data even on a shared org. The date plan (policy-tz
+`Asia/Shanghai`) derives from "today":
+
+- **valid** = today−3-ish and **quota** = today−2-ish, chosen so BOTH fall in the
+  SAME `calendar_month` cycle (quota is per-cycle) and inside the submit window;
+- **type / reason / attachment** = a few more days back (past, inside the window;
+  cycle membership is irrelevant — these requests roll back);
+- **future** = today+2 (`MAKEUP_PUNCH_FUTURE_DATE_UNSUPPORTED`);
+- **windowExpired** = today−45 (older than the 30-day submit window).
+
+Seed one disposable subject user + active org membership (SQL, upsert):
+`mp6-smoke-<stamp>-subject`. Then seed 5 `partial` `attendance_records` (SQL) for
+that subject on the valid / quota / type / reason / attachment dates: `status =
+'partial'`, `first_in_at` present, `last_out_at` NULL — so
+`deriveMakeupAnomalyFacts` yields exactly `['missing_check_out']`. This
+materializes SERVER truth; the type gate never trusts client anomaly prefill.
+
+All accrual, rejection, and approval go through the deployed API; only seed and
+assert use SQL.
+
+## Step 1 — enable the policy
+
+`PUT /api/attendance/settings` with the makeup policy (only key touched):
+
+```json
+{
+  "makeupPunchPolicy": {
+    "enabled": true,
+    "timezone": "Asia/Shanghai",
+    "cycle": { "type": "calendar_month", "startDay": 1 },
+    "quota": { "maxRequestsPerCycle": 1, "countStatuses": ["pending", "approved"], "principal": "self_service_user" },
+    "submitWindow": { "unit": "calendar_day", "days": 30 },
+    "allowedAnomalyTypes": ["missing_check_in", "missing_check_out", "late", "severe_late", "absence_late", "early_leave"],
+    "allowedRequestTypes": ["missed_check_in", "missed_check_out", "time_correction"],
+    "requireReason": true,
+    "requireAttachment": true
+  }
+}
+```
+
+`PUT /api/attendance/settings` deep-merges per policy key — this PUT does not
+disturb sibling policies, and the restore in Step 5 must therefore re-assert the
+whole makeup policy (never PUT an empty snapshot; the #3303 lesson).
+
+## Step 2 — rejection cases (fail-closed)
+
+As the subject, `POST /api/attendance/requests` (each provides the type's
+required timestamp: `requestedInAt` for `missed_check_in`, `requestedOutAt`
+otherwise):
+
+- `missed_check_out`, `workDate=<future>` → `422 MAKEUP_PUNCH_FUTURE_DATE_UNSUPPORTED`;
+- `missed_check_out`, `workDate=<today-45>` → `422 MAKEUP_PUNCH_WINDOW_EXPIRED`;
+- `missed_check_in`, `workDate=<type date>` (fact is `missing_check_out`) →
+  `422 MAKEUP_PUNCH_TYPE_NOT_ALLOWED`;
+- `missed_check_out`, empty reason → `422 MAKEUP_PUNCH_REASON_REQUIRED`;
+- `missed_check_out`, no attachment → `422 MAKEUP_PUNCH_ATTACHMENT_REQUIRED`.
+
+Each throws inside the request transaction, so no `attendance_requests` /
+`approval_instances` row is created — confirm each is `422` and rolls back.
+
+## Step 3 — valid request (anomaly-prefill accepted) + snapshot
+
+As the subject, `POST /api/attendance/requests` `missed_check_out` on the valid
+date, with a stamped reason and `metadata.attachmentUrl` → `201`, `pending`.
+
+Backend assertion (SQL): `attendance_requests.metadata->>'makeupPunchPolicySnapshot'`
+is the full snapshot — `version=1`, `enabled=true`, `quota.maxRequestsPerCycle=1`
+with `countStatuses` + `principal`, `submitWindow.days=30`, and
+`matchedAnomalyTypes` includes `missing_check_out`.
+
+## Step 4 — quota + approval-adjusted-record
+
+1. As the subject, a second `missed_check_out` on the quota date (same cycle) →
+   `422 MAKEUP_PUNCH_QUOTA_EXCEEDED` (the pending valid fills the cap of 1).
+   Confirm exactly one subject request row exists (all rejections rolled back).
+2. As admin, `POST /api/attendance/requests/:id/approve` the valid request →
+   `200`, finalized.
+
+Backend assertions (SQL):
+
+```sql
+-- request finalized
+SELECT status FROM attendance_requests WHERE id = :valid_request_id AND org_id = :org_id;  -- 'approved'
+-- adjusted record
+SELECT status FROM attendance_records WHERE org_id = :org_id AND user_id = :subject AND work_date = :valid_date;  -- 'adjusted'
+-- adjustment event with the REDUCED policy snapshot (quota = maxRequestsPerCycle only)
+SELECT meta FROM attendance_events
+WHERE org_id = :org_id AND event_type = 'adjustment' AND meta->>'requestId' = :valid_request_id;
+```
+
+Expected: exactly one adjustment event; `meta.makeupPolicySnapshot` present with
+`version=1`, `enabled=true`, `quota={ maxRequestsPerCycle: 1 }` (NO
+`countStatuses` / `principal` — the event carries the reduced summary), and
+`matchedAnomalyTypes` including `missing_check_out`.
+
+## Step 5 — cleanup and EXPLICIT settings restore
+
+Settings restore first, and never by PUT-ing an empty or partial snapshot:
+`PUT /api/attendance/settings` deep-merges per policy key, so an empty-body
+restore is a NO-OP that leaks the enabled makeup policy (the #3303 lesson).
+Restore by re-asserting the whole makeup policy — the pre-smoke `GET` returns a
+FULLY-NORMALIZED `makeupPunchPolicy`, so PUT-ing that snapshot back (with an
+`enabled:false` floor for the impossible absent-key case) restores every nested
+field. Then re-GET and verify the makeup policy compares equal (stable JSON) to
+the pre-smoke snapshot; a restore that silently leaves it enabled fails the
+smoke.
+
+Cleanup deletes only stamped/captured rows, in FK-safe order: approval records /
+assignments → adjustment events (by captured request ids) → records (by user
+prefix) → requests (by captured ids OR user prefix) → approval instances (by
+captured ids) → `user_orgs` → `users`. Deliveries are never written and never
+deleted.
+
+## Step 6 — residue check
+
+After cleanup, every category must be zero. Use the literal `:stamp` matching
+`/^mp6-smoke-[A-Za-z0-9-]+$/`, `:user_prefix = :stamp || '-'`, and the captured
+`:request_ids` / `:approval_ids`; do not use an unescaped wildcard stamp.
+
+```sql
+SELECT
+  (SELECT count(*) FROM attendance_requests
+    WHERE org_id = :org_id AND (id = ANY(:request_ids::uuid[]) OR left(user_id, length(:user_prefix)) = :user_prefix)) AS requests,
+  (SELECT count(*) FROM attendance_records
+    WHERE org_id = :org_id AND left(user_id, length(:user_prefix)) = :user_prefix) AS records,
+  (SELECT count(*) FROM attendance_events
+    WHERE org_id = :org_id AND meta->>'requestId' = ANY(:request_ids::text[])) AS events,
+  (SELECT count(*) FROM approval_instances WHERE id = ANY(:approval_ids::text[])) AS approval_instances,
+  (SELECT count(*) FROM approval_assignments WHERE instance_id = ANY(:approval_ids::text[])) AS approval_assignments,
+  (SELECT count(*) FROM approval_records WHERE instance_id = ANY(:approval_ids::text[])) AS approval_records,
+  (SELECT count(*) FROM attendance_notification_deliveries
+    WHERE org_id = :org_id AND left(recipient_user_id, length(:user_prefix)) = :user_prefix) AS deliveries,
+  (SELECT count(*) FROM user_orgs
+    WHERE org_id = :org_id AND left(user_id, length(:user_prefix)) = :user_prefix) AS user_orgs,
+  (SELECT count(*) FROM users WHERE left(id, length(:user_prefix)) = :user_prefix) AS users;
+```
+
+The approval-engine categories are counted on purpose: the request create /
+approve chain writes `approval_instances` / `approval_assignments` /
+`approval_records`, and leaving them behind is a failed smoke, not a harmless
+warning. The `deliveries` category must be zero because this smoke never writes
+notification deliveries — a non-zero count means cross-smoke interference in the
+bundled window. Do not narrow residue to only the rows that are easy to delete.
+
+## Expected PASS Stamp
+
+Use this exact shape after all steps pass and the operator-decision blocks are
+resolved:
+
+```text
+MP6_MAKEUP_PUNCH_STAGING_SMOKE_PASS deploy=<sha> stamp=<mp6-smoke-...> org=<org> quota=1 approvals=1 residue=0
+```
+
+Backfill text:
+
+> **回填（YYYY-MM-DD makeup-punch MP-6 staging closeout）**：staging smoke
+> `MP6_MAKEUP_PUNCH_STAGING_SMOKE_PASS` on deploy `<sha>`（stamp `<stamp>`）：enabled
+> makeupPunchPolicy 拒 future / window-expired / type-mismatch / empty-reason /
+> missing-attachment（5 codes fail-closed，均 rollback 无残留）；seeded partial
+> record 的 missed_check_out 以服务端 `missing_check_out` 事实通过、pending 且带
+> full snapshot；同周期第二条补卡 `MAKEUP_PUNCH_QUOTA_EXCEEDED`（cap 1）；审批通过后
+> record=adjusted、adjustment event 带 reduced `makeupPolicySnapshot`
+> （matchedAnomalyTypes=missing_check_out）；settings restored and verified；cleanup
+> residue=0（zero deliveries）。OQ-1/OQ-3 decisions recorded：`<...>`。MP-6 closed
+> ✅（delegated/admin submit + workday window 仍 gated 于 MP-v2）。
+
+## On FAIL
+
+- A future or expired-window `workDate` is accepted: the date guards regressed;
+  do not pass.
+- `missed_check_in` against a `missing_check_out` fact is accepted: the type gate
+  is trusting client prefill or not intersecting server facts; do not pass.
+- Empty reason / missing attachment is accepted while the flags are on: the
+  reason/attachment gate regressed; do not pass.
+- The valid request lands with no `makeupPunchPolicySnapshot`, or the snapshot
+  misses `matchedAnomalyTypes`: the MP-3 snapshot write regressed; do not pass.
+- The second same-cycle makeup is accepted: quota is mis-scoped (submit-time
+  instead of workDate cycle, or actor instead of subject); do not pass.
+- After approval the record is not `adjusted`, or the adjustment event lacks
+  `meta.makeupPolicySnapshot`, or that snapshot carries the FULL (not reduced)
+  quota shape: the finalize audit regressed; do not pass.
+- Settings do not compare equal after restore: the deep-merge restore hygiene
+  regressed — fix the restore before re-running anything else in the window.
+- Residue is nonzero (any category, incl deliveries): inspect the stamped rows
+  before re-running.
+
+## Safety
+
+- Uses only synthetic `mp6-smoke-*` users, seeded synthetic records, and recent
+  work dates on the subject's own rows (no real data is read or written).
+- Every enforcement read is subject-scoped, so there is no org-wide enumeration
+  (the OT-bank settlement-population guard does not apply). The single blast
+  radius is the GLOBAL settings row while the policy is enabled — mitigated by a
+  short window, the single-tenant posture (OQ-3), and a verified settings
+  restore.
+- Saves and restores attendance settings, re-asserting the whole makeup policy
+  and verifying the compare (never PUTs an empty snapshot).
+- Does not change scheduler flags, worker flags, or notification channel
+  configuration; never writes or deletes notification deliveries.
+- Does not delete by broad text/type; cleanup is stamped and keyed by captured
+  ids and the user prefix.

--- a/docs/development/attendance-staging-window-bundle-20260702.md
+++ b/docs/development/attendance-staging-window-bundle-20260702.md
@@ -23,10 +23,22 @@ run time**, never from memory.
 | 1 | **AE-4** anomaly-result-edit closeout | `docs/development/attendance-ae4-anomaly-result-edit-staging-smoke-runbook-20260701.md` | `scripts/ops/staging-attendance-ae4-result-edit-smoke.mjs` (`AE4_RESULT_EDIT_API_DB_SMOKE_PASS`) | `AE4_RESULT_EDIT_STAGING_SMOKE_PASS deploy=<sha> stamp=<ae4-smoke-...> org=<org> notifyRecord=<uuid> skipRecord=<uuid> residue=0` |
 | 2 | **RD-4/5** report-digest config card + producer/worker | `docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md` | `scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs` (`RD45_REPORT_DIGEST_API_DB_SMOKE_PASS`) | `RD45_REPORT_DIGEST_STAGING_SMOKE_PASS deploy=<sha> stamp=<rd45-smoke-...> org=<rd45-smoke-...-org> produced=<n> dedupOk=1 sendProof=<sent\|failed_recipient_not_bound\|failed_channel_not_configured> residue=0` |
 | 3 | **OT-bank v1-8** 三例验收 + settlement | `docs/development/attendance-overtime-bank-v18-staging-smoke-runbook-20260702.md` | `scripts/ops/staging-attendance-overtime-bank-v18-smoke.mjs` (`OTBANK_V18_API_DB_SMOKE_PASS`) | `OTBANK_V18_STAGING_SMOKE_PASS deploy=<sha> stamp=<otbank-v18-smoke-...> org=<org> cycle=<uuid> residue=0` |
+| 4 | **MP-6** makeup-punch (optional) | `docs/development/attendance-makeup-punch-mp6-staging-smoke-runbook-20260703.md` | `scripts/ops/staging-attendance-makeup-punch-mp6-smoke.mjs` (`MP6_MAKEUP_PUNCH_API_DB_SMOKE_PASS`) | `MP6_MAKEUP_PUNCH_STAGING_SMOKE_PASS deploy=<sha> stamp=<mp6-smoke-...> org=<org> quota=1 approvals=1 residue=0` |
 
 Each helper prints an `*_API_DB_SMOKE_PASS` line that is **not** the final
 stamp; the final `*_STAGING_SMOKE_PASS` stamps are recorded by the operator in
 the respective runbooks after the manual/decision steps there.
+
+**Optional 4th smoke (MP-6 makeup-punch).** Row 4 is an OPTIONAL addition to
+this window — it can run standalone OR as the 4th smoke on the SAME deploy SHA.
+Run it AFTER OT-bank v1-8, since it also touches `attendance_requests` /
+`attendance_records` and the approval-engine tables; its distinct `mp6-smoke-`
+stamp keeps it fully isolated from the three smokes above (which are not
+rewritten here). MP-6 enforcement is subject-scoped — no org-wide enumeration, so
+the OT-bank settlement-population guard does not apply — but enabling
+`makeupPunchPolicy` flips a GLOBAL settings row, so run it under the window's
+single-tenant posture (its runbook OQ-3 records that decision). MP-6 writes NO
+notification deliveries.
 
 ## 2. One deploy SHA for the whole window
 
@@ -150,9 +162,10 @@ residue query is anchored on the stamp — never on broad text or types:
 | AE-4 | `ae4-smoke-<suffix>-…` | `ae4-smoke:<STAMP>:…` |
 | RD-4/5 | `rd45-smoke-<suffix>-…` | `rd45-smoke:<STAMP>:…` (no occupant — digest source keys are deterministic; see the RD runbook's known-family-deviation section) |
 | OT-bank v1-8 | `otbank-v18-smoke-<suffix>-…` | `otbank-v18-smoke:<STAMP>:…` |
+| MP-6 (optional) | `mp6-smoke-<suffix>-…` | `mp6-smoke:<STAMP>:…` (attachment key only) |
 
-The three prefixes are mutually exclusive by construction, so residue queries
-cannot collide. Helpers regex-lock their stamps and refuse unstamped ids.
+The prefixes are mutually exclusive by construction, so residue queries cannot
+collide. Helpers regex-lock their stamps and refuse unstamped ids.
 
 **Settings.** `PUT /api/attendance/settings` merges per policy key, so each
 smoke PUTs ONLY its own keys and siblings survive: AE-4 owns
@@ -254,6 +267,21 @@ SELECT count(*) AS holidays FROM attendance_holidays WHERE name = :otbank_holida
 -- approval-engine rows written by the v1-8 request chain (ids captured by the helper)
 SELECT count(*) AS approval_instances FROM approval_instances WHERE id = ANY(:otbank_approval_ids::text[]);
 
+-- MP-6 makeup-punch (optional 4th smoke) — subject-scoped rows by the mp6 stamp/prefix
+-- (all zero; ids captured from the MP-6 helper run). 'mp6-smoke-' is 10 chars.
+SELECT count(*) AS mp6_requests FROM attendance_requests
+ WHERE org_id = :org_id AND (id = ANY(:mp6_request_ids::uuid[]) OR left(user_id, 10) = 'mp6-smoke-');
+SELECT count(*) AS mp6_records FROM attendance_records
+ WHERE org_id = :org_id AND left(user_id, 10) = 'mp6-smoke-';
+SELECT count(*) AS mp6_events FROM attendance_events
+ WHERE org_id = :org_id AND meta->>'requestId' = ANY(:mp6_request_ids::text[]);
+SELECT count(*) AS mp6_approval_instances FROM approval_instances WHERE id = ANY(:mp6_approval_ids::text[]);
+SELECT count(*) AS mp6_users FROM users WHERE left(id, 10) = 'mp6-smoke-';
+SELECT count(*) AS mp6_user_orgs FROM user_orgs WHERE left(user_id, 10) = 'mp6-smoke-';
+-- MP-6 writes NO deliveries — this must be 0 (never delete by source_type alone)
+SELECT count(*) AS mp6_deliveries FROM attendance_notification_deliveries
+ WHERE org_id = :org_id AND left(recipient_user_id, 10) = 'mp6-smoke-';
+
 -- settings: compare the live document to the window baseline
 -- (GET /api/attendance/settings vs /tmp/window-settings-before.json — policy keys equal)
 ```
@@ -284,6 +312,10 @@ the window baseline.
       `OTBANK_V18_STAGING_SMOKE_PASS` recorded in the v1-8 runbook with deploy
       SHA + residue 0; the v1-8 row in the overtime-bank design-verification
       doc flips to done in a follow-up docs PR (not from this plan alone).
+- [ ] MP-6 (optional): helper `MP6_MAKEUP_PUNCH_API_DB_SMOKE_PASS`; OQ-1 (token)
+      and OQ-3 (single-tenant / org) decisions recorded; final
+      `MP6_MAKEUP_PUNCH_STAGING_SMOKE_PASS` recorded in the MP-6 runbook with
+      deploy SHA + residue 0. Skip cleanly if MP-6 is not run this window.
 - [ ] Consolidated residue sweep (§7) all-zero; env flags rolled back;
       settings equal the window baseline.
 - [ ] Each stamp names the exact deployed SHA (the precedent window's missing

--- a/scripts/ops/staging-attendance-makeup-punch-mp6-smoke.mjs
+++ b/scripts/ops/staging-attendance-makeup-punch-mp6-smoke.mjs
@@ -1,0 +1,659 @@
+#!/usr/bin/env node
+// MP-6 makeup-punch staging smoke helper — quota / window / type / anomaly-prefill /
+// approval-adjusted-record / residue chain for the 补卡规则 (makeup-punch policy).
+//
+// This helper drives the real staging HTTP API for every business write (settings PUT to
+// enable makeupPunchPolicy, request create, approve) and uses SQL only for synthetic seed
+// (users + partial attendance_records that materialize the SERVER-derived anomaly facts that
+// `deriveMakeupAnomalyFacts` reads — never client anomaly prefill), exact assertions (request
+// metadata snapshot + adjustment event meta have no API read surface), and stamped cleanup. It
+// intentionally does NOT claim the final MP-6 staging closeout; the operator-decision blocks and
+// the final stamp live in
+// docs/development/attendance-makeup-punch-mp6-staging-smoke-runbook-20260703.md.
+//
+// Grounding (all on origin/main in plugins/plugin-attendance/index.cjs):
+//   DEFAULT_SETTINGS.makeupPunchPolicy L284; MAKEUP_PUNCH_ALLOWED_REQUEST_TYPES L12650;
+//   MAKEUP_REQUEST_TYPE_ANOMALY_TABLE L12727; deriveMakeupAnomalyFacts L12739;
+//   buildMakeupPunchPolicySnapshot L12812; enforceMakeupPunchPolicy L12843 (order: future L12851 →
+//   window L12857 → type L12862 → reason L12872 → attachment L12875 → quota L12881); POST enforce
+//   wiring L26736-26782; final-approval adjusted record L28441-28459 (mode:'override',
+//   statusOverride:'adjusted'); adjustment event + reduced meta.makeupPolicySnapshot L28546-28600
+//   (gated on snapshot PRESENCE L28561).
+//
+// Cases (one synthetic subject, quota cap = 1):
+//   reject: FUTURE_DATE_UNSUPPORTED (workDate = today+2, throws before type gate — no seed)
+//   reject: WINDOW_EXPIRED         (workDate = today-45, older than submitWindow.days=30)
+//   reject: TYPE_NOT_ALLOWED       (missed_check_IN against a missing_check_out fact)
+//   reject: REASON_REQUIRED        (valid fact, empty reason)
+//   reject: ATTACHMENT_REQUIRED    (valid fact, reason present, no attachmentUrl)
+//   valid : missed_check_out against a seeded partial record → pending + full snapshot
+//   quota : a second same-cycle valid makeup → QUOTA_EXCEEDED (the pending valid fills the 1 slot)
+//   approve: the valid request → adjusted record + adjustment event carrying the REDUCED snapshot
+//   residue: stamped cleanup over every dirtied table, residue=0, zero deliveries.
+
+import { randomUUID } from 'node:crypto'
+import { pathToFileURL } from 'node:url'
+
+// --- pure helpers (exported for the companion .test.mjs) -----------------------------------
+
+export const STAMP_PATTERN = /^mp6-smoke-[A-Za-z0-9-]+$/
+
+// Only makeupPunchPolicy is toggled; PUT /api/attendance/settings deep-merges per policy key, so
+// the restore re-asserts the whole normalized policy (see buildRestoreSettingsBody).
+export const RESTORED_POLICY_KEYS = ['makeupPunchPolicy']
+
+// The smoke policy: quota cap 1 makes the quota probe deterministic (one pending fills the slot);
+// requireAttachment true so the ATTACHMENT_REQUIRED code is provable (valid/quota carry a stamped
+// attachmentUrl to pass it). allowedAnomalyTypes keeps the design preset.
+export const SMOKE_TIMEZONE = 'Asia/Shanghai'
+export const SMOKE_MAX_REQUESTS = 1
+export const SMOKE_WINDOW_DAYS = 30
+
+export function buildEnabledMakeupPolicy() {
+  return {
+    enabled: true,
+    timezone: SMOKE_TIMEZONE,
+    cycle: { type: 'calendar_month', startDay: 1 },
+    quota: {
+      maxRequestsPerCycle: SMOKE_MAX_REQUESTS,
+      countStatuses: ['pending', 'approved'],
+      principal: 'self_service_user',
+    },
+    submitWindow: { unit: 'calendar_day', days: SMOKE_WINDOW_DAYS },
+    allowedAnomalyTypes: ['missing_check_in', 'missing_check_out', 'late', 'severe_late', 'absence_late', 'early_leave'],
+    allowedRequestTypes: ['missed_check_in', 'missed_check_out', 'time_correction'],
+    requireReason: true,
+    requireAttachment: true,
+  }
+}
+
+// The six enforcement codes MP-6 proves, in the order enforceMakeupPunchPolicy checks them
+// (future → window → type → reason → attachment → quota). Reference table for the .test.mjs.
+export const MAKEUP_PUNCH_CODES = Object.freeze([
+  'MAKEUP_PUNCH_FUTURE_DATE_UNSUPPORTED',
+  'MAKEUP_PUNCH_WINDOW_EXPIRED',
+  'MAKEUP_PUNCH_TYPE_NOT_ALLOWED',
+  'MAKEUP_PUNCH_REASON_REQUIRED',
+  'MAKEUP_PUNCH_ATTACHMENT_REQUIRED',
+  'MAKEUP_PUNCH_QUOTA_EXCEEDED',
+])
+
+export function stableJson(value) {
+  return JSON.stringify(value ?? null)
+}
+
+export function jwtSubject(jwt) {
+  try {
+    const seg = String(jwt).split('.')[1]
+    if (!seg) return null
+    const payload = JSON.parse(Buffer.from(seg, 'base64url').toString('utf8'))
+    return payload.id ?? payload.sub ?? payload.userId ?? null
+  } catch {
+    return null
+  }
+}
+
+export function parseJson(value) {
+  if (value == null || typeof value === 'object') return value
+  try { return JSON.parse(value) } catch { return null }
+}
+
+export function isStampedId(value, prefix) {
+  return typeof value === 'string' && value.startsWith(prefix) && value.length > prefix.length
+}
+
+export function addDaysToDateKey(ymd, days) {
+  const next = new Date(`${ymd}T00:00:00.000Z`)
+  next.setUTCDate(next.getUTCDate() + days)
+  return next.toISOString().slice(0, 10)
+}
+
+export function dayOfMonth(ymd) {
+  return Number(String(ymd).slice(8, 10))
+}
+
+export function sameCalendarMonth(a, b) {
+  return String(a).slice(0, 7) === String(b).slice(0, 7)
+}
+
+// Resolve "today" in the policy timezone (server enforce anchors workDate on policy-tz local date,
+// see toWorkDate at enforce L12848). en-CA yields YYYY-MM-DD.
+export function todayLocalKey(timezone, now = new Date()) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now)
+}
+
+// Deterministic date plan from a policy-tz "today". The VALID + QUOTA dates MUST share one
+// calendar_month cycle (startDay=1) because the quota count is per-(org,subject,cycle) — anchored
+// on workDate, not submit time. All valid/reject-at-type dates are past and inside submitWindow.days;
+// FUTURE and WINDOW dates sit safely outside on either side (±-day margins absorb midnight drift).
+export function pickMakeupDates(todayKey, { windowDays = SMOKE_WINDOW_DAYS } = {}) {
+  // quotaDate: 2 days ago, nudged off a day-1 boundary so validDate (quotaDate-1) stays same-month.
+  let quotaDate = addDaysToDateKey(todayKey, -2)
+  if (dayOfMonth(quotaDate) < 2) quotaDate = addDaysToDateKey(quotaDate, -1)
+  const validDate = addDaysToDateKey(quotaDate, -1)
+  // reject-at-type dates: only need past + within window; cycle membership is irrelevant (they roll back).
+  const typeDate = addDaysToDateKey(validDate, -1)
+  const reasonDate = addDaysToDateKey(validDate, -2)
+  const attachDate = addDaysToDateKey(validDate, -3)
+  const futureDate = addDaysToDateKey(todayKey, 2)
+  const windowExpiredDate = addDaysToDateKey(todayKey, -(windowDays + 15))
+  return { validDate, quotaDate, typeDate, reasonDate, attachDate, futureDate, windowExpiredDate }
+}
+
+// PUT /api/attendance/settings deep-merges per policy key (mergeSettings, index.cjs ~L13116), so a
+// restore that PUTs an empty/partial snapshot is a NO-OP that leaks this smoke's enabled policy.
+// getSettings returns the FULLY-NORMALIZED makeupPunchPolicy (normalizeMakeupPunchPolicySetting fills
+// every nested field from DEFAULT), so spreading the pre-smoke policy restores every field exactly;
+// the `enabled: false` floor only guards the impossible case where the key is absent.
+export function buildRestoreSettingsBody(originalSettings) {
+  const original = originalSettings && typeof originalSettings === 'object' ? originalSettings : {}
+  return {
+    ...original,
+    makeupPunchPolicy: {
+      enabled: false,
+      ...(original.makeupPunchPolicy ?? {}),
+    },
+  }
+}
+
+// Env-only contract (no CLI args), mirroring the OT-bank v1-8 helper: BASE_URL/DATABASE_URL required,
+// DEPLOY_SHA mandatory (the PASS stamp must name the staging build actually smoked), STAMP regex-locked
+// so cleanup stays visibly synthetic and LIKE-free.
+export function resolveEnvConfig(env = {}) {
+  const errors = []
+  const baseUrl = String(env.BASE_URL || env.BASE || '').replace(/\/$/, '')
+  const databaseUrl = String(env.DATABASE_URL || '')
+  const orgId = String(env.ORG_ID || 'default')
+  const deploySha = String(env.DEPLOY_SHA || env.EXPECTED_DEPLOY_SHA || '')
+  if (!baseUrl || !databaseUrl) {
+    errors.push('BASE_URL and DATABASE_URL are required.')
+  }
+  if (!deploySha || deploySha === '<fill-from-staging-build>') {
+    errors.push('DEPLOY_SHA is required so the PASS stamp names the staging build that was actually smoked.')
+  }
+  const suffix = Date.now().toString(36)
+  const stamp = String(env.STAMP || `mp6-smoke-${suffix}`)
+  if (!STAMP_PATTERN.test(stamp)) {
+    errors.push('STAMP must match /^mp6-smoke-[A-Za-z0-9-]+$/ so cleanup remains visibly synthetic and LIKE-free.')
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    config: { baseUrl, databaseUrl, orgId, deploySha, stamp, suffix },
+  }
+}
+
+// --- runtime wiring -------------------------------------------------------------------------
+
+const IS_MAIN = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false
+const ENTRY = resolveEnvConfig(process.env)
+if (IS_MAIN && !ENTRY.ok) {
+  for (const message of ENTRY.errors) console.error(`FAIL: ${message}`)
+  console.error('  e.g. BASE_URL=http://127.0.0.1:8082 DATABASE_URL=postgresql://USER@127.0.0.1:5432/metasheet DEPLOY_SHA=<deployed-sha> ADMIN_TOKEN=<jwt> SUBJECT_TOKEN=<jwt> node scripts/ops/staging-attendance-makeup-punch-mp6-smoke.mjs')
+  process.exit(2)
+}
+
+const { baseUrl: BASE_URL, databaseUrl: DATABASE_URL, orgId: ORG_ID, deploySha: DEPLOY_SHA, stamp: STAMP } = ENTRY.config
+const USER_PREFIX = `${STAMP}-`
+const KEY_PREFIX = `mp6-smoke:${STAMP}:`
+
+const USERS = {
+  admin: process.env.ADMIN_USER_ID || `${USER_PREFIX}admin`,
+  subject: process.env.SUBJECT_USER_ID || `${USER_PREFIX}subject`,
+}
+const ATTACHMENT_URL = `${KEY_PREFIX}attachment`
+
+let adminToken = process.env.ADMIN_TOKEN || process.env.SMOKE_TOKEN || process.env.TOKEN || ''
+let subjectToken = process.env.SUBJECT_TOKEN || ''
+let originalSettings = null
+let cleanupAllowed = false
+let dates = null
+let pass = 0
+const failures = []
+
+const created = {
+  requestIds: [],
+  approvalInstanceIds: new Set(),
+  validRequestId: null,
+}
+
+let pool = null
+const q = (text, params = []) => pool.query(text, params).then(result => result.rows)
+
+function ok(condition, label, detail) {
+  if (condition) {
+    pass += 1
+    console.log(`  PASS  ${label}`)
+    return
+  }
+  failures.push(label)
+  const suffix = detail === undefined ? '' : ` - ${JSON.stringify(detail)}`
+  console.error(`  FAIL  ${label}${suffix}`)
+}
+
+function assertSyntheticUser(userId, label) {
+  if (isStampedId(userId, USER_PREFIX)) return
+  throw new Error(`refusing to run: ${label} "${userId}" is not stamped with ${USER_PREFIX}. This smoke deletes its synthetic users during cleanup.`)
+}
+
+function authHeaders(token) {
+  const headers = { 'Content-Type': 'application/json', 'x-org-id': ORG_ID }
+  if (token) headers.Authorization = `Bearer ${token}`
+  return headers
+}
+
+async function api(token, pathname, { method = 'GET', body } = {}) {
+  const url = new URL(`${BASE_URL}${pathname}`)
+  if (!url.searchParams.has('orgId')) url.searchParams.set('orgId', ORG_ID)
+  const res = await fetch(url, {
+    method,
+    headers: authHeaders(token),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  let json = null
+  try { json = await res.json() } catch { /* non-json */ }
+  return { status: res.status, body: json }
+}
+
+async function mintToken(userId, { roles = 'user', perms }) {
+  const res = await api('', `/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`)
+  const token = res.body?.token || ''
+  if (!token) {
+    throw new Error(`could not mint dev-token for ${userId} (status ${res.status}); provide explicit ADMIN_TOKEN/SUBJECT_TOKEN for staging environments that 404 the dev-token route (production node-env)`)
+  }
+  return token
+}
+
+async function resolveTokens() {
+  assertSyntheticUser(USERS.admin, 'ADMIN_USER_ID')
+  assertSyntheticUser(USERS.subject, 'SUBJECT_USER_ID')
+  if (!adminToken) {
+    adminToken = await mintToken(USERS.admin, { roles: 'admin', perms: 'attendance:read,attendance:write,attendance:admin,attendance:approve' })
+    console.log('  minted admin dev-token')
+  } else {
+    const subject = jwtSubject(adminToken)
+    if (subject != null) console.log(`  using supplied admin token (subject ${subject})`)
+  }
+  if (subjectToken) {
+    // Requests are created AS the token subject; a mismatched supplied token would attribute the
+    // makeup request to a user this smoke does not clean up.
+    const subject = jwtSubject(subjectToken)
+    if (subject !== USERS.subject) {
+      throw new Error(`SUBJECT_TOKEN subject "${subject}" does not equal subject user id "${USERS.subject}"`)
+    }
+    console.log(`  using supplied subject token (subject ${subject})`)
+  } else {
+    subjectToken = await mintToken(USERS.subject, { roles: 'user', perms: 'attendance:read,attendance:write' })
+    console.log('  minted subject dev-token')
+  }
+}
+
+async function preflightDatabase() {
+  const row = (await q(
+    `SELECT
+       to_regclass('public.users') IS NOT NULL AS users_ok,
+       to_regclass('public.user_orgs') IS NOT NULL AS user_orgs_ok,
+       to_regclass('public.attendance_requests') IS NOT NULL AS requests_ok,
+       to_regclass('public.attendance_records') IS NOT NULL AS records_ok,
+       to_regclass('public.attendance_events') IS NOT NULL AS events_ok,
+       to_regclass('public.attendance_notification_deliveries') IS NOT NULL AS deliveries_ok,
+       to_regclass('public.approval_instances') IS NOT NULL AS approval_instances_ok,
+       to_regclass('public.approval_assignments') IS NOT NULL AS approval_assignments_ok,
+       to_regclass('public.approval_records') IS NOT NULL AS approval_records_ok,
+       to_regclass('public.system_configs') IS NOT NULL AS settings_ok`,
+  ))[0] || {}
+  const ready = Object.values(row).every(value => value === true)
+  ok(ready, 'DB assertion channel reachable and makeup-punch tables exist', row)
+  if (!ready) throw new Error('staging DB missing tables the MP-6 smoke needs, or DATABASE_URL points at the wrong database')
+}
+
+async function preflightNoExistingResidue() {
+  const row = (await q(
+    `SELECT
+       (SELECT count(*)::int FROM users WHERE left(id, $2) = $3) AS users,
+       (SELECT count(*)::int FROM user_orgs WHERE org_id = $1 AND left(user_id, $2) = $3) AS user_orgs,
+       (SELECT count(*)::int FROM attendance_requests WHERE org_id = $1 AND left(user_id, $2) = $3) AS requests,
+       (SELECT count(*)::int FROM attendance_records WHERE org_id = $1 AND left(user_id, $2) = $3) AS records`,
+    [ORG_ID, USER_PREFIX.length, USER_PREFIX],
+  ))[0] || {}
+  const clean = Object.values(row).every(value => Number(value) === 0)
+  ok(clean, 'no pre-existing residue for this MP-6 smoke stamp', row)
+  if (!clean) throw new Error(`pre-existing residue found for ${STAMP}; use a fresh STAMP or inspect before running`)
+}
+
+async function getSettings() {
+  const res = await api(adminToken, '/api/attendance/settings')
+  ok(res.status === 200, `GET settings through staging API (status ${res.status})`, res.body)
+  if (res.status !== 200) throw new Error('cannot read attendance settings')
+  return res.body?.data ?? {}
+}
+
+async function enableMakeupPolicy() {
+  const res = await api(adminToken, '/api/attendance/settings', { method: 'PUT', body: { makeupPunchPolicy: buildEnabledMakeupPolicy() } })
+  ok(res.status === 200, `enable makeupPunchPolicy (quota=${SMOKE_MAX_REQUESTS}, window=${SMOKE_WINDOW_DAYS}d) (status ${res.status})`, res.body)
+  if (res.status !== 200) throw new Error('failed to enable makeupPunchPolicy')
+}
+
+async function verifySettingsCoherence() {
+  const row = (await q(
+    `SELECT value::jsonb #> '{makeupPunchPolicy,enabled}' AS enabled
+     FROM system_configs
+     WHERE key = 'attendance.settings'
+     LIMIT 1`,
+  ))[0]
+  const enabled = row?.enabled
+  ok(enabled === true, 'API settings write is visible through DATABASE_URL (makeupPunchPolicy.enabled=true)', row)
+  if (enabled !== true) throw new Error('BASE_URL and DATABASE_URL do not appear coherent for attendance settings')
+}
+
+function assertWindow() {
+  const d = dates
+  const today = todayLocalKey(SMOKE_TIMEZONE)
+  const withinWindow = (key) => today > key && addDaysToDateKey(today, -SMOKE_WINDOW_DAYS) <= key
+  ok(sameCalendarMonth(d.validDate, d.quotaDate), 'valid + quota dates share one calendar_month cycle (quota is per-cycle)', d)
+  ok(d.quotaDate === addDaysToDateKey(d.validDate, 1), 'quotaDate is the day after validDate', d)
+  ok([d.validDate, d.quotaDate, d.typeDate, d.reasonDate, d.attachDate].every(withinWindow), 'all makeup work dates are past and inside the submit window', d)
+  ok(d.futureDate > today, 'futureDate is strictly in the future', { today, futureDate: d.futureDate })
+  ok(addDaysToDateKey(today, -SMOKE_WINDOW_DAYS) > d.windowExpiredDate, 'windowExpiredDate is older than the submit window', { today, windowExpiredDate: d.windowExpiredDate })
+}
+
+async function seedUsers() {
+  const userId = USERS.subject
+  assertSyntheticUser(userId, 'subject user')
+  await pool.query(
+    `INSERT INTO users (id, email, password_hash, name, role, is_active)
+     VALUES ($1, $2, 'no-login', $3, 'user', true)
+     ON CONFLICT (id) DO UPDATE SET is_active = true, email = EXCLUDED.email, name = EXCLUDED.name`,
+    [userId, `${userId}@example.test`, userId],
+  )
+  await pool.query(
+    `INSERT INTO user_orgs (user_id, org_id, is_active)
+     VALUES ($1, $2, true)
+     ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = true`,
+    [userId, ORG_ID],
+  )
+  cleanupAllowed = true
+  ok(true, 'seeded synthetic subject user + org membership', { stamp: STAMP })
+}
+
+// Seed a `partial` attendance_record (one side punched): first_in_at present, last_out_at NULL →
+// deriveMakeupAnomalyFacts (L12758-12760) yields exactly ['missing_check_out']. This materializes
+// SERVER truth so the type gate reads a real fact — not client anomaly prefill.
+async function seedPartialRecord(workDate, label) {
+  await pool.query(
+    `INSERT INTO attendance_records
+       (user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta, updated_at)
+     VALUES ($1, $2, $3, $4, $5, NULL, 0, 0, 0, 'partial', true, $6::jsonb, now())
+     ON CONFLICT (user_id, work_date, org_id)
+     DO UPDATE SET status = 'partial', first_in_at = EXCLUDED.first_in_at, last_out_at = NULL, meta = EXCLUDED.meta, updated_at = now()`,
+    [USERS.subject, ORG_ID, workDate, SMOKE_TIMEZONE, `${workDate}T01:00:00.000Z`, JSON.stringify({ smokeStamp: STAMP, seed: label })],
+  )
+}
+
+async function seedAnomalies() {
+  await seedPartialRecord(dates.validDate, 'valid')
+  await seedPartialRecord(dates.quotaDate, 'quota')
+  await seedPartialRecord(dates.typeDate, 'type')
+  await seedPartialRecord(dates.reasonDate, 'reason')
+  await seedPartialRecord(dates.attachDate, 'attachment')
+  ok(true, 'seeded 5 synthetic partial records (missing_check_out fact) for the subject', { dates })
+}
+
+async function captureApprovalInstanceId(requestId) {
+  const rows = await q('SELECT approval_instance_id FROM attendance_requests WHERE id = $1 AND org_id = $2', [requestId, ORG_ID])
+  const approvalId = rows[0]?.approval_instance_id
+  if (approvalId) created.approvalInstanceIds.add(String(approvalId))
+}
+
+async function postRequest(body) {
+  const res = await api(subjectToken, '/api/attendance/requests', { method: 'POST', body: { orgId: ORG_ID, ...body } })
+  const id = res.body?.data?.request?.id ?? null
+  if (id) {
+    created.requestIds.push(String(id))
+    await captureApprovalInstanceId(id)
+  }
+  return { res, id }
+}
+
+function makeupBody(workDate, requestType, { reason, attachment = true } = {}) {
+  const body = {
+    workDate,
+    requestType,
+    reason: reason === undefined ? `MP-6 smoke ${STAMP} ${requestType} ${workDate}` : reason,
+    metadata: attachment ? { attachmentUrl: ATTACHMENT_URL } : {},
+  }
+  if (requestType === 'missed_check_in') body.requestedInAt = `${workDate}T01:00:00.000Z`
+  else body.requestedOutAt = `${workDate}T10:00:00.000Z`
+  return body
+}
+
+async function expectRejection(body, expectedCode, label) {
+  const { res, id } = await postRequest(body)
+  ok(res.status === 422 && res.body?.error?.code === expectedCode, `${label} → 422 ${expectedCode}`, { status: res.status, code: res.body?.error?.code })
+  if (id) throw new Error(`${label}: a rejected makeup request unexpectedly created request row ${id}`)
+}
+
+async function approveRequest(requestId) {
+  return api(adminToken, `/api/attendance/requests/${requestId}/approve`, {
+    method: 'POST',
+    body: { comment: `MP-6 smoke ${STAMP} approve` },
+  })
+}
+
+// --- phases ----------------------------------------------------------------------------------
+
+async function runRejectionCases() {
+  // FUTURE and WINDOW throw before the type gate (no seed needed); the rest need a seeded fact.
+  await expectRejection(makeupBody(dates.futureDate, 'missed_check_out'), 'MAKEUP_PUNCH_FUTURE_DATE_UNSUPPORTED', 'future workDate')
+  await expectRejection(makeupBody(dates.windowExpiredDate, 'missed_check_out'), 'MAKEUP_PUNCH_WINDOW_EXPIRED', 'expired-window workDate')
+  await expectRejection(makeupBody(dates.typeDate, 'missed_check_in'), 'MAKEUP_PUNCH_TYPE_NOT_ALLOWED', 'missed_check_in against a missing_check_out fact')
+  await expectRejection(makeupBody(dates.reasonDate, 'missed_check_out', { reason: '' }), 'MAKEUP_PUNCH_REASON_REQUIRED', 'empty reason')
+  await expectRejection(makeupBody(dates.attachDate, 'missed_check_out', { attachment: false }), 'MAKEUP_PUNCH_ATTACHMENT_REQUIRED', 'missing attachment')
+}
+
+function assertFullSnapshot(snapshot) {
+  const okShape = snapshot
+    && snapshot.version === 1
+    && snapshot.enabled === true
+    && snapshot.timezone === SMOKE_TIMEZONE
+    && snapshot.cycle?.type === 'calendar_month'
+    && snapshot.cycle?.startDay === 1
+    && Number(snapshot.quota?.maxRequestsPerCycle) === SMOKE_MAX_REQUESTS
+    && Array.isArray(snapshot.quota?.countStatuses)
+    && snapshot.quota?.principal === 'self_service_user'
+    && snapshot.submitWindow?.unit === 'calendar_day'
+    && Number(snapshot.submitWindow?.days) === SMOKE_WINDOW_DAYS
+    && Array.isArray(snapshot.allowedAnomalyTypes)
+    && typeof snapshot.requestEvaluatedAt === 'string'
+    && Array.isArray(snapshot.matchedAnomalyTypes)
+    && snapshot.matchedAnomalyTypes.includes('missing_check_out')
+  ok(Boolean(okShape), 'valid request: metadata.makeupPunchPolicySnapshot carries the FULL snapshot (matched=missing_check_out)', snapshot)
+}
+
+async function runValidAndQuota() {
+  // VALID (anomaly-prefill accepted): created pending with a fresh full snapshot on the metadata.
+  const valid = await postRequest(makeupBody(dates.validDate, 'missed_check_out'))
+  ok(valid.res.status === 201 && valid.id, `valid missed_check_out created pending (status ${valid.res.status})`, valid.res.body)
+  if (!valid.id) throw new Error('valid makeup request creation failed')
+  created.validRequestId = valid.id
+
+  const metaRows = await q('SELECT status, metadata FROM attendance_requests WHERE id = $1 AND org_id = $2', [valid.id, ORG_ID])
+  ok(metaRows[0]?.status === 'pending', 'valid request row is status=pending before approval', metaRows[0]?.status)
+  const snapshot = (parseJson(metaRows[0]?.metadata) ?? {}).makeupPunchPolicySnapshot ?? null
+  assertFullSnapshot(snapshot)
+
+  // QUOTA: a second same-cycle valid makeup — the pending valid fills the cap of 1 → rejected.
+  await expectRejection(makeupBody(dates.quotaDate, 'missed_check_out'), 'MAKEUP_PUNCH_QUOTA_EXCEEDED', 'second same-cycle makeup')
+
+  // Every reject rolled back: exactly the one pending valid row remains for the subject.
+  const countRows = await q('SELECT count(*)::int AS total FROM attendance_requests WHERE org_id = $1 AND left(user_id, $2) = $3', [ORG_ID, USER_PREFIX.length, USER_PREFIX])
+  ok(Number(countRows[0]?.total) === 1, 'exactly one subject request row exists (all rejections rolled back)', countRows[0])
+}
+
+async function runApprovalAdjustedRecord() {
+  const approve = await approveRequest(created.validRequestId)
+  ok(approve.status === 200, `valid request approved (status ${approve.status})`, approve.body)
+
+  const reqRows = await q('SELECT status FROM attendance_requests WHERE id = $1 AND org_id = $2', [created.validRequestId, ORG_ID])
+  ok(reqRows[0]?.status === 'approved', 'approved request row is status=approved', reqRows[0]?.status)
+
+  const recordRows = await q('SELECT status FROM attendance_records WHERE org_id = $1 AND user_id = $2 AND work_date = $3', [ORG_ID, USERS.subject, dates.validDate])
+  ok(recordRows[0]?.status === 'adjusted', 'attendance_record for the valid work date is status=adjusted (makeup applied)', recordRows[0]?.status)
+
+  const eventRows = await q(
+    `SELECT meta FROM attendance_events
+     WHERE org_id = $1 AND event_type = 'adjustment' AND meta->>'requestId' = $2`,
+    [ORG_ID, created.validRequestId],
+  )
+  ok(eventRows.length === 1, 'exactly one adjustment event exists for the approved makeup request', { count: eventRows.length })
+  const eventMeta = parseJson(eventRows[0]?.meta) ?? {}
+  const snap = eventMeta.makeupPolicySnapshot ?? null
+  // The event meta carries the REDUCED snapshot (L28568-28580): quota is { maxRequestsPerCycle } ONLY.
+  const reducedOk = snap
+    && snap.version === 1
+    && snap.enabled === true
+    && Number(snap.quota?.maxRequestsPerCycle) === SMOKE_MAX_REQUESTS
+    && snap.quota?.countStatuses === undefined
+    && snap.quota?.principal === undefined
+    && Array.isArray(snap.matchedAnomalyTypes)
+    && snap.matchedAnomalyTypes.includes('missing_check_out')
+    && typeof snap.requestEvaluatedAt === 'string'
+  ok(Boolean(reducedOk), 'adjustment event meta carries the REDUCED makeupPolicySnapshot (quota=maxRequestsPerCycle only)', snap)
+}
+
+// --- cleanup / residue -----------------------------------------------------------------------
+
+async function residueCounts() {
+  const requestIds = created.requestIds
+  const approvalIds = Array.from(created.approvalInstanceIds)
+  const row = (await q(
+    `SELECT
+       (SELECT count(*)::int FROM attendance_requests
+         WHERE org_id = $1 AND (id = ANY($4::uuid[]) OR left(user_id, $2) = $3)) AS requests,
+       (SELECT count(*)::int FROM attendance_records WHERE org_id = $1 AND left(user_id, $2) = $3) AS records,
+       (SELECT count(*)::int FROM attendance_events
+         WHERE org_id = $1 AND meta->>'requestId' = ANY($5::text[])) AS events,
+       (SELECT count(*)::int FROM approval_instances WHERE id = ANY($6::text[])) AS approval_instances,
+       (SELECT count(*)::int FROM approval_assignments WHERE instance_id = ANY($6::text[])) AS approval_assignments,
+       (SELECT count(*)::int FROM approval_records WHERE instance_id = ANY($6::text[])) AS approval_records,
+       (SELECT count(*)::int FROM attendance_notification_deliveries
+         WHERE org_id = $1 AND left(recipient_user_id, $2) = $3) AS deliveries,
+       (SELECT count(*)::int FROM user_orgs WHERE org_id = $1 AND left(user_id, $2) = $3) AS user_orgs,
+       (SELECT count(*)::int FROM users WHERE left(id, $2) = $3) AS users`,
+    [ORG_ID, USER_PREFIX.length, USER_PREFIX, requestIds, requestIds, approvalIds],
+  ))[0] || {}
+  return row
+}
+
+async function restoreSettings({ strict = false } = {}) {
+  if (!originalSettings) return
+  const res = await api(adminToken, '/api/attendance/settings', { method: 'PUT', body: buildRestoreSettingsBody(originalSettings) })
+  if (strict) {
+    ok(res.status === 200, `restore original attendance settings (status ${res.status})`, res.body)
+    if (res.status !== 200) throw new Error('failed to restore original attendance settings')
+    const restored = await getSettings()
+    for (const key of RESTORED_POLICY_KEYS) {
+      const restoredPolicy = restored[key] ?? null
+      const originalPolicy = originalSettings[key] ?? null
+      ok(stableJson(restoredPolicy) === stableJson(originalPolicy), `restored ${key} matches the pre-smoke value`, restoredPolicy)
+      if (stableJson(restoredPolicy) !== stableJson(originalPolicy)) {
+        throw new Error(`${key} did not restore to its pre-smoke value`)
+      }
+    }
+    return
+  }
+  if (res.status !== 200) {
+    console.error(`WARN: failed to restore attendance settings (status ${res.status})`)
+  }
+}
+
+async function cleanup({ strictSettingsRestore = false } = {}) {
+  if (!cleanupAllowed) return
+  await restoreSettings({ strict: strictSettingsRestore }).catch(error => {
+    if (strictSettingsRestore) throw error
+    console.error(`WARN: failed to restore attendance settings: ${error?.message || error}`)
+  })
+  const requestIds = created.requestIds
+  const approvalIds = Array.from(created.approvalInstanceIds)
+  // FK-safe order: approval children → adjustment events → records → requests (which FK
+  // approval_instance_id) → approval instances → user_orgs (FK users) → users. Deliveries are never
+  // written by this smoke, so they are asserted zero but never deleted.
+  await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds]).catch(() => undefined)
+  await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds]).catch(() => undefined)
+  await pool.query(`DELETE FROM attendance_events WHERE org_id = $1 AND meta->>'requestId' = ANY($2::text[])`, [ORG_ID, requestIds]).catch(() => undefined)
+  await pool.query('DELETE FROM attendance_records WHERE org_id = $1 AND left(user_id, $2) = $3', [ORG_ID, USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+  await pool.query('DELETE FROM attendance_requests WHERE org_id = $1 AND (id = ANY($2::uuid[]) OR left(user_id, $3) = $4)', [ORG_ID, requestIds, USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+  await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds]).catch(() => undefined)
+  await pool.query('DELETE FROM user_orgs WHERE org_id = $1 AND left(user_id, $2) = $3', [ORG_ID, USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+  await pool.query('DELETE FROM users WHERE left(id, $1) = $2', [USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+}
+
+// --- main ------------------------------------------------------------------------------------
+
+async function main() {
+  console.log(`MP-6 makeup-punch API/DB staging smoke helper @ ${BASE_URL}`)
+  console.log(`  deploy=${DEPLOY_SHA} org=${ORG_ID} stamp=${STAMP}`)
+  console.log('  NOTE: this helper does not close MP-6 by itself; record the final stamp only through the MP-6 runbook after its operator-decision blocks are resolved.')
+
+  await resolveTokens()
+  await preflightDatabase()
+  await preflightNoExistingResidue()
+  originalSettings = await getSettings()
+
+  const today = todayLocalKey(SMOKE_TIMEZONE)
+  dates = pickMakeupDates(today)
+  console.log(`  policy-tz today=${today} (${SMOKE_TIMEZONE})`)
+  assertWindow()
+
+  await seedUsers()
+  await enableMakeupPolicy()
+  await verifySettingsCoherence()
+  await seedAnomalies()
+
+  await runRejectionCases()
+  await runValidAndQuota()
+  await runApprovalAdjustedRecord()
+
+  await cleanup({ strictSettingsRestore: true })
+  const residue = await residueCounts()
+  const residueOk = Object.values(residue).every(value => Number(value) === 0)
+  ok(residueOk, 'cleanup residue is zero (incl zero notification deliveries)', residue)
+  if (!residueOk) throw new Error(`residue not zero: ${JSON.stringify(residue)}`)
+  if (failures.length) {
+    throw new Error(`MP-6 makeup-punch API/DB smoke had ${failures.length} failed assertion(s): ${failures.join('; ')}`)
+  }
+
+  console.log(`MP6_MAKEUP_PUNCH_API_DB_SMOKE_PASS deploy=${DEPLOY_SHA} stamp=${STAMP} org=${ORG_ID} quota=${SMOKE_MAX_REQUESTS} approvals=1 residue=0`)
+  console.log(`Assertions passed: ${pass}`)
+}
+
+if (IS_MAIN) {
+  let pg
+  try {
+    pg = await import('pg')
+  } catch {
+    console.error('FAIL: package "pg" is required. Run this helper from a prepared metasheet2 checkout with dependencies installed.')
+    process.exit(2)
+  }
+  pool = new pg.default.Pool({ connectionString: DATABASE_URL })
+  main()
+    .catch(async (error) => {
+      console.error(`FAIL: ${error?.message || error}`)
+      try {
+        await cleanup()
+        const residue = await residueCounts()
+        console.error(`Residue after best-effort cleanup: ${JSON.stringify(residue)}`)
+      } catch (cleanupError) {
+        console.error(`WARN: cleanup failed: ${cleanupError?.message || cleanupError}`)
+      }
+      process.exitCode = 1
+    })
+    .finally(async () => {
+      await pool.end().catch(() => undefined)
+    })
+}

--- a/scripts/ops/staging-attendance-makeup-punch-mp6-smoke.test.mjs
+++ b/scripts/ops/staging-attendance-makeup-punch-mp6-smoke.test.mjs
@@ -1,0 +1,212 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import {
+  STAMP_PATTERN,
+  RESTORED_POLICY_KEYS,
+  SMOKE_TIMEZONE,
+  SMOKE_MAX_REQUESTS,
+  SMOKE_WINDOW_DAYS,
+  MAKEUP_PUNCH_CODES,
+  buildEnabledMakeupPolicy,
+  buildRestoreSettingsBody,
+  addDaysToDateKey,
+  dayOfMonth,
+  sameCalendarMonth,
+  pickMakeupDates,
+  isStampedId,
+  resolveEnvConfig,
+} from './staging-attendance-makeup-punch-mp6-smoke.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const script = readFileSync(join(here, 'staging-attendance-makeup-punch-mp6-smoke.mjs'), 'utf8')
+const runbook = readFileSync(join(here, '../../docs/development/attendance-makeup-punch-mp6-staging-smoke-runbook-20260703.md'), 'utf8')
+
+test('MP-6 env contract: BASE_URL/DATABASE_URL/DEPLOY_SHA required, STAMP regex-locked, defaults applied', () => {
+  const missing = resolveEnvConfig({})
+  assert.equal(missing.ok, false)
+  assert.ok(missing.errors.some(msg => msg.includes('BASE_URL and DATABASE_URL')))
+  assert.ok(missing.errors.some(msg => msg.includes('DEPLOY_SHA is required')))
+
+  const placeholder = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: '<fill-from-staging-build>',
+  })
+  assert.equal(placeholder.ok, false)
+  assert.ok(placeholder.errors.some(msg => msg.includes('DEPLOY_SHA is required')))
+
+  const good = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082/',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: 'abc123def456',
+  })
+  assert.equal(good.ok, true)
+  assert.equal(good.config.baseUrl, 'http://127.0.0.1:8082', 'trailing slash stripped')
+  assert.equal(good.config.orgId, 'default')
+  assert.match(good.config.stamp, STAMP_PATTERN)
+  assert.ok(good.config.stamp.startsWith('mp6-smoke-'))
+
+  const badStamp = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: 'abc123def456',
+    STAMP: 'otbank-v18-smoke-wrong-family',
+  })
+  assert.equal(badStamp.ok, false)
+  assert.ok(badStamp.errors.some(msg => msg.includes('mp6-smoke')))
+})
+
+test('MP-6 enabled policy body matches the design preset (quota cap 1, 30d window, both requires on)', () => {
+  const policy = buildEnabledMakeupPolicy()
+  assert.equal(policy.enabled, true)
+  assert.equal(policy.timezone, SMOKE_TIMEZONE)
+  assert.equal(policy.cycle.type, 'calendar_month')
+  assert.equal(policy.cycle.startDay, 1)
+  assert.equal(policy.quota.maxRequestsPerCycle, SMOKE_MAX_REQUESTS)
+  assert.equal(SMOKE_MAX_REQUESTS, 1, 'cap 1 makes the quota probe deterministic (one pending fills the slot)')
+  assert.deepEqual(policy.quota.countStatuses, ['pending', 'approved'])
+  assert.equal(policy.quota.principal, 'self_service_user')
+  assert.equal(policy.submitWindow.unit, 'calendar_day')
+  assert.equal(policy.submitWindow.days, SMOKE_WINDOW_DAYS)
+  assert.ok(policy.allowedAnomalyTypes.includes('missing_check_out'), 'the valid missed_check_out fact must be an allowed anomaly')
+  assert.deepEqual(policy.allowedRequestTypes, ['missed_check_in', 'missed_check_out', 'time_correction'])
+  assert.equal(policy.requireReason, true)
+  assert.equal(policy.requireAttachment, true, 'requireAttachment on so ATTACHMENT_REQUIRED is provable')
+})
+
+test('MP-6 date plan: valid+quota share one calendar_month cycle, all within window, future/expired outside', () => {
+  // Sweep a full year of "today" anchors incl. month starts/ends and Feb boundaries.
+  const anchors = []
+  for (let m = 1; m <= 12; m += 1) {
+    for (const day of [1, 2, 3, 15, 27, 28]) {
+      anchors.push(`2027-${String(m).padStart(2, '0')}-${String(day).padStart(2, '0')}`)
+    }
+  }
+  anchors.push('2028-02-29', '2028-03-01', '2027-01-01', '2027-12-31')
+
+  for (const today of anchors) {
+    const d = pickMakeupDates(today, { windowDays: SMOKE_WINDOW_DAYS })
+    const all = [d.validDate, d.quotaDate, d.typeDate, d.reasonDate, d.attachDate]
+
+    assert.ok(sameCalendarMonth(d.validDate, d.quotaDate), `${today}: valid+quota same cycle`)
+    assert.equal(d.quotaDate, addDaysToDateKey(d.validDate, 1), `${today}: quota is day after valid`)
+    assert.ok(dayOfMonth(d.quotaDate) >= 2, `${today}: quotaDate nudged off day-1 so valid stays same month`)
+
+    // every makeup date is strictly past and inside the submit window
+    for (const date of all) {
+      assert.ok(date < today, `${today}: ${date} must be past`)
+      assert.ok(addDaysToDateKey(today, -SMOKE_WINDOW_DAYS) <= date, `${today}: ${date} inside submit window`)
+    }
+    // all distinct
+    assert.equal(new Set(all).size, all.length, `${today}: makeup dates are distinct`)
+
+    assert.ok(d.futureDate > today, `${today}: future date is future`)
+    assert.ok(addDaysToDateKey(today, -SMOKE_WINDOW_DAYS) > d.windowExpiredDate, `${today}: expired date beyond window`)
+  }
+})
+
+test('MP-6 the six enforcement codes are the ratified makeup-punch codes in enforce order', () => {
+  assert.deepEqual(MAKEUP_PUNCH_CODES, [
+    'MAKEUP_PUNCH_FUTURE_DATE_UNSUPPORTED',
+    'MAKEUP_PUNCH_WINDOW_EXPIRED',
+    'MAKEUP_PUNCH_TYPE_NOT_ALLOWED',
+    'MAKEUP_PUNCH_REASON_REQUIRED',
+    'MAKEUP_PUNCH_ATTACHMENT_REQUIRED',
+    'MAKEUP_PUNCH_QUOTA_EXCEEDED',
+  ])
+  // every code the helper asserts must be a ratified code
+  for (const code of MAKEUP_PUNCH_CODES) {
+    assert.match(script, new RegExp(code), `${code} is asserted by the helper`)
+  }
+})
+
+test('MP-6 settings restore body never PUTs an empty snapshot (deep-merge #3303 lesson)', () => {
+  assert.deepEqual(RESTORED_POLICY_KEYS, ['makeupPunchPolicy'])
+
+  const fromEmpty = buildRestoreSettingsBody({})
+  assert.ok(fromEmpty.makeupPunchPolicy && typeof fromEmpty.makeupPunchPolicy === 'object', 'makeupPunchPolicy explicitly re-asserted')
+  assert.equal(fromEmpty.makeupPunchPolicy.enabled, false, 'defaults to disabled when the pre-smoke settings never carried it')
+
+  // getSettings returns a fully-normalized policy, so a real pre-smoke policy is restored verbatim.
+  const original = {
+    someSiblingPolicy: { enabled: true, keep: 'me' },
+    makeupPunchPolicy: { enabled: true, timezone: 'UTC', quota: { maxRequestsPerCycle: 5, countStatuses: ['pending'], principal: 'self_service_user' } },
+  }
+  const restored = buildRestoreSettingsBody(original)
+  assert.deepEqual(restored.someSiblingPolicy, { enabled: true, keep: 'me' }, 'sibling policies pass through untouched')
+  assert.equal(restored.makeupPunchPolicy.enabled, true, 'a genuinely-enabled pre-smoke policy is restored enabled')
+  assert.equal(restored.makeupPunchPolicy.quota.maxRequestsPerCycle, 5, 'the pre-smoke nested value is carried back')
+})
+
+test('MP-6 synthetic-id predicate refuses unstamped ids', () => {
+  assert.equal(isStampedId('mp6-smoke-abc-subject', 'mp6-smoke-abc-'), true)
+  assert.equal(isStampedId('mp6-smoke-abc-', 'mp6-smoke-abc-'), false, 'bare prefix is not a user id')
+  assert.equal(isStampedId('real-employee-42', 'mp6-smoke-abc-'), false)
+  assert.equal(isStampedId(null, 'mp6-smoke-abc-'), false)
+})
+
+test('MP-6 helper does not claim the final staging pass', () => {
+  assert.match(script, /MP6_MAKEUP_PUNCH_API_DB_SMOKE_PASS/)
+  assert.doesNotMatch(script, /MP6_MAKEUP_PUNCH_STAGING_SMOKE_PASS/)
+  assert.match(runbook, /This is \*\*not\*\* the final MP-6 PASS stamp/)
+})
+
+test('MP-6 helper cleanup is stamped, LIKE-free, and FK-safe (approval children + requests before instances)', () => {
+  assert.match(script, /STAMP must match \/\^mp6-smoke-\[A-Za-z0-9-\]\+\$\//)
+  assert.doesNotMatch(script, /LIKE '%/)
+  assert.doesNotMatch(script, /metadata::text LIKE/)
+  assert.doesNotMatch(script, /meta::text LIKE/)
+  assert.doesNotMatch(script, /left\(user_id, 17\)/, 'no hard-coded prefix length; uses USER_PREFIX.length')
+
+  const idx = (needle) => script.indexOf(needle)
+  const approvalRecords = idx('DELETE FROM approval_records')
+  const approvalAssignments = idx('DELETE FROM approval_assignments')
+  const events = idx('DELETE FROM attendance_events')
+  const records = idx('DELETE FROM attendance_records')
+  const requests = idx('DELETE FROM attendance_requests')
+  const approvalInstances = idx('DELETE FROM approval_instances')
+  const userOrgs = idx('DELETE FROM user_orgs')
+  const users = idx('DELETE FROM users')
+  for (const [name, value] of Object.entries({ approvalRecords, approvalAssignments, events, records, requests, approvalInstances, userOrgs, users })) {
+    assert.ok(value !== -1, `${name} delete exists`)
+  }
+  assert.ok(approvalRecords < approvalInstances && approvalAssignments < approvalInstances, 'approval children deleted before their instance')
+  assert.ok(requests < approvalInstances, 'attendance_requests (FK approval_instance_id) deleted before approval_instances')
+  assert.ok(events < requests && records < requests, 'events + records deleted before requests')
+  assert.ok(userOrgs < users, 'user_orgs (FK users) deleted before users')
+})
+
+test('MP-6 residue categories cover every table the smoke can dirty (incl attendance_events + approval tables)', () => {
+  // deleted + counted + preflighted surfaces
+  for (const table of [
+    'attendance_requests',
+    'attendance_records',
+    'attendance_events',
+    'approval_instances',
+    'approval_assignments',
+    'approval_records',
+    'user_orgs',
+    'users',
+  ]) {
+    assert.match(script, new RegExp(`to_regclass\\('public\\.${table}'\\)`), `${table} is preflighted`)
+    assert.match(script, new RegExp(`FROM ${table}`), `${table} is counted`)
+    assert.match(script, new RegExp(`DELETE FROM ${table}`), `${table} is cleaned`)
+  }
+  // counted-only surface: deliveries must be zero (makeup writes none) and must NOT be deleted.
+  assert.match(script, /to_regclass\('public\.attendance_notification_deliveries'\)/, 'deliveries preflighted')
+  assert.match(script, /FROM attendance_notification_deliveries/, 'deliveries counted')
+  assert.doesNotMatch(script, /DELETE FROM attendance_notification_deliveries/, 'the makeup smoke writes no deliveries and must not delete any (coexistence with the AE/RD smokes)')
+})
+
+test('MP-6 helper fails the run before printing PASS and refuses unstamped subjects', () => {
+  assert.match(script, /if \(failures\.length\)/)
+  assert.match(script, /failed assertion\(s\)/)
+  assert.match(script, /refusing to run/)
+  assert.match(script, /assertSyntheticUser/)
+  // the reduced-vs-full snapshot precision trap is encoded
+  assert.match(script, /countStatuses === undefined/)
+})


### PR DESCRIPTION
Prepares the **MP-6 makeup-punch staging smoke** — docs + ops scripts only, **no real staging run** (Status: PREPARED, claims no PASS). Completes the MP line's staging prep so a window can run it turnkey. Modeled exactly on the on-main v1-8 / RD-4/5 / AE-4 helper family.

## What (4 files, +1377/-2; no runtime touched)

- `scripts/ops/staging-attendance-makeup-punch-mp6-smoke.mjs` (+659) + `.test.mjs` (+212) — API-drives makeup requests + approval, asserts via `DATABASE_URL` (the snapshot/record/event have no API read), stamped FK-safe cleanup.
- `docs/development/attendance-makeup-punch-mp6-staging-smoke-runbook-20260703.md` (+472).
- `docs/development/attendance-staging-window-bundle-20260702.md` (+34/-2) — adds MP-6 as an **optional 4th smoke** (runs standalone OR on the same deploy SHA after v1-8; distinct `mp6-smoke-` stamp; §1 row + §5 stamp + §7 residue sweep + §8 checklist). The three existing smokes are not rewritten.

## The six proofs (design-lock §7 line 243)

quota (N+1 → `MAKEUP_PUNCH_QUOTA_EXCEEDED`), window (`WINDOW_EXPIRED`), type (`TYPE_NOT_ALLOWED`), anomaly-prefill (SQL-seeded `partial` record → server-derived `missing_check_out` fact → valid makeup created `pending` with a metadata snapshot), **approval-adjusted-record** (approve → `attendance_records.status='adjusted'` + one `attendance_events` adjustment row carrying the **reduced** `meta.makeupPolicySnapshot`), residue=0.

The design is grounded in the enforcement's **quota-last check order** (future→window→type→reason→attachment→quota), so the window/type probes return their specific codes even after the quota cap is hit — that is what lets one subject with quota cap 1 prove all paths + then approve.

## Verification

`node --check` OK; `node --test` mp6 **10/10**, v1-8 (untouched) **9/9**. Independently adversarially reviewed against origin/main: approve route + finalize (`action==='approve'` L28135; adjusted record + reduced snapshot L28560-28585) confirmed; residue covers `attendance_events` + approval tables with FK-safe LIKE-free stamped deletes; `attendance_notification_deliveries` asserted zero (coexistence); restore re-asserts `makeupPunchPolicy` disabled (deep-merge, never PUT empty); no brand names. Full review: `/tmp/pr-mp6-runbook-review-claude-20260703.md`.

## After merge

MP-6 is turnkey for the window. When the staging window runs (AE-4 + RD-4/5 + OT-bank v1-8 + MP-6 on one deploy SHA, or MP-6 standalone), backfill the PASS stamps → close umbrella #3317 → mark the MP line staging-proven. Genuine host-side unknowns are in the runbook's OQ blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
