### PR TITLE
[codex] feat(multitable): window grouped grid rows

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -33,7 +33,10 @@
           </tr>
         </thead>
         <tbody v-if="groupedRows">
-          <template v-for="item in groupRenderItems" :key="item.kind + ':' + (item.kind === 'data' ? item.row.id : item.path + ':' + item.kind)">
+          <tr v-if="topSpacerHeight > 0" class="meta-grid__spacer" aria-hidden="true" data-test="grid-top-spacer">
+            <td :colspan="colSpan" :style="{ height: `${topSpacerHeight}px`, padding: '0', border: 'none' }"></td>
+          </tr>
+          <template v-for="item in windowedGroupRenderItems" :key="item.kind + ':' + (item.kind === 'data' ? item.row.id : item.path + ':' + item.kind)">
             <!-- Nested group header: one per level, indented by depth, per-level collapse toggle -->
             <tr v-if="item.kind === 'header'" class="meta-grid__group-header" :class="`meta-grid__group-header--l${item.level}`" data-test="group-header" :data-group-path="item.path" :data-group-level="item.level" @click="toggleGroup(item.path)">
               <td :colspan="colSpan">
@@ -143,6 +146,9 @@
               </td>
             </tr>
           </template>
+          <tr v-if="bottomSpacerHeight > 0" class="meta-grid__spacer" aria-hidden="true" data-test="grid-bottom-spacer">
+            <td :colspan="colSpan" :style="{ height: `${bottomSpacerHeight}px`, padding: '0', border: 'none' }"></td>
+          </tr>
           <tr v-if="!rows.length && !loading">
             <td :colspan="colSpan" class="meta-grid__empty">
               <div class="meta-grid__empty-icon">&#x1F4CB;</div>
@@ -597,6 +603,8 @@ const tableWrap = ref<HTMLElement | null>(null)
 const scrollTop = ref(0)
 const viewportHeight = ref(0)
 const measuredRowHeight = ref(0)
+const measuredGroupHeaderHeight = ref(0)
+const measuredGroupSubtotalHeight = ref(0)
 // Overscan rows above/below the viewport so fast scroll / keyboard nav never reveals a blank gap.
 const OVERSCAN_ROWS = 8
 // Below this many rows the common case renders identically (no spacer rows) — small datasets are
@@ -612,6 +620,8 @@ function densityRowHeight(): number {
   return 36
 }
 const rowHeightPx = computed(() => (measuredRowHeight.value > 0 ? measuredRowHeight.value : densityRowHeight()))
+const groupHeaderHeightPx = computed(() => (measuredGroupHeaderHeight.value > 0 ? measuredGroupHeaderHeight.value : rowHeightPx.value))
+const groupSubtotalHeightPx = computed(() => (measuredGroupSubtotalHeight.value > 0 ? measuredGroupSubtotalHeight.value : rowHeightPx.value))
 
 // While printing we render EVERY row (a windowed table would print only ~20 rows). beforeprint flips
 // this and afterprint restores it (the print itself reads the synchronously-rendered DOM).
@@ -657,9 +667,19 @@ const windowRows = computed<Array<{ row: MetaRecord; index: number }>>(() => {
 })
 // Spacer heights reserve the off-screen rows' vertical space so the scrollbar + scroll position match a
 // fully-rendered table. zero when windowing is off (no spacer rows are emitted then).
-const topSpacerHeight = computed(() => (flatWindowEnabled.value ? windowStart.value * rowHeightPx.value : 0))
+const topSpacerHeight = computed(() =>
+  flatWindowEnabled.value
+    ? windowStart.value * rowHeightPx.value
+    : groupedWindowEnabled.value
+      ? groupedItemOffsets.value[groupWindowStart.value]
+      : 0,
+)
 const bottomSpacerHeight = computed(() =>
-  flatWindowEnabled.value ? (filteredRows.value.length - windowEnd.value) * rowHeightPx.value : 0,
+  flatWindowEnabled.value
+    ? (filteredRows.value.length - windowEnd.value) * rowHeightPx.value
+    : groupedWindowEnabled.value
+      ? groupedTotalHeight.value - groupedItemOffsets.value[groupWindowEnd.value]
+      : 0,
 )
 
 // ── A1: infinite-scroll trigger (the ACTIVATION of the windowing above) ─────────────────────────────
@@ -700,6 +720,12 @@ function measureViewport() {
   const firstRow = tableWrap.value.querySelector<HTMLElement>('tbody tr.meta-grid__row')
   const rh = firstRow?.offsetHeight ?? 0
   if (rh > 0) measuredRowHeight.value = rh
+  const firstGroupHeader = tableWrap.value.querySelector<HTMLElement>('tbody tr.meta-grid__group-header')
+  const gh = firstGroupHeader?.offsetHeight ?? 0
+  if (gh > 0) measuredGroupHeaderHeight.value = gh
+  const firstGroupSubtotal = tableWrap.value.querySelector<HTMLElement>('tbody tr.meta-grid__group-subtotal')
+  const gs = firstGroupSubtotal?.offsetHeight ?? 0
+  if (gs > 0) measuredGroupSubtotalHeight.value = gs
   maybeKickWhenNotScrollable()
 }
 
