### PR TITLE
feat(web): approval detail snapshot labels + sticky action bar + quick phrases (UX batch-1 B1-02/B1-05)

### DIFF
--- a/apps/web/src/approvals/detailField.ts
+++ b/apps/web/src/approvals/detailField.ts
@@ -357,3 +357,95 @@ export function findDetailFieldInSchema(
   if (!field || field.type !== 'detail' || !Array.isArray(field.columns)) return null
   return field
 }
+
+export interface DisplayField {
+  /** Original formSnapshot key — used for `:key` binding and any cross-lookup (e.g. detailTables). */
+  key: string
+  label: string
+  value: string
+}
+
+function matchOptionLabel(options: FormOption[] | undefined, value: unknown): string {
+  const match = (options ?? []).find((option) => option.value === value)
+  return match ? match.label : String(value)
+}
+
+/**
+ * Mirrors the detail view's own zh-CN date formatting (`new Date(x).toLocaleString('zh-CN')`),
+ * but — unlike that helper — passes the raw value through unchanged when it doesn't parse as a
+ * date, instead of surfacing the JS-internal "Invalid Date" string to the reader.
+ */
+function formatDisplayDate(value: unknown): string {
+  const raw = String(value)
+  const parsed = new Date(raw)
+  return Number.isNaN(parsed.getTime()) ? raw : parsed.toLocaleString('zh-CN')
+}
+
+/**
+ * Formats a single scalar snapshot value for display, driven by its frozen schema field type.
+ * null/undefined/'' always render as '-' regardless of type. `select` maps the stored value to
+ * its option label, falling back to the raw value when no option matches (e.g. an option
+ * renamed/removed after the instance was created); `multi-select` maps each stored value the
+ * same way and joins with '、'; `date` uses `formatDisplayDate` (pass-through on unparsable);
+ * `number` localizes finite values via zh-CN grouping. Everything else (text/textarea/user/
+ * attachment) stringifies as-is.
+ */
+function formatDisplayValue(field: FormField, value: unknown): string {
+  if (value === null || value === undefined || value === '') return '-'
+  switch (field.type) {
+    case 'select':
+      return matchOptionLabel(field.options, value)
+    case 'multi-select': {
+      const values = Array.isArray(value) ? value : [value]
+      return values.map((entry) => matchOptionLabel(field.options, entry)).join('、')
+    }
+    case 'date':
+    case 'datetime':
+      return formatDisplayDate(value)
+    case 'number': {
+      const num = Number(value)
+      return Number.isFinite(num) ? num.toLocaleString('zh-CN') : String(value)
+    }
+    default:
+      return String(value)
+  }
+}
+
+/**
+ * B1-02: humanized scalar-field display entries for the detail view's form snapshot — schema
+ * order, resolved labels, and typed value formatting (option labels instead of raw stored
+ * values, localized numbers, formatted dates) — instead of the raw-machine-key / raw-value
+ * rendering the view previously fell back to for every snapshot entry.
+ *
+ * `detail` fields are deliberately excluded: they keep rendering via the existing
+ * `buildDetailRowsForDisplay` / `detailTables` table path, untouched by this helper. Snapshot
+ * keys that have no matching schema field (stale/legacy data) are appended AFTER the
+ * schema-ordered entries, using the raw key as label — so unexpected data is surfaced, not
+ * silently dropped.
+ */
+export function buildDisplayFields(
+  formSchema: FormSchema | null | undefined,
+  formSnapshot: Record<string, unknown> | null | undefined,
+): DisplayField[] {
+  const snapshot = formSnapshot ?? {}
+  const fields = formSchema?.fields ?? []
+  const knownFieldIds = new Set(fields.map((field) => field.id))
+  const result: DisplayField[] = []
+
+  for (const field of fields) {
+    if (field.type === 'detail') continue
+    if (!Object.prototype.hasOwnProperty.call(snapshot, field.id)) continue
+    result.push({
+      key: field.id,
+      label: field.label || field.id,
+      value: formatDisplayValue(field, snapshot[field.id]),
+    })
+  }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (knownFieldIds.has(key)) continue
+    result.push({ key, label: key, value: String(value) })
+  }
+
+  return result
+}

