### PR TITLE
fix(bridge-agent): keep readonly scheduled task alive

### DIFF
--- a/docs/operations/bridge-agent-readonly-runbook-20260521.md
+++ b/docs/operations/bridge-agent-readonly-runbook-20260521.md
@@ -172,7 +172,14 @@ Expected markers:
 [bridge-agent-readonly-task] Task start requested.
 [bridge-agent-readonly-task] State: Running
 [bridge-agent-readonly-task] Local TCP listener: 127.0.0.1:19091 reachable
+[bridge-agent-readonly-task] Health: healthy
 ```
+
+The helper installs the listener task with an unlimited execution time
+(`ExecutionTimeLimit = 0`). This is intentional: the readonly Bridge Agent is a
+long-running localhost listener, not a bounded batch job. A repaired or
+reinstalled task must not inherit Windows Scheduled Task's default 72-hour
+execution limit.
 
 Useful management commands:
 
@@ -186,7 +193,9 @@ powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-r
 `Status` deliberately checks only the Scheduled Task state, `LastTaskResult`,
 and the local TCP listener. It does not call `/health`, because `/health`
 requires `X-MetaSheet-Bridge-Secret` and the helper must not read or print the
-shared secret. Use the smoke commands below for authenticated protocol checks.
+shared secret. `Status` exits unhealthy when the task is not `Running` or when
+`127.0.0.1:19091` is not reachable. Use the smoke commands below for
+authenticated protocol checks.
 
 ## Smoke Commands
 

--- a/scripts/ops/bridge-agent-readonly-scheduled-task.ps1
+++ b/scripts/ops/bridge-agent-readonly-scheduled-task.ps1
@@ -137,6 +137,23 @@ function Test-LocalTcpPort {
   }
 }
 
+function Test-BridgeTaskHealthy {
+  $task = Get-BridgeTask
+  if (-not $task) { return $false }
+  $state = [string]$task.State
+  return $state -eq 'Running' -and (Test-LocalTcpPort -TargetPort $Port)
+}
+
+function Wait-BridgeTaskHealthy {
+  param([int]$TimeoutSeconds = 15)
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  while ((Get-Date) -lt $deadline) {
+    if (Test-BridgeTaskHealthy) { return $true }
+    Start-Sleep -Seconds 1
+  }
+  return (Test-BridgeTaskHealthy)
+}
+
 function Get-BridgeTask {
   return Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
 }
@@ -157,6 +174,7 @@ function Install-BridgeTask {
     -AllowStartIfOnBatteries `
     -DontStopIfGoingOnBatteries `
     -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
     -RestartCount 3 `
     -RestartInterval (New-TimeSpan -Minutes 1)
   $task = New-ScheduledTask -Action $taskAction -Trigger $taskTrigger -Principal $taskPrincipal -Settings $taskSettings
@@ -180,8 +198,8 @@ function Start-BridgeTask {
   if ($PSCmdlet.ShouldProcess("$TaskPath$TaskName", 'Start readonly Bridge Agent task')) {
     Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
     Write-BridgeTaskInfo 'Task start requested.'
-    Start-Sleep -Seconds 2
-    Show-BridgeTaskStatus
+    Wait-BridgeTaskHealthy -TimeoutSeconds 15 | Out-Null
+    Show-BridgeTaskStatus -RequireHealthy
   }
 }
 
