### PR TITLE
feat(attendance): #3530 batch anomaly resolution modal (frontend-only)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1062,12 +1062,44 @@
             </button>
           </div>
           <small class="attendance__field-hint">{{ anomaliesTimezoneContextHint }}</small>
+          <div v-if="anomalies.length > 0" class="attendance__batch-toolbar" data-attendance-batch-toolbar>
+            <button
+              v-if="attendanceResultEditCapabilityUnknown"
+              class="attendance__btn"
+              data-attendance-batch-probe
+              @click="probeBatchAnomalyCapability"
+            >
+              {{ tr('Check edit access', '检查更正权限') }}
+            </button>
+            <template v-else>
+              <span class="attendance__field-hint" data-attendance-batch-selected-count>
+                {{ tr(`Selected anomaly rows: ${batchAnomalySelectedCount}`, `已选异常行：${batchAnomalySelectedCount}`) }}
+              </span>
+              <button
+                class="attendance__btn attendance__btn--primary"
+                :disabled="Boolean(batchAnomalySubmitDisabledReason)"
+                :title="batchAnomalySubmitDisabledReason || undefined"
+                data-attendance-batch-resolve
+                @click="openBatchAnomalyModal"
+              >
+                {{ tr('Batch resolve', '批量处理') }}
+              </button>
+              <small
+                v-if="batchAnomalySubmitDisabledReason"
+                class="attendance__field-hint"
+                data-attendance-batch-disabled-reason
+              >
+                {{ batchAnomalySubmitDisabledReason }}
+              </small>
+            </template>
+          </div>
           <div v-if="anomaliesLoading" class="attendance__empty">{{ tr('Loading anomalies...', '正在加载异常...') }}</div>
           <div v-else-if="anomalies.length === 0" class="attendance__empty">{{ tr('No anomalies.', '暂无异常。') }}</div>
           <div v-else class="attendance__table-wrapper">
             <table class="attendance__table">
               <thead>
                 <tr>
+                  <th class="attendance__batch-check-col"></th>
                   <th>{{ tr('Date', '日期') }}</th>
                   <th>{{ tr('Status', '状态') }}</th>
                   <th>{{ tr('Warnings', '警告') }}</th>
@@ -1077,6 +1109,16 @@
               </thead>
               <tbody>
                 <tr v-for="item in anomalies" :key="item.recordId">
+                  <td class="attendance__batch-check-col">
+                    <input
+                      type="checkbox"
+                      :checked="isBatchAnomalyRowSelected(item.recordId)"
+                      :disabled="!isBatchAnomalyRowSelectable(item)"
+                      :title="isBatchAnomalyRowSelectable(item) ? undefined : (attendanceResultEditDisabledReason(item) || tr('Check admin permission before editing.', '更正前需先检查管理员权限。'))"
+                      data-attendance-batch-select
+                      @change="toggleBatchAnomalyRow(item)"
+                    />
+                  </td>
                   <td>{{ item.workDate }}</td>
                   <td>{{ formatStatus(item.status) }}</td>
                   <td>{{ formatWarningsShort(item.warnings) }}</td>
@@ -9034,6 +9076,136 @@
         </div>
       </div>
     </div>
