### PR TITLE
feat(approval): surface requester/department analytics in the SLA dashboard (arc B)

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -594,6 +594,22 @@ export interface ApprovalMetricsReport {
   breachedTemplates: ApprovalMetricsTopTemplateRow[]
 }
 
+// Mirrors backend `MetricsDimensionRow` — one aggregation bucket keyed by the
+// requester (person) or the requester's frozen department (team). `key` is the
+// requester id / department string (`null` = the unattributed bucket); `name`
+// is a representative display name. Note: the backend surfaces `slaBreachRate`
+// (a ratio) here, NOT the raw breach/candidate counts.
+export interface ApprovalMetricsDimensionRow {
+  key: string | null
+  name: string | null
+  total: number
+  approved: number
+  rejected: number
+  revoked: number
+  avgDurationSeconds: number | null
+  slaBreachRate: number
+}
+
 export interface ApprovalMetricsNodeBreakdownEntry {
   nodeKey: string
   activatedAt: string | null
@@ -698,6 +714,52 @@ export async function fetchApprovalMetricsReport(query?: {
 export async function fetchApprovalMetricsBreaches(): Promise<ApprovalMetricsRow[]> {
   if (USE_MOCK) return []
   const data = await apiGet<{ ok: boolean; data: ApprovalMetricsRow[] }>('/api/approvals/metrics/breaches')
+  return data?.data ?? []
+}
+
+// Per-department aggregation (`approvals:admin`). Read-only.
+export async function fetchApprovalMetricsTeams(query?: {
+  since?: string
+  until?: string
+  limit?: number
+}): Promise<ApprovalMetricsDimensionRow[]> {
+  if (USE_MOCK) {
+    return [
+      { key: 'Engineering', name: 'Engineering', total: 24, approved: 20, rejected: 3, revoked: 1, avgDurationSeconds: 6800, slaBreachRate: 0.12 },
+      { key: 'Sales', name: 'Sales', total: 15, approved: 12, rejected: 2, revoked: 1, avgDurationSeconds: 10200, slaBreachRate: 0.27 },
+    ]
+  }
+  const params = new URLSearchParams()
+  if (query?.since) params.set('since', query.since)
+  if (query?.until) params.set('until', query.until)
+  if (query?.limit) params.set('limit', String(query.limit))
+  const qs = params.toString()
+  const data = await apiGet<{ ok: boolean; data: ApprovalMetricsDimensionRow[] }>(
+    `/api/approvals/metrics/teams${qs ? `?${qs}` : ''}`,
+  )
+  return data?.data ?? []
+}
+
+// Per-requester (person) aggregation (`approvals:analytics`). Read-only.
+export async function fetchApprovalMetricsPeople(query?: {
+  since?: string
+  until?: string
+  limit?: number
+}): Promise<ApprovalMetricsDimensionRow[]> {
+  if (USE_MOCK) {
+    return [
+      { key: 'u-1', name: 'Alice', total: 9, approved: 8, rejected: 1, revoked: 0, avgDurationSeconds: 5400, slaBreachRate: 0.11 },
+      { key: 'u-2', name: 'Bob', total: 6, approved: 4, rejected: 1, revoked: 1, avgDurationSeconds: 12600, slaBreachRate: 0.33 },
+    ]
+  }
+  const params = new URLSearchParams()
+  if (query?.since) params.set('since', query.since)
+  if (query?.until) params.set('until', query.until)
+  if (query?.limit) params.set('limit', String(query.limit))
+  const qs = params.toString()
+  const data = await apiGet<{ ok: boolean; data: ApprovalMetricsDimensionRow[] }>(
+    `/api/approvals/metrics/people${qs ? `?${qs}` : ''}`,
+  )
   return data?.data ?? []
 }
 

--- a/apps/web/src/views/approval/ApprovalMetricsView.vue
+++ b/apps/web/src/views/approval/ApprovalMetricsView.vue
@@ -88,6 +88,74 @@
       </el-table>
     </el-card>
 
+    <el-card class="approval-metrics__section" data-testid="metrics-section-teams">
+      <template #header>
+        <span>按部门汇总</span>
+      </template>
+      <div data-testid="metrics-table-teams">
+        <el-table :data="teams" stripe v-loading="teamsLoading" empty-text="暂无部门数据">
+          <el-table-column label="部门" min-width="220">
+            <template #default="{ row }">
+              <span>{{ row.name || row.key || '未归属部门' }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column prop="total" label="总量" width="90" />
+          <el-table-column prop="approved" label="通过" width="90" />
+          <el-table-column prop="rejected" label="驳回" width="90" />
+          <el-table-column prop="revoked" label="撤回" width="90" />
+          <el-table-column label="平均耗时" width="130">
+            <template #default="{ row }">{{ formatDuration(row.avgDurationSeconds) }}</template>
+          </el-table-column>
+          <el-table-column label="SLA 超时率" min-width="180">
+            <template #default="{ row }">
+              <div class="metric-bar">
+                <div class="metric-bar__track">
+                  <div class="metric-bar__fill" :style="{ width: barWidth(row.slaBreachRate) }"></div>
+                </div>
+                <span class="metric-bar__label">{{ formatPercent(row.slaBreachRate) }}</span>
+              </div>
+            </template>
+          </el-table-column>
+        </el-table>
+      </div>
+    </el-card>
+
+    <el-card
+      v-if="canViewPeople"
+      class="approval-metrics__section"
+      data-testid="metrics-section-people"
+    >
+      <template #header>
+        <span>按发起人汇总</span>
+      </template>
+      <div data-testid="metrics-table-people">
+        <el-table :data="people" stripe v-loading="peopleLoading" empty-text="暂无发起人数据">
+          <el-table-column label="发起人" min-width="220">
+            <template #default="{ row }">
+              <span>{{ row.name || row.key || '未归属发起人' }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column prop="total" label="总量" width="90" />
+          <el-table-column prop="approved" label="通过" width="90" />
+          <el-table-column prop="rejected" label="驳回" width="90" />
+          <el-table-column prop="revoked" label="撤回" width="90" />
+          <el-table-column label="平均耗时" width="130">
+            <template #default="{ row }">{{ formatDuration(row.avgDurationSeconds) }}</template>
+          </el-table-column>
+          <el-table-column label="SLA 超时率" min-width="180">
+            <template #default="{ row }">
+              <div class="metric-bar">
+                <div class="metric-bar__track">
+                  <div class="metric-bar__fill" :style="{ width: barWidth(row.slaBreachRate) }"></div>
+                </div>
+                <span class="metric-bar__label">{{ formatPercent(row.slaBreachRate) }}</span>
+              </div>
+            </template>
+          </el-table-column>
+        </el-table>
+      </div>
+    </el-card>
+
     <el-card class="approval-metrics__section">
       <template #header>
         <span>运行中且已超时实例</span>
@@ -178,10 +246,14 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { useAuth } from '../../composables/useAuth'
 import {
   fetchApprovalMetricsBreaches,
+  fetchApprovalMetricsPeople,
   fetchApprovalMetricsReport,
   fetchApprovalMetricsSummary,
+  fetchApprovalMetricsTeams,
+  type ApprovalMetricsDimensionRow,
   type ApprovalMetricsRow,
   type ApprovalMetricsSummary,
   type ApprovalMetricsTopInstanceRow,
@@ -189,6 +261,14 @@ import {
 } from '../../approvals/api'
 
 const router = useRouter()
+const { hasPermission } = useAuth()
+
+// Person-level analytics (/people) is gated behind a SEPARATE `approvals:analytics`
+// permission on the backend (a who-is-slowest ranking is more sensitive than
+// approval administration). Mirror that gate here as defense-in-depth: hide the
+// requester section (and skip its fetch) when the actor lacks the permission.
+// The hard gate remains the backend rbacGuard — a 403 is caught gracefully below.
+const canViewPeople = computed(() => hasPermission('approvals:analytics'))
 
 const summary = ref<ApprovalMetricsSummary>({
   total: 0, approved: 0, rejected: 0, revoked: 0, returned: 0, running: 0,
@@ -198,11 +278,17 @@ const summary = ref<ApprovalMetricsSummary>({
 const breaches = ref<ApprovalMetricsRow[]>([])
 const slowestInstances = ref<ApprovalMetricsTopInstanceRow[]>([])
 const breachedTemplates = ref<ApprovalMetricsTopTemplateRow[]>([])
+const teams = ref<ApprovalMetricsDimensionRow[]>([])
+const people = ref<ApprovalMetricsDimensionRow[]>([])
 const dateRange = ref<[string, string] | null>(null)
 const loading = ref(false)
 const breachLoading = ref(false)
 const reportLoading = ref(false)
+const teamsLoading = ref(false)
+const peopleLoading = ref(false)
 const errorMessage = ref('')
+
+const BREAKDOWN_LIMIT = 20
 
 const approvalRatePercent = computed(() => {
   const decided = summary.value.approved + summary.value.rejected + summary.value.revoked + summary.value.returned
@@ -256,8 +342,51 @@ async function loadReport(): Promise<void> {
   }
 }
 
+function rangeQuery(base: { limit?: number } = {}): { since?: string; until?: string; limit?: number } {
+  const query: { since?: string; until?: string; limit?: number } = { ...base }
+  if (dateRange.value && dateRange.value[0]) query.since = `${dateRange.value[0]}T00:00:00Z`
+  if (dateRange.value && dateRange.value[1]) query.until = `${dateRange.value[1]}T23:59:59Z`
+  return query
+}
+
+async function loadTeams(): Promise<void> {
+  teamsLoading.value = true
+  try {
+    teams.value = await fetchApprovalMetricsTeams(rangeQuery({ limit: BREAKDOWN_LIMIT }))
+  } catch (error) {
+    errorMessage.value = `加载部门汇总失败: ${error instanceof Error ? error.message : String(error)}`
+  } finally {
+    teamsLoading.value = false
+  }
+}
+
+async function loadPeople(): Promise<void> {
+  // Skip entirely without the analytics permission — the section is hidden and
+  // the backend would answer 403.
+  if (!canViewPeople.value) {
+    people.value = []
+    return
+  }
+  peopleLoading.value = true
+  try {
+    people.value = await fetchApprovalMetricsPeople(rangeQuery({ limit: BREAKDOWN_LIMIT }))
+  } catch (error) {
+    // Graceful degrade: an unexpected 403 (permission drift) must not blank the
+    // whole dashboard — surface a note and leave the other sections intact.
+    people.value = []
+    errorMessage.value = `加载发起人汇总失败: ${error instanceof Error ? error.message : String(error)}`
+  } finally {
+    peopleLoading.value = false
+  }
+}
+
 async function loadAll(): Promise<void> {
-  await Promise.all([loadSummary(), loadBreaches(), loadReport()])
+  await Promise.all([loadSummary(), loadBreaches(), loadReport(), loadTeams(), loadPeople()])
+}
+
+function barWidth(rate: number | null | undefined): string {
+  const pct = typeof rate === 'number' && Number.isFinite(rate) ? rate * 100 : 0
+  return `${Math.min(100, Math.max(0, pct))}%`
 }
 
 function formatDuration(seconds: number | null | undefined): string {
@@ -341,5 +470,29 @@ onMounted(() => { void loadAll() })
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
   gap: 16px;
+}
+.metric-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.metric-bar__track {
+  flex: 1;
+  min-width: 48px;
+  height: 8px;
+  border-radius: 4px;
+  background: #f0f0f0;
+  overflow: hidden;
+}
+.metric-bar__fill {
+  height: 100%;
+  border-radius: 4px;
+  background: #f59e0b;
+}
+.metric-bar__label {
+  font-size: 12px;
+  color: #4b5563;
+  min-width: 44px;
+  text-align: right;
 }
 </style>

--- a/apps/web/tests/approvalMetricsView.spec.ts
+++ b/apps/web/tests/approvalMetricsView.spec.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp } from 'vue'
+
+// ---------------------------------------------------------------------------
+// B — Approval analytics dashboard: the requester/department breakdown sections
+// (按部门汇总 / 按发起人汇总) that surface `getMetricsByDimension`, the one metric
+// the backend computes but the FE never rendered.
+//
+//   - department section (/teams, approvals:admin) always renders on the
+//     admin-gated page.
+//   - requester section (/people, approvals:analytics) renders + fetches ONLY
+//     when hasPermission('approvals:analytics') is true (defense-in-depth; the
+//     hard gate is the backend). Both branches exercised.
+//   - read-only: only GET fetchers are called; the sole affordance (refresh)
+//     re-reads.
+//
+// The api module is fully mocked so no fetch touches the mock-mode fixtures.
+// ---------------------------------------------------------------------------
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: pushSpy }),
+  }
+})
+
+const hasPermissionSpy = vi.fn<(p: string) => boolean>(() => true)
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({ hasPermission: hasPermissionSpy }),
+}))
+
+const summarySpy = vi.fn()
+const reportSpy = vi.fn()
+const breachesSpy = vi.fn()
+const teamsSpy = vi.fn()
+const peopleSpy = vi.fn()
+vi.mock('../src/approvals/api', () => ({
+  fetchApprovalMetricsSummary: (...a: unknown[]) => summarySpy(...a),
+  fetchApprovalMetricsReport: (...a: unknown[]) => reportSpy(...a),
+  fetchApprovalMetricsBreaches: (...a: unknown[]) => breachesSpy(...a),
+  fetchApprovalMetricsTeams: (...a: unknown[]) => teamsSpy(...a),
+  fetchApprovalMetricsPeople: (...a: unknown[]) => peopleSpy(...a),
+}))
+
+function emptySummary() {
+  return {
+    total: 0, approved: 0, rejected: 0, revoked: 0, returned: 0, running: 0,
+    avgDurationSeconds: null, p50DurationSeconds: null, p95DurationSeconds: null,
+    slaBreachCount: 0, slaCandidateCount: 0, slaBreachRate: 0, byTemplate: [],
+  }
+}
+
+const TEAM_ROWS = [
+  { key: 'Engineering', name: 'Engineering', total: 24, approved: 20, rejected: 3, revoked: 1, avgDurationSeconds: 6800, slaBreachRate: 0.12 },
+  { key: 'Sales', name: 'Sales', total: 15, approved: 12, rejected: 2, revoked: 1, avgDurationSeconds: 10200, slaBreachRate: 0.27 },
+]
+const PEOPLE_ROWS = [
+  { key: 'u-1', name: 'Alice', total: 9, approved: 8, rejected: 1, revoked: 0, avgDurationSeconds: 5400, slaBreachRate: 0.11 },
+]
+
+// Element Plus stubs. ElTable surfaces its bound `data` length as data-rows so a
+// stubbed table (which can't invoke scoped slots) still proves the mocked data
+// reached the section.
+function passthrough(name: string, tag = 'div') {
+  return defineComponent({
+    name,
+    props: { modelValue: {}, type: String, loading: Boolean, title: String },
+    emits: ['update:modelValue', 'click', 'change', 'close'],
+    render() {
+      return h(tag, { 'data-stub': name, onClick: (e: Event) => this.$emit('click', e) }, this.$slots.default?.())
+    },
+  })
+}
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, loading: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', { 'data-el-button': this.type || 'default', onClick: (e: Event) => this.$emit('click', e) }, this.$slots.default?.())
+  },
+})
+const ElCard = defineComponent({
+  name: 'ElCard',
+  render() {
+    return h('div', { 'data-el-card': '' }, [
+      this.$slots.header ? h('div', { 'data-el-card-header': '' }, this.$slots.header()) : null,
+      this.$slots.default?.(),
+    ])
+  },
+})
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: { type: Array, default: () => [] } },
+  render() {
+    return h('div', { 'data-el-table': '', 'data-rows': String((this.data as unknown[]).length) })
+  },
+})
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String },
+  render() { return h('div', { 'data-column': this.prop || this.label }) },
+})
+// Drives the shared date-range: clicking emits a v-model update + @change so the
+// view re-runs loadAll with a concrete since/until.
+const ElDatePicker = defineComponent({
+  name: 'ElDatePicker',
+  props: { modelValue: { type: Array, default: null } },
+  emits: ['update:modelValue', 'change'],
+  render() {
+    return h('button', {
+      'data-testid': 'set-date-range',
+      onClick: () => {
+        const range = ['2026-04-01', '2026-04-25']
+        this.$emit('update:modelValue', range)
+        this.$emit('change', range)
+      },
+    }, 'range')
+  },
+})
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function mountView(): Promise<{ app: VueApp<Element>; container: HTMLDivElement }> {
+  const { default: ApprovalMetricsView } = await import('../src/views/approval/ApprovalMetricsView.vue')
+  const Host = defineComponent({ setup() { return () => h(ApprovalMetricsView as never) } })
+  const app = createApp(Host)
+  for (const name of ['ElAlert', 'ElLink']) app.component(name, passthrough(name))
+  app.component('ElButton', ElButton)
+  app.component('ElCard', ElCard)
+  app.component('ElTable', ElTable)
+  app.component('ElTableColumn', ElTableColumn)
+  app.component('ElDatePicker', ElDatePicker)
+  app.directive('loading', { mounted() {}, updated() {} })
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  app.mount(container)
+  await flushUi()
+  return { app, container }
+}
+
+function rowsOf(container: HTMLElement, sectionTestId: string): number | null {
+  const table = container.querySelector(`[data-testid="${sectionTestId}"] [data-el-table]`)
+  return table ? Number(table.getAttribute('data-rows')) : null
+}
+
+describe('ApprovalMetricsView — B analytics breakdown sections', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    hasPermissionSpy.mockReset().mockReturnValue(true)
+    summarySpy.mockReset().mockResolvedValue(emptySummary())
+    reportSpy.mockReset().mockResolvedValue({ summary: emptySummary(), slowestInstances: [], breachedTemplates: [] })
+    breachesSpy.mockReset().mockResolvedValue([])
+    teamsSpy.mockReset().mockResolvedValue(TEAM_ROWS)
+    peopleSpy.mockReset().mockResolvedValue(PEOPLE_ROWS)
+    pushSpy.mockClear()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  it('renders the department section from the mocked /teams fetcher', async () => {
+    const m = await mountView()
+    app = m.app; container = m.container
+
+    expect(teamsSpy).toHaveBeenCalledTimes(1)
+    // No date range set on load → limit only (the section's fixed depth).
+    expect(teamsSpy).toHaveBeenCalledWith({ limit: 20 })
+    expect(container.textContent).toContain('按部门汇总')
+    expect(rowsOf(container, 'metrics-table-teams')).toBe(TEAM_ROWS.length)
+  })
+
+  it('renders the requester section + fetches /people when approvals:analytics is granted', async () => {
+    hasPermissionSpy.mockReturnValue(true)
+    const m = await mountView()
+    app = m.app; container = m.container
+
+    expect(hasPermissionSpy).toHaveBeenCalledWith('approvals:analytics')
+    expect(peopleSpy).toHaveBeenCalledTimes(1)
+    expect(peopleSpy).toHaveBeenCalledWith({ limit: 20 })
+    expect(container.textContent).toContain('按发起人汇总')
+    expect(rowsOf(container, 'metrics-table-people')).toBe(PEOPLE_ROWS.length)
+  })
+
+  it('hides the requester section AND does not fetch /people without approvals:analytics', async () => {
+    hasPermissionSpy.mockReturnValue(false)
+    const m = await mountView()
+    app = m.app; container = m.container
+
+    expect(peopleSpy).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-testid="metrics-section-people"]')).toBeNull()
+    expect(container.textContent).not.toContain('按发起人汇总')
+    // The department section (admin-gated) is unaffected.
+    expect(teamsSpy).toHaveBeenCalledTimes(1)
+    expect(rowsOf(container, 'metrics-table-teams')).toBe(TEAM_ROWS.length)
+  })
+
+  it('read-only: only GET fetchers run; refresh re-reads the breakdowns', async () => {
+    const m = await mountView()
+    app = m.app; container = m.container
+
+    expect(teamsSpy).toHaveBeenCalledTimes(1)
+    expect(peopleSpy).toHaveBeenCalledTimes(1)
+
+    const refresh = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('刷新'))
+    expect(refresh, 'a 刷新 button exists').toBeTruthy()
+    refresh!.click()
+    await flushUi()
+
+    // Refresh is a pure re-read of the same GET endpoints — never a mutation.
+    expect(teamsSpy).toHaveBeenCalledTimes(2)
+    expect(peopleSpy).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('form')).toBeNull()
+  })
+
+  it('propagates the shared date-range to the breakdown fetchers', async () => {
+    const m = await mountView()
+    app = m.app; container = m.container
+    teamsSpy.mockClear()
+    peopleSpy.mockClear()
+
+    const picker = container.querySelector<HTMLButtonElement>('[data-testid="set-date-range"]')
+    expect(picker, 'the date-range picker stub is present').toBeTruthy()
+    picker!.click()
+    await flushUi()
+
+    const expected = { since: '2026-04-01T00:00:00Z', until: '2026-04-25T23:59:59Z', limit: 20 }
+    expect(teamsSpy).toHaveBeenCalledWith(expected)
+    expect(peopleSpy).toHaveBeenCalledWith(expected)
+  })
+})

