### PR TITLE
feat(web): approval resubmit — prefill a new draft from a rejected instance (UX B2-13)

### DIFF
--- a/apps/web/src/approvals/prefillFromSnapshot.ts
+++ b/apps/web/src/approvals/prefillFromSnapshot.ts
@@ -1,0 +1,89 @@
+import type { FormFieldType, FormSchema } from '../types/approval'
+
+/**
+ * Runtime shape check for "does this stored snapshot value still fit the CURRENT field's declared
+ * type" — the sole "compatible type" gate `prefillFromSnapshot` (below) relies on. `attachment` is
+ * always incompatible (B2-28 stopgap — no working uploader yet, nothing legitimate to prefill);
+ * `detail`/`multi-select` require an array (the row-array / multi-value shape); `date`/`datetime`
+ * require a value `Date` can actually parse; everything else requires the exact JS primitive type
+ * the corresponding fill-view widget binds via `v-model`. `null`/`undefined` are never compatible —
+ * there is nothing to prefill for an unset value; the field just keeps whatever `ApprovalNewView`'s
+ * own default-seeding already gave it.
+ */
+function isCompatibleValue(type: FormFieldType, value: unknown): boolean {
+  if (value === null || value === undefined) return false
+  switch (type) {
+    case 'attachment':
+      return false
+    case 'text':
+    case 'textarea':
+    case 'user':
+      return typeof value === 'string'
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value)
+    case 'date':
+    case 'datetime':
+      if (typeof value !== 'string' && typeof value !== 'number') return false
+      return !Number.isNaN(new Date(value).getTime())
+    case 'select':
+      return typeof value === 'string' || typeof value === 'number'
+    case 'multi-select':
+      return Array.isArray(value)
+    case 'detail':
+      return Array.isArray(value)
+    default:
+      return false
+  }
+}
+
+/**
+ * UX B2-13 (再次提交) — drift-safe prefill for a FRESH `ApprovalNewView` draft, seeded from a
+ * REJECTED/REVOKED/CANCELLED instance's `formSnapshot` (the requester's own prior submission; see
+ * `ApprovalDetailView`'s 「再次提交」button). The reject→fix→resubmit loop is the requester's
+ * biggest-friction moment today — they hand-retype the whole form — so this prefills whatever of
+ * the old answer still safely applies.
+ *
+ * Deliberately takes only the CURRENT template's `formSchema` (never the source instance's own
+ * possibly-frozen one) plus the raw snapshot values — the source's original field TYPES are not
+ * needed: "compatible type" is decided by checking whether the stored raw value's runtime SHAPE
+ * still fits what the CURRENT field declares (`isCompatibleValue` above). A field the author
+ * DROPPED since the original submission is skipped for free (this only ever looks up ids that
+ * exist in the CURRENT schema); a field the author RETYPED (e.g. select → number) is caught
+ * because the old stored value's shape no longer matches the new type's expectation. Either way:
+ * no crash, no bad value ever lands in the fresh draft's `formData`.
+ *
+ * `attachment` fields are ALWAYS skipped — B2-28 disabled attachment authoring entirely, so there
+ * is nothing legitimate to prefill there regardless of the stored value.
+ *
+ * `detail` (子表/明细) fields prefill their WHOLE row array verbatim when the field still exists as
+ * `type: 'detail'` and the stored value is an array — per-row/per-column drift is already handled
+ * downstream for free by the existing submit-time pruning (`pruneHiddenFormDataWithDetail` /
+ * `pruneHiddenDetailRow` in `detailField.ts`, driven by the CURRENT `columns`), so this does not
+ * duplicate that column-level filtering here.
+ *
+ * Pure — no Vue/Element Plus dependency, no reads of `route`/stores — so the caller merges the
+ * result into its own reactive `formData` (e.g. `Object.assign(formData, prefillFromSnapshot(...))`).
+ * Returns `{}` when `snapshot` is missing/empty/not-an-object, or when the schema has no fields —
+ * the caller can treat an empty result as "nothing to prefill, no notice to show".
+ */
+export function prefillFromSnapshot(
+  formSchema: FormSchema,
+  snapshot: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  if (!snapshot || typeof snapshot !== 'object') return result
+  const fields = formSchema?.fields
+  if (!Array.isArray(fields)) return result
+
+  for (const field of fields) {
+    // Not in the snapshot at all — either the original submission left it unset, or (irrelevant
+    // here either way) it never existed back then. Nothing to carry over.
+    if (!Object.prototype.hasOwnProperty.call(snapshot, field.id)) continue
+    const value = snapshot[field.id]
+    // Dropped-from-current-schema fields never reach this loop at all (it only iterates the
+    // CURRENT schema's fields); a RETYPED field is caught here instead, by shape.
+    if (!isCompatibleValue(field.type, value)) continue
+    result[field.id] = value
+  }
+  return result
+}

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -377,14 +377,25 @@
             <el-button plain :loading="store.loading" @click="openCommentDialog">评论</el-button>
           </div>
         </template>
