### PR TITLE
feat(web): UF-5 approval-center shared table — four copy-pasted el-tables converge to one component

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -57,8 +57,10 @@ on:
       - 'apps/web/tests/lineDerivation.test.ts'
       - 'apps/web/src/views/approval/ApprovalMobileList.vue'
       - 'apps/web/src/views/approval/ApprovalCenterView.vue'
+      - 'apps/web/src/views/approval/ApprovalCenterTable.vue'
       - 'apps/web/tests/approvalMobileI18n.spec.ts'
       - 'apps/web/tests/approvalMobileResponsive.spec.ts'
+      - 'apps/web/tests/approvalCenterTable.spec.ts'
       # UF-3 — status-color convergence: the shared StatusTag/statusDomains map now renders the
       # approvalInstance status tag (ApprovalCenterView/ApprovalMobileList/ApprovalDetailView
       # header/ApprovalInboxView) and the delegation status tag (MyDelegationView/
@@ -125,8 +127,10 @@ on:
       - 'apps/web/tests/lineDerivation.test.ts'
       - 'apps/web/src/views/approval/ApprovalMobileList.vue'
       - 'apps/web/src/views/approval/ApprovalCenterView.vue'
+      - 'apps/web/src/views/approval/ApprovalCenterTable.vue'
       - 'apps/web/tests/approvalMobileI18n.spec.ts'
       - 'apps/web/tests/approvalMobileResponsive.spec.ts'
+      - 'apps/web/tests/approvalCenterTable.spec.ts'
       # UF-3 — status-color convergence: the shared StatusTag/statusDomains map now renders the
       # approvalInstance status tag (ApprovalCenterView/ApprovalMobileList/ApprovalDetailView
       # header/ApprovalInboxView) and the delegation status tag (MyDelegationView/
@@ -219,4 +223,9 @@ jobs:
         # UF-3b: approvalTemplate status domain — statusTag's new domain cases (published/draft/
         # archived tone+label) and approval-e2e-permissions (TemplateDetailView header StatusTag
         # regression via data-status selector; had no gate before this wiring, 40 tests).
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions --reporter=dot
+        # UF-5: ApprovalCenterTable — the shared table body ApprovalCenterView's four tabs all
+        # render now (had no gate before this wiring); approvalCenterTable.spec.ts locks column
+        # rendering from `rows`, row-click/selection-change re-emission, the per-tab difference
+        # props (showSelection/selectable/showWaitColumn/actionsWidth), the `actions` slot
+        # presence/absence toggling the 操作 column, and the empty state.
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable --reporter=dot

