### PR TITLE
feat(multitable): personal views Slice 2 — per-user field-order overlay (actor-scoped, flag default-off)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -318,6 +318,7 @@ jobs:
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             tests/integration/data-source-test-ephemeral-realdb.test.ts \
             tests/integration/multitable-personal-views-slice1-realdb.test.ts \
+            tests/integration/multitable-personal-views-slice2-fieldorder-realdb.test.ts \
             --reporter=dot
 
       - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward + continuous_managers chain walk + common template presets)

--- a/docs/development/multitable-personal-views-slice2-verification-20260705.md
+++ b/docs/development/multitable-personal-views-slice2-verification-20260705.md
@@ -1,0 +1,50 @@
+# Personal views — Slice 2 (per-user field order) — VERIFICATION — 2026-07-05
+
+> Verifies Slice 2 of the ratified design-lock `multitable-personal-views-design-lock-20260705.md` (§6). Slice 2 adds a
+> **per-user field-order** overlay facet, carried through the SAME actor-scoped table + CRUD + resolution as Slice 1
+> (#3637, on main). No new table, no new flag, no new client-supplied-id surface. **Default-OFF.** Built in-session
+> (Opus) after two build-agent runs died to infra errors (watchdog stall / API disconnect) — the change is small
+> enough to author + review directly.
+
+## 1. What was built (small, additive)
+
+| File | Change |
+|---|---|
+| `multitable/personal-view-config.ts` | Added `fieldOrder?: string[]` to `PersonalViewConfigOverlay`, `OVERLAY_KEYS`, `sanitizePersonalOverlayConfig` (string[] whitelist), and `applyPersonalViewOverlay` (additive spread). Nothing else changed — same actor-scoped module (never reads `req`). |
+| `routes/univer-meta.ts` | Added `fieldOrder?: string[]` to `UniverMetaViewConfig` so the served view config can carry it. **No wiring change** — `GET /views` already applies `applyPersonalViewOverlay`, so the new facet flows automatically; `redactViewConfigFilterLiterals` spreads `...view`, preserving `fieldOrder`. |
+| `tests/integration/multitable-personal-views-slice2-fieldorder-realdb.test.ts` | Slice-2 goldens (below). |
+| `.github/workflows/plugin-tests.yml` | Wires the golden into the Node-20 required real-DB step. |
+
+## 2. Why the load-bearing isolation is inherited (not re-proven from scratch)
+
+`fieldOrder` is written/read through the **identical actor-scoped path** as Slice 1: the CRUD keys on
+`(view_id, user_id) = (viewId, actorUserId)`, `actorUserId` comes only from the authenticated actor, and the config
+jsonb just carries one more key. The actor-keying is **unchanged code** — so Slice 1's **observed-RED (#3639: breaking
+the actor keying made the goldens go red)** already proves this exact keying has teeth. Slice 2 does not weaken or
+re-route it; its goldens confirm the fieldOrder facet specifically **flows and is isolated** on top of that proven
+mechanism.
+
+## 3. Fail-first goldens (real-DB, in the required Node-20 step)
+
+- **field-order actor isolation:** A's `fieldOrder` is served to A, **undefined for B** (B sees the sheet-global
+  order). RED if resolution keys on non-actor.
+- **byte-identical (flag-off / no override):** flag-off with A's row present ⇒ no `fieldOrder` served; flag-on with no
+  override for B ⇒ no `fieldOrder`. RED if the overlay perturbs the shared path.
+- **forged-identity:** A writing `fieldOrder` with a forged `body.userId=B` does NOT touch B's row (A's own row gets
+  it). RED if a client-supplied id selected the write target.
+- **additive:** setting only `fieldOrder` leaves `filterInfo` (and the other facets) falling through to shared.
+
+## 4. Enablement (unchanged)
+
+Same `MULTITABLE_ENABLE_PERSONAL_VIEWS`, **default-OFF**. This slice does not enable it. The flag-on checklist
+(`multitable-personal-views-flag-on-checklist-20260705.md`) applies — re-run its §B because slice 2 adds a served key.
+
+## 5. What was and was NOT executed locally (honest provenance)
+
+- **Verified by review:** the change is a small additive facet; the module, the type, the wiring (auto-flow +
+  redaction spread preserving `fieldOrder`), and the goldens were authored + read end-to-end.
+- **NOT run locally:** no `DATABASE_URL` in the authoring environment ⇒ the real-DB golden did not run here; **the
+  PR's `test (20.x)` is the first execution.**
+- **observed-RED:** the load-bearing actor-keying is the SAME code Slice 1 already observed-RED'd (#3639), so a fresh
+  observed-RED is not strictly required for the isolation invariant; if desired before any flag-on, the same
+  throwaway-CI method applies. Human reviewer: confirm the PR's `test (20.x)` runs the new golden GREEN.

