### PR TITLE
feat(plm): adopt ECO Phase 0 discriminated write-back 409s (pact + relay + panel)

### DIFF
--- a/apps/web/src/components/plm/PlmBomReviewPanel.vue
+++ b/apps/web/src/components/plm/PlmBomReviewPanel.vue
@@ -44,14 +44,23 @@
         未找到该 Part 的 BOM 数据。
       </p>
 
-      <PlmBomReviewTable
-        v-else-if="reviewState === 'table' && context"
-        :context="context"
-        editable
-        :submitting-line-id="submittingLineId"
-        :line-messages="lineMessages"
-        @submit-line="submitLinePatch"
-      />
+      <template v-else-if="reviewState === 'table' && context">
+        <p
+          v-if="advisoryLocked"
+          class="bom-review__hint bom-review__hint--strong"
+          data-testid="plm-bom-review-locked-hint"
+        >
+          该 Part 处于锁定状态（{{ context.part.state }}），已暂停行内编辑；修改需通过 PLM 的 ECO
+          变更流程。
+        </p>
+        <PlmBomReviewTable
+          :context="context"
+          :editable="!advisoryLocked"
+          :submitting-line-id="submittingLineId"
+          :line-messages="lineMessages"
+          @submit-line="submitLinePatch"
+        />
+      </template>
     </div>
   </section>
 </template>
@@ -79,6 +88,20 @@ const retryKeys = ref<Record<string, string>>({})
 const context = computed(() =>
   result.value && result.value.available ? result.value.context : null,
 )
+
+// ECO Phase 0 advisory pre-gate (ratified C2): the provider's lock set is DATA-DRIVEN
+// (version_lock on lifecycle states), so the consumer cannot enumerate it authoritatively.
+// This is the provider's default-seed locked set, used ONLY to pause inline editing up front
+// for the common case; the discriminated 409 (reason 'lifecycle_locked') stays the
+// authoritative gate for the residual race or a tenant-customized lock set. The gate keys on
+// the ROOT part's state -- the provider evaluates the lock on the PARENT part, and per-line
+// `state` is the CHILD part's state (display-only, wrong semantics for the write gate).
+const ADVISORY_LOCKED_STATES = new Set(['Released', 'Suspended', 'Obsolete'])
+
+const advisoryLocked = computed(() => {
+  const state = context.value?.part.state
+  return typeof state === 'string' && ADVISORY_LOCKED_STATES.has(state)
+})
 
 // idle (nothing loaded) -> loading -> one of: unavailable (no support / degraded), upgrade
 // (supported but not entitled), error (entitled but the provider fetch failed transiently),
