### PR TITLE
feat(web): B3-04 D-2 — real participant pickers replace hardcoded fake people (transfer/add-sign/user-field/delegation)

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -1085,3 +1085,54 @@ export async function dispatchAction(
   }
   return postApprovalJson(`/api/approvals/${id}/actions`, req)
 }
+
+// ---------------------------------------------------------------------------
+// B3-04 D-2 — participant directory picker (transfer / add-sign / fill-form user field /
+// delegation delegatee). Wraps the D-1 endpoint (#3664) GET /api/approvals/directory/users,
+// guarded server-side by the least-privilege union approvals:read|write|act — the SAME
+// endpoint any approval participant (not just a template author) can reach.
+//
+// Deliberately UNGATED by USE_MOCK, unlike almost everything else in this file: this is a
+// read-only, degrade-to-empty-safely lookup, not a CRUD path that needs a dev-mode fixture.
+// Every failure mode (network error, non-OK response, malformed JSON, malformed entries)
+// resolves to `[]` instead of throwing — a picker with no options degrades to manual entry,
+// it never crashes the surrounding form. This is a candidate directory, NOT an authorization
+// fact: the downstream dispatchAction/createApproval/delegation-create calls still gate the
+// real action against the real candidate.
+// ---------------------------------------------------------------------------
+export interface ApprovalDirectoryUser {
+  id: string
+  name: string
+  email: string
+}
+
+export async function searchApprovalDirectoryUsers(
+  q: string,
+  limit = 20,
+): Promise<ApprovalDirectoryUser[]> {
+  try {
+    const params = new URLSearchParams()
+    const normalized = q.trim()
+    if (normalized) params.set('q', normalized)
+    params.set('limit', String(limit))
+    const response = await apiFetch(`/api/approvals/directory/users?${params.toString()}`)
+    if (!response.ok) return []
+    const payload = await response.json().catch(() => null) as { users?: unknown } | null
+    if (!payload || !Array.isArray(payload.users)) return []
+    const users: ApprovalDirectoryUser[] = []
+    for (const entry of payload.users) {
+      if (!entry || typeof entry !== 'object') continue
+      const record = entry as Record<string, unknown>
+      const id = typeof record.id === 'string' ? record.id : ''
+      if (!id) continue
+      users.push({
+        id,
+        name: typeof record.name === 'string' ? record.name : '',
+        email: typeof record.email === 'string' ? record.email : '',
+      })
+    }
+    return users
+  } catch {
+    return []
+  }
+}

--- a/apps/web/src/approvals/components/ApprovalUserPicker.vue
+++ b/apps/web/src/approvals/components/ApprovalUserPicker.vue
@@ -1,0 +1,129 @@
+<template>
+  <el-select
+    :model-value="modelValue ?? undefined"
+    filterable
+    remote
+    clearable
+    :remote-method="handleSearch"
+    :loading="loading"
+    :disabled="disabled"
+    :placeholder="placeholder"
+    data-testid="approval-user-picker"
+    style="width: 100%"
+    @update:model-value="onSelect"
+    @visible-change="onVisibleChange"
+  >
+    <el-option
+      v-for="option in displayOptions"
+      :key="option.id"
+      :label="optionLabel(option)"
+      :value="option.id"
+    />
+  </el-select>
+</template>
+
+<script setup lang="ts">
+// B3-04 D-2 — the ONE reusable participant picker for real approval actors, replacing the
+// hardcoded 李四/王五/赵六/张三 fake option lists that previously shipped in the transfer /
+// add-sign / fill-form user field / delegation delegatee surfaces (a production correctness
+// defect — those ids were never real users). Hits the D-1 participant directory endpoint
+// (GET /api/approvals/directory/users, #3664) via `searchApprovalDirectoryUsers`, which any
+// approval participant can reach (approvals:read|write|act union), not just a template author.
+//
+// Modeled on the AUTHOR picker (TemplateAuthoringView's `approval-step-user-picker`, backed by
+// `useApprovalDirectory`): same filterable+remote+remote-method el-select shape, same
+// `visible-change` re-search-on-open, same "name · email" label fallback-to-id formatting. This
+// component is deliberately simpler (no composable, no ensure-visible-after-page reconciliation)
+// since it is single-select and none of its 4 call sites currently need to preserve a
+// prior-page selection across a re-search — the `initialOption` prop covers the one case that
+// legitimately needs a pre-existing label (a preselected id with a known display name).
+//
+// Kept dumb/pure: no store coupling, no side effects beyond the directory fetch. Emits the
+// picked id via standard v-model (`update:modelValue`) plus a richer `select` event carrying the
+// full { id, name, email } option — the latter lets a caller that manages its OWN list (e.g. the
+// add-sign "repeated pick" chips) show a friendly label without a second lookup.
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { searchApprovalDirectoryUsers, type ApprovalDirectoryUser } from '../api'
+
+export type ApprovalUserPickerOption = ApprovalDirectoryUser
+
+const props = withDefaults(defineProps<{
+  modelValue?: string | null
+  placeholder?: string
+  disabled?: boolean
+  /** Seeds a display label for a pre-existing modelValue before/without a matching fetched page (edit/preselected case). */
+  initialOption?: ApprovalUserPickerOption | null
+}>(), {
+  modelValue: null,
+  placeholder: '搜索用户名 / 邮箱 / ID',
+  disabled: false,
+  initialOption: null,
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | null): void
+  (e: 'select', option: ApprovalUserPickerOption | null): void
+}>()
+
+const fetchedOptions = ref<ApprovalUserPickerOption[]>([])
+const loading = ref(false)
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+// Keeps `initialOption` visible even after a search page that doesn't happen to include its id —
+// without this, a preselected value would render as a blank/id-only chip once any search runs.
+const displayOptions = computed<ApprovalUserPickerOption[]>(() => {
+  const initial = props.initialOption
+  if (!initial || !initial.id || fetchedOptions.value.some((option) => option.id === initial.id)) {
+    return fetchedOptions.value
+  }
+  return [initial, ...fetchedOptions.value]
+})
+
+function optionLabel(option: ApprovalUserPickerOption): string {
+  const primary = option.name?.trim() || option.id
+  const email = option.email?.trim()
+  return email ? `${primary} · ${email}` : primary
+}
+
+async function runSearch(query: string): Promise<void> {
+  loading.value = true
+  try {
+    fetchedOptions.value = await searchApprovalDirectoryUsers(query)
+  } catch {
+    // Defensive belt-and-suspenders: searchApprovalDirectoryUsers already never throws (it
+    // resolves to [] on any failure internally) — this catch only guards a misbehaving mock/DI
+    // in tests from ever reaching the caller.
+    fetchedOptions.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+// ~300ms debounce on typed queries (matches MetaPersonPicker/MetaLinkPicker's established
+// setTimeout convention in this codebase) — the initial page (onMounted) and the
+// re-search-on-open (visible-change) below run immediately, undebounced.
+function handleSearch(query: string): void {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => {
+    void runSearch(query)
+  }, 300)
+}
+
+function onVisibleChange(visible: boolean): void {
+  if (visible) void runSearch('')
+}
+
+function onSelect(value: unknown): void {
+  const id = typeof value === 'string' && value.length > 0 ? value : null
+  emit('update:modelValue', id)
+  emit('select', id ? displayOptions.value.find((option) => option.id === id) ?? null : null)
+}
+
+onMounted(() => {
+  void runSearch('')
+})
+
+onBeforeUnmount(() => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+})
+</script>

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -452,14 +452,11 @@
     >
       <el-form>
         <el-form-item label="转交给">