--- a/docs/development/approval-B-analytics-dashboard-design-lock-20260703.md
+++ b/docs/development/approval-B-analytics-dashboard-design-lock-20260703.md
@@ -1,0 +1,116 @@
+# Design Lock — B: Approval Analytics Dashboard (审批效率看板 completion)
+
+Date: 2026-07-03
+Branch: `claude/approval-B-analytics-dashboard-20260703`
+Status: design-lock (implement to this doc)
+
+## 1. Goal
+
+Close the 钉钉/飞书 "审批效率看板" gap by surfacing the approval analytics the
+backend **already computes** but the front-end does not yet render.
+
+## 2. Grounding — what already exists (verified in this branch)
+
+The task brief assumed the metrics endpoints might not be exposed and no
+dashboard existed. Neither is true on `origin/main`:
+
+- **Service** `ApprovalMetricsService` exposes `getMetricsSummary`,
+  `getMetricsByDimension('requester'|'department')` (+ the
+  `getMetricsByRequester` / `getMetricsByDepartment` wrappers),
+  `getMetricsReport`, `getInstanceMetrics`, `listActiveBreaches`.
+- **HTTP routes** (`packages/core-backend/src/routes/approval-metrics.ts`,
+  mounted in `index.ts` via `app.use(approvalMetricsRouter())`) already expose:
+  - `GET /api/approvals/metrics/summary`  — `approvals:admin`
+  - `GET /api/approvals/metrics/report`   — `approvals:admin`
+  - `GET /api/approvals/metrics/people`   — `approvals:analytics` (person ranking = more sensitive; migration `zzzz20260630090000` grants it to the global `admin` role only)
+  - `GET /api/approvals/metrics/teams`    — `approvals:admin`
+  - `GET /api/approvals/metrics/breaches` — `approvals:admin`
+  - `GET /api/approvals/metrics/instances/:instanceId` — `approvals:read` (participant-or-admin ACL)
+  - All of these are **already permission-tested** in
+    `tests/unit/approval-metrics-router.test.ts` and service-level real-DB
+    tested in `tests/integration/approval-metrics-people-teams.test.ts`.
+- **Front-end** `apps/web/src/views/approval/ApprovalMetricsView.vue` is
+  **already routed** at `/approvals/metrics` (`requiresAdmin`) and nav-linked in
+  `App.vue` (`审批 SLA`). It already consumes summary + report/TopN + breaches.
+
+### The single gap
+
+`getMetricsByDimension` (per-**requester** and per-**department** aggregation)
+is the ONLY thing the backend computes that the FE never surfaces. The
+`/people` and `/teams` endpoints exist and are gated/tested; the FE has **no
+consumer** for them (`apps/web/src/approvals/api.ts` has no
+`fetchApprovalMetricsPeople` / `fetchApprovalMetricsTeams`).
+
+## 3. Decision — extend, do not duplicate; no new endpoint
+
+- **No new backend endpoint.** The task's "add ONE if not exposed" is already
+  satisfied. Backend source is untouched.
+- **Extend the existing `ApprovalMetricsView.vue`**, not a parallel
+  `ApprovalAnalyticsView.vue` — a parallel view would duplicate the
+  summary/report/breach wiring. This is the reuse-over-duplication call.
+
+## 4. Scope — files changed
+
+1. `apps/web/src/approvals/api.ts`
+   - Add `ApprovalMetricsDimensionRow` type (mirrors backend `MetricsDimensionRow`:
+     `key`, `name`, `total`, `approved`, `rejected`, `revoked`,
+     `avgDurationSeconds`, `slaBreachRate`).
+   - Add `fetchApprovalMetricsTeams(query)` → `GET /teams`.
+   - Add `fetchApprovalMetricsPeople(query)` → `GET /people`.
+   - Both follow the existing `fetchApprovalMetricsReport` fetcher pattern
+     (since/until/limit → `URLSearchParams`, `USE_MOCK` branch, `apiGet`).
+2. `apps/web/src/views/approval/ApprovalMetricsView.vue`
+   - Two new **read-only** sections wired into the existing `loadAll` (so they
+     respect the shared date-range picker):
+     - **按部门汇总** (department / `/teams`, `approvals:admin` — same gate as the page).
+     - **按发起人汇总** (requester / `/people`, `approvals:analytics`).
+   - Columns: 部门/发起人, 总量, 通过, 驳回, 撤回, 平均耗时, SLA 超时率 (with an
+     inline CSS bar). `MetricsDimensionRow` carries `slaBreachRate` but NOT raw
+     breach/candidate counts — surface the **rate** via the existing
+     `formatPercent`, consistent with the `byTemplate` table.
+3. `apps/web/tests/approvalMetricsView.spec.ts` (new — first test for this view).
+
+## 5. Explicit judgment calls (reviewer can redirect)
+
+- **Chart library:** `echarts` IS a dependency (used only by
+  `multitable/MetaChartRenderer.vue`). The metrics endpoints return **aggregates,
+  not time-series**, so there is no "trend" to chart. Chosen: **inline CSS
+  breach-rate bars** in the tables (unit-testable, no canvas, consistent with the
+  existing table-based dashboard). If a chart is ever wanted, reuse the
+  tree-shaken `echarts/core` + `echarts.use([...])` pattern — do NOT reuse
+  multitable's `MetaChartRenderer` (would couple approval FE to multitable).
+- **Node breakdown:** OUT OF SCOPE. There is **no aggregate** node-breakdown in
+  the service — only per-instance `node_breakdown` (via the instance endpoint).
+  Building a cross-instance node aggregate = inventing new metrics math, which
+  the brief forbids. Not added.
+- **People-section FE gate:** the page is `requiresAdmin` and
+  `hasPermission('approvals:analytics')` short-circuits `true` for any admin, so
+  the FE gate is effectively always-true for page-reachers — the **real** gate is
+  the backend `rbacGuard('approvals:analytics')`. The FE gate + a graceful
+  `catch` on a 403 are kept as **defense-in-depth**; the test mocks
+  `hasPermission` to exercise BOTH branches.
+
+## 6. Constraints honored
+
+- Read-only (GET only; no mutations).
+- No new dependency.
+- Tenant-scoped (server resolves tenant from `req.user`).
+- Admin/metrics-permission gated (department = `approvals:admin`, requester =
+  `approvals:analytics`) — matches existing route gating.
+- **i18n:** the approval module has NO i18n infra; strings are hardcoded 中文,
+  which is consistent with the rest of the module (and the existing
+  `ApprovalMetricsView.vue`). Noted, not "fixed".
+
+## 7. Verification plan
+
+- Backend `tsc --noEmit` → 0 (untouched; confirm no regression).
+- Backend: **no new integration test** (task's real-DB test is conditional on
+  adding an endpoint; none added). PROVE existing
+  `approval-metrics-router.test.ts` + `approval-metrics-people-teams.test.ts`
+  still green.
+- FE `vue-tsc -b` → 0.
+- FE new spec `approvalMetricsView.spec.ts` (RED-first): department + requester
+  sections render from mocked fetchers; people section present + fetched when
+  `hasPermission('approvals:analytics')` is true, absent + NOT fetched when
+  false; read-only (only read fetchers invoked; refresh re-reads).
+- Prove existing approval FE specs (center/detail/mobile) still green.


