### PR TITLE
fix(multitable): tolerate roles without descriptions in permission lists

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1975,7 +1975,11 @@ function isUndefinedTableError(err: unknown, tableName: string): boolean {
   return msg.includes(`relation "${tableName}" does not exist`)
 }
 
-const OPTIONAL_MEMBER_GROUP_COLUMN_ERROR_HINTS = [
+const OPTIONAL_PERMISSION_SUBJECT_HYDRATION_COLUMN_ERROR_HINTS = [
+  'column r.description does not exist',
+  'column "r"."description" does not exist',
+  'column roles.description does not exist',
+  'column "roles"."description" does not exist',
   'column g.name does not exist',
   'column g.description does not exist',
   'column "g"."name" does not exist',
@@ -1986,12 +1990,12 @@ const OPTIONAL_MEMBER_GROUP_COLUMN_ERROR_HINTS = [
   'column "platform_member_groups"."description" does not exist',
 ]
 
-function isOptionalMemberGroupDirectoryError(err: unknown): boolean {
+function isOptionalPermissionSubjectHydrationError(err: unknown): boolean {
   if (isUndefinedTableError(err, 'platform_member_groups')) return true
   const code = typeof (err as any)?.code === 'string' ? (err as any).code : null
   if (code !== '42703') return false
   const msg = typeof (err as any)?.message === 'string' ? (err as any).message.toLowerCase() : ''
-  return OPTIONAL_MEMBER_GROUP_COLUMN_ERROR_HINTS.some((hint) => msg.includes(hint))
+  return OPTIONAL_PERMISSION_SUBJECT_HYDRATION_COLUMN_ERROR_HINTS.some((hint) => msg.includes(hint))
 }
 
 function mapFieldType(type: string): UniverMetaField['type'] {
@@ -7134,7 +7138,7 @@ export function univerMetaRouter(): Router {
           [viewId],
         )
       } catch (err) {
-        if (!isOptionalMemberGroupDirectoryError(err)) throw err
+        if (!isOptionalPermissionSubjectHydrationError(err)) throw err
         result = await pool.query(
           `SELECT
               vp.id,
@@ -7148,7 +7152,7 @@ export function univerMetaRouter(): Router {
               u.email AS user_email,
               u.is_active AS user_is_active,
               r.name AS role_name,
-              r.description AS role_description,
+              NULL::text AS role_description,
               NULL::text AS group_name,
               NULL::text AS group_description
            FROM meta_view_permissions vp
@@ -7349,7 +7353,7 @@ export function univerMetaRouter(): Router {
           [sheetId],
         )
       } catch (err) {
-        if (!isOptionalMemberGroupDirectoryError(err)) throw err
+        if (!isOptionalPermissionSubjectHydrationError(err)) throw err
         result = await pool.query(
           `SELECT
               fp.id,
@@ -7364,7 +7368,7 @@ export function univerMetaRouter(): Router {
               u.email AS user_email,
               u.is_active AS user_is_active,
               r.name AS role_name,
-              r.description AS role_description,
+              NULL::text AS role_description,
               NULL::text AS group_name,
               NULL::text AS group_description
            FROM field_permissions fp
@@ -7605,7 +7609,7 @@ export function univerMetaRouter(): Router {
           [sheetId, recordId],
         )
       } catch (err) {
-        if (!isOptionalMemberGroupDirectoryError(err)) throw err
+        if (!isOptionalPermissionSubjectHydrationError(err)) throw err
         result = await pool.query(
           `SELECT
               rp.id,
@@ -7620,7 +7624,7 @@ export function univerMetaRouter(): Router {
               u.email AS user_email,
               u.is_active AS user_is_active,
               r.name AS role_name,
-              r.description AS role_description,
+              NULL::text AS role_description,
               NULL::text AS group_name,
               NULL::text AS group_description
            FROM record_permissions rp

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -3194,6 +3194,38 @@ describe('Multitable sheet-scoped permissions API', () => {
     expect(String(fieldPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
   })
 
+  test('lists field permissions when the roles directory schema lacks descriptions', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('FROM field_permissions fp') && sql.includes('r.description AS role_description')) {
+          throw undefinedColumnError('r.description')
+        }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/field-permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([])
+    const fieldPermissionCalls = mockPool.query.mock.calls.filter(([sql]) => String(sql).includes('FROM field_permissions fp'))
+    expect(fieldPermissionCalls).toHaveLength(2)
+    expect(String(fieldPermissionCalls[0]?.[0])).toContain('r.description AS role_description')
+    expect(String(fieldPermissionCalls[1]?.[0])).not.toContain('r.description AS role_description')
+    expect(String(fieldPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
+  })
+
   test('lists view permissions when the optional member-group directory table is absent', async () => {
     const { app, mockPool } = await createApp({
       tokenPerms: ['multitable:read'],
@@ -3256,6 +3288,38 @@ describe('Multitable sheet-scoped permissions API', () => {
     expect(String(viewPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
   })
 
+  test('lists view permissions when the roles directory schema lacks descriptions', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, sheet_id FROM meta_views WHERE id = $1')) {
+          expect(params).toEqual(['view_ops'])
+          return { rows: [{ id: 'view_ops', sheet_id: 'sheet_ops' }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('FROM meta_view_permissions vp') && sql.includes('r.description AS role_description')) {
+          throw undefinedColumnError('r.description')
+        }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/views/view_ops/permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([])
+    const viewPermissionCalls = mockPool.query.mock.calls.filter(([sql]) => String(sql).includes('FROM meta_view_permissions vp'))
+    expect(viewPermissionCalls).toHaveLength(2)
+    expect(String(viewPermissionCalls[0]?.[0])).toContain('r.description AS role_description')
+    expect(String(viewPermissionCalls[1]?.[0])).not.toContain('r.description AS role_description')
+    expect(String(viewPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
+  })
+
   test('lists record permissions when the optional member-group directory table is absent', async () => {
     const { app, mockPool } = await createApp({
       tokenPerms: ['multitable:read'],
@@ -3292,6 +3356,46 @@ describe('Multitable sheet-scoped permissions API', () => {
     const recordPermissionCalls = mockPool.query.mock.calls.filter(([sql]) => String(sql).includes('FROM record_permissions rp'))
     expect(recordPermissionCalls).toHaveLength(2)
     expect(String(recordPermissionCalls[0]?.[0])).toContain('LEFT JOIN platform_member_groups g')
+    expect(String(recordPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
+  })
+
+  test('lists record permissions when the roles directory schema lacks descriptions', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('SELECT id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+          expect(params).toEqual(['record_1', 'sheet_ops'])
+          return { rows: [{ id: 'record_1' }] }
+        }
+        if (sql.includes('FROM record_permissions rp') && sql.includes('r.description AS role_description')) {
+          throw undefinedColumnError('r.description')
+        }
+        if (sql.includes('FROM record_permissions rp') && !sql.includes('r.description AS role_description')) {
+          expect(params).toEqual(['sheet_ops', 'record_1'])
+          return { rows: [] }
+        }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/records/record_1/permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([])
+    const recordPermissionCalls = mockPool.query.mock.calls.filter(([sql]) => String(sql).includes('FROM record_permissions rp'))
+    expect(recordPermissionCalls).toHaveLength(2)
+    expect(String(recordPermissionCalls[0]?.[0])).toContain('r.description AS role_description')
+    expect(String(recordPermissionCalls[1]?.[0])).not.toContain('r.description AS role_description')
     expect(String(recordPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
   })
 


### PR DESCRIPTION
## Summary
- extend the permission-list hydration fallback to cover legacy/current `roles` schemas without a `description` column
- make the fallback query avoid `r.description`, while still returning role names and stable permission entries
- add right-reason regression coverage for field/view/record permission list endpoints when `r.description` raises Postgres `42703`

## Why
The latest retest after #3547 still reports the same three permission-list 500s. #3547 covered optional `platform_member_groups` schema drift, but the main schema evidence shows `roles` is created with only `id/name/created_at/updated_at` and no later migration adds `description`. All three failing list endpoints select `r.description AS role_description`, so a missing role-description column is a stronger shared 3x500 candidate.

## Verification
- `pnpm install --frozen-lockfile --offline` in the temp worktree
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts --testNamePattern "optional member-group directory|roles directory schema" --watch=false`
- `pnpm --filter @metasheet/core-backend type-check`

## Notes
- This remains read/list-only; permission gates and write paths are unchanged.
- The fallback degrades only optional subject subtitles: role descriptions become null, member-group labels fall back to subject ids.
- The full `multitable-sheet-permissions.api.test.ts` file still has unrelated existing mock drift on current main; the targeted compatibility locks pass.