### PR TITLE
feat(web): multitable UI P2-1a — shared MtButton/MtIconButton/MtBadge primitives (additive)

### DIFF
--- a/apps/web/src/multitable/ui/MtBadge.vue
+++ b/apps/web/src/multitable/ui/MtBadge.vue
@@ -1,0 +1,89 @@
+<template>
+  <span
+    v-if="dot || shouldShowCount"
+    class="mt-badge"
+    :class="[`mt-badge--${tone}`, { 'mt-badge--dot': dot }]"
+  >
+    <template v-if="!dot">{{ displayCount }}</template>
+  </span>
+</template>
+
+<script setup lang="ts">
+// MtBadge — P2-1a shared UI primitive (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1).
+// Small count/status pill mirroring MetaCommentAffordance's badge sizing, re-expressed on UF-1
+// `--ms-*` / `--el-*` tokens instead of that component's bespoke hex (design-lock §8 / §3.1).
+import { computed } from 'vue'
+
+export type MtBadgeTone = 'info' | 'primary' | 'success' | 'warning' | 'danger'
+
+const props = withDefaults(defineProps<{
+  count?: number
+  showZero?: boolean
+  dot?: boolean
+  tone?: MtBadgeTone
+}>(), {
+  count: 0,
+  showZero: false,
+  dot: false,
+  tone: 'info',
+})
+
+const shouldShowCount = computed(() => props.count > 0 || props.showZero)
+// Cap the same way most list badges do (e.g. "99+") so a large count never blows out the pill.
+const displayCount = computed(() => (props.count > 99 ? '99+' : props.count))
+</script>
+
+<style scoped>
+.mt-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.mt-badge--dot {
+  min-width: 6px;
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  border-radius: 50%;
+}
+
+.mt-badge--info {
+  background: var(--el-color-info-light-9);
+  color: var(--ms-color-info);
+}
+
+.mt-badge--primary {
+  background: var(--el-color-primary-light-9);
+  color: var(--ms-color-primary);
+}
+
+.mt-badge--success {
+  background: var(--el-color-success-light-9);
+  color: var(--ms-color-success);
+}
+
+.mt-badge--warning {
+  background: var(--el-color-warning-light-9);
+  color: var(--ms-color-warning);
+}
+
+.mt-badge--danger {
+  background: var(--el-color-danger-light-9);
+  color: var(--ms-color-danger);
+}
+
+.mt-badge--dot.mt-badge--info { background: var(--ms-color-info); }
+.mt-badge--dot.mt-badge--primary { background: var(--ms-color-primary); }
+.mt-badge--dot.mt-badge--success { background: var(--ms-color-success); }
+.mt-badge--dot.mt-badge--warning { background: var(--ms-color-warning); }
+.mt-badge--dot.mt-badge--danger { background: var(--ms-color-danger); }
+</style>

