### PR TITLE
ci(multitable): give teeth to the public-form show-IF/required-IF guard

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -61,6 +61,12 @@ on:
       - 'apps/web/src/multitable/components/cells/MetaCellEditor.vue'
       - 'apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts'
       - 'apps/web/tests/multitable-yjs-cell-editor.spec.ts'
+      - 'apps/web/src/multitable/utils/field-visibility.ts'
+      - 'apps/web/src/multitable/utils/conditional-formatting.ts'
+      - 'apps/web/src/multitable/components/MetaFormView.vue'
+      - 'apps/web/tests/multitable-field-visibility.spec.ts'
+      - 'apps/web/tests/multitable-required-if.spec.ts'
+      - 'apps/web/tests/multitable-conditional-formatting.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
     branches: [main]
@@ -110,6 +116,12 @@ on:
       - 'apps/web/src/multitable/components/cells/MetaCellEditor.vue'
       - 'apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts'
       - 'apps/web/tests/multitable-yjs-cell-editor.spec.ts'
+      - 'apps/web/src/multitable/utils/field-visibility.ts'
+      - 'apps/web/src/multitable/utils/conditional-formatting.ts'
+      - 'apps/web/src/multitable/components/MetaFormView.vue'
+      - 'apps/web/tests/multitable-field-visibility.spec.ts'
+      - 'apps/web/tests/multitable-required-if.spec.ts'
+      - 'apps/web/tests/multitable-conditional-formatting.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
 
 jobs:
@@ -156,4 +168,14 @@ jobs:
         # accumulation/loadMore) added so the grid virtualization ACTIVATION has real CI enforcement —
         # the guard already triggers on MetaGridTable.vue / useMultitableGrid.ts / MultitableWorkbench.vue
         # edits but, before this, ran none of those specs (and plugin-tests.yml only build-checks web).
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker --reporter=dot
+        #
+        # 20260705 gap-closure: field-visibility / required-if / conditional-formatting added.
+        # field-visibility.ts + MetaFormView.vue (the public-form conditional show-IF/required-IF
+        # gate) and conditional-formatting.ts (the shared rule evaluator both reuse) had NO CI teeth
+        # at all — not a path trigger on this workflow, not in this vitest filter, and the only other
+        # lane touching conditional-formatting.ts (multitable-browser-verify.yml) is a Playwright
+        # render/screenshot check, not a unit test of the pure evaluator/guard functions. A regressed
+        # "hidden field is never conditionally required" invariant (MetaFormView `validate()`) could
+        # land green and silently block public-form submission. See docs/development/
+        # multitable-formview-conditional-guard-{design,verification}-20260705.md.
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting --reporter=dot

