### PR TITLE
feat(multitable): personal views Slice 3d — additive personal-config writes (default-off)

### DIFF
--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -16,6 +16,7 @@ import type {
 } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
 import { isPropertyHiddenField } from '../utils/field-permissions'
+import { writePersonalConfigMerged } from '../utils/personal-config-write'
 import { metaCoreLabel } from '../utils/meta-core-labels'
 import { resolveRollupFieldProperty, rollupResultType } from '../utils/field-config'
 
@@ -801,9 +802,13 @@ export function useMultitableGrid(opts: {
   // Slice 3 G-FE-2 write-routing: the ONE switch every in-place config edit below funnels through. ON (for
   // this viewId) → PUT personal-config (actor-scoped, no identity in the request — see client.ts); OFF/absent
   // → the shared updateView path, byte-identical to pre-Slice-3 behavior.
+  //
+  // Slice 3d: the personal write is ADDITIVE (read-merge-write) — a single-facet edit (e.g. { sortInfo }) must
+  // not wipe the actor's other personal facets, because the backend PUT replaces the whole row. See
+  // utils/personal-config-write.ts. The shared (updateView) path is unchanged.
   async function persistViewConfig(vid: string, input: PersonalViewConfigOverlay) {
     if (opts.isPersonalMode?.(vid)) {
-      await client.putPersonalViewConfig(vid, input)
+      await writePersonalConfigMerged(client, vid, input)
     } else {
       await client.updateView(vid, input)
     }

--- a/apps/web/src/multitable/utils/personal-config-write.ts
+++ b/apps/web/src/multitable/utils/personal-config-write.ts
@@ -1,0 +1,36 @@
+import type { PersonalViewConfigOverlay } from '../types'
+
+/**
+ * Slice 3d — additive personal-config writes.
+ *
+ * The backend `PUT /views/:id/personal-config` REPLACES the whole row (upsertPersonalViewConfig does
+ * `DO UPDATE SET config = $3`). So sending only the edited facet (e.g. `{ sortInfo }`) would WIPE the actor's
+ * other personal facets (filter/group/hidden/fieldOrder). This read-merge-write reads the current personal
+ * config, merges the patch over it, and writes the whole thing back — a single-facet edit preserves the rest.
+ *
+ * Clearing still works: a patch facet set to `undefined` overrides the base value, and since `JSON.stringify`
+ * drops `undefined`, the backend receives no such key and its `sanitizePersonalOverlayConfig` omits it — i.e.
+ * the facet is cleared, while facets ABSENT from the patch (never mentioned) are preserved from `base`.
+ *
+ * Mirrors the read-merge-write already used by the column-reorder path (utils/reorder-view-fields.ts).
+ */
+export interface PersonalConfigWriteClient {
+  getPersonalViewConfig(viewId: string): Promise<{ config: PersonalViewConfigOverlay | null }>
+  putPersonalViewConfig(viewId: string, overlay: PersonalViewConfigOverlay): Promise<unknown>
+}
+
+export async function writePersonalConfigMerged(
+  client: PersonalConfigWriteClient,
+  viewId: string,
+  patch: PersonalViewConfigOverlay,
+): Promise<void> {
+  let base: PersonalViewConfigOverlay = {}
+  try {
+    // A view with no personal row yet returns { config: null } (row created lazily on first write); a genuine
+    // 404 (flag off / view gone) is caught → treat as empty and still write the patch.
+    base = (await client.getPersonalViewConfig(viewId))?.config ?? {}
+  } catch {
+    base = {}
+  }
+  await client.putPersonalViewConfig(viewId, { ...base, ...patch })
+}

--- a/apps/web/src/multitable/utils/personal-config-write.ts
+++ b/apps/web/src/multitable/utils/personal-config-write.ts
@@ -26,10 +26,13 @@ export async function writePersonalConfigMerged(
 ): Promise<void> {
   let base: PersonalViewConfigOverlay = {}
   try {
-    // A view with no personal row yet returns { config: null } (row created lazily on first write); a genuine
-    // 404 (flag off / view gone) is caught → treat as empty and still write the patch.
+    // A view with no personal row yet returns { config: null } (row created lazily on first write).
     base = (await client.getPersonalViewConfig(viewId))?.config ?? {}
-  } catch {
+  } catch (err) {
+    // FAIL-CLOSED: only a 404 (no row / flag off / view gone) is a safe "start from empty". Any OTHER
+    // failure (500 / network / transient auth) must NOT proceed — writing { ...{}, ...patch } would REPLACE
+    // the row and wipe the actor's other personal facets (the very thing this helper exists to prevent).
+    if ((err as { status?: number } | null)?.status !== 404) throw err
     base = {}
   }
   await client.putPersonalViewConfig(viewId, { ...base, ...patch })

--- a/apps/web/tests/multitable-grid-personal-additive-write.spec.ts
+++ b/apps/web/tests/multitable-grid-personal-additive-write.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Slice 3d — additive personal-config writes. A single-facet personal edit must NOT wipe the actor's other
+ * personal facets (the backend PUT replaces the whole row). Design:
+ * docs/development/multitable-personal-views-slice3d-additive-writes-20260706.md.
+ *
+ * Named `multitable-grid-*` so the multitable-web-guard `multitable-grid` filter runs it.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { writePersonalConfigMerged, type PersonalConfigWriteClient } from '../src/multitable/utils/personal-config-write'
+import { useMultitableGrid } from '../src/multitable/composables/useMultitableGrid'
+import { MultitableApiClient } from '../src/multitable/api/client'
+
+// ---- unit goldens for the merge helper ----
+
+function mockClient(config: unknown): PersonalConfigWriteClient {
+  return {
+    getPersonalViewConfig: vi.fn(async () => ({ config: config as never })),
+    putPersonalViewConfig: vi.fn(async () => ({})),
+  }
+}
+const putArg = (c: PersonalConfigWriteClient) => (c.putPersonalViewConfig as ReturnType<typeof vi.fn>).mock.calls[0]
+
+describe('writePersonalConfigMerged — additive personal writes', () => {
+  it('GOLDEN: existing {filter, sort, hidden} + single-facet {hiddenFieldIds} edit ⇒ filter & sort preserved', async () => {
+    const existing = {
+      filterInfo: { conjunction: 'and', conditions: [{ fieldId: 'a', operator: 'is', value: 'x' }] },
+      sortInfo: { fieldId: 'b', direction: 'desc' },
+      hiddenFieldIds: ['old'],
+    }
+    const client = mockClient({ ...existing })
+    await writePersonalConfigMerged(client, 'v1', { hiddenFieldIds: ['new'] })
+    expect(client.getPersonalViewConfig).toHaveBeenCalledWith('v1')
+    expect(putArg(client)).toEqual(['v1', { filterInfo: existing.filterInfo, sortInfo: existing.sortInfo, hiddenFieldIds: ['new'] }])
+  })
+
+  it('a {sortInfo} edit preserves an existing personal fieldOrder + filter', async () => {
+    const client = mockClient({ filterInfo: { conjunction: 'or', conditions: [] }, fieldOrder: ['c', 'a', 'b'] })
+    await writePersonalConfigMerged(client, 'v1', { sortInfo: { fieldId: 'a', direction: 'asc' } })
+    expect(putArg(client)[1]).toEqual({ filterInfo: { conjunction: 'or', conditions: [] }, fieldOrder: ['c', 'a', 'b'], sortInfo: { fieldId: 'a', direction: 'asc' } })
+  })
+
+  it('no existing row (config: null) ⇒ writes just the patch', async () => {
+    const client = mockClient(null)
+    await writePersonalConfigMerged(client, 'v1', { groupInfo: { fieldIds: ['g'] } })
+    expect(putArg(client)[1]).toEqual({ groupInfo: { fieldIds: ['g'] } })
+  })
+
+  it('GET failure (404 / flag flip) ⇒ still writes the patch, does not throw', async () => {
+    const client: PersonalConfigWriteClient = {
+      getPersonalViewConfig: vi.fn(async () => { throw Object.assign(new Error('not found'), { status: 404 }) }),
+      putPersonalViewConfig: vi.fn(async () => ({})),
+    }
+    await expect(writePersonalConfigMerged(client, 'v1', { sortInfo: { fieldId: 'a', direction: 'asc' } })).resolves.toBeUndefined()
+    expect(client.putPersonalViewConfig).toHaveBeenCalledWith('v1', { sortInfo: { fieldId: 'a', direction: 'asc' } })
+  })
+
+  it('clearing a facet: patch {filterInfo: undefined} drops filter (JSON omits undefined) while others persist', async () => {
+    const client = mockClient({ filterInfo: { conjunction: 'and', conditions: [] }, sortInfo: { fieldId: 'b', direction: 'asc' }, hiddenFieldIds: ['z'] })
+    await writePersonalConfigMerged(client, 'v1', { filterInfo: undefined })
+    const sent = JSON.parse(JSON.stringify(putArg(client)[1]))
+    expect(sent).toEqual({ sortInfo: { fieldId: 'b', direction: 'asc' }, hiddenFieldIds: ['z'] })
+  })
+})
+
+// ---- grid wiring: personal in-place edit routes through the additive write; shared path unchanged ----
+
+function gridClient(personalConfig: unknown) {
+  const client = new MultitableApiClient({ fetchFn: vi.fn(async () => new Response('{}', { status: 200 })) })
+  vi.spyOn(client, 'getPersonalViewConfig').mockResolvedValue({ viewId: 'v1', config: personalConfig as never, updatedAt: null })
+  vi.spyOn(client, 'putPersonalViewConfig').mockResolvedValue({ viewId: 'v1', config: personalConfig as never, updatedAt: null })
+  vi.spyOn(client, 'updateView').mockResolvedValue({} as never)
+  return client
+}
+
+describe('useMultitableGrid — personal in-place edit is additive (Slice 3d wiring)', () => {
+  it('personal ON: toggling a hidden field merges over the existing personal config (sort preserved), not updateView', async () => {
+    const client = gridClient({ sortInfo: { fieldId: 'b', direction: 'desc' } })
+    const grid = useMultitableGrid({ sheetId: ref('s1'), viewId: ref('v1'), client, isPersonalMode: () => true })
+    grid.toggleFieldVisibility('f1')
+    await vi.waitFor(() => expect(client.putPersonalViewConfig).toHaveBeenCalled())
+    expect(client.putPersonalViewConfig).toHaveBeenCalledWith('v1', { sortInfo: { fieldId: 'b', direction: 'desc' }, hiddenFieldIds: ['f1'] })
+    expect(client.updateView).not.toHaveBeenCalled()
+  })
+
+  it('personal OFF: toggling a hidden field uses the shared updateView path, no personal-config calls', async () => {
+    const client = gridClient(null)
+    const grid = useMultitableGrid({ sheetId: ref('s1'), viewId: ref('v1'), client, isPersonalMode: () => false })
+    grid.toggleFieldVisibility('f1')
+    await vi.waitFor(() => expect(client.updateView).toHaveBeenCalled())
+    expect(client.updateView).toHaveBeenCalledWith('v1', { hiddenFieldIds: ['f1'] })
+    expect(client.putPersonalViewConfig).not.toHaveBeenCalled()
+    expect(client.getPersonalViewConfig).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/multitable-grid-personal-additive-write.spec.ts
+++ b/apps/web/tests/multitable-grid-personal-additive-write.spec.ts
@@ -56,6 +56,15 @@ describe('writePersonalConfigMerged — additive personal writes', () => {
     expect(client.putPersonalViewConfig).toHaveBeenCalledWith('v1', { sortInfo: { fieldId: 'a', direction: 'asc' } })
   })
 
+  it('FAIL-CLOSED: a non-404 GET failure (500 / network) ⇒ REJECTS and does NOT PUT (never overwrites other facets)', async () => {
+    const client: PersonalConfigWriteClient = {
+      getPersonalViewConfig: vi.fn(async () => { throw Object.assign(new Error('server error'), { status: 500 }) }),
+      putPersonalViewConfig: vi.fn(async () => ({})),
+    }
+    await expect(writePersonalConfigMerged(client, 'v1', { sortInfo: { fieldId: 'a', direction: 'asc' } })).rejects.toThrow('server error')
+    expect(client.putPersonalViewConfig).not.toHaveBeenCalled()
+  })
+
   it('clearing a facet: patch {filterInfo: undefined} drops filter (JSON omits undefined) while others persist', async () => {
     const client = mockClient({ filterInfo: { conjunction: 'and', conditions: [] }, sortInfo: { fieldId: 'b', direction: 'asc' }, hiddenFieldIds: ['z'] })
     await writePersonalConfigMerged(client, 'v1', { filterInfo: undefined })

--- a/docs/development/multitable-personal-views-slice3d-additive-writes-20260706.md
+++ b/docs/development/multitable-personal-views-slice3d-additive-writes-20260706.md
@@ -1,0 +1,59 @@
+# Personal views — Slice 3d (additive personal-config writes) — DESIGN + VERIFICATION — 2026-07-06
+
+> Closes the follow-up flagged in `multitable-personal-views-slice3c-fieldorder-write-20260706.md` ("Known
+> follow-up"): a single-facet personal edit must NOT wipe the actor's other personal facets. Default-OFF; no
+> flag/backend change. Grounded on `origin/main` @ `0315bcf3c`. **For-review; not merged.**
+>
+> Built by the unattended autonomous cadence loop. Per its guardrails: for-review PR only, no merge, no flag/
+> protection changes.
+
+## Design (the problem + the fix)
+
+The backend `PUT /views/:id/personal-config` REPLACES the whole config row (`upsertPersonalViewConfig`:
+`DO UPDATE SET config = $3`). Slice 3's in-place personal edits (`persistViewConfig` in `useMultitableGrid.ts`)
+send only the edited facet — `persistSortFilter` → `{ sortInfo, filterInfo }`, group → `{ groupInfo }`,
+`persistHiddenFields` → `{ hiddenFieldIds }`. So in personal mode, editing one facet **wiped the others**
+(e.g. changing personal sort dropped personal filter / hidden / fieldOrder). This violated the design-lock's
+§1-D ("additive; unset facets fall through").
+
+**Fix — read-merge-write** (same pattern Slice 3c uses for column reorder): `utils/personal-config-write.ts`
+`writePersonalConfigMerged(client, viewId, patch)` reads the actor's current personal config, merges the patch
+over it (`{ ...base, ...patch }`), and PUTs the whole thing. `persistViewConfig`'s personal branch now calls it;
+the shared (`updateView`) branch is unchanged. Clearing still works: a patch facet set to `undefined` overrides
+`base` and `JSON.stringify` drops it, so the backend `sanitize` omits it (cleared) — while facets ABSENT from the
+patch are preserved from `base`. No backend change; the FE now sends the complete desired overlay each write.
+
+## Scope
+
+FE-only, one composable + one small util. Default-OFF (feature gated by `MULTITABLE_ENABLE_PERSONAL_VIEWS`; the
+personal branch only runs when `isPersonalMode` is true, which is itself flag-gated). No new surface, no new flag,
+no security-membrane change ⇒ L2.
+
+## Verification
+
+Goldens `apps/web/tests/multitable-grid-personal-additive-write.spec.ts` (7, all green):
+- **Core golden (the ask):** existing `{filter, sort, hidden}` + a single-facet `{hiddenFieldIds}` edit ⇒ filter
+  & sort preserved, hidden updated.
+- a `{sortInfo}` edit preserves an existing personal `fieldOrder` + filter (cross-facet durability).
+- no existing row (`config: null`) ⇒ writes just the patch (row created lazily).
+- GET 404 (flag flip / no row) ⇒ still writes, no throw.
+- clearing: patch `{filterInfo: undefined}` drops filter on the wire while sort/hidden persist.
+- **grid wiring:** personal ON — `toggleFieldVisibility` merges over the existing personal config (sort
+  preserved), `updateView` NOT called; personal OFF — uses the shared `updateView` path, no personal-config call.
+
+Run: `cd apps/web && npx vitest run tests/multitable-grid-personal-additive-write.spec.ts` → **7 passed**.
+Regression: `multitable-grid` filter → **14 files / 132 tests pass** (the change is inert on the shared path and
+for a first personal write with no existing row). vue-tsc clean. The spec is caught by the existing
+`multitable-web-guard` `multitable-grid` filter (no workflow change needed).
+
+## Interaction with Slice 3c (#3728, open)
+
+3c's column-reorder path already does read-merge-write via `utils/reorder-view-fields.ts`; 3d generalizes the same
+guarantee to the in-place facet edits via `utils/personal-config-write.ts`. Both are additive; when #3728 merges,
+a later cleanup could dedupe the two read-merge-write helpers (noted, non-blocking). This PR branches off current
+`origin/main` (which does not yet include #3728) — a trivial rebase may be needed depending on merge order.
+
+## Posture
+
+Default-OFF, no flag/backend/enablement change. Backend actor-isolation and `/context` overlay unchanged. Awaits
+owner review + "合".

--- a/docs/development/multitable-personal-views-slice3d-additive-writes-20260706.md
+++ b/docs/development/multitable-personal-views-slice3d-additive-writes-20260706.md
@@ -36,7 +36,10 @@ Goldens `apps/web/tests/multitable-grid-personal-additive-write.spec.ts` (7, all
   & sort preserved, hidden updated.
 - a `{sortInfo}` edit preserves an existing personal `fieldOrder` + filter (cross-facet durability).
 - no existing row (`config: null`) ⇒ writes just the patch (row created lazily).
-- GET 404 (flag flip / no row) ⇒ still writes, no throw.
+- GET **404** (flag flip / no row) ⇒ still writes, no throw.
+- **FAIL-CLOSED:** a non-404 GET failure (500 / network / transient auth) ⇒ re-throws and does NOT PUT — a blind
+  write on a failed read would REPLACE the row and wipe the actor's other facets (the exact thing this helper
+  prevents). Golden asserts reject + `putPersonalViewConfig` not called.
 - clearing: patch `{filterInfo: undefined}` drops filter on the wire while sort/hidden persist.
 - **grid wiring:** personal ON — `toggleFieldVisibility` merges over the existing personal config (sort
   preserved), `updateView` NOT called; personal OFF — uses the shared `updateView` path, no personal-config call.


### PR DESCRIPTION
## What

Closes the follow-up flagged in Slice 3c (#3728): **a single-facet personal edit must not wipe the actor's other personal facets.** Default-OFF, FE-only, no backend/flag change.

## Problem
The backend `PUT /views/:id/personal-config` **replaces** the whole config row. Slice 3's in-place personal edits (`persistViewConfig`) send only the edited facet — so in personal mode, changing sort dropped personal filter/hidden/fieldOrder (violates design-lock §1-D "additive").

## Fix
`utils/personal-config-write.ts` `writePersonalConfigMerged` does **read-merge-write** (GET current → `{ ...base, ...patch }` → PUT). `persistViewConfig`'s personal branch calls it; the shared `updateView` path is unchanged. Clearing still works (patch facet `= undefined` → `JSON.stringify` drops it → backend `sanitize` omits; facets absent from the patch are preserved). Same pattern Slice 3c uses for column reorder.

## Goldens — `multitable-grid-personal-additive-write.spec.ts`, 7/7
- **core (the ask):** existing `{filter, sort, hidden}` + single-facet `{hiddenFieldIds}` edit ⇒ filter & sort preserved.
- `{sortInfo}` edit preserves existing personal `fieldOrder` + filter (cross-facet).
- no-row ⇒ writes just the patch; GET-404 ⇒ still writes, no throw; clear via `undefined`.
- **grid wiring:** personal ON — `toggleFieldVisibility` merges over existing config (sort preserved), `updateView` NOT called; OFF — shared `updateView`, no personal-config call.

Regression: `multitable-grid` → **14 files / 132 tests pass**; vue-tsc clean; caught by the `multitable-web-guard` `multitable-grid` filter (no workflow change).

## Notes
Generalizes Slice 3c's read-merge-write to in-place edits; when #3728 merges, the two read-merge-write helpers can be deduped (non-blocking). Branches off current `origin/main` (without #3728) — a trivial rebase may be needed depending on merge order.

Built by the unattended autonomous cadence loop — **for-review only, not merged, no flag/protection change.**

Grounded on `origin/main` @ `0315bcf3c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)