--- a/apps/web/src/approvals/quickPhrases.ts
+++ b/apps/web/src/approvals/quickPhrases.ts
@@ -1,0 +1,61 @@
+/**
+ * B1-05: 审批意见「快捷短语」— 纯 localStorage 模块，零后端。
+ *
+ * 通过/驳回/评论时反复手打同类措辞（'同意' / '不符合要求' / '已阅'…）是纯粹的重复劳动；
+ * 这里为每个动作准备一份固定的常用短语表，并按 userId 记录真正点过、原样提交过的短语，
+ * 让常用措辞排到最前面。Mirrors `recentTemplates.ts`'s per-user localStorage discipline: max
+ * 3 entries, dedupe, most-recent-first, corrupt-safe (bad JSON → []), no-op without a userId.
+ */
+
+export type QuickPhraseAction = 'approve' | 'reject' | 'comment'
+
+export const QUICK_PHRASES: Record<QuickPhraseAction, string[]> = {
+  approve: ['同意', '情况属实', '已核实无误'],
+  reject: ['不符合要求', '请补充材料后重新提交'],
+  comment: ['已阅', '请尽快处理'],
+}
+
+const KEY_PREFIX = 'approval-quick-phrases:'
+const MAX_ENTRIES = 3
+
+function isQuickPhraseAction(action: string): action is QuickPhraseAction {
+  return action === 'approve' || action === 'reject' || action === 'comment'
+}
+
+/** The fixed preset phrases offered for an action; an unrecognized action offers none. */
+export function phrasesForAction(action: string): string[] {
+  return isQuickPhraseAction(action) ? QUICK_PHRASES[action] : []
+}
+
+function storageKey(userId: string, action: string): string {
+  return `${KEY_PREFIX}${userId}:${action}`
+}
+
+/** Phrases this user actually clicked+submitted for this action, most-recent-first. */
+export function recentPhrases(userId: string | null | undefined, action: string): string[] {
+  if (!userId) return []
+  try {
+    const raw = window.localStorage.getItem(storageKey(userId, action))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((entry): entry is string => typeof entry === 'string').slice(0, MAX_ENTRIES)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Records a used phrase for this user+action, most-recent-first, deduped, capped at 3. No-ops
+ * without a userId or an empty phrase — an anonymous/unresolved session never persists a
+ * shortcut, and there is nothing useful to remember for blank input.
+ */
+export function rememberPhrase(userId: string | null | undefined, action: string, phrase: string): void {
+  if (!userId || !phrase) return
+  try {
+    const next = [phrase, ...recentPhrases(userId, action).filter((entry) => entry !== phrase)].slice(0, MAX_ENTRIES)
+    window.localStorage.setItem(storageKey(userId, action), JSON.stringify(next))
+  } catch {
+    // Quota/serialization failures must never break the submit path — the shortcut is best-effort.
+  }
+}

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -79,25 +79,35 @@
           <el-divider />
 
           <div v-if="approval.formSnapshot" class="approval-detail__snapshot">
+            <!-- B1-02: humanized scalar fields — ordered + labeled via the frozen formSchema
+                 (buildDisplayFields), so readers see field labels and option labels instead of
+                 raw machine keys/values. `detail` fields are excluded here; they keep rendering
+                 via the detailTables loop below, unchanged. -->
             <div
-              v-for="(value, key) in approval.formSnapshot"
+              v-for="field in displayFields"
+              :key="field.key"
+              class="approval-detail__field"
+            >
+              <span class="approval-detail__label">{{ field.label }}</span>
+              <span>{{ field.value }}</span>
+            </div>
+            <!-- detail / sub-form (明细): render the frozen rows × columns as a read-only
+                 table driven by the instance's FROZEN formSchema columns (never the live
+                 template). -->
+            <div
+              v-for="(table, key) in detailTables"
               :key="key"
               class="approval-detail__field"
             >
-              <span class="approval-detail__label">{{ String(key) }}</span>
-              <!-- detail / sub-form (明细): render the frozen rows × columns as a read-only
-                   table driven by the instance's FROZEN formSchema columns (never the live
-                   template). Falls back to the stringify rendering when the field is not a
-                   usable detail or the value is not an array. -->
+              <span class="approval-detail__label">{{ key }}</span>
               <el-table
