### PR TITLE
feat(web): UF-3b approvalTemplate status domain — template status ternaries converge to StatusTag

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -75,6 +75,12 @@ on:
       - 'apps/web/tests/approvalDelegationView.spec.ts'
       - 'apps/web/tests/approvalDelegationStatus.spec.ts'
       - 'apps/web/tests/approval-e2e-lifecycle.spec.ts'
+      # UF-3b — approvalTemplate status domain: TemplateCenterView's status column,
+      # TemplateDetailView's header tag, and ApprovalNewView's info-card tag converge on
+      # `<StatusTag domain="approvalTemplate">`. approval-e2e-permissions.spec.ts asserts the
+      # TemplateDetailView status tag by `data-status` and had no gate wiring before this (its
+      # 40 tests ran in no required workflow).
+      - 'apps/web/tests/approval-e2e-permissions.spec.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -137,6 +143,12 @@ on:
       - 'apps/web/tests/approvalDelegationView.spec.ts'
       - 'apps/web/tests/approvalDelegationStatus.spec.ts'
       - 'apps/web/tests/approval-e2e-lifecycle.spec.ts'
+      # UF-3b — approvalTemplate status domain: TemplateCenterView's status column,
+      # TemplateDetailView's header tag, and ApprovalNewView's info-card tag converge on
+      # `<StatusTag domain="approvalTemplate">`. approval-e2e-permissions.spec.ts asserts the
+      # TemplateDetailView status tag by `data-status` and had no gate wiring before this (its
+      # 40 tests ran in no required workflow).
+      - 'apps/web/tests/approval-e2e-permissions.spec.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -204,4 +216,7 @@ jobs:
         # approval-inbox-auth-guard (ApprovalInboxView, had no gate before this wiring),
         # myDelegationView/approvalDelegationView (MyDelegationView/DelegationSettingsView status
         # cell), approvalDelegationStatus (delegationStatus.ts, had no gate before this wiring).
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus --reporter=dot
+        # UF-3b: approvalTemplate status domain — statusTag's new domain cases (published/draft/
+        # archived tone+label) and approval-e2e-permissions (TemplateDetailView header StatusTag
+        # regression via data-status selector; had no gate before this wiring, 40 tests).
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions --reporter=dot

--- a/apps/web/src/utils/statusDomains.ts
+++ b/apps/web/src/utils/statusDomains.ts
@@ -10,14 +10,22 @@
 // display status to a tone; `automationRun` derives its zh/en labels by calling the existing
 // `automationStatusLabel` (multitable/utils/meta-automation-labels.ts) rather than re-declaring
 // automation copy here.
+//
+// UF-3b — closes the 4th "status domain" gap UF-3 flagged but didn't land: `approvalTemplate`
+// (TemplateCenterView's tab/column tag, TemplateDetailView's header tag, ApprovalNewView's
+// info-card tag) previously each hand-rolled a `published`/`draft`/`archived` ternary or a
+// two-branch `status === 'published' ? ... : ...` map. Vocabulary is the `ApprovalTemplateStatus`
+// type (types/approval.ts) — verified against source, NOT the three-value guess ("draft/
+// published/disabled") floated before grounding; the real third state is `archived`.
 
 import { automationStatusLabel } from '../multitable/utils/meta-automation-labels'
 import type { WorkflowJobStatus } from '../multitable/types'
 import type { DelegationDisplayStatus } from '../approvals/delegationStatus'
+import type { ApprovalTemplateStatus } from '../types/approval'
 
 export type StatusTone = 'success' | 'warning' | 'danger' | 'info' | 'primary' | 'neutral'
 
