### PR TITLE
feat(multitable): inline masked per-field diff in Global History Center detail

### DIFF
--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -53,9 +53,35 @@
             <p v-else-if="!detail" class="meta-hist__hint">{{ t('无法打开该批次', 'This batch is unavailable') }}</p>
             <ul v-else class="meta-hist__changes">
               <li v-for="(c, i) in detail.changes" :key="`${c.recordId}-${i}`" class="meta-hist__change" data-test="hist-change">
-                <span class="meta-hist__change-action" :data-action="c.action">{{ actionLabel(c.action) }}</span>
-                <span class="meta-hist__change-rec" :title="c.recordId">{{ shortRecordId(c.recordId) }}</span>
-                <span class="meta-hist__change-fields">{{ fieldsLabel(c.changedFieldIds.length) }}</span>
+                <div class="meta-hist__change-summary">
+                  <span class="meta-hist__change-action" :data-action="c.action">{{ actionLabel(c.action) }}</span>
+                  <span class="meta-hist__change-rec" :title="c.recordId">{{ shortRecordId(c.recordId) }}</span>
+                  <span class="meta-hist__change-fields">{{ fieldsLabel(c.changedFieldIds.length) }}</span>
+                </div>
+                <ul v-if="c.changedFieldIds.length" class="meta-hist__diff" data-test="hist-diff">
+                  <li v-for="d in changeFieldDiffs(c)" :key="d.fieldId" class="meta-hist__diff-row" data-test="hist-diff-row">
+                    <span class="meta-hist__diff-label" :title="diffFieldName(d.fieldId)">{{ diffFieldName(d.fieldId) }}</span>
+                    <span class="meta-hist__diff-values">
+                      <template v-if="d.shape === 'masked'">
+                        <span class="meta-hist__diff-masked" data-test="hist-diff-masked">{{ diffMaskedLabel() }}</span>
+                      </template>
+                      <template v-else-if="d.shape === 'set'">
+                        <span class="meta-hist__diff-op" data-test="hist-diff-op">{{ diffOpLabel('set') }}</span>
+                        <span class="meta-hist__diff-after" :title="d.after">{{ d.after }}</span>
+                      </template>
+                      <template v-else-if="d.shape === 'cleared'">
+                        <span class="meta-hist__diff-before" :title="d.before">{{ d.before }}</span>
+                        <span class="meta-hist__diff-arrow" aria-hidden="true">→</span>
+                        <span class="meta-hist__diff-op" data-test="hist-diff-op">{{ diffOpLabel('cleared') }}</span>
+                      </template>
+                      <template v-else>
+                        <span class="meta-hist__diff-before" :title="d.before">{{ d.before }}</span>
+                        <span class="meta-hist__diff-arrow" aria-hidden="true">→</span>
+                        <span class="meta-hist__diff-after" :title="d.after">{{ d.after }}</span>
+                      </template>
+                    </span>
+                  </li>
+                </ul>
               </li>
             </ul>
           </div>