@@ -119,7 +142,13 @@ function makeIdempotencyKey(): string {
   return `bom-write-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
-function writebackMessage(status: number): string {
+function writebackMessage(status: number, reason?: string): string {
+  // ECO Phase 0: the provider's two write-back 409s are discriminated by the relayed reason
+  // (detail.code). An unknown/absent reason degrades to the legacy status-keyed copy.
+  if (reason === 'lifecycle_locked')
+    return '该 Part 处于生命周期锁定状态，写回被拒；修改需通过 PLM 的 ECO 变更流程。'
+  if (reason === 'idempotency_conflict')
+    return '提交键已用于另一次不同的写入；已为该行更换新的提交键，请确认单元格后重试。'
   if (status === 412) return '此行已被他人修改，已重新载入最新值，请确认后重试。'
   if (status === 403) return '无写回授权或权限不足。'
   if (status === 404) return '该 BOM 行不存在或不属于当前 Part。'
@@ -169,7 +198,22 @@ async function submitLinePatch(payload: { line: PlmBomMultitableLine; patch: Plm
       lineMessages.value = { ...lineMessages.value, [lineId]: writebackMessage(412) }
       return
     }
-    lineMessages.value = { ...lineMessages.value, [lineId]: writebackMessage(outcome.status) }
+    if (outcome.status === 409 && outcome.reason === 'idempotency_conflict') {
+      // ECO Phase 0: the key is burned for a DIFFERENT write intent -- replaying it can never
+      // succeed. Drop this line's retry key so the next submit mints a fresh Idempotency-Key
+      // (the 412 flow's key rotation, minus the reload: the server state did not change).
+      const { [lineId]: _burnedKey, ...rest } = retryKeys.value
+      retryKeys.value = rest
+      lineMessages.value = {
+        ...lineMessages.value,
+        [lineId]: writebackMessage(outcome.status, outcome.reason),
+      }
+      return
+    }
+    lineMessages.value = {
+      ...lineMessages.value,
+      [lineId]: writebackMessage(outcome.status, outcome.reason),
+    }
   } catch {
     lineMessages.value = { ...lineMessages.value, [lineId]: '写回暂时失败，请稍后重试。' }
   } finally {

--- a/apps/web/tests/PlmBomReviewPanel.spec.ts
+++ b/apps/web/tests/PlmBomReviewPanel.spec.ts
@@ -11,7 +11,11 @@ vi.mock('../src/services/integration/workbench', () => ({
 import PlmBomReviewPanel from '../src/components/plm/PlmBomReviewPanel.vue'
 
 const CONTEXT = {
-  part: { part_id: 'P1', item_number: 'P-001', name: 'Assembly', state: 'Released', generation: 3 },
+  // Root part state 'Draft': the write specs below model the provider's Draft fast-path (200 on
+  // write). A locked root (Released/Suspended/Obsolete) now advisory-pre-gates editing entirely —
+  // covered by the dedicated ECO Phase 0 pre-gate specs, not the write-path specs. (The old
+  // 'Released' fixture value contradicted the provider, which 409s writes under a locked root.)
+  part: { part_id: 'P1', item_number: 'P-001', name: 'Assembly', state: 'Draft', generation: 3 },
   lines: [
     { bom_line_id: 'R1', part_id: 'C1', write_etag: '"bom-line:etag-r1"', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: ['P1'], path_labels: ['P-001'], source_version: 1, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
     { bom_line_id: 'R2', part_id: 'D1', item_number: 'D-001', name: 'Screw', state: 'Released', generation: 2, quantity: 4, uom: 'EA', find_num: '20', refdes: 'R3', level: 2, path: ['P1', 'C1'], path_labels: ['P-001', 'C-001'], source_version: 2, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
@@ -180,6 +184,101 @@ describe('PlmBomReviewPanel (P3-C BOM review + governed write-back)', () => {
     await flushUi()
     expect(updateLineMock).toHaveBeenNthCalledWith(2, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-2', '"bom-line:etag-r1"')
     expect(container.textContent).toContain('写回成功。')
+  })
+
+  // --- ECO Phase 0: discriminated-409 handling + advisory locked pre-gate -----------------------
+
+  it('renders the distinct ECO guidance when the write is rejected with reason lifecycle_locked', async () => {
+    // The residual race: the advisory pre-gate saw an editable state, but the provider's
+    // authoritative lock rejected the write with the discriminated code.
+    vi.stubGlobal('crypto', { randomUUID: () => 'submit-key-1' })
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
+    updateLineMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      reason: 'lifecycle_locked',
+      message: "Item is locked in state 'Released'",
+    })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+
+    const refdes = container.querySelector('[data-testid="plm-bom-review-refdes-input"]') as HTMLInputElement
+    refdes.value = 'R9'
+    refdes.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container.textContent).toContain('ECO')
+    expect(container.textContent).toContain('生命周期锁定')
+    // NOT the generic conflated 409 copy
+    expect(container.textContent).not.toContain('提交键已用于不同写入')
+  })
+
+  it('on reason idempotency_conflict mints a FRESH key for the next submit (burned key never replayed)', async () => {
+    const randomUUID = vi.fn()
+      .mockReturnValueOnce('submit-key-1')
+      .mockReturnValueOnce('submit-key-2')
+    vi.stubGlobal('crypto', { randomUUID })
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
+    updateLineMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        reason: 'idempotency_conflict',
+        message: 'Idempotency-Key reused for a different write',
+      })
+      .mockResolvedValueOnce({ ok: true, bom_line_id: 'R1' })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+
+    const refdes = container.querySelector('[data-testid="plm-bom-review-refdes-input"]') as HTMLInputElement
+    refdes.value = 'R9'
+    refdes.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    const save = container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement
+    save.click()
+    await flushUi()
+    expect(container.textContent).toContain('更换新的提交键')
+    save.click()
+    await flushUi()
+
+    expect(updateLineMock).toHaveBeenNthCalledWith(1, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-1', '"bom-line:etag-r1"')
+    // the burned key was dropped -> the retry minted submit-key-2 instead of replaying it
+    expect(updateLineMock).toHaveBeenNthCalledWith(2, 'plm-ds', 'P1', 'R1', { refdes: 'R9' }, 'submit-key-2', '"bom-line:etag-r1"')
+    expect(randomUUID).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('写回成功。')
+  })
+
+  it('advisory-pre-gates editing (banner + no inputs) when the ROOT part is in a locked state', async () => {
+    const locked = cloneContext()
+    locked.part.state = 'Released'
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: locked })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+
+    expect(stateOf()).toBe('table')
+    // rows still render (read-only review stays useful) ...
+    expect(container.querySelectorAll('[data-testid="plm-bom-review-row"]').length).toBe(2)
+    // ... but no cell is editable and the ECO guidance banner shows
+    expect(container.querySelector('[data-testid="plm-bom-review-quantity-input"]')).toBeNull()
+    expect(container.querySelector('[data-testid="plm-bom-review-locked-hint"]')).not.toBeNull()
+    expect(container.textContent).toContain('ECO')
+  })
+
+  it('does NOT pre-gate on a locked per-line CHILD state (the gate keys on the root part only)', async () => {
+    // line R2's child state is 'Released' in the shared fixture while the root is 'Draft' --
+    // per-line state is the CHILD part's state and must not disable editing.
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+
+    expect(container.querySelector('[data-testid="plm-bom-review-locked-hint"]')).toBeNull()
+    expect(container.querySelector('[data-testid="plm-bom-review-quantity-input"]')).not.toBeNull()
   })
 
   it('shows the upgrade affordance (no table) when supported but not entitled', async () => {

--- a/packages/core-backend/src/routes/plm-workbench.ts
+++ b/packages/core-backend/src/routes/plm-workbench.ts
@@ -866,13 +866,36 @@ function providerErrorStatus(error: unknown): number | null {
   return typeof status === 'number' ? status : null
 }
 
+// ECO Phase 0 (Yuantus provider contract, plm-collab-eco-phase0-contract-taskbook-20260704.md):
+// the provider's write-back 409 carries a discriminated body {detail: {code, ...}} with
+// code ∈ lifecycle_locked | idempotency_conflict. The AxiosError reaches this route with
+// response.data intact, so read the code here. Contract rule: an UNKNOWN or absent code must
+// degrade to the legacy flattened reason ('provider-rejected'), never leak through raw.
+const PROVIDER_409_REASON_CODES = new Set(['lifecycle_locked', 'idempotency_conflict'])
+
+function providerConflictReasonCode(error: unknown): string | null {
+  const candidate = error as { response?: { data?: unknown } } | null
+  const data = candidate?.response?.data
+  if (!data || typeof data !== 'object') return null
+  const detail = (data as { detail?: unknown }).detail
+  if (!detail || typeof detail !== 'object') return null
+  const code = (detail as { code?: unknown }).code
+  return typeof code === 'string' && PROVIDER_409_REASON_CODES.has(code) ? code : null
+}
+
 function relayProviderWritebackError(error: unknown): { status: number; reason: string } {
   const status = providerErrorStatus(error)
   // 412 = stale If-Match (optimistic-concurrency conflict): distinct reason so the UI reloads.
   if (status === 412) {
     return { status: 412, reason: 'precondition-failed' }
   }
-  if (status && [400, 403, 404, 409, 422].includes(status)) {
+  // 409 = discriminated by the provider since ECO Phase 0: surface the code as the reason so the
+  // UI can distinguish "lifecycle-locked, needs the ECO route" from "Idempotency-Key burned for a
+  // different write". Unknown/absent code falls back to the legacy flattened reason.
+  if (status === 409) {
+    return { status: 409, reason: providerConflictReasonCode(error) ?? 'provider-rejected' }
+  }
+  if (status && [400, 403, 404, 422].includes(status)) {
     return { status, reason: 'provider-rejected' }
   }
   return { status: 502, reason: 'provider-unavailable' }

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -9,7 +9,7 @@
     "pactSpecification": {
       "version": "3.0.0"
     },
-    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. Wave 1 now includes the real schema-discovery call already used by mainline PLMAdapter.getItemMetadata in yuantus mode: GET /api/v1/aml/metadata/{type}. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute. Wave 5 adds the nine CAD endpoints already called on main: CAD properties, CAD view state, CAD review, CAD history, CAD diff, and CAD mesh stats. Release-readiness adds the governance drilldown endpoint already called on main: GET /api/v1/release-readiness/items/{item_id}."
+    "claudeNote": "Hand-authored Wave 1 plus document-semantics Wave 2 contract per docs/PACT_FIRST_INTEGRATION_PLAN_20260407.md. Match-by-type, not match-by-value. Replace with @pact-foundation/pact generated artifact when that dep is approved. Wave 1 now includes the real schema-discovery call already used by mainline PLMAdapter.getItemMetadata in yuantus mode: GET /api/v1/aml/metadata/{type}. Wave 2 adds the real document semantics calls already used by PLMAdapter.getProductDocuments in yuantus mode: GET /api/v1/file/item/{item_id}, GET /api/v1/file/{file_id}, and POST /api/v1/aml/query with expand ['Document Part']. Wave 3 adds where-used, BOM compare schema, and ECO approval-history/action interactions. Wave 4 adds the real approval list/detail and BOM substitute calls already used by mainline getApprovals/getApprovalById/getBomSubstitutes/addBomSubstitute/removeBomSubstitute. Wave 5 adds the nine CAD endpoints already called on main: CAD properties, CAD view state, CAD review, CAD history, CAD diff, and CAD mesh stats. Release-readiness adds the governance drilldown endpoint already called on main: GET /api/v1/release-readiness/items/{item_id}. ECO Phase 0 adds the first two ERROR interactions (discriminated 409s on the governed write-back PATCH): lifecycle_locked (with eco_required boolean field) vs idempotency_conflict, discriminated by detail.code alone per docs/development/plm-collab-eco-phase0-contract-taskbook-20260704.md; detail.code and eco_required are exact-match (discriminator), message/state match-by-type."
   },
   "interactions": [
     {
@@ -4026,6 +4026,143 @@
                 {
                   "match": "regex",
                   "regex": "^https://[^/]+$"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "attempt to write back a governed BOM multi-table line whose parent is lifecycle-locked",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_multitable_writeback license and part 01H000000000000000000000W4 is lifecycle-locked in state 'Released' with Part-BOM line 01H000000000000000000000W6"
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000W4/lines/01H000000000000000000000W6",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1",
+          "Content-Type": "application/json",
+          "Idempotency-Key": "pact-writeback-locked-0001"
+        },
+        "body": {
+          "quantity": 7
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            },
+            "$.Idempotency-Key": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.quantity": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 409,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "detail": {
+            "code": "lifecycle_locked",
+            "message": "Item is locked in state 'Released'",
+            "state": "Released",
+            "eco_required": true
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.detail.message": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.detail.state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "replay a write-back Idempotency-Key with a different payload",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_multitable_writeback license and Idempotency-Key pact-writeback-conflict-0001 was already used for a different write on part 01H000000000000000000000W7 line 01H000000000000000000000W9"
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000W7/lines/01H000000000000000000000W9",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1",
+          "Content-Type": "application/json",
+          "Idempotency-Key": "pact-writeback-conflict-0001"
+        },
+        "body": {
+          "quantity": 42
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 409,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "detail": {
+            "code": "idempotency_conflict",
+            "message": "Idempotency-Key reused for a different write"
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.detail.message": {
+              "matchers": [
+                {
+                  "match": "type"
                 }
               ]
             }

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -131,7 +131,22 @@ const PARENT_HOST_PACT_PATHS = [
   { method: 'POST', path: '/api/v1/bom/multitable/01H000000000000000000000P1/embed-token' },
 ] as const
 
-const PACT_PATHS = [...PLM_ADAPTER_PACT_PATHS, ...PARENT_HOST_PACT_PATHS] as const
+const ERROR_CONTRACT_PACT_PATHS = [
+  // ECO Phase 0 (Yuantus taskbook plm-collab-eco-phase0-contract-taskbook-20260704.md, provider
+  // #969): the pact's FIRST error interactions — the write-back's two discriminated 409s,
+  // machine-distinguishable by detail.code ALONE (lifecycle_locked vs idempotency_conflict).
+  // They live on DEDICATED provider fixtures (W4/W6 locked parent, W7/W9 burned replay key) so the
+  // W1/W3 success-only pin above stays intact. Same PLMAdapter endpoint template as the 200
+  // write-back — no new consumer callsite.
+  { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000W4/lines/01H000000000000000000000W6' },
+  { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000W7/lines/01H000000000000000000000W9' },
+] as const
+
+const PACT_PATHS = [
+  ...PLM_ADAPTER_PACT_PATHS,
+  ...PARENT_HOST_PACT_PATHS,
+  ...ERROR_CONTRACT_PACT_PATHS,
+] as const
 
 function loadPact(): PactDocument {
   const raw = readFileSync(PACT_PATH, 'utf8')
@@ -272,6 +287,47 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       ok: true,
       bom_line_id: '01H000000000000000000000W3',
     })
+  })
+
+  // ECO Phase 0: the discriminated-409 error contract (Yuantus provider #968 taskbook + #969 impl).
+  // detail.code is the ONLY discriminator; eco_required is a boolean FIELD (not a third code);
+  // message keeps the legacy human-readable strings; unknown code ⇒ treat as generic 409.
+  it('ECO Phase 0: the two write-back 409s are machine-distinguishable by detail.code alone', () => {
+    const pact = loadPact()
+
+    const locked = pact.interactions.find(
+      i =>
+        i.request.path ===
+        '/api/v1/bom/multitable/01H000000000000000000000W4/lines/01H000000000000000000000W6',
+    )
+    expect(locked).toBeDefined()
+    expect(locked!.request.method).toBe('PATCH')
+    expect(locked!.response.status).toBe(409)
+    const lockedDetail = (locked!.response.body as { detail: Record<string, unknown> }).detail
+    expect(lockedDetail.code).toBe('lifecycle_locked')
+    expect(lockedDetail.eco_required).toBe(true)
+    expect(typeof lockedDetail.message).toBe('string')
+    expect(typeof lockedDetail.state).toBe('string')
+    // exact payload key-set: no eco_id / entitlement / ECO-existence leakage on the error path
+    expect(Object.keys(lockedDetail).sort()).toEqual(['code', 'eco_required', 'message', 'state'])
+    expect(locked!.providerStates![0].name).toContain('lifecycle-locked')
+
+    const conflict = pact.interactions.find(
+      i =>
+        i.request.path ===
+        '/api/v1/bom/multitable/01H000000000000000000000W7/lines/01H000000000000000000000W9',
+    )
+    expect(conflict).toBeDefined()
+    expect(conflict!.request.method).toBe('PATCH')
+    expect(conflict!.response.status).toBe(409)
+    const conflictDetail = (conflict!.response.body as { detail: Record<string, unknown> }).detail
+    expect(conflictDetail.code).toBe('idempotency_conflict')
+    expect(Object.keys(conflictDetail).sort()).toEqual(['code', 'message'])
+    // the Idempotency-Key is EXACT-match (the provider state pre-seeds the replay row on it)
+    expect(conflict!.request.headers).toHaveProperty(
+      'Idempotency-Key',
+      'pact-writeback-conflict-0001',
+    )
   })
 
   it('aml/apply request body documents the RPC envelope shape used by PLMAdapter', () => {

--- a/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
@@ -290,6 +290,99 @@ describe('plm-workbench BOM multi-table review route (PLM-COLLAB P3-C)', () => {
     expect(res.body.reason).toBe('provider-rejected')
   })
 
+  // ECO Phase 0: the provider 409 is discriminated by detail.code (lifecycle_locked vs
+  // idempotency_conflict); the relay surfaces the code as the reason instead of flattening.
+  // A bodyless or unknown-code 409 still flattens to 'provider-rejected' (test above).
+  it('write route surfaces a discriminated lifecycle_locked 409 reason', async () => {
+    const locked = Object.assign(new Error('Request failed with status code 409'), {
+      response: {
+        status: 409,
+        data: {
+          detail: {
+            code: 'lifecycle_locked',
+            message: "Item is locked in state 'Released'",
+            state: 'Released',
+            eco_required: true,
+          },
+        },
+      },
+    })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: true } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine: vi.fn().mockResolvedValue({ data: [], error: locked }),
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .send({ quantity: 5 })
+    expect(res.status).toBe(409)
+    expect(res.body.reason).toBe('lifecycle_locked')
+  })
+
+  it('write route surfaces a discriminated idempotency_conflict 409 reason', async () => {
+    const burned = Object.assign(new Error('Request failed with status code 409'), {
+      response: {
+        status: 409,
+        data: {
+          detail: {
+            code: 'idempotency_conflict',
+            message: 'Idempotency-Key reused for a different write',
+          },
+        },
+      },
+    })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: true } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine: vi.fn().mockResolvedValue({ data: [], error: burned }),
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .send({ quantity: 5 })
+    expect(res.status).toBe(409)
+    expect(res.body.reason).toBe('idempotency_conflict')
+  })
+
+  it('write route flattens an unknown discriminated 409 code to provider-rejected (forward-compat)', async () => {
+    const future = Object.assign(new Error('Request failed with status code 409'), {
+      response: {
+        status: 409,
+        data: { detail: { code: 'some_future_code', message: 'new provider semantics' } },
+      },
+    })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(
+          { supported: true, api_version: 'v1', entitled: true },
+          { bom_multitable_writeback: { supported: true, api_version: 'v1', entitled: true } },
+        ),
+      }),
+      getBomMultitableContext: vi.fn(),
+      updateBomMultitableLine: vi.fn().mockResolvedValue({ data: [], error: future }),
+    })
+    const res = await request(app)
+      .patch(WRITE_URL)
+      .set('Idempotency-Key', 'submit-1')
+      .send({ quantity: 5 })
+    expect(res.status).toBe(409)
+    expect(res.body.reason).toBe('provider-rejected')
+  })
+
   it('write route forwards the client If-Match header to the provider (optimistic concurrency)', async () => {
     const updateBomMultitableLine = vi.fn().mockResolvedValue({ data: [{ ok: true, bom_line_id: 'R1' }] })
     dsMocks.getDataSource.mockReturnValue({


### PR DESCRIPTION
## What (consumer half of Yuantus locked-BOM ECO route Phase 0)

Adopts the provider contract shipped on Yuantus main (taskbook adharamans/yuantus-plm#968 + impl adharamans/yuantus-plm#969): the governed BOM write-back's two 409s are now discriminated by `detail.code` ∈ `lifecycle_locked` | `idempotency_conflict`.

**Pact (34→36 interactions — the artifact's first error interactions).** Byte-synced with the Yuantus provider copy; dedicated fixtures (`W4/W6` locked parent, `W7/W9` burned replay key) keep the `W1/W3` success-only pin intact. `PACT_PATHS` extended in lockstep (count + order pins); a new contract test pins both 409 shapes including the exact key-set (no `eco_id` / entitlement / ECO-existence leakage on the error path).

**Relay** (`plm-workbench.ts`): the write-back 409 mapper now surfaces `detail.code` as the relayed `reason` instead of flattening; unknown/absent code degrades to `provider-rejected` (the contract's forward-compat rule). The AxiosError body was always available — only the mapper ignored it. +3 route tests (both codes + unknown-code fallback).

**Panel** (`PlmBomReviewPanel.vue`):
- `lifecycle_locked` → distinct ECO-guidance copy (no longer conflated with key reuse).
- `idempotency_conflict` → distinct copy + drops the burned retry key so the next submit mints a fresh `Idempotency-Key` (replaying a burned key can never succeed — mirrors the 412 flow's key rotation, minus the reload).
- **Advisory pre-gate (ratified C2)**: inline editing pauses + ECO banner when the ROOT part state is in the provider's default-seed locked set (`Released/Suspended/Obsolete`). Advisory only — the lock set is data-driven provider-side, so the discriminated 409 stays authoritative. Keys on root `part.state` (per-line `state` is the CHILD part's state — wrong semantics for the write gate; pinned by a dedicated spec).
- Embed untouched: table component unchanged, embed passes no `editable` prop; read-only invariant intact (existing embed spec still asserts zero inputs).

**Spec fixture correction**: root part state `Released`→`Draft` — the old value contradicted the provider (which 409s writes under a locked root); the write specs model the Draft fast-path, and the locked case now has its own pre-gate specs.

## Verification (local, worktree)

| Gate | Result |
|---|---|
| `test:contract` | 21/21 |
| relay route tests | 18/18 (15 existing + 3 new) |
| full `@metasheet/core-backend` suite | 5270 passed (one unrelated flake on first run, clean rerun) |
| web panel/service/embed specs | 35/35 (incl. 4 new) |
| `pnpm lint` / `pnpm type-check` / `@metasheet/web build` | green |

Broker note: on merge, push:main publishes the 36-interaction pact; the Yuantus provider already satisfies both new interactions on its main (strict verifier green there), so the provider's blocking broker gate stays green. A tiny Yuantus follow-up will reverse-sync its committed copy to this file's canonical interaction order (`sync_metasheet2_pact.sh --check` byte parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)