### PR TITLE
feat(approval): CFG-2 card-config self-service — server-side secret generate + URL save (admin-gated, no echo)

### DIFF
--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -277,6 +277,8 @@ export type DirectoryIntegrationSummary = {
     appKey: string
     appSecretConfigured: boolean
     workNotificationAgentIdConfigured: boolean
+    approvalCardLinkSecretConfigured: boolean
+    approvalCardPublicAppUrl: string | null
     rootDepartmentId: string
     baseUrl: string | null
     pageSize: number
@@ -976,6 +978,8 @@ function parseIntegrationConfig(row: Pick<DirectoryIntegrationRow, 'config'>): D
 
 function summarizeIntegration(row: DirectoryIntegrationRow): DirectoryIntegrationSummary {
   const config = parseIntegrationConfig(row)
+  // Approval-card keys are presence-only in summaries (secret never decrypted here).
+  const rawConfig = parseJsonRecord(row.config)
   return {
     id: row.id,
     orgId: row.org_id,
@@ -995,6 +999,8 @@ function summarizeIntegration(row: DirectoryIntegrationRow): DirectoryIntegratio
       appKey: config.appKey,
       appSecretConfigured: Boolean(config.appSecret),
       workNotificationAgentIdConfigured: Boolean(config.workNotificationAgentId),
+      approvalCardLinkSecretConfigured: Boolean(normalizeText(rawConfig.approvalCardLinkSecret)),
+      approvalCardPublicAppUrl: normalizeText(rawConfig.approvalCardPublicAppUrl) || null,
       rootDepartmentId: config.rootDepartmentId,
       baseUrl: config.baseUrl ?? null,
       pageSize: config.pageSize,
@@ -1579,6 +1585,13 @@ export async function updateDirectoryIntegration(
     memberGroupDefaultRoleIds: normalized.memberGroupDefaultRoleIds,
     memberGroupDefaultNamespaces: normalized.memberGroupDefaultNamespaces,
   })
+  // Carry-through for keys NOT edited by this generic form (approval-card config lives in the
+  // same JSONB but is written only via its dedicated admin endpoints): the rebuild below would
+  // otherwise silently wipe them on every integration-form save. The encrypted secret is carried
+  // as-is — never decrypted here.
+  const rawCurrentConfig = parseJsonRecord(current.config)
+  const carriedApprovalCardLinkSecret = normalizeText(rawCurrentConfig.approvalCardLinkSecret) || null
+  const carriedApprovalCardPublicAppUrl = normalizeText(rawCurrentConfig.approvalCardPublicAppUrl) || null
   const result = await query<DirectoryIntegrationRow>(
     `UPDATE directory_integrations
      SET name = $2,
@@ -1613,6 +1626,8 @@ export async function updateDirectoryIntegration(
         memberGroupDepartmentIds: normalized.memberGroupDepartmentIds,
         memberGroupDefaultRoleIds: normalized.memberGroupDefaultRoleIds,
         memberGroupDefaultNamespaces: normalized.memberGroupDefaultNamespaces,
+        approvalCardLinkSecret: carriedApprovalCardLinkSecret,
+        approvalCardPublicAppUrl: carriedApprovalCardPublicAppUrl,
       }),
       Boolean(normalized.syncEnabled),
       normalized.scheduleCron,

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-config.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-config.ts
@@ -14,8 +14,10 @@
  * - FAIL-CLOSED: any miss (no env, no row, decrypt failure, query failure) resolves to '' —
  *   the card action refuses to send and the wrapper refuses to verify. Never a fallback secret.
  */
+import { randomBytes } from 'crypto'
+
 import { query } from '../../db/pg'
-import { decryptStoredSecretValue } from '../../security/encrypted-secrets'
+import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../../security/encrypted-secrets'
 
 const DEFAULT_PROVIDER = 'dingtalk'
 export const APPROVAL_CARD_LINK_SECRET_CONFIG_KEY = 'approvalCardLinkSecret'
@@ -90,4 +92,154 @@ export async function resolveApprovalCardPublicAppUrl(queryFn: QueryFn = query):
   } catch {
     return null
   }
+}
+
+/* ================================================================
+ * CFG-2 (card-config lock §3.2): admin self-service write surface.
+ * The secret is generated SERVER-SIDE, stored encrypted, and NEVER
+ * returned by any function below — responses carry booleans only.
+ * ================================================================ */
+
+type ConfigSource = 'env' | 'stored' | 'missing'
+
+export type ApprovalCardConfigStatus = {
+  integration: { id: string; name: string; status: string }
+  linkSecret: {
+    configured: boolean
+    source: ConfigSource
+    /** env wins at runtime — the UI must warn that a stored value is inert while env is set. */
+    envOverrideActive: boolean
+    valuePrinted: false
+  }
+  publicAppUrl: {
+    /** The stored URL (plain, not a secret) — null when unset. */
+    storedValue: string | null
+    source: ConfigSource
+    envOverrideActive: boolean
+  }
+}
+
+type IntegrationConfigRow = {
+  id: string
+  name: string
+  status: string
+  config: unknown
+}
+
+async function loadIntegrationById(queryFn: QueryFn, integrationId: string): Promise<IntegrationConfigRow | null> {
+  const normalizedId = normalizeText(integrationId)
+  if (!normalizedId) return null
+  const result = await queryFn(
+    `SELECT id, name, status, config
+       FROM directory_integrations
+      WHERE id = $1 AND provider = $2
+      LIMIT 1`,
+    [normalizedId, DEFAULT_PROVIDER],
+  )
+  return (result.rows[0] ?? null) as IntegrationConfigRow | null
+}
+
+function buildStatus(row: IntegrationConfigRow): ApprovalCardConfigStatus {
+  const config = parseJsonRecord(row.config)
+  const envSecret = (process.env.APPROVAL_CARD_LINK_SECRET ?? '').trim()
+  const storedSecret = normalizeText(config[APPROVAL_CARD_LINK_SECRET_CONFIG_KEY])
+  const envUrl = process.env.PUBLIC_APP_URL?.trim() || process.env.APP_BASE_URL?.trim() || ''
+  const storedUrl = normalizeText(config[APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY])
+  return {
+    integration: { id: row.id, name: row.name, status: row.status },
+    linkSecret: {
+      configured: Boolean(envSecret || storedSecret),
+      source: envSecret ? 'env' : storedSecret ? 'stored' : 'missing',
+      envOverrideActive: Boolean(envSecret),
+      valuePrinted: false,
+    },
+    publicAppUrl: {
+      storedValue: storedUrl || null,
+      source: envUrl ? 'env' : storedUrl ? 'stored' : 'missing',
+      envOverrideActive: Boolean(envUrl),
+    },
+  }
+}
+
+export async function getApprovalCardConfigStatus(
+  integrationId: string,
+  queryFn: QueryFn = query,
+): Promise<ApprovalCardConfigStatus | null> {
+  const row = await loadIntegrationById(queryFn, integrationId)
+  if (!row) return null
+  return buildStatus(row)
+}
+
+/**
+ * Generate a fresh 32-byte link secret server-side and store it ENCRYPTED
+ * (normalizeStoredSecretValue — same path as appSecret). The plaintext never
+ * leaves this function; callers get presence booleans only.
+ * Rotation semantics: overwriting an existing secret invalidates in-flight
+ * card links (they fail verify) — the UI confirms before regenerate.
+ */
+export async function generateApprovalCardLinkSecret(
+  integrationId: string,
+  queryFn: QueryFn = query,
+): Promise<ApprovalCardConfigStatus | null> {
+  const row = await loadIntegrationById(queryFn, integrationId)
+  if (!row) return null
+  const secret = randomBytes(32).toString('hex')
+  const encrypted = normalizeStoredSecretValue(secret)
+  const updated = await queryFn(
+    `UPDATE directory_integrations
+        SET config = jsonb_set(COALESCE(config, '{}'::jsonb), $2, to_jsonb($3::text), true),
+            updated_at = NOW()
+      WHERE id = $1 AND provider = $4
+      RETURNING id, name, status, config`,
+    [row.id, `{${APPROVAL_CARD_LINK_SECRET_CONFIG_KEY}}`, encrypted, DEFAULT_PROVIDER],
+  )
+  const updatedRow = (updated.rows[0] ?? null) as IntegrationConfigRow | null
+  if (!updatedRow) return null
+  return buildStatus(updatedRow)
+}
+
+/**
+ * Save (or clear, with '') the stored public app URL for the decision deep link.
+ * Only http(s) absolute URLs are accepted — the stored value redirects where
+ * approval deep links point, so scheme laundering is rejected at the write.
+ */
+export async function saveApprovalCardPublicAppUrl(
+  integrationId: string,
+  publicAppUrl: string,
+  queryFn: QueryFn = query,
+): Promise<ApprovalCardConfigStatus | null> {
+  const trimmed = typeof publicAppUrl === 'string' ? publicAppUrl.trim() : ''
+  if (trimmed) {
+    let parsed: URL
+    try {
+      parsed = new URL(trimmed)
+    } catch {
+      throw new Error('publicAppUrl must be an absolute http(s) URL')
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('publicAppUrl must use http or https')
+    }
+  }
+  const row = await loadIntegrationById(queryFn, integrationId)
+  if (!row) return null
+  const updated = trimmed
+    ? await queryFn(
+      `UPDATE directory_integrations
+          SET config = jsonb_set(COALESCE(config, '{}'::jsonb), $2, to_jsonb($3::text), true),
+              updated_at = NOW()
+        WHERE id = $1 AND provider = $4
+        RETURNING id, name, status, config`,
+      [row.id, `{${APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY}}`, trimmed, DEFAULT_PROVIDER],
+    )
+    : await queryFn(
+      `UPDATE directory_integrations
+          SET config = COALESCE(config, '{}'::jsonb) - $2::text,
+              updated_at = NOW()
+        WHERE id = $1 AND provider = $3
+        RETURNING id, name, status, config`,
+      [row.id, APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY, DEFAULT_PROVIDER],
+    )
+  const updatedRow = (updated.rows[0] ?? null) as IntegrationConfigRow | null
+  if (!updatedRow) return null
+  return buildStatus(updatedRow)
 }

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -27,6 +27,11 @@ import {
   saveDingTalkWorkNotificationAgentId,
   testDingTalkWorkNotificationAgentId,
 } from '../integrations/dingtalk/work-notification-settings'
+import {
+  generateApprovalCardLinkSecret,
+  getApprovalCardConfigStatus,
+  saveApprovalCardPublicAppUrl,
+} from '../integrations/dingtalk/approval-card-config'
 import { refreshDirectoryIntegrationSchedule } from '../directory/directory-sync-scheduler'
 import { isAdmin as isRbacAdmin } from '../rbac/service'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
@@ -183,6 +188,83 @@ export function adminDirectoryRouter(): Router {
       jsonOk(res, { integration })
     } catch (error) {
       jsonError(res, 400, 'DIRECTORY_UPDATE_FAILED', readErrorMessage(error, 'Failed to update directory integration'))
+    }
+  })
+
+  // CFG-2 (card-config lock §3.2): approval-card self-service config. The secret is generated
+  // server-side, stored encrypted, and NEVER echoed — responses carry presence booleans only.
+  router.get('/integrations/:integrationId/approval-card-config', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const status = await getApprovalCardConfigStatus(req.params.integrationId)
+      if (!status) {
+        jsonError(res, 404, 'DIRECTORY_NOT_FOUND', 'Directory integration not found')
+        return
+      }
+      jsonOk(res, { status })
+    } catch (error) {
+      jsonError(res, 500, 'APPROVAL_CARD_CONFIG_STATUS_FAILED', readErrorMessage(error, 'Failed to load approval card config status'))
+    }
+  })
+
+  router.post('/integrations/:integrationId/approval-card-config/secret/generate', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const status = await generateApprovalCardLinkSecret(req.params.integrationId)
+      if (!status) {
+        jsonError(res, 404, 'DIRECTORY_NOT_FOUND', 'Directory integration not found')
+        return
+      }
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'update',
+        resourceType: 'approval-card-config',
+        resourceId: status.integration.id,
+        meta: {
+          integrationId: status.integration.id,
+          operation: 'generate_link_secret',
+          valuePrinted: false,
+          envOverrideActive: status.linkSecret.envOverrideActive,
+        },
+      })
+      jsonOk(res, { status })
+    } catch (error) {
+      jsonError(res, 400, 'APPROVAL_CARD_SECRET_GENERATE_FAILED', readErrorMessage(error, 'Failed to generate approval card link secret'))
+    }
+  })
+
+  router.put('/integrations/:integrationId/approval-card-config', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const body = (req.body ?? {}) as Record<string, unknown>
+      const publicAppUrl = typeof body.publicAppUrl === 'string' ? body.publicAppUrl : ''
+      const status = await saveApprovalCardPublicAppUrl(req.params.integrationId, publicAppUrl)
+      if (!status) {
+        jsonError(res, 404, 'DIRECTORY_NOT_FOUND', 'Directory integration not found')
+        return
+      }
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'update',
+        resourceType: 'approval-card-config',
+        resourceId: status.integration.id,
+        meta: {
+          integrationId: status.integration.id,
+          operation: 'save_public_app_url',
+          publicAppUrl: status.publicAppUrl.storedValue,
+        },
+      })
+      jsonOk(res, { status })
+    } catch (error) {
+      jsonError(res, 400, 'APPROVAL_CARD_CONFIG_SAVE_FAILED', readErrorMessage(error, 'Failed to save approval card config'))
     }
   })
 

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -244,8 +244,13 @@ export function adminDirectoryRouter(): Router {
 
     try {
       const body = (req.body ?? {}) as Record<string, unknown>
-      const publicAppUrl = typeof body.publicAppUrl === 'string' ? body.publicAppUrl : ''
-      const status = await saveApprovalCardPublicAppUrl(req.params.integrationId, publicAppUrl)
+      // Explicit contract: clearing requires an explicit '' — a missing field is a caller bug,
+      // never a silent clear.
+      if (typeof body.publicAppUrl !== 'string') {
+        jsonError(res, 400, 'APPROVAL_CARD_CONFIG_SAVE_FAILED', 'publicAppUrl is required (send "" to clear)')
+        return
+      }
+      const status = await saveApprovalCardPublicAppUrl(req.params.integrationId, body.publicAppUrl)
       if (!status) {
         jsonError(res, 404, 'DIRECTORY_NOT_FOUND', 'Directory integration not found')
         return

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -23,6 +23,11 @@ import {
   markDingTalkApprovalCardDeliverySent,
 } from '../../src/integrations/dingtalk/approval-card-deliveries'
 import { normalizeStoredSecretValue } from '../../src/security/encrypted-secrets'
+import {
+  generateApprovalCardLinkSecret,
+  resolveApprovalCardLinkSecret,
+} from '../../src/integrations/dingtalk/approval-card-config'
+import { updateDirectoryIntegration } from '../../src/directory/directory-sync'
 import { createHmac } from 'crypto'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
@@ -162,6 +167,51 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
       expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: storedToken, viewerUserId: APPROVER })).status).toBe('ok')
       // The env-signed token no longer matches — stored source is authoritative when env is unset.
       expect(await verifyApprovalCardLinkToken(deliveryId, tokenFor(deliveryId), q)).toBe(false)
+    } finally {
+      await q('DELETE FROM directory_integrations WHERE id = $1', [integrationId]).catch(() => {})
+      if (prev === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET
+      else process.env.APPROVAL_CARD_LINK_SECRET = prev
+    }
+  })
+
+  test('CFG-2 closed loop: generate → resolver → sign → wrapper verifies; generic integration save does NOT wipe the secret', async () => {
+    const instanceId = await newInstance()
+    const deliveryId = await newSentDelivery(instanceId)
+    const prev = process.env.APPROVAL_CARD_LINK_SECRET
+    delete process.env.APPROVAL_CARD_LINK_SECRET
+    const fixtureName = `cdw-cfg2-${TS}`
+    const inserted = await q(
+      `INSERT INTO directory_integrations (name, provider, status, corp_id, config, updated_at)
+       VALUES ($1, 'dingtalk', 'active', $2, $3::jsonb, now())
+       RETURNING id`,
+      [fixtureName, `corp_cfg2_${TS}`, JSON.stringify({ appKey: 'cfg2-key', appSecret: normalizeStoredSecretValue('cfg2-secret') })],
+    )
+    const integrationId = (inserted.rows[0] as { id: string }).id
+    try {
+      // Generate server-side: response carries presence only, never the value.
+      const status = await generateApprovalCardLinkSecret(integrationId, q)
+      expect(status?.linkSecret).toMatchObject({ configured: true, source: 'stored', valuePrinted: false })
+      expect(JSON.stringify(status)).not.toMatch(/[0-9a-f]{64}/)
+
+      // Same-source closed loop: what the resolver yields signs a token the wrapper verifies.
+      const secret = await resolveApprovalCardLinkSecret(q)
+      expect(secret).toMatch(/^[0-9a-f]{64}$/)
+      const token = createHmac('sha256', secret).update(deliveryId).digest('hex').slice(0, 32)
+      expect(await verifyApprovalCardLinkToken(deliveryId, token, q)).toBe(true)
+      expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token, viewerUserId: APPROVER })).status).toBe('ok')
+
+      // WIPE REGRESSION (carry-through proof): the generic integration-form save rebuilds the
+      // config JSONB from a whitelist — without carry-through it would silently drop the secret
+      // and every in-flight card link would die. RED-before: remove the carry-through in
+      // updateDirectoryIntegration and this assertion fails.
+      const updatedSummary = await updateDirectoryIntegration(integrationId, {
+        name: fixtureName,
+        corpId: `corp_cfg2_${TS}`,
+        appKey: 'cfg2-key',
+      } as never)
+      expect(updatedSummary?.config.approvalCardLinkSecretConfigured).toBe(true)
+      expect(await resolveApprovalCardLinkSecret(q)).toBe(secret)
+      expect(await verifyApprovalCardLinkToken(deliveryId, token, q)).toBe(true)
     } finally {
       await q('DELETE FROM directory_integrations WHERE id = $1', [integrationId]).catch(() => {})
       if (prev === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -264,6 +264,16 @@ describe('adminDirectoryRouter', () => {
       })
       expect(bad.statusCode).toBe(400)
     })
+
+    it('rejects a PUT missing publicAppUrl instead of silently clearing', async () => {
+      const response = await invokeRoute('put', '/integrations/:integrationId/approval-card-config', {
+        params: { integrationId: 'dir-1' },
+        body: {},
+        user: { id: 'admin-1', role: 'admin' },
+      })
+      expect(response.statusCode).toBe(400)
+      expect(approvalCardConfigMocks.saveApprovalCardPublicAppUrl).not.toHaveBeenCalled()
+    })
   })
 
   it('rejects unauthenticated requests', async () => {

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -75,10 +75,22 @@ vi.mock('../../src/directory/directory-sync-scheduler', () => ({
   refreshDirectoryIntegrationSchedule: schedulerMocks.refreshDirectoryIntegrationSchedule,
 }))
 
+const approvalCardConfigMocks = vi.hoisted(() => ({
+  generateApprovalCardLinkSecret: vi.fn(),
+  getApprovalCardConfigStatus: vi.fn(),
+  saveApprovalCardPublicAppUrl: vi.fn(),
+}))
+
 vi.mock('../../src/integrations/dingtalk/work-notification-settings', () => ({
   getDingTalkWorkNotificationRuntimeStatusFromStore: workNotificationMocks.getDingTalkWorkNotificationRuntimeStatusFromStore,
   saveDingTalkWorkNotificationAgentId: workNotificationMocks.saveDingTalkWorkNotificationAgentId,
   testDingTalkWorkNotificationAgentId: workNotificationMocks.testDingTalkWorkNotificationAgentId,
+}))
+
+vi.mock('../../src/integrations/dingtalk/approval-card-config', () => ({
+  generateApprovalCardLinkSecret: approvalCardConfigMocks.generateApprovalCardLinkSecret,
+  getApprovalCardConfigStatus: approvalCardConfigMocks.getApprovalCardConfigStatus,
+  saveApprovalCardPublicAppUrl: approvalCardConfigMocks.saveApprovalCardPublicAppUrl,
 }))
 
 import { adminDirectoryRouter } from '../../src/routes/admin-directory'
@@ -177,6 +189,81 @@ describe('adminDirectoryRouter', () => {
     workNotificationMocks.getDingTalkWorkNotificationRuntimeStatusFromStore.mockReset()
     workNotificationMocks.saveDingTalkWorkNotificationAgentId.mockReset()
     workNotificationMocks.testDingTalkWorkNotificationAgentId.mockReset()
+    approvalCardConfigMocks.generateApprovalCardLinkSecret.mockReset()
+    approvalCardConfigMocks.getApprovalCardConfigStatus.mockReset()
+    approvalCardConfigMocks.saveApprovalCardPublicAppUrl.mockReset()
+  })
+
+  describe('approval-card config (CFG-2)', () => {
+    const CARD_STATUS = {
+      integration: { id: 'dir-1', name: 'DingTalk CN', status: 'active' },
+      linkSecret: { configured: true, source: 'stored', envOverrideActive: false, valuePrinted: false },
+      publicAppUrl: { storedValue: 'https://app.example.com', source: 'stored', envOverrideActive: false },
+    }
+
+    it('admin-gates all three routes (403 for non-admin)', async () => {
+      rbacMocks.isRbacAdmin.mockResolvedValue(false)
+      for (const [method, path] of [
+        ['get', '/integrations/:integrationId/approval-card-config'],
+        ['post', '/integrations/:integrationId/approval-card-config/secret/generate'],
+        ['put', '/integrations/:integrationId/approval-card-config'],
+      ] as const) {
+        const response = await invokeRoute(method, path, {
+          params: { integrationId: 'dir-1' },
+          user: { id: 'user-1' },
+        })
+        expect(response.statusCode).toBe(403)
+      }
+      expect(approvalCardConfigMocks.generateApprovalCardLinkSecret).not.toHaveBeenCalled()
+      expect(approvalCardConfigMocks.getApprovalCardConfigStatus).not.toHaveBeenCalled()
+      expect(approvalCardConfigMocks.saveApprovalCardPublicAppUrl).not.toHaveBeenCalled()
+    })
+
+    it('generates the secret with a redacted audit entry and never echoes a value', async () => {
+      approvalCardConfigMocks.generateApprovalCardLinkSecret.mockResolvedValue(CARD_STATUS)
+
+      const response = await invokeRoute('post', '/integrations/:integrationId/approval-card-config/secret/generate', {
+        params: { integrationId: 'dir-1' },
+        user: { id: 'admin-1', role: 'admin' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toMatchObject({ ok: true, data: { status: { linkSecret: { configured: true, valuePrinted: false } } } })
+      // No 64-hex plaintext anywhere in the wire response.
+      expect(JSON.stringify(response.body)).not.toMatch(/[0-9a-f]{64}/)
+      expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+        resourceType: 'approval-card-config',
+        meta: expect.objectContaining({ operation: 'generate_link_secret', valuePrinted: false }),
+      }))
+    })
+
+    it('returns 404 for an unknown integration', async () => {
+      approvalCardConfigMocks.generateApprovalCardLinkSecret.mockResolvedValue(null)
+      const response = await invokeRoute('post', '/integrations/:integrationId/approval-card-config/secret/generate', {
+        params: { integrationId: 'ghost' },
+        user: { id: 'admin-1', role: 'admin' },
+      })
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('saves the public app URL and surfaces validation failures as 400', async () => {
+      approvalCardConfigMocks.saveApprovalCardPublicAppUrl.mockResolvedValue(CARD_STATUS)
+      const ok = await invokeRoute('put', '/integrations/:integrationId/approval-card-config', {
+        params: { integrationId: 'dir-1' },
+        body: { publicAppUrl: 'https://app.example.com' },
+        user: { id: 'admin-1', role: 'admin' },
+      })
+      expect(ok.statusCode).toBe(200)
+      expect(approvalCardConfigMocks.saveApprovalCardPublicAppUrl).toHaveBeenCalledWith('dir-1', 'https://app.example.com')
+
+      approvalCardConfigMocks.saveApprovalCardPublicAppUrl.mockRejectedValue(new Error('publicAppUrl must use http or https'))
+      const bad = await invokeRoute('put', '/integrations/:integrationId/approval-card-config', {
+        params: { integrationId: 'dir-1' },
+        body: { publicAppUrl: 'javascript:alert(1)' },
+        user: { id: 'admin-1', role: 'admin' },
+      })
+      expect(bad.statusCode).toBe(400)
+    })
   })
 
   it('rejects unauthenticated requests', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-approval-card-config.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-approval-card-config.test.ts
@@ -14,8 +14,11 @@ vi.mock('../../src/db/pg', () => ({
 import {
   APPROVAL_CARD_LINK_SECRET_CONFIG_KEY,
   APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY,
+  generateApprovalCardLinkSecret,
+  getApprovalCardConfigStatus,
   resolveApprovalCardLinkSecret,
   resolveApprovalCardPublicAppUrl,
+  saveApprovalCardPublicAppUrl,
 } from '../../src/integrations/dingtalk/approval-card-config'
 import { verifyApprovalCardLinkToken } from '../../src/services/ApprovalCardDeliveryAction'
 
@@ -90,6 +93,102 @@ describe('approval card config resolvers (CFG-1)', () => {
       // Even a token forged with an EMPTY HMAC key must be rejected — no secret means no verify.
       const emptyKeyForgery = createHmac('sha256', '').update('card-delivery-1').digest('hex').slice(0, 32)
       await expect(verifyApprovalCardLinkToken('card-delivery-1', emptyKeyForgery)).resolves.toBe(false)
+    })
+  })
+
+  describe('CFG-2 generateApprovalCardLinkSecret', () => {
+    function mockIntegration(config: Record<string, unknown> = {}) {
+      return { id: 'dir-1', name: 'DingTalk CN', status: 'active', config }
+    }
+
+    it('stores an ENCRYPTED 32-byte secret and never echoes the plaintext', async () => {
+      let storedParam = ''
+      dbMocks.query
+        .mockResolvedValueOnce({ rows: [mockIntegration()] })
+        .mockImplementationOnce(async (_sql: string, params: unknown[]) => {
+          storedParam = String(params[2])
+          return { rows: [mockIntegration({ [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: storedParam })] }
+        })
+      const status = await generateApprovalCardLinkSecret('dir-1')
+      expect(status?.linkSecret.configured).toBe(true)
+      expect(status?.linkSecret.source).toBe('stored')
+      expect(status?.linkSecret.valuePrinted).toBe(false)
+      // Written value is encrypted-at-rest — never the raw hex.
+      expect(storedParam.startsWith('enc:')).toBe(true)
+      expect(/^[0-9a-f]{64}$/.test(storedParam)).toBe(false)
+      // The response must not leak the plaintext (64 hex chars) anywhere.
+      expect(JSON.stringify(status)).not.toMatch(/[0-9a-f]{64}/)
+      const updateSql = dbMocks.query.mock.calls[1][0] as string
+      expect(updateSql).toContain('jsonb_set')
+    })
+
+    it('returns null for an unknown integration (no write issued)', async () => {
+      dbMocks.query.mockResolvedValueOnce({ rows: [] })
+      await expect(generateApprovalCardLinkSecret('ghost')).resolves.toBeNull()
+      expect(dbMocks.query).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports envOverrideActive when env still wins at runtime', async () => {
+      vi.stubEnv('APPROVAL_CARD_LINK_SECRET', 'env-secret')
+      dbMocks.query
+        .mockResolvedValueOnce({ rows: [mockIntegration()] })
+        .mockResolvedValueOnce({ rows: [mockIntegration({ [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: 'enc:x' })] })
+      const status = await generateApprovalCardLinkSecret('dir-1')
+      expect(status?.linkSecret.envOverrideActive).toBe(true)
+      expect(status?.linkSecret.source).toBe('env')
+    })
+  })
+
+  describe('CFG-2 saveApprovalCardPublicAppUrl', () => {
+    function mockIntegration(config: Record<string, unknown> = {}) {
+      return { id: 'dir-1', name: 'DingTalk CN', status: 'active', config }
+    }
+
+    it('accepts absolute http(s) URLs and echoes the stored value (not a secret)', async () => {
+      dbMocks.query
+        .mockResolvedValueOnce({ rows: [mockIntegration()] })
+        .mockResolvedValueOnce({ rows: [mockIntegration({ [APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY]: 'https://app.example.com' })] })
+      const status = await saveApprovalCardPublicAppUrl('dir-1', 'https://app.example.com')
+      expect(status?.publicAppUrl.storedValue).toBe('https://app.example.com')
+      expect(status?.publicAppUrl.source).toBe('stored')
+    })
+
+    it('rejects non-http(s) and relative URLs at the write (scheme allowlist)', async () => {
+      await expect(saveApprovalCardPublicAppUrl('dir-1', 'javascript:alert(1)')).rejects.toThrow('http or https')
+      await expect(saveApprovalCardPublicAppUrl('dir-1', 'ftp://host/x')).rejects.toThrow('http or https')
+      await expect(saveApprovalCardPublicAppUrl('dir-1', 'not a url')).rejects.toThrow('absolute http(s) URL')
+      // Validation happens BEFORE any DB access.
+      expect(dbMocks.query).not.toHaveBeenCalled()
+    })
+
+    it('clears the stored URL when saving empty', async () => {
+      dbMocks.query
+        .mockResolvedValueOnce({ rows: [mockIntegration({ [APPROVAL_CARD_PUBLIC_APP_URL_CONFIG_KEY]: 'https://old.example.com' })] })
+        .mockResolvedValueOnce({ rows: [mockIntegration({})] })
+      const status = await saveApprovalCardPublicAppUrl('dir-1', '')
+      expect(status?.publicAppUrl.storedValue).toBeNull()
+      expect(status?.publicAppUrl.source).toBe('missing')
+      const clearSql = dbMocks.query.mock.calls[1][0] as string
+      expect(clearSql).toContain("- $2::text")
+    })
+  })
+
+  describe('CFG-2 getApprovalCardConfigStatus', () => {
+    it('reports presence booleans only, with env-first sourcing', async () => {
+      vi.stubEnv('PUBLIC_APP_URL', 'https://env.example.com')
+      dbMocks.query.mockResolvedValueOnce({
+        rows: [{ id: 'dir-1', name: 'n', status: 'active', config: { [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('s') } }],
+      })
+      const status = await getApprovalCardConfigStatus('dir-1')
+      expect(status?.linkSecret).toEqual({ configured: true, source: 'stored', envOverrideActive: false, valuePrinted: false })
+      expect(status?.publicAppUrl.source).toBe('env')
+      expect(status?.publicAppUrl.envOverrideActive).toBe(true)
+      expect(JSON.stringify(status)).not.toContain('enc:')
+    })
+
+    it('returns null for an unknown integration', async () => {
+      dbMocks.query.mockResolvedValueOnce({ rows: [] })
+      await expect(getApprovalCardConfigStatus('ghost')).resolves.toBeNull()
     })
   })
 


### PR DESCRIPTION
Implements **CFG-2** of the card-config settings design-lock (#3690, ratified; CFG-1 = #3693 merged).

## What
- **`generateApprovalCardLinkSecret`**: `crypto.randomBytes(32)` **server-side**, stored via `normalizeStoredSecretValue` (encrypted-at-rest, same path as appSecret — review P3 enforced at the write). The plaintext never leaves the function; every response carries presence booleans only (`valuePrinted: false`).
- **`saveApprovalCardPublicAppUrl`**: absolute **http(s)-only** scheme allowlist at the write (review P3 — the stored URL steers where approval deep links point); empty clears the key.
- **`getApprovalCardConfigStatus`**: presence + source (`env|stored|missing`) + `envOverrideActive` flags so the UI can warn that env wins at runtime.
- **Routes** (`admin-directory`, all `ensurePlatformAdmin`-gated with redacted audit entries): `GET/PUT /integrations/:id/approval-card-config`, `POST .../secret/generate`.
- **WIPE-TRAP FIX**: `updateDirectoryIntegration` rebuilds the config JSONB from a whitelist — every generic integration-form save would silently drop the stored secret and kill all in-flight card links. Added carry-through (encrypted value carried as-is, never decrypted). **Mutation-proven**: removing the carry-through turns the new real-DB regression RED.
- Integration summaries now expose `approvalCardLinkSecretConfigured` + `approvalCardPublicAppUrl` (presence/plain, mirrors `appSecretConfigured`) for the CFG-3 chip.

## Verification
- Unit **17/17** (encrypted write, no 64-hex leak in any response, scheme allowlist incl. `javascript:` rejection before any DB access, env-override reporting)
- Route gates **31/31** (403 non-admin on all three routes, 404 unknown, redacted audit, 400 invalid URL)
- Real-DB **9/9** on fresh DB incl. **CFG-2 closed loop** (generate → resolver → sign → wrapper verify) + wipe regression; A-2b sign-side 5/5 unchanged
- `tsc --noEmit` 0 errors

## Out of scope
- CFG-3 settings UI (generate button + chip + regenerate confirm + URL field) — next slice, Sonnet agent per model split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)