### PR TITLE
feat(approval): DingTalk one-tap chain — task_created trigger + approval card + decision page (A-2a/A-2b/A-3+A-4-core, lock #3594)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -308,6 +308,7 @@ jobs:
             tests/integration/automation-approval-completed-trigger.test.ts \
             tests/integration/automation-approval-task-created-trigger.test.ts \
             tests/integration/automation-dingtalk-approval-card-action.test.ts \
+            tests/integration/approval-card-delivery-wrapper.db.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -307,6 +307,7 @@ jobs:
             tests/integration/multitable-form-submit-start-approval-smoke.test.ts \
             tests/integration/automation-approval-completed-trigger.test.ts \
             tests/integration/automation-approval-task-created-trigger.test.ts \
+            tests/integration/automation-dingtalk-approval-card-action.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -306,6 +306,7 @@ jobs:
             tests/integration/multitable-inbound-webhook-trigger.test.ts \
             tests/integration/multitable-form-submit-start-approval-smoke.test.ts \
             tests/integration/automation-approval-completed-trigger.test.ts \
+            tests/integration/automation-approval-task-created-trigger.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/apps/web/src/approvals/cardDecision.ts
+++ b/apps/web/src/approvals/cardDecision.ts
@@ -1,0 +1,95 @@
+/**
+ * A-3 (one-tap lock #3594 §5): the mobile decision page's ONLY api surface.
+ *
+ * Talks exclusively to the card-delivery endpoints — resolution is deliveryId + HMAC token,
+ * never an instance id, and this module deliberately has NO import from `./api` so the page
+ * cannot drift into calling the raw per-instance approval action route (locked by a tripwire spec).
+ */
+import { apiFetch } from '../utils/api'
+
+export interface ApprovalCardSummary {
+  deliveryId: string
+  cardState: 'sent' | 'acted' | 'superseded' | 'expired' | 'revoked'
+  sendStatus: 'pending' | 'sent' | 'failed'
+  nodeKey: string
+  recipientUserId: string
+  viewerIsRecipient: boolean
+  actionable: boolean
+  approval: {
+    instanceId: string
+    title: string | null
+    requestNo: string | null
+    status: string
+    currentNodeKey: string | null
+    rejectCommentRequired: boolean
+  }
+  actedAction: string | null
+  actedAt: string | null
+}
+
+export interface ApprovalCardActionError {
+  code: string
+  message: string
+  /** Server may attach the real card summary alongside the error (409 stale / engine 4xx). */
+  summary?: ApprovalCardSummary
+}
+
+async function parseError(response: Response): Promise<ApprovalCardActionError> {
+  try {
+    const payload = await response.json() as { error?: { code?: string; message?: string }; data?: ApprovalCardSummary }
+    return {
+      code: payload.error?.code ?? `HTTP_${response.status}`,
+      message: payload.error?.message ?? `请求失败（${response.status}）`,
+      summary: payload.data,
+    }
+  } catch {
+    return { code: `HTTP_${response.status}`, message: `请求失败（${response.status}）` }
+  }
+}
+
+/**
+ * Lock §5: an unauthenticated card deep link drives the DingTalk OAuth launch DIRECTLY (not the
+ * generic /login page). Mirrors LoginView's launch contract: GET the launch endpoint with the
+ * decision page as redirect, then navigate to the returned URL. Returns false (with a message)
+ * when the launch is unavailable so the page can render a manual retry button.
+ */
+export async function launchDingTalkLoginForDecision(fullPath: string): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const response = await apiFetch(`/api/auth/dingtalk/launch?redirect=${encodeURIComponent(fullPath)}`, {
+      method: 'GET',
+      suppressUnauthorizedRedirect: true,
+    } as RequestInit)
+    const payload = await response.json().catch(() => null) as { success?: boolean; data?: { url?: string }; error?: { message?: string } } | null
+    const launchUrl = typeof payload?.data?.url === 'string' ? payload.data.url : ''
+    if (!response.ok || payload?.success !== true || !launchUrl) {
+      return { ok: false, message: payload?.error?.message ?? '钉钉登录暂不可用，请稍后重试。' }
+    }
+    window.location.href = launchUrl
+    return { ok: true }
+  } catch {
+    return { ok: false, message: '钉钉登录暂不可用，请稍后重试。' }
+  }
+}
+
+export async function fetchApprovalCardSummary(deliveryId: string, token: string): Promise<ApprovalCardSummary> {
+  const response = await apiFetch(`/api/approval-card-deliveries/${encodeURIComponent(deliveryId)}?t=${encodeURIComponent(token)}`)
+  if (!response.ok) throw Object.assign(new Error('card summary failed'), { cardError: await parseError(response) })
+  const payload = await response.json() as { data: ApprovalCardSummary }
+  return payload.data
+}
+
+export async function submitApprovalCardDecision(
+  deliveryId: string,
+  token: string,
+  decision: 'approve' | 'reject',
+  comment?: string,
+): Promise<ApprovalCardSummary> {
+  const response = await apiFetch(`/api/approval-card-deliveries/${encodeURIComponent(deliveryId)}/actions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ t: token, decision, ...(comment ? { comment } : {}) }),
+  })
+  if (!response.ok) throw Object.assign(new Error('card decision failed'), { cardError: await parseError(response) })
+  const payload = await response.json() as { data: ApprovalCardSummary }
+  return payload.data
+}

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1848,6 +1848,7 @@ function describeTrigger(rule: AutomationRule): string {
     // T1-2/T1-3: editor-exposed triggers get their localized type label in the card summary.
     case 'webhook.received':
     case 'approval.completed':
+    case 'approval.task_created':
       return automationTriggerTypeLabel(rule.triggerType, isZh.value)
     default:
       return String(rule.triggerType)

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -695,6 +695,15 @@
               </div>
             </div>
 
+            <!-- send_dingtalk_approval_card (A-2b): no inputs — recipient fixed from the event -->
+            <div v-if="action.type === 'send_dingtalk_approval_card'" class="meta-rule-editor__action-config">
+              <div class="meta-rule-editor__hint" data-field="approvalCardHint">
+                {{ isZh
+                  ? '发送带「查看并处理」按钮的钉钉审批卡片给该待办的受理人。收件人固定来自审批待办事件（不可手填）；卡片只含标题/编号等元数据，深链仅携带投递 ID 与签名令牌。仅可用于「当产生新审批待办时」触发器；未绑定钉钉的受理人记录为 skipped，不会猜测映射。'
+                  : 'Sends a DingTalk approval card with a 查看并处理 button to the pending task\'s assignee. The recipient is FIXED from the approval-task event (never author-supplied); the card carries metadata only and the deep link holds just the delivery id + signed token. Only valid on the approval.task_created trigger; unbound recipients are recorded as skipped — mappings are never guessed.' }}
+              </div>
+            </div>
+
             <!-- send_dingtalk_person_message config -->
             <div v-if="action.type === 'send_dingtalk_person_message'" class="meta-rule-editor__action-config">
               <div class="meta-rule-editor__preset-row">
@@ -1433,6 +1442,11 @@ const APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES = new Set<string>([
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
 ])
+// A-2b: the approval card additionally mounts on the pending-task trigger (and ONLY there).
+const APPROVAL_TASK_CREATED_FE_ALLOWED_ACTION_TYPES = new Set<string>([
+  ...APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES,
+  'send_dingtalk_approval_card',
+])
 
 function approvalCompletedOutcomeLabel(outcome: ApprovalCompletedOutcome): string {
   const zh = isZh.value
@@ -1469,12 +1483,12 @@ const approvalTaskCreatedBlockReason = computed<string>(() => {
   if (draft.value.conditions.conditions.length > 0) {
     return zh ? '审批待办触发器不支持触发条件，请先移除所有条件。' : 'The approval-task trigger does not support conditions — remove them first.'
   }
-  const disallowed = draft.value.actions.find((action) => !APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES.has(action.type))
+  const disallowed = draft.value.actions.find((action) => !APPROVAL_TASK_CREATED_FE_ALLOWED_ACTION_TYPES.has(action.type))
   if (disallowed) {
     const label = automationActionTypeLabel(disallowed.type, zh)
     return zh
-      ? `动作「${label}」不可用于审批待办触发器（仅支持通知类动作）。`
-      : `Action "${label}" is not allowed on the approval-task trigger (notification-family actions only).`
+      ? `动作「${label}」不可用于审批待办触发器（仅支持通知类动作与审批卡片）。`
+      : `Action "${label}" is not allowed on the approval-task trigger (notification-family actions and the approval card only).`
   }
   return ''
 })
@@ -1514,6 +1528,8 @@ const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
   'send_email',
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
+  // A-2b: approval card — recipient comes from the approval.task_created event, config is empty.
+  'send_dingtalk_approval_card',
   // T0-3: expose only the safe authoring shape — same-base trigger-record delete, config: {}.
   // Cross-base delete remains backend/runtime-only and is not surfaced in this editor.
   'delete_record',

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -47,6 +47,7 @@
             -->
             <option value="webhook.received">{{ automationTriggerTypeLabel('webhook.received', isZh) }}</option>
             <option value="approval.completed">{{ automationTriggerTypeLabel('approval.completed', isZh) }}</option>
+            <option value="approval.task_created">{{ automationTriggerTypeLabel('approval.task_created', isZh) }}</option>
           </select>
 
           <!-- field.value_changed config -->
@@ -149,6 +150,24 @@
             </div>
             <div v-if="approvalCompletedBlockReason" class="meta-rule-editor__hint" data-field="approvalCompletedBlockReason" style="color: var(--ms-color-danger, #d03050);">
               {{ approvalCompletedBlockReason }}
+            </div>
+          </template>
+
+          <!-- approval.task_created (A-2a template-routed) config -->
+          <template v-if="draft.triggerType === 'approval.task_created'">
+            <label class="meta-rule-editor__label">{{ isZh ? '审批模板' : 'Approval template' }}</label>
+            <select v-if="approvalTemplates.length > 0" v-model="draft.triggerConfig.templateId" class="meta-rule-editor__select" data-field="approvalTaskCreatedTemplateId">
+              <option value="">{{ isZh ? '请选择审批模板' : 'Select an approval template' }}</option>
+              <option v-for="t in approvalTemplates" :key="t.id" :value="t.id">{{ t.name || t.id }}</option>
+            </select>
+            <input v-else v-model="draft.triggerConfig.templateId" class="meta-rule-editor__input" type="text" :placeholder="isZh ? '审批模板 ID' : 'Approval template ID'" data-field="approvalTaskCreatedTemplateId" />
+            <div class="meta-rule-editor__hint" data-field="approvalTaskCreatedHint">
+              {{ isZh
+                ? '该模板产生新的审批待办（每位受理人一条）时触发。退回/跳转形成的新一轮待办会再次触发；同一轮重复投递自动去重。无记录上下文：动作仅支持通知类，不支持记录读写与发起审批，且不支持触发条件；创建者需持有审批读取权限并对该模板可见（保存与触发时均校验）。'
+                : 'Fires when this template produces a NEW pending approval task (one per recipient). A returned/jumped node fires again for its fresh round; duplicate deliveries of the same round dedupe. Record-less: only notification-family actions — no record actions, no start-approval, no conditions; the rule creator must hold approvals read permission and template visibility (checked at save AND at fire).' }}
+            </div>
+            <div v-if="approvalTaskCreatedBlockReason" class="meta-rule-editor__hint" data-field="approvalTaskCreatedBlockReason" style="color: var(--ms-color-danger, #d03050);">
+              {{ approvalTaskCreatedBlockReason }}
             </div>
           </template>
         </section>
@@ -1440,6 +1459,26 @@ const approvalCompletedOutcomes = computed<string[]>({
   },
 })
 
+// A-2a: same structural gates as approval.completed (templateId required, no conditions,
+// notification-family actions only) — mirrored so the reason names the right trigger.
+const approvalTaskCreatedBlockReason = computed<string>(() => {
+  if (draft.value.triggerType !== 'approval.task_created') return ''
+  const zh = isZh.value
+  const templateId = typeof draft.value.triggerConfig.templateId === 'string' ? draft.value.triggerConfig.templateId.trim() : ''
+  if (!templateId) return zh ? '请选择审批模板。' : 'Select an approval template.'
+  if (draft.value.conditions.conditions.length > 0) {
+    return zh ? '审批待办触发器不支持触发条件，请先移除所有条件。' : 'The approval-task trigger does not support conditions — remove them first.'
+  }
+  const disallowed = draft.value.actions.find((action) => !APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES.has(action.type))
+  if (disallowed) {
+    const label = automationActionTypeLabel(disallowed.type, zh)
+    return zh
+      ? `动作「${label}」不可用于审批待办触发器（仅支持通知类动作）。`
+      : `Action "${label}" is not allowed on the approval-task trigger (notification-family actions only).`
+  }
+  return ''
+})
+
 const approvalCompletedBlockReason = computed<string>(() => {
   if (draft.value.triggerType !== 'approval.completed') return ''
   const zh = isZh.value
@@ -2353,6 +2392,7 @@ const canSave = computed(() => {
   if (draft.value.actions.length < 1) return false
   // T1-3: mirror the backend save gate (templateId / no-conditions / notification-only actions).
   if (draft.value.triggerType === 'approval.completed' && approvalCompletedBlockReason.value) return false
+  if (draft.value.triggerType === 'approval.task_created' && approvalTaskCreatedBlockReason.value) return false
   // T1-2: a signing secret is required; an existing rule with a stored (redacted-on-read) secret may
   // leave the field blank to keep it.
   if (draft.value.triggerType === 'webhook.received') {
@@ -3118,6 +3158,10 @@ function buildPayload(): Partial<AutomationRule> {
     // Normalize the date-reminder config so an unset/garbage direction or offset can't persist a no-op rule.
     triggerConfig.direction = triggerConfig.direction === 'after' ? 'after' : 'before'
     triggerConfig.offsetDays = Number(triggerConfig.offsetDays) || 0
+  }
+  if (d.triggerType === 'approval.task_created') {
+    // A-2a: trimmed templateId is the only config key.
+    triggerConfig.templateId = typeof triggerConfig.templateId === 'string' ? triggerConfig.templateId.trim() : ''
   }
   if (d.triggerType === 'approval.completed') {
     // T1-3: trimmed templateId; outcomes only when a valid non-empty selection exists (omitted =

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -973,6 +973,7 @@ export type AutomationTriggerType =
   | 'webhook.received'
   | 'form.submitted'
   | 'approval.completed'
+  | 'approval.task_created'
   // Legacy aliases
   | 'field.changed'
 

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -1014,6 +1014,7 @@ export type AutomationActionType =
   | 'send_email'
   | 'send_dingtalk_group_message'
   | 'send_dingtalk_person_message'
+  | 'send_dingtalk_approval_card'
   | 'delete_record'
   | 'lock_record'
   | 'wait_for_callback'

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -900,6 +900,8 @@ export function automationActionTypeLabel(type: AutomationActionType | UnknownAu
       return isZh ? '发送钉钉群消息' : 'Send DingTalk group message'
     case 'send_dingtalk_person_message':
       return isZh ? '发送钉钉个人消息' : 'Send DingTalk person message'
+    case 'send_dingtalk_approval_card':
+      return isZh ? '发送审批卡片（钉钉）' : 'Send approval card (DingTalk)'
     case 'delete_record':
       return isZh ? '删除记录' : 'Delete record'
     case 'lock_record':

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -939,6 +939,8 @@ export function automationTriggerTypeLabel(type: AutomationTriggerType | Unknown
       return isZh ? '当表单提交时' : 'When form submitted'
     case 'approval.completed':
       return isZh ? '当审批完成时' : 'When approval completes'
+    case 'approval.task_created':
+      return isZh ? '当产生新审批待办时' : 'When an approval task is created'
     case 'field.changed':
       return isZh ? '当字段变化时' : 'When field changed'
     default:

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -259,6 +259,18 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'New Approval', titleZh: '发起审批', requiresAuth: true }
   },
   {
+    // A-3 (one-tap lock #3594 §5): the card deep-link decision page. Query carries ONLY
+    // d=<deliveryId> + t=<HMAC token>; everything else resolves server-side via the
+    // card-delivery endpoints — this page never calls raw /api/approvals/:id/actions.
+    path: '/m/approval-decision',
+    name: 'approval-card-decision',
+    component: () => import('../views/approval/ApprovalCardDecisionView.vue'),
+    // requiresAuth is deliberately FALSE: the generic guard would bounce to /login, but lock §5
+    // requires the card deep link to drive the DingTalk launch flow directly — the view detects
+    // the missing session itself and redirects to /api/auth/dingtalk/launch?redirect=<self>.
+    meta: { title: 'Approval Decision', titleZh: '审批处理', hideNavbar: true, requiresAuth: false }
+  },
+  {
     path: '/approvals/:id',
     name: 'approval-detail',
     component: () => import('../views/approval/ApprovalDetailView.vue'),

--- a/apps/web/src/views/approval/ApprovalCardDecisionView.vue
+++ b/apps/web/src/views/approval/ApprovalCardDecisionView.vue
@@ -1,0 +1,280 @@
+<template>
+  <section class="card-decision" data-testid="card-decision-page">
+    <div v-if="loading" v-loading="true" class="card-decision__loading" />
+
+    <el-alert
+      v-else-if="loadError"
+      :title="loadError"
+      type="error"
+      show-icon
+      :closable="false"
+      data-testid="card-decision-load-error"
+    />
+
+    <div v-else-if="needsLogin" class="card-decision__login" data-testid="card-decision-login">
+      <p class="card-decision__meta">{{ launchMessage || '需要登录后处理该审批待办。' }}</p>
+      <el-button type="primary" size="large" data-testid="card-decision-launch" @click="startDingTalkLaunch">
+        使用钉钉登录
+      </el-button>
+    </div>
+
+    <template v-else-if="summary">
+      <header class="card-decision__header">
+        <h1 data-testid="card-decision-title">{{ summary.approval.title ?? '审批待办' }}</h1>
+        <p v-if="summary.approval.requestNo" class="card-decision__meta">编号：{{ summary.approval.requestNo }}</p>
+        <p class="card-decision__meta">节点：{{ summary.nodeKey }}</p>
+      </header>
+
+      <!-- Terminal / stale states render the REAL ledger state instead of dead buttons. -->
+      <el-alert
+        v-if="!summary.actionable"
+        :title="staleTitle"
+        :type="summary.cardState === 'acted' ? 'success' : 'info'"
+        show-icon
+        :closable="false"
+        data-testid="card-decision-stale"
+      />
+
+      <template v-else>
+        <el-alert
+          v-if="!summary.viewerIsRecipient"
+          title="此待办的受理人不是当前账号；提交将按服务端受理校验执行。"
+          type="warning"
+          show-icon
+          :closable="false"
+        />
+        <div class="card-decision__comment">
+          <label class="card-decision__label">
+            处理意见<span v-if="summary.approval.rejectCommentRequired">（驳回必填）</span>
+          </label>
+          <el-input
+            v-model="comment"
+            type="textarea"
+            :rows="3"
+            placeholder="填写处理意见"
+            data-testid="card-decision-comment"
+          />
+        </div>
+        <el-alert
+          v-if="submitError"
+          :title="submitError"
+          type="error"
+          show-icon
+          :closable="false"
+          data-testid="card-decision-submit-error"
+        />
+        <div class="card-decision__actions">
+          <el-button
+            type="success"
+            size="large"
+            :loading="submitting === 'approve'"
+            :disabled="submitting !== ''"
+            data-testid="card-decision-approve"
+            @click="submit('approve')"
+          >
+            同意
+          </el-button>
+          <el-button
+            type="danger"
+            size="large"
+            :loading="submitting === 'reject'"
+            :disabled="submitting !== '' || rejectBlocked"
+            data-testid="card-decision-reject"
+            @click="submit('reject')"
+          >
+            驳回
+          </el-button>
+        </div>
+        <p v-if="rejectBlocked" class="card-decision__hint" data-testid="card-decision-reject-hint">
+          驳回前请先填写处理意见。
+        </p>
+      </template>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+// A-3 (one-tap lock #3594 §5): minimal mobile decision page for the DingTalk approval card.
+// Deep link carries ONLY ?d=<deliveryId>&t=<HMAC token>; the page resolves everything through the
+// card-delivery endpoints (cardDecision.ts) and MUST NOT call the raw per-instance action route —
+// direct calls would bypass the ledger card_state writeback + channel attribution (tripwire spec).
+import { computed, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import {
+  fetchApprovalCardSummary,
+  launchDingTalkLoginForDecision,
+  submitApprovalCardDecision,
+  type ApprovalCardActionError,
+  type ApprovalCardSummary,
+} from '../../approvals/cardDecision'
+import { useAuth } from '../../composables/useAuth'
+
+const route = useRoute()
+
+const loading = ref(true)
+const loadError = ref('')
+// Lock §5: unauthenticated deep link auto-launches DingTalk OAuth ONCE per delivery; a bounce-back
+// still unauthenticated (cancelled/failed OAuth) renders a manual retry button instead of looping.
+const needsLogin = ref(false)
+const launchMessage = ref('')
+const summary = ref<ApprovalCardSummary | null>(null)
+const comment = ref('')
+const submitting = ref<'' | 'approve' | 'reject'>('')
+const submitError = ref('')
+
+const deliveryId = computed(() => (typeof route.query.d === 'string' ? route.query.d : ''))
+const token = computed(() => (typeof route.query.t === 'string' ? route.query.t : ''))
+
+const rejectBlocked = computed(() =>
+  (summary.value?.approval.rejectCommentRequired ?? true) && comment.value.trim().length === 0,
+)
+
+const staleTitle = computed(() => {
+  const s = summary.value
+  if (!s) return ''
+  if (s.cardState === 'acted') {
+    return `该待办已处理（${s.actedAction === 'approve' ? '同意' : s.actedAction === 'reject' ? '驳回' : s.actedAction ?? ''}）。`
+  }
+  if (s.approval.status !== 'pending') return '该审批已办结，无需处理。'
+  if (s.sendStatus !== 'sent') return '该卡片未成功投递，无法在此处理。'
+  return '该待办已流转（转办/新一轮），此卡片不再有效。'
+})
+
+function cardErrorOf(error: unknown): ApprovalCardActionError | null {
+  const holder = error as { cardError?: ApprovalCardActionError }
+  return holder?.cardError ?? null
+}
+
+function launchGuardKey(): string {
+  return `approval-card-launch-attempted:${deliveryId.value}`
+}
+
+async function startDingTalkLaunch(): Promise<void> {
+  launchMessage.value = ''
+  const result = await launchDingTalkLoginForDecision(route.fullPath)
+  if (!result.ok) {
+    needsLogin.value = true
+    launchMessage.value = result.message ?? ''
+  }
+  // ok → browser is navigating away; nothing else to render.
+}
+
+async function load() {
+  loading.value = true
+  loadError.value = ''
+  needsLogin.value = false
+  if (!deliveryId.value || !token.value) {
+    loading.value = false
+    loadError.value = '链接无效：缺少必要参数。'
+    return
+  }
+  // Lock §5: session check BEFORE any api call — missing session drives the DingTalk launch flow
+  // directly (never the generic /login page).
+  const userId = await useAuth().getCurrentUserId().catch(() => null)
+  if (!userId) {
+    loading.value = false
+    let attempted = false
+    try {
+      attempted = window.sessionStorage.getItem(launchGuardKey()) === '1'
+      window.sessionStorage.setItem(launchGuardKey(), '1')
+    } catch { /* storage unavailable → still attempt once */ }
+    if (!attempted) {
+      await startDingTalkLaunch()
+      if (!needsLogin.value) return // navigating away
+    } else {
+      needsLogin.value = true
+    }
+    return
+  }
+  try {
+    window.sessionStorage.removeItem(launchGuardKey())
+  } catch { /* noop */ }
+  try {
+    summary.value = await fetchApprovalCardSummary(deliveryId.value, token.value)
+  } catch (error) {
+    const cardError = cardErrorOf(error)
+    loadError.value = cardError?.code === 'APPROVAL_CARD_DELIVERY_NOT_FOUND'
+      ? '链接无效或已失效。'
+      : cardError?.message ?? '加载失败，请稍后重试。'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function submit(decision: 'approve' | 'reject') {
+  if (submitting.value) return
+  submitError.value = ''
+  submitting.value = decision
+  try {
+    summary.value = await submitApprovalCardDecision(
+      deliveryId.value,
+      token.value,
+      decision,
+      comment.value.trim() || undefined,
+    )
+  } catch (error) {
+    const cardError = cardErrorOf(error)
+    // A stale/terminal response carries the REAL summary — render it instead of a dead form.
+    if (cardError?.summary) summary.value = cardError.summary
+    submitError.value = cardError?.message ?? '提交失败，请重试。'
+  } finally {
+    submitting.value = ''
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.card-decision {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-decision__loading {
+  min-height: 200px;
+}
+
+.card-decision__header h1 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.card-decision__meta {
+  color: var(--el-text-color-secondary, #909399);
+  font-size: 13px;
+  margin: 2px 0;
+}
+
+.card-decision__label {
+  display: block;
+  font-size: 13px;
+  color: var(--el-text-color-secondary, #909399);
+  margin-bottom: 6px;
+}
+
+.card-decision__actions {
+  display: flex;
+  gap: 12px;
+  position: sticky;
+  bottom: 0;
+  padding: 8px 0 calc(8px + env(safe-area-inset-bottom));
+  background: var(--el-bg-color, #fff);
+}
+
+.card-decision__actions .el-button {
+  flex: 1;
+  min-height: 44px;
+}
+
+.card-decision__hint {
+  color: var(--el-text-color-secondary, #909399);
+  font-size: 12px;
+  margin: 0;
+}
+</style>

--- a/apps/web/tests/approvalCardDecisionView.spec.ts
+++ b/apps/web/tests/approvalCardDecisionView.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * A-3 decision page (one-tap lock #3594 §5) — view behavior + the no-raw-/actions tripwire.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp } from 'vue'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+let routeQuery: Record<string, string> = {}
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRoute: () => ({
+      query: routeQuery,
+      params: {},
+      path: '/m/approval-decision',
+      fullPath: `/m/approval-decision${Object.keys(routeQuery).length ? `?${new URLSearchParams(routeQuery).toString()}` : ''}`,
+      meta: {},
+    }),
+  }
+})
+
+const apiFetchMock = vi.fn()
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+let mockUserId: string | null = 'user_a'
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({ getCurrentUserId: vi.fn().mockImplementation(async () => mockUserId) }),
+}))
+
+import ApprovalCardDecisionView from '../src/views/approval/ApprovalCardDecisionView.vue'
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function summaryFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    deliveryId: 'del_1',
+    cardState: 'sent',
+    sendStatus: 'sent',
+    nodeKey: 'approval_1',
+    recipientUserId: 'user_a',
+    viewerIsRecipient: true,
+    actionable: true,
+    approval: {
+      instanceId: 'apv_1',
+      title: '出差报销',
+      requestNo: 'AP-1001',
+      status: 'pending',
+      currentNodeKey: 'approval_1',
+      rejectCommentRequired: true,
+    },
+    actedAction: null,
+    actedAt: null,
+    ...overrides,
+  }
+}
+
+const stub = (name: string, tag = 'div') => defineComponent({
+  name,
+  props: { title: String, type: String, modelValue: {}, loading: Boolean, disabled: Boolean },
+  emits: ['update:modelValue', 'click'],
+  render() {
+    if (name === 'ElInput') {
+      return h('textarea', {
+        value: this.modelValue as string,
+        onInput: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLTextAreaElement).value),
+      })
+    }
+    if (name === 'ElButton') {
+      return h('button', {
+        disabled: this.disabled || undefined,
+        onClick: (e: Event) => this.$emit('click', e),
+      }, this.$slots.default?.())
+    }
+    return h(tag, { 'data-stub': name, 'data-title': this.title ?? '' }, [this.title ?? '', this.$slots.default?.()])
+  },
+})
+
+async function flushUi(cycles = 6) {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('ApprovalCardDecisionView (A-3)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  async function mountView() {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(ApprovalCardDecisionView)
+    for (const name of ['ElAlert', 'ElInput', 'ElButton']) app.component(name, stub(name))
+    app.directive('loading', { mounted() {}, updated() {} })
+    app.mount(container)
+    await flushUi()
+  }
+
+  beforeEach(() => {
+    routeQuery = { d: 'del_1', t: 'a'.repeat(32) }
+    apiFetchMock.mockReset()
+    mockUserId = 'user_a'
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+  })
+
+  it('renders the summary and blocks 驳回 until a comment is typed (rejectCommentRequired)', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, data: summaryFixture() }))
+    await mountView()
+
+    expect(container!.querySelector('[data-testid="card-decision-title"]')?.textContent).toBe('出差报销')
+    const reject = container!.querySelector('[data-testid="card-decision-reject"]') as HTMLButtonElement
+    expect(reject.disabled).toBe(true)
+    expect(container!.querySelector('[data-testid="card-decision-reject-hint"]')).toBeTruthy()
+
+    const commentBox = container!.querySelector('[data-testid="card-decision-comment"] textarea, textarea') as HTMLTextAreaElement
+    commentBox.value = '材料不全'
+    commentBox.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect((container!.querySelector('[data-testid="card-decision-reject"]') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('approve submits to the card-delivery endpoint and renders the terminal state', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, data: summaryFixture() }))
+    await mountView()
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      data: summaryFixture({ cardState: 'acted', actionable: false, actedAction: 'approve', approval: { ...summaryFixture().approval, status: 'approved' } }),
+    }))
+
+    ;(container!.querySelector('[data-testid="card-decision-approve"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const calls = apiFetchMock.mock.calls.map((c) => String(c[0]))
+    expect(calls[1]).toBe('/api/approval-card-deliveries/del_1/actions')
+    const init = apiFetchMock.mock.calls[1][1] as RequestInit
+    expect(JSON.parse(String(init.body))).toEqual({ t: 'a'.repeat(32), decision: 'approve' })
+    expect(container!.querySelector('[data-testid="card-decision-stale"]')?.getAttribute('data-title')).toContain('已处理')
+  })
+
+  it('a 409 stale response swaps in the REAL terminal summary instead of a dead form', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, data: summaryFixture() }))
+    await mountView()
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({
+      error: { code: 'APPROVAL_CARD_DELIVERY_STALE', message: 'This card is no longer actionable' },
+      data: summaryFixture({ cardState: 'superseded', actionable: false }),
+    }, 409))
+
+    ;(container!.querySelector('[data-testid="card-decision-approve"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(container!.querySelector('[data-testid="card-decision-stale"]')).toBeTruthy()
+  })
+
+  it('missing d/t query renders an invalid-link error without calling the api', async () => {
+    routeQuery = {}
+    await mountView()
+    expect(container!.querySelector('[data-testid="card-decision-load-error"]')?.getAttribute('data-title')).toContain('链接无效')
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('P2: an unauthenticated deep link auto-launches DingTalk OAuth — never the generic /login', async () => {
+    mockUserId = null
+    const originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, href: 'http://localhost/m/approval-decision?d=del_1' },
+    })
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: { url: 'https://oapi.dingtalk.com/launch/abc' } }))
+
+    await mountView()
+
+    const calls = apiFetchMock.mock.calls.map((c) => String(c[0]))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('/api/auth/dingtalk/launch?redirect=')
+    expect(decodeURIComponent(calls[0].split('redirect=')[1])).toBe(`/m/approval-decision?d=del_1&t=${'a'.repeat(32)}`)
+    expect(window.location.href).toBe('https://oapi.dingtalk.com/launch/abc')
+    // no summary fetch, no /login navigation of any kind
+    expect(calls.some((u) => u.includes('/api/approval-card-deliveries/'))).toBe(false)
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+  })
+
+  it('P2: bounced back still unauthenticated → manual 钉钉登录 button instead of a redirect loop', async () => {
+    mockUserId = null
+    sessionStorage.setItem('approval-card-launch-attempted:del_1', '1')
+    await mountView()
+    expect(apiFetchMock).not.toHaveBeenCalled()
+    expect(container!.querySelector('[data-testid="card-decision-launch"]')).toBeTruthy()
+  })
+
+  it('P2: an authenticated visit never triggers the launch flow', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, data: summaryFixture() }))
+    await mountView()
+    const calls = apiFetchMock.mock.calls.map((c) => String(c[0]))
+    expect(calls.some((u) => u.includes('/api/auth/dingtalk/launch'))).toBe(false)
+    expect(calls[0]).toContain('/api/approval-card-deliveries/del_1')
+  })
+
+  it('P2: a missing d/t link stays a LOCAL invalid-link error — no launch, no api call', async () => {
+    mockUserId = null
+    routeQuery = {}
+    await mountView()
+    expect(apiFetchMock).not.toHaveBeenCalled()
+    expect(container!.querySelector('[data-testid="card-decision-load-error"]')?.getAttribute('data-title')).toContain('链接无效')
+  })
+
+  it('TRIPWIRE: the decision page and its api module never touch raw /api/approvals/ paths', () => {
+    // Direct calls would bypass the card ledger writeback + channel attribution (lock §5 hard rule).
+    const view = readFileSync(resolve(__dirname, '../src/views/approval/ApprovalCardDecisionView.vue'), 'utf8')
+    const api = readFileSync(resolve(__dirname, '../src/approvals/cardDecision.ts'), 'utf8')
+    for (const source of [view, api]) {
+      expect(source).not.toContain("'/api/approvals/")
+      expect(source).not.toContain('`/api/approvals/')
+    }
+    expect(api).toContain('/api/approval-card-deliveries/')
+  })
+})

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -255,6 +255,28 @@ describe('MetaAutomationRuleEditor', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('A-2a: approval.task_created config requires a template and blocks disallowed actions', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    triggerSelect.value = 'approval.task_created'
+    triggerSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // templateId input rendered (text fallback without loaded templates) + block reason asks for a template
+    expect(container.querySelector('[data-field="approvalTaskCreatedTemplateId"]')).toBeTruthy()
+    const reason = container.querySelector('[data-field="approvalTaskCreatedBlockReason"]')
+    expect(reason?.textContent).toContain('Select an approval template')
+
+    const templateInput = container.querySelector('[data-field="approvalTaskCreatedTemplateId"]') as HTMLInputElement
+    templateInput.value = 'a4b1c2d3-0000-4111-8222-333344445555'
+    templateInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+    // default draft action is update_record — not notification-family → still blocked, names the action
+    expect(container.querySelector('[data-field="approvalTaskCreatedBlockReason"]')?.textContent).toContain('not allowed')
+  })
+
   it('renders trigger type selector when visible', async () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
@@ -263,11 +285,13 @@ describe('MetaAutomationRuleEditor', () => {
     expect(triggerSelect).toBeTruthy()
     // record.created/updated/deleted + field.value_changed + form.submitted + schedule.cron/interval/date_field
     // + webhook.received (selectable since the signed inbound endpoint shipped, T1-2 #3489)
-    // + approval.completed (T1-3 #3467 template-routed trigger).
-    expect(triggerSelect.options.length).toBe(10)
+    // + approval.completed (T1-3 #3467 template-routed trigger)
+    // + approval.task_created (A-2a one-tap lock #3594 pending-task trigger).
+    expect(triggerSelect.options.length).toBe(11)
     const triggerValues = Array.from(triggerSelect.options).map((option) => option.value)
     expect(triggerValues).toContain('webhook.received')
     expect(triggerValues).toContain('approval.completed')
+    expect(triggerValues).toContain('approval.task_created')
   })
 
   it('localizes core rule editor chrome in zh-CN while keeping raw select values', async () => {

--- a/packages/core-backend/src/db/migrations/zzzz20260705140000_add_approval_task_created_trigger_type.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260705140000_add_approval_task_created_trigger_type.ts
@@ -1,0 +1,41 @@
+/**
+ * Migration: `approval.task_created` automation trigger (A-2a, one-tap lock #3594 implementation
+ * decision) — widen the trigger_type CHECK constraint.
+ *
+ * The pending-task trigger is added to the application's VALID_TRIGGER_TYPES (automation-service +
+ * automation-triggers). The DB CHECK constraint `chk_automation_trigger_type` on `automation_rules`
+ * predates it, so persisting a rule with trigger_type='approval.task_created' would be rejected
+ * (23514). This widens the allowed set, preserving every existing value (base = the latest
+ * constraint from the approval.completed migration). Pure DDL; idempotent via DROP CONSTRAINT
+ * IF EXISTS.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval', 'schedule.date_field',
+      'webhook.received', 'form.submitted', 'approval.completed',
+      'approval.task_created'
+    ))
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval', 'schedule.date_field',
+      'webhook.received', 'form.submitted', 'approval.completed'
+    ))
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260705150000_add_send_dingtalk_approval_card_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260705150000_add_send_dingtalk_approval_card_automation_action.ts
@@ -1,0 +1,42 @@
+/**
+ * Migration: `send_dingtalk_approval_card` automation action (A-2b, one-tap lock #3594) — widen the
+ * action_type CHECK constraint. A dedicated action (NOT reusing send_dingtalk_person_message):
+ * it writes the dingtalk_approval_card_deliveries ledger, generates the signed decision deep link,
+ * and later carries the Slice-B interactive-card outTrackId. Pure DDL; idempotent.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export const AUTOMATION_ACTION_TYPES_BEFORE_APPROVAL_CARD = [
+  'notify', 'update_field', 'update_record', 'create_record', 'delete_record',
+  'send_webhook', 'send_notification', 'send_email',
+  'send_dingtalk_group_message', 'send_dingtalk_person_message',
+  'lock_record', 'wait_for_callback', 'condition_branch', 'start_approval',
+  'parallel_branch', 'record_click',
+] as const
+
+export const AUTOMATION_ACTION_TYPES_WITH_APPROVAL_CARD = [
+  ...AUTOMATION_ACTION_TYPES_BEFORE_APPROVAL_CARD,
+  'send_dingtalk_approval_card',
+] as const
+
+function quoted(actions: readonly string[]): string {
+  return actions.map((action) => `'${action}'`).join(', ')
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quoted(AUTOMATION_ACTION_TYPES_WITH_APPROVAL_CARD)}))
+  `).execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quoted(AUTOMATION_ACTION_TYPES_BEFORE_APPROVAL_CARD)}))
+  `).execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260705150100_add_send_columns_to_dingtalk_approval_card_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260705150100_add_send_columns_to_dingtalk_approval_card_deliveries.ts
@@ -1,0 +1,26 @@
+/**
+ * Migration: send-tracking columns for the approval-card ledger (A-2b, one-tap lock #3594).
+ * The owner-ratified spec requires a traceable ledger state/error when the send fails:
+ * `send_status` pending → sent | failed (card lifecycle `card_state` stays orthogonal — a card is
+ * only actionable while card_state='sent' AND send_status='sent'), `send_error` carries the reason.
+ * Unbound recipients never get a ledger row (nothing to anchor); their skip is recorded on the
+ * existing dingtalk_person_deliveries telemetry instead.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE dingtalk_approval_card_deliveries
+    ADD COLUMN IF NOT EXISTS send_status TEXT NOT NULL DEFAULT 'pending'
+      CHECK (send_status IN ('pending', 'sent', 'failed')),
+    ADD COLUMN IF NOT EXISTS send_error TEXT
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE dingtalk_approval_card_deliveries
+    DROP COLUMN IF EXISTS send_error,
+    DROP COLUMN IF EXISTS send_status
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1551,6 +1551,8 @@ export interface DingTalkApprovalCardDeliveriesTable {
   acted_action: string | null
   acted_by: string | null
   acted_at: NullableTimestamp
+  send_status: 'pending' | 'sent' | 'failed'
+  send_error: string | null
   created_at: CreatedAt
   updated_at: CreatedAt
 }

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -93,10 +93,11 @@ export async function findDingTalkApprovalCardDeliveryById(
 }
 
 /**
- * Atomic acted-claim: succeeds for exactly one caller while the card is still `sent`.
- * Returns the updated row for the winner, `null` for everyone else (duplicate callback, double
- * tap, or a card already superseded/expired) — losers re-read via `find…ById` to render the
- * real terminal state.
+ * Atomic acted-claim: succeeds for exactly one caller while the card is still `sent` AND was
+ * actually delivered (`send_status='sent'` — review P2: a pending/failed send never produced a
+ * live button, so nothing may claim it). Returns the updated row for the winner, `null` for
+ * everyone else (duplicate callback, double tap, undelivered card, or a card already
+ * superseded/expired) — losers re-read via `find…ById` to render the real terminal state.
  */
 export async function claimDingTalkApprovalCardDeliveryActed(
   query: QueryFn,
@@ -106,7 +107,7 @@ export async function claimDingTalkApprovalCardDeliveryActed(
   const result = await query(
     `UPDATE dingtalk_approval_card_deliveries
      SET card_state = 'acted', acted_action = $2, acted_by = $3, acted_at = NOW(), updated_at = NOW()
-     WHERE id = $1 AND card_state = 'sent'
+     WHERE id = $1 AND card_state = 'sent' AND send_status = 'sent'
      RETURNING ${RETURNING_COLUMNS}`,
     [id, input.action, input.actedBy],
   )

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -35,6 +35,8 @@ export interface DingTalkApprovalCardDeliveryRow {
   acted_action: string | null
   acted_by: string | null
   acted_at: Date | string | null
+  send_status: 'pending' | 'sent' | 'failed'
+  send_error: string | null
   created_at: Date | string
   updated_at: Date | string
 }
@@ -42,7 +44,7 @@ export interface DingTalkApprovalCardDeliveryRow {
 type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
 
 const RETURNING_COLUMNS =
-  'id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, card_state, acted_action, acted_by, acted_at, created_at, updated_at'
+  'id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, card_state, acted_action, acted_by, acted_at, send_status, send_error, created_at, updated_at'
 
 export interface InsertDingTalkApprovalCardDeliveryInput {
   /** Optional caller-supplied id; defaults to a fresh UUID. Doubles as the interactive-card outTrackId (Slice B). */
@@ -107,6 +109,38 @@ export async function claimDingTalkApprovalCardDeliveryActed(
      WHERE id = $1 AND card_state = 'sent'
      RETURNING ${RETURNING_COLUMNS}`,
     [id, input.action, input.actedBy],
+  )
+  return (result.rows[0] as DingTalkApprovalCardDeliveryRow | undefined) ?? null
+}
+
+/** A-2b: records a successful send — task_id from asyncsend_v2, send_status pending→sent. */
+export async function markDingTalkApprovalCardDeliverySent(
+  query: QueryFn,
+  id: string,
+  taskId: string | null,
+): Promise<DingTalkApprovalCardDeliveryRow | null> {
+  const result = await query(
+    `UPDATE dingtalk_approval_card_deliveries
+     SET send_status = 'sent', task_id = $2, send_error = NULL, updated_at = NOW()
+     WHERE id = $1 AND send_status = 'pending'
+     RETURNING ${RETURNING_COLUMNS}`,
+    [id, taskId],
+  )
+  return (result.rows[0] as DingTalkApprovalCardDeliveryRow | undefined) ?? null
+}
+
+/** A-2b: records a failed send — traceable per the owner-ratified spec (send_status + send_error). */
+export async function markDingTalkApprovalCardDeliverySendFailed(
+  query: QueryFn,
+  id: string,
+  error: string,
+): Promise<DingTalkApprovalCardDeliveryRow | null> {
+  const result = await query(
+    `UPDATE dingtalk_approval_card_deliveries
+     SET send_status = 'failed', send_error = $2, updated_at = NOW()
+     WHERE id = $1 AND send_status = 'pending'
+     RETURNING ${RETURNING_COLUMNS}`,
+    [id, error],
   )
   return (result.rows[0] as DingTalkApprovalCardDeliveryRow | undefined) ?? null
 }

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -641,6 +641,86 @@ export async function getDingTalkUserDetail(
   }
 }
 
+/**
+ * A-2b (one-tap lock #3594): action_card work notification — same corp-app channel as the markdown
+ * variant, but the OA `action_card` msgtype renders a tappable button (URL jump; in-chat callback
+ * buttons are the Slice-B interactive-card upgrade). Single-button form only.
+ */
+export interface DingTalkWorkNotificationActionCardInput {
+  userIds: string[]
+  title: string
+  /** Card body, markdown subset per the OA action_card contract. */
+  markdown: string
+  /** Button label (e.g. 查看并处理). */
+  singleTitle: string
+  /** Button target URL — the signed decision deep link. */
+  singleUrl: string
+}
+
+export async function sendDingTalkWorkNotificationActionCard(
+  accessToken: string,
+  input: DingTalkWorkNotificationActionCardInput,
+  config: DingTalkMessageConfig = readDingTalkMessageConfig(),
+  options?: DingTalkRequestOptions,
+): Promise<DingTalkWorkNotificationResult> {
+  const userIds = Array.from(new Set(
+    input.userIds
+      .map((userId) => String(userId ?? '').trim())
+      .filter(Boolean),
+  ))
+  const title = input.title.trim()
+  const markdown = input.markdown.trim()
+  const singleTitle = input.singleTitle.trim()
+  const singleUrl = input.singleUrl.trim()
+
+  if (userIds.length === 0) throw new Error('At least one DingTalk userId is required')
+  if (!title) throw new Error('DingTalk title is required')
+  if (!markdown) throw new Error('DingTalk markdown is required')
+  if (!singleTitle || !singleUrl) throw new Error('DingTalk action_card button title and url are required')
+
+  const payload = await requestDingTalkDirectoryJson(
+    `/topapi/message/corpconversation/asyncsend_v2?access_token=${encodeURIComponent(accessToken)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agent_id: Number.isNaN(Number(config.agentId)) ? config.agentId : Number(config.agentId),
+        userid_list: userIds.join(','),
+        to_all_user: false,
+        msg: {
+          msgtype: 'action_card',
+          action_card: {
+            title,
+            markdown,
+            single_title: singleTitle,
+            single_url: singleUrl,
+          },
+        },
+      }),
+    },
+    'Failed to send DingTalk action-card work notification',
+    config.baseUrl,
+    options,
+  )
+
+  const result = readNestedPayload(payload)
+  const taskIdValue = payload.task_id ?? payload.taskId ?? result.task_id ?? result.taskId
+  const requestIdValue = payload.request_id ?? payload.requestId ?? result.request_id ?? result.requestId
+  return {
+    taskId:
+      typeof taskIdValue === 'number'
+        ? String(taskIdValue)
+        : typeof taskIdValue === 'string'
+          ? taskIdValue
+              : undefined,
+    requestId:
+      typeof requestIdValue === 'string'
+        ? requestIdValue
+          : undefined,
+    raw: payload,
+  }
+}
+
 export async function sendDingTalkWorkNotification(
   accessToken: string,
   input: DingTalkWorkNotificationInput,

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -12,6 +12,9 @@ export type AutomationActionType =
   | 'send_email'
   | 'send_dingtalk_group_message'
   | 'send_dingtalk_person_message'
+  // A-2b (one-tap lock #3594): approval-card delivery — ledger-anchored action_card send whose
+  // recipient is FIXED from the approval.task_created event (never author-supplied).
+  | 'send_dingtalk_approval_card'
   | 'lock_record'
   | 'wait_for_callback'
   | 'condition_branch'
@@ -31,6 +34,7 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'send_email',
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
+  'send_dingtalk_approval_card',
   'lock_record',
   'wait_for_callback',
   'condition_branch',

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -19,8 +19,15 @@ import {
   DingTalkRequestError,
   fetchDingTalkAppAccessToken,
   sendDingTalkWorkNotification,
+  sendDingTalkWorkNotificationActionCard,
 } from '../integrations/dingtalk/client'
 import { readDingTalkMessageConfigFromRuntime } from '../integrations/dingtalk/work-notification-settings'
+import {
+  insertDingTalkApprovalCardDelivery,
+  markDingTalkApprovalCardDeliverySendFailed,
+  markDingTalkApprovalCardDeliverySent,
+} from '../integrations/dingtalk/approval-card-deliveries'
+import { createHmac } from 'crypto'
 import type { EventBus } from '../integration/events/event-bus'
 import {
   buildDingTalkMarkdown,
@@ -1660,6 +1667,9 @@ export class AutomationExecutor {
         case 'send_dingtalk_person_message':
           result = await this.executeSendDingTalkPersonMessage(action.config as unknown as SendDingTalkPersonMessageConfig, context)
           break
+        case 'send_dingtalk_approval_card':
+          result = await this.executeSendDingTalkApprovalCard(context)
+          break
         case 'lock_record':
           result = await this.executeLockRecord(action.config, context)
           break
@@ -2518,6 +2528,146 @@ export class AutomationExecutor {
         notificationStatus: result.status,
         recipientCount: recipients.length,
       },
+    }
+  }
+
+  /**
+   * A-2b (one-tap lock #3594, owner-ratified): approval-card delivery.
+   * - Only meaningful on approval.task_created rules: the recipient is FIXED from the trigger
+   *   event's assignee (rule authors cannot supply users — no misdelivery surface).
+   * - Ledger-first: the dingtalk_approval_card_deliveries row is written BEFORE the send (the
+   *   callback/decision-page anchor), task_id recorded on success, send_status/send_error make a
+   *   failed send traceable. Unbound recipients get a `skipped` row on the person-delivery
+   *   telemetry (no card row — nothing to anchor) and NEVER a guessed mapping.
+   * - The deep link carries ONLY the delivery id + an HMAC token (values-free): the decision page
+   *   resolves everything server-side through the card-delivery wrapper (§4/§5), never raw /actions.
+   */
+  private async executeSendDingTalkApprovalCard(context: ExecutionContext): Promise<AutomationStepResult> {
+    const actionType = 'send_dingtalk_approval_card' as const
+    const event = context.triggerEvent as {
+      eventType?: unknown
+      approval?: { instanceId?: unknown; requestNo?: unknown; templateId?: unknown }
+      task?: { nodeKey?: unknown; entryEpoch?: unknown; assigneeUserId?: unknown; sourceStep?: unknown }
+    } | null
+    const instanceId = typeof event?.approval?.instanceId === 'string' ? event.approval.instanceId : ''
+    const nodeKey = typeof event?.task?.nodeKey === 'string' ? event.task.nodeKey : ''
+    const assigneeUserId = typeof event?.task?.assigneeUserId === 'string' ? event.task.assigneeUserId : ''
+    if (event?.eventType !== 'approval.task_created' || !instanceId || !nodeKey || !assigneeUserId) {
+      return { actionType, status: 'failed', error: 'send_dingtalk_approval_card requires an approval.task_created trigger event' }
+    }
+
+    const baseUrl = resolveAutomationAppBaseUrl()
+    if (!baseUrl) {
+      return { actionType, status: 'failed', error: 'PUBLIC_APP_URL or APP_BASE_URL is required for the approval decision link' }
+    }
+    const linkSecret = (process.env.APPROVAL_CARD_LINK_SECRET ?? '').trim()
+    if (!linkSecret) {
+      return { actionType, status: 'failed', error: 'APPROVAL_CARD_LINK_SECRET is required for signed approval decision links' }
+    }
+
+    // Instance metadata for the card summary — ids/title/request_no only, NO form values.
+    const instanceResult = await this.deps.queryFn(
+      `SELECT title, request_no FROM approval_instances WHERE id = $1`,
+      [instanceId],
+    )
+    const instanceRow = (instanceResult.rows[0] ?? null) as { title?: string | null; request_no?: string | null } | null
+    if (!instanceRow) {
+      return { actionType, status: 'failed', error: 'Approval instance not found for the pending-task event' }
+    }
+    const approvalTitle = typeof instanceRow.title === 'string' && instanceRow.title.trim() ? instanceRow.title.trim() : '审批待办'
+    const requestNo = typeof instanceRow.request_no === 'string' ? instanceRow.request_no.trim() : ''
+
+    // Recipient mapping: same directory-link lateral the person-message action uses; fail-closed.
+    const recipientResult = await this.deps.queryFn(
+      `SELECT u.id AS local_user_id,
+              u.is_active AS local_user_active,
+              linked.external_user_id AS dingtalk_user_id
+         FROM users u
+         LEFT JOIN LATERAL (
+           SELECT a.external_user_id
+             FROM directory_account_links l
+             JOIN directory_accounts a ON a.id = l.directory_account_id
+            WHERE l.local_user_id = u.id
+              AND l.link_status = 'linked'
+              AND a.provider = 'dingtalk'
+              AND a.is_active = TRUE
+            ORDER BY a.updated_at DESC
+            LIMIT 1
+         ) linked ON TRUE
+        WHERE u.id = $1`,
+      [assigneeUserId],
+    )
+    const recipientRow = (recipientResult.rows[0] ?? null) as { local_user_active?: boolean; dingtalk_user_id?: string | null } | null
+    const dingtalkUserId = typeof recipientRow?.dingtalk_user_id === 'string' ? recipientRow.dingtalk_user_id.trim() : ''
+    if (!recipientRow || recipientRow.local_user_active !== true || !dingtalkUserId) {
+      await recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
+        localUserId: assigneeUserId,
+        sourceType: 'automation',
+        subject: `审批待办：${approvalTitle}`,
+        content: '(approval card skipped)',
+        success: false,
+        status: 'skipped',
+        errorMessage: 'DingTalk account is not linked or user is inactive',
+        automationRuleId: context.ruleId,
+        recordId: context.recordId,
+        initiatedBy: context.actorId ?? null,
+      })
+      return { actionType, status: 'failed', error: 'Recipient has no linked, active DingTalk account (skipped — mappings are never guessed)' }
+    }
+
+    // Ledger FIRST — the row is the only legitimate delivery → instance anchor.
+    const entryEpochRaw = event.task?.entryEpoch
+    const sourceStepRaw = event.task?.sourceStep
+    const delivery = await insertDingTalkApprovalCardDelivery(this.deps.queryFn, {
+      instanceId,
+      nodeKey,
+      recipientUserId: assigneeUserId,
+      recipientDingTalkUserId: dingtalkUserId,
+      deliveryKind: 'work_notice_action_card',
+    })
+
+    const token = createHmac('sha256', linkSecret).update(delivery.id).digest('hex').slice(0, 32)
+    const decisionUrl = buildAppLink(baseUrl, '/m/approval-decision', { d: delivery.id, t: token })
+    const markdownLines = [
+      `### 审批待办：${approvalTitle}`,
+      requestNo ? `- 编号：${requestNo}` : '',
+      `- 节点：${nodeKey}${typeof sourceStepRaw === 'number' ? `（第 ${sourceStepRaw} 步）` : ''}`,
+      '',
+      '请点击下方按钮处理。',
+    ].filter(Boolean)
+
+    try {
+      const messageConfig = await readDingTalkMessageConfigFromRuntime()
+      const accessToken = await fetchDingTalkAppAccessToken(messageConfig, { fetchFn: this.deps.fetchFn })
+      const result = await sendDingTalkWorkNotificationActionCard(
+        accessToken,
+        {
+          userIds: [dingtalkUserId],
+          title: `审批待办：${approvalTitle}`,
+          markdown: markdownLines.join('\n'),
+          singleTitle: '查看并处理',
+          singleUrl: decisionUrl,
+        },
+        messageConfig,
+        { fetchFn: this.deps.fetchFn },
+      )
+      await markDingTalkApprovalCardDeliverySent(this.deps.queryFn, delivery.id, result.taskId ?? null)
+      return {
+        actionType,
+        status: 'success',
+        output: {
+          deliveryId: delivery.id,
+          instanceId,
+          nodeKey,
+          entryEpoch: typeof entryEpochRaw === 'number' ? entryEpochRaw : null,
+          recipientUserId: assigneeUserId,
+          taskId: result.taskId ?? null,
+        },
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      await markDingTalkApprovalCardDeliverySendFailed(this.deps.queryFn, delivery.id, errorMessage).catch(() => null)
+      return { actionType, status: 'failed', error: errorMessage, output: { deliveryId: delivery.id } }
     }
   }
 

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -125,7 +125,28 @@ const APPROVAL_COMPLETION_TRIGGER_EVENT_TYPES: readonly string[] = [
 // trigger_config.templateId; record-less; v1 allows ONLY non-record-targeting side effects (no record
 // writes / start_approval / delete_record), so no automation loop can form through pending events.
 const APPROVAL_TASK_CREATED_TRIGGER = 'approval.task_created'
-const APPROVAL_TASK_CREATED_ALLOWED_ACTION_TYPES: ReadonlySet<string> = APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES
+// A-2b: the card action joins the notification family HERE ONLY — it is meaningless (and rejected)
+// on every other trigger because its recipient comes from the pending-task event.
+const APPROVAL_CARD_ACTION_TYPE = 'send_dingtalk_approval_card'
+const APPROVAL_TASK_CREATED_ALLOWED_ACTION_TYPES: ReadonlySet<string> = new Set([
+  ...APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES,
+  APPROVAL_CARD_ACTION_TYPE,
+])
+
+/** A-2b placement gate: send_dingtalk_approval_card only mounts on approval.task_created rules. */
+function validateApprovalCardActionPlacement(
+  triggerType: string,
+  actionType: string,
+  nestedActions: AutomationAction[],
+): string | null {
+  if (triggerType === APPROVAL_TASK_CREATED_TRIGGER) return null
+  const usesCard = actionType === APPROVAL_CARD_ACTION_TYPE
+    || nestedActions.some((action) => action.type === APPROVAL_CARD_ACTION_TYPE)
+  if (usesCard) {
+    return 'send_dingtalk_approval_card is only allowed on approval.task_created rules (its recipient comes from the pending-task event)'
+  }
+  return null
+}
 
 const APPROVAL_TEMPLATE_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -986,6 +1007,9 @@ export class AutomationService {
     )
     if (approvalTaskCreatedError) throw new AutomationRuleValidationError(approvalTaskCreatedError)
 
+    const cardPlacementError = validateApprovalCardActionPlacement(input.triggerType, input.actionType, actionsForValidation)
+    if (cardPlacementError) throw new AutomationRuleValidationError(cardPlacementError)
+
     // date_field rules carry a SERVER-SET activation `effectiveAt` (= now) so the firing floor is the rule's
     // activation, not its row createdAt. Spread-then-set overwrites any client-supplied effectiveAt (no backfill bypass).
     const persistedTriggerConfig: Record<string, unknown> =
@@ -1249,18 +1273,22 @@ export class AutomationService {
       const existingForApproval = existingRuleSnapshot !== undefined ? existingRuleSnapshot : await this.getRule(ruleId)
       if (!existingForApproval || existingForApproval.sheet_id !== sheetId) return null
       const nextTriggerType = input.triggerType ?? existingForApproval.trigger_type
+      const nextTriggerConfig = (
+        input.triggerConfig !== undefined ? input.triggerConfig : existingForApproval.trigger_config
+      ) as Record<string, unknown> | null
+      const nextActionType = input.actionType ?? existingForApproval.action_type
+      const nextActionConfig = (input.actionConfig ?? existingForApproval.action_config) as Record<string, unknown>
+      const nextActions = input.actions !== undefined ? input.actions : existingForApproval.actions ?? null
+      const nextExecutionMode = input.executionMode !== undefined
+        ? normalizeExecutionMode(input.executionMode)
+        : existingForApproval.execution_mode ?? null
+      const nextConditions = input.conditions !== undefined ? input.conditions : existingForApproval.conditions ?? null
+      const approvalActions = collectNestedAutomationActions(nextActionType, nextActionConfig, nextActions, nextExecutionMode)
+      // A-2b: placement gate runs for EVERY resulting shape (a card action smuggled onto a
+      // non-task_created rule via a partial update must not survive either).
+      const cardPlacementError = validateApprovalCardActionPlacement(nextTriggerType, nextActionType, approvalActions)
+      if (cardPlacementError) throw new AutomationRuleValidationError(cardPlacementError)
       if (nextTriggerType === APPROVAL_COMPLETED_TRIGGER || nextTriggerType === APPROVAL_TASK_CREATED_TRIGGER) {
-        const nextTriggerConfig = (
-          input.triggerConfig !== undefined ? input.triggerConfig : existingForApproval.trigger_config
-        ) as Record<string, unknown> | null
-        const nextActionType = input.actionType ?? existingForApproval.action_type
-        const nextActionConfig = (input.actionConfig ?? existingForApproval.action_config) as Record<string, unknown>
-        const nextActions = input.actions !== undefined ? input.actions : existingForApproval.actions ?? null
-        const nextExecutionMode = input.executionMode !== undefined
-          ? normalizeExecutionMode(input.executionMode)
-          : existingForApproval.execution_mode ?? null
-        const nextConditions = input.conditions !== undefined ? input.conditions : existingForApproval.conditions ?? null
-        const approvalActions = collectNestedAutomationActions(nextActionType, nextActionConfig, nextActions, nextExecutionMode)
         const approvalCompletedError = await this.validateApprovalCompletedRuleAtSave(
           nextTriggerType,
           nextTriggerConfig,

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -63,6 +63,7 @@ import {
   type AutomationApprovalBridgeRow,
 } from './automation-approval-bridge-service'
 import type { ApprovalCompletionEventV1 } from '../services/ApprovalCompletionEvent'
+import type { ApprovalTaskCreatedEventV1 } from '../services/ApprovalTaskCreatedEvent'
 import { applyTemplateVisibilityFilter, type ApprovalTemplateVisibilityActor } from '../services/ApprovalProductService'
 import { metrics } from '../metrics/metrics'
 import {
@@ -97,6 +98,7 @@ const VALID_TRIGGER_TYPES = new Set([
   'webhook.received',
   'form.submitted',
   'approval.completed',
+  'approval.task_created',
 ])
 
 // ── T1-3 approval.completed trigger (first-batch ballot 2026-07-01) ────────
@@ -118,6 +120,13 @@ const APPROVAL_COMPLETION_TRIGGER_EVENT_TYPES: readonly string[] = [
   'approval.revoked',
   'approval.cancelled',
 ]
+// ── A-2a approval.task_created trigger (one-tap lock #3594 implementation decision, owner-ratified
+// 2026-07-05). Same dedicated template-keyed dispatch as approval.completed: routed by REQUIRED
+// trigger_config.templateId; record-less; v1 allows ONLY non-record-targeting side effects (no record
+// writes / start_approval / delete_record), so no automation loop can form through pending events.
+const APPROVAL_TASK_CREATED_TRIGGER = 'approval.task_created'
+const APPROVAL_TASK_CREATED_ALLOWED_ACTION_TYPES: ReadonlySet<string> = APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES
+
 const APPROVAL_TEMPLATE_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 /** Q6: outcomes filter — omitted/invalid persisted config degrades to approved-only (fail-closed default). */
@@ -879,6 +888,20 @@ export class AutomationService {
       this.subscriptionIds.push(id)
     }
 
+    // A-2a: pending-task events ride their own subscription — one event per new actionable
+    // assignment/recipient, routed by templateId like approval.completed.
+    {
+      const id = this.eventBus.subscribe<ApprovalTaskCreatedEventV1>(
+        'approval.task_created',
+        (payload) => {
+          this.handleApprovalTaskCreatedTrigger(payload).catch((err) => {
+            logger.error('Automation approval.task_created trigger error', err instanceof Error ? err : undefined)
+          })
+        },
+      )
+      this.subscriptionIds.push(id)
+    }
+
     logger.info('AutomationService initialized (V1)')
   }
 
@@ -952,6 +975,16 @@ export class AutomationService {
       input.createdBy ?? null,
     )
     if (approvalCompletedError) throw new AutomationRuleValidationError(approvalCompletedError)
+
+    const approvalTaskCreatedError = await this.validateApprovalTaskCreatedRuleAtSave(
+      input.triggerType,
+      (input.triggerConfig ?? null) as Record<string, unknown> | null,
+      input.actionType,
+      actionsForValidation,
+      input.conditions ?? null,
+      input.createdBy ?? null,
+    )
+    if (approvalTaskCreatedError) throw new AutomationRuleValidationError(approvalTaskCreatedError)
 
     // date_field rules carry a SERVER-SET activation `effectiveAt` (= now) so the firing floor is the rule's
     // activation, not its row createdAt. Spread-then-set overwrites any client-supplied effectiveAt (no backfill bypass).
@@ -1216,7 +1249,7 @@ export class AutomationService {
       const existingForApproval = existingRuleSnapshot !== undefined ? existingRuleSnapshot : await this.getRule(ruleId)
       if (!existingForApproval || existingForApproval.sheet_id !== sheetId) return null
       const nextTriggerType = input.triggerType ?? existingForApproval.trigger_type
-      if (nextTriggerType === APPROVAL_COMPLETED_TRIGGER) {
+      if (nextTriggerType === APPROVAL_COMPLETED_TRIGGER || nextTriggerType === APPROVAL_TASK_CREATED_TRIGGER) {
         const nextTriggerConfig = (
           input.triggerConfig !== undefined ? input.triggerConfig : existingForApproval.trigger_config
         ) as Record<string, unknown> | null
@@ -1237,6 +1270,15 @@ export class AutomationService {
           existingForApproval.created_by,
         )
         if (approvalCompletedError) throw new AutomationRuleValidationError(approvalCompletedError)
+        const approvalTaskCreatedError = await this.validateApprovalTaskCreatedRuleAtSave(
+          nextTriggerType,
+          nextTriggerConfig,
+          nextActionType,
+          approvalActions,
+          nextConditions,
+          existingForApproval.created_by,
+        )
+        if (approvalTaskCreatedError) throw new AutomationRuleValidationError(approvalTaskCreatedError)
       }
     }
 
@@ -1762,6 +1804,54 @@ export class AutomationService {
     if (!createdBy) return 'approval.completed rules require an authenticated creator'
     if (!(await this.approvalCompletedCreatorAuthorized(createdBy))) {
       return 'approval.completed rules require the creator to hold approvals:read for the configured template'
+    }
+    if (!(await this.approvalTemplateVisibleToCreator(templateId, createdBy))) {
+      return 'trigger_config.templateId must reference an approval template visible to the rule creator'
+    }
+    return null
+  }
+
+  /**
+   * A-2a mirror of validateApprovalCompletedRuleAtSave for approval.task_created rules: REQUIRED existing
+   * templateId, no conditions (record-less v1), side-effect-only action allowlist (structurally no record
+   * writes / start_approval / delete_record — the owner-ratified v1 boundary), and the same two creator
+   * legs (approvals:read + template visibility) checked at save AND re-checked at fire.
+   */
+  private async validateApprovalTaskCreatedRuleAtSave(
+    triggerType: string,
+    triggerConfig: Record<string, unknown> | null,
+    actionType: string,
+    nestedActions: AutomationAction[],
+    conditions: ConditionGroup | null | undefined,
+    createdBy: string | null,
+  ): Promise<string | null> {
+    if (triggerType !== APPROVAL_TASK_CREATED_TRIGGER) return null
+    const config = triggerConfig ?? {}
+    const templateIdRaw = config.templateId
+    const templateId = typeof templateIdRaw === 'string' ? templateIdRaw.trim() : ''
+    if (!templateId) return 'trigger_config.templateId is required for approval.task_created rules'
+    if (!APPROVAL_TEMPLATE_UUID_RE.test(templateId)) {
+      return 'trigger_config.templateId must reference an existing approval template'
+    }
+    const template = await this.queryFn('SELECT id FROM approval_templates WHERE id = $1', [templateId])
+    if (template.rows.length === 0) {
+      return 'trigger_config.templateId must reference an existing approval template'
+    }
+    if (conditions) {
+      const nodes = Array.isArray(conditions.conditions) ? conditions.conditions : null
+      if (!nodes || nodes.length > 0) {
+        return 'approval.task_created rules cannot carry conditions (no record context in v1)'
+      }
+    }
+    const actionTypes = new Set<string>([actionType, ...nestedActions.map((action) => action.type)])
+    for (const type of actionTypes) {
+      if (!APPROVAL_TASK_CREATED_ALLOWED_ACTION_TYPES.has(type)) {
+        return `action ${type} is not allowed on approval.task_created rules (record-less v1 allows: ${[...APPROVAL_TASK_CREATED_ALLOWED_ACTION_TYPES].join(', ')})`
+      }
+    }
+    if (!createdBy) return 'approval.task_created rules require an authenticated creator'
+    if (!(await this.approvalCompletedCreatorAuthorized(createdBy))) {
+      return 'approval.task_created rules require the creator to hold approvals:read for the configured template'
     }
     if (!(await this.approvalTemplateVisibleToCreator(templateId, createdBy))) {
       return 'trigger_config.templateId must reference an approval template visible to the rule creator'
@@ -2432,6 +2522,64 @@ export class AutomationService {
   }
 
   /**
+   * A-2a dispatch for approval.task_created — one event per NEW actionable assignment/recipient
+   * (eventId embeds instanceId+nodeKey+entryEpoch+assigneeUserId, so a return/jump's fresh round
+   * re-fires while duplicate deliveries of the same round dedupe via the T2-6 ledger). Mirrors the
+   * completion dispatch: template-keyed routing, fire-time re-check of BOTH creator legs, per-rule
+   * exactly-once claim, record-less payload, and the same recursion-depth guard.
+   */
+  async handleApprovalTaskCreatedTrigger(event: ApprovalTaskCreatedEventV1): Promise<void> {
+    if (event.version !== 1 || event.source !== 'approval-product') return
+    if (event.eventType !== APPROVAL_TASK_CREATED_TRIGGER) return
+    const templateId = event.approval.templateId
+    if (!templateId) {
+      logger.debug(`approval task ${event.eventId} carries no templateId; approval.task_created rules cannot match (v1 out-of-contract)`)
+      return
+    }
+    const rules = await this.loadEnabledApprovalTaskCreatedRules(templateId)
+    if (rules.length === 0) return
+
+    const parentDepth = await this.approvalBridgeAutomationDepth(event.approval.instanceId)
+    const depth = parentDepth === null ? 0 : parentDepth + 1
+    if (depth >= MAX_AUTOMATION_DEPTH) {
+      logger.warn(`Automation recursion guard triggered (depth=${depth}) for approval.task_created on template ${templateId}`)
+      return
+    }
+
+    this.kickEventDedupLedgerSweepIfDue(Date.now())
+    for (const rule of rules) {
+      if (!(await this.approvalCompletedCreatorAuthorized(rule.created_by))) {
+        logger.warn(`approval.task_created rule ${rule.id} skipped: creator lacks approvals:read at fire time`)
+        continue
+      }
+      if (!(await this.approvalTemplateVisibleToCreator(templateId, rule.created_by))) {
+        logger.warn(`approval.task_created rule ${rule.id} skipped: template ${templateId} not visible to creator at fire time`)
+        continue
+      }
+      try {
+        const claimed = await this.claimEventDelivery(rule.id, `approval.task_created:${event.eventId}`)
+        if (!claimed) continue
+        const payload: AutomationEventPayload & Record<string, unknown> = {
+          sheetId: rule.sheet_id,
+          recordId: '',
+          data: {},
+          actorId: null,
+          _automationDepth: depth,
+          eventId: event.eventId,
+          eventType: event.eventType,
+          occurredAt: event.occurredAt,
+          approval: event.approval,
+          task: event.task,
+          requester: event.requester,
+        }
+        await this.executeRule(toExecutorRule(rule), payload)
+      } catch (err) {
+        logger.error(`approval.task_created rule ${rule.id} failed`, err instanceof Error ? err : undefined)
+      }
+    }
+  }
+
+  /**
    * Q4(b) helper: the parent automation depth for a bridge-originated approval instance, or null when no
    * bridge exists (human/API-started approval — a fresh chain). A bridge whose trigger_event carries no
    * depth counts as depth 0 (chain start). Lookup errors degrade to null — safe because approval.completed
@@ -2797,6 +2945,19 @@ export class AutomationService {
       .selectFrom('automation_rules')
       .selectAll()
       .where('trigger_type', '=', APPROVAL_COMPLETED_TRIGGER)
+      .where('enabled', '=', true)
+      .where(sql<string>`trigger_config->>'templateId'`, '=', templateId)
+      .orderBy('created_at', 'asc')
+      .execute()
+    return rows.map((r) => this.mapRow(r))
+  }
+
+  /** A-2a: same template-keyed routing for approval.task_created rules (see loadEnabledApprovalCompletedRules). */
+  async loadEnabledApprovalTaskCreatedRules(templateId: string): Promise<AutomationRule[]> {
+    const rows = await this.db
+      .selectFrom('automation_rules')
+      .selectAll()
+      .where('trigger_type', '=', APPROVAL_TASK_CREATED_TRIGGER)
       .where('enabled', '=', true)
       .where(sql<string>`trigger_config->>'templateId'`, '=', templateId)
       .orderBy('created_at', 'asc')

--- a/packages/core-backend/src/multitable/automation-triggers.ts
+++ b/packages/core-backend/src/multitable/automation-triggers.ts
@@ -14,6 +14,7 @@ export type AutomationTriggerType =
   | 'webhook.received'
   | 'form.submitted'
   | 'approval.completed'
+  | 'approval.task_created'
 
 export const ALL_TRIGGER_TYPES: AutomationTriggerType[] = [
   'record.created',
@@ -26,6 +27,7 @@ export const ALL_TRIGGER_TYPES: AutomationTriggerType[] = [
   'webhook.received',
   'form.submitted',
   'approval.completed',
+  'approval.task_created',
 ]
 
 /** Config shape for field.value_changed */
@@ -62,6 +64,16 @@ export interface WebhookReceivedConfig {
 export interface ApprovalCompletedConfig {
   templateId: string
   outcomes?: Array<'approved' | 'rejected' | 'revoked' | 'cancelled'>
+}
+
+/**
+ * Config shape for approval.task_created (A-2a, one-tap lock #3594 implementation decision).
+ * Same template-keyed dedicated dispatch path as approval.completed — one event per NEW actionable
+ * assignment/recipient; NOT a multitable record event. templateId is REQUIRED; a pending event whose
+ * instance carries no templateId is v1 out-of-contract (debug log, no match).
+ */
+export interface ApprovalTaskCreatedConfig {
+  templateId: string
 }
 
 export interface AutomationTrigger {

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -16,6 +16,10 @@ import { rbacGuard, rbacGuardAny } from '../rbac/rbac'
 import { REFUND_WORKFLOW_KEY, type AfterSalesApprovalBridgeService } from '../services/AfterSalesApprovalBridgeService'
 import { ApprovalBridgeService, ServiceError } from '../services/ApprovalBridgeService'
 import {
+  executeApprovalActionFromCardDelivery,
+  getApprovalCardDeliverySummary,
+} from '../services/ApprovalCardDeliveryAction'
+import {
   ApprovalProductService,
   resolveApprovalListPaging,
   type ApprovalTemplateVisibilityActor,
@@ -1555,6 +1559,85 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         'APPROVAL_BULK_REASSIGN_FAILED',
         'Failed to bulk reassign approvals',
       )
+    }
+  })
+
+  // ── A-3/A-4 core (one-tap lock #3594 §4/§5): card-delivery decision surface ──────────────
+  // The mobile decision page's ONLY api. Resolution is ledger-only (deliveryId + HMAC token);
+  // instance ids never ride the wire here. Raw /api/approvals/:id/actions stays untouched — and the
+  // page is FORBIDDEN from calling it (tripwire in the FE spec).
+  r.get('/api/approval-card-deliveries/:deliveryId', authenticate, rbacGuard('approvals', 'act'), async (req: Request, res: Response) => {
+    try {
+      const userId = resolveApprovalActorId(req)
+      if (!userId) {
+        return res.status(401).json(approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'))
+      }
+      const token = typeof req.query?.t === 'string' ? req.query.t : ''
+      const result = await getApprovalCardDeliverySummary(
+        { query: (sql, params) => pool.query(sql, params) },
+        { deliveryId: String(req.params.deliveryId ?? ''), token, viewerUserId: userId },
+      )
+      if (result.status === 'not_found') {
+        // Invalid token and unknown id are indistinguishable on purpose (no existence oracle).
+        return res.status(404).json(approvalErrorResponse('APPROVAL_CARD_DELIVERY_NOT_FOUND', 'Card delivery not found'))
+      }
+      return res.json({ ok: true, data: result.summary })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_CARD_DELIVERY_SUMMARY_FAILED', 'Failed to load card delivery')
+    }
+  })
+
+  r.post('/api/approval-card-deliveries/:deliveryId/actions', authenticate, rbacGuard('approvals', 'act'), async (req: Request, res: Response) => {
+    try {
+      const userId = resolveApprovalActorId(req)
+      if (!userId) {
+        return res.status(401).json(approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'))
+      }
+      const decision = req.body?.decision
+      if (decision !== 'approve' && decision !== 'reject') {
+        return res.status(400).json({
+          error: { code: 'VALIDATION_ERROR', message: 'decision must be approve or reject' },
+        })
+      }
+      const token = typeof req.body?.t === 'string' ? req.body.t : ''
+      const comment = typeof req.body?.comment === 'string' ? req.body.comment : undefined
+      const outcome = await executeApprovalActionFromCardDelivery(
+        {
+          query: (sql, params) => pool.query(sql, params),
+          approvals: getProductService(),
+        },
+        {
+          deliveryId: String(req.params.deliveryId ?? ''),
+          token,
+          decision,
+          comment,
+          actor: {
+            userId,
+            userName: resolveApprovalActorName(req, userId),
+            roles: resolveApprovalActorRoles(req),
+            ip: req.ip || null,
+            userAgent: req.get('user-agent') || null,
+          },
+        },
+      )
+      if (outcome.status === 'not_found') {
+        return res.status(404).json(approvalErrorResponse('APPROVAL_CARD_DELIVERY_NOT_FOUND', 'Card delivery not found'))
+      }
+      if (outcome.status === 'stale') {
+        return res.status(409).json({
+          error: { code: 'APPROVAL_CARD_DELIVERY_STALE', message: 'This card is no longer actionable' },
+          data: outcome.summary,
+        })
+      }
+      if (outcome.status === 'engine_rejected') {
+        return res.status(outcome.httpStatus >= 400 && outcome.httpStatus < 600 ? outcome.httpStatus : 400).json({
+          error: { code: outcome.code, message: outcome.message },
+          data: outcome.summary,
+        })
+      }
+      return res.json({ ok: true, data: outcome.summary })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_CARD_ACTION_FAILED', 'Failed to submit card decision')
     }
   })
 

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -1,0 +1,194 @@
+/**
+ * A-4 core (one-tap lock #3594 §4): the card-delivery action wrapper — the ONLY execution path for
+ * card-originated approval decisions. Both fronts share it: the Slice-A mobile decision page
+ * (session actor) and the Slice-B Stream callback (DingTalk actor, mapped fail-closed).
+ *
+ * Hard rules it encodes (owner-ratified):
+ * - Resolution is LEDGER-ONLY: deliveryId(+HMAC token) → dingtalk_approval_card_deliveries →
+ *   instance_id. Payload-supplied instance ids never exist on this surface.
+ * - Zero bypass: the decision funnels into ApprovalProductService.dispatchAction — assignee check,
+ *   reject-comment-required, nodeEntryEpoch round-scoping and version conflicts apply untouched.
+ * - Channel attribution is injected SERVER-SIDE (`channelOrigin` → approval_records.metadata);
+ *   HTTP bodies never carry it.
+ * - A card is actionable only while card_state='sent' AND send_status='sent' (review P2).
+ */
+import { createHmac, timingSafeEqual } from 'crypto'
+
+import type { ApprovalProductService } from './ApprovalProductService'
+import {
+  claimDingTalkApprovalCardDeliveryActed,
+  findDingTalkApprovalCardDeliveryById,
+  type DingTalkApprovalCardDeliveryRow,
+} from '../integrations/dingtalk/approval-card-deliveries'
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+export type ApprovalCardDecision = 'approve' | 'reject'
+
+export interface ApprovalCardDeliverySummary {
+  deliveryId: string
+  cardState: DingTalkApprovalCardDeliveryRow['card_state']
+  sendStatus: DingTalkApprovalCardDeliveryRow['send_status']
+  nodeKey: string
+  recipientUserId: string
+  viewerIsRecipient: boolean
+  /** card live + send delivered + instance still pending — the page may offer 同意/拒绝. */
+  actionable: boolean
+  approval: {
+    instanceId: string
+    title: string | null
+    requestNo: string | null
+    status: string
+    currentNodeKey: string | null
+    /** Mirrors the engine's hard gate so the page can make the comment required BEFORE submit. */
+    rejectCommentRequired: boolean
+  }
+  actedAction: string | null
+  actedAt: string | null
+}
+
+export type ApprovalCardActionOutcome =
+  | { status: 'ok'; summary: ApprovalCardDeliverySummary }
+  | { status: 'not_found' }
+  | { status: 'stale'; summary: ApprovalCardDeliverySummary }
+  | { status: 'engine_rejected'; code: string; message: string; httpStatus: number; summary: ApprovalCardDeliverySummary }
+
+/**
+ * Deep-link token: HMAC-SHA256(deliveryId, APPROVAL_CARD_LINK_SECRET) truncated to 32 hex chars —
+ * matches the executor's link composition exactly. Fail-closed without the secret.
+ */
+export function verifyApprovalCardLinkToken(deliveryId: string, token: string): boolean {
+  const secret = (process.env.APPROVAL_CARD_LINK_SECRET ?? '').trim()
+  if (!secret || !deliveryId || !token || token.length !== 32) return false
+  const expected = createHmac('sha256', secret).update(deliveryId).digest('hex').slice(0, 32)
+  const a = Buffer.from(expected, 'utf8')
+  const b = Buffer.from(token, 'utf8')
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+interface InstanceSummaryRow {
+  id: string
+  title: string | null
+  request_no: string | null
+  status: string
+  current_node_key: string | null
+  policy_snapshot: unknown
+}
+
+function rejectCommentRequiredFromPolicy(policySnapshot: unknown): boolean {
+  if (policySnapshot && typeof policySnapshot === 'object' && !Array.isArray(policySnapshot)) {
+    const value = (policySnapshot as Record<string, unknown>).rejectCommentRequired
+    // The engine treats anything but an explicit false as required — mirror that default.
+    return value !== false
+  }
+  return true
+}
+
+async function buildSummary(
+  query: QueryFn,
+  delivery: DingTalkApprovalCardDeliveryRow,
+  viewerUserId: string,
+): Promise<ApprovalCardDeliverySummary | null> {
+  const result = await query(
+    `SELECT id, title, request_no, status, current_node_key, policy_snapshot
+       FROM approval_instances WHERE id = $1`,
+    [delivery.instance_id],
+  )
+  const instance = (result.rows[0] ?? null) as InstanceSummaryRow | null
+  if (!instance) return null
+  return {
+    deliveryId: delivery.id,
+    cardState: delivery.card_state,
+    sendStatus: delivery.send_status,
+    nodeKey: delivery.node_key,
+    recipientUserId: delivery.recipient_user_id,
+    viewerIsRecipient: delivery.recipient_user_id === viewerUserId,
+    actionable:
+      delivery.card_state === 'sent'
+      && delivery.send_status === 'sent'
+      && instance.status === 'pending',
+    approval: {
+      instanceId: instance.id,
+      title: instance.title,
+      requestNo: instance.request_no,
+      status: instance.status,
+      currentNodeKey: instance.current_node_key,
+      rejectCommentRequired: rejectCommentRequiredFromPolicy(instance.policy_snapshot),
+    },
+    actedAction: delivery.acted_action,
+    actedAt: delivery.acted_at ? new Date(delivery.acted_at as string | Date).toISOString() : null,
+  }
+}
+
+export async function getApprovalCardDeliverySummary(
+  deps: { query: QueryFn },
+  input: { deliveryId: string; token: string; viewerUserId: string },
+): Promise<{ status: 'ok'; summary: ApprovalCardDeliverySummary } | { status: 'not_found' }> {
+  if (!verifyApprovalCardLinkToken(input.deliveryId, input.token)) return { status: 'not_found' }
+  const delivery = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
+  if (!delivery) return { status: 'not_found' }
+  const summary = await buildSummary(deps.query, delivery, input.viewerUserId)
+  if (!summary) return { status: 'not_found' }
+  return { status: 'ok', summary }
+}
+
+export async function executeApprovalActionFromCardDelivery(
+  deps: { query: QueryFn; approvals: Pick<ApprovalProductService, 'dispatchAction'> },
+  input: {
+    deliveryId: string
+    token: string
+    decision: ApprovalCardDecision
+    comment?: string
+    actor: { userId: string; userName: string; roles?: string[]; ip?: string | null; userAgent?: string | null }
+  },
+): Promise<ApprovalCardActionOutcome> {
+  if (!verifyApprovalCardLinkToken(input.deliveryId, input.token)) return { status: 'not_found' }
+  const delivery = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
+  if (!delivery) return { status: 'not_found' }
+
+  const preSummary = await buildSummary(deps.query, delivery, input.actor.userId)
+  if (!preSummary) return { status: 'not_found' }
+  if (!preSummary.actionable) return { status: 'stale', summary: preSummary }
+
+  try {
+    await deps.approvals.dispatchAction(
+      delivery.instance_id,
+      {
+        action: input.decision,
+        comment: input.comment,
+        // A-4: server-side attribution — HTTP bodies never carry this (see ApprovalActionRequest).
+        channelOrigin: { channel: 'dingtalk_card', cardDeliveryId: delivery.id },
+      },
+      {
+        userId: input.actor.userId,
+        userName: input.actor.userName,
+        roles: input.actor.roles ?? [],
+        ip: input.actor.ip ?? null,
+        userAgent: input.actor.userAgent ?? null,
+      },
+    )
+  } catch (error) {
+    const err = error as { statusCode?: number; status?: number; code?: string; message?: string }
+    const summary = (await (async () => {
+      const fresh = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
+      return fresh ? buildSummary(deps.query, fresh, input.actor.userId) : null
+    })()) ?? preSummary
+    return {
+      status: 'engine_rejected',
+      code: typeof err.code === 'string' ? err.code : 'APPROVAL_ACTION_FAILED',
+      message: typeof err.message === 'string' ? err.message : 'Approval action failed',
+      httpStatus: typeof err.statusCode === 'number' ? err.statusCode : typeof err.status === 'number' ? err.status : 400,
+      summary,
+    }
+  }
+
+  // Engine success — claim the card's terminal state. A lost race (concurrent duplicate) is fine:
+  // the ledger already reflects the real terminal state; re-read and return it.
+  await claimDingTalkApprovalCardDeliveryActed(deps.query, delivery.id, {
+    action: input.decision,
+    actedBy: input.actor.userId,
+  })
+  const fresh = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
+  const summary = fresh ? await buildSummary(deps.query, fresh, input.actor.userId) : null
+  return { status: 'ok', summary: summary ?? preSummary }
+}

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -73,6 +73,12 @@ import {
   type ApprovalCompletionEventV1,
   type ApprovalCompletionTransitionSnapshot,
 } from './ApprovalCompletionEvent'
+import {
+  buildApprovalTaskCreatedEvent,
+  emitApprovalTaskCreatedEvent,
+  type ApprovalTaskCreatedInstanceSnapshot,
+  type ApprovalTaskCreatedTaskSnapshot,
+} from './ApprovalTaskCreatedEvent'
 import { getApprovalRecordProjectionService } from '../multitable/approval-record-projection-service'
 import { Logger } from '../core/logger'
 import { eventBus } from '../integration/events/event-bus'
@@ -3453,6 +3459,8 @@ export class ApprovalProductService {
     }
 
     let completionEvent: ApprovalCompletionEventV1 | null = null
+    // A-2a: user-typed assignment rows created in this transaction — emitted post-commit.
+    const createdTaskEvents: ApprovalTaskCreatedTaskSnapshot[] = []
     let client: ApprovalDbClient | null = null
     try {
       client = await pool.connect()
@@ -3494,7 +3502,7 @@ export class ApprovalProductService {
       // ACTIVATION (nodeEntryEpoch §4·A): initial node activation mints a fresh epoch. The
       // same-transaction auto-approval cascade at this node carries that same epoch (§7).
       const initialEntryEpoch = await this.bumpNodeActivationSeq(client, instanceId)
-      await this.insertAssignments(client, instanceId, initial.assignments, initialEntryEpoch)
+      createdTaskEvents.push(...(await this.insertAssignments(client, instanceId, initial.assignments, initialEntryEpoch)))
       await this.insertAutoApprovalEvents(client, instanceId, 0, initial.status, initial.autoApprovalEvents, initialEntryEpoch)
       await this.insertCcEvents(client, instanceId, 0, initial.status, initial.ccEvents)
       await this.insertApprovalRecord(client, instanceId, {
@@ -3593,6 +3601,10 @@ export class ApprovalProductService {
     // the emit makes auto-approve-at-create deterministic — the create hook writes the ONE terminal row
     // and the subsequent completion-event reconcile is a version-guarded no-op (not a second row).
     await this.projectApprovalOnCreate(instanceId)
+
+    // A-2a: after commit — the emitter re-checks is_active so an auto-approve cascade that
+    // deactivated the entry-node rows in the same transaction emits nothing.
+    await this.emitApprovalTaskCreatedEventsPostCommit(instanceId, createdTaskEvents)
 
     if (completionEvent) {
       emitApprovalCompletionEvent(completionEvent)
@@ -3771,7 +3783,7 @@ export class ApprovalProductService {
       )
       // ACTIVATION (nodeEntryEpoch §4·A): admin jump lands the instance on a (re)activated node.
       const jumpEntryEpoch = await this.bumpNodeActivationSeq(client, id)
-      await this.insertAssignments(client, id, resolution.assignments, jumpEntryEpoch)
+      const createdTaskEvents = await this.insertAssignments(client, id, resolution.assignments, jumpEntryEpoch)
       await this.insertApprovalRecord(client, id, {
         action: 'jump',
         actorId: actor.userId,
@@ -3811,6 +3823,7 @@ export class ApprovalProductService {
         )
       }
       await client.query('COMMIT')
+      await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
 
       jumpEvent = {
         instanceId: id,
@@ -4011,8 +4024,9 @@ export class ApprovalProductService {
               AND is_active = TRUE`,
           [instanceId, fromUserId],
         )
+        const createdTaskEvents: ApprovalTaskCreatedTaskSnapshot[] = []
         for (const [epoch, bucket] of reassignmentsByEpoch) {
-          await this.insertAssignments(client, instanceId, bucket, epoch)
+          createdTaskEvents.push(...(await this.insertAssignments(client, instanceId, bucket, epoch)))
         }
         await client.query(
           `UPDATE approval_instances
@@ -4044,6 +4058,7 @@ export class ApprovalProductService {
         }
 
         await client.query('COMMIT')
+        await this.emitApprovalTaskCreatedEventsPostCommit(instanceId, createdTaskEvents) // A-2a
         result.succeeded.push(instanceId)
         if (requesterId) affectedRequesters.add(requesterId)
       } catch (error) {
@@ -4199,7 +4214,7 @@ export class ApprovalProductService {
            WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE`,
           [id, currentNodeKey],
         )
-        await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, targetUserId), timeoutTransferEntryEpoch)
+        const createdTaskEvents = await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, targetUserId), timeoutTransferEntryEpoch)
         // Parity with the dispatch transfer: an in-place handover does not bump the instance version.
         await this.insertApprovalRecord(client, id, {
           action: 'transfer',
@@ -4215,6 +4230,7 @@ export class ApprovalProductService {
         })
         await consumeTimeout()
         await client.query('COMMIT')
+        await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
         return 'applied'
       }
 
@@ -4273,7 +4289,7 @@ export class ApprovalProductService {
       )
       // ACTIVATION (nodeEntryEpoch §4·A): timeout-jump re-activates the jump target node.
       const timeoutJumpEntryEpoch = await this.bumpNodeActivationSeq(client, id)
-      await this.insertAssignments(client, id, resolution.assignments, timeoutJumpEntryEpoch)
+      const createdTaskEvents = await this.insertAssignments(client, id, resolution.assignments, timeoutJumpEntryEpoch)
       await this.insertApprovalRecord(client, id, {
         action: 'jump',
         actorId: APPROVAL_TIMEOUT_SYSTEM_ACTOR,
@@ -4310,6 +4326,7 @@ export class ApprovalProductService {
       }
       await consumeTimeout()
       await client.query('COMMIT')
+      await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
 
       // Post-commit best-effort metrics, mirroring the return path: close the timed-out node's open
       // breakdown entry, then re-entry activation re-stamps the target node (incl. its own timeout).
@@ -4451,7 +4468,7 @@ export class ApprovalProductService {
         // the read otherwise) and stamp the handed-to assignee with it; NEVER bump node_activation_seq.
         const transferEntryEpoch = await this.currentNodeEntryEpoch(client, id, currentNodeKey)
         await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
-        await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, request.targetUserId), transferEntryEpoch)
+        const createdTaskEvents = await this.insertAssignments(client, id, executor.buildTransferAssignments(currentNodeKey, request.targetUserId), transferEntryEpoch)
         await this.insertApprovalRecord(client, id, {
           action: 'transfer',
           actorId: actor.userId,
@@ -4465,6 +4482,7 @@ export class ApprovalProductService {
           targetUserId: request.targetUserId,
         }, actor)
         await client.query('COMMIT')
+        await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
         return (await this.getApproval(id))!
       }
 
@@ -4499,7 +4517,7 @@ export class ApprovalProductService {
         // approve must count toward the same quorum, so preserve the node's current epoch (its active
         // siblings still hold it here — no deactivation precedes this insert); NEVER bump the seq.
         const addSignEntryEpoch = await this.currentNodeEntryEpoch(client, id, currentNodeKey)
-        await this.insertAssignments(
+        const createdTaskEvents = await this.insertAssignments(
           client,
           id,
           executor.buildAddSignAssignments(currentNodeKey, targetUserIds, actor.userId),
@@ -4522,6 +4540,7 @@ export class ApprovalProductService {
           targetUserId: targetUserIds[0],
         }, actor)
         await client.query('COMMIT')
+        await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
         return (await this.getApproval(id))!
       }
 
@@ -4740,7 +4759,7 @@ export class ApprovalProductService {
         // Its same-transaction auto-approval cascade (e.g. requester merge) carries this new epoch,
         // so the re-entered threshold node's stale prior-round votes (a different epoch) never count.
         const returnEntryEpoch = await this.bumpNodeActivationSeq(client, id)
-        await this.insertAssignments(client, id, resolution.assignments, returnEntryEpoch)
+        const createdTaskEvents = await this.insertAssignments(client, id, resolution.assignments, returnEntryEpoch)
         await this.insertApprovalRecord(client, id, {
           action: 'return',
           actorId: actor.userId,
@@ -4759,6 +4778,7 @@ export class ApprovalProductService {
         await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents, returnEntryEpoch)
         await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
         await client.query('COMMIT')
+        await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
         this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
         if (resolution.currentNodeKey) {
           this.emitNodeActivationMetric(id, resolution.currentNodeKey, resolveCalendarSlaOrgId(toNullableRecord(instance.requester_snapshot)), nodeTimeoutForKey(runtimeGraph, resolution.currentNodeKey))
@@ -5153,7 +5173,7 @@ export class ApprovalProductService {
       // captured before any deactivation); only the newly-inserted assignments + the cascade at the
       // next node carry `advanceEntryEpoch`.
       const advanceEntryEpoch = await this.bumpNodeActivationSeq(client, id)
-      await this.insertAssignments(client, id, resolution.assignments, advanceEntryEpoch)
+      const createdTaskEvents = await this.insertAssignments(client, id, resolution.assignments, advanceEntryEpoch)
       const approveRecordMetadata: Record<string, unknown> = {
         nodeKey: currentNodeKey,
         nextNodeKey: resolution.currentNodeKey,
@@ -5246,6 +5266,7 @@ export class ApprovalProductService {
         : null
 
       await client.query('COMMIT')
+      await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
 
       // Wave 2 WP5 slice 1 — emit metrics after commit so rollback failures
       // never leave dangling breakdown entries. All hooks are guarded.
@@ -5512,8 +5533,12 @@ export class ApprovalProductService {
     instanceId: string,
     assignments: Array<{ assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string; sourceStep: number; metadata?: unknown }>,
     entryEpoch: number | null,
-  ): Promise<void> {
+  ): Promise<ApprovalTaskCreatedTaskSnapshot[]> {
     await this.assertNoActiveAssignmentConflicts(client, instanceId, assignments)
+    // A-2a: every USER-typed row is one new actionable pending item — collected by the caller
+    // (still inside its transaction) and emitted as approval.task_created AFTER commit, mirroring
+    // the completion-event discipline. Role-typed rows do not fire v1 recipient events.
+    const createdTasks: ApprovalTaskCreatedTaskSnapshot[] = []
     for (const assignment of assignments) {
       await client.query(
         `INSERT INTO approval_assignments
@@ -5528,6 +5553,66 @@ export class ApprovalProductService {
           entryEpoch,
           JSON.stringify(assignment.metadata ?? {}),
         ],
+      )
+      if (assignment.assignmentType === 'user') {
+        createdTasks.push({
+          nodeKey: assignment.nodeKey,
+          entryEpoch,
+          assigneeUserId: assignment.assigneeId,
+          sourceStep: assignment.sourceStep,
+        })
+      }
+    }
+    return createdTasks
+  }
+
+  /**
+   * A-2a: post-commit emission of approval.task_created — one event per user-typed assignment row
+   * created by the just-committed operation. Best-effort by contract: a lookup/emit failure NEVER
+   * fails the approval flow (the T2-6 dedupe ledger also absorbs any later re-emission), and the
+   * instance snapshot is re-read AFTER commit so the event reflects durable state.
+   */
+  private async emitApprovalTaskCreatedEventsPostCommit(
+    instanceId: string,
+    tasks: ApprovalTaskCreatedTaskSnapshot[],
+  ): Promise<void> {
+    if (tasks.length === 0) return
+    try {
+      // Same-transaction cascades (auto-approve at entry, immediate handover) can deactivate a row
+      // BEFORE commit — only still-active assignments are real pending items, so re-check against
+      // durable state and drop the rest (values-free: key fields only).
+      const activeResult = await pool.query(
+        `SELECT node_key, assignee_id, entry_epoch FROM approval_assignments
+          WHERE instance_id = $1 AND is_active = TRUE AND assignment_type = 'user'`,
+        [instanceId],
+      )
+      const activeKeys = new Set(
+        (activeResult.rows as Array<{ node_key: string; assignee_id: string; entry_epoch: number | string | null }>).map(
+          (row) => `${row.node_key}:${row.entry_epoch === null ? 'null' : String(Number(row.entry_epoch))}:${row.assignee_id}`,
+        ),
+      )
+      const seen = new Set<string>()
+      const liveTasks = tasks.filter((task) => {
+        const key = `${task.nodeKey}:${task.entryEpoch === null ? 'null' : String(task.entryEpoch)}:${task.assigneeUserId}`
+        if (seen.has(key) || !activeKeys.has(key)) return false
+        seen.add(key)
+        return true
+      })
+      if (liveTasks.length === 0) return
+      const result = await pool.query(
+        `SELECT id, request_no, template_id, template_version_id, published_definition_id,
+                business_key, workflow_key, requester_snapshot
+           FROM approval_instances WHERE id = $1`,
+        [instanceId],
+      )
+      const instance = result.rows[0] as ApprovalTaskCreatedInstanceSnapshot | undefined
+      if (!instance) return
+      for (const task of liveTasks) {
+        emitApprovalTaskCreatedEvent(buildApprovalTaskCreatedEvent({ instance, task }))
+      }
+    } catch (error) {
+      approvalProductLogger.warn(
+        `approval.task_created post-commit emission failed for ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
       )
     }
   }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4808,7 +4808,11 @@ export class ApprovalProductService {
           toStatus: 'rejected',
           fromVersion: instance.version,
           toVersion: nextVersion,
-          metadata: { nodeKey: currentNodeKey },
+          metadata: {
+            nodeKey: currentNodeKey,
+            // A-4: server-side channel attribution (card wrapper only; never request-sourced over HTTP).
+            ...(request.channelOrigin ? { channel: request.channelOrigin.channel, cardDeliveryId: request.channelOrigin.cardDeliveryId } : {}),
+          },
         }, actor)
         const completionEvent = this.buildCompletionEvent(
           instance,
@@ -5179,6 +5183,8 @@ export class ApprovalProductService {
         nextNodeKey: resolution.currentNodeKey,
         approvalMode,
         aggregateComplete: true,
+        // A-4: server-side channel attribution (card wrapper only; never request-sourced over HTTP).
+        ...(request.channelOrigin ? { channel: request.channelOrigin.channel, cardDeliveryId: request.channelOrigin.cardDeliveryId } : {}),
         ...(currentNodeEpoch !== null ? { nodeEntryEpoch: currentNodeEpoch } : {}),
       }
       if (isInParallelRegion) {

--- a/packages/core-backend/src/services/ApprovalTaskCreatedEvent.ts
+++ b/packages/core-backend/src/services/ApprovalTaskCreatedEvent.ts
@@ -1,0 +1,110 @@
+import { Logger } from '../core/logger'
+import { eventBus } from '../integration/events/event-bus'
+
+const logger = new Logger('ApprovalTaskCreatedEvent')
+
+/**
+ * A-2a (one-tap design-lock #3594, implementation decision ratified 2026-07-05): a NEW actionable
+ * pending item for ONE recipient. Emitted post-commit for every user-typed assignment row
+ * `insertAssignments` creates — node activations AND same-round mutations (transfer/add-sign/
+ * reassign) alike, so a handover recipient gets a fresh task event too.
+ *
+ * Event granularity is "one assignment / one recipient". The eventId embeds
+ * instanceId + nodeKey + entryEpoch + assigneeUserId so a return/jump that re-activates a node
+ * (new epoch, nodeEntryEpoch design-lock) re-fires cleanly, while duplicate deliveries of the SAME
+ * round dedupe via the T2-6 automation event-fire ledger (`approval.task_created:${eventId}`).
+ * A legacy NULL epoch serializes as the literal 'null' segment — stable, documented, dedupe-safe.
+ *
+ * Payload is metadata-only (ids, request_no, node/epoch, requester id) — NO form values ride on
+ * the event; consumers that need display content re-read server-side at execution time.
+ */
+export type ApprovalTaskCreatedEventType = 'approval.task_created'
+export const APPROVAL_TASK_CREATED_EVENT_TYPE: ApprovalTaskCreatedEventType = 'approval.task_created'
+
+export interface ApprovalTaskCreatedInstanceSnapshot {
+  id: string
+  request_no?: string | null
+  template_id?: string | null
+  template_version_id?: string | null
+  published_definition_id?: string | null
+  business_key?: string | null
+  workflow_key?: string | null
+  requester_snapshot?: unknown
+}
+
+/** One user-typed assignment row `insertAssignments` created (role-typed rows do not fire v1 events). */
+export interface ApprovalTaskCreatedTaskSnapshot {
+  nodeKey: string
+  entryEpoch: number | null
+  assigneeUserId: string
+  sourceStep: number
+}
+
+export interface ApprovalTaskCreatedEventV1 {
+  version: 1
+  eventId: string
+  eventType: ApprovalTaskCreatedEventType
+  occurredAt: string
+  source: 'approval-product'
+  approval: {
+    instanceId: string
+    requestNo: string | null
+    templateId: string | null
+    templateVersionId: string | null
+    publishedDefinitionId: string | null
+    businessKey: string | null
+    workflowKey: string | null
+  }
+  task: ApprovalTaskCreatedTaskSnapshot
+  requester: {
+    id: string | null
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+export function buildApprovalTaskCreatedEvent(input: {
+  instance: ApprovalTaskCreatedInstanceSnapshot
+  task: ApprovalTaskCreatedTaskSnapshot
+  occurredAt?: Date
+}): ApprovalTaskCreatedEventV1 {
+  const requesterSnapshot = isRecord(input.instance.requester_snapshot)
+    ? input.instance.requester_snapshot
+    : {}
+  return {
+    version: 1,
+    eventId: `approval-task:${input.instance.id}:${input.task.nodeKey}:${String(input.task.entryEpoch)}:${input.task.assigneeUserId}`,
+    eventType: APPROVAL_TASK_CREATED_EVENT_TYPE,
+    occurredAt: (input.occurredAt ?? new Date()).toISOString(),
+    source: 'approval-product',
+    approval: {
+      instanceId: input.instance.id,
+      requestNo: nullableString(input.instance.request_no),
+      templateId: nullableString(input.instance.template_id),
+      templateVersionId: nullableString(input.instance.template_version_id),
+      publishedDefinitionId: nullableString(input.instance.published_definition_id),
+      businessKey: nullableString(input.instance.business_key),
+      workflowKey: nullableString(input.instance.workflow_key),
+    },
+    task: input.task,
+    requester: {
+      id: nullableString(requesterSnapshot['id']),
+    },
+  }
+}
+
+export function emitApprovalTaskCreatedEvent(event: ApprovalTaskCreatedEventV1): void {
+  try {
+    eventBus.emit(event.eventType, event)
+  } catch (error) {
+    logger.warn(
+      `approval task_created event ${event.eventId} failed: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -432,6 +432,12 @@ export interface CreateApprovalRequest {
 export interface ApprovalActionRequest {
   action: ApprovalActionType
   comment?: string
+  /**
+   * A-4 (one-tap lock #3594 §4): INTERNAL-ONLY channel attribution injected by the card-delivery
+   * wrapper — never accepted from HTTP bodies (the /actions route constructs its request from an
+   * explicit field whitelist). Recorded onto the approve/reject approval_records metadata.
+   */
+  channelOrigin?: { channel: string; cardDeliveryId: string }
   targetUserId?: string
   targetNodeKey?: string
   /**

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -1,0 +1,269 @@
+/**
+ * A-4 core wrapper — real-DB integration (one-tap lock #3594 §4).
+ *
+ * Locks the owner matrix for the card-delivery decision path:
+ * ledger-only resolution (bad token/unknown id → not_found, no existence oracle) · undelivered
+ * (send_status='pending') card → stale · approve funnels through dispatchAction with SERVER-side
+ * channelOrigin (approval_records.metadata.channel='dingtalk_card' + cardDeliveryId) and claims the
+ * card acted · reject-comment-required surfaces as engine_rejected and the card STAYS claimable ·
+ * a second approve on the acted card → stale with the real terminal summary.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { randomUUID } from 'crypto'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import {
+  executeApprovalActionFromCardDelivery,
+  getApprovalCardDeliverySummary,
+  verifyApprovalCardLinkToken,
+} from '../../src/services/ApprovalCardDeliveryAction'
+import {
+  insertDingTalkApprovalCardDelivery,
+  markDingTalkApprovalCardDeliverySent,
+} from '../../src/integrations/dingtalk/approval-card-deliveries'
+import { createHmac } from 'crypto'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const CREATOR = `u_cdw_creator_${TS}`
+const REQUESTER = `u_cdw_req_${TS}`
+const APPROVER = `u_cdw_appr_${TS}`
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+
+let approvals: ApprovalProductService
+let templateId = ''
+const SECRET = 'cdw-test-secret'
+
+function tokenFor(deliveryId: string): string {
+  return createHmac('sha256', SECRET).update(deliveryId).digest('hex').slice(0, 32)
+}
+
+async function newInstance(): Promise<string> {
+  const dto = await approvals.createApproval(
+    { templateId, formData: { summary: 'wrapper test' } },
+    { userId: REQUESTER, userName: REQUESTER },
+  )
+  return (dto as { id: string }).id
+}
+
+async function newSentDelivery(instanceId: string): Promise<string> {
+  const row = await insertDingTalkApprovalCardDelivery(q, {
+    instanceId,
+    nodeKey: 'approval_1',
+    recipientUserId: APPROVER,
+    recipientDingTalkUserId: `dd_${APPROVER}`,
+    deliveryKind: 'work_notice_action_card',
+  })
+  await markDingTalkApprovalCardDeliverySent(q, row.id, 'task_cdw')
+  return row.id
+}
+
+const approverActor = { userId: '', userName: '' }
+
+describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
+  let savedSecret: string | undefined
+  beforeAll(async () => {
+    savedSecret = process.env.APPROVAL_CARD_LINK_SECRET
+    process.env.APPROVAL_CARD_LINK_SECRET = SECRET
+    approverActor.userId = APPROVER
+    approverActor.userName = APPROVER
+
+    await q(`INSERT INTO permissions (code, name, description) VALUES ('approvals:read','r','t'),('approvals:write','w','t'),('approvals:act','a','t') ON CONFLICT (code) DO NOTHING`)
+    for (const uid of [CREATOR, REQUESTER, APPROVER]) {
+      await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+               VALUES ($1,$2,$1,'x','user','[]'::jsonb,TRUE,FALSE) ON CONFLICT (id) DO UPDATE SET is_active = TRUE`, [uid, `${uid}@cdw.test`])
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+
+    approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate({
+      key: `cdw-${TS}`,
+      name: 'Card Wrapper Template',
+      formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          { key: 'approval_1', type: 'approval', name: 'First', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] } },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+        ],
+      },
+    } as never)
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+  })
+
+  afterAll(async () => {
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [templateId]).catch(() => ({ rows: [] as unknown[] }))
+    for (const row of instances.rows as Array<{ id: string }>) {
+      await q('DELETE FROM dingtalk_approval_card_deliveries WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
+    }
+    await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER]]).catch(() => {})
+    if (savedSecret === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET
+    else process.env.APPROVAL_CARD_LINK_SECRET = savedSecret
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('token discipline: bad token / unknown id / missing secret are all not_found (no existence oracle)', async () => {
+    const instanceId = await newInstance()
+    const deliveryId = await newSentDelivery(instanceId)
+
+    expect(verifyApprovalCardLinkToken(deliveryId, tokenFor(deliveryId))).toBe(true)
+    expect(verifyApprovalCardLinkToken(deliveryId, 'f'.repeat(32))).toBe(false)
+
+    expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: 'f'.repeat(32), viewerUserId: APPROVER })).status).toBe('not_found')
+    const ghost = randomUUID()
+    expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId: ghost, token: tokenFor(ghost), viewerUserId: APPROVER })).status).toBe('not_found')
+
+    const prev = process.env.APPROVAL_CARD_LINK_SECRET
+    delete process.env.APPROVAL_CARD_LINK_SECRET
+    try {
+      expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })).status).toBe('not_found')
+    } finally {
+      process.env.APPROVAL_CARD_LINK_SECRET = prev
+    }
+  })
+
+  test('undelivered card (send_status=pending) is stale — never actionable', async () => {
+    const instanceId = await newInstance()
+    const row = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: `dd_${APPROVER}`, deliveryKind: 'work_notice_action_card',
+    })
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId: row.id, token: tokenFor(row.id), decision: 'approve', actor: approverActor },
+    )
+    expect(outcome.status).toBe('stale')
+  })
+
+  test('approve: engine gates apply, channel attribution lands on approval_records, card claims acted', async () => {
+    const instanceId = await newInstance()
+    const deliveryId = await newSentDelivery(instanceId)
+
+    const summary = await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })
+    expect(summary.status).toBe('ok')
+    if (summary.status === 'ok') {
+      expect(summary.summary.actionable).toBe(true)
+      expect(summary.summary.viewerIsRecipient).toBe(true)
+      expect(summary.summary.approval.rejectCommentRequired).toBe(true)
+    }
+
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '同意', actor: approverActor },
+    )
+    expect(outcome.status).toBe('ok')
+    if (outcome.status === 'ok') {
+      expect(outcome.summary.cardState).toBe('acted')
+      expect(outcome.summary.actedAction).toBe('approve')
+      expect(outcome.summary.approval.status).toBe('approved')
+    }
+
+    const record = await q(
+      `SELECT metadata FROM approval_records WHERE instance_id = $1 AND action = 'approve' ORDER BY created_at DESC LIMIT 1`,
+      [instanceId],
+    )
+    const metadata = (record.rows[0] as { metadata: Record<string, unknown> }).metadata
+    expect(metadata.channel).toBe('dingtalk_card')
+    expect(metadata.cardDeliveryId).toBe(deliveryId)
+
+    // duplicate tap after the terminal state → stale with the REAL summary, engine untouched
+    const dup = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'approve', actor: approverActor },
+    )
+    expect(dup.status).toBe('stale')
+    if (dup.status === 'stale') expect(dup.summary.cardState).toBe('acted')
+  })
+
+  test('reject without a comment: engine_rejected (comment required), card STAYS actionable', async () => {
+    const instanceId = await newInstance()
+    const deliveryId = await newSentDelivery(instanceId)
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'reject', actor: approverActor },
+    )
+    expect(outcome.status).toBe('engine_rejected')
+    if (outcome.status === 'engine_rejected') {
+      expect(outcome.httpStatus).toBeGreaterThanOrEqual(400)
+      expect(outcome.summary.cardState).toBe('sent') // NOT claimed — retry with a comment succeeds
+    }
+    const retry = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'reject', comment: '材料不全', actor: approverActor },
+    )
+    expect(retry.status).toBe('ok')
+    if (retry.status === 'ok') {
+      expect(retry.summary.actedAction).toBe('reject')
+      expect(retry.summary.approval.status).toBe('rejected')
+    }
+  })
+
+  test('CONCURRENCY tripwire: two simultaneous approves — exactly one engine action, one claim, loser gets the real terminal state', async () => {
+    // The wrapper is dispatch-THEN-claim, so in a true concurrent window BOTH requests can enter
+    // the engine — the engine's own gates (FOR UPDATE + status/version) must reduce them to one.
+    // A sequential duplicate-tap test cannot prove this; Promise.all does.
+    const instanceId = await newInstance()
+    const deliveryId = await newSentDelivery(instanceId)
+
+    const [first, second] = await Promise.all([
+      executeApprovalActionFromCardDelivery(
+        { query: q, approvals },
+        { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '并发A', actor: approverActor },
+      ),
+      executeApprovalActionFromCardDelivery(
+        { query: q, approvals },
+        { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '并发B', actor: approverActor },
+      ),
+    ])
+    const outcomes = [first, second]
+    const winners = outcomes.filter((o) => o.status === 'ok')
+    expect(winners).toHaveLength(1)
+    // the loser is engine_rejected (raced into the engine) or stale (arrived after the claim) —
+    // either way it carries the REAL terminal summary, never a dead form
+    const loser = outcomes.find((o) => o.status !== 'ok')!
+    expect(['engine_rejected', 'stale']).toContain(loser.status)
+    if (loser.status === 'engine_rejected' || loser.status === 'stale') {
+      expect(loser.summary.approval.status).toBe('approved')
+    }
+
+    // exactly ONE engine approve record, exactly ONE channel attribution
+    const records = await q(
+      `SELECT metadata FROM approval_records WHERE instance_id = $1 AND action = 'approve'`,
+      [instanceId],
+    )
+    expect(records.rows).toHaveLength(1)
+    const channelRecords = (records.rows as Array<{ metadata: Record<string, unknown> }>)
+      .filter((r) => r.metadata?.channel === 'dingtalk_card')
+    expect(channelRecords).toHaveLength(1)
+
+    // exactly ONE acted claim on the card
+    const card = await q(`SELECT card_state, acted_by, acted_action FROM dingtalk_approval_card_deliveries WHERE id = $1`, [deliveryId])
+    expect((card.rows[0] as { card_state: string }).card_state).toBe('acted')
+    expect((card.rows[0] as { acted_action: string }).acted_action).toBe('approve')
+  })
+
+    test('non-assignee actor is rejected by the ENGINE (zero bypass), card stays claimable', async () => {
+    const instanceId = await newInstance()
+    const deliveryId = await newSentDelivery(instanceId)
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'approve', actor: { userId: REQUESTER, userName: REQUESTER } },
+    )
+    expect(outcome.status).toBe('engine_rejected')
+    if (outcome.status === 'engine_rejected') expect(outcome.summary.cardState).toBe('sent')
+  })
+})

--- a/packages/core-backend/tests/integration/automation-approval-task-created-trigger.test.ts
+++ b/packages/core-backend/tests/integration/automation-approval-task-created-trigger.test.ts
@@ -1,0 +1,347 @@
+/**
+ * A-2a `approval.task_created` automation trigger — real-DB integration (one-tap lock #3594
+ * implementation decision, owner-ratified 2026-07-05).
+ *
+ * Real event chain over real Postgres + the real in-process eventBus:
+ *   ApprovalProductService (create / transfer / add-sign / return) → insertAssignments collector
+ *     → emitApprovalTaskCreatedEventsPostCommit (is_active re-checked post-commit)
+ *       → AutomationService subscription → handleApprovalTaskCreatedTrigger (template-routed)
+ *         → T2-6 ledger claim (`approval.task_created:{eventId}`) → executeRule (record-less)
+ *           → send_notification → eventBus 'automation.notification' (fixture-free oracle).
+ *
+ * Owner review matrix: per-recipient granularity (NOT per-node) · eventId quad
+ * instanceId+nodeKey+entryEpoch+assigneeUserId · same-eventId replay = no-op ·
+ * templateId-null out-of-contract · save-time hidden-template reject + post-save scope flip =
+ * fire-skip · record-write/start_approval/delete_record/conditions rejected at create AND update ·
+ * transfer/add-sign/return re-round paths fire · deactivated (acted) assignments never re-fire.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import type { ApprovalTaskCreatedEventV1 } from '../../src/services/ApprovalTaskCreatedEvent'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_atc_${TS}`
+const SHEET_ID = `sheet_atc_${TS}`
+const CREATOR = `u_atc_creator_${TS}`
+const REQUESTER = `u_atc_req_${TS}`
+const APPROVER_1 = `u_atc_appr1_${TS}`
+const APPROVER_2 = `u_atc_appr2_${TS}`
+const TRANSFEREE = `u_atc_transferee_${TS}`
+const OUTSIDER = `u_atc_out_${TS}`
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+const queryFn = ((sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)) as never
+
+let svc: AutomationService
+let approvals: ApprovalProductService
+let templateId = ''
+const ruleIds: string[] = []
+const taskEvents: ApprovalTaskCreatedEventV1[] = []
+const notifications: Array<{ userIds: string[]; message: string }> = []
+
+function approvalTemplateRequest() {
+  return {
+    key: `atc-${TS}`,
+    name: 'approval.task_created Trigger Template',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'First',
+          config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER_1] }] },
+        },
+        {
+          key: 'approval_2',
+          type: 'approval',
+          name: 'Second',
+          config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER_2] }] },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-approval_2', source: 'approval_1', target: 'approval_2' },
+        { key: 'edge-approval_2-end', source: 'approval_2', target: 'end' },
+      ],
+    },
+  }
+}
+
+const requesterActor = () => ({ userId: REQUESTER, userName: REQUESTER })
+const approver1Actor = () => ({ userId: APPROVER_1, userName: APPROVER_1 })
+const approver2Actor = () => ({ userId: APPROVER_2, userName: APPROVER_2 })
+
+async function startApprovalInstance(): Promise<string> {
+  const dto = await approvals.createApproval(
+    { templateId, formData: { summary: 'task trigger test' } },
+    requesterActor(),
+  )
+  return (dto as { id: string }).id
+}
+
+async function executionCount(ruleId: string): Promise<number> {
+  const r = await q('SELECT COUNT(*)::int AS count FROM multitable_automation_executions WHERE rule_id = $1', [ruleId])
+  return (r.rows[0] as { count: number }).count
+}
+
+async function waitForExecutionCount(ruleId: string, expected: number, timeoutMs = 6000): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const count = await executionCount(ruleId)
+    if (count >= expected || Date.now() > deadline) return count
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+async function settle(ms = 250): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describeIfDatabase('A-2a approval.task_created automation trigger (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'ATC Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'ATC Sheet'])
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('approvals:read', 'Approvals Read', 'ATC test'),
+              ('approvals:write', 'Approvals Write', 'ATC test'),
+              ('approvals:act', 'Approvals Act', 'ATC test')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    for (const uid of [CREATOR, REQUESTER, APPROVER_1, APPROVER_2, TRANSFEREE, OUTSIDER]) {
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+        [uid, `${uid}@atc.test`],
+      )
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:read') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    for (const uid of [APPROVER_1, APPROVER_2]) {
+      await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:act') ON CONFLICT DO NOTHING`, [uid])
+    }
+
+    approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate(approvalTemplateRequest() as never)
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+
+    integrationEventBus.subscribe('approval.task_created', (payload) => {
+      taskEvents.push(payload as ApprovalTaskCreatedEventV1)
+    })
+    integrationEventBus.subscribe('automation.notification', (payload) => {
+      notifications.push(payload as (typeof notifications)[number])
+    })
+
+    svc = new AutomationService(integrationEventBus, db as never, queryFn)
+    svc.init()
+  })
+
+  afterAll(async () => {
+    try { svc?.shutdown() } catch { /* noop */ }
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [templateId]).catch(() => ({ rows: [] as unknown[] }))
+    for (const row of instances.rows as Array<{ id: string }>) {
+      await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
+    }
+    if (ruleIds.length > 0) {
+      await q('DELETE FROM meta_automation_event_fires WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    }
+    await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER_1, APPROVER_2, TRANSFEREE, OUTSIDER]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER_1, APPROVER_2, TRANSFEREE, OUTSIDER]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('save gate (create + update): templateId / actions / conditions / creator legs all fail-closed', async () => {
+    const base = {
+      name: 'approval task rule',
+      triggerType: 'approval.task_created',
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'new task' },
+      createdBy: CREATOR,
+    }
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: {} } as never))
+      .rejects.toThrow(/templateId is required/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId: '00000000-0000-4000-8000-000000000000' } } as never))
+      .rejects.toThrow(/must reference an existing approval template/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId }, actionType: 'update_record', actionConfig: { fieldId: 'x', value: 1 } } as never))
+      .rejects.toThrow(/not allowed on approval.task_created rules/)
+    // start_approval is structurally rejected before the allowlist (execution-mode gate, then its own
+    // config validation) — any of these throws keeps it off the trigger; the allowlist itself is
+    // exercised directly by the update_record case above and the update-time cases below.
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId }, actionType: 'start_approval', actionConfig: { templateId } } as never))
+      .rejects.toThrow(/requires execution_mode workflow_job_v1|formDataMapping is required|not allowed on approval.task_created rules/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId }, actionType: 'delete_record', actionConfig: {} } as never))
+      .rejects.toThrow(/not allowed on approval.task_created rules|delete_record/)
+    await expect(svc.createRule(SHEET_ID, {
+      ...base,
+      triggerConfig: { templateId },
+      conditions: { logic: 'and', conditions: [{ fieldId: 'x', operator: 'equals', value: 1 }] },
+    } as never)).rejects.toThrow(/cannot carry conditions/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId }, createdBy: OUTSIDER } as never))
+      .rejects.toThrow(/approvals:read/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId }, createdBy: null } as never))
+      .rejects.toThrow(/authenticated creator/)
+
+    // update-time resulting-shape gate: a valid rule cannot smuggle a disallowed shape via partial edits
+    const rule = await svc.createRule(SHEET_ID, { ...base, triggerConfig: { templateId } } as never)
+    ruleIds.push(rule.id)
+    await expect(svc.updateRule(rule.id, SHEET_ID, {
+      conditions: { logic: 'and', conditions: [{ fieldId: 'x', operator: 'equals', value: 1 }] },
+    } as never)).rejects.toThrow(/cannot carry conditions/)
+    await expect(svc.updateRule(rule.id, SHEET_ID, {
+      actionType: 'update_record',
+      actionConfig: { fieldId: 'x', value: 1 },
+    } as never)).rejects.toThrow(/not allowed on approval.task_created rules/)
+    await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('fires per NEW recipient with the quad eventId; ledger claim + replay no-op; acted assignment never re-fires', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'notify on new approval task',
+      triggerType: 'approval.task_created',
+      triggerConfig: { templateId },
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'task for {{approval.instanceId}}' },
+      createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+
+    taskEvents.length = 0
+    const instanceId = await startApprovalInstance()
+    expect(await waitForExecutionCount(rule.id, 1)).toBe(1)
+
+    // per-recipient event with the locked quad eventId
+    const created = taskEvents.find((e) => e.approval.instanceId === instanceId && e.task.nodeKey === 'approval_1')
+    expect(created).toBeTruthy()
+    expect(created!.task.assigneeUserId).toBe(APPROVER_1)
+    expect(created!.eventId).toBe(
+      `approval-task:${instanceId}:approval_1:${String(created!.task.entryEpoch)}:${APPROVER_1}`,
+    )
+    // T2-6 ledger row carries the namespaced key
+    const fire = await q('SELECT dedup_key FROM meta_automation_event_fires WHERE rule_id = $1 ORDER BY 1', [rule.id])
+    expect((fire.rows as Array<{ dedup_key: string }>).some((r) => r.dedup_key === `approval.task_created:${created!.eventId}`)).toBe(true)
+
+    // same-eventId replay → dedup no-op
+    integrationEventBus.emit('approval.task_created', created!)
+    await settle()
+    expect(await executionCount(rule.id)).toBe(1)
+
+    // advance: approver_1 acts — their assignment deactivates (never re-fires), approver_2's NEW task fires
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, approver1Actor())
+    expect(await waitForExecutionCount(rule.id, 2)).toBe(2)
+    const second = taskEvents.find((e) => e.approval.instanceId === instanceId && e.task.nodeKey === 'approval_2')
+    expect(second?.task.assigneeUserId).toBe(APPROVER_2)
+
+    // return to approval_1 → fresh round (new entryEpoch) → fires again with a DIFFERENT eventId
+    await approvals.dispatchAction(instanceId, { action: 'return', targetNodeKey: 'approval_1' } as never, approver2Actor())
+    expect(await waitForExecutionCount(rule.id, 3)).toBe(3)
+    const returned = taskEvents.filter((e) => e.approval.instanceId === instanceId && e.task.nodeKey === 'approval_1')
+    // Emission is at-least-once BY CONTRACT (the T2-6 ledger is the exactly-once layer): assert two
+    // DISTINCT rounds (create-round + return-round eventIds/epochs) and that any duplicate emits of
+    // the same round were dedup-absorbed (execution count stayed exactly 3).
+    const distinctIds = [...new Set(returned.map((e) => e.eventId))]
+    expect(distinctIds.length).toBe(2)
+    const epochs = [...new Set(returned.map((e) => String(e.task.entryEpoch)))]
+    expect(epochs.length).toBe(2)
+    expect(await executionCount(rule.id)).toBe(3)
+    const returnRound = returned[returned.length - 1]
+    expect(returnRound.eventId).not.toBe(returned[0].eventId)
+
+    // transfer within the round → transferee gets a NEW task event (same epoch, different assignee)
+    await approvals.dispatchAction(instanceId, { action: 'transfer', targetUserId: TRANSFEREE, comment: 'over to you' } as never, approver1Actor())
+    expect(await waitForExecutionCount(rule.id, 4)).toBe(4)
+    const transferred = taskEvents.find((e) => e.approval.instanceId === instanceId && e.task.assigneeUserId === TRANSFEREE)
+    expect(transferred?.task.nodeKey).toBe('approval_1')
+    expect(String(transferred?.task.entryEpoch)).toBe(String(returnRound.task.entryEpoch))
+
+    // add-sign → added approver gets a NEW task event in the same round
+    await approvals.dispatchAction(instanceId, { action: 'add_sign', targetUserIds: [APPROVER_2], addSignMode: 'parallel' } as never, { userId: TRANSFEREE, userName: TRANSFEREE })
+    expect(await waitForExecutionCount(rule.id, 5)).toBe(5)
+    const added = taskEvents.find((e) => e.approval.instanceId === instanceId && e.task.assigneeUserId === APPROVER_2 && e.task.nodeKey === 'approval_1')
+    expect(added).toBeTruthy()
+
+    await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('templateId-null pending event is v1 out-of-contract: no match, no execution', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'null-template guard',
+      triggerType: 'approval.task_created',
+      triggerConfig: { templateId },
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'x' },
+      createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+    const before = await executionCount(rule.id)
+    integrationEventBus.emit('approval.task_created', {
+      version: 1,
+      eventId: `approval-task:synthetic:${TS}:null:nobody`,
+      eventType: 'approval.task_created',
+      occurredAt: new Date().toISOString(),
+      source: 'approval-product',
+      approval: { instanceId: 'synthetic', requestNo: null, templateId: null, templateVersionId: null, publishedDefinitionId: null, businessKey: null, workflowKey: null },
+      task: { nodeKey: 'approval_1', entryEpoch: 1, assigneeUserId: 'nobody', sourceStep: 1 },
+      requester: { id: null },
+    } satisfies ApprovalTaskCreatedEventV1)
+    await settle()
+    expect(await executionCount(rule.id)).toBe(before)
+    await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('post-save visibility flip = fire-skip (no hidden-template task leak)', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'scope flip guard',
+      triggerType: 'approval.task_created',
+      triggerConfig: { templateId },
+      actionType: 'send_notification',
+      actionConfig: { userIds: [CREATOR], message: 'x' },
+      createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+    const before = await executionCount(rule.id)
+    // Flip the template out of the creator's sight AFTER save (restore the ORIGINAL value — the
+    // column is NOT NULL). The engine hides a dept-scoped template from the requester too, so the
+    // fire-skip leg is exercised with a well-formed SYNTHETIC event straight at the dispatch layer —
+    // exactly what a still-live emitter would deliver for a now-hidden template.
+    const original = await q('SELECT visibility_scope FROM approval_templates WHERE id = $1', [templateId])
+    const originalScope = JSON.stringify((original.rows[0] as { visibility_scope: unknown }).visibility_scope)
+    await q(`UPDATE approval_templates SET visibility_scope = '{"type":"dept","ids":["dept_never"]}'::jsonb WHERE id = $1`, [templateId])
+    try {
+      integrationEventBus.emit('approval.task_created', {
+        version: 1,
+        eventId: `approval-task:scope-flip:${TS}:1:${APPROVER_1}`,
+        eventType: 'approval.task_created',
+        occurredAt: new Date().toISOString(),
+        source: 'approval-product',
+        approval: { instanceId: 'scope-flip', requestNo: null, templateId, templateVersionId: null, publishedDefinitionId: null, businessKey: null, workflowKey: null },
+        task: { nodeKey: 'approval_1', entryEpoch: 1, assigneeUserId: APPROVER_1, sourceStep: 1 },
+        requester: { id: REQUESTER },
+      } satisfies ApprovalTaskCreatedEventV1)
+      await settle(600)
+      expect(await executionCount(rule.id)).toBe(before) // fire-skip: creator can no longer see the template
+    } finally {
+      await q(`UPDATE approval_templates SET visibility_scope = $2::jsonb WHERE id = $1`, [templateId, originalScope])
+      await svc.deleteRule(rule.id, SHEET_ID)
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -1,0 +1,253 @@
+/**
+ * A-2b `send_dingtalk_approval_card` action — real-DB integration (one-tap lock #3594).
+ *
+ * Chain under test: approval.task_created rule + card action → ledger row written BEFORE the send
+ * (the §3 anchor), action_card sent over an injected fetchFn (gettoken + asyncsend_v2 faked),
+ * task_id recorded on success, send failures traceable (send_status/send_error), unbound recipients
+ * recorded as `skipped` person-delivery telemetry with NO card row and NO guessed mapping, and the
+ * deep link carrying ONLY deliveryId + HMAC token (values-free — never the instanceId).
+ * Placement gate: the card action saves ONLY on approval.task_created (create + update).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_card_${TS}`
+const SHEET_ID = `sheet_card_${TS}`
+const CREATOR = `u_card_creator_${TS}`
+const REQUESTER = `u_card_req_${TS}`
+const APPROVER = `u_card_appr_${TS}`
+import { randomUUID } from 'crypto'
+const DD_INTEGRATION = randomUUID()
+const DD_ACCOUNT = randomUUID()
+const DD_USER_ID = `dd_ext_${TS}`
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+const queryFn = ((sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)) as never
+
+let svc: AutomationService
+let approvals: ApprovalProductService
+let templateId = ''
+const ruleIds: string[] = []
+const sentBodies: Array<Record<string, unknown>> = []
+let failNextSend = false
+
+const fakeFetch: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = String(input)
+  if (url.includes('/gettoken')) {
+    return new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'tok_test' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  }
+  if (url.includes('/topapi/message/corpconversation/asyncsend_v2')) {
+    if (failNextSend) {
+      failNextSend = false
+      return new Response(JSON.stringify({ errcode: 88, errmsg: 'ding: simulated send failure' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }
+    sentBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+    return new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 424242 }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  }
+  throw new Error(`unexpected fetch ${url}`)
+}) as typeof fetch
+
+function cardTemplateRequest() {
+  return {
+    key: `card-${TS}`,
+    name: 'Approval Card Action Template',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        { key: 'approval_1', type: 'approval', name: 'First', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] } },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+async function cardRows(instanceId: string) {
+  const r = await q('SELECT * FROM dingtalk_approval_card_deliveries WHERE instance_id = $1 ORDER BY created_at', [instanceId])
+  return r.rows as Array<Record<string, unknown>>
+}
+
+async function waitFor<T>(fn: () => Promise<T[]>, timeoutMs = 6000): Promise<T[]> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const rows = await fn()
+    if (rows.length > 0 || Date.now() > deadline) return rows
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
+  const savedEnv: Record<string, string | undefined> = {}
+  beforeAll(async () => {
+    for (const [k, v] of Object.entries({
+      DINGTALK_APP_KEY: 'test_app_key',
+      DINGTALK_APP_SECRET: 'test_app_secret',
+      DINGTALK_AGENT_ID: '1000001',
+      PUBLIC_APP_URL: 'https://ms.example.test',
+      APPROVAL_CARD_LINK_SECRET: 'card-link-secret-for-tests',
+    })) {
+      savedEnv[k] = process.env[k]
+      process.env[k] = v
+    }
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Card Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'Card Sheet'])
+    await q(`INSERT INTO permissions (code, name, description) VALUES ('approvals:read','r','t'),('approvals:write','w','t'),('approvals:act','a','t') ON CONFLICT (code) DO NOTHING`)
+    for (const uid of [CREATOR, REQUESTER, APPROVER]) {
+      await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+               VALUES ($1,$2,$1,'x','user','[]'::jsonb,TRUE,FALSE) ON CONFLICT (id) DO UPDATE SET is_active = TRUE`, [uid, `${uid}@card.test`])
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:read') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+
+    approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate(cardTemplateRequest() as never)
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+
+    svc = new AutomationService(integrationEventBus, db as never, queryFn, fakeFetch as never)
+    svc.init()
+  })
+
+  afterAll(async () => {
+    try { svc?.shutdown() } catch { /* noop */ }
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [templateId]).catch(() => ({ rows: [] as unknown[] }))
+    for (const row of instances.rows as Array<{ id: string }>) {
+      await q('DELETE FROM dingtalk_approval_card_deliveries WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
+    }
+    if (ruleIds.length > 0) {
+      await q('DELETE FROM meta_automation_event_fires WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+      await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    }
+    await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
+    await q('DELETE FROM dingtalk_person_deliveries WHERE local_user_id = ANY($1::text[])', [[APPROVER]]).catch(() => {})
+    await q('DELETE FROM directory_account_links WHERE local_user_id = $1', [APPROVER]).catch(() => {})
+    await q('DELETE FROM directory_accounts WHERE id = $1', [DD_ACCOUNT]).catch(() => {})
+    await q('DELETE FROM directory_integrations WHERE id = $1', [DD_INTEGRATION]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER]]).catch(() => {})
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('placement gate: the card action saves ONLY on approval.task_created (create + update)', async () => {
+    const base = {
+      name: 'card placement',
+      actionType: 'send_dingtalk_approval_card',
+      actionConfig: {},
+      createdBy: CREATOR,
+    }
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerType: 'record.created', triggerConfig: {} } as never))
+      .rejects.toThrow(/only allowed on approval.task_created rules/)
+    await expect(svc.createRule(SHEET_ID, { ...base, triggerType: 'approval.completed', triggerConfig: { templateId } } as never))
+      .rejects.toThrow(/not allowed on approval.completed rules/)
+
+    // update-time smuggle: a notify rule on record.created cannot swap its action to the card
+    const notifyRule = await svc.createRule(SHEET_ID, {
+      name: 'plain notify', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'send_notification', actionConfig: { userIds: [CREATOR], message: 'x' }, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(notifyRule.id)
+    await expect(svc.updateRule(notifyRule.id, SHEET_ID, { actionType: 'send_dingtalk_approval_card', actionConfig: {} } as never))
+      .rejects.toThrow(/only allowed on approval.task_created rules/)
+    await svc.deleteRule(notifyRule.id, SHEET_ID)
+  })
+
+  test('unbound recipient: skipped person-delivery telemetry, NO card row, mapping never guessed', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'card unbound', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+
+    const dto = await approvals.createApproval({ templateId, formData: { summary: 'unbound run' } }, { userId: REQUESTER, userName: REQUESTER })
+    const instanceId = (dto as { id: string }).id
+    const skipped = await waitFor(async () => {
+      const r = await q(`SELECT status, error_message FROM dingtalk_person_deliveries WHERE local_user_id = $1 AND status = 'skipped'`, [APPROVER])
+      return r.rows
+    })
+    expect(skipped.length).toBeGreaterThan(0)
+    expect((skipped[0] as { error_message: string }).error_message).toContain('not linked')
+    expect(await cardRows(instanceId)).toHaveLength(0)
+    await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('bound recipient: ledger-first send — sent card, task_id, signed values-free deep link', async () => {
+    await q(`INSERT INTO directory_integrations (id, name, corp_id) VALUES ($1, 'card-test', 'corp_card_test')`, [DD_INTEGRATION])
+    await q(`INSERT INTO directory_accounts (id, integration_id, provider, external_user_id, external_key, name, is_active)
+             VALUES ($1, $2, 'dingtalk', $3, $3, 'Card Approver', TRUE)`, [DD_ACCOUNT, DD_INTEGRATION, DD_USER_ID])
+    await q(`INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status) VALUES ($1, $2, 'linked')`, [DD_ACCOUNT, APPROVER])
+
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'card bound', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+
+    sentBodies.length = 0
+    const dto = await approvals.createApproval({ templateId, formData: { summary: 'SECRET-FORM-VALUE' } }, { userId: REQUESTER, userName: REQUESTER })
+    const instanceId = (dto as { id: string }).id
+    const rows = await waitFor(() => cardRows(instanceId))
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row.delivery_kind).toBe('work_notice_action_card')
+    expect(row.card_state).toBe('sent')
+    expect(row.send_status).toBe('sent')
+    expect(row.task_id).toBe('424242')
+    expect(row.recipient_user_id).toBe(APPROVER)
+    expect(row.recipient_dingtalk_user_id).toBe(DD_USER_ID)
+
+    expect(sentBodies).toHaveLength(1)
+    const body = sentBodies[0]
+    expect(body.userid_list).toBe(DD_USER_ID)
+    const msg = body.msg as { msgtype: string; action_card: { single_url: string; markdown: string; single_title: string } }
+    expect(msg.msgtype).toBe('action_card')
+    expect(msg.action_card.single_title).toBe('查看并处理')
+    const url = msg.action_card.single_url
+    expect(url).toContain(`d=${row.id}`)
+    expect(url).toMatch(/t=[0-9a-f]{32}/)
+    expect(url).not.toContain(instanceId) // values-free deep link: ledger id + token ONLY
+    expect(msg.action_card.markdown).not.toContain('SECRET-FORM-VALUE') // no form values on the card
+    await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('send failure is traceable: send_status=failed + send_error on the ledger row', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'card send-fail', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+
+    failNextSend = true
+    const dto = await approvals.createApproval({ templateId, formData: { summary: 'fail run' } }, { userId: REQUESTER, userName: REQUESTER })
+    const instanceId = (dto as { id: string }).id
+    const rows = await waitFor(async () => (await cardRows(instanceId)).filter((r) => r.send_status !== 'pending'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].send_status).toBe('failed')
+    expect(String(rows[0].send_error)).toContain('Failed to send DingTalk action-card work notification')
+    await svc.deleteRule(rule.id, SHEET_ID)
+  })
+})

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
@@ -13,6 +13,8 @@ import {
   claimDingTalkApprovalCardDeliveryActed,
   findDingTalkApprovalCardDeliveryById,
   insertDingTalkApprovalCardDelivery,
+  markDingTalkApprovalCardDeliverySendFailed,
+  markDingTalkApprovalCardDeliverySent,
   supersedeDingTalkApprovalCardDeliveriesForInstance,
 } from '../../src/integrations/dingtalk/approval-card-deliveries'
 
@@ -65,6 +67,8 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
       deliveryKind: 'interactive_card',
     })
 