@@ -718,9 +744,21 @@ function maybeKickWhenNotScrollable() {
 // Keep the focused row inside the mounted window during keyboard navigation so arrow-keys never land on
 // an un-rendered row. No-op when windowing is off or no row is focused.
 function scrollFocusedRowIntoWindow() {
-  if (!flatWindowEnabled.value || !tableWrap.value || focusRow.value < 0) return
-  const rowTop = focusRow.value * rowHeightPx.value
-  const rowBottom = rowTop + rowHeightPx.value
+  if (!tableWrap.value || focusRow.value < 0) return
+  let rowTop = 0
+  let rowBottom = 0
+  if (groupedWindowEnabled.value) {
+    const itemIndex = groupedDataItemIndexForNavIndex(focusRow.value)
+    if (itemIndex < 0) return
+    const offsets = groupedItemOffsets.value
+    rowTop = offsets[itemIndex]
+    rowBottom = offsets[itemIndex + 1]
+  } else if (flatWindowEnabled.value) {
+    rowTop = focusRow.value * rowHeightPx.value
+    rowBottom = rowTop + rowHeightPx.value
+  } else {
+    return
+  }
   const viewTop = tableWrap.value.scrollTop
   const viewBottom = viewTop + effectiveViewportHeight.value
   let next = viewTop
@@ -859,6 +897,86 @@ const groupRenderItems = computed<GroupRenderItem[]>(() => {
   walk(groupedRows.value)
   return items
 })
+
+const renderableGroupItems = computed(() =>
+  hasGroupSubtotals.value ? groupRenderItems.value : groupRenderItems.value.filter((item) => item.kind !== 'subtotal'),
+)
+
+const groupedWindowEnabled = computed(() =>
+  !printing.value
+  && !!groupedRows.value
+  && renderableGroupItems.value.length > VIRTUALIZE_MIN_ROWS,
+)
+
+function groupRenderItemHeight(item: GroupRenderItem): number {
+  if (item.kind === 'header') return groupHeaderHeightPx.value
+  if (item.kind === 'subtotal') return groupSubtotalHeightPx.value
+  return rowHeightPx.value
+}
+
+const groupedItemOffsets = computed(() => {
+  const offsets: number[] = [0]
+  let next = 0
+  for (const item of renderableGroupItems.value) {
+    next += groupRenderItemHeight(item)
+    offsets.push(next)
+  }
+  return offsets
+})
+
+const groupedTotalHeight = computed(() => groupedItemOffsets.value[groupedItemOffsets.value.length - 1] ?? 0)
+
+function groupedItemIndexAtOffset(pixelTop: number): number {
+  const items = renderableGroupItems.value
+  if (items.length === 0) return 0
+  const offsets = groupedItemOffsets.value
+  const clamped = Math.max(0, Math.min(pixelTop, groupedTotalHeight.value - 1))
+  let lo = 0
+  let hi = items.length
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi + 1) / 2)
+    if (offsets[mid] <= clamped) lo = mid
+    else hi = mid - 1
+  }
+  return Math.min(items.length - 1, lo)
+}
+
+function groupedEndIndexAtOffset(pixelBottom: number): number {
+  const items = renderableGroupItems.value
+  if (items.length === 0) return 0
+  const offsets = groupedItemOffsets.value
+  const clamped = Math.max(0, Math.min(pixelBottom, groupedTotalHeight.value))
+  let lo = 0
+  let hi = items.length
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2)
+    if (offsets[mid] < clamped) lo = mid + 1
+    else hi = mid
+  }
+  return Math.max(1, Math.min(items.length, lo))
+}
+
+const groupWindowStart = computed(() => {
+  if (!groupedWindowEnabled.value) return 0
+  return Math.max(0, groupedItemIndexAtOffset(scrollTop.value) - OVERSCAN_ROWS)
+})
+
+const groupWindowEnd = computed(() => {
+  const items = renderableGroupItems.value
+  if (!groupedWindowEnabled.value) return items.length
+  const visibleEnd = groupedEndIndexAtOffset(scrollTop.value + effectiveViewportHeight.value)
+  return Math.max(groupWindowStart.value + 1, Math.min(items.length, visibleEnd + OVERSCAN_ROWS))
+})
+
+const windowedGroupRenderItems = computed(() => {
+  const items = renderableGroupItems.value
+  if (!groupedWindowEnabled.value) return items
+  return items.slice(groupWindowStart.value, groupWindowEnd.value)
+})
+
+function groupedDataItemIndexForNavIndex(navIndex: number): number {
+  return renderableGroupItems.value.findIndex((item) => item.kind === 'data' && item.navIndex === navIndex)
+}
 
 // Flat list for keyboard nav (data rows only, respecting collapsed groups). Built from the same tree so
 // it matches groupRenderItems' navIndex ordering exactly.

--- a/apps/web/tests/meta-grid-table-virtualization.spec.ts
+++ b/apps/web/tests/meta-grid-table-virtualization.spec.ts
@@ -12,7 +12,7 @@
  * conditional-format cells still render in-window) — never brittle exact pixel counts.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, h, nextTick, type App } from 'vue'
