### PR TITLE
feat(web): multitable grid UI polish P0 (§8 line) — consume UF-1 tokens, presentation-only

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldHeader.vue
+++ b/apps/web/src/multitable/components/MetaFieldHeader.vue
@@ -97,7 +97,7 @@ const headerStyle = computed(() => {
     style.position = 'sticky'
     style.left = `${props.frozenLeft}px`
     style.zIndex = '4'
-    style.background = '#f9fafb'
+    style.background = 'var(--ms-bg-card, #fff)'
   }
   return Object.keys(style).length ? style : undefined
 })
@@ -121,11 +121,11 @@ function onResizeStart(e: MouseEvent) {
 <style scoped>
 .meta-field-header {
   padding: 8px 12px; text-align: left; font-weight: 500; font-size: 13px;
-  border-bottom: 2px solid #e5e7eb; background: #f9fafb; white-space: nowrap;
+  border-bottom: 1px solid var(--ms-border-light, #e7e8ec); background: var(--ms-bg-card, #fff); white-space: nowrap;
   user-select: none; position: sticky; top: 0; z-index: 1; position: relative;
 }
 .meta-field-header--sortable { cursor: pointer; }
-.meta-field-header--sortable:hover { background: #f0f2f5; }
+.meta-field-header--sortable:hover { background: var(--ms-bg-page, #f5f6f8); }
 .meta-field-header__icon { display: inline-block; width: 22px; text-align: center; color: #999; font-size: 12px; margin-right: 4px; }
 .meta-field-header__name { overflow: hidden; text-overflow: ellipsis; }
 .meta-field-header__sort { margin-left: 4px; font-size: 10px; color: #409eff; }

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -1376,14 +1376,29 @@ function onKeydown(e: KeyboardEvent) {
 </script>
 
 <style scoped>
-.meta-grid { position: relative; display: flex; flex-direction: column; flex: 1; min-height: 0; outline: none; }
+.meta-grid {
+  position: relative; display: flex; flex-direction: column; flex: 1; min-height: 0; outline: none;
+  border: 1px solid var(--ms-border-light, #e7e8ec);
+  border-radius: var(--ms-radius-lg, 12px);
+  background: var(--ms-bg-card, #fff);
+  box-shadow: var(--ms-shadow-card, 0 1px 2px rgba(31,35,41,.04), 0 8px 24px rgba(31,35,41,.06));
+  overflow: hidden;
+}
 .meta-grid__table-wrap { flex: 1; overflow: auto; }
+/* Header-only refinements: target thead specifically so the shared
+   row-num/check-col classes (also used on body td) keep their existing
+   body-row appearance — only the header cells adopt the panel/token look. */
+thead .meta-grid__row-num,
+thead .meta-grid__check-col {
+  background: var(--ms-bg-card, #fff);
+  border-bottom: 1px solid var(--ms-border-light, #e7e8ec);
+}
 .meta-grid__table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .meta-grid__row-num { width: 56px; min-width: 56px; text-align: center; color: #999; font-size: 12px; background: #f9fafb; border-bottom: 1px solid #eee; border-right: 1px solid #eee; padding: 6px 4px; position: sticky; left: 0; z-index: 1; }
 .meta-grid__row-num > span { display: inline-flex; align-items: center; justify-content: center; }
 .meta-grid__check-col { position: sticky; z-index: 1; }
 .meta-grid__row { transition: background 0.1s; content-visibility: auto; contain-intrinsic-size: auto 36px; }
-.meta-grid__row:hover { background: #f5f7fa; }
+.meta-grid__row:hover { background: var(--ms-bg-page, #f5f6f8); }
 .meta-grid__row--selected, .meta-grid__row--focused { background: #ecf5ff; }
 .meta-grid__cell { position: relative; padding: 6px 12px; border-bottom: 1px solid #eee; overflow: hidden; text-overflow: ellipsis; cursor: default; }
 .meta-grid__cell--editing { padding: 2px 4px; background: #fff; }

--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -117,6 +117,7 @@
       </div>
 
       <!-- Undo/Redo -->
+      <span class="meta-toolbar__divider" aria-hidden="true"></span>
       <button class="meta-toolbar__btn" :disabled="!canUndo" :title="l('toolbar.undoTitle')" :aria-label="l('toolbar.undo')" @click="emit('undo')">&#x21A9;</button>
       <button class="meta-toolbar__btn" :disabled="!canRedo" :title="l('toolbar.redoTitle')" :aria-label="l('toolbar.redo')" @click="emit('redo')">&#x21AA;</button>
       <!--
@@ -140,6 +141,7 @@
         <button v-if="searchText" class="meta-toolbar__search-clear" :aria-label="l('toolbar.clearSearch')" @click="emit('update:search-text', '')">&times;</button>
       </div>
       <span v-if="totalRows !== undefined" class="meta-toolbar__row-count">{{ rowCount(totalRows, isZh) }}</span>
+      <span class="meta-toolbar__divider" aria-hidden="true"></span>
       <!-- Row density -->
       <div class="meta-toolbar__dropdown">
         <button class="meta-toolbar__btn" :title="l('toolbar.rowHeight')" :aria-label="l('toolbar.rowHeight')" @click="showDensityPanel = !showDensityPanel">&#x2195; {{ l('toolbar.rows') }}</button>
@@ -317,20 +319,25 @@ function onAddFilterGroup() {
 </script>
 
 <style scoped>
-.meta-toolbar { display: flex; justify-content: space-between; align-items: center; padding: 6px 12px; border-bottom: 1px solid #e5e7eb; background: #fff; }
-.meta-toolbar__left { display: flex; gap: 4px; align-items: center; }
-.meta-toolbar__right { display: flex; gap: 4px; }
-.meta-toolbar__btn { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; font-size: 13px; border: 1px solid #ddd; border-radius: 4px; background: #fff; cursor: pointer; color: #555; }
-.meta-toolbar__btn:hover:not(:disabled) { background: #f5f5f5; border-color: #ccc; }
+.meta-toolbar { display: flex; justify-content: space-between; align-items: center; padding: 6px 12px; border-bottom: 1px solid var(--ms-border-light, #e7e8ec); background: var(--ms-bg-card, #fff); }
+.meta-toolbar__left { display: flex; gap: 2px; align-items: center; }
+.meta-toolbar__right { display: flex; gap: 4px; align-items: center; }
+.meta-toolbar__divider { display: inline-block; width: 1px; align-self: stretch; margin: 4px 6px; background: var(--ms-border-light, #e7e8ec); flex-shrink: 0; }
+.meta-toolbar__btn {
+  display: inline-flex; align-items: center; gap: 4px; height: var(--ms-control-height, 32px); box-sizing: border-box;
+  padding: 0 10px; font-size: 13px; border: 1px solid transparent; border-radius: var(--ms-radius-sm, 6px);
+  background: transparent; cursor: pointer; color: var(--ms-text-2, #646a73);
+}
+.meta-toolbar__btn:hover:not(:disabled) { background: var(--ms-bg-page, #f5f6f8); color: var(--ms-text-1, #1f2329); }
 .meta-toolbar__btn:disabled { opacity: 0.35; cursor: not-allowed; }
-.meta-toolbar__btn--primary { background: #409eff; color: #fff; border-color: #409eff; }
-.meta-toolbar__btn--primary:hover { background: #66b1ff; }
+.meta-toolbar__btn--primary { background: var(--ms-color-primary, #245bdb); color: #fff; border-color: var(--ms-color-primary, #245bdb); }
+.meta-toolbar__btn--primary:hover:not(:disabled) { background: var(--el-color-primary-dark-2, #1e4fc0); color: #fff; }
 .meta-toolbar__btn--reset-personal { color: #067647; border-color: #6ce9a6; background: #ecfdf3; }
 .meta-toolbar__btn--reset-personal:hover { background: #d1fadf; }
 .meta-toolbar__btn-icon { font-size: 14px; }
-.meta-toolbar__badge { font-size: 10px; background: #409eff; color: #fff; padding: 0 5px; border-radius: 8px; min-width: 16px; text-align: center; }
+.meta-toolbar__badge { font-size: 10px; background: var(--ms-color-primary, #245bdb); color: #fff; padding: 0 5px; border-radius: 8px; min-width: 16px; text-align: center; }
 .meta-toolbar__dropdown { position: relative; }
-.meta-toolbar__panel { position: absolute; top: 100%; left: 0; z-index: 20; min-width: 200px; background: #fff; border: 1px solid #ddd; border-radius: 4px; box-shadow: 0 4px 12px rgba(0,0,0,.1); padding: 8px; margin-top: 4px; }
+.meta-toolbar__panel { position: absolute; top: 100%; left: 0; z-index: 20; min-width: 200px; background: var(--ms-bg-card, #fff); border: 1px solid var(--ms-border-light, #e7e8ec); border-radius: var(--ms-radius-sm, 6px); box-shadow: var(--ms-shadow-pop, 0 4px 12px rgba(0,0,0,.1)); padding: 8px; margin-top: 4px; }
 .meta-toolbar__panel--filter { min-width: 420px; }
 .meta-toolbar__panel--density { min-width: 120px; }
 .meta-toolbar__field-toggle { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 13px; cursor: pointer; }
@@ -346,8 +353,8 @@ function onAddFilterGroup() {
 .meta-toolbar__add { border: none; background: none; color: #409eff; cursor: pointer; font-size: 12px; padding: 4px 0; }
 .meta-toolbar__add:hover { text-decoration: underline; }
 .meta-toolbar__add--danger { color: #f56c6c; }
-.meta-toolbar__apply { display: block; width: 100%; margin-top: 8px; padding: 5px 0; background: #409eff; color: #fff; border: none; border-radius: 3px; font-size: 12px; cursor: pointer; }
-.meta-toolbar__apply:hover { background: #66b1ff; }
+.meta-toolbar__apply { display: block; width: 100%; margin-top: 8px; padding: 5px 0; background: var(--ms-color-primary, #245bdb); color: #fff; border: none; border-radius: var(--ms-radius-sm, 6px); font-size: 12px; cursor: pointer; }
+.meta-toolbar__apply:hover { background: var(--el-color-primary-dark-2, #1e4fc0); }
 .meta-toolbar__apply-hint { margin: 6px 0 0; color: #777; font-size: 11px; }
 .meta-toolbar__group-none { color: #999; }
 .meta-toolbar__field-type { font-size: 10px; color: #aaa; margin-left: auto; }
@@ -359,9 +366,9 @@ function onAddFilterGroup() {
 .meta-toolbar__group-remove:hover { color: #f56c6c; }
 .meta-toolbar__group-add { border: none; background: none; color: #409eff; cursor: pointer; font-size: 12px; padding: 4px 0; }
 .meta-toolbar__group-add:hover { text-decoration: underline; }
-.meta-toolbar__search { display: flex; align-items: center; gap: 4px; border: 1px solid #ddd; border-radius: 4px; padding: 2px 8px; background: #fafafa; transition: border-color 0.2s, background 0.2s; }
-.meta-toolbar__search:focus-within { border-color: #409eff; background: #fff; }
-.meta-toolbar__search--active { border-color: #409eff; background: #ecf5ff; }
+.meta-toolbar__search { display: flex; align-items: center; gap: 4px; height: var(--ms-control-height, 32px); box-sizing: border-box; border: 1px solid var(--ms-border-light, #e7e8ec); border-radius: var(--ms-radius-sm, 6px); padding: 0 8px; background: var(--ms-bg-page, #f5f6f8); transition: border-color 0.2s, background 0.2s; }
+.meta-toolbar__search:focus-within { border-color: var(--ms-color-primary, #245bdb); background: var(--ms-bg-card, #fff); }
+.meta-toolbar__search--active { border-color: var(--ms-color-primary, #245bdb); background: var(--el-color-primary-light-9, #eef3ff); }
 .meta-toolbar__search-icon { font-size: 12px; opacity: 0.5; }
 .meta-toolbar__search-input { border: none; outline: none; font-size: 12px; width: 140px; background: transparent; color: #333; }
 .meta-toolbar__search-input::placeholder { color: #bbb; }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -4256,36 +4256,50 @@ defineExpose({
 .mt-workbench__actions { display: flex; gap: 6px; padding: 4px 16px 0; }
 .mt-workbench__capability-banner {
   margin: 8px 16px 0;
-  padding: 8px 12px;
-  border: 1px solid #d9d9d9;
-  border-radius: 10px;
-  background: #fafafa;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  padding: 3px 10px;
+  border: 1px solid var(--ms-border-light, #e7e8ec);
+  border-radius: 999px;
+  background: var(--ms-bg-page, #f5f6f8);
+  display: inline-flex;
+  align-self: flex-start;
+  align-items: center;
+  gap: 6px;
   font-size: 12px;
-  color: #595959;
+  line-height: 1.6;
+  color: var(--ms-text-2, #646a73);
+  max-width: 100%;
 }
-.mt-workbench__capability-banner strong { font-weight: 600; color: inherit; }
-.mt-workbench__capability-banner--admin {
-  border-color: #87e8de;
-  background: #f6ffed;
-  color: #135200;
+.mt-workbench__capability-banner::before {
+  content: '\1F512';
+  font-size: 10px;
+  line-height: 1;
+  opacity: 0.7;
 }
+.mt-workbench__capability-banner strong {
+  font-weight: 600;
+  color: var(--ms-text-1, #1f2329);
+}
+.mt-workbench__capability-banner span {
+  color: var(--ms-text-2, #646a73);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mt-workbench__capability-banner--admin,
 .mt-workbench__capability-banner--global-rbac {
-  border-color: #b7eb8f;
-  background: #f6ffed;
-  color: #237804;
+  border-color: var(--ms-border-light, #e7e8ec);
+  background: var(--ms-bg-page, #f5f6f8);
+  color: var(--ms-text-2, #646a73);
 }
 .mt-workbench__capability-banner--sheet-grant {
-  border-color: #91d5ff;
-  background: #e6f4ff;
-  color: #0958d9;
+  border-color: var(--el-color-primary-light-9, #eef3ff);
+  background: var(--el-color-primary-light-9, #eef3ff);
+  color: var(--el-color-primary-dark-2, #1e4fc0);
 }
 .mt-workbench__capability-banner--sheet-scope {
-  border-color: #ffd591;
-  background: #fff7e6;
-  color: #ad6800;
+  border-color: var(--ms-border-light, #e7e8ec);
+  background: var(--ms-bg-page, #f5f6f8);
+  color: var(--ms-text-2, #646a73);
 }
 .mt-workbench__presence-chip { display: inline-flex; align-items: center; gap: 4px; padding: 3px 10px; border: 1px solid #91caff; border-radius: 12px; background: #e6f4ff; color: #0958d9; font-size: 12px; }
 .mt-workbench__presence-chip strong { font-weight: 600; color: #003eb3; }

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -117,4 +117,15 @@
   --el-color-info-light-8: #e1e3e6;
   --el-color-info-light-9: #f0f1f2;
   --el-color-info-dark-2: #565b66;
+
+  /* ---- Elevation + control sizing ----
+   * Generic additions the UF-1 base set did not yet define; consumed first
+   * by the multitable grid line (design-lock §8, an independent line) but
+   * deliberately named generically (no grid-specific vocabulary) so they
+   * extend the single-source foundation rather than compete with it.
+   * Values follow the UF neutral palette. Dark-theme values are NOT defined
+   * here — dark theme is its own independent line under §8. */
+  --ms-control-height: 32px;
+  --ms-shadow-card: 0 1px 2px rgba(17,24,39,.04), 0 8px 24px rgba(17,24,39,.06);
+  --ms-shadow-pop: 0 6px 20px rgba(17,24,39,.12);
 }

--- a/apps/web/tests/tokens-foundation.spec.ts
+++ b/apps/web/tests/tokens-foundation.spec.ts
@@ -21,4 +21,16 @@ describe('UF-1 design-token foundation (tokens.css)', () => {
   it('contains no !important (tokens win by import order, not specificity hacks)', () => {
     expect(tokensCss).not.toContain('!important')
   })
+
+  // Generic elevation + control-sizing tokens added when the multitable grid line
+  // (design-lock §8, an independent line) needed values the UF-1 base did not yet
+  // define. Pinned here so a future "dead CSS" sweep cannot silently drop them —
+  // they are consumed by the grid/toolbar surface, not just their own file.
+  it.each([
+    '--ms-control-height',
+    '--ms-shadow-card',
+    '--ms-shadow-pop',
+  ])('defines the generic foundation token %s', (token) => {
+    expect(tokensCss).toMatch(new RegExp(`${token}:\\s*[^;]+;`))
+  })
 })


### PR DESCRIPTION
## What & why
Slice-1 of the **multitable grid UI uplift** — the "independent line" carved out by the UI foundation design-lock **§8** (`docs/development/ui-foundation-design-lock-20260706.md`). Owner ratified **gate = A** (verbal decision + PR-scope constraint; no separate short lock for P0).

Applies calm, Feishu-parity presentation to the grid container, capability banner, and toolbar — **consuming the already-ratified UF-1 tokens**, not defining any new design language.

## Scope discipline (owner口径)
**Allowed (this PR):** presentation-only CSS; consume UF `--ms-*`/`--el-color-*` tokens; the 3 generic foundation additions below + their spec pin.
**NOT in this PR:** new token vocabulary · dark theme · grid-specific tokens · layout/interaction refactor. (P1 icons / P2 structural = separate PRs; P2 gets its own short design-lock first.)

## Changes
- `styles/tokens.css` — **+3 generic** foundation tokens the UF-1 base did not define yet: `--ms-control-height`, `--ms-shadow-card`, `--ms-shadow-pop`. Generic names (no grid vocabulary), no dark block (dark is its own §8 line). **No competing `--ms-*` palette** — the first cut's second vocabulary was reworked out; everything now maps to UF (`--ms-color-primary` / `--ms-text-1/2` / `--ms-border-light` / `--ms-bg-page/card` / `--ms-radius-sm/lg` + EP shades).
- `tests/tokens-foundation.spec.ts` — **pins** the 3 new generic tokens exist, so a future dead-CSS sweep can't silently drop them (they're consumed by the grid surface, not just their own file).
- `MultitableWorkbench.vue` — capability banner: full-width colored box → slim status pill chip (`<style>`-only; `v-if`/computed untouched).
- `MetaGridTable.vue` — grid card (border/radius/shadow, `overflow:hidden` verified Teleport-safe), row hover + header-only refinements tokenized (body row-num/check-col appearance preserved).
- `MetaFieldHeader.vue` — header cell bg/border/hover tokenized.
- `MetaToolbar.vue` — consistent control height, ghost secondary buttons, single filled accent CTA, group dividers.

## Verify
- `vue-tsc -b` type-check: pass.
- `tokens-foundation.spec.ts`: 6/6 (3 existing UF-1 + 3 new pins).
- Every component `--ms-*`/`--el-*` reference resolves to a defined token.
- Presentation-only: `MetaToolbar` `@click`/`<button>` counts unchanged (23/23); no template/prop/emit/computed/route logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)