### PR TITLE
test(multitable): W1-2 permission-matrix B2 — oracle/no-leak goldens (G-5, G-4)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -168,7 +168,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope + mirror-read-only enumeration hardening + cross-base editable-mirror write-through op + cross-base mirror write-through Decision-F concurrency + personal-views slice-1 actor-scoped isolation + W1-2 permission-matrix B1 side-door goldens (Yjs bridge flush actor-tier/lock/row-deny/rule-deny, OAPI token write re-gate parity, base-write/sheet-write non-intersection) + W1-1 formula freshness goldens (Yjs-bridge formula recompute GF1-GF4/GF9 + expression-change bulk recompute GF5-GF8/GF12))
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope + mirror-read-only enumeration hardening + cross-base editable-mirror write-through op + cross-base mirror write-through Decision-F concurrency + personal-views slice-1 actor-scoped isolation + W1-2 permission-matrix B1 side-door goldens (Yjs bridge flush actor-tier/lock/row-deny/rule-deny, OAPI token write re-gate parity, base-write/sheet-write non-intersection) + W1-2 permission-matrix B2 oracle/no-leak goldens (G-5 row-level-read-deny zero-presence on export + history, G-4 OAPI token-vs-interactive read-mask parity across the 5 records:read routes) + W1-1 formula freshness goldens (Yjs-bridge formula recompute GF1-GF4/GF9 + expression-change bulk recompute GF5-GF8/GF12))
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -203,6 +203,7 @@ jobs:
             tests/integration/multitable-oapi-scope-guard-realdb.test.ts \
             tests/integration/multitable-oapi-token-create-scope.api.test.ts \
             tests/integration/multitable-permmatrix-b1-oapi-token-write-realdb.test.ts \
+            tests/integration/multitable-permmatrix-b2-g4-oapi-mask-parity-realdb.test.ts \
             tests/integration/multitable-mirror-readonly-enumeration-realdb.test.ts \
             tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts \
             tests/integration/multitable-crossbase-mirror-writethrough-concurrency-realdb.test.ts \
@@ -210,6 +211,7 @@ jobs:
             tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \
             tests/integration/multitable-rowlevel-readdeny-flag-endpoint.test.ts \
+            tests/integration/multitable-permmatrix-b2-g5-collection-noleak-realdb.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \
             tests/integration/multitable-record-restore.test.ts \
             tests/integration/multitable-record-recycle-bin.test.ts \

