### PR TITLE
feat(web): UF-6 style lint gate — inline-style purge + hardcoded-color guard on the UF surface set

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -90,6 +90,20 @@ on:
       - 'apps/web/src/views/WorkflowHubView.vue'
       - 'apps/web/src/views/workflowHubLabels.ts'
       - 'apps/web/tests/workflowHubView.spec.ts'
+      # UF-6 (design-lock §6): style="..." purge + hardcoded-hex-in-<style> lint across the full
+      # UF surface set. Files below round out that set beyond what earlier UF slices already
+      # listed (ApprovalDetailView/ApprovalNewView/TemplateAuthoringView/ApprovalMetricsView/
+      # TemplateCenterView/TemplateDetailView/DelegationSettingsView/MyDelegationView/PageShell/
+      # PageHeader/ApprovalMobileList/ApprovalCenterView/ApprovalCenterTable/StatusTag/
+      # ApprovalInboxView above).
+      - 'apps/web/src/views/approval/ApprovalCardDecisionView.vue'
+      - 'apps/web/src/views/AutomationExecutionsView.vue'
+      - 'apps/web/src/views/WorkflowDesigner.vue'
+      - 'apps/web/src/multitable/components/MetaAutomationManager.vue'
+      - 'apps/web/src/multitable/components/MetaAutomationRuleEditor.vue'
+      - 'apps/web/src/styles/form-layout-utilities.css'
+      - 'apps/web/.eslintrc.cjs'
+      - 'apps/web/tests/ui-foundation-style-guard.spec.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -167,6 +181,20 @@ on:
       - 'apps/web/src/views/WorkflowHubView.vue'
       - 'apps/web/src/views/workflowHubLabels.ts'
       - 'apps/web/tests/workflowHubView.spec.ts'
+      # UF-6 (design-lock §6): style="..." purge + hardcoded-hex-in-<style> lint across the full
+      # UF surface set. Files below round out that set beyond what earlier UF slices already
+      # listed (ApprovalDetailView/ApprovalNewView/TemplateAuthoringView/ApprovalMetricsView/
+      # TemplateCenterView/TemplateDetailView/DelegationSettingsView/MyDelegationView/PageShell/
+      # PageHeader/ApprovalMobileList/ApprovalCenterView/ApprovalCenterTable/StatusTag/
+      # ApprovalInboxView above).
+      - 'apps/web/src/views/approval/ApprovalCardDecisionView.vue'
+      - 'apps/web/src/views/AutomationExecutionsView.vue'
+      - 'apps/web/src/views/WorkflowDesigner.vue'
+      - 'apps/web/src/multitable/components/MetaAutomationManager.vue'
+      - 'apps/web/src/multitable/components/MetaAutomationRuleEditor.vue'
+      - 'apps/web/src/styles/form-layout-utilities.css'
+      - 'apps/web/.eslintrc.cjs'
+      - 'apps/web/tests/ui-foundation-style-guard.spec.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -247,4 +275,11 @@ jobs:
         # locale → English everywhere, no mixed card), the chip/status/role/source enum labels
         # resolve through the key-table (not bare English enum values), the pager range label is
         # locale-aware, and a static tripwire against the original hardcoded-English literals.
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView --reporter=dot
+        # UF-6: style="..." purge + hardcoded-hex-in-<style> lint across the UF surface set
+        # (approval views + ApprovalInboxView/AutomationExecutionsView/WorkflowHubView/
+        # WorkflowDesigner + PageHeader/PageShell/StatusTag + MetaAutomationManager/
+        # MetaAutomationRuleEditor). ui-foundation-style-guard.spec.ts fs-reads all 21 target
+        # files and asserts zero static style= attributes and zero hex/rgb() literals inside
+        # <style> blocks (var() references + transparent/inherit/currentColor/none allowed);
+        # had no gate before this wiring.
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView ui-foundation-style-guard --reporter=dot

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -50,5 +50,43 @@ module.exports = {
         vi: 'readonly',
       },
     },
+    // UI foundation design-lock (docs/development/ui-foundation-design-lock-20260706.md §6
+    // UF-6): "ESLint 禁 style=" scoped to the migrated UF surface set. `allowBinding: true`
+    // only forbids the static `style="..."` attribute — it does NOT police `:style="{...}"`
+    // bindings (several of these views legitimately compute layout via :style, e.g. the
+    // TemplateAuthoringView canvas), matching the fs-source guard's scope
+    // (tests/ui-foundation-style-guard.spec.ts). Note: apps/web's `lint` script invokes eslint
+    // with an explicit file list that today only includes WorkflowDesigner.vue/
+    // WorkflowHubView.vue from this set, so the ui-foundation-style-guard.spec.ts vitest gate
+    // — not `pnpm lint` — is the CI-enforced check for the rest of the set; this override
+    // still makes the rule active for IDE feedback and any future `pnpm lint` glob expansion.
+    {
+      files: [
+        'src/views/approval/ApprovalCardDecisionView.vue',
+        'src/views/approval/ApprovalCenterTable.vue',
+        'src/views/approval/ApprovalCenterView.vue',
+        'src/views/approval/ApprovalDetailView.vue',
+        'src/views/approval/ApprovalMetricsView.vue',
+        'src/views/approval/ApprovalMobileList.vue',
+        'src/views/approval/ApprovalNewView.vue',
+        'src/views/approval/DelegationSettingsView.vue',
+        'src/views/approval/MyDelegationView.vue',
+        'src/views/approval/TemplateAuthoringView.vue',
+        'src/views/approval/TemplateCenterView.vue',
+        'src/views/approval/TemplateDetailView.vue',
+        'src/views/ApprovalInboxView.vue',
+        'src/views/AutomationExecutionsView.vue',
+        'src/views/WorkflowHubView.vue',
+        'src/views/WorkflowDesigner.vue',
+        'src/components/layout/PageHeader.vue',
+        'src/components/layout/PageShell.vue',
+        'src/components/status/StatusTag.vue',
+        'src/multitable/components/MetaAutomationManager.vue',
+        'src/multitable/components/MetaAutomationRuleEditor.vue',
+      ],
+      rules: {
+        'vue/no-static-inline-styles': ['error', { allowBinding: true }],
+      },
+    },
   ],
 }

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -14,6 +14,10 @@ import './styles/tokens.css'
 // here once so multitable Calendar view, attendance personal calendar, and
 // holiday admin section all see the same `--calendar-source-accent` vars.
 import './styles/calendar-source-palette.css'
+// Shared form-layout utility classes (UF-6) — replaces the inline
+// `style="width: …"` / `style="margin-…"` attributes purged from the
+// approval/workflow surface set so the no-static-style= gate has a home.
+import './styles/form-layout-utilities.css'
 import App from './App.vue'
 import { useAuth } from './composables/useAuth'
 import { resolveAdminRouteRedirect } from './router/adminAccess'

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -150,7 +150,7 @@
                 ? '配置的审批模板完成时触发。该触发器无记录上下文：动作仅支持通知类（站内通知 / Webhook / 邮件 / 钉钉消息），不支持记录读写与发起审批，且不支持触发条件；创建者需持有审批读取权限并对该模板可见（保存与触发时均校验）。'
                 : 'Fires when the configured approval template completes. Record-less: only notification-family actions (notification / webhook / email / DingTalk) are allowed — no record actions, no start-approval, no conditions; the rule creator must hold approvals read permission and template visibility (checked at save AND at fire).' }}
             </div>
-            <div v-if="approvalCompletedBlockReason" class="meta-rule-editor__hint" data-field="approvalCompletedBlockReason" style="color: var(--ms-color-danger);">
+            <div v-if="approvalCompletedBlockReason" class="meta-rule-editor__hint meta-rule-editor__hint--danger" data-field="approvalCompletedBlockReason">
               {{ approvalCompletedBlockReason }}
             </div>
           </template>
@@ -168,7 +168,7 @@
                 ? '该模板产生新的审批待办（每位受理人一条）时触发。退回/跳转形成的新一轮待办会再次触发；同一轮重复投递自动去重。无记录上下文：动作仅支持通知类，不支持记录读写与发起审批，且不支持触发条件；创建者需持有审批读取权限并对该模板可见（保存与触发时均校验）。'
                 : 'Fires when this template produces a NEW pending approval task (one per recipient). A returned/jumped node fires again for its fresh round; duplicate deliveries of the same round dedupe. Record-less: only notification-family actions — no record actions, no start-approval, no conditions; the rule creator must hold approvals read permission and template visibility (checked at save AND at fire).' }}
             </div>
-            <div v-if="approvalTaskCreatedBlockReason" class="meta-rule-editor__hint" data-field="approvalTaskCreatedBlockReason" style="color: var(--ms-color-danger);">
+            <div v-if="approvalTaskCreatedBlockReason" class="meta-rule-editor__hint meta-rule-editor__hint--danger" data-field="approvalTaskCreatedBlockReason">
               {{ approvalTaskCreatedBlockReason }}
             </div>
           </template>
