### PR TITLE
feat(web): approval forgiving errors — server messages, dialog-scoped alerts, reject-comment pre-flight (UX batch-1 B1-04)

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -849,6 +849,62 @@ export async function getApprovalHistory(id: string): Promise<UnifiedApprovalHis
   return apiGet(`/api/approvals/${id}/history`)
 }
 
+// ---------------------------------------------------------------------------
+// B1-04 (宽恕型错误三件套) — typed error surfacing for the approval create/action
+// write paths. Generalizes the ad hoc `payload.error.code/message` parsing
+// `remindApproval` already does for its 429/failure branches (further below,
+// unchanged): a failed response is expected to carry `{ error: { code,
+// message } }`; the server's message is threaded through VERBATIM so the UI
+// can render the real reason instead of collapsing every failure into
+// '操作失败，请重试'. `apiPost`/`apiGet` (utils/api.ts) intentionally keep their
+// existing generic-message throw for every OTHER caller — this helper is
+// scoped to the approval create/action endpoints below.
+// ---------------------------------------------------------------------------
+export class ApprovalApiError extends Error {
+  /** HTTP status of the failed response — lets callers branch on 4xx/5xx without re-parsing `message`. */
+  readonly status: number
+  /** Server-declared machine code, when present (`payload.error.code`). */
+  readonly code?: string
+
+  constructor(message: string, status: number, code?: string) {
+    super(message)
+    this.name = 'ApprovalApiError'
+    this.status = status
+    this.code = code
+  }
+}
+
+/**
+ * Reads a failed response's `{ error: { code, message } }` body and throws an `ApprovalApiError`
+ * carrying the server's message verbatim (falling back to a generic status-coded message for a
+ * non-JSON or shape-less body). Exported standalone (rather than folded into a fetch wrapper) so
+ * it is unit-testable against a fabricated `Response` independent of `USE_MOCK`.
+ */
+export async function approvalRequestError(response: Response): Promise<never> {
+  const payload = await response.json().catch(() => null) as { error?: { code?: string; message?: string } } | null
+  const rawMessage = payload?.error?.message
+  const message = typeof rawMessage === 'string' && rawMessage.trim().length > 0
+    ? rawMessage
+    : `请求失败（${response.status}）`
+  throw new ApprovalApiError(message, response.status, payload?.error?.code)
+}
+
+/**
+ * POST + parse-JSON, surfacing a failed response via `approvalRequestError` instead of the
+ * generic `apiPost` throw. Used by `createApproval` and `dispatchAction` — the two write paths
+ * B1-04 covers; every other approval-template endpoint below is unchanged.
+ */
+async function postApprovalJson<T>(path: string, payload: unknown): Promise<T> {
+  const response = await apiFetch(path, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    await approvalRequestError(response)
+  }
+  return response.json()
+}
+
 export async function createApproval(req: CreateApprovalRequest): Promise<UnifiedApprovalDTO> {
   if (USE_MOCK) {
     return {
@@ -859,7 +915,7 @@ export async function createApproval(req: CreateApprovalRequest): Promise<Unifie
       formSnapshot: req.formData as Record<string, unknown>,
     }
   }
-  return apiPost('/api/approvals', req)
+  return postApprovalJson('/api/approvals', req)
 }
 
 /**
@@ -1027,5 +1083,5 @@ export async function dispatchAction(
     }
     return { ...base, status: statusMap[req.action] ?? base.status }
   }
-  return apiPost(`/api/approvals/${id}/actions`, req)
+  return postApprovalJson(`/api/approvals/${id}/actions`, req)
 }

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -407,7 +407,7 @@
         v-model="batchRejectComment"
         type="textarea"
         :rows="3"
-        placeholder="驳回意见（部分审批模板要求必填）"
+        :placeholder="batchRejectCommentRequired ? '驳回原因（必填）' : '驳回意见（选填）'"
         data-testid="approval-batch-reject-comment"
       />
       <template #footer>
@@ -415,6 +415,7 @@
         <el-button
           type="danger"
           :loading="batchRunning"
+          :disabled="batchRejectConfirmDisabled"
           data-testid="approval-batch-reject-confirm"
           @click="handleBatchReject"
         >
@@ -547,7 +548,18 @@ function openBatchReject(): void {
   batchRejectDialogVisible.value = true
 }
 
+// B1-04 (宽恕型错误三件套 part 3): batch reject pre-flight. List rows already carry `policy`
+// (UnifiedApprovalDTO.policy), so this mirrors the single-instance reject dialog's conservative
+// default — required unless EVERY selected row's policy explicitly opts out with `false`.
+const batchRejectCommentRequired = computed(() =>
+  selectedPending.value.some((row) => row.policy?.rejectCommentRequired !== false),
+)
+const batchRejectConfirmDisabled = computed(() =>
+  batchRejectCommentRequired.value && !batchRejectComment.value.trim(),
+)
+
 async function handleBatchReject(): Promise<void> {
+  if (batchRejectConfirmDisabled.value) return
   await runBatch('reject', batchRejectComment.value)
   batchRejectDialogVisible.value = false
 }

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -347,8 +347,19 @@
       :title="actionDialogTitle"
       width="480px"
     >
+      <!-- B1-04: dialog-scoped failure message — the server's own reason, kept in place of a
+           generic toast so the reader learns WHY without losing the dialog/typed comment. -->
+      <el-alert
+        v-if="actionDialogError"
+        type="error"
+        show-icon
+        :closable="false"
+        :title="actionDialogError"
+        data-testid="approval-action-dialog-error"
+        class="approval-detail__dialog-error"
+      />
       <el-form>
-        <el-form-item label="审批意见">
+        <el-form-item :label="actionCommentLabel">
           <!-- B1-05: quick phrases — this user's recently-used phrases first, then the fixed
                preset list for 通过/驳回. Clicking a chip fills (or appends to) the textarea;
                free-typed text is never remembered, only a submitted phrase that exactly
@@ -369,7 +380,7 @@
             v-model="actionComment"
             type="textarea"
             :rows="3"
-            placeholder="请输入审批意见"
+            :placeholder="actionCommentPlaceholder"
           />
         </el-form-item>
       </el-form>
@@ -378,6 +389,7 @@
         <el-button
           :type="currentAction === 'approve' ? 'success' : 'danger'"
           :loading="store.loading"
+          :disabled="actionConfirmDisabled"
           @click="submitAction"
         >
           确认
@@ -521,6 +533,16 @@
       title="添加评论"
       width="480px"
     >
+      <!-- B1-04: same dialog-scoped failure message as the 通过/驳回 dialog above. -->
+      <el-alert
+        v-if="actionDialogError"
+        type="error"
+        show-icon
+        :closable="false"
+        :title="actionDialogError"
+        data-testid="approval-action-dialog-error"
+        class="approval-detail__dialog-error"
+      />
       <el-form>
         <el-form-item label="评论内容">
           <!-- B1-05: quick phrases — see the 通过/驳回 dialog above for the same mechanics. -->
@@ -749,6 +771,12 @@ const commentDialogVisible = ref(false)
 const returnDialogVisible = ref(false)
 const currentAction = ref<ApprovalActionType>('approve')
 const actionComment = ref('')
+// B1-04: dialog-scoped failure message for the approve/reject + comment dialogs (宽恕型错误三件套
+// part 2). Cleared on next dialog open / next submit attempt; the catch blocks below set it
+// INSTEAD OF a generic toast so the reader sees the server's actual reason without losing their
+// typed comment — the dialog stays open (see `submitAction`/`submitComment`). Non-dialog actions
+// (revoke's popconfirm) are unaffected and keep their existing toast.
+const actionDialogError = ref<string | null>(null)
 const transferUserId = ref('')
 const returnTargetNodeKey = ref('')
 // P1-B 加签/减签 dialog state.
@@ -799,6 +827,17 @@ const returnableNodes = computed(() => {
 const actionDialogTitle = computed(() =>
   currentAction.value === 'approve' ? '审批通过' : '审批驳回',
 )
+
+// B1-04: reject-comment pre-flight. `policy.rejectCommentRequired` defaults to "required" — only
+// an explicit `false` waives it, so an absent/legacy policy snapshot stays conservative. Scoped to
+// the reject action only; the 通过 dialog's "审批意见" stays optional (mirrors the add-sign
+// disabled-until-complete pattern already used by `submitAddSign`/`submitReduceSign` below).
+const rejectCommentRequired = computed(() =>
+  currentAction.value === 'reject' && approval.value?.policy?.rejectCommentRequired !== false,
+)
+const actionCommentLabel = computed(() => (rejectCommentRequired.value ? '驳回原因（必填）' : '审批意见'))
+const actionCommentPlaceholder = computed(() => (rejectCommentRequired.value ? '请填写驳回原因' : '请输入审批意见'))
+const actionConfirmDisabled = computed(() => rejectCommentRequired.value && !actionComment.value.trim())
 
 // B1-05: quick-phrase chips for whichever action's dialog is currently open — this user's own
 // recently-used phrases (most-recent-first) first, then the fixed preset list, deduped, capped
@@ -964,6 +1003,7 @@ function retryLoad() {
 function openActionDialog(action: 'approve' | 'reject') {
   currentAction.value = action
   actionComment.value = ''
+  actionDialogError.value = null
   actionDialogVisible.value = true
 }
 
@@ -984,6 +1024,7 @@ function openCommentDialog() {
   // 'comment' preset/recent list here (rather than whatever approve/reject dialog ran last).
   currentAction.value = 'comment'
   actionComment.value = ''
+  actionDialogError.value = null
   commentDialogVisible.value = true
 }
 
@@ -994,11 +1035,27 @@ function openCommentDialog() {
 // detail + history so the mobile action bar reflects live state instead of a
 // stale one. Scoped to the mobile layout so desktop behavior is unchanged.
 function is4xxConflict(error: unknown): boolean {
+  // B1-04: `dispatchAction`'s real failures now carry a typed `.status` (see
+  // `ApprovalApiError`/`approvalRequestError` in approvals/api.ts) whose `.message` is the
+  // server's own text — it no longer matches the legacy "API error: NNN" shape below. Check
+  // `.status` first; keep the regex as a fallback for anything still throwing the old generic
+  // format (e.g. a mocked/legacy rejection).
+  if (error && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status?: unknown }).status
+    if (typeof status === 'number') return status >= 400 && status < 500
+  }
   const message = error instanceof Error ? error.message : String(error ?? '')
   const match = /API error:\s*(\d{3})/.exec(message)
   if (!match) return false
   const status = Number(match[1])
   return status >= 400 && status < 500
+}
+
+// B1-04: prefer the typed/thrown error's own message (server text, or the helper's
+// status-coded fallback); anything else (a non-Error throw) falls back to the caller-supplied
+// generic copy so the dialog never renders a blank alert.
+function dialogErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback
 }
 
 async function refreshAfterStaleMobileAction(id: string, error: unknown): Promise<void> {
@@ -1008,7 +1065,9 @@ async function refreshAfterStaleMobileAction(id: string, error: unknown): Promis
 }
 
 async function submitAction() {
+  if (actionConfirmDisabled.value) return
   const id = route.params.id as string
+  actionDialogError.value = null
   try {
     await store.executeAction(id, {
       action: currentAction.value,
@@ -1019,7 +1078,9 @@ async function submitAction() {
     actionDialogVisible.value = false
     await store.loadHistory(id)
   } catch (error) {
-    ElMessage.error('操作失败，请重试')
+    // B1-04: keep the dialog open + show the server's own reason inline instead of a generic
+    // toast (see `actionDialogError` above); non-dialog actions further down keep their toasts.
+    actionDialogError.value = dialogErrorMessage(error, '操作失败，请重试')
     await refreshAfterStaleMobileAction(id, error)
   }
 }
@@ -1092,6 +1153,7 @@ async function submitReduceSign() {
 async function submitComment() {
   if (!actionComment.value.trim()) return
   const id = route.params.id as string
+  actionDialogError.value = null
   try {
     await store.executeAction(id, {
       action: 'comment',
@@ -1102,7 +1164,8 @@ async function submitComment() {
     commentDialogVisible.value = false
     await store.loadHistory(id)
   } catch (error) {
-    ElMessage.error('评论提交失败，请重试')
+    // B1-04: same dialog-scoped inline error as `submitAction` above.
+    actionDialogError.value = dialogErrorMessage(error, '评论提交失败，请重试')
     await refreshAfterStaleMobileAction(id, error)
   }
 }
@@ -1224,6 +1287,11 @@ onMounted(async () => {
 }
 
 .approval-detail__error {
+  margin-bottom: 16px;
+}
+
+/* B1-04: dialog-scoped failure alert (approve/reject + comment dialogs). */
+.approval-detail__dialog-error {
   margin-bottom: 16px;
 }
 

