### PR TITLE
feat(web): approval detail timeline — current handler + upcoming nodes (UX B2-08)

### DIFF
--- a/apps/web/src/approvals/assigneeSource.ts
+++ b/apps/web/src/approvals/assigneeSource.ts
@@ -1,0 +1,63 @@
+import type {
+  ApprovalAssigneeSource,
+  ApprovalNode,
+  ApprovalNodeConfig,
+  CcNodeConfig,
+} from '../types/approval'
+
+/**
+ * Human-readable summary of a single assignee source (审批人来源) — one short Chinese phrase per
+ * source kind. Moved here (UX B2-08) from `TemplateAuthoringView.vue`'s G-1 read-only graph
+ * preview (`nodeConfigSummary`) so the approval detail view's "upcoming nodes" synthesis (see
+ * `upcomingNodes.ts`) can reuse the exact same wording instead of re-deriving it. Behavior is
+ * byte-identical to the original — no wording change, since it is already shipped in the G-1
+ * preview.
+ */
+export function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
+  switch (source.kind) {
+    case 'static_user': return `指定用户：${source.userIds.join('、') || '（无）'}`
+    case 'static_role': return `指定角色：${source.roleIds.join('、') || '（无）'}`
+    case 'requester': return '发起人'
+    case 'form_field_user': return `表单用户字段：${source.fieldId}`
+    case 'direct_manager': return '直属上级'
+    case 'dept_head': return '部门主管'
+    case 'continuous_managers': return `连续多级上级（${source.levels} 级）`
+    case 'manager_at_level': return `指定层级上级（第 ${source.level} 级）`
+    default: return JSON.stringify(source)
+  }
+}
+
+/**
+ * Node-level assignee-source summary (UX B2-08) — a single display line describing WHO/WHAT
+ * resolves the pending handler(s) at a node, for the approval detail view's requester-facing
+ * "upcoming nodes" preview (not an authoring tool, so no ids-heavy dump — just enough to
+ * recognize the step).
+ *
+ * For an `approval` node this prefers the current `assigneeSources` shape (joins every
+ * configured source with '、'), and falls back to the older `assigneeType`/`assigneeIds` shape —
+ * still a valid, round-tripped shape (see `ApprovalProductService`'s graph validation, which
+ * accepts EITHER shape, and `TemplateDetailView.vue`'s own node-assignee rendering, which in fact
+ * handles ONLY this legacy shape) — so a template authored before `assigneeSources` existed still
+ * gets a real summary instead of "unconfigured". `cc`/`condition`/`parallel`/`end` each get a
+ * fixed one-line description; `start` (never an "upcoming" node in a valid DAG) falls through to
+ * `''`.
+ */
+export function nodeAssigneeSourceSummary(node: ApprovalNode): string {
+  if (node.type === 'approval') {
+    const cfg = node.config as ApprovalNodeConfig
+    const sources = cfg.assigneeSources ?? []
+    if (sources.length > 0) return sources.map(assigneeSourceSummary).join('、')
+    if (cfg.assigneeType && cfg.assigneeIds && cfg.assigneeIds.length > 0) {
+      return `${cfg.assigneeType === 'role' ? '指定角色' : '指定成员'}：${cfg.assigneeIds.join('、')}`
+    }
+    return '（未配置审批人）'
+  }
+  if (node.type === 'cc') {
+    const cfg = node.config as CcNodeConfig
+    return `抄送${cfg.targetType === 'role' ? '角色' : '成员'}`
+  }
+  if (node.type === 'condition') return '按条件进入后续分支'
+  if (node.type === 'parallel') return '进入并行分支'
+  if (node.type === 'end') return '流程结束'
+  return ''
+}

