### PR TITLE
feat(web): approval list key-field summary — decide without opening (UX B2-01)

### DIFF
--- a/apps/web/src/approvals/detailField.ts
+++ b/apps/web/src/approvals/detailField.ts
@@ -449,3 +449,45 @@ export function buildDisplayFields(
 
   return result
 }
+
+/**
+ * B2-01 (待办列表关键字段摘要) — the first `limit` NON-attachment, NON-detail leaf fields, in
+ * schema order, that are actually present in the snapshot. Reuses `buildDisplayFields` for every
+ * bit of VALUE formatting (option labels, localized numbers, formatted dates) so that logic lives
+ * exactly once; this function only narrows WHICH of its entries qualify for a glanceable summary.
+ *
+ * Deliberately does NOT inherit `buildDisplayFields`'s "snapshot keys absent from the schema" tail
+ * (see that function's own doc comment) — those are raw/legacy data with no real label, and a
+ * caller with no schema at all (e.g. a list row whose templateId has no live template, or none)
+ * must degrade to NO summary rather than a raw-key dump of unrelated snapshot data. Returns `[]`
+ * whenever `formSchema` is missing/empty or has no eligible leaf field.
+ */
+export function summaryFields(
+  formSchema: FormSchema | null | undefined,
+  formSnapshot: Record<string, unknown> | null | undefined,
+  limit = 3,
+): DisplayField[] {
+  const fields = formSchema?.fields
+  if (!Array.isArray(fields) || fields.length === 0) return []
+
+  const eligibleFieldIds = new Set(
+    fields
+      .filter((field) => field.type !== 'attachment' && field.type !== 'detail')
+      .map((field) => field.id),
+  )
+  if (eligibleFieldIds.size === 0) return []
+
+  return buildDisplayFields(formSchema, formSnapshot)
+    .filter((field) => eligibleFieldIds.has(field.key))
+    .slice(0, limit)
+}
+
+/**
+ * Joins `summaryFields`' output into the list-row glance line, e.g.
+ * `请假类型：年假 · 时长：2 · 事由：出差`. A pure string join — the caller renders it inside a
+ * single-line container with CSS `text-overflow: ellipsis`, so truncation stays purely visual
+ * (never a substring cut here that could clip mid-character).
+ */
+export function formatSummaryLine(fields: DisplayField[]): string {
+  return fields.map((field) => `${field.label}：${field.value}`).join(' · ')
+}