-          <el-select v-model="transferUserId" placeholder="选择用户" filterable style="width: 100%">
-            <template #prefix>
-              <el-icon><Search /></el-icon>
-            </template>
-            <el-option label="李四 (部门经理)" value="user_2" />
-            <el-option label="王五 (总监)" value="user_3" />
-            <el-option label="赵六 (VP)" value="user_4" />
-          </el-select>
+          <ApprovalUserPicker
+            :model-value="transferUserId || null"
+            placeholder="搜索并选择转交对象"
+            @update:model-value="transferUserId = $event ?? ''"
+          />
         </el-form-item>
         <el-form-item label="转交说明">
           <el-input
@@ -486,18 +483,26 @@
     >
       <el-form>
         <el-form-item label="加签人">
-          <el-select
-            v-model="addSignUserIds"
-            multiple
-            filterable
-            placeholder="选择加签审批人"
-            style="width: 100%"
-            data-testid="approval-add-sign-users"
-          >
-            <el-option label="李四 (部门经理)" value="user_2" />
-            <el-option label="王五 (总监)" value="user_3" />
-            <el-option label="赵六 (VP)" value="user_4" />
-          </el-select>
+          <!-- P1-B 加签 target picker: ApprovalUserPicker is single-select by design (v-model one
+               id), so multi-target add-sign uses a REPEATED-PICK pattern instead of a multi-select
+               dropdown — pick one, it lands as a removable chip below, the picker resets for the
+               next pick. `addSignUserIds` (the submit payload shape) is unchanged. -->
+          <div v-if="addSignUserIds.length > 0" class="approval-detail__add-sign-chips" data-testid="approval-add-sign-chips">
+            <el-tag
+              v-for="uid in addSignUserIds"
+              :key="uid"
+              closable
+              class="approval-detail__add-sign-chip"
+              @close="removeAddSignUser(uid)"
+            >
+              {{ addSignUserLabels[uid] || uid }}
+            </el-tag>
+          </div>
+          <ApprovalUserPicker
+            :model-value="addSignPickerValue"
+            placeholder="搜索并添加加签人"
+            @select="onAddSignUserSelected"
+          />
         </el-form-item>
         <el-form-item label="加签方式">
           <el-radio-group v-model="addSignMode" data-testid="approval-add-sign-mode">