-                v-if="detailTables[String(key)]"
-                :data="detailTables[String(key)].rows"
+                :data="table.rows"
                 border
                 size="small"
                 class="approval-detail__detail-table"
               >
                 <el-table-column
-                  v-for="column in detailTables[String(key)].columns"
+                  v-for="column in table.columns"
                   :key="column.id"
                   :label="column.label"
                 >
@@ -106,7 +116,6 @@
                   </template>
                 </el-table-column>
               </el-table>
-              <span v-else>{{ formatFieldValue(value) }}</span>
             </div>
           </div>
           <el-empty v-else description="暂无表单数据" :image-size="80" />
@@ -340,6 +349,22 @@
     >
       <el-form>
         <el-form-item label="审批意见">
+          <!-- B1-05: quick phrases — this user's recently-used phrases first, then the fixed
+               preset list for 通过/驳回. Clicking a chip fills (or appends to) the textarea;
+               free-typed text is never remembered, only a submitted phrase that exactly
+               matches one of these chips (see `rememberQuickPhraseIfOffered`). -->
+          <div v-if="quickPhraseChips.length > 0" class="approval-detail__quick-phrases">
+            <el-tag
+              v-for="(phrase, index) in quickPhraseChips"
+              :key="phrase"
+              class="approval-detail__quick-phrase-chip"
+              effect="plain"
+              :data-testid="`approval-quick-phrase-${index}`"
+              @click="applyQuickPhrase(phrase)"
+            >
+              {{ phrase }}
+            </el-tag>
+          </div>
           <el-input
             v-model="actionComment"
             type="textarea"
@@ -498,6 +523,19 @@
     >
       <el-form>
         <el-form-item label="评论内容">
+          <!-- B1-05: quick phrases — see the 通过/驳回 dialog above for the same mechanics. -->
+          <div v-if="quickPhraseChips.length > 0" class="approval-detail__quick-phrases">
+            <el-tag
+              v-for="(phrase, index) in quickPhraseChips"
+              :key="phrase"
+              class="approval-detail__quick-phrase-chip"
+              effect="plain"
+              :data-testid="`approval-quick-phrase-${index}`"
+              @click="applyQuickPhrase(phrase)"
+            >
+              {{ phrase }}
+            </el-tag>
+          </div>
           <el-input
             v-model="actionComment"
             type="textarea"
@@ -576,9 +614,12 @@ import { useFeatureFlags } from '../../stores/featureFlags'
 import { useMobileViewport } from '../../composables/useMobileViewport'
 import {
   buildDetailRowsForDisplay,
+  buildDisplayFields,
   findDetailFieldInSchema,
   type DetailDisplayTable,
+  type DisplayField,
 } from '../../approvals/detailField'
+import { phrasesForAction, recentPhrases, rememberPhrase } from '../../approvals/quickPhrases'
 
 const route = useRoute()
 const router = useRouter()
@@ -616,6 +657,13 @@ const detailTables = computed<Record<string, DetailDisplayTable>>(() => {
   }
   return result
 })
+
+// B1-02: humanized scalar fields (label + formatted value, schema-ordered) — see
+// `buildDisplayFields` for the full contract. `detail` fields are excluded; they render via
+// `detailTables` above.
+const displayFields = computed<DisplayField[]>(() =>
+  buildDisplayFields(approval.value?.formSchema ?? null, approval.value?.formSnapshot ?? null),
+)
 
 // B1-01: real session identity — the previous `=== 'user_1'` mock meant production requesters
 // NEVER saw the requester-only actions (撤回/催办) this view already ships. Seeded SYNCHRONOUSLY
