### PR TITLE
feat(approval): A-1 DingTalk approval-card delivery ledger + typed accessor (one-tap lock §3)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -351,6 +351,7 @@ jobs:
             tests/integration/approval-nofm-threshold.test.ts \
             tests/integration/approval-bulk-reassign.api.test.ts \
             tests/integration/approval-node-signature-policy.api.test.ts \
+            tests/integration/dingtalk-approval-card-deliveries.db.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/src/db/migrations/zzzz20260705120000_create_dingtalk_approval_card_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260705120000_create_dingtalk_approval_card_deliveries.ts
@@ -1,0 +1,53 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * A-1 (one-tap design-lock §3): dedicated ledger binding a DingTalk approval card delivery to its
+ * approval instance. One row = one actionable card sent to one recipient. Callbacks and the mobile
+ * decision page resolve ONLY through this ledger (id → instance_id); payload-supplied instance ids
+ * are never trusted. Deliberately NOT an extension of dingtalk_person_deliveries — that table is
+ * generic notification telemetry with a different lifecycle.
+ *
+ * State machine (enforced by CHECK + the accessor's atomic claim):
+ *   sent → acted | superseded | expired | revoked
+ * `acted_*` audit columns are present exactly when card_state='acted' (CHECK dacd_acted_consistency).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS dingtalk_approval_card_deliveries (
+      id TEXT PRIMARY KEY,
+      instance_id TEXT NOT NULL REFERENCES approval_instances(id) ON DELETE CASCADE,
+      node_key TEXT NOT NULL,
+      recipient_user_id TEXT NOT NULL,
+      recipient_dingtalk_user_id TEXT NOT NULL,
+      delivery_kind TEXT NOT NULL CHECK (delivery_kind IN ('work_notice_action_card', 'interactive_card')),
+      task_id TEXT,
+      card_state TEXT NOT NULL DEFAULT 'sent' CHECK (card_state IN ('sent', 'acted', 'superseded', 'expired', 'revoked')),
+      acted_action TEXT,
+      acted_by TEXT,
+      acted_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT dacd_acted_consistency CHECK (
+        (card_state = 'acted') = (acted_action IS NOT NULL AND acted_by IS NOT NULL AND acted_at IS NOT NULL)
+      )
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dacd_instance
+    ON dingtalk_approval_card_deliveries(instance_id, created_at DESC)
+  `.execute(db)
+
+  // Supersede sweeps + "open card?" checks touch only card_state='sent' rows.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dacd_instance_sent
+    ON dingtalk_approval_card_deliveries(instance_id)
+    WHERE card_state = 'sent'
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_dacd_instance_sent`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_dacd_instance`.execute(db)
+  await sql`DROP TABLE IF EXISTS dingtalk_approval_card_deliveries`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -126,6 +126,7 @@ export interface Database {
   dingtalk_group_destinations: DingTalkGroupDestinationsTable
   dingtalk_group_deliveries: DingTalkGroupDeliveriesTable
   dingtalk_person_deliveries: DingTalkPersonDeliveriesTable
+  dingtalk_approval_card_deliveries: DingTalkApprovalCardDeliveriesTable
 }
 
 export interface SnapshotsTable {
@@ -1531,6 +1532,27 @@ export interface DingTalkGroupDeliveriesTable {
   initiated_by: string | null
   created_at: CreatedAt
   delivered_at: NullableTimestamp
+}
+
+/**
+ * A-1 (one-tap design-lock §3): actionable approval-card delivery ledger. One row = one card sent
+ * to one recipient; `id` doubles as the interactive-card outTrackId (Slice B). Callbacks resolve
+ * instance identity ONLY through this table.
+ */
+export interface DingTalkApprovalCardDeliveriesTable {
+  id: string
+  instance_id: string
+  node_key: string
+  recipient_user_id: string
+  recipient_dingtalk_user_id: string
+  delivery_kind: 'work_notice_action_card' | 'interactive_card'
+  task_id: string | null
+  card_state: 'sent' | 'acted' | 'superseded' | 'expired' | 'revoked'
+  acted_action: string | null
+  acted_by: string | null
+  acted_at: NullableTimestamp
+  created_at: CreatedAt
+  updated_at: CreatedAt
 }
 
 export interface DingTalkPersonDeliveriesTable {

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -1,0 +1,138 @@
+/**
+ * A-1 (one-tap design-lock §3/§4): typed accessor for the `dingtalk_approval_card_deliveries`
+ * ledger — the ONLY legitimate path from a card interaction back to an approval instance.
+ *
+ * Import-side-effect-free (no pool/eventBus/scheduler): callers inject the query function, same
+ * discipline as the multitable permission path. Consumers per lock §8: A-2 (send path) uses
+ * `insert…`; A-4 (card-delivery action endpoint + wrapper) uses `find…` + `claim…Acted` +
+ * `supersede…ForInstance`; Slice B's Stream callback reuses the same primitives.
+ *
+ * The state machine's write side is deliberately narrow:
+ *   - `claim…Acted` is an ATOMIC claim (`WHERE card_state='sent'`) — the idempotency anchor for
+ *     duplicate callbacks / double taps; exactly one claimant wins, everyone else sees `null`
+ *     and re-reads the row for the real terminal state.
+ *   - `supersede…ForInstance` sweeps still-`sent` cards when the instance moves past them.
+ * `expired` / `revoked` transitions get their own primitives when a slice consumes them (no dead
+ * helpers ahead of need).
+ */
+import { randomUUID } from 'crypto'
+
+export const DINGTALK_APPROVAL_CARD_DELIVERY_KINDS = ['work_notice_action_card', 'interactive_card'] as const
+export type DingTalkApprovalCardDeliveryKind = (typeof DINGTALK_APPROVAL_CARD_DELIVERY_KINDS)[number]
+
+export const DINGTALK_APPROVAL_CARD_STATES = ['sent', 'acted', 'superseded', 'expired', 'revoked'] as const
+export type DingTalkApprovalCardState = (typeof DINGTALK_APPROVAL_CARD_STATES)[number]
+
+export interface DingTalkApprovalCardDeliveryRow {
+  id: string
+  instance_id: string
+  node_key: string
+  recipient_user_id: string
+  recipient_dingtalk_user_id: string
+  delivery_kind: DingTalkApprovalCardDeliveryKind
+  task_id: string | null
+  card_state: DingTalkApprovalCardState
+  acted_action: string | null
+  acted_by: string | null
+  acted_at: Date | string | null
+  created_at: Date | string
+  updated_at: Date | string
+}
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+const RETURNING_COLUMNS =
+  'id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, card_state, acted_action, acted_by, acted_at, created_at, updated_at'
+
+export interface InsertDingTalkApprovalCardDeliveryInput {
+  /** Optional caller-supplied id; defaults to a fresh UUID. Doubles as the interactive-card outTrackId (Slice B). */
+  id?: string
+  instanceId: string
+  nodeKey: string
+  recipientUserId: string
+  recipientDingTalkUserId: string
+  deliveryKind: DingTalkApprovalCardDeliveryKind
+  /** asyncsend_v2 task id — recorded after the send call returns (Slice A). */
+  taskId?: string | null
+}
+
+export async function insertDingTalkApprovalCardDelivery(
+  query: QueryFn,
+  input: InsertDingTalkApprovalCardDeliveryInput,
+): Promise<DingTalkApprovalCardDeliveryRow> {
+  const id = input.id && input.id.trim().length > 0 ? input.id.trim() : randomUUID()
+  const result = await query(
+    `INSERT INTO dingtalk_approval_card_deliveries
+       (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING ${RETURNING_COLUMNS}`,
+    [
+      id,
+      input.instanceId,
+      input.nodeKey,
+      input.recipientUserId,
+      input.recipientDingTalkUserId,
+      input.deliveryKind,
+      input.taskId ?? null,
+    ],
+  )
+  return result.rows[0] as DingTalkApprovalCardDeliveryRow
+}
+
+export async function findDingTalkApprovalCardDeliveryById(
+  query: QueryFn,
+  id: string,
+): Promise<DingTalkApprovalCardDeliveryRow | null> {
+  const result = await query(
+    `SELECT ${RETURNING_COLUMNS} FROM dingtalk_approval_card_deliveries WHERE id = $1`,
+    [id],
+  )
+  return (result.rows[0] as DingTalkApprovalCardDeliveryRow | undefined) ?? null
+}
+
+/**
+ * Atomic acted-claim: succeeds for exactly one caller while the card is still `sent`.
+ * Returns the updated row for the winner, `null` for everyone else (duplicate callback, double
+ * tap, or a card already superseded/expired) — losers re-read via `find…ById` to render the
+ * real terminal state.
+ */
+export async function claimDingTalkApprovalCardDeliveryActed(
+  query: QueryFn,
+  id: string,
+  input: { action: string; actedBy: string },
+): Promise<DingTalkApprovalCardDeliveryRow | null> {
+  const result = await query(
+    `UPDATE dingtalk_approval_card_deliveries
+     SET card_state = 'acted', acted_action = $2, acted_by = $3, acted_at = NOW(), updated_at = NOW()
+     WHERE id = $1 AND card_state = 'sent'
+     RETURNING ${RETURNING_COLUMNS}`,
+    [id, input.action, input.actedBy],
+  )
+  return (result.rows[0] as DingTalkApprovalCardDeliveryRow | undefined) ?? null
+}
+
+/**
+ * Marks every still-`sent` card of an instance `superseded` (node advanced past them, or the
+ * instance reached a terminal state). `excludeId` spares the delivery that triggered the
+ * transition (it is claimed `acted` separately). Returns the swept ids.
+ */
+export async function supersedeDingTalkApprovalCardDeliveriesForInstance(
+  query: QueryFn,
+  instanceId: string,
+  options: { excludeId?: string } = {},
+): Promise<string[]> {
+  const params: unknown[] = [instanceId]
+  let excludeClause = ''
+  if (options.excludeId) {
+    params.push(options.excludeId)
+    excludeClause = ' AND id <> $2'
+  }
+  const result = await query(
+    `UPDATE dingtalk_approval_card_deliveries
+     SET card_state = 'superseded', updated_at = NOW()
+     WHERE instance_id = $1 AND card_state = 'sent'${excludeClause}
+     RETURNING id`,
+    params,
+  )
+  return (result.rows as Array<{ id: string }>).map((row) => row.id)
+}

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
@@ -1,0 +1,171 @@
+/**
+ * A-1 (one-tap design-lock §3) — dingtalk_approval_card_deliveries ledger + accessor (real DB).
+ *
+ * Locks the load-bearing properties the P1 review correction demanded:
+ *   - ledger row binds delivery → instance (FK, CASCADE),
+ *   - the acted-claim is ATOMIC on card_state='sent' (idempotency anchor: exactly one winner),
+ *   - supersede sweeps only still-`sent` rows of the instance,
+ *   - the DB CHECKs reject invalid states and acted-audit inconsistencies.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { pool } from '../../src/db/pg'
+import {
+  claimDingTalkApprovalCardDeliveryActed,
+  findDingTalkApprovalCardDeliveryById,
+  insertDingTalkApprovalCardDelivery,
+  supersedeDingTalkApprovalCardDeliveriesForInstance,
+} from '../../src/integrations/dingtalk/approval-card-deliveries'
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => pool.query(sql, params)
+
+const INSTANCE = `apv_dacd_test_${Date.now()}`
+const INSTANCE_CASCADE = `apv_dacd_cascade_${Date.now()}`
+
+describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
+  beforeAll(async () => {
+    await q(`INSERT INTO approval_instances (id, status, current_node_key) VALUES ($1, 'pending', 'approval_1') ON CONFLICT (id) DO NOTHING`, [INSTANCE])
+    await q(`INSERT INTO approval_instances (id, status, current_node_key) VALUES ($1, 'pending', 'approval_1') ON CONFLICT (id) DO NOTHING`, [INSTANCE_CASCADE])
+  })
+
+  afterAll(async () => {
+    await q(`DELETE FROM dingtalk_approval_card_deliveries WHERE instance_id = ANY($1::text[])`, [[INSTANCE, INSTANCE_CASCADE]]).catch(() => {})
+    await q(`DELETE FROM approval_instances WHERE id = ANY($1::text[])`, [[INSTANCE, INSTANCE_CASCADE]]).catch(() => {})
+  })
+
+  it('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('insert → findById round-trip; defaults card_state=sent and generates an id (the outTrackId)', async () => {
+    const row = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_a',
+      recipientDingTalkUserId: 'dd_user_a',
+      deliveryKind: 'work_notice_action_card',
+      taskId: 'task_123',
+    })
+    expect(row.id).toBeTruthy()
+    expect(row.card_state).toBe('sent')
+    expect(row.task_id).toBe('task_123')
+
+    const found = await findDingTalkApprovalCardDeliveryById(q, row.id)
+    expect(found?.instance_id).toBe(INSTANCE)
+    expect(found?.node_key).toBe('approval_1')
+    expect(found?.recipient_dingtalk_user_id).toBe('dd_user_a')
+  })
+
+  it('acted-claim is atomic: exactly one winner, the duplicate sees null and re-reads the terminal state', async () => {
+    const row = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_b',
+      recipientDingTalkUserId: 'dd_user_b',
+      deliveryKind: 'interactive_card',
+    })
+
+    const [first, second] = await Promise.all([
+      claimDingTalkApprovalCardDeliveryActed(q, row.id, { action: 'approve', actedBy: 'user_b' }),
+      claimDingTalkApprovalCardDeliveryActed(q, row.id, { action: 'approve', actedBy: 'user_b' }),
+    ])
+    const winners = [first, second].filter(Boolean)
+    expect(winners).toHaveLength(1) // exactly one claim wins the WHERE card_state='sent' race
+    expect(winners[0]?.card_state).toBe('acted')
+    expect(winners[0]?.acted_action).toBe('approve')
+
+    // the loser re-reads the real terminal state
+    const reread = await findDingTalkApprovalCardDeliveryById(q, row.id)
+    expect(reread?.card_state).toBe('acted')
+    expect(reread?.acted_by).toBe('user_b')
+    expect(reread?.acted_at).toBeTruthy()
+
+    // a third claim after the terminal state is a clean null, not an error
+    expect(await claimDingTalkApprovalCardDeliveryActed(q, row.id, { action: 'reject', actedBy: 'user_x' })).toBeNull()
+  })
+
+  it('supersede sweeps only still-sent rows of the instance and honours excludeId', async () => {
+    const acted = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE_CASCADE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_c',
+      recipientDingTalkUserId: 'dd_user_c',
+      deliveryKind: 'work_notice_action_card',
+    })
+    await claimDingTalkApprovalCardDeliveryActed(q, acted.id, { action: 'approve', actedBy: 'user_c' })
+
+    const keep = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE_CASCADE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_d',
+      recipientDingTalkUserId: 'dd_user_d',
+      deliveryKind: 'work_notice_action_card',
+    })
+    const sweep1 = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE_CASCADE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_e',
+      recipientDingTalkUserId: 'dd_user_e',
+      deliveryKind: 'interactive_card',
+    })
+
+    const swept = await supersedeDingTalkApprovalCardDeliveriesForInstance(q, INSTANCE_CASCADE, { excludeId: keep.id })
+    expect(swept).toEqual([sweep1.id]) // acted row untouched, excluded row spared
+
+    expect((await findDingTalkApprovalCardDeliveryById(q, acted.id))?.card_state).toBe('acted')
+    expect((await findDingTalkApprovalCardDeliveryById(q, keep.id))?.card_state).toBe('sent')
+    expect((await findDingTalkApprovalCardDeliveryById(q, sweep1.id))?.card_state).toBe('superseded')
+
+    // full sweep (no exclude) takes the remaining sent row
+    const sweptAll = await supersedeDingTalkApprovalCardDeliveriesForInstance(q, INSTANCE_CASCADE)
+    expect(sweptAll).toEqual([keep.id])
+  })
+
+  it('DB CHECKs reject invalid delivery_kind / card_state / acted-audit inconsistency; FK rejects unknown instances', async () => {
+    await expect(
+      q(`INSERT INTO dingtalk_approval_card_deliveries (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind)
+         VALUES ('bad_kind', $1, 'n1', 'u', 'dd', 'carrier_pigeon')`, [INSTANCE]),
+    ).rejects.toThrow()
+
+    await expect(
+      q(`INSERT INTO dingtalk_approval_card_deliveries (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, card_state)
+         VALUES ('bad_state', $1, 'n1', 'u', 'dd', 'interactive_card', 'teleported')`, [INSTANCE]),
+    ).rejects.toThrow()
+
+    // acted without audit columns violates dacd_acted_consistency
+    await expect(
+      q(`INSERT INTO dingtalk_approval_card_deliveries (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, card_state)
+         VALUES ('bad_acted', $1, 'n1', 'u', 'dd', 'interactive_card', 'acted')`, [INSTANCE]),
+    ).rejects.toThrow()
+
+    // audit columns without acted state violate the same CHECK from the other side
+    await expect(
+      q(`INSERT INTO dingtalk_approval_card_deliveries (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, acted_action, acted_by, acted_at)
+         VALUES ('bad_audit', $1, 'n1', 'u', 'dd', 'interactive_card', 'approve', 'u', NOW())`, [INSTANCE]),
+    ).rejects.toThrow()
+
+    await expect(
+      insertDingTalkApprovalCardDelivery(q, {
+        instanceId: 'apv_does_not_exist',
+        nodeKey: 'n1',
+        recipientUserId: 'u',
+        recipientDingTalkUserId: 'dd',
+        deliveryKind: 'interactive_card',
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('ON DELETE CASCADE removes ledger rows with their instance', async () => {
+    const doomedInstance = `apv_dacd_doomed_${Date.now()}`
+    await q(`INSERT INTO approval_instances (id, status, current_node_key) VALUES ($1, 'pending', 'approval_1')`, [doomedInstance])
+    const row = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: doomedInstance,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_f',
+      recipientDingTalkUserId: 'dd_user_f',
+      deliveryKind: 'work_notice_action_card',
+    })
+    await q(`DELETE FROM approval_instances WHERE id = $1`, [doomedInstance])
+    expect(await findDingTalkApprovalCardDeliveryById(q, row.id)).toBeNull()
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -57,6 +57,11 @@ export default defineConfig({
       // T3-3 node signaturePolicy declared-inert floor: real HTTP + real DB round-trip.
       // Excluded from the no-DB default and wired into approval real-DB CI so it cannot skip-green.
       'tests/integration/approval-node-signature-policy.api.test.ts',
+      // A-1 DingTalk approval-card delivery ledger (one-tap lock §3): DATABASE_URL-gated
+      // (describeIfDb). Excluded from the no-DB default job so it doesn't skip-green, and wired as
+      // a WHOLE FILE into the `Run approval real-DB integration` step in plugin-tests.yml where it
+      // runs against real Postgres every PR.
+      'tests/integration/dingtalk-approval-card-deliveries.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## Summary

一键处理 design-lock（#3594，已 ratify）checklist 的 **A-1**：专用台账 + 类型化 accessor。

- **迁移** `dingtalk_approval_card_deliveries`：TEXT PK（即 Slice B 的 `outTrackId`）、`instance_id` FK `ON DELETE CASCADE`（沿用 approval_reads/metrics 惯例）、`delivery_kind`/`card_state` CHECK 枚举、`dacd_acted_consistency` CHECK（acted_* 审计列当且仅当 `card_state='acted'`）、instance 索引 + sent 部分索引。
- **Accessor**（import-side-effect-free，query 注入）：`insert` / `findById` / `claimActed` / `supersedeForInstance`。**`claimActed` 是幂等锚点**：`UPDATE … WHERE card_state='sent'` 原子抢占，恰一胜者；败者 re-read 渲染真实终态。`expired`/`revoked` 转移待有消费切片时再加（不留 dead helper）。消费方按锁 §8：A-2 用 insert，A-4 用 find/claim/supersede，Slice B 复用同一套。
- `db/types.ts` 注册。

## 锁定属性（P1 修正的落地面）

台账行绑定 delivery → instance；回调/落地页**只能**经 `id → 台账 → instance_id` 反查——payload 的 instanceId 永不读取（该禁令的端点级 tripwire 按锁随 A-4 落）。

## Verification

- 迁移在本地真库执行成功
- 集成 **6/6**：insert 往返（默认 sent）/ **原子 claim 竞态**（`Promise.all` 双抢恰一胜）/ supersede 只扫 sent 且 honour excludeId / CHECK 矩阵（含 acted-audit 双向）/ FK 拒绝 + CASCADE
- `tsc` 0；**unit 全量 5271 passed / 0 failed**（纯新增，未触任何共享 resolver）

Next: A-2（action_card 发送 + 深链 + 写台账）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)