### PR TITLE
feat(attendance-web): import section UX — field-picker template builder + one-click download + core/advanced grouping

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -60,6 +60,7 @@ on:
       - 'apps/web/tests/attendance-import-file-guard.spec.ts'
       - 'apps/web/tests/attendance-import-preview-regression.spec.ts'
       - 'apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts'
+      - 'apps/web/tests/attendance-import-template-columns.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
@@ -78,6 +79,7 @@ on:
       - 'apps/web/tests/attendance-import-file-guard.spec.ts'
       - 'apps/web/tests/attendance-import-preview-regression.spec.ts'
       - 'apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts'
+      - 'apps/web/tests/attendance-import-template-columns.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -120,4 +122,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns --reporter=dot

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -18080,12 +18080,15 @@ function triggerImportCsvDownload(filename: string, csv: string) {
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
   const url = URL.createObjectURL(blob)
   const link = document.createElement('a')
-  link.href = url
-  link.download = filename
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  URL.revokeObjectURL(url)
+  try {
+    link.href = url
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+  } finally {
+    link.remove()
+    URL.revokeObjectURL(url)
+  }
 }
 
 // D3 field-picker actions: build the header from the current selection.

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -18032,8 +18032,22 @@ async function loadImportTemplate() {
 
 async function downloadImportTemplateCsv() {
   // One-click (import-section-ux design-lock D2): auto-load the template first
-  // instead of erroring, so the download works from a cold panel.
+  // instead of erroring, so the download works from a cold panel. Guard: only
+  // when the payload is untouched — loadImportTemplate overwrites
+  // importForm.payload, and a hand-edited (or mid-edit, unparseable) payload
+  // must never be silently destroyed by a template download.
   if (!importTemplateGuide.value) {
+    const rawPayload = String(importForm.payload ?? '').trim()
+    if (rawPayload && rawPayload !== '{}') {
+      setStatus(
+        tr(
+          'Payload JSON has content but no template columns — fix or clear it, or click "Load template" to replace it.',
+          '负载 JSON 已有内容但无法生成模板——请修正/清空后再试，或点「加载模板」覆盖当前负载。',
+        ),
+        'error',
+      )
+      return
+    }
     await loadImportTemplate()
   }
   const guide = importTemplateGuide.value

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -5832,11 +5832,14 @@
                   <button class="attendance__btn" :disabled="importLoading" @click="loadImportTemplate">
                     {{ importLoading ? tr('Loading...', '加载中...') : tr('Load template', '加载模板') }}
                   </button>
-                  <button class="attendance__btn" :disabled="importLoading || !importTemplateGuide" @click="downloadImportTemplateCsv">
+                  <button class="attendance__btn" :disabled="importLoading" @click="downloadImportTemplateCsv">
                     {{ tr('Download CSV template', '下载 CSV 模板') }}
                   </button>
                 </div>
               </div>
+              <small v-if="!importTemplateGuide" class="attendance__field-hint attendance__import-template-hint">
+                {{ tr('Click "Load template" to pick fields and generate an import template.', '点击「加载模板」可勾选字段生成导入模板。') }}
+              </small>
               <div v-if="importTemplateGuide" class="attendance__template-guide">
                 <div class="attendance__template-guide-header">
                   <strong>{{ tr('Template guide', '模板说明') }}</strong>
@@ -5925,6 +5928,47 @@
                       </tbody>
                     </table>
                   </div>
+                  <div v-if="importFieldGroups.length" class="attendance__template-guide-card attendance__template-guide-card--full attendance__field-picker" data-testid="attendance-import-field-picker">
+                    <div class="attendance__template-guide-title">{{ tr('Pick fields to generate a template', '选择字段，生成导入模板') }}</div>
+                    <div class="attendance__field-picker-groups">
+                      <div v-for="group in importFieldGroups" :key="group.key" class="attendance__field-picker-group">
+                        <div class="attendance__field-picker-group-label">{{ tr(group.labelEn, group.labelZh) }}</div>
+                        <div class="attendance__field-picker-options">
+                          <label
+                            v-for="option in group.options"
+                            :key="option.key"
+                            class="attendance__field-picker-option"
+                            :title="tr(option.meaningEn, option.meaningZh)"
+                          >
+                            <input
+                              type="checkbox"
+                              :checked="importTemplateFieldKeys.has(option.key)"
+                              @change="toggleImportTemplateField(option.key)"
+                            />
+                            <span>{{ option.columnName }}</span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="attendance__field-picker-preview">
+                      <span>{{ tr('Header preview (required columns locked)', '表头预览（必填列已锁定）') }}:</span>
+                      <code data-testid="attendance-import-header-preview">{{ importTemplateHeaderPreview.join(',') }}</code>
+                    </div>
+                    <div class="attendance__admin-actions">
+                      <button class="attendance__btn" type="button" @click="downloadImportSelectedTemplateCsv">
+                        {{ tr('Download template (selected fields)', '下载模板（所选列）') }}
+                      </button>
+                      <button class="attendance__btn" type="button" @click="copyImportTemplateHeader">
+                        {{ tr('Copy header', '复制表头') }}
+                      </button>
+                      <button class="attendance__btn" type="button" @click="selectAllImportTemplateFields">
+                        {{ tr('Select all', '全选') }}
+                      </button>
+                      <button class="attendance__btn" type="button" @click="resetImportTemplateFields">
+                        {{ tr('Reset to default', '恢复默认') }}
+                      </button>
+                    </div>
+                  </div>
                 </div>
               </div>
               <div class="attendance__admin-grid">
@@ -5982,6 +6026,23 @@
                   />
                   <small v-if="importCsvFileName" class="attendance__field-hint">{{ tr('Selected', '已选择') }}: {{ importCsvFileName }}</small>
                 </label>
+              </div>
+              <div class="attendance__import-advanced-toggle">
+                <button
+                  class="attendance__btn"
+                  type="button"
+                  data-testid="attendance-import-advanced-toggle"
+                  :aria-expanded="importAdvancedOpen ? 'true' : 'false'"
+                  @click="importAdvancedOpen = !importAdvancedOpen"
+                >
+                  {{ importAdvancedOpen ? tr('Hide advanced options', '收起高级选项') : tr('Advanced options', '高级选项') }}
+                  <span v-if="importAdvancedActiveCount > 0" class="attendance__import-advanced-badge">{{ importAdvancedActiveCount }}</span>
+                </button>
+                <small v-if="!importAdvancedOpen" class="attendance__field-hint">
+                  {{ tr('Header row, delimiter, user map, grouping, payload JSON.', '表头行、分隔符、用户映射、分组、负载 JSON。') }}
+                </small>
+              </div>
+              <div v-show="importAdvancedOpen" class="attendance__admin-grid attendance__import-advanced" data-testid="attendance-import-advanced">
                 <label class="attendance__field" for="attendance-import-csv-header">
                   <span>{{ tr('CSV header row', 'CSV 表头行') }}</span>
                   <input
@@ -9643,6 +9704,13 @@ import {
   detectSpreadsheetByName,
   inspectImportFile,
 } from './attendance/importFileGuard'
+import {
+  IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS,
+  allSelectableImportFieldKeys,
+  buildTemplateHeaderFromSelection,
+  groupSupportedImportColumns,
+  type AttendanceImportMappingColumnLike,
+} from './attendance/importTemplateColumns'
 import { resolveMakeupPunchRequestStatusCopy } from './attendance/makeupPunchRequestStatus'
 import {
   buildPunchRetryWithNotePayload,
@@ -13018,6 +13086,25 @@ const payrollCycleSummary = ref<AttendanceSummary | null>(null)
 const importProfileId = ref('')
 const importMode = ref<'override' | 'merge'>('override')
 const importMappingProfiles = ref<AttendanceImportMappingProfile[]>([])
+// D3 field-picker (import-section-ux design-lock): raw mapping columns from
+// /api/attendance/import/template (previously discarded) → grouped options.
+const importMappingColumnsRaw = ref<AttendanceImportMappingColumnLike[]>([])
+const importFieldGroups = computed(() => groupSupportedImportColumns(importMappingColumnsRaw.value))
+const importTemplateFieldKeys = ref<Set<string>>(new Set(IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS))
+const importTemplateHeaderPreview = computed(() =>
+  buildTemplateHeaderFromSelection(importFieldGroups.value, importTemplateFieldKeys.value))
+function toggleImportTemplateField(key: string) {
+  const next = new Set(importTemplateFieldKeys.value)
+  if (next.has(key)) next.delete(key)
+  else next.add(key)
+  importTemplateFieldKeys.value = next
+}
+function selectAllImportTemplateFields() {
+  importTemplateFieldKeys.value = new Set(allSelectableImportFieldKeys(importFieldGroups.value))
+}
+function resetImportTemplateFields() {
+  importTemplateFieldKeys.value = new Set(IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS)
+}
 const selectedImportProfile = computed(() => {
   if (!importProfileId.value) return null
   return importMappingProfiles.value.find(profile => profile.id === importProfileId.value) ?? null
@@ -13656,6 +13743,25 @@ const importGroupAutoCreate = ref(false)
 const importGroupAutoAssign = ref(false)
 const importGroupRuleSetId = ref('')
 const importGroupTimezone = ref('')
+// D1 core/advanced grouping (import-section-ux design-lock): advanced fields
+// collapse behind a toggle; count tracks non-default advanced settings so the
+// badge (and initial auto-expand) reflect hidden active configuration.
+const importAdvancedOpen = ref(false)
+const importAdvancedActiveCount = computed(() => {
+  let count = 0
+  if (String(importCsvHeaderRow.value ?? '').trim() !== '') count += 1
+  if (importCsvDelimiter.value && importCsvDelimiter.value !== ',') count += 1
+  if (importUserMap.value) count += 1
+  if (importGroupAutoCreate.value) count += 1
+  if (importGroupAutoAssign.value) count += 1
+  if (importGroupRuleSetId.value) count += 1
+  if (importGroupTimezone.value) count += 1
+  if (String(importForm.userId ?? '').trim() !== '') count += 1
+  return count
+})
+onMounted(() => {
+  if (importAdvancedActiveCount.value > 0) importAdvancedOpen.value = true
+})
 const importCommitToken = ref('')
 const importCommitTokenExpiresAt = ref('')
 const attendanceImportBatchStorageKey = computed(() =>
@@ -17915,6 +18021,7 @@ async function loadImportTemplate() {
     importMode.value = payloadExample?.mode === 'merge' ? 'merge' : 'override'
     importForm.payload = JSON.stringify(payloadExample, null, 2)
     importMappingProfiles.value = Array.isArray(data.data?.mappingProfiles) ? data.data.mappingProfiles : []
+    importMappingColumnsRaw.value = Array.isArray(data.data?.mapping?.columns) ? data.data.mapping.columns : []
     setStatus(tr('Import template loaded.', '导入模板已加载。'))
   } catch (error) {
     setStatus(readErrorMessage(error, tr('Failed to load import template', '加载导入模板失败')), 'error')
@@ -17923,7 +18030,12 @@ async function loadImportTemplate() {
   }
 }
 
-function downloadImportTemplateCsv() {
+async function downloadImportTemplateCsv() {
+  // One-click (import-section-ux design-lock D2): auto-load the template first
+  // instead of erroring, so the download works from a cold panel.
+  if (!importTemplateGuide.value) {
+    await loadImportTemplate()
+  }
   const guide = importTemplateGuide.value
   if (!guide) {
     setStatus(tr('Load the import template before downloading CSV guidance.', '请先加载导入模板，再下载 CSV 模板。'), 'error')
@@ -17948,6 +18060,48 @@ function downloadImportTemplateCsv() {
   document.body.removeChild(link)
   URL.revokeObjectURL(url)
   setStatus(tr('CSV template downloaded.', 'CSV 模板已下载。'))
+}
+
+function triggerImportCsvDownload(filename: string, csv: string) {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+// D3 field-picker actions: build the header from the current selection.
+function downloadImportSelectedTemplateCsv() {
+  const header = importTemplateHeaderPreview.value
+  if (header.length === 0) {
+    setStatus(tr('Load the import template to pick fields first.', '请先加载导入模板并勾选字段。'), 'error')
+    return
+  }
+  const csv = `${header.map(escapeCsvCell).join(',')}\n${header.map(() => '').join(',')}\n`
+  triggerImportCsvDownload('attendance-import-template-selected.csv', csv)
+  setStatus(tr(
+    `CSV template downloaded (${header.length} columns).`,
+    `CSV 模板已下载（${header.length} 列）。`,
+  ))
+}
+
+async function copyImportTemplateHeader() {
+  const headerLine = importTemplateHeaderPreview.value.join(',')
+  if (!headerLine) {
+    setStatus(tr('Load the import template to pick fields first.', '请先加载导入模板并勾选字段。'), 'error')
+    return
+  }
+  try {
+    if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable')
+    await navigator.clipboard.writeText(headerLine)
+    setStatus(tr('Template header copied.', '模板表头已复制。'))
+  } catch {
+    setStatus(tr('Copy failed — please copy the header preview manually.', '复制失败——请手动复制表头预览。'), 'error')
+  }
 }
 
 function applyImportProfile() {
@@ -30177,5 +30331,90 @@ const holidaySectionBindings = {
   flex-direction: column;
   gap: 4px;
   margin-top: 8px;
+}
+
+/* Import section UX (import-section-ux design-lock 20260706) — all values
+   from UF --ms-* tokens; new hardcoded hex here would be a defect. */
+.attendance__import-template-hint {
+  display: block;
+  margin: var(--ms-space-1) 0 var(--ms-space-2);
+  color: var(--ms-text-3);
+}
+
+.attendance__field-picker-groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+  margin-top: var(--ms-space-2);
+}
+
+.attendance__field-picker-group-label {
+  font-weight: var(--ms-font-weight-title);
+  color: var(--ms-text-2);
+  margin-bottom: var(--ms-space-1);
+  font-size: 12px;
+}
+
+.attendance__field-picker-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ms-space-2);
+}
+
+.attendance__field-picker-option {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ms-space-1);
+  padding: var(--ms-space-1) var(--ms-space-2);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-sm);
+  background: var(--ms-bg-card);
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--ms-text-2);
+}
+
+.attendance__field-picker-option:has(input:checked) {
+  border-color: var(--ms-color-primary);
+  color: var(--ms-color-primary);
+}
+
+.attendance__field-picker-preview {
+  margin: var(--ms-space-3) 0 var(--ms-space-2);
+  font-size: 12px;
+  color: var(--ms-text-2);
+  word-break: break-all;
+}
+
+.attendance__field-picker-preview code {
+  background: var(--ms-bg-page);
+  padding: var(--ms-space-1) var(--ms-space-2);
+  border-radius: var(--ms-radius-sm);
+}
+
+.attendance__import-advanced-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-3);
+  margin: var(--ms-space-3) 0 var(--ms-space-2);
+}
+
+.attendance__import-advanced-badge {
+  display: inline-block;
+  margin-left: var(--ms-space-1);
+  min-width: 16px;
+  padding: 0 var(--ms-space-1);
+  border-radius: 999px;
+  background: var(--ms-color-primary);
+  color: var(--ms-bg-card);
+  font-size: 11px;
+  line-height: 16px;
+  text-align: center;
+}
+
+.attendance__import-advanced {
+  margin-top: var(--ms-space-2);
+  padding-top: var(--ms-space-3);
+  border-top: 1px dashed var(--ms-border-light);
 }
 </style>

--- a/apps/web/src/views/attendance/importTemplateColumns.ts
+++ b/apps/web/src/views/attendance/importTemplateColumns.ts
@@ -55,7 +55,11 @@ const GROUP_DEFS: Array<{ key: string; labelEn: string; labelZh: string; targets
     key: 'durations',
     labelEn: 'Durations & hours',
     labelZh: '时长与工时',
-    targets: ['workHours', 'workMinutes', 'lateMinutes', 'earlyLeaveMinutes', 'leaveHours', 'leaveMinutes', 'overtimeHours', 'overtimeMinutes'],
+    // leaveMinutes/overtimeMinutes are deliberately absent: they only carry
+    // English API aliases (leave_hours/overtime_duration) and duplicate the
+    // 请假小时/加班小时 semantics — including them would leak English column
+    // names into the generated Chinese template.
+    targets: ['workHours', 'workMinutes', 'lateMinutes', 'earlyLeaveMinutes', 'leaveHours', 'overtimeHours'],
   },
   {
     key: 'shift-group',
@@ -67,7 +71,7 @@ const GROUP_DEFS: Array<{ key: string; labelEn: string; labelZh: string; targets
     key: 'people',
     labelEn: 'People profile',
     labelZh: '人员画像',
-    targets: ['department', 'role', 'entryTime'],
+    targets: ['department', 'role', 'entryTime', 'resignTime'],
   },
   {
     key: 'approval',
@@ -106,6 +110,7 @@ const FIELD_MEANINGS: Record<string, { en: string; zh: string }> = {
   department: { en: 'Department (also drives rules)', zh: '部门（可参与规则匹配）' },
   role: { en: 'Role/position (also drives rules)', zh: '职位（可参与规则匹配）' },
   entryTime: { en: 'Entry (hire) date', zh: '入职时间' },
+  resignTime: { en: 'Resignation date', zh: '离职时间' },
   approvalSummary: { en: 'Linked approval summary', zh: '关联的审批单摘要' },
 }
 

--- a/apps/web/src/views/attendance/importTemplateColumns.ts
+++ b/apps/web/src/views/attendance/importTemplateColumns.ts
@@ -1,0 +1,191 @@
+// Field-picker vocabulary for the attendance import template: turns the raw
+// mapping columns already returned by GET /api/attendance/import/template
+// (data.mapping.columns — sourceField/targetField alias pairs) into grouped,
+// selectable, Chinese-first field options, and assembles a CSV template header
+// from a selection. Pure and dependency-free; shared so the AttendanceView
+// shell and the import-workflow composable/Section render the same vocabulary.
+// See docs/development/attendance-import-section-ux-design-lock-20260706.md.
+
+export interface AttendanceImportMappingColumnLike {
+  sourceField?: unknown
+  targetField?: unknown
+}
+
+export interface AttendanceImportFieldOption {
+  /** stable selection key = canonical targetField */
+  key: string
+  /** Chinese-first column name written into the generated template header */
+  columnName: string
+  /** every accepted source alias (for tooltips / recognition) */
+  aliases: string[]
+  meaningEn: string
+  meaningZh: string
+}
+
+export interface AttendanceImportFieldGroup {
+  key: string
+  labelEn: string
+  labelZh: string
+  options: AttendanceImportFieldOption[]
+}
+
+/** Base columns every generated template starts with (identity + user match). */
+export const IMPORT_TEMPLATE_BASE_COLUMNS = ['日期', '工号', '姓名'] as const
+
+const GROUP_DEFS: Array<{ key: string; labelEn: string; labelZh: string; targets: string[] }> = [
+  {
+    key: 'punch-times',
+    labelEn: 'Punch times',
+    labelZh: '打卡时间',
+    targets: ['firstInAt', 'lastOutAt', 'clockIn2', 'clockOut2', 'clockIn3', 'clockOut3'],
+  },
+  {
+    key: 'punch-results',
+    labelEn: 'Punch results',
+    labelZh: '打卡结果',
+    targets: ['punchResultIn1', 'punchResultOut1', 'punchResultIn2', 'punchResultOut2', 'punchResultIn3', 'punchResultOut3'],
+  },
+  {
+    key: 'status',
+    labelEn: 'Status & exceptions',
+    labelZh: '状态与异常',
+    targets: ['status', 'exceptionReason'],
+  },
+  {
+    key: 'durations',
+    labelEn: 'Durations & hours',
+    labelZh: '时长与工时',
+    targets: ['workHours', 'workMinutes', 'lateMinutes', 'earlyLeaveMinutes', 'leaveHours', 'leaveMinutes', 'overtimeHours', 'overtimeMinutes'],
+  },
+  {
+    key: 'shift-group',
+    labelEn: 'Shift & group',
+    labelZh: '班次与分组',
+    targets: ['shiftName', 'attendanceClass', 'attendanceGroup'],
+  },
+  {
+    key: 'people',
+    labelEn: 'People profile',
+    labelZh: '人员画像',
+    targets: ['department', 'role', 'entryTime'],
+  },
+  {
+    key: 'approval',
+    labelEn: 'Approvals',
+    labelZh: '审批关联',
+    targets: ['approvalSummary'],
+  },
+]
+
+const FIELD_MEANINGS: Record<string, { en: string; zh: string }> = {
+  firstInAt: { en: 'First clock-in time of the day', zh: '当日第一次上班打卡时间' },
+  lastOutAt: { en: 'Last clock-out time of the day', zh: '当日最后一次下班打卡时间' },
+  clockIn2: { en: 'Second-slot clock-in', zh: '第二段上班打卡时间' },
+  clockOut2: { en: 'Second-slot clock-out', zh: '第二段下班打卡时间' },
+  clockIn3: { en: 'Third-slot clock-in', zh: '第三段上班打卡时间' },
+  clockOut3: { en: 'Third-slot clock-out', zh: '第三段下班打卡时间' },
+  punchResultIn1: { en: 'Result of clock-in #1', zh: '上班1打卡结果（正常/迟到…）' },
+  punchResultOut1: { en: 'Result of clock-out #1', zh: '下班1打卡结果' },
+  punchResultIn2: { en: 'Result of clock-in #2', zh: '上班2打卡结果' },
+  punchResultOut2: { en: 'Result of clock-out #2', zh: '下班2打卡结果' },
+  punchResultIn3: { en: 'Result of clock-in #3', zh: '上班3打卡结果' },
+  punchResultOut3: { en: 'Result of clock-out #3', zh: '下班3打卡结果' },
+  status: { en: 'Attendance result for the day', zh: '当日考勤结果（正常/迟到/缺卡…）' },
+  exceptionReason: { en: 'Exception reason text', zh: '异常原因说明' },
+  workHours: { en: 'Expected/total work hours', zh: '应出勤/总工时（小时）' },
+  workMinutes: { en: 'Actual work duration', zh: '实出勤工时' },
+  lateMinutes: { en: 'Late duration (minutes)', zh: '迟到时长（分钟）' },
+  earlyLeaveMinutes: { en: 'Early-leave duration (minutes)', zh: '早退时长（分钟）' },
+  leaveHours: { en: 'Leave hours (incl. comp leave)', zh: '请假/调休小时' },
+  leaveMinutes: { en: 'Leave duration', zh: '请假时长' },
+  overtimeHours: { en: 'Overtime hours', zh: '加班小时' },
+  overtimeMinutes: { en: 'Overtime duration', zh: '加班时长' },
+  shiftName: { en: 'Shift name (drives shift window)', zh: '班次名称（参与班次时间窗计算）' },
+  attendanceClass: { en: 'Attendance class label', zh: '出勤班次标签' },
+  attendanceGroup: { en: 'Attendance group name', zh: '考勤组名称' },
+  department: { en: 'Department (also drives rules)', zh: '部门（可参与规则匹配）' },
+  role: { en: 'Role/position (also drives rules)', zh: '职位（可参与规则匹配）' },
+  entryTime: { en: 'Entry (hire) date', zh: '入职时间' },
+  approvalSummary: { en: 'Linked approval summary', zh: '关联的审批单摘要' },
+}
+
+const CJK_RE = /[一-鿿]/
+
+function normalizeCell(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/**
+ * Group the raw mapping columns into selectable, deduped, Chinese-first field
+ * options. Aliases sharing a targetField merge into one option; the displayed
+ * (and generated) column name prefers the first Chinese alias.
+ */
+export function groupSupportedImportColumns(
+  columns: readonly AttendanceImportMappingColumnLike[] | null | undefined,
+): AttendanceImportFieldGroup[] {
+  const byTarget = new Map<string, { aliases: string[]; cjk: string | null }>()
+  for (const column of Array.isArray(columns) ? columns : []) {
+    const source = normalizeCell(column?.sourceField)
+    const target = normalizeCell(column?.targetField)
+    if (!source || !target) continue
+    const entry = byTarget.get(target) ?? { aliases: [], cjk: null }
+    if (!entry.aliases.includes(source)) entry.aliases.push(source)
+    if (!entry.cjk && CJK_RE.test(source)) entry.cjk = source
+    byTarget.set(target, entry)
+  }
+
+  const groups: AttendanceImportFieldGroup[] = []
+  for (const def of GROUP_DEFS) {
+    const options: AttendanceImportFieldOption[] = []
+    for (const target of def.targets) {
+      const entry = byTarget.get(target)
+      if (!entry) continue
+      const meaning = FIELD_MEANINGS[target] ?? { en: `Field ${target}`, zh: `字段 ${target}` }
+      options.push({
+        key: target,
+        columnName: entry.cjk ?? entry.aliases[0],
+        aliases: entry.aliases,
+        meaningEn: meaning.en,
+        meaningZh: meaning.zh,
+      })
+    }
+    if (options.length > 0) {
+      groups.push({ key: def.key, labelEn: def.labelEn, labelZh: def.labelZh, options })
+    }
+  }
+  return groups
+}
+
+/** Default selection = the starter template's semantic fields. */
+export const IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS = [
+  'attendanceGroup',
+  'firstInAt',
+  'lastOutAt',
+  'status',
+  'exceptionReason',
+] as const
+
+/**
+ * Assemble the template header from a selection: locked base columns first,
+ * then selected fields in group/definition order (selection set order does
+ * not matter). Unknown keys are ignored.
+ */
+export function buildTemplateHeaderFromSelection(
+  groups: readonly AttendanceImportFieldGroup[],
+  selectedKeys: ReadonlySet<string> | readonly string[],
+): string[] {
+  const selected = selectedKeys instanceof Set ? selectedKeys : new Set(selectedKeys)
+  const header: string[] = [...IMPORT_TEMPLATE_BASE_COLUMNS]
+  for (const group of groups) {
+    for (const option of group.options) {
+      if (!selected.has(option.key)) continue
+      if (!header.includes(option.columnName)) header.push(option.columnName)
+    }
+  }
+  return header
+}
+
+/** All selectable keys across groups (for 全选). */
+export function allSelectableImportFieldKeys(groups: readonly AttendanceImportFieldGroup[]): string[] {
+  return groups.flatMap(group => group.options.map(option => option.key))
+}

--- a/apps/web/tests/attendance-import-preview-regression.spec.ts
+++ b/apps/web/tests/attendance-import-preview-regression.spec.ts
@@ -444,6 +444,28 @@ describe('Attendance import preview regression', () => {
     expect(container!.textContent).toContain('CSV template downloaded.')
   })
 
+  it('one-click download never destroys a hand-edited payload: errors instead of auto-loading', async () => {
+    const apiFetchMock = mockTemplateEndpoint()
+    stubObjectUrl()
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    const vm = app.mount(container!)
+    await flushUi(6)
+    const setupState = (vm as any).$?.setupState as Record<string, unknown>
+    const editedPayload = '{"source":"manual","rows":['
+    ;(setupState.importForm as { payload: string }).payload = editedPayload
+    await flushUi(2)
+    apiFetchMock.mockClear()
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Download CSV template').click()
+    await flushUi(6)
+
+    expect(apiFetchMock.mock.calls.some(call => String(call[0]).startsWith('/api/attendance/import/template'))).toBe(false)
+    expect((setupState.importForm as { payload: string }).payload).toBe(editedPayload)
+    expect(container!.textContent).toContain('Payload JSON has content but no template columns')
+  })
+
   it('advanced options collapse by default; core fields stay visible; toggle expands', async () => {
     mockTemplateEndpoint()
 

--- a/apps/web/tests/attendance-import-preview-regression.spec.ts
+++ b/apps/web/tests/attendance-import-preview-regression.spec.ts
@@ -349,4 +349,119 @@ describe('Attendance import preview regression', () => {
       setLocale(previousLocale)
     }
   })
+
+  function mockTemplateEndpoint(): ReturnType<typeof vi.mocked<typeof apiFetch>> {
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(async (path: string) => {
+      const url = String(path)
+      if (url.startsWith('/api/attendance/import/template')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            payloadExample: {
+              source: 'dingtalk_csv',
+              mode: 'override',
+              columns: ['日期', '工号', '姓名', '考勤组', '上班1打卡时间', '下班1打卡时间', '考勤结果', '异常原因'],
+              requiredFields: ['日期'],
+            },
+            mappingProfiles: [],
+            mapping: {
+              columns: [
+                { sourceField: '上班1打卡时间', targetField: 'firstInAt' },
+                { sourceField: '下班1打卡时间', targetField: 'lastOutAt' },
+                { sourceField: '考勤结果', targetField: 'status' },
+                { sourceField: '异常原因', targetField: 'exceptionReason' },
+                { sourceField: '加班小时', targetField: 'overtimeHours' },
+                { sourceField: '考勤组', targetField: 'attendanceGroup' },
+              ],
+            },
+          },
+        })
+      }
+      return jsonResponse(200, { ok: true, data: { items: [], summary: null } })
+    })
+    return apiFetchMock
+  }
+
+  function stubObjectUrl() {
+    const createObjectURL = vi.fn(() => 'blob:mock')
+    const revokeObjectURL = vi.fn()
+    Object.defineProperty(URL, 'createObjectURL', { value: createObjectURL, configurable: true })
+    Object.defineProperty(URL, 'revokeObjectURL', { value: revokeObjectURL, configurable: true })
+    return { createObjectURL, revokeObjectURL }
+  }
+
+  it('field picker: load template renders grouped checkboxes and selection drives the header preview + download', async () => {
+    mockTemplateEndpoint()
+    const { createObjectURL } = stubObjectUrl()
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(6)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Load template').click()
+    await flushUi(6)
+
+    const picker = container!.querySelector('[data-testid="attendance-import-field-picker"]') as HTMLElement | null
+    expect(picker, 'expected field picker card').toBeTruthy()
+    expect(picker!.textContent).toContain('Punch times')
+
+    const preview = () => (container!.querySelector('[data-testid="attendance-import-header-preview"]') as HTMLElement).textContent ?? ''
+    expect(preview()).toBe('日期,工号,姓名,上班1打卡时间,下班1打卡时间,考勤结果,异常原因,考勤组')
+
+    const overtime = Array.from(picker!.querySelectorAll('label')).find(
+      candidate => candidate.textContent?.trim() === '加班小时'
+    )
+    expect(overtime, 'expected 加班小时 option').toBeTruthy()
+    ;(overtime!.querySelector('input') as HTMLInputElement).click()
+    await flushUi(2)
+    expect(preview()).toContain('加班小时')
+
+    findButton(picker!, 'Download template (selected fields)').click()
+    await flushUi(2)
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(container!.textContent).toContain('CSV template downloaded (9 columns).')
+  })
+
+  it('one-click template download: works from a cold panel by auto-loading first', async () => {
+    const apiFetchMock = mockTemplateEndpoint()
+    const { createObjectURL } = stubObjectUrl()
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(6)
+    apiFetchMock.mockClear()
+
+    const importSection = findImportSection(container!)
+    const download = findButton(importSection, 'Download CSV template')
+    expect(download.disabled).toBe(false)
+    download.click()
+    await flushUi(8)
+
+    expect(apiFetchMock.mock.calls.some(call => String(call[0]).startsWith('/api/attendance/import/template'))).toBe(true)
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(container!.textContent).toContain('CSV template downloaded.')
+  })
+
+  it('advanced options collapse by default; core fields stay visible; toggle expands', async () => {
+    mockTemplateEndpoint()
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(6)
+
+    const advanced = container!.querySelector('[data-testid="attendance-import-advanced"]') as HTMLElement | null
+    expect(advanced, 'expected advanced group container').toBeTruthy()
+    expect(advanced!.style.display).toBe('none')
+    expect(container!.querySelector('#attendance-import-csv'), 'core csv input stays visible').toBeTruthy()
+    expect(advanced!.querySelector('#attendance-import-payload'), 'payload JSON lives in advanced').toBeTruthy()
+
+    const toggle = container!.querySelector('[data-testid="attendance-import-advanced-toggle"]') as HTMLButtonElement
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    toggle.click()
+    await flushUi(2)
+    expect(advanced!.style.display).not.toBe('none')
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+  })
 })

--- a/apps/web/tests/attendance-import-template-columns.spec.ts
+++ b/apps/web/tests/attendance-import-template-columns.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   IMPORT_TEMPLATE_BASE_COLUMNS,
@@ -74,6 +76,30 @@ describe('importTemplateColumns', () => {
     const groups = groupSupportedImportColumns(MAPPING_COLUMNS)
     const header = buildTemplateHeaderFromSelection(groups, new Set(IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS))
     expect(header).toEqual(['日期', '工号', '姓名', '上班1打卡时间', '下班1打卡时间', '考勤结果', '异常原因', '考勤组'])
+  })
+
+  it('default selection stays in sync with the backend starter template (fixture-sync)', () => {
+    // Guard against silent drift (review P3-1): the hardcoded default keys must
+    // keep reproducing the backend's first template profile. Reads the real
+    // plugin source so a backend starter-template change turns this red.
+    const source = readFileSync(
+      resolve(__dirname, '../../../plugins/plugin-attendance/index.cjs'),
+      'utf8',
+    )
+    const mappingBlock = source.match(/const IMPORT_MAPPING_COLUMNS = \[([\s\S]*?)\n\]/)?.[1]
+    expect(mappingBlock, 'expected IMPORT_MAPPING_COLUMNS in plugin source').toBeTruthy()
+    const realColumns = Array.from(
+      mappingBlock!.matchAll(/sourceField: '([^']+)', targetField: '([^']+)'/g),
+    ).map(match => ({ sourceField: match[1], targetField: match[2] }))
+    expect(realColumns.length).toBeGreaterThan(30)
+
+    const starterBlock = source.match(/templateColumns: \[([^\]]+)\]/)?.[1]
+    expect(starterBlock, 'expected first profile templateColumns').toBeTruthy()
+    const starterColumns = Array.from(starterBlock!.matchAll(/'([^']+)'/g)).map(match => match[1])
+
+    const groups = groupSupportedImportColumns(realColumns)
+    const header = buildTemplateHeaderFromSelection(groups, new Set(IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS))
+    expect([...header].sort()).toEqual([...starterColumns].sort())
   })
 
   it('select-all covers every option across groups', () => {

--- a/apps/web/tests/attendance-import-template-columns.spec.ts
+++ b/apps/web/tests/attendance-import-template-columns.spec.ts
@@ -18,6 +18,9 @@ const MAPPING_COLUMNS = [
   { sourceField: '异常原因', targetField: 'exceptionReason' },
   { sourceField: '迟到分钟', targetField: 'lateMinutes' },
   { sourceField: '加班小时', targetField: 'overtimeHours' },
+  { sourceField: 'leave_hours', targetField: 'leaveMinutes' },
+  { sourceField: 'overtime_duration', targetField: 'overtimeMinutes' },
+  { sourceField: '离职时间', targetField: 'resignTime' },
   { sourceField: '班次', targetField: 'shiftName' },
   { sourceField: '考勤组', targetField: 'attendanceGroup' },
   { sourceField: '部门', targetField: 'department' },
@@ -38,7 +41,17 @@ describe('importTemplateColumns', () => {
     expect(byKey['status']?.options.map(option => option.columnName)).toEqual(['考勤结果', '异常原因'])
     expect(byKey['durations']?.options.map(option => option.key)).toEqual(['lateMinutes', 'overtimeHours'])
     expect(byKey['shift-group']?.options.map(option => option.columnName)).toEqual(['班次', '考勤组'])
+    expect(byKey['people']?.options.map(option => option.columnName)).toEqual(['部门', '离职时间'])
     expect(byKey['approval']?.options).toHaveLength(1)
+  })
+
+  it('excludes English-only near-duplicate targets so generated headers stay Chinese', () => {
+    const groups = groupSupportedImportColumns(MAPPING_COLUMNS)
+    const keys = allSelectableImportFieldKeys(groups)
+    expect(keys).not.toContain('leaveMinutes')
+    expect(keys).not.toContain('overtimeMinutes')
+    const header = buildTemplateHeaderFromSelection(groups, keys)
+    expect(header.filter(column => /[A-Za-z_]/.test(column))).toEqual([])
   })
 
   it('skips empty/unknown mapping rows and empty input', () => {

--- a/apps/web/tests/attendance-import-template-columns.spec.ts
+++ b/apps/web/tests/attendance-import-template-columns.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IMPORT_TEMPLATE_BASE_COLUMNS,
+  IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS,
+  allSelectableImportFieldKeys,
+  buildTemplateHeaderFromSelection,
+  groupSupportedImportColumns,
+} from '../src/views/attendance/importTemplateColumns'
+
+const MAPPING_COLUMNS = [
+  { sourceField: '1_on_duty_user_check_time', targetField: 'firstInAt' },
+  { sourceField: '上班1打卡时间', targetField: 'firstInAt' },
+  { sourceField: 'check_in', targetField: 'firstInAt' },
+  { sourceField: '下班1打卡时间', targetField: 'lastOutAt' },
+  { sourceField: '上班2打卡时间', targetField: 'clockIn2' },
+  { sourceField: '考勤结果', targetField: 'status' },
+  { sourceField: 'attend_result', targetField: 'status' },
+  { sourceField: '异常原因', targetField: 'exceptionReason' },
+  { sourceField: '迟到分钟', targetField: 'lateMinutes' },
+  { sourceField: '加班小时', targetField: 'overtimeHours' },
+  { sourceField: '班次', targetField: 'shiftName' },
+  { sourceField: '考勤组', targetField: 'attendanceGroup' },
+  { sourceField: '部门', targetField: 'department' },
+  { sourceField: '关联的审批单', targetField: 'approvalSummary' },
+]
+
+describe('importTemplateColumns', () => {
+  it('groups by semantic category, dedupes aliases, prefers Chinese column names', () => {
+    const groups = groupSupportedImportColumns(MAPPING_COLUMNS)
+    const byKey = Object.fromEntries(groups.map(group => [group.key, group]))
+
+    const punchTimes = byKey['punch-times']
+    expect(punchTimes).toBeTruthy()
+    const firstIn = punchTimes.options.find(option => option.key === 'firstInAt')
+    expect(firstIn?.columnName).toBe('上班1打卡时间')
+    expect(firstIn?.aliases).toEqual(['1_on_duty_user_check_time', '上班1打卡时间', 'check_in'])
+
+    expect(byKey['status']?.options.map(option => option.columnName)).toEqual(['考勤结果', '异常原因'])
+    expect(byKey['durations']?.options.map(option => option.key)).toEqual(['lateMinutes', 'overtimeHours'])
+    expect(byKey['shift-group']?.options.map(option => option.columnName)).toEqual(['班次', '考勤组'])
+    expect(byKey['approval']?.options).toHaveLength(1)
+  })
+
+  it('skips empty/unknown mapping rows and empty input', () => {
+    expect(groupSupportedImportColumns(null)).toEqual([])
+    expect(groupSupportedImportColumns([
+      { sourceField: '', targetField: 'firstInAt' },
+      { sourceField: 'x', targetField: '' },
+      { sourceField: 'mystery', targetField: 'notARealTarget' },
+    ])).toEqual([])
+  })
+
+  it('builds the header with locked base columns first, in group order, ignoring unknown keys', () => {
+    const groups = groupSupportedImportColumns(MAPPING_COLUMNS)
+    const header = buildTemplateHeaderFromSelection(groups, new Set(['status', 'firstInAt', 'bogus']))
+    expect(header.slice(0, IMPORT_TEMPLATE_BASE_COLUMNS.length)).toEqual([...IMPORT_TEMPLATE_BASE_COLUMNS])
+    expect(header).toEqual(['日期', '工号', '姓名', '上班1打卡时间', '考勤结果'])
+  })
+
+  it('default selection reproduces the starter-template shape', () => {
+    const groups = groupSupportedImportColumns(MAPPING_COLUMNS)
+    const header = buildTemplateHeaderFromSelection(groups, new Set(IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS))
+    expect(header).toEqual(['日期', '工号', '姓名', '上班1打卡时间', '下班1打卡时间', '考勤结果', '异常原因', '考勤组'])
+  })
+
+  it('select-all covers every option across groups', () => {
+    const groups = groupSupportedImportColumns(MAPPING_COLUMNS)
+    const all = allSelectableImportFieldKeys(groups)
+    expect(new Set(all).size).toBe(all.length)
+    const header = buildTemplateHeaderFromSelection(groups, all)
+    expect(header).toHaveLength(IMPORT_TEMPLATE_BASE_COLUMNS.length + all.length)
+  })
+})

--- a/docs/development/attendance-import-section-ux-design-lock-20260706.md
+++ b/docs/development/attendance-import-section-ux-design-lock-20260706.md
@@ -1,0 +1,46 @@
+# 考勤导入 section 体验（排版分组 + 模板可发现性）design-lock — 2026-07-06
+
+> **Status: RATIFIED（owner 对话拍板 2026-07-06：排版"确实一下子不太理想"→ 同意立独立切片；
+> 追问"客户不知道都有哪些列名可以导入，何况要客户自己输入字段列名么"→ 支持列必须产品化呈现）。**
+> 纯前端 display/interaction 切片；后端 `plugins/plugin-attendance` 零改动。
+> Token 消费既有 UF `--ms-*` 词汇（ui-foundation-design-lock-20260706，新硬编码 hex = 缺陷），不自立体系。
+
+## 1. 病灶（客户截图 + 代码审计实证）
+
+| # | 问题 | 证据 |
+|---|---|---|
+| 1 | 核心动线（选文件→预览→导入）被 16 个平铺字段淹没，高频与一年一用的高级项同层级 | `AttendanceView.vue` 导入字段区单一 `attendance__admin-grid` 平铺 |
+| 2 | 工程师视角泄漏：负载 (JSON)、用户映射 JSON 直接暴露 | 同上 |
+| 3 | 模板可发现性差：「下载 CSV 模板」默认灰，需先点「加载模板」，无解释 | `:disabled="importLoading \|\| !importTemplateGuide"` + `:17929` 报错文案 |
+| 4 | **支持列不可见**：完整 60+ 列别名词汇（多段打卡/迟到早退/加班/班次/部门…）接口已返回（`/api/attendance/import/template` → `data.mapping.columns` = `IMPORT_MAPPING_COLUMNS`），前端 `loadImportTemplate` 丢弃；「字段说明」卡解释的是 payload JSON 键，非 CSV 列 | `loadImportTemplate` 只取 payloadExample/mappingProfiles；guide `fieldGuides` = payloadExample 的 keys |
+| 5 | 模板 CSV 只含 8 起步列，客户无从得知还能加什么列 | `IMPORT_TEMPLATE_PROFILES[].templateColumns` |
+
+## 2. 方案（四个决策）
+
+- **D1 字段分组**：字段区拆「常用」（CSV 文件 / 导入模式 / 规则集 / 映射配置，4 项）+「高级选项」折叠区（其余 12 项：表头行/分隔符/用户映射×3/分组×4/用户 ID/时区/负载 JSON）。折叠用按钮 + `v-show`（DOM 常驻 → 既有测试选择器不受影响）；带"已配置 N 项"徽标；挂载时若有非默认高级项则自动展开。
+- **D2 模板一键下载**：composable 版本**已经是一键**（server-first 取 `template.csv` + guide 缺失自动 load fallback）——是旧壳落后：`:disabled="!importTemplateGuide"` + 未加载报错。本切片把 shell 补齐到同水位：未加载自动先 `loadImportTemplate` 再下载，按钮不再因未加载而禁用；composable 零改动。
+- **D3 字段勾选生成模板（本切片核心增量；owner 追加拍板 2026-07-06："客户可以选择相应的字段来产生列名么"→ 从"看字典"升级为"勾选生成"）**：新共享纯函数模块 `apps/web/src/views/attendance/importTemplateColumns.ts`：
+  - `groupSupportedImportColumns(columns)`：按 targetField 语义分组（打卡时间/打卡结果/状态与异常/时长与工时/班次与分组/人员画像/审批），同 target 多别名去重合并，**中文别名优先**作为展示/生成列名；
+  - `buildTemplateHeaderFromSelection(groups, selectedKeys)`：锁定基础列（日期/工号/姓名）置首 + 按分组顺序拼接所选字段的中文优先列名，产出表头。
+  加载模板后 guide 区新增「选择字段，生成导入模板」全宽卡：分组渲染**可勾选**字段 chips（中文名 + 含义提示）；「日期/工号/姓名」必填锁定常亮；默认勾选 = 起步模板对应字段；**实时表头预览**；动作 =「下载模板（所选列）」（客户端合成 CSV：所选表头 + 一行空样例）/「复制表头」（clipboard + 状态反馈）/「全选」/「恢复默认」。未加载时按钮旁新增一行提示「点击"加载模板"可勾选字段生成模板」。
+- **D4 保全与 token**：既有 id/name/label/文案/testid 全部不动（300+ 文案断言安全）；新增结构样式只用 `--ms-*`（border-light/space/radius/text-2/bg-card 等）；新增文案均为新 key 走 `tr()` 双语。
+
+## 3. 边界（OUT）
+
+- **选文件后"列识别回显"**（读客户 CSV 表头对照词汇表，绿=识别/灰=忽略/红=缺必填当场回显）：下一个独立 opt-in 切片——动选文件读取路径（与 xlsx 护栏同片代码），单独设计→审阅。
+- 自定义映射配置 CRUD / 自定义字段落库进报表：独立 gated 切片（客户若要"自定义新字段进统计"再立锁）。
+- 后端模板/映射常量、导入逻辑、接口形状：零改动。
+- 向导式整页重构（真 stepper）、Settings 巨表单、其他 section：留在 UI arc P3b 队列。
+- orphan `AttendanceImportWorkflowSection.vue` 的字典卡渲染：共享模块已就绪，接入随该 Section 的挂载切片走（本切片只给 composable 接 D2）。
+
+## 4. 测试契约
+
+1. 新单测 `attendance-import-template-columns.spec.ts`：分组/去重/中文优先/勾选表头组装（基础列锁定置首、按分组序、全选/默认集）。
+2. 真挂载（preview-regression spec 模式）：mock `/import/template` 返回 `mapping.columns` → 点「加载模板」→ 勾选卡分组渲染、默认勾选、切换勾选后表头预览变化、「下载模板（所选列）」产出所选表头；「下载 CSV 模板」在未加载状态直接点击 → 自动请求 `/import/template` 后触发下载（一键化）；高级区默认收起、点按钮展开、常用 4 字段始终可见。
+3. composable spec：D2 一键下载（guide 空 → 自动 load → downloadText 被调）+ 既有先加载后下载路径回归。
+4. Mutation 证明：摘 D2 自动加载 → 一键下载测试红；摘勾选→表头组装 → 勾选卡测试红。
+5. 新 spec 进 `attendance-web-guard` run-list + 双 path-filter 块。
+
+## 5. 完成口径
+
+实现 → opus 对抗审阅 0 P1/P2 → 三红线（fresh-green + up-to-date）→ 验证 MD。FE 串行车道（触碰 `AttendanceView.vue`）。


### PR DESCRIPTION
## 背景（客户同一导入页的三个体验缺口）

1. **支持列不可见**：`/api/attendance/import/template` 早已返回 60+ 列别名词汇（`mapping.columns`），前端丢弃——客户不知道能导哪些列，更不该让客户手打列名（owner 拍板：勾选生成）。
2. **模板不可发现**：「下载 CSV 模板」默认灰，需先点「加载模板」且无解释（composable 版本已是一键，旧壳落后）。
3. **核心动线被淹没**：选文件→预览→导入被 16 个平铺字段（含负载 JSON）淹没。

## 变更（纯前端；后端零改动）

- **D3 字段勾选生成模板**：共享纯模块 `importTemplateColumns.ts`（按语义分组、别名去重、中文优先）；模板说明区新增勾选卡——分组 checkbox（含义悬浮）、必填列锁定、**实时表头预览**、「下载模板（所选列）/复制表头/全选/恢复默认」。
- **D2 一键下载**：旧壳补齐到 composable 水位（未加载自动先 load 再下载；按钮不再禁用；冷面板加提示行）。
- **D1 常用/高级分组**：常用 4 字段（CSV 文件/导入模式/规则集/映射配置）+ 高级折叠区（表头行/分隔符/用户映射/分组/用户 ID/时区/负载 JSON），带"已配置 N 项"徽标，非默认自动展开；`v-show` 保 DOM 常驻（既有选择器/测试零影响）。
- 新样式全部消费 UF `--ms-*` tokens（零新硬编码 hex）。

## 验证

- 新单测（分组/去重/中文优先/表头组装）5 绿；真挂载测试：勾选卡渲染+勾选驱动预览+下载所选列、冷面板一键下载（自动请求 template）、高级区默认收起/切换展开，全绿。
- **双 mutation 证明**：摘自动加载 → 一键测试红；短路表头组装 → 5 测齐红；还原复绿。
- web-guard 全家 + 新 spec：14 spec files / 329 tests 绿；`vue-tsc -b` 干净。
- 新 spec 已进 web-guard run-list + 双 path-filter 块。

设计锁：`docs/development/attendance-import-section-ux-design-lock-20260706.md`（含 OUT：列识别回显=下一独立切片；自定义映射 CRUD/自定义字段进报表=另立锁）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