@@ -751,6 +799,30 @@ const returnableNodes = computed(() => {
 const actionDialogTitle = computed(() =>
   currentAction.value === 'approve' ? '审批通过' : '审批驳回',
 )
+
+// B1-05: quick-phrase chips for whichever action's dialog is currently open — this user's own
+// recently-used phrases (most-recent-first) first, then the fixed preset list, deduped, capped
+// at 5. `currentAction` is kept in sync with the open dialog by `openActionDialog`/
+// `openCommentDialog` below.
+const quickPhraseChips = computed<string[]>(() => {
+  const merged = [...recentPhrases(currentUserId.value, currentAction.value), ...phrasesForAction(currentAction.value)]
+  return Array.from(new Set(merged)).slice(0, 5)
+})
+
+function applyQuickPhrase(phrase: string): void {
+  actionComment.value = actionComment.value ? `${actionComment.value}，${phrase}` : phrase
+}
+
+/**
+ * Only remembers a submitted comment as a quick-phrase shortcut when it exactly matches one of
+ * the phrases OFFERED for the currently open dialog's action (recent ∪ preset, i.e.
+ * `quickPhraseChips` at submit time) — free-typed comments are never persisted, so this can't
+ * become a backdoor free-text log.
+ */
+function rememberQuickPhraseIfOffered(comment: string): void {
+  if (!quickPhraseChips.value.includes(comment)) return
+  rememberPhrase(currentUserId.value, currentAction.value, comment)
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -908,6 +980,9 @@ function openReturnDialog() {
 }
 
 function openCommentDialog() {
+  // B1-05: keeps `currentAction` in sync with the open dialog so `quickPhraseChips` offers the
+  // 'comment' preset/recent list here (rather than whatever approve/reject dialog ran last).
+  currentAction.value = 'comment'
   actionComment.value = ''
   commentDialogVisible.value = true
 }
@@ -940,6 +1015,7 @@ async function submitAction() {
       comment: actionComment.value || undefined,
     })
     ElMessage.success(currentAction.value === 'approve' ? '审批已通过' : '审批已驳回')
+    rememberQuickPhraseIfOffered(actionComment.value)
     actionDialogVisible.value = false
     await store.loadHistory(id)
   } catch (error) {
@@ -1022,6 +1098,7 @@ async function submitComment() {
       comment: actionComment.value,
     })
     ElMessage.success('评论已提交')
+    rememberQuickPhraseIfOffered(actionComment.value)
     commentDialogVisible.value = false
     await store.loadHistory(id)
   } catch (error) {
@@ -1208,6 +1285,17 @@ onMounted(async () => {
   margin-top: 4px;
 }
 
+.approval-detail__quick-phrases {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.approval-detail__quick-phrase-chip {
+  cursor: pointer;
+}
+
 .approval-detail__timeline-content {
   padding: 0;
 }
@@ -1289,16 +1377,23 @@ onMounted(async () => {
   color: var(--el-text-color-secondary, #606266);
 }
 
+/* B1-05: sticky at the viewport bottom so approve/reject/... stay reachable while the form
+   snapshot / timeline scroll underneath, instead of requiring a scroll-to-bottom first. The
+   safe-area padding keeps the buttons clear of the home-indicator area on notched devices. */
 .approval-detail__actions {
   margin-top: 24px;
   padding: 16px 20px;
-  background: #fff;
+  padding-bottom: calc(8px + env(safe-area-inset-bottom));
+  background: var(--el-bg-color, #fff);
   border: 1px solid var(--el-border-color-lighter, #e4e7ed);
   border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
 }
 
 .approval-detail__actions-primary {
@@ -1333,14 +1428,26 @@ onMounted(async () => {
     align-items: stretch;
   }
 
-  .approval-detail__actions-primary,
+  /* B1-05: the primary 通过/驳回 pair stays a two-up row (not a full column stack) so both
+     land in comfortable thumb reach; flex: 1 + min-height 44px keeps them evenly-sized,
+     tappable targets. The deferred secondary set keeps the existing full-width column stack —
+     its visibility/action set is unchanged (T3-1 v0 mobile gating still applies above). */
+  .approval-detail__actions-primary {
+    flex-direction: row;
+  }
+
   .approval-detail__actions-secondary {
     flex-direction: column;
     align-items: stretch;
     justify-content: center;
   }
 
-  .approval-detail__actions-primary :deep(.el-button),
+  .approval-detail__actions-primary :deep(.el-button) {
+    flex: 1;
+    min-height: 44px;
+    margin-left: 0;
+  }
+
   .approval-detail__actions-secondary :deep(.el-button) {
     width: 100%;
     margin-left: 0;

--- a/apps/web/tests/approval-detail-field.test.ts
+++ b/apps/web/tests/approval-detail-field.test.ts
@@ -3,6 +3,7 @@ import type { FormField, FormSchema } from '../src/types/approval'
 import {
   buildDetailColumns,
   buildDetailRowsForDisplay,
+  buildDisplayFields,
   createEmptyDetailColumnDraft,
   createEmptyDetailRow,
   detailColumnDraftsFromField,
@@ -326,5 +327,118 @@ describe('isDetailCellVisible — per-field (two detail groups may share a sub-f
   it('a column without a visibilityRule is always visible', () => {
     const group = makeGroup('items', 'x')
     expect(isDetailCellVisible(group, group.columns![0], { kind: 'whatever' })).toBe(true)
+  })
+})
+
+describe('detailField — buildDisplayFields (B1-02 humanized scalar snapshot)', () => {
+  const displaySchema: FormSchema = {
+    fields: [
+      {
+        id: 'fld_type',
+        type: 'select',
+        label: '类型',
+        options: [{ label: '采购', value: 'purchase' }, { label: '报销', value: 'reimbursement' }],
+      },
+      {
+        id: 'fld_tags',
+        type: 'multi-select',
+        label: '标签',
+        options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }],
+      },
+      { id: 'fld_amount', type: 'number', label: '金额' },
+      { id: 'fld_date', type: 'date', label: '日期' },
+      { id: 'fld_reason', type: 'textarea', label: '原因' },
+      { id: 'items', type: 'detail', label: '明细', columns: [{ id: 'x', type: 'text', label: 'X' }] },
+    ],
+  }
+
+  it('orders scalar entries by schema order regardless of snapshot key order, skipping detail fields', () => {
+    const snapshot = {
+      fld_reason: '出差',
+      fld_date: '2026-01-02T03:04:05Z',
+      fld_amount: 1234.5,
+      fld_tags: ['a', 'b'],
+      fld_type: 'reimbursement',
+      items: [{ x: '1' }],
+    }
+    const fields = buildDisplayFields(displaySchema, snapshot)
+    expect(fields.map((f) => f.key)).toEqual(['fld_type', 'fld_tags', 'fld_amount', 'fld_date', 'fld_reason'])
+  })
+
+  it('maps a select value to its option label, falling back to the raw value when unmatched', () => {
+    const known = buildDisplayFields(displaySchema, { fld_type: 'reimbursement' })
+    expect(known[0]).toEqual({ key: 'fld_type', label: '类型', value: '报销' })
+
+    const unknown = buildDisplayFields(displaySchema, { fld_type: 'unknown_value' })
+    expect(unknown[0].value).toBe('unknown_value')
+  })
+
+  it('multi-select maps each stored value to its option label and joins with 、, falling back per-entry', () => {
+    const fields = buildDisplayFields(displaySchema, { fld_tags: ['a', 'b', 'c'] })
+    // 'c' has no matching option -> falls back to the raw value for that entry only.
+    expect(fields[0].value).toBe('A、B、c')
+  })
+
+  it('localizes a finite number via zh-CN grouping, falling back to String(value) when not finite', () => {
+    const finite = buildDisplayFields(displaySchema, { fld_amount: 1234567.5 })
+    expect(finite[0].value).toBe((1234567.5).toLocaleString('zh-CN'))
+
+    const notFinite = buildDisplayFields(displaySchema, { fld_amount: 'not-a-number' })
+    expect(notFinite[0].value).toBe('not-a-number')
+  })
+
+  it('formats a parsable date value and passes an unparsable one through unchanged', () => {
+    const parsable = buildDisplayFields(displaySchema, { fld_date: '2026-01-02T03:04:05Z' })
+    expect(parsable[0].value).toBe(new Date('2026-01-02T03:04:05Z').toLocaleString('zh-CN'))
+
+    // datetime fields format through the same branch (review fix: the spec's list named only `date`)
+    const dt = buildDisplayFields(
+      { fields: [{ id: 'fld_dt', label: '会议时间', type: 'datetime' }] } as never,
+      { fld_dt: '2026-01-02T03:04:05Z' },
+    )
+    expect(dt[0].value).toBe(new Date('2026-01-02T03:04:05Z').toLocaleString('zh-CN'))
+
+    const unparsable = buildDisplayFields(displaySchema, { fld_date: 'not-a-date' })
+    expect(unparsable[0].value).toBe('not-a-date')
+  })
+
+  it('appends snapshot keys absent from the schema after schema-ordered entries, using the raw key as label', () => {
+    const fields = buildDisplayFields(displaySchema, {
+      fld_reason: '原因内容',
+      legacy_field: 'some-legacy-value',
+      fld_type: 'purchase',
+    })
+    expect(fields.map((f) => f.key)).toEqual(['fld_type', 'fld_reason', 'legacy_field'])
+    const legacy = fields.find((f) => f.key === 'legacy_field')!
+    expect(legacy.label).toBe('legacy_field')
+    expect(legacy.value).toBe('some-legacy-value')
+  })
+
+  it('excludes detail fields entirely — they render elsewhere as tables, never as a raw/unknown entry', () => {
+    const fields = buildDisplayFields(displaySchema, { items: [{ x: '1' }], fld_reason: 'r' })
+    expect(fields.map((f) => f.key)).toEqual(['fld_reason'])
+    expect(fields.some((f) => f.key === 'items')).toBe(false)
+  })
+
+  it('renders null/undefined/empty-string scalar values as \'-\' regardless of field type', () => {
+    const fields = buildDisplayFields(displaySchema, { fld_reason: '', fld_amount: null, fld_date: undefined })
+    expect(fields.map((f) => f.value)).toEqual(['-', '-', '-'])
+  })
+
+  it('falls back to field.id as the label when label is empty, and skips fields absent from the snapshot', () => {
+    const schema: FormSchema = {
+      fields: [
+        { id: 'no_label_field', type: 'text', label: '' },
+        { id: 'absent_field', type: 'text', label: '不会出现' },
+      ],
+    }
+    const fields = buildDisplayFields(schema, { no_label_field: 'v' })
+    expect(fields).toEqual([{ key: 'no_label_field', label: 'no_label_field', value: 'v' }])
+  })
+
+  it('tolerates a missing schema and/or snapshot without throwing', () => {
+    expect(buildDisplayFields(null, { a: 'b' })).toEqual([{ key: 'a', label: 'a', value: 'b' }])
+    expect(buildDisplayFields(displaySchema, null)).toEqual([])
+    expect(buildDisplayFields(undefined, undefined)).toEqual([])
   })
 })

--- a/apps/web/tests/approvalMobileDetailActions.spec.ts
+++ b/apps/web/tests/approvalMobileDetailActions.spec.ts
@@ -123,6 +123,34 @@ const ElPopconfirm = defineComponent({
   props: { title: String },
   render() { return h('div', { 'data-el-popconfirm': this.title }, this.$slots.reference?.()) },
 })
+// B1-05: quick-phrase chips are `<el-tag @click="...">`; the generic `stub()` helper declares
+// 'click' under `emits` but never wires a native listener, so a real click would silently no-op.
+// A minimal dedicated stub that forwards the click keeps the chip-click test honest.
+const ElTag = defineComponent({
+  name: 'ElTag',
+  props: { type: String, size: String, effect: String },
+  emits: ['click'],
+  render() {
+    return h('span', {
+      'data-el-tag': this.type || 'default',
+      onClick: (e: Event) => this.$emit('click', e),
+    }, this.$slots.default?.())
+  },
+})
+// B1-05: the comment/quick-phrase test needs a real v-model round-trip (fill via ref assignment,
+// read back via `.value`); the generic `stub()` helper renders a static div with no such wiring.
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: [String, Number], type: String, rows: Number, placeholder: String },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      'data-el-input': 'true',
+      value: this.modelValue ?? '',
+      onInput: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLInputElement).value),
+    })
+  },
+})
 
 const stubDirective = { mounted() {}, updated() {} }
 
