### PR TITLE
feat(multitable): personal views Slice 1 — per-user config overlay (actor-scoped, flag default-off)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -168,7 +168,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope + mirror-read-only enumeration hardening + cross-base editable-mirror write-through op + cross-base mirror write-through Decision-F concurrency)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope + mirror-read-only enumeration hardening + cross-base editable-mirror write-through op + cross-base mirror write-through Decision-F concurrency + personal-views slice-1 actor-scoped isolation)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -314,6 +314,7 @@ jobs:
             tests/integration/multitable-ai-suggest-formula.test.ts \
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             tests/integration/data-source-test-ephemeral-realdb.test.ts \
+            tests/integration/multitable-personal-views-slice1-realdb.test.ts \
             --reporter=dot
 
       - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward + continuous_managers chain walk + common template presets)

--- a/docs/development/multitable-personal-views-slice1-verification-20260705.md
+++ b/docs/development/multitable-personal-views-slice1-verification-20260705.md
@@ -1,0 +1,61 @@
+# Personal (per-user) views — Slice 1 — VERIFICATION — 2026-07-05
+
+> Verifies Slice 1 of the ratified design-lock `multitable-personal-views-design-lock-20260705.md` (merged #3631).
+> Slice 1 = backend data model + resolution contract + shared-fallback + actor-scoped isolation, **flag default-OFF**.
+> No FE, no field-order overlay (slice 2). Built by an unattended L2 agent (Sonnet 5); reviewed by the orchestrator
+> (Opus). **Provenance note:** the build agent stalled during its own real-DB self-check *after* the code was
+> complete — see §5 for exactly what was and was NOT executed locally.
+
+## 1. What was built
+
+| File | Role |
+|---|---|
+| `db/migrations/zzzz20260705150000_create_meta_view_personal_configs.ts` | NEW table `meta_view_personal_configs(view_id text REFERENCES meta_views(id) ON DELETE CASCADE, user_id, config jsonb, updated_at)`, `UNIQUE (view_id, user_id)` + view/user indexes (§7 Q1 LOCKED) |
+| `multitable/personal-view-config.ts` | Resolution + CRUD module. **Never reads `req`** — callers pass an already-resolved actor id, so a client-supplied id is structurally impossible here (§1-B). `applyPersonalViewOverlay` returns the ORIGINAL view reference when there is no overlay (byte-identical shared path by construction, §1-C/G-B). Facet-whitelist sanitizer drops any smuggled `userId`/`viewId`. Flag gate `isPersonalViewsEnabled()` default-OFF. |
+| `routes/univer-meta.ts` | Wiring: on `GET /views`, overlay applied only when `isPersonalViewsEnabled() && requestAccess.userId` and `overlays.size > 0`, else `effectiveViews === views`. Three new routes `GET/PUT/DELETE /views/:viewId/personal-config`, all 404 when flag-off. Target user = `resolveSheetCapabilities(req).access.userId` (JWT/session actor), never body/query/`x-user-id`. `canRead` + `access.userId` fail-closed. Reads `meta_views` (current system), never legacy `views`/`view_states`. |
+| `tests/integration/multitable-personal-views-slice1-realdb.test.ts` | Real-DB goldens (below). |
+| `.github/workflows/plugin-tests.yml` | Wires the golden into the Node-20 real-DB required step (teeth). |
+
+## 2. Security invariants held (Opus-reviewed against the design-lock)
+
+- **§1-B actor-scoped (LOAD-BEARING):** the target user id is sourced ONLY from the authenticated actor
+  (`resolveRequestAccess(req).userId` / `resolveSheetCapabilities(req).access.userId`). The module never sees `req`;
+  every SQL keys on `user_id = actorUserId`. A forged `body.userId` / `query.userId` / `x-user-id` cannot select
+  another user's row. Confirmed by reading every read/write path.
+- **§7 Q1 / §8 anti-precedent:** uses the NEW `meta_view_personal_configs` table only. The legacy
+  `views`/`view_states`/`kanban` path (client-supplied `x-user-id` `kanban.ts:25`, `|| 0` `views.ts:273,298`) is NOT
+  touched or reused.
+- **§1-C / §P2 shared-fallback + flag-off byte-identical:** flag-off OR no override ⇒ `effectiveViews === views`,
+  bit-for-bit today's shared config. Not a careful merge — the same object reference.
+- **fail-closed:** blank/absent actor ⇒ no overlay / `sendForbidden`.
+
+## 3. Fail-first goldens (discriminator-sound)
+
+- **G-A read isolation (LOAD-BEARING):** A's override applies for A, is INVISIBLE to B (B sees shared); GET
+  personal-config is actor-scoped (B never reads A's row). Unset facet falls through to shared (§1-D). RED if
+  resolution keys on anything but the authenticated actor.
+- **G-C write isolation + forged-identity (LOAD-BEARING):** A writing with forged `body.userId=B` (and the harness
+  also injects forged `query.userId` / `x-user-id`) does NOT touch B's row. RED if any client-supplied id alters the
+  write/read target.
+- **G-B shared byte-identical:** flag-off with an override row present ⇒ shared unchanged; flag-on, no override ⇒
+  shared byte-identical. RED if the overlay perturbs the shared path.
+- **flag-off inert:** the three new routes 404 (not no-op) when the flag is off.
+
+## 4. Enablement (unchanged from the lock)
+
+Lands **default-OFF** (`MULTITABLE_ENABLE_PERSONAL_VIEWS`). Flag-on is NOT authorized by this slice — per design-lock
+§5, flag-on requires G-A + G-C green in required CI + an actor-scoping audit. This PR does not enable the flag.
+
+## 5. What was and was NOT executed locally (honest provenance)
+
+- **Executed / verified by review:** the code is complete and self-consistent (Opus read the module, the wiring, the
+  migration, and the goldens end-to-end); arg orders, `effectiveViews` handling, route closure, and the actor-scoping
+  are correct.
+- **NOT executed locally:** the build agent **stalled during its own real-DB self-check before running the suite**,
+  so neither the golden run nor the **observed-RED** (revert the actor-scoping → G-A/G-C go red) was captured here.
+  The goldens are **structurally fail-first** (sound discriminators, traced above) and are now wired into the required
+  Node-20 real-DB CI step, so the PR's CI is the first real execution.
+- **Human reviewer MUST:** (a) confirm the PR's `test (20.x)` runs the new golden GREEN; (b) run the observed-RED once
+  (revert the `user_id = actorUserId` keying → confirm G-A/G-C fail) to convert structural-fail-first into
+  observed-fail-first before any flag-on; (c) sanity-check that `resolveSheetCapabilities().access.userId` is the
+  fully-authenticated identity in this deployment (no upstream shim populates it from a header).

--- a/docs/development/multitable-personal-views-slice1-verification-20260705.md
+++ b/docs/development/multitable-personal-views-slice1-verification-20260705.md
@@ -37,6 +37,12 @@
 - **G-C write isolation + forged-identity (LOAD-BEARING):** A writing with forged `body.userId=B` (and the harness
   also injects forged `query.userId` / `x-user-id`) does NOT touch B's row. RED if any client-supplied id alters the
   write/read target.
+- **G-A drift redaction:** GET personal-config reuses the same field-permission-aware filter-literal redaction as the
+  shared view serializers. A stored personal filter literal is omitted after that field becomes unreadable to the
+  actor, so the actor-scoped endpoint cannot become a stale-literal bypass.
+- **G-C bounded save:** personal `filterInfo` is rejected when it exceeds the shared view-config filter nesting limit,
+  before persistence. This keeps stored overlays bounded so later read/merge redaction cannot recurse over an abusive
+  blob.
 - **G-B shared byte-identical:** flag-off with an override row present ⇒ shared unchanged; flag-on, no override ⇒
   shared byte-identical. RED if the overlay perturbs the shared path.
 - **flag-off inert:** the three new routes 404 (not no-op) when the flag is off.
@@ -55,6 +61,9 @@ Lands **default-OFF** (`MULTITABLE_ENABLE_PERSONAL_VIEWS`). Flag-on is NOT autho
   so neither the golden run nor the **observed-RED** (revert the actor-scoping → G-A/G-C go red) was captured here.
   The goldens are **structurally fail-first** (sound discriminators, traced above) and are now wired into the required
   Node-20 real-DB CI step, so the PR's CI is the first real execution.
+- **Executed during adversarial re-review:** `pnpm --filter @metasheet/core-backend type-check` and `git diff --check`
+  passed. The targeted real-DB spec command was run from a clean review worktree, but the local environment had no
+  `DATABASE_URL`, so Vitest skipped the file; CI remains the required real-DB execution surface for the new goldens.
 - **Human reviewer MUST:** (a) confirm the PR's `test (20.x)` runs the new golden GREEN; (b) run the observed-RED once
   (revert the `user_id = actorUserId` keying → confirm G-A/G-C fail) to convert structural-fail-first into
   observed-fail-first before any flag-on; (c) sanity-check that `resolveSheetCapabilities().access.userId` is the

--- a/docs/development/multitable-personal-views-slice1-verification-20260705.md
+++ b/docs/development/multitable-personal-views-slice1-verification-20260705.md
@@ -57,14 +57,17 @@ Lands **default-OFF** (`MULTITABLE_ENABLE_PERSONAL_VIEWS`). Flag-on is NOT autho
 - **Executed / verified by review:** the code is complete and self-consistent (Opus read the module, the wiring, the
   migration, and the goldens end-to-end); arg orders, `effectiveViews` handling, route closure, and the actor-scoping
   are correct.
-- **NOT executed locally:** the build agent **stalled during its own real-DB self-check before running the suite**,
-  so neither the golden run nor the **observed-RED** (revert the actor-scoping → G-A/G-C go red) was captured here.
-  The goldens are **structurally fail-first** (sound discriminators, traced above) and are now wired into the required
-  Node-20 real-DB CI step, so the PR's CI is the first real execution.
+- **CI GREEN with the guard:** this PR's `test (20.x)` ran the new goldens **green** (first real execution — the build
+  agent had stalled before its own self-check).
+- **observed-RED CONFIRMED (2026-07-05):** a throwaway branch deliberately breaking the actor keying (dropped
+  `user_id` from the read queries + made the PUT route honor `body.userId`) was run through CI — its `test (20.x)`
+  **FAILED** on the personal-views goldens (job `85215174961`), while `test (18.x)` (no real-DB step) passed. The
+  goldens are thus **bidirectionally proven**: GREEN with correct actor-scoping, RED without it. The throwaway
+  PR/branch was closed and deleted. This satisfies the flag-on observed-RED precondition.
 - **Executed during adversarial re-review:** `pnpm --filter @metasheet/core-backend type-check` and `git diff --check`
   passed. The targeted real-DB spec command was run from a clean review worktree, but the local environment had no
   `DATABASE_URL`, so Vitest skipped the file; CI remains the required real-DB execution surface for the new goldens.
-- **Human reviewer MUST:** (a) confirm the PR's `test (20.x)` runs the new golden GREEN; (b) run the observed-RED once
-  (revert the `user_id = actorUserId` keying → confirm G-A/G-C fail) to convert structural-fail-first into
-  observed-fail-first before any flag-on; (c) sanity-check that `resolveSheetCapabilities().access.userId` is the
-  fully-authenticated identity in this deployment (no upstream shim populates it from a header).
+- **Human reviewer MUST:** (a) confirm the PR's `test (20.x)` is GREEN — **done** (green); (b) observed-RED — **done**,
+  confirmed via the throwaway CI run above (green-with-guard + red-without-guard); (c) sanity-check that
+  `resolveSheetCapabilities().access.userId` is the fully-authenticated identity in this deployment (no upstream shim
+  populates it from a header) — the one remaining item, a deployment-config check.

--- a/packages/core-backend/src/db/migrations/zzzz20260705150000_create_meta_view_personal_configs.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260705150000_create_meta_view_personal_configs.ts
@@ -1,0 +1,41 @@
+/**
+ * Personal (per-user) view config overlay — Slice 1 data model.
+ *
+ * Ratified design: docs/development/multitable-personal-views-design-lock-20260705.md
+ *
+ * §7 Q1 (LOCKED per review): v1 data model is a NEW table, FK to `meta_views(id)`, UNIQUE
+ * `(view_id, user_id)`. `user_id` is ALWAYS the authenticated actor (see
+ * `../../multitable/personal-view-config.ts`) — NEVER sourced from a client-supplied
+ * body/query/header value.
+ *
+ * Anti-precedent (§7 Q1 / §8, explicit NON-GOAL): this is NOT an extension of the legacy
+ * `views` / `view_states` / `kanban` state. Those routes resolve the target user via a
+ * client-supplied `x-user-id` header (`routes/kanban.ts:25`) and an `|| 0` default
+ * (`routes/views.ts:273,298`) — a direct violation of the actor-scoped isolation rule
+ * (§1-B). Personal views MUST NOT reuse or extend `view_states`; this new table is the
+ * only storage for the per-user presentation overlay on the current `meta_views` system.
+ */
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_view_personal_configs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      view_id text NOT NULL REFERENCES meta_views(id) ON DELETE CASCADE,
+      user_id text NOT NULL,
+      config jsonb NOT NULL DEFAULT '{}'::jsonb,
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT meta_view_personal_configs_unique UNIQUE (view_id, user_id)
+    )
+  `.execute(db)
+
+  await sql`CREATE INDEX IF NOT EXISTS idx_meta_view_personal_configs_view ON meta_view_personal_configs(view_id)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_meta_view_personal_configs_user ON meta_view_personal_configs(user_id)`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_view_personal_configs CASCADE`.execute(db)
+}

