### PR TITLE
fix(web): approval detail uses real session identity — requester actions work in production (UX batch-1 B1-01)

### DIFF
--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -22,6 +22,16 @@
       >
         并行中 · {{ parallelBranchNodeKeys.map(nodeLabel).join(' / ') }}
       </el-tag>
+      <!-- B1-01: my-turn cue — the reader is an active assignee at the current node(s). -->
+      <el-tag
+        v-if="approval && isMyTurn"
+        type="success"
+        size="large"
+        effect="light"
+        data-testid="approval-my-turn-badge"
+      >
+        等待你处理
+      </el-tag>
     </header>
 
     <el-alert
@@ -561,6 +571,7 @@ import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { markApprovalRead, remindApproval } from '../../approvals/api'
+import { useAuth } from '../../composables/useAuth'
 import { useFeatureFlags } from '../../stores/featureFlags'
 import { useMobileViewport } from '../../composables/useMobileViewport'
 import {
@@ -606,9 +617,39 @@ const detailTables = computed<Record<string, DetailDisplayTable>>(() => {
   return result
 })
 
+// B1-01: real session identity — the previous `=== 'user_1'` mock meant production requesters
+// NEVER saw the requester-only actions (撤回/催办) this view already ships. Seeded SYNCHRONOUSLY
+// from the session cache so the first paint is already correct (no requester-actions pop-in);
+// a cold cache falls back to the async lookup in onMounted. Until either resolves the requester
+// affordances simply stay hidden (fail-closed).
+const auth = useAuth()
+const currentUserId = ref<string | null>(((): string | null => {
+  const user = auth.getCurrentUser?.()
+  const id = user && typeof user === 'object' ? (user as { id?: unknown }).id : null
+  return typeof id === 'string' && id.length > 0 ? id : null
+})())
+
 const isRequester = computed(() => {
-  // Simple heuristic: mock current user as 'user_1'
-  return approval.value?.requester?.id === 'user_1'
+  return !!currentUserId.value && approval.value?.requester?.id === currentUserId.value
+})
+
+// B1-01: "等待你处理" cue — the reader holds a still-active user assignment at the current
+// node (or any branch of a parallel region). Mirrors, not replaces, the server-side action gate.
+const isMyTurn = computed(() => {
+  const me = currentUserId.value
+  const detail = approval.value
+  if (!me || !detail || detail.status !== 'pending') return false
+  const currentKeys = new Set(
+    parallelBranchNodeKeys.value.length > 0
+      ? parallelBranchNodeKeys.value
+      : detail.currentNodeKey
+        ? [detail.currentNodeKey]
+        : [],
+  )
+  if (currentKeys.size === 0) return false
+  return detail.assignments.some(
+    (a) => a.isActive && a.type === 'user' && a.assigneeId === me && !!a.nodeKey && currentKeys.has(a.nodeKey),
+  )
 })
 
 // Parallel gateway (并行分支) — the instance is inside a parallel region when
@@ -1067,6 +1108,16 @@ onMounted(async () => {
     // eslint-disable-next-line no-console
     console.warn('[approval-detail] mark-read failed', error)
   })
+  // B1-01: cold-cache fallback for the session identity — fire-and-forget in parallel with
+  // the detail load; a failed session lookup just leaves requester-only actions hidden.
+  if (!currentUserId.value) {
+    void auth
+      .getCurrentUserId()
+      .then((uid) => {
+        currentUserId.value = uid
+      })
+      .catch(() => {})
+  }
   await Promise.all([store.loadDetail(id), store.loadHistory(id)])
   if (store.activeApproval?.templateId) {
     await templateStore.loadTemplate(store.activeApproval.templateId).catch(() => undefined)

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -122,6 +122,15 @@ vi.mock('../src/approvals/templateStore', () => ({
 
 // ---------------------------------------------------------------------------
 // Approval permissions mock
+// B1-01: detail-view requester affordances (撤回/催一下) now key off the real session
+// identity — pin it to the shared fixtures' requester so the lifecycle assertions hold.
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getCurrentUser: () => ({ id: 'user_1' }),
+    getCurrentUserId: vi.fn().mockResolvedValue('user_1'),
+  }),
+}))
+
 // ---------------------------------------------------------------------------
 const mockPermissionState = ref({
   canRead: true,

--- a/apps/web/tests/approvalCenterRemindBadge.spec.ts
+++ b/apps/web/tests/approvalCenterRemindBadge.spec.ts
@@ -108,6 +108,15 @@ vi.mock('../src/approvals/templateStore', () => ({
   }),
 }))
 
