### PR TITLE
feat(approval): delegation self-service + audit visibility (arc C · UX/governance layer)

### DIFF
--- a/apps/web/src/approvals/delegations.ts
+++ b/apps/web/src/approvals/delegations.ts
@@ -14,6 +14,9 @@ export interface DelegationRecord {
   startAt: string
   endAt: string
   active: boolean
+  // Audit-only: approvals routed via this delegator (per-delegator, derived server-side).
+  // Present on the admin audit list + the self-service /mine list; absent otherwise.
+  routedApprovalCount?: number
 }
 
 export interface CreateDelegationPayload {
@@ -35,10 +38,21 @@ export interface UpdateDelegationPayload {
 }
 
 const mockDelegations: DelegationRecord[] = []
+// The self-service (我的委托) surface is scoped server-side to the actor; in mock/DEV mode
+// there is no auth context, so own rows are tagged with this sentinel delegator id.
+const MOCK_SELF = '__me__'
 
-export async function listDelegations(): Promise<DelegationRecord[]> {
-  if (USE_MOCK) return mockDelegations.filter((d) => d.active)
-  const res = await apiGet<{ data: DelegationRecord[] }>('/api/approval-delegations')
+export async function listDelegations(opts: { includeInactive?: boolean } = {}): Promise<DelegationRecord[]> {
+  if (USE_MOCK) return opts.includeInactive ? [...mockDelegations] : mockDelegations.filter((d) => d.active)
+  const qs = opts.includeInactive ? '?includeInactive=true' : ''
+  const res = await apiGet<{ data: DelegationRecord[] }>(`/api/approval-delegations${qs}`)
+  return res.data ?? []
+}
+
+/** Self-service: the caller's OWN delegations (active + history), scoped server-side to the actor. */
+export async function listOwnDelegations(): Promise<DelegationRecord[]> {
+  if (USE_MOCK) return mockDelegations.filter((d) => d.delegatorUserId === MOCK_SELF)
+  const res = await apiGet<{ data: DelegationRecord[] }>('/api/approval-delegations/mine')
   return res.data ?? []
 }
 
@@ -121,4 +135,63 @@ export function buildCreatePayload(form: DelegationForm): CreateDelegationPayloa
     startAt: new Date(form.startAt).toISOString(),
     endAt: new Date(form.endAt).toISOString(),
   }
+}
+
+// ── Self-service (我的委托) ──────────────────────────────────────────────────
+// The delegator is ALWAYS the caller (forced server-side), so the own form/payload omit it.
+export interface OwnDelegationForm {
+  delegateeUserId: string
+  scope: 'all' | 'template'
+  scopeTemplateId: string
+  startAt: string
+  endAt: string
+}
+
+export type OwnCreateDelegationPayload = Omit<CreateDelegationPayload, 'delegatorUserId'>
+
+export function validateOwnDelegationForm(form: OwnDelegationForm): string | null {
+  if (!form.delegateeUserId.trim()) return '请填写被委托人'
+  if (form.scope === 'template' && !form.scopeTemplateId.trim()) return '指定模板范围需要选择模板'
+  if (!form.startAt || !form.endAt) return '请填写时间窗'
+  if (new Date(form.endAt).getTime() <= new Date(form.startAt).getTime()) return '结束时间必须晚于开始时间'
+  return null
+}
+
+export function buildOwnCreatePayload(form: OwnDelegationForm): OwnCreateDelegationPayload {
+  return {
+    delegateeUserId: form.delegateeUserId.trim(),
+    scope: form.scope,
+    scopeTemplateId: form.scope === 'template' ? form.scopeTemplateId.trim() : null,
+    startAt: new Date(form.startAt).toISOString(),
+    endAt: new Date(form.endAt).toISOString(),
+  }
+}
+
+export async function createOwnDelegation(payload: OwnCreateDelegationPayload): Promise<DelegationRecord> {
+  if (USE_MOCK) {
+    const rec: DelegationRecord = {
+      id: `mock-mine-${mockDelegations.length + 1}`,
+      delegatorUserId: MOCK_SELF,
+      delegateeUserId: payload.delegateeUserId,
+      scope: payload.scope,
+      scopeTemplateId: payload.scope === 'template' ? payload.scopeTemplateId ?? null : null,
+      startAt: payload.startAt,
+      endAt: payload.endAt,
+      active: true,
+    }
+    mockDelegations.push(rec)
+    return rec
+  }
+  const res = await apiPost<{ data: DelegationRecord }>('/api/approval-delegations/mine', payload)
+  return res.data
+}
+
+export async function disableOwnDelegation(id: string): Promise<void> {
+  if (USE_MOCK) {
+    const d = mockDelegations.find((x) => x.id === id && x.delegatorUserId === MOCK_SELF)
+    if (d) d.active = false
+    return
+  }
+  const res = await apiFetch(`/api/approval-delegations/mine/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  if (!res.ok) throw new Error(`Failed to disable delegation (${res.status})`)
 }

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -277,6 +277,14 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Delegation Settings', titleZh: '委托设置', requiresAuth: true, permissions: ['approval-templates:manage'] }
   },
   {
+    // Self-service: any authenticated user manages THEIR OWN delegation (delegator forced
+    // to the actor server-side). No manage permission — only requiresAuth.
+    path: '/my-delegation',
+    name: 'my-delegation',
+    component: () => import('../views/approval/MyDelegationView.vue'),
+    meta: { title: 'My Delegation', titleZh: '我的委托', requiresAuth: true }
+  },
+  {
     path: '/approval-templates/new',
     name: 'approval-template-create',
     component: () => import('../views/approval/TemplateAuthoringView.vue'),

--- a/apps/web/src/views/approval/MyDelegationView.vue
+++ b/apps/web/src/views/approval/MyDelegationView.vue
@@ -1,25 +1,14 @@
 <template>
-  <div class="delegation-settings">
+  <div class="my-delegation">
     <div class="header">
       <div>
-        <h2>委托设置</h2>
-        <p class="sub">为审批人配置时间窗内的委托（委托人 → 被委托人）。同一委托人 + 范围目标仅允许一条生效委托。</p>
+        <h2>我的委托</h2>
+        <p class="sub">设置或取消你自己的审批委托（委托人恒为你本人）。同一范围目标仅允许一条生效委托。</p>
       </div>
-      <div class="actions">
-        <el-switch
-          v-model="includeInactive"
-          data-testid="delegation-history-toggle"
-          active-text="显示历史"
-          @change="load"
-        />
-        <el-button type="primary" :disabled="!canManage" data-testid="delegation-new" @click="openCreate">新建委托</el-button>
-      </div>
+      <el-button type="primary" data-testid="my-delegation-new" @click="openCreate">新建委托</el-button>
     </div>
 
-    <el-alert v-if="!canManage" type="info" :closable="false" title="需要审批模板管理权限才能配置委托" />
-
-    <el-table v-loading="loading" :data="delegations" data-testid="delegation-table" :empty-text="includeInactive ? '暂无委托' : '暂无生效委托'">
-      <el-table-column label="委托人" prop="delegatorUserId" />
+    <el-table v-loading="loading" :data="delegations" data-testid="my-delegation-table" empty-text="暂无委托">
       <el-table-column label="被委托人" prop="delegateeUserId" />
       <el-table-column label="范围">
         <template #default="{ row }">{{ row.scope === 'template' ? `指定模板：${row.scopeTemplateId}` : '全部审批' }}</template>
@@ -32,34 +21,31 @@
           <el-tag :type="row.active ? 'success' : 'info'" size="small">{{ row.active ? '生效' : '已停用' }}</el-tag>
         </template>
       </el-table-column>
-      <el-table-column v-if="includeInactive" label="已路由审批" width="110">
+      <el-table-column label="已路由审批" width="110">
         <template #default="{ row }">
-          <span data-testid="delegation-routed" :title="'经该委托人路由的审批数（按委托人聚合，含历史窗口）'">{{ row.routedApprovalCount ?? 0 }}</span>
+          <span data-testid="my-delegation-routed" :title="'经你的委托路由的审批数（按委托人聚合，含历史窗口）'">{{ row.routedApprovalCount ?? 0 }}</span>
         </template>
       </el-table-column>
       <el-table-column label="操作" width="100">
         <template #default="{ row }">
-          <el-button v-if="row.active" type="danger" text size="small" :disabled="!canManage" data-testid="delegation-disable" @click="disable(row.id)">停用</el-button>
+          <el-button v-if="row.active" type="danger" text size="small" data-testid="my-delegation-disable" @click="disable(row.id)">停用</el-button>
         </template>
       </el-table-column>
     </el-table>
 
-    <el-dialog v-model="dialogOpen" title="新建委托" width="480px">
+    <el-dialog v-model="dialogOpen" title="新建我的委托" width="480px">
       <el-form label-width="92px">
-        <el-form-item label="委托人">
-          <el-input v-model="form.delegatorUserId" placeholder="委托人用户 ID" data-testid="delegation-delegator" />
-        </el-form-item>
         <el-form-item label="被委托人">
-          <el-input v-model="form.delegateeUserId" placeholder="被委托人用户 ID" data-testid="delegation-delegatee" />
+          <el-input v-model="form.delegateeUserId" placeholder="被委托人用户 ID" data-testid="my-delegation-delegatee" />
         </el-form-item>
         <el-form-item label="范围">
-          <el-select v-model="form.scope" data-testid="delegation-scope">
+          <el-select v-model="form.scope" data-testid="my-delegation-scope">
             <el-option label="全部审批" value="all" />
             <el-option label="指定模板" value="template" />
           </el-select>
         </el-form-item>
         <el-form-item v-if="form.scope === 'template'" label="模板">
-          <el-input v-model="form.scopeTemplateId" placeholder="审批模板 ID" data-testid="delegation-template" />
+          <el-input v-model="form.scopeTemplateId" placeholder="审批模板 ID" data-testid="my-delegation-template" />
         </el-form-item>
         <el-form-item label="开始时间">
           <el-date-picker v-model="form.startAt" type="datetime" value-format="YYYY-MM-DDTHH:mm" />
@@ -70,7 +56,7 @@
       </el-form>
       <template #footer>
         <el-button @click="dialogOpen = false">取消</el-button>
-        <el-button type="primary" :loading="saving" data-testid="delegation-submit" @click="submit">保存</el-button>
+        <el-button type="primary" :loading="saving" data-testid="my-delegation-submit" @click="submit">保存</el-button>
       </template>
     </el-dialog>
   </div>
@@ -79,27 +65,22 @@
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue'
 import { ElMessage } from 'element-plus'
-import { useApprovalPermissions } from '../../approvals/permissions'
 import {
-  listDelegations,
-  createDelegation,
-  disableDelegation,
-  validateDelegationForm,
-  buildCreatePayload,
+  listOwnDelegations,
+  createOwnDelegation,
+  disableOwnDelegation,
+  validateOwnDelegationForm,
+  buildOwnCreatePayload,
   type DelegationRecord,
-  type DelegationForm,
+  type OwnDelegationForm,
 } from '../../approvals/delegations'
 
-const { canManageTemplates: canManage } = useApprovalPermissions()
 const delegations = ref<DelegationRecord[]>([])
 const loading = ref(false)
 const saving = ref(false)
 const dialogOpen = ref(false)
-// Audit toggle: off = active only (default); on = active + history (disabled/expired).
-const includeInactive = ref(false)
 
-const form = reactive<DelegationForm>({
-  delegatorUserId: '',
+const form = reactive<OwnDelegationForm>({
   delegateeUserId: '',
   scope: 'all',
   scopeTemplateId: '',
@@ -115,7 +96,7 @@ function fmt(iso: string): string {
 async function load() {
   loading.value = true
   try {
-    delegations.value = await listDelegations({ includeInactive: includeInactive.value })
+    delegations.value = await listOwnDelegations()
   } catch (e) {
     ElMessage.error(e instanceof Error ? e.message : '加载委托失败')
   } finally {
@@ -124,19 +105,19 @@ async function load() {
 }
 
 function openCreate() {
-  Object.assign(form, { delegatorUserId: '', delegateeUserId: '', scope: 'all', scopeTemplateId: '', startAt: '', endAt: '' })
+  Object.assign(form, { delegateeUserId: '', scope: 'all', scopeTemplateId: '', startAt: '', endAt: '' })
   dialogOpen.value = true
 }
 
 async function submit() {
-  const error = validateDelegationForm(form)
+  const error = validateOwnDelegationForm(form)
   if (error) {
     ElMessage.warning(error)
     return
   }
   saving.value = true
   try {
-    await createDelegation(buildCreatePayload(form))
+    await createOwnDelegation(buildOwnCreatePayload(form))
     ElMessage.success('委托已创建')
     dialogOpen.value = false
     await load()
@@ -149,7 +130,7 @@ async function submit() {
 
 async function disable(id: string) {
   try {
-    await disableDelegation(id)
+    await disableOwnDelegation(id)
     await load()
   } catch (e) {
     ElMessage.error(e instanceof Error ? e.message : '停用委托失败')
@@ -160,9 +141,8 @@ onMounted(load)
 </script>
 
 <style scoped>
-.delegation-settings { padding: 16px; }
+.my-delegation { padding: 16px; }
 .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 12px; }
 .header h2 { margin: 0; }
-.actions { display: flex; align-items: center; gap: 12px; }
 .sub { color: var(--el-text-color-secondary); font-size: 13px; margin: 4px 0 0; }
 </style>

--- a/apps/web/tests/myDelegationForm.spec.ts
+++ b/apps/web/tests/myDelegationForm.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { validateOwnDelegationForm, buildOwnCreatePayload, type OwnDelegationForm } from '../src/approvals/delegations'
+
+const base: OwnDelegationForm = {
+  delegateeUserId: 'B',
+  scope: 'all',
+  scopeTemplateId: '',
+  startAt: '2026-06-22T00:00',
+  endAt: '2026-06-23T00:00',
+}
+
+describe('validateOwnDelegationForm (self-service — delegator is implicit)', () => {
+  it('passes a valid all-scope form', () => {
+    expect(validateOwnDelegationForm(base)).toBeNull()
+  })
+  it('requires a delegatee', () => {
+    expect(validateOwnDelegationForm({ ...base, delegateeUserId: '  ' })).toBe('请填写被委托人')
+  })
+  it("requires a template for scope='template'", () => {
+    expect(validateOwnDelegationForm({ ...base, scope: 'template' })).toBe('指定模板范围需要选择模板')
+  })
+  it('rejects an inverted / empty window', () => {
+    expect(validateOwnDelegationForm({ ...base, startAt: '2026-06-23T00:00', endAt: '2026-06-22T00:00' })).toBe('结束时间必须晚于开始时间')
+    expect(validateOwnDelegationForm({ ...base, endAt: '' })).toBe('请填写时间窗')
+  })
+})
+
+describe('buildOwnCreatePayload', () => {
+  it('never carries a delegatorUserId (delegator is forced server-side to the actor)', () => {
+    const payload = buildOwnCreatePayload(base)
+    expect('delegatorUserId' in payload).toBe(false)
+  })
+  it('trims the delegatee, nulls the template id for all-scope, and ISO-normalizes the window', () => {
+    const p = buildOwnCreatePayload({ ...base, delegateeUserId: ' B ', scope: 'all', scopeTemplateId: 't1' })
+    expect(p).toMatchObject({ delegateeUserId: 'B', scope: 'all', scopeTemplateId: null })
+    expect(p.startAt).toMatch(/Z$/)
+    expect(p.endAt).toMatch(/Z$/)
+  })
+  it('keeps the trimmed template id for template-scope', () => {
+    expect(buildOwnCreatePayload({ ...base, scope: 'template', scopeTemplateId: ' t1 ' }).scopeTemplateId).toBe('t1')
+  })
+})

--- a/apps/web/tests/myDelegationRoute.spec.ts
+++ b/apps/web/tests/myDelegationRoute.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+/**
+ * Source guard against the 我的委托 self-service page becoming an orphan: MyDelegationView.vue
+ * is only a usable capability if wired into the router. Asserted on the appRoutes.ts SOURCE
+ * (not an import — top-level view imports pull in Element Plus CSS vitest can't transform).
+ *
+ * Unlike 委托设置 (admin, approval-templates:manage), self-service is available to ANY
+ * authenticated user — it must be requiresAuth WITHOUT a manage permission.
+ */
+const routesSrc = readFileSync(
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/router/appRoutes.ts'),
+  'utf8',
+)
+
+describe('我的委托 (self-service) route', () => {
+  it('declares the /my-delegation route (MyDelegationView is reachable)', () => {
+    expect(routesSrc, 'no /my-delegation route — MyDelegationView would be unreachable').toContain("path: '/my-delegation'")
+  })
+
+  it('points the route at MyDelegationView', () => {
+    expect(routesSrc).toMatch(/my-delegation[\s\S]{0,200}MyDelegationView\.vue/)
+  })
+
+  it('does NOT gate self-service behind a manage permission (any authenticated user)', () => {
+    const block = routesSrc.slice(routesSrc.indexOf("path: '/my-delegation'"))
+    const meta = block.slice(0, block.indexOf('}', block.indexOf('meta:')))
+    expect(meta).toContain('requiresAuth: true')
+    expect(meta).not.toContain('permissions')
+  })
+})

--- a/docs/development/approval-C-delegation-selfservice-design-lock-20260703.md
+++ b/docs/development/approval-C-delegation-selfservice-design-lock-20260703.md
@@ -1,0 +1,95 @@
+# 审批委托 · C 委托体验增强（自助 + 审计可见）— 设计锁（design-lock）
+
+> **状态**：design-lock（2026-07-03）+ 本 slice 实现随本次提交落地（未 push，评审后 PR）。
+> **口径**：本文写 MetaSheet 自有设计口径（自助委托 / 审计可见 / 越权拒绝）。不引用任何竞品产品。审批模块**无 i18n 基础设施**——沿用既有硬编码中文（与 `DelegationSettingsView.vue` / `delegations.ts` 一致），本文记录此约定。
+> **基线**：代码实测 @ `origin/main`（worktree `metasheet2-cdeleg`）。
+> **承重前提**：委托**运行时已 SHIPPED**——resolve-time 冻结代换语义（frozen-at-start）**不改**。本 slice 只加运行时之上的**治理/体验层**：自助 + 审计可见，**不新建委托引擎**。
+
+---
+
+## 0. 一句话
+
+委托运行时（引擎）已完成；本 slice 补两个真实缺口——**普通用户自助管理自己的委托** + **管理员审计可见（含历史 + 有效期 + 经委托路由的审批数）**——并只在确有未防护缺口处加边界守卫。
+
+---
+
+## 1. 已 SHIPPED 的委托面（勿重建）
+
+代码实证（`origin/main`）：
+
+| 层 | 文件 | 已有能力 |
+|---|---|---|
+| 读种子（resolve 冻结） | `packages/core-backend/src/services/ApprovalDelegations.ts` | `resolveActiveDelegationMap(query, {templateId, now})` → 冻结 `delegator→delegatee` 代换 map；只 SELECT、不写；template scope 覆盖 all scope；无 self 边（表 CHECK）。 |
+| 配置 CRUD（写路径） | `packages/core-backend/src/services/ApprovalDelegationConfig.ts` | `createDelegation` / `listDelegations`（**仅 `WHERE active`**）/ `disableDelegation` / `updateDelegation`。`delegatorUserId` 是**任意可选字段**（管理员为任意人配置）。enum-strict 校验 + 表 CHECK 双保险；唯一活跃索引 → 同 (delegator, scope target) 二条活跃 = 409。 |
+| 路由 | `packages/core-backend/src/routes/approvals.ts` L800-857 | `GET/POST/PATCH/DELETE /api/approval-delegations` **全部** `approvalTemplateAdminGuard`（`rbacGuardAny(['approval-templates:manage','approvals:admin-templates'])`）——**100% 管理员专属**。 |
+| 前端 client | `apps/web/src/approvals/delegations.ts` | list/create/update/disable + 表单校验（中文）+ `buildCreatePayload`；create payload **携带 `delegatorUserId`**（管理员语义）。 |
+| 前端视图 | `apps/web/src/views/approval/DelegationSettingsView.vue`（route `/approval-delegations`，`permissions: ['approval-templates:manage']`） | 委托设置表格 + 新建对话框；**仅列活跃**。 |
+| resolve 代换 | `ApprovalAssigneeResolver.ts` `pushResolved` | 代换在 dedup key 前发生；**单跳**（delegatee 自己的委托不再解析，L111）；user-only；被代换的 assignment 带 `metadata.delegatedFrom = <原 delegator>`（审计痕迹）。 |
+| 代换审计痕迹落库 | `ApprovalProductService.insertAssignments` | `metadata`（含 `delegatedFrom`）JSONB 落入 `approval_assignments.metadata` → **「经委托路由」DB 可派生**（`metadata->>'delegatedFrom'`）。 |
+| 迁移 | `zzzz20260622060000_create_approval_delegations.ts` | 表 + window/not-self/scope/scope-target 4 个 CHECK + 唯一活跃索引 + 查询索引。 |
+
+---
+
+## 2. 缺口界定（EXACTLY 本 slice 填什么 / 什么已 SHIPPED）
+
+| 需求 | 现状 | 结论 |
+|---|---|---|
+| **自助**：用户设/撤自己的委托 | 路由 100% 管理员 guard；用户无路径。 | **真缺口 → 建**。 |
+| **审计/有效期可见** | `listDelegations` 只 `WHERE active`——历史（停用/过期）永不返回；无「经委托路由」读路径（数据在 assignment metadata 但无查询）。 | **真缺口 → 建**（含历史 + routed 数）。 |
+| 边界：self 委托（delegator==delegatee） | service 校验 + 表 CHECK 双防护。 | **已防护 → 仅记录**，不重建。 |
+| 边界：时间窗重叠调度 | 迁移注释明写「一 scope target 一条活跃」= 唯一活跃索引；多窗调度是 reopen-only。 | **设计既定 → 不加**。 |
+| 边界：委托链 A→B→C | resolver **单跳**（L111 明写 delegatee 自己的委托不再解析）。 | **已防护（冻结语义）→ 仅记录**。 |
+
+---
+
+## 3. 本 slice 设计锁（只新增 2 个边界）
+
+本 slice 只引入两条新边界；resolve 语义不动。
+
+### 3.1 自助（delegator = 自己，结构性强制）
+- 新增 `authenticate` + `rbacGuard('approvals','read')`（审批参与者底线，与 `/pending` 同）自助路由：
+  - `GET  /api/approval-delegations/mine` — 列**自己的**委托（活跃 + 历史），附 routed 数。
+  - `POST /api/approval-delegations/mine` — 建自己的委托；**`delegator_user_id` 服务端强制 = actor id，绝不读 body 的 `delegatorUserId`**（越权是结构性不可能，而非可回归的校验）。
+  - `DELETE /api/approval-delegations/mine/:id` — 停用自己的委托。
+- **无自助 PATCH**：「设/撤」= 建 + 停用；admin 路径里 delegator 本就不可改。
+- **权限口径**：自助授权的承重点是**归属校验**（delegator 强制 = actor + 停用前归属检查），RBAC 层只是「是不是审批用户」的底线；故 `approvals:read`。前端 route 仅 `requiresAuth`。
+
+### 3.2 越权停用 = 403 而非 404（SELECT-then-check 判别器）
+- `DELETE /mine/:id`：**先 SELECT**——不存在 → 404；存在但 `delegator_user_id ≠ actor` → **403**；否则停用 → 200。
+- 承重：一个 scoped `UPDATE ... WHERE id AND delegator=actor` 对「别人的行」返回 0 行 → 会误报 404，**破坏 VERIFY 要求的 403**。故 service 返回判别联合 `{status:'not_found'|'forbidden'|'ok'}`，路由映射状态码。
+
+### 3.3 审计可见（复用既有查询 + 派生）
+- 扩 `listDelegations(query, { delegatorUserId?, includeInactive? })`：`includeInactive` 时不加 `WHERE active`（管理员审计历史）；默认行为不变（活跃 only，向后兼容）。
+- 扩 `GET /api/approval-delegations` 接受 `?includeInactive=true`。
+- `routedApprovalCount`（该 delegator 名下经委托路由的**去重 instance 数**）派生自 `SELECT metadata->>'delegatedFrom' AS delegator, COUNT(DISTINCT instance_id) FROM approval_assignments WHERE metadata->>'delegatedFrom' IS NOT NULL GROUP BY 1`。
+- **热路径纪律（性能）**：该聚合是对 `approval_assignments`（增长最快的审批表）的 hash aggregate，且 `delegatedFrom` **无表达式索引** → 仅在 **audit 模式（`includeInactive=true`）** 计算并附加；默认「活跃/运营」视图**不付**该聚合、保持单条小查询（避免在最常用的默认视图上引入 seq-scan 回归）。FE「已路由审批」列亦仅在 audit（显示历史）模式渲染——默认视图**不显示**该列（避免误导性 0）。
+- **粒度诚实声明**：assignment metadata 只记 `delegatedFrom = delegator id`，**不记具体委托窗行**；故 routed 数是**按 delegator 聚合**（同 delegator 各行显示同一总数），非按单条委托窗。文档 + FE tooltip 明写此口径。
+
+### 3.4 前端（1 新视图 + 1 扩展视图）
+- 新 `MyDelegationView.vue`（route `/my-delegation`，仅 `requiresAuth`，任意登录用户）：我的委托——设/撤自己的（只填被委托人 + 范围 + 时间窗，委托人隐含=自己）+ 列自己的活跃 + 历史 + routed 数。
+- 扩 `DelegationSettingsView.vue`：加「显示历史」开关（`includeInactive`）；「已路由审批」列**仅在开关打开（audit 模式）时渲染**（默认运营视图不显示、不触发聚合）。**不建第二个审计视图**。
+
+---
+
+## 4. 验证计划（fail-first / real-DB）
+
+DB：`metasheet_cdeleg_test`（`CREATE DATABASE` → `migrate.ts` → `vitest.integration.config.ts`）。
+
+- **RED-before**：`/mine` 路由在 `origin/main` 不存在 → 自助测试初跑 404（红），实现后转绿。
+- 后端 real-DB（新 `approval-delegation-selfservice.db.test.ts`）：
+  1. 自助 actor 建自己的委托（即便 body 塞别人的 `delegatorUserId` 也强制 = actor）→ 201 且 delegator = actor。
+  2. 自助 actor 列自己的（含一条已停用的历史）。
+  3. 自助 actor 停用**自己的** → 200。
+  4. 自助 actor 停用**别人的** → **403**（判别器）。
+  5. 自助 actor 停用不存在的 → 404。
+- 后端 real-DB（扩既有 `approval-delegation-api.db.test.ts`）：
+  6. 管理员 `?includeInactive=true` 见到已停用行（历史）。
+  7. routed 数：扩既有「建委托 → 起审批 → assignment 解析到 delegatee」e2e，断言管理员审计 `routedApprovalCount ≥ 1` 且反映真实 resolver 输出（**真 resolver 输出，非手插 metadata fixture** — 遵 wire-vs-fixture-drift 规则；去重 instance 计数）。
+- 后端 unit（扩 `approval-delegation-config.test.ts`，fake query）：`includeInactive` SQL 分支 + `disableOwnDelegation` 判别联合三态。
+- 前端：`MyDelegationView` 渲染 + own 表单校验 + 扩展 admin 视图历史开关；`vue-tsc -b` 0 + `vitest`。
+- 回归：既有委托测试仍绿；后端 `tsc --noEmit` 0。
+
+---
+
+## 5. 不做（reopen-only）
+- 多窗重叠调度 / 委托链多跳 / 修改 resolve 冻结语义 / self-service PATCH / 逐委托窗的精确 routed 归因（需 metadata 增列，非本 slice）。

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -38,7 +38,7 @@ import {
   fetchCuratedApprovalRoleIds,
 } from '../services/approval-directory'
 import { isDatabaseSchemaError } from '../utils/database-errors'
-import { createDelegation, listDelegations, disableDelegation, updateDelegation } from '../services/ApprovalDelegationConfig'
+import { createDelegation, listDelegations, disableDelegation, updateDelegation, disableOwnDelegation, countDelegatedApprovals } from '../services/ApprovalDelegationConfig'
 import type { FormSchema } from '../types/approval-product'
 
 const logger = new Logger('ApprovalsRouter')
@@ -803,9 +803,73 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   r.get('/api/approval-delegations', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const delegatorUserId = typeof req.query.delegatorUserId === 'string' ? req.query.delegatorUserId : undefined
-      res.json({ data: await listDelegations(pool.query.bind(pool), { delegatorUserId }) })
+      // Audit mode: `?includeInactive=true` also returns disabled/expired rows (history).
+      const includeInactive = req.query.includeInactive === 'true' || req.query.includeInactive === '1'
+      const rows = await listDelegations(pool.query.bind(pool), { delegatorUserId, includeInactive })
+      // The routed-approval count is an AUDIT metric derived from the frozen `delegatedFrom`
+      // trail on approval_assignments.metadata (per-delegator granularity). It is a hash
+      // aggregate over approval_assignments (no expression index on delegatedFrom), so it is
+      // computed ONLY in audit mode — the default (active/operational) view stays a single
+      // small query and never pays the aggregate on its hot path.
+      if (!includeInactive) {
+        return res.json({ data: rows })
+      }
+      const routed = await countDelegatedApprovals(pool.query.bind(pool), delegatorUserId ? { delegatorUserId } : {})
+      res.json({ data: rows.map((row) => ({ ...row, routedApprovalCount: routed[row.delegatorUserId] ?? 0 })) })
     } catch (error) {
       handleApprovalsError(res, error, 'APPROVAL_DELEGATION_LIST_FAILED', 'Failed to list delegations')
+    }
+  })
+
+  // 我的委托 (self-service) — participant-gated (approvals:read), scoped to the ACTOR.
+  // The two boundaries this introduces (design-lock §3): create FORCES delegator = actor
+  // (body.delegatorUserId is ignored), and disable is 403 (not 404) on another's row.
+  // Registered BEFORE the admin `/:id` routes so `/mine` is never shadowed by `:id`.
+  r.get('/api/approval-delegations/mine', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      const actorId = resolveApprovalActorId(req)
+      if (!actorId) return res.status(401).json(approvalErrorResponse('APPROVAL_ACTOR_UNRESOLVED', 'Unable to resolve actor'))
+      // Own active + history (audit visibility for the delegator themselves), newest first.
+      const rows = await listDelegations(pool.query.bind(pool), { delegatorUserId: actorId, includeInactive: true })
+      const routed = await countDelegatedApprovals(pool.query.bind(pool), { delegatorUserId: actorId })
+      res.json({ data: rows.map((row) => ({ ...row, routedApprovalCount: routed[row.delegatorUserId] ?? 0 })) })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DELEGATION_MINE_LIST_FAILED', 'Failed to list own delegations')
+    }
+  })
+
+  r.post('/api/approval-delegations/mine', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      const actorId = resolveApprovalActorId(req)
+      if (!actorId) return res.status(401).json(approvalErrorResponse('APPROVAL_ACTOR_UNRESOLVED', 'Unable to resolve actor'))
+      const body = (req.body ?? {}) as Record<string, unknown>
+      // delegator is FORCED to the actor — body.delegatorUserId is never read (structural
+      // guarantee that a user cannot create a delegation on someone else's behalf).
+      const created = await createDelegation(pool.query.bind(pool), {
+        delegatorUserId: actorId,
+        delegateeUserId: typeof body.delegateeUserId === 'string' ? body.delegateeUserId : '',
+        scope: (typeof body.scope === 'string' ? body.scope : '') as 'all' | 'template',
+        scopeTemplateId: typeof body.scopeTemplateId === 'string' ? body.scopeTemplateId : null,
+        startAt: typeof body.startAt === 'string' ? body.startAt : '',
+        endAt: typeof body.endAt === 'string' ? body.endAt : '',
+      })
+      res.status(201).json({ data: created })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DELEGATION_MINE_CREATE_FAILED', 'Failed to create own delegation')
+    }
+  })
+
+  r.delete('/api/approval-delegations/mine/:id', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      const actorId = resolveApprovalActorId(req)
+      if (!actorId) return res.status(401).json(approvalErrorResponse('APPROVAL_ACTOR_UNRESOLVED', 'Unable to resolve actor'))
+      const id = typeof req.params.id === 'string' ? req.params.id : ''
+      const result = await disableOwnDelegation(pool.query.bind(pool), id, actorId)
+      if (result.status === 'not_found') return res.status(404).json(approvalErrorResponse('APPROVAL_DELEGATION_NOT_FOUND', 'Delegation not found'))
+      if (result.status === 'forbidden') return res.status(403).json(approvalErrorResponse('APPROVAL_DELEGATION_FORBIDDEN', 'You can only manage your own delegation'))
+      res.json({ data: { id, disabled: true } })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DELEGATION_MINE_DISABLE_FAILED', 'Failed to disable own delegation')
     }
   })
 

--- a/packages/core-backend/src/services/ApprovalDelegationConfig.ts
+++ b/packages/core-backend/src/services/ApprovalDelegationConfig.ts
@@ -118,15 +118,96 @@ export async function createDelegation(query: QueryFn, input: CreateDelegationIn
 }
 
 /**
- * List active delegations (admin view), newest window first; optionally filtered to one
- * delegator. Admin-managed — returns all delegators' rows, not just one caller's.
+ * List delegations, newest window first; optionally filtered to one delegator.
+ *
+ * Default is active-only (the shipped admin/list behavior — unchanged). Pass
+ * `includeInactive: true` for the audit/history view (also returns disabled/expired rows);
+ * pass `delegatorUserId` to scope to one delegator (the self-service `/mine` list forces
+ * this to the actor). Admin-managed unless the caller scopes it to their own id.
  */
-export async function listDelegations(query: QueryFn, filter: { delegatorUserId?: string } = {}): Promise<DelegationRecord[]> {
+export async function listDelegations(
+  query: QueryFn,
+  filter: { delegatorUserId?: string; includeInactive?: boolean } = {},
+): Promise<DelegationRecord[]> {
+  const delegator = filter.delegatorUserId?.trim()
+  const conditions: string[] = []
+  const params: unknown[] = []
+  if (!filter.includeInactive) conditions.push('active')
+  if (delegator) {
+    params.push(delegator)
+    conditions.push(`delegator_user_id = $${params.length}`)
+  }
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  const rows = (await query<DelegationRow>(`SELECT * FROM approval_delegations ${where} ORDER BY start_at DESC`, params)).rows
+  return rows.map(rowToRecord)
+}
+
+export type DisableOwnResult = { status: 'ok' } | { status: 'not_found' } | { status: 'forbidden' }
+
+/**
+ * Self-service disable (soft-delete) of the caller's OWN delegation. The route passes the
+ * authenticated actor's id as `delegatorUserId`; this SELECTs first so the outcome
+ * distinguishes:
+ *   - unknown id                              → `not_found` (route → 404)
+ *   - found but owned by someone else         → `forbidden` (route → 403, NOT a masking 404)
+ *   - found and owned by the caller           → `ok`        (route → 200; idempotent if already inactive)
+ *
+ * The SELECT-then-check is load-bearing: a scoped `UPDATE ... WHERE id AND delegator=actor`
+ * would affect 0 rows for another user's delegation and leak as a 404 — hiding the越权 attempt.
+ */
+export async function disableOwnDelegation(query: QueryFn, id: string, delegatorUserId: string): Promise<DisableOwnResult> {
+  const owner = delegatorUserId?.trim()
+  if (!owner) return { status: 'forbidden' }
+  const existing = (
+    await query<{ delegator_user_id: string }>(`SELECT delegator_user_id FROM approval_delegations WHERE id = $1`, [id])
+  ).rows[0]
+  if (!existing) return { status: 'not_found' }
+  if (existing.delegator_user_id !== owner) return { status: 'forbidden' }
+  await query(`UPDATE approval_delegations SET active = FALSE, updated_at = NOW() WHERE id = $1 AND active`, [id])
+  return { status: 'ok' }
+}
+
+/**
+ * Audit derivation (read-only): how many approvals were ROUTED via a delegation, keyed by
+ * the original delegator. Derived from the frozen `delegatedFrom` audit trail the resolver
+ * stamps on `approval_assignments.metadata` — counts DISTINCT approval instances (not
+ * assignment rows) per delegator. Optionally scoped to one delegator.
+ *
+ * Granularity note: the metadata records only the delegator id, not the specific delegation
+ * window, so the count is PER-DELEGATOR (every window row of a delegator shares the total),
+ * not per-delegation-row. Empty map when nothing was ever routed.
+ */
+export async function countDelegatedApprovals(
+  query: QueryFn,
+  filter: { delegatorUserId?: string } = {},
+): Promise<Record<string, number>> {
   const delegator = filter.delegatorUserId?.trim()
   const rows = delegator
-    ? (await query<DelegationRow>(`SELECT * FROM approval_delegations WHERE active AND delegator_user_id = $1 ORDER BY start_at DESC`, [delegator])).rows
-    : (await query<DelegationRow>(`SELECT * FROM approval_delegations WHERE active ORDER BY start_at DESC`)).rows
-  return rows.map(rowToRecord)
+    ? (
+        await query<{ delegator: string | null; cnt: string | number }>(
+          `SELECT metadata->>'delegatedFrom' AS delegator, COUNT(DISTINCT instance_id) AS cnt
+             FROM approval_assignments
+            WHERE metadata->>'delegatedFrom' = $1
+            GROUP BY metadata->>'delegatedFrom'`,
+          [delegator],
+        )
+      ).rows
+    : (
+        await query<{ delegator: string | null; cnt: string | number }>(
+          `SELECT metadata->>'delegatedFrom' AS delegator, COUNT(DISTINCT instance_id) AS cnt
+             FROM approval_assignments
+            WHERE metadata->>'delegatedFrom' IS NOT NULL
+            GROUP BY metadata->>'delegatedFrom'`,
+        )
+      ).rows
+  const map: Record<string, number> = {}
+  for (const row of rows) {
+    const key = typeof row.delegator === 'string' ? row.delegator.trim() : ''
+    if (!key) continue
+    const parsed = typeof row.cnt === 'number' ? row.cnt : Number.parseInt(String(row.cnt), 10)
+    map[key] = Number.isFinite(parsed) ? parsed : 0
+  }
+  return map
 }
 
 /**

--- a/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
@@ -166,6 +166,11 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
     const after = await req(base, '/api/approval-delegations', adminTok)
     const afterRows = ((await after.json()) as { data: Array<{ id: string }> }).data
     expect(afterRows.find((r) => r.id === id)).toBeUndefined()
+
+    // audit history: ?includeInactive=true surfaces the disabled row again (active:false)
+    const hist = await req(base, '/api/approval-delegations?includeInactive=true', adminTok)
+    const histRows = ((await hist.json()) as { data: Array<{ id: string; active: boolean }> }).data
+    expect(histRows.find((r) => r.id === id)).toMatchObject({ active: false })
   })
 
   it('end-to-end: create a delegation via the API → start an approval → assignment resolves to the delegatee', async () => {
@@ -210,5 +215,13 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
     ).rows.map((r) => r.assignee_id)
     expect(assignees).toContain(e2eTo)
     expect(assignees).not.toContain(e2eFrom)
+
+    // 4) audit derivation from REAL resolver output: the admin audit view reports
+    //    routedApprovalCount for the delegator, derived from the `delegatedFrom` trail the
+    //    resolver stamped on approval_assignments.metadata (NOT a hand-inserted fixture).
+    const audit = await req(base, `/api/approval-delegations?includeInactive=true&delegatorUserId=${encodeURIComponent(e2eFrom)}`, adminTok)
+    const auditRows = ((await audit.json()) as { data: Array<{ delegatorUserId: string; routedApprovalCount: number }> }).data
+    // e2eFrom is unique per run and exactly one instance routed through the delegation → exactly 1.
+    expect(auditRows.find((r) => r.delegatorUserId === e2eFrom)?.routedApprovalCount).toBe(1)
   })
 })

--- a/packages/core-backend/tests/integration/approval-delegation-selfservice.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-delegation-selfservice.db.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Delegation (委托) SELF-SERVICE — real-DB API. Exercises the participant-gated
+ * /api/approval-delegations/mine routes (approvals:read floor) against real Postgres.
+ *
+ * The two NEW boundaries this slice introduces (design-lock §3):
+ *   1. create-own FORCES delegator = actor (never reads body.delegatorUserId), and
+ *   2. disable-own on ANOTHER's row is 403 (not 404) — the SELECT-then-check discriminator.
+ *
+ * A regular approval participant (non-admin, holds only approvals:read) can manage
+ * their OWN delegation and see their own history, but can never touch someone else's.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const ACTOR = `del-self-actor-${TS}`
+const OTHER = `del-self-other-${TS}`
+const DELEGATEE = `del-self-to-${TS}`
+const NOPERM = `del-self-noperm-${TS}`
+const ADMIN = `del-self-admin-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string, roles: string, perms: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+const WINDOW = { startAt: new Date(Date.now() - 3600_000).toISOString(), endAt: new Date(Date.now() + 3600_000).toISOString() }
+
+describeIfDatabase('delegation (委托) self-service — real-DB API', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let actorTok = ''
+  let adminTok = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    const seedPool = poolManager.get()
+    // ACTOR: a non-admin participant whose only grant is approvals:read (legacy
+    // users.permissions path — approvals is a NON-namespaced resource so no admission
+    // row is needed). This proves the participant floor admits a self-service user.
+    await seedPool.query(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '["approvals:read"]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET permissions = '["approvals:read"]'::jsonb, is_admin = FALSE, is_active = TRUE`,
+      [ACTOR, `${ACTOR}@example.test`],
+    )
+    // NOPERM: a non-admin with an UNRELATED grant — must be rejected by the floor.
+    await seedPool.query(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '["multitable:read"]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET permissions = '["multitable:read"]'::jsonb, is_admin = FALSE, is_active = TRUE`,
+      [NOPERM, `${NOPERM}@example.test`],
+    )
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    actorTok = await tok(base, ACTOR, 'user', 'approvals:read')
+    adminTok = await tok(base, ADMIN, 'admin', '*:*')
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      await pool.query(`DELETE FROM approval_delegations WHERE delegator_user_id LIKE $1`, [`%-${TS}`])
+      await pool.query(`DELETE FROM users WHERE id = ANY($1)`, [[ACTOR, NOPERM]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // Floor: a non-admin WITHOUT approvals:read is rejected; a participant is admitted.
+  it('gates /mine on the approvals:read participant floor', async () => {
+    const noPermTok = await tok(base, NOPERM, 'user', 'multitable:read')
+    expect((await req(base, '/api/approval-delegations/mine', noPermTok)).status).toBe(403)
+    expect((await req(base, '/api/approval-delegations/mine', actorTok)).status).toBe(200)
+  })
+
+  // Boundary 1 — create FORCES delegator = actor (body.delegatorUserId is ignored).
+  it('creates own delegation with delegator forced to the actor (ignores body.delegatorUserId)', async () => {
+    const created = await req(base, '/api/approval-delegations/mine', actorTok, {
+      method: 'POST',
+      body: { delegatorUserId: OTHER, delegateeUserId: DELEGATEE, scope: 'all', ...WINDOW },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const rec = ((await created.json()) as { data: { id: string; delegatorUserId: string; delegateeUserId: string } }).data
+    expect(rec.delegatorUserId).toBe(ACTOR)
+    expect(rec.delegatorUserId).not.toBe(OTHER)
+    expect(rec.delegateeUserId).toBe(DELEGATEE)
+
+    // list own — the row is present and active
+    const listed = await req(base, '/api/approval-delegations/mine', actorTok)
+    const rows = ((await listed.json()) as { data: Array<{ id: string; delegatorUserId: string; active: boolean }> }).data
+    expect(rows.every((r) => r.delegatorUserId === ACTOR)).toBe(true)
+    expect(rows.find((r) => r.id === rec.id)).toMatchObject({ active: true })
+
+    // disable own → 200; then it stays visible as history (active:false)
+    expect((await req(base, `/api/approval-delegations/mine/${rec.id}`, actorTok, { method: 'DELETE' })).status).toBe(200)
+    const afterList = await req(base, '/api/approval-delegations/mine', actorTok)
+    const afterRows = ((await afterList.json()) as { data: Array<{ id: string; active: boolean }> }).data
+    expect(afterRows.find((r) => r.id === rec.id)).toMatchObject({ active: false })
+  })
+
+  // Boundary 2 — disable another's delegation is 403 (NOT 404); it also never appears in own list.
+  it('rejects disabling ANOTHER user delegation with 403 (not 404)', async () => {
+    // seed OTHER's delegation via the admin route (delegator = OTHER)
+    const seeded = await req(base, '/api/approval-delegations', adminTok, {
+      method: 'POST',
+      body: { delegatorUserId: OTHER, delegateeUserId: DELEGATEE, scope: 'all', ...WINDOW },
+    })
+    expect(seeded.status, await seeded.clone().text()).toBe(201)
+    const otherId = ((await seeded.json()) as { data: { id: string } }).data.id
+
+    // ACTOR cannot see OTHER's row in their own list
+    const ownList = await req(base, '/api/approval-delegations/mine', actorTok)
+    const ownRows = ((await ownList.json()) as { data: Array<{ id: string }> }).data
+    expect(ownRows.find((r) => r.id === otherId)).toBeUndefined()
+
+    // ACTOR disabling OTHER's row → 403 (found-but-not-owner), never a masking 404
+    expect((await req(base, `/api/approval-delegations/mine/${otherId}`, actorTok, { method: 'DELETE' })).status).toBe(403)
+
+    // OTHER's row is untouched (still active) — the 403 did not soft-delete it
+    const stillActive = (
+      await poolManager.get().query<{ active: boolean }>(`SELECT active FROM approval_delegations WHERE id = $1`, [otherId])
+    ).rows[0]
+    expect(stillActive?.active).toBe(true)
+  })
+
+  // Unknown id → 404 (distinct from the 403 above).
+  it('returns 404 disabling a non-existent delegation', async () => {
+    expect(
+      (await req(base, `/api/approval-delegations/mine/00000000-0000-0000-0000-000000000000`, actorTok, { method: 'DELETE' })).status,
+    ).toBe(404)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-delegation-config.test.ts
+++ b/packages/core-backend/tests/unit/approval-delegation-config.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { createDelegation, listDelegations, disableDelegation, updateDelegation } from '../../src/services/ApprovalDelegationConfig'
+import {
+  createDelegation,
+  listDelegations,
+  disableDelegation,
+  updateDelegation,
+  disableOwnDelegation,
+  countDelegatedApprovals,
+} from '../../src/services/ApprovalDelegationConfig'
 
 const WINDOW = { startAt: '2026-06-22T00:00:00Z', endAt: '2026-06-23T00:00:00Z' }
 const okRow = {
@@ -58,6 +65,78 @@ describe('ApprovalDelegationConfig.listDelegations', () => {
     expect(list).toEqual([
       { id: 'd1', delegatorUserId: 'A', delegateeUserId: 'B', scope: 'template', scopeTemplateId: 't1', startAt: '2026-06-22T00:00:00.000Z', endAt: '2026-06-23T00:00:00.000Z', active: true },
     ])
+  })
+
+  it('default (active-only) filters WHERE active; delegator filter is parameterized', async () => {
+    let sql = ''
+    let params: unknown[] = []
+    const q = async <Row>(text: string, p?: unknown[]): Promise<{ rows: Row[] }> => {
+      sql = text
+      params = p ?? []
+      return { rows: [] as Row[] }
+    }
+    await listDelegations(q, { delegatorUserId: '  A  ' })
+    expect(sql).toMatch(/WHERE active AND delegator_user_id = \$1/)
+    expect(params).toEqual(['A'])
+  })
+
+  it('includeInactive drops the active predicate (history/audit view)', async () => {
+    let sql = ''
+    const q = async <Row>(text: string): Promise<{ rows: Row[] }> => {
+      sql = text
+      return { rows: [] as Row[] }
+    }
+    await listDelegations(q, { includeInactive: true })
+    expect(sql).not.toMatch(/WHERE/)
+    await listDelegations(q, { delegatorUserId: 'A', includeInactive: true })
+    expect(sql).toMatch(/WHERE delegator_user_id = \$1/)
+    expect(sql).not.toMatch(/active/)
+  })
+})
+
+describe('ApprovalDelegationConfig.disableOwnDelegation (self-service 403-vs-404 discriminator)', () => {
+  it('returns not_found for an unknown id (route → 404)', async () => {
+    expect(await disableOwnDelegation(rowsQuery([]), 'd1', 'A')).toEqual({ status: 'not_found' })
+  })
+  it("returns forbidden when the row is owned by someone else (route → 403, NOT a masking 404)", async () => {
+    expect(await disableOwnDelegation(rowsQuery([{ delegator_user_id: 'B' }]), 'd1', 'A')).toEqual({ status: 'forbidden' })
+  })
+  it('returns forbidden when no actor id is supplied', async () => {
+    expect(await disableOwnDelegation(rowsQuery([{ delegator_user_id: 'A' }]), 'd1', '   ')).toEqual({ status: 'forbidden' })
+  })
+  it('returns ok when the caller owns the row, and issues the disabling UPDATE', async () => {
+    const seen: string[] = []
+    const q = async <Row>(text: string): Promise<{ rows: Row[] }> => {
+      seen.push(text)
+      return { rows: (seen.length === 1 ? [{ delegator_user_id: 'A' }] : []) as Row[] }
+    }
+    expect(await disableOwnDelegation(q, 'd1', '  A  ')).toEqual({ status: 'ok' })
+    expect(seen[0]).toMatch(/SELECT delegator_user_id/)
+    expect(seen[1]).toMatch(/UPDATE approval_delegations SET active = FALSE/)
+  })
+})
+
+describe('ApprovalDelegationConfig.countDelegatedApprovals (audit derivation)', () => {
+  it('parses bigint COUNT strings into a delegator→count map', async () => {
+    const map = await countDelegatedApprovals(rowsQuery([
+      { delegator: 'A', cnt: '3' },
+      { delegator: 'C', cnt: 1 },
+    ]))
+    expect(map).toEqual({ A: 3, C: 1 })
+  })
+  it('scopes the query to one delegator when filtered', async () => {
+    let params: unknown[] = []
+    const q = async <Row>(_text: string, p?: unknown[]): Promise<{ rows: Row[] }> => {
+      params = p ?? []
+      return { rows: [{ delegator: 'A', cnt: '2' }] as Row[] }
+    }
+    const map = await countDelegatedApprovals(q, { delegatorUserId: '  A  ' })
+    expect(params).toEqual(['A'])
+    expect(map).toEqual({ A: 2 })
+  })
+  it('ignores rows with a null/blank delegator key', async () => {
+    const map = await countDelegatedApprovals(rowsQuery([{ delegator: null, cnt: '9' }]))
+    expect(map).toEqual({})
   })
 })
 


### PR DESCRIPTION
Arc **C** — the UX/governance layer on the **already-shipped** delegation (委托) runtime. Grounded the shipped surface first (`ApprovalDelegations` resolve-time frozen map · `ApprovalDelegationConfig` CRUD · admin-only `/api/approval-delegations` · `DelegationSettingsView` · `delegatedFrom` metadata trail · self/overlap/chain guards) and **did not rebuild it** — only filled the two genuine gaps.

## Gaps filled
- **Self-service (was 100% admin-only):** participant-gated (`approvals:read`) `/api/approval-delegations/mine` GET/POST/DELETE + `MyDelegationView.vue` at `/my-delegation` (`requiresAuth`, no manage perm). **Security:** create **FORCES `delegator = actor`** (`body.delegatorUserId` is ignored — structural, not validated-away); disable is **403 (not 404)** on another's row via a SELECT-then-check discriminator (`disableOwnDelegation`).
- **Audit visibility:** `listDelegations` gained `includeInactive` (history); the admin view gets a "显示历史" toggle surfacing active+historical + a per-delegator `routedApprovalCount` (`COUNT(DISTINCT instance_id)` from the real `delegatedFrom` trail). Efficiency-review fix: the routed-count aggregate runs **only in audit mode**, so the default operational view keeps its single small query.
- **Boundaries:** self-delegation / range-overlap / delegatee-chains are **already guarded** (service check + table CHECK + one-active unique index + single-hop resolver) — documented, not rebuilt.

## Verification (real-DB `metasheet_cdeleg_test`)
`tsc` 0 · `vue-tsc` 0 · **RED-before proven** (self-service test hit `Cannot POST /api/approval-delegations/mine` 404 before impl) · self-service **5/5** (incl. forced-delegator + 403-not-404) · api **5/5** (history + real-resolver routed count `toBe(1)`) · unit 22 · regression 118 · FE 20. Reviewed by two agents (correctness: zero bugs) + advisor.

## For your confirmation (flagged)
- `/mine` gate = `approvals:read` (participant floor, matches `/pending`); the **self-ownership constraint is the real authorization**. Defensible vs `approvals:act` — your call.
- Routed attribution is **per-delegator**, not per-window (metadata records the delegator id, not which delegation window) — stated in the doc + FE tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)