--- a/apps/web/src/views/approval/ApprovalCenterTable.vue
+++ b/apps/web/src/views/approval/ApprovalCenterTable.vue
@@ -1,0 +1,192 @@
+<template>
+  <el-table
+    ref="tableRef"
+    v-loading="loading"
+    :data="rows"
+    size="default"
+    style="width: 100%"
+    max-height="560"
+    stripe
+    highlight-current-row
+    :row-key="showSelection ? resolveRowKey : undefined"
+    @row-click="$emit('row-click', $event)"
+    @selection-change="$emit('selection-change', $event)"
+  >
+    <el-table-column
+      v-if="showSelection"
+      type="selection"
+      width="44"
+      :selectable="selectable"
+    />
+    <el-table-column prop="requestNo" label="审批编号" width="180" />
+    <el-table-column label="标题" min-width="200">
+      <!-- B2-01: key-field summary — a muted second line under the title so common items are
+           decidable without opening (see useApprovalListFieldSummary.ts, owned by the parent
+           view and passed down here as a resolved `summaryLineFor(row)` function since its
+           template-schema cache is shared across all four tabs). -->
+      <template #default="{ row }: { row: UnifiedApprovalDTO }">
+        {{ row.title }}
+        <div
+          v-if="summaryLineFor(row)"
+          class="approval-center__row-summary"
+          :title="summaryLineFor(row)"
+        >
+          {{ summaryLineFor(row) }}
+        </div>
+      </template>
+    </el-table-column>
+    <el-table-column label="发起人" width="120">
+      <template #default="{ row }: { row: UnifiedApprovalDTO }">
+        {{ row.requester?.name ?? '-' }}
+      </template>
+    </el-table-column>
+    <el-table-column label="状态" width="100">
+      <template #default="{ row }: { row: UnifiedApprovalDTO }">
+        <StatusTag domain="approvalInstance" :status="row.status" />
+      </template>
+    </el-table-column>
+    <el-table-column label="发起时间" width="180">
+      <template #default="{ row }: { row: UnifiedApprovalDTO }">
+        {{ formatDate(row.createdAt) }}
+      </template>
+    </el-table-column>
+    <!-- B1-03 (part 2): 已等待 aging — glanceable severity (>3d warn / >7d urgent), pending-tab
+         only. The 第 X/Y 步 sub-line only renders when both numbers are present. -->
+    <el-table-column v-if="showWaitColumn" label="已等待" width="140">
+      <template #default="{ row }: { row: UnifiedApprovalDTO }">
+        <span :class="waitClass(row.createdAt)">{{ formatRelativeWait(row.createdAt) }}</span>
+        <div
+          v-if="row.currentStep != null && row.totalSteps != null"
+          class="approval-center__wait-progress"
+        >
+          第 {{ row.currentStep }}/{{ row.totalSteps }} 步
+        </div>
+      </template>
+    </el-table-column>
+    <!-- Per-tab action column content differs materially (pending: inline approve/reject;
+         mine: 已等待 hint + 催办; cc/completed: none) so the parent supplies it via slot rather
+         than four boolean props; omitting the slot omits the column entirely (cc/completed). -->
+    <el-table-column v-if="$slots.actions" label="操作" :width="actionsWidth" fixed="right">
+      <template #default="{ row }: { row: UnifiedApprovalDTO }">
+        <slot name="actions" :row="row" />
+      </template>
+    </el-table-column>
+    <template #empty>
+      <el-empty :description="emptyText" :image-size="100" />
+    </template>
+  </el-table>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { UnifiedApprovalDTO } from '../../types/approval'
+import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
+import StatusTag from '../../components/status/StatusTag.vue'
+
+// UF-5 (ui-foundation-design-lock-20260706.md §6): the shared table body behind ApprovalCenterView's
+// four tabs (待我处理/我发起的/抄送我的/已完成), which previously each hand-rolled the same
+// ~90-line `<el-table>` block (编号/标题/发起人/状态/发起时间/操作 columns) with copy-paste drift
+// risk. Column set here is the UNION of what the four originals rendered; per-tab visibility is
+// gated ONLY where the originals genuinely differed:
+//   - selection column + row-key + `selection-change` — pending only (batch approve/reject)
+//   - 已等待 column — pending only (mine's own 已等待 hint lives inside its `actions` slot content)
+//   - 操作 column — pending (approve/reject) and mine (催办) supply an `actions` slot; cc/completed
+//     supply none, so the column itself does not render (mirrors the originals having NO 操作
+//     column at all on those two tabs)
+// Presentation-only: every data-testid, handler, and event lives in the parent's slot content /
+// prop wiring, unchanged.
+withDefaults(
+  defineProps<{
+    rows: UnifiedApprovalDTO[]
+    loading: boolean
+    emptyText: string
+    /** Renders the selection column + enables `row-key`; pending tab only. */
+    showSelection?: boolean
+    /** `:selectable` predicate for the selection column (only consulted when `showSelection`). */
+    selectable?: (row: UnifiedApprovalDTO) => boolean
+    /** Renders the 已等待 aging column; pending tab only. */
+    showWaitColumn?: boolean
+    /** Width of the 操作 column when the `actions` slot is supplied (pending 150 / mine 170). */
+    actionsWidth?: string | number
+    /** Shared row-summary lookup owned by the parent (see useApprovalListFieldSummary.ts). */
+    summaryLineFor: (row: UnifiedApprovalDTO) => string
+  }>(),
+  {
+    showSelection: false,
+    selectable: undefined,
+    showWaitColumn: false,
+    actionsWidth: 150,
+  },
+)
+
+defineEmits<{
+  (e: 'row-click', row: UnifiedApprovalDTO): void
+  (e: 'selection-change', rows: UnifiedApprovalDTO[]): void
+}>()
+
+const tableRef = ref<{ clearSelection: () => void } | null>(null)
+
+// Only ever bound when `showSelection` is true (the other three tabs never had a `row-key`
+// attribute on their `<el-table>` at all).
+function resolveRowKey(row: UnifiedApprovalDTO): string {
+  return row.id
+}
+
+function formatDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return '-'
+  return new Date(dateStr).toLocaleString('zh-CN')
+}
+
+// B1-03: 已等待 aging severity class — shared by the 已等待 column above.
+function waitClass(createdAt: string): string {
+  return `approval-center__wait approval-center__wait--${waitSeverity(createdAt)}`
+}
+
+// Exposed so the parent's existing `pendingTableRef.value?.clearSelection()` guard keeps working
+// unchanged against this wrapper (the parent still only attaches its ref to the pending tab's
+// instance of this component).
+defineExpose({
+  clearSelection: () => {
+    if (typeof tableRef.value?.clearSelection === 'function') {
+      tableRef.value.clearSelection()
+    }
+  },
+})
+</script>
+
+<style scoped>
+/* B2-01: key-field summary line — muted, single-line, ellipsis-truncated so a long value never
+   wraps the row or blows out the column width; the full text stays reachable via the native
+   `:title` tooltip. */
+.approval-center__row-summary {
+  margin-top: 2px;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  color: #909399;
+}
+
+/* B1-03: 已等待 aging severity — normal inherits the surrounding text color; warn/urgent escalate. */
+.approval-center__wait {
+  display: inline-block;
+  margin-right: 8px;
+  font-size: 13px;
+  color: #606266;
+}
+
+.approval-center__wait--warn {
+  color: #e6a23c;
+}
+
+.approval-center__wait--urgent {
+  color: #f56c6c;
+}
+
+.approval-center__wait-progress {
+  margin-top: 2px;
+  font-size: 12px;
+  color: #909399;
+}
+</style>

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -7,7 +7,7 @@
             v-model="searchText"
             placeholder="搜索审批编号或标题"
             clearable
-            style="width: 240px"
+            class="approval-center__toolbar-search"
             @clear="handleSearch"
             @keyup.enter="handleSearch"
           >
@@ -19,7 +19,7 @@
             v-model="statusFilter"
             placeholder="状态筛选"
             clearable
