### PR TITLE
fix(multitable): schedule config-revision retention sweep (T9 D4 one-knob-ages-both)

### DIFF
--- a/packages/core-backend/src/multitable/meta-revision-retention.ts
+++ b/packages/core-backend/src/multitable/meta-revision-retention.ts
@@ -198,7 +198,8 @@ export interface MetaRevisionRetentionSchedulerOptions {
 }
 
 /**
- * Runtime entry: start the periodic retention sweep. **No-op (returns immediately) when retention is
+ * Runtime entry: start the periodic retention sweep of BOTH `meta_record_revisions` and
+ * `meta_config_revisions` (T9 D4 — one knob ages both). **No-op (returns immediately) when retention is
  * disabled** — which is the default — so wiring this into bootstrap changes nothing until the owner
  * sets `MULTITABLE_META_REVISION_RETENTION_ENABLED=1`. Mirrors `startMultitableAttachmentCleanup`
  * (setInterval + returned stop fn; errors are logged, never crash the process). Returns a stop fn.
@@ -214,10 +215,18 @@ export function startMetaRevisionRetention(options: MetaRevisionRetentionSchedul
   const queryFn = options.query ?? (dbQuery as unknown as RetentionQueryFn)
   const intervalMs = options.intervalMs ?? resolveIntervalMs(env.MULTITABLE_META_REVISION_RETENTION_INTERVAL_MS)
   const runSweep = () => {
+    // T9 D4: one knob ages BOTH append-only logs. Sweep record revisions AND config/schema
+    // revisions each tick, under the same policy/flag/interval (#3168 "same policy as records").
+    // The two are isolated: a failure of one never blocks the other, and each keeps the
+    // never-delete-latest floor inside its own sweep fn.
     void Promise.resolve()
       .then(() => sweepMetaRevisionRetention(queryFn, config))
-      .then((deleted) => { if (deleted > 0) logger.info(`Meta-revision retention pruned ${deleted} revision(s)`) })
+      .then((deleted) => { if (deleted > 0) logger.info(`Meta-revision retention pruned ${deleted} record revision(s)`) })
       .catch((error) => logger.warn('Meta-revision retention sweep failed', error as Error))
+    void Promise.resolve()
+      .then(() => sweepConfigRevisionRetention(queryFn, config))
+      .then((deleted) => { if (deleted > 0) logger.info(`Meta-revision retention pruned ${deleted} config revision(s)`) })
+      .catch((error) => logger.warn('Config-revision retention sweep failed', error as Error))
   }
   const timer = setInterval(runSweep, intervalMs)
   if (typeof timer === 'object' && 'unref' in timer) (timer as { unref: () => void }).unref()

--- a/packages/core-backend/tests/unit/meta-revision-retention.test.ts
+++ b/packages/core-backend/tests/unit/meta-revision-retention.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import {
   META_REVISION_RETENTION_DEFAULT_KEEP_N,
@@ -69,5 +69,30 @@ describe('meta-revision retention config', () => {
     })
     expect(typeof stop).toBe('function')
     stop() // clears the interval without error
+  })
+
+  test('scheduler: enabled sweeps BOTH record and config revisions on a tick (T9 D4 — one knob ages both)', async () => {
+    const seenSql: string[] = []
+    const queryFn = (async (sql: string) => { seenSql.push(String(sql)); return { rows: [], rowCount: 0 } }) as never
+    vi.useFakeTimers()
+    try {
+      const stop = startMetaRevisionRetention({
+        env: { MULTITABLE_META_REVISION_RETENTION_ENABLED: '1' },
+        query: queryFn,
+        logger: silentLogger,
+        intervalMs: 1_000,
+      })
+      await vi.advanceTimersByTimeAsync(1_000) // fire one tick + flush the async sweep chains
+      stop()
+    } finally {
+      vi.useRealTimers()
+    }
+    const joined = seenSql.join('\n')
+    // record-revision sweep ran (already wired before this fix)…
+    expect(joined).toContain('meta_record_revisions')
+    // …AND the config-revision sweep ran — the wiring gap this fix closes (config revisions
+    // were never pruned by the scheduler even with retention enabled, despite #3168's
+    // "same policy as records" / one-knob-ages-both intent).
+    expect(joined).toContain('meta_config_revisions')
   })
 })


### PR DESCRIPTION
## The gap
`startMetaRevisionRetention` wired only `sweepMetaRevisionRetention` (record revisions). `sweepConfigRevisionRetention` existed and was real-DB tested, but the scheduler **never called it** — so `meta_config_revisions` grew unbounded even with retention enabled, contradicting #3168's design intent ("T9 D4 config-revision retention sweep **same policy as records**" / "one knob ages both").

Found during a primary-source re-assessment of the Global History / version-restore line (the line is otherwise essentially complete; this was the one genuine runtime gap — everything else remaining is owner-gated or a doc-staleness fix).

## The fix
`runSweep` now runs **both** sweeps each tick, isolated (one failing never blocks the other), under the same flag/policy/interval, each keeping its own never-delete-latest floor. Inert until `MULTITABLE_META_REVISION_RETENTION_ENABLED=1` (unchanged default-off gate) — so this changes nothing in prod today.

## Verify
Unit test asserts one tick sweeps BOTH `meta_record_revisions` and `meta_config_revisions` (would have failed before the wiring). `8/8` pass in `tests/unit/meta-revision-retention.test.ts`. The sweep functions themselves are unchanged (their real-DB tests still hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)