### PR TITLE
feat(multitable): T1b — hydrate masked per-field before values in history batch detail

### DIFF
--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -223,21 +223,23 @@ describe('HistoryCenterModal — inline masked per-field diff (detail expansion)
     }
   })
 
-  // loadHistoryBatchDetail (packages/core-backend/src/multitable/history-projection.ts, ~line 560) currently
-  // ALWAYS sends `before: null` for every change — "T1b: before/after diff hydration is a detail
-  // refinement" is not yet implemented server-side; `after` is the permission-masked snapshot. This test
-  // pins the FE against TODAY's real wire shape (not just a hypothetical future one): a wholly-null
-  // `before` must render every field as "set" (never crash, never re-fetch), not as a false "masked" or
-  // a false empty-string "before" value.
-  it('matches the CURRENT real backend shape (`before` wholly null) — renders every field as "set"', async () => {
-    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+  // T1b (packages/core-backend/src/multitable/history-projection.ts `loadHistoryBatchDetail`) hydrates
+  // `before` from the immediately-previous revision's masked snapshot for `update` actions, and from the
+  // delete revision's own masked snapshot for `delete` actions — it is no longer unconditionally null.
+  // A wholly-null `before` is still a REAL wire shape, though: a `create` action has no prior state (there
+  // is nothing to hydrate), so `before` stays null there. The FE diff renderer (`changeFieldDiffs`) is
+  // action-agnostic — it only inspects `before`/`after` object membership — so this fixture locks that
+  // still-current null-before shape (create) rendering every field as "set" (never crash, never re-fetch),
+  // not as a false "masked" or a false empty-string "before" value.
+  it('a create-action change (`before` wholly null, no prior state) renders every field as "set"', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch({ action: 'create' })], total: 1, nextCursor: null, searchTruncated: false })
     const detail: HistoryBatchDetail = {
       batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
       visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 1,
       changes: [{
-        sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+        sheetId: 'sheet_1', recordId: 'rec_1', action: 'create', version: 1,
         changedFieldIds: ['fld_name'],
-        before: null, // real current wire value, always
+        before: null, // real wire value for a create — no prior revision exists to hydrate from
         after: { fld_name: 'New Name' },
       }],
     }

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -14,6 +14,12 @@
  *
  * LOCK-11: deterministic ordering `created_at DESC, version DESC, id DESC` (the existing table has a uuid
  * PK and no sequence).
+ *
+ * T1b before-image hydration (`loadHistoryBatchDetail`): `before` is populated per action — null for
+ * `create` (no prior state), the immediately-previous revision's snapshot for `update` (ONE extra batched
+ * query for the whole detail, never per-change), and the revision's own snapshot column for `delete` (it
+ * already captures the pre-delete state — see `loadPreviousSnapshots` for the full schema evidence).
+ * `before` is masked through the EXACT SAME allow-set as `after` (masking parity).
  */
 import type { QueryFn } from './permission-service'
 import { loadDeniedRecordIds, loadRowLevelReadDenyEnabled } from './permission-service'
