### PR TITLE
feat(multitable): W3-5b — batchId echo on /patch + History Center batch deep-link

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -208,6 +208,7 @@ jobs:
             tests/integration/multitable-crossbase-mirror-writethrough-realdb.test.ts \
             tests/integration/multitable-crossbase-mirror-writethrough-concurrency-realdb.test.ts \
             tests/integration/multitable-fieldperm-write-gate-patch-realdb.test.ts \
+            tests/integration/multitable-patch-batchid-echo-realdb.test.ts \
             tests/integration/multitable-permmatrix-b3-mgmt-403-matrix-realdb.test.ts \
             tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \

--- a/apps/web/src/multitable/components/HistoryBatchChangesList.vue
+++ b/apps/web/src/multitable/components/HistoryBatchChangesList.vue
@@ -1,0 +1,134 @@
+<!--
+  Shared per-field diff renderer for a Global History batch's changes[] payload — used by BOTH the
+  per-row expansion in HistoryCenterModal.vue (existing) and the W3-5b pinned-batch banner (a deep-linked
+  batch that may not be on the modal's current page). Extracted so the two render paths can never drift
+  apart; purely presentational — renders EXACTLY what the batch-detail payload already carries
+  (`HistoryChange.before`/`after`, already permission-masked server-side per LOCK-3), no extra fetch, no
+  un-masking, no widened field set.
+-->
+<template>
+  <ul class="meta-hist__changes">
+    <li v-for="(c, i) in changes" :key="`${c.recordId}-${i}`" class="meta-hist__change" data-test="hist-change">
+      <div class="meta-hist__change-summary">
+        <span class="meta-hist__change-action" :data-action="c.action">{{ actionLabel(c.action) }}</span>
+        <span class="meta-hist__change-rec" :title="c.recordId">{{ shortRecordId(c.recordId) }}</span>
+        <span class="meta-hist__change-fields">{{ fieldsLabel(c.changedFieldIds.length) }}</span>
+      </div>
+      <ul v-if="c.changedFieldIds.length" class="meta-hist__diff" data-test="hist-diff">
+        <li v-for="d in changeFieldDiffs(c)" :key="d.fieldId" class="meta-hist__diff-row" data-test="hist-diff-row">
+          <span class="meta-hist__diff-label" :title="diffFieldName(d.fieldId)">{{ diffFieldName(d.fieldId) }}</span>
+          <span class="meta-hist__diff-values">
+            <template v-if="d.shape === 'masked'">
+              <span class="meta-hist__diff-masked" data-test="hist-diff-masked">{{ diffMaskedLabel() }}</span>
+            </template>
+            <template v-else-if="d.shape === 'set'">
+              <span class="meta-hist__diff-op" data-test="hist-diff-op">{{ diffOpLabel('set') }}</span>
+              <span class="meta-hist__diff-after" :title="d.after">{{ d.after }}</span>
+            </template>
+            <template v-else-if="d.shape === 'cleared'">
+              <span class="meta-hist__diff-before" :title="d.before">{{ d.before }}</span>
+              <span class="meta-hist__diff-arrow" aria-hidden="true">→</span>
+              <span class="meta-hist__diff-op" data-test="hist-diff-op">{{ diffOpLabel('cleared') }}</span>
+            </template>
+            <template v-else>
+              <span class="meta-hist__diff-before" :title="d.before">{{ d.before }}</span>
+              <span class="meta-hist__diff-arrow" aria-hidden="true">→</span>
+              <span class="meta-hist__diff-after" :title="d.after">{{ d.after }}</span>
+            </template>
+          </span>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { useLocale } from '../../composables/useLocale'
+import { recordLabel } from '../utils/meta-record-labels'
+import type { HistoryChange } from '../types'
+
+const props = defineProps<{
+  changes: HistoryChange[]
+  fields?: Array<{ id: string; name: string }>
+  /** Reuses the caller's own action-label map (kept as a single source of truth in HistoryCenterModal.vue —
+   *  this is prop-drilling, not a shared-module extraction, per the AI-fields S1 design-lock's constraint
+   *  on `sourceLabel` NOT applying here since this is a distinct map (per-change action, not source)). */
+  actionLabel: (action: string) => string
+}>()
+
+const { isZh } = useLocale()
+
+function fieldsLabel(n: number): string {
+  return isZh.value ? `${n} 个字段` : `${n} field(s)`
+}
+function shortRecordId(id: string): string {
+  const trimmed = id.startsWith('rec_') ? id.slice(4) : id
+  return `#${trimmed.slice(0, 8)}`
+}
+
+// --- Inline per-field diff (read-only detail expansion) ---
+// Renders EXACTLY what the batch-detail payload already carries (HistoryChange.before/after, both
+// already permission-masked server-side per LOCK-3) — no extra fetch, no un-masking. A field is only
+// ever a diff row here because it is already listed in `changedFieldIds` (itself post-mask); this code
+// never widens that set.
+type FieldDiffShape = 'changed' | 'set' | 'cleared' | 'masked'
+interface FieldDiffRow { fieldId: string; shape: FieldDiffShape; before: string; after: string }
+
+function hasFieldValue(container: Record<string, unknown> | null, fieldId: string): boolean {
+  return !!container && Object.prototype.hasOwnProperty.call(container, fieldId)
+}
+function formatDiffValue(v: unknown): string {
+  if (v === null || v === undefined) return '—'
+  if (typeof v === 'object') {
+    try { return JSON.stringify(v) } catch { return String(v) }
+  }
+  return String(v)
+}
+// Shape rule (per changed field id):
+//  - present on both sides           → 'changed' (normal before→after diff)
+//  - present only on the after side  → 'set'      (no prior value — e.g. a create, or a field just added)
+//  - present only on the before side → 'cleared'  (the field was emptied)
+//  - present on NEITHER side         → 'masked'   (LOCK-3 hid the value on both sides even though the
+//                                                   batch still reports the field as changed)
+function changeFieldDiffs(c: HistoryChange): FieldDiffRow[] {
+  return c.changedFieldIds.map((fieldId) => {
+    const beforeHas = hasFieldValue(c.before, fieldId)
+    const afterHas = hasFieldValue(c.after, fieldId)
+    const shape: FieldDiffShape = beforeHas && afterHas ? 'changed' : afterHas ? 'set' : beforeHas ? 'cleared' : 'masked'
+    return {
+      fieldId,
+      shape,
+      before: beforeHas ? formatDiffValue((c.before as Record<string, unknown>)[fieldId]) : '',
+      after: afterHas ? formatDiffValue((c.after as Record<string, unknown>)[fieldId]) : '',
+    }
+  })
+}
+function diffFieldName(fieldId: string): string {
+  return props.fields?.find((f) => f.id === fieldId)?.name ?? fieldId
+}
+function diffOpLabel(shape: 'set' | 'cleared'): string {
+  return recordLabel(shape === 'set' ? 'record.restorePreviewSet' : 'record.restorePreviewUnset', isZh.value)
+}
+function diffMaskedLabel(): string {
+  return recordLabel('record.historyDiffMasked', isZh.value)
+}
+</script>
+
+<style scoped>
+.meta-hist__changes { list-style: none; margin: 0; padding: 0; }
+.meta-hist__change { padding: 3px 0; font-size: 12px; }
+.meta-hist__change-summary { display: flex; gap: 10px; align-items: center; }
+.meta-hist__change-action { font-weight: 500; min-width: 48px; }
+.meta-hist__change-rec { color: var(--meta-text-secondary, #888); }
+.meta-hist__change-fields { color: var(--meta-text-secondary, #888); }
+.meta-hist__diff { list-style: none; margin: 4px 0 0; padding: 0; }
+.meta-hist__diff-row { display: flex; align-items: baseline; gap: 8px; padding: 2px 0; }
+.meta-hist__diff-row + .meta-hist__diff-row { border-top: 1px dashed var(--meta-border, #eee); }
+.meta-hist__diff-label { flex: 0 0 auto; max-width: 38%; font-weight: 600; color: var(--meta-text-secondary, #475569); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-hist__diff-values { flex: 1 1 auto; display: flex; align-items: baseline; gap: 6px; min-width: 0; }
+.meta-hist__diff-before { color: #94a3b8; text-decoration: line-through; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 45%; }
+.meta-hist__diff-arrow { flex: 0 0 auto; color: #cbd5e1; }
+.meta-hist__diff-after { color: var(--meta-text, #0f172a); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.meta-hist__diff-op { flex: 0 0 auto; font-style: italic; color: var(--meta-text-secondary, #888); }
+.meta-hist__diff-masked { color: var(--meta-text-secondary, #888); font-style: italic; }
+</style>

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -13,6 +13,23 @@
         <button class="meta-hist__close" type="button" :aria-label="t('关闭', 'Close')" @click="emit('close')">×</button>
       </header>
 
+      <div v-if="initialBatchId && !pinnedDismissed" class="meta-hist__pinned" data-test="hist-pinned-batch">
+        <div class="meta-hist__pinned-head">
+          <span class="meta-hist__pinned-label">{{ t('已定位到该批次', 'Jumped to this batch') }}</span>
+          <button class="meta-hist__pinned-dismiss" type="button" data-test="hist-pinned-dismiss" @click="dismissPinned">{{ t('清除定位', 'Clear') }}</button>
+        </div>
+        <p v-if="pinnedLoading" class="meta-hist__hint">{{ t('加载中…', 'Loading…') }}</p>
+        <p v-else-if="!pinnedDetail" class="meta-hist__hint">{{ t('无法打开该批次', 'This batch is unavailable') }}</p>
+        <template v-else>
+          <div class="meta-hist__pinned-summary">
+            <span class="meta-hist__who">{{ actorLabel(pinnedDetail.actorName, pinnedDetail.actorId) }} · {{ sourceLabel(pinnedDetail.source) }}</span>
+            <span class="meta-hist__when">{{ formatTime(pinnedDetail.createdAt) }}</span>
+            <span class="meta-hist__counts" data-test="hist-pinned-counts">{{ countLabel(pinnedDetail) }}</span>
+          </div>
+          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :action-label="actionLabel" />
+        </template>
+      </div>
+
       <div class="meta-hist__filters">
         <input v-model.trim="filterSearch" class="meta-hist__filter" :placeholder="t('搜索可见数据', 'Search visible data')" data-test="hist-filter-search" @keyup.enter="reload" />
         <input v-model.trim="filterActor" class="meta-hist__filter" :placeholder="t('操作人 ID', 'Actor id')" data-test="hist-filter-actor" @keyup.enter="reload" />
@@ -51,39 +68,7 @@
           <div v-if="expandedId === b.batchId" class="meta-hist__detail" data-test="hist-detail">
             <p v-if="detailLoading" class="meta-hist__hint">{{ t('加载中…', 'Loading…') }}</p>
             <p v-else-if="!detail" class="meta-hist__hint">{{ t('无法打开该批次', 'This batch is unavailable') }}</p>
-            <ul v-else class="meta-hist__changes">
-              <li v-for="(c, i) in detail.changes" :key="`${c.recordId}-${i}`" class="meta-hist__change" data-test="hist-change">
-                <div class="meta-hist__change-summary">
-                  <span class="meta-hist__change-action" :data-action="c.action">{{ actionLabel(c.action) }}</span>
-                  <span class="meta-hist__change-rec" :title="c.recordId">{{ shortRecordId(c.recordId) }}</span>
-                  <span class="meta-hist__change-fields">{{ fieldsLabel(c.changedFieldIds.length) }}</span>
-                </div>
-                <ul v-if="c.changedFieldIds.length" class="meta-hist__diff" data-test="hist-diff">
-                  <li v-for="d in changeFieldDiffs(c)" :key="d.fieldId" class="meta-hist__diff-row" data-test="hist-diff-row">
-                    <span class="meta-hist__diff-label" :title="diffFieldName(d.fieldId)">{{ diffFieldName(d.fieldId) }}</span>
-                    <span class="meta-hist__diff-values">
-                      <template v-if="d.shape === 'masked'">
-                        <span class="meta-hist__diff-masked" data-test="hist-diff-masked">{{ diffMaskedLabel() }}</span>
-                      </template>
-                      <template v-else-if="d.shape === 'set'">
-                        <span class="meta-hist__diff-op" data-test="hist-diff-op">{{ diffOpLabel('set') }}</span>
-                        <span class="meta-hist__diff-after" :title="d.after">{{ d.after }}</span>
-                      </template>
-                      <template v-else-if="d.shape === 'cleared'">
-                        <span class="meta-hist__diff-before" :title="d.before">{{ d.before }}</span>
-                        <span class="meta-hist__diff-arrow" aria-hidden="true">→</span>
-                        <span class="meta-hist__diff-op" data-test="hist-diff-op">{{ diffOpLabel('cleared') }}</span>
-                      </template>
-                      <template v-else>
-                        <span class="meta-hist__diff-before" :title="d.before">{{ d.before }}</span>
-                        <span class="meta-hist__diff-arrow" aria-hidden="true">→</span>
-                        <span class="meta-hist__diff-after" :title="d.after">{{ d.after }}</span>
-                      </template>
-                    </span>
-                  </li>
-                </ul>
-              </li>
-            </ul>
+            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :action-label="actionLabel" />
           </div>
         </li>
       </ul>
@@ -104,8 +89,8 @@
 import { ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import { useHistoryCenter } from '../composables/useHistoryCenter'
-import { historyActor, recordLabel } from '../utils/meta-record-labels'
-import type { HistoryBatchSummary, HistoryChange } from '../types'
+import { historyActor } from '../utils/meta-record-labels'
+import HistoryBatchChangesList from './HistoryBatchChangesList.vue'
 
 const props = defineProps<{
   open: boolean
@@ -113,11 +98,14 @@ const props = defineProps<{
   sheetId?: string
   fields?: Array<{ id: string; name: string }>
   /**
-   * W3-5: a commit toast's "view in history" deep-link sets this to the batch it just wrote — on open, the
-   * modal loads the normal (unfiltered) list AND immediately expands this one batch's detail via the SAME
-   * `toggle`/`getHistoryBatch` mechanism a manual row click uses (no new filtering API). If the batch has
-   * since scrolled off the default page (or ages out under retention), the expand silently finds nothing —
-   * same as any other detail-load miss; it never throws.
+   * W3-5/W3-5b: a commit toast's "view in history" deep-link sets this to the batch it just wrote. On open,
+   * the modal loads the normal (unfiltered) list AND ALSO fetches this one batch's own detail via the SAME
+   * `getHistoryBatch` mechanism a manual row click uses (no new filtering API) into a PINNED banner at the
+   * top of the modal (see `pinnedDetail`/`loadPinned`) — independent of whether the batch is among the rows
+   * on the current page (a different active filter, or many commits since, would otherwise leave it with no
+   * row to expand under; the pinned banner ALWAYS shows it). A "clear" affordance on the banner dismisses it
+   * without affecting the normal paged list. If the batch is unavailable (e.g. aged out under retention),
+   * the banner shows the same "unavailable" hint as a normal row's failed expand — it never throws.
    */
   initialBatchId?: string | null
 }>()
@@ -135,7 +123,15 @@ const filterTo = ref('')
 const filterField = ref('')
 const scopeAllSheets = ref(false) // T2b: default to the active sheet; opt in to all readable tables
 
-const { batches, loading, loadingMore, error, nextCursor, searchTruncated, expandedId, detail, detailLoading, load, loadMore, toggle: toggleBatch } = useHistoryCenter()
+const {
+  batches, loading, loadingMore, error, nextCursor, searchTruncated, expandedId, detail, detailLoading, load, loadMore, toggle: toggleBatch,
+  pinnedDetail, pinnedLoading, loadPinned, clearPinned,
+} = useHistoryCenter()
+
+// W3-5b: local dismiss flag for the pinned banner — reset whenever a fresh deep-linked open fires (below),
+// so re-opening the modal with a NEW initialBatchId always shows its own pinned banner even if a PREVIOUS
+// one was dismissed in this same mounted instance.
+const pinnedDismissed = ref(false)
 
 function reload(): Promise<void> {
   return load(props.baseId, {
@@ -161,13 +157,22 @@ watch(
   () => [props.open, props.baseId] as const,
   ([open]) => {
     if (!open || !props.baseId) return
-    void reload().then(() => {
-      // W3-5: a deep-linked open — expand the target batch right away, same as a manual row click.
-      if (props.initialBatchId) void toggle(props.initialBatchId)
-    })
+    void reload()
+    // W3-5b: the pinned banner is the sole deep-link display mechanism (see the prop doc above) — it does
+    // NOT depend on `reload()` finishing or on the batch being present in the resulting page, so it fires
+    // independently. Reset any earlier dismissal, and drop a stale pin from a previous deep-linked open
+    // when this open has no `initialBatchId` (e.g. the toolbar's plain "History" button).
+    pinnedDismissed.value = false
+    if (props.initialBatchId) void loadPinned(props.baseId, props.initialBatchId)
+    else clearPinned()
   },
   { immediate: true },
 )
+
+function dismissPinned(): void {
+  pinnedDismissed.value = true
+  clearPinned()
+}
 
 function actorLabel(name: string | null | undefined, actorId: string | null): string {
   if (name) return name
@@ -190,63 +195,12 @@ function actionLabel(action: string): string {
   const pair = map[action]
   return pair ? t(pair[0], pair[1]) : action
 }
-function countLabel(b: HistoryBatchSummary): string {
+// countLabel is shared by the per-row batch button (b: HistoryBatchSummary) AND the W3-5b pinned banner
+// (pinnedDetail: HistoryBatchDetail) — both carry the same two visible-count fields, so the parameter
+// type only requires that structural subset (never the full HistoryBatchSummary shape).
+function countLabel(b: { visibleAffectedRecordCount: number; visibleAffectedFieldCount: number }): string {
   return t(`${b.visibleAffectedRecordCount} 条记录 · ${b.visibleAffectedFieldCount} 个字段`,
     `${b.visibleAffectedRecordCount} record(s) · ${b.visibleAffectedFieldCount} field(s)`)
-}
-function fieldsLabel(n: number): string {
-  return t(`${n} 个字段`, `${n} field(s)`)
-}
-function shortRecordId(id: string): string {
-  const trimmed = id.startsWith('rec_') ? id.slice(4) : id
-  return `#${trimmed.slice(0, 8)}`
-}
-
-// --- Inline per-field diff (read-only detail expansion) ---
-// Renders EXACTLY what the batch-detail payload already carries (HistoryChange.before/after, both
-// already permission-masked server-side per LOCK-3) — no extra fetch, no un-masking. A field is only
-// ever a diff row here because it is already listed in `changedFieldIds` (itself post-mask); this code
-// never widens that set.
-type FieldDiffShape = 'changed' | 'set' | 'cleared' | 'masked'
-interface FieldDiffRow { fieldId: string; shape: FieldDiffShape; before: string; after: string }
-
-function hasFieldValue(container: Record<string, unknown> | null, fieldId: string): boolean {
-  return !!container && Object.prototype.hasOwnProperty.call(container, fieldId)
-}
-function formatDiffValue(v: unknown): string {
-  if (v === null || v === undefined) return '—'
-  if (typeof v === 'object') {
-    try { return JSON.stringify(v) } catch { return String(v) }
-  }
-  return String(v)
-}
-// Shape rule (per changed field id):
-//  - present on both sides           → 'changed' (normal before→after diff)
-//  - present only on the after side  → 'set'      (no prior value — e.g. a create, or a field just added)
-//  - present only on the before side → 'cleared'  (the field was emptied)
-//  - present on NEITHER side         → 'masked'   (LOCK-3 hid the value on both sides even though the
-//                                                   batch still reports the field as changed)
-function changeFieldDiffs(c: HistoryChange): FieldDiffRow[] {
-  return c.changedFieldIds.map((fieldId) => {
-    const beforeHas = hasFieldValue(c.before, fieldId)
-    const afterHas = hasFieldValue(c.after, fieldId)
-    const shape: FieldDiffShape = beforeHas && afterHas ? 'changed' : afterHas ? 'set' : beforeHas ? 'cleared' : 'masked'
-    return {
-      fieldId,
-      shape,
-      before: beforeHas ? formatDiffValue((c.before as Record<string, unknown>)[fieldId]) : '',
-      after: afterHas ? formatDiffValue((c.after as Record<string, unknown>)[fieldId]) : '',
-    }
-  })
-}
-function diffFieldName(fieldId: string): string {
-  return props.fields?.find((f) => f.id === fieldId)?.name ?? fieldId
-}
-function diffOpLabel(shape: 'set' | 'cleared'): string {
-  return recordLabel(shape === 'set' ? 'record.restorePreviewSet' : 'record.restorePreviewUnset', isZh.value)
-}
-function diffMaskedLabel(): string {
-  return recordLabel('record.historyDiffMasked', isZh.value)
 }
 function formatTime(iso: string): string {
   if (!iso) return ''
@@ -272,22 +226,16 @@ function formatTime(iso: string): string {
 .meta-hist__who { flex: 1; min-width: 0; color: var(--meta-text-secondary, #888); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .meta-hist__when { color: var(--meta-text-secondary, #888); font-size: 12px; white-space: nowrap; }
 .meta-hist__detail { padding: 4px 0 10px 12px; }
-.meta-hist__changes { list-style: none; margin: 0; padding: 0; }
-.meta-hist__change { padding: 3px 0; font-size: 12px; }
-.meta-hist__change-summary { display: flex; gap: 10px; align-items: center; }
-.meta-hist__change-action { font-weight: 500; min-width: 48px; }
-.meta-hist__change-rec { color: var(--meta-text-secondary, #888); }
-.meta-hist__change-fields { color: var(--meta-text-secondary, #888); }
-.meta-hist__diff { list-style: none; margin: 4px 0 0; padding: 0; }
-.meta-hist__diff-row { display: flex; align-items: baseline; gap: 8px; padding: 2px 0; }
-.meta-hist__diff-row + .meta-hist__diff-row { border-top: 1px dashed var(--meta-border, #eee); }
-.meta-hist__diff-label { flex: 0 0 auto; max-width: 38%; font-weight: 600; color: var(--meta-text-secondary, #475569); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.meta-hist__diff-values { flex: 1 1 auto; display: flex; align-items: baseline; gap: 6px; min-width: 0; }
-.meta-hist__diff-before { color: #94a3b8; text-decoration: line-through; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 45%; }
-.meta-hist__diff-arrow { flex: 0 0 auto; color: #cbd5e1; }
-.meta-hist__diff-after { color: var(--meta-text, #0f172a); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.meta-hist__diff-op { flex: 0 0 auto; font-style: italic; color: var(--meta-text-secondary, #888); }
-.meta-hist__diff-masked { color: var(--meta-text-secondary, #888); font-style: italic; }
+/* W3-5b pinned-batch banner — new markup, so per the UI-foundation design-lock (tokens.css §3.1) it takes
+   color/spacing/radius ONLY from the real, always-resolvable `--ms-*` tokens (no hardcoded hex, no new
+   token vocabulary), unlike this file's pre-existing `--meta-*` hex-fallback pattern above/below (legacy,
+   left as-is — out of scope for this additive change). */
+.meta-hist__pinned { border: 1px solid var(--ms-border); border-left: 3px solid var(--ms-color-primary); border-radius: var(--ms-radius-md); padding: var(--ms-space-3); margin-bottom: var(--ms-space-4); background: var(--ms-bg-card); }
+.meta-hist__pinned-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--ms-space-2); }
+.meta-hist__pinned-label { font-size: 12px; font-weight: 600; color: var(--ms-color-primary); }
+.meta-hist__pinned-dismiss { font-size: 12px; padding: 2px 8px; border: 1px solid var(--ms-border); border-radius: var(--ms-radius-sm); background: none; color: var(--ms-text-2); cursor: pointer; }
+.meta-hist__pinned-dismiss:hover { background: var(--ms-bg-page); }
+.meta-hist__pinned-summary { display: flex; gap: 12px; align-items: center; margin-bottom: var(--ms-space-2); }
 .meta-hist__error { color: var(--meta-danger, #c0392b); margin: 0 0 8px; }
 .meta-hist__hint { color: var(--meta-text-secondary, #888); padding: 12px 0; }
 </style>

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -107,7 +107,20 @@ import { useHistoryCenter } from '../composables/useHistoryCenter'
 import { historyActor, recordLabel } from '../utils/meta-record-labels'
 import type { HistoryBatchSummary, HistoryChange } from '../types'
 
-const props = defineProps<{ open: boolean; baseId: string; sheetId?: string; fields?: Array<{ id: string; name: string }> }>()
+const props = defineProps<{
+  open: boolean
+  baseId: string
+  sheetId?: string
+  fields?: Array<{ id: string; name: string }>
+  /**
+   * W3-5: a commit toast's "view in history" deep-link sets this to the batch it just wrote — on open, the
+   * modal loads the normal (unfiltered) list AND immediately expands this one batch's detail via the SAME
+   * `toggle`/`getHistoryBatch` mechanism a manual row click uses (no new filtering API). If the batch has
+   * since scrolled off the default page (or ages out under retention), the expand silently finds nothing —
+   * same as any other detail-load miss; it never throws.
+   */
+  initialBatchId?: string | null
+}>()
 const emit = defineEmits<{ (e: 'close'): void }>()
 
 const { isZh } = useLocale()
@@ -147,7 +160,11 @@ function toggle(batchId: string): Promise<void> {
 watch(
   () => [props.open, props.baseId] as const,
   ([open]) => {
-    if (open && props.baseId) void reload()
+    if (!open || !props.baseId) return
+    void reload().then(() => {
+      // W3-5: a deep-linked open — expand the target batch right away, same as a manual row click.
+      if (props.initialBatchId) void toggle(props.initialBatchId)
+    })
   },
   { immediate: true },
 )

--- a/apps/web/src/multitable/components/MetaToast.vue
+++ b/apps/web/src/multitable/components/MetaToast.vue
@@ -9,6 +9,13 @@
       >
         <span class="meta-toast__icon">{{ icons[toast.type] }}</span>
         <span class="meta-toast__message">{{ toast.message }}</span>
+        <button
+          v-if="toast.action"
+          class="meta-toast__action"
+          type="button"
+          data-test="meta-toast-action"
+          @click="runAction(toast)"
+        >{{ toast.action.label }}</button>
         <button class="meta-toast__close" @click="dismiss(toast.id)">&times;</button>
       </div>
     </TransitionGroup>
@@ -18,10 +25,17 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
+export interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
 export interface ToastItem {
   id: number
   message: string
   type: 'error' | 'success' | 'info'
+  /** W3-5: an optional clickable action (e.g. "View in history") rendered before the close button. */
+  action?: ToastAction
 }
 
 const icons: Record<string, string> = {
@@ -33,9 +47,9 @@ const icons: Record<string, string> = {
 const toasts = ref<ToastItem[]>([])
 let nextId = 0
 
-function show(message: string, type: ToastItem['type'] = 'info', duration = 3000) {
+function show(message: string, type: ToastItem['type'] = 'info', duration = 3000, action?: ToastAction) {
   const id = nextId++
-  toasts.value.push({ id, message, type })
+  toasts.value.push({ id, message, type, action })
   if (duration > 0) setTimeout(() => dismiss(id), duration)
 }
 
@@ -43,8 +57,13 @@ function dismiss(id: number) {
   toasts.value = toasts.value.filter((t) => t.id !== id)
 }
 
+function runAction(toast: ToastItem) {
+  toast.action?.onClick()
+  dismiss(toast.id)
+}
+
 function showError(message: string) { show(message, 'error', 5000) }
-function showSuccess(message: string) { show(message, 'success', 3000) }
+function showSuccess(message: string, action?: ToastAction) { show(message, 'success', action ? 6000 : 3000, action) }
 
 defineExpose({ show, showError, showSuccess, dismiss })
 </script>
@@ -57,6 +76,8 @@ defineExpose({ show, showError, showSuccess, dismiss })
 .meta-toast--info { background: #409eff; }
 .meta-toast__icon { font-size: 15px; flex-shrink: 0; }
 .meta-toast__message { flex: 1; line-height: 1.4; }
+.meta-toast__action { border: 1px solid rgba(255,255,255,.6); background: none; color: #fff; font-size: 12px; cursor: pointer; padding: 2px 8px; border-radius: 4px; flex-shrink: 0; white-space: nowrap; }
+.meta-toast__action:hover { background: rgba(255,255,255,.15); }
 .meta-toast__close { border: none; background: none; color: rgba(255,255,255,.7); font-size: 16px; cursor: pointer; padding: 0 2px; flex-shrink: 0; }
 .meta-toast__close:hover { color: #fff; }
 .meta-toast-enter-active { transition: all 0.3s ease; }

--- a/apps/web/src/multitable/composables/useHistoryCenter.ts
+++ b/apps/web/src/multitable/composables/useHistoryCenter.ts
@@ -99,5 +99,34 @@ export function useHistoryCenter(client: HistoryClient = multitableClient) {
     }
   }
 
-  return { batches, loading, loadingMore, error, nextCursor, searchTruncated, expandedId, detail, detailLoading, load, loadMore, toggle }
+
+  // W3-5b: an INDEPENDENT batch-detail fetch for a commit toast's "view in history" deep-link — decoupled
+  // from the per-row expandedId/detail pair above so a manual row click elsewhere never clobbers (or is
+  // clobbered by) the pinned banner, and the pinned banner keeps showing even after the user expands/
+  // collapses unrelated rows. Same never-throw contract as toggle(): a failure surfaces via a null
+  // pinnedDetail, never an unhandled rejection.
+  const pinnedDetail = ref<HistoryBatchDetail | null>(null)
+  const pinnedLoading = ref(false)
+
+  async function loadPinned(baseId: string, batchId: string): Promise<void> {
+    pinnedLoading.value = true
+    pinnedDetail.value = null
+    try {
+      pinnedDetail.value = await client.getHistoryBatch(baseId, batchId)
+    } catch {
+      pinnedDetail.value = null
+    } finally {
+      pinnedLoading.value = false
+    }
+  }
+  function clearPinned(): void {
+    pinnedDetail.value = null
+    pinnedLoading.value = false
+  }
+
+  return {
+    batches, loading, loadingMore, error, nextCursor, searchTruncated, expandedId, detail, detailLoading, load, loadMore, toggle,
+    // W3-5b pinned-batch banner (deep-link display, independent of the paged list / row-expansion state)
+    pinnedDetail, pinnedLoading, loadPinned, clearPinned,
+  }
 }

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -497,6 +497,10 @@ export function useMultitableGrid(opts: {
   const accumulationCapped = ref(false)
   const error = ref<string | null>(null)
   const conflict = ref<GridConflictState | null>(null)
+  // W3-5: the batchId of the most recent successful commit (patchCell / bulkPatch), so a caller can
+  // surface a "view in history" deep-link without re-deriving it. Cleared on a failed commit (never
+  // stale-points at a PRIOR successful batch after a later failure); null before any commit this session.
+  const lastBatchId = ref<string | null>(null)
   // Monotonic request id shared by loadViewData (reset/replace) AND loadMore (append). A reset bumps it,
   // so any in-flight append re-checking it AFTER its await bails instead of appending stale, cross-filter
   // rows onto the freshly-reset set. This is the single guard that keeps the masked/filtered/sorted
@@ -1068,6 +1072,9 @@ export function useMultitableGrid(opts: {
         changes: [{ recordId, fieldId, value, expectedVersion: version }],
       })
       applyPatchResult(result)
+      // W3-5: record the commit's batchId (undefined for a server that predates the seam) so a caller can
+      // offer a "view in history" deep-link for THIS commit only — never carries a prior commit's id forward.
+      lastBatchId.value = result.batchId ?? null
       // Push to undo history
       editHistory.value = editHistory.value.slice(0, historyIndex.value + 1)
       editHistory.value.push({ recordId, fieldId, oldValue, newValue: value, version, oldLinkSummaries, newLinkSummaries: nextLinkSummaries })
@@ -1076,6 +1083,7 @@ export function useMultitableGrid(opts: {
       // Revert optimistic update
       if (row) row.data[fieldId] = oldValue
       setLinkSummaries(recordId, fieldId, oldLinkSummaries)
+      lastBatchId.value = null
       if (e?.code === 'VERSION_CONFLICT') {
         conflict.value = {
           recordId,
@@ -1159,6 +1167,7 @@ export function useMultitableGrid(opts: {
       changes,
     })
     applyPatchResult(result)
+    lastBatchId.value = result.batchId ?? null
     const updated = (result.updated ?? []).map((u) => u.recordId)
     const failed = (result.failed ?? []).map((failure) => ({
       recordId: failure.recordId,
@@ -1376,7 +1385,7 @@ export function useMultitableGrid(opts: {
 
   return {
     // State
-    fields, rows, linkSummaries, personSummaries, attachmentSummaries, fieldPermissions, viewPermission, capabilityOrigin, rowActions, rowActionOverrides, loading, error, conflict, page, hiddenFieldIds, visibleFields, readOnlyFieldIds,
+    fields, rows, linkSummaries, personSummaries, attachmentSummaries, fieldPermissions, viewPermission, capabilityOrigin, rowActions, rowActionOverrides, loading, error, conflict, lastBatchId, page, hiddenFieldIds, visibleFields, readOnlyFieldIds,
     // A1 infinite-scroll accumulation state
     loadingMore, accumulationCapped,
     sortRules, filterRules, filterConjunction, nestedFilterNodes, filterGroups, sortFilterDirty,

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -712,6 +712,9 @@ export interface PatchResult {
   linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
   attachmentSummaries?: Record<string, Record<string, MetaAttachment[]>>
   relatedRecords?: Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }>
+  /** W3-5: the server-minted batchId this commit's revision(s) were grouped under — absent only if the
+   *  server predates the seam. Lets a caller deep-link into the History Center for this exact commit. */
+  batchId?: string
 }
 
 // --- Form submit ---

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -30,7 +30,7 @@ export type WorkbenchLabelKey =
   | 'toast.recordCreateBlocked' | 'toast.recordEditBlocked' | 'toast.recordDeleteBlocked'
   | 'toast.datesUpdated' | 'toast.hierarchyUpdated' | 'toast.recordDeleted' | 'toast.recordDuplicated'
   | 'toast.recordLocked' | 'toast.recordUnlocked' | 'toast.recordLockFailed'
-  | 'toast.loadedLatest' | 'toast.changeReapplied' | 'toast.recordUpdated'
+  | 'toast.loadedLatest' | 'toast.changeReapplied' | 'toast.recordUpdated' | 'toast.viewInHistory'
   | 'toast.commentUpdated' | 'toast.commentAdded'
   | 'toast.commentResolved' | 'toast.commentDeleted' | 'toast.linkedRecordsUpdated'
   | 'toast.viewSettingsSaved'
@@ -136,6 +136,7 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.loadedLatest': { en: 'Loaded the latest row state', zh: '已加载最新行状态' },
   'toast.changeReapplied': { en: 'Change reapplied', zh: '修改已重新应用' },
   'toast.recordUpdated': { en: 'Record updated', zh: '记录已更新' },
+  'toast.viewInHistory': { en: 'View in history', zh: '在历史记录中查看' },
   'toast.commentUpdated': { en: 'Comment updated', zh: '评论已更新' },
   'toast.commentAdded': { en: 'Comment added', zh: '评论已添加' },
   'toast.commentResolved': { en: 'Comment resolved', zh: '评论已解决' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -62,7 +62,7 @@
       <button v-if="activeViewType === 'form'" class="mt-workbench__mgr-btn" @click="showFormShareManager = true">&#x1F517; {{ wb('toolbar.shareForm', isZh) }}</button>
       <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true">&#x1F511; {{ wb('toolbar.apiWebhooks', isZh) }}</button>
       <button v-if="caps.canDeleteRecord.value" class="mt-workbench__mgr-btn" @click="showTrash = true">&#x1F5D1; {{ wb('toolbar.trash', isZh) }}</button>
-      <button v-if="activeBaseId" class="mt-workbench__mgr-btn" data-action="open-history" @click="showHistory = true">&#x1F570; {{ isZh ? '历史' : 'History' }}</button>
+      <button v-if="activeBaseId" class="mt-workbench__mgr-btn" data-action="open-history" @click="historyDeepLinkBatchId = null; showHistory = true">&#x1F570; {{ isZh ? '历史' : 'History' }}</button>
       <button v-if="workbench.activeSheetId.value" class="mt-workbench__mgr-btn" data-action="open-config-history" @click="openConfigHistory">&#x2699; {{ isZh ? '配置历史' : 'Config history' }}</button>
     </div>
     <ResetToPointPicker
@@ -533,7 +533,8 @@
       :base-id="activeBaseId || ''"
       :sheet-id="workbench.activeSheetId.value"
       :fields="propertyVisibleGridFields"
-      @close="showHistory = false"
+      :initial-batch-id="historyDeepLinkBatchId"
+      @close="closeHistory"
     />
     <MetaConfigHistoryModal
       :visible="configHistory.visible"
@@ -663,7 +664,7 @@ import MetaCalendarView from '../components/MetaCalendarView.vue'
 import MetaTimelineView from '../components/MetaTimelineView.vue'
 import MetaGanttView from '../components/MetaGanttView.vue'
 import MetaHierarchyView from '../components/MetaHierarchyView.vue'
-import MetaToast from '../components/MetaToast.vue'
+import MetaToast, { type ToastAction } from '../components/MetaToast.vue'
 import MetaImportModal from '../components/MetaImportModal.vue'
 import MetaBulkEditDialog from '../components/MetaBulkEditDialog.vue'
 import MetaMentionPopover from '../components/MetaMentionPopover.vue'
@@ -942,6 +943,18 @@ const showFormShareManager = ref(false)
 const showApiTokenManager = ref(false)
 const showTrash = ref(false)
 const showHistory = ref(false)
+// W3-5: set by a commit toast's "view in history" action — deep-links the History Center straight to the
+// batch that toast is about. Cleared on close so re-opening the modal manually (toolbar button) shows the
+// normal unfiltered list, not a stale deep-link from a previous toast.
+const historyDeepLinkBatchId = ref<string | null>(null)
+function openHistoryForBatch(batchId: string) {
+  historyDeepLinkBatchId.value = batchId
+  showHistory.value = true
+}
+function closeHistory() {
+  showHistory.value = false
+  historyDeepLinkBatchId.value = null
+}
 
 // T9-R4: config/schema-change history view. The server gates per entity type — the FE renders what it returns
 // (faithful client; no client-side security filtering). The entity-type filter only narrows within the gated set.
@@ -1108,8 +1121,16 @@ function showError(msg: string) {
   toastRef.value?.showError(msg)
 }
 
-function showSuccess(msg: string) {
-  toastRef.value?.showSuccess(msg)
+function showSuccess(msg: string, action?: ToastAction) {
+  toastRef.value?.showSuccess(msg, action)
+}
+
+// W3-5: a commit toast's "View in history" action — deep-links straight to the batch this commit wrote.
+// Omitted (no action) when the server response carried no batchId (e.g. a server predating the seam, or a
+// no-op commit where nothing was actually written).
+function historyLinkAction(batchId: string | null): ToastAction | undefined {
+  if (!batchId) return undefined
+  return { label: wb('toast.viewInHistory', isZh.value), onClick: () => openHistoryForBatch(batchId) }
 }
 
 function ensureCanCreateRecord(): boolean {
@@ -2244,7 +2265,7 @@ async function onDrawerPatch(fieldId: string, value: unknown) {
       data: { ...deepLinkedRecord.value.data, [fieldId]: value },
     }
   }
-  showSuccess(wb('toast.recordUpdated', isZh.value))
+  showSuccess(wb('toast.recordUpdated', isZh.value), historyLinkAction(grid.lastBatchId.value))
 }
 
 async function onFormSubmit(data: Record<string, unknown>) {

--- a/apps/web/tests/multitable-history-center-pinned-batch-deeplink.spec.ts
+++ b/apps/web/tests/multitable-history-center-pinned-batch-deeplink.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * W3-5b — pinned-batch banner: a commit toast's "view in history" deep-link (`initialBatchId`) must ALWAYS
+ * render the target batch's detail, even when that batch is NOT among the rows on the modal's current
+ * page (a different active filter, or many commits since — see the prop doc in HistoryCenterModal.vue).
+ * Before this fix, the deep-link only expanded a matching ROW via `toggle()`; if no row matched, the fetched
+ * detail had nowhere to render. This spec locks the fix: the pinned banner fetches + renders the batch
+ * independent of the paged list, and its "clear" affordance dismisses it without touching the list.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import HistoryCenterModal from '../src/multitable/components/HistoryCenterModal.vue'
+import type { HistoryBatchDetail, HistoryBatchSummary } from '../src/multitable/types'
+
+const { mockListHistoryEvents, mockGetHistoryBatch } = vi.hoisted(() => ({
+  mockListHistoryEvents: vi.fn(),
+  mockGetHistoryBatch: vi.fn(),
+}))
+
+vi.mock('../src/multitable/api/client', () => ({
+  multitableClient: {
+    listHistoryEvents: mockListHistoryEvents,
+    getHistoryBatch: mockGetHistoryBatch,
+  },
+}))
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function otherBatch(): HistoryBatchSummary {
+  return {
+    batchId: 'batch_on_page', sheetId: 'sheet_1', actorId: 'user_1', actorName: null, source: 'rest',
+    action: 'update', createdAt: new Date().toISOString(), visibleAffectedRecordCount: 1,
+    visibleAffectedFieldCount: 1, provenanceQuality: 'stamped',
+  }
+}
+
+function mountModal(initialBatchId: string | null) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp(HistoryCenterModal, {
+    open: true, baseId: 'base_1', initialBatchId,
+    fields: [{ id: 'fld_name', name: 'Name' }],
+  })
+  app.mount(container)
+  return { app, container }
+}
+
+describe('HistoryCenterModal — W3-5b pinned-batch deep-link banner', () => {
+  it('renders the deep-linked batch via the pinned banner even when it is NOT in the current page', async () => {
+    // The paged list comes back WITHOUT the deep-linked batch (e.g. it scrolled off, or a filter excludes it).
+    mockListHistoryEvents.mockResolvedValue({ batches: [otherBatch()], total: 1, nextCursor: null, searchTruncated: false })
+    const pinned: HistoryBatchDetail = {
+      batchId: 'batch_deep_linked', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 1,
+      changes: [{
+        sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+        changedFieldIds: ['fld_name'],
+        before: { fld_name: 'Old Name' },
+        after: { fld_name: 'New Name' },
+      }],
+    }
+    mockGetHistoryBatch.mockResolvedValue(pinned)
+
+    const { app, container } = mountModal('batch_deep_linked')
+    try {
+      await flushPromises()
+      // The pinned banner fetched the target batch directly, independent of the paged list.
+      expect(mockGetHistoryBatch).toHaveBeenCalledWith('base_1', 'batch_deep_linked')
+
+      const banner = container.querySelector('[data-test="hist-pinned-batch"]')
+      expect(banner).not.toBeNull()
+      const diffRow = banner!.querySelector('[data-test="hist-diff-row"]')
+      expect(diffRow).not.toBeNull()
+      expect(diffRow!.querySelector('.meta-hist__diff-before')?.textContent).toContain('Old Name')
+      expect(diffRow!.querySelector('.meta-hist__diff-after')?.textContent).toContain('New Name')
+
+      // The normal paged list is untouched — the OTHER batch still renders as a plain, unexpanded row.
+      const rows = container.querySelectorAll('[data-test="hist-batch"]')
+      expect(rows.length).toBe(1)
+      expect(container.querySelector('[data-test="hist-detail"]')).toBeNull() // no row auto-expanded
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('dismissing the pinned banner clears it without touching the normal list', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [otherBatch()], total: 1, nextCursor: null, searchTruncated: false })
+    const pinned: HistoryBatchDetail = {
+      batchId: 'batch_deep_linked', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 1,
+      changes: [{ sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2, changedFieldIds: [], before: {}, after: {} }],
+    }
+    mockGetHistoryBatch.mockResolvedValue(pinned)
+
+    const { app, container } = mountModal('batch_deep_linked')
+    try {
+      await flushPromises()
+      expect(container.querySelector('[data-test="hist-pinned-batch"]')).not.toBeNull()
+
+      container.querySelector<HTMLButtonElement>('[data-test="hist-pinned-dismiss"]')!.click()
+      await flushPromises()
+
+      expect(container.querySelector('[data-test="hist-pinned-batch"]')).toBeNull()
+      // The normal list is unaffected by the dismiss.
+      expect(container.querySelectorAll('[data-test="hist-batch"]').length).toBe(1)
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('no pinned banner renders for a normal (non-deep-linked) open', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [otherBatch()], total: 1, nextCursor: null, searchTruncated: false })
+    const callsBeforeOpen = mockGetHistoryBatch.mock.calls.length
+    const { app, container } = mountModal(null)
+    try {
+      await flushPromises()
+      // No initialBatchId -> the pinned-banner fetch never fires (relative count: the mock is shared across
+      // this file's tests, so an absolute "never called" assertion would be a false positive/negative).
+      expect(mockGetHistoryBatch.mock.calls.length).toBe(callsBeforeOpen)
+      expect(container.querySelector('[data-test="hist-pinned-batch"]')).toBeNull()
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+})

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -307,6 +307,15 @@ export interface RecordPatchResult {
   linkSummaries?: Record<string, unknown>
   attachmentSummaries?: Record<string, unknown>
   relatedRecords?: Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }>
+  /**
+   * W3-5: the batch grouping id this call's revision(s) were stamped with (LOCK-B1/B2 seam) — the caller's
+   * explicit `batchId` if supplied, else the fresh `randomUUID()` this call minted (`bulkBatchId`). Echoed
+   * back so a REST/grid caller can deep-link into the History Center for exactly this commit (read-only;
+   * echoing an already-server-minted, already-persisted id changes no write-path semantics — LOCK-B5).
+   * Omitted (not merely undefined-valued) when `updated` is empty (nothing was actually written, e.g. every
+   * change was a same-value no-op), so a caller never deep-links to a batch that has no revisions.
+   */
+  batchId?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -649,6 +658,16 @@ export class RecordWriteService {
 
     const h = this.helpers
 
+    // Global-history T1 (LOCK-12): one bulk patchRecords call = ONE user action = ONE batch. Share a single
+    // batch_id across every record's revision so the history projection groups them as one batch, not many
+    // unrelated ones. AI-fields S1 (LOCK-B1/B2): a caller MAY supply its own batchId to group MULTIPLE
+    // patchRecords calls into one commit-action batch — absent, this is the same fresh randomUUID() as
+    // before the seam existed (byte-identical default for every non-AI caller). Hoisted above the mutation
+    // transaction (W3-5) so the RESULT can echo it back for a caller's history deep-link — it is otherwise
+    // unreachable outside the transaction closure. Purely a value computation with no side effect ordering
+    // dependency on running inside the transaction.
+    const bulkBatchId = batchId ?? randomUUID()
+
     // -----------------------------------------------------------------------
     // Step 0: Validate changes (field writability + value constraints)
     // -----------------------------------------------------------------------
@@ -768,12 +787,7 @@ export class RecordWriteService {
         if (fid && ids.length > 0) personRestrictByFieldId.set(fid, ids)
       }
 
-      // Global-history T1 (LOCK-12): one bulk patchRecords call = ONE user action = ONE batch. Share a
-      // single batch_id across every record's revision so the history projection groups them as one batch,
-      // not many unrelated ones. AI-fields S1 (LOCK-B1/B2): a caller MAY supply its own batchId to group
-      // MULTIPLE patchRecords calls into one commit-action batch — absent, this is the same fresh
-      // randomUUID() as before the seam existed (byte-identical default for every non-AI caller).
-      const bulkBatchId = batchId ?? randomUUID()
+      // bulkBatchId is computed above (hoisted, W3-5) — shared by every record this call writes.
       for (const [recordId, changes] of changesByRecord.entries()) {
         const expectedVersion = Array.from(
           new Set(changes.map((c) => c.expectedVersion).filter((v): v is number => typeof v === 'number')),
@@ -1411,6 +1425,9 @@ export class RecordWriteService {
       ...(patchLinkSummaries ? { linkSummaries: patchLinkSummaries } : {}),
       ...(patchAttachmentSummaries ? { attachmentSummaries: patchAttachmentSummaries } : {}),
       ...(crossSheetRelated.length > 0 ? { relatedRecords: crossSheetRelated } : {}),
+      // W3-5: only echo the batchId when something was actually written under it (never point a caller's
+      // history deep-link at a batch with zero revisions).
+      ...(updates.length > 0 ? { batchId: bulkBatchId } : {}),
     }
   }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -16039,6 +16039,12 @@ export function univerMetaRouter(): Router {
           ...(result.linkSummaries ? { linkSummaries: result.linkSummaries } : {}),
           ...(result.attachmentSummaries ? { attachmentSummaries: result.attachmentSummaries } : {}),
           ...(result.relatedRecords ? { relatedRecords: result.relatedRecords } : {}),
+          // W3-5: echo the batchId so a REST/grid caller can deep-link into the History Center for exactly
+          // this commit. NOTE (scope, not fixed here): only meaningful for this single patchRecords call —
+          // the `partialSuccess` branch above calls patchRecords ONCE PER RECORD with no shared batchId, so
+          // each record there mints its OWN batch (unlike the AI bulk-commit route, which explicitly shares
+          // one). That is a pre-existing gap in this route, out of scope for this additive change.
+          ...(result.batchId ? { batchId: result.batchId } : {}),
         },
       })
     } catch (err) {

--- a/packages/core-backend/tests/integration/multitable-patch-batchid-echo-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-patch-batchid-echo-realdb.test.ts
@@ -1,0 +1,112 @@
+/**
+ * W3-5b — `POST /patch` response.batchId wire round-trip (real DB).
+ *
+ * W3-5/W3-5a proved (DB-level only, via multitable-ai-write-provenance-batch-grouping-realdb.test.ts's G6)
+ * that a plain (non-AI) `/patch` call mints a fresh `batch_id` on `meta_record_revisions`. Separately,
+ * `RecordWriteService.patchRecords` now returns that same id as `result.batchId`, and the `/patch` route
+ * echoes it onto the JSON response (`data.batchId`) so a REST/grid caller can deep-link into the History
+ * Center for exactly this commit (see `HistoryCenterModal.vue`'s `initialBatchId` prop + the toast "View in
+ * history" action in `MultitableWorkbench.vue`). That response-level echo was never asserted over the wire
+ * — only the DB column was golden-covered. This suite closes that gap:
+ *   - a single-record `/patch` echoes a truthy `data.batchId` that equals the `batch_id` actually written
+ *     to `meta_record_revisions` for that commit;
+ *   - a multi-record `/patch` (one request, several records) shares ONE `data.batchId` across all of them,
+ *     matching every record's persisted `batch_id` — mirrors the AI-route sharing golden (G2), but for the
+ *     plain grid PATCH path.
+ *
+ * Out of scope (left exactly as-is, LOCK-12): the `partialSuccess` branch of `/patch` calls
+ * `patchRecords` ONCE PER RECORD with no shared batchId — each record there mints its OWN batch. That is a
+ * pre-existing gap noted in the route's own W3-5b comment, not something this suite touches.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI, matching this repo's real-DB suites).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_pbe_${TS}`
+const SHEET_ID = `sheet_pbe_${TS}`
+const F1 = `fld_pbe_a_${TS}`
+const F2 = `fld_pbe_b_${TS}`
+const REC1 = `rec_pbe_1_${TS}`
+const REC2 = `rec_pbe_2_${TS}`
+const USER_ID = `user_pbe_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+
+const patch = (changes: Array<{ recordId: string; fieldId: string; value: unknown }>) =>
+  request(app).post('/api/multitable/patch').send({ sheetId: SHEET_ID, changes })
+
+type RevisionRow = { batch_id: string | null }
+async function batchIdFor(recordId: string): Promise<string | null | undefined> {
+  const res = await q(
+    'SELECT batch_id FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 ORDER BY created_at DESC LIMIT 1',
+    [SHEET_ID, recordId],
+  )
+  return (res.rows[0] as RevisionRow | undefined)?.batch_id
+}
+
+describeIfDatabase('W3-5b — POST /patch response.batchId wire round-trip (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = { id: USER_ID, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'PBE Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'PBE Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F1, SHEET_ID, 'A', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F2, SHEET_ID, 'B', 'string', '{}', 2])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC1, SHEET_ID, JSON.stringify({ [F1]: 'orig-1', [F2]: 'orig-1b' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC2, SHEET_ID, JSON.stringify({ [F1]: 'orig-2', [F2]: 'orig-2b' })])
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('single-record /patch echoes a truthy data.batchId equal to the persisted batch_id', async () => {
+    const res = await patch([{ recordId: REC1, fieldId: F1, value: 'new-1' }])
+    expect(res.status).toBe(200)
+    expect(res.body.data.batchId).toBeTruthy()
+
+    const persisted = await batchIdFor(REC1)
+    expect(persisted).toBeTruthy()
+    expect(res.body.data.batchId).toBe(persisted)
+  })
+
+  test('multi-record /patch (one request) shares ONE data.batchId, matching every record\'s persisted batch_id', async () => {
+    const res = await patch([
+      { recordId: REC1, fieldId: F1, value: 'multi-1' },
+      { recordId: REC2, fieldId: F1, value: 'multi-2' },
+    ])
+    expect(res.status).toBe(200)
+    expect(res.body.data.batchId).toBeTruthy()
+
+    const [p1, p2] = await Promise.all([batchIdFor(REC1), batchIdFor(REC2)])
+    expect(p1).toBe(res.body.data.batchId)
+    expect(p2).toBe(res.body.data.batchId)
+  })
+})


### PR DESCRIPTION
## What
Part B of goal-pool W3-5 (Part A golden = #3719). After a commit, the success toast gains a **"View in history"** action that deep-links into the History Center, opened directly on that batch.

- **Backend**: hoist `bulkBatchId` out of the `patchRecords` tx closure → echo `batchId` on `RecordPatchResult` + the `/patch` response (`res.body.data.batchId`).
- **FE**: `PatchResult.batchId` → `grid.lastBatchId` → drawer-commit success toast `ToastAction` → opens `HistoryCenterModal` with `initialBatchId`.
- **Pinned-batch banner** (fixes the off-page gap): a deep-linked batch now renders in a top banner via an independent `loadPinned()` (same `getHistoryBatch` mechanism, decoupled from per-row expansion), so it shows even when the batch isn't on the modal's current page. Dismissable. Per-field diff markup extracted to shared `HistoryBatchChangesList.vue` so pin + row-expansion can't drift.

## Tests
- **Wire round-trip** (real-DB): `multitable-patch-batchid-echo-realdb.test.ts` — `/patch` response `.data.batchId` truthy + equals persisted `batch_id`; multi-record `/patch` shares one batchId. 3/3 green on local pg; wired into CI allowlist.
- **FE**: `multitable-history-center-pinned-batch-deeplink.spec.ts` (3) — banner renders when batch absent from page, dismiss works, no banner on normal open. Both type-checks clean.

## Flags for you
- **UX copy** (not design-locked): pinned banner reads "已定位到该批次 / Jumped to this batch" + "Clear". Reasonable default — adjust if you want.
- **Scope**: only the drawer-commit path shows the toast+link today (grid inline edit / pickers / form-submit don't yet). Kept small.
- **Adjacent finding (NOT fixed here)**: LOCK-12 `/patch` partialSuccess mints per-record batches — `/tmp/finding-lock12-partialsuccess-per-record-batch-20260706.md`. Owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)