### PR TITLE
docs(env): scaffold A-5 one-tap card env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,15 @@ JWT_EXPIRES_IN=2h
 # DINGTALK_AUTH_AUTO_LINK_EMAIL=0
 # DINGTALK_AUTH_AUTO_PROVISION=0
 # DINGTALK_AUTH_REQUIRE_GRANT=0
+#
+# ---- Approval one-tap card (A-5 verification; design-lock #3594) --------------
+# APP_KEY/SECRET/AGENT_ID above ARE the same corp-app used to SEND the approval
+# action_card (asyncsend_v2). The card decision deep link additionally needs:
+# APPROVAL_CARD_LINK_SECRET — HMAC key signing the /m/approval-decision?d=&t= link.
+#   Random >= 32 bytes. MISSING => the card action fail-closes (nothing sent), by design.
+# APPROVAL_CARD_LINK_SECRET=change-me-random-32-plus-bytes
+# PUBLIC_APP_URL (or APP_BASE_URL) — externally reachable base the deep link is built on.
+# PUBLIC_APP_URL=https://app.example.com
 
 # =============================================================================
 # REDIS CACHE (Optional)


### PR DESCRIPTION
Documents APPROVAL_CARD_LINK_SECRET + PUBLIC_APP_URL in .env.example so the A-5 UAT env checklist is executable. Values are owner-provisioned; this only documents the keys + fail-closed-without-secret behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)