@@ -200,13 +228,15 @@ describe('ApprovalDetailView — T3-1 mobile action-set restriction', () => {
     const Host = defineComponent({ setup() { return () => h(ApprovalDetailView as any) } })
     app = createApp(Host)
     // Broad Element Plus stubs; the action buttons are the assertion surface.
-    for (const name of ['ElTag', 'ElAlert', 'ElDivider', 'ElEmpty', 'ElTable', 'ElTimeline', 'ElTimelineItem', 'ElForm', 'ElFormItem', 'ElInput', 'ElSelect', 'ElOption', 'ElRadioGroup', 'ElRadio', 'ElIcon']) {
+    for (const name of ['ElAlert', 'ElDivider', 'ElEmpty', 'ElTable', 'ElTimeline', 'ElTimelineItem', 'ElForm', 'ElFormItem', 'ElSelect', 'ElOption', 'ElRadioGroup', 'ElRadio', 'ElIcon']) {
       app.component(name, stub(name))
     }
     app.component('ElTableColumn', ElTableColumn)
     app.component('ElButton', ElButton)
     app.component('ElDialog', ElDialog)
     app.component('ElPopconfirm', ElPopconfirm)
+    app.component('ElTag', ElTag)
+    app.component('ElInput', ElInput)
     app.directive('loading', stubDirective)
     app.mount(container!)
     await flushUi()
@@ -313,5 +343,28 @@ describe('ApprovalDetailView — T3-1 mobile action-set restriction', () => {
     mockCurrentUserId.value = 'user_uninvolved'
     await mountView()
     expect(container!.querySelector('[data-testid="approval-my-turn-badge"]')).toBeNull()
+  })
+
+  it('B1-05: opening 通过 dialog shows quick-phrase chips; clicking one fills the comment input', async () => {
+    await mountView()
+
+    const approveBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('通过'))
+    expect(approveBtn).toBeTruthy()
+    approveBtn!.click()
+    await flushUi()
+
+    const dialog = container!.querySelector('[data-el-dialog]')
+    expect(dialog).toBeTruthy()
+
+    // Preset chips for 'approve' (no recent phrases yet for this — unresolved — user).
+    const chip = dialog!.querySelector('[data-testid="approval-quick-phrase-0"]') as HTMLElement
+    expect(chip).toBeTruthy()
+    expect(chip.textContent?.trim()).toBe('同意')
+
+    chip.click()
+    await flushUi()
+
+    const textarea = dialog!.querySelector('[data-el-input]') as HTMLInputElement
+    expect(textarea.value).toBe('同意')
   })
 })