--- a/apps/web/src/approvals/useApprovalListFieldSummary.ts
+++ b/apps/web/src/approvals/useApprovalListFieldSummary.ts
@@ -1,0 +1,96 @@
+import { reactive } from 'vue'
+import type { FormSchema, UnifiedApprovalDTO } from '../types/approval'
+import { getTemplate } from './api'
+import { formatSummaryLine, summaryFields } from './detailField'
+
+/**
+ * B2-01 (待办列表关键字段摘要) — row-level glue: resolve `row.templateId` against a templateId ->
+ * FormSchema cache, then build the summary line via `summaryFields`/`formatSummaryLine`. Exported
+ * standalone (not only reachable via the composable below) so `ApprovalMobileList.vue` — which
+ * receives the cache as a plain `templateSchemas` prop, not the composable instance — shares the
+ * exact same glue instead of re-deriving it. Returns `''` whenever there is no templateId, no
+ * cached schema yet (not fetched / still in flight / fetch failed), or no eligible field, so a
+ * caller can gate rendering with a plain truthy `v-if`.
+ */
+export function resolveRowSummaryLine(
+  schemas: Map<string, FormSchema> | undefined,
+  row: Pick<UnifiedApprovalDTO, 'templateId' | 'formSnapshot'>,
+  limit = 3,
+): string {
+  const templateId = row.templateId
+  const schema = templateId ? schemas?.get(templateId) : undefined
+  if (!schema) return ''
+  return formatSummaryLine(summaryFields(schema, row.formSnapshot, limit))
+}
+
+/**
+ * B2-01 (待办列表关键字段摘要) — lazy per-templateId `FormSchema` cache backing the approval
+ * list's row summary line, shared by `ApprovalCenterView`'s desktop table (all four tabs) and
+ * `ApprovalMobileList`'s card list so the fetch + cache lives in exactly one place per view
+ * session.
+ *
+ * WHY THE LIVE TEMPLATE, NOT THE FROZEN ONE: `UnifiedApprovalDTO` (the list DTO) never carries the
+ * instance's frozen per-version `formSchema` — only the single-instance detail read does a second
+ * DB round trip for that (`ApprovalBridgeService.getApproval`'s `template_version_id` follow-up
+ * query; `listApprovals`/`toUnifiedDTO` never sets it). Fetching per-ROW would defeat the point of
+ * a list (N calls instead of a handful keyed by distinct templateId), so this substitutes the LIVE
+ * template schema via `getTemplate(id)` — the SAME `approvals:read` permission every list viewer
+ * already needs (`GET /api/approval-templates/:id` and the list route `GET /api/approvals` both
+ * resolve to the identical `rbacGuard` permission code).
+ *
+ * LIVE-LABEL DRIFT CAVEAT: if a template's labels/options are edited after an instance was
+ * created, this summary can show today's label for yesterday's stored value (e.g. a renamed select
+ * option, or a since-reordered field). That is an accepted, DISPLAY-ONLY tradeoff — this line
+ * exists purely so an approver can decide whether an item is worth opening, never to be the
+ * authoritative rendering. The detail view keeps rendering from the instance's own FROZEN
+ * `formSchema` via `buildDisplayFields`, which stays the single source of truth.
+ *
+ * A templateId is fetched AT MOST ONCE per view session regardless of outcome — `attempted` tracks
+ * both successes and failures, so a deleted/broken template is not re-hit on every list reload or
+ * tab switch. A failed fetch is swallowed silently: the affected rows simply render without a
+ * summary (never a thrown error, never a toast).
+ */
+export function useApprovalListFieldSummary() {
+  const schemas: Map<string, FormSchema> = reactive(new Map())
+  const attempted = new Set<string>()
+  const inflight = new Map<string, Promise<void>>()
+
+  function loadOne(templateId: string): Promise<void> {
+    const existing = inflight.get(templateId)
+    if (existing) return existing
+    const promise = getTemplate(templateId)
+      .then((detail) => {
+        schemas.set(templateId, detail.formSchema)
+      })
+      .catch(() => {
+        // Silent by design — see the module doc comment above.
+      })
+      .finally(() => {
+        attempted.add(templateId)
+        inflight.delete(templateId)
+      })
+    inflight.set(templateId, promise)
+    return promise
+  }
+
+  /**
+   * Fetch the schema for every DISTINCT `templateId` among `rows` not already attempted this
+   * session. Safe to call repeatedly (e.g. on every list reload/tab switch) — already-attempted
+   * ids are skipped, and concurrent calls sharing a not-yet-settled id share the same in-flight
+   * fetch instead of double-firing.
+   */
+  async function ensureLoadedForRows(rows: Array<Pick<UnifiedApprovalDTO, 'templateId'>>): Promise<void> {
+    const distinctIds = new Set(
+      rows
+        .map((row) => row.templateId)
+        .filter((id): id is string => !!id && !attempted.has(id)),
+    )
+    await Promise.all(Array.from(distinctIds, (id) => loadOne(id)))
+  }
+
+  function summaryLineFor(row: Pick<UnifiedApprovalDTO, 'templateId' | 'formSnapshot'>): string {
+    return resolveRowSummaryLine(schemas, row)
+  }
+
+  return { schemas, ensureLoadedForRows, summaryLineFor }
+}

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -152,6 +152,7 @@
           :approvals="store.pendingApprovals"
           :loading="store.loading"
           :empty-text="mobileEmptyText.pending"
+          :template-schemas="templateSchemas"
           @select="handleRowClick"
         />
         <el-table
@@ -173,7 +174,22 @@
             :selectable="isRowBatchSelectable"
           />
           <el-table-column prop="requestNo" label="审批编号" width="180" />
-          <el-table-column prop="title" label="标题" min-width="200" />
+          <el-table-column label="标题" min-width="200">
+            <!-- B2-01: key-field summary — a muted second line under the title so common items
+                 are decidable without opening (top 2-3 non-attachment/non-detail leaf fields from
+                 the LIVE template schema; see useApprovalListFieldSummary.ts for the live-label
+                 drift caveat). Absent for rows with no templateId or no cached schema yet. -->
+            <template #default="{ row }">
+              {{ row.title }}
+              <div
+                v-if="summaryLineFor(row)"
+                class="approval-center__row-summary"
+                :title="summaryLineFor(row)"
+              >
+                {{ summaryLineFor(row) }}
+              </div>
+            </template>
+          </el-table-column>
           <el-table-column label="发起人" width="120">
             <template #default="{ row }">
               {{ row.requester?.name ?? '-' }}
@@ -267,6 +283,7 @@
           :approvals="store.myApprovals"
           :loading="store.loading"
           :empty-text="mobileEmptyText.mine"
+          :template-schemas="templateSchemas"
           @select="handleRowClick"
         />
         <el-table
@@ -280,7 +297,22 @@
           @row-click="handleRowClick"
         >
           <el-table-column prop="requestNo" label="审批编号" width="180" />
