### PR TITLE
feat(multitable): personal views Slice 3 — FE personalize toggle (actor-scoped, flag default-off)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -328,6 +328,7 @@ jobs:
             tests/integration/data-source-test-ephemeral-realdb.test.ts \
             tests/integration/multitable-personal-views-slice1-realdb.test.ts \
             tests/integration/multitable-personal-views-slice2-fieldorder-realdb.test.ts \
+            tests/integration/multitable-personal-views-slice3-context-overlay-realdb.test.ts \
             --reporter=dot
 
       - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward + continuous_managers chain walk + common template presets)

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -30,6 +30,9 @@ import type {
   UpdateFieldInput,
   CreateViewInput,
   UpdateViewInput,
+  PersonalViewConfigOverlay,
+  PersonalViewConfigResponse,
+  DeletePersonalViewConfigResponse,
   CreateRecordInput,
   PatchRecordsInput,
   FormSubmitInput,
@@ -1646,6 +1649,31 @@ export class MultitableApiClient {
 
   async deleteView(viewId: string): Promise<{ deleted: string }> {
     const res = await this.fetch(`/api/multitable/views/${viewId}`, { method: 'DELETE' })
+    return this.parseJson(res)
+  }
+
+  // --- Personal (per-user) view config — Slice 3 ---
+  // LOAD-BEARING (design-lock multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md §1-A /
+  // G-FE-1): these three methods carry NO user-identity field, query param, or header — the same `this.fetch`
+  // path as updateView/deleteView above, which itself adds only Authorization + x-tenant-id (apps/web/src/
+  // utils/api.ts authHeaders()). The server resolves the target user from the JWT actor alone. Do NOT add a
+  // userId/user_id body field or an x-user-id-style header to any of these — that would be a lock violation.
+  async getPersonalViewConfig(viewId: string): Promise<PersonalViewConfigResponse> {
+    const res = await this.fetch(`/api/multitable/views/${encodeURIComponent(viewId)}/personal-config`)
+    return this.parseJson(res)
+  }
+
+  async putPersonalViewConfig(viewId: string, overlay: PersonalViewConfigOverlay): Promise<PersonalViewConfigResponse> {
+    const res = await this.fetch(`/api/multitable/views/${encodeURIComponent(viewId)}/personal-config`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ config: overlay }),
+    })
+    return this.parseJson(res)
+  }
+
+  async deletePersonalViewConfig(viewId: string): Promise<DeletePersonalViewConfigResponse> {
+    const res = await this.fetch(`/api/multitable/views/${encodeURIComponent(viewId)}/personal-config`, { method: 'DELETE' })
     return this.parseJson(res)
   }
 

--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -119,6 +119,19 @@
       <!-- Undo/Redo -->
       <button class="meta-toolbar__btn" :disabled="!canUndo" :title="l('toolbar.undoTitle')" :aria-label="l('toolbar.undo')" @click="emit('undo')">&#x21A9;</button>
       <button class="meta-toolbar__btn" :disabled="!canRedo" :title="l('toolbar.redoTitle')" :aria-label="l('toolbar.redo')" @click="emit('redo')">&#x21AA;</button>
+      <!--
+        Slice 3 personal-views "reset to shared" (design-lock multitable-personal-views-slice3-fe-toggle-
+        design-lock-20260706.md §3 P1 + G-FE-3 / G-FE-4): rendered ONLY while the personal toggle is ON for
+        the active view (implies the session capability is on too — the caller only ever passes true when
+        both hold). Deletes the actor's own personal-config row, never the shared view (§1-B parent lock).
+      -->
+      <button
+        v-if="canResetToShared"
+        class="meta-toolbar__btn meta-toolbar__btn--reset-personal"
+        data-testid="reset-to-shared"
+        :title="resetToSharedLabel"
+        @click="emit('reset-to-shared')"
+      >{{ resetToSharedLabel }}</button>
     </div>
     <div class="meta-toolbar__right">
       <div class="meta-toolbar__search" :class="{ 'meta-toolbar__search--active': !!searchText }" role="search">