### PR DESCRIPTION
Arc **B** — with an honest reorientation surfaced by grounding: the approval **SLA dashboard already ships** (`ApprovalMetricsView.vue` at `/approvals/metrics`, `requiresAdmin`, nav-linked "审批 SLA") and the metrics endpoints (`/summary /report /people /teams /breaches /instances`) already exist and are permission-tested. The one **computed-but-unsurfaced** metric was `getMetricsByDimension` (per-requester / per-department). So this slice **completes the existing dashboard**, it does not build one.

## What ships (FE-only; backend + routes + nav untouched, already existed)
- Two read-only sections added to the existing view: **按部门汇总** (`/teams`, `approvals:admin`) and **按发起人汇总** (`/people`, `approvals:analytics`) — 总量/通过/驳回/撤回/平均耗时 + SLA 超时率 with inline breach-rate bars, wired into the shared date-range `loadAll`.
- `api.ts`: `fetchApprovalMetricsTeams` / `fetchApprovalMetricsPeople` (GET-only, since/until/limit).

## Verification
`vue-tsc -b` 0 · new `approvalMetricsView.spec.ts` **5/5**, **RED-first verified** (4/4 failing before the view change): sections render from mocked fetchers with exact args; requester section present+fetched only with `approvals:analytics`, hidden+not-fetched otherwise; read-only; shared date-range propagates since/until. Backend `tsc` 0; `approval-metrics-router` 9/9; `approval-metrics-people-teams` 3/3 real-DB; existing approval FE specs 61/61.

## Honest scope notes
- **The deeper T3-6 differentiation payoff** — building multitable-native views/charts *on the projection base* ("approval analytics = reuse multitable") — is **NOT this slice**; it's a separate, larger slice gated behind arc A's visibility. B completes the *aggregate* SLA dashboard.
- FE `approvals:analytics` gate is defense-in-depth (the page is `requiresAdmin` so it short-circuits true for admins) — the real gate is the backend `rbacGuard('approvals:analytics')`; the test exercises both branches.
- No chart added (endpoints are aggregates, not time-series → inline CSS bars, no new dep); aggregate node-breakdown out of scope (no backend aggregate — would invent metrics math); i18n consistent with the module (no i18n infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)