@@ -514,6 +520,66 @@ export interface HistoryBatchDetail {
 }
 
 /**
+ * T1b before-image lookup key: `${sheetId}::${recordId}::${version}` (the CURRENT change's own version,
+ * not the previous one) so the hydration result maps back onto the exact row it was fetched for.
+ */
+function beforeLookupKey(sheetId: string, recordId: string, version: number): string {
+  return `${sheetId}::${recordId}::${version}`
+}
+
+/**
+ * T1b: batched previous-revision-snapshot lookup, ONE extra query for the whole batch (never N+1).
+ *
+ * Schema evidence for the source of the before-image (read from the capture writer, not guessed):
+ *   - `update` (record-service.ts patchRecord / record-write-service.ts bulk patch): the revision's OWN
+ *     `patch` column carries only the NEW values of changed fields (old values are never written), and its
+ *     `snapshot` column is `{ ...previousData, ...patch }` — the POST-update full state (`after`). Neither
+ *     column on the row itself carries a pre-update value, so the only place the prior state exists is the
+ *     immediately-preceding revision's `snapshot` for the SAME record — hence this lookup.
+ *   - `create` needs no lookup (no prior state; the caller leaves `before` null).
+ *   - `delete` (record-service.ts deleteRecord) needs no lookup either: its own `snapshot` column is
+ *     `normalizeJson(currentRow.data)` captured BEFORE the DELETE — i.e. the delete revision's own snapshot
+ *     column already IS the pre-delete state, so the caller reads it directly (no join needed).
+ *
+ * `targets` is deliberately restricted by the caller to `update` rows only. For each target we want the
+ * revision with the LARGEST version strictly less than the target's version for the same (sheet_id,
+ * record_id) — the nearest surviving prior revision, not `version - 1` (a `meta_revision_retention` sweep
+ * can thin the middle of the log, leaving gaps — LOCK-11/retention doc). A `JOIN LATERAL ... LIMIT 1` per
+ * target, batched via `unnest`, does this in one round trip using the existing
+ * `(sheet_id, record_id, version DESC)` index — no per-change N+1 query.
+ */
+async function loadPreviousSnapshots(
+  query: QueryFn,
+  targets: Array<{ sheetId: string; recordId: string; version: number }>,
+): Promise<Map<string, Record<string, unknown> | null>> {
+  const result = new Map<string, Record<string, unknown> | null>()
+  if (targets.length === 0) return result
+  const res = await query(
+    `SELECT t.sheet_id, t.record_id, t.version AS target_version, r.snapshot AS prev_snapshot
+     FROM unnest($1::text[], $2::text[], $3::int[]) AS t(sheet_id, record_id, version)
+     JOIN LATERAL (
+       SELECT snapshot
+       FROM meta_record_revisions
+       WHERE sheet_id = t.sheet_id AND record_id = t.record_id AND version < t.version
+       ORDER BY version DESC
+       LIMIT 1
+     ) r ON true`,
+    [targets.map((t) => t.sheetId), targets.map((t) => t.recordId), targets.map((t) => t.version)],
+  )
+  for (const row of res.rows as Array<Record<string, unknown>>) {
+    const sheetId = String(row.sheet_id)
+    const recordId = String(row.record_id)
+    const version = Number(row.target_version)
+    const snap = row.prev_snapshot
+    result.set(
+      beforeLookupKey(sheetId, recordId, version),
+      snap && typeof snap === 'object' && !Array.isArray(snap) ? (snap as Record<string, unknown>) : null,
+    )
+  }
+  return result
+}
+
+/**
  * Batch detail, permission-filtered. Returns null when the batch is unknown OR fully denied — the SAME
  * shape for missing and denied (LOCK-3: no existence oracle). The caller maps null → 404 not-found.
  */
