### PR TITLE
feat(web): UF-4 automation manager/editor migrate onto Element Plus — the biggest 'two products' fix

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -19,43 +19,41 @@
           <div class="meta-automation__form-title">{{ editingRuleId ? l('manager.quickEditTitle') : l('manager.quickNewTitle') }}</div>
 
           <label class="meta-automation__label">{{ l('editor.name') }}</label>
-          <input
+          <el-input
             v-model="draft.name"
-            class="meta-automation__input"
             type="text"
             :placeholder="l('editor.namePlaceholder')"
             data-automation-field="name"
           />
 
           <label class="meta-automation__label">{{ l('trigger.title') }}</label>
-          <select v-model="draft.triggerType" class="meta-automation__select" data-automation-field="triggerType">
-            <option value="record.created">{{ automationTriggerTypeLabel('record.created', isZh) }}</option>
-            <option value="record.updated">{{ automationTriggerTypeLabel('record.updated', isZh) }}</option>
-            <option value="form.submitted">{{ automationTriggerTypeLabel('form.submitted', isZh) }}</option>
-            <option value="field.changed">{{ automationTriggerTypeLabel('field.changed', isZh) }}</option>
-          </select>
+          <el-select v-model="draft.triggerType" class="meta-automation__select" data-automation-field="triggerType">
+            <el-option value="record.created" data-value="record.created" :label="automationTriggerTypeLabel('record.created', isZh)" />
+            <el-option value="record.updated" data-value="record.updated" :label="automationTriggerTypeLabel('record.updated', isZh)" />
+            <el-option value="form.submitted" data-value="form.submitted" :label="automationTriggerTypeLabel('form.submitted', isZh)" />
+            <el-option value="field.changed" data-value="field.changed" :label="automationTriggerTypeLabel('field.changed', isZh)" />
+          </el-select>
 
           <template v-if="draft.triggerType === 'field.changed'">
             <label class="meta-automation__label">{{ l('trigger.watchField') }}</label>
-            <select v-model="draft.triggerFieldId" class="meta-automation__select" data-automation-field="triggerFieldId">
-              <option value="">{{ l('trigger.selectField') }}</option>
-              <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-            </select>
+            <el-select v-model="draft.triggerFieldId" class="meta-automation__select" :placeholder="l('trigger.selectField')" data-automation-field="triggerFieldId">
+              <el-option value="" data-value="" :label="l('trigger.selectField')" />
+              <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+            </el-select>
           </template>
 
           <label class="meta-automation__label">{{ l('manager.action') }}</label>
-          <select v-model="draft.actionType" class="meta-automation__select" data-automation-field="actionType">
-            <option value="notify">{{ automationActionTypeLabel('notify', isZh) }}</option>
-            <option value="update_field">{{ automationActionTypeLabel('update_field', isZh) }}</option>
-            <option value="send_dingtalk_group_message">{{ automationActionTypeLabel('send_dingtalk_group_message', isZh) }}</option>
-            <option value="send_dingtalk_person_message">{{ automationActionTypeLabel('send_dingtalk_person_message', isZh) }}</option>
-          </select>
+          <el-select v-model="draft.actionType" class="meta-automation__select" data-automation-field="actionType">
+            <el-option value="notify" data-value="notify" :label="automationActionTypeLabel('notify', isZh)" />
+            <el-option value="update_field" data-value="update_field" :label="automationActionTypeLabel('update_field', isZh)" />
+            <el-option value="send_dingtalk_group_message" data-value="send_dingtalk_group_message" :label="automationActionTypeLabel('send_dingtalk_group_message', isZh)" />
+            <el-option value="send_dingtalk_person_message" data-value="send_dingtalk_person_message" :label="automationActionTypeLabel('send_dingtalk_person_message', isZh)" />
+          </el-select>
 
           <template v-if="draft.actionType === 'notify'">
             <label class="meta-automation__label">{{ l('actionConfig.message') }}</label>
-            <input
+            <el-input
               v-model="draft.notifyMessage"
-              class="meta-automation__input"
               type="text"
               :placeholder="l('actionConfig.notificationMessagePlaceholder')"
               data-automation-field="notifyMessage"
@@ -64,14 +62,13 @@
 
           <template v-if="draft.actionType === 'update_field'">
             <label class="meta-automation__label">{{ l('manager.targetField') }}</label>
-            <select v-model="draft.targetFieldId" class="meta-automation__select" data-automation-field="targetFieldId">
-              <option value="">{{ l('trigger.selectField') }}</option>
-              <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-            </select>
+            <el-select v-model="draft.targetFieldId" class="meta-automation__select" :placeholder="l('trigger.selectField')" data-automation-field="targetFieldId">
+              <el-option value="" data-value="" :label="l('trigger.selectField')" />
+              <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+            </el-select>
             <label class="meta-automation__label">{{ l('editor.value') }}</label>
-            <input
+            <el-input
               v-model="draft.targetValue"
-              class="meta-automation__input"
               type="text"
               :placeholder="l('manager.newValuePlaceholder')"
               data-automation-field="targetValue"
@@ -81,22 +78,27 @@
           <template v-if="draft.actionType === 'send_dingtalk_group_message'">
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">{{ l('dingtalk.preset') }}</span>
-              <button class="meta-automation__btn" type="button" data-automation-preset="group-form" @click="applyGroupPreset('form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</button>
-              <button class="meta-automation__btn" type="button" data-automation-preset="group-internal" @click="applyGroupPreset('internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</button>
-              <button class="meta-automation__btn" type="button" data-automation-preset="group-both" @click="applyGroupPreset('form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</button>
+              <el-button size="small" data-automation-preset="group-form" @click="applyGroupPreset('form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</el-button>
+              <el-button size="small" data-automation-preset="group-internal" @click="applyGroupPreset('internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</el-button>
+              <el-button size="small" data-automation-preset="group-both" @click="applyGroupPreset('form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</el-button>
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.addGroups') }}</label>
-            <select
+            <el-select
               v-model="draft.dingtalkDestinationPickerId"
               class="meta-automation__select"
+              :placeholder="l('dingtalk.addGroupOption')"
               data-automation-field="dingtalkDestinationPickerId"
-              @change="appendDingTalkGroupDestination($event.target as HTMLSelectElement)"
+              @change="appendDingTalkGroupDestination"
             >
-              <option value="">{{ l('dingtalk.addGroupOption') }}</option>
-              <option v-for="destination in availableDingTalkGroupDestinations" :key="destination.id" :value="destination.id">
-                {{ destination.name }} · {{ dingTalkDestinationScopeLabel(destination) }}
-              </option>
-            </select>
+              <el-option value="" data-value="" :label="l('dingtalk.addGroupOption')" />
+              <el-option
+                v-for="destination in availableDingTalkGroupDestinations"
+                :key="destination.id"
+                :value="destination.id"
+                :data-value="destination.id"
+                :label="`${destination.name} · ${dingTalkDestinationScopeLabel(destination)}`"
+              />
+            </el-select>
             <div class="meta-automation__hint" data-automation-field="dingtalkDestinationPickerHint">
               {{ l('dingtalk.groupsRegisteredHint') }}
             </div>
@@ -125,24 +127,23 @@
               </button>
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.recordGroupFieldPaths') }}</label>
-            <input
+            <el-input
               v-model="draft.dingtalkDestinationFieldPath"
-              class="meta-automation__input"
               type="text"
               placeholder="record.opsDestinationId, record.escalationDestinationIds"
               data-automation-field="dingtalkDestinationFieldPath"
             />
             <label class="meta-automation__label">{{ l('dingtalk.pickGroupField') }}</label>
-            <select
+            <el-select
+              :model-value="''"
               class="meta-automation__select"
+              :placeholder="l('dingtalk.pickFieldOption')"
               data-automation-field="dingtalkDestinationFieldSelect"
-              @change="appendDingTalkGroupDestinationField($event.target as HTMLSelectElement)"
+              @change="appendDingTalkGroupDestinationField"
             >
-              <option value="">{{ l('dingtalk.pickFieldOption') }}</option>
-              <option v-for="field in dingTalkGroupDestinationCandidateFields" :key="field.id" :value="field.id">
-                {{ field.name }}
-              </option>
-            </select>
+              <el-option value="" data-value="" :label="l('dingtalk.pickFieldOption')" />
+              <el-option v-for="field in dingTalkGroupDestinationCandidateFields" :key="field.id" :value="field.id" :data-value="field.id" :label="field.name" />
+            </el-select>
             <div
               v-if="selectedDingTalkGroupDestinationFields.length"
               class="meta-automation__recipient-list meta-automation__recipient-list--selected"
@@ -168,9 +169,8 @@
               {{ warning }}
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.titleTemplate') }}</label>
-            <input
+            <el-input
               v-model="draft.dingtalkTitleTemplate"
-              class="meta-automation__input"
               type="text"
               :placeholder="l('dingtalk.titleTemplatePlaceholder')"
               data-automation-field="dingtalkTitleTemplate"
@@ -184,25 +184,24 @@
             </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">{{ l('dingtalk.templateTokens') }}</span>
-              <button
+              <el-button
                 v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
                 :key="token.key"
-                class="meta-automation__btn"
-                type="button"
+                size="small"
                 :data-automation-token="`group-title-${token.key}`"
                 @click="appendGroupTemplateToken('title', token.value)"
               >
                 {{ dingTalkTemplateTokenLabel(token, isZh) }}
-              </button>
+              </el-button>
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.bodyTemplate') }}</label>
-            <textarea
+            <el-input
               v-model="draft.dingtalkBodyTemplate"
-              class="meta-automation__input"
-              rows="4"
+              type="textarea"
+              :rows="4"
               :placeholder="l('dingtalk.bodyTemplatePlaceholder')"
               data-automation-field="dingtalkBodyTemplate"
-            ></textarea>
+            />
             <div
               v-for="warning in templateSyntaxWarnings(draft.dingtalkBodyTemplate)"
               :key="`draft-group-body-${warning}`"
@@ -212,22 +211,21 @@
             </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">{{ l('dingtalk.templateTokens') }}</span>
-              <button
+              <el-button
                 v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
                 :key="token.key"
-                class="meta-automation__btn"
-                type="button"
+                size="small"
                 :data-automation-token="`group-body-${token.key}`"
                 @click="appendGroupTemplateToken('body', token.value)"
               >
                 {{ dingTalkTemplateTokenLabel(token, isZh) }}
-              </button>
+              </el-button>
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.publicFormView') }}</label>
-            <select v-model="draft.publicFormViewId" class="meta-automation__select" data-automation-field="publicFormViewId">
-              <option value="">{{ l('dingtalk.noPublicFormLinkOption') }}</option>
-              <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
-            </select>
+            <el-select v-model="draft.publicFormViewId" class="meta-automation__select" :placeholder="l('dingtalk.noPublicFormLinkOption')" data-automation-field="publicFormViewId">
+              <el-option value="" data-value="" :label="l('dingtalk.noPublicFormLinkOption')" />
+              <el-option v-for="view in formViews" :key="view.id" :value="view.id" :data-value="view.id" :label="view.name" />
+            </el-select>
             <div
               v-for="warning in publicFormLinkWarnings(draft.publicFormViewId, true)"
               :key="`draft-group-public-form-${warning}`"
@@ -236,10 +234,10 @@
               {{ warning }}
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.internalProcessingView') }}</label>
-            <select v-model="draft.internalViewId" class="meta-automation__select" data-automation-field="internalViewId">
-              <option value="">{{ l('dingtalk.noInternalLinkOption') }}</option>
-              <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
-            </select>
+            <el-select v-model="draft.internalViewId" class="meta-automation__select" :placeholder="l('dingtalk.noInternalLinkOption')" data-automation-field="internalViewId">
+              <el-option value="" data-value="" :label="l('dingtalk.noInternalLinkOption')" />
+              <el-option v-for="view in internalViews" :key="view.id" :value="view.id" :data-value="view.id" :label="view.name" />
+            </el-select>
             <div
               v-for="warning in internalViewLinkWarnings(draft.internalViewId)"
               :key="`draft-group-internal-view-${warning}`"
@@ -255,25 +253,27 @@
               <div class="meta-automation__preview-body"><strong>{{ l('dingtalk.bodyTemplate') }}:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, l('dingtalk.noBodyTemplate')) }}</div>
               <div class="meta-automation__preview-line">
                 <span><strong>{{ l('dingtalk.renderedTitle') }}:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, l('dingtalk.noRenderedTitle')) }}</span>
-                <button
+                <el-button
+                  size="small"
+                  round
                   class="meta-automation__copy-btn"
-                  type="button"
                   data-automation-copy="group-rendered-title"
                   @click="copyPreviewText('group-title', renderedTemplateExample(draft.dingtalkTitleTemplate, ''))"
                 >
                   {{ copiedPreviewKey === 'group-title' ? l('dingtalk.copied') : l('dingtalk.copy') }}
-                </button>
+                </el-button>
               </div>
               <div class="meta-automation__preview-line meta-automation__preview-body">
                 <span><strong>{{ l('dingtalk.renderedBody') }}:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, l('dingtalk.noRenderedBody')) }}</span>
-                <button
+                <el-button
+                  size="small"
+                  round
                   class="meta-automation__copy-btn"
-                  type="button"
                   data-automation-copy="group-rendered-body"
                   @click="copyPreviewText('group-body', renderedTemplateExample(draft.dingtalkBodyTemplate, ''))"
                 >
                   {{ copiedPreviewKey === 'group-body' ? l('dingtalk.copied') : l('dingtalk.copy') }}
-                </button>
+                </el-button>
               </div>
               <div><strong>{{ l('dingtalk.publicForm') }}:</strong> {{ viewSummaryName(draft.publicFormViewId, l('dingtalk.noPublicFormLink')) }}</div>
               <div
@@ -294,14 +294,13 @@
           <template v-if="draft.actionType === 'send_dingtalk_person_message'">
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">{{ l('dingtalk.preset') }}</span>
-              <button class="meta-automation__btn" type="button" data-automation-preset="person-form" @click="applyPersonPreset('form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</button>
-              <button class="meta-automation__btn" type="button" data-automation-preset="person-internal" @click="applyPersonPreset('internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</button>
-              <button class="meta-automation__btn" type="button" data-automation-preset="person-both" @click="applyPersonPreset('form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</button>
+              <el-button size="small" data-automation-preset="person-form" @click="applyPersonPreset('form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</el-button>
+              <el-button size="small" data-automation-preset="person-internal" @click="applyPersonPreset('internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</el-button>
+              <el-button size="small" data-automation-preset="person-both" @click="applyPersonPreset('form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</el-button>
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.searchUsersOrGroups') }}</label>
-            <input
+            <el-input
               v-model="dingtalkPersonUserSearch"
-              class="meta-automation__input"
               type="text"
               :placeholder="l('dingtalk.searchUsersOrGroupsPlaceholder')"
               data-automation-field="dingtalkPersonUserSearch"
@@ -359,40 +358,45 @@
               </button>
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.localUserIds') }}</label>
-            <textarea
+            <el-input
               v-model="draft.dingtalkPersonUserIds"
-              class="meta-automation__input"
-              rows="3"
+              type="textarea"
+              :rows="3"
               :placeholder="l('dingtalk.localUserIdsPlaceholder')"
               data-automation-field="dingtalkPersonUserIds"
-            ></textarea>
+            />
             <label class="meta-automation__label">{{ l('dingtalk.memberGroupIds') }}</label>
-            <textarea
+            <el-input
               v-model="draft.dingtalkPersonMemberGroupIds"
-              class="meta-automation__input"
-              rows="2"
+              type="textarea"
+              :rows="2"
               :placeholder="l('dingtalk.memberGroupIdsPlaceholder')"
               data-automation-field="dingtalkPersonMemberGroupIds"
-            ></textarea>
+            />
             <label class="meta-automation__label">{{ l('dingtalk.recordRecipientFieldPaths') }}</label>
-            <input
+            <el-input
               v-model="draft.dingtalkPersonRecipientFieldPath"
-              class="meta-automation__input"
               type="text"
               :placeholder="l('dingtalk.recordRecipientFieldPathPlaceholder')"
               data-automation-field="dingtalkPersonRecipientFieldPath"
             />
             <label class="meta-automation__label">{{ l('dingtalk.pickRecipientField') }}</label>
-            <select
+            <el-select
+              :model-value="''"
               class="meta-automation__select"
+              :placeholder="l('dingtalk.chooseUserFieldOption')"
               data-automation-field="dingtalkPersonRecipientFieldSelect"
-              @change="appendDingTalkPersonRecipientField($event.target as HTMLSelectElement)"
+              @change="appendDingTalkPersonRecipientField"
             >
-              <option value="">{{ l('dingtalk.chooseUserFieldOption') }}</option>
-              <option v-for="field in dingTalkPersonRecipientCandidateFields" :key="field.id" :value="field.id">
-                {{ field.name }} (record.{{ field.id }})
-              </option>
-            </select>
+              <el-option value="" data-value="" :label="l('dingtalk.chooseUserFieldOption')" />
+              <el-option
+                v-for="field in dingTalkPersonRecipientCandidateFields"
+                :key="field.id"
+                :value="field.id"
+                :data-value="field.id"
+                :label="`${field.name} (record.${field.id})`"
+              />
+            </el-select>
             <div
               v-if="selectedDingTalkPersonRecipientFields.length"
               class="meta-automation__recipient-list meta-automation__recipient-list--selected"
@@ -420,24 +424,29 @@
               {{ l('dingtalk.recordRecipientFieldPathHint') }}
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.recordMemberGroupFieldPaths') }}</label>
-            <input
+            <el-input
               v-model="draft.dingtalkPersonMemberGroupRecipientFieldPath"
-              class="meta-automation__input"
               type="text"
               :placeholder="l('dingtalk.recordMemberGroupFieldPathPlaceholder')"
               data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"
             />
             <label class="meta-automation__label">{{ l('dingtalk.pickMemberGroupField') }}</label>
-            <select
+            <el-select
+              :model-value="''"
               class="meta-automation__select"
+              :placeholder="l('dingtalk.chooseMemberGroupFieldOption')"
               data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"
-              @change="appendDingTalkPersonMemberGroupRecipientField($event.target as HTMLSelectElement)"
+              @change="appendDingTalkPersonMemberGroupRecipientField"
             >
-              <option value="">{{ l('dingtalk.chooseMemberGroupFieldOption') }}</option>
-              <option v-for="field in dingTalkPersonMemberGroupRecipientCandidateFields" :key="field.id" :value="field.id">
-                {{ field.name }} (record.{{ field.id }})
-              </option>
-            </select>
+              <el-option value="" data-value="" :label="l('dingtalk.chooseMemberGroupFieldOption')" />
+              <el-option
+                v-for="field in dingTalkPersonMemberGroupRecipientCandidateFields"
+                :key="field.id"
+                :value="field.id"
+                :data-value="field.id"
+                :label="`${field.name} (record.${field.id})`"
+              />
+            </el-select>
             <div
               v-if="selectedDingTalkPersonMemberGroupRecipientFields.length"
               class="meta-automation__recipient-list meta-automation__recipient-list--selected"
@@ -465,9 +474,8 @@
               {{ l('dingtalk.recordMemberGroupFieldPathHint') }}
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.titleTemplate') }}</label>
-            <input
+            <el-input
               v-model="draft.dingtalkPersonTitleTemplate"
-              class="meta-automation__input"
               type="text"
               :placeholder="l('dingtalk.titleTemplatePlaceholder')"
               data-automation-field="dingtalkPersonTitleTemplate"
@@ -481,25 +489,24 @@
             </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">{{ l('dingtalk.templateTokens') }}</span>
-              <button
+              <el-button
                 v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
                 :key="token.key"
-                class="meta-automation__btn"
-                type="button"
+                size="small"
                 :data-automation-token="`person-title-${token.key}`"
                 @click="appendPersonTemplateToken('title', token.value)"
               >
                 {{ dingTalkTemplateTokenLabel(token, isZh) }}
-              </button>
+              </el-button>
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.bodyTemplate') }}</label>
-            <textarea
+            <el-input
               v-model="draft.dingtalkPersonBodyTemplate"
-              class="meta-automation__input"
-              rows="4"
+              type="textarea"
+              :rows="4"
               :placeholder="l('dingtalk.bodyTemplatePlaceholder')"
               data-automation-field="dingtalkPersonBodyTemplate"
-            ></textarea>
+            />
             <div
               v-for="warning in templateSyntaxWarnings(draft.dingtalkPersonBodyTemplate)"
               :key="`draft-person-body-${warning}`"
@@ -509,22 +516,21 @@
             </div>
             <div class="meta-automation__preset-row">
               <span class="meta-automation__preset-label">{{ l('dingtalk.templateTokens') }}</span>
-              <button
+              <el-button
                 v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
                 :key="token.key"
-                class="meta-automation__btn"
-                type="button"
+                size="small"
                 :data-automation-token="`person-body-${token.key}`"
                 @click="appendPersonTemplateToken('body', token.value)"
               >
                 {{ dingTalkTemplateTokenLabel(token, isZh) }}
-              </button>
+              </el-button>
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.publicFormView') }}</label>
-            <select v-model="draft.dingtalkPersonPublicFormViewId" class="meta-automation__select" data-automation-field="dingtalkPersonPublicFormViewId">
-              <option value="">{{ l('dingtalk.noPublicFormLinkOption') }}</option>
-              <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
-            </select>
+            <el-select v-model="draft.dingtalkPersonPublicFormViewId" class="meta-automation__select" :placeholder="l('dingtalk.noPublicFormLinkOption')" data-automation-field="dingtalkPersonPublicFormViewId">
+              <el-option value="" data-value="" :label="l('dingtalk.noPublicFormLinkOption')" />
+              <el-option v-for="view in formViews" :key="view.id" :value="view.id" :data-value="view.id" :label="view.name" />
+            </el-select>
             <div
               v-for="warning in publicFormLinkWarnings(draft.dingtalkPersonPublicFormViewId, true)"
               :key="`draft-person-public-form-${warning}`"
@@ -533,10 +539,10 @@
               {{ warning }}
             </div>
             <label class="meta-automation__label">{{ l('dingtalk.internalProcessingView') }}</label>
-            <select v-model="draft.dingtalkPersonInternalViewId" class="meta-automation__select" data-automation-field="dingtalkPersonInternalViewId">
-              <option value="">{{ l('dingtalk.noInternalLinkOption') }}</option>
-              <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
-            </select>
+            <el-select v-model="draft.dingtalkPersonInternalViewId" class="meta-automation__select" :placeholder="l('dingtalk.noInternalLinkOption')" data-automation-field="dingtalkPersonInternalViewId">
+              <el-option value="" data-value="" :label="l('dingtalk.noInternalLinkOption')" />
+              <el-option v-for="view in internalViews" :key="view.id" :value="view.id" :data-value="view.id" :label="view.name" />
+            </el-select>
             <div
               v-for="warning in internalViewLinkWarnings(draft.dingtalkPersonInternalViewId)"
               :key="`draft-person-internal-view-${warning}`"
@@ -553,25 +559,27 @@
               <div class="meta-automation__preview-body"><strong>{{ l('dingtalk.bodyTemplate') }}:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, l('dingtalk.noBodyTemplate')) }}</div>
               <div class="meta-automation__preview-line">
                 <span><strong>{{ l('dingtalk.renderedTitle') }}:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, l('dingtalk.noRenderedTitle')) }}</span>
-                <button
+                <el-button
+                  size="small"
+                  round
                   class="meta-automation__copy-btn"
-                  type="button"
                   data-automation-copy="person-rendered-title"
                   @click="copyPreviewText('person-title', renderedTemplateExample(draft.dingtalkPersonTitleTemplate, ''))"
                 >
                   {{ copiedPreviewKey === 'person-title' ? l('dingtalk.copied') : l('dingtalk.copy') }}
-                </button>
+                </el-button>
               </div>
               <div class="meta-automation__preview-line meta-automation__preview-body">
                 <span><strong>{{ l('dingtalk.renderedBody') }}:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, l('dingtalk.noRenderedBody')) }}</span>
-                <button
+                <el-button
+                  size="small"
+                  round
                   class="meta-automation__copy-btn"
-                  type="button"
                   data-automation-copy="person-rendered-body"
                   @click="copyPreviewText('person-body', renderedTemplateExample(draft.dingtalkPersonBodyTemplate, ''))"
                 >
                   {{ copiedPreviewKey === 'person-body' ? l('dingtalk.copied') : l('dingtalk.copy') }}
-                </button>
+                </el-button>
               </div>
               <div><strong>{{ l('dingtalk.publicForm') }}:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, l('dingtalk.noPublicFormLink')) }}</div>
               <div
@@ -590,31 +598,30 @@
           </template>
 
           <div class="meta-automation__form-actions">
-            <button class="meta-automation__btn meta-automation__btn--primary" type="button" :disabled="!canSave" @click="onSave">
+            <el-button type="primary" class="meta-automation__btn--primary" :disabled="!canSave" @click="onSave">
               {{ editingRuleId ? l('manager.update') : l('manager.create') }}
-            </button>
-            <button class="meta-automation__btn" type="button" @click="cancelForm">{{ l('editor.cancel') }}</button>
+            </el-button>
+            <el-button @click="cancelForm">{{ l('editor.cancel') }}</el-button>
           </div>
         </section>
 
         <!-- Add buttons -->
         <div v-if="!showForm && !showRuleEditor" class="meta-automation__add-row">
-          <button
-            class="meta-automation__btn meta-automation__btn--primary"
-            type="button"
+          <el-button
+            type="primary"
+            class="meta-automation__btn--primary"
             data-automation-new-rule="advanced"
             @click="openRuleEditor()"
           >
             {{ l('manager.newAutomation') }}
-          </button>
-          <button
-            class="meta-automation__btn meta-automation__btn-add"
-            type="button"
+          </el-button>
+          <el-button
+            class="meta-automation__btn-add"
             data-automation-new-rule="quick"
             @click="openCreateForm"
           >
             {{ l('manager.quickLegacyForm') }}
-          </button>
+          </el-button>
         </div>
 
         <!-- Rule list -->
@@ -630,15 +637,14 @@
         >
           <div class="meta-automation__card-header">
             <strong class="meta-automation__card-name">{{ rule.name }}</strong>
-            <label class="meta-automation__toggle">
-              <input
-                type="checkbox"
-                :checked="rule.enabled"
-                data-automation-toggle="true"
-                @change="onToggle(rule)"
-              />
-              <span>{{ rule.enabled ? l('manager.enabled') : l('manager.disabled') }}</span>
-            </label>
+            <el-checkbox
+              class="meta-automation__toggle"
+              :model-value="rule.enabled"
+              data-automation-toggle="true"
+              @change="onToggle(rule)"
+            >
+              {{ rule.enabled ? l('manager.enabled') : l('manager.disabled') }}
+            </el-checkbox>
           </div>
           <div class="meta-automation__card-desc">
             {{ describeTrigger(rule) }} &rarr; {{ describeAction(rule) }}
@@ -649,25 +655,25 @@
               :key="link.key"
               class="meta-automation__card-link-item"
             >
-              <a
+              <el-button
                 v-if="link.href"
-                class="meta-automation__btn meta-automation__btn-link"
+                tag="a"
+                class="meta-automation__btn-link"
                 :href="link.href"
                 target="_blank"
                 rel="noopener noreferrer"
                 :data-automation-card-link="link.key"
               >
                 {{ link.label }}
-              </a>
-              <button
+              </el-button>
+              <el-button
                 v-else
-                class="meta-automation__btn meta-automation__btn-link"
-                type="button"
+                class="meta-automation__btn-link"
                 :data-automation-card-link="link.key"
                 @click="openInternalView(link.viewId ?? '')"
               >
                 {{ link.label }}
-              </button>
+              </el-button>
               <span
                 v-if="link.accessSummary"
                 class="meta-automation__card-link-access"
@@ -700,27 +706,23 @@
             {{ ruleTestRunStates[rule.id].message }}
           </div>
           <div class="meta-automation__card-actions">