+import { createApp, h, nextTick, ref, type App } from 'vue'
 import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
 import type { MetaField, MetaRecord } from '../src/multitable/types'
 import type { EvaluatedFormatting, FieldScaleMap } from '../src/multitable/utils/conditional-formatting'
@@ -33,11 +33,12 @@ const FIELDS: MetaField[] = [
   { id: 'title', name: 'Title', type: 'string' },
   { id: 'score', name: 'Score', type: 'number' },
 ]
+const GROUP_FIELD: MetaField = { id: 'group', name: 'Group', type: 'string' }
 
 function makeRows(n: number): MetaRecord[] {
   const rows: MetaRecord[] = []
   for (let i = 0; i < n; i++) {
-    rows.push({ id: `r${i}`, version: 1, data: { title: `Row ${i}`, score: i } })
+    rows.push({ id: `r${i}`, version: 1, data: { title: `Row ${i}`, score: i, group: `Group ${i % 30}` } })
   }
   return rows
 }
@@ -89,6 +90,16 @@ function dataRowIds(root: HTMLDivElement): string[] {
 
 function renderedRowCount(root: HTMLDivElement): number {
   return root.querySelectorAll('tbody tr.meta-grid__row').length
+}
+
+function renderedGroupItemCount(root: HTMLDivElement): number {
+  return root.querySelectorAll('tbody tr.meta-grid__row, tbody tr.meta-grid__group-header, tbody tr.meta-grid__group-subtotal').length
+}
+
+function spacerHeight(root: HTMLDivElement, selector: string): number {
+  const cell = root.querySelector<HTMLElement>(`${selector} td`)
+  const parsed = Number.parseFloat(cell?.style.height ?? '0')
+  return Number.isFinite(parsed) ? parsed : 0
 }
 
 describe('MetaGridTable row virtualization (A1)', () => {
@@ -222,6 +233,189 @@ describe('MetaGridTable row virtualization (A1)', () => {
     expect(renderedRowCount(root)).toBe(2000)
     expect(root.querySelector('[data-test="grid-top-spacer"]')).toBeNull()
     expect(root.querySelector('[data-test="grid-bottom-spacer"]')).toBeNull()
+  })
+})
+
+describe('MetaGridTable grouped row virtualization (GW)', () => {
+  it('renders only a windowed subset of grouped rows when grouped item count is large', async () => {
+    const root = mountGrid(makeRows(3000), { groupField: GROUP_FIELD })
+    setViewport(root, 600)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    expect(renderedRowCount(root)).toBeGreaterThan(0)
+    expect(renderedRowCount(root)).toBeLessThan(200)
+    expect(renderedGroupItemCount(root)).toBeLessThan(240)
+    expect(root.querySelector('[data-test="grid-bottom-spacer"]')).toBeTruthy()
+    // C1: spacers reserve the exact full grouped stream height under jsdom's 36px density fallback.
+    const fullItems = 3000 + 30 // data rows + group headers; no subtotal rows without aggregateGroups
+    const mountedItems = renderedGroupItemCount(root)
+    expect(spacerHeight(root, '[data-test="grid-top-spacer"]') + mountedItems * 36 + spacerHeight(root, '[data-test="grid-bottom-spacer"]')).toBe(fullItems * 36)
+  })
+
+  it('shifts the grouped rendered window when the container is scrolled', async () => {
+    const root = mountGrid(makeRows(3000), { groupField: GROUP_FIELD })
+    const wrap = setViewport(root, 600)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    const firstBefore = dataRowIds(root)[0]
+    expect(firstBefore).toBe('1')
+
+    wrap.scrollTop = 18000
+    wrap.dispatchEvent(new Event('scroll'))
+    await nextTick()
+
+    const firstAfter = dataRowIds(root)[0]
+    expect(firstAfter).not.toBe(firstBefore)
+    expect(Number(firstAfter)).toBeGreaterThan(100)
+    expect(renderedRowCount(root)).toBeLessThan(200)
+    expect(root.querySelector('[data-test="grid-top-spacer"]')).toBeTruthy()
+  })
+
+  it('renders small grouped sets fully without spacer rows', async () => {
+    const root = mountGrid(makeRows(10), { groupField: GROUP_FIELD })
+    setViewport(root, 600)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    expect(renderedRowCount(root)).toBe(10)
+    expect(root.querySelector('[data-test="grid-top-spacer"]')).toBeNull()
+    expect(root.querySelector('[data-test="grid-bottom-spacer"]')).toBeNull()
+  })
+
+  it('keeps the keyboard-focused grouped row inside the rendered window while navigating down', async () => {
+    const root = mountGrid(makeRows(3000), { groupField: GROUP_FIELD })
+    const wrap = setViewport(root, 600)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    const grid = root.querySelector('.meta-grid') as HTMLElement
+    const scrollBefore = wrap.scrollTop
+    const PRESSES = 80
+    for (let i = 0; i < PRESSES; i++) {
+      grid.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    }
+    await nextTick()
+
+    expect(wrap.scrollTop).toBeGreaterThan(scrollBefore)
+    const focused = root.querySelector('tbody tr.meta-grid__row--focused') as HTMLElement | null
+    expect(focused).toBeTruthy()
+    expect(focused!.querySelector('.meta-grid__row-num span')?.textContent?.trim()).toBe(String(PRESSES))
+    expect(renderedRowCount(root)).toBeLessThan(200)
+  })
+
+  it('keeps select-all model-based under grouped windowing', async () => {
+    const onSelectionChange = vi.fn()
+    const root = mountGrid(makeRows(3000), {
+      groupField: GROUP_FIELD,
+      enableMultiSelect: true,
+      onSelectionChange,
+    })
+    setViewport(root, 600)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    expect(renderedRowCount(root)).toBeLessThan(200)
+    const checkbox = root.querySelector('thead input[type="checkbox"]') as HTMLInputElement
+    checkbox.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    const selected = onSelectionChange.mock.calls.at(-1)?.[0] as string[]
+    expect(selected).toHaveLength(3000)
+    expect(selected[0]).toBe('r0')
+    expect(selected.at(-1)).toBe('r2999')
+  })
+
+  it('forces full grouped render during print and restores windowing after print', async () => {
+    const root = mountGrid(makeRows(3000), { groupField: GROUP_FIELD })
+    setViewport(root, 600)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    expect(renderedRowCount(root)).toBeLessThan(200)
+    window.dispatchEvent(new Event('beforeprint'))
+    await nextTick()
+
+    expect(renderedRowCount(root)).toBe(3000)
+    expect(root.querySelector('[data-test="grid-top-spacer"]')).toBeNull()
+    expect(root.querySelector('[data-test="grid-bottom-spacer"]')).toBeNull()
+
+    window.dispatchEvent(new Event('afterprint'))
+    await nextTick()
+    expect(renderedRowCount(root)).toBeLessThan(200)
+    expect(root.querySelector('[data-test="grid-bottom-spacer"]')).toBeTruthy()
+  })
+
+  it('keeps server subtotal values intact inside the grouped window', async () => {
+    const root = mountGrid(makeRows(300), {
+      groupField: GROUP_FIELD,
+      aggregationConfig: { score: 'sum' },
+      aggregateGroups: Array.from({ length: 30 }, (_, i) => ({
+        key: `Group ${i}`,
+        count: 10,
+        aggregates: { score: { fn: 'sum', value: 9000 + i } },
+      })),
+    })
+    setViewport(root, 600)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    expect(renderedGroupItemCount(root)).toBeLessThan(120)
+    const subtotal = root.querySelector('[data-test="group-subtotal"][data-group-path="Group 0"]') as HTMLElement | null
+    expect(subtotal).toBeTruthy()
+    expect(subtotal!.textContent).toContain('9000')
+  })
+
+  it('clamps to a nonblank grouped window after a controlled collapse while scrolled', async () => {
+    app?.unmount()
+    container?.remove()
+    const collapsed = ref<string[]>([])
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      setup() {
+        return () => h(MetaGridTable, {
+          rows: makeRows(3000),
+          visibleFields: FIELDS,
+          sortRules: [],
+          loading: false,
+          currentPage: 1,
+          totalPages: 1,
+          startIndex: 0,
+          canEdit: true,
+          canDelete: true,
+          searchText: '',
+          rowDensity: 'normal',
+          groupField: GROUP_FIELD,
+          collapsedGroupKeys: collapsed.value,
+          onToggleGroup: (key: string) => {
+            collapsed.value = collapsed.value.includes(key)
+              ? collapsed.value.filter((item) => item !== key)
+              : [...collapsed.value, key]
+          },
+        })
+      },
+    })
+    app.mount(container)
+    const root = container
+    const wrap = setViewport(root, 600)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+
+    wrap.scrollTop = 18000
+    wrap.dispatchEvent(new Event('scroll'))
+    await nextTick()
+
+    const header = root.querySelector('[data-test="group-header"]') as HTMLElement
+    const toggledPath = header.getAttribute('data-group-path')
+    header.click()
+    await nextTick()
+
+    expect(collapsed.value).toContain(toggledPath)
+    expect(renderedGroupItemCount(root)).toBeGreaterThan(0)
+    expect(renderedGroupItemCount(root)).toBeLessThan(240)
+    expect(root.querySelector(`[data-test="group-header"][data-group-path="${toggledPath}"]`)).toBeTruthy()
   })
 })
 

