### PR TITLE
docs(approval): owner ratifies A3 egress destination authorization (A1-A4 all adopt-default)

### DIFF
--- a/docs/development/approval-automation-third-batch-ballot-20260702.md
+++ b/docs/development/approval-automation-third-batch-ballot-20260702.md
@@ -25,10 +25,16 @@ authorization decision.
 
 | # | Decision | Proposed default | Vote |
 |---|---|---|---|
-| A1 | First destination scope | Authorize exactly one named staging destination first; production destination requires a separate follow-up approval after staging evidence. | ⬜ |
-| A2 | Host entry shape | Exact ASCII DNS host only, no scheme/path/port/wildcard/CIDR/IP literal; values supplied through `BPMN_HTTP_TASK_EGRESS_POLICY`, never request/BPMN variables. | ⬜ |
-| A3 | Evidence and smoke | Values-free smoke proving allowed host reaches mocked/approved transport and disallowed/private/redirect cases still deny; no full URL, headers, body, response, or secrets in evidence. | ⬜ |
-| A4 | Rollback | Removing or blanking the env policy returns the engine to deny-all with no DB migration or tenant data rewrite. | ⬜ |
+| A1 | First destination scope | Authorize exactly one named staging destination first; production destination requires a separate follow-up approval after staging evidence. | ✅ |
+| A2 | Host entry shape | Exact ASCII DNS host only, no scheme/path/port/wildcard/CIDR/IP literal; values supplied through `BPMN_HTTP_TASK_EGRESS_POLICY`, never request/BPMN variables. | ✅ |
+| A3 | Evidence and smoke | Values-free smoke proving allowed host reaches mocked/approved transport and disallowed/private/redirect cases still deny; no full URL, headers, body, response, or secrets in evidence. | ✅ |
+| A4 | Rollback | Removing or blanking the env policy returns the engine to deny-all with no DB migration or tenant data rewrite. | ✅ |
+
+**A3 — RATIFIED 2026-07-05 (owner vote): A1–A4 all ✅ adopt-default.** The governance shape is locked: staging-first
+single named destination, exact-ASCII-DNS-host-only via `BPMN_HTTP_TASK_EGRESS_POLICY`, values-free smoke evidence,
+env-blank rollback to deny-all. **This vote authorizes the framework, not any egress:** the engine stays **deny-all**
+until a named staging host is supplied AND the policy is enabled — naming that first staging host is a separate,
+explicit follow-up input. Production destinations remain a distinct later approval (A1).
 
 **Build/ops contract**
 


### PR DESCRIPTION
Records the **owner's per-rung vote** on the third-batch ballot: **A3 — BPMN HTTP-task egress destination authorization (governance-only) → A1–A4 all ✅ adopt-default.**

## What this locks (framework only)
- **A1** staging-first: authorize exactly one named staging destination first; production is a separate later approval.
- **A2** exact ASCII DNS host only (no scheme/path/port/wildcard/CIDR/IP), supplied via `BPMN_HTTP_TASK_EGRESS_POLICY`, never request/BPMN vars.
- **A3** values-free smoke evidence (allowed reaches, disallowed/private/redirect deny; no URL/headers/body/secrets in evidence).
- **A4** env-blank rollback to deny-all, no DB migration / no tenant data rewrite.

## What this does NOT do
**This vote authorizes the framework, not any egress.** The engine stays **deny-all** until a named staging host is supplied AND the policy is enabled. Naming that first staging host is a separate, explicit follow-up input.

## Scope
Doc-only. Records one owner vote. Other rungs (T3-2 / T3-3 / T3-1 / T3-6) remain **PROPOSED / unvoted**. Grounded on `origin/main` @ `5c34b2db7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)