+    await markDingTalkApprovalCardDeliverySent(q, row.id, 'task_claim_test') // P2: only delivered cards are claimable
+
     const [first, second] = await Promise.all([
       claimDingTalkApprovalCardDeliveryActed(q, row.id, { action: 'approve', actedBy: 'user_b' }),
       claimDingTalkApprovalCardDeliveryActed(q, row.id, { action: 'approve', actedBy: 'user_b' }),
@@ -92,6 +96,7 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
       recipientDingTalkUserId: 'dd_user_c',
       deliveryKind: 'work_notice_action_card',
     })
+    await markDingTalkApprovalCardDeliverySent(q, acted.id, 'task_supersede_test')
     await claimDingTalkApprovalCardDeliveryActed(q, acted.id, { action: 'approve', actedBy: 'user_c' })
 
     const keep = await insertDingTalkApprovalCardDelivery(q, {
@@ -121,7 +126,41 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
     expect(sweptAll).toEqual([keep.id])
   })
 
-  it('DB CHECKs reject invalid delivery_kind / card_state / acted-audit inconsistency; FK rejects unknown instances', async () => {
+  it('P2: pending/failed sends are NEVER claimable — only a delivered card is actionable', async () => {
+    const pending = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_p2a',
+      recipientDingTalkUserId: 'dd_user_p2a',
+      deliveryKind: 'work_notice_action_card',
+    })
+    expect(await claimDingTalkApprovalCardDeliveryActed(q, pending.id, { action: 'approve', actedBy: 'user_p2a' })).toBeNull()
+    expect((await findDingTalkApprovalCardDeliveryById(q, pending.id))?.card_state).toBe('sent')
+
+    const failed = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_p2b',
+      recipientDingTalkUserId: 'dd_user_p2b',
+      deliveryKind: 'work_notice_action_card',
+    })
+    await markDingTalkApprovalCardDeliverySendFailed(q, failed.id, 'boom')
+    expect(await claimDingTalkApprovalCardDeliveryActed(q, failed.id, { action: 'approve', actedBy: 'user_p2b' })).toBeNull()
+    expect((await findDingTalkApprovalCardDeliveryById(q, failed.id))?.send_status).toBe('failed')
+
+    // a delivered card claims normally (control)
+    const delivered = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_p2c',
+      recipientDingTalkUserId: 'dd_user_p2c',
+      deliveryKind: 'work_notice_action_card',
+    })
+    await markDingTalkApprovalCardDeliverySent(q, delivered.id, null)
+    expect((await claimDingTalkApprovalCardDeliveryActed(q, delivered.id, { action: 'reject', actedBy: 'user_p2c' }))?.card_state).toBe('acted')
+  })
+
+    it('DB CHECKs reject invalid delivery_kind / card_state / acted-audit inconsistency; FK rejects unknown instances', async () => {
     await expect(
       q(`INSERT INTO dingtalk_approval_card_deliveries (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind)
          VALUES ('bad_kind', $1, 'n1', 'u', 'dd', 'carrier_pigeon')`, [INSTANCE]),

--- a/packages/core-backend/tests/unit/approval-card-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-card-automation-action-migration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
+import {
+  AUTOMATION_ACTION_TYPES_BEFORE_APPROVAL_CARD,
+  AUTOMATION_ACTION_TYPES_WITH_APPROVAL_CARD,
+} from '../../src/db/migrations/zzzz20260705150000_add_send_dingtalk_approval_card_automation_action'
+
+describe('send_dingtalk_approval_card automation action migration (A-2b)', () => {
+  it('keeps the latest database action constraint in sync with app-level action types', () => {
+    // This migration widens chk_automation_action_type to the CURRENT ALL_ACTION_TYPES — so a future
+    // action type added to the app without a DB migration trips this drift guard RED.
+    for (const actionType of ALL_ACTION_TYPES) {
+      expect(AUTOMATION_ACTION_TYPES_WITH_APPROVAL_CARD).toContain(actionType)
+    }
+  })
+
+  it('adds send_dingtalk_approval_card on top of the prior record_click action set, and nothing else', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_APPROVAL_CARD).toContain('send_dingtalk_approval_card')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_APPROVAL_CARD).not.toContain('send_dingtalk_approval_card')
+    expect(AUTOMATION_ACTION_TYPES_WITH_APPROVAL_CARD.filter((a) => a !== 'send_dingtalk_approval_card'))
+      .toEqual([...AUTOMATION_ACTION_TYPES_BEFORE_APPROVAL_CARD])
+  })
+
+  it('rolls back only the approval-card widening (record_click + delete_record remain)', () => {
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_APPROVAL_CARD).toContain('record_click')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_APPROVAL_CARD).toContain('delete_record')
+  })
+})

