### PR TITLE
feat(multitable): complete Global History remaining code gates

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1044,7 +1044,9 @@ export interface MetaConfigRevision {
 }
 
 // T9-W: the would-be revert of a recorded config change (server-computed; the FE renders it as-is).
-export interface ConfigRestorePreview {
+export type ConfigRestoreExecuteConfirm = 'uncreate' | 'undelete' | 'revert-permission'
+
+export interface ConfigRestoreUpdatePreview {
   revisionId: string
   entityType: string
   entityId: string
@@ -1058,6 +1060,46 @@ export interface ConfigRestorePreview {
   /** the server-minted preview identity, REQUIRED by execute (preview-first; a client-computed hash is rejected). */
   previewToken: string
 }
+
+export interface ConfigRestoreUncreatePreview {
+  revisionId: string
+  previewToken: string
+  uncreate: {
+    entityType: string
+    entityId: string
+    entityName?: string
+    note?: string
+  }
+}
+
+export interface ConfigRestoreUndeletePreview {
+  revisionId: string
+  previewToken: string
+  undelete: {
+    entityType: string
+    entityId: string
+    entityName?: string
+    note?: string
+    idCollision?: boolean
+  }
+}
+
+export interface ConfigRestorePermissionRevertPreview {
+  revisionId: string
+  previewToken: string
+  permissionRevert: {
+    scope: string
+    direction: 'de-escalation' | 'escalation' | 'noop' | string
+    supported?: boolean
+    note?: string
+  }
+}
+
+export type ConfigRestorePreview =
+  | ConfigRestoreUpdatePreview
+  | ConfigRestoreUncreatePreview
+  | ConfigRestoreUndeletePreview
+  | ConfigRestorePermissionRevertPreview
 
 export interface AiShortcutPreviewData {
   status: 'succeeded'
@@ -1320,9 +1362,34 @@ export interface AiUsageSummary {
   }
 }
 
+function normalizeConfigRestorePreview(
+  revisionId: string,
+  data: {
+    preview?: ConfigRestoreUpdatePreview
+    uncreate?: ConfigRestoreUncreatePreview['uncreate']
+    undelete?: ConfigRestoreUndeletePreview['undelete']
+    permissionRevert?: ConfigRestorePermissionRevertPreview['permissionRevert']
+    previewToken: string
+  },
+): ConfigRestorePreview {
+  if (data.uncreate) return { revisionId, previewToken: data.previewToken, uncreate: data.uncreate }
+  if (data.undelete) return { revisionId, previewToken: data.previewToken, undelete: data.undelete }
+  if (data.permissionRevert) return { revisionId, previewToken: data.previewToken, permissionRevert: data.permissionRevert }
+  if (data.preview) return { ...data.preview, revisionId: data.preview.revisionId ?? revisionId, previewToken: data.previewToken }
+  throw new Error('Invalid config restore preview response')
+}
+
+function configRestoreConfirmForPreview(preview: ConfigRestorePreview): ConfigRestoreExecuteConfirm | undefined {
+  if ('uncreate' in preview) return 'uncreate'
+  if ('undelete' in preview) return 'undelete'
+  if ('permissionRevert' in preview) return 'revert-permission'
+  return undefined
+}
+
 export class MultitableApiClient {
   private fetch: FetchFn
   private readonly isZhOption?: ApiErrorLocaleOption
+  private readonly configRestoreConfirmByToken = new Map<string, ConfigRestoreExecuteConfirm>()
 
   constructor(opts?: { fetchFn?: FetchFn; isZh?: ApiErrorLocaleOption }) {
     this.fetch = opts?.fetchFn ?? defaultFetchFn()
@@ -1969,19 +2036,37 @@ export class MultitableApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ revisionId }),
     })
-    const data = await this.parseJson<{ preview: ConfigRestorePreview; previewToken: string }>(res)
-    return { ...data.preview, previewToken: data.previewToken } // fold the server-minted token into the preview the modal holds
+    const data = await this.parseJson<{
+      preview?: ConfigRestoreUpdatePreview
+      uncreate?: ConfigRestoreUncreatePreview['uncreate']
+      undelete?: ConfigRestoreUndeletePreview['undelete']
+      permissionRevert?: ConfigRestorePermissionRevertPreview['permissionRevert']
+      previewToken: string
+    }>(res)
+    const preview = normalizeConfigRestorePreview(revisionId, data)
+    const confirm = configRestoreConfirmForPreview(preview)
+    if (confirm) this.configRestoreConfirmByToken.set(preview.previewToken, confirm)
+    else this.configRestoreConfirmByToken.delete(preview.previewToken)
+    return preview
   }
 
   // T9-W: execute a config-restore (forward-only write). The server-minted previewToken binds it to the preview and
   // is REQUIRED — a client-computed hash alone is rejected (preview-first); a stale token → 409.
