### PR TITLE
feat(multitable): render AI-shortcut prompt config history

### DIFF
--- a/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
+++ b/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
@@ -37,12 +37,15 @@
                   @click="openRevert(rev)"
                 >{{ l('record.configRestoreAction') }}</button>
               </div>
-              <ul v-if="rev.action === 'update' && rev.changedKeys.length" class="cfg-history__changes">
-                <li v-for="k in rev.changedKeys" :key="k" class="cfg-history__change">
-                  <span class="cfg-history__key">{{ k }}</span>
-                  <span class="cfg-history__before">{{ display(rev.before?.[k]) }}</span>
-                  <span class="cfg-history__arrow">→</span>
-                  <span class="cfg-history__after">{{ display(rev.after?.[k]) }}</span>
+              <ul v-if="renderedChanges(rev).length" class="cfg-history__changes">
+                <li v-for="change in renderedChanges(rev)" :key="change.key" class="cfg-history__change">
+                  <span class="cfg-history__key">{{ change.key }}</span>
+                  <template v-if="change.mode === 'update'">
+                    <span class="cfg-history__before">{{ change.before }}</span>
+                    <span class="cfg-history__arrow">→</span>
+                    <span class="cfg-history__after">{{ change.after }}</span>
+                  </template>
+                  <span v-else class="cfg-history__after">{{ change.value }}</span>
                 </li>
               </ul>
               <div class="cfg-history__meta">
@@ -97,6 +100,7 @@
 import { ref } from 'vue'
 
 import type { MetaConfigRevision, ConfigRestorePreview } from '../api/client'
+import { redactString } from '../utils/automation-log-redact'
 import { recordLabel, type MetaRecordLabelKey } from '../utils/meta-record-labels'
 
 const props = defineProps<{
@@ -127,10 +131,9 @@ const ACTION_KEY: Record<string, MetaRecordLabelKey> = {
 const filterLabel = (opt: string): string => (opt === '' ? l('record.configHistoryFilterAll') : entityLabel(opt))
 const entityLabel = (t: string): string => (ENTITY_KEY[t] ? l(ENTITY_KEY[t]) : t)
 const actionLabel = (a: string): string => (ACTION_KEY[a] ? l(ACTION_KEY[a]) : a)
-// Render a config value (a view filter/sort/group, a permission grant, a hidden-field list, a scalar) as a compact
-// human summary instead of a raw JSON blob — objects become `k: v` pairs, primitive arrays join, and anything deeper
-// than two levels falls back to JSON (safe). These are CONFIG values (never record data), so no value-masking is
-// needed. No translatable strings are introduced (the separators/markers are structural).
+// Render structural config values (a view filter/sort/group, a permission grant, a hidden-field list, a scalar) as a
+// compact human summary instead of a raw JSON blob. The one free-text config shape, field.property.aiShortcut.params,
+// is handled by a dedicated redacting branch below.
 function summarizeConfigValue(value: unknown, depth = 0): string {
   if (value === null || value === undefined) return '∅'
   if (typeof value === 'string') return value
@@ -150,6 +153,123 @@ function summarizeConfigValue(value: unknown, depth = 0): string {
 }
 function display(value: unknown): string {
   return summarizeConfigValue(value)
+}
+
+type RenderedConfigChange =
+  | { key: string; mode: 'update'; before: string; after: string }
+  | { key: string; mode: 'single'; value: string }
+
+const AI_SHORTCUT_PARAM_KEYS = ['options', 'targetLang', 'instruction'] as const
+
+function renderedChanges(rev: MetaConfigRevision): RenderedConfigChange[] {
+  if (rev.action === 'update') {
+    const changes: RenderedConfigChange[] = []
+    for (const key of rev.changedKeys) {
+      if (key === 'property') {
+        const aiChanges = renderAiShortcutPropertyUpdate(rev)
+        if (aiChanges.length > 0) {
+          changes.push(...aiChanges)
+          continue
+        }
+      }
+      changes.push({
+        key,
+        mode: 'update',
+        before: display(rev.before?.[key]),
+        after: display(rev.after?.[key]),
+      })
+    }
+    return changes
+  }
+
+  if (rev.action === 'create' || rev.action === 'delete') {
+    return renderAiShortcutPropertySingle(rev)
+  }
+
+  return []
+}
+
+function renderAiShortcutPropertyUpdate(rev: MetaConfigRevision): RenderedConfigChange[] {
+  const before = aiShortcutFromRevisionSide(rev.before)
+  const after = aiShortcutFromRevisionSide(rev.after)
+  if (!before && !after) return []
+
+  const changes: RenderedConfigChange[] = []
+  pushAiShortcutUpdate(changes, 'aiShortcut.kind', before?.kind, after?.kind, formatScalarParam)
+  pushAiShortcutUpdate(changes, 'aiShortcut.sourceFieldIds', before?.sourceFieldIds, after?.sourceFieldIds, formatSourceFieldIds)
+  const beforeParams = asObject(before?.params)
+  const afterParams = asObject(after?.params)
+  for (const paramKey of AI_SHORTCUT_PARAM_KEYS) {
+    pushAiShortcutUpdate(
+      changes,
+      `aiShortcut.params.${paramKey}`,
+      beforeParams?.[paramKey],
+      afterParams?.[paramKey],
+      formatAiShortcutParam,
+    )
+  }
+  return changes
+}
+
+function renderAiShortcutPropertySingle(rev: MetaConfigRevision): RenderedConfigChange[] {
+  const config = aiShortcutFromRevisionSide(rev.action === 'delete' ? rev.before : rev.after)
+  if (!config) return []
+
+  const changes: RenderedConfigChange[] = [
+    { key: 'aiShortcut.kind', mode: 'single', value: formatScalarParam(config.kind) },
+    { key: 'aiShortcut.sourceFieldIds', mode: 'single', value: formatSourceFieldIds(config.sourceFieldIds) },
+  ]
+  const params = asObject(config.params)
+  for (const paramKey of AI_SHORTCUT_PARAM_KEYS) {
+    if (params && Object.prototype.hasOwnProperty.call(params, paramKey)) {
+      changes.push({
+        key: `aiShortcut.params.${paramKey}`,
+        mode: 'single',
+        value: formatAiShortcutParam(params[paramKey]),
+      })
+    }
+  }
+  return changes
+}
+
+function pushAiShortcutUpdate(
+  changes: RenderedConfigChange[],
+  key: string,
+  before: unknown,
+  after: unknown,
+  formatter: (value: unknown) => string,
+): void {
+  const beforeText = formatter(before)
+  const afterText = formatter(after)
+  if (beforeText === afterText) return
+  changes.push({ key, mode: 'update', before: beforeText, after: afterText })
+}
+
+function aiShortcutFromRevisionSide(side: Record<string, unknown> | null): Record<string, unknown> | null {
+  const property = asObject(side?.property)
+  return asObject(property?.aiShortcut)
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function formatScalarParam(value: unknown): string {
+  return typeof value === 'string' ? redactString(value) : display(value)
+}
+
+function formatSourceFieldIds(value: unknown): string {
+  if (!Array.isArray(value)) return display(value)
+  if (value.length === 0) return '[]'
+  return value.map((entry) => typeof entry === 'string' ? props.recordLabelOf(entry) : display(entry)).join('; ')
+}
+
+function formatAiShortcutParam(value: unknown): string {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    return value.map((entry) => typeof entry === 'string' ? redactString(entry) : display(entry)).join('; ')
+  }
+  return typeof value === 'string' ? redactString(value) : display(value)
 }
 
 // --- T9-W revert flow (the gate stays server-side; this only shows the server's preview + confirms) ---

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -95,6 +95,129 @@ describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
   })
 })
 
