### PR TITLE
feat(attendance): add owed-punch anomaly filter

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1062,6 +1062,28 @@
             </button>
           </div>
           <small class="attendance__field-hint">{{ anomaliesTimezoneContextHint }}</small>
+          <div class="attendance__filter-pills" data-attendance-anomaly-filter>
+            <button
+              type="button"
+              class="attendance__filter-pill"
+              :class="{ 'attendance__filter-pill--active': anomalyFilter === 'all' }"
+              data-attendance-anomaly-filter-value="all"
+              :disabled="anomaliesLoading"
+              @click="setAnomalyFilter('all')"
+            >
+              {{ tr('All anomalies', '全部异常') }}
+            </button>
+            <button
+              type="button"
+              class="attendance__filter-pill"
+              :class="{ 'attendance__filter-pill--active': anomalyFilter === 'owed_punch' }"
+              data-attendance-anomaly-filter-value="owed_punch"
+              :disabled="anomaliesLoading"
+              @click="setAnomalyFilter('owed_punch')"
+            >
+              {{ tr('Owed punch only', '仅欠卡') }}
+            </button>
+          </div>
           <div v-if="anomalies.length > 0" class="attendance__batch-toolbar" data-attendance-batch-toolbar>
             <button
               v-if="attendanceResultEditCapabilityUnknown"