@@ -663,7 +668,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import {
   ArrowLeft,
-  Search,
   Check,
   Close,
   Right,
@@ -677,7 +681,8 @@ import type { ApprovalActionType, ApprovalAssignmentDTO, ApprovalGraph } from '.
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
-import { markApprovalRead, remindApproval } from '../../approvals/api'
+import { markApprovalRead, remindApproval, type ApprovalDirectoryUser } from '../../approvals/api'
+import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
 import { useAuth } from '../../composables/useAuth'
 import { useFeatureFlags } from '../../stores/featureFlags'
 import { useMobileViewport } from '../../composables/useMobileViewport'
@@ -910,6 +915,12 @@ const returnTargetNodeKey = ref('')
 // P1-B 加签/减签 dialog state.
 const addSignDialogVisible = ref(false)
 const addSignUserIds = ref<string[]>([])
+// B3-04 D-2: the repeated-pick picker's OWN transient slot (always reset to null after each pick
+// so it is ready for the next one) + a display-name side map keyed by id (ApprovalUserPicker only
+// carries ids in `addSignUserIds` — the submit payload shape — so the chip labels need their own
+// lookup, populated from the picker's richer `select` event).
+const addSignPickerValue = ref<string | null>(null)
+const addSignUserLabels = ref<Record<string, string>>({})
 const addSignMode = ref<'before' | 'parallel'>('parallel')
 const reduceSignDialogVisible = ref(false)
 const reduceSignUserId = ref('')
@@ -1232,9 +1243,27 @@ async function submitTransfer() {
 
 function openAddSignDialog() {
   addSignUserIds.value = []
+  addSignUserLabels.value = {}
+  addSignPickerValue.value = null
   addSignMode.value = 'parallel'
   actionComment.value = ''
   addSignDialogVisible.value = true
+}
+
+// B3-04 D-2: repeated-pick handler for the add-sign target picker — append the picked id (no
+// duplicates), remember its display label for the chip, then reset the picker's transient slot
+// so it is ready for the next pick.
+function onAddSignUserSelected(option: ApprovalDirectoryUser | null): void {
+  if (!option) return
+  if (!addSignUserIds.value.includes(option.id)) {
+    addSignUserIds.value = [...addSignUserIds.value, option.id]
+    addSignUserLabels.value = { ...addSignUserLabels.value, [option.id]: option.name || option.id }
+  }
+  addSignPickerValue.value = null
+}
+
+function removeAddSignUser(id: string): void {
+  addSignUserIds.value = addSignUserIds.value.filter((existing) => existing !== id)
 }
 
 async function submitAddSign() {
@@ -1501,6 +1530,13 @@ onMounted(async () => {
 
 .approval-detail__quick-phrase-chip {
   cursor: pointer;
+}
+
+.approval-detail__add-sign-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .approval-detail__timeline-content {

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -135,21 +135,12 @@
               />
             </el-select>
 
-            <!-- user (placeholder picker) -->
-            <el-select
+            <!-- user (B3-04 D-2: real participant directory picker) -->
+            <ApprovalUserPicker
               v-else-if="field.type === 'user'"
-              v-model="formData[field.id]"
-              placeholder="选择用户"
-              filterable
-              style="width: 100%"
-            >
-              <template #prefix>
-                <el-icon><Search /></el-icon>
-              </template>
-              <el-option label="张三" value="user_1" />
-              <el-option label="李四" value="user_2" />
-              <el-option label="王五" value="user_3" />
-            </el-select>
+              :model-value="(formData[field.id] as string | null | undefined) ?? null"
+              @update:model-value="formData[field.id] = $event"
+            />
 
             <!-- detail / sub-form (明细): editable rows × leaf-column cells. `formData[field.id]`
                  is an array of row objects keyed by sub-field id; each cell reuses the matching
@@ -237,17 +228,11 @@
                         :value="opt.value"
                       />
                     </el-select>
-                    <el-select
+                    <ApprovalUserPicker
                       v-else-if="column.type === 'user'"
-                      v-model="row[column.id]"
-                      placeholder="选择用户"
-                      filterable
-                      style="width: 100%"
-                    >
-                      <el-option label="张三" value="user_1" />
-                      <el-option label="李四" value="user_2" />
-                      <el-option label="王五" value="user_3" />
-                    </el-select>
+                      :model-value="(row[column.id] as string | null | undefined) ?? null"
+                      @update:model-value="row[column.id] = $event"
+                    />
                     <el-input v-else v-model="row[column.id]" :placeholder="column.label" />
                     </template>
                   </template>
@@ -339,7 +324,7 @@ import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import type { FormInstance, FormRules } from 'element-plus'
-import { ArrowLeft, Search } from '@element-plus/icons-vue'
+import { ArrowLeft } from '@element-plus/icons-vue'
 import type { FormField, FormSchema } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
@@ -350,6 +335,7 @@ import { useAuth } from '../../composables/useAuth'
 import { useAutoSumTotal } from '../../approvals/useAutoSumTotal'
 import { isRowDerivationActive } from '../../approvals/lineDerivation'
 import { numberFieldProps } from '../../approvals/numberFieldProps'
+import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
 import {
   createEmptyDetailRow,
   isDetailCellVisible,

--- a/apps/web/src/views/approval/MyDelegationView.vue
+++ b/apps/web/src/views/approval/MyDelegationView.vue
@@ -39,7 +39,10 @@
     <el-dialog v-model="dialogOpen" title="新建我的委托" width="480px">
       <el-form label-width="92px">
         <el-form-item label="被委托人">
-          <el-input v-model="form.delegateeUserId" placeholder="被委托人用户 ID" data-testid="my-delegation-delegatee" />
+          <ApprovalUserPicker
+            :model-value="form.delegateeUserId || null"
+            @update:model-value="form.delegateeUserId = $event ?? ''"
+          />
         </el-form-item>
         <el-form-item label="范围">
           <el-select v-model="form.scope" data-testid="my-delegation-scope">
@@ -78,6 +81,7 @@ import {
   type OwnDelegationForm,
 } from '../../approvals/delegations'
 import { delegationDisplayStatus, DELEGATION_STATUS_TAG_TYPE } from '../../approvals/delegationStatus'
+import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
 
 const delegations = ref<DelegationRecord[]>([])
 const loading = ref(false)

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -4,6 +4,8 @@
  * Full lifecycle coverage: template -> publish -> initiate -> approve/reject/transfer/comment/revoke
  * Uses the same component-level E2E pattern as approval-center.spec.ts.
  */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
 import {
@@ -92,6 +94,26 @@ vi.mock('../src/approvals/store', () => ({
     executeAction: executeActionSpy,
   }),
 }))
+
+// ---------------------------------------------------------------------------
+// B3-04 D-2 — participant directory picker mock. ApprovalUserPicker (used by the transfer /
+// add-sign dialogs below) fetches its option list through `searchApprovalDirectoryUsers`; the
+// fixture below preserves the SAME ids (user_2/user_3/user_4) the deleted hardcoded 李四/王五/赵六
+// option lists used to hardcode, so the pre-existing `select.value = 'user_2'` / `'user_3'`
+// assertions further down keep working unchanged. `vi.importActual` keeps every OTHER export
+// (dispatchAction, ApprovalApiError, ...) real — only this one function is overridden.
+// ---------------------------------------------------------------------------
+vi.mock('../src/approvals/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/approvals/api')>('../src/approvals/api')
+  return {
+    ...actual,
+    searchApprovalDirectoryUsers: vi.fn().mockResolvedValue([
+      { id: 'user_2', name: '李四', email: '' },
+      { id: 'user_3', name: '王五', email: '' },
+      { id: 'user_4', name: '赵六', email: '' },
+    ]),
+  }
+})
 
 // ---------------------------------------------------------------------------
 // Template store mock
@@ -1174,11 +1196,11 @@ describe('Approval E2E Lifecycle', () => {
       await flushUi()
 
       const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="加签"]')!
-      // Multiple-select: selecting an option emits the array shape the v-model
-      // binds (the stub wraps the chosen value into a string[]). A single
-      // <select> can only hold one option value, so we pick one — enough to
-      // assert the array contract reaches the action.
-      const select = dialog.querySelector('[data-el-select-multiple="true"]') as HTMLSelectElement
+      // B3-04 D-2: add-sign now uses ApprovalUserPicker's REPEATED-PICK pattern (single-select,
+      // picking one appends it to `addSignUserIds` and resets the picker) instead of a multi-select
+      // dropdown. Picking one user is enough to assert the array contract (`targetUserIds`) reaches
+      // the action — the picker component itself owns the "pick several" UX (chips + reset).
+      const select = dialog.querySelector('[data-el-select]') as HTMLSelectElement
       select.value = 'user_2'
       select.dispatchEvent(new Event('change', { bubbles: true }))
       await flushUi()
@@ -1253,6 +1275,62 @@ describe('Approval E2E Lifecycle', () => {
         action: 'reduce_sign',
         targetAssignmentUserId: 'manager-9',
       }))
+    })
+  })
+
+  // =========================================================================
+  // B3-04 D-2 — real participant pickers replace the hardcoded fake people
+  // (production correctness defect: transfer/add-sign used to offer 李四/王五/赵六/张三,
+  // ids that were never real users).
+  // =========================================================================
+  describe('B3-04 D-2: real participant pickers (transfer / add-sign)', () => {
+    const DETAIL_VIEW_SRC = readFileSync(
+      join(__dirname, '../src/views/approval/ApprovalDetailView.vue'),
+      'utf8',
+    )
+
+    it('static tripwire: the view source no longer contains the hardcoded fake-people literals', () => {
+      for (const fakeName of ['李四', '王五', '赵六', '张三']) {
+        expect(DETAIL_VIEW_SRC, `should not contain fake fixture name "${fakeName}"`).not.toContain(fakeName)
+      }
+    })
+
+    it('the transfer dialog renders the real ApprovalUserPicker', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const transferBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '转交')
+      transferBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="转交审批"]')
+      expect(dialog?.querySelector('[data-testid="approval-user-picker"]')).toBeTruthy()
+    })
+
+    it('the add-sign dialog renders the real ApprovalUserPicker and accumulates a pick as a labeled chip', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const addBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '加签')
+      addBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="加签"]')!
+      expect(dialog.querySelector('[data-testid="approval-user-picker"]')).toBeTruthy()
+
+      const select = dialog.querySelector('[data-el-select]') as HTMLSelectElement
+      select.value = 'user_2'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi()
+
+      // Picked via the real directory fixture (id user_2 -> name 李四) — the chip shows the
+      // friendly name, not the raw id, proving the `select` event's richer option payload wired
+      // through to the label map.
+      expect(dialog.querySelector('[data-testid="approval-add-sign-chips"]')?.textContent).toContain('李四')
     })
   })
 

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -54,6 +54,25 @@ vi.mock('vue-router', async () => {
 })
 
 // ---------------------------------------------------------------------------