--- a/apps/web/src/approvals/upcomingNodes.ts
+++ b/apps/web/src/approvals/upcomingNodes.ts
@@ -1,0 +1,60 @@
+import type { ApprovalGraph, ApprovalNode } from '../types/approval'
+import { nodeAssigneeSourceSummary } from './assigneeSource'
+
+export interface UpcomingApprovalNode {
+  key: string
+  name: string
+  assigneeSummary: string
+  isConditional: boolean
+}
+
+/**
+ * UX B2-08 — walks the approval graph FORWARD from `currentNodeKey`, one hop at a time, to
+ * synthesize the "what's next" section of the detail view's timeline. The real history only ever
+ * has PAST actions — there is no history row for the currently-open step — so a requester can't
+ * otherwise tell what comes after it. Ordered nearest-first (current node's immediate successor
+ * first).
+ *
+ * Stops the instant the path becomes ambiguous — any node with anything other than exactly one
+ * outgoing edge. That covers a `condition` node (branches depend on unevaluated form data) AND a
+ * `parallel` fan-out (concurrent branches) with the SAME rule: don't fabricate a single guessed
+ * path. The fan-out node itself is still included as the last entry (for `condition`,
+ * `isConditional: true` + the honest "按条件进入后续分支" summary — see
+ * `nodeAssigneeSourceSummary`) — only what comes AFTER it is left out. A dangling edge (target not
+ * in `graph.nodes`) or a dead end (no outgoing edge, short of reaching `end`) also stops the walk
+ * without throwing. A defensive `visited` guard additionally stops a cycle — approval graphs are
+ * authored/validated as DAGs (see `graphLayout.graphHasCycle`) — so this walk stays safe even
+ * against a malformed one.
+ */
+export function buildUpcomingNodes(graph: ApprovalGraph, currentNodeKey: string): UpcomingApprovalNode[] {
+  const nodesByKey = new Map(graph.nodes.map((node) => [node.key, node]))
+  const outgoingByNode = new Map<string, string[]>()
+  for (const edge of graph.edges) {
+    if (!outgoingByNode.has(edge.source)) outgoingByNode.set(edge.source, [])
+    outgoingByNode.get(edge.source)!.push(edge.target)
+  }
+
+  const result: UpcomingApprovalNode[] = []
+  const visited = new Set<string>([currentNodeKey])
+  let cursor = currentNodeKey
+  // Bounded by node count (a walk can't visit more distinct nodes than exist) instead of an
+  // unconditional loop — mirrors the defensive bounded-pass style already used by `graphLayout.ts`.
+  for (let hop = 0; hop < graph.nodes.length; hop += 1) {
+    const targets = outgoingByNode.get(cursor) ?? []
+    if (targets.length !== 1) break // dead end, or a fan-out we won't guess through
+    const next = targets[0]
+    if (visited.has(next)) break // cycle guard (graphs are authored as DAGs; defensive only)
+    visited.add(next)
+    const node: ApprovalNode | undefined = nodesByKey.get(next)
+    if (!node) break // dangling edge guard
+    result.push({
+      key: node.key,
+      name: node.name?.trim() || node.key,
+      assigneeSummary: nodeAssigneeSourceSummary(node),
+      isConditional: node.type === 'condition',
+    })
+    if (node.type === 'end') break
+    cursor = next
+  }
+  return result
+}

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -244,6 +244,43 @@
             </el-timeline>
           </template>
           <el-empty v-else description="暂无审批历史" :image-size="80" />
+
+          <!-- UX B2-08: current handler + upcoming nodes — synthesized (NOT real history rows),
+               appended at the END of the timeline so a requester can see who it's stuck with and
+               what's next, not just what already happened. Deliberately NOT built from
+               `<el-timeline-item>` — its own lightweight dot+line rail instead — so it stays
+               visually distinct (upcoming = greyed) and never perturbs the real history item
+               count above. -->
+          <div
+            v-if="currentHandlerEntries.length > 0 || upcomingTimelineNodes.length > 0"
+            class="approval-detail__timeline-upcoming"
+            data-testid="approval-timeline-upcoming-section"
+          >
+            <div
+              v-for="entry in currentHandlerEntries"
+              :key="`current-${entry.assignmentId}`"
+              class="approval-detail__timeline-upcoming-item approval-detail__timeline-upcoming-item--current"
+              data-testid="approval-current-handler-item"
+            >
+              <span class="approval-detail__timeline-upcoming-dot" />
+              <span class="approval-detail__timeline-upcoming-text">
+                当前处理人：{{ entry.label }} · 已等待 {{ entry.wait }}
+              </span>
+            </div>
+            <div
+              v-for="node in upcomingTimelineNodes"
+              :key="`upcoming-${node.key}`"
+              class="approval-detail__timeline-upcoming-item approval-detail__timeline-upcoming-item--future"
+              :class="{ 'approval-detail__timeline-upcoming-item--conditional': node.isConditional }"
+              data-testid="approval-upcoming-node-item"
+            >
+              <span class="approval-detail__timeline-upcoming-dot" />
+              <span class="approval-detail__timeline-upcoming-text">
+                <strong>{{ node.name }}</strong>
+                <span class="approval-detail__timeline-upcoming-summary">{{ node.assigneeSummary }}</span>
+              </span>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -636,7 +673,7 @@ import {
   CirclePlus,
   Remove,
 } from '@element-plus/icons-vue'
-import type { ApprovalActionType } from '../../types/approval'
+import type { ApprovalActionType, ApprovalAssignmentDTO, ApprovalGraph } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
@@ -653,6 +690,7 @@ import {
 } from '../../approvals/detailField'
 import { phrasesForAction, recentPhrases, rememberPhrase } from '../../approvals/quickPhrases'
 import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
+import { buildUpcomingNodes, type UpcomingApprovalNode } from '../../approvals/upcomingNodes'
 
 const route = useRoute()
 const router = useRouter()