--- a/packages/core-backend/tests/unit/delete-record-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/delete-record-automation-action-migration.test.ts
@@ -10,7 +10,7 @@ describe('delete_record automation action migration (Phase C2)', () => {
     // No longer the LATEST migration (record_click widened the constraint afterwards — see
     // record-click-automation-action-migration.test.ts for the live "latest in sync" guard). Every
     // app-level action type except the ones introduced by a strictly-later migration must be here.
-    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['record_click'])
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['record_click', 'send_dingtalk_approval_card'])
     for (const actionType of ALL_ACTION_TYPES) {
       if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD).toContain(actionType)

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -363,7 +363,8 @@ describe('AutomationService', () => {
       const unsubscribeSpy = vi.spyOn(bus, 'unsubscribe')
 
       service.init()
-      expect(subscribeSpy).toHaveBeenCalledTimes(8)
+      // 4 record events + 4 approval completion events + approval.task_created (A-2a)
+      expect(subscribeSpy).toHaveBeenCalledTimes(9)
       expect(subscribeSpy).toHaveBeenCalledWith(
         'multitable.record.created',
         expect.any(Function),
@@ -398,7 +399,7 @@ describe('AutomationService', () => {
       )
 
       service.shutdown()
-      expect(unsubscribeSpy).toHaveBeenCalledTimes(8)
+      expect(unsubscribeSpy).toHaveBeenCalledTimes(9)
     })
   })
 })