+describe('MetaConfigHistoryModal — S2 aiShortcut prompt-config history rendering', () => {
+  const aiShortcut = (over: Record<string, unknown> = {}) => ({
+    kind: 'classify',
+    sourceFieldIds: ['fld_source'],
+    params: { options: ['keep', 'review'], instruction: 'Flag competitor mentions' },
+    ...over,
+  })
+  const propertyWithAi = (over: Record<string, unknown> = {}) => ({ aiShortcut: aiShortcut(over) })
+
+  it('renders field create property.aiShortcut as labeled lines, not a nested raw JSON blob', async () => {
+    mountModal({
+      recordLabelOf: (id) => id === 'fld_source' ? 'Source Text' : `name:${id}`,
+      items: [
+        rev({
+          id: 'ai-create',
+          action: 'create',
+          after: { property: propertyWithAi({ kind: 'translate', params: { targetLang: 'French', instruction: 'Translate politely' } }) },
+        }),
+      ],
+    })
+    await nextTick()
+
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('aiShortcut.kind')
+    expect(text).toContain('translate')
+    expect(text).toContain('aiShortcut.sourceFieldIds')
+    expect(text).toContain('Source Text')
+    expect(text).toContain('aiShortcut.params.targetLang')
+    expect(text).toContain('French')
+    expect(text).toContain('aiShortcut.params.instruction')
+    expect(text).toContain('Translate politely')
+    expect(text).not.toContain('{"targetLang"')
+    expect(text).not.toContain('"instruction"')
+  })
+
+  it('renders aiShortcut instruction updates with the existing redactor and never leaks secret-shaped text', async () => {
+    mountModal({
+      items: [
+        rev({
+          id: 'ai-update',
+          action: 'update',
+          changedKeys: ['property'],
+          before: { property: propertyWithAi({ params: { instruction: 'Use normal wording' } }) },
+          after: { property: propertyWithAi({ params: { instruction: 'Use key sk-123456789012345678901234 for context' } }) },
+        }),
+      ],
+    })
+    await nextTick()
+
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('aiShortcut.params.instruction')
+    expect(text).toContain('Use normal wording')
+    expect(text).toContain('sk-<redacted>')
+    expect(text).not.toContain('sk-123456789012345678901234')
+    expect(text).not.toContain('{"instruction"')
+  })
+
+  it('keeps non-aiShortcut property changes on the legacy compact summary path', async () => {
+    mountModal({
+      items: [
+        rev({
+          id: 'ordinary-property',
+          action: 'update',
+          changedKeys: ['property'],
+          before: { property: { options: ['A'] } },
+          after: { property: { options: ['A', 'B'] } },
+        }),
+      ],
+    })
+    await nextTick()
+
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('options: A')
+    expect(text).toContain('options: A; B')
+    expect(text).not.toContain('aiShortcut.kind')
+  })
+
+  it('renders mixed aiShortcut property and ordinary name changes without either branch swallowing the other', async () => {
+    mountModal({
+      items: [
+        rev({
+          id: 'mixed-update',
+          action: 'update',
+          changedKeys: ['property', 'name'],
+          before: {
+            name: 'Old field',
+            property: propertyWithAi({ params: { instruction: 'Old instruction' } }),
+          },
+          after: {
+            name: 'New field',
+            property: propertyWithAi({ params: { instruction: 'New instruction' } }),
+          },
+        }),
+      ],
+    })
+    await nextTick()
+
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('aiShortcut.params.instruction')
+    expect(text).toContain('Old instruction')
+    expect(text).toContain('New instruction')
+    expect(text).toContain('name')
+    expect(text).toContain('Old field')
+    expect(text).toContain('New field')
+  })
+
+  it('falls back to the raw source field id when the workbench label resolver cannot name it', async () => {
+    mountModal({
+      recordLabelOf: (id) => id === 'fld_missing' ? id : `name:${id}`,
+      items: [
+        rev({
+          id: 'missing-source-label',
+          action: 'create',
+          after: { property: propertyWithAi({ sourceFieldIds: ['fld_missing'] }) },
+        }),
+      ],
+    })
+    await nextTick()
+
+    expect(document.body.textContent).toContain('fld_missing')
+  })
+})
+
 describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE renders the decision)', () => {
   const updateRev = () => rev({ id: 'a', action: 'update', changedKeys: ['name'], before: { name: 'Old' }, after: { name: 'New' } })
 