@@ -731,13 +769,7 @@ const isMyTurn = computed(() => {
   const me = currentUserId.value
   const detail = approval.value
   if (!me || !detail || detail.status !== 'pending') return false
-  const currentKeys = new Set(
-    parallelBranchNodeKeys.value.length > 0
-      ? parallelBranchNodeKeys.value
-      : detail.currentNodeKey
-        ? [detail.currentNodeKey]
-        : [],
-  )
+  const currentKeys = new Set(currentActiveNodeKeys.value)
   if (currentKeys.size === 0) return false
   return detail.assignments.some(
     (a) => a.isActive && a.type === 'user' && a.assigneeId === me && !!a.nodeKey && currentKeys.has(a.nodeKey),
@@ -785,6 +817,80 @@ const timelineBranchGroups = computed<TimelineGroup[]>(() => {
     buckets.get(bucketKey)!.items.push(item)
   }
   return order.map((key) => buckets.get(key)!)
+})
+
+// ---------------------------------------------------------------------------
+// UX B2-08: current handler + upcoming nodes ("卡在谁那里 / 接下来到谁")
+// ---------------------------------------------------------------------------
+// The history timeline above only ever has PAST actions — there is no history row for the
+// CURRENTLY open step — so a requester can't tell who it's stuck with or what comes next. This
+// synthesizes that (NOT real history rows) and is rendered at the very end of the timeline, only
+// while the instance is still `pending`.
+
+// Every node key with an active pending assignment right now. Single source of truth for both
+// `isMyTurn` (above) and `currentHandlerEntries` (below) — mirrors the same parallel-vs-linear
+// resolution `isMyTurn` used inline before this slice.
+const currentActiveNodeKeys = computed<string[]>(() => {
+  if (!approval.value) return []
+  if (parallelBranchNodeKeys.value.length > 0) return parallelBranchNodeKeys.value
+  return approval.value.currentNodeKey ? [approval.value.currentNodeKey] : []
+})
+
+interface CurrentHandlerEntry {
+  assignmentId: string
+  label: string
+  wait: string
+}
+
+// `assignment.metadata` carries no display name today — only `assigneeId` (see
+// `ApprovalAssignmentDTO`). This defensively prefers a future `metadata.assigneeName` if the
+// backend ever adds one, else falls back to the raw id — same "don't fetch, just display"
+// convention `reducibleAssignees` already uses above.
+function assignmentDisplayLabel(assignment: ApprovalAssignmentDTO): string {
+  const metaName = assignment.metadata.assigneeName
+  return typeof metaName === 'string' && metaName.trim() ? metaName : assignment.assigneeId
+}
+
+// One entry per ACTIVE assignment at the current node(s) — every currently-pending handler, not
+// just "is it me" (that's `isMyTurn`). `wait` reuses `formatRelativeWait` (B1-03) against
+// `updatedAt` rather than `createdAt`: an assignment row carries no timestamp of its own, and
+// `updatedAt` — bumped whenever an action actually moves/changes the instance, but NOT by a plain
+// comment (see backend `ApprovalProductService`) — approximates "since this step became current"
+// far better than the header chip's `createdAt` (since the whole approval was first created).
+const currentHandlerEntries = computed<CurrentHandlerEntry[]>(() => {
+  const detail = approval.value
+  if (!detail || detail.status !== 'pending') return []
+  const keys = new Set(currentActiveNodeKeys.value)
+  if (keys.size === 0) return []
+  const wait = formatRelativeWait(detail.updatedAt)
+  return detail.assignments
+    .filter((a) => a.isActive && !!a.nodeKey && keys.has(a.nodeKey))
+    .map((a) => ({ assignmentId: a.id, label: assignmentDisplayLabel(a), wait }))
+})
+
+// Prefer the instance's FROZEN template version (pinned at creation) over the LIVE template
+// loaded below for `nodeLabel` — the live template may have been edited (renamed/reordered/
+// removed nodes) since this instance started, which would silently mis-render the "upcoming
+// nodes" preview against a graph the instance will never actually traverse. Falls back to the
+// live template when no pinned version was reachable (see `onMounted`) — DRIFT RISK: that
+// fallback path can render upcoming nodes that no longer match this instance's real remaining
+// path.
+const pinnedGraph = computed<ApprovalGraph | null>(() => {
+  return templateStore.activeVersion?.approvalGraph ?? templateStore.activeTemplate?.approvalGraph ?? null
+})
+
+// Parallel regions have no single unambiguous "current node" to walk forward from until the
+// branches rejoin at their `joinNodeKey` — skip rather than fabricate a merged/guessed path (the
+// "并行中" badge in the header already communicates the parallel state itself).
+const upcomingTimelineNodes = computed<UpcomingApprovalNode[]>(() => {
+  const detail = approval.value
+  if (!detail || detail.status !== 'pending') return []
+  if (isInParallelRegion.value) return []
+  const currentNodeKey = detail.currentNodeKey
+  if (!currentNodeKey) return []
+  const graph = pinnedGraph.value
+  if (!graph) return []
+  return buildUpcomingNodes(graph, currentNodeKey)
 })
 
 const actionDialogVisible = ref(false)
@@ -1281,8 +1387,19 @@ onMounted(async () => {
       .catch(() => {})
   }
   await Promise.all([store.loadDetail(id), store.loadHistory(id)])
-  if (store.activeApproval?.templateId) {
-    await templateStore.loadTemplate(store.activeApproval.templateId).catch(() => undefined)
+  const detail = store.activeApproval
+  if (detail?.templateId) {
+    const templateFetches: Array<Promise<unknown>> = [
+      templateStore.loadTemplate(detail.templateId).catch(() => undefined),
+    ]
+    // B2-08: ALSO fetch the instance's pinned template version (if the DTO exposes one) so
+    // `pinnedGraph`/the current+upcoming synthesis can walk the FROZEN graph. Kept as an
+    // ADDITIONAL fetch (not a replacement) so `nodeLabel`'s existing history lookups keep using
+    // the live template exactly as before.
+    if (detail.templateVersionId) {
+      templateFetches.push(templateStore.loadVersion(detail.templateId, detail.templateVersionId).catch(() => undefined))
+    }
+    await Promise.all(templateFetches)
   }
 })
 </script>
@@ -1465,6 +1582,53 @@ onMounted(async () => {
 .approval-detail__timeline-group-count {
   font-size: 12px;
   color: var(--el-text-color-secondary, #606266);
+}
+
+/* UX B2-08: synthesized "current handler + upcoming nodes" rail, appended after the real
+   history entries. A lightweight dot+line rail of its own (not `<el-timeline-item>`) so the
+   upcoming (future/uncertain) entries can render visibly greyed without touching the styling
+   of real history rows above. */
+.approval-detail__timeline-upcoming {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px dashed var(--el-border-color-lighter, #e4e7ed);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.approval-detail__timeline-upcoming-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.approval-detail__timeline-upcoming-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  margin-top: 4px;
+  border-radius: 50%;
+  background: var(--el-color-primary, #409eff);
+}
+
+.approval-detail__timeline-upcoming-item--future .approval-detail__timeline-upcoming-dot {
+  background: var(--el-text-color-placeholder, #c0c4cc);
+}
+
+.approval-detail__timeline-upcoming-item--current .approval-detail__timeline-upcoming-text {
+  color: var(--el-text-color-primary, #303133);
+  font-weight: 500;
+}
+
+.approval-detail__timeline-upcoming-item--future .approval-detail__timeline-upcoming-text {
+  color: var(--el-text-color-placeholder, #909399);
+}
+
+.approval-detail__timeline-upcoming-summary {
+  margin-left: 6px;
 }
 
 /* B1-05: sticky at the viewport bottom so approve/reject/... stay reachable while the form

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1223,6 +1223,7 @@ import type {
   ParallelNodeConfig,
 } from '../../types/approval'
 import { useApprovalDirectory } from '../../approvals/useApprovalDirectory'
+import { assigneeSourceSummary } from '../../approvals/assigneeSource'
 
 const route = useRoute()
 const router = useRouter()
@@ -1278,19 +1279,9 @@ function nodeTypeLabel(type: string): string {
   return NODE_TYPE_LABELS[type] ?? type
 }
 
-function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
-  switch (source.kind) {
-    case 'static_user': return `指定用户：${source.userIds.join('、') || '（无）'}`
-    case 'static_role': return `指定角色：${source.roleIds.join('、') || '（无）'}`
-    case 'requester': return '发起人'
-    case 'form_field_user': return `表单用户字段：${source.fieldId}`
-    case 'direct_manager': return '直属上级'
-    case 'dept_head': return '部门主管'
-    case 'continuous_managers': return `连续多级上级（${source.levels} 级）`
-    case 'manager_at_level': return `指定层级上级（第 ${source.level} 级）`
-    default: return JSON.stringify(source)
-  }
-}
+// `assigneeSourceSummary` (single-source label) now lives in `../../approvals/assigneeSource` —
+// UX B2-08 reuses it from the approval detail view's "upcoming nodes" preview, so it moved to a
+// shared module instead of staying private here. Imported above; behavior is unchanged.
 
 // One read-only descriptor per node config, covering ALL three complex types (condition / parallel
 // / cc) plus approval — so no type silently renders as "unsupported". Returns `[]` for nodes

--- a/apps/web/tests/approval-assignee-source.test.ts
+++ b/apps/web/tests/approval-assignee-source.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalAssigneeSource, ApprovalNode } from '../src/types/approval'
+import { assigneeSourceSummary, nodeAssigneeSourceSummary } from '../src/approvals/assigneeSource'
+
+// UX B2-08 — `assigneeSourceSummary` moved here (byte-identical) from
+// `TemplateAuthoringView.vue`'s private `nodeConfigSummary` helper so the approval detail view's
+// "upcoming nodes" preview can reuse the exact same wording. This is its first dedicated test
+// coverage (it shipped untested as part of the G-1 read-only graph preview).
+
+describe('assigneeSourceSummary (single source)', () => {
+  it('static_user: joins userIds with 、, falls back to （无） when empty', () => {
+    expect(assigneeSourceSummary({ kind: 'static_user', userIds: ['alice', 'bob'] })).toBe('指定用户：alice、bob')
+    expect(assigneeSourceSummary({ kind: 'static_user', userIds: [] })).toBe('指定用户：（无）')
+  })
+
+  it('static_role: joins roleIds with 、, falls back to （无） when empty', () => {
+    expect(assigneeSourceSummary({ kind: 'static_role', roleIds: ['role_manager', 'role_finance'] })).toBe('指定角色：role_manager、role_finance')
+    expect(assigneeSourceSummary({ kind: 'static_role', roleIds: [] })).toBe('指定角色：（无）')
+  })
+
+  it('requester: fixed label', () => {
+    expect(assigneeSourceSummary({ kind: 'requester' })).toBe('发起人')
+  })
+
+  it('form_field_user: names the field id', () => {
+    expect(assigneeSourceSummary({ kind: 'form_field_user', fieldId: 'fld_assignee' })).toBe('表单用户字段：fld_assignee')
+  })
+
+  it('direct_manager: fixed label', () => {
+    expect(assigneeSourceSummary({ kind: 'direct_manager' })).toBe('直属上级')
+  })
+
+  it('dept_head: fixed label', () => {
+    expect(assigneeSourceSummary({ kind: 'dept_head' })).toBe('部门主管')
+  })
+
+  it('continuous_managers: includes the level count', () => {
+    expect(assigneeSourceSummary({ kind: 'continuous_managers', levels: 3 })).toBe('连续多级上级（3 级）')
+  })
+
+  it('manager_at_level: includes the specific level', () => {
+    expect(assigneeSourceSummary({ kind: 'manager_at_level', level: 2 })).toBe('指定层级上级（第 2 级）')
+  })
+
+  it('falls back to a JSON dump for an unrecognized kind (defensive default)', () => {
+    const unknown = { kind: 'unknown_kind' } as unknown as ApprovalAssigneeSource
+    expect(assigneeSourceSummary(unknown)).toBe(JSON.stringify(unknown))
+  })
+})
+
+describe('nodeAssigneeSourceSummary (node-level)', () => {
+  it('approval node with assigneeSources: joins every source with 、', () => {
+    const node: ApprovalNode = {
+      key: 'a1',
+      type: 'approval',
+      name: '部门主管审批',
+      config: { assigneeSources: [{ kind: 'direct_manager' }, { kind: 'dept_head' }] },
+    }
+    expect(nodeAssigneeSourceSummary(node)).toBe('直属上级、部门主管')
+  })
+
+  it('approval node with ONLY the legacy assigneeType/assigneeIds shape: still gets a real summary', () => {
+    const node: ApprovalNode = {
+      key: 'a2',
+      type: 'approval',
+      name: '财务审批',
+      config: { assigneeType: 'user', assigneeIds: ['user_finance'] },
+    }
+    expect(nodeAssigneeSourceSummary(node)).toBe('指定成员：user_finance')
+
+    const roleNode: ApprovalNode = {
+      key: 'a3',
+      type: 'approval',
+      name: '角色审批',
+      config: { assigneeType: 'role', assigneeIds: ['role_manager', 'role_finance'] },
+    }
+    expect(nodeAssigneeSourceSummary(roleNode)).toBe('指定角色：role_manager、role_finance')
+  })
+
+  it('approval node with neither shape configured: falls back to unconfigured', () => {
+    const node: ApprovalNode = { key: 'a4', type: 'approval', config: {} }
+    expect(nodeAssigneeSourceSummary(node)).toBe('（未配置审批人）')
+  })
+
+  it('assigneeSources takes precedence over a co-present legacy shape', () => {
+    const node: ApprovalNode = {
+      key: 'a5',
+      type: 'approval',
+      config: {
+        assigneeType: 'user',
+        assigneeIds: ['user_legacy'],
+        assigneeSources: [{ kind: 'requester' }],
+      },
+    }
+    expect(nodeAssigneeSourceSummary(node)).toBe('发起人')
+  })
+
+  it('cc node: names the target type (成员 vs 角色)', () => {
+    const userCc: ApprovalNode = { key: 'cc1', type: 'cc', config: { targetType: 'user', targetIds: ['user_1'] } }
+    const roleCc: ApprovalNode = { key: 'cc2', type: 'cc', config: { targetType: 'role', targetIds: ['role_1'] } }
+    expect(nodeAssigneeSourceSummary(userCc)).toBe('抄送成员')
+    expect(nodeAssigneeSourceSummary(roleCc)).toBe('抄送角色')
+  })
+
+  it('condition node: the honest "按条件进入后续分支" label (no fabricated branch)', () => {
+    const node: ApprovalNode = {
+      key: 'cond1',
+      type: 'condition',
+      config: { branches: [{ edgeKey: 'e-high', rules: [] }], defaultEdgeKey: 'e-low' },
+    }
+    expect(nodeAssigneeSourceSummary(node)).toBe('按条件进入后续分支')
+  })
+
+  it('parallel node: the honest "进入并行分支" label', () => {
+    const node: ApprovalNode = {
+      key: 'par1',
+      type: 'parallel',
+      config: { branches: ['b1', 'b2'], joinMode: 'all', joinNodeKey: 'join1' },
+    }
+    expect(nodeAssigneeSourceSummary(node)).toBe('进入并行分支')
+  })
+
+  it('end node: a friendly "流程结束" label', () => {
+    const node: ApprovalNode = { key: 'end', type: 'end', config: {} }
+    expect(nodeAssigneeSourceSummary(node)).toBe('流程结束')
+  })
+
+  it('start node: empty string (never an "upcoming" node in a valid DAG, but stays defensive)', () => {
+    const node: ApprovalNode = { key: 'start', type: 'start', config: {} }
+    expect(nodeAssigneeSourceSummary(node)).toBe('')
+  })
+})

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -97,6 +97,11 @@ vi.mock('../src/approvals/store', () => ({
 // Template store mock
 // ---------------------------------------------------------------------------
 const mockActiveTemplate = ref<any>(null)
+// UX B2-08 — settable (was hardcoded `null`) so tests can simulate the instance's PINNED
+// template version having already loaded (mirrors how `mockActiveTemplate` above simulates a
+// pre-loaded live template). Defaults to `null`, so every pre-existing test (which never touches
+// this) is byte-identical to before.
+const mockActiveVersion = ref<any>(null)
 const mockTemplates = ref<any[]>([])
 const mockTemplateLoading = ref(false)
 const mockTemplateError = ref<string | null>(null)
@@ -110,7 +115,7 @@ vi.mock('../src/approvals/templateStore', () => ({
   useApprovalTemplateStore: () => ({
     get templates() { return mockTemplates.value },
     get activeTemplate() { return mockActiveTemplate.value },
-    get activeVersion() { return null },
+    get activeVersion() { return mockActiveVersion.value },
     get loading() { return mockTemplateLoading.value },
     get error() { return mockTemplateError.value },
     get total() { return mockTemplateTotal.value },
@@ -501,6 +506,7 @@ describe('Approval E2E Lifecycle', () => {
     mockCcApprovals.value = []
     mockCompletedApprovals.value = []
     mockActiveTemplate.value = null
+    mockActiveVersion.value = null
     mockTemplates.value = []
     mockTemplateLoading.value = false
     mockTemplateError.value = null
@@ -1409,6 +1415,128 @@ describe('Approval E2E Lifecycle', () => {
 
       const empty = container!.querySelector('.approval-detail__form [data-el-empty]')
       expect(empty?.textContent).toContain('暂无表单数据')
+    })
+  })
+
+  // =========================================================================
+  // UX B2-08: current handler + upcoming nodes
+  // =========================================================================
+  describe('UX B2-08: current handler + upcoming nodes', () => {
+    it('a pending instance renders 当前处理人 with the active assignee + 已等待', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const section = container!.querySelector('[data-testid="approval-timeline-upcoming-section"]')
+      expect(section).toBeTruthy()
+
+      const item = container!.querySelector('[data-testid="approval-current-handler-item"]')
+      expect(item).toBeTruthy()
+      expect(item!.textContent).toContain('当前处理人')
+      expect(item!.textContent).toContain('user_current') // the fixture's active assigneeId
+      expect(item!.textContent).toContain('已等待')
+    })
+
+    it('a non-pending instance renders NO current/upcoming section', async () => {
+      routeParams = { id: 'apv_approved_1' }
+      mockActiveApproval.value = mockApprovedApproval()
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountDetailView()
+
+      expect(container!.querySelector('[data-testid="approval-timeline-upcoming-section"]')).toBeNull()
+      expect(container!.querySelector('[data-testid="approval-current-handler-item"]')).toBeNull()
+      expect(container!.querySelector('[data-testid="approval-upcoming-node-item"]')).toBeNull()
+    })
+
+    it('renders upcoming nodes greyed with assignee summaries, via the live-template fallback when no pinned version is loaded', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval() // currentNodeKey: 'approval_1'
+      mockActiveTemplate.value = mockPublishedTemplate() // start -> approval_1 -> approval_2 -> end
+      // activeVersion stays null (default) — exercises the live-template FALLBACK path.
+      await mountDetailView()
+
+      const items = Array.from(container!.querySelectorAll('[data-testid="approval-upcoming-node-item"]'))
+      expect(items.map((el) => el.textContent)).toEqual([
+        expect.stringContaining('财务审批'),
+        expect.stringContaining('结束'),
+      ])
+      // legacy assigneeType/assigneeIds shape (the fixture graph predates assigneeSources) still
+      // resolves to a real summary, not "unconfigured".
+      expect(items[0].textContent).toContain('指定成员：user_finance')
+      expect(items[1].textContent).toContain('流程结束')
+      // Greyed via the dedicated CSS class (--future), not the current/highlighted one.
+      expect(items[0].classList.contains('approval-detail__timeline-upcoming-item--future')).toBe(true)
+    })
+
+    it('prefers the PINNED template version over a drifted LIVE template', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      const pinned = mockPublishedTemplate()
+      const driftedLive = mockPublishedTemplate({
+        approvalGraph: {
+          nodes: pinned.approvalGraph.nodes.map((n) =>
+            n.key === 'approval_2' ? { ...n, name: 'LIVE_DRIFTED_STALE_NODE_NAME' } : n),
+          edges: pinned.approvalGraph.edges,
+        },
+      })
+      mockActiveTemplate.value = driftedLive // the LIVE (drifted) template
+      mockActiveVersion.value = { approvalGraph: pinned.approvalGraph } // the PINNED (frozen) version
+      await mountDetailView()
+
+      const text = container!.textContent ?? ''
+      expect(text).toContain('财务审批') // pinned name
+      expect(text).not.toContain('LIVE_DRIFTED_STALE_NODE_NAME') // drifted live name never leaks in
+    })
+
+    it('a condition branch ahead renders "按条件进入后续分支" honestly, without fabricating a branch', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval({ currentNodeKey: 'approval_1' })
+      mockActiveTemplate.value = mockPublishedTemplate({
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', name: '发起', config: {} },
+            { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeType: 'role', assigneeIds: ['role_manager'] } },
+            { key: 'cond_amount', type: 'condition', name: '金额分支', config: { branches: [{ edgeKey: 'e-high', rules: [] }], defaultEdgeKey: 'e-low' } },
+            { key: 'high', type: 'approval', name: '高额审批', config: { assigneeType: 'role', assigneeIds: ['role_finance_director'] } },
+            { key: 'low', type: 'approval', name: '低额审批', config: { assigneeType: 'user', assigneeIds: ['user_finance'] } },
+            { key: 'end', type: 'end', name: '结束', config: {} },
+          ],
+          edges: [
+            { key: 'e1', source: 'start', target: 'approval_1' },
+            { key: 'e2', source: 'approval_1', target: 'cond_amount' },
+            { key: 'e-high', source: 'cond_amount', target: 'high' },
+            { key: 'e-low', source: 'cond_amount', target: 'low' },
+            { key: 'e3', source: 'high', target: 'end' },
+            { key: 'e4', source: 'low', target: 'end' },
+          ],
+        },
+      })
+      await mountDetailView()
+
+      const items = Array.from(container!.querySelectorAll('[data-testid="approval-upcoming-node-item"]'))
+      expect(items).toHaveLength(1)
+      expect(items[0].textContent).toContain('金额分支')
+      expect(items[0].textContent).toContain('按条件进入后续分支')
+      expect(items[0].classList.contains('approval-detail__timeline-upcoming-item--conditional')).toBe(true)
+      // Neither branch is fabricated.
+      const text = container!.textContent ?? ''
+      expect(text).not.toContain('高额审批')
+      expect(text).not.toContain('低额审批')
+    })
+
+    it('does NOT add extra .el-timeline-item entries (history-item count assertions elsewhere stay accurate)', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      mockHistory.value = mockHistoryItems() // 2 history rows
+      mockActiveTemplate.value = mockPublishedTemplate()
+      await mountDetailView()
+
+      // The synthesized section renders (current handler + 2 upcoming nodes)...
+      expect(container!.querySelector('[data-testid="approval-current-handler-item"]')).toBeTruthy()
+      expect(container!.querySelectorAll('[data-testid="approval-upcoming-node-item"]').length).toBeGreaterThan(0)
+      // ...yet the real history item count (what `queryHistoryItems` / several OTHER guard
+      // specs rely on) is untouched.
+      expect(container!.querySelectorAll('.el-timeline-item').length).toBe(2)
     })
   })
 })

--- a/apps/web/tests/approval-upcoming-nodes.test.ts
+++ b/apps/web/tests/approval-upcoming-nodes.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph } from '../src/types/approval'
+import { buildUpcomingNodes } from '../src/approvals/upcomingNodes'
+
+// UX B2-08 — pure graph-walk contract for the approval detail view's "upcoming nodes" preview.
+// Mirrors the fixture style already used by `approval-graph-layout.test.ts`.
+
+const LINEAR: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeSources: [{ kind: 'direct_manager' }] } },
+    { key: 'approval_2', type: 'approval', name: '财务审批', config: { assigneeSources: [{ kind: 'static_user' as const, userIds: ['user_finance'] }] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e1', source: 'start', target: 'approval_1' },
+    { key: 'e2', source: 'approval_1', target: 'approval_2' },
+    { key: 'e3', source: 'approval_2', target: 'end' },
+  ],
+}
+
+// start → cond → {high, low} → join → end (a rejoin — same topology style as
+// `approval-graph-layout.test.ts`'s REJOIN fixture).
+const REJOIN: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', config: {} },
+    { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeSources: [{ kind: 'direct_manager' }] } },
+    { key: 'cond', type: 'condition', name: '金额分支', config: { branches: [{ edgeKey: 'e-high', rules: [] }], defaultEdgeKey: 'e-low' } },
+    { key: 'high', type: 'approval', name: '高额审批', config: { assigneeSources: [{ kind: 'dept_head' }] } },
+    { key: 'low', type: 'approval', name: '低额审批', config: { assigneeSources: [{ kind: 'requester' }] } },
+    { key: 'join', type: 'approval', name: '汇总审批', config: { assigneeSources: [{ kind: 'requester' }] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e-s', source: 'start', target: 'approval_1' },
+    { key: 'e-a-c', source: 'approval_1', target: 'cond' },
+    { key: 'e-high', source: 'cond', target: 'high' },
+    { key: 'e-low', source: 'cond', target: 'low' },
+    { key: 'e-h-j', source: 'high', target: 'join' },
+    { key: 'e-l-j', source: 'low', target: 'join' },
+    { key: 'e-j-e', source: 'join', target: 'end' },
+  ],
+}
+
+// start → a1 → par (fans into b1/b2) → join → end.
+const PARALLEL: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', config: {} },
+    { key: 'approval_1', type: 'approval', name: '前置审批', config: { assigneeSources: [{ kind: 'direct_manager' }] } },
+    { key: 'par', type: 'parallel', name: '并行网关', config: { branches: ['b1', 'b2'], joinMode: 'all', joinNodeKey: 'join' } },
+    { key: 'b1', type: 'approval', name: '法务审批', config: { assigneeSources: [{ kind: 'dept_head' }] } },
+    { key: 'b2', type: 'approval', name: '合规审批', config: { assigneeSources: [{ kind: 'dept_head' }] } },
+    { key: 'join', type: 'approval', name: '汇总审批', config: { assigneeSources: [{ kind: 'requester' }] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e-s', source: 'start', target: 'approval_1' },
+    { key: 'e-a-p', source: 'approval_1', target: 'par' },
+    { key: 'e-p-b1', source: 'par', target: 'b1' },
+    { key: 'e-p-b2', source: 'par', target: 'b2' },
+    { key: 'e-b1-j', source: 'b1', target: 'join' },
+    { key: 'e-b2-j', source: 'b2', target: 'join' },
+    { key: 'e-j-e', source: 'join', target: 'end' },
+  ],
+}
+
+describe('buildUpcomingNodes', () => {
+  it('linear chain: returns every node after current, in order, ending at `end`', () => {
+    const upcoming = buildUpcomingNodes(LINEAR, 'approval_1')
+    expect(upcoming.map((n) => n.key)).toEqual(['approval_2', 'end'])
+    expect(upcoming[0]).toEqual({
+      key: 'approval_2',
+      name: '财务审批',
+      assigneeSummary: '指定用户：user_finance',
+      isConditional: false,
+    })
+    expect(upcoming[1]).toEqual({
+      key: 'end',
+      name: '结束',
+      assigneeSummary: '流程结束',
+      isConditional: false,
+    })
+  })
+
+  it('current at the last approval node before end: walk still resolves through to `end`', () => {
+    const upcoming = buildUpcomingNodes(LINEAR, 'approval_2')
+    expect(upcoming.map((n) => n.key)).toEqual(['end'])
+  })
+
+  it('current AT end: nothing further (empty)', () => {
+    expect(buildUpcomingNodes(LINEAR, 'end')).toEqual([])
+  })
+
+  it('current key not present in the graph at all: empty, no throw', () => {
+    expect(buildUpcomingNodes(LINEAR, 'does_not_exist')).toEqual([])
+  })
+
+  it('condition node ahead: includes ONE honest entry, isConditional true, no fabricated branch', () => {
+    const upcoming = buildUpcomingNodes(REJOIN, 'approval_1')
+    expect(upcoming.map((n) => n.key)).toEqual(['cond'])
+    expect(upcoming[0]).toEqual({
+      key: 'cond',
+      name: '金额分支',
+      assigneeSummary: '按条件进入后续分支',
+      isConditional: true,
+    })
+    // Neither branch (`high`/`low`) — nor the rejoin (`join`) — is fabricated past the condition.
+    expect(upcoming.some((n) => n.key === 'high' || n.key === 'low' || n.key === 'join')).toBe(false)
+  })
+
+  it('current key IS the condition node itself: no single honest "next" to report (empty)', () => {
+    expect(buildUpcomingNodes(REJOIN, 'cond')).toEqual([])
+  })
+
+  it('parallel fan-out ahead: includes ONE honest entry, isConditional false, no fabricated branch', () => {
+    const upcoming = buildUpcomingNodes(PARALLEL, 'approval_1')
+    expect(upcoming.map((n) => n.key)).toEqual(['par'])
+    expect(upcoming[0]).toEqual({
+      key: 'par',
+      name: '并行网关',
+      assigneeSummary: '进入并行分支',
+      isConditional: false,
+    })
+    expect(upcoming.some((n) => n.key === 'b1' || n.key === 'b2' || n.key === 'join')).toBe(false)
+  })
+
+  it('a dangling edge (target not in graph.nodes) stops the walk without throwing', () => {
+    const dangling: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', name: '审批', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' },
+        { key: 'e2', source: 'approval_1', target: 'missing_node' },
+      ],
+    }
+    expect(buildUpcomingNodes(dangling, 'approval_1')).toEqual([])
+  })
+
+  it('a cycle does not infinite-loop (defensive visited guard)', () => {
+    const cyclic: ApprovalGraph = {
+      nodes: [
+        { key: 'a', type: 'approval', name: 'A', config: {} },
+        { key: 'b', type: 'approval', name: 'B', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'a', target: 'b' },
+        { key: 'e2', source: 'b', target: 'a' },
+      ],
+    }
+    const upcoming = buildUpcomingNodes(cyclic, 'a')
+    expect(upcoming.map((n) => n.key)).toEqual(['b'])
+  })
+
+  it('falls back to the node key when a node has no name', () => {
+    const noName: ApprovalGraph = {
+      nodes: [
+        { key: 'a1', type: 'approval', config: {} },
+        { key: 'a2', type: 'approval', config: {} },
+      ],
+      edges: [{ key: 'e1', source: 'a1', target: 'a2' }],
+    }
+    expect(buildUpcomingNodes(noName, 'a1')[0].name).toBe('a2')
+  })
+})


### PR DESCRIPTION
## Summary

UX 阶梯 §7 **parity 必需切片 B2-08**（Sonnet 代理实现 + Fable 审查）：发起人打开详情看不到「卡在谁那里 / 接下来到谁」——时间线只有历史动作。现在末尾合成「当前 + 后续」段：

- **当前处理人**：当前节点每个 active assignment 渲染「当前处理人：<name/id> · 已等待 <formatRelativeWait>」（仅 pending；已等待用 `updatedAt` 代理——DTO 无 per-assignment 时间戳）
- **后续节点**：从当前节点沿图走到 end，灰显每个后续节点名 + 受理来源摘要；condition/fan-out 诚实渲染「按条件进入后续分支」不编造路径；并行区（currentNodeKeys≥2）跳过后续走图（无单一起点）
- 新纯模块 `upcomingNodes.ts`（`buildUpcomingNodes`，bounded-pass 防环，镜像 graphLayout 风格）+ `assigneeSource.ts`（从 TemplateAuthoringView **原样抽取** private `assigneeSourceSummary` 到共享模块，覆盖全 8 种 assignee kind + legacy node shape 回退）

## 关键决策
- **钉住冻结版本**：`pinnedGraph` 优先 `templateStore.activeVersion`（既有但未用的 `loadVersion` API），live 模板仅回退（漂移风险注释）——「后续链」匹配实例实际将走的定义
- **自定义 rail 非 el-timeline-item**：既有守护 spec 断言精确 `.el-timeline-item` 计数量历史列表；自绘 dot+line 避免扰动

## Verification
- 新增 34 测试（upcomingNodes 10 / assigneeSource 18 / view 6）；rebase 后焦点 83/83 + vue-tsc 0
- TemplateAuthoringView 抽取为字节级等价（其既有 spec 原样绿）；预存失败 stash 复验非本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)