### PR TITLE
feat(attendance): override-import guard — forced-preview confirm + backup export (G1-G3)

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -12,9 +12,14 @@
 # for the shared AE-3 result-edit callback), attendance-selfservice-dashboard.spec.ts,
 # attendance-caliber-transparency.spec.ts (display-only 口径透明 slice — #3575 design-lock:
 # G1 records-header title, G2 team-availability legend equation, G3 caliber-guide card),
-# and attendance-punch-outcome.spec.ts (punch outcome clarity: 202 pendingApproval /
+# attendance-punch-outcome.spec.ts (punch outcome clarity: 202 pendingApproval /
 # OUTDOOR_NOTE_REQUIRED / LOCATION_RESTRICTED — see
-# docs/development/attendance-punch-outcome-clarity-design-lock-20260705.md). The full
+# docs/development/attendance-punch-outcome-clarity-design-lock-20260705.md), and
+# attendance-import-override-guard.spec.ts (override-import confirm gate: forced-preview
+# submit-disable, in-DOM confirm with rowCount/date-range/user-count lines + generic
+# irreversible warning (never a precise overwrite count), export-backup wire shape, merge
+# one-click, G3 manual-adjustment ledger note — see
+# docs/development/attendance-override-import-guard-design-lock-20260705.md, PR #3597). The full
 # `@metasheet/web` vitest suite still has historical/flaky failures, so wiring the whole
 # suite as a required gate now would be red on arrival. Keep expanding the `vitest run`
 # filter (or move to the full web suite) as more web specs are cleaned up.
@@ -31,6 +36,7 @@ on:
       - 'apps/web/tests/attendance-selfservice-dashboard.spec.ts'
       - 'apps/web/tests/attendance-caliber-transparency.spec.ts'
       - 'apps/web/tests/attendance-punch-outcome.spec.ts'
+      - 'apps/web/tests/attendance-import-override-guard.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
@@ -43,6 +49,7 @@ on:
       - 'apps/web/tests/attendance-selfservice-dashboard.spec.ts'
       - 'apps/web/tests/attendance-caliber-transparency.spec.ts'
       - 'apps/web/tests/attendance-punch-outcome.spec.ts'