@@ -169,6 +292,28 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     await nextTick(); (q('[data-test="config-history-revert"]') as HTMLButtonElement).click(); await flush()
     expect(q('[data-test="config-restore-drift"]')).toBeTruthy()
     expect((q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('pure aiShortcut property updates still rely on the server-gated revert preview, not a new FE restore surface', async () => {
+    const previewRevert = vi.fn(async () => previewOf({ opKind: 'gated', gatedReason: 'property reverts are gated' }))
+    mountModal({
+      items: [
+        rev({
+          id: 'a',
+          action: 'update',
+          changedKeys: ['property'],
+          before: { property: { aiShortcut: { kind: 'summarize', sourceFieldIds: ['fld_a'], params: { instruction: 'old' } } } },
+          after: { property: { aiShortcut: { kind: 'summarize', sourceFieldIds: ['fld_a'], params: { instruction: 'new' } } } },
+        }),
+      ],
+      previewRevert,
+      executeRevert: vi.fn(),
+    })
+    await nextTick(); (q('[data-test="config-history-revert"]') as HTMLButtonElement).click(); await flush()
+    expect(previewRevert).toHaveBeenCalledWith('a')
+    expect(q('[data-test="config-restore-gated"]')).toBeTruthy()
+    expect(document.body.textContent).toContain('property reverts are gated')
+    expect(q('[data-test="config-restore-confirm-btn"]')).toBeFalsy()
   })
 })
 


### PR DESCRIPTION
## Summary

Implements the ratified S2 render-only slice from #3618 for AI-shortcut prompt-config history:

- adds an `aiShortcut`-aware render branch in the existing `MetaConfigHistoryModal.vue`
- expands `field.property.aiShortcut` config history into labeled `kind`, `sourceFieldIds`, and `params.*` lines instead of a nested JSON blob
- reuses the existing UI `redactString` helper for free-text prompt params before rendering
- preserves the legacy compact summary path for non-aiShortcut property changes
- leaves backend, storage, routes, restore/revert behavior, and non-aiShortcut config rendering unchanged

## Scope

Touched files:

- `apps/web/src/multitable/components/MetaConfigHistoryModal.vue`
- `apps/web/tests/multitable-config-history-modal.spec.ts`

No backend changes, no migration, no new route, no new modal, no restore surface change.

## Verification

Ran in `/private/tmp/mt-ai-s2-render` after rebasing onto `origin/main` (`9f08a4bf9`):

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-config-history-modal.spec.ts --watch=false` → 19/19 pass
- `pnpm --filter @metasheet/web type-check` → clean
- `git diff --check` → clean
