### PR TITLE
feat(integration): bounded material-LIST pageIndex (1..10) — BL4 candidate discovery (#3703)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -1024,6 +1024,21 @@ async function testK3WebApiMaterialListReadSmoke() {
   assert.equal(wildcardKey.records.length, 2, 'LIST wildcard-shaped key still runs as a bounded internal input')
   const wildcardCall = calls.filter((call) => call.pathname === '/K3API/Material/GetList').at(-1)
   assert.equal(wildcardCall.body.Data.Filter, "FNumber like '%MAT_001%'", 'LIST key uses K3 freeform quoting instead of T-SQL bracket escaping')
+  // Bounded pageIndex (#3703): the requested page reaches the K3 body and the values-free paging echo.
+  const pagedRead = await adapter.read(buildMarkedListRequest({ object: 'material', mode: 'list', pageIndex: 3 }))
+  const pagedCall = calls.filter((call) => call.pathname === '/K3API/Material/GetList').at(-1)
+  assert.equal(pagedCall.body.Data.PageIndex, 3, 'bounded pageIndex reaches the K3 request body')
+  assert.equal(pagedCall.body.Data.Top, 2, 'paged LIST keeps the bounded Top')
+  assert.equal(pagedCall.body.Data.PageSize, 2, 'paged LIST keeps the bounded PageSize')
+  assert.equal(pagedRead.metadata.requestedPageIndex, 3, 'paged LIST surfaces the requested page in the echo')
+  // Out-of-bound / non-integer pageIndex fails closed BEFORE any K3 call (defense-in-depth re-guard).
+  for (const badPage of [0, 11, 1.5, '3', null]) {
+    const before = calls.filter((call) => call.pathname === '/K3API/Material/GetList').length
+    const rejected = await adapter.read(markedListRequestWith({ options: Object.assign(buildMarkedListRequest().options, { listPageIndex: badPage }) })).catch((error) => error)
+    assert.ok(rejected instanceof AdapterValidationError, `pageIndex ${JSON.stringify(badPage)} must be rejected`)
+    assert.equal(rejected.details.code, 'K3_WISE_READ_LIST_PAGE_INDEX_INVALID')
+    assert.equal(calls.filter((call) => call.pathname === '/K3API/Material/GetList').length, before, 'rejected pageIndex produces no K3 GetList call')
+  }
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Save'), false, 'LIST smoke must not Save')
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Submit'), false, 'LIST smoke must not Submit')
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Audit'), false, 'LIST smoke must not Audit')

--- a/plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs
@@ -64,6 +64,40 @@ assert.deepEqual(normalizeReadSmokeContract({
   key: 'MAT-',
 }, 'LIST key is trimmed and preserved only as an internal FNumber filter input')
 
+// --- bounded LIST pageIndex (#3703): integer 1..10 only, list-mode only ---
+assert.deepEqual(normalizeReadSmokeContract({
+  presetId: 'k3wise.material-list.v1',
+  intent: { object: 'material', mode: 'list', pageIndex: 3 },
+}), {
+  presetId: 'k3wise.material-list.v1',
+  object: 'material',
+  mode: 'list',
+  pageIndex: 3,
+}, 'LIST accepts a bounded integer pageIndex')
+assert.deepEqual(normalizeReadSmokeContract({
+  presetId: 'k3wise.material-list.v1',
+  intent: { object: 'material', mode: 'list', key: 'MAT-', pageIndex: 10 },
+}), {
+  presetId: 'k3wise.material-list.v1',
+  object: 'material',
+  mode: 'list',
+  pageIndex: 10,
+  key: 'MAT-',
+}, 'LIST pageIndex composes with the internal filter key; the max bound (10) is accepted')
+for (const badPage of [0, 11, -1, 1.5, '3', ' 3', null, true, {}, [], Number.NaN, Infinity]) {
+  assert.throws(
+    () => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', pageIndex: badPage } }),
+    isErr('page_index_invalid'),
+    `LIST pageIndex ${JSON.stringify(badPage)} must fail closed`,
+  )
+}
+// pageIndex on a non-list mode is rejected, never silently dropped
+assert.throws(
+  () => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: { object: 'material', mode: 'single_record_detail', key: 'M-001', pageIndex: 2 } }),
+  isErr('page_index_not_allowed'),
+  'detail-mode pageIndex must be rejected',
+)
+
 // --- fail-closed ---
 assert.throws(() => normalizeReadSmokeContract(null), isErr('not_object'))
 assert.throws(() => normalizeReadSmokeContract('x'), isErr('not_object'))

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -87,6 +87,11 @@ assert.equal(keyedListReq.limit, 10)
 assert.equal(keyedListReq.options.k3ReadMode, 'list')
 assert.equal(keyedListReq.options.listKey, 'MAT-')
 assert.equal(keyedListReq.options[READ_SMOKE_LIST_REQUEST_MARKER], true, 'keyed LIST request also carries the internal route-only marker')