+// B3-04 D-2 — participant directory picker mock (see approval-e2e-lifecycle.spec.ts for the
+// fuller rationale). ApprovalUserPicker (used by the transfer dialog below) fetches its options
+// through `searchApprovalDirectoryUsers`; the fixture preserves the SAME id (user_3) the deleted
+// hardcoded 王五 option used to hardcode, so the existing `select.value = 'user_3'` assertion
+// keeps working unchanged.
+// ---------------------------------------------------------------------------
+vi.mock('../src/approvals/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/approvals/api')>('../src/approvals/api')
+  return {
+    ...actual,
+    searchApprovalDirectoryUsers: vi.fn().mockResolvedValue([
+      { id: 'user_2', name: '李四', email: '' },
+      { id: 'user_3', name: '王五', email: '' },
+      { id: 'user_4', name: '赵六', email: '' },
+    ]),
+  }
+})
+
+// ---------------------------------------------------------------------------
 // Approval store mock
 // ---------------------------------------------------------------------------
 const mockActiveApproval = ref<any>(null)

--- a/apps/web/tests/approvalMobileDetailActions.spec.ts
+++ b/apps/web/tests/approvalMobileDetailActions.spec.ts
@@ -40,6 +40,10 @@ vi.mock('../src/approvals/permissions', () => ({
 vi.mock('../src/approvals/api', () => ({
   markApprovalRead: vi.fn().mockResolvedValue({ ok: true }),
   remindApproval: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+  // B3-04 D-2: ApprovalUserPicker (transfer/add-sign dialogs) calls this on mount; this suite
+  // never opens those dialogs, but stubbing it keeps the eager mount-time search a clean resolved
+  // no-op instead of an unhandled real-fetch attempt.
+  searchApprovalDirectoryUsers: vi.fn().mockResolvedValue([]),
 }))
 
 // B1-01: mutable session identity — per-test control over requester/my-turn affordances.

--- a/apps/web/tests/approvalNewView.spec.ts
+++ b/apps/web/tests/approvalNewView.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
 import type { FormField, FormSchema } from '../src/types/approval'
@@ -46,6 +48,19 @@ vi.mock('../src/composables/useAuth', () => ({
     getCurrentUserId: vi.fn().mockResolvedValue('user_1'),
   }),
 }))
+
+// B3-04 D-2 — ApprovalUserPicker (the fill-form `user` field renderer, see the describe block
+// further below) fetches its options through `searchApprovalDirectoryUsers`. `vi.importActual`
+// keeps every other export (dispatchAction, createApproval, ...) real; this suite's OTHER tests
+// never render a `user`-type field so this mock is inert for them.
+const searchApprovalDirectoryUsersSpy = vi.fn().mockResolvedValue([])
+vi.mock('../src/approvals/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/approvals/api')>('../src/approvals/api')
+  return {
+    ...actual,
+    searchApprovalDirectoryUsers: (...args: unknown[]) => searchApprovalDirectoryUsersSpy(...args),
+  }
+})
 
 const mockActiveTemplate = ref<any>(null)
 const loadTemplateSpy = vi.fn().mockResolvedValue(undefined)
