### PR TITLE
feat(approval): CFG-1 card-config resolvers — env-first, stored-encrypted fallback (one-tap config lock)

### DIFF
--- a/packages/core-backend/src/integrations/dingtalk/approval-card-config.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-config.ts
@@ -1,0 +1,93 @@
+/**
+ * CFG-1 (card-config settings lock, §3.1): runtime resolvers for the one-tap approval-card
+ * configuration — the deep-link HMAC signing secret and the public app URL the links point at.
+ *
+ * Resolution order (mirrors readDingTalkMessageConfigFromRuntime): env FIRST, stored
+ * directory_integrations.config fallback second. The stored secret is written through
+ * security/encrypted-secrets (same path as appSecret / workNotificationAgentId) and is only
+ * ever decrypted here, server-side.
+ *
+ * Invariants:
+ * - SAME-SOURCE: the card sender (sign) and the card-delivery wrapper (verify) must both call
+ *   these resolvers so a token signed on send always verifies on decision — guaranteed by
+ *   "env first, else the one stored dingtalk integration".
+ * - FAIL-CLOSED: any miss (no env, no row, decrypt failure, query failure) resolves to '' —
+ *   the card action refuses to send and the wrapper refuses to verify. Never a fallback secret.
+ */
+import { query } from '../../db/pg'
+import { decryptStoredSecretValue } from '../../security/encrypted-secrets'
+
+const DEFAULT_PROVIDER = 'dingtalk'
+export const APPROVAL_CARD_LINK_SECRET_CONFIG_KEY = 'approvalCardLinkSecret'
+export const APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY = 'approvalCardPublicAppUrl'
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+type JsonRecord = Record<string, unknown>
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function parseJsonRecord(value: unknown): JsonRecord {
+  if (!value) return {}
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return parsed && typeof parsed === 'object' ? parsed as JsonRecord : {}
+    } catch {
+      return {}
+    }
+  }
+  return typeof value === 'object' ? value as JsonRecord : {}
+}
+
+/** Same integration pick as loadStoredWorkNotificationConfig: active first, then most recent. */
+async function loadStoredApprovalCardConfig(queryFn: QueryFn): Promise<JsonRecord> {
+  const result = await queryFn(
+    `SELECT config
+       FROM directory_integrations
+      WHERE provider = $1
+      ORDER BY CASE WHEN status = 'active' THEN 0 ELSE 1 END, updated_at DESC
+      LIMIT 1`,
+    [DEFAULT_PROVIDER],
+  )
+  const row = (result.rows[0] ?? null) as { config?: unknown } | null
+  return parseJsonRecord(row?.config)
+}
+
+/**
+ * Deep-link HMAC signing secret: env `APPROVAL_CARD_LINK_SECRET` first, else the stored
+ * (encrypted-at-rest) `approvalCardLinkSecret`, else '' (fail-closed).
+ */
+export async function resolveApprovalCardLinkSecret(queryFn: QueryFn = query): Promise<string> {
+  const fromEnv = (process.env.APPROVAL_CARD_LINK_SECRET ?? '').trim()
+  if (fromEnv) return fromEnv
+  try {
+    const config = await loadStoredApprovalCardConfig(queryFn)
+    const stored = normalizeText(config[APPROVAL_CARD_LINK_SECRET_CONFIG_KEY])
+    if (!stored) return ''
+    return decryptStoredSecretValue(stored).trim()
+  } catch {
+    // Fail-closed: an unreadable/undecryptable stored secret must never sign or verify.
+    return ''
+  }
+}
+
+/**
+ * Public base URL for the decision deep link: env (`PUBLIC_APP_URL` / `APP_BASE_URL`) first,
+ * else the stored `approvalCardPublicAppUrl` (plaintext — not a secret), else null.
+ * Normalized to a trailing slash exactly like resolveAutomationAppBaseUrl.
+ */
+export async function resolveApprovalCardPublicAppUrl(queryFn: QueryFn = query): Promise<string | null> {
+  const fromEnv = process.env.PUBLIC_APP_URL?.trim() || process.env.APP_BASE_URL?.trim() || ''
+  if (fromEnv) return fromEnv.endsWith('/') ? fromEnv : `${fromEnv}/`
+  try {
+    const config = await loadStoredApprovalCardConfig(queryFn)
+    const stored = normalizeText(config[APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY])
+    if (!stored) return null
+    return stored.endsWith('/') ? stored : `${stored}/`
+  } catch {
+    return null
+  }
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -23,6 +23,10 @@ import {
 } from '../integrations/dingtalk/client'
 import { readDingTalkMessageConfigFromRuntime } from '../integrations/dingtalk/work-notification-settings'
 import {
+  resolveApprovalCardLinkSecret,
+  resolveApprovalCardPublicAppUrl,
+} from '../integrations/dingtalk/approval-card-config'
+import {
   insertDingTalkApprovalCardDelivery,
   markDingTalkApprovalCardDeliverySendFailed,
   markDingTalkApprovalCardDeliverySent,
@@ -2556,13 +2560,15 @@ export class AutomationExecutor {
       return { actionType, status: 'failed', error: 'send_dingtalk_approval_card requires an approval.task_created trigger event' }
     }
 
-    const baseUrl = resolveAutomationAppBaseUrl()
+    // CFG-1: env first, stored directory-integration config as fallback (same-source with the
+    // wrapper's verify — see approval-card-config.ts). Empty still fail-closes the send.
+    const baseUrl = await resolveApprovalCardPublicAppUrl(this.deps.queryFn)
     if (!baseUrl) {
-      return { actionType, status: 'failed', error: 'PUBLIC_APP_URL or APP_BASE_URL is required for the approval decision link' }
+      return { actionType, status: 'failed', error: 'PUBLIC_APP_URL or APP_BASE_URL (or the stored approval-card public app URL) is required for the approval decision link' }
     }
-    const linkSecret = (process.env.APPROVAL_CARD_LINK_SECRET ?? '').trim()
+    const linkSecret = await resolveApprovalCardLinkSecret(this.deps.queryFn)
     if (!linkSecret) {
-      return { actionType, status: 'failed', error: 'APPROVAL_CARD_LINK_SECRET is required for signed approval decision links' }
+      return { actionType, status: 'failed', error: 'APPROVAL_CARD_LINK_SECRET (env or stored approval-card link secret) is required for signed approval decision links' }
     }
 
     // Instance metadata for the card summary — ids/title/request_no only, NO form values.

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -15,6 +15,7 @@
 import { createHmac, timingSafeEqual } from 'crypto'
 
 import type { ApprovalProductService } from './ApprovalProductService'
+import { resolveApprovalCardLinkSecret } from '../integrations/dingtalk/approval-card-config'
 import {
   claimDingTalkApprovalCardDeliveryActed,
   findDingTalkApprovalCardDeliveryById,
@@ -54,12 +55,19 @@ export type ApprovalCardActionOutcome =
   | { status: 'engine_rejected'; code: string; message: string; httpStatus: number; summary: ApprovalCardDeliverySummary }
 
 /**
- * Deep-link token: HMAC-SHA256(deliveryId, APPROVAL_CARD_LINK_SECRET) truncated to 32 hex chars —
- * matches the executor's link composition exactly. Fail-closed without the secret.
+ * Deep-link token: HMAC-SHA256(deliveryId, approval-card link secret) truncated to 32 hex chars —
+ * matches the executor's link composition exactly. CFG-1: the secret resolves env-first with the
+ * stored (encrypted) directory-integration config as fallback — the SAME source the executor signs
+ * with. Fail-closed without the secret.
  */
-export function verifyApprovalCardLinkToken(deliveryId: string, token: string): boolean {
-  const secret = (process.env.APPROVAL_CARD_LINK_SECRET ?? '').trim()
-  if (!secret || !deliveryId || !token || token.length !== 32) return false
+export async function verifyApprovalCardLinkToken(
+  deliveryId: string,
+  token: string,
+  queryFn?: QueryFn,
+): Promise<boolean> {
+  if (!deliveryId || !token || token.length !== 32) return false
+  const secret = await resolveApprovalCardLinkSecret(queryFn)
+  if (!secret) return false
   const expected = createHmac('sha256', secret).update(deliveryId).digest('hex').slice(0, 32)
   const a = Buffer.from(expected, 'utf8')
   const b = Buffer.from(token, 'utf8')
@@ -124,7 +132,7 @@ export async function getApprovalCardDeliverySummary(
   deps: { query: QueryFn },
   input: { deliveryId: string; token: string; viewerUserId: string },
 ): Promise<{ status: 'ok'; summary: ApprovalCardDeliverySummary } | { status: 'not_found' }> {
-  if (!verifyApprovalCardLinkToken(input.deliveryId, input.token)) return { status: 'not_found' }
+  if (!(await verifyApprovalCardLinkToken(input.deliveryId, input.token, deps.query))) return { status: 'not_found' }
   const delivery = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
   if (!delivery) return { status: 'not_found' }
   const summary = await buildSummary(deps.query, delivery, input.viewerUserId)
@@ -142,7 +150,7 @@ export async function executeApprovalActionFromCardDelivery(
     actor: { userId: string; userName: string; roles?: string[]; ip?: string | null; userAgent?: string | null }
   },
 ): Promise<ApprovalCardActionOutcome> {
-  if (!verifyApprovalCardLinkToken(input.deliveryId, input.token)) return { status: 'not_found' }
+  if (!(await verifyApprovalCardLinkToken(input.deliveryId, input.token, deps.query))) return { status: 'not_found' }
   const delivery = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
   if (!delivery) return { status: 'not_found' }
 

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -22,6 +22,7 @@ import {
   insertDingTalkApprovalCardDelivery,
   markDingTalkApprovalCardDeliverySent,
 } from '../../src/integrations/dingtalk/approval-card-deliveries'
+import { normalizeStoredSecretValue } from '../../src/security/encrypted-secrets'
 import { createHmac } from 'crypto'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
@@ -121,8 +122,8 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     const instanceId = await newInstance()
     const deliveryId = await newSentDelivery(instanceId)
 
-    expect(verifyApprovalCardLinkToken(deliveryId, tokenFor(deliveryId))).toBe(true)
-    expect(verifyApprovalCardLinkToken(deliveryId, 'f'.repeat(32))).toBe(false)
+    expect(await verifyApprovalCardLinkToken(deliveryId, tokenFor(deliveryId))).toBe(true)
+    expect(await verifyApprovalCardLinkToken(deliveryId, 'f'.repeat(32))).toBe(false)
 
     expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: 'f'.repeat(32), viewerUserId: APPROVER })).status).toBe('not_found')
     const ghost = randomUUID()
@@ -134,6 +135,35 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
       expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })).status).toBe('not_found')
     } finally {
       process.env.APPROVAL_CARD_LINK_SECRET = prev
+    }
+  })
+
+  test('CFG-1 stored-secret fallback: env unset → wrapper verifies a token signed with the stored (encrypted) secret', async () => {
+    const instanceId = await newInstance()
+    const deliveryId = await newSentDelivery(instanceId)
+    const storedSecret = `cdw-stored-secret-${TS}`
+    const prev = process.env.APPROVAL_CARD_LINK_SECRET
+    delete process.env.APPROVAL_CARD_LINK_SECRET
+    // Far-future updated_at so the resolver's "active first, most recent" pick lands on this row
+    // even in the shared plugin-tests database; removed in finally (shared-DB fixture discipline).
+    const inserted = await q(
+      `INSERT INTO directory_integrations (name, provider, status, corp_id, config, updated_at)
+       VALUES ($1, 'dingtalk', 'active', $2, $3::jsonb, '2099-01-01T00:00:00Z')
+       RETURNING id`,
+      [`cdw-card-config-${TS}`, `corp_cdw_${TS}`, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(storedSecret) })],
+    )
+    const integrationId = (inserted.rows[0] as { id: string }).id
+    try {
+      const storedToken = createHmac('sha256', storedSecret).update(deliveryId).digest('hex').slice(0, 32)
+      // Same-source invariant at the DB level: sign with the stored secret, verify through the wrapper.
+      expect(await verifyApprovalCardLinkToken(deliveryId, storedToken, q)).toBe(true)
+      expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: storedToken, viewerUserId: APPROVER })).status).toBe('ok')
+      // The env-signed token no longer matches — stored source is authoritative when env is unset.
+      expect(await verifyApprovalCardLinkToken(deliveryId, tokenFor(deliveryId), q)).toBe(false)
+    } finally {
+      await q('DELETE FROM directory_integrations WHERE id = $1', [integrationId]).catch(() => {})
+      if (prev === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET
+      else process.env.APPROVAL_CARD_LINK_SECRET = prev
     }
   })
 

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -144,11 +144,13 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     const storedSecret = `cdw-stored-secret-${TS}`
     const prev = process.env.APPROVAL_CARD_LINK_SECRET
     delete process.env.APPROVAL_CARD_LINK_SECRET
