### PR TITLE
feat(integration-web): resolver_lookup R3 — config-authoring UI (resolverRule + rule-specific inputs) (#1709)

### DIFF
--- a/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
@@ -72,10 +72,39 @@
           </label>
         </template>
 
-        <label v-if="draft.mode === 'resolver_lookup'" class="integration-read-source__field">
-          <span>multiplicityRuleField(必填)</span>
-          <input v-model="draft.multiplicityRuleField" data-testid="rsc-multiplicity-field" placeholder="FIsCurrent" />
-        </label>
+        <template v-if="draft.mode === 'resolver_lookup'">
+          <label class="integration-read-source__field">
+            <span>resolverRule(必填)</span>
+            <select v-model="draft.resolverRule" data-testid="rsc-resolver-rule">
+              <option value="">选择解析规则…</option>
+              <option value="exactly_one">exactly_one(唯一命中)</option>
+              <option value="first_when_sorted">first_when_sorted(排序取首)</option>
+              <option value="field_equals">field_equals(判别字段相等)</option>
+            </select>
+          </label>
+          <!-- first_when_sorted: sort field + direction. exactly_one shows none of these three. -->
+          <label v-if="draft.resolverRule === 'first_when_sorted'" class="integration-read-source__field">
+            <span>multiplicityRuleField(排序字段,必填)</span>
+            <input v-model="draft.multiplicityRuleField" data-testid="rsc-resolver-sort-field" placeholder="FVersion" />
+          </label>
+          <label v-if="draft.resolverRule === 'first_when_sorted'" class="integration-read-source__field">
+            <span>resolverSortDirection(必填)</span>
+            <select v-model="draft.resolverSortDirection" data-testid="rsc-resolver-sort-direction">
+              <option value="">选择方向…</option>
+              <option value="asc">asc(升序取首)</option>
+              <option value="desc">desc(降序取首)</option>
+            </select>
+          </label>
+          <!-- field_equals: discriminator field + bounded token value. -->
+          <label v-if="draft.resolverRule === 'field_equals'" class="integration-read-source__field">
+            <span>multiplicityRuleField(判别字段,必填)</span>
+            <input v-model="draft.multiplicityRuleField" data-testid="rsc-resolver-discriminator-field" placeholder="FIsCurrent" />
+          </label>
+          <label v-if="draft.resolverRule === 'field_equals'" class="integration-read-source__field">
+            <span>resolverDiscriminatorValue(有界枚举样 token,必填)</span>
+            <input v-model="draft.resolverDiscriminatorValue" data-testid="rsc-resolver-discriminator-value" placeholder="Y" />
+          </label>
+        </template>
 
         <label v-if="draft.mode !== 'detail_with_lines'" class="integration-read-source__field">
           <span>containerPaths(逗号/换行分隔的点号路径,必填)</span>

--- a/apps/web/src/services/integration/readSourceConfigs.ts
+++ b/apps/web/src/services/integration/readSourceConfigs.ts
@@ -12,6 +12,20 @@ import type { IntegrationScope } from './workbench'
 export const READ_SOURCE_MODES = ['single_record', 'list_page', 'detail_with_lines', 'resolver_lookup'] as const
 export type ReadSourceMode = typeof READ_SOURCE_MODES[number]
 
+// R3 (#1709): resolver_lookup config-authoring vocabulary — mirrors the R0 server contract
+// (plugins/plugin-integration-core/lib/read-source-config.cjs RESOLVER_RULES / RESOLVER_SORT_DIRECTIONS).
+// The server stays authoritative; these drive the per-rule form + coarse client gating only.
+export const RESOLVER_RULES = ['exactly_one', 'first_when_sorted', 'field_equals'] as const
+export type ResolverRule = typeof RESOLVER_RULES[number]
+export const RESOLVER_SORT_DIRECTIONS = ['asc', 'desc'] as const
+export type ResolverSortDirection = typeof RESOLVER_SORT_DIRECTIONS[number]
+// Coarse mirror of the server's bounded enum-like discriminator token (isBoundedIdentifier). Client hint
+// only; the server re-checks + runs the secret-shape scan.
+const RESOLVER_DISCRIMINATOR_TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$/
+export function isCoarseResolverDiscriminatorToken(value: string): boolean {
+  return RESOLVER_DISCRIMINATOR_TOKEN.test(value.trim())
+}
+
 export const READ_SOURCE_METHODS = ['GET', 'POST'] as const
 export type ReadSourceMethod = typeof READ_SOURCE_METHODS[number]
 
@@ -39,6 +53,9 @@ export interface ReadSourceConfigPayload {
   keyField?: string
   keyEncoding?: ReadSourceKeyEncoding
   multiplicityRuleField?: string
+  resolverRule?: ResolverRule
+  resolverSortDirection?: ResolverSortDirection
+  resolverDiscriminatorValue?: string
   containerPaths?: string[]
   headerContainerPaths?: string[]
   lineContainerPaths?: string[]
@@ -57,6 +74,9 @@ export interface ReadSourceConfigDraft {
   keyField: string
   keyEncoding: '' | ReadSourceKeyEncoding
   multiplicityRuleField: string
+  resolverRule: '' | ResolverRule
+  resolverSortDirection: '' | ResolverSortDirection
+  resolverDiscriminatorValue: string
   containerPaths: string
   headerContainerPaths: string
   lineContainerPaths: string
@@ -205,7 +225,10 @@ export const READ_SOURCE_MODE_REQUIRED_FIELDS: Record<ReadSourceMode, string[]> 
   single_record: ['keyField', 'containerPaths'],
   list_page: ['containerPaths'],
   detail_with_lines: ['headerContainerPaths', 'lineContainerPaths'],
-  resolver_lookup: ['keyField', 'containerPaths', 'multiplicityRuleField'],
+  // R3: mirrors R0's MODE_REQUIRED_FIELDS — multiplicityRuleField is no longer unconditional
+  // (it became rule-specific); resolverRule is the required base field. Per-rule required fields
+  // (sort field/direction, discriminator field/value) are enforced in validateReadSourceDraft.
+  resolver_lookup: ['keyField', 'containerPaths', 'resolverRule'],
 }
 
 export function createReadSourceConfigDraft(): ReadSourceConfigDraft {
@@ -220,6 +243,9 @@ export function createReadSourceConfigDraft(): ReadSourceConfigDraft {
     keyField: '',
     keyEncoding: '',
     multiplicityRuleField: '',
+    resolverRule: '',
+    resolverSortDirection: '',
+    resolverDiscriminatorValue: '',
     containerPaths: '',
     headerContainerPaths: '',
     lineContainerPaths: '',
@@ -262,8 +288,8 @@ export function validateReadSourceDraft(draft: ReadSourceConfigDraft): string[] 
   }
   for (const field of READ_SOURCE_MODE_REQUIRED_FIELDS[draft.mode] ?? []) {
     if (field === 'keyField' && !draft.keyField.trim()) problems.push(`keyField 为 ${draft.mode} 模式必填`)
-    if (field === 'multiplicityRuleField' && !draft.multiplicityRuleField.trim()) {
-      problems.push(`multiplicityRuleField 为 ${draft.mode} 模式必填`)
+    if (field === 'resolverRule' && !draft.resolverRule) {
+      problems.push('resolverRule 为 resolver_lookup 模式必填')
     }
     if (field === 'containerPaths' && parseContainerPathList(draft.containerPaths).length === 0) {
       problems.push(`containerPaths 为 ${draft.mode} 模式必填`)
@@ -282,6 +308,25 @@ export function validateReadSourceDraft(draft: ReadSourceConfigDraft): string[] 
       problems.push('fieldMap 行需同时填写 source 与 target(或整行留空)')
       break
     }
+  }
+  // R3: resolver_lookup per-rule required/forbidden — mirrors R0's validateResolverContract. The
+  // server is authoritative; this gives instant coarse feedback (values never echoed).
+  if (draft.mode === 'resolver_lookup' && draft.resolverRule) {
+    const nonEmptyFieldMap = draft.fieldMap.filter((e) => e.source.trim() && e.target.trim())
+    if (nonEmptyFieldMap.length !== 1) problems.push('resolver_lookup 需恰好一个 fieldMap 目标')
+    if (draft.resolverRule === 'first_when_sorted') {
+      if (!draft.multiplicityRuleField.trim()) problems.push('multiplicityRuleField(排序字段)为 first_when_sorted 必填')
+      if (!draft.resolverSortDirection) problems.push('resolverSortDirection 为 first_when_sorted 必填')
+    } else if (draft.resolverRule === 'field_equals') {
+      if (!draft.multiplicityRuleField.trim()) problems.push('multiplicityRuleField(判别字段)为 field_equals 必填')
+      if (!draft.resolverDiscriminatorValue.trim()) {
+        problems.push('resolverDiscriminatorValue 为 field_equals 必填')
+      } else if (!isCoarseResolverDiscriminatorToken(draft.resolverDiscriminatorValue)) {
+        problems.push('resolverDiscriminatorValue 需为有界枚举样 token(不接受空格/路径/密钥样字符串)')
+      }
+    }
+    // exactly_one: multiplicityRuleField / sortDirection / discriminatorValue are all forbidden —
+    // the form does not render them, so no forbidden-field problem is reachable here.
   }
   return problems
 }
@@ -305,8 +350,19 @@ export function buildReadSourceConfigPayload(draft: ReadSourceConfigDraft): Read
   const wantsKeyField = draft.mode === 'single_record' || draft.mode === 'resolver_lookup' || draft.mode === 'detail_with_lines'
   if (wantsKeyField && draft.keyField.trim()) payload.keyField = draft.keyField.trim()
   if (wantsKeyField && draft.keyEncoding) payload.keyEncoding = draft.keyEncoding
-  if (draft.mode === 'resolver_lookup' && draft.multiplicityRuleField.trim()) {
-    payload.multiplicityRuleField = draft.multiplicityRuleField.trim()
+  if (draft.mode === 'resolver_lookup' && draft.resolverRule) {
+    // Send resolverRule always, and ONLY the rule-relevant fields — R0's validator rejects a
+    // field forbidden for the chosen rule (e.g. discriminatorValue on first_when_sorted), so the
+    // form must not ride them along.
+    payload.resolverRule = draft.resolverRule
+    if (draft.resolverRule === 'first_when_sorted') {
+      if (draft.multiplicityRuleField.trim()) payload.multiplicityRuleField = draft.multiplicityRuleField.trim()
+      if (draft.resolverSortDirection) payload.resolverSortDirection = draft.resolverSortDirection
+    } else if (draft.resolverRule === 'field_equals') {
+      if (draft.multiplicityRuleField.trim()) payload.multiplicityRuleField = draft.multiplicityRuleField.trim()
+      if (draft.resolverDiscriminatorValue.trim()) payload.resolverDiscriminatorValue = draft.resolverDiscriminatorValue.trim()
+    }
+    // exactly_one: no multiplicityRuleField / sortDirection / discriminatorValue (all forbidden server-side).
   }
   if (draft.mode === 'detail_with_lines') {
     const header = parseContainerPathList(draft.headerContainerPaths)

--- a/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
@@ -64,7 +64,12 @@ describe('readSourceConfigs pure helpers', () => {
       draft.keyField = 'FNumber'
       draft.containerPaths = 'Data'
     }
-    if (mode === 'resolver_lookup') draft.multiplicityRuleField = 'FIsCurrent'
+    // R3: a valid resolver_lookup needs resolverRule + exactly one fieldMap target. Base = exactly_one
+    // (the simplest rule — no multiplicityRuleField / sortDirection / discriminatorValue).
+    if (mode === 'resolver_lookup') {
+      draft.resolverRule = 'exactly_one'
+      draft.fieldMap = [{ source: 'FItemID', target: 'item_id' }]
+    }
     if (mode === 'list_page') draft.containerPaths = 'Data.Data, Data.DATA'
     if (mode === 'detail_with_lines') {
       draft.headerContainerPaths = 'Data.Page1'
@@ -91,13 +96,57 @@ describe('readSourceConfigs pure helpers', () => {
     missingLines.lineContainerPaths = ''
     expect(validateReadSourceDraft(missingLines).some((p) => p.includes('lineContainerPaths'))).toBe(true)
 
-    const missingMultiplicity = validDraft('resolver_lookup')
-    missingMultiplicity.multiplicityRuleField = ''
-    expect(validateReadSourceDraft(missingMultiplicity).some((p) => p.includes('multiplicityRuleField'))).toBe(true)
+    const missingRule = validDraft('resolver_lookup')
+    missingRule.resolverRule = ''
+    expect(validateReadSourceDraft(missingRule).some((p) => p.includes('resolverRule'))).toBe(true)
 
     const halfFieldMap = validDraft('single_record')
     halfFieldMap.fieldMap = [{ source: 'FName', target: '' }]
     expect(validateReadSourceDraft(halfFieldMap).some((p) => p.includes('fieldMap'))).toBe(true)
+  })
+
+  it('R3 resolver_lookup: per-rule required/forbidden validation + rule-specific payload shaping', () => {
+    // exactly_one (from validDraft) is valid with just resolverRule + one fieldMap target; sends none of
+    // the three rule-specific keys.
+    const one = validDraft('resolver_lookup')
+    expect(validateReadSourceDraft(one)).toEqual([])
+    const onePayload = buildReadSourceConfigPayload(one)
+    expect(onePayload.resolverRule).toBe('exactly_one')
+    expect(onePayload.multiplicityRuleField).toBeUndefined()
+    expect(onePayload.resolverSortDirection).toBeUndefined()
+    expect(onePayload.resolverDiscriminatorValue).toBeUndefined()
+
+    // first_when_sorted: needs sort field + direction; forbids discriminatorValue (not sent even if set).
+    const sorted = validDraft('resolver_lookup')
+    sorted.resolverRule = 'first_when_sorted'
+    expect(validateReadSourceDraft(sorted).some((p) => p.includes('multiplicityRuleField'))).toBe(true)
+    sorted.multiplicityRuleField = 'FVersion'
+    expect(validateReadSourceDraft(sorted).some((p) => p.includes('resolverSortDirection'))).toBe(true)
+    sorted.resolverSortDirection = 'desc'
+    sorted.resolverDiscriminatorValue = 'STRAY' // set but forbidden for this rule
+    expect(validateReadSourceDraft(sorted)).toEqual([])
+    const sortedPayload = buildReadSourceConfigPayload(sorted)
+    expect(sortedPayload).toMatchObject({ resolverRule: 'first_when_sorted', multiplicityRuleField: 'FVersion', resolverSortDirection: 'desc' })
+    expect(sortedPayload.resolverDiscriminatorValue).toBeUndefined() // forbidden field never rides along
+
+    // field_equals: needs discriminator field + bounded token value; forbids sortDirection.
+    const eq = validDraft('resolver_lookup')
+    eq.resolverRule = 'field_equals'
+    eq.multiplicityRuleField = 'FIsCurrent'
+    expect(validateReadSourceDraft(eq).some((p) => p.includes('resolverDiscriminatorValue'))).toBe(true)
+    eq.resolverDiscriminatorValue = 'has space' // not a bounded token
+    expect(validateReadSourceDraft(eq).some((p) => p.includes('token'))).toBe(true)
+    eq.resolverDiscriminatorValue = 'Y'
+    eq.resolverSortDirection = 'asc' // set but forbidden for this rule
+    expect(validateReadSourceDraft(eq)).toEqual([])
+    const eqPayload = buildReadSourceConfigPayload(eq)
+    expect(eqPayload).toMatchObject({ resolverRule: 'field_equals', multiplicityRuleField: 'FIsCurrent', resolverDiscriminatorValue: 'Y' })
+    expect(eqPayload.resolverSortDirection).toBeUndefined()
+
+    // resolver_lookup requires exactly one fieldMap target.
+    const twoTargets = validDraft('resolver_lookup')
+    twoTargets.fieldMap = [{ source: 'FItemID', target: 'a' }, { source: 'FName', target: 'b' }]
+    expect(validateReadSourceDraft(twoTargets).some((p) => p.includes('fieldMap'))).toBe(true)
   })
 
   it('coarse relative-path guard mirrors the server reject classes', () => {
@@ -402,10 +451,29 @@ describe('IntegrationReadSourceConfigPanel', () => {
     expect(root.querySelector('[data-testid="rsc-header-container-paths"]')).not.toBeNull()
     expect(root.querySelector('[data-testid="rsc-line-container-paths"]')).not.toBeNull()
 
-    // resolver_lookup: multiplicity field appears
+    // resolver_lookup R3: resolverRule select appears; per-rule inputs show/hide.
     setSelect(root, 'rsc-mode', 'resolver_lookup')
     await flushUi()
-    expect(root.querySelector('[data-testid="rsc-multiplicity-field"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-resolver-rule"]')).not.toBeNull()
+    // exactly_one: none of the three rule-specific inputs render.
+    setSelect(root, 'rsc-resolver-rule', 'exactly_one')
+    await flushUi()
+    expect(root.querySelector('[data-testid="rsc-resolver-sort-field"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-resolver-sort-direction"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-resolver-discriminator-field"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rsc-resolver-discriminator-value"]')).toBeNull()
+    // first_when_sorted: sort field + direction, NO discriminator value.
+    setSelect(root, 'rsc-resolver-rule', 'first_when_sorted')
+    await flushUi()
+    expect(root.querySelector('[data-testid="rsc-resolver-sort-field"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-resolver-sort-direction"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-resolver-discriminator-value"]')).toBeNull()
+    // field_equals: discriminator field + value, NO sort direction.
+    setSelect(root, 'rsc-resolver-rule', 'field_equals')
+    await flushUi()
+    expect(root.querySelector('[data-testid="rsc-resolver-discriminator-field"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-resolver-discriminator-value"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="rsc-resolver-sort-direction"]')).toBeNull()
 
     // valid single_record enables the buttons
     setSelect(root, 'rsc-mode', 'single_record')


### PR DESCRIPTION
## What

**R3** — the resolver_lookup config-authoring UI form (the deferred piece; R0 contract / R1 evaluator / R2 runtime already merged). Lets a consultant author a resolver_lookup config in the panel. **Frontend-only** — no backend/runtime/write change; the R0 server validator stays authoritative.

## Per-rule input gating (mode=resolver_lookup)

- `resolverRule` select always.
- **exactly_one** → none of the three rule-specific inputs render (they're server-forbidden).
- **first_when_sorted** → `multiplicityRuleField`(排序字段) + `resolverSortDirection`(asc/desc); no discriminator value.
- **field_equals** → `multiplicityRuleField`(判别字段) + `resolverDiscriminatorValue`(bounded token, client-hint mirror of isBoundedIdentifier); no sort direction.
- fieldMap = exactly one resolver output target.

Save payload sends `resolverRule` + only the rule-relevant keys (forbidden fields dropped — matching what R0 accepts). Server 400s (`READ_SOURCE_RESOLVER_*` / `READ_SOURCE_MODE_FIELD_REQUIRED`) surface as coarse field+reason, **no submitted-value echo**.

Also fixes a stale client drift: `MODE_REQUIRED_FIELDS.resolver_lookup` was still `[keyField, containerPaths, multiplicityRuleField]` (pre-R0) → corrected to `[keyField, containerPaths, resolverRule]` (multiplicityRuleField became rule-specific in R0).

## Verification

Panel spec 19/19; the two workbench specs 79/79; web type-check + lint clean. Diff confirmed frontend-only (3 files). Evidence display (resolver codes/rule/counts) already landed in R0's UI mirror — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)