@@ -349,5 +364,31 @@ describe('ApprovalNewView — B2-02 number field props + B2-28 honest attachment
     // Positive control — the non-attachment fields DID make it through, so the missing key isn't
     // just an artifact of an empty/failed payload.
     expect(payload.formData).toMatchObject({ reason: '出差申请', leave_days: 1 })
+  })
+
+  // -------------------------------------------------------------------------
+  // B3-04 D-2 — the fill-form `user` field now uses the real ApprovalUserPicker (participant
+  // directory), replacing the hardcoded 张三/李四/王五 fake option list — a production correctness
+  // defect, since those ids were never real users.
+  // -------------------------------------------------------------------------
+  it('static tripwire: the view source no longer contains the hardcoded fake-people literals', () => {
+    const src = readFileSync(join(__dirname, '../src/views/approval/ApprovalNewView.vue'), 'utf8')
+    for (const fakeName of ['张三', '李四', '王五', '赵六']) {
+      expect(src, `should not contain fake fixture name "${fakeName}"`).not.toContain(fakeName)
+    }
+  })
+
+  it('renders the real ApprovalUserPicker for a `user`-type form field', async () => {
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_userfield',
+      formSchema: {
+        fields: [{ id: 'fld_assignee', type: 'user', label: '经办人', required: false } as FormField],
+      },
+    })
+    searchApprovalDirectoryUsersSpy.mockResolvedValue([{ id: 'u1', name: 'Alice', email: '' }])
+
+    await mountView()
+
+    expect(container!.querySelector('[data-testid="approval-user-picker"]')).toBeTruthy()
   })
 })

