### PR TITLE
feat(web): UF-1 design-token foundation — tokens.css + Element Plus variable mapping

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -237,7 +237,7 @@ html, body {
   font-size: 14px;
   line-height: 1.5;
   color: #333;
-  background-color: #f5f5f5;
+  background-color: var(--ms-bg-page);
 }
 
 #app {
@@ -268,7 +268,7 @@ html, body {
 .brand-text {
   font-size: 18px;
   font-weight: 600;
-  color: #1976d2;
+  color: var(--ms-color-primary);
   white-space: nowrap;
 }
 
@@ -350,8 +350,8 @@ html, body {
 }
 
 .nav-link.router-link-active {
-  background-color: #e3f2fd;
-  color: #1976d2;
+  background-color: var(--el-color-primary-light-9);
+  color: var(--ms-color-primary);
 }
 
 .app-main {

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -6,6 +6,10 @@ import { createPinia } from 'pinia'
 import { createRouter, createWebHistory } from 'vue-router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
+// MetaSheet design tokens (single source of truth per the UI foundation
+// design-lock). MUST come after the element-plus stylesheet so the
+// `--el-color-*` overrides in tokens.css win the cascade.
+import './styles/tokens.css'
 // Shared border-left accent palette for effective-calendar chips. Imported
 // here once so multitable Calendar view, attendance personal calendar, and
 // holiday admin section all see the same `--calendar-source-accent` vars.

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,0 +1,110 @@
+/**
+ * MetaSheet design tokens — SINGLE SOURCE OF TRUTH for color / spacing /
+ * radius / typography / container widths, per the UI foundation design-lock
+ * (docs/development/ui-foundation-design-lock-20260706.md, RATIFIED).
+ *
+ * Rules (design-lock §3.1):
+ * - Views take color/spacing/radius/type ONLY from these `--ms-*` tokens.
+ * - New hardcoded hex values in views are DEFECTS — add/consume a token instead.
+ *
+ * Element Plus mapping: the `--el-color-*` overrides below repaint the whole
+ * component library from the same palette (EP's official theming path).
+ * Derived shades are precomputed hex literals (no build-time theme tooling):
+ *   light-i : per-channel c' = round(c + (255 - c) * i / 10)   (mix toward white)
+ *   dark-2  : per-channel c' = round(c * 0.8)                  (mix 20% toward black)
+ */
+
+:root {
+  /* ---- Semantic colors (design-lock §4) ---- */
+  --ms-color-primary: #2563eb; /* single site-wide primary */
+  --ms-color-success: #16a34a; /* approved / success */
+  --ms-color-warning: #d97706; /* waiting / timeout warning */
+  --ms-color-danger: #dc2626;  /* rejected / failure */
+  --ms-color-info: #6b7280;    /* neutral / cancelled / skipped */
+
+  /* ---- Text (3-step gray scale) ---- */
+  --ms-text-1: #111827; /* titles */
+  --ms-text-2: #4b5563; /* body */
+  --ms-text-3: #9ca3af; /* auxiliary */
+
+  /* ---- Borders ---- */
+  --ms-border: #d1d5db;
+  --ms-border-light: #e5e7eb;
+
+  /* ---- Backgrounds ---- */
+  --ms-bg-page: #f5f6f8;
+  --ms-bg-card: #ffffff;
+
+  /* ---- Spacing scale ---- */
+  --ms-space-1: 4px;
+  --ms-space-2: 8px;
+  --ms-space-3: 12px;
+  --ms-space-4: 16px;
+  --ms-space-5: 24px;
+  --ms-space-6: 32px;
+
+  /* ---- Radius scale ---- */
+  --ms-radius-sm: 6px;
+  --ms-radius-md: 8px;
+  --ms-radius-lg: 12px;
+
+  /* ---- Typography ---- */
+  --ms-font-size-page-title: 20px;
+  --ms-font-weight-title: 600;
+  --ms-font-size-section-title: 16px;
+
+  /* ---- Container widths (PageShell tiers; wide = 100%) ---- */
+  --ms-page-narrow: 800px;
+  --ms-page-default: 1200px;
+
+  /* ================================================================
+   * Element Plus semantic-color mapping.
+   * Shades derived from the --ms-* base values above (formulas in the
+   * header comment); recompute if a base value ever changes.
+   * ================================================================ */
+
+  /* primary — base #2563eb */
+  --el-color-primary: var(--ms-color-primary);
+  --el-color-primary-light-3: #6692f1;
+  --el-color-primary-light-5: #92b1f5;
+  --el-color-primary-light-7: #bed0f9;
+  --el-color-primary-light-8: #d3e0fb;
+  --el-color-primary-light-9: #e9effd;
+  --el-color-primary-dark-2: #1e4fbc;
+
+  /* success — base #16a34a */
+  --el-color-success: var(--ms-color-success);
+  --el-color-success-light-3: #5cbf80;
+  --el-color-success-light-5: #8bd1a5;
+  --el-color-success-light-7: #b9e3c9;
+  --el-color-success-light-8: #d0eddb;
+  --el-color-success-light-9: #e8f6ed;
+  --el-color-success-dark-2: #12823b;
+
+  /* warning — base #d97706 */
+  --el-color-warning: var(--ms-color-warning);
+  --el-color-warning-light-3: #e4a051;
+  --el-color-warning-light-5: #ecbb83;
+  --el-color-warning-light-7: #f4d6b4;
+  --el-color-warning-light-8: #f7e4cd;
+  --el-color-warning-light-9: #fbf1e6;
+  --el-color-warning-dark-2: #ae5f05;
+
+  /* danger — base #dc2626 */
+  --el-color-danger: var(--ms-color-danger);
+  --el-color-danger-light-3: #e76767;
+  --el-color-danger-light-5: #ee9393;
+  --el-color-danger-light-7: #f5bebe;
+  --el-color-danger-light-8: #f8d4d4;
+  --el-color-danger-light-9: #fce9e9;
+  --el-color-danger-dark-2: #b01e1e;
+
+  /* info — base #6b7280 */
+  --el-color-info: var(--ms-color-info);
+  --el-color-info-light-3: #979ca6;
+  --el-color-info-light-5: #b5b9c0;
+  --el-color-info-light-7: #d3d5d9;
+  --el-color-info-light-8: #e1e3e6;
+  --el-color-info-light-9: #f0f1f2;
+  --el-color-info-dark-2: #565b66;
+}

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -99,6 +99,16 @@
   --el-color-danger-light-9: #fce9e9;
   --el-color-danger-dark-2: #b01e1e;
 
+  /* error — Element Plus's alias family for danger (form validation text etc.);
+   * left unmapped it would keep EP's stock red beside our danger red. */
+  --el-color-error: var(--ms-color-danger);
+  --el-color-error-light-3: #e76767;
+  --el-color-error-light-5: #ee9393;
+  --el-color-error-light-7: #f5bebe;
+  --el-color-error-light-8: #f8d4d4;
+  --el-color-error-light-9: #fce9e9;
+  --el-color-error-dark-2: #b01e1e;
+
   /* info — base #6b7280 */
   --el-color-info: var(--ms-color-info);
   --el-color-info-light-3: #979ca6;

--- a/apps/web/tests/tokens-foundation.spec.ts
+++ b/apps/web/tests/tokens-foundation.spec.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * UF-1 guard: styles/tokens.css is the single source of truth per the UI
+ * foundation design-lock (docs/development/ui-foundation-design-lock-20260706.md).
+ * These assertions pin the contract, not the palette values.
+ */
+const tokensCss = readFileSync(resolve(__dirname, '../src/styles/tokens.css'), 'utf8')
+
+describe('UF-1 design-token foundation (tokens.css)', () => {
+  it('defines --ms-color-danger (previously a ghost token referenced with a fallback hex)', () => {
+    expect(tokensCss).toMatch(/--ms-color-danger:\s*#[0-9a-fA-F]{6}\s*;/)
+  })
+
+  it('maps --el-color-primary to var(--ms-color-primary)', () => {
+    expect(tokensCss).toMatch(/--el-color-primary:\s*var\(--ms-color-primary\)\s*;/)
+  })
+
+  it('contains no !important (tokens win by import order, not specificity hacks)', () => {
+    expect(tokensCss).not.toContain('!important')
+  })
+})


### PR DESCRIPTION
Implements **UF-1** of the UI foundation design-lock (`docs/development/ui-foundation-design-lock-20260706.md`, RATIFIED — lock PR #3696).

## What
- **`apps/web/src/styles/tokens.css`** (new): single source of truth — `--ms-*` semantic colors (one primary `#2563eb`, success/warning/danger/info), 3-step text grays, borders, backgrounds, spacing scale 4..32, radius scale, title typography, PageShell container widths. Header states the rule: new hardcoded hex in views = defect.
- **Element Plus mapping**: `--el-color-{primary,success,warning,danger,error,info}` + light-3/5/7/8/9 + dark-2 derived per EP's mix convention, precomputed hex literals (no build tooling). *error family mapped onto danger* so EP form-validation red matches token red (review fix).
- **`main.ts`**: tokens.css imported after the EP stylesheet so overrides win — **intentional app-wide repaint** per lock §5 (one-shot re-skin; pages converge in later UF slices).
- **`App.vue`** shell convergence: `#1976d2` brand/active-nav → `var(--ms-color-primary)`, `#e3f2fd` → `var(--el-color-primary-light-9)`, body `#f5f5f5` → `var(--ms-bg-page)`. No structural change.
- Grounds the previously-ghost `--ms-color-danger` (referenced in MetaAutomationRuleEditor with a fallback; call sites untouched, now render token red).
- Guard spec `tests/tokens-foundation.spec.ts`: danger token defined · `--el-color-primary` maps to the ms token · no `!important`.

## Verification
- `vue-tsc -b` 0 errors · `@metasheet/web` production build green · guard spec 3/3
- Derived shades independently recomputed by the reviewer (main loop) — exact match
- No existing test asserts the replaced hexes (grepped)
- Presentation-only: no API/permission/data-path change (lock §5 discipline)

Implemented by a Fable 5 agent per the model-split policy; reviewed + hardened (error-family mapping) by the main loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)