+// Bounded pageIndex (#3703) rides as the dedicated option; absent → no option (adapter default page 1).
+assert.equal(listReq.options.listPageIndex, undefined, 'no pageIndex → no listPageIndex option')
+const pagedListReq = buildReadSmokeRequest(LIST_PRESET, { object: 'material', mode: 'list', pageIndex: 4 })
+assert.equal(pagedListReq.options.listPageIndex, 4, 'contract pageIndex maps to options.listPageIndex')
+assert.equal(pagedListReq.options[READ_SMOKE_LIST_REQUEST_MARKER], true, 'paged LIST request still carries the internal route-only marker')
 
 // --- non-persisted read config overlay: target-side Save config is preserved, read config is in-memory only ---
 const storedSystem = {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -51,6 +51,9 @@ class K3WiseWebApiAdapterError extends Error {
 
 const DEFAULT_OBJECTS = getK3WiseDocumentObjectDefaults()
 const DEFAULT_MATERIAL_LIST_MAX_LIMIT = 10
+// Bounded LIST page selection (#3703, owner-approved 2026-07-06): mirrors READ_SMOKE_LIST_MAX_PAGE_INDEX
+// in read-smoke.cjs — the adapter re-guards the same 1..10 bound (defense in depth, never wider).
+const MAX_MATERIAL_LIST_PAGE_INDEX = 10
 // C4 BOM read (#1709): GetDetail has no paging, so a large bill returns every line. Bound the records we
 // retain and the line count we report so a values-free read-smoke stays bounded regardless of bill size.
 const DEFAULT_MATERIAL_BOM_MAX_LINES = 1000
@@ -704,7 +707,7 @@ function assertMaterialListReadOnlyScope(request, objectConfig) {
       fields: Object.keys(request.filters),
     })
   }