+
+    <div
+      v-if="batchAnomalyModal.open && batchAnomalyModal.snapshot"
+      class="attendance__modal"
+      role="dialog"
+      aria-modal="true"
+      data-attendance-batch-modal
+    >
+      <div class="attendance__modal-body attendance__result-edit-modal">
+        <div class="attendance__admin-section-header">
+          <div>
+            <h4>{{ tr('Batch resolve anomalies', '批量处理异常') }}</h4>
+            <small class="attendance__field-hint">
+              {{ tr(`Selected anomaly rows: ${batchAnomalyModal.snapshot.rows.length}`, `已选异常行：${batchAnomalyModal.snapshot.rows.length}`) }}
+              <template v-if="batchAnomalyModal.snapshot.rows[0] && batchAnomalyModal.snapshot.rows[0].targetUserId">
+                · {{ batchAnomalyModal.snapshot.rows[0].targetUserId }}
+              </template>
+            </small>
+          </div>
+          <button class="attendance__btn" type="button" @click="closeBatchAnomalyModal">
+            {{ tr('Close', '关闭') }}
+          </button>
+        </div>
+
+        <p class="attendance__field-hint" data-attendance-batch-individual-warning>
+          {{ tr('Rows are processed individually; failures are reported per row.', '各行逐条处理，失败按行分别报告。') }}
+        </p>
+
+        <div class="attendance__result-edit-summary" data-attendance-batch-preview>
+          <div
+            v-for="row in batchAnomalyModal.snapshot.rows"
+            :key="row.recordId"
+            data-attendance-batch-preview-row
+          >
+            <span>{{ row.workDate }} · {{ formatStatus(row.sourceStatus) }}</span>
+            <span
+              v-if="batchAnomalyRowResult(row.recordId)"
+              class="attendance__status-chip"
+              :data-attendance-batch-row-state="batchAnomalyRowResult(row.recordId)?.state"
+            >
+              <template v-if="batchAnomalyRowResult(row.recordId)?.state === 'ok'">
+                {{ batchAnomalyRowResult(row.recordId)?.alreadyApplied ? tr('Already applied', '已应用') : tr('Applied', '已更正') }}
+                <template v-if="batchAnomalyRowResult(row.recordId)?.editId"> · {{ batchAnomalyRowResult(row.recordId)?.editId }}</template>
+              </template>
+              <template v-else-if="batchAnomalyRowResult(row.recordId)?.state === 'error'">
+                {{ batchAnomalyRowResult(row.recordId)?.errorMessage }}
+              </template>
+              <template v-else>{{ tr('Submitting...', '提交中...') }}</template>
+            </span>
+          </div>
+        </div>
+
+        <div class="attendance__request-form attendance__result-edit-form">
+          <label class="attendance__field" for="attendance-batch-target">
+            <span>{{ tr('Target status', '目标状态') }}</span>
+            <select
+              id="attendance-batch-target"
+              v-model="batchAnomalyModal.targetStatus"
+              name="batchTargetStatus"
+              data-attendance-batch-target
+            >
+              <option v-for="status in ATTENDANCE_RESULT_EDIT_TARGET_STATUSES" :key="status" :value="status">
+                {{ attendanceResultEditTargetLabel(status) }}
+              </option>
+            </select>
+          </label>
+          <label class="attendance__field attendance__field--full" for="attendance-batch-reason">
+            <span>{{ tr('Reason', '原因') }}</span>
+            <textarea
+              id="attendance-batch-reason"
+              v-model="batchAnomalyModal.reason"
+              maxlength="500"
+              name="batchReason"
+              rows="3"
+              data-attendance-batch-reason
+            />
+            <small class="attendance__field-hint">
+              {{ attendanceResultEditReasonRequired ? tr('Required by policy.', '策略要求填写。') : tr('Optional by policy.', '策略未强制要求。') }}
+            </small>
+          </label>
+          <label class="attendance__field" for="attendance-batch-evidence-label">
+            <span>{{ tr('Evidence label', '证据标签') }}</span>
+            <input
+              id="attendance-batch-evidence-label"
+              v-model="batchAnomalyModal.evidenceLabel"
+              maxlength="240"
+              name="batchEvidenceLabel"
+              type="text"
+              data-attendance-batch-evidence-label
+            />
+          </label>
+          <label class="attendance__field" for="attendance-batch-evidence-url">
+            <span>{{ tr('Evidence URL', '证据链接') }}</span>
+            <input
+              id="attendance-batch-evidence-url"
+              v-model="batchAnomalyModal.evidenceUrl"
+              name="batchEvidenceUrl"
+              placeholder="https://"
+              type="url"
+              data-attendance-batch-evidence-url
+            />
+          </label>
+        </div>
+
+        <p
+          v-if="batchAnomalyOutcome === 'completed_with_errors'"
+          class="attendance__error"
+          data-attendance-batch-outcome-error
+        >
+          {{ tr('Some rows failed. Retry the failed rows, or close to refresh.', '部分行失败。请重试失败行，或关闭以刷新。') }}
+        </p>
+
+        <div class="attendance__admin-actions">
+          <button class="attendance__btn" type="button" @click="closeBatchAnomalyModal">
+            {{ tr('Close', '关闭') }}
+          </button>
+          <button
+            class="attendance__btn attendance__btn--primary"
+            :disabled="batchAnomalySubmitBlocked"
+            type="button"
+            data-attendance-batch-submit
+            @click="submitBatchAnomalyModal"
+          >
+            {{ batchAnomalyModal.submitting
+              ? tr('Submitting...', '提交中...')
+              : (batchAnomalyHasResults ? tr('Retry failed rows', '重试失败行') : tr('Submit batch', '提交批量')) }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -9059,6 +9231,14 @@ import {
 import { useAttendanceAdminImportBatches } from './attendance/useAttendanceAdminImportBatches'
 import { normalizeImportPayloadColumns } from './attendance/attendanceImportPayload'
 import { resolveMakeupPunchRequestStatusCopy } from './attendance/makeupPunchRequestStatus'
+import {
+  BATCH_ANOMALY_MAX_ROWS,
+  canRunBatchAnomalyResolution,
+  runBatchAnomalyResolution,
+  summarizeBatchAnomalyOutcome,
+  type BatchAnomalyRowResult,
+  type BatchAnomalyRowSnapshot,
+} from './attendance/batchAnomalyResolution'
 import {
   buildRuleSetPreviewRecommendations,
   summarizeRuleSetPreviewResult,
@@ -10638,6 +10818,20 @@ const attendanceResultEditModal = reactive({
   submitting: false,
   error: '',
   result: null as AttendanceResultEditResult | null,
+})
+// #3530 batch anomaly resolution — selection over the currently loaded anomaly rows,
+// plus a batch modal that mirrors the single-row modal but submits one AE-1 correction
+// per selected row. Kept separate from attendanceResultEditModal so the two never entangle.
+const batchAnomalySelectedRecordIds = reactive(new Set<string>())
+const batchAnomalyModal = reactive({
+  open: false,
+  snapshot: null as { batchClientId: string; rows: BatchAnomalyRowSnapshot[] } | null,
+  targetStatus: 'normal' as AttendanceResultEditTargetStatus,
+  reason: '',
+  evidenceLabel: '',
+  evidenceUrl: '',
+  submitting: false,
+  results: {} as Record<string, BatchAnomalyRowResult>,
 })
 const missedPunchReminderCandidates = ref<MissedPunchReminderCandidate[]>([])
 const missedPunchReminderLoading = ref(false)
@@ -15188,6 +15382,10 @@ function resetAttendanceResultEditModal(): void {
 
 function clearAttendanceResultEditTransientState(): void {
   resetAttendanceResultEditModal()
+  // #3530 §6.3 hard gate: batch selection + modal + per-row results are transient too.
+  // This function is already called at loadAnomalies() start and on org/date/user filter
+  // changes, so extending it here wires the batch stale-clear to every §6.3 trigger.
+  resetBatchAnomalyModal()
 }
 
 async function openResultEditModal(item: AttendanceAnomaly): Promise<void> {
@@ -15294,6 +15492,195 @@ async function submitResultEditModal(): Promise<void> {
     attendanceResultEditModal.error = attendanceResultEditErrorMessage(error)
   } finally {
     attendanceResultEditModal.submitting = false
+  }
+}
+
+// ===== #3530 batch anomaly resolution handlers =====
+function resetBatchAnomalyModal(): void {
+  batchAnomalyModal.open = false
+  batchAnomalyModal.snapshot = null
+  batchAnomalyModal.targetStatus = 'normal'
+  batchAnomalyModal.reason = ''
+  batchAnomalyModal.evidenceLabel = ''
+  batchAnomalyModal.evidenceUrl = ''
+  batchAnomalyModal.submitting = false
+  batchAnomalyModal.results = {}
+  batchAnomalySelectedRecordIds.clear()
+}
+
+// A row is selectable only when the admin capability is allowed and the same AE-3
+// eligibility that gates the single-row action passes (source status editable, not
+// pending, policy enabled, has recordId). Ineligible rows stay visible, unselectable.
+function isBatchAnomalyRowSelectable(item: AttendanceAnomaly): boolean {
+  return canEditAttendanceAnomalyResult.value && attendanceResultEditDisabledReason(item) === ''
+}
+
+function isBatchAnomalyRowSelected(recordId: string): boolean {
+  return batchAnomalySelectedRecordIds.has(recordId)
+}
+
+function toggleBatchAnomalyRow(item: AttendanceAnomaly): void {
+  if (!isBatchAnomalyRowSelectable(item)) return
+  if (batchAnomalySelectedRecordIds.has(item.recordId)) batchAnomalySelectedRecordIds.delete(item.recordId)
+  else batchAnomalySelectedRecordIds.add(item.recordId)
+}
+
+const batchAnomalySelectedCount = computed(() => batchAnomalySelectedRecordIds.size)
+
+// Toolbar-level gate: selection count + cap (design §4.3 / §7 gate-4).
+const batchAnomalySubmitDisabledReason = computed(() => {
+  if (batchAnomalyModal.submitting) return tr('Batch in progress...', '批量处理中...')
+  if (batchAnomalySelectedCount.value === 0) return tr('Select at least one eligible anomaly row.', '请至少选择一行可更正的异常。')
+  if (batchAnomalySelectedCount.value > BATCH_ANOMALY_MAX_ROWS) {
+    return tr(`Select at most ${BATCH_ANOMALY_MAX_ROWS} rows.`, `最多选择 ${BATCH_ANOMALY_MAX_ROWS} 行。`)
+  }
+  return ''
+})
+
+// Modal-level gate: policy + required reason (mirrors attendanceResultEditSubmitDisabled).
+const batchAnomalySubmitBlocked = computed(() =>
+  batchAnomalyModal.submitting
+  || !batchAnomalyModal.snapshot
+  || !attendanceResultEditPolicyEnabled.value
+  || (attendanceResultEditReasonRequired.value && batchAnomalyModal.reason.trim().length === 0),
+)
+
+const batchAnomalyOutcome = computed(() => summarizeBatchAnomalyOutcome(Object.values(batchAnomalyModal.results)))
+const batchAnomalyHasResults = computed(() => Object.keys(batchAnomalyModal.results).length > 0)
+
+function batchAnomalyRowResult(recordId: string): BatchAnomalyRowResult | null {
+  return batchAnomalyModal.results[recordId] ?? null
+}
+
+function buildBatchAnomalyEvidence(): Array<Record<string, string>> {
+  const label = batchAnomalyModal.evidenceLabel.trim()
+  const url = batchAnomalyModal.evidenceUrl.trim()
+  if (!label && !url) return []
+  const entry: Record<string, string> = {}
+  if (label) entry.label = label
+  if (url) entry.url = url
+  return [entry]
+}
+
+async function probeBatchAnomalyCapability(): Promise<void> {
+  const verified = await ensureAttendanceResultEditCapability()
+  if (!verified) {
+    const message = attendanceResultEditAdminCapability.value === 'forbidden'
+      ? tr('Admin permission required.', '需要管理员权限。')
+      : tr('Unable to verify admin permission.', '无法确认管理员权限。')
+    setStatus(appendStatusContext(message, anomaliesTimezoneContextHint.value), 'error')
+  }
+}
+
+async function openBatchAnomalyModal(): Promise<void> {
+  const capabilityVerified = await ensureAttendanceResultEditCapability()
+  if (!capabilityVerified) {
+    const message = attendanceResultEditAdminCapability.value === 'forbidden'
+      ? tr('Admin permission required.', '需要管理员权限。')
+      : tr('Unable to verify admin permission.', '无法确认管理员权限。')
+    setStatus(appendStatusContext(message, anomaliesTimezoneContextHint.value), 'error')
+    return
+  }
+  const rows = anomalies.value.filter(item => batchAnomalySelectedRecordIds.has(item.recordId) && isBatchAnomalyRowSelectable(item))
+  if (rows.length === 0) {
+    setStatus(appendStatusContext(tr('Select at least one eligible anomaly row.', '请至少选择一行可更正的异常。'), anomaliesTimezoneContextHint.value), 'error')
+    return
+  }
+  if (!canRunBatchAnomalyResolution(rows.length)) {
+    setStatus(appendStatusContext(tr(`Select at most ${BATCH_ANOMALY_MAX_ROWS} rows.`, `最多选择 ${BATCH_ANOMALY_MAX_ROWS} 行。`), anomaliesTimezoneContextHint.value), 'error')
+    return
+  }
+  batchAnomalyModal.open = true
+  batchAnomalyModal.snapshot = {
+    batchClientId: attendanceResultEditIdempotencyKey(),
+    rows: rows.map(item => ({
+      recordId: item.recordId,
+      workDate: item.workDate,
+      targetUserId: normalizedUserId() ?? currentUserId.value ?? '',
+      sourceStatus: normalizeAttendanceResultStatus(item.status),
+      request: item.request ? { ...item.request } : null,
+      warnings: [...(Array.isArray(item.warnings) ? item.warnings : [])],
+      idempotencyKey: attendanceResultEditIdempotencyKey(),
+    })),
+  }
+  batchAnomalyModal.targetStatus = 'normal'
+  batchAnomalyModal.reason = ''
+  batchAnomalyModal.evidenceLabel = ''
+  batchAnomalyModal.evidenceUrl = ''
+  batchAnomalyModal.submitting = false
+  batchAnomalyModal.results = {}
+}
+
+function closeBatchAnomalyModal(): void {
+  const hadResults = batchAnomalyHasResults.value
+  resetBatchAnomalyModal()
+  // Refresh the anomaly list only after a batch actually ran (corrected rows drop out).
+  // Deferring loadAnomalies() to close keeps per-row results visible during review; the
+  // stale-clear it triggers is a no-op now that state is already reset here.
+  if (hadResults) void Promise.all([loadAnomalies(), loadRecords(), loadSummary()])
+}
+
+async function submitBatchAnomalyModal(): Promise<void> {
+  const snapshot = batchAnomalyModal.snapshot
+  if (!snapshot) return
+  if (batchAnomalySubmitBlocked.value) return
+  batchAnomalyModal.submitting = true
+  const reason = batchAnomalyModal.reason.trim() || undefined
+  const evidence = buildBatchAnomalyEvidence()
+  const targetStatus = batchAnomalyModal.targetStatus
+  const current = new Map<string, BatchAnomalyRowResult>(Object.entries(batchAnomalyModal.results))
+  try {
+    const finalResults = await runBatchAnomalyResolution(
+      snapshot.rows,
+      current,
+      async (row) => {
+        try {
+          const body = {
+            orgId: normalizedOrgId(),
+            recordId: row.recordId,
+            targetStatus,
+            reason,
+            evidence,
+            idempotencyKey: row.idempotencyKey,
+          }
+          const response = await apiFetch('/api/attendance/anomaly-result-edits', {
+            method: 'POST',
+            body: JSON.stringify(body),
+          })
+          const data = await response.json().catch(() => null)
+          if (!response.ok || !data?.ok) {
+            throw createApiError(response, data, tr('Result edit failed', '考勤结果更正失败'))
+          }
+          const result = normalizeAttendanceResultEditResult(data.data)
+          return {
+            ok: true as const,
+            result: {
+              editId: result.id,
+              beforeStatus: result.beforeStatus,
+              afterStatus: result.afterStatus,
+              notificationDeliveryId: result.notificationDeliveryId,
+              notificationSkippedReason: result.notificationSkippedReason,
+              alreadyApplied: result.alreadyApplied,
+            },
+          }
+        } catch (error) {
+          return { ok: false as const, errorMessage: attendanceResultEditErrorMessage(error) }
+        }
+      },
+      (recordId, result) => {
+        batchAnomalyModal.results = { ...batchAnomalyModal.results, [recordId]: result }
+      },
+    )
+    batchAnomalyModal.results = Object.fromEntries(finalResults)
+    const values = [...finalResults.values()]
+    const okCount = values.filter(r => r.state === 'ok').length
+    const errCount = values.filter(r => r.state === 'error').length
+    const line = tr(`Batch resolve: ${okCount} applied, ${errCount} failed.`, `批量处理：${okCount} 成功，${errCount} 失败。`)
+    setStatus(appendStatusContext(line, anomaliesTimezoneContextHint.value), errCount > 0 ? 'error' : undefined)
+    // loadRecords/loadSummary do NOT clear batch state; the anomaly list refreshes on close.
+    await Promise.all([loadRecords(), loadSummary()])
+  } finally {
+    batchAnomalyModal.submitting = false
   }
 }
 

--- a/apps/web/src/views/attendance/batchAnomalyResolution.ts
+++ b/apps/web/src/views/attendance/batchAnomalyResolution.ts
@@ -1,0 +1,90 @@
+// #3530 batch anomaly resolution — pure, testable orchestration.
+//
+// The AE-1 single-row correction route (`POST /api/attendance/anomaly-result-edits`)
+// stays the sole write path. This module holds ONLY the pure pieces the design-lock
+// gates care about — the row-cap rule, the per-row snapshot shape, and the sequential
+// runner — so they can be unit-tested in isolation (inject a fake `submitOne`) without
+// mounting the 28k-line SFC. It performs no network, no Vue reactivity, no policy
+// decision: the backend remains the authority for every row.
+//
+// Design lock: docs/development/attendance-anomaly-batch-resolution-design-lock-20260703.md
+
+export const BATCH_ANOMALY_MAX_ROWS = 50
+
+export interface BatchAnomalyRowSnapshot {
+  recordId: string
+  workDate: string
+  /** The committed anomaly-list query target — NOT a per-row employee identity. */
+  targetUserId: string
+  sourceStatus: string
+  request: unknown | null
+  warnings: string[]
+  idempotencyKey: string
+}
+
+export type BatchAnomalyRowState = 'submitting' | 'ok' | 'error'
+
+export interface BatchAnomalyRowResult {
+  recordId: string
+  state: BatchAnomalyRowState
+  editId?: string
+  beforeStatus?: string
+  afterStatus?: string
+  notificationDeliveryId?: string | null
+  notificationSkippedReason?: string | null
+  alreadyApplied?: boolean
+  errorMessage?: string
+}
+
+export type BatchAnomalyOutcome = 'idle' | 'running' | 'completed' | 'completed_with_errors'
+
+/** 1..50 selected rows may be submitted. Over the cap disables submit (design §4.3). */
+export function canRunBatchAnomalyResolution(selectedCount: number): boolean {
+  return selectedCount >= 1 && selectedCount <= BATCH_ANOMALY_MAX_ROWS
+}
+
+/**
+ * Aggregate per-row results into the batch outcome. A batch is only `completed`
+ * when EVERY row is ok/alreadyApplied; a single failure yields
+ * `completed_with_errors` (design §4.5 — never claim full success on any failure).
+ */
+export function summarizeBatchAnomalyOutcome(results: BatchAnomalyRowResult[]): BatchAnomalyOutcome {
+  if (results.length === 0) return 'idle'
+  if (results.some(r => r.state === 'submitting')) return 'running'
+  if (results.some(r => r.state === 'error')) return 'completed_with_errors'
+  return 'completed'
+}
+
+export type BatchSubmitOutcome =
+  | { ok: true; result: Omit<BatchAnomalyRowResult, 'recordId' | 'state'> }
+  | { ok: false; errorMessage: string }
+
+/**
+ * Submit each row sequentially through the injected `submitOne`. Rows already marked
+ * `ok` in `current` are NOT re-submitted (retry from the same modal only re-runs
+ * non-succeeded rows — design §4.3). A row failure does not stop the others; the final
+ * map carries every row's outcome. `onProgress` fires after each state transition so the
+ * UI can render per-row results live. Returns the accumulated result map (a fresh copy).
+ */
+export async function runBatchAnomalyResolution(
+  rows: BatchAnomalyRowSnapshot[],
+  current: Map<string, BatchAnomalyRowResult>,
+  submitOne: (row: BatchAnomalyRowSnapshot) => Promise<BatchSubmitOutcome>,
+  onProgress?: (recordId: string, result: BatchAnomalyRowResult) => void,
+): Promise<Map<string, BatchAnomalyRowResult>> {
+  const results = new Map(current)
+  for (const row of rows) {
+    const existing = results.get(row.recordId)
+    if (existing && existing.state === 'ok') continue
+    const submitting: BatchAnomalyRowResult = { recordId: row.recordId, state: 'submitting' }
+    results.set(row.recordId, submitting)
+    onProgress?.(row.recordId, submitting)
+    const outcome = await submitOne(row)
+    const next: BatchAnomalyRowResult = outcome.ok
+      ? { recordId: row.recordId, state: 'ok', ...outcome.result }
+      : { recordId: row.recordId, state: 'error', errorMessage: outcome.errorMessage }
+    results.set(row.recordId, next)
+    onProgress?.(row.recordId, next)
+  }
+  return results
+}

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -2,6 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, ref, type App } from 'vue'
 import AttendanceView from '../src/views/AttendanceView.vue'
 import { apiFetch } from '../src/utils/api'
+import {
+  canRunBatchAnomalyResolution,
+  runBatchAnomalyResolution,
+  summarizeBatchAnomalyOutcome,
+  type BatchAnomalyRowResult,
+  type BatchAnomalyRowSnapshot,
+} from '../src/views/attendance/batchAnomalyResolution'
 
 vi.mock('../src/composables/usePlugins', () => ({
   usePlugins: () => ({
@@ -121,6 +128,9 @@ describe('Attendance admin regressions', () => {
   let attendanceRequestsData: unknown[] | null = null
   let attendanceAnomaliesData: unknown[] | null = null
   let attendanceResultEditPosts: Array<Record<string, unknown>> = []
+  // #3530 batch: recordIds in this set get a 422 from the anomaly-result-edit route,
+  // so partial-failure batches can be exercised without a real backend.
+  let attendanceResultEditFailRecordIds = new Set<string>()
   let autoShiftPreviewStatus = 200
   let autoShiftPreviewData: Record<string, unknown> | null = null
   let autoShiftApplyStatus = 200
@@ -140,6 +150,7 @@ describe('Attendance admin regressions', () => {
     attendanceRequestsData = null
     attendanceAnomaliesData = null
     attendanceResultEditPosts = []
+    attendanceResultEditFailRecordIds = new Set<string>()
     autoShiftPreviewStatus = 200
     autoShiftPreviewData = null
     autoShiftApplyStatus = 200
@@ -703,12 +714,18 @@ describe('Attendance admin regressions', () => {
       if (url.includes('/api/attendance/anomaly-result-edits')) {
         const body = JSON.parse(String((init as { body?: string } | undefined)?.body || '{}')) as Record<string, unknown>
         attendanceResultEditPosts.push(body)
+        if (attendanceResultEditFailRecordIds.has(String(body.recordId))) {
+          return jsonResponse(422, {
+            ok: false,
+            error: { code: 'ATTENDANCE_RESULT_EDIT_SOURCE_NOT_EDITABLE', message: 'source not editable' },
+          })
+        }
         return jsonResponse(200, {
           ok: true,
           data: {
             alreadyApplied: false,
             edit: {
-              id: 'edit-1',
+              id: `edit-${String(body.recordId)}`,
               beforeStatus: 'late',
               afterStatus: body.targetStatus,
               notificationDeliveryId: 'delivery-1',
@@ -1048,6 +1065,111 @@ describe('Attendance admin regressions', () => {
     await flushUi(2)
 
     expect(container!.querySelector('[data-attendance-result-edit-modal]')).toBeNull()
+  })
+
+  // ===== #3530 batch anomaly resolution =====
+  function makeBatchAnomaly(recordId: string, over: Record<string, unknown> = {}) {
+    return {
+      recordId,
+      workDate: '2026-05-13',
+      status: 'late',
+      firstInAt: '2026-05-13T09:12:00.000Z',
+      lastOutAt: '2026-05-13T18:00:00.000Z',
+      workMinutes: 480,
+      lateMinutes: 12,
+      earlyLeaveMinutes: 0,
+      warnings: ['late'],
+      state: 'open',
+      request: null,
+      suggestedRequestType: 'time_correction',
+      ...over,
+    }
+  }
+  async function mountBatchAdmin(
+    rows: unknown[],
+    settings: Record<string, unknown> = { attendanceResultEditPolicy: { enabled: true, requireReason: false } },
+  ) {
+    attendanceSettingsData = settings
+    attendanceAnomaliesData = rows
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(12)
+    // Probe admin capability through the batch toolbar → checkboxes become enabled.
+    container!.querySelector<HTMLButtonElement>('[data-attendance-batch-probe]')!.click()
+    await flushUi(12)
+  }
+  const batchCheckboxes = () =>
+    Array.from(container!.querySelectorAll<HTMLInputElement>('[data-attendance-batch-select]'))
+
+  it('#3530 batch: only eligible anomaly rows are selectable', async () => {
+    await mountBatchAdmin([
+      makeBatchAnomaly('record-a'),
+      makeBatchAnomaly('record-pending', { state: 'pending' }),
+      makeBatchAnomaly('record-nonedit', { status: 'normal' }),
+    ])
+    const boxes = batchCheckboxes()
+    expect(boxes).toHaveLength(3)
+    expect(boxes[0].disabled).toBe(false)
+    expect(boxes[1].disabled).toBe(true)
+    expect(boxes[2].disabled).toBe(true)
+  })
+
+  it('#3530 batch: selecting more than 50 rows disables the batch submit', async () => {
+    await mountBatchAdmin(Array.from({ length: 51 }, (_, i) => makeBatchAnomaly(`record-${i}`)))
+    for (const box of batchCheckboxes()) box.click()
+    await flushUi(3)
+    const submit = container!.querySelector<HTMLButtonElement>('[data-attendance-batch-resolve]')!
+    expect(submit.disabled).toBe(true)
+    expect(container!.querySelector('[data-attendance-batch-disabled-reason]')?.textContent).toContain('at most 50')
+  })
+
+  it('#3530 batch: N selected rows produce N POSTs with frozen recordIds + distinct keys, no overrideMetrics', async () => {
+    await mountBatchAdmin([makeBatchAnomaly('record-a'), makeBatchAnomaly('record-b'), makeBatchAnomaly('record-c')])
+    const boxes = batchCheckboxes()
+    boxes[0].click()
+    boxes[2].click()
+    await flushUi(3)
+    container!.querySelector<HTMLButtonElement>('[data-attendance-batch-resolve]')!.click()
+    await flushUi(4)
+    expect(container!.querySelector('[data-attendance-batch-modal]')).toBeTruthy()
+    container!.querySelector<HTMLButtonElement>('[data-attendance-batch-submit]')!.click()
+    await flushUi(16)
+    expect(attendanceResultEditPosts).toHaveLength(2)
+    expect(attendanceResultEditPosts.map(p => p.recordId).sort()).toEqual(['record-a', 'record-c'])
+    expect(new Set(attendanceResultEditPosts.map(p => p.idempotencyKey)).size).toBe(2)
+    expect(attendanceResultEditPosts[0]).not.toHaveProperty('overrideMetrics')
+  })
+
+  it('#3530 batch: partial failure renders mixed per-row results and never claims full success', async () => {
+    attendanceResultEditFailRecordIds = new Set(['record-b'])
+    await mountBatchAdmin([makeBatchAnomaly('record-a'), makeBatchAnomaly('record-b')])
+    const boxes = batchCheckboxes()
+    boxes[0].click()
+    boxes[1].click()
+    await flushUi(3)
+    container!.querySelector<HTMLButtonElement>('[data-attendance-batch-resolve]')!.click()
+    await flushUi(4)
+    container!.querySelector<HTMLButtonElement>('[data-attendance-batch-submit]')!.click()
+    await flushUi(16)
+    expect(attendanceResultEditPosts).toHaveLength(2)
+    expect(container!.querySelector('[data-attendance-batch-row-state="ok"]')).toBeTruthy()
+    expect(container!.querySelector('[data-attendance-batch-row-state="error"]')).toBeTruthy()
+    expect(container!.querySelector('[data-attendance-batch-outcome-error]')).toBeTruthy()
+  })
+
+  it('#3530 batch: selection + modal clear when anomalies reload (stale-state gate)', async () => {
+    await mountBatchAdmin([makeBatchAnomaly('record-a'), makeBatchAnomaly('record-b')])
+    batchCheckboxes()[0].click()
+    await flushUi(3)
+    container!.querySelector<HTMLButtonElement>('[data-attendance-batch-resolve]')!.click()
+    await flushUi(4)
+    expect(container!.querySelector('[data-attendance-batch-modal]')).toBeTruthy()
+    const reloadButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Reload anomalies'))
+    reloadButton!.click()
+    await flushUi(4)
+    expect(container!.querySelector('[data-attendance-batch-modal]')).toBeNull()
+    expect(container!.querySelector('[data-attendance-batch-selected-count]')?.textContent).toContain('0')
   })
 
   it('overview self-service — the annual leave card reads the token-locked /me balance (no userId param)', async () => {
@@ -7410,5 +7532,55 @@ describe('Attendance admin regressions', () => {
     expect(importBatchesSection!.textContent).toContain('Mapping viewer')
     expect(importBatchesSection!.textContent).toContain('Selected item detail')
     expect(importBatchesSection!.textContent).toContain('Engine: bulk')
+  })
+})
+
+describe('#3530 batch anomaly resolution (pure)', () => {
+  const snap = (recordId: string): BatchAnomalyRowSnapshot => ({
+    recordId,
+    workDate: '2026-05-13',
+    targetUserId: 'user-1',
+    sourceStatus: 'late',
+    request: null,
+    warnings: [],
+    idempotencyKey: `key-${recordId}`,
+  })
+
+  it('canRunBatchAnomalyResolution enforces the 1..50 cap', () => {
+    expect(canRunBatchAnomalyResolution(0)).toBe(false)
+    expect(canRunBatchAnomalyResolution(1)).toBe(true)
+    expect(canRunBatchAnomalyResolution(50)).toBe(true)
+    expect(canRunBatchAnomalyResolution(51)).toBe(false)
+  })
+
+  it('summarizeBatchAnomalyOutcome: all ok => completed; any error => completed_with_errors', () => {
+    expect(summarizeBatchAnomalyOutcome([])).toBe('idle')
+    expect(summarizeBatchAnomalyOutcome([{ recordId: 'a', state: 'submitting' }])).toBe('running')
+    expect(summarizeBatchAnomalyOutcome([{ recordId: 'a', state: 'ok' }])).toBe('completed')
+    expect(
+      summarizeBatchAnomalyOutcome([{ recordId: 'a', state: 'ok' }, { recordId: 'b', state: 'error' }]),
+    ).toBe('completed_with_errors')
+  })
+
+  it('runBatchAnomalyResolution: sequential, skips already-ok rows, records each per-row outcome', async () => {
+    const calls: string[] = []
+    const current = new Map<string, BatchAnomalyRowResult>([['a', { recordId: 'a', state: 'ok' }]])
+    const results = await runBatchAnomalyResolution(
+      [snap('a'), snap('b'), snap('c')],
+      current,
+      async (row) => {
+        calls.push(row.recordId)
+        return row.recordId === 'b'
+          ? { ok: false as const, errorMessage: 'boom' }
+          : { ok: true as const, result: { editId: `e-${row.recordId}` } }
+      },
+    )
+    // 'a' was already ok → not re-submitted; b then c in order.
+    expect(calls).toEqual(['b', 'c'])
+    expect(results.get('a')?.state).toBe('ok')
+    expect(results.get('b')?.state).toBe('error')
+    expect(results.get('b')?.errorMessage).toBe('boom')
+    expect(results.get('c')?.state).toBe('ok')
+    expect(results.get('c')?.editId).toBe('e-c')
   })
 })


### PR DESCRIPTION
Implements the RATIFIED batch-anomaly design-lock (`docs/development/attendance-anomaly-batch-resolution-design-lock-20260703.md`). Frontend-only, 3 files, no backend/schema/migration, no new admin section. Awaiting the owner's 11-gate review before merge.

## What

Desktop admins select multiple eligible anomaly rows and apply one shared correction. Each selected row is submitted as **one AE-1 single-row call** (`POST /api/attendance/anomaly-result-edits`) — no batch endpoint, no new accounting primitive.

- **New pure module** `apps/web/src/views/attendance/batchAnomalyResolution.ts` — the 50-row cap, the per-row snapshot shape, and `runBatchAnomalyResolution` (sequential; skips already-`ok` rows on retry; records each per-row outcome). Unit-tested in isolation.
- **`AttendanceView.vue`** — a checkbox column on the anomaly table (only eligible rows, reusing the AE-3 `attendanceResultEditDisabledReason` eligibility), a `Batch resolve / 批量处理` toolbar action (capability probe when unknown), and a batch modal mirroring the single-row modal: modal-open snapshot + **per-row `idempotencyKey`**, one POST per row, live per-row results, `completed_with_errors` on any failure, **never optimistic**.
- **Stale-clear** rides on the existing `clearAttendanceResultEditTransientState()` (already called at `loadAnomalies()` start + `watch(orgId)` + `watch([fromDate,toDate,targetUserId])`), extended to reset batch selection/modal/results — one place covers every §6.3 trigger.

## The 11 gates

1 no backend route/schema · 2 single-row reuse (N distinct keys, no overrideMetrics) · 3 eligibility (pending/non-editable/policy-off/no-capability unselectable) · 4 cap 50 · 5 partial failure (mixed per-row, no full-success claim) · 6 no optimistic success · 7 stale-clear (mutation-verified) · 8 request-center parity (RequestCenterSection unmounted → overview canonical, commented) · 9 web-guard (tests in the already-guarded `attendance-admin-regressions.spec.ts`) · 10 no brand names · 11 **no multi-user overclaim** — copy is "selected anomaly rows / 已选异常行", target user is the committed filter target, not a per-row identity.

## Verification

`attendance-admin-regressions` **109 passed** (101 prior + 8 new: 5 mounted + 3 pure); guard siblings (`attendance-admin-anchor-nav`, `AttendanceRequestCenterSection.result-edit`, `attendance-selfservice-dashboard`) **67 passed**, anchor-nav unchanged; `vue-tsc -b` exit 0. **Mutation-verified**: neutering the batch stale-clear makes the stale-clear test fail. No `ATTENDANCE_ADMIN_SECTION_IDS` change, no backend file, no duplicate DOM id. Self-review: `/tmp/pr-3530-runtime-review-claude-20260703.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)