+      - 'apps/web/tests/attendance-import-override-guard.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -85,4 +92,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard --reporter=dot

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -18534,15 +18534,39 @@ function closeImportOverrideConfirm(): void {
 
 function confirmImportOverride(): void {
   if (!importOverrideConfirm.confirmChecked) return
+  // [P1 TOCTOU fix] onConfirm funnels into runImport(), which rebuilds the payload from
+  // the LIVE form via buildImportPayload() — so G1 freshness must hold at CONFIRM time,
+  // not only when the modal opened (requestRunImport). If ANYTHING that feeds the payload
+  // was edited while the modal sat open (fingerprint drift ⇒ importOverridePreviewFresh
+  // flips false — this includes flipping the mode selector), refuse to submit: close the
+  // modal, never call runImport(), and require a fresh Preview. Without this re-check,
+  // Preview → open modal → edit form → Confirm would commit a never-previewed payload.
+  if (!importOverridePreviewFresh.value) {
+    closeImportOverrideConfirm()
+    setStatus(appendStatusContext(
+      tr(
+        'Import settings changed after Preview — run Preview again before an override import.',
+        '预览后导入设置已被修改——请重新预览后再执行覆盖导入。',
+      ),
+      importPreviewTimezoneHint.value,
+    ), 'error', {
+      hint: tr('The confirm dialog was closed without importing anything.', '确认弹窗已关闭，本次未执行任何导入。'),
+      action: 'retry-preview-import',
+    })
+    return
+  }
   const cb = importOverrideConfirm.onConfirm
   closeImportOverrideConfirm()
   if (cb) cb()
 }
 
 // Entry point wired to the Import button (replaces a direct @click="runImport"). Merge
-// stays one-click (G2); override snapshots the Preview's resolved scope NOW — same
-// snapshot-not-live-form discipline as requestAnnualAdjust()/requestAnnualAccrualCommit()
-// above — so editing the form while the modal is open cannot change what gets submitted.
+// stays one-click (G2); override snapshots the Preview's resolved scope NOW for the
+// modal's DISPLAY lines (same display-snapshot discipline as requestAnnualAdjust()/
+// requestAnnualAccrualCommit() above). The SUBMITTED payload, however, is rebuilt from
+// the live form inside runImport() — its integrity is enforced by the confirm-time
+// freshness re-check in confirmImportOverride() (a drifted form closes the modal and
+// requires a fresh Preview), not by this snapshot.
 function requestRunImport(): void {
   if (!importModeRequiresConfirm(importMode.value)) {
     void runImport()

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -5905,9 +5905,9 @@
                     <option value="override">{{ tr('override', '覆盖') }}</option>
                     <option value="merge">{{ tr('merge', '合并') }}</option>
                   </select>
-                  <small class="attendance__field-hint">
-                    <code>{{ tr('override', '覆盖') }}</code>: {{ tr('overwrite same user/date.', '覆盖同用户同日期记录。') }}
-                    <code>{{ tr('merge', '合并') }}</code>: {{ tr('keep existing fields when present.', '存在字段时保留已有值。') }}
+                  <small class="attendance__field-hint" data-import-mode-compare-hint>
+                    <code>{{ tr('override', '覆盖') }}</code>: {{ tr('overwrites same user/date rows and cannot be restored via rollback.', '覆盖同用户同日期记录，且无法通过 rollback 恢复。') }}
+                    <code>{{ tr('merge', '合并') }}</code>: {{ tr('keeps existing punches — only fills fields that are missing (non-destructive).', '保留已有打卡记录——仅补充缺失字段（不具破坏性）。') }}
                   </small>
                 </label>
                 <label class="attendance__field" for="attendance-import-profile">
@@ -6081,10 +6081,18 @@
                 <button class="attendance__btn" :disabled="importLoading" @click="previewImport">
                   {{ importLoading ? tr('Working...', '处理中...') : tr('Preview', '预览') }}
                 </button>
-                <button class="attendance__btn attendance__btn--primary" :disabled="importLoading" @click="runImport">
+                <button
+                  class="attendance__btn attendance__btn--primary"
+                  :disabled="importLoading || importOverrideSubmitBlocked"
+                  data-import-run
+                  @click="requestRunImport"
+                >
                   {{ importLoading ? tr('Importing...', '导入中...') : tr('Import', '导入') }}
                 </button>
               </div>
+              <small v-if="importOverrideSubmitBlocked" class="attendance__field-hint" data-import-override-preview-required-hint>
+                {{ tr('override mode requires a fresh Preview of the current file/mode/settings before Import is enabled.', '覆盖模式需要先对当前文件/模式/设置执行一次预览，才能启用导入。') }}
+              </small>
               <div v-if="importPlanVisible" class="attendance__template-version-panel attendance__template-version-panel--full">
                 <div class="attendance__subheading-row">
                   <div>
@@ -6246,6 +6254,44 @@
                     </tr>
                   </tbody>
                 </table>
+              </div>
+              <div v-if="importOverrideConfirm.open" class="attendance__modal" role="dialog" aria-modal="true" data-import-override-confirm>
+                <div class="attendance__modal-body">
+                  <h5>{{ tr('Confirm override import', '确认覆盖导入') }}</h5>
+                  <table class="attendance__table">
+                    <tbody><tr v-for="(line, i) in importOverrideConfirm.lines" :key="i"><th>{{ line.label }}</th><td>{{ line.value }}</td></tr></tbody>
+                  </table>
+                  <p class="attendance__hint" data-import-override-warning>⚠ {{ importOverrideConfirm.warning }}</p>
+                  <label class="attendance__field" data-import-override-extra-confirm>
+                    <input type="checkbox" v-model="importOverrideConfirm.confirmChecked" /> <span>{{ importOverrideConfirm.confirmLabel }}</span>
+                  </label>
+                  <div class="attendance__admin-actions">
+                    <button
+                      class="attendance__btn"
+                      type="button"
+                      :disabled="!importOverrideConfirm.backupTargetUserId || importOverrideConfirm.backupStatus === 'exporting'"
+                      data-import-override-export-backup
+                      @click="() => exportImportOverrideBackup()"
+                    >
+                      {{ tr('Export backup first', '先导出备份') }}
+                    </button>
+                    <span class="attendance__field-hint" data-import-override-backup-status>{{ importOverrideBackupStatusLabel }}</span>
+                  </div>
+                  <small v-if="!importOverrideConfirm.backupTargetUserId" class="attendance__field-hint" data-import-override-backup-hint>
+                    {{ tr('Backup export needs a single target user — set User ID above, or the preview must resolve to exactly one user.', '一键导出备份需要单一目标用户——请在上方填写用户 ID，或预览结果需恰好命中一个用户。') }}
+                  </small>
+                  <div class="attendance__admin-actions">
+                    <button class="attendance__btn" type="button" @click="() => closeImportOverrideConfirm()">{{ tr('Cancel', '取消') }}</button>
+                    <button
+                      class="attendance__btn attendance__btn--primary"
+                      :disabled="!importOverrideConfirm.confirmChecked"
+                      data-import-override-confirm-submit
+                      @click="() => confirmImportOverride()"
+                    >
+                      {{ tr('Confirm', '确认') }}
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -9307,6 +9353,19 @@ import {
 } from './attendance/attendanceCalendarPolicyOverrides'
 import { useAttendanceAdminImportBatches } from './attendance/useAttendanceAdminImportBatches'
 import { normalizeImportPayloadColumns } from './attendance/attendanceImportPayload'
+import {
+  buildImportBackupExportQuery,
+  buildImportOverrideConfirmLines,
+  buildImportOverrideConfirmCheckboxLabel,
+  buildImportOverrideWarningText,
+  buildManualAdjustDeductionLedgerLine,
+  isOverrideSubmitBlocked,
+  resolveImportBackupTargetUserId,
+  summarizeImportPreviewRange,
+  type ImportBackupExportStatus,
+  type ImportOverrideConfirmLine,
+  type ImportPreviewRangeSummary,
+} from './attendance/importOverrideGuard'
 import { resolveMakeupPunchRequestStatusCopy } from './attendance/makeupPunchRequestStatus'
 import {
   buildPunchRetryWithNotePayload,
@@ -18398,6 +18457,143 @@ async function runImport() {
   }
 }
 
+// ===== Override import guard (frontend-only, 2026-07-05 design-lock, posture A) =====
+// See docs/development/attendance-override-import-guard-design-lock-20260705.md (PR #3597,
+// RATIFIED). G1: override submits are gated behind a forced-fresh-Preview + an in-DOM
+// two-step confirm mirroring annualOpsConfirm's shape (kept as its OWN state object here
+// since this one also carries the "export backup first" action, which annualOpsConfirm has
+// no use for). G2 (merge stays one-click) is enforced simply by requestRunImport() never
+// opening this modal for merge mode. G3 (manual-adjustment ledger note) is wired into
+// requestAnnualAdjust() below.
+
+// -- freshness: a captured fingerprint of the fully-resolved payload (mirrors what
+// buildImportPayload() returns) at the moment the last preview task actually completed.
+// Comparing it against the LIVE current draft (importPayloadDraft is a computed, so this
+// re-evaluates on every relevant edit) means ANY change to file/mode/rule-set/profile/
+// user-map/group-sync/timezone/payload text invalidates freshness immediately, with no
+// need to hunt down every individual mutation site across applyImportCsvFile/
+// applyImportProfile/etc. — same reasoning as accrual's
+// `watch(() => [period, asOf], () => dry.value = null)` (~L23007-ish) but expressed as a
+// fingerprint comparison instead of a null-out, since we don't want editing an unrelated
+// field to also blank the visible preview table (only the override submit gate). --
+const importOverridePreviewFreshFingerprint = ref<string | null>(null)
+watch(
+  () => importPreviewTask.value?.status,
+  (status) => {
+    importOverridePreviewFreshFingerprint.value = status === 'completed'
+      ? JSON.stringify(importPayloadDraft.value)
+      : null
+  },
+)
+const importOverridePreviewFresh = computed(() =>
+  importOverridePreviewFreshFingerprint.value !== null
+  && importOverridePreviewFreshFingerprint.value === JSON.stringify(importPayloadDraft.value)
+)
+const importOverrideSubmitBlocked = computed(() => isOverrideSubmitBlocked(importMode.value, importOverridePreviewFresh.value))
+
+interface ImportOverrideConfirmState {
+  open: boolean
+  lines: ImportOverrideConfirmLine[]
+  warning: string
+  confirmLabel: string
+  confirmChecked: boolean
+  backupRange: ImportPreviewRangeSummary
+  backupTargetUserId: string | null
+  backupStatus: ImportBackupExportStatus
+  onConfirm: (() => void) | null
+}
+const importOverrideConfirm = reactive<ImportOverrideConfirmState>({
+  open: false,
+  lines: [],
+  warning: '',
+  confirmLabel: '',
+  confirmChecked: false,
+  backupRange: { from: null, to: null, userIds: [] },
+  backupTargetUserId: null,
+  backupStatus: 'idle',
+  onConfirm: null,
+})
+
+const importOverrideBackupStatusLabel = computed(() => {
+  switch (importOverrideConfirm.backupStatus) {
+    case 'exporting': return tr('Exporting...', '导出中...')
+    case 'exported': return tr('Backup exported', '已导出备份')
+    case 'failed': return tr('Backup export failed', '备份导出失败')
+    default: return tr('Not exported yet', '尚未导出')
+  }
+})
+
+function closeImportOverrideConfirm(): void {
+  importOverrideConfirm.open = false
+  importOverrideConfirm.onConfirm = null
+}
+
+function confirmImportOverride(): void {
+  if (!importOverrideConfirm.confirmChecked) return
+  const cb = importOverrideConfirm.onConfirm
+  closeImportOverrideConfirm()
+  if (cb) cb()
+}
+
+// Entry point wired to the Import button (replaces a direct @click="runImport"). Merge
+// stays one-click (G2); override snapshots the Preview's resolved scope NOW — same
+// snapshot-not-live-form discipline as requestAnnualAdjust()/requestAnnualAccrualCommit()
+// above — so editing the form while the modal is open cannot change what gets submitted.
+function requestRunImport(): void {
+  if (importMode.value !== 'override') {
+    void runImport()
+    return
+  }
+  if (isOverrideSubmitBlocked(importMode.value, importOverridePreviewFresh.value)) return
+  const range = summarizeImportPreviewRange(importPreview.value)
+  importOverrideConfirm.lines = buildImportOverrideConfirmLines({ rowCount: importPreviewTotalRows.value, range }, tr)
+  importOverrideConfirm.warning = buildImportOverrideWarningText(tr)
+  importOverrideConfirm.confirmLabel = buildImportOverrideConfirmCheckboxLabel(tr)
+  importOverrideConfirm.confirmChecked = false
+  importOverrideConfirm.backupRange = range
+  importOverrideConfirm.backupTargetUserId = resolveImportBackupTargetUserId(importForm.userId, range.userIds)
+  importOverrideConfirm.backupStatus = 'idle'
+  importOverrideConfirm.open = true
+  importOverrideConfirm.onConfirm = () => { void runImport() }
+}
+
+// One-click "export backup first" (design-lock §2/§4): calls the EXISTING read-only
+// GET /api/attendance/export route (zero backend changes) scoped to the Preview's
+// resolved date range + a single target user. Does not block/gate the confirm submit —
+// only the checkbox does; this only updates the status indicator (design-lock: "下载与否
+// 不阻塞提交，但按钮点过与否显示状态").
+async function exportImportOverrideBackup(): Promise<void> {
+  const targetUserId = importOverrideConfirm.backupTargetUserId
+  if (!targetUserId) return
+  importOverrideConfirm.backupStatus = 'exporting'
+  try {
+    const queryParams = buildImportBackupExportQuery({
+      orgId: normalizedOrgId() || '',
+      targetUserId,
+      range: importOverrideConfirm.backupRange,
+    })
+    const search = buildQuery(queryParams)
+    const response = await apiFetch(`/api/attendance/export?${search.toString()}`)
+    const text = await response.text()
+    if (!response.ok) {
+      let message = tr('Backup export failed', '备份导出失败')
+      try {
+        message = readErrorMessage(JSON.parse(text), message)
+      } catch {
+        message = text || message
+      }
+      throw new Error(message)
+    }
+    const disposition = response.headers.get('content-disposition')
+    const match = disposition?.match(/filename="?([^";]+)"?/)
+    downloadCsvText(match?.[1] || `attendance-override-backup-${targetUserId}.csv`, text)
+    importOverrideConfirm.backupStatus = 'exported'
+  } catch (error) {
+    importOverrideConfirm.backupStatus = 'failed'
+    setStatus(readErrorMessage(error, tr('Backup export failed', '备份导出失败')), 'error')
+  }
+}
+
 function downloadCsvText(filename: string, csvText: string) {
   const blob = new Blob([csvText], { type: 'text/csv' })
   const url = URL.createObjectURL(blob)
@@ -22893,6 +23089,9 @@ function requestAnnualAdjust(): void {
       ...(preview && preview.user === userId ? [{ label: tr('Remaining (preview)', '剩余(预览)'), value: `${preview.before} → ${preview.after}` }] : []),
       { label: tr('Reason', '原因'), value: reason },
       { label: tr('Idempotency key', '幂等键'), value: annualAdjustIdemKey.value },
+      // G3 (override-import-guard design-lock, 2026-07-05): negative adjustments (deductions)
+      // get an extra irreversibility note — pure copy, no behavior change.
+      ...(delta < 0 ? [buildManualAdjustDeductionLedgerLine(tr)] : []),
     ],
     onConfirm: () => { void submitAnnualAdjust(snapshot) },
   })

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6278,7 +6278,7 @@
                     <span class="attendance__field-hint" data-import-override-backup-status>{{ importOverrideBackupStatusLabel }}</span>
                   </div>
                   <small v-if="!importOverrideConfirm.backupTargetUserId" class="attendance__field-hint" data-import-override-backup-hint>
-                    {{ tr('Backup export needs a single target user — set User ID above, or the preview must resolve to exactly one user.', '一键导出备份需要单一目标用户——请在上方填写用户 ID，或预览结果需恰好命中一个用户。') }}
+                    {{ tr('Backup export needs a single target user — set User ID above, or the preview must resolve to exactly one user (a truncated preview sample never auto-resolves).', '一键导出备份需要单一目标用户——请在上方填写用户 ID，或预览结果需恰好命中一个用户（预览为截断样本时不做自动判定）。') }}
                   </small>
                   <div class="attendance__admin-actions">
                     <button class="attendance__btn" type="button" @click="() => closeImportOverrideConfirm()">{{ tr('Cancel', '取消') }}</button>
@@ -9356,6 +9356,7 @@ import { normalizeImportPayloadColumns } from './attendance/attendanceImportPayl
 import {
   buildImportBackupExportQuery,
   buildImportOverrideConfirmLines,
+  importModeRequiresConfirm,
   buildImportOverrideConfirmCheckboxLabel,
   buildImportOverrideWarningText,
   buildManualAdjustDeductionLedgerLine,
@@ -13580,6 +13581,9 @@ const importPreviewTotalRows = computed(() => {
   if (taskRows > 0) return taskRows
   return importPreviewShownRows.value
 })
+// Review P3-1: the loaded rows can be a truncated sample of the full import (same
+// predicate the shown/total scorecard uses) — the override confirm modal must say so.
+const importPreviewSampleTruncated = computed(() => importPreviewTotalRows.value > importPreviewShownRows.value)
 const importPreviewUserCount = computed(() =>
   new Set(importPreview.value.map(item => item.userId).filter(Boolean)).size
 )
@@ -18540,18 +18544,24 @@ function confirmImportOverride(): void {
 // snapshot-not-live-form discipline as requestAnnualAdjust()/requestAnnualAccrualCommit()
 // above — so editing the form while the modal is open cannot change what gets submitted.
 function requestRunImport(): void {
-  if (importMode.value !== 'override') {
+  if (!importModeRequiresConfirm(importMode.value)) {
     void runImport()
     return
   }
   if (isOverrideSubmitBlocked(importMode.value, importOverridePreviewFresh.value)) return
   const range = summarizeImportPreviewRange(importPreview.value)
-  importOverrideConfirm.lines = buildImportOverrideConfirmLines({ rowCount: importPreviewTotalRows.value, range }, tr)
+  importOverrideConfirm.lines = buildImportOverrideConfirmLines({
+    rowCount: importPreviewTotalRows.value,
+    range,
+    sampleTruncated: importPreviewSampleTruncated.value
+      ? { shown: importPreviewShownRows.value, total: importPreviewTotalRows.value }
+      : null,
+  }, tr)
   importOverrideConfirm.warning = buildImportOverrideWarningText(tr)
   importOverrideConfirm.confirmLabel = buildImportOverrideConfirmCheckboxLabel(tr)
   importOverrideConfirm.confirmChecked = false
   importOverrideConfirm.backupRange = range
-  importOverrideConfirm.backupTargetUserId = resolveImportBackupTargetUserId(importForm.userId, range.userIds)
+  importOverrideConfirm.backupTargetUserId = resolveImportBackupTargetUserId(importForm.userId, range.userIds, importPreviewSampleTruncated.value)
   importOverrideConfirm.backupStatus = 'idle'
   importOverrideConfirm.open = true
   importOverrideConfirm.onConfirm = () => { void runImport() }
@@ -18955,6 +18965,14 @@ async function runStatusAction() {
     if (canResumeImportJobFromStatus.value) {
       await refreshImportAsyncJob({ silent: true })
       await resumeImportAsyncJobPolling()
+      return
+    }
+    // Review P2-1 fix: the retry action must pass the SAME override confirm/preview gate
+    // as the Import button — a direct runImport() here was a gate bypass (e.g. a merge
+    // import fails, the operator switches the selector to override, clicks Retry, and a
+    // never-confirmed override would have committed). Merge keeps its awaited one-click.
+    if (importModeRequiresConfirm(importMode.value)) {
+      requestRunImport()
       return
     }
     await runImport()

--- a/apps/web/src/views/attendance/importOverrideGuard.ts
+++ b/apps/web/src/views/attendance/importOverrideGuard.ts
@@ -1,0 +1,182 @@
+// Override import guard (frontend-only, 2026-07-05 design-lock, posture A — forced
+// preview-first): pure helpers for the override-import confirm gate. AttendanceView.vue
+// wires these into the Import button so overwriting attendance rows always goes through
+// a forced Preview + an explicit, honest, irreversible-warning confirm before `runImport()`
+// fires — for BOTH the sync and async (`/import/commit-async`) commit lanes, since the gate
+// sits before `runImport()` is even called, not inside it.
+//
+// See docs/development/attendance-override-import-guard-design-lock-20260705.md (PR #3597,
+// RATIFIED — posture A; posture B "confirm-modal-only, no forced preview" was rejected).
+//
+// Hard boundaries carried over from the lock (§4):
+//   - Zero backend changes. The "export backup first" action only calls the existing
+//     read-only `GET /api/attendance/export` (single-userId-scoped, `attendance:read`).
+//   - NEVER show a precise overwrite-count N. The confirm only restates the Preview's
+//     already-resolved scope (parsed row count + date range + distinct user count) plus a
+//     generic "cannot be restored via rollback" warning — computing an exact N would need
+//     either a backend change or one export/read call per distinct user, both deferred
+//     (§6).
+//   - merge mode never gates (non-destructive union) and the default import mode is
+//     unchanged (still `override`).
+//
+// Current-state anchors this slice is built against (2026-07-05, re-verified against the
+// checked-out `main` tip, not just the lock's own audit numbers):
+//   - `AttendanceView.vue`: mode selector ~L5902-5911, Import button ~L6084,
+//     `previewImport()` ~L18013, `runImport()` ~L18244 (internally picks sync vs
+//     `/import/commit-async` by row-count threshold — the gate wraps the call, not a
+//     branch inside it), `annualOpsConfirm`/`openAnnualOpsConfirm` ~L7100-7113/~L22760
+//     (the in-DOM two-step-confirm idiom this gate's modal structure mirrors),
+//     `requestAnnualAdjust()` ~L22866 (G3 target), `exportCsv()` ~L20633 (existing
+//     `/api/attendance/export` call site this backup button's query-building mirrors).
+//   - `plugins/plugin-attendance/index.cjs`: `GET /api/attendance/export` ~L41529-41531 —
+//     `targetUserId = query.userId ?? requesterId` (strictly single-user; there is no
+//     "all users in org" mode). A multi-user override import (CSV + user-map) therefore
+//     can only get an honest one-click backup when the Preview resolves to exactly one
+//     distinct user, or the operator has filled in the top-level "User ID" field — see
+//     `resolveImportBackupTargetUserId` below and the PR body for the documented tradeoff.
+
+export type ImportMode = 'override' | 'merge'
+export type TranslateFn = (en: string, zh: string) => string
+
+/** G2: only `override` is destructive (row-level overwrite, not restorable via rollback);
+ *  `merge` stays one-click. */
+export function importModeRequiresConfirm(mode: ImportMode): boolean {
+  return mode === 'override'
+}
+
+/** G1 posture A: mirrors the accrual `:disabled="!annualAccrualDry"` idiom — override
+ *  cannot be submitted without a Preview that is still fresh for the CURRENT payload. */
+export function isOverrideSubmitBlocked(mode: ImportMode, hasFreshPreview: boolean): boolean {
+  return mode === 'override' && !hasFreshPreview
+}
+
+export interface ImportPreviewRangeItem {
+  userId?: string | null
+  workDate?: string | null
+}
+
+export interface ImportPreviewRangeSummary {
+  /** Earliest `workDate` across the currently-loaded preview rows (may be a truncated
+   *  sample, not the full import — this is advisory scope, not a guarantee). */
+  from: string | null
+  to: string | null
+  /** De-duplicated, order-stable list of `userId`s seen in the loaded preview rows. */
+  userIds: string[]
+}
+
+/** Derive a best-effort affected date range + distinct-user set from whatever preview
+ *  rows are currently loaded. This is the Preview's own already-resolved (rule-set /
+ *  timezone / user-map applied) output — the honest, available substitute for a precise
+ *  overwrite count (design-lock §2/§4/§6: computing exact N is out of scope for this
+ *  slice). */
+export function summarizeImportPreviewRange(items: ImportPreviewRangeItem[]): ImportPreviewRangeSummary {
+  let from: string | null = null
+  let to: string | null = null
+  const seenUsers = new Set<string>()
+  const userIds: string[] = []
+  for (const item of items) {
+    const workDate = typeof item.workDate === 'string' ? item.workDate.trim() : ''
+    if (workDate) {
+      if (from === null || workDate < from) from = workDate
+      if (to === null || workDate > to) to = workDate
+    }
+    const userId = typeof item.userId === 'string' ? item.userId.trim() : ''
+    if (userId && !seenUsers.has(userId)) {
+      seenUsers.add(userId)
+      userIds.push(userId)
+    }
+  }
+  return { from, to, userIds }
+}
+
+export interface ImportOverrideConfirmLine {
+  label: string
+  value: string
+}
+
+export interface BuildImportOverrideConfirmLinesInput {
+  /** The Preview's already-resolved parsed-row count (`importPreviewTotalRows` in the
+   *  view) — NOT an overwrite count. */
+  rowCount: number
+  range: ImportPreviewRangeSummary
+}
+
+/** G1 lines: mode + Preview's rowCount + date range / distinct-user set. Deliberately
+ *  never includes an overwrite/existing-row count — design-lock §4 hard boundary. */
+export function buildImportOverrideConfirmLines(
+  input: BuildImportOverrideConfirmLinesInput,
+  tr: TranslateFn,
+): ImportOverrideConfirmLine[] {
+  const { rowCount, range } = input
+  const dateRangeValue = range.from && range.to
+    ? (range.from === range.to ? range.from : `${range.from} ~ ${range.to}`)
+    : tr('unknown (no preview rows loaded)', '未知（无预览行）')
+  return [
+    { label: tr('Mode', '模式'), value: tr('override (overwrite same user/date)', '覆盖（同用户同日期）') },
+    { label: tr('Parsed rows (preview)', '解析行数（预览）'), value: String(rowCount) },
+    { label: tr('Date range (preview)', '日期范围（预览）'), value: dateRangeValue },
+    { label: tr('Distinct users (preview)', '涉及用户数（预览）'), value: String(range.userIds.length) },
+  ]
+}
+
+/** G1 generic, honest irreversible-warning text — never a precise overwrite count. */
+export function buildImportOverrideWarningText(tr: TranslateFn): string {
+  return tr(
+    'Overwritten rows cannot be restored via rollback.',
+    '被覆盖行无法通过 rollback 恢复。',
+  )
+}
+
+/** G1 mandatory-checkbox label (mirrors `annualOpsConfirm.extraConfirmLabel`). */
+export function buildImportOverrideConfirmCheckboxLabel(tr: TranslateFn): string {
+  return tr(
+    'I understand overwritten rows cannot be restored via rollback.',
+    '我已知晓被覆盖行无法通过 rollback 恢复。',
+  )
+}
+
+/** G3: manual (negative-delta) adjustment ledger-irreversibility note, appended to
+ *  `requestAnnualAdjust()`'s `annualOpsConfirm.lines` only when `deltaMinutes < 0`. Pure
+ *  text — no behavior change. */
+export function buildManualAdjustDeductionLedgerLine(tr: TranslateFn): ImportOverrideConfirmLine {
+  return {
+    label: tr('Note', '提示'),
+    value: tr(
+      'The deduction is written to the ledger; restoring it needs a reverse adjustment (it cannot be undone directly).',
+      '扣减将写入台账，需以反向调整回补（不可直接撤销）。',
+    ),
+  }
+}
+
+/** The existing `GET /api/attendance/export` route is strictly single-userId-scoped
+ *  (defaults to the calling admin when `userId` is omitted) — so the one-click backup can
+ *  only target a real user when either the import form names one explicitly, or the
+ *  Preview happens to resolve to exactly one distinct user. Otherwise there is no honest
+ *  single-call target (falling back to "no userId" would silently back up the acting
+ *  admin's own records, not the imported employees' — worse than no backup button at all),
+ *  so callers should disable the backup action instead. */
+export function resolveImportBackupTargetUserId(formUserId: string, previewUserIds: string[]): string | null {
+  const trimmed = formUserId.trim()
+  if (trimmed) return trimmed
+  if (previewUserIds.length === 1) return previewUserIds[0]
+  return null
+}
+
+/** Exact wire query for the backup-export call — kept pure/exported so the shape is
+ *  unit-testable without a network mock (mirrors `exportCsv()`'s `buildQuery({...})`
+ *  usage at ~L20648, scoped to the import's own range/target instead of the Records tab's
+ *  filters). */
+export function buildImportBackupExportQuery(input: {
+  orgId: string
+  targetUserId: string
+  range: ImportPreviewRangeSummary
+}): Record<string, string> {
+  const query: Record<string, string> = { format: 'csv' }
+  if (input.orgId) query.orgId = input.orgId
+  if (input.targetUserId) query.userId = input.targetUserId
+  if (input.range.from) query.from = input.range.from
+  if (input.range.to) query.to = input.range.to
+  return query
+}
+
+export type ImportBackupExportStatus = 'idle' | 'exporting' | 'exported' | 'failed'

--- a/apps/web/src/views/attendance/importOverrideGuard.ts
+++ b/apps/web/src/views/attendance/importOverrideGuard.ts
@@ -99,6 +99,9 @@ export interface BuildImportOverrideConfirmLinesInput {
    *  view) — NOT an overwrite count. */
   rowCount: number
   range: ImportPreviewRangeSummary
+  /** Set when the loaded preview rows are a truncated sample (shown < total): the modal
+   *  must say so, since the date-range/user-count lines are sample-derived (review P3-1). */
+  sampleTruncated?: { shown: number; total: number } | null
 }
 
 /** G1 lines: mode + Preview's rowCount + date range / distinct-user set. Deliberately
@@ -111,12 +114,23 @@ export function buildImportOverrideConfirmLines(
   const dateRangeValue = range.from && range.to
     ? (range.from === range.to ? range.from : `${range.from} ~ ${range.to}`)
     : tr('unknown (no preview rows loaded)', '未知（无预览行）')
-  return [
+  const lines: ImportOverrideConfirmLine[] = [
     { label: tr('Mode', '模式'), value: tr('override (overwrite same user/date)', '覆盖（同用户同日期）') },
     { label: tr('Parsed rows (preview)', '解析行数（预览）'), value: String(rowCount) },
     { label: tr('Date range (preview)', '日期范围（预览）'), value: dateRangeValue },
     { label: tr('Distinct users (preview)', '涉及用户数（预览）'), value: String(range.userIds.length) },
   ]
+  if (input.sampleTruncated) {
+    const { shown, total } = input.sampleTruncated
+    lines.push({
+      label: tr('Sample truncated', '样本已截断'),
+      value: tr(
+        `${shown}/${total} rows loaded — the date-range/user figures above reflect the loaded sample only`,
+        `已加载 ${shown}/${total} 行——上方日期范围/用户数仅基于已加载样本`,
+      ),
+    })
+  }
+  return lines
 }
 
 /** G1 generic, honest irreversible-warning text — never a precise overwrite count. */
@@ -155,10 +169,18 @@ export function buildManualAdjustDeductionLedgerLine(tr: TranslateFn): ImportOve
  *  single-call target (falling back to "no userId" would silently back up the acting
  *  admin's own records, not the imported employees' — worse than no backup button at all),
  *  so callers should disable the backup action instead. */
-export function resolveImportBackupTargetUserId(formUserId: string, previewUserIds: string[]): string | null {
+export function resolveImportBackupTargetUserId(
+  formUserId: string,
+  previewUserIds: string[],
+  sampleTruncated = false,
+): string | null {
   const trimmed = formUserId.trim()
   if (trimmed) return trimmed
-  if (previewUserIds.length === 1) return previewUserIds[0]
+  // Review P3-1: when the loaded preview is a truncated sample, "exactly one distinct
+  // user in the sample" says nothing about the full import — auto-resolving would offer a
+  // confident-looking backup that may cover only part of the affected users. Only an
+  // explicit form userId counts then.
+  if (!sampleTruncated && previewUserIds.length === 1) return previewUserIds[0]
   return null
 }
 

--- a/apps/web/tests/attendance-import-override-guard.spec.ts
+++ b/apps/web/tests/attendance-import-override-guard.spec.ts
@@ -415,6 +415,88 @@ describe('Attendance override-import guard (wired UI)', () => {
     expect(importSection.textContent).toContain('override mode requires a fresh Preview')
   })
 
+  // [P1 TOCTOU golden] The confirm-modal path must ALSO be freshness-gated at CONFIRM
+  // time: runImport() rebuilds the payload from the live form, so editing anything after
+  // the modal opened would otherwise submit a never-previewed payload (the Import-button
+  // disable above only guards modal OPENING, not an already-open modal).
+  it('override: editing the form while the confirm modal is open makes Confirm a no-op that requires a fresh Preview (no commit call)', async () => {
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(baseApiFetchRouter({
+      preview: { items: [{ userId: 'user-1', workDate: '2026-04-04' }], rowCount: 1 },
+      commitImported: 1,
+    }))
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Preview').click()
+    await flushUi(8)
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(6)
+
+    const modal = container!.querySelector('[data-import-override-confirm]')!
+    expect(modal, 'expected the override confirm modal to open').toBeTruthy()
+
+    // Edit a payload-feeding field AFTER the modal is open (the TOCTOU window).
+    setInput(importSection, '#attendance-import-user', 'a-user-never-previewed')
+    await flushUi(2)
+
+    const checkbox = modal.querySelector<HTMLInputElement>('[data-import-override-extra-confirm] input[type="checkbox"]')!
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    modal.querySelector<HTMLButtonElement>('[data-import-override-confirm-submit]')!.click()
+    await flushUi(8)
+
+    // Confirm must NOT have committed the drifted, never-previewed payload…
+    const commitCalled = apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/attendance/import/commit'))
+    expect(commitCalled).toBe(false)
+    // …the modal is closed (stale confirmation context must not linger)…
+    expect(container!.querySelector('[data-import-override-confirm]')).toBeFalsy()
+    // …and the operator is told to re-run Preview.
+    expect(container!.textContent).toContain('Import settings changed after Preview')
+  })
+
+  it('override: flipping the mode selector to merge while the confirm modal is open is also a drifted-confirm no-op', async () => {
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(baseApiFetchRouter({
+      preview: { items: [{ userId: 'user-1', workDate: '2026-04-04' }], rowCount: 1 },
+      commitImported: 1,
+    }))
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Preview').click()
+    await flushUi(8)
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(6)
+
+    const modal = container!.querySelector('[data-import-override-confirm]')!
+    expect(modal, 'expected the override confirm modal to open').toBeTruthy()
+
+    // Mode is part of the payload fingerprint: flipping it mid-modal is drift too —
+    // the confirmed-as-override submission must not silently run as a merge (or any
+    // other un-previewed shape).
+    selectOption(importSection, '#attendance-import-mode', 'merge')
+    await flushUi(2)
+
+    const checkbox = modal.querySelector<HTMLInputElement>('[data-import-override-extra-confirm] input[type="checkbox"]')!
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    modal.querySelector<HTMLButtonElement>('[data-import-override-confirm-submit]')!.click()
+    await flushUi(8)
+
+    const commitCalled = apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/attendance/import/commit'))
+    expect(commitCalled).toBe(false)
+    expect(container!.querySelector('[data-import-override-confirm]')).toBeFalsy()
+  })
+
   it('merge: Import never opens the confirm modal and submits directly, even with no prior Preview', async () => {
     const apiFetchMock = vi.mocked(apiFetch)
     apiFetchMock.mockImplementation(baseApiFetchRouter({ commitImported: 0 }))

--- a/apps/web/tests/attendance-import-override-guard.spec.ts
+++ b/apps/web/tests/attendance-import-override-guard.spec.ts
@@ -133,6 +133,7 @@ interface PreviewFixture { items: Array<{ userId: string; workDate: string }>; r
 function baseApiFetchRouter(overrides: {
   preview?: PreviewFixture
   commitImported?: number
+  commitStatus?: number
   exportText?: string
   exportFilename?: string
 } = {}) {
@@ -149,6 +150,9 @@ function baseApiFetchRouter(overrides: {
       })
     }
     if (url.startsWith('/api/attendance/import/commit')) {
+      if (overrides.commitStatus && overrides.commitStatus >= 400) {
+        return jsonResponse(overrides.commitStatus, { ok: false, error: { code: 'IMPORT_COMMIT_FAILED', message: 'boom' } })
+      }
       return jsonResponse(200, { ok: true, data: { imported: overrides.commitImported ?? 0, meta: {} } })
     }
     if (url.startsWith('/api/attendance/export')) {
@@ -180,7 +184,21 @@ describe('Attendance override-import guard (pure module)', () => {
     ])).toEqual({ from: '2026-04-04', to: '2026-04-06', userIds: ['user-2', 'user-1'] })
   })
 
-  it('buildImportOverrideConfirmLines: exactly 4 lines (mode/rowCount/date-range/user-count) — never a 5th overwrite-count line', () => {
+  it('buildImportOverrideConfirmLines: 4 base lines (mode/rowCount/date-range/user-count) + a sample-truncated line ONLY when flagged — never an overwrite-count line', () => {
+    const truncatedLines = buildImportOverrideConfirmLines(
+      {
+        rowCount: 5,
+        range: { from: '2026-04-04', to: '2026-04-06', userIds: ['a', 'b'] },
+        sampleTruncated: { shown: 2, total: 5 },
+      },
+      tr,
+    )
+    expect(truncatedLines).toHaveLength(5)
+    expect(truncatedLines[4].label).toBe('Sample truncated')
+    expect(truncatedLines[4].value).toContain('2/5 rows loaded')
+    // the truncated line talks about the SAMPLE, never about overwritten/existing rows
+    expect(truncatedLines[4].value).not.toMatch(/overwrit|existing/i)
+
     const lines = buildImportOverrideConfirmLines(
       { rowCount: 5, range: { from: '2026-04-04', to: '2026-04-06', userIds: ['a', 'b'] } },
       tr,
@@ -217,7 +235,10 @@ describe('Attendance override-import guard (pure module)', () => {
     expect(line.value).toContain('cannot be undone directly')
   })
 
-  it('resolveImportBackupTargetUserId: prefers the form userId, falls back to a single distinct preview user, else null', () => {
+  it('resolveImportBackupTargetUserId: form userId wins; single-sample auto-resolve only when NOT truncated (review P3-1)', () => {
+    expect(resolveImportBackupTargetUserId('', ['only-user'], true)).toBe(null) // truncated sample: never auto-resolve
+    expect(resolveImportBackupTargetUserId(' explicit ', ['a', 'b'], true)).toBe('explicit') // explicit form intent still wins
+
     expect(resolveImportBackupTargetUserId('user-1', [])).toBe('user-1')
     expect(resolveImportBackupTargetUserId('  ', ['solo-user'])).toBe('solo-user')
     expect(resolveImportBackupTargetUserId('', ['user-a', 'user-b'])).toBeNull()
@@ -325,6 +346,8 @@ describe('Attendance override-import guard (wired UI)', () => {
       { label: 'Parsed rows (preview)', value: '5' },
       { label: 'Date range (preview)', value: '2026-04-04 ~ 2026-04-06' },
       { label: 'Distinct users (preview)', value: '2' },
+      // rowCount(5) > loaded items(2) → the modal must disclose the truncated sample (P3-1)
+      { label: 'Sample truncated', value: '2/5 rows loaded — the date-range/user figures above reflect the loaded sample only' },
     ])
 
     const warningEl = modal!.querySelector('[data-import-override-warning]')
@@ -506,6 +529,120 @@ describe('Attendance override-import guard (wired UI)', () => {
     const backupBtn = modal.querySelector<HTMLButtonElement>('[data-import-override-export-backup]')!
     expect(backupBtn.disabled).toBe(true)
     expect(modal.querySelector('[data-import-override-backup-hint]')?.textContent).toContain('needs a single target user')
+  })
+
+  it('P2-1 fix: a failed merge import switched to override cannot commit via Retry — the retry action passes the same gate', async () => {
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(baseApiFetchRouter({ commitStatus: 500 }))
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    const modeSelect = importSection.querySelector<HTMLSelectElement>('#attendance-import-mode')!
+    modeSelect.value = 'merge'
+    modeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    // merge is one-click; the commit fails → the status area offers "Retry import"
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(8)
+    const commitCallsAfterMerge = apiFetchMock.mock.calls.filter(([url]) => String(url).startsWith('/api/attendance/import/commit')).length
+    expect(commitCallsAfterMerge).toBe(1)
+    const retryBtn = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(btn => btn.textContent?.trim() === 'Retry import')
+    expect(retryBtn, 'expected the failed import to surface a Retry action').toBeTruthy()
+
+    // operator flips the selector to override, then clicks Retry: the OLD code committed
+    // directly (never-confirmed override submit); the gate must block it instead —
+    // no fresh Preview exists, so no modal, no commit, and the preview-required hint shows.
+    modeSelect.value = 'override'
+    modeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    retryBtn!.click()
+    await flushUi(6)
+
+    const commitCallsAfterRetry = apiFetchMock.mock.calls.filter(([url]) => String(url).startsWith('/api/attendance/import/commit')).length
+    expect(commitCallsAfterRetry).toBe(1) // unchanged — the bypass is closed
+    expect(container!.querySelector('[data-import-override-confirm]')).toBeFalsy()
+    expect(importSection.textContent).toContain('override mode requires a fresh Preview')
+  })
+
+  it('P2-1 fix: a failed override import re-opens the confirm modal on Retry instead of re-committing directly', async () => {
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(baseApiFetchRouter({
+      preview: { items: [{ userId: 'user-1', workDate: '2026-04-04' }], rowCount: 1 },
+      commitStatus: 500,
+    }))
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Preview').click()
+    await flushUi(8)
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(4)
+    const modal = container!.querySelector('[data-import-override-confirm]')!
+    const checkbox = modal.querySelector<HTMLInputElement>('[data-import-override-extra-confirm] input[type="checkbox"]')!
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    modal.querySelector<HTMLButtonElement>('[data-import-override-confirm-submit]')!.click()
+    await flushUi(8)
+
+    const commitCalls = () => apiFetchMock.mock.calls.filter(([url]) => String(url).startsWith('/api/attendance/import/commit')).length
+    expect(commitCalls()).toBe(1) // the confirmed submit failed server-side
+
+    const retryBtn = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(btn => btn.textContent?.trim() === 'Retry import')
+    expect(retryBtn, 'expected the failed import to surface a Retry action').toBeTruthy()
+    retryBtn!.click()
+    await flushUi(6)
+
+    // Security invariant (the whole point of P2-1): Retry must NOT silently re-commit an
+    // override. It routes through requestRunImport(), so the operator faces the gate again —
+    // either the confirm modal re-opens (if the preview is still fresh) or the
+    // preview-required hint (if the failed commit invalidated the payload fingerprint). In
+    // NEITHER case does a commit fire without a fresh, re-confirmed submit.
+    expect(commitCalls()).toBe(1) // no bypass commit
+    const gateSection = findImportSection(container!)
+    const modalReopened = container!.querySelector('[data-import-override-confirm]') !== null
+    const previewGateShown = gateSection.textContent!.includes('override mode requires a fresh Preview')
+    expect(modalReopened || previewGateShown, 'retry must re-present the override gate, never a silent commit').toBe(true)
+  })
+
+  it('P3-1 fix: a truncated preview sample suppresses single-user backup auto-resolution until User ID is explicit', async () => {
+    vi.mocked(apiFetch).mockImplementation(baseApiFetchRouter({
+      // single distinct user in the LOADED sample, but rowCount says there are more rows
+      preview: { items: [{ userId: 'user-1', workDate: '2026-04-04' }], rowCount: 9 },
+    }))
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Preview').click()
+    await flushUi(6)
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(4)
+
+    const modal = container!.querySelector('[data-import-override-confirm]')!
+    expect(modal.textContent).toContain('Sample truncated')
+    const backupBtn = modal.querySelector<HTMLButtonElement>('[data-import-override-export-backup]')!
+    expect(backupBtn.disabled).toBe(true) // sample-derived single user is NOT trusted
+    expect(modal.querySelector('[data-import-override-backup-hint]')?.textContent).toContain('truncated preview sample')
+
+    // explicit operator intent still enables the backup
+    ;(container!.querySelector('[data-import-override-confirm] .attendance__admin-actions button') as HTMLButtonElement).click() // cancel
+    await flushUi(2)
+    setInput(importSection, '#attendance-import-user', 'user-1')
+    findButton(importSection, 'Preview').click()
+    await flushUi(6)
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(4)
+    const modal2 = container!.querySelector('[data-import-override-confirm]')!
+    expect(modal2.querySelector<HTMLButtonElement>('[data-import-override-export-backup]')!.disabled).toBe(false)
   })
 
   it('G2: the mode-selector hint states the override/merge tradeoff (overwrite+non-recoverable vs. non-destructive union)', async () => {

--- a/apps/web/tests/attendance-import-override-guard.spec.ts
+++ b/apps/web/tests/attendance-import-override-guard.spec.ts
@@ -1,0 +1,607 @@
+// Override import guard (frontend-only, 2026-07-05 design-lock, posture A — forced
+// preview-first). See
+// docs/development/attendance-override-import-guard-design-lock-20260705.md (PR #3597,
+// RATIFIED).
+//
+// G1: override submits are gated behind (i) a forced-fresh-Preview (submit disabled
+// without one; file/mode/key-param edits invalidate it), (ii) an in-DOM two-step confirm
+// restating mode + the Preview's rowCount/date-range/distinct-user set + a GENERIC
+// irreversible-rollback warning (deliberately never a precise overwrite count — design-lock
+// §4 hard boundary), a mandatory checkbox, and a one-click "export backup first" action
+// that calls the existing read-only GET /api/attendance/export (zero backend changes).
+// G2: merge mode never gates (non-destructive union) and stays one-click.
+// G3: the manual (negative) balance-adjustment confirm gets an extra ledger-irreversibility
+// line (pure copy).
+//
+// Mirrors the mount/mock harness used by the sibling
+// attendance-import-preview-regression.spec.ts / attendance-import-ops-summary.spec.ts /
+// attendance-admin-regressions.spec.ts (annual ops section) specs.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import { ref } from 'vue'
+import AttendanceView from '../src/views/AttendanceView.vue'
+import { apiFetch } from '../src/utils/api'
+import {
+  buildImportBackupExportQuery,
+  buildImportOverrideConfirmLines,
+  buildImportOverrideConfirmCheckboxLabel,
+  buildImportOverrideWarningText,
+  buildManualAdjustDeductionLedgerLine,
+  isOverrideSubmitBlocked,
+  resolveImportBackupTargetUserId,
+  summarizeImportPreviewRange,
+} from '../src/views/attendance/importOverrideGuard'
+
+vi.mock('../src/composables/usePlugins', () => ({
+  usePlugins: () => ({
+    plugins: ref([
+      {
+        name: 'plugin-attendance',
+        status: 'active',
+      },
+    ]),
+    views: ref([]),
+    navItems: ref([]),
+    loading: ref(false),
+    error: ref(null),
+    fetchPlugins: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+function jsonResponse(status: number, payload: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+    blob: async () => new Blob([JSON.stringify(payload)], { type: 'application/json' }),
+  } as unknown as Response
+}
+
+function textResponse(status: number, text: string, headers: Record<string, string> = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    json: async () => JSON.parse(text),
+    text: async () => text,
+    blob: async () => new Blob([text], { type: headers['Content-Type'] || 'text/plain' }),
+  } as unknown as Response
+}
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    candidate => candidate.textContent?.trim() === label
+  )
+  expect(button, `expected button "${label}"`).toBeTruthy()
+  return button as HTMLButtonElement
+}
+
+function findImportSection(container: HTMLElement): HTMLElement {
+  const heading = Array.from(container.querySelectorAll('h4')).find(
+    candidate => candidate.textContent?.trim() === 'Import (DingTalk / Manual)'
+  )
+  expect(heading, 'expected import section heading').toBeTruthy()
+  const section = heading!.closest('.attendance__admin-section')
+  expect(section, 'expected import section container').toBeTruthy()
+  return section as HTMLElement
+}
+
+function setInput(container: HTMLElement, selector: string, value: string): void {
+  const input = container.querySelector<HTMLInputElement>(selector)
+  expect(input, `expected input ${selector}`).toBeTruthy()
+  input!.value = value
+  input!.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+function selectOption(container: HTMLElement, selector: string, value: string): void {
+  const select = container.querySelector<HTMLSelectElement>(selector)
+  expect(select, `expected select ${selector}`).toBeTruthy()
+  select!.value = value
+  select!.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+/** `orgId` is only rendered in the DOM for `mode: 'overview' | 'reports'` (the filters bar
+ *  is `v-if="showOverview || showReports"`) — in `mode: 'admin'` it must be set directly via
+ *  the exposed setup state, mirroring attendance-import-ops-summary.spec.ts's helper. */
+function assignSetupState(target: Record<string, any>, key: string, next: unknown): void {
+  const current = target[key]
+  if (current && typeof current === 'object' && 'value' in current) {
+    current.value = next
+    return
+  }
+  target[key] = next
+}
+
+interface PreviewFixture { items: Array<{ userId: string; workDate: string }>; rowCount: number }
+
+/** Shared route table: prepare (commit token) + preview + commit + export + a generic
+ *  fallback for every other background call the mounted view makes (settings, rule sets,
+ *  batches, etc.) — same fallback shape used by the sibling import spec files. */
+function baseApiFetchRouter(overrides: {
+  preview?: PreviewFixture
+  commitImported?: number
+  exportText?: string
+  exportFilename?: string
+} = {}) {
+  return async (path: string, init?: RequestInit): Promise<Response> => {
+    const url = String(path)
+    if (url.startsWith('/api/attendance/import/prepare')) {
+      return jsonResponse(200, { ok: true, data: { commitToken: 'token-1', expiresAt: '2099-01-01T00:00:00.000Z' } })
+    }
+    if (url.startsWith('/api/attendance/import/preview')) {
+      const preview = overrides.preview ?? { items: [], rowCount: 0 }
+      return jsonResponse(200, {
+        ok: true,
+        data: { items: preview.items, csvWarnings: [], groupWarnings: [], rowCount: preview.rowCount },
+      })
+    }
+    if (url.startsWith('/api/attendance/import/commit')) {
+      return jsonResponse(200, { ok: true, data: { imported: overrides.commitImported ?? 0, meta: {} } })
+    }
+    if (url.startsWith('/api/attendance/export')) {
+      return textResponse(200, overrides.exportText ?? 'work_date,user_id\n2026-04-04,user-1\n', {
+        'Content-Type': 'text/csv',
+        'Content-Disposition': `attachment; filename="${overrides.exportFilename ?? 'attendance-override-backup.csv'}"`,
+      })
+    }
+    return jsonResponse(200, { ok: true, data: { items: [], summary: null } })
+  }
+}
+
+describe('Attendance override-import guard (pure module)', () => {
+  const tr = (en: string, _zh: string) => en
+
+  it('importModeRequiresConfirm / isOverrideSubmitBlocked: only override gates, and only without a fresh preview', () => {
+    expect(isOverrideSubmitBlocked('override', false)).toBe(true)
+    expect(isOverrideSubmitBlocked('override', true)).toBe(false)
+    expect(isOverrideSubmitBlocked('merge', false)).toBe(false)
+    expect(isOverrideSubmitBlocked('merge', true)).toBe(false)
+  })
+
+  it('summarizeImportPreviewRange: derives min/max workDate and a de-duplicated, order-stable user list', () => {
+    expect(summarizeImportPreviewRange([])).toEqual({ from: null, to: null, userIds: [] })
+    expect(summarizeImportPreviewRange([
+      { userId: 'user-2', workDate: '2026-04-06' },
+      { userId: 'user-1', workDate: '2026-04-04' },
+      { userId: 'user-2', workDate: '2026-04-05' }, // duplicate user, distinct date
+    ])).toEqual({ from: '2026-04-04', to: '2026-04-06', userIds: ['user-2', 'user-1'] })
+  })
+
+  it('buildImportOverrideConfirmLines: exactly 4 lines (mode/rowCount/date-range/user-count) — never a 5th overwrite-count line', () => {
+    const lines = buildImportOverrideConfirmLines(
+      { rowCount: 5, range: { from: '2026-04-04', to: '2026-04-06', userIds: ['a', 'b'] } },
+      tr,
+    )
+    expect(lines).toHaveLength(4)
+    expect(lines.map(l => l.label)).toEqual([
+      'Mode',
+      'Parsed rows (preview)',
+      'Date range (preview)',
+      'Distinct users (preview)',
+    ])
+    expect(lines.find(l => l.label === 'Parsed rows (preview)')?.value).toBe('5')
+    expect(lines.find(l => l.label === 'Date range (preview)')?.value).toBe('2026-04-04 ~ 2026-04-06')
+    expect(lines.find(l => l.label === 'Distinct users (preview)')?.value).toBe('2')
+  })
+
+  it('buildImportOverrideConfirmLines: falls back to an honest "unknown" date range when no preview rows are loaded', () => {
+    const lines = buildImportOverrideConfirmLines({ rowCount: 0, range: { from: null, to: null, userIds: [] } }, tr)
+    expect(lines.find(l => l.label === 'Date range (preview)')?.value).toBe('unknown (no preview rows loaded)')
+  })
+
+  it('the warning + checkbox copy is generic and never contains a digit (no precise overwrite count)', () => {
+    const warning = buildImportOverrideWarningText(tr)
+    const checkboxLabel = buildImportOverrideConfirmCheckboxLabel(tr)
+    expect(warning).toBe('Overwritten rows cannot be restored via rollback.')
+    expect(checkboxLabel).toContain('cannot be restored via rollback')
+    expect(warning).not.toMatch(/\d/)
+    expect(checkboxLabel).not.toMatch(/\d/)
+  })
+
+  it('G3: the manual-adjustment ledger line is pure copy about reverse adjustment, not a new behavior', () => {
+    const line = buildManualAdjustDeductionLedgerLine(tr)
+    expect(line.value).toContain('reverse adjustment')
+    expect(line.value).toContain('cannot be undone directly')
+  })
+
+  it('resolveImportBackupTargetUserId: prefers the form userId, falls back to a single distinct preview user, else null', () => {
+    expect(resolveImportBackupTargetUserId('user-1', [])).toBe('user-1')
+    expect(resolveImportBackupTargetUserId('  ', ['solo-user'])).toBe('solo-user')
+    expect(resolveImportBackupTargetUserId('', ['user-a', 'user-b'])).toBeNull()
+    expect(resolveImportBackupTargetUserId('', [])).toBeNull()
+  })
+
+  it('buildImportBackupExportQuery: exact wire shape, omitting unset fields', () => {
+    expect(buildImportBackupExportQuery({
+      orgId: 'org-1',
+      targetUserId: 'user-1',
+      range: { from: '2026-04-04', to: '2026-04-05', userIds: [] },
+    })).toEqual({ format: 'csv', orgId: 'org-1', userId: 'user-1', from: '2026-04-04', to: '2026-04-05' })
+
+    expect(buildImportBackupExportQuery({
+      orgId: '',
+      targetUserId: 'user-1',
+      range: { from: null, to: null, userIds: [] },
+    })).toEqual({ format: 'csv', userId: 'user-1' })
+  })
+})
+
+describe('Attendance override-import guard (wired UI)', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+  let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.setItem('metasheet_locale', 'en')
+    vi.mocked(apiFetch).mockImplementation(baseApiFetchRouter())
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    if (originalScrollIntoView) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: originalScrollIntoView,
+      })
+    }
+    app = null
+    container = null
+  })
+
+  it('override: Import stays disabled until a fresh Preview completes, then enables', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    const importBtn = importSection.querySelector<HTMLButtonElement>('[data-import-run]')!
+    expect(importBtn.disabled).toBe(true)
+    expect(importSection.textContent).toContain('override mode requires a fresh Preview')
+
+    vi.mocked(apiFetch).mockImplementation(baseApiFetchRouter({
+      preview: { items: [{ userId: 'user-1', workDate: '2026-04-04' }], rowCount: 1 },
+    }))
+    findButton(importSection, 'Preview').click()
+    await flushUi(6)
+
+    expect(importBtn.disabled).toBe(false)
+    expect(importSection.textContent).not.toContain('override mode requires a fresh Preview')
+  })
+
+  it('override: clicking Import after a fresh Preview opens the in-DOM confirm with mode/rowCount/date-range/user-count — no precise overwrite count', async () => {
+    vi.mocked(apiFetch).mockImplementation(baseApiFetchRouter({
+      // rowCount (5) intentionally exceeds items.length (2) — simulates a truncated preview
+      // sample; the modal's rowCount line must reflect the backend's resolved total, while
+      // the date-range/user-count lines are honestly derived from just the loaded sample.
+      preview: {
+        items: [
+          { userId: 'user-1', workDate: '2026-04-04' },
+          { userId: 'user-2', workDate: '2026-04-06' },
+        ],
+        rowCount: 5,
+      },
+    }))
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Preview').click()
+    await flushUi(6)
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(4)
+
+    const modal = container!.querySelector('[data-import-override-confirm]')
+    expect(modal, 'expected the override confirm modal to open').toBeTruthy()
+
+    const rows = Array.from(modal!.querySelectorAll('table tr')).map(row => ({
+      label: row.querySelector('th')?.textContent?.trim(),
+      value: row.querySelector('td')?.textContent?.trim(),
+    }))
+    expect(rows).toEqual([
+      { label: 'Mode', value: 'override (overwrite same user/date)' },
+      { label: 'Parsed rows (preview)', value: '5' },
+      { label: 'Date range (preview)', value: '2026-04-04 ~ 2026-04-06' },
+      { label: 'Distinct users (preview)', value: '2' },
+    ])
+
+    const warningEl = modal!.querySelector('[data-import-override-warning]')
+    expect(warningEl?.textContent?.trim()).toBe('⚠ Overwritten rows cannot be restored via rollback.')
+    // The generic warning line itself must never carry a digit (no precise overwrite count).
+    expect(warningEl?.textContent).not.toMatch(/\d/)
+  })
+
+  it('override: confirm-submit stays disabled until the mandatory checkbox is checked, then proceeds to the real import commit', async () => {
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(baseApiFetchRouter({
+      preview: { items: [{ userId: 'user-1', workDate: '2026-04-04' }], rowCount: 1 },
+      commitImported: 1,
+    }))
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Preview').click()
+    await flushUi(8)
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(6)
+
+    const modal = container!.querySelector('[data-import-override-confirm]')!
+    expect(modal, 'expected the override confirm modal to open').toBeTruthy()
+    const submitBtn = modal.querySelector<HTMLButtonElement>('[data-import-override-confirm-submit]')!
+    expect(submitBtn.disabled).toBe(true)
+
+    const checkbox = modal.querySelector<HTMLInputElement>('[data-import-override-extra-confirm] input[type="checkbox"]')!
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    expect(submitBtn.disabled).toBe(false)
+
+    const commitCalledBefore = apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/attendance/import/commit'))
+    expect(commitCalledBefore).toBe(false)
+    submitBtn.click()
+    await flushUi(8)
+
+    const commitCalledAfter = apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/attendance/import/commit'))
+    expect(commitCalledAfter).toBe(true)
+    expect(container!.querySelector('[data-import-override-confirm]')).toBeFalsy() // modal closes after confirm
+  })
+
+  it('override: editing a key import param after a fresh Preview invalidates it again (Import re-disables)', async () => {
+    vi.mocked(apiFetch).mockImplementation(baseApiFetchRouter({
+      preview: { items: [{ userId: 'user-1', workDate: '2026-04-04' }], rowCount: 1 },
+    }))
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Preview').click()
+    await flushUi(6)
+    const importBtn = importSection.querySelector<HTMLButtonElement>('[data-import-run]')!
+    expect(importBtn.disabled).toBe(false)
+
+    setInput(importSection, '#attendance-import-user', 'a-different-user')
+    await flushUi(2)
+
+    expect(importBtn.disabled).toBe(true)
+    expect(importSection.textContent).toContain('override mode requires a fresh Preview')
+  })
+
+  it('merge: Import never opens the confirm modal and submits directly, even with no prior Preview', async () => {
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(baseApiFetchRouter({ commitImported: 0 }))
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    selectOption(importSection, '#attendance-import-mode', 'merge')
+    await flushUi(2)
+
+    const importBtn = importSection.querySelector<HTMLButtonElement>('[data-import-run]')!
+    expect(importBtn.disabled).toBe(false) // merge never requires a preview
+
+    importBtn.click()
+    await flushUi(8)
+
+    expect(container!.querySelector('[data-import-override-confirm]')).toBeFalsy()
+    const commitCalled = apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/attendance/import/commit'))
+    expect(commitCalled).toBe(true)
+  })
+
+  it('export backup: calls the existing GET /api/attendance/export with an exact org/user/date-range query, and updates the status indicator', async () => {
+    // jsdom has no URL.createObjectURL/revokeObjectURL — stub them exactly like the existing
+    // exportCsv()/exportAuditLogsCsv() coverage in attendance-admin-regressions.spec.ts does,
+    // since exportImportOverrideBackup() reuses the same downloadCsvText() helper.
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const createObjectURL = vi.fn(() => 'blob:attendance-override-backup')
+    const revokeObjectURL = vi.fn()
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+
+    try {
+      vi.mocked(apiFetch).mockImplementation(baseApiFetchRouter({
+        preview: {
+          items: [
+            { userId: 'user-1', workDate: '2026-04-04' },
+            { userId: 'user-1', workDate: '2026-04-05' },
+          ],
+          rowCount: 2,
+        },
+      }))
+      app = createApp(AttendanceView, { mode: 'admin' })
+      const vm = app.mount(container!)
+      await flushUi(8)
+
+      const importSection = findImportSection(container!)
+      // orgId's own input only renders in mode: 'overview' | 'reports' — set it directly here.
+      assignSetupState((vm as any).$?.setupState as Record<string, any>, 'orgId', 'org-guard-1')
+      setInput(importSection, '#attendance-import-user', 'user-1')
+      await flushUi(2)
+
+      findButton(importSection, 'Preview').click()
+      await flushUi(6)
+      importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+      await flushUi(4)
+
+      const modal = container!.querySelector('[data-import-override-confirm]')!
+      const backupBtn = modal.querySelector<HTMLButtonElement>('[data-import-override-export-backup]')!
+      expect(backupBtn.disabled).toBe(false) // a single target user (form field) resolved
+      expect(modal.querySelector('[data-import-override-backup-status]')?.textContent).toBe('Not exported yet')
+
+      const apiFetchMock = vi.mocked(apiFetch)
+      backupBtn.click()
+      await flushUi(6)
+
+      const exportCall = apiFetchMock.mock.calls.find(([url]) => String(url).startsWith('/api/attendance/export'))
+      expect(exportCall, 'expected a GET /api/attendance/export call').toBeTruthy()
+      const [calledUrl, calledInit] = exportCall!
+      expect(calledInit).toBeUndefined() // a plain GET, mirrors exportCsv()'s single-argument call
+      const query = new URLSearchParams(String(calledUrl).split('?')[1] ?? '')
+      expect(query.get('format')).toBe('csv')
+      expect(query.get('orgId')).toBe('org-guard-1')
+      expect(query.get('userId')).toBe('user-1')
+      expect(query.get('from')).toBe('2026-04-04')
+      expect(query.get('to')).toBe('2026-04-05')
+
+      expect(modal.querySelector('[data-import-override-backup-status]')?.textContent).toBe('Backup exported')
+      expect(createObjectURL).toHaveBeenCalledTimes(1)
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:attendance-override-backup')
+    } finally {
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  it('export backup: disables the button and explains why when no single target user can be resolved', async () => {
+    vi.mocked(apiFetch).mockImplementation(baseApiFetchRouter({
+      preview: {
+        items: [
+          { userId: 'user-1', workDate: '2026-04-04' },
+          { userId: 'user-2', workDate: '2026-04-05' },
+        ],
+        rowCount: 2,
+      },
+    }))
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    // deliberately leave the top-level "User ID" field blank — two distinct users in the
+    // preview means there is no single honest backup target.
+    findButton(importSection, 'Preview').click()
+    await flushUi(6)
+    importSection.querySelector<HTMLButtonElement>('[data-import-run]')!.click()
+    await flushUi(4)
+
+    const modal = container!.querySelector('[data-import-override-confirm]')!
+    const backupBtn = modal.querySelector<HTMLButtonElement>('[data-import-override-export-backup]')!
+    expect(backupBtn.disabled).toBe(true)
+    expect(modal.querySelector('[data-import-override-backup-hint]')?.textContent).toContain('needs a single target user')
+  })
+
+  it('G2: the mode-selector hint states the override/merge tradeoff (overwrite+non-recoverable vs. non-destructive union)', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const importSection = findImportSection(container!)
+    const hint = importSection.querySelector('[data-import-mode-compare-hint]')
+    expect(hint?.textContent).toContain('cannot be restored via rollback')
+    expect(hint?.textContent).toContain('non-destructive')
+  })
+})
+
+describe('Attendance override-import guard — G3 manual-adjustment ledger note', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+  let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView | undefined
+
+  const enabledPolicySettings = () => jsonResponse(200, {
+    ok: true,
+    data: { annualLeavePolicy: { enabled: true, tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [{ minYears: 1, maxYears: null, days: 5 }], carryover: { enabled: false }, timezone: 'Asia/Shanghai' } },
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.setItem('metasheet_locale', 'en')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    if (originalScrollIntoView) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: originalScrollIntoView,
+      })
+    }
+    app = null
+    container = null
+  })
+
+  async function openAdjustConfirm(deltaMinutes: string) {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-annual-leave-operations"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-annual-leave-operations')!
+    const card = section.querySelector<HTMLElement>('[data-annual-ops-card="adjust"]')!
+    const inputs = card.querySelectorAll<HTMLInputElement>('input')
+    inputs[0].value = 'u1'; inputs[0].dispatchEvent(new Event('input'))
+    inputs[1].value = deltaMinutes; inputs[1].dispatchEvent(new Event('input'))
+    inputs[2].value = 'correction'; inputs[2].dispatchEvent(new Event('input'))
+    await flushUi(2)
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Adjust balance'))!.click()
+    await flushUi(2)
+    return section
+  }
+
+  it('a negative (deduction) adjustment adds the reverse-adjustment ledger note to the confirm lines', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input: string) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/settings')) return enabledPolicySettings()
+      return jsonResponse(200, { ok: true, data: { items: [], summary: null } })
+    })
+
+    const section = await openAdjustConfirm('-120')
+
+    const confirmModal = section.querySelector('[data-annual-ops-confirm]')
+    expect(confirmModal, 'expected the shared annualOpsConfirm modal to open').toBeTruthy()
+    expect(confirmModal!.textContent).toContain('The deduction is written to the ledger')
+    expect(confirmModal!.textContent).toContain('reverse adjustment')
+    expect(confirmModal!.textContent).toContain('cannot be undone directly')
+  })
+
+  it('a positive (grant) adjustment does NOT add the ledger note', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input: string) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/settings')) return enabledPolicySettings()
+      return jsonResponse(200, { ok: true, data: { items: [], summary: null } })
+    })
+
+    const section = await openAdjustConfirm('120')
+
+    const confirmModal = section.querySelector('[data-annual-ops-confirm]')
+    expect(confirmModal, 'expected the shared annualOpsConfirm modal to open').toBeTruthy()
+    expect(confirmModal!.textContent).not.toContain('reverse adjustment')
+    expect(confirmModal!.textContent).not.toContain('written to the ledger')
+  })
+})


### PR DESCRIPTION
## Summary

Implements the override-import guardrail per the RATIFIED design-lock (posture A) at
`docs/development/attendance-override-import-guard-design-lock-20260705.md` on PR #3597
(`claude/attendance-override-import-guard-lock-20260705`, head `6d48d9626`). Frontend-only,
zero backend changes, default import mode unchanged.

- **G1 — override submit gate (posture A, forced Preview-first).** `importMode==='override'`:
  the Import button is disabled until a fresh Preview completes (mirrors the accrual
  dry-run-required idiom — `:disabled="!annualAccrualDry"` + param-change clears the dry-run);
  any edit to file/mode/rule-set/profile/user-map/group-sync/timezone/payload invalidates
  that freshness live. Clicking Import then opens an in-DOM two-step confirm (same shape as
  `annualOpsConfirm`, kept as its own state since it also carries the backup action):
  restates mode + the Preview's `rowCount` + date range + distinct-user count, shows a
  **generic** "cannot be restored via rollback" warning (never a precise overwrite count —
  hard boundary, see below), requires a mandatory checkbox, and offers one-click "export
  backup first" against the existing `GET /api/attendance/export` route. Only after
  confirming does the original `runImport()` fire — the gate sits before the call, so it
  covers both the sync commit and the `/import/commit-async` lane identically.
- **G2 — merge stays one-click.** Non-destructive union never gates; the mode-selector's
  hint text now states the tradeoff explicitly (override = overwrite + non-recoverable;
  merge = non-destructive union).
- **G3 — manual-adjustment ledger note.** A negative (deduction) manual balance adjustment's
  existing `annualOpsConfirm` lines get one extra line: the deduction is written to the
  ledger and needs a reverse adjustment to restore (pure copy, no behavior change).

New pure module `apps/web/src/views/attendance/importOverrideGuard.ts` (a `<script setup>`
block can't export functions for direct unit testing) holds the confirm-gate's logic: line
building, warning/checkbox copy, preview-range summarizing, backup-target resolution, and
the export query shape. `AttendanceView.vue` wires it into the existing import state/handlers
(`requestRunImport()` replaces the old direct `@click="runImport"`).

### Precise-N hard boundary (design-lock §4)

The confirm modal never shows a precise "N existing rows will be overwritten" count. `GET
/api/attendance/export` (re-verified at `plugins/plugin-attendance/index.cjs` ~L41529) is
strictly single-`userId`-scoped (`targetUserId = query.userId ?? requesterId`) with no
"all users in org" mode — computing an exact overwrite count would need either a backend
change or one read call per distinct user, both out of scope here (design-lock §6 Deferred).
The modal only restates the Preview's own already-resolved scope (parsed row count + best-
effort date range/user set over whatever preview rows are currently loaded).

### Backup-export tradeoff (documented per design-lock §4 guidance)

The same single-`userId` scoping means a multi-user override import (CSV + user-map, no
top-level "User ID" set) has no honest single-call backup target. Rather than silently
export the *acting admin's own* range-scoped records (misleading — it would look like a real
backup but cover the wrong person), `resolveImportBackupTargetUserId()` only resolves a
target when the form's "User ID" field is set **or** the loaded Preview resolves to exactly
one distinct user; otherwise the "Export backup first" button is disabled with an inline
explanation. This is the documented tradeoff: date-range-level, single-user backup via the
existing route, not an all-employees-in-one-click backup (which the export route cannot do
without a backend change).

## Test plan

- [x] New `apps/web/tests/attendance-import-override-guard.spec.ts` (18 tests): 8 pure-module
      unit tests (line/warning/checkbox copy, range summarizing, backup-target/query
      resolution — including an explicit "never contains a digit" assertion on the warning
      text) + 10 mounted-component integration tests (override disabled-without-preview →
      enabled-after-preview, confirm modal opens with exact 4-line contents and no 5th
      overwrite-count line, confirm-submit gated on the checkbox and proceeds to the real
      `/import/commit` call, param-edit invalidates a fresh preview, merge one-click with no
      modal, exact `GET /api/attendance/export` wire-shape assertion (org/user/date-range
      query, parsed via `URLSearchParams`) + backup-disabled-when-ambiguous case, G2 hint
      copy, G3 ledger-note present-for-negative/absent-for-positive).
- [x] Wired into `attendance-web-guard` (both `pull_request`/`push` path-filter lists + the
      `vitest run` filter argument).
- [x] Local real run: `pnpm install --prefer-offline` → new spec alone (18/18) → full guard
      set `attendance-admin-regressions attendance-admin-anchor-nav
      AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard
      attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard`
      (220/220) → adjacent import specs (`attendance-import-preview-regression`,
      `attendance-import-ops-summary`, `AttendanceImportBatchesSection`,
      `AttendanceImportWorkflowSection`, `useAttendanceAdminImportBatches`,
      `useAttendanceAdminImportWorkflow`, 39/39) → `vue-tsc -b` (exit 0).
      (`attendance-import-batch-timezone-status.spec.ts` fails both before and after this
      branch — confirmed pre-existing on `origin/main`, unrelated to this change, and not
      part of the attendance-web-guard targeted set.)
- [x] Mutation self-check: committed, then cut the G1 gate (`requestRunImport()` forced to
      call `runImport()` unconditionally) — 4 of the 18 tests (the ones asserting the confirm
      modal actually opens/gates/backs-up) went red as expected; reverted via
      `git checkout --`, full guard set re-verified green (220/220), `vue-tsc -b` re-verified
      (exit 0).

Co-Authored-By: Claude <noreply@anthropic.com>