-    // Far-future updated_at so the resolver's "active first, most recent" pick lands on this row
-    // even in the shared plugin-tests database; removed in finally (shared-DB fixture discipline).
+    // Freshest updated_at (now()) so the resolver's "active first, most recent" pick lands on this
+    // row in the shared plugin-tests database; removed in finally (shared-DB fixture discipline).
+    // Deliberately NOT far-future: if a crash ever skips the finally, a now() row cannot
+    // permanently shadow later-updated real integrations.
     const inserted = await q(
       `INSERT INTO directory_integrations (name, provider, status, corp_id, config, updated_at)
-       VALUES ($1, 'dingtalk', 'active', $2, $3::jsonb, '2099-01-01T00:00:00Z')
+       VALUES ($1, 'dingtalk', 'active', $2, $3::jsonb, now())
        RETURNING id`,
       [`cdw-card-config-${TS}`, `corp_cdw_${TS}`, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(storedSecret) })],
     )

--- a/packages/core-backend/tests/unit/dingtalk-approval-card-config.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-approval-card-config.test.ts
@@ -1,0 +1,120 @@
+import { createHmac } from 'crypto'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { normalizeStoredSecretValue } from '../../src/security/encrypted-secrets'
+
+const dbMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: dbMocks.query,
+}))
+
+import {
+  APPROVAL_CARD_LINK_SECRET_CONFIG_KEY,
+  APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY,
+  resolveApprovalCardLinkSecret,
+  resolveApprovalCardPublicAppUrl,
+} from '../../src/integrations/dingtalk/approval-card-config'
+import { verifyApprovalCardLinkToken } from '../../src/services/ApprovalCardDeliveryAction'
+
+function integrationRow(config: Record<string, unknown> = {}) {
+  return { config }
+}
+
+function clearCardEnv() {
+  vi.stubEnv('APPROVAL_CARD_LINK_SECRET', '')
+  vi.stubEnv('PUBLIC_APP_URL', '')
+  vi.stubEnv('APP_BASE_URL', '')
+}
+
+describe('approval card config resolvers (CFG-1)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+    dbMocks.query.mockReset()
+    clearCardEnv()
+  })
+
+  describe('resolveApprovalCardLinkSecret', () => {
+    it('env wins and skips the store entirely', async () => {
+      vi.stubEnv('APPROVAL_CARD_LINK_SECRET', '  env-secret  ')
+      await expect(resolveApprovalCardLinkSecret()).resolves.toBe('env-secret')
+      expect(dbMocks.query).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the stored encrypted secret and decrypts it', async () => {
+      dbMocks.query.mockResolvedValueOnce({
+        rows: [integrationRow({ [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('stored-card-secret') })],
+      })
+      await expect(resolveApprovalCardLinkSecret()).resolves.toBe('stored-card-secret')
+      const [sql, params] = dbMocks.query.mock.calls[0] as [string, unknown[]]
+      expect(sql).toContain('FROM directory_integrations')
+      expect(params).toEqual(['dingtalk'])
+    })
+
+    it('resolves empty (fail-closed) when no integration row or no stored key', async () => {
+      dbMocks.query.mockResolvedValueOnce({ rows: [] })
+      await expect(resolveApprovalCardLinkSecret()).resolves.toBe('')
+      dbMocks.query.mockResolvedValueOnce({ rows: [integrationRow({})] })
+      await expect(resolveApprovalCardLinkSecret()).resolves.toBe('')
+    })
+
+    it('resolves empty (fail-closed) on query failure or undecryptable stored value', async () => {
+      dbMocks.query.mockRejectedValueOnce(new Error('db down'))
+      await expect(resolveApprovalCardLinkSecret()).resolves.toBe('')
+      dbMocks.query.mockResolvedValueOnce({
+        rows: [integrationRow({ [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: 'enc:not-a-real-ciphertext' })],
+      })
+      await expect(resolveApprovalCardLinkSecret()).resolves.toBe('')
+    })
+
+    it('sign/verify same-source invariant: a token signed with the resolved stored secret verifies', async () => {
+      const stored = integrationRow({ [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('same-source-secret') })
+      dbMocks.query.mockResolvedValue({ rows: [stored] })
+
+      // Executor side: sign with whatever the resolver yields (env unset → stored path).
+      const secret = await resolveApprovalCardLinkSecret()
+      expect(secret).toBe('same-source-secret')
+      const deliveryId = 'card-delivery-1'
+      const token = createHmac('sha256', secret).update(deliveryId).digest('hex').slice(0, 32)
+
+      // Wrapper side: verify resolves the SAME stored source.
+      await expect(verifyApprovalCardLinkToken(deliveryId, token)).resolves.toBe(true)
+      await expect(verifyApprovalCardLinkToken(deliveryId, 'f'.repeat(32))).resolves.toBe(false)
+    })
+
+    it('verify fail-closes when neither env nor store has a secret', async () => {
+      dbMocks.query.mockResolvedValue({ rows: [] })
+      await expect(verifyApprovalCardLinkToken('card-delivery-1', 'f'.repeat(32))).resolves.toBe(false)
+      // Even a token forged with an EMPTY HMAC key must be rejected — no secret means no verify.
+      const emptyKeyForgery = createHmac('sha256', '').update('card-delivery-1').digest('hex').slice(0, 32)
+      await expect(verifyApprovalCardLinkToken('card-delivery-1', emptyKeyForgery)).resolves.toBe(false)
+    })
+  })
+
+  describe('resolveApprovalCardPublicAppUrl', () => {
+    it('env wins (PUBLIC_APP_URL then APP_BASE_URL) with trailing-slash normalization', async () => {
+      vi.stubEnv('PUBLIC_APP_URL', 'https://app.example.com')
+      await expect(resolveApprovalCardPublicAppUrl()).resolves.toBe('https://app.example.com/')
+      vi.stubEnv('PUBLIC_APP_URL', '')
+      vi.stubEnv('APP_BASE_URL', 'https://base.example.com/')
+      await expect(resolveApprovalCardPublicAppUrl()).resolves.toBe('https://base.example.com/')
+      expect(dbMocks.query).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the stored plaintext URL, normalized', async () => {
+      dbMocks.query.mockResolvedValueOnce({
+        rows: [integrationRow({ [APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY]: 'https://stored.example.com' })],
+      })
+      await expect(resolveApprovalCardPublicAppUrl()).resolves.toBe('https://stored.example.com/')
+    })
+
+    it('resolves null when nothing is configured or the store is unreadable', async () => {
+      dbMocks.query.mockResolvedValueOnce({ rows: [integrationRow({})] })
+      await expect(resolveApprovalCardPublicAppUrl()).resolves.toBeNull()
+      dbMocks.query.mockRejectedValueOnce(new Error('db down'))
+      await expect(resolveApprovalCardPublicAppUrl()).resolves.toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
Implements **CFG-1** of the card-config settings design-lock `docs/development/approval-card-config-settings-ui-design-lock-20260706.md` (#3690, **PROPOSED**) — merging this PR = ratifying the lock's direction for the resolver layer.

## What
- **New `integrations/dingtalk/approval-card-config.ts`**: `resolveApprovalCardLinkSecret()` + `resolveApprovalCardPublicAppUrl()` — **env FIRST** (operator override unchanged), then stored `directory_integrations.config` fallback (`approvalCardLinkSecret` decrypted via `security/encrypted-secrets` — same path as appSecret/workNotificationAgentId; `approvalCardPublicAppUrl` plaintext), else **fail-closed empty**. Store/decrypt failures resolve empty — never a fallback secret.
- **Two read-point switches** (the only as-built `process.env.APPROVAL_CARD_LINK_SECRET` readers):
  - `automation-executor.ts` `executeSendDingTalkApprovalCard` — sign side
  - `ApprovalCardDeliveryAction.ts` `verifyApprovalCardLinkToken` — verify side, now async with `deps.query` passthrough
  - **Same-source invariant**: both resolve env-first-else-the-same-stored-row → a token signed on send always verifies on decision.
- **Behavior with env set is byte-identical** (env short-circuits before any query) — the ratified #3594 chain is untouched; this only adds the stored fallback CFG-2/CFG-3 will write into.

## Verification
- Unit 9/9 (`tests/unit/dingtalk-approval-card-config.test.ts`): env priority skips store · stored decrypt · missing row/key + query failure + undecryptable value all fail-closed · **empty-key forgery rejected** · sign/verify same-source round-trip · URL env order/trailing-slash/stored fallback.
- Real-DB (fresh `ms2_cfg1_verify` DB, migrations from zero): one-tap set **18/18** — A-2b action 5/5 + A-4 wrapper 8/8 (incl. **new** stored-secret fallback round-trip: env unset → wrapper verifies stored-signed token, rejects env-signed token; fixture removed in finally per shared-DB discipline) + task_created trigger 5/5.
- `tsc --noEmit` clean. No new CI wiring needed: unit file rides the default config; the wrapper file is already in plugin-tests.yml.

## Out of scope (lock checklist)
- CFG-2 generate endpoint (admin-gated, `{configured:true}` never echoes the value)
- CFG-3 DirectoryManagementView UI (generate button + chip + regenerate confirm + URL field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)