--- a/apps/web/src/multitable/ui/MtButton.vue
+++ b/apps/web/src/multitable/ui/MtButton.vue
@@ -1,0 +1,150 @@
+<template>
+  <button
+    type="button"
+    class="mt-button"
+    :class="[`mt-button--${variant}`, `mt-button--${size}`, { 'is-loading': loading }]"
+    :disabled="isDisabled"
+    @click="onClick"
+  >
+    <span v-if="loading" class="mt-button__icon mt-button__icon--spinner">
+      <el-icon class="mt-button__spinner"><Loading /></el-icon>
+    </span>
+    <span v-else-if="$slots.icon" class="mt-button__icon">
+      <slot name="icon" />
+    </span>
+    <span v-if="$slots.default" class="mt-button__label"><slot /></span>
+  </button>
+</template>
+
+<script setup lang="ts">
+// MtButton — P2-1a shared UI primitive (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1).
+// Presentation-only: no business logic, no data fetching. Consumes ONLY UF-1 `--ms-*` / `--el-*`
+// tokens (design-lock §8 / §3.1) — never introduce a new hardcoded hex here.
+import { computed } from 'vue'
+import { ElIcon } from 'element-plus'
+import { Loading } from '@element-plus/icons-vue'
+
+export type MtButtonVariant = 'primary' | 'ghost' | 'danger'
+export type MtButtonSize = 'sm' | 'md'
+
+const props = withDefaults(defineProps<{
+  variant?: MtButtonVariant
+  size?: MtButtonSize
+  disabled?: boolean
+  loading?: boolean
+}>(), {
+  variant: 'ghost',
+  size: 'md',
+  disabled: false,
+  loading: false,
+})
+
+const emit = defineEmits<{
+  (e: 'click', evt: MouseEvent): void
+}>()
+
+// Loading implies disabled — a single source of truth for the `disabled` DOM attribute so the
+// native button already blocks pointer/keyboard activation without extra guard logic downstream.
+const isDisabled = computed(() => props.disabled || props.loading)
+
+function onClick(evt: MouseEvent) {
+  if (isDisabled.value) return
+  emit('click', evt)
+}
+</script>
+
+<style scoped>
+.mt-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ms-space-1);
+  box-sizing: border-box;
+  border-radius: var(--ms-radius-sm);
+  border: 1px solid transparent;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.mt-button:focus-visible {
+  outline: 2px solid var(--ms-color-primary);
+  outline-offset: 1px;
+}
+
+.mt-button.is-loading,
+.mt-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* ---- sizes ---- */
+.mt-button--md {
+  height: var(--ms-control-height);
+  padding: 0 var(--ms-space-4);
+}
+
+.mt-button--sm {
+  height: calc(var(--ms-control-height) - 8px);
+  padding: 0 var(--ms-space-3);
+  font-size: 12px;
+}
+
+/* ---- variants ---- */
+.mt-button--ghost {
+  background: transparent;
+  color: var(--ms-text-2);
+  border-color: transparent;
+}
+
+.mt-button--ghost:hover:not(:disabled) {
+  background: var(--ms-bg-page);
+  color: var(--ms-text-1);
+}
+
+.mt-button--primary {
+  background: var(--ms-color-primary);
+  border-color: var(--ms-color-primary);
+  color: var(--ms-bg-card);
+}
+
+.mt-button--primary:hover:not(:disabled) {
+  background: var(--el-color-primary-dark-2);
+  border-color: var(--el-color-primary-dark-2);
+}
+
+.mt-button--danger {
+  background: var(--ms-color-danger);
+  border-color: var(--ms-color-danger);
+  color: var(--ms-bg-card);
+}
+
+.mt-button--danger:hover:not(:disabled) {
+  background: var(--el-color-danger-dark-2);
+  border-color: var(--el-color-danger-dark-2);
+}
+
+/* ---- icon / spinner ---- */
+.mt-button__icon {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.mt-button__spinner {
+  animation: mt-button-spin 0.8s linear infinite;
+}
+
+@keyframes mt-button-spin {
+  to { transform: rotate(360deg); }
+}
+
+.mt-button__label {
+  display: inline-flex;
+  align-items: center;
+}
+</style>

--- a/apps/web/src/multitable/ui/MtIconButton.vue
+++ b/apps/web/src/multitable/ui/MtIconButton.vue
@@ -1,0 +1,66 @@
+<template>
+  <MtButton
+    class="mt-icon-button"
+    :class="`mt-icon-button--${size}`"
+    :variant="variant"
+    :size="size"
+    :disabled="disabled"
+    :loading="loading"
+    :title="title"
+    :aria-label="ariaLabel || title"
+    @click="emit('click', $event)"
+  >
+    <template #icon>
+      <el-icon v-if="icon"><component :is="icon" /></el-icon>
+      <slot v-else name="icon"><slot /></slot>
+    </template>
+  </MtButton>
+</template>
+
+<script setup lang="ts">
+// MtIconButton — P2-1a shared UI primitive (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1).
+// A square icon-only button; wraps MtButton so variants/sizes/tokens stay in one place. Accepts the
+// icon either as a component reference (`icon` prop, wrapped in <el-icon> internally per the UI-P1
+// icon idiom) or as slotted markup (named `icon` slot, falling back to the default slot) for callers
+// that already hold their own <el-icon><component :is="..."/></el-icon> markup.
+import type { Component } from 'vue'
+import { ElIcon } from 'element-plus'
+import MtButton, { type MtButtonVariant, type MtButtonSize } from './MtButton.vue'
+
+withDefaults(defineProps<{
+  icon?: Component
+  variant?: MtButtonVariant
+  size?: MtButtonSize
+  disabled?: boolean
+  loading?: boolean
+  title?: string
+  ariaLabel?: string
+}>(), {
+  variant: 'ghost',
+  size: 'md',
+  disabled: false,
+  loading: false,
+})
+
+const emit = defineEmits<{
+  (e: 'click', evt: MouseEvent): void
+}>()
+</script>
+
+<style scoped>
+/* Overrides MtButton's own `.mt-button--{size}` horizontal padding so the icon sits centered in a
+   square box; `!important` is deliberate here (both rules share single-class specificity and the
+   cascade order between a component and its child's <style> block is otherwise load-order
+   dependent — this pins the intent instead of relying on it). */
+.mt-icon-button {
+  padding: 0 !important;
+}
+
+.mt-icon-button--md {
+  width: var(--ms-control-height);
+}
+
+.mt-icon-button--sm {
+  width: calc(var(--ms-control-height) - 8px);
+}
+</style>

--- a/apps/web/src/multitable/ui/README.md
+++ b/apps/web/src/multitable/ui/README.md
@@ -1,0 +1,123 @@
+# multitable/ui — shared UI primitives (P2-1a)
+
+Design-lock: `docs/development/multitable-ui-p2-structure-designlock-20260706.md` §2 P2-1.
+
+These are stateless, presentation-only primitives meant to replace the per-SFC bespoke-CSS
+buttons/badges scattered across `apps/web/src/multitable/components/` and `views/`. They consume
+**only** UF-1 design tokens (`apps/web/src/styles/tokens.css`, `--ms-*` / `--el-*`) — never a new
+hardcoded hex, never a new token vocabulary.
+
+This slice (P2-1a) is **additive only**: no existing component has been migrated to use these yet.
+Migration is a separate, later slice (P2-1c), one SFC's buttons/badges at a time, presentation-only
+and click/emit-count-preserving.
+
+## MtButton
+
+```vue
+<script setup lang="ts">
+import { MtButton } from '@/multitable/ui'
+import { ElIcon } from 'element-plus'
+import { Plus } from '@element-plus/icons-vue'
+</script>
+
+<template>
+  <!-- default (ghost) -->
+  <MtButton @click="onCancel">Cancel</MtButton>
+
+  <!-- primary, with a leading icon (UI-P1 idiom: <el-icon><component :is="..."/></el-icon>) -->
+  <MtButton variant="primary" @click="onCreate">
+    <template #icon><el-icon><Plus /></el-icon></template>
+    New record
+  </MtButton>
+
+  <!-- danger, small, loading (shows a spinner + disables the button) -->
+  <MtButton variant="danger" size="sm" :loading="isDeleting" @click="onDelete">
+    Delete
+  </MtButton>
+</template>
+```
+
+Props:
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `variant` | `'primary' \| 'ghost' \| 'danger'` | `'ghost'` | primary = filled `--ms-color-primary`; ghost = transparent, `--ms-text-2`, hover `--ms-bg-page`; danger = filled `--ms-color-danger` |
+| `size` | `'sm' \| 'md'` | `'md'` | md height = `--ms-control-height`; sm = that minus 8px |
+| `disabled` | `boolean` | `false` | |
+| `loading` | `boolean` | `false` | shows a spinner in place of the `icon` slot and forces `disabled` |
+
+Slots: default (label), `icon` (leading, optional — hidden while `loading`).
+Emits: `click(evt: MouseEvent)` — not emitted while `disabled`/`loading`.
+
+## MtIconButton
+
+A square icon-only `MtButton`. Accepts the icon either as a component reference (wrapped in
+`<el-icon>` internally) or as slotted markup for callers that already hold their own `<el-icon>`.
+
+```vue
+<script setup lang="ts">
+import { MtIconButton } from '@/multitable/ui'
+import { Delete } from '@element-plus/icons-vue'
+</script>
+
+<template>
+  <!-- icon via prop -->
+  <MtIconButton :icon="Delete" variant="danger" title="Delete row" @click="onDelete" />
+
+  <!-- icon via slot -->
+  <MtIconButton title="More actions" @click="onMore">
+    <template #icon><el-icon><MoreFilled /></el-icon></template>
+  </MtIconButton>
+</template>
+```
+
+Props: same as `MtButton` (`variant`, `size`, `disabled`, `loading`) plus:
+
+| Prop | Type | Notes |
+|---|---|---|
+| `icon` | `Component` (optional) | rendered as `<el-icon><component :is="icon"/></el-icon>` |
+| `title` | `string` (optional) | native tooltip; also the `aria-label` fallback |
+| `ariaLabel` | `string` (optional) | overrides `title` for `aria-label` when they should differ |
+
+Slots: `icon` (falls back to the default slot) — use when you need custom icon markup instead of the
+`icon` prop.
+Emits: `click(evt: MouseEvent)`.
+
+## MtBadge
+
+Small count/status pill — same sizing as the existing comment-badge affordance
+(`MetaCommentAffordance.vue`), re-expressed on tokens instead of that component's hardcoded hex.
+
+```vue
+<script setup lang="ts">
+import { MtBadge } from '@/multitable/ui'
+</script>
+
+<template>
+  <!-- count pill, hidden when count is 0 -->
+  <MtBadge :count="unresolvedCount" tone="danger" />
+
+  <!-- always show, even at 0 -->
+  <MtBadge :count="0" show-zero tone="info" />
+
+  <!-- status dot instead of a count -->
+  <MtBadge dot tone="success" />
+</template>
+```
+
+Props:
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `count` | `number` | `0` | pill hidden when `0` unless `showZero`; renders `99+` above 99 |
+| `showZero` | `boolean` | `false` | |
+| `dot` | `boolean` | `false` | renders a small solid dot instead of the count |
+| `tone` | `'info' \| 'primary' \| 'success' \| 'warning' \| 'danger'` | `'info'` | maps to `--ms-color-*` / `--el-color-*-light-9` |
+
+## Token discipline
+
+Every color declaration in these three components is a `var(--ms-*)` or `var(--el-*)` reference —
+no hex/rgb literals, including as `var(..., #fallback)` fallbacks (the UF-6 style guard closes that
+exact escape hatch for its target file set; these new files hold to the same discipline even though
+they are not yet in that guard's list). Non-color sizing (font-size, gap) that has no dedicated token
+follows the existing convention in `MetaToolbar.vue` (e.g. `font-size: 13px`).

--- a/apps/web/src/multitable/ui/index.ts
+++ b/apps/web/src/multitable/ui/index.ts
@@ -1,0 +1,8 @@
+// Barrel for the P2-1a shared UI primitives (multitable-ui-p2-structure-designlock-20260706.md §2
+// P2-1). Additive only — nothing here changes any existing component's behavior; migration of
+// existing SFCs onto these primitives is a separate, later slice (P2-1c).
+export { default as MtButton } from './MtButton.vue'
+export type { MtButtonVariant, MtButtonSize } from './MtButton.vue'
+export { default as MtIconButton } from './MtIconButton.vue'
+export { default as MtBadge } from './MtBadge.vue'
+export type { MtBadgeTone } from './MtBadge.vue'


### PR DESCRIPTION
First slice of UI-P2 (design-lock #3742). **Additive only** — 5 new files under `apps/web/src/multitable/ui/` (MtButton, MtIconButton, MtBadge, index barrel, README); no existing file touched. Consumes UF-1 `--ms-*`/`--el-*` tokens exclusively (grep: zero hardcoded hex). vue-tsc clean. Migration of existing components = later P2-1c slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)