### PR TITLE
fix(integration): C-R4 client error-path values-free + exact step-code allowlist + ledger refresh

### DIFF
--- a/apps/web/src/services/integration/readSourceCompositions.ts
+++ b/apps/web/src/services/integration/readSourceCompositions.ts
@@ -20,6 +20,7 @@
 // readSourceConfigs.ts + multitable-resolver-vocab-mirror.spec.ts.
 
 import { apiFetch } from '../../utils/api'
+import { READ_SOURCE_PROBE_ERROR_CODES } from './readSourceConfigs'
 import type { IntegrationScope } from './workbench'
 
 export const COMPOSITION_PLAN_ERROR_CODES = [
@@ -36,6 +37,14 @@ export const COMPOSITION_PLAN_ERROR_CODES = [
 export type CompositionPlanErrorCode = typeof COMPOSITION_PLAN_ERROR_CODES[number]
 
 const COMPOSITION_PLAN_ERROR_CODE_SET: ReadonlySet<string> = new Set(COMPOSITION_PLAN_ERROR_CODES)
+
+// Exact registered union for a stitched-vector per-step errorCode: the composition coarse codes (this
+// mirror) PLUS the per-hop probe/resolver codes (READ_SOURCE_PROBE_ERROR_CODES already includes the
+// resolver codes). Anything outside this union is dropped by normalizeRunStep.
+const STEP_ERROR_CODE_SET: ReadonlySet<string> = new Set<string>([
+  ...COMPOSITION_PLAN_ERROR_CODES,
+  ...READ_SOURCE_PROBE_ERROR_CODES,
+])
 
 // Narrow a raw evidence errorCode string to the mirrored closed vocabulary; null for an unknown code so a
 // caller (the C-R4-3 UI) shows the raw code verbatim rather than mislabeling it as a known one.
@@ -99,13 +108,40 @@ function buildQuery(input: Record<string, unknown>): string {
   return query ? `?${query}` : ''
 }
 
+// Coarse-code / reason clamps (mirror readSourceConfigs.ts ReadSourceApiError). The raw server
+// error.message is NEVER surfaced — only a clamped code + optional clamped reason — so the error path is
+// values-free BY CONSTRUCTION, not by trusting the server to keep messages coarse (a future server bug
+// echoing a business value into message can never reach the client render).
+const COMPOSITION_ERROR_CODE_PATTERN = /^[A-Z0-9_]{1,80}$/
+const COMPOSITION_ERROR_REASON_PATTERN = /^[a-z0-9_:-]{1,80}$/
+
+export class ReadSourceCompositionApiError extends Error {
+  status: number
+  code: string
+  reason: string
+  constructor(status: number, code: string, reason: string) {
+    // .message is built from the clamped code (+reason) only — the panel renders error.message, so this
+    // is the values-free string it shows.
+    super(reason ? `${code}: ${reason}` : code)
+    this.name = 'ReadSourceCompositionApiError'
+    this.status = status
+    this.code = code
+    this.reason = reason
+  }
+}
+
 async function parseCompositionResponse<T>(response: Response): Promise<T> {
   const payload = await response.json().catch(() => null)
-  if (!response.ok) {
+  if (!response.ok || (isPlainObject(payload) && payload.ok === false)) {
     const error = isPlainObject(payload) && isPlainObject(payload.error) ? payload.error : {}
-    const code = typeof error.code === 'string' ? error.code : `HTTP_${response.status}`
-    const message = typeof error.message === 'string' ? error.message : `request failed (${response.status})`
-    throw new Error(`${code}: ${message}`)
+    const details = isPlainObject(error.details) ? error.details : {}
+    const code = typeof error.code === 'string' && COMPOSITION_ERROR_CODE_PATTERN.test(error.code)
+      ? error.code
+      : 'READ_SOURCE_COMPOSITION_REQUEST_FAILED'
+    const reason = typeof details.reason === 'string' && COMPOSITION_ERROR_REASON_PATTERN.test(details.reason)
+      ? details.reason
+      : ''
+    throw new ReadSourceCompositionApiError(response.status, code, reason)
   }
   return (isPlainObject(payload) && 'data' in payload ? payload.data : payload) as T
 }
@@ -132,10 +168,11 @@ function normalizeRunStep(value: unknown): CompositionRunStep | null {
   if (value.rule === 'exactly_one' || value.rule === 'first_when_sorted' || value.rule === 'field_equals') {
     step.rule = value.rule
   }
-  // errorCode may be a composition coarse code (mirror) OR a per-hop probe/resolver code; surface a
-  // string verbatim (all server codes are values-free), preferring the mirror-narrowed form when it matches.
-  if (typeof value.errorCode === 'string' && value.errorCode) {
-    step.errorCode = asCompositionPlanErrorCode(value.errorCode) ?? value.errorCode
+  // errorCode may be a composition coarse code (the mirror) OR a per-hop probe/resolver code — surface it
+  // ONLY when it is in the EXACT registered union (never a verbatim fallthrough): an unknown string (e.g.
+  // a future server bug leaking a business identifier that looks like A_CODE) is DROPPED, not rendered.
+  if (typeof value.errorCode === 'string' && STEP_ERROR_CODE_SET.has(value.errorCode)) {
+    step.errorCode = value.errorCode
   }
   return step
 }

--- a/apps/web/src/services/integration/readSourceConfigs.ts
+++ b/apps/web/src/services/integration/readSourceConfigs.ts
@@ -408,7 +408,10 @@ export const RESOLVER_ERROR_CODES = [
   'READ_SOURCE_RESOLVER_FAILED',
 ] as const
 
-const READ_SOURCE_PROBE_ERROR_CODES = new Set([
+// Exported so the composition service layer (readSourceCompositions.ts) can exact-allowlist a per-step
+// errorCode against the SAME probe/resolver coarse-code set (a composition run's per-hop errorCode is a
+// probe/resolver code). Includes the resolver codes via the spread below.
+export const READ_SOURCE_PROBE_ERROR_CODES: ReadonlySet<string> = new Set([
   'READ_SOURCE_PROBE_CONTRACT_INVALID',
   'READ_SOURCE_PROBE_FAILED',
   'READ_SOURCE_PROBE_AUTH_FAILED',

--- a/apps/web/tests/readSourceCompositions.service.spec.ts
+++ b/apps/web/tests/readSourceCompositions.service.spec.ts
@@ -81,6 +81,31 @@ describe('runReadSourceComposition', () => {
     apiFetchMock.mockResolvedValueOnce(errorResponse('READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED', 'not approved', 409))
     await expect(runReadSourceComposition('rscc_draft', 'M-001', SCOPE)).rejects.toThrow('READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED')
   })
+
+  it('drops the raw server error.message from the thrown error — values-free by construction', async () => {
+    // A (hypothetical) server bug echoing a business value into error.message must NEVER reach the client
+    // error render. The thrown error carries only the clamped code (+ clamped reason), not the raw message.
+    apiFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { code: 'READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID', message: 'boom near MAT-001 SECRET', details: { reason: 'unexpected_field' } } }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const err = await runReadSourceComposition('rscc_1', 'M-001', SCOPE).then(() => null, (e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toBe('READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID: unexpected_field')
+    // The raw server message (and any business value in it) never rides into the error the panel renders.
+    expect(JSON.stringify({ message: (err as Error).message, ...(err as Record<string, unknown>) })).not.toContain('MAT-001 SECRET')
+    expect((err as Error).message).not.toContain('boom')
+  })
+
+  it('coarsens a non-conforming server error code to a fixed fallback', async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { code: 'leaky code MAT-001', message: 'x' } }), { status: 500, headers: { 'Content-Type': 'application/json' } }),
+    )
+    const err = await runReadSourceComposition('rscc_1', 'M-001', SCOPE).then(() => null, (e) => e)
+    expect((err as Error).message).toBe('READ_SOURCE_COMPOSITION_REQUEST_FAILED')
+    expect((err as Error).message).not.toContain('MAT-001')
+  })
 })
 
 describe('normalizeCompositionRunResult (values-free allowlist)', () => {
@@ -111,6 +136,26 @@ describe('normalizeCompositionRunResult (values-free allowlist)', () => {
     expect(nonScalar.data).toBeNull()
     const boolVal = normalizeCompositionRunResult({ evidence: { ok: true, failedStep: null, steps: [] }, data: { resolver: { target: 't', value: true } } })
     expect(boolVal.data).toBeNull()
+  })
+
+  it('exact-allowlists per-step errorCode against the composition ∪ probe/resolver union; drops unknown', () => {
+    const result = normalizeCompositionRunResult({
+      evidence: {
+        ok: false, failedStep: 0,
+        steps: [
+          { step: 0, ok: false, rule: 'exactly_one', errorCode: 'MAT_001_SECRET' },       // unknown → dropped
+          { step: 1, ok: false, errorCode: 'READ_SOURCE_RESOLVER_AMBIGUOUS' },             // resolver → kept
+          { step: 2, ok: false, errorCode: 'READ_SOURCE_PROBE_TIMEOUT' },                  // probe → kept
+          { step: 3, ok: false, errorCode: 'READ_SOURCE_COMPOSITION_STEP_NOT_RUN' },       // composition → kept
+        ],
+      },
+      data: null,
+    })
+    expect(result.evidence.steps[0]).toEqual({ step: 0, ok: false, rule: 'exactly_one' }) // errorCode dropped
+    expect(result.evidence.steps[1].errorCode).toBe('READ_SOURCE_RESOLVER_AMBIGUOUS')
+    expect(result.evidence.steps[2].errorCode).toBe('READ_SOURCE_PROBE_TIMEOUT')
+    expect(result.evidence.steps[3].errorCode).toBe('READ_SOURCE_COMPOSITION_STEP_NOT_RUN')
+    expect(JSON.stringify(result)).not.toContain('MAT_001_SECRET')
   })
 
   it('keeps values-free planErrors triples and drops malformed ones', () => {

--- a/docs/development/integration-read-source-resolver-composition-cr0-cr3-dev-verification-20260705.md
+++ b/docs/development/integration-read-source-resolver-composition-cr0-cr3-dev-verification-20260705.md
@@ -28,7 +28,7 @@ composition orchestrates hops, it does not fork a second read/resolver path.
 | **C-R0** | (docs) | `integration-read-source-resolver-composition-design-lock-20260703.md` | Direction lock: bounded ordered approved-config chain, typed single-value handoff, per-hop + chain fail-closed, values-free stitched evidence, read-only; recursion excluded | Docs only — authorizes no runtime |
 | **C-R1** | #3553 | `665504041` | Chain **config model + save-time validator**: migration `063_create_integration_read_source_composition_configs.sql`, content-keyed versioned store + approve/retire, depth-bounded (exactly two steps in v1), acyclic, write-shaped-step rejected | No runtime, no chaining execution |
 | **C-R2** | #3563 | `7e9c844d4` | **Pure planner/evaluator**: `planReadSourceComposition` (reuses the C-R1 validator verbatim), `deriveCompositionStepInput` (typed single-scalar handoff via the runtime's own key predicate), `evaluateCompositionOutcome` (values-free per-step vector + last-hop-only data projection) | No route, no outbound, no adapter, no persistence, no write, no recursion |
-| **C-R2 hardening** | #3568 | *(in-flight, parallel session)* | Two seam fail-closes: (1) `planReadSourceComposition` requires an approval-config map (omission = PLAN_INVALID, not a preview); (2) a hop is a success only when `evidence.ok === true` **and** it carries a chain-usable scalar | Same scope fence; pure lib |
+| **C-R2 hardening** | #3568 | `cfd3dcd0` (MERGED) | Two seam fail-closes: (1) `planReadSourceComposition` requires an approval-config map (omission = PLAN_INVALID, not a preview); (2) a hop is a success only when `evidence.ok === true` **and** it carries a chain-usable scalar | Same scope fence; pure lib |
 | **C-R3** | #3565 | `e68fe39ce` | **Chain runtime executor**: `executeReadSourceComposition` — orchestrates approved step configs in order, per-hop fail-closed, values-free stitched evidence, read-only; reuses S3-1 `executeConfiguredRead` + R1 resolver per hop | No route, no persistence lookup inside, no write, no recursion, no new credential path |
 
 ## 2. The locks, and where each is enforced
@@ -84,8 +84,8 @@ module's own stated defense-in-depth invariant hold):
 - L3 named request-shape vectors got red tests (JSON `__proto__` own-key rejected at body+inputs,
   getter-on-key read exactly once, object/array key fails closed at hop 0 with no outbound read).
 
-**C-R2 hardening (#3568, in-flight)** — cross-verified against merged C-R3: after rebasing #3568 onto
-main-with-C-R3, the full composition suite (planner + runtime + neighbors) is green; guard 2's
+**C-R2 hardening (#3568, merged `cfd3dcd0`)** — cross-verified against merged C-R3: after rebasing #3568
+onto main-with-C-R3, the full composition suite (planner + runtime + neighbors) is green; guard 2's
 `evidence.ok` requirement is satisfied by C-R3's real-producer hops, and the non-scalar handoff test
 still yields `STEP_OUTPUT_NOT_SCALAR`. The hardening does not regress C-R3.
 
@@ -135,6 +135,24 @@ authorized by this document:
 
 C-R1 / C-R2 / C-R3 merged and adversarially verified; the read-only composition chain
 (materialNumber → FItemID → FBOMNumber shape) executes end-to-end behind approved-only / key-only /
-values-free / fail-closed locks. C-R2 hardening (#3568) is in-flight and cross-verified compatible.
-The arc rests at its opt-in boundary: **C-R4 (route/UI/mirror) is the next rung and awaits an explicit
-opt-in.**
+values-free / fail-closed locks. C-R2 hardening (#3568, `cfd3dcd0`) merged.
+
+## 8. C-R4 addendum — read-only composition arc feature-complete (2026-07-05)
+
+C-R4 was opted in (owner, 2026-07-05) and delivered in staged rungs, each verified and merged:
+
+| Rung | PR | Merged SHA | Scope |
+| --- | --- | --- | --- |
+| **C-R4-1** | #3573 | `7821f776` | Composition HTTP surface — authoring routes + the approved-only / key-only / values-free / read-only **run route** (`POST /read-source-compositions/:id/run`); approved-only **double gate** (composition config + each step read config via `getForRuntime`, planner re-validation); adversarial `confirmed:[]` + planner defense-in-depth coverage (gate #2b). |
+| **C-R4-2** | #3576 | `3779121f` | Client **vocab mirror** of the 8 `READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES` + CI parity tripwire (fail-first verified). |
+| **C-R4-3a** | #3583 | `4899c608` | Client **runtime service layer** — `listReadSourceCompositions` / `runReadSourceComposition` (strict `{ inputs: { key } }`) + a values-free response normalizer. |
+| **C-R4-3b** | #3585 | `8c6ddaa3` | Advisor/operator **run panel UI** (dedicated component) — select an approved composition, enter the first business key, run, render values-free evidence + last-hop output; read-tier, no authoring. |
+
+Post-merge review hardened the C-R4-3a client error path to be values-free **by construction** (the raw
+server `error.message` is dropped; only a clamped code + reason is surfaced) and exact-allowlisted the
+per-step `errorCode` against the composition ∪ probe/resolver code union (unknown → dropped).
+
+**The read-only composition arc is feature-complete end-to-end** (design-lock → config → planner →
+runtime → route → client mirror → service → UI). Still gated, each a separate explicit opt-in:
+**recursive / unbounded BOM expansion** (its own design-lock) and **all write paths** (Save / Submit /
+Audit / external / production write — production write customer-barred).


### PR DESCRIPTION
Addresses post-merge review of the C-R4 composition client layer (3 findings).

## P2-a — run-error path values-free **by construction**

The service threw an error built from the raw server `error.message`, and the C-R4-3b panel renders `error.message`. Server routes return coarse messages today (no live leak), but a future server bug echoing a business value into `message` would render it. Now `ReadSourceCompositionApiError` (mirrors `ReadSourceApiError`) carries only a **clamped code + clamped reason** — the raw server message is dropped, so `.message` is values-free by construction.

- Red test: server message `'boom near MAT-001 SECRET'` never reaches the thrown error; a non-conforming code coarsens to `READ_SOURCE_COMPOSITION_REQUEST_FAILED`.

## P2-b — exact-allowlist the per-step errorCode

`normalizeRunStep` passed an unknown string `errorCode` through verbatim. Now exact-allowlisted against the **composition ∪ probe/resolver** code union (`READ_SOURCE_PROBE_ERROR_CODES`, now exported from `readSourceConfigs.ts`, already includes the resolver codes); an unknown code (e.g. a leaked `MAT_001_SECRET`) is **dropped**, not rendered.

- Red test: `MAT_001_SECRET` dropped while real resolver / probe / composition codes are kept.

## P3 — refresh the committed ledger

`…composition-cr0-cr3-dev-verification-20260705.md`: #3568 marked merged (`cfd3dcd0`), and a **§8 C-R4 addendum** records the arc **feature-complete** (C-R4-1 #3573 / C-R4-2 #3576 / C-R4-3a #3583 / C-R4-3b #3585) with the still-gated recursion + write paths.

## Verification

- 19 service/panel/mirror tests green; `type-check` clean; `git diff --check` clean.
- The C-R4-3b panel tests still pass — the error render is now values-free code-only (the 409 test's `toContain(code)` + no-key-echo assertions hold).

## Boundary

```text
serverRuntimeTouched=false   (client service + one export + docs only)
writePathTouched=false
recursionSupported=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