-            <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openRuleEditor(rule)">{{ l('manager.edit') }}</button>
-            <button class="meta-automation__btn" type="button" data-automation-logs="true" @click="openLogViewer(rule)">{{ l('manager.viewLogs') }}</button>
-            <button
+            <el-button data-automation-edit="true" @click="openRuleEditor(rule)">{{ l('manager.edit') }}</el-button>
+            <el-button data-automation-logs="true" @click="openLogViewer(rule)">{{ l('manager.viewLogs') }}</el-button>
+            <el-button
               v-if="ruleHasActionType(rule, 'send_dingtalk_group_message')"
-              class="meta-automation__btn"
-              type="button"
               :data-automation-group-deliveries="rule.id"
               @click="openGroupDeliveryViewer(rule)"
             >
               {{ l('manager.viewDeliveries') }}
-            </button>
-            <button
+            </el-button>
+            <el-button
               v-if="ruleHasActionType(rule, 'send_dingtalk_person_message')"
-              class="meta-automation__btn"
-              type="button"
               :data-automation-person-deliveries="rule.id"
               @click="openPersonDeliveryViewer(rule)"
             >
               {{ l('manager.viewDeliveries') }}
-            </button>
-            <button class="meta-automation__btn meta-automation__btn--danger" type="button" data-automation-delete="true" @click="onDelete(rule)">{{ l('manager.delete') }}</button>
+            </el-button>
+            <el-button type="danger" plain data-automation-delete="true" @click="onDelete(rule)">{{ l('manager.delete') }}</el-button>
           </div>
         </div>
       </div>
