### PR TITLE
feat(integration): composition authoring panel — consultant config-time UI

### DIFF
--- a/apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
@@ -1,0 +1,420 @@
+<template>
+  <div class="integration-read-source-composition-authoring" data-testid="read-source-composition-authoring-panel">
+    <p class="integration-read-source-composition-authoring__hint" data-testid="rscauth-boundary">
+      配置面(authoring)——运行在运行面板;只读链;不含任何写路径。
+      顾问/管理员在这里选择两个已审批的 resolver_lookup 读取源,组装成一条两跳读取组合:
+      第一跳的解析输出作为第二跳的业务 key。保存后需审批,运行时才可选用;停用后运行时立即不可选用。
+    </p>
+
+    <div class="integration-read-source-composition-authoring__columns">
+      <div class="integration-read-source-composition-authoring__form" data-testid="rscauth-form">
+        <h3>新建组合</h3>
+
+        <label class="integration-read-source-composition-authoring__field">
+          <span>第一跳读取源(已审批 resolver_lookup)</span>
+          <select v-model="draft.step1ConfigId" data-testid="rscauth-step1">
+            <option value="">请选择第一跳读取源…</option>
+            <option v-for="row in resolverConfigs" :key="row.id" :value="row.id">
+              {{ row.id }} · {{ row.object }}
+            </option>
+          </select>
+        </label>
+
+        <label class="integration-read-source-composition-authoring__field">
+          <span>第二跳读取源(已审批 resolver_lookup)</span>
+          <select v-model="draft.step2ConfigId" data-testid="rscauth-step2">
+            <option value="">请选择第二跳读取源…</option>
+            <option v-for="row in resolverConfigs" :key="row.id" :value="row.id">
+              {{ row.id }} · {{ row.object }}
+            </option>
+          </select>
+        </label>
+
+        <label class="integration-read-source-composition-authoring__field">
+          <span>name(组合标识符)</span>
+          <input v-model="draft.name" data-testid="rscauth-name" placeholder="material_to_bom_v1" />
+        </label>
+
+        <label class="integration-read-source-composition-authoring__field">
+          <span>sourceTarget(第一跳输出字段名,交接给第二跳作为 key)</span>
+          <input v-model="draft.sourceTarget" data-testid="rscauth-source-target" placeholder="internal_id" />
+        </label>
+
+        <ul v-if="draftProblems.length > 0" class="integration-read-source-composition-authoring__problems" data-testid="rscauth-draft-problems">
+          <li v-for="problem in draftProblems" :key="problem">{{ problem }}</li>
+        </ul>
+
+        <p v-if="!canWrite" class="integration-read-source-composition-authoring__hint integration-read-source-composition-authoring__hint--strong" data-testid="rscauth-permission-hint">
+          当前用户只有只读权限,不能保存 / 审批 / 停用组合(需要 integration:write)。
+        </p>
+
+        <div class="integration-read-source-composition-authoring__actions">
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rscauth-refresh"
+            :disabled="pickerLoading"
+            @click="refreshPickers"
+          >{{ pickerLoading ? '加载中…' : '刷新读取源列表' }}</button>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rscauth-save"
+            :disabled="!canSave"
+            @click="save"
+          >{{ saving ? '保存中…' : '保存组合版本' }}</button>
+        </div>
+
+        <p v-if="pickerError" class="integration-read-source-composition-authoring__error" data-testid="rscauth-picker-error">{{ pickerError }}</p>
+        <p v-if="!pickerLoading && resolverConfigs.length === 0" class="integration-read-source-composition-authoring__empty" data-testid="rscauth-empty">
+          暂无已审批的 resolver_lookup 读取源,请先在上方"读取源配置"面板配置并审批两个读取源。
+        </p>
+
+        <p v-if="actionError" class="integration-read-source-composition-authoring__error" data-testid="rscauth-error">{{ actionError }}</p>
+
+        <ul v-if="saveFieldErrors.length > 0" class="integration-read-source-composition-authoring__problems" data-testid="rscauth-field-errors">
+          <li v-for="(entry, index) in saveFieldErrors" :key="index">{{ entry.code }} · {{ entry.field }} · {{ entry.reason }}</li>
+        </ul>
+      </div>
+
+      <div v-if="savedRow" class="integration-read-source-composition-authoring__saved" data-testid="rscauth-saved">
+        <h4>已保存组合</h4>
+        <p>
+          id: {{ savedRow.id }} · v{{ savedRow.version }} · status: {{ statusLabel(savedRow.status) }}
+          · {{ savedRow.reused ? '复用已有版本' : '新版本' }}
+        </p>
+        <div class="integration-read-source-composition-authoring__row-actions">
+          <button
+            v-if="savedRow.status === 'draft'"
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rscauth-approve"
+            :disabled="!canApprove"
+            @click="approve"
+          >{{ approving ? '审批中…' : '审批' }}</button>
+          <button
+            v-if="savedRow.status === 'approved'"
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rscauth-retire"
+            :disabled="!canRetire"
+            @click="retire"
+          >{{ retiring ? '停用中…' : '停用' }}</button>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="rscauth-audit-toggle"
+            :disabled="auditLoading"
+            @click="toggleAudit"
+          >{{ auditOpen ? '收起审计' : (auditLoading ? '加载中…' : '审计') }}</button>
+        </div>
+
+        <ul v-if="auditOpen" class="integration-read-source-composition-authoring__audit" data-testid="rscauth-audit">
+          <li v-if="auditRows.length === 0">暂无审计记录。</li>
+          <li v-for="(entry, index) in auditRows" :key="index">
+            {{ auditActionLabel(entry.action) }} · {{ entry.actor || '(unknown)' }}<template v-if="entry.detail.from || entry.detail.to"> · {{ entry.detail.from }} → {{ entry.detail.to }}</template> · {{ entry.createdAt || '' }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Read-source resolver composition — authoring-tier panel (C-R4-4, #1709). Consultant/admin config-time
+// UI over the C-R4-3a authoring service layer, replacing the API-only Phase 1 flow in the entity runbook
+// (docs/development/integration-composition-entity-e2e-runbook-20260705.md). Client-only: picks two
+// APPROVED resolver_lookup read-source configs, wires step 1's resolved output to step 2's key, and
+// exposes save/approve/retire/audit. It never builds the wire payload itself — every request goes
+// through the shared service functions (buildReadSourceCompositionPayload is used ONLY inside
+// saveReadSourceCompositionVersion), so a draft can never smuggle an extra field into the body. Every
+// write action (save/approve/retire) is gated on the SAME integration:write permission idiom the
+// workbench uses for its other write-tier actions (see IntegrationWorkbenchView.vue
+// externalWriteCanApply / applyExternalWrite / applyTableAction: disabled computed + handler-level
+// guard, auth.hasPermission('integration:write')) — list/audit stay read-tier and ungated, mirroring the
+// server's requireAccess('read') vs requireAccess('write') split in read-source-compositions HTTP routes.
+import { computed, reactive, ref, watch } from 'vue'
+import { useAuth } from '../../composables/useAuth'
+import type { IntegrationScope } from '../../services/integration/workbench'
+import { listReadSourceConfigs, type ReadSourceConfigRow } from '../../services/integration/readSourceConfigs'
+import {
+  approveReadSourceComposition,
+  createReadSourceCompositionDraft,
+  listReadSourceCompositionAudit,
+  retireReadSourceComposition,
+  saveReadSourceCompositionVersion,
+  validateReadSourceCompositionDraft,
+  ReadSourceCompositionApiError,
+  type CompositionStatus,
+  type ReadSourceCompositionAuditRow,
+  type ReadSourceCompositionFieldError,
+  type ReadSourceCompositionSaveResult,
+} from '../../services/integration/readSourceCompositions'
+
+const props = defineProps<{
+  scope: IntegrationScope
+}>()
+
+const auth = useAuth()
+// Same permission the server requires for save/approve/retire (requireAccess(req, 'write') in
+// readSourceCompositionsSave/Approve/Retire) and the same string the workbench's other apply-tier
+// actions gate on (dry-run=read · apply=write/admin badge).
+const canWrite = computed(() => auth.hasPermission('integration:write'))
+
+const draft = reactive(createReadSourceCompositionDraft())
+// Panel-level default (not the bare service factory default): the runbook's proven two-hop shape names
+// the handoff field internal_id.
+draft.sourceTarget = 'internal_id'
+
+const resolverConfigs = ref<ReadSourceConfigRow[]>([])
+const pickerLoading = ref(false)
+const pickerError = ref('')
+
+const saving = ref(false)
+const savedRow = ref<ReadSourceCompositionSaveResult | null>(null)
+const actionError = ref('')
+const saveFieldErrors = ref<ReadSourceCompositionFieldError[]>([])
+
+const approving = ref(false)
+const retiring = ref(false)
+
+const auditOpen = ref(false)
+const auditLoading = ref(false)
+const auditRows = ref<ReadSourceCompositionAuditRow[]>([])
+
+const draftProblems = computed(() => validateReadSourceCompositionDraft(draft))
+const canSave = computed(() => !saving.value && canWrite.value && draftProblems.value.length === 0)
+const canApprove = computed(() => !approving.value && canWrite.value)
+const canRetire = computed(() => !retiring.value && canWrite.value)
+
+// Any draft edit invalidates the previously saved row's relevance — a consultant editing the form is
+// composing a DIFFERENT composition, so its stale approve/retire/audit surface must not linger.
+watch(draft, () => {
+  savedRow.value = null
+  actionError.value = ''
+  saveFieldErrors.value = []
+})
+
+watch(savedRow, () => {
+  auditOpen.value = false
+  auditRows.value = []
+})
+
+function statusLabel(status: CompositionStatus): string {
+  if (status === 'approved') return '已审批'
+  if (status === 'retired') return '已停用'
+  return '草稿'
+}
+
+function auditActionLabel(action: ReadSourceCompositionAuditRow['action']): string {
+  if (action === 'save_version') return '保存新版本'
+  if (action === 'reuse_version') return '复用已有版本'
+  return '状态变更'
+}
+
+function coarseErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return '组合接口请求失败'
+}
+
+async function refreshPickers(): Promise<void> {
+  pickerLoading.value = true
+  pickerError.value = ''
+  try {
+    const rows = await listReadSourceConfigs(props.scope, { status: 'approved' })
+    resolverConfigs.value = rows.filter((row) => row.mode === 'resolver_lookup')
+  } catch (error) {
+    pickerError.value = coarseErrorMessage(error)
+  } finally {
+    pickerLoading.value = false
+  }
+}
+
+// Request-id + draft-signature stale guard (mirrors IntegrationWorkbenchView.vue's
+// isCurrentStockPreparationTargetRequest idiom): a save's response is applied ONLY when no newer save
+// started AND the draft that produced it still matches the current form — if the consultant changes a
+// picker selection while the save is in flight, the eventual response describes a composition that no
+// longer matches the visible form, so it must be dropped rather than rendered as the saved row.
+let saveRequestId = 0
+function currentDraftSignature(): string {
+  return JSON.stringify({
+    name: draft.name,
+    step1ConfigId: draft.step1ConfigId,
+    step2ConfigId: draft.step2ConfigId,
+    sourceTarget: draft.sourceTarget,
+  })
+}
+function isCurrentSaveRequest(requestId: number, signature: string): boolean {
+  return requestId === saveRequestId && currentDraftSignature() === signature
+}
+
+async function save(): Promise<void> {
+  if (!canWrite.value) {
+    actionError.value = '当前用户没有 write 权限,不能保存组合草稿。'
+    return
+  }
+  if (draftProblems.value.length > 0) return
+  actionError.value = ''
+  saveFieldErrors.value = []
+  const signature = currentDraftSignature()
+  const requestId = ++saveRequestId
+  saving.value = true
+  try {
+    // The wire payload is built ENTIRELY inside saveReadSourceCompositionVersion
+    // (buildReadSourceCompositionPayload) — this component never assembles the request body itself, so
+    // no field beyond the four named draft properties can ever ride into { config }.
+    const result = await saveReadSourceCompositionVersion(draft, props.scope)
+    if (!isCurrentSaveRequest(requestId, signature)) return
+    savedRow.value = result
+  } catch (error) {
+    if (!isCurrentSaveRequest(requestId, signature)) return
+    if (error instanceof ReadSourceCompositionApiError) {
+      actionError.value = coarseErrorMessage(error)
+      saveFieldErrors.value = error.fieldErrors
+    } else {
+      actionError.value = coarseErrorMessage(error)
+    }
+  } finally {
+    if (requestId === saveRequestId) saving.value = false
+  }
+}
+
+async function approve(): Promise<void> {
+  const row = savedRow.value
+  if (!row) return
+  if (!canWrite.value) {
+    actionError.value = '当前用户没有 write 权限,不能审批组合。'
+    return
+  }
+  if (!window.confirm(`审批后运行时即可选用该组合(${row.name || row.id} v${row.version})。确认审批?`)) return
+  const id = row.id
+  actionError.value = ''
+  approving.value = true
+  try {
+    const updated = await approveReadSourceComposition(id, props.scope)
+    if (savedRow.value?.id !== id) return
+    if (updated) savedRow.value = { ...savedRow.value, ...updated }
+  } catch (error) {
+    if (savedRow.value?.id !== id) return
+    actionError.value = coarseErrorMessage(error)
+  } finally {
+    if (savedRow.value?.id === id) approving.value = false
+  }
+}
+
+async function retire(): Promise<void> {
+  const row = savedRow.value
+  if (!row) return
+  if (!canWrite.value) {
+    actionError.value = '当前用户没有 write 权限,不能停用组合。'
+    return
+  }
+  const id = row.id
+  actionError.value = ''
+  retiring.value = true
+  try {
+    const updated = await retireReadSourceComposition(id, props.scope)
+    if (savedRow.value?.id !== id) return
+    if (updated) savedRow.value = { ...savedRow.value, ...updated }
+  } catch (error) {
+    if (savedRow.value?.id !== id) return
+    actionError.value = coarseErrorMessage(error)
+  } finally {
+    if (savedRow.value?.id === id) retiring.value = false
+  }
+}
+
+async function toggleAudit(): Promise<void> {
+  if (auditOpen.value) {
+    auditOpen.value = false
+    return
+  }
+  const row = savedRow.value
+  if (!row) return
+  const id = row.id
+  actionError.value = ''
+  auditLoading.value = true
+  try {
+    const rows = await listReadSourceCompositionAudit(id, props.scope)
+    if (savedRow.value?.id !== id) return
+    auditRows.value = rows
+    auditOpen.value = true
+  } catch (error) {
+    if (savedRow.value?.id !== id) return
+    actionError.value = coarseErrorMessage(error)
+  } finally {
+    if (savedRow.value?.id === id) auditLoading.value = false
+  }
+}
+
+void refreshPickers()
+</script>
+
+<style scoped>
+.integration-read-source-composition-authoring__hint {
+  color: #666;
+  font-size: 13px;
+  margin: 0 0 12px;
+}
+.integration-read-source-composition-authoring__hint--strong {
+  color: #b45309;
+}
+.integration-read-source-composition-authoring__columns {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(360px, 1.2fr);
+  gap: 20px;
+}
+.integration-read-source-composition-authoring__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__field input,
+.integration-read-source-composition-authoring__field select {
+  padding: 6px 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+}
+.integration-read-source-composition-authoring__actions {
+  display: flex;
+  gap: 8px;
+  margin: 10px 0;
+}
+.integration-read-source-composition-authoring__problems {
+  color: #b45309;
+  font-size: 12px;
+  padding-left: 18px;
+}
+.integration-read-source-composition-authoring__error {
+  color: #b91c1c;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__empty {
+  color: #888;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__saved {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+.integration-read-source-composition-authoring__row-actions {
+  display: flex;
+  gap: 8px;
+  margin: 8px 0;
+}
+.integration-read-source-composition-authoring__audit {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  font-size: 12px;
+  color: #555;
+}
+@media (max-width: 960px) {
+  .integration-read-source-composition-authoring__columns {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -259,6 +259,16 @@
     <section class="integration-workbench__panel">
       <div class="integration-workbench__panel-head">
         <div>
+          <h2>读取源组合配置(顾问/管理员自助)</h2>
+          <p>选择两个已审批的 resolver_lookup 读取源,组装成两跳组合:保存版本(内容寻址,幂等)→ 审批后运行时才可选用。本面板不含写入外部系统的能力。</p>
+        </div>
+      </div>
+      <IntegrationReadSourceCompositionAuthoringPanel :scope="currentScope()" />
+    </section>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__panel-head">
+        <div>
           <h2>读取源组合运行(顾问/操作员自助)</h2>
           <p>选择已审批的组合链,提供首个业务 key 后运行:中间键由平台派生,证据 values-free,数据仅末跳输出。本面板不含配置编写或写入。</p>
         </div>
@@ -1474,6 +1484,7 @@ import {
 import MetaIntegrationFieldRuleAuthoring from '../components/integration/MetaIntegrationFieldRuleAuthoring.vue'
 import IntegrationReadSourceConfigPanel from '../components/integration/IntegrationReadSourceConfigPanel.vue'
 import IntegrationReadSourceCompositionPanel from '../components/integration/IntegrationReadSourceCompositionPanel.vue'
+import IntegrationReadSourceCompositionAuthoringPanel from '../components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
 import PlmBomReviewPanel from '../components/plm/PlmBomReviewPanel.vue'
 
 type WorkbenchSide = 'source' | 'target'

--- a/apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App as VueApp } from 'vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: vi.fn(),
+}))
+
+import IntegrationReadSourceCompositionAuthoringPanel from '../src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ data }), { status, headers: { 'Content-Type': 'application/json' } })
+}
+function errorResponse(status: number, code: string, message: string, details?: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ error: { code, message, details } }), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function deferredResponse(): { promise: Promise<Response>; resolve: (data: unknown, status?: number) => void } {
+  let resolvePromise: (response: Response) => void = () => undefined
+  const promise = new Promise<Response>((resolve) => {
+    resolvePromise = resolve
+  })
+  return {
+    promise,
+    resolve: (data: unknown, status = 200) => resolvePromise(jsonResponse(data, status)),
+  }
+}
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function waitUntil(condition: () => boolean, label: string, attempts = 50): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+  throw new Error(`waitUntil timed out: ${label}`)
+}
+
+const APPROVED_RESOLVER_ROWS = [
+  { id: 'rsc_material_lookup', systemId: 'sys_k3', object: 'material', mode: 'resolver_lookup', version: 1, status: 'approved', contentKey: 'ck1', createdBy: null, updatedAt: '2026-07-05' },
+  { id: 'rsc_bom_lookup', systemId: 'sys_k3', object: 'bom', mode: 'resolver_lookup', version: 1, status: 'approved', contentKey: 'ck2', createdBy: null, updatedAt: '2026-07-05' },
+  // Same status (approved) but the WRONG mode — must never appear in the pickers.
+  { id: 'rsc_list_page', systemId: 'sys_k3', object: 'material_list', mode: 'list_page', version: 1, status: 'approved', contentKey: 'ck3', createdBy: null, updatedAt: '2026-07-05' },
+  // A draft resolver_lookup row — the mock mirrors the real server's status=approved query filter (see
+  // routeApiFetch below), so this row never reaches the component at all; it documents that the picker's
+  // approved-only guarantee comes from the query, while the mode filter below is the component's own.
+  { id: 'rsc_draft_resolver', systemId: 'sys_k3', object: 'other', mode: 'resolver_lookup', version: 1, status: 'draft', contentKey: 'ck4', createdBy: null, updatedAt: '2026-07-05' },
+]
+
+function routeApiFetch(handlers: {
+  save?: (init?: RequestInit) => Response | Promise<Response>
+  approve?: (id: string) => Response | Promise<Response>
+  retire?: (id: string) => Response | Promise<Response>
+  audit?: (id: string) => Response | Promise<Response>
+} = {}): (url: string, init?: RequestInit) => Promise<Response> {
+  return async (url: string, init?: RequestInit) => {
+    if (url.startsWith('/api/integration/read-source-configs')) {
+      return jsonResponse(APPROVED_RESOLVER_ROWS.filter((row) => row.status === 'approved'))
+    }
+    const approveMatch = /\/api\/integration\/read-source-compositions\/([^/?]+)\/approve/.exec(url)
+    if (approveMatch) return handlers.approve ? handlers.approve(approveMatch[1]) : jsonResponse({})
+    const retireMatch = /\/api\/integration\/read-source-compositions\/([^/?]+)\/retire/.exec(url)
+    if (retireMatch) return handlers.retire ? handlers.retire(retireMatch[1]) : jsonResponse({})
+    const auditMatch = /\/api\/integration\/read-source-compositions\/([^/?]+)\/audit/.exec(url)
+    if (auditMatch) return handlers.audit ? handlers.audit(auditMatch[1]) : jsonResponse([])
+    if (url.startsWith('/api/integration/read-source-compositions')) {
+      return handlers.save ? handlers.save(init) : jsonResponse({})
+    }
+    throw new Error(`unexpected URL ${url}`)
+  }
+}
+
+describe('IntegrationReadSourceCompositionAuthoringPanel', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+  let originalConfirm: typeof window.confirm
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    if (typeof localStorage?.clear === 'function') localStorage.clear()
+    originalConfirm = window.confirm
+    window.confirm = vi.fn(() => true)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    window.confirm = originalConfirm
+  })
+
+  function mountPanel(): HTMLDivElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () => h(IntegrationReadSourceCompositionAuthoringPanel, {
+        scope: { tenantId: 'default', workspaceId: null },
+      }),
+    })
+    app.mount(container)
+    return container
+  }
+
+  function q<T extends HTMLElement>(root: HTMLElement, testid: string): T {
+    const el = root.querySelector<T>(`[data-testid="${testid}"]`)
+    if (!el) throw new Error(`missing [data-testid=${testid}]`)
+    return el
+  }
+
+  function setInput(root: HTMLElement, testid: string, value: string): void {
+    const input = q<HTMLInputElement>(root, testid)
+    input.value = value
+    input.dispatchEvent(new Event('input'))
+  }
+
+  function setSelect(root: HTMLElement, testid: string, value: string): void {
+    const select = q<HTMLSelectElement>(root, testid)
+    select.value = value
+    select.dispatchEvent(new Event('change'))
+  }
+
+  async function fillValidDraft(root: HTMLElement): Promise<void> {
+    await waitUntil(() => root.querySelector('option[value="rsc_material_lookup"]') !== null, 'pickers load')
+    setSelect(root, 'rscauth-step1', 'rsc_material_lookup')
+    setSelect(root, 'rscauth-step2', 'rsc_bom_lookup')
+    setInput(root, 'rscauth-name', 'material_to_bom_v1')
+    setInput(root, 'rscauth-source-target', 'internal_id')
+    await flushUi()
+  }
+
+  it('lists ONLY approved resolver_lookup configs in both pickers', async () => {
+    apiFetchMock.mockImplementation(routeApiFetch())
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('option[value="rsc_material_lookup"]') !== null, 'pickers load')
+
+    const step1Options = Array.from(q<HTMLSelectElement>(root, 'rscauth-step1').querySelectorAll('option')).map((o) => o.value)
+    const step2Options = Array.from(q<HTMLSelectElement>(root, 'rscauth-step2').querySelectorAll('option')).map((o) => o.value)
+    for (const options of [step1Options, step2Options]) {
+      expect(options).toContain('rsc_material_lookup')
+      expect(options).toContain('rsc_bom_lookup')
+      expect(options).not.toContain('rsc_list_page')
+      expect(options).not.toContain('rsc_draft_resolver')
+    }
+  })
+
+  it('write-tier gating: without integration:write the save/approve action is disabled even with a valid draft', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:read']))
+    apiFetchMock.mockImplementation(routeApiFetch())
+    const root = mountPanel()
+    await fillValidDraft(root)
+
+    expect(q<HTMLButtonElement>(root, 'rscauth-save').disabled).toBe(true)
+    expect(q(root, 'rscauth-permission-hint')).toBeTruthy()
+
+    q<HTMLButtonElement>(root, 'rscauth-save').click()
+    await flushUi()
+    expect(apiFetchMock.mock.calls.some(([url]) => String(url).includes('/read-source-compositions?'))).toBe(false)
+  })
+
+  it('save POSTs exactly { config } with the pinned payload — an extra draft field never rides into the body', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    let sentBody: Record<string, unknown> | undefined
+    apiFetchMock.mockImplementation(routeApiFetch({
+      save: (init) => {
+        sentBody = JSON.parse(String(init?.body || '{}'))
+        return jsonResponse({ id: 'rscc_1', name: 'material_to_bom_v1', version: 1, status: 'draft', contentKey: 'ck', updatedAt: '2026-07-05', reused: false }, 201)
+      },
+    }))
+    const root = mountPanel()
+    await fillValidDraft(root)
+
+    q<HTMLButtonElement>(root, 'rscauth-save').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscauth-saved"]') !== null, 'saved row appears')
+
+    // The pinned shape: version/operations/step ids/toInput/fromStep are fixed constants that only the
+    // shared service builder assembles — this component never rebuilds the payload itself, so a smuggled
+    // extra draft field (already proven unreachable at the service layer in
+    // readSourceCompositions.service.spec.ts) can never reach the body via this component either.
+    expect(Object.keys(sentBody as object)).toEqual(['config'])
+    const config = (sentBody as { config: Record<string, unknown> }).config
+    expect(Object.keys(config)).toEqual(['version', 'name', 'operations', 'steps'])
+    expect(config).toEqual({
+      version: 1,
+      name: 'material_to_bom_v1',
+      operations: ['read'],
+      steps: [
+        { id: 'step-1', readSourceConfigId: 'rsc_material_lookup' },
+        { id: 'step-2', readSourceConfigId: 'rsc_bom_lookup', input: { fromStep: 'step-1', sourceTarget: 'internal_id', toInput: 'key' } },
+      ],
+    })
+
+    expect(q(root, 'rscauth-saved').textContent).toContain('rscc_1')
+    expect(q(root, 'rscauth-saved').textContent).toContain('新版本')
+  })
+
+  it('400 CONFIG_INVALID renders clamped fieldErrors — a business-value triple is dropped whole', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    apiFetchMock.mockImplementation(routeApiFetch({
+      save: () => errorResponse(400, 'READ_SOURCE_COMPOSITION_CONFIG_INVALID', 'composition config is invalid', {
+        errors: [
+          { code: 'READ_SOURCE_COMPOSITION_NAME_INVALID', field: 'name', reason: 'invalid_identifier' },
+          // business-value field (space + business token) → dropped whole by the clamp.
+          { code: 'READ_SOURCE_COMPOSITION_STEP_REF_INVALID', field: 'MAT-001 SECRET', reason: 'invalid_reference' },
+        ],
+      }),
+    }))
+    const root = mountPanel()
+    await fillValidDraft(root)
+
+    q<HTMLButtonElement>(root, 'rscauth-save').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscauth-field-errors"]') !== null, 'field errors render')
+
+    const text = q(root, 'rscauth-field-errors').textContent ?? ''
+    expect(text).toContain('READ_SOURCE_COMPOSITION_NAME_INVALID')
+    expect(text).toContain('invalid_identifier')
+    // Sentinel scan across the whole rendered surface, not just the field-errors block.
+    expect(root.innerHTML).not.toContain('MAT-001 SECRET')
+    expect(root.querySelector('[data-testid="rscauth-saved"]')).toBeNull()
+  })
+
+  it('approve/retire happy path transitions the saved row; a 409 renders a coarse message with no value echo', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    let status = 'draft'
+    apiFetchMock.mockImplementation(routeApiFetch({
+      save: () => jsonResponse({ id: 'rscc_1', name: 'material_to_bom_v1', version: 1, status: 'draft', contentKey: 'ck', updatedAt: '2026-07-05', reused: false }, 201),
+      approve: () => {
+        status = 'approved'
+        return jsonResponse({ id: 'rscc_1', name: 'material_to_bom_v1', version: 1, status, contentKey: 'ck', updatedAt: '2026-07-05' })
+      },
+      retire: () => errorResponse(409, 'READ_SOURCE_COMPOSITION_CONFIG_STATUS_CONFLICT', 'status conflict MAT-001 SECRET'),
+    }))
+    const root = mountPanel()
+    await fillValidDraft(root)
+    q<HTMLButtonElement>(root, 'rscauth-save').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscauth-saved"]') !== null, 'saved row appears')
+
+    expect(root.querySelector('[data-testid="rscauth-approve"]')).toBeTruthy()
+    q<HTMLButtonElement>(root, 'rscauth-approve').click()
+    await waitUntil(() => q(root, 'rscauth-saved').textContent?.includes('已审批') === true, 'row becomes approved')
+    expect(root.querySelector('[data-testid="rscauth-retire"]')).toBeTruthy()
+    expect(root.querySelector('[data-testid="rscauth-approve"]')).toBeNull()
+
+    q<HTMLButtonElement>(root, 'rscauth-retire').click()
+    await waitUntil(() => root.querySelector('[data-testid="rscauth-error"]') !== null, 'retire error appears')
+    const message = q(root, 'rscauth-error').textContent ?? ''
+    expect(message).toContain('READ_SOURCE_COMPOSITION_CONFIG_STATUS_CONFLICT')
+    expect(message).not.toContain('MAT-001 SECRET')
+    // The row stays approved (retire failed) — a 409 must not optimistically flip local status.
+    expect(q(root, 'rscauth-saved').textContent).toContain('已审批')
+  })
+
+  it('stale-response guard: changing the selection mid-flight drops the eventual save response', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    const deferred = deferredResponse()
+    apiFetchMock.mockImplementation(routeApiFetch({
+      save: () => deferred.promise,
+    }))
+    const root = mountPanel()
+    await fillValidDraft(root)
+
+    q<HTMLButtonElement>(root, 'rscauth-save').click()
+    await flushUi()
+    expect(q<HTMLButtonElement>(root, 'rscauth-save').textContent).toContain('保存中')
+
+    // Change the step-2 selection while the save is still in flight — the pending response describes a
+    // composition that no longer matches the visible form.
+    setSelect(root, 'rscauth-step2', 'rsc_material_lookup') // NOTE: now duplicates step1, but that only
+    // matters for a NEW save attempt; the point here is the draft signature changed underneath the
+    // in-flight request.
+    await flushUi()
+
+    deferred.resolve({ id: 'rscc_1', name: 'material_to_bom_v1', version: 1, status: 'draft', contentKey: 'ck', updatedAt: '2026-07-05', reused: false }, 201)
+    await flushUi(10)
+
+    expect(root.querySelector('[data-testid="rscauth-saved"]')).toBeNull()
+    expect(q<HTMLButtonElement>(root, 'rscauth-save').textContent).not.toContain('保存中')
+  })
+})


