### PR TITLE
feat(integration): read-source composition C-R4-1 HTTP surface (authoring + approved-only key-only run route)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -6586,7 +6586,7 @@ async function testReadSourceCompositionRoutes() {
     ],
   }
 
-  function compositionServices({ itemRows, bomRows, compositionStatus = 'approved', bomConfigStatus = 'approved' } = {}) {
+  function compositionServices({ itemRows, bomRows, compositionStatus = 'approved', bomConfigStatus = 'approved', bomConfigMode = 'resolver_lookup' } = {}) {
     const reads = []
     const writes = []
     const services = createMockServices({
@@ -6618,7 +6618,9 @@ async function testReadSourceCompositionRoutes() {
             error.details = { id: input.id, status: bomConfigStatus }
             throw error
           }
-          const config = input.id === 'cfg-bom' ? BOM_CONFIG : ITEM_CONFIG
+          // bomConfigMode lets a test return an APPROVED (getForRuntime passes) but WRONG-SHAPE step
+          // config, so the C-R2 planner's defense-in-depth re-validation is exercised at the route level.
+          const config = input.id === 'cfg-bom' ? { ...BOM_CONFIG, mode: bomConfigMode } : ITEM_CONFIG
           return { id: input.id, systemId: 'sys_1', status: 'approved', config }
         },
       },
@@ -6684,6 +6686,27 @@ async function testReadSourceCompositionRoutes() {
     assert.equal(res.statusCode, 409)
     assert.equal(res.body.error.code, 'READ_SOURCE_CONFIG_NOT_APPROVED')
     assert.equal(reads.length, 0, 'no hop runs when a step config is not approved')
+  }
+
+  // ── approved-only gate #2b (planner defense-in-depth): a step config that is APPROVED (getForRuntime
+  //    passes) but WRONG-SHAPE (not resolver_lookup) is rejected by the C-R2 planner inside the executor —
+  //    values-free PLAN_INVALID, no hop runs. This is the "planner re-validates the bundle" layer the
+  //    design-lock requires; without it, gate #2 (approval) alone would let a wrong-mode config through. ──
+  {
+    const { services, reads } = compositionServices({ itemRows: [{ FItemID: 'I' }], bomRows: [{ FBOMNumber: 'B' }], bomConfigMode: 'single_record' })
+    const res = await invoke(mountRoutes(services).routes, 'POST', '/api/integration/read-source-compositions/:id/run', {
+      user: READ_USER, params: { id: 'rscc_1' }, body: { inputs: { key: 'M-001' } },
+    })
+    assertOkResponse(res, 200)
+    assert.equal(res.body.data.evidence.ok, false)
+    assert.equal(res.body.data.evidence.errorCode, 'READ_SOURCE_COMPOSITION_PLAN_INVALID')
+    assert.ok(Array.isArray(res.body.data.evidence.planErrors) && res.body.data.evidence.planErrors.length > 0)
+    assert.equal(res.body.data.data, null)
+    assert.equal(reads.length, 0, 'an approved-but-wrong-shape step config must be rejected by the planner before any hop runs')
+    const evStr = JSON.stringify(res.body.data.evidence)
+    for (const leak of ['secret-token', '/K3API', 'FBOMNumber', 'FItemId']) {
+      assert.ok(!evStr.includes(leak), `planner-rejection evidence must not leak ${leak}`)
+    }
   }
 
   // ── key-only allowlist: a config override / extra body field → 400, before any store access ──

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -10,6 +10,7 @@ const { PLM_STOCK_PREPARATION_ACTION_ID } = require(path.join(__dirname, '..', '
 const { STOCK_PREPARATION_MAIN_TABLE_TEMPLATE } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
 const { READ_SMOKE_LIST_REQUEST_MARKER } = require(path.join(__dirname, '..', 'lib', 'read-smoke-marker.cjs'))
 const { createReadSourceConfigStore, ReadSourceConfigNotApprovedError } = require(path.join(__dirname, '..', 'lib', 'read-source-config-store.cjs'))
+const { ReadSourceCompositionConfigNotApprovedError } = require(path.join(__dirname, '..', 'lib', 'read-source-composition-config-store.cjs'))
 // S4: adapter self-described metadata — the mock registry serves the REAL per-module metadata
 // so the /adapters route assertions verify the actual shipped values (no duplicated literal).
 const ADAPTER_METADATA_BY_KIND = {
@@ -287,6 +288,37 @@ function createMockServices(overrides = {}) {
       },
       async listAudit(input) {
         calls.push(['readSourceConfigListAudit', input])
+        return []
+      },
+    },
+    // C-R4-1: default mock so requireService('readSourceCompositionConfigStore', ...) mounts for every test.
+    readSourceCompositionConfigStore: {
+      async saveVersion(input) {
+        calls.push(['readSourceCompositionSaveVersion', input])
+        return { id: 'rscc_1', name: 'material-to-bom', version: 1, status: 'draft', contentKey: 'ck', reused: false, config: {} }
+      },
+      async list(input) {
+        calls.push(['readSourceCompositionList', input])
+        return []
+      },
+      async get(input) {
+        calls.push(['readSourceCompositionGet', input])
+        return { id: input.id, status: 'draft' }
+      },
+      async getForRuntime(input) {
+        calls.push(['readSourceCompositionGetForRuntime', input])
+        return { id: input.id, status: 'approved', name: 'material-to-bom', config: {} }
+      },
+      async approve(input) {
+        calls.push(['readSourceCompositionApprove', input])
+        return { id: input.id, status: 'approved' }
+      },
+      async retire(input) {
+        calls.push(['readSourceCompositionRetire', input])
+        return { id: input.id, status: 'retired' }
+      },
+      async listAudit(input) {
+        calls.push(['readSourceCompositionListAudit', input])
         return []
       },
     },
@@ -6531,6 +6563,202 @@ async function testReadSourceResolverReadRoute() {
   console.log('  testReadSourceResolverReadRoute OK')
 }
 
+// C-R4-1 (#1709 composition): the composition HTTP surface — authoring routes + the approved-only,
+// key-only, values-free, read-only RUN route wiring executeReadSourceComposition.
+async function testReadSourceCompositionRoutes() {
+  const ITEM_CONFIG = {
+    version: 1, systemId: 'sys_1', requiredKind: 'erp:k3-wise-webapi', object: 'material',
+    mode: 'resolver_lookup', readPath: '/K3API/Material/GetList', readMethod: 'POST', operations: ['read'],
+    keyField: 'FNumber', containerPaths: ['Data.Rows'], resolverRule: 'exactly_one',
+    fieldMap: [{ source: 'FItemID', target: 'internal_id' }],
+  }
+  const BOM_CONFIG = {
+    version: 1, systemId: 'sys_1', requiredKind: 'erp:k3-wise-webapi', object: 'bom',
+    mode: 'resolver_lookup', readPath: '/K3API/BOM/GetList', readMethod: 'POST', operations: ['read'],
+    keyField: 'FItemId', containerPaths: ['Data.Rows'], resolverRule: 'exactly_one',
+    fieldMap: [{ source: 'FBOMNumber', target: 'bom_number' }],
+  }
+  const COMPOSITION_CONFIG = {
+    version: 1, name: 'material-to-bom', operations: ['read'],
+    steps: [
+      { id: 'a', readSourceConfigId: 'cfg-item' },
+      { id: 'b', readSourceConfigId: 'cfg-bom', input: { fromStep: 'a', sourceTarget: 'internal_id', toInput: 'key' } },
+    ],
+  }
+
+  function compositionServices({ itemRows, bomRows, compositionStatus = 'approved', bomConfigStatus = 'approved' } = {}) {
+    const reads = []
+    const writes = []
+    const services = createMockServices({
+      externalSystemRegistry: {
+        async getExternalSystemForAdapter(input) {
+          return { id: input.id, kind: 'erp:k3-wise-webapi', credentials: { bearerToken: 'secret-token' }, config: { objects: {} } }
+        },
+      },
+      readSourceCompositionConfigStore: {
+        async saveVersion() { return {} }, async list() { return [] }, async get() { return {} },
+        async approve() { return {} }, async retire() { return {} }, async listAudit() { return [] },
+        async getForRuntime(input) {
+          if (compositionStatus !== 'approved') {
+            const error = new Error('composition not approved')
+            Object.setPrototypeOf(error, ReadSourceCompositionConfigNotApprovedError.prototype)
+            error.details = { status: compositionStatus }
+            throw error
+          }
+          return { id: input.id, status: 'approved', name: 'material-to-bom', config: COMPOSITION_CONFIG }
+        },
+      },
+      readSourceConfigStore: {
+        async saveVersion() { return {} }, async list() { return [] }, async get() { return {} },
+        async approve() { return {} }, async retire() { return {} }, async listAudit() { return [] },
+        async getForRuntime(input) {
+          if (input.id === 'cfg-bom' && bomConfigStatus !== 'approved') {
+            const error = new Error('read config not approved')
+            Object.setPrototypeOf(error, ReadSourceConfigNotApprovedError.prototype)
+            error.details = { id: input.id, status: bomConfigStatus }
+            throw error
+          }
+          const config = input.id === 'cfg-bom' ? BOM_CONFIG : ITEM_CONFIG
+          return { id: input.id, systemId: 'sys_1', status: 'approved', config }
+        },
+      },
+      adapterRegistry: {
+        createAdapter() {
+          return {
+            async read(req) {
+              reads.push({ object: req.object, filters: req.filters })
+              if (req.object === 'material') return { raw: { Data: { Rows: itemRows } } }
+              if (req.object === 'bom') return { raw: { Data: { Rows: bomRows } } }
+              throw new Error(`unexpected object ${req.object}`)
+            },
+            async upsert(b) { writes.push(['upsert', b]); return {} },
+            async save(b) { writes.push(['save', b]); return {} },
+          }
+        },
+      },
+    }).services
+    return { services, reads, writes }
+  }
+
+  // ── happy path: approved two-hop chain, read-tier, derived intermediate key, last-hop-only data ──
+  {
+    const { services, reads, writes } = compositionServices({
+      itemRows: [{ FItemID: 'ITEM-777' }], bomRows: [{ FBOMNumber: 'BOM-2026-X' }],
+    })
+    const { routes } = mountRoutes(services)
+    const ok = await invoke(routes, 'POST', '/api/integration/read-source-compositions/:id/run', {
+      user: READ_USER, params: { id: 'rscc_1' }, body: { inputs: { key: 'M-001' } },
+    })
+    assertOkResponse(ok, 200)
+    assert.equal(ok.body.data.evidence.ok, true)
+    assert.deepEqual(ok.body.data.data, { resolver: { target: 'bom_number', value: 'BOM-2026-X' } })
+    // Hop 0 filters on the business key; hop 1 filters on the DERIVED intermediate key.
+    assert.equal(reads.length, 2)
+    assert.deepEqual(reads[0], { object: 'material', filters: { FNumber: 'M-001' } })
+    assert.deepEqual(reads[1], { object: 'bom', filters: { FItemId: 'ITEM-777' } })
+    assert.equal(writes.length, 0, 'composition run is read-only')
+    // Evidence is values-free; the intermediate ITEM-777 appears nowhere in evidence.
+    const evStr = JSON.stringify(ok.body.data.evidence)
+    for (const leak of ['ITEM-777', 'internal_id', 'FItemID', 'FBOMNumber', 'M-001', 'secret-token', '/K3API', 'bom_number']) {
+      assert.ok(!evStr.includes(leak), `composition evidence must not leak ${leak}`)
+    }
+  }
+
+  // ── approved-only gate #1: composition not approved → 409 ──
+  {
+    const { services, reads } = compositionServices({ itemRows: [{ FItemID: 'I' }], bomRows: [{ FBOMNumber: 'B' }], compositionStatus: 'draft' })
+    const res = await invoke(mountRoutes(services).routes, 'POST', '/api/integration/read-source-compositions/:id/run', {
+      user: READ_USER, params: { id: 'rscc_draft' }, body: { inputs: { key: 'M-001' } },
+    })
+    assert.equal(res.statusCode, 409)
+    assert.equal(res.body.error.code, 'READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED')
+    assert.equal(reads.length, 0, 'no hop runs when the composition is not approved')
+  }
+
+  // ── approved-only gate #2: a step read config not approved → 409, no chain execution ──
+  {
+    const { services, reads } = compositionServices({ itemRows: [{ FItemID: 'I' }], bomRows: [{ FBOMNumber: 'B' }], bomConfigStatus: 'draft' })
+    const res = await invoke(mountRoutes(services).routes, 'POST', '/api/integration/read-source-compositions/:id/run', {
+      user: READ_USER, params: { id: 'rscc_1' }, body: { inputs: { key: 'M-001' } },
+    })
+    assert.equal(res.statusCode, 409)
+    assert.equal(res.body.error.code, 'READ_SOURCE_CONFIG_NOT_APPROVED')
+    assert.equal(reads.length, 0, 'no hop runs when a step config is not approved')
+  }
+
+  // ── key-only allowlist: a config override / extra body field → 400, before any store access ──
+  {
+    const { services, reads } = compositionServices({ itemRows: [{ FItemID: 'I' }], bomRows: [{ FBOMNumber: 'B' }] })
+    const { routes } = mountRoutes(services)
+    for (const badBody of [{ inputs: { key: 'M-001' }, config: { steps: [] } }, { inputs: { key: 'M-001' }, sheetId: 'x' }]) {
+      const res = await invoke(routes, 'POST', '/api/integration/read-source-compositions/:id/run', {
+        user: READ_USER, params: { id: 'rscc_1' }, body: badBody,
+      })
+      assert.equal(res.statusCode, 400)
+      assert.equal(res.body.error.code, 'READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID')
+    }
+    assert.equal(reads.length, 0, 'a config-override request must be rejected before any store/adapter access')
+    // A per-hop key inside inputs (only { key } allowed) → contract invalid from the executor's normalizer.
+    const perHopKey = await invoke(routes, 'POST', '/api/integration/read-source-compositions/:id/run', {
+      user: READ_USER, params: { id: 'rscc_1' }, body: { inputs: { key: 'M-001', key1: 'ITEM-777' } },
+    })
+    assert.equal(perHopKey.statusCode, 400)
+    assert.equal(perHopKey.body.error.code, 'READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID')
+  }
+
+  // ── hop-0 abort: ambiguous → chain aborts, hop 1 never reads, 200 values-free ──
+  {
+    const { services, reads } = compositionServices({ itemRows: [{ FItemID: 'I1' }, { FItemID: 'I2' }], bomRows: [{ FBOMNumber: 'B' }] })
+    const res = await invoke(mountRoutes(services).routes, 'POST', '/api/integration/read-source-compositions/:id/run', {
+      user: READ_USER, params: { id: 'rscc_1' }, body: { inputs: { key: 'M-001' } },
+    })
+    assertOkResponse(res, 200)
+    assert.equal(res.body.data.evidence.ok, false)
+    assert.equal(res.body.data.evidence.failedStep, 0)
+    assert.equal(res.body.data.evidence.steps[0].errorCode, 'READ_SOURCE_RESOLVER_AMBIGUOUS')
+    assert.deepEqual(res.body.data.evidence.steps[1], { step: 1, ok: false, errorCode: 'READ_SOURCE_COMPOSITION_STEP_NOT_RUN' })
+    assert.equal(res.body.data.data, null)
+    assert.equal(reads.length, 1, 'hop 1 must not read after hop 0 aborts')
+  }
+
+  // ── authoring tier: run is read-tier; save/approve/retire are write-tier ──
+  {
+    const { services } = compositionServices({ itemRows: [{ FItemID: 'I' }], bomRows: [{ FBOMNumber: 'B' }] })
+    const { routes } = mountRoutes(services)
+    // Save requires write; a read-only principal is rejected.
+    const denied = await invoke(routes, 'POST', '/api/integration/read-source-compositions', {
+      user: READ_USER, body: { config: COMPOSITION_CONFIG },
+    })
+    assert.equal(denied.statusCode, 403, 'authoring a composition is write-tier')
+  }
+
+  // ── authoring lifecycle against the default mock store: methods called, tiers enforced ──
+  {
+    const { calls, services } = createMockServices()
+    const { routes } = mountRoutes(services)
+    const saved = await invoke(routes, 'POST', '/api/integration/read-source-compositions', {
+      user: WRITE_USER, body: { config: COMPOSITION_CONFIG },
+    })
+    assert.equal(saved.statusCode, 201)
+    findCall(calls, 'readSourceCompositionSaveVersion')
+    const listed = await invoke(routes, 'GET', '/api/integration/read-source-compositions', { user: READ_USER, query: {} })
+    assertOkResponse(listed, 200)
+    findCall(calls, 'readSourceCompositionList')
+    const approved = await invoke(routes, 'POST', '/api/integration/read-source-compositions/:id/approve', {
+      user: WRITE_USER, params: { id: 'rscc_1' },
+    })
+    assertOkResponse(approved, 200)
+    findCall(calls, 'readSourceCompositionApprove')
+    const audited = await invoke(routes, 'GET', '/api/integration/read-source-compositions/:id/audit', {
+      user: READ_USER, params: { id: 'rscc_1' }, query: {},
+    })
+    assertOkResponse(audited, 200)
+    findCall(calls, 'readSourceCompositionListAudit')
+  }
+
+  console.log('  testReadSourceCompositionRoutes OK')
+}
+
 async function main() {
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
@@ -6556,6 +6784,7 @@ async function main() {
   await testReadSourceConfigRoutes()
   await testReadSourceConfiguredReadRoute()
   await testReadSourceResolverReadRoute()
+  await testReadSourceCompositionRoutes()
   await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testExternalSystemTestClearsErrorToActiveOnSuccess()

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -20,6 +20,7 @@ const { createCredentialStore } = require('./lib/credential-store.cjs')
 const { createDb } = require('./lib/db.cjs')
 const { createExternalSystemRegistry } = require('./lib/external-systems.cjs')
 const { createReadSourceConfigStore } = require('./lib/read-source-config-store.cjs')
+const { createReadSourceCompositionConfigStore } = require('./lib/read-source-composition-config-store.cjs')
 const { createAdapterRegistry } = require('./lib/contracts.cjs')
 const { createHttpAdapterFactory, HTTP_ADAPTER_METADATA } = require('./lib/adapters/http-adapter.cjs')
 const { createYuantusPlmWrapperAdapterFactory, YUANTUS_PLM_ADAPTER_METADATA } = require('./lib/adapters/plm-yuantus-wrapper.cjs')
@@ -49,6 +50,7 @@ let activeContext = null
 let credentialStore = null
 let externalSystemRegistry = null
 let readSourceConfigStore = null
+let readSourceCompositionConfigStore = null
 let adapterRegistry = null
 let pipelineRegistry = null
 let templateRegistry = null
@@ -214,6 +216,9 @@ module.exports = {
     })
     // S2-c (#1709): content-keyed read-source config versions + values-free audit.
     readSourceConfigStore = createReadSourceConfigStore({ db })
+    // C-R4-1 (#1709): the composition config store validates each step's read config is approved at
+    // save time via readSourceConfigStore.getForRuntime, and the run route re-loads them at runtime.
+    readSourceCompositionConfigStore = createReadSourceCompositionConfigStore({ db, readSourceConfigStore })
     adapterRegistry = createAdapterRegistry({ logger })
       .registerAdapter('http', createHttpAdapterFactory(), { metadata: HTTP_ADAPTER_METADATA })
       .registerAdapter('plm:yuantus-wrapper', createYuantusPlmWrapperAdapterFactory(), { metadata: YUANTUS_PLM_ADAPTER_METADATA })
@@ -267,6 +272,7 @@ module.exports = {
       services: {
         externalSystemRegistry,
         readSourceConfigStore,
+        readSourceCompositionConfigStore,
         adapterRegistry,
         pipelineRegistry,
         templateRegistry,
@@ -292,6 +298,7 @@ module.exports = {
     credentialStore = null
     externalSystemRegistry = null
     readSourceConfigStore = null
+    readSourceCompositionConfigStore = null
     adapterRegistry = null
     pipelineRegistry = null
     templateRegistry = null

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -25,6 +25,13 @@ const ROUTES = [
   ['POST', '/api/integration/read-source-configs/:id/approve', 'readSourceConfigsApprove'],
   ['POST', '/api/integration/read-source-configs/:id/retire', 'readSourceConfigsRetire'],
   ['POST', '/api/integration/read-source-configs/:id/read', 'readSourceConfigsRead'],
+  ['POST', '/api/integration/read-source-compositions', 'readSourceCompositionsSave'],
+  ['GET', '/api/integration/read-source-compositions', 'readSourceCompositionsList'],
+  ['GET', '/api/integration/read-source-compositions/:id', 'readSourceCompositionsGet'],
+  ['GET', '/api/integration/read-source-compositions/:id/audit', 'readSourceCompositionsAudit'],
+  ['POST', '/api/integration/read-source-compositions/:id/approve', 'readSourceCompositionsApprove'],
+  ['POST', '/api/integration/read-source-compositions/:id/retire', 'readSourceCompositionsRetire'],
+  ['POST', '/api/integration/read-source-compositions/:id/run', 'readSourceCompositionsRun'],
   ['GET', '/api/integration/external-systems/:id/objects', 'externalSystemObjects'],
   ['GET', '/api/integration/external-systems/:id/schema', 'externalSystemSchema'],
   ['GET', '/api/integration/pipelines', 'pipelinesList'],
@@ -109,12 +116,27 @@ const {
   ReadSourceConfigConflictError,
   ReadSourceConfigNotApprovedError,
 } = require('./read-source-config-store.cjs')
+// C-R4-1 (#1709 composition): the composition config store error surface (mirrors the read-source-config
+// store) — for the composition authoring routes + the approved-only run route error mapping.
+const {
+  ReadSourceCompositionConfigValidationError,
+  ReadSourceCompositionConfigNotFoundError,
+  ReadSourceCompositionConfigConflictError,
+  ReadSourceCompositionConfigNotApprovedError,
+} = require('./read-source-composition-config-store.cjs')
 // S3-2 (#1709 self-service): runtime-tier configured read — consumes an APPROVED stored config version;
 // data plane (mapped values) flows to the authorized caller, evidence stays values-free.
 const {
   prepareConfiguredRead,
   executeConfiguredRead,
 } = require('./read-source-read-runtime.cjs')
+// C-R4-1 (#1709 composition): the chain runtime executor — orchestrates an approved two-hop composition
+// read-only. The run route loads the approved composition + each approved step config + system, then
+// hands them in; the executor throws only on a client-supplied runtime-request contract violation.
+const {
+  executeReadSourceComposition,
+  ReadSourceCompositionRuntimeError,
+} = require('./read-source-composition-runtime.cjs')
 const { K3_REFERENCE_MAPPING_TEMPLATES } = require('./reference-mapping-templates.cjs')
 const { listReferenceIntegrationTemplates } = require('./reference-integration-templates.cjs')
 // DF-T2c: read-only derive route reuses the DF-T2a helper (no duplication; pure compute, no write).
@@ -1492,6 +1514,27 @@ function mapReadSourceConfigError(error) {
   return error
 }
 
+// C-R4-1: map composition config store errors to HTTP, values-free — the C-R1 validator's
+// { code, field, reason } tuples ride through untouched; nothing echoes the submitted config, a step
+// config id, a host, or a key. Mirrors mapReadSourceConfigError.
+function mapReadSourceCompositionConfigError(error) {
+  if (error instanceof ReadSourceCompositionConfigValidationError) {
+    // The C-R1 validator uses fixed markers for unexpected keys ('(unexpected)' / 'steps.N.(unexpected)'),
+    // so no raw caller key rides in field — the tuples are already values-free; pass them through.
+    return new HttpRouteError(400, 'READ_SOURCE_COMPOSITION_CONFIG_INVALID', 'read-source composition config is invalid', error.details)
+  }
+  if (error instanceof ReadSourceCompositionConfigNotFoundError) {
+    return new HttpRouteError(404, 'READ_SOURCE_COMPOSITION_CONFIG_NOT_FOUND', 'read-source composition config not found')
+  }
+  if (error instanceof ReadSourceCompositionConfigNotApprovedError) {
+    return new HttpRouteError(409, 'READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED', 'read-source composition config version is not approved', { status: error.details && error.details.status })
+  }
+  if (error instanceof ReadSourceCompositionConfigConflictError) {
+    return new HttpRouteError(409, 'READ_SOURCE_COMPOSITION_CONFIG_STATUS_CONFLICT', 'read-source composition config status transition is not allowed', error.details)
+  }
+  return error
+}
+
 function createHandlers(services, options = {}) {
   function requireService(name, methods) {
     const service = services[name]
@@ -1512,6 +1555,7 @@ function createHandlers(services, options = {}) {
   const stagingInstaller = requireService('stagingInstaller', ['installStaging', 'listStagingDescriptors'])
   const templateRegistry = requireService('templateRegistry', ['upsertTemplate', 'getTemplate', 'listTemplates', 'deleteTemplate', 'instantiateTemplate'])
   const readSourceConfigs = requireService('readSourceConfigStore', ['saveVersion', 'list', 'get', 'approve', 'retire', 'listAudit', 'getForRuntime'])
+  const readSourceCompositions = requireService('readSourceCompositionConfigStore', ['saveVersion', 'list', 'get', 'approve', 'retire', 'listAudit', 'getForRuntime'])
   const context = options.context || {}
   const configuredTableActions = context && context.config
     ? (context.config.stockPreparationTableActions || context.config.tableActions)
@@ -1886,6 +1930,155 @@ function createHandlers(services, options = {}) {
         // (same guard, second layer) is unreachable here unless the runtime module changes.
         if (error instanceof ReadSourceProbeRuntimeError) {
           throw new HttpRouteError(409, 'READ_SOURCE_READ_KIND_MISMATCH', 'external system kind does not match the approved config')
+        }
+        throw error
+      }
+    },
+
+    // C-R4-1 (#1709 composition): the composition HTTP surface. Authoring routes (save/list/get/audit/
+    // approve/retire) are config-time (write/read tier) mirrors of the read-source-config routes; the run
+    // route is the runtime tier — approved-only, key-only, values-free, read-only.
+    async readSourceCompositionsSave(req, res) {
+      // Consultant/admin tier: minting a persisted composition version is config-time trust.
+      requireAccess(req, 'write')
+      const body = requestBody(req)
+      try {
+        const saved = await readSourceCompositions.saveVersion(scopedInput(req, {
+          config: body.config,
+          actor: requestPrincipal(req),
+        }))
+        return sendOk(res, saved, saved.reused ? 200 : 201)
+      } catch (error) {
+        throw mapReadSourceCompositionConfigError(error)
+      }
+    },
+
+    async readSourceCompositionsList(req, res) {
+      requireAccess(req, 'read')
+      const query = requestQuery(req)
+      try {
+        return sendOk(res, await readSourceCompositions.list(scopedInput(req, {
+          status: query.status,
+          limit: asListLimit(query.limit),
+          offset: asListOffset(query.offset),
+        })))
+      } catch (error) {
+        throw mapReadSourceCompositionConfigError(error)
+      }
+    },
+
+    async readSourceCompositionsGet(req, res) {
+      requireAccess(req, 'read')
+      try {
+        return sendOk(res, await readSourceCompositions.get(scopedInput(req, { id: requestParams(req).id })))
+      } catch (error) {
+        throw mapReadSourceCompositionConfigError(error)
+      }
+    },
+
+    async readSourceCompositionsAudit(req, res) {
+      requireAccess(req, 'read')
+      const query = requestQuery(req)
+      try {
+        return sendOk(res, await readSourceCompositions.listAudit(scopedInput(req, {
+          configId: requestParams(req).id,
+          limit: asListLimit(query.limit),
+          offset: asListOffset(query.offset),
+        })))
+      } catch (error) {
+        throw mapReadSourceCompositionConfigError(error)
+      }
+    },
+
+    async readSourceCompositionsApprove(req, res) {
+      requireAccess(req, 'write')
+      try {
+        return sendOk(res, await readSourceCompositions.approve(scopedInput(req, {
+          id: requestParams(req).id,
+          actor: requestPrincipal(req),
+        })))
+      } catch (error) {
+        throw mapReadSourceCompositionConfigError(error)
+      }
+    },
+
+    async readSourceCompositionsRetire(req, res) {
+      requireAccess(req, 'write')
+      try {
+        return sendOk(res, await readSourceCompositions.retire(scopedInput(req, {
+          id: requestParams(req).id,
+          actor: requestPrincipal(req),
+        })))
+      } catch (error) {
+        throw mapReadSourceCompositionConfigError(error)
+      }
+    },
+
+    // C-R4-1 run route: the runtime tier for an approved composition chain. read-tier + key-only body
+    // ({ inputs: { key } }) — exactly the S3-2 single-read surface, extended to a chain. Approved-only is
+    // a DOUBLE gate: the composition config AND each referenced step read config are loaded via their
+    // stores' getForRuntime (throws NOT_APPROVED for a non-approved version), and the C-R2 planner
+    // re-validates the bundle inside the executor. Intermediate keys are derived by the platform; no raw
+    // endpoint/filter/body/response-path or per-hop key can enter. Evidence stays values-free; chain data
+    // is only the last hop's single resolver output.
+    async readSourceCompositionsRun(req, res) {
+      requireAccess(req, 'read')
+      const body = requestBody(req)
+      // Strict body allowlist BEFORE any store access: only { inputs } may ride in (the deep
+      // { inputs: { key } } bound is enforced by the executor's own normalizer below).
+      if (body !== undefined && body !== null) {
+        if (typeof body !== 'object' || Array.isArray(body)) {
+          throw new HttpRouteError(400, 'READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID', 'composition run request is invalid', { reason: 'not_object' })
+        }
+        const unexpected = Object.keys(body).filter((key) => key !== 'inputs')
+        if (unexpected.length > 0) {
+          throw new HttpRouteError(400, 'READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID', 'composition run request is invalid', { reason: 'unexpected_field' })
+        }
+      }
+
+      // Load the approved composition config (approved-only gate #1).
+      let composition
+      try {
+        composition = await readSourceCompositions.getForRuntime(scopedInput(req, { id: requestParams(req).id }))
+      } catch (error) {
+        throw mapReadSourceCompositionConfigError(error)
+      }
+
+      // Resolve each referenced step: its approved read config (approved-only gate #2 — getForRuntime
+      // throws NOT_APPROVED) + its backend system (dynamic credential context via the stored systemId
+      // reference). The bundle carries status:'approved' by construction (getForRuntime only returns
+      // approved rows); the C-R2 planner re-validates it as defense-in-depth.
+      const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
+        ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
+        : externalSystems.getExternalSystem.bind(externalSystems)
+      const steps = composition && composition.config && Array.isArray(composition.config.steps)
+        ? composition.config.steps
+        : []
+      const stepConfigsById = {}
+      for (const step of steps) {
+        if (!step || typeof step.readSourceConfigId !== 'string' || Object.prototype.hasOwnProperty.call(stepConfigsById, step.readSourceConfigId)) {
+          continue
+        }
+        let row
+        try {
+          row = await readSourceConfigs.getForRuntime(scopedInput(req, { id: step.readSourceConfigId }))
+        } catch (error) {
+          throw mapReadSourceConfigError(error)
+        }
+        const system = await loadSystem(scopedInput(req, { id: row.systemId }))
+        stepConfigsById[step.readSourceConfigId] = { status: 'approved', config: row.config, system }
+      }
+
+      try {
+        const { evidence, data } = await executeReadSourceComposition(composition.config, body || {}, {
+          stepConfigsById,
+          createAdapter: (adapterSystem) => adapterRegistry.createAdapter(adapterSystem, { principal: requestPrincipal(req) }),
+        })
+        return sendOk(res, { evidence, data })
+      } catch (error) {
+        // Only a client-supplied runtime-request contract violation throws; coarse, values-free reason.
+        if (error instanceof ReadSourceCompositionRuntimeError) {
+          throw new HttpRouteError(400, 'READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID', 'composition run request is invalid', { reason: error && typeof error.reason === 'string' ? error.reason : 'invalid' })
         }
         throw error
       }


### PR DESCRIPTION
## Summary

**C-R4-1** (opt-in authorized 2026-07-05) of the composition line (#1709): the **HTTP surface** over the merged C-R1 config store (#3553) + C-R3 runtime executor (#3565). **Server-only** — no client code, no UI. C-R4-2 (client vocab mirror + tripwire) and C-R4-3 (UI) are staged after this.

- **Store registration** (index.cjs): registers the composition config store as a plugin service. It validates each step's read config is approved **at save time** (via `readSourceConfigStore.getForRuntime`) and the run route re-loads them at runtime.
- **Authoring routes** (mirror the read-source-config routes): `save` (write), `list`/`get`/`audit` (read), `approve`/`retire` (write) + a values-free composition-config error mapper.
- **Run route** `POST /api/integration/read-source-compositions/:id/run` — the runtime tier:
  - **read-tier** + strict `{ inputs }` body allowlist (config override / extra field rejected **before any store access**; per-hop key rejected by the executor's own `{ inputs: { key } }` normalizer);
  - **approved-only DOUBLE gate** — the composition config **and** each referenced step read config are loaded via their stores' `getForRuntime` (throws `NOT_APPROVED` for a non-approved version), and the C-R2 planner re-validates the assembled bundle inside the executor as defense-in-depth;
  - intermediate keys **derived by the platform** (never runtime-supplied);
  - **values-free** evidence, chain data = last hop's single output only, **read-only** (no adapter write surface).

## Boundary

```text
clientCodeTouched=false     (C-R4-2 = vocab mirror + tripwire; C-R4-3 = UI)
uiTouched=false
writePathTouched=false
recursionSupported=false
newRuntimeSuppliedInput=false   (only the first business key; intermediate keys derived)
approvedOnlyDoubleGate=true
```

## Verification

- `node __tests__/http-routes.test.cjs` — `testReadSourceCompositionRoutes` **OK** + full suite green: happy-path two-hop (derived intermediate key on hop-1 filter, last-hop-only data, values-free evidence, no write), approved-only gate #1 (composition draft → 409, **no hop runs**), approved-only gate #2 (step config draft → 409, **no hop runs**), key-only allowlist (config-override / extra field → 400 before store access; per-hop key → 400), hop-0 ambiguate abort (hop 1 never reads, 200 values-free), authoring tier enforcement (run=read, save=write), authoring lifecycle.
- `node --check` clean on index.cjs + http-routes.cjs; composition modules + http-routes load OK.
- Neighbors green (composition-config-store / composition-runtime / composition-planner / read-source-config-store).

> The composition vocab **client/server mirror + CI tripwire is C-R4-2** (landing before the C-R4-3 UI consumes these codes); no client code is touched here, so no existing mirror is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