@@ -762,7 +764,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
-import { ElDrawer } from 'element-plus'
+import { ElButton, ElCheckbox, ElDrawer, ElInput, ElOption, ElSelect } from 'element-plus'
 import { useRouter } from 'vue-router'
 import type {
   AutomationExecution,
@@ -1172,12 +1174,11 @@ const availableDingTalkGroupDestinations = computed(() => {
   return dingTalkDestinations.value.filter((destination) => !selected.has(destination.id))
 })
 
-function appendDingTalkGroupDestination(select: HTMLSelectElement) {
-  const destinationId = select.value.trim()
+function appendDingTalkGroupDestination(value: string) {
+  const destinationId = value.trim()
   if (!destinationId) return
   draft.value.dingtalkDestinationIds = Array.from(new Set([...draft.value.dingtalkDestinationIds, destinationId]))
   draft.value.dingtalkDestinationPickerId = ''
-  select.value = ''
 }
 
 function removeDingTalkGroupDestination(destinationId: string) {
@@ -1399,15 +1400,14 @@ const dingTalkGroupFieldSummary = computed(() => {
   return labels.join(', ')
 })
 
-function appendDingTalkGroupDestinationField(select: HTMLSelectElement) {
-  const value = select.value.trim()
+function appendDingTalkGroupDestinationField(selected: string) {
+  const value = selected.trim()
   if (!value) return
   const paths = parseRecipientFieldPathsText(draft.value.dingtalkDestinationFieldPath)
   paths.push(value)
   draft.value.dingtalkDestinationFieldPath = Array.from(new Set(paths))
     .map((path) => `record.${path}`)
     .join(', ')
-  select.value = ''
 }
 
 function removeDingTalkGroupDestinationField(path: string) {
@@ -1417,15 +1417,14 @@ function removeDingTalkGroupDestinationField(path: string) {
     .join(', ')
 }
 
-function appendDingTalkPersonRecipientField(select: HTMLSelectElement) {
-  const value = select.value.trim()
+function appendDingTalkPersonRecipientField(selected: string) {
+  const value = selected.trim()
   if (!value) return
   const paths = parseRecipientFieldPathsText(draft.value.dingtalkPersonRecipientFieldPath)
   paths.push(value)
   draft.value.dingtalkPersonRecipientFieldPath = Array.from(new Set(paths))
     .map((path) => `record.${path}`)
     .join(', ')
-  select.value = ''
 }
 
 function removeDingTalkPersonRecipientField(path: string) {
@@ -1435,15 +1434,14 @@ function removeDingTalkPersonRecipientField(path: string) {
     .join(', ')
 }
 
-function appendDingTalkPersonMemberGroupRecipientField(select: HTMLSelectElement) {
-  const value = select.value.trim()
+function appendDingTalkPersonMemberGroupRecipientField(selected: string) {
+  const value = selected.trim()
   if (!value) return
   const paths = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
   paths.push(value)
   draft.value.dingtalkPersonMemberGroupRecipientFieldPath = Array.from(new Set(paths))
     .map((path) => `record.${path}`)
     .join(', ')
-  select.value = ''
 }
 
 function removeDingTalkPersonMemberGroupRecipientField(path: string) {
@@ -1933,12 +1931,14 @@ watch(
 </script>
 
 <style scoped>
-/* UF-4: the hand-rolled fixed overlay + panel + header/close chrome is now provided by el-drawer. */
+/* UF-4: the hand-rolled fixed overlay + panel + header/close chrome is now provided by el-drawer,
+   and native control skins (.meta-automation__input/__select/__btn…) by Element Plus. Remaining
+   rules are layout + this component's own semantic surfaces, colored via tokens.css only. */
 .meta-automation__title {
   margin: 0;
   font-size: 16px;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--ms-text-1);
 }
 
 .meta-automation__body {
@@ -1951,21 +1951,21 @@ watch(
   padding: 10px 12px;
   border-radius: 10px;
   font-size: 13px;
-  background: #fef2f2;
-  color: #b91c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
 }
 
 .meta-automation__empty {
   padding: 10px 12px;
   border-radius: 10px;
   font-size: 13px;
-  background: #f8fafc;
-  color: #64748b;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-3);
 }
 
 /* Form */
 .meta-automation__form {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 10px;
   padding: 14px;
   display: flex;
@@ -1976,40 +1976,28 @@ watch(
 .meta-automation__form-title {
   font-size: 14px;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--ms-text-1);
   margin-bottom: 4px;
 }
 
 .meta-automation__label {
   font-size: 12px;
   font-weight: 600;
-  color: #475569;
+  color: var(--ms-text-2);
   margin-top: 4px;
 }
 
 .meta-automation__hint {
   font-size: 12px;
-  color: #64748b;
+  color: var(--ms-text-3);
 }
 
 .meta-automation__hint--error {
-  color: #b91c1c;
+  color: var(--el-color-danger-dark-2);
 }
 
 .meta-automation__hint--warning {
-  color: #b45309;
-}
-
-.meta-automation__input,
-.meta-automation__select {
-  width: 100%;
-  min-width: 0;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 8px 10px;
-  font-size: 13px;
-  background: #fff;
-  box-sizing: border-box;
+  color: var(--el-color-warning-dark-2);
 }
 
 .meta-automation__recipient-list {
@@ -2034,24 +2022,24 @@ watch(
 .meta-automation__preset-label {
   font-size: 12px;
   font-weight: 600;
-  color: #475569;
+  color: var(--ms-text-2);
 }
 
 .meta-automation__preview {
-  border: 1px solid #dbeafe;
-  background: #f8fbff;
+  border: 1px solid var(--el-color-primary-light-8);
+  background: var(--el-color-primary-light-9);
   border-radius: 8px;
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
-  color: #334155;
+  color: var(--ms-text-2);
 }
 
 .meta-automation__preview-title {
   font-weight: 700;
-  color: #1e3a8a;
+  color: var(--el-color-primary-dark-2);
 }
 
 .meta-automation__preview-line {
@@ -2067,13 +2055,6 @@ watch(
 
 .meta-automation__copy-btn {
   flex-shrink: 0;
-  border: 1px solid #bfdbfe;
-  background: #fff;
-  color: #1d4ed8;
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 11px;
-  cursor: pointer;
 }
 
 .meta-automation__recipient-option,
@@ -2082,19 +2063,19 @@ watch(
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--ms-border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--ms-bg-card);
   padding: 8px 10px;
   cursor: pointer;
-  color: #0f172a;
+  color: var(--ms-text-1);
 }
 
 .meta-automation__recipient-option span,
 .meta-automation__recipient-chip span,
 .meta-automation__recipient-chip em {
   font-size: 12px;
-  color: #64748b;
+  color: var(--ms-text-3);
   font-style: normal;
 }
 
@@ -2106,7 +2087,7 @@ watch(
 
 /* Cards */
 .meta-automation__card {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 10px;
   padding: 12px 14px;
   display: flex;
@@ -2122,21 +2103,12 @@ watch(
 
 .meta-automation__card-name {
   font-size: 14px;
-  color: #0f172a;
-}
-
-.meta-automation__toggle {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: #64748b;
-  cursor: pointer;
+  color: var(--ms-text-1);
 }
 
 .meta-automation__card-desc {
   font-size: 13px;
-  color: #475569;
+  color: var(--ms-text-2);
 }
 
 .meta-automation__card-links {
@@ -2155,37 +2127,37 @@ watch(
 
 .meta-automation__card-link-access {
   border-radius: 999px;
-  background: #f8fafc;
-  color: #475569;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1;
   padding: 5px 8px;
 }
 
 .meta-automation__card-link-access--public {
-  background: #fffbeb;
-  color: #92400e;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
 }
 
 .meta-automation__card-link-access--dingtalk {
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
 }
 
 .meta-automation__card-link-access--dingtalk_granted {
-  background: #ecfdf5;
-  color: #047857;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .meta-automation__card-link-access--unavailable {
-  background: #fef2f2;
-  color: #b91c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
 }
 
 .meta-automation__card-link-audience {
   border-radius: 999px;
-  background: #f8fafc;
-  color: #475569;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1;
   padding: 5px 8px;
@@ -2197,28 +2169,28 @@ watch(
 }
 
 .meta-automation__public-form-access--none {
-  background: #f8fafc;
-  color: #475569;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .meta-automation__public-form-access--public {
-  background: #fffbeb;
-  color: #92400e;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
 }
 
 .meta-automation__public-form-access--dingtalk {
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
 }
 
 .meta-automation__public-form-access--dingtalk_granted {
-  background: #ecfdf5;
-  color: #047857;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .meta-automation__public-form-access--unavailable {
-  background: #fef2f2;
-  color: #b91c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
 }
 
 .meta-automation__card-actions {
@@ -2227,35 +2199,8 @@ watch(
   margin-top: 4px;
 }
 
-/* Buttons */
-.meta-automation__btn {
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 6px 14px;
-  background: #fff;
-  color: #0f172a;
-  font-size: 13px;
-  cursor: pointer;
-}
-
 .meta-automation__btn-link {
   text-decoration: none;
-}
-
-.meta-automation__btn:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.meta-automation__btn--primary {
-  border-color: #2563eb;
-  background: #2563eb;
-  color: #fff;
-}
-
-.meta-automation__btn--danger {
-  border-color: #ef4444;
-  color: #b91c1c;
 }
 
 .meta-automation__btn-add {
@@ -2269,16 +2214,16 @@ watch(
 }
 
 .meta-automation__stat { font-weight: 600; }
-.meta-automation__stat--success { color: #16a34a; }
-.meta-automation__stat--failed { color: #dc2626; }
+.meta-automation__stat--success { color: var(--ms-color-success); }
+.meta-automation__stat--failed { color: var(--ms-color-danger); }
 
 .meta-automation__test-run-status {
   font-size: 12px;
   font-weight: 600;
 }
 
-.meta-automation__test-run-status--success { color: #15803d; }
-.meta-automation__test-run-status--failed { color: #b91c1c; }
-.meta-automation__test-run-status--skipped { color: #b45309; }
-.meta-automation__test-run-status--running { color: #1d4ed8; }
+.meta-automation__test-run-status--success { color: var(--el-color-success-dark-2); }
+.meta-automation__test-run-status--failed { color: var(--el-color-danger-dark-2); }
+.meta-automation__test-run-status--skipped { color: var(--el-color-warning-dark-2); }
+.meta-automation__test-run-status--running { color: var(--el-color-primary-dark-2); }
 </style>

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -1,12 +1,17 @@
 <template>
-  <div v-if="visible" class="meta-automation__overlay" @click.self="$emit('close')">
-    <div class="meta-automation">
-      <div class="meta-automation__header">
-        <h4 class="meta-automation__title">{{ l('manager.title') }}</h4>
-        <button class="meta-automation__close" type="button" @click="$emit('close')">&times;</button>
-      </div>
+  <el-drawer
+    v-if="visible"
+    :model-value="visible"
+    class="meta-automation"
+    direction="rtl"
+    size="640px"
+    @update:model-value="(value) => { if (!value) $emit('close') }"
+  >
+    <template #header>
+      <h4 class="meta-automation__title">{{ l('manager.title') }}</h4>
+    </template>
 
-      <div class="meta-automation__body">
+    <div class="meta-automation__body">
         <div v-if="error" class="meta-automation__error" role="alert">{{ error }}</div>
 
         <!-- Create / Edit form -->
@@ -719,7 +724,6 @@
           </div>
         </div>
       </div>
-    </div>
     <MetaAutomationRuleEditor
       :visible="showRuleEditor"
       :sheet-id="sheetId"
@@ -753,11 +757,12 @@
       :client="client"
       @close="showGroupDeliveryViewer = false"
     />
-  </div>
+  </el-drawer>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ElDrawer } from 'element-plus'
 import { useRouter } from 'vue-router'
 import type {
   AutomationExecution,
@@ -1928,35 +1933,7 @@ watch(
 </script>
 
 <style scoped>
-.meta-automation__overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.35);
-}
-
-.meta-automation {
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
-  width: 560px;
-  max-width: 95vw;
-  max-height: 85vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.meta-automation__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 18px 20px 12px;
-  border-bottom: 1px solid #e2e8f0;
-}
-
+/* UF-4: the hand-rolled fixed overlay + panel + header/close chrome is now provided by el-drawer. */
 .meta-automation__title {
   margin: 0;
   font-size: 16px;
@@ -1964,19 +1941,7 @@ watch(
   color: #0f172a;
 }
 
-.meta-automation__close {
-  border: none;
-  background: none;
-  font-size: 22px;
-  cursor: pointer;
-  color: #64748b;
-  line-height: 1;
-  padding: 0 4px;
-}
-
 .meta-automation__body {
-  padding: 16px 20px 20px;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1,12 +1,17 @@
 <template>
-  <div v-if="visible" class="meta-rule-editor__overlay" @click.self="requestClose">
-    <div class="meta-rule-editor">
-      <div class="meta-rule-editor__header">
-        <h4 class="meta-rule-editor__title">{{ rule ? automationLabel('editor.titleEdit', isZh) : automationLabel('editor.titleNew', isZh) }}</h4>
-        <button class="meta-rule-editor__close" type="button" @click="requestClose">&times;</button>
-      </div>
+  <el-drawer
+    v-if="visible"
+    :model-value="visible"
+    class="meta-rule-editor"
+    direction="rtl"
+    size="640px"
+    :before-close="() => requestClose()"
+  >
+    <template #header>
+      <h4 class="meta-rule-editor__title">{{ rule ? automationLabel('editor.titleEdit', isZh) : automationLabel('editor.titleNew', isZh) }}</h4>
+    </template>
 
-      <div class="meta-rule-editor__body">
+    <div class="meta-rule-editor__body">
         <div v-if="error" class="meta-rule-editor__error" role="alert">{{ error }}</div>
 
         <!-- Name -->
@@ -1198,9 +1203,10 @@
             @click="addAction"
           >{{ automationLabel('editor.addAction', isZh) }}</button>
         </section>
-      </div>
+    </div>
 
-      <!-- Footer -->
+    <!-- Footer -->
+    <template #footer>
       <div class="meta-rule-editor__footer">
         <div class="meta-rule-editor__test-run-feedback">
           <div v-if="savedRuleHasDingTalkActions" class="meta-rule-editor__hint meta-rule-editor__hint--warning" data-field="dingtalkTestRunWarning">
@@ -1236,12 +1242,13 @@
         </button>
         <button class="meta-rule-editor__btn" type="button" @click="requestClose">{{ automationLabel('editor.cancel', isZh) }}</button>
       </div>
-    </div>
-  </div>
+    </template>
+  </el-drawer>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ElDrawer } from 'element-plus'
 import { useLocale } from '../../composables/useLocale'
 import type { MultitableApiClient } from '../api/client'
 import type {
@@ -3404,45 +3411,13 @@ function onTestRun() {
 </script>
 
 <style scoped>
-.meta-rule-editor__overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.35);
-}
-
-.meta-rule-editor {
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
-  width: 640px;
-  max-width: 95vw;
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.meta-rule-editor__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 18px 20px 12px;
-  border-bottom: 1px solid #e2e8f0;
-}
-
+/* UF-4: the hand-rolled fixed overlay + panel + header/close chrome is now provided by el-drawer. */
 .meta-rule-editor__title { margin: 0; font-size: 16px; font-weight: 700; color: #0f172a; }
-.meta-rule-editor__close { border: none; background: none; font-size: 22px; cursor: pointer; color: #64748b; line-height: 1; padding: 0 4px; }
 
 .meta-rule-editor__body {
-  padding: 16px 20px;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  flex: 1;
 }
 
 .meta-rule-editor__error { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: #fef2f2; color: #b91c1c; }
@@ -3725,8 +3700,6 @@ function onTestRun() {
   align-items: center;
   flex-wrap: wrap;
   gap: 8px;
-  padding: 12px 20px 16px;
-  border-top: 1px solid #e2e8f0;
 }
 
 .meta-rule-editor__btn {

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -16,33 +16,32 @@
 
         <!-- Name -->
         <label class="meta-rule-editor__label">{{ automationLabel('editor.name', isZh) }}</label>
-        <input v-model="draft.name" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('editor.namePlaceholder', isZh)" data-field="name" />
+        <el-input v-model="draft.name" type="text" :placeholder="automationLabel('editor.namePlaceholder', isZh)" data-field="name" />
 
         <!-- Execution mode (A6-1 opt-in): persist a per-action WorkflowJob plane -->
-        <label class="meta-rule-editor__label" data-field="executionModeToggle">
-          <input
-            type="checkbox"
-            :checked="draft.executionMode === 'workflow_job_v1' || requiresJobMode"
-            :disabled="requiresJobMode"
-            data-field="executionMode"
-            @change="setExecutionMode(($event.target as HTMLInputElement).checked)"
-          />
+        <el-checkbox
+          class="meta-rule-editor__label"
+          data-field="executionModeToggle"
+          :model-value="draft.executionMode === 'workflow_job_v1' || requiresJobMode"
+          :disabled="requiresJobMode"
+          @change="setExecutionMode($event === true)"
+        >
           {{ automationLabel('editor.executionModeLabel', isZh) }}
-        </label>
+        </el-checkbox>
         <div class="meta-rule-editor__hint" data-field="executionModeHint">{{ requiresJobMode ? automationLabel('editor.executionModeRequiredHint', isZh) : automationLabel('editor.executionModeHint', isZh) }}</div>
 
         <!-- 1. Trigger selector -->
         <section class="meta-rule-editor__section">
           <div class="meta-rule-editor__section-title">{{ automationLabel('trigger.title', isZh) }}</div>
-          <select v-model="draft.triggerType" class="meta-rule-editor__select" data-field="triggerType">
-            <option value="record.created">{{ automationTriggerTypeLabel('record.created', isZh) }}</option>
-            <option value="record.updated">{{ automationTriggerTypeLabel('record.updated', isZh) }}</option>
-            <option value="record.deleted">{{ automationTriggerTypeLabel('record.deleted', isZh) }}</option>
-            <option value="field.value_changed">{{ automationTriggerTypeLabel('field.value_changed', isZh) }}</option>
-            <option value="form.submitted">{{ automationTriggerTypeLabel('form.submitted', isZh) }}</option>
-            <option value="schedule.cron">{{ automationTriggerTypeLabel('schedule.cron', isZh) }}</option>
-            <option value="schedule.interval">{{ automationTriggerTypeLabel('schedule.interval', isZh) }}</option>
-            <option value="schedule.date_field">{{ automationTriggerTypeLabel('schedule.date_field', isZh) }}</option>
+          <el-select v-model="draft.triggerType" class="meta-rule-editor__select" data-field="triggerType">
+            <el-option value="record.created" data-value="record.created" :label="automationTriggerTypeLabel('record.created', isZh)" />
+            <el-option value="record.updated" data-value="record.updated" :label="automationTriggerTypeLabel('record.updated', isZh)" />
+            <el-option value="record.deleted" data-value="record.deleted" :label="automationTriggerTypeLabel('record.deleted', isZh)" />
+            <el-option value="field.value_changed" data-value="field.value_changed" :label="automationTriggerTypeLabel('field.value_changed', isZh)" />
+            <el-option value="form.submitted" data-value="form.submitted" :label="automationTriggerTypeLabel('form.submitted', isZh)" />
+            <el-option value="schedule.cron" data-value="schedule.cron" :label="automationTriggerTypeLabel('schedule.cron', isZh)" />
+            <el-option value="schedule.interval" data-value="schedule.interval" :label="automationTriggerTypeLabel('schedule.interval', isZh)" />
+            <el-option value="schedule.date_field" data-value="schedule.date_field" :label="automationTriggerTypeLabel('schedule.date_field', isZh)" />
             <!--
               `webhook.received` is live since the signed inbound endpoint shipped (T1-2):
               POST /api/multitable/automation/webhooks/:ruleId with HMAC-SHA256 timestamp-bound
@@ -50,77 +49,76 @@
               trigger (record-less v1 — the backend save gate restricts its actions to the
               notification family and requires template visibility for the rule creator).
             -->
-            <option value="webhook.received">{{ automationTriggerTypeLabel('webhook.received', isZh) }}</option>
-            <option value="approval.completed">{{ automationTriggerTypeLabel('approval.completed', isZh) }}</option>
-            <option value="approval.task_created">{{ automationTriggerTypeLabel('approval.task_created', isZh) }}</option>
-          </select>
+            <el-option value="webhook.received" data-value="webhook.received" :label="automationTriggerTypeLabel('webhook.received', isZh)" />
+            <el-option value="approval.completed" data-value="approval.completed" :label="automationTriggerTypeLabel('approval.completed', isZh)" />
+            <el-option value="approval.task_created" data-value="approval.task_created" :label="automationTriggerTypeLabel('approval.task_created', isZh)" />
+          </el-select>
 
           <!-- field.value_changed config -->
           <template v-if="draft.triggerType === 'field.value_changed'">
             <label class="meta-rule-editor__label">{{ automationLabel('trigger.watchField', isZh) }}</label>
-            <select v-model="draft.triggerConfig.fieldId" class="meta-rule-editor__select" data-field="triggerFieldId">
-              <option value="">{{ automationLabel('trigger.selectField', isZh) }}</option>
-              <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-            </select>
+            <el-select v-model="(draft.triggerConfig.fieldId as string)" class="meta-rule-editor__select" :placeholder="automationLabel('trigger.selectField', isZh)" data-field="triggerFieldId">
+              <el-option value="" data-value="" :label="automationLabel('trigger.selectField', isZh)" />
+              <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+            </el-select>
             <label class="meta-rule-editor__label">{{ automationLabel('trigger.condition', isZh) }}</label>
-            <select v-model="draft.triggerConfig.condition" class="meta-rule-editor__select" data-field="triggerCondition">
-              <option value="any">{{ automationTriggerConditionLabel('any', isZh) }}</option>
-              <option value="equals">{{ automationTriggerConditionLabel('equals', isZh) }}</option>
-              <option value="changed_to">{{ automationTriggerConditionLabel('changed_to', isZh) }}</option>
-            </select>
+            <el-select v-model="(draft.triggerConfig.condition as string)" class="meta-rule-editor__select" data-field="triggerCondition">
+              <el-option value="any" data-value="any" :label="automationTriggerConditionLabel('any', isZh)" />
+              <el-option value="equals" data-value="equals" :label="automationTriggerConditionLabel('equals', isZh)" />
+              <el-option value="changed_to" data-value="changed_to" :label="automationTriggerConditionLabel('changed_to', isZh)" />
+            </el-select>
             <template v-if="draft.triggerConfig.condition !== 'any'">
               <label class="meta-rule-editor__label">{{ automationLabel('editor.value', isZh) }}</label>
-              <input v-model="draft.triggerConfig.value" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('editor.value', isZh)" data-field="triggerValue" />
+              <el-input v-model="(draft.triggerConfig.value as string)" type="text" :placeholder="automationLabel('editor.value', isZh)" data-field="triggerValue" />
             </template>
           </template>
 
           <!-- schedule.cron config -->
           <template v-if="draft.triggerType === 'schedule.cron'">
             <label class="meta-rule-editor__label">{{ automationLabel('trigger.preset', isZh) }}</label>
-            <select v-model="cronPreset" class="meta-rule-editor__select" data-field="cronPreset">
-              <option value="*/5 * * * *">{{ automationCronPresetLabel('*/5 * * * *', isZh) }}</option>
-              <option value="0 * * * *">{{ automationCronPresetLabel('0 * * * *', isZh) }}</option>
-              <option value="0 0 * * *">{{ automationCronPresetLabel('0 0 * * *', isZh) }}</option>
-              <option value="0 0 * * 1">{{ automationCronPresetLabel('0 0 * * 1', isZh) }}</option>
-              <option value="custom">{{ automationCronPresetLabel('custom', isZh) }}</option>
-            </select>
+            <el-select v-model="cronPreset" class="meta-rule-editor__select" data-field="cronPreset">
+              <el-option value="*/5 * * * *" data-value="*/5 * * * *" :label="automationCronPresetLabel('*/5 * * * *', isZh)" />
+              <el-option value="0 * * * *" data-value="0 * * * *" :label="automationCronPresetLabel('0 * * * *', isZh)" />
+              <el-option value="0 0 * * *" data-value="0 0 * * *" :label="automationCronPresetLabel('0 0 * * *', isZh)" />
+              <el-option value="0 0 * * 1" data-value="0 0 * * 1" :label="automationCronPresetLabel('0 0 * * 1', isZh)" />
+              <el-option value="custom" data-value="custom" :label="automationCronPresetLabel('custom', isZh)" />
+            </el-select>
             <template v-if="cronPreset === 'custom'">
               <label class="meta-rule-editor__label">{{ automationLabel('trigger.cronExpression', isZh) }}</label>
-              <input v-model="draft.triggerConfig.cron" class="meta-rule-editor__input" type="text" placeholder="* * * * *" data-field="cronExpression" />
+              <el-input v-model="(draft.triggerConfig.cron as string)" type="text" placeholder="* * * * *" data-field="cronExpression" />
             </template>
           </template>
 
           <!-- schedule.interval config -->
           <template v-if="draft.triggerType === 'schedule.interval'">
             <label class="meta-rule-editor__label">{{ automationLabel('trigger.intervalMinutes', isZh) }}</label>
-            <input v-model.number="draft.triggerConfig.intervalMinutes" class="meta-rule-editor__input" type="number" min="1" placeholder="5" data-field="intervalMinutes" />
+            <el-input v-model.number="(draft.triggerConfig.intervalMinutes as number | undefined)" type="number" min="1" placeholder="5" data-field="intervalMinutes" />
           </template>
 
           <!-- schedule.date_field (date reminder) config -->
           <template v-if="draft.triggerType === 'schedule.date_field'">
             <label class="meta-rule-editor__label">{{ isZh ? '日期字段' : 'Date field' }}</label>
-            <select v-model="draft.triggerConfig.dateFieldId" class="meta-rule-editor__select" data-field="dateFieldId">
-              <option value="">{{ isZh ? '请选择日期字段' : 'Select a date field' }}</option>
-              <option v-for="field in dateReminderCandidateFields" :key="field.id" :value="field.id">{{ field.name }}</option>
-            </select>
+            <el-select v-model="(draft.triggerConfig.dateFieldId as string)" class="meta-rule-editor__select" :placeholder="isZh ? '请选择日期字段' : 'Select a date field'" data-field="dateFieldId">
+              <el-option value="" data-value="" :label="isZh ? '请选择日期字段' : 'Select a date field'" />
+              <el-option v-for="field in dateReminderCandidateFields" :key="field.id" :value="field.id" :data-value="field.id" :label="field.name" />
+            </el-select>
             <label class="meta-rule-editor__label">{{ isZh ? '提前 / 延后天数' : 'Days offset' }}</label>
-            <input v-model.number="draft.triggerConfig.offsetDays" class="meta-rule-editor__input" type="number" min="0" placeholder="3" data-field="offsetDays" />
+            <el-input v-model.number="(draft.triggerConfig.offsetDays as number | undefined)" type="number" min="0" placeholder="3" data-field="offsetDays" />
             <label class="meta-rule-editor__label">{{ isZh ? '方向' : 'Direction' }}</label>
-            <select v-model="draft.triggerConfig.direction" class="meta-rule-editor__select" data-field="direction">
-              <option value="before">{{ isZh ? '日期之前' : 'Before the date' }}</option>
-              <option value="after">{{ isZh ? '日期之后' : 'After the date' }}</option>
-            </select>
+            <el-select v-model="(draft.triggerConfig.direction as string)" class="meta-rule-editor__select" data-field="direction">
+              <el-option value="before" data-value="before" :label="isZh ? '日期之前' : 'Before the date'" />
+              <el-option value="after" data-value="after" :label="isZh ? '日期之后' : 'After the date'" />
+            </el-select>
             <label class="meta-rule-editor__label">{{ isZh ? '触发时间（UTC，可选）' : 'Time of day (UTC, optional)' }}</label>
-            <input v-model="draft.triggerConfig.timeOfDay" class="meta-rule-editor__input" type="time" placeholder="09:00" data-field="timeOfDay" />
+            <el-input v-model="(draft.triggerConfig.timeOfDay as string)" type="time" placeholder="09:00" data-field="timeOfDay" />
             <div class="meta-rule-editor__hint" data-field="dateFieldTimeHint">{{ isZh ? '每天按此 UTC 时间触发；服务重启后会补发当天到点的提醒。' : 'Fires daily at this UTC time; a restart catches up today\'s due reminders.' }}</div>
           </template>
 
           <!-- webhook.received (signed inbound) config -->
           <template v-if="draft.triggerType === 'webhook.received'">
             <label class="meta-rule-editor__label">{{ isZh ? '签名密钥（Secret）' : 'Signing secret' }}</label>
-            <input
-              v-model="draft.triggerConfig.secret"
-              class="meta-rule-editor__input"
+            <el-input
+              v-model="(draft.triggerConfig.secret as string)"
               type="password"
               autocomplete="new-password"
               :placeholder="savedWebhookSecretConfigured ? (isZh ? '已配置 — 留空保持不变，输入新值以更换' : 'Configured — leave blank to keep, enter a new value to rotate') : (isZh ? '必填：用于 HMAC-SHA256 请求签名' : 'Required: used for HMAC-SHA256 request signing')"
@@ -136,24 +134,23 @@
           <!-- approval.completed (T1-3 template-routed) config -->
           <template v-if="draft.triggerType === 'approval.completed'">
             <label class="meta-rule-editor__label">{{ isZh ? '审批模板' : 'Approval template' }}</label>
-            <select v-if="approvalTemplates.length > 0" v-model="draft.triggerConfig.templateId" class="meta-rule-editor__select" data-field="approvalCompletedTemplateId">
-              <option value="">{{ isZh ? '请选择审批模板' : 'Select an approval template' }}</option>
-              <option v-for="t in approvalTemplates" :key="t.id" :value="t.id">{{ t.name || t.id }}</option>
-            </select>
-            <input v-else v-model="draft.triggerConfig.templateId" class="meta-rule-editor__input" type="text" :placeholder="isZh ? '审批模板 ID' : 'Approval template ID'" data-field="approvalCompletedTemplateId" />
+            <el-select v-if="approvalTemplates.length > 0" v-model="(draft.triggerConfig.templateId as string)" class="meta-rule-editor__select" :placeholder="isZh ? '请选择审批模板' : 'Select an approval template'" data-field="approvalCompletedTemplateId">
+              <el-option value="" data-value="" :label="isZh ? '请选择审批模板' : 'Select an approval template'" />
+              <el-option v-for="t in approvalTemplates" :key="t.id" :value="t.id" :data-value="t.id" :label="t.name || t.id" />
+            </el-select>
+            <el-input v-else v-model="(draft.triggerConfig.templateId as string)" type="text" :placeholder="isZh ? '审批模板 ID' : 'Approval template ID'" data-field="approvalCompletedTemplateId" />
             <label class="meta-rule-editor__label">{{ isZh ? '触发的完成结果（默认仅“通过”）' : 'Completion outcomes that fire (default: approved only)' }}</label>
-            <div class="meta-rule-editor__hint" data-field="approvalCompletedOutcomes">
-              <label v-for="outcome in APPROVAL_COMPLETED_OUTCOME_OPTIONS" :key="outcome" style="margin-right: 12px;">
-                <input v-model="approvalCompletedOutcomes" type="checkbox" :value="outcome" :data-field="`approvalOutcome-${outcome}`" />
+            <el-checkbox-group v-model="approvalCompletedOutcomes" class="meta-rule-editor__hint" data-field="approvalCompletedOutcomes">
+              <el-checkbox v-for="outcome in APPROVAL_COMPLETED_OUTCOME_OPTIONS" :key="outcome" :value="outcome" :data-field="`approvalOutcome-${outcome}`">
                 {{ approvalCompletedOutcomeLabel(outcome) }}
-              </label>
-            </div>
+              </el-checkbox>
+            </el-checkbox-group>
             <div class="meta-rule-editor__hint" data-field="approvalCompletedHint">
               {{ isZh
                 ? '配置的审批模板完成时触发。该触发器无记录上下文：动作仅支持通知类（站内通知 / Webhook / 邮件 / 钉钉消息），不支持记录读写与发起审批，且不支持触发条件；创建者需持有审批读取权限并对该模板可见（保存与触发时均校验）。'
                 : 'Fires when the configured approval template completes. Record-less: only notification-family actions (notification / webhook / email / DingTalk) are allowed — no record actions, no start-approval, no conditions; the rule creator must hold approvals read permission and template visibility (checked at save AND at fire).' }}
             </div>
-            <div v-if="approvalCompletedBlockReason" class="meta-rule-editor__hint" data-field="approvalCompletedBlockReason" style="color: var(--ms-color-danger, #d03050);">
+            <div v-if="approvalCompletedBlockReason" class="meta-rule-editor__hint" data-field="approvalCompletedBlockReason" style="color: var(--ms-color-danger);">
               {{ approvalCompletedBlockReason }}
             </div>
           </template>
@@ -161,17 +158,17 @@
           <!-- approval.task_created (A-2a template-routed) config -->
           <template v-if="draft.triggerType === 'approval.task_created'">
             <label class="meta-rule-editor__label">{{ isZh ? '审批模板' : 'Approval template' }}</label>
-            <select v-if="approvalTemplates.length > 0" v-model="draft.triggerConfig.templateId" class="meta-rule-editor__select" data-field="approvalTaskCreatedTemplateId">
-              <option value="">{{ isZh ? '请选择审批模板' : 'Select an approval template' }}</option>
-              <option v-for="t in approvalTemplates" :key="t.id" :value="t.id">{{ t.name || t.id }}</option>
-            </select>
-            <input v-else v-model="draft.triggerConfig.templateId" class="meta-rule-editor__input" type="text" :placeholder="isZh ? '审批模板 ID' : 'Approval template ID'" data-field="approvalTaskCreatedTemplateId" />
+            <el-select v-if="approvalTemplates.length > 0" v-model="(draft.triggerConfig.templateId as string)" class="meta-rule-editor__select" :placeholder="isZh ? '请选择审批模板' : 'Select an approval template'" data-field="approvalTaskCreatedTemplateId">
+              <el-option value="" data-value="" :label="isZh ? '请选择审批模板' : 'Select an approval template'" />
+              <el-option v-for="t in approvalTemplates" :key="t.id" :value="t.id" :data-value="t.id" :label="t.name || t.id" />
+            </el-select>
+            <el-input v-else v-model="(draft.triggerConfig.templateId as string)" type="text" :placeholder="isZh ? '审批模板 ID' : 'Approval template ID'" data-field="approvalTaskCreatedTemplateId" />
             <div class="meta-rule-editor__hint" data-field="approvalTaskCreatedHint">
               {{ isZh
                 ? '该模板产生新的审批待办（每位受理人一条）时触发。退回/跳转形成的新一轮待办会再次触发；同一轮重复投递自动去重。无记录上下文：动作仅支持通知类，不支持记录读写与发起审批，且不支持触发条件；创建者需持有审批读取权限并对该模板可见（保存与触发时均校验）。'
                 : 'Fires when this template produces a NEW pending approval task (one per recipient). A returned/jumped node fires again for its fresh round; duplicate deliveries of the same round dedupe. Record-less: only notification-family actions — no record actions, no start-approval, no conditions; the rule creator must hold approvals read permission and template visibility (checked at save AND at fire).' }}
             </div>
-            <div v-if="approvalTaskCreatedBlockReason" class="meta-rule-editor__hint" data-field="approvalTaskCreatedBlockReason" style="color: var(--ms-color-danger, #d03050);">
+            <div v-if="approvalTaskCreatedBlockReason" class="meta-rule-editor__hint" data-field="approvalTaskCreatedBlockReason" style="color: var(--ms-color-danger);">
               {{ approvalTaskCreatedBlockReason }}
             </div>
           </template>
@@ -184,18 +181,20 @@
             <span class="meta-rule-editor__hint">{{ automationLabel('condition.optional', isZh) }}</span>
           </div>
           <div v-if="draft.conditions.conditions.length > 1" class="meta-rule-editor__conjunction">
-            <button
-              type="button"
+            <el-button
+              size="small"
               class="meta-rule-editor__toggle-btn"
               :class="{ 'meta-rule-editor__toggle-btn--active': draft.conditions.conjunction === 'AND' }"
+              :type="draft.conditions.conjunction === 'AND' ? 'primary' : 'default'"
               @click="draft.conditions.conjunction = 'AND'"
-            >{{ automationLabel('condition.and', isZh) }}</button>
-            <button
-              type="button"
+            >{{ automationLabel('condition.and', isZh) }}</el-button>
+            <el-button
+              size="small"
               class="meta-rule-editor__toggle-btn"
               :class="{ 'meta-rule-editor__toggle-btn--active': draft.conditions.conjunction === 'OR' }"
+              :type="draft.conditions.conjunction === 'OR' ? 'primary' : 'default'"
               @click="draft.conditions.conjunction = 'OR'"
-            >{{ automationLabel('condition.or', isZh) }}</button>
+            >{{ automationLabel('condition.or', isZh) }}</el-button>
           </div>
           <div class="meta-rule-editor__condition-list">
             <template v-for="entry in conditionEditorEntries" :key="entry.pathKey">
@@ -207,29 +206,31 @@
               >
                 <span class="meta-rule-editor__group-label">{{ automationLabel('condition.group', isZh) }}</span>
                 <div class="meta-rule-editor__conjunction">
-                  <button
-                    type="button"
+                  <el-button
+                    size="small"
                     class="meta-rule-editor__toggle-btn"
                     :class="{ 'meta-rule-editor__toggle-btn--active': normalizeConditionConjunction(entry.group) === 'AND' }"
+                    :type="normalizeConditionConjunction(entry.group) === 'AND' ? 'primary' : 'default'"
                     @click="setGroupConjunction(entry.group, 'AND')"
-                  >{{ automationLabel('condition.and', isZh) }}</button>
-                  <button
-                    type="button"
+                  >{{ automationLabel('condition.and', isZh) }}</el-button>
+                  <el-button
+                    size="small"
                     class="meta-rule-editor__toggle-btn"
                     :class="{ 'meta-rule-editor__toggle-btn--active': normalizeConditionConjunction(entry.group) === 'OR' }"
+                    :type="normalizeConditionConjunction(entry.group) === 'OR' ? 'primary' : 'default'"
                     @click="setGroupConjunction(entry.group, 'OR')"
-                  >{{ automationLabel('condition.or', isZh) }}</button>
+                  >{{ automationLabel('condition.or', isZh) }}</el-button>
                 </div>
                 <div class="meta-rule-editor__condition-actions">
-                  <button class="meta-rule-editor__btn" type="button" data-action="add-nested-condition" @click="addConditionToGroup(entry.path)">{{ automationLabel('condition.addNestedCondition', isZh) }}</button>
-                  <button
+                  <el-button size="small" class="meta-rule-editor__btn" data-action="add-nested-condition" @click="addConditionToGroup(entry.path)">{{ automationLabel('condition.addNestedCondition', isZh) }}</el-button>
+                  <el-button
+                    size="small"
                     class="meta-rule-editor__btn"
-                    type="button"
                     data-action="add-condition-group"
                     :disabled="!entry.canAddGroup"
                     @click="addGroupToGroup(entry.path)"
-                  >{{ automationLabel('condition.addNestedGroup', isZh) }}</button>
-                  <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeConditionNode(entry.path)" :title="automationLabel('condition.removeGroupTitle', isZh)">&times;</button>
+                  >{{ automationLabel('condition.addNestedGroup', isZh) }}</el-button>
+                  <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeConditionNode(entry.path)" :title="automationLabel('condition.removeGroupTitle', isZh)">&times;</el-button>
                 </div>
               </div>
               <div
@@ -239,84 +240,83 @@
                 :data-condition-index="entry.pathKey"
                 :data-condition-path="entry.pathKey"
               >
-                <select
-                  :value="entry.condition.fieldId"
+                <el-select
+                  :model-value="entry.condition.fieldId"
                   class="meta-rule-editor__select meta-rule-editor__select--sm"
-                  @change="onConditionFieldChange(entry.condition, ($event.target as HTMLSelectElement).value)"
+                  :placeholder="automationLabel('condition.selectField', isZh)"
+                  @change="onConditionFieldChange(entry.condition, $event)"
                 >
-                  <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
-                  <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-                </select>
-                <select
-                  :value="entry.condition.operator"
+                  <el-option value="" data-value="" :label="automationLabel('condition.selectField', isZh)" />
+                  <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+                </el-select>
+                <el-select
+                  :model-value="entry.condition.operator"
                   class="meta-rule-editor__select meta-rule-editor__select--sm"
-                  @change="onConditionOperatorChange(entry.condition, ($event.target as HTMLSelectElement).value as ConditionOperator)"
+                  @change="onConditionOperatorChange(entry.condition, $event as ConditionOperator)"
                 >
-                  <option v-for="op in conditionOperatorsForField(entry.condition.fieldId)" :key="op.value" :value="op.value">{{ automationConditionOperatorLabel(op.value, isZh) }}</option>
-                </select>
+                  <el-option v-for="op in conditionOperatorsForField(entry.condition.fieldId)" :key="op.value" :value="op.value" :data-value="op.value" :label="automationConditionOperatorLabel(op.value, isZh)" />
+                </el-select>
                 <template v-if="!isUnaryOperator(entry.condition.operator)">
-                  <select
+                  <el-select
                     v-if="conditionValueWidget(entry.condition) === 'booleanMultiSelect'"
-                    :value="booleanMultiSelectConditionValues(entry.condition)"
+                    :model-value="booleanMultiSelectConditionValues(entry.condition)"
                     class="meta-rule-editor__select meta-rule-editor__select--sm"
                     data-condition-value="boolean-multi-select"
                     multiple
                     @change="onBooleanMultiSelectConditionValueChange(entry.condition, $event)"
                   >
-                    <option value="true">true</option>
-                    <option value="false">false</option>
-                  </select>
-                  <select
+                    <el-option value="true" data-value="true" label="true" />
+                    <el-option value="false" data-value="false" label="false" />
+                  </el-select>
+                  <el-select
                     v-else-if="conditionValueWidget(entry.condition) === 'boolean'"
-                    :value="booleanConditionValue(entry.condition)"
+                    :model-value="booleanConditionValue(entry.condition)"
                     class="meta-rule-editor__select meta-rule-editor__select--sm"
+                    :placeholder="automationLabel('condition.selectValue', isZh)"
                     data-condition-value="boolean"
-                    @change="onBooleanConditionValueChange(entry.condition, ($event.target as HTMLSelectElement).value)"
+                    @change="onBooleanConditionValueChange(entry.condition, $event)"
                   >
-                    <option value="">{{ automationLabel('condition.selectValue', isZh) }}</option>
-                    <option value="true">true</option>
-                    <option value="false">false</option>
-                  </select>
-                  <select
+                    <el-option value="" data-value="" :label="automationLabel('condition.selectValue', isZh)" />
+                    <el-option value="true" data-value="true" label="true" />
+                    <el-option value="false" data-value="false" label="false" />
+                  </el-select>
+                  <el-select
                     v-else-if="conditionValueWidget(entry.condition) === 'select'"
-                    :value="singleSelectConditionValue(entry.condition)"
+                    :model-value="singleSelectConditionValue(entry.condition)"
                     class="meta-rule-editor__select meta-rule-editor__select--sm"
+                    :placeholder="automationLabel('condition.selectValue', isZh)"
                     data-condition-value="select"
-                    @change="entry.condition.value = ($event.target as HTMLSelectElement).value"
+                    @change="entry.condition.value = $event"
                   >
-                    <option value="">{{ automationLabel('condition.selectValue', isZh) }}</option>
-                    <option v-for="option in conditionFieldOptions(entry.condition)" :key="option.value" :value="option.value">
-                      {{ optionLabel(option) }}
-                    </option>
-                  </select>
-                  <select
+                    <el-option value="" data-value="" :label="automationLabel('condition.selectValue', isZh)" />
+                    <el-option v-for="option in conditionFieldOptions(entry.condition)" :key="option.value" :value="option.value" :data-value="option.value" :label="optionLabel(option)" />
+                  </el-select>
+                  <el-select
                     v-else-if="conditionValueWidget(entry.condition) === 'multiSelect'"
-                    :value="multiSelectConditionValues(entry.condition)"
+                    :model-value="multiSelectConditionValues(entry.condition)"
                     class="meta-rule-editor__select meta-rule-editor__select--sm"
                     data-condition-value="multi-select"
                     multiple
                     @change="onMultiSelectConditionValueChange(entry.condition, $event)"
                   >
-                    <option v-for="option in conditionFieldOptions(entry.condition)" :key="option.value" :value="option.value">
-                      {{ optionLabel(option) }}
-                    </option>
-                  </select>
-                  <input
+                    <el-option v-for="option in conditionFieldOptions(entry.condition)" :key="option.value" :value="option.value" :data-value="option.value" :label="optionLabel(option)" />
+                  </el-select>
+                  <el-input
                     v-else
-                    v-model="entry.condition.value"
-                    class="meta-rule-editor__input meta-rule-editor__input--sm"
+                    v-model="(entry.condition.value as string)"
+                    class="meta-rule-editor__input--sm"
                     :type="conditionValueInputType(entry.condition)"
                     :inputmode="conditionValueInputMode(entry.condition)"
                     :placeholder="conditionValuePlaceholder(entry.condition)"
                   />
                 </template>
-                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeConditionNode(entry.path)" :title="automationLabel('condition.removeConditionTitle', isZh)">&times;</button>
+                <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeConditionNode(entry.path)" :title="automationLabel('condition.removeConditionTitle', isZh)">&times;</el-button>
               </div>
             </template>
           </div>
           <div class="meta-rule-editor__condition-actions">
-            <button class="meta-rule-editor__btn" type="button" data-action="add-condition" @click="addCondition">{{ automationLabel('condition.addCondition', isZh) }}</button>
-            <button class="meta-rule-editor__btn" type="button" data-action="add-condition-group" @click="addGroupToGroup([])">{{ automationLabel('condition.addGroup', isZh) }}</button>
+            <el-button size="small" class="meta-rule-editor__btn" data-action="add-condition" @click="addCondition">{{ automationLabel('condition.addCondition', isZh) }}</el-button>
+            <el-button size="small" class="meta-rule-editor__btn" data-action="add-condition-group" @click="addGroupToGroup([])">{{ automationLabel('condition.addGroup', isZh) }}</el-button>
           </div>
         </section>
 
@@ -331,157 +331,161 @@
           >
             <div class="meta-rule-editor__action-header">
               <span class="meta-rule-editor__action-num">{{ idx + 1 }}.</span>
-              <select v-model="action.type" class="meta-rule-editor__select" @change="onDraftActionTypeChange(action)">
-                <option
+              <el-select v-model="action.type" class="meta-rule-editor__select" @change="onDraftActionTypeChange(action)">
+                <el-option
                   v-for="type in selectableActionTypes(action.type)"
                   :key="type"
                   :value="type"
+                  :data-value="type"
                   :disabled="isUnsupportedSelectableActionType(type)"
-                >
-                  {{ automationActionTypeLabel(type, isZh) }}
-                </option>
-              </select>
+                  :label="automationActionTypeLabel(type, isZh)"
+                />
+              </el-select>
               <div class="meta-rule-editor__action-btns">
-                <button v-if="idx > 0" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, -1)" :title="automationLabel('editor.moveUpTitle', isZh)">&#x2191;</button>
-                <button v-if="idx < draft.actions.length - 1" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, 1)" :title="automationLabel('editor.moveDownTitle', isZh)">&#x2193;</button>
-                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeAction(idx)" :title="automationLabel('editor.removeActionTitle', isZh)">&times;</button>
+                <el-button v-if="idx > 0" size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="moveAction(idx, -1)" :title="automationLabel('editor.moveUpTitle', isZh)">&#x2191;</el-button>
+                <el-button v-if="idx < draft.actions.length - 1" size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="moveAction(idx, 1)" :title="automationLabel('editor.moveDownTitle', isZh)">&#x2193;</el-button>
+                <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeAction(idx)" :title="automationLabel('editor.removeActionTitle', isZh)">&times;</el-button>
               </div>
             </div>
 
             <!-- update_record config -->
             <div v-if="action.type === 'update_record'" class="meta-rule-editor__action-config">
               <div v-for="(pair, pidx) in (action.config.fieldUpdates as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
-                <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
-                  <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
-                  <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-                </select>
-                <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('editor.value', isZh)" />
-                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeFieldUpdate(action, pidx)">&times;</button>
+                <el-select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm" :placeholder="automationLabel('condition.selectField', isZh)">
+                  <el-option value="" data-value="" :label="automationLabel('condition.selectField', isZh)" />
+                  <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+                </el-select>
+                <el-input v-model="pair.value" class="meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('editor.value', isZh)" />
+                <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeFieldUpdate(action, pidx)">&times;</el-button>
               </div>
-              <button class="meta-rule-editor__btn" type="button" @click="addFieldUpdate(action)">{{ automationLabel('editor.addField', isZh) }}</button>
+              <el-button size="small" class="meta-rule-editor__btn" @click="addFieldUpdate(action)">{{ automationLabel('editor.addField', isZh) }}</el-button>
             </div>
 
             <!-- create_record config -->
             <div v-if="action.type === 'create_record'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.targetSheetId', isZh) }}</label>
-              <input v-model="action.config.targetSheetId" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('actionConfig.sheetIdPlaceholder', isZh)" />
+              <el-input v-model="action.config.targetSheetId" type="text" :placeholder="automationLabel('actionConfig.sheetIdPlaceholder', isZh)" />
               <div v-for="(pair, pidx) in (action.config.fieldValues as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
-                <input v-model="pair.fieldId" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('actionConfig.fieldIdPlaceholder', isZh)" />
-                <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('editor.value', isZh)" />
-                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeCreateFieldValue(action, pidx)">&times;</button>
+                <el-input v-model="pair.fieldId" class="meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('actionConfig.fieldIdPlaceholder', isZh)" />
+                <el-input v-model="pair.value" class="meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('editor.value', isZh)" />
+                <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeCreateFieldValue(action, pidx)">&times;</el-button>
               </div>
-              <button class="meta-rule-editor__btn" type="button" @click="addCreateFieldValue(action)">{{ automationLabel('editor.addField', isZh) }}</button>
+              <el-button size="small" class="meta-rule-editor__btn" @click="addCreateFieldValue(action)">{{ automationLabel('editor.addField', isZh) }}</el-button>
             </div>
 
             <!-- send_webhook config -->
             <div v-if="action.type === 'send_webhook'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.url', isZh) }}</label>
-              <input v-model="action.config.url" class="meta-rule-editor__input" type="url" placeholder="https://..." />
+              <el-input v-model="action.config.url" type="url" placeholder="https://..." />
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.method', isZh) }}</label>
-              <select v-model="action.config.method" class="meta-rule-editor__select">
-                <option value="POST">POST</option>
-                <option value="PUT">PUT</option>
-                <option value="GET">GET</option>
-              </select>
+              <el-select v-model="action.config.method" class="meta-rule-editor__select">
+                <el-option value="POST" data-value="POST" label="POST" />
+                <el-option value="PUT" data-value="PUT" label="PUT" />
+                <el-option value="GET" data-value="GET" label="GET" />
+              </el-select>
             </div>
 
             <!-- send_notification config -->
             <div v-if="action.type === 'send_notification'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.userId', isZh) }}</label>
-              <input v-model="action.config.userId" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('actionConfig.userId', isZh)" />
+              <el-input v-model="action.config.userId" type="text" :placeholder="automationLabel('actionConfig.userId', isZh)" />
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.message', isZh) }}</label>
-              <textarea v-model="action.config.message" class="meta-rule-editor__textarea" :placeholder="automationLabel('actionConfig.notificationMessagePlaceholder', isZh)" rows="3"></textarea>
+              <el-input v-model="action.config.message" type="textarea" :placeholder="automationLabel('actionConfig.notificationMessagePlaceholder', isZh)" :rows="3" />
             </div>
 
             <!-- start_approval config -->
             <div v-if="action.type === 'start_approval'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__label">{{ isZh ? '审批模板' : 'Approval template' }}</label>
-              <select v-if="approvalTemplates.length > 0" v-model="action.config.templateId" class="meta-rule-editor__select" data-field="approvalTemplateId">
-                <option value="">{{ isZh ? '请选择审批模板' : 'Select an approval template' }}</option>
-                <option v-for="t in approvalTemplates" :key="t.id" :value="t.id">{{ t.name || t.id }}</option>
-              </select>
-              <input v-else v-model="action.config.templateId" class="meta-rule-editor__input" type="text" :placeholder="isZh ? '审批模板 ID' : 'Approval template ID'" data-field="approvalTemplateId" />
+              <el-select v-if="approvalTemplates.length > 0" v-model="(action.config.templateId as string)" class="meta-rule-editor__select" :placeholder="isZh ? '请选择审批模板' : 'Select an approval template'" data-field="approvalTemplateId">
+                <el-option value="" data-value="" :label="isZh ? '请选择审批模板' : 'Select an approval template'" />
+                <el-option v-for="t in approvalTemplates" :key="t.id" :value="t.id" :data-value="t.id" :label="t.name || t.id" />
+              </el-select>
+              <el-input v-else v-model="(action.config.templateId as string)" type="text" :placeholder="isZh ? '审批模板 ID' : 'Approval template ID'" data-field="approvalTemplateId" />
               <label class="meta-rule-editor__label">{{ isZh ? '表单字段映射（审批字段 → 记录字段）' : 'Form-data mapping (approval field → record field)' }}</label>
               <div v-for="(pair, pidx) in (action.config.formDataMappingPairs as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
-                <input v-model="pair.fieldId" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" :placeholder="isZh ? '审批字段' : 'Approval field'" data-field="approvalMappingKey" />
-                <select v-model="pair.value" class="meta-rule-editor__select meta-rule-editor__select--sm" data-field="approvalMappingValue">
-                  <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
-                  <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-                </select>
-                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeApprovalMapping(action, pidx)">&times;</button>
+                <el-input v-model="pair.fieldId" class="meta-rule-editor__input--sm" type="text" :placeholder="isZh ? '审批字段' : 'Approval field'" data-field="approvalMappingKey" />
+                <el-select v-model="pair.value" class="meta-rule-editor__select meta-rule-editor__select--sm" :placeholder="automationLabel('condition.selectField', isZh)" data-field="approvalMappingValue">
+                  <el-option value="" data-value="" :label="automationLabel('condition.selectField', isZh)" />
+                  <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+                </el-select>
+                <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeApprovalMapping(action, pidx)">&times;</el-button>
               </div>
-              <button class="meta-rule-editor__btn" type="button" @click="addApprovalMapping(action)">{{ automationLabel('editor.addField', isZh) }}</button>
+              <el-button size="small" class="meta-rule-editor__btn" @click="addApprovalMapping(action)">{{ automationLabel('editor.addField', isZh) }}</el-button>
 
               <!-- W7 approval-result writeback (optional): three source-field pickers. Type compat is a hint; the
                    currently-configured value is always preserved as a marked option (see resultWritebackFieldOptions). -->
               <label class="meta-rule-editor__label">{{ automationLabel('resultWriteback.title', isZh) }}</label>
               <div class="meta-rule-editor__hint">{{ automationLabel('resultWriteback.hint', isZh) }}</div>
               <label class="meta-rule-editor__label meta-rule-editor__label--sub">{{ automationLabel('resultWriteback.statusField', isZh) }}</label>
-              <select v-model="action.config.resultWritebackStatusField" class="meta-rule-editor__select" data-field="resultWritebackStatusField">
-                <option value="">{{ automationLabel('resultWriteback.none', isZh) }}</option>
-                <option v-for="opt in resultWritebackFieldOptions('status', action.config.resultWritebackStatusField)" :key="opt.id" :value="opt.id" :data-marked="opt.marked || undefined">{{ opt.label }}</option>
-              </select>
+              <el-select v-model="action.config.resultWritebackStatusField" class="meta-rule-editor__select" :placeholder="automationLabel('resultWriteback.none', isZh)" data-field="resultWritebackStatusField">
+                <el-option value="" data-value="" :label="automationLabel('resultWriteback.none', isZh)" />
+                <el-option v-for="opt in resultWritebackFieldOptions('status', action.config.resultWritebackStatusField)" :key="opt.id" :value="opt.id" :data-value="opt.id" :data-marked="opt.marked || undefined" :label="opt.label" />
+              </el-select>
               <label class="meta-rule-editor__label meta-rule-editor__label--sub">{{ automationLabel('resultWriteback.approverField', isZh) }}</label>
-              <select v-model="action.config.resultWritebackApproverField" class="meta-rule-editor__select" data-field="resultWritebackApproverField">
-                <option value="">{{ automationLabel('resultWriteback.none', isZh) }}</option>
-                <option v-for="opt in resultWritebackFieldOptions('approver', action.config.resultWritebackApproverField)" :key="opt.id" :value="opt.id" :data-marked="opt.marked || undefined">{{ opt.label }}</option>
-              </select>
+              <el-select v-model="action.config.resultWritebackApproverField" class="meta-rule-editor__select" :placeholder="automationLabel('resultWriteback.none', isZh)" data-field="resultWritebackApproverField">
+                <el-option value="" data-value="" :label="automationLabel('resultWriteback.none', isZh)" />
+                <el-option v-for="opt in resultWritebackFieldOptions('approver', action.config.resultWritebackApproverField)" :key="opt.id" :value="opt.id" :data-value="opt.id" :data-marked="opt.marked || undefined" :label="opt.label" />
+              </el-select>
               <label class="meta-rule-editor__label meta-rule-editor__label--sub">{{ automationLabel('resultWriteback.completedAtField', isZh) }}</label>
-              <select v-model="action.config.resultWritebackCompletedAtField" class="meta-rule-editor__select" data-field="resultWritebackCompletedAtField">
-                <option value="">{{ automationLabel('resultWriteback.none', isZh) }}</option>
-                <option v-for="opt in resultWritebackFieldOptions('completedAt', action.config.resultWritebackCompletedAtField)" :key="opt.id" :value="opt.id" :data-marked="opt.marked || undefined">{{ opt.label }}</option>
-              </select>
+              <el-select v-model="action.config.resultWritebackCompletedAtField" class="meta-rule-editor__select" :placeholder="automationLabel('resultWriteback.none', isZh)" data-field="resultWritebackCompletedAtField">
+                <el-option value="" data-value="" :label="automationLabel('resultWriteback.none', isZh)" />
+                <el-option v-for="opt in resultWritebackFieldOptions('completedAt', action.config.resultWritebackCompletedAtField)" :key="opt.id" :value="opt.id" :data-value="opt.id" :data-marked="opt.marked || undefined" :label="opt.label" />
+              </el-select>
             </div>
 
             <!-- send_email config -->
             <div v-if="action.type === 'send_email'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.recipients', isZh) }}</label>
-              <textarea
+              <el-input
                 v-model="action.config.recipientsText"
-                class="meta-rule-editor__textarea"
-                rows="3"
+                type="textarea"
+                :rows="3"
                 placeholder="ops@example.com, owner@example.com"
                 data-field="emailRecipients"
-              ></textarea>
+              />
               <div class="meta-rule-editor__hint">{{ automationLabel('actionConfig.emailRecipientsHint', isZh) }}</div>
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.subjectTemplate', isZh) }}</label>
-              <input
+              <el-input
                 v-model="action.config.subjectTemplate"
-                class="meta-rule-editor__input"
                 type="text"
                 :placeholder="automationLabel('actionConfig.emailSubjectPlaceholder', isZh)"
                 data-field="emailSubjectTemplate"
               />
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.bodyTemplate', isZh) }}</label>
-              <textarea
+              <el-input
                 v-model="action.config.bodyTemplate"
-                class="meta-rule-editor__textarea"
-                rows="4"
+                type="textarea"
+                :rows="4"
                 :placeholder="automationLabel('actionConfig.emailBodyPlaceholder', isZh)"
                 data-field="emailBodyTemplate"
-              ></textarea>
+              />
             </div>
 
             <!-- send_dingtalk_group_message config -->
             <div v-if="action.type === 'send_dingtalk_group_message'" class="meta-rule-editor__action-config">
               <div class="meta-rule-editor__preset-row">
                 <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.preset', isZh) }}</span>
-                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetForm" @click="applyGroupPreset(action, 'form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</button>
-                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetInternal" @click="applyGroupPreset(action, 'internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</button>
-                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetBoth" @click="applyGroupPreset(action, 'form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</button>
+                <el-button size="small" class="meta-rule-editor__btn" data-field="groupPresetForm" @click="applyGroupPreset(action, 'form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</el-button>
+                <el-button size="small" class="meta-rule-editor__btn" data-field="groupPresetInternal" @click="applyGroupPreset(action, 'internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</el-button>
+                <el-button size="small" class="meta-rule-editor__btn" data-field="groupPresetBoth" @click="applyGroupPreset(action, 'form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</el-button>
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.addGroups', isZh) }}</label>
-              <select
+              <el-select
                 v-model="action.config.destinationPickerId"
                 class="meta-rule-editor__select"
+                :placeholder="automationLabel('dingtalk.addGroupOption', isZh)"
                 data-field="dingtalkDestinationPickerId"
-                @change="appendGroupDestination(action, $event.target as HTMLSelectElement)"
+                @change="appendGroupDestination(action, $event)"
               >
-                <option value="">{{ automationLabel('dingtalk.addGroupOption', isZh) }}</option>
-                <option v-for="destination in availableGroupDestinations(action)" :key="destination.id" :value="destination.id">
-                  {{ destination.name }} · {{ groupDestinationScopeLabel(destination) }}
-                </option>
-              </select>
+                <el-option value="" data-value="" :label="automationLabel('dingtalk.addGroupOption', isZh)" />
+                <el-option
+                  v-for="destination in availableGroupDestinations(action)"
+                  :key="destination.id"
+                  :value="destination.id"
+                  :data-value="destination.id"
+                  :label="`${destination.name} · ${groupDestinationScopeLabel(destination)}`"
+                />
+              </el-select>
               <div class="meta-rule-editor__hint" data-field="dingtalkDestinationPickerHint">
                 {{ automationLabel('dingtalk.groupsRegisteredHint', isZh) }}
               </div>
@@ -511,9 +515,8 @@
               </div>
               <div v-if="dingTalkDestinationsError" class="meta-rule-editor__hint">{{ dingTalkDestinationsError }}</div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.recordGroupFieldPaths', isZh) }}</label>
-              <input
+              <el-input
                 v-model="action.config.destinationFieldPath"
-                class="meta-rule-editor__input"
                 type="text"
                 placeholder="record.opsDestinationId, record.escalationDestinationIds"
                 data-field="dingtalkDestinationFieldPath"
@@ -522,16 +525,16 @@
                 {{ automationLabel('dingtalk.recordGroupFieldPathHint', isZh) }}
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.pickGroupField', isZh) }}</label>
-              <select
+              <el-select
+                :model-value="''"
                 class="meta-rule-editor__select"
+                :placeholder="automationLabel('dingtalk.pickFieldOption', isZh)"
                 data-field="dingtalkDestinationFieldSelect"
-                @change="appendGroupDestinationFieldPath(action, $event.target as HTMLSelectElement)"
+                @change="appendGroupDestinationFieldPath(action, $event)"
               >
-                <option value="">{{ automationLabel('dingtalk.pickFieldOption', isZh) }}</option>
-                <option v-for="field in groupDestinationCandidateFields" :key="field.id" :value="field.id">
-                  {{ field.name }}
-                </option>
-              </select>
+                <el-option value="" data-value="" :label="automationLabel('dingtalk.pickFieldOption', isZh)" />
+                <el-option v-for="field in groupDestinationCandidateFields" :key="field.id" :value="field.id" :data-value="field.id" :label="field.name" />
+              </el-select>
               <div
                 v-if="selectedGroupDestinationFields(action).length"
                 class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
@@ -557,9 +560,8 @@
                 {{ warning }}
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.titleTemplate', isZh) }}</label>
-              <input
+              <el-input
                 v-model="action.config.titleTemplate"
-                class="meta-rule-editor__input"
                 type="text"
                 :placeholder="automationLabel('dingtalk.titleTemplatePlaceholder', isZh)"
                 data-field="dingtalkTitleTemplate"
@@ -573,25 +575,25 @@
               </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.templateTokens', isZh) }}</span>
-                <button
+                <el-button
                   v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
                   :key="token.key"
+                  size="small"
                   class="meta-rule-editor__btn"
-                  type="button"
                   :data-field="`groupTitleToken-${token.key}`"
                   @click="appendGroupTemplateToken(action, 'titleTemplate', token.value)"
                 >
                   {{ dingTalkTemplateTokenLabel(token, isZh) }}
-                </button>
+                </el-button>
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.bodyTemplate', isZh) }}</label>
-              <textarea
+              <el-input
                 v-model="action.config.bodyTemplate"
-                class="meta-rule-editor__textarea"
-                rows="4"
+                type="textarea"
+                :rows="4"
                 :placeholder="automationLabel('dingtalk.bodyTemplatePlaceholder', isZh)"
                 data-field="dingtalkBodyTemplate"
-              ></textarea>
+              />
               <div
                 v-for="warning in templateSyntaxWarnings(action.config.bodyTemplate)"
                 :key="`group-body-${warning}`"
@@ -601,26 +603,27 @@
               </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.templateTokens', isZh) }}</span>
-                <button
+                <el-button
                   v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
                   :key="token.key"
+                  size="small"
                   class="meta-rule-editor__btn"
-                  type="button"
                   :data-field="`groupBodyToken-${token.key}`"
                   @click="appendGroupTemplateToken(action, 'bodyTemplate', token.value, true)"
                 >
                   {{ dingTalkTemplateTokenLabel(token, isZh) }}
-                </button>
+                </el-button>
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.publicFormView', isZh) }}</label>
-              <select
+              <el-select
                 v-model="action.config.publicFormViewId"
                 class="meta-rule-editor__select"
+                :placeholder="automationLabel('dingtalk.noPublicFormLinkOption', isZh)"
                 data-field="publicFormViewId"
               >
-                  <option value="">{{ automationLabel('dingtalk.noPublicFormLinkOption', isZh) }}</option>
-                <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
-              </select>
+                <el-option value="" data-value="" :label="automationLabel('dingtalk.noPublicFormLinkOption', isZh)" />
+                <el-option v-for="view in formViews" :key="view.id" :value="view.id" :data-value="view.id" :label="view.name" />
+              </el-select>
               <div
                 v-for="warning in publicFormLinkWarnings(action.config.publicFormViewId, true)"
                 :key="`group-public-form-${warning}`"
@@ -650,14 +653,15 @@
                 </div>
               </template>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.internalProcessingView', isZh) }}</label>
-              <select
+              <el-select
                 v-model="action.config.internalViewId"
                 class="meta-rule-editor__select"
+                :placeholder="automationLabel('dingtalk.noInternalLinkOption', isZh)"
                 data-field="internalViewId"
               >
-                <option value="">{{ automationLabel('dingtalk.noInternalLinkOption', isZh) }}</option>
-                <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
-              </select>
+                <el-option value="" data-value="" :label="automationLabel('dingtalk.noInternalLinkOption', isZh)" />
+                <el-option v-for="view in internalViews" :key="view.id" :value="view.id" :data-value="view.id" :label="view.name" />
+              </el-select>
               <div
                 v-for="warning in internalViewLinkWarnings(action.config.internalViewId)"
                 :key="`group-internal-view-${warning}`"
@@ -673,25 +677,27 @@
                 <div class="meta-rule-editor__preview-body"><strong>{{ automationLabel('dingtalk.bodyTemplate', isZh) }}:</strong> {{ templatePreviewText(action.config.bodyTemplate, automationLabel('dingtalk.noBodyTemplate', isZh)) }}</div>
                 <div class="meta-rule-editor__preview-line">
                   <span><strong>{{ automationLabel('dingtalk.renderedTitle', isZh) }}:</strong> {{ renderedTemplateExample(action.config.titleTemplate, automationLabel('dingtalk.noRenderedTitle', isZh)) }}</span>
-                  <button
+                  <el-button
+                    size="small"
+                    round
                     class="meta-rule-editor__copy-btn"
-                    type="button"
                     :data-field="`groupRenderedTitleCopy-${idx}`"
                     @click="copyPreviewText(`group-title-${idx}`, renderedTemplateExample(action.config.titleTemplate, ''))"
                   >
                     {{ copiedPreviewKey === `group-title-${idx}` ? automationLabel('dingtalk.copied', isZh) : automationLabel('dingtalk.copy', isZh) }}
-                  </button>
+                  </el-button>
                 </div>
                 <div class="meta-rule-editor__preview-line meta-rule-editor__preview-body">
                   <span><strong>{{ automationLabel('dingtalk.renderedBody', isZh) }}:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, automationLabel('dingtalk.noRenderedBody', isZh)) }}</span>
-                  <button
+                  <el-button
+                    size="small"
+                    round
                     class="meta-rule-editor__copy-btn"
-                    type="button"
                     :data-field="`groupRenderedBodyCopy-${idx}`"
                     @click="copyPreviewText(`group-body-${idx}`, renderedTemplateExample(action.config.bodyTemplate, ''))"
                   >
                     {{ copiedPreviewKey === `group-body-${idx}` ? automationLabel('dingtalk.copied', isZh) : automationLabel('dingtalk.copy', isZh) }}
-                  </button>
+                  </el-button>
                 </div>
                 <div><strong>{{ automationLabel('dingtalk.publicForm', isZh) }}:</strong> {{ viewSummaryName(action.config.publicFormViewId, automationLabel('dingtalk.noPublicFormLink', isZh)) }}</div>
                 <div><strong>{{ automationLabel('dingtalk.publicFormAccess', isZh) }}:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
@@ -713,14 +719,13 @@
             <div v-if="action.type === 'send_dingtalk_person_message'" class="meta-rule-editor__action-config">
               <div class="meta-rule-editor__preset-row">
                 <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.preset', isZh) }}</span>
-                <button class="meta-rule-editor__btn" type="button" data-field="personPresetForm" @click="applyPersonPreset(action, 'form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</button>
-                <button class="meta-rule-editor__btn" type="button" data-field="personPresetInternal" @click="applyPersonPreset(action, 'internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</button>
-                <button class="meta-rule-editor__btn" type="button" data-field="personPresetBoth" @click="applyPersonPreset(action, 'form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</button>
+                <el-button size="small" class="meta-rule-editor__btn" data-field="personPresetForm" @click="applyPersonPreset(action, 'form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</el-button>
+                <el-button size="small" class="meta-rule-editor__btn" data-field="personPresetInternal" @click="applyPersonPreset(action, 'internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</el-button>
+                <el-button size="small" class="meta-rule-editor__btn" data-field="personPresetBoth" @click="applyPersonPreset(action, 'form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</el-button>
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.searchUsersOrGroups', isZh) }}</label>
-              <input
+              <el-input
                 v-model="action.config.userIdsSearch"
-                class="meta-rule-editor__input"
                 type="text"
                 :placeholder="automationLabel('dingtalk.searchUsersOrGroupsPlaceholder', isZh)"
                 data-field="dingtalkPersonUserSearch"
@@ -778,40 +783,45 @@
                 </button>
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.localUserIds', isZh) }}</label>
-              <textarea
+              <el-input
                 v-model="action.config.userIdsText"
-                class="meta-rule-editor__textarea"
-                rows="3"
+                type="textarea"
+                :rows="3"
                 :placeholder="automationLabel('dingtalk.localUserIdsPlaceholder', isZh)"
                 data-field="dingtalkPersonUserIds"
-              ></textarea>
+              />
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.memberGroupIds', isZh) }}</label>
-              <textarea
+              <el-input
                 v-model="action.config.memberGroupIdsText"
-                class="meta-rule-editor__textarea"
-                rows="2"
+                type="textarea"
+                :rows="2"
                 :placeholder="automationLabel('dingtalk.memberGroupIdsPlaceholder', isZh)"
                 data-field="dingtalkPersonMemberGroupIds"
-              ></textarea>
+              />
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.recordRecipientFieldPaths', isZh) }}</label>
-              <input
+              <el-input
                 v-model="action.config.recipientFieldPath"
-                class="meta-rule-editor__input"
                 type="text"
                 :placeholder="automationLabel('dingtalk.recordRecipientFieldPathPlaceholder', isZh)"
                 data-field="dingtalkPersonRecipientFieldPath"
               />
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.pickRecipientField', isZh) }}</label>
-              <select
+              <el-select
+                :model-value="''"
                 class="meta-rule-editor__select"
+                :placeholder="automationLabel('dingtalk.chooseUserFieldOption', isZh)"
                 data-field="dingtalkPersonRecipientFieldSelect"
-                @change="appendRecipientFieldPath(action, ($event.target as HTMLSelectElement))"
+                @change="appendRecipientFieldPath(action, $event)"
               >
-                <option value="">{{ automationLabel('dingtalk.chooseUserFieldOption', isZh) }}</option>
-                <option v-for="field in recipientCandidateFields" :key="field.id" :value="field.id">
-                  {{ field.name }} (record.{{ field.id }})
-                </option>
-              </select>
+                <el-option value="" data-value="" :label="automationLabel('dingtalk.chooseUserFieldOption', isZh)" />
+                <el-option
+                  v-for="field in recipientCandidateFields"
+                  :key="field.id"
+                  :value="field.id"
+                  :data-value="field.id"
+                  :label="`${field.name} (record.${field.id})`"
+                />
+              </el-select>
               <div
                 v-if="selectedRecipientFields(action).length"
                 class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
@@ -839,24 +849,29 @@
                 {{ automationLabel('dingtalk.recordRecipientFieldPathHint', isZh) }}
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.recordMemberGroupFieldPaths', isZh) }}</label>
-              <input
+              <el-input
                 v-model="action.config.memberGroupRecipientFieldPath"
-                class="meta-rule-editor__input"
                 type="text"
                 :placeholder="automationLabel('dingtalk.recordMemberGroupFieldPathPlaceholder', isZh)"
                 data-field="dingtalkPersonMemberGroupRecipientFieldPath"
               />
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.pickMemberGroupField', isZh) }}</label>
-              <select
+              <el-select
+                :model-value="''"
                 class="meta-rule-editor__select"
+                :placeholder="automationLabel('dingtalk.chooseMemberGroupFieldOption', isZh)"
                 data-field="dingtalkPersonMemberGroupRecipientFieldSelect"
-                @change="appendMemberGroupRecipientFieldPath(action, $event.target as HTMLSelectElement)"
+                @change="appendMemberGroupRecipientFieldPath(action, $event)"
               >
-                <option value="">{{ automationLabel('dingtalk.chooseMemberGroupFieldOption', isZh) }}</option>
-                <option v-for="field in memberGroupRecipientCandidateFields" :key="field.id" :value="field.id">
-                  {{ field.name }} (record.{{ field.id }})
-                </option>
-              </select>
+                <el-option value="" data-value="" :label="automationLabel('dingtalk.chooseMemberGroupFieldOption', isZh)" />
+                <el-option
+                  v-for="field in memberGroupRecipientCandidateFields"
+                  :key="field.id"
+                  :value="field.id"
+                  :data-value="field.id"
+                  :label="`${field.name} (record.${field.id})`"
+                />
+              </el-select>
               <div
                 v-if="selectedMemberGroupRecipientFields(action).length"
                 class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
@@ -884,9 +899,8 @@
                 {{ automationLabel('dingtalk.recordMemberGroupFieldPathHint', isZh) }}
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.titleTemplate', isZh) }}</label>
-              <input
+              <el-input
                 v-model="action.config.titleTemplate"
-                class="meta-rule-editor__input"
                 type="text"
                 :placeholder="automationLabel('dingtalk.titleTemplatePlaceholder', isZh)"
                 data-field="dingtalkPersonTitleTemplate"
@@ -900,25 +914,25 @@
               </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.templateTokens', isZh) }}</span>
-                <button
+                <el-button
                   v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
                   :key="token.key"
+                  size="small"
                   class="meta-rule-editor__btn"
-                  type="button"
                   :data-field="`personTitleToken-${token.key}`"
                   @click="appendPersonTemplateToken(action, 'titleTemplate', token.value)"
                 >
                   {{ dingTalkTemplateTokenLabel(token, isZh) }}
-                </button>
+                </el-button>
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.bodyTemplate', isZh) }}</label>
-              <textarea
+              <el-input
                 v-model="action.config.bodyTemplate"
-                class="meta-rule-editor__textarea"
-                rows="4"
+                type="textarea"
+                :rows="4"
                 :placeholder="automationLabel('dingtalk.bodyTemplatePlaceholder', isZh)"
                 data-field="dingtalkPersonBodyTemplate"
-              ></textarea>
+              />
               <div
                 v-for="warning in templateSyntaxWarnings(action.config.bodyTemplate)"
                 :key="`person-body-${warning}`"
@@ -928,26 +942,27 @@
               </div>
               <div class="meta-rule-editor__token-row">
                 <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.templateTokens', isZh) }}</span>
-                <button
+                <el-button
                   v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
                   :key="token.key"
+                  size="small"
                   class="meta-rule-editor__btn"
-                  type="button"
                   :data-field="`personBodyToken-${token.key}`"
                   @click="appendPersonTemplateToken(action, 'bodyTemplate', token.value, true)"
                 >
                   {{ dingTalkTemplateTokenLabel(token, isZh) }}
-                </button>
+                </el-button>
               </div>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.publicFormView', isZh) }}</label>
-              <select
+              <el-select
                 v-model="action.config.publicFormViewId"
                 class="meta-rule-editor__select"
+                :placeholder="automationLabel('dingtalk.noPublicFormLinkOption', isZh)"
                 data-field="dingtalkPersonPublicFormViewId"
               >
-                <option value="">{{ automationLabel('dingtalk.noPublicFormLinkOption', isZh) }}</option>
-                <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
-              </select>
+                <el-option value="" data-value="" :label="automationLabel('dingtalk.noPublicFormLinkOption', isZh)" />
+                <el-option v-for="view in formViews" :key="view.id" :value="view.id" :data-value="view.id" :label="view.name" />
+              </el-select>
               <div
                 v-for="warning in publicFormLinkWarnings(action.config.publicFormViewId, true)"
                 :key="`person-public-form-${warning}`"
@@ -977,14 +992,15 @@
                 </div>
               </template>
               <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.internalProcessingView', isZh) }}</label>
-              <select
+              <el-select
                 v-model="action.config.internalViewId"
                 class="meta-rule-editor__select"
+                :placeholder="automationLabel('dingtalk.noInternalLinkOption', isZh)"
                 data-field="dingtalkPersonInternalViewId"
               >
-                <option value="">{{ automationLabel('dingtalk.noInternalLinkOption', isZh) }}</option>
-                <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
-              </select>
+                <el-option value="" data-value="" :label="automationLabel('dingtalk.noInternalLinkOption', isZh)" />
+                <el-option v-for="view in internalViews" :key="view.id" :value="view.id" :data-value="view.id" :label="view.name" />
+              </el-select>
               <div
                 v-for="warning in internalViewLinkWarnings(action.config.internalViewId)"
                 :key="`person-internal-view-${warning}`"
@@ -1001,25 +1017,27 @@
                 <div class="meta-rule-editor__preview-body"><strong>{{ automationLabel('dingtalk.bodyTemplate', isZh) }}:</strong> {{ templatePreviewText(action.config.bodyTemplate, automationLabel('dingtalk.noBodyTemplate', isZh)) }}</div>
                 <div class="meta-rule-editor__preview-line">
                   <span><strong>{{ automationLabel('dingtalk.renderedTitle', isZh) }}:</strong> {{ renderedTemplateExample(action.config.titleTemplate, automationLabel('dingtalk.noRenderedTitle', isZh)) }}</span>
-                  <button
+                  <el-button
+                    size="small"
+                    round
                     class="meta-rule-editor__copy-btn"
-                    type="button"
                     :data-field="`personRenderedTitleCopy-${idx}`"
                     @click="copyPreviewText(`person-title-${idx}`, renderedTemplateExample(action.config.titleTemplate, ''))"
                   >
                     {{ copiedPreviewKey === `person-title-${idx}` ? automationLabel('dingtalk.copied', isZh) : automationLabel('dingtalk.copy', isZh) }}
-                  </button>
+                  </el-button>
                 </div>
                 <div class="meta-rule-editor__preview-line meta-rule-editor__preview-body">
                   <span><strong>{{ automationLabel('dingtalk.renderedBody', isZh) }}:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, automationLabel('dingtalk.noRenderedBody', isZh)) }}</span>
-                  <button
+                  <el-button
+                    size="small"
+                    round
                     class="meta-rule-editor__copy-btn"
-                    type="button"
                     :data-field="`personRenderedBodyCopy-${idx}`"
                     @click="copyPreviewText(`person-body-${idx}`, renderedTemplateExample(action.config.bodyTemplate, ''))"
                   >
                     {{ copiedPreviewKey === `person-body-${idx}` ? automationLabel('dingtalk.copied', isZh) : automationLabel('dingtalk.copy', isZh) }}
-                  </button>
+                  </el-button>
                 </div>
                 <div><strong>{{ automationLabel('dingtalk.publicForm', isZh) }}:</strong> {{ viewSummaryName(action.config.publicFormViewId, automationLabel('dingtalk.noPublicFormLink', isZh)) }}</div>
                 <div><strong>{{ automationLabel('dingtalk.publicFormAccess', isZh) }}:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
@@ -1030,10 +1048,13 @@
 
             <!-- lock_record config -->
             <div v-if="action.type === 'lock_record'" class="meta-rule-editor__action-config">
-              <label class="meta-rule-editor__toggle-label">
-                <input type="checkbox" v-model="action.config.locked" />
+              <el-checkbox
+                class="meta-rule-editor__toggle-label"
+                :model-value="action.config.locked === true"
+                @update:model-value="action.config.locked = $event === true"
+              >
                 {{ automationLabel('actionConfig.lockRecord', isZh) }}
-              </label>
+              </el-checkbox>
             </div>
 
             <!-- delete_record config (T0-3): same-base trigger-record only; acknowledgement is UI-only. -->
@@ -1041,15 +1062,14 @@
               <div class="meta-rule-editor__hint meta-rule-editor__hint--warning" data-field="deleteRecordWarning">
                 {{ automationLabel('actionConfig.deleteRecordWarning', isZh) }}
               </div>
-              <label class="meta-rule-editor__toggle-label">
-                <input
-                  type="checkbox"
-                  data-field="deleteRecordAck"
-                  :checked="isDeleteRecordAcknowledged(action)"
-                  @change="setDeleteRecordAcknowledged(action, ($event.target as HTMLInputElement).checked)"
-                />
+              <el-checkbox
+                class="meta-rule-editor__toggle-label"
+                data-field="deleteRecordAck"
+                :model-value="isDeleteRecordAcknowledged(action)"
+                @change="setDeleteRecordAcknowledged(action, $event === true)"
+              >
                 {{ automationLabel('actionConfig.deleteRecordAck', isZh) }}
-              </label>
+              </el-checkbox>
             </div>
 
             <!-- wait_for_callback config (A6-2: info-only, ZERO params — the suspend point; no
@@ -1067,88 +1087,88 @@
                 <div class="meta-rule-editor__hint">{{ automationLabel('conditionBranch.hint', isZh) }}</div>
                 <div v-for="(branch, bIdx) in action.config.branches" :key="bIdx" class="meta-rule-editor__branch" :data-branch-index="bIdx">
                   <div class="meta-rule-editor__branch-header">
-                    <input v-model="branch.key" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.key', isZh)" data-field="branch-key" />
-                    <input v-model="branch.label" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.label', isZh)" data-field="branch-label" />
-                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" data-action="remove-branch" @click="removeBranch(action, bIdx)">&times;</button>
+                    <el-input v-model="branch.key" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.key', isZh)" data-field="branch-key" />
+                    <el-input v-model="branch.label" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.label', isZh)" data-field="branch-label" />
+                    <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" data-action="remove-branch" @click="removeBranch(action, bIdx)">&times;</el-button>
                   </div>
                   <div v-if="branch.conditions.length > 1" class="meta-rule-editor__conjunction">
-                    <button type="button" class="meta-rule-editor__toggle-btn" :class="{ 'meta-rule-editor__toggle-btn--active': branch.conjunction === 'AND' }" @click="branch.conjunction = 'AND'">{{ automationLabel('condition.and', isZh) }}</button>
-                    <button type="button" class="meta-rule-editor__toggle-btn" :class="{ 'meta-rule-editor__toggle-btn--active': branch.conjunction === 'OR' }" @click="branch.conjunction = 'OR'">{{ automationLabel('condition.or', isZh) }}</button>
+                    <el-button size="small" class="meta-rule-editor__toggle-btn" :class="{ 'meta-rule-editor__toggle-btn--active': branch.conjunction === 'AND' }" :type="branch.conjunction === 'AND' ? 'primary' : 'default'" @click="branch.conjunction = 'AND'">{{ automationLabel('condition.and', isZh) }}</el-button>
+                    <el-button size="small" class="meta-rule-editor__toggle-btn" :class="{ 'meta-rule-editor__toggle-btn--active': branch.conjunction === 'OR' }" :type="branch.conjunction === 'OR' ? 'primary' : 'default'" @click="branch.conjunction = 'OR'">{{ automationLabel('condition.or', isZh) }}</el-button>
                   </div>
                   <div v-for="(cond, cIdx) in branch.conditions" :key="cIdx" class="meta-rule-editor__condition-row" :data-branch-condition-index="cIdx">
-                    <select :value="cond.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onConditionFieldChange(cond, ($event.target as HTMLSelectElement).value)">
-                      <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
-                      <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-                    </select>
-                    <select :value="cond.operator" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onConditionOperatorChange(cond, ($event.target as HTMLSelectElement).value as ConditionOperator)">
-                      <option v-for="op in conditionOperatorsForField(cond.fieldId)" :key="op.value" :value="op.value">{{ automationConditionOperatorLabel(op.value, isZh) }}</option>
-                    </select>
-                    <input v-if="!isUnaryOperator(cond.operator)" v-model="cond.value" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('condition.selectValue', isZh)" />
-                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchCondition(branch, cIdx)">&times;</button>
+                    <el-select :model-value="cond.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm" :placeholder="automationLabel('condition.selectField', isZh)" @change="onConditionFieldChange(cond, $event)">
+                      <el-option value="" data-value="" :label="automationLabel('condition.selectField', isZh)" />
+                      <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+                    </el-select>
+                    <el-select :model-value="cond.operator" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onConditionOperatorChange(cond, $event as ConditionOperator)">
+                      <el-option v-for="op in conditionOperatorsForField(cond.fieldId)" :key="op.value" :value="op.value" :data-value="op.value" :label="automationConditionOperatorLabel(op.value, isZh)" />
+                    </el-select>
+                    <el-input v-if="!isUnaryOperator(cond.operator)" v-model="(cond.value as string)" class="meta-rule-editor__input--sm" :placeholder="automationLabel('condition.selectValue', isZh)" />
+                    <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeBranchCondition(branch, cIdx)">&times;</el-button>
                   </div>
-                  <button class="meta-rule-editor__btn" type="button" data-action="add-branch-condition" @click="addBranchCondition(branch)">{{ automationLabel('condition.addCondition', isZh) }}</button>
+                  <el-button size="small" class="meta-rule-editor__btn" data-action="add-branch-condition" @click="addBranchCondition(branch)">{{ automationLabel('condition.addCondition', isZh) }}</el-button>
                   <div v-for="(bAct, aIdx) in branch.actions" :key="aIdx" class="meta-rule-editor__branch-action" :data-branch-action-index="aIdx">
-                    <select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
-                      <option v-for="t in CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
-                    </select>
+                    <el-select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
+                      <el-option v-for="t in CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t" :data-value="t" :label="automationActionTypeLabel(t, isZh)" />
+                    </el-select>
                     <template v-if="bAct.type === 'update_record'">
                       <div v-for="(pair, pIdx) in bAct.fieldUpdates" :key="pIdx" class="meta-rule-editor__field-pair">
-                        <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
-                          <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
-                          <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-                        </select>
-                        <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.value', isZh)" />
-                        <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchFieldPair(bAct, pIdx)">&times;</button>
+                        <el-select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm" :placeholder="automationLabel('condition.selectField', isZh)">
+                          <el-option value="" data-value="" :label="automationLabel('condition.selectField', isZh)" />
+                          <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+                        </el-select>
+                        <el-input v-model="pair.value" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.value', isZh)" />
+                        <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeBranchFieldPair(bAct, pIdx)">&times;</el-button>
                       </div>
-                      <button class="meta-rule-editor__btn" type="button" data-action="add-branch-field" @click="addBranchFieldPair(bAct)">{{ automationLabel('conditionBranch.addField', isZh) }}</button>
+                      <el-button size="small" class="meta-rule-editor__btn" data-action="add-branch-field" @click="addBranchFieldPair(bAct)">{{ automationLabel('conditionBranch.addField', isZh) }}</el-button>
                     </template>
                     <template v-else-if="bAct.type === 'send_notification'">
-                      <input v-model="bAct.userId" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.userIds', isZh)" />
-                      <input v-model="bAct.message" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.message', isZh)" />
+                      <el-input v-model="bAct.userId" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.userIds', isZh)" />
+                      <el-input v-model="bAct.message" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.message', isZh)" />
                     </template>
                     <!-- A6-3-3b branch-local wait_for_callback: zero-param suspend point (no fields to author) -->
                     <template v-else-if="bAct.type === 'wait_for_callback'">
                       <span class="meta-rule-editor__hint" data-field="branch-wait-for-callback-hint">{{ automationLabel('actionConfig.waitForCallbackHint', isZh) }}</span>
                     </template>
-                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchAction(branch, aIdx)">&times;</button>
+                    <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeBranchAction(branch, aIdx)">&times;</el-button>
                   </div>
-                  <button class="meta-rule-editor__btn" type="button" data-action="add-branch-action" @click="addBranchAction(branch)">{{ automationLabel('conditionBranch.addAction', isZh) }}</button>
+                  <el-button size="small" class="meta-rule-editor__btn" data-action="add-branch-action" @click="addBranchAction(branch)">{{ automationLabel('conditionBranch.addAction', isZh) }}</el-button>
                 </div>
-                <button class="meta-rule-editor__btn" type="button" data-action="add-branch" @click="addBranch(action)">{{ automationLabel('conditionBranch.addBranch', isZh) }}</button>
+                <el-button size="small" class="meta-rule-editor__btn" data-action="add-branch" @click="addBranch(action)">{{ automationLabel('conditionBranch.addBranch', isZh) }}</el-button>
                 <div v-if="action.config.defaultBranch" class="meta-rule-editor__branch" data-field="default-branch">
                   <div class="meta-rule-editor__branch-header">
                     <span class="meta-rule-editor__group-label">{{ automationLabel('conditionBranch.default', isZh) }}</span>
-                    <input v-model="action.config.defaultBranch.key" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.key', isZh)" data-field="default-branch-key" />
-                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" data-action="remove-default-branch" @click="removeDefaultBranch(action)">&times;</button>
+                    <el-input v-model="action.config.defaultBranch.key" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.key', isZh)" data-field="default-branch-key" />
+                    <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" data-action="remove-default-branch" @click="removeDefaultBranch(action)">&times;</el-button>
                   </div>
                   <div v-for="(bAct, aIdx) in action.config.defaultBranch.actions" :key="aIdx" class="meta-rule-editor__branch-action" :data-default-branch-action-index="aIdx">
-                    <select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
-                      <option v-for="t in CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
-                    </select>
+                    <el-select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
+                      <el-option v-for="t in CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t" :data-value="t" :label="automationActionTypeLabel(t, isZh)" />
+                    </el-select>
                     <template v-if="bAct.type === 'update_record'">
                       <div v-for="(pair, pIdx) in bAct.fieldUpdates" :key="pIdx" class="meta-rule-editor__field-pair">
-                        <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
-                          <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
-                          <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-                        </select>
-                        <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.value', isZh)" />
-                        <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchFieldPair(bAct, pIdx)">&times;</button>
+                        <el-select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm" :placeholder="automationLabel('condition.selectField', isZh)">
+                          <el-option value="" data-value="" :label="automationLabel('condition.selectField', isZh)" />
+                          <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+                        </el-select>
+                        <el-input v-model="pair.value" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.value', isZh)" />
+                        <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeBranchFieldPair(bAct, pIdx)">&times;</el-button>
                       </div>
-                      <button class="meta-rule-editor__btn" type="button" @click="addBranchFieldPair(bAct)">{{ automationLabel('conditionBranch.addField', isZh) }}</button>
+                      <el-button size="small" class="meta-rule-editor__btn" @click="addBranchFieldPair(bAct)">{{ automationLabel('conditionBranch.addField', isZh) }}</el-button>
                     </template>
                     <template v-else-if="bAct.type === 'send_notification'">
-                      <input v-model="bAct.userId" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.userIds', isZh)" />
-                      <input v-model="bAct.message" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.message', isZh)" />
+                      <el-input v-model="bAct.userId" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.userIds', isZh)" />
+                      <el-input v-model="bAct.message" class="meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.message', isZh)" />
                     </template>
                     <!-- A6-3-3b branch-local wait_for_callback (default branch): zero-param suspend point -->
                     <template v-else-if="bAct.type === 'wait_for_callback'">
                       <span class="meta-rule-editor__hint" data-field="branch-wait-for-callback-hint">{{ automationLabel('actionConfig.waitForCallbackHint', isZh) }}</span>
                     </template>
-                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchAction(action.config.defaultBranch, aIdx)">&times;</button>
+                    <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeBranchAction(action.config.defaultBranch, aIdx)">&times;</el-button>
                   </div>
-                  <button class="meta-rule-editor__btn" type="button" @click="addBranchAction(action.config.defaultBranch)">{{ automationLabel('conditionBranch.addAction', isZh) }}</button>
+                  <el-button size="small" class="meta-rule-editor__btn" @click="addBranchAction(action.config.defaultBranch)">{{ automationLabel('conditionBranch.addAction', isZh) }}</el-button>
                 </div>
-                <button v-else class="meta-rule-editor__btn" type="button" data-action="add-default-branch" @click="addDefaultBranch(action)">{{ automationLabel('conditionBranch.addDefault', isZh) }}</button>
+                <el-button v-else size="small" class="meta-rule-editor__btn" data-action="add-default-branch" @click="addDefaultBranch(action)">{{ automationLabel('conditionBranch.addDefault', isZh) }}</el-button>
                 <div v-if="conditionBranchKeyError" class="meta-rule-editor__error" data-field="branch-key-error">{{ conditionBranchKeyError }}</div>
               </template>
             </div>
@@ -1162,46 +1182,46 @@
                 <div class="meta-rule-editor__hint">{{ automationLabel('parallelBranch.hint', isZh) }}</div>
                 <div v-for="(branch, bIdx) in action.config.parallelBranches" :key="bIdx" class="meta-rule-editor__branch" :data-parallel-branch-index="bIdx">
                   <div class="meta-rule-editor__branch-header">
-                    <input v-model="branch.key" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.key', isZh)" data-field="parallel-branch-key" />
-                    <input v-model="branch.label" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.label', isZh)" data-field="parallel-branch-label" />
-                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" data-action="remove-parallel-branch" @click="removeParallelBranch(action, bIdx)">&times;</button>
+                    <el-input v-model="branch.key" class="meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.key', isZh)" data-field="parallel-branch-key" />
+                    <el-input v-model="branch.label" class="meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.label', isZh)" data-field="parallel-branch-label" />
+                    <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" data-action="remove-parallel-branch" @click="removeParallelBranch(action, bIdx)">&times;</el-button>
                   </div>
                   <div v-for="(bAct, aIdx) in branch.actions" :key="aIdx" class="meta-rule-editor__branch-action" :data-parallel-branch-action-index="aIdx">
-                    <select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
-                      <option v-for="t in BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
-                    </select>
+                    <el-select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
+                      <el-option v-for="t in BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t" :data-value="t" :label="automationActionTypeLabel(t, isZh)" />
+                    </el-select>
                     <template v-if="bAct.type === 'update_record'">
                       <div v-for="(pair, pIdx) in bAct.fieldUpdates" :key="pIdx" class="meta-rule-editor__field-pair">
-                        <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
-                          <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
-                          <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-                        </select>
-                        <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.value', isZh)" />
-                        <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchFieldPair(bAct, pIdx)">&times;</button>
+                        <el-select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm" :placeholder="automationLabel('condition.selectField', isZh)">
+                          <el-option value="" data-value="" :label="automationLabel('condition.selectField', isZh)" />
+                          <el-option v-for="f in fields" :key="f.id" :value="f.id" :data-value="f.id" :label="f.name" />
+                        </el-select>
+                        <el-input v-model="pair.value" class="meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.value', isZh)" />
+                        <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeBranchFieldPair(bAct, pIdx)">&times;</el-button>
                       </div>
-                      <button class="meta-rule-editor__btn" type="button" data-action="add-parallel-branch-field" @click="addBranchFieldPair(bAct)">{{ automationLabel('parallelBranch.addField', isZh) }}</button>
+                      <el-button size="small" class="meta-rule-editor__btn" data-action="add-parallel-branch-field" @click="addBranchFieldPair(bAct)">{{ automationLabel('parallelBranch.addField', isZh) }}</el-button>
                     </template>
                     <template v-else-if="bAct.type === 'send_notification'">
-                      <input v-model="bAct.userId" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.userIds', isZh)" />
-                      <input v-model="bAct.message" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.message', isZh)" />
+                      <el-input v-model="bAct.userId" class="meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.userIds', isZh)" />
+                      <el-input v-model="bAct.message" class="meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.message', isZh)" />
                     </template>
-                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchAction(branch, aIdx)">&times;</button>
+                    <el-button size="small" class="meta-rule-editor__btn meta-rule-editor__btn--icon" @click="removeBranchAction(branch, aIdx)">&times;</el-button>
                   </div>
-                  <button class="meta-rule-editor__btn" type="button" data-action="add-parallel-branch-action" @click="addBranchAction(branch)">{{ automationLabel('parallelBranch.addAction', isZh) }}</button>
+                  <el-button size="small" class="meta-rule-editor__btn" data-action="add-parallel-branch-action" @click="addBranchAction(branch)">{{ automationLabel('parallelBranch.addAction', isZh) }}</el-button>
                 </div>
-                <button class="meta-rule-editor__btn" type="button" data-action="add-parallel-branch" @click="addParallelBranch(action)">{{ automationLabel('parallelBranch.addBranch', isZh) }}</button>
+                <el-button size="small" class="meta-rule-editor__btn" data-action="add-parallel-branch" @click="addParallelBranch(action)">{{ automationLabel('parallelBranch.addBranch', isZh) }}</el-button>
                 <div v-if="parallelBranchKeyError" class="meta-rule-editor__error" data-field="parallel-branch-key-error">{{ parallelBranchKeyError }}</div>
                 <div v-if="parallelBranchActionError" class="meta-rule-editor__error" data-field="parallel-branch-action-error">{{ parallelBranchActionError }}</div>
               </template>
             </div>
           </div>
-          <button
+          <el-button
             v-if="draft.actions.length < 3"
+            size="small"
             class="meta-rule-editor__btn"
-            type="button"
             data-action="add-action"
             @click="addAction"
-          >{{ automationLabel('editor.addAction', isZh) }}</button>
+          >{{ automationLabel('editor.addAction', isZh) }}</el-button>
         </section>
     </div>
 
@@ -1228,19 +1248,18 @@
             {{ props.testRunState.message }}
           </div>
         </div>
-        <button class="meta-rule-editor__btn meta-rule-editor__btn--primary" type="button" :disabled="!canSave || saving" data-action="save" @click="onSave">
+        <el-button type="primary" class="meta-rule-editor__btn--primary" :disabled="!canSave || saving" data-action="save" @click="onSave">
           {{ saving ? automationLabel('editor.saving', isZh) : automationLabel('editor.save', isZh) }}
-        </button>
-        <button
+        </el-button>
+        <el-button
           class="meta-rule-editor__btn"
-          type="button"
           :disabled="saving || !props.rule?.id || props.testRunState?.status === 'running'"
           @click="onTestRun"
           data-action="test"
         >
           {{ props.testRunState?.status === 'running' ? automationLabel('testRun.running', isZh) : automationLabel('testRun.button', isZh) }}
-        </button>
-        <button class="meta-rule-editor__btn" type="button" @click="requestClose">{{ automationLabel('editor.cancel', isZh) }}</button>
+        </el-button>
+        <el-button class="meta-rule-editor__btn" @click="requestClose">{{ automationLabel('editor.cancel', isZh) }}</el-button>
       </div>
     </template>
   </el-drawer>
@@ -1248,7 +1267,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
-import { ElDrawer } from 'element-plus'
+import { ElButton, ElCheckbox, ElCheckboxGroup, ElDrawer, ElInput, ElOption, ElSelect } from 'element-plus'
 import { useLocale } from '../../composables/useLocale'
 import type { MultitableApiClient } from '../api/client'
 import type {
@@ -1765,14 +1784,12 @@ function onBooleanConditionValueChange(condition: AutomationCondition, value: st
   }
 }
 
-function onBooleanMultiSelectConditionValueChange(condition: AutomationCondition, event: Event) {
-  const select = event.target as HTMLSelectElement
-  condition.value = Array.from(select.selectedOptions).map((option) => option.value)
+function onBooleanMultiSelectConditionValueChange(condition: AutomationCondition, values: string[]) {
+  condition.value = [...values]
 }
 
-function onMultiSelectConditionValueChange(condition: AutomationCondition, event: Event) {
-  const select = event.target as HTMLSelectElement
-  condition.value = Array.from(select.selectedOptions).map((option) => option.value)
+function onMultiSelectConditionValueChange(condition: AutomationCondition, values: string[]) {
+  condition.value = [...values]
 }
 
 function isNumericConditionFieldType(fieldType: string | undefined): boolean {
@@ -2737,15 +2754,14 @@ function availableGroupDestinations(action: DraftAction) {
   return dingTalkDestinations.value.filter((destination) => !selected.has(destination.id))
 }
 
-function appendGroupDestination(action: DraftAction, select: HTMLSelectElement) {
-  const destinationId = select.value.trim()
+function appendGroupDestination(action: DraftAction, selected: string) {
+  const destinationId = selected.trim()
   if (!destinationId) return
   const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
   destinationIds.push(destinationId)
   action.config.destinationIds = Array.from(new Set(destinationIds))
   action.config.destinationId = action.config.destinationIds[0] || ''
   action.config.destinationPickerId = ''
-  select.value = ''
 }
 
 function removeGroupDestination(action: DraftAction, destinationId: string) {
@@ -2772,15 +2788,14 @@ function groupDestinationFieldPathSummary(value: unknown) {
   return labels.join(', ')
 }
 
-function appendGroupDestinationFieldPath(action: DraftAction, select: HTMLSelectElement) {
-  const fieldId = select.value.trim()
+function appendGroupDestinationFieldPath(action: DraftAction, selected: string) {
+  const fieldId = selected.trim()
   if (!fieldId) return
   const paths = parseRecipientFieldPathsText(action.config.destinationFieldPath)
   paths.push(fieldId)
   action.config.destinationFieldPath = Array.from(new Set(paths))
     .map((path) => `record.${path}`)
     .join(', ')
-  select.value = ''
 }
 
 function removeGroupDestinationFieldPath(action: DraftAction, path: string) {
@@ -2928,15 +2943,14 @@ function memberGroupRecipientFieldPathSummary(value: unknown) {
   return labels.join(', ')
 }
 
-function appendRecipientFieldPath(action: DraftAction, select: HTMLSelectElement) {
-  const fieldId = select.value.trim()
+function appendRecipientFieldPath(action: DraftAction, selected: string) {
+  const fieldId = selected.trim()
   if (!fieldId) return
   const paths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
   paths.push(fieldId)
   action.config.recipientFieldPath = Array.from(new Set(paths))
     .map((path) => `record.${path}`)
     .join(', ')
-  select.value = ''
 }
 
 function removeRecipientFieldPath(action: DraftAction, path: string) {
@@ -2946,15 +2960,14 @@ function removeRecipientFieldPath(action: DraftAction, path: string) {
     .join(', ')
 }
 
-function appendMemberGroupRecipientFieldPath(action: DraftAction, select: HTMLSelectElement) {
-  const fieldId = select.value.trim()
+function appendMemberGroupRecipientFieldPath(action: DraftAction, selected: string) {
+  const fieldId = selected.trim()
   if (!fieldId) return
   const paths = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
   paths.push(fieldId)
   action.config.memberGroupRecipientFieldPath = Array.from(new Set(paths))
     .map((path) => `record.${path}`)
     .join(', ')
-  select.value = ''
 }
 
 function removeMemberGroupRecipientFieldPath(action: DraftAction, path: string) {
@@ -3412,7 +3425,7 @@ function onTestRun() {
 
 <style scoped>
 /* UF-4: the hand-rolled fixed overlay + panel + header/close chrome is now provided by el-drawer. */
-.meta-rule-editor__title { margin: 0; font-size: 16px; font-weight: 700; color: #0f172a; }
+.meta-rule-editor__title { margin: 0; font-size: 16px; font-weight: 700; color: var(--ms-text-1); }
 
 .meta-rule-editor__body {
   display: flex;
@@ -3420,10 +3433,10 @@ function onTestRun() {
   gap: 8px;
 }
 
-.meta-rule-editor__error { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: #fef2f2; color: #b91c1c; }
+.meta-rule-editor__error { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: var(--el-color-danger-light-9); color: var(--el-color-danger-dark-2); }
 
 .meta-rule-editor__section {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 10px;
   padding: 12px;
   display: flex;
@@ -3431,8 +3444,8 @@ function onTestRun() {
   gap: 8px;
 }
 
-.meta-rule-editor__section-title { font-size: 14px; font-weight: 600; color: #0f172a; }
-.meta-rule-editor__hint { font-weight: 400; color: #94a3b8; font-size: 12px; }
+.meta-rule-editor__section-title { font-size: 14px; font-weight: 600; color: var(--ms-text-1); }
+.meta-rule-editor__hint { font-weight: 400; color: var(--ms-text-3); font-size: 12px; }
 
 .meta-rule-editor__access-summary {
   border-radius: 8px;
@@ -3441,36 +3454,36 @@ function onTestRun() {
 
 .meta-rule-editor__access-audience {
   border-radius: 8px;
-  background: #f8fafc;
-  color: #475569;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
   padding: 6px 8px;
 }
 
 .meta-rule-editor__access-summary--public {
-  background: #fffbeb;
-  color: #92400e;
+  background: var(--ms-bg-card)beb;
+  color: var(--el-color-warning-dark-2);
 }
 
 .meta-rule-editor__access-summary--dingtalk {
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
 }
 
 .meta-rule-editor__access-summary--dingtalk_granted {
-  background: #ecfdf5;
-  color: #047857;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .meta-rule-editor__access-summary--unavailable {
-  background: #fef2f2;
-  color: #b91c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
 }
 
-.meta-rule-editor__label { font-size: 12px; font-weight: 600; color: #475569; margin-top: 4px; }
+.meta-rule-editor__label { font-size: 12px; font-weight: 600; color: var(--ms-text-2); margin-top: 4px; }
 
-.meta-rule-editor__hint--error { color: #b91c1c; }
+.meta-rule-editor__hint--error { color: var(--el-color-danger-dark-2); }
 
-.meta-rule-editor__hint--warning { color: #b45309; }
+.meta-rule-editor__hint--warning { color: var(--el-color-warning-dark-2); }
 
 .meta-rule-editor__test-run-feedback {
   flex: 1 1 280px;
@@ -3484,25 +3497,10 @@ function onTestRun() {
   font-weight: 600;
 }
 
-.meta-rule-editor__test-run-status--success { color: #15803d; }
-.meta-rule-editor__test-run-status--failed { color: #b91c1c; }
-.meta-rule-editor__test-run-status--skipped { color: #b45309; }
-.meta-rule-editor__test-run-status--running { color: #1d4ed8; }
-
-.meta-rule-editor__input,
-.meta-rule-editor__select,
-.meta-rule-editor__textarea {
-  width: 100%;
-  min-width: 0;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 8px 10px;
-  font-size: 13px;
-  background: #fff;
-  box-sizing: border-box;
-}
-
-.meta-rule-editor__textarea { resize: vertical; font-family: inherit; }
+.meta-rule-editor__test-run-status--success { color: var(--el-color-success-dark-2); }
+.meta-rule-editor__test-run-status--failed { color: var(--el-color-danger-dark-2); }
+.meta-rule-editor__test-run-status--skipped { color: var(--el-color-warning-dark-2); }
+.meta-rule-editor__test-run-status--running { color: var(--el-color-primary-dark-2); }
 
 .meta-rule-editor__input--sm,
 .meta-rule-editor__select--sm {
@@ -3533,13 +3531,13 @@ function onTestRun() {
   gap: 8px;
   align-items: center;
   padding: 8px;
-  border: 1px dashed #cbd5e1;
+  border: 1px dashed var(--ms-border);
   border-radius: 8px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .meta-rule-editor__group-label {
-  color: #475569;
+  color: var(--ms-text-2);
   font-size: 12px;
   font-weight: 600;
 }
@@ -3553,24 +3551,8 @@ function onTestRun() {
 
 .meta-rule-editor__conjunction { display: flex; gap: 4px; }
 
-.meta-rule-editor__toggle-btn {
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
-  padding: 4px 12px;
-  background: #fff;
-  font-size: 12px;
-  cursor: pointer;
-  color: #475569;
-}
-
-.meta-rule-editor__toggle-btn--active {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #fff;
-}
-
 .meta-rule-editor__action-row {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
   padding: 10px;
   display: flex;
@@ -3584,7 +3566,7 @@ function onTestRun() {
   gap: 8px;
 }
 
-.meta-rule-editor__action-num { font-weight: 700; font-size: 14px; color: #2563eb; }
+.meta-rule-editor__action-num { font-weight: 700; font-size: 14px; color: var(--ms-color-primary); }
 
 .meta-rule-editor__action-btns { display: flex; gap: 4px; margin-left: auto; }
 
@@ -3613,24 +3595,24 @@ function onTestRun() {
 .meta-rule-editor__preset-label {
   font-size: 12px;
   font-weight: 600;
-  color: #475569;
+  color: var(--ms-text-2);
 }
 
 .meta-rule-editor__preview {
-  border: 1px solid #dbeafe;
-  background: #f8fbff;
+  border: 1px solid var(--el-color-primary-light-8);
+  background: var(--el-color-primary-light-9);
   border-radius: 8px;
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
-  color: #334155;
+  color: var(--ms-text-2);
 }
 
 .meta-rule-editor__preview-title {
   font-weight: 700;
-  color: #1e3a8a;
+  color: var(--el-color-primary-dark-2);
 }
 
 .meta-rule-editor__preview-line {
@@ -3646,13 +3628,6 @@ function onTestRun() {
 
 .meta-rule-editor__copy-btn {
   flex-shrink: 0;
-  border: 1px solid #bfdbfe;
-  background: #fff;
-  color: #1d4ed8;
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 11px;
-  cursor: pointer;
 }
 
 .meta-rule-editor__recipient-list {
@@ -3671,19 +3646,19 @@ function onTestRun() {
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--ms-border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--ms-bg-card);
   padding: 8px 10px;
   cursor: pointer;
-  color: #0f172a;
+  color: var(--ms-text-1);
 }
 
 .meta-rule-editor__recipient-option span,
 .meta-rule-editor__recipient-chip span,
 .meta-rule-editor__recipient-chip em {
   font-size: 12px;
-  color: #64748b;
+  color: var(--ms-text-3);
   font-style: normal;
 }
 
@@ -3692,7 +3667,7 @@ function onTestRun() {
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: #475569;
+  color: var(--ms-text-2);
 }
 
 .meta-rule-editor__footer {
@@ -3701,19 +3676,4 @@ function onTestRun() {
   flex-wrap: wrap;
   gap: 8px;
 }
-
-.meta-rule-editor__btn {
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 6px 14px;
-  background: #fff;
-  color: #0f172a;
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.meta-rule-editor__btn:disabled { opacity: 0.55; cursor: not-allowed; }
-.meta-rule-editor__btn--primary { border-color: #2563eb; background: #2563eb; color: #fff; }
-.meta-rule-editor__btn--danger { border-color: #ef4444; color: #b91c1c; }
-.meta-rule-editor__btn--icon { padding: 4px 8px; font-size: 14px; line-height: 1; }
 </style>

--- a/apps/web/tests/conditionBranchEditor.spec.ts
+++ b/apps/web/tests/conditionBranchEditor.spec.ts
@@ -4,6 +4,7 @@ import { createApp, h, nextTick } from 'vue'
 import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomationRuleEditor.vue'
 import { useLocale } from '../src/composables/useLocale'
 import type { AutomationRule } from '../src/multitable/types'
+import { epOptions, epSelectValue, epSelectValues, epSetSelect } from './helpers/epControls'
 
 function flush() {
   return new Promise<void>((r) => setTimeout(r, 0)).then(() => nextTick())
@@ -28,9 +29,8 @@ function setInput(container: HTMLElement, selector: string, value: string) {
   el.dispatchEvent(new Event('input'))
 }
 function selectAction0(container: HTMLElement, type: string) {
-  const sel = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-  sel.value = type
-  sel.dispatchEvent(new Event('change'))
+  const sel = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+  epSetSelect(sel, type)
 }
 function ruleWithBranch(config: Record<string, unknown>): AutomationRule {
   return {
@@ -51,7 +51,7 @@ describe('A6-3-2a condition_branch editor', () => {
     setInput(container, '[data-field="name"]', 'Branch rule')
     selectAction0(container, 'condition_branch')
     await flush()
-    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    const toggle = container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement
     expect(toggle.checked).toBe(true)
     expect(toggle.disabled).toBe(true)
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
@@ -74,18 +74,18 @@ describe('A6-3-2a condition_branch editor', () => {
     ;(container.querySelector('[data-branch-index="0"] [data-action="add-branch-condition"]') as HTMLButtonElement).click()
     await flush()
     const condRow = container.querySelector('[data-branch-index="0"] [data-branch-condition-index="0"]') as HTMLElement
-    const fieldSel = condRow.querySelector('select') as HTMLSelectElement
-    fieldSel.value = 'fld_2'; fieldSel.dispatchEvent(new Event('change'))
+    const fieldSel = condRow.querySelector('.el-select') as HTMLElement
+    epSetSelect(fieldSel, 'fld_2')
     await flush()
-    const valInput = condRow.querySelector('input') as HTMLInputElement
+    const valInput = condRow.querySelector('.el-input__inner') as HTMLInputElement
     valInput.value = 'vip'; valInput.dispatchEvent(new Event('input'))
     // branch_1 action 0 (update_record default): add a field pair Status=done
     ;(container.querySelector('[data-branch-index="0"] [data-action="add-branch-field"]') as HTMLButtonElement).click()
     await flush()
     const pair = container.querySelector('[data-branch-index="0"] .meta-rule-editor__field-pair') as HTMLElement
-    const pairField = pair.querySelector('select') as HTMLSelectElement
-    pairField.value = 'fld_1'; pairField.dispatchEvent(new Event('change'))
-    const pairVal = pair.querySelector('input') as HTMLInputElement
+    const pairField = pair.querySelector('.el-select') as HTMLElement
+    epSetSelect(pairField, 'fld_1')
+    const pairVal = pair.querySelector('.el-input__inner') as HTMLInputElement
     pairVal.value = 'done'; pairVal.dispatchEvent(new Event('input'))
     await flush()
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
@@ -153,10 +153,10 @@ describe('A6-3-2a condition_branch editor', () => {
     setInput(container, '[data-field="name"]', 'Switch')
     selectAction0(container, 'condition_branch')
     await flush()
-    expect((container.querySelector('[data-field="executionMode"]') as HTMLInputElement).disabled).toBe(true)
+    expect((container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement).disabled).toBe(true)
     selectAction0(container, 'update_record')
     await flush()
-    expect((container.querySelector('[data-field="executionMode"]') as HTMLInputElement).disabled).toBe(false)
+    expect((container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement).disabled).toBe(false)
   })
 })
 
@@ -170,9 +170,9 @@ describe('A6-3-3b branch-local wait_for_callback editor', () => {
     selectAction0(container, 'condition_branch')
     await flush()
     const branchActionSelect = container.querySelector(
-      '[data-action-config="condition_branch"] [data-branch-action-index="0"] select',
-    ) as HTMLSelectElement
-    const options = Array.from(branchActionSelect.options).map((o) => o.value)
+      '[data-action-config="condition_branch"] [data-branch-action-index="0"] .el-select',
+    ) as HTMLElement
+    const options = epOptions(branchActionSelect).map((o) => o.value)
     expect(options).toContain('wait_for_callback')
     expect(options).toContain('update_record')
     expect(options).toContain('send_notification')
@@ -190,15 +190,14 @@ describe('A6-3-3b branch-local wait_for_callback editor', () => {
     selectAction0(container, 'condition_branch')
     await flush()
     // auto-lock is already in effect because the rule action is condition_branch
-    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    const toggle = container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement
     expect(toggle.checked).toBe(true)
     expect(toggle.disabled).toBe(true)
     // branch_1 action 0: switch its type select to wait_for_callback
     const branchActionSelect = container.querySelector(
-      '[data-action-config="condition_branch"] [data-branch-action-index="0"] select',
-    ) as HTMLSelectElement
-    branchActionSelect.value = 'wait_for_callback'
-    branchActionSelect.dispatchEvent(new Event('change'))
+      '[data-action-config="condition_branch"] [data-branch-action-index="0"] .el-select',
+    ) as HTMLElement
+    epSetSelect(branchActionSelect, 'wait_for_callback')
     await flush()
     // the zero-param hint renders (no fields to author for a wait)
     expect(

--- a/apps/web/tests/helpers/epControls.ts
+++ b/apps/web/tests/helpers/epControls.ts
@@ -1,0 +1,73 @@
+/**
+ * UF-4 spec helpers: drive Element Plus selects from raw-DOM tests the way the
+ * suites used to drive native <select> elements.
+ *
+ * An el-select renders its trigger in place and (by default) teleports its
+ * dropdown to document.body; the trigger's combobox input points at the
+ * dropdown list via aria-controls, so both teleported and inline poppers
+ * resolve the same way. Every el-option in these components carries a
+ * `data-value` attribute mirroring its bound value, and Element Plus keeps the
+ * option list mounted (persistent tooltip), so options are clickable without
+ * opening the dropdown first.
+ */
+
+export interface EpOptionView {
+  value: string
+  textContent: string | null
+  disabled: boolean
+  el: HTMLElement
+}
+
+function optionList(select: Element): Element | null {
+  const combobox = select.querySelector('[role="combobox"]')
+  const listId = combobox?.getAttribute('aria-controls')
+  if (listId) {
+    const byId = document.getElementById(listId)
+    if (byId) return byId
+  }
+  return select.querySelector('.el-select-dropdown__list')
+}
+
+/** All options of an el-select, in DOM order (mirror of HTMLSelectElement#options). */
+export function epOptions(select: Element | null): EpOptionView[] {
+  if (!select) throw new Error('epOptions: select element not found')
+  const list = optionList(select)
+  if (!list) return []
+  return Array.from(list.querySelectorAll('li.el-select-dropdown__item')).map((li) => ({
+    value: li.getAttribute('data-value') ?? '',
+    textContent: li.textContent,
+    disabled: li.classList.contains('is-disabled'),
+    el: li as HTMLElement,
+  }))
+}
+
+/**
+ * Select an option by value — the el-select analogue of
+ * `select.value = v; select.dispatchEvent(new Event('change'))`.
+ * For `multiple` selects this toggles the option, like flipping
+ * `option.selected` on a native multi-select.
+ */
+export function epSetSelect(select: Element | null, value: string): void {
+  if (!select) throw new Error('epSetSelect: select element not found')
+  const option = epOptions(select).find((item) => item.value === value)
+  if (!option) {
+    const available = epOptions(select).map((item) => item.value)
+    throw new Error(`epSetSelect: option "${value}" not found (available: ${available.join(', ')})`)
+  }
+  option.el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+}
+
+/** Read the selected value of a single el-select (mirror of HTMLSelectElement#value). */
+export function epSelectValue(select: Element | null): string {
+  if (!select) throw new Error('epSelectValue: select element not found')
+  const selected = epOptions(select).filter((item) => item.el.classList.contains('is-selected'))
+  return selected[0]?.value ?? ''
+}
+
+/** Read the selected values of a `multiple` el-select. */
+export function epSelectValues(select: Element | null): string[] {
+  if (!select) throw new Error('epSelectValues: select element not found')
+  return epOptions(select)
+    .filter((item) => item.el.classList.contains('is-selected'))
+    .map((item) => item.value)
+}

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -17,6 +17,7 @@ import { MultitableApiClient } from '../src/multitable/api/client'
 import { useLocale } from '../src/composables/useLocale'
 import { AppRouteNames } from '../src/router/types'
 import type { AutomationRule, DingTalkGroupDelivery, DingTalkPersonDelivery } from '../src/multitable/types'
+import { epOptions, epSelectValue, epSelectValues, epSetSelect } from './helpers/epControls'
 
 function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
   return {
@@ -367,11 +368,11 @@ describe('MetaAutomationManager', () => {
     await nextTick()
 
     const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
     expect(container.querySelector('.meta-automation__form-title')?.textContent).toContain('新建自动化')
     expect(nameInput.placeholder).toBe('自动化名称')
-    expect(actionSelect.value).toBe('notify')
-    expect(Array.from(actionSelect.options).map((option) => option.value)).toEqual([
+    expect(epSelectValue(actionSelect)).toBe('notify')
+    expect(epOptions(actionSelect).map((option) => option.value)).toEqual([
       'notify',
       'update_field',
       'send_dingtalk_group_message',
@@ -385,13 +386,12 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelectorAll('[title]')).toHaveLength(0)
     expect(container.querySelectorAll('[placeholder]')).toHaveLength(2)
 
-    actionSelect.value = 'update_field'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    epSetSelect(actionSelect, 'update_field')
     await nextTick()
 
-    const targetField = container.querySelector('[data-automation-field="targetFieldId"]') as HTMLSelectElement
+    const targetField = container.querySelector('[data-automation-field="targetFieldId"]') as HTMLElement
     const targetValue = container.querySelector('[data-automation-field="targetValue"]') as HTMLInputElement
-    expect(targetField.value).toBe('')
+    expect(epSelectValue(targetField)).toBe('')
     expect(targetValue.placeholder).toBe('新值')
     expect(container.querySelector('.meta-automation__btn--primary')?.textContent).toContain('创建')
     expect(container.querySelectorAll('[placeholder]')).toHaveLength(2)
@@ -445,9 +445,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     expect(container.textContent).toContain('消息预设')
@@ -701,17 +700,14 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'Advanced DingTalk group'
     nameInput.dispatchEvent(new Event('input'))
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
-    destinationSelect.value = 'dt_1'
-    destinationSelect.dispatchEvent(new Event('change'))
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLElement
+    epSetSelect(destinationSelect, 'dt_1')
     await flushPromises()
-    destinationSelect.value = 'dt_2'
-    destinationSelect.dispatchEvent(new Event('change'))
+    epSetSelect(destinationSelect, 'dt_2')
 
     const destinationFieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
     destinationFieldInput.value = 'record.fld_2'
@@ -725,13 +721,11 @@ describe('MetaAutomationManager', () => {
     bodyInput.value = 'Please fill {{record.status}}'
     bodyInput.dispatchEvent(new Event('input'))
 
-    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
 
-    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLSelectElement
-    internalViewSelect.value = 'view_grid'
-    internalViewSelect.dispatchEvent(new Event('change'))
+    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLElement
+    epSetSelect(internalViewSelect, 'view_grid')
     await flushPromises()
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
@@ -789,9 +783,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'Advanced DingTalk person'
     nameInput.dispatchEvent(new Event('input'))
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -818,13 +811,11 @@ describe('MetaAutomationManager', () => {
     bodyInput.value = 'Please process {{record.status}}'
     bodyInput.dispatchEvent(new Event('input'))
 
-    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
 
-    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
-    internalViewSelect.value = 'view_grid'
-    internalViewSelect.dispatchEvent(new Event('change'))
+    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLElement
+    epSetSelect(internalViewSelect, 'view_grid')
     await flushPromises()
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
@@ -914,7 +905,8 @@ describe('MetaAutomationManager', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
     await flushPromises()
 
-    const toggle = container.querySelector('[data-automation-toggle]') as HTMLInputElement
+    // UF-4 shape adaptation: the rule toggle is an el-checkbox; the native input lives inside it
+    const toggle = container.querySelector('[data-automation-toggle] input') as HTMLInputElement
     expect(toggle.checked).toBe(true)
     toggle.click()
     await flushPromises()
@@ -975,15 +967,14 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-automation-field="triggerFieldId"]')).toBeNull()
 
     // Change trigger type to field.changed
-    const triggerSelect = container.querySelector('[data-automation-field="triggerType"]') as HTMLSelectElement
-    triggerSelect.value = 'field.changed'
-    triggerSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const triggerSelect = container.querySelector('[data-automation-field="triggerType"]') as HTMLElement
+    epSetSelect(triggerSelect, 'field.changed')
     await nextTick()
 
-    const fieldPicker = container.querySelector('[data-automation-field="triggerFieldId"]') as HTMLSelectElement
+    const fieldPicker = container.querySelector('[data-automation-field="triggerFieldId"]') as HTMLElement
     expect(fieldPicker).not.toBeNull()
     // Should have option for each field plus the placeholder
-    expect(fieldPicker.options.length).toBe(fields.length + 1)
+    expect(epOptions(fieldPicker).length).toBe(fields.length + 1)
   })
 
   it('shows appropriate action config for each action type', async () => {
@@ -1001,9 +992,8 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-automation-field="targetFieldId"]')).toBeNull()
 
     // Switch to update_field
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'update_field'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'update_field')
     await nextTick()
 
     expect(container.querySelector('[data-automation-field="notifyMessage"]')).toBeNull()
@@ -1024,17 +1014,14 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
-    destinationSelect.value = 'dt_1'
-    destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLElement
+    epSetSelect(destinationSelect, 'dt_1')
     await flushPromises()
-    destinationSelect.value = 'dt_2'
-    destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    epSetSelect(destinationSelect, 'dt_2')
 
     const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -1044,13 +1031,11 @@ describe('MetaAutomationManager', () => {
     bodyInput.value = 'Please fill {{record.status}}'
     bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
 
-    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLSelectElement
-    internalViewSelect.value = 'view_grid'
-    internalViewSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLElement
+    epSetSelect(internalViewSelect, 'view_grid')
     await flushPromises()
 
     expect(container.querySelector('[data-automation-group-destination="dt_1"]')).not.toBeNull()
@@ -1099,15 +1084,13 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'Org DingTalk notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
-    expect(destinationSelect.textContent).toContain('Organization catalog')
-    destinationSelect.value = 'dt_org'
-    destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLElement
+    expect(epOptions(destinationSelect).map((option) => option.textContent).join('\n')).toContain('Organization catalog')
+    epSetSelect(destinationSelect, 'dt_org')
     await flushPromises()
 
     const chip = container.querySelector('[data-automation-group-destination="dt_org"]') as HTMLElement
@@ -1149,9 +1132,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk dynamic groups'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const emptyState = container.querySelector('[data-automation-field="dingtalkDestinationEmpty"]')
@@ -1212,13 +1194,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLSelectElement
-    const optionValues = Array.from(internalViewSelect.options).map((option) => option.value)
+    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLElement
+    const optionValues = epOptions(internalViewSelect).map((option) => option.value)
     expect(optionValues).toContain('view_grid')
     expect(optionValues).not.toContain('view_other_sheet')
   })
@@ -1241,13 +1222,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
-    const optionValues = Array.from(publicFormSelect.options).map((option) => option.value)
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLElement
+    const optionValues = epOptions(publicFormSelect).map((option) => option.value)
     expect(optionValues).toContain('view_form')
     expect(optionValues).not.toContain('view_other_form')
   })
@@ -1265,14 +1245,12 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
-    destinationSelect.value = 'dt_1'
-    destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLElement
+    epSetSelect(destinationSelect, 'dt_1')
 
     const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -1282,9 +1260,8 @@ describe('MetaAutomationManager', () => {
     bodyInput.value = 'Please fill {{record.status}}'
     bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
@@ -1310,9 +1287,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk dynamic groups'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const destinationFieldInput = container.querySelector('[data-automation-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
@@ -1356,9 +1332,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk invalid dynamic groups'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const destinationFieldInput = container.querySelector('[data-automation-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
@@ -1392,14 +1367,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-automation-field="dingtalkDestinationFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'fld_2'
-    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkDestinationFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'fld_2')
     await flushPromises()
 
     const fieldInput = container.querySelector('[data-automation-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
@@ -1418,9 +1391,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const fieldInput = container.querySelector('[data-automation-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
@@ -1441,14 +1413,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
@@ -1475,14 +1445,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
@@ -1508,14 +1476,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
@@ -1535,14 +1501,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
@@ -1568,14 +1532,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
@@ -1594,14 +1556,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is missing a public token')
@@ -1624,9 +1584,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk person notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -1641,9 +1600,8 @@ describe('MetaAutomationManager', () => {
     bodyInput.value = 'Please fill {{record.status}}'
     bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
@@ -1669,9 +1627,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk person notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -1686,13 +1643,11 @@ describe('MetaAutomationManager', () => {
     bodyInput.value = 'Please fill {{record.status}}'
     bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
 
-    const internalViewSelect = container.querySelector('[data-automation-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
-    internalViewSelect.value = 'view_grid'
-    internalViewSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const internalViewSelect = container.querySelector('[data-automation-field="dingtalkPersonInternalViewId"]') as HTMLElement
+    epSetSelect(internalViewSelect, 'view_grid')
     await flushPromises()
 
     const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
@@ -1725,9 +1680,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk dynamic notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -1777,9 +1731,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk dynamic member-group notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -1829,9 +1782,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk invalid dynamic recipients'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -1873,9 +1825,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk invalid static recipients'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -1913,9 +1864,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -1941,9 +1891,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -1963,9 +1912,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -1985,14 +1933,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'watcherGroupIds'
-    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'watcherGroupIds')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -2010,13 +1956,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLSelectElement
-    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLElement
+    const optionValues = epOptions(fieldSelect).map((option) => option.value)
     expect(optionValues).toContain('watcherGroupIds')
     expect(optionValues).toContain('escalationGroupId')
     expect(optionValues).not.toContain('assigneeUserIds')
@@ -2032,14 +1977,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'assigneeUserIds'
-    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'assigneeUserIds')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -2057,13 +2000,12 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
-    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLElement
+    const optionValues = epOptions(fieldSelect).map((option) => option.value)
     expect(optionValues).toContain('assigneeUserIds')
     expect(optionValues).toContain('reviewerUserId')
     expect(optionValues).not.toContain('fld_1')
@@ -2082,17 +2024,14 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk multi dynamic notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'assigneeUserIds'
-    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'assigneeUserIds')
     await flushPromises()
-    fieldSelect.value = 'reviewerUserId'
-    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    epSetSelect(fieldSelect, 'reviewerUserId')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -2131,17 +2070,14 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'assigneeUserIds'
-    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const fieldSelect = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'assigneeUserIds')
     await flushPromises()
-    fieldSelect.value = 'reviewerUserId'
-    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    epSetSelect(fieldSelect, 'reviewerUserId')
     await flushPromises()
 
     const firstChip = container.querySelector('[data-automation-recipient-field="assigneeUserIds"]') as HTMLButtonElement
@@ -2167,9 +2103,8 @@ describe('MetaAutomationManager', () => {
     nameInput.value = 'DingTalk search notify'
     nameInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const searchInput = container.querySelector('[data-automation-field="dingtalkPersonUserSearch"]') as HTMLInputElement
@@ -2271,9 +2206,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const searchInput = container.querySelector('[data-automation-field="dingtalkPersonUserSearch"]') as HTMLInputElement
@@ -2340,7 +2274,7 @@ describe('MetaAutomationManager', () => {
 
     const statusFilter = document.querySelector('.meta-person-delivery [data-field="statusFilter"]') as HTMLSelectElement
     statusFilter.value = 'skipped'
-    statusFilter.dispatchEvent(new Event('change'))
+    statusFilter.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
     expect(document.querySelector('[data-person-delivery-id="dpd_1"]')).toBeNull()
@@ -2744,9 +2678,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const presetBtn = container.querySelector('[data-automation-preset="group-form"]') as HTMLButtonElement
@@ -2755,13 +2688,13 @@ describe('MetaAutomationManager', () => {
 
     const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
     const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
-    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
-    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLSelectElement
+    const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLElement
+    const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLElement
 
     expect(titleInput.value).toBe('{{recordId}} needs input')
     expect(bodyInput.value).toContain('Please complete this form request')
-    expect(publicFormSelect.value).toBe('view_form')
-    expect(internalViewSelect.value).toBe('')
+    expect(epSelectValue(publicFormSelect)).toBe('view_form')
+    expect(epSelectValue(internalViewSelect)).toBe('')
   })
 
   it('applies DingTalk person presets in the inline create form', async () => {
@@ -2773,9 +2706,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-automation-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -2788,14 +2720,14 @@ describe('MetaAutomationManager', () => {
 
     const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
     const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
-    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    const internalViewSelect = container.querySelector('[data-automation-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    const internalViewSelect = container.querySelector('[data-automation-field="dingtalkPersonInternalViewId"]') as HTMLElement
 
     expect(userIdsInput.value).toBe('user_1')
     expect(titleInput.value).toBe('{{recordId}} needs input and processing')
     expect(bodyInput.value).toContain('Please complete the required form input')
-    expect(publicFormSelect.value).toBe('view_form')
-    expect(internalViewSelect.value).toBe('view_grid')
+    expect(epSelectValue(publicFormSelect)).toBe('view_form')
+    expect(epSelectValue(internalViewSelect)).toBe('view_grid')
   })
 
   it('inserts DingTalk template tokens in the inline create form', async () => {
@@ -2807,9 +2739,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     ;(container.querySelector('[data-automation-token="person-title-recordId"]') as HTMLButtonElement).click()
@@ -2831,9 +2762,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -2852,9 +2782,8 @@ describe('MetaAutomationManager', () => {
     bodyInput.value = 'Handle {{record.xxx}}'
     bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const publicFormSelect = container.querySelector('[data-automation-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     const summary = container.querySelector('[data-automation-summary="person"]')
@@ -2939,8 +2868,8 @@ describe('MetaAutomationManager', () => {
     editBtn.click()
     await flushPromises()
 
-    const actionSelect = document.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    expect(actionSelect.value).toBe('send_dingtalk_group_message')
+    const actionSelect = document.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    expect(epSelectValue(actionSelect)).toBe('send_dingtalk_group_message')
     expect(document.querySelector('[data-group-destination="dt_1"]')?.textContent).toContain('Ops Group')
     expect(document.querySelector('[data-group-destination="dt_2"]')?.textContent).toContain('Escalation Group')
     expect((document.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
@@ -2975,9 +2904,9 @@ describe('MetaAutomationManager', () => {
     editBtn.click()
     await flushPromises()
 
-    const actionSelect = document.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    const actionSelect = document.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
     const recipientFieldInput = document.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
-    expect(actionSelect.value).toBe('send_dingtalk_person_message')
+    expect(epSelectValue(actionSelect)).toBe('send_dingtalk_person_message')
     expect(recipientFieldInput.value).toBe('record.assigneeUserIds')
     expect((document.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
     expect((document.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please fill {{record.status}}')
@@ -3022,9 +2951,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
@@ -3044,9 +2972,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
@@ -3066,9 +2993,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -3088,9 +3014,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -3110,9 +3035,8 @@ describe('MetaAutomationManager', () => {
     addBtn.click()
     await nextTick()
 
-    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -379,7 +379,9 @@ describe('MetaAutomationManager', () => {
     ])
     expect(actionSelect.textContent).toContain('发送通知')
     expect((container.querySelector('[data-automation-field="notifyMessage"]') as HTMLInputElement).placeholder).toBe('通知内容')
-    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    // UF-4 shape adaptation: el-drawer's built-in close button carries a localized aria-label by
+    // design; the guard below still asserts the AUTHORED surface adds no aria-label noise.
+    expect(container.querySelectorAll('[aria-label]:not(.el-drawer__close-btn)')).toHaveLength(0)
     expect(container.querySelectorAll('[title]')).toHaveLength(0)
     expect(container.querySelectorAll('[placeholder]')).toHaveLength(2)
 
@@ -483,7 +485,9 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('消息摘要')
     expect(summary?.textContent).toContain('渲染正文')
     expect(summary?.textContent).toContain('处理 示例字段值')
-    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    // UF-4 shape adaptation: el-drawer's built-in close button carries a localized aria-label by
+    // design; the guard below still asserts the AUTHORED surface adds no aria-label noise.
+    expect(container.querySelectorAll('[aria-label]:not(.el-drawer__close-btn)')).toHaveLength(0)
     expect(container.querySelectorAll('[title]')).toHaveLength(0)
     expect(container.querySelectorAll('[placeholder]')).toHaveLength(8)
   })
@@ -769,7 +773,7 @@ describe('MetaAutomationManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-automation-rule="rule_new"]')?.textContent).toContain('Advanced DingTalk group')
     expect(container.querySelector('[data-automation-rule="rule_new"] .meta-automation__card-desc')?.textContent).toContain('Send DingTalk group message')
-    expect(container.querySelector('.meta-rule-editor__overlay')).toBeNull()
+    expect(container.querySelector('.meta-rule-editor')).toBeNull()
   })
 
   it('creates DingTalk person automation via the advanced rule editor', async () => {
@@ -866,7 +870,7 @@ describe('MetaAutomationManager', () => {
     expect(updatedSpy).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-automation-rule="rule_new"]')?.textContent).toContain('Advanced DingTalk person')
     expect(container.querySelector('[data-automation-rule="rule_new"] .meta-automation__card-desc')?.textContent).toContain('Send DingTalk person message')
-    expect(container.querySelector('.meta-rule-editor__overlay')).toBeNull()
+    expect(container.querySelector('.meta-rule-editor')).toBeNull()
   })
 
   it('creates rule via form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -243,8 +243,9 @@ describe('MetaAutomationRuleEditor', () => {
     expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('unsaved changes'))
     expect(onClose).not.toHaveBeenCalled()
 
-    // the × close path is guarded too
-    const xBtn = container.querySelector('.meta-rule-editor__close') as HTMLButtonElement
+    // the × close path is guarded too (UF-4 shape adaptation: the hand-rolled × is now
+    // el-drawer's built-in close button, routed through the same requestClose guard)
+    const xBtn = container.querySelector('.el-drawer__close-btn') as HTMLButtonElement
     xBtn.click()
     await flushPromises()
     expect(onClose).not.toHaveBeenCalled()
@@ -576,7 +577,9 @@ describe('MetaAutomationRuleEditor', () => {
     expect(summary?.textContent).toContain('消息摘要')
     expect(summary?.textContent).toContain('渲染正文')
     expect(summary?.textContent).toContain('处理 示例字段值')
-    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    // UF-4 shape adaptation: el-drawer's built-in close button carries a localized aria-label by
+    // design; the guard below still asserts the AUTHORED surface adds no aria-label noise.
+    expect(container.querySelectorAll('[aria-label]:not(.el-drawer__close-btn)')).toHaveLength(0)
     expect(container.querySelectorAll('[title]')).toHaveLength(1)
     expect(container.querySelectorAll('[placeholder]')).toHaveLength(4)
   })
@@ -586,7 +589,9 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    // UF-4 shape adaptation: el-drawer's built-in close button carries a localized aria-label by
+    // design; the guard below still asserts the AUTHORED surface adds no aria-label noise.
+    expect(container.querySelectorAll('[aria-label]:not(.el-drawer__close-btn)')).toHaveLength(0)
     expect(container.querySelectorAll('[title]')).toHaveLength(1)
     expect(container.querySelectorAll('[placeholder]')).toHaveLength(1)
   })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -9,6 +9,7 @@ import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomatio
 import { automationTriggerTypeLabel } from '../src/multitable/utils/meta-automation-labels'
 import { useLocale } from '../src/composables/useLocale'
 import type { AutomationRule, ConditionGroup } from '../src/multitable/types'
+import { epOptions, epSelectValue, epSelectValues, epSetSelect } from './helpers/epControls'
 
 const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
@@ -260,9 +261,8 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    triggerSelect.value = 'approval.task_created'
-    triggerSelect.dispatchEvent(new Event('change'))
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    epSetSelect(triggerSelect, 'approval.task_created')
     await flushPromises()
 
     // templateId input rendered (text fallback without loaded templates) + block reason asks for a template
@@ -282,14 +282,14 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
     expect(triggerSelect).toBeTruthy()
     // record.created/updated/deleted + field.value_changed + form.submitted + schedule.cron/interval/date_field
     // + webhook.received (selectable since the signed inbound endpoint shipped, T1-2 #3489)
     // + approval.completed (T1-3 #3467 template-routed trigger)
     // + approval.task_created (A-2a one-tap lock #3594 pending-task trigger).
-    expect(triggerSelect.options.length).toBe(11)
-    const triggerValues = Array.from(triggerSelect.options).map((option) => option.value)
+    expect(epOptions(triggerSelect).length).toBe(11)
+    const triggerValues = epOptions(triggerSelect).map((option) => option.value)
     expect(triggerValues).toContain('webhook.received')
     expect(triggerValues).toContain('approval.completed')
     expect(triggerValues).toContain('approval.task_created')
@@ -300,7 +300,9 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    const text = container.textContent ?? ''
+    // UF-4 shape adaptation: el-select option labels live in teleported dropdown lists,
+    // so the zh-CN sweep scans the document (the container's superset), not just the container.
+    const text = document.body.textContent ?? ''
     expect(text).toContain('新建自动化规则')
     expect(text).toContain('名称')
     expect(text).toContain('触发器')
@@ -314,19 +316,18 @@ describe('MetaAutomationRuleEditor', () => {
     const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
     expect(nameInput.placeholder).toBe('自动化名称')
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    expect(triggerSelect.options[0]?.value).toBe('record.created')
-    expect(triggerSelect.options[0]?.textContent?.trim()).toBe('当记录创建时')
-    expect(triggerSelect.options[3]?.value).toBe('field.value_changed')
-    expect(triggerSelect.options[3]?.textContent?.trim()).toBe('当字段值变化时')
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    expect(epOptions(triggerSelect)[0]?.value).toBe('record.created')
+    expect(epOptions(triggerSelect)[0]?.textContent?.trim()).toBe('当记录创建时')
+    expect(epOptions(triggerSelect)[3]?.value).toBe('field.value_changed')
+    expect(epOptions(triggerSelect)[3]?.textContent?.trim()).toBe('当字段值变化时')
 
-    triggerSelect.value = 'schedule.cron'
-    triggerSelect.dispatchEvent(new Event('change'))
+    epSetSelect(triggerSelect, 'schedule.cron')
     await flushPromises()
 
-    const cronSelect = container.querySelector('[data-field="cronPreset"]') as HTMLSelectElement
-    expect(cronSelect.options[0]?.value).toBe('*/5 * * * *')
-    expect(cronSelect.options[0]?.textContent?.trim()).toBe('每 5 分钟')
+    const cronSelect = container.querySelector('[data-field="cronPreset"]') as HTMLElement
+    expect(epOptions(cronSelect)[0]?.value).toBe('*/5 * * * *')
+    expect(epOptions(cronSelect)[0]?.textContent?.trim()).toBe('每 5 分钟')
   })
 
   it('localizes condition builder labels and placeholders without translating field options', async () => {
@@ -338,22 +339,20 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    expect(fieldSelect.options[0]?.textContent?.trim()).toBe('-- 字段 --')
-    expect(fieldSelect.options[1]?.textContent?.trim()).toBe('Status')
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    expect(epOptions(fieldSelect)[0]?.textContent?.trim()).toBe('-- 字段 --')
+    expect(epOptions(fieldSelect)[1]?.textContent?.trim()).toBe('Status')
 
-    fieldSelect.value = 'fld_score'
-    fieldSelect.dispatchEvent(new Event('change'))
+    epSetSelect(fieldSelect, 'fld_score')
     await flushPromises()
 
-    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
-    expect(operatorSelect.options[0]?.value).toBe('equals')
-    expect(operatorSelect.options[0]?.textContent?.trim()).toBe('等于')
-    operatorSelect.value = 'in'
-    operatorSelect.dispatchEvent(new Event('change'))
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('.el-select'))[1] as HTMLElement
+    expect(epOptions(operatorSelect)[0]?.value).toBe('equals')
+    expect(epOptions(operatorSelect)[0]?.textContent?.trim()).toBe('等于')
+    epSetSelect(operatorSelect, 'in')
     await flushPromises()
 
-    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    const valueInput = conditionRow.querySelector('.el-input__inner') as HTMLInputElement
     expect(valueInput.placeholder).toBe('逗号分隔的值')
   })
 
@@ -362,12 +361,11 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    expect(actionSelect.options[0]?.value).toBe('update_record')
-    expect(actionSelect.options[0]?.textContent?.trim()).toBe('更新记录')
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    expect(epOptions(actionSelect)[0]?.value).toBe('update_record')
+    expect(epOptions(actionSelect)[0]?.textContent?.trim()).toBe('更新记录')
 
-    actionSelect.value = 'send_email'
-    actionSelect.dispatchEvent(new Event('change'))
+    epSetSelect(actionSelect, 'send_email')
     await flushPromises()
 
     const text = container.textContent ?? ''
@@ -387,8 +385,8 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    const actionValues = Array.from(actionSelect.options).map((option) => option.value)
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    const actionValues = epOptions(actionSelect).map((option) => option.value)
     expect(actionValues).toContain('update_record')
     expect(actionValues).toContain('create_record')
     expect(actionValues).toContain('send_webhook')
@@ -399,7 +397,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(actionValues).toContain('wait_for_callback')
     // rank 8: lock_record is now a complete contract → re-exposed as a selectable, enabled action.
     expect(actionValues).toContain('lock_record')
-    const lockOption = Array.from(actionSelect.options).find((option) => option.value === 'lock_record')
+    const lockOption = epOptions(actionSelect).find((option) => option.value === 'lock_record')
     expect(lockOption?.disabled).toBe(false)
   })
 
@@ -411,13 +409,12 @@ describe('MetaAutomationRuleEditor', () => {
     ;(container.querySelector('[data-field="name"]') as HTMLInputElement).value = 'Delete trigger record'
     ;(container.querySelector('[data-field="name"]') as HTMLInputElement).dispatchEvent(new Event('input'))
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    const deleteOption = Array.from(actionSelect.options).find((option) => option.value === 'delete_record')
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    const deleteOption = epOptions(actionSelect).find((option) => option.value === 'delete_record')
     expect(deleteOption).toBeTruthy()
     expect(deleteOption?.disabled).toBe(false)
 
-    actionSelect.value = 'delete_record'
-    actionSelect.dispatchEvent(new Event('change'))
+    epSetSelect(actionSelect, 'delete_record')
     await flushPromises()
 
     expect(container.querySelector('[data-action-config="delete_record"]')).toBeTruthy()
@@ -429,7 +426,7 @@ describe('MetaAutomationRuleEditor', () => {
     saveBtn.click()
     expect(saved).not.toHaveBeenCalled()
 
-    const ack = container.querySelector('[data-field="deleteRecordAck"]') as HTMLInputElement
+    const ack = container.querySelector('[data-field="deleteRecordAck"] input') as HTMLInputElement
     expect(ack.checked).toBe(false)
     ack.checked = true
     ack.dispatchEvent(new Event('change'))
@@ -458,9 +455,9 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    const ack = container.querySelector('[data-field="deleteRecordAck"]') as HTMLInputElement
-    expect(actionSelect.value).toBe('delete_record')
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    const ack = container.querySelector('[data-field="deleteRecordAck"] input') as HTMLInputElement
+    expect(epSelectValue(actionSelect)).toBe('delete_record')
     expect(ack.checked).toBe(true)
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
@@ -486,9 +483,9 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    const lockOption = Array.from(actionSelect.options).find((option) => option.value === 'lock_record')
-    expect(actionSelect.value).toBe('lock_record')
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    const lockOption = epOptions(actionSelect).find((option) => option.value === 'lock_record')
+    expect(epSelectValue(actionSelect)).toBe('lock_record')
     expect(lockOption).toBeTruthy()
     // rank 8: lock_record is a complete contract → the existing rule's option stays selectable & enabled
     // (previously hidden behind the #2278 stop-gap that disabled the then-broken action).
@@ -545,9 +542,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     expect(container.textContent).toContain('消息预设')
@@ -600,9 +596,8 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    triggerSelect.value = 'field.value_changed'
-    triggerSelect.dispatchEvent(new Event('change'))
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    epSetSelect(triggerSelect, 'field.value_changed')
     await flushPromises()
 
     const fieldSelect = container.querySelector('[data-field="triggerFieldId"]')
@@ -613,9 +608,8 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    triggerSelect.value = 'schedule.cron'
-    triggerSelect.dispatchEvent(new Event('change'))
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    epSetSelect(triggerSelect, 'schedule.cron')
     await flushPromises()
 
     const cronSelect = container.querySelector('[data-field="cronPreset"]')
@@ -626,9 +620,8 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    triggerSelect.value = 'schedule.date_field'
-    triggerSelect.dispatchEvent(new Event('change'))
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    epSetSelect(triggerSelect, 'schedule.date_field')
     await flushPromises()
 
     expect(container.querySelector('[data-field="dateFieldId"]')).toBeTruthy()
@@ -645,9 +638,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'On form submit'
     nameInput.dispatchEvent(new Event('input'))
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    triggerSelect.value = 'form.submitted'
-    triggerSelect.dispatchEvent(new Event('change'))
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    epSetSelect(triggerSelect, 'form.submitted')
     await flushPromises()
 
     // form.submitted is config-less — none of the type-specific config sub-forms render for it.
@@ -668,8 +660,8 @@ describe('MetaAutomationRuleEditor', () => {
     } as AutomationRule
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule })
     await flushPromises()
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    expect(triggerSelect.value).toBe('form.submitted')
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    expect(epSelectValue(triggerSelect)).toBe('form.submitted')
   })
 
   it('exposes start_approval as a selectable action with template + form-data mapping, and saves it', async () => {
@@ -679,9 +671,9 @@ describe('MetaAutomationRuleEditor', () => {
     const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
     nameInput.value = 'start approval'; nameInput.dispatchEvent(new Event('input'))
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    expect(Array.from(actionSelect.options).map((o) => o.value)).toContain('start_approval')
-    actionSelect.value = 'start_approval'; actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    expect(epOptions(actionSelect).map((o) => o.value)).toContain('start_approval')
+    epSetSelect(actionSelect, 'start_approval')
     await flushPromises()
 
     // No client injected → the template picker degrades to a free-text input (the rbac/empty fallback).
@@ -694,9 +686,9 @@ describe('MetaAutomationRuleEditor', () => {
     addBtn.click()
     await flushPromises()
     const keyInput = cfg.querySelector('[data-field="approvalMappingKey"]') as HTMLInputElement
-    const valSelect = cfg.querySelector('[data-field="approvalMappingValue"]') as HTMLSelectElement
+    const valSelect = cfg.querySelector('[data-field="approvalMappingValue"]') as HTMLElement
     keyInput.value = 'amount'; keyInput.dispatchEvent(new Event('input'))
-    valSelect.value = 'fld_2'; valSelect.dispatchEvent(new Event('change'))
+    epSetSelect(valSelect, 'fld_2')
     await flushPromises()
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
@@ -720,10 +712,10 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
     await flushPromises()
     // form.submitted trigger + start_approval action coexist; the mapping disassembled into an editable row.
-    expect((container.querySelector('[data-field="triggerType"]') as HTMLSelectElement).value).toBe('form.submitted')
+    expect(epSelectValue(container.querySelector('[data-field="triggerType"]'))).toBe('form.submitted')
     expect((container.querySelector('[data-field="approvalTemplateId"]') as HTMLInputElement).value).toBe('tmpl_9')
     expect((container.querySelector('[data-field="approvalMappingKey"]') as HTMLInputElement).value).toBe('amount')
-    expect((container.querySelector('[data-field="approvalMappingValue"]') as HTMLSelectElement).value).toBe('fld_2')
+    expect(epSelectValue(container.querySelector('[data-field="approvalMappingValue"]'))).toBe('fld_2')
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
     await flushPromises()
@@ -754,8 +746,8 @@ describe('MetaAutomationRuleEditor', () => {
   async function selectStartApproval(container: HTMLElement) {
     const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
     nameInput.value = 'start approval'; nameInput.dispatchEvent(new Event('input'))
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'start_approval'; actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'start_approval')
     await flushPromises()
     const tmpl = container.querySelector('[data-field="approvalTemplateId"]') as HTMLInputElement
     tmpl.value = 'tmpl_1'; tmpl.dispatchEvent(new Event('input'))
@@ -767,21 +759,21 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
     await selectStartApproval(container)
 
-    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLSelectElement
-    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLSelectElement
-    const completedSel = container.querySelector('[data-field="resultWritebackCompletedAtField"]') as HTMLSelectElement
+    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLElement
+    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLElement
+    const completedSel = container.querySelector('[data-field="resultWritebackCompletedAtField"]') as HTMLElement
     expect(statusSel).not.toBeNull()
     expect(approverSel).not.toBeNull()
     expect(completedSel).not.toBeNull()
 
     // status hint = string / longText / select → Status(select), Name(string), Priority(select); plus "(not written)".
-    const statusVals = Array.from(statusSel.options).map((o) => o.value)
+    const statusVals = epOptions(statusSel).map((o) => o.value)
     expect(statusVals).toContain('')
     expect(statusVals).toEqual(expect.arrayContaining(['fld_1', 'fld_2', 'fld_priority']))
     expect(statusVals).not.toContain('fld_score') // number is not a status-compatible hint
     // approver hint = string / longText → only Name(string).
-    expect(Array.from(approverSel.options).map((o) => o.value)).toEqual(expect.arrayContaining(['', 'fld_2']))
-    expect(Array.from(approverSel.options).map((o) => o.value)).not.toContain('fld_1')
+    expect(epOptions(approverSel).map((o) => o.value)).toEqual(expect.arrayContaining(['', 'fld_2']))
+    expect(epOptions(approverSel).map((o) => o.value)).not.toContain('fld_1')
   })
 
   it('W7: OMITS config.resultWriteback when no writeback picker is set (omit-when-empty, not an invalid {})', async () => {
@@ -800,10 +792,10 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
     await flushPromises()
     await selectStartApproval(container)
-    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLSelectElement
-    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLSelectElement
-    statusSel.value = 'fld_1'; statusSel.dispatchEvent(new Event('change'))
-    approverSel.value = 'fld_2'; approverSel.dispatchEvent(new Event('change'))
+    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLElement
+    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLElement
+    epSetSelect(statusSel, 'fld_1')
+    epSetSelect(approverSel, 'fld_2')
     await flushPromises()
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
     await flushPromises()
@@ -827,7 +819,7 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
     await flushPromises()
     // draftConfigFromAction backfilled the pickers from the loaded config.
-    expect((container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLSelectElement).value).toBe('fld_1')
+    expect(epSelectValue(container.querySelector('[data-field="resultWritebackStatusField"]'))).toBe('fld_1')
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
     await flushPromises()
     const cfg = saved.mock.calls[0][0].actions[0].config
@@ -859,14 +851,14 @@ describe('MetaAutomationRuleEditor', () => {
     // option → select.value falls back to '' → these go RED. (The save assertion below passes via Vue v-model
     // binding-persistence regardless of P2 — Vue never clears a bound value just because it left the options —
     // so the DOM is the genuine P2 regression lever; see the design-lock §3 P2 / §4 reconciliation.)
-    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLSelectElement
-    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLSelectElement
-    expect(statusSel.value).toBe('fld_score')
-    const statusOpt = Array.from(statusSel.options).find((o) => o.value === 'fld_score')
+    const statusSel = container.querySelector('[data-field="resultWritebackStatusField"]') as HTMLElement
+    const approverSel = container.querySelector('[data-field="resultWritebackApproverField"]') as HTMLElement
+    expect(epSelectValue(statusSel)).toBe('fld_score')
+    const statusOpt = epOptions(statusSel).find((o) => o.value === 'fld_score')
     expect(statusOpt).toBeTruthy()
-    expect(statusOpt?.getAttribute('data-marked')).toBe('true') // appended as the marked current-value option
-    expect(approverSel.value).toBe('fld_gone')
-    expect(Array.from(approverSel.options).some((o) => o.value === 'fld_gone')).toBe(true)
+    expect(statusOpt?.el.getAttribute('data-marked')).toBe('true') // appended as the marked current-value option
+    expect(epSelectValue(approverSel)).toBe('fld_gone')
+    expect(epOptions(approverSel).some((o) => o.value === 'fld_gone')).toBe(true)
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
     await flushPromises()
@@ -904,28 +896,25 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
 
-    fieldSelect.value = 'fld_2'
-    fieldSelect.dispatchEvent(new Event('change'))
+    epSetSelect(fieldSelect, 'fld_2')
     await flushPromises()
 
-    expect(Array.from(operatorSelect.options).map((option) => option.value)).toContain('contains')
-    expect(Array.from(operatorSelect.options).map((option) => option.value)).not.toContain('greater_than')
+    expect(epOptions(operatorSelect).map((option) => option.value)).toContain('contains')
+    expect(epOptions(operatorSelect).map((option) => option.value)).not.toContain('greater_than')
 
-    operatorSelect.value = 'contains'
-    operatorSelect.dispatchEvent(new Event('change'))
+    epSetSelect(operatorSelect, 'contains')
     await flushPromises()
-    expect(operatorSelect.value).toBe('contains')
+    expect(epSelectValue(operatorSelect)).toBe('contains')
 
-    fieldSelect.value = 'fld_score'
-    fieldSelect.dispatchEvent(new Event('change'))
+    epSetSelect(fieldSelect, 'fld_score')
     await flushPromises()
 
-    const numericOperatorValues = Array.from(operatorSelect.options).map((option) => option.value)
+    const numericOperatorValues = epOptions(operatorSelect).map((option) => option.value)
     expect(numericOperatorValues).toContain('greater_than')
     expect(numericOperatorValues).not.toContain('contains')
-    expect(operatorSelect.value).toBe('equals')
+    expect(epSelectValue(operatorSelect)).toBe('equals')
   })
 
   it('limits attachment field conditions to empty-state operators', async () => {
@@ -941,14 +930,13 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_files'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_files')
     await flushPromises()
 
-    expect(Array.from(operatorSelect.options).map((option) => option.value)).toEqual(['is_empty', 'is_not_empty'])
-    expect(operatorSelect.value).toBe('is_empty')
-    expect(conditionRow.querySelector('input')).toBeNull()
+    expect(epOptions(operatorSelect).map((option) => option.value)).toEqual(['is_empty', 'is_not_empty'])
+    expect(epSelectValue(operatorSelect)).toBe('is_empty')
+    expect(conditionRow.querySelector('.el-input__inner')).toBeNull()
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
     await flushPromises()
@@ -969,7 +957,7 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'job rule'
     nameInput.dispatchEvent(new Event('input'))
 
-    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    const toggle = container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement
     expect(toggle).not.toBeNull()
     expect(toggle.checked).toBe(false) // default off — existing rules unaffected
 
@@ -994,7 +982,7 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
     await flushPromises()
 
-    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    const toggle = container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement
     expect(toggle.checked).toBe(true) // draftFromRule reflected the saved opt-in
 
     toggle.checked = false
@@ -1017,20 +1005,19 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'wait rule'
     nameInput.dispatchEvent(new Event('input'))
 
-    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    const toggle = container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement
     expect(toggle.checked).toBe(false) // off by default
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    expect(Array.from(actionSelect.options).map((o) => o.value)).toContain('wait_for_callback')
-    actionSelect.value = 'wait_for_callback'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    expect(epOptions(actionSelect).map((o) => o.value)).toContain('wait_for_callback')
+    epSetSelect(actionSelect, 'wait_for_callback')
     await flushPromises()
 
     // Info-only: the hint renders and there are ZERO param inputs (no webhook-URL/timer/manual-task fields).
     const cfg = container.querySelector('[data-action-config="wait_for_callback"]') as HTMLElement
     expect(cfg).not.toBeNull()
     expect(container.querySelector('[data-field="wait-for-callback-hint"]')).not.toBeNull()
-    expect(cfg.querySelectorAll('input, textarea, select').length).toBe(0)
+    expect(cfg.querySelectorAll('input, textarea, .el-select').length).toBe(0)
 
     // BLOCKING FIX: selecting wait_for_callback auto-enables AND LOCKS workflow_job_v1 (can't turn it off
     // into the runtime-fail-closed state).
@@ -1056,7 +1043,7 @@ describe('MetaAutomationRuleEditor', () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
     await flushPromises()
 
-    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    const toggle = container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement
     expect(toggle.checked).toBe(true) // forced on
     expect(toggle.disabled).toBe(true) // locked
 
@@ -1080,12 +1067,11 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_score'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_score')
     await flushPromises()
 
-    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    const valueInput = conditionRow.querySelector('.el-input__inner') as HTMLInputElement
     expect(valueInput.type).toBe('number')
     valueInput.value = '42.5'
     valueInput.dispatchEvent(new Event('input'))
@@ -1114,17 +1100,15 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_score'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_score')
     await flushPromises()
 
-    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
-    operatorSelect.value = 'in'
-    operatorSelect.dispatchEvent(new Event('change'))
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('.el-select'))[1] as HTMLElement
+    epSetSelect(operatorSelect, 'in')
     await flushPromises()
 
-    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    const valueInput = conditionRow.querySelector('.el-input__inner') as HTMLInputElement
     expect(valueInput.type).toBe('text')
     expect(valueInput.placeholder).toBe('Comma-separated values')
     valueInput.value = '1, 2.5, -3'
@@ -1154,17 +1138,15 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_score'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_score')
     await flushPromises()
 
-    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
-    operatorSelect.value = 'not_in'
-    operatorSelect.dispatchEvent(new Event('change'))
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('.el-select'))[1] as HTMLElement
+    epSetSelect(operatorSelect, 'not_in')
     await flushPromises()
 
-    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    const valueInput = conditionRow.querySelector('.el-input__inner') as HTMLInputElement
     valueInput.value = '1, nope'
     valueInput.dispatchEvent(new Event('input'))
     await flushPromises()
@@ -1190,15 +1172,13 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_done'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_done')
     await flushPromises()
 
-    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean"]') as HTMLSelectElement
+    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean"]') as HTMLElement
     expect(valueSelect).toBeTruthy()
-    valueSelect.value = 'false'
-    valueSelect.dispatchEvent(new Event('change'))
+    epSetSelect(valueSelect, 'false')
     await flushPromises()
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
@@ -1224,22 +1204,22 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_done'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_done')
     await flushPromises()
 
-    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
-    operatorSelect.value = 'in'
-    operatorSelect.dispatchEvent(new Event('change'))
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('.el-select'))[1] as HTMLElement
+    epSetSelect(operatorSelect, 'in')
     await flushPromises()
 
-    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean-multi-select"]') as HTMLSelectElement
-    expect(valueSelect.multiple).toBe(true)
-    valueSelect.options[0].selected = true
-    valueSelect.options[1].selected = true
-    valueSelect.dispatchEvent(new Event('change'))
+    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean-multi-select"]') as HTMLElement
+    // UF-4 shape adaptation: toggle the multi-select's options by clicking them (el-select
+    // multiple), instead of flipping native option.selected + dispatching change.
+    epSetSelect(valueSelect, epOptions(valueSelect)[0].value)
     await flushPromises()
+    epSetSelect(valueSelect, epOptions(valueSelect)[1].value)
+    await flushPromises()
+    expect(epSelectValues(valueSelect)).toHaveLength(2)
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
     await flushPromises()
@@ -1264,18 +1244,18 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_done'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_done')
     await flushPromises()
 
-    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
-    operatorSelect.value = 'not_in'
-    operatorSelect.dispatchEvent(new Event('change'))
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('.el-select'))[1] as HTMLElement
+    epSetSelect(operatorSelect, 'not_in')
     await flushPromises()
 
-    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean-multi-select"]') as HTMLSelectElement
-    expect(valueSelect.multiple).toBe(true)
+    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean-multi-select"]') as HTMLElement
+    // UF-4 shape adaptation: `multiple` is a native-select property; assert the el-select
+    // renders with no selected values instead (the empty state under test).
+    expect(epSelectValues(valueSelect)).toHaveLength(0)
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
     expect(saveBtn.disabled).toBe(true)
@@ -1298,15 +1278,13 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_priority'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_priority')
     await flushPromises()
 
-    const valueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLSelectElement
-    expect(Array.from(valueSelect.options).map((option) => option.textContent)).toEqual(['-- value --', 'Low', 'High'])
-    valueSelect.value = 'high'
-    valueSelect.dispatchEvent(new Event('change'))
+    const valueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLElement
+    expect(epOptions(valueSelect).map((option) => option.textContent)).toEqual(['-- value --', 'Low', 'High'])
+    epSetSelect(valueSelect, 'high')
     await flushPromises()
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
@@ -1349,28 +1327,24 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_priority'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_priority')
     await flushPromises()
 
-    const priorityValueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLSelectElement
-    priorityValueSelect.value = 'high'
-    priorityValueSelect.dispatchEvent(new Event('change'))
+    const priorityValueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLElement
+    epSetSelect(priorityValueSelect, 'high')
     await flushPromises()
     expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(false)
 
-    fieldSelect.value = 'fld_stage'
-    fieldSelect.dispatchEvent(new Event('change'))
+    epSetSelect(fieldSelect, 'fld_stage')
     await flushPromises()
 
-    const stageValueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLSelectElement
-    expect(operatorSelect.value).toBe('equals')
-    expect(stageValueSelect.value).toBe('')
+    const stageValueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLElement
+    expect(epSelectValue(operatorSelect)).toBe('equals')
+    expect(epSelectValue(stageValueSelect)).toBe('')
     expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
 
-    stageValueSelect.value = 'todo'
-    stageValueSelect.dispatchEvent(new Event('change'))
+    epSetSelect(stageValueSelect, 'todo')
     await flushPromises()
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
@@ -1396,20 +1370,19 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_tags'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_tags')
     await flushPromises()
 
-    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
-    operatorSelect.value = 'in'
-    operatorSelect.dispatchEvent(new Event('change'))
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('.el-select'))[1] as HTMLElement
+    epSetSelect(operatorSelect, 'in')
     await flushPromises()
 
-    const valueSelect = conditionRow.querySelector('[data-condition-value="multi-select"]') as HTMLSelectElement
-    valueSelect.options[0].selected = true
-    valueSelect.options[1].selected = true
-    valueSelect.dispatchEvent(new Event('change'))
+    const valueSelect = conditionRow.querySelector('[data-condition-value="multi-select"]') as HTMLElement
+    // UF-4 shape adaptation: toggle the multi-select's options by clicking them (el-select multiple).
+    epSetSelect(valueSelect, epOptions(valueSelect)[0].value)
+    await flushPromises()
+    epSetSelect(valueSelect, epOptions(valueSelect)[1].value)
     await flushPromises()
 
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
@@ -1435,12 +1408,11 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_due'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_due')
     await flushPromises()
 
-    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    const valueInput = conditionRow.querySelector('.el-input__inner') as HTMLInputElement
     expect(valueInput.type).toBe('date')
     valueInput.value = '2026-05-11'
     valueInput.dispatchEvent(new Event('input'))
@@ -1474,20 +1446,18 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    fieldSelect.value = 'fld_1'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(fieldSelect, 'fld_1')
     await flushPromises()
 
-    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
-    operatorSelect.value = 'in'
-    operatorSelect.dispatchEvent(new Event('change'))
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('.el-select'))[1] as HTMLElement
+    epSetSelect(operatorSelect, 'in')
     await flushPromises()
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
     expect(saveBtn.disabled).toBe(true)
 
-    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    const valueInput = conditionRow.querySelector('.el-input__inner') as HTMLInputElement
     valueInput.value = 'Ready, Blocked'
     valueInput.dispatchEvent(new Event('input'))
     await flushPromises()
@@ -1532,7 +1502,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.querySelector('[data-condition-group-path="1"]')).toBeTruthy()
 
     const nestedNameRow = container.querySelector('[data-condition-path="1-0"]') as HTMLElement
-    const nestedValueInput = nestedNameRow.querySelector('input') as HTMLInputElement
+    const nestedValueInput = nestedNameRow.querySelector('.el-input__inner') as HTMLInputElement
     nestedValueInput.value = 'Enterprise'
     nestedValueInput.dispatchEvent(new Event('input'))
     await flushPromises()
@@ -1574,11 +1544,10 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const rootConditionRow = container.querySelector('[data-condition-path="0"]') as HTMLElement
-    const rootSelects = Array.from(rootConditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    rootSelects[0].value = 'fld_1'
-    rootSelects[0].dispatchEvent(new Event('change'))
+    const rootSelects = Array.from(rootConditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(rootSelects[0], 'fld_1')
     await flushPromises()
-    const rootValueInput = rootConditionRow.querySelector('input') as HTMLInputElement
+    const rootValueInput = rootConditionRow.querySelector('.el-input__inner') as HTMLInputElement
     rootValueInput.value = 'Ready'
     rootValueInput.dispatchEvent(new Event('input'))
 
@@ -1591,14 +1560,12 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const nestedConditionRow = container.querySelector('[data-condition-path="1-0"]') as HTMLElement
-    const nestedSelects = Array.from(nestedConditionRow.querySelectorAll('select')) as HTMLSelectElement[]
-    nestedSelects[0].value = 'fld_2'
-    nestedSelects[0].dispatchEvent(new Event('change'))
+    const nestedSelects = Array.from(nestedConditionRow.querySelectorAll('.el-select')) as HTMLElement[]
+    epSetSelect(nestedSelects[0], 'fld_2')
     await flushPromises()
-    nestedSelects[1].value = 'contains'
-    nestedSelects[1].dispatchEvent(new Event('change'))
+    epSetSelect(nestedSelects[1], 'contains')
     await flushPromises()
-    const nestedValueInput = nestedConditionRow.querySelector('input') as HTMLInputElement
+    const nestedValueInput = nestedConditionRow.querySelector('.el-input__inner') as HTMLInputElement
     nestedValueInput.value = 'VIP'
     nestedValueInput.dispatchEvent(new Event('input'))
     await flushPromises()
@@ -1832,9 +1799,11 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'notify'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    // UF-4 shape adaptation: the native test assigned .value = 'notify', which is not one of the
+    // selectable options (the assignment blanked the select); with el-select we change the draft
+    // action through a real option — any non-DingTalk type exercises the same guard.
+    epSetSelect(actionSelect, 'send_notification')
     await flushPromises()
 
     ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
@@ -1926,8 +1895,8 @@ describe('MetaAutomationRuleEditor', () => {
     const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
     expect(nameInput.value).toBe('Existing')
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    expect(triggerSelect.value).toBe('record.updated')
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    expect(epSelectValue(triggerSelect)).toBe('record.updated')
   })
 
   it('emits normalized send_email action payload', async () => {
@@ -1944,9 +1913,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'Email owner'
     nameInput.dispatchEvent(new Event('input'))
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_email'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_email')
     await flushPromises()
 
     const recipientsInput = container.querySelector('[data-field="emailRecipients"]') as HTMLTextAreaElement
@@ -1999,9 +1967,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'Wait then update'
     nameInput.dispatchEvent(new Event('input'))
 
-    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    firstActionSelect.value = 'wait_for_callback'
-    firstActionSelect.dispatchEvent(new Event('change'))
+    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(firstActionSelect, 'wait_for_callback')
     await flushPromises()
 
     ;(container.querySelector('[data-action="add-action"]') as HTMLButtonElement).click()
@@ -2011,10 +1978,9 @@ describe('MetaAutomationRuleEditor', () => {
     ;(followUpRow.querySelector('.meta-rule-editor__action-config .meta-rule-editor__btn') as HTMLButtonElement).click()
     await flushPromises()
 
-    const fieldSelect = followUpRow.querySelector('.meta-rule-editor__field-pair select') as HTMLSelectElement
-    fieldSelect.value = 'fld_1'
-    fieldSelect.dispatchEvent(new Event('change'))
-    const valueInput = followUpRow.querySelector('.meta-rule-editor__field-pair input') as HTMLInputElement
+    const fieldSelect = followUpRow.querySelector('.meta-rule-editor__field-pair .el-select') as HTMLElement
+    epSetSelect(fieldSelect, 'fld_1')
+    const valueInput = followUpRow.querySelector('.meta-rule-editor__field-pair .el-input__inner') as HTMLInputElement
     valueInput.value = 'Done'
     valueInput.dispatchEvent(new Event('input'))
     await flushPromises()
@@ -2049,21 +2015,19 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'Wait then create'
     nameInput.dispatchEvent(new Event('input'))
 
-    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    firstActionSelect.value = 'wait_for_callback'
-    firstActionSelect.dispatchEvent(new Event('change'))
+    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(firstActionSelect, 'wait_for_callback')
     await flushPromises()
 
     ;(container.querySelector('[data-action="add-action"]') as HTMLButtonElement).click()
     await flushPromises()
 
     const followUpRow = container.querySelector('[data-action-index="1"]') as HTMLElement
-    const followUpSelect = followUpRow.querySelector('.meta-rule-editor__action-header select') as HTMLSelectElement
-    followUpSelect.value = 'create_record'
-    followUpSelect.dispatchEvent(new Event('change'))
+    const followUpSelect = followUpRow.querySelector('.meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(followUpSelect, 'create_record')
     await flushPromises()
 
-    const targetSheetInput = followUpRow.querySelector('.meta-rule-editor__action-config > input') as HTMLInputElement
+    const targetSheetInput = followUpRow.querySelector('.meta-rule-editor__action-config .el-input__inner') as HTMLInputElement
     targetSheetInput.value = 'sheet_target'
     targetSheetInput.dispatchEvent(new Event('input'))
     ;(followUpRow.querySelector('.meta-rule-editor__action-config .meta-rule-editor__btn') as HTMLButtonElement).click()
@@ -2104,21 +2068,19 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'Wait then notify'
     nameInput.dispatchEvent(new Event('input'))
 
-    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    firstActionSelect.value = 'wait_for_callback'
-    firstActionSelect.dispatchEvent(new Event('change'))
+    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(firstActionSelect, 'wait_for_callback')
     await flushPromises()
 
     ;(container.querySelector('[data-action="add-action"]') as HTMLButtonElement).click()
     await flushPromises()
 
     const followUpRow = container.querySelector('[data-action-index="1"]') as HTMLElement
-    const followUpSelect = followUpRow.querySelector('.meta-rule-editor__action-header select') as HTMLSelectElement
-    followUpSelect.value = 'send_notification'
-    followUpSelect.dispatchEvent(new Event('change'))
+    const followUpSelect = followUpRow.querySelector('.meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(followUpSelect, 'send_notification')
     await flushPromises()
 
-    const [userInput, messageInput] = Array.from(followUpRow.querySelectorAll('input, textarea')) as Array<HTMLInputElement | HTMLTextAreaElement>
+    const [userInput, messageInput] = Array.from(followUpRow.querySelectorAll('.el-input__inner, textarea')) as Array<HTMLInputElement | HTMLTextAreaElement>
     userInput.value = 'user_1, user_2'
     userInput.dispatchEvent(new Event('input'))
     messageInput.value = 'Resume completed'
@@ -2153,9 +2115,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'Email owner'
     nameInput.dispatchEvent(new Event('input'))
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_email'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_email')
     await flushPromises()
 
     const recipientsInput = container.querySelector('[data-field="emailRecipients"]') as HTMLTextAreaElement
@@ -2192,20 +2153,17 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const pickerHint = container.querySelector('[data-field="dingtalkDestinationPickerHint"]')
     expect(pickerHint?.textContent).toContain('registered for this table')
 
-    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
-    destinationSelect.value = 'dt_1'
-    destinationSelect.dispatchEvent(new Event('change'))
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLElement
+    epSetSelect(destinationSelect, 'dt_1')
     await flushPromises()
-    destinationSelect.value = 'dt_2'
-    destinationSelect.dispatchEvent(new Event('change'))
+    epSetSelect(destinationSelect, 'dt_2')
 
     const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -2215,13 +2173,11 @@ describe('MetaAutomationRuleEditor', () => {
     bodyInput.value = 'Please review {{record.status}}'
     bodyInput.dispatchEvent(new Event('input'))
 
-    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
 
-    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLSelectElement
-    internalViewSelect.value = 'view_grid'
-    internalViewSelect.dispatchEvent(new Event('change'))
+    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLElement
+    epSetSelect(internalViewSelect, 'view_grid')
     await flushPromises()
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
@@ -2287,15 +2243,13 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
-    expect(destinationSelect.textContent).toContain('Organization catalog')
-    destinationSelect.value = 'dt_org'
-    destinationSelect.dispatchEvent(new Event('change'))
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLElement
+    expect(epOptions(destinationSelect).map((option) => option.textContent).join('\n')).toContain('Organization catalog')
+    epSetSelect(destinationSelect, 'dt_org')
     await flushPromises()
 
     const chip = container.querySelector('[data-group-destination="dt_org"]') as HTMLElement
@@ -2344,9 +2298,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const emptyState = container.querySelector('[data-field="dingtalkDestinationEmpty"]')
@@ -2413,8 +2366,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    expect(actionSelect.value).toBe('send_dingtalk_group_message')
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    expect(epSelectValue(actionSelect)).toBe('send_dingtalk_group_message')
     expect(container.querySelector('[data-group-destination="dt_1"]')?.textContent).toContain('Ops Group')
     expect(container.querySelector('[data-group-destination="dt_2"]')?.textContent).toContain('Escalation Group')
     expect((container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
@@ -2460,9 +2413,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const fieldPathHint = container.querySelector('[data-field="dingtalkDestinationFieldPathHint"]')
@@ -2517,9 +2469,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const destinationFieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
@@ -2554,14 +2505,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-field="dingtalkDestinationFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'fld_2'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const fieldSelect = container.querySelector('[data-field="dingtalkDestinationFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'fld_2')
     await flushPromises()
 
     const fieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
@@ -2582,9 +2531,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const fieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
@@ -2607,14 +2555,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing is disabled for "Public Form"')
@@ -2641,14 +2587,12 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'Notify DingTalk'
     nameInput.dispatchEvent(new Event('input'))
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
-    destinationSelect.value = 'dt_1'
-    destinationSelect.dispatchEvent(new Event('change'))
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLElement
+    epSetSelect(destinationSelect, 'dt_1')
 
     const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -2658,9 +2602,8 @@ describe('MetaAutomationRuleEditor', () => {
     bodyInput.value = 'Please review {{record.status}}'
     bodyInput.dispatchEvent(new Event('input'))
 
-    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
@@ -2682,14 +2625,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
@@ -2716,14 +2657,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
@@ -2745,14 +2684,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).not.toContain('allows all bound DingTalk users to submit')
@@ -2812,14 +2749,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.querySelector('[data-field="personPublicFormAccessSummary-0"]')?.textContent)
@@ -2845,14 +2780,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" is fully public')
@@ -2874,14 +2807,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     expect(container.textContent).toContain('Public form sharing for "Public Form" allows all bound DingTalk users to submit')
@@ -2910,9 +2841,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -2927,13 +2857,11 @@ describe('MetaAutomationRuleEditor', () => {
     bodyInput.value = 'Please review {{record.status}}'
     bodyInput.dispatchEvent(new Event('input'))
 
-    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
 
-    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
-    internalViewSelect.value = 'view_grid'
-    internalViewSelect.dispatchEvent(new Event('change'))
+    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLElement
+    epSetSelect(internalViewSelect, 'view_grid')
     await flushPromises()
 
     expect(container.querySelector('[data-field="personMessageSummary"]')?.textContent).toContain('Fully public; anyone with the link can submit')
@@ -3016,9 +2944,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.value = 'Notify People'
     nameInput.dispatchEvent(new Event('input'))
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -3033,9 +2960,8 @@ describe('MetaAutomationRuleEditor', () => {
     bodyInput.value = 'Please review {{record.status}}'
     bodyInput.dispatchEvent(new Event('input'))
 
-    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    publicFormSelect.value = 'view_form'
-    publicFormSelect.dispatchEvent(new Event('change'))
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    epSetSelect(publicFormSelect, 'view_form')
     await flushPromises()
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
@@ -3100,9 +3026,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -3164,9 +3089,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -3212,9 +3136,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -3272,8 +3195,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    expect(actionSelect.value).toBe('send_dingtalk_person_message')
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    expect(epSelectValue(actionSelect)).toBe('send_dingtalk_person_message')
     expect((container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement).value).toBe('record.assigneeUserIds')
     expect((container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement).value).toBe('Ticket {{recordId}}')
     expect((container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement).value).toBe('Please review {{record.status}}')
@@ -3320,9 +3243,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -3367,9 +3289,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -3397,9 +3318,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -3421,9 +3341,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -3445,14 +3364,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'watcherGroupIds'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'watcherGroupIds')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -3471,13 +3388,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLSelectElement
-    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldSelect"]') as HTMLElement
+    const optionValues = epOptions(fieldSelect).map((option) => option.value)
     expect(optionValues).toContain('watcherGroupIds')
     expect(optionValues).toContain('escalationGroupId')
     expect(optionValues).not.toContain('assigneeUserIds')
@@ -3495,14 +3411,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'assigneeUserIds'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'assigneeUserIds')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -3521,13 +3435,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
-    const optionValues = Array.from(fieldSelect.options).map((option) => option.value)
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLElement
+    const optionValues = epOptions(fieldSelect).map((option) => option.value)
     expect(optionValues).toContain('assigneeUserIds')
     expect(optionValues).toContain('reviewerUserId')
     expect(optionValues).not.toContain('fld_1')
@@ -3551,17 +3464,14 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'assigneeUserIds'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'assigneeUserIds')
     await flushPromises()
-    fieldSelect.value = 'reviewerUserId'
-    fieldSelect.dispatchEvent(new Event('change'))
+    epSetSelect(fieldSelect, 'reviewerUserId')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -3601,17 +3511,14 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
-    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLSelectElement
-    fieldSelect.value = 'assigneeUserIds'
-    fieldSelect.dispatchEvent(new Event('change'))
+    const fieldSelect = container.querySelector('[data-field="dingtalkPersonRecipientFieldSelect"]') as HTMLElement
+    epSetSelect(fieldSelect, 'assigneeUserIds')
     await flushPromises()
-    fieldSelect.value = 'reviewerUserId'
-    fieldSelect.dispatchEvent(new Event('change'))
+    epSetSelect(fieldSelect, 'reviewerUserId')
     await flushPromises()
 
     const firstChip = container.querySelector('[data-field-recipient="assigneeUserIds"]') as HTMLButtonElement
@@ -3642,9 +3549,8 @@ describe('MetaAutomationRuleEditor', () => {
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const searchInput = container.querySelector('[data-field="dingtalkPersonUserSearch"]') as HTMLInputElement
@@ -3749,9 +3655,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const searchInput = container.querySelector('[data-field="dingtalkPersonUserSearch"]') as HTMLInputElement
@@ -3798,9 +3703,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const presetBtn = container.querySelector('[data-field="groupPresetBoth"]') as HTMLButtonElement
@@ -3809,13 +3713,13 @@ describe('MetaAutomationRuleEditor', () => {
 
     const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
     const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
-    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
-    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLSelectElement
+    const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLElement
+    const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLElement
 
     expect(titleInput.value).toBe('{{recordId}} needs input and processing')
     expect(bodyInput.value).toContain('Please complete the required form input')
-    expect(publicFormSelect.value).toBe('view_form')
-    expect(internalViewSelect.value).toBe('view_grid')
+    expect(epSelectValue(publicFormSelect)).toBe('view_form')
+    expect(epSelectValue(internalViewSelect)).toBe('view_grid')
   })
 
   it('applies DingTalk person message presets without touching recipients', async () => {
@@ -3829,9 +3733,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const userIdsInput = container.querySelector('[data-field="dingtalkPersonUserIds"]') as HTMLTextAreaElement
@@ -3844,14 +3747,14 @@ describe('MetaAutomationRuleEditor', () => {
 
     const titleInput = container.querySelector('[data-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
     const bodyInput = container.querySelector('[data-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
-    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLSelectElement
-    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
+    const publicFormSelect = container.querySelector('[data-field="dingtalkPersonPublicFormViewId"]') as HTMLElement
+    const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLElement
 
     expect(userIdsInput.value).toBe('user_1')
     expect(titleInput.value).toBe('{{recordId}} needs processing')
     expect(bodyInput.value).toContain('Please review and process this record')
-    expect(publicFormSelect.value).toBe('')
-    expect(internalViewSelect.value).toBe('view_grid')
+    expect(epSelectValue(publicFormSelect)).toBe('')
+    expect(epSelectValue(internalViewSelect)).toBe('view_grid')
   })
 
   it('inserts DingTalk template tokens in the rule editor', async () => {
@@ -3865,9 +3768,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     ;(container.querySelector('[data-field="groupTitleToken-recordId"]') as HTMLButtonElement).click()
@@ -3891,14 +3793,12 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
-    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
-    destinationSelect.value = 'dt_1'
-    destinationSelect.dispatchEvent(new Event('change'))
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLElement
+    epSetSelect(destinationSelect, 'dt_1')
 
     const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
     titleInput.value = 'Ticket {{recordId}}'
@@ -3930,9 +3830,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
@@ -3954,9 +3853,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
@@ -3978,9 +3876,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const recipientFieldInput = container.querySelector('[data-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement
@@ -4002,9 +3899,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_person_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_person_message')
     await flushPromises()
 
     const memberGroupFieldInput = container.querySelector('[data-field="dingtalkPersonMemberGroupRecipientFieldPath"]') as HTMLInputElement
@@ -4026,9 +3922,8 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_dingtalk_group_message'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_dingtalk_group_message')
     await flushPromises()
 
     const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
@@ -4047,8 +3942,8 @@ describe('MetaAutomationRuleEditor', () => {
   it('exposes webhook.received and approval.completed as trigger options with localized labels', async () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    const values = Array.from(triggerSelect.options).map((option) => option.value)
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    const values = epOptions(triggerSelect).map((option) => option.value)
     expect(values).toContain('webhook.received')
     expect(values).toContain('approval.completed')
     expect(automationTriggerTypeLabel('approval.completed', false)).toBe('When approval completes')
@@ -4063,9 +3958,8 @@ describe('MetaAutomationRuleEditor', () => {
     ;(container.querySelector('[data-field="name"]') as HTMLInputElement).value = 'Notify on completion'
     ;(container.querySelector('[data-field="name"]') as HTMLInputElement).dispatchEvent(new Event('input'))
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    triggerSelect.value = 'approval.completed'
-    triggerSelect.dispatchEvent(new Event('change'))
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    epSetSelect(triggerSelect, 'approval.completed')
     await flushPromises()
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
@@ -4085,14 +3979,13 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.querySelector('[data-field="approvalCompletedBlockReason"]')?.textContent)
       .toContain('notification-family actions only')
 
-    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-    actionSelect.value = 'send_notification'
-    actionSelect.dispatchEvent(new Event('change'))
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'send_notification')
     await flushPromises()
 
     // Outcomes default to approved-only; add "rejected".
-    const approvedBox = container.querySelector('[data-field="approvalOutcome-approved"]') as HTMLInputElement
-    const rejectedBox = container.querySelector('[data-field="approvalOutcome-rejected"]') as HTMLInputElement
+    const approvedBox = container.querySelector('[data-field="approvalOutcome-approved"] input') as HTMLInputElement
+    const rejectedBox = container.querySelector('[data-field="approvalOutcome-rejected"] input') as HTMLInputElement
     expect(approvedBox.checked).toBe(true)
     expect(rejectedBox.checked).toBe(false)
     rejectedBox.click()
@@ -4116,9 +4009,8 @@ describe('MetaAutomationRuleEditor', () => {
     ;(container.querySelector('[data-field="name"]') as HTMLInputElement).value = 'Inbound hook'
     ;(container.querySelector('[data-field="name"]') as HTMLInputElement).dispatchEvent(new Event('input'))
 
-    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
-    triggerSelect.value = 'webhook.received'
-    triggerSelect.dispatchEvent(new Event('change'))
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLElement
+    epSetSelect(triggerSelect, 'webhook.received')
     await flushPromises()
 
     const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -251,9 +251,14 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
     expect(onClose).not.toHaveBeenCalled()
 
+    // Review P2 (UF-4): the confirm=true leg must go through the X button — i.e. through
+    // el-drawer's `before-close` — not the Cancel button (which calls requestClose directly).
+    // A bypassed `before-close` (e.g. `(done) => done()`) closes the drawer WITHOUT emitting
+    // close, so this exact assertion is what turns red under that mutation.
     confirmSpy.mockReturnValue(true)
-    cancelBtn.click()
+    xBtn.click()
     await flushPromises()
+    expect(confirmSpy).toHaveBeenCalledTimes(3)
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/web/tests/parallelBranchEditor.spec.ts
+++ b/apps/web/tests/parallelBranchEditor.spec.ts
@@ -4,6 +4,7 @@ import { createApp, h, nextTick } from 'vue'
 import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomationRuleEditor.vue'
 import { useLocale } from '../src/composables/useLocale'
 import type { AutomationRule } from '../src/multitable/types'
+import { epOptions, epSelectValue, epSelectValues, epSetSelect } from './helpers/epControls'
 
 function flush() {
   return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
@@ -29,9 +30,8 @@ function setInput(container: HTMLElement, selector: string, value: string) {
 }
 
 function selectAction0(container: HTMLElement, type: string) {
-  const select = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
-  select.value = type
-  select.dispatchEvent(new Event('change'))
+  const select = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+  epSetSelect(select, type)
 }
 
 function ruleWithParallel(config: Record<string, unknown>): AutomationRule {
@@ -62,7 +62,7 @@ describe('A6-3-4/W3-2a parallel_branch editor', () => {
     selectAction0(container, 'parallel_branch')
     await flush()
 
-    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    const toggle = container.querySelector('[data-field="executionModeToggle"] input') as HTMLInputElement
     expect(toggle.checked).toBe(true)
     expect(toggle.disabled).toBe(true)
     expect(container.querySelector('[data-action-config="parallel_branch"]')).not.toBeNull()
@@ -87,10 +87,9 @@ describe('A6-3-4/W3-2a parallel_branch editor', () => {
     ;(container.querySelector('[data-parallel-branch-index="0"] [data-action="add-parallel-branch-field"]') as HTMLButtonElement).click()
     await flush()
     const pair = container.querySelector('[data-parallel-branch-index="0"] .meta-rule-editor__field-pair') as HTMLElement
-    const pairField = pair.querySelector('select') as HTMLSelectElement
-    pairField.value = 'fld_1'
-    pairField.dispatchEvent(new Event('change'))
-    const pairValue = pair.querySelector('input') as HTMLInputElement
+    const pairField = pair.querySelector('.el-select') as HTMLElement
+    epSetSelect(pairField, 'fld_1')
+    const pairValue = pair.querySelector('.el-input__inner') as HTMLInputElement
     pairValue.value = 'done'
     pairValue.dispatchEvent(new Event('input'))
     await flush()
@@ -172,9 +171,9 @@ describe('A6-3-4/W3-2a parallel_branch editor', () => {
     await flush()
 
     const branchActionSelect = container.querySelector(
-      '[data-action-config="parallel_branch"] [data-parallel-branch-action-index="0"] select',
-    ) as HTMLSelectElement
-    const options = Array.from(branchActionSelect.options).map((o) => o.value)
+      '[data-action-config="parallel_branch"] [data-parallel-branch-action-index="0"] .el-select',
+    ) as HTMLElement
+    const options = epOptions(branchActionSelect).map((o) => o.value)
     expect(options).toContain('update_record')
     expect(options).toContain('send_notification')
     expect(options).not.toContain('wait_for_callback')


### PR DESCRIPTION
Implements **UF-4** of the UI foundation design-lock — the single largest source of the 'unpolished' impression per the audit: the automation surfaces were a hand-rolled parallel design system (stacked `position:fixed` overlays, native controls, alien palette).

## What (two commits)
- **UF-4a containers**: both overlays → `el-drawer` (nested editor drawer, in-place rendering so every spec query path survives; `v-if` semantics preserved — closed = absent). ALL close paths (X / backdrop / **Esc, newly standard**) route through the existing `requestClose` dirty-draft confirm guard via `:before-close`.
- **UF-4b controls + palette**: 51 native selects → `el-select` (option values/types preserved — payload-feeding options all strings, as before), inputs/textareas → `el-input`, checkboxes → `el-checkbox`, buttons → `el-button`; both style blocks fully tokenized (**remaining hardcoded hex = 0**); stale `--ms-color-danger` fallbacks dropped. Justified exception: bespoke card-shaped chip buttons stay native (converting = restyling EP internals, forbidden by lock §2).
- New spec helper `tests/helpers/epControls.ts` (drives teleported el-select dropdowns); ~270 spec call sites codemodded, all adaptations shape-only and listed in commit bodies.

## Adversarial review (Opus, refute-first): APPROVE
The **zero behavior/logic/payload change** claim was attacked and UPHELD: script diff = imports + 10 handler signatures only; `buildPayload`/`buildConditionValuePayload`/`canSave` byte-untouched; dirty-guard NOT bypassable via outer drawer/Esc (probed); payload types preserved (option-value type mutation → 3 tests RED). Review MD: `/tmp/uf4-review-claude-20260707.md`.
- **P2 fixed (last commit)**: the `before-close` guard was correct-but-unlocked (bypass mutation survived 195 greens) — the confirm=true leg now drives close through the X button; the bypass mutation now turns exactly that assertion RED (verified, reverted).
- P3 noted: `intervalMinutes` clear-to-empty emits `undefined` vs native `''` — reachable only on an already-invalid rule; accepted.

## Verification
- `vue-tsc -b` 0 · build green · automation specs **233/233** post-rebase (had 283/283 incl. sweep pre-rebase)
- Workbench sweep byte-identical to base (pre-existing failures proven by stash-rerun, not introduced)
- Esc-to-close on the manager is the one (standard, guard-routed) behavior addition — called out honestly

Implemented by a Fable 5 agent per model-split policy; adversarially reviewed + P2 hardened by the main loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)