### PR TITLE
fix(integration): stock-prep S1 wizard residual hardening (#3561 follow-up)

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1352,14 +1352,15 @@ export async function syncIntegrationStockPreparationOptions(
   return parseIntegrationResponse<IntegrationStockPreparationOptionSyncResult>(response)
 }
 
+// Readiness inspects the already-bound canonical target; the server only consumes baseId on
+// ensure (create/bind). The plain IntegrationScope parameter structurally forbids callers from
+// passing a baseId here, so the request always mirrors what the server evaluates.
 export async function getIntegrationStockPreparationTargetReadiness(
-  scope: IntegrationStockPreparationTargetScope = {},
+  scope: IntegrationScope = {},
 ): Promise<IntegrationStockPreparationTargetReadinessResult> {
   const query = buildQueryString({
     tenantId: scope.tenantId,
     workspaceId: scope.workspaceId,
-    projectId: scope.projectId,
-    baseId: scope.baseId,
   })
   const response = await apiFetch(`/api/integration/stock-preparation/target/readiness${query ? `?${query}` : ''}`)
   return parseIntegrationResponse<IntegrationStockPreparationTargetReadinessResult>(response)

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1353,8 +1353,9 @@ export async function syncIntegrationStockPreparationOptions(
 }
 
 // Readiness inspects the already-bound canonical target; the server only consumes baseId on
-// ensure (create/bind). The plain IntegrationScope parameter structurally forbids callers from
-// passing a baseId here, so the request always mirrors what the server evaluates.
+// ensure (create/bind). The plain IntegrationScope parameter keeps callers from passing a baseId
+// here, and the query builder no longer reads one at all, so the request always mirrors what the
+// server evaluates.
 export async function getIntegrationStockPreparationTargetReadiness(
   scope: IntegrationScope = {},
 ): Promise<IntegrationStockPreparationTargetReadinessResult> {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -4531,7 +4531,7 @@ async function checkStockPreparationTargetReadiness(): Promise<void> {
   try {
     // Readiness inspects the already-bound canonical target; the server only consumes baseId on
     // ensure (create/bind). Send the plain scope so the request mirrors what the server evaluates
-    // (the service signature now forbids baseId structurally). The baseId input is disabled while a
+    // (the service no longer accepts or serializes baseId). The baseId input is disabled while a
     // request runs; the staleness signature keeping baseId is the belt behind that — a programmatic
     // in-flight change still conservatively drops the result.
     const result = await getIntegrationStockPreparationTargetReadiness(currentScope())

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -805,7 +805,7 @@
         <div class="integration-workbench__grid integration-workbench__grid--compact">
           <label>
             <span>目标 baseId（可选，仅创建/绑定时使用）</span>
-            <input v-model="stockPreparationTargetBaseId" data-testid="stock-preparation-s1-base-id" placeholder="创建或绑定时可填写目标 baseId；readiness 检查针对已绑定目标，不受此输入影响" />
+            <input v-model="stockPreparationTargetBaseId" data-testid="stock-preparation-s1-base-id" :disabled="stockPreparationTargetRunning !== ''" placeholder="创建或绑定时可填写目标 baseId；readiness 检查针对已绑定目标，不受此输入影响" />
           </label>
         </div>
         <p class="integration-workbench__hint" data-testid="stock-preparation-s1-boundary">
@@ -4530,8 +4530,10 @@ async function checkStockPreparationTargetReadiness(): Promise<void> {
   stockPreparationTargetResult.value = null
   try {
     // Readiness inspects the already-bound canonical target; the server only consumes baseId on
-    // ensure (create/bind). Send the plain scope so the request mirrors what the server evaluates.
-    // The staleness signature still covers baseId: an in-flight edit conservatively drops the result.
+    // ensure (create/bind). Send the plain scope so the request mirrors what the server evaluates
+    // (the service signature now forbids baseId structurally). The baseId input is disabled while a
+    // request runs; the staleness signature keeping baseId is the belt behind that — a programmatic
+    // in-flight change still conservatively drops the result.
     const result = await getIntegrationStockPreparationTargetReadiness(currentScope())
     if (!isCurrentStockPreparationTargetRequest(requestId, signature)) return
     stockPreparationTargetResult.value = result

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -3776,6 +3776,9 @@ describe('IntegrationWorkbenchView', () => {
     app.mount(container)
     await flushUi(8)
 
+    // Mount anchor: an ungated sibling panel proves the view rendered — the absence below is the
+    // permission gate at work, not a render failure false-passing the test.
+    expect(container.querySelector('[data-testid="external-write-panel"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="stock-preparation-s1-panel"]')).toBeNull()
     expect(calls.some((url) => url.includes('/stock-preparation/target/'))).toBe(false)
   })

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -3563,7 +3563,7 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent).toContain('target not_ready · canonical_missing')
     expect(container.querySelector('[data-testid="stock-preparation-s1-metrics"]')?.textContent).toContain('missing 2')
     expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).toContain('projectNo')
-    expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).not.toContain('sheet_stock_private')
+    expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent).not.toContain('sheet_stock_private')
   })
 
   it('S1: creates or binds the standard stock-preparation target without client-supplied sheet scope', async () => {
@@ -3625,9 +3625,12 @@ describe('IntegrationWorkbenchView', () => {
     expect(ensureBodies[0]).not.toHaveProperty('source')
     expect(ensureBodies[0]).not.toHaveProperty('target')
     expect(ensureBodies[0]).not.toHaveProperty('plan')
-    expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent).toContain('target ready · canonical_create')
-    expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).not.toContain('sheet_stock_private')
-    expect(container.querySelector('[data-testid="stock-preparation-s1-evidence"]')?.textContent).not.toContain('fld_project_no_private')
+    const boundResultText = container.querySelector('[data-testid="stock-preparation-s1-result"]')?.textContent || ''
+    expect(boundResultText).toContain('target ready · canonical_create')
+    // Leak lock covers the WHOLE result panel (summary + metrics + hint + evidence), not just the
+    // evidence <pre>: the mock's targetBinding carries realistic private ids and none may render.
+    expect(boundResultText).not.toContain('sheet_stock_private')
+    expect(boundResultText).not.toContain('fld_project_no_private')
   })
 
   it('S1: ignores stale standard stock-preparation target responses', async () => {
@@ -3723,6 +3726,10 @@ describe('IntegrationWorkbenchView', () => {
     await flushUi()
     ;(container.querySelector('[data-testid="stock-preparation-s1-readiness"]') as HTMLButtonElement).click()
     await flushUi()
+    // In-flight lock: the baseId input is disabled while a request runs. The programmatic edit
+    // below still lands (dispatchEvent bypasses the disabled attribute), which is exactly what the
+    // signature guard exists to catch — it is the belt behind the disabled input.
+    expect(baseInput.disabled).toBe(true)
     baseInput.value = 'base_after'
     baseInput.dispatchEvent(new Event('input', { bubbles: true }))
     await flushUi()
@@ -3746,6 +3753,31 @@ describe('IntegrationWorkbenchView', () => {
 
     expect(container.querySelector('[data-testid="stock-preparation-s1-result"]')).toBeNull()
     expect((container.querySelector('[data-testid="stock-preparation-s1-readiness"]') as HTMLButtonElement).disabled).toBe(false)
+    expect(baseInput.disabled).toBe(false)
+  })
+
+  it('S1: hides the standard stock-preparation panel and its wire without integration:admin', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    const calls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string) => {
+      calls.push(url)
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+
+    expect(container.querySelector('[data-testid="stock-preparation-s1-panel"]')).toBeNull()
+    expect(calls.some((url) => url.includes('/stock-preparation/target/'))).toBe(false)
   })
 
   it('C5-2: runs a configured table action via dry-run token without client-supplied plan or sheet scope', async () => {


### PR DESCRIPTION
Completes the non-blocking residual items from the #3561 independent review (both review channels; deliverable at `/tmp/pr3561-review-claude-20260704.md`). #3561 merged before the residuals landed, so they ship as this follow-up. Frontend-only, zero backend change, no wire change.

## What
1. **Readiness scope type narrowed** (`workbench.ts`): `getIntegrationStockPreparationTargetReadiness` now takes plain `IntegrationScope` — the signature **structurally forbids** `baseId` on readiness (server handler only consumes `baseId` on `ensure`; readiness inspects the already-bound canonical target). No wire change: the caller already sent `tenantId`/`workspaceId` only, and the existing test lock (readiness URL never carries `baseId`) stays.
2. **In-flight input lock** (`IntegrationWorkbenchView.vue`): the baseId input is `:disabled` while a request runs — closes the operator-confusion window where editing baseId mid-flight silently dropped a completed `ensure` receipt (server had created/bound; FE showed nothing). The staleness signature keeps covering `baseId` as the **belt** behind the disabled input; a mid-flight `disabled === true` assertion + the existing programmatic-edit drop test lock both layers.
3. **Leak lock widened** (spec): private-binding non-render assertions now cover the **whole** `s1-result` panel textContent, not just the evidence `<pre>` (the mock's `targetBinding` carries realistic private `sheetId`/`fieldIdMap` values; none may render anywhere in the panel).
4. **Deny-path test** (spec): an `integration:write` (non-admin) user sees no S1 panel and no `/stock-preparation/target/` wire.

## Recorded-as-is (deliberate, no code)
- Signature conservatism on readiness (covers baseId though the request doesn't) — intentional belt.
- `IntegrationStockPreparationTargetScope.projectId` stays for `ensure` forward-compat (server consumes it).

## Verification
- `vitest run tests/IntegrationWorkbenchView.spec.ts` → **48/48** (47 existing + 1 new deny-path)
- `vue-tsc -b` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)