@@ -211,10 +229,14 @@ function Uninstall-BridgeTask {
 }
 
 function Show-BridgeTaskStatus {
+  param([switch]$RequireHealthy)
   Ensure-ScheduledTaskModule
   $task = Get-BridgeTask
   if (-not $task) {
     Write-BridgeTaskInfo "Task not found: $TaskPath$TaskName"
+    if ($RequireHealthy) {
+      Throw-BridgeTaskError "Task not found: $TaskPath$TaskName"
+    }
     return
   }
 
@@ -225,10 +247,23 @@ function Show-BridgeTaskStatus {
   Write-BridgeTaskInfo "LastTaskResult: $($info.LastTaskResult)"
   Write-BridgeTaskInfo "NextRunTime: $($info.NextRunTime)"
 
-  if (Test-LocalTcpPort -TargetPort $Port) {
+  $state = [string]$task.State
+  $listenerReachable = Test-LocalTcpPort -TargetPort $Port
+
+  if ($listenerReachable) {
     Write-BridgeTaskInfo "Local TCP listener: 127.0.0.1:$Port reachable"
   } else {
     Write-BridgeTaskInfo "Local TCP listener: 127.0.0.1:$Port not reachable"
+  }
+
+  if ($state -eq 'Running' -and $listenerReachable) {
+    Write-BridgeTaskInfo 'Health: healthy'
+    return
+  }
+
+  Write-BridgeTaskInfo 'Health: unhealthy'
+  if ($RequireHealthy) {
+    Throw-BridgeTaskError "Task is not healthy (state=$state, listenerReachable=$listenerReachable)."
   }
 }
 
@@ -238,7 +273,7 @@ switch ($Action) {
   'Install' { Install-BridgeTask }
   'Start' { Start-BridgeTask }
   'Stop' { Stop-BridgeTask }
-  'Status' { Show-BridgeTaskStatus }
+  'Status' { Show-BridgeTaskStatus -RequireHealthy }
   'Uninstall' { Uninstall-BridgeTask }
   default { Throw-BridgeTaskError "Unknown action: $Action" }
 }

--- a/scripts/ops/bridge-agent-readonly-task-contract.test.mjs
+++ b/scripts/ops/bridge-agent-readonly-task-contract.test.mjs
@@ -22,6 +22,7 @@ test('scheduled task helper installs the readonly bridge as a SYSTEM startup tas
     "New-ScheduledTaskTrigger -AtStartup",
     "New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest",
     "New-ScheduledTaskAction",
+    "-ExecutionTimeLimit (New-TimeSpan -Seconds 0)",
     "-NoProfile",
     "-ExecutionPolicy Bypass",
     "bridge-agent-readonly.ps1",
@@ -40,11 +41,23 @@ test('scheduled task helper surfaces status without needing bridge secrets', asy
     'System.Net.Sockets.TcpClient',
     '127.0.0.1:$Port reachable',
     '127.0.0.1:$Port not reachable',
+    'Health: healthy',
+    'Health: unhealthy',
+    'Wait-BridgeTaskHealthy -TimeoutSeconds 15',
+    'Show-BridgeTaskStatus -RequireHealthy',
   ]) {
     assert.match(script, escaped(marker));
   }
 
   assert.doesNotMatch(script, /Invoke-RestMethod[\s\S]+X-MetaSheet-Bridge-Secret/i);
+});
+
+test('scheduled task helper does not keep the Windows default 72h execution limit', async () => {
+  const script = await readTaskScript();
+
+  assert.match(script, escaped('-ExecutionTimeLimit (New-TimeSpan -Seconds 0)'));
+  assert.doesNotMatch(script, /ExecutionTimeLimit\s+['"]?PT72H/i);
+  assert.doesNotMatch(script, /New-TimeSpan\s+-Hours\s+72/i);
 });
 
 test('scheduled task helper does not print or embed Bridge Agent secrets', async () => {

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -507,9 +507,11 @@ function verify_bridge_agent_tooling_contract() {
   search_fixed_string 'MetaSheetReadonlyBridgeAgent' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must use a stable task name"
   search_fixed_string 'Register-ScheduledTask' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must register a Windows Scheduled Task"
   search_fixed_string "New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest" "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must run as SYSTEM"
+  search_fixed_string '-ExecutionTimeLimit (New-TimeSpan -Seconds 0)' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must disable the default 72h task execution limit"
   search_fixed_string 'bridge-agent-readonly.ps1' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must launch the readonly agent script"
   search_fixed_string 'Get-ScheduledTaskInfo' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must report LastTaskResult"
   search_fixed_string 'System.Net.Sockets.TcpClient' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must include a secret-free local listener check"
+  search_fixed_string 'Health: unhealthy' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must flag unhealthy task/listener status"
 
   search_fixed_string '"host": "127.0.0.1"' "$readonly_config" || die "readonly Bridge Agent example config must bind to localhost"
   search_fixed_string 'METASHEET_BRIDGE_SQL_USERNAME' "$readonly_config" || die "readonly Bridge Agent config must keep SQL username in an env var"


### PR DESCRIPTION
## Summary

Refs #3556.

Fixes the readonly Bridge Agent Windows Scheduled Task helper so the long-running localhost listener does not inherit Windows Scheduled Task's default 72-hour execution limit.

Changes:
- install task settings with `-ExecutionTimeLimit (New-TimeSpan -Seconds 0)`;
- make `Status` fail unhealthy when the task is not `Running` or `127.0.0.1:19091` is closed;
- make `Start` / `Install -StartAfterInstall` wait briefly for healthy status before failing;
- lock the contract in `bridge-agent-readonly-task-contract.test.mjs` and package verification;
- document the unlimited execution-time requirement and unhealthy status behavior in the runbook.

## Verification

- `node --test scripts/ops/bridge-agent-readonly-task-contract.test.mjs` -> 4/4 pass
- `bash -n scripts/ops/multitable-onprem-package-verify.sh` -> pass
- `LC_ALL=C grep -n '[^ -~]' scripts/ops/bridge-agent-readonly-scheduled-task.ps1 || true` -> no output
- `git diff --check` -> clean

## Operational follow-up

This PR changes the package/helper. Existing on-prem installs still need an operator repair/reinstall using the refreshed package, then values-free verification:

- Scheduled Task setting shows `ExecutionTimeLimit=0` / unlimited;
- task state is `Running`;
- `127.0.0.1:19091` is reachable;
- Data Factory bridge source test no longer fails solely because the listener was stopped by the 72h task limit.

No K3 Save / Submit / Audit / BOM write is touched.
