### PR TITLE
fix(integration): gate stock-prep source readiness

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -2009,8 +2009,17 @@ const selectedPlmBomMultitableCapabilityEntry = computed<PlmBomCapabilityEntry |
   }
 })
 const sqlChannelDisabledHint = computed(() => {
-  const hasDisabledSql = systems.value.some((system) => system.kind === 'erp:k3-wise-sqlserver' && runtimeBlockerForSystem(system) !== '')
-  return hasDisabledSql ? '高级 SQL 通道未启用 / SQLSERVER_EXECUTOR_MISSING / 需要部署侧注入 queryExecutor。已有 SQL 连接配置会保留但暂不能作为 Dry-run 来源。' : ''
+  const sqlBlockers = systems.value
+    .filter((system) => system.kind === 'erp:k3-wise-sqlserver')
+    .map((system) => runtimeBlockerForSystem(system))
+    .filter(Boolean)
+  if (sqlBlockers.some((blocker) => blocker.includes('SQLSERVER_EXECUTOR_MISSING'))) {
+    return '高级 SQL 通道未启用 / SQLSERVER_EXECUTOR_MISSING / 需要部署侧注入 queryExecutor。已有 SQL 连接配置会保留但暂不能作为 Dry-run 来源。'
+  }
+  if (sqlBlockers.some((blocker) => blocker.includes('SQLSERVER_TEST_FAILED'))) {
+    return 'PLM SQL source 连接测试失败（SQLSERVER_TEST_FAILED）；表内已有数据或对象元数据不等于 live source 已就绪，暂不能作为 Dry-run 来源。'
+  }
+  return sqlBlockers.length > 0 ? 'SQL 只读来源当前未就绪；请先通过连接测试与样本预览，再作为 Dry-run 来源。' : ''
 })
 const connectionDraftTitle = computed(() => {
   if (connectionDraftMode.value === 'edit') return `编辑连接${connectionDraft.id ? `：${connectionDraft.id}` : ''}`
@@ -2741,8 +2750,14 @@ function runtimeBlockerForSystem(system: WorkbenchExternalSystem | null): string
   if (system.kind === 'erp:k3-wise-sqlserver' && /SQLSERVER_EXECUTOR_MISSING|queryExecutor|executor|injected|注入|执行器/i.test(errorText)) {
     return 'SQL 连接已配置，但当前部署未注入 SQL 执行器（SQLSERVER_EXECUTOR_MISSING）；可保留为高级连接，暂不能作为可读 source 执行 dry-run。'
   }
+  if (system.kind === 'erp:k3-wise-sqlserver' && /SQLSERVER_TEST_FAILED|TLS\/SSL unsupported protocol|unsupported protocol/i.test(errorText)) {
+    return 'PLM SQL source 连接测试失败（SQLSERVER_TEST_FAILED）；对象列表或表内历史数据只能证明配置/数据存在，不能证明 live source 已连接。'
+  }
   if (system.kind === 'erp:k3-wise-sqlserver' && system.status === 'error' && !errorText) {
     return 'K3 SQL Server 只读通道需要部署 allowlist queryExecutor 后才能读取样本或作为 source。'
+  }
+  if (system.kind === 'erp:k3-wise-sqlserver' && system.status === 'error') {
+    return 'SQL 只读来源当前处于异常状态；请先通过连接测试和样本预览，再作为 source 执行 dry-run。'
   }
   return ''
 }

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1482,6 +1482,75 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.textContent).toContain('SQLSERVER_EXECUTOR_MISSING')
   })
 
+  it('blocks full source readiness when SQL Server connection test failed but K3 target is active', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'erp:k3-wise-sqlserver', label: 'K3 WISE SQL Server Channel', roles: ['source'], supports: ['read', 'listObjects', 'getSchema'], advanced: true },
+          { kind: 'erp:k3-wise-webapi', label: 'K3 WISE WebAPI', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'plm_sql',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'PLM SQL Source',
+            kind: 'erp:k3-wise-sqlserver',
+            role: 'source',
+            status: 'error',
+            lastError: 'SQLSERVER_TEST_FAILED: TLS/SSL unsupported protocol during SQL Server connection test',
+          },
+          {
+            id: 'k3_target',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'K3 Target',
+            kind: 'erp:k3-wise-webapi',
+            role: 'target',
+            status: 'active',
+            lastTestedAt: '2026-07-04T00:00:00Z',
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).click()
+    await flushUi()
+
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    const sqlOption = container.querySelector('[data-testid="source-system-option-plm_sql"]') as HTMLOptionElement | null
+    expect(sqlOption).not.toBeNull()
+    expect(sqlOption!.disabled).toBe(true)
+    expect(sqlOption!.getAttribute('data-disabled')).toBe('true')
+    expect(sourceSystemSelect.value).toBe('')
+    expect(container.querySelector('[data-testid="source-empty-state"]')?.textContent).toContain('还没有可读取的数据源')
+    expect(container.querySelector('[data-testid="dry-run-readiness-summary"]')?.textContent).toContain('选择可读取的数据源')
+
+    expect(container.textContent).toContain('SQLSERVER_TEST_FAILED')
+    expect(container.textContent).toContain('表内已有数据或对象元数据不等于 live source 已就绪')
+    expect(container.textContent).not.toContain('TLS/SSL unsupported protocol')
+  })
+
   it('surfaces staging-creation CTA in source-empty and staging-empty when no readable source exists', async () => {
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url === '/api/integration/adapters') {


### PR DESCRIPTION
## Summary

Fixes the Workbench readiness signal for the stock-preparation source/target split:

- treats a K3/PLM SQL Server source with `SQLSERVER_TEST_FAILED` as a source runtime blocker;
- keeps K3 target connectivity separate from PLM SQL source readiness;
- updates the SQL-channel hint so table data / object metadata are not presented as proof of live PLM source connectivity;
- keeps the existing `SQLSERVER_EXECUTOR_MISSING` path intact.

## Root Cause

The Workbench already blocked dry-run when a selected source was not `active`, but the source picker/runtime-blocker layer only special-cased missing SQL executors. A PLM SQL source whose connection test failed with `SQLSERVER_TEST_FAILED` could still look like a selectable/runnable source while the K3 target was healthy and table data existed.

## Boundary

UI/readiness only:

- no adapter behavior change;
- no SQL Server TLS compatibility change;
- no source read/sample preview execution;
- no K3 Save / Submit / Audit / BOM write;
- no external write path change.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false` -> 43/43 pass
- `pnpm --filter @metasheet/web type-check` -> pass
- `git diff --check` -> pass

Refs #3555