-            style="width: 140px; margin-left: 12px"
+            class="approval-center__toolbar-select"
             @change="handleSearch"
           >
             <el-option label="待处理" value="pending" />
@@ -30,7 +30,7 @@
           <el-select
             v-model="sourceSystemFilter"
             placeholder="来源系统"
-            style="width: 140px; margin-left: 12px"
+            class="approval-center__toolbar-select"
             data-testid="approval-source-filter"
             @change="handleSourceSystemChange"
           >
@@ -41,7 +41,7 @@
           <el-button
             v-if="canWrite"
             type="primary"
-            style="margin-left: 12px"
+            class="approval-center__toolbar-button"
             @click="router.push({ name: 'approval-template-list' })"
           >
             发起审批
@@ -156,115 +156,57 @@
           :template-schemas="templateSchemas"
           @select="handleRowClick"
         />
-        <el-table
+        <ApprovalCenterTable
           v-else
           ref="pendingTableRef"
-          v-loading="store.loading"
-          :data="store.pendingApprovals"
-          style="width: 100%"
-          max-height="560"
-          stripe
-          highlight-current-row
-          :row-key="rowKey"
+          :rows="store.pendingApprovals"
+          :loading="store.loading"
+          :empty-text="searchText ? '未找到匹配的审批' : '暂无待处理审批'"
+          :summary-line-for="summaryLineFor"
+          show-selection
+          :selectable="isRowBatchSelectable"
+          show-wait-column
+          :actions-width="150"
           @row-click="handleRowClick"
           @selection-change="handlePendingSelectionChange"
         >