+// B1-01: the detail view now resolves the real session identity for requester-only
+// affordances (催一下/撤回) — pin it to the fixture requester.
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getCurrentUser: () => ({ id: 'user_1' }),
+    getCurrentUserId: vi.fn().mockResolvedValue('user_1'),
+  }),
+}))
+
 vi.mock('../src/approvals/api', () => ({
   dispatchAction: vi.fn().mockResolvedValue({}),
   getPendingCount: (sourceSystem?: 'all' | 'platform' | 'plm') => getPendingCountSpy(sourceSystem),

--- a/apps/web/tests/approvalMobileDetailActions.spec.ts
+++ b/apps/web/tests/approvalMobileDetailActions.spec.ts
@@ -42,6 +42,15 @@ vi.mock('../src/approvals/api', () => ({
   remindApproval: vi.fn().mockResolvedValue({ ok: true, data: {} }),
 }))
 
+// B1-01: mutable session identity — per-test control over requester/my-turn affordances.
+const mockCurrentUserId = ref<string | null>(null)
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getCurrentUser: () => (mockCurrentUserId.value ? { id: mockCurrentUserId.value } : null),
+    getCurrentUserId: vi.fn().mockImplementation(async () => mockCurrentUserId.value),
+  }),
+}))
+
 vi.mock('../src/approvals/templateStore', () => ({
   useApprovalTemplateStore: () => ({
     activeTemplate: null,
@@ -172,6 +181,7 @@ describe('ApprovalDetailView — T3-1 mobile action-set restriction', () => {
     loadDetailSpy.mockClear()
     loadHistorySpy.mockClear()
     pushSpy.mockClear()
+    mockCurrentUserId.value = null
     setViewport(false)
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -272,5 +282,36 @@ describe('ApprovalDetailView — T3-1 mobile action-set restriction', () => {
     expect(executeActionSpy).toHaveBeenCalled()
     expect(loadDetailSpy).toHaveBeenCalledWith('apv_1')
     expect(loadHistorySpy).toHaveBeenCalledWith('apv_1')
+  })
+
+  it('B1-01: requester-only actions key off the REAL session identity (RED-before: user_1 mock)', async () => {
+    // the reader IS the requester → 催一下 + 撤回 visible on desktop
+    mockCurrentUserId.value = 'user_99'
+    await mountView()
+    let texts = buttonTexts(container!)
+    expect(texts.some((t) => t.includes('催一下'))).toBe(true)
+    expect(texts).toContain('撤回')
+    app!.unmount()
+    container!.innerHTML = ''
+
+    // a different reader → requester-only actions hidden
+    mockCurrentUserId.value = 'user_someone_else'
+    await mountView()
+    texts = buttonTexts(container!)
+    expect(texts.some((t) => t.includes('催一下'))).toBe(false)
+    expect(texts).not.toContain('撤回')
+  })
+
+  it('B1-01: 等待你处理 badge shows only for an active assignee at the current node', async () => {
+    // fixture assignment: user_add active at approval_1 (the current node)
+    mockCurrentUserId.value = 'user_add'
+    await mountView()
+    expect(container!.querySelector('[data-testid="approval-my-turn-badge"]')).not.toBeNull()
+    app!.unmount()
+    container!.innerHTML = ''
+
+    mockCurrentUserId.value = 'user_uninvolved'
+    await mountView()
+    expect(container!.querySelector('[data-testid="approval-my-turn-badge"]')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

UX 审阅 (#3564) 三个「伪装成 UX 问题的生产正确性缺陷」中的 #1：`ApprovalDetailView` 的 `isRequester` 硬编码为 `=== 'user_1'`（遗留 mock）→ **生产环境真实发起人永远看不到已建成的 撤回/催一下 按钮**。

- 身份从 session 缓存**同步**种入（首帧即正确，无 pop-in），冷缓存走 onMounted 异步兜底；身份未解析时发起人专属动作保持隐藏（fail-closed）
- 新增「等待你处理」badge：读者在当前节点（或并行分支）持有 still-active user assignment——只做镜像提示，不替代服务端动作门控

## Verification

- 移动详情 spec：可变身份 mock + 2 个新用例（发起人动作随真实 uid 显隐——**RED-before**：旧 user_1 mock 下必红；my-turn badge 仅对当前节点活跃受理人）
- remind-badge / lifecycle spec 的身份钉到 fixture 的 requester
- 首版纯异步实现导致 lifecycle revoke 用例间歇红（首帧后的身份翻转引发渲染churn）→ 同步种入后 **5 连跑全绿**
- `vue-tsc -b` 0；相邻 spec（unread badge / e2e-permissions / detail-field）80/80

Batch-1 PR-A₁；PR-A₂（B1-02 快照人性化渲染 / B1-04 宽恕型错误 / B1-05 sticky 操作栏+常用意见）在 #3535/#3536 合并后跟进（api.ts 碰撞已解除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)