-        <el-alert
-          v-else
-          title="该审批已结束"
-          type="info"
-          show-icon
-          :closable="false"
-          style="flex: 1"
-        />
+        <template v-else>
+          <el-alert
+            title="该审批已结束"
+            type="info"
+            show-icon
+            :closable="false"
+            style="flex: 1"
+          />
+          <!-- UX B2-13: 再次提交 — own+terminal (rejected/revoked/cancelled) only; see
+               `canResubmit`/`handleResubmit`. -->
+          <el-button
+            v-if="canResubmit"
+            type="primary"
+            data-testid="approval-resubmit-button"
+            @click="handleResubmit"
+          >
+            再次提交
+          </el-button>
+        </template>
       </div>
     </div>
 
@@ -768,6 +779,20 @@ const isRequester = computed(() => {
   return !!currentUserId.value && approval.value?.requester?.id === currentUserId.value
 })
 
+// UX B2-13 (再次提交) — the reject→fix→resubmit loop is a requester's biggest-friction moment
+// today (hand-retype the whole form). Eligible ONLY for the CURRENT USER'S OWN instance (reuses
+// `isRequester` above) in a TERMINAL state that means "this didn't go through and nothing
+// downstream is acting on it any more": rejected / revoked / cancelled. `approved` is deliberately
+// EXCLUDED — it already succeeded, there is nothing to fix/resubmit. An instance with no
+// `templateId` (e.g. synced in from an external source system) has no fill-form to route back to,
+// so it is excluded too — fail-closed rather than a dead button.
+const RESUBMIT_ELIGIBLE_STATUSES = new Set(['rejected', 'revoked', 'cancelled'])
+const canResubmit = computed(() => {
+  const detail = approval.value
+  if (!detail || !isRequester.value || !detail.templateId) return false
+  return RESUBMIT_ELIGIBLE_STATUSES.has(detail.status)
+})
+
 // B1-01: "等待你处理" cue — the reader holds a still-active user assignment at the current
 // node (or any branch of a parallel region). Mirrors, not replaces, the server-side action gate.
 const isMyTurn = computed(() => {
@@ -1137,6 +1162,20 @@ function retryLoad() {
   const id = route.params.id as string
   store.error = null
   Promise.all([store.loadDetail(id), store.loadHistory(id)])
+}
+
+// UX B2-13 (再次提交) — route to the SAME template's fill page, carrying this instance's id as
+// `fromInstance` so `ApprovalNewView` can load it and prefill the fresh draft (see
+// `prefillFromSnapshot`). Does NOT submit anything itself — the requester still reviews + submits
+// the new draft normally (B2-15 validation, B2-07 preview, etc. all still apply).
+function handleResubmit(): void {
+  const detail = approval.value
+  if (!detail?.templateId) return
+  router.push({
+    name: 'approval-create',
+    params: { templateId: detail.templateId },
+    query: { fromInstance: detail.id },
+  })
 }
 
 function openActionDialog(action: 'approve' | 'reject') {

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -22,7 +22,7 @@
       </template>
     </el-alert>
 
-    <div v-loading="templateStore.loading || approvalStore.loading" class="approval-new__content-wrapper">
+    <div v-loading="templateStore.loading || approvalStore.loading || prefillLoading" class="approval-new__content-wrapper">
       <div v-if="template" class="approval-new__body">
         <!-- Template info card -->
         <el-card class="approval-new__info-card" shadow="never">
@@ -37,6 +37,20 @@
           <p v-if="template.description" class="approval-new__info-desc">{{ template.description }}</p>
           <p v-else class="approval-new__info-desc approval-new__info-desc--empty">暂无描述</p>
         </el-card>
+
+        <!-- UX B2-13 (再次提交): shown only once a `?fromInstance=` prefill actually applied at
+             least one field (see `applyResubmitPrefill`) — a requester fixing a rejected/revoked/
+             cancelled submission should know the form was pre-populated, not silently discover it. -->
+        <el-alert
+          v-if="prefillNoticeVisible"
+          title="已从上一次申请预填，请检查后提交"
+          type="info"
+          show-icon
+          :closable="true"
+          class="approval-new__prefill-notice"
+          data-testid="approval-prefill-notice"
+          @close="prefillNoticeVisible = false"
+        />
 
         <!-- UX B2-07: submit-time flow preview ("会到谁手上、几步") — read-only, derived from the
              loaded template's approvalGraph, so a requester can see the flow BEFORE filling the
@@ -376,6 +390,8 @@ import {
   validateDetailRows,
 } from '../../approvals/detailField'
 import { summarizeApprovalFlow, type ApprovalFlowStep } from '../../approvals/graphSummary'
+import { getApproval } from '../../approvals/api'
+import { prefillFromSnapshot } from '../../approvals/prefillFromSnapshot'
 
 const route = useRoute()
 const router = useRouter()
@@ -385,6 +401,13 @@ const { canWrite } = useApprovalPermissions()
 
 const formRef = ref<FormInstance>()
 const formData = reactive<Record<string, unknown>>({})
+// UX B2-13 (再次提交): true once a `?fromInstance=` prefill actually applied at least one field —
+// see `applyResubmitPrefill` below. Drives the "已从上一次申请预填" notice.
+const prefillNoticeVisible = ref(false)
+// UX B2-13: folded into the SAME `v-loading` overlay as the template/submit loads (below) so the
+// form can't be interacted with — and submitted un-prefilled — during the brief window between
+// the template finishing its own load and the source-instance prefill fetch resolving.
+const prefillLoading = ref(false)
 const template = computed(() => templateStore.activeTemplate)
 const visibleFields = computed(() => {
   if (!template.value) return []
@@ -573,6 +596,33 @@ async function handleSubmit() {
   }
 }
 
+// UX B2-13 (再次提交) — `?fromInstance=<id>` (set by `ApprovalDetailView`'s 「再次提交」button)
+// carries a REJECTED/REVOKED/CANCELLED source instance to prefill this fresh draft from, so a
+// requester fixing a rejected submission doesn't have to retype the whole form. Runs AFTER the
+// defaultValue seeding in `onMounted` below so a prefilled value always wins over a field's own
+// `defaultValue`. `prefillFromSnapshot`'s drift guard (dropped/retyped fields, no attachments) is
+// the ONLY gate — no crash / bad value regardless of how much the template changed since the
+// source was submitted. Best-effort: a failed source-instance fetch never blocks filling the form
+// fresh — it just silently skips the prefill.
+async function applyResubmitPrefill(): Promise<void> {
+  if (!template.value) return
+  const fromInstance = route.query.fromInstance
+  const sourceId = typeof fromInstance === 'string' ? fromInstance : null
+  if (!sourceId) return
+  prefillLoading.value = true
+  try {
+    const source = await getApproval(sourceId)
+    const prefilled = prefillFromSnapshot(template.value.formSchema, source.formSnapshot)
+    if (Object.keys(prefilled).length === 0) return
+    Object.assign(formData, prefilled)
+    prefillNoticeVisible.value = true
+  } catch {
+    // best-effort — the fresh form still works fully unprefilled.
+  } finally {
+    prefillLoading.value = false
+  }
+}
+
 onMounted(async () => {
   const templateId = route.params.templateId as string
   await templateStore.loadTemplate(templateId)
@@ -589,6 +639,7 @@ onMounted(async () => {
       }
     }
   }
+  await applyResubmitPrefill()
 })
 
 function syncVisibleFormState() {
@@ -644,6 +695,11 @@ watch([visibleFieldIds, template], () => {
 }
 
 .approval-new__info-card {
+  margin-bottom: 8px;
+}
+
+/* UX B2-13: 再次提交 prefill notice — same weight as the top-level error alert, but info-toned. */
+.approval-new__prefill-notice {
   margin-bottom: 8px;
 }
 

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -1409,25 +1409,37 @@ describe('Approval E2E Lifecycle', () => {
       expect(loadHistorySpy).toHaveBeenCalledWith('apv_pending_1')
     })
 
-    it('revoked approval does not show action buttons', async () => {
+    it('revoked approval does not show action buttons (except UX B2-13\'s own-requester 再次提交)', async () => {
       routeParams = { id: 'apv_revoked_1' }
       mockActiveApproval.value = mockRevokedApproval()
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
       expect(actions).toBeTruthy()
-      expect(actions?.querySelectorAll('button').length).toBe(0)
+      // UX B2-13: this fixture's requester ('user_1') IS the mocked session user above, and
+      // 'revoked' is one of the resubmit-eligible terminal statuses, so 再次提交 now renders here
+      // too — carve it out of the "no action buttons" check instead of asserting a magic total, so
+      // a REAL regression (an approve/reject/etc. button leaking through for a terminal instance)
+      // still fails this test.
+      const otherButtons = Array.from(actions?.querySelectorAll('button') ?? [])
+        .filter((button) => button.getAttribute('data-testid') !== 'approval-resubmit-button')
+      expect(otherButtons.length).toBe(0)
+      expect(actions?.querySelector('[data-testid="approval-resubmit-button"]')).toBeTruthy()
       expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
 
-    it('rejected approval does not show action buttons', async () => {
+    it('rejected approval does not show action buttons (except UX B2-13\'s own-requester 再次提交)', async () => {
       routeParams = { id: 'apv_rejected_1' }
       mockActiveApproval.value = mockRejectedApproval()
       await mountDetailView()
 
       const actions = container!.querySelector('.approval-detail__actions')
       expect(actions).toBeTruthy()
-      expect(actions?.querySelectorAll('button').length).toBe(0)
+      // UX B2-13: same carve-out as the revoked case above — 'rejected' is also resubmit-eligible.
+      const otherButtons = Array.from(actions?.querySelectorAll('button') ?? [])
+        .filter((button) => button.getAttribute('data-testid') !== 'approval-resubmit-button')
+      expect(otherButtons.length).toBe(0)
+      expect(actions?.querySelector('[data-testid="approval-resubmit-button"]')).toBeTruthy()
       expect(actions?.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
     })
   })

--- a/apps/web/tests/approval-prefill-from-snapshot.test.ts
+++ b/apps/web/tests/approval-prefill-from-snapshot.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import type { FormField, FormSchema } from '../src/types/approval'
+import { prefillFromSnapshot } from '../src/approvals/prefillFromSnapshot'
+
+function schema(fields: FormField[]): FormSchema {
+  return { fields }
+}
+
+describe('approvals/prefillFromSnapshot — UX B2-13 (再次提交)', () => {
+  it('prefills fields present in the snapshot with a value matching the CURRENT field type', () => {
+    const formSchema = schema([
+      { id: 'reason', type: 'text', label: '事由' },
+      { id: 'amount', type: 'number', label: '金额' },
+      { id: 'urgent', type: 'select', label: '紧急程度', options: [{ label: '高', value: 'high' }] },
+    ])
+    const snapshot = { reason: '出差报销', amount: 5000, urgent: 'high' }
+
+    expect(prefillFromSnapshot(formSchema, snapshot)).toEqual({
+      reason: '出差报销',
+      amount: 5000,
+      urgent: 'high',
+    })
+  })
+
+  it('skips a field the current template DROPPED since the original submission', () => {
+    // 'legacy_field' is no longer part of the current schema at all.
+    const formSchema = schema([{ id: 'reason', type: 'text', label: '事由' }])
+    const snapshot = { reason: '出差报销', legacy_field: 'old value' }
+
+    expect(prefillFromSnapshot(formSchema, snapshot)).toEqual({ reason: '出差报销' })
+  })
+
+  it('skips a field the current template RETYPED to something the old value no longer fits', () => {
+    // Same id ('amount'), but the author retyped it from number -> select; the old numeric value
+    // is not a valid shape for a select's stored option value... use a case that is UNAMBIGUOUSLY
+    // incompatible instead: retyped number -> multi-select (requires an array), old value a plain
+    // number.
+    const formSchema = schema([{ id: 'amount', type: 'multi-select', label: '金额档位' }])
+    const snapshot = { amount: 5000 }
+
+    expect(prefillFromSnapshot(formSchema, snapshot)).toEqual({})
+  })
+
+  it('skips a field retyped from text -> number when the old string value is not numeric-shaped', () => {
+    const formSchema = schema([{ id: 'note', type: 'number', label: '备注' }])
+    const snapshot = { note: '出差备注文本' }
+
+    expect(prefillFromSnapshot(formSchema, snapshot)).toEqual({})
+  })
+
+  it('always skips attachment fields, regardless of the stored value', () => {
+    const formSchema = schema([{ id: 'proof', type: 'attachment', label: '证明材料' }])
+    const snapshot = { proof: 'some-file-name.pdf' }
+
+    expect(prefillFromSnapshot(formSchema, snapshot)).toEqual({})
+  })
+
+  it('prefills detail rows verbatim when the detail field still exists as type "detail"', () => {
+    const formSchema = schema([
+      {
+        id: 'items',
+        type: 'detail',
+        label: '报销明细',
+        columns: [
+          { id: 'item_name', type: 'text', label: '项目' },
+          { id: 'amount_text', type: 'text', label: '金额说明' },
+        ],
+      },
+    ])
+    const rows = [
+      { item_name: '机票', amount_text: '合计 1000 元' },
+      { item_name: '酒店', amount_text: '合计 500 元' },
+    ]
+    const snapshot = { items: rows }
+
+    expect(prefillFromSnapshot(formSchema, snapshot)).toEqual({ items: rows })
+  })
+
+  it('skips a detail field whose stored value is not an array (retyped away from detail)', () => {
+    const formSchema = schema([{ id: 'items', type: 'detail', label: '报销明细', columns: [] }])
+    const snapshot = { items: 'not-an-array' }
+
+    expect(prefillFromSnapshot(formSchema, snapshot)).toEqual({})
+  })
+
+  it('empty snapshot -> {}', () => {
+    const formSchema = schema([{ id: 'reason', type: 'text', label: '事由' }])
+    expect(prefillFromSnapshot(formSchema, {})).toEqual({})
+  })
+
+  it('missing snapshot (null/undefined) -> {}', () => {
+    const formSchema = schema([{ id: 'reason', type: 'text', label: '事由' }])
+    expect(prefillFromSnapshot(formSchema, null)).toEqual({})
+    expect(prefillFromSnapshot(formSchema, undefined)).toEqual({})
+  })
+
+  it('skips a key present with an explicit null/undefined value', () => {
+    const formSchema = schema([{ id: 'reason', type: 'text', label: '事由' }])
+    expect(prefillFromSnapshot(formSchema, { reason: null })).toEqual({})
+    expect(prefillFromSnapshot(formSchema, { reason: undefined })).toEqual({})
+  })
+
+  it('a schema with no fields -> {}', () => {
+    expect(prefillFromSnapshot(schema([]), { reason: 'x' })).toEqual({})
+  })
+
+  it('multi-select requires an array; a scalar value for a multi-select field is skipped', () => {
+    const formSchema = schema([{ id: 'tags', type: 'multi-select', label: '标签' }])
+    expect(prefillFromSnapshot(formSchema, { tags: ['a', 'b'] })).toEqual({ tags: ['a', 'b'] })
+    expect(prefillFromSnapshot(formSchema, { tags: 'a' })).toEqual({})
+  })
+
+  it('date/datetime require a value Date can actually parse', () => {
+    const formSchema = schema([
+      { id: 'due', type: 'date', label: '截止日期' },
+      { id: 'meet', type: 'datetime', label: '会议时间' },
+    ])
+    expect(prefillFromSnapshot(formSchema, { due: '2026-07-01', meet: '2026-07-01T10:00:00Z' })).toEqual({
+      due: '2026-07-01',
+      meet: '2026-07-01T10:00:00Z',
+    })
+    expect(prefillFromSnapshot(formSchema, { due: 'not-a-date' })).toEqual({})
+  })
+
+  it('does not mutate the input snapshot or schema', () => {
+    const formSchema = schema([{ id: 'reason', type: 'text', label: '事由' }])
+    const snapshot = { reason: '出差报销' }
+    const snapshotCopy = { ...snapshot }
+    const schemaCopy = JSON.parse(JSON.stringify(formSchema))
+
+    prefillFromSnapshot(formSchema, snapshot)
+
+    expect(snapshot).toEqual(snapshotCopy)
+    expect(formSchema).toEqual(schemaCopy)
+  })
+})

--- a/apps/web/tests/approvalNewView.spec.ts
+++ b/apps/web/tests/approvalNewView.spec.ts
@@ -19,6 +19,9 @@ import { mockPendingApproval, mockPublishedTemplate } from './helpers/approval-t
 //   - B2-15: validation depth — required rules trigger on blur+change, and a `detail` row
 //     missing a required cell aborts submit with a readable message instead of an unreadable
 //     backend 400.
+//   - B2-13: 再次提交 prefill — a `?fromInstance=<id>` query param loads that (rejected/revoked/
+//     cancelled) source instance and prefills `formData` via `prefillFromSnapshot`, showing a
+//     subtle notice; absent the query, behavior is unchanged.
 //
 // General render/submit/visibility-rule coverage for this view already lives in
 // approval-e2e-permissions.spec.ts / approval-e2e-lifecycle.spec.ts — this file only exercises
@@ -46,6 +49,11 @@ vi.mock('element-plus', () => ({
   },
 }))
 
+// B2-13 — mutable so the resubmit-prefill suite can set `fromInstance` per-test; every
+// PRE-EXISTING test in this file never touches `routeQuery`, so it stays `{}` for them exactly as
+// the previous hardcoded literal was.
+let routeQuery: Record<string, string> = {}
+
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
   return {
@@ -53,7 +61,7 @@ vi.mock('vue-router', async () => {
     useRouter: () => ({ push: pushSpy, back: backSpy }),
     useRoute: () => ({
       params: { templateId: 'tpl_numfields' },
-      query: {},
+      query: routeQuery,
       path: '/approvals/new/tpl_numfields',
       meta: {},
     }),
@@ -76,11 +84,16 @@ vi.mock('../src/composables/useAuth', () => ({
 // keeps every other export (dispatchAction, createApproval, ...) real; this suite's OTHER tests
 // never render a `user`-type field so this mock is inert for them.
 const searchApprovalDirectoryUsersSpy = vi.fn().mockResolvedValue([])
+// B2-13 — the resubmit-prefill suite mocks the source-instance fetch; every other describe block
+// in this file never sets `?fromInstance=`, so `applyResubmitPrefill` short-circuits before ever
+// calling this, leaving it unused (and unconfigured) for them.
+const getApprovalSpy = vi.fn()
 vi.mock('../src/approvals/api', async () => {
   const actual = await vi.importActual<typeof import('../src/approvals/api')>('../src/approvals/api')
   return {
     ...actual,
     searchApprovalDirectoryUsers: (...args: unknown[]) => searchApprovalDirectoryUsersSpy(...args),
+    getApproval: (...args: unknown[]) => getApprovalSpy(...args),
   }
 })
 
@@ -730,5 +743,184 @@ describe('ApprovalNewView — B2-15 validation depth', () => {
     expect(submitApprovalSpy).toHaveBeenCalledTimes(1)
     const payload = submitApprovalSpy.mock.calls[0][0]
     expect(payload.formData.items).toEqual([{ item_name: '机票', amount_text: '合计 1000 元' }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// UX B2-13 — 再次提交 prefill. `?fromInstance=<id>` loads that source instance and prefills
+// `formData` via `prefillFromSnapshot` (unit-tested in isolation in
+// approval-prefill-from-snapshot.test.ts — this block only exercises the VIEW's wiring: does it
+// call `getApproval` with the right id, does the merged value actually reach `formData`, does the
+// notice show, and does an absent query / a failed fetch leave the fresh-form behavior unchanged).
+// Own describe block (own mount lifecycle), same reasoning as the B2-07/B2-15 blocks above.
+// ---------------------------------------------------------------------------
+describe('ApprovalNewView — B2-13 再次提交 prefill', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    routeQuery = {}
+    submitApprovalSpy.mockReset()
+    submitApprovalSpy.mockResolvedValue(mockPendingApproval({ id: 'apv_resubmit_1' }))
+    getApprovalSpy.mockReset()
+    loadTemplateSpy.mockClear()
+    pushSpy.mockClear()
+    backSpy.mockClear()
+    messageWarningSpy.mockClear()
+    messageSuccessSpy.mockClear()
+    messageErrorSpy.mockClear()
+    capturedFormRules = undefined
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    routeQuery = {}
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalNewView } = await import('../src/views/approval/ApprovalNewView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalNewView as any) })
+    app = createApp(Host)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElDivider', ElDivider)
+    app.component('ElEmpty', ElEmpty)
+    app.component('ElForm', ElForm)
+    app.component('ElFormItem', ElFormItem)
+    app.component('ElIcon', ElIcon)
+    app.component('ElInput', ElInput)
+    app.component('ElInputNumber', ElInputNumber)
+    app.component('ElOption', ElOption)
+    app.component('ElSelect', ElSelect)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElUpload', ElUpload)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  function submitButton(): HTMLButtonElement {
+    const btn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('提交审批'))
+    expect(btn).toBeTruthy()
+    return btn as HTMLButtonElement
+  }
+
+  function prefillNotice(): HTMLElement | null {
+    return container!.querySelector('[data-testid="approval-prefill-notice"]')
+  }
+
+  function formSchemaRequiredReasonAndAmount(): FormSchema {
+    return {
+      fields: [
+        { id: 'reason', type: 'text', label: '事由', required: true } as FormField,
+        { id: 'amount', type: 'number', label: '金额', required: true } as FormField,
+      ],
+    }
+  }
+
+  it('loads the source instance, prefills formData, and shows the notice', async () => {
+    routeQuery = { fromInstance: 'apv_source_1' }
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_resubmit',
+      formSchema: formSchemaRequiredReasonAndAmount(),
+    })
+    getApprovalSpy.mockResolvedValue(
+      mockPendingApproval({
+        id: 'apv_source_1',
+        status: 'rejected',
+        formSnapshot: { reason: '出差报销（第一次）', amount: 3000 },
+      }),
+    )
+
+    await mountView()
+
+    expect(getApprovalSpy).toHaveBeenCalledWith('apv_source_1')
+    expect(prefillNotice()).toBeTruthy()
+    expect(prefillNotice()?.textContent).toContain('已从上一次申请预填')
+
+    // Neither 'reason' nor 'amount' has a `defaultValue` in this schema — a successful submit
+    // (required-field validation passing) is only possible if the prefill actually reached
+    // `formData`, not just fetched-and-discarded.
+    submitButton().click()
+    await flushUi()
+
+    expect(submitApprovalSpy).toHaveBeenCalledTimes(1)
+    const payload = submitApprovalSpy.mock.calls[0][0]
+    expect(payload.formData).toMatchObject({ reason: '出差报销（第一次）', amount: 3000 })
+  })
+
+  it('does not prefill when there is no `fromInstance` query — unchanged behavior', async () => {
+    routeQuery = {}
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_resubmit_none',
+      formSchema: formSchemaRequiredReasonAndAmount(),
+    })
+
+    await mountView()
+
+    expect(getApprovalSpy).not.toHaveBeenCalled()
+    expect(prefillNotice()).toBeNull()
+
+    // Both required fields are still unset (no defaultValue, no prefill) — submit fails
+    // client-side validation exactly as it did before this feature existed.
+    submitButton().click()
+    await flushUi()
+
+    expect(submitApprovalSpy).not.toHaveBeenCalled()
+    expect(messageWarningSpy).toHaveBeenCalledWith('请检查表单中的必填项')
+  })
+
+  it('a failed source-instance fetch silently skips prefill — the fresh form still works', async () => {
+    routeQuery = { fromInstance: 'apv_missing' }
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_resubmit_fail',
+      formSchema: { fields: [{ id: 'reason', type: 'text', label: '事由', required: false } as FormField] },
+    })
+    getApprovalSpy.mockRejectedValue(new Error('not found'))
+
+    await mountView()
+
+    expect(prefillNotice()).toBeNull()
+
+    submitButton().click()
+    await flushUi()
+
+    expect(submitApprovalSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('a field dropped from the current template is skipped (view-level drift guard) — no crash', async () => {
+    routeQuery = { fromInstance: 'apv_source_drift' }
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_resubmit_drift',
+      formSchema: { fields: [{ id: 'reason', type: 'text', label: '事由', required: true } as FormField] },
+    })
+    getApprovalSpy.mockResolvedValue(
+      mockPendingApproval({
+        id: 'apv_source_drift',
+        status: 'rejected',
+        // 'legacy_field_removed' no longer exists on the current template.
+        formSnapshot: { reason: '出差报销', legacy_field_removed: 'old value' },
+      }),
+    )
+
+    await mountView()
+
+    submitButton().click()
+    await flushUi()
+
+    expect(submitApprovalSpy).toHaveBeenCalledTimes(1)
+    const payload = submitApprovalSpy.mock.calls[0][0]
+    expect(payload.formData).toMatchObject({ reason: '出差报销' })
+    expect(payload.formData).not.toHaveProperty('legacy_field_removed')
   })
 })

--- a/apps/web/tests/approvalResubmitButton.spec.ts
+++ b/apps/web/tests/approvalResubmitButton.spec.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+
+// ---------------------------------------------------------------------------
+// UX B2-13 (再次提交) — ApprovalDetailView's resubmit entry point.
+//
+//   - shown ONLY for the CURRENT USER'S OWN instance (isRequester) in a TERMINAL state that
+//     means "this didn't go through": rejected / revoked / cancelled.
+//   - hidden for 'approved' (nothing to fix) and for a non-requester viewing someone else's
+//     terminal instance.
+//   - hidden entirely while still 'pending' (the normal approve/reject/... action bar renders
+//     instead — see the shared `.approval-detail__actions` v-else branch).
+//   - clicking it navigates to the SAME template's fill route with `?fromInstance=<id>`.
+//
+// Same mount scaffold as approvalMobileDetailActions.spec.ts (store/router/auth/permissions
+// mocked directly; the real `ApprovalDetailView.vue` + a broad Element Plus stub set).
+// ---------------------------------------------------------------------------
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: pushSpy, back: vi.fn() }),
+    useRoute: () => ({ params: { id: 'apv_1' }, query: {}, path: '/approvals/apv_1', meta: {} }),
+  }
+})
+
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({ hasFeature: () => false }),
+}))
+
+// The reader is never an active approver in this suite — only requester-side affordances
+// (催一下/撤回/再次提交) are under test, not canAct's approve/reject bar.
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({ canAct: { value: false } }),
+}))
+
+vi.mock('../src/approvals/api', () => ({
+  markApprovalRead: vi.fn().mockResolvedValue({ ok: true }),
+  remindApproval: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+  searchApprovalDirectoryUsers: vi.fn().mockResolvedValue([]),
+}))
+
+// B1-01: mutable session identity — per-test control over requester affordances (mirrors
+// approvalMobileDetailActions.spec.ts).
+const mockCurrentUserId = ref<string | null>(null)
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getCurrentUser: () => (mockCurrentUserId.value ? { id: mockCurrentUserId.value } : null),
+    getCurrentUserId: vi.fn().mockImplementation(async () => mockCurrentUserId.value),
+  }),
+}))
+
+vi.mock('../src/approvals/templateStore', () => ({
+  useApprovalTemplateStore: () => ({
+    activeTemplate: null,
+    activeVersion: null,
+    loadTemplate: vi.fn().mockResolvedValue(undefined),
+    loadVersion: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+const mockActiveApproval = ref<any>(null)
+const mockHistory = ref<any[]>([])
+const mockLoading = ref(false)
+const executeActionSpy = vi.fn()
+const loadDetailSpy = vi.fn().mockResolvedValue(undefined)
+const loadHistorySpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../src/approvals/store', () => ({
+  useApprovalStore: () => ({
+    get activeApproval() { return mockActiveApproval.value },
+    get history() { return mockHistory.value },
+    get loading() { return mockLoading.value },
+    get error() { return null },
+    set error(_v: unknown) { /* noop */ },
+    loadDetail: loadDetailSpy,
+    loadHistory: loadHistorySpy,
+    executeAction: executeActionSpy,
+  }),
+}))
+
+function stub(name: string, tag = 'div') {
+  return defineComponent({
+    name,
+    props: { modelValue: {}, type: String, label: String, title: String },
+    emits: ['update:modelValue', 'click', 'confirm', 'change'],
+    render() {
+      return h(tag, { 'data-stub': name }, this.$slots.default?.())
+    },
+  })
+}
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { type: String, loading: Boolean, disabled: Boolean, text: Boolean, plain: Boolean },
+  emits: ['click'],
+  render() {
+    const isDisabled = this.disabled || this.loading
+    return h('button', {
+      'data-el-button': this.type || 'default',
+      disabled: isDisabled,
+      onClick: (e: Event) => {
+        if (isDisabled) return
+        this.$emit('click', e)
+      },
+    }, this.$slots.default?.())
+  },
+})
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, type: String, closable: Boolean, showIcon: Boolean },
+  render() { return h('div', { 'data-el-alert': this.type || 'default' }, this.title) },
+})
+const ElPopconfirm = defineComponent({
+  name: 'ElPopconfirm',
+  props: { title: String },
+  render() { return h('div', { 'data-el-popconfirm': this.title }, this.$slots.reference?.()) },
+})
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String },
+  render() { return h('div', { 'data-column': this.prop || this.label }) },
+})
+
+const stubDirective = { mounted() {}, updated() {} }
+
+async function flushUi(cycles = 5): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function baseInstance(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: 'apv_1',
+    title: '出差报销',
+    status: 'pending',
+    templateId: 'tpl_1',
+    requester: { id: 'user_99', name: '张三' },
+    requestNo: 'AP-100001',
+    currentStep: 1,
+    totalSteps: 2,
+    currentNodeKey: 'approval_1',
+    formSnapshot: { fld_reason: '出差报销' },
+    assignments: [],
+    ...overrides,
+  }
+}
+
+function resubmitButton(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('[data-testid="approval-resubmit-button"]')
+}
+
+describe('ApprovalDetailView — UX B2-13 再次提交', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    mockActiveApproval.value = baseInstance()
+    mockHistory.value = []
+    mockLoading.value = false
+    executeActionSpy.mockReset()
+    executeActionSpy.mockResolvedValue({})
+    loadDetailSpy.mockClear()
+    loadHistorySpy.mockClear()
+    pushSpy.mockClear()
+    mockCurrentUserId.value = null
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalDetailView } = await import('../src/views/approval/ApprovalDetailView.vue')
+    const Host = defineComponent({ setup() { return () => h(ApprovalDetailView as any) } })
+    app = createApp(Host)
+    for (const name of ['ElDivider', 'ElEmpty', 'ElTable', 'ElTimeline', 'ElTimelineItem', 'ElForm', 'ElFormItem', 'ElSelect', 'ElOption', 'ElRadioGroup', 'ElRadio', 'ElIcon', 'ElInput', 'ElTag', 'ElDialog']) {
+      app.component(name, stub(name))
+    }
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElButton', ElButton)
+    app.component('ElAlert', ElAlert)
+    app.component('ElPopconfirm', ElPopconfirm)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  it('shows 再次提交 for the requester\'s own REJECTED instance', async () => {
+    mockCurrentUserId.value = 'user_99'
+    mockActiveApproval.value = baseInstance({ status: 'rejected' })
+    await mountView()
+
+    expect(resubmitButton(container!)).toBeTruthy()
+  })
+
+  it('shows 再次提交 for the requester\'s own REVOKED instance', async () => {
+    mockCurrentUserId.value = 'user_99'
+    mockActiveApproval.value = baseInstance({ status: 'revoked' })
+    await mountView()
+
+    expect(resubmitButton(container!)).toBeTruthy()
+  })
+
+  it('shows 再次提交 for the requester\'s own CANCELLED instance', async () => {
+    mockCurrentUserId.value = 'user_99'
+    mockActiveApproval.value = baseInstance({ status: 'cancelled' })
+    await mountView()
+
+    expect(resubmitButton(container!)).toBeTruthy()
+  })
+
+  it('hides 再次提交 for an APPROVED instance — nothing to resubmit, even for the requester', async () => {
+    mockCurrentUserId.value = 'user_99'
+    mockActiveApproval.value = baseInstance({ status: 'approved' })
+    await mountView()
+
+    expect(resubmitButton(container!)).toBeNull()
+    // the "该审批已结束" alert still shows — only the NEW button is gated off.
+    expect(container!.querySelector('[data-el-alert="info"]')?.textContent).toContain('该审批已结束')
+  })
+
+  it('hides 再次提交 while still PENDING (the normal action bar renders instead)', async () => {
+    mockCurrentUserId.value = 'user_99'
+    mockActiveApproval.value = baseInstance({ status: 'pending' })
+    await mountView()
+
+    expect(resubmitButton(container!)).toBeNull()
+  })
+
+  it('hides 再次提交 for a NON-REQUESTER viewing someone else\'s rejected instance', async () => {
+    mockCurrentUserId.value = 'user_someone_else'
+    mockActiveApproval.value = baseInstance({ status: 'rejected' })
+    await mountView()
+
+    expect(resubmitButton(container!)).toBeNull()
+  })
+
+  it('hides 再次提交 when the session identity is unresolved (fail-closed, no currentUserId)', async () => {
+    mockCurrentUserId.value = null
+    mockActiveApproval.value = baseInstance({ status: 'rejected' })
+    await mountView()
+
+    expect(resubmitButton(container!)).toBeNull()
+  })
+
+  it('hides 再次提交 when the instance has no templateId (nothing to route back to)', async () => {
+    mockCurrentUserId.value = 'user_99'
+    mockActiveApproval.value = baseInstance({ status: 'rejected', templateId: null })
+    await mountView()
+
+    expect(resubmitButton(container!)).toBeNull()
+  })
+
+  it('clicking 再次提交 navigates to the SAME template\'s fill route with ?fromInstance=<id>', async () => {
+    mockCurrentUserId.value = 'user_99'
+    mockActiveApproval.value = baseInstance({ status: 'rejected', templateId: 'tpl_42', id: 'apv_source_1' })
+    await mountView()
+
+    const btn = resubmitButton(container!)
+    expect(btn).toBeTruthy()
+    btn!.click()
+    await flushUi()
+
+    expect(pushSpy).toHaveBeenCalledWith({
+      name: 'approval-create',
+      params: { templateId: 'tpl_42' },
+      query: { fromInstance: 'apv_source_1' },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

UX 阶梯 §7 **parity 切片最后一刀 B2-13**（Sonnet 代理实现 + Fable 审查）——完成即 **§7 桌面 parity 达标**。

驳回→改→重提是发起人最恼火却摩擦最大的环节（今天要手抄整张表）。加「再次提交」从被驳回实例预填新草稿：

- **入口**（ApprovalDetailView）：仅**本人 + 终态**（rejected/revoked/cancelled，approved 排除——无可改）显示「再次提交」；`isRequester` 复用 B1-01 真身份；门控加 `templateId` 存在（外部无模板实例无处可回）
- **预填 + drift guard**（ApprovalNewView，`?fromInstance=`）：新纯模块 `prefillFromSnapshot(formSchema, snapshot)`——只填**当前模板仍存在且类型兼容**的字段（丢弃/改类型/attachment 跳过，防脏值），明细行保留、逐列漂移交既有 submit 剪枝；notice「已从上一次申请预填，请检查后提交」；不自动提交（仍走 B2-15 校验/B2-07 预览）
- **源实例加载**：直调 `getApproval(id)` 不用 `store.loadDetail`——避免污染 DetailView 共享的 activeApproval/loading 态

## Verification
- 新增 27 测试（prefill 14 / resubmit 按钮 9 / view 4）；rebase 后焦点 50/50 + vue-tsc 0
- **无 clobber**：D-2 选人器/B2-28 附件/B2-07 流程链/B2-15 校验 stash A/B 验证字节级不变，守护测试原样绿（假人仍 0）；guard-spec 冲突（user_1 既是 mock 用户又是 fixtures 发起人）按新行为 carve-out 再次提交按钮

## §7 桌面 parity 达标
本 PR 落地即完成 P 切片 5/5：B2-01 摘要 · B2-08 时间线 · B2-07 流程链 · B2-15 校验 · **B2-13 再次提交**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)