--- a/packages/core-backend/src/multitable/personal-view-config.ts
+++ b/packages/core-backend/src/multitable/personal-view-config.ts
@@ -25,12 +25,14 @@
 
 export type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
 
-/** The facets a personal overlay may set. Field-order overlay is OUT of scope for slice 1 (slice 2). */
+/** The facets a personal overlay may set. `fieldOrder` added in slice 2 (per-user field order). */
 export type PersonalViewConfigOverlay = {
   filterInfo?: Record<string, unknown>
   sortInfo?: Record<string, unknown>
   groupInfo?: Record<string, unknown>
   hiddenFieldIds?: string[]
+  // slice 2: per-user field order — an ordered list of field ids overriding the sheet-global order for THIS actor.
+  fieldOrder?: string[]
 }
 
 export type PersonalViewConfigRecord = {
@@ -40,7 +42,7 @@ export type PersonalViewConfigRecord = {
   updatedAt: string
 }
 
-const OVERLAY_KEYS = ['filterInfo', 'sortInfo', 'groupInfo', 'hiddenFieldIds'] as const
+const OVERLAY_KEYS = ['filterInfo', 'sortInfo', 'groupInfo', 'hiddenFieldIds', 'fieldOrder'] as const
 
 export const PERSONAL_VIEWS_FLAG_ENV = 'MULTITABLE_ENABLE_PERSONAL_VIEWS'
 
@@ -68,6 +70,9 @@ export function sanitizePersonalOverlayConfig(input: unknown): PersonalViewConfi
   if (Array.isArray(input.hiddenFieldIds)) {
     out.hiddenFieldIds = input.hiddenFieldIds.filter((id): id is string => typeof id === 'string')
   }
+  if (Array.isArray(input.fieldOrder)) {
+    out.fieldOrder = input.fieldOrder.filter((id): id is string => typeof id === 'string')
+  }
   return out
 }
 
@@ -89,6 +94,7 @@ export function applyPersonalViewOverlay<
     sortInfo?: Record<string, unknown>
     groupInfo?: Record<string, unknown>
     hiddenFieldIds?: string[]
+    fieldOrder?: string[]
   },
 >(view: T, overlay: PersonalViewConfigOverlay | null | undefined): T {
   if (!overlay) return view
@@ -101,6 +107,7 @@ export function applyPersonalViewOverlay<
     ...(overlay.sortInfo !== undefined ? { sortInfo: overlay.sortInfo } : {}),
     ...(overlay.groupInfo !== undefined ? { groupInfo: overlay.groupInfo } : {}),
     ...(overlay.hiddenFieldIds !== undefined ? { hiddenFieldIds: overlay.hiddenFieldIds } : {}),
+    ...(overlay.fieldOrder !== undefined ? { fieldOrder: overlay.fieldOrder } : {}),
   }
 }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -418,6 +418,9 @@ type UniverMetaViewConfig = {
   sortInfo?: Record<string, unknown>
   groupInfo?: Record<string, unknown>
   hiddenFieldIds?: string[]
+  // slice 2: per-user personal field order, served only when the personal-views flag is on and this
+  // actor has a fieldOrder override (via applyPersonalViewOverlay). Absent otherwise — sheet-global order stands.
+  fieldOrder?: string[]
   config?: Record<string, unknown>
 }
 

