### PR TITLE
feat(web): UF-3 StatusTag + status-domain map — six status-color systems converge to one

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -59,6 +59,22 @@ on:
       - 'apps/web/src/views/approval/ApprovalCenterView.vue'
       - 'apps/web/tests/approvalMobileI18n.spec.ts'
       - 'apps/web/tests/approvalMobileResponsive.spec.ts'
+      # UF-3 — status-color convergence: the shared StatusTag/statusDomains map now renders the
+      # approvalInstance status tag (ApprovalCenterView/ApprovalMobileList/ApprovalDetailView
+      # header/ApprovalInboxView) and the delegation status tag (MyDelegationView/
+      # DelegationSettingsView, via the existing delegationStatus.ts).
+      - 'apps/web/src/components/status/StatusTag.vue'
+      - 'apps/web/src/utils/statusDomains.ts'
+      - 'apps/web/src/approvals/delegationStatus.ts'
+      - 'apps/web/src/views/ApprovalInboxView.vue'
+      - 'apps/web/src/views/approval/MyDelegationView.vue'
+      - 'apps/web/src/views/approval/DelegationSettingsView.vue'
+      - 'apps/web/tests/statusTag.spec.ts'
+      - 'apps/web/tests/approval-inbox-auth-guard.spec.ts'
+      - 'apps/web/tests/myDelegationView.spec.ts'
+      - 'apps/web/tests/approvalDelegationView.spec.ts'
+      - 'apps/web/tests/approvalDelegationStatus.spec.ts'
+      - 'apps/web/tests/approval-e2e-lifecycle.spec.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -105,6 +121,22 @@ on:
       - 'apps/web/src/views/approval/ApprovalCenterView.vue'
       - 'apps/web/tests/approvalMobileI18n.spec.ts'
       - 'apps/web/tests/approvalMobileResponsive.spec.ts'
+      # UF-3 — status-color convergence: the shared StatusTag/statusDomains map now renders the
+      # approvalInstance status tag (ApprovalCenterView/ApprovalMobileList/ApprovalDetailView
+      # header/ApprovalInboxView) and the delegation status tag (MyDelegationView/
+      # DelegationSettingsView, via the existing delegationStatus.ts).
+      - 'apps/web/src/components/status/StatusTag.vue'
+      - 'apps/web/src/utils/statusDomains.ts'
+      - 'apps/web/src/approvals/delegationStatus.ts'
+      - 'apps/web/src/views/ApprovalInboxView.vue'
+      - 'apps/web/src/views/approval/MyDelegationView.vue'
+      - 'apps/web/src/views/approval/DelegationSettingsView.vue'
+      - 'apps/web/tests/statusTag.spec.ts'
+      - 'apps/web/tests/approval-inbox-auth-guard.spec.ts'
+      - 'apps/web/tests/myDelegationView.spec.ts'
+      - 'apps/web/tests/approvalDelegationView.spec.ts'
+      - 'apps/web/tests/approvalDelegationStatus.spec.ts'
+      - 'apps/web/tests/approval-e2e-lifecycle.spec.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -167,4 +199,9 @@ jobs:
         # container + header components all approval views converged on. pageShell.spec.ts locks
         # the width-tier→token mapping + title/subtitle/actions/meta slots + the back-navigation
         # contract (backTo path-push vs back event-delegation, and back taking priority over backTo).
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell --reporter=dot
+        # UF-3: status-color convergence — statusTag (StatusTag.vue + statusDomains.ts unit/mount
+        # coverage), approval-e2e-lifecycle (ApprovalDetailView header StatusTag regression),
+        # approval-inbox-auth-guard (ApprovalInboxView, had no gate before this wiring),
+        # myDelegationView/approvalDelegationView (MyDelegationView/DelegationSettingsView status
+        # cell), approvalDelegationStatus (delegationStatus.ts, had no gate before this wiring).
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus --reporter=dot

--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -67,6 +67,14 @@ on:
       - 'apps/web/tests/multitable-field-visibility.spec.ts'
       - 'apps/web/tests/multitable-required-if.spec.ts'
       - 'apps/web/tests/multitable-conditional-formatting.spec.ts'
+      # UF-3 — status-color convergence: the automation run/step status badges now render via the
+      # shared StatusTag/statusDomains map instead of AutomationExecutionsView's own hex badge CSS.
+      - 'apps/web/src/views/AutomationExecutionsView.vue'
+      - 'apps/web/src/components/status/StatusTag.vue'
+      - 'apps/web/src/utils/statusDomains.ts'
+      - 'apps/web/tests/statusTag.spec.ts'
+      - 'apps/web/tests/AutomationExecutionsView.spec.ts'
+      - 'apps/web/tests/parallelBranchRunsView.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
     branches: [main]
@@ -122,6 +130,14 @@ on:
       - 'apps/web/tests/multitable-field-visibility.spec.ts'
       - 'apps/web/tests/multitable-required-if.spec.ts'
       - 'apps/web/tests/multitable-conditional-formatting.spec.ts'
+      # UF-3 — status-color convergence: the automation run/step status badges now render via the
+      # shared StatusTag/statusDomains map instead of AutomationExecutionsView's own hex badge CSS.
+      - 'apps/web/src/views/AutomationExecutionsView.vue'
+      - 'apps/web/src/components/status/StatusTag.vue'
+      - 'apps/web/src/utils/statusDomains.ts'
+      - 'apps/web/tests/statusTag.spec.ts'
+      - 'apps/web/tests/AutomationExecutionsView.spec.ts'
+      - 'apps/web/tests/parallelBranchRunsView.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
 
 jobs:
@@ -178,4 +194,7 @@ jobs:
         # "hidden field is never conditionally required" invariant (MetaFormView `validate()`) could
         # land green and silently block public-form submission. See docs/development/
         # multitable-formview-conditional-guard-{design,verification}-20260705.md.
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting --reporter=dot
+        # UF-3: status-color convergence — statusTag (StatusTag.vue + statusDomains.ts unit/mount
+        # coverage), AutomationExecutionsView + parallelBranchRunsView (automationRun domain status
+        # badges, run + step level, including the parallel-branch readability regression).
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting statusTag AutomationExecutionsView parallelBranchRunsView --reporter=dot

