### PR TITLE
feat(web): approval/automation UX batch-1 arc C — lifecycle fix, discard guards, recent templates

### DIFF
--- a/apps/web/src/approvals/recentTemplates.ts
+++ b/apps/web/src/approvals/recentTemplates.ts
@@ -1,0 +1,54 @@
+/**
+ * B1-08: 最近使用模板捷径 — 纯 localStorage 模块，零后端。
+ *
+ * 发起热路径的现实是 90% 场景反复用同 2-3 个模板；提交成功时记录，模板中心顶部渲染
+ * 「最近使用」chips 深链填单页。按 userId 隔离（同浏览器多账号不串），最多保留 5 条，
+ * 按 templateId 去重、最近优先。存储损坏（手改/版本漂移）一律降级为空列表。
+ */
+
+export interface RecentTemplateEntry {
+  templateId: string
+  name: string
+  category: string | null
+  at: number
+}
+
+const KEY_PREFIX = 'approval-recent-templates:'
+const MAX_ENTRIES = 5
+
+function storageKey(userId: string): string {
+  return `${KEY_PREFIX}${userId}`
+}
+
+export function listRecentTemplates(userId: string | null | undefined): RecentTemplateEntry[] {
+  if (!userId) return []
+  try {
+    const raw = window.localStorage.getItem(storageKey(userId))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (e): e is RecentTemplateEntry =>
+        !!e && typeof e === 'object' && typeof e.templateId === 'string' && typeof e.name === 'string',
+    ).slice(0, MAX_ENTRIES)
+  } catch {
+    return []
+  }
+}
+
+export function recordRecentTemplate(
+  userId: string | null | undefined,
+  entry: { templateId: string; name: string; category?: string | null },
+  now: number = Date.now(),
+): void {
+  if (!userId || !entry.templateId) return
+  try {
+    const next: RecentTemplateEntry[] = [
+      { templateId: entry.templateId, name: entry.name, category: entry.category ?? null, at: now },
+      ...listRecentTemplates(userId).filter((e) => e.templateId !== entry.templateId),
+    ].slice(0, MAX_ENTRIES)
+    window.localStorage.setItem(storageKey(userId), JSON.stringify(next))
+  } catch {
+    // Quota/serialization failures must never break the submit path — the shortcut is best-effort.
+  }
+}

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -809,6 +809,7 @@ import {
   automationCardLinkSummary,
   automationCardStats,
   automationCardTriggerSummary,
+  automationDeleteRuleConfirmMessage,
   automationDingTalkDestinationScopeLabel,
   automationDingTalkDestinationSubtitle,
   automationDingTalkPersonAccessLabel,
@@ -1817,6 +1818,10 @@ async function onToggle(rule: AutomationRule) {
 }
 
 async function onDelete(rule: AutomationRule) {
+  // B1-06: irreversible + takes the rule's execution-history entry point with it — confirm first,
+  // with cumulative run counts as blast radius when stats are already loaded. window.confirm is the
+  // established pattern here (the rule editor's DingTalk test-run confirm uses the same).
+  if (!window.confirm(automationDeleteRuleConfirmMessage(rule.name, ruleStats.value[rule.id], isZh.value))) return
   try {
     await deleteRule(props.sheetId, rule.id)
     emit('updated')

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1,9 +1,9 @@
 <template>
-  <div v-if="visible" class="meta-rule-editor__overlay" @click.self="$emit('close')">
+  <div v-if="visible" class="meta-rule-editor__overlay" @click.self="requestClose">
     <div class="meta-rule-editor">
       <div class="meta-rule-editor__header">
         <h4 class="meta-rule-editor__title">{{ rule ? automationLabel('editor.titleEdit', isZh) : automationLabel('editor.titleNew', isZh) }}</h4>
-        <button class="meta-rule-editor__close" type="button" @click="$emit('close')">&times;</button>
+        <button class="meta-rule-editor__close" type="button" @click="requestClose">&times;</button>
       </div>
 
       <div class="meta-rule-editor__body">
@@ -1206,7 +1206,7 @@
         >
           {{ props.testRunState?.status === 'running' ? automationLabel('testRun.running', isZh) : automationLabel('testRun.button', isZh) }}
         </button>
-        <button class="meta-rule-editor__btn" type="button" @click="$emit('close')">{{ automationLabel('editor.cancel', isZh) }}</button>
+        <button class="meta-rule-editor__btn" type="button" @click="requestClose">{{ automationLabel('editor.cancel', isZh) }}</button>
       </div>
     </div>
   </div>
@@ -2063,6 +2063,10 @@ function draftFromRule(rule: AutomationRule): Draft {
 }
 
 const draft = ref<Draft>(emptyDraft())
+// B1-07: serialized snapshot taken when the editor opens — the dirty check for close-path
+// discard protection. JSON.stringify is stable here: the draft is rebuilt from the same
+// builders on every open, so key order is deterministic.
+const draftSnapshot = ref('')
 const deleteRecordAcknowledgements = ref<Record<string, boolean>>({})
 const conditionEditorEntries = computed(() => collectConditionEditorEntries(draft.value.conditions.conditions))
 
@@ -2286,6 +2290,7 @@ watch(
   async (v) => {
     if (v) {
       draft.value = props.rule ? draftFromRule(props.rule) : emptyDraft()
+      draftSnapshot.value = JSON.stringify(draft.value) // B1-07: dirty baseline per open
       resetDeleteRecordAcknowledgements()
       error.value = ''
       saving.value = false
@@ -2315,6 +2320,14 @@ watch(
   },
   { immediate: true },
 )
+
+// B1-07: discard protection — all three close paths (overlay click, ×, cancel) route here.
+// A successful save is closed by the parent on the 'save' emit and never passes through this guard.
+function requestClose(): void {
+  const dirty = JSON.stringify(draft.value) !== draftSnapshot.value
+  if (dirty && !window.confirm(automationLabel('editor.discardConfirm', isZh.value))) return
+  emit('close')
+}
 
 function resetDeleteRecordAcknowledgements(): void {
   const next: Record<string, boolean> = {}

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -84,6 +84,7 @@ export type AutomationLabelKey =
   | 'editor.save'
   | 'editor.saving'
   | 'editor.cancel'
+  | 'editor.discardConfirm'
   | 'editor.actions'
   | 'editor.actionStepHint'
   | 'editor.addField'
@@ -340,6 +341,7 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'editor.save',
   'editor.saving',
   'editor.cancel',
+  'editor.discardConfirm',
   'editor.actions',
   'editor.actionStepHint',
   'editor.addField',
@@ -593,6 +595,10 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'editor.save': { en: 'Save', zh: '保存' },
   'editor.saving': { en: 'Saving...', zh: '正在保存...' },
   'editor.cancel': { en: 'Cancel', zh: '取消' },
+  'editor.discardConfirm': {
+    en: 'You have unsaved changes; closing will discard them. Continue?',
+    zh: '有未保存的更改，关闭将丢弃这些更改。是否继续？',
+  },
   'editor.actions': { en: 'Actions', zh: '动作' },
   'editor.actionStepHint': { en: '(1-3 steps)', zh: '（1-3 步）' },
   'editor.addField': { en: '+ Field', zh: '+ 字段' },
@@ -1050,6 +1056,26 @@ export function automationCardLinkSummary(variant: AutomationCardLinkVariant, vi
 export function automationCardStats(count: number, status: AutomationCardStatType, isZh: boolean): string {
   const key = status === 'ok' ? 'manager.statOk' : 'manager.statFail'
   return `${count} ${automationLabel(key, isZh)}`
+}
+
+/**
+ * B1-06: delete-rule confirmation copy. Deleting a rule is irreversible and takes its execution
+ * history entry point with it, so the confirm names the rule and — when stats are already in
+ * memory — states its cumulative run counts as the blast radius.
+ */
+export function automationDeleteRuleConfirmMessage(
+  name: string,
+  stats: { success: number; failed: number } | undefined,
+  isZh: boolean,
+): string {
+  const title = isZh ? `确定删除规则「${name}」？` : `Delete rule "${name}"?`
+  const statsLine = stats
+    ? isZh
+      ? `该规则累计成功 ${stats.success} 次 / 失败 ${stats.failed} 次。`
+      : `This rule has ${stats.success} succeeded / ${stats.failed} failed runs. `
+    : ''
+  const tail = isZh ? '删除后不可恢复。' : 'This cannot be undone.'
+  return `${title}\n${statsLine}${tail}`
 }
 
 export function automationDingTalkPresetLabel(preset: AutomationDingTalkPreset | UnknownAutomationString, isZh: boolean): string {

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -491,6 +491,9 @@
       @update-field-permission="onFieldPermissionUpdated"
       @update-view-permission="onViewPermissionUpdated"
     />
+    <!-- B1-06: rule updates (toggle/delete/save all emit `updated`) must NOT dismiss the manager —
+         it maintains its own list state in place; only an explicit close does. Closing on every
+         update forced users to reopen the modal after each toggle/delete/save. -->
     <MetaAutomationManager
       :visible="showAutomationManager"
       :sheet-id="workbench.activeSheetId.value"
@@ -498,7 +501,6 @@
       :client="workbench.client"
       :views="workbench.views.value"
       @close="showAutomationManager = false"
-      @updated="showAutomationManager = false"
     />
     <MetaFormShareManager
       :visible="showFormShareManager"

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -341,6 +341,8 @@ import { useApprovalStore } from '../../approvals/store'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { getVisibleFormFields } from '../../approvals/fieldVisibility'
+import { recordRecentTemplate } from '../../approvals/recentTemplates'
+import { useAuth } from '../../composables/useAuth'
 import { useAutoSumTotal } from '../../approvals/useAutoSumTotal'
 import { isRowDerivationActive } from '../../approvals/lineDerivation'
 import {
@@ -457,6 +459,20 @@ async function handleSubmit() {
       formData: template.value ? pruneHiddenFormDataWithDetail(template.value.formSchema, formData) : { ...formData },
     })
     ElMessage.success('审批已提交')
+    // B1-08: best-effort 最近使用 record — must never delay or fail the navigation.
+    const submittedTemplate = template.value
+    if (submittedTemplate) {
+      void useAuth()
+        .getCurrentUserId()
+        .then((uid) =>
+          recordRecentTemplate(uid, {
+            templateId,
+            name: submittedTemplate.name,
+            category: submittedTemplate.category,
+          }),
+        )
+        .catch(() => {})
+    }
     router.push({ name: 'approval-detail', params: { id: result.id } })
   } catch {
     ElMessage.error('提交审批失败，请重试')

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1112,8 +1112,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 import { ArrowLeft, Plus } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useApprovalPermissions } from '../../approvals/permissions'
@@ -1200,6 +1200,14 @@ const unsupportedReason = ref<string | null>(null)
 // unsupported — the form/metadata stay editable and save preserves the graph verbatim.
 const graphReadOnlyMessage = ref<string | null>(null)
 const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
+// B1-07: dirty baseline for discard protection — refreshed on every load/save so only real
+// unsaved edits trigger the leave confirm. Serialized compare; the draft is rebuilt from the
+// same builders on load/save, so key order is deterministic.
+const draftBaseline = ref(JSON.stringify(draft.value))
+const isDraftDirty = computed(() => JSON.stringify(draft.value) !== draftBaseline.value)
+function snapshotDraft() {
+  draftBaseline.value = JSON.stringify(draft.value)
+}
 const conditionFormulaDryRunSamples = ref<Record<string, string>>({})
 const conditionFormulaDryRunResults = ref<Record<string, string>>({})
 const conditionFormulaDryRunBusy = ref<Record<string, boolean>>({})
@@ -1788,6 +1796,7 @@ async function loadTemplateForEdit() {
     draft.value = createEmptyTemplateDraft()
     unsupportedReason.value = null
     graphReadOnlyMessage.value = null
+    snapshotDraft()
     return
   }
   loading.value = true
@@ -1798,6 +1807,7 @@ async function loadTemplateForEdit() {
     graphReadOnlyMessage.value = graphReadOnlyReason(template)
     draft.value = draftFromTemplate(template)
     syncAllStepOptions()
+    snapshotDraft()
   } catch (error: any) {
     loadError.value = error?.message ?? '加载审批模板失败'
   } finally {
@@ -1823,12 +1833,14 @@ async function persistDraft() {
       draft.value = draftFromTemplate(updated)
       unsupportedReason.value = unsupportedTemplateAuthoringReason(updated)
       graphReadOnlyMessage.value = graphReadOnlyReason(updated)
+      snapshotDraft()
       return updated
     }
     const created = await createTemplate(buildCreateTemplatePayload(draft.value))
     draft.value = draftFromTemplate(created)
     unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
     graphReadOnlyMessage.value = graphReadOnlyReason(created)
+    snapshotDraft() // before the route replace so the leave guard stays quiet
     await router.replace({ path: `/approval-templates/${created.id}/edit` })
     return created
   } catch (error: any) {
@@ -1849,6 +1861,7 @@ async function createFromPreset(presetId: CommonApprovalTemplatePresetId) {
     unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
     graphReadOnlyMessage.value = graphReadOnlyReason(created)
     syncAllStepOptions()
+    snapshotDraft() // before the route replace so the leave guard stays quiet
     await router.replace({ path: `/approval-templates/${created.id}/edit` })
     ElMessage.success('模板草稿已创建')
   } catch (error: any) {
@@ -1896,6 +1909,31 @@ onMounted(() => {
   void directory.loadRoles()
   void directory.loadFormulaRoles()
   void loadTemplateForEdit()
+})
+
+// B1-07: discard protection — the editor is the longest-lived form in the approval admin
+// surface and previously lost all edits on a stray back-click. Route leaves confirm when
+// dirty; hard reloads/closures get the browser-native prompt (same pattern as WorkflowDesigner).
+onBeforeRouteLeave(async () => {
+  if (!isDraftDirty.value) return true
+  try {
+    await ElMessageBox.confirm('有未保存的更改，离开将丢失编辑内容。确定离开吗？', '未保存的更改', {
+      confirmButtonText: '离开',
+      cancelButtonText: '留下',
+      type: 'warning',
+    })
+    return true
+  } catch {
+    return false
+  }
+})
+
+watch(isDraftDirty, (dirty) => {
+  window.onbeforeunload = dirty ? () => '有未保存的更改' : null
+})
+
+onUnmounted(() => {
+  window.onbeforeunload = null
 })
 </script>
 

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -50,6 +50,26 @@
       </div>
     </header>
 
+    <!-- B1-08: 最近使用 — 发起热路径从「进模板全表找行」降到 1 击。localStorage per-user，
+         点击已删除/已归档模板时由填单页的加载错误 + 返回兜底。 -->
+    <div
+      v-if="canWrite && recentTemplates.length > 0"
+      class="template-center__recent"
+      data-testid="template-center-recent"
+    >
+      <span class="template-center__recent-label">最近使用</span>
+      <el-tag
+        v-for="entry in recentTemplates"
+        :key="entry.templateId"
+        class="template-center__recent-chip"
+        effect="plain"
+        :data-testid="`template-center-recent-${entry.templateId}`"
+        @click="startApproval(entry.templateId)"
+      >
+        {{ entry.name }}
+      </el-tag>
+    </div>
+
     <el-alert
       v-if="store.error"
       :title="store.error"
@@ -179,10 +199,13 @@ import type { ApprovalTemplateListItemDTO, ApprovalTemplateStatus } from '../../
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { cloneTemplate, listTemplateCategories } from '../../approvals/api'
+import { listRecentTemplates, type RecentTemplateEntry } from '../../approvals/recentTemplates'
+import { useAuth } from '../../composables/useAuth'
 
 const router = useRouter()
 const store = useApprovalTemplateStore()
 const { canWrite, canManageTemplates } = useApprovalPermissions()
+const recentTemplates = ref<RecentTemplateEntry[]>([])
 
 const statusTab = ref<'all' | ApprovalTemplateStatus>('all')
 const searchText = ref('')
@@ -302,6 +325,13 @@ async function handleClone(row: ApprovalTemplateListItemDTO) {
 onMounted(() => {
   loadData()
   loadCategories()
+  // B1-08: best-effort — a missing session just means no shortcut row.
+  void useAuth()
+    .getCurrentUserId()
+    .then((uid) => {
+      recentTemplates.value = listRecentTemplates(uid)
+    })
+    .catch(() => {})
 })
 </script>
 
@@ -347,5 +377,22 @@ onMounted(() => {
 .template-center__category-empty {
   color: var(--el-text-color-secondary, #909399);
   font-size: 12px;
+}
+
+.template-center__recent {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.template-center__recent-label {
+  color: var(--el-text-color-secondary, #909399);
+  font-size: 13px;
+}
+
+.template-center__recent-chip {
+  cursor: pointer;
 }
 </style>

--- a/apps/web/tests/approvalRecentTemplates.spec.ts
+++ b/apps/web/tests/approvalRecentTemplates.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * B1-08: 最近使用模板捷径 — localStorage module contract.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { listRecentTemplates, recordRecentTemplate } from '../src/approvals/recentTemplates'
+
+describe('approvals/recentTemplates', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('records and lists most-recent-first, deduping by templateId', () => {
+    recordRecentTemplate('u1', { templateId: 't1', name: '请假申请' }, 1000)
+    recordRecentTemplate('u1', { templateId: 't2', name: '报销申请', category: '财务' }, 2000)
+    recordRecentTemplate('u1', { templateId: 't1', name: '请假申请' }, 3000)
+
+    const list = listRecentTemplates('u1')
+    expect(list.map((e) => e.templateId)).toEqual(['t1', 't2'])
+    expect(list[0].at).toBe(3000)
+    expect(list[1].category).toBe('财务')
+  })
+
+  it('caps at 5 entries, evicting the oldest', () => {
+    for (let i = 1; i <= 6; i++) {
+      recordRecentTemplate('u1', { templateId: `t${i}`, name: `模板${i}` }, i * 1000)
+    }
+    const list = listRecentTemplates('u1')
+    expect(list).toHaveLength(5)
+    expect(list.map((e) => e.templateId)).toEqual(['t6', 't5', 't4', 't3', 't2'])
+  })
+
+  it('isolates per user and no-ops without a userId', () => {
+    recordRecentTemplate('u1', { templateId: 't1', name: 'A' }, 1000)
+    recordRecentTemplate(null, { templateId: 't9', name: 'X' }, 2000)
+    expect(listRecentTemplates('u2')).toEqual([])
+    expect(listRecentTemplates(null)).toEqual([])
+    expect(listRecentTemplates('u1')).toHaveLength(1)
+  })
+
+  it('degrades corrupted storage to an empty list', () => {
+    localStorage.setItem('approval-recent-templates:u1', '{not json')
+    expect(listRecentTemplates('u1')).toEqual([])
+    localStorage.setItem('approval-recent-templates:u1', JSON.stringify({ nope: true }))
+    expect(listRecentTemplates('u1')).toEqual([])
+    // malformed entries are filtered, valid ones survive
+    localStorage.setItem(
+      'approval-recent-templates:u1',
+      JSON.stringify([{ templateId: 't1', name: 'A', category: null, at: 1 }, { bogus: true }, null]),
+    )
+    expect(listRecentTemplates('u1').map((e) => e.templateId)).toEqual(['t1'])
+  })
+})

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1318,4 +1318,19 @@ describe('TemplateAuthoringView', () => {
     expect(mergeToggle).not.toBeNull()
     expect(mergeToggle.disabled).toBe(true)
   })
+
+  it('B1-07: dirty-draft tracking arms the browser leave protection, and only when dirty', async () => {
+    window.onbeforeunload = null
+    await mountView()
+    await flushUi()
+
+    // pristine draft → no protection
+    expect(window.onbeforeunload).toBeNull()
+
+    setInput('approval-template-name', '出差审批')
+    await flushUi()
+    // dirty → beforeunload armed (route-leaves confirm through the same isDraftDirty source)
+    expect(window.onbeforeunload).not.toBeNull()
+    window.onbeforeunload = null
+  })
 })

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -11,6 +11,7 @@ import {
   automationConditionOperatorLabel,
   automationConditionValuePlaceholder,
   automationCronPresetLabel,
+  automationDeleteRuleConfirmMessage,
   automationDingTalkAllowlistSummary,
   automationDingTalkDestinationScopeLabel,
   automationDingTalkDestinationSubtitle,
@@ -162,6 +163,17 @@ describe('meta-automation-labels', () => {
 
     expect(automationCardStats(1, 'ok', false)).toBe('1 ok')
     expect(automationCardStats(3, 'fail', true)).toBe('3 失败')
+  })
+
+  it('B1-06: composes delete-rule confirm copy with optional run-count blast radius', () => {
+    expect(automationDeleteRuleConfirmMessage('通知规则', { success: 12, failed: 3 }, true))
+      .toBe('确定删除规则「通知规则」？\n该规则累计成功 12 次 / 失败 3 次。删除后不可恢复。')
+    expect(automationDeleteRuleConfirmMessage('通知规则', undefined, true))
+      .toBe('确定删除规则「通知规则」？\n删除后不可恢复。')
+    expect(automationDeleteRuleConfirmMessage('Notify', { success: 1, failed: 0 }, false))
+      .toBe('Delete rule "Notify"?\nThis rule has 1 succeeded / 0 failed runs. This cannot be undone.')
+    expect(automationDeleteRuleConfirmMessage('Notify', undefined, false))
+      .toBe('Delete rule "Notify"?\nThis cannot be undone.')
   })
 
   it('localizes manager test-run messages with raw details and empty fallbacks', () => {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -921,7 +921,8 @@ describe('MetaAutomationManager', () => {
     expect(body.enabled).toBe(false)
   })
 
-  it('deletes rule', async () => {
+  it('deletes rule after confirmation naming the rule', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const { client, fetchFn } = mockClient([fakeRule()])
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
     await flushPromises()
@@ -930,9 +931,30 @@ describe('MetaAutomationManager', () => {
     deleteBtn.click()
     await flushPromises()
 
+    // B1-06: the confirm names the rule, states its run counts (stats already loaded), and irreversibility
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Notify on create'))
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('This cannot be undone'))
     const deleteCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'DELETE')
     expect(deleteCalls.length).toBe(1)
     expect(container.querySelectorAll('[data-automation-rule]').length).toBe(0)
+    confirmSpy.mockRestore()
+  })
+
+  it('B1-06: cancelling the delete confirmation keeps the rule and issues no DELETE', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { client, fetchFn } = mockClient([fakeRule()])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const deleteBtn = container.querySelector('[data-automation-delete]') as HTMLButtonElement
+    deleteBtn.click()
+    await flushPromises()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    const deleteCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'DELETE')
+    expect(deleteCalls.length).toBe(0)
+    expect(container.querySelectorAll('[data-automation-rule]').length).toBe(1)
+    confirmSpy.mockRestore()
   })
 
   it('shows field picker for field.changed trigger', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -212,6 +212,49 @@ describe('MetaAutomationRuleEditor', () => {
     useLocale().setLocale('en')
   })
 
+  it('B1-07: closes without confirm when the draft is untouched', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    const onClose = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onClose })
+    await flushPromises()
+
+    const cancelBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'Cancel') as HTMLButtonElement
+    cancelBtn.click()
+    await flushPromises()
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('B1-07: a dirty draft asks before discarding — cancel keeps the editor, confirm closes it', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const onClose = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onClose })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'My edited rule'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const cancelBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'Cancel') as HTMLButtonElement
+    cancelBtn.click()
+    await flushPromises()
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('unsaved changes'))
+    expect(onClose).not.toHaveBeenCalled()
+
+    // the × close path is guarded too
+    const xBtn = container.querySelector('.meta-rule-editor__close') as HTMLButtonElement
+    xBtn.click()
+    await flushPromises()
+    expect(onClose).not.toHaveBeenCalled()
+
+    confirmSpy.mockReturnValue(true)
+    cancelBtn.click()
+    await flushPromises()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it('renders trigger type selector when visible', async () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()


### PR DESCRIPTION
## Summary

操作页面 UX 审阅（#3564 阶梯）的 batch-1 **PR-C 弧**（B1-06/07/08，全前端）：

### B1-06 自动化管理器生命周期修复 + 删除确认（审计头部缺陷 #2）
- `MultitableWorkbench` 不再在每次 `updated`（启停/删除/保存都会 emit）时关闭整个自动化管理器——此前连续管理 3 条规则要重开 3 次模态；管理器自身就地维护列表状态，只有显式关闭才退出。
- 规则删除增加确认：点名规则 + 用内存中 ruleStats 给出「累计成功 N / 失败 M 次，删除后不可恢复」的爆炸半径；文案走 `meta-automation-labels` 类型化 helper（i18n 纪律）。

### B1-07 两个最长时投入编辑器的丢稿防护
- `MetaAutomationRuleEditor`（3673 行长表单）：遮罩点击/×/取消三条关闭路径统一走 dirty 检查（每次打开取 JSON 快照），脏时确认（新增 `editor.discardConfirm` label key）；保存路径不受影响（父组件收 `save` 后关闭）。
- `TemplateAuthoringView`：dirty 基线在 加载/保存/预设创建 时刷新；`onBeforeRouteLeave` 确认 + `beforeunload` 仅在脏时武装（复制 WorkflowDesigner 全仓唯一先例模式）。

### B1-08 最近使用模板捷径
- 新纯模块 `approvals/recentTemplates.ts`（per-user localStorage，上限 5、去重、损坏降级空）；发起成功时 best-effort 记录（绝不阻塞导航）；模板中心顶部渲染「最近使用」chips 深链填单页——发起热路径从 3+ 次导航降到 1 击。

## Verification

- 4 个受影响 spec 单跑全绿（211/211 含 12 个新用例：删除确认/取消路径、确认文案组合、干净关 vs 脏关（取消+×）、beforeunload 武装、recentTemplates 模块契约）
- RED-before：去掉 confirm 守卫 → cancel 测试红；去掉 watch → beforeunload 测试红
- `vue-tsc -b` 0
- 全 web 套件与 origin/main 基线逐文件一致（本地环境预存 15 文件/106 用例，两侧同数；无一新增）

红线合规：未触碰移动动作集（ballot Q8）；multitable 文案全部走 meta-automation-labels；审批 views 按约定内联中文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)