--- a/packages/core-backend/tests/integration/multitable-permmatrix-b2-g4-oapi-mask-parity-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-permmatrix-b2-g4-oapi-mask-parity-realdb.test.ts
@@ -1,0 +1,208 @@
+/**
+ * W1-2 permission matrix — B2 / G-4: OAPI read-mask PARITY, per-route differential (real DB).
+ * Spec: docs/development/multitable-w1-2-permission-matrix-spec-20260705.md §3 G-4.
+ *
+ * G-4 in one line: an `mst_` API-token read must produce output EQUIVALENT to the SAME creator's
+ * interactive-channel (session) masked output — never more — across all 5 `records:read` OAPI-1 routes
+ * (oapi-read-allowlist.ts docstring: "records:read — GET /records (list), /records/:id (single), /view,
+ * /sheets/:sheetId/view-aggregate, /records-summary... apply the creator's row-deny + field-permission
+ * stack per-request (Option A)"). `multitable-oapi1-token-read-realdb.test.ts` already proves auth
+ * mechanics (guards mounted, scope enforcement) and a PARTIAL semantic property (a row-deny doesn't leak
+ * through the token on 2 of the 5 routes, via conditional_read_rules) — but no existing golden performs
+ * a direct per-route DIFFERENTIAL: the same two requests (token vs interactive) for the SAME creator, on
+ * the SAME data, with BOTH a field_permissions mask (M1) and a row-level read-deny (M2) live, asserting
+ * the two channel outputs are the SAME masked shape. That differential is what this file adds, once per
+ * route (not re-deriving the auth-mechanics matrix already covered).
+ *
+ * Fixture: one creator (real `users` row, `multitable:read` only — non-admin) with:
+ *   - a `field_permissions` deny on FLD_SECRET (M1) — must be masked identically via both channels;
+ *   - a `record_permissions` 'none' scope + `row_level_read_permissions_enabled` flag ON on REC_DENIED
+ *     (M2) — must be absent identically via both channels (except the single-GET route, whose LOCKED
+ *     contract is 403 + no `data`, unchanged by this file — see
+ *     multitable-permmatrix-b2-g5-collection-noleak-realdb.test.ts's header for that contract).
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { db } from '../../src/db/db'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApiTokenService } from '../../src/multitable/api-token-service'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_b2g4_${TS}`
+const SHEET_ID = `sheet_b2g4_${TS}`
+const FLD_STATUS = `fld_b2g4_status_${TS}` // readable — the non-vacuous positive control
+const FLD_SECRET = `fld_b2g4_secret_${TS}` // field_permissions-denied for CREATOR (M1)
+const REC_OPEN = `rec_b2g4_open_${TS}`
+const REC_DENIED = `rec_b2g4_denied_${TS}` // record_permissions 'none' for CREATOR (M2)
+const CREATOR = `user_b2g4_${TS}`
+const SECRET_OPEN = 'topsecret_open_value'
+const SECRET_DENIED = 'topsecret_denied_value'
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let tokenApp: Express // NO fake middleware — apiTokenAuth must resolve the actor from the Bearer token
+let interactiveApp: Express // fake middleware injecting the SAME creator as an interactive session
+let token = ''
+
+const viaToken = (path: string) => request(tokenApp).get(path).set('Authorization', `Bearer ${token}`)
+const viaInteractive = (path: string) => request(interactiveApp).get(path)
+
+// Sort-stable projection helpers so array-order differences between the two channels never cause a
+// false mismatch (both SHOULD be identically ordered — deterministic queries — but this keeps the
+// comparison honest about WHAT it's proving: mask parity, not incidental ordering).
+const byId = <T extends { id: string }>(arr: T[]) => [...arr].sort((a, b) => a.id.localeCompare(b.id))
+
+describeIfDatabase('W1-2 B2 G-4 — OAPI read-mask parity: token output ≡ creator interactive output (real DB)', () => {
+  beforeAll(async () => {
+    tokenApp = express()
+    tokenApp.use(express.json())
+    tokenApp.use('/api/multitable', univerMetaRouter())
+
+    interactiveApp = express()
+    interactiveApp.use(express.json())
+    interactiveApp.use((req, _res, next) => {
+      ;(req as any).user = { id: CREATOR, roles: [], perms: ['multitable:read'], permissions: ['multitable:read'] }
+      next()
+    })
+    interactiveApp.use('/api/multitable', univerMetaRouter())
+
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1,$2,$3,'x','member',$4::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET permissions = EXCLUDED.permissions`,
+      [CREATOR, `${CREATOR}@t.local`, 'B2 G4 Creator', JSON.stringify(['multitable:read'])],
+    )
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'B2 G4 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name, row_level_read_permissions_enabled) VALUES ($1,$2,$3,TRUE)', [SHEET_ID, BASE_ID, 'B2 G4 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_STATUS, SHEET_ID, 'Status', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
+
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+      REC_OPEN, SHEET_ID, JSON.stringify({ [FLD_STATUS]: 'open', [FLD_SECRET]: SECRET_OPEN }),
+    ])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+      REC_DENIED, SHEET_ID, JSON.stringify({ [FLD_STATUS]: 'secret_row', [FLD_SECRET]: SECRET_DENIED }),
+    ])
+
+    // M1: field_permissions denies FLD_SECRET for CREATOR.
+    await q(
+      `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`,
+      [SHEET_ID, FLD_SECRET, CREATOR],
+    )
+    // M2: record_permissions 'none' scope for CREATOR on REC_DENIED (flag already ON on the sheet row above).
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)', [SHEET_ID, REC_DENIED, 'user', CREATOR, 'none'])
+
+    const svc = new ApiTokenService(db)
+    token = (await svc.createToken(CREATOR, { name: 'b2-g4-read', scopes: ['records:read'] })).plainTextToken
+  })
+
+  afterAll(async () => {
+    await db.deleteFrom('multitable_api_tokens').where('created_by', '=', CREATOR).execute().catch(() => {})
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [CREATOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── Route 1/5: GET /records (list) ──────────────────────────────────────────────────────────────
+  test('route 1/5 — GET /records: token output ≡ interactive output (M1 field mask + M2 row-deny parity)', async () => {
+    const t = await viaToken('/api/multitable/records').query({ sheetId: SHEET_ID, limit: 100 })
+    const i = await viaInteractive('/api/multitable/records').query({ sheetId: SHEET_ID, limit: 100 })
+    expect(t.status).toBe(200)
+    expect(i.status).toBe(200)
+
+    const tRecords = byId((t.body?.data?.records ?? []) as Array<{ id: string; data: Record<string, unknown> }>)
+    const iRecords = byId((i.body?.data?.records ?? []) as Array<{ id: string; data: Record<string, unknown> }>)
+    const tPairs = tRecords.map((r) => ({ id: r.id, data: r.data }))
+    const iPairs = iRecords.map((r) => ({ id: r.id, data: r.data }))
+    expect(tPairs).toEqual(iPairs) // byte-for-byte parity of the masked projection
+
+    // non-vacuous: both contain the visible record, with the readable field intact
+    expect(tPairs.some((r) => r.id === REC_OPEN && r.data[FLD_STATUS] === 'open')).toBe(true)
+    // leak-free (M1): neither channel exposes the denied field's value anywhere
+    expect(JSON.stringify(t.body)).not.toContain(SECRET_OPEN)
+    expect(JSON.stringify(i.body)).not.toContain(SECRET_OPEN)
+    // zero presence (M2): the row-denied record is absent from BOTH channels
+    expect(tPairs.some((r) => r.id === REC_DENIED)).toBe(false)
+    expect(iPairs.some((r) => r.id === REC_DENIED)).toBe(false)
+  })
+
+  // ── Route 2/5: GET /records/:recordId (single) ──────────────────────────────────────────────────
+  test('route 2/5 — GET /records/:id: token ≡ interactive for the readable record (M1), and the SAME 403+no-data shape for the denied one (M2)', async () => {
+    const tOpen = await viaToken(`/api/multitable/records/${REC_OPEN}`).query({ sheetId: SHEET_ID })
+    const iOpen = await viaInteractive(`/api/multitable/records/${REC_OPEN}`).query({ sheetId: SHEET_ID })
+    expect(tOpen.status).toBe(200)
+    expect(iOpen.status).toBe(200)
+    expect(tOpen.body?.data?.record?.data).toEqual(iOpen.body?.data?.record?.data)
+    expect(tOpen.body?.data?.record?.data?.[FLD_STATUS]).toBe('open') // non-vacuous
+    expect(tOpen.body?.data?.record?.data?.[FLD_SECRET]).toBeUndefined() // M1 masked
+    expect(iOpen.body?.data?.record?.data?.[FLD_SECRET]).toBeUndefined()
+
+    // The single-GET LOCKED contract (403 + no `data`) is unchanged — proven identical on BOTH channels.
+    const tDenied = await viaToken(`/api/multitable/records/${REC_DENIED}`).query({ sheetId: SHEET_ID })
+    const iDenied = await viaInteractive(`/api/multitable/records/${REC_DENIED}`).query({ sheetId: SHEET_ID })
+    expect(tDenied.status).toBe(403)
+    expect(iDenied.status).toBe(403)
+    expect(JSON.stringify(tDenied.body)).not.toContain('"data"')
+    expect(JSON.stringify(iDenied.body)).not.toContain('"data"')
+  })
+
+  // ── Route 3/5: GET /view ─────────────────────────────────────────────────────────────────────────
+  test('route 3/5 — GET /view: token output ≡ interactive output (M1 field mask + M2 row-deny parity)', async () => {
+    const t = await viaToken('/api/multitable/view').query({ sheetId: SHEET_ID })
+    const i = await viaInteractive('/api/multitable/view').query({ sheetId: SHEET_ID })
+    expect(t.status).toBe(200)
+    expect(i.status).toBe(200)
+
+    const tRows = byId((t.body?.data?.rows ?? []) as Array<{ id: string; data: Record<string, unknown> }>)
+    const iRows = byId((i.body?.data?.rows ?? []) as Array<{ id: string; data: Record<string, unknown> }>)
+    const tPairs = tRows.map((r) => ({ id: r.id, data: r.data }))
+    const iPairs = iRows.map((r) => ({ id: r.id, data: r.data }))
+    expect(tPairs).toEqual(iPairs)
+
+    expect(tPairs.some((r) => r.id === REC_OPEN && r.data[FLD_STATUS] === 'open')).toBe(true) // non-vacuous
+    expect(JSON.stringify(t.body)).not.toContain(SECRET_OPEN) // M1 leak-free
+    expect(JSON.stringify(i.body)).not.toContain(SECRET_OPEN)
+    expect(tPairs.some((r) => r.id === REC_DENIED)).toBe(false) // M2 zero presence
+    expect(iPairs.some((r) => r.id === REC_DENIED)).toBe(false)
+  })
+
+  // ── Route 4/5: GET /sheets/:sheetId/view-aggregate ──────────────────────────────────────────────
+  test('route 4/5 — GET /view-aggregate: token total ≡ interactive total (M2 row-deny excluded identically from both)', async () => {
+    const t = await viaToken(`/api/multitable/sheets/${SHEET_ID}/view-aggregate`).query({ sheetId: SHEET_ID })
+    const i = await viaInteractive(`/api/multitable/sheets/${SHEET_ID}/view-aggregate`).query({ sheetId: SHEET_ID })
+    expect(t.status).toBe(200)
+    expect(i.status).toBe(200)
+    expect(t.body?.data?.total).toBe(i.body?.data?.total)
+    expect(t.body?.data?.total).toBe(1) // REC_DENIED excluded from both — not 2
+  })
+
+  // ── Route 5/5: GET /records-summary ─────────────────────────────────────────────────────────────
+  test('route 5/5 — GET /records-summary: token output ≡ interactive output (M1 display value + M2 row-deny parity)', async () => {
+    const t = await viaToken('/api/multitable/records-summary').query({ sheetId: SHEET_ID, displayFieldId: FLD_STATUS, limit: 100 })
+    const i = await viaInteractive('/api/multitable/records-summary').query({ sheetId: SHEET_ID, displayFieldId: FLD_STATUS, limit: 100 })
+    expect(t.status).toBe(200)
+    expect(i.status).toBe(200)
+
+    const tRecords = byId((t.body?.data?.records ?? []) as Array<{ id: string; display: unknown }>)
+    const iRecords = byId((i.body?.data?.records ?? []) as Array<{ id: string; display: unknown }>)
+    expect(tRecords).toEqual(iRecords)
+
+    expect(tRecords.some((r) => r.id === REC_OPEN && r.display === 'open')).toBe(true) // non-vacuous
+    expect(tRecords.some((r) => r.id === REC_DENIED)).toBe(false) // M2 zero presence
+    expect(iRecords.some((r) => r.id === REC_DENIED)).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-permmatrix-b2-g5-collection-noleak-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-permmatrix-b2-g5-collection-noleak-realdb.test.ts
@@ -1,0 +1,339 @@
+/**
+ * W1-2 permission matrix — B2 / G-5: row-level read-deny (M2) "zero presence" on the COLLECTION
+ * surfaces the existing goldens don't yet cover (real DB).
+ * Spec: docs/development/multitable-w1-2-permission-matrix-spec-20260705.md §3 G-5.
+ *
+ * G-5 in one line: a record the actor is row-level read-DENIED (per-sheet opt-in flag
+ * `row_level_read_permissions_enabled` + a `record_permissions` 'none' scope — M2, `permission-service.ts`
+ * `loadRowLevelReadDenyEnabled`/`loadDeniedRecordIds`) must leave ZERO existence footprint on every
+ * collection/aggregate surface: absent from lists, not counted in aggregates/summaries, absent from
+ * export, absent from history. This is a DIFFERENT contract from the single-record GET, which is
+ * explicitly NOT touched here (see below).
+ *
+ * ── NOT re-tested here (already locked — see spec §1 + this investigation) ─────────────────────────
+ *  - Single-record GET keeps its LOCKED contract: 403 + NO `data` key (univer-meta.ts `GET
+ *    /records/:recordId`, `requireRecordReadable` → `sendForbidden`). Pinned by
+ *    `multitable-rowlevel-readdeny-enforce.test.ts` ("flag ON: the none-scoped record is DENIED (403)").
+ *    This file does NOT change or re-assert that contract, and does NOT introduce a 404/denied≡missing
+ *    shape for it — that would be a read-path contract change, explicitly out of scope (spec §3 G-5).
+ *  - GET /records (cursor list): flag ON already excludes the none-scoped record — pinned by
+ *    `multitable-rowlevel-readdeny-enforce.test.ts` ("GET /records flag ON: the none-scoped record is
+ *    EXCLUDED, the non-scoped one remains").
+ *  - GET /records-summary (link-picker candidates): flag ON already excludes it — pinned by the same
+ *    file ("/records-summary flag ON: the none-scoped record is EXCLUDED from the picker").
+ *  - GET /sheets/:sheetId/view-aggregate: flag ON already excludes it from the total — pinned by the
+ *    same file ("view-aggregate flag ON: the none-scoped record is EXCLUDED from the total").
+ *  All three above are driven DIRECTLY off the M2 mechanism (record_permissions='none') this file also
+ *  uses — genuinely redundant to re-assert, so this file does NOT duplicate them.
+ *
+ * ── NEW coverage in this file (the actual G-5 gap) ──────────────────────────────────────────────────
+ *  1. EXPORT (GET /sheets/:sheetId/export-xlsx): the route DOES implement the M2 exclusion
+ *     (`exportDeniedIds` via `loadRowLevelReadDenyEnabled` + `loadDeniedRecordIds`, univer-meta.ts
+ *     ~12148-12420) in BOTH its code branches — the no-filter/no-sort cursor-pagination stream AND the
+ *     view-filter/sort load-all path — but NO existing golden exercises the M2 flag against export
+ *     (multitable-export-allrows-maskroute-realdb.test.ts covers field_permissions + view filter/sort
+ *     only; multitable-export-permission-canary.test.ts's own header explicitly says record-scope was
+ *     "NOT covered" at the time it was authored, pre-dating the #18 M2 feature). This is the primary new
+ *     ground this file covers.
+ *  2. HISTORY (GET /bases/:baseId/history/events[/:batchId]): `history-projection.ts` shares the SAME
+ *     `loadDeniedRecordIds` consumer contract (LOCK-3), and `multitable-history-events-realdb.test.ts`
+ *     already thoroughly locks that CONSUMER contract (batch invisible / total excludes it / detail
+ *     404-parity / admin bypass / flag-off inert) — but drives it via the M4 conditional-rule-deny path
+ *     (`conditional_read_rules`), never via a pure M2 `record_permissions`='none' grant-deny row. Since
+ *     `loadDeniedRecordIds` computes grant-deny (M2) and rule-deny (M4) via two INDEPENDENT SQL branches
+ *     unioned into one Set (permission-service.ts `loadDeniedRecordIds` (a) vs (b)), the M4-driven test
+ *     does not exercise the M2 branch's SQL. This file adds a SMALL, non-duplicating M2-direct
+ *     confirmatory pair (not the full LOCK-3 matrix — cursor/search/tie-break stay in the existing file)
+ *     to close that specific loop.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+const xlsx = (await import('xlsx')) as unknown as {
+  read: (data: unknown, opts: { type: string }) => { SheetNames: string[]; Sheets: Record<string, unknown> }
+  utils: { sheet_to_json: (ws: unknown, opts: { header: 1; raw: false; defval: string }) => string[][] }
+}
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+// ════════════════════════════════════════════════════════════════════════════════════════════════════
+// PART A — EXPORT (GET /sheets/:sheetId/export-xlsx)
+// ════════════════════════════════════════════════════════════════════════════════════════════════════
+describeIfDatabase('W1-2 B2 G-5 — export "zero presence" for a row-level read-denied record (real DB)', () => {
+  const TS = Date.now()
+  const BASE_ID = `base_b2exp_${TS}`
+  const SHEET_ID = `sheet_b2exp_${TS}`
+  const F_NAME = `fld_b2exp_name_${TS}`
+  const F_AMOUNT = `fld_b2exp_amount_${TS}`
+  const REC_DENIED = `rec_b2exp_denied_${TS}` // record_permissions 'none' scope for USER (M2)
+  const REC_OK_A = `rec_b2exp_ok_a_${TS}`
+  const REC_OK_B = `rec_b2exp_ok_b_${TS}`
+  const USER_ID = `user_b2exp_${TS}`
+  const VIEW_SORTED = `view_b2exp_sorted_${TS}` // exercises the OTHER runtime branch (view load-all path)
+
+  let app: Express
+  const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+
+  async function exportXlsxRows(query: Record<string, string> = {}): Promise<string[][]> {
+    const res = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/export-xlsx`)
+      .query(query)
+      .buffer(true)
+      .parse((r, cb) => {
+        const chunks: Buffer[] = []
+        r.on('data', (c) => chunks.push(Buffer.from(c)))
+        r.on('end', () => cb(null, Buffer.concat(chunks)))
+      })
+    expect(res.status).toBe(200)
+    const parsed = xlsx.read(res.body, { type: 'buffer' })
+    return xlsx.utils.sheet_to_json(parsed.Sheets[parsed.SheetNames[0]], { header: 1, raw: false, defval: '' })
+  }
+
+  async function exportCsvRows(query: Record<string, string> = {}): Promise<string[][]> {
+    const res = await request(app)
+      .get(`/api/multitable/sheets/${SHEET_ID}/export-xlsx`)
+      .query({ format: 'csv', ...query })
+      .buffer(true)
+      .parse((r, cb) => {
+        const chunks: Buffer[] = []
+        r.on('data', (c) => chunks.push(Buffer.from(c)))
+        r.on('end', () => cb(null, Buffer.concat(chunks)))
+      })
+    expect(res.status).toBe(200)
+    const text = Buffer.isBuffer(res.body) ? res.body.toString('utf8').replace(/^﻿/, '') : ''
+    return text.length === 0 ? [] : text.split('\r\n').map((line) => line.split(','))
+  }
+
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = { id: USER_ID, roles: [], perms: ['multitable:read'], permissions: ['multitable:read'] }
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [USER_ID])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'B2 Export Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'B2 Export Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_NAME, SHEET_ID, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_AMOUNT, SHEET_ID, 'Amount', 'number', '{}', 2])
+
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_DENIED, SHEET_ID, JSON.stringify({ [F_NAME]: 'denied_secret_row', [F_AMOUNT]: 999 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_OK_A, SHEET_ID, JSON.stringify({ [F_NAME]: 'row_a', [F_AMOUNT]: 1 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_OK_B, SHEET_ID, JSON.stringify({ [F_NAME]: 'row_b', [F_AMOUNT]: 2 })])
+
+    // Pure M2: a 'none' record_permissions scope for USER on REC_DENIED. No conditional_read_rules (M4)
+    // involved anywhere in this describe block — this is the grant-deny branch specifically.
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)', [SHEET_ID, REC_DENIED, 'user', USER_ID, 'none'])
+
+    // A saved view with a sort, to route export through the OTHER runtime branch (view load-all path,
+    // where denied records are dropped via `all = all.filter(...)` BEFORE filter/sort/cap — not just the
+    // no-view cursor-stream branch's per-page `continue`).
+    await q(
+      'INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, hidden_field_ids) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb)',
+      [VIEW_SORTED, SHEET_ID, 'B2 Sorted', 'grid', 'null', JSON.stringify({ rules: [{ fieldId: F_AMOUNT, desc: true }] }), '[]'],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [USER_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('control (non-vacuous baseline): flag OFF exports the denied row too (grant-additive default)', async () => {
+    await setFlag(false)
+    const rows = await exportXlsxRows()
+    const names = new Set(rows.slice(1).map((r) => r[0]))
+    expect(names.has('denied_secret_row')).toBe(true) // proves the row is genuinely exportable absent the flag
+    expect(names.size).toBe(3)
+  })
+
+  test('no-view branch: flag ON excludes the M2-denied record — zero presence (no id, no leaked value, exact count)', async () => {
+    await setFlag(true)
+    const rows = await exportXlsxRows()
+    const body = rows.slice(1)
+    expect(body.length).toBe(2) // exactly the 2 non-denied rows — not 3
+    const names = new Set(body.map((r) => r[0]))
+    expect(names.has('row_a')).toBe(true)
+    expect(names.has('row_b')).toBe(true)
+    expect(names.has('denied_secret_row')).toBe(false) // absent, not just masked
+    expect(rows.flat().some((c) => c.includes('999'))).toBe(false) // no leaked Amount value either
+  })
+
+  test('no-view branch (CSV format): the SAME M2 exclusion holds for the CSV re-serialization', async () => {
+    await setFlag(true)
+    const rows = await exportCsvRows()
+    const body = rows.slice(1)
+    expect(body.length).toBe(2)
+    expect(body.some((r) => r[0] === 'denied_secret_row')).toBe(false)
+  })
+
+  test('view load-all branch (filter/sort present): flag ON STILL excludes the denied record, sort stays correct', async () => {
+    await setFlag(true)
+    const rows = await exportXlsxRows({ viewId: VIEW_SORTED })
+    const body = rows.slice(1)
+    expect(body.length).toBe(2) // denied row dropped BEFORE sort/cap in the load-all branch too
+    const names = body.map((r) => r[0])
+    expect(names).not.toContain('denied_secret_row')
+    // Amount desc among the surviving rows: row_b(2) then row_a(1) — proves a real sort over the
+    // ALREADY-filtered set, not an accidental pass.
+    expect(names).toEqual(['row_b', 'row_a'])
+  })
+
+  test('admin bypass: flag ON, an admin actor still sees the denied record in export (M2 is non-admin only)', async () => {
+    await setFlag(true)
+    const adminApp = express()
+    adminApp.use(express.json())
+    adminApp.use((req, _res, next) => {
+      ;(req as any).user = { id: USER_ID, roles: ['admin'], perms: ['multitable:read'], permissions: ['multitable:read'] }
+      next()
+    })
+    adminApp.use('/api/multitable', univerMetaRouter())
+    const res = await request(adminApp)
+      .get(`/api/multitable/sheets/${SHEET_ID}/export-xlsx`)
+      .buffer(true)
+      .parse((r, cb) => {
+        const chunks: Buffer[] = []
+        r.on('data', (c) => chunks.push(Buffer.from(c)))
+        r.on('end', () => cb(null, Buffer.concat(chunks)))
+      })
+    expect(res.status).toBe(200)
+    const parsed = xlsx.read(res.body, { type: 'buffer' })
+    const rows = xlsx.utils.sheet_to_json(parsed.Sheets[parsed.SheetNames[0]], { header: 1, raw: false, defval: '' }) as string[][]
+    const names = new Set(rows.slice(1).map((r) => r[0]))
+    expect(names.has('denied_secret_row')).toBe(true) // admin bypasses the M2 deny
+    expect(names.size).toBe(3)
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════════════════════════════
+// PART B — HISTORY (GET /bases/:baseId/history/events[/:batchId]) — M2-direct supplementary check
+// ════════════════════════════════════════════════════════════════════════════════════════════════════
+describeIfDatabase('W1-2 B2 G-5 — history "zero presence" for a row-level read-denied record, M2-direct (real DB)', () => {
+  const TS = Date.now()
+  const BASE_ID = `base_b2hist_${TS}`
+  const SHEET_ID = `sheet_b2hist_${TS}`
+  const STATUS = `fld_b2hist_status_${TS}`
+  const REC_SECRET = `rec_b2hist_secret_${TS}` // record_permissions 'none' for USER (M2, not a conditional rule)
+  const REC_PUBLIC = `rec_b2hist_public_${TS}`
+  const BULK_BATCH = `batch_b2hist_bulk_${TS}` // one bulk action touching BOTH records (shared batch id)
+  const SECRET_BATCH = `batch_b2hist_secret_${TS}` // a single-record action on the secret record only
+  const USER_ID = `user_b2hist_${TS}`
+
+  let app: Express
+  let testRoles: string[] = []
+  const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+  const events = (query: Record<string, unknown> = {}) =>
+    request(app).get(`/api/multitable/bases/${BASE_ID}/history/events`).query({ limit: 100, ...query })
+  const detail = (batchId: string) => request(app).get(`/api/multitable/bases/${BASE_ID}/history/events/${batchId}`)
+  const batchIds = (res: { body?: { data?: { batches?: Array<{ batchId: string }> } } }) =>
+    (res.body?.data?.batches ?? []).map((b) => b.batchId)
+  const batchOf = (res: { body?: { data?: { batches?: Array<{ batchId: string }> } } }, id: string) =>
+    (res.body?.data?.batches ?? []).find((b) => b.batchId === id) as { batchId: string; visibleAffectedRecordCount: number } | undefined
+
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = { id: USER_ID, roles: testRoles, perms: ['multitable:read', 'multitable:write'] }
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'B2 History Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'B2 History Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_SECRET, SHEET_ID, JSON.stringify({ [STATUS]: 'secret' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_PUBLIC, SHEET_ID, JSON.stringify({ [STATUS]: 'public' })])
+
+    const rev = (rid: string, batchId: string, status: string) =>
+      q(
+        `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+         VALUES (gen_random_uuid(), $1, $2, 1, 'update', 'rest', $3, ARRAY[$4]::text[], '{}'::jsonb, $5::jsonb, $6)`,
+        [SHEET_ID, rid, USER_ID, STATUS, JSON.stringify({ [STATUS]: status }), batchId],
+      )
+    await rev(REC_SECRET, BULK_BATCH, 'secret')
+    await rev(REC_PUBLIC, BULK_BATCH, 'public')
+    await rev(REC_SECRET, SECRET_BATCH, 'secret')
+
+    // Pure M2: a 'none' record_permissions scope for USER on REC_SECRET. NO conditional_read_rules
+    // anywhere in this describe block — the existing history LOCK-3 goldens
+    // (multitable-history-events-realdb.test.ts) already drive the identical consumer contract via M4
+    // (conditional_read_rules); this block closes the loop for the OTHER `loadDeniedRecordIds` branch.
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)', [SHEET_ID, REC_SECRET, 'user', USER_ID, 'none'])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [USER_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    testRoles = []
+    await setFlag(false)
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('control (non-vacuous baseline): flag OFF, the M2-scoped batch is visible and counted', async () => {
+    const res = await events()
+    expect(res.status).toBe(200)
+    expect(batchIds(res)).toContain(SECRET_BATCH)
+    expect(res.body?.data?.total).toBe(2)
+    expect(batchOf(res, BULK_BATCH)?.visibleAffectedRecordCount).toBe(2)
+  })
+
+  test('flag ON (M2-direct): the all-denied batch is invisible + uncounted; the mixed batch drops the denied record', async () => {
+    await setFlag(true)
+    const res = await events()
+    expect(res.status).toBe(200)
+    const ids = batchIds(res)
+    expect(ids).not.toContain(SECRET_BATCH) // every record in this batch is M2-denied → batch invisible
+    expect(ids).toContain(BULK_BATCH)
+    expect(res.body?.data?.total).toBe(1) // post-filter total — the denied batch is NOT counted
+    expect(batchOf(res, BULK_BATCH)?.visibleAffectedRecordCount).toBe(1) // secret record dropped from the mixed batch
+  })
+
+  test('flag ON (M2-direct): batch detail for the denied batch shares the SAME 404 shape as a missing batch', async () => {
+    await setFlag(true)
+    const denied = await detail(SECRET_BATCH)
+    const missing = await detail(`batch_b2hist_missing_${TS}`)
+    expect(denied.status).toBe(404)
+    expect(missing.status).toBe(404)
+    expect(denied.body?.error?.code).toBe(missing.body?.error?.code) // no existence oracle
+  })
+
+  test('admin bypass: flag ON (M2-direct), an admin sees the denied batch and the full count', async () => {
+    await setFlag(true)
+    testRoles = ['admin']
+    const res = await events()
+    expect(res.status).toBe(200)
+    expect(batchIds(res)).toContain(SECRET_BATCH)
+    expect(batchOf(res, BULK_BATCH)?.visibleAffectedRecordCount).toBe(2)
+    expect((await detail(SECRET_BATCH)).status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary

Real-DB integration goldens for the W1-2 permission-matrix spec's **B2 (oracle/no-leak)** batch
(`docs/development/multitable-w1-2-permission-matrix-spec-20260705.md` §3/§5), the direct follow-on
to the **B1 (side-door)** batch shipped in #3649.

Two new test files, one per gap:

### G-5 — surface-consistency (row-level read-deny "zero presence" on collection surfaces)

`packages/core-backend/tests/integration/multitable-permmatrix-b2-g5-collection-noleak-realdb.test.ts` (11 tests)

A record the actor is row-level read-**denied** (M2: `row_level_read_permissions_enabled` flag +
`record_permissions` `'none'` scope) must leave **zero existence footprint** on collection/aggregate
surfaces. Grounded directly against current `origin/main` (not the spec's line numbers):

- **Export** (`GET /sheets/:sheetId/export-xlsx`) — genuinely new coverage. The route already
  implements the M2 exclusion (`exportDeniedIds` via `loadRowLevelReadDenyEnabled` +
  `loadDeniedRecordIds`, `univer-meta.ts` ~12148-12420) in **both** its branches — the no-view
  cursor-pagination stream and the view-filter/sort load-all path — but no existing golden
  exercised the M2 flag against export (`multitable-export-allrows-maskroute-realdb.test.ts` only
  covers `field_permissions` + view filter/sort; `multitable-export-permission-canary.test.ts`'s own
  header says record-scope was "NOT covered" — written before the M2 feature existed). 6 tests: flag-off
  control, no-view branch (xlsx + csv), view load-all branch (sort still correct on the surviving
  set), admin bypass.
- **History** (`GET /bases/:baseId/history/events[/:batchId]`) — a small, non-duplicating M2-direct
  supplementary check (5 tests: control, batch invisible + total excludes it + mixed-batch drops the
  record, detail 404-parity with a missing batch, admin bypass). `loadDeniedRecordIds` unions M2
  grant-deny and M4 rule-deny into one `Set`, and `multitable-history-events-realdb.test.ts` already
  thoroughly locks the *consumer* contract (LOCK-3) via the M4 trigger — but never via a pure M2 row.
  This closes that specific loop without re-deriving the full existing LOCK-3/cursor/search matrix.

**Dropped as redundant (not duplicated, referenced instead):** list (`GET /records`),
`/records-summary`, and `view-aggregate` zero-presence are **already locked directly against this
same M2 mechanism** by `multitable-rowlevel-readdeny-enforce.test.ts` ("GET /records flag ON:
EXCLUDED", "/records-summary flag ON: EXCLUDED", "view-aggregate flag ON: EXCLUDED"). Re-asserting
them would be genuine duplication. The single-record GET's **LOCKED** 403+no-`data` contract is
explicitly unchanged and not re-asserted (per the spec's owner-corrected G-5 scope) — it stays
pinned by the existing golden.

### G-4 — OAPI read-mask parity (per-route differential)

`packages/core-backend/tests/integration/multitable-permmatrix-b2-g4-oapi-mask-parity-realdb.test.ts` (6 tests)

An `mst_` token read is differentially compared against the **same creator's interactive (session)
read**, per route, across all 5 `records:read` OAPI-1 routes (`oapi-read-allowlist.ts`'s own
docstring enumeration: list, single, `/view`, `view-aggregate`, `/records-summary`). Existing
coverage (`multitable-oapi1-token-read-realdb.test.ts`) proves auth mechanics (guards mounted, scope
enforcement) and a partial semantic property (row-deny doesn't leak through the token on 2 of the 5
routes) — but no existing golden performs a direct differential with **both** a `field_permissions`
mask (M1) **and** a row-level deny (M2) live simultaneously, asserting the two channel outputs are
the *same* masked shape (not just independently "safe"). One test per route (5) + sentinel.

## Non-vacuousness proof

Temporarily commented out the M2 `record_permissions` deny-seed in the export fixture and re-ran the
`no-view branch` tests: both flipped RED (`expected 3 to be 2`, the denied row reappeared). Reverted
immediately after confirming. See commit history is clean — the revert is not a separate commit, it
was verified pre-commit.

## Verification (fresh dedicated DB, real numbers)

```
createdb metasheet_w12b2_test
DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_w12b2_test pnpm --filter @metasheet/core-backend db:migrate
# 233 migrations applied cleanly
```

- New goldens alone: **2 files, 17/17 passed** (11 + 6).
- Combined with all directly-referenced sibling suites (rowlevel-readdeny-{enforce,xrec,flag-endpoint},
  history-events{,-hasmore}-realdb, export-allrows-maskroute-realdb, export-permission-canary,
  oapi1-{token,comments}-read-realdb, oapi-scope-guard-realdb, permmatrix-b1-oapi-token-write-realdb):
  **13 files, 134/134 passed** — no interference (module-level caches, shared tables).
- `tsc --noEmit` on `packages/core-backend`: **clean (exit 0)**.
- Orphaned rows after the full run: **zero** across `meta_bases/meta_sheets/meta_fields/meta_records/meta_views/meta_record_revisions/record_permissions/field_permissions/users/multitable_api_tokens` for every seeded id prefix.
- **No runtime leak found.** Both files pass against unmodified current `main` on the first run — this
  PR pins existing correct behavior; it does not fix anything. (The only RED observed anywhere was the
  intentional, reverted non-vacuousness flip above — a weakened *test fixture*, not a runtime change.)

## Scope

Test-only. No `src/` runtime file touched — confirmed via `git status`/diff (only the two new test
files + the `.github/workflows/plugin-tests.yml` explicit allowlist wiring, verified enumerated not a
glob).

Cross-refs: #3649 (B1 side-door), `docs/development/multitable-w1-2-permission-matrix-spec-20260705.md`
§3 (G-4, G-5) / §5 (B2 batch definition).

Do not merge — owner will verify and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)