### PR TITLE
test(multitable): PIT hardening goldens — cross-strategy token rejection matrix + route-level golden

### DIFF
--- a/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
@@ -12,6 +12,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { hashPreviewChanges, mintRestorePreviewIdentity } from '../../src/multitable/restore-preview-identity'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -248,5 +249,23 @@ describeIfDatabase('multitable T8-1 PIT undelete-execute (real DB)', () => {
       await q(`DROP TRIGGER IF EXISTS ${TRG} ON meta_records`, []).catch(() => {})
       await q(`DROP FUNCTION IF EXISTS ${FN}()`, []).catch(() => {})
     }
+  })
+
+  test('(n) cross-strategy token rejection: a SINGLE-record restore-preview token (wrong `type`) is rejected at the route, not just in the unit contract', async () => {
+    process.env[FLAG] = 'true'
+    // A token minted by a DIFFERENT strategy (T6-1 single-record restore-preview, `type: 'restore-preview'`) is
+    // signed with the same secret, so JWT signature/expiry verification alone would pass it — only the
+    // discriminated `type` check in verifyPitRevertPreviewIdentity rejects it (`wrong_type`). This proves the
+    // guard is wired at THIS route's execute path, not merely exercised in the pure-unit contract test.
+    const wrongStrategyToken = mintRestorePreviewIdentity({
+      sheetId: SHEET, recordId: U, targetVersion: 1, strategy: 'revert',
+      changesHash: hashPreviewChanges([{ fieldId: NAME, op: 'set', value: 'irrelevant' }]),
+      actorId: ACTOR,
+    })
+    const x = await execute(T1, wrongStrategyToken, 'undelete')
+    expect(x.status).toBe(409)
+    expect(x.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID')
+    expect(x.body?.error?.message).toContain('wrong_type')
+    expect(await liveRow(U)).toBeUndefined() // rejected before any write — nothing resurrected
   })
 })

--- a/packages/core-backend/tests/unit/restore-preview-identity.test.ts
+++ b/packages/core-backend/tests/unit/restore-preview-identity.test.ts
@@ -8,12 +8,35 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  hashDeleteSet,
+  hashPermissionGrant,
   hashPreviewChanges,
+  hashResurrectSet,
   hashScope,
+  hashUncreatePlan,
+  hashUndeletePlan,
+  mintConfigPermissionRevertPreviewIdentity,
+  mintConfigRestorePreviewIdentity,
+  mintConfigUncreatePreviewIdentity,
+  mintConfigUndeletePreviewIdentity,
+  mintPitResetPreviewIdentity,
+  mintPitRevertPreviewIdentity,
   mintRestorePreviewIdentity,
   mintScopedRestorePreviewIdentity,
+  verifyConfigPermissionRevertPreviewIdentity,
+  verifyConfigRestorePreviewIdentity,
+  verifyConfigUncreatePreviewIdentity,
+  verifyConfigUndeletePreviewIdentity,
+  verifyPitResetPreviewIdentity,
+  verifyPitRevertPreviewIdentity,
   verifyRestorePreviewIdentity,
   verifyScopedRestorePreviewIdentity,
+  type ConfigPermissionRevertPreviewIdentityClaims,
+  type ConfigRestorePreviewIdentityClaims,
+  type ConfigUncreatePreviewIdentityClaims,
+  type ConfigUndeletePreviewIdentityClaims,
+  type PitResetPreviewIdentityClaims,
+  type PitRevertPreviewIdentityClaims,
   type RestorePreviewIdentityClaims,
   type ScopedRestorePreviewIdentityClaims,
 } from '../../src/multitable/restore-preview-identity'