@@ -78,8 +104,8 @@
 import { ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import { useHistoryCenter } from '../composables/useHistoryCenter'
-import { historyActor } from '../utils/meta-record-labels'
-import type { HistoryBatchSummary } from '../types'
+import { historyActor, recordLabel } from '../utils/meta-record-labels'
+import type { HistoryBatchSummary, HistoryChange } from '../types'
 
 const props = defineProps<{ open: boolean; baseId: string; sheetId?: string; fields?: Array<{ id: string; name: string }> }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
@@ -158,6 +184,53 @@ function shortRecordId(id: string): string {
   const trimmed = id.startsWith('rec_') ? id.slice(4) : id
   return `#${trimmed.slice(0, 8)}`
 }
+
+// --- Inline per-field diff (read-only detail expansion) ---
+// Renders EXACTLY what the batch-detail payload already carries (HistoryChange.before/after, both
+// already permission-masked server-side per LOCK-3) — no extra fetch, no un-masking. A field is only
+// ever a diff row here because it is already listed in `changedFieldIds` (itself post-mask); this code
+// never widens that set.
+type FieldDiffShape = 'changed' | 'set' | 'cleared' | 'masked'
+interface FieldDiffRow { fieldId: string; shape: FieldDiffShape; before: string; after: string }
+
+function hasFieldValue(container: Record<string, unknown> | null, fieldId: string): boolean {
+  return !!container && Object.prototype.hasOwnProperty.call(container, fieldId)
+}
+function formatDiffValue(v: unknown): string {
+  if (v === null || v === undefined) return '—'
+  if (typeof v === 'object') {
+    try { return JSON.stringify(v) } catch { return String(v) }
+  }
+  return String(v)
+}
+// Shape rule (per changed field id):
+//  - present on both sides           → 'changed' (normal before→after diff)
+//  - present only on the after side  → 'set'      (no prior value — e.g. a create, or a field just added)
+//  - present only on the before side → 'cleared'  (the field was emptied)
+//  - present on NEITHER side         → 'masked'   (LOCK-3 hid the value on both sides even though the
+//                                                   batch still reports the field as changed)
+function changeFieldDiffs(c: HistoryChange): FieldDiffRow[] {
+  return c.changedFieldIds.map((fieldId) => {
+    const beforeHas = hasFieldValue(c.before, fieldId)
+    const afterHas = hasFieldValue(c.after, fieldId)
+    const shape: FieldDiffShape = beforeHas && afterHas ? 'changed' : afterHas ? 'set' : beforeHas ? 'cleared' : 'masked'
+    return {
+      fieldId,
+      shape,
+      before: beforeHas ? formatDiffValue((c.before as Record<string, unknown>)[fieldId]) : '',
+      after: afterHas ? formatDiffValue((c.after as Record<string, unknown>)[fieldId]) : '',
+    }
+  })
+}
+function diffFieldName(fieldId: string): string {
+  return props.fields?.find((f) => f.id === fieldId)?.name ?? fieldId
+}
+function diffOpLabel(shape: 'set' | 'cleared'): string {
+  return recordLabel(shape === 'set' ? 'record.restorePreviewSet' : 'record.restorePreviewUnset', isZh.value)
+}
+function diffMaskedLabel(): string {
+  return recordLabel('record.historyDiffMasked', isZh.value)
+}
 function formatTime(iso: string): string {
   if (!iso) return ''
   const d = new Date(iso)
@@ -183,10 +256,21 @@ function formatTime(iso: string): string {
 .meta-hist__when { color: var(--meta-text-secondary, #888); font-size: 12px; white-space: nowrap; }
 .meta-hist__detail { padding: 4px 0 10px 12px; }
 .meta-hist__changes { list-style: none; margin: 0; padding: 0; }
-.meta-hist__change { display: flex; gap: 10px; align-items: center; padding: 3px 0; font-size: 12px; }
+.meta-hist__change { padding: 3px 0; font-size: 12px; }
+.meta-hist__change-summary { display: flex; gap: 10px; align-items: center; }
 .meta-hist__change-action { font-weight: 500; min-width: 48px; }
 .meta-hist__change-rec { color: var(--meta-text-secondary, #888); }
 .meta-hist__change-fields { color: var(--meta-text-secondary, #888); }
+.meta-hist__diff { list-style: none; margin: 4px 0 0; padding: 0; }
+.meta-hist__diff-row { display: flex; align-items: baseline; gap: 8px; padding: 2px 0; }
+.meta-hist__diff-row + .meta-hist__diff-row { border-top: 1px dashed var(--meta-border, #eee); }
+.meta-hist__diff-label { flex: 0 0 auto; max-width: 38%; font-weight: 600; color: var(--meta-text-secondary, #475569); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-hist__diff-values { flex: 1 1 auto; display: flex; align-items: baseline; gap: 6px; min-width: 0; }
+.meta-hist__diff-before { color: #94a3b8; text-decoration: line-through; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 45%; }
+.meta-hist__diff-arrow { flex: 0 0 auto; color: #cbd5e1; }
+.meta-hist__diff-after { color: var(--meta-text, #0f172a); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.meta-hist__diff-op { flex: 0 0 auto; font-style: italic; color: var(--meta-text-secondary, #888); }
+.meta-hist__diff-masked { color: var(--meta-text-secondary, #888); font-style: italic; }
 .meta-hist__error { color: var(--meta-danger, #c0392b); margin: 0 0 8px; }
 .meta-hist__hint { color: var(--meta-text-secondary, #888); padding: 12px 0; }
 </style>

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -55,6 +55,8 @@ export type MetaRecordLabelKey =
   | 'record.batchReasonUnavailable' | 'record.batchReasonVersionUnavailable' | 'record.batchReasonUnsupported'
   | 'record.batchReasonSnapshotUnavailable' | 'record.batchReasonSchemaDrift' | 'record.batchReasonNoChange'
   | 'record.batchReasonDenied' | 'record.batchReasonConflict' | 'record.batchReasonForbidden' | 'record.batchReasonError'
+  // --- Global History Center inline per-field diff (read-only detail expansion) ---
+  | 'record.historyDiffMasked'
   // --- T9-R4 config-history view ---
   | 'record.configHistoryTitle' | 'record.configHistoryClose' | 'record.configHistoryFilterAll'
   | 'record.configHistoryEntityField' | 'record.configHistoryEntityView' | 'record.configHistoryEntityPermission'
@@ -138,6 +140,12 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.restorePreviewLoading': { en: 'Loading preview…', zh: '正在加载预览…' },
   'record.restorePreviewSet': { en: 'set', zh: '设为' },
   'record.restorePreviewUnset': { en: 'clear', zh: '清空' },
+  // Global History Center inline diff: a changed field whose value is hidden on BOTH sides (LOCK-3
+  // field-level permission mask) — reused for both the before and after slot of a masked row. Distinct
+  // from a legitimate set/clear (record.restorePreviewSet / record.restorePreviewUnset, reused below),
+  // which are one-sided absences the FE can tell apart from a mask (see changeFieldDiffs in
+  // HistoryCenterModal.vue).
+  'record.historyDiffMasked': { en: 'Masked', zh: '已脱敏' },
   // BS-4 batch restore
   'record.batchRestoreTitle': { en: 'Batch restore', zh: '批量恢复' },
   'record.batchRestoreRevertOriginal': { en: 'Revert selected records to their original version', zh: '将所选记录恢复到初始版本' },

--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Global History Center — inline masked per-field diff in the expandable batch detail.
+ *
+ * SCOPE: the batch-detail wire payload (`HistoryBatchDetail.changes[]`, see
+ * apps/web/src/multitable/types.ts `HistoryChange` and
+ * packages/core-backend/src/multitable/history-projection.ts `loadHistoryBatchDetail`) already carries
+ * `changedFieldIds` plus permission-masked `before`/`after` objects keyed by field id (LOCK-3: fields the
+ * actor cannot read are dropped from `changedFieldIds` AND from `before`/`after` by the SAME allow-set —
+ * see `filterDataByAllowedFields`). This spec locks the FE rendering of that payload as an inline
+ * before→after diff, entirely from data already on the wire (no extra request).
+ *
+ * Shape rule under test (HistoryCenterModal.vue `changeFieldDiffs`):
+ *  - field id present as an own key on BOTH `before` and `after`  → normal diff (before struck through,
+ *    arrow, after)
+ *  - present only on `after`  → "set" (no prior value — e.g. newly populated)
+ *  - present only on `before` → "cleared" (value emptied)
+ *  - present on NEITHER (yet still listed in `changedFieldIds`)   → masked placeholder (LOCK-3 hid the
+ *    value on both sides while still reporting that the field changed)
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import HistoryCenterModal from '../src/multitable/components/HistoryCenterModal.vue'
+import type { HistoryBatchDetail, HistoryBatchSummary } from '../src/multitable/types'
+
+const { mockListHistoryEvents, mockGetHistoryBatch } = vi.hoisted(() => ({
+  mockListHistoryEvents: vi.fn(),
+  mockGetHistoryBatch: vi.fn(),
+}))
+
+vi.mock('../src/multitable/api/client', () => ({
+  multitableClient: {
+    listHistoryEvents: mockListHistoryEvents,
+    getHistoryBatch: mockGetHistoryBatch,
+  },
+}))
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function batch(over: Partial<HistoryBatchSummary> = {}): HistoryBatchSummary {
+  return {
+    batchId: 'batch_1', sheetId: 'sheet_1', actorId: 'user_1', actorName: null, source: 'rest',
+    action: 'update', createdAt: new Date().toISOString(), visibleAffectedRecordCount: 1,
+    visibleAffectedFieldCount: 1, provenanceQuality: 'stamped', ...over,
+  }
+}
+
+function mountModal(fields?: Array<{ id: string; name: string }>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp(HistoryCenterModal, { open: true, baseId: 'base_1', ...(fields ? { fields } : {}) })
+  app.mount(container)
+  return { app, container }
+}
+
+describe('HistoryCenterModal — inline masked per-field diff (detail expansion)', () => {
+  it('(a) renders a before→after diff row for a normally-visible changed field', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    const detail: HistoryBatchDetail = {
+      batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 1,
+      changes: [{
+        sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+        changedFieldIds: ['fld_name'],
+        before: { fld_name: 'Old Name' },
+        after: { fld_name: 'New Name' },
+      }],
+    }
+    mockGetHistoryBatch.mockResolvedValue(detail)
+    const { app, container } = mountModal([{ id: 'fld_name', name: 'Name' }])
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const rows = container.querySelectorAll<HTMLElement>('[data-test="hist-diff-row"]')
+      expect(rows.length).toBe(1)
+      expect(rows[0].querySelector('.meta-hist__diff-label')?.textContent).toContain('Name')
+      expect(rows[0].querySelector('.meta-hist__diff-before')?.textContent).toContain('Old Name')
+      expect(rows[0].querySelector('.meta-hist__diff-arrow')).not.toBeNull()
+      expect(rows[0].querySelector('.meta-hist__diff-after')?.textContent).toContain('New Name')
+      // masked-op elements must NOT appear on a fully-visible row
+      expect(rows[0].querySelector('[data-test="hist-diff-masked"]')).toBeNull()
+      expect(rows[0].querySelector('[data-test="hist-diff-op"]')).toBeNull()
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('(b) a field changed but hidden on BOTH sides (LOCK-3) renders the masked placeholder, never fetches more', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    const detail: HistoryBatchDetail = {
+      batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 1,
+      changes: [{
+        sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+        changedFieldIds: ['fld_secret'],
+        // Both sides are present-but-empty objects: filterDataByAllowedFields' shape for "the actor may
+        // read OTHER fields in this batch, but not this one" — the field id survives in changedFieldIds
+        // (the count/id is metadata) while its value is dropped from both snapshots.
+        before: {},
+        after: {},
+      }],
+    }
+    mockGetHistoryBatch.mockResolvedValue(detail)
+    const { app, container } = mountModal([{ id: 'fld_secret', name: 'Secret' }])
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const callsAfterOpen = mockGetHistoryBatch.mock.calls.length
+      const masked = container.querySelector('[data-test="hist-diff-masked"]')
+      expect(masked).not.toBeNull()
+      expect(masked?.textContent).toContain('Masked')
+      // no before/after value spans on a masked row
+      expect(container.querySelector('.meta-hist__diff-before')).toBeNull()
+      expect(container.querySelector('.meta-hist__diff-after')).toBeNull()
+      // never fetches more to resolve the mask
+      expect(mockGetHistoryBatch.mock.calls.length).toBe(callsAfterOpen)
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('(c) set (no prior value) and cleared (emptied) shapes render distinctly from a normal diff', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    const detail: HistoryBatchDetail = {
+      batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 2,
+      changes: [{
+        sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 3,
+        changedFieldIds: ['fld_new', 'fld_gone'],
+        // fld_new: absent from `before`, present in `after` → "set" (no prior value).
+        // fld_gone: present in `before`, absent from `after` → "cleared" (value emptied).
+        before: { fld_gone: 'Was Set' },
+        after: { fld_new: 'Hello' },
+      }],
+    }
+    mockGetHistoryBatch.mockResolvedValue(detail)
+    const { app, container } = mountModal([
+      { id: 'fld_new', name: 'New Field' },
+      { id: 'fld_gone', name: 'Gone Field' },
+    ])
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const rows = [...container.querySelectorAll<HTMLElement>('[data-test="hist-diff-row"]')]
+      expect(rows.length).toBe(2)
+
+      const setRow = rows.find((r) => r.querySelector('.meta-hist__diff-label')?.textContent?.includes('New Field'))!
+      expect(setRow.querySelector('.meta-hist__diff-before')).toBeNull() // no prior value shown
+      expect(setRow.querySelector('[data-test="hist-diff-op"]')?.textContent).toBe('set')
+      expect(setRow.querySelector('.meta-hist__diff-after')?.textContent).toContain('Hello')
+
+      const clearedRow = rows.find((r) => r.querySelector('.meta-hist__diff-label')?.textContent?.includes('Gone Field'))!
+      expect(clearedRow.querySelector('.meta-hist__diff-after')).toBeNull() // no new value shown
+      expect(clearedRow.querySelector('[data-test="hist-diff-op"]')?.textContent).toBe('clear')
+      expect(clearedRow.querySelector('.meta-hist__diff-before')?.textContent).toContain('Was Set')
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('(d) the existing changed-field-count summary still renders correctly alongside the new diff rows', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch({ visibleAffectedFieldCount: 2 })], total: 1, nextCursor: null, searchTruncated: false })
+    const detail: HistoryBatchDetail = {
+      batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 2,
+      changes: [{
+        sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+        changedFieldIds: ['fld_a', 'fld_b'],
+        before: { fld_a: 1, fld_b: 2 },
+        after: { fld_a: 10, fld_b: 20 },
+      }],
+    }
+    mockGetHistoryBatch.mockResolvedValue(detail)
+    const { app, container } = mountModal([{ id: 'fld_a', name: 'A' }, { id: 'fld_b', name: 'B' }])
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const fieldsSummary = container.querySelector('.meta-hist__change-fields')
+      expect(fieldsSummary?.textContent).toContain('2')
+      expect(fieldsSummary?.textContent).toContain('field')
+      const rows = container.querySelectorAll<HTMLElement>('[data-test="hist-diff-row"]')
+      expect(rows.length).toBe(2)
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('a field id not present in the `fields` prop falls back to the raw field id (no crash, no fetch)', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    const detail: HistoryBatchDetail = {
+      batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 1,
+      changes: [{
+        sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+        changedFieldIds: ['fld_unknown'],
+        before: { fld_unknown: 'a' },
+        after: { fld_unknown: 'b' },
+      }],
+    }
+    mockGetHistoryBatch.mockResolvedValue(detail)
+    const { app, container } = mountModal() // no `fields` prop at all
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const label = container.querySelector('.meta-hist__diff-label')
+      expect(label?.textContent).toContain('fld_unknown')
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  // loadHistoryBatchDetail (packages/core-backend/src/multitable/history-projection.ts, ~line 560) currently
+  // ALWAYS sends `before: null` for every change — "T1b: before/after diff hydration is a detail
+  // refinement" is not yet implemented server-side; `after` is the permission-masked snapshot. This test
+  // pins the FE against TODAY's real wire shape (not just a hypothetical future one): a wholly-null
+  // `before` must render every field as "set" (never crash, never re-fetch), not as a false "masked" or
+  // a false empty-string "before" value.
+  it('matches the CURRENT real backend shape (`before` wholly null) — renders every field as "set"', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    const detail: HistoryBatchDetail = {
+      batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 1,
+      changes: [{
+        sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+        changedFieldIds: ['fld_name'],
+        before: null, // real current wire value, always
+        after: { fld_name: 'New Name' },
+      }],
+    }
+    mockGetHistoryBatch.mockResolvedValue(detail)
+    const { app, container } = mountModal([{ id: 'fld_name', name: 'Name' }])
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const callsAfterOpen = mockGetHistoryBatch.mock.calls.length
+      const row = container.querySelector('[data-test="hist-diff-row"]')!
+      expect(row.querySelector('.meta-hist__diff-before')).toBeNull()
+      expect(row.querySelector('[data-test="hist-diff-op"]')?.textContent).toBe('set')
+      expect(row.querySelector('.meta-hist__diff-after')?.textContent).toContain('New Name')
+      expect(mockGetHistoryBatch.mock.calls.length).toBe(callsAfterOpen) // no extra fetch
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+})


### PR DESCRIPTION
Implements the one non-gated optional product item from the verified-state-map (§4b, #3542): render the already-carried masked per-field values as an inline diff in \`HistoryCenterModal\`'s expandable batch detail, instead of only a changed-field count.

## Behavior
Per changed field id (driven strictly by \`changedFieldIds\`, itself post-mask — this code never widens the set):
- present both sides → before → after diff row
- after-only → *set* badge + value (reuses \`record.restorePreviewSet\`)
- before-only → value → *clear* badge (reuses \`record.restorePreviewUnset\`)
- neither side → masked placeholder (new key \`record.historyDiffMasked\`, en/zh)

**Read-only, display-only**: no API change, no new requests, LOCK-3 masking untouched. Count summary preserved. \`data-test\` selectors on all new elements.

## Wire-shape grounding (anti wire-vs-fixture drift)
Fixtures match the real payload: \`HistoryChange\` (\`types.ts:352\`) ⟷ \`loadHistoryBatchDetail\` (\`history-projection.ts:~552\`) — which today sets \`before: null\` unconditionally (T1b hydration is server-side future work), so a dedicated spec covers exactly that real shape (everything renders as *set*). Full before→after rows light up automatically once T1b hydrates \`before\`; the masked shape is a defensive path documented in code (current backend drops masked ids from \`changedFieldIds\` itself).

## i18n
One new key in \`meta-record-labels\` (the module this component already draws from); two existing keys reused — no helper redeclaration, no hardcoded strings.

## Verify
- New spec file \`multitable-history-center-inline-diff.spec.ts\` (6 specs: normal/masked/set/cleared shapes, count summary unchanged, unknown-field-id fallback, today's real \`before:null\` backend shape).
- History-center-related suites: **51/51 pass**. \`vue-tsc -b\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)