--- a/apps/web/tests/approvalQuickPhrases.spec.ts
+++ b/apps/web/tests/approvalQuickPhrases.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * B1-05: 审批意见「快捷短语」— localStorage module contract.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { phrasesForAction, QUICK_PHRASES, recentPhrases, rememberPhrase } from '../src/approvals/quickPhrases'
+
+describe('approvals/quickPhrases', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('exposes the fixed preset phrases for each action', () => {
+    expect(QUICK_PHRASES.approve).toEqual(['同意', '情况属实', '已核实无误'])
+    expect(QUICK_PHRASES.reject).toEqual(['不符合要求', '请补充材料后重新提交'])
+    expect(QUICK_PHRASES.comment).toEqual(['已阅', '请尽快处理'])
+  })
+
+  it('phrasesForAction returns the matching preset list, [] for an unrecognized action', () => {
+    expect(phrasesForAction('approve')).toEqual(QUICK_PHRASES.approve)
+    expect(phrasesForAction('reject')).toEqual(QUICK_PHRASES.reject)
+    expect(phrasesForAction('comment')).toEqual(QUICK_PHRASES.comment)
+    expect(phrasesForAction('transfer')).toEqual([])
+    expect(phrasesForAction('')).toEqual([])
+  })
+
+  it('remembers and lists most-recent-first, deduping by phrase text', () => {
+    rememberPhrase('u1', 'approve', '同意')
+    rememberPhrase('u1', 'approve', '情况属实')
+    rememberPhrase('u1', 'approve', '同意') // re-used -> bumps back to the front, no duplicate entry
+    expect(recentPhrases('u1', 'approve')).toEqual(['同意', '情况属实'])
+  })
+
+  it('caps at 3 entries, evicting the oldest', () => {
+    rememberPhrase('u1', 'reject', 'A')
+    rememberPhrase('u1', 'reject', 'B')
+    rememberPhrase('u1', 'reject', 'C')
+    rememberPhrase('u1', 'reject', 'D')
+    expect(recentPhrases('u1', 'reject')).toEqual(['D', 'C', 'B'])
+  })
+
+  it('isolates per user and per action, and no-ops without a userId', () => {
+    rememberPhrase('u1', 'approve', '同意')
+    rememberPhrase(null, 'approve', '不应该被记住')
+    expect(recentPhrases('u2', 'approve')).toEqual([])
+    expect(recentPhrases(null, 'approve')).toEqual([])
+    expect(recentPhrases('u1', 'reject')).toEqual([]) // different action, same user
+    expect(recentPhrases('u1', 'approve')).toEqual(['同意'])
+  })
+
+  it('no-ops on an empty phrase', () => {
+    rememberPhrase('u1', 'comment', '')
+    expect(recentPhrases('u1', 'comment')).toEqual([])
+  })
+
+  it('degrades corrupted storage to an empty list, keeping only well-formed string entries', () => {
+    localStorage.setItem('approval-quick-phrases:u1:approve', '{not json')
+    expect(recentPhrases('u1', 'approve')).toEqual([])
+
+    localStorage.setItem('approval-quick-phrases:u1:approve', JSON.stringify({ nope: true }))
+    expect(recentPhrases('u1', 'approve')).toEqual([])
+
+    localStorage.setItem('approval-quick-phrases:u1:approve', JSON.stringify(['ok', 123, null, 'ok2']))
+    expect(recentPhrases('u1', 'approve')).toEqual(['ok', 'ok2'])
+  })
+})


