### PR TITLE
feat(web): approval list hot path — inline actions, aging chips, batch failure manifest (UX batch-1 B1-03)

### DIFF
--- a/apps/web/src/approvals/relativeWait.ts
+++ b/apps/web/src/approvals/relativeWait.ts
@@ -1,0 +1,53 @@
+/**
+ * Approval list hot-path — 已等待 aging + severity glanceability (UX batch-1 B1-03).
+ *
+ * Pure, Element-Plus-free helpers so "how long has this been waiting" is unit-testable
+ * independent of the views that render it (`ApprovalCenterView`'s 待我处理/我发起的 tabs,
+ * `ApprovalMobileList`'s card date line, `ApprovalDetailView`'s pending chip). The wording is
+ * intentionally Chinese-only (not routed through `useLocale()`) — approval views use inline
+ * Chinese by convention, and half-translating a label around an always-Chinese duration
+ * ("Waited 3 天") would read worse than staying fully Chinese.
+ */
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+/**
+ * Milliseconds elapsed between `createdAt` and `now`, clamped to >= 0 (a `createdAt` that is
+ * slightly in the future — clock skew — reads as "just now" rather than a negative duration).
+ * Returns `null` for an unparseable `createdAt` so callers can fail quiet instead of rendering
+ * "NaN 小时".
+ */
+function elapsedMs(createdAt: string, now: Date): number | null {
+  const createdMs = new Date(createdAt).getTime()
+  if (Number.isNaN(createdMs)) return null
+  return Math.max(0, now.getTime() - createdMs)
+}
+
+/**
+ * Human-readable "已等待" duration: '刚刚' under an hour, whole hours (rounded down) from an
+ * hour up to a day, whole days (rounded down) from a day onward. An invalid/unparseable
+ * `createdAt` renders as '' so callers can `v-if` it away.
+ */
+export function formatRelativeWait(createdAt: string, now: Date = new Date()): string {
+  const elapsed = elapsedMs(createdAt, now)
+  if (elapsed === null) return ''
+  if (elapsed < HOUR_MS) return '刚刚'
+  if (elapsed < DAY_MS) return `${Math.floor(elapsed / HOUR_MS)} 小时`
+  return `${Math.floor(elapsed / DAY_MS)} 天`
+}
+
+/** Aging severity band for coloring the 已等待 signal. */
+export type ApprovalWaitSeverity = 'normal' | 'warn' | 'urgent'
+
+/**
+ * `normal` at or under 3 days, `warn` beyond 3 days, `urgent` beyond 7 days. An invalid
+ * `createdAt` is treated as `normal` (fail-quiet, paired with `formatRelativeWait`'s '').
+ */
+export function waitSeverity(createdAt: string, now: Date = new Date()): ApprovalWaitSeverity {
+  const elapsed = elapsedMs(createdAt, now)
+  if (elapsed === null) return 'normal'
+  if (elapsed > 7 * DAY_MS) return 'urgent'
+  if (elapsed > 3 * DAY_MS) return 'warn'
+  return 'normal'
+}

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -191,6 +191,58 @@
               {{ formatDate(row.createdAt) }}
             </template>
           </el-table-column>