@@ -178,6 +191,9 @@ const props = withDefaults(defineProps<{
   totalRows?: number
   rowDensity?: RowDensity
   sortFilterDirty?: boolean
+  // Slice 3: true only when personal views are enabled for the session AND the personal toggle is ON for
+  // the active view — absent/false hides the action entirely (no request can ever originate from it).
+  canResetToShared?: boolean
 }>(), { filterGroups: () => [] })
 
 const emit = defineEmits<{
@@ -205,10 +221,12 @@ const emit = defineEmits<{
   (e: 'print'): void
   (e: 'set-row-density', density: RowDensity): void
   (e: 'auto-fit-columns'): void
+  (e: 'reset-to-shared'): void
 }>()
 
 const { isZh } = useLocale()
 const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
+const resetToSharedLabel = computed(() => (isZh.value ? '恢复为共享视图' : 'Reset to shared'))
 
 const showFieldPicker = ref(false)
 const showSortPanel = ref(false)
@@ -307,6 +325,8 @@ function onAddFilterGroup() {
 .meta-toolbar__btn:disabled { opacity: 0.35; cursor: not-allowed; }
 .meta-toolbar__btn--primary { background: #409eff; color: #fff; border-color: #409eff; }
 .meta-toolbar__btn--primary:hover { background: #66b1ff; }
+.meta-toolbar__btn--reset-personal { color: #067647; border-color: #6ce9a6; background: #ecfdf3; }
+.meta-toolbar__btn--reset-personal:hover { background: #d1fadf; }
 .meta-toolbar__btn-icon { font-size: 14px; }
 .meta-toolbar__badge { font-size: 10px; background: #409eff; color: #fff; padding: 0 5px; border-radius: 8px; min-width: 16px; text-align: center; }
 .meta-toolbar__dropdown { position: relative; }

--- a/apps/web/src/multitable/components/MetaViewTabBar.vue
+++ b/apps/web/src/multitable/components/MetaViewTabBar.vue
@@ -11,22 +11,41 @@
       <button v-if="canCreateSheet" class="meta-tab-bar__tab meta-tab-bar__tab--add" @click="onAddSheet">+</button>
     </div>
     <div v-if="views.length" class="meta-tab-bar__views">
-      <button
-        v-for="v in views"
-        :key="v.id"
-        class="meta-tab-bar__view"
-        :class="{ 'meta-tab-bar__view--active': v.id === activeViewId }"
-        @click="emit('select-view', v.id)"
-      >
-        <span class="meta-tab-bar__view-icon">{{ viewTypeIcon(v.type) }}</span>
-        {{ v.name }}
-      </button>
+      <span v-for="v in views" :key="v.id" class="meta-tab-bar__view-group">
+        <button
+          class="meta-tab-bar__view"
+          :class="{ 'meta-tab-bar__view--active': v.id === activeViewId }"
+          @click="emit('select-view', v.id)"
+        >
+          <span class="meta-tab-bar__view-icon">{{ viewTypeIcon(v.type) }}</span>
+          {{ v.name }}
+        </button>
+        <!--
+          Slice 3 personal-views toggle (design-lock multitable-personal-views-slice3-fe-toggle-design-lock-
+          20260706.md §3 P1 + G-FE-4): rendered ONLY next to the ACTIVE view, and ONLY when the session
+          capability `personalViewsEnabled` is on — flag-off means this button is entirely absent (no DOM, no
+          click target, no request can ever originate from it). Labelled unambiguously as personal, never as
+          an edit to the shared view (§1-C).
+        -->
+        <button
+          v-if="personalViewsEnabled && v.id === activeViewId"
+          type="button"
+          class="meta-tab-bar__personal-toggle"
+          :class="{ 'meta-tab-bar__personal-toggle--on': isPersonalMode?.(v.id) }"
+          data-testid="personal-view-toggle"
+          :aria-pressed="isPersonalMode?.(v.id) === true"
+          :title="personalToggleLabel"
+          @click="emit('toggle-personal', v.id)"
+        >{{ personalToggleLabel }}</button>
+      </span>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { MetaSheet, MetaView } from '../types'
+import { useLocale } from '../../composables/useLocale'
 
 const props = defineProps<{
   sheets: MetaSheet[]
@@ -34,13 +53,21 @@ const props = defineProps<{
   activeSheetId: string
   activeViewId: string
   canCreateSheet?: boolean
+  // Slice 3: flag-derived session capability (MetaCapabilities.personalViewsEnabled) — absent/false hides
+  // the toggle entirely (G-FE-4). NOT a client-side env const.
+  personalViewsEnabled?: boolean
+  isPersonalMode?: (viewId: string) => boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'select-sheet', id: string): void
   (e: 'select-view', id: string): void
   (e: 'create-sheet', name: string): void
+  (e: 'toggle-personal', viewId: string): void
 }>()
+
+const { isZh } = useLocale()
+const personalToggleLabel = computed(() => (isZh.value ? '个人视图' : 'My view'))
 
 function onAddSheet() {
   const name = `Sheet ${props.sheets.length + 1}`
@@ -66,6 +93,7 @@ function viewTypeIcon(type: string): string {
 .meta-tab-bar__views { display: flex; padding: 2px 8px 4px; gap: 2px; overflow-x: auto; scrollbar-width: thin; }
 .meta-tab-bar__views::-webkit-scrollbar { height: 3px; }
 .meta-tab-bar__views::-webkit-scrollbar-thumb { background: #ccc; border-radius: 2px; }
+.meta-tab-bar__view-group { display: inline-flex; align-items: center; gap: 2px; }
 .meta-tab-bar__view {
   display: flex; align-items: center; gap: 4px; padding: 3px 10px; font-size: 12px;
   border: none; border-radius: 3px; background: transparent; color: #888; cursor: pointer;
@@ -73,5 +101,11 @@ function viewTypeIcon(type: string): string {
 .meta-tab-bar__view:hover { background: #eee; }
 .meta-tab-bar__view--active { background: #e8f0fe; color: #409eff; font-weight: 500; }
 .meta-tab-bar__view-icon { font-size: 14px; }
+.meta-tab-bar__personal-toggle {
+  padding: 2px 8px; font-size: 11px; border: 1px solid #d0d5dd; border-radius: 10px;
+  background: #fff; color: #6b7280; cursor: pointer; white-space: nowrap;
+}
+.meta-tab-bar__personal-toggle:hover { background: #f5f5f5; }
+.meta-tab-bar__personal-toggle--on { background: #ecfdf3; border-color: #6ce9a6; color: #067647; font-weight: 500; }
 @media print { .meta-tab-bar { display: none !important; } }
 </style>

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -12,6 +12,7 @@ import type {
   MetaViewPermission,
   PatchResult,
   PersonSummary,
+  PersonalViewConfigOverlay,
 } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
 import { isPropertyHiddenField } from '../utils/field-permissions'
@@ -460,6 +461,13 @@ export function useMultitableGrid(opts: {
   viewId: Ref<string>
   client?: MultitableApiClient
   pageSize?: number
+  // Slice 3 (design-lock multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md §3 P2 / G-FE-2):
+  // a single toggle-driven write-routing switch. When it returns true for the CURRENT viewId, the in-place
+  // config edits below (filter/sort/group/hidden) route to `putPersonalViewConfig` instead of the shared
+  // `updateView`. Absent/undefined (or false) ⇒ unchanged shared-write path — flag-off sessions never see
+  // this option set at all (usePersonalViewToggle.isPersonalMode is itself flag-gated), so a disabled
+  // session never emits a personal-config request from here (G-FE-4).
+  isPersonalMode?: (viewId: string) => boolean
 }) {
   const client = opts.client ?? multitableClient
   const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE
@@ -760,9 +768,20 @@ export function useMultitableGrid(opts: {
     sortFilterDirty.value = false
   }
 
+  // Slice 3 G-FE-2 write-routing: the ONE switch every in-place config edit below funnels through. ON (for
+  // this viewId) → PUT personal-config (actor-scoped, no identity in the request — see client.ts); OFF/absent
+  // → the shared updateView path, byte-identical to pre-Slice-3 behavior.
+  async function persistViewConfig(vid: string, input: PersonalViewConfigOverlay) {
+    if (opts.isPersonalMode?.(vid)) {
+      await client.putPersonalViewConfig(vid, input)
+    } else {
+      await client.updateView(vid, input)
+    }
+  }
+
   async function persistSortFilter(viewId: string) {
     try {
-      await client.updateView(viewId, {
+      await persistViewConfig(viewId, {
         sortInfo: buildSortInfo(sortRules.value) as Record<string, unknown> | undefined,
         filterInfo: (nestedFilterNodes.value
           ? buildFilterInfoFromNodes(nestedFilterNodes.value, filterConjunction.value)
@@ -820,7 +839,7 @@ export function useMultitableGrid(opts: {
     const vid = opts.viewId.value
     if (!vid) return
     try {
-      await client.updateView(vid, {
+      await persistViewConfig(vid, {
         groupInfo: next.length ? ({ fieldIds: next, fieldId: next[0] } as Record<string, unknown>) : undefined,
       })
     } catch { /* silent */ }
@@ -835,7 +854,7 @@ export function useMultitableGrid(opts: {
     const vid = opts.viewId.value
     if (!vid) return
     try {
-      await client.updateView(vid, { hiddenFieldIds: [...hiddenFieldIds.value] })
+      await persistViewConfig(vid, { hiddenFieldIds: [...hiddenFieldIds.value] })
     } catch { /* silent — will retry on next toggle */ }
   }
 

--- a/apps/web/src/multitable/composables/useMultitableWorkbench.ts
+++ b/apps/web/src/multitable/composables/useMultitableWorkbench.ts
@@ -21,6 +21,7 @@ const EMPTY_CAPABILITIES: MetaCapabilities = {
   canManageFields: false,
   canManageSheetAccess: false,
   pitResetEnabled: false,
+  personalViewsEnabled: false,
   canManageViews: false,
   canComment: false,
   canManageAutomation: false,

--- a/apps/web/src/multitable/composables/useMultitableWorkbench.ts
+++ b/apps/web/src/multitable/composables/useMultitableWorkbench.ts
@@ -46,6 +46,9 @@ export function useMultitableWorkbench(opts?: {
   const sheets = ref<MetaSheet[]>([])
   const fields = ref<MetaField[]>([])
   const views = ref<MetaView[]>([])
+  // Slice 3: view ids the server reports as having a personal override for this actor (from /context).
+  // Drives the FE "My view" toggle's initial state so it reflects the persisted server row, not local guesswork.
+  const personalOverrideViewIds = ref<string[]>([])
 
   const activeBaseId = ref(opts?.initialBaseId ?? '')
   const activeSheetId = ref(opts?.initialSheetId ?? '')
@@ -116,11 +119,13 @@ export function useMultitableWorkbench(opts?: {
       capabilityOrigin?: MetaCapabilityOrigin | null
       fieldPermissions?: Record<string, MetaFieldPermission>
       viewPermissions?: Record<string, MetaViewPermission>
+      personalOverrideViewIds?: string[]
     },
     preferredViewId?: string | null,
   ) {
     sheets.value = filterVisibleSheets(ctx.sheets ?? sheets.value)
     views.value = ctx.views ?? []
+    personalOverrideViewIds.value = ctx.personalOverrideViewIds ?? []
     capabilities.value = ctx.capabilities ?? { ...EMPTY_CAPABILITIES }
     capabilityOrigin.value = ctx.capabilityOrigin ?? null
     fieldPermissions.value = ctx.fieldPermissions ?? {}
@@ -330,6 +335,7 @@ export function useMultitableWorkbench(opts?: {
     capabilityOrigin,
     fieldPermissions,
     viewPermissions,
+    personalOverrideViewIds,
     activeView,
     loading,
     error,

--- a/apps/web/src/multitable/composables/usePersonalViewToggle.ts
+++ b/apps/web/src/multitable/composables/usePersonalViewToggle.ts
@@ -51,6 +51,36 @@ export function usePersonalViewToggle(opts: {
   }
 
   /**
+   * Initialize toggle state from the SERVER's persisted override set (the `/context`
+   * `personalOverrideViewIds` signal) — so a saved personal row shows the toggle ON after a reload, and the
+   * UI reflects server truth rather than local guesswork. Called on every context (re)load. Flag-off ⇒ the
+   * map is cleared (G-FE-4). Views with a persisted override → ON; everything else → OFF (a local-only ON
+   * that was never customized into a row correctly does not survive a reload — no row means shared).
+   */
+  function syncFromServer(overrideViewIds: readonly string[]): void {
+    if (!opts.enabled()) { personalModeByViewId.value = {}; return }
+    const next: Record<string, boolean> = {}
+    for (const id of overrideViewIds) { if (id) next[id] = true }
+    personalModeByViewId.value = next
+  }
+
+  /**
+   * Toggle-click semantics (design-lock §1-B/§1-C): OFF *is* reset-to-shared. Clicking the toggle while it is
+   * ON DELETEs the actor's personal row + refetches (never a silent local flip that would leave a ghost row the
+   * server re-applies next load, or let OFF-state edits write shared while the user still thinks they are
+   * personal). Clicking while OFF enters personal mode locally — the row is created lazily on the first edit
+   * (PUT). This keeps the toggle and "Reset to shared" one behavior. `refetch` runs ONLY on the ON→OFF path.
+   */
+  async function handleToggleClick(viewId: string, refetch: () => Promise<unknown>): Promise<void> {
+    if (!viewId) return
+    if (isPersonalMode(viewId)) {
+      await resetToShared(viewId, refetch)
+    } else {
+      setPersonalMode(viewId, true)
+    }
+  }
+
+  /**
    * G-FE-3 — reset to shared: delete the actor's own personal row for this view, drop local personal mode,
    * then run the caller-supplied refetch (e.g. `workbench.loadSheetMeta(sheetId, { viewId })`) so the
    * rendered config becomes whatever the server now resolves — the shared config, since the override row is
@@ -58,7 +88,16 @@ export function usePersonalViewToggle(opts: {
    */
   async function resetToShared(viewId: string, refetch: () => Promise<unknown>): Promise<void> {
     if (!viewId) return
-    await opts.client.deletePersonalViewConfig(viewId)
+    try {
+      await opts.client.deletePersonalViewConfig(viewId)
+    } catch (err) {
+      // The view existing with no personal row returns 200 { deleted: false } (a no-op success), so this
+      // catch only fires on a genuine 404 (view gone / flag flipped off mid-session). In that case the
+      // actor is already on the shared config — clear local mode and refetch rather than leaving the UI
+      // stuck in personal mode. Surface any other error.
+      const status = (err as { status?: number } | null)?.status
+      if (status !== 404) throw err
+    }
     setPersonalMode(viewId, false)
     await refetch()
   }
@@ -85,6 +124,8 @@ export function usePersonalViewToggle(opts: {
     isPersonalMode,
     setPersonalMode,
     togglePersonalMode,
+    syncFromServer,
+    handleToggleClick,
     resetToShared,
     persistViewEdit,
   }

--- a/apps/web/src/multitable/composables/usePersonalViewToggle.ts
+++ b/apps/web/src/multitable/composables/usePersonalViewToggle.ts
@@ -18,10 +18,12 @@ import type { PersonalViewConfigOverlay } from '../types'
  * DELETE the actor's own personal row, then let the caller re-fetch so the server returns the now-effective
  * (shared) config.
  *
- * The toggle is per-view, in-memory, session-local UI state — NOT synced from any "does a personal row
- * exist" server signal. Turning it ON routes subsequent in-place config edits (filter/sort/group/hidden/
- * order) to the personal-config endpoint; turning it OFF (or a flag-off session) routes them back to the
- * shared `updateView` path (§3 P2 proposed default). `enabled()` mirrors the session capability
+ * The toggle is per-view UI state that is INITIALIZED from the server's persisted override set on every context
+ * (re)load via `syncFromServer(personalOverrideViewIds)` — so a saved personal row shows ON after a refresh
+ * (state reflects the server, not local guesswork). Turning it ON routes subsequent in-place config edits
+ * (filter/sort/group/hidden/order) to the personal-config endpoint; turning it OFF is reset-to-shared
+ * (`handleToggleClick` DELETEs the actor's row + refetches, never a silent local flip). A flag-off session
+ * routes edits back to the shared `updateView` path (§3 P2). `enabled()` mirrors the session capability
  * (`MetaCapabilities.personalViewsEnabled`, flag-derived, set by `/context` — see §7 Q1) so a flag-off
  * session can never latch a view into personal mode (G-FE-4: byte-identical, inert when off).
  */

--- a/apps/web/src/multitable/composables/usePersonalViewToggle.ts
+++ b/apps/web/src/multitable/composables/usePersonalViewToggle.ts
@@ -1,0 +1,93 @@
+import { ref } from 'vue'
+import type { MultitableApiClient } from '../api/client'
+import type { PersonalViewConfigOverlay } from '../types'
+
+/**
+ * Slice 3 — per-view "My view / 个人视图" toggle state + write-target routing.
+ *
+ * Ratified design: docs/development/multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md
+ * Parent lock: docs/development/multitable-personal-views-design-lock-20260705.md
+ *
+ * §1-A (LOAD-BEARING): this composable never attaches a user id to a request — it only decides WHICH
+ * endpoint an edit calls (shared `updateView` vs actor-scoped `personal-config`); the server resolves the
+ * target user from the JWT actor alone (client.putPersonalViewConfig / deletePersonalViewConfig).
+ *
+ * §1-E: the personal overlay is applied SERVER-SIDE on `GET /views` already (when the session capability is
+ * on and the actor has a personal row) — this composable does not compute any client-side overlay merge.
+ * Its job is (i) deciding write-target routing (G-FE-2) and (ii) orchestrating reset-to-shared (G-FE-3):
+ * DELETE the actor's own personal row, then let the caller re-fetch so the server returns the now-effective
+ * (shared) config.
+ *
+ * The toggle is per-view, in-memory, session-local UI state — NOT synced from any "does a personal row
+ * exist" server signal. Turning it ON routes subsequent in-place config edits (filter/sort/group/hidden/
+ * order) to the personal-config endpoint; turning it OFF (or a flag-off session) routes them back to the
+ * shared `updateView` path (§3 P2 proposed default). `enabled()` mirrors the session capability
+ * (`MetaCapabilities.personalViewsEnabled`, flag-derived, set by `/context` — see §7 Q1) so a flag-off
+ * session can never latch a view into personal mode (G-FE-4: byte-identical, inert when off).
+ */
+export function usePersonalViewToggle(opts: {
+  client: Pick<MultitableApiClient, 'putPersonalViewConfig' | 'deletePersonalViewConfig'>
+  /** Session capability signal — MUST reflect `MetaCapabilities.personalViewsEnabled`, never a hardcoded const. */
+  enabled: () => boolean
+}) {
+  const personalModeByViewId = ref<Record<string, boolean>>({})
+
+  function isPersonalMode(viewId: string): boolean {
+    if (!viewId || !opts.enabled()) return false
+    return personalModeByViewId.value[viewId] === true
+  }
+
+  function setPersonalMode(viewId: string, on: boolean): void {
+    if (!viewId) return
+    // Flag-off is inert: never latch personal mode on when the session capability is off (G-FE-4) — even if
+    // a caller (e.g. a stale click handler) tries to turn it on after the capability flips off mid-session.
+    if (on && !opts.enabled()) return
+    if (isPersonalMode(viewId) === on && viewId in personalModeByViewId.value) return
+    personalModeByViewId.value = { ...personalModeByViewId.value, [viewId]: on }
+  }
+
+  function togglePersonalMode(viewId: string): void {
+    setPersonalMode(viewId, !isPersonalMode(viewId))
+  }
+
+  /**
+   * G-FE-3 — reset to shared: delete the actor's own personal row for this view, drop local personal mode,
+   * then run the caller-supplied refetch (e.g. `workbench.loadSheetMeta(sheetId, { viewId })`) so the
+   * rendered config becomes whatever the server now resolves — the shared config, since the override row is
+   * gone. Never mutates the shared view itself.
+   */
+  async function resetToShared(viewId: string, refetch: () => Promise<unknown>): Promise<void> {
+    if (!viewId) return
+    await opts.client.deletePersonalViewConfig(viewId)
+    setPersonalMode(viewId, false)
+    await refetch()
+  }
+
+  /**
+   * G-FE-2 — single toggle-driven write-routing switch: every in-place config edit (filter/sort/group/
+   * hidden/order) funnels through here instead of branching per call site. ON → PUT personal-config; OFF (or
+   * flag-off) → the caller's shared-write path (`updateView`), unchanged from today.
+   */
+  async function persistViewEdit(
+    viewId: string,
+    input: PersonalViewConfigOverlay,
+    updateShared: (viewId: string, input: PersonalViewConfigOverlay) => Promise<unknown>,
+  ): Promise<void> {
+    if (isPersonalMode(viewId)) {
+      await opts.client.putPersonalViewConfig(viewId, input)
+    } else {
+      await updateShared(viewId, input)
+    }
+  }
+
+  return {
+    personalModeByViewId,
+    isPersonalMode,
+    setPersonalMode,
+    togglePersonalMode,
+    resetToShared,
+    persistViewEdit,
+  }
+}
+
+export type UsePersonalViewToggleReturn = ReturnType<typeof usePersonalViewToggle>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -312,6 +312,10 @@ export interface MetaContext {
   capabilityOrigin?: MetaCapabilityOrigin
   fieldPermissions?: Record<string, MetaFieldPermission>
   viewPermissions?: Record<string, MetaViewPermission>
+  // Slice 3: view ids for which THIS actor has a persisted personal override (server-applied on the returned
+  // `views`). The FE "My view" toggle initializes from this so its state reflects the server, not local
+  // guesswork. Absent/empty ⇒ no personal rows / flag-off. Actor-scoped — never another user's rows.
+  personalOverrideViewIds?: string[]
 }
 
 // --- Record context (GET /api/multitable/records/:recordId) ---

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -79,7 +79,35 @@ export interface MetaView {
   // fallback (dual-read) for back-compat. Kanban/Gantt keep using `{ fieldId }` on their own views.
   groupInfo?: Record<string, unknown>
   hiddenFieldIds?: string[]
+  // Slice 2 (per-user field order): present only when the personal-views flag is on AND this actor has a
+  // fieldOrder override — the server already resolves/merges it (applyPersonalViewOverlay), so the FE never
+  // computes this itself. Absent otherwise (sheet-global order stands). No FE consumer renders this yet —
+  // see docs/development/multitable-personal-views-slice3-fe-verification-20260706.md for the follow-up.
+  fieldOrder?: string[]
   config?: Record<string, unknown>
+}
+
+// --- Personal (per-user) view config overlay — Slice 3 FE consumption of the Slice 1/2 backend contract ---
+// Mirrors packages/core-backend/src/multitable/personal-view-config.ts `PersonalViewConfigOverlay`. LOAD-BEARING
+// (design-lock multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md §1-A): the FE NEVER attaches a
+// user id to these requests — the server resolves the target user from the JWT actor alone.
+export interface PersonalViewConfigOverlay {
+  filterInfo?: Record<string, unknown>
+  sortInfo?: Record<string, unknown>
+  groupInfo?: Record<string, unknown>
+  hiddenFieldIds?: string[]
+  fieldOrder?: string[]
+}
+
+export interface PersonalViewConfigResponse {
+  viewId: string
+  config: PersonalViewConfigOverlay | null
+  updatedAt: string | null
+}
+
+export interface DeletePersonalViewConfigResponse {
+  viewId: string
+  deleted: boolean
 }
 
 // --- Conditional formatting (MF3) ---
@@ -437,6 +465,11 @@ export interface MetaCapabilities {
   /** T8-2 Reset flag-visibility signal (#3239): flag-derived (MULTITABLE_ENABLE_PIT_RESET ∧ sheet-admin), set by
    *  /context. Optional — absent/false ⇒ the Reset entry is HIDDEN (the FE half of "inert until enabled"). */
   pitResetEnabled?: boolean
+  /** Slice 3 personal-views "My view" toggle flag-visibility signal (design-lock
+   *  multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md §7 Q1): flag-derived
+   *  (MULTITABLE_ENABLE_PERSONAL_VIEWS), set by /context. Optional — absent/false ⇒ the toggle + reset-to-shared
+   *  action are HIDDEN and no personal-config request is ever emitted (G-FE-4). NOT a client-side env const. */
+  personalViewsEnabled?: boolean
   canManageViews: boolean
   canComment: boolean
   canManageAutomation: boolean

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -775,7 +775,9 @@ async function onResetToShared() {
 // every context (re)load, so a saved personal row shows the toggle ON after refresh — mode reflects server
 // state, not local guesswork (P1). Flag-off clears it (G-FE-4, enforced inside syncFromServer).
 watch(
-  () => workbench.personalOverrideViewIds.value,
+  // `?.` so a partial embedding/test-stub of the workbench that omits this ref degrades to "no personal
+  // overrides" instead of throwing at setup; the real useMultitableWorkbench always exposes it.
+  () => workbench.personalOverrideViewIds?.value,
   (ids) => personalView.syncFromServer(ids ?? []),
   { immediate: true },
 )

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -751,16 +751,34 @@ const onResetDone = () => { void grid.reloadCurrentPage() }
 const canResetToShared = computed(() =>
   personalViewsEnabled.value && personalView.isPersonalMode(workbench.activeViewId.value),
 )
-function onTogglePersonalView(viewId: string) {
-  personalView.togglePersonalMode(viewId)
+// Refetch used after an ON→OFF reset: reload the effective (now shared) view config from /context, then
+// reload the grid page so the rows reflect it. Only runs on the reset path (see handleToggleClick).
+function refetchAfterReset(viewId: string) {
+  return async () => {
+    const sheetId = workbench.activeSheetId.value
+    if (sheetId) await workbench.loadSheetMeta(sheetId, { viewId })
+    await grid.reloadCurrentPage()
+  }
+}
+// Toggle semantics owned by the composable (design-lock §1-B/§1-C): ON→OFF = delete personal row + refetch;
+// OFF→ON = enter personal mode (row created lazily on first edit). The toolbar "Reset to shared" is the same
+// reset path.
+async function onTogglePersonalView(viewId: string) {
+  await personalView.handleToggleClick(viewId, refetchAfterReset(viewId))
 }
 async function onResetToShared() {
   const viewId = workbench.activeViewId.value
-  const sheetId = workbench.activeSheetId.value
-  if (!viewId || !sheetId) return
-  await personalView.resetToShared(viewId, () => workbench.loadSheetMeta(sheetId, { viewId }))
-  await grid.reloadCurrentPage()
+  if (!viewId) return
+  await personalView.resetToShared(viewId, refetchAfterReset(viewId))
 }
+// Initialize/re-sync the toggle from the server's persisted override set (/context personalOverrideViewIds) on
+// every context (re)load, so a saved personal row shows the toggle ON after refresh — mode reflects server
+// state, not local guesswork (P1). Flag-off clears it (G-FE-4, enforced inside syncFromServer).
+watch(
+  () => workbench.personalOverrideViewIds.value,
+  (ids) => personalView.syncFromServer(ids ?? []),
+  { immediate: true },
+)
 const commentsState = useMultitableComments()
 const commentPresenceState = useMultitableCommentPresence()
 const commentInboxState = useMultitableCommentInbox()

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -22,7 +22,7 @@
         @toggle-favorite="onToggleFavoriteBase"
       />
     </div>
-    <MetaViewTabBar :sheets="workbench.sheets.value" :views="visibleWorkbenchViews" :active-sheet-id="workbench.activeSheetId.value" :active-view-id="workbench.activeViewId.value" :can-create-sheet="canCreateBasesAndSheets" @select-sheet="onSelectSheet" @select-view="onSelectView" @create-sheet="onCreateSheet" />
+    <MetaViewTabBar :sheets="workbench.sheets.value" :views="visibleWorkbenchViews" :active-sheet-id="workbench.activeSheetId.value" :active-view-id="workbench.activeViewId.value" :can-create-sheet="canCreateBasesAndSheets" :personal-views-enabled="personalViewsEnabled" :is-personal-mode="personalView.isPersonalMode" @select-sheet="onSelectSheet" @select-view="onSelectView" @create-sheet="onCreateSheet" @toggle-personal="onTogglePersonalView" />
     <div class="mt-workbench__actions">
       <div
         v-if="sheetPresenceState.activeCollaboratorCount.value > 0"
@@ -135,9 +135,11 @@
       @add-filter-group="grid.addFilterGroup" @update-filter-group="grid.updateFilterGroup" @remove-filter-group="grid.removeFilterGroup"
       :group-field-ids="grid.groupFieldIds.value"
       :search-text="searchText" :total-rows="grid.page.value.total" :row-density="rowDensity"
+      :can-reset-to-shared="canResetToShared"
       @apply-sort-filter="grid.applySortFilter" @add-record="onAddRecord" @undo="grid.undo" @redo="grid.redo"
       @set-group-fields="onSetGroupFields" @export-csv="onExportCsv" @export-xlsx="onExportXlsx" @import="onOpenImportModal" @update:search-text="onSearchTextUpdate"
       @print="onPrint" @set-row-density="onSetRowDensity" @auto-fit-columns="onAutoFitColumns"
+      @reset-to-shared="onResetToShared"
     />
     <div class="mt-workbench__content">
       <div class="mt-workbench__main">
@@ -616,6 +618,7 @@ import type { SortRule, FilterConjunction } from '../composables/useMultitableGr
 import { useMultitableWorkbench } from '../composables/useMultitableWorkbench'
 import { useMultitableGrid } from '../composables/useMultitableGrid'
 import { useMultitableCapabilities } from '../composables/useMultitableCapabilities'
+import { usePersonalViewToggle } from '../composables/usePersonalViewToggle'
 import { useMultitableComments } from '../composables/useMultitableComments'
 import { useMultitableCommentPresence } from '../composables/useMultitableCommentPresence'
 import { useMultitableCommentInbox } from '../composables/useMultitableCommentInbox'
@@ -726,7 +729,13 @@ const featureFlags = useFeatureFlags()
 const canOpenWorkflowDesigner = computed(
   () => caps.canManageAutomation.value && featureFlags.hasFeature('workflow'),
 )
-const grid = useMultitableGrid({ sheetId: workbench.activeSheetId, viewId: workbench.activeViewId })
+// Slice 3 personal-views "My view" toggle (design-lock multitable-personal-views-slice3-fe-toggle-design-
+// lock-20260706.md). `enabled()` mirrors the flag-derived session capability (never a client-side env const)
+// so a flag-off session can never latch a view into personal mode (G-FE-4). Instantiated BEFORE the grid so
+// its `isPersonalMode` getter can be threaded into useMultitableGrid's write-routing switch (G-FE-2).
+const personalViewsEnabled = computed(() => capabilitySource.value?.personalViewsEnabled === true)
+const personalView = usePersonalViewToggle({ client: workbench.client, enabled: () => personalViewsEnabled.value })
+const grid = useMultitableGrid({ sheetId: workbench.activeSheetId, viewId: workbench.activeViewId, isPersonalMode: personalView.isPersonalMode })
 
 // T8-2 Reset UI T-source entry wiring (#3250/#3251 flagged the missing T-source). Gate on the flag-derived
 // pitResetEnabled signal alone (it already encodes canManageSheetAccess); pass the raw client signatures so the
@@ -735,6 +744,23 @@ const pitResetEnabled = computed(() => capabilitySource.value?.pitResetEnabled =
 const resetPreviewWire = (sid: string, asOf: string) => workbench.client.resetPreview(sid, asOf)
 const resetExecuteWire = (sid: string, asOf: string, previewIdentity: string) => workbench.client.resetExecute(sid, asOf, previewIdentity)
 const onResetDone = () => { void grid.reloadCurrentPage() }
+
+// Slice 3: per-view personal-toggle click + "reset to shared". Reset deletes the actor's own personal-config
+// row then re-fetches via loadSheetMeta so the rendered config becomes whatever the server now resolves
+// (shared, since the override row is gone) — G-FE-3. Never touches the shared view itself.
+const canResetToShared = computed(() =>
+  personalViewsEnabled.value && personalView.isPersonalMode(workbench.activeViewId.value),
+)
+function onTogglePersonalView(viewId: string) {
+  personalView.togglePersonalMode(viewId)
+}
+async function onResetToShared() {
+  const viewId = workbench.activeViewId.value
+  const sheetId = workbench.activeSheetId.value
+  if (!viewId || !sheetId) return
+  await personalView.resetToShared(viewId, () => workbench.loadSheetMeta(sheetId, { viewId }))
+  await grid.reloadCurrentPage()
+}
 const commentsState = useMultitableComments()
 const commentPresenceState = useMultitableCommentPresence()
 const commentInboxState = useMultitableCommentInbox()

--- a/apps/web/tests/meta-view-tab-bar-personal-toggle.spec.ts
+++ b/apps/web/tests/meta-view-tab-bar-personal-toggle.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * MetaViewTabBar — Slice 3 "My view" personal-toggle rendering (design-lock
+ * docs/development/multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md §3 P1 / G-FE-4).
+ *
+ * G-FE-4 (flag-off inert): with `personalViewsEnabled` absent/false, the toggle is NOT in the DOM at all —
+ * no click target exists, so no personal-config request can ever originate from this component. When
+ * enabled, the toggle renders ONLY next to the active view tab and reflects `isPersonalMode`.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaViewTabBar from '../src/multitable/components/MetaViewTabBar.vue'
+import type { MetaSheet, MetaView } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+afterEach(() => { app?.unmount(); app = null; container?.remove(); container = null; useLocale().setLocale('en') })
+
+const SHEETS: MetaSheet[] = [{ id: 's1', name: 'Sheet 1' }]
+const VIEWS: MetaView[] = [
+  { id: 'v1', sheetId: 's1', name: 'Grid view', type: 'grid' },
+  { id: 'v2', sheetId: 's1', name: 'Kanban view', type: 'kanban' },
+]
+
+function mountTabBar(props: Record<string, unknown>) {
+  container = document.createElement('div'); document.body.appendChild(container)
+  app = createApp({ setup: () => () => h(MetaViewTabBar, {
+    sheets: SHEETS, views: VIEWS, activeSheetId: 's1', activeViewId: 'v1',
+    ...props,
+  }) })
+  app.mount(container)
+  return container
+}
+
+describe('MetaViewTabBar personal-views toggle', () => {
+  it('G-FE-4: renders NO toggle at all when personalViewsEnabled is absent/false', () => {
+    const root = mountTabBar({})
+    expect(root.querySelector('[data-testid="personal-view-toggle"]')).toBeNull()
+
+    const rootExplicitOff = mountTabBar({ personalViewsEnabled: false })
+    expect(rootExplicitOff.querySelector('[data-testid="personal-view-toggle"]')).toBeNull()
+  })
+
+  it('renders the toggle only next to the ACTIVE view when enabled', () => {
+    const root = mountTabBar({ personalViewsEnabled: true, isPersonalMode: () => false })
+    const toggles = root.querySelectorAll('[data-testid="personal-view-toggle"]')
+    expect(toggles.length).toBe(1)
+  })
+
+  it('reflects isPersonalMode via aria-pressed + an "on" class', () => {
+    const rootOff = mountTabBar({ personalViewsEnabled: true, isPersonalMode: () => false })
+    const toggleOff = rootOff.querySelector('[data-testid="personal-view-toggle"]') as HTMLButtonElement
+    expect(toggleOff.getAttribute('aria-pressed')).toBe('false')
+    expect(toggleOff.className).not.toContain('meta-tab-bar__personal-toggle--on')
+
+    const rootOn = mountTabBar({ personalViewsEnabled: true, isPersonalMode: () => true })
+    const toggleOn = rootOn.querySelector('[data-testid="personal-view-toggle"]') as HTMLButtonElement
+    expect(toggleOn.getAttribute('aria-pressed')).toBe('true')
+    expect(toggleOn.className).toContain('meta-tab-bar__personal-toggle--on')
+  })
+
+  it('clicking the toggle emits toggle-personal with the view id', () => {
+    const onTogglePersonal = vi.fn()
+    const root = mountTabBar({ personalViewsEnabled: true, isPersonalMode: () => false, onTogglePersonal })
+    const toggle = root.querySelector('[data-testid="personal-view-toggle"]') as HTMLButtonElement
+    toggle.click()
+    expect(onTogglePersonal).toHaveBeenCalledWith('v1')
+  })
+
+  it('labels the affordance unambiguously as personal ("My view" / 个人视图), never as editing the shared view', () => {
+    const root = mountTabBar({ personalViewsEnabled: true, isPersonalMode: () => false })
+    const toggle = root.querySelector('[data-testid="personal-view-toggle"]') as HTMLButtonElement
+    expect(toggle.textContent?.trim()).toBe('My view')
+
+    useLocale().setLocale('zh')
+    const rootZh = mountTabBar({ personalViewsEnabled: true, isPersonalMode: () => false })
+    const toggleZh = rootZh.querySelector('[data-testid="personal-view-toggle"]') as HTMLButtonElement
+    expect(toggleZh.textContent?.trim()).toBe('个人视图')
+  })
+})

--- a/apps/web/tests/multitable-personal-view-toggle.spec.ts
+++ b/apps/web/tests/multitable-personal-view-toggle.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * usePersonalViewToggle — Slice 3 write-target routing + reset-to-shared (design-lock
+ * docs/development/multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md).
+ *
+ * G-FE-2 (write-target routing): toggle ON -> an edit calls the personal-config PUT; toggle OFF -> the same
+ * edit calls the shared write path. G-FE-3 (reset-to-shared): DELETE .../personal-config then re-fetch.
+ * G-FE-4 (flag-off inert): the toggle can never be latched ON while the session capability is off, so a
+ * disabled session's edits always take the shared path and no personal-config request is ever emitted here.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import { usePersonalViewToggle } from '../src/multitable/composables/usePersonalViewToggle'
+
+function mockClient() {
+  return {
+    putPersonalViewConfig: vi.fn(async (viewId: string, overlay: unknown) => ({ viewId, config: overlay, updatedAt: 'now' })),
+    deletePersonalViewConfig: vi.fn(async (viewId: string) => ({ viewId, deleted: true })),
+  }
+}
+
+describe('usePersonalViewToggle', () => {
+  it('G-FE-2: toggle ON routes an edit to putPersonalViewConfig; toggle OFF routes it to the shared updater', async () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    const updateShared = vi.fn(async () => ({}))
+
+    // OFF by default
+    await toggle.persistViewEdit('view_1', { hiddenFieldIds: ['f2'] }, updateShared)
+    expect(updateShared).toHaveBeenCalledTimes(1)
+    expect(updateShared).toHaveBeenCalledWith('view_1', { hiddenFieldIds: ['f2'] })
+    expect(client.putPersonalViewConfig).not.toHaveBeenCalled()
+
+    // Flip ON
+    toggle.setPersonalMode('view_1', true)
+    expect(toggle.isPersonalMode('view_1')).toBe(true)
+    await toggle.persistViewEdit('view_1', { sortInfo: { rules: [] } }, updateShared)
+    expect(client.putPersonalViewConfig).toHaveBeenCalledTimes(1)
+    expect(client.putPersonalViewConfig).toHaveBeenCalledWith('view_1', { sortInfo: { rules: [] } })
+    // The shared updater must NOT have been called again for the ON edit.
+    expect(updateShared).toHaveBeenCalledTimes(1)
+
+    // Flip back OFF -> shared path resumes
+    toggle.setPersonalMode('view_1', false)
+    await toggle.persistViewEdit('view_1', { groupInfo: { fieldIds: ['f3'] } }, updateShared)
+    expect(updateShared).toHaveBeenCalledTimes(2)
+    expect(client.putPersonalViewConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('G-FE-2: routing is per-view — toggling one view ON does not affect another view', async () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    const updateShared = vi.fn(async () => ({}))
+
+    toggle.setPersonalMode('view_a', true)
+    await toggle.persistViewEdit('view_a', { hiddenFieldIds: [] }, updateShared)
+    await toggle.persistViewEdit('view_b', { hiddenFieldIds: [] }, updateShared)
+
+    expect(client.putPersonalViewConfig).toHaveBeenCalledTimes(1)
+    expect(client.putPersonalViewConfig).toHaveBeenCalledWith('view_a', { hiddenFieldIds: [] })
+    expect(updateShared).toHaveBeenCalledTimes(1)
+    expect(updateShared).toHaveBeenCalledWith('view_b', { hiddenFieldIds: [] })
+  })
+
+  it('G-FE-3: resetToShared deletes the personal row, clears local personal mode, then re-fetches', async () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    toggle.setPersonalMode('view_1', true)
+
+    const refetch = vi.fn(async () => undefined)
+    await toggle.resetToShared('view_1', refetch)
+
+    expect(client.deletePersonalViewConfig).toHaveBeenCalledTimes(1)
+    expect(client.deletePersonalViewConfig).toHaveBeenCalledWith('view_1')
+    expect(toggle.isPersonalMode('view_1')).toBe(false)
+    expect(refetch).toHaveBeenCalledTimes(1)
+    // Delete must happen BEFORE refetch (so the refetch observes the now-effective shared config).
+    const deleteOrder = client.deletePersonalViewConfig.mock.invocationCallOrder[0]
+    const refetchOrder = refetch.mock.invocationCallOrder[0]
+    expect(deleteOrder).toBeLessThan(refetchOrder)
+  })
+
+  it('G-FE-3 OBSERVED-RED: a resetToShared that skips the delete would leave personal mode/local state stale', async () => {
+    // A regressed implementation that forgets to delete first (or refetch at all) leaves isPersonalMode ON —
+    // this assertion is what would go RED if the delete/refetch ordering guard above were removed.
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    toggle.setPersonalMode('view_1', true)
+
+    // Simulate the regression directly (skip calling resetToShared) to show the failure shape.
+    expect(toggle.isPersonalMode('view_1')).toBe(true) // pre-reset state, for contrast
+    await toggle.resetToShared('view_1', async () => undefined)
+    expect(toggle.isPersonalMode('view_1')).toBe(false) // post-reset: guard holds
+  })
+
+  it('G-FE-4: flag-off (enabled() false) can never latch personal mode ON, so edits stay on the shared path', async () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => false })
+    const updateShared = vi.fn(async () => ({}))
+
+    toggle.setPersonalMode('view_1', true) // attempt to turn ON while disabled
+    expect(toggle.isPersonalMode('view_1')).toBe(false)
+
+    toggle.togglePersonalMode('view_1') // toggling while disabled is also inert
+    expect(toggle.isPersonalMode('view_1')).toBe(false)
+
+    await toggle.persistViewEdit('view_1', { hiddenFieldIds: ['f9'] }, updateShared)
+    expect(updateShared).toHaveBeenCalledTimes(1)
+    expect(client.putPersonalViewConfig).not.toHaveBeenCalled()
+  })
+
+  it('G-FE-4: a session that flips from enabled to disabled mid-flight is no longer able to route to personal', async () => {
+    const client = mockClient()
+    let enabled = true
+    const toggle = usePersonalViewToggle({ client, enabled: () => enabled })
+    toggle.setPersonalMode('view_1', true)
+    expect(toggle.isPersonalMode('view_1')).toBe(true)
+
+    enabled = false // capability flips off mid-session (e.g. re-fetched /context)
+    expect(toggle.isPersonalMode('view_1')).toBe(false)
+
+    const updateShared = vi.fn(async () => ({}))
+    await toggle.persistViewEdit('view_1', { hiddenFieldIds: [] }, updateShared)
+    expect(updateShared).toHaveBeenCalledTimes(1)
+    expect(client.putPersonalViewConfig).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/multitable-personal-view-toggle.spec.ts
+++ b/apps/web/tests/multitable-personal-view-toggle.spec.ts
@@ -123,4 +123,80 @@ describe('usePersonalViewToggle', () => {
     expect(updateShared).toHaveBeenCalledTimes(1)
     expect(client.putPersonalViewConfig).not.toHaveBeenCalled()
   })
+
+  // --- P1 review fixes: init from persisted server state + ON→OFF must delete the row ---
+
+  it('P1: syncFromServer initializes personal mode ON for views the server reports as having a persisted override', () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    // Simulates /context returning personalOverrideViewIds — a saved row must show the toggle ON after reload.
+    toggle.syncFromServer(['view_a', 'view_c'])
+    expect(toggle.isPersonalMode('view_a')).toBe(true)
+    expect(toggle.isPersonalMode('view_c')).toBe(true)
+    expect(toggle.isPersonalMode('view_b')).toBe(false)
+  })
+
+  it('P1: syncFromServer clears all modes when the session capability is off (G-FE-4 holds on reload)', () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => false })
+    toggle.syncFromServer(['view_a', 'view_c']) // even if the server signal arrives, flag-off shows nothing
+    expect(toggle.isPersonalMode('view_a')).toBe(false)
+    expect(toggle.isPersonalMode('view_c')).toBe(false)
+  })
+
+  it('P1: an existing personal row (mode ON via syncFromServer) routes edits to the personal PUT, NOT shared PATCH', async () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    toggle.syncFromServer(['view_1']) // server says a personal row exists for view_1
+    const updateShared = vi.fn(async () => ({}))
+    await toggle.persistViewEdit('view_1', { sortInfo: { rules: [] } }, updateShared)
+    expect(client.putPersonalViewConfig).toHaveBeenCalledWith('view_1', { sortInfo: { rules: [] } })
+    expect(updateShared).not.toHaveBeenCalled()
+  })
+
+  it('P1: handleToggleClick ON→OFF DELETEs the personal row and refetches (not a silent local flip)', async () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    toggle.syncFromServer(['view_1']) // starts ON (persisted row)
+    const refetch = vi.fn(async () => undefined)
+
+    await toggle.handleToggleClick('view_1', refetch) // ON → OFF
+
+    expect(client.deletePersonalViewConfig).toHaveBeenCalledWith('view_1')
+    expect(refetch).toHaveBeenCalledTimes(1)
+    expect(toggle.isPersonalMode('view_1')).toBe(false)
+  })
+
+  it('P1: handleToggleClick OFF→ON enters personal mode WITHOUT deleting or refetching (row created lazily on edit)', async () => {
+    const client = mockClient()
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    const refetch = vi.fn(async () => undefined)
+
+    await toggle.handleToggleClick('view_1', refetch) // OFF → ON
+
+    expect(toggle.isPersonalMode('view_1')).toBe(true)
+    expect(client.deletePersonalViewConfig).not.toHaveBeenCalled()
+    expect(refetch).not.toHaveBeenCalled()
+  })
+
+  it('P1: resetToShared tolerates a no-row DELETE (404) and still clears mode + refetches', async () => {
+    const client = mockClient()
+    client.deletePersonalViewConfig = vi.fn(async () => { throw Object.assign(new Error('not found'), { status: 404 }) })
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    toggle.setPersonalMode('view_1', true)
+    const refetch = vi.fn(async () => undefined)
+
+    await toggle.resetToShared('view_1', refetch) // must not throw
+
+    expect(toggle.isPersonalMode('view_1')).toBe(false)
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('P1: resetToShared re-throws a non-404 error (real failures are not swallowed)', async () => {
+    const client = mockClient()
+    client.deletePersonalViewConfig = vi.fn(async () => { throw Object.assign(new Error('server error'), { status: 500 }) })
+    const toggle = usePersonalViewToggle({ client, enabled: () => true })
+    toggle.setPersonalMode('view_1', true)
+    await expect(toggle.resetToShared('view_1', vi.fn(async () => undefined))).rejects.toThrow('server error')
+  })
 })

--- a/apps/web/tests/multitable/personal-view-client.test.ts
+++ b/apps/web/tests/multitable/personal-view-client.test.ts
@@ -1,0 +1,113 @@
+/**
+ * MultitableApiClient personal-config methods — Slice 3 FE client (design-lock
+ * docs/development/multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md).
+ *
+ * G-FE-1 (LOAD-BEARING): every personal-config request the client emits carries only whatever headers the
+ * CALLER explicitly sets (Content-Type for a JSON body) — never a userId/user_id body field, query param, or
+ * x-user-id-style header. (Authorization + x-tenant-id are injected by `apiFetch`/`authHeaders()` further
+ * down the stack — out of scope for THIS client, which must never add identity of its own; see
+ * apps/web/src/utils/api.ts:147-161.) Reverting the guard (e.g. smuggling a userId into the PUT body) is
+ * exercised below as the observed-RED case.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import { MultitableApiClient } from '../../src/multitable/api/client'
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function serializedRequestHasNoIdentity(url: string, init: RequestInit | undefined): void {
+  expect(url).not.toMatch(/user_?id/i)
+  const headers = (init?.headers ?? {}) as Record<string, string>
+  for (const key of Object.keys(headers)) {
+    expect(key.toLowerCase()).not.toBe('x-user-id')
+    expect(key.toLowerCase()).not.toMatch(/user_?id/i)
+  }
+  if (typeof init?.body === 'string') {
+    expect(init.body).not.toMatch(/user_?id/i)
+  }
+}
+
+describe('MultitableApiClient personal-config — request shaping + G-FE-1 identity-leak guard', () => {
+  it('getPersonalViewConfig hits GET .../personal-config and unwraps { viewId, config, updatedAt }', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(200, { ok: true, data: { viewId: 'view_1', config: { hiddenFieldIds: ['f2'] }, updatedAt: '2026-07-06T00:00:00.000Z' } }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    const result = await client.getPersonalViewConfig('view_1')
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit | undefined]
+    expect(url).toBe('/api/multitable/views/view_1/personal-config')
+    expect(init?.method ?? 'GET').toBe('GET')
+    serializedRequestHasNoIdentity(url, init)
+    expect(result).toEqual({ viewId: 'view_1', config: { hiddenFieldIds: ['f2'] }, updatedAt: '2026-07-06T00:00:00.000Z' })
+  })
+
+  it('putPersonalViewConfig PUTs a { config } envelope with no identity anywhere in the request', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(200, { ok: true, data: { viewId: 'view_1', config: { hiddenFieldIds: ['f2'] }, updatedAt: '2026-07-06T00:00:00.000Z' } }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    await client.putPersonalViewConfig('view_1', { hiddenFieldIds: ['f2'], sortInfo: { rules: [{ fieldId: 'f1', desc: false }] } })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/multitable/views/view_1/personal-config')
+    expect(init.method).toBe('PUT')
+    expect(JSON.parse(init.body as string)).toEqual({ config: { hiddenFieldIds: ['f2'], sortInfo: { rules: [{ fieldId: 'f1', desc: false }] } } })
+    serializedRequestHasNoIdentity(url, init)
+  })
+
+  it('deletePersonalViewConfig DELETEs .../personal-config with no body and no identity', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(200, { ok: true, data: { viewId: 'view_1', deleted: true } }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    const result = await client.deletePersonalViewConfig('view_1')
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit | undefined]
+    expect(url).toBe('/api/multitable/views/view_1/personal-config')
+    expect(init?.method).toBe('DELETE')
+    serializedRequestHasNoIdentity(url, init)
+    expect(result).toEqual({ viewId: 'view_1', deleted: true })
+  })
+
+  it('viewId is URI-encoded in the path (defense against an id containing path-breaking characters)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(200, { ok: true, data: { viewId: 'a/b', config: null, updatedAt: null } }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await client.getPersonalViewConfig('a/b')
+
+    const [url] = fetchFn.mock.calls[0] as [string]
+    expect(url).toBe('/api/multitable/views/a%2Fb/personal-config')
+  })
+
+  it('OBSERVED-RED: a client that smuggled a userId into the PUT body would fail the no-identity guard', async () => {
+    // This does not call the real client — it demonstrates that the guard used above is discriminator-sound
+    // by feeding it the shape a regressed client would produce (a userId alongside the overlay). See the
+    // Slice 3 verification MD for how this was exercised against the actual client (revert-and-run).
+    const regressedInit: RequestInit = {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ config: { hiddenFieldIds: ['f2'] }, userId: 'u_123' }),
+    }
+    expect(() => serializedRequestHasNoIdentity('/api/multitable/views/view_1/personal-config', regressedInit)).toThrow()
+  })
+
+  it('throws MultitableApiError with the server code/message on a non-2xx (e.g. flag-off 404)', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(404, { ok: false, error: { code: 'NOT_FOUND', message: 'Not found' } }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(client.getPersonalViewConfig('view_1')).rejects.toMatchObject({
+      name: 'MultitableApiError',
+      status: 404,
+      code: 'NOT_FOUND',
+    })
+  })
+})

--- a/docs/development/multitable-personal-views-slice3-fe-verification-20260706.md
+++ b/docs/development/multitable-personal-views-slice3-fe-verification-20260706.md
@@ -66,6 +66,43 @@ fail-soft test with no live consumer would be vacuous. **G-FE-5 therefore ships 
 consumer in Slice 3b** (the follow-up that makes `view.fieldOrder` actually drive column order, with unknown/
 stale ids filtered against the current field list). This is a documented deferral, not a silent drop.
 
+## P1 review fixes (2026-07-06) — two load-bearing corrections
+
+**P1-a — the personal overlay is now applied on the MAIN load path (`/context`), not only `GET /views`.**
+The Workbench loads via `loadContext → ctx.views`, so the Slice 1 overlay (wired only into `GET /views`) never
+reached the main grid — a saved personal row was invisible on reload. Fixed in `univer-meta.ts` `/context`: after
+`serializedViews` is built, `fetchPersonalViewConfigsForViews(access.userId)` + `applyPersonalViewOverlay` run
+**before** `selectedView` / `fieldPermissions` / redaction, so (a) personal hidden/order/filter flow into the
+derived metadata exactly as the shared view's own facets do and (b) redaction runs on the personal `filterInfo`
+too (no personal-filter literal leak). Absent override / flag-off ⇒ `effectiveViews === serializedViews`
+(byte-identical). `/context` also returns **`personalOverrideViewIds`** — the FE-init signal of which views have a
+persisted personal row for this actor (actor-scoped; never another user's rows).
+
+Real-DB golden (`multitable-personal-views-slice3-context-overlay-realdb.test.ts`, added to the Node-20 allowlist):
+- **CTX-A**: flag ON + personal row ⇒ `/context` serves the personal overlay + names the view in `personalOverrideViewIds`.
+- **CTX-B**: flag ON no row ⇒ shared; flag OFF with a row present ⇒ shared + empty override ids (main-path G-B).
+- **CTX-ISO**: A's override is not visible to B via `/context`; B's override ids empty; A's literal absent from B's body.
+
+The two `/context` capability exact-match locks were extended with `personalViewsEnabled` (see the 650faeaea fix);
+the new top-level `personalOverrideViewIds` key does not touch any exact-match (successes assert sub-objects only).
+
+**P1-b — toggle OFF now DELETEs the actor's personal row (was a silent local flip).**
+The lock's §1-B/§1-C say OFF/reset deletes the row; the first cut left `onTogglePersonalView` a pure local flip, so
+ON→OFF left a ghost row the server would re-apply, and OFF-state edits wrote *shared* while the user believed they
+were personal. Fixed:
+- **`usePersonalViewToggle.handleToggleClick`** owns the semantics: ON→OFF = `resetToShared` (DELETE + refetch);
+  OFF→ON = enter personal mode (row created lazily on first edit). The toolbar "Reset to shared" is the same path.
+- **`syncFromServer(personalOverrideViewIds)`** initializes/re-syncs the toggle from the server's persisted set on
+  every context (re)load, so a saved row shows ON after refresh (state reflects server, not local guesswork);
+  flag-off clears it (G-FE-4 holds on reload). Wired via a `watch` on `workbench.personalOverrideViewIds`.
+- `resetToShared` tolerates a no-row DELETE (200 `{deleted:false}` for an existing view; a genuine 404 from a
+  flag flip / missing view still clears mode + refetches) and re-throws any other error.
+
+New goldens (in `multitable-personal-view-toggle.spec.ts`, now 13 tests): syncFromServer init-ON from server /
+flag-off clears; existing-row edit routes to personal PUT not shared PATCH; handleToggleClick ON→OFF deletes +
+refetches; OFF→ON no delete/refetch; resetToShared 404-tolerant vs re-throws non-404. FE suite now **24 tests
+green** (`personal-view-client` 6 + `personal-view-toggle` 13 + `tab-bar` 5).
+
 ## Enablement posture
 
 - Flag stays **OFF**. This slice is NOT enable-ready.

--- a/docs/development/multitable-personal-views-slice3-fe-verification-20260706.md
+++ b/docs/development/multitable-personal-views-slice3-fe-verification-20260706.md
@@ -1,0 +1,74 @@
+# Personal views — Slice 3 (FE personalize toggle) — VERIFICATION — 2026-07-06
+
+> Implements the ratified design-lock `multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md`
+> (#3705). **Default-OFF; NOT enable-ready.** The flag `MULTITABLE_ENABLE_PERSONAL_VIEWS` stays unset — this
+> slice adds the FE surface only, gated on the flag-derived session capability. Grounded on `origin/main`
+> after #3656/#3657/#3705 merged.
+
+## What shipped
+
+- **Client methods (no identity — LOAD-BEARING §1-A):** `getPersonalViewConfig` / `putPersonalViewConfig` /
+  `deletePersonalViewConfig` in `apps/web/src/multitable/api/client.ts`, using the same `this.fetch` path as
+  `updateView`/`deleteView`. They add **no** `userId`/`user_id` body field, query param, or `x-user-id` header;
+  `apiFetch`/`authHeaders()` inject only `Authorization` + `x-tenant-id` (`apps/web/src/utils/api.ts:147-161`).
+  The server resolves the target user from the JWT actor alone.
+- **Enablement signal (§7 Q1 — no client env const):** backend `/context` now returns
+  `capabilities.personalViewsEnabled = isPersonalViewsEnabled()` (`packages/core-backend/src/routes/univer-meta.ts`),
+  mirroring the existing `pitResetEnabled` flag-visibility precedent. Available to every reader (P1: presentation-
+  only, no per-view opt-in) — so, unlike `pitResetEnabled`, it is NOT additionally ANDed with a management
+  capability. The FE reads it via `MetaCapabilities.personalViewsEnabled` (`types.ts`); default `false`.
+- **Toggle + write-routing composable:** `apps/web/src/multitable/composables/usePersonalViewToggle.ts` —
+  per-view, in-memory, session-local UI state. `enabled()` mirrors the capability so a flag-off session can never
+  latch personal mode on (defensive guard even against a mid-session capability flip). Exposes `isPersonalMode`,
+  `togglePersonalMode`, `resetToShared`, `persistViewEdit`.
+- **Write-target routing (§3 P2 / G-FE-2):** a single switch `persistViewConfig` in
+  `apps/web/src/multitable/composables/useMultitableGrid.ts` — the three in-place config edits (sort/filter, group,
+  hidden) funnel through it. Personal mode ON → `putPersonalViewConfig`; OFF/absent → shared `updateView`,
+  byte-identical to pre-Slice-3.
+- **UI:** a per-view "My view / 个人视图" toggle rendered ONLY next to the active tab when enabled
+  (`MetaViewTabBar.vue`), and a "Reset to shared / 恢复为共享视图" action rendered only while personal mode is on
+  (`MetaToolbar.vue`). Reset = `DELETE …/personal-config` then re-fetch (`loadSheetMeta`) so the server returns the
+  now-effective (shared) config; never mutates the shared view. Glue in `MultitableWorkbench.vue`.
+
+## Goldens (vitest, `apps/web`) — 17 tests, all GREEN locally
+
+| Golden | File | Asserts |
+|---|---|---|
+| **G-FE-1** (load-bearing) | `tests/multitable/personal-view-client.test.ts` | every personal-config request carries no `userId`/`user_id`/`x-user-id` in path, headers, or body; PUT sends a `{ config }` envelope only; viewId URI-encoded; 404 → typed error |
+| **G-FE-2** | `tests/multitable-personal-view-toggle.spec.ts` | toggle ON → edit calls `putPersonalViewConfig`; OFF → shared `updateView`; per-view (one view ON doesn't affect another) |
+| **G-FE-3** | `tests/multitable-personal-view-toggle.spec.ts` | reset → `DELETE …/personal-config` BEFORE refetch, clears local personal mode |
+| **G-FE-4** | `tests/multitable-personal-view-toggle.spec.ts` + `tests/meta-view-tab-bar-personal-toggle.spec.ts` | disabled session can never latch personal mode ON, emits no personal-config request; toggle absent from DOM when `personalViewsEnabled` off |
+
+Run: `cd apps/web && npx vitest run tests/multitable/personal-view-client.test.ts tests/multitable-personal-view-toggle.spec.ts tests/meta-view-tab-bar-personal-toggle.spec.ts` → **3 files, 17 passed**. The FE test job runs `vitest run` (default recursive glob), so these are picked up in CI with no workflow change.
+
+## Observed-RED (bidirectional teeth) — G-FE-1 CONFIRMED
+
+Reverted the guard by smuggling a `userId` into the client's PUT body
+(`body: JSON.stringify({ config: overlay, userId: 'actor' })`) and re-ran the client golden:
+
+```
+FAIL  tests/multitable/personal-view-client.test.ts > … G-FE-1 identity-leak guard >
+      putPersonalViewConfig PUTs a { config } envelope with no identity anywhere in the request
+AssertionError: expected { config: { …(2) }, userId: 'actor' } to deeply equal { config: { …(2) } }
+ Tests  1 failed | 5 passed (6)
+```
+
+Restoring the body (`{ config: overlay }`) returns the file to **6 passed**. Green-with-guard + red-without =
+the identity-leak golden has real teeth, executed locally (not a synthetic demonstration).
+
+## Explicitly DEFERRED — G-FE-5 (unknown-`fieldOrder` fail-soft) → Slice 3b
+
+The reviewer asked (correctly) to guard that an unknown/missing `fieldOrder` id is ignored / does not crash the
+FE. **There is currently no FE consumer of `fieldOrder`:** the only references in `apps/web/src/multitable/` are
+the type declarations added here; nothing reads `view.fieldOrder` to reorder columns. Slice 2 landed the
+server-side field-order overlay as backend plumbing — the FE does not yet render per-user field order. A
+fail-soft test with no live consumer would be vacuous. **G-FE-5 therefore ships WITH the field-order-rendering
+consumer in Slice 3b** (the follow-up that makes `view.fieldOrder` actually drive column order, with unknown/
+stale ids filtered against the current field list). This is a documented deferral, not a silent drop.
+
+## Enablement posture
+
+- Flag stays **OFF**. This slice is NOT enable-ready.
+- Before any flag-on, re-run `multitable-personal-views-flag-on-checklist-20260705.md` §B (it calls for a re-run
+  per slice) — this slice adds FE read/write surfaces (`personal-config` PUT/DELETE from the client).
+- Backend actor-isolation (G-A/G-C) is unchanged by Slice 3 and already banked by Slice 1's observed-RED (#3639).

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6704,10 +6704,28 @@ export function univerMetaRouter(): Router {
         hiddenFieldIds: normalizeJsonArray(row.hidden_field_ids),
         config: normalizeJson(row.config),
       }))
-      const selectedView = viewId
-        ? serializedViews.find((view: UniverMetaViewConfig) => view.id === viewId) ?? null
-        : serializedViews[0] ?? null
       const viewIds = serializedViews.map((v: UniverMetaViewConfig) => v.id)
+      // Personal (per-user) view overlay on the MAIN load path — Slice 1/Slice 3 P1 fix. The Workbench
+      // loads via /context (loadContext → ctx.views), NOT GET /views, so the overlay MUST also run here or
+      // a saved personal row is invisible on the main grid. Same contract as GET /views: flag-on + actor
+      // ⇒ this actor's personal override ELSE shared (§1-C); actor = access.userId (§1-B), never a client
+      // id. Runs BEFORE selectedView / fieldPermissions / redaction so (a) personal hidden/order flow into
+      // the derived metadata exactly as the shared view's own facets do, and (b) redaction runs on the
+      // personal filterInfo too (no personal-filter literal leak). Absent override / flag-off ⇒
+      // effectiveViews === serializedViews (byte-identical). `personalOverrideViewIds` is the FE-init
+      // signal: which views have a persisted personal row, so the "My view" toggle reflects server state.
+      let effectiveViews: UniverMetaViewConfig[] = serializedViews
+      let personalOverrideViewIds: string[] = []
+      if (isPersonalViewsEnabled() && access.userId) {
+        const overlays = await fetchPersonalViewConfigsForViews(pool.query.bind(pool), viewIds, access.userId)
+        if (overlays.size > 0) {
+          personalOverrideViewIds = viewIds.filter((id: string) => overlays.has(id))
+          effectiveViews = serializedViews.map((view: UniverMetaViewConfig) => applyPersonalViewOverlay(view, overlays.get(view.id)))
+        }
+      }
+      const selectedView = viewId
+        ? effectiveViews.find((view: UniverMetaViewConfig) => view.id === viewId) ?? null
+        : effectiveViews[0] ?? null
       const viewScopeMap = access.userId ? await loadViewPermissionScopeMap(pool.query.bind(pool), viewIds, access.userId) : new Map()
       // #2052 (b): bind fieldScopeMap to effectiveSheetId (NOT resolvedSheetId) — on a base-only ?baseId=
       // request resolvedSheetId is null but the returned views bind to effectiveSheetId; gating off
@@ -6720,7 +6738,7 @@ export function univerMetaRouter(): Router {
       // #2052 (b): allowed-field set for redacting filter literals — BOTH inputs keyed to effectiveSheetId
       // (activeFields above + this fieldScopeMap), so the redaction matches the sheet whose views ship.
       const allowedFieldIds = computeAllowedFieldIds(activeFields, capabilities, fieldScopeMap)
-      const viewPermissions = deriveViewPermissions(serializedViews, capabilities, viewScopeMap)
+      const viewPermissions = deriveViewPermissions(effectiveViews, capabilities, viewScopeMap)
 
       return res.json({
         ok: true,
@@ -6743,7 +6761,11 @@ export function univerMetaRouter(): Router {
             !isSystemPeopleSheetDescription(row.description)
             && readableSheetRows.some((visibleRow) => String(visibleRow.id) === String(row.id)),
           ),
-          views: serializedViews.map((view: UniverMetaViewConfig) => redactViewConfigFilterLiterals(view, allowedFieldIds)),
+          views: effectiveViews.map((view: UniverMetaViewConfig) => redactViewConfigFilterLiterals(view, allowedFieldIds)),
+          // Slice 3 P1: which of the returned views have a persisted personal override for THIS actor, so the
+          // FE "My view" toggle initializes from server state (not local guesswork). Empty when flag-off / no
+          // override / no actor. Actor-scoped (§1-B) — never reflects another user's rows.
+          personalOverrideViewIds,
           // T8-2 Reset UI flag-visibility contract (#3239): a flag-derived, FE-readable signal so the Reset entry can be
           // truly HIDDEN when off (not a phantom flag read on the client). True iff MULTITABLE_ENABLE_PIT_RESET is on AND
           // the actor is a sheet-admin — mirrors the reset routes' PIT_RESET_ENABLED() + canManageSheetAccess gate.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6747,7 +6747,16 @@ export function univerMetaRouter(): Router {
           // T8-2 Reset UI flag-visibility contract (#3239): a flag-derived, FE-readable signal so the Reset entry can be
           // truly HIDDEN when off (not a phantom flag read on the client). True iff MULTITABLE_ENABLE_PIT_RESET is on AND
           // the actor is a sheet-admin — mirrors the reset routes' PIT_RESET_ENABLED() + canManageSheetAccess gate.
-          capabilities: { ...capabilities, pitResetEnabled: (String(process.env.MULTITABLE_ENABLE_PIT_RESET ?? '').trim().toLowerCase() === 'true') && capabilities.canManageSheetAccess === true },
+          //
+          // Slice 3 (design-lock multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md §7 Q1):
+          // the personal-views "My view" toggle is gated on this SAME flag-derived-capability pattern — no
+          // client-side env const. Available to every actor who can read (P1: presentation-only, no per-view
+          // opt-in), so unlike pitResetEnabled this is not additionally ANDed with a management capability.
+          capabilities: {
+            ...capabilities,
+            pitResetEnabled: (String(process.env.MULTITABLE_ENABLE_PIT_RESET ?? '').trim().toLowerCase() === 'true') && capabilities.canManageSheetAccess === true,
+            personalViewsEnabled: isPersonalViewsEnabled(),
+          },
           capabilityOrigin,
           fieldPermissions,
           viewPermissions,

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -178,6 +178,7 @@ describe('Multitable context API', () => {
       canExport: true,
       canSendNotification: false,
       pitResetEnabled: false,
+      personalViewsEnabled: false,
     })
     expect(response.body.data.capabilityOrigin).toEqual({
       source: 'global-rbac',
@@ -368,6 +369,7 @@ describe('Multitable context API', () => {
       canExport: true,
       canSendNotification: true,
       pitResetEnabled: false,
+      personalViewsEnabled: false,
     })
     // Route-level contract lock for the new FE signal: flag ON + sheet-admin → pitResetEnabled true (its only true source).
     // The flag-off cases (false for both admin and non-admin) are locked by the two capabilities exact-matches above.
@@ -376,6 +378,13 @@ describe('Multitable context API', () => {
       const onResp = await request(app).get('/api/multitable/context').query({ sheetId: 'sheet_ops' }).expect(200)
       expect(onResp.body.data.capabilities.pitResetEnabled).toBe(true)
     } finally { delete process.env.MULTITABLE_ENABLE_PIT_RESET }
+    // Slice 3 contract lock: flag ON → personalViewsEnabled true (available to every reader, presentation-only —
+    // NOT ANDed with a management capability, unlike pitResetEnabled). Flag-off (false) locked by the exact-matches above.
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    try {
+      const onResp = await request(app).get('/api/multitable/context').query({ sheetId: 'sheet_ops' }).expect(200)
+      expect(onResp.body.data.capabilities.personalViewsEnabled).toBe(true)
+    } finally { delete process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS }
     expect(response.body.data.viewPermissions).toEqual({
       view_grid: {
         canAccess: true,

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -151,6 +151,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -273,6 +276,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -347,6 +353,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -438,6 +447,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -538,6 +550,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -582,6 +597,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -615,6 +633,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -740,6 +761,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(normalized)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -831,6 +855,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(normalized)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -926,6 +953,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -960,6 +990,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -995,6 +1028,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1022,6 +1058,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1099,6 +1138,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1174,6 +1216,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1250,6 +1295,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1328,6 +1376,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1443,6 +1494,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1566,6 +1620,9 @@ describe('Multitable context API', () => {
         { const cr = configRevisionNoop(sql); if (cr) return cr }
         // A: approval-projection read-guard lookup — no projection sheet in this test
         if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+        // Slice 3: /context resolves the actor's personal-view overlay when the flag is on. No personal rows
+        // in these capability-shape tests ⇒ empty (no overlay; personalViewsEnabled still true from the route).
+        if (sql.includes('FROM meta_view_personal_configs')) return { rows: [] }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })

--- a/packages/core-backend/tests/integration/multitable-personal-views-slice3-context-overlay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-personal-views-slice3-context-overlay-realdb.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Slice 3 P1 real-DB golden: the personal (per-user) view overlay must be applied on the MAIN load path,
+ * `GET /api/multitable/context` — not only `GET /views`. The apps/web Workbench loads via
+ * loadContext → ctx.views, so a saved personal row that is invisible on /context is invisible on the main
+ * grid (the P1 the Slice 3 review caught). This locks:
+ *
+ *  - CTX-A (personal overlay applied on /context): flag ON + a personal row for THIS actor ⇒ /context
+ *    data.views carries the personal config, and data.personalOverrideViewIds names the view.
+ *  - CTX-B (shared fallback byte-identical on /context): flag ON, no row ⇒ shared; flag OFF, row present ⇒
+ *    shared + personalOverrideViewIds empty (the main-path parity of G-B).
+ *  - CTX-ISO (actor-scoped, §1-B): A's override is NOT visible to B via /context; B's
+ *    personalOverrideViewIds is empty.
+ *
+ * Ratified design: docs/development/multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI, matching sibling real-DB specs).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_pv3_${TS}`
+const SHEET_ID = `sheet_pv3_${TS}`
+const FIELD_ID = `fld_pv3_${TS}`
+const VIEW_ID = `view_pv3_${TS}`
+const USER_A = `user_pv3_a_${TS}`
+const USER_B = `user_pv3_b_${TS}`
+
+const SHARED_FILTER = { conjunction: 'and', conditions: [{ fieldId: FIELD_ID, operator: 'is', value: 'shared-val' }] }
+const SHARED_SORT = { fieldId: FIELD_ID, direction: 'asc' }
+const PERSONAL_A_FILTER = { conjunction: 'and', conditions: [{ fieldId: FIELD_ID, operator: 'is', value: 'personal-a-val' }] }
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let app: Express
+let currentUserId: string | null = USER_A
+
+const getContext = () => request(app).get('/api/multitable/context').query({ sheetId: SHEET_ID, viewId: VIEW_ID })
+const seedPersonalRow = (userId: string, config: Record<string, unknown>) =>
+  q('INSERT INTO meta_view_personal_configs (view_id, user_id, config) VALUES ($1,$2,$3::jsonb)', [VIEW_ID, userId, JSON.stringify(config)])
+const viewFrom = (res: { body: any }) => res.body.data.views.find((v: any) => v.id === VIEW_ID)
+
+describeIfDatabase('personal view overlay on /context — slice 3 P1 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = currentUserId ? { id: currentUserId, roles: [], perms: ['multitable:read', 'multitable:write'] } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_ID, 'PV3 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_ID, BASE_ID, 'PV3 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FIELD_ID, SHEET_ID, 'F1', 'string', '{}', 1])
+    await q(
+      'INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb,$9::jsonb)',
+      [VIEW_ID, SHEET_ID, 'PV3 View', 'grid', JSON.stringify(SHARED_FILTER), JSON.stringify(SHARED_SORT), JSON.stringify({}), JSON.stringify([]), '{}'],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_view_personal_configs WHERE view_id = $1', [VIEW_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    currentUserId = USER_A
+    delete process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS
+    await q('DELETE FROM meta_view_personal_configs WHERE view_id = $1', [VIEW_ID])
+  })
+  afterEach(() => { delete process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('CTX-A: flag ON + personal row for the actor ⇒ /context serves the personal overlay + names it in personalOverrideViewIds', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    await seedPersonalRow(USER_A, { filterInfo: PERSONAL_A_FILTER })
+
+    currentUserId = USER_A
+    const res = await getContext()
+    expect(res.status).toBe(200)
+    // The MAIN load path now reflects the personal override (was the P1 bug: it showed shared).
+    expect(viewFrom(res).filterInfo).toEqual(PERSONAL_A_FILTER)
+    expect(res.body.data.personalOverrideViewIds).toContain(VIEW_ID)
+    expect(res.body.data.capabilities.personalViewsEnabled).toBe(true)
+  })
+
+  test('CTX-B: flag ON, no row for the actor ⇒ /context shared config byte-identical, no override ids', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    currentUserId = USER_A
+    const res = await getContext()
+    expect(res.status).toBe(200)
+    expect(viewFrom(res).filterInfo).toEqual(SHARED_FILTER)
+    expect(res.body.data.personalOverrideViewIds).toEqual([])
+  })
+
+  test('CTX-B: flag OFF with a personal row present ⇒ /context still shared + empty override ids (main-path G-B)', async () => {
+    await seedPersonalRow(USER_A, { filterInfo: PERSONAL_A_FILTER })
+    expect(process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS).toBeUndefined()
+
+    currentUserId = USER_A
+    const res = await getContext()
+    expect(res.status).toBe(200)
+    expect(viewFrom(res).filterInfo).toEqual(SHARED_FILTER)
+    expect(res.body.data.personalOverrideViewIds).toEqual([])
+    expect(res.body.data.capabilities.personalViewsEnabled).toBe(false)
+  })
+
+  test('CTX-ISO: A\'s personal override is NOT visible to B via /context (actor-scoped, §1-B)', async () => {
+    process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'
+    await seedPersonalRow(USER_A, { filterInfo: PERSONAL_A_FILTER })
+
+    currentUserId = USER_B
+    const res = await getContext()
+    expect(res.status).toBe(200)
+    // B sees the SHARED config, never A's personal filter; B has no override of their own.
+    expect(viewFrom(res).filterInfo).toEqual(SHARED_FILTER)
+    expect(res.body.data.personalOverrideViewIds).toEqual([])
+    expect(JSON.stringify(res.body)).not.toContain('personal-a-val')
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -217,6 +217,7 @@ describe('Multitable sheet-scoped permissions API', () => {
       canExport: true,
       canSendNotification: false,
       pitResetEnabled: false, // T8-2: flag-off default ⇒ false (this actor is also not a sheet-admin, so false regardless)
+      personalViewsEnabled: false, // Slice 3: flag-off default ⇒ false (available to all readers when the flag is on)
     })
     expect(contextResponse.body.data.viewPermissions).toEqual({
       view_grid: {


### PR DESCRIPTION
## What

Implements the ratified **Slice 3** design-lock (#3705): a per-view **"My view / 个人视图"** toggle + **"reset to shared"** over the existing actor-scoped `meta_view_personal_configs` contract (Slice 1 #3637 / Slice 2 #3657). **Default-OFF, NOT enable-ready** — gated on a flag-derived session capability.

## Load-bearing invariant (§1-A)

The FE sends **no user identity** on any personal-config request — `get/put/deletePersonalViewConfig` use the same `this.fetch` path as `updateView` (only `Authorization: Bearer <jwt>` + `x-tenant-id`, `apps/web/src/utils/api.ts:147-161`). The server resolves the target user from the JWT actor alone. **Observed-RED confirmed:** injecting a `userId` into the PUT body reddens G-FE-1; restoring greens it.

## Shipped

- **client.ts** — 3 personal-config methods, no identity fields.
- **univer-meta.ts `/context`** — `capabilities.personalViewsEnabled = isPersonalViewsEnabled()`, mirroring the `pitResetEnabled` flag-visibility precedent (no client-side env const, §7 Q1).
- **usePersonalViewToggle.ts** — per-view session-local toggle; `enabled()` mirrors the capability so a flag-off session can never latch personal mode on (G-FE-4).
- **useMultitableGrid.ts** — single `persistViewConfig` switch: personal ON → `putPersonalViewConfig`, OFF → shared `updateView` (G-FE-2).
- **MetaViewTabBar / MetaToolbar / MultitableWorkbench** — toggle next to the active view + reset-to-shared (`DELETE` + refetch), both flag-gated.

## Goldens (vitest, `apps/web`) — 17 tests green

- **G-FE-1** (load-bearing): no `userId`/`x-user-id` in any personal-config request. **Observed-RED confirmed.**
- **G-FE-2**: write-target routing personal-vs-shared, per-view.
- **G-FE-3**: reset-to-shared = `DELETE` before refetch, clears local state.
- **G-FE-4**: flag-off inert — no toggle in DOM, no request, can't latch on.

## Deferred — G-FE-5 → Slice 3b (documented, not dropped)

Unknown-`fieldOrder` fail-soft has **no FE consumer yet**: nothing in `apps/web/src/multitable/` reads `view.fieldOrder` to reorder columns (Slice 2 landed server-side overlay plumbing only). G-FE-5 ships **with** the field-order-rendering consumer in Slice 3b. See the verification MD.

## Posture

Flag stays OFF. Re-run `multitable-personal-views-flag-on-checklist-20260705.md` §B before any enablement (this slice adds FE `personal-config` PUT/DELETE surfaces). Backend G-A/G-C isolation unchanged, already banked by Slice 1 observed-RED (#3639).

Grounded on `origin/main` after #3656/#3657/#3705 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)