### PR TITLE
feat(web): approval admin polish — publish pre-flight checklist, metrics names+shortcuts, delegation 4-state (UX B2-03/04/05)

### DIFF
--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -4,6 +4,7 @@ import type {
   ApprovalNode,
   ApprovalNodeConfig,
 } from '../types/approval'
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../types/approval'
 
 // G-5 — approval-node editing inside a preserved complex graph. SCOPE: the approver SOURCE only
 // (`assigneeSources`). `approvalMode` / `emptyAssigneePolicy` / `autoApprovalPolicy` / any other
@@ -150,4 +151,20 @@ export function validateApprovalNodeEdits(
     }
   }
   return errors
+}
+
+/**
+ * B2-03 publish pre-flight: node keys whose FIRST assignee source is still the starter-preset
+ * placeholder role (`APPROVAL_ROLE_CONFIGURE_SENTINEL`). The backend fail-fasts on this at PUBLISH
+ * (`assertNoUnconfiguredPlaceholderRoles`, ApprovalProductService.ts) — this mirrors that check so
+ * the publish-checklist can warn BEFORE the confirm instead of after a rejected request. Non-fatal
+ * for save (mirrors the in-editor sentinel hint, which is also non-blocking).
+ */
+export function placeholderRoleNodeKeys(edits: ApprovalNodeEdits): string[] {
+  return Object.values(edits)
+    .filter((edit) => {
+      const source = edit.assigneeSources[0]
+      return source?.kind === 'static_role' && source.roleIds.includes(APPROVAL_ROLE_CONFIGURE_SENTINEL)
+    })
+    .map((edit) => edit.nodeKey)
 }

--- a/apps/web/src/approvals/delegationStatus.ts
+++ b/apps/web/src/approvals/delegationStatus.ts
@@ -1,0 +1,63 @@
+// B2-05 — time-aware delegation status. A `DelegationRecord` only carries a raw `active` boolean
+// (server-side: "not manually disabled" — see disableDelegation/disableOwnDelegation in
+// delegations.ts, both of which just flip/DELETE the row). Neither list view previously consulted
+// the `startAt`/`endAt` window at all, so a delegation whose window had already lapsed (or hadn't
+// started yet) still rendered a flat "生效" tag — the UI lies. This combines `active` with the
+// window against `now` into the true 4-state display status both views render.
+//
+// Read BOTH DelegationSettingsView.vue (admin) and MyDelegationView.vue (self-service) before
+// writing this: they share the IDENTICAL `DelegationRecord` row shape (`active: boolean`,
+// `startAt`/`endAt`: ISO string) — no per-view field-name normalization was actually needed. The
+// parameter type below stays a narrow structural shape (not `DelegationRecord` itself) so this
+// module has no view/Vue import and stays unit-testable in isolation (mirrors the other pure
+// helpers in this folder, e.g. templateAuthoring.ts's validate* functions).
+export interface DelegationStatusRow {
+  active: boolean
+  startAt: string
+  endAt: string
+}
+
+export type DelegationDisplayStatus = '未开始' | '生效中' | '已过期' | '已停用'
+
+export interface DelegationStatusResult {
+  status: DelegationDisplayStatus
+  /** True only when `status === '生效中'` AND `endAt` is within the next 72h (boundary inclusive). */
+  expiringSoon: boolean
+}
+
+const EXPIRING_SOON_WINDOW_MS = 72 * 60 * 60 * 1000
+
+/**
+ * `active === false` (manually disabled) always wins — a disabled delegation reads "已停用"
+ * regardless of what its window would otherwise say (including an already-past or not-yet-started
+ * window). Otherwise the window against `now` decides 未开始 / 生效中 / 已过期. `startAt`/`endAt`
+ * are treated as an INCLUSIVE window (`startAt <= now <= endAt` = 生效中), matching
+ * `validateDelegationForm`'s only constraint (`endAt` strictly after `startAt`).
+ *
+ * Defensive: an unparseable boundary can't gate a real comparison, so it is treated as absent
+ * (never trips 未开始/已过期 on its own) rather than throwing or silently miscategorizing —
+ * malformed data degrades to 生效中 (the same "trust active" behavior the old binary tag had).
+ */
+export function delegationDisplayStatus(row: DelegationStatusRow, now: Date = new Date()): DelegationStatusResult {
+  if (!row.active) return { status: '已停用', expiringSoon: false }
+
+  const nowMs = now.getTime()
+  const startMs = new Date(row.startAt).getTime()
+  const endMs = new Date(row.endAt).getTime()
+  const hasStart = Number.isFinite(startMs)
+  const hasEnd = Number.isFinite(endMs)
+
+  if (hasStart && nowMs < startMs) return { status: '未开始', expiringSoon: false }
+  if (hasEnd && nowMs > endMs) return { status: '已过期', expiringSoon: false }
+
+  const expiringSoon = hasEnd && (endMs - nowMs) <= EXPIRING_SOON_WINDOW_MS
+  return { status: '生效中', expiringSoon }
+}
+
+/** Element Plus `el-tag` `type` per status — one distinct color per state. */
+export const DELEGATION_STATUS_TAG_TYPE: Record<DelegationDisplayStatus, 'info' | 'success' | 'warning' | 'danger'> = {
+  未开始: 'info',
+  生效中: 'success',
+  已过期: 'warning',
+  已停用: 'danger',
+}

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -66,6 +66,7 @@ export { PARALLEL_JOIN_MODES } from './parallelEdit'
 export type { CcEdits, CcNodeEdit } from './ccEdit'
 export { CC_TARGET_TYPES } from './ccEdit'
 export type { ApprovalNodeEdits, ApprovalNodeSourceEdit } from './approvalNodeEdit'
+export { placeholderRoleNodeKeys } from './approvalNodeEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
@@ -1021,7 +1022,11 @@ export function buildSlaHours(draft: TemplateAuthoringDraft): number | null {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : Number.NaN
 }
 
-export function validateTemplateDraft(
+// B2-03: split out of the former monolithic `validateTemplateDraft` so the publish pre-flight
+// checklist can show a "表单字段" bucket independently (without re-deriving/duplicating the rules).
+// `validateTemplateDraft` below composes this + `validateTemplateApprovalFlow` in the SAME order as
+// before the split, so its combined output is byte-identical to the pre-split function.
+export function validateTemplateFormFields(
   draft: TemplateAuthoringDraft,
   unsupportedReason?: string | null,
 ): string[] {
@@ -1102,6 +1107,13 @@ export function validateTemplateDraft(
     cycleState.set(fieldId, 2)
   }
   visibilityDeps.forEach((_dependsOn, fieldId) => visitVisibility(fieldId))
+  return errors
+}
+
+// B2-03: the other half of the split — step / graph-edit ("审批流程") errors only. See
+// `validateTemplateFormFields` above for the rationale.
+export function validateTemplateApprovalFlow(draft: TemplateAuthoringDraft): string[] {
+  const errors: string[] = []
   // A complex graph (preservedGraph) carries no editable steps — the step requirement only
   // applies to linear drafts that build their graph from `steps`.
   if (!draft.preservedGraph && draft.steps.length === 0) errors.push('至少需要一个审批步骤')
@@ -1134,6 +1146,16 @@ export function validateTemplateDraft(
     }
   })
   return errors
