### PR TITLE
fix(db): drifted-history migration hardening — FK type guard + un-swallowed conditional constraint

### DIFF
--- a/packages/core-backend/src/db/migrations/20250925_create_view_tables.sql
+++ b/packages/core-backend/src/db/migrations/20250925_create_view_tables.sql
@@ -15,9 +15,36 @@ CREATE TABLE IF NOT EXISTS tables (
   UNIQUE(name, workspace_id, deleted_at)
 );
 
--- Add FK constraint only if users table exists
+-- Add FK constraint only if users table exists AND users.id's type is
+-- compatible with tables.owner_id (integer). This migration historically ran
+-- before the users table existed (fresh installs create users later, in
+-- zzzz20260119100000_create_users_table.ts, whose id column is TEXT), so the
+-- table-existence-only guard below never fired the ALTER on that path and the
+-- FK was simply (silently) never added -- that is today's real end state on
+-- every environment where this migration succeeded. But this migrator runs
+-- with allowUnorderedMigrations: true (see migrate.ts), so a drifted/stale
+-- environment can apply this migration AFTER users already exists with its
+-- TEXT id, and PL/pgSQL's `EXCEPTION WHEN duplicate_object` does not catch a
+-- 42804 datatype mismatch -- it propagates and aborts the whole migration
+-- transaction (reproduced: "foreign key constraint \"tables_owner_id_fkey\"
+-- cannot be implemented ... Key columns \"owner_id\" and \"id\" are of
+-- incompatible types: integer and text"). Adding the type check makes this
+-- migration a no-op-equivalent everywhere it used to succeed (types never
+-- matched there either -- the FK genuinely never gets added on any current
+-- schema) while turning the crash on the drifted path into the same safe
+-- skip, so it is safe in-place for both worlds: already-applied environments
+-- never re-run this migration (kysely skips by name), and not-yet-applied
+-- environments now converge on the same end state the working path already
+-- produces.
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users') THEN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users')
+     AND EXISTS (
+       SELECT 1
+       FROM information_schema.columns u
+       JOIN information_schema.columns t ON t.data_type = u.data_type
+       WHERE u.table_schema = 'public' AND u.table_name = 'users' AND u.column_name = 'id'
+         AND t.table_schema = 'public' AND t.table_name = 'tables' AND t.column_name = 'owner_id'
+     ) THEN
     BEGIN
       ALTER TABLE tables ADD CONSTRAINT tables_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES users(id);
     EXCEPTION WHEN duplicate_object THEN NULL; END;
@@ -45,9 +72,18 @@ CREATE TABLE IF NOT EXISTS views (
   CONSTRAINT unique_default_view EXCLUDE (table_id WITH =) WHERE (is_default = TRUE AND deleted_at IS NULL)
 );
 
--- Add FK constraint only if users table exists
+-- Add FK constraint only if users table exists AND its id type matches
+-- views.created_by (integer) -- see the tables_owner_id_fkey comment above
+-- for the full both-worlds-safety rationale; same pattern applied here.
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users') THEN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users')
+     AND EXISTS (
+       SELECT 1
+       FROM information_schema.columns u
+       JOIN information_schema.columns t ON t.data_type = u.data_type
+       WHERE u.table_schema = 'public' AND u.table_name = 'users' AND u.column_name = 'id'
+         AND t.table_schema = 'public' AND t.table_name = 'views' AND t.column_name = 'created_by'
+     ) THEN
     BEGIN
       ALTER TABLE views ADD CONSTRAINT views_created_by_fkey FOREIGN KEY (created_by) REFERENCES users(id);
     EXCEPTION WHEN duplicate_object THEN NULL; END;
@@ -65,9 +101,18 @@ CREATE TABLE IF NOT EXISTS view_states (
   UNIQUE(view_id, user_id)
 );
 
--- Add FK constraint only if users table exists
+-- Add FK constraint only if users table exists AND its id type matches
+-- view_states.user_id (integer) -- see the tables_owner_id_fkey comment
+-- above for the full both-worlds-safety rationale; same pattern applied here.
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users') THEN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users')
+     AND EXISTS (
+       SELECT 1
+       FROM information_schema.columns u
+       JOIN information_schema.columns t ON t.data_type = u.data_type
+       WHERE u.table_schema = 'public' AND u.table_name = 'users' AND u.column_name = 'id'
+         AND t.table_schema = 'public' AND t.table_name = 'view_states' AND t.column_name = 'user_id'
+     ) THEN
     BEGIN
       ALTER TABLE view_states ADD CONSTRAINT view_states_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
     EXCEPTION WHEN duplicate_object THEN NULL; END;