-  const allowedOptionKeys = new Set(['k3ReadMode', 'listKey'])
+  const allowedOptionKeys = new Set(['k3ReadMode', 'listKey', 'listPageIndex'])
   const unknownOptions = Object.keys(request.options || {}).filter((key) => !allowedOptionKeys.has(key))
   if (unknownOptions.length > 0) {
     throw new AdapterValidationError('K3 WISE Material LIST smoke does not accept request-supplied options', {
@@ -712,6 +715,19 @@ function assertMaterialListReadOnlyScope(request, objectConfig) {
       object: request.object,
       fields: unknownOptions,
     })
+  }
+  // Bounded page selection (#3703, owner-approved 2026-07-06): defense-in-depth re-guard of the contract
+  // bound — a plain integer 1..MAX only. Anything else fails closed before any outbound call.
+  if (request.options.listPageIndex !== undefined) {
+    const pageIndex = request.options.listPageIndex
+    if (typeof pageIndex !== 'number' || !Number.isInteger(pageIndex) || pageIndex < 1 || pageIndex > MAX_MATERIAL_LIST_PAGE_INDEX) {
+      throw new AdapterValidationError('K3 WISE Material LIST smoke pageIndex is out of the fixed bound', {
+        code: 'K3_WISE_READ_LIST_PAGE_INDEX_INVALID',
+        object: request.object,
+        field: 'listPageIndex',
+        maxPageIndex: MAX_MATERIAL_LIST_PAGE_INDEX,
+      })
+    }
   }
   const maxLimit = toPositiveNumber(objectConfig.maxListLimit) || DEFAULT_MATERIAL_LIST_MAX_LIMIT
   if (request.limit > maxLimit) {
@@ -924,10 +940,13 @@ function buildListReadBody(request, objectConfig) {
     ? objectConfig.topField.trim()
     : 'Top'
   const container = isPlainObject(template[bodyKey]) ? template[bodyKey] : {}
+  // Bounded page selection (#3703): the scope guard has already enforced integer 1..MAX; absent → the
+  // shipped fixed page 1 (unchanged default).
+  const pageIndex = typeof request.options.listPageIndex === 'number' ? request.options.listPageIndex : 1
   template[bodyKey] = {
     ...container,
     [topField]: request.limit,
-    [pageIndexField]: 1,
+    [pageIndexField]: pageIndex,
     [pageSizeField]: request.limit,
   }
   const listFields = Array.isArray(objectConfig.readListFields)
@@ -1705,11 +1724,12 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       const listShapeProbe = materialListShapeProbe(readResponse.data)
       const dataDataPresent = listShapeProbe.dataData || listShapeProbe.dataLowerData || listShapeProbe.dataPascalData
       const dataRowCount = materialListRowCount(readResponse.data)
-      // Paging echo: what K3 reports it applied, vs what we requested (Top=PageSize=request.limit, PageIndex=1).
+      // Paging echo: what K3 reports it applied, vs what we requested (Top=PageSize=request.limit;
+      // PageIndex = the bounded requested page, default 1 — #3703).
       const dataPageSize = materialListPageSize(readResponse.data)
       const dataPageIndex = materialListPageIndex(readResponse.data)
       const requestedLimit = request.limit
-      const requestedPageIndex = 1
+      const requestedPageIndex = typeof request.options.listPageIndex === 'number' ? request.options.listPageIndex : 1
       const responseShapeProbe = materialListResponseShapeProbe(readResponse.data)
       if (!materialListBusinessSuccess(readResponse.data, config)) {
         const failureCode = materialListBusinessFailureCode(readResponse.data)

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -306,6 +306,9 @@ function buildReadSmokeRequest(preset, contractOrKey) {
       enumerable: true,
     })
     if (contract.key !== undefined) request.options.listKey = contract.key
+    // Bounded page selection (#3703): already contract-validated 1..MAX; rides as a dedicated option the
+    // adapter re-guards. Absent → adapter default page 1 (shipped behavior unchanged).
+    if (contract.pageIndex !== undefined) request.options.listPageIndex = contract.pageIndex
     return request
   }
   if (mode === 'bom') {
@@ -464,7 +467,11 @@ function readSmokeSafeErrorCode(value) {
 // body/response/credential/config can never ride in (strict key allowlist); unknown preset/object/mode → a
 // coarse reason; the key is never echoed in an error.
 const READ_SMOKE_CONTRACT_TOP_KEYS = Object.freeze(['presetId', 'key', 'intent'])
-const READ_SMOKE_CONTRACT_INTENT_KEYS = Object.freeze(['object', 'mode', 'key'])
+const READ_SMOKE_CONTRACT_INTENT_KEYS = Object.freeze(['object', 'mode', 'key', 'pageIndex'])
+// BL4 candidate-discovery follow-up (#3703, owner-approved 2026-07-06): LIST reads may name a BOUNDED page.
+// An integer page number only — never a filter/body/field surface; anything outside 1..MAX fails closed at
+// the contract AND again at the adapter scope guard. Detail/BOM modes reject the key outright.
+const READ_SMOKE_LIST_MAX_PAGE_INDEX = 10
 
 class ReadSmokeContractError extends Error {
   constructor(reason, message) {
@@ -516,16 +523,32 @@ function normalizeReadSmokeContract(input) {
   if (!Array.isArray(preset.allowedModes) || !preset.allowedModes.includes(mode)) {
     throw new ReadSmokeContractError('mode_not_allowed', 'mode is not allowlisted for this preset')
   }
+  const rawPageIndex = hasIntent ? input.intent.pageIndex : undefined
   if (mode === 'list') {
     if (!hasIntent) {
       throw new ReadSmokeContractError('intent_required', 'list mode requires the intent shape')
     }
+    const contract = { presetId: preset.presetId, object, mode }
+    // Bounded page selection (#3703): a plain integer 1..MAX only — no strings, no floats, no zero/negative,
+    // no unbounded scan. Fail-closed on anything else; the adapter re-guards the same bound.
+    if (rawPageIndex !== undefined) {
+      if (typeof rawPageIndex !== 'number' || !Number.isInteger(rawPageIndex)
+        || rawPageIndex < 1 || rawPageIndex > READ_SMOKE_LIST_MAX_PAGE_INDEX) {
+        throw new ReadSmokeContractError('page_index_invalid', `pageIndex must be an integer 1..${READ_SMOKE_LIST_MAX_PAGE_INDEX}`)
+      }
+      contract.pageIndex = rawPageIndex
+    }
     if (rawKey === undefined) {
-      return { presetId: preset.presetId, object, mode }
+      return contract
     }
     const key = typeof rawKey === 'string' ? rawKey.trim() : ''
     if (!key) throw new ReadSmokeContractError('key_required', 'a non-empty key is required when supplied')
-    return { presetId: preset.presetId, object, mode, key }
+    contract.key = key
+    return contract
+  }
+  // Fail-closed the other way: a pageIndex supplied to a non-list mode is rejected, not silently dropped.
+  if (rawPageIndex !== undefined) {
+    throw new ReadSmokeContractError('page_index_not_allowed', 'pageIndex is only allowed for list mode')
   }
 
   // Key is runtime-only and never echoed; require a non-empty string for single-record detail reads.
@@ -545,4 +568,5 @@ module.exports = {
   readSmokeResponseShapeContainerEvidence,
   ReadSmokeContractError,
   normalizeReadSmokeContract,
+  READ_SMOKE_LIST_MAX_PAGE_INDEX,
 }


### PR DESCRIPTION
## Summary
#3703 BL4 happy path 卡在"找单 BOM 物料样本":现场无样本(option 1 NOT_AVAILABLE),平台 LIST 钉死 PageIndex=1,实体机**正确拒绝**服务器内部凭证直采(option 3 DECLINED)。Owner 批准 option 2:**有界翻页参数**。

### 改动(最小面)
- 契约层:`intent.pageIndex` 进 allowlist,**整数 1..10** 硬界(`page_index_invalid`);非 list 模式携带 → `page_index_not_allowed`(拒绝不静默丢弃)
- builder:`contract.pageIndex → options.listPageIndex`(专用 option,非 filter/body 面)
- adapter:option allowlist + **同界再守卫**(`K3_WISE_READ_LIST_PAGE_INDEX_INVALID`,出界零外呼);body `PageIndex` 用界内值,缺省仍 1(shipped 行为零变化);paging echo `requestedPageIndex` 反映实际请求页
- 仍走既有 Symbol marker 门;零新路由、零 filter/field 面、零写

### 验证
- 契约测试:接受 3/10、拒 12 种坏值(0/11/-1/1.5/'3'/null/NaN/Infinity…)、detail 模式拒
- adapter 测试:body PageIndex=3 真实到达 K3 请求体、echo 对齐、5 种坏值**零 GetList 外呼**
- **mutation 3/3 KILLED**(契约界 / adapter 再守卫 / body 接线)
- 本地插件全链 72 suites 绿

### 用途
实体机翻页扫物料候选 → 逐个用已上线 BL2 standalone read 查 BOM 数 → 命中单 BOM 物料 → BL4 happy path。有界翻页对今后 discovery probe 通用。

Refs #3703 #1709

🤖 Generated with [Claude Code](https://claude.com/claude-code)