### PR TITLE
test(integration-web): tripwire — resolver vocab client/server mirror parity (#1709)

### DIFF
--- a/apps/web/src/services/integration/readSourceConfigs.ts
+++ b/apps/web/src/services/integration/readSourceConfigs.ts
@@ -384,13 +384,30 @@ const EVIDENCE_CONTAINER_ALIASES = ['primary', 'header', 'lines'] as const
 const EVIDENCE_SHAPE_TYPES = new Set(['array', 'null', 'object', 'string', 'number', 'boolean', 'missing', 'other'])
 const EVIDENCE_BOOLEAN_KEYS = ['containerLocated', 'boundedSmokeExecuted', 'timeoutReached', 'capReached', 'ambiguous', 'resolved'] as const
 const EVIDENCE_COUNT_KEYS = ['recordCount', 'rowCount', 'sampleCount', 'candidateCount', 'matchedCount'] as const
-// R0: resolver evidence `rule` closed vocabulary (mirrors read-source-config RESOLVER_RULES).
-const EVIDENCE_RESOLVER_RULES = new Set(['exactly_one', 'first_when_sorted', 'field_equals'])
+// R0: resolver evidence `rule` closed vocabulary (mirrors read-source-config RESOLVER_RULES). Exported for
+// the mirror-parity tripwire.
+export const EVIDENCE_RESOLVER_RULES = new Set(['exactly_one', 'first_when_sorted', 'field_equals'])
 
 // Client-side mirrors of the FROZEN S2-a vocabularies — source of truth:
 // plugins/plugin-integration-core/lib/read-source-probe-contract.cjs
 // (READ_SOURCE_PROBE_ERROR_CODES / READ_SOURCE_PROBE_ERROR_TYPES). Anything outside these closed
 // sets — even an enum-SHAPED string — is replaced by the coarse fallback, never rendered verbatim.
+// R0 (#1709 resolver): the 9 exact resolver coarse codes (no prefix match — unknown resolver-looking
+// codes still fall back to READ_SOURCE_PROBE_FAILED). Client mirror of the server's exported
+// READ_SOURCE_RESOLVER_ERROR_CODES (read-source-probe-contract.cjs); kept as a named export so the
+// mirror-parity tripwire (multitable-resolver-vocab-mirror.spec.ts) can assert it === the server set.
+export const RESOLVER_ERROR_CODES = [
+  'READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND',
+  'READ_SOURCE_RESOLVER_SHAPE_MISMATCH',
+  'READ_SOURCE_RESOLVER_NO_MATCH',
+  'READ_SOURCE_RESOLVER_AMBIGUOUS',
+  'READ_SOURCE_RESOLVER_CAP_REACHED',
+  'READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED',
+  'READ_SOURCE_RESOLVER_RULE_INVALID',
+  'READ_SOURCE_RESOLVER_FIELD_MISSING',
+  'READ_SOURCE_RESOLVER_FAILED',
+] as const
+
 const READ_SOURCE_PROBE_ERROR_CODES = new Set([
   'READ_SOURCE_PROBE_CONTRACT_INVALID',
   'READ_SOURCE_PROBE_FAILED',
@@ -403,17 +420,7 @@ const READ_SOURCE_PROBE_ERROR_CODES = new Set([
   'READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED',
   'READ_SOURCE_PROBE_SHAPE_MISMATCH',
   'READ_SOURCE_PROBE_TIMEOUT',
-  // R0 (#1709 resolver): the 9 exact resolver coarse codes (no prefix match — unknown resolver-looking
-  // codes still fall back to READ_SOURCE_PROBE_FAILED).
-  'READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND',
-  'READ_SOURCE_RESOLVER_SHAPE_MISMATCH',
-  'READ_SOURCE_RESOLVER_NO_MATCH',
-  'READ_SOURCE_RESOLVER_AMBIGUOUS',
-  'READ_SOURCE_RESOLVER_CAP_REACHED',
-  'READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED',
-  'READ_SOURCE_RESOLVER_RULE_INVALID',
-  'READ_SOURCE_RESOLVER_FIELD_MISSING',
-  'READ_SOURCE_RESOLVER_FAILED',
+  ...RESOLVER_ERROR_CODES,
 ])
 const READ_SOURCE_PROBE_ERROR_TYPES = new Set([
   'Error',

--- a/apps/web/tests/multitable-resolver-vocab-mirror.spec.ts
+++ b/apps/web/tests/multitable-resolver-vocab-mirror.spec.ts
@@ -1,0 +1,48 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Mirror-sync tripwire (#1709): the resolver_lookup closed vocabularies are mirrored client-side in
+// readSourceConfigs.ts from the server source-of-truth (plugins/plugin-integration-core/lib/*.cjs). If the
+// server ever extends a rule, sort direction, or coarse code and the client is not synced, the client
+// silently drops the new value. This test fails RED the moment the two diverge — sync readSourceConfigs.ts
+// (and the R3 UI/tests) whenever it does.
+import {
+  RESOLVER_RULES,
+  RESOLVER_SORT_DIRECTIONS,
+  RESOLVER_ERROR_CODES,
+  EVIDENCE_RESOLVER_RULES,
+} from '../src/services/integration/readSourceConfigs'
+
+const require = createRequire(import.meta.url)
+const pluginLib = path.resolve(__dirname, '../../../plugins/plugin-integration-core/lib')
+// The server exports these directly — require, never text-parse.
+const { RESOLVER_RULES: SERVER_RESOLVER_RULES, RESOLVER_SORT_DIRECTIONS: SERVER_RESOLVER_SORT_DIRECTIONS } =
+  require(path.join(pluginLib, 'read-source-config.cjs'))
+const { READ_SOURCE_RESOLVER_ERROR_CODES: SERVER_RESOLVER_ERROR_CODES, READ_SOURCE_RESOLVER_RULES: SERVER_EVIDENCE_RESOLVER_RULES } =
+  require(path.join(pluginLib, 'read-source-probe-contract.cjs'))
+
+const set = (values: Iterable<string>): Set<string> => new Set(values)
+
+describe('resolver vocab client/server mirror parity (tripwire)', () => {
+  it('client RESOLVER_RULES === server RESOLVER_RULES', () => {
+    expect(set(RESOLVER_RULES)).toEqual(set(SERVER_RESOLVER_RULES))
+  })
+
+  it('client RESOLVER_SORT_DIRECTIONS === server RESOLVER_SORT_DIRECTIONS', () => {
+    expect(set(RESOLVER_SORT_DIRECTIONS)).toEqual(set(SERVER_RESOLVER_SORT_DIRECTIONS))
+  })
+
+  it('client RESOLVER_ERROR_CODES === server READ_SOURCE_RESOLVER_ERROR_CODES (the 9 exact codes)', () => {
+    expect(set(RESOLVER_ERROR_CODES)).toEqual(set(SERVER_RESOLVER_ERROR_CODES))
+    // guard the count so a same-size swap still trips
+    expect(RESOLVER_ERROR_CODES.length).toBe(9)
+    expect(new Set(RESOLVER_ERROR_CODES).size).toBe(9)
+  })
+
+  it('client EVIDENCE_RESOLVER_RULES === server READ_SOURCE_RESOLVER_RULES, both === RESOLVER_RULES', () => {
+    expect(EVIDENCE_RESOLVER_RULES).toEqual(set(SERVER_EVIDENCE_RESOLVER_RULES))
+    expect(EVIDENCE_RESOLVER_RULES).toEqual(set(RESOLVER_RULES))
+    expect(set(SERVER_EVIDENCE_RESOLVER_RULES)).toEqual(set(SERVER_RESOLVER_RULES))
+  })
+})


### PR DESCRIPTION
## What

Mirror-sync tripwire (owner-requested). The resolver_lookup closed vocabularies are mirrored client-side (readSourceConfigs.ts) from the server source-of-truth; if either side extends a rule/code without the other syncing, the client silently drops the new value. This test fails **RED** whenever they diverge — so CI catches the drift instead of a human.

## How

New `apps/web/tests/multitable-resolver-vocab-mirror.spec.ts` (web vitest, 4 tests). `require`s the server exports via `createRequire` + relative path (no text-parse — both server .cjs export the consts). Set-equality (order-independent, exact membership + size guards so a same-size swap still trips):
- client RESOLVER_RULES === server RESOLVER_RULES
- client RESOLVER_SORT_DIRECTIONS === server RESOLVER_SORT_DIRECTIONS
- client RESOLVER_ERROR_CODES === server READ_SOURCE_RESOLVER_ERROR_CODES (9 codes)
- client EVIDENCE_RESOLVER_RULES === server READ_SOURCE_RESOLVER_RULES, both === RESOLVER_RULES

**Export-only, zero runtime change:** extracted the 9 resolver codes (previously inline in the client READ_SOURCE_PROBE_ERROR_CODES set) into a named `export const RESOLVER_ERROR_CODES` and spread them back into that set — identical membership, one client source of truth; `EVIDENCE_RESOLVER_RULES` const→export.

## Verification

Fail-first proven: injecting a fake code into the client set turns the test RED (set-diff + count guard), reverted → green. Gates: tripwire 4/4; workbench specs 65/65 (no regression); web type-check + lint clean.

Closes the client/server mirror-drift hazard flagged after R3 (the class that bit R0's client MODE_REQUIRED + the C6 token comment this line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)