### PR TITLE
ci(db): drop 20250925 from migration-replay exclude (root cause fixed by #3627)

### DIFF
--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -72,21 +72,20 @@ jobs:
           # TODO: Rewrite these migrations with correct PostgreSQL syntax
           # Exclude 20250924120000_create_views_view_states.ts - View states migration with schema issues
           # Exclude 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # Exclude 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay
           # Exclude 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
           # Exclude 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
           # Exclude 20251201000001_create_change_management_tables.ts - legacy snapshot_id text FKs no longer match replay-built uuid snapshot ids
           # Exclude zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility
           # Exclude 042a_core_model_views.sql - References non-existent last_accessed column
           # TODO: Fix last_accessed column reference in 042a_core_model_views.sql
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:migrate
           pnpm -F @metasheet/core-backend db:migrate
       - name: List migrations
         env:
           DATABASE_URL: postgresql://127.0.0.1/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: pnpm -F @metasheet/core-backend db:list
 
       - name: Upload install logs on failure


### PR DESCRIPTION
Follow-up hygiene to #3627: the `20250925_create_view_tables.sql` exclusion in `migration-replay.yml` worked around the owner_id FK type-mismatch crash — #3627 fixed that root cause (type-compatibility guards on all 7 FK blocks), so the exclusion can be retired and the file goes back under replay coverage.

**Verified** by replicating the workflow recipe exactly on a fresh postgres:16 with the NEW exclude list: `db:migrate` ×2 both exit 0 (double-run idempotence), `db:list` → Pending: 0. #3627's own verification independently proved the same. Other exclusions untouched (their root causes are separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)