@@ -142,9 +187,19 @@ CREATE TABLE IF NOT EXISTS form_responses (
   status VARCHAR(20) DEFAULT 'submitted' CHECK (status IN ('submitted', 'processed', 'archived'))
 );
 
--- Add FK constraint only if users table exists
+-- Add FK constraint only if users table exists AND its id type matches
+-- form_responses.submitted_by (integer) -- see the tables_owner_id_fkey
+-- comment above for the full both-worlds-safety rationale; same pattern
+-- applied here.
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users') THEN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users')
+     AND EXISTS (
+       SELECT 1
+       FROM information_schema.columns u
+       JOIN information_schema.columns t ON t.data_type = u.data_type
+       WHERE u.table_schema = 'public' AND u.table_name = 'users' AND u.column_name = 'id'
+         AND t.table_schema = 'public' AND t.table_name = 'form_responses' AND t.column_name = 'submitted_by'
+     ) THEN
     BEGIN
       ALTER TABLE form_responses ADD CONSTRAINT form_responses_submitted_by_fkey FOREIGN KEY (submitted_by) REFERENCES users(id);
     EXCEPTION WHEN duplicate_object THEN NULL; END;
@@ -169,12 +224,30 @@ CREATE TABLE IF NOT EXISTS view_permissions (
   )
 );
 
--- Add FK constraints only if referenced tables exist with matching types
+-- Add FK constraints only if referenced tables exist with matching types --
+-- see the tables_owner_id_fkey comment above for the full both-worlds-safety
+-- rationale; same pattern applied here for user_id/created_by (integer).
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users') THEN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users')
+     AND EXISTS (
+       SELECT 1
+       FROM information_schema.columns u
+       JOIN information_schema.columns t ON t.data_type = u.data_type
+       WHERE u.table_schema = 'public' AND u.table_name = 'users' AND u.column_name = 'id'
+         AND t.table_schema = 'public' AND t.table_name = 'view_permissions' AND t.column_name = 'user_id'
+     ) THEN
     BEGIN
       ALTER TABLE view_permissions ADD CONSTRAINT view_permissions_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
     EXCEPTION WHEN duplicate_object THEN NULL; END;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users')
+     AND EXISTS (
+       SELECT 1
+       FROM information_schema.columns u
+       JOIN information_schema.columns t ON t.data_type = u.data_type
+       WHERE u.table_schema = 'public' AND u.table_name = 'users' AND u.column_name = 'id'
+         AND t.table_schema = 'public' AND t.table_name = 'view_permissions' AND t.column_name = 'created_by'
+     ) THEN
     BEGIN
       ALTER TABLE view_permissions ADD CONSTRAINT view_permissions_created_by_fkey FOREIGN KEY (created_by) REFERENCES users(id);
     EXCEPTION WHEN duplicate_object THEN NULL; END;
@@ -202,9 +275,18 @@ CREATE TABLE IF NOT EXISTS view_activity (
   PRIMARY KEY (id, created_at)  -- Must include partition key created_at
 ) PARTITION BY RANGE (created_at);
 
--- Add FK constraint only if users table exists
+-- Add FK constraint only if users table exists AND its id type matches
+-- view_activity.user_id (integer) -- see the tables_owner_id_fkey comment
+-- above for the full both-worlds-safety rationale; same pattern applied here.
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users') THEN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users')
+     AND EXISTS (
+       SELECT 1
+       FROM information_schema.columns u
+       JOIN information_schema.columns t ON t.data_type = u.data_type
+       WHERE u.table_schema = 'public' AND u.table_name = 'users' AND u.column_name = 'id'
+         AND t.table_schema = 'public' AND t.table_name = 'view_activity' AND t.column_name = 'user_id'
+     ) THEN
     BEGIN
       ALTER TABLE view_activity ADD CONSTRAINT view_activity_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
     EXCEPTION WHEN duplicate_object THEN NULL; END;

