### PR TITLE
feat(integration): composition C-R4-2 client vocab mirror + CI tripwire

### DIFF
--- a/apps/web/src/services/integration/readSourceCompositions.ts
+++ b/apps/web/src/services/integration/readSourceCompositions.ts
@@ -1,0 +1,36 @@
+// Read-source resolver composition — client vocabulary mirror (C-R4-2, #1709).
+//
+// The composition chain-evidence coarse codes are the SERVER's closed vocabulary
+// (plugins/plugin-integration-core/lib/read-source-composition-planner.cjs
+// READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES). They surface in the run route's values-free chain evidence
+// (evidence.errorCode + per-step steps[].errorCode) that the C-R4-3 composition UI renders. This module
+// mirrors them client-side so the UI can label/branch on a known enum instead of a raw string.
+//
+// Source of truth = the server. If the server ever extends the vocabulary and this mirror is not synced,
+// the client silently drops the new value. The parity tripwire
+// (apps/web/tests/composition-vocab-mirror.spec.ts) fails RED the moment the two diverge — sync this
+// module (and any C-R4-3 UI/tests) whenever it does. Same discipline as the resolver mirror in
+// readSourceConfigs.ts + multitable-resolver-vocab-mirror.spec.ts.
+
+export const COMPOSITION_PLAN_ERROR_CODES = [
+  'READ_SOURCE_COMPOSITION_PLAN_INVALID',
+  'READ_SOURCE_COMPOSITION_STEP_ORDINAL_INVALID',
+  'READ_SOURCE_COMPOSITION_HANDOFF_VALUE_MISSING',
+  'READ_SOURCE_COMPOSITION_HANDOFF_TARGET_MISMATCH',
+  'READ_SOURCE_COMPOSITION_HANDOFF_VALUE_INVALID',
+  'READ_SOURCE_COMPOSITION_STEP_FAILED',
+  'READ_SOURCE_COMPOSITION_STEP_NOT_RUN',
+  'READ_SOURCE_COMPOSITION_STEP_OUTPUT_NOT_SCALAR',
+] as const
+
+export type CompositionPlanErrorCode = typeof COMPOSITION_PLAN_ERROR_CODES[number]
+
+const COMPOSITION_PLAN_ERROR_CODE_SET: ReadonlySet<string> = new Set(COMPOSITION_PLAN_ERROR_CODES)
+
+// Narrow a raw evidence errorCode string to the mirrored closed vocabulary; null for an unknown code so a
+// caller (the C-R4-3 UI) shows the raw code verbatim rather than mislabeling it as a known one.
+export function asCompositionPlanErrorCode(value: unknown): CompositionPlanErrorCode | null {
+  return typeof value === 'string' && COMPOSITION_PLAN_ERROR_CODE_SET.has(value)
+    ? (value as CompositionPlanErrorCode)
+    : null
+}

--- a/apps/web/tests/composition-vocab-mirror.spec.ts
+++ b/apps/web/tests/composition-vocab-mirror.spec.ts
@@ -1,0 +1,46 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Mirror-sync tripwire (C-R4-2, #1709): the composition chain-evidence coarse codes are mirrored
+// client-side in readSourceCompositions.ts from the server source-of-truth
+// (plugins/plugin-integration-core/lib/read-source-composition-planner.cjs). If the server ever extends
+// the coarse-code vocabulary and the client is not synced, the client silently drops the new value and
+// the C-R4-3 UI mislabels it. This test fails RED the moment the two diverge — sync
+// readSourceCompositions.ts (and any C-R4-3 UI/tests) whenever it does. Same discipline as
+// multitable-resolver-vocab-mirror.spec.ts.
+import {
+  COMPOSITION_PLAN_ERROR_CODES,
+  asCompositionPlanErrorCode,
+} from '../src/services/integration/readSourceCompositions'
+
+const require = createRequire(import.meta.url)
+const pluginLib = path.resolve(__dirname, '../../../plugins/plugin-integration-core/lib')
+// The server exports the frozen array directly — require, never text-parse.
+const { READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES: SERVER_COMPOSITION_PLAN_ERROR_CODES } =
+  require(path.join(pluginLib, 'read-source-composition-planner.cjs'))
+
+const set = (values: Iterable<string>): Set<string> => new Set(values)
+
+describe('composition vocab client/server mirror parity (tripwire)', () => {
+  it('client COMPOSITION_PLAN_ERROR_CODES === server READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES', () => {
+    expect(set(COMPOSITION_PLAN_ERROR_CODES)).toEqual(set(SERVER_COMPOSITION_PLAN_ERROR_CODES))
+    // Guard the count so a same-size swap still trips.
+    expect(COMPOSITION_PLAN_ERROR_CODES.length).toBe(8)
+    expect(new Set(COMPOSITION_PLAN_ERROR_CODES).size).toBe(8)
+    expect(SERVER_COMPOSITION_PLAN_ERROR_CODES.length).toBe(8)
+  })
+
+  it('every server code is a recognized client code (no unknown coarse code slips through)', () => {
+    for (const code of SERVER_COMPOSITION_PLAN_ERROR_CODES) {
+      expect(asCompositionPlanErrorCode(code)).toBe(code)
+    }
+  })
+
+  it('asCompositionPlanErrorCode narrows unknown / non-string to null', () => {
+    expect(asCompositionPlanErrorCode('READ_SOURCE_COMPOSITION_NOT_A_REAL_CODE')).toBeNull()
+    expect(asCompositionPlanErrorCode('MAT_001_SECRET')).toBeNull()
+    expect(asCompositionPlanErrorCode(undefined)).toBeNull()
+    expect(asCompositionPlanErrorCode(42)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

**C-R4-2** of the composition line (#1709): mirror the composition **chain-evidence coarse-code vocabulary** client-side, guarded by a **parity tripwire** — the exact discipline the resolver line uses (`readSourceConfigs.ts` + `multitable-resolver-vocab-mirror.spec.ts`). Client-only.

- `apps/web/src/services/integration/readSourceCompositions.ts` — mirrors the 8 `READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES` (the closed vocab that surfaces in the run route's values-free chain evidence: `evidence.errorCode` + per-step `steps[].errorCode`) as a typed `const` + `asCompositionPlanErrorCode()` narrowing helper (unknown / non-string → `null`, so the C-R4-3 UI shows a raw code verbatim rather than mislabeling it).
- `apps/web/tests/composition-vocab-mirror.spec.ts` — requires the server planner CJS (source of truth) and asserts client === server set-equality + `length===8` + `size===8`; **fail-first verified** (dropping a client code reds the suite, restoring greens it).

## Why these codes

Server source of truth = `read-source-composition-planner.cjs` `READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES` (merged on main via #3563). The C-R1 config-validator codes stay **values-free display-only** (no client enum) — matching how the resolver line displays validator tuples verbatim without a strict client enum.

## Boundary

```text
serverCodeTouched=false
uiTouched=false            (C-R4-3 UI imports this enum next)
independentOf=#3573        (mirrors C-R2 planner codes already on main)
```

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/composition-vocab-mirror.spec.ts` — 3 pass; **fail-first confirmed** (drop a code → 2 red; restore → 3 green).
- `pnpm --filter @metasheet/web type-check` — clean.
- `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