--- a/apps/web/tests/multitable-grid-perf-baseline.spec.ts
+++ b/apps/web/tests/multitable-grid-perf-baseline.spec.ts
@@ -111,8 +111,8 @@ describe('grid perf baseline — flat (windowed) path', () => {
   })
 })
 
-describe('grid perf baseline — grouped path (NOT windowed — confirms the code-level finding)', () => {
-  it('grouped mode renders EVERY row into the DOM regardless of scale (no windowing on this path)', () => {
+describe('grid perf baseline — grouped path (windowed after GW runtime)', () => {
+  it('grouped mode renders a bounded row window at scale', () => {
     const N = 3_000
     const rows = makeRows(N, 30) // 30 groups, ~100 rows/group
     const groupField = FIELDS.find((f) => f.id === 'group')!
@@ -121,10 +121,9 @@ describe('grid perf baseline — grouped path (NOT windowed — confirms the cod
     const mountMs = performance.now() - t0
     const rendered = domRowCount(root)
     // eslint-disable-next-line no-console
-    console.log(`[grid-perf] GROUPED ${N} rows / 30 groups: mount=${mountMs.toFixed(1)}ms, DOM rows=${rendered} (expect ≈${N}, i.e. unwindowed)`)
-    // The component's own code comment says windowing is "active only on the flat path... otherwise the
-    // template renders every row exactly as before" — this assertion proves that in a REAL render, not
-    // just from reading the comment.
-    expect(rendered).toBeGreaterThan(N * 0.9)
+    console.log(`[grid-perf] GROUPED ${N} rows / 30 groups: mount=${mountMs.toFixed(1)}ms, DOM rows=${rendered} (windowed)`)
+    expect(rendered).toBeGreaterThan(0)
+    expect(rendered).toBeLessThan(200)
+    expect(root.querySelector('[data-test="grid-bottom-spacer"]')).toBeTruthy()
   })
 })

--- a/apps/web/verification/grouped-windowing-harness.html
+++ b/apps/web/verification/grouped-windowing-harness.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Multitable grouped windowing — browser verification harness</title></head>
+  <body style="margin:16px;font-family:system-ui">
+    <h3>Grouped grid windowing — browser verification</h3>
+    <div id="app"></div>
+    <script type="module" src="./grouped-windowing-harness.ts"></script>
+  </body>
+</html>

--- a/apps/web/verification/grouped-windowing-harness.ts
+++ b/apps/web/verification/grouped-windowing-harness.ts
@@ -1,0 +1,159 @@
+// Browser-verification harness for grouped grid windowing. It mounts the real
+// MetaGridTable with a production-scale grouped row set and publishes bounded,
+// values-free render metrics for Playwright to assert.
+import { createApp, h, nextTick } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+
+declare global {
+  interface Window {
+    __GW_METRICS__?: GroupedWindowingMetrics
+  }
+}
+
+interface Snapshot {
+  dataRows: number
+  groupHeaders: number
+  groupSubtotals: number
+  mountedItems: number
+  topSpacerHeight: number
+  bottomSpacerHeight: number
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  firstRowNumber: string | null
+  lastRowNumber: string | null
+}
+
+interface GroupedWindowingMetrics {
+  ready: true
+  rows: number
+  groups: number
+  expectedFullDataRows: number
+  expectedFullGroupHeaders: number
+  mountMs: number
+  scrollFrameMs: number
+  initial: Snapshot
+  afterScroll: Snapshot
+}
+
+const params = new URLSearchParams(window.location.search)
+const ROW_COUNT = Math.max(1, Math.min(20_000, Number(params.get('rows') ?? 5_000) || 5_000))
+const GROUP_COUNT = Math.max(1, Math.min(500, Number(params.get('groups') ?? 50) || 50))
+
+const FIELDS: MetaField[] = [
+  { id: 'group', name: 'Group', type: 'string' },
+  { id: 'title', name: 'Title', type: 'string' },
+  { id: 'score', name: 'Score', type: 'number' },
+]
+const GROUP_FIELD = FIELDS[0]
+
+function makeRows(n: number, groups: number): MetaRecord[] {
+  const rows: MetaRecord[] = []
+  for (let i = 0; i < n; i++) {
+    const group = `Group ${String(i % groups).padStart(3, '0')}`
+    rows.push({
+      id: `r${i}`,
+      version: 1,
+      data: {
+        group,
+        title: `Row ${i}`,
+        score: i,
+      },
+    })
+  }
+  return rows
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+}
+
+async function flushRender(): Promise<void> {
+  await nextTick()
+  await nextFrame()
+  await nextTick()
+}
+
+function spacerHeight(selector: string): number {
+  const el = document.querySelector<HTMLElement>(selector)
+  const cell = el?.querySelector<HTMLElement>('td')
+  if (!cell) return 0
+  const parsed = Number.parseFloat(cell.style.height || getComputedStyle(cell).height || '0')
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function snapshot(): Snapshot {
+  const wrap = document.querySelector<HTMLElement>('.meta-grid__table-wrap')
+  const rowNumbers = Array.from(document.querySelectorAll<HTMLElement>('tbody tr.meta-grid__row .meta-grid__row-num span'))
+    .map((el) => el.textContent?.trim() ?? '')
+    .filter(Boolean)
+  const dataRows = document.querySelectorAll('tbody tr.meta-grid__row').length
+  const groupHeaders = document.querySelectorAll('tbody tr.meta-grid__group-header').length
+  const groupSubtotals = document.querySelectorAll('tbody tr.meta-grid__group-subtotal').length
+  return {
+    dataRows,
+    groupHeaders,
+    groupSubtotals,
+    mountedItems: dataRows + groupHeaders + groupSubtotals,
+    topSpacerHeight: spacerHeight('[data-test="grid-top-spacer"]'),
+    bottomSpacerHeight: spacerHeight('[data-test="grid-bottom-spacer"]'),
+    scrollTop: wrap?.scrollTop ?? 0,
+    scrollHeight: wrap?.scrollHeight ?? 0,
+    clientHeight: wrap?.clientHeight ?? 0,
+    firstRowNumber: rowNumbers[0] ?? null,
+    lastRowNumber: rowNumbers[rowNumbers.length - 1] ?? null,
+  }
+}
+
+const rows = makeRows(ROW_COUNT, GROUP_COUNT)
+const mountStart = performance.now()
+
+createApp({
+  setup() {
+    return () => h('div', { style: 'height:640px;border:1px solid #d8dee4;display:flex;min-height:0' }, [
+      h(MetaGridTable, {
+        rows,
+        visibleFields: FIELDS,
+        sortRules: [],
+        loading: false,
+        currentPage: 1,
+        totalPages: 1,
+        startIndex: 0,
+        canEdit: true,
+        canDelete: true,
+        searchText: '',
+        rowDensity: 'normal',
+        groupField: GROUP_FIELD,
+      }),
+    ])
+  },
+}).mount('#app')
+
+async function run() {
+  await flushRender()
+  const mountMs = performance.now() - mountStart
+  const initial = snapshot()
+  const wrap = document.querySelector<HTMLElement>('.meta-grid__table-wrap')
+  const scrollStart = performance.now()
+  if (wrap) {
+    wrap.scrollTop = Math.max(0, Math.floor(wrap.scrollHeight * 0.5))
+    wrap.dispatchEvent(new Event('scroll'))
+  }
+  await flushRender()
+  const scrollFrameMs = performance.now() - scrollStart
+  window.__GW_METRICS__ = {
+    ready: true,
+    rows: ROW_COUNT,
+    groups: GROUP_COUNT,
+    expectedFullDataRows: ROW_COUNT,
+    expectedFullGroupHeaders: GROUP_COUNT,
+    mountMs,
+    scrollFrameMs,
+    initial,
+    afterScroll: snapshot(),
+  }
+  window.dispatchEvent(new Event('gw-metrics-ready'))
+}
+
+void run()

--- a/apps/web/verification/grouped-windowing.spec.ts
+++ b/apps/web/verification/grouped-windowing.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+
+const OUT = 'verification-output'
+const HARNESS = '/verification/grouped-windowing-harness.html?rows=5000&groups=50'
+const EXPECT_UNWINDOWED = process.env.GW_EXPECT_UNWINDOWED === '1'
+
+test('grouped grid render is browser-windowed at 5k rows / 50 groups', async ({ page }) => {
+  mkdirSync(OUT, { recursive: true })
+  const errs: string[] = []
+  page.on('console', (m) => { if (m.type() === 'error') errs.push(`console: ${m.text()}`) })
+  page.on('pageerror', (e) => errs.push(`pageerror: ${String(e)}`))
+
+  await page.goto(HARNESS, { waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(() => window.__GW_METRICS__?.ready === true, null, { timeout: 60_000 })
+  await page.screenshot({ path: `${OUT}/gw-grouped-windowing.png`, fullPage: true })
+  const metrics = await page.evaluate(() => window.__GW_METRICS__!)
+  writeFileSync(`${OUT}/gw-grouped-windowing.json`, `${JSON.stringify(metrics, null, 2)}\n`)
+  // eslint-disable-next-line no-console
+  console.log(`[gw-browser] rows=${metrics.rows}, groups=${metrics.groups}, mount=${metrics.mountMs.toFixed(1)}ms, scrollFrame=${metrics.scrollFrameMs.toFixed(1)}ms, initialItems=${metrics.initial.mountedItems}, afterScrollItems=${metrics.afterScroll.mountedItems}, firstBefore=${metrics.initial.firstRowNumber}, firstAfter=${metrics.afterScroll.firstRowNumber}`)
+
+  expect(metrics.rows).toBe(5_000)
+  expect(metrics.groups).toBe(50)
+  expect(metrics.mountMs).toBeGreaterThan(0)
+  expect(metrics.scrollFrameMs).toBeGreaterThan(0)
+
+  if (EXPECT_UNWINDOWED) {
+    expect(metrics.initial.dataRows).toBe(metrics.expectedFullDataRows)
+    expect(metrics.initial.groupHeaders).toBe(metrics.expectedFullGroupHeaders)
+    expect(metrics.initial.bottomSpacerHeight).toBe(0)
+    expect(metrics.initial.mountedItems).toBeGreaterThanOrEqual(5_050)
+  } else {
+    expect(metrics.initial.dataRows).toBeGreaterThan(0)
+    expect(metrics.initial.dataRows).toBeLessThan(220)
+    expect(metrics.initial.mountedItems).toBeLessThan(280)
+    expect(metrics.initial.bottomSpacerHeight).toBeGreaterThan(0)
+    expect(metrics.afterScroll.dataRows).toBeGreaterThan(0)
+    expect(metrics.afterScroll.dataRows).toBeLessThan(220)
+    expect(metrics.afterScroll.mountedItems).toBeLessThan(280)
+    expect(metrics.afterScroll.topSpacerHeight).toBeGreaterThan(0)
+    expect(metrics.afterScroll.firstRowNumber).not.toBe(metrics.initial.firstRowNumber)
+  }
+
+  expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
+})

--- a/docs/development/multitable-grid-grouped-windowing-runtime-verification-20260705.md
+++ b/docs/development/multitable-grid-grouped-windowing-runtime-verification-20260705.md
@@ -1,0 +1,137 @@
+# Multitable grid grouped-windowing runtime — dev & verification (2026-07-05)
+
+> **Design-lock**: `docs/development/multitable-grid-grouped-windowing-designlock-20260705.md`
+> (`#3591`, squash `b061d4166`).
+>
+> **Runtime**: PR #3648.
+>
+> **Runtime scope**: frontend render-only in `MetaGridTable.vue`, plus jsdom and Playwright
+> verification. No backend, API, storage, data-shape, env-flag, grouped paging, server-side grouping,
+> or cross-page grouping behavior changed.
+
+## 1. Line summary
+
+The measure-first baseline (`docs/development/multitable-grid-perf-baseline-20260705.md`, `#3582`,
+`b891780bd`) showed the flat grid path was already windowed, while the grouped `<tbody>` still mounted
+the whole flattened group stream. This runtime extends the existing flat-window architecture to grouped
+mode by slicing the already-existing `groupRenderItems` stream and reserving off-screen item height with
+top/bottom spacer rows.
+
+The slice is intentionally narrow: it makes large grouped render surfaces bounded in the DOM. It does
+not change grouped pagination, grouping semantics, server aggregate contracts, or how many records the
+workbench loads.
+
+## 2. Implementation
+
+Primary file:
+
+- `apps/web/src/multitable/components/MetaGridTable.vue`
+
+Runtime behavior:
+
+- The grouped branch now renders `windowedGroupRenderItems` rather than the full `groupRenderItems` list.
+- `renderableGroupItems` filters subtotal entries when there are no server subtotals, so the offset table
+  matches the actual mounted stream.
+- Grouped mode uses a per-kind height table:
+  - data row: existing density-aware `rowHeightPx`
+  - group header: measured first mounted `.meta-grid__group-header`, fallback to row height
+  - group subtotal: measured first mounted `.meta-grid__group-subtotal`, fallback to row height
+- `groupedItemOffsets` is a prefix-sum table over the renderable stream; scroll offset resolves to item
+  index by binary search.
+- The existing spacer row pattern is reused for grouped mode:
+  - `topSpacerHeight = offset[groupWindowStart]`
+  - `bottomSpacerHeight = totalHeight - offset[groupWindowEnd]`
+- Keyboard focus scroll-in-view now resolves grouped row pixel offsets through the grouped offset table;
+  flat focus math remains flat-only.
+- `printing` disables grouped windowing exactly as it already disables flat windowing.
+
+Verification files:
+
+- `apps/web/tests/meta-grid-table-virtualization.spec.ts`
+- `apps/web/tests/multitable-grid-perf-baseline.spec.ts`
+- `apps/web/verification/grouped-windowing-harness.html`
+- `apps/web/verification/grouped-windowing-harness.ts`
+- `apps/web/verification/grouped-windowing.spec.ts`
+
+## 3. Golden matrix
+
+| Lock | Proof |
+| --- | --- |
+| GW1 bounded grouped DOM | `3,000 rows / 30 groups` now mounts a bounded grouped window; baseline grouped spec flipped from "documents full render" to "locks bounded render". |
+| GW2 scroll sequence | Scrolling the grouped container changes the mounted first row while keeping DOM count bounded. |
+| GW3 spacer invariant | Under jsdom's 36px density fallback, `top spacer + mounted item heights + bottom spacer == full grouped stream height`. |
+| GW4 keyboard nav | Arrow navigation to an off-window grouped record scrolls that exact absolute `navIndex` into the mounted window. |
+| GW5 collapse clamp | Controlled group collapse while scrolled deep leaves a nonblank bounded window and keeps the toggled header mounted. |
+| GW6 subtotal parity | Server-provided `aggregateGroups` values render unchanged inside the grouped window. |
+| GW7 select-all parity | Header select-all emits all model row ids (`3,000`), not only mounted DOM ids. |
+| GW8 print | `beforeprint` forces full grouped render and zero spacers; `afterprint` restores windowing. |
+| GW9 flat path | Existing flat virtualization tests and related grouped/collapse/aggregation/link-chip regressions remain green. |
+| GW10 small grouped sets | `<=60` grouped items render fully with no spacer rows. |
+
+## 4. Browser measurements
+
+The design-lock required Playwright-driven before/after numbers against a live Vite dev server at a
+production-realistic grouped scale. The same `grouped-windowing` verification harness was run twice:
+
+- **Before**: temporary detached worktree at `origin/main@696b4824f` (the goal-pool refresh before this
+  runtime), with only the verification harness copied in and `GW_EXPECT_UNWINDOWED=1`.
+- **After**: this runtime branch, using the committed Playwright verification harness.
+
+Scale: `5,000` data rows / `50` groups.
+
+| Build | Mount time | Scroll-frame time | Initial mounted items | After-scroll mounted items | First row before -> after scroll |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Before `696b4824f` | `575.5ms` | `74.1ms` | `5,050` | `5,050` | `1 -> 1` |
+| After runtime branch | `22.3ms` | `11.9ms` | `29` | `38` | `1 -> 2493` |
+
+Interpretation:
+
+- Before: grouped mode mounted every data row plus every group header; scrolling did not change the
+  mounted stream because there was no window.
+- After: grouped mode mounts only the visible stream plus overscan; scrolling changes the mounted window
+  while preserving scroll geometry with spacers.
+
+The committed browser verifier writes the evidence to `apps/web/verification-output/gw-grouped-windowing.json`
+and asserts the bounded DOM/spacer/scroll-shift contract. The output directory is gitignored.
+
+## 5. Commands
+
+Local validation in `/private/tmp/mt-gw-runtime`:
+
+```text
+pnpm --filter @metasheet/web exec vitest run tests/meta-grid-table-virtualization.spec.ts tests/multitable-grid-perf-baseline.spec.ts --watch=false
+=> 23 tests / 2 files pass
+
+pnpm --filter @metasheet/web exec vitest run tests/multitable-grid-controlled-collapse.spec.ts tests/multitable-agg-footer-grid.spec.ts tests/multitable-grid-grouped-link-chip.spec.ts --watch=false
+=> 22 tests / 3 files pass
+
+pnpm --filter @metasheet/web type-check
+=> vue-tsc -b clean
+
+pnpm --filter @metasheet/web exec playwright test --config playwright.verification.config.ts
+=> 2 tests pass (cf-reactions + grouped-windowing)
+
+git diff --check
+=> clean
+```
+
+Before-browser measurement in `/private/tmp/mt-gw-before-browser`:
+
+```text
+GW_EXPECT_UNWINDOWED=1 pnpm --filter @metasheet/web exec playwright test --config playwright.verification.config.ts grouped-windowing.spec.ts
+=> 1 test pass; initialItems=5050; mount=575.5ms; scrollFrame=74.1ms
+```
+
+## 6. Boundaries
+
+Still out of scope and not touched:
+
+- grouped-mode infinite-scroll accumulation
+- server-side grouping or cross-page group coalescing
+- in-memory accumulation caps
+- grouped expand rows
+- backend/API changes
+- generic variable-height virtualizer adoption
+
+This runtime closes the grouped DOM-windowing gap only. It unlocks grouped scaling follow-ups; it does
+not silently implement them.

--- a/docs/development/multitable-window-goal-pool-todo-20260705.md
+++ b/docs/development/multitable-window-goal-pool-todo-20260705.md
@@ -38,7 +38,7 @@
 ## W2 — build 车道(各自 lock ratify 后解锁)
 
 - ✅ **W2-3 S2 runtime**(prompt-config-history UI)— runtime MERGED `6e844cf89`(#3643); verification MD added in `multitable-ai-shortcut-prompt-config-history-s2-dev-verification-20260705.md`。
-- ⬜ **W2-4 GW runtime**(grouped 视图窗口化)— 前置已达:#3582 baseline + #3591 ratified design-lock。Fable 5 build(offset-table + 不变量;难度高);占 grid 互斥锁;验收含 Playwright 真浏览器前后数字(lock 硬性条款);交付 verification MD。
+- ✅ **W2-4 GW runtime**(grouped 视图窗口化)— runtime PR #3648 已开:offset-table grouped windowing + jsdom goldens + Playwright 真浏览器前后数字 + verification MD。仍不含 grouped infinite-scroll / 跨页分组 / server-side grouping。
   W2-3 与 W2-4 文件面不重叠,可并行(不超并发上限)。
 
 ## W3 — 顺手批(单项 ≤半天;排在 W0 清空之后)


### PR DESCRIPTION
## Summary

- add grouped-path windowing to `MetaGridTable` by slicing the existing flattened `groupRenderItems` stream with per-kind height prefix offsets
- reuse the existing top/bottom spacer pattern for grouped mode, keep absolute `navIndex` and model-based selection semantics intact
- add jsdom goldens plus a Playwright verification harness for 5k rows / 50 groups, with before/after browser numbers recorded in a dev-verification MD

## Boundaries

- no backend/API/storage/env-flag changes
- no grouped infinite-scroll accumulation
- no server-side grouping or cross-page group coalescing
- no generic variable-height virtualizer adoption

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/meta-grid-table-virtualization.spec.ts tests/multitable-grid-perf-baseline.spec.ts --watch=false` => 23/23 pass
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-grid-controlled-collapse.spec.ts tests/multitable-agg-footer-grid.spec.ts tests/multitable-grid-grouped-link-chip.spec.ts --watch=false` => 22/22 pass
- `pnpm --filter @metasheet/web type-check` => clean
- `pnpm --filter @metasheet/web exec playwright test --config playwright.verification.config.ts` => 2/2 pass
- before browser run on old main `696b4824f` with the same harness: 5,050 mounted items, mount 575.5ms, scroll frame 74.1ms
- after browser run on this branch: 29 -> 38 mounted items, mount 22.3ms, scroll frame 11.9ms
- `git diff --check` => clean