+}
+
+export function validateTemplateDraft(
+  draft: TemplateAuthoringDraft,
+  unsupportedReason?: string | null,
+): string[] {
+  return [
+    ...validateTemplateFormFields(draft, unsupportedReason),
+    ...validateTemplateApprovalFlow(draft),
+  ]
 }
 
 export function buildCreateTemplatePayload(draft: TemplateAuthoringDraft): CreateApprovalTemplateRequest {

--- a/apps/web/src/views/approval/ApprovalMetricsView.vue
+++ b/apps/web/src/views/approval/ApprovalMetricsView.vue
@@ -11,6 +11,7 @@
           start-placeholder="开始日期"
           end-placeholder="结束日期"
           value-format="YYYY-MM-DD"
+          :shortcuts="DATE_RANGE_SHORTCUTS"
           @change="loadAll"
         />
         <el-button type="primary" @click="loadAll" :loading="loading">
@@ -58,7 +59,7 @@
         <span>按模板汇总</span>
       </template>
       <el-table :data="summary.byTemplate" stripe v-loading="loading">
-        <el-table-column prop="templateId" label="模板 ID" min-width="240">
+        <el-table-column prop="templateId" label="模板" min-width="240">
           <template #default="{ row }">
             <el-link
               v-if="row.templateId"
@@ -66,7 +67,7 @@
               type="primary"
               @click="goTemplate(row.templateId)"
             >
-              {{ row.templateId }}
+              {{ templateDisplayName(row.templateId) }}
             </el-link>
             <span v-else class="metric-muted">未关联模板</span>
           </template>
@@ -194,7 +195,7 @@
           <el-table-column label="模板" min-width="180">
             <template #default="{ row }">
               <el-link v-if="row.templateId" type="primary" @click="goTemplate(row.templateId)">
-                {{ row.templateId }}
+                {{ templateDisplayName(row.templateId) }}
               </el-link>
               <span v-else class="metric-muted">未关联模板</span>
             </template>
@@ -219,7 +220,7 @@
           <el-table-column label="模板" min-width="220">
             <template #default="{ row }">
               <el-link v-if="row.templateId" type="primary" @click="goTemplate(row.templateId)">
-                {{ row.templateId }}
+                {{ templateDisplayName(row.templateId) }}
               </el-link>
               <span v-else class="metric-muted">未关联模板</span>
             </template>
@@ -253,6 +254,7 @@ import {
   fetchApprovalMetricsReport,
   fetchApprovalMetricsSummary,
   fetchApprovalMetricsTeams,
+  listTemplates,
   type ApprovalMetricsDimensionRow,
   type ApprovalMetricsRow,
   type ApprovalMetricsSummary,
@@ -287,8 +289,42 @@ const reportLoading = ref(false)
 const teamsLoading = ref(false)
 const peopleLoading = ref(false)
 const errorMessage = ref('')
+// B2-04: template id → name, fetched ONCE on mount (not tied to the date range/refresh) so the
+// per-template tables below can render a scannable name instead of a raw UUID.
+const templateNameById = ref<Map<string, string>>(new Map())
 
 const BREAKDOWN_LIMIT = 20
+// B2-04: quick date-range presets for the toolbar picker. Each `value` is a function so "近 7
+// 天"/"近 30 天"/"本月" stay relative to "now" at the moment the shortcut is clicked, not frozen
+// at module-eval time.
+const DATE_RANGE_SHORTCUTS = [
+  {
+    text: '近 7 天',
+    value: (): [Date, Date] => {
+      const end = new Date()
+      const start = new Date()
+      start.setDate(start.getDate() - 7)
+      return [start, end]
+    },
+  },
+  {
+    text: '近 30 天',
+    value: (): [Date, Date] => {
+      const end = new Date()
+      const start = new Date()
+      start.setDate(start.getDate() - 30)
+      return [start, end]
+    },
+  },
+  {
+    text: '本月',
+    value: (): [Date, Date] => {
+      const end = new Date()
+      const start = new Date(end.getFullYear(), end.getMonth(), 1)
+      return [start, end]
+    },
+  },
+]
 
 const approvalRatePercent = computed(() => {
   const decided = summary.value.approved + summary.value.rejected + summary.value.revoked + summary.value.returned
@@ -384,6 +420,23 @@ async function loadAll(): Promise<void> {
   await Promise.all([loadSummary(), loadBreaches(), loadReport(), loadTeams(), loadPeople()])
 }
 
+// B2-04: best-effort id→name lookup, fetched once (a generous pageSize so typical template
+// catalogs resolve in one page — the backend caps pageSize at 200 regardless). Non-fatal: a
+// failure (or a template outside the fetched page) just leaves the id unmapped, and
+// `templateDisplayName` falls back to the raw id, same as before this change.
+async function loadTemplateNames(): Promise<void> {
+  try {
+    const { data } = await listTemplates({ pageSize: 200 })
+    templateNameById.value = new Map(data.map((template) => [template.id, template.name]))
+  } catch {
+    templateNameById.value = new Map()
+  }
+}
+
+function templateDisplayName(templateId: string): string {
+  return templateNameById.value.get(templateId) ?? templateId
+}
+
 function barWidth(rate: number | null | undefined): string {
   const pct = typeof rate === 'number' && Number.isFinite(rate) ? rate * 100 : 0
   return `${Math.min(100, Math.max(0, pct))}%`
@@ -416,7 +469,10 @@ function goTemplate(templateId: string): void {
   router.push({ name: 'approval-template-detail', params: { id: templateId } })
 }
 
-onMounted(() => { void loadAll() })
+onMounted(() => {
+  void loadAll()
+  void loadTemplateNames()
+})
 </script>
 
 <style scoped>

--- a/apps/web/src/views/approval/DelegationSettingsView.vue
+++ b/apps/web/src/views/approval/DelegationSettingsView.vue
@@ -27,9 +27,12 @@
       <el-table-column label="时间窗">
         <template #default="{ row }">{{ fmt(row.startAt) }} ~ {{ fmt(row.endAt) }}</template>
       </el-table-column>
-      <el-table-column label="状态">
+      <el-table-column label="状态" width="150">
         <template #default="{ row }">
-          <el-tag :type="row.active ? 'success' : 'info'" size="small">{{ row.active ? '生效' : '已停用' }}</el-tag>
+          <el-tag :type="DELEGATION_STATUS_TAG_TYPE[delegationDisplayStatus(row).status]" size="small">
+            {{ delegationDisplayStatus(row).status }}
+          </el-tag>
+          <span v-if="delegationDisplayStatus(row).expiringSoon" class="expiring-soon-hint">即将到期</span>
         </template>
       </el-table-column>
       <el-table-column v-if="includeInactive" label="已路由审批" width="110">
@@ -78,7 +81,7 @@
 
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue'
-import { ElMessage } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import {
   listDelegations,
@@ -89,6 +92,7 @@ import {
   type DelegationRecord,
   type DelegationForm,
 } from '../../approvals/delegations'
+import { delegationDisplayStatus, DELEGATION_STATUS_TAG_TYPE } from '../../approvals/delegationStatus'
 
 const { canManageTemplates: canManage } = useApprovalPermissions()
 const delegations = ref<DelegationRecord[]>([])
@@ -147,7 +151,18 @@ async function submit() {
   }
 }
 
+// B2-05: 停用 is a routing-affecting action (it takes the delegatee out of the assignee
+// resolution immediately) but was previously zero-friction — one click, no confirmation.
 async function disable(id: string) {
+  try {
+    await ElMessageBox.confirm(
+      '停用后该委托立即失效，进行中的转交不受影响。确定停用吗？',
+      '停用委托',
+      { confirmButtonText: '停用', cancelButtonText: '取消', type: 'warning' },
+    )
+  } catch {
+    return
+  }
   try {
     await disableDelegation(id)
     await load()
@@ -165,4 +180,10 @@ onMounted(load)
 .header h2 { margin: 0; }
 .actions { display: flex; align-items: center; gap: 12px; }
 .sub { color: var(--el-text-color-secondary); font-size: 13px; margin: 4px 0 0; }
+.expiring-soon-hint {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--el-color-warning, #e6a23c);
+}
 </style>

--- a/apps/web/src/views/approval/MyDelegationView.vue
+++ b/apps/web/src/views/approval/MyDelegationView.vue
@@ -16,9 +16,12 @@
       <el-table-column label="时间窗">
         <template #default="{ row }">{{ fmt(row.startAt) }} ~ {{ fmt(row.endAt) }}</template>
       </el-table-column>
-      <el-table-column label="状态">
+      <el-table-column label="状态" width="150">
         <template #default="{ row }">
-          <el-tag :type="row.active ? 'success' : 'info'" size="small">{{ row.active ? '生效' : '已停用' }}</el-tag>
+          <el-tag :type="DELEGATION_STATUS_TAG_TYPE[delegationDisplayStatus(row).status]" size="small">
+            {{ delegationDisplayStatus(row).status }}
+          </el-tag>
+          <span v-if="delegationDisplayStatus(row).expiringSoon" class="expiring-soon-hint">即将到期</span>
         </template>
       </el-table-column>
       <el-table-column label="已路由审批" width="110">
@@ -64,7 +67,7 @@
 
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue'
-import { ElMessage } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import {
   listOwnDelegations,
   createOwnDelegation,
@@ -74,6 +77,7 @@ import {
   type DelegationRecord,
   type OwnDelegationForm,
 } from '../../approvals/delegations'
+import { delegationDisplayStatus, DELEGATION_STATUS_TAG_TYPE } from '../../approvals/delegationStatus'
 
 const delegations = ref<DelegationRecord[]>([])
 const loading = ref(false)
@@ -128,7 +132,18 @@ async function submit() {
   }
 }
 
+// B2-05: 停用 is a routing-affecting action (it takes the delegatee out of the assignee
+// resolution immediately) but was previously zero-friction — one click, no confirmation.
 async function disable(id: string) {
+  try {
+    await ElMessageBox.confirm(
+      '停用后该委托立即失效，进行中的转交不受影响。确定停用吗？',
+      '停用委托',
+      { confirmButtonText: '停用', cancelButtonText: '取消', type: 'warning' },
+    )
+  } catch {
+    return
+  }
   try {
     await disableOwnDelegation(id)
     await load()
@@ -145,4 +160,10 @@ onMounted(load)
 .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 12px; }
 .header h2 { margin: 0; }
 .sub { color: var(--el-text-color-secondary); font-size: 13px; margin: 4px 0 0; }
+.expiring-soon-hint {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--el-color-warning, #e6a23c);
+}
 </style>

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -23,7 +23,7 @@
           :loading="publishing"
           :disabled="!canSave"
           data-testid="approval-template-publish-button"
-          @click="handlePublish"
+          @click="openPublishChecklist"
         >
           发布
         </el-button>
@@ -1108,6 +1108,43 @@
         </el-collapse>
       </el-card>
     </div>
+
+    <!-- B2-03: publish pre-flight checklist — replaces the old "confirm first, validate after"
+         ElMessageBox.confirm. Every item mirrors an already-exported validator (see the
+         publishChecklist computed); the confirm button stays disabled until all are ✓. -->
+    <el-dialog
+      v-model="publishChecklistVisible"
+      title="发布前检查"
+      width="480px"
+      data-testid="approval-publish-checklist"
+    >
+      <ul class="template-authoring__publish-checklist">
+        <li
+          v-for="item in publishChecklist"
+          :key="item.key"
+          class="template-authoring__publish-checklist-item"
+          :class="item.ok ? 'is-ok' : 'is-fail'"
+          :data-testid="`approval-publish-checklist-item-${item.key}`"
+          :data-ok="item.ok"
+        >
+          <span class="template-authoring__publish-checklist-icon">{{ item.ok ? '✓' : '✗' }}</span>
+          <span class="template-authoring__publish-checklist-label">{{ item.label }}</span>
+          <span v-if="!item.ok && item.detail" class="template-authoring__publish-checklist-detail">{{ item.detail }}</span>
+        </li>
+      </ul>
+      <template #footer>
+        <el-button @click="publishChecklistVisible = false">取消</el-button>
+        <el-button
+          type="primary"
+          :loading="publishing"
+          :disabled="!canConfirmPublish"
+          data-testid="approval-publish-checklist-confirm"
+          @click="confirmPublish"
+        >
+          确认发布
+        </el-button>
+      </template>
+    </el-dialog>
   </section>
 </template>
 
@@ -1141,6 +1178,9 @@ import {
   setStepFieldPermission,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
+  validateTemplateFormFields,
+  validateTemplateApprovalFlow,
+  placeholderRoleNodeKeys,
   approvalFormulaInsertOptions,
   CONDITION_RULE_OPERATORS,
   PARALLEL_JOIN_MODES,
@@ -1170,7 +1210,6 @@ import {
   COMMON_APPROVAL_TEMPLATE_PRESETS,
   type CommonApprovalTemplatePresetId,
 } from '../../approvals/commonTemplatePresets'
-import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../../types/approval'
 import type {
   ApprovalAssigneeSource,
   ApprovalAssigneeSourceKind,
@@ -1523,10 +1562,11 @@ function approvalSourceIds(nodeKey: string): string[] {
 }
 // G-5 sentinel hint: true when the source is a static_role still carrying the starter-preset
 // placeholder (APPROVAL_ROLE_CONFIGURE_SENTINEL). The backend blocks publish on it; this surfaces it
-// in the editor so the admin replaces it first. Non-blocking — the draft still saves.
+// in the editor so the admin replaces it first. Non-blocking — the draft still saves. Delegates to
+// the shared `placeholderRoleNodeKeys` (B2-03) so the per-node hint and the aggregate publish
+// checklist item share one predicate.
 function approvalSourceIsPlaceholder(nodeKey: string): boolean {
-  return approvalSourceKind(nodeKey) === 'static_role'
-    && approvalSourceIds(nodeKey).includes(APPROVAL_ROLE_CONFIGURE_SENTINEL)
+  return publishPlaceholderRoleKeys.value.includes(nodeKey)
 }
 
 // ── D-2/D-3 topology authoring (structural graph edits via graphTopologyEdit + applyTopologyToComplexDraft) ──
@@ -1589,6 +1629,38 @@ const canvasValidity = computed<string[]>(() => (draft.value.preservedGraph ? gr
 function canvasNodeByKey(key: string): ApprovalNode | undefined {
   return canvasEffectiveGraph.value.nodes.find((n) => n.key === key)
 }
+
+// B2-03 publish pre-flight checklist — aggregates the SAME already-exported validators used
+// elsewhere in this view (validateTemplateFormFields / validateTemplateApprovalFlow + canvasValidity
+// / the G-5 sentinel scan) into one array the publish dialog renders BEFORE the admin commits to
+// publishing, instead of only discovering an invalid draft after the confirm (promise-then-renege).
+// This only surfaces existing checks earlier; it never relaxes any of them.
+interface PublishChecklistItem {
+  key: string
+  label: string
+  ok: boolean
+  detail?: string
+}
+const publishFormFieldIssues = computed<string[]>(() => validateTemplateFormFields(draft.value, unsupportedReason.value))
+// "审批流程" bundles the step/graph-edit errors with the canvas topology preview (graphValidityIssues)
+// — two independent validators that both gate a successful publish server-side.
+const publishApprovalFlowIssues = computed<string[]>(() => [
+  ...validateTemplateApprovalFlow(draft.value),
+  ...canvasValidity.value,
+])
+const publishPlaceholderRoleKeys = computed<string[]>(() => placeholderRoleNodeKeys(draft.value.approvalNodeEdits ?? {}))
+const publishPlaceholderRoleIssues = computed<string[]>(() =>
+  publishPlaceholderRoleKeys.value.map(
+    (key) => `审批节点「${canvasNodeByKey(key)?.name || key}」仍为占位审批角色，请先替换为真实角色`,
+  ),
+)
+const publishChecklist = computed<PublishChecklistItem[]>(() => [
+  { key: 'fields', label: '表单字段', ok: publishFormFieldIssues.value.length === 0, detail: publishFormFieldIssues.value[0] },
+  { key: 'flow', label: '审批流程', ok: publishApprovalFlowIssues.value.length === 0, detail: publishApprovalFlowIssues.value[0] },
+  { key: 'placeholder', label: '审批人占位', ok: publishPlaceholderRoleIssues.value.length === 0, detail: publishPlaceholderRoleIssues.value[0] },
+])
+const canConfirmPublish = computed(() => publishChecklist.value.every((item) => item.ok))
+const publishChecklistVisible = ref(false)
 const canvasEdgeLines = computed(() => {
   const pos = new Map(canvasLayout.value.nodes.map((n) => [n.key, n]))
   return canvasEffectiveGraph.value.edges.map((edge) => {
@@ -1879,17 +1951,18 @@ async function handleSave() {
   }
 }
 
-async function handlePublish() {
+// B2-03: publish pre-flight — opens the checklist dialog INSTEAD of confirming immediately, so an
+// invalid draft is visible before the admin commits (the dialog's own confirm button stays disabled
+// while `canConfirmPublish` is false). Once the checklist is all-green, `confirmPublish` runs the
+// SAME persistDraft → publishTemplate → success-routing sequence as before this change.
+function openPublishChecklist() {
   if (!canSave.value || publishing.value) return
-  try {
-    await ElMessageBox.confirm('发布后用户即可从模板中心发起审批，确认发布吗？', '发布审批模板', {
-      confirmButtonText: '发布',
-      cancelButtonText: '取消',
-      type: 'warning',
-    })
-  } catch {
-    return
-  }
+  publishChecklistVisible.value = true
+}
+
+async function confirmPublish() {
+  if (!canConfirmPublish.value) return
+  publishChecklistVisible.value = false
   publishing.value = true
   try {
     const saved = await persistDraft()
@@ -2166,6 +2239,43 @@ onUnmounted(() => {
 .template-authoring__error-list {
   margin: 6px 0 0;
   padding-left: 20px;
+}
+
+.template-authoring__publish-checklist {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.template-authoring__publish-checklist-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--el-fill-color-lighter, #f5f7fa);
+}
+
+.template-authoring__publish-checklist-item.is-ok .template-authoring__publish-checklist-icon {
+  color: var(--el-color-success, #67c23a);
+}
+
+.template-authoring__publish-checklist-item.is-fail .template-authoring__publish-checklist-icon {
+  color: var(--el-color-danger, #f56c6c);
+}
+
+.template-authoring__publish-checklist-icon {
+  font-weight: 700;
+}
+
+.template-authoring__publish-checklist-detail {
+  flex-basis: 100%;
+  font-size: 12px;
+  color: var(--el-text-color-secondary, #606266);
 }
 
 pre {

--- a/apps/web/tests/approvalDelegationStatus.spec.ts
+++ b/apps/web/tests/approvalDelegationStatus.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import {
+  delegationDisplayStatus,
+  DELEGATION_STATUS_TAG_TYPE,
+  type DelegationStatusRow,
+} from '../src/approvals/delegationStatus'
+
+// B2-05 — PURE-LOGIC tests (no .vue / no Element Plus) for the time-aware delegation status
+// matrix. A `DelegationRecord` only carries a raw `active` boolean (server-side: "not manually
+// disabled"); neither DelegationSettingsView nor MyDelegationView previously consulted the
+// startAt/endAt window, so an expired (or not-yet-started) delegation still showed a flat "生效"
+// tag. See delegationStatus.ts for the full rationale; this file locks the matrix: before-start /
+// active / expired / disabled (+ disabled-overrides-window precedence) / expiringSoon boundaries /
+// inclusive window edges / malformed-input defensiveness / the default-`now` path.
+
+const NOW = new Date('2026-07-04T12:00:00Z')
+const HOUR = 60 * 60 * 1000
+
+function row(overrides: Partial<DelegationStatusRow> = {}): DelegationStatusRow {
+  return {
+    active: true,
+    startAt: new Date(NOW.getTime() - HOUR).toISOString(),
+    endAt: new Date(NOW.getTime() + HOUR).toISOString(),
+    ...overrides,
+  }
+}
+
+describe('delegationDisplayStatus', () => {
+  it('未开始: now before startAt (active window not yet reached)', () => {
+    const r = row({ startAt: new Date(NOW.getTime() + HOUR).toISOString(), endAt: new Date(NOW.getTime() + 2 * HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '未开始', expiringSoon: false })
+  })
+
+  it('生效中: now strictly inside the window, far from expiry', () => {
+    const r = row({ startAt: new Date(NOW.getTime() - HOUR).toISOString(), endAt: new Date(NOW.getTime() + 200 * HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '生效中', expiringSoon: false })
+  })
+
+  it('已过期: now after endAt', () => {
+    const r = row({ startAt: new Date(NOW.getTime() - 2 * HOUR).toISOString(), endAt: new Date(NOW.getTime() - HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '已过期', expiringSoon: false })
+  })
+
+  it('已停用: active === false reads 已停用 even though the window is currently 生效中', () => {
+    const r = row({ active: false, startAt: new Date(NOW.getTime() - HOUR).toISOString(), endAt: new Date(NOW.getTime() + HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '已停用', expiringSoon: false })
+  })
+
+  it('已停用 takes precedence over an otherwise-已过期 window (disabled always wins)', () => {
+    const r = row({ active: false, startAt: new Date(NOW.getTime() - 2 * HOUR).toISOString(), endAt: new Date(NOW.getTime() - HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '已停用', expiringSoon: false })
+  })
+
+  it('已停用 takes precedence over an otherwise-未开始 window (disabled always wins)', () => {
+    const r = row({ active: false, startAt: new Date(NOW.getTime() + HOUR).toISOString(), endAt: new Date(NOW.getTime() + 2 * HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '已停用', expiringSoon: false })
+  })
+
+  it('window boundaries are INCLUSIVE: now === startAt is already 生效中', () => {
+    const r = row({ startAt: NOW.toISOString(), endAt: new Date(NOW.getTime() + HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW).status).toBe('生效中')
+  })
+
+  it('window boundaries are INCLUSIVE: now === endAt is still 生效中 (not yet 已过期)', () => {
+    const r = row({ startAt: new Date(NOW.getTime() - HOUR).toISOString(), endAt: NOW.toISOString() })
+    expect(delegationDisplayStatus(r, NOW).status).toBe('生效中')
+  })
+
+  it('expiringSoon: true exactly at the 72h boundary (inclusive)', () => {
+    const r = row({ endAt: new Date(NOW.getTime() + 72 * HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '生效中', expiringSoon: true })
+  })
+
+  it('expiringSoon: false just past the 72h boundary', () => {
+    const r = row({ endAt: new Date(NOW.getTime() + 72 * HOUR + 60_000).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '生效中', expiringSoon: false })
+  })
+
+  it('expiringSoon: false when 已停用, even if the window would otherwise be within 72h', () => {
+    const r = row({ active: false, endAt: new Date(NOW.getTime() + HOUR).toISOString() })
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '已停用', expiringSoon: false })
+  })
+
+  it('is defensive against unparseable startAt/endAt: does not throw, degrades to 生效中', () => {
+    const r = row({ startAt: 'not-a-date', endAt: 'also-not-a-date' })
+    expect(() => delegationDisplayStatus(r, NOW)).not.toThrow()
+    expect(delegationDisplayStatus(r, NOW)).toEqual({ status: '生效中', expiringSoon: false })
+  })
+
+  it('defaults `now` to the current time when omitted', () => {
+    const r = row({
+      startAt: new Date(Date.now() - HOUR).toISOString(),
+      endAt: new Date(Date.now() + 200 * HOUR).toISOString(),
+    })
+    expect(delegationDisplayStatus(r).status).toBe('生效中')
+  })
+
+  it('DELEGATION_STATUS_TAG_TYPE maps one distinct el-tag type per status', () => {
+    expect(DELEGATION_STATUS_TAG_TYPE).toEqual({
+      未开始: 'info',
+      生效中: 'success',
+      已过期: 'warning',
+      已停用: 'danger',
+    })
+  })
+})

--- a/apps/web/tests/approvalDelegationView.spec.ts
+++ b/apps/web/tests/approvalDelegationView.spec.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, inject, nextTick, provide, reactive, type App as VueApp, type Slot } from 'vue'
+import type { DelegationRecord } from '../src/approvals/delegations'
+
+// B2-05 — DelegationSettingsView (admin 委托设置) MOUNTED-component coverage. Neither
+// approvalDelegationForm.spec.ts nor approvalDelegationRoute.spec.ts (the only pre-existing specs
+// naming this view) actually mount it — they test the pure form-validation helpers and the router
+// source text respectively. This is the first mounted harness for this view, added because B2-05
+// is a rendering + confirm-dialog behavior change (status tag per state, confirm-before-disable),
+// which needs an actual mount to assert on.
+//
+// ElTable/ElTableColumn use the same "column registry via provide/inject" stub proven in
+// approvalMetricsTopnReport.spec.ts, since the status/操作 columns render via scoped slots the
+// simpler count-only ElTable stub (approvalMetricsView.spec.ts's style) can't exercise.
+
+const canManageTemplates = { value: true }
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({ canManageTemplates }),
+}))
+
+const listDelegationsSpy = vi.fn()
+const disableDelegationSpy = vi.fn().mockResolvedValue(undefined)
+const createDelegationSpy = vi.fn()
+vi.mock('../src/approvals/delegations', async () => {
+  const actual = await vi.importActual<typeof import('../src/approvals/delegations')>('../src/approvals/delegations')
+  return {
+    ...actual,
+    listDelegations: (opts?: unknown) => listDelegationsSpy(opts),
+    disableDelegation: (id: string) => disableDelegationSpy(id),
+    createDelegation: (payload: unknown) => createDelegationSpy(payload),
+  }
+})
+
+const confirmSpy = vi.fn().mockResolvedValue(undefined)
+const messageErrorSpy = vi.fn()
+vi.mock('element-plus', () => ({
+  ElMessage: { success: vi.fn(), warning: vi.fn(), error: (...a: unknown[]) => messageErrorSpy(...a) },
+  ElMessageBox: { confirm: (...a: unknown[]) => confirmSpy(...a) },
+}))
+
+type ColumnRegistryEntry = { key: string; prop?: string; label?: string; defaultSlot?: Slot }
+type ColumnRegistry = { columns: ColumnRegistryEntry[]; register: (entry: ColumnRegistryEntry) => void }
+const COLUMN_REGISTRY_KEY = Symbol('delegation-table-columns')
+let columnSeq = 0
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: { type: Array, default: () => [] }, emptyText: String },
+  setup(props, { slots }) {
+    const registry = reactive<ColumnRegistry>({ columns: [], register(entry) { registry.columns.push(entry) } })
+    provide(COLUMN_REGISTRY_KEY, registry)
+    return () => {
+      const columnInstances = slots.default?.() ?? []
+      const rows = (props.data as DelegationRecord[] | undefined) ?? []
+      return h('div', { 'data-el-table': 'true' }, [
+        h('div', { style: 'display:none' }, columnInstances),
+        ...rows.map((row, index) =>
+          h('div', { 'data-el-row': String(index) },
+            registry.columns.map((column) =>
+              h('div', { 'data-el-cell': column.prop || column.label || column.key },
+                column.defaultSlot ? column.defaultSlot({ row }) : String((row as never)[column.prop ?? ''] ?? ''),
+              ),
+            ),
+          ),
+        ),
+      ])
+    }
+  },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number] },
+  setup(props, { slots }) {
+    const registry = inject<ColumnRegistry | null>(COLUMN_REGISTRY_KEY, null)
+    if (registry) registry.register({ key: `col-${columnSeq++}`, prop: props.prop, label: props.label, defaultSlot: slots.default })
+    return () => null
+  },
+})
+
+const ElTag = defineComponent({
+  name: 'ElTag',
+  props: { type: String, size: String },
+  render() {
+    return h('span', { 'data-el-tag-type': this.type || 'default' }, this.$slots.default?.())
+  },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, text: Boolean, size: String, disabled: Boolean, loading: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      type: 'button',
+      disabled: this.disabled || this.loading,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onClick: (e: Event) => this.$emit('click', e),
+    }, this.$slots.default?.())
+  },
+})
+
+const ElSwitch = defineComponent({
+  name: 'ElSwitch',
+  props: { modelValue: Boolean },
+  emits: ['update:modelValue', 'change'],
+  render() {
+    return h('input', {
+      type: 'checkbox',
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      checked: this.modelValue,
+      onChange: (e: Event) => {
+        const checked = (e.target as HTMLInputElement).checked
+        this.$emit('update:modelValue', checked)
+        this.$emit('change', checked)
+      },
+    })
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String },
+  render() { return h('div', { 'data-el-alert': 'true' }, this.title) },
+})
+
+// The 新建委托 dialog's contents never render in these tests (dialogOpen stays false — see
+// ElDialog below), but Vue's compiled render function resolves EVERY tag referenced in the
+// template on each pass regardless of whether that branch/slot actually runs, so these still need
+// registering to avoid "Failed to resolve component" console noise. Purely cosmetic passthroughs.
+function passthrough(name: string, tag = 'div') {
+  return defineComponent({
+    name,
+    render() { return h(tag, {}, this.$slots.default?.()) },
+  })
+}
+const ElForm = passthrough('ElForm', 'form')
+const ElFormItem = passthrough('ElFormItem', 'label')
+const ElInput = passthrough('ElInput', 'input')
+const ElSelect = passthrough('ElSelect', 'select')
+const ElOption = passthrough('ElOption', 'option')
+const ElDatePicker = passthrough('ElDatePicker', 'input')
+
+// Visibility-gated, matching the real component: content only renders while open (the 新建委托
+// dialog is never opened in these tests, so its inner ElForm/ElInput/etc. never need stubs).
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String, width: String },
+  emits: ['update:modelValue'],
+  render() {
+    if (!this.modelValue) return null
+    return h('div', { 'data-el-dialog': 'true' }, [this.$slots.default?.(), this.$slots.footer?.()])
+  },
+})
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+const HOUR = 60 * 60 * 1000
+function fixtureRow(overrides: Partial<DelegationRecord> = {}): DelegationRecord {
+  const now = Date.now()
+  return {
+    id: 'd-1',
+    delegatorUserId: 'alice',
+    delegateeUserId: 'bob',
+    scope: 'all',
+    scopeTemplateId: null,
+    startAt: new Date(now - HOUR).toISOString(),
+    endAt: new Date(now + HOUR).toISOString(),
+    active: true,
+    ...overrides,
+  }
+}
+
+describe('DelegationSettingsView (admin 委托设置) — B2-05 status tag + disable confirm', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    canManageTemplates.value = true
+    listDelegationsSpy.mockReset()
+    disableDelegationSpy.mockReset().mockResolvedValue(undefined)
+    createDelegationSpy.mockReset()
+    confirmSpy.mockReset().mockResolvedValue(undefined)
+    messageErrorSpy.mockReset()
+    columnSeq = 0
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+  })
+
+  async function mountView(rows: DelegationRecord[]) {
+    listDelegationsSpy.mockResolvedValue(rows)
+    const { default: DelegationSettingsView } = await import('../src/views/approval/DelegationSettingsView.vue')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(DelegationSettingsView)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElButton', ElButton)
+    app.component('ElSwitch', ElSwitch)
+    app.component('ElAlert', ElAlert)
+    app.component('ElDialog', ElDialog)
+    app.component('ElForm', ElForm)
+    app.component('ElFormItem', ElFormItem)
+    app.component('ElInput', ElInput)
+    app.component('ElSelect', ElSelect)
+    app.component('ElOption', ElOption)
+    app.component('ElDatePicker', ElDatePicker)
+    app.directive('loading', {})
+    app.mount(container)
+    await flushUi()
+  }
+
+  function statusCell(rowIndex: number): HTMLElement {
+    return container!.querySelector(`[data-el-row="${rowIndex}"] [data-el-cell="状态"]`) as HTMLElement
+  }
+
+  it('renders the correct status tag TYPE + label for 未开始 / 生效中 / 已过期 / 已停用', async () => {
+    const rows = [
+      fixtureRow({ id: 'not-started', startAt: new Date(Date.now() + HOUR).toISOString(), endAt: new Date(Date.now() + 2 * HOUR).toISOString() }),
+      fixtureRow({ id: 'active', startAt: new Date(Date.now() - HOUR).toISOString(), endAt: new Date(Date.now() + 200 * HOUR).toISOString() }),
+      fixtureRow({ id: 'expired', startAt: new Date(Date.now() - 2 * HOUR).toISOString(), endAt: new Date(Date.now() - HOUR).toISOString() }),
+      fixtureRow({ id: 'disabled', active: false }),
+    ]
+    await mountView(rows)
+
+    const expectations: Array<[number, string, string]> = [
+      [0, '未开始', 'info'],
+      [1, '生效中', 'success'],
+      [2, '已过期', 'warning'],
+      [3, '已停用', 'danger'],
+    ]
+    for (const [index, label, tagType] of expectations) {
+      const cell = statusCell(index)
+      expect(cell.textContent, `row ${index} label`).toContain(label)
+      expect(cell.querySelector('[data-el-tag-type]')?.getAttribute('data-el-tag-type'), `row ${index} tag type`).toBe(tagType)
+    }
+  })
+
+  it('shows the 即将到期 hint only for a 生效中 row expiring within 72h, not for other states', async () => {
+    const rows = [
+      fixtureRow({ id: 'expiring-soon', startAt: new Date(Date.now() - HOUR).toISOString(), endAt: new Date(Date.now() + HOUR).toISOString() }),
+      fixtureRow({ id: 'not-expiring', startAt: new Date(Date.now() - HOUR).toISOString(), endAt: new Date(Date.now() + 200 * HOUR).toISOString() }),
+      fixtureRow({ id: 'disabled-but-in-window', active: false }),
+    ]
+    await mountView(rows)
+
+    expect(statusCell(0).textContent).toContain('即将到期')
+    expect(statusCell(1).textContent).not.toContain('即将到期')
+    expect(statusCell(2).textContent).not.toContain('即将到期')
+  })
+
+  it('asks for confirmation before disabling; confirming calls disableDelegation and reloads', async () => {
+    await mountView([fixtureRow({ id: 'd-1', active: true })])
+    listDelegationsSpy.mockResolvedValue([]) // the reload after disable
+
+    const disableButton = container!.querySelector('[data-testid="delegation-disable"]') as HTMLButtonElement
+    expect(disableButton).not.toBeNull()
+    disableButton.click()
+    await flushUi()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(confirmSpy.mock.calls[0]?.[0]).toContain('停用后该委托立即失效，进行中的转交不受影响')
+    expect(disableDelegationSpy).toHaveBeenCalledWith('d-1')
+    expect(listDelegationsSpy).toHaveBeenCalledTimes(2) // initial load + post-disable reload
+  })
+
+  it('cancelling the confirm dialog calls NO api (disableDelegation never runs)', async () => {
+    confirmSpy.mockRejectedValue(new Error('cancel'))
+    await mountView([fixtureRow({ id: 'd-1', active: true })])
+
+    const disableButton = container!.querySelector('[data-testid="delegation-disable"]') as HTMLButtonElement
+    disableButton.click()
+    await flushUi()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(disableDelegationSpy).not.toHaveBeenCalled()
+    expect(listDelegationsSpy).toHaveBeenCalledTimes(1) // no reload — disable never ran
+  })
+})

--- a/apps/web/tests/approvalMetricsTopnReport.spec.ts
+++ b/apps/web/tests/approvalMetricsTopnReport.spec.ts
@@ -61,10 +61,17 @@ const fetchReportSpy = vi.fn().mockResolvedValue({
   }],
 })
 
+// B2-04: id→name lookup for the template-keyed columns (按模板汇总 / TopN 最慢实例 / TopN SLA
+// 风险模板 all render `templateDisplayName(row.templateId)`). Defaults to an empty page so the
+// pre-existing tests below (which assert the RAW id 'tmpl-risk-1' renders) keep passing unless a
+// test opts into a name mapping.
+const listTemplatesSpy = vi.fn().mockResolvedValue({ data: [], total: 0 })
+
 vi.mock('../src/approvals/api', () => ({
   fetchApprovalMetricsSummary: (query?: unknown) => fetchSummarySpy(query),
   fetchApprovalMetricsBreaches: () => fetchBreachesSpy(),
   fetchApprovalMetricsReport: (query?: unknown) => fetchReportSpy(query),
+  listTemplates: (query?: unknown) => listTemplatesSpy(query),
 }))
 
 type ColumnRegistryEntry = {
@@ -183,6 +190,8 @@ describe('ApprovalMetricsView TopN report', () => {
     fetchSummarySpy.mockClear()
     fetchBreachesSpy.mockClear()
     fetchReportSpy.mockClear()
+    listTemplatesSpy.mockClear()
+    listTemplatesSpy.mockResolvedValue({ data: [], total: 0 })
     columnSeq = 0
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -239,5 +248,72 @@ describe('ApprovalMetricsView TopN report', () => {
 
     expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-detail', params: { id: 'apr-slow-1' } })
     expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-template-detail', params: { id: 'tmpl-risk-1' } })
+  })
+
+  // B2-04: template-keyed tables previously rendered the raw templateId (unscannable). Both TopN
+  // tables key off the same 'tmpl-risk-1' fixture id, so a single listTemplates() mock covers both.
+  it('B2-04: renders the mapped template NAME instead of the raw id once listTemplates resolves a match', async () => {
+    listTemplatesSpy.mockResolvedValue({ data: [{ id: 'tmpl-risk-1', name: '采购审批' }], total: 1 })
+    const { default: ApprovalMetricsView } = await import('../src/views/approval/ApprovalMetricsView.vue')
+    app = createApp(ApprovalMetricsView)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElLink', ElLink)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.directive('loading', {})
+    app.mount(container!)
+    await flushPromises()
+    await flushPromises() // listTemplates resolves on a separate onMounted call — give it a beat
+
+    expect(listTemplatesSpy).toHaveBeenCalledWith({ pageSize: 200 })
+    expect(container!.textContent).toContain('采购审批')
+    expect(container!.textContent).not.toContain('tmpl-risk-1')
+    // routing is untouched by the display mapping — still routes by the real id.
+    const buttons = Array.from(container!.querySelectorAll('button'))
+    buttons.find((button) => button.textContent?.includes('采购审批'))?.click()
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-template-detail', params: { id: 'tmpl-risk-1' } })
+  })
+
+  it('B2-04: falls back to the raw template id when listTemplates has no match (and stays non-fatal on rejection)', async () => {
+    listTemplatesSpy.mockResolvedValue({ data: [{ id: 'some-other-template', name: '别的模板' }], total: 1 })
+    const { default: ApprovalMetricsView } = await import('../src/views/approval/ApprovalMetricsView.vue')
+    app = createApp(ApprovalMetricsView)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElLink', ElLink)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.directive('loading', {})
+    app.mount(container!)
+    await flushPromises()
+    await flushPromises()
+
+    expect(container!.textContent).toContain('tmpl-risk-1') // unmapped id → raw id fallback
+    expect(container!.textContent).not.toContain('别的模板')
+  })
+
+  it('B2-04: a rejected listTemplates does not break the dashboard (non-fatal, falls back to raw ids)', async () => {
+    listTemplatesSpy.mockRejectedValue(new Error('network error'))
+    const { default: ApprovalMetricsView } = await import('../src/views/approval/ApprovalMetricsView.vue')
+    app = createApp(ApprovalMetricsView)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElLink', ElLink)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.directive('loading', {})
+    app.mount(container!)
+    await flushPromises()
+    await flushPromises()
+
+    expect(container!.textContent).toContain('TopN 最慢实例') // dashboard still renders
+    expect(container!.textContent).toContain('tmpl-risk-1') // falls back to the raw id
   })
 })

--- a/apps/web/tests/approvalMetricsView.spec.ts
+++ b/apps/web/tests/approvalMetricsView.spec.ts
@@ -36,12 +36,18 @@ const reportSpy = vi.fn()
 const breachesSpy = vi.fn()
 const teamsSpy = vi.fn()
 const peopleSpy = vi.fn()
+// B2-04: id→name lookup for the template-keyed tables. Defaults to an empty page (falls back to
+// raw ids); the mapped-name / fallback behaviour itself is covered in
+// approvalMetricsTopnReport.spec.ts, whose stub can render table CELL content (this file's ElTable
+// stub is count-only — see `rowsOf()` below — so it stays scoped to what it can assert here).
+const listTemplatesSpy = vi.fn().mockResolvedValue({ data: [], total: 0 })
 vi.mock('../src/approvals/api', () => ({
   fetchApprovalMetricsSummary: (...a: unknown[]) => summarySpy(...a),
   fetchApprovalMetricsReport: (...a: unknown[]) => reportSpy(...a),
   fetchApprovalMetricsBreaches: (...a: unknown[]) => breachesSpy(...a),
   fetchApprovalMetricsTeams: (...a: unknown[]) => teamsSpy(...a),
   fetchApprovalMetricsPeople: (...a: unknown[]) => peopleSpy(...a),
+  listTemplates: (...a: unknown[]) => listTemplatesSpy(...a),
 }))
 
 function emptySummary() {
@@ -103,14 +109,17 @@ const ElTableColumn = defineComponent({
   render() { return h('div', { 'data-column': this.prop || this.label }) },
 })
 // Drives the shared date-range: clicking emits a v-model update + @change so the
-// view re-runs loadAll with a concrete since/until.
+// view re-runs loadAll with a concrete since/until. B2-04: also surfaces the bound `shortcuts`
+// prop as a data attribute (labels only) so a test can assert the picker received presets
+// without needing to simulate Element Plus's real shortcut-panel DOM.
 const ElDatePicker = defineComponent({
   name: 'ElDatePicker',
-  props: { modelValue: { type: Array, default: null } },
+  props: { modelValue: { type: Array, default: null }, shortcuts: { type: Array, default: () => [] } },
   emits: ['update:modelValue', 'change'],
   render() {
     return h('button', {
       'data-testid': 'set-date-range',
+      'data-shortcut-labels': (this.shortcuts as Array<{ text: string }>).map((s) => s.text).join(','),
       onClick: () => {
         const range = ['2026-04-01', '2026-04-25']
         this.$emit('update:modelValue', range)
@@ -161,6 +170,7 @@ describe('ApprovalMetricsView — B analytics breakdown sections', () => {
     breachesSpy.mockReset().mockResolvedValue([])
     teamsSpy.mockReset().mockResolvedValue(TEAM_ROWS)
     peopleSpy.mockReset().mockResolvedValue(PEOPLE_ROWS)
+    listTemplatesSpy.mockReset().mockResolvedValue({ data: [], total: 0 })
     pushSpy.mockClear()
   })
 
@@ -240,5 +250,39 @@ describe('ApprovalMetricsView — B analytics breakdown sections', () => {
     const expected = { since: '2026-04-01T00:00:00Z', until: '2026-04-25T23:59:59Z', limit: 20 }
     expect(teamsSpy).toHaveBeenCalledWith(expected)
     expect(peopleSpy).toHaveBeenCalledWith(expected)
+  })
+
+  it('B2-04: the date-range picker receives quick-range shortcuts (近 7 天 / 近 30 天 / 本月)', async () => {
+    const m = await mountView()
+    app = m.app; container = m.container
+
+    const picker = container.querySelector<HTMLButtonElement>('[data-testid="set-date-range"]')
+    expect(picker, 'the date-range picker stub is present').toBeTruthy()
+    const labels = picker!.getAttribute('data-shortcut-labels')?.split(',') ?? []
+    expect(labels).toEqual(['近 7 天', '近 30 天', '本月'])
+  })
+
+  it('B2-04: fetches the template id→name lookup once on mount with a generous pageSize', async () => {
+    const m = await mountView()
+    app = m.app; container = m.container
+
+    expect(listTemplatesSpy).toHaveBeenCalledTimes(1)
+    expect(listTemplatesSpy).toHaveBeenCalledWith({ pageSize: 200 })
+
+    // Refreshing re-reads the breakdowns but must NOT re-fetch the template lookup — it is a
+    // once-on-mount catalog fetch, independent of the date range/refresh button.
+    const refresh = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('刷新'))
+    refresh!.click()
+    await flushUi()
+    expect(listTemplatesSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('B2-04: a rejected template lookup is non-fatal — the dashboard still renders', async () => {
+    listTemplatesSpy.mockReset().mockRejectedValue(new Error('network error'))
+    const m = await mountView()
+    app = m.app; container = m.container
+
+    expect(container.textContent).toContain('按部门汇总')
+    expect(rowsOf(container, 'metrics-table-teams')).toBe(TEAM_ROWS.length)
   })
 })

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -201,6 +201,20 @@ const ElAlert = defineComponent({
   },
 })
 
+// B2-03: publish pre-flight checklist dialog. Mirrors the real component's v-model visibility gate
+// (only rendered while `modelValue` is true) so tests can assert the dialog opens/closes.
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String, width: String },
+  emits: ['update:modelValue'],
+  render() {
+    if (!this.modelValue) return null
+    return h('div', {
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+    }, [this.$slots.default?.(), this.$slots.footer?.()])
+  },
+})
+
 function installStubs(app: VueApp<Element>) {
   app.directive('loading', {})
   app.component('ElButton', ElButton)
@@ -210,6 +224,7 @@ function installStubs(app: VueApp<Element>) {
   app.component('ElOption', ElOption)
   app.component('ElCheckbox', ElCheckbox)
   app.component('ElAlert', ElAlert)
+  app.component('ElDialog', ElDialog)
   app.component('ElTable', ElTable)
   app.component('ElTableColumn', ElTableColumn)
   app.component('ElCard', passthrough('ElCard', 'section'))
@@ -1207,12 +1222,88 @@ describe('TemplateAuthoringView', () => {
 
     setInput('approval-template-key', 'purchase')
     setInput('approval-template-name', '采购审批')
+    // B2-03: publish now opens the pre-flight checklist FIRST; the real persist/publish sequence
+    // only runs once the dialog's own confirm button is clicked (a fresh linear draft with just
+    // key+name filled is all-green, so the confirm button is enabled).
     ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(createTemplateSpy).not.toHaveBeenCalled()
+    const dialog = container!.querySelector('[data-testid="approval-publish-checklist"]')
+    expect(dialog).not.toBeNull()
+    // all-green: every checklist item ✓, confirm enabled.
+    for (const key of ['fields', 'flow', 'placeholder']) {
+      const item = dialog!.querySelector(`[data-testid="approval-publish-checklist-item-${key}"]`)
+      expect(item).not.toBeNull()
+      expect(item!.getAttribute('data-ok')).toBe('true')
+      expect(item!.textContent).toContain('✓')
+    }
+    const confirmButton = dialog!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+    expect(confirmButton.disabled).toBe(false)
+
+    confirmButton.click()
     await flushUi()
 
     expect(createTemplateSpy).toHaveBeenCalledTimes(1)
     expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_created', { policy: { allowRevoke: true } })
     expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created' })
+  })
+
+  it('B2-03: an invalid draft (blank key/name) opens the publish checklist with a failing "表单字段" item and disables the confirm button', async () => {
+    await mountView()
+    // leave key/name blank — validateTemplateFormFields fails ('模板 Key 必填' / '模板名称必填').
+
+    ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const dialog = container!.querySelector('[data-testid="approval-publish-checklist"]')
+    expect(dialog).not.toBeNull()
+    const fieldsItem = dialog!.querySelector('[data-testid="approval-publish-checklist-item-fields"]')
+    expect(fieldsItem).not.toBeNull()
+    expect(fieldsItem!.getAttribute('data-ok')).toBe('false')
+    expect(fieldsItem!.textContent).toContain('✗')
+    expect(fieldsItem!.textContent).toContain('模板 Key 必填')
+
+    const confirmButton = dialog!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+    expect(confirmButton.disabled).toBe(true)
+
+    confirmButton.click()
+    await flushUi()
+    expect(createTemplateSpy).not.toHaveBeenCalled()
+    expect(publishTemplateSpy).not.toHaveBeenCalled()
+  })
+
+  it('B2-03: a starter-preset placeholder role fails ONLY the "审批人占位" checklist item (fields/flow stay ✓) and disables the confirm button', async () => {
+    routeParams = { id: 'tpl_sentinel_publish' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildG5ComplexGraph({
+        assigneeSources: [{ kind: 'static_role', roleIds: [APPROVAL_ROLE_CONFIGURE_SENTINEL] }],
+        approvalMode: 'single',
+        emptyAssigneePolicy: 'error',
+      }),
+    }))
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const dialog = container!.querySelector('[data-testid="approval-publish-checklist"]')
+    expect(dialog).not.toBeNull()
+    expect(dialog!.querySelector('[data-testid="approval-publish-checklist-item-fields"]')!.getAttribute('data-ok')).toBe('true')
+    expect(dialog!.querySelector('[data-testid="approval-publish-checklist-item-flow"]')!.getAttribute('data-ok')).toBe('true')
+    const placeholderItem = dialog!.querySelector('[data-testid="approval-publish-checklist-item-placeholder"]')
+    expect(placeholderItem).not.toBeNull()
+    expect(placeholderItem!.getAttribute('data-ok')).toBe('false')
+    expect(placeholderItem!.textContent).toContain('✗')
+    expect(placeholderItem!.textContent).toContain('主管') // the placeholder node's name, so the admin can find it
+    expect(placeholderItem!.textContent).toContain('占位')
+
+    const confirmButton = dialog!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+    expect(confirmButton.disabled).toBe(true)
+
+    confirmButton.click()
+    await flushUi()
+    expect(publishTemplateSpy).not.toHaveBeenCalled()
   })
 
   it('T7: wires the self-approver toggle through the mounted view into the saved payload', async () => {

--- a/apps/web/tests/myDelegationView.spec.ts
+++ b/apps/web/tests/myDelegationView.spec.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, inject, nextTick, provide, reactive, type App as VueApp, type Slot } from 'vue'
+import type { DelegationRecord } from '../src/approvals/delegations'
+
+// B2-05 — MyDelegationView (self-service 我的委托) MOUNTED-component coverage. Neither
+// myDelegationForm.spec.ts nor myDelegationRoute.spec.ts (the only pre-existing specs naming this
+// view) actually mount it — they test the pure form-validation helpers and the router source text
+// respectively. This is the first mounted harness for this view, mirroring
+// approvalDelegationView.spec.ts (the admin 委托设置 counterpart) since B2-05 changes both views
+// identically (shared DelegationRecord shape + shared delegationStatus helper).
+
+const listOwnDelegationsSpy = vi.fn()
+const disableOwnDelegationSpy = vi.fn().mockResolvedValue(undefined)
+const createOwnDelegationSpy = vi.fn()
+vi.mock('../src/approvals/delegations', async () => {
+  const actual = await vi.importActual<typeof import('../src/approvals/delegations')>('../src/approvals/delegations')
+  return {
+    ...actual,
+    listOwnDelegations: () => listOwnDelegationsSpy(),
+    disableOwnDelegation: (id: string) => disableOwnDelegationSpy(id),
+    createOwnDelegation: (payload: unknown) => createOwnDelegationSpy(payload),
+  }
+})
+
+const confirmSpy = vi.fn().mockResolvedValue(undefined)
+const messageErrorSpy = vi.fn()
+vi.mock('element-plus', () => ({
+  ElMessage: { success: vi.fn(), warning: vi.fn(), error: (...a: unknown[]) => messageErrorSpy(...a) },
+  ElMessageBox: { confirm: (...a: unknown[]) => confirmSpy(...a) },
+}))
+
+type ColumnRegistryEntry = { key: string; prop?: string; label?: string; defaultSlot?: Slot }
+type ColumnRegistry = { columns: ColumnRegistryEntry[]; register: (entry: ColumnRegistryEntry) => void }
+const COLUMN_REGISTRY_KEY = Symbol('my-delegation-table-columns')
+let columnSeq = 0
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: { type: Array, default: () => [] }, emptyText: String },
+  setup(props, { slots }) {
+    const registry = reactive<ColumnRegistry>({ columns: [], register(entry) { registry.columns.push(entry) } })
+    provide(COLUMN_REGISTRY_KEY, registry)
+    return () => {
+      const columnInstances = slots.default?.() ?? []
+      const rows = (props.data as DelegationRecord[] | undefined) ?? []
+      return h('div', { 'data-el-table': 'true' }, [
+        h('div', { style: 'display:none' }, columnInstances),
+        ...rows.map((row, index) =>
+          h('div', { 'data-el-row': String(index) },
+            registry.columns.map((column) =>
+              h('div', { 'data-el-cell': column.prop || column.label || column.key },
+                column.defaultSlot ? column.defaultSlot({ row }) : String((row as never)[column.prop ?? ''] ?? ''),
+              ),
+            ),
+          ),
+        ),
+      ])
+    }
+  },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number] },
+  setup(props, { slots }) {
+    const registry = inject<ColumnRegistry | null>(COLUMN_REGISTRY_KEY, null)
+    if (registry) registry.register({ key: `col-${columnSeq++}`, prop: props.prop, label: props.label, defaultSlot: slots.default })
+    return () => null
+  },
+})
+
+const ElTag = defineComponent({
+  name: 'ElTag',
+  props: { type: String, size: String },
+  render() {
+    return h('span', { 'data-el-tag-type': this.type || 'default' }, this.$slots.default?.())
+  },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, text: Boolean, size: String, disabled: Boolean, loading: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      type: 'button',
+      disabled: this.disabled || this.loading,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onClick: (e: Event) => this.$emit('click', e),
+    }, this.$slots.default?.())
+  },
+})
+
+// The 新建委托 dialog's contents never render in these tests (dialogOpen stays false — see
+// ElDialog below), but Vue's compiled render function resolves EVERY tag referenced in the
+// template on each pass regardless of whether that branch/slot actually runs, so these still need
+// registering to avoid "Failed to resolve component" console noise. Purely cosmetic passthroughs.
+function passthrough(name: string, tag = 'div') {
+  return defineComponent({
+    name,
+    render() { return h(tag, {}, this.$slots.default?.()) },
+  })
+}
+const ElForm = passthrough('ElForm', 'form')
+const ElFormItem = passthrough('ElFormItem', 'label')
+const ElInput = passthrough('ElInput', 'input')
+const ElSelect = passthrough('ElSelect', 'select')
+const ElOption = passthrough('ElOption', 'option')
+const ElDatePicker = passthrough('ElDatePicker', 'input')
+
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String, width: String },
+  emits: ['update:modelValue'],
+  render() {
+    if (!this.modelValue) return null
+    return h('div', { 'data-el-dialog': 'true' }, [this.$slots.default?.(), this.$slots.footer?.()])
+  },
+})
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+const HOUR = 60 * 60 * 1000
+function fixtureRow(overrides: Partial<DelegationRecord> = {}): DelegationRecord {
+  const now = Date.now()
+  return {
+    id: 'd-1',
+    delegatorUserId: '__me__',
+    delegateeUserId: 'bob',
+    scope: 'all',
+    scopeTemplateId: null,
+    startAt: new Date(now - HOUR).toISOString(),
+    endAt: new Date(now + HOUR).toISOString(),
+    active: true,
+    ...overrides,
+  }
+}
+
+describe('MyDelegationView (self-service 我的委托) — B2-05 status tag + disable confirm', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    listOwnDelegationsSpy.mockReset()
+    disableOwnDelegationSpy.mockReset().mockResolvedValue(undefined)
+    createOwnDelegationSpy.mockReset()
+    confirmSpy.mockReset().mockResolvedValue(undefined)
+    messageErrorSpy.mockReset()
+    columnSeq = 0
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+  })
+
+  async function mountView(rows: DelegationRecord[]) {
+    listOwnDelegationsSpy.mockResolvedValue(rows)
+    const { default: MyDelegationView } = await import('../src/views/approval/MyDelegationView.vue')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(MyDelegationView)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElButton', ElButton)
+    app.component('ElDialog', ElDialog)
+    app.component('ElForm', ElForm)
+    app.component('ElFormItem', ElFormItem)
+    app.component('ElInput', ElInput)
+    app.component('ElSelect', ElSelect)
+    app.component('ElOption', ElOption)
+    app.component('ElDatePicker', ElDatePicker)
+    app.directive('loading', {})
+    app.mount(container)
+    await flushUi()
+  }
+
+  function statusCell(rowIndex: number): HTMLElement {
+    return container!.querySelector(`[data-el-row="${rowIndex}"] [data-el-cell="状态"]`) as HTMLElement
+  }
+
+  it('renders the correct status tag TYPE + label for 未开始 / 生效中 / 已过期 / 已停用', async () => {
+    const rows = [
+      fixtureRow({ id: 'not-started', startAt: new Date(Date.now() + HOUR).toISOString(), endAt: new Date(Date.now() + 2 * HOUR).toISOString() }),
+      fixtureRow({ id: 'active', startAt: new Date(Date.now() - HOUR).toISOString(), endAt: new Date(Date.now() + 200 * HOUR).toISOString() }),
+      fixtureRow({ id: 'expired', startAt: new Date(Date.now() - 2 * HOUR).toISOString(), endAt: new Date(Date.now() - HOUR).toISOString() }),
+      fixtureRow({ id: 'disabled', active: false }),
+    ]
+    await mountView(rows)
+
+    const expectations: Array<[number, string, string]> = [
+      [0, '未开始', 'info'],
+      [1, '生效中', 'success'],
+      [2, '已过期', 'warning'],
+      [3, '已停用', 'danger'],
+    ]
+    for (const [index, label, tagType] of expectations) {
+      const cell = statusCell(index)
+      expect(cell.textContent, `row ${index} label`).toContain(label)
+      expect(cell.querySelector('[data-el-tag-type]')?.getAttribute('data-el-tag-type'), `row ${index} tag type`).toBe(tagType)
+    }
+  })
+
+  it('shows the 即将到期 hint only for a 生效中 row expiring within 72h, not for other states', async () => {
+    const rows = [
+      fixtureRow({ id: 'expiring-soon', startAt: new Date(Date.now() - HOUR).toISOString(), endAt: new Date(Date.now() + HOUR).toISOString() }),
+      fixtureRow({ id: 'not-expiring', startAt: new Date(Date.now() - HOUR).toISOString(), endAt: new Date(Date.now() + 200 * HOUR).toISOString() }),
+      fixtureRow({ id: 'disabled-but-in-window', active: false }),
+    ]
+    await mountView(rows)
+
+    expect(statusCell(0).textContent).toContain('即将到期')
+    expect(statusCell(1).textContent).not.toContain('即将到期')
+    expect(statusCell(2).textContent).not.toContain('即将到期')
+  })
+
+  it('asks for confirmation before disabling; confirming calls disableOwnDelegation and reloads', async () => {
+    await mountView([fixtureRow({ id: 'd-1', active: true })])
+    listOwnDelegationsSpy.mockResolvedValue([]) // the reload after disable
+
+    const disableButton = container!.querySelector('[data-testid="my-delegation-disable"]') as HTMLButtonElement
+    expect(disableButton).not.toBeNull()
+    disableButton.click()
+    await flushUi()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(confirmSpy.mock.calls[0]?.[0]).toContain('停用后该委托立即失效，进行中的转交不受影响')
+    expect(disableOwnDelegationSpy).toHaveBeenCalledWith('d-1')
+    expect(listOwnDelegationsSpy).toHaveBeenCalledTimes(2) // initial load + post-disable reload
+  })
+
+  it('cancelling the confirm dialog calls NO api (disableOwnDelegation never runs)', async () => {
+    confirmSpy.mockRejectedValue(new Error('cancel'))
+    await mountView([fixtureRow({ id: 'd-1', active: true })])
+
+    const disableButton = container!.querySelector('[data-testid="my-delegation-disable"]') as HTMLButtonElement
+    disableButton.click()
+    await flushUi()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(disableOwnDelegationSpy).not.toHaveBeenCalled()
+    expect(listOwnDelegationsSpy).toHaveBeenCalledTimes(1) // no reload — disable never ran
+  })
+})


### PR DESCRIPTION
## Summary

UX 阶梯（#3564）batch-2 管理面三件（Sonnet 代理实现 + Fable 审查）：

### B2-03 发布前校验清单前置
- `handlePublish` 原是先 confirm 再校验（承诺后打脸）；现前置：`validateTemplateDraft` 沿自然接缝拆为 `validateTemplateFormFields`+`validateTemplateApprovalFlow`（**字节级输出保持**，47 既有测试原样绿）+ 新增「审批人占位」桶（`placeholderRoleNodeKeys`，镜像后端 assertNoUnconfiguredPlaceholderRoles）；发布对话框内渲染 ✓/✗ 清单，红项禁用发布。

### B2-04 指标看板模板名映射 + 日期快捷档
- 挂载时一次拉模板建 id→name Map，三张表裸 UUID → 模板名（缺失回退 id，失败非致命）；date-picker 加近 7 天/近 30 天/本月 shortcuts。

### B2-05 委托 4 态时间感知 + 停用确认
- 新纯模块 `delegationStatus.ts`：`active` 布尔 × start/end 窗口 → 未开始/生效中/已过期/已停用（+ 72h 内即将到期），修掉「endAt 已过仍显示生效」的界面撒谎；双视图接线；停用前 ElMessageBox 确认。**文案经代理派研究 agent 核对后端**（委托 resolve 是创建时一次性快照，停用不影响进行中实例）→「停用后该委托立即失效，进行中的转交不受影响」属实。

## Verification

- 新增 25 测试（delegationStatus 14 边界 / authoring 2 / metrics 6 / 双委托视图 8 起）；rebase 后焦点 76/76 + vue-tsc 0
- 代理自查清理了拆分产生的死 import；预存 approvalStaticPicker 失败 stash 复验非本 PR 引入

🤖 Generated with [Claude Code](https://claude.com/claude-code)