--- a/packages/core-backend/src/db/migrations/zzzz20260411120100_approval_templates_and_instance_extensions.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260411120100_approval_templates_and_instance_extensions.ts
@@ -48,13 +48,46 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
   )`.execute(db)
 
-  await sql`ALTER TABLE approval_templates
-    ADD CONSTRAINT approval_templates_active_version_fk
-    FOREIGN KEY (active_version_id) REFERENCES approval_template_versions(id) ON DELETE SET NULL`.execute(db).catch(() => undefined)
+  // These two FKs used to be guarded with `.execute(db).catch(() => undefined)`.
+  // That swallows ANY error, not just "already exists" -- and on Postgres a
+  // failed statement poisons the enclosing (implicit, per-migration)
+  // transaction, so once the swallowed error fired, the very next statement
+  // in this migration (the CREATE UNIQUE INDEX below) failed with
+  // "current transaction is aborted, commands ignored until end of
+  // transaction block" (reproduced by pre-creating one of these constraints
+  // and replaying this statement sequence in one transaction). Following the
+  // pg_constraint-existence-check pattern already used elsewhere in this
+  // migration set (e.g. zzzz20260409134000_create_delegated_role_scope_templates.ts)
+  // avoids ever attempting the ALTER when the constraint is already there,
+  // so nothing can fail and nothing needs to be swallowed. This is a safe
+  // in-place edit for both worlds: environments where this migration is
+  // already recorded as applied never re-run it (kysely skips by name), and
+  // environments where it hasn't run yet reach the identical end state
+  // (both FKs present) that the previous code intended -- just without the
+  // poisoning failure mode.
+  await sql`DO $$ BEGIN
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'approval_templates_active_version_fk'
+        AND conrelid = 'approval_templates'::regclass
+    ) THEN
+      ALTER TABLE approval_templates
+        ADD CONSTRAINT approval_templates_active_version_fk
+        FOREIGN KEY (active_version_id) REFERENCES approval_template_versions(id) ON DELETE SET NULL;
+    END IF;
+  END $$`.execute(db)
 
-  await sql`ALTER TABLE approval_templates
-    ADD CONSTRAINT approval_templates_latest_version_fk
-    FOREIGN KEY (latest_version_id) REFERENCES approval_template_versions(id) ON DELETE SET NULL`.execute(db).catch(() => undefined)
+  await sql`DO $$ BEGIN
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'approval_templates_latest_version_fk'
+        AND conrelid = 'approval_templates'::regclass
+    ) THEN
+      ALTER TABLE approval_templates
+        ADD CONSTRAINT approval_templates_latest_version_fk
+        FOREIGN KEY (latest_version_id) REFERENCES approval_template_versions(id) ON DELETE SET NULL;
+    END IF;
+  END $$`.execute(db)
 
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_templates_key
     ON approval_templates(key)`.execute(db)


### PR DESCRIPTION
Fixes the two latent migration defects recorded in PR #3609's discussion. **Honest reframing from investigation:** a vanilla empty-PG `db:migrate` on current main is actually clean (237/237, exit 0) — these bugs bite on **drifted/out-of-order histories**, a path this repo explicitly supports (`allowUnorderedMigrations: true`, `migrate.ts:32`). Bug 1 is independently corroborated as real by CI itself: `migration-replay.yml:75` excludes the file with the comment "legacy owner_id FK assumes pre-text user ids during replay" — CI has been working around it, not fixing it.

## Bug 1 — `20250925_create_view_tables.sql` FK guards (7 blocks)
Guards checked only that `users` EXISTS, not that `users.id` (text) is type-compatible with the local integer columns; `EXCEPTION WHEN duplicate_object` does not catch a 42804 type mismatch, so on a drifted path the whole migration transaction aborts (exact error reproduced in-branch). **Fix:** AND a type-compatibility check (`information_schema.columns` data_type join) onto each existence guard. Both-worlds-safe: on every schema where this migration already succeeded the types never matched either — the FK was already silently never added — so the edit is no-op-equivalent there and merely converts the drifted-path crash into the same safe skip. Already-applied environments never re-run it (kysely skips by name).

## Bug 2 — `zzzz20260411120100_approval_templates…` swallowed `.catch()`
`.execute(db).catch(() => undefined)` swallows ANY error; a failed ALTER poisons the per-migration transaction so the NEXT statement dies with "current transaction is aborted" (reproduced). **Fix:** `pg_constraint`-existence `DO $$` guards (the pattern already used by `zzzz20260409134000_…`); nothing attempted when present, nothing swallowed, identical end state (both FKs present).

## Verify (all real)
- Empty postgres:16 → full `db:migrate`: exit 0, `Applied: 237, Pending: 0`.
- End-state `\d` dumps for all 7 touched tables identical to the pre-fix succeeding baseline.
- Guard idempotence: manually replayed 2-3× incl. pre-existing constraint — clean.
- CI migration-replay recipe (same MIGRATION_EXCLUDE, double-run): green. **Bonus:** also passes with `20250925_create_view_tables.sql` REMOVED from the exclude list — the root cause CI works around is now fixed; removing the exclusion is left as a separate maintainer decision (workflow untouched).
- `tsc --noEmit` clean.

Also found (NOT fixed, out of scope, recorded for awareness): under the off-by-default `MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL=true` debug flag, a different uuid/text FK mismatch fires first in `20250924120000_create_views_view_states.ts` (legacy 051/052 SQL creates `views.id` as text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)