--- a/packages/core-backend/tests/integration/multitable-personal-views-slice2-fieldorder-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-personal-views-slice2-fieldorder-realdb.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Slice 2 real-DB goldens for the personal (per-user) FIELD-ORDER overlay.
+ *
+ * Design: docs/development/multitable-personal-views-design-lock-20260705.md (§6 slice 2)
+ * Verification: docs/development/multitable-personal-views-slice2-verification-20260705.md
+ *
+ * Slice 2 adds a `fieldOrder` facet to the existing `PersonalViewConfigOverlay`, carried through the
+ * SAME actor-scoped table (`meta_view_personal_configs`) + CRUD + `applyPersonalViewOverlay` as slice 1.
+ * It is served on the `GET /views` view config so the FE (slice 3) can reorder; it reuses slice 1's
+ * actor-scoping wholesale (no new client-supplied-id surface). Flag: same `MULTITABLE_ENABLE_PERSONAL_VIEWS`.
+ *
+ * Goldens: field-order actor isolation (A's order invisible to B) · byte-identical shared (flag-off /
+ * no override → no fieldOrder served) · forged-identity (a forged body.userId cannot write another user's
+ * row) · additive (setting only fieldOrder leaves the other facets falling through to shared).
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI, matching sibling real-DB specs).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_pv2_${TS}`
+const SHEET_ID = `sheet_pv2_${TS}`
+const F1 = `fld_pv2_1_${TS}`
+const F2 = `fld_pv2_2_${TS}`
+const VIEW_ID = `view_pv2_${TS}`
+const USER_A = `user_pv2_a_${TS}`
+const USER_B = `user_pv2_b_${TS}`
+
+// Sheet-global order is F1(1) then F2(2). A's personal order flips them.
+const PERSONAL_A_ORDER = [F2, F1]
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let app: Express
+let currentUserId: string | null = USER_A
+let currentForgedHeader: string | undefined
+
+const listViews = () => {
+  const r = request(app).get('/api/multitable/views').query({ sheetId: SHEET_ID })
+  return currentForgedHeader ? r.set('x-user-id', currentForgedHeader) : r
+}
+const putPersonalConfig = (viewId: string, config: Record<string, unknown>, opts?: { forgedBodyUserId?: string }) => {
+  const r = request(app)
+    .put(`/api/multitable/views/${viewId}/personal-config`)
+    .send({ config, ...(opts?.forgedBodyUserId ? { userId: opts.forgedBodyUserId } : {}) })
+  return currentForgedHeader ? r.set('x-user-id', currentForgedHeader) : r
+}
+const viewFromList = (res: { body: unknown }) =>
+  (((res.body as { data?: { views?: unknown } })?.data?.views ?? []) as Array<{ id: string; fieldOrder?: string[]; filterInfo?: unknown }>)
+    .find((v) => v.id === VIEW_ID)
+const rowForUser = async (userId: string) =>
+  (await q('SELECT config FROM meta_view_personal_configs WHERE view_id = $1 AND user_id = $2', [VIEW_ID, userId]))
+    .rows[0] as { config: { fieldOrder?: string[] } } | undefined
+
+describeIfDatabase('personal views — slice 2 field-order overlay (real DB)', () => {
+  beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as unknown as { user?: unknown }).user = currentUserId
+        ? { id: currentUserId, roles: [], perms: ['multitable:read', 'multitable:write'] }
+        : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'PV2 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'PV2 Sheet'])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6),($7,$8,$9,$10,$11::jsonb,$12)',
+      [F1, SHEET_ID, 'F1', 'string', '{}', 1, F2, SHEET_ID, 'F2', 'string', '{}', 2],
+    )
+    await q(
+      'INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb,$9::jsonb)',
+      [VIEW_ID, SHEET_ID, 'PV2 View', 'grid', '{}', '{}', '{}', '[]', '{}'],
+    )
+  })
+
+  afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS
+    await q('DELETE FROM meta_view_personal_configs WHERE view_id = $1', [VIEW_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await poolManager.get().end?.()
+  })
+
+  afterEach(async () => {
+    await q('DELETE FROM meta_view_personal_configs WHERE view_id = $1', [VIEW_ID]).catch(() => {})
+    currentUserId = USER_A
+    currentForgedHeader = undefined
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('field-order actor isolation: A order applied for A, INVISIBLE to B', async () => {
+    currentUserId = USER_A
+    const put = await putPersonalConfig(VIEW_ID, { fieldOrder: PERSONAL_A_ORDER })
+    expect(put.status).toBe(200)
+    expect(viewFromList(await listViews())?.fieldOrder).toEqual(PERSONAL_A_ORDER)
+
+    currentUserId = USER_B
+    expect(viewFromList(await listViews())?.fieldOrder).toBeUndefined() // B sees sheet-global order — A's order invisible
+  })
+
+  test('byte-identical: flag OFF with A row present → no fieldOrder served', async () => {
+    currentUserId = USER_A
+    await putPersonalConfig(VIEW_ID, { fieldOrder: PERSONAL_A_ORDER })
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'false'
+    expect(viewFromList(await listViews())?.fieldOrder).toBeUndefined()
+  })
+
+  test('byte-identical: flag ON, no override for this actor → no fieldOrder', async () => {
+    currentUserId = USER_B
+    expect(viewFromList(await listViews())?.fieldOrder).toBeUndefined()
+  })
+
+  test('forged-identity: A writing fieldOrder with forged body.userId=B does NOT touch B row', async () => {
+    currentUserId = USER_A
+    const res = await putPersonalConfig(VIEW_ID, { fieldOrder: PERSONAL_A_ORDER }, { forgedBodyUserId: USER_B })
+    expect(res.status).toBe(200)
+    expect(await rowForUser(USER_B)).toBeUndefined() // B untouched — target is the authenticated actor A
+    expect((await rowForUser(USER_A))?.config?.fieldOrder).toEqual(PERSONAL_A_ORDER)
+  })
+
+  test('additive: setting only fieldOrder leaves other facets falling through to shared', async () => {
+    currentUserId = USER_A
+    await putPersonalConfig(VIEW_ID, { fieldOrder: PERSONAL_A_ORDER })
+    const a = viewFromList(await listViews())
+    expect(a?.fieldOrder).toEqual(PERSONAL_A_ORDER)
+    expect(a?.filterInfo).toEqual({}) // shared filter untouched (not clobbered by the fieldOrder-only overlay)
+  })
+})


### PR DESCRIPTION
Slice 2 of the ratified personal-views design-lock (#3631/#3637): a **per-user field-order** overlay facet.

> **WARNING: Built in-session (Opus) after two L2 build agents died to infra errors — reviewed directly; still requires human adversarial verification before merge; do not merge on green alone.**

## Small, additive
- Adds `fieldOrder?: string[]` to `PersonalViewConfigOverlay` (+ `OVERLAY_KEYS`, sanitizer, `applyPersonalViewOverlay`) and to `UniverMetaViewConfig`. Carried through the **SAME actor-scoped table + CRUD + resolution as Slice 1** — no new table, no new flag, **no new client-supplied-id surface**.
- `GET /views` already applies the overlay ⇒ the facet flows automatically; `redactViewConfigFilterLiterals` spreads `...view`, preserving `fieldOrder`.

## Goldens (real-DB, required Node-20 step)
field-order actor isolation · byte-identical (flag-off / no override) · forged-identity (a forged `body.userId` can't write another user's row) · additive.

## Isolation inherited, not re-proven from scratch
The actor-keying is unchanged code that **Slice 1 already observed-RED'd (#3639)** — breaking it made the goldens red. Slice 2 rides that proven mechanism; its goldens confirm the `fieldOrder` facet flows + is isolated. (verification MD §2/§5.)

## Enablement
Same `MULTITABLE_ENABLE_PERSONAL_VIEWS`, **default-OFF**; this PR does not enable it. flag-on checklist (#3656) applies. First real execution is this PR's `test (20.x)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)