### PR TITLE
fix(integration): C-R4 composition client — registered-set error.code + bounded planErrors clamp

### DIFF
--- a/apps/web/src/services/integration/readSourceCompositions.ts
+++ b/apps/web/src/services/integration/readSourceCompositions.ts
@@ -112,8 +112,32 @@ function buildQuery(input: Record<string, unknown>): string {
 // error.message is NEVER surfaced — only a clamped code + optional clamped reason — so the error path is
 // values-free BY CONSTRUCTION, not by trusting the server to keep messages coarse (a future server bug
 // echoing a business value into message can never reach the client render).
-const COMPOSITION_ERROR_CODE_PATTERN = /^[A-Z0-9_]{1,80}$/
 const COMPOSITION_ERROR_REASON_PATTERN = /^[a-z0-9_:-]{1,80}$/
+// planErrors[].field is a structural path the C-R1 validator emits (e.g. `steps.1.readSourceConfigId`,
+// `(root)`, `steps.0.(unexpected)`). Bound it to that shape so a business value can never ride in.
+const COMPOSITION_ERROR_FIELD_PATTERN = /^[A-Za-z0-9_.()]{1,60}$/
+// planErrors[].code is a composition validator code (READ_SOURCE_COMPOSITION_*). Requiring the prefix is
+// stricter than a bare uppercase regex — a code-shaped business value (e.g. MAT_001_SECRET) is rejected.
+const COMPOSITION_VALIDATOR_CODE_PATTERN = /^READ_SOURCE_COMPOSITION_[A-Z_]{1,60}$/
+
+// The EXACT registered set of HTTP error.code values the composition run/list routes emit (the composition
+// config errors + the read-source-config errors re-surfaced during per-step loading + the auth codes).
+// error.code is clamped against this set — NOT a bare regex — so a code-SHAPED business value (uppercase +
+// underscore, e.g. MAT_001_SECRET, which would pass a regex) coarsens to the fixed fallback instead of
+// rendering. An unregistered-but-legit future server code also coarsens (safe degradation, never a leak).
+const COMPOSITION_REQUEST_ERROR_CODES: ReadonlySet<string> = new Set([
+  'READ_SOURCE_COMPOSITION_CONFIG_INVALID',
+  'READ_SOURCE_COMPOSITION_CONFIG_NOT_FOUND',
+  'READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED',
+  'READ_SOURCE_COMPOSITION_CONFIG_STATUS_CONFLICT',
+  'READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID',
+  'READ_SOURCE_CONFIG_INVALID',
+  'READ_SOURCE_CONFIG_NOT_FOUND',
+  'READ_SOURCE_CONFIG_NOT_APPROVED',
+  'READ_SOURCE_CONFIG_STATUS_CONFLICT',
+  'UNAUTHENTICATED',
+  'FORBIDDEN',
+])
 
 export class ReadSourceCompositionApiError extends Error {
   status: number
@@ -135,7 +159,7 @@ async function parseCompositionResponse<T>(response: Response): Promise<T> {
   if (!response.ok || (isPlainObject(payload) && payload.ok === false)) {
     const error = isPlainObject(payload) && isPlainObject(payload.error) ? payload.error : {}
     const details = isPlainObject(error.details) ? error.details : {}
-    const code = typeof error.code === 'string' && COMPOSITION_ERROR_CODE_PATTERN.test(error.code)
+    const code = typeof error.code === 'string' && COMPOSITION_REQUEST_ERROR_CODES.has(error.code)
       ? error.code
       : 'READ_SOURCE_COMPOSITION_REQUEST_FAILED'
     const reason = typeof details.reason === 'string' && COMPOSITION_ERROR_REASON_PATTERN.test(details.reason)
@@ -194,9 +218,15 @@ export function normalizeCompositionRunResult(value: unknown): CompositionRunRes
     const coarse = asCompositionPlanErrorCode(rawEvidence.errorCode)
     if (coarse) evidence.errorCode = coarse
     if (Array.isArray(rawEvidence.planErrors)) {
+      // Bounded-clamp EACH triple field (code / field / reason) — not just typeof string — so the triple
+      // is values-free by construction: a future server bug echoing a business value into any of the
+      // three cannot ride in. An entry failing any clamp is dropped whole (fail-closed).
       const triples = rawEvidence.planErrors
         .filter(isPlainObject)
-        .filter((e) => typeof e.code === 'string' && typeof e.field === 'string' && typeof e.reason === 'string')
+        .filter((e) =>
+          typeof e.code === 'string' && COMPOSITION_VALIDATOR_CODE_PATTERN.test(e.code)
+          && typeof e.field === 'string' && COMPOSITION_ERROR_FIELD_PATTERN.test(e.field)
+          && typeof e.reason === 'string' && COMPOSITION_ERROR_REASON_PATTERN.test(e.reason))
         .map((e) => ({ code: e.code as string, field: e.field as string, reason: e.reason as string }))
       if (triples.length > 0) evidence.planErrors = triples
     }

--- a/apps/web/tests/readSourceCompositions.service.spec.ts
+++ b/apps/web/tests/readSourceCompositions.service.spec.ts
@@ -106,6 +106,22 @@ describe('runReadSourceComposition', () => {
     expect((err as Error).message).toBe('READ_SOURCE_COMPOSITION_REQUEST_FAILED')
     expect((err as Error).message).not.toContain('MAT-001')
   })
+
+  it('clamps error.code to the EXACT registered set — a code-SHAPED business value coarsens to fallback', async () => {
+    // A regex clamp (uppercase+underscore) would PASS this; the registered-set clamp coarsens it.
+    apiFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { code: 'MAT_001_SECRET', message: 'x' } }), { status: 409, headers: { 'Content-Type': 'application/json' } }),
+    )
+    const err = await runReadSourceComposition('rscc_1', 'M-001', SCOPE).then(() => null, (e) => e)
+    expect((err as Error).message).toBe('READ_SOURCE_COMPOSITION_REQUEST_FAILED')
+    expect((err as Error).message).not.toContain('MAT_001_SECRET')
+    // A genuinely registered code still passes through.
+    apiFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { code: 'READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED', message: 'x' } }), { status: 409, headers: { 'Content-Type': 'application/json' } }),
+    )
+    const ok = await runReadSourceComposition('rscc_1', 'M-001', SCOPE).then(() => null, (e) => e)
+    expect((ok as Error).message).toBe('READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED')
+  })
 })
 
 describe('normalizeCompositionRunResult (values-free allowlist)', () => {
@@ -173,5 +189,31 @@ describe('normalizeCompositionRunResult (values-free allowlist)', () => {
     expect(result.evidence.planErrors).toEqual([
       { code: 'READ_SOURCE_COMPOSITION_STEP_NOT_APPROVED', field: 'steps.1.readSourceConfigId', reason: 'approved_read_config_required' },
     ])
+  })
+
+  it('bounded-clamps each planErrors field — a business value in code/field/reason drops the entry', () => {
+    const result = normalizeCompositionRunResult({
+      evidence: {
+        ok: false, failedStep: null, steps: [], errorCode: 'READ_SOURCE_COMPOSITION_PLAN_INVALID',
+        planErrors: [
+          // reason carries a business value (uppercase/space) → whole entry dropped.
+          { code: 'READ_SOURCE_COMPOSITION_STEP_NOT_APPROVED', field: 'steps.1.readSourceConfigId', reason: 'material MAT-001 SECRET' },
+          // field carries a business value → dropped.
+          { code: 'READ_SOURCE_COMPOSITION_STEP_MODE_INVALID', field: 'MAT-001 the material number', reason: 'resolver_lookup_required' },
+          // code is a code-SHAPED business value (no READ_SOURCE_COMPOSITION_ prefix) → dropped.
+          { code: 'MAT_001_SECRET', field: 'steps.0.readSourceConfigId', reason: 'approved_read_config_required' },
+          // a well-formed validator triple survives.
+          { code: 'READ_SOURCE_COMPOSITION_WRITE_CONFIG_REJECTED', field: 'steps.0.savePath', reason: 'write_shaped_key' },
+        ],
+      },
+      data: null,
+    })
+    expect(result.evidence.planErrors).toEqual([
+      { code: 'READ_SOURCE_COMPOSITION_WRITE_CONFIG_REJECTED', field: 'steps.0.savePath', reason: 'write_shaped_key' },
+    ])
+    const text = JSON.stringify(result)
+    for (const leak of ['MAT-001 SECRET', 'MAT-001 the material number', 'MAT_001_SECRET']) {
+      expect(text).not.toContain(leak)
+    }
   })
 })


