### PR TITLE
feat(data-factory): add stock-preparation S1 readiness wizard

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1236,6 +1236,18 @@ export interface IntegrationStockPreparationOptionSyncResult {
   evidence?: Record<string, unknown>
 }
 
+export interface IntegrationStockPreparationTargetScope extends IntegrationScope {
+  projectId?: string | null
+  baseId?: string | null
+}
+
+export interface IntegrationStockPreparationTargetReadinessResult {
+  ready: boolean
+  mode?: string
+  targetBinding?: Record<string, unknown> | null
+  evidence?: Record<string, unknown>
+}
+
 export async function listIntegrationTableActions(scope: IntegrationScope = {}): Promise<IntegrationTableActionMetadata[]> {
   const query = buildQueryString({
     tenantId: scope.tenantId,
@@ -1338,6 +1350,34 @@ export async function syncIntegrationStockPreparationOptions(
     body: JSON.stringify(payload),
   })
   return parseIntegrationResponse<IntegrationStockPreparationOptionSyncResult>(response)
+}
+
+export async function getIntegrationStockPreparationTargetReadiness(
+  scope: IntegrationStockPreparationTargetScope = {},
+): Promise<IntegrationStockPreparationTargetReadinessResult> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+    baseId: scope.baseId,
+  })
+  const response = await apiFetch(`/api/integration/stock-preparation/target/readiness${query ? `?${query}` : ''}`)
+  return parseIntegrationResponse<IntegrationStockPreparationTargetReadinessResult>(response)
+}
+
+export async function ensureIntegrationStockPreparationTarget(
+  payload: IntegrationStockPreparationTargetScope = {},
+): Promise<IntegrationStockPreparationTargetReadinessResult> {
+  const response = await apiFetch('/api/integration/stock-preparation/target/ensure', {
+    method: 'POST',
+    body: JSON.stringify({
+      tenantId: payload.tenantId,
+      workspaceId: payload.workspaceId,
+      projectId: payload.projectId,
+      baseId: payload.baseId,
+    }),
+  })
+  return parseIntegrationResponse<IntegrationStockPreparationTargetReadinessResult>(response)
 }
 
 // FOS-2/FOS-3: generic, preset-driven field-option-sync. Resolves a FOS-1 preset by presetId and

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -804,8 +804,8 @@
         </div>
         <div class="integration-workbench__grid integration-workbench__grid--compact">
           <label>
-            <span>目标 baseId（可选）</span>
-            <input v-model="stockPreparationTargetBaseId" data-testid="stock-preparation-s1-base-id" placeholder="创建时可填写目标 baseId；留空使用默认上下文" />
+            <span>目标 baseId（可选，仅创建/绑定时使用）</span>
+            <input v-model="stockPreparationTargetBaseId" data-testid="stock-preparation-s1-base-id" placeholder="创建或绑定时可填写目标 baseId；readiness 检查针对已绑定目标，不受此输入影响" />
           </label>
         </div>
         <p class="integration-workbench__hint" data-testid="stock-preparation-s1-boundary">
