### PR TITLE
feat(integration): composition C-R4-3a runtime-tier service layer

### DIFF
--- a/apps/web/src/services/integration/readSourceCompositions.ts
+++ b/apps/web/src/services/integration/readSourceCompositions.ts
@@ -1,4 +1,11 @@
-// Read-source resolver composition — client vocabulary mirror (C-R4-2, #1709).
+// Read-source resolver composition — client service layer + vocabulary mirror (C-R4-2 / C-R4-3a, #1709).
+//
+// C-R4-3a adds the runtime-tier service calls (list approved compositions + run an approved chain) and a
+// VALUES-FREE client normalizer for the run response. The server already returns values-free chain
+// evidence + a last-hop-only data payload; this normalizer is defense-in-depth — it copies ONLY the
+// allowlisted shape (ok / failedStep / a bounded per-step vector of {step, ok, rule?, errorCode?} /
+// coarse errorCode via the mirror / values-free planErrors triples) and drops anything else a response
+// might carry. It never fabricates or widens the data plane.
 //
 // The composition chain-evidence coarse codes are the SERVER's closed vocabulary
 // (plugins/plugin-integration-core/lib/read-source-composition-planner.cjs
@@ -11,6 +18,9 @@
 // (apps/web/tests/composition-vocab-mirror.spec.ts) fails RED the moment the two diverge — sync this
 // module (and any C-R4-3 UI/tests) whenever it does. Same discipline as the resolver mirror in
 // readSourceConfigs.ts + multitable-resolver-vocab-mirror.spec.ts.