@@ -146,5 +169,80 @@ describe('restore preview identity — BS-1 scoped (multi-record) contract', () 
     const token = mintScopedRestorePreviewIdentity(claims)
     const tampered = token.slice(0, -3) + (token.slice(-3) === 'AAA' ? 'BBB' : 'AAA')
     expect(verifyScopedRestorePreviewIdentity(tampered, claims).valid).toBe(false)
+  })
+})
+
+// ── cross-strategy disjointness matrix: every `type`-discriminated preview-identity family that exists in the
+// module, exhaustively pairwise. All families share ONE secret (getSecret()), so a wrong-family token STILL has a
+// valid JWT signature — only the `type` claim / wrong_type check stands between "signed by us" and "authorizes THIS
+// strategy's execute". D6 disjointness above only covered single<->scoped; this closes the remaining families
+// (pit-revert / pit-reset / config-restore / config-uncreate / config-undelete / config-permission-revert), so a
+// token minted for family X is proven REJECTED when verified as family Y for EVERY ordered pair (X, Y), X !== Y.
+interface StrategyEntry {
+  name: string
+  mintOwn: () => string
+  /** verify an arbitrary token against THIS family's own (self-consistent) expected claims. */
+  verifyAsSelf: (token: string) => { valid: boolean; reason?: string }
+}
+
+const strategyPitRevertClaims = (): PitRevertPreviewIdentityClaims => ({
+  sheetId: 'sheet_x', asOf: '2026-01-01T00:00:00.000Z', strategy: 'revert',
+  scopeHash: hashScope([]), resurrectScopeHash: hashResurrectSet([]), actorId: 'user_x',
+})
+const strategyPitResetClaims = (): PitResetPreviewIdentityClaims => ({
+  sheetId: 'sheet_x', asOf: '2026-01-01T00:00:00.000Z', strategy: 'reset',
+  revertScopeHash: hashScope([]), deleteScopeHash: hashDeleteSet([]), actorId: 'user_x',
+})
+const strategyConfigRestoreClaims = (): ConfigRestorePreviewIdentityClaims => ({
+  sheetId: 'sheet_x', revisionId: 'rev_x', entityType: 'field', entityId: 'f_x', baselineHash: 'deadbeef', actorId: 'user_x',
+})
+const strategyConfigUncreateClaims = (): ConfigUncreatePreviewIdentityClaims => ({
+  sheetId: 'sheet_x', revisionId: 'rev_x', entityType: 'field', entityId: 'f_x',
+  planHash: hashUncreatePlan({ entityAlive: true, cascadeViewIds: [], orderShiftIds: [], columnDataPresent: false }),
+  actorId: 'user_x',
+})
+const strategyConfigUndeleteClaims = (): ConfigUndeletePreviewIdentityClaims => ({
+  sheetId: 'sheet_x', revisionId: 'rev_x', entityType: 'field', entityId: 'f_x',
+  undeleteHash: hashUndeletePlan({ idFree: true, insertOrder: 0, trailingShiftIds: [], targetConfigHash: 'abc' }),
+  actorId: 'user_x',
+})
+const strategyConfigPermissionRevertClaims = (): ConfigPermissionRevertPreviewIdentityClaims => ({
+  sheetId: 'sheet_x', revisionId: 'rev_x', entityId: 'f_x', currentGrantHash: hashPermissionGrant(null), actorId: 'user_x',
+})
+
+const strategyEntries: StrategyEntry[] = [
+  { name: 'single-record restore', mintOwn: () => mintRestorePreviewIdentity(singleClaims()), verifyAsSelf: (t) => verifyRestorePreviewIdentity(t, singleClaims()) },
+  { name: 'scoped (multi-record) restore', mintOwn: () => mintScopedRestorePreviewIdentity(scopedClaims(['A', 'B'])), verifyAsSelf: (t) => verifyScopedRestorePreviewIdentity(t, scopedClaims(['A', 'B'])) },
+  { name: 'PIT revert', mintOwn: () => mintPitRevertPreviewIdentity(strategyPitRevertClaims()), verifyAsSelf: (t) => verifyPitRevertPreviewIdentity(t, strategyPitRevertClaims()) },
+  { name: 'PIT reset', mintOwn: () => mintPitResetPreviewIdentity(strategyPitResetClaims()), verifyAsSelf: (t) => verifyPitResetPreviewIdentity(t, strategyPitResetClaims()) },
+  { name: 'config-restore', mintOwn: () => mintConfigRestorePreviewIdentity(strategyConfigRestoreClaims()), verifyAsSelf: (t) => verifyConfigRestorePreviewIdentity(t, strategyConfigRestoreClaims()) },
+  { name: 'config-uncreate', mintOwn: () => mintConfigUncreatePreviewIdentity(strategyConfigUncreateClaims()), verifyAsSelf: (t) => verifyConfigUncreatePreviewIdentity(t, strategyConfigUncreateClaims()) },
+  { name: 'config-undelete', mintOwn: () => mintConfigUndeletePreviewIdentity(strategyConfigUndeleteClaims()), verifyAsSelf: (t) => verifyConfigUndeletePreviewIdentity(t, strategyConfigUndeleteClaims()) },
+  { name: 'config-permission-revert', mintOwn: () => mintConfigPermissionRevertPreviewIdentity(strategyConfigPermissionRevertClaims()), verifyAsSelf: (t) => verifyConfigPermissionRevertPreviewIdentity(t, strategyConfigPermissionRevertClaims()) },
+]
+
+describe('restore preview identity — cross-strategy disjointness (all discriminated `type` families)', () => {
+  it('sanity: each family round-trips valid against its OWN mint + own expected claims', () => {
+    for (const entry of strategyEntries) {
+      expect(entry.verifyAsSelf(entry.mintOwn())).toEqual({ valid: true })
+    }
+  })
+
+  const crossPairs = strategyEntries.flatMap((minter) =>
+    strategyEntries.filter((verifier) => verifier.name !== minter.name).map((verifier) => ({ minterName: minter.name, verifierName: verifier.name }))
+  )
+
+  it('the matrix covers every ORDERED pair (X, Y), X !== Y — no family silently excluded', () => {
+    expect(crossPairs.length).toBe(strategyEntries.length * (strategyEntries.length - 1))
+    expect(strategyEntries.length).toBe(8) // pins the enumerated family count itself (catches a silently-dropped entry)
+  })
+
+  it.each(crossPairs)('a token minted for $minterName is rejected wrong_type when verified as $verifierName', ({ minterName, verifierName }) => {
+    const minter = strategyEntries.find((e) => e.name === minterName)!
+    const verifier = strategyEntries.find((e) => e.name === verifierName)!
+    const token = minter.mintOwn()
+    const result = verifier.verifyAsSelf(token)
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe('wrong_type')
   })
 })