--- a/apps/web/tests/approval-center.spec.ts
+++ b/apps/web/tests/approval-center.spec.ts
@@ -84,9 +84,20 @@ const ElTabPane = defineComponent({
 const ElTable = defineComponent({
   name: 'ElTable',
   props: { data: Array, loading: Boolean, stripe: Boolean, highlightCurrentRow: Boolean },
-  emits: ['row-click'],
+  emits: ['row-click', 'selection-change'],
   render() {
-    return h('div', { 'data-el-table': 'true' }, this.$slots.default?.())
+    return h('div', { 'data-el-table': 'true' }, [
+      // B1-04 test-only affordance: the real checkbox selection column can't be driven
+      // headlessly here, so expose a direct trigger for "select every row currently bound to
+      // `data`" — the SFC's own `handlePendingSelectionChange` still applies
+      // `isRowBatchSelectable`, so this stays honest about what ends up selected.
+      h('button', {
+        type: 'button',
+        'data-testid': 'test-select-all-rows',
+        onClick: () => this.$emit('selection-change', this.data ?? []),
+      }, 'select-all'),
+      this.$slots.default?.(),
+    ])
   },
 })
 
@@ -112,7 +123,11 @@ const ElInput = defineComponent({
   props: { modelValue: String, placeholder: String, clearable: Boolean, type: String, rows: Number },
   emits: ['update:modelValue', 'clear'],
   render() {
-    return h('input', { 'data-el-input': 'true' })
+    return h('input', {
+      'data-el-input': 'true',
+      value: this.modelValue ?? '',
+      onInput: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLInputElement).value),
+    })
   },
 })
 