--- a/apps/web/src/components/status/StatusTag.vue
+++ b/apps/web/src/components/status/StatusTag.vue
@@ -1,0 +1,79 @@
+<template>
+  <span
+    class="ms-status-tag"
+    :class="`ms-status-tag--${size}`"
+    :data-domain="domain"
+    :data-status="status"
+    :data-tone="display.tone"
+    :style="tagStyle"
+  >{{ display.label }}</span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import { resolveStatusDisplay, type StatusDomain, type StatusTone } from '../../utils/statusDomains'
+
+// UF-3 — the ONE status-color renderer (design-lock §3.4 "状态 = 语义"). Framework-free by
+// design (no Element Plus import) so it drops into both EP table cells (ApprovalCenterView,
+// MyDelegationView, DelegationSettingsView) and hand-rolled markup (ApprovalMobileList,
+// AutomationExecutionsView, ApprovalInboxView) alike. Colors come ONLY from CSS custom
+// properties (tokens.css / the EP variable mapping UF-1 wrote) — never a hardcoded hex — so a
+// future palette change repaints every status tag site-wide from one place.
+const props = withDefaults(
+  defineProps<{
+    domain: StatusDomain
+    status: string
+    size?: 'sm' | 'md'
+  }>(),
+  {
+    size: 'md',
+  },
+)
+
+const { isZh } = useLocale()
+
+const display = computed(() => resolveStatusDisplay(props.domain, props.status, isZh.value))
+
+function toneColors(tone: StatusTone): { background: string; color: string } {
+  if (tone === 'neutral') {
+    return { background: 'var(--ms-bg-page)', color: 'var(--ms-text-2)' }
+  }
+  return {
+    background: `var(--el-color-${tone}-light-9)`,
+    color: `var(--el-color-${tone})`,
+  }
+}
+
+const tagStyle = computed(() => {
+  const { background, color } = toneColors(display.value.tone)
+  const paddingInline = props.size === 'sm' ? 'var(--ms-space-2)' : 'var(--ms-space-3)'
+  return {
+    background,
+    color,
+    borderRadius: 'var(--ms-radius-sm)',
+    paddingTop: 'var(--ms-space-1)',
+    paddingBottom: 'var(--ms-space-1)',
+    paddingLeft: paddingInline,
+    paddingRight: paddingInline,
+  }
+})
+</script>
+
+<style scoped>
+.ms-status-tag {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.4;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.ms-status-tag--md {
+  font-size: 12px;
+}
+
+.ms-status-tag--sm {
+  font-size: 11px;
+}
+</style>

--- a/apps/web/src/utils/statusDomains.ts
+++ b/apps/web/src/utils/statusDomains.ts
@@ -1,0 +1,115 @@
+// UF-3 — status-color convergence (docs/development/ui-foundation-design-lock-20260706.md §3.4,
+// §6). Six views previously each declared their own status → color/label map (or, for
+// ApprovalInboxView, rendered the raw enum with no color at all). This is the ONE place status
+// semantics live: a domain table of `status → { tone, zh, en }` per StatusTag consumer, plus the
+// `resolveStatusDisplay` lookup StatusTag.vue calls.
+//
+// Governance (design-lock §2): this file converges PRESENTATION only. It does not recompute or
+// fork any domain's status LOGIC — `delegation` calls the existing `delegationDisplayStatus`
+// (approvals/delegationStatus.ts) upstream of this module and only maps its already-computed
+// display status to a tone; `automationRun` derives its zh/en labels by calling the existing
+// `automationStatusLabel` (multitable/utils/meta-automation-labels.ts) rather than re-declaring
+// automation copy here.
+
+import { automationStatusLabel } from '../multitable/utils/meta-automation-labels'
+import type { WorkflowJobStatus } from '../multitable/types'
+import type { DelegationDisplayStatus } from '../approvals/delegationStatus'
+
+export type StatusTone = 'success' | 'warning' | 'danger' | 'info' | 'primary' | 'neutral'
+
+export type StatusDomain = 'approvalInstance' | 'delegation' | 'automationRun'
+
+export interface StatusDisplayEntry {
+  tone: StatusTone
+  zh: string
+  en: string
+}
+
+export interface StatusDisplayResult {
+  tone: StatusTone
+  label: string
+}
+
+// ---------------------------------------------------------------------------
+// approvalInstance — the shared instance-status vocabulary rendered by
+// ApprovalCenterView (all 4 tabs), ApprovalMobileList, ApprovalDetailView's header tag, and
+// ApprovalInboxView's status column. Enumerated from what those views' now-deleted local
+// `statusTagType`/`statusLabel` maps actually handled (pending/approved/rejected/revoked/
+// cancelled) — `ApprovalStatus` also allows `draft`, and the underlying instance model separately
+// tracks a `returned` terminal state (approvals/api.ts `terminalState`), but neither ever reached
+// these status-tag call sites as a literal `row.status` value, so both fall through to the
+// fail-safe neutral/raw-text branch below rather than being asserted as colored here.
+const APPROVAL_INSTANCE_STATUS_DOMAIN: Record<string, StatusDisplayEntry> = {
+  pending: { tone: 'warning', zh: '待处理', en: 'Pending' },
+  approved: { tone: 'success', zh: '已通过', en: 'Approved' },
+  rejected: { tone: 'danger', zh: '已驳回', en: 'Rejected' },
+  revoked: { tone: 'info', zh: '已撤回', en: 'Revoked' },
+  cancelled: { tone: 'info', zh: '已取消', en: 'Cancelled' },
+}
+
+// ---------------------------------------------------------------------------
+// delegation — the FOUR display statuses `delegationDisplayStatus()` computes (never a raw
+// `active` boolean or an English enum). This table only adds tone + an English label; the status
+// derivation itself (window-vs-now precedence, disabled-overrides-window, etc.) stays owned by
+// delegationStatus.ts. Tone values are carried over unchanged from that file's
+// `DELEGATION_STATUS_TAG_TYPE` (semantics preserved, not re-decided here).
+const DELEGATION_STATUS_DOMAIN: Record<DelegationDisplayStatus, StatusDisplayEntry> = {
+  未开始: { tone: 'info', zh: '未开始', en: 'Not started' },
+  生效中: { tone: 'success', zh: '生效中', en: 'Active' },
+  已过期: { tone: 'warning', zh: '已过期', en: 'Expired' },
+  已停用: { tone: 'danger', zh: '已停用', en: 'Disabled' },
+}
+
+// ---------------------------------------------------------------------------
+// automationRun — the full WorkflowJobStatus set AutomationExecutionsView surfaces for both runs
+// and steps. zh/en labels are NOT re-declared here — they're read straight off the existing
+// `automationStatusLabel` chrome table so this module can never drift from it.
+const AUTOMATION_RUN_STATUSES: WorkflowJobStatus[] = [
+  'queued',
+  'running',
+  'suspended',
+  'resolved',
+  'failed',
+  'skipped',
+  'rejected',
+  'errored',
+]
+
+const AUTOMATION_RUN_TONE: Record<WorkflowJobStatus, StatusTone> = {
+  queued: 'primary',
+  running: 'primary',
+  suspended: 'primary',
+  resolved: 'success',
+  failed: 'danger',
+  errored: 'danger',
+  rejected: 'danger',
+  skipped: 'neutral',
+}
+
+const AUTOMATION_RUN_STATUS_DOMAIN: Record<string, StatusDisplayEntry> = Object.fromEntries(
+  AUTOMATION_RUN_STATUSES.map((status) => [
+    status,
+    {
+      tone: AUTOMATION_RUN_TONE[status],
+      zh: automationStatusLabel(status, true),
+      en: automationStatusLabel(status, false),
+    },
+  ]),
+)
+
+const DOMAIN_TABLES: Record<StatusDomain, Record<string, StatusDisplayEntry>> = {
+  approvalInstance: APPROVAL_INSTANCE_STATUS_DOMAIN,
+  delegation: DELEGATION_STATUS_DOMAIN,
+  automationRun: AUTOMATION_RUN_STATUS_DOMAIN,
+}
+
+/**
+ * Resolve a `(domain, status)` pair to a tone + localized label. Fail-safe: a status absent from
+ * the domain's table (including domains passed a stale/unexpected value) never throws and never
+ * renders blank — it degrades to tone `'neutral'` with the raw status string as the label.
+ */
+export function resolveStatusDisplay(domain: StatusDomain, status: string, isZh: boolean): StatusDisplayResult {
+  const entry = DOMAIN_TABLES[domain]?.[status]
+  if (!entry) return { tone: 'neutral', label: status }
+  return { tone: entry.tone, label: isZh ? entry.zh : entry.en }
+}

--- a/apps/web/src/views/ApprovalInboxView.vue
+++ b/apps/web/src/views/ApprovalInboxView.vue
@@ -37,7 +37,7 @@
               :class="{ 'approval-inbox__row--active': selectedApprovalId === approval.id }"
             >
               <td class="mono">{{ approval.id }}</td>
-              <td>{{ approval.status }}</td>
+              <td><StatusTag domain="approvalInstance" :status="approval.status" /></td>
               <td>{{ formatPendingVersion(approval) }}</td>
               <td>{{ formatDate(approval.updated_at || approval.created_at) }}</td>
               <td>
@@ -116,6 +116,7 @@ import { computed, onMounted, ref } from 'vue'
 import type { ApprovalHistoryEntry } from './plm/plmPanelModels'
 import { useLocale } from '../composables/useLocale'
 import { apiFetch } from '../utils/api'
+import StatusTag from '../components/status/StatusTag.vue'
 import {
   buildApprovalInboxActionPayload,
   canActOnApprovalInboxEntry,

--- a/apps/web/src/views/AutomationExecutionsView.vue
+++ b/apps/web/src/views/AutomationExecutionsView.vue
@@ -49,9 +49,7 @@
       >
         <div class="automation-runs__summary">
           <span class="automation-runs__time">{{ formatTime(run.triggeredAt) }}</span>
-          <span class="automation-runs__badge" :class="`automation-runs__badge--${run.status}`" :data-status="run.status">
-            {{ automationStatusLabel(run.status, isZh) }}
-          </span>
+          <StatusTag domain="automationRun" :status="run.status" />
           <span class="automation-runs__rule" data-field="ruleId">{{ run.ruleId }}</span>
           <span v-if="run.sheetId" class="automation-runs__sheet" data-field="sheetId">{{ run.sheetId }}</span>
           <span class="automation-runs__trigger" data-field="triggeredBy">{{ run.triggeredBy }}</span>
@@ -75,9 +73,7 @@
               <span v-else-if="parallelChildStep(step.stepKey)" class="automation-runs__branch-child" data-field="parallel-child">
                 ↳ {{ automationLabel('runs.parallelBranchStep', isZh) }} {{ parallelChildStep(step.stepKey)?.branchKey }} · #{{ parallelChildStep(step.stepKey)?.actionIndex }}
               </span>
-              <span class="automation-runs__badge automation-runs__badge--sm" :class="`automation-runs__badge--${step.status}`">
-                {{ automationStatusLabel(step.status, isZh) }}
-              </span>
+              <StatusTag domain="automationRun" :status="step.status" size="sm" />
               <!-- A6-2: resume a suspended step (admin detail only; token used internally, never shown). -->
               <button
                 v-if="step.status === 'suspended' && step.suspend?.resumeToken"
@@ -127,6 +123,7 @@ import { multitableClient, type MultitableApiClient } from '../multitable/api/cl
 import type { AutomationRunView, AutomationRunStepView, WorkflowJobStatus } from '../multitable/types'
 import { automationLabel, automationStatusLabel, type AutomationLabelKey } from '../multitable/utils/meta-automation-labels'
 import { redactString, redactValue, summarizeStepError, summarizeStepOutput } from '../multitable/utils/automation-log-redact'
+import StatusTag from '../components/status/StatusTag.vue'
 
 const props = defineProps<{ client?: MultitableApiClient }>()
 const client = props.client ?? multitableClient
@@ -326,12 +323,9 @@ if (isAdmin) void loadData()
 .automation-runs__sheet { color: #475569; }
 .automation-runs__trigger { color: #475569; }
 .automation-runs__duration { margin-left: auto; color: #94a3b8; }
-.automation-runs__badge { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 11px; font-weight: 600; text-transform: uppercase; background: #f1f5f9; color: #475569; }
-.automation-runs__badge--resolved { background: #dcfce7; color: #16a34a; }
-.automation-runs__badge--failed, .automation-runs__badge--errored, .automation-runs__badge--rejected { background: #fef2f2; color: #dc2626; }
-.automation-runs__badge--skipped { background: #f1f5f9; color: #64748b; }
-.automation-runs__badge--running, .automation-runs__badge--queued, .automation-runs__badge--suspended { background: #eff6ff; color: #2563eb; }
-.automation-runs__badge--sm { font-size: 10px; padding: 1px 6px; }
+/* UF-3: the run/step status badges are now <StatusTag domain="automationRun"> (utils/
+   statusDomains.ts) — this file's own uppercase/hex badge palette (one of six independent
+   status-color implementations the UI foundation design-lock audit found) is removed. */
 .automation-runs__detail { margin-top: 8px; padding-top: 8px; border-top: 1px solid #e2e8f0; display: flex; flex-direction: column; gap: 6px; }
 .automation-runs__detail-h { margin: 6px 0 2px; font-size: 12px; font-weight: 700; color: #475569; text-transform: uppercase; }
 .automation-runs__step { display: flex; align-items: center; gap: 8px; font-size: 12px; flex-wrap: wrap; }

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -198,9 +198,7 @@
           </el-table-column>
           <el-table-column label="状态" width="100">
             <template #default="{ row }">
-              <el-tag :type="statusTagType(row.status)" size="small" :data-status="row.status">
-                {{ statusLabel(row.status) }}
-              </el-tag>
+              <StatusTag domain="approvalInstance" :status="row.status" />
             </template>
           </el-table-column>
           <el-table-column label="发起时间" width="180">
@@ -321,9 +319,7 @@
           </el-table-column>
           <el-table-column label="状态" width="100">
             <template #default="{ row }">
-              <el-tag :type="statusTagType(row.status)" size="small" :data-status="row.status">
-                {{ statusLabel(row.status) }}
-              </el-tag>
+              <StatusTag domain="approvalInstance" :status="row.status" />
             </template>
           </el-table-column>
           <el-table-column label="发起时间" width="180">
@@ -414,9 +410,7 @@
           </el-table-column>
           <el-table-column label="状态" width="100">
             <template #default="{ row }">
-              <el-tag :type="statusTagType(row.status)" size="small" :data-status="row.status">
-                {{ statusLabel(row.status) }}
-              </el-tag>
+              <StatusTag domain="approvalInstance" :status="row.status" />
             </template>
           </el-table-column>
           <el-table-column label="发起时间" width="180">
@@ -485,9 +479,7 @@
           </el-table-column>
           <el-table-column label="状态" width="100">
             <template #default="{ row }">
-              <el-tag :type="statusTagType(row.status)" size="small" :data-status="row.status">
-                {{ statusLabel(row.status) }}
-              </el-tag>
+              <StatusTag domain="approvalInstance" :status="row.status" />
             </template>
           </el-table-column>
           <el-table-column label="发起时间" width="180">
@@ -645,6 +637,7 @@ import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
 import ApprovalMobileList from './ApprovalMobileList.vue'
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
+import StatusTag from '../../components/status/StatusTag.vue'
 
 const router = useRouter()
 const store = useApprovalStore()
@@ -1002,28 +995,10 @@ const attendanceRequestsSection = 'attendance-overview-requests'
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-function statusTagType(status: string) {
-  const map: Record<string, string> = {
-    pending: 'warning',
-    approved: 'success',
-    rejected: 'danger',
-    revoked: 'info',
-    cancelled: 'info',
-  }
-  return map[status] ?? ''
-}
-
-function statusLabel(status: string) {
-  const map: Record<string, string> = {
-    pending: '待处理',
-    approved: '已通过',
-    rejected: '已驳回',
-    revoked: '已撤回',
-    cancelled: '已取消',
-  }
-  return map[status] ?? status
-}
-
+// UF-3: status coloring/labels now come from <StatusTag domain="approvalInstance"> (see
+// utils/statusDomains.ts) — the local statusTagType/statusLabel maps this file used to declare
+// were one of six independent status-color implementations audited in the UI foundation
+// design-lock and are removed here.
 function formatDate(dateStr: string) {
   if (!dateStr) return '-'
   return new Date(dateStr).toLocaleString('zh-CN')

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -8,12 +8,7 @@
       @back="goBack"
     >
       <template v-if="approval" #meta>
-        <el-tag
-          :type="statusTagType(approval.status)"
-          size="large"
-        >
-          {{ statusLabel(approval.status) }}
-        </el-tag>
+        <StatusTag domain="approvalInstance" :status="approval.status" />
         <!-- B1-03: 已等待 aging — glanceable next to the status tag, only while still pending. -->
         <el-tag
           v-if="approval.status === 'pending'"
@@ -710,6 +705,7 @@ import {
 import { phrasesForAction, recentPhrases, rememberPhrase } from '../../approvals/quickPhrases'
 import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
 import { buildUpcomingNodes, type UpcomingApprovalNode } from '../../approvals/upcomingNodes'
+import StatusTag from '../../components/status/StatusTag.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -1036,6 +1032,12 @@ function rememberQuickPhraseIfOffered(comment: string): void {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+// UF-3: the header status tag now renders via <StatusTag domain="approvalInstance"> (see
+// utils/statusDomains.ts). `statusTagType` stays — it's still used below by
+// `timelineActionTagType` to color the timeline's per-entry ACTION tag (approve/reject/pending
+// are borrowed here as an action-outcome palette, not a rendered instance status — the timeline's
+// own event-kind badges like 自动审批/会签完成/退回 are a separate, out-of-scope concept; see
+// `.approval-detail__meta-badge*`).
 function statusTagType(status: string) {
   const map: Record<string, string> = {
     pending: 'warning',
@@ -1045,17 +1047,6 @@ function statusTagType(status: string) {
     cancelled: 'info',
   }
   return map[status] ?? ''
-}
-
-function statusLabel(status: string) {
-  const map: Record<string, string> = {
-    pending: '待处理',
-    approved: '已通过',
-    rejected: '已驳回',
-    revoked: '已撤回',
-    cancelled: '已取消',
-  }
-  return map[status] ?? status
 }
 
 function actionLabel(action: string, metadata?: Record<string, unknown>) {

--- a/apps/web/src/views/approval/ApprovalMobileList.vue
+++ b/apps/web/src/views/approval/ApprovalMobileList.vue
@@ -26,13 +26,7 @@
     >
       <div class="approval-mobile-list__card-top">
         <span class="approval-mobile-list__title">{{ row.title ?? t.titleFallback }}</span>
-        <span
-          class="approval-mobile-list__status"
-          :class="`approval-mobile-list__status--${statusTagType(row.status)}`"
-          :data-status="row.status"
-        >
-          {{ statusLabel(row.status) }}
-        </span>
+        <StatusTag domain="approvalInstance" :status="row.status" size="sm" />
       </div>
       <div class="approval-mobile-list__meta">
         <span class="approval-mobile-list__request-no">{{ row.requestNo ?? '-' }}</span>
@@ -66,6 +60,7 @@ import type { FormSchema, UnifiedApprovalDTO } from '../../types/approval'
 import { useLocale } from '../../composables/useLocale'
 import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
 import { resolveRowSummaryLine } from '../../approvals/useApprovalListFieldSummary'
+import StatusTag from '../../components/status/StatusTag.vue'
 
 // T3-1 v0 — dedicated touch-first list card (ballot Q10). Replaces the desktop
 // `el-table` (fixed column widths + horizontal scroll + tiny row-click targets)
@@ -106,26 +101,12 @@ const t = computed(() => (isZh.value
       loading: '加载中…',
       empty: '暂无审批',
       titleFallback: '审批申请',
-      status: {
-        pending: '待处理',
-        approved: '已通过',
-        rejected: '已驳回',
-        revoked: '已撤回',
-        cancelled: '已取消',
-      } as Record<string, string>,
       dateLocale: 'zh-CN',
     }
   : {
       loading: 'Loading…',
       empty: 'No approvals',
       titleFallback: 'Approval request',
-      status: {
-        pending: 'Pending',
-        approved: 'Approved',
-        rejected: 'Rejected',
-        revoked: 'Revoked',
-        cancelled: 'Cancelled',
-      } as Record<string, string>,
       dateLocale: 'en-US',
     }
 ))
@@ -135,20 +116,9 @@ const t = computed(() => (isZh.value
 // localized default rather than a hardcoded literal.
 const resolvedEmptyText = computed(() => props.emptyText ?? t.value.empty)
 
-function statusTagType(status: string): string {
-  const map: Record<string, string> = {
-    pending: 'warning',
-    approved: 'success',
-    rejected: 'danger',
-    revoked: 'info',
-    cancelled: 'info',
-  }
-  return map[status] ?? 'info'
-}
-
-function statusLabel(status: string): string {
-  return t.value.status[status] ?? status
-}
+// UF-3: status coloring/labels now come from <StatusTag domain="approvalInstance"> (see
+// utils/statusDomains.ts), which absorbed this file's zh/en status dictionary — one of six
+// independent status-color implementations the UI foundation design-lock audit found.
 
 function formatDate(dateStr: string): string {
   if (!dateStr) return '-'
@@ -203,35 +173,19 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
   gap: 12px;
 }
 
+/* UF-3: keep the status chip from shrinking next to the (possibly long) title, same as the
+   card-top flex row previously relied on `.approval-mobile-list__status { flex-shrink: 0 }` for.
+   Vue applies this component's scope id to a mounted child's root node, so this scoped selector
+   reaches <StatusTag>'s root <span>. */
+.approval-mobile-list__card-top :deep(.ms-status-tag) {
+  flex-shrink: 0;
+}
+
 .approval-mobile-list__title {
   font-size: 15px;
   font-weight: 600;
   color: var(--el-text-color-primary, #303133);
   line-height: 1.4;
-}
-
-.approval-mobile-list__status {
-  flex-shrink: 0;
-  font-size: 12px;
-  padding: 2px 8px;
-  border-radius: 4px;
-  background: var(--el-fill-color-light, #f5f7fa);
-  color: var(--el-text-color-secondary, #909399);
-}
-
-.approval-mobile-list__status--warning {
-  background: #fdf6ec;
-  color: #e6a23c;
-}
-
-.approval-mobile-list__status--success {
-  background: #f0f9eb;
-  color: #67c23a;
-}
-
-.approval-mobile-list__status--danger {
-  background: #fef0f0;
-  color: #f56c6c;
 }
 
 .approval-mobile-list__meta {

--- a/apps/web/src/views/approval/DelegationSettingsView.vue
+++ b/apps/web/src/views/approval/DelegationSettingsView.vue
@@ -30,9 +30,7 @@
       </el-table-column>
       <el-table-column label="状态" width="150">
         <template #default="{ row }">
-          <el-tag :type="DELEGATION_STATUS_TAG_TYPE[delegationDisplayStatus(row).status]" size="small">
-            {{ delegationDisplayStatus(row).status }}
-          </el-tag>
+          <StatusTag domain="delegation" :status="delegationDisplayStatus(row).status" />
           <span v-if="delegationDisplayStatus(row).expiringSoon" class="expiring-soon-hint">即将到期</span>
         </template>
       </el-table-column>
@@ -95,7 +93,8 @@ import {
   type DelegationRecord,
   type DelegationForm,
 } from '../../approvals/delegations'
-import { delegationDisplayStatus, DELEGATION_STATUS_TAG_TYPE } from '../../approvals/delegationStatus'
+import { delegationDisplayStatus } from '../../approvals/delegationStatus'
+import StatusTag from '../../components/status/StatusTag.vue'
 
 const { canManageTemplates: canManage } = useApprovalPermissions()
 const delegations = ref<DelegationRecord[]>([])

--- a/apps/web/src/views/approval/MyDelegationView.vue
+++ b/apps/web/src/views/approval/MyDelegationView.vue
@@ -19,9 +19,7 @@
       </el-table-column>
       <el-table-column label="状态" width="150">
         <template #default="{ row }">
-          <el-tag :type="DELEGATION_STATUS_TAG_TYPE[delegationDisplayStatus(row).status]" size="small">
-            {{ delegationDisplayStatus(row).status }}
-          </el-tag>
+          <StatusTag domain="delegation" :status="delegationDisplayStatus(row).status" />
           <span v-if="delegationDisplayStatus(row).expiringSoon" class="expiring-soon-hint">即将到期</span>
         </template>
       </el-table-column>
@@ -83,8 +81,9 @@ import {
   type DelegationRecord,
   type OwnDelegationForm,
 } from '../../approvals/delegations'
-import { delegationDisplayStatus, DELEGATION_STATUS_TAG_TYPE } from '../../approvals/delegationStatus'
+import { delegationDisplayStatus } from '../../approvals/delegationStatus'
 import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
+import StatusTag from '../../components/status/StatusTag.vue'
 
 const delegations = ref<DelegationRecord[]>([])
 const loading = ref(false)

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -8,6 +8,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import {
   mockPendingApproval,
   mockApprovedApproval,
@@ -518,6 +519,12 @@ describe('Approval E2E Lifecycle', () => {
   let container: HTMLDivElement | null = null
 
   beforeEach(() => {
+    // UF-3: the header status tag is now locale-aware (<StatusTag domain="approvalInstance">,
+    // via useLocale()/isZh) rather than the previous hardcoded-Chinese-always literal map. This
+    // whole spec's fixtures/assertions are Chinese, so pin the locale explicitly rather than
+    // relying on jsdom's default `navigator.language`.
+    useLocale().setLocale('zh-CN')
+
     // Reset all reactive state
     mockActiveApproval.value = null
     mockHistory.value = []
@@ -822,7 +829,9 @@ describe('Approval E2E Lifecycle', () => {
       const h1 = container!.querySelector('.approval-detail__header h1')
       expect(h1?.textContent).toBe('出差报销申请')
 
-      const tag = container!.querySelector('.approval-detail__header [data-el-tag]')
+      // UF-3: the header status tag is now <StatusTag> (framework-free by design, not `<el-tag>`)
+      // — select it by its `data-status` attribute instead of the ElTag test stub's `data-el-tag`.
+      const tag = container!.querySelector('.approval-detail__header [data-status]')
       expect(tag?.textContent).toContain('待处理')
     })
 

--- a/apps/web/tests/approvalDelegationView.spec.ts
+++ b/apps/web/tests/approvalDelegationView.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, inject, nextTick, provide, reactive, type App as VueApp, type Slot } from 'vue'
 import type { DelegationRecord } from '../src/approvals/delegations'
+import { useLocale } from '../src/composables/useLocale'
 
 // B2-05 — DelegationSettingsView (admin 委托设置) MOUNTED-component coverage. Neither
 // approvalDelegationForm.spec.ts nor approvalDelegationRoute.spec.ts (the only pre-existing specs
@@ -181,6 +182,12 @@ describe('DelegationSettingsView (admin 委托设置) — B2-05 status tag + dis
   let container: HTMLDivElement | null = null
 
   beforeEach(() => {
+    // UF-3: the status cell is now locale-aware (<StatusTag domain="delegation">, via
+    // useLocale()/isZh) rather than the previous hardcoded-Chinese-always
+    // `delegationDisplayStatus().status` literal. This suite's fixtures/assertions are Chinese,
+    // so pin the locale explicitly rather than relying on jsdom's default `navigator.language`.
+    useLocale().setLocale('zh-CN')
+
     canManageTemplates.value = true
     listDelegationsSpy.mockReset()
     disableDelegationSpy.mockReset().mockResolvedValue(undefined)
@@ -243,7 +250,9 @@ describe('DelegationSettingsView (admin 委托设置) — B2-05 status tag + dis
     for (const [index, label, tagType] of expectations) {
       const cell = statusCell(index)
       expect(cell.textContent, `row ${index} label`).toContain(label)
-      expect(cell.querySelector('[data-el-tag-type]')?.getAttribute('data-el-tag-type'), `row ${index} tag type`).toBe(tagType)
+      // UF-3: the status cell now renders <StatusTag domain="delegation"> (not `<el-tag>`) —
+      // select its tone by `data-tone` instead of the ElTag test stub's `data-el-tag-type`.
+      expect(cell.querySelector('[data-tone]')?.getAttribute('data-tone'), `row ${index} tag type`).toBe(tagType)
     }
   })
 

--- a/apps/web/tests/myDelegationView.spec.ts
+++ b/apps/web/tests/myDelegationView.spec.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, inject, nextTick, provide, reactive, type App as VueApp, type Slot } from 'vue'
 import type { DelegationRecord } from '../src/approvals/delegations'
+import { useLocale } from '../src/composables/useLocale'
 
 // B2-05 — MyDelegationView (self-service 我的委托) MOUNTED-component coverage. Neither
 // myDelegationForm.spec.ts nor myDelegationRoute.spec.ts (the only pre-existing specs naming this
@@ -160,6 +161,12 @@ describe('MyDelegationView (self-service 我的委托) — B2-05 status tag + di
   let container: HTMLDivElement | null = null
 
   beforeEach(() => {
+    // UF-3: the status cell is now locale-aware (<StatusTag domain="delegation">, via
+    // useLocale()/isZh) rather than the previous hardcoded-Chinese-always
+    // `delegationDisplayStatus().status` literal. This suite's fixtures/assertions are Chinese,
+    // so pin the locale explicitly rather than relying on jsdom's default `navigator.language`.
+    useLocale().setLocale('zh-CN')
+
     listOwnDelegationsSpy.mockReset()
     disableOwnDelegationSpy.mockReset().mockResolvedValue(undefined)
     createOwnDelegationSpy.mockReset()
@@ -219,7 +226,9 @@ describe('MyDelegationView (self-service 我的委托) — B2-05 status tag + di
     for (const [index, label, tagType] of expectations) {
       const cell = statusCell(index)
       expect(cell.textContent, `row ${index} label`).toContain(label)
-      expect(cell.querySelector('[data-el-tag-type]')?.getAttribute('data-el-tag-type'), `row ${index} tag type`).toBe(tagType)
+      // UF-3: the status cell now renders <StatusTag domain="delegation"> (not `<el-tag>`) —
+      // select its tone by `data-tone` instead of the ElTag test stub's `data-el-tag-type`.
+      expect(cell.querySelector('[data-tone]')?.getAttribute('data-tone'), `row ${index} tag type`).toBe(tagType)
     }
   })
 

--- a/apps/web/tests/parallelBranchRunsView.spec.ts
+++ b/apps/web/tests/parallelBranchRunsView.spec.ts
@@ -141,6 +141,9 @@ describe('A6-3-4/W3-2b parallel_branch runs readability', () => {
     expect(childRows[1]?.textContent ?? '').toContain('parallel branch tail')
     expect(childRows[1]?.textContent ?? '').toContain('#1')
     expect(c.textContent ?? '').toContain('skipped')
-    expect(c.querySelectorAll('.automation-runs__badge--skipped').length).toBeGreaterThanOrEqual(2)
+    // UF-3: step-status badges are now <StatusTag domain="automationRun"> (utils/statusDomains.ts),
+    // not a per-status `.automation-runs__badge--<status>` CSS class — select by the tag's own
+    // `data-status` attribute instead (still present: StatusTag always emits it).
+    expect(c.querySelectorAll('[data-status="skipped"]').length).toBeGreaterThanOrEqual(2)
   })
 })

--- a/apps/web/tests/statusTag.spec.ts
+++ b/apps/web/tests/statusTag.spec.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import StatusTag from '../src/components/status/StatusTag.vue'
+import { resolveStatusDisplay } from '../src/utils/statusDomains'
+import { useLocale } from '../src/composables/useLocale'
+
+// UF-3 — StatusTag + status-domain map convergence (docs/development/
+// ui-foundation-design-lock-20260706.md §3.4, §6). Locks: tone-per-domain mapping, the
+// unknown-status fail-safe (never throw / never blank), zh<->en label switching, and the "no
+// hardcoded hex" guard the design-lock's "颜色只从 tokens.css 取" principle requires of any new
+// status-color renderer.
+
+describe('resolveStatusDisplay (pure)', () => {
+  it('maps approvalInstance tones: approved -> success, rejected -> danger, pending -> warning', () => {
+    expect(resolveStatusDisplay('approvalInstance', 'approved', true)).toEqual({ tone: 'success', label: '已通过' })
+    expect(resolveStatusDisplay('approvalInstance', 'rejected', true)).toEqual({ tone: 'danger', label: '已驳回' })
+    expect(resolveStatusDisplay('approvalInstance', 'pending', true)).toEqual({ tone: 'warning', label: '待处理' })
+    expect(resolveStatusDisplay('approvalInstance', 'revoked', true)).toEqual({ tone: 'info', label: '已撤回' })
+    expect(resolveStatusDisplay('approvalInstance', 'cancelled', true)).toEqual({ tone: 'info', label: '已取消' })
+  })
+
+  it('maps delegation tones exactly per the existing DELEGATION_STATUS_TAG_TYPE semantics', () => {
+    expect(resolveStatusDisplay('delegation', '未开始', true)).toEqual({ tone: 'info', label: '未开始' })
+    expect(resolveStatusDisplay('delegation', '生效中', true)).toEqual({ tone: 'success', label: '生效中' })
+    expect(resolveStatusDisplay('delegation', '已过期', true)).toEqual({ tone: 'warning', label: '已过期' })
+    expect(resolveStatusDisplay('delegation', '已停用', true)).toEqual({ tone: 'danger', label: '已停用' })
+  })
+
+  it('maps automationRun tones: resolved -> success, failed/errored/rejected -> danger, skipped -> neutral, in-flight -> primary', () => {
+    expect(resolveStatusDisplay('automationRun', 'resolved', false)).toEqual({ tone: 'success', label: 'resolved' })
+    expect(resolveStatusDisplay('automationRun', 'failed', false)).toEqual({ tone: 'danger', label: 'failed' })
+    expect(resolveStatusDisplay('automationRun', 'errored', false)).toEqual({ tone: 'danger', label: 'errored' })
+    expect(resolveStatusDisplay('automationRun', 'rejected', false)).toEqual({ tone: 'danger', label: 'rejected' })
+    expect(resolveStatusDisplay('automationRun', 'skipped', false)).toEqual({ tone: 'neutral', label: 'skipped' })
+    expect(resolveStatusDisplay('automationRun', 'running', false)).toEqual({ tone: 'primary', label: 'running' })
+    expect(resolveStatusDisplay('automationRun', 'queued', false)).toEqual({ tone: 'primary', label: 'queued' })
+    expect(resolveStatusDisplay('automationRun', 'suspended', false)).toEqual({ tone: 'primary', label: 'suspended' })
+  })
+
+  it('zh/en switch flips the label without changing the tone', () => {
+    const zh = resolveStatusDisplay('approvalInstance', 'approved', true)
+    const en = resolveStatusDisplay('approvalInstance', 'approved', false)
+    expect(zh.tone).toBe(en.tone)
+    expect(zh.label).toBe('已通过')
+    expect(en.label).toBe('Approved')
+  })
+
+  it('fail-safe: an unknown status per domain renders tone "neutral" and the raw status as label (never throws, never blank)', () => {
+    expect(resolveStatusDisplay('approvalInstance', 'draft', true)).toEqual({ tone: 'neutral', label: 'draft' })
+    expect(resolveStatusDisplay('approvalInstance', 'totally-unknown-status', false)).toEqual({ tone: 'neutral', label: 'totally-unknown-status' })
+    expect(resolveStatusDisplay('delegation', 'not-a-real-delegation-status', true)).toEqual({ tone: 'neutral', label: 'not-a-real-delegation-status' })
+    expect(resolveStatusDisplay('automationRun', 'not-a-real-automation-status', false)).toEqual({ tone: 'neutral', label: 'not-a-real-automation-status' })
+    expect(() => resolveStatusDisplay('approvalInstance', '', true)).not.toThrow()
+  })
+})
+
+describe('StatusTag.vue (mounted)', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    useLocale().setLocale('zh-CN')
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+  })
+
+  function mount(domain: string, status: string, size?: 'sm' | 'md') {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({ render: () => h(StatusTag, { domain, status, size }) })
+    app.mount(container)
+    return container
+  }
+
+  it('renders the resolved label and data-domain/data-status/data-tone attributes', async () => {
+    const c = mount('approvalInstance', 'approved')
+    await nextTick()
+    const el = c.querySelector('.ms-status-tag') as HTMLElement
+    expect(el).not.toBeNull()
+    expect(el.textContent).toBe('已通过')
+    expect(el.getAttribute('data-domain')).toBe('approvalInstance')
+    expect(el.getAttribute('data-status')).toBe('approved')
+    expect(el.getAttribute('data-tone')).toBe('success')
+  })
+
+  it('unknown status renders the raw status text with tone "neutral", never blank', async () => {
+    const c = mount('automationRun', 'some_future_status')
+    await nextTick()
+    const el = c.querySelector('.ms-status-tag') as HTMLElement
+    expect(el.textContent).toBe('some_future_status')
+    expect(el.getAttribute('data-tone')).toBe('neutral')
+  })
+
+  it('switches label text when the locale changes (zh <-> en), tone stays stable', async () => {
+    const { setLocale } = useLocale()
+    const c = mount('delegation', '生效中')
+    await nextTick()
+    const el = c.querySelector('.ms-status-tag') as HTMLElement
+    expect(el.textContent).toBe('生效中')
+    expect(el.getAttribute('data-tone')).toBe('success')
+
+    setLocale('en')
+    await nextTick()
+    expect(el.textContent).toBe('Active')
+    expect(el.getAttribute('data-tone')).toBe('success')
+
+    setLocale('zh-CN')
+    await nextTick()
+    expect(el.textContent).toBe('生效中')
+  })
+
+  it('guard: the rendered inline style references only CSS custom properties, never a hardcoded hex', async () => {
+    // jsdom's CSSStyleDeclaration NORMALIZES any literal color it's given (hex, `rgb()`, named
+    // color) to `rgb(r, g, b)` on assignment — a `background: '#f5f6f8'` mutation would NOT
+    // survive as `#f5f6f8` in `el.getAttribute('style')`, it would read back as `rgb(245, 246,
+    // 248)`. So the real "did someone hardcode a color" signal in a jsdom-rendered style
+    // attribute is the presence of an `rgb(`/`rgba(` function — a `var(--...)` reference is
+    // never resolved by jsdom and passes through as literal text. Assert against BOTH forms
+    // (verified by mutation: swapping the neutral-tone background to a hex literal made this
+    // assertion fail via the `rgb(` branch, not the `#` branch).
+    const cases: Array<[string, string]> = [
+      ['approvalInstance', 'approved'],
+      ['approvalInstance', 'rejected'],
+      ['approvalInstance', 'pending'],
+      ['approvalInstance', 'revoked'],
+      ['delegation', '未开始'],
+      ['delegation', '生效中'],
+      ['delegation', '已过期'],
+      ['delegation', '已停用'],
+      ['automationRun', 'resolved'],
+      ['automationRun', 'failed'],
+      ['automationRun', 'skipped'],
+      ['automationRun', 'running'],
+      ['automationRun', 'unknown-guard-case'],
+    ]
+    for (const [domain, status] of cases) {
+      const c = mount(domain, status)
+      await nextTick()
+      const el = c.querySelector('.ms-status-tag') as HTMLElement
+      const styleAttr = el.getAttribute('style') ?? ''
+      expect(styleAttr, `${domain}/${status} style: ${styleAttr}`).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
+      expect(styleAttr, `${domain}/${status} style: ${styleAttr}`).not.toMatch(/rgba?\(/)
+      expect(styleAttr, `${domain}/${status} style: ${styleAttr}`).toMatch(/var\(--/)
+      app?.unmount()
+      container?.remove()
+      app = null
+      container = null
+    }
+  })
+})


### PR DESCRIPTION
Implements **UF-3** of the UI foundation design-lock (UF-1 #3697 + UF-2 #3706 merged; rebased over UF-2's header restructuring with conflicts resolved by the main loop).

## What
- **`utils/statusDomains.ts`**: the ONE place status presentation lives — domain tables (`approvalInstance` / `delegation` / `automationRun`) mapping status → tone + zh/en label. Governance: converges presentation ONLY — delegation status derivation stays in `delegationStatus.ts`, automation copy read from the existing `automationStatusLabel` table (cannot drift). Fail-safe: unknown status → neutral tone + raw text, never throws/blank.
- **`components/status/StatusTag.vue`**: framework-free chip (no EP dependency — drops into both EP tables and hand-rolled views), colors ONLY from CSS vars (`--el-color-<tone>-light-9` bg / `--el-color-<tone>` text), `data-domain/status/tone` attributes for testability.
- **Six sites converged** (local maps + chip-hex CSS deleted): ApprovalCenterView (4 tabs) · ApprovalMobileList · ApprovalDetailView header (timeline meta-badges = event-kinds, deliberately untouched) · ApprovalInboxView (**previously raw uncolored enum text**) · MyDelegationView + DelegationSettingsView (**fixed a real defect: status rendered Chinese-only regardless of locale — now locale-aware**) · AutomationExecutionsView (run + step badges, its 4th palette deleted).

## Verification
- `vue-tsc -b` 0 · production build green
- Post-rebase union guard-spec run: **413/413** (both approval-web-guard + wired additions)
- New `statusTag.spec.ts` 9 tests: per-domain tone mapping, unknown-status fail-safe, zh/en switch, **no-hardcoded-color guard hardened against jsdom's hex→rgb() normalization** (mutation-verified: planting a literal hex turns it red)
- Spec adaptations (shape-only, listed in commit body): `[data-el-tag]`→`[data-status]` etc., + locale pins in 3 specs whose fixtures relied on the old always-Chinese rendering
- CI wiring: statusTag/inbox/delegation specs added to approval-web-guard + multitable-web-guard (several files had NO gate before)
- Presentation-only; status semantics unchanged

Known follow-up (flagged, not in this slice): a 4th `template` status domain exists (ApprovalNewView/TemplateDetailView ternaries) — UF-3b micro-slice candidate.

Implemented by a Sonnet agent per model-split policy; reviewed + conflict-rebased by the main loop. Queued behind #3707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)