### PR DESCRIPTION
Closes the two test-hardening recommendations from the verified-state-map doc (§5, #3542).

## Golden 1 — multi-resurrect forced-failure atomicity: already on main
Verified test \`(m)\` in \`multitable-undelete-pit-realdb.test.ts\` (landed #3351) is equivalent to the recommendation — 2-record undelete, trigger-forced failure on record 2, asserts full rollback. **Not duplicated**; instead mutation-proven here: temporarily splitting the single \`pool.transaction\` into per-record transactions turned test (m) red at \`liveRow(U)\` (partial resurrect observed), restored. The readiness-refresh doc §2.2 listing it as "建议补" is stale (will be reconciled in the round's consolidated MD).

## Golden 2 — cross-strategy preview-token rejection (NEW)
All 8 discriminated preview-identity families share ONE HS256 secret — only the \`type\` claim separates "signed by us" from "authorizes THIS strategy's execute".
- **Unit**: exhaustive 8×7=56 ordered-pair matrix, each pair asserted \`valid:false\` + \`reason:'wrong_type'\` exactly; plus per-family round-trip sanity and a count-pin (\`families===8\`, catches silently added/dropped families). 72/72 pass.
- **Real-DB route golden \`(n)\`**: a valid single-record \`restore-preview\` token submitted to the PIT undelete execute route → \`409 PREVIEW_IDENTITY_INVALID\` (\`wrong_type\`), nothing resurrected — proves the guard is wired at the route, not just the unit contract. 15/15 pass with a disposable Postgres.

## Mutation evidence
1. Disabled \`wrong_type\` in \`verifyPitRevertPreviewIdentity\` → route golden (n) red. Restored.
2. Disabled \`wrong_type\` in \`verifyConfigRestorePreviewIdentity\` → exactly the 7 matrix pairs with config-restore as verifier red (65/72). Restored.

Test-only (+117); no runtime source touched. No P1 findings — every verify checks \`type\` first, now pinned for all 56 pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)