### PR TITLE
docs(integration): close out B3/B4/C3 wind-down items (#1709 closure plan)

### DIFF
--- a/docs/development/integration-line-closure-plan-20260705.md
+++ b/docs/development/integration-line-closure-plan-20260705.md
@@ -72,13 +72,13 @@ A 能力关键路径
 B 质量收尾
   ⬜ B1 integration CI guard lane(我;最高优先)
   ⬜ B2 W1 处置(owner 二选一 → 我执行)
-  ⬜ B3 stale 注释清理(我)
-  ⬜ B4 冒烟姿态声明(我 docs / owner 可改链入)
+  ✅ B3 stale 注释清理(我)
+  ✅ B4 冒烟姿态声明(我 docs / owner 可改链入)
   ⬜ B5 :id/read 无 UI 声明(owner 一句话)
 C 治理收尾
   ⬜ C1 #1709 关闭重组(owner)
   ⬜ C2 卫星 issue 处置(owner+我)
-  ⬜ C3 gated 池冻结声明表(我,并入收尾文档)
+  ✅ C3 gated 池冻结声明表(我,并入收尾文档)
 ```
 
 **建议起手序**(并行三轨):A1(owner 实体机)∥ B1+B3(我,今天可完)∥ B2/C1 两个 owner 决定
@@ -97,3 +97,39 @@ C 治理收尾
 
 递归/写执行/K3 Save-Submit-Audit/delete/生产写全维持冻结;BL1+ 仍待 opt-in;本文档 authorizes
 nothing。
+
+## 8. 姿态声明与冻结清单(B4/C3 落实,2026-07-05)
+
+### 8.1 冒烟姿态声明(B4)
+
+读自助化(#3481/#3484)与组合(#3600)的 postdeploy 冒烟均为 `workflow_dispatch`-only 独立 lane,
+**不**链入 docker-build 部署 job——当前仅 K3 冒烟以 `continue-on-error` 链入该部署 job。这是**有意
+姿态**,而非遗漏:
+
+- 这两条冒烟都需要实体机(entity-machine)K3 凭证 + owner 提供的样例 key 才能跑出有意义的结果;
+  没有这些,冒烟要么被跳过、要么只能验证纯 mock 路径,起不到部署门禁的作用。
+- 因此它们的定位是 **owner 手动验收通道**,不是部署 gate:owner 在具备凭证/样例 key 的窗口内按需
+  `workflow_dispatch` 触发,把结果作为实体机验证证据的一部分(参见 §2 A 层 BL 链)。
+- 若未来要把它们改链入部署 job(例如补齐了可在 CI 中安全使用的凭证注入机制),那是一个**独立的
+  owner 决定**,不在本次收尾范围内,也不由本文档隐含授权。
+
+### 8.2 gated 池冻结清单(C3)
+
+以下每一项均处于其各自设计锁/门禁下的冻结态。**冻结即完成**——这些项不计入本线("数据库及系统
+连接线 #1709")的未完成项;解锁需要各自标注的门(named demand / opt-in / owner 显式再决定),本文档
+不解锁其中任何一项。
+
+| 项 | 门 | 说明 |
+| --- | --- | --- |
+| REC-R1 / REC-R2 / REC-R3(递归展开) | 双门:named demand + opt-in | 参见 `integration-read-source-recursive-expansion-direction-design-lock-20260705.md`;二跳以上的递归组合链仍待具名需求 + 显式 opt-in |
+| connector 模板目录 | 各自 design-lock 先行 + opt-in | 属于对标基准(benchmark §4)中列出的待办能力,尚无设计锁 |
+| 事件驱动入站(event-driven inbound) | 各自 design-lock 先行 + opt-in | 同上,benchmark §4 |
+| 可视化数据清洗(visual data prep) | 各自 design-lock 先行 + opt-in | 同上,benchmark §4 |
+| OAuth / SaaS 连接器 | 各自 design-lock 先行 + opt-in | 同上,benchmark §4 |
+| marker-gating enforcement | 已在 S1 递延(deferred at S1) | 非本线当前范围;沿用 S1 阶段的递延决定 |
+| delete 轨道 | W0 锁中硬排除(hard-excluded),无解锁路径 | 当前无 unlock path 定义,不在任何 opt-in 序列中 |
+| K3 Save / Submit / Audit + 外部/生产写 | 客户明令禁止(customer-barred);需显式授权 + sandbox-first | 与 BOM→stock-prep 轨的 C4 同口径:仅当获得显式授权且完成 sandbox 验证后才可能重新评估 |
+| 永久边界锁:host-allowlist 放宽 | 需显式再决定 | 现状为永久锁,非"待办",重开需专门决策 |
+| 永久边界锁:终端用户自由表单连接器(end-user free-form connector) | 需显式再决定 | 同上 |
+| 永久边界锁:按系统凭证路径(per-system credential path) | 需显式再决定 | 同上 |
+| 永久边界锁:组合深度 > 2(composition depth > 2) | 需显式再决定 | 现有组合链锁定为两跳(C-R1→C-R4);超过两跳属于永久边界锁范畴,与上面的递归展开条目(REC-R1..R3)共享同一物理限制但走独立的再决定路径 |

--- a/plugins/plugin-integration-core/lib/read-source-composition-planner.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-composition-planner.cjs
@@ -4,7 +4,9 @@
 // docs/development/integration-read-source-resolver-composition-design-lock-20260703.md).
 //
 // Scope fence: pure functions only. NO route, NO outbound call, NO adapter, NO persistence, NO write,
-// NO recursion. The C-R3 chain runtime executor is a separate, later, gated opt-in. This module only:
+// NO recursion. The C-R3 chain runtime executor has since shipped and lives in
+// read-source-composition-runtime.cjs, which consumes this planner's output; later rungs (recursive
+// expansion) remain a separate, gated opt-in. This module only:
 //   1. plans an approved two-hop composition (reusing the C-R1 save-time validator verbatim, so
 //      approved-only / resolver_lookup-only / write-shaped-step-rejected all hold at plan time),
 //   2. derives hop N+1's key-only input from hop N's resolved single value — a typed scalar handoff

--- a/plugins/plugin-integration-core/lib/read-source-read-runtime.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-read-runtime.cjs
@@ -38,9 +38,10 @@ const CONFIGURED_READ_BODY_KEYS = Object.freeze(['config', 'inputs'])
 
 // R2 (#1709, owner-authorized 2026-07-03): resolver_lookup is now a supported runtime mode — its multiplicity
 // selection semantics were designed (resolver design-lock) and implemented as the R1 pure evaluator, which
-// this executor invokes. STANDALONE ONLY: the resolver resolves one key to one value and returns it; its
-// output is NEVER fed into a second read / BOM lookup / any chained call (no composition — a separate,
-// still-ungated slice). The other three modes keep the generic field-map data plane below.
+// this executor invokes. STANDALONE: called directly, the resolver resolves one key to one value and
+// returns it to the caller, with no chaining here. The composition path (C-R3, merged) lives in
+// read-source-composition-runtime.cjs and orchestrates this executor per hop, feeding one hop's resolved
+// value into the next hop's key input. The other three modes keep the generic field-map data plane below.
 const CONFIGURED_READ_SUPPORTED_MODES = Object.freeze(['single_record', 'list_page', 'detail_with_lines', 'resolver_lookup'])
 
 function isPlainObject(value) {
@@ -176,8 +177,9 @@ async function executeConfiguredRead(prepared, { system, createAdapter, timeoutM
   // R2 (#1709): resolver_lookup BYPASSES the generic field-map data plane below. The R1 evaluator locates the
   // candidate container, applies the config's multiplicity rule (exactly_one / first_when_sorted /
   // field_equals — each with its own fail-closed detail), and returns { evidence, data } where data carries
-  // ONLY the one resolver output target+value. STANDALONE: that value is returned to the caller and NEVER
-  // fed into a second read / BOM lookup / chained call (composition is a separate, still-ungated slice).
+  // ONLY the one resolver output target+value. STANDALONE: called directly here, that value is returned to
+  // the caller with no further chaining. The composition path (C-R3, merged, read-source-composition-runtime.cjs)
+  // orchestrates this executor per hop instead of calling it standalone.
   if (plan.mode === 'resolver_lookup') {
     return evaluateResolver(config, raw, { rowCap: plan.rowCap })
   }


### PR DESCRIPTION
**Closure-plan B3 + B4 + C3** — comment/docs only, zero runtime.

- **B3**: stale scope-fence comments in `read-source-read-runtime.cjs` (×2) and `read-source-composition-planner.cjs` (×1) still said composition was 'a separate, still-ungated slice' / 'C-R3 ... a separate, later, gated opt-in' — C-R1→C-R4 shipped. Comments now state the current truth (standalone resolver stays standalone here; the composition path lives in `read-source-composition-runtime.cjs`, C-R3 merged, orchestrating this executor per hop; later recursion rungs remain gated). Verified: `node --check` + planner **purity tripwire** still green (no `require(`/`fetch(`/`query(` tokens introduced).
- **B4** (§8.1): smoke dispatch-only posture declared **intentional** (owner-run acceptance channels, not deploy gates), verified against the actual smoke workflows + docker-build deploy job.
- **C3** (§8.2): frozen-pool table — REC-R1/R2/R3, connector catalog, event-driven inbound, visual data prep, OAuth/SaaS, marker-gating, delete track, K3 Save/Submit/Audit + production write, and the four permanent boundary locks — all **冻结即完成** (do not count as unfinished for closure).
- §5 checklist B3/B4/C3 flipped ⬜→✅.

Independently re-verified: node-check + planner/read-runtime tests green; comment-only in the two .cjs (no code lines changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)