+
+import { apiFetch } from '../../utils/api'
+import type { IntegrationScope } from './workbench'
 
 export const COMPOSITION_PLAN_ERROR_CODES = [
   'READ_SOURCE_COMPOSITION_PLAN_INVALID',
@@ -33,4 +43,165 @@ export function asCompositionPlanErrorCode(value: unknown): CompositionPlanError
   return typeof value === 'string' && COMPOSITION_PLAN_ERROR_CODE_SET.has(value)
     ? (value as CompositionPlanErrorCode)
     : null
+}
+
+// --- runtime-tier service layer (C-R4-3a) -----------------------------------
+
+const COMPOSITION_STATUSES = ['draft', 'approved', 'retired'] as const
+export type CompositionStatus = typeof COMPOSITION_STATUSES[number]
+
+export interface ReadSourceCompositionRow {
+  id: string
+  name: string
+  version: number
+  status: CompositionStatus
+  contentKey: string
+  updatedAt: string | null
+}
+
+// A values-free per-step outcome from the stitched chain evidence.
+export interface CompositionRunStep {
+  step: number
+  ok: boolean
+  rule?: string
+  errorCode?: string
+}
+
+export interface CompositionRunEvidence {
+  ok: boolean
+  failedStep: number | null
+  steps: CompositionRunStep[]
+  errorCode?: CompositionPlanErrorCode
+  planErrors?: Array<{ code: string, field: string, reason: string }>
+}
+
+// The chain data is ONLY the last hop's single resolver output (target + scalar value), or null.
+export interface CompositionRunData {
+  resolver: { target: string, value: string | number }
+}
+
+export interface CompositionRunResult {
+  evidence: CompositionRunEvidence
+  data: CompositionRunData | null
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function buildQuery(input: Record<string, unknown>): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null || value === '') continue
+    params.set(key, String(value))
+  }
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}
+
+async function parseCompositionResponse<T>(response: Response): Promise<T> {
+  const payload = await response.json().catch(() => null)
+  if (!response.ok) {
+    const error = isPlainObject(payload) && isPlainObject(payload.error) ? payload.error : {}
+    const code = typeof error.code === 'string' ? error.code : `HTTP_${response.status}`
+    const message = typeof error.message === 'string' ? error.message : `request failed (${response.status})`
+    throw new Error(`${code}: ${message}`)
+  }
+  return (isPlainObject(payload) && 'data' in payload ? payload.data : payload) as T
+}
+
+function normalizeCompositionRow(value: unknown): ReadSourceCompositionRow | null {
+  if (!isPlainObject(value) || typeof value.id !== 'string' || !value.id) return null
+  const status = typeof value.status === 'string' && (COMPOSITION_STATUSES as readonly string[]).includes(value.status)
+    ? (value.status as CompositionStatus)
+    : 'draft'
+  return {
+    id: value.id,
+    name: typeof value.name === 'string' ? value.name : '',
+    version: typeof value.version === 'number' && Number.isFinite(value.version) ? value.version : 0,
+    status,
+    contentKey: typeof value.contentKey === 'string' ? value.contentKey : '',
+    updatedAt: typeof value.updatedAt === 'string' ? value.updatedAt : null,
+  }
+}
+
+function normalizeRunStep(value: unknown): CompositionRunStep | null {
+  if (!isPlainObject(value) || typeof value.step !== 'number' || !Number.isInteger(value.step)) return null
+  const step: CompositionRunStep = { step: value.step, ok: value.ok === true }
+  // rule is a closed resolver vocabulary; only surface a recognized value.
+  if (value.rule === 'exactly_one' || value.rule === 'first_when_sorted' || value.rule === 'field_equals') {
+    step.rule = value.rule
+  }
+  // errorCode may be a composition coarse code (mirror) OR a per-hop probe/resolver code; surface a
+  // string verbatim (all server codes are values-free), preferring the mirror-narrowed form when it matches.
+  if (typeof value.errorCode === 'string' && value.errorCode) {
+    step.errorCode = asCompositionPlanErrorCode(value.errorCode) ?? value.errorCode
+  }
+  return step
+}
+
+// Values-free allowlist of the run response. Copies ONLY the known shape; a resolved data value is
+// accepted only when it is a finite number or a non-blank string (the last hop's single scalar output).
+export function normalizeCompositionRunResult(value: unknown): CompositionRunResult {
+  const rawEvidence = isPlainObject(value) ? value.evidence : null
+  const evidence: CompositionRunEvidence = {
+    ok: isPlainObject(rawEvidence) && rawEvidence.ok === true,
+    failedStep: isPlainObject(rawEvidence) && typeof rawEvidence.failedStep === 'number' && Number.isInteger(rawEvidence.failedStep)
+      ? rawEvidence.failedStep
+      : null,
+    steps: isPlainObject(rawEvidence) && Array.isArray(rawEvidence.steps)
+      ? rawEvidence.steps.map(normalizeRunStep).filter((s): s is CompositionRunStep => s !== null)
+      : [],
+  }
+  if (isPlainObject(rawEvidence) && !evidence.ok) {
+    const coarse = asCompositionPlanErrorCode(rawEvidence.errorCode)
+    if (coarse) evidence.errorCode = coarse
+    if (Array.isArray(rawEvidence.planErrors)) {
+      const triples = rawEvidence.planErrors
+        .filter(isPlainObject)
+        .filter((e) => typeof e.code === 'string' && typeof e.field === 'string' && typeof e.reason === 'string')
+        .map((e) => ({ code: e.code as string, field: e.field as string, reason: e.reason as string }))
+      if (triples.length > 0) evidence.planErrors = triples
+    }
+  }
+
+  let data: CompositionRunData | null = null
+  const rawData = isPlainObject(value) ? value.data : null
+  if (evidence.ok && isPlainObject(rawData) && isPlainObject(rawData.resolver)) {
+    const { target, value: resolved } = rawData.resolver as Record<string, unknown>
+    const scalar = (typeof resolved === 'number' && Number.isFinite(resolved))
+      || (typeof resolved === 'string' && resolved.trim().length > 0)
+    if (typeof target === 'string' && target && scalar) {
+      data = { resolver: { target, value: resolved as string | number } }
+    }
+  }
+  return { evidence, data }
+}
+
+// List compositions (read-tier). Pass status:'approved' for the runnable set the operator picks from.
+export async function listReadSourceCompositions(
+  scope: IntegrationScope,
+  filters: { status?: CompositionStatus } = {},
+): Promise<ReadSourceCompositionRow[]> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId, status: filters.status })
+  const response = await apiFetch(`/api/integration/read-source-compositions${query}`)
+  const data = await parseCompositionResponse<unknown[]>(response)
+  return (Array.isArray(data) ? data : [])
+    .map(normalizeCompositionRow)
+    .filter((row): row is ReadSourceCompositionRow => row !== null)
+}
+
+// Run an APPROVED composition with ONLY the first business key (the strict { inputs: { key } } contract).
+// Never sends a config/plan/target/per-hop key. Returns the values-free { evidence, data }.
+export async function runReadSourceComposition(
+  id: string,
+  key: string,
+  scope: IntegrationScope,
+): Promise<CompositionRunResult> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-compositions/${encodeURIComponent(id)}/run${query}`, {
+    method: 'POST',
+    body: JSON.stringify({ inputs: { key } }),
+  })
+  return normalizeCompositionRunResult(await parseCompositionResponse<unknown>(response))
 }

--- a/apps/web/tests/readSourceCompositions.service.spec.ts
+++ b/apps/web/tests/readSourceCompositions.service.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// C-R4-3a: the composition runtime-tier service layer — list approved compositions + run an approved
+// chain with the strict { inputs: { key } } contract, plus a values-free response normalizer.
+
+const apiFetchMock = vi.fn()
+vi.mock('../src/utils/api', () => ({ apiFetch: (...args: unknown[]) => apiFetchMock(...args) }))
+
+import {
+  listReadSourceCompositions,
+  runReadSourceComposition,
+  normalizeCompositionRunResult,
+} from '../src/services/integration/readSourceCompositions'
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ data }), { status, headers: { 'Content-Type': 'application/json' } })
+}
+function errorResponse(code: string, message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: { code, message } }), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+const SCOPE = { tenantId: 'default', workspaceId: null }
+
+beforeEach(() => apiFetchMock.mockReset())
+afterEach(() => vi.clearAllMocks())
+
+describe('listReadSourceCompositions', () => {
+  it('requests approved compositions and normalizes rows, dropping malformed ones', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse([
+      { id: 'rscc_1', name: 'material-to-bom', version: 2, status: 'approved', contentKey: 'ck', updatedAt: '2026-07-05' },
+      { id: '', name: 'bad' },       // no id → dropped
+      { name: 'no-id' },             // no id → dropped
+      { id: 'rscc_2', status: 'weird' }, // unknown status → coerced to draft
+    ]))
+    const rows = await listReadSourceCompositions(SCOPE, { status: 'approved' })
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/integration/read-source-compositions?tenantId=default&status=approved')
+    expect(rows).toEqual([
+      { id: 'rscc_1', name: 'material-to-bom', version: 2, status: 'approved', contentKey: 'ck', updatedAt: '2026-07-05' },
+      { id: 'rscc_2', name: '', version: 0, status: 'draft', contentKey: '', updatedAt: null },
+    ])
+  })
+})
+
+describe('runReadSourceComposition', () => {
+  it('POSTs ONLY { inputs: { key } } — never a config/plan/target/per-hop key', async () => {
+    let sentBody: Record<string, unknown> | undefined
+    apiFetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+      sentBody = JSON.parse(String(init?.body || '{}'))
+      return jsonResponse({
+        evidence: { ok: true, failedStep: null, steps: [{ step: 0, ok: true, rule: 'exactly_one' }, { step: 1, ok: true, rule: 'first_when_sorted' }] },
+        data: { resolver: { target: 'bom_number', value: 'BOM-2026-X' } },
+      })
+    })
+    const result = await runReadSourceComposition('rscc_1', 'M-001', SCOPE)
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/integration/read-source-compositions/rscc_1/run?tenantId=default', expect.objectContaining({ method: 'POST' }))
+    expect(sentBody).toEqual({ inputs: { key: 'M-001' } })
+    expect(Object.keys(sentBody as object)).toEqual(['inputs'])
+    expect(Object.keys((sentBody as { inputs: object }).inputs)).toEqual(['key'])
+    expect(result.evidence.ok).toBe(true)
+    expect(result.data).toEqual({ resolver: { target: 'bom_number', value: 'BOM-2026-X' } })
+  })
+
+  it('surfaces a fail-closed run outcome (approved chain, hop aborted) values-free', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({
+      evidence: {
+        ok: false, failedStep: 0,
+        steps: [{ step: 0, ok: false, rule: 'exactly_one', errorCode: 'READ_SOURCE_RESOLVER_AMBIGUOUS' }, { step: 1, ok: false, errorCode: 'READ_SOURCE_COMPOSITION_STEP_NOT_RUN' }],
+        errorCode: 'READ_SOURCE_COMPOSITION_STEP_FAILED',
+      },
+      data: null,
+    }))
+    const result = await runReadSourceComposition('rscc_1', 'M-001', SCOPE)
+    expect(result.evidence.ok).toBe(false)
+    expect(result.evidence.failedStep).toBe(0)
+    expect(result.evidence.errorCode).toBe('READ_SOURCE_COMPOSITION_STEP_FAILED')
+    expect(result.evidence.steps[1]).toEqual({ step: 1, ok: false, errorCode: 'READ_SOURCE_COMPOSITION_STEP_NOT_RUN' })
+    expect(result.data).toBeNull()
+  })
+
+  it('throws a coarse error on a 409 approved-only gate', async () => {
+    apiFetchMock.mockResolvedValueOnce(errorResponse('READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED', 'not approved', 409))
+    await expect(runReadSourceComposition('rscc_draft', 'M-001', SCOPE)).rejects.toThrow('READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED')
+  })
+})
+
+describe('normalizeCompositionRunResult (values-free allowlist)', () => {
+  it('drops unknown fields and never widens the data plane', () => {
+    const result = normalizeCompositionRunResult({
+      evidence: {
+        ok: true, failedStep: null,
+        steps: [{ step: 0, ok: true, rule: 'exactly_one', host: 'SECRET_HOST', candidateValues: ['SECRET'] }],
+        secretField: 'LEAK',
+      },
+      data: { resolver: { target: 'bom_number', value: 'BOM-OK', host: 'SECRET_HOST' }, rawRows: [{ x: 'SECRET' }] },
+    })
+    // step vector keeps ONLY the allowlisted keys.
+    expect(result.evidence.steps).toEqual([{ step: 0, ok: true, rule: 'exactly_one' }])
+    // chain data keeps ONLY target+value.
+    expect(result.data).toEqual({ resolver: { target: 'bom_number', value: 'BOM-OK' } })
+    const text = JSON.stringify(result)
+    for (const leak of ['SECRET_HOST', 'candidateValues', 'secretField', 'rawRows']) {
+      expect(text).not.toContain(leak)
+    }
+  })
+
+  it('coarsens an unknown errorCode to nothing and rejects a non-scalar resolved value', () => {
+    const unknownCode = normalizeCompositionRunResult({ evidence: { ok: false, failedStep: 1, steps: [], errorCode: 'MAT_001_SECRET' }, data: null })
+    expect(unknownCode.evidence.errorCode).toBeUndefined() // unknown code not surfaced as a coarse enum
+    // a non-scalar resolved value (object/boolean) is never placed into data even if evidence says ok.
+    const nonScalar = normalizeCompositionRunResult({ evidence: { ok: true, failedStep: null, steps: [] }, data: { resolver: { target: 't', value: { leak: 'x' } } } })
+    expect(nonScalar.data).toBeNull()
+    const boolVal = normalizeCompositionRunResult({ evidence: { ok: true, failedStep: null, steps: [] }, data: { resolver: { target: 't', value: true } } })
+    expect(boolVal.data).toBeNull()
+  })
+
+  it('keeps values-free planErrors triples and drops malformed ones', () => {
+    const result = normalizeCompositionRunResult({
+      evidence: {
+        ok: false, failedStep: null, steps: [], errorCode: 'READ_SOURCE_COMPOSITION_PLAN_INVALID',
+        planErrors: [
+          { code: 'READ_SOURCE_COMPOSITION_STEP_NOT_APPROVED', field: 'steps.1.readSourceConfigId', reason: 'approved_read_config_required' },
+          { code: 'X', field: 'y' }, // missing reason → dropped
+          { nope: true },            // malformed → dropped
+        ],
+      },
+      data: null,
+    })
+    expect(result.evidence.planErrors).toEqual([
+      { code: 'READ_SOURCE_COMPOSITION_STEP_NOT_APPROVED', field: 'steps.1.readSourceConfigId', reason: 'approved_read_config_required' },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

**C-R4-3a** of the composition line (#1709): the client **runtime-tier service layer** the C-R4-3 UI needs, plus a **values-free response normalizer**. Extends the C-R4-2 vocab mirror (#3576). Client-only, no UI yet (C-R4-3b is the panel).

- `listReadSourceCompositions(scope, {status})` — GET the (approved) set the operator picks from; drops malformed rows, coerces unknown status.
- `runReadSourceComposition(id, key, scope)` — POSTs **ONLY `{ inputs: { key } }`** (the strict key-only contract; never a config/plan/target/per-hop key), returns the normalized `{ evidence, data }`.
- `normalizeCompositionRunResult` — **values-free client allowlist** (defense in depth over the already-values-free server): copies ONLY `ok` / `failedStep` / a bounded per-step `{step, ok, rule?, errorCode?}` vector / coarse `errorCode` via the mirror / values-free `planErrors` triples. Chain data is accepted **only** when the last hop's resolved value is a finite number or a non-blank string. Unknown fields, non-scalar values, and unknown coarse codes are dropped, never surfaced.

## Boundary

```text
uiTouched=false          (C-R4-3b panel consumes these next)
keyOnlyContract=true     (POST body is exactly { inputs: { key } })
dataPlaneWidened=false   (normalizer only narrows; non-scalar/object/boolean data → null)
```

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/readSourceCompositions.service.spec.ts tests/composition-vocab-mirror.spec.ts` — 10 pass: key-only POST body assertion, fail-closed run outcome surfaced values-free, 409 approved-only gate throws coarse, normalizer drops host/candidate/raw-row leaks + rejects non-scalar/object/boolean data + coarsens unknown errorCode + keeps only well-formed planErrors triples.
- `pnpm --filter @metasheet/web type-check` — clean. `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