@@ -147,7 +162,28 @@ const ElButton = defineComponent({
   props: { type: String, text: Boolean, link: Boolean, plain: Boolean, size: String, loading: Boolean, disabled: Boolean },
   emits: ['click'],
   render() {
-    return h('button', { 'data-el-button': this.type || 'default', onClick: (e: Event) => this.$emit('click', e) }, this.$slots.default?.())
+    // B1-04: reflect `disabled`/`loading` on the native button (matches real el-button, which
+    // also treats `loading` as disabled) so the batch-reject pre-flight is actually testable — a
+    // disabled button must not fire its click handler.
+    const isDisabled = this.disabled || this.loading
+    return h('button', {
+      'data-el-button': this.type || 'default',
+      disabled: isDisabled,
+      onClick: (e: Event) => {
+        if (isDisabled) return
+        this.$emit('click', e)
+      },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String, width: String },
+  emits: ['update:modelValue'],
+  render() {
+    if (!this.modelValue) return null
+    return h('div', { 'data-el-dialog': this.title }, [this.$slots.default?.(), this.$slots.footer?.()])
   },
 })
 
@@ -224,6 +260,7 @@ describe('ApprovalCenterView', () => {
     app.component('ElPagination', ElPagination)
     app.component('ElButton', ElButton)
     app.component('ElAlert', ElAlert)
+    app.component('ElDialog', ElDialog)
     app.component('ElEmpty', ElEmpty)
     app.directive('loading', stubDirective)
     app.mount(container!)
@@ -339,5 +376,90 @@ describe('ApprovalCenterView', () => {
       name: 'attendance',
       query: { section: 'attendance-overview-requests' },
     })
+  })
+
+  // ---------------------------------------------------------------------------
+  // B1-04 (宽恕型错误三件套 part 3) — batch reject pre-flight. List rows already carry `policy`
+  // (UnifiedApprovalDTO.policy), so `ApprovalCenterView` mirrors the single-instance reject
+  // dialog's conservative default: required unless EVERY selected row's policy explicitly opts
+  // out with `false`.
+  // ---------------------------------------------------------------------------
+  function pendingRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'apv_1',
+      requestNo: 'AP-100001',
+      title: '出差报销',
+      status: 'pending',
+      requester: { name: '张三' },
+      createdAt: '2026-04-10T08:00:00Z',
+      assignments: [],
+      policy: null,
+      ...overrides,
+    }
+  }
+
+  function selectAllPendingRows(): void {
+    const trigger = container!.querySelector('[data-testid="test-select-all-rows"]') as HTMLButtonElement
+    trigger.click()
+  }
+
+  it('B1-04: batch reject confirm is disabled until a comment is entered (default/undefined policy = required)', async () => {
+    mockPendingApprovals.value = [pendingRow()]
+    await mountView()
+
+    selectAllPendingRows()
+    await flushUi()
+
+    const openBtn = container!.querySelector('[data-testid="approval-batch-reject"]') as HTMLButtonElement
+    expect(openBtn.disabled).toBe(false)
+    openBtn.click()
+    await flushUi()
+
+    const confirmBtn = container!.querySelector('[data-testid="approval-batch-reject-confirm"]') as HTMLButtonElement
+    expect(confirmBtn).toBeTruthy()
+    expect(confirmBtn.disabled).toBe(true)
+
+    const commentInput = container!.querySelector('[data-testid="approval-batch-reject-comment"]') as HTMLInputElement
+    commentInput.value = '金额有误'
+    commentInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    expect(confirmBtn.disabled).toBe(false)
+  })
+
+  it('B1-04: batch reject confirm stays enabled with an empty comment when every selected row opts out', async () => {
+    mockPendingApprovals.value = [
+      pendingRow({ id: 'apv_1', policy: { rejectCommentRequired: false } }),
+      pendingRow({ id: 'apv_2', policy: { rejectCommentRequired: false } }),
+    ]
+    await mountView()
+
+    selectAllPendingRows()
+    await flushUi()
+
+    const openBtn = container!.querySelector('[data-testid="approval-batch-reject"]') as HTMLButtonElement
+    openBtn.click()
+    await flushUi()
+
+    const confirmBtn = container!.querySelector('[data-testid="approval-batch-reject-confirm"]') as HTMLButtonElement
+    expect(confirmBtn.disabled).toBe(false)
+  })
+
+  it('B1-04: batch reject confirm stays disabled when only SOME selected rows opt out (conservative default)', async () => {
+    mockPendingApprovals.value = [
+      pendingRow({ id: 'apv_1', policy: { rejectCommentRequired: false } }),
+      pendingRow({ id: 'apv_2', policy: null }),
+    ]
+    await mountView()
+
+    selectAllPendingRows()
+    await flushUi()
+
+    const openBtn = container!.querySelector('[data-testid="approval-batch-reject"]') as HTMLButtonElement
+    openBtn.click()
+    await flushUi()
+
+    const confirmBtn = container!.querySelector('[data-testid="approval-batch-reject-confirm"]') as HTMLButtonElement
+    expect(confirmBtn.disabled).toBe(true)
   })
 })

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -952,8 +952,17 @@ describe('Approval E2E Lifecycle', () => {
       rejectBtn!.click()
       await flushUi()
 
-      // Click confirm (danger button)
+      // B1-04: the fixture's policy.rejectCommentRequired=true disables confirm until a reason is
+      // entered — type one first (mirrors "entering comment before approving sends comment in
+      // action" above for the approve flow).
       const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const textarea = dialog!.querySelector('[data-el-input]') as HTMLInputElement
+      const nativeInputEvent = new Event('input', { bubbles: true })
+      Object.defineProperty(nativeInputEvent, 'target', { value: { value: '金额有误' } })
+      textarea.dispatchEvent(nativeInputEvent)
+      await flushUi()
+
+      // Click confirm (danger button)
       const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
         .find((b) => b.textContent?.trim() === '确认')
       confirmBtn!.click()
@@ -961,7 +970,7 @@ describe('Approval E2E Lifecycle', () => {
 
       expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', {
         action: 'reject',
-        comment: undefined,
+        comment: '金额有误',
       })
     })
 
