### PR TITLE
test(attendance): report-sync A2 scheduled-trigger staging smoke tooling (S3)

### DIFF
--- a/docs/development/attendance-report-sync-a2-staging-smoke-runbook-20260705.md
+++ b/docs/development/attendance-report-sync-a2-staging-smoke-runbook-20260705.md
@@ -1,0 +1,272 @@
+# Report-sync A2 scheduled-trigger staging smoke runbook
+
+**Date:** 2026-07-05
+**Scope:** ops tooling only — this runbook and its companion helper build the S3 staging-smoke
+slice of `docs/development/attendance-report-sync-a2-scheduled-trigger-design-lock-20260705.md`
+(#3623, RATIFIED owner-delegated). Zero runtime/product code changes. It does **not** mark
+report-sync A2 complete by itself — the design-lock's §4 completion bar also requires the
+backend runtime + reverse tests (that is #3630, not this slice) and an Opus adversarial review
+pass, and this runbook's own tracker line only flips after a real staging PASS with residue `0`.
+
+## Dependency note (read first)
+
+This runbook and its helper assert against the settings keys / job shapes / exported test seam
+that **#3630 (report-sync A2 scheduled trigger runtime, OPEN as of this writing)** introduces:
+
+- `reportSync.scheduledTrigger.{enabled,cadence,maxOrgsPerRun,maxUsersPerRun}` settings (default
+  all-off);
+- env flag `ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED`;
+- scheduler job name `attendance-report-sync-scheduled`;
+- test seam `attendancePlugin.__attendanceReportFieldCatalogForTests.runAttendanceReportSyncScheduledTriggerOnce`
+  (and its siblings `resolveAttendanceReportSyncScheduledTriggerOrgIds` /
+  `resetAttendanceSettingsCacheForTests`).
+
+**The helper cannot run until #3630 merges and is deployed to the target environment.** If #3630's
+implementation shape changes during its own review (settings keys, function names, return shape,
+job statuses), this runbook and `scripts/ops/staging-attendance-report-sync-a2-smoke.mjs` /
+`.test.mjs` must be updated to match before the next run — see the PR body for the exact
+dependency this slice took on #3630's diff as read at authoring time.
+
+## Automated helper
+
+The env+settings-gate / seed / tick / idempotency / throttle / residue steps below are scripted by
+`scripts/ops/staging-attendance-report-sync-a2-smoke.mjs` (+ companion `.test.mjs` contract
+tests), modeled on two existing helpers:
+
+- structure/style/two-stage-stamp convention from
+  `scripts/ops/staging-attendance-manual-missed-punch-reminder-hmr5-smoke.mjs` (pure helpers
+  exported for the companion `.test.mjs`, `IS_MAIN` gate, `resolveEnvConfig`, STAMP regex lock);
+- the scheduler-job mechanics (direct plugin require + in-process tick calls + a second-tick
+  idempotency proof) from `scripts/ops/staging-attendance-auto-shift-a2-smoke.mjs` — this helper
+  calls the exported A2 tick function directly against the staging DB, the same way that helper
+  does, rather than waiting on `AttendanceScheduler`'s own interval loop.
+
+Run it from a prepared metasheet2 checkout, on a host that can reach both the staging API and its
+Postgres (the helper calls the scheduled-trigger tick function **directly in this Node process**,
+not through the deployed server — see SCOPE NOTE below):
+
+```bash
+BASE_URL=http://127.0.0.1:8082 \
+DATABASE_URL=postgresql://USER@127.0.0.1:5432/metasheet \
+DEPLOY_SHA=<staging-main-sha> \
+ATTENDANCE_SCHEDULER_ENABLED=true \
+ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED=true \
+node scripts/ops/staging-attendance-report-sync-a2-smoke.mjs
+```
+
+Optional env: `SMOKE_TOKEN=<admin bearer>` (else the helper mints its own dev-token — dev-node-env
+only), `STAMP=reportsync-a2-smoke-...` (else auto-generated), `RUN_DATE=YYYY-MM-DD` (else today,
+UTC), `ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT=1` (see the cross-org fan-out hazard below — required
+whenever the target DB already has other orgs' `attendance_rules` rows).
+
+It prints `REPORT_SYNC_A2_API_DB_SMOKE_PASS deploy=<sha> stamp=reportsync-a2-smoke-...
+org=<main-org> orgs=<gate>|<main>|<throttle> synced=<n> collateralOtherOrgs=<n> residue=0`, which
+is **not** the final PASS stamp — same two-stage pattern as the HMR-5 / MP-6 / AE-4 / RD-4/5
+helpers. See "Manual close-out steps" below for what it does not cover and the final stamp name.
+
+### SCOPE NOTE — two things the automated helper deliberately does not prove
+
+1. **Real multitable base/sheet writes.** The helper's `context.api.multitable` is an in-process,
+   in-memory stand-in (`createFakeReportRecordsMultitable` in the `.mjs`), matching the exact same
+   shape the real-DB CI gate's own fake uses — not the real multitable REST/plugin stack. The
+   design-lock explicitly delegates every write to the **existing**
+   `syncAttendanceReportRecordsForUsers` writer and says A2 must not re-implement multitable
+   writes; that writer's real multitable behavior is already staging-proven separately (2026-05-19
+   live evidence via `pnpm run verify:attendance-report-fields:live` JOB_MODE=1,
+   `scripts/ops/attendance-report-fields-live-acceptance.mjs`). This helper's job is the genuinely
+   **new** part: the scheduling/claim/idempotency/throttle layer around that writer, proven for
+   real against real staging Postgres and the real settings HTTP API — hence the `API_DB` stamp
+   name, not an `API_MULTITABLE` one.
+2. **The real `AttendanceScheduler` interval pickup.** Like the auto-shift-A2 helper, this one
+   calls the exported tick function directly in the helper's own process. It does not prove the
+   real deployed scheduler actually registers and ticks `attendance-report-sync-scheduled` on its
+   own interval once both gates are left open for real.
+
+### Cross-org fan-out hazard
+
+`resolveAttendanceReportSyncScheduledTriggerOrgIds` (the org-fan-out helper #3630 adds) has **no
+per-org filter** — `SELECT DISTINCT org_id FROM attendance_rules ORDER BY org_id`, sliced to
+`maxOrgsPerRun`. A gate-open tick claims+runs a report-sync job for **every** org with an
+`attendance_rules` row, up to that cap (deterministic `ORDER BY org_id` as of the #3630 review
+pass; still no allowlist). This helper computes `maxOrgsPerRun` wide enough to guarantee its own
+3 synthetic orgs are always covered, which means it also sweeps in any pre-existing real orgs on
+the target DB — read-only reads of their `attendance_records`, plus one real
+`plugin_attendance_report_sync_jobs` row created for each (no multitable write escapes to them,
+per the SCOPE NOTE above).
+
+The helper **refuses to run** against a DB with pre-existing other-org `attendance_rules` rows
+unless `ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT=1` is set, and — even when allowed — reports (but does
+not delete) any collateral job rows it caused for those other orgs at the end, so an operator can
+review/clean them up manually. Prefer running this against a scratch/isolated staging Postgres
+with no other tenants' `attendance_rules` rows if at all possible.
+
+## What This Proves
+
+- both gate halves (env flag, settings) independently no-op when either is off — byte-exact
+  `{ ran:false, reason:'disabled', orgs:[] }`, zero job rows either way;
+- with both gates open, a tick claims (creates) a `mode:'enqueue'` / `kind:'daily_records'` job row
+  for an org, delegates to the existing writer, and the SAME tick both **creates** a report-record
+  for a brand-new user and **patches** a pre-existing-but-stale one (dual-fingerprint compare) in
+  one page;
+- a repeat tick in the same period is a byte-exact no-op (`claimed:false,
+  reason:'already_completed'`, same `jobId`, zero additional writes) — the job table's
+  `(org_id, idempotency_key)` unique index plus the writer's own fingerprint compare;
+- `maxUsersPerRun` throttles pagination: the SAME job resumes (not recreated) across several ticks
+  until the whole roster drains, then further ticks are no-ops;
+- `maxOrgsPerRun` throttles the org fan-out itself (proven directly against the exported pure
+  helper, not by guessing which orgs a full run happens to cover);
+- cleanup removes every synthetic org/user/rule/record/job row this helper created, with residue
+  `0` (collateral rows on **other**, pre-existing orgs are reported, not deleted — see the hazard
+  note above).
+
+## Prerequisites
+
+1. Staging (or the target environment) runs a build containing #3630 (report-sync A2 scheduled
+   trigger runtime) — merged on top of #3623 (this design-lock, already RATIFIED and merged).
+2. Migrations current through `plugin_attendance_report_sync_jobs`
+   (`zzzz20260519070000_create_plugin_attendance_report_sync_jobs`) and the settings schema change
+   #3630 adds (no new migration — `reportSync` lives in the existing JSONB settings blob).
+3. Run from a host that can reach both the API and the Postgres the API itself uses:
+
+```bash
+BASE_URL=http://127.0.0.1:8082
+DATABASE_URL=postgresql://USER@127.0.0.1:5432/metasheet
+DEPLOY_SHA=<staging-main-sha>
+ATTENDANCE_SCHEDULER_ENABLED=true
+ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED=true
+```
+
+4. Confirm no pre-existing `attendance_rules` rows for other orgs, or plan to set
+   `ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT=1` and review the collateral report at the end.
+5. This helper mints its own admin dev-token via `/api/auth/dev-token` (dev/staging node-env
+   only). Supply `SMOKE_TOKEN=<bearer>` for an environment that 404s that route.
+
+## Manual fallback (if the helper cannot run on a given host)
+
+The helper is a thin, mechanical wrapper around:
+
+1. `GET /api/attendance/settings` → capture `data.reportSync` for restore.
+2. Seed one `attendance_rules` row (`is_default=true`, `timezone='UTC'`) + one or more
+   `users`/`user_orgs` rows + `attendance_records` rows per synthetic org, for 3 disposable orgs
+   (`<stamp>-gate`, `<stamp>-main`, `<stamp>-throttle`).
+3. `PUT /api/attendance/settings` with `{ reportSync: { scheduledTrigger: { enabled, cadence,
+   maxOrgsPerRun, maxUsersPerRun } } }`.
+4. In a Node REPL from the repo root, with `ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED` set
+   appropriately:
+   ```js
+   const plugin = require('./plugins/plugin-attendance/index.cjs')
+   const seam = plugin.__attendanceReportFieldCatalogForTests
+   // context.api.multitable needs a records/provisioning stand-in — see createFakeReportRecordsMultitable
+   // in the .mjs helper for the exact shape to hand-construct here.
+   await seam.runAttendanceReportSyncScheduledTriggerOnce(context, pluginDb, console, { now, emitEvent: () => {} })
+   ```
+5. Inspect `plugin_attendance_report_sync_jobs` rows directly by `org_id`.
+
+Prefer the `.mjs` helper — this fallback exists only for a host without Node/`pg` access to run it.
+
+## Residue Check
+
+Before cleanup, record evidence (replace `:GATE_ORG`/`:MAIN_ORG`/`:THROTTLE_ORG` with the actual
+stamped org ids the helper printed, or query by `stamp` prefix):
+
+```sql
+SELECT org_id, status, mode, kind, idempotency_key, totals
+FROM plugin_attendance_report_sync_jobs
+WHERE org_id IN (:GATE_ORG, :MAIN_ORG, :THROTTLE_ORG)
+ORDER BY org_id;
+```
+
+Cleanup (the helper does this automatically; shown here for the manual-fallback path):
+
+```sql
+DELETE FROM plugin_attendance_report_sync_jobs WHERE org_id = ANY(ARRAY[:GATE_ORG, :MAIN_ORG, :THROTTLE_ORG]);
+DELETE FROM attendance_records WHERE org_id = ANY(ARRAY[:GATE_ORG, :MAIN_ORG, :THROTTLE_ORG]);
+DELETE FROM attendance_rules WHERE org_id = ANY(ARRAY[:GATE_ORG, :MAIN_ORG, :THROTTLE_ORG]);
+DELETE FROM user_orgs WHERE user_id = ANY(ARRAY[/* every synthetic user id */]);
+DELETE FROM users WHERE id = ANY(ARRAY[/* every synthetic user id */]);
+```
+
+Residue must be zero:
+
+```sql
+SELECT
+  (SELECT count(*) FROM plugin_attendance_report_sync_jobs WHERE org_id = ANY(ARRAY[:GATE_ORG, :MAIN_ORG, :THROTTLE_ORG])) AS jobs,
+  (SELECT count(*) FROM attendance_records WHERE org_id = ANY(ARRAY[:GATE_ORG, :MAIN_ORG, :THROTTLE_ORG])) AS records,
+  (SELECT count(*) FROM attendance_rules WHERE org_id = ANY(ARRAY[:GATE_ORG, :MAIN_ORG, :THROTTLE_ORG])) AS rules;
+```
+
+Collateral cross-org rows (informational only — these belong to orgs the helper did not create and
+are intentionally left in place; review and decide manually):
+
+```sql
+SELECT org_id, count(*) FROM plugin_attendance_report_sync_jobs
+WHERE org_id NOT IN (:GATE_ORG, :MAIN_ORG, :THROTTLE_ORG)
+  AND created_by = 'system:attendance-report-sync-scheduled-trigger'
+  AND created_at >= :SMOKE_STARTED_AT
+GROUP BY org_id;
+```
+
+## Manual close-out steps
+
+The automated helper's `REPORT_SYNC_A2_API_DB_SMOKE_PASS` stamp is not the final PASS stamp. Two
+manual steps close the gap the SCOPE NOTE above describes:
+
+1. **Required — real scheduler interval pickup.** With both gates left open for real (env flag +
+   settings `enabled:true` on the actual deployed backend, not just this helper's own process),
+   wait one real `AttendanceScheduler` interval and confirm a NEW
+   `plugin_attendance_report_sync_jobs` row appears for a real org **without any manual/helper
+   trigger** — i.e. the registration wired in #3630's plugin bootstrap actually ticks on its own.
+   Then turn the settings back off (or leave on, per the owner's rollout decision) once confirmed.
+2. **Optional, recommended — real multitable spot-check.** If an operator wants to go beyond the
+   "delegates to an already-proven writer" argument and see a real multitable row for themselves:
+   create one `mode:'manual_step'` job via the existing
+   `POST /api/attendance/report-sync-jobs` + `.../run-next-page` routes (already staging-proven
+   2026-05-19) for a throwaway user/date, and inspect the resulting report-record row through the
+   normal multitable UI/API. This is the same underlying writer the scheduled trigger delegates to,
+   so it is not required to close A2 — it is an extra confidence check some operators may want.
+
+## Expected PASS Stamps
+
+Two-stage, same convention as HMR-5 / MP-6 / AE-4 / RD-4/5:
+
+```text
+REPORT_SYNC_A2_API_DB_SMOKE_PASS deploy=<sha> stamp=reportsync-a2-smoke-... org=<main-org> orgs=<gate>|<main>|<throttle> synced=<n> collateralOtherOrgs=<n> residue=0
+```
+
+Only after that helper run passes **and** the required manual scheduler-interval-pickup step above
+is confirmed, record:
+
+```text
+REPORT_SYNC_A2_STAGING_SMOKE_PASS deploy=<sha> stamp=reportsync-a2-smoke-... residue=0
+```
+
+## Tracker note
+
+Report-sync A2 is **not** part of the current staging-window 5-smoke bundle (that bundle is
+tracked separately and is a distinct, already-scoped set) — this slice is independent. Once both
+PASS stamps above are recorded, add one line to the attendance/report-sync tracker noting "A2
+smoke ready" with the two stamps; do not fold this into the 5-smoke bundle's own tracking doc.
+
+## Failure Hints
+
+- `requireRunnerExport()` throws "attendance plugin is missing exported test seam(s)": #3630 is not
+  merged/deployed yet on the target checkout — this is expected until it lands; do not try to work
+  around it by hand-patching the plugin file.
+- Gate-closed tick returns `ran:true` or a non-empty `orgs` array: the double-gate regressed —
+  check both `isAttendanceReportSyncScheduledTriggerRuntimeEnabled()` (env) and
+  `trigger.enabled` (settings) are each independently `false`-safe in the deployed source.
+- Main-flow tick 1 totals show `patched:0` for the stale user: the dual-fingerprint compare
+  (`existingSource === sourceFingerprint && existingField === fieldFingerprint`) may be comparing
+  against the wrong physical field id, or the stale fixture's marker values coincidentally match a
+  freshly-computed fingerprint — regenerate the stale markers to be obviously distinct strings.
+- Repeat tick creates a second job row instead of a no-op: the `(org_id, idempotency_key)` unique
+  index may be missing on the target DB — verify migration
+  `zzzz20260519070000_create_plugin_attendance_report_sync_jobs` applied cleanly.
+- `assertCrossOrgFanoutRisk()` refuses to run: expected on a shared staging DB with other real
+  orgs — either set `ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT=1` deliberately, or point `DATABASE_URL` at
+  a more isolated DB.
+- `resolveMaxOrgsPerRunForFullCoverage` throws "caps maxOrgsPerRun at 50": the target DB already has
+  47+ distinct orgs in `attendance_rules` — clean up stale/unrelated orgs first, or accept that this
+  helper cannot guarantee its own org's inclusion on that DB.
+- Residue is non-zero after cleanup: inspect rows by the printed `stamp`-prefixed org ids; the
+  helper's own `cleanup()` is idempotent-safe to re-run manually with the same org ids.

--- a/scripts/ops/staging-attendance-report-sync-a2-smoke.mjs
+++ b/scripts/ops/staging-attendance-report-sync-a2-smoke.mjs
@@ -1,0 +1,801 @@
+#!/usr/bin/env node
+// Report-sync A2 scheduled-trigger staging smoke helper — the "missing 'enqueue' worker" for
+// plugin_attendance_report_sync_jobs (design-lock #3623, RATIFIED owner-delegated 2026-07-05;
+// runtime #3630). This is S3 of the design-lock's §3 completion bar.
+//
+// Structure/style/two-stage-stamp convention mirrors
+// scripts/ops/staging-attendance-manual-missed-punch-reminder-hmr5-smoke.mjs (pure helpers exported
+// for the companion .test.mjs, IS_MAIN gate, resolveEnvConfig, STAMP regex lock, two-stage PASS
+// stamp). The actual scheduler-job mechanics (direct plugin require + in-process tick calls + a
+// second-tick idempotency proof) mirror scripts/ops/staging-attendance-auto-shift-a2-smoke.mjs — this
+// helper runs the exported A2 tick directly against the staging DB, without waiting for
+// AttendanceScheduler's own interval loop, same convention as that helper.
+//
+// Grounding (plugins/plugin-attendance/index.cjs, once #3630 lands):
+//   DEFAULT_SETTINGS.reportSync.scheduledTrigger = { enabled:false, cadence:'daily', maxOrgsPerRun:5,
+//   maxUsersPerRun:100 }; env gate ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED (double-gate with
+//   settings.reportSync.scheduledTrigger.enabled — BOTH required, missing either is a byte-exact
+//   no-op: { ran:false, reason:'disabled', orgs:[] }); scheduler job name
+//   'attendance-report-sync-scheduled'; test seam
+//   attendancePlugin.__attendanceReportFieldCatalogForTests.runAttendanceReportSyncScheduledTriggerOnce
+//   (context, db, logger, { now, emitEvent }) -> { ran, cadence, orgs: [{ orgId, claimed, status,
+//   freshlyCreated, totals, jobId, workDate, idempotencyKey, reason? }] }; per-org claim delegates to
+//   the EXISTING runAttendanceReportSyncJobNextPage -> syncAttendanceReportRecordsForUsers path (zero
+//   write-semantics change, design-lock §3); repeat-tick idempotency is the job table's
+//   (org_id, idempotency_key) partial unique index PLUS the writer's own dual source/field-fingerprint
+//   compare (skip vs create vs patch); resolveAttendanceReportSyncScheduledTriggerOrgIds does
+//   `SELECT DISTINCT org_id FROM attendance_rules ORDER BY org_id` with NO per-org filter, sliced to
+//   maxOrgsPerRun — see the SCOPE NOTE below.
+//
+// SCOPE NOTE (read before extending this helper) — two things this smoke deliberately does NOT prove:
+//
+//  1. Real multitable base/sheet writes. context.api.multitable here is an in-process, in-memory
+//     stand-in (createFakeReportRecordsMultitable below), not the real multitable REST/plugin stack.
+//     The design-lock explicitly delegates writes to the EXISTING syncAttendanceReportRecordsForUsers
+//     writer and says A2 must not "re-implement stats/multitable writes" (§2 S2) — that writer's real
+//     multitable behavior is already staging-proven separately (2026-05-19 live evidence via
+//     `pnpm run verify:attendance-report-fields:live` JOB_MODE=1, scripts/ops/attendance-report-fields-
+//     live-acceptance.mjs) and covered by the existing real-DB CI gate (which uses an identically-shaped
+//     fake — see the 'attendance report sync scheduled trigger (A2)' describe block added to
+//     packages/core-backend/tests/integration/attendance-plugin.test.ts by #3630). This smoke's job is
+//     the NEW part: the scheduling/claim/idempotency/throttle layer around that writer, proven for real
+//     against real staging Postgres (attendance_rules/users/user_orgs/attendance_records and the
+//     plugin_attendance_report_sync_jobs control-plane table) and the real settings HTTP API — hence the
+//     API_DB stamp name below, not an API_MULTITABLE one. See the runbook's "Manual close-out steps" for
+//     the real-multitable spot-check some operators may want as an extra, optional proof.
+//
+//  2. The real AttendanceScheduler interval pickup. Like the auto-shift-a2 smoke, this helper calls the
+//     exported tick function directly in this Node process — it does not prove the REAL deployed
+//     scheduler actually registers and ticks 'attendance-report-sync-scheduled' on its own interval.
+//     See the runbook's required manual step for that.
+//
+// CROSS-ORG FAN-OUT HAZARD (read before running on a real shared staging DB): resolveAttendance-
+// ReportSyncScheduledTriggerOrgIds has NO per-org filter — a gate-open tick claims+runs a report-sync
+// job for every org with an attendance_rules row, up to maxOrgsPerRun (deterministic ORDER BY org_id
+// as of the #3630 review pass; still no allowlist). This helper computes maxOrgsPerRun wide enough to
+// guarantee ITS OWN synthetic orgs are covered every time, which means it ALSO sweeps in any
+// pre-existing real orgs on the target DB (read-only reads of their attendance_records, plus one real
+// plugin_attendance_report_sync_jobs row created for each — this helper's in-memory multitable adapter
+// means no multitable write escapes to them). See assertCrossOrgFanoutRisk() below: this helper REFUSES
+// to run against a DB with pre-existing other-org attendance_rules rows unless
+// ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT=1 is set, and reports (but does not delete) any collateral job rows
+// it caused for those other orgs at the end.
+//
+// Usage:
+//   BASE_URL=http://127.0.0.1:8082 \
+//   DATABASE_URL=postgresql://USER@127.0.0.1:5432/metasheet \
+//   DEPLOY_SHA=<staging-main-sha> \
+//   ATTENDANCE_SCHEDULER_ENABLED=true \
+//   ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED=true \
+//   node scripts/ops/staging-attendance-report-sync-a2-smoke.mjs
+//
+// Optional: SMOKE_TOKEN=<admin bearer> STAMP=reportsync-a2-smoke-... RUN_DATE=2026-07-05
+//           ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT=1
+
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+// --- pure helpers (exported for the companion .test.mjs) -------------------------------------
+
+export const STAMP_PATTERN = /^reportsync-a2-smoke-[A-Za-z0-9-]+$/
+
+export const ATTENDANCE_SCHEDULER_ENABLED_ENV = 'ATTENDANCE_SCHEDULER_ENABLED'
+export const REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG = 'ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED'
+export const REPORT_SYNC_JOB_TABLE = 'plugin_attendance_report_sync_jobs'
+// Mirrors ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_CREATED_BY (index.cjs) — used ONLY for the
+// informational (non-asserted) collateral cross-org report at the end, never for a pass/fail gate. If
+// this literal ever drifts from the real constant the report just undercounts; low risk by design.
+export const REPORT_SYNC_SCHEDULED_TRIGGER_CREATED_BY = 'system:attendance-report-sync-scheduled-trigger'
+export const ALLOW_CROSS_ORG_FANOUT_ENV = 'ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT'
+// zod ceiling on reportSync.scheduledTrigger.maxOrgsPerRun (index.cjs settingsSchema, design-lock §2 S1).
+export const MAX_ORGS_PER_RUN_CEILING = 50
+
+export function isStampedId(value, prefix) {
+  return typeof value === 'string' && value.startsWith(prefix) && value.length > prefix.length
+}
+
+// Env-only contract (no CLI args), mirroring the HMR-5 helper: BASE_URL/DATABASE_URL required,
+// DEPLOY_SHA mandatory (the PASS stamp must name the staging build actually smoked), STAMP regex-
+// locked. All three synthetic org ids are DERIVED from the stamp (no separate ORG_ID override) so they
+// are always visibly disposable and always prefix-safe for cleanup.
+export function resolveEnvConfig(env = {}) {
+  const errors = []
+  const baseUrl = String(env.BASE_URL || env.BASE || '').replace(/\/$/, '')
+  const databaseUrl = String(env.DATABASE_URL || '')
+  if (!baseUrl || !databaseUrl) {
+    errors.push('BASE_URL and DATABASE_URL are required.')
+  }
+  const deploySha = String(env.DEPLOY_SHA || env.EXPECTED_DEPLOY_SHA || '')
+  if (!deploySha || deploySha === '<fill-from-staging-build>') {
+    errors.push('DEPLOY_SHA is required so the PASS stamp names the staging build that was actually smoked.')
+  }
+  const suffix = Date.now().toString(36)
+  const stamp = String(env.STAMP || `reportsync-a2-smoke-${suffix}`)
+  if (!STAMP_PATTERN.test(stamp)) {
+    errors.push('STAMP must match /^reportsync-a2-smoke-[A-Za-z0-9-]+$/ so cleanup stays visibly synthetic and LIKE-free.')
+  }
+  const orgIds = {
+    gate: `${stamp}-gate`,
+    main: `${stamp}-main`,
+    throttle: `${stamp}-throttle`,
+  }
+  const runDate = String(env.RUN_DATE || '').trim()
+  if (runDate && !/^\d{4}-\d{2}-\d{2}$/.test(runDate)) {
+    errors.push('RUN_DATE must be YYYY-MM-DD when set.')
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    config: {
+      baseUrl,
+      databaseUrl,
+      deploySha,
+      stamp,
+      suffix,
+      orgIds,
+      runDate,
+      allowCrossOrgFanout: env[ALLOW_CROSS_ORG_FANOUT_ENV] === '1',
+    },
+  }
+}
+
+// Mirrors attendanceReportRecordRowKey in plugins/plugin-attendance/index.cjs (design-lock #3623,
+// pre-existing since the 2026-05-19 report-sync-jobs PR2 writer) — keep in sync. Only the one-line
+// row-key FORMULA is duplicated here so this helper can pre-compute expected rowKeys for its in-memory
+// fixture; the actual sync/writer logic itself is never re-implemented (design-lock §2 S2).
+export function attendanceReportRecordRowKey(orgId, userId, workDate) {
+  return `${orgId}:${userId}:${workDate}`
+}
+
+// In-process stand-in for context.api.multitable, matching the SAME shape (records.queryRecords/
+// createRecord/patchRecord, provisioning.ensureObject/resolveFieldIds) as the fake the #3630 real-DB
+// vitest gate itself uses ('attendance report sync scheduled trigger (A2)' describe block) — including
+// its 'fld_' physical-id prefixing convention, so this helper genuinely exercises the physical/logical
+// field-id indirection rather than a degenerate identity mapping. See the file-header SCOPE NOTE:
+// this is intentionally NOT the real multitable stack.
+export function createFakeReportRecordsMultitable() {
+  const store = []
+  let seq = 0
+  const rowKeyFieldId = 'fld_row_key'
+  const fieldFingerprintFieldId = 'fld_field_fingerprint'
+  const sourceFingerprintFieldId = 'fld_source_fingerprint'
+  const records = {
+    queryRecords: async ({ filters } = {}) => {
+      const want = filters || {}
+      return store.filter((row) => Object.entries(want).every(([key, value]) => row.data[key] === value))
+    },
+    createRecord: async ({ data }) => {
+      const rec = { id: `rec-${++seq}`, data: { ...data } }
+      store.push(rec)
+      return rec
+    },
+    patchRecord: async ({ recordId, changes }) => {
+      const rec = store.find((row) => row.id === recordId)
+      if (rec) rec.data = { ...rec.data, ...changes }
+      return rec
+    },
+  }
+  const provisioning = {
+    ensureObject: async () => ({ baseId: 'base_rr', sheet: { id: 'sheet_rr' } }),
+    resolveFieldIds: async ({ fieldIds }) => Object.fromEntries(fieldIds.map((fieldId) => [fieldId, `fld_${fieldId}`])),
+  }
+  return { store, records, provisioning, rowKeyFieldId, fieldFingerprintFieldId, sourceFingerprintFieldId }
+}
+
+// Seeds a stale pre-existing report-record row (mismatched dual fingerprint) directly into the fake
+// store so the FIRST tick must PATCH it rather than create/skip it — the "陈旧报表事实" (stale report
+// fact) S3 asks for, reconstructed in-process per the design-lock's own "(或既有 report-record 对象的
+// 可重建输入)" allowance, rather than requiring a real pre-existing staging multitable row.
+export function seedStaleReportRecordFixture(fake, rowKey) {
+  fake.store.push({
+    id: 'rec-stale-seed',
+    data: {
+      [fake.rowKeyFieldId]: rowKey,
+      [fake.fieldFingerprintFieldId]: 'stale-field-fingerprint-marker',
+      [fake.sourceFingerprintFieldId]: 'stale-source-fingerprint-marker',
+    },
+  })
+}
+
+// --- pure assertion-shape predicates (unit-testable without DB/network) ----------------------
+// Each mirrors a shape documented/observed directly in #3630's own diff and its real-DB vitest gate
+// (packages/core-backend/tests/integration/attendance-plugin.test.ts, 'attendance report sync
+// scheduled trigger (A2)' describe block), so the companion .test.mjs can lock them against
+// hand-built fixtures without needing #3630 merged into this checkout.
+
+export function isDoubleGateClosedResult(result) {
+  return !!result
+    && result.ran === false
+    && result.reason === 'disabled'
+    && Array.isArray(result.orgs)
+    && result.orgs.length === 0
+}
+
+export function findOrgResult(result, orgId) {
+  const orgs = Array.isArray(result?.orgs) ? result.orgs : []
+  return orgs.find((entry) => entry?.orgId === orgId) ?? null
+}
+
+export function isFreshCompletedClaim(orgResult) {
+  return !!orgResult
+    && orgResult.claimed === true
+    && orgResult.freshlyCreated === true
+    && orgResult.status === 'completed'
+}
+
+export function isIdempotentNoOpRepeat(orgResult, expectedJobId) {
+  return !!orgResult
+    && orgResult.claimed === false
+    && orgResult.reason === 'already_completed'
+    && orgResult.jobId === expectedJobId
+}
+
+export function isResumingQueuedClaim(orgResult, expectedJobId) {
+  return !!orgResult
+    && orgResult.claimed === true
+    && orgResult.freshlyCreated === false
+    && orgResult.status === 'queued'
+    && orgResult.jobId === expectedJobId
+}
+
+// maxOrgsPerRun is capped at MAX_ORGS_PER_RUN_CEILING (zod). To guarantee THIS helper's own synthetic
+// orgs are always included in a capped fan-out regardless of SELECT DISTINCT ordering, it asks for
+// enough headroom to cover every existing distinct org on the target DB plus its own. If that would
+// exceed the real ceiling, refuse with a clear, actionable message rather than silently under-covering
+// (which would make this helper's own assertions flaky against a crowded shared staging DB).
+export function resolveMaxOrgsPerRunForFullCoverage(existingDistinctOrgCount, headroom = 3) {
+  const needed = Math.max(1, Math.floor(Number(existingDistinctOrgCount) || 0) + headroom)
+  if (needed > MAX_ORGS_PER_RUN_CEILING) {
+    return {
+      ok: false,
+      error: `staging attendance_rules already has ${existingDistinctOrgCount} distinct org(s) — need `
+        + `maxOrgsPerRun=${needed} to guarantee this smoke's synthetic orgs are covered every tick, but `
+        + `the settings schema caps maxOrgsPerRun at ${MAX_ORGS_PER_RUN_CEILING}. Clean up stale/unrelated `
+        + 'orgs on this DB first, or point DATABASE_URL at a less crowded one.',
+    }
+  }
+  return { ok: true, value: Math.min(MAX_ORGS_PER_RUN_CEILING, needed) }
+}
+
+export function residueIsZero(counts) {
+  return Object.values(counts).every((value) => Number(value) === 0)
+}
+
+// --- runtime wiring ----------------------------------------------------------------------------
+
+const IS_MAIN = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false
+const ENTRY = resolveEnvConfig(process.env)
+if (IS_MAIN && !ENTRY.ok) {
+  for (const message of ENTRY.errors) console.error(`FAIL: ${message}`)
+  console.error('  e.g. BASE_URL=http://127.0.0.1:8082 DATABASE_URL=postgresql://USER@127.0.0.1:5432/metasheet DEPLOY_SHA=<deployed-sha> ATTENDANCE_SCHEDULER_ENABLED=true ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED=true node scripts/ops/staging-attendance-report-sync-a2-smoke.mjs')
+  process.exit(2)
+}
+
+const {
+  baseUrl: BASE_URL,
+  databaseUrl: DATABASE_URL,
+  deploySha: DEPLOY_SHA,
+  stamp: STAMP,
+  orgIds: ORG_IDS,
+  runDate: RUN_DATE_OVERRIDE,
+} = ENTRY.config
+
+const RUN_NOW = RUN_DATE_OVERRIDE ? new Date(`${RUN_DATE_OVERRIDE}T12:00:00.000Z`) : (() => {
+  const now = new Date()
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0))
+})()
+const WORK_DATE = RUN_NOW.toISOString().slice(0, 10)
+
+const USERS = {
+  gate: `${ORG_IDS.gate}-u`,
+  mainFresh: `${ORG_IDS.main}-fresh`,
+  mainStale: `${ORG_IDS.main}-stale`,
+  throttle: [1, 2, 3].map((n) => `${ORG_IDS.throttle}-u${n}`),
+}
+const ALL_ORG_IDS = [ORG_IDS.gate, ORG_IDS.main, ORG_IDS.throttle]
+const ALL_USER_IDS = [USERS.gate, USERS.mainFresh, USERS.mainStale, ...USERS.throttle]
+
+let token = process.env.SMOKE_TOKEN || process.env.ADMIN_TOKEN || process.env.TOKEN || ''
+let originalReportSync = null
+let cleanupAllowed = false
+let seam = null
+let runner = null
+
+let pass = 0
+const failures = []
+function ok(condition, label, detail) {
+  if (condition) {
+    pass += 1
+    console.log(`  PASS  ${label}`)
+    return
+  }
+  failures.push(label)
+  const extra = detail === undefined ? '' : ` — ${JSON.stringify(detail)}`
+  console.error(`  FAIL  ${label}${extra}`)
+}
+
+function assertRequiredRuntimeEnv() {
+  const required = [ATTENDANCE_SCHEDULER_ENABLED_ENV, REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG]
+  const missing = required.filter((name) => process.env[name] !== 'true')
+  if (missing.length) {
+    throw new Error(`refusing to run: missing required staging runtime env in this runner process: ${missing.join(', ')}. This helper calls the scheduled-trigger runner directly (bypassing the interval scheduler, same convention as staging-attendance-auto-shift-a2-smoke.mjs), but still requires these flags exported truthfully so a PASS here reflects what the REAL deployed scheduler would also do once turned on. Export them (or run from the deployed backend/container environment) before invoking this helper.`)
+  }
+  ok(true, 'required scheduler/A2 report-sync runtime env flags are true in this runner process')
+}
+
+function requireRunnerExport() {
+  const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+  const require = createRequire(import.meta.url)
+  const attendancePlugin = require(path.join(repoRoot, 'plugins/plugin-attendance/index.cjs'))
+  seam = attendancePlugin.__attendanceReportFieldCatalogForTests || {}
+  const requiredExports = [
+    'runAttendanceReportSyncScheduledTriggerOnce',
+    'resolveAttendanceReportSyncScheduledTriggerOrgIds',
+    'resetAttendanceSettingsCacheForTests',
+  ]
+  const missingExports = requiredExports.filter((name) => typeof seam[name] !== 'function')
+  ok(missingExports.length === 0, 'attendance plugin exports the A2 scheduled-trigger test seam', missingExports)
+  if (missingExports.length) {
+    throw new Error(`attendance plugin is missing exported test seam(s): ${missingExports.join(', ')}. Is the deployed/checked-out source at/after #3630 (report-sync A2 scheduled trigger runtime)? This helper depends on #3630 merging first.`)
+  }
+  runner = seam.runAttendanceReportSyncScheduledTriggerOnce
+}
+
+async function withEnvFlag(value, fn) {
+  const prev = process.env[REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG]
+  if (value === undefined) delete process.env[REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG]
+  else process.env[REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG] = value
+  try {
+    return await fn()
+  } finally {
+    if (prev === undefined) delete process.env[REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG]
+    else process.env[REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG] = prev
+  }
+}
+
+async function api(pathname, { method = 'GET', body } = {}) {
+  const url = new URL(`${BASE_URL}${pathname}`)
+  const headers = { 'Content-Type': 'application/json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  let json = null
+  try { json = await res.json() } catch { /* non-json */ }
+  return { status: res.status, body: json }
+}
+
+async function mintToken() {
+  const userId = `${STAMP}-admin`
+  const res = await api(`/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('attendance:read,attendance:write,attendance:admin')}`)
+  token = res.body?.token || ''
+  if (!token) throw new Error(`could not mint dev-token (status ${res.status}); set SMOKE_TOKEN for staging auth`)
+  console.log('  minted dev-token for the smoke admin')
+}
+
+async function putReportSyncSettings(scheduledTrigger) {
+  const res = await api('/api/attendance/settings', { method: 'PUT', body: { reportSync: { scheduledTrigger } } })
+  ok(res.status === 200, `PUT reportSync.scheduledTrigger settings (${res.status})`, res.body)
+  if (res.status !== 200) throw new Error('could not PUT reportSync.scheduledTrigger settings')
+  return res.body?.data?.reportSync ?? null
+}
+
+function resetSettingsCache() {
+  seam.resetAttendanceSettingsCacheForTests?.()
+}
+
+const poolBox = { pool: null }
+const q = (text, params) => poolBox.pool.query(text, params).then((result) => result.rows)
+
+function createPluginDb(poolForRunner) {
+  return {
+    query: async (text, params) => (await poolForRunner.query(text, params)).rows,
+    transaction: async (callback) => {
+      const client = await poolForRunner.connect()
+      try {
+        await client.query('BEGIN')
+        const trx = { query: async (text, params) => (await client.query(text, params)).rows }
+        const result = await callback(trx)
+        await client.query('COMMIT')
+        return result
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => undefined)
+        throw error
+      } finally {
+        client.release()
+      }
+    },
+  }
+}
+
+let pluginDb = null
+let fake = null
+let context = null
+
+function runTick() {
+  return runner(context, pluginDb, console, { now: RUN_NOW, emitEvent: () => undefined })
+}
+
+async function jobRowCount(orgId) {
+  const rows = await q(`SELECT count(*)::int AS n FROM ${REPORT_SYNC_JOB_TABLE} WHERE org_id = $1`, [orgId])
+  return Number(rows[0]?.n || 0)
+}
+
+async function countDistinctAttendanceRulesOrgs() {
+  const rows = await q('SELECT count(DISTINCT org_id)::int AS n FROM attendance_rules')
+  return Number(rows[0]?.n || 0)
+}
+
+async function computeCoveringMaxOrgsPerRun() {
+  const total = await countDistinctAttendanceRulesOrgs()
+  const resolved = resolveMaxOrgsPerRunForFullCoverage(total)
+  if (!resolved.ok) throw new Error(resolved.error)
+  return resolved.value
+}
+
+// --- preflight -----------------------------------------------------------------------------
+
+async function preflightNoExistingResidue() {
+  const rows = await q(
+    `SELECT
+       (SELECT count(*)::int FROM ${REPORT_SYNC_JOB_TABLE} WHERE org_id = ANY($1::text[])) AS jobs,
+       (SELECT count(*)::int FROM attendance_records WHERE org_id = ANY($1::text[])) AS records,
+       (SELECT count(*)::int FROM attendance_rules WHERE org_id = ANY($1::text[])) AS rules,
+       (SELECT count(*)::int FROM user_orgs WHERE user_id = ANY($2::text[])) AS user_orgs,
+       (SELECT count(*)::int FROM users WHERE id = ANY($2::text[])) AS users`,
+    [ALL_ORG_IDS, ALL_USER_IDS],
+  )
+  const row = rows[0] || {}
+  const clean = Object.values(row).every((value) => Number(value) === 0)
+  ok(clean, 'no pre-existing residue for this stamp\'s synthetic orgs/users', row)
+  if (!clean) throw new Error(`pre-existing residue found for stamp ${STAMP}; use a fresh STAMP or inspect before running`)
+}
+
+// resolveAttendanceReportSyncScheduledTriggerOrgIds has no per-org filter (see file-header CROSS-ORG
+// FAN-OUT HAZARD note) — refuse to open the gate on a DB with pre-existing other-org attendance_rules
+// rows unless explicitly overridden.
+async function assertCrossOrgFanoutRisk() {
+  const rows = await q('SELECT DISTINCT org_id FROM attendance_rules WHERE org_id <> ALL($1::text[]) ORDER BY org_id', [ALL_ORG_IDS])
+  const otherOrgIds = rows.map((row) => row.org_id)
+  const allowed = ENTRY.config.allowCrossOrgFanout
+  if (otherOrgIds.length > 0 && !allowed) {
+    throw new Error(
+      `refusing to run: resolveAttendanceReportSyncScheduledTriggerOrgIds has no per-org filter — `
+      + `SELECT DISTINCT org_id FROM attendance_rules scans EVERY org on this DB. Once this helper opens `
+      + `the double-gate, a tick will ALSO claim+run a report-sync job for ${otherOrgIds.length} `
+      + `pre-existing other org(s) (${otherOrgIds.slice(0, 8).join(', ')}${otherOrgIds.length > 8 ? ', ...' : ''}), `
+      + `creating real ${REPORT_SYNC_JOB_TABLE} rows this helper's cleanup will NOT remove (out of `
+      + 'blast-radius scope — those orgs were not created by this run). This helper\'s own multitable '
+      + `adapter is in-process/in-memory only (see file-header SCOPE NOTE), so no multitable write `
+      + `escapes to those orgs — but the job-table row and the read of their real attendance_records IS `
+      + `real. Set ${ALLOW_CROSS_ORG_FANOUT_ENV}=1 to proceed anyway, or point DATABASE_URL at a DB with `
+      + 'no other orgs\' attendance_rules rows first.',
+    )
+  }
+  ok(
+    otherOrgIds.length === 0 || allowed,
+    otherOrgIds.length === 0
+      ? 'no pre-existing other-org attendance_rules rows (no cross-org fan-out risk)'
+      : `cross-org fan-out allowed by explicit override (${otherOrgIds.length} other org(s))`,
+    otherOrgIds,
+  )
+  return otherOrgIds
+}
+
+// --- seed ------------------------------------------------------------------------------------
+
+async function seedRule(orgId, timezone = 'UTC') {
+  await q(
+    `INSERT INTO attendance_rules
+       (id, org_id, name, timezone, work_start_time, work_end_time, late_grace_minutes, early_grace_minutes,
+        severe_late_threshold_minutes, absence_late_threshold_minutes, rounding_minutes, working_days, is_default)
+     VALUES ($1, $2, $3, $4, '09:00', '18:00', 5, 5, 30, 60, 1, '[1,2,3,4,5]'::jsonb, true)`,
+    [randomUUID(), orgId, `A2 report-sync smoke rule ${orgId}`, timezone],
+  )
+}
+
+async function seedUser(userId, orgId) {
+  await q(
+    `INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'no-login', true)
+     ON CONFLICT (id) DO UPDATE SET is_active = true`,
+    [userId, `${userId}@example.test`],
+  )
+  await q(
+    `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)
+     ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = true`,
+    [userId, orgId],
+  )
+}
+
+async function seedAttendanceRecord(orgId, userId, workDate) {
+  await q(
+    `INSERT INTO attendance_records
+     (id, user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes,
+      early_leave_minutes, status, is_workday, meta, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, 'UTC', $5, $6, 480, 0, 0, 'normal', true, '{}'::jsonb, now(), now())
+     ON CONFLICT DO NOTHING`,
+    [randomUUID(), userId, orgId, workDate, new Date(`${workDate}T09:00:00Z`), new Date(`${workDate}T18:00:00Z`)],
+  )
+}
+
+// --- scenario 1: double-gate closed ------------------------------------------------------------
+
+async function assertDoubleGateClosedBothHalves(orgId) {
+  // half 1: env unset, settings still at their off default (never PUT anything yet).
+  const envUnset = await withEnvFlag(undefined, () => runTick())
+  ok(isDoubleGateClosedResult(envUnset), 'gate closed (env unset, settings default-off): byte-exact no-op', envUnset)
+  ok(await jobRowCount(orgId) === 0, 'zero job rows for the gate org after the env-unset tick')
+
+  // half 2: env true, settings still off (isolates that env=true ALONE does not open the gate).
+  const settingsOff = await withEnvFlag('true', () => runTick())
+  ok(isDoubleGateClosedResult(settingsOff), 'gate closed (env true, settings still off): byte-exact no-op', settingsOff)
+  ok(await jobRowCount(orgId) === 0, 'zero job rows for the gate org after the settings-off tick')
+
+  // half 3: settings enabled=true globally, but env temporarily unset for this ONE call — isolates
+  // that the ENV half independently gates the runner, not just settings (mirrors #3630's own
+  // 'double-gate: settings.enabled=true but env flag unset' vitest case).
+  await putReportSyncSettings({ enabled: true, cadence: 'daily', maxOrgsPerRun: await computeCoveringMaxOrgsPerRun(), maxUsersPerRun: 100 })
+  resetSettingsCache()
+  const envUnsetAgain = await withEnvFlag(undefined, () => runTick())
+  ok(isDoubleGateClosedResult(envUnsetAgain), 'gate closed (settings true, env unset): byte-exact no-op', envUnsetAgain)
+  ok(await jobRowCount(orgId) === 0, 'zero job rows for the gate org even with settings enabled while env is unset')
+  // Settings stay enabled=true globally for scenarios 2/3 below; the required env flag is already
+  // 'true' in this process per assertRequiredRuntimeEnv().
+}
+
+// --- scenario 2: create + patch + idempotent repeat tick ----------------------------------------
+
+async function assertMainFlowCreateAndPatch() {
+  const orgId = ORG_IDS.main
+  await seedRule(orgId)
+  await seedUser(USERS.mainFresh, orgId)
+  await seedAttendanceRecord(orgId, USERS.mainFresh, WORK_DATE)
+  await seedUser(USERS.mainStale, orgId)
+  await seedAttendanceRecord(orgId, USERS.mainStale, WORK_DATE)
+
+  const staleRowKey = attendanceReportRecordRowKey(orgId, USERS.mainStale, WORK_DATE)
+  seedStaleReportRecordFixture(fake, staleRowKey)
+
+  await putReportSyncSettings({ enabled: true, cadence: 'daily', maxOrgsPerRun: await computeCoveringMaxOrgsPerRun(), maxUsersPerRun: 100 })
+  resetSettingsCache()
+  const tick1 = await runTick()
+  const mine1 = findOrgResult(tick1, orgId)
+  ok(isFreshCompletedClaim(mine1), 'main flow tick 1: fresh claim, completed in one page', mine1)
+  ok(
+    mine1?.totals?.usersScanned === 2 && mine1.totals.created === 1 && mine1.totals.patched === 1 && mine1.totals.skipped === 0,
+    'main flow tick 1 totals: 1 created (fresh user) + 1 patched (stale user), 0 skipped',
+    mine1?.totals,
+  )
+
+  const jobRow = (await q(
+    `SELECT status, mode, kind, idempotency_key FROM ${REPORT_SYNC_JOB_TABLE} WHERE org_id = $1`,
+    [orgId],
+  ))[0]
+  ok(
+    jobRow?.status === 'completed' && jobRow?.mode === 'enqueue' && jobRow?.kind === 'daily_records'
+      && jobRow?.idempotency_key === mine1?.idempotencyKey,
+    'main flow: job control-plane row shape (mode=enqueue, kind=daily_records, status=completed, idempotency_key matches)',
+    jobRow,
+  )
+
+  const freshRowKey = attendanceReportRecordRowKey(orgId, USERS.mainFresh, WORK_DATE)
+  const freshRec = fake.store.find((row) => row.data[fake.rowKeyFieldId] === freshRowKey)
+  const staleRec = fake.store.find((row) => row.data[fake.rowKeyFieldId] === staleRowKey)
+  ok(!!freshRec, 'fresh user got a genuinely CREATED report-record row', freshRec)
+  ok(
+    !!staleRec
+      && staleRec.data[fake.fieldFingerprintFieldId] !== 'stale-field-fingerprint-marker'
+      && staleRec.data[fake.sourceFingerprintFieldId] !== 'stale-source-fingerprint-marker',
+    'stale user\'s pre-seeded row was genuinely PATCHED away from its stale dual-fingerprint markers',
+    staleRec,
+  )
+  ok(fake.store.length === 2, 'exactly 2 report-record rows exist after tick 1 (no extras)', fake.store.length)
+
+  resetSettingsCache()
+  const tick2 = await runTick()
+  const mine2 = findOrgResult(tick2, orgId)
+  ok(isIdempotentNoOpRepeat(mine2, mine1?.jobId), 'main flow tick 2 (same period): idempotent no-op, same jobId, reason=already_completed', mine2)
+  ok(await jobRowCount(orgId) === 1, 'main flow: still exactly 1 job row after the repeat tick (no duplicate job)')
+  ok(fake.store.length === 2, 'main flow: still exactly 2 report-record rows after the repeat tick (no duplicate/second write)', fake.store.length)
+
+  return { totalsTick1: mine1?.totals ?? null }
+}
+
+// --- scenario 3: maxUsersPerRun throttles pagination across ticks ------------------------------
+
+async function assertMaxUsersPerRunThrottle() {
+  const orgId = ORG_IDS.throttle
+  const baseline = fake.store.length
+  await seedRule(orgId)
+  for (const userId of USERS.throttle) {
+    await seedUser(userId, orgId)
+    await seedAttendanceRecord(orgId, userId, WORK_DATE)
+  }
+
+  await putReportSyncSettings({ enabled: true, cadence: 'daily', maxOrgsPerRun: await computeCoveringMaxOrgsPerRun(), maxUsersPerRun: 1 })
+
+  resetSettingsCache()
+  const t1 = findOrgResult(await runTick(), orgId)
+  ok(isFreshCompletedClaim(t1) === false && t1?.claimed === true && t1?.freshlyCreated === true && t1?.status === 'queued',
+    'throttle tick 1: fresh claim, queued (page 1 of 3, not yet complete)', t1)
+  ok(fake.store.length === baseline + 1, 'throttle tick 1: exactly 1 new report-record row (maxUsersPerRun=1 paged one user)', fake.store.length - baseline)
+  ok(await jobRowCount(orgId) === 1, 'throttle: exactly 1 job row after tick 1')
+  const jobId = t1?.jobId
+
+  resetSettingsCache()
+  const t2 = findOrgResult(await runTick(), orgId)
+  ok(isResumingQueuedClaim(t2, jobId), 'throttle tick 2: resumes the SAME job (not recreated), still queued (page 2 of 3)', t2)
+  ok(fake.store.length === baseline + 2, 'throttle tick 2: exactly 2 new rows total so far', fake.store.length - baseline)
+  ok(await jobRowCount(orgId) === 1, 'throttle: still exactly 1 job row after tick 2 (resumed, not duplicated)')
+
+  resetSettingsCache()
+  const t3 = findOrgResult(await runTick(), orgId)
+  ok(t3?.claimed === true && t3.freshlyCreated === false && t3.status === 'completed' && t3.jobId === jobId,
+    'throttle tick 3: SAME job completes (page 3 of 3, roster fully drained)', t3)
+  ok(fake.store.length === baseline + 3, 'throttle tick 3: all 3 throttle users synced', fake.store.length - baseline)
+  const expectedRowKeys = new Set(USERS.throttle.map((userId) => attendanceReportRecordRowKey(orgId, userId, WORK_DATE)))
+  const actualRowKeys = new Set(fake.store.slice(baseline).map((row) => row.data[fake.rowKeyFieldId]))
+  ok(
+    actualRowKeys.size === expectedRowKeys.size && [...expectedRowKeys].every((key) => actualRowKeys.has(key)),
+    'throttle: the 3 synced rowKeys exactly match the 3 throttle users',
+    { expected: [...expectedRowKeys], actual: [...actualRowKeys] },
+  )
+
+  resetSettingsCache()
+  const t4 = findOrgResult(await runTick(), orgId)
+  ok(isIdempotentNoOpRepeat(t4, jobId), 'throttle tick 4: roster already drained -> no-op (reason=already_completed)', t4)
+  ok(fake.store.length === baseline + 3, 'throttle tick 4: no additional writes', fake.store.length - baseline)
+  ok(await jobRowCount(orgId) === 1, 'throttle: still exactly 1 job row after the roster fully drains')
+
+  return { totalsAfterDrain: t3?.totals ?? null }
+}
+
+// --- maxOrgsPerRun throttle (pure helper, direct call — no full-flow org-inclusion guessing needed) --
+
+async function assertMaxOrgsPerRunThrottle() {
+  const total = await countDistinctAttendanceRulesOrgs()
+  const resolveOrgIds = seam.resolveAttendanceReportSyncScheduledTriggerOrgIds
+  const capped = await resolveOrgIds(pluginDb, 1, console)
+  ok(capped.length === 1, 'maxOrgsPerRun=1 caps the org fan-out to exactly 1 org', capped.length)
+  const exact = await resolveOrgIds(pluginDb, total, console)
+  ok(exact.length === total, `maxOrgsPerRun=<total distinct orgs=${total}> covers every org`, exact.length)
+  const overshoot = await resolveOrgIds(pluginDb, total + 25, console)
+  ok(overshoot.length === total, 'maxOrgsPerRun far above the real total does not pad past the real total', overshoot.length)
+}
+
+// --- collateral cross-org report (informational only, never asserted) --------------------------
+
+async function reportCollateralCrossOrgJobRows(smokeStartedAt) {
+  const rows = await q(
+    `SELECT org_id, count(*)::int AS n FROM ${REPORT_SYNC_JOB_TABLE}
+     WHERE org_id <> ALL($1::text[]) AND created_by = $2 AND created_at >= $3
+     GROUP BY org_id ORDER BY org_id`,
+    [ALL_ORG_IDS, REPORT_SYNC_SCHEDULED_TRIGGER_CREATED_BY, smokeStartedAt],
+  )
+  if (rows.length) {
+    console.warn(`  WARN: this run's gate-open ticks also claimed+ran a report-sync job for ${rows.length} pre-existing OTHER org(s) — outside this helper's cleanup scope, left in place for operator review: ${JSON.stringify(rows)}`)
+  }
+  return rows
+}
+
+// --- cleanup / residue ---------------------------------------------------------------------------
+
+async function residueCounts() {
+  const rows = await q(
+    `SELECT
+       (SELECT count(*)::int FROM ${REPORT_SYNC_JOB_TABLE} WHERE org_id = ANY($1::text[])) AS jobs,
+       (SELECT count(*)::int FROM attendance_records WHERE org_id = ANY($1::text[])) AS records,
+       (SELECT count(*)::int FROM attendance_rules WHERE org_id = ANY($1::text[])) AS rules,
+       (SELECT count(*)::int FROM user_orgs WHERE user_id = ANY($2::text[])) AS user_orgs,
+       (SELECT count(*)::int FROM users WHERE id = ANY($2::text[])) AS users`,
+    [ALL_ORG_IDS, ALL_USER_IDS],
+  )
+  return rows[0] || {}
+}
+
+async function cleanup() {
+  if (!cleanupAllowed) {
+    console.log('  cleanup skipped: helper did not pass the initial safety/auth gate')
+    return
+  }
+  // Scoped restore of just the reportSync sub-key (not a whole-blob PUT-back) — every top-level
+  // settings key is independently .optional(), so this never touches unrelated sibling settings and
+  // never inherits an unrelated sibling's round-trip quirk (mirrors #3630's own vitest teardown note).
+  await api('/api/attendance/settings', {
+    method: 'PUT',
+    body: { reportSync: originalReportSync ?? { scheduledTrigger: { enabled: false } } },
+  }).catch((error) => console.error(`  settings restore failed: ${error?.message || error}`))
+
+  await q(`DELETE FROM ${REPORT_SYNC_JOB_TABLE} WHERE org_id = ANY($1::text[])`, [ALL_ORG_IDS]).catch((error) => console.error(`  delete job rows failed: ${error?.message || error}`))
+  await q('DELETE FROM attendance_records WHERE org_id = ANY($1::text[])', [ALL_ORG_IDS]).catch((error) => console.error(`  delete records failed: ${error?.message || error}`))
+  await q('DELETE FROM attendance_rules WHERE org_id = ANY($1::text[])', [ALL_ORG_IDS]).catch((error) => console.error(`  delete rules failed: ${error?.message || error}`))
+  await q('DELETE FROM user_orgs WHERE user_id = ANY($1::text[])', [ALL_USER_IDS]).catch((error) => console.error(`  delete user_orgs failed: ${error?.message || error}`))
+  await q('DELETE FROM users WHERE id = ANY($1::text[])', [ALL_USER_IDS]).catch((error) => console.error(`  delete users failed: ${error?.message || error}`))
+}
+
+// --- main ------------------------------------------------------------------------------------
+
+async function main() {
+  console.log(`Report-sync A2 scheduled-trigger API/DB staging smoke @ ${BASE_URL}`)
+  console.log(`  deploy=${DEPLOY_SHA} stamp=${STAMP} workDate=${WORK_DATE} orgs=${ALL_ORG_IDS.join(',')}`)
+  console.log('  SCOPE NOTE: this helper proves the SCHEDULING/claim/idempotency/throttle layer for real')
+  console.log('  against staging Postgres + the real settings API. It does NOT prove real multitable')
+  console.log('  base/sheet writes (in-memory adapter, see file header) or the real scheduler interval')
+  console.log('  pickup (direct tick call, same convention as the auto-shift A2 smoke). See the runbook\'s')
+  console.log('  "Manual close-out steps" — the final REPORT_SYNC_A2_STAGING_SMOKE_PASS stamp is recorded')
+  console.log('  only after both this helper and those manual steps pass.')
+
+  const smokeStartedAt = new Date().toISOString()
+
+  assertRequiredRuntimeEnv()
+  requireRunnerExport()
+
+  if (!token) await mintToken()
+  const got = await api('/api/attendance/settings')
+  ok(got.status === 200, `auth/settings reachable (${got.status})`, got.body)
+  if (got.status !== 200) throw new Error('settings API not reachable/authenticated')
+  originalReportSync = got.body?.data?.reportSync ?? null
+
+  await preflightNoExistingResidue()
+  const collateralRiskOrgIds = await assertCrossOrgFanoutRisk()
+  cleanupAllowed = true
+
+  pluginDb = createPluginDb(poolBox.pool)
+  fake = createFakeReportRecordsMultitable()
+  context = { api: { multitable: { provisioning: fake.provisioning, records: fake.records }, database: pluginDb } }
+
+  await seedRule(ORG_IDS.gate)
+  await seedUser(USERS.gate, ORG_IDS.gate)
+  await seedAttendanceRecord(ORG_IDS.gate, USERS.gate, WORK_DATE)
+  await assertDoubleGateClosedBothHalves(ORG_IDS.gate)
+
+  const { totalsTick1 } = await assertMainFlowCreateAndPatch()
+  const { totalsAfterDrain } = await assertMaxUsersPerRunThrottle()
+  await assertMaxOrgsPerRunThrottle()
+
+  await reportCollateralCrossOrgJobRows(smokeStartedAt)
+
+  await cleanup()
+  const residue = await residueCounts()
+  const residueOk = residueIsZero(residue)
+  ok(residueOk, 'cleanup residue is zero', residue)
+  if (!residueOk) throw new Error(`residue not zero: ${JSON.stringify(residue)}`)
+
+  if (failures.length) {
+    throw new Error(`report-sync A2 API/DB smoke had ${failures.length} failed assertion(s): ${failures.join('; ')}`)
+  }
+
+  const synced = Number(totalsTick1?.synced || 0) + Number(totalsAfterDrain?.synced || 0)
+  console.log(`\nAssertions passed: ${pass}`)
+  console.log(`REPORT_SYNC_A2_API_DB_SMOKE_PASS deploy=${DEPLOY_SHA} stamp=${STAMP} org=${ORG_IDS.main} orgs=${ALL_ORG_IDS.join('|')} synced=${synced} collateralOtherOrgs=${collateralRiskOrgIds.length} residue=0`)
+}
+
+if (IS_MAIN) {
+  let pgModule
+  try {
+    pgModule = await import('pg')
+  } catch {
+    console.error('FAIL: package "pg" is required. Run this helper from a prepared metasheet2 checkout with dependencies installed.')
+    process.exit(2)
+  }
+  poolBox.pool = new pgModule.default.Pool({ connectionString: DATABASE_URL })
+  try {
+    await main()
+  } catch (error) {
+    console.error(`FAIL: ${error?.message || error}`)
+    try {
+      await cleanup()
+      const residue = await residueCounts()
+      console.error(`Residue after best-effort cleanup: ${JSON.stringify(residue)}`)
+    } catch (cleanupError) {
+      console.error(`WARN: cleanup failed: ${cleanupError?.message || cleanupError}`)
+    }
+    process.exitCode = 1
+  } finally {
+    await poolBox.pool.end().catch(() => undefined)
+  }
+}

--- a/scripts/ops/staging-attendance-report-sync-a2-smoke.mjs
+++ b/scripts/ops/staging-attendance-report-sync-a2-smoke.mjs
@@ -593,14 +593,21 @@ async function assertMainFlowCreateAndPatch() {
     'stale user\'s pre-seeded row was genuinely PATCHED away from its stale dual-fingerprint markers',
     staleRec,
   )
-  ok(fake.store.length === 2, 'exactly 2 report-record rows exist after tick 1 (no extras)', fake.store.length)
+  // review P2: count only THIS (main) org's rows. The gate-open tick fans out to every org with an
+  // attendance_rules row (resolveAttendanceReportSyncScheduledTriggerOrgIds has no per-org filter), so
+  // the gate org's own same-day record also lands in the shared fake.store — an absolute ===2 would
+  // false-FAIL on real staging. Scope by the main org's rowKey prefix (scenario 3's idiom).
+  const mainOrgRowCount = () => fake.store.filter(
+    (row) => String(row.data[fake.rowKeyFieldId] ?? '').startsWith(`${orgId}:`),
+  ).length
+  ok(mainOrgRowCount() === 2, 'exactly 2 main-org report-record rows exist after tick 1 (no extras)', mainOrgRowCount())
 
   resetSettingsCache()
   const tick2 = await runTick()
   const mine2 = findOrgResult(tick2, orgId)
   ok(isIdempotentNoOpRepeat(mine2, mine1?.jobId), 'main flow tick 2 (same period): idempotent no-op, same jobId, reason=already_completed', mine2)
   ok(await jobRowCount(orgId) === 1, 'main flow: still exactly 1 job row after the repeat tick (no duplicate job)')
-  ok(fake.store.length === 2, 'main flow: still exactly 2 report-record rows after the repeat tick (no duplicate/second write)', fake.store.length)
+  ok(mainOrgRowCount() === 2, 'main flow: still exactly 2 main-org report-record rows after the repeat tick (no duplicate/second write)', mainOrgRowCount())
 
   return { totalsTick1: mine1?.totals ?? null }
 }

--- a/scripts/ops/staging-attendance-report-sync-a2-smoke.test.mjs
+++ b/scripts/ops/staging-attendance-report-sync-a2-smoke.test.mjs
@@ -1,0 +1,289 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import {
+  STAMP_PATTERN,
+  ATTENDANCE_SCHEDULER_ENABLED_ENV,
+  REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG,
+  REPORT_SYNC_JOB_TABLE,
+  ALLOW_CROSS_ORG_FANOUT_ENV,
+  MAX_ORGS_PER_RUN_CEILING,
+  isStampedId,
+  resolveEnvConfig,
+  attendanceReportRecordRowKey,
+  createFakeReportRecordsMultitable,
+  seedStaleReportRecordFixture,
+  isDoubleGateClosedResult,
+  findOrgResult,
+  isFreshCompletedClaim,
+  isIdempotentNoOpRepeat,
+  isResumingQueuedClaim,
+  resolveMaxOrgsPerRunForFullCoverage,
+  residueIsZero,
+} from './staging-attendance-report-sync-a2-smoke.mjs'
+
+// This file intentionally does NOT connect to a real DB/network and does NOT require the attendance
+// plugin file — it locks this helper's OWN pure logic (env contract, in-memory fixture behavior,
+// assertion-shape predicates against hand-built fixtures matching #3630's documented contract, and the
+// helper's own source-text shape: SQL parameterization, cleanup-table completeness, PASS stamp format).
+// #3630 (the A2 scheduled-trigger runtime) is not merged into this checkout yet — see the PR body for
+// the dependency note. Real-DB end-to-end coverage is the .mjs helper itself, run by an operator on
+// staging per the runbook.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const scriptPath = join(here, 'staging-attendance-report-sync-a2-smoke.mjs')
+const script = readFileSync(scriptPath, 'utf8')
+
+test('env contract: BASE_URL/DATABASE_URL/DEPLOY_SHA required, STAMP regex-locked, org ids derived from stamp', () => {
+  const missing = resolveEnvConfig({})
+  assert.equal(missing.ok, false)
+  assert.ok(missing.errors.some((msg) => msg.includes('BASE_URL and DATABASE_URL')))
+  assert.ok(missing.errors.some((msg) => msg.includes('DEPLOY_SHA is required')))
+
+  const placeholder = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: '<fill-from-staging-build>',
+  })
+  assert.equal(placeholder.ok, false)
+  assert.ok(placeholder.errors.some((msg) => msg.includes('DEPLOY_SHA is required')))
+
+  const good = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082/',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: 'abc123def456',
+  })
+  assert.equal(good.ok, true)
+  assert.equal(good.config.baseUrl, 'http://127.0.0.1:8082', 'trailing slash stripped')
+  assert.match(good.config.stamp, STAMP_PATTERN)
+  assert.ok(good.config.stamp.startsWith('reportsync-a2-smoke-'))
+  assert.equal(good.config.orgIds.gate, `${good.config.stamp}-gate`)
+  assert.equal(good.config.orgIds.main, `${good.config.stamp}-main`)
+  assert.equal(good.config.orgIds.throttle, `${good.config.stamp}-throttle`)
+  for (const orgId of Object.values(good.config.orgIds)) {
+    assert.ok(isStampedId(orgId, good.config.stamp), `${orgId} must be prefixed with the stamp`)
+  }
+  assert.equal(good.config.allowCrossOrgFanout, false, 'ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT defaults to false')
+
+  const badStamp = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: 'abc123def456',
+    STAMP: 'hmr5-smoke-wrong-family',
+  })
+  assert.equal(badStamp.ok, false)
+  assert.ok(badStamp.errors.some((msg) => msg.includes('reportsync-a2-smoke')))
+
+  const allowedOverride = resolveEnvConfig({
+    BASE_URL: 'http://127.0.0.1:8082',
+    DATABASE_URL: 'postgresql://u@127.0.0.1:5432/metasheet',
+    DEPLOY_SHA: 'abc123def456',
+    [ALLOW_CROSS_ORG_FANOUT_ENV]: '1',
+  })
+  assert.equal(allowedOverride.config.allowCrossOrgFanout, true)
+})
+
+test('env contract: RUN_DATE must be YYYY-MM-DD when set, otherwise passes through untouched', () => {
+  const base = { BASE_URL: 'http://x', DATABASE_URL: 'postgresql://x', DEPLOY_SHA: 'abc123' }
+  const unset = resolveEnvConfig(base)
+  assert.equal(unset.ok, true)
+  assert.equal(unset.config.runDate, '')
+
+  const good = resolveEnvConfig({ ...base, RUN_DATE: '2026-07-05' })
+  assert.equal(good.ok, true)
+  assert.equal(good.config.runDate, '2026-07-05')
+
+  const bad = resolveEnvConfig({ ...base, RUN_DATE: '07/05/2026' })
+  assert.equal(bad.ok, false)
+  assert.ok(bad.errors.some((msg) => msg.includes('RUN_DATE must be YYYY-MM-DD')))
+})
+
+test('isStampedId: true only for values that start with the prefix and have extra content', () => {
+  assert.equal(isStampedId('reportsync-a2-smoke-abc-gate', 'reportsync-a2-smoke-abc'), true)
+  assert.equal(isStampedId('reportsync-a2-smoke-abc', 'reportsync-a2-smoke-abc'), false, 'exact match with nothing extra is rejected')
+  assert.equal(isStampedId('other-org', 'reportsync-a2-smoke-abc'), false)
+  assert.equal(isStampedId(123, 'reportsync-a2-smoke-abc'), false, 'non-string is rejected')
+})
+
+test('attendanceReportRecordRowKey: mirrors the documented `${orgId}:${userId}:${workDate}` formula from #3630/the design-lock', () => {
+  assert.equal(attendanceReportRecordRowKey('org1', 'user1', '2026-07-05'), 'org1:user1:2026-07-05')
+  assert.equal(
+    attendanceReportRecordRowKey('reportsync-a2-smoke-x-main', 'reportsync-a2-smoke-x-main-fresh', '2026-07-05'),
+    'reportsync-a2-smoke-x-main:reportsync-a2-smoke-x-main-fresh:2026-07-05',
+  )
+})
+
+test('createFakeReportRecordsMultitable: create/query/patch semantics match the real writer\'s contract shape', async () => {
+  const fake = createFakeReportRecordsMultitable()
+  assert.deepEqual(fake.store, [])
+  assert.equal(fake.rowKeyFieldId, 'fld_row_key')
+  assert.equal(fake.fieldFingerprintFieldId, 'fld_field_fingerprint')
+  assert.equal(fake.sourceFingerprintFieldId, 'fld_source_fingerprint')
+
+  const created = await fake.records.createRecord({ data: { [fake.rowKeyFieldId]: 'org:u:2026-07-05', [fake.fieldFingerprintFieldId]: 'ff1' } })
+  assert.ok(created.id)
+  assert.equal(fake.store.length, 1)
+
+  const found = await fake.records.queryRecords({ filters: { [fake.rowKeyFieldId]: 'org:u:2026-07-05' } })
+  assert.equal(found.length, 1)
+  assert.equal(found[0].id, created.id)
+
+  const notFound = await fake.records.queryRecords({ filters: { [fake.rowKeyFieldId]: 'nope' } })
+  assert.equal(notFound.length, 0)
+
+  await fake.records.patchRecord({ recordId: created.id, changes: { [fake.fieldFingerprintFieldId]: 'ff2' } })
+  assert.equal(fake.store[0].data[fake.fieldFingerprintFieldId], 'ff2', 'patch merges onto the existing row')
+  assert.equal(fake.store[0].data[fake.rowKeyFieldId], 'org:u:2026-07-05', 'patch preserves untouched fields')
+  assert.equal(fake.store.length, 1, 'patch never creates a second row')
+
+  const resolved = await fake.provisioning.resolveFieldIds({ fieldIds: ['row_key', 'field_fingerprint'] })
+  assert.deepEqual(resolved, { row_key: 'fld_row_key', field_fingerprint: 'fld_field_fingerprint' })
+  const ensured = await fake.provisioning.ensureObject({})
+  assert.ok(ensured.baseId && ensured.sheet?.id)
+})
+
+test('seedStaleReportRecordFixture: seeds exactly one row with the given rowKey and stale dual-fingerprint markers', () => {
+  const fake = createFakeReportRecordsMultitable()
+  seedStaleReportRecordFixture(fake, 'org:stale-user:2026-07-05')
+  assert.equal(fake.store.length, 1)
+  const row = fake.store[0]
+  assert.equal(row.data[fake.rowKeyFieldId], 'org:stale-user:2026-07-05')
+  assert.equal(row.data[fake.fieldFingerprintFieldId], 'stale-field-fingerprint-marker')
+  assert.equal(row.data[fake.sourceFingerprintFieldId], 'stale-source-fingerprint-marker')
+})
+
+test('isDoubleGateClosedResult: true only for the exact { ran:false, reason:"disabled", orgs:[] } shape', () => {
+  assert.equal(isDoubleGateClosedResult({ ran: false, reason: 'disabled', orgs: [] }), true)
+  assert.equal(isDoubleGateClosedResult({ ran: true, reason: 'disabled', orgs: [] }), false, 'ran must be false')
+  assert.equal(isDoubleGateClosedResult({ ran: false, reason: 'other', orgs: [] }), false, 'reason must be "disabled"')
+  assert.equal(isDoubleGateClosedResult({ ran: false, reason: 'disabled', orgs: [{ orgId: 'x' }] }), false, 'orgs must be empty')
+  assert.equal(isDoubleGateClosedResult({ ran: false, reason: 'disabled' }), false, 'orgs must be an array')
+  assert.equal(isDoubleGateClosedResult(null), false)
+  assert.equal(isDoubleGateClosedResult(undefined), false)
+})
+
+test('findOrgResult: finds the matching org among several, returns null when absent', () => {
+  const result = { ran: true, cadence: 'daily', orgs: [{ orgId: 'a', claimed: false }, { orgId: 'b', claimed: true }] }
+  assert.deepEqual(findOrgResult(result, 'b'), { orgId: 'b', claimed: true })
+  assert.equal(findOrgResult(result, 'zzz'), null)
+  assert.equal(findOrgResult({ orgs: [] }, 'a'), null)
+  assert.equal(findOrgResult(null, 'a'), null)
+  assert.equal(findOrgResult(undefined, 'a'), null)
+})
+
+test('isFreshCompletedClaim: true only for claimed + freshlyCreated + status=completed', () => {
+  assert.equal(isFreshCompletedClaim({ claimed: true, freshlyCreated: true, status: 'completed' }), true)
+  assert.equal(isFreshCompletedClaim({ claimed: true, freshlyCreated: true, status: 'queued' }), false, 'must be completed')
+  assert.equal(isFreshCompletedClaim({ claimed: true, freshlyCreated: false, status: 'completed' }), false, 'must be freshlyCreated')
+  assert.equal(isFreshCompletedClaim({ claimed: false, freshlyCreated: true, status: 'completed' }), false, 'must be claimed')
+  assert.equal(isFreshCompletedClaim(null), false)
+})
+
+test('isIdempotentNoOpRepeat: true only for claimed:false + reason=already_completed + matching jobId', () => {
+  assert.equal(isIdempotentNoOpRepeat({ claimed: false, reason: 'already_completed', jobId: 'j1' }, 'j1'), true)
+  assert.equal(isIdempotentNoOpRepeat({ claimed: true, reason: 'already_completed', jobId: 'j1' }, 'j1'), false, 'must be claimed:false')
+  assert.equal(isIdempotentNoOpRepeat({ claimed: false, reason: 'error', jobId: 'j1' }, 'j1'), false, 'must be reason=already_completed')
+  assert.equal(isIdempotentNoOpRepeat({ claimed: false, reason: 'already_completed', jobId: 'j2' }, 'j1'), false, 'jobId must match')
+})
+
+test('isResumingQueuedClaim: true only for claimed:true + freshlyCreated:false + status=queued + matching jobId', () => {
+  assert.equal(isResumingQueuedClaim({ claimed: true, freshlyCreated: false, status: 'queued', jobId: 'j1' }, 'j1'), true)
+  assert.equal(isResumingQueuedClaim({ claimed: true, freshlyCreated: true, status: 'queued', jobId: 'j1' }, 'j1'), false, 'must NOT be freshlyCreated (that would mean a new job, not a resume)')
+  assert.equal(isResumingQueuedClaim({ claimed: true, freshlyCreated: false, status: 'completed', jobId: 'j1' }, 'j1'), false, 'must still be queued, not completed')
+  assert.equal(isResumingQueuedClaim({ claimed: true, freshlyCreated: false, status: 'queued', jobId: 'j2' }, 'j1'), false, 'jobId must match (same job, not a new one)')
+  assert.equal(isResumingQueuedClaim({ claimed: false, freshlyCreated: false, status: 'queued', jobId: 'j1' }, 'j1'), false, 'must be claimed')
+})
+
+test('resolveMaxOrgsPerRunForFullCoverage: adds headroom, caps at the real zod ceiling, refuses loudly past it', () => {
+  assert.deepEqual(resolveMaxOrgsPerRunForFullCoverage(0), { ok: true, value: 3 })
+  assert.deepEqual(resolveMaxOrgsPerRunForFullCoverage(2), { ok: true, value: 5 })
+  assert.deepEqual(resolveMaxOrgsPerRunForFullCoverage(47), { ok: true, value: MAX_ORGS_PER_RUN_CEILING }, '47+3=50 exactly at the ceiling is still ok')
+
+  const overCeiling = resolveMaxOrgsPerRunForFullCoverage(48)
+  assert.equal(overCeiling.ok, false)
+  assert.match(overCeiling.error, /caps maxOrgsPerRun at 50/)
+  assert.match(overCeiling.error, /48 distinct org/)
+
+  const customHeadroom = resolveMaxOrgsPerRunForFullCoverage(10, 1)
+  assert.deepEqual(customHeadroom, { ok: true, value: 11 })
+})
+
+test('residueIsZero: true only when every counter is exactly zero', () => {
+  assert.equal(residueIsZero({ jobs: 0, records: 0, rules: 0, user_orgs: 0, users: 0 }), true)
+  assert.equal(residueIsZero({ jobs: 0, records: 1, rules: 0, user_orgs: 0, users: 0 }), false)
+  assert.equal(residueIsZero({}), true, 'no keys vacuously passes (matches Array.prototype.every semantics)')
+})
+
+// --- source-text shape locks (regex against this helper's own script, no DB/network needed) --------
+
+test('source shape: required runtime env flags are checked by their real literal names', () => {
+  assert.match(script, /ATTENDANCE_SCHEDULER_ENABLED_ENV = 'ATTENDANCE_SCHEDULER_ENABLED'/)
+  assert.match(script, /REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG = 'ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED'/)
+  assert.equal(ATTENDANCE_SCHEDULER_ENABLED_ENV, 'ATTENDANCE_SCHEDULER_ENABLED')
+  assert.equal(REPORT_SYNC_SCHEDULED_TRIGGER_ENV_FLAG, 'ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED')
+  assert.match(script, /assertRequiredRuntimeEnv/)
+})
+
+test('source shape: the PASS stamp template names every field this helper promises', () => {
+  assert.match(script, /REPORT_SYNC_A2_API_DB_SMOKE_PASS deploy=\$\{DEPLOY_SHA\} stamp=\$\{STAMP\} org=\$\{ORG_IDS\.main\} orgs=\$\{ALL_ORG_IDS\.join\('\|'\)\} synced=\$\{synced\} collateralOtherOrgs=\$\{collateralRiskOrgIds\.length\} residue=0/)
+})
+
+test('source shape: cross-org fan-out guard exists and is gated by the documented override env var', () => {
+  assert.match(script, /ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT/)
+  assert.equal(ALLOW_CROSS_ORG_FANOUT_ENV, 'ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT')
+  assert.match(script, /assertCrossOrgFanoutRisk/)
+  assert.match(script, /refusing to run: resolveAttendanceReportSyncScheduledTriggerOrgIds has no per-org filter/)
+})
+
+test('source shape: SQL statements use parameterized placeholders for org/user/date values, not string interpolation', () => {
+  // Every WHERE clause that filters by org/user id in this helper's own SQL must use a $N placeholder,
+  // never a template-literal-interpolated value. This regex looks for the dangerous shape
+  // (`= '${...}'` or `= "${...}"` inside a SQL template) and asserts it never appears.
+  assert.doesNotMatch(script, /(WHERE|AND)\s+\w+\s*=\s*['"]\$\{/i, 'no interpolated literal values in SQL WHERE clauses')
+  // Every INSERT statement in this helper uses numbered placeholders ($1, $2, ...) for its VALUES.
+  const insertStatements = script.match(/INSERT INTO \w+[\s\S]*?VALUES\s*\([^)]*\)/g) || []
+  assert.ok(insertStatements.length >= 3, 'expected at least the rules/users/user_orgs/attendance_records INSERT statements')
+  for (const statement of insertStatements) {
+    assert.match(statement, /\$\d/, `INSERT statement should use $N placeholders: ${statement.slice(0, 80)}...`)
+  }
+})
+
+test('source shape: cleanup DELETEs cover every table this helper seeds INTO (dual reachability)', () => {
+  const insertedTables = new Set([...script.matchAll(/INSERT INTO (\w+)/g)].map((match) => match[1]))
+  // DELETE targets are either a template-literal-interpolated constant (`DELETE FROM ${CONST_NAME}`) or
+  // a plain identifier (`DELETE FROM table_name`) — match both forms.
+  const deletedTables = new Set(
+    [...script.matchAll(/DELETE FROM (?:\$\{(\w+)\}|(\w+))/g)].map((match) => match[1] || match[2]),
+  )
+  // REPORT_SYNC_JOB_TABLE is interpolated as `${REPORT_SYNC_JOB_TABLE}`, not a literal identifier — the
+  // regex above captures the constant NAME in that case, so normalize it to the real table name.
+  if (deletedTables.has('REPORT_SYNC_JOB_TABLE')) {
+    deletedTables.delete('REPORT_SYNC_JOB_TABLE')
+    deletedTables.add(REPORT_SYNC_JOB_TABLE)
+  }
+  for (const table of insertedTables) {
+    assert.ok(deletedTables.has(table), `table "${table}" is INSERTed by a seed helper but has no matching DELETE FROM in cleanup()`)
+  }
+  // plugin_attendance_report_sync_jobs is never INSERTed by this helper directly (the runner creates
+  // those rows) but MUST still be cleaned up.
+  assert.ok(deletedTables.has(REPORT_SYNC_JOB_TABLE), `${REPORT_SYNC_JOB_TABLE} must be cleaned up even though this helper never INSERTs it directly`)
+})
+
+test('source shape: settings restore in cleanup() is scoped to just reportSync, not a whole-blob PUT-back', () => {
+  assert.match(script, /body:\s*\{\s*reportSync:\s*originalReportSync/)
+})
+
+test('source shape: the scenario functions exist for every S3 assertion the design-lock/PR body promise', () => {
+  for (const fn of [
+    'assertDoubleGateClosedBothHalves',
+    'assertMainFlowCreateAndPatch',
+    'assertMaxUsersPerRunThrottle',
+    'assertMaxOrgsPerRunThrottle',
+    'reportCollateralCrossOrgJobRows',
+  ]) {
+    assert.match(script, new RegExp(`function ${fn}`), `expected a ${fn}() function`)
+  }
+})


### PR DESCRIPTION
## Summary

S3 of `docs/development/attendance-report-sync-a2-scheduled-trigger-design-lock-20260705.md`
(#3623, RATIFIED owner-delegated) — the staging-smoke slice. Ops tooling only, **zero
runtime/product code changes**:

- `scripts/ops/staging-attendance-report-sync-a2-smoke.mjs` — calls the A2 scheduled-trigger tick
  directly against a real staging Postgres (same convention as
  `staging-attendance-auto-shift-a2-smoke.mjs`: bypasses the interval scheduler, real DB, real
  settings HTTP API), and proves: both double-gate halves independently no-op; a gate-open tick
  claims a job and in one page both **creates** a report-record for a new user and **patches** a
  pre-existing-but-stale one (dual fingerprint); a repeat tick in the same period is a byte-exact
  idempotent no-op; `maxUsersPerRun` resumes the same job across ticks until the roster drains;
  `maxOrgsPerRun` throttles the org fan-out (checked directly against the exported pure helper);
  cleanup to residue `0`.
- `scripts/ops/staging-attendance-report-sync-a2-smoke.test.mjs` — contract tests for the helper's
  own pure logic (env config, in-memory fixture behavior, assertion-shape predicates, SQL
  parameterization, cleanup-table dual-reachability, PASS-stamp format). Does not touch a real
  DB/network. `node --test` locally: **20/20 passing**.
- `docs/development/attendance-report-sync-a2-staging-smoke-runbook-20260705.md` — runbook
  mirroring the HMR-5 two-stage-stamp convention, including a documented cross-org fan-out hazard
  and the two manual close-out steps the helper's own SCOPE NOTE says it does not cover.

## Dependency on #3630 (report-sync A2 scheduled trigger runtime, OPEN)

This helper asserts against settings keys / job shapes / the exported test seam that **#3630**
introduces (not yet merged). It was written against #3630's diff as read at authoring time
(`reportSync.scheduledTrigger.{enabled,cadence,maxOrgsPerRun,maxUsersPerRun}`,
`ATTENDANCE_REPORT_SYNC_SCHEDULED_TRIGGER_ENABLED`, job name `attendance-report-sync-scheduled`,
test seam `runAttendanceReportSyncScheduledTriggerOnce`/`resolveAttendanceReportSyncScheduledTriggerOrgIds`/
`resetAttendanceSettingsCacheForTests` on `__attendanceReportFieldCatalogForTests`). **The helper
cannot run until #3630 merges and is deployed.** If #3630's shape changes during its own review,
this helper/runbook need a follow-up sync pass — flagged explicitly rather than silently assumed
stable.

## Two scope decisions worth a reviewer's eyes

1. **`context.api.multitable` is an in-process, in-memory stand-in**, not the real multitable
   stack — matching the exact shape the #3630 real-DB CI gate's own fake uses. The design-lock
   explicitly delegates writes to the existing `syncAttendanceReportRecordsForUsers` writer and
   says A2 must not re-implement multitable writes; that writer's real multitable behavior is
   already staging-proven separately (2026-05-19 live evidence,
   `scripts/ops/attendance-report-fields-live-acceptance.mjs`). This smoke's job is the genuinely
   new part — the scheduling/claim/idempotency/throttle layer — hence the `API_DB` stamp name, not
   `API_MULTITABLE`. Full reasoning in the `.mjs` file header SCOPE NOTE and the runbook.
2. **Cross-org fan-out hazard**: `resolveAttendanceReportSyncScheduledTriggerOrgIds` has no
   per-org filter (`SELECT DISTINCT org_id FROM attendance_rules ORDER BY org_id`, sliced to
   `maxOrgsPerRun`) — a gate-open tick sweeps in every org with an `attendance_rules` row, not just
   this helper's own synthetic ones. The helper refuses to run against a DB with pre-existing
   other-org rows unless `ALLOW_CROSS_ORG_REPORT_SYNC_FANOUT=1`, and reports (without deleting) any
   collateral job rows it causes for those other orgs. This is a real, load-bearing safety guard,
   not defensive boilerplate — worth double-checking the reasoning in `assertCrossOrgFanoutRisk()`.

## Test plan

- [x] `node --check` on both new `.mjs` files
- [x] `node --test scripts/ops/staging-attendance-report-sync-a2-smoke.test.mjs` — 20/20 passing locally
- [ ] Operator runs the `.mjs` helper against real staging once #3630 merges + deploys (not run in
      this PR — see runbook "Automated helper" + "Manual close-out steps" for the two-stage PASS
      stamps)

Refs: design-lock #3623 (RATIFIED, merged), runtime #3630 (OPEN, dependency).
