### PR TITLE
test(integration): #3365 OAPI allowlist⟺guard dual-reachability tripwire

### DIFF
--- a/packages/core-backend/tests/unit/multitable-oapi-allowlist-guard-tripwire.test.ts
+++ b/packages/core-backend/tests/unit/multitable-oapi-allowlist-guard-tripwire.test.ts
@@ -21,22 +21,24 @@
  * are the same set, following the same whole-file structural-scan discipline as
  * `multitable-stored-data-taint-chokepoint.guard.test.ts`:
  *
- *   1. Scan every `router.<verb>('<path>', ...)` registration in `routes/univer-meta.ts` and
- *      `routes/comments.ts` — confirmed (via `rg -ln apiTokenAuth packages/core-backend/src`) to be the
- *      ONLY two files where `apiTokenAuth` is ever mounted on a route — and split them into GUARDED
+ *   1. First scan every TypeScript file under `src/routes` to prove the explicit `ROUTE_FILES` scope
+ *      covers every route file that references `apiTokenAuth`.
+ *   2. Scan every `router.<verb>('<path>', ...)` registration in `routes/univer-meta.ts` and
+ *      `routes/comments.ts` — currently the ONLY two files where `apiTokenAuth` is mounted — and split
+ *      them into GUARDED
  *      (the registration's own argument list contains both `apiTokenAuth` and `requireScope(`) and
  *      UNGUARDED (every other registered route in the same two files).
- *   2. For each GUARDED route, assert the exported `isOapiAllowlistRequest` (the real gate function,
+ *   3. For each GUARDED route, assert the exported `isOapiAllowlistRequest` (the real gate function,
  *      not a re-typed copy) admits it.
- *   3. For each UNGUARDED route, assert `isOapiAllowlistRequest` REJECTS it — this is what actually
+ *   4. For each UNGUARDED route, assert `isOapiAllowlistRequest` REJECTS it — this is what actually
  *      proves the allowlist isn't over-broad: it's checked against every OTHER real route Express would
  *      dispatch on these two routers, not just a few hand-picked "adjacent path" guesses.
  *
  * If this test fails, you added/changed a route's guard-mounting or the allowlist's shape without
  * updating the other — see the two failure messages below for which direction drifted and what to fix.
  */
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
 
 import { describe, expect, test } from 'vitest'
 
@@ -47,6 +49,7 @@ const read = (rel: string) => readFileSync(join(SRC, rel), 'utf8')
 
 /** The only two files where `apiTokenAuth` is ever mounted on a route (verified by whole-`src` grep). */
 const ROUTE_FILES = ['routes/univer-meta.ts', 'routes/comments.ts'] as const
+const ROUTE_FILE_SET = new Set<string>(ROUTE_FILES)
 
 interface RouteRegistration {
   file: (typeof ROUTE_FILES)[number]
@@ -103,7 +106,41 @@ const ALL_ROUTES = ROUTE_FILES.flatMap(extractRoutes)
 const GUARDED = ALL_ROUTES.filter((r) => r.guarded)
 const UNGUARDED = ALL_ROUTES.filter((r) => !r.guarded)
 
+function listRouteSourceFiles(dir = join(SRC, 'routes')): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...listRouteSourceFiles(abs))
+    else if (entry.isFile() && entry.name.endsWith('.ts')) out.push(relative(SRC, abs).split(sep).join('/'))
+  }
+  return out.sort()
+}
+
+const routeFilesReferencingApiTokenAuth = listRouteSourceFiles()
+  .filter((file) => /\bapiTokenAuth\b/.test(read(file)))
+
 describe('#3365 OAPI allowlist⟺guard dual-reachability tripwire', () => {
+  test('ROUTE_FILES covers every route source file that references apiTokenAuth', () => {
+    const missing = routeFilesReferencingApiTokenAuth.filter((file) => !ROUTE_FILE_SET.has(file))
+    const stale = ROUTE_FILES.filter((file) => !routeFilesReferencingApiTokenAuth.includes(file))
+
+    expect(
+      missing,
+      `${missing.length} route file(s) reference apiTokenAuth but are outside ROUTE_FILES, so this ` +
+        `allowlist/guard tripwire would not scan their guarded OR unguarded routes:\n` +
+        missing.map((file) => `  - ${file}`).join('\n') +
+        `\n\nAdd the file to ROUTE_FILES and teach fullPath() its mount prefix, or avoid mounting ` +
+        `apiTokenAuth there.`,
+    ).toEqual([])
+
+    expect(
+      stale,
+      `${stale.length} ROUTE_FILES entry/entries no longer reference apiTokenAuth; remove stale scope ` +
+        `or update the tripwire's route discovery:\n` +
+        stale.map((file) => `  - ${file}`).join('\n'),
+    ).toEqual([])
+  })
+
   test('sanity: the source scan found a real population of routes on both sides (guards against a silent scan regression)', () => {
     // Both files register dozens of routes; if a future refactor changes the registration STYLE (e.g.
     // multi-line calls, a route-table object instead of direct `router.verb()` calls), this regex-based

--- a/packages/core-backend/tests/unit/multitable-oapi-allowlist-guard-tripwire.test.ts
+++ b/packages/core-backend/tests/unit/multitable-oapi-allowlist-guard-tripwire.test.ts
@@ -1,0 +1,142 @@
+/**
+ * #3365 allowlist⟺guard dual-reachability tripwire (Tier-B gap #5, permission golden matrix —
+ * `docs/research/multitable-feishu-refresh-audit-20260629.md` line 58): "pin that the OAPI allowlist
+ * set equals the set of `apiTokenAuth`-guarded routes (currently lockstep-by-hand)."
+ *
+ * `oapi-read-allowlist.ts` is the single fail-closed switch the global JWT gate consults to let an
+ * `mst_` API token reach a route's OWN `apiTokenAuth` + `requireScope` guards. Its own module comment
+ * says the allowlist must be kept "in exact lockstep" with the routes that mount those guards — today
+ * that lockstep is maintained BY HAND (two independently-edited call sites: the allowlist regex/route
+ * arrays in `oapi-read-allowlist.ts`, and the `router.<verb>(...)` registrations in `univer-meta.ts` /
+ * `comments.ts`). Nothing forces them to move together, so they can silently drift in either direction:
+ *
+ *   - a route gains `apiTokenAuth` + `requireScope` but nobody adds the matching allowlist entry → the
+ *     guard is DEAD (an `mst_` token 401s at the global gate before ever reaching it) — harmless but a
+ *     silent regression in whatever the route was meant to expose.
+ *   - an allowlist entry is widened (or added) without a route actually mounting BOTH guards → a SILENT
+ *     NO-AUTH BYPASS (`requireScope` fail-opens when no token scopes are attached, per its own doc
+ *     comment in `middleware/api-token-auth.ts`) — the dangerous direction.
+ *
+ * This test derives BOTH sides from real source (no hand-duplicated list of its own) and asserts they
+ * are the same set, following the same whole-file structural-scan discipline as
+ * `multitable-stored-data-taint-chokepoint.guard.test.ts`:
+ *
+ *   1. Scan every `router.<verb>('<path>', ...)` registration in `routes/univer-meta.ts` and
+ *      `routes/comments.ts` — confirmed (via `rg -ln apiTokenAuth packages/core-backend/src`) to be the
+ *      ONLY two files where `apiTokenAuth` is ever mounted on a route — and split them into GUARDED
+ *      (the registration's own argument list contains both `apiTokenAuth` and `requireScope(`) and
+ *      UNGUARDED (every other registered route in the same two files).
+ *   2. For each GUARDED route, assert the exported `isOapiAllowlistRequest` (the real gate function,
+ *      not a re-typed copy) admits it.
+ *   3. For each UNGUARDED route, assert `isOapiAllowlistRequest` REJECTS it — this is what actually
+ *      proves the allowlist isn't over-broad: it's checked against every OTHER real route Express would
+ *      dispatch on these two routers, not just a few hand-picked "adjacent path" guesses.
+ *
+ * If this test fails, you added/changed a route's guard-mounting or the allowlist's shape without
+ * updating the other — see the two failure messages below for which direction drifted and what to fix.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+import { isOapiAllowlistRequest } from '../../src/multitable/oapi-read-allowlist'
+
+const SRC = join(__dirname, '../../src')
+const read = (rel: string) => readFileSync(join(SRC, rel), 'utf8')
+
+/** The only two files where `apiTokenAuth` is ever mounted on a route (verified by whole-`src` grep). */
+const ROUTE_FILES = ['routes/univer-meta.ts', 'routes/comments.ts'] as const
+
+interface RouteRegistration {
+  file: (typeof ROUTE_FILES)[number]
+  method: string
+  /** The literal Express registration path (e.g. `/records/:recordId`), as written in source. */
+  registeredPath: string
+  guarded: boolean
+}
+
+/**
+ * Extract every `router.<verb>('<path>', ...rest)` registration. Both files write each registration as
+ * ONE physical source line (`router.verb('path', mw1, mw2, ..., async (req, res) => {`), so a per-line
+ * regex is sufficient and mirrors the files' actual style — this is re-verified below by asserting the
+ * scan finds a large, non-trivial number of registrations in each file (a style change that broke the
+ * regex would silently return an empty/tiny list, which the sanity test below catches).
+ */
+function extractRoutes(file: (typeof ROUTE_FILES)[number]): RouteRegistration[] {
+  const src = read(file)
+  const lineRe = /^\s*router\.(get|post|patch|delete|put)\(\s*'([^']+)'\s*,(.*)$/
+  const out: RouteRegistration[] = []
+  for (const rawLine of src.split('\n')) {
+    const m = rawLine.match(lineRe)
+    if (!m) continue
+    const [, method, registeredPath, restOfArgs] = m
+    const guarded = /\bapiTokenAuth\b/.test(restOfArgs) && /\brequireScope\(/.test(restOfArgs)
+    out.push({ file, method: method.toUpperCase(), registeredPath, guarded })
+  }
+  return out
+}
+
+/**
+ * `univer-meta.ts` routes are mounted at `/api/multitable` (verified: `index.ts` does
+ * `this.app.use('/api/multitable', univerMetaRouter())`, and every registration inside the file uses a
+ * bare relative path — zero absolute `/api/...` registrations). `comments.ts` routes already register
+ * fully-absolute paths (e.g. `/api/comments`, `/api/multitable/:spreadsheetId/comments/presence`) and
+ * its router is mounted with NO prefix (`this.app.use(commentsRouter(...))`).
+ */
+function fullPath(r: RouteRegistration): string {
+  return r.file === 'routes/comments.ts' ? r.registeredPath : `/api/multitable${r.registeredPath}`
+}
+
+/**
+ * Every allowlist pattern matches a param segment with `[^/]+` (verified by reading
+ * `oapi-read-allowlist.ts`), so any single non-slash token is representative — replace every Express
+ * `:param` segment with the SAME fixed probe token.
+ */
+function concretePath(r: RouteRegistration): string {
+  return fullPath(r).replace(/:[^/]+/g, 'probe1')
+}
+
+const MST = 'Bearer mst_test0000000000000000'
+
+const ALL_ROUTES = ROUTE_FILES.flatMap(extractRoutes)
+const GUARDED = ALL_ROUTES.filter((r) => r.guarded)
+const UNGUARDED = ALL_ROUTES.filter((r) => !r.guarded)
+
+describe('#3365 OAPI allowlist⟺guard dual-reachability tripwire', () => {
+  test('sanity: the source scan found a real population of routes on both sides (guards against a silent scan regression)', () => {
+    // Both files register dozens of routes; if a future refactor changes the registration STYLE (e.g.
+    // multi-line calls, a route-table object instead of direct `router.verb()` calls), this regex-based
+    // scan would silently return near-zero matches and every test below would vacuously pass. Fail loud
+    // instead.
+    expect(ALL_ROUTES.length).toBeGreaterThan(50)
+    expect(GUARDED.length).toBeGreaterThan(0)
+    expect(UNGUARDED.length).toBeGreaterThan(0)
+  })
+
+  test('every apiTokenAuth+requireScope-guarded route is admitted by the OAPI allowlist', () => {
+    const missing = GUARDED.filter((r) => !isOapiAllowlistRequest(r.method, concretePath(r), MST))
+    expect(
+      missing,
+      `${missing.length} route(s) mount BOTH apiTokenAuth + requireScope but are NOT reachable through ` +
+        `the OAPI allowlist gate — an mst_ token would 401 at the global gate before ever reaching the ` +
+        `route's own guard (a dead guard, likely a forgotten allowlist entry):\n` +
+        missing.map((r) => `  - ${r.file}: ${r.method} ${fullPath(r)}`).join('\n') +
+        `\n\nAdd a matching entry to OAPI_READ_PATHS / OAPI_WRITE_ROUTES in oapi-read-allowlist.ts, or ` +
+        `remove the apiTokenAuth/requireScope mount if the route was never meant to be token-reachable.`,
+    ).toEqual([])
+  })
+
+  test('every route registered in these two files WITHOUT both guards is rejected by the OAPI allowlist (no silent over-match / bypass)', () => {
+    const leaked = UNGUARDED.filter((r) => isOapiAllowlistRequest(r.method, concretePath(r), MST))
+    expect(
+      leaked,
+      `${leaked.length} route(s) are admitted by the OAPI allowlist gate but do NOT mount BOTH ` +
+        `apiTokenAuth + requireScope — an mst_ token would reach this route with NO per-route scope ` +
+        `check (requireScope fail-opens when absent): a silent no-auth bypass:\n` +
+        leaked.map((r) => `  - ${r.file}: ${r.method} ${fullPath(r)}`).join('\n') +
+        `\n\nNarrow the matching pattern in OAPI_READ_PATHS / OAPI_WRITE_ROUTES in oapi-read-allowlist.ts, ` +
+        `or mount apiTokenAuth + requireScope on this route if it was actually meant to be token-reachable.`,
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Tier-B gap #5 from `docs/research/multitable-feishu-refresh-audit-20260629.md` line 58 (permission golden matrix): *"pin that the OAPI allowlist set equals the set of `apiTokenAuth`-guarded routes (currently lockstep-by-hand)."* **Test-only, zero `src` changes.**

## What it does

Two independently-edited call sites currently have to move together by hand: the allowlist regex/route arrays in `oapi-read-allowlist.ts`, and the `router.<verb>(...)` registrations in `univer-meta.ts` / `comments.ts` (the only two files that ever mount `apiTokenAuth` — confirmed by whole-`src` grep). Nothing forces them to stay in sync, so they can drift in either direction:

- a route gains `apiTokenAuth` + `requireScope` but the allowlist entry is never added → dead guard (harmless, but silently breaks whatever was meant to be exposed)
- an allowlist entry is widened/added without a route mounting both guards → **silent no-auth bypass** (`requireScope` fail-opens when no token scopes are attached)

This test source-scans every route registration in both files, splits them into GUARDED vs UNGUARDED by whether `apiTokenAuth` + `requireScope(` appear on the same registration line, and asserts both directions against the real exported `isOapiAllowlistRequest` — no hand-duplicated list of its own. Style follows the `multitable-stored-data-taint-chokepoint.guard.test.ts` precedent (whole-file structural scan, not a few hand-picked cases).

## Proof of non-vacuousness (deliberate mutate → RED → revert → GREEN)

- Stripped the guard from `GET /fields` → **test 3 went RED**, naming the exact leaked route (`routes/univer-meta.ts: GET /api/multitable/fields`) — proves the bypass direction is actually caught.
- Added a new guarded-but-unallowlisted probe route → **test 2 went RED**, naming the exact dead-guard route — proves the dead-guard direction is actually caught.
- Reverted both mutations; `diff` confirmed byte-identical to `origin/main` after each.

## Verification

- New test: **3/3 pass** today (the invariant currently holds — PR #3365 wired it correctly).
- Adjacent suite unaffected: existing hand-written `multitable-oapi-read-allowlist.test.ts` (14/14) + the `taint-chokepoint` precedent guard (3/3) still green alongside it — **20/20 total**.
- `git status`/`git diff --stat` after commit: only the one new test file, zero `src` touched.

Awaiting review — not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)