--- a/apps/web/tests/approvalUserPicker.spec.ts
+++ b/apps/web/tests/approvalUserPicker.spec.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp } from 'vue'
+
+// B3-04 D-2 — ApprovalUserPicker is the ONE reusable remote participant picker wired into
+// transfer / add-sign / fill-form user field / delegation delegatee, replacing the hardcoded
+// 李四/王五/赵六/张三 fake option lists (see approvalDetailViewFakePickers / approvalNewViewFakePickers
+// / myDelegationViewFakePickers site-level specs for the per-site tripwire + presence assertions).
+// This file covers the component's OWN contract in isolation.
+const searchSpy = vi.fn()
+vi.mock('../src/approvals/api', () => ({
+  searchApprovalDirectoryUsers: (...args: unknown[]) => searchSpy(...args),
+}))
+
+import ApprovalUserPicker from '../src/approvals/components/ApprovalUserPicker.vue'
+
+// Minimal el-select/el-option stubs exposing JUST the surface ApprovalUserPicker depends on:
+// `remote-method` invoked on typed input (a plain <input>, since a native <select> has no
+// search-box concept), `update:modelValue` on pick (a plain <select> change), `loading`/
+// `disabled`/`placeholder` as fallthrough-visible attrs. Real Element Plus renders far more
+// (popper, keyboard nav) — this stub only proves ApprovalUserPicker wires the CONTRACT correctly.
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: {
+    modelValue: { type: String, default: undefined },
+    loading: Boolean,
+    disabled: Boolean,
+    placeholder: String,
+    filterable: Boolean,
+    remote: Boolean,
+    clearable: Boolean,
+    remoteMethod: { type: Function, default: undefined },
+  },
+  emits: ['update:modelValue', 'visible-change'],
+  render() {
+    const remoteMethod = this.remoteMethod as ((q: string) => void) | undefined
+    return h('div', { 'data-el-select-stub': 'true' }, [
+      h('input', {
+        'data-testid': 'stub-query-input',
+        onInput: (e: Event) => remoteMethod?.((e.target as HTMLInputElement).value),
+      }),
+      h('select', {
+        'data-testid': 'stub-select',
+        value: this.modelValue ?? '',
+        onChange: (e: Event) => {
+          const value = (e.target as HTMLSelectElement).value
+          this.$emit('update:modelValue', value)
+        },
+      }, this.$slots.default?.()),
+    ])
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() { return h('option', { value: this.value }, this.label) },
+})
+
+async function flushUi(cycles = 5): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('ApprovalUserPicker', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    searchSpy.mockReset()
+    searchSpy.mockResolvedValue([])
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+    vi.useRealTimers()
+  })
+
+  async function mountPicker(props: Record<string, unknown> = {}) {
+    const events: { 'update:modelValue': unknown[]; select: unknown[] } = {
+      'update:modelValue': [],
+      select: [],
+    }
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h(ApprovalUserPicker, {
+            ...props,
+            'onUpdate:modelValue': (value: unknown) => events['update:modelValue'].push(value),
+            onSelect: (option: unknown) => events.select.push(option),
+          })
+      },
+    })
+    app = createApp(Host)
+    app.component('ElSelect', ElSelect)
+    app.component('ElOption', ElOption)
+    app.mount(container!)
+    await flushUi()
+    return events
+  }
+
+  it('renders with the canonical testid and shows the returned options on mount (eager empty-query search)', async () => {
+    searchSpy.mockResolvedValue([
+      { id: 'u1', name: 'Alice', email: 'a@x.io' },
+      { id: 'u2', name: 'Bob', email: '' },
+    ])
+    await mountPicker()
+
+    expect(container!.querySelector('[data-testid="approval-user-picker"]')).toBeTruthy()
+    expect(searchSpy).toHaveBeenCalledWith('')
+    const options = Array.from(container!.querySelectorAll('option'))
+    expect(options.map((o) => o.textContent)).toEqual(['Alice · a@x.io', 'Bob'])
+  })
+
+  it('debounces remote-method (~300ms): rapid typing fires exactly one search, for the LAST query', async () => {
+    vi.useFakeTimers()
+    await mountPicker()
+    searchSpy.mockClear() // drop the mount-time eager call; this test is about the typed path
+
+    const input = container!.querySelector('[data-testid="stub-query-input"]') as HTMLInputElement
+    input.value = 'a'
+    input.dispatchEvent(new Event('input'))
+    await vi.advanceTimersByTimeAsync(100)
+    input.value = 'al'
+    input.dispatchEvent(new Event('input'))
+    await vi.advanceTimersByTimeAsync(100)
+    input.value = 'ali'
+    input.dispatchEvent(new Event('input'))
+
+    // Still inside the 300ms settle window since the last keystroke — no search yet.
+    await vi.advanceTimersByTimeAsync(200)
+    expect(searchSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(150)
+    expect(searchSpy).toHaveBeenCalledTimes(1)
+    expect(searchSpy).toHaveBeenCalledWith('ali')
+  })
+
+  it('selecting an option emits the id via update:modelValue and the full option via select', async () => {
+    searchSpy.mockResolvedValue([{ id: 'u1', name: 'Alice', email: 'a@x.io' }])
+    const events = await mountPicker()
+
+    const select = container!.querySelector('[data-testid="stub-select"]') as HTMLSelectElement
+    select.value = 'u1'
+    select.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    expect(events['update:modelValue']).toEqual(['u1'])
+    expect(events.select).toEqual([{ id: 'u1', name: 'Alice', email: 'a@x.io' }])
+  })
+
+  it('api failure degrades to empty options — no throw, no crash', async () => {
+    searchSpy.mockRejectedValue(new Error('boom'))
+
+    await expect(mountPicker()).resolves.toBeTruthy()
+    expect(container!.querySelectorAll('option').length).toBe(0)
+    expect(container!.querySelector('[data-testid="approval-user-picker"]')).toBeTruthy()
+  })
+
+  it('initialOption stays visible until a fetched page includes a matching id', async () => {
+    searchSpy.mockResolvedValue([{ id: 'u9', name: 'Nina', email: '' }])
+    await mountPicker({ initialOption: { id: 'u-preset', name: 'Preset Person', email: '' } })
+
+    let labels = Array.from(container!.querySelectorAll('option')).map((o) => o.textContent)
+    expect(labels).toEqual(['Preset Person', 'Nina'])
+
+    // Once a fetched page DOES include the same id, the fetched (authoritative) entry wins —
+    // no duplicate option for that id.
+    searchSpy.mockResolvedValue([{ id: 'u-preset', name: 'Real Name', email: 'real@x.io' }])
+    const input = container!.querySelector('[data-testid="stub-query-input"]') as HTMLInputElement
+    input.value = 'preset'
+    input.dispatchEvent(new Event('input'))
+    await new Promise((resolve) => setTimeout(resolve, 320))
+    await flushUi()
+
+    labels = Array.from(container!.querySelectorAll('option')).map((o) => o.textContent)
+    expect(labels).toEqual(['Real Name · real@x.io'])
+  })
+})