-          <el-table-column prop="title" label="标题" min-width="200" />
+          <el-table-column label="标题" min-width="200">
+            <!-- B2-01: key-field summary — a muted second line under the title so common items
+                 are decidable without opening (top 2-3 non-attachment/non-detail leaf fields from
+                 the LIVE template schema; see useApprovalListFieldSummary.ts for the live-label
+                 drift caveat). Absent for rows with no templateId or no cached schema yet. -->
+            <template #default="{ row }">
+              {{ row.title }}
+              <div
+                v-if="summaryLineFor(row)"
+                class="approval-center__row-summary"
+                :title="summaryLineFor(row)"
+              >
+                {{ summaryLineFor(row) }}
+              </div>
+            </template>
+          </el-table-column>
           <el-table-column label="发起人" width="120">
             <template #default="{ row }">
               {{ row.requester?.name ?? '-' }}
@@ -344,6 +376,7 @@
           :approvals="store.ccApprovals"
           :loading="store.loading"
           :empty-text="mobileEmptyText.cc"
+          :template-schemas="templateSchemas"
           @select="handleRowClick"
         />
         <el-table
@@ -357,7 +390,22 @@
           @row-click="handleRowClick"
         >
           <el-table-column prop="requestNo" label="审批编号" width="180" />
-          <el-table-column prop="title" label="标题" min-width="200" />
+          <el-table-column label="标题" min-width="200">
+            <!-- B2-01: key-field summary — a muted second line under the title so common items
+                 are decidable without opening (top 2-3 non-attachment/non-detail leaf fields from
+                 the LIVE template schema; see useApprovalListFieldSummary.ts for the live-label
+                 drift caveat). Absent for rows with no templateId or no cached schema yet. -->
+            <template #default="{ row }">
+              {{ row.title }}
+              <div
+                v-if="summaryLineFor(row)"
+                class="approval-center__row-summary"
+                :title="summaryLineFor(row)"
+              >
+                {{ summaryLineFor(row) }}
+              </div>
+            </template>
+          </el-table-column>
           <el-table-column label="发起人" width="120">
             <template #default="{ row }">
               {{ row.requester?.name ?? '-' }}
@@ -399,6 +447,7 @@
           :approvals="store.completedApprovals"
           :loading="store.loading"
           :empty-text="mobileEmptyText.completed"
+          :template-schemas="templateSchemas"
           @select="handleRowClick"
         />
         <el-table
@@ -412,7 +461,22 @@
           @row-click="handleRowClick"
         >
           <el-table-column prop="requestNo" label="审批编号" width="180" />
-          <el-table-column prop="title" label="标题" min-width="200" />
+          <el-table-column label="标题" min-width="200">
+            <!-- B2-01: key-field summary — a muted second line under the title so common items
+                 are decidable without opening (top 2-3 non-attachment/non-detail leaf fields from
+                 the LIVE template schema; see useApprovalListFieldSummary.ts for the live-label
+                 drift caveat). Absent for rows with no templateId or no cached schema yet. -->
+            <template #default="{ row }">
+              {{ row.title }}
+              <div
+                v-if="summaryLineFor(row)"
+                class="approval-center__row-summary"
+                :title="summaryLineFor(row)"
+              >
+                {{ summaryLineFor(row) }}
+              </div>
+            </template>
+          </el-table-column>
           <el-table-column label="发起人" width="120">
             <template #default="{ row }">
               {{ row.requester?.name ?? '-' }}
@@ -562,7 +626,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { Search } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
@@ -572,6 +636,7 @@ import { useApprovalPermissions } from '../../approvals/permissions'
 import { dispatchAction, getPendingCount, markAllApprovalsRead, remindApproval } from '../../approvals/api'
 import { runApprovalBatchAction, type ApprovalBatchActionResult } from '../../approvals/useApprovalBatchActions'
 import { useApprovalCountsRealtime, type ApprovalCountsUpdatedPayload } from '../../approvals/useApprovalCountsRealtime'
+import { useApprovalListFieldSummary } from '../../approvals/useApprovalListFieldSummary'
 import { useFeatureFlags } from '../../stores/featureFlags'
 import { useMobileViewport } from '../../composables/useMobileViewport'
 import { useLocale } from '../../composables/useLocale'
@@ -581,6 +646,25 @@ import ApprovalMobileList from './ApprovalMobileList.vue'
 const router = useRouter()
 const store = useApprovalStore()
 const { canWrite } = useApprovalPermissions()