### PR DESCRIPTION
## Summary

UX 阶梯（#3564）batch-1 **PR-A₂ 前半**（B1-02 + B1-05，全前端）。Sonnet 代理按审计草图实现，Fable 审查 + 补 datetime 分支后推送。

### B1-02 详情页快照人性化渲染
- 新纯 helper `buildDisplayFields(formSchema, formSnapshot)`（detailField.ts，可单测）：按**冻结 schema 顺序**迭代；label = field.label；select/multi-select 存储值→选项 label（无匹配回退原值）；date/**datetime** 格式化（不可解析原样透传，不再出现 "Invalid Date"）；number zh-CN 千分位；空值 '-'；schema 外 key 追加末尾原样渲染（防御性不丢数据）；detail 字段继续走既有明细表路径。

### B1-05 决策动作人体工学
- 操作栏 sticky 底部（safe-area padding + z-index 对齐 MetaGridTable 既有 sticky 惯例）；移动端主按钮全宽 44px，**动作集不变（ballot Q8 边界内）**。
- 新纯模块 `quickPhrases.ts`（镜像 recentTemplates.ts 风格）：按动作预设短语 + localStorage 按 user+action 记最近 3 条（去重/损坏降级/无 user no-op）；通过/驳回与评论两个对话框 textarea 上方渲染 chips（空填充/非空追加）；仅当提交意见恰为所供短语时记忆（不存自由文本）。

## Verification

- 受影响 3 spec **56/56**（含 9 个 buildDisplayFields 新用例 + datetime 审查补测 + 7 个 quickPhrases 用例 + chip 点击填充）
- 6 个守护 spec（mobile-detail/remind-badge/lifecycle/permissions/unread-badge/detail-field）同批 **157/157**
- `vue-tsc -b` 0；全量 sanity 与 origin/main 基线一致（15 个预存失败文件逐一 stash 复验非本 PR 引入）
- 审查偏差处理：datetime 与 date 同分支（规格疏漏，已补 + 测试）；radio 不存在于 FormFieldType（正确略过）；两个对话框均接 chips 且 comment 对话框补 currentAction 语义

🤖 Generated with [Claude Code](https://claude.com/claude-code)