-          <el-table-column
-            type="selection"
-            width="44"
-            :selectable="isRowBatchSelectable"
-          />
-          <el-table-column prop="requestNo" label="审批编号" width="180" />
-          <el-table-column label="标题" min-width="200">
-            <!-- B2-01: key-field summary — a muted second line under the title so common items
-                 are decidable without opening (top 2-3 non-attachment/non-detail leaf fields from
-                 the LIVE template schema; see useApprovalListFieldSummary.ts for the live-label
-                 drift caveat). Absent for rows with no templateId or no cached schema yet. -->
-            <template #default="{ row }">
-              {{ row.title }}
-              <div
-                v-if="summaryLineFor(row)"
-                class="approval-center__row-summary"
-                :title="summaryLineFor(row)"
-              >
-                {{ summaryLineFor(row) }}
-              </div>
-            </template>
-          </el-table-column>
-          <el-table-column label="发起人" width="120">
-            <template #default="{ row }">
-              {{ row.requester?.name ?? '-' }}
-            </template>
-          </el-table-column>
-          <el-table-column label="状态" width="100">
-            <template #default="{ row }">
-              <StatusTag domain="approvalInstance" :status="row.status" />
-            </template>
-          </el-table-column>
-          <el-table-column label="发起时间" width="180">
-            <template #default="{ row }">
-              {{ formatDate(row.createdAt) }}
-            </template>
-          </el-table-column>
-          <!-- B1-03 (part 2): 已等待 aging — glanceable severity (>3d warn / >7d urgent) so a
-               reviewer can triage the oldest requests first. The 第 X/Y 步 sub-line only renders
-               when both numbers are present (mirrors ApprovalDetailView's "进度" meta item). -->
-          <el-table-column label="已等待" width="140">
-            <template #default="{ row }">
-              <span :class="waitClass(row.createdAt)">{{ formatRelativeWait(row.createdAt) }}</span>
-              <div
-                v-if="row.currentStep != null && row.totalSteps != null"
-                class="approval-center__wait-progress"
-              >
-                第 {{ row.currentStep }}/{{ row.totalSteps }} 步
-              </div>
-            </template>
-          </el-table-column>
           <!-- B1-03 (part 1): inline approve/reject hot path — only for platform-native pending
                rows (reuses `isRowBatchSelectable`; attendance-bridged rows keep routing to the
                attendance module via row-click and never show these). @click.stop on every
                reference so opening the popconfirm / reject dialog never also navigates the row. -->
-          <el-table-column label="操作" width="150" fixed="right">
-            <template #default="{ row }">
-              <template v-if="isRowBatchSelectable(row)">
-                <el-popconfirm
-                  :title="`确认通过「${row.title}」？`"
-                  confirm-button-text="确认"
-                  cancel-button-text="取消"
-                  @confirm="handleInlineApprove(row)"
-                >
-                  <template #reference>
-                    <el-button
-                      type="primary"
-                      link
-                      :loading="inlineApprovingId === row.id"
-                      :disabled="inlineApprovingId !== null"
-                      :data-testid="`approval-row-approve-${row.id}`"
-                      @click.stop
-                    >
-                      通过
-                    </el-button>
-                  </template>
-                </el-popconfirm>
-                <el-button
-                  type="danger"
-                  link
-                  :disabled="inlineApprovingId !== null"
-                  :data-testid="`approval-row-reject-${row.id}`"
-                  @click.stop="openRowReject(row)"
-                >
-                  驳回
-                </el-button>
-              </template>
+          <template #actions="{ row }">
+            <template v-if="isRowBatchSelectable(row)">
+              <el-popconfirm
+                :title="`确认通过「${row.title}」？`"
+                confirm-button-text="确认"
+                cancel-button-text="取消"
+                @confirm="handleInlineApprove(row)"
+              >
+                <template #reference>
+                  <el-button
+                    type="primary"
+                    link
+                    :loading="inlineApprovingId === row.id"
+                    :disabled="inlineApprovingId !== null"
+                    :data-testid="`approval-row-approve-${row.id}`"
+                    @click.stop
+                  >
+                    通过
+                  </el-button>
+                </template>
+              </el-popconfirm>
+              <el-button
+                type="danger"
+                link
+                :disabled="inlineApprovingId !== null"
+                :data-testid="`approval-row-reject-${row.id}`"
+                @click.stop="openRowReject(row)"
+              >
+                驳回
+              </el-button>
             </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty
-              :description="searchText ? '未找到匹配的审批' : '暂无待处理审批'"
-              :image-size="100"
-            />
           </template>
-        </el-table>
+        </ApprovalCenterTable>
         <el-pagination
           class="approval-center__pagination"
           background
@@ -285,77 +227,36 @@
           :template-schemas="templateSchemas"
           @select="handleRowClick"
         />
-        <el-table
+        <ApprovalCenterTable
           v-else
-          v-loading="store.loading"
-          :data="store.myApprovals"
-          style="width: 100%"
-          max-height="560"
-          stripe
-          highlight-current-row
+          :rows="store.myApprovals"
+          :loading="store.loading"
+          :empty-text="searchText ? '未找到匹配的审批' : '暂无我发起的审批'"
+          :summary-line-for="summaryLineFor"
+          :actions-width="170"
           @row-click="handleRowClick"
         >
-          <el-table-column prop="requestNo" label="审批编号" width="180" />
-          <el-table-column label="标题" min-width="200">
-            <!-- B2-01: key-field summary — a muted second line under the title so common items
-                 are decidable without opening (top 2-3 non-attachment/non-detail leaf fields from
-                 the LIVE template schema; see useApprovalListFieldSummary.ts for the live-label
-                 drift caveat). Absent for rows with no templateId or no cached schema yet. -->
-            <template #default="{ row }">
-              {{ row.title }}
-              <div
-                v-if="summaryLineFor(row)"
-                class="approval-center__row-summary"
-                :title="summaryLineFor(row)"
-              >
-                {{ summaryLineFor(row) }}
-              </div>
-            </template>
-          </el-table-column>
-          <el-table-column label="发起人" width="120">
-            <template #default="{ row }">
-              {{ row.requester?.name ?? '-' }}
-            </template>
-          </el-table-column>
-          <el-table-column label="状态" width="100">
-            <template #default="{ row }">
-              <StatusTag domain="approvalInstance" :status="row.status" />
-            </template>
-          </el-table-column>
-          <el-table-column label="发起时间" width="180">
-            <template #default="{ row }">
-              {{ formatDate(row.createdAt) }}
-            </template>
-          </el-table-column>
           <!-- 催办: a requester nudge to the current approver, only meaningful while the instance is
                still pending. Server-side rate-limited (1/instance/user/hour); 429 surfaces gracefully.
                B1-03: 已等待 sits right next to it — the longer a request has waited, the more it
                motivates the requester to actually click 催办. -->
-          <el-table-column label="操作" width="170" fixed="right">
-            <template #default="{ row }">
-              <span v-if="row.status === 'pending'" :class="waitClass(row.createdAt)">
-                已等待 {{ formatRelativeWait(row.createdAt) }}
-              </span>
-              <el-button
-                v-if="row.status === 'pending'"
-                type="primary"
-                link
-                :loading="remindingId === row.id"
-                :disabled="remindingId !== null"
-                :data-testid="`approval-urge-${row.id}`"
-                @click.stop="handleUrge(row)"
-              >
-                催办
-              </el-button>
-            </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty
-              :description="searchText ? '未找到匹配的审批' : '暂无我发起的审批'"
-              :image-size="100"
-            />
+          <template #actions="{ row }">
+            <span v-if="row.status === 'pending'" :class="waitClass(row.createdAt)">
+              已等待 {{ formatRelativeWait(row.createdAt) }}
+            </span>
+            <el-button
+              v-if="row.status === 'pending'"
+              type="primary"
+              link
+              :loading="remindingId === row.id"
+              :disabled="remindingId !== null"
+              :data-testid="`approval-urge-${row.id}`"
+              @click.stop="handleUrge(row)"
+            >
+              催办
+            </el-button>
           </template>
-        </el-table>
+        </ApprovalCenterTable>
         <el-pagination
           class="approval-center__pagination"
           background
@@ -376,55 +277,14 @@
           :template-schemas="templateSchemas"
           @select="handleRowClick"
         />
-        <el-table
+        <ApprovalCenterTable
           v-else
-          v-loading="store.loading"
-          :data="store.ccApprovals"
-          style="width: 100%"
-          max-height="560"
-          stripe
-          highlight-current-row
+          :rows="store.ccApprovals"
+          :loading="store.loading"
+          :empty-text="searchText ? '未找到匹配的审批' : '暂无抄送我的审批'"
+          :summary-line-for="summaryLineFor"
           @row-click="handleRowClick"
-        >
-          <el-table-column prop="requestNo" label="审批编号" width="180" />
-          <el-table-column label="标题" min-width="200">
-            <!-- B2-01: key-field summary — a muted second line under the title so common items
-                 are decidable without opening (top 2-3 non-attachment/non-detail leaf fields from
-                 the LIVE template schema; see useApprovalListFieldSummary.ts for the live-label
-                 drift caveat). Absent for rows with no templateId or no cached schema yet. -->
-            <template #default="{ row }">
-              {{ row.title }}
-              <div
-                v-if="summaryLineFor(row)"
-                class="approval-center__row-summary"
-                :title="summaryLineFor(row)"
-              >
-                {{ summaryLineFor(row) }}
-              </div>
-            </template>
-          </el-table-column>
-          <el-table-column label="发起人" width="120">
-            <template #default="{ row }">
-              {{ row.requester?.name ?? '-' }}
-            </template>
-          </el-table-column>
-          <el-table-column label="状态" width="100">
-            <template #default="{ row }">
-              <StatusTag domain="approvalInstance" :status="row.status" />
-            </template>
-          </el-table-column>
-          <el-table-column label="发起时间" width="180">
-            <template #default="{ row }">
-              {{ formatDate(row.createdAt) }}
-            </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty
-              :description="searchText ? '未找到匹配的审批' : '暂无抄送我的审批'"
-              :image-size="100"
-            />
-          </template>
-        </el-table>
+        />
         <el-pagination
           class="approval-center__pagination"
           background
@@ -445,55 +305,14 @@
           :template-schemas="templateSchemas"
           @select="handleRowClick"
         />
-        <el-table
+        <ApprovalCenterTable
           v-else
-          v-loading="store.loading"
-          :data="store.completedApprovals"
-          style="width: 100%"
-          max-height="560"
-          stripe
-          highlight-current-row
+          :rows="store.completedApprovals"
+          :loading="store.loading"
+          :empty-text="searchText ? '未找到匹配的审批' : '暂无已完成审批'"
+          :summary-line-for="summaryLineFor"
           @row-click="handleRowClick"
-        >
-          <el-table-column prop="requestNo" label="审批编号" width="180" />
-          <el-table-column label="标题" min-width="200">
-            <!-- B2-01: key-field summary — a muted second line under the title so common items
-                 are decidable without opening (top 2-3 non-attachment/non-detail leaf fields from
-                 the LIVE template schema; see useApprovalListFieldSummary.ts for the live-label
-                 drift caveat). Absent for rows with no templateId or no cached schema yet. -->
-            <template #default="{ row }">
-              {{ row.title }}
-              <div
-                v-if="summaryLineFor(row)"
-                class="approval-center__row-summary"
-                :title="summaryLineFor(row)"
-              >
-                {{ summaryLineFor(row) }}
-              </div>
-            </template>
-          </el-table-column>
-          <el-table-column label="发起人" width="120">
-            <template #default="{ row }">
-              {{ row.requester?.name ?? '-' }}
-            </template>
-          </el-table-column>
-          <el-table-column label="状态" width="100">
-            <template #default="{ row }">
-              <StatusTag domain="approvalInstance" :status="row.status" />
-            </template>
-          </el-table-column>
-          <el-table-column label="发起时间" width="180">
-            <template #default="{ row }">
-              {{ formatDate(row.createdAt) }}
-            </template>
-          </el-table-column>
-          <template #empty>
-            <el-empty
-              :description="searchText ? '未找到匹配的审批' : '暂无已完成审批'"
-              :image-size="100"
-            />
-          </template>
-        </el-table>
+        />
         <el-pagination
           class="approval-center__pagination"
           background
@@ -635,9 +454,9 @@ import { useMobileViewport } from '../../composables/useMobileViewport'
 import { useLocale } from '../../composables/useLocale'
 import { formatRelativeWait, waitSeverity } from '../../approvals/relativeWait'
 import ApprovalMobileList from './ApprovalMobileList.vue'
+import ApprovalCenterTable from './ApprovalCenterTable.vue'
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
-import StatusTag from '../../components/status/StatusTag.vue'
 
 const router = useRouter()
 const store = useApprovalStore()
@@ -703,14 +522,11 @@ const batchRejectDialogVisible = ref(false)
 const batchRejectComment = ref('')
 const remindingId = ref<string | null>(null)
 
-// B1-03: 已等待 aging severity class — shared by the pending table's column and the 我发起的
-// tab's inline hint next to 催办 (same warn/urgent palette everywhere it appears).
+// B1-03: 已等待 aging severity class — the 我发起的 tab's inline hint next to 催办 (same
+// warn/urgent palette as ApprovalCenterTable's own internal 已等待 column, kept separate since
+// this one lives in this view's `actions` slot content rather than the shared table body).
 function waitClass(createdAt: string): string {
   return `approval-center__wait approval-center__wait--${waitSeverity(createdAt)}`
-}
-
-function rowKey(row: UnifiedApprovalDTO): string {
-  return row.id
 }
 
 // Only platform-native pending rows are batch-actionable here; attendance-backed approvals live in the
@@ -999,10 +815,8 @@ const attendanceRequestsSection = 'attendance-overview-requests'
 // utils/statusDomains.ts) — the local statusTagType/statusLabel maps this file used to declare
 // were one of six independent status-color implementations audited in the UI foundation
 // design-lock and are removed here.
-function formatDate(dateStr: string) {
-  if (!dateStr) return '-'
-  return new Date(dateStr).toLocaleString('zh-CN')
-}
+// UF-5: the per-row `发起时间` date formatter moved into ApprovalCenterTable.vue along with the
+// table markup that was its only caller.
 
 // ---------------------------------------------------------------------------
 // Handlers
@@ -1102,6 +916,15 @@ onMounted(() => {
 .approval-center__toolbar {
   display: flex;
   align-items: center;
+  gap: var(--ms-space-3);
+}
+
+.approval-center__toolbar-search {
+  width: 240px;
+}
+
+.approval-center__toolbar-select {
+  width: 140px;
 }
 
 .approval-center__error {
@@ -1162,25 +985,6 @@ onMounted(() => {
 
 .approval-center__wait--urgent {
   color: #f56c6c;
-}
-
-.approval-center__wait-progress {
-  margin-top: 2px;
-  font-size: 12px;
-  color: #909399;
-}
-
-/* B2-01: key-field summary line — muted, single-line, ellipsis-truncated so a long value never
-   wraps the row or blows out the column width; the full text is still available via the native
-   `:title` tooltip. */
-.approval-center__row-summary {
-  margin-top: 2px;
-  max-width: 100%;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  font-size: 12px;
-  color: #909399;
 }
 
 .approval-center__row-reject-summary {
@@ -1270,17 +1074,16 @@ onMounted(() => {
 @media (max-width: 768px) {
   .approval-center__toolbar {
     flex-wrap: wrap;
-    gap: 8px;
+    gap: var(--ms-space-2);
   }
 
-  .approval-center__toolbar :deep(.el-input),
-  .approval-center__toolbar :deep(.el-select) {
-    width: 100% !important;
-    margin-left: 0 !important;
-  }
-
-  .approval-center__toolbar :deep(.el-button) {
-    margin-left: 0 !important;
+  /* UF-5: these three classes previously carried the fixed desktop widths as inline `style=`
+     attributes, which forced the `!important` overrides below (an inline style always wins over
+     a plain class rule). Now that the width lives in a class rule of ordinary specificity, this
+     media-query rule (declared later in the cascade) overrides it without `!important`. */
+  .approval-center__toolbar-search,
+  .approval-center__toolbar-select,
+  .approval-center__toolbar-button {
     width: 100%;
   }
 

--- a/apps/web/tests/approvalCenterTable.spec.ts
+++ b/apps/web/tests/approvalCenterTable.spec.ts
@@ -1,0 +1,335 @@
+/**
+ * UF-5 (ui-foundation-design-lock-20260706.md §6): ApprovalCenterTable.vue is the shared table
+ * body ApprovalCenterView's four tabs (待我处理/我发起的/抄送我的/已完成) all render, replacing
+ * four near-identical ~90-line `<el-table>` blocks. This spec exercises the component directly
+ * (not through ApprovalCenterView) — column rendering from `rows`, event re-emission, the four
+ * per-tab difference props (`showSelection` / `selectable` / `showWaitColumn` / `actions` slot),
+ * and the empty state.
+ *
+ * Uses the same Element Plus registry-stub pattern as `approval-center.spec.ts` (ElTableColumn
+ * children register their `#default="{ row }"` slot into a shared registry; ElTable then walks
+ * `data` × registry to emit real per-row markup) so scoped-slot content is genuinely exercised
+ * rather than just counting placeholder divs. `StatusTag` is left un-stubbed — it is
+ * Element-Plus-free (see components/status/StatusTag.vue) and resolves via ApprovalCenterTable's
+ * own local import regardless of what is globally registered.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createApp,
+  defineComponent,
+  h,
+  inject,
+  nextTick,
+  provide,
+  reactive,
+  type App as VueApp,
+  type Slot,
+} from 'vue'
+import type { UnifiedApprovalDTO } from '../src/types/approval'
+
+type ColumnRegistryEntry = {
+  key: string
+  type?: string
+  prop?: string
+  label?: string
+  defaultSlot?: Slot
+}
+type ColumnRegistry = {
+  columns: ColumnRegistryEntry[]
+  register: (entry: ColumnRegistryEntry) => void
+}
+const COLUMN_REGISTRY_KEY = Symbol('el-table-columns')
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: {
+    data: Array,
+    loading: Boolean,
+    size: String,
+    stripe: Boolean,
+    highlightCurrentRow: Boolean,
+    maxHeight: [String, Number],
+    rowKey: [String, Function],
+  },
+  emits: ['row-click', 'selection-change'],
+  setup(props, { slots, emit }) {
+    const registry = reactive<ColumnRegistry>({
+      columns: [],
+      register(entry) {
+        registry.columns.push(entry)
+      },
+    })
+    provide(COLUMN_REGISTRY_KEY, registry)
+    return () => {
+      const columnInstances = slots.default?.() ?? []
+      const rows = (props.data as UnifiedApprovalDTO[] | undefined) ?? []
+      if (rows.length === 0) {
+        return h('div', { 'data-el-table': 'true' }, [
+          h('div', { style: 'display:none' }, columnInstances),
+          h('div', { 'data-el-table-empty': 'true' }, slots.empty?.()),
+        ])
+      }
+      return h('div', { 'data-el-table': 'true' }, [
+        h('div', { style: 'display:none' }, columnInstances),
+        ...rows.map((row, i) =>
+          h(
+            'div',
+            {
+              'data-el-row': (row?.id as string | undefined) ?? String(i),
+              key: (row?.id as string | undefined) ?? String(i),
+              onClick: () => emit('row-click', row),
+            },
+            registry.columns.map((col) =>
+              h(
+                'div',
+                { 'data-el-cell': col.type === 'selection' ? 'selection' : (col.prop || col.label || col.key) },
+                // Real el-table auto-renders `row[prop]` for a column with a bare `prop` and no
+                // scoped `#default` slot (e.g. `requestNo` below) — replicate that fallback.
+                col.defaultSlot ? col.defaultSlot({ row }) : (col.prop ? String((row as any)[col.prop] ?? '') : null),
+              ),
+            ),
+          ),
+        ),
+        h('button', {
+          type: 'button',
+          'data-testid': 'test-select-all-rows',
+          onClick: () => emit('selection-change', rows),
+        }, 'select-all'),
+      ])
+    }
+  },
+})
+
+let columnSeq = 0
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: {
+    prop: String,
+    label: String,
+    width: [String, Number],
+    minWidth: [String, Number],
+    fixed: String,
+    type: String,
+    selectable: Function,
+  },
+  setup(props, { slots }) {
+    const registry = inject<ColumnRegistry | null>(COLUMN_REGISTRY_KEY, null)
+    if (registry) {
+      registry.register({
+        key: `col-${columnSeq++}`,
+        type: props.type,
+        prop: props.prop,
+        label: props.label,
+        defaultSlot: slots.default,
+      })
+    }
+    return () => null
+  },
+})
+
+const ElEmpty = defineComponent({
+  name: 'ElEmpty',
+  props: { description: String, imageSize: Number },
+  render() {
+    return h('div', { 'data-el-empty': 'true' }, this.description)
+  },
+})
+
+const stubDirective = { mounted() {}, updated() {} }
+
+async function flushUi(cycles = 3): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function buildRow(overrides: Partial<UnifiedApprovalDTO> = {}): UnifiedApprovalDTO {
+  return {
+    id: 'apv_1',
+    sourceSystem: 'platform',
+    externalApprovalId: null,
+    workflowKey: null,
+    businessKey: null,
+    title: '出差报销',
+    status: 'pending',
+    requester: { name: '张三' } as any,
+    subject: null,
+    policy: null,
+    currentStep: null,
+    totalSteps: null,
+    requestNo: 'AP-100001',
+    createdAt: '2026-04-10T08:00:00Z',
+    ...overrides,
+  } as UnifiedApprovalDTO
+}
+
+describe('ApprovalCenterTable', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    columnSeq = 0
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  async function mountTable(
+    props: Record<string, unknown>,
+    slots: Record<string, (scope: any) => unknown> = {},
+  ) {
+    const { default: ApprovalCenterTable } = await import('../src/views/approval/ApprovalCenterTable.vue')
+    const Host = defineComponent({
+      setup() {
+        return () => h(ApprovalCenterTable as any, props, slots)
+      },
+    })
+    app = createApp(Host)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElEmpty', ElEmpty)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+    return app
+  }
+
+  it('renders columns from rows (requestNo/title/requester/status/createdAt)', async () => {
+    const rows = [buildRow()]
+    await mountTable({
+      rows,
+      loading: false,
+      emptyText: '暂无待处理审批',
+      summaryLineFor: () => '',
+    })
+
+    const row = container!.querySelector('[data-el-row="apv_1"]')!
+    expect(row.querySelector('[data-el-cell="requestNo"]')?.textContent).toContain('AP-100001')
+    expect(row.querySelector('[data-el-cell="标题"]')?.textContent).toContain('出差报销')
+    expect(row.querySelector('[data-el-cell="发起人"]')?.textContent).toContain('张三')
+    expect(row.querySelector('[data-el-cell="发起时间"]')?.textContent?.trim().length).toBeGreaterThan(0)
+
+    // StatusTag is real (Element-Plus-free) — asserts through its own data attributes.
+    const statusTag = row.querySelector('[data-el-cell="状态"] .ms-status-tag')
+    expect(statusTag?.getAttribute('data-domain')).toBe('approvalInstance')
+    expect(statusTag?.getAttribute('data-status')).toBe('pending')
+
+    // No selection column, no 已等待 column, no 操作 column by default.
+    expect(row.querySelector('[data-el-cell="selection"]')).toBeNull()
+    expect(row.querySelector('[data-el-cell="已等待"]')).toBeNull()
+    expect(container!.querySelector('[data-el-cell="操作"]')).toBeNull()
+  })
+
+  it('renders the B2-01 row-summary line only when summaryLineFor returns non-empty', async () => {
+    const rows = [buildRow()]
+    await mountTable({
+      rows,
+      loading: false,
+      emptyText: 'empty',
+      summaryLineFor: (row: UnifiedApprovalDTO) => (row.id === 'apv_1' ? '请假类型：年假' : ''),
+    })
+    const summary = container!.querySelector('[data-el-cell="标题"] .approval-center__row-summary')
+    expect(summary?.textContent?.trim()).toBe('请假类型：年假')
+  })
+
+  it('emits row-click with the clicked row', async () => {
+    const rows = [buildRow(), buildRow({ id: 'apv_2', requestNo: 'AP-100002' })]
+    let clicked: UnifiedApprovalDTO | null = null
+    // Vue maps an `onRowClick` prop key to a listener for the `row-click` emit.
+    await mountTable({
+      rows,
+      loading: false,
+      emptyText: 'empty',
+      summaryLineFor: () => '',
+      onRowClick: (row: UnifiedApprovalDTO) => { clicked = row },
+    })
+
+    ;(container!.querySelector('[data-el-row="apv_2"]') as HTMLElement).click()
+    await flushUi()
+    expect(clicked).not.toBeNull()
+    expect((clicked as unknown as UnifiedApprovalDTO).id).toBe('apv_2')
+  })
+
+  it('emits selection-change with the raw row set (unfiltered — caller applies its own predicate)', async () => {
+    const rows = [buildRow(), buildRow({ id: 'apv_2' })]
+    let selected: UnifiedApprovalDTO[] | null = null
+    await mountTable({
+      rows,
+      loading: false,
+      emptyText: 'empty',
+      summaryLineFor: () => '',
+      showSelection: true,
+      selectable: (row: UnifiedApprovalDTO) => row.id === 'apv_1',
+      onSelectionChange: (r: UnifiedApprovalDTO[]) => { selected = r },
+    })
+
+    ;(container!.querySelector('[data-testid="test-select-all-rows"]') as HTMLElement).click()
+    await flushUi()
+    expect(selected).not.toBeNull()
+    expect((selected as unknown as UnifiedApprovalDTO[]).map((r) => r.id)).toEqual(['apv_1', 'apv_2'])
+  })
+
+  it('showSelection renders the selection column (pending-tab shape)', async () => {
+    const rows = [buildRow()]
+    await mountTable({
+      rows,
+      loading: false,
+      emptyText: 'empty',
+      summaryLineFor: () => '',
+      showSelection: true,
+      selectable: () => true,
+    })
+    expect(container!.querySelector('[data-el-cell="selection"]')).not.toBeNull()
+  })
+
+  it('showWaitColumn renders the 已等待 column with severity class + step progress (pending-tab shape)', async () => {
+    const rows = [buildRow({
+      createdAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+      currentStep: 2,
+      totalSteps: 3,
+    })]
+    await mountTable({
+      rows,
+      loading: false,
+      emptyText: 'empty',
+      summaryLineFor: () => '',
+      showWaitColumn: true,
+    })
+    const cell = container!.querySelector('[data-el-cell="已等待"]')
+    expect(cell?.textContent).toContain('8 天')
+    expect(cell?.textContent).toContain('第 2/3 步')
+    expect(cell?.querySelector('.approval-center__wait--urgent')).toBeTruthy()
+  })
+
+  it('the actions slot renders the 操作 column; omitting the slot omits the column (cc/completed-tab shape)', async () => {
+    const rows = [buildRow()]
+    await mountTable(
+      { rows, loading: false, emptyText: 'empty', summaryLineFor: () => '' },
+      { actions: ({ row }: { row: UnifiedApprovalDTO }) => h('button', { 'data-testid': `act-${row.id}` }, '通过') },
+    )
+    expect(container!.querySelector('[data-el-cell="操作"] [data-testid="act-apv_1"]')).not.toBeNull()
+
+    if (app) app.unmount()
+    container!.innerHTML = ''
+    await mountTable({ rows, loading: false, emptyText: 'empty', summaryLineFor: () => '' })
+    expect(container!.querySelector('[data-el-cell="操作"]')).toBeNull()
+  })
+
+  it('renders the empty state via el-empty with the caller-supplied emptyText', async () => {
+    await mountTable({
+      rows: [],
+      loading: false,
+      emptyText: '暂无我发起的审批',
+      summaryLineFor: () => '',
+    })
+    const empty = container!.querySelector('[data-el-table-empty] [data-el-empty]')
+    expect(empty?.textContent).toBe('暂无我发起的审批')
+  })
+})


### PR DESCRIPTION
Implements **UF-5** of the UI foundation design-lock (UF-1..3 + 3b landed/landing).

## What
- **`ApprovalCenterTable.vue`** (new, view-local child): ONE table renders all four tabs. Real per-tab differences (diffed honestly, listed in commit body) modeled as narrow props + one `actions` scoped slot:
  - selection column + row-key + aging column → pending tab only
  - 操作 column = scoped slot; tabs without one supply no slot and the column is omitted entirely (`v-if="$slots.actions"`)
  - per-tab empty text + action-column width
- **−298 lines of duplicated table markup** deleted from ApprovalCenterView (net: 4 blocks → 1 component + 4 thin call sites).
- Toolbar inline `style=` → `--ms-space` token classes, which lets the ≤768px media query **drop its `!important` overrides entirely** (cascade now wins naturally).
- Zero-behavior discipline: kept the exact pre-existing class names (`approval-center__wait--urgent` etc.) inside the child's scoped styles so **all 7 pre-existing spec files pass unmodified**.

## Verification
- `vue-tsc -b` 0 · production build green
- **103/103** across 8 spec files (7 pre-existing unmodified + new `approvalCenterTable.spec.ts` 8 tests)
- Mutation self-check: neutering the `v-if="$slots.actions"` guard turns 2 assertions red (restored, diff-clean)
- Two-point CI wiring into approval-web-guard
- Presentation-only; handlers re-emitted to the parent which keeps its existing logic

Implemented by a Sonnet agent per model-split policy; reviewed by the main loop. Queued behind #3714/#3716 in the serial lander (will rebase over #3716's workflow-yml line on landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)