--- a/packages/core-backend/src/multitable/personal-view-config.ts
+++ b/packages/core-backend/src/multitable/personal-view-config.ts
@@ -1,0 +1,196 @@
+/**
+ * Personal (per-user) view config overlay — Slice 1.
+ *
+ * Ratified design: docs/development/multitable-personal-views-design-lock-20260705.md
+ * Verification: docs/development/multitable-personal-views-slice1-verification-20260705.md
+ *
+ * §1-B (LOAD-BEARING, actor-scoped isolation): every read/write of personal config in this
+ * module is keyed to the AUTHENTICATED ACTOR's user id, resolved via
+ * `resolveRequestAccess(req).userId` (JWT/session-derived, `../rbac` + `req.user`) at the
+ * route layer — NEVER from `req.body`, `req.query`, or an `x-user-id`-style header. This
+ * module itself never reads `req` at all: callers MUST pass the already-resolved actor id,
+ * which keeps the anti-precedent (legacy `view_states` / `kanban.ts:25` client-supplied
+ * `x-user-id`, `views.ts:273,298` `|| 0`) structurally impossible to reintroduce here.
+ *
+ * §1-C (resolution contract): effective config = personal override for the actor (if a row
+ * exists) ELSE the shared view config. Absent/partial override degrades to shared, never to
+ * empty/broken. `applyPersonalViewOverlay` returns the ORIGINAL view object unchanged
+ * (same reference) when there is no overlay to apply, so the flag-off / no-override path is
+ * byte-identical to today's shared path (G-B) by construction, not by careful merging.
+ *
+ * §P2 (flag default-off): `isPersonalViewsEnabled()` reads `MULTITABLE_ENABLE_PERSONAL_VIEWS`
+ * (same env-flag convention as the other `MULTITABLE_ENABLE_*` gates in `routes/univer-meta.ts`)
+ * and defaults to OFF. Route call sites MUST check this before ever fetching/applying overlays.
+ */
+
+export type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+/** The facets a personal overlay may set. Field-order overlay is OUT of scope for slice 1 (slice 2). */
+export type PersonalViewConfigOverlay = {
+  filterInfo?: Record<string, unknown>
+  sortInfo?: Record<string, unknown>
+  groupInfo?: Record<string, unknown>
+  hiddenFieldIds?: string[]
+}
+
+export type PersonalViewConfigRecord = {
+  viewId: string
+  userId: string
+  config: PersonalViewConfigOverlay
+  updatedAt: string
+}
+
+const OVERLAY_KEYS = ['filterInfo', 'sortInfo', 'groupInfo', 'hiddenFieldIds'] as const
+
+export const PERSONAL_VIEWS_FLAG_ENV = 'MULTITABLE_ENABLE_PERSONAL_VIEWS'
+
+/** P2: default-OFF feature gate. Flag-on is NOT authorized by this slice — see the design-lock §5. */
+export function isPersonalViewsEnabled(): boolean {
+  return String(process.env[PERSONAL_VIEWS_FLAG_ENV] ?? '').trim().toLowerCase() === 'true'
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Whitelist-sanitize a client-supplied overlay body down to only the known slice-1 facets,
+ * with the expected shape per facet. Unknown keys (including any attempt to smuggle a
+ * `userId` / `viewId` override inside the config body) are silently dropped — the actor and
+ * view identity are NEVER taken from this payload, only from the route's own resolved values.
+ */
+export function sanitizePersonalOverlayConfig(input: unknown): PersonalViewConfigOverlay {
+  if (!isPlainObject(input)) return {}
+  const out: PersonalViewConfigOverlay = {}
+  if (isPlainObject(input.filterInfo)) out.filterInfo = input.filterInfo
+  if (isPlainObject(input.sortInfo)) out.sortInfo = input.sortInfo
+  if (isPlainObject(input.groupInfo)) out.groupInfo = input.groupInfo
+  if (Array.isArray(input.hiddenFieldIds)) {
+    out.hiddenFieldIds = input.hiddenFieldIds.filter((id): id is string => typeof id === 'string')
+  }
+  return out
+}
+
+function normalizeStoredOverlay(value: unknown): PersonalViewConfigOverlay {
+  // Defensive: a row's `config` jsonb should already be sanitized on write, but normalize again
+  // on read so a legacy/hand-edited row can never inject an unexpected facet into resolution.
+  return sanitizePersonalOverlayConfig(value)
+}
+
+/**
+ * §1-C resolution: merge a personal overlay onto a shared view, facet-by-facet. Facets absent
+ * from the overlay fall through to the shared value untouched (§1-D, additive). When there is
+ * no overlay at all, the ORIGINAL view reference is returned unchanged — this is what makes
+ * the flag-off / no-override path byte-identical to today (G-B), not merely "similar".
+ */
+export function applyPersonalViewOverlay<
+  T extends {
+    filterInfo?: Record<string, unknown>
+    sortInfo?: Record<string, unknown>
+    groupInfo?: Record<string, unknown>
+    hiddenFieldIds?: string[]
+  },
+>(view: T, overlay: PersonalViewConfigOverlay | null | undefined): T {
+  if (!overlay) return view
+  const hasAnyFacet = OVERLAY_KEYS.some((key) => overlay[key] !== undefined)
+  if (!hasAnyFacet) return view
+
+  return {
+    ...view,
+    ...(overlay.filterInfo !== undefined ? { filterInfo: overlay.filterInfo } : {}),
+    ...(overlay.sortInfo !== undefined ? { sortInfo: overlay.sortInfo } : {}),
+    ...(overlay.groupInfo !== undefined ? { groupInfo: overlay.groupInfo } : {}),
+    ...(overlay.hiddenFieldIds !== undefined ? { hiddenFieldIds: overlay.hiddenFieldIds } : {}),
+  }
+}
+
+/**
+ * Fetch this actor's personal overrides for a batch of views in one query. Callers MUST pass
+ * an already-resolved authenticated actor id (never a client-supplied value) — see the
+ * module-level note. Returns an empty map for an empty/blank userId (fail-closed: no actor,
+ * no overlay).
+ */
+export async function fetchPersonalViewConfigsForViews(
+  query: QueryFn,
+  viewIds: string[],
+  actorUserId: string,
+): Promise<Map<string, PersonalViewConfigOverlay>> {
+  const map = new Map<string, PersonalViewConfigOverlay>()
+  const ids = Array.from(new Set(viewIds.filter((id) => typeof id === 'string' && id.length > 0)))
+  if (ids.length === 0 || !actorUserId) return map
+
+  const result = await query(
+    'SELECT view_id, config FROM meta_view_personal_configs WHERE user_id = $1 AND view_id = ANY($2::text[])',
+    [actorUserId, ids],
+  )
+  for (const row of result.rows as Array<{ view_id: string; config: unknown }>) {
+    map.set(String(row.view_id), normalizeStoredOverlay(row.config))
+  }
+  return map
+}
+
+/** Read the actor's own personal override for a single view (or null if none exists). */
+export async function getPersonalViewConfig(
+  query: QueryFn,
+  viewId: string,
+  actorUserId: string,
+): Promise<PersonalViewConfigRecord | null> {
+  if (!viewId || !actorUserId) return null
+  const result = await query(
+    'SELECT view_id, user_id, config, updated_at FROM meta_view_personal_configs WHERE view_id = $1 AND user_id = $2',
+    [viewId, actorUserId],
+  )
+  const row = (result.rows as Array<{ view_id: string; user_id: string; config: unknown; updated_at: unknown }>)[0]
+  if (!row) return null
+  return {
+    viewId: String(row.view_id),
+    userId: String(row.user_id),
+    config: normalizeStoredOverlay(row.config),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at),
+  }
+}
+
+/**
+ * Upsert the actor's own personal override. `viewId` and `actorUserId` MUST both come from the
+ * route (viewId from the URL param / a validated existing view row, actorUserId from
+ * `resolveRequestAccess(req).userId`) — this function has no way to write any other user's row
+ * because the SQL keys the write on `(view_id, user_id)` = `(viewId, actorUserId)` exactly; there
+ * is no code path here that accepts a target user id from the overlay payload.
+ */
+export async function upsertPersonalViewConfig(
+  query: QueryFn,
+  viewId: string,
+  actorUserId: string,
+  overlay: PersonalViewConfigOverlay,
+): Promise<PersonalViewConfigRecord> {
+  const sanitized = sanitizePersonalOverlayConfig(overlay)
+  const result = await query(
+    `INSERT INTO meta_view_personal_configs (view_id, user_id, config, updated_at)
+     VALUES ($1, $2, $3::jsonb, now())
+     ON CONFLICT (view_id, user_id)
+     DO UPDATE SET config = $3::jsonb, updated_at = now()
+     RETURNING view_id, user_id, config, updated_at`,
+    [viewId, actorUserId, JSON.stringify(sanitized)],
+  )
+  const row = (result.rows as Array<{ view_id: string; user_id: string; config: unknown; updated_at: unknown }>)[0]
+  return {
+    viewId: String(row.view_id),
+    userId: String(row.user_id),
+    config: normalizeStoredOverlay(row.config),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at),
+  }
+}
+
+/** Delete the actor's own personal override (no-op if none exists). Returns whether a row was deleted. */
+export async function deletePersonalViewConfig(
+  query: QueryFn,
+  viewId: string,
+  actorUserId: string,
+): Promise<boolean> {
+  if (!viewId || !actorUserId) return false
+  const result = await query(
+    'DELETE FROM meta_view_personal_configs WHERE view_id = $1 AND user_id = $2',
+    [viewId, actorUserId],
+  )
+  return (result.rowCount ?? 0) > 0
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -212,6 +212,15 @@ import {
 } from '../multitable/post-commit-hooks'
 import { listRecordRevisions, recordRecordRevision, type RecordRevisionEntry } from '../multitable/record-history-service'
 import {
+  isPersonalViewsEnabled,
+  applyPersonalViewOverlay,
+  fetchPersonalViewConfigsForViews,
+  getPersonalViewConfig,
+  upsertPersonalViewConfig,
+  deletePersonalViewConfig,
+  sanitizePersonalOverlayConfig,
+} from '../multitable/personal-view-config'
+import {
   countUnreadRecordSubscriptionNotifications,
   getRecordSubscriptionStatus,
   listRecordSubscriptionNotifications,
@@ -10831,9 +10840,29 @@ export function univerMetaRouter(): Router {
         config: normalizeJson(r.config),
       }))
 
