### PR TITLE
feat(web): approval fill-form parity — submit-time flow preview + validation depth (UX B2-07/B2-15)

### DIFF
--- a/apps/web/src/approvals/detailField.ts
+++ b/apps/web/src/approvals/detailField.ts
@@ -1,5 +1,6 @@
 import type { FormField, FormFieldType, FormOption, FormSchema } from '../types/approval'
-import { getVisibleFormFields, pruneHiddenFormData } from './fieldVisibility'
+import { getVisibleFormFields, isEmptyValue, pruneHiddenFormData } from './fieldVisibility'
+import { isRowDerivationActive } from './lineDerivation'
 
 /**
  * Pure (Element-Plus-free) helpers for the `detail` / sub-form (明细/子表单) field type.
@@ -296,6 +297,55 @@ export function pruneHiddenFormDataWithDetail(
     result[key] = detailField ? pruneHiddenDetailRows(detailField, value) : value
   }
   return result
+}
+
+/**
+ * UX B2-15 (item 3) — client-side required-cell check for `detail` (子表) rows. `el-form`'s
+ * `rules` (see `ApprovalNewView.vue`'s `formRules`) only ever cover TOP-LEVEL fields; a detail
+ * column's `required: true` has never been enforced client-side — the fill view's `<el-table>` grid
+ * has no validation of its own — so a requester could submit a row missing a required cell and only
+ * find out from an unreadable backend 400. Pure + Element-Plus-free, mirroring this module's
+ * existing convention, so it is directly unit-testable without mounting the view.
+ *
+ * A required column is SKIPPED (never flagged) for a given row when:
+ *  - it is hidden FOR THAT ROW by its own `visibilityRule` (mirrors `isDetailCellVisible` — a
+ *    hidden cell can never be filled by the user, so it can never be "missing");
+ *  - it is an ACTIVELY-derived read-only target for that row (mirrors the view's
+ *    `isDetailDerivedColumnReadOnly`, via `isRowDerivationActive` from `lineDerivation.ts`) — the
+ *    user cannot type into it directly, so flagging it would block submission on a cell nobody can
+ *    fix; a real gap surfaces instead as its own violation on the empty OPERAND column(s).
+ *
+ * Message shape mirrors the audit's own example — `"报销明细" 第 2 行缺少 "金额"` — table label +
+ * 1-based row number + column label, specific enough to act on directly. Non-`detail` fields are
+ * ignored entirely (top-level required-ness is `el-form`'s job, not this function's).
+ */
+export function validateDetailRows(
+  formSchema: FormSchema,
+  formData: Record<string, unknown>,
+): string[] {
+  const violations: string[] = []
+  for (const field of formSchema.fields) {
+    if (field.type !== 'detail') continue
+    const columns = field.columns ?? []
+    const requiredColumns = columns.filter((column) => column.required)
+    if (requiredColumns.length === 0) continue
+    const rows = formData[field.id]
+    if (!Array.isArray(rows)) continue
+    const fieldLabel = field.label || field.id
+
+    rows.forEach((rawRow, index) => {
+      const row = rawRow && typeof rawRow === 'object' ? (rawRow as Record<string, unknown>) : {}
+      const visibleIds = new Set(visibleDetailColumnsForRow(columns, row).map((column) => column.id))
+      for (const column of requiredColumns) {
+        if (!visibleIds.has(column.id)) continue // hidden this row — can never be "missing"
+        if (isRowDerivationActive(columns, column, row)) continue // read-only derived target
+        if (isEmptyValue(row[column.id])) {
+          violations.push(`"${fieldLabel}" 第 ${index + 1} 行缺少 "${column.label || column.id}"`)
+        }
+      }
+    })
+  }
+  return violations
 }
 
 export interface DetailDisplayColumn {

--- a/apps/web/src/approvals/fieldVisibility.ts
+++ b/apps/web/src/approvals/fieldVisibility.ts
@@ -1,6 +1,9 @@
 import type { FormField, FormFieldVisibilityRule, FormSchema } from '../types/approval'
 
-function isEmptyValue(value: unknown): boolean {
+// Exported (UX B2-15) so `detailField.ts`'s `validateDetailRows` can reuse the exact same
+// empty-value semantics as visibility's `isEmpty`/`notEmpty` operators instead of redefining a
+// third copy alongside `formRules`' own inline version in `ApprovalNewView.vue`.
+export function isEmptyValue(value: unknown): boolean {
   return value === null
     || value === undefined
     || value === ''

--- a/apps/web/src/approvals/graphSummary.ts
+++ b/apps/web/src/approvals/graphSummary.ts
@@ -1,0 +1,38 @@
+import type { ApprovalGraph } from '../types/approval'
+import { buildUpcomingNodes, type UpcomingApprovalNode } from './upcomingNodes'
+
+/**
+ * UX B2-07 — one step in the submit-time flow preview (see `summarizeApprovalFlow` below).
+ * Structurally identical to `UpcomingApprovalNode` (UX B2-08) — an alias, not a new shape, so the
+ * two features stay byte-compatible for free and any future shared rendering needs no adapter.
+ */
+export type ApprovalFlowStep = UpcomingApprovalNode
+
+/**
+ * UX B2-07 — submit-time flow preview for the requester filling out `ApprovalNewView` ("会到谁
+ * 手上、几步" — before submitting, a requester has no way to see who will handle the request or
+ * how many steps it takes). Walks the WHOLE approval graph from its `start` node through to `end`,
+ * in order.
+ *
+ * DRY: `buildUpcomingNodes(graph, seedKey)` (UX B2-08, `upcomingNodes.ts`) already walks forward
+ * from a seed node — excluding the seed itself from the result, one hop at a time — honestly
+ * stopping (never fabricating a path) the instant a node has anything other than exactly one
+ * outgoing edge (a `condition` branch or a `parallel` fan-out), plus dangling-edge/cycle guards.
+ * That is *exactly* the walk this needs too, just seeded at the graph's `start` node instead of an
+ * in-flight instance's current node — so this is a thin wrapper reusing that walk verbatim, not a
+ * parallel implementation. `nodeAssigneeSourceSummary` (the per-node label, `assigneeSource.ts`) is
+ * therefore also reused transitively through `buildUpcomingNodes`, not re-imported here.
+ *
+ * The requester-facing "发起人" chip is rendered by the VIEW, not included in this list — the
+ * graph's `start` node carries no assignee summary of its own (`nodeAssigneeSourceSummary` returns
+ * `''` for a `start` node, which is exactly why `buildUpcomingNodes` never emits the seed itself).
+ *
+ * Returns `[]` (view renders nothing) when the graph has no `start` node, or the walk stops
+ * immediately (e.g. a single-node graph with no outgoing edge, or an empty graph) — never throws
+ * on a malformed/empty graph.
+ */
+export function summarizeApprovalFlow(graph: ApprovalGraph): ApprovalFlowStep[] {
+  const startKey = graph.nodes.find((node) => node.type === 'start')?.key
+  if (!startKey) return []
+  return buildUpcomingNodes(graph, startKey)
+}

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -38,6 +38,39 @@
           <p v-else class="approval-new__info-desc approval-new__info-desc--empty">暂无描述</p>
         </el-card>
 
+        <!-- UX B2-07: submit-time flow preview ("会到谁手上、几步") — read-only, derived from the
+             loaded template's approvalGraph, so a requester can see the flow BEFORE filling the
+             form in. STATIC per the loaded template only: no per-form-value resolution of which
+             conditional branch will actually be taken (that live-resolve is the gated B3-05
+             enhancement) — a condition/fan-out step honestly renders "按条件进入后续分支"
+             (see `summarizeApprovalFlow`) instead of fabricating a guessed path. -->
+        <el-card
+          v-if="flowPreviewSteps.length > 0"
+          class="approval-new__flow-preview"
+          shadow="never"
+          data-testid="approval-flow-preview"
+        >
+          <template #header>
+            <span class="approval-new__flow-preview-header">审批流程</span>
+          </template>
+          <div class="approval-new__flow-preview-row">
+            <span class="approval-new__flow-preview-chip approval-new__flow-preview-chip--requester">
+              发起人
+            </span>
+            <template v-for="step in flowPreviewSteps" :key="step.key">
+              <span class="approval-new__flow-preview-arrow">→</span>
+              <span
+                class="approval-new__flow-preview-chip"
+                :class="{ 'approval-new__flow-preview-chip--conditional': step.isConditional }"
+                data-testid="approval-flow-preview-step"
+              >
+                {{ step.name }}
+                <span class="approval-new__flow-preview-chip-summary">{{ step.assigneeSummary }}</span>
+              </span>
+            </template>
+          </div>
+        </el-card>
+
         <el-divider content-position="left">填写表单</el-divider>
 
         <el-form
@@ -340,7 +373,9 @@ import {
   createEmptyDetailRow,
   isDetailCellVisible,
   pruneHiddenFormDataWithDetail,
+  validateDetailRows,
 } from '../../approvals/detailField'
+import { summarizeApprovalFlow, type ApprovalFlowStep } from '../../approvals/graphSummary'
 
 const route = useRoute()
 const router = useRouter()
@@ -357,6 +392,14 @@ const visibleFields = computed(() => {
 })
 const visibleFieldIds = computed(() => visibleFields.value.map((field) => field.id))
 
+// UX B2-07: submit-time flow preview ("审批流程") — STATIC per the loaded template (walks the
+// whole graph from `start`; no per-form-value branch resolution, see the template comment above).
+const flowPreviewSteps = computed<ApprovalFlowStep[]>(() => {
+  const graph = template.value?.approvalGraph
+  if (!graph) return []
+  return summarizeApprovalFlow(graph)
+})
+
 // Detail-row auto-sum (design-lock #3189, Gate B): when the template declares amountConsistencyCheck the
 // total field is derived from the detail rows (read-only) — auto-fill (UX) + backend total-check
 // (tamper-proof). FE-only. See useAutoSumTotal for the watch + the backend-identical mirror.
@@ -370,7 +413,11 @@ const formRules = computed<FormRules>(() => {
     // there is no way for the user to satisfy it. Excluded from validation entirely.
     if (field.required && field.type !== 'attachment') {
       rules[field.id] = [
-        { required: true, message: `请填写${field.label}`, trigger: 'blur' },
+        // B2-15: `blur` alone never reliably fires for a select / date-picker (the user picks via
+        // a click in a popper, not a native blur on a text input), so a required select/date left
+        // unset could silently pass validation until submit-time. `change` catches those; `blur`
+        // stays too so leaving a text/textarea/number field empty validates without a submit click.
+        { required: true, message: `请填写${field.label}`, trigger: ['blur', 'change'] },
       ]
     }
   }
@@ -466,12 +513,35 @@ function buildSubmitFormData(): Record<string, unknown> {
   return stripAttachmentFields(template.value.formSchema, pruned)
 }
 
+// B2-15 (item 2): on a failed `el-form` validation, the first invalid field can already be
+// scrolled past on a long form, leaving no visual cue that IT is why submit did nothing beyond the
+// toast. Element Plus marks an invalid `<el-form-item>`'s root with `.is-error`. jsdom does not
+// implement `scrollIntoView` at all — optional-chaining the METHOD itself (not just the element)
+// is the no-op guard, mirroring `PlmProductPanel.vue`'s existing convention for the same gap.
+function scrollFirstErrorIntoView(): void {
+  const firstError = document.querySelector<HTMLElement>('.el-form-item.is-error')
+  firstError?.scrollIntoView?.({ behavior: 'smooth', block: 'center' })
+}
+
 async function handleSubmit() {
   if (formRef.value) {
     try {
       await formRef.value.validate()
     } catch {
       ElMessage.warning('请检查表单中的必填项')
+      scrollFirstErrorIntoView()
+      return
+    }
+  }
+
+  // B2-15 (item 3): `el-form`'s `rules` only ever cover TOP-LEVEL fields — a `detail` (子表)
+  // column's `required` has no client-side check of its own, so a missing required cell would
+  // otherwise only surface as an unreadable backend 400. Checked AFTER the top-level validate()
+  // above succeeds, so both validation layers must pass before anything is submitted.
+  if (template.value) {
+    const detailViolations = validateDetailRows(template.value.formSchema, formData)
+    if (detailViolations.length > 0) {
+      ElMessage.warning(detailViolations[0])
       return
     }
   }
@@ -598,6 +668,56 @@ watch([visibleFieldIds, template], () => {
 .approval-new__info-desc--empty {
   color: var(--el-text-color-placeholder, #c0c4cc);
   font-style: italic;
+}
+
+/* UX B2-07: submit-time flow preview — a muted, horizontal step/chip row (发起人 → node → node …),
+   deliberately NOT the authoring canvas's node-graph styling — this is a compact glance, not an
+   editing surface. */
+.approval-new__flow-preview {
+  margin-bottom: 8px;
+}
+
+.approval-new__flow-preview-header {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.approval-new__flow-preview-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.approval-new__flow-preview-chip {
+  display: inline-flex;
+  flex-direction: column;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--el-fill-color-light, #f5f7fa);
+  color: var(--el-text-color-regular, #606266);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.approval-new__flow-preview-chip--requester {
+  background: var(--el-color-primary-light-9, #ecf5ff);
+  color: var(--el-color-primary, #409eff);
+  font-weight: 500;
+}
+
+.approval-new__flow-preview-chip--conditional {
+  border: 1px dashed var(--el-color-warning, #e6a23c);
+}
+
+.approval-new__flow-preview-chip-summary {
+  font-size: 11px;
+  color: var(--el-text-color-placeholder, #909399);
+}
+
+.approval-new__flow-preview-arrow {
+  color: var(--el-text-color-placeholder, #c0c4cc);
+  font-size: 12px;
 }
 
 .approval-new__field-hint {

--- a/apps/web/tests/approval-detail-field.test.ts
+++ b/apps/web/tests/approval-detail-field.test.ts
@@ -18,6 +18,7 @@ import {
   pruneHiddenFormDataWithDetail,
   summaryFields,
   validateDetailColumnsDraft,
+  validateDetailRows,
   visibleDetailColumnsForRow,
   type DetailColumnDraft,
 } from '../src/approvals/detailField'
@@ -543,5 +544,128 @@ describe('formatSummaryLine (B2-01)', () => {
 
   it('returns an empty string for an empty array', () => {
     expect(formatSummaryLine([])).toBe('')
+  })
+})
+
+describe('validateDetailRows (UX B2-15 item 3 — client-side detail-row required check)', () => {
+  const expenseSchema: FormSchema = {
+    fields: [
+      { id: 'reason', type: 'text', label: '事由', required: true },
+      {
+        id: 'items',
+        type: 'detail',
+        label: '报销明细',
+        columns: [
+          { id: 'item_name', type: 'text', label: '项目', required: true },
+          { id: 'amount', type: 'number', label: '金额', required: true },
+          { id: 'note', type: 'text', label: '备注' }, // not required — never flagged
+        ],
+      },
+    ],
+  }
+
+  it('a missing required cell produces a violation with the table label, 1-based row #, and column label', () => {
+    const violations = validateDetailRows(expenseSchema, {
+      reason: '出差',
+      items: [{ item_name: '机票', amount: 1000 }, { item_name: '', amount: 500 }],
+    })
+    expect(violations).toEqual(['"报销明细" 第 2 行缺少 "项目"'])
+  })
+
+  it('every empty required cell across every row gets its own violation', () => {
+    const violations = validateDetailRows(expenseSchema, {
+      reason: '出差',
+      items: [{ item_name: '', amount: undefined }, { item_name: '酒店', amount: 300 }],
+    })
+    expect(violations).toEqual([
+      '"报销明细" 第 1 行缺少 "项目"',
+      '"报销明细" 第 1 行缺少 "金额"',
+    ])
+  })
+
+  it('all required cells filled -> no violations (note stays optional even when blank)', () => {
+    const violations = validateDetailRows(expenseSchema, {
+      reason: '出差',
+      items: [{ item_name: '机票', amount: 1000, note: '' }],
+    })
+    expect(violations).toEqual([])
+  })
+
+  it('a non-detail field (even top-level required) is never checked here — that is el-form’s job', () => {
+    const violations = validateDetailRows(expenseSchema, { reason: '', items: [] })
+    expect(violations).toEqual([])
+  })
+
+  it('no rows at all (empty array, or missing entirely) -> no violations', () => {
+    expect(validateDetailRows(expenseSchema, { reason: 'x', items: [] })).toEqual([])
+    expect(validateDetailRows(expenseSchema, { reason: 'x' })).toEqual([])
+    expect(validateDetailRows(expenseSchema, { reason: 'x', items: 'not-an-array' })).toEqual([])
+  })
+
+  it('a detail field with no required columns is skipped without inspecting rows', () => {
+    const noRequiredSchema: FormSchema = {
+      fields: [{ id: 'items', type: 'detail', label: '明细', columns: [{ id: 'note', type: 'text', label: '备注' }] }],
+    }
+    expect(validateDetailRows(noRequiredSchema, { items: [{ note: '' }, {}] })).toEqual([])
+  })
+
+  it('a cell hidden for THIS row by its own visibilityRule is never flagged, even if required and empty', () => {
+    const gatedSchema: FormSchema = {
+      fields: [{
+        id: 'items',
+        type: 'detail',
+        label: '明细',
+        columns: [
+          { id: 'kind', type: 'select', label: '类型', options: [{ label: '常规', value: 'normal' }, { label: '其他', value: 'other' }] },
+          { id: 'note', type: 'text', label: '备注', required: true, visibilityRule: { fieldId: 'kind', operator: 'eq', value: 'other' } },
+        ],
+      }],
+    }
+    // note is hidden for a 'normal' row -> not flagged despite required+empty; shown (and empty) for
+    // an 'other' row -> flagged.
+    const violations = validateDetailRows(gatedSchema, {
+      items: [{ kind: 'normal', note: undefined }, { kind: 'other', note: undefined }],
+    })
+    expect(violations).toEqual(['"明细" 第 2 行缺少 "备注"'])
+  })
+
+  it('an actively-derived (read-only) required column is never flagged — the real gap is its operand(s)', () => {
+    const derivedSchema: FormSchema = {
+      fields: [{
+        id: 'items',
+        type: 'detail',
+        label: '明细',
+        columns: [
+          { id: 'qty', type: 'number', label: '数量' },
+          { id: 'price', type: 'number', label: '单价' },
+          {
+            id: 'subtotal',
+            type: 'number',
+            label: '小计',
+            required: true,
+            props: { derivedFrom: { operandColumnIds: ['qty', 'price'], operation: 'product' } },
+          },
+        ],
+      }],
+    }
+    // subtotal is required but derivation-active (both operands visible) -> the user can't type
+    // into it directly, so it must never be the reported violation even though it's still empty.
+    const violations = validateDetailRows(derivedSchema, {
+      items: [{ qty: 2, price: 10, subtotal: undefined }],
+    })
+    expect(violations).toEqual([])
+  })
+
+  it('falls back to field.id / column.id in the message when label is empty', () => {
+    const noLabelSchema: FormSchema = {
+      fields: [{
+        id: 'items',
+        type: 'detail',
+        label: '',
+        columns: [{ id: 'col_a', type: 'text', label: '', required: true }],
+      }],
+    }
+    const violations = validateDetailRows(noLabelSchema, { items: [{ col_a: '' }] })
+    expect(violations).toEqual(['"items" 第 1 行缺少 "col_a"'])
   })
 })

--- a/apps/web/tests/approval-graph-summary.test.ts
+++ b/apps/web/tests/approval-graph-summary.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph } from '../src/types/approval'
+import { summarizeApprovalFlow } from '../src/approvals/graphSummary'
+
+// UX B2-07 — pure graph-walk contract for ApprovalNewView's submit-time flow preview.
+// `summarizeApprovalFlow` is a thin, start-seeded wrapper over the SAME walk
+// `buildUpcomingNodes` (UX B2-08) already implements — see `approval-upcoming-nodes.test.ts` for
+// that walk's own exhaustive coverage (dangling edges, cycles, no-name fallback, ...). Fixture
+// style mirrors that file; these tests focus on what's specific to seeding at `start`.
+
+const LINEAR: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeSources: [{ kind: 'direct_manager' }] } },
+    { key: 'approval_2', type: 'approval', name: '财务审批', config: { assigneeSources: [{ kind: 'static_user' as const, userIds: ['user_finance'] }] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e1', source: 'start', target: 'approval_1' },
+    { key: 'e2', source: 'approval_1', target: 'approval_2' },
+    { key: 'e3', source: 'approval_2', target: 'end' },
+  ],
+}
+
+// start → a1 → cond → {high, low} → join → end (a rejoin — same topology as
+// `approval-upcoming-nodes.test.ts`'s REJOIN fixture).
+const REJOIN: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', config: {} },
+    { key: 'approval_1', type: 'approval', name: '部门主管审批', config: { assigneeSources: [{ kind: 'direct_manager' }] } },
+    { key: 'cond', type: 'condition', name: '金额分支', config: { branches: [{ edgeKey: 'e-high', rules: [] }], defaultEdgeKey: 'e-low' } },
+    { key: 'high', type: 'approval', name: '高额审批', config: { assigneeSources: [{ kind: 'dept_head' }] } },
+    { key: 'low', type: 'approval', name: '低额审批', config: { assigneeSources: [{ kind: 'requester' }] } },
+    { key: 'join', type: 'approval', name: '汇总审批', config: { assigneeSources: [{ kind: 'requester' }] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e-s', source: 'start', target: 'approval_1' },
+    { key: 'e-a-c', source: 'approval_1', target: 'cond' },
+    { key: 'e-high', source: 'cond', target: 'high' },
+    { key: 'e-low', source: 'cond', target: 'low' },
+    { key: 'e-h-j', source: 'high', target: 'join' },
+    { key: 'e-l-j', source: 'low', target: 'join' },
+    { key: 'e-j-e', source: 'join', target: 'end' },
+  ],
+}
+
+describe('summarizeApprovalFlow', () => {
+  it('linear graph: walks start -> end in order, excluding the start node itself', () => {
+    const steps = summarizeApprovalFlow(LINEAR)
+    expect(steps.map((s) => s.key)).toEqual(['approval_1', 'approval_2', 'end'])
+    expect(steps[0]).toEqual({
+      key: 'approval_1',
+      name: '部门主管审批',
+      assigneeSummary: '直属上级',
+      isConditional: false,
+    })
+    expect(steps[2]).toEqual({
+      key: 'end',
+      name: '结束',
+      assigneeSummary: '流程结束',
+      isConditional: false,
+    })
+    expect(steps.some((s) => s.key === 'start')).toBe(false)
+  })
+
+  it('a condition node ahead: one honest entry, isConditional true, no fabricated branch', () => {
+    const steps = summarizeApprovalFlow(REJOIN)
+    expect(steps.map((s) => s.key)).toEqual(['approval_1', 'cond'])
+    expect(steps[1]).toEqual({
+      key: 'cond',
+      name: '金额分支',
+      assigneeSummary: '按条件进入后续分支',
+      isConditional: true,
+    })
+    // Neither branch (`high`/`low`) nor the rejoin (`join`) is fabricated past the condition.
+    expect(steps.some((s) => s.key === 'high' || s.key === 'low' || s.key === 'join')).toBe(false)
+  })
+
+  it('a single-node graph (start only, no edges) is safe: empty, no throw', () => {
+    const single: ApprovalGraph = { nodes: [{ key: 'start', type: 'start', config: {} }], edges: [] }
+    expect(summarizeApprovalFlow(single)).toEqual([])
+  })
+
+  it('an empty graph (no nodes at all) is safe: empty, no throw', () => {
+    expect(summarizeApprovalFlow({ nodes: [], edges: [] })).toEqual([])
+  })
+
+  it('a graph with no `start`-type node is safe: empty, no throw', () => {
+    const noStart: ApprovalGraph = {
+      nodes: [{ key: 'a', type: 'approval', name: 'A', config: {} }],
+      edges: [],
+    }
+    expect(summarizeApprovalFlow(noStart)).toEqual([])
+  })
+})

--- a/apps/web/tests/approvalNewView.spec.ts
+++ b/apps/web/tests/approvalNewView.spec.ts
@@ -2,11 +2,11 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
-import type { FormField, FormSchema } from '../src/types/approval'
+import type { ApprovalGraph, FormField, FormSchema } from '../src/types/approval'
 import { mockPendingApproval, mockPublishedTemplate } from './helpers/approval-test-fixtures'
 
 // ---------------------------------------------------------------------------
-// ApprovalNewView — focused coverage for two UX-audit fixes:
+// ApprovalNewView — focused coverage for UX-audit fixes:
 //
 //   - B2-02: `el-input-number` actually receives the schema field's declared `props`
 //     (min/max/step/precision) instead of silently ignoring them.
@@ -14,15 +14,37 @@ import { mockPendingApproval, mockPublishedTemplate } from './helpers/approval-t
 //     the real upload pipeline lands) instead of a fake `el-upload` that silently drops the
 //     File on submit; a `required` attachment must never block submission, and its key must
 //     never reach the create-approval payload.
+//   - B2-07: a read-only submit-time flow preview ("审批流程") derived from the loaded
+//     template's approvalGraph.
+//   - B2-15: validation depth — required rules trigger on blur+change, and a `detail` row
+//     missing a required cell aborts submit with a readable message instead of an unreadable
+//     backend 400.
 //
 // General render/submit/visibility-rule coverage for this view already lives in
 // approval-e2e-permissions.spec.ts / approval-e2e-lifecycle.spec.ts — this file only exercises
-// the two behaviors above, mounted with the same real-view + stubbed-Element-Plus pattern used
+// the behaviors above, mounted with the same real-view + stubbed-Element-Plus pattern used
 // by approvalMobileDetailActions.spec.ts.
 // ---------------------------------------------------------------------------
 
 const pushSpy = vi.fn().mockResolvedValue(undefined)
 const backSpy = vi.fn()
+
+// B2-15 — `ApprovalNewView.vue`'s only 'element-plus' VALUE import is `ElMessage` (the sibling
+// `FormInstance`/`FormRules` import is `import type`, erased at compile time, so mocking the
+// module doesn't touch it). Spied so the validation-depth tests can assert on the shown message
+// instead of depending on real Element Plus DOM/timer behavior under jsdom (mirrors the existing
+// `vi.mock('element-plus', ...)` pattern already used by approvalTemplateAuthoring.spec.ts /
+// approvalDelegationView.spec.ts).
+const messageWarningSpy = vi.fn()
+const messageSuccessSpy = vi.fn()
+const messageErrorSpy = vi.fn()
+vi.mock('element-plus', () => ({
+  ElMessage: {
+    success: (...args: unknown[]) => messageSuccessSpy(...args),
+    warning: (...args: unknown[]) => messageWarningSpy(...args),
+    error: (...args: unknown[]) => messageErrorSpy(...args),
+  },
+}))
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
@@ -94,6 +116,12 @@ function isEmptyValue(value: unknown): boolean {
     || (Array.isArray(value) && value.length === 0)
 }
 
+// B2-15 — captured on every render so the validation-depth tests can inspect the ACTUAL `rules`
+// object the view computed (in particular each rule's `trigger`), without the view exposing
+// `formRules` itself (it's local to `<script setup>`). Reset in each suite's `beforeEach`.
+type CapturedFormRule = { required?: boolean; message?: string; trigger?: string | string[] }
+let capturedFormRules: Record<string, CapturedFormRule[]> | undefined
+
 // A minimal but REAL rule-checking ElForm stub. `validate()` actually inspects the `:model`/`:rules`
 // props the view computed, instead of always resolving — a stub that always resolves would make "a
 // required attachment does not block submit" true for free, which would prove nothing about whether
@@ -112,7 +140,10 @@ const ElForm = defineComponent({
       return hasFailure ? Promise.reject(new Error('validation failed')) : Promise.resolve(true)
     }
     expose({ validate })
-    return () => h('form', { 'data-el-form': 'true' }, slots.default?.())
+    return () => {
+      capturedFormRules = props.rules as Record<string, CapturedFormRule[]> | undefined
+      return h('form', { 'data-el-form': 'true' }, slots.default?.())
+    }
   },
 })
 
@@ -390,5 +421,314 @@ describe('ApprovalNewView — B2-02 number field props + B2-28 honest attachment
     await mountView()
 
     expect(container!.querySelector('[data-testid="approval-user-picker"]')).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// UX B2-07 — submit-time flow preview ("审批流程"). Own describe block (own mount lifecycle) so
+// it doesn't disturb the B2-02/B2-28/D-2 suite above; reuses the SAME module-scoped stub
+// components (ElCard, ElForm, ...) and mocks already declared for this file.
+// ---------------------------------------------------------------------------
+describe('ApprovalNewView — B2-07 submit-time flow preview', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    submitApprovalSpy.mockReset()
+    submitApprovalSpy.mockResolvedValue(mockPendingApproval({ id: 'apv_flowpreview_1' }))
+    loadTemplateSpy.mockClear()
+    pushSpy.mockClear()
+    backSpy.mockClear()
+    messageWarningSpy.mockClear()
+    messageSuccessSpy.mockClear()
+    messageErrorSpy.mockClear()
+    capturedFormRules = undefined
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalNewView } = await import('../src/views/approval/ApprovalNewView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalNewView as any) })
+    app = createApp(Host)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElDivider', ElDivider)
+    app.component('ElEmpty', ElEmpty)
+    app.component('ElForm', ElForm)
+    app.component('ElFormItem', ElFormItem)
+    app.component('ElIcon', ElIcon)
+    app.component('ElInput', ElInput)
+    app.component('ElInputNumber', ElInputNumber)
+    app.component('ElOption', ElOption)
+    app.component('ElSelect', ElSelect)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElUpload', ElUpload)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  function flowPreview(): HTMLElement | null {
+    return container!.querySelector('[data-testid="approval-flow-preview"]')
+  }
+
+  function flowPreviewSteps(): HTMLElement[] {
+    return Array.from(container!.querySelectorAll('[data-testid="approval-flow-preview-step"]'))
+  }
+
+  it('renders 发起人 followed by each graph node in order, with its assignee summary', async () => {
+    // mockPublishedTemplate()'s default approvalGraph: start -> approval_1 (指定角色 role_manager)
+    // -> approval_2 (指定成员 user_finance) -> end — see approval-test-fixtures.ts.
+    mockActiveTemplate.value = mockPublishedTemplate({ id: 'tpl_flow_linear' })
+    await mountView()
+
+    const preview = flowPreview()
+    expect(preview).toBeTruthy()
+    expect(preview?.textContent).toContain('审批流程')
+    expect(preview?.textContent).toContain('发起人')
+
+    const steps = flowPreviewSteps()
+    expect(steps).toHaveLength(3)
+    expect(steps[0].textContent).toContain('部门主管审批')
+    expect(steps[0].textContent).toContain('指定角色：role_manager')
+    expect(steps[1].textContent).toContain('财务审批')
+    expect(steps[1].textContent).toContain('指定成员：user_finance')
+    expect(steps[2].textContent).toContain('结束')
+    expect(steps[2].textContent).toContain('流程结束')
+  })
+
+  it('a condition node ahead renders ONE honest "按条件进入后续分支" step — never a fabricated branch', async () => {
+    const conditionalGraph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'cond',
+          type: 'condition',
+          name: '金额分支',
+          config: { branches: [{ edgeKey: 'e-high', rules: [] }], defaultEdgeKey: 'e-low' },
+        },
+        { key: 'high', type: 'approval', name: '高额审批', config: { assigneeSources: [{ kind: 'dept_head' }] } },
+        { key: 'low', type: 'approval', name: '低额审批', config: { assigneeSources: [{ kind: 'requester' }] } },
+      ],
+      edges: [
+        { key: 'e-s', source: 'start', target: 'cond' },
+        { key: 'e-high', source: 'cond', target: 'high' },
+        { key: 'e-low', source: 'cond', target: 'low' },
+      ],
+    }
+    mockActiveTemplate.value = mockPublishedTemplate({ id: 'tpl_flow_cond', approvalGraph: conditionalGraph })
+    await mountView()
+
+    const steps = flowPreviewSteps()
+    expect(steps).toHaveLength(1)
+    expect(steps[0].textContent).toContain('金额分支')
+    expect(steps[0].textContent).toContain('按条件进入后续分支')
+    expect(steps[0].classList.toString()).toContain('approval-new__flow-preview-chip--conditional')
+
+    // Neither branch is fabricated into the preview — only the condition node itself is shown.
+    expect(flowPreview()?.textContent).not.toContain('高额审批')
+    expect(flowPreview()?.textContent).not.toContain('低额审批')
+  })
+
+  it('a template without a usable graph (empty approvalGraph) renders nothing, no crash', async () => {
+    const empty: ApprovalGraph = { nodes: [], edges: [] }
+    mockActiveTemplate.value = mockPublishedTemplate({ id: 'tpl_flow_empty', approvalGraph: empty })
+    await mountView()
+
+    expect(flowPreview()).toBeNull()
+    // Smoke check: the rest of the view still rendered fine (no crash from the empty-graph walk).
+    expect(container!.querySelector('.approval-new__header h1')?.textContent).toBe('发起审批')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// UX B2-15 — validation depth: required rules trigger on blur+change, a failed submit scrolls the
+// first error into view (jsdom-guarded no-op), and a `detail` row missing a required cell aborts
+// submit with a readable message instead of an unreadable backend 400. Own describe block (own
+// mount lifecycle), same reasoning as the B2-07 block above.
+// ---------------------------------------------------------------------------
+describe('ApprovalNewView — B2-15 validation depth', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    submitApprovalSpy.mockReset()
+    submitApprovalSpy.mockResolvedValue(mockPendingApproval({ id: 'apv_validation_1' }))
+    loadTemplateSpy.mockClear()
+    pushSpy.mockClear()
+    backSpy.mockClear()
+    messageWarningSpy.mockClear()
+    messageSuccessSpy.mockClear()
+    messageErrorSpy.mockClear()
+    capturedFormRules = undefined
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalNewView } = await import('../src/views/approval/ApprovalNewView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalNewView as any) })
+    app = createApp(Host)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElDivider', ElDivider)
+    app.component('ElEmpty', ElEmpty)
+    app.component('ElForm', ElForm)
+    app.component('ElFormItem', ElFormItem)
+    app.component('ElIcon', ElIcon)
+    app.component('ElInput', ElInput)
+    app.component('ElInputNumber', ElInputNumber)
+    app.component('ElOption', ElOption)
+    app.component('ElSelect', ElSelect)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElUpload', ElUpload)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  function submitButton(): HTMLButtonElement {
+    const btn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('提交审批'))
+    expect(btn).toBeTruthy()
+    return btn as HTMLButtonElement
+  }
+
+  function addRowButton(): HTMLButtonElement {
+    const btn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('添加一行'))
+    expect(btn).toBeTruthy()
+    return btn as HTMLButtonElement
+  }
+
+  // `items.defaultValue`, when present, seeds `formData.items` directly on mount (bypasses the
+  // add-row button) — used to get a FULLY FILLED detail row without depending on the detail
+  // table's per-row scoped-slot cell inputs, which this file's ElTableColumn stub does not render
+  // (it only renders a placeholder per column definition — see ElTableColumn above). The
+  // add-row button itself is a plain sibling `<el-button>`, NOT inside that scoped slot, so it
+  // stays real/clickable regardless.
+  function formSchemaWithRequiredDetailColumns(itemsDefaultValue?: unknown): FormSchema {
+    return {
+      fields: [
+        { id: 'reason', type: 'text', label: '事由', required: true, defaultValue: '出差申请' } as FormField,
+        {
+          id: 'items',
+          type: 'detail',
+          label: '报销明细',
+          columns: [
+            { id: 'item_name', type: 'text', label: '项目', required: true },
+            { id: 'amount_text', type: 'text', label: '金额说明', required: true },
+          ],
+          ...(itemsDefaultValue !== undefined ? { defaultValue: itemsDefaultValue } : {}),
+        } as FormField,
+      ],
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // item 1 — required rules trigger on blur AND change
+  // -------------------------------------------------------------------------
+  it('required rules carry trigger: ["blur", "change"] (B2-28 still excludes attachment entirely)', async () => {
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_trigger',
+      formSchema: {
+        fields: [
+          { id: 'reason', type: 'text', label: '事由', required: true, defaultValue: '出差申请' } as FormField,
+          { id: 'leave_days', type: 'number', label: '请假天数', required: true, defaultValue: 1 } as FormField,
+          { id: 'proof', type: 'attachment', label: '证明材料', required: true } as FormField,
+        ],
+      },
+    })
+    await mountView()
+
+    expect(capturedFormRules?.reason?.[0]?.trigger).toEqual(['blur', 'change'])
+    expect(capturedFormRules?.leave_days?.[0]?.trigger).toEqual(['blur', 'change'])
+    // B2-28: attachment stays excluded from `rules` entirely — never gets a trigger at all.
+    expect(capturedFormRules?.proof).toBeUndefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // item 2 — failed submit does not crash under jsdom (scrollIntoView guarded no-op)
+  // -------------------------------------------------------------------------
+  it('a failed top-level validation shows the warning, does not submit, and does not throw (jsdom scrollIntoView guard)', async () => {
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_missing_reason',
+      formSchema: {
+        fields: [{ id: 'reason', type: 'text', label: '事由', required: true } as FormField], // no defaultValue -> empty
+      },
+    })
+    await mountView()
+
+    // No `.el-form-item.is-error` exists under this file's stubs (ElFormItem sets a
+    // `data-el-form-item` attribute, not a real `.el-form-item` class), so `scrollFirstErrorIntoView`
+    // exercises its "no element found" no-op branch here; jsdom's separate "element found but
+    // `scrollIntoView` is not a function" gap is guarded by the same optional-chained call. Either
+    // way, a throw inside the `catch` block would surface as a rejected/errored `handleSubmit` —
+    // this test's real assertion is that neither happens: the flow completes, warns, and never calls
+    // `submitApproval`.
+    submitButton().click()
+    await flushUi()
+
+    expect(submitApprovalSpy).not.toHaveBeenCalled()
+    expect(messageWarningSpy).toHaveBeenCalledWith('请检查表单中的必填项')
+  })
+
+  // -------------------------------------------------------------------------
+  // item 3 — detail-row required-cell check
+  // -------------------------------------------------------------------------
+  it('a submit with a missing required detail cell aborts: warns, does not call store.submitApproval', async () => {
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_detail_missing',
+      formSchema: formSchemaWithRequiredDetailColumns(),
+    })
+    await mountView()
+
+    addRowButton().click()
+    await flushUi()
+
+    submitButton().click()
+    await flushUi()
+
+    expect(submitApprovalSpy).not.toHaveBeenCalled()
+    expect(messageWarningSpy).toHaveBeenCalledWith('"报销明细" 第 1 行缺少 "项目"')
+  })
+
+  it('a valid submit (detail row fully filled) proceeds — does not clobber D-2/B2-28 submit path', async () => {
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_detail_filled',
+      formSchema: formSchemaWithRequiredDetailColumns([{ item_name: '机票', amount_text: '合计 1000 元' }]),
+    })
+    await mountView()
+
+    submitButton().click()
+    await flushUi()
+
+    expect(messageWarningSpy).not.toHaveBeenCalled()
+    expect(submitApprovalSpy).toHaveBeenCalledTimes(1)
+    const payload = submitApprovalSpy.mock.calls[0][0]
+    expect(payload.formData.items).toEqual([{ item_name: '机票', amount_text: '合计 1000 元' }])
   })
 })


### PR DESCRIPTION
## Summary

UX 阶梯 §7 **parity 切片 B2-07 + B2-15**（Sonnet 代理实现 + Fable 审查）——填单面两刀。

### B2-07 提交前流程链
- 发起人填单前看得到「会到谁手上、几步」。新 `graphSummary.ts` 的 `summarizeApprovalFlow(graph)` = **一行 DRY 包 `buildUpcomingNodes(graph, startKey)`**（复用 B2-08 图遍历，仅改从 start 起播），零重复；condition/fan-out 诚实「按条件进入后续分支」；`data-testid="approval-flow-preview"`，静态（动态真人=gated B3-05）
### B2-15 校验深度
- required 加 `trigger:['blur','change']`；提交失败 scroll-to-first-error（jsdom guard）；新 `validateDetailRows` 明细行必填（「"报销明细" 第 2 行缺少 "金额"」），**派生只读列豁免**（防自动小计列误阻）

## Verification
- 新增 21 测试（graphSummary 5 / validateDetailRows 9 / view 7）；rebase 后焦点绿 + vue-tsc 0
- **无 clobber**：D-2 用户选人器 + B2-28 附件路径字节级不变，守护测试原样绿（假人仍 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)