+
+// B2-01 (待办列表关键字段摘要) — lazy per-templateId FormSchema cache + row summary-line lookup,
+// shared by the desktop table below (all four tabs) and ApprovalMobileList (passed the raw
+// `templateSchemas` cache as a prop). See `useApprovalListFieldSummary.ts` for the full rationale
+// (live-template substitute for the list DTO's missing frozen formSchema, the live-label drift
+// tradeoff, and the session-scoped negative caching on fetch failure).
+const { schemas: templateSchemas, ensureLoadedForRows, summaryLineFor } = useApprovalListFieldSummary()
+const allVisibleApprovals = computed<UnifiedApprovalDTO[]>(() => [
+  ...store.pendingApprovals,
+  ...store.myApprovals,
+  ...store.ccApprovals,
+  ...store.completedApprovals,
+])
+// `immediate: true` covers the case where a tab's data is already populated at setup time (e.g.
+// a fresh mount whose store was pre-loaded); every subsequent load (tab switch/page/search/filter)
+// re-fires this because `allVisibleApprovals` recomputes to a new array reference.
+watch(allVisibleApprovals, (rows) => {
+  void ensureLoadedForRows(rows)
+}, { immediate: true })
 
 // T3-1 v0 — mobile approval surface (ballot Q10/Q11). The layout switches to the
 // touch-first card list ONLY when the tenant/user has opted in via the