--- a/apps/web/tests/myDelegationView.spec.ts
+++ b/apps/web/tests/myDelegationView.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, inject, nextTick, provide, reactive, type App as VueApp, type Slot } from 'vue'
 import type { DelegationRecord } from '../src/approvals/delegations'
@@ -28,6 +30,18 @@ vi.mock('element-plus', () => ({
   ElMessage: { success: vi.fn(), warning: vi.fn(), error: (...a: unknown[]) => messageErrorSpy(...a) },
   ElMessageBox: { confirm: (...a: unknown[]) => confirmSpy(...a) },
 }))
+
+// B3-04 D-2 — the 新建委托 dialog's delegatee field now uses the real ApprovalUserPicker
+// (participant directory), replacing the manual free-text id input. `vi.importActual` keeps every
+// other export (listDelegations, createDelegation, ...) real.
+const searchApprovalDirectoryUsersSpy = vi.fn().mockResolvedValue([])
+vi.mock('../src/approvals/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/approvals/api')>('../src/approvals/api')
+  return {
+    ...actual,
+    searchApprovalDirectoryUsers: (...args: unknown[]) => searchApprovalDirectoryUsersSpy(...args),
+  }
+})
 
 type ColumnRegistryEntry = { key: string; prop?: string; label?: string; defaultSlot?: Slot }
 type ColumnRegistry = { columns: ColumnRegistryEntry[]; register: (entry: ColumnRegistryEntry) => void }
@@ -248,5 +262,26 @@ describe('MyDelegationView (self-service 我的委托) — B2-05 status tag + di
     expect(confirmSpy).toHaveBeenCalledTimes(1)
     expect(disableOwnDelegationSpy).not.toHaveBeenCalled()
     expect(listOwnDelegationsSpy).toHaveBeenCalledTimes(1) // no reload — disable never ran
+  })
+
+  // ---------------------------------------------------------------------------
+  // B3-04 D-2 — the 新建委托 dialog's delegatee field now uses the real ApprovalUserPicker
+  // instead of a manual free-text id input.
+  // ---------------------------------------------------------------------------
+  it('the 新建委托 dialog renders the real ApprovalUserPicker for the delegatee field', async () => {
+    await mountView([])
+
+    const newButton = container!.querySelector('[data-testid="my-delegation-new"]') as HTMLButtonElement
+    newButton.click()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-user-picker"]')).toBeTruthy()
+  })
+
+  it('static tripwire: the view source contains no hardcoded fake-people literals', () => {
+    const src = readFileSync(join(__dirname, '../src/views/approval/MyDelegationView.vue'), 'utf8')
+    for (const fakeName of ['张三', '李四', '王五', '赵六']) {
+      expect(src, `should not contain fake fixture name "${fakeName}"`).not.toContain(fakeName)
+    }
   })
 })