+      const requestAccess = await resolveRequestAccess(req)
       // #2052 (b): redact denied-field filter literals per the requester's allowed-field set.
-      const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, (await resolveRequestAccess(req)).userId, capabilities)
-      return res.json({ ok: true, data: { views: views.map((view: UniverMetaViewConfig) => redactViewConfigFilterLiterals(view, allowedFieldIds)) } })
+      const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, requestAccess.userId, capabilities)
+
+      // Personal (per-user) view config overlay — Slice 1, flag default-OFF (design-lock
+      // docs/development/multitable-personal-views-design-lock-20260705.md §1-C / §P2). §1-C
+      // resolution: this actor's personal override (if a row exists) ELSE the shared config —
+      // absent override / flag-off leaves `effectiveViews === views` unchanged (byte-identical,
+      // G-B). `requestAccess.userId` is the authenticated actor resolved above (JWT/session via
+      // `resolveRequestAccess`) — NEVER a client-supplied id (§1-B).
+      let effectiveViews: UniverMetaViewConfig[] = views
+      if (isPersonalViewsEnabled() && requestAccess.userId) {
+        const overlays = await fetchPersonalViewConfigsForViews(
+          pool.query.bind(pool),
+          views.map((view) => view.id),
+          requestAccess.userId,
+        )
+        if (overlays.size > 0) {
+          effectiveViews = views.map((view) => applyPersonalViewOverlay(view, overlays.get(view.id)))
+        }
+      }
+
+      return res.json({ ok: true, data: { views: effectiveViews.map((view: UniverMetaViewConfig) => redactViewConfigFilterLiterals(view, allowedFieldIds)) } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -11518,6 +11547,113 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] delete view failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete view' } })
+    }
+  })
+
+  // Personal (per-user) view config overlay — Slice 1 (design-lock
+  // docs/development/multitable-personal-views-design-lock-20260705.md). Flag default-OFF
+  // (§P2): while `MULTITABLE_ENABLE_PERSONAL_VIEWS` is unset/false these three routes 404 —
+  // they do not exist on the wire, so there is nothing for a flag-off deployment to expose.
+  // §1-B (LOAD-BEARING): the target user of every read/write below is
+  // `resolveSheetCapabilities(req, ...).access.userId` — the authenticated actor resolved from
+  // `req.user` (JWT/session) — NEVER `req.body.userId` / `req.query.userId` / an `x-user-id`
+  // header. No parameter on these routes can select a different user's row.
+  async function loadViewForPersonalConfig(
+    pool: ReturnType<typeof poolManager.get>,
+    viewId: string,
+  ): Promise<{ id: string; sheetId: string } | null> {
+    const current = await pool.query('SELECT id, sheet_id FROM meta_views WHERE id = $1', [viewId])
+    const row = (current as any).rows[0]
+    if (!row) return null
+    return { id: String(row.id), sheetId: String(row.sheet_id) }
+  }
+
+  router.get('/views/:viewId/personal-config', async (req: Request, res: Response) => {
+    if (!isPersonalViewsEnabled()) {
+      return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Not found' } })
+    }
+    const viewId = req.params.viewId
+    if (!viewId || typeof viewId !== 'string') {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'viewId is required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const view = await loadViewForPersonalConfig(pool, viewId)
+      if (!view) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
+      }
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), view.sheetId)
+      if (!capabilities.canRead) return sendForbidden(res)
+      if (!access.userId) return sendForbidden(res)
+
+      const record = await getPersonalViewConfig(pool.query.bind(pool), viewId, access.userId)
+      return res.json({ ok: true, data: { viewId, config: record?.config ?? null, updatedAt: record?.updatedAt ?? null } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] get personal view config failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load personal view config' } })
+    }
+  })
+
+  router.put('/views/:viewId/personal-config', async (req: Request, res: Response) => {
+    if (!isPersonalViewsEnabled()) {
+      return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Not found' } })
+    }
+    const viewId = req.params.viewId
+    if (!viewId || typeof viewId !== 'string') {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'viewId is required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const view = await loadViewForPersonalConfig(pool, viewId)
+      if (!view) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
+      }
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), view.sheetId)
+      // Presentation-only overlay of a view the actor can already READ (§1-A); this is not a
+      // write to shared config/permissions, so the gate is read access, not canManageViews.
+      if (!capabilities.canRead) return sendForbidden(res)
+      if (!access.userId) return sendForbidden(res)
+
+      // Any `userId`/`actorId` field inside the request body is ignored entirely —
+      // `sanitizePersonalOverlayConfig` only ever extracts the known presentation facets.
+      const overlay = sanitizePersonalOverlayConfig((req.body as { config?: unknown } | undefined)?.config)
+      const record = await upsertPersonalViewConfig(pool.query.bind(pool), viewId, access.userId, overlay)
+      return res.json({ ok: true, data: { viewId, config: record.config, updatedAt: record.updatedAt } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] upsert personal view config failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to save personal view config' } })
+    }
+  })
+
+  router.delete('/views/:viewId/personal-config', async (req: Request, res: Response) => {
+    if (!isPersonalViewsEnabled()) {
+      return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Not found' } })
+    }
+    const viewId = req.params.viewId
+    if (!viewId || typeof viewId !== 'string') {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'viewId is required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const view = await loadViewForPersonalConfig(pool, viewId)
+      if (!view) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
+      }
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), view.sheetId)
+      if (!capabilities.canRead) return sendForbidden(res)
+      if (!access.userId) return sendForbidden(res)
+
+      const deleted = await deletePersonalViewConfig(pool.query.bind(pool), viewId, access.userId)
+      return res.json({ ok: true, data: { viewId, deleted } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] delete personal view config failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete personal view config' } })
     }
   })
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -219,6 +219,7 @@ import {
   upsertPersonalViewConfig,
   deletePersonalViewConfig,
   sanitizePersonalOverlayConfig,
+  type PersonalViewConfigOverlay,
 } from '../multitable/personal-view-config'
 import {
   countUnreadRecordSubscriptionNotifications,
@@ -11568,6 +11569,13 @@ export function univerMetaRouter(): Router {
     return { id: String(row.id), sheetId: String(row.sheet_id) }
   }
 
+  function redactPersonalOverlayFilterLiterals(
+    config: PersonalViewConfigOverlay | null,
+    allowedFieldIds: Set<string>,
+  ): PersonalViewConfigOverlay | null {
+    return redactViewConfigFilterLiterals(config, allowedFieldIds)
+  }
+
   router.get('/views/:viewId/personal-config', async (req: Request, res: Response) => {
     if (!isPersonalViewsEnabled()) {
       return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Not found' } })
@@ -11587,7 +11595,12 @@ export function univerMetaRouter(): Router {
       if (!access.userId) return sendForbidden(res)
 
       const record = await getPersonalViewConfig(pool.query.bind(pool), viewId, access.userId)
-      return res.json({ ok: true, data: { viewId, config: record?.config ?? null, updatedAt: record?.updatedAt ?? null } })
+      let config: PersonalViewConfigOverlay | null = null
+      if (record) {
+        const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), view.sheetId, access.userId, capabilities)
+        config = redactPersonalOverlayFilterLiterals(record.config, allowedFieldIds)
+      }
+      return res.json({ ok: true, data: { viewId, config, updatedAt: record?.updatedAt ?? null } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -11619,6 +11632,12 @@ export function univerMetaRouter(): Router {
       // Any `userId`/`actorId` field inside the request body is ignored entirely —
       // `sanitizePersonalOverlayConfig` only ever extracts the known presentation facets.
       const overlay = sanitizePersonalOverlayConfig((req.body as { config?: unknown } | undefined)?.config)
+      if (overlay.filterInfo !== undefined && filterInfoExceedsMaxDepth(overlay.filterInfo, 0)) {
+        return res.status(400).json({
+          ok: false,
+          error: { code: 'VALIDATION_ERROR', message: `Filter nesting exceeds the maximum depth of ${MAX_FILTER_DEPTH}` },
+        })
+      }
       const record = await upsertPersonalViewConfig(pool.query.bind(pool), viewId, access.userId, overlay)
       return res.json({ ok: true, data: { viewId, config: record.config, updatedAt: record.updatedAt } })
     } catch (err) {

--- a/packages/core-backend/tests/integration/multitable-personal-views-slice1-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-personal-views-slice1-realdb.test.ts
@@ -41,6 +41,7 @@ const SHARED_GROUP = {}
 const SHARED_HIDDEN: string[] = []
 
 const PERSONAL_A_FILTER = { conjunction: 'and', conditions: [{ fieldId: FIELD_ID, operator: 'is', value: 'personal-a-val' }] }
+const PERSONAL_SECRET_LITERAL = 'personal-secret-literal-do-not-leak'
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
@@ -78,6 +79,19 @@ const rowForUser = async (userId: string) =>
   (await q('SELECT config FROM meta_view_personal_configs WHERE view_id = $1 AND user_id = $2', [VIEW_ID, userId]))
     .rows[0] as { config: unknown } | undefined
 
+const bodyText = (res: { body: unknown }) => JSON.stringify(res.body)
+
+function buildTooDeepFilter(): Record<string, unknown> {
+  const root: { conjunction: string; conditions: unknown[] } = { conjunction: 'and', conditions: [] }
+  let cursor = root
+  for (let i = 0; i < 6; i += 1) {
+    const child: { conjunction: string; conditions: unknown[] } = { conjunction: 'and', conditions: [] }
+    cursor.conditions.push(child)
+    cursor = child
+  }
+  return root
+}
+
 describeIfDatabase('personal (per-user) view config overlay — slice 1 (real DB)', () => {
   beforeAll(async () => {
     app = express()
@@ -99,6 +113,7 @@ describeIfDatabase('personal (per-user) view config overlay — slice 1 (real DB
 
   afterAll(async () => {
     await q('DELETE FROM meta_view_personal_configs WHERE view_id = $1', [VIEW_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
@@ -110,6 +125,7 @@ describeIfDatabase('personal (per-user) view config overlay — slice 1 (real DB
     currentPerms = ['multitable:read', 'multitable:write']
     currentForgedHeader = undefined
     delete process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID])
     await q('DELETE FROM meta_view_personal_configs WHERE view_id = $1', [VIEW_ID])
   })
 
@@ -203,6 +219,33 @@ describeIfDatabase('personal (per-user) view config overlay — slice 1 (real DB
     expect(resB.body.data.config).toBeNull() // B has no row of their own
   })
 
+  test('G-A: GET personal-config redacts denied-field filter literals after permission drift', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    await q(
+      `INSERT INTO meta_view_personal_configs (view_id, user_id, config) VALUES ($1, $2, $3::jsonb)`,
+      [VIEW_ID, USER_A, JSON.stringify({
+        filterInfo: {
+          conjunction: 'and',
+          conditions: [{ fieldId: FIELD_ID, operator: 'is', value: PERSONAL_SECRET_LITERAL }],
+        },
+      })],
+    )
+    await q(
+      `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only)
+       VALUES ($1, $2, 'user', $3, false, false)`,
+      [SHEET_ID, FIELD_ID, USER_A],
+    )
+
+    currentUserId = USER_A
+    const res = await getPersonalConfig(VIEW_ID)
+    expect(res.status).toBe(200)
+    expect(bodyText(res)).not.toContain(PERSONAL_SECRET_LITERAL)
+    expect(res.body.data.config.filterInfo).toEqual({
+      conjunction: 'and',
+      conditions: [{ fieldId: FIELD_ID, operator: 'is' }],
+    })
+  })
+
   // ---------------------------------------------------------------------------------------
   // G-C — write isolation (LOAD-BEARING) + forged-identity clause
   // ---------------------------------------------------------------------------------------
@@ -214,6 +257,15 @@ describeIfDatabase('personal (per-user) view config overlay — slice 1 (real DB
 
     expect(await rowForUser(USER_A)).toBeDefined() // A's own row was written
     expect(await rowForUser(USER_B)).toBeUndefined() // B's row was NEVER created
+  })
+
+  test('G-C: over-depth personal filterInfo is rejected before persistence', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    currentUserId = USER_A
+    const res = await putPersonalConfig(VIEW_ID, { filterInfo: buildTooDeepFilter() })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(await rowForUser(USER_A)).toBeUndefined()
   })
 
   test('G-C + forged-identity: A writing with a forged query.userId=B does NOT touch B\'s row', async () => {

--- a/packages/core-backend/tests/integration/multitable-personal-views-slice1-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-personal-views-slice1-realdb.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Slice 1 real-DB goldens for personal (per-user) view config overlay.
+ *
+ * Ratified design: docs/development/multitable-personal-views-design-lock-20260705.md
+ * Verification: docs/development/multitable-personal-views-slice1-verification-20260705.md
+ *
+ * Scope: data model (`meta_view_personal_configs`) + resolution contract (§1-C, shared-fallback)
+ * + actor-scoped isolation (§1-B, LOAD-BEARING) on `GET /views` and the new
+ * `GET|PUT|DELETE /views/:viewId/personal-config` routes. NO frontend, NO field-order overlay
+ * (slice 2).
+ *
+ * Goldens (design-lock §4):
+ *  - G-A (read isolation, LOAD-BEARING): user A's override is not visible to user B.
+ *  - G-B (shared fallback byte-identical): no override / flag-off => shared config unchanged.
+ *  - G-C (write isolation, LOAD-BEARING): A cannot create/update B's override.
+ *  - forged-identity clause: forged body.userId / query.userId / x-user-id header MUST NOT
+ *    change the read/write target — the target is always the authenticated actor.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI, matching sibling real-DB specs).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_pv1_${TS}`
+const SHEET_ID = `sheet_pv1_${TS}`
+const FIELD_ID = `fld_pv1_${TS}`
+const VIEW_ID = `view_pv1_${TS}`
+const USER_A = `user_pv1_a_${TS}`
+const USER_B = `user_pv1_b_${TS}`
+
+const SHARED_FILTER = { conjunction: 'and', conditions: [{ fieldId: FIELD_ID, operator: 'is', value: 'shared-val' }] }
+const SHARED_SORT = { fieldId: FIELD_ID, direction: 'asc' }
+const SHARED_GROUP = {}
+const SHARED_HIDDEN: string[] = []
+
+const PERSONAL_A_FILTER = { conjunction: 'and', conditions: [{ fieldId: FIELD_ID, operator: 'is', value: 'personal-a-val' }] }
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let app: Express
+let currentUserId: string | null = USER_A
+let currentPerms: string[] = ['multitable:read', 'multitable:write']
+let currentForgedHeader: string | undefined
+
+const listViews = () => {
+  const r = request(app).get('/api/multitable/views').query({ sheetId: SHEET_ID })
+  return currentForgedHeader ? r.set('x-user-id', currentForgedHeader) : r
+}
+const getPersonalConfig = (viewId: string, opts?: { forgedQueryUserId?: string }) => {
+  let r = request(app).get(`/api/multitable/views/${viewId}/personal-config`)
+  if (opts?.forgedQueryUserId) r = r.query({ userId: opts.forgedQueryUserId })
+  return currentForgedHeader ? r.set('x-user-id', currentForgedHeader) : r
+}
+const putPersonalConfig = (
+  viewId: string,
+  config: Record<string, unknown>,
+  opts?: { forgedBodyUserId?: string; forgedQueryUserId?: string },
+) => {
+  let r = request(app)
+    .put(`/api/multitable/views/${viewId}/personal-config`)
+    .send({ config, ...(opts?.forgedBodyUserId ? { userId: opts.forgedBodyUserId } : {}) })
+  if (opts?.forgedQueryUserId) r = r.query({ userId: opts.forgedQueryUserId })
+  return currentForgedHeader ? r.set('x-user-id', currentForgedHeader) : r
+}
+const deletePersonalConfig = (viewId: string) => {
+  const r = request(app).delete(`/api/multitable/views/${viewId}/personal-config`)
+  return currentForgedHeader ? r.set('x-user-id', currentForgedHeader) : r
+}
+
+const rowForUser = async (userId: string) =>
+  (await q('SELECT config FROM meta_view_personal_configs WHERE view_id = $1 AND user_id = $2', [VIEW_ID, userId]))
+    .rows[0] as { config: unknown } | undefined
+
+describeIfDatabase('personal (per-user) view config overlay — slice 1 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = currentUserId ? { id: currentUserId, roles: [], perms: currentPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_ID, 'PV1 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_ID, BASE_ID, 'PV1 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FIELD_ID, SHEET_ID, 'F1', 'string', '{}', 1])
+    await q(
+      'INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb,$9::jsonb)',
+      [VIEW_ID, SHEET_ID, 'PV1 View', 'grid', JSON.stringify(SHARED_FILTER), JSON.stringify(SHARED_SORT), JSON.stringify(SHARED_GROUP), JSON.stringify(SHARED_HIDDEN), '{}'],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_view_personal_configs WHERE view_id = $1', [VIEW_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    currentUserId = USER_A
+    currentPerms = ['multitable:read', 'multitable:write']
+    currentForgedHeader = undefined
+    delete process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS
+    await q('DELETE FROM meta_view_personal_configs WHERE view_id = $1', [VIEW_ID])
+  })
+
+  afterEach(() => {
+    delete process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ---------------------------------------------------------------------------------------
+  // G-B — shared fallback byte-identical
+  // ---------------------------------------------------------------------------------------
+  test('G-B: flag OFF — shared config served unchanged even with a personal override row present', async () => {
+    // A personal override row exists for USER_A...
+    await q(
+      `INSERT INTO meta_view_personal_configs (view_id, user_id, config) VALUES ($1, $2, $3::jsonb)`,
+      [VIEW_ID, USER_A, JSON.stringify({ filterInfo: PERSONAL_A_FILTER })],
+    )
+    // ...but the flag is OFF (default-off, §P2): the overlay must be completely inert.
+    expect(process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS).toBeUndefined()
+
+    currentUserId = USER_A
+    const res = await listViews()
+    expect(res.status).toBe(200)
+    const view = res.body.data.views.find((v: any) => v.id === VIEW_ID)
+    expect(view.filterInfo).toEqual(SHARED_FILTER)
+    expect(view.sortInfo).toEqual(SHARED_SORT)
+    expect(view.groupInfo).toEqual(SHARED_GROUP)
+    expect(view.hiddenFieldIds).toEqual(SHARED_HIDDEN)
+  })
+
+  test('G-B: flag ON, no override row for this actor — shared config byte-identical', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    currentUserId = USER_B // no override row for B
+    const res = await listViews()
+    expect(res.status).toBe(200)
+    const view = res.body.data.views.find((v: any) => v.id === VIEW_ID)
+    expect(view.filterInfo).toEqual(SHARED_FILTER)
+    expect(view.sortInfo).toEqual(SHARED_SORT)
+    expect(view.groupInfo).toEqual(SHARED_GROUP)
+    expect(view.hiddenFieldIds).toEqual(SHARED_HIDDEN)
+  })
+
+  test('flag OFF — the new personal-config routes are inert (404), not merely no-op', async () => {
+    currentUserId = USER_A
+    const getRes = await getPersonalConfig(VIEW_ID)
+    expect(getRes.status).toBe(404)
+    const putRes = await putPersonalConfig(VIEW_ID, { filterInfo: PERSONAL_A_FILTER })
+    expect(putRes.status).toBe(404)
+    // and no row was written
+    expect(await rowForUser(USER_A)).toBeUndefined()
+  })
+
+  // ---------------------------------------------------------------------------------------
+  // G-A — read isolation (LOAD-BEARING)
+  // ---------------------------------------------------------------------------------------
+  test('G-A: user A personal override is applied for A but NOT visible to user B', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    await q(
+      `INSERT INTO meta_view_personal_configs (view_id, user_id, config) VALUES ($1, $2, $3::jsonb)`,
+      [VIEW_ID, USER_A, JSON.stringify({ filterInfo: PERSONAL_A_FILTER })],
+    )
+
+    currentUserId = USER_A
+    const resA = await listViews()
+    const viewA = resA.body.data.views.find((v: any) => v.id === VIEW_ID)
+    expect(viewA.filterInfo).toEqual(PERSONAL_A_FILTER) // A sees own override
+    expect(viewA.sortInfo).toEqual(SHARED_SORT) // unset facet falls through (§1-D, additive)
+
+    currentUserId = USER_B
+    const resB = await listViews()
+    const viewB = resB.body.data.views.find((v: any) => v.id === VIEW_ID)
+    expect(viewB.filterInfo).toEqual(SHARED_FILTER) // B sees SHARED — A's override is invisible to B
+  })
+
+  test('G-A: GET personal-config is actor-scoped — B reading the endpoint never sees A row', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    await q(
+      `INSERT INTO meta_view_personal_configs (view_id, user_id, config) VALUES ($1, $2, $3::jsonb)`,
+      [VIEW_ID, USER_A, JSON.stringify({ filterInfo: PERSONAL_A_FILTER })],
+    )
+
+    currentUserId = USER_A
+    const resA = await getPersonalConfig(VIEW_ID)
+    expect(resA.body.data.config).toEqual({ filterInfo: PERSONAL_A_FILTER })
+
+    currentUserId = USER_B
+    const resB = await getPersonalConfig(VIEW_ID)
+    expect(resB.body.data.config).toBeNull() // B has no row of their own
+  })
+
+  // ---------------------------------------------------------------------------------------
+  // G-C — write isolation (LOAD-BEARING) + forged-identity clause
+  // ---------------------------------------------------------------------------------------
+  test('G-C + forged-identity: A writing with a forged body.userId=B does NOT touch B\'s row', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    currentUserId = USER_A
+    const res = await putPersonalConfig(VIEW_ID, { filterInfo: PERSONAL_A_FILTER }, { forgedBodyUserId: USER_B })
+    expect(res.status).toBe(200)
+
+    expect(await rowForUser(USER_A)).toBeDefined() // A's own row was written
+    expect(await rowForUser(USER_B)).toBeUndefined() // B's row was NEVER created
+  })
+
+  test('G-C + forged-identity: A writing with a forged query.userId=B does NOT touch B\'s row', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    currentUserId = USER_A
+    const res = await putPersonalConfig(VIEW_ID, { filterInfo: PERSONAL_A_FILTER }, { forgedQueryUserId: USER_B })
+    expect(res.status).toBe(200)
+
+    expect(await rowForUser(USER_A)).toBeDefined()
+    expect(await rowForUser(USER_B)).toBeUndefined()
+  })
+
+  test('G-C + forged-identity: A writing with a forged x-user-id: B header does NOT touch B\'s row', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    currentUserId = USER_A
+    currentForgedHeader = USER_B
+    const res = await putPersonalConfig(VIEW_ID, { filterInfo: PERSONAL_A_FILTER })
+    expect(res.status).toBe(200)
+
+    expect(await rowForUser(USER_A)).toBeDefined() // written under the AUTHENTICATED actor (A)
+    expect(await rowForUser(USER_B)).toBeUndefined() // forged header never redirected the write to B
+  })
+
+  test('G-C: A cannot delete B\'s override by forging identity; only B\'s own request can', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    // B creates their own override first (as B, for real).
+    currentUserId = USER_B
+    await putPersonalConfig(VIEW_ID, { sortInfo: { fieldId: FIELD_ID, direction: 'desc' } })
+    expect(await rowForUser(USER_B)).toBeDefined()
+
+    // A tries to delete "B's" override via a forged header while authenticated as A.
+    currentUserId = USER_A
+    currentForgedHeader = USER_B
+    const res = await deletePersonalConfig(VIEW_ID)
+    expect(res.status).toBe(200)
+    expect(res.body.data.deleted).toBe(false) // A has no row of their own — nothing to delete
+    expect(await rowForUser(USER_B)).toBeDefined() // B's row is UNTOUCHED
+
+    // B deletes their own row for real — that succeeds.
+    currentUserId = USER_B
+    currentForgedHeader = undefined
+    const resB = await deletePersonalConfig(VIEW_ID)
+    expect(resB.status).toBe(200)
+    expect(resB.body.data.deleted).toBe(true)
+    expect(await rowForUser(USER_B)).toBeUndefined()
+  })
+
+  test('unauthenticated request is rejected, not defaulted to some fallback user', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    currentUserId = null
+    const res = await putPersonalConfig(VIEW_ID, { filterInfo: PERSONAL_A_FILTER })
+    expect([401, 403]).toContain(res.status)
+  })
+})


### PR DESCRIPTION
Implements **Slice 1** of the ratified design-lock **#3631** (`multitable-personal-views-design-lock-20260705.md`): the backend per-user view-config overlay. **First genuine post-ratification greenfield construction** in this line (not hardening).

> **WARNING: Generated by an unattended L2 build agent (Sonnet 5) WITHOUT independent adversarial review — requires human adversarial verification before merge; do not merge on green alone.**

## What it does
- **New table** `meta_view_personal_configs(view_id → meta_views(id) ON DELETE CASCADE, user_id, config jsonb, updated_at)`, `UNIQUE (view_id, user_id)` (§7 Q1 LOCKED — a NEW table; legacy `view_states` NOT reused).
- **Resolution (§1-C):** on `GET /views`, a personal override for the authenticated actor ELSE the shared config; `effectiveViews === views` when flag-off or no override ⇒ **byte-identical** shared path (G-B) by construction.
- **Actor-scoped (§1-B, load-bearing):** the module never reads `req`; the target user is `resolveRequestAccess(req).userId` / `resolveSheetCapabilities(req).access.userId` (JWT/session), **never** `body.userId`/`query.userId`/`x-user-id`. Three new routes `GET/PUT/DELETE /views/:viewId/personal-config`, all **404 when flag-off**.
- **Flag default-OFF** (`MULTITABLE_ENABLE_PERSONAL_VIEWS`); this PR does NOT enable it.

## Goldens (real-DB, wired into the Node-20 required step)
G-A read isolation · G-C write isolation + forged-identity (`body.userId`/`query.userId`/`x-user-id` cannot select another user's row) · G-B shared byte-identical · flag-off routes inert (404).

## ⚠ Honest provenance (verification MD §5)
The build agent **stalled during its own real-DB self-check after the code was complete**, so **observed-RED was NOT captured locally**. The goldens are **structurally fail-first** (Opus-reviewed, sound discriminators) and are now gated in required CI — **this PR's `test (20.x)` is the first real execution**. Before any flag-on, a human should run the observed-RED once (revert the `user_id = actorUserId` keying → confirm G-A/G-C go red).

Design: #3631 (merged). Grounded on `origin/main` with the design-lock present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)