### PR TITLE
feat(multitable): personal views Slice 3b — FE fieldOrder column consumer (fail-soft, G-FE-5)

### DIFF
--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -510,13 +510,34 @@ export function useMultitableGrid(opts: {
 
   // Field visibility
   const hiddenFieldIds = ref<string[]>([])
-  const visibleFields = computed(() =>
-    fields.value.filter((f) =>
+  // Slice 3b — per-view (incl. per-user personal overlay) column order. The server already resolves the
+  // effective order onto `view.fieldOrder` (applyPersonalViewOverlay); this is the FE CONSUMER that renders
+  // columns in that order. Empty ⇒ natural field order (server `field.order`), unchanged from before.
+  const fieldOrder = ref<string[]>([])
+  const visibleFields = computed(() => {
+    const base = fields.value.filter((f) =>
       !hiddenFieldIds.value.includes(f.id)
       && !isPropertyHiddenField(f)
       && fieldPermissions.value[f.id]?.visible !== false,
-    ),
-  )
+    )
+    if (fieldOrder.value.length === 0) return base
+    // Apply fieldOrder as a presentation reorder, FAIL-SOFT (G-FE-5): an id in fieldOrder that no longer
+    // maps to a currently-visible field (deleted, hidden, permission-denied, or an unknown/stale id — the
+    // backend only whitelists string[], it does not validate sheet membership) is simply skipped — no
+    // crash, no blank column. Visible fields NOT named in fieldOrder keep their natural order, appended
+    // after the ordered ones, so a partial/stale order never drops a real column.
+    const byId = new Map(base.map((f) => [f.id, f]))
+    const seen = new Set<string>()
+    const ordered: typeof base = []
+    for (const id of fieldOrder.value) {
+      const f = byId.get(id)
+      if (f && !seen.has(id)) { ordered.push(f); seen.add(id) }
+    }
+    for (const f of base) {
+      if (!seen.has(f.id)) ordered.push(f)
+    }
+    return ordered
+  })
   const readOnlyFieldIds = computed(() =>
     fields.value
       .filter((field) => fieldPermissions.value[field.id]?.readOnly === true)
@@ -736,7 +757,7 @@ export function useMultitableGrid(opts: {
     }
   }
 
-  function syncFromView(view: { filterInfo?: Record<string, unknown>; sortInfo?: Record<string, unknown>; hiddenFieldIds?: string[] }) {
+  function syncFromView(view: { filterInfo?: Record<string, unknown>; sortInfo?: Record<string, unknown>; hiddenFieldIds?: string[]; fieldOrder?: string[] }) {
     // Parse server sort
     if (view.sortInfo && Array.isArray((view.sortInfo as any).rules)) {
       sortRules.value = ((view.sortInfo as any).rules as any[]).map((r: any) => ({
@@ -756,6 +777,11 @@ export function useMultitableGrid(opts: {
       nestedFilterNodes.value = tree && tree.nodes.some(isFilterGroup) ? tree.nodes : null
     }
     if (view.hiddenFieldIds) hiddenFieldIds.value = [...view.hiddenFieldIds]
+    // Slice 3b: capture the effective (server-resolved, personal-overlay-applied) column order for this view.
+    // Only string ids are kept; membership is NOT validated here — visibleFields fail-softs stale/unknown ids.
+    fieldOrder.value = Array.isArray(view.fieldOrder)
+      ? view.fieldOrder.filter((id): id is string => typeof id === 'string')
+      : []
     // Dual-read for back-compat: prefer the NEW ordered groupInfo.fieldIds; fall back to the legacy
     // single groupInfo.fieldId so views persisted before nested grouping keep their (one) group level.
     const gi = (view as any).groupInfo as { fieldId?: unknown; fieldIds?: unknown } | undefined

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -79,10 +79,10 @@ export interface MetaView {
   // fallback (dual-read) for back-compat. Kanban/Gantt keep using `{ fieldId }` on their own views.
   groupInfo?: Record<string, unknown>
   hiddenFieldIds?: string[]
-  // Slice 2 (per-user field order): present only when the personal-views flag is on AND this actor has a
-  // fieldOrder override — the server already resolves/merges it (applyPersonalViewOverlay), so the FE never
-  // computes this itself. Absent otherwise (sheet-global order stands). No FE consumer renders this yet —
-  // see docs/development/multitable-personal-views-slice3-fe-verification-20260706.md for the follow-up.
+  // Slice 2/3b (per-view, incl. per-user personal overlay, column order): the server resolves/merges the
+  // effective order onto this field (applyPersonalViewOverlay) — the FE never computes the merge. Slice 3b's
+  // grid consumer (useMultitableGrid `visibleFields`) renders columns in this order, FAIL-SOFT on
+  // stale/unknown/hidden ids. Absent ⇒ natural field order (server `field.order`).
   fieldOrder?: string[]
   config?: Record<string, unknown>
 }

--- a/apps/web/tests/multitable-grid-fieldorder-consumer.spec.ts
+++ b/apps/web/tests/multitable-grid-fieldorder-consumer.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Slice 3b — the FE consumer of per-view (incl. per-user personal overlay) column order.
+ * `useMultitableGrid.visibleFields` renders columns in the effective `view.fieldOrder` (server-resolved via
+ * applyPersonalViewOverlay), FAIL-SOFT on stale/unknown/hidden ids.
+ *
+ * Design: docs/development/multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md (G-FE-5).
+ * G-FE-5: an unknown / missing / stale fieldOrder id must be ignored — no crash, no blank column, and no
+ * real column ever dropped. The backend only whitelists string[]; it does NOT validate sheet membership,
+ * so the FE must be robust.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useMultitableGrid } from '../src/multitable/composables/useMultitableGrid'
+import { MultitableApiClient } from '../src/multitable/api/client'
+import type { MetaField } from '../src/multitable/types'
+
+const field = (id: string, order: number): MetaField => ({ id, name: id, type: 'string', order })
+const makeGrid = () =>
+  useMultitableGrid({
+    sheetId: ref('s1'),
+    viewId: ref('v1'),
+    client: new MultitableApiClient({ fetchFn: vi.fn(async () => new Response('{}', { status: 200 })) }),
+  })
+const ids = (grid: ReturnType<typeof makeGrid>) => grid.visibleFields.value.map((f) => f.id)
+
+describe('useMultitableGrid — Slice 3b fieldOrder column consumer', () => {
+  it('renders columns in view.fieldOrder; fields absent from fieldOrder keep natural order, appended', () => {
+    const grid = makeGrid()
+    grid.fields.value = [field('a', 1), field('b', 2), field('c', 3)]
+    grid.syncFromView({ fieldOrder: ['c', 'a'] })
+    expect(ids(grid)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('empty / absent fieldOrder ⇒ natural field order, unchanged from before Slice 3b', () => {
+    const grid = makeGrid()
+    grid.fields.value = [field('a', 1), field('b', 2)]
+    grid.syncFromView({ fieldOrder: [] })
+    expect(ids(grid)).toEqual(['a', 'b'])
+    grid.syncFromView({}) // no fieldOrder key at all
+    expect(ids(grid)).toEqual(['a', 'b'])
+  })
+
+  it('G-FE-5: unknown / stale ids in fieldOrder are ignored — no crash, no blank column, no real column dropped', () => {
+    const grid = makeGrid()
+    grid.fields.value = [field('a', 1), field('b', 2)]
+    grid.syncFromView({ fieldOrder: ['ghost', 'b', 'also-gone', 'a'] })
+    expect(ids(grid)).toEqual(['b', 'a']) // real fields ordered; unknown ids dropped
+    expect(ids(grid)).not.toContain('ghost')
+    expect(grid.visibleFields.value.length).toBe(2) // exactly the real fields — no phantom column
+  })
+
+  it('G-FE-5: a fieldOrder that is ENTIRELY unknown ids falls back to natural order (never empties the grid)', () => {
+    const grid = makeGrid()
+    grid.fields.value = [field('a', 1), field('b', 2)]
+    grid.syncFromView({ fieldOrder: ['x', 'y', 'z'] })
+    expect(ids(grid)).toEqual(['a', 'b'])
+  })
+
+  it('G-FE-5: a duplicate id in fieldOrder does not duplicate the column', () => {
+    const grid = makeGrid()
+    grid.fields.value = [field('a', 1), field('b', 2)]
+    grid.syncFromView({ fieldOrder: ['a', 'a', 'b'] })
+    expect(ids(grid)).toEqual(['a', 'b'])
+  })
+
+  it('a fieldOrder id pointing at a HIDDEN field is skipped (stays hidden); the rest of the order is honored', () => {
+    const grid = makeGrid()
+    grid.fields.value = [field('a', 1), field('b', 2), field('c', 3)]
+    grid.syncFromView({ hiddenFieldIds: ['b'], fieldOrder: ['b', 'c', 'a'] })
+    expect(ids(grid)).toEqual(['c', 'a']) // b is hidden ⇒ never rendered, even though named first in fieldOrder
+  })
+
+  it('non-string entries in fieldOrder are filtered on ingest (defensive against a malformed payload)', () => {
+    const grid = makeGrid()
+    grid.fields.value = [field('a', 1), field('b', 2)]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    grid.syncFromView({ fieldOrder: ['b', 123 as any, null as any, 'a'] })
+    expect(ids(grid)).toEqual(['b', 'a'])
+  })
+})

--- a/docs/development/multitable-personal-views-slice3b-fieldorder-consumer-20260706.md
+++ b/docs/development/multitable-personal-views-slice3b-fieldorder-consumer-20260706.md
@@ -1,0 +1,58 @@
+# Personal views — Slice 3b (FE fieldOrder consumer + G-FE-5) — VERIFICATION — 2026-07-06
+
+> Closes the deferral from Slice 3 (#3711): the FE now RENDERS per-view column order from `view.fieldOrder`
+> (server-resolved, personal-overlay-applied), fail-soft on stale/unknown ids — the G-FE-5 golden that had no
+> live consumer until now. Design ref: `multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md`.
+> **No flag, no new surface, no runtime opt-in.** Presentation-only; default behavior (no `fieldOrder`) is
+> byte-identical to before. Grounded on `origin/main` @ `2fe166d6a`.
+
+## Background — why this was deferred, why it's now unblocked
+
+Slice 2 (#3657) landed the `fieldOrder` overlay as **backend plumbing** (stored per (view,user), server-applied
+onto the served view). Slice 3 (#3711) shipped the toggle but had **no FE consumer of `fieldOrder`** — nothing
+read `view.fieldOrder` to reorder columns — so the unknown-id fail-soft golden (G-FE-5) would have been vacuous.
+The reviewer explicitly carried G-FE-5 to "Slice 3b, with the field-order-rendering consumer." This is that slice.
+
+## What shipped (FE only)
+
+- **`useMultitableGrid`** (`apps/web/src/multitable/composables/useMultitableGrid.ts`):
+  - New `fieldOrder` ref, captured in `syncFromView` from the loaded view's `fieldOrder` (string-filtered on
+    ingest; membership NOT validated here — the consumer fail-softs).
+  - `visibleFields` now applies `fieldOrder` as a **presentation reorder** over the already-filtered
+    (hidden/permission) set: fields named in `fieldOrder` first, in that order; visible fields NOT named keep
+    their natural order (server `field.order`), appended after. Empty/absent `fieldOrder` ⇒ returns the base
+    filtered list unchanged (byte-identical to pre-Slice-3b).
+- **`types.ts`** — corrected the `MetaView.fieldOrder` comment (it previously said "No FE consumer renders this
+  yet"); now documents the Slice 3b consumer + fail-soft.
+
+The grid renders `visibleFields` as its columns, so reordering `visibleFields` reorders the rendered columns with
+no change to `MetaGridTable` or any other component.
+
+## G-FE-5 (fail-soft) — the golden that motivated this slice
+
+`apps/web/tests/multitable-grid-fieldorder-consumer.spec.ts` (7 tests, all green):
+- renders columns in `fieldOrder`; unnamed fields appended in natural order.
+- empty / absent `fieldOrder` ⇒ natural order unchanged.
+- **unknown / stale ids ignored** — no crash, no blank column, no real column dropped.
+- **entirely-unknown `fieldOrder`** ⇒ falls back to natural order (never empties the grid).
+- duplicate id ⇒ no duplicated column.
+- an id naming a HIDDEN field ⇒ skipped (stays hidden), rest of order honored.
+- non-string entries filtered on ingest (malformed-payload defense).
+
+Run: `cd apps/web && npx vitest run tests/multitable-grid-fieldorder-consumer.spec.ts` → **7 passed**. Regression:
+`multitable-grid multitable-field-visibility multitable-frozen-columns-grid multitable-grid-bulk-edit` → **15
+files / 142 tests pass** (the reorder is inert when `fieldOrder` is empty, which is every existing test). vue-tsc
+clean.
+
+## Scope boundary — what is NOT in this slice
+
+This is the **read/render** side only. The **write** side (a user dragging columns while personal mode is ON to
+persist a per-user `fieldOrder` via `PUT …/personal-config`) is a separate follow-up (call it Slice 3c) — the
+existing field-reorder drag still targets the shared order and is untouched here. Slice 3b makes any stored
+`fieldOrder` (however authored) render correctly and safely; it does not add a new authoring path.
+
+## Enablement posture
+
+Unchanged. The overlay only carries a `fieldOrder` when `MULTITABLE_ENABLE_PERSONAL_VIEWS` is on AND the actor has
+a personal row (Slice 1/2 contract); with the flag off there is no `fieldOrder` and this consumer is inert. No new
+flag, no new gate. Backend actor-isolation (G-A/G-C) and the `/context` overlay (Slice 3 P1) are unchanged.


### PR DESCRIPTION
## What

Closes the **Slice 3 (#3711) deferral**: the FE now **renders per-view column order** from `view.fieldOrder` (server-resolved, personal-overlay-applied). Slice 2 (#3657) stored the order as backend plumbing; Slice 3 shipped the toggle but had no consumer of `fieldOrder` — so the **G-FE-5 fail-soft golden** had nothing to guard. This is that consumer.

Presentation-only. **No flag, no new surface.** Default behavior (no `fieldOrder`) is byte-identical to before.

## Change

- **`useMultitableGrid`**: new `fieldOrder` ref captured in `syncFromView`; `visibleFields` applies it as a presentation reorder over the already-filtered (hidden/permission) set — named fields first in order, unnamed fields keep natural `field.order`, appended. Empty/absent `fieldOrder` ⇒ base list unchanged.
- **`types.ts`**: corrected the stale `MetaView.fieldOrder` comment ("no FE consumer renders this yet").

The grid renders `visibleFields` as its columns, so reordering it reorders columns with no component change.

## G-FE-5 fail-soft (the golden this slice makes real)

`multitable-grid-fieldorder-consumer.spec.ts` — 7 tests, all green:
- renders in `fieldOrder`; unnamed fields appended natural order
- empty/absent `fieldOrder` ⇒ natural order unchanged
- **unknown/stale ids ignored** — no crash, no blank column, no real column dropped
- **entirely-unknown order** ⇒ falls back to natural order (never empties the grid)
- duplicate id ⇒ no duplicate column
- HIDDEN field named in order ⇒ skipped (stays hidden)
- non-string entries filtered on ingest

Regression: `multitable-grid / field-visibility / frozen-columns / bulk-edit` → **15 files, 142 tests pass** (reorder is inert when `fieldOrder` empty). vue-tsc clean. CI's `multitable-web-guard` `multitable-grid` filter runs the new spec.

## Scope boundary

**Read/render side only.** The personal-order **write** path (drag columns while personal mode ON → `PUT …/personal-config`) is a separate **Slice 3c**; the existing reorder-drag still targets the shared order and is untouched. This slice makes any stored `fieldOrder` render correctly and safely.

Grounded on `origin/main` @ `2fe166d6a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)