### PR TITLE
feat(integration): composition postdeploy smoke — chain lifecycle, values-free (script + workflow)

### DIFF
--- a/.github/workflows/integration-composition-postdeploy-smoke.yml
+++ b/.github/workflows/integration-composition-postdeploy-smoke.yml
@@ -1,0 +1,120 @@
+name: Integration Composition Postdeploy Smoke
+
+# Read-source resolver composition (#1709 composition line) — post-deploy E2E smoke lane.
+# Values-free by construction: the smoke script prints only statuses/booleans/counts/coarse codes.
+# Mirrors the read self-service postdeploy smoke lane (same token resolver, secrets, and vars).
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Deployed backend base URL (defaults to repo var / entity host)
+        required: false
+      tenant_id:
+        description: Tenant scope (defaults to repo var)
+        required: false
+      workspace_id:
+        description: Workspace scope (optional)
+        required: false
+      system_id:
+        description: Registered external system id (required for the composition chain)
+        required: true
+      sample_key:
+        description: Private sample key (material key) for the chain run (never echoed)
+        required: true
+      step1_read_path:
+        description: Hop 1 (material) relative read path override
+        required: false
+        default: /K3API/Material/GetList
+      step2_read_path:
+        description: Hop 2 (bom) relative read path override
+        required: false
+        default: /K3API/BOM/GetList
+      container_paths:
+        description: Comma-separated container paths shared by both hops (default Data.Rows)
+        required: false
+        default: Data.Rows
+      timeout_ms:
+        description: Per-request timeout in ms
+        required: false
+        default: '15000'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve smoke token
+        id: token
+        env:
+          METASHEET_K3WISE_SMOKE_TOKEN_SECRET: ${{ secrets.METASHEET_K3WISE_SMOKE_TOKEN }}
+          K3_WISE_TOKEN_RESOLVE_REQUIRED: 'true'
+          K3_WISE_TOKEN_AUTO_DISCOVER_TENANT: ${{ vars.K3_WISE_TOKEN_AUTO_DISCOVER_TENANT || 'false' }}
+          METASHEET_TENANT_ID: ${{ github.event.inputs.tenant_id || vars.METASHEET_TENANT_ID || '' }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
+        run: |
+          set -euo pipefail
+          scripts/ops/resolve-k3wise-smoke-token.sh
+
+      - name: Run composition postdeploy smoke
+        id: smoke
+        env:
+          METASHEET_BASE_URL: ${{ github.event.inputs.base_url || vars.METASHEET_BASE_URL || vars.PUBLIC_APP_URL || 'http://23.254.236.11:8081' }}
+          METASHEET_TENANT_ID: ${{ github.event.inputs.tenant_id || vars.METASHEET_TENANT_ID || '' }}
+          METASHEET_WORKSPACE_ID: ${{ github.event.inputs.workspace_id || '' }}
+          SMOKE_SYSTEM_ID: ${{ github.event.inputs.system_id }}
+          SMOKE_SAMPLE_KEY: ${{ github.event.inputs.sample_key }}
+          SMOKE_STEP1_READ_PATH: ${{ github.event.inputs.step1_read_path || '/K3API/Material/GetList' }}
+          SMOKE_STEP2_READ_PATH: ${{ github.event.inputs.step2_read_path || '/K3API/BOM/GetList' }}
+          SMOKE_CONTAINER_PATHS: ${{ github.event.inputs.container_paths || 'Data.Rows' }}
+          TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '15000' }}
+        run: |
+          set -euo pipefail
+          out_dir="output/integration-composition-postdeploy-smoke/manual"
+          rm -rf "$out_dir"
+          mkdir -p "$out_dir"
+
+          args=(
+            --base-url "$METASHEET_BASE_URL"
+            --system-id "$SMOKE_SYSTEM_ID"
+            --sample-key "$SMOKE_SAMPLE_KEY"
+            --step1-read-path "$SMOKE_STEP1_READ_PATH"
+            --step2-read-path "$SMOKE_STEP2_READ_PATH"
+            --container-paths "$SMOKE_CONTAINER_PATHS"
+            --timeout-ms "$TIMEOUT_MS"
+            --out-dir "$out_dir"
+          )
+          if [[ -n "${METASHEET_TENANT_ID:-}" ]]; then args+=(--tenant-id "$METASHEET_TENANT_ID"); fi
+          if [[ -n "${METASHEET_WORKSPACE_ID:-}" ]]; then args+=(--workspace-id "$METASHEET_WORKSPACE_ID"); fi
+          if [[ -n "${K3_WISE_SMOKE_TOKEN:-}" ]]; then
+            export METASHEET_AUTH_TOKEN="$K3_WISE_SMOKE_TOKEN"
+          fi
+
+          node scripts/ops/integration-composition-postdeploy-smoke.mjs "${args[@]}"
+
+      - name: Write summary
+        if: always()
+        run: |
+          set -euo pipefail
+          echo "## Composition Postdeploy Smoke" >> "$GITHUB_STEP_SUMMARY"
+          echo '```text' >> "$GITHUB_STEP_SUMMARY"
+          cat output/integration-composition-postdeploy-smoke/manual/summary.txt 2>/dev/null >> "$GITHUB_STEP_SUMMARY" || echo "no summary produced" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: composition-postdeploy-smoke
+          path: output/integration-composition-postdeploy-smoke/manual
+          if-no-files-found: ignore