@@ -4529,7 +4529,10 @@ async function checkStockPreparationTargetReadiness(): Promise<void> {
   stockPreparationTargetRunning.value = 'readiness'
   stockPreparationTargetResult.value = null
   try {
-    const result = await getIntegrationStockPreparationTargetReadiness(scope)
+    // Readiness inspects the already-bound canonical target; the server only consumes baseId on
+    // ensure (create/bind). Send the plain scope so the request mirrors what the server evaluates.
+    // The staleness signature still covers baseId: an in-flight edit conservatively drops the result.
+    const result = await getIntegrationStockPreparationTargetReadiness(currentScope())
     if (!isCurrentStockPreparationTargetRequest(requestId, signature)) return
     stockPreparationTargetResult.value = result
     setStatus(result.ready ? '标准备料表 readiness 已满足。' : '标准备料表尚未 ready；请查看 missing fields。', result.ready ? 'success' : 'idle')

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -794,6 +794,55 @@
         {{ dryRunEmptyPreviewNotice }}
       </div>
 
+      <div v-if="auth.hasPermission('integration:admin')" class="integration-workbench__table-action" data-testid="stock-preparation-s1-panel">
+        <div class="integration-workbench__panel-head">
+          <div>
+            <h3>标准备料表 S1</h3>
+            <p>创建或绑定 `plm.stock-preparation.main.v1` 标准备料表，并检查目标 readiness；本步骤只处理元数据。</p>
+          </div>
+          <span class="integration-workbench__badge">admin · metadata-only</span>
+        </div>
+        <div class="integration-workbench__grid integration-workbench__grid--compact">
+          <label>
+            <span>目标 baseId（可选）</span>
+            <input v-model="stockPreparationTargetBaseId" data-testid="stock-preparation-s1-base-id" placeholder="创建时可填写目标 baseId；留空使用默认上下文" />
+          </label>
+        </div>
+        <p class="integration-workbench__hint" data-testid="stock-preparation-s1-boundary">
+          只调用 target readiness / ensure；不读取 PLM，不写业务行，不执行 table action，不触发 Apply，不调用 K3 Save / Submit / Audit / BOM write。
+        </p>
+        <div class="integration-workbench__actions">
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="stock-preparation-s1-readiness"
+            :disabled="stockPreparationTargetRunning !== ''"
+            @click="checkStockPreparationTargetReadiness"
+          >
+            {{ stockPreparationTargetRunning === 'readiness' ? '检查中' : '检查 readiness' }}
+          </button>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="stock-preparation-s1-ensure"
+            :disabled="stockPreparationTargetRunning !== ''"
+            @click="ensureStockPreparationTarget"
+          >
+            {{ stockPreparationTargetRunning === 'ensure' ? '处理中' : '创建或绑定标准表' }}
+          </button>
+        </div>
+        <div v-if="stockPreparationTargetResult" class="integration-workbench__table-action-review" data-testid="stock-preparation-s1-result">
+          <strong>{{ stockPreparationTargetSummary }}</strong>
+          <div class="integration-workbench__metric-row" data-testid="stock-preparation-s1-metrics">
+            <span v-for="metric in stockPreparationTargetMetrics" :key="metric.id">{{ metric.label }} {{ metric.value }}</span>
+          </div>
+          <p class="integration-workbench__hint" data-testid="stock-preparation-s1-token-state">
+            target binding 仅用于当前租户运行时；公开证据只贴 readiness status / mode / counts / missingFields。
+          </p>
+          <pre v-if="stockPreparationTargetEvidenceText" data-testid="stock-preparation-s1-evidence">{{ stockPreparationTargetEvidenceText }}</pre>
+        </div>
+      </div>
+
       <div class="integration-workbench__table-action" data-testid="external-write-panel">
         <div class="integration-workbench__panel-head">
           <div>
@@ -1353,7 +1402,9 @@ import {
   deleteWorkbenchExternalSystem,
   dryRunIntegrationExternalWrite,
   dryRunIntegrationTableAction,
+  ensureIntegrationStockPreparationTarget,
   getDefaultIntegrationScope,
+  getIntegrationStockPreparationTargetReadiness,
   isIntegrationScopedProjectId,
   normalizeIntegrationProjectId,
   getExternalSystemSchema,
@@ -1401,6 +1452,7 @@ import {
   type IntegrationSystemObject,
   type IntegrationFieldRule,
   type IntegrationReferenceMappingSource,
+  type IntegrationStockPreparationTargetReadinessResult,
   type IntegrationTableActionApplyResult,
   type IntegrationTableActionConflictPolicyResult,
   type IntegrationTableActionDryRunResult,
@@ -1636,6 +1688,10 @@ const tableActionDuplicateRunPolicies = ref<Record<string, string>>({})
 const tableActionTableScopePolicies = ref<IntegrationTableActionConflictPolicyResult | null>(null)
 const tableActionConflictPolicySaving = ref('')
 const tableActionConflictPolicyDirty = ref(false)
+const stockPreparationTargetBaseId = ref('')
+const stockPreparationTargetRunning = ref<'readiness' | 'ensure' | ''>('')
+const stockPreparationTargetResult = ref<IntegrationStockPreparationTargetReadinessResult | null>(null)
+let stockPreparationTargetRequestId = 0
 const stockPreparationOptionSyncText = ref('')
 const stockPreparationOptionSyncResult = ref<IntegrationStockPreparationOptionSyncResult | null>(null)
 const syncingStockPreparationOptions = ref(false)
@@ -2586,6 +2642,35 @@ const tableActionDuplicateGroups = computed<DuplicateExpandedGroupView[]>(() => 
 })
 const tableActionEvidenceText = computed(() => {
   const evidence = tableActionApplyResult.value?.evidence || tableActionDryRunResult.value?.evidence
+  return evidence ? JSON.stringify(evidence, null, 2) : ''
+})
+const stockPreparationTargetEvidence = computed(() => {
+  const evidence = stockPreparationTargetResult.value?.evidence
+  return isRecord(evidence) ? evidence : null
+})
+const stockPreparationTargetSummary = computed(() => {
+  const result = stockPreparationTargetResult.value
+  if (!result) return '尚未检查标准备料表 readiness。'
+  const status = result.ready ? 'ready' : 'not_ready'
+  const mode = result.mode || String(stockPreparationTargetEvidence.value?.mode || 'unknown')
+  return `target ${status} · ${mode}`
+})
+const stockPreparationTargetMetrics = computed(() => {
+  const evidence = stockPreparationTargetEvidence.value
+  if (!evidence) return []
+  const metrics: Array<{ id: string, label: string, value: string }> = []
+  const fieldCounts = isRecord(evidence.fieldCounts) ? evidence.fieldCounts : null
+  const missingFields = Array.isArray(evidence.missingFields) ? evidence.missingFields : []
+  if (fieldCounts && typeof fieldCounts.total === 'number') metrics.push({ id: 'fields', label: 'fields', value: String(fieldCounts.total) })
+  if (fieldCounts && typeof fieldCounts.plmSystem === 'number') metrics.push({ id: 'system', label: 'system', value: String(fieldCounts.plmSystem) })
+  if (fieldCounts && typeof fieldCounts.humanPreserved === 'number') metrics.push({ id: 'human', label: 'human', value: String(fieldCounts.humanPreserved) })
+  metrics.push({ id: 'missing', label: 'missing', value: String(missingFields.length) })
+  const optionSources = Array.isArray(evidence.optionSources) ? evidence.optionSources : []
+  metrics.push({ id: 'optionSources', label: 'optionSources', value: String(optionSources.length) })
+  return metrics
+})
+const stockPreparationTargetEvidenceText = computed(() => {
+  const evidence = stockPreparationTargetEvidence.value
   return evidence ? JSON.stringify(evidence, null, 2) : ''
 })
 // FOS-3: the field-option-sync presets resolve a FOS-1 preset on the generic
@@ -4416,6 +4501,67 @@ function payloadCarriesActionBindings(payload: Record<string, unknown>): boolean
     }
   }
   return false
+}
+
+function stockPreparationTargetScope() {
+  return {
+    ...currentScope(),
+    baseId: stockPreparationTargetBaseId.value.trim() || null,
+  }
+}
+
+function stockPreparationTargetSignature(scope = stockPreparationTargetScope()): string {
+  return JSON.stringify(scope)
+}
+
+function isCurrentStockPreparationTargetRequest(requestId: number, signature: string): boolean {
+  return requestId === stockPreparationTargetRequestId && stockPreparationTargetSignature() === signature
+}
+
+async function checkStockPreparationTargetReadiness(): Promise<void> {
+  if (!auth.hasPermission('integration:admin')) {
+    setStatus('只有管理员可以检查标准备料表 readiness。', 'error')
+    return
+  }
+  const scope = stockPreparationTargetScope()
+  const signature = stockPreparationTargetSignature(scope)
+  const requestId = ++stockPreparationTargetRequestId
+  stockPreparationTargetRunning.value = 'readiness'
+  stockPreparationTargetResult.value = null
+  try {
+    const result = await getIntegrationStockPreparationTargetReadiness(scope)
+    if (!isCurrentStockPreparationTargetRequest(requestId, signature)) return
+    stockPreparationTargetResult.value = result
+    setStatus(result.ready ? '标准备料表 readiness 已满足。' : '标准备料表尚未 ready；请查看 missing fields。', result.ready ? 'success' : 'idle')
+  } catch (error) {
+    if (!isCurrentStockPreparationTargetRequest(requestId, signature)) return
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    if (requestId === stockPreparationTargetRequestId) stockPreparationTargetRunning.value = ''
+  }
+}
+
+async function ensureStockPreparationTarget(): Promise<void> {
+  if (!auth.hasPermission('integration:admin')) {
+    setStatus('只有管理员可以创建或绑定标准备料表。', 'error')
+    return
+  }
+  const scope = stockPreparationTargetScope()
+  const signature = stockPreparationTargetSignature(scope)
+  const requestId = ++stockPreparationTargetRequestId
+  stockPreparationTargetRunning.value = 'ensure'
+  stockPreparationTargetResult.value = null
+  try {
+    const result = await ensureIntegrationStockPreparationTarget(scope)
+    if (!isCurrentStockPreparationTargetRequest(requestId, signature)) return
+    stockPreparationTargetResult.value = result
+    setStatus(result.ready ? '标准备料表已创建或绑定。' : '标准备料表未 ready；请查看 readiness evidence。', result.ready ? 'success' : 'idle')
+  } catch (error) {
+    if (!isCurrentStockPreparationTargetRequest(requestId, signature)) return
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    if (requestId === stockPreparationTargetRequestId) stockPreparationTargetRunning.value = ''
+  }
 }
 
 async function syncFieldOptions(): Promise<void> {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -3516,7 +3516,7 @@ describe('IntegrationWorkbenchView', () => {
       if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
       if (url === '/api/integration/staging/descriptors') return jsonResponse([])
       if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
-      if (url === '/api/integration/stock-preparation/target/readiness?tenantId=default&baseId=base_stock_readiness') {
+      if (url === '/api/integration/stock-preparation/target/readiness?tenantId=default') {
         return jsonResponse({
           ready: false,
           mode: 'canonical_missing',
@@ -3554,7 +3554,9 @@ describe('IntegrationWorkbenchView', () => {
     ;(container.querySelector('[data-testid="stock-preparation-s1-readiness"]') as HTMLButtonElement).click()
     await flushUi(8)
 
-    expect(calls.some((call) => call.url === '/api/integration/stock-preparation/target/readiness?tenantId=default&baseId=base_stock_readiness')).toBe(true)
+    expect(calls.some((call) => call.url === '/api/integration/stock-preparation/target/readiness?tenantId=default')).toBe(true)
+    // baseId is create/bind-time input only: even with the input filled, readiness must not carry it.
+    expect(calls.some((call) => call.url.startsWith('/api/integration/stock-preparation/target/readiness') && call.url.includes('baseId'))).toBe(false)
     expect(calls.some((call) => call.url.includes('/dry-run'))).toBe(false)
     expect(calls.some((call) => call.url.includes('/apply'))).toBe(false)
     expect(calls.some((call) => call.url.includes('/options/sync'))).toBe(false)
@@ -3703,7 +3705,7 @@ describe('IntegrationWorkbenchView', () => {
       if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
       if (url === '/api/integration/staging/descriptors') return jsonResponse([])
       if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
-      if (url === '/api/integration/stock-preparation/target/readiness?tenantId=default&baseId=base_before') return readinessResponse.promise
+      if (url === '/api/integration/stock-preparation/target/readiness?tenantId=default') return readinessResponse.promise
       throw new Error(`unexpected URL ${url}`)
     })
 

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -16,6 +16,17 @@ function jsonResponse(data: unknown): Response {
   })
 }
 
+function deferredResponse(): { promise: Promise<Response>; resolve: (data: unknown) => void } {
+  let resolvePromise: (response: Response) => void = () => undefined
+  const promise = new Promise<Response>((resolve) => {
+    resolvePromise = resolve
+  })
+  return {
+    promise,
+    resolve: (data: unknown) => resolvePromise(jsonResponse(data)),
+  }
+}
+
 function rawJsonResponse(data: unknown): Response {
   return new Response(JSON.stringify(data), {
     status: 200,
@@ -3492,6 +3503,247 @@ describe('IntegrationWorkbenchView', () => {
     sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushUi(8)
     expect(container.querySelector('[data-testid="plm-approval-capability-entry"]')).toBeNull()
+  })
+
+  it('S1: checks standard stock-preparation target readiness without source reads or writes', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:admin']))
+    const calls: Array<{ url: string, method: string, body?: Record<string, unknown> }> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = String(init?.method || 'GET')
+      const body = init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : undefined
+      calls.push({ url, method, body })
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/stock-preparation/target/readiness?tenantId=default&baseId=base_stock_readiness') {
+        return jsonResponse({
+          ready: false,
+          mode: 'canonical_missing',
+          targetBinding: null,
+          evidence: {
+            status: 'missing',
+            mode: 'canonical_missing',
+            objectId: 'plm_stock_preparation_main',
+            fieldMapMode: 'canonical',
+            keyField: 'idempotencyKey',
+            fieldCounts: { total: 23, plmSystem: 15, humanPreserved: 8, required: 12 },
+            missingFields: ['projectNo', 'idempotencyKey'],
+            optionSources: [{ field: 'materialType', type: 'config_info', key: 'material_type' }],
+            target: { objectId: 'plm_stock_preparation_main', keyField: 'idempotencyKey', fieldIdMapEmpty: true },
+          },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+
+    expect(container.querySelector('[data-testid="stock-preparation-s1-panel"]')?.textContent).toContain('metadata-only')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-boundary"]')?.textContent).toContain('不读取 PLM')
+    const baseInput = container.querySelector('[data-testid="stock-preparation-s1-base-id"]') as HTMLInputElement
+    baseInput.value = 'base_stock_readiness'
+    baseInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="stock-preparation-s1-readiness"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    expect(calls.some((call) => call.url === '/api/integration/stock-preparation/target/readiness?tenantId=default&baseId=base_stock_readiness')).toBe(true)
+    expect(calls.some((call) => call.url.includes('/dry-run'))).toBe(false)
+    expect(calls.some((call) => call.url.includes('/apply'))).toBe(false)
+    expect(calls.some((call) => call.url.includes('/options/sync'))).toBe(false)
+    expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent).toContain('target not_ready · canonical_missing')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-metrics"]')?.textContent).toContain('missing 2')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).toContain('projectNo')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).not.toContain('sheet_stock_private')
+  })
+
+  it('S1: creates or binds the standard stock-preparation target without client-supplied sheet scope', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:admin']))
+    const ensureBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/stock-preparation/target/ensure') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        ensureBodies.push(body)
+        return jsonResponse({
+          ready: true,
+          mode: 'canonical_create',
+          targetBinding: {
+            sheetId: 'sheet_stock_private',
+            objectId: 'plm_stock_preparation_main',
+            keyField: 'idempotencyKey',
+            fieldIdMap: { projectNo: 'fld_project_no_private' },
+          },
+          evidence: {
+            status: 'ready',
+            mode: 'canonical_create',
+            objectId: 'plm_stock_preparation_main',
+            fieldMapMode: 'canonical',
+            keyField: 'idempotencyKey',
+            fieldCounts: { total: 23, plmSystem: 15, humanPreserved: 8, required: 12 },
+            missingFields: [],
+            optionSources: [],
+            target: { objectId: 'plm_stock_preparation_main', keyField: 'idempotencyKey', fieldIdMapEmpty: false },
+          },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+
+    const baseInput = container.querySelector('[data-testid="stock-preparation-s1-base-id"]') as HTMLInputElement
+    baseInput.value = 'base_stock'
+    baseInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="stock-preparation-s1-ensure"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    expect(ensureBodies).toEqual([{ tenantId: 'default', workspaceId: null, baseId: 'base_stock' }])
+    expect(ensureBodies[0]).not.toHaveProperty('projectId')
+    expect(ensureBodies[0]).not.toHaveProperty('sheetId')
+    expect(ensureBodies[0]).not.toHaveProperty('fieldIdMap')
+    expect(ensureBodies[0]).not.toHaveProperty('source')
+    expect(ensureBodies[0]).not.toHaveProperty('target')
+    expect(ensureBodies[0]).not.toHaveProperty('plan')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent).toContain('target ready · canonical_create')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).not.toContain('sheet_stock_private')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).not.toContain('fld_project_no_private')
+  })
+
+  it('S1: ignores stale standard stock-preparation target responses', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:admin']))
+    const readinessResponse = deferredResponse()
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/stock-preparation/target/readiness?tenantId=default') return readinessResponse.promise
+      if (url === '/api/integration/stock-preparation/target/ensure') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        expect(body).toEqual({ tenantId: 'default', workspaceId: null, baseId: null })
+        return jsonResponse({
+          ready: true,
+          mode: 'canonical_create',
+          evidence: {
+            status: 'ready',
+            mode: 'canonical_create',
+            objectId: 'plm_stock_preparation_main',
+            fieldMapMode: 'canonical',
+            keyField: 'idempotencyKey',
+            fieldCounts: { total: 23, plmSystem: 15, humanPreserved: 8, required: 12 },
+            missingFields: [],
+            optionSources: [],
+            target: { objectId: 'plm_stock_preparation_main', keyField: 'idempotencyKey', fieldIdMapEmpty: false },
+          },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+
+    ;(container.querySelector('[data-testid="stock-preparation-s1-readiness"]') as HTMLButtonElement).dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="stock-preparation-s1-ensure"]') as HTMLButtonElement).dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent).toContain('target ready · canonical_create')
+    readinessResponse.resolve({
+      ready: false,
+      mode: 'canonical_missing',
+      evidence: {
+        status: 'missing',
+        mode: 'canonical_missing',
+        objectId: 'plm_stock_preparation_main',
+        fieldMapMode: 'canonical',
+        keyField: 'idempotencyKey',
+        fieldCounts: { total: 23, plmSystem: 15, humanPreserved: 8, required: 12 },
+        missingFields: ['projectNo'],
+        optionSources: [],
+        target: { objectId: 'plm_stock_preparation_main', keyField: 'idempotencyKey', fieldIdMapEmpty: true },
+      },
+    })
+    await flushUi(8)
+
+    expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent).toContain('target ready · canonical_create')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent).not.toContain('canonical_missing')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).not.toContain('projectNo')
+  })
+
+  it('S1: ignores standard stock-preparation target readiness when scope changes in flight', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:admin']))
+    const readinessResponse = deferredResponse()
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/stock-preparation/target/readiness?tenantId=default&baseId=base_before') return readinessResponse.promise
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+
+    const baseInput = container.querySelector('[data-testid="stock-preparation-s1-base-id"]') as HTMLInputElement
+    baseInput.value = 'base_before'
+    baseInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="stock-preparation-s1-readiness"]') as HTMLButtonElement).click()
+    await flushUi()
+    baseInput.value = 'base_after'
+    baseInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    readinessResponse.resolve({
+      ready: false,
+      mode: 'canonical_missing',
+      evidence: {
+        status: 'missing',
+        mode: 'canonical_missing',
+        objectId: 'plm_stock_preparation_main',
+        fieldMapMode: 'canonical',
+        keyField: 'idempotencyKey',
+        fieldCounts: { total: 23, plmSystem: 15, humanPreserved: 8, required: 12 },
+        missingFields: ['projectNo'],
+        optionSources: [],
+        target: { objectId: 'plm_stock_preparation_main', keyField: 'idempotencyKey', fieldIdMapEmpty: true },
+      },
+    })
+    await flushUi(8)
+
+    expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')).toBeNull()
+    expect((container.querySelector('[data-testid="stock-preparation-s1-readiness"]') as HTMLButtonElement).disabled).toBe(false)
   })
 
   it('C5-2: runs a configured table action via dry-run token without client-supplied plan or sheet scope', async () => {


### PR DESCRIPTION
## Summary

Adds the #3551 S1 create/bind/readiness wizard surface for the standard stock-preparation table.

What changed:
- adds typed frontend service calls for the existing metadata-only endpoints:
  - `GET /api/integration/stock-preparation/target/readiness`
  - `POST /api/integration/stock-preparation/target/ensure`
- adds an admin-only Workbench panel for `plm.stock-preparation.main.v1` readiness and create/bind;
- shows only values-free readiness evidence: status/mode/counts/missing logical field ids;
- keeps private `targetBinding` material out of the rendered evidence;
- adds focused UI tests for readiness and ensure boundaries.

## Boundary

S1 only. Metadata create/bind/readiness only.

```text
plmReadExecuted=false
businessRowWriteExecuted=false
tableActionDryRunExecuted=false
applyExecuted=false
k3SaveSubmitAuditBomWrite=false
externalWriteExecuted=false
productionOrBatchRollout=false
browserSuppliesSheetId=false
browserSuppliesFieldIdMap=false
browserSuppliesSourceTargetPlanPayload=false
```

S2 projectNo action, S3/S4 synchronization/snapshot policy, Apply, K3 writes, external writes, and production/batch rollout remain separate opt-ins.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false` — 45/45 pass
- `pnpm --filter @metasheet/web type-check`
- `git diff --check`