@@ -1123,6 +1207,19 @@ onMounted(() => {
 
 .approval-center__wait-progress {
   margin-top: 2px;
+  font-size: 12px;
+  color: #909399;
+}
+
+/* B2-01: key-field summary line — muted, single-line, ellipsis-truncated so a long value never
+   wraps the row or blows out the column width; the full text is still available via the native
+   `:title` tooltip. */
+.approval-center__row-summary {
+  margin-top: 2px;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   font-size: 12px;
   color: #909399;
 }

--- a/apps/web/src/views/approval/ApprovalMobileList.vue
+++ b/apps/web/src/views/approval/ApprovalMobileList.vue
@@ -38,6 +38,17 @@
         <span class="approval-mobile-list__request-no">{{ row.requestNo ?? '-' }}</span>
         <span class="approval-mobile-list__requester">{{ row.requester?.name ?? '-' }}</span>
       </div>
+      <!-- B2-01: key-field summary — same muted glance line as the desktop table's title column,
+           built from the LIVE template schema cache the parent passes down (see
+           useApprovalListFieldSummary.ts for the live-label drift caveat). Absent for rows with no
+           templateId or no cached schema yet. -->
+      <div
+        v-if="rowSummaryLine(row)"
+        class="approval-mobile-list__summary"
+        :title="rowSummaryLine(row)"
+      >
+        {{ rowSummaryLine(row) }}
+      </div>
       <div
         class="approval-mobile-list__date"
         :class="`approval-mobile-list__date--${waitSeverity(row.createdAt)}`"
@@ -51,9 +62,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { UnifiedApprovalDTO } from '../../types/approval'
+import type { FormSchema, UnifiedApprovalDTO } from '../../types/approval'
 import { useLocale } from '../../composables/useLocale'
 import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
+import { resolveRowSummaryLine } from '../../approvals/useApprovalListFieldSummary'
 
 // T3-1 v0 — dedicated touch-first list card (ballot Q10). Replaces the desktop
 // `el-table` (fixed column widths + horizontal scroll + tiny row-click targets)
@@ -70,10 +82,16 @@ const props = withDefaults(
     approvals: UnifiedApprovalDTO[]
     loading?: boolean
     emptyText?: string
+    // B2-01 (待办列表关键字段摘要) — live-template schema cache keyed by templateId, owned by the
+    // parent (ApprovalCenterView's useApprovalListFieldSummary). This component never fetches, it
+    // only formats whatever is already cached; a templateId with no entry yet (not fetched / still
+    // in flight / fetch failed) or a row with no templateId simply renders no summary line.
+    templateSchemas?: Map<string, FormSchema>
   }>(),
   {
     loading: false,
     emptyText: undefined,
+    templateSchemas: () => new Map(),
   },
 )
 
@@ -135,6 +153,12 @@ function statusLabel(status: string): string {
 function formatDate(dateStr: string): string {
   if (!dateStr) return '-'
   return new Date(dateStr).toLocaleString(t.value.dateLocale)
+}
+
+// B2-01: same row-summary glue the desktop table uses, resolved against the `templateSchemas`
+// cache the parent owns and passes down as a prop.
+function rowSummaryLine(row: UnifiedApprovalDTO): string {
+  return resolveRowSummaryLine(props.templateSchemas, row)
 }
 </script>
 
@@ -217,6 +241,17 @@ function formatDate(dateStr: string): string {
   gap: 12px;
   font-size: 13px;
   color: var(--el-text-color-regular, #606266);
+}
+
+/* B2-01: key-field summary line — muted, single-line, ellipsis-truncated (mirrors the desktop
+   table's `.approval-center__row-summary`); the full text stays reachable via the native `:title`
+   tooltip. */
+.approval-mobile-list__summary {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  color: var(--el-text-color-secondary, #909399);
 }
 
 .approval-mobile-list__date {

--- a/apps/web/tests/approval-center.spec.ts
+++ b/apps/web/tests/approval-center.spec.ts
@@ -45,17 +45,24 @@ vi.mock('element-plus', async () => {
 // (single-instance and, via `runApprovalBatchAction`'s `dispatch` callback, per-row in a batch),
 // so this needs to be independently resolvable/rejectable per test rather than the real module's
 // always-succeeds mock-mode fixture.
+//
+// B2-01: `getTemplate` backs the list row key-field summary (`useApprovalListFieldSummary`).
+// Defaults to an empty-fields schema so any row that happens to carry a templateId in a test that
+// isn't specifically about the summary still resolves harmlessly (no unhandled rejection, no
+// summary rendered since there is nothing eligible in an empty `fields` array).
 // ---------------------------------------------------------------------------
 const dispatchActionSpy = vi.fn<[string, unknown], Promise<unknown>>().mockResolvedValue({})
 const getPendingCountSpy = vi.fn().mockResolvedValue({ count: 0, unreadCount: 0 })
 const markAllApprovalsReadSpy = vi.fn().mockResolvedValue({ markedCount: 0 })
 const remindApprovalSpy = vi.fn().mockResolvedValue({ ok: true, data: {} })
+const getTemplateSpy = vi.fn().mockResolvedValue({ formSchema: { fields: [] } })
 
 vi.mock('../src/approvals/api', () => ({
   dispatchAction: (...args: [string, unknown]) => dispatchActionSpy(...args),
   getPendingCount: (...args: unknown[]) => getPendingCountSpy(...args),
   markAllApprovalsRead: (...args: unknown[]) => markAllApprovalsReadSpy(...args),
   remindApproval: (...args: unknown[]) => remindApprovalSpy(...args),
+  getTemplate: (...args: [string]) => getTemplateSpy(...args),
 }))
 
 vi.mock('vue-router', async () => {
@@ -396,6 +403,8 @@ describe('ApprovalCenterView', () => {
     markAllApprovalsReadSpy.mockResolvedValue({ markedCount: 0 })
     remindApprovalSpy.mockClear()
     remindApprovalSpy.mockResolvedValue({ ok: true, data: {} })
+    getTemplateSpy.mockClear()
+    getTemplateSpy.mockResolvedValue({ formSchema: { fields: [] } })
 
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -807,5 +816,87 @@ describe('ApprovalCenterView', () => {
     expect(dispatchActionSpy).toHaveBeenNthCalledWith(3, 'apv_b', { action: 'approve' })
     // Full success on retry closes the dialog.
     expect(container!.querySelector('[data-testid="approval-batch-result-dialog"]')).toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // B2-01 (待办列表关键字段摘要) — list row key-field summary line. The list DTO never carries
+  // the frozen per-instance formSchema (only the detail endpoint does), so the summary is built
+  // from the LIVE template schema fetched via `getTemplate` and cached per templateId.
+  // ---------------------------------------------------------------------------
+  describe('B2-01: list row key-field summary', () => {
+    const leaveTemplateSchema = {
+      fields: [
+        {
+          id: 'fld_leave_type',
+          type: 'select',
+          label: '请假类型',
+          options: [{ label: '年假', value: 'annual' }, { label: '事假', value: 'personal' }],
+        },
+        { id: 'fld_duration', type: 'number', label: '时长' },
+        { id: 'fld_reason', type: 'textarea', label: '事由' },
+        { id: 'fld_attachment', type: 'attachment', label: '附件' },
+      ],
+    }
+
+    it('a row whose template has fields renders the summary line with mapped labels/values', async () => {
+      getTemplateSpy.mockResolvedValue({ formSchema: leaveTemplateSchema })
+      mockPendingApprovals.value = [
+        pendingRow({
+          id: 'apv_1',
+          templateId: 'tpl_leave',
+          formSnapshot: {
+            fld_leave_type: 'annual',
+            fld_duration: 2,
+            fld_reason: '家里有事',
+            fld_attachment: ['file_1'],
+          },
+        }),
+      ]
+      await mountView()
+      await flushUi(6)
+
+      expect(getTemplateSpy).toHaveBeenCalledWith('tpl_leave')
+      expect(getTemplateSpy).toHaveBeenCalledTimes(1)
+
+      const cell = container!.querySelector('[data-el-row="apv_1"] [data-el-cell="标题"]')
+      expect(cell).toBeTruthy()
+      expect(cell!.textContent).toContain('出差报销')
+      const summary = cell!.querySelector('.approval-center__row-summary')
+      expect(summary).toBeTruthy()
+      expect(summary!.textContent?.trim()).toBe('请假类型：年假 · 时长：2 · 事由：家里有事')
+      // The attachment field is a schema field but never part of the summary.
+      expect(summary!.textContent).not.toContain('附件')
+    })
+
+    it('a row without templateId renders no summary and never calls getTemplate', async () => {
+      mockPendingApprovals.value = [
+        pendingRow({ id: 'apv_1', templateId: null, formSnapshot: { fld_reason: '出差' } }),
+      ]
+      await mountView()
+      await flushUi(6)
+
+      expect(getTemplateSpy).not.toHaveBeenCalled()
+      const cell = container!.querySelector('[data-el-row="apv_1"] [data-el-cell="标题"]')
+      expect(cell).toBeTruthy()
+      expect(cell!.textContent).toContain('出差报销')
+      expect(cell!.querySelector('.approval-center__row-summary')).toBeNull()
+    })
+
+    it('a template-fetch failure leaves the row summary-less, without throwing', async () => {
+      getTemplateSpy.mockRejectedValueOnce(new Error('模板不存在'))
+      mockPendingApprovals.value = [
+        pendingRow({ id: 'apv_1', templateId: 'tpl_missing', formSnapshot: { fld_reason: '出差' } }),
+      ]
+      await mountView()
+      await flushUi(6)
+
+      expect(getTemplateSpy).toHaveBeenCalledWith('tpl_missing')
+      const cell = container!.querySelector('[data-el-row="apv_1"] [data-el-cell="标题"]')
+      expect(cell).toBeTruthy()
+      expect(cell!.textContent).toContain('出差报销')
+      expect(cell!.querySelector('.approval-center__row-summary')).toBeNull()
+      // Silent by design — no toast, no console-visible rejection reaching the view layer.
+      expect(elErrorSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/web/tests/approval-detail-field.test.ts
+++ b/apps/web/tests/approval-detail-field.test.ts
@@ -9,12 +9,14 @@ import {
   detailColumnDraftsFromField,
   DETAIL_LEAF_FIELD_TYPES,
   findDetailFieldInSchema,
+  formatSummaryLine,
   isDetailCellVisible,
   isDetailField,
   isDetailLeafFieldType,
   parseRowBound,
   pruneHiddenDetailRow,
   pruneHiddenFormDataWithDetail,
+  summaryFields,
   validateDetailColumnsDraft,
   visibleDetailColumnsForRow,
   type DetailColumnDraft,
@@ -440,5 +442,106 @@ describe('detailField — buildDisplayFields (B1-02 humanized scalar snapshot)',
     expect(buildDisplayFields(null, { a: 'b' })).toEqual([{ key: 'a', label: 'a', value: 'b' }])
     expect(buildDisplayFields(displaySchema, null)).toEqual([])
     expect(buildDisplayFields(undefined, undefined)).toEqual([])
+  })
+})
+
+describe('summaryFields (B2-01 list row key-field summary)', () => {
+  const summarySchema: FormSchema = {
+    fields: [
+      {
+        id: 'fld_leave_type',
+        type: 'select',
+        label: '请假类型',
+        options: [{ label: '年假', value: 'annual' }, { label: '事假', value: 'personal' }],
+      },
+      { id: 'fld_duration', type: 'number', label: '时长' },
+      { id: 'fld_reason', type: 'textarea', label: '事由' },
+      { id: 'fld_attachment', type: 'attachment', label: '附件' },
+      { id: 'items', type: 'detail', label: '明细', columns: [{ id: 'x', type: 'text', label: 'X' }] },
+    ],
+  }
+
+  it('returns the first `limit` eligible fields in schema order, formatted like buildDisplayFields', () => {
+    const snapshot = {
+      fld_leave_type: 'annual',
+      fld_duration: 2,
+      fld_reason: '出差',
+      fld_attachment: ['f1'],
+      items: [{ x: '1' }],
+    }
+    const fields = summaryFields(summarySchema, snapshot, 3)
+    expect(fields.map((f) => f.key)).toEqual(['fld_leave_type', 'fld_duration', 'fld_reason'])
+    // Option-label mapping is reused verbatim from buildDisplayFields, not re-derived here.
+    expect(fields[0]).toEqual({ key: 'fld_leave_type', label: '请假类型', value: '年假' })
+  })
+
+  it('excludes attachment fields even when present in the snapshot and earlier in schema order', () => {
+    const schemaAttachmentFirst: FormSchema = {
+      fields: [
+        { id: 'fld_attachment', type: 'attachment', label: '附件' },
+        { id: 'fld_reason', type: 'textarea', label: '事由' },
+      ],
+    }
+    const fields = summaryFields(schemaAttachmentFirst, { fld_attachment: ['f1'], fld_reason: '出差' }, 3)
+    expect(fields.map((f) => f.key)).toEqual(['fld_reason'])
+  })
+
+  it('excludes detail fields (mirrors buildDisplayFields, which never surfaces them as raw/unknown either)', () => {
+    const fields = summaryFields(summarySchema, { items: [{ x: '1' }], fld_reason: '出差' }, 3)
+    expect(fields.map((f) => f.key)).toEqual(['fld_reason'])
+  })
+
+  it('never falls back to snapshot keys absent from the schema (unlike buildDisplayFields\'s own tail)', () => {
+    const fields = summaryFields(summarySchema, { legacy_field: 'x', fld_reason: '出差' }, 3)
+    expect(fields.map((f) => f.key)).toEqual(['fld_reason'])
+  })
+
+  it('honors the limit: 0 returns none, and a limit above the eligible count returns all available', () => {
+    const snapshot = { fld_leave_type: 'annual', fld_duration: 2, fld_reason: '出差' }
+    expect(summaryFields(summarySchema, snapshot, 0)).toEqual([])
+    expect(summaryFields(summarySchema, snapshot, 1).map((f) => f.key)).toEqual(['fld_leave_type'])
+    expect(summaryFields(summarySchema, snapshot, 50).map((f) => f.key)).toEqual([
+      'fld_leave_type', 'fld_duration', 'fld_reason',
+    ])
+  })
+
+  it('defaults the limit to 3 when omitted', () => {
+    const snapshot = { fld_leave_type: 'annual', fld_duration: 2, fld_reason: '出差' }
+    expect(summaryFields(summarySchema, snapshot).map((f) => f.key)).toEqual([
+      'fld_leave_type', 'fld_duration', 'fld_reason',
+    ])
+  })
+
+  it('returns [] for a missing/empty schema, a schema with no eligible field, or no matching snapshot data', () => {
+    expect(summaryFields(null, { a: 'b' })).toEqual([])
+    expect(summaryFields(undefined, undefined)).toEqual([])
+    expect(summaryFields({ fields: [] }, { a: 'b' })).toEqual([])
+
+    const onlyAttachmentAndDetail: FormSchema = {
+      fields: [
+        { id: 'fld_attachment', type: 'attachment', label: '附件' },
+        { id: 'items', type: 'detail', label: '明细', columns: [{ id: 'x', type: 'text', label: 'X' }] },
+      ],
+    }
+    expect(summaryFields(onlyAttachmentAndDetail, { fld_attachment: ['f1'], items: [] })).toEqual([])
+    expect(summaryFields(summarySchema, {})).toEqual([])
+  })
+})
+
+describe('formatSummaryLine (B2-01)', () => {
+  it('joins label：value pairs with " · "', () => {
+    const line = formatSummaryLine([
+      { key: 'a', label: '请假类型', value: '年假' },
+      { key: 'b', label: '时长', value: '2' },
+    ])
+    expect(line).toBe('请假类型：年假 · 时长：2')
+  })
+
+  it('returns a single entry without a separator', () => {
+    expect(formatSummaryLine([{ key: 'a', label: '事由', value: '出差' }])).toBe('事由：出差')
+  })
+
+  it('returns an empty string for an empty array', () => {
+    expect(formatSummaryLine([])).toBe('')
   })
 })

--- a/apps/web/tests/approvalMobileResponsive.spec.ts
+++ b/apps/web/tests/approvalMobileResponsive.spec.ts
@@ -38,12 +38,18 @@ vi.mock('../src/stores/featureFlags', () => ({
   }),
 }))
 
+// B2-01: `getTemplate` backs the list row key-field summary (`useApprovalListFieldSummary`) — a
+// named spy (unlike the other inline `vi.fn()`s above) so individual tests can control its
+// resolved/rejected value and assert on calls.
+const getTemplateSpy = vi.fn().mockResolvedValue({ formSchema: { fields: [] } })
+
 // Keep the on-mount badge/realtime side-effects off the real wire.
 vi.mock('../src/approvals/api', () => ({
   dispatchAction: vi.fn().mockResolvedValue({}),
   getPendingCount: vi.fn().mockResolvedValue({ count: 0, unreadCount: 0 }),
   markAllApprovalsRead: vi.fn().mockResolvedValue({ markedCount: 0 }),
   remindApproval: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+  getTemplate: (...args: [string]) => getTemplateSpy(...args),
 }))
 vi.mock('../src/approvals/useApprovalCountsRealtime', () => ({
   useApprovalCountsRealtime: () => undefined,
@@ -201,6 +207,8 @@ describe('ApprovalCenterView — T3-1 mobile responsive gate', () => {
     mockLoading.value = false
     loadPendingSpy.mockClear()
     pushSpy.mockClear()
+    getTemplateSpy.mockClear()
+    getTemplateSpy.mockResolvedValue({ formSchema: { fields: [] } })
     setViewport(false)
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -310,5 +318,79 @@ describe('ApprovalCenterView — T3-1 mobile responsive gate', () => {
     expect(dateEl!.textContent).toContain('8 天')
     expect(dateEl!.classList.contains('approval-mobile-list__date--urgent')).toBe(true)
     expect(dateEl!.getAttribute('title')).toBeTruthy()
+  })
+
+  // ---------------------------------------------------------------------------
+  // B2-01 (待办列表关键字段摘要) — the mobile card list surfaces the same live-template summary
+  // line as the desktop table's title column, resolved from the `templateSchemas` cache
+  // ApprovalCenterView owns (useApprovalListFieldSummary) and passes down as a prop.
+  // ---------------------------------------------------------------------------
+  describe('B2-01: mobile card key-field summary', () => {
+    const leaveTemplateSchema = {
+      fields: [
+        {
+          id: 'fld_leave_type',
+          type: 'select',
+          label: '请假类型',
+          options: [{ label: '年假', value: 'annual' }],
+        },
+        { id: 'fld_duration', type: 'number', label: '时长' },
+        { id: 'fld_attachment', type: 'attachment', label: '附件' },
+      ],
+    }
+
+    it('flag ON + narrow → a card whose template has fields shows the summary line', async () => {
+      getTemplateSpy.mockResolvedValue({ formSchema: leaveTemplateSchema })
+      mockApprovalMobileFlag.value = true
+      setViewport(true)
+      mockPendingApprovals.value = [
+        {
+          ...pendingRow('1', '出差报销'),
+          templateId: 'tpl_leave',
+          formSnapshot: { fld_leave_type: 'annual', fld_duration: 2, fld_attachment: ['f1'] },
+        },
+      ]
+      await mountView()
+      await flushUi(6)
+
+      expect(getTemplateSpy).toHaveBeenCalledWith('tpl_leave')
+      const card = container!.querySelector('[data-testid="approval-mobile-card"]')
+      expect(card).toBeTruthy()
+      const summary = card!.querySelector('.approval-mobile-list__summary')
+      expect(summary).toBeTruthy()
+      expect(summary!.textContent?.trim()).toBe('请假类型：年假 · 时长：2')
+      // The attachment field is a schema field but never part of the summary.
+      expect(summary!.textContent).not.toContain('附件')
+    })
+
+    it('flag ON + narrow → a card without templateId shows no summary and never calls getTemplate', async () => {
+      mockApprovalMobileFlag.value = true
+      setViewport(true)
+      mockPendingApprovals.value = [pendingRow('1', '出差报销')]
+      await mountView()
+      await flushUi(6)
+
+      expect(getTemplateSpy).not.toHaveBeenCalled()
+      const card = container!.querySelector('[data-testid="approval-mobile-card"]')
+      expect(card).toBeTruthy()
+      expect(card!.querySelector('.approval-mobile-list__summary')).toBeNull()
+    })
+
+    it('flag ON + narrow → a template-fetch failure leaves the card summary-less, without throwing', async () => {
+      getTemplateSpy.mockRejectedValueOnce(new Error('模板不存在'))
+      mockApprovalMobileFlag.value = true
+      setViewport(true)
+      mockPendingApprovals.value = [
+        { ...pendingRow('1', '出差报销'), templateId: 'tpl_missing', formSnapshot: { fld_reason: '出差' } },
+      ]
+      await mountView()
+      await flushUi(6)
+
+      expect(getTemplateSpy).toHaveBeenCalledWith('tpl_missing')
+      const card = container!.querySelector('[data-testid="approval-mobile-card"]')
+      expect(card).toBeTruthy()
+      expect(card!.textContent).toContain('出差报销')
+      expect(card!.querySelector('.approval-mobile-list__summary')).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
## Summary

UX 阶梯 §7 **parity 必需切片首项 B2-01**（Sonnet 代理实现 + Fable 审查）：待办列表行只有编号/标题/发起人/状态/时间——审批员被迫每单点开才能决策。现在标题下内联渲染前 2-3 个关键表单字段摘要，「不点开就能决策」（钉钉/飞书卡片核心）。

- 新 `summaryFields(formSchema, formSnapshot, limit=3)` + `formatSummaryLine`（detailField.ts）：schema 顺序取前 N 个非 attachment/非 detail 叶子字段，复用 B1-02 的 `buildDisplayFields` 做值格式化（**刻意不继承其 unknown-key 尾巴**——否则无 schema 行会 dump 脏 legacy key）
- 新 `useApprovalListFieldSummary` composable：惰性 `Map<templateId, FormSchema>` 缓存（既有 `getTemplate` 拉取，仅需 `approvals:read` = 列表本身权限）+ session-scoped `attempted` 集（含失败项每 session 最多拉一次）；`resolveRowSummaryLine` 独立函数供移动列表共享（DRY）
- 四 tab 桌面表 + 移动卡片接线；无 templateId 行（PLM/考勤桥接）降级无摘要不崩
- **live-label 漂移**：展示用 live 模板 schema（详情页用冻结快照做权威渲染）——代码注释 + commit body 声明权衡

## Verification

- 新增 16 测试（helper 10 边界 + 桌面/移动各 3）；rebase 后焦点 81/81 + vue-tsc 0 + eslint 0
- 代理另识别 4 个 USE_MOCK 风险 spec 一并跑绿（共 202）；预存失败 stash 复验非本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)