### PR TITLE
feat(integration): composition authoring panel

### DIFF
--- a/apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
@@ -1,0 +1,386 @@
+<template>
+  <div class="integration-read-source-composition-authoring" data-testid="rscomp-author-panel">
+    <p class="integration-read-source-composition-authoring__hint">
+      顾问/管理员在这里把两个已审批 resolver_lookup 读取源编排成只读组合链。面板只保存组合配置版本,
+      不执行组合、不提交逐跳 key、不含写入能力。
+    </p>
+
+    <div class="integration-read-source-composition-authoring__columns">
+      <div class="integration-read-source-composition-authoring__form" data-testid="rscomp-author-form">
+        <h3>新建组合版本</h3>
+
+        <label class="integration-read-source-composition-authoring__field">
+          <span>组合名称</span>
+          <input v-model="draft.name" data-testid="rscomp-author-name" placeholder="material-to-bom" />
+        </label>
+
+        <label class="integration-read-source-composition-authoring__field">
+          <span>step 1 resolver_lookup</span>
+          <select v-model="draft.step1ConfigId" data-testid="rscomp-author-step1">
+            <option value="">选择已审批 resolver 读取源…</option>
+            <option v-for="row in resolverConfigs" :key="row.id" :value="row.id">
+              {{ readConfigLabel(row) }}
+            </option>
+          </select>
+        </label>
+
+        <label class="integration-read-source-composition-authoring__field">
+          <span>step 2 resolver_lookup</span>
+          <select v-model="draft.step2ConfigId" data-testid="rscomp-author-step2">
+            <option value="">选择已审批 resolver 读取源…</option>
+            <option v-for="row in resolverConfigs" :key="row.id" :value="row.id">
+              {{ readConfigLabel(row) }}
+            </option>
+          </select>
+        </label>
+
+        <label class="integration-read-source-composition-authoring__field">
+          <span>sourceTarget(step 1 输出目标,必须匹配 step 2 wiring)</span>
+          <input v-model="draft.sourceTarget" data-testid="rscomp-author-source-target" placeholder="itemId" />
+        </label>
+
+        <ul v-if="validationProblems.length > 0" class="integration-read-source-composition-authoring__problems" data-testid="rscomp-author-validation">
+          <li v-for="problem in validationProblems" :key="problem">{{ problem }}</li>
+        </ul>
+
+        <div class="integration-read-source-composition-authoring__actions">
+          <button type="button" class="integration-workbench__button" data-testid="rscomp-author-refresh" :disabled="loading" @click="refresh">
+            {{ loading ? '加载中…' : '刷新配置与组合' }}
+          </button>
+          <button type="button" class="integration-workbench__button" data-testid="rscomp-author-save" :disabled="saving || validationProblems.length > 0" @click="saveVersion">
+            {{ saving ? '保存中…' : '保存组合版本' }}
+          </button>
+        </div>
+
+        <p v-if="actionError" class="integration-read-source-composition-authoring__error" data-testid="rscomp-author-error">{{ actionError }}</p>
+
+        <ul v-if="fieldErrors.length > 0" class="integration-read-source-composition-authoring__field-errors" data-testid="rscomp-author-field-errors">
+          <li v-for="entry in fieldErrors" :key="`${entry.code}:${entry.field}:${entry.reason}`">
+            {{ entry.code }} · {{ entry.field }} · {{ entry.reason }}
+          </li>
+        </ul>
+
+        <p v-if="saveResult" class="integration-read-source-composition-authoring__save-result" data-testid="rscomp-author-save-result">
+          {{ saveResult.reused ? `已复用现有组合 v${saveResult.version}` : `已保存新组合 v${saveResult.version}` }}(status: {{ saveResult.status }})
+        </p>
+      </div>
+
+      <div class="integration-read-source-composition-authoring__list" data-testid="rscomp-author-list">
+        <div class="integration-read-source-composition-authoring__list-head">
+          <h3>已保存组合</h3>
+          <span>{{ compositions.length }} 项</span>
+        </div>
+
+        <p v-if="listError" class="integration-read-source-composition-authoring__error" data-testid="rscomp-author-list-error">{{ listError }}</p>
+        <p v-if="!loading && compositions.length === 0" class="integration-read-source-composition-authoring__empty" data-testid="rscomp-author-empty">
+          暂无组合配置。
+        </p>
+
+        <table v-if="compositions.length > 0" class="integration-read-source-composition-authoring__table">
+          <thead>
+            <tr>
+              <th>名称</th><th>版本</th><th>状态</th><th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <template v-for="row in compositions" :key="row.id">
+              <tr :data-testid="`rscomp-author-row-${row.id}`">
+                <td>{{ row.name || row.id }}</td>
+                <td>v{{ row.version }}</td>
+                <td>
+                  <span class="integration-read-source-composition-authoring__status" :data-status="row.status" :data-testid="`rscomp-author-status-${row.id}`">
+                    {{ statusLabel(row.status) }}
+                  </span>
+                </td>
+                <td class="integration-read-source-composition-authoring__row-actions">
+                  <button
+                    v-if="row.status === 'draft'"
+                    type="button"
+                    class="integration-workbench__button"
+                    :data-testid="`rscomp-author-approve-${row.id}`"
+                    @click="approve(row)"
+                  >审批</button>
+                  <button
+                    v-if="row.status === 'approved'"
+                    type="button"
+                    class="integration-workbench__button"
+                    :data-testid="`rscomp-author-retire-${row.id}`"
+                    @click="retire(row)"
+                  >停用</button>
+                  <button
+                    type="button"
+                    class="integration-workbench__button"
+                    :data-testid="`rscomp-author-audit-toggle-${row.id}`"
+                    @click="toggleAudit(row)"
+                  >{{ auditConfigId === row.id ? '收起审计' : '审计' }}</button>
+                </td>
+              </tr>
+              <tr v-if="auditConfigId === row.id" :data-testid="`rscomp-author-audit-${row.id}`">
+                <td colspan="4">
+                  <ul class="integration-read-source-composition-authoring__audit" data-testid="rscomp-author-audit-list">
+                    <li v-if="auditRows.length === 0">暂无审计记录。</li>
+                    <li v-for="(entry, index) in auditRows" :key="index">
+                      {{ auditActionLabel(entry.action) }} · {{ entry.actor || '(unknown)' }} · {{ entry.createdAt || '' }}<template v-if="auditDetailLabel(entry)"> · {{ auditDetailLabel(entry) }}</template>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Read-source composition authoring panel (N2, #1709). Consultant/config tier only:
+// choose two approved resolver_lookup read configs, save a read-only composition version, then approve/retire.
+// It never runs the chain, never submits a runtime key, and renders only clamped error/audit metadata.
+import { computed, reactive, ref, watch } from 'vue'
+import {
+  ReadSourceApiError,
+  listReadSourceConfigs,
+  type ReadSourceConfigRow,
+} from '../../services/integration/readSourceConfigs'
+import {
+  ReadSourceCompositionApiError,
+  approveReadSourceComposition,
+  createReadSourceCompositionDraft,
+  listReadSourceCompositionAudit,
+  listReadSourceCompositions,
+  retireReadSourceComposition,
+  saveReadSourceCompositionVersion,
+  validateReadSourceCompositionDraft,
+  type CompositionStatus,
+  type ReadSourceCompositionAuditRow,
+  type ReadSourceCompositionFieldError,
+  type ReadSourceCompositionRow,
+  type ReadSourceCompositionSaveResult,
+} from '../../services/integration/readSourceCompositions'
+import type { IntegrationScope } from '../../services/integration/workbench'
+
+const props = defineProps<{
+  scope: IntegrationScope
+}>()
+
+const draft = reactive(createReadSourceCompositionDraft())
+const readConfigs = ref<ReadSourceConfigRow[]>([])
+const compositions = ref<ReadSourceCompositionRow[]>([])
+const auditConfigId = ref('')
+const auditRows = ref<ReadSourceCompositionAuditRow[]>([])
+const fieldErrors = ref<ReadSourceCompositionFieldError[]>([])
+const saveResult = ref<ReadSourceCompositionSaveResult | null>(null)
+const loading = ref(false)
+const saving = ref(false)
+const actionError = ref('')
+const listError = ref('')
+
+const resolverConfigs = computed(() =>
+  readConfigs.value.filter((row) => row.status === 'approved' && row.mode === 'resolver_lookup'))
+const validationProblems = computed(() => validateReadSourceCompositionDraft(draft))
+
+watch(draft, () => {
+  saveResult.value = null
+  fieldErrors.value = []
+  actionError.value = ''
+})
+
+function readConfigLabel(row: ReadSourceConfigRow): string {
+  return `${row.object || row.id} · ${row.systemId || '(system?)'} · v${row.version}`
+}
+
+function statusLabel(status: CompositionStatus): string {
+  if (status === 'approved') return '已审批'
+  if (status === 'retired') return '已停用'
+  return '草稿'
+}
+
+function auditActionLabel(action: ReadSourceCompositionAuditRow['action']): string {
+  if (action === 'save_version') return '保存版本'
+  if (action === 'reuse_version') return '复用版本'
+  return '状态变更'
+}
+
+function auditDetailLabel(entry: ReadSourceCompositionAuditRow): string {
+  const { from, to } = entry.detail
+  return from || to ? `${from || '?'}→${to || '?'}` : ''
+}
+
+function setError(error: unknown): void {
+  fieldErrors.value = []
+  if (error instanceof ReadSourceCompositionApiError) {
+    actionError.value = error.message
+    fieldErrors.value = error.fieldErrors
+    return
+  }
+  if (error instanceof ReadSourceApiError) {
+    actionError.value = error.message
+    return
+  }
+  actionError.value = '组合配置请求失败'
+}
+
+async function refresh(): Promise<void> {
+  loading.value = true
+  listError.value = ''
+  try {
+    const [configs, rows] = await Promise.all([
+      listReadSourceConfigs(props.scope, { status: 'approved' }),
+      listReadSourceCompositions(props.scope),
+    ])
+    readConfigs.value = configs
+    compositions.value = rows
+  } catch (error) {
+    listError.value = error instanceof ReadSourceApiError || error instanceof ReadSourceCompositionApiError
+      ? error.message
+      : '组合配置列表加载失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveVersion(): Promise<void> {
+  actionError.value = ''
+  fieldErrors.value = []
+  saveResult.value = null
+  saving.value = true
+  try {
+    saveResult.value = await saveReadSourceCompositionVersion(draft, props.scope)
+    await refresh()
+  } catch (error) {
+    setError(error)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function approve(row: ReadSourceCompositionRow): Promise<void> {
+  if (!window.confirm(`审批后运行时即可选用该组合(${row.name || row.id} v${row.version})。确认审批?`)) return
+  actionError.value = ''
+  try {
+    await approveReadSourceComposition(row.id, props.scope)
+    await refresh()
+  } catch (error) {
+    setError(error)
+  }
+}
+
+async function retire(row: ReadSourceCompositionRow): Promise<void> {
+  actionError.value = ''
+  try {
+    await retireReadSourceComposition(row.id, props.scope)
+    await refresh()
+  } catch (error) {
+    setError(error)
+  }
+}
+
+async function toggleAudit(row: ReadSourceCompositionRow): Promise<void> {
+  if (auditConfigId.value === row.id) {
+    auditConfigId.value = ''
+    auditRows.value = []
+    return
+  }
+  actionError.value = ''
+  try {
+    auditRows.value = await listReadSourceCompositionAudit(row.id, props.scope)
+    auditConfigId.value = row.id
+  } catch (error) {
+    setError(error)
+  }
+}
+
+void refresh()
+</script>
+
+<style scoped>
+.integration-read-source-composition-authoring__hint {
+  color: #666;
+  font-size: 13px;
+  margin: 0 0 12px;
+}
+.integration-read-source-composition-authoring__columns {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(360px, 1.2fr);
+  gap: 20px;
+}
+.integration-read-source-composition-authoring__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__field input,
+.integration-read-source-composition-authoring__field select {
+  padding: 6px 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+}
+.integration-read-source-composition-authoring__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 10px 0;
+}
+.integration-read-source-composition-authoring__problems,
+.integration-read-source-composition-authoring__field-errors {
+  color: #b45309;
+  font-size: 12px;
+  padding-left: 18px;
+}
+.integration-read-source-composition-authoring__error {
+  color: #b91c1c;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__save-result {
+  color: #15803d;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__list-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.integration-read-source-composition-authoring__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__table th,
+.integration-read-source-composition-authoring__table td {
+  border-bottom: 1px solid #eee;
+  padding: 6px 8px;
+  text-align: left;
+}
+.integration-read-source-composition-authoring__status[data-status='approved'] {
+  color: #15803d;
+}
+.integration-read-source-composition-authoring__status[data-status='draft'] {
+  color: #b45309;
+}
+.integration-read-source-composition-authoring__status[data-status='retired'] {
+  color: #6b7280;
+}
+.integration-read-source-composition-authoring__row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.integration-read-source-composition-authoring__empty {
+  color: #888;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__audit {
+  margin: 4px 0;
+  padding-left: 18px;
+  font-size: 12px;
+  color: #555;
+}
+@media (max-width: 960px) {
+  .integration-read-source-composition-authoring__columns {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -259,6 +259,16 @@
     <section class="integration-workbench__panel">
       <div class="integration-workbench__panel-head">
         <div>
+          <h2>读取源组合配置(顾问自助)</h2>
+          <p>选择两个已审批 resolver_lookup 读取源,声明单标量交接字段,保存内容寻址版本并审批后供运行面板选用。本面板不执行组合、不含写入。</p>
+        </div>
+      </div>
+      <IntegrationReadSourceCompositionAuthoringPanel :scope="currentScope()" />
+    </section>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__panel-head">
+        <div>
           <h2>读取源组合运行(顾问/操作员自助)</h2>
           <p>选择已审批的组合链,提供首个业务 key 后运行:中间键由平台派生,证据 values-free,数据仅末跳输出。本面板不含配置编写或写入。</p>
         </div>
@@ -1473,6 +1483,7 @@ import {
 } from '../services/integration/workbench'
 import MetaIntegrationFieldRuleAuthoring from '../components/integration/MetaIntegrationFieldRuleAuthoring.vue'
 import IntegrationReadSourceConfigPanel from '../components/integration/IntegrationReadSourceConfigPanel.vue'
+import IntegrationReadSourceCompositionAuthoringPanel from '../components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
 import IntegrationReadSourceCompositionPanel from '../components/integration/IntegrationReadSourceCompositionPanel.vue'
 import PlmBomReviewPanel from '../components/plm/PlmBomReviewPanel.vue'
 

--- a/apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App as VueApp } from 'vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: vi.fn(),
+}))
+
+import IntegrationReadSourceCompositionAuthoringPanel from '../src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ data }), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function errorResponse(error: unknown, status = 400): Response {
+  return new Response(JSON.stringify({ error }), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function waitUntil(condition: () => boolean, label: string, attempts = 60): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+  throw new Error(`waitUntil timed out: ${label}`)
+}
+
+const SCOPE = { tenantId: 'default', workspaceId: null }
+
+const APPROVED_RESOLVERS = [
+  { id: 'rsc_item_resolver', systemId: 'k3', object: 'material', mode: 'resolver_lookup', version: 1, status: 'approved', contentKey: 'ck1', createdBy: null, updatedAt: null },
+  { id: 'rsc_bom_resolver', systemId: 'k3', object: 'bom', mode: 'resolver_lookup', version: 2, status: 'approved', contentKey: 'ck2', createdBy: null, updatedAt: null },
+  { id: 'rsc_detail', systemId: 'k3', object: 'material', mode: 'single_record', version: 1, status: 'approved', contentKey: 'ck3', createdBy: null, updatedAt: null },
+  { id: 'rsc_draft_resolver', systemId: 'k3', object: 'draft', mode: 'resolver_lookup', version: 1, status: 'draft', contentKey: 'ck4', createdBy: null, updatedAt: null },
+]
+
+const COMPOSITIONS = [
+  { id: 'rscc_draft', name: 'material-to-bom', version: 1, status: 'draft', contentKey: 'cc1', updatedAt: '2026-07-05' },
+  { id: 'rscc_approved', name: 'approved-chain', version: 2, status: 'approved', contentKey: 'cc2', updatedAt: '2026-07-05' },
+]
+
+function baseMock(): void {
+  apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (url === '/api/integration/read-source-configs?tenantId=default&status=approved') {
+      return jsonResponse(APPROVED_RESOLVERS)
+    }
+    if (url === '/api/integration/read-source-compositions?tenantId=default' && !init) {
+      return jsonResponse(COMPOSITIONS)
+    }
+    return jsonResponse({})
+  })
+}
+
+describe('IntegrationReadSourceCompositionAuthoringPanel', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.restoreAllMocks()
+  })
+
+  function mountPanel(): HTMLDivElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () => h(IntegrationReadSourceCompositionAuthoringPanel, {
+        scope: SCOPE,
+      }),
+    })
+    app.mount(container)
+    return container
+  }
+
+  function q<T extends HTMLElement>(root: HTMLElement, testid: string): T {
+    const el = root.querySelector<T>(`[data-testid="${testid}"]`)
+    if (!el) throw new Error(`missing [data-testid=${testid}]`)
+    return el
+  }
+
+  function setInput(root: HTMLElement, testid: string, value: string): void {
+    const input = q<HTMLInputElement>(root, testid)
+    input.value = value
+    input.dispatchEvent(new Event('input'))
+  }
+
+  function setSelect(root: HTMLElement, testid: string, value: string): void {
+    const select = q<HTMLSelectElement>(root, testid)
+    select.value = value
+    select.dispatchEvent(new Event('change'))
+  }
+
+  it('lists only approved resolver_lookup configs as composition steps', async () => {
+    baseMock()
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rsc_item_resolver"]') !== null, 'resolver configs load')
+
+    expect(root.querySelector('option[value="rsc_item_resolver"]')).not.toBeNull()
+    expect(root.querySelector('option[value="rsc_bom_resolver"]')).not.toBeNull()
+    expect(root.querySelector('option[value="rsc_detail"]')).toBeNull()
+    expect(root.querySelector('option[value="rsc_draft_resolver"]')).toBeNull()
+    expect(root.querySelector('[data-testid="rscomp-author-row-rscc_draft"]')).not.toBeNull()
+  })
+
+  it('saves exactly the pinned composition config and cannot submit runtime keys or write-shaped fields', async () => {
+    const postedBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/read-source-configs?tenantId=default&status=approved') return jsonResponse(APPROVED_RESOLVERS)
+      if (url === '/api/integration/read-source-compositions?tenantId=default' && !init) return jsonResponse(COMPOSITIONS)
+      if (url === '/api/integration/read-source-compositions?tenantId=default' && init?.method === 'POST') {
+        postedBodies.push(JSON.parse(String(init.body || '{}')))
+        return jsonResponse({ id: 'rscc_new', name: 'material-to-bom', version: 1, status: 'draft', contentKey: 'cc-new', updatedAt: '2026-07-05', reused: false }, 201)
+      }
+      return jsonResponse({})
+    })
+
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rsc_item_resolver"]') !== null, 'resolver configs load')
+    setInput(root, 'rscomp-author-name', ' material-to-bom ')
+    setSelect(root, 'rscomp-author-step1', 'rsc_item_resolver')
+    setSelect(root, 'rscomp-author-step2', 'rsc_bom_resolver')
+    setInput(root, 'rscomp-author-source-target', ' itemId ')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rscomp-author-save').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-author-save-result"]') !== null, 'save result')
+
+    expect(postedBodies).toHaveLength(1)
+    expect(Object.keys(postedBodies[0])).toEqual(['config'])
+    expect(postedBodies[0]).toEqual({
+      config: {
+        version: 1,
+        name: 'material-to-bom',
+        operations: ['read'],
+        steps: [
+          { id: 'step-1', readSourceConfigId: 'rsc_item_resolver' },
+          { id: 'step-2', readSourceConfigId: 'rsc_bom_resolver', input: { fromStep: 'step-1', sourceTarget: 'itemId', toInput: 'key' } },
+        ],
+      },
+    })
+    expect(JSON.stringify(postedBodies[0])).not.toContain('MAT-001')
+    expect(JSON.stringify(postedBodies[0])).not.toContain('write')
+  })
+
+  it('renders CONFIG_INVALID field errors through the clamped values-free channel', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/read-source-configs?tenantId=default&status=approved') return jsonResponse(APPROVED_RESOLVERS)
+      if (url === '/api/integration/read-source-compositions?tenantId=default' && !init) return jsonResponse(COMPOSITIONS)
+      if (url === '/api/integration/read-source-compositions?tenantId=default' && init?.method === 'POST') {
+        return errorResponse({
+          code: 'READ_SOURCE_COMPOSITION_CONFIG_INVALID',
+          message: 'bad config near MAT-001 SECRET',
+          details: {
+            reason: 'invalid_config',
+            errors: [
+              { code: 'READ_SOURCE_COMPOSITION_NAME_INVALID', field: 'name', reason: 'invalid_identifier' },
+              { code: 'READ_SOURCE_COMPOSITION_STEP_INVALID', field: 'MAT-001 field', reason: 'invalid_reference' },
+              { code: 'READ_SOURCE_COMPOSITION_STEP_REF_INVALID', field: 'steps.0.readSourceConfigId', reason: 'material MAT-001 SECRET' },
+            ],
+          },
+        }, 400)
+      }
+      return jsonResponse({})
+    })
+
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rsc_item_resolver"]') !== null, 'resolver configs load')
+    setInput(root, 'rscomp-author-name', 'material-to-bom')
+    setSelect(root, 'rscomp-author-step1', 'rsc_item_resolver')
+    setSelect(root, 'rscomp-author-step2', 'rsc_bom_resolver')
+    setInput(root, 'rscomp-author-source-target', 'itemId')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rscomp-author-save').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-author-field-errors"]') !== null, 'field errors')
+
+    expect(q(root, 'rscomp-author-error').textContent).toContain('READ_SOURCE_COMPOSITION_CONFIG_INVALID')
+    expect(q(root, 'rscomp-author-field-errors').textContent).toContain('READ_SOURCE_COMPOSITION_NAME_INVALID')
+    const text = root.textContent ?? ''
+    expect(text).not.toContain('bad config near MAT-001 SECRET')
+    expect(text).not.toContain('MAT-001 field')
+    expect(text).not.toContain('material MAT-001 SECRET')
+  })
+
+  it('coarsens unexpected thrown errors instead of rendering raw messages', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/read-source-configs?tenantId=default&status=approved') return jsonResponse(APPROVED_RESOLVERS)
+      if (url === '/api/integration/read-source-compositions?tenantId=default' && !init) return jsonResponse(COMPOSITIONS)
+      if (url === '/api/integration/read-source-compositions?tenantId=default' && init?.method === 'POST') {
+        throw new Error('transport failed near MAT-001 SECRET')
+      }
+      return jsonResponse({})
+    })
+
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rsc_item_resolver"]') !== null, 'resolver configs load')
+    setInput(root, 'rscomp-author-name', 'material-to-bom')
+    setSelect(root, 'rscomp-author-step1', 'rsc_item_resolver')
+    setSelect(root, 'rscomp-author-step2', 'rsc_bom_resolver')
+    setInput(root, 'rscomp-author-source-target', 'itemId')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rscomp-author-save').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-author-error"]')?.textContent?.includes('组合配置请求失败') === true, 'generic error')
+
+    const text = root.textContent ?? ''
+    expect(text).toContain('组合配置请求失败')
+    expect(text).not.toContain('transport failed')
+    expect(text).not.toContain('MAT-001 SECRET')
+  })
+
+  it('approves, retires, and renders audit rows without surfacing version or smuggled detail', async () => {
+    const urls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      urls.push(`${init?.method || 'GET'} ${url}`)
+      if (url === '/api/integration/read-source-configs?tenantId=default&status=approved') return jsonResponse(APPROVED_RESOLVERS)
+      if (url === '/api/integration/read-source-compositions?tenantId=default' && !init) return jsonResponse(COMPOSITIONS)
+      if (url.endsWith('/approve?tenantId=default')) return jsonResponse({ ...COMPOSITIONS[0], status: 'approved' })
+      if (url.endsWith('/retire?tenantId=default')) return jsonResponse({ ...COMPOSITIONS[1], status: 'retired' })
+      if (url.endsWith('/audit?tenantId=default')) {
+        return jsonResponse([
+          { action: 'status_change', actor: 'user-1', detail: { from: 'draft', to: 'approved', secret: 'MAT-001 SECRET' }, createdAt: '2026-07-05T00:00:00Z' },
+          { action: 'save_version', actor: null, detail: { version: 9, secret: 'LEAK' }, createdAt: '2026-07-05T00:01:00Z' },
+          { action: 'raw_action', actor: 'x', detail: { secret: 'LEAK2' }, createdAt: '2026-07-05T00:02:00Z' },
+        ])
+      }
+      return jsonResponse({})
+    })
+
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-author-row-rscc_draft"]') !== null, 'composition rows')
+
+    q<HTMLButtonElement>(root, 'rscomp-author-approve-rscc_draft').click()
+    await waitUntil(() => urls.some((url) => url.includes('/rscc_draft/approve')), 'approve call')
+    q<HTMLButtonElement>(root, 'rscomp-author-retire-rscc_approved').click()
+    await waitUntil(() => urls.some((url) => url.includes('/rscc_approved/retire')), 'retire call')
+    q<HTMLButtonElement>(root, 'rscomp-author-audit-toggle-rscc_approved').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscomp-author-audit-list"]')?.textContent?.includes('状态变更') === true, 'audit renders')
+
+    const text = root.textContent ?? ''
+    expect(text).toContain('draft→approved')
+    expect(text).toContain('保存版本')
+    for (const leak of ['MAT-001 SECRET', 'version', 'LEAK', 'LEAK2', 'raw_action']) {
+      expect(text).not.toContain(leak)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add an independent read-source composition authoring panel for consultant/admin use
- select two approved resolver_lookup read-source configs, save a pinned read-only composition version, and approve/retire/audit saved compositions
- mount the authoring panel separately from the existing key-only composition run panel

## Boundaries
- no server/runtime changes; consumes the #3617 authoring-tier client service only
- no chain execution from the authoring panel, no runtime key submission, no recursion, no write/delete path
- error and audit rendering stays values-free via the existing client clamps

## Verification
- pnpm install --frozen-lockfile --prefer-offline
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationReadSourceCompositionPanel.spec.ts tests/readSourceCompositions.service.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- git diff --check

Related: #1709