-  async executeConfigRestore(sheetId: string, revisionId: string, previewToken: string): Promise<void> {
+  async executeConfigRestore(
+    sheetId: string,
+    revisionId: string,
+    previewToken: string,
+    confirm?: ConfigRestoreExecuteConfirm,
+  ): Promise<void> {
+    const effectiveConfirm = confirm ?? this.configRestoreConfirmByToken.get(previewToken)
+    const body = effectiveConfirm ? { revisionId, previewToken, confirm: effectiveConfirm } : { revisionId, previewToken }
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/config-restore-execute`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ revisionId, previewToken }),
+      body: JSON.stringify(body),
     })
     await this.parseJson<{ restored: unknown }>(res)
+    this.configRestoreConfirmByToken.delete(previewToken)
   }
 
   // T8-2: preview a sheet-wide Reset-to-T (DESTRUCTIVE — records created after T → recycle bin; survivors reverted).

--- a/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
+++ b/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
@@ -63,10 +63,10 @@
             <p v-if="revert.loading" class="cfg-history__hint" data-test="config-restore-loading">{{ l('record.configHistoryLoading') }}</p>
             <p v-else-if="revert.error" class="cfg-restore-error" data-test="config-restore-error">{{ revert.error }}</p>
             <template v-else-if="revert.preview">
-              <p v-if="revert.preview.opKind === 'gated'" class="cfg-restore-gated" data-test="config-restore-gated">
+              <p v-if="isUpdatePreview(revert.preview) && revert.preview.opKind === 'gated'" class="cfg-restore-gated" data-test="config-restore-gated">
                 {{ revert.preview.gatedReason || l('record.configRestoreGated') }}
               </p>
-              <template v-else>
+              <template v-else-if="isUpdatePreview(revert.preview)">
                 <p v-if="revert.preview.driftConflict" class="cfg-restore-drift" data-test="config-restore-drift">{{ l('record.configRestoreDrift') }}</p>
                 <p class="cfg-restore-summary">{{ l('record.configRestoreWillRevert') }}</p>
                 <ul class="cfg-restore-changes" data-test="config-restore-changes">
@@ -78,14 +78,34 @@
                   </li>
                 </ul>
               </template>
+              <template v-else>
+                <p class="cfg-restore-summary" data-test="config-restore-destructive-summary">{{ l('record.configRestoreServerSummary') }}</p>
+                <ul class="cfg-restore-changes" data-test="config-restore-changes">
+                  <li v-for="row in destructiveSummaryRows(revert.preview)" :key="row.key" class="cfg-history__change">
+                    <span class="cfg-history__key">{{ row.key }}</span>
+                    <span class="cfg-history__after">{{ row.value }}</span>
+                  </li>
+                </ul>
+                <p v-if="!canExecutePreview(revert.preview)" class="cfg-restore-gated" data-test="config-restore-gated">
+                  {{ blockedReason(revert.preview) }}
+                </p>
+                <label v-else class="cfg-restore-type" data-test="config-restore-type-label">
+                  {{ typedConfirmPrompt(requiredConfirm(revert.preview)) }}
+                  <input
+                    v-model="revert.typedConfirm"
+                    data-test="config-restore-type-input"
+                    :aria-label="typedConfirmPrompt(requiredConfirm(revert.preview))"
+                  />
+                </label>
+              </template>
             </template>
             <div class="cfg-restore-actions">
               <button type="button" data-test="config-restore-cancel" @click="cancelRevert">{{ l('record.configRestoreCancel') }}</button>
               <button
-                v-if="revert.preview && revert.preview.opKind === 'safe'"
+                v-if="revert.preview && canExecutePreview(revert.preview)"
                 type="button"
                 data-test="config-restore-confirm-btn"
-                :disabled="revert.preview.driftConflict || revert.executing"
+                :disabled="!canConfirmCurrentPreview || revert.executing"
                 @click="confirmRevert"
               >{{ l('record.configRestoreConfirm') }}</button>
             </div>
@@ -97,9 +117,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
-import type { MetaConfigRevision, ConfigRestorePreview } from '../api/client'
+import type { MetaConfigRevision, ConfigRestoreExecuteConfirm, ConfigRestorePreview, ConfigRestoreUpdatePreview } from '../api/client'
 import { redactString } from '../utils/automation-log-redact'
 import { recordLabel, type MetaRecordLabelKey } from '../utils/meta-record-labels'
 
@@ -114,7 +134,7 @@ const props = defineProps<{
   isZh: boolean
   /** T9-W: when provided, an update row gets a Revert action wired through these (the workbench owns the client). */
   previewRevert?: (revisionId: string) => Promise<ConfigRestorePreview>
-  executeRevert?: (revisionId: string, previewToken: string) => Promise<void>
+  executeRevert?: (revisionId: string, previewToken: string, confirm?: ConfigRestoreExecuteConfirm) => Promise<void>
 }>()
 
 const emit = defineEmits<{ (e: 'close'): void; (e: 'filter-change', entityType: string): void; (e: 'reverted'): void }>()
@@ -273,33 +293,123 @@ function formatAiShortcutParam(value: unknown): string {
 }
 
 // --- T9-W revert flow (the gate stays server-side; this only shows the server's preview + confirms) ---
-interface RevertState { visible: boolean; loading: boolean; executing: boolean; error: string; preview: ConfigRestorePreview | null }
-const revert = ref<RevertState>({ visible: false, loading: false, executing: false, error: '', preview: null })
-const canRevert = (rev: MetaConfigRevision): boolean => typeof props.previewRevert === 'function' && rev.action === 'update'
+interface RevertState {
+  visible: boolean
+  loading: boolean
+  executing: boolean
+  error: string
+  preview: ConfigRestorePreview | null
+  typedConfirm: string
+}
+const emptyRevertState = (): RevertState => ({
+  visible: false,
+  loading: false,
+  executing: false,
+  error: '',
+  preview: null,
+  typedConfirm: '',
+})
+const revert = ref<RevertState>(emptyRevertState())
+const canRevert = (_rev: MetaConfigRevision): boolean => typeof props.previewRevert === 'function'
+const canConfirmCurrentPreview = computed(() => {
+  const preview = revert.value.preview
+  if (!preview || !canExecutePreview(preview)) return false
+  if (isUpdatePreview(preview)) return preview.opKind === 'safe' && !preview.driftConflict
+  const confirm = requiredConfirm(preview)
+  return !confirm || revert.value.typedConfirm.trim() === confirm
+})
 
 async function openRevert(rev: MetaConfigRevision): Promise<void> {
   if (!props.previewRevert) return
-  revert.value = { visible: true, loading: true, executing: false, error: '', preview: null }
+  revert.value = { ...emptyRevertState(), visible: true, loading: true }
   try {
     const preview = await props.previewRevert(rev.id)
-    revert.value = { visible: true, loading: false, executing: false, error: '', preview }
+    revert.value = { visible: true, loading: false, executing: false, error: '', preview, typedConfirm: '' }
   } catch (e) {
-    revert.value = { visible: true, loading: false, executing: false, error: (e as Error)?.message ?? l('record.configRestoreError'), preview: null }
+    revert.value = {
+      visible: true,
+      loading: false,
+      executing: false,
+      error: (e as Error)?.message ?? l('record.configRestoreError'),
+      preview: null,
+      typedConfirm: '',
+    }
   }
 }
 async function confirmRevert(): Promise<void> {
   const preview = revert.value.preview
-  if (!preview || !props.executeRevert) return
+  if (!preview || !props.executeRevert || !canConfirmCurrentPreview.value) return
   revert.value = { ...revert.value, executing: true, error: '' }
   try {
-    await props.executeRevert(preview.revisionId, preview.previewToken)
-    revert.value = { visible: false, loading: false, executing: false, error: '', preview: null }
+    await props.executeRevert(preview.revisionId, preview.previewToken, requiredConfirm(preview))
+    revert.value = emptyRevertState()
     emit('reverted')
   } catch (e) {
     revert.value = { ...revert.value, executing: false, error: (e as Error)?.message ?? l('record.configRestoreError') }
   }
 }
-function cancelRevert(): void { revert.value = { visible: false, loading: false, executing: false, error: '', preview: null } }
+function cancelRevert(): void { revert.value = emptyRevertState() }
+
+function isUpdatePreview(preview: ConfigRestorePreview): preview is ConfigRestoreUpdatePreview {
+  return 'opKind' in preview
+}
+
+function requiredConfirm(preview: ConfigRestorePreview): ConfigRestoreExecuteConfirm | undefined {
+  if ('uncreate' in preview) return 'uncreate'
+  if ('undelete' in preview) return 'undelete'
+  if ('permissionRevert' in preview) return 'revert-permission'
+  return undefined
+}
+
+function canExecutePreview(preview: ConfigRestorePreview): boolean {
+  if (isUpdatePreview(preview)) return preview.opKind === 'safe'
+  if ('undelete' in preview) return preview.undelete.idCollision !== true
+  if ('permissionRevert' in preview) return preview.permissionRevert.supported === true
+  return 'uncreate' in preview
+}
+
+function blockedReason(preview: ConfigRestorePreview): string {
+  if ('permissionRevert' in preview) return preview.permissionRevert.note || l('record.configRestoreBlocked')
+  if ('undelete' in preview && preview.undelete.idCollision === true) return l('record.configRestoreIdCollisionBlocked')
+  return l('record.configRestoreBlocked')
+}
+
+function destructiveSummaryRows(preview: ConfigRestorePreview): Array<{ key: string; value: string }> {
+  if ('uncreate' in preview) {
+    return [
+      { key: l('record.configRestoreEntity'), value: entitySummary(preview.uncreate.entityType, preview.uncreate.entityId, preview.uncreate.entityName) },
+      { key: l('record.configRestoreNote'), value: preview.uncreate.note || l('record.configRestoreBlocked') },
+    ]
+  }
+  if ('undelete' in preview) {
+    return [
+      { key: l('record.configRestoreEntity'), value: entitySummary(preview.undelete.entityType, preview.undelete.entityId, preview.undelete.entityName) },
+      { key: l('record.configRestoreNote'), value: preview.undelete.note || l('record.configRestoreBlocked') },
+      { key: l('record.configRestoreIdCollision'), value: boolLabel(preview.undelete.idCollision === true) },
+    ]
+  }
+  if ('permissionRevert' in preview) {
+    return [
+      { key: l('record.configRestoreScope'), value: preview.permissionRevert.scope },
+      { key: l('record.configRestoreDirection'), value: preview.permissionRevert.direction },
+      { key: l('record.configRestoreNote'), value: preview.permissionRevert.note || l('record.configRestoreBlocked') },
+    ]
+  }
+  return []
+}
+
+function entitySummary(entityType: string, entityId: string, entityName?: string): string {
+  return entityName ? `${entityLabel(entityType)} ${entityName} (${entityId})` : `${entityLabel(entityType)} ${entityId}`
+}
+
+function boolLabel(value: boolean): string {
+  return props.isZh ? (value ? '是' : '否') : (value ? 'yes' : 'no')
+}
+
+function typedConfirmPrompt(confirm: ConfigRestoreExecuteConfirm | undefined): string {
+  const token = confirm ?? ''
+  return props.isZh ? `输入 ${token} 以确认：` : `Type ${token} to confirm:`
+}
 </script>
 
 <style scoped>
@@ -337,6 +447,8 @@ function cancelRevert(): void { revert.value = { visible: false, loading: false,
 .cfg-restore-drift { margin: 0; color: var(--warning, #b45309); font-size: 12px; }
 .cfg-restore-summary { margin: 0; font-size: 12px; color: var(--text-secondary, #64748b); }
 .cfg-restore-changes { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 3px; }
+.cfg-restore-type { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--text-secondary, #64748b); }
+.cfg-restore-type input { width: 100%; box-sizing: border-box; padding: 5px 8px; border: 1px solid var(--border, #cbd5e1); border-radius: 6px; font-size: 13px; color: var(--text-primary, #0f172a); }
 .cfg-restore-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px; }
 .cfg-restore-actions button { padding: 4px 12px; border-radius: 6px; border: 1px solid var(--border, #cbd5e1); background: var(--surface, #fff); cursor: pointer; font-size: 13px; }
 .cfg-restore-actions button[disabled] { opacity: 0.5; cursor: not-allowed; }

--- a/apps/web/src/multitable/components/ResetToPointPicker.vue
+++ b/apps/web/src/multitable/components/ResetToPointPicker.vue
@@ -3,9 +3,9 @@
   "entry-wiring needs a T-source"). Lets a sheet-admin pick a point-in-time T and hands it to the existing
   ResetConfirmDialog as `asOf`. The dialog owns preview → typed two-step confirm → execute; this only sources T.
 
-  T-source = a free datetime-local picker (minimal "只差产品入口"). Alternative (deferred): present recent
-  HistoryCenterModal batch timestamps as selectable options — richer, still read-only consumption of history.
-  The `asOf` derivation is the single swappable seam (`localToIso` / the `asOf` computed) so that change is local.
+  T-source = recent Global History batch timestamps first. The free datetime-local picker remains as an advanced
+  fallback, but the normal destructive path is anchored to an audited history batch and passes that batch's
+  `createdAt` ISO to reset-preview/execute.
 
   Timezone: datetime-local is browser-local; `asOf` is the corresponding UTC ISO for the API. The human-facing
   "Target" line is derived FROM `asOf` (not the raw input), so what the user sees can never diverge from what the
@@ -14,16 +14,54 @@
 -->
 <template>
   <div v-if="pitResetEnabled" class="reset-picker" data-test="reset-picker">
-    <label class="reset-picker__label">
-      <span>Reset this sheet to a point in time</span>
-      <input
-        type="datetime-local"
-        class="reset-picker__input"
-        data-test="reset-picker-input"
-        v-model="localValue"
-        :max="nowLocalValue"
-      />
-    </label>
+    <div class="reset-picker__history" data-test="reset-picker-history">
+      <div class="reset-picker__heading">Reset this sheet to a Global History point</div>
+      <div class="reset-picker__history-row">
+        <label class="reset-picker__label">
+          <span>History point</span>
+          <select
+            class="reset-picker__input reset-picker__select"
+            data-test="reset-picker-history-select"
+            v-model="selectedBatchId"
+            :disabled="historyLoading || historyOptions.length === 0"
+            @change="mode = 'history'"
+          >
+            <option value="">Select a recent history batch</option>
+            <option v-for="batch in historyOptions" :key="batch.batchId" :value="batch.batchId">
+              {{ historyBatchLabel(batch) }}
+            </option>
+          </select>
+        </label>
+        <button
+          type="button"
+          class="reset-picker__refresh"
+          data-test="reset-picker-history-refresh"
+          :disabled="historyLoading || !canLoadHistory"
+          @click="loadHistoryBatches"
+        >
+          Refresh
+        </button>
+      </div>
+      <p v-if="historyLoading" class="reset-picker__hint" data-test="reset-picker-history-loading">Loading history points...</p>
+      <p v-else-if="historyError" class="reset-picker__hint reset-picker__hint--warn" data-test="reset-picker-history-error">{{ historyError }}</p>
+      <p v-else-if="canLoadHistory && historyOptions.length === 0" class="reset-picker__hint" data-test="reset-picker-history-empty">No recent history batches found.</p>
+      <p v-else-if="!canLoadHistory" class="reset-picker__hint" data-test="reset-picker-history-unavailable">History points unavailable.</p>
+    </div>
+
+    <details class="reset-picker__manual" data-test="reset-picker-manual">
+      <summary>Advanced manual time</summary>
+      <label class="reset-picker__label">
+        <span>Manual point in time</span>
+        <input
+          type="datetime-local"
+          class="reset-picker__input"
+          data-test="reset-picker-input"
+          v-model="localValue"
+          :max="nowLocalValue"
+          @input="mode = 'manual'"
+        />
+      </label>
+    </details>
 
     <!-- datetime-local coerces invalid text to '' so a non-empty-unparseable value can't occur; if `asOf` is somehow
          null it simply renders nothing below (fail-safe: no dialog), so no separate invalid branch is needed. -->
@@ -34,6 +72,7 @@
     <template v-else-if="asOf">
       <p class="reset-picker__target" data-test="reset-picker-target">
         Target: <strong>{{ targetDisplay }}</strong> (your local time)
+        <span v-if="selectedHistoryBatch && mode === 'history'"> from history batch {{ shortSelectedBatchId }}</span>
       </p>
       <ResetConfirmDialog
         :pit-reset-enabled="true"
@@ -47,22 +86,39 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import ResetConfirmDialog from './ResetConfirmDialog.vue'
 import type { ResetPreview, ResetResult } from '../api/client'
+import type { HistoryBatchSummary } from '../types'
+
+type ListHistoryEvents = (
+  baseId: string,
+  params?: { sheetId?: string; limit?: number },
+) => Promise<{ batches: HistoryBatchSummary[] }>
 
 const props = defineProps<{
   /** flag-derived capability (MULTITABLE_ENABLE_PIT_RESET ∧ canManageSheetAccess); off/absent ⇒ whole entry hidden. */
   pitResetEnabled?: boolean
+  /** base-level Global History scope. Required for the primary history-anchored picker path. */
+  baseId?: string
   /** bound here (not in the dialog) so the (sheetId, asOf) wiring is covered by THIS component's unit test. */
   sheetId: string
+  listHistoryEvents?: ListHistoryEvents
   resetPreview: (sheetId: string, asOf: string) => Promise<ResetPreview>
   resetExecute: (sheetId: string, asOf: string, previewIdentity: string) => Promise<ResetResult>
   onDone?: () => void
 }>()
 
+const RECENT_HISTORY_LIMIT = 20
+
 const localValue = ref('')
+const selectedBatchId = ref('')
+const historyBatches = ref<HistoryBatchSummary[]>([])
+const historyLoading = ref(false)
+const historyError = ref<string | null>(null)
+const mode = ref<'history' | 'manual'>('history')
+let historyLoadSeq = 0
 
 /** The single T-source seam: a browser-local datetime-local string → UTC ISO instant, or null if unparseable. */
 function localToIso(local: string): string | null {
@@ -71,7 +127,33 @@ function localToIso(local: string): string | null {
   return Number.isNaN(d.getTime()) ? null : d.toISOString()
 }
 
-const asOf = computed<string | null>(() => localToIso(localValue.value))
+function hasUsableCreatedAt(batch: HistoryBatchSummary): boolean {
+  return typeof batch.createdAt === 'string' && batch.createdAt.length > 0 && !Number.isNaN(new Date(batch.createdAt).getTime())
+}
+
+function historyBatchLabel(batch: HistoryBatchSummary): string {
+  const when = new Date(batch.createdAt).toLocaleString()
+  const actor = batch.actorName || batch.actorId || 'System'
+  const action = batch.action || 'update'
+  const records = batch.visibleAffectedRecordCount === 1 ? '1 record' : `${batch.visibleAffectedRecordCount} records`
+  return `${when} - ${action} - ${actor} - ${records}`
+}
+
+const canLoadHistory = computed(() =>
+  props.pitResetEnabled === true &&
+  typeof props.baseId === 'string' &&
+  props.baseId.length > 0 &&
+  typeof props.listHistoryEvents === 'function',
+)
+
+const historyOptions = computed(() => historyBatches.value.filter(hasUsableCreatedAt))
+const selectedHistoryBatch = computed(() =>
+  historyOptions.value.find((batch) => batch.batchId === selectedBatchId.value) ?? null,
+)
+const shortSelectedBatchId = computed(() => selectedHistoryBatch.value?.batchId.slice(0, 8) ?? '')
+const historyAsOf = computed<string | null>(() => selectedHistoryBatch.value?.createdAt ?? null)
+const manualAsOf = computed<string | null>(() => localToIso(localValue.value))
+const asOf = computed<string | null>(() => (mode.value === 'manual' ? manualAsOf.value : historyAsOf.value))
 // Derived FROM asOf (never from the raw input) so the displayed target and the API asOf cannot diverge.
 const targetDisplay = computed(() => (asOf.value ? new Date(asOf.value).toLocaleString() : ''))
 const isFuture = computed(() => (asOf.value ? new Date(asOf.value).getTime() > Date.now() : false))
@@ -82,14 +164,63 @@ const nowLocalValue = computed(() => {
   return d.toISOString().slice(0, 16)
 })
 
+async function loadHistoryBatches(): Promise<void> {
+  const loadSeq = ++historyLoadSeq
+  if (!canLoadHistory.value) {
+    historyBatches.value = []
+    selectedBatchId.value = ''
+    historyError.value = null
+    historyLoading.value = false
+    return
+  }
+
+  const baseId = props.baseId as string
+  const listHistoryEvents = props.listHistoryEvents as ListHistoryEvents
+  historyLoading.value = true
+  historyError.value = null
+  try {
+    const res = await listHistoryEvents(baseId, { sheetId: props.sheetId, limit: RECENT_HISTORY_LIMIT })
+    if (loadSeq !== historyLoadSeq) return
+    historyBatches.value = Array.isArray(res.batches) ? res.batches : []
+    if (!historyOptions.value.some((batch) => batch.batchId === selectedBatchId.value)) {
+      selectedBatchId.value = ''
+      if (mode.value !== 'manual') mode.value = 'history'
+    }
+  } catch (err) {
+    if (loadSeq !== historyLoadSeq) return
+    historyBatches.value = []
+    selectedBatchId.value = ''
+    historyError.value = err instanceof Error ? err.message : 'Failed to load history points'
+  } finally {
+    if (loadSeq === historyLoadSeq) historyLoading.value = false
+  }
+}
+
+watch(
+  () => [props.pitResetEnabled === true, props.baseId, props.sheetId, props.listHistoryEvents] as const,
+  () => {
+    void loadHistoryBatches()
+  },
+  { immediate: true },
+)
+
 const boundPreview = (a: string): Promise<ResetPreview> => props.resetPreview(props.sheetId, a)
 const boundExecute = (a: string, identity: string): Promise<ResetResult> => props.resetExecute(props.sheetId, a, identity)
 </script>
 
 <style scoped>
 .reset-picker { display: flex; flex-direction: column; gap: 8px; padding: 12px; border: 1px solid #fda29b; border-radius: 8px; background: #fffbfa; }
+.reset-picker__history { display: flex; flex-direction: column; gap: 6px; }
+.reset-picker__heading { font-size: 13px; font-weight: 600; color: #912018; }
+.reset-picker__history-row { display: flex; align-items: flex-end; gap: 8px; flex-wrap: wrap; }
 .reset-picker__label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: #912018; }
 .reset-picker__input { padding: 6px 8px; border: 1px solid #d0d5dd; border-radius: 6px; max-width: 240px; }
+.reset-picker__select { min-width: min(520px, 100%); max-width: min(640px, 100%); }
+.reset-picker__refresh { padding: 6px 10px; border: 1px solid #d0d5dd; border-radius: 6px; background: #fff; color: #912018; cursor: pointer; }
+.reset-picker__refresh:disabled { cursor: default; opacity: 0.6; }
+.reset-picker__manual { color: #912018; font-size: 12px; }
+.reset-picker__manual > summary { cursor: pointer; }
+.reset-picker__manual .reset-picker__label { margin-top: 6px; }
 .reset-picker__hint { font-size: 12px; margin: 0; }
 .reset-picker__hint--warn { color: #b42318; }
 .reset-picker__target { font-size: 13px; margin: 0; }

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -66,6 +66,9 @@ export type MetaRecordLabelKey =
   | 'record.configRestoreAction' | 'record.configRestoreTitle' | 'record.configRestoreWillRevert'
   | 'record.configRestoreDrift' | 'record.configRestoreGated' | 'record.configRestoreConfirm'
   | 'record.configRestoreCancel' | 'record.configRestoreError'
+  | 'record.configRestoreServerSummary' | 'record.configRestoreEntity' | 'record.configRestoreNote'
+  | 'record.configRestoreIdCollision' | 'record.configRestoreIdCollisionBlocked' | 'record.configRestoreScope'
+  | 'record.configRestoreDirection' | 'record.configRestoreBlocked'
   // FE-owned static fallback strings (the `error?.message ?? l(...)`
   // pattern from T3A2). Backend error.message remains raw when present.
   | 'record.errorHistoryLoad' | 'record.errorWatchLoad' | 'record.errorWatchUpdate'
@@ -192,6 +195,14 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.configRestoreConfirm': { en: 'Revert', zh: '确认撤销' },
   'record.configRestoreCancel': { en: 'Cancel', zh: '取消' },
   'record.configRestoreError': { en: 'Revert failed', zh: '撤销失败' },
+  'record.configRestoreServerSummary': { en: 'Server preview:', zh: '服务端预览：' },
+  'record.configRestoreEntity': { en: 'Entity', zh: '对象' },
+  'record.configRestoreNote': { en: 'Note', zh: '说明' },
+  'record.configRestoreIdCollision': { en: 'ID collision', zh: 'ID 冲突' },
+  'record.configRestoreIdCollisionBlocked': { en: 'An entity with this id already exists. Re-preview after resolving the collision.', zh: '已有对象占用此 ID。请处理冲突后重新预览。' },
+  'record.configRestoreScope': { en: 'Scope', zh: '范围' },
+  'record.configRestoreDirection': { en: 'Direction', zh: '方向' },
+  'record.configRestoreBlocked': { en: 'This preview is not executable.', zh: '此预览不可执行。' },
   'record.errorRestore': { en: 'Restore failed', zh: '恢复失败' },
   'record.errorHistoryLoad': { en: 'Failed to load history', zh: '加载历史失败' },
   'record.errorWatchLoad': { en: 'Failed to load watch status', zh: '加载关注状态失败' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -68,7 +68,9 @@
     <ResetToPointPicker
       v-if="workbench.activeSheetId.value"
       :pit-reset-enabled="pitResetEnabled"
+      :base-id="activeBaseId || ''"
       :sheet-id="workbench.activeSheetId.value"
+      :list-history-events="listHistoryEventsWire"
       :reset-preview="resetPreviewWire"
       :reset-execute="resetExecuteWire"
       :on-done="onResetDone"
@@ -635,7 +637,7 @@ import MetaGridTable from '../components/MetaGridTable.vue'
 import MetaExportDialog, { type ExportConfirmPayload } from '../components/MetaExportDialog.vue'
 import RestorePreviewDialog from '../components/RestorePreviewDialog.vue'
 import RestoreBatchDialog from '../components/RestoreBatchDialog.vue'
-import type { RestorePreviewChange, RestoreBatchPreviewRecord, RestoreBatchExecuteRecord } from '../api/client'
+import type { ConfigRestoreExecuteConfirm, RestorePreviewChange, RestoreBatchPreviewRecord, RestoreBatchExecuteRecord } from '../api/client'
 import { buildBatchExpectedVersions } from '../utils/batch-restore-expected-versions'
 import { resolveSelectionLabels } from '../utils/batch-restore-labels'
 import MetaFormView from '../components/MetaFormView.vue'
@@ -778,9 +780,13 @@ const personalView = usePersonalViewToggle({ client: workbench.client, enabled: 
 const grid = useMultitableGrid({ sheetId: workbench.activeSheetId, viewId: workbench.activeViewId, isPersonalMode: personalView.isPersonalMode })
 
 // T8-2 Reset UI T-source entry wiring (#3250/#3251 flagged the missing T-source). Gate on the flag-derived
-// pitResetEnabled signal alone (it already encodes canManageSheetAccess); pass the raw client signatures so the
-// picker owns + tests the (sheetId, asOf) composition; refresh the grid after a successful reset.
+// pitResetEnabled signal alone (it already encodes canManageSheetAccess); pass Global History listing plus the raw
+// reset client signatures so the picker owns + tests the (sheetId, asOf) composition; refresh the grid after success.
 const pitResetEnabled = computed(() => capabilitySource.value?.pitResetEnabled === true)
+const listHistoryEventsWire = (
+  baseId: string,
+  params?: Parameters<typeof workbench.client.listHistoryEvents>[1],
+) => workbench.client.listHistoryEvents(baseId, params)
 const resetPreviewWire = (sid: string, asOf: string) => workbench.client.resetPreview(sid, asOf)
 const resetExecuteWire = (sid: string, asOf: string, previewIdentity: string) => workbench.client.resetExecute(sid, asOf, previewIdentity)
 const onResetDone = () => { void grid.reloadCurrentPage() }
@@ -1020,8 +1026,8 @@ async function loadConfigHistory(entityType: string) {
 function configRestorePreview(revisionId: string) {
   return workbench.client.getConfigRestorePreview(workbench.activeSheetId.value, revisionId)
 }
-function configRestoreExecute(revisionId: string, previewToken: string) {
-  return workbench.client.executeConfigRestore(workbench.activeSheetId.value, revisionId, previewToken)
+function configRestoreExecute(revisionId: string, previewToken: string, confirm?: ConfigRestoreExecuteConfirm) {
+  return workbench.client.executeConfigRestore(workbench.activeSheetId.value, revisionId, previewToken, confirm)
 }
 async function onConfigReverted() {
   // A revert changes field name/order or view filter/config — reload sheet meta + grid so the field

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -23,7 +23,7 @@ const rev = (over: Partial<MetaConfigRevision>): MetaConfigRevision => ({
 type Props = {
   visible: boolean; items: MetaConfigRevision[]; loading: boolean; entityType: string
   recordLabelOf: (id: string) => string; isZh: boolean; onClose: () => void; onFilterChange: (t: string) => void
-  previewRevert?: (id: string) => Promise<ConfigRestorePreview>; executeRevert?: (id: string, h: string) => Promise<void>; onReverted?: () => void
+  previewRevert?: (id: string) => Promise<ConfigRestorePreview>; executeRevert?: (id: string, h: string, confirm?: string) => Promise<void>; onReverted?: () => void
 }
 const mounted: Array<{ unmount: () => void }> = []
 function mountModal(over: Partial<Props>) {
@@ -36,6 +36,12 @@ function mountModal(over: Partial<Props>) {
 }
 const q = (s: string) => document.body.querySelector(s) as HTMLElement | null
 const flush = async () => { await Promise.resolve(); await nextTick(); await Promise.resolve(); await nextTick() }
+const typeInto = async (selector: string, value: string) => {
+  const input = q(selector) as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input'))
+  await flush()
+}
 // Poll until a condition holds (CI-robust): the real client's fetch→text→parse→render chain takes a variable number
 // of ticks, so a fixed `flush()` count races in CI. Retry-with-flush until the predicate is true (or time out).
 const waitUntil = async (pred: () => boolean, tries = 100): Promise<void> => {
@@ -239,8 +245,101 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     expect(document.body.textContent).toContain('Old') // target
     ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
     await flush()
-    expect(executeRevert).toHaveBeenCalledWith('a', 'tok1') // the server-minted previewToken, NOT a client hash
+    expect(executeRevert).toHaveBeenCalledWith('a', 'tok1', undefined) // the server-minted previewToken, NOT a client hash
     expect(onReverted).toHaveBeenCalledTimes(1)
+  })
+
+  it('UNCREATE: create rows open server preview, show the server note, and require typed confirm before execute', async () => {
+    const previewRevert = vi.fn(async (): Promise<ConfigRestorePreview> => ({
+      revisionId: 'create-1',
+      previewToken: 'uncreate-token',
+      uncreate: {
+        entityType: 'field',
+        entityId: 'fld_created',
+        entityName: 'Temporary field',
+        note: 'Server says this permanently drops the created field and values.',
+      },
+    }))
+    const executeRevert = vi.fn(async () => {})
+    mountModal({
+      items: [rev({ id: 'create-1', action: 'create', entityId: 'fld_created', after: { name: 'Temporary field' } })],
+      previewRevert,
+      executeRevert,
+    })
+    await nextTick()
+    ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(previewRevert).toHaveBeenCalledWith('create-1')
+    expect(document.body.textContent).toContain('Server says this permanently drops')
+    expect(document.body.textContent).toContain('Temporary field')
+    expect((q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).disabled).toBe(true)
+
+    await typeInto('[data-test="config-restore-type-input"]', 'uncreate')
+    expect((q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).disabled).toBe(false)
+    ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
+    await flush()
+    expect(executeRevert).toHaveBeenCalledWith('create-1', 'uncreate-token', 'uncreate')
+  })
+
+  it('UNDELETE collision: delete rows show note + idCollision and fail closed without execute', async () => {
+    mountModal({
+      items: [rev({ id: 'delete-1', action: 'delete', before: { name: 'Deleted field' }, after: null })],
+      previewRevert: vi.fn(async (): Promise<ConfigRestorePreview> => ({
+        revisionId: 'delete-1',
+        previewToken: 'undelete-token',
+        undelete: {
+          entityType: 'field',
+          entityId: 'fld_deleted',
+          entityName: 'Deleted field',
+          note: 'Definition only; values are not restored.',
+          idCollision: true,
+        },
+      })),
+      executeRevert: vi.fn(),
+    })
+    await nextTick()
+    ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(document.body.textContent).toContain('Definition only')
+    expect(document.body.textContent).toContain('ID collision')
+    expect(document.body.textContent).toContain('yes')
+    expect(q('[data-test="config-restore-type-input"]')).toBeFalsy()
+    expect(q('[data-test="config-restore-confirm-btn"]')).toBeFalsy()
+  })
+
+  it('PERMISSION revert: permission rows show direction/note and require revert-permission confirm', async () => {
+    const executeRevert = vi.fn(async () => {})
+    mountModal({
+      items: [rev({ id: 'perm-1', entityType: 'permission', entityId: 'sheet:[\"user\",\"u1\"]', action: 'create' })],
+      previewRevert: vi.fn(async (): Promise<ConfigRestorePreview> => ({
+        revisionId: 'perm-1',
+        previewToken: 'permission-token',
+        permissionRevert: {
+          scope: 'sheet',
+          direction: 'de-escalation',
+          supported: true,
+          note: "Server says this reduces the subject's access.",
+        },
+      })),
+      executeRevert,
+    })
+    await nextTick()
+    ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(document.body.textContent).toContain('Direction')
+    expect(document.body.textContent).toContain('de-escalation')
+    expect(document.body.textContent).toContain('reduces the subject')
+    ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
+    await flush()
+    expect(executeRevert).not.toHaveBeenCalled()
+
+    await typeInto('[data-test="config-restore-type-input"]', 'revert-permission')
+    ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
+    await flush()
+    expect(executeRevert).toHaveBeenCalledWith('perm-1', 'permission-token', 'revert-permission')
   })
 
   it('END-TO-END wire: Revert button → real client → config-restore-preview then -execute with the SERVER previewToken', async () => {
@@ -260,7 +359,7 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     mountModal({
       items: [updateRev()], onReverted,
       previewRevert: (id: string) => client.getConfigRestorePreview('sheet_1', id),
-      executeRevert: (id: string, token: string) => client.executeConfigRestore('sheet_1', id, token),
+      executeRevert: (id: string, token: string, confirm) => client.executeConfigRestore('sheet_1', id, token, confirm),
     })
     await nextTick()
     ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
@@ -273,6 +372,46 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     // the execute body carries the SERVER-minted token (not a client hash) — preview-first can't be bypassed via the UI
     const execBody = JSON.parse((fetchFn.mock.calls[1][1] as RequestInit).body as string)
     expect(execBody.previewToken).toBe('server-token-xyz')
+    expect(execBody.baselineHash).toBeUndefined()
+    expect(onReverted).toHaveBeenCalledTimes(1)
+  })
+
+  it('DESTRUCTIVE wire: real client carries previewToken + confirm:"uncreate" to execute', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('config-restore-preview')) {
+        return new Response(JSON.stringify({ ok: true, data: {
+          uncreate: {
+            entityType: 'field',
+            entityId: 'fld_created',
+            entityName: 'Created Field',
+            note: 'Server destructive note.',
+          },
+          previewToken: 'server-uncreate-token',
+        } }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ ok: true, data: { uncreated: { entityType: 'field', entityId: 'fld_created' } } }), { status: 200 })
+    })
+    const client = new MultitableApiClient({ fetchFn })
+    const onReverted = vi.fn()
+    mountModal({
+      items: [rev({ id: 'create-1', action: 'create', entityId: 'fld_created', after: { name: 'Created Field' } })],
+      onReverted,
+      previewRevert: (id: string) => client.getConfigRestorePreview('sheet_1', id),
+      // Workbench-style forwarder: the modal passes the destructive confirm explicitly while safe update bodies stay unchanged.
+      executeRevert: (id: string, token: string, confirm) => client.executeConfigRestore('sheet_1', id, token, confirm),
+    })
+    await nextTick()
+    ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
+    await waitUntil(() => !!q('[data-test="config-restore-type-input"]'))
+    await typeInto('[data-test="config-restore-type-input"]', 'uncreate')
+    ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
+    await waitUntil(() => fetchFn.mock.calls.length >= 2 && onReverted.mock.calls.length >= 1)
+
+    expect(fetchFn.mock.calls[0][0]).toContain('/config-restore-preview')
+    expect(fetchFn.mock.calls[1][0]).toContain('/config-restore-execute')
+    const execBody = JSON.parse((fetchFn.mock.calls[1][1] as RequestInit).body as string)
+    expect(execBody.previewToken).toBe('server-uncreate-token')
+    expect(execBody.confirm).toBe('uncreate')
     expect(execBody.baselineHash).toBeUndefined()
     expect(onReverted).toHaveBeenCalledTimes(1)
   })

--- a/apps/web/tests/multitable-reset-tsource-picker.spec.ts
+++ b/apps/web/tests/multitable-reset-tsource-picker.spec.ts
@@ -1,22 +1,40 @@
 // @vitest-environment jsdom
 /**
  * T8-2 Reset UI — ResetToPointPicker (the T-source the #3250 dialog was missing). Hidden unless `pitResetEnabled`.
- * Sources a point-in-time T from a datetime-local input, mounts the existing ResetConfirmDialog only once T is a
- * valid PAST instant, and binds the (sheetId, asOf) wire to the client. The WIRE test below is the real verification
- * (not a fixture): it asserts the picker's sheetId + the UTC-ISO derived from the local input both reach reset-preview
- * with no timezone inversion.
+ * Sources a point-in-time T from recent Global History batches first, keeps datetime-local as an advanced fallback,
+ * and binds the (sheetId, asOf) wire to the client. The WIRE tests below assert the selected history batch's
+ * `createdAt` ISO reaches reset-preview/reset-execute.
  */
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { createApp, nextTick } from 'vue'
 
 import ResetToPointPicker from '../src/multitable/components/ResetToPointPicker.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
+import type { HistoryBatchSummary } from '../src/multitable/types'
 
 const mounted: Array<{ unmount: () => void }> = []
+function historyBatch(id: string, createdAt = '2020-01-15T10:30:00.000Z'): HistoryBatchSummary {
+  return {
+    batchId: id,
+    sheetId: 'sheet_xyz',
+    actorId: 'u1',
+    actorName: 'Ada',
+    source: 'rest',
+    action: 'update',
+    createdAt,
+    visibleAffectedRecordCount: 1,
+    visibleAffectedFieldCount: 1,
+    provenanceQuality: 'stamped',
+  }
+}
+
 function mount(over: Record<string, unknown> = {}) {
+  const batches = [historyBatch('batch_new'), historyBatch('batch_old', '2020-01-14T09:00:00.000Z')]
   const props: Record<string, unknown> = {
     pitResetEnabled: true,
+    baseId: 'base_abc',
     sheetId: 'sheet_xyz',
+    listHistoryEvents: vi.fn(async () => ({ batches, total: batches.length, nextCursor: null, searchTruncated: false })),
     resetPreview: vi.fn(async () => ({ asOf: '', strategy: 'reset', summary: { visibleRevertCount: 0, deleteCount: 0 }, deleteRecordIds: [], previewIdentity: 't' })),
     resetExecute: vi.fn(async () => ({ asOf: '', strategy: 'reset', revertedCount: 0, deletedRecordIds: [] })),
     ...over,
@@ -31,6 +49,7 @@ const waitUntil = async (pred: () => boolean, tries = 100): Promise<void> => {
   throw new Error('waitUntil: condition not met')
 }
 const setInput = (sel: string, val: string) => { const el = q(sel) as HTMLInputElement; el.value = val; el.dispatchEvent(new Event('input')) }
+const setSelect = (sel: string, val: string) => { const el = q(sel) as HTMLSelectElement; el.value = val; el.dispatchEvent(new Event('change')) }
 afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
 
 describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
@@ -42,40 +61,46 @@ describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
     expect(q('[data-test="reset-picker"]')).toBeFalsy()
   })
 
-  it('(b) enabled: shows the datetime picker, but NO dialog/target until a T is chosen', async () => {
-    mount(); await nextTick()
-    expect(q('[data-test="reset-picker-input"]')).toBeTruthy()
+  it('(b) enabled: loads and shows recent Global History batches, but NO dialog/target until a T is chosen', async () => {
+    const props = mount(); await nextTick()
+    await waitUntil(() => (q('[data-test="reset-picker-history-select"]') as HTMLSelectElement | null)?.options.length === 3)
+    expect(q('[data-test="reset-picker-history-select"]')).toBeTruthy()
+    expect(q('[data-test="reset-picker-input"]')).toBeTruthy() // advanced/manual fallback stays mounted
     expect(q('[data-test="reset-picker-target"]')).toBeFalsy()
     expect(q('[data-test="reset-entry"]')).toBeFalsy() // the dialog isn't mounted yet → no second reset button
+    expect((props.listHistoryEvents as ReturnType<typeof vi.fn>).mock.calls[0]).toEqual(['base_abc', { sheetId: 'sheet_xyz', limit: 20 }])
   })
 
-  it('(c) FUTURE T → future hint, no dialog (can only reset to the past)', async () => {
+  it('(c) FUTURE manual fallback T → future hint, no dialog (can only reset to the past)', async () => {
     mount(); await nextTick()
     setInput('[data-test="reset-picker-input"]', '2099-01-01T00:00'); await flush()
     expect(q('[data-test="reset-picker-future"]')).toBeTruthy()
     expect(q('[data-test="reset-entry"]')).toBeFalsy()
   })
 
-  it('(e) valid PAST T → shows local target + mounts the ResetConfirmDialog entry', async () => {
+  it('(e) valid history batch T → shows local target + mounts the ResetConfirmDialog entry', async () => {
     mount(); await nextTick()
-    setInput('[data-test="reset-picker-input"]', '2020-01-15T10:30'); await flush()
+    await waitUntil(() => (q('[data-test="reset-picker-history-select"]') as HTMLSelectElement | null)?.options.length === 3)
+    setSelect('[data-test="reset-picker-history-select"]', 'batch_new'); await flush()
     expect(q('[data-test="reset-picker-target"]')).toBeTruthy()
     await waitUntil(() => !!q('[data-test="reset-entry"]')) // dialog mounted → its own entry button present
   })
 
-  it('(f) WIRE: choosing T → reset-preview hits the picker sheetId with the UTC-ISO of the input (no tz inversion)', async () => {
-    const local = '2020-01-15T10:30'
+  it('(f) WIRE: choosing a history batch → reset-preview hits the picker sheetId with that batch createdAt ISO', async () => {
+    const batchCreatedAt = '2020-01-15T10:30:00.000Z'
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({ ok: true, data: {
       asOf: '', strategy: 'reset', summary: { visibleRevertCount: 1, deleteCount: 0 }, deleteRecordIds: [], previewIdentity: 'srv',
     } }), { status: 200 }))
     const client = new MultitableApiClient({ fetchFn })
     mount({
+      listHistoryEvents: vi.fn(async () => ({ batches: [historyBatch('batch_wire', batchCreatedAt)], total: 1, nextCursor: null, searchTruncated: false })),
       sheetId: 'sheet_xyz',
       resetPreview: (sid: string, asOf: string) => client.resetPreview(sid, asOf),
       resetExecute: (sid: string, asOf: string, id: string) => client.resetExecute(sid, asOf, id),
     })
     await nextTick()
-    setInput('[data-test="reset-picker-input"]', local); await flush()
+    await waitUntil(() => (q('[data-test="reset-picker-history-select"]') as HTMLSelectElement | null)?.options.length === 2)
+    setSelect('[data-test="reset-picker-history-select"]', 'batch_wire'); await flush()
     await waitUntil(() => !!q('[data-test="reset-entry"]'))
     ;(q('[data-test="reset-entry"]') as HTMLButtonElement).click()
     await waitUntil(() => fetchFn.mock.calls.length >= 1)
@@ -83,14 +108,12 @@ describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
     const body = JSON.parse((fetchFn.mock.calls[0][1] as RequestInit).body as string)
     expect(url).toContain('sheet_xyz')           // sheetId wiring (picker → client), not a fixture
     expect(url).toContain('/reset-preview')
-    // the asOf is the UTC-ISO of the local input AND round-trips to the same instant (no inversion / double-convert)
-    expect(typeof body.asOf).toBe('string')
-    expect(new Date(body.asOf).getTime()).toBe(new Date(local).getTime())
-    expect(body.asOf).toBe(new Date(local).toISOString())
+    expect(body.asOf).toBe(batchCreatedAt)
   })
 
-  it('(g) POST-EXECUTE SEAM: a successful reset fires onDone (→ workbench grid refresh) and hits reset-execute with the picker sheetId', async () => {
+  it('(g) POST-EXECUTE SEAM: a successful reset fires onDone and hits reset-execute with the history batch ISO', async () => {
     const onDone = vi.fn()
+    const batchCreatedAt = '2020-01-15T10:30:00.000Z'
     const fetchFn = vi.fn(async (url: string) => {
       // deleteCount:0 → the dialog's revert-equivalent path (no typed confirm) so we can drive execute simply.
       if (String(url).includes('reset-preview')) return new Response(JSON.stringify({ ok: true, data: {
@@ -101,11 +124,13 @@ describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
     const client = new MultitableApiClient({ fetchFn })
     mount({
       sheetId: 'sheet_xyz', onDone,
+      listHistoryEvents: vi.fn(async () => ({ batches: [historyBatch('batch_execute', batchCreatedAt)], total: 1, nextCursor: null, searchTruncated: false })),
       resetPreview: (sid: string, asOf: string) => client.resetPreview(sid, asOf),
       resetExecute: (sid: string, asOf: string, id: string) => client.resetExecute(sid, asOf, id),
     })
     await nextTick()
-    setInput('[data-test="reset-picker-input"]', '2020-01-15T10:30'); await flush()
+    await waitUntil(() => (q('[data-test="reset-picker-history-select"]') as HTMLSelectElement | null)?.options.length === 2)
+    setSelect('[data-test="reset-picker-history-select"]', 'batch_execute'); await flush()
     await waitUntil(() => !!q('[data-test="reset-entry"]'))
     ;(q('[data-test="reset-entry"]') as HTMLButtonElement).click()
     await waitUntil(() => !!q('[data-test="reset-confirm-btn"]')) // revert-equivalent confirm (deleteCount 0)
@@ -113,6 +138,7 @@ describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
     await waitUntil(() => fetchFn.mock.calls.length >= 2)
     expect(String(fetchFn.mock.calls[1][0])).toContain('sheet_xyz')
     expect(String(fetchFn.mock.calls[1][0])).toContain('/reset-execute')
+    expect(JSON.parse((fetchFn.mock.calls[1][1] as RequestInit).body as string).asOf).toBe(batchCreatedAt)
     await waitUntil(() => onDone.mock.calls.length >= 1) // the seam back to the workbench (grid refresh) fired
   })
 })

--- a/docs/development/multitable-global-history-final-code-dev-verification-20260707.md
+++ b/docs/development/multitable-global-history-final-code-dev-verification-20260707.md
@@ -1,0 +1,165 @@
+# Global History — final code-dev pass verification (2026-07-07)
+
+This is a dated implementation and verification record for the 2026-07-07 owner GO:
+"complete the remaining code-development items for the history/restore line, plan/order parallel work, and deliver a
+design + verification MD." The canonical source remains current `origin/main` plus the existing
+`multitable-global-history-*` docs; this file records what this pass changed.
+
+Base reviewed and re-verified after rebase: `origin/main` at `7bb0a5feace1bf2540a5c016f481e514e45c2ddf`.
+
+## 0. Execution order
+
+1. **Backend safety guard first** — block PIT Reset whenever meta-revision retention is enabled. This is a fail-closed
+   safety invariant and is independent of UI.
+2. **Reset T-source product entry** — replace the normal destructive Reset entry's free-form time source with an
+   audited Global History batch selector, keeping manual datetime only as an Advanced fallback.
+3. **Config-restore destructive FE** — expose the already-shipped T9-W destructive/sensitive config tiers through the
+   existing Config History modal using server previews and typed confirms.
+4. **Boundary review** — re-read delete-revision / field-value recovery code. The honest boundary is unchanged:
+   historical bytes and link edges that were never captured cannot be recovered retroactively.
+
+Items 2 and 3 were developed in isolated worktrees in parallel, then integrated into one final branch with item 1.
+
+## 1. Code changes
+
+### 1.1 PIT Reset retention conflict guard
+
+Files:
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts`
+
+Behavior:
+- If `MULTITABLE_ENABLE_PIT_RESET=true` and `MULTITABLE_META_REVISION_RETENTION_ENABLED=1`, both
+  `/reset-preview` and `/reset-execute` now return:
+  - HTTP `409`
+  - `RESET_RETENTION_CONFLICT`
+  - zero writes
+- This turns the previous runbook-level STOP-SHIP condition into an executable backend guard. It does not enable any
+  flag.
+
+Golden:
+- `(b2) retention guard: PIT_RESET + meta revision retention enabled -> 409 RESET_RETENTION_CONFLICT, ZERO writes`
+  verifies preview refusal, execute refusal, survivor records unchanged, post-T record still live, no trash insert, and
+  no `source='restore'` revision.
+
+### 1.2 History-anchored Reset T-source
+
+Files:
+- `apps/web/src/multitable/components/ResetToPointPicker.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/tests/multitable-reset-tsource-picker.spec.ts`
+
+Behavior:
+- The default Reset entry now lists recent Global History batches via `listHistoryEvents(baseId, { sheetId, limit: 20 })`.
+- Selecting a batch passes that batch's exact `createdAt` ISO to `reset-preview` and `reset-execute`.
+- Manual `datetime-local` remains available under Advanced manual time as an explicit fallback.
+- The entry remains hidden unless `pitResetEnabled` is true.
+
+Wire locks:
+- history list is scoped by base + sheet;
+- preview receives the selected batch `createdAt` ISO, not a recomputed local time;
+- execute receives the same selected batch ISO and fires the existing refresh seam on success.
+
+### 1.3 T9-W destructive/sensitive config restore FE
+
+Files:
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/src/multitable/components/MetaConfigHistoryModal.vue`
+- `apps/web/src/multitable/utils/meta-record-labels.ts`
+- `apps/web/tests/multitable-config-history-modal.spec.ts`
+
+Behavior:
+- The Config History modal now lets create/delete/permission revision rows open the server preview instead of hiding
+  the action client-side.
+- Existing safe update previews keep the old diff UI and execute body.
+- Destructive/sensitive server preview shapes are rendered faithfully:
+  - `uncreate` -> typed confirm `uncreate`;
+  - `undelete` -> typed confirm `undelete`, blocked on `idCollision`;
+  - `permissionRevert` -> typed confirm `revert-permission`, executable only when server says `supported: true`.
+- The modal passes the typed confirm explicitly to the workbench/client. The client also keeps a token->confirm fallback
+  for compatibility, but the workbench path no longer relies on hidden client state.
+
+Wire locks:
+- ordinary update execute still sends server `previewToken` and no client baseline hash;
+- destructive execute sends `previewToken + confirm:"uncreate"`;
+- permission and undelete previews cannot execute until their server-shaped conditions are satisfied.
+
+## 2. Boundary deliberately not changed
+
+No production/staging flags were enabled in this pass.
+
+The single-record version restore route still refuses delete revisions with `RESTORE_UNSUPPORTED`. That is not the same
+as PIT undelete or recycle-bin restore:
+- PIT undelete reconstructs a record at a point in time and is already implemented behind `MULTITABLE_ENABLE_PIT_UNDELETE`.
+- Trash restore resurrects the delete-time trash row.
+- A record-version target whose revision action is `delete` means "the record did not exist at that version"; treating
+  its pre-delete snapshot as a normal restore target would be a semantic lie.
+
+Value-level recovery for already-destroyed field data also remains impossible: historical config revisions store field
+definitions, not the removed per-record column bytes, link edges, or auto-number sequence state. A forward-looking
+tombstone-capture feature could preserve future destructive deletes/retypes, but it cannot recover bytes that were
+never captured before this pass.
+
+## 3. Verification
+
+Targeted first pass:
+
+```bash
+cd /private/tmp/ms2-gh-final/apps/web
+./node_modules/.bin/vitest run \
+  tests/multitable-reset-tsource-picker.spec.ts \
+  tests/multitable-config-history-modal.spec.ts \
+  --watch=false --reporter=dot
+# 2 files, 29 tests passed
+
+./node_modules/.bin/vue-tsc -b
+# passed
+
+cd /private/tmp/ms2-gh-final
+/Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/tsc \
+  -p packages/core-backend/tsconfig.json --noEmit
+# passed
+```
+
+Backend real-DB guard pass:
+
+```bash
+DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/<fresh-db> \
+  vitest --config vitest.integration.config.ts \
+  run tests/integration/multitable-reset-pit-realdb.test.ts --reporter=dot
+# 1 file, 13 tests passed
+```
+
+Scoped Global History / restore backend pass on a fresh migrated DB:
+
+```bash
+DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/<fresh-db> \
+  vitest --config vitest.integration.config.ts run <31 history/restore real-DB files> --reporter=dot
+# 31 files, 303 tests passed
+```
+
+Scoped Global History / restore frontend pass:
+
+```bash
+cd /private/tmp/ms2-gh-final/apps/web
+./node_modules/.bin/vitest run <13 history/restore FE specs> --watch=false --reporter=dot
+# 13 files, 104 tests passed
+```
+
+Cleanup:
+- both disposable PostgreSQL databases were dropped with `DROP DATABASE ... WITH (FORCE)`;
+- dependency symlinks used only to run tests from the temporary worktree were not staged.
+
+## 4. Final state
+
+The code-completable remainder opened by this GO is implemented:
+- retention conflict is an executable backend guard;
+- Reset has a history-anchored T-source product entry;
+- destructive/sensitive T9-W config restore tiers have FE preview/confirm/execute wiring.
+
+Remaining work is not autonomous code completion:
+- environment flag enablement is an operator/owner rollout decision;
+- production rollout is separate from staging;
+- already-destroyed field values/link edges cannot be recovered without prior tombstone capture;
+- any future tombstone-capture/value-level recovery feature is forward-looking and should be designed as its own
+  product capability, not represented as retroactive recovery.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -9711,9 +9711,18 @@ export function univerMetaRouter(): Router {
   // writes happen in ONE transaction; a single denied/forbidden/locked/conflicted target aborts the whole Reset with
   // zero writes/deletes/revisions.
   const PIT_RESET_ENABLED = () => String(process.env.MULTITABLE_ENABLE_PIT_RESET ?? '').trim().toLowerCase() === 'true'
+  const PIT_RESET_RETENTION_BLOCKED = () => String(process.env.MULTITABLE_META_REVISION_RETENTION_ENABLED ?? '').trim() === '1'
+  const sendPitResetRetentionBlocked = (res: Response) => res.status(409).json({
+    ok: false,
+    error: {
+      code: 'RESET_RETENTION_CONFLICT',
+      message: 'Reset-to-T is refused while meta revision retention is enabled; disable MULTITABLE_META_REVISION_RETENTION_ENABLED before using PIT reset.',
+    },
+  })
 
   router.post('/sheets/:sheetId/reset-preview', async (req: Request, res: Response) => {
     if (!PIT_RESET_ENABLED()) return res.status(403).json({ ok: false, error: { code: 'RESET_DISABLED', message: 'Reset-to-T is disabled (MULTITABLE_ENABLE_PIT_RESET is off).' } })
+    if (PIT_RESET_RETENTION_BLOCKED()) return sendPitResetRetentionBlocked(res)
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const parsed = z.object({ asOf: z.string().min(1) }).safeParse(req.body)
     if (!sheetId || !parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and asOf are required' } })
@@ -9754,6 +9763,7 @@ export function univerMetaRouter(): Router {
 
   router.post('/sheets/:sheetId/reset-execute', async (req: Request, res: Response) => {
     if (!PIT_RESET_ENABLED()) return res.status(403).json({ ok: false, error: { code: 'RESET_DISABLED', message: 'Reset-to-T is disabled (MULTITABLE_ENABLE_PIT_RESET is off).' } })
+    if (PIT_RESET_RETENTION_BLOCKED()) return sendPitResetRetentionBlocked(res)
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     // D4: a typed two-step confirm — Reset (destructive) cannot be triggered by a stray Revert-shaped call.
     const parsed = z.object({ asOf: z.string().min(1), previewIdentity: z.string().min(1), confirm: z.literal('reset') }).safeParse(req.body)

--- a/packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts
@@ -1,7 +1,8 @@
 /**
  * T8-2: Point-in-Time Reset-to-T (DESTRUCTIVE sheet rollback) — real DB. Reset = Revert (surviving records → their
  * T-state) + SOFT-DELETE the records created after T. Goldens: (a) flag-off → inert 403; (b) flag-on → post-T-created
- * SOFT-DELETED (to recycle-bin trash) + survivors reverted (source=restore); (c) PIT-2 all-or-nothing — a LOCKED
+ * SOFT-DELETED (to recycle-bin trash) + survivors reverted (source=restore); (b2) retention guard refuses Reset
+ * while meta revision retention is enabled; (c) PIT-2 all-or-nothing — a LOCKED
  * delete-target → 409 RESET_BLOCKED with ZERO writes (mutation-proven: drop the not-locked preflight check → D is
  * deleted → this golden fails); (d) row-deny added after preview → 409 RESET_BLOCKED with ZERO writes and no blocker
  * details; (e) ceiling → 413; (f) typed confirm:'reset' required → 400; (g) delete-set divergence — a record created
@@ -67,11 +68,13 @@ describeIfDatabase('multitable T8-2 Reset-to-T (DESTRUCTIVE, real DB)', () => {
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
     await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+    delete process.env.MULTITABLE_META_REVISION_RETENTION_ENABLED
   })
   beforeEach(async () => {
     curRoles = ['member']
     curPerms = ['multitable:read', 'multitable:write', 'multitable:share']
     process.env.MULTITABLE_ENABLE_PIT_RESET = 'true' // flag ON for most tests; (a) turns it off
+    delete process.env.MULTITABLE_META_REVISION_RETENTION_ENABLED
     await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SHEET])
     await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
@@ -104,6 +107,25 @@ describeIfDatabase('multitable T8-2 Reset-to-T (DESTRUCTIVE, real DB)', () => {
     expect(await inTrash(D)).toBe(true) // ...recoverable in the recycle bin (NOT hard-deleted)
     const restoreRevs = (await q(`SELECT count(*)::int AS c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }
     expect(restoreRevs.c).toBeGreaterThanOrEqual(2) // the reverts wrote source=restore forward revisions
+  })
+
+  test('(b2) retention guard: PIT_RESET + meta revision retention enabled → 409 RESET_RETENTION_CONFLICT, ZERO writes', async () => {
+    process.env.MULTITABLE_META_REVISION_RETENTION_ENABLED = '1'
+    const pv = await resetPreview()
+    expect(pv.status).toBe(409)
+    expect(pv.body?.error?.code).toBe('RESET_RETENTION_CONFLICT')
+    const ex = await resetExecute({ asOf: T1, previewIdentity: 'x', confirm: 'reset' })
+    expect(ex.status).toBe(409)
+    expect(ex.body?.error?.code).toBe('RESET_RETENTION_CONFLICT')
+    for (const id of [A, B]) {
+      const r = await recordRow(id)
+      expect(r?.data?.[NAME]).toBe('new')
+      expect(r?.version).toBe(2)
+    }
+    expect(await recordRow(D)).toBeTruthy()
+    expect(await inTrash(D)).toBe(false)
+    const restoreRevs = (await q(`SELECT count(*)::int AS c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }
+    expect(restoreRevs.c).toBe(0)
   })
 
   test('(c) PIT-2 all-or-nothing: a LOCKED post-T-created target → 409 RESET_BLOCKED, ZERO writes', async () => {


### PR DESCRIPTION
## Summary
- add a backend fail-closed guard for PIT Reset when meta-revision retention is enabled (`RESET_RETENTION_CONFLICT`, zero writes)
- replace the normal Reset T-source with a Global History batch selector, keeping manual datetime as an Advanced fallback
- wire destructive/sensitive T9-W config restore previews in the Config History modal (`uncreate`, `undelete`, `revert-permission`) with typed confirms and explicit execute confirm forwarding
- add `docs/development/multitable-global-history-final-code-dev-verification-20260707.md` as the dated design + verification record

## Verification
- `apps/web`: `vitest run tests/multitable-reset-tsource-picker.spec.ts tests/multitable-config-history-modal.spec.ts --watch=false --reporter=dot` -> 29 passed
- `apps/web`: `vue-tsc -b` -> passed
- `packages/core-backend`: `tsc -p packages/core-backend/tsconfig.json --noEmit` -> passed
- fresh DB scoped backend: 31 Global History / restore real-DB files -> 303 passed
- scoped frontend: 13 Global History / restore specs -> 104 passed

## Boundaries
- no staging/prod flag was enabled
- single-record delete-revision restore remains intentionally unsupported; PIT undelete and trash restore are the honest supported recovery paths
- already-destroyed field values/link edges cannot be recovered retroactively without prior tombstone capture
