### PR TITLE
feat(integration): list_page 配置读接受有界 pageIndex 输入 — BL4 候选发现数据面 (#3703)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/read-source-read-runtime.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-read-runtime.test.cjs
@@ -253,6 +253,46 @@ async function testListPageCapAndProjection() {
   assert.deepEqual(data.containers.primary.records[0], { colGamma: 'SIGMA-VALUE-0', colDelta: null, colAbsent: null })
   assertEvidenceValuesFree(evidence)
   assert.equal(state.readArgs[0].limit, 10)
+  // No pageIndex input → no listPageIndex option (adapter default page 1, shipped behavior unchanged).
+  assert.equal(state.readArgs[0].options.listPageIndex, undefined)
+}
+
+// Bounded LIST page input (#3703): list_page configured reads accept inputs.pageIndex (integer 1..10),
+// which rides to the adapter as the dedicated listPageIndex option — the data plane itself is unchanged.
+async function testListPageBoundedPageIndexInput() {
+  const prepared = prepareConfiguredRead({ config: normalizedConfig('list_page'), inputs: { pageIndex: 3 } })
+  const { deps, state } = mockDeps({
+    read: () => ({ records: [], raw: { Data: { Data: [{ FSigmaField: 'SIGMA-VALUE-P3' }] } } }),
+  })
+  const { evidence, data } = await executeConfiguredRead(prepared, deps)
+  assert.equal(evidence.ok, true)
+  assert.equal(data.containers.primary.records.length, 1)
+  assertEvidenceValuesFree(evidence)
+  assert.equal(state.readArgs[0].options.listPageIndex, 3, 'bounded pageIndex reaches the adapter request option')
+  assert.equal(state.readArgs[0].limit, 10, 'row cap unchanged by paging')
+
+  // Bounds fail closed at input normalization — before any adapter/outbound.
+  for (const badPage of [0, 11, -1, 1.5, '3', null, true, {}, [], Number.NaN]) {
+    assert.throws(
+      () => prepareConfiguredRead({ config: normalizedConfig('list_page'), inputs: { pageIndex: badPage } }),
+      (error) => error instanceof ReadSourceProbeContractError && error.reason === 'page_index_invalid',
+      `pageIndex ${JSON.stringify(badPage)} must fail closed`,
+    )
+  }
+  // pageIndex on a non-list mode is rejected, never silently dropped.
+  for (const mode of ['single_record', 'resolver_lookup']) {
+    assert.throws(
+      () => prepareConfiguredRead({ config: normalizedConfig(mode), inputs: { key: 'M-001', pageIndex: 2 } }),
+      (error) => error instanceof ReadSourceProbeContractError && error.reason === 'page_index_not_allowed',
+      `${mode} pageIndex must be rejected`,
+    )
+  }
+  // keyField'd list_page: key + pageIndex compose.
+  const keyed = prepareConfiguredRead({
+    config: normalizedConfig('list_page', { keyField: 'FNumber' }),
+    inputs: { key: 'M-001', pageIndex: 2 },
+  })
+  assert.deepEqual({ ...keyed.inputs }, { key: 'M-001', pageIndex: 2 })
 }
 
 async function testDetailWithLinesBothContainersMapped() {
@@ -368,6 +408,7 @@ async function main() {
   await testResolverLookupRuntime()
   await testSingleRecordDataPlane()
   await testListPageCapAndProjection()
+  await testListPageBoundedPageIndexInput()
   await testDetailWithLinesBothContainersMapped()
   await testContainerMissingAndShapeMismatch()
   await testAdapterErrorsAreCoarseWithNullData()

--- a/plugins/plugin-integration-core/lib/read-source-probe-runtime.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-probe-runtime.cjs
@@ -45,10 +45,16 @@ function isBomListByMaterialPlan(plan) {
 // inputs (the plan's requiredNamedInputs) ride BESIDE the frozen contract, never inside it, so the S2-a
 // top-key allowlist stays untouched.
 const READ_SOURCE_PROBE_BODY_INPUT_KEY = 'inputs'
-const READ_SOURCE_PROBE_INPUT_KEYS = Object.freeze(['key'])
+const READ_SOURCE_PROBE_INPUT_KEYS = Object.freeze(['key', 'pageIndex'])
 // A named key input is a bound business VALUE (e.g. a material number): bounded, control-char-free, and —
 // like the read-smoke key — never echoed into any error or evidence.
 const READ_SOURCE_PROBE_KEY_MAX_LENGTH = 128
+// Bounded LIST page input (#3703, owner-approved 2026-07-06 — the data-plane half of the same bounded
+// pageIndex authorization already shipped for the evidence-only read-smoke route in #3709): list_page
+// configured reads may name a page, integer 1..10 only, so an authorized operator can walk bounded pages
+// through the EXISTING fieldMap data plane. Not a filter/body/field surface; rejected on any other mode;
+// the adapter re-guards the same bound.
+const READ_SOURCE_PROBE_MAX_PAGE_INDEX = 10
 
 class ReadSourceProbeRuntimeError extends Error {
   constructor(reason) {
@@ -83,17 +89,32 @@ function normalizeReadSourceProbeInputs(plan, inputs) {
   if (!Object.keys(source).every((key) => READ_SOURCE_PROBE_INPUT_KEYS.includes(key))) {
     throw new ReadSourceProbeContractError('inputs_unexpected_field')
   }
+  // Bounded LIST page input (#3703): list_page only; integer 1..MAX only; fail-closed on any other mode
+  // (never silently dropped) and on any non-conforming value.
+  let pageIndex
+  if (source.pageIndex !== undefined) {
+    if (plan.mode !== 'list_page') {
+      throw new ReadSourceProbeContractError('page_index_not_allowed')
+    }
+    if (typeof source.pageIndex !== 'number' || !Number.isInteger(source.pageIndex)
+      || source.pageIndex < 1 || source.pageIndex > READ_SOURCE_PROBE_MAX_PAGE_INDEX) {
+      throw new ReadSourceProbeContractError('page_index_invalid')
+    }
+    pageIndex = source.pageIndex
+  }
   if (plan.requiredNamedInputs.includes('key')) {
     if (!isBoundedProbeKeyValue(source.key)) {
       throw new ReadSourceProbeContractError('key_required')
     }
-    return Object.freeze({ key: String(source.key).trim() })
+    const normalized = { key: String(source.key).trim() }
+    if (pageIndex !== undefined) normalized.pageIndex = pageIndex
+    return Object.freeze(normalized)
   }
   // Fail-closed the other way too: a key supplied to a keyless plan is rejected, not silently dropped.
   if (source.key !== undefined) {
     throw new ReadSourceProbeContractError('key_not_allowed')
   }
-  return Object.freeze({})
+  return Object.freeze(pageIndex !== undefined ? { pageIndex } : {})
 }
 
 // Split the route body into { contract, inputs }, normalize the contract through the S2-a normalizer
@@ -151,6 +172,9 @@ function buildReadSourceProbeOverlayPreset(plan) {
 function buildReadSourceProbeRequest(plan, inputs) {
   if (plan.mode === 'list_page') {
     const request = { object: plan.object, limit: plan.rowCap, options: { k3ReadMode: 'list' } }
+    // Bounded page input (#3703): contract-validated 1..MAX above; the adapter re-guards the same bound
+    // (K3_WISE_READ_LIST_PAGE_INDEX_INVALID). Absent → adapter default page 1 (shipped behavior unchanged).
+    if (inputs.pageIndex !== undefined) request.options.listPageIndex = inputs.pageIndex
     Object.defineProperty(request.options, READ_SMOKE_LIST_REQUEST_MARKER, { value: true, enumerable: true })
     return request
   }


### PR DESCRIPTION
## Summary
#3709 落地了 **evidence-only**(read-smoke)路的有界 pageIndex 后,实体机确认了缺口:read-smoke 证据面 values-free by design,**候选键值取不到**;数据面(S3 configured read 的 fieldMap data plane)本就存在,但 list_page 固定 page 1。本 PR 补齐**同一 owner 授权的另一半**:

- `inputs.pageIndex`(list_page 配置读 named input):整数 **1..10** 契约校验;非 list_page 模式携带 → `page_index_not_allowed`(拒绝不静默丢弃)
- 映射为已合并的 `options.listPageIndex`(adapter #3709 同界再守卫,零新 adapter 面)
- 缺省 → 原 page-1 行为零变化;row cap/evidence/data plane 结构不变

### 验证
- 新用例:pageIndex=3 达 adapter option、10 种坏值 fail-closed、single_record/resolver 拒、keyField'd list_page key+pageIndex 组合
- **mutation 3/3 KILLED**(bound / mode gate / request mapping)+ kill-then-green sanity
- 全链 **EXIT=0, 72 suites**(先 commit 后 mutation,新规执行)

### 用途(#3703 执行序)
operator 授权屏内走数据面翻页取候选(FNumber/FItemID)→ 逐候选 BL2 standalone read 查 BOM 数 → 命中单 BOM → BL4 happy path。键值仍全程本地,issue 回贴仍 values-free。

Refs #3703 #3709

🤖 Generated with [Claude Code](https://claude.com/claude-code)