### PR TITLE
fix(attendance-web): drop stale sniff verdicts on rapid CSV re-selection (race guard)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -18238,6 +18238,10 @@ async function handleImportCsvChange(event: Event) {
   importCsvRecognition.value = null
   if (file) {
     const verdict = await inspectImportFile(file)
+    // Rapid re-selection race (xlsx-guard lock §7): the sniff is async — if the
+    // input no longer holds this file, a newer selection owns the state now;
+    // drop this stale verdict (accepting OR blocking) instead of clobbering it.
+    if ((target?.files?.[0] ?? null) !== file) return
     if (!verdict.ok) {
       importCsvFile.value = null
       importCsvFileName.value = ''

--- a/apps/web/src/views/attendance/useAttendanceAdminImportWorkflow.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminImportWorkflow.ts
@@ -1323,6 +1323,10 @@ export function useAttendanceAdminImportWorkflow({
     const file = extractFileFromEvent(event)
     if (file) {
       const verdict = await inspectImportFile(file)
+      // Rapid re-selection race (xlsx-guard lock §7): if the input no longer
+      // holds this file, a newer selection owns the state — drop this stale
+      // verdict (accepting OR blocking) instead of clobbering it.
+      if (extractFileFromEvent(event) !== file) return
       if (!verdict.ok) {
         setImportCsvFile(null)
         const blocked = blockedSpreadsheetMessage(verdict.kind)

--- a/apps/web/tests/attendance-import-preview-regression.spec.ts
+++ b/apps/web/tests/attendance-import-preview-regression.spec.ts
@@ -522,6 +522,37 @@ describe('Attendance import preview regression', () => {
     expect(warning!.textContent).toContain('No date column found')
   })
 
+  it('race guard: a stale sniff verdict cannot clobber a newer selection in the shell handler', async () => {
+    mockTemplateEndpoint()
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    const vm = app.mount(container!)
+    await flushUi(6)
+    const setupState = (vm as any).$?.setupState as Record<string, any>
+
+    let releaseSlow!: (buffer: ArrayBuffer) => void
+    const slowFile = {
+      name: 'slow.csv',
+      slice: () => ({ arrayBuffer: () => new Promise<ArrayBuffer>(resolve => { releaseSlow = resolve }) }),
+    }
+    const fastFile = new File(['姓名,日期\n张三,2026-06-01\n'], 'fast.csv', { type: 'text/csv' })
+
+    const sharedInput = { files: [slowFile], value: 'slow.csv' }
+    const pending = setupState.handleImportCsvChange({ target: sharedInput })
+    sharedInput.files = [fastFile]
+    sharedInput.value = 'fast.csv'
+    await setupState.handleImportCsvChange({ target: sharedInput })
+
+    releaseSlow(new Uint8Array([0x50, 0x4b, 0x03, 0x04]).buffer)
+    await pending
+    await flushUi(4)
+
+    expect(unwrapRef<File | null>(setupState.importCsvFile)).toBe(fastFile)
+    expect(unwrapRef<string>(setupState.importCsvFileName)).toBe('fast.csv')
+    expect(sharedInput.value).toBe('fast.csv')
+    expect(container!.textContent).not.toContain('This looks like an Excel file')
+  })
+
   it('advanced options collapse by default; core fields stay visible; toggle expands', async () => {
     mockTemplateEndpoint()
 

--- a/apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts
+++ b/apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts
@@ -670,6 +670,53 @@ describe('useAttendanceAdminImportWorkflow', () => {
     expect(setStatus.mock.calls[0][1]).toBe('error')
   })
 
+  it('race guard: a stale BLOCKED verdict cannot clobber a newer selection', async () => {
+    const { workflow, setStatus } = createWorkflow({ tr: (_en: string, zh: string) => zh })
+    let releaseSlow!: (buffer: ArrayBuffer) => void
+    const slowFile = {
+      name: 'slow.csv',
+      slice: () => ({ arrayBuffer: () => new Promise<ArrayBuffer>(resolve => { releaseSlow = resolve }) }),
+    } as unknown as File
+    const fastFile = new File(['userId,workDate\nu-1,2026-03-12\n'], 'fast.csv', { type: 'text/csv' })
+
+    const sharedInput = { files: [slowFile], value: 'slow.csv' }
+    const pending = workflow.handleImportCsvChange({ target: sharedInput } as unknown as Event)
+    sharedInput.files = [fastFile]
+    sharedInput.value = 'fast.csv'
+    await workflow.handleImportCsvChange({ target: sharedInput } as unknown as Event)
+    expect(workflow.importCsvFile.value).toBe(fastFile)
+
+    releaseSlow(new Uint8Array([0x50, 0x4b, 0x03, 0x04]).buffer)
+    await pending
+
+    expect(workflow.importCsvFile.value).toBe(fastFile)
+    expect(workflow.importCsvFileName.value).toBe('fast.csv')
+    expect(sharedInput.value).toBe('fast.csv')
+    expect(setStatus).not.toHaveBeenCalled()
+  })
+
+  it('race guard: a stale ACCEPT verdict cannot overwrite the newer file either', async () => {
+    const { workflow } = createWorkflow()
+    let releaseSlow!: (buffer: ArrayBuffer) => void
+    const slowFile = {
+      name: 'slow.csv',
+      slice: () => ({ arrayBuffer: () => new Promise<ArrayBuffer>(resolve => { releaseSlow = resolve }) }),
+    } as unknown as File
+    const fastFile = new File(['userId,workDate\nu-1,2026-03-12\n'], 'fast.csv', { type: 'text/csv' })
+
+    const sharedInput = { files: [slowFile], value: 'slow.csv' }
+    const pending = workflow.handleImportCsvChange({ target: sharedInput } as unknown as Event)
+    sharedInput.files = [fastFile]
+    sharedInput.value = 'fast.csv'
+    await workflow.handleImportCsvChange({ target: sharedInput } as unknown as Event)
+
+    releaseSlow(new TextEncoder().encode('userId,w').buffer as ArrayBuffer)
+    await pending
+
+    expect(workflow.importCsvFile.value).toBe(fastFile)
+    expect(workflow.importCsvFileName.value).toBe('fast.csv')
+  })
+
   it('still accepts a normal csv through handleImportCsvChange', async () => {
     const { workflow, apiFetch, setStatus } = createWorkflow()
     const csv = new File(['userId,workDate\nu-1,2026-03-12\n'], 'attendance.csv', { type: 'text/csv' })

--- a/docs/development/attendance-import-xlsx-guard-design-lock-20260706.md
+++ b/docs/development/attendance-import-xlsx-guard-design-lock-20260706.md
@@ -57,3 +57,14 @@
 ## 6. 完成口径
 
 共享模块 + 双接入 + R2 + 三档测试 → opus 对抗审阅 0 P1/P2 → 三红线（0 P1/P2；纯前端 display/guard、default-preserving；fresh-green required checks + up-to-date）。FE 串行车道（触碰 `AttendanceView.vue`）。
+
+## 7. 追加硬化（2026-07-06 自主批次）：选文件异步竞态守卫
+
+> owner 复审 #3694 时点名的 P3 follow-up（"极端情况下用户快速连续选择两个文件，前一个 sniff
+> 晚返回可能覆盖后一个选择；顺手可在返回前确认 `target.files?.[0] === file` 再写状态"）。
+
+`handleImportCsvChange` 的 `inspectImportFile` 是异步的（读魔术字节）：快速连选 A→B 时，
+A 的检查晚返回会以 A 的结论写状态——若 A 被拦截还会清空 input（毁掉 B 的选择）。
+修复（shell + composable 双接入，同护栏纪律）：`await inspectImportFile` 返回后、写任何状态前，
+确认 `target.files?.[0] === file` 仍成立，否则直接丢弃过期结论。测试用可控 resolve 的
+File-like 复现 A 慢 B 快，断言 B 的选择不被 A 的迟到结论（无论放行或拦截）扰动；mutation 证明。


### PR DESCRIPTION
owner 复审 #3694 点名的 P3 follow-up：选文件 sniff 异步，快速连选 A→B 时 A 的迟到结论会覆盖 B（最坏：迟到的拦截结论清空 input 毁掉 B 的有效选择）。sniff 返回后确认 input 仍持有该文件才写状态（shell+composable 双接入）。可控 resolve File-like 复现慢 A 快 B（迟到拦截/迟到放行两变体+真挂载 shell 路径）；mutation 证明（摘任一守卫 → 对应测试红）；201 测绿 + typecheck 干净。锁修正案：xlsx-guard lock §7。

**审阅安排**：opus 对抗审阅额度恢复后执行，审毕 0 P1/P2 才合并（本 PR 保持 OPEN 等审）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)