+          <!-- B1-03 (part 2): 已等待 aging — glanceable severity (>3d warn / >7d urgent) so a
+               reviewer can triage the oldest requests first. The 第 X/Y 步 sub-line only renders
+               when both numbers are present (mirrors ApprovalDetailView's "进度" meta item). -->
+          <el-table-column label="已等待" width="140">
+            <template #default="{ row }">
+              <span :class="waitClass(row.createdAt)">{{ formatRelativeWait(row.createdAt) }}</span>
+              <div
+                v-if="row.currentStep != null && row.totalSteps != null"
+                class="approval-center__wait-progress"
+              >
+                第 {{ row.currentStep }}/{{ row.totalSteps }} 步
+              </div>
+            </template>
+          </el-table-column>
+          <!-- B1-03 (part 1): inline approve/reject hot path — only for platform-native pending
+               rows (reuses `isRowBatchSelectable`; attendance-bridged rows keep routing to the
+               attendance module via row-click and never show these). @click.stop on every
+               reference so opening the popconfirm / reject dialog never also navigates the row. -->
+          <el-table-column label="操作" width="150" fixed="right">
+            <template #default="{ row }">
+              <template v-if="isRowBatchSelectable(row)">
+                <el-popconfirm
+                  :title="`确认通过「${row.title}」？`"
+                  confirm-button-text="确认"
+                  cancel-button-text="取消"
+                  @confirm="handleInlineApprove(row)"
+                >
+                  <template #reference>
+                    <el-button
+                      type="primary"
+                      link
+                      :loading="inlineApprovingId === row.id"
+                      :disabled="inlineApprovingId !== null"
+                      :data-testid="`approval-row-approve-${row.id}`"
+                      @click.stop
+                    >
+                      通过
+                    </el-button>
+                  </template>
+                </el-popconfirm>
+                <el-button
+                  type="danger"
+                  link
+                  :disabled="inlineApprovingId !== null"
+                  :data-testid="`approval-row-reject-${row.id}`"
+                  @click.stop="openRowReject(row)"
+                >
+                  驳回
+                </el-button>
+              </template>
+            </template>
+          </el-table-column>
           <template #empty>
             <el-empty
               :description="searchText ? '未找到匹配的审批' : '暂无待处理审批'"
@@ -247,9 +299,14 @@
             </template>
           </el-table-column>
           <!-- 催办: a requester nudge to the current approver, only meaningful while the instance is
-               still pending. Server-side rate-limited (1/instance/user/hour); 429 surfaces gracefully. -->
-          <el-table-column label="操作" width="100" fixed="right">
+               still pending. Server-side rate-limited (1/instance/user/hour); 429 surfaces gracefully.
+               B1-03: 已等待 sits right next to it — the longer a request has waited, the more it
+               motivates the requester to actually click 催办. -->
+          <el-table-column label="操作" width="170" fixed="right">
             <template #default="{ row }">
+              <span v-if="row.status === 'pending'" :class="waitClass(row.createdAt)">
+                已等待 {{ formatRelativeWait(row.createdAt) }}
+              </span>
               <el-button
                 v-if="row.status === 'pending'"
                 type="primary"
@@ -423,6 +480,84 @@
         </el-button>
       </template>
     </el-dialog>
+
+    <!-- B1-03 (part 1): per-row reject dialog — mirrors the batch-reject dialog's comment/policy
+         gating but targets a single row (`rowRejectTarget`); kept fully separate from the batch
+         dialog's own state so the two flows never cross-contaminate each other's comment/error. -->
+    <el-dialog
+      v-model="rowRejectDialogVisible"
+      title="驳回审批"
+      width="440px"
+      data-testid="approval-row-reject-dialog"
+    >
+      <el-alert
+        v-if="rowRejectError"
+        type="error"
+        show-icon
+        :closable="false"
+        :title="rowRejectError"
+        data-testid="approval-row-reject-error"
+        class="approval-center__row-reject-error"
+      />
+      <p v-if="rowRejectTarget" class="approval-center__row-reject-summary">
+        确认驳回「{{ rowRejectTarget.title }}」？
+      </p>
+      <el-input
+        v-model="rowRejectComment"
+        type="textarea"
+        :rows="3"
+        :placeholder="rowRejectCommentRequired ? '驳回原因（必填）' : '驳回意见（选填）'"
+        data-testid="approval-row-reject-comment"
+      />
+      <template #footer>
+        <el-button data-testid="approval-row-reject-cancel" @click="rowRejectDialogVisible = false">取消</el-button>
+        <el-button
+          type="danger"
+          :loading="rowRejectSubmitting"
+          :disabled="rowRejectConfirmDisabled"
+          data-testid="approval-row-reject-confirm"
+          @click="submitRowReject"
+        >
+          确认驳回
+        </el-button>
+      </template>
+    </el-dialog>
+
+    <!-- B1-03 (part 3): batch failure manifest — replaces the old collapsed toast whenever at
+         least one row fails, so the operator sees WHICH rows failed and WHY, then can retry just
+         the failed subset (same action + comment) without re-selecting anything. -->
+    <el-dialog
+      v-model="batchResultDialogVisible"
+      title="批量处理结果"
+      width="480px"
+      data-testid="approval-batch-result-dialog"
+    >
+      <p class="approval-center__batch-result-summary">
+        <template v-if="batchSucceededCount > 0">成功 {{ batchSucceededCount }} 项，失败 {{ batchFailureRows.length }} 项：</template>
+        <template v-else>全部 {{ batchFailureRows.length }} 项处理失败：</template>
+      </p>
+      <ul class="approval-center__batch-result-list">
+        <li
+          v-for="row in batchFailureRows"
+          :key="row.id"
+          class="approval-center__batch-result-item"
+        >
+          <div class="approval-center__batch-result-item-title">{{ row.requestNo }} · {{ row.title }}</div>
+          <div class="approval-center__batch-result-item-message">{{ row.message }}</div>
+        </li>
+      </ul>
+      <template #footer>
+        <el-button data-testid="approval-batch-result-close" @click="batchResultDialogVisible = false">关闭</el-button>
+        <el-button
+          type="primary"
+          :loading="batchRunning"
+          data-testid="approval-batch-retry"
+          @click="retryBatchFailures"
+        >
+          重试失败项
+        </el-button>
+      </template>
+    </el-dialog>
   </section>
 </template>
 
@@ -435,11 +570,12 @@ import type { UnifiedApprovalDTO, ApprovalStatus } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { dispatchAction, getPendingCount, markAllApprovalsRead, remindApproval } from '../../approvals/api'
-import { runApprovalBatchAction } from '../../approvals/useApprovalBatchActions'
+import { runApprovalBatchAction, type ApprovalBatchActionResult } from '../../approvals/useApprovalBatchActions'
 import { useApprovalCountsRealtime, type ApprovalCountsUpdatedPayload } from '../../approvals/useApprovalCountsRealtime'
 import { useFeatureFlags } from '../../stores/featureFlags'
 import { useMobileViewport } from '../../composables/useMobileViewport'
 import { useLocale } from '../../composables/useLocale'
+import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
 import ApprovalMobileList from './ApprovalMobileList.vue'
 
 const router = useRouter()
@@ -487,6 +623,12 @@ const batchRejectDialogVisible = ref(false)
 const batchRejectComment = ref('')
 const remindingId = ref<string | null>(null)
 
+// B1-03: 已等待 aging severity class — shared by the pending table's column and the 我发起的
+// tab's inline hint next to 催办 (same warn/urgent palette everywhere it appears).
+function waitClass(createdAt: string): string {
+  return `approval-center__wait approval-center__wait--${waitSeverity(createdAt)}`
+}
+
 function rowKey(row: UnifiedApprovalDTO): string {
   return row.id
 }
@@ -510,28 +652,91 @@ function clearPendingSelection(): void {
   }
 }
 