### PR DESCRIPTION
Completes the values-free-by-construction posture on the composition client error path — follow-up to #3586 (same defense-in-depth class, two remaining seams the reviewer flagged against #3586's head).

## error.code — registered set, not a regex
`error.code` was regex-clamped, so a **code-SHAPED business value** (e.g. `MAT_001_SECRET`, which passes `/^[A-Z0-9_]+$/`) would pass through and render. Now clamped to the **exact registered set** of codes the composition run/list routes emit (composition config errors + the read-source-config errors re-surfaced during per-step loading + `UNAUTHENTICATED`/`FORBIDDEN`); anything else coarsens to `READ_SOURCE_COMPOSITION_REQUEST_FAILED` (safe degradation, never a leak).
- Red test: `MAT_001_SECRET` → fallback; a real registered code (`…CONFIG_NOT_APPROVED`) still passes.

## planErrors — bounded clamp per field
The triples were only `typeof`-string checked. Now each is bounded-clamped: `code` must match `/^READ_SOURCE_COMPOSITION_[A-Z_]+$/` (prefix-strict — rejects a code-shaped business value), `field` the structural-path pattern, `reason` the reason pattern; an entry failing any clamp is **dropped whole**.
- Red test: business values in code / field / reason each drop their entry; a well-formed validator triple survives; no sentinel leaks.

## Verification
- 21 service/panel/mirror tests green; `type-check` clean; `git diff --check` clean.

## Boundary
Client service only — no server runtime, no write path, no recursion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)