### PR TITLE
docs(integration): record resolver standalone entity smoke pass

### DIFF
--- a/docs/development/integration-core-external-api-read-self-service-line-completion-dev-verification-20260702.md
+++ b/docs/development/integration-core-external-api-read-self-service-line-completion-dev-verification-20260702.md
@@ -89,5 +89,6 @@ S2 设计锁 10 条 × 实际落点:
 
 ### 8.3 后续边界更新
 
-- `resolver_lookup` 运行时设计锁已合并(#3479 → 5f48dadeb,修订版含 R0 契约/证据面扩展切片、multiplicityRuleField 对账、demand gate);R0–R3 仍为各自独立 opt-in,启动前置 = #1709 的 material→FBillNo GATE-front 形状回传(#3415 规范)。
+- `resolver_lookup` 后续线已推进到 standalone read 完成:R0 契约/证据面、R1 纯评估器、R2 runtime 接线、R3 配置 UI 均已合并,并在 2026-07-04 用 `17688041f` on-prem 包完成实体机 standalone resolver smoke PASS。详见 `integration-read-source-resolver-remaining-scope-dev-verification-20260703.md` §7。
+- 仍 gated:material→FBillNo composition、递归 BOM、Save/Submit/Audit、外部写、生产写;这些没有被 standalone resolver PASS 解锁。
 - #1709 保持 OPEN/on-hold;§6 的其余 OUT 项不变。

--- a/docs/development/integration-read-source-resolver-remaining-scope-dev-verification-20260703.md
+++ b/docs/development/integration-read-source-resolver-remaining-scope-dev-verification-20260703.md
@@ -39,3 +39,75 @@ IntegrationReadSourceConfigPanel.vue + readSourceConfigs.ts:mode=resolver_lookup
 ## 6. 当前基线(canonical)
 
 resolver:R0+R1+R2 运行时闭合(standalone read)+ R3 配置 UI。composition/递归 BOM = 设计锁已备、build gated。写路径 = W0 方向锁已备、build gated(客户禁 + sandbox-first 前置)。**没有任何不可逆的生产写被本轮建出或解封。**
+
+## 7. 实体机 standalone resolver smoke addendum(2026-07-04,#1709)
+
+本节固化 #1709 operator 回传的 values-free 实体机证据。它验证的是**当前 R2 standalone resolver_lookup 运行时**,
+不是后续 material→FBillNo composition 链,也不是 C3 LIST marker/list 语义。
+
+### 7.1 部署包
+
+| 项 | 证据 |
+| --- | --- |
+| package | `metasheet-multitable-onprem-v2.5.0-resolver-standalone-20260703-17688041f.zip` |
+| packageContainsMainSha | `17688041f` |
+| zipChecksum | PASS |
+| deployApplyExit | 0 |
+| healthcheck | PASS |
+
+### 7.2 Smoke config shape(values-free)
+
+```text
+mode=resolver_lookup
+readPath=/K3API/Material/GetDetail
+keyField=FNumber
+containerPaths=Data
+resolverRule=exactly_one
+fieldMap.source=Data.FItemID
+fieldMap.target=resolved_item_id
+getDetailContainerShape=Data array length 1; row.Data contains FItemID:number
+```
+
+### 7.3 PASS evidence(values-free)
+
+```text
+resolverStandaloneSmoke=PASS
+loginHttp=200
+externalSystemsHttp=200
+k3SystemLocated=true
+saveConfigHttp=201
+approveHttp=200
+runtimeHttp=200
+evidenceOk=true
+rule=exactly_one
+containerLocated=true
+candidateCount=1
+resolved=true
+resolverDataPresent=true
+sampleKeyEchoed=false
+resolvedValueEchoed=false
+rawPayloadIncluded=false
+postRetireRead=409_READ_SOURCE_CONFIG_NOT_APPROVED
+valuesFreeEvidence=true
+```
+
+Boundary held:
+
+```text
+compositionExecuted=false
+bomExecuted=false
+recursiveBomExpansionExecuted=false
+writeExecuted=false
+thisSmokeAuthorizesComposition=false
+thisSmokeAuthorizesListResolverSemantics=false
+thisSmokeAuthorizesRecursiveBom=false
+thisSmokeAuthorizesSaveSubmitAudit=false
+thisSmokeAuthorizesExternalWrite=false
+thisSmokeAuthorizesProductionWrite=false
+```
+
+### 7.4 Updated disposition
+
+R0+R1+R2+R3 现在是 **built + entity-machine verified for standalone resolver_lookup**。
+剩余 gate 不变:material→FBillNo composition、递归 BOM、Save/Submit/Audit、外部写、生产写,
+均需要各自单独 owner opt-in。


### PR DESCRIPTION
## Summary

Record the #1709 entity-machine PASS for the standalone `resolver_lookup` runtime:

- add a values-free addendum to the resolver remaining-scope dev/verification report
- update the read self-service completion report's stale follow-up wording from "R0-R3 still opt-in" to "standalone resolver built + entity-verified"
- keep composition, recursive BOM, Save/Submit/Audit, external write, and production write explicitly gated

## Evidence recorded

- package contains `17688041f`
- deploy/checksum/health PASS
- resolver standalone smoke PASS with `candidateCount=1`, `resolved=true`, `sampleKeyEchoed=false`, `resolvedValueEchoed=false`, `rawPayloadIncluded=false`
- post-retire read returns `409_READ_SOURCE_CONFIG_NOT_APPROVED`

## Verification

- `git diff --check`

Docs-only; no runtime, route, package, or gate change.