### PR DESCRIPTION
## Summary

**N2** of the authoring-surface round (#1709): the consultant/config-time **authoring panel** — closes the runbook-flagged gap (composition authoring previously required raw curl). Consumes the N1 service layer (#3617) exclusively.

- Dedicated component `IntegrationReadSourceCompositionAuthoringPanel.vue` (NOT inlined into the 22k workbench SFC): two step pickers (approved `resolver_lookup` configs only, distinct-selection enforced), name + `sourceTarget` inputs, client pre-check list, save → saved row (id/version/status/reused) with **clamped fieldErrors** on 400, approve/retire with disable-on-inflight + **requestId+signature stale guard**, values-free audit list, boundary hint.
- **Payload discipline**: the component never assembles the wire body — the draft goes to `saveReadSourceCompositionVersion` (pinned builder inside the service), so a tampered draft field can't reach the wire (test-locked).
- **Permission idiom**: `integration:write` actions-denied (disabled + handler guard), deliberately NOT panel-hide — matches the server's exact route split (save/approve/retire = write-tier; list/get/audit/run = read-tier), so pickers/audit stay readable while mutations are gated.
- Mount: 11-line diff in the workbench view, between the read-source config panel and the run panel.

## Verification

- **87/87** re-verified independently in a clean worktree: authoring 6 + run panel 6 + service 24 + vocab mirror 3 + full `IntegrationWorkbenchView.spec.ts` 48; `vue-tsc -b` clean; `git diff --check` clean.
- Sentinel scans in tests (7 assertions): business-value triples dropped from rendered HTML; 409 coarse render with no value echo.

## Boundary

Client config-time surface over existing routes; no server change, no write path, no recursion. Entity-runbook Phase 1 can now be panel-driven end-to-end.

Drafted by a Sonnet-5 agent against a discipline-pinned spec; reviewed (payload-discipline, permission-tier decision, stale guard) + independently re-verified before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)