### PR TITLE
feat(web): IU-1 integration error-code humanized labels (design-lock #3739)

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -9,8 +9,10 @@
 #   1. the plugin's own CJS test chain (`pnpm --filter plugin-integration-core test`) — 35 pure suites
 #      covering read-source config/probe/resolver/composition/write-target;
 #   2. the integration web specs that carry the values-free / mirror-parity guarantees: the two vocab
-#      mirror tripwires, the read-source config / composition run / composition authoring panels, and
-#      the composition service layer.
+#      mirror tripwires, the read-source config / composition run / composition authoring panels, the
+#      composition service layer, the IU-1 error-code label module + its mirror tripwire, and the two
+#      dead-letter display views (Workbench + K3 WISE setup) that carry the IU-1 RATIFIED
+#      errorMessage-never-renders-raw addendum.
 # Expand the spec list as more integration web specs are added.
 name: Integration Guard
 
@@ -20,15 +22,21 @@ on:
       - 'plugins/plugin-integration-core/**'
       - 'apps/web/src/services/integration/readSourceConfigs.ts'
       - 'apps/web/src/services/integration/readSourceCompositions.ts'
+      - 'apps/web/src/services/integration/errorCodeLabels.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
+      - 'apps/web/src/views/IntegrationWorkbenchView.vue'
+      - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
       - 'apps/web/tests/composition-vocab-mirror.spec.ts'
       - 'apps/web/tests/multitable-resolver-vocab-mirror.spec.ts'
+      - 'apps/web/tests/integrationErrorCodeLabels.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
+      - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
+      - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - '.github/workflows/integration-guard.yml'
   push:
     branches: [main]
@@ -36,15 +44,21 @@ on:
       - 'plugins/plugin-integration-core/**'
       - 'apps/web/src/services/integration/readSourceConfigs.ts'
       - 'apps/web/src/services/integration/readSourceCompositions.ts'
+      - 'apps/web/src/services/integration/errorCodeLabels.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
+      - 'apps/web/src/views/IntegrationWorkbenchView.vue'
+      - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
       - 'apps/web/tests/composition-vocab-mirror.spec.ts'
       - 'apps/web/tests/multitable-resolver-vocab-mirror.spec.ts'
+      - 'apps/web/tests/integrationErrorCodeLabels.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
+      - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
+      - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - '.github/workflows/integration-guard.yml'
 
 jobs:
@@ -90,4 +104,4 @@ jobs:
         run: pnpm --filter plugin-integration-core test
 
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationK3WiseSetupView --reporter=dot

--- a/apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue
@@ -54,15 +54,16 @@
           <li v-if="result.evidence.failedStep !== null" data-testid="rscomp-evidence-failed-step">
             failedStep: {{ result.evidence.failedStep }}
           </li>
-          <li v-if="result.evidence.errorCode" data-testid="rscomp-evidence-error-code">
-            errorCode: {{ result.evidence.errorCode }}
+          <li v-if="result.evidence.errorCode" data-testid="rscomp-evidence-error-label">
+            {{ resultErrorLabel }}<template v-if="resultErrorHint"> — {{ resultErrorHint }}</template>
+            <small data-testid="rscomp-evidence-error-code">errorCode: {{ result.evidence.errorCode }}</small>
           </li>
           <li
             v-for="step in result.evidence.steps"
             :key="step.step"
             :data-testid="`rscomp-step-${step.step}`"
           >
-            step {{ step.step }}: ok={{ step.ok ? 'true' : 'false' }}<template v-if="step.rule">, rule={{ step.rule }}</template><template v-if="step.errorCode">, errorCode={{ step.errorCode }}</template>
+            step {{ step.step }}: ok={{ step.ok ? 'true' : 'false' }}<template v-if="step.rule">, rule={{ step.rule }}</template><template v-if="step.errorCode">, errorCode={{ step.errorCode }} ({{ stepErrorLabel(step.errorCode) }})</template>
           </li>
           <li v-for="(entry, index) in result.evidence.planErrors ?? []" :key="index" data-testid="rscomp-plan-error">
             {{ entry.code }} · {{ entry.field }} · {{ entry.reason }}
@@ -84,7 +85,9 @@
 // key, and renders the values-free chain evidence + last-hop-only output. No authoring/approval, no
 // write path; the server + client normalizer already enforce values-free — this panel renders exactly
 // what they return, nothing more.
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../../services/integration/errorCodeLabels'
 import type { IntegrationScope } from '../../services/integration/workbench'
 import {
   listReadSourceCompositions,
@@ -97,6 +100,8 @@ const props = defineProps<{
   scope: IntegrationScope
 }>()
 
+const { locale } = useLocale()
+
 const compositions = ref<ReadSourceCompositionRow[]>([])
 const selectedId = ref('')
 const businessKey = ref('')
@@ -105,6 +110,17 @@ const running = ref(false)
 const listError = ref('')
 const runError = ref('')
 const result = ref<CompositionRunResult | null>(null)
+
+// IU-1: humanized chain-evidence errorCode label (+ optional hint). The raw code stays visible in a
+// demoted spot (data-testid="rscomp-evidence-error-code") — no errorMessage field exists on this
+// evidence shape, so there is nothing unsafe to hide here; the code is a registered, values-free
+// vocabulary.
+const resultErrorLabel = computed(() => integrationErrorCodeDisplayLabel(result.value?.evidence.errorCode, locale.value))
+const resultErrorHint = computed(() => integrationErrorCodeHint(result.value?.evidence.errorCode, locale.value))
+function stepErrorLabel(errorCode: string | undefined): string | null {
+  if (!errorCode) return null
+  return integrationErrorCodeDisplayLabel(errorCode, locale.value)
+}
 
 watch(selectedId, () => {
   result.value = null

--- a/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
@@ -203,7 +203,10 @@
             <li v-if="probeEvidence.timeoutReached !== undefined" data-testid="rsc-evidence-timeout">
               timeoutReached: {{ probeEvidence.timeoutReached ? 'true' : 'false' }}
             </li>
-            <li v-if="probeEvidence.errorCode" data-testid="rsc-evidence-error-code">errorCode: {{ probeEvidence.errorCode }}</li>
+            <li v-if="probeEvidence.errorCode" data-testid="rsc-evidence-error-label">
+              {{ probeEvidenceErrorLabel }}<template v-if="probeEvidenceErrorHint"> — {{ probeEvidenceErrorHint }}</template>
+              <small data-testid="rsc-evidence-error-code">errorCode: {{ probeEvidence.errorCode }}</small>
+            </li>
             <li v-if="probeEvidence.errorType" data-testid="rsc-evidence-error-type">errorType: {{ probeEvidence.errorType }}</li>
           </ul>
         </div>
@@ -289,6 +292,8 @@
 // The probe evidence path is allowlist-normalized in the service layer, so row values or
 // field keys can never reach this template even from a malformed response.
 import { computed, reactive, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../../services/integration/errorCodeLabels'
 import type { IntegrationScope, WorkbenchExternalSystem } from '../../services/integration/workbench'
 import {
   READ_SOURCE_KEY_ENCODINGS,
@@ -315,6 +320,8 @@ const props = defineProps<{
   systems: WorkbenchExternalSystem[]
 }>()
 
+const { locale } = useLocale()
+
 const draft = reactive(createReadSourceConfigDraft())
 const boundedSmoke = ref(false)
 const probeKey = ref('')
@@ -338,6 +345,16 @@ const evidenceContainers = computed(() => {
     return shape ? [{ alias, shape }] : []
   })
 })
+// IU-1: humanized probe evidence errorCode label (+ optional hint). The raw code stays visible in a
+// demoted/secondary spot (data-testid="rsc-evidence-error-code") for expert troubleshooting — only the
+// backend's free-text errorMessage (which does not exist on this evidence shape) would be unsafe to
+// render; the code itself is a registered, values-free vocabulary.
+const probeEvidenceErrorLabel = computed(() =>
+  integrationErrorCodeDisplayLabel(probeEvidence.value?.errorCode, locale.value),
+)
+const probeEvidenceErrorHint = computed(() =>
+  integrationErrorCodeHint(probeEvidence.value?.errorCode, locale.value),
+)
 const showKeyField = computed(() => draft.mode !== 'list_page')
 const keyFieldRequired = computed(() => draft.mode === 'single_record' || draft.mode === 'resolver_lookup')
 // The S2-b runtime requires inputs.key exactly when the config declares a keyField.

--- a/apps/web/src/services/integration/errorCodeLabels.ts
+++ b/apps/web/src/services/integration/errorCodeLabels.ts
@@ -1,0 +1,381 @@
+// Integration error-code humanization (IU-1, design-lock
+// docs/development/integration-ux-workbench-redesign-design-lock-20260706.md, #3739).
+//
+// Scope: a values-free, exact-key lookup from a closed-ish set of integration error CODES to a
+// human-readable {zh, en} label (+ optional hint). This module never touches raw backend `errorMessage`
+// free text — that channel is NOT safe to render (it can carry secret-shaped values scrubbed only at
+// dead-letter write time, see plugin-integration-core/lib/dead-letter.cjs scrubSecretStringValue). Codes,
+// by contrast, are drawn from a small registered vocabulary and are safe to show even when unlabeled here
+// (the raw code, never the message, may still appear in a secondary/collapsed "expert" slot at call sites).
+//
+// Lookup is EXACT-KEY ONLY (plain object own-key access) — never a prefix/regex match. An enum-SHAPED
+// string that is not itself a registered key (e.g. a future code this module hasn't caught up to yet)
+// must resolve to `null` from `integrationErrorCodeLabel`, never a guessed label.
+//
+// Source of truth for each family (verify current spelling against these files before extending):
+//   - Resolver (9) / Probe (11): apps/web/src/services/integration/readSourceConfigs.ts
+//     RESOLVER_ERROR_CODES / READ_SOURCE_PROBE_ERROR_CODES (client mirrors of
+//     plugins/plugin-integration-core/lib/read-source-probe-contract.cjs).
+//   - Composition (8): apps/web/src/services/integration/readSourceCompositions.ts
+//     COMPOSITION_PLAN_ERROR_CODES (client mirror of
+//     plugins/plugin-integration-core/lib/read-source-composition-planner.cjs
+//     READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES).
+//   - K3 WISE BOM-list-by-material (8): plugins/plugin-integration-core/lib/
+//     read-source-bom-list-by-material-contract.cjs K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES.
+//     NOT YET WIRED to any UI display site (no BOM-list-by-material UI exists yet as of IU-1) — labeled
+//     here for completeness/future use per design-lock IU-1 scope. Mirrored locally (below) rather than
+//     added to readSourceConfigs.ts, since nothing there references it today.
+//   - Dead-letter mainline (10): plugins/plugin-integration-core/lib/pipeline-runner.cjs (the mainline
+//     pipeline path) plus generic fallbacks used there and in external-write-dry-run.cjs. Dead-letter
+//     `errorCode` is fed from multiple origins and is NOT one closed server-exported array, so only the
+//     known mainline + generic-fallback codes are labeled; anything else falls back to the generic
+//     unknown label via `integrationErrorCodeDisplayLabel`.
+//
+// Deliberately NOT labeled here: the C6 external-write-specific `SAFE_WRITE_ERROR_CODES` set in
+// plugins/plugin-integration-core/lib/external-write-dry-run.cjs (AdapterValidationError,
+// DATA_SOURCE_*, DataSource*Error, DUPLICATE_KEY, and the test-injection code). Those belong to the
+// still-W1-gated external-write self-service ladder, not the mainline read/monitor flow this slice
+// touches — inventing zh/en semantics for a not-yet-shipped write surface would be scope creep.
+
+import type { AppLocale } from '../../composables/useLocale'
+
+export type IntegrationErrorLabel = {
+  zh: string
+  en: string
+  hint?: { zh: string; en: string }
+}
+
+// K3 WISE BOM-list-by-material — local mirror of the server's closed vocabulary. Not referenced by
+// readSourceConfigs.ts (nothing there consumes it yet); kept here only so this module's coverage is
+// complete. See module header for rationale.
+export const K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES = [
+  'K3_WISE_BOM_LIST_BY_MATERIAL_NOT_CONFIGURED',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_KEY_INVALID',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_REJECTED',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_FAILED',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_SHAPE_MISMATCH',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_NOT_FOUND',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_AMBIGUOUS',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_FIELD_MISSING',
+] as const
+
+// Dead-letter "known mainline" codes — not a single server-exported array (dead-letter `errorCode` is
+// fed from multiple pipeline stages), so this is a hand-curated list of the known mainline + generic
+// fallback codes only. See module header.
+export const DEAD_LETTER_MAINLINE_ERROR_CODES = [
+  'INVALID_SOURCE_RECORD',
+  'TRANSFORM_FAILED',
+  'VALIDATION_FAILED',
+  'IDEMPOTENCY_FAILED',
+  'TARGET_PREVIEW_FAILED',
+  'TARGET_WRITE_FAILED',
+  'TARGET_WRITE_UNMATCHED_ERROR',
+  'TARGET_WRITE_AGGREGATE_FAILED',
+  'WRITE_FAILED',
+  'UNKNOWN_ERROR',
+] as const
+
+export type IntegrationErrorCode =
+  // Resolver (9)
+  | 'READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND'
+  | 'READ_SOURCE_RESOLVER_SHAPE_MISMATCH'
+  | 'READ_SOURCE_RESOLVER_NO_MATCH'
+  | 'READ_SOURCE_RESOLVER_AMBIGUOUS'
+  | 'READ_SOURCE_RESOLVER_CAP_REACHED'
+  | 'READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED'
+  | 'READ_SOURCE_RESOLVER_RULE_INVALID'
+  | 'READ_SOURCE_RESOLVER_FIELD_MISSING'
+  | 'READ_SOURCE_RESOLVER_FAILED'
+  // Probe (11 own; union with resolver = 20)
+  | 'READ_SOURCE_PROBE_CONTRACT_INVALID'
+  | 'READ_SOURCE_PROBE_FAILED'
+  | 'READ_SOURCE_PROBE_AUTH_FAILED'
+  | 'READ_SOURCE_PROBE_CAP_REACHED'
+  | 'READ_SOURCE_PROBE_CONFIG_INVALID'
+  | 'READ_SOURCE_PROBE_CONTAINER_NOT_FOUND'
+  | 'READ_SOURCE_PROBE_NETWORK_FAILED'
+  | 'READ_SOURCE_PROBE_REJECTED'
+  | 'READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED'
+  | 'READ_SOURCE_PROBE_SHAPE_MISMATCH'
+  | 'READ_SOURCE_PROBE_TIMEOUT'
+  // Composition (8)
+  | 'READ_SOURCE_COMPOSITION_PLAN_INVALID'
+  | 'READ_SOURCE_COMPOSITION_STEP_ORDINAL_INVALID'
+  | 'READ_SOURCE_COMPOSITION_HANDOFF_VALUE_MISSING'
+  | 'READ_SOURCE_COMPOSITION_HANDOFF_TARGET_MISMATCH'
+  | 'READ_SOURCE_COMPOSITION_HANDOFF_VALUE_INVALID'
+  | 'READ_SOURCE_COMPOSITION_STEP_FAILED'
+  | 'READ_SOURCE_COMPOSITION_STEP_NOT_RUN'
+  | 'READ_SOURCE_COMPOSITION_STEP_OUTPUT_NOT_SCALAR'
+  // K3 WISE BOM-list-by-material (8) — see K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES above
+  | (typeof K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES)[number]
+  // Dead-letter known mainline (10) — see DEAD_LETTER_MAINLINE_ERROR_CODES above
+  | (typeof DEAD_LETTER_MAINLINE_ERROR_CODES)[number]
+
+const INTEGRATION_ERROR_CODE_LABELS: Record<IntegrationErrorCode, IntegrationErrorLabel> = {
+  // --- Resolver (9) ---
+  READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND: {
+    zh: '未找到用于解析的数据容器',
+    en: 'The data container used for resolving could not be found.',
+  },
+  READ_SOURCE_RESOLVER_SHAPE_MISMATCH: {
+    zh: '数据形状与解析规则不匹配',
+    en: 'The data shape does not match the resolver rule.',
+  },
+  READ_SOURCE_RESOLVER_NO_MATCH: {
+    zh: '未匹配到符合条件的记录',
+    en: 'No record matched the resolver rule.',
+    hint: { zh: '请检查筛选条件是否过窄', en: 'Check whether the filter is too narrow.' },
+  },
+  READ_SOURCE_RESOLVER_AMBIGUOUS: {
+    zh: '匹配到多条记录，无法唯一确定',
+    en: 'Multiple records matched; the result is ambiguous.',
+    hint: {
+      zh: '请收窄筛选条件或改用唯一性字段',
+      en: 'Narrow the filter or use a field that uniquely identifies the record.',
+    },
+  },
+  READ_SOURCE_RESOLVER_CAP_REACHED: {
+    zh: '候选记录数超过处理上限',
+    en: 'The number of candidate records exceeded the processing cap.',
+    hint: { zh: '请收窄筛选范围', en: 'Narrow the filter scope.' },
+  },
+  READ_SOURCE_RESOLVER_RULE_NOT_SUPPORTED: {
+    zh: '该解析规则暂不支持',
+    en: 'This resolver rule is not supported.',
+  },
+  READ_SOURCE_RESOLVER_RULE_INVALID: {
+    zh: '解析规则配置无效',
+    en: 'The resolver rule configuration is invalid.',
+  },
+  READ_SOURCE_RESOLVER_FIELD_MISSING: {
+    zh: '解析规则所需字段缺失',
+    en: 'A field required by the resolver rule is missing.',
+  },
+  READ_SOURCE_RESOLVER_FAILED: {
+    zh: '解析执行失败',
+    en: 'Resolver execution failed.',
+  },
+
+  // --- Probe (11) ---
+  READ_SOURCE_PROBE_CONTRACT_INVALID: {
+    zh: '读取源配置不符合契约要求',
+    en: 'The read-source configuration does not satisfy the contract.',
+  },
+  READ_SOURCE_PROBE_FAILED: {
+    zh: '探测执行失败',
+    en: 'The probe run failed.',
+  },
+  READ_SOURCE_PROBE_AUTH_FAILED: {
+    zh: '连接鉴权失败',
+    en: 'Authentication to the source failed.',
+    hint: { zh: '请检查连接凭据是否有效', en: 'Check whether the connection credentials are still valid.' },
+  },
+  READ_SOURCE_PROBE_CAP_REACHED: {
+    zh: '探测数据量超过上限',
+    en: 'The probed data volume exceeded the cap.',
+  },
+  READ_SOURCE_PROBE_CONFIG_INVALID: {
+    zh: '读取源配置无效',
+    en: 'The read-source configuration is invalid.',
+  },
+  READ_SOURCE_PROBE_CONTAINER_NOT_FOUND: {
+    zh: '未找到目标数据容器',
+    en: 'The target data container could not be found.',
+    hint: { zh: '请检查容器/表名是否正确', en: 'Check that the container or table name is correct.' },
+  },
+  READ_SOURCE_PROBE_NETWORK_FAILED: {
+    zh: '网络连接失败',
+    en: 'The network connection failed.',
+    hint: {
+      zh: '请检查网络与目标地址是否可达',
+      en: 'Check network connectivity and that the target address is reachable.',
+    },
+  },
+  READ_SOURCE_PROBE_REJECTED: {
+    zh: '目标系统拒绝了本次探测请求',
+    en: 'The target system rejected the probe request.',
+  },
+  READ_SOURCE_PROBE_RESPONSE_UNRECOGNIZED: {
+    zh: '目标系统返回的数据格式无法识别',
+    en: 'The response returned by the target system was not recognized.',
+  },
+  READ_SOURCE_PROBE_SHAPE_MISMATCH: {
+    zh: '返回数据的形状与预期不符',
+    en: 'The returned data shape did not match what was expected.',
+  },
+  READ_SOURCE_PROBE_TIMEOUT: {
+    zh: '探测请求超时',
+    en: 'The probe request timed out.',
+    hint: { zh: '可稍后重试或缩小探测范围', en: 'Retry later or narrow the probe scope.' },
+  },
+
+  // --- Composition (8) ---
+  READ_SOURCE_COMPOSITION_PLAN_INVALID: {
+    zh: '组合链配置无效',
+    en: 'The composition chain configuration is invalid.',
+  },
+  READ_SOURCE_COMPOSITION_STEP_ORDINAL_INVALID: {
+    zh: '组合链步骤顺序无效',
+    en: 'The composition step ordering is invalid.',
+  },
+  READ_SOURCE_COMPOSITION_HANDOFF_VALUE_MISSING: {
+    zh: '上一步输出值缺失，无法传递到下一步',
+    en: "The previous step's output value is missing, so it cannot be passed to the next step.",
+  },
+  READ_SOURCE_COMPOSITION_HANDOFF_TARGET_MISMATCH: {
+    zh: '上一步输出与下一步输入字段不匹配',
+    en: "The previous step's output does not match the next step's expected input field.",
+  },
+  READ_SOURCE_COMPOSITION_HANDOFF_VALUE_INVALID: {
+    zh: '传递到下一步的值格式无效',
+    en: 'The value passed to the next step has an invalid format.',
+  },
+  READ_SOURCE_COMPOSITION_STEP_FAILED: {
+    zh: '组合链某一步执行失败',
+    en: 'A step in the composition chain failed.',
+  },
+  READ_SOURCE_COMPOSITION_STEP_NOT_RUN: {
+    zh: '该步骤尚未执行',
+    en: 'This step has not been run yet.',
+  },
+  READ_SOURCE_COMPOSITION_STEP_OUTPUT_NOT_SCALAR: {
+    zh: '该步骤输出不是单一值，无法用于下一步',
+    en: "This step's output is not a single scalar value, so it cannot feed the next step.",
+  },
+
+  // --- K3 WISE BOM-list-by-material (8) — NOT yet wired to any UI display site ---
+  K3_WISE_BOM_LIST_BY_MATERIAL_NOT_CONFIGURED: {
+    zh: '该能力尚未配置',
+    en: 'This capability has not been configured.',
+  },
+  K3_WISE_BOM_LIST_BY_MATERIAL_KEY_INVALID: {
+    zh: '物料内码必须是纯数字',
+    en: 'The material internal code must be a numeric string.',
+  },
+  K3_WISE_BOM_LIST_BY_MATERIAL_REJECTED: {
+    zh: '目标系统拒绝了本次请求',
+    en: 'The target system rejected the request.',
+  },
+  K3_WISE_BOM_LIST_BY_MATERIAL_FAILED: {
+    zh: '查询执行失败',
+    en: 'The query failed to execute.',
+  },
+  K3_WISE_BOM_LIST_BY_MATERIAL_SHAPE_MISMATCH: {
+    zh: '返回数据的形状与预期不符',
+    en: 'The returned data shape did not match what was expected.',
+  },
+  K3_WISE_BOM_LIST_BY_MATERIAL_NOT_FOUND: {
+    zh: '未找到该物料的 BOM',
+    en: 'No BOM was found for this material.',
+  },
+  K3_WISE_BOM_LIST_BY_MATERIAL_AMBIGUOUS: {
+    zh: '该物料存在多个 BOM，按唯一性策略未自动选择',
+    en: 'Multiple BOMs exist for this material; the uniqueness policy did not auto-select one.',
+    hint: {
+      zh: '可提供单一 BOM 的样例，或增加版本等筛选条件',
+      en: 'Provide a sample with a single BOM, or add a version filter to narrow the match.',
+    },
+  },
+  K3_WISE_BOM_LIST_BY_MATERIAL_FIELD_MISSING: {
+    zh: '所需字段缺失',
+    en: 'A required field is missing.',
+  },
+
+  // --- Dead-letter known mainline (10) ---
+  INVALID_SOURCE_RECORD: {
+    zh: '源记录格式不符合要求',
+    en: 'The source record does not meet the required format.',
+  },
+  TRANSFORM_FAILED: {
+    zh: '数据转换失败',
+    en: 'Data transformation failed.',
+  },
+  VALIDATION_FAILED: {
+    zh: '数据校验未通过',
+    en: 'Data validation failed.',
+  },
+  IDEMPOTENCY_FAILED: {
+    zh: '幂等键处理失败',
+    en: 'Idempotency-key handling failed.',
+  },
+  TARGET_PREVIEW_FAILED: {
+    zh: '目标预览生成失败',
+    en: 'Generating the target preview failed.',
+  },
+  TARGET_WRITE_FAILED: {
+    zh: '写入目标系统失败',
+    en: 'Writing to the target system failed.',
+  },
+  TARGET_WRITE_UNMATCHED_ERROR: {
+    zh: '写入失败，且无法归属到具体记录',
+    en: 'The write failed and could not be attributed to a specific record.',
+  },
+  TARGET_WRITE_AGGREGATE_FAILED: {
+    zh: '批量写入中有记录未逐条归因失败原因',
+    en: 'Some records in the batch write failed without a per-record reason.',
+  },
+  WRITE_FAILED: {
+    zh: '写入失败',
+    en: 'The write failed.',
+  },
+  UNKNOWN_ERROR: {
+    zh: '发生未知错误',
+    en: 'An unknown error occurred.',
+  },
+}
+
+/**
+ * Exact-key lookup ONLY (own-key access on a plain object — no prefix/regex matching). Returns `null`
+ * for anything not an exact registered key, including enum-SHAPED strings this module hasn't caught up
+ * to (e.g. a new server-side code not yet mirrored here).
+ */
+export function integrationErrorCodeLabel(
+  code: string | undefined | null,
+  locale: AppLocale,
+): IntegrationErrorLabel | null {
+  if (!code) return null
+  if (!Object.prototype.hasOwnProperty.call(INTEGRATION_ERROR_CODE_LABELS, code)) return null
+  const entry = INTEGRATION_ERROR_CODE_LABELS[code as IntegrationErrorCode]
+  // The returned label always carries BOTH zh/en text — locale selection happens in the
+  // display-string helper below (`integrationErrorCodeDisplayLabel`), so this raw lookup stays
+  // locale-agnostic. `locale` is accepted here only to keep the call sites consistent (and to leave
+  // room for locale-specific label variants later without a signature change).
+  void locale
+  return {
+    zh: entry.zh,
+    en: entry.en,
+    ...(entry.hint ? { hint: entry.hint } : {}),
+  }
+}
+
+// Generic-unknown "prominent slot" copy — never the raw code, never a raw message.
+const INTEGRATION_UNKNOWN_ERROR_CODE_LABEL: { zh: string; en: string } = {
+  zh: '未知错误',
+  en: 'Unknown error',
+}
+
+/**
+ * The single string to render in the PROMINENT position: the registered label's zh/en text for a known
+ * code, or the generic unknown-error text for anything not registered (never the raw code, never the
+ * raw message).
+ */
+export function integrationErrorCodeDisplayLabel(
+  code: string | undefined | null,
+  locale: AppLocale,
+): string {
+  const label = integrationErrorCodeLabel(code, locale)
+  const isZh = locale === 'zh-CN'
+  if (!label) return isZh ? INTEGRATION_UNKNOWN_ERROR_CODE_LABEL.zh : INTEGRATION_UNKNOWN_ERROR_CODE_LABEL.en
+  return isZh ? label.zh : label.en
+}
+
+/** The hint text (if any) for a registered code, in the given locale — `null` when absent/unregistered. */
+export function integrationErrorCodeHint(
+  code: string | undefined | null,
+  locale: AppLocale,
+): string | null {
+  const label = integrationErrorCodeLabel(code, locale)
+  if (!label?.hint) return null
+  return locale === 'zh-CN' ? label.hint.zh : label.hint.en
+}

--- a/apps/web/src/services/integration/readSourceConfigs.ts
+++ b/apps/web/src/services/integration/readSourceConfigs.ts
@@ -424,6 +424,18 @@ export const READ_SOURCE_PROBE_ERROR_CODES: ReadonlySet<string> = new Set([
   'READ_SOURCE_PROBE_SHAPE_MISMATCH',
   'READ_SOURCE_PROBE_TIMEOUT',
   ...RESOLVER_ERROR_CODES,
+  // BL2 (#3695): the K3 BOM/GetList-by-material coarse-code family joined the server's registered probe
+  // vocabulary (read-source-probe-contract.cjs spreads K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES). Client
+  // mirror sync — without these, a by-material second-hop failure code arriving in probe/composition
+  // evidence is scrubbed to the generic fallback BEFORE the IU-1 label layer can humanize it.
+  'K3_WISE_BOM_LIST_BY_MATERIAL_NOT_CONFIGURED',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_KEY_INVALID',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_REJECTED',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_FAILED',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_SHAPE_MISMATCH',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_NOT_FOUND',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_AMBIGUOUS',
+  'K3_WISE_BOM_LIST_BY_MATERIAL_FIELD_MISSING',
 ])
 const READ_SOURCE_PROBE_ERROR_TYPES = new Set([
   'Error',

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -385,13 +385,14 @@
             </div>
             <div v-if="deadLetters.length === 0" class="k3-setup__empty">暂无 open dead letters。</div>
             <template v-else>
-              <div v-for="deadLetter in deadLetters" :key="deadLetter.id" class="k3-setup__record">
+              <div v-for="deadLetter in deadLetters" :key="deadLetter.id" class="k3-setup__record" :data-testid="`k3-dead-letter-${deadLetter.id}`">
                 <div class="k3-setup__record-main">
-                  <strong>{{ deadLetter.errorCode }}</strong>
+                  <strong :data-testid="`k3-dead-letter-label-${deadLetter.id}`">{{ deadLetterErrorLabel(deadLetter) }}</strong>
                   <span class="k3-setup__badge" :data-status="deadLetter.status">{{ deadLetter.status }}</span>
                 </div>
                 <small>{{ deadLetter.id }} · retry {{ deadLetter.retryCount }}</small>
-                <small class="k3-setup__saved-error">{{ deadLetter.errorMessage }}</small>
+                <small v-if="deadLetterErrorHint(deadLetter)" class="k3-setup__saved-error">{{ deadLetterErrorHint(deadLetter) }}</small>
+                <small :data-testid="`k3-dead-letter-code-${deadLetter.id}`">errorCode: {{ deadLetter.errorCode }}</small>
                 <small v-if="deadLetter.payloadRedacted">payload redacted</small>
               </div>
             </template>
@@ -924,6 +925,8 @@
 
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
+import { useLocale } from '../composables/useLocale'
+import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../services/integration/errorCodeLabels'
 import {
   K3_WISE_SQLSERVER_KIND,
   K3_WISE_WEBAPI_KIND,
@@ -982,6 +985,8 @@ import {
   normalizeIntegrationProjectId,
 } from '../services/integration/workbench'
 
+const { locale } = useLocale()
+
 const form = reactive(createDefaultK3WiseSetupForm())
 const webApiSystems = ref<IntegrationExternalSystem[]>([])
 const sqlSystems = ref<IntegrationExternalSystem[]>([])
@@ -1013,6 +1018,15 @@ const webApiLastTest = ref<{
 } | null>(null)
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
 const deadLetters = ref<IntegrationDeadLetter[]>([])
+// IU-1 (RATIFIED addendum): same treatment as IntegrationWorkbenchView's dead-letter list — the raw
+// `errorMessage` free-text field must NEVER reach the DOM (see that view's comment for the scrub-gap
+// rationale). Humanized label is prominent; raw `errorCode` (values-free, safe) stays in a secondary spot.
+function deadLetterErrorLabel(deadLetter: IntegrationDeadLetter): string {
+  return integrationErrorCodeDisplayLabel(deadLetter.errorCode, locale.value)
+}
+function deadLetterErrorHint(deadLetter: IntegrationDeadLetter): string | null {
+  return integrationErrorCodeHint(deadLetter.errorCode, locale.value)
+}
 const stagingDescriptors = ref<IntegrationStagingDescriptor[]>([])
 const templatePreviewTarget = ref<K3WisePipelineTarget>('material')
 

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -1205,8 +1205,9 @@
           <div v-if="deadLetters.length === 0" class="integration-workbench__empty">暂无 open dead letters。</div>
           <ol v-else class="integration-workbench__record-list" data-testid="dead-letters">
             <li v-for="deadLetter in deadLetters" :key="deadLetter.id" :data-testid="`dead-letter-${deadLetter.id}`">
-              <strong>{{ deadLetter.errorCode }}</strong>
-              <span>{{ deadLetter.errorMessage }}</span>
+              <strong :data-testid="`dead-letter-label-${deadLetter.id}`">{{ deadLetterErrorLabel(deadLetter) }}</strong>
+              <span v-if="deadLetterErrorHint(deadLetter)">{{ deadLetterErrorHint(deadLetter) }}</span>
+              <small :data-testid="`dead-letter-code-${deadLetter.id}`">errorCode: {{ deadLetter.errorCode }}</small>
               <small>
                 {{ deadLetter.status }} · {{ deadLetter.createdAt || deadLetter.id }}<template v-if="deadLetter.retryCount"> · retries {{ deadLetter.retryCount }}</template><template v-if="deadLetter.idempotencyKey"> · key {{ deadLetter.idempotencyKey }}</template>
               </small>
@@ -1410,6 +1411,8 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useAuth } from '../composables/useAuth'
+import { useLocale } from '../composables/useLocale'
+import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../services/integration/errorCodeLabels'
 import { buildXlsxBuffer } from '../multitable/import/xlsx-mapping'
 import { getDataSourceSchema, listDataSources } from '../data-sources/api'
 import type { DataSourceListItem, DataSourceTableInfo } from '../data-sources/types'
@@ -1598,6 +1601,7 @@ const flowSteps = [
   { title: '4. Dry-run / 推送', description: '预览 payload 后导出或 Save-only 写回' },
 ]
 const auth = useAuth()
+const { locale } = useLocale()
 
 const stagingDatasetCopy: Record<string, { area: string; name: string; description: string }> = {
   plm_raw_items: {
@@ -1719,6 +1723,18 @@ const stockPreparationOptionSyncResult = ref<IntegrationStockPreparationOptionSy
 const syncingStockPreparationOptions = ref(false)
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
 const deadLetters = ref<IntegrationDeadLetter[]>([])
+// IU-1 (RATIFIED addendum): the raw `errorMessage` free-text field must NEVER reach the DOM — it is
+// scrubbed for secret-shaped values only at dead-letter *write* time (see
+// plugins/plugin-integration-core/lib/dead-letter.cjs scrubSecretStringValue), so rendering it here would
+// be a leak-hole. The humanized label (generic-unknown fallback for unregistered codes) is the prominent
+// text; the raw `errorCode` (a registered, values-free vocabulary, safe to show) stays available in a
+// demoted/secondary spot for expert troubleshooting.
+function deadLetterErrorLabel(deadLetter: IntegrationDeadLetter): string {
+  return integrationErrorCodeDisplayLabel(deadLetter.errorCode, locale.value)
+}
+function deadLetterErrorHint(deadLetter: IntegrationDeadLetter): string | null {
+  return integrationErrorCodeHint(deadLetter.errorCode, locale.value)
+}
 const expandedRunIds = ref<Set<string>>(new Set())
 // DF-N2-3 (read-only): per-dead-letter cross-run provenance timeline, fetched lazily
 // on expand by the row's idempotency key (rowId). No write/replay affordance here.

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -92,6 +92,10 @@ function mockIntegrationApi(): void {
 async function flushUi(cycles = 4): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
+    // Macrotask hop: drain timer-scheduled continuations too. Microtask+nextTick alone is enough on
+    // newer Node schedulers but NOT on Node 20 (the CI runtime) — these specs' first CI run exposed
+    // that the fetch-mock chains need a timer turn before the view leaves its loading state.
+    await new Promise((resolve) => setTimeout(resolve, 0))
     await nextTick()
   }
 }

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -419,4 +419,77 @@ describe('IntegrationK3WiseSetupView', () => {
     expect(materialLink?.textContent).toContain('打开多维表')
     expect(bomLink?.getAttribute('href')).toBe('/multitable/sheet_bom_cleanse/view_bom_cleanse?baseId=base_k3')
   })
+
+  it('IU-1: humanizes dead-letter errorCode in the K3 setup mini-list and NEVER renders the raw errorMessage (RATIFIED addendum)', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/external-systems?')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url.startsWith('/api/integration/runs?') && url.includes('pipelineId=pipe_iu1')) return jsonResponse([])
+      if (url.startsWith('/api/integration/dead-letters?') && url.includes('pipelineId=pipe_iu1')) {
+        return jsonResponse([
+          {
+            id: 'dl_k3_known',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_iu1',
+            runId: 'run_iu1',
+            idempotencyKey: 'K-1',
+            errorCode: 'VALIDATION_FAILED',
+            errorMessage: 'SENTINEL-RAW-MESSAGE-K3',
+            retryCount: 0,
+            status: 'open',
+          },
+          {
+            id: 'dl_k3_unknown',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_iu1',
+            runId: 'run_iu1',
+            idempotencyKey: 'K-2',
+            errorCode: 'TOTALLY_UNKNOWN_CODE',
+            errorMessage: 'ANOTHER-SENTINEL-K3',
+            retryCount: 0,
+            status: 'open',
+          },
+        ])
+      }
+      return jsonResponse({})
+    })
+
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    registerRouterLinkStub(app)
+    app.mount(container)
+    await flushUi()
+
+    const materialPipelineInput = inputByLabel(container, '物料 Pipeline ID')
+    materialPipelineInput.value = 'pipe_iu1'
+    materialPipelineInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const refreshButton = Array.from(container.querySelectorAll('button')).find((item) => item.textContent?.includes('刷新物料状态')) as HTMLButtonElement
+    expect(refreshButton).toBeDefined()
+    expect(refreshButton.disabled).toBe(false)
+    refreshButton.click()
+    await flushUi(8)
+
+    // Test environment defaults useLocale() to 'en' (jsdom navigator.language, no localStorage override).
+    const knownLabel = container.querySelector('[data-testid="k3-dead-letter-label-dl_k3_known"]') as HTMLElement
+    expect(knownLabel).not.toBeNull()
+    expect(knownLabel.textContent).toContain('Data validation failed.')
+    expect(container.querySelector('[data-testid="k3-dead-letter-code-dl_k3_known"]')?.textContent).toContain('VALIDATION_FAILED')
+    expect(container.textContent).not.toContain('SENTINEL-RAW-MESSAGE')
+    expect(container.innerHTML).not.toContain('SENTINEL-RAW-MESSAGE')
+
+    // Unregistered code falls back to the generic unknown label in the PROMINENT slot; raw code stays
+    // in the secondary/collapsed spot (expert retention).
+    const unknownLabel = container.querySelector('[data-testid="k3-dead-letter-label-dl_k3_unknown"]') as HTMLElement
+    expect(unknownLabel).not.toBeNull()
+    expect(unknownLabel.textContent).toContain('Unknown error')
+    expect(unknownLabel.textContent).not.toContain('TOTALLY_UNKNOWN_CODE')
+    expect(container.querySelector('[data-testid="k3-dead-letter-code-dl_k3_unknown"]')?.textContent).toContain('TOTALLY_UNKNOWN_CODE')
+    expect(container.textContent).not.toContain('ANOTHER-SENTINEL-K3')
+  })
 })

--- a/apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts
@@ -178,6 +178,11 @@ describe('IntegrationReadSourceCompositionPanel', () => {
     expect(q(root, 'rscomp-evidence-error-code').textContent).toContain('READ_SOURCE_COMPOSITION_STEP_FAILED')
     expect(q(root, 'rscomp-step-1').textContent).toContain('READ_SOURCE_COMPOSITION_STEP_NOT_RUN')
     expect(root.querySelector('[data-testid="rscomp-output"]')).toBeNull()
+
+    // IU-1: the humanized label renders prominently (its own testid); the raw code is still present
+    // (demoted) for expert troubleshooting. Test environment defaults useLocale() to 'en'.
+    expect(q(root, 'rscomp-evidence-error-label').textContent).toContain('A step in the composition chain failed.')
+    expect(q(root, 'rscomp-evidence-error-code').textContent).toContain('READ_SOURCE_COMPOSITION_STEP_FAILED')
   })
 
   it('surfaces a 409 approved-only gate as a coarse error without echoing the key', async () => {

--- a/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
@@ -593,6 +593,11 @@ describe('IntegrationReadSourceConfigPanel', () => {
     expect(q(root, 'rsc-evidence-error-code').textContent).toContain('READ_SOURCE_PROBE_CONTAINER_NOT_FOUND')
     expect(q(root, 'rsc-evidence-error-type').textContent).toContain('ReadSourceProbeRuntimeError')
     expect(q(root, 'rsc-evidence-located').textContent).toContain('false')
+
+    // IU-1: the humanized label renders prominently; the raw code is still present (demoted) for
+    // expert troubleshooting. Test environment defaults useLocale() to 'en'.
+    expect(q(root, 'rsc-evidence-error-label').textContent).toContain('The target data container could not be found.')
+    expect(q(root, 'rsc-evidence-error-code').textContent).toContain('READ_SOURCE_PROBE_CONTAINER_NOT_FOUND')
   })
 
   it('surfaces contract 400 as coarse code/reason without echoing values', async () => {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -37,6 +37,10 @@ function rawJsonResponse(data: unknown): Response {
 async function flushUi(cycles = 5): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
+    // Macrotask hop: drain timer-scheduled continuations too. Microtask+nextTick alone is enough on
+    // newer Node schedulers but NOT on Node 20 (the CI runtime) — these specs' first CI run exposed
+    // that the fetch-mock chains need a timer turn before the view leaves its loading state.
+    await new Promise((resolve) => setTimeout(resolve, 0))
     await nextTick()
   }
 }

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1815,6 +1815,82 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.textContent).toContain('Replay 成功')
   })
 
+  it('IU-1: humanizes dead-letter errorCode and NEVER renders the raw errorMessage (RATIFIED addendum)', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_iu1&limit=5') return jsonResponse([])
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_iu1&status=open&limit=5') {
+        return jsonResponse([
+          {
+            id: 'dl_iu1_known',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_iu1',
+            runId: 'run_iu1',
+            idempotencyKey: 'K-1',
+            errorCode: 'VALIDATION_FAILED',
+            errorMessage: 'SENTINEL-RAW-MESSAGE-\u{1F645}',
+            retryCount: 0,
+            status: 'open',
+          },
+          {
+            id: 'dl_iu1_unknown',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_iu1',
+            runId: 'run_iu1',
+            idempotencyKey: 'K-2',
+            errorCode: 'TOTALLY_UNKNOWN_CODE',
+            errorMessage: 'ANOTHER-SENTINEL-RAW-MESSAGE',
+            retryCount: 0,
+            status: 'open',
+          },
+        ])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_iu1'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="refresh-observation"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // Registered code humanizes; raw errorMessage never reaches the DOM anywhere.
+    // Test environment defaults useLocale() to 'en' (jsdom navigator.language, no localStorage override).
+    const knownLabel = container.querySelector('[data-testid="dead-letter-label-dl_iu1_known"]') as HTMLElement
+    expect(knownLabel).not.toBeNull()
+    expect(knownLabel.textContent).toContain('Data validation failed.')
+    expect(container.querySelector('[data-testid="dead-letter-code-dl_iu1_known"]')?.textContent).toContain('VALIDATION_FAILED')
+    expect(container.textContent).not.toContain('SENTINEL-RAW-MESSAGE')
+    expect(container.innerHTML).not.toContain('SENTINEL-RAW-MESSAGE')
+
+    // Unregistered code falls back to the generic unknown label in the PROMINENT slot; the raw code is
+    // still present in the secondary/collapsed spot (expert retention).
+    const unknownLabel = container.querySelector('[data-testid="dead-letter-label-dl_iu1_unknown"]') as HTMLElement
+    expect(unknownLabel).not.toBeNull()
+    expect(unknownLabel.textContent).toContain('Unknown error')
+    expect(unknownLabel.textContent).not.toContain('TOTALLY_UNKNOWN_CODE')
+    expect(container.querySelector('[data-testid="dead-letter-code-dl_iu1_unknown"]')?.textContent).toContain('TOTALLY_UNKNOWN_CODE')
+    expect(container.textContent).not.toContain('ANOTHER-SENTINEL-RAW-MESSAGE')
+  })
+
   it('expands a dead-letter into a read-only cross-run provenance timeline (fires by-rowId GET with rowId+pipelineId)', async () => {
     const provenanceCalls: Array<{ url: string; method?: string }> = []
     apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {

--- a/apps/web/tests/integrationErrorCodeLabels.spec.ts
+++ b/apps/web/tests/integrationErrorCodeLabels.spec.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import { READ_SOURCE_PROBE_ERROR_CODES as CLIENT_PROBE_ERROR_CODES } from '../src/services/integration/readSourceConfigs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
@@ -39,16 +40,21 @@ describe('errorCodeLabels coverage (mirror tripwire)', () => {
   })
 
   it('every server probe code (union set) has a label', () => {
-    // NOTE: as of this writing the server's READ_SOURCE_PROBE_ERROR_CODES spreads in BOTH the 9
-    // resolver codes AND the 8 K3 WISE BOM-list-by-material codes (BL2), so the union is 28, not the
-    // 20 originally cited in the design-lock research doc (11 probe-own + 9 resolver) — the doc itself
-    // warned the cited line numbers/counts might have shifted since. This is a PRE-EXISTING drift
-    // between the server vocabulary and the client mirror in readSourceConfigs.ts (which still only
-    // spreads in the 9 resolver codes, not the 8 BOM-list codes) — out of scope to fix here (IU-1 is
-    // labels-only, zero behavior change), but every code in the server's CURRENT union set must still
-    // have a label in this module, which is asserted below.
+    // The server's READ_SOURCE_PROBE_ERROR_CODES spreads in BOTH the 9 resolver codes AND the 8
+    // K3 WISE BOM-list-by-material codes (BL2) — union 28.
     expect(SERVER_PROBE_ERROR_CODES.length).toBe(28)
     for (const code of SERVER_PROBE_ERROR_CODES) expectLabeled(code)
+  })
+
+  it('client probe-code mirror covers the full server union (no client-side scrubbing of registered codes)', () => {
+    // Mirror-drift tripwire (quality-gate finding on IU-1): the client allowlist in readSourceConfigs.ts
+    // must contain EVERY server-registered probe/resolver/BOM-list code — otherwise a registered code
+    // arriving in probe/composition evidence is scrubbed to the generic fallback BEFORE the label layer
+    // sees it, and its label is dead code. A future server-side family addition fails here until the
+    // client mirror (and its labels) are synced.
+    for (const code of SERVER_PROBE_ERROR_CODES) {
+      expect(CLIENT_PROBE_ERROR_CODES.has(code), `client mirror missing ${code}`).toBe(true)
+    }
   })
 
   it('every server composition code (8) has a label', () => {

--- a/apps/web/tests/integrationErrorCodeLabels.spec.ts
+++ b/apps/web/tests/integrationErrorCodeLabels.spec.ts
@@ -1,0 +1,116 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Mirror-sync tripwire (IU-1, design-lock docs/development/integration-ux-workbench-redesign-design-lock-20260706.md,
+// #3739): every code in the server's registered vocabularies (resolver/probe/composition/BOM-list) must
+// have a non-empty zh + en label entry in errorCodeLabels.ts. If the server ever extends a vocabulary and
+// this module is not synced, this test fails RED — same discipline as
+// multitable-resolver-vocab-mirror.spec.ts / composition-vocab-mirror.spec.ts.
+import {
+  DEAD_LETTER_MAINLINE_ERROR_CODES,
+  K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES,
+  integrationErrorCodeDisplayLabel,
+  integrationErrorCodeLabel,
+} from '../src/services/integration/errorCodeLabels'
+
+const require = createRequire(import.meta.url)
+const pluginLib = path.resolve(__dirname, '../../../plugins/plugin-integration-core/lib')
+
+// The server exports these directly — require, never text-parse.
+const { READ_SOURCE_PROBE_ERROR_CODES: SERVER_PROBE_ERROR_CODES, READ_SOURCE_RESOLVER_ERROR_CODES: SERVER_RESOLVER_ERROR_CODES } =
+  require(path.join(pluginLib, 'read-source-probe-contract.cjs'))
+const { READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES: SERVER_COMPOSITION_ERROR_CODES } =
+  require(path.join(pluginLib, 'read-source-composition-planner.cjs'))
+const { K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES: SERVER_BOM_LIST_ERROR_CODES } =
+  require(path.join(pluginLib, 'read-source-bom-list-by-material-contract.cjs'))
+
+function expectLabeled(code: string): void {
+  const label = integrationErrorCodeLabel(code, 'en')
+  expect(label, `expected a label entry for ${code}`).not.toBeNull()
+  expect(label?.zh, `${code} zh must be non-empty`).toBeTruthy()
+  expect(label?.en, `${code} en must be non-empty`).toBeTruthy()
+}
+
+describe('errorCodeLabels coverage (mirror tripwire)', () => {
+  it('every server resolver code (9) has a label', () => {
+    expect(SERVER_RESOLVER_ERROR_CODES.length).toBe(9)
+    for (const code of SERVER_RESOLVER_ERROR_CODES) expectLabeled(code)
+  })
+
+  it('every server probe code (union set) has a label', () => {
+    // NOTE: as of this writing the server's READ_SOURCE_PROBE_ERROR_CODES spreads in BOTH the 9
+    // resolver codes AND the 8 K3 WISE BOM-list-by-material codes (BL2), so the union is 28, not the
+    // 20 originally cited in the design-lock research doc (11 probe-own + 9 resolver) — the doc itself
+    // warned the cited line numbers/counts might have shifted since. This is a PRE-EXISTING drift
+    // between the server vocabulary and the client mirror in readSourceConfigs.ts (which still only
+    // spreads in the 9 resolver codes, not the 8 BOM-list codes) — out of scope to fix here (IU-1 is
+    // labels-only, zero behavior change), but every code in the server's CURRENT union set must still
+    // have a label in this module, which is asserted below.
+    expect(SERVER_PROBE_ERROR_CODES.length).toBe(28)
+    for (const code of SERVER_PROBE_ERROR_CODES) expectLabeled(code)
+  })
+
+  it('every server composition code (8) has a label', () => {
+    expect(SERVER_COMPOSITION_ERROR_CODES.length).toBe(8)
+    for (const code of SERVER_COMPOSITION_ERROR_CODES) expectLabeled(code)
+  })
+
+  it('every server K3 WISE BOM-list-by-material code (8) has a label, and the local mirror matches the server set', () => {
+    expect(SERVER_BOM_LIST_ERROR_CODES.length).toBe(8)
+    expect(new Set(K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES)).toEqual(new Set(SERVER_BOM_LIST_ERROR_CODES))
+    for (const code of SERVER_BOM_LIST_ERROR_CODES) expectLabeled(code)
+  })
+
+  it('every dead-letter known-mainline code (10) has a label', () => {
+    expect(DEAD_LETTER_MAINLINE_ERROR_CODES.length).toBe(10)
+    for (const code of DEAD_LETTER_MAINLINE_ERROR_CODES) expectLabeled(code)
+  })
+})
+
+describe('integrationErrorCodeLabel / integrationErrorCodeDisplayLabel (exact-key lookup only)', () => {
+  it('returns null for an enum-shaped-but-unregistered code', () => {
+    expect(integrationErrorCodeLabel('READ_SOURCE_PROBE_NOT_A_REAL_CODE', 'en')).toBeNull()
+  })
+
+  it('returns null for undefined / null / empty string', () => {
+    expect(integrationErrorCodeLabel(undefined, 'en')).toBeNull()
+    expect(integrationErrorCodeLabel(null, 'en')).toBeNull()
+    expect(integrationErrorCodeLabel('', 'en')).toBeNull()
+  })
+
+  it('does not prefix/substring match — a code that merely CONTAINS a registered code is not a hit', () => {
+    expect(integrationErrorCodeLabel('READ_SOURCE_PROBE_TIMEOUT_EXTRA', 'en')).toBeNull()
+    expect(integrationErrorCodeLabel('XREAD_SOURCE_PROBE_TIMEOUT', 'en')).toBeNull()
+  })
+
+  it('never resolves inherited Object.prototype keys as a "code"', () => {
+    expect(integrationErrorCodeLabel('toString', 'en')).toBeNull()
+    expect(integrationErrorCodeLabel('constructor', 'en')).toBeNull()
+    expect(integrationErrorCodeLabel('hasOwnProperty', 'en')).toBeNull()
+  })
+
+  it('integrationErrorCodeDisplayLabel returns the generic unknown text for unregistered codes', () => {
+    expect(integrationErrorCodeDisplayLabel('READ_SOURCE_PROBE_NOT_A_REAL_CODE', 'en')).toBe('Unknown error')
+    expect(integrationErrorCodeDisplayLabel('READ_SOURCE_PROBE_NOT_A_REAL_CODE', 'zh-CN')).toBe('未知错误')
+    expect(integrationErrorCodeDisplayLabel(undefined, 'en')).toBe('Unknown error')
+  })
+
+  it('locale switching: the same registered code returns different zh vs en text', () => {
+    const zh = integrationErrorCodeLabel('READ_SOURCE_RESOLVER_AMBIGUOUS', 'zh-CN')
+    const en = integrationErrorCodeLabel('READ_SOURCE_RESOLVER_AMBIGUOUS', 'en')
+    expect(zh?.zh).toBe('匹配到多条记录，无法唯一确定')
+    expect(en?.en).toBe('Multiple records matched; the result is ambiguous.')
+    expect(zh?.zh).not.toBe(en?.en)
+
+    expect(integrationErrorCodeDisplayLabel('READ_SOURCE_RESOLVER_AMBIGUOUS', 'zh-CN')).toBe('匹配到多条记录，无法唯一确定')
+    expect(integrationErrorCodeDisplayLabel('READ_SOURCE_RESOLVER_AMBIGUOUS', 'en')).toBe(
+      'Multiple records matched; the result is ambiguous.',
+    )
+  })
+
+  it('a registered code with a hint carries it through; one without does not', () => {
+    expect(integrationErrorCodeLabel('READ_SOURCE_RESOLVER_AMBIGUOUS', 'en')?.hint?.en).toBeTruthy()
+    expect(integrationErrorCodeLabel('READ_SOURCE_RESOLVER_FAILED', 'en')?.hint).toBeUndefined()
+  })
+})

--- a/docs/development/integration-iu1-error-code-labels-dev-verification-20260706.md
+++ b/docs/development/integration-iu1-error-code-labels-dev-verification-20260706.md
@@ -1,0 +1,171 @@
+# IU-1: Integration error-code humanization — dev verification (2026-07-06)
+
+Scope: design-lock `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md` (PR
+#3739, overall PROPOSED, IU-1 owner-authorized to proceed) + the RATIFIED addendum (errorMessage must
+never render raw, anywhere on the integration surface). Pure frontend, zero behavior change: one new
+label module, label-only edits to 4 Vue display sites, tests, CI path-filter additions, this MD.
+
+## What changed
+
+1. **New module**: `apps/web/src/services/integration/errorCodeLabels.ts` — an exact-key (own-property)
+   lookup from a closed-ish set of integration error CODES to a `{zh, en, hint?}` label. Exports:
+   `IntegrationErrorLabel`, `integrationErrorCodeLabel(code, locale)` (exact lookup, `null` on miss),
+   `integrationErrorCodeDisplayLabel(code, locale)` (prominent-slot string, generic "未知错误"/"Unknown
+   error" fallback on miss), `integrationErrorCodeHint(code, locale)`, plus the local
+   `K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES` mirror and the hand-curated
+   `DEAD_LETTER_MAINLINE_ERROR_CODES` list.
+2. **4 display sites wired** (label-only edits, `useLocale` imported where absent):
+   - `apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue` — probe evidence
+     `errorCode` line: humanized label + hint now prominent; raw code demoted into a nested `<small
+     data-testid="rsc-evidence-error-code">`; new `data-testid="rsc-evidence-error-label"` on the label.
+   - `apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue` — standalone chain
+     `evidence.errorCode` line: same treatment (`rscomp-evidence-error-label` new testid,
+     `rscomp-evidence-error-code` kept on the demoted raw-code element); per-step inline debug line gets
+     the label appended in parens (`errorCode=X (Human label)`), no new testid (already a dense
+     expert/debug line per the task's own priority call).
+   - `apps/web/src/views/IntegrationWorkbenchView.vue` — dead-letter list: raw `<span>{{
+     deadLetter.errorMessage }}</span>` **deleted**; `<strong>` now shows the humanized label (generic
+     "Unknown error" fallback for unregistered codes); hint (if any) renders where the message used to be;
+     raw `errorCode` demoted into `<small data-testid="dead-letter-code-<id>">`; new
+     `data-testid="dead-letter-label-<id>"` on the label.
+   - `apps/web/src/views/IntegrationK3WiseSetupView.vue` — K3 setup's own mini dead-letter list: same
+     treatment. This block had **no** `data-testid`s at all before; added
+     `k3-dead-letter-<id>` / `k3-dead-letter-label-<id>` / `k3-dead-letter-code-<id>`, following the
+     Workbench view's `` `dead-letter-${id}` `` templating convention.
+3. **CI**: `.github/workflows/integration-guard.yml` path filters (both `pull_request` and `push`)
+   extended to cover `errorCodeLabels.ts`, `integrationErrorCodeLabels.spec.ts`,
+   `IntegrationWorkbenchView.vue`/`.spec.ts`, `IntegrationK3WiseSetupView.vue`/`.spec.ts`; the guard's
+   `vitest run` command extended to include all of these (both view specs run clean standalone, see Test
+   evidence below, so both are included in the gated command — not deferred).
+
+## RATIFIED addendum: errorMessage leak-hole — CLOSED
+
+Grepped the whole integration surface for `deadLetter.errorMessage` (the dead-letter shape's raw
+free-text field, distinct from the many unrelated local-component `errorMessage` refs elsewhere in
+`apps/web/src`, e.g. `LoginView.vue`, `SpreadsheetsView.vue`, `AttendanceView.vue`, etc. — those are a
+different concept and out of scope). Confirmed exactly 2 render sites, both closed:
+
+1. `IntegrationWorkbenchView.vue` (~line 1208-1209, now ~1207-1212): raw `errorMessage` interpolation
+   deleted entirely. Sentinel test (`IntegrationWorkbenchView.spec.ts`, new `it` block "IU-1: humanizes
+   dead-letter errorCode and NEVER renders the raw errorMessage") asserts
+   `container.textContent` / `container.innerHTML` do **not** contain the sentinel
+   `SENTINEL-RAW-MESSAGE-🙅` (or the second fixture's `ANOTHER-SENTINEL-RAW-MESSAGE`) anywhere, for both a
+   registered code (`VALIDATION_FAILED` → humanized) and an unregistered one (`TOTALLY_UNKNOWN_CODE` →
+   generic "Unknown error"). PASSED.
+2. `IntegrationK3WiseSetupView.vue` (~line 388-394, now ~388-396): same treatment, same sentinel pattern.
+   New `it` block "IU-1: humanizes dead-letter errorCode in the K3 setup mini-list and NEVER renders the
+   raw errorMessage (RATIFIED addendum)" in `IntegrationK3WiseSetupView.spec.ts` — this spec had no
+   dead-letter mock/test coverage at all before, so a minimal `/api/integration/dead-letters?...` mock was
+   added following the pattern already used by `IntegrationWorkbenchView.spec.ts`. PASSED.
+
+Both sites: unknown/unregistered `errorCode` → the PROMINENT slot shows the generic "未知错误"/"Unknown
+error" label (never the raw code, never any part of the message); the raw CODE (not message) remains
+visible in a demoted/secondary `<small>` element for expert troubleshooting.
+
+**Noted gap, explicitly out of scope**: `IntegrationK3WiseSetupView.vue`'s neighboring `run.errorSummary`
+field (~line 376, in the "最近运行" pipeline-run list, not the dead-letter list) is a separate free-text
+field with no paired `errorCode` to derive a label from. It still renders raw. This is a related leak but
+a different kind of fix (there's nothing to key a label lookup off of) — flagged here for a future slice,
+not touched in IU-1.
+
+## Coverage table
+
+| Code family | Count labeled | Source of truth |
+|---|---|---|
+| Resolver | 9 | `apps/web/src/services/integration/readSourceConfigs.ts` `RESOLVER_ERROR_CODES` (mirrors `plugins/plugin-integration-core/lib/read-source-probe-contract.cjs` `READ_SOURCE_RESOLVER_ERROR_CODES`) |
+| Probe (own, 11) | 11 | same file `READ_SOURCE_PROBE_ERROR_CODES` (own entries, before resolver/BOM-list spread) |
+| Composition | 8 | `apps/web/src/services/integration/readSourceCompositions.ts` `COMPOSITION_PLAN_ERROR_CODES` (mirrors `plugins/plugin-integration-core/lib/read-source-composition-planner.cjs` `READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES`) |
+| K3 WISE BOM-list-by-material | 8 | `plugins/plugin-integration-core/lib/read-source-bom-list-by-material-contract.cjs` `K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES`; mirrored locally in `errorCodeLabels.ts` (not added to `readSourceConfigs.ts` — nothing there references it). **NOT yet wired to any UI display site** — no BOM-list-by-material UI exists yet; labeled for completeness/future use per design-lock scope. |
+| Dead-letter known mainline | 10 | Hand-curated from `plugins/plugin-integration-core/lib/pipeline-runner.cjs` (mainline path) + generic fallbacks also used in `external-write-dry-run.cjs` (`WRITE_FAILED`, `UNKNOWN_ERROR`). Not a single server-exported array — dead-letter `errorCode` is fed from multiple origins. |
+| **Total labeled** | **46** (28 in the server's current probe union set + 8 composition + 10 dead-letter, with resolver's 9 counted inside the probe union) | — |
+
+### Research-drift finding (verified against current `main`, not re-derived from the design-lock doc)
+
+The design-lock research doc cited the server's probe/resolver union set size as 20 (11 probe-own + 9
+resolver). As of this branch's base commit, the server's exported `READ_SOURCE_PROBE_ERROR_CODES` in
+`read-source-probe-contract.cjs` **also** spreads in the 8 K3 WISE BOM-list-by-material codes (a BL2
+addition), making the true current union **28**. This is a **pre-existing** drift between the server
+vocabulary and the client mirror in `readSourceConfigs.ts` (which still only spreads in the 9 resolver
+codes, not the 8 BOM-list codes) — **out of scope to fix here** (IU-1 is labels-only, zero behavior
+change; fixing the client mirror's own allowlist is a `readSourceConfigs.ts` runtime change, not a label
+change). The mirror-tripwire test (`integrationErrorCodeLabels.spec.ts`) asserts every code in the
+server's **current** union (28) has a label — it already does, since this module labels the BOM-list
+family separately. Flagging this drift here so it isn't silently rediscovered later.
+
+### Deliberately NOT labeled (owner-flagged in the task, reconfirmed against current source)
+
+The C6 external-write-specific `SAFE_WRITE_ERROR_CODES` set in
+`plugins/plugin-integration-core/lib/external-write-dry-run.cjs` (~line 23-38, verified current):
+`AdapterValidationError`, `DATA_SOURCE_BRIDGE_CONFIG_ERROR`, `DATA_SOURCE_GENERIC_QUERY_DISABLED_REQUIRED`,
+`DATA_SOURCE_NOT_C6_WRITE_TARGET`, `DATA_SOURCE_NOT_FOUND`, `DATA_SOURCE_NOT_VISIBLE`,
+`DATA_SOURCE_NOT_WRITABLE`, `DATA_SOURCE_PRINCIPAL_REQUIRED`, `DATA_SOURCE_QUERY_INVALID`,
+`DataSourceBridgeConfigError`, `DataSourceNotC6WriteTargetError`, `DataSourceNotWritableError`,
+`DataSourceQueryDisabledError`, `DataSourceUnavailableError`, `DUPLICATE_KEY`, plus a test-injection code.
+**Reasoning**: these belong to the still-W1-gated external-write self-service ladder (per project memory:
+W1 config is still mid-review, W2-W4 not started), not the mainline read/monitor flow this slice touches.
+Inventing zh/en semantics for a not-yet-shipped write surface would be scope creep and risks getting the
+copy wrong before the surface's own design is settled. Listed explicitly here (not labeled) rather than
+silently omitted.
+
+## Zero-behavior-change statement
+
+- No route changes, no service-wire shape changes, no permission changes, no backend logic changes.
+- All edits are: (a) one new pure frontend module with no side effects, (b) label-only template edits to 4
+  existing Vue files (adding/reordering display text + `data-testid`s; no new network calls, no new
+  computed state beyond the label/hint derivation, no changed control flow), (c) tests, (d) CI path
+  filters, (e) this MD.
+- `vue-tsc -b` (`pnpm --filter @metasheet/web run type-check`) is clean — no new type errors.
+- All pre-existing tests in the 4 touched Vue files' specs continue to pass unmodified (25 + 49 + 7 =
+  81 pre-existing tests all still green after the edits, before any new `it` blocks were added).
+
+## Test evidence
+
+Ran `pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationK3WiseSetupView --reporter=dot`
+(exactly the CI guard's post-change command):
+
+```
+✓ tests/integrationErrorCodeLabels.spec.ts        (12 tests)
+✓ tests/readSourceCompositions.service.spec.ts    (24 tests)
+✓ tests/multitable-resolver-vocab-mirror.spec.ts  (4 tests)
+✓ tests/composition-vocab-mirror.spec.ts          (3 tests)
+✓ tests/IntegrationReadSourceCompositionPanel.spec.ts        (6 tests)
+✓ tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts (7 tests)
+✓ tests/IntegrationReadSourceConfigPanel.spec.ts  (19 tests)
+✓ tests/IntegrationK3WiseSetupView.spec.ts        (7 tests)
+✓ tests/IntegrationWorkbenchView.spec.ts          (49 tests)
+
+Test Files  9 passed (9)
+     Tests  131 passed (131)
+```
+
+No pre-existing failures were found in either large view spec (`IntegrationWorkbenchView.spec.ts` 48/48
+before + 1 new = 49/49; `IntegrationK3WiseSetupView.spec.ts` 6/6 before + 1 new = 7/7) — both confirmed
+clean standalone before being added to the CI guard's gated command, per the task's instruction.
+
+Also ran the plugin's own CJS test chain (`pnpm --filter plugin-integration-core test`) — all suites OK,
+confirming the server-side contracts this module mirrors are unchanged.
+
+New label-module spec: `apps/web/tests/integrationErrorCodeLabels.spec.ts` (12 tests) — mirror-tripwire
+coverage (every server resolver/probe/composition/BOM-list code has a non-empty zh+en label; every
+dead-letter mainline code has one), exact-key-lookup negative tests (unregistered/enum-shaped code →
+`null`; substring/prefix is NOT a match; `Object.prototype` keys like `toString`/`constructor` are never
+resolved), generic-unknown-fallback tests, and a locale-switching test.
+
+### Typecheck
+
+`pnpm --filter @metasheet/web run type-check` (`vue-tsc -b`) — clean, no errors.
+
+## Files touched
+
+- `apps/web/src/services/integration/errorCodeLabels.ts` (new)
+- `apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue`
+- `apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue`
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/integrationErrorCodeLabels.spec.ts` (new)
+- `apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts`
+- `apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+- `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`
+- `.github/workflows/integration-guard.yml`
+- `docs/development/integration-iu1-error-code-labels-dev-verification-20260706.md` (this file)

--- a/docs/development/integration-iu1-error-code-labels-dev-verification-20260706.md
+++ b/docs/development/integration-iu1-error-code-labels-dev-verification-20260706.md
@@ -169,3 +169,16 @@ resolved), generic-unknown-fallback tests, and a locale-switching test.
 - `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`
 - `.github/workflows/integration-guard.yml`
 - `docs/development/integration-iu1-error-code-labels-dev-verification-20260706.md` (this file)
+
+
+## 附:质量闸补强(主循环审阅,2026-07-06)
+
+- **mutation 4/4 KILLED**:①重插 raw errorMessage 渲染 → 哨兵测试红;②删一条 label →
+  mirror-tripwire 红;③未知码改直出 → generic-unknown 测试红;④client mirror 删一码 →
+  新增 mirror-drift tripwire 红。各 KILLED 后复绿 sanity 通过。
+- **mirror drift 修复(闸内发现,随本 PR)**:client `readSourceConfigs.ts` 的
+  `READ_SOURCE_PROBE_ERROR_CODES` allowlist 补齐 BL2 的 8 个 `K3_WISE_BOM_LIST_BY_MATERIAL_*`
+  码(server 契约 #3695 起已含)——否则该族码在 probe/组合证据里先被客户端洗成 generic,
+  IU-1 标签成死代码。新增 tripwire:client mirror 必须覆盖 server 全 union(未来 server 侧
+  加族,客户端不同步则 CI 红)。
+- 全 guard 面 132/132 绿;`vue-tsc -b` 干净。


### PR DESCRIPTION
## Summary

Implements slice IU-1 (错误码人话化) of the integration UX ladder, per
`docs/development/integration-ux-workbench-redesign-design-lock-20260706.md`
(design-lock PR #3739, overall PROPOSED, IU-1 owner-authorized to proceed) plus
a RATIFIED addendum. Pure frontend, zero behavior change.

- New module `apps/web/src/services/integration/errorCodeLabels.ts`: an
  exact-key (own-property) lookup — never prefix/regex — from a closed-ish set
  of integration error CODES to a `{zh, en, hint?}` label. Covers resolver (9),
  probe (11 own), composition (8), K3 WISE BOM-list-by-material (8, not yet
  wired to any UI — labeled for completeness), and dead-letter known-mainline
  (10) codes. Exports `integrationErrorCodeLabel`, `integrationErrorCodeDisplayLabel`
  (prominent-slot string with generic "未知错误"/"Unknown error" fallback), and
  `integrationErrorCodeHint`.
- Wired into the 4 display sites that render `errorCode` today:
  `IntegrationReadSourceConfigPanel.vue`, `IntegrationReadSourceCompositionPanel.vue`,
  `IntegrationWorkbenchView.vue`, `IntegrationK3WiseSetupView.vue`. Raw codes
  stay visible in a demoted/secondary spot for expert troubleshooting; only the
  humanized label (or generic fallback) is prominent.
- CI: extended `.github/workflows/integration-guard.yml` path filters + the
  `vitest run` command to cover the new module/spec and the two dead-letter
  views (previously in NO CI workflow — a pre-existing gap).

## RATIFIED addendum closure: errorMessage leak-hole

Grepped the whole integration surface for `deadLetter.errorMessage` (the
dead-letter shape's raw free-text field) — exactly 2 render sites, both closed:

1. `IntegrationWorkbenchView.vue` dead-letter list — raw `<span>{{ deadLetter.errorMessage }}</span>` deleted.
2. `IntegrationK3WiseSetupView.vue`'s own mini dead-letter list — same treatment.

Both: unregistered/unknown `errorCode` → PROMINENT slot shows generic
"未知错误"/"Unknown error" (never the raw code, never any part of the raw
message); raw CODE (safe, registered vocabulary) stays in a secondary spot.
Sentinel tests assert `container.textContent`/`innerHTML` never contain the
raw message string, for both a registered and an unregistered code, at both
sites.

Noted (not fixed) gap: `IntegrationK3WiseSetupView.vue`'s `run.errorSummary`
field (pipeline-run list, not dead-letter list) is a separate free-text field
with no paired `errorCode` — flagged for a future slice, different kind of fix.

## Coverage table

| Family | Count | Source of truth |
|---|---|---|
| Resolver | 9 | `readSourceConfigs.ts` `RESOLVER_ERROR_CODES` |
| Probe (own) | 11 | `readSourceConfigs.ts` `READ_SOURCE_PROBE_ERROR_CODES` (own entries) |
| Composition | 8 | `readSourceCompositions.ts` `COMPOSITION_PLAN_ERROR_CODES` |
| K3 WISE BOM-list-by-material | 8 | `read-source-bom-list-by-material-contract.cjs` (local mirror only, not yet UI-wired) |
| Dead-letter known mainline | 10 | hand-curated from `pipeline-runner.cjs` + generic fallbacks |

**Research-drift finding**: the design-lock doc cited the server probe/resolver
union as 20; the server's `READ_SOURCE_PROBE_ERROR_CODES` now also spreads in
the 8 BOM-list codes (BL2), so the true current union is 28 — a pre-existing
client-mirror drift in `readSourceConfigs.ts` (out of scope to fix here, noted
in the verification MD).

**Deliberately NOT labeled**: the C6 external-write-specific
`SAFE_WRITE_ERROR_CODES` set in `external-write-dry-run.cjs`
(`AdapterValidationError`, `DATA_SOURCE_*`, `DataSource*Error`,
`DUPLICATE_KEY`, plus a test-injection code) — these belong to the still
W1-gated external-write self-service ladder, not the mainline flow this slice
touches. Inventing zh/en semantics for a not-yet-shipped write surface would be
scope creep.

## Zero-behavior-change statement

No route changes, no service-wire shape changes, no permission changes, no
backend logic changes. All edits are label-only template changes (+ new
values-free lookup module + tests + CI filters). `vue-tsc -b` clean.

## Test evidence

```
pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror \
  multitable-resolver-vocab-mirror integrationErrorCodeLabels \
  IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel \
  IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service \
  IntegrationWorkbenchView IntegrationK3WiseSetupView --reporter=dot

Test Files  9 passed (9)
     Tests  131 passed (131)
```

Both `IntegrationWorkbenchView.spec.ts` (49/49) and `IntegrationK3WiseSetupView.spec.ts`
(7/7) confirmed fully green standalone (no pre-existing failures) before being
added to the CI guard's gated command.

`pnpm --filter plugin-integration-core test` — all suites OK (server contracts
unchanged).

## Test plan

- [x] New label-module spec (`integrationErrorCodeLabels.spec.ts`, 12 tests):
      mirror-tripwire coverage + exact-key-lookup negative tests + generic
      fallback + locale switching
- [x] Component render tests for all 4 display sites (sentinel-absence +
      unknown-code-fallback for the 2 dead-letter sites; label-renders for the
      2 evidence sites)
- [x] `vue-tsc -b` type-check clean
- [x] CI path filters + gated `vitest run` command extended and verified
      locally to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)