### PR TITLE
feat(integration): composition authoring-tier client service calls

### DIFF
--- a/apps/web/src/services/integration/readSourceCompositions.ts
+++ b/apps/web/src/services/integration/readSourceCompositions.ts
@@ -139,11 +139,34 @@ const COMPOSITION_REQUEST_ERROR_CODES: ReadonlySet<string> = new Set([
   'FORBIDDEN',
 ])
 
+// Authoring-tier (save/approve/retire/audit) validation-error surface: the C-R1 validator's
+// details.errors triples (save-time CONFIG_INVALID). Clamped with the SAME three patterns as the
+// run-route planErrors triples above — a triple failing ANY clamp is dropped whole (fail-closed),
+// mirroring #3588's planErrors clamp discipline.
+export interface ReadSourceCompositionFieldError {
+  code: string
+  field: string
+  reason: string
+}
+
+function clampCompositionFieldErrors(value: unknown): ReadSourceCompositionFieldError[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((entry) => {
+    if (!isPlainObject(entry)) return []
+    const { code, field, reason } = entry
+    if (typeof code !== 'string' || !COMPOSITION_VALIDATOR_CODE_PATTERN.test(code)) return []
+    if (typeof field !== 'string' || !COMPOSITION_ERROR_FIELD_PATTERN.test(field)) return []
+    if (typeof reason !== 'string' || !COMPOSITION_ERROR_REASON_PATTERN.test(reason)) return []
+    return [{ code, field, reason }]
+  })
+}
+
 export class ReadSourceCompositionApiError extends Error {
   status: number
   code: string
   reason: string
-  constructor(status: number, code: string, reason: string) {
+  fieldErrors: ReadSourceCompositionFieldError[]
+  constructor(status: number, code: string, reason: string, fieldErrors: ReadSourceCompositionFieldError[] = []) {
     // .message is built from the clamped code (+reason) only — the panel renders error.message, so this
     // is the values-free string it shows.
     super(reason ? `${code}: ${reason}` : code)
@@ -151,6 +174,7 @@ export class ReadSourceCompositionApiError extends Error {
     this.status = status
     this.code = code
     this.reason = reason
+    this.fieldErrors = fieldErrors
   }
 }
 
@@ -165,7 +189,7 @@ async function parseCompositionResponse<T>(response: Response): Promise<T> {
     const reason = typeof details.reason === 'string' && COMPOSITION_ERROR_REASON_PATTERN.test(details.reason)
       ? details.reason
       : ''
-    throw new ReadSourceCompositionApiError(response.status, code, reason)
+    throw new ReadSourceCompositionApiError(response.status, code, reason, clampCompositionFieldErrors(details.errors))
   }
   return (isPlainObject(payload) && 'data' in payload ? payload.data : payload) as T
 }
@@ -271,4 +295,178 @@ export async function runReadSourceComposition(
     body: JSON.stringify({ inputs: { key } }),
   })
   return normalizeCompositionRunResult(await parseCompositionResponse<unknown>(response))