--- a/apps/web/tests/searchApprovalDirectoryUsers.spec.ts
+++ b/apps/web/tests/searchApprovalDirectoryUsers.spec.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// B3-04 D-2 — unit coverage for the typed frontend wrapper around the D-1 participant directory
+// endpoint (GET /api/approvals/directory/users, #3664). Modeled on useApprovalDirectory.spec.ts's
+// coverage of the sibling AUTHOR-picker composable, but this function is deliberately UNGATED by
+// USE_MOCK (see the comment in approvals/api.ts) so it always exercises the real apiFetch path —
+// unlike most of that file's exports, which approvalApiErrorSurfacing.spec.ts notes always take
+// their mock branch under Vitest (import.meta.env.DEV is true). Mocks `../src/utils/api`'s
+// `apiFetch` directly, which is safe: every OTHER function in approvals/api.ts stays on its
+// USE_MOCK branch under Vitest and never reaches apiFetch, so this mock cannot affect them.
+const apiFetchMock = vi.fn()
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+import { searchApprovalDirectoryUsers } from '../src/approvals/api'
+
+function jsonResponse(body: unknown, init: { status?: number; ok?: boolean } = {}): Response {
+  const status = init.status ?? 200
+  return {
+    ok: init.ok ?? (status >= 200 && status < 300),
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+describe('searchApprovalDirectoryUsers', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('200 → maps the bare {users} shape to ApprovalDirectoryUser[]', async () => {
+    apiFetchMock.mockResolvedValue(
+      jsonResponse({ users: [{ id: 'u1', name: 'Alice', email: 'a@x.io' }] }),
+    )
+
+    const result = await searchApprovalDirectoryUsers('ali')
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    expect(apiFetchMock.mock.calls[0]?.[0]).toBe('/api/approvals/directory/users?q=ali&limit=20')
+    expect(result).toEqual([{ id: 'u1', name: 'Alice', email: 'a@x.io' }])
+  })
+
+  it('trims the query, omits `q` when blank, and always sends `limit`', async () => {
+    apiFetchMock.mockResolvedValue(jsonResponse({ users: [] }))
+
+    await searchApprovalDirectoryUsers('  ')
+
+    expect(apiFetchMock.mock.calls[0]?.[0]).toBe('/api/approvals/directory/users?limit=20')
+  })
+
+  it('honors a custom limit', async () => {
+    apiFetchMock.mockResolvedValue(jsonResponse({ users: [] }))
+
+    await searchApprovalDirectoryUsers('bob', 5)
+
+    expect(apiFetchMock.mock.calls[0]?.[0]).toBe('/api/approvals/directory/users?q=bob&limit=5')
+  })
+
+  it('drops malformed entries (no id) and coerces missing name/email', async () => {
+    apiFetchMock.mockResolvedValue(
+      jsonResponse({
+        users: [{ id: 'u1' }, { name: 'no-id' }, null, { id: 'u2', name: 'Bob', email: 'b@x.io' }],
+      }),
+    )
+
+    const result = await searchApprovalDirectoryUsers('x')
+
+    expect(result).toEqual([
+      { id: 'u1', name: '', email: '' },
+      { id: 'u2', name: 'Bob', email: 'b@x.io' },
+    ])
+  })
+
+  it('a non-OK response resolves to [] (never throws)', async () => {
+    apiFetchMock.mockResolvedValue(jsonResponse({ error: 'forbidden' }, { status: 403, ok: false }))
+
+    await expect(searchApprovalDirectoryUsers('x')).resolves.toEqual([])
+  })
+
+  it('a malformed (non-array `users`) body resolves to []', async () => {
+    apiFetchMock.mockResolvedValue(jsonResponse({ users: 'not-an-array' }))
+
+    await expect(searchApprovalDirectoryUsers('x')).resolves.toEqual([])
+  })
+
+  it('a JSON-parse failure resolves to []', async () => {
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => { throw new Error('Unexpected token') },
+    } as unknown as Response)
+
+    await expect(searchApprovalDirectoryUsers('x')).resolves.toEqual([])
+  })
+
+  it('a network/fetch rejection resolves to [] (never throws)', async () => {
+    apiFetchMock.mockRejectedValue(new Error('network down'))
+
+    await expect(searchApprovalDirectoryUsers('x')).resolves.toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

B3-04 **D-2**：前端四处选人器接 D-1 端点（#3664），**删除硬编码假人**——修正性缺陷（转交/加签/表单选人/委托自助在生产上实质不可用）。「目录端点半程」→ 完整。

- 新 `searchApprovalDirectoryUsers(q, limit)`（api.ts）：包 `GET /api/approvals/directory/users`（D-1）；**刻意不走 USE_MOCK**（该 flag 在 vitest 下恒 true 会使真 fetch 路径不可测）；三重 silent-degrade（`!ok`/`非数组`/`catch` → `[]`，picker 无选项即降级手动，绝不抛）
- 新 `ApprovalUserPicker.vue`：el-select filterable+remote + ~300ms 防抖 + 挂载/展开即搜 + `initialOption` 预选 + 单选，emit id
- 四处接线 + **假人全删**（`grep 李四/王五/赵六/张三` → 空，静态 tripwire 锁）：转交对话框、加签对话框（**改 chips 重复选保留多选能力**）、ApprovalNew user 字段（顶层 + 明细列单元格两处）、MyDelegation 委托人
- 动作调用形状零改——picker 只把假/手填 id 换成真实 id，下游 dispatchAction/createApproval/delegation-create 仍兜底校验（候选 ≠ 授权）

## Verification
- 新增 20 测试（api 8 / picker 5 / 四站点 7）；rebase 后焦点 77/77 + vue-tsc 0
- 全量 stash 复验：与 clean main 逐文件一致（预存 17/106 失败非本 PR），零回归
- 审查偏差核可：attrs-fallthrough 导致 data-testid 被父覆盖 → 改结构化 scope；add-sign 单选组件 + chips 重复选

🤖 Generated with [Claude Code](https://claude.com/claude-code)