### PR TITLE
feat(integration): composition C-R4-3b run panel (advisor/operator UI)

### DIFF
--- a/apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue
@@ -1,0 +1,203 @@
+<template>
+  <div class="integration-read-source-composition" data-testid="read-source-composition-panel">
+    <p class="integration-read-source-composition__hint">
+      顾问/操作员在这里运行已审批的读取源组合链(materialNumber → FItemID → FBOMNumber 等)：只能选择已审批组合、
+      只提供首个业务 key，中间键由平台派生，永远不能提交组合配置 / 计划 / 逐跳 key。本面板不含配置编写或审批能力，
+      也不含任何写入操作。
+    </p>
+
+    <div class="integration-read-source-composition__columns">
+      <div class="integration-read-source-composition__form" data-testid="rscomp-form">
+        <label class="integration-read-source-composition__field">
+          <span>已审批组合</span>
+          <select v-model="selectedId" data-testid="rscomp-select">
+            <option value="">请选择已审批组合…</option>
+            <option v-for="row in compositions" :key="row.id" :value="row.id">
+              {{ row.name || row.id }} (v{{ row.version }})
+            </option>
+          </select>
+        </label>
+
+        <label class="integration-read-source-composition__field">
+          <span>首个业务 key(仅首步;中间键由平台派生)</span>
+          <input v-model="businessKey" data-testid="rscomp-key" placeholder="MAT-001" />
+        </label>
+
+        <div class="integration-read-source-composition__actions">
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rscomp-refresh"
+            :disabled="loading"
+            @click="refresh"
+          >{{ loading ? '加载中…' : '刷新组合列表' }}</button>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rscomp-run"
+            :disabled="running || !selectedId || !businessKey.trim()"
+            @click="run"
+          >{{ running ? '运行中…' : '运行' }}</button>
+        </div>
+
+        <p v-if="listError" class="integration-read-source-composition__error" data-testid="rscomp-list-error">{{ listError }}</p>
+        <p v-if="runError" class="integration-read-source-composition__error" data-testid="rscomp-error">{{ runError }}</p>
+        <p v-if="!loading && compositions.length === 0" class="integration-read-source-composition__empty" data-testid="rscomp-empty">
+          暂无已审批组合。
+        </p>
+      </div>
+
+      <div v-if="result" class="integration-read-source-composition__evidence" data-testid="rscomp-result">
+        <h4>链证据(values-free)</h4>
+        <ul>
+          <li data-testid="rscomp-evidence-ok">ok: {{ result.evidence.ok ? 'true' : 'false' }}</li>
+          <li v-if="result.evidence.failedStep !== null" data-testid="rscomp-evidence-failed-step">
+            failedStep: {{ result.evidence.failedStep }}
+          </li>
+          <li v-if="result.evidence.errorCode" data-testid="rscomp-evidence-error-code">
+            errorCode: {{ result.evidence.errorCode }}
+          </li>
+          <li
+            v-for="step in result.evidence.steps"
+            :key="step.step"
+            :data-testid="`rscomp-step-${step.step}`"
+          >
+            step {{ step.step }}: ok={{ step.ok ? 'true' : 'false' }}<template v-if="step.rule">, rule={{ step.rule }}</template><template v-if="step.errorCode">, errorCode={{ step.errorCode }}</template>
+          </li>
+          <li v-for="(entry, index) in result.evidence.planErrors ?? []" :key="index" data-testid="rscomp-plan-error">
+            {{ entry.code }} · {{ entry.field }} · {{ entry.reason }}
+          </li>
+        </ul>
+
+        <div v-if="result.data" class="integration-read-source-composition__output" data-testid="rscomp-output">
+          <h4>末跳输出(仅最后一跳)</h4>
+          <p data-testid="rscomp-output-value">{{ result.data.resolver.target }} = {{ result.data.resolver.value }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Read-source composition run panel (C-R4-3b, #1709) — advisor/operator-tier UI over the C-R4-1 run
+// route + C-R4-3a client service layer. Selects an APPROVED composition, sends ONLY the first business
+// key, and renders the values-free chain evidence + last-hop-only output. No authoring/approval, no
+// write path; the server + client normalizer already enforce values-free — this panel renders exactly
+// what they return, nothing more.
+import { ref, watch } from 'vue'
+import type { IntegrationScope } from '../../services/integration/workbench'
+import {
+  listReadSourceCompositions,
+  runReadSourceComposition,
+  type CompositionRunResult,
+  type ReadSourceCompositionRow,
+} from '../../services/integration/readSourceCompositions'
+
+const props = defineProps<{
+  scope: IntegrationScope
+}>()
+
+const compositions = ref<ReadSourceCompositionRow[]>([])
+const selectedId = ref('')
+const businessKey = ref('')
+const loading = ref(false)
+const running = ref(false)
+const listError = ref('')
+const runError = ref('')
+const result = ref<CompositionRunResult | null>(null)
+
+watch(selectedId, () => {
+  result.value = null
+  runError.value = ''
+})
+
+function coarseErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return '组合运行请求失败'
+}
+
+async function refresh(): Promise<void> {
+  loading.value = true
+  listError.value = ''
+  try {
+    compositions.value = await listReadSourceCompositions(props.scope, { status: 'approved' })
+  } catch (error) {
+    listError.value = coarseErrorMessage(error)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function run(): Promise<void> {
+  runError.value = ''
+  result.value = null
+  running.value = true
+  try {
+    result.value = await runReadSourceComposition(selectedId.value, businessKey.value.trim(), props.scope)
+  } catch (error) {
+    runError.value = coarseErrorMessage(error)
+  } finally {
+    running.value = false
+  }
+}
+
+void refresh()
+</script>
+
+<style scoped>
+.integration-read-source-composition__hint {
+  color: #666;
+  font-size: 13px;
+  margin: 0 0 12px;
+}
+.integration-read-source-composition__columns {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(360px, 1.2fr);
+  gap: 20px;
+}
+.integration-read-source-composition__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+.integration-read-source-composition__field input,
+.integration-read-source-composition__field select {
+  padding: 6px 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+}
+.integration-read-source-composition__actions {
+  display: flex;
+  gap: 8px;
+  margin: 10px 0;
+}
+.integration-read-source-composition__error {
+  color: #b91c1c;
+  font-size: 13px;
+}
+.integration-read-source-composition__empty {
+  color: #888;
+  font-size: 13px;
+}
+.integration-read-source-composition__evidence {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+.integration-read-source-composition__evidence ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+.integration-read-source-composition__output {
+  margin-top: 10px;
+  color: #15803d;
+}
+@media (max-width: 960px) {
+  .integration-read-source-composition__columns {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -259,6 +259,16 @@
     <section class="integration-workbench__panel">
       <div class="integration-workbench__panel-head">
         <div>
+          <h2>读取源组合运行(顾问/操作员自助)</h2>
+          <p>选择已审批的组合链,提供首个业务 key 后运行:中间键由平台派生,证据 values-free,数据仅末跳输出。本面板不含配置编写或写入。</p>
+        </div>
+      </div>
+      <IntegrationReadSourceCompositionPanel :scope="currentScope()" />
+    </section>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__panel-head">
+        <div>
           <h2>选择系统与数据集</h2>
           <p>来源对象决定从哪里取数，目标模板决定写到哪里。先选系统，再加载可选数据集或模板。</p>
         </div>
@@ -1463,6 +1473,7 @@ import {
 } from '../services/integration/workbench'
 import MetaIntegrationFieldRuleAuthoring from '../components/integration/MetaIntegrationFieldRuleAuthoring.vue'
 import IntegrationReadSourceConfigPanel from '../components/integration/IntegrationReadSourceConfigPanel.vue'
+import IntegrationReadSourceCompositionPanel from '../components/integration/IntegrationReadSourceCompositionPanel.vue'
 import PlmBomReviewPanel from '../components/plm/PlmBomReviewPanel.vue'
 
 type WorkbenchSide = 'source' | 'target'

--- a/apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App as VueApp } from 'vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: vi.fn(),
+}))
+
+import IntegrationReadSourceCompositionPanel from '../src/components/integration/IntegrationReadSourceCompositionPanel.vue'
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ data }), { status, headers: { 'Content-Type': 'application/json' } })
+}
+function errorResponse(status: number, code: string, message: string): Response {
+  return new Response(JSON.stringify({ error: { code, message } }), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function waitUntil(condition: () => boolean, label: string, attempts = 50): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+  throw new Error(`waitUntil timed out: ${label}`)
+}
+
+describe('IntegrationReadSourceCompositionPanel', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  function mountPanel(): HTMLDivElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () => h(IntegrationReadSourceCompositionPanel, {
+        scope: { tenantId: 'default', workspaceId: null },
+      }),
+    })
+    app.mount(container)
+    return container
+  }
+
+  function q<T extends HTMLElement>(root: HTMLElement, testid: string): T {
+    const el = root.querySelector<T>(`[data-testid="${testid}"]`)
+    if (!el) throw new Error(`missing [data-testid=${testid}]`)
+    return el
+  }
+
+  function setInput(root: HTMLElement, testid: string, value: string): void {
+    const input = q<HTMLInputElement>(root, testid)
+    input.value = value
+    input.dispatchEvent(new Event('input'))
+  }
+
+  function setSelect(root: HTMLElement, testid: string, value: string): void {
+    const select = q<HTMLSelectElement>(root, testid)
+    select.value = value
+    select.dispatchEvent(new Event('change'))
+  }
+
+  it('lists ONLY approved compositions on mount and disables run until a composition + key are set', async () => {
+    const listUrls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string) => {
+      listUrls.push(url)
+      return jsonResponse([
+        { id: 'rscc_1', name: 'material-to-bom', version: 2, status: 'approved', contentKey: 'ck', updatedAt: '2026-07-05' },
+      ])
+    })
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rscc_1"]') !== null, 'composition list loads')
+
+    expect(listUrls[0]).toBe('/api/integration/read-source-compositions?tenantId=default&status=approved')
+    expect(q<HTMLButtonElement>(root, 'rscomp-run').disabled).toBe(true)
+
+    setSelect(root, 'rscomp-select', 'rscc_1')
+    await flushUi()
+    expect(q<HTMLButtonElement>(root, 'rscomp-run').disabled).toBe(true) // key still empty
+
+    setInput(root, 'rscomp-key', 'MAT-001')
+    await flushUi()
+    expect(q<HTMLButtonElement>(root, 'rscomp-run').disabled).toBe(false)
+  })
+
+  it('renders the empty state when there are no approved compositions', async () => {
+    apiFetchMock.mockImplementation(async () => jsonResponse([]))
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-empty"]') !== null, 'empty state renders')
+    expect(q(root, 'rscomp-empty')).toBeTruthy()
+  })
+
+  it('run posts ONLY { inputs: { key } } and renders values-free success evidence + last-hop output', async () => {
+    const runBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/integration/read-source-compositions') && url.includes('/run')) {
+        runBodies.push(JSON.parse(String(init?.body || '{}')))
+        return jsonResponse({
+          evidence: {
+            ok: true,
+            failedStep: null,
+            steps: [
+              { step: 0, ok: true, rule: 'exactly_one' },
+              { step: 1, ok: true, rule: 'first_when_sorted' },
+            ],
+          },
+          data: { resolver: { target: 'bom_number', value: 'BOM-2026-X' } },
+        })
+      }
+      return jsonResponse([{ id: 'rscc_1', name: 'material-to-bom', version: 2, status: 'approved', contentKey: 'ck', updatedAt: '2026-07-05' }])
+    })
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rscc_1"]') !== null, 'composition list loads')
+    setSelect(root, 'rscomp-select', 'rscc_1')
+    setInput(root, 'rscomp-key', ' MAT-001 ')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rscomp-run').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-result"]') !== null, 'run result appears')
+
+    expect(runBodies).toHaveLength(1)
+    expect(runBodies[0]).toEqual({ inputs: { key: 'MAT-001' } })
+    expect(Object.keys(runBodies[0])).toEqual(['inputs'])
+
+    expect(q(root, 'rscomp-evidence-ok').textContent).toContain('ok: true')
+    expect(q(root, 'rscomp-step-0').textContent).toContain('rule=exactly_one')
+    expect(q(root, 'rscomp-step-1').textContent).toContain('rule=first_when_sorted')
+    expect(q(root, 'rscomp-output-value').textContent).toContain('bom_number = BOM-2026-X')
+  })
+
+  it('renders a fail-closed run outcome values-free (failedStep + coarse errorCode + per-step vector)', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/run')) {
+        return jsonResponse({
+          evidence: {
+            ok: false,
+            failedStep: 0,
+            steps: [
+              { step: 0, ok: false, rule: 'exactly_one', errorCode: 'READ_SOURCE_RESOLVER_AMBIGUOUS' },
+              { step: 1, ok: false, errorCode: 'READ_SOURCE_COMPOSITION_STEP_NOT_RUN' },
+            ],
+            errorCode: 'READ_SOURCE_COMPOSITION_STEP_FAILED',
+          },
+          data: null,
+        })
+      }
+      return jsonResponse([{ id: 'rscc_1', name: 'material-to-bom', version: 2, status: 'approved', contentKey: 'ck', updatedAt: '2026-07-05' }])
+    })
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rscc_1"]') !== null, 'composition list loads')
+    setSelect(root, 'rscomp-select', 'rscc_1')
+    setInput(root, 'rscomp-key', 'MAT-001')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rscomp-run').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-result"]') !== null, 'run result appears')
+
+    expect(q(root, 'rscomp-evidence-ok').textContent).toContain('ok: false')
+    expect(q(root, 'rscomp-evidence-failed-step').textContent).toContain('failedStep: 0')
+    expect(q(root, 'rscomp-evidence-error-code').textContent).toContain('READ_SOURCE_COMPOSITION_STEP_FAILED')
+    expect(q(root, 'rscomp-step-1').textContent).toContain('READ_SOURCE_COMPOSITION_STEP_NOT_RUN')
+    expect(root.querySelector('[data-testid="rscomp-output"]')).toBeNull()
+  })
+
+  it('surfaces a 409 approved-only gate as a coarse error without echoing the key', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/run')) return errorResponse(409, 'READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED', 'not approved')
+      return jsonResponse([{ id: 'rscc_1', name: 'material-to-bom', version: 2, status: 'approved', contentKey: 'ck', updatedAt: '2026-07-05' }])
+    })
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rscc_1"]') !== null, 'composition list loads')
+    setSelect(root, 'rscomp-select', 'rscc_1')
+    setInput(root, 'rscomp-key', 'MAT-001')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rscomp-run').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-error"]') !== null, 'run error appears')
+
+    const message = q(root, 'rscomp-error').textContent ?? ''
+    expect(message).toContain('READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED')
+    expect(message.includes('MAT-001')).toBe(false)
+  })
+
+  it('switching the selected composition clears stale run results and errors', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/run')) {
+        return jsonResponse({ evidence: { ok: true, failedStep: null, steps: [] }, data: { resolver: { target: 't', value: 'V' } } })
+      }
+      return jsonResponse([
+        { id: 'rscc_1', name: 'a', version: 1, status: 'approved', contentKey: 'ck1', updatedAt: null },
+        { id: 'rscc_2', name: 'b', version: 1, status: 'approved', contentKey: 'ck2', updatedAt: null },
+      ])
+    })
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rscc_1"]') !== null, 'composition list loads')
+    setSelect(root, 'rscomp-select', 'rscc_1')
+    setInput(root, 'rscomp-key', 'MAT-001')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rscomp-run').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-result"]') !== null, 'run result appears')
+
+    setSelect(root, 'rscomp-select', 'rscc_2')
+    await flushUi()
+    expect(root.querySelector('[data-testid="rscomp-result"]')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

**C-R4-3b** of the composition line (#1709): the operator/advisor-facing **UI panel** over the C-R4-1 run route (#3573) + C-R4-3a client service layer (#3583). This is the last rung named in the composition arc's gated boundary (`docs/development/integration-read-source-resolver-composition-cr0-cr3-dev-verification-20260705.md` §6, "C-R4 — route + ... + UI").

- `IntegrationReadSourceCompositionPanel.vue` — lists **only approved** compositions (`status: 'approved'`), lets the operator pick one and type the **first business key only**, runs it, and renders the values-free chain evidence (`ok` / `failedStep` / per-step `{step, ok, rule?, errorCode?}` vector / coarse `errorCode` / `planErrors`) plus the **last-hop-only** output. No authoring, no approve/retire, no write path — mirrors the read-only discipline of `IntegrationReadSourceConfigPanel.vue`.
- Wired into `IntegrationWorkbenchView.vue` as a new panel section alongside the existing read-source-config panel.
- `IntegrationReadSourceCompositionPanel.spec.ts` — approved-only list fetch, run button gating (composition + key both required), key-only POST body assertion (`{ inputs: { key } }` exactly), values-free success/failure evidence rendering, 409 approved-only gate surfaced coarse without echoing the key, stale-result clearing on re-selection.

## Boundary

```text
uiTouched=true              (this IS the C-R4-3 UI; no authoring added)
authoringTouched=false      (no save/approve/retire in this panel)
writePathTouched=false
keyOnlyContract=true        (POST body is exactly { inputs: { key } })
serverTouched=false
recursionSupported=false
```

## Verification

- `pnpm exec vitest run tests/IntegrationReadSourceCompositionPanel.spec.ts` — 6/6 pass.
- `pnpm exec vitest run tests/readSourceCompositions.service.spec.ts tests/composition-vocab-mirror.spec.ts tests/IntegrationReadSourceConfigPanel.spec.ts tests/multitable-resolver-vocab-mirror.spec.ts` — all green (neighbors unaffected).
- `pnpm run type-check` (`vue-tsc -b`) — clean.
- `pnpm exec eslint` on the changed files — clean.
- Full `apps/web` suite run for parity: `tests/IntegrationWorkbenchView.spec.ts` shows the same 22 pre-existing failures with and without this change (confirmed via `git stash`) — unrelated environment flakiness in this sandbox, not a regression from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwCQWnL8v2sNspJRs5N1Lq)_