@@ -9539,6 +9561,9 @@ interface AttendanceAnomaly {
   overtimeMinutes?: number
   warnings: string[]
   state: 'open' | 'pending'
+  owedPunch?: boolean
+  missingSide?: 'check_in' | 'check_out' | 'both' | null
+  owedPunchReason?: string | null
   request?: {
     id: string
     status: string
@@ -9549,6 +9574,7 @@ interface AttendanceAnomaly {
 
 const ATTENDANCE_RESULT_EDIT_SOURCE_STATUSES = new Set(['late', 'early_leave', 'late_early', 'partial', 'absent'])
 const ATTENDANCE_RESULT_EDIT_TARGET_STATUSES = ['normal', 'late', 'early_leave', 'late_early', 'partial', 'absent', 'adjusted'] as const
+type AttendanceAnomalyFilter = 'all' | 'owed_punch'
 type AttendanceResultEditTargetStatus = typeof ATTENDANCE_RESULT_EDIT_TARGET_STATUSES[number]
 type AttendanceResultEditAdminCapability = 'unknown' | 'checking' | 'allowed' | 'forbidden'
 
@@ -10807,6 +10833,7 @@ const scheduleDispatchSaving = ref(false)
 const focusedAttendanceRequestId = computed(() => props.initialRequestId.trim())
 const anomalies = ref<AttendanceAnomaly[]>([])
 const anomaliesLoading = ref(false)
+const anomalyFilter = ref<AttendanceAnomalyFilter>('all')
 const attendanceResultEditAdminCapability = ref<AttendanceResultEditAdminCapability>('unknown')
 const attendanceResultEditModal = reactive({
   open: false,
@@ -11045,6 +11072,11 @@ const summaryTimezoneContextHint = computed(() =>
 const anomaliesTimezoneContextHint = computed(() =>
   `${tr('Anomalies timezone context', '异常时区上下文')}: ${overviewTimezoneLabel.value}`
 )
+function anomalyFilterLabel(filter: AttendanceAnomalyFilter = anomalyFilter.value): string {
+  return filter === 'owed_punch'
+    ? tr('Owed punch only', '仅欠卡')
+    : tr('All anomalies', '全部异常')
+}
 const missedPunchReminderSelectedItems = computed(() => {
   const selected = new Set(missedPunchReminderSelectedIds.value)
   return missedPunchReminderCandidates.value.filter(item => selected.has(item.recordId))
@@ -19848,6 +19880,7 @@ async function confirmMissedPunchReminder(): Promise<void> {
 
 async function loadAnomalies() {
   clearAttendanceResultEditTransientState()
+  anomalies.value = []
   anomaliesLoading.value = true
   try {
     const query = buildQuery({
@@ -19857,6 +19890,7 @@ async function loadAnomalies() {
       pageSize: '50',
       orgId: normalizedOrgId(),
       userId: normalizedUserId(),
+      filter: anomalyFilter.value === 'owed_punch' ? 'owed_punch' : undefined,
     })
     const response = await apiFetch(`/api/attendance/anomalies?${query.toString()}`)
     const data = await response.json()
@@ -19866,6 +19900,30 @@ async function loadAnomalies() {
     anomalies.value = data.data?.items ?? []
   } finally {
     anomaliesLoading.value = false
+  }
+}
+
+async function setAnomalyFilter(filter: AttendanceAnomalyFilter): Promise<void> {
+  if (anomalyFilter.value === filter || anomaliesLoading.value) return
+  anomalyFilter.value = filter
+  try {
+    await loadAnomalies()
+    setStatus(
+      appendStatusContext(
+        tr(
+          `Anomalies loaded (${anomalyFilterLabel(filter)}: ${anomalies.value.length}).`,
+          `异常已加载（${anomalyFilterLabel(filter)}：${anomalies.value.length} 条）。`,
+        ),
+        anomaliesTimezoneContextHint.value,
+      ),
+    )
+  } catch (error: any) {
+    setStatusFromErrorWithContext(
+      error,
+      tr('Failed to load anomalies', '加载异常失败'),
+      anomaliesTimezoneContextHint.value,
+      'refresh',
+    )
   }
 }
 
@@ -19985,7 +20043,10 @@ async function reloadAnomaliesWithStatus() {
     await loadAnomalies()
     setStatus(
       appendStatusContext(
-        tr(`Anomalies loaded (${anomalies.value.length}).`, `异常已加载（${anomalies.value.length} 条）。`),
+        tr(
+          `Anomalies loaded (${anomalyFilterLabel()}: ${anomalies.value.length}).`,
+          `异常已加载（${anomalyFilterLabel()}：${anomalies.value.length} 条）。`,
+        ),
         anomaliesTimezoneContextHint.value,
       ),
     )

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -127,6 +127,7 @@ describe('Attendance admin regressions', () => {
   let scheduleDispatchRequestsData: Record<string, unknown> | null = null
   let attendanceRequestsData: unknown[] | null = null
   let attendanceAnomaliesData: unknown[] | null = null
+  let attendanceAnomaliesResponseQueue: Array<() => Promise<Response>> = []
   let attendanceResultEditPosts: Array<Record<string, unknown>> = []
   // #3530 batch: recordIds in this set get a 422 from the anomaly-result-edit route,
   // so partial-failure batches can be exercised without a real backend.
@@ -149,6 +150,7 @@ describe('Attendance admin regressions', () => {
     scheduleDispatchRequestsData = null
     attendanceRequestsData = null
     attendanceAnomaliesData = null
+    attendanceAnomaliesResponseQueue = []
     attendanceResultEditPosts = []
     attendanceResultEditFailRecordIds = new Set<string>()
     autoShiftPreviewStatus = 200
@@ -701,6 +703,8 @@ describe('Attendance admin regressions', () => {
         })
       }
       if (url.includes('/api/attendance/anomalies')) {
+        const queued = attendanceAnomaliesResponseQueue.shift()
+        if (queued) return queued()
         return jsonResponse(200, {
           ok: true,
           data: {
@@ -1170,6 +1174,75 @@ describe('Attendance admin regressions', () => {
     await flushUi(4)
     expect(container!.querySelector('[data-attendance-batch-modal]')).toBeNull()
     expect(container!.querySelector('[data-attendance-batch-selected-count]')?.textContent).toContain('0')
+  })
+
+  it('#3531 owed-punch filter defaults to all anomalies without sending a filter', async () => {
+    attendanceAnomaliesData = [makeBatchAnomaly('record-a')]
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(12)
+
+    const anomalyUrls = vi.mocked(apiFetch).mock.calls
+      .map(call => String(call[0]))
+      .filter(url => url.includes('/api/attendance/anomalies'))
+    expect(anomalyUrls.length).toBeGreaterThan(0)
+    expect(anomalyUrls.every(url => !url.includes('filter='))).toBe(true)
+    expect(container!.querySelector('[data-attendance-anomaly-filter-value="all"]')?.className).toContain('attendance__filter-pill--active')
+  })
+
+  it('#3531 owed-punch filter clears stale rows while loading and preserves pending request chips', async () => {
+    attendanceAnomaliesData = [makeBatchAnomaly('record-late')]
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(12)
+
+    expect(container!.querySelectorAll('[data-attendance-batch-select]')).toHaveLength(1)
+
+    let resolveOwed!: (response: Response) => void
+    attendanceAnomaliesResponseQueue.push(() => new Promise<Response>((resolve) => { resolveOwed = resolve }))
+    container!.querySelector<HTMLButtonElement>('[data-attendance-anomaly-filter-value="owed_punch"]')!.click()
+    await flushUi(2)
+
+    const anomalyUrls = vi.mocked(apiFetch).mock.calls
+      .map(call => String(call[0]))
+      .filter(url => url.includes('/api/attendance/anomalies'))
+    expect(anomalyUrls.some(url => url.includes('filter=owed_punch'))).toBe(true)
+    expect(container!.querySelectorAll('[data-attendance-batch-select]')).toHaveLength(0)
+    expect(container!.textContent).toContain('Loading anomalies')
+
+    resolveOwed(jsonResponse(200, {
+      ok: true,
+      data: {
+        items: [
+          makeBatchAnomaly('record-owed', {
+            status: 'partial',
+            firstInAt: null,
+            lastOutAt: '2026-05-13T18:00:00.000Z',
+            owedPunch: true,
+            missingSide: 'check_in',
+            owedPunchReason: 'partial_missing_check_in',
+            state: 'pending',
+            request: { id: 'request-owed', status: 'pending', requestType: 'missed_check_in' },
+            suggestedRequestType: 'missed_check_in',
+          }),
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 50,
+      },
+    }))
+    await flushUi(12)
+
+    expect(container!.querySelectorAll('[data-attendance-batch-select]')).toHaveLength(1)
+    expect(container!.textContent).toContain('Pending')
+    expect(
+      vi.mocked(apiFetch).mock.calls.some(([url]) => String(url).includes('/api/attendance/manual-missed-punch-reminders/enqueue')),
+    ).toBe(false)
+    expect(
+      vi.mocked(apiFetch).mock.calls.some(([url]) => String(url).includes('/api/attendance/notification-deliveries')),
+    ).toBe(false)
   })
 
   it('overview self-service — the annual leave card reads the token-locked /me balance (no userId param)', async () => {

--- a/packages/core-backend/tests/integration/attendance-makeup-punch-policy.test.ts
+++ b/packages/core-backend/tests/integration/attendance-makeup-punch-policy.test.ts
@@ -100,8 +100,23 @@ describeDb('补卡规则 MP-2/MP-3 makeup punch policy (real DB, route-level)', 
     requestJson(`${baseUrl}/api/attendance/requests/${id}/approve`, { method: 'POST', headers: authHeaders(token), body: JSON.stringify({ comment: 'ok' }) })
   const reject = (token: string, id: string) =>
     requestJson(`${baseUrl}/api/attendance/requests/${id}/reject`, { method: 'POST', headers: authHeaders(token), body: JSON.stringify({ comment: 'no' }) })
-  const anomalies = (token: string, userId: string, from: string, to: string) =>
-    requestJson(`${baseUrl}/api/attendance/anomalies?userId=${encodeURIComponent(userId)}&from=${from}&to=${to}`, { headers: authHeaders(token) })
+  const anomalies = (
+    token: string,
+    userId: string,
+    from: string,
+    to: string,
+    options: { filter?: string; page?: number; pageSize?: number } = {},
+  ) => {
+    const params = new URLSearchParams({
+      userId,
+      from,
+      to,
+    })
+    if (options.filter) params.set('filter', options.filter)
+    if (options.page) params.set('page', String(options.page))
+    if (options.pageSize) params.set('pageSize', String(options.pageSize))
+    return requestJson(`${baseUrl}/api/attendance/anomalies?${params.toString()}`, { headers: authHeaders(token) })
+  }
 
   // Date helpers in UTC so the test's date math matches the policy (timezone:'UTC' below).
   const dayKey = (offset: number): string => {
@@ -418,6 +433,42 @@ describeDb('补卡规则 MP-2/MP-3 makeup punch policy (real DB, route-level)', 
       expect(created.status).toBe(201)
       const snap = (await reqRow(requestIdOf(created)))?.metadata?.makeupPunchPolicySnapshot as Record<string, unknown> | undefined
       expect(snap?.matchedAnomalyTypes).toEqual(['missing_check_out'])
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  it('owed-punch anomaly filter uses the missed-punch predicate and paginates after filtering', async () => {
+    const u = uid('owed')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wdIn = dayKey(-4)
+    const wdOut = dayKey(-3)
+    const wdBoth = dayKey(-2)
+    const wdLate = dayKey(-1)
+    try {
+      await seedMissingCheckIn(u, wdIn)
+      await seedMissingCheckOut(u, wdOut)
+      await seedRecord(u, wdBoth, { status: 'absent', firstIn: null, lastOut: null })
+      await seedLate(u, wdLate)
+
+      const all = await anomalies(tU, u, wdIn, wdLate)
+      expect(all.status).toBe(200)
+      const allData = (all.body as { data?: { items?: Array<Record<string, unknown>>; total?: number } } | undefined)?.data
+      expect(allData?.total).toBe(4)
+      expect(allData?.items?.some(item => item.status === 'late')).toBe(true)
+
+      const owedPage = await anomalies(tU, u, wdIn, wdLate, { filter: 'owed_punch', pageSize: 2 })
+      expect(owedPage.status).toBe(200)
+      const owedData = (owedPage.body as { data?: { items?: Array<Record<string, unknown>>; total?: number; pageSize?: number } } | undefined)?.data
+      expect(owedData?.total).toBe(3)
+      expect(owedData?.pageSize).toBe(2)
+      expect(owedData?.items).toHaveLength(2)
+      expect(owedData?.items?.every(item => item.owedPunch === true)).toBe(true)
+
+      const owedAll = await anomalies(tU, u, wdIn, wdLate, { filter: 'owed_punch' })
+      const owedItems = ((owedAll.body as { data?: { items?: Array<Record<string, unknown>> } } | undefined)?.data?.items ?? [])
+      expect(owedItems.map(item => item.missingSide).sort()).toEqual(['both', 'check_in', 'check_out'])
+      expect(owedItems.some(item => item.status === 'late')).toBe(false)
     } finally {
       await cleanupUser(u)
     }

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -2110,6 +2110,19 @@ describe('attendance UUID route validation', () => {
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_records r'))).toBe(false)
   })
 
+  it('rejects invalid owed-punch anomaly filters before querying records', async () => {
+    const { db, routes } = await createHarness()
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/anomalies', {
+      query: { from: '2026-06-10', to: '2026-06-10', filter: 'late' },
+      user: { id: 'worker-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
   it('enqueues missed-punch reminders idempotently through the C5 outbox', async () => {
     const { db, routes } = await createHarness('false')
     let insertCalls = 0

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -24623,17 +24623,43 @@ module.exports = {
 	      handleAttendanceRecordsGet
 	    )
 
+	    const buildOwedPunchRecordPredicateSql = (alias = '') => {
+		      const p = alias ? `${alias}.` : ''
+		      return `COALESCE(${p}is_workday, true) = true
+		               AND (
+		                 (${p}status = 'partial' AND (${p}first_in_at IS NULL OR ${p}last_out_at IS NULL))
+		                 OR ${p}status = 'absent'
+		               )`
+		    }
+
+	    const classifyOwedPunchRecord = (row) => {
+		      const status = String(row?.status ?? '')
+		      if (row?.is_workday === false) {
+		        return { owedPunch: false, missingSide: null, owedPunchReason: 'non_workday' }
+		      }
+		      if (status === 'absent') {
+		        return { owedPunch: true, missingSide: 'both', owedPunchReason: 'absent_workday' }
+		      }
+		      if (status !== 'partial') {
+		        return { owedPunch: false, missingSide: null, owedPunchReason: status ? `status_${status}` : 'status_unknown' }
+		      }
+		      const missingIn = !row.first_in_at
+		      const missingOut = !row.last_out_at
+		      if (missingIn && missingOut) {
+		        return { owedPunch: true, missingSide: 'both', owedPunchReason: 'partial_missing_both' }
+		      }
+		      if (missingIn) {
+		        return { owedPunch: true, missingSide: 'check_in', owedPunchReason: 'partial_missing_check_in' }
+		      }
+		      if (missingOut) {
+		        return { owedPunch: true, missingSide: 'check_out', owedPunchReason: 'partial_missing_check_out' }
+		      }
+		      return { owedPunch: false, missingSide: null, owedPunchReason: 'partial_complete' }
+		    }
+
 	    const resolveManualMissedPunchReminderMissingSide = (row) => {
-	      const status = String(row?.status ?? '')
-	      if (status === 'absent') return 'both'
-	      if (status !== 'partial') return null
-	      const missingIn = !row.first_in_at
-	      const missingOut = !row.last_out_at
-	      if (missingIn && missingOut) return 'both'
-	      if (missingIn) return 'check_in'
-	      if (missingOut) return 'check_out'
-	      return null
-	    }
+		      return classifyOwedPunchRecord(row).missingSide
+		    }
 
 	    const summarizeManualMissedPunchReminderRequest = (row) => row ? {
 	      id: row.id,
@@ -24753,18 +24779,14 @@ module.exports = {
 	          const params = [orgId, from, to]
 	          const userClause = parsed.data.userId ? `AND r.user_id = $${params.push(parsed.data.userId)}` : ''
 	          const candidateRows = await db.query(
-	            `SELECT r.*
-	             FROM attendance_records r
-	             WHERE r.org_id = $1
-	               AND r.work_date BETWEEN $2::date AND $3::date
-	               AND COALESCE(r.is_workday, true) = true
-	               AND (
-	                 (r.status = 'partial' AND (r.first_in_at IS NULL OR r.last_out_at IS NULL))
-	                 OR r.status = 'absent'
-	               )
-	               ${userClause}
+		            `SELECT r.*
+		             FROM attendance_records r
+		             WHERE r.org_id = $1
+		               AND r.work_date BETWEEN $2::date AND $3::date
+		               AND (${buildOwedPunchRecordPredicateSql('r')})
+		               ${userClause}
 	             ORDER BY r.work_date DESC, r.user_id ASC, r.id ASC`,
-	            params
+		            params
 	          )
 
 	          const scopedRows = await filterManualMissedPunchReminderCandidatesByScope(db, orgId, access, candidateRows)
@@ -25043,10 +25065,11 @@ module.exports = {
 	      '/api/attendance/anomalies',
 	      withPermission('attendance:read', async (req, res) => {
 	        const schema = z.object({
-	          userId: z.string().optional(),
+		          userId: z.string().optional(),
 	          orgId: z.string().optional(),
 	          from: z.string().optional(),
 	          to: z.string().optional(),
+	          filter: z.enum(['all', 'owed_punch']).optional(),
 	        })
 
 	        const parsed = schema.safeParse({
@@ -25054,6 +25077,7 @@ module.exports = {
 	          orgId: typeof req.query.orgId === 'string' ? req.query.orgId : undefined,
 	          from: typeof req.query.from === 'string' ? req.query.from : undefined,
 	          to: typeof req.query.to === 'string' ? req.query.to : undefined,
+	          filter: typeof req.query.filter === 'string' ? req.query.filter : undefined,
 	        })
 
 	        if (!parsed.success) {
@@ -25086,6 +25110,10 @@ module.exports = {
 	        const { from, to } = dateRange
 
 	        const excludedStatuses = ['normal', 'off', 'adjusted']
+	        const anomalyFilter = parsed.data.filter ?? 'all'
+	        const owedPunchFilterClause = anomalyFilter === 'owed_punch'
+	          ? `AND (${buildOwedPunchRecordPredicateSql()})`
+	          : ''
 
 	        const extractWarnings = (snapshot) => {
 	          if (!snapshot || typeof snapshot !== 'object') return []
@@ -25119,7 +25147,8 @@ module.exports = {
 	               AND org_id = $2
 	               AND work_date BETWEEN $3 AND $4
 	               AND COALESCE(is_workday, true) = true
-	               AND COALESCE(status, '') <> ALL($5)`,
+	               AND COALESCE(status, '') <> ALL($5)
+	               ${owedPunchFilterClause}`,
 	            [targetUserId, orgId, from, to, excludedStatuses]
 	          )
 	          const total = Number(countRows[0]?.total ?? 0)
@@ -25132,6 +25161,7 @@ module.exports = {
 	               AND work_date BETWEEN $3 AND $4
 	               AND COALESCE(is_workday, true) = true
 	               AND COALESCE(status, '') <> ALL($5)
+	               ${owedPunchFilterClause}
 	             ORDER BY work_date DESC
 	             LIMIT $6 OFFSET $7`,
 	            [targetUserId, orgId, from, to, excludedStatuses, pageSize, offset]
@@ -25179,6 +25209,7 @@ module.exports = {
 	            const warnings = extractWarnings(meta)
 	            const requestSummary = requestByDate.get(workDate) ?? { hasPending: false, pending: null, latest: null }
 	            const suggestedRequestType = suggestRequestType(row)
+	            const owedPunch = classifyOwedPunchRecord(row)
 	            const state = requestSummary.hasPending ? 'pending' : 'open'
 	            const resolvedContext = resolveWorkContextFromPrefetch({
 	              orgId,
@@ -25201,6 +25232,9 @@ module.exports = {
 	              leaveMinutes: approved.leaveMinutes,
 	              overtimeMinutes: approved.overtimeMinutes,
 	              warnings,
+	              owedPunch: owedPunch.owedPunch,
+	              missingSide: owedPunch.missingSide,
+	              owedPunchReason: owedPunch.owedPunchReason,
 	              workdayContext: buildWorkdayContextSummary({
 	                workDate,
 	                storedIsWorkday: row.is_workday,


### PR DESCRIPTION
## Summary
- Add a shared owed-punch classifier/predicate used by both the manual missed-punch reminder candidate route and the anomalies API.
- Add `filter=owed_punch` to `/api/attendance/anomalies`, keeping `all`/omitted as the existing default and computing total after filtering.
- Add the overview anomaly filter UI with load-start stale clearing and focused frontend/backend coverage for #3531.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- Targeted Vitest commands attempted locally but the fresh worktree has no installed project runner (`Command "vitest" not found`); required CI should run the backend and web guard suites.

## Notes
- No reminder enqueue or notification delivery writes are introduced; this is a read/filter UI slice only.
- #3531 remains the design-lock reference for the runtime review gates.