+}
+
+// --- authoring-tier service layer (consultant/admin, config-time) ----------
+//
+// Config-time mirrors of the readSourceConfigs.ts save/approve/retire/audit calls — for a future
+// authoring panel over the C-R4-1 composition routes. Read-only line honored: operations is pinned
+// to ['read'] and is never caller-suppliable; step ids / toInput / fromStep are likewise pinned by
+// buildReadSourceCompositionPayload, not by the draft. Values-free line honored: the audit
+// normalizer keeps ONLY the coarse {from,to} status pair from `detail` (never a version number or
+// any other field a response might carry), and the API error surface adds clamped fieldErrors on
+// top of the existing clamped code+reason (never the raw server message).
+
+// Coarse client-side mirrors of the server's isBoundedIdentifier / isBoundedConfigId
+// (read-source-composition-config.cjs). Client hint only — the server re-validates authoritatively.
+const COMPOSITION_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$/
+const COMPOSITION_CONFIG_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/
+const COMPOSITION_SOURCE_TARGET_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$/
+
+// Authoring draft: the v1 two-hop shape reduced to what a form actually edits. Everything else
+// (version, operations, step ids, fromStep, toInput) is fixed by the builder below — never editable.
+export interface ReadSourceCompositionDraft {
+  name: string
+  step1ConfigId: string
+  step2ConfigId: string
+  sourceTarget: string
+}
+
+export interface ReadSourceCompositionStepInput {
+  fromStep: 'step-1'
+  sourceTarget: string
+  toInput: 'key'
+}
+
+export interface ReadSourceCompositionPayload {
+  version: 1
+  name: string
+  operations: ['read']
+  steps: [
+    { id: 'step-1', readSourceConfigId: string },
+    { id: 'step-2', readSourceConfigId: string, input: ReadSourceCompositionStepInput },
+  ]
+}
+
+export function createReadSourceCompositionDraft(): ReadSourceCompositionDraft {
+  return { name: '', step1ConfigId: '', step2ConfigId: '', sourceTarget: '' }
+}
+
+// Pure builder: assembles the EXACT server config shape (read-source-composition-config.cjs v1).
+// version/operations/step ids/toInput/fromStep are pinned constants — a draft can never smuggle an
+// extra field into the payload, since only the four named draft properties are ever read here.
+export function buildReadSourceCompositionPayload(draft: ReadSourceCompositionDraft): ReadSourceCompositionPayload {
+  return {
+    version: 1,
+    name: draft.name.trim(),
+    operations: ['read'],
+    steps: [
+      { id: 'step-1', readSourceConfigId: draft.step1ConfigId.trim() },
+      {
+        id: 'step-2',
+        readSourceConfigId: draft.step2ConfigId.trim(),
+        input: { fromStep: 'step-1', sourceTarget: draft.sourceTarget.trim(), toInput: 'key' },
+      },
+    ],
+  }
+}
+
+// Coarse client-side pre-checks (field-name-keyed messages only; values are never echoed — mirrors
+// validateReadSourceDraft in readSourceConfigs.ts). The server (read-source-composition-config.cjs)
+// stays authoritative; this only gives a future authoring panel instant, values-free feedback.
+export function validateReadSourceCompositionDraft(draft: ReadSourceCompositionDraft): string[] {
+  const problems: string[] = []
+  if (!COMPOSITION_NAME_PATTERN.test(draft.name.trim())) {
+    problems.push('name 必须是合法标识符(字母/数字开头,长度不超过 64)')
+  }
+  const step1Valid = COMPOSITION_CONFIG_ID_PATTERN.test(draft.step1ConfigId.trim())
+  if (!step1Valid) problems.push('step1ConfigId 必须是合法引用标识符(长度不超过 128)')
+  const step2Valid = COMPOSITION_CONFIG_ID_PATTERN.test(draft.step2ConfigId.trim())
+  if (!step2Valid) problems.push('step2ConfigId 必须是合法引用标识符(长度不超过 128)')
+  if (step1Valid && step2Valid && draft.step1ConfigId.trim() === draft.step2ConfigId.trim()) {
+    problems.push('step1ConfigId 与 step2ConfigId 不能相同')
+  }
+  if (!COMPOSITION_SOURCE_TARGET_PATTERN.test(draft.sourceTarget.trim())) {
+    problems.push('sourceTarget 必须是合法标识符(字母/数字开头,长度不超过 64)')
+  }
+  return problems
+}
+
+export interface ReadSourceCompositionSaveResult extends ReadSourceCompositionRow {
+  reused: boolean
+}
+
+export async function saveReadSourceCompositionVersion(
+  draft: ReadSourceCompositionDraft,
+  scope: IntegrationScope,
+): Promise<ReadSourceCompositionSaveResult> {
+  const config = buildReadSourceCompositionPayload(draft)
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-compositions${query}`, {
+    method: 'POST',
+    body: JSON.stringify({ config }),
+  })
+  const data = await parseCompositionResponse<unknown>(response)
+  const row = normalizeCompositionRow(data)
+  return {
+    id: row?.id ?? '',
+    name: row?.name ?? '',
+    version: row?.version ?? 0,
+    status: row?.status ?? 'draft',
+    contentKey: row?.contentKey ?? '',
+    updatedAt: row?.updatedAt ?? null,
+    reused: isPlainObject(data) && data.reused === true,
+  }
+}
+
+export async function approveReadSourceComposition(id: string, scope: IntegrationScope): Promise<ReadSourceCompositionRow | null> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-compositions/${encodeURIComponent(id)}/approve${query}`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+  return normalizeCompositionRow(await parseCompositionResponse<unknown>(response))
+}
+
+export async function retireReadSourceComposition(id: string, scope: IntegrationScope): Promise<ReadSourceCompositionRow | null> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-compositions/${encodeURIComponent(id)}/retire${query}`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+  return normalizeCompositionRow(await parseCompositionResponse<unknown>(response))
+}
+
+// Values-free audit row: action/actor/createdAt are coarse by construction (closed enum / plain
+// string / ISO string); `detail` is clamped to ONLY the {from,to} status-transition pair — a
+// `version` number (present on save_version/reuse_version rows) or any other field the row might
+// carry is dropped, never surfaced.
+export interface ReadSourceCompositionAuditRow {
+  action: 'save_version' | 'reuse_version' | 'status_change'
+  actor: string | null
+  detail: { from?: CompositionStatus; to?: CompositionStatus }
+  createdAt: string | null
+}
+
+const COMPOSITION_STATUS_SET: ReadonlySet<string> = new Set(COMPOSITION_STATUSES)
+
+function clampCompositionAuditDetail(value: unknown): { from?: CompositionStatus; to?: CompositionStatus } {
+  const detail: { from?: CompositionStatus; to?: CompositionStatus } = {}
+  if (!isPlainObject(value)) return detail
+  if (typeof value.from === 'string' && COMPOSITION_STATUS_SET.has(value.from)) {
+    detail.from = value.from as CompositionStatus
+  }
+  if (typeof value.to === 'string' && COMPOSITION_STATUS_SET.has(value.to)) {
+    detail.to = value.to as CompositionStatus
+  }
+  return detail
+}
+
+export async function listReadSourceCompositionAudit(id: string, scope: IntegrationScope): Promise<ReadSourceCompositionAuditRow[]> {
+  const query = buildQuery({ tenantId: scope.tenantId, workspaceId: scope.workspaceId })
+  const response = await apiFetch(`/api/integration/read-source-compositions/${encodeURIComponent(id)}/audit${query}`)
+  const data = await parseCompositionResponse<unknown[]>(response)
+  return (Array.isArray(data) ? data : []).flatMap((row) => {
+    if (!isPlainObject(row)) return []
+    const action = row.action === 'save_version' || row.action === 'reuse_version' || row.action === 'status_change'
+      ? row.action
+      : null
+    if (!action) return []
+    return [{
+      action,
+      actor: typeof row.actor === 'string' ? row.actor : null,
+      detail: clampCompositionAuditDetail(row.detail),
+      createdAt: typeof row.createdAt === 'string' ? row.createdAt : null,
+    }]
+  })
 }

--- a/apps/web/tests/readSourceCompositions.service.spec.ts
+++ b/apps/web/tests/readSourceCompositions.service.spec.ts
@@ -10,6 +10,14 @@ import {
   listReadSourceCompositions,
   runReadSourceComposition,
   normalizeCompositionRunResult,
+  buildReadSourceCompositionPayload,
+  validateReadSourceCompositionDraft,
+  saveReadSourceCompositionVersion,
+  approveReadSourceComposition,
+  retireReadSourceComposition,
+  listReadSourceCompositionAudit,
+  ReadSourceCompositionApiError,
+  type ReadSourceCompositionDraft,
 } from '../src/services/integration/readSourceCompositions'
 
 function jsonResponse(data: unknown, status = 200): Response {
@@ -213,6 +221,208 @@ describe('normalizeCompositionRunResult (values-free allowlist)', () => {
     ])
     const text = JSON.stringify(result)
     for (const leak of ['MAT-001 SECRET', 'MAT-001 the material number', 'MAT_001_SECRET']) {
+      expect(text).not.toContain(leak)
+    }
+  })
+})
+
+// --- authoring-tier service layer (save / approve / retire / audit) --------
+
+const VALID_DRAFT: ReadSourceCompositionDraft = {
+  name: 'material-to-bom',
+  step1ConfigId: 'rsc_material_lookup',
+  step2ConfigId: 'rsc_bom_lookup',
+  sourceTarget: 'itemId',
+}
+
+describe('buildReadSourceCompositionPayload', () => {
+  it('pins version/operations/toInput/step ids — a smuggled extra draft field never reaches the payload', () => {
+    const hostileDraft = {
+      ...VALID_DRAFT,
+      // Fields a hostile/careless caller might attach to the draft object; the builder only ever
+      // reads the four named draft properties, so none of these can ride into the payload.
+      operations: ['write'],
+      version: 99,
+      steps: [{ id: 'evil' }],
+      toInput: 'body',
+    } as unknown as ReadSourceCompositionDraft
+    const payload = buildReadSourceCompositionPayload(hostileDraft)
+    expect(payload).toEqual({
+      version: 1,
+      name: 'material-to-bom',
+      operations: ['read'],
+      steps: [
+        { id: 'step-1', readSourceConfigId: 'rsc_material_lookup' },
+        {
+          id: 'step-2',
+          readSourceConfigId: 'rsc_bom_lookup',
+          input: { fromStep: 'step-1', sourceTarget: 'itemId', toInput: 'key' },
+        },
+      ],
+    })
+  })
+
+  it('trims whitespace-padded draft fields', () => {
+    const payload = buildReadSourceCompositionPayload({
+      name: '  material-to-bom  ',
+      step1ConfigId: '  rsc_a  ',
+      step2ConfigId: '  rsc_b  ',
+      sourceTarget: '  itemId  ',
+    })
+    expect(payload.name).toBe('material-to-bom')
+    expect(payload.steps[0].readSourceConfigId).toBe('rsc_a')
+    expect(payload.steps[1].readSourceConfigId).toBe('rsc_b')
+    expect(payload.steps[1].input.sourceTarget).toBe('itemId')
+  })
+})
+
+describe('validateReadSourceCompositionDraft', () => {
+  it('passes a well-formed draft with zero problems', () => {
+    expect(validateReadSourceCompositionDraft(VALID_DRAFT)).toEqual([])
+  })
+
+  it('catches a bad name without echoing the raw value in any message', () => {
+    const problems = validateReadSourceCompositionDraft({ ...VALID_DRAFT, name: 'has spaces MAT-001 SECRET' })
+    expect(problems.length).toBeGreaterThan(0)
+    expect(problems.join(' ')).not.toContain('MAT-001 SECRET')
+  })
+
+  it('catches duplicate step config ids', () => {
+    const problems = validateReadSourceCompositionDraft({ ...VALID_DRAFT, step2ConfigId: VALID_DRAFT.step1ConfigId })
+    expect(problems).toContain('step1ConfigId 与 step2ConfigId 不能相同')
+  })
+
+  it('catches a secret-shaped overlong value in step/target fields WITHOUT echoing it in any message', () => {
+    const secret = `sk-${'A'.repeat(200)}`
+    const problems = validateReadSourceCompositionDraft({ ...VALID_DRAFT, step1ConfigId: secret, sourceTarget: secret })
+    expect(problems.length).toBeGreaterThan(0)
+    expect(problems.join(' ')).not.toContain(secret)
+  })
+})
+
+describe('saveReadSourceCompositionVersion', () => {
+  it('POSTs exactly { config } (the pinned payload) and reports reused:false on a 201 mint', async () => {
+    let sentBody: Record<string, unknown> | undefined
+    apiFetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+      sentBody = JSON.parse(String(init?.body || '{}'))
+      return jsonResponse(
+        { id: 'rscc_1', name: 'material-to-bom', version: 1, status: 'draft', contentKey: 'ck1', updatedAt: '2026-07-05', reused: false },
+        201,
+      )
+    })
+    const result = await saveReadSourceCompositionVersion(VALID_DRAFT, SCOPE)
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/integration/read-source-compositions?tenantId=default',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(Object.keys(sentBody as object)).toEqual(['config'])
+    expect((sentBody as { config: unknown }).config).toEqual(buildReadSourceCompositionPayload(VALID_DRAFT))
+    expect(result).toEqual({
+      id: 'rscc_1', name: 'material-to-bom', version: 1, status: 'draft', contentKey: 'ck1', updatedAt: '2026-07-05', reused: false,
+    })
+  })
+
+  it('reports reused:true on a 200 content-key hit', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(
+      { id: 'rscc_1', name: 'material-to-bom', version: 1, status: 'draft', contentKey: 'ck1', updatedAt: '2026-07-05', reused: true },
+      200,
+    ))
+    const result = await saveReadSourceCompositionVersion(VALID_DRAFT, SCOPE)
+    expect(result.reused).toBe(true)
+  })
+
+  it('surfaces a 400 CONFIG_INVALID with CLAMPED fieldErrors — a well-formed triple is kept, a triple carrying a business-shaped value in field/reason/code is dropped whole', async () => {
+    apiFetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      error: {
+        code: 'READ_SOURCE_COMPOSITION_CONFIG_INVALID',
+        message: 'composition config is invalid',
+        details: {
+          errors: [
+            { code: 'READ_SOURCE_COMPOSITION_NAME_INVALID', field: 'name', reason: 'invalid_identifier' },
+            // business-value field (space + business token) → dropped whole
+            { code: 'READ_SOURCE_COMPOSITION_STEP_REF_INVALID', field: 'MAT-001 the material number', reason: 'invalid_reference' },
+            // business-value reason (space + business token) → dropped whole
+            { code: 'READ_SOURCE_COMPOSITION_STEP_INVALID', field: 'steps.0.id', reason: 'material MAT-001 SECRET' },
+            // code-SHAPED business value without the required prefix → dropped whole
+            { code: 'MAT_001_SECRET', field: 'steps.0.readSourceConfigId', reason: 'invalid_reference' },
+          ],
+        },
+      },
+    }), { status: 400, headers: { 'Content-Type': 'application/json' } }))
+    const err = await saveReadSourceCompositionVersion(VALID_DRAFT, SCOPE).then(() => null, (e) => e)
+    expect(err).toBeInstanceOf(ReadSourceCompositionApiError)
+    const apiError = err as ReadSourceCompositionApiError
+    expect(apiError.code).toBe('READ_SOURCE_COMPOSITION_CONFIG_INVALID')
+    expect(apiError.fieldErrors).toEqual([
+      { code: 'READ_SOURCE_COMPOSITION_NAME_INVALID', field: 'name', reason: 'invalid_identifier' },
+    ])
+    const text = JSON.stringify({ message: apiError.message, ...apiError })
+    for (const leak of ['MAT-001 the material number', 'MAT-001 SECRET', 'MAT_001_SECRET']) {
+      expect(text).not.toContain(leak)
+    }
+  })
+})
+
+describe('approveReadSourceComposition / retireReadSourceComposition', () => {
+  it('POST to the approve/retire URLs and return the normalized row', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(
+      { id: 'rscc_1', name: 'material-to-bom', version: 1, status: 'approved', contentKey: 'ck1', updatedAt: '2026-07-05' },
+    ))
+    const approved = await approveReadSourceComposition('rscc_1', SCOPE)
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/integration/read-source-compositions/rscc_1/approve?tenantId=default',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(approved?.status).toBe('approved')
+
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(
+      { id: 'rscc_1', name: 'material-to-bom', version: 1, status: 'retired', contentKey: 'ck1', updatedAt: '2026-07-05' },
+    ))
+    const retired = await retireReadSourceComposition('rscc_1', SCOPE)
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/integration/read-source-compositions/rscc_1/retire?tenantId=default',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(retired?.status).toBe('retired')
+  })
+
+  it('throw with a clamped code only on a 409 NOT_APPROVED / STATUS_CONFLICT — the raw message never rides along', async () => {
+    apiFetchMock.mockResolvedValueOnce(errorResponse('READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED', 'not approved yet MAT-001 SECRET', 409))
+    const err1 = await approveReadSourceComposition('rscc_draft', SCOPE).then(() => null, (e) => e)
+    expect((err1 as Error).message).toBe('READ_SOURCE_COMPOSITION_CONFIG_NOT_APPROVED')
+    expect((err1 as Error).message).not.toContain('MAT-001 SECRET')
+
+    apiFetchMock.mockResolvedValueOnce(errorResponse('READ_SOURCE_COMPOSITION_CONFIG_STATUS_CONFLICT', 'status conflict MAT-001 SECRET', 409))
+    const err2 = await retireReadSourceComposition('rscc_1', SCOPE).then(() => null, (e) => e)
+    expect((err2 as Error).message).toBe('READ_SOURCE_COMPOSITION_CONFIG_STATUS_CONFLICT')
+    expect((err2 as Error).message).not.toContain('MAT-001 SECRET')
+  })
+})
+
+describe('listReadSourceCompositionAudit', () => {
+  it('keeps only coarse fields; clamps detail to {from,to}; drops a smuggled value-bearing detail field and an unknown action', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse([
+      {
+        action: 'status_change', actor: 'user-1',
+        detail: { from: 'draft', to: 'approved', secretNote: 'MAT-001 SECRET' },
+        createdAt: '2026-07-05T00:00:00Z',
+      },
+      {
+        // save_version rows carry a `version` number in real detail — must be dropped, never surfaced.
+        action: 'save_version', actor: null,
+        detail: { version: 3, secretNote: 'LEAK' },
+        createdAt: '2026-07-04T00:00:00Z',
+      },
+      { action: 'weird_action', actor: 'x', detail: {}, createdAt: '2026-07-03T00:00:00Z' }, // unknown action → dropped
+    ]))
+    const rows = await listReadSourceCompositionAudit('rscc_1', SCOPE)
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/integration/read-source-compositions/rscc_1/audit?tenantId=default')
+    expect(rows).toEqual([
+      { action: 'status_change', actor: 'user-1', detail: { from: 'draft', to: 'approved' }, createdAt: '2026-07-05T00:00:00Z' },
+      { action: 'save_version', actor: null, detail: {}, createdAt: '2026-07-04T00:00:00Z' },
+    ])
+    const text = JSON.stringify(rows)
+    for (const leak of ['MAT-001 SECRET', 'LEAK', 'weird_action']) {
       expect(text).not.toContain(leak)
     }
   })


### PR DESCRIPTION
## Summary

**N1** of the authoring-surface round (#1709): the config-time client service calls the composition **authoring panel** (N2, next slice) needs — closing the runbook-flagged gap where composition authoring required raw curl. Client-only; the C-R4-1 server routes are untouched.

- `buildReadSourceCompositionPayload(draft)` — pure builder; `version:1` / `operations:['read']` / step ids / `fromStep` / `toInput:'key'` all **pinned constants** (only the 4 named draft fields are ever read — a smuggled extra draft field can't reach the payload; test-locked).
- `validateReadSourceCompositionDraft` — coarse bounded-identifier pre-checks; field-keyed messages that **never echo raw values** (test: secret-shaped overlong values not present in any message).
- `saveReadSourceCompositionVersion` (POSTs exactly `{config}`; 201→`reused:false`, 200→`reused:true`) + `approveReadSourceComposition` / `retireReadSourceComposition`.
- `listReadSourceCompositionAudit` — values-free rows: action closed-enum (unknown actions dropped whole), `detail` clamped to only `{from,to}` status enums (a `version` or smuggled field is dropped).
- `ReadSourceCompositionApiError.fieldErrors` — save-time CONFIG_INVALID triples clamped with the SAME three patterns as #3588's planErrors (entry failing any clamp dropped whole; sentinel-scanned).

## Verification

- 33/33 (service 24 + mirror 3 + run panel 6) — re-verified independently in a clean worktree; `type-check` clean.
- Only 2 files touched (service + its spec); run panel / mirror spec / server untouched.

## Boundary

Client config-time surface over existing routes; no server change, no write path, no recursion.

Drafted by a Sonnet-5 agent against a discipline-pinned spec; reviewed line-by-line (clamps, pins, audit normalizer, no-echo) + locally re-verified before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)