@@ -536,14 +602,35 @@ export async function loadHistoryBatchDetail(
   if (rows.length === 0) return null
   const deniedBySheet = await loadDeniedBySheet(query, [...new Set(rows.map((r) => String(r.sheet_id)))], access)
 
-  const changes: HistoryChange[] = []
-  const visibleRecords = new Set<string>()
-  const visibleFields = new Set<string>()
-  let head: Record<string, unknown> | null = null
+  // Pass 1: drop denied rows (LOCK-3 row layer) BEFORE deciding which changes need a before-image lookup,
+  // so a denied record's version never appears in the batched query (nothing to hide there, just no waste).
+  const visible: Array<{ row: Record<string, unknown>; sheetId: string; recordId: string; action: string; version: number }> = []
   for (const r of rows) {
     const sheetId = String(r.sheet_id)
     const recordId = String(r.record_id)
     if (isDenied(deniedBySheet, sheetId, recordId)) continue // LOCK-3: row layer
+    visible.push({
+      row: r,
+      sheetId,
+      recordId,
+      action: typeof r.action === 'string' ? r.action : 'update',
+      version: Number(r.version ?? 0),
+    })
+  }
+  if (visible.length === 0) return null // fully denied → same as missing (LOCK-3, no oracle)
+
+  // ONE extra query for the whole batch (not per-change): only `update` rows need a previous-revision
+  // lookup (see loadPreviousSnapshots doc for why `create`/`delete` don't).
+  const prevSnapshotByKey = await loadPreviousSnapshots(
+    query,
+    visible.filter((v) => v.action === 'update').map((v) => ({ sheetId: v.sheetId, recordId: v.recordId, version: v.version })),
+  )
+
+  const changes: HistoryChange[] = []
+  const visibleRecords = new Set<string>()
+  const visibleFields = new Set<string>()
+  let head: Record<string, unknown> | null = null
+  for (const { row: r, sheetId, recordId, action, version } of visible) {
     if (!head) head = r
     visibleRecords.add(recordId)
     // LOCK-3 field layer: drop field ids / snapshot values / counts for fields this actor cannot read, so a
@@ -551,13 +638,23 @@ export async function loadHistoryBatchDetail(
     const allowed = allowedFieldsFor(allowedFieldsBySheet, sheetId)
     const fields = (Array.isArray(r.changed_field_ids) ? r.changed_field_ids.map(String) : []).filter((f) => allowed.has(f))
     for (const f of fields) visibleFields.add(f)
+    // T1b before-image, sourced per action semantics (see loadPreviousSnapshots doc):
+    //   create → null (no prior state); update → the immediately-previous revision's snapshot (looked up
+    //   above); delete → this revision's OWN snapshot column (the pre-delete state it captured).
+    // MASKING PARITY: `before` is filtered through the EXACT SAME `allowed` set as `after` — a field this
+    // actor cannot read never appears on either side, and `changedFieldIds` stays post-mask (unwidened).
+    const beforeSource = action === 'update'
+      ? prevSnapshotByKey.get(beforeLookupKey(sheetId, recordId, version)) ?? null
+      : action === 'delete'
+        ? r.snapshot
+        : null
     changes.push({
       sheetId,
       recordId,
-      action: typeof r.action === 'string' ? r.action : 'update',
-      version: Number(r.version ?? 0),
+      action,
+      version,
       changedFieldIds: fields,
-      before: null, // T1b: before/after diff hydration is a detail refinement; after = snapshot
+      before: filterDataByAllowedFields(beforeSource, allowed),
       after: filterDataByAllowedFields(r.snapshot, allowed),
     })
   }

--- a/packages/core-backend/tests/integration/multitable-history-before-hydration-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-before-hydration-realdb.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Global History & Point-in-Time Restore — T1b `before`-image hydration goldens (real DB).
+ *
+ * `loadHistoryBatchDetail` (history-projection.ts) used to return `before: null` unconditionally. This
+ * suite pins the hydrated contract:
+ *   - update: `before` = the immediately-previous revision's snapshot for the SAME record (looked up via
+ *     ONE extra batched query — see `loadPreviousSnapshots`), not the first-ever revision;
+ *   - create: `before` stays null (no prior state);
+ *   - delete: `before` = the delete revision's OWN snapshot column (record-service.ts `deleteRecord`
+ *     captures the pre-delete state there BEFORE issuing the DELETE);
+ *   - MASKING PARITY (the load-bearing invariant): `before` is filtered through the EXACT SAME
+ *     `allowed` field-id set as `after` — a field_permissions-denied field never appears on either side,
+ *     and stays out of `changedFieldIds` (post-mask, unwidened) — mirrors the field-mask discipline in
+ *     `multitable-history-events-realdb.test.ts` / `multitable-record-history-field-mask.test.ts`.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_t1b_${TS}`
+const SHEET_ID = `sheet_t1b_${TS}`
+const STATUS = `fld_t1b_status_${TS}`
+const SALARY = `fld_t1b_salary_${TS}` // field_permission-deniable (masking-parity golden)
+const USER_ID = `user_t1b_${TS}`
+
+const REC_UPD = `rec_t1b_upd_${TS}` // 3 revisions: create(v1) -> update(v2) -> update(v3) — goldens (a) + (e)
+const REC_CREATE = `rec_t1b_create_${TS}` // 1 revision: create(v1) — golden (c)
+const REC_DELETE = `rec_t1b_delete_${TS}` // 3 revisions: create(v1) -> update(v2) -> delete(v3) — golden (d)
+const REC_MASK = `rec_t1b_mask_${TS}` // 2 revisions: create(v1) -> update(v2), both fields — golden (b)
+
+const UPDATE_BATCH = `batch_t1b_update_${TS}`
+const CREATE_BATCH = `batch_t1b_create_${TS}`
+const DELETE_BATCH = `batch_t1b_delete_${TS}`
+const MASK_BATCH = `batch_t1b_mask_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let testUserId = USER_ID
+const testPerms: string[] = ['multitable:read', 'multitable:write']
+const testRoles: string[] = ['member']
+
+const detail = (batchId: string) => request(app).get(`/api/multitable/bases/${BASE_ID}/history/events/${batchId}`)
+type ChangeShape = {
+  recordId: string
+  action: string
+  changedFieldIds: string[]
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+}
+const changeOf = (res: { body?: { data?: { changes?: ChangeShape[] } } }, recordId: string) =>
+  (res.body?.data?.changes ?? []).find((c) => c.recordId === recordId)
+
+// Own-batch revision insert (own batch_id = its own row id when `batchId` omitted), matching the write
+// path's shapes exactly (record-service.ts / record-write-service.ts): `patch` carries only new values,
+// `snapshot` carries the FULL post-action state (or, for `delete`, the pre-delete state it captured).
+const insertRevision = (input: {
+  recordId: string
+  version: number
+  action: 'create' | 'update' | 'delete'
+  changedFieldIds: string[]
+  snapshot: Record<string, unknown> | null
+  batchId?: string
+}) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, 'rest', $5, $6::text[], '{}'::jsonb, $7::jsonb, $8)`,
+    [
+      SHEET_ID,
+      input.recordId,
+      input.version,
+      input.action,
+      USER_ID,
+      input.changedFieldIds,
+      input.snapshot === null ? null : JSON.stringify(input.snapshot),
+      input.batchId ?? null,
+    ],
+  )
+
+const denyFieldForUser = (fieldId: string) =>
+  q(
+    `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only)
+     VALUES ($1,$2,'user',$3,false,false)`,
+    [SHEET_ID, fieldId, USER_ID],
+  )
+
+const seed = async () => {
+  await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID])
+  await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
+
+  // ----- REC_UPD: create(v1, STATUS='v1') -> update(v2, STATUS='v2') -> update(v3, STATUS='v3') -----
+  // Goldens (a)+(e): detail(UPDATE_BATCH) exposes only v3; before must resolve to v2's snapshot (the
+  // IMMEDIATELY previous revision), never v1's (the first) — v1/v2/v3 are all distinct values so a bug
+  // that picks the wrong revision (or the current one) is caught, not vacuously passed.
+  await insertRevision({ recordId: REC_UPD, version: 1, action: 'create', changedFieldIds: [STATUS], snapshot: { [STATUS]: 'v1' } })
+  await insertRevision({ recordId: REC_UPD, version: 2, action: 'update', changedFieldIds: [STATUS], snapshot: { [STATUS]: 'v2' } })
+  await insertRevision({ recordId: REC_UPD, version: 3, action: 'update', changedFieldIds: [STATUS], snapshot: { [STATUS]: 'v3' }, batchId: UPDATE_BATCH })
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,3)', [REC_UPD, SHEET_ID, JSON.stringify({ [STATUS]: 'v3' })])
+
+  // ----- REC_CREATE: create(v1) only ----- golden (c): before stays null (no prior revision to find).
+  await insertRevision({ recordId: REC_CREATE, version: 1, action: 'create', changedFieldIds: [STATUS], snapshot: { [STATUS]: 'created' }, batchId: CREATE_BATCH })
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_CREATE, SHEET_ID, JSON.stringify({ [STATUS]: 'created' })])
+
+  // ----- REC_DELETE: create(v1, 'alive') -> update(v2, 'updated') -> delete(v3) -----
+  // golden (d): the delete revision's OWN snapshot column already IS the pre-delete state ('updated', the
+  // LAST state before deletion) — distinct from v1's 'alive' so a bug reusing the first snapshot is caught.
+  await insertRevision({ recordId: REC_DELETE, version: 1, action: 'create', changedFieldIds: [STATUS], snapshot: { [STATUS]: 'alive' } })
+  await insertRevision({ recordId: REC_DELETE, version: 2, action: 'update', changedFieldIds: [STATUS], snapshot: { [STATUS]: 'updated' } })
+  await insertRevision({ recordId: REC_DELETE, version: 3, action: 'delete', changedFieldIds: [], snapshot: { [STATUS]: 'updated' }, batchId: DELETE_BATCH })
+  // deleteRecord hard-deletes the live row; meta_records intentionally has none for REC_DELETE.
+
+  // ----- REC_MASK: create(v1, STATUS='a', SALARY=1000) -> update(v2, STATUS='b', SALARY=2000) -----
+  // golden (b): masking parity. detail(MASK_BATCH) exposes only v2.
+  await insertRevision({ recordId: REC_MASK, version: 1, action: 'create', changedFieldIds: [STATUS, SALARY], snapshot: { [STATUS]: 'a', [SALARY]: 1000 } })
+  await insertRevision({ recordId: REC_MASK, version: 2, action: 'update', changedFieldIds: [STATUS, SALARY], snapshot: { [STATUS]: 'b', [SALARY]: 2000 }, batchId: MASK_BATCH })
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [REC_MASK, SHEET_ID, JSON.stringify({ [STATUS]: 'b', [SALARY]: 2000 })])
+}
+
+describeIfDatabase('T1b before-image hydration goldens (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: testRoles, perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'T1b Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'T1b Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET_ID, 'Salary', 'number', '{}', 2])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  afterEach(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    testUserId = USER_ID
+    await seed()
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('(a) update-action: before = prior value, after = new value (both sides real values)', async () => {
+    const res = await detail(UPDATE_BATCH)
+    expect(res.status).toBe(200)
+    const change = changeOf(res, REC_UPD)
+    expect(change?.action).toBe('update')
+    expect(change?.changedFieldIds).toContain(STATUS)
+    expect(change?.before?.[STATUS]).toBe('v2')
+    expect(change?.after?.[STATUS]).toBe('v3')
+  })
+
+  test('(e) multi-revision record: before reflects the IMMEDIATELY-previous revision, not the first', async () => {
+    const res = await detail(UPDATE_BATCH)
+    expect(res.status).toBe(200)
+    const change = changeOf(res, REC_UPD)
+    expect(change?.before?.[STATUS]).not.toBe('v1') // would be the wrong (first) revision
+    expect(change?.before?.[STATUS]).toBe('v2') // the correct (immediately previous) revision
+  })
+
+  test('(c) create-action: before is null', async () => {
+    const res = await detail(CREATE_BATCH)
+    expect(res.status).toBe(200)
+    const change = changeOf(res, REC_CREATE)
+    expect(change?.action).toBe('create')
+    expect(change?.before).toBeNull()
+    expect(change?.after?.[STATUS]).toBe('created')
+  })
+
+  test('(d) delete-action: before = last snapshot (masked)', async () => {
+    const res = await detail(DELETE_BATCH)
+    expect(res.status).toBe(200)
+    const change = changeOf(res, REC_DELETE)
+    expect(change?.action).toBe('delete')
+    expect(change?.before?.[STATUS]).toBe('updated') // the LAST state before deletion, not the first ('alive')
+  })
+
+  test('(b) control (non-vacuous): with NO field denial, before+after both carry SALARY (genuine values)', async () => {
+    const res = await detail(MASK_BATCH)
+    expect(res.status).toBe(200)
+    const change = changeOf(res, REC_MASK)
+    expect(change?.changedFieldIds).toEqual(expect.arrayContaining([STATUS, SALARY]))
+    expect(change?.before?.[SALARY]).toBe(1000)
+    expect(change?.after?.[SALARY]).toBe(2000)
+  })
+
+  test('(b) masking parity: a field-denied viewer gets NEITHER before nor after for that field, and it stays out of changedFieldIds', async () => {
+    await denyFieldForUser(SALARY)
+    const res = await detail(MASK_BATCH)
+    expect(res.status).toBe(200)
+    const change = changeOf(res, REC_MASK)
+    expect(change?.changedFieldIds).toEqual([STATUS]) // SALARY id absent
+    expect(change?.before?.[SALARY]).toBeUndefined() // SALARY absent from before
+    expect(change?.after?.[SALARY]).toBeUndefined() // SALARY absent from after (pre-existing contract)
+    // the SAME change's other field is unaffected (surgical masking, not a wholesale drop)
+    expect(change?.before?.[STATUS]).toBe('a')
+    expect(change?.after?.[STATUS]).toBe('b')
+  })
+})


### PR DESCRIPTION
Closes the read-only T1b "before/after diff hydration" refinement noted in `history-projection.ts` since #2961 — the last non-gated item on the Global History line. The FE inline diff (#3608) lights up full before→after rows automatically; no FE code change.

## Design (schema-evidenced, not guessed)
- **create** → `before: null` (no prior state)
- **update** → the **nearest surviving prior revision's** `snapshot` (the row's own `patch`/`snapshot` only carry post-update values — verified in `record-service.ts`/`record-write-service.ts`); *nearest surviving*, not `version-1`, because retention sweeps can thin the log
- **delete** → the revision's OWN `snapshot` column (`deleteRecord` captures it pre-delete; no lookup needed)

**One extra query for the whole batch** (never per-change N+1): `unnest`-batched `JOIN LATERAL … LIMIT 1`, restricted to the batch's `update` rows, riding the existing `(sheet_id, record_id, version DESC)` index. Denied rows are dropped BEFORE the lookup (their versions never enter the query).

**Masking parity (the critical invariant):** `before` passes through the EXACT same allow-set filter as `after`; `changedFieldIds` stays post-mask/unwidened. Wire contract unchanged (`before: object|null`).

## Verify
- New realdb golden suite (7): update before/after, masking parity (control+denial), create-null, delete-snapshot, multi-revision immediately-previous.
- **Mutation-proven:** (1) reading the wrong revision reddened exactly the value goldens; (2) skipping the mask on `before` only reddened exactly the masking-parity golden (others stayed green — isolation confirmed). Both reverted.
- Full history/mask realdb sweep: **85/85** (7 new + 78 pre-existing across events/hasMore/audit-grant/reveal/taint/field-mask suites) on disposable PG16 (CI's migration recipe).
- `tsc --noEmit` clean. OpenAPI untouched (route not in base.yml — grep-verified, zero dist drift).
- FE spec `multitable-history-center-inline-diff.spec.ts` 6/6 — one spec's stale "server always sends null" premise re-targeted to the still-real create-action shape (renderer coverage unchanged).

Honest gap: with retention enabled (default off), a pruned middle revision means `before` reflects the nearest *surviving* older state — an inherent retention tradeoff, documented in the lookup's comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)