@@ -978,7 +987,14 @@ describe('Approval E2E Lifecycle', () => {
       rejectBtn!.click()
       await flushUi()
 
+      // B1-04: same required-reason pre-flight as above.
       const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const textarea = dialog!.querySelector('[data-el-input]') as HTMLInputElement
+      const nativeInputEvent = new Event('input', { bubbles: true })
+      Object.defineProperty(nativeInputEvent, 'target', { value: { value: '金额有误' } })
+      textarea.dispatchEvent(nativeInputEvent)
+      await flushUi()
+
       const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
         .find((b) => b.textContent?.trim() === '确认')
       confirmBtn!.click()

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -206,7 +206,13 @@ const ElInput = defineComponent({
   name: 'ElInput',
   props: { modelValue: [String, Number], placeholder: String, clearable: Boolean, type: String, rows: Number },
   emits: ['update:modelValue', 'clear'],
-  render() { return h('input', { 'data-el-input': 'true' }) },
+  render() {
+    return h('input', {
+      'data-el-input': 'true',
+      value: this.modelValue ?? '',
+      onInput: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLInputElement).value),
+    })
+  },
 })
 
 const ElInputNumber = defineComponent({
@@ -757,7 +763,14 @@ describe('Approval E2E Permissions', () => {
       rejectBtn!.click()
       await flushUi()
 
+      // B1-04: the fixture's policy.rejectCommentRequired=true disables confirm until a reason is
+      // entered.
       const dialog = container!.querySelector('[data-dialog-visible="true"]')
+      const textarea = dialog!.querySelector('[data-el-input]') as HTMLInputElement
+      textarea.value = '金额有误'
+      textarea.dispatchEvent(new Event('input'))
+      await flushUi()
+
       const confirmBtn = Array.from(dialog!.querySelectorAll('button'))
         .find((b) => b.textContent?.trim() === '确认')
       confirmBtn!.click()
@@ -765,7 +778,7 @@ describe('Approval E2E Permissions', () => {
 
       expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', {
         action: 'reject',
-        comment: undefined,
+        comment: '金额有误',
       })
     })
 

--- a/apps/web/tests/approvalApiErrorSurfacing.spec.ts
+++ b/apps/web/tests/approvalApiErrorSurfacing.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { ApprovalApiError, approvalRequestError } from '../src/approvals/api'
+
+/**
+ * B1-04 (宽恕型错误三件套) — unit coverage for the error-surfacing helper that
+ * `createApproval` and `dispatchAction` (apps/web/src/approvals/api.ts) funnel their failed
+ * (non-OK) responses through, generalizing the ad hoc `payload.error.code/message` parsing
+ * `remindApproval` already did for its own failure branches.
+ *
+ * This exercises `approvalRequestError` directly against a fabricated `Response`, rather than
+ * via `createApproval`/`dispatchAction` themselves: `approvals/api.ts`'s `USE_MOCK` flag is
+ * `import.meta.env.DEV || ...`, and `DEV` is always `true` under Vitest, so those exported
+ * functions always take their mock branch here and never reach the real fetch path. The helper
+ * itself has no such gate, so it is independently testable.
+ */
+function fakeResponse(status: number, jsonImpl: () => Promise<unknown>): Response {
+  return { status, json: jsonImpl } as unknown as Response
+}
+
+describe('approvalRequestError', () => {
+  it('surfaces the server error message + code verbatim', async () => {
+    const response = fakeResponse(400, async () => ({
+      error: { code: 'AMOUNT_MISMATCH', message: '金额合计不一致' },
+    }))
+
+    let caught: unknown
+    try {
+      await approvalRequestError(response)
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(ApprovalApiError)
+    const error = caught as ApprovalApiError
+    expect(error.message).toBe('金额合计不一致')
+    expect(error.code).toBe('AMOUNT_MISMATCH')
+    expect(error.status).toBe(400)
+  })
+
+  it('falls back to a status-coded message for a non-JSON body', async () => {
+    const response = fakeResponse(500, async () => {
+      throw new Error('Unexpected token < in JSON')
+    })
+
+    let caught: unknown
+    try {
+      await approvalRequestError(response)
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(ApprovalApiError)
+    const error = caught as ApprovalApiError
+    expect(error.message).toBe('请求失败（500）')
+    expect(error.code).toBeUndefined()
+    expect(error.status).toBe(500)
+  })
+
+  it('falls back to a status-coded message when the JSON body has no `error.message`', async () => {
+    const response = fakeResponse(403, async () => ({ ok: false }))
+
+    let caught: unknown
+    try {
+      await approvalRequestError(response)
+    } catch (err) {
+      caught = err
+    }
+
+    expect((caught as ApprovalApiError).message).toBe('请求失败（403）')
+    expect((caught as ApprovalApiError).code).toBeUndefined()
+  })
+
+  it('ignores a blank server message and falls back to the status-coded message', async () => {
+    const response = fakeResponse(422, async () => ({ error: { code: 'X', message: '   ' } }))
+
+    let caught: unknown
+    try {
+      await approvalRequestError(response)
+    } catch (err) {
+      caught = err
+    }
+
+    const error = caught as ApprovalApiError
+    expect(error.message).toBe('请求失败（422）')
+    expect(error.code).toBe('X')
+  })
+})

--- a/apps/web/tests/approvalMobileDetailActions.spec.ts
+++ b/apps/web/tests/approvalMobileDetailActions.spec.ts
@@ -94,11 +94,26 @@ const ElButton = defineComponent({
   props: { type: String, loading: Boolean, disabled: Boolean, text: Boolean, plain: Boolean },
   emits: ['click'],
   render() {
+    // B1-04: reflect `disabled`/`loading` on the native button (matches real el-button, which
+    // also treats `loading` as disabled) so the reject-comment pre-flight is actually testable —
+    // a disabled button must not fire its click handler.
+    const isDisabled = this.disabled || this.loading
     return h('button', {
       'data-el-button': this.type || 'default',
-      onClick: (e: Event) => this.$emit('click', e),
+      disabled: isDisabled,
+      onClick: (e: Event) => {
+        if (isDisabled) return
+        this.$emit('click', e)
+      },
     }, this.$slots.default?.())
   },
+})
+// B1-04: dialog-scoped error alert needs its `title` text rendered so the SERVER-message
+// assertion can read it back; the generic `stub()` helper below only renders the default slot.
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, type: String, closable: Boolean, showIcon: Boolean },
+  render() { return h('div', { 'data-el-alert': this.type || 'default' }, this.title) },
 })
 const ElDialog = defineComponent({
   name: 'ElDialog',
@@ -228,11 +243,12 @@ describe('ApprovalDetailView — T3-1 mobile action-set restriction', () => {
     const Host = defineComponent({ setup() { return () => h(ApprovalDetailView as any) } })
     app = createApp(Host)
     // Broad Element Plus stubs; the action buttons are the assertion surface.
-    for (const name of ['ElAlert', 'ElDivider', 'ElEmpty', 'ElTable', 'ElTimeline', 'ElTimelineItem', 'ElForm', 'ElFormItem', 'ElSelect', 'ElOption', 'ElRadioGroup', 'ElRadio', 'ElIcon']) {
+    for (const name of ['ElDivider', 'ElEmpty', 'ElTable', 'ElTimeline', 'ElTimelineItem', 'ElForm', 'ElFormItem', 'ElSelect', 'ElOption', 'ElRadioGroup', 'ElRadio', 'ElIcon']) {
       app.component(name, stub(name))
     }
     app.component('ElTableColumn', ElTableColumn)
     app.component('ElButton', ElButton)
+    app.component('ElAlert', ElAlert)
     app.component('ElDialog', ElDialog)
     app.component('ElPopconfirm', ElPopconfirm)
     app.component('ElTag', ElTag)
@@ -366,5 +382,85 @@ describe('ApprovalDetailView — T3-1 mobile action-set restriction', () => {
 
     const textarea = dialog!.querySelector('[data-el-input]') as HTMLInputElement
     expect(textarea.value).toBe('同意')
+  })
+
+  // ---------------------------------------------------------------------------
+  // B1-04 (宽恕型错误三件套) — dialog-scoped server errors + reject-comment pre-flight.
+  // ---------------------------------------------------------------------------
+
+  it('B1-04: action failure keeps the dialog open and shows the inline SERVER message', async () => {
+    await mountView()
+    const serverError = Object.assign(new Error('金额合计不一致'), { code: 'AMOUNT_MISMATCH', status: 400 })
+    executeActionSpy.mockRejectedValueOnce(serverError)
+
+    const approveBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('通过'))
+    approveBtn!.click()
+    await flushUi()
+
+    const confirmBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.trim() === '确认')
+    confirmBtn!.click()
+    await flushUi()
+
+    // Dialog stays open (no generic toast closed it) and shows the server's own message.
+    const dialog = container!.querySelector('[data-el-dialog]')
+    expect(dialog).toBeTruthy()
+    const alert = dialog!.querySelector('[data-testid="approval-action-dialog-error"]')
+    expect(alert?.textContent).toBe('金额合计不一致')
+  })
+
+  it('B1-04: reject confirm is disabled until a reason is entered when policy.rejectCommentRequired=true', async () => {
+    mockActiveApproval.value = { ...pendingInstance(), policy: { rejectCommentRequired: true } }
+    await mountView()
+
+    const rejectBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('驳回'))
+    rejectBtn!.click()
+    await flushUi()
+
+    const dialog = container!.querySelector('[data-el-dialog]')
+    const confirmBtn = Array.from(dialog!.querySelectorAll('button')).find((b) => b.textContent?.trim() === '确认') as HTMLButtonElement
+    expect(confirmBtn.disabled).toBe(true)
+
+    const textarea = dialog!.querySelector('[data-el-input]') as HTMLInputElement
+    textarea.value = '金额有误'
+    textarea.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    expect(confirmBtn.disabled).toBe(false)
+    confirmBtn.click()
+    await flushUi()
+    expect(executeActionSpy).toHaveBeenCalledWith('apv_1', expect.objectContaining({ action: 'reject', comment: '金额有误' }))
+  })
+
+  it('B1-04: reject confirm stays enabled with an empty comment when policy.rejectCommentRequired=false', async () => {
+    mockActiveApproval.value = { ...pendingInstance(), policy: { rejectCommentRequired: false } }
+    await mountView()
+
+    const rejectBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('驳回'))
+    rejectBtn!.click()
+    await flushUi()
+
+    const dialog = container!.querySelector('[data-el-dialog]')
+    const confirmBtn = Array.from(dialog!.querySelectorAll('button')).find((b) => b.textContent?.trim() === '确认') as HTMLButtonElement
+    expect(confirmBtn.disabled).toBe(false)
+  })
+
+  it('B1-04: a typed error (status property) also triggers refresh-on-4xx, not just the legacy "API error: NNN" string', async () => {
+    mockApprovalMobileFlag.value = true
+    setViewport(true)
+    const typedError = Object.assign(new Error('审批流程已终止，无法执行操作'), { status: 409, code: 'APPROVAL_STATE_CONFLICT' })
+    executeActionSpy.mockRejectedValueOnce(typedError)
+    await mountView()
+    loadDetailSpy.mockClear()
+    loadHistorySpy.mockClear()
+
+    const approveBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('通过'))
+    approveBtn!.click()
+    await flushUi()
+    const confirmBtn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.trim() === '确认')
+    confirmBtn!.click()
+    await flushUi()
+
+    expect(loadDetailSpy).toHaveBeenCalledWith('apv_1')
+    expect(loadHistorySpy).toHaveBeenCalledWith('apv_1')
   })
 })