@@ -3484,6 +3484,7 @@ function onTestRun() {
 .meta-rule-editor__hint--error { color: var(--el-color-danger-dark-2); }
 
 .meta-rule-editor__hint--warning { color: var(--el-color-warning-dark-2); }
+.meta-rule-editor__hint--danger { color: var(--ms-color-danger); }
 
 .meta-rule-editor__test-run-feedback {
   flex: 1 1 280px;

--- a/apps/web/src/styles/form-layout-utilities.css
+++ b/apps/web/src/styles/form-layout-utilities.css
@@ -1,0 +1,83 @@
+/**
+ * MetaSheet form-layout utility classes — UF-6.
+ *
+ * Per the UI foundation design-lock §6 (UF-6), inline `style="..."` attributes
+ * are banned in the approval/workflow-automation surface set (ESLint gate).
+ * The residual inline styles were almost all one-off widths/margins on form
+ * controls (el-select/el-input width, spacing between inline form fields).
+ * These utility classes replace them so the "no static style=" rule has
+ * somewhere to land, without inventing a general-purpose CSS framework —
+ * only the exact values that were actually in use across 3+ views are here.
+ *
+ * Values intentionally match the pre-existing pixel widths (visual
+ * byte-for-byte parity); this is a mechanical `style=` -> `class=` move, not
+ * a redesign.
+ */
+
+.ms-w-100pct {
+  width: 100%;
+}
+
+.ms-w-110 {
+  width: 110px;
+}
+
+.ms-w-120 {
+  width: 120px;
+}
+
+.ms-w-130 {
+  width: 130px;
+}
+
+.ms-w-140 {
+  width: 140px;
+}
+
+.ms-w-160 {
+  width: 160px;
+}
+
+.ms-w-200 {
+  width: 200px;
+}
+
+.ms-w-220 {
+  width: 220px;
+}
+
+.ms-w-240 {
+  width: 240px;
+}
+
+.ms-w-320 {
+  width: 320px;
+}
+
+.ms-w-360 {
+  width: 360px;
+}
+
+.ms-flex-1 {
+  flex: 1;
+}
+
+.ms-mr-4 {
+  margin-right: var(--ms-space-1);
+}
+
+.ms-mr-8 {
+  margin-right: var(--ms-space-2);
+}
+
+.ms-mr-12 {
+  margin-right: var(--ms-space-3);
+}
+
+.ms-ml-8 {
+  margin-left: var(--ms-space-2);
+}
+
+.ms-ml-12 {
+  margin-left: var(--ms-space-3);
+}

--- a/apps/web/src/views/ApprovalInboxView.vue
+++ b/apps/web/src/views/ApprovalInboxView.vue
@@ -400,7 +400,7 @@ onMounted(() => {
 
 .approval-inbox__header p {
   margin: 6px 0 0;
-  color: #6b7280;
+  color: var(--ms-text-2);
 }
 
 .approval-inbox__layout {
@@ -410,8 +410,8 @@ onMounted(() => {
 }
 
 .approval-inbox__card {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--ms-bg-card);
+  border: 1px solid var(--ms-border-light);
   border-radius: 16px;
   padding: 20px;
   display: grid;
@@ -422,8 +422,8 @@ onMounted(() => {
   min-width: 32px;
   padding: 4px 10px;
   border-radius: 999px;
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
   text-align: center;
   font-size: 12px;
   font-weight: 600;
@@ -432,12 +432,12 @@ onMounted(() => {
 .approval-inbox__comment {
   display: grid;
   gap: 8px;
-  color: #475569;
+  color: var(--ms-text-2);
 }
 
 .approval-inbox__comment input {
   min-height: 40px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--ms-border);
   border-radius: 10px;
   padding: 0 12px;
 }
@@ -451,13 +451,13 @@ onMounted(() => {
 .approval-inbox__table th,
 .approval-inbox__table td {
   padding: 10px 12px;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--ms-bg-page);
   text-align: left;
   vertical-align: top;
 }
 
 .approval-inbox__row--active {
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .approval-inbox__actions {
@@ -471,18 +471,18 @@ onMounted(() => {
 .approval-inbox__status {
   padding: 18px;
   border-radius: 12px;
-  background: #f8fafc;
-  color: #475569;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .approval-inbox__error {
-  background: #fef2f2;
-  color: #b91c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
 }
 
 .approval-inbox__status {
-  background: #ecfdf5;
-  color: #047857;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .btn {
@@ -493,15 +493,15 @@ onMounted(() => {
   min-height: 36px;
   padding: 0 14px;
   border-radius: 10px;
-  border: 1px solid #d1d5db;
-  background: #fff;
-  color: #111827;
+  border: 1px solid var(--ms-border);
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
   text-decoration: none;
   cursor: pointer;
 }
 
 .btn--ghost {
-  background: #fff;
+  background: var(--ms-bg-card);
 }
 
 .btn--mini {

--- a/apps/web/src/views/AutomationExecutionsView.vue
+++ b/apps/web/src/views/AutomationExecutionsView.vue
@@ -307,33 +307,33 @@ if (isAdmin) void loadData()
 <style scoped>
 .automation-runs { padding: 20px 24px; max-width: 1000px; margin: 0 auto; }
 .automation-runs__header { margin-bottom: 16px; }
-.automation-runs__title { margin: 0; font-size: 20px; font-weight: 700; color: #0f172a; }
-.automation-runs__subtitle { margin: 4px 0 0; font-size: 13px; color: #64748b; }
-.automation-runs__denied { padding: 14px 16px; border-radius: 10px; background: #fef2f2; color: #b91c1c; font-size: 14px; }
+.automation-runs__title { margin: 0; font-size: 20px; font-weight: 700; color: var(--ms-text-1); }
+.automation-runs__subtitle { margin: 4px 0 0; font-size: 13px; color: var(--ms-text-2); }
+.automation-runs__denied { padding: 14px 16px; border-radius: 10px; background: var(--el-color-danger-light-9); color: var(--el-color-danger-dark-2); font-size: 14px; }
 .automation-runs__toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
-.automation-runs__select, .automation-runs__input { border: 1px solid #cbd5e1; border-radius: 8px; padding: 6px 10px; font-size: 13px; background: #fff; }
-.automation-runs__btn { border: 1px solid #cbd5e1; border-radius: 8px; padding: 6px 14px; background: #fff; color: #0f172a; font-size: 13px; cursor: pointer; }
-.automation-runs__empty { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: #f8fafc; color: #64748b; }
-.automation-runs__error { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: #fef2f2; color: #b91c1c; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
-.automation-runs__item { border: 1px solid #e2e8f0; border-radius: 8px; padding: 10px 12px; cursor: pointer; margin-bottom: 8px; }
-.automation-runs__item:hover { background: #f8fafc; }
+.automation-runs__select, .automation-runs__input { border: 1px solid var(--ms-border); border-radius: 8px; padding: 6px 10px; font-size: 13px; background: var(--ms-bg-card); }
+.automation-runs__btn { border: 1px solid var(--ms-border); border-radius: 8px; padding: 6px 14px; background: var(--ms-bg-card); color: var(--ms-text-1); font-size: 13px; cursor: pointer; }
+.automation-runs__empty { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: var(--ms-bg-page); color: var(--ms-text-2); }
+.automation-runs__error { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: var(--el-color-danger-light-9); color: var(--el-color-danger-dark-2); display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
+.automation-runs__item { border: 1px solid var(--ms-border-light); border-radius: 8px; padding: 10px 12px; cursor: pointer; margin-bottom: 8px; }
+.automation-runs__item:hover { background: var(--ms-bg-page); }
 .automation-runs__summary { display: flex; align-items: center; gap: 10px; font-size: 13px; flex-wrap: wrap; }
-.automation-runs__time { color: #64748b; min-width: 150px; }
-.automation-runs__rule { color: #334155; font-weight: 600; }
-.automation-runs__sheet { color: #475569; }
-.automation-runs__trigger { color: #475569; }
-.automation-runs__duration { margin-left: auto; color: #94a3b8; }
+.automation-runs__time { color: var(--ms-text-2); min-width: 150px; }
+.automation-runs__rule { color: var(--ms-text-2); font-weight: 600; }
+.automation-runs__sheet { color: var(--ms-text-2); }
+.automation-runs__trigger { color: var(--ms-text-2); }
+.automation-runs__duration { margin-left: auto; color: var(--ms-text-3); }
 /* UF-3: the run/step status badges are now <StatusTag domain="automationRun"> (utils/
    statusDomains.ts) — this file's own uppercase/hex badge palette (one of six independent
    status-color implementations the UI foundation design-lock audit found) is removed. */
-.automation-runs__detail { margin-top: 8px; padding-top: 8px; border-top: 1px solid #e2e8f0; display: flex; flex-direction: column; gap: 6px; }
-.automation-runs__detail-h { margin: 6px 0 2px; font-size: 12px; font-weight: 700; color: #475569; text-transform: uppercase; }
+.automation-runs__detail { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--ms-border-light); display: flex; flex-direction: column; gap: 6px; }
+.automation-runs__detail-h { margin: 6px 0 2px; font-size: 12px; font-weight: 700; color: var(--ms-text-2); text-transform: uppercase; }
 .automation-runs__step { display: flex; align-items: center; gap: 8px; font-size: 12px; flex-wrap: wrap; }
-.automation-runs__step-key { font-weight: 700; color: #2563eb; }
-.automation-runs__step--branch-child { margin-left: 20px; border-left: 2px solid #e2e8f0; padding-left: 8px; }
-.automation-runs__branch-child { color: #64748b; font-size: 11px; }
-.automation-runs__branch-selection { width: 100%; padding: 4px 8px; background: #eff6ff; color: #1d4ed8; border-radius: 4px; font-size: 11px; font-weight: 600; }
-.automation-runs__step-error { width: 100%; padding: 4px 8px; background: #fef2f2; color: #dc2626; border-radius: 4px; font-size: 11px; }
-.automation-runs__step-output { width: 100%; padding: 4px 8px; background: #f8fafc; color: #475569; border-radius: 4px; font-size: 11px; word-break: break-all; }
-.automation-runs__json { width: 100%; margin: 0; padding: 8px; background: #f8fafc; color: #334155; border-radius: 6px; font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 200px; overflow: auto; }
+.automation-runs__step-key { font-weight: 700; color: var(--ms-color-primary); }
+.automation-runs__step--branch-child { margin-left: 20px; border-left: 2px solid var(--ms-border-light); padding-left: 8px; }
+.automation-runs__branch-child { color: var(--ms-text-2); font-size: 11px; }
+.automation-runs__branch-selection { width: 100%; padding: 4px 8px; background: var(--el-color-primary-light-9); color: var(--el-color-primary-dark-2); border-radius: 4px; font-size: 11px; font-weight: 600; }
+.automation-runs__step-error { width: 100%; padding: 4px 8px; background: var(--el-color-danger-light-9); color: var(--ms-color-danger); border-radius: 4px; font-size: 11px; }
+.automation-runs__step-output { width: 100%; padding: 4px 8px; background: var(--ms-bg-page); color: var(--ms-text-2); border-radius: 4px; font-size: 11px; word-break: break-all; }
+.automation-runs__json { width: 100%; margin: 0; padding: 8px; background: var(--ms-bg-page); color: var(--ms-text-2); border-radius: 6px; font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 200px; overflow: auto; }
 </style>

--- a/apps/web/src/views/WorkflowDesigner.vue
+++ b/apps/web/src/views/WorkflowDesigner.vue
@@ -862,42 +862,10 @@ watch(isDirty, (dirty) => {
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  background: #f4f8ff;
-  border-bottom: 1px solid #d9e7ff;
-  color: #315ea8;
+  background: var(--el-color-primary-light-9);
+  border-bottom: 1px solid var(--el-color-primary-light-8);
+  color: var(--el-color-primary-dark-2);
   font-size: 13px;
-}
-
-/* Header */
-.designer-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  background: var(--el-bg-color);
-  border-bottom: 1px solid var(--el-border-color-light);
-}
-
-.header-left {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.workflow-name {
-  font-size: 16px;
-  font-weight: 500;
-}
-
-.header-center {
-  display: flex;
-  align-items: center;
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 /* Main Content */
@@ -908,111 +876,13 @@ watch(isDirty, (dirty) => {
   position: relative;
 }
 
-/* Tool Palette */
-.tool-palette {
-  width: 200px;
-  background: var(--el-bg-color);
-  border-right: 1px solid var(--el-border-color-light);
-  overflow-y: auto;
-  padding: 12px;
-}
-
-.palette-section {
-  margin-bottom: 16px;
-}
-
-.section-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--el-text-color-secondary);
-  text-transform: uppercase;
-  margin-bottom: 8px;
-  padding-left: 4px;
-}
-
-.palette-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px;
-  border-radius: 6px;
-  cursor: grab;
-  transition: background 0.2s;
-  margin-bottom: 4px;
-}
-
-.palette-item:hover {
-  background: var(--el-fill-color-light);
-}
-
-.palette-item:active {
-  cursor: grabbing;
-}
-
-.item-icon {
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  font-size: 14px;
-}
-
-.item-label {
-  font-size: 13px;
-  color: var(--el-text-color-regular);
-}
-
-/* Canvas Container */
-.canvas-container {
-  flex: 1;
-  position: relative;
-  overflow: hidden;
-}
-
-.bpmn-canvas {
-  width: 100%;
-  height: 100%;
-}
-
-.drop-zone {
-  position: absolute;
-  inset: 0;
-  background: rgba(64, 158, 255, 0.1);
-  border: 2px dashed var(--el-color-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 18px;
-  color: var(--el-color-primary);
-  pointer-events: all;
-}
-
-/* Properties Panel */
-.properties-panel {
-  width: 280px;
-  background: var(--el-bg-color);
-  border-left: 1px solid var(--el-border-color-light);
-  display: flex;
-  flex-direction: column;
-}
-
-.panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--el-border-color-light);
-  font-weight: 500;
-}
-
-.panel-content {
-  flex: 1;
-  padding: 16px;
-  overflow-y: auto;
-}
+/* dead CSS removed (UF-6): .designer-header/.header-left/.workflow-name/.header-center/
+   .header-right/.tool-palette/.palette-section/.section-title/.palette-item/.item-icon/
+   .item-label/.canvas-container/.bpmn-canvas/.drop-zone/.properties-panel/.panel-header/
+   .panel-content styled nothing — this markup was extracted into WorkflowDesignerToolbar,
+   WorkflowPalette, WorkflowCanvasShell and WorkflowPropertyPanel; verified zero template
+   references to these class names before deletion (design-lock §8 allows dead-CSS deletion
+   here without touching the canvas body itself). */
 
 /* Slide animation */
 .slide-right-enter-active,
@@ -1090,8 +960,8 @@ watch(isDirty, (dirty) => {
 .template-dialog__recent {
   padding: 14px;
   border-radius: 12px;
-  border: 1px solid #dbeafe;
-  background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 100%);
+  border: 1px solid var(--el-color-primary-light-8);
+  background: linear-gradient(180deg, var(--ms-bg-card) 0%, var(--el-color-primary-light-9) 100%);
 }
 
 .template-dialog__toolbar,
@@ -1116,7 +986,7 @@ watch(isDirty, (dirty) => {
   padding: 14px;
   border-radius: 12px;
   border: 1px solid var(--el-border-color-light);
-  background: #fff;
+  background: var(--ms-bg-card);
   text-align: left;
   display: grid;
   gap: 10px;
@@ -1125,7 +995,7 @@ watch(isDirty, (dirty) => {
 
 .template-dialog__item.is-active {
   border-color: var(--el-color-primary);
-  box-shadow: 0 0 0 1px rgba(64, 158, 255, 0.12);
+  box-shadow: 0 0 0 1px var(--el-color-primary-light-7);
 }
 
 .template-dialog__item p,
@@ -1155,25 +1025,25 @@ watch(isDirty, (dirty) => {
 }
 
 .template-dialog__badge {
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
 }
 
 .template-dialog__badge[data-source='builtin'] {
-  background: #ecfccb;
-  color: #3f6212;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .template-dialog__badge[data-source='database'] {
-  background: #ede9fe;
-  color: #7c3aed;
+  background: var(--el-color-info-light-9);
+  color: var(--el-color-info-dark-2);
 }
 
 .template-dialog__detail {
   border: 1px solid var(--el-border-color-light);
   border-radius: 14px;
   padding: 16px;
-  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  background: linear-gradient(180deg, var(--ms-bg-card) 0%, var(--ms-bg-page) 100%);
 }
 
 .template-dialog__detail-header {
@@ -1204,24 +1074,24 @@ watch(isDirty, (dirty) => {
 }
 
 .template-dialog__tag {
-  background: #f3f4f6;
-  color: #374151;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .template-dialog__recent-chip {
-  border: 1px solid #dbeafe;
-  background: #fff;
+  border: 1px solid var(--el-color-primary-light-8);
+  background: var(--ms-bg-card);
   border-radius: 999px;
   padding: 8px 12px;
   display: inline-flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  color: #1f2937;
+  color: var(--ms-text-1);
 }
 
 .template-dialog__recent-chip small {
-  color: #64748b;
+  color: var(--ms-text-2);
   text-transform: uppercase;
 }
 
@@ -1229,13 +1099,13 @@ watch(isDirty, (dirty) => {
 .template-dialog__error {
   padding: 18px;
   border-radius: 12px;
-  background: #f8fafc;
-  color: #475569;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .template-dialog__error {
-  background: #fef2f2;
-  color: #b91c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
 }
 
 @media (max-width: 960px) {

--- a/apps/web/src/views/WorkflowHubView.vue
+++ b/apps/web/src/views/WorkflowHubView.vue
@@ -904,7 +904,7 @@ watch(
 .workflow-hub__template-top p,
 .workflow-hub__secondary {
   margin: 6px 0 0;
-  color: #6b7280;
+  color: var(--ms-text-2);
 }
 
 .workflow-hub__grid {
@@ -918,8 +918,8 @@ watch(
   gap: 12px;
   padding: 18px;
   border-radius: 18px;
-  border: 1px solid #dbeafe;
-  background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 100%);
+  border: 1px solid var(--el-color-primary-light-8);
+  background: linear-gradient(180deg, var(--ms-bg-card) 0%, var(--el-color-primary-light-9) 100%);
 }
 
 .workflow-hub__saved-list {
@@ -929,12 +929,12 @@ watch(
 }
 
 .workflow-hub__saved-card {
-  border: 1px solid #dbeafe;
+  border: 1px solid var(--el-color-primary-light-8);
   border-radius: 14px;
   padding: 14px;
   display: grid;
   gap: 10px;
-  background: #fff;
+  background: var(--ms-bg-card);
 }
 
 .workflow-hub__actions,
@@ -950,8 +950,8 @@ watch(
 }
 
 .workflow-hub__card {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--ms-bg-card);
+  border: 1px solid var(--ms-border-light);
   border-radius: 18px;
   padding: 20px;
   display: grid;
@@ -971,58 +971,58 @@ watch(
 }
 
 .workflow-hub__count {
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
 }
 
 .chip {
-  background: #f3f4f6;
-  color: #374151;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .chip[data-tone='draft'] {
-  background: #fff7ed;
-  color: #c2410c;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
 }
 
 .chip[data-tone='published'] {
-  background: #ecfdf5;
-  color: #047857;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .chip[data-tone='archived'] {
-  background: #f3f4f6;
-  color: #6b7280;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .chip[data-tone='owner'] {
-  background: #ede9fe;
-  color: #6d28d9;
+  background: var(--el-color-info-light-9);
+  color: var(--el-color-info-dark-2);
 }
 
 .chip[data-tone='editor'] {
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
 }
 
 .chip[data-tone='viewer'] {
-  background: #f3f4f6;
-  color: #4b5563;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .chip[data-tone='builtin'] {
-  background: #ecfccb;
-  color: #3f6212;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .chip[data-tone='database'] {
-  background: #ede9fe;
-  color: #7c3aed;
+  background: var(--el-color-info-light-9);
+  color: var(--el-color-info-dark-2);
 }
 
 .tag {
-  background: #f8fafc;
-  color: #475569;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .workflow-hub__table {
@@ -1034,7 +1034,7 @@ watch(
 .workflow-hub__table th,
 .workflow-hub__table td {
   padding: 10px 12px;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--ms-bg-page);
   text-align: left;
   vertical-align: top;
 }
@@ -1053,8 +1053,8 @@ watch(
   gap: 12px;
   padding: 16px;
   border-radius: 16px;
-  border: 1px solid #dbeafe;
-  background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 100%);
+  border: 1px solid var(--el-color-primary-light-8);
+  background: linear-gradient(180deg, var(--ms-bg-card) 0%, var(--el-color-primary-light-9) 100%);
 }
 
 .workflow-hub__recent-list {
@@ -1063,36 +1063,36 @@ watch(
 }
 
 .workflow-hub__recent-card {
-  border: 1px solid #dbeafe;
+  border: 1px solid var(--el-color-primary-light-8);
   border-radius: 14px;
   padding: 14px;
   display: grid;
   gap: 10px;
-  background: #fff;
+  background: var(--ms-bg-card);
 }
 
 .workflow-hub__template-card {
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--ms-border-light);
   border-radius: 14px;
   padding: 14px;
   display: grid;
   gap: 12px;
-  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  background: linear-gradient(180deg, var(--ms-bg-card) 0%, var(--ms-bg-page) 100%);
 }
 
 .workflow-hub__meta-row {
   font-size: 12px;
-  color: #64748b;
+  color: var(--ms-text-2);
 }
 
 .workflow-hub__input,
 .workflow-hub__select {
   min-height: 38px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--ms-border);
   border-radius: 10px;
   padding: 0 12px;
-  background: #fff;
-  color: #111827;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
 }
 
 .workflow-hub__input {
@@ -1108,13 +1108,13 @@ watch(
 .workflow-hub__error {
   padding: 18px;
   border-radius: 12px;
-  background: #f8fafc;
-  color: #475569;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .workflow-hub__error {
-  background: #fef2f2;
-  color: #b91c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
 }
 
 .btn {
@@ -1125,21 +1125,21 @@ watch(
   min-height: 36px;
   padding: 0 14px;
   border-radius: 10px;
-  border: 1px solid #d1d5db;
-  background: #fff;
-  color: #111827;
+  border: 1px solid var(--ms-border);
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
   text-decoration: none;
   cursor: pointer;
 }
 
 .btn--primary {
-  background: #111827;
-  border-color: #111827;
-  color: #fff;
+  background: var(--ms-text-1);
+  border-color: var(--ms-text-1);
+  color: var(--ms-bg-card);
 }
 
 .btn--ghost {
-  background: #fff;
+  background: var(--ms-bg-card);
 }
 
 .btn--mini {

--- a/apps/web/src/views/approval/ApprovalCardDecisionView.vue
+++ b/apps/web/src/views/approval/ApprovalCardDecisionView.vue
@@ -246,7 +246,7 @@ onMounted(load)
 }
 
 .card-decision__meta {
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
   font-size: 13px;
   margin: 2px 0;
 }
@@ -254,7 +254,7 @@ onMounted(load)
 .card-decision__label {
   display: block;
   font-size: 13px;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
   margin-bottom: 6px;
 }
 
@@ -264,7 +264,7 @@ onMounted(load)
   position: sticky;
   bottom: 0;
   padding: 8px 0 calc(8px + env(safe-area-inset-bottom));
-  background: var(--el-bg-color, #fff);
+  background: var(--el-bg-color);
 }
 
 .card-decision__actions .el-button {
@@ -273,7 +273,7 @@ onMounted(load)
 }
 
 .card-decision__hint {
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
   font-size: 12px;
   margin: 0;
 }

--- a/apps/web/src/views/approval/ApprovalCenterTable.vue
+++ b/apps/web/src/views/approval/ApprovalCenterTable.vue
@@ -4,7 +4,7 @@
     v-loading="loading"
     :data="rows"
     size="default"
-    style="width: 100%"
+    class="ms-w-100pct"
     max-height="560"
     stripe
     highlight-current-row
@@ -165,7 +165,7 @@ defineExpose({
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 12px;
-  color: #909399;
+  color: var(--el-text-color-secondary);
 }
 
 /* B1-03: 已等待 aging severity — normal inherits the surrounding text color; warn/urgent escalate. */
@@ -173,20 +173,20 @@ defineExpose({
   display: inline-block;
   margin-right: 8px;
   font-size: 13px;
-  color: #606266;
+  color: var(--el-text-color-regular);
 }
 
 .approval-center__wait--warn {
-  color: #e6a23c;
+  color: var(--el-color-warning);
 }
 
 .approval-center__wait--urgent {
-  color: #f56c6c;
+  color: var(--el-color-danger);
 }
 
 .approval-center__wait-progress {
   margin-top: 2px;
   font-size: 12px;
-  color: #909399;
+  color: var(--el-text-color-secondary);
 }
 </style>

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -961,13 +961,13 @@ onMounted(() => {
 
 .approval-center__selection-count {
   margin-right: auto;
-  color: #4b5563;
+  color: var(--ms-text-2);
   font-size: 13px;
 }
 
 .approval-center__batch-reject-summary {
   margin: 0 0 12px;
-  color: #4b5563;
+  color: var(--ms-text-2);
   font-size: 14px;
 }
 
@@ -976,20 +976,20 @@ onMounted(() => {
   display: inline-block;
   margin-right: 8px;
   font-size: 13px;
-  color: #606266;
+  color: var(--el-text-color-regular);
 }
 
 .approval-center__wait--warn {
-  color: #e6a23c;
+  color: var(--el-color-warning);
 }
 
 .approval-center__wait--urgent {
-  color: #f56c6c;
+  color: var(--el-color-danger);
 }
 
 .approval-center__row-reject-summary {
   margin: 0 0 12px;
-  color: #4b5563;
+  color: var(--ms-text-2);
   font-size: 14px;
 }
 
@@ -999,7 +999,7 @@ onMounted(() => {
 
 .approval-center__batch-result-summary {
   margin: 0 0 12px;
-  color: #4b5563;
+  color: var(--ms-text-2);
   font-size: 14px;
 }
 
@@ -1013,7 +1013,7 @@ onMounted(() => {
 
 .approval-center__batch-result-item {
   padding: 8px 0;
-  border-bottom: 1px solid #ebeef5;
+  border-bottom: 1px solid var(--el-border-color-lighter);
 }
 
 .approval-center__batch-result-item:last-child {
@@ -1022,13 +1022,13 @@ onMounted(() => {
 
 .approval-center__batch-result-item-title {
   font-size: 14px;
-  color: #303133;
+  color: var(--el-text-color-primary);
 }
 
 .approval-center__batch-result-item-message {
   margin-top: 2px;
   font-size: 13px;
-  color: #f56c6c;
+  color: var(--el-color-danger);
 }
 
 .approval-center__attendance-entry {
@@ -1038,9 +1038,9 @@ onMounted(() => {
   gap: 16px;
   padding: 14px 16px;
   margin-bottom: 12px;
-  border: 1px solid #dbeafe;
+  border: 1px solid var(--el-color-primary-light-8);
   border-radius: 8px;
-  background: #eff6ff;
+  background: var(--el-color-primary-light-9);
 }
 
 .approval-center__attendance-entry-copy {
@@ -1049,13 +1049,13 @@ onMounted(() => {
 }
 
 .approval-center__attendance-entry-copy strong {
-  color: #1f2937;
+  color: var(--ms-text-1);
   font-size: 14px;
 }
 
 .approval-center__attendance-entry-copy p {
   margin: 0;
-  color: #4b5563;
+  color: var(--ms-text-2);
   font-size: 13px;
   line-height: 1.5;
 }

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -358,7 +358,7 @@
               data-testid="approval-remind-button"
               @click="handleRemind"
             >
-              <el-icon style="margin-right: 4px"><Bell /></el-icon>催一下
+              <el-icon class="ms-mr-4"><Bell /></el-icon>催一下
             </el-button>
             <el-popconfirm
               v-if="isRequester && !isMobileLayout"
@@ -380,7 +380,7 @@
             type="info"
             show-icon
             :closable="false"
-            style="flex: 1"
+            class="ms-flex-1"
           />
           <!-- UX B2-13: 再次提交 — own+terminal (rejected/revoked/cancelled) only; see
                `canResubmit`/`handleResubmit`. -->
@@ -553,7 +553,7 @@
             v-model="reduceSignUserId"
             filterable
             placeholder="选择要移除的加签人"
-            style="width: 100%"
+            class="ms-w-100pct"
             data-testid="approval-reduce-sign-user"
           >
             <el-option
@@ -642,7 +642,7 @@
     >
       <el-form>
         <el-form-item label="退回至节点">
-          <el-select v-model="returnTargetNodeKey" placeholder="选择退回目标节点" style="width: 100%">
+          <el-select v-model="returnTargetNodeKey" placeholder="选择退回目标节点" class="ms-w-100pct">
             <el-option
               v-for="node in returnableNodes"
               :key="node.key"
@@ -1491,8 +1491,8 @@ onMounted(async () => {
 
 .approval-detail__form,
 .approval-detail__timeline {
-  background: #fff;
-  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  background: var(--ms-bg-card);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
   padding: 20px;
 }
@@ -1518,7 +1518,7 @@ onMounted(async () => {
 
 .approval-detail__label {
   font-size: 12px;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
 }
 
 .approval-detail__snapshot {
@@ -1568,7 +1568,7 @@ onMounted(async () => {
 
 .approval-detail__timeline-comment {
   margin: 4px 0 0;
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
   font-size: 13px;
 }
 
@@ -1584,23 +1584,23 @@ onMounted(async () => {
   font-size: 11px;
   padding: 1px 6px;
   border-radius: 4px;
-  background: var(--el-fill-color-light, #f5f7fa);
-  color: var(--el-text-color-secondary, #909399);
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-secondary);
 }
 
 .approval-detail__meta-badge--auto {
-  background: #e6f7ff;
-  color: #1890ff;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary);
 }
 
 .approval-detail__meta-badge--complete {
-  background: #f6ffed;
-  color: #52c41a;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success);
 }
 
 .approval-detail__meta-badge--return {
-  background: #fff7e6;
-  color: #fa8c16;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning);
 }
 
 .approval-detail__parallel-badge {
@@ -1610,11 +1610,11 @@ onMounted(async () => {
 }
 
 .approval-detail__timeline-group {
-  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 6px;
   padding: 12px 16px;
   margin-bottom: 12px;
-  background: var(--el-fill-color-blank, #fff);
+  background: var(--el-fill-color-blank);
 }
 
 .approval-detail__timeline-group-header {
@@ -1623,17 +1623,17 @@ onMounted(async () => {
   justify-content: space-between;
   margin-bottom: 8px;
   padding-bottom: 6px;
-  border-bottom: 1px dashed var(--el-border-color-lighter, #ebedf0);
+  border-bottom: 1px dashed var(--el-border-color-lighter);
 }
 
 .approval-detail__timeline-group-label {
   font-weight: 600;
-  color: var(--el-text-color-primary, #303133);
+  color: var(--el-text-color-primary);
 }
 
 .approval-detail__timeline-group-count {
   font-size: 12px;
-  color: var(--el-text-color-secondary, #606266);
+  color: var(--el-text-color-secondary);
 }
 
 /* UX B2-08: synthesized "current handler + upcoming nodes" rail, appended after the real
@@ -1643,7 +1643,7 @@ onMounted(async () => {
 .approval-detail__timeline-upcoming {
   margin-top: 16px;
   padding-top: 12px;
-  border-top: 1px dashed var(--el-border-color-lighter, #e4e7ed);
+  border-top: 1px dashed var(--el-border-color-lighter);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -1663,20 +1663,20 @@ onMounted(async () => {
   height: 8px;
   margin-top: 4px;
   border-radius: 50%;
-  background: var(--el-color-primary, #409eff);
+  background: var(--el-color-primary);
 }
 
 .approval-detail__timeline-upcoming-item--future .approval-detail__timeline-upcoming-dot {
-  background: var(--el-text-color-placeholder, #c0c4cc);
+  background: var(--el-text-color-placeholder);
 }
 
 .approval-detail__timeline-upcoming-item--current .approval-detail__timeline-upcoming-text {
-  color: var(--el-text-color-primary, #303133);
+  color: var(--el-text-color-primary);
   font-weight: 500;
 }
 
 .approval-detail__timeline-upcoming-item--future .approval-detail__timeline-upcoming-text {
-  color: var(--el-text-color-placeholder, #909399);
+  color: var(--el-text-color-placeholder);
 }
 
 .approval-detail__timeline-upcoming-summary {
@@ -1690,8 +1690,8 @@ onMounted(async () => {
   margin-top: 24px;
   padding: 16px 20px;
   padding-bottom: calc(8px + env(safe-area-inset-bottom));
-  background: var(--el-bg-color, #fff);
-  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  background: var(--el-bg-color);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
   display: flex;
   align-items: center;

--- a/apps/web/src/views/approval/ApprovalMetricsView.vue
+++ b/apps/web/src/views/approval/ApprovalMetricsView.vue
@@ -496,25 +496,25 @@ onMounted(() => {
   gap: 16px;
 }
 .approval-metrics__card--breach :deep(.el-card__body) {
-  background: #fff7e6;
+  background: var(--el-color-warning-light-9);
 }
 .metric-label {
   font-size: 13px;
-  color: #6b7280;
+  color: var(--ms-text-2);
   margin-bottom: 8px;
 }
 .metric-value {
   font-size: 28px;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--ms-text-1);
 }
 .metric-sub {
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--ms-text-3);
   margin-top: 6px;
 }
 .metric-muted {
-  color: #9ca3af;
+  color: var(--ms-text-3);
 }
 .approval-metrics__section {
   width: 100%;
@@ -534,17 +534,17 @@ onMounted(() => {
   min-width: 48px;
   height: 8px;
   border-radius: 4px;
-  background: #f0f0f0;
+  background: var(--ms-bg-page);
   overflow: hidden;
 }
 .metric-bar__fill {
   height: 100%;
   border-radius: 4px;
-  background: #f59e0b;
+  background: var(--ms-color-warning);
 }
 .metric-bar__label {
   font-size: 12px;
-  color: #4b5563;
+  color: var(--ms-text-2);
   min-width: 44px;
   text-align: right;
 }

--- a/apps/web/src/views/approval/ApprovalMobileList.vue
+++ b/apps/web/src/views/approval/ApprovalMobileList.vue
@@ -143,7 +143,7 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
 .approval-mobile-list__empty {
   padding: 32px 16px;
   text-align: center;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
   font-size: 14px;
 }
 
@@ -154,7 +154,7 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
   width: 100%;
   text-align: left;
   background: #fff;
-  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 10px;
   padding: 14px 16px;
   cursor: pointer;
@@ -163,7 +163,7 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
 }
 
 .approval-mobile-list__card:active {
-  background: var(--el-fill-color-light, #f5f7fa);
+  background: var(--el-fill-color-light);
 }
 
 .approval-mobile-list__card-top {
@@ -184,7 +184,7 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
 .approval-mobile-list__title {
   font-size: 15px;
   font-weight: 600;
-  color: var(--el-text-color-primary, #303133);
+  color: var(--el-text-color-primary);
   line-height: 1.4;
 }
 
@@ -194,7 +194,7 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
   justify-content: space-between;
   gap: 12px;
   font-size: 13px;
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
 }
 
 /* B2-01: key-field summary line — muted, single-line, ellipsis-truncated (mirrors the desktop
@@ -205,12 +205,12 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 12px;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
 }
 
 .approval-mobile-list__date {
   font-size: 12px;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
 }
 
 /* B1-03: 已等待 aging severity — same warn/urgent palette as the desktop table. */

--- a/apps/web/src/views/approval/ApprovalMobileList.vue
+++ b/apps/web/src/views/approval/ApprovalMobileList.vue
@@ -153,7 +153,7 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
   gap: 8px;
   width: 100%;
   text-align: left;
-  background: #fff;
+  background: var(--ms-bg-card);
   border: 1px solid var(--el-border-color-lighter);
   border-radius: 10px;
   padding: 14px 16px;
@@ -215,10 +215,10 @@ function rowSummaryLine(row: UnifiedApprovalDTO): string {
 
 /* B1-03: 已等待 aging severity — same warn/urgent palette as the desktop table. */
 .approval-mobile-list__date--warn {
-  color: #e6a23c;
+  color: var(--ms-color-warning);
 }
 
 .approval-mobile-list__date--urgent {
-  color: #f56c6c;
+  color: var(--ms-color-danger);
 }
 </style>

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -128,7 +128,7 @@
               :disabled="isAutoSummedTotal(field.id)"
               :controls="!isAutoSummedTotal(field.id)"
               v-bind="numberFieldProps(field)"
-              style="width: 100%"
+              class="ms-w-100pct"
             />
 
             <!-- date -->
@@ -137,7 +137,7 @@
               v-model="formData[field.id]"
               type="date"
               :placeholder="field.placeholder || `请选择${field.label}`"
-              style="width: 100%"
+              class="ms-w-100pct"
             />
 
             <!-- datetime -->
@@ -146,7 +146,7 @@
               v-model="formData[field.id]"
               type="datetime"
               :placeholder="field.placeholder || `请选择${field.label}`"
-              style="width: 100%"
+              class="ms-w-100pct"
             />
 
             <!-- select -->
@@ -154,7 +154,7 @@
               v-else-if="field.type === 'select'"
               v-model="formData[field.id]"
               :placeholder="field.placeholder || `请选择${field.label}`"
-              style="width: 100%"
+              class="ms-w-100pct"
             >
               <el-option
                 v-for="opt in (field.options || [])"
@@ -170,7 +170,7 @@
               v-model="formData[field.id]"
               multiple
               :placeholder="field.placeholder || `请选择${field.label}`"
-              style="width: 100%"
+              class="ms-w-100pct"
             >
               <el-option
                 v-for="opt in (field.options || [])"
@@ -230,27 +230,27 @@
                       :controls="false"
                       :disabled="isDetailDerivedColumnReadOnly(field, column, row)"
                       v-bind="numberFieldProps(column)"
-                      style="width: 100%"
+                      class="ms-w-100pct"
                     />
                     <el-date-picker
                       v-else-if="column.type === 'date'"
                       v-model="row[column.id]"
                       type="date"
                       :placeholder="column.label"
-                      style="width: 100%"
+                      class="ms-w-100pct"
                     />
                     <el-date-picker
                       v-else-if="column.type === 'datetime'"
                       v-model="row[column.id]"
                       type="datetime"
                       :placeholder="column.label"
-                      style="width: 100%"
+                      class="ms-w-100pct"
                     />
                     <el-select
                       v-else-if="column.type === 'select'"
                       v-model="row[column.id]"
                       :placeholder="column.label"
-                      style="width: 100%"
+                      class="ms-w-100pct"
                     >
                       <el-option
                         v-for="opt in (column.options || [])"
@@ -264,7 +264,7 @@
                       v-model="row[column.id]"
                       multiple
                       :placeholder="column.label"
-                      style="width: 100%"
+                      class="ms-w-100pct"
                     >
                       <el-option
                         v-for="opt in (column.options || [])"
@@ -766,7 +766,7 @@ watch([visibleFieldIds, template], () => {
 }
 
 .approval-new__form {
-  background: #fff;
+  background: var(--ms-bg-card);
   border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
   padding: 24px;

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -697,13 +697,13 @@ watch([visibleFieldIds, template], () => {
 }
 
 .approval-new__info-desc {
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
   margin: 0;
   font-size: 14px;
 }
 
 .approval-new__info-desc--empty {
-  color: var(--el-text-color-placeholder, #c0c4cc);
+  color: var(--el-text-color-placeholder);
   font-style: italic;
 }
 
@@ -731,29 +731,29 @@ watch([visibleFieldIds, template], () => {
   flex-direction: column;
   padding: 4px 10px;
   border-radius: 6px;
-  background: var(--el-fill-color-light, #f5f7fa);
-  color: var(--el-text-color-regular, #606266);
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-regular);
   font-size: 12px;
   line-height: 1.4;
 }
 
 .approval-new__flow-preview-chip--requester {
-  background: var(--el-color-primary-light-9, #ecf5ff);
-  color: var(--el-color-primary, #409eff);
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary);
   font-weight: 500;
 }
 
 .approval-new__flow-preview-chip--conditional {
-  border: 1px dashed var(--el-color-warning, #e6a23c);
+  border: 1px dashed var(--el-color-warning);
 }
 
 .approval-new__flow-preview-chip-summary {
   font-size: 11px;
-  color: var(--el-text-color-placeholder, #909399);
+  color: var(--el-text-color-placeholder);
 }
 
 .approval-new__flow-preview-arrow {
-  color: var(--el-text-color-placeholder, #c0c4cc);
+  color: var(--el-text-color-placeholder);
   font-size: 12px;
 }
 
@@ -761,13 +761,13 @@ watch([visibleFieldIds, template], () => {
   display: block;
   font-size: 12px;
   font-weight: 400;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
   margin-top: 2px;
 }
 
 .approval-new__form {
   background: #fff;
-  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
   padding: 24px;
 }
@@ -776,10 +776,10 @@ watch([visibleFieldIds, template], () => {
   width: 100%;
   box-sizing: border-box;
   padding: 12px 16px;
-  border: 1px dashed var(--el-border-color, #dcdfe6);
+  border: 1px dashed var(--el-border-color);
   border-radius: 6px;
-  background: var(--el-fill-color-lighter, #f5f7fa);
-  color: var(--el-text-color-secondary, #909399);
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-secondary);
   font-size: 13px;
   line-height: 1.6;
 }
@@ -798,7 +798,7 @@ watch([visibleFieldIds, template], () => {
 }
 
 .approval-new__detail-required {
-  color: var(--el-color-danger, #f56c6c);
+  color: var(--el-color-danger);
   margin-left: 2px;
 }
 
@@ -812,6 +812,6 @@ watch([visibleFieldIds, template], () => {
 .approval-new__detail-hint,
 .approval-new__detail-empty {
   font-size: 12px;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
 }
 </style>

--- a/apps/web/src/views/approval/DelegationSettingsView.vue
+++ b/apps/web/src/views/approval/DelegationSettingsView.vue
@@ -182,6 +182,6 @@ onMounted(load)
   display: block;
   margin-top: 2px;
   font-size: 12px;
-  color: var(--el-color-warning, #e6a23c);
+  color: var(--el-color-warning);
 }
 </style>

--- a/apps/web/src/views/approval/MyDelegationView.vue
+++ b/apps/web/src/views/approval/MyDelegationView.vue
@@ -166,6 +166,6 @@ onMounted(load)
   display: block;
   margin-top: 2px;
   font-size: 12px;
-  color: var(--el-color-warning, #e6a23c);
+  color: var(--el-color-warning);
 }
 </style>

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -2060,7 +2060,7 @@ onUnmounted(() => {
   gap: 12px;
   min-height: 148px;
   padding: 14px;
-  border: 1px solid var(--el-border-color-lighter, #ebeef5);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
 }
 
@@ -2068,7 +2068,7 @@ onUnmounted(() => {
   margin: 6px 0 0;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--el-text-color-secondary, #606266);
+  color: var(--el-text-color-secondary);
 }
 
 .template-authoring__visibility {
@@ -2082,7 +2082,7 @@ onUnmounted(() => {
   margin-top: 6px;
   font-size: 12px;
   line-height: 1.5;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
 }
 
 .template-authoring__inline > .el-input {
@@ -2107,7 +2107,7 @@ onUnmounted(() => {
 
 .template-authoring__item {
   padding: 14px;
-  border: 1px solid var(--el-border-color-lighter, #ebeef5);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
 }
 
@@ -2123,8 +2123,8 @@ onUnmounted(() => {
   font-size: 12px;
   padding: 2px 8px;
   border-radius: 10px;
-  background: var(--el-fill-color-light, #f5f7fa);
-  color: var(--el-text-color-secondary, #606266);
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-secondary);
 }
 
 .template-authoring__node-summary {
@@ -2132,7 +2132,7 @@ onUnmounted(() => {
   padding-left: 20px;
   font-size: 13px;
   line-height: 1.7;
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
 }
 
 /* G-2 condition editor */
@@ -2141,7 +2141,7 @@ onUnmounted(() => {
 }
 
 .template-authoring__condition-branch {
-  border: 1px dashed var(--el-border-color, #dcdfe6);
+  border: 1px dashed var(--el-border-color);
   border-radius: 6px;
   padding: 10px 12px;
   margin-bottom: 10px;
@@ -2154,7 +2154,7 @@ onUnmounted(() => {
   gap: 8px;
   margin-bottom: 8px;
   font-size: 13px;
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
 }
 
 .template-authoring__condition-rule {
@@ -2198,7 +2198,7 @@ onUnmounted(() => {
 .template-authoring__condition-formula-dryrun-result {
   font-size: 12px;
   line-height: 1.5;
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
 }
 
 .template-authoring__condition-default {
@@ -2226,15 +2226,15 @@ onUnmounted(() => {
   gap: 8px;
   padding: 8px 10px;
   border-radius: 6px;
-  background: var(--el-fill-color-lighter, #f5f7fa);
+  background: var(--el-fill-color-lighter);
 }
 
 .template-authoring__publish-checklist-item.is-ok .template-authoring__publish-checklist-icon {
-  color: var(--el-color-success, #67c23a);
+  color: var(--el-color-success);
 }
 
 .template-authoring__publish-checklist-item.is-fail .template-authoring__publish-checklist-icon {
-  color: var(--el-color-danger, #f56c6c);
+  color: var(--el-color-danger);
 }
 
 .template-authoring__publish-checklist-icon {
@@ -2244,7 +2244,7 @@ onUnmounted(() => {
 .template-authoring__publish-checklist-detail {
   flex-basis: 100%;
   font-size: 12px;
-  color: var(--el-text-color-secondary, #606266);
+  color: var(--el-text-color-secondary);
 }
 
 pre {
@@ -2272,7 +2272,7 @@ pre {
 .template-authoring__canvas {
   position: relative;
   overflow: auto;
-  border: 1px solid var(--el-border-color, #dcdfe6);
+  border: 1px solid var(--el-border-color);
   border-radius: 6px;
   background: #fafafa;
   min-height: 200px;
@@ -2280,7 +2280,7 @@ pre {
 .template-authoring__canvas-node {
   box-sizing: border-box;
   padding: 6px 10px;
-  border: 1px solid var(--el-border-color, #dcdfe6);
+  border: 1px solid var(--el-border-color);
   border-radius: 6px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
@@ -2291,8 +2291,8 @@ pre {
   font-size: 12px;
 }
 .template-authoring__canvas-node.is-selected {
-  border-color: var(--el-color-primary, #409eff);
-  box-shadow: 0 0 0 2px var(--el-color-primary-light-5, #a0cfff);
+  border-color: var(--el-color-primary);
+  box-shadow: 0 0 0 2px var(--el-color-primary-light-5);
 }
 .template-authoring__canvas-node-actions {
   display: flex;

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -144,7 +144,7 @@
           </el-form-item>
           <el-form-item label="可见范围">
             <div class="template-authoring__inline">
-              <el-select v-model="draft.visibilityType" :disabled="readOnly" style="width: 140px">
+              <el-select v-model="draft.visibilityType" :disabled="readOnly" class="ms-w-140">
                 <el-option label="全员" value="all" />
                 <el-option label="部门" value="dept" />
                 <el-option label="角色" value="role" />
@@ -207,7 +207,7 @@
               <el-input v-model="field.label" :disabled="readOnly" />
             </el-form-item>
             <el-form-item label="类型">
-              <el-select v-model="field.type" :disabled="readOnly" style="width: 100%">
+              <el-select v-model="field.type" :disabled="readOnly" class="ms-w-100pct">
                 <el-option label="文本" value="text" />
                 <el-option label="多行文本" value="textarea" />
                 <el-option label="数字" value="number" />
@@ -265,7 +265,7 @@
                   </el-table-column>
                   <el-table-column label="类型" min-width="120">
                     <template #default="{ row }">
-                      <el-select v-model="row.type" :disabled="readOnly" style="width: 100%">
+                      <el-select v-model="row.type" :disabled="readOnly" class="ms-w-100pct">
                         <el-option
                           v-for="leaf in detailLeafTypeOptions"
                           :key="leaf.value"
@@ -322,13 +322,13 @@
                     v-model="field.minRowsText"
                     :disabled="readOnly"
                     placeholder="最小行数"
-                    style="width: 120px"
+                    class="ms-w-120"
                   />
                   <el-input
                     v-model="field.maxRowsText"
                     :disabled="readOnly"
                     placeholder="最大行数"
-                    style="width: 120px"
+                    class="ms-w-120"
                   />
                 </div>
               </div>
@@ -338,7 +338,7 @@
                 <el-select
                   v-model="field.visibility.dependsOnFieldId"
                   :disabled="readOnly"
-                  style="width: 200px"
+                  class="ms-w-200"
                   data-testid="approval-field-visibility-depends"
                 >
                   <el-option label="无（始终显示）" value="" />
@@ -353,7 +353,7 @@
                   <el-select
                     v-model="field.visibility.operator"
                     :disabled="readOnly"
-                    style="width: 130px"
+                    class="ms-w-130"
                     data-testid="approval-field-visibility-operator"
                   >
                     <el-option label="等于" value="eq" />
@@ -369,7 +369,7 @@
                     type="textarea"
                     :rows="2"
                     placeholder="每行一个值"
-                    style="width: 240px"
+                    class="ms-w-240"
                     data-testid="approval-field-visibility-values"
                   />
                   <el-input
@@ -377,7 +377,7 @@
                     v-model="field.visibility.valueText"
                     :disabled="readOnly"
                     placeholder="比较值"
-                    style="width: 240px"
+                    class="ms-w-240"
                     data-testid="approval-field-visibility-value"
                   />
                 </template>
@@ -439,7 +439,7 @@
             data-testid="approval-graph-canvas"
             :style="{ position: 'relative', height: canvasLayout.height + 'px', width: canvasLayout.width + 'px' }"
           >
-            <svg class="template-authoring__canvas-edges" :width="canvasLayout.width" :height="canvasLayout.height" style="position:absolute;left:0;top:0">
+            <svg class="template-authoring__canvas-edges" :width="canvasLayout.width" :height="canvasLayout.height">
               <defs>
                 <marker id="approval-canvas-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
                   <path d="M0,0 L7,3 L0,6 Z" fill="#bbb" />
@@ -550,7 +550,7 @@
                     :model-value="branch.predicateMode"
                     size="small"
                     :disabled="readOnly"
-                    style="width: 130px"
+                    class="ms-w-130"
                     data-testid="approval-condition-predicate-mode"
                     @update:model-value="(mode: string) => setConditionBranchPredicateMode(branch, mode)"
                   >
@@ -562,7 +562,7 @@
                     v-model="branch.conjunction"
                     size="small"
                     :disabled="readOnly"
-                    style="width: 110px"
+                    class="ms-w-110"
                     data-testid="approval-condition-conjunction"
                   >
                     <el-option label="全部满足 (AND)" value="and" />
@@ -582,7 +582,7 @@
                       filterable
                       placeholder="字段"
                       :disabled="readOnly"
-                      style="width: 160px"
+                      class="ms-w-160"
                       data-testid="approval-condition-rule-field"
                     >
                       <el-option
@@ -596,7 +596,7 @@
                       v-model="rule.operator"
                       size="small"
                       :disabled="readOnly"
-                      style="width: 120px"
+                      class="ms-w-120"
                       data-testid="approval-condition-rule-operator"
                     >
                       <el-option
@@ -612,7 +612,7 @@
                       size="small"
                       placeholder="比较值"
                       :disabled="readOnly"
-                      style="width: 160px"
+                      class="ms-w-160"
                       data-testid="approval-condition-rule-value"
                       @update:model-value="(text: string) => setConditionRuleValue(rule, text)"
                     />
@@ -733,7 +733,7 @@
                   size="small"
                   clearable
                   :disabled="readOnly"
-                  style="width: 220px"
+                  class="ms-w-220"
                   placeholder="（无默认分支）"
                   data-testid="approval-condition-default-edge"
                 >
@@ -761,7 +761,7 @@
                   v-model="parallelEditFor(node.key)!.joinMode"
                   size="small"
                   :disabled="readOnly"
-                  style="width: 240px"
+                  class="ms-w-240"
                   data-testid="approval-parallel-join-mode"
                 >
                   <el-option
@@ -792,7 +792,7 @@
                   v-model="ccEditFor(node.key)!.targetType"
                   size="small"
                   :disabled="readOnly"
-                  style="width: 240px"
+                  class="ms-w-240"
                   data-testid="approval-cc-target-type"
                 >
                   <el-option
@@ -812,7 +812,7 @@
                   default-first-option
                   size="small"
                   :disabled="readOnly"
-                  style="width: 360px"
+                  class="ms-w-360"
                   placeholder="输入用户/角色 ID 后回车"
                   data-testid="approval-cc-target-ids"
                 />
@@ -833,7 +833,7 @@
                   :model-value="approvalSourceKind(node.key)"
                   size="small"
                   :disabled="readOnly"
-                  style="width: 240px"
+                  class="ms-w-240"
                   data-testid="approval-node-source-kind"
                   @update:model-value="(kind: ApprovalAssigneeSourceKind) => setApprovalSourceKind(node.key, kind)"
                 >
@@ -857,7 +857,7 @@
                   default-first-option
                   size="small"
                   :disabled="readOnly"
-                  style="width: 360px"
+                  class="ms-w-360"
                   placeholder="输入 ID 后回车"
                   data-testid="approval-node-source-ids"
                   @update:model-value="(ids: string[]) => setApprovalSourceIds(node.key, ids)"
@@ -871,7 +871,7 @@
                   :model-value="approvalSourceFieldId(node.key)"
                   size="small"
                   :disabled="readOnly"
-                  style="width: 240px"
+                  class="ms-w-240"
                   placeholder="顶层 user 字段 ID"
                   data-testid="approval-node-source-field"
                   @update:model-value="(fieldId: string) => setApprovalSourceFieldId(node.key, fieldId)"
@@ -936,7 +936,7 @@
               <el-input v-model="step.name" :disabled="readOnly" />
             </el-form-item>
             <el-form-item label="审批人来源">
-              <el-select v-model="step.sourceKind" :disabled="readOnly" style="width: 100%" data-testid="approval-step-source-kind" @change="syncStepOptions(step)">
+              <el-select v-model="step.sourceKind" :disabled="readOnly" class="ms-w-100pct" data-testid="approval-step-source-kind" @change="syncStepOptions(step)">
                 <el-option label="指定用户" value="static_user" />
                 <el-option label="指定角色" value="static_role" />
                 <el-option label="发起人" value="requester" />
@@ -979,7 +979,7 @@
                 :remote-method="onUserSearch"
                 :loading="directory.usersLoading.value"
                 :disabled="readOnly"
-                style="width: 100%"
+                class="ms-w-100pct"
                 placeholder="搜索用户名 / 邮箱 / ID"
                 data-testid="approval-step-user-picker"
                 @update:model-value="(ids: string[]) => setStepIds(step, ids)"
@@ -999,7 +999,7 @@
                 multiple
                 filterable
                 :disabled="readOnly"
-                style="width: 100%"
+                class="ms-w-100pct"
                 placeholder="选择角色"
                 data-testid="approval-step-role-picker"
                 @update:model-value="(ids: string[]) => setStepIds(step, ids)"
@@ -1016,7 +1016,7 @@
               <el-input v-model="step.idsText" :disabled="readOnly" placeholder="逗号或换行分隔" data-testid="approval-step-ids-text" />
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'form_field_user'" label="表单用户字段">
-              <el-select v-model="step.fieldId" :disabled="readOnly" style="width: 100%">
+              <el-select v-model="step.fieldId" :disabled="readOnly" class="ms-w-100pct">
                 <el-option
                   v-for="field in userFields"
                   :key="field.id"
@@ -1026,14 +1026,14 @@
               </el-select>
             </el-form-item>
             <el-form-item label="审批模式">
-              <el-select v-model="step.approvalMode" :disabled="readOnly" style="width: 100%">
+              <el-select v-model="step.approvalMode" :disabled="readOnly" class="ms-w-100pct">
                 <el-option label="单人通过" value="single" />
                 <el-option label="全部通过" value="all" />
                 <el-option label="任一通过" value="any" />
               </el-select>
             </el-form-item>
             <el-form-item label="空审批人策略">
-              <el-select v-model="step.emptyAssigneePolicy" :disabled="readOnly" style="width: 100%">
+              <el-select v-model="step.emptyAssigneePolicy" :disabled="readOnly" class="ms-w-100pct">
                 <el-option label="报错" value="error" />
                 <el-option label="自动通过" value="auto-approve" />
               </el-select>
@@ -1072,7 +1072,7 @@
                 :model-value="stepFieldAccess(step, field.id)"
                 :disabled="readOnly"
                 size="small"
-                style="width: 130px"
+                class="ms-w-130"
                 :data-testid="`approval-step-field-access-${field.id}`"
                 @update:model-value="(access: NodeFieldAccess) => onStepFieldAccessChange(step, field.id, access)"
               >
@@ -2274,16 +2274,21 @@ pre {
   overflow: auto;
   border: 1px solid var(--el-border-color);
   border-radius: 6px;
-  background: #fafafa;
+  background: var(--ms-bg-page);
   min-height: 200px;
+}
+.template-authoring__canvas-edges {
+  position: absolute;
+  left: 0;
+  top: 0;
 }
 .template-authoring__canvas-node {
   box-sizing: border-box;
   padding: 6px 10px;
   border: 1px solid var(--el-border-color);
   border-radius: 6px;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  background: var(--ms-bg-card);
+  box-shadow: var(--el-box-shadow-lighter);
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -8,7 +8,7 @@
             placeholder="全部分类"
             clearable
             data-testid="template-center-category-filter"
-            style="width: 160px; margin-right: 12px"
+            class="ms-w-160 ms-mr-12"
             @change="handleCategoryChange"
           >
             <el-option
@@ -22,7 +22,7 @@
             v-model="searchText"
             placeholder="搜索模板名称"
             clearable
-            style="width: 240px"
+            class="ms-w-240"
             @clear="handleSearch"
             @keyup.enter="handleSearch"
           >
@@ -33,7 +33,7 @@
           <el-button
             v-if="canManageTemplates"
             type="primary"
-            style="margin-left: 12px"
+            class="ms-ml-12"
             data-testid="template-center-new-button"
             @click="createTemplate"
           >
@@ -41,7 +41,7 @@
           </el-button>
           <el-button
             v-if="canManageTemplates"
-            style="margin-left: 8px"
+            class="ms-ml-8"
             data-testid="template-center-delegations-link"
             @click="$router.push('/approval-delegations')"
           >
@@ -95,7 +95,7 @@
     <el-table
       v-loading="store.loading"
       :data="store.templates"
-      style="width: 100%"
+      class="ms-w-100pct"
       max-height="560"
       stripe
       highlight-current-row

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -336,7 +336,7 @@ onMounted(() => {
 }
 
 .template-center__category-empty {
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
   font-size: 12px;
 }
 
@@ -349,7 +349,7 @@ onMounted(() => {
 }
 
 .template-center__recent-label {
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
   font-size: 13px;
 }
 

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -657,7 +657,7 @@ onMounted(() => {
 }
 
 .template-detail__info p {
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
   margin: 0 0 12px;
 }
 
@@ -665,7 +665,7 @@ onMounted(() => {
   display: flex;
   gap: 24px;
   font-size: 13px;
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
   flex-wrap: wrap;
 }
 
@@ -680,16 +680,16 @@ onMounted(() => {
 }
 
 .template-detail__category-label {
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
   margin-right: 4px;
 }
 
 .template-detail__category-empty {
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
 }
 
 .template-detail__visibility-ids {
-  color: var(--el-text-color-secondary, #909399);
+  color: var(--el-text-color-secondary);
 }
 
 .template-detail__content {
@@ -700,7 +700,7 @@ onMounted(() => {
 
 .template-detail__section {
   background: #fff;
-  border: 1px solid var(--el-border-color-lighter, #e4e7ed);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
   padding: 20px;
 }
@@ -720,7 +720,7 @@ onMounted(() => {
 
 .template-detail__node-assignee {
   font-size: 12px;
-  color: var(--el-text-color-regular, #606266);
+  color: var(--el-text-color-regular);
 }
 
 .template-detail__node-mode,

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -74,7 +74,7 @@
                 text
                 size="small"
                 data-testid="template-detail-category-edit-button"
-                style="margin-left: 8px"
+                class="ms-ml-8"
                 @click="beginEditCategory"
               >
                 编辑
@@ -85,7 +85,7 @@
                 v-model="categoryDraft"
                 size="small"
                 placeholder="分组标识，用于模板中心筛选，留空表示未分组"
-                style="width: 240px; margin-right: 8px"
+                class="ms-w-240 ms-mr-8"
                 maxlength="64"
                 data-testid="template-detail-category-input"
                 @keyup.enter="saveCategory"
@@ -128,7 +128,7 @@
                 text
                 size="small"
                 data-testid="template-detail-visibility-edit-button"
-                style="margin-left: 8px"
+                class="ms-ml-8"
                 @click="beginEditVisibility"
               >
                 编辑
@@ -138,7 +138,7 @@
               <el-select
                 v-model="visibilityTypeDraft"
                 size="small"
-                style="width: 120px; margin-right: 8px"
+                class="ms-w-120 ms-mr-8"
                 data-testid="template-detail-visibility-type"
               >
                 <el-option label="全员" value="all" />
@@ -150,7 +150,7 @@
                 v-model="visibilityIdsDraft"
                 size="small"
                 placeholder="逗号分隔 id，如 dept-finance, role-manager"
-                style="width: 320px; margin-right: 8px"
+                class="ms-w-320 ms-mr-8"
                 :disabled="visibilityTypeDraft === 'all'"
                 data-testid="template-detail-visibility-ids-input"
                 @keyup.enter="saveVisibility"
@@ -199,7 +199,7 @@
                 text
                 size="small"
                 data-testid="template-detail-sla-edit-button"
-                style="margin-left: 8px"
+                class="ms-ml-8"
                 @click="beginEditSla"
               >
                 编辑
@@ -211,7 +211,7 @@
                 :min="1"
                 :max="8760"
                 size="small"
-                style="width: 160px; margin-right: 8px"
+                class="ms-w-160 ms-mr-8"
                 data-testid="template-detail-sla-input"
                 placeholder="留空清除"
                 :controls="false"
@@ -247,7 +247,7 @@
           <!-- Form schema section -->
           <div class="template-detail__section">
             <h2>表单字段</h2>
-            <el-table :data="template.formSchema.fields" style="width: 100%" max-height="400" stripe>
+            <el-table :data="template.formSchema.fields" class="ms-w-100pct" max-height="400" stripe>
               <el-table-column prop="label" label="字段名" min-width="160" />
               <el-table-column label="类型" width="120">
                 <template #default="{ row }">
@@ -286,7 +286,7 @@
               description="暂无字段显隐规则"
               :image-size="60"
             />
-            <el-table v-else :data="visibilityRuleSummaries" style="width: 100%" stripe>
+            <el-table v-else :data="visibilityRuleSummaries" class="ms-w-100pct" stripe>
               <el-table-column label="字段" min-width="160">
                 <template #default="{ row }">
                   {{ row.field.label }}
@@ -699,7 +699,7 @@ onMounted(() => {
 }
 
 .template-detail__section {
-  background: #fff;
+  background: var(--ms-bg-card);
   border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
   padding: 20px;

--- a/apps/web/tests/ui-foundation-style-guard.spec.ts
+++ b/apps/web/tests/ui-foundation-style-guard.spec.ts
@@ -5,10 +5,11 @@ import { describe, expect, it } from 'vitest'
 // UI foundation design-lock (docs/development/ui-foundation-design-lock-20260706.md §6 UF-6):
 // "ESLint 禁 style="（存量 57 处清零）+ 表单布局工具类；同时加「新增硬编码 hex」lint"。
 //
-// Mechanism note: the installed eslint-plugin-vue version has no `vue/no-static-inline-styles`
-// rule (checked — see the UF-6 landing commit body), and there is no built-in ESLint rule for
-// "hex/rgb literal inside a <style> block" at all. So this fs-level source guard IS the gate for
-// both halves of UF-6, not a supplement to an ESLint rule.
+// Mechanism note: `vue/no-static-inline-styles` IS configured (apps/web/.eslintrc.cjs override,
+// scoped to this same file set) — but apps/web's `lint` script runs an explicit file list that
+// today covers only 2 of these 21 files, and no ESLint rule can police "hex/rgb literal inside a
+// <style> block" at all. So this fs-level source guard is the CI-enforced gate for both halves
+// of UF-6; the ESLint rule is IDE feedback + future-glob insurance.
 //
 // Scope = the exact UF surface set named in the design-lock: the approval views, the shared
 // automation rule editor/manager, the workflow hub/designer, and the shared layout/status

--- a/apps/web/tests/ui-foundation-style-guard.spec.ts
+++ b/apps/web/tests/ui-foundation-style-guard.spec.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// UI foundation design-lock (docs/development/ui-foundation-design-lock-20260706.md §6 UF-6):
+// "ESLint 禁 style="（存量 57 处清零）+ 表单布局工具类；同时加「新增硬编码 hex」lint"。
+//
+// Mechanism note: the installed eslint-plugin-vue version has no `vue/no-static-inline-styles`
+// rule (checked — see the UF-6 landing commit body), and there is no built-in ESLint rule for
+// "hex/rgb literal inside a <style> block" at all. So this fs-level source guard IS the gate for
+// both halves of UF-6, not a supplement to an ESLint rule.
+//
+// Scope = the exact UF surface set named in the design-lock: the approval views, the shared
+// automation rule editor/manager, the workflow hub/designer, and the shared layout/status
+// components. This is a TARGETED gate, not a whole-repo lint — the rest of the app is
+// unmigrated and tracked separately (design-lock §6 slice ladder).
+const TARGET_FILES = [
+  'src/views/approval/ApprovalCardDecisionView.vue',
+  'src/views/approval/ApprovalCenterTable.vue',
+  'src/views/approval/ApprovalCenterView.vue',
+  'src/views/approval/ApprovalDetailView.vue',
+  'src/views/approval/ApprovalMetricsView.vue',
+  'src/views/approval/ApprovalMobileList.vue',
+  'src/views/approval/ApprovalNewView.vue',
+  'src/views/approval/DelegationSettingsView.vue',
+  'src/views/approval/MyDelegationView.vue',
+  'src/views/approval/TemplateAuthoringView.vue',
+  'src/views/approval/TemplateCenterView.vue',
+  'src/views/approval/TemplateDetailView.vue',
+  'src/views/ApprovalInboxView.vue',
+  'src/views/AutomationExecutionsView.vue',
+  'src/views/WorkflowHubView.vue',
+  'src/views/WorkflowDesigner.vue',
+  'src/components/layout/PageHeader.vue',
+  'src/components/layout/PageShell.vue',
+  'src/components/status/StatusTag.vue',
+  'src/multitable/components/MetaAutomationManager.vue',
+  'src/multitable/components/MetaAutomationRuleEditor.vue',
+] as const
+
+// Per-file allowlist for counts that are legitimately un-clearable. Keep this EMPTY unless a
+// concrete, justified exception shows up — every entry must carry a one-line reason. The UF-6
+// purge cleared all 21 target files to zero on both axes, so both maps start empty; a future PR
+// that needs an exception adds `'src/views/.../Foo.vue': N, // reason` here, never widens the
+// regex or silently allowlists a whole file.
+const STATIC_STYLE_ALLOWLIST: Partial<Record<(typeof TARGET_FILES)[number], number>> = {}
+
+const HEX_COLOR_ALLOWLIST: Partial<Record<(typeof TARGET_FILES)[number], number>> = {}
+
+function readTarget(rel: string): string {
+  return readFileSync(join(__dirname, '..', rel), 'utf8')
+}
+
+// Matches a static `style="..."` attribute but not the Vue binding `:style="..."` /
+// `v-bind:style="..."` (both end in `:style="`, so a negative lookbehind on the colon is enough —
+// no word-boundary trick needed since whitespace/`"`/`<` all precede a genuine static attribute).
+const STATIC_STYLE_RE = /(?<!:)style="/g
+
+function countStaticStyleAttrs(src: string): number {
+  const matches = src.match(STATIC_STYLE_RE)
+  return matches ? matches.length : 0
+}
+
+const STYLE_BLOCK_RE = /<style[^>]*>([\s\S]*?)<\/style>/g
+
+function extractStyleBlocks(src: string): string[] {
+  const blocks: string[] = []
+  let match: RegExpExecArray | null
+  STYLE_BLOCK_RE.lastIndex = 0
+  while ((match = STYLE_BLOCK_RE.exec(src))) {
+    blocks.push(match[1])
+  }
+  return blocks
+}
+
+// Hex literals (#abc / #aabbcc / #aabbccdd) OR rgb()/rgba() functional notation, anywhere in a
+// <style> block — including inside a `var(--x, <literal>)` fallback, which is exactly the escape
+// hatch this guard exists to close. `var(...)` references to other custom properties, and the
+// bare keywords transparent/inherit/currentColor/none, are unaffected (they never match either
+// pattern) — those are the only allowed color-authoring forms left after the UF-1..UF-3 tokens.
+function countHexOrRgbLiterals(styleBlock: string): number {
+  const hexMatches = styleBlock.match(/#[0-9a-fA-F]{3,8}\b/g)
+  const rgbMatches = styleBlock.match(/\brgba?\(/g)
+  return (hexMatches ? hexMatches.length : 0) + (rgbMatches ? rgbMatches.length : 0)
+}
+
+describe('UI foundation style guard (UF-6)', () => {
+  describe('zero static style= attributes', () => {
+    it.each(TARGET_FILES)('%s', (rel) => {
+      const src = readTarget(rel)
+      const allowed = STATIC_STYLE_ALLOWLIST[rel] ?? 0
+      expect(countStaticStyleAttrs(src)).toBe(allowed)
+    })
+  })
+
+  describe('zero hex/rgb() color literals in <style> blocks', () => {
+    it.each(TARGET_FILES)('%s', (rel) => {
+      const src = readTarget(rel)
+      const blocks = extractStyleBlocks(src)
+      const total = blocks.reduce((sum, block) => sum + countHexOrRgbLiterals(block), 0)
+      const allowed = HEX_COLOR_ALLOWLIST[rel] ?? 0
+      expect(total).toBe(allowed)
+    })
+  })
+
+  // Regex self-checks (not a substitute for the mutation test run against the real tree — see
+  // the UF-6 PR body — but pins the two counting helpers' behavior so a future refactor of this
+  // spec can't accidentally regress them to "always pass").
+  describe('helper regressions', () => {
+    it('does not flag a Vue :style binding as a static style=', () => {
+      const fixture = '<div :style="{ color: x }"></div>'
+      expect(countStaticStyleAttrs(fixture)).toBe(0)
+    })
+
+    it('flags a static style= attribute', () => {
+      const fixture = '<div style="width: 100%"></div>'
+      expect(countStaticStyleAttrs(fixture)).toBe(1)
+    })
+
+    it('does not flag var() references to other custom properties', () => {
+      const fixture = '<style scoped>.x { color: var(--ms-color-danger); }</style>'
+      const blocks = extractStyleBlocks(fixture)
+      const total = blocks.reduce((sum, block) => sum + countHexOrRgbLiterals(block), 0)
+      expect(total).toBe(0)
+    })
+
+    it('flags a hex literal used as a var() fallback', () => {
+      const fixture = '<style scoped>.x { color: var(--ms-color-danger, #dc2626); }</style>'
+      const blocks = extractStyleBlocks(fixture)
+      const total = blocks.reduce((sum, block) => sum + countHexOrRgbLiterals(block), 0)
+      expect(total).toBe(1)
+    })
+
+    it('flags an rgba() literal', () => {
+      const fixture = '<style scoped>.x { box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08); }</style>'
+      const blocks = extractStyleBlocks(fixture)
+      const total = blocks.reduce((sum, block) => sum + countHexOrRgbLiterals(block), 0)
+      expect(total).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
Implements **UF-6** of the UI foundation design-lock — the enforcement knife: the lock's §3.1 rule (new hardcoded hex in views = defect) becomes a CI-enforced gate, after purging the remaining stock.

## What
- **Stock purged to ZERO on all 21 target files** (approval views + Inbox/AutomationExecutions/WorkflowHub/WorkflowDesigner + PageShell/PageHeader/StatusTag + MetaAutomation manager/editor): every static `style=` attribute → scoped classes / new `form-layout-utilities.css` (--ms tokens); every hex/rgb() in `<style>` blocks → semantic `--ms-*`/`--el-*` tokens (per-file before/after table in commit body; heaviest: WorkflowHubView 54, AutomationExecutionsView 33, WorkflowDesigner 27 + confirmed-dead CSS deleted per lock §8).
- **The gate**: `tests/ui-foundation-style-guard.spec.ts` (47 assertions) fs-reads the target set and asserts zero static `style=` + zero hex/rgb() literals — **including `var(--x, #hex)` fallbacks** (the escape hatch this closes). Allowlists exist but are **EMPTY** (every future exception needs a justified entry, never a regex loophole). Wired two-point into approval-web-guard.
- `vue/no-static-inline-styles` (present in installed eslint-plugin-vue) configured scoped to the set — honest note: `pnpm lint`'s explicit globs cover only 2/21 of these files today, so **the vitest spec is the CI gate**; the ESLint rule is IDE feedback + future-glob insurance.
- Judgment calls documented: no purple/lime semantic tokens exist → database/builtin source badges mapped to info/success; WorkflowHubView's black primary button kept its look via text/bg tokens (design convergence is other slices' territory).

## Verification
- Mutation-verified both guard axes (planted style= + planted hex → each red → precise-edit revert)
- `vue-tsc -b` 0 · build green · **apps/web `pnpm lint` green at --max-warnings=0**
- approval-web-guard full set green (27 files/509 tests pre-rebase); post-rebase-over-UF-7: guard 47/47 + workflowHubView 4/4 (the UF-7×UF-6 merge on WorkflowHubView verified against both gates)
- 716 tests across all touched-view specs; 2 pre-existing failures proven present on origin/main (unrelated)
- Presentation-only; zero behavior change

Survived a mid-task agent death (session limit) via WIP-checkpoint discipline; resumed by a second agent; reviewed + rebase-conflict-resolved (3 union hunks) by the main loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)