--- a/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
@@ -10,7 +10,7 @@ describe('parallel_branch automation action migration (A6-3-4 / W3-1)', () => {
     // This is no longer the LATEST migration (delete_record widened the constraint afterwards — see
     // `delete-record-automation-action-migration.test.ts` for the live "latest in sync" guard). Every
     // app-level action type except the ones introduced by a strictly-later migration must already be here.
-    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['delete_record', 'record_click'])
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['delete_record', 'record_click', 'send_dingtalk_approval_card'])
     for (const actionType of ALL_ACTION_TYPES) {
       if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH).toContain(actionType)

--- a/packages/core-backend/tests/unit/record-click-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/record-click-automation-action-migration.test.ts
@@ -6,10 +6,12 @@ import {
 } from '../../src/db/migrations/zzzz20260615150000_add_record_click_automation_action'
 
 describe('record_click automation action migration (B1-a1)', () => {
-  it('keeps the latest database action constraint in sync with app-level action types', () => {
-    // This migration widens chk_automation_action_type to the CURRENT ALL_ACTION_TYPES — so a future
-    // action type added to the app without a DB migration trips this drift guard RED.
+  it('keeps this constraint in sync with app-level action types except those added by later migrations', () => {
+    // No longer the LATEST migration (send_dingtalk_approval_card widened the constraint afterwards —
+    // see approval-card-automation-action-migration.test.ts for the live "latest in sync" guard).
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['send_dingtalk_approval_card'])
     for (const actionType of ALL_ACTION_TYPES) {
+      if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_RECORD_CLICK).toContain(actionType)
     }
   })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -62,6 +62,10 @@ export default defineConfig({
       // a WHOLE FILE into the `Run approval real-DB integration` step in plugin-tests.yml where it
       // runs against real Postgres every PR.
       'tests/integration/dingtalk-approval-card-deliveries.db.test.ts',
+      // A-2a approval.task_created trigger chain: DATABASE_URL-gated (describeIfDatabase). Excluded
+      // from the no-DB default job so it doesn't skip-green, and wired as a WHOLE FILE into the
+      // automation real-DB step in plugin-tests.yml where it runs against real Postgres every PR.
+      'tests/integration/automation-approval-task-created-trigger.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -68,6 +68,8 @@ export default defineConfig({
       'tests/integration/automation-approval-task-created-trigger.test.ts',
       // A-2b approval-card action chain: DATABASE_URL-gated. Same two-point wiring (no skip-green).
       'tests/integration/automation-dingtalk-approval-card-action.test.ts',
+      // A-4 card-delivery wrapper: DATABASE_URL-gated. Same two-point wiring (no skip-green).
+      'tests/integration/approval-card-delivery-wrapper.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -66,6 +66,8 @@ export default defineConfig({
       // from the no-DB default job so it doesn't skip-green, and wired as a WHOLE FILE into the
       // automation real-DB step in plugin-tests.yml where it runs against real Postgres every PR.
       'tests/integration/automation-approval-task-created-trigger.test.ts',
+      // A-2b approval-card action chain: DATABASE_URL-gated. Same two-point wiring (no skip-green).
+      'tests/integration/automation-dingtalk-approval-card-action.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## Summary

一键处理 design-lock（#3594，已 ratify）的 **A-2 → A-4-core 一体切片**，三提交边界与 owner 审定一致：

| Commit | 内容 |
|---|---|
| `fcf2d5e79` **A-2a** | `approval.task_created` 一级自动化触发器：**每受理人一事件**（非按节点泛发），eventId 四元组 `instanceId:nodeKey:entryEpoch:assigneeUserId`；引擎 9 个 `insertAssignments` 调用点 collector 化 + **post-commit 发射**（emitter 复核 is_active——同事务 auto-approve 级联零误发）；T2-6 dedup `approval.task_created:${eventId}`；templateId-null v1 out-of-contract；保存门 create+**update resulting-shape** 双闸 + creator 两腿（approvals:read + 模板可见性）保存与 fire 双查；通知类动作白名单；CHECK-widen 迁移 + FE 触发器全套 |
| `56bfdca5a` **A-2b** | `send_dingtalk_approval_card` 专名动作：**收件人固定取事件 assignee**（config 空，无手填面）+ 放置闸双端（仅 task_created）；**台账先行**（发送前写 A-1 台账 → 成功补 task_id → 失败 send_status/send_error 可追踪）；未绑定 → person-delivery `skipped` 遥测 + 无卡片行 + 绝不猜映射；深链仅 `d=<deliveryId>&t=<HMAC>`（values-free，URL 无 instanceId、卡片体无表单值，测试双断言）；action_card client 函数；迁移 parity tripwire 四文件同步 |
| `aee1041ed` **A-3+A-4-core** | **Review P1（死链边界）按选项 1 关闭**：`/m/approval-decision` 决策页 + card-delivery 端点同 PR 成活链。§4 wrapper：token 校验（timingSafeEqual + 无 secret fail-closed）/ ledger-only 反查 / `dispatchAction` 零旁路 / **channelOrigin 服务端注入**（HTTP 白名单构造不可 body 注入）→ `approval_records.metadata.channel='dingtalk_card'`；`GET/POST /api/approval-card-deliveries/:deliveryId(/actions)`（404 无存在性预言 / 409 带真实态 / 引擎 4xx 透传）。**Review P2（claim）**：`send_status='sent'` 并入 claim 条件 + pending/failed 负例。**Review P2（登录语义）**：公开 shell + 未登录直走 `/api/auth/dingtalk/launch?redirect=<深链>`（LoginView 契约）+ sessionStorage 防循环 + 弹回手动按钮。**P3 缩进**已修 |

## Owner review 口径逐条对照

- ✅ 每新 active assignment/recipient 发事件（transfer/add-sign/return/jump 路径真库逐一验证；acted 行不复发）
- ✅ eventId 四元组锁死；退回/跳转新轮重发；同轮重复 emit 被 T2-6 吃掉（at-least-once 契约，已知 create/return 同轮双 emit 由账本吸收、执行数精确——PR 声明）
- ✅ fire 两腿复查与 completed 同级（含 post-save visibility 翻转 fire-skip 合成事件用例）
- ✅ 保存门盖 create+update 局部更新走私洞
- ✅ **并发 tripwire**：`Promise.all` 双 approve → 恰一 engine action / 恰一 approve 记录 / 恰一 channel metadata / 恰一 claim；败者携真实终态（dispatch-then-claim 窗口由引擎关闭，test-locked）
- ✅ 决策页禁直连 raw 动作路由（静态 tripwire，开发期逮住过自家注释）

## Verification

- 真库集成 **17/17** 三文件（trigger 5 / card action 5 / wrapper 7），全部两点 CI 接线同 commit
- 换底后冒烟：backend tsc 0、vue-tsc 0、FE specs 124/124；换底前全量 unit 5332/0
- 迁移 ×3 本地真库执行成功
- **A-5 跟进**：生产构建 + 真实钉钉应用 UAT（USE_MOCK 只盖 DEV）+ 验证 MD，随锁 checklist 下一项

🤖 Generated with [Claude Code](https://claude.com/claude-code)