+// B1-03 (part 3): batch failure manifest. A collapsed toast used to be the ceiling of feedback
+// for a partial/total batch failure — the operator could see a COUNT but not which rows or why.
+// `batchFailureRows` carries each failure's title/requestNo (looked up from a snapshot of the
+// selected rows taken at launch, since `loadCurrentTab()` reloads the list out from under the
+// original selection before the operator gets to read the dialog) plus the server's own message.
+interface ApprovalBatchFailureRow {
+  id: string
+  title: string
+  requestNo: string
+  message: string
+}
+const batchResultDialogVisible = ref(false)
+const batchFailureRows = ref<ApprovalBatchFailureRow[]>([])
+const batchSucceededCount = ref(0)
+const lastBatchAction = ref<'approve' | 'reject'>('approve')
+const lastBatchComment = ref('')
+let batchRowSnapshot = new Map<string, UnifiedApprovalDTO>()
+
+function buildFailureRows(failed: ApprovalBatchActionResult['failed']): ApprovalBatchFailureRow[] {
+  return failed.map(({ id, message }) => {
+    const row = batchRowSnapshot.get(id)
+    return {
+      id,
+      title: row?.title ?? id,
+      requestNo: row?.requestNo ?? '-',
+      message,
+    }
+  })
+}
+
+async function dispatchBatchAndHandleResult(
+  ids: string[],
+  action: 'approve' | 'reject',
+  comment: string,
+): Promise<void> {
+  const trimmed = comment.trim()
+  const result = await runApprovalBatchAction(
+    ids,
+    () => (trimmed ? { action, comment: trimmed } : { action }),
+    (id, req) => dispatchAction(id, req),
+  )
+  if (result.failed.length === 0) {
+    ElMessage.success(`已${action === 'approve' ? '通过' : '驳回'} ${result.succeeded.length} 项`)
+    batchResultDialogVisible.value = false
+    batchFailureRows.value = []
+  } else {
+    // B1-03: any failure now opens the manifest dialog instead of a toast (whether partial or
+    // total); only the all-success path above keeps today's light toast.
+    lastBatchAction.value = action
+    lastBatchComment.value = comment
+    batchSucceededCount.value = result.succeeded.length
+    batchFailureRows.value = buildFailureRows(result.failed)
+    batchResultDialogVisible.value = true
+  }
+  clearPendingSelection()
+  loadCurrentTab()
+  void refreshPendingBadgeCount()
+}
+
 async function runBatch(action: 'approve' | 'reject', comment: string): Promise<void> {
-  const ids = selectedPending.value.map((row) => row.id)
-  if (ids.length === 0 || batchRunning.value) return
+  const rows = selectedPending.value
+  if (rows.length === 0 || batchRunning.value) return
+  batchRowSnapshot = new Map(rows.map((row) => [row.id, row]))
   batchRunning.value = true
   batchAction.value = action
   try {
-    const trimmed = comment.trim()
-    const result = await runApprovalBatchAction(
-      ids,
-      () => (trimmed ? { action, comment: trimmed } : { action }),
-      (id, req) => dispatchAction(id, req),
-    )
-    if (result.failed.length === 0) {
-      ElMessage.success(`已${action === 'approve' ? '通过' : '驳回'} ${result.succeeded.length} 项`)
-    } else if (result.succeeded.length === 0) {
-      ElMessage.error(`全部 ${result.failed.length} 项处理失败：${result.failed[0]?.message ?? ''}`)
-    } else {
-      ElMessage.warning(`成功 ${result.succeeded.length} 项，失败 ${result.failed.length} 项（失败项仍在列表中）`)
-    }
-    clearPendingSelection()
-    loadCurrentTab()
-    void refreshPendingBadgeCount()
+    await dispatchBatchAndHandleResult(rows.map((row) => row.id), action, comment)
+  } finally {
+    batchRunning.value = false
+    batchAction.value = null
+  }
+}
+
+// 「重试失败项」— re-runs the SAME action + comment over just the ids still in the manifest.
+// `batchRowSnapshot` already carries these rows' title/requestNo from the original launch, so a
+// still-failing row keeps its label; `dispatchBatchAndHandleResult` overwrites `batchFailureRows`
+// in place with whatever is left (or closes the dialog on full success).
+async function retryBatchFailures(): Promise<void> {
+  if (batchRunning.value) return
+  const ids = batchFailureRows.value.map((row) => row.id)
+  if (ids.length === 0) return
+  batchRunning.value = true
+  batchAction.value = lastBatchAction.value
+  try {
+    await dispatchBatchAndHandleResult(ids, lastBatchAction.value, lastBatchComment.value)
   } finally {
     batchRunning.value = false
     batchAction.value = null
@@ -562,6 +767,68 @@ async function handleBatchReject(): Promise<void> {
   if (batchRejectConfirmDisabled.value) return
   await runBatch('reject', batchRejectComment.value)
   batchRejectDialogVisible.value = false
+}
+
+// ── B1-03 (part 1): inline approve/reject hot path on the pending list ─────
+// `inlineApprovingId` gates every row's approve button (not just the clicked row) while a
+// request is in flight — mirrors the existing `remindingId`-gates-every-催办-button convention
+// below, so a slow request can't be raced by mashing a different row.
+const inlineApprovingId = ref<string | null>(null)
+
+async function handleInlineApprove(row: UnifiedApprovalDTO): Promise<void> {
+  if (inlineApprovingId.value) return
+  inlineApprovingId.value = row.id
+  try {
+    await dispatchAction(row.id, { action: 'approve' })
+    ElMessage.success('审批已通过')
+    loadCurrentTab()
+    void refreshPendingBadgeCount()
+  } catch (error) {
+    ElMessage.error(error instanceof Error && error.message ? error.message : '操作失败，请重试')
+  } finally {
+    inlineApprovingId.value = null
+  }
+}
+
+// Per-row reject dialog — deliberately its OWN state (`rowRejectTarget`/`rowRejectComment`/
+// `rowRejectError`), never overloading the batch-reject dialog's refs above, so the two flows
+// can never cross-contaminate each other's comment or error message.
+const rowRejectDialogVisible = ref(false)
+const rowRejectTarget = ref<UnifiedApprovalDTO | null>(null)
+const rowRejectComment = ref('')
+const rowRejectError = ref<string | null>(null)
+const rowRejectSubmitting = ref(false)
+
+function openRowReject(row: UnifiedApprovalDTO): void {
+  rowRejectTarget.value = row
+  rowRejectComment.value = ''
+  rowRejectError.value = null
+  rowRejectDialogVisible.value = true
+}
+
+// B1-04-style conservative default: required unless THIS row's policy explicitly opts out.
+const rowRejectCommentRequired = computed(() => rowRejectTarget.value?.policy?.rejectCommentRequired !== false)
+const rowRejectConfirmDisabled = computed(() => rowRejectCommentRequired.value && !rowRejectComment.value.trim())
+
+async function submitRowReject(): Promise<void> {
+  if (rowRejectConfirmDisabled.value || !rowRejectTarget.value) return
+  const target = rowRejectTarget.value
+  const trimmed = rowRejectComment.value.trim()
+  rowRejectSubmitting.value = true
+  rowRejectError.value = null
+  try {
+    await dispatchAction(target.id, trimmed ? { action: 'reject', comment: trimmed } : { action: 'reject' })
+    ElMessage.success('审批已驳回')
+    rowRejectDialogVisible.value = false
+    loadCurrentTab()
+    void refreshPendingBadgeCount()
+  } catch (error) {
+    // Mirrors B1-04's dialog-scoped inline error: keep the dialog open with the server's own
+    // reason instead of a toast, so the typed comment is never lost on a retry-in-place.
+    rowRejectError.value = error instanceof Error && error.message ? error.message : '操作失败，请重试'
+  } finally {
+    rowRejectSubmitting.value = false
+  }
 }
 
 async function handleUrge(row: UnifiedApprovalDTO): Promise<void> {
@@ -836,6 +1103,72 @@ onMounted(() => {
   margin: 0 0 12px;
   color: #4b5563;
   font-size: 14px;
+}
+
+/* B1-03: 已等待 aging severity — normal inherits the surrounding text color; warn/urgent escalate. */
+.approval-center__wait {
+  display: inline-block;
+  margin-right: 8px;
+  font-size: 13px;
+  color: #606266;
+}
+
+.approval-center__wait--warn {
+  color: #e6a23c;
+}
+
+.approval-center__wait--urgent {
+  color: #f56c6c;
+}
+
+.approval-center__wait-progress {
+  margin-top: 2px;
+  font-size: 12px;
+  color: #909399;
+}
+
+.approval-center__row-reject-summary {
+  margin: 0 0 12px;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.approval-center__row-reject-error {
+  margin-bottom: 12px;
+}
+
+.approval-center__batch-result-summary {
+  margin: 0 0 12px;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.approval-center__batch-result-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.approval-center__batch-result-item {
+  padding: 8px 0;
+  border-bottom: 1px solid #ebeef5;
+}
+
+.approval-center__batch-result-item:last-child {
+  border-bottom: none;
+}
+
+.approval-center__batch-result-item-title {
+  font-size: 14px;
+  color: #303133;
+}
+
+.approval-center__batch-result-item-message {
+  margin-top: 2px;
+  font-size: 13px;
+  color: #f56c6c;
 }
 
 .approval-center__attendance-entry {

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -13,6 +13,16 @@
       >
         {{ statusLabel(approval.status) }}
       </el-tag>
+      <!-- B1-03: 已等待 aging — glanceable next to the status tag, only while still pending. -->
+      <el-tag
+        v-if="approval && approval.status === 'pending'"
+        :type="waitChipType"
+        size="large"
+        effect="plain"
+        data-testid="approval-wait-chip"
+      >
+        已等待 {{ waitChipLabel }}
+      </el-tag>
       <el-tag
         v-if="approval && isInParallelRegion"
         type="warning"
@@ -642,6 +652,7 @@ import {
   type DisplayField,
 } from '../../approvals/detailField'
 import { phrasesForAction, recentPhrases, rememberPhrase } from '../../approvals/quickPhrases'
+import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
 
 const route = useRoute()
 const router = useRouter()
@@ -661,6 +672,17 @@ const { isMobile } = useMobileViewport()
 const isMobileLayout = computed(() => hasFeature('approvalMobile') && isMobile.value)
 
 const approval = computed(() => store.activeApproval)
+
+// B1-03: 已等待 chip — a glanceable "how long has this been sitting" cue next to the status tag,
+// only meaningful while the instance is still pending (once resolved, `updatedAt`/the history
+// timeline already tell that story). Severity mirrors the list view's warn/urgent bands.
+const waitChipLabel = computed(() => (approval.value ? formatRelativeWait(approval.value.createdAt) : ''))
+const waitChipType = computed(() => {
+  const severity = approval.value ? waitSeverity(approval.value.createdAt) : 'normal'
+  if (severity === 'urgent') return 'danger'
+  if (severity === 'warn') return 'warning'
+  return 'info'
+})
 
 // Read-only detail (明细) tables, keyed by snapshot field id. Built from the instance's FROZEN
 // formSchema (C-3a read-path) so a later column rename/reorder on the live template never

--- a/apps/web/src/views/approval/ApprovalMobileList.vue
+++ b/apps/web/src/views/approval/ApprovalMobileList.vue
@@ -38,7 +38,13 @@
         <span class="approval-mobile-list__request-no">{{ row.requestNo ?? '-' }}</span>
         <span class="approval-mobile-list__requester">{{ row.requester?.name ?? '-' }}</span>
       </div>
-      <div class="approval-mobile-list__date">{{ formatDate(row.createdAt) }}</div>
+      <div
+        class="approval-mobile-list__date"
+        :class="`approval-mobile-list__date--${waitSeverity(row.createdAt)}`"
+        :title="formatDate(row.createdAt)"
+      >
+        已等待 {{ formatRelativeWait(row.createdAt) }}
+      </div>
     </button>
   </div>
 </template>
@@ -47,6 +53,7 @@
 import { computed } from 'vue'
 import type { UnifiedApprovalDTO } from '../../types/approval'
 import { useLocale } from '../../composables/useLocale'
+import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
 
 // T3-1 v0 — dedicated touch-first list card (ballot Q10). Replaces the desktop
 // `el-table` (fixed column widths + horizontal scroll + tiny row-click targets)
@@ -215,5 +222,14 @@ function formatDate(dateStr: string): string {
 .approval-mobile-list__date {
   font-size: 12px;
   color: var(--el-text-color-secondary, #909399);
+}
+
+/* B1-03: 已等待 aging severity — same warn/urgent palette as the desktop table. */
+.approval-mobile-list__date--warn {
+  color: #e6a23c;
+}
+
+.approval-mobile-list__date--urgent {
+  color: #f56c6c;
 }
 </style>

--- a/apps/web/tests/approval-center.spec.ts
+++ b/apps/web/tests/approval-center.spec.ts
@@ -1,7 +1,62 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import {
+  createApp,
+  defineComponent,
+  h,
+  inject,
+  nextTick,
+  provide,
+  reactive,
+  ref,
+  Teleport,
+  type App as VueApp,
+  type Slot,
+} from 'vue'
 
 const pushSpy = vi.fn().mockResolvedValue(undefined)
+
+// ---------------------------------------------------------------------------
+// element-plus — ElMessage spies. `ApprovalCenterView` imports `ElMessage` (a plain JS API,
+// not a component — the `<el-table>`/`<el-button>` etc. tags below are resolved purely via the
+// `app.component(...)` stub registrations in `mountView()`, unrelated to this mock) directly, so
+// mocking the module lets B1-03's inline-approve/reject + batch-manifest tests assert on the
+// exact toast copy without rendering real Element Plus notifications into `document.body`.
+// ---------------------------------------------------------------------------
+const elSuccessSpy = vi.fn()
+const elWarningSpy = vi.fn()
+const elErrorSpy = vi.fn()
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('element-plus').catch(() => ({}))
+  return {
+    ...actual,
+    ElMessage: {
+      success: elSuccessSpy,
+      warning: elWarningSpy,
+      error: elErrorSpy,
+      info: vi.fn(),
+    },
+  }
+})
+
+// ---------------------------------------------------------------------------
+// approvals/api — dispatchAction/getPendingCount/markAllApprovalsRead/remindApproval. B1-03's
+// inline approve/reject and the batch failure manifest all go through `dispatchAction`
+// (single-instance and, via `runApprovalBatchAction`'s `dispatch` callback, per-row in a batch),
+// so this needs to be independently resolvable/rejectable per test rather than the real module's
+// always-succeeds mock-mode fixture.
+// ---------------------------------------------------------------------------
+const dispatchActionSpy = vi.fn<[string, unknown], Promise<unknown>>().mockResolvedValue({})
+const getPendingCountSpy = vi.fn().mockResolvedValue({ count: 0, unreadCount: 0 })
+const markAllApprovalsReadSpy = vi.fn().mockResolvedValue({ markedCount: 0 })
+const remindApprovalSpy = vi.fn().mockResolvedValue({ ok: true, data: {} })
+
+vi.mock('../src/approvals/api', () => ({
+  dispatchAction: (...args: [string, unknown]) => dispatchActionSpy(...args),
+  getPendingCount: (...args: unknown[]) => getPendingCountSpy(...args),
+  markAllApprovalsRead: (...args: unknown[]) => markAllApprovalsReadSpy(...args),
+  remindApproval: (...args: unknown[]) => remindApprovalSpy(...args),
+}))
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
@@ -81,32 +136,133 @@ const ElTabPane = defineComponent({
   },
 })
 
+// B1-03 needs to actually exercise per-row scoped-slot content (inline approve/reject buttons,
+// the 已等待 cell) rather than just count table/column placeholders, so ElTable/ElTableColumn
+// upgrade to the same registry pattern as `approvalTemplateCenterCategory.spec.ts`:
+// ElTableColumn children register their `#default="{ row }"` slot into a shared registry via
+// provide/inject; ElTable then walks `data` × registry to emit real per-row markup. The
+// `test-select-all-rows` trigger (B1-04) and the `data-el-table` marker are both preserved.
+type ColumnRegistryEntry = {
+  key: string
+  prop?: string
+  label?: string
+  defaultSlot?: Slot
+}
+type ColumnRegistry = {
+  columns: ColumnRegistryEntry[]
+  register: (entry: ColumnRegistryEntry) => void
+}
+const COLUMN_REGISTRY_KEY = Symbol('el-table-columns')
+
 const ElTable = defineComponent({
   name: 'ElTable',
-  props: { data: Array, loading: Boolean, stripe: Boolean, highlightCurrentRow: Boolean },
+  props: {
+    data: Array,
+    loading: Boolean,
+    stripe: Boolean,
+    highlightCurrentRow: Boolean,
+    maxHeight: [String, Number],
+    rowKey: [String, Function],
+  },
   emits: ['row-click', 'selection-change'],
-  render() {
-    return h('div', { 'data-el-table': 'true' }, [
-      // B1-04 test-only affordance: the real checkbox selection column can't be driven
-      // headlessly here, so expose a direct trigger for "select every row currently bound to
-      // `data`" — the SFC's own `handlePendingSelectionChange` still applies
-      // `isRowBatchSelectable`, so this stays honest about what ends up selected.
-      h('button', {
-        type: 'button',
-        'data-testid': 'test-select-all-rows',
-        onClick: () => this.$emit('selection-change', this.data ?? []),
-      }, 'select-all'),
-      this.$slots.default?.(),
-    ])
+  setup(props, { slots, emit }) {
+    const registry = reactive<ColumnRegistry>({
+      columns: [],
+      register(entry) {
+        registry.columns.push(entry)
+      },
+    })
+    provide(COLUMN_REGISTRY_KEY, registry)
+    return () => {
+      // Instantiate the default slot once so each ElTableColumn child's setup() runs and
+      // registers itself; rendered off-screen since the real per-row output is emitted below.
+      const columnInstances = slots.default?.() ?? []
+      const rows = (props.data as any[] | undefined) ?? []
+      return h('div', { 'data-el-table': 'true' }, [
+        // B1-04 test-only affordance: the real checkbox selection column can't be driven
+        // headlessly here, so expose a direct trigger for "select every row currently bound to
+        // `data`" — the SFC's own `handlePendingSelectionChange` still applies
+        // `isRowBatchSelectable`, so this stays honest about what ends up selected.
+        h('button', {
+          type: 'button',
+          'data-testid': 'test-select-all-rows',
+          onClick: () => emit('selection-change', rows),
+        }, 'select-all'),
+        h('div', { style: 'display:none' }, columnInstances),
+        ...rows.map((row, i) =>
+          h(
+            'div',
+            {
+              'data-el-row': (row?.id as string | undefined) ?? String(i),
+              key: (row?.id as string | undefined) ?? String(i),
+              // Bubble phase (the default): a descendant button's `.stop` (e.g. the inline
+              // 通过/驳回 actions) correctly prevents this from firing, matching real
+              // `@row-click` vs a row-scoped action button.
+              onClick: () => emit('row-click', row),
+            },
+            registry.columns.map((col) =>
+              col.defaultSlot
+                ? h('div', { 'data-el-cell': col.prop || col.label || col.key }, col.defaultSlot({ row }))
+                : h('div', { 'data-el-cell-header': col.prop || col.label }, ''),
+            ),
+          ),
+        ),
+      ])
+    }
   },
 })
 
+let columnSeq = 0
 const ElTableColumn = defineComponent({
   name: 'ElTableColumn',
-  props: { prop: String, label: String, width: [String, Number], minWidth: [String, Number], fixed: String },
+  props: {
+    prop: String,
+    label: String,
+    width: [String, Number],
+    minWidth: [String, Number],
+    fixed: String,
+    type: String,
+    selectable: Function,
+  },
+  setup(props, { slots }) {
+    const registry = inject<ColumnRegistry | null>(COLUMN_REGISTRY_KEY, null)
+    if (registry) {
+      registry.register({
+        key: `col-${columnSeq++}`,
+        prop: props.prop,
+        label: props.label,
+        defaultSlot: slots.default,
+      })
+    }
+    return () => null
+  },
+})
+
+// B1-03: real popconfirm semantics are two clicks — the reference OPENS the popup (real
+// Element Plus never dispatches anything on that click alone), and a SEPARATE 确认 button
+// INSIDE the popup (which Element Plus renders in a teleported popper, OUTSIDE the reference's
+// DOM subtree) actually emits `confirm`. Teleporting this test-only confirm trigger to
+// `document.body` reproduces that structural guarantee — a click on it can never bubble to an
+// ancestor row's `@row-click`, by construction, regardless of the reference's own `.stop` or any
+// re-render timing. (An earlier `onClickCapture`-on-a-wrapping-span design tried to fake this via
+// event-PHASE ordering instead of DOM structure; it raced against Vue's re-render scheduling —
+// intermittently failing only when run alongside other spec files — so it was replaced with this
+// unconditionally-robust Teleport.)
+const ElPopconfirm = defineComponent({
+  name: 'ElPopconfirm',
+  props: { title: String, confirmButtonText: String, cancelButtonText: String },
+  emits: ['confirm', 'cancel'],
   render() {
-    // Do not invoke scoped slots — they expect { row } context from el-table
-    return h('div', { 'data-column': this.prop || this.label })
+    return h('span', { 'data-el-popconfirm': this.title ?? '' }, [
+      this.$slots.reference?.(),
+      h(Teleport, { to: 'body' }, [
+        h('button', {
+          type: 'button',
+          'data-el-popconfirm-confirm': this.title ?? '',
+          onClick: () => this.$emit('confirm'),
+        }, '确认'),
+      ]),
+    ])
   },
 })
 
@@ -229,6 +385,18 @@ describe('ApprovalCenterView', () => {
     loadCompletedSpy.mockClear()
     pushSpy.mockClear()
 
+    elSuccessSpy.mockClear()
+    elWarningSpy.mockClear()
+    elErrorSpy.mockClear()
+    dispatchActionSpy.mockClear()
+    dispatchActionSpy.mockResolvedValue({})
+    getPendingCountSpy.mockClear()
+    getPendingCountSpy.mockResolvedValue({ count: 0, unreadCount: 0 })
+    markAllApprovalsReadSpy.mockClear()
+    markAllApprovalsReadSpy.mockResolvedValue({ markedCount: 0 })
+    remindApprovalSpy.mockClear()
+    remindApprovalSpy.mockResolvedValue({ ok: true, data: {} })
+
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -262,6 +430,7 @@ describe('ApprovalCenterView', () => {
     app.component('ElAlert', ElAlert)
     app.component('ElDialog', ElDialog)
     app.component('ElEmpty', ElEmpty)
+    app.component('ElPopconfirm', ElPopconfirm)
     app.directive('loading', stubDirective)
     app.mount(container!)
     await flushUi()
@@ -461,5 +630,182 @@ describe('ApprovalCenterView', () => {
 
     const confirmBtn = container!.querySelector('[data-testid="approval-batch-reject-confirm"]') as HTMLButtonElement
     expect(confirmBtn.disabled).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // B1-03 (审批中心列表热路径包) — part 1: inline approve/reject on the pending list.
+  // ---------------------------------------------------------------------------
+  it('B1-03: inline 通过 popconfirm-confirm dispatches exactly one approve action; row-click is not triggered', async () => {
+    mockPendingApprovals.value = [pendingRow({ id: 'apv_1', title: '出差报销' })]
+    await mountView()
+
+    const approveBtn = container!.querySelector('[data-testid="approval-row-approve-apv_1"]') as HTMLButtonElement
+    expect(approveBtn).toBeTruthy()
+    approveBtn.click()
+    await flushUi()
+    // The reference only OPENS the popup in real Element Plus — `.stop` must keep the row's own
+    // navigation untouched, and nothing should have dispatched yet.
+    expect(pushSpy).not.toHaveBeenCalled()
+    expect(dispatchActionSpy).not.toHaveBeenCalled()
+
+    const confirmBtn = document.querySelector('[data-el-popconfirm-confirm="确认通过「出差报销」？"]') as HTMLButtonElement
+    expect(confirmBtn).toBeTruthy()
+    confirmBtn.click()
+    await flushUi()
+
+    expect(dispatchActionSpy).toHaveBeenCalledTimes(1)
+    expect(dispatchActionSpy).toHaveBeenCalledWith('apv_1', { action: 'approve' })
+    expect(elSuccessSpy).toHaveBeenCalledWith('审批已通过')
+    expect(pushSpy).not.toHaveBeenCalled()
+
+    // Sanity: the row's OWN click handler (outside any action button) still navigates — proves
+    // the absence of navigation above is because of `.stop`, not a broken row-click wire.
+    const rowEl = container!.querySelector('[data-el-row="apv_1"]') as HTMLElement
+    rowEl.click()
+    await flushUi()
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-detail', params: { id: 'apv_1' } })
+  })
+
+  it('B1-03: inline 通过 failure surfaces the server message as a toast (approve never opens a dialog)', async () => {
+    mockPendingApprovals.value = [pendingRow({ id: 'apv_1', title: '出差报销' })]
+    dispatchActionSpy.mockRejectedValueOnce(new Error('该审批已被他人处理'))
+    await mountView()
+
+    ;(container!.querySelector('[data-testid="approval-row-approve-apv_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(document.querySelector('[data-el-popconfirm-confirm="确认通过「出差报销」？"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(elErrorSpy).toHaveBeenCalledWith('该审批已被他人处理')
+    expect(elSuccessSpy).not.toHaveBeenCalled()
+  })
+
+  it('B1-03: inline 驳回 dialog gates confirm on a required comment, then dispatches with it', async () => {
+    mockPendingApprovals.value = [pendingRow({ id: 'apv_1', policy: null })]
+    await mountView()
+
+    const rejectBtn = container!.querySelector('[data-testid="approval-row-reject-apv_1"]') as HTMLButtonElement
+    expect(rejectBtn).toBeTruthy()
+    rejectBtn.click()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-row-reject-dialog"]')).toBeTruthy()
+    const confirmBtn = container!.querySelector('[data-testid="approval-row-reject-confirm"]') as HTMLButtonElement
+    expect(confirmBtn.disabled).toBe(true)
+
+    const commentInput = container!.querySelector('[data-testid="approval-row-reject-comment"]') as HTMLInputElement
+    commentInput.value = '材料不全'
+    commentInput.dispatchEvent(new Event('input'))
+    await flushUi()
+    expect(confirmBtn.disabled).toBe(false)
+
+    confirmBtn.click()
+    await flushUi()
+
+    expect(dispatchActionSpy).toHaveBeenCalledWith('apv_1', { action: 'reject', comment: '材料不全' })
+    expect(elSuccessSpy).toHaveBeenCalledWith('审批已驳回')
+    expect(container!.querySelector('[data-testid="approval-row-reject-dialog"]')).toBeNull()
+    expect(pushSpy).not.toHaveBeenCalled()
+  })
+
+  it('B1-03: inline 驳回 confirm stays enabled with an empty comment when the row opts out, and omits the comment key', async () => {
+    mockPendingApprovals.value = [pendingRow({ id: 'apv_1', policy: { rejectCommentRequired: false } })]
+    await mountView()
+
+    ;(container!.querySelector('[data-testid="approval-row-reject-apv_1"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const confirmBtn = container!.querySelector('[data-testid="approval-row-reject-confirm"]') as HTMLButtonElement
+    expect(confirmBtn.disabled).toBe(false)
+
+    confirmBtn.click()
+    await flushUi()
+    expect(dispatchActionSpy).toHaveBeenCalledWith('apv_1', { action: 'reject' })
+  })
+
+  it('B1-03: inline 驳回 failure keeps the dialog open and shows the server message inline (not a toast)', async () => {
+    mockPendingApprovals.value = [pendingRow({ id: 'apv_1', policy: { rejectCommentRequired: false } })]
+    dispatchActionSpy.mockRejectedValueOnce(new Error('该审批已被撤回'))
+    await mountView()
+
+    ;(container!.querySelector('[data-testid="approval-row-reject-apv_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-row-reject-confirm"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-row-reject-dialog"]')).toBeTruthy()
+    expect(container!.querySelector('[data-testid="approval-row-reject-error"]')?.textContent).toContain('该审批已被撤回')
+    expect(elErrorSpy).not.toHaveBeenCalled()
+  })
+
+  // ---------------------------------------------------------------------------
+  // B1-03 — part 2: 已等待 aging + progress glanceability.
+  // ---------------------------------------------------------------------------
+  it('B1-03: pending tab 已等待 column shows aging text, urgent severity class, and step progress', async () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+    mockPendingApprovals.value = [
+      pendingRow({ id: 'apv_1', createdAt: eightDaysAgo, currentStep: 2, totalSteps: 3 }),
+    ]
+    await mountView()
+
+    const cell = container!.querySelector('[data-el-row="apv_1"] [data-el-cell="已等待"]')
+    expect(cell).toBeTruthy()
+    expect(cell!.textContent).toContain('8 天')
+    expect(cell!.textContent).toContain('第 2/3 步')
+    expect(cell!.querySelector('.approval-center__wait--urgent')).toBeTruthy()
+  })
+
+  it('B1-03: mine tab shows 已等待 next to 催办 for pending rows', async () => {
+    const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString()
+    mockMyApprovals.value = [pendingRow({ id: 'apv_mine_1', createdAt: fiveHoursAgo })]
+    await mountView()
+
+    const cell = container!.querySelector('[data-el-row="apv_mine_1"] [data-el-cell="操作"]')
+    expect(cell).toBeTruthy()
+    expect(cell!.textContent).toContain('已等待')
+    expect(cell!.textContent).toContain('5 小时')
+    expect(cell!.querySelector('[data-testid="approval-urge-apv_mine_1"]')).toBeTruthy()
+  })
+
+  // ---------------------------------------------------------------------------
+  // B1-03 — part 3: batch failure manifest (replaces the old collapsed toast).
+  // ---------------------------------------------------------------------------
+  it('B1-03: a batch failure opens a manifest dialog listing failed rows; 重试失败项 re-dispatches only the failed ids', async () => {
+    mockPendingApprovals.value = [
+      pendingRow({ id: 'apv_a', title: 'AAA 报销', requestNo: 'AP-A' }),
+      pendingRow({ id: 'apv_b', title: 'BBB 报销', requestNo: 'AP-B' }),
+    ]
+    dispatchActionSpy.mockImplementation((id: unknown) =>
+      id === 'apv_b' ? Promise.reject(new Error('冲突：状态已变更')) : Promise.resolve({}),
+    )
+    await mountView()
+
+    selectAllPendingRows()
+    await flushUi()
+
+    const approveBtn = container!.querySelector('[data-testid="approval-batch-approve"]') as HTMLButtonElement
+    approveBtn.click()
+    await flushUi(6)
+
+    const dialog = container!.querySelector('[data-testid="approval-batch-result-dialog"]')
+    expect(dialog).toBeTruthy()
+    expect(dialog!.textContent).toContain('AP-B')
+    expect(dialog!.textContent).toContain('BBB 报销')
+    expect(dialog!.textContent).toContain('冲突：状态已变更')
+    // The succeeded row never shows up in the manifest.
+    expect(dialog!.textContent).not.toContain('AP-A')
+    expect(dispatchActionSpy).toHaveBeenCalledTimes(2)
+
+    // The retry succeeds this time.
+    dispatchActionSpy.mockImplementation(() => Promise.resolve({}))
+    const retryBtn = container!.querySelector('[data-testid="approval-batch-retry"]') as HTMLButtonElement
+    retryBtn.click()
+    await flushUi(6)
+
+    // Only the still-failed id (apv_b) is retried — apv_a is never re-dispatched.
+    expect(dispatchActionSpy).toHaveBeenCalledTimes(3)
+    expect(dispatchActionSpy).toHaveBeenNthCalledWith(3, 'apv_b', { action: 'approve' })
+    // Full success on retry closes the dialog.
+    expect(container!.querySelector('[data-testid="approval-batch-result-dialog"]')).toBeNull()
   })
 })

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -798,6 +798,27 @@ describe('Approval E2E Lifecycle', () => {
       expect(tag?.textContent).toContain('待处理')
     })
 
+    // B1-03 (审批中心列表热路径包): the 已等待 chip sits next to the status tag and is scoped
+    // to status === 'pending' — once resolved, `updatedAt`/the history timeline already tell
+    // the "how long" story, so the chip should not linger.
+    it('B1-03: 已等待 chip renders next to the status tag while pending', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const chip = container!.querySelector('[data-testid="approval-wait-chip"]')
+      expect(chip).toBeTruthy()
+      expect(chip!.textContent).toContain('已等待')
+    })
+
+    it('B1-03: 已等待 chip is absent once the approval is no longer pending', async () => {
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval()
+      await mountDetailView()
+
+      expect(container!.querySelector('[data-testid="approval-wait-chip"]')).toBeNull()
+    })
+
     it('shows action buttons when status is pending', async () => {
       routeParams = { id: 'apv_pending_1' }
       mockActiveApproval.value = mockPendingApproval()

--- a/apps/web/tests/approvalMobileResponsive.spec.ts
+++ b/apps/web/tests/approvalMobileResponsive.spec.ts
@@ -169,14 +169,14 @@ async function flushUi(cycles = 4): Promise<void> {
   }
 }
 
-function pendingRow(id: string, title: string): any {
+function pendingRow(id: string, title: string, createdAt = '2026-04-10T08:00:00Z'): any {
   return {
     id,
     requestNo: `AP-${id}`,
     title,
     status: 'pending',
     requester: { name: '张三' },
-    createdAt: '2026-04-10T08:00:00Z',
+    createdAt,
     assignments: [],
   }
 }
@@ -289,5 +289,26 @@ describe('ApprovalCenterView — T3-1 mobile responsive gate', () => {
     await flushUi()
 
     expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-detail', params: { id: '42' } })
+  })
+
+  // ---------------------------------------------------------------------------
+  // B1-03 (审批中心列表热路径包) — the mobile card's date line switches to 已等待 aging with
+  // severity coloring; the absolute date is preserved as a `:title` tooltip rather than lost.
+  // ---------------------------------------------------------------------------
+  it('flag ON + narrow → mobile card shows 已等待 aging with severity coloring (absolute date kept as a tooltip)', async () => {
+    mockApprovalMobileFlag.value = true
+    setViewport(true)
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+    mockPendingApprovals.value = [pendingRow('1', '出差报销', eightDaysAgo)]
+    await mountView()
+
+    const card = container!.querySelector('[data-testid="approval-mobile-card"]')
+    expect(card).toBeTruthy()
+    const dateEl = card!.querySelector('.approval-mobile-list__date')
+    expect(dateEl).toBeTruthy()
+    expect(dateEl!.textContent).toContain('已等待')
+    expect(dateEl!.textContent).toContain('8 天')
+    expect(dateEl!.classList.contains('approval-mobile-list__date--urgent')).toBe(true)
+    expect(dateEl!.getAttribute('title')).toBeTruthy()
   })
 })

--- a/apps/web/tests/approvalRelativeWait.spec.ts
+++ b/apps/web/tests/approvalRelativeWait.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * B1-03: 已等待 aging + severity — pure `relativeWait` module contract.
+ *
+ * `now` is always passed explicitly here so the matrix is independent of wall-clock time.
+ */
+import { describe, expect, it } from 'vitest'
+import { formatRelativeWait, waitSeverity } from '../src/approvals/relativeWait'
+
+const NOW = new Date('2026-07-05T12:00:00Z')
+const minutesAgo = (m: number) => new Date(NOW.getTime() - m * 60 * 1000).toISOString()
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 60 * 60 * 1000).toISOString()
+const daysAgo = (d: number) => new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000).toISOString()
+
+describe('approvals/relativeWait', () => {
+  describe('formatRelativeWait', () => {
+    it('renders 刚刚 under an hour (boundary: 59m)', () => {
+      expect(formatRelativeWait(minutesAgo(59), NOW)).toBe('刚刚')
+    })
+
+    it('renders whole hours from 1h up to (not including) 24h', () => {
+      expect(formatRelativeWait(hoursAgo(1), NOW)).toBe('1 小时')
+      expect(formatRelativeWait(hoursAgo(23), NOW)).toBe('23 小时')
+    })
+
+    it('renders whole days (rounded down) from 24h onward (boundary: 24h -> 1 天)', () => {
+      expect(formatRelativeWait(hoursAgo(24), NOW)).toBe('1 天')
+      expect(formatRelativeWait(daysAgo(3), NOW)).toBe('3 天')
+      expect(formatRelativeWait(daysAgo(7), NOW)).toBe('7 天')
+    })
+
+    it('rounds a partial day down (e.g. 3 天 5 小时 -> 3 天)', () => {
+      expect(formatRelativeWait(hoursAgo(3 * 24 + 5), NOW)).toBe('3 天')
+    })
+
+    it('returns "" for an invalid/unparseable createdAt', () => {
+      expect(formatRelativeWait('not-a-date', NOW)).toBe('')
+      expect(formatRelativeWait('', NOW)).toBe('')
+    })
+
+    it('treats a future createdAt (clock skew) as 刚刚 rather than a negative duration', () => {
+      expect(formatRelativeWait(minutesAgo(-5), NOW)).toBe('刚刚')
+    })
+
+    it('defaults `now` to the current wall clock when omitted', () => {
+      expect(formatRelativeWait(new Date().toISOString())).toBe('刚刚')
+    })
+  })
+
+  describe('waitSeverity', () => {
+    it('is normal at and under 3 days', () => {
+      expect(waitSeverity(hoursAgo(1), NOW)).toBe('normal')
+      expect(waitSeverity(daysAgo(3), NOW)).toBe('normal')
+    })
+
+    it('is warn beyond 3 days and at/under 7 days (boundary: 3d+1ms, 7d)', () => {
+      expect(waitSeverity(new Date(NOW.getTime() - (3 * 24 * 60 * 60 * 1000 + 1)).toISOString(), NOW)).toBe('warn')
+      expect(waitSeverity(daysAgo(7), NOW)).toBe('warn')
+    })
+
+    it('is urgent beyond 7 days (boundary: 7d+1ms)', () => {
+      expect(waitSeverity(new Date(NOW.getTime() - (7 * 24 * 60 * 60 * 1000 + 1)).toISOString(), NOW)).toBe('urgent')
+      expect(waitSeverity(daysAgo(30), NOW)).toBe('urgent')
+    })
+
+    it('is normal for an invalid/unparseable createdAt (fail-quiet, pairs with formatRelativeWait\'s "")', () => {
+      expect(waitSeverity('not-a-date', NOW)).toBe('normal')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

UX 阶梯（#3564）**batch-1 收官件 B1-03**（Sonnet 代理实现 + Fable 审查）。至此 batch-1 全部 8 项完成。

### 1. 待办列表行内 通过/驳回（桌面 pending tab）
- 固定右侧操作列，仅对 `isRowBatchSelectable(row)` 行渲染（考勤桥接行继续走行点击进考勤模块）；「通过」el-popconfirm（标题含单据名）→ 复用批量机制的同一单实例 dispatch + 成功后同款 loadCurrentTab/badge 刷新；「驳回」独立单行对话框（不复用批量对话框状态），**继承 B1-04 必填语义**（`policy?.rejectCommentRequired === false` 才免必填）+ 框内错误展示；全部 `@click.stop` 保护行点击导航。
- 高频体感：简单单据「看一眼→同意」从 4 步跨页降到列表内 2 击。

### 2. 已等待 aging + 进度可扫读
- 新纯模块 `relativeWait.ts`：刚刚/X 小时/X 天 + 分级（>3 天 warn 橙 / >7 天 urgent 红）；时钟偏斜钳制为「刚刚」、无效日期渲染空（防 NaN）。
- 四处接线：pending 列（含「第 X/Y 步」小字）/ mine 列（紧邻催办按钮强化催办动机）/ 移动卡片（绝对时间进 tooltip）/ 详情页 pending 专属 chip。

### 3. 批量失败清单 + 重试
- 部分失败不再折叠成一条 warning toast：结果对话框逐行列出 标题/编号 + manifest 的逐行原因，「重试失败项」按原 action+意见只重跑失败 ids，就地更新；全成功保持轻 toast。

## Verification

- 新增 22 测试（relativeWait 边界矩阵 11 / 行内动作+批量清单 8 / 移动分级 1 / 详情 chip 2），焦点跑 **193 全绿**，rebase 后复跑 83/83 + vue-tsc 0
- 测试基建升级：el-table stub 换用仓内已有的 provide/inject 列注册模式（原 stub 不能执行 scoped slot）；popconfirm stub 用 Teleport 结构性镜像 Element Plus 真实 popper（修掉一个 capture-phase 与渲染调度的测试竞态——生产 `.stop` 全程正确）
- 全量与基线逐文件一致（stash 复验）

🤖 Generated with [Claude Code](https://claude.com/claude-code)