--- a/scripts/ops/integration-composition-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-composition-postdeploy-smoke.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+'use strict'
+
+// Read-source resolver composition — post-deploy E2E smoke (#1709 composition line).
+//
+// Exercises the read-only material→FItemID→FBOMNumber two-hop chain against a DEPLOYED environment
+// over HTTP: save read config #1 (draft)→approve → save read config #2 (draft)→approve → save
+// composition (draft) → NEGATIVE run before approve (409) → approve composition → run (200, evidence
+// + coarse chain outcome) → NEGATIVE config-override run (400) → retire → NEGATIVE post-retire run (409).
+//
+// Mirrors scripts/ops/integration-read-selfservice-postdeploy-smoke.mjs idiom-for-idiom (arg parsing,
+// requestJson helper, values-free evidence collection, summary JSON, PASS/FAIL exit).
+//
+// Values-free output discipline: this script prints ONLY statuses, booleans, counts, and coarse enum
+// codes. It never prints the sample key, resolved values, row content, read paths, hostnames, or tokens.
+// A chain that fail-closes with a coarse code (e.g. NO_MATCH on the sample key) is still a PASS of the
+// PLATFORM chain — only HTTP/contract failures are smoke FAIL (recorded separately as `runChainOutcome`).
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const RESULT = { checks: [], summary: {} }
+
+// Fixed handoff wiring (matches the design-lock fixture — plugins/plugin-integration-core/__tests__/
+// read-source-composition-runtime.test.cjs): step 1 resolves the intermediate scalar under this exact
+// target name, step 2 consumes it as `key` and resolves the final scalar under this exact target name.
+// These are NOT salted — the composition's step-to-step handoff wiring is fixed platform structure, not
+// per-run smoke scratch data.
+const INTERMEDIATE_TARGET = 'internal_id'
+const FINAL_TARGET = 'bom_number'
+const SYSTEM_KIND = 'erp:k3-wise-webapi'
+
+function parseArgs(argv) {
+  const args = {
+    baseUrl: '',
+    tenantId: '',
+    workspaceId: '',
+    systemId: '',
+    sampleKey: process.env.METASHEET_COMPOSITION_SMOKE_SAMPLE_KEY || '',
+    step1ReadPath: '/K3API/Material/GetList',
+    step1KeyField: 'FNumber',
+    step1Source: 'FItemID',
+    step1Object: 'material',
+    step2ReadPath: '/K3API/BOM/GetList',
+    step2KeyField: 'FItemId',
+    step2Source: 'FBOMNumber',
+    step2Object: 'bom',
+    containerPaths: 'Data.Rows',
+    timeoutMs: 15000,
+    outDir: '',
+  }
+  for (let i = 2; i < argv.length; i++) {
+    const flag = argv[i]
+    const next = () => argv[++i]
+    if (flag === '--base-url') args.baseUrl = next()
+    else if (flag === '--tenant-id') args.tenantId = next()
+    else if (flag === '--workspace-id') args.workspaceId = next()
+    else if (flag === '--system-id') args.systemId = next()
+    else if (flag === '--sample-key') args.sampleKey = next()
+    else if (flag === '--step1-read-path') args.step1ReadPath = next()
+    else if (flag === '--step1-key-field') args.step1KeyField = next()
+    else if (flag === '--step1-source') args.step1Source = next()
+    else if (flag === '--step1-object') args.step1Object = next()
+    else if (flag === '--step2-read-path') args.step2ReadPath = next()
+    else if (flag === '--step2-key-field') args.step2KeyField = next()
+    else if (flag === '--step2-source') args.step2Source = next()
+    else if (flag === '--step2-object') args.step2Object = next()
+    else if (flag === '--container-paths') args.containerPaths = next()
+    else if (flag === '--timeout-ms') args.timeoutMs = Number(next())
+    else if (flag === '--out-dir') args.outDir = next()
+    else throw new Error(`unknown flag: ${flag}`)
+  }
+  if (!args.baseUrl) throw new Error('--base-url is required')
+  if (!args.systemId) throw new Error('--system-id is required')
+  // Every step of this lifecycle (including the before-approve negative run) submits { inputs: { key } },
+  // so the sample key is required unconditionally, not only for the final positive-run step.
+  if (!args.sampleKey) throw new Error('--sample-key is required')
+  return args
+}
+
+// Build the S1-shaped resolver_lookup read config for one hop.
+export function buildStepReadConfig({ systemId, object, readPath, keyField, containerPaths, source, target }) {
+  return {
+    version: 1,
+    systemId,
+    requiredKind: SYSTEM_KIND,
+    object,
+    mode: 'resolver_lookup',
+    readPath,
+    readMethod: 'POST',
+    operations: ['read'],
+    keyField,
+    containerPaths: containerPaths.split(',').map((p) => p.trim()).filter(Boolean),
+    resolverRule: 'exactly_one',
+    fieldMap: [{ source, target }],
+  }
+}
+
+// Build the C-R1-shaped composition config. `name` is salted per run so a fresh draft→approved→retired
+// lifecycle is exercised every run (a stable name would collide with a PRIOR run's retired content —
+// re-saving retired content is a 409 CONFLICT, not a fresh 201 — see read-source-composition-config-
+// store.cjs reuseExisting()). The handoff target names stay fixed (see header comment).
+export function buildCompositionConfig({ step1ConfigId, step2ConfigId, salt }) {
+  return {
+    version: 1,
+    name: `composition-smoke-${salt}`,
+    operations: ['read'],
+    steps: [
+      { id: 'resolve-item', readSourceConfigId: step1ConfigId },
+      { id: 'resolve-bom', readSourceConfigId: step2ConfigId, input: { fromStep: 'resolve-item', sourceTarget: INTERMEDIATE_TARGET, toInput: 'key' } },
+    ],
+  }
+}
+
+// Values-free leak scan: none of the given sentinel strings may appear in the serialized subject.
+export function leakScan(subject, sentinels) {
+  const text = JSON.stringify(subject)
+  const leaks = []
+  for (const sentinel of sentinels) {
+    if (typeof sentinel === 'string' && sentinel.length > 0 && text.includes(sentinel)) leaks.push(true)
+  }
+  return leaks.length === 0
+}
+
+export function formatSummaryBlock(summary) {
+  const lines = ['READ_SOURCE_COMPOSITION_POSTDEPLOY_SMOKE']
+  for (const [key, value] of Object.entries(summary)) lines.push(`${key}=${value}`)
+  return lines.join('\n')
+}
+
+function check(name, ok, detail = '') {
+  RESULT.checks.push({ name, ok: ok === true, detail })
+  const mark = ok === true ? 'ok' : 'FAIL'
+  process.stderr.write(`[smoke] ${name}: ${mark}${detail ? ` (${detail})` : ''}\n`)
+  return ok === true
+}
+
+async function requestJson(baseUrl, pathname, { token, timeoutMs, method = 'GET', body, accept = [200] } = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const headers = { Accept: 'application/json' }
+    if (token) headers.Authorization = `Bearer ${token}`
+    const init = { method, headers, signal: controller.signal }
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json'
+      init.body = JSON.stringify(body)
+    }
+    const response = await fetch(`${baseUrl}${pathname}`, init)
+    const text = await response.text()
+    let parsed = null
+    try { parsed = text ? JSON.parse(text) : null } catch { parsed = null }
+    return { status: response.status, body: parsed, ok: accept.includes(response.status) }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function scopeQuery(args) {
+  const params = new URLSearchParams()
+  if (args.tenantId) params.set('tenantId', args.tenantId)
+  if (args.workspaceId) params.set('workspaceId', args.workspaceId)
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+// Save a hop's read config and ensure it is approved. Tolerant of idempotent reuse: since the hop
+// configs are NOT salted (their K3 defaults are stable, real business wiring, not scratch data), a
+// re-run of this smoke against the same system will legitimately reuse an ALREADY-APPROVED row (200,
+// not 201) — approving an already-approved row would 409 CONFLICT, so approve is only attempted when
+// the returned status is 'draft'.
+async function saveAndApproveReadConfig(baseUrl, scope, token, timeoutMs, config, label, S, must) {
+  const save = await requestJson(baseUrl, `/api/integration/read-source-configs${scope}`, {
+    token, timeoutMs, method: 'POST', body: { config }, accept: [200, 201],
+  })
+  const row = save.body?.data || {}
+  S[`${label}SaveHttp`] = save.status
+  S[`${label}SaveStatusName`] = row.status || ''
+  must(`${label} save http 200/201`, save.ok && Boolean(row.id), `http=${save.status}`)
+  if (!row.id) return null
+  const configId = row.id
+  if (row.status === 'draft') {
+    const approve = await requestJson(baseUrl, `/api/integration/read-source-configs/${configId}/approve${scope}`, {
+      token, timeoutMs, method: 'POST', body: {},
+    })
+    S[`${label}ApproveHttp`] = approve.status
+    S[`${label}ApprovedStatusName`] = approve.body?.data?.status || ''
+    must(`${label} approve → 200 approved`, approve.ok && S[`${label}ApprovedStatusName`] === 'approved', `http=${approve.status}`)
+  } else {
+    S[`${label}ApproveHttp`] = 'skipped_already_approved'
+    S[`${label}ApprovedStatusName`] = row.status
+    must(`${label} reused config already approved`, row.status === 'approved', `status=${row.status}`)
+  }
+  return configId
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  const token = process.env.METASHEET_AUTH_TOKEN || ''
+  const salt = `t${Math.floor(Date.now() / 1000)}`
+  const scope = scopeQuery(args)
+  const S = RESULT.summary
+  let failed = false
+  const must = (name, ok, detail) => { if (!check(name, ok, detail)) failed = true }
+  const evidenceSentinels = [args.sampleKey, args.step1ReadPath, args.step2ReadPath]
+
+  // 0. auth round-trip (deploy SOP: silent 401 usually = schema/token gap) — mirrors the read
+  // self-service smoke's preliminary gate.
+  const status = await requestJson(args.baseUrl, '/api/integration/status', { token, timeoutMs: args.timeoutMs })
+  S.statusHttp = status.status
+  must('status auth round-trip', status.ok, `http=${status.status}`)
+  if (!status.ok) return finish(failed, args)
+
+  // 1. hop 1 read config: material → FItemID (resolver output target: internal_id)
+  const step1Config = buildStepReadConfig({
+    systemId: args.systemId, object: args.step1Object, readPath: args.step1ReadPath,
+    keyField: args.step1KeyField, containerPaths: args.containerPaths,
+    source: args.step1Source, target: INTERMEDIATE_TARGET,
+  })
+  const step1ConfigId = await saveAndApproveReadConfig(args.baseUrl, scope, token, args.timeoutMs, step1Config, 'step1', S, must)
+  if (!step1ConfigId) return finish(true, args)
+
+  // 2. hop 2 read config: bom (keyed by the hop-1 output) → FBOMNumber (resolver output target: bom_number)
+  const step2Config = buildStepReadConfig({
+    systemId: args.systemId, object: args.step2Object, readPath: args.step2ReadPath,
+    keyField: args.step2KeyField, containerPaths: args.containerPaths,
+    source: args.step2Source, target: FINAL_TARGET,
+  })
+  const step2ConfigId = await saveAndApproveReadConfig(args.baseUrl, scope, token, args.timeoutMs, step2Config, 'step2', S, must)
+  if (!step2ConfigId) return finish(true, args)
+
+  // 3. composition config referencing both approved hops (draft; fresh every run via salted name)
+  const compositionConfig = buildCompositionConfig({ step1ConfigId, step2ConfigId, salt })
+  const saveComp = await requestJson(args.baseUrl, `/api/integration/read-source-compositions${scope}`, {
+    token, timeoutMs: args.timeoutMs, method: 'POST', body: { config: compositionConfig }, accept: [200, 201],
+  })
+  const compRow = saveComp.body?.data || {}
+  S.compositionSaveHttp = saveComp.status
+  S.compositionSaveStatusName = compRow.status || ''
+  must('composition save http 200/201', saveComp.ok && Boolean(compRow.id), `http=${saveComp.status}`)
+  must('composition save status draft', compRow.status === 'draft', `status=${compRow.status || '-'}`)
+  if (!compRow.id) return finish(true, args)
+  const compositionId = compRow.id
+
+  // 4. NEGATIVE: run before approve → 409 NOT_APPROVED
+  const preApproveRun = await requestJson(args.baseUrl, `/api/integration/read-source-compositions/${compositionId}/run${scope}`, {
+    token, timeoutMs: args.timeoutMs, method: 'POST', body: { inputs: { key: args.sampleKey } }, accept: [409],
+  })
+  S.preApproveRunHttp = preApproveRun.status
+  S.preApproveRunCode = preApproveRun.body?.error?.code || ''
+  must('pre-approve run → 409 not approved', preApproveRun.ok && S.preApproveRunCode === 'READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED', `http=${preApproveRun.status} code=${S.preApproveRunCode || '-'}`)
+  must('pre-approve run response values-free', leakScan(preApproveRun.body || {}, evidenceSentinels))
+
+  // 5. approve composition
+  const approveComp = await requestJson(args.baseUrl, `/api/integration/read-source-compositions/${compositionId}/approve${scope}`, {
+    token, timeoutMs: args.timeoutMs, method: 'POST', body: {},
+  })
+  S.compositionApproveHttp = approveComp.status
+  S.compositionApprovedStatusName = approveComp.body?.data?.status || ''
+  must('composition approve → 200 approved', approveComp.ok && S.compositionApprovedStatusName === 'approved', `http=${approveComp.status}`)
+
+  // 6. runtime run — HTTP 200 is the only hard bar; a coarse fail-closed chain outcome (e.g. NO_MATCH on
+  // the sample key) is a legitimate PLATFORM pass, recorded separately as chainOutcome, never asserted.
+  const run = await requestJson(args.baseUrl, `/api/integration/read-source-compositions/${compositionId}/run${scope}`, {
+    token, timeoutMs: args.timeoutMs, method: 'POST', body: { inputs: { key: args.sampleKey } },
+  })
+  const runData = run.body?.data || {}
+  const evidence = runData.evidence || {}
+  const dataPlane = runData.data || null
+  S.runHttp = run.status
+  must('run http 200', run.ok, `http=${run.status}`)
+  const evidenceShapeValid = typeof evidence.ok === 'boolean' && Array.isArray(evidence.steps)
+  must('run evidence shape valid', evidenceShapeValid, `keys=${Object.keys(evidence).length}`)
+  S.runEvidenceOk = evidence.ok === true
+  S.runFailedStep = (evidence.failedStep === undefined || evidence.failedStep === null) ? 'null' : evidence.failedStep
+  S.runStepsVector = evidenceShapeValid
+    ? JSON.stringify(evidence.steps.map((s) => ({ step: s.step, ok: s.ok === true, rule: s.rule || '', errorCode: s.errorCode || '' })))
+    : '[]'
+  S.runErrorCode = typeof evidence.errorCode === 'string' ? evidence.errorCode : ''
+  S.runDataResolved = dataPlane !== null && dataPlane !== undefined
+  S.runDataTarget = (dataPlane && dataPlane.resolver && typeof dataPlane.resolver.target === 'string') ? dataPlane.resolver.target : ''
+  S.runChainOutcome = S.runEvidenceOk ? 'resolved' : 'fail_closed'
+  const resolvedValueSentinel = (dataPlane && dataPlane.resolver && typeof dataPlane.resolver.value === 'string') ? [dataPlane.resolver.value] : []
+  must('run evidence values-free', leakScan(evidence, [...evidenceSentinels, ...resolvedValueSentinel]))
+
+  // 7. NEGATIVE: config-override body → 400 RUN_CONTRACT_INVALID
+  const overrideRun = await requestJson(args.baseUrl, `/api/integration/read-source-compositions/${compositionId}/run${scope}`, {
+    token, timeoutMs: args.timeoutMs, method: 'POST',
+    body: { inputs: { key: args.sampleKey }, config: {} }, accept: [400],
+  })
+  S.overrideRunHttp = overrideRun.status
+  S.overrideRunCode = overrideRun.body?.error?.code || ''
+  must('override run → 400 contract invalid', overrideRun.ok && S.overrideRunCode === 'READ_SOURCE_COMPOSITION_RUN_CONTRACT_INVALID', `http=${overrideRun.status} code=${S.overrideRunCode || '-'}`)
+  must('override run response values-free', leakScan(overrideRun.body || {}, evidenceSentinels))
+
+  // 8. retire, then post-retire run fail-closes
+  const retire = await requestJson(args.baseUrl, `/api/integration/read-source-compositions/${compositionId}/retire${scope}`, {
+    token, timeoutMs: args.timeoutMs, method: 'POST', body: {},
+  })
+  S.retireHttp = retire.status
+  S.retiredStatusName = retire.body?.data?.status || ''
+  must('retire → 200 retired', retire.ok && S.retiredStatusName === 'retired', `http=${retire.status}`)
+
+  const postRetireRun = await requestJson(args.baseUrl, `/api/integration/read-source-compositions/${compositionId}/run${scope}`, {
+    token, timeoutMs: args.timeoutMs, method: 'POST', body: { inputs: { key: args.sampleKey } }, accept: [409],
+  })
+  S.postRetireRunHttp = postRetireRun.status
+  S.postRetireRunCode = postRetireRun.body?.error?.code || ''
+  must('post-retire run → 409 not approved', postRetireRun.ok && S.postRetireRunCode === 'READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED', `http=${postRetireRun.status} code=${S.postRetireRunCode || '-'}`)
+  must('post-retire run response values-free', leakScan(postRetireRun.body || {}, evidenceSentinels))
+
+  return finish(failed, args)
+}
+
+function finish(failed, args) {
+  const S = RESULT.summary
+  S.pass = !failed && RESULT.checks.every((c) => c.ok)
+  const block = formatSummaryBlock(S)
+  process.stdout.write(`${block}\n`)
+  if (args.outDir) {
+    fs.mkdirSync(args.outDir, { recursive: true })
+    fs.writeFileSync(path.join(args.outDir, 'summary.txt'), `${block}\n`)
+    fs.writeFileSync(path.join(args.outDir, 'checks.json'), JSON.stringify(RESULT.checks, null, 2))
+  }
+  process.exitCode = S.pass ? 0 : 1
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))
+if (invokedDirectly) {
+  main().catch((error) => {
+    process.stderr.write(`[smoke] fatal: ${error && error.name ? error.name : 'Error'}\n`)
+    RESULT.summary.pass = false
+    RESULT.summary.fatal = true
+    process.stdout.write(`${formatSummaryBlock(RESULT.summary)}\n`)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary

Post-deploy smoke for the read-only composition chain (material→FItemID→FBOMNumber), mirroring the read-selfservice smoke idiom-for-idiom: **script** `scripts/ops/integration-composition-postdeploy-smoke.mjs` + **workflow** `.github/workflows/integration-composition-postdeploy-smoke.yml` (workflow_dispatch only, same token-resolve step).

Lifecycle: auth round-trip → save+approve both hop read configs (idempotent-tolerant re-run: reused approved rows accepted, approve only when draft) → save composition → **negative pre-approve run (409)** → approve → run `{inputs:{key}}` (HTTP 200 = hard bar; a coarse fail-closed chain outcome like NO_MATCH is a PLATFORM pass recorded as `chainOutcome`, never asserted) → **negative config-override (400 RUN_CONTRACT_INVALID)** → retire → **post-retire run (409)**.

**Values-free discipline enforced in-script**: `leakScan` sentinels (sample key, both read paths, and the resolved value itself) asserted against evidence/summary surfaces; summary carries statuses/coarse codes/booleans/`dataTarget` name only.

Design deviations from the literal read-smoke mirror (each grounded in real store semantics, documented in-file): composition `name` timestamp-salted (content-key 409 on identical re-save after retire), hop configs NOT salted (real business wiring; idempotent reuse), `--sample-key` unconditionally required (no key-less path in this line).

Verified: `node --check` OK; YAML parses (js-yaml + python-yaml); required-arg fail-closed with no network call; no network run performed.

Companion runbook: #3598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)