-export type StatusDomain = 'approvalInstance' | 'delegation' | 'automationRun'
+export type StatusDomain = 'approvalInstance' | 'approvalTemplate' | 'delegation' | 'automationRun'
 
 export interface StatusDisplayEntry {
   tone: StatusTone
@@ -45,6 +53,17 @@ const APPROVAL_INSTANCE_STATUS_DOMAIN: Record<string, StatusDisplayEntry> = {
   rejected: { tone: 'danger', zh: '已驳回', en: 'Rejected' },
   revoked: { tone: 'info', zh: '已撤回', en: 'Revoked' },
   cancelled: { tone: 'info', zh: '已取消', en: 'Cancelled' },
+}
+
+// ---------------------------------------------------------------------------
+// approvalTemplate — the THREE `ApprovalTemplateStatus` values (types/approval.ts). Tone/label
+// values carried over unchanged from the three call sites' now-deleted local
+// `statusTagType`/`statusLabel` maps (semantics preserved, not re-decided here): `published`
+// mapped to EP `success`, `draft` to `warning`, `archived` to `info`.
+const APPROVAL_TEMPLATE_STATUS_DOMAIN: Record<ApprovalTemplateStatus, StatusDisplayEntry> = {
+  published: { tone: 'success', zh: '已发布', en: 'Published' },
+  draft: { tone: 'warning', zh: '草稿', en: 'Draft' },
+  archived: { tone: 'info', zh: '已归档', en: 'Archived' },
 }
 
 // ---------------------------------------------------------------------------
@@ -99,6 +118,7 @@ const AUTOMATION_RUN_STATUS_DOMAIN: Record<string, StatusDisplayEntry> = Object.
 
 const DOMAIN_TABLES: Record<StatusDomain, Record<string, StatusDisplayEntry>> = {
   approvalInstance: APPROVAL_INSTANCE_STATUS_DOMAIN,
+  approvalTemplate: APPROVAL_TEMPLATE_STATUS_DOMAIN,
   delegation: DELEGATION_STATUS_DOMAIN,
   automationRun: AUTOMATION_RUN_STATUS_DOMAIN,
 }

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -29,9 +29,7 @@
           <template #header>
             <div class="approval-new__info-header">
               <h2>{{ template.name }}</h2>
-              <el-tag :type="template.status === 'published' ? 'success' : 'info'" size="small">
-                {{ template.status === 'published' ? '已发布' : template.status }}
-              </el-tag>
+              <StatusTag domain="approvalTemplate" :status="template.status" size="sm" />
             </div>
           </template>
           <p v-if="template.description" class="approval-new__info-desc">{{ template.description }}</p>
@@ -373,6 +371,7 @@ import { ElMessage } from 'element-plus'
 import type { FormInstance, FormRules } from 'element-plus'
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
+import StatusTag from '../../components/status/StatusTag.vue'
 import type { FormField, FormSchema } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -130,13 +130,7 @@
       </el-table-column>
       <el-table-column label="状态" width="100">
         <template #default="{ row }">
-          <el-tag
-            :type="templateStatusTagType(row.status)"
-            size="small"
-            :effect="row.status === 'published' ? 'dark' : 'light'"
-          >
-            {{ templateStatusLabel(row.status) }}
-          </el-tag>
+          <StatusTag domain="approvalTemplate" :status="row.status" size="sm" />
         </template>
       </el-table-column>
       <el-table-column label="最近更新" width="180">
@@ -194,6 +188,7 @@
 <script setup lang="ts">
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
+import StatusTag from '../../components/status/StatusTag.vue'
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { Search } from '@element-plus/icons-vue'
@@ -218,24 +213,6 @@ const categories = ref<string[]>([])
 const cloningId = ref<string | null>(null)
 const currentPage = ref(1)
 const pageSize = ref(10)
-
-function templateStatusTagType(status: string) {
-  const map: Record<string, string> = {
-    published: 'success',
-    draft: 'warning',
-    archived: 'info',
-  }
-  return map[status] ?? ''
-}
-
-function templateStatusLabel(status: string) {
-  const map: Record<string, string> = {
-    published: '已发布',
-    draft: '草稿',
-    archived: '已归档',
-  }
-  return map[status] ?? status
-}
 
 function visibilityScopeLabel(scope: ApprovalTemplateListItemDTO['visibilityScope']) {
   if (!scope || scope.type === 'all') return '全员可见'

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -8,13 +8,7 @@
       @back="goBack"
     >
       <template v-if="template" #meta>
-        <el-tag
-          :type="statusTagType(template.status)"
-          size="large"
-          :effect="template.status === 'published' ? 'dark' : 'light'"
-        >
-          {{ statusLabel(template.status) }}
-        </el-tag>
+        <StatusTag domain="approvalTemplate" :status="template.status" />
       </template>
       <template v-if="template" #actions>
         <el-button
@@ -361,6 +355,7 @@
 import { computed, onMounted, ref } from 'vue'
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
+import StatusTag from '../../components/status/StatusTag.vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
   Flag,
@@ -540,24 +535,6 @@ async function saveVisibility() {
   } finally {
     visibilitySaving.value = false
   }
-}
-
-function statusTagType(status: string) {
-  const map: Record<string, string> = {
-    published: 'success',
-    draft: 'warning',
-    archived: 'info',
-  }
-  return map[status] ?? ''
-}
-
-function statusLabel(status: string) {
-  const map: Record<string, string> = {
-    published: '已发布',
-    draft: '草稿',
-    archived: '已归档',
-  }
-  return map[status] ?? status
 }
 
 function fieldTypeLabel(type: FormFieldType) {

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -13,6 +13,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import {
   mockPendingApproval,
   mockApprovedApproval,
@@ -453,6 +454,13 @@ describe('Approval E2E Permissions', () => {
   let container: HTMLDivElement | null = null
 
   beforeEach(() => {
+    // UF-3b — the template detail header tag is now <StatusTag domain="approvalTemplate">
+    // (locale-aware via useLocale()/isZh), not a hardcoded-Chinese-always ternary. This spec's
+    // fixtures/assertions are Chinese, so pin the locale explicitly rather than relying on
+    // jsdom's default `navigator.language` (same fix as approval-e2e-lifecycle.spec.ts's UF-3
+    // pin for the approvalInstance domain).
+    useLocale().setLocale('zh-CN')
+
     mockActiveApproval.value = null
     mockHistoryRef.value = []
     mockLoading.value = false
@@ -881,8 +889,10 @@ describe('Approval E2E Permissions', () => {
       const h1 = container!.querySelector('.template-detail__header h1')
       expect(h1?.textContent).toBe('通用审批模板')
 
-      // Status tag (published)
-      const statusTag = container!.querySelector('.template-detail__header [data-el-tag]')
+      // Status tag (published) — UF-3b: now <StatusTag> (framework-free by design, not
+      // `<el-tag>`), select it by its `data-status` attribute instead of the ElTag test stub's
+      // `data-el-tag`.
+      const statusTag = container!.querySelector('.template-detail__header [data-status]')
       expect(statusTag?.textContent).toContain('已发布')
 
       // "发起审批" button present for published

--- a/apps/web/tests/statusTag.spec.ts
+++ b/apps/web/tests/statusTag.spec.ts
@@ -19,6 +19,15 @@ describe('resolveStatusDisplay (pure)', () => {
     expect(resolveStatusDisplay('approvalInstance', 'cancelled', true)).toEqual({ tone: 'info', label: '已取消' })
   })
 
+  it('maps approvalTemplate tones: published -> success, draft -> warning, archived -> info', () => {
+    expect(resolveStatusDisplay('approvalTemplate', 'published', true)).toEqual({ tone: 'success', label: '已发布' })
+    expect(resolveStatusDisplay('approvalTemplate', 'draft', true)).toEqual({ tone: 'warning', label: '草稿' })
+    expect(resolveStatusDisplay('approvalTemplate', 'archived', true)).toEqual({ tone: 'info', label: '已归档' })
+    expect(resolveStatusDisplay('approvalTemplate', 'published', false)).toEqual({ tone: 'success', label: 'Published' })
+    expect(resolveStatusDisplay('approvalTemplate', 'draft', false)).toEqual({ tone: 'warning', label: 'Draft' })
+    expect(resolveStatusDisplay('approvalTemplate', 'archived', false)).toEqual({ tone: 'info', label: 'Archived' })
+  })
+
   it('maps delegation tones exactly per the existing DELEGATION_STATUS_TAG_TYPE semantics', () => {
     expect(resolveStatusDisplay('delegation', '未开始', true)).toEqual({ tone: 'info', label: '未开始' })
     expect(resolveStatusDisplay('delegation', '生效中', true)).toEqual({ tone: 'success', label: '生效中' })
@@ -48,6 +57,7 @@ describe('resolveStatusDisplay (pure)', () => {
   it('fail-safe: an unknown status per domain renders tone "neutral" and the raw status as label (never throws, never blank)', () => {
     expect(resolveStatusDisplay('approvalInstance', 'draft', true)).toEqual({ tone: 'neutral', label: 'draft' })
     expect(resolveStatusDisplay('approvalInstance', 'totally-unknown-status', false)).toEqual({ tone: 'neutral', label: 'totally-unknown-status' })
+    expect(resolveStatusDisplay('approvalTemplate', 'not-a-real-template-status', true)).toEqual({ tone: 'neutral', label: 'not-a-real-template-status' })
     expect(resolveStatusDisplay('delegation', 'not-a-real-delegation-status', true)).toEqual({ tone: 'neutral', label: 'not-a-real-delegation-status' })
     expect(resolveStatusDisplay('automationRun', 'not-a-real-automation-status', false)).toEqual({ tone: 'neutral', label: 'not-a-real-automation-status' })
     expect(() => resolveStatusDisplay('approvalInstance', '', true)).not.toThrow()
@@ -128,6 +138,9 @@ describe('StatusTag.vue (mounted)', () => {
       ['approvalInstance', 'rejected'],
       ['approvalInstance', 'pending'],
       ['approvalInstance', 'revoked'],
+      ['approvalTemplate', 'published'],
+      ['approvalTemplate', 'draft'],
+      ['approvalTemplate', 'archived'],
       ['delegation', '未开始'],
       ['delegation', '生效中'],
       ['delegation', '已过期'],


### PR DESCRIPTION
Closes the 4th status-domain gap UF-3 (#3710) flagged: template status was still three hand-rolled ternaries/local maps.

## What
- `statusDomains.ts` + domain `approvalTemplate` — vocabulary grounded against `ApprovalTemplateStatus` (types/approval.ts): **published→success, draft→warning, archived→info** (tones/labels carried over from the deleted local maps, semantics unchanged; the brief's 'disabled' guess was wrong — real third state is `archived`).
- Three sites converged: TemplateCenterView status column · TemplateDetailView PageHeader meta tag · ApprovalNewView info-card tag (**which previously leaked raw English `draft`/`archived` for non-published — now localizes 草稿/已归档**).
- TemplateAuthoringView/ApprovalCenterView checked: no template-status site exists (nothing left for UF-5's file).

## Verification
- `vue-tsc -b` 0 · build green · eslint 0 on touched files
- statusTag spec 10/10 (3 statuses zh+en + fail-safe + hex guard) · touched-spec run 138/138 · **full updated guard set 454/454**
- Mutation self-check: mutating published→danger turns the spec red (committed-first, safe checkout revert)
- Gate-gap closed: `approval-e2e-permissions.spec.ts` (40 tests, covers TemplateDetailView) had NO CI gate — wired into approval-web-guard (two-point); its stale `[data-el-tag]` selector + missing locale pin fixed (same shape as UF-3's adaptations)

Implemented by a Sonnet agent per model-split policy; reviewed by the main loop. Queued behind #3714 in the serial lander.

🤖 Generated with [Claude Code](https://claude.com/claude-code)