--- a/docs/development/multitable-formview-conditional-guard-design-20260705.md
+++ b/docs/development/multitable-formview-conditional-guard-design-20260705.md
@@ -1,0 +1,101 @@
+# Multitable — public-form conditional show-IF/required-IF guard: CI gap closure (design)
+
+Date: 2026-07-05
+Area: multitable
+Type: CI-gate wiring only (no runtime change)
+
+## The gap
+
+`MetaFormView.vue` implements the public-form "conditional show-IF / required-IF"
+feature (design MVP 2026-06-14, A4 follow-up): a field can carry
+`property.visibilityRule` (hide/show based on another field's value) and/or
+`property.requiredWhen` (require it conditionally). The load-bearing invariant,
+stated explicitly in the component's own comments, is:
+
+> a field hidden by a visibility rule is never treated as conditionally required
+> (`MetaFormView.vue`, around `validate()`)
+
+and in the shared evaluator (`field-visibility.ts`):
+
+> a field hidden by a visibility rule is NEVER conditionally required (you
+> cannot fill an invisible field; it must not block submit)
+
+This is a real correctness guard on a **public, unauthenticated** form: if it
+regresses, an external form-filler can be shown a submit-blocking "required"
+error on a field that isn't even rendered — the form becomes unsubmittable
+with no way for the user to see why.
+
+Both `isFieldVisible` and `isFieldConditionallyRequired` (in `field-visibility.ts`)
+reuse `evaluateRule` from `conditional-formatting.ts` — the same rule grammar
+that drives cell conditional-formatting.
+
+**Before this change, none of this had CI teeth:**
+
+- `apps/web/src/multitable/utils/field-visibility.ts`, `apps/web/src/multitable/
+  components/MetaFormView.vue`, and `apps/web/src/multitable/utils/
+  conditional-formatting.ts` were **not** in the `paths:` trigger list of
+  `.github/workflows/multitable-web-guard.yml` — editing any of them would not
+  even cause the workflow to run.
+- The corresponding fail-first specs (`apps/web/tests/multitable-field-
+  visibility.spec.ts`, `apps/web/tests/multitable-required-if.spec.ts`,
+  `apps/web/tests/multitable-conditional-formatting.spec.ts`) were **not** in
+  the `vitest run <filter>` list inside that workflow, so even a manual/
+  unrelated trigger of the workflow would not execute them.
+- `plugin-tests.yml` (the main PR gate) only runs `pnpm --filter @metasheet/web
+  build` for the web app — a TypeScript compile check, not a behavior test. A
+  logic regression (e.g. `validate()` iterating the full field list instead of
+  the visible subset) compiles cleanly and would go undetected.
+- `.github/workflows/multitable-browser-verify.yml` **does** trigger on
+  `conditional-formatting.ts` changes, but it is a real-browser Playwright
+  render/screenshot lane (cell rendering + a reaction click), not a unit test
+  of the pure evaluator functions (`evaluateRule`, `sanitizeRule`,
+  `composeStyleObject`, …) or of the form's submit-gate logic. It does not
+  exercise `MetaFormView.vue` or `field-visibility.ts` at all.
+
+So a revert of the "hidden field is never conditionally required" invariant —
+or of the underlying visibility-hide behavior — could land on `main` fully
+green. This is a toothless guard: the fix exists, the fail-first tests already
+exist and are of good quality (evaluator-level + full component mount/submit
+assertions), but nothing in CI runs them for the files that implement the
+guard.
+
+## The fix (CI/config only)
+
+Wired `apps/web/tests/multitable-field-visibility.spec.ts`,
+`apps/web/tests/multitable-required-if.spec.ts`, and
+`apps/web/tests/multitable-conditional-formatting.spec.ts` into
+`.github/workflows/multitable-web-guard.yml`:
+
+1. Added `field-visibility.ts`, `MetaFormView.vue`, `conditional-formatting.ts`,
+   and the three spec files to the `paths:` filters (both `pull_request` and
+   `push: branches: [main]`) so the workflow actually runs when any of them
+   change.
+2. Added `multitable-field-visibility multitable-required-if
+   multitable-conditional-formatting` to the `vitest run` filter list so the
+   workflow, once triggered, executes those specs.
+
+No runtime/product source was touched. `git diff` for this PR is confined to
+`.github/workflows/multitable-web-guard.yml` and these two doc files.
+
+## Why this is the smallest clean gap here
+
+- `multitable-permission-oapi-guard-tripwire-20260705` (open PR #3574) already
+  covers an OAPI-allowlist/guard reachability gap — skipped to avoid overlap.
+- Several other open PRs in this window (#3618, #3602, #3593, #3591, #3582)
+  are design-lock / TODO / verification-record docs, not competing CI fixes —
+  no overlap with this workflow file.
+- The three specs here already exist, are well-constructed (both pure-function
+  and full component-mount/submit-event assertions), and pass cleanly today —
+  this is a pure "wire it in" fix, the lowest-risk category the task allows.
+
+## What a human reviewer should check
+
+- Confirm the new `paths:` entries and vitest filter terms in
+  `multitable-web-guard.yml` are exact matches for real files (see verification
+  doc for the local run proving the filter resolves to exactly the intended
+  spec files, no accidental substring collisions).
+- Confirm no other open PR is concurrently editing
+  `multitable-web-guard.yml` (would conflict/need rebase).
+- This PR does not change what the guard *tests*, only what triggers it and
+  what subset of already-passing specs it runs — merge risk should be limited
+  to "workflow now runs slightly more often / a bit longer."

--- a/docs/development/multitable-formview-conditional-guard-verification-20260705.md
+++ b/docs/development/multitable-formview-conditional-guard-verification-20260705.md
@@ -1,0 +1,157 @@
+# Multitable — public-form conditional show-IF/required-IF guard: CI gap closure (verification)
+
+Date: 2026-07-05
+Grounded on: `origin/main` @ `1fb2c10c4a151d1997eae5ea6cb009b9e51bf765`
+Worktree: `/private/tmp/gap-mt-df` (fresh `git worktree add ... origin/main`)
+
+## 1. Proof the gap was real (before this change)
+
+```
+$ grep -n "field-visibility\|MetaFormView\|conditional-formatting" \
+    .github/workflows/multitable-web-guard.yml
+(no matches in paths:)
+
+$ grep -n "vitest run" .github/workflows/multitable-web-guard.yml
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker --reporter=dot
+```
+
+`multitable-field-visibility`, `multitable-required-if`, and
+`multitable-conditional-formatting` are absent from that filter, and none of
+`field-visibility.ts` / `MetaFormView.vue` / `conditional-formatting.ts` are in
+the `paths:` block (confirmed against the full workflow file — see the
+`design-20260705.md` companion doc for the full paths listing at time of
+survey).
+
+`plugin-tests.yml` only runs `pnpm --filter @metasheet/web build` for the web
+app (`grep -n "vitest\|apps/web" .github/workflows/plugin-tests.yml` shows no
+`vitest run` against `apps/web`). `multitable-browser-verify.yml` triggers on
+`conditional-formatting.ts` but only runs
+`pnpm --filter @metasheet/web exec playwright test --config
+playwright.verification.config.ts` — a Playwright browser lane, not `vitest`,
+and it does not reference `field-visibility.ts` or `MetaFormView.vue` at all.
+
+Net: prior to this PR, a regression to any of these three files could merge
+to `main` fully green.
+
+## 2. Baseline: the existing specs pass today (GREEN)
+
+```
+$ pnpm --filter @metasheet/web exec vitest run \
+    multitable-field-visibility multitable-required-if \
+    multitable-conditional-formatting --reporter=dot
+
+ ✓ tests/multitable-conditional-formatting.spec.ts  (25 tests) 3ms
+ ✓ tests/multitable-field-visibility.spec.ts  (8 tests) 15ms
+ ✓ tests/multitable-required-if.spec.ts  (13 tests) 23ms
+
+ Test Files  3 passed (3)
+      Tests  46 passed (46)
+```
+
+## 3. Observed RED — the discriminator is sound
+
+Two independent temporary reverts were made **locally only**, run, observed
+red, then the files were restored byte-for-byte (`git status --porcelain`
+confirmed clean / `git diff --stat` empty after restore, before any commit was
+made). No product code changes are included in this PR.
+
+### 3a. Revert the `validate()` hidden-field exemption (`MetaFormView.vue`)
+
+Changed the submit-gate loop from the visible-only set to the full field list:
+
+```diff
+- for (const f of editableFields.value) {
++ for (const f of props.fields) {
+    const v = formData[f.id]
+    if (fieldIsRequired(f) && isEmptyFormValue(v)) {
+```
+
+Re-ran `vitest run multitable-required-if --reporter=verbose`:
+
+```
+ ✓ ... condition TRUE → empty conditionally-required field BLOCKS submit
+ × ... condition TRUE but field FILLED → submit allowed
+   → expected "spy" to be called 1 times, but got 0 times
+ ✓ ... condition FALSE → conditionally-required field is OPTIONAL
+ × ... HIDDEN field with requiredWhen → NOT required (does not block submit)
+   → expected "spy" to be called 1 times, but got 0 times
+ ✓ ... static required still blocks regardless of any requiredWhen
+
+ Test Files  1 failed (1)
+      Tests  2 failed | 11 passed (13)
+```
+
+This is exactly the regression class the guard exists to prevent: a hidden
+`requiredWhen`-satisfied field silently blocks public-form submission (spy
+never called ⇒ submit was blocked). Reverted the file back
+(`git diff --stat` empty afterward), re-ran the full 3-file suite — back to
+46/46 green.
+
+### 3b. Revert `isFieldVisible`'s rule evaluation (`field-visibility.ts`)
+
+```diff
+  const rule = getFieldVisibilityRule(field)
+  if (!rule) return true
+- return evaluateConditionRule(rule, recordData, fieldsById, options)
++ return true // BUG-INJECTED: always visible regardless of rule
+```
+
+Re-ran `vitest run multitable-field-visibility --reporter=dot`:
+
+```
+ × isFieldVisible — evaluator > dangling dependency reference ⇒ hidden
+   → expected true to be false
+ × MetaFormView — conditional field visibility (live) > hides the rule-gated
+   field until its dependency satisfies the condition
+   → expected <input ...> to be null
+
+ Test Files  1 failed (1)
+      Tests  3 failed | 5 passed (8)
+```
+
+Reverted the file back, re-ran the full 3-file suite — back to 46/46 green.
+Both RED observations prove the specs are sound fail-first discriminators for
+the guard, not tautologies.
+
+## 4. CI-gate wiring proof (after the fix)
+
+Ran the exact updated `vitest run` command from the modified
+`multitable-web-guard.yml` (all 26 filter terms, including the 3 newly added)
+against the untouched worktree:
+
+```
+ Test Files  41 passed (41)
+      Tests  419 passed (419)
+```
+
+41 files matched (38 previously-covered + 3 newly wired), confirming:
+
+- the new filter terms (`multitable-field-visibility`, `multitable-required-if`,
+  `multitable-conditional-formatting`) resolve to exactly the 3 intended spec
+  files with no accidental substring collisions against any other spec name.
+- the whole targeted guard suite is green with the addition, so wiring it in
+  will not turn `multitable-web-guard.yml` red on arrival.
+
+## 5. What was NOT changed
+
+- No product/runtime source in the final diff (`git diff --stat` against
+  `origin/main` for this branch touches only `.github/workflows/
+  multitable-web-guard.yml` plus these two docs).
+- No CI workflow was made a *required* status check here (out of scope) —
+  only the existing targeted-guard workflow's trigger surface and test
+  selection were widened, matching the `approval-web-guard.yml` precedent.
+
+## 6. What a human must still check
+
+- Whether `multitable-web-guard.yml` is (or should be) a required check on
+  branch protection — this PR does not change that, only what it runs.
+- Whether the `conditional-formatting.ts` addition to this workflow's paths
+  causes any duplicate/redundant run alongside `multitable-browser-verify.yml`
+  on the same PR (both would now trigger on that file — intentional, since
+  they test different things: unit logic vs. browser rendering, but worth a
+  human eyeballing CI time impact).
+- I did not run the workflow in GitHub Actions itself (only reproduced the
+  exact `vitest run` command locally); a human should watch the PR's Checks
+  tab to confirm `Multitable Web Guard` actually fires and passes on this PR
+  (it should, since it edits `multitable-web-guard.yml` itself, which is
+  already in the trigger paths).


### PR DESCRIPTION
WARNING: Generated by an unattended L2 build agent (Sonnet 5) WITHOUT independent adversarial review — requires human adversarial verification before merge; do not merge on green alone.

## Summary

- `field-visibility.ts` / `MetaFormView.vue` (public-form conditional show-IF / required-IF submit gate) and `conditional-formatting.ts` (the shared rule evaluator both reuse) had **zero CI enforcement**: none of the three files were `paths:` triggers for `multitable-web-guard.yml`, and their existing fail-first specs (`multitable-field-visibility.spec.ts`, `multitable-required-if.spec.ts`, `multitable-conditional-formatting.spec.ts`) were not in that workflow's `vitest run` filter either.
- `plugin-tests.yml` only build-checks `apps/web` (no vitest). `multitable-browser-verify.yml` triggers on `conditional-formatting.ts` but is a Playwright browser-render/screenshot lane — it does not exercise `MetaFormView.vue`, `field-visibility.ts`, or the pure evaluator logic.
- Net effect before this PR: a regression to the invariant "a field hidden by a visibility rule is never conditionally required" (documented directly in the component's own comments) could merge to `main` fully green, and would silently make a public, unauthenticated form unsubmittable (a required-but-invisible field blocking submit with no visible error).
- Fix is CI/config-only: added the 3 source files + 3 spec files to `multitable-web-guard.yml`'s `paths:` (pull_request + push) and added the 3 spec-name filters to its `vitest run` command. No runtime/product source changed.

## Evidence the gap was real + the fix is sound

- Confirmed via `grep` that none of the 3 files appeared in the workflow's paths or vitest filter, and that no other workflow unit-tests them (see design doc).
- Ran the 3 existing specs locally against unmodified `origin/main` — GREEN (46/46 tests, 3 files).
- Temporarily reverted the guard in two places and observed RED, then restored (verified `git status`/`git diff --stat` clean before committing):
  - `MetaFormView.vue` `validate()`: changed the visible-only iteration back to the full field list → 2 tests failed (submit incorrectly blocked by a hidden required field).
  - `field-visibility.ts` `isFieldVisible`: hardcoded `return true` → 3 tests failed (dangling-dependency + live-hide assertions).
- Ran the exact updated `multitable-web-guard.yml` `vitest run` command (all 26 filter terms) — 41 files / 419 tests, all green, confirming the new filter terms resolve to exactly the intended 3 spec files with no accidental collisions.

Full writeup: `docs/development/multitable-formview-conditional-guard-design-20260705.md` and `docs/development/multitable-formview-conditional-guard-verification-20260705.md`.

Grounded on fresh `origin/main` @ `1fb2c10c4a151d1997eae5ea6cb009b9e51bf765`.

## Test plan

- [ ] Confirm `Multitable Web Guard` check fires and passes on this PR (it edits the workflow file itself, which is already in-scope for its own trigger).
- [ ] Reviewer spot-checks that the new `paths:`/filter entries are typo-free exact matches (I verified locally, see verification doc §4).
- [ ] Confirm no branch-protection/required-check changes are needed/implied — this PR only widens what an existing (already-registered) workflow runs, it does not add or require a new check.
- [ ] Do not merge on green alone — human adversarial review required per policy.