### PR DESCRIPTION
## Summary

UX 阶梯（#3564）batch-1 **B1-04 宽恕型错误三件套**（Sonnet 代理实现 + Fable 审查）：

1. **服务端错误体透出**：新 `ApprovalApiError`（携 `.status`/`.code`）+ `approvalRequestError` helper（泛化 remindApproval 既有的 `payload.error` 解析模式），只接入 `createApproval`/`dispatchAction` 真实分支——`utils/api.ts` 其他调用方与 `USE_MOCK` 分支零改动。「金额合计不一致」等真实原因取代「操作失败，请重试」。
2. **失败不关框**：通过/驳回与评论两个对话框失败时保持打开，框内渲染 `el-alert`（`data-testid="approval-action-dialog-error"`），非对话框动作（撤回 popconfirm）保留 toast。
3. **驳回意见前置必填**：`policy.rejectCommentRequired !== false` 时（镜像引擎默认必填语义）label/placeholder 变必填态 + 确认键置灰至意见非空；**批量驳回**同款前置（保守默认：所选行中除非全部显式 `false` 否则必填，placeholder 动态化）。

**交互捕获（代理自查出的必要联动）**：`is4xxConflict` 原靠 `"API error: NNN"` 正则识别冲突——错误形状改变后会静默失效；现优先读 typed `.status`，正则保留兜底（有测试锁定）。3 个既有断言（空意见点驳回确认）按新行为一致性更新。

## Verification

- 新增/扩展 11 测试（helper 4 / 详情对话框 4 / 批量前置 3），触达 specs **72/72**，守护全绿合计 **168/168**
- `vue-tsc -b` 0；全量与基线逐文件一致（stash 复验预存失败非本 PR 引入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)