### PR TITLE
feat(web): IU-6 integration embedded help — empty-state guidance + field hints + help center (design-lock #3739)

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -10,9 +10,10 @@
 #      covering read-source config/probe/resolver/composition/write-target;
 #   2. the integration web specs that carry the values-free / mirror-parity guarantees: the two vocab
 #      mirror tripwires, the read-source config / composition run / composition authoring panels, the
-#      composition service layer, the IU-1 error-code label module + its mirror tripwire, and the two
+#      composition service layer, the IU-1 error-code label module + its mirror tripwire, the two
 #      dead-letter display views (Workbench + K3 WISE setup) that carry the IU-1 RATIFIED
-#      errorMessage-never-renders-raw addendum.
+#      errorMessage-never-renders-raw addendum, the IU-6b field-hint module, and the IU-6c help-center
+#      view (whose error-code table is a single-source tripwire on the IU-1 label module).
 # Expand the spec list as more integration web specs are added.
 name: Integration Guard
 
@@ -23,20 +24,24 @@ on:
       - 'apps/web/src/services/integration/readSourceConfigs.ts'
       - 'apps/web/src/services/integration/readSourceCompositions.ts'
       - 'apps/web/src/services/integration/errorCodeLabels.ts'
+      - 'apps/web/src/services/integration/fieldHints.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
+      - 'apps/web/src/views/IntegrationHelpView.vue'
       - 'apps/web/tests/composition-vocab-mirror.spec.ts'
       - 'apps/web/tests/multitable-resolver-vocab-mirror.spec.ts'
       - 'apps/web/tests/integrationErrorCodeLabels.spec.ts'
+      - 'apps/web/tests/fieldHints.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
+      - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - '.github/workflows/integration-guard.yml'
   push:
     branches: [main]
@@ -45,20 +50,24 @@ on:
       - 'apps/web/src/services/integration/readSourceConfigs.ts'
       - 'apps/web/src/services/integration/readSourceCompositions.ts'
       - 'apps/web/src/services/integration/errorCodeLabels.ts'
+      - 'apps/web/src/services/integration/fieldHints.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
+      - 'apps/web/src/views/IntegrationHelpView.vue'
       - 'apps/web/tests/composition-vocab-mirror.spec.ts'
       - 'apps/web/tests/multitable-resolver-vocab-mirror.spec.ts'
       - 'apps/web/tests/integrationErrorCodeLabels.spec.ts'
+      - 'apps/web/tests/fieldHints.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
+      - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - '.github/workflows/integration-guard.yml'
 
 jobs:
@@ -104,4 +113,4 @@ jobs:
         run: pnpm --filter plugin-integration-core test
 
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationK3WiseSetupView --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot

--- a/apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
@@ -11,7 +11,9 @@
         <h3>新建组合</h3>
 
         <label class="integration-read-source-composition-authoring__field">
-          <span>第一跳读取源(已审批 resolver_lookup)</span>
+          <el-tooltip :content="fieldHint('composition.step1ConfigId')" placement="top" data-testid="rscauth-hint-step1">
+            <span>第一跳读取源(已审批 resolver_lookup)</span>
+          </el-tooltip>
           <select v-model="draft.step1ConfigId" data-testid="rscauth-step1">
             <option value="">请选择第一跳读取源…</option>
             <option v-for="row in resolverConfigs" :key="row.id" :value="row.id">
@@ -21,7 +23,9 @@
         </label>
 
         <label class="integration-read-source-composition-authoring__field">
-          <span>第二跳读取源(已审批 resolver_lookup)</span>
+          <el-tooltip :content="fieldHint('composition.step2ConfigId')" placement="top" data-testid="rscauth-hint-step2">
+            <span>第二跳读取源(已审批 resolver_lookup)</span>
+          </el-tooltip>
           <select v-model="draft.step2ConfigId" data-testid="rscauth-step2">
             <option value="">请选择第二跳读取源…</option>
             <option v-for="row in resolverConfigs" :key="row.id" :value="row.id">
@@ -31,12 +35,16 @@
         </label>
 
         <label class="integration-read-source-composition-authoring__field">
-          <span>name(组合标识符)</span>
+          <el-tooltip :content="fieldHint('composition.name')" placement="top" data-testid="rscauth-hint-name">
+            <span>name(组合标识符)</span>
+          </el-tooltip>
           <input v-model="draft.name" data-testid="rscauth-name" placeholder="material_to_bom_v1" />
         </label>
 
         <label class="integration-read-source-composition-authoring__field">
-          <span>sourceTarget(第一跳输出字段名,交接给第二跳作为 key)</span>
+          <el-tooltip :content="fieldHint('composition.sourceTarget')" placement="top" data-testid="rscauth-hint-source-target">
+            <span>sourceTarget(第一跳输出字段名,交接给第二跳作为 key)</span>
+          </el-tooltip>
           <input v-model="draft.sourceTarget" data-testid="rscauth-source-target" placeholder="internal_id" />
         </label>
 
@@ -66,9 +74,20 @@
         </div>
 
         <p v-if="pickerError" class="integration-read-source-composition-authoring__error" data-testid="rscauth-picker-error">{{ pickerError }}</p>
-        <p v-if="!pickerLoading && resolverConfigs.length === 0" class="integration-read-source-composition-authoring__empty" data-testid="rscauth-empty">
-          暂无已审批的 resolver_lookup 读取源,请先在上方"读取源配置"面板配置并审批两个读取源。
-        </p>
+        <div
+          v-if="!pickerLoading && resolverConfigs.length === 0"
+          class="integration-read-source-composition-authoring__empty integration-read-source-composition-authoring__empty--guided"
+          data-testid="rscauth-empty"
+        >
+          <strong data-testid="rscauth-empty-what">{{ bi(
+            '这里把两个已审批的"解析定位"读取源组装成一条两跳链，用于从一个业务键派生到另一个关联记录。',
+            'This assembles two APPROVED resolver-lookup read sources into a two-hop chain, deriving one linked record from a business key.',
+          ) }}</strong>
+          <p data-testid="rscauth-empty-first-step">{{ bi(
+            '第一步：请先在上方"读取源配置"面板配置并审批两个 resolver_lookup 读取源，审批后即可在这里选用。',
+            'First step: configure and approve two resolver_lookup read sources in the "read-source config" panel above — once approved, they become selectable here.',
+          ) }}</p>
+        </div>
 
         <p v-if="actionError" class="integration-read-source-composition-authoring__error" data-testid="rscauth-error">{{ actionError }}</p>
 
@@ -135,6 +154,8 @@
 // server's requireAccess('read') vs requireAccess('write') split in read-source-compositions HTTP routes.
 import { computed, reactive, ref, watch } from 'vue'
 import { useAuth } from '../../composables/useAuth'
+import { useLocale } from '../../composables/useLocale'
+import { integrationFieldHint, type IntegrationFieldHintKey } from '../../services/integration/fieldHints'
 import type { IntegrationScope } from '../../services/integration/workbench'
 import { listReadSourceConfigs, ReadSourceApiError, type ReadSourceConfigRow } from '../../services/integration/readSourceConfigs'
 import {
@@ -156,6 +177,18 @@ const props = defineProps<{
 }>()
 
 const auth = useAuth()
+const { locale } = useLocale()
+
+// IU-6b: field-level hint copy (values-free, zh+en) for the composition step-wiring fields —
+// exact-key lookup against the dedicated fieldHints module (shared with the read-source config panel).
+function fieldHint(key: IntegrationFieldHintKey): string {
+  return integrationFieldHint(key, locale.value)
+}
+
+// IU-6a: bilingual guidance copy helper — same locale pattern as `fieldHint` above.
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
 // Same permission the server requires for save/approve/retire (requireAccess(req, 'write') in
 // readSourceCompositionsSave/Approve/Retire) and the same string the workbench's other apply-tier
 // actions gate on (dry-run=read · apply=write/admin badge).
@@ -394,6 +427,18 @@ void refreshPickers()
 .integration-read-source-composition-authoring__empty {
   color: #888;
   font-size: 13px;
+}
+/* IU-6a guided empty state: "what this is" + "first step" — new styling only, tokens per UF-1. */
+.integration-read-source-composition-authoring__empty--guided {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+}
+.integration-read-source-composition-authoring__empty--guided strong {
+  color: var(--ms-text-1);
+}
+.integration-read-source-composition-authoring__empty--guided p {
+  margin: 0;
 }
 .integration-read-source-composition-authoring__saved {
   border: 1px solid #e0e0e0;

--- a/apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue
@@ -42,9 +42,20 @@
 
         <p v-if="listError" class="integration-read-source-composition__error" data-testid="rscomp-list-error">{{ listError }}</p>
         <p v-if="runError" class="integration-read-source-composition__error" data-testid="rscomp-error">{{ runError }}</p>
-        <p v-if="!loading && compositions.length === 0" class="integration-read-source-composition__empty" data-testid="rscomp-empty">
-          暂无已审批组合。
-        </p>
+        <div
+          v-if="!loading && compositions.length === 0"
+          class="integration-read-source-composition__empty integration-read-source-composition__empty--guided"
+          data-testid="rscomp-empty"
+        >
+          <strong data-testid="rscomp-empty-what">{{ bi(
+            '这里运行已审批的两跳读取源组合（例如从一个业务键派生到另一个关联记录）。',
+            'This runs an APPROVED two-hop read-source composition (e.g. deriving one linked record from a business key).',
+          ) }}</strong>
+          <p data-testid="rscomp-empty-first-step">{{ bi(
+            '第一步：请先在上方"读取源组合配置"面板保存并审批一条组合，审批后会出现在这里的下拉列表中。',
+            'First step: save and approve a composition in the "composition config" panel above — once approved, it will appear in the dropdown here.',
+          ) }}</p>
+        </div>
       </div>
 
       <div v-if="result" class="integration-read-source-composition__evidence" data-testid="rscomp-result">
@@ -122,6 +133,12 @@ function stepErrorLabel(errorCode: string | undefined): string | null {
   return integrationErrorCodeDisplayLabel(errorCode, locale.value)
 }
 
+// IU-6a: bilingual guidance copy helper — same locale pattern as the IU-1 error labels above (reads
+// `locale.value` synchronously; safe to call directly from the template without a dedicated computed).
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
 watch(selectedId, () => {
   result.value = null
   runError.value = ''
@@ -196,6 +213,18 @@ void refresh()
 .integration-read-source-composition__empty {
   color: #888;
   font-size: 13px;
+}
+/* IU-6a guided empty state: "what this is" + "first step" — new styling only, tokens per UF-1. */
+.integration-read-source-composition__empty--guided {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+}
+.integration-read-source-composition__empty--guided strong {
+  color: var(--ms-text-1);
+}
+.integration-read-source-composition__empty--guided p {
+  margin: 0;
 }
 .integration-read-source-composition__evidence {
   border: 1px solid #e0e0e0;

--- a/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
@@ -20,7 +20,9 @@
         </label>
 
         <label class="integration-read-source__field">
-          <span>requiredKind(随所选系统)</span>
+          <el-tooltip :content="fieldHint('readSource.requiredKind')" placement="top" data-testid="rsc-hint-required-kind">
+            <span>requiredKind(随所选系统)</span>
+          </el-tooltip>
           <input :value="draft.requiredKind" data-testid="rsc-required-kind" readonly placeholder="选择系统后自动填充" />
         </label>
 
@@ -30,14 +32,18 @@
         </label>
 
         <label class="integration-read-source__field">
-          <span>mode(四种已验证读取模式)</span>
+          <el-tooltip :content="fieldHint('readSource.mode')" placement="top" data-testid="rsc-hint-mode">
+            <span>mode(四种已验证读取模式)</span>
+          </el-tooltip>
           <select v-model="draft.mode" data-testid="rsc-mode">
             <option v-for="mode in READ_SOURCE_MODES" :key="mode" :value="mode">{{ mode }}</option>
           </select>
         </label>
 
         <label class="integration-read-source__field">
-          <span>readPath(仅相对路径;绝对 URL、%、\、.. 会被拒绝)</span>
+          <el-tooltip :content="fieldHint('readSource.readPath')" placement="top" data-testid="rsc-hint-read-path">
+            <span>readPath(仅相对路径;绝对 URL、%、\、.. 会被拒绝)</span>
+          </el-tooltip>
           <input v-model="draft.readPath" data-testid="rsc-read-path" placeholder="/K3API/Material/GetDetail" />
         </label>
 
@@ -60,11 +66,15 @@
 
         <template v-if="showKeyField">
           <label class="integration-read-source__field">
-            <span>keyField{{ keyFieldRequired ? '(必填)' : '(可选)' }}</span>
+            <el-tooltip :content="fieldHint('readSource.keyField')" placement="top" data-testid="rsc-hint-key-field">
+              <span>keyField{{ keyFieldRequired ? '(必填)' : '(可选)' }}</span>
+            </el-tooltip>
             <input v-model="draft.keyField" data-testid="rsc-key-field" placeholder="FNumber" />
           </label>
           <label class="integration-read-source__field">
-            <span>keyEncoding(可选)</span>
+            <el-tooltip :content="fieldHint('readSource.keyEncoding')" placement="top" data-testid="rsc-hint-key-encoding">
+              <span>keyEncoding(可选)</span>
+            </el-tooltip>
             <select v-model="draft.keyEncoding" data-testid="rsc-key-encoding">
               <option value="">(不指定)</option>
               <option v-for="encoding in READ_SOURCE_KEY_ENCODINGS" :key="encoding" :value="encoding">{{ encoding }}</option>
@@ -74,7 +84,9 @@
 
         <template v-if="draft.mode === 'resolver_lookup'">
           <label class="integration-read-source__field">
-            <span>resolverRule(必填)</span>
+            <el-tooltip :content="fieldHint('readSource.resolverRule')" placement="top" data-testid="rsc-hint-resolver-rule">
+              <span>resolverRule(必填)</span>
+            </el-tooltip>
             <select v-model="draft.resolverRule" data-testid="rsc-resolver-rule">
               <option value="">选择解析规则…</option>
               <option value="exactly_one">exactly_one(唯一命中)</option>
@@ -84,11 +96,15 @@
           </label>
           <!-- first_when_sorted: sort field + direction. exactly_one shows none of these three. -->
           <label v-if="draft.resolverRule === 'first_when_sorted'" class="integration-read-source__field">
-            <span>multiplicityRuleField(排序字段,必填)</span>
+            <el-tooltip :content="fieldHint('readSource.resolverSortField')" placement="top" data-testid="rsc-hint-resolver-sort-field">
+              <span>multiplicityRuleField(排序字段,必填)</span>
+            </el-tooltip>
             <input v-model="draft.multiplicityRuleField" data-testid="rsc-resolver-sort-field" placeholder="FVersion" />
           </label>
           <label v-if="draft.resolverRule === 'first_when_sorted'" class="integration-read-source__field">
-            <span>resolverSortDirection(必填)</span>
+            <el-tooltip :content="fieldHint('readSource.resolverSortDirection')" placement="top" data-testid="rsc-hint-resolver-sort-direction">
+              <span>resolverSortDirection(必填)</span>
+            </el-tooltip>
             <select v-model="draft.resolverSortDirection" data-testid="rsc-resolver-sort-direction">
               <option value="">选择方向…</option>
               <option value="asc">asc(升序取首)</option>
@@ -97,34 +113,46 @@
           </label>
           <!-- field_equals: discriminator field + bounded token value. -->
           <label v-if="draft.resolverRule === 'field_equals'" class="integration-read-source__field">
-            <span>multiplicityRuleField(判别字段,必填)</span>
+            <el-tooltip :content="fieldHint('readSource.resolverDiscriminatorField')" placement="top" data-testid="rsc-hint-resolver-discriminator-field">
+              <span>multiplicityRuleField(判别字段,必填)</span>
+            </el-tooltip>
             <input v-model="draft.multiplicityRuleField" data-testid="rsc-resolver-discriminator-field" placeholder="FIsCurrent" />
           </label>
           <label v-if="draft.resolverRule === 'field_equals'" class="integration-read-source__field">
-            <span>resolverDiscriminatorValue(有界枚举样 token,必填)</span>
+            <el-tooltip :content="fieldHint('readSource.resolverDiscriminatorValue')" placement="top" data-testid="rsc-hint-resolver-discriminator-value">
+              <span>resolverDiscriminatorValue(有界枚举样 token,必填)</span>
+            </el-tooltip>
             <input v-model="draft.resolverDiscriminatorValue" data-testid="rsc-resolver-discriminator-value" placeholder="Y" />
           </label>
         </template>
 
         <label v-if="draft.mode !== 'detail_with_lines'" class="integration-read-source__field">
-          <span>containerPaths(逗号/换行分隔的点号路径,必填)</span>
+          <el-tooltip :content="fieldHint('readSource.containerPaths')" placement="top" data-testid="rsc-hint-container-paths">
+            <span>containerPaths(逗号/换行分隔的点号路径,必填)</span>
+          </el-tooltip>
           <input v-model="draft.containerPaths" data-testid="rsc-container-paths" placeholder="Data.Data, Data.DATA" />
         </label>
 
         <template v-if="draft.mode === 'detail_with_lines'">
           <label class="integration-read-source__field">
-            <span>headerContainerPaths(必填)</span>
+            <el-tooltip :content="fieldHint('readSource.headerContainerPaths')" placement="top" data-testid="rsc-hint-header-container-paths">
+              <span>headerContainerPaths(必填)</span>
+            </el-tooltip>
             <input v-model="draft.headerContainerPaths" data-testid="rsc-header-container-paths" placeholder="Data.Page1" />
           </label>
           <label class="integration-read-source__field">
-            <span>lineContainerPaths(必填)</span>
+            <el-tooltip :content="fieldHint('readSource.lineContainerPaths')" placement="top" data-testid="rsc-hint-line-container-paths">
+              <span>lineContainerPaths(必填)</span>
+            </el-tooltip>
             <input v-model="draft.lineContainerPaths" data-testid="rsc-line-container-paths" placeholder="Data.Page2" />
           </label>
         </template>
 
         <div class="integration-read-source__field-map">
           <div class="integration-read-source__field-map-head">
-            <span>fieldMap(数据面字段映射,可选;source=响应字段路径,target=清洗列)</span>
+            <el-tooltip :content="fieldHint('readSource.fieldMap')" placement="top" data-testid="rsc-hint-field-map">
+              <span>fieldMap(数据面字段映射,可选;source=响应字段路径,target=清洗列)</span>
+            </el-tooltip>
             <button type="button" class="integration-workbench__button" data-testid="rsc-field-map-add" @click="addFieldMapRow">
               添加映射行
             </button>
@@ -150,7 +178,9 @@
         <div class="integration-read-source__probe-controls">
           <label class="integration-read-source__inline">
             <input v-model="boundedSmoke" type="checkbox" data-testid="rsc-bounded-smoke" />
-            <span>bounded smoke(受平台上限约束的试读计数)</span>
+            <el-tooltip :content="fieldHint('readSource.boundedSmoke')" placement="top" data-testid="rsc-hint-bounded-smoke">
+              <span>bounded smoke(受平台上限约束的试读计数)</span>
+            </el-tooltip>
           </label>
           <label v-if="probeNeedsKey" class="integration-read-source__inline">
             <span>探测 key(业务键值,仅用于本次探测,不会保存)</span>
@@ -224,9 +254,20 @@
           </button>
         </div>
         <p v-if="listError" class="integration-read-source__error" data-testid="rsc-list-error">{{ listError }}</p>
-        <p v-if="!loading && configs.length === 0" class="integration-read-source__empty" data-testid="rsc-empty">
-          暂无读取源配置。
-        </p>
+        <div
+          v-if="!loading && configs.length === 0"
+          class="integration-read-source__empty integration-read-source__empty--guided"
+          data-testid="rsc-empty"
+        >
+          <strong data-testid="rsc-empty-what">{{ bi(
+            '这里展示已保存的读取源版本（草稿 / 已审批 / 已停用）。',
+            'This list shows saved read-source versions (draft / approved / retired).',
+          ) }}</strong>
+          <p data-testid="rsc-empty-first-step">{{ bi(
+            '第一步：在左侧表单选系统、填必填字段并「定位容器探测」，通过后「保存版本」即可出现在此列表。',
+            'First step: pick a system on the left, fill in the required fields, run "locate container probe", then "save version" — it will then appear in this list.',
+          ) }}</p>
+        </div>
         <table v-if="configs.length > 0" class="integration-read-source__table">
           <thead>
             <tr>
@@ -294,6 +335,7 @@
 import { computed, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../../services/integration/errorCodeLabels'
+import { integrationFieldHint, type IntegrationFieldHintKey } from '../../services/integration/fieldHints'
 import type { IntegrationScope, WorkbenchExternalSystem } from '../../services/integration/workbench'
 import {
   READ_SOURCE_KEY_ENCODINGS,
@@ -355,6 +397,19 @@ const probeEvidenceErrorLabel = computed(() =>
 const probeEvidenceErrorHint = computed(() =>
   integrationErrorCodeHint(probeEvidence.value?.errorCode, locale.value),
 )
+// IU-6b: field-level hint copy (values-free, zh+en) for the highest-confusion fields. Exact-key
+// lookup against the dedicated fieldHints module — no copy lives in this component.
+function fieldHint(key: IntegrationFieldHintKey): string {
+  return integrationFieldHint(key, locale.value)
+}
+
+// IU-6a: bilingual guidance copy helper — same locale pattern as `fieldHint`/the IU-1 error labels
+// (reads `locale.value` synchronously; Vue's render tracking makes template calls to this reactive
+// without needing a dedicated `computed` per string).
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
 const showKeyField = computed(() => draft.mode !== 'list_page')
 const keyFieldRequired = computed(() => draft.mode === 'single_record' || draft.mode === 'resolver_lookup')
 // The S2-b runtime requires inputs.key exactly when the config declares a keyField.
@@ -583,6 +638,18 @@ void refresh()
 .integration-read-source__empty {
   color: #888;
   font-size: 13px;
+}
+/* IU-6a guided empty state: "what this is" + "first step" — new styling only, tokens per UF-1. */
+.integration-read-source__empty--guided {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+}
+.integration-read-source__empty--guided strong {
+  color: var(--ms-text-1);
+}
+.integration-read-source__empty--guided p {
+  margin: 0;
 }
 .integration-read-source__audit {
   margin: 4px 0;

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -229,6 +229,18 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Data Factory', titleZh: '数据工厂', requiresAuth: true, permissions: ['integration:write'] }
   },
   {
+    // IU-6c (design-lock docs/development/integration-ux-workbench-redesign-design-lock-20260706.md,
+    // #3739): read-only help center for the Data Factory / integration surface. No write path, no
+    // integration:write gate — mirrors the /data-sources info-page pattern (requiresAuth only) rather
+    // than the workbench's write-tier gate, since the content here (when-to-use guidance, error-code
+    // reference, FAQ) is useful to any authenticated user who hits an error, including someone without
+    // integration:write who is just trying to understand a failure.
+    path: '/help/integration',
+    name: 'integration-help',
+    component: () => import('../views/IntegrationHelpView.vue'),
+    meta: { title: 'Integration Help', titleZh: '集成帮助中心', requiresAuth: true },
+  },
+  {
     path: '/integrations/k3-wise',
     name: AppRouteNames.INTEGRATION_K3_WISE,
     component: () => import('../views/IntegrationK3WiseSetupView.vue'),

--- a/apps/web/src/services/integration/errorCodeLabels.ts
+++ b/apps/web/src/services/integration/errorCodeLabels.ts
@@ -112,7 +112,9 @@ export type IntegrationErrorCode =
   // Dead-letter known mainline (10) — see DEAD_LETTER_MAINLINE_ERROR_CODES above
   | (typeof DEAD_LETTER_MAINLINE_ERROR_CODES)[number]
 
-const INTEGRATION_ERROR_CODE_LABELS: Record<IntegrationErrorCode, IntegrationErrorLabel> = {
+// Exported (IU-6c, design-lock §2 IU-6c): the help-center error-code table renders straight off this
+// map so a future label addition/removal shows up there automatically — SINGLE SOURCE, no copy-paste.
+export const INTEGRATION_ERROR_CODE_LABELS: Record<IntegrationErrorCode, IntegrationErrorLabel> = {
   // --- Resolver (9) ---
   READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND: {
     zh: '未找到用于解析的数据容器',
@@ -378,4 +380,20 @@ export function integrationErrorCodeHint(
   const label = integrationErrorCodeLabel(code, locale)
   if (!label?.hint) return null
   return locale === 'zh-CN' ? label.hint.zh : label.hint.en
+}
+
+export type IntegrationErrorCodeEntry = { code: IntegrationErrorCode } & IntegrationErrorLabel
+
+/**
+ * All registered codes as a flat, display-ready array — the single-source feed for the IU-6c help
+ * center's error-code table. Iterates `INTEGRATION_ERROR_CODE_LABELS`'s own keys ONLY (no server call,
+ * no duplication of the label text), so any future addition/removal to that map is reflected here with
+ * zero further edits. Order matches declaration order in the map (grouped by family, per the module
+ * header's family list).
+ */
+export function integrationErrorCodeEntries(): IntegrationErrorCodeEntry[] {
+  return (Object.keys(INTEGRATION_ERROR_CODE_LABELS) as IntegrationErrorCode[]).map((code) => ({
+    code,
+    ...INTEGRATION_ERROR_CODE_LABELS[code],
+  }))
 }

--- a/apps/web/src/services/integration/fieldHints.ts
+++ b/apps/web/src/services/integration/fieldHints.ts
@@ -1,0 +1,141 @@
+// Integration field-level hints (IU-6b, design-lock
+// docs/development/integration-ux-workbench-redesign-design-lock-20260706.md, #3739).
+//
+// Scope: a values-free, exact-key lookup from a field-hint KEY (one per highest-confusion field in
+// the read-source config panel and the read-source composition authoring panel) to a one-sentence
+// {zh, en} tooltip copy. Same shape/discipline as ../errorCodeLabels.ts:
+//   - EXACT-KEY ONLY lookup (plain object own-key access, typed key union — no runtime string keys
+//     from outside this module's own call sites reach the lookup).
+//   - values-free: no real business values (material numbers, BOM numbers, etc.) ever appear in the
+//     copy — only descriptive placeholders/field-name examples that are themselves not business data
+//     (e.g. a field NAME like "the sort field" is fine; a business VALUE like an actual material
+//     number is not, and none appear here).
+//   - one sentence per entry, zh + en, non-empty.
+//
+// Consumed by:
+//   - IntegrationReadSourceConfigPanel.vue (readSource.* keys) via el-tooltip on the highest-confusion
+//     field labels.
+//   - IntegrationReadSourceCompositionAuthoringPanel.vue (composition.* keys) via el-tooltip on the
+//     two-hop step-wiring fields.
+//   - IntegrationHelpView.vue does NOT consume this module directly (its scope is the error-code
+//     table + FAQ, not field hints) — kept separate so IU-2's restructure can re-consume this module
+//     without pulling in help-center-specific content.
+//
+// This module is a pure data + lookup layer: no Vue imports, no DOM, so it stays trivially reusable
+// by IU-2's restructured panels without carrying any component dependency.
+
+import type { AppLocale } from '../../composables/useLocale'
+
+export type IntegrationFieldHintKey =
+  // --- read-source config panel ---
+  | 'readSource.requiredKind'
+  | 'readSource.mode'
+  | 'readSource.readPath'
+  | 'readSource.keyField'
+  | 'readSource.keyEncoding'
+  | 'readSource.resolverRule'
+  | 'readSource.resolverSortField'
+  | 'readSource.resolverSortDirection'
+  | 'readSource.resolverDiscriminatorField'
+  | 'readSource.resolverDiscriminatorValue'
+  | 'readSource.containerPaths'
+  | 'readSource.headerContainerPaths'
+  | 'readSource.lineContainerPaths'
+  | 'readSource.fieldMap'
+  | 'readSource.boundedSmoke'
+  // --- read-source composition authoring panel ---
+  | 'composition.step1ConfigId'
+  | 'composition.step2ConfigId'
+  | 'composition.name'
+  | 'composition.sourceTarget'
+
+export type IntegrationFieldHintEntry = { zh: string; en: string }
+
+export const INTEGRATION_FIELD_HINTS: Record<IntegrationFieldHintKey, IntegrationFieldHintEntry> = {
+  'readSource.requiredKind': {
+    zh: '由所选外部系统自动带出，决定该读取源允许消费的系统类型；此处只读，不能手填。',
+    en: 'Auto-filled from the selected external system; determines which system kind this read source may consume, and is read-only here.',
+  },
+  'readSource.mode': {
+    zh: '四种读取模式各自对应不同的返回形状：单条记录、列表分页、主从明细、或按规则解析定位单条记录。',
+    en: 'Each of the four read modes expects a different response shape: a single record, a paged list, a header-with-lines detail, or a rule-resolved single record.',
+  },
+  'readSource.readPath': {
+    zh: '只能是相对路径，不允许绝对地址、百分号编码或路径穿越片段；平台会拼接到已配置的连接基址上。',
+    en: 'Must be a relative path only — absolute URLs, percent-encoding, and path-traversal segments are rejected; the platform appends it to the already-configured connection base.',
+  },
+  'readSource.keyField': {
+    zh: '用于按业务键定位单条记录的字段名；仅在单条记录或解析类模式下需要，不是记录的值本身。',
+    en: 'The field name used to locate a single record by its business key; needed only for single-record or resolver modes — it names the field, not a record value.',
+  },
+  'readSource.keyEncoding': {
+    zh: '可选：声明业务键在发往目标系统前需要的编码方式；不指定则按原样传递。',
+    en: 'Optional: declares how the business key must be encoded before being sent to the target system; unspecified means it is passed through as-is.',
+  },
+  'readSource.resolverRule': {
+    zh: '候选记录多于一条时的取舍策略：唯一命中要求恰好一条、排序取首按字段排序后取第一条、判别字段相等按固定值筛选。',
+    en: 'The tie-break strategy when more than one candidate record matches: exactly-one requires a single hit, sorted-first picks the first row after sorting by a field, and field-equals filters by a fixed discriminator value.',
+  },
+  'readSource.resolverSortField': {
+    zh: '排序取首规则使用的排序字段名；决定多条候选记录中哪一条排在最前。',
+    en: 'The field name the sorted-first rule sorts by; determines which of several candidate records is treated as first.',
+  },
+  'readSource.resolverSortDirection': {
+    zh: '排序方向：升序取最小值那条，降序取最大值那条。',
+    en: 'Sort direction: ascending picks the smallest-value row, descending picks the largest-value row.',
+  },
+  'readSource.resolverDiscriminatorField': {
+    zh: '判别字段相等规则用来比较的字段名，例如标记"当前有效版本"的字段。',
+    en: 'The field name the field-equals rule compares, such as a field that flags the currently-effective version.',
+  },
+  'readSource.resolverDiscriminatorValue': {
+    zh: '判别字段需要等于的固定值；一个有界的枚举样 token，不是任意自由文本。',
+    en: 'The fixed value the discriminator field must equal; a bounded enum-shaped token, not free-form text.',
+  },
+  'readSource.containerPaths': {
+    zh: '响应体中数据数组所在的点号路径，可填多个候选路径，命中第一个存在的即可。',
+    en: 'The dot-notation path to the data array inside the response body; multiple candidate paths may be listed, and the first one that exists is used.',
+  },
+  'readSource.headerContainerPaths': {
+    zh: '主从明细模式下，表头（主记录）所在的容器路径。',
+    en: 'In header-with-lines mode, the container path where the header (parent record) lives.',
+  },
+  'readSource.lineContainerPaths': {
+    zh: '主从明细模式下，明细行数组所在的容器路径。',
+    en: 'In header-with-lines mode, the container path where the line-item array lives.',
+  },
+  'readSource.fieldMap': {
+    zh: '把响应字段路径映射到清洗后的列名；只保存字段名对应关系，不经过这里读取或展示任何行值。',
+    en: 'Maps a response field path to a cleansed column name; only the field-name mapping is stored here — no row value ever passes through this control.',
+  },
+  'readSource.boundedSmoke': {
+    zh: '勾选后探测会额外拉取受平台上限约束的少量样本行，用于验证形状；不勾选只验证容器是否存在。',
+    en: 'When checked, the probe also fetches a small, platform-capped sample of rows to verify shape; unchecked, it only verifies that the container exists.',
+  },
+  'composition.step1ConfigId': {
+    zh: '两跳组合的第一跳：必须是已审批的"解析定位"类读取源，其输出将交给第二跳作为业务键。',
+    en: 'The first hop of the two-hop composition: must be an approved resolver-lookup read source whose output is handed to the second hop as its business key.',
+  },
+  'composition.step2ConfigId': {
+    zh: '两跳组合的第二跳：同样必须是已审批的"解析定位"类读取源，接收第一跳的输出值。',
+    en: 'The second hop of the two-hop composition: also must be an approved resolver-lookup read source, and it receives the first hop\'s output value.',
+  },
+  'composition.name': {
+    zh: '组合的可读标识符，仅用于在列表中区分不同组合，不影响运行逻辑。',
+    en: 'A human-readable identifier for the composition, used only to tell compositions apart in lists — it does not affect run behavior.',
+  },
+  'composition.sourceTarget': {
+    zh: '第一跳输出字段名，将作为第二跳读取源的业务键输入；两跳之间的交接完全由平台完成，不经过浏览器。',
+    en: "The first hop's output field name, used as the business-key input to the second hop's read source; the handoff between hops happens entirely on the platform, never through the browser.",
+  },
+}
+
+/**
+ * Exact-key lookup (typed key union, own-key access). Every `IntegrationFieldHintKey` is guaranteed
+ * present in `INTEGRATION_FIELD_HINTS` at compile time, so this never needs an "unknown key" fallback
+ * the way `integrationErrorCodeLabel` does for server-sourced codes.
+ */
+export function integrationFieldHint(key: IntegrationFieldHintKey, locale: AppLocale): string {
+  const entry = INTEGRATION_FIELD_HINTS[key]
+  return locale === 'zh-CN' ? entry.zh : entry.en
+}

--- a/apps/web/src/views/IntegrationHelpView.vue
+++ b/apps/web/src/views/IntegrationHelpView.vue
@@ -1,0 +1,228 @@
+<template>
+  <PageShell width="default">
+    <PageHeader
+      :title="bi('集成帮助中心', 'Integration Help Center')"
+      :subtitle="bi('数据工厂 / 读取源 / 组合链的使用说明与排障参考', 'Usage guidance and troubleshooting reference for Data Factory read sources and compositions')"
+      back-to="/integrations/workbench"
+      :back-label="bi('返回数据工厂', 'Back to Data Factory')"
+    />
+
+    <el-card class="integration-help__section" shadow="never" data-testid="help-section-when-to-use">
+      <h2>{{ bi('何时用读取源 vs 组合', 'When to use a read source vs. a composition') }}</h2>
+      <p>
+        {{ bi(
+          '读取源（单跳）：一次调用就能直接取到你需要的记录或列表——例如按业务键取一条记录的详情。',
+          'Read source (single hop): one call gets you the record or list you need directly — e.g. fetching a single record\'s detail by its business key.',
+        ) }}
+      </p>
+      <p>
+        {{ bi(
+          '组合（两跳）：需要先用第一跳的输出作为第二跳的输入才能拿到最终数据——例如先按业务键定位到一个内部标识，再用这个内部标识取到关联记录。两跳之间的交接完全由平台完成，浏览器和使用者都不会看到中间值。',
+          'Composition (two hops): the first hop\'s output becomes the second hop\'s input before you get the final data — e.g. resolving a business key to an internal identifier, then using that identifier to fetch a linked record. The handoff between hops happens entirely on the platform; the browser and the end user never see the intermediate value.',
+        ) }}
+      </p>
+      <ul class="integration-help__compare-list" data-testid="help-when-to-use-compare">
+        <li>
+          <strong>{{ bi('选读取源，当…', 'Choose a read source when…') }}</strong>
+          {{ bi('目标数据一次调用就能取到，不需要先定位一个中间标识。', 'the target data can be fetched in one call, with no need to first resolve an intermediate identifier.') }}
+        </li>
+        <li>
+          <strong>{{ bi('选组合，当…', 'Choose a composition when…') }}</strong>
+          {{ bi('必须先定位一个中间标识，再用它取最终数据（两跳链）。', 'you must first resolve an intermediate identifier, then use it to fetch the final data (a two-hop chain).') }}
+        </li>
+      </ul>
+    </el-card>
+
+    <el-card class="integration-help__section" shadow="never" data-testid="help-section-error-codes">
+      <h2>{{ bi('错误码对照表', 'Error code reference') }}</h2>
+      <p>
+        {{ bi(
+          '机器码只用于排障；正常使用时页面只展示下表右侧的人话说明。本表由错误码标签模块自动生成——新增/调整标签会自动出现在这里，不需要手改本页。',
+          'The raw machine code is only for troubleshooting — normal usage only ever shows the human-readable text on the right. This table is generated automatically from the error-code label module — a future label addition/change appears here with no edits to this page.',
+        ) }}
+      </p>
+      <div class="integration-help__table-wrap">
+        <table class="integration-help__table" data-testid="help-error-code-table">
+          <thead>
+            <tr>
+              <th>{{ bi('机器码', 'Code') }}</th>
+              <th>{{ bi('说明', 'Meaning') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="entry in errorCodeEntries"
+              :key="entry.code"
+              :data-testid="`help-error-code-row-${entry.code}`"
+            >
+              <td><code>{{ entry.code }}</code></td>
+              <td>
+                <div>{{ bi(entry.zh, entry.en) }}</div>
+                <small v-if="entry.hint">{{ bi(entry.hint.zh, entry.hint.en) }}</small>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </el-card>
+
+    <el-card class="integration-help__section" shadow="never" data-testid="help-section-faq">
+      <h2>{{ bi('常见排障 FAQ', 'Common troubleshooting FAQ') }}</h2>
+      <details
+        v-for="(item, index) in faqItems"
+        :key="index"
+        class="integration-help__faq-item"
+        :data-testid="`help-faq-${index}`"
+      >
+        <summary :data-testid="`help-faq-question-${index}`">{{ bi(item.zhQ, item.enQ) }}</summary>
+        <p :data-testid="`help-faq-answer-${index}`">{{ bi(item.zhA, item.enA) }}</p>
+      </details>
+    </el-card>
+  </PageShell>
+</template>
+
+<script setup lang="ts">
+// IU-6c help center (design-lock docs/development/integration-ux-workbench-redesign-design-lock-20260706.md
+// #3739): a read-only reference page for the Data Factory / integration surface. Three sections:
+//   1. When to use a read source (single hop) vs. a composition (two hop) — values-free explanation.
+//   2. Error-code reference table — SINGLE SOURCE: iterates `integrationErrorCodeEntries()` from the
+//      IU-1 label module (errorCodeLabels.ts) rather than copying label text into this view, so a
+//      future label addition/removal is reflected here automatically (see integrationHelpView.spec.ts
+//      "single-source tripwire": rendered row count === the module's registered code count).
+//   3. Common troubleshooting FAQ — distilled from docs/development/integration-composition-entity-e2e-
+//      runbook-20260705.md and integration-core-external-api-read-self-service-entity-e2e-runbook-
+//      20260702.md (values-free; no real material/BOM numbers, only descriptive placeholders).
+// Zero behavior change elsewhere: this view has no service calls, no write path, no permission-gated
+// action — it only reads the (already-loaded) label module and renders static, values-free copy.
+import { computed } from 'vue'
+import { useLocale } from '../composables/useLocale'
+import { integrationErrorCodeEntries, type IntegrationErrorCodeEntry } from '../services/integration/errorCodeLabels'
+import PageShell from '../components/layout/PageShell.vue'
+import PageHeader from '../components/layout/PageHeader.vue'
+
+const { locale } = useLocale()
+
+// Same locale pattern as the rest of the integration surface (errorCodeLabels/fieldHints): reads
+// `locale.value` synchronously, safe to call directly from the template.
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+// Single-source (IU-6c hard requirement): NEVER hand-copy label text here — always iterate the
+// module's own registered entries so additions/removals need zero edits to this view.
+const errorCodeEntries = computed<IntegrationErrorCodeEntry[]>(() => integrationErrorCodeEntries())
+
+type FaqItem = { zhQ: string; enQ: string; zhA: string; enA: string }
+
+// Distilled from the composition entity e2e runbook (20260705) and the external-API read
+// self-service entity e2e runbook (20260702) — see module header. Values-free: no real material/BOM
+// numbers, only descriptive placeholders (field/code names, never business data).
+const faqItems: FaqItem[] = [
+  {
+    zhQ: '探测返回"未找到目标数据容器"（READ_SOURCE_PROBE_CONTAINER_NOT_FOUND / READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND）怎么办？',
+    zhA: '说明容器路径（containerPaths）与目标系统实际返回形状不匹配。先重新运行一次"定位容器探测"确认真实返回结构，再核对/修正 containerPaths；同一模式在不同环境上的真实形状也可能不同，不要凭猜测直接改。',
+    enQ: 'The probe returns "container not found" (READ_SOURCE_PROBE_CONTAINER_NOT_FOUND / READ_SOURCE_RESOLVER_CONTAINER_NOT_FOUND) — what should I do?',
+    enA: 'This means the configured container path does not match the target system\'s actual response shape. Re-run "locate container probe" to confirm the real structure, then check/fix containerPaths — the same mode can return a different shape per environment, so do not guess.',
+  },
+  {
+    zhQ: '一个物料存在多个 BOM，返回"存在多个 BOM"（K3_WISE_BOM_LIST_BY_MATERIAL_AMBIGUOUS / READ_SOURCE_RESOLVER_AMBIGUOUS）是 bug 吗？',
+    zhA: '不是。这是唯一性策略的正确行为——平台从不按状态 / 版本 / 日期自动选择候选记录，多条候选时会如实报告"存在歧义"，避免静默选错。需要收窄筛选条件，或改用能唯一区分候选记录的解析规则。',
+    enQ: 'A material has multiple BOMs and the system reports "ambiguous — multiple BOMs exist" — is this a bug?',
+    enA: 'No. This is the uniqueness policy working correctly — the platform never auto-picks a candidate by status / version / date; when more than one row matches, it reports ambiguity instead of silently guessing wrong. Narrow the filter, or use a resolver rule that can uniquely tell the candidates apart.',
+  },
+  {
+    zhQ: '凭证（credentials）在哪里配置？',
+    zhA: '凭证在后端注册，不在这个页面填写——读取源配置面板从不展示或保存凭证字段。若运行时报"凭证缺失"类错误，需要请管理员确认该外部系统已在部署环境上登记凭证。',
+    enQ: 'Where are credentials configured?',
+    enA: 'Credentials are registered on the backend — this page never shows or stores a credential field. If a run fails with a "credentials missing" error, ask an admin to confirm the external system has credentials registered on the deployed environment.',
+  },
+  {
+    zhQ: '保存版本时报 500，是我配置写错了吗？',
+    zhA: '大概率不是——先确认数据库迁移已执行到位，这是常见的部署缺口而不是配置错误；确认迁移已跑后再排查配置本身。',
+    enQ: 'Save-version returns a 500 error — did I misconfigure something?',
+    enA: 'Probably not — first confirm the required database migrations have been applied; a save-version 500 on an un-migrated database is a common deployment gap, not a config mistake. Check the configuration itself only after confirming migrations.',
+  },
+  {
+    zhQ: '组合运行报"该步骤尚未执行"（STEP_NOT_RUN）正常吗？',
+    zhA: '正常。这是两跳链路的 fail-closed 设计——任意一跳失败后，后续步骤一律标记为"未执行"，绝不会继续用错误的中间结果往下跑。',
+    enQ: 'Is it expected for a composition run to report "step not run" (STEP_NOT_RUN)?',
+    enA: 'Yes. This is the two-hop chain\'s fail-closed design — once one hop fails, every step after it is clamped to "not run" rather than continuing with a bad intermediate result.',
+  },
+  {
+    zhQ: '组合运行报通用的"该步骤执行失败"（STEP_FAILED），看不出具体原因怎么办？',
+    zhA: '这是一个粗粒度兜底码，可能是系统类型不匹配、凭证缺失或网络错误等多种原因之一。请对比该跳读取源配置的 requiredKind 与已注册外部系统的 kind 是否一致，确认凭证已在该环境注册，也可单独重跑该跳自身的读取来定位问题。',
+    enQ: 'A composition run reports the generic "step failed" (STEP_FAILED) with no further detail — what should I check?',
+    enA: 'This is a coarse fallback code that can mean a system-kind mismatch, missing credentials, or a network error, among others. Compare that hop\'s requiredKind against the registered external system\'s kind, confirm credentials are registered, and try re-running that hop\'s own standalone read to isolate the problem.',
+  },
+  {
+    zhQ: 'keyField 和 containerPaths 具体是做什么的，为什么保存前必须先探测？',
+    zhA: 'keyField 是按业务键定位单条记录的字段名，containerPaths 是数据在返回体中的容器路径；两者都强依赖目标系统的真实返回形状，即使是"已验证"的模式在不同环境上也可能不同，所以必须先跑"定位容器探测"确认真实结构，再保存版本。',
+    enQ: 'What are keyField and containerPaths for, and why must I probe before saving?',
+    enA: 'keyField names the field used to locate a single record by its business key, and containerPaths is where the data lives inside the response body — both depend on the target system\'s real response shape, which can differ by environment even for an already-verified mode. Always probe first to confirm the real structure before saving.',
+  },
+]
+</script>
+
+<style scoped>
+.integration-help__section {
+  margin-bottom: var(--ms-space-5);
+}
+.integration-help__section h2 {
+  margin: 0 0 var(--ms-space-3);
+  font-size: var(--ms-font-size-section-title);
+  color: var(--ms-text-1);
+}
+.integration-help__section p {
+  margin: 0 0 var(--ms-space-3);
+  color: var(--ms-text-2);
+  line-height: 1.6;
+}
+.integration-help__compare-list {
+  margin: 0;
+  padding-left: var(--ms-space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-2);
+}
+.integration-help__compare-list strong {
+  margin-right: var(--ms-space-2);
+  color: var(--ms-text-1);
+}
+.integration-help__table-wrap {
+  overflow-x: auto;
+}
+.integration-help__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.integration-help__table th,
+.integration-help__table td {
+  border-bottom: 1px solid var(--ms-border-light);
+  padding: var(--ms-space-2) var(--ms-space-3);
+  text-align: left;
+  vertical-align: top;
+}
+.integration-help__table small {
+  display: block;
+  margin-top: var(--ms-space-1);
+  color: var(--ms-text-3);
+}
+.integration-help__faq-item {
+  padding: var(--ms-space-2) 0;
+  border-bottom: 1px solid var(--ms-border-light);
+}
+.integration-help__faq-item:last-child {
+  border-bottom: none;
+}
+.integration-help__faq-item summary {
+  cursor: pointer;
+  font-weight: var(--ms-font-weight-title);
+  color: var(--ms-text-1);
+}
+.integration-help__faq-item p {
+  margin: var(--ms-space-2) 0 0;
+  color: var(--ms-text-2);
+  line-height: 1.6;
+}
+</style>

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -6,7 +6,12 @@
         <h1>数据工厂</h1>
         <p class="integration-workbench__lead">连接任意 CRM / PLM / ERP / SRM / HTTP / SQL 系统，把数据落到多维表清洗后，先 dry-run，再导出或 Save-only 推送。</p>
       </div>
-      <router-link class="integration-workbench__k3-link" to="/integrations/k3-wise">K3 WISE 预设模板</router-link>
+      <div class="integration-workbench__header-links">
+        <router-link class="integration-workbench__k3-link" to="/integrations/k3-wise">K3 WISE 预设模板</router-link>
+        <router-link class="integration-workbench__k3-link" to="/help/integration" data-testid="integration-help-link">
+          {{ bi('帮助', 'Help') }}
+        </router-link>
+      </div>
     </header>
 
     <nav class="integration-workbench__flow" aria-label="data factory flow" data-testid="data-factory-flow">
@@ -67,7 +72,16 @@
         <div>
           <h3>已配置连接</h3>
           <p class="integration-workbench__muted">在这里编辑、复制、停用 / 启用或删除连接；删除仅限未被清洗流程引用的连接。</p>
-          <div v-if="systems.length === 0" class="integration-workbench__empty">暂无连接。请使用 K3 WISE 预设或后续连接向导创建。</div>
+          <div v-if="systems.length === 0" class="integration-workbench__empty" data-testid="connections-empty-state">
+            <strong data-testid="connections-empty-what">{{ bi(
+              '这里是你已连接的外部系统（CRM / PLM / ERP / SRM / HTTP / SQL）。',
+              'This lists the external systems you have connected (CRM / PLM / ERP / SRM / HTTP / SQL).',
+            ) }}</strong>
+            <p data-testid="connections-empty-first-step">{{ bi(
+              '第一步：使用 K3 WISE 预设快速开始，或点击上方"新增连接草稿"创建一个连接。',
+              'First step: start quickly with the K3 WISE preset, or click "new connection draft" above to create one.',
+            ) }}</p>
+          </div>
           <ul v-else class="integration-workbench__inventory-list">
             <li v-for="system in systems" :key="system.id">
               <strong>{{ system.name }}</strong>
@@ -926,7 +940,14 @@
           <span class="integration-workbench__badge" data-testid="table-action-permission-note">dry-run=read · apply=write/admin</span>
         </div>
         <div v-if="tableActions.length === 0" class="integration-workbench__empty" data-testid="table-action-empty">
-          当前部署没有暴露表动作。
+          <strong data-testid="table-action-empty-what">{{ bi(
+            '参数化表动作是管理员预先配置好的安全写入操作，浏览器只填 allowlist 参数，来源/目标由服务端决定。',
+            'Parameterized table actions are safe write operations pre-configured by an admin — the browser only fills allowlisted parameters; source/target are decided server-side.',
+          ) }}</strong>
+          <p data-testid="table-action-empty-first-step">{{ bi(
+            '当前部署没有暴露表动作；如需要，请联系管理员在后端配置。',
+            'This deployment does not expose any table actions; contact an admin to configure one on the backend if needed.',
+          ) }}</p>
         </div>
         <template v-else>
           <div class="integration-workbench__grid integration-workbench__grid--compact">
@@ -1174,7 +1195,16 @@
       <div class="integration-workbench__observation">
         <div>
           <h3>最近运行</h3>
-          <div v-if="pipelineRuns.length === 0" class="integration-workbench__empty">暂无运行记录。</div>
+          <div v-if="pipelineRuns.length === 0" class="integration-workbench__empty" data-testid="pipeline-runs-empty">
+            <strong data-testid="pipeline-runs-empty-what">{{ bi(
+              '这里展示最近的清洗流程运行记录（状态 / 读取 / 清洗 / 写入 / 失败行数）。',
+              'This shows recent pipeline run records (status / rows read / cleaned / written / failed).',
+            ) }}</strong>
+            <p data-testid="pipeline-runs-empty-first-step">{{ bi(
+              '第一步：在上方"运行与推送"区保存清洗流程后执行一次 Dry-run 或 Save-only 推送，运行记录会出现在这里。',
+              'First step: save the pipeline above, then run a Dry-run or Save-only push — the run record will then appear here.',
+            ) }}</p>
+          </div>
           <ol v-else class="integration-workbench__record-list" data-testid="pipeline-runs">
             <li v-for="run in pipelineRuns" :key="run.id" :data-testid="`pipeline-run-${run.id}`">
               <div class="integration-workbench__run-head">
@@ -1202,7 +1232,16 @@
         </div>
         <div>
           <h3>Open Dead Letters</h3>
-          <div v-if="deadLetters.length === 0" class="integration-workbench__empty">暂无 open dead letters。</div>
+          <div v-if="deadLetters.length === 0" class="integration-workbench__empty" data-testid="dead-letters-empty">
+            <strong data-testid="dead-letters-empty-what">{{ bi(
+              'Dead letter 是清洗流程运行中未能成功写入的行，按原因分组，便于排查后再决定是否重放。',
+              'Dead letters are rows that failed to write during a pipeline run, grouped by reason so you can investigate before deciding whether to replay.',
+            ) }}</strong>
+            <p data-testid="dead-letters-empty-first-step">{{ bi(
+              '当前没有 open dead letters；出现失败行时会自动列在这里，可点击"准备 Replay"重跑。',
+              'There are no open dead letters right now; failed rows will be listed here automatically, and you can click "prepare replay" to re-run them.',
+            ) }}</p>
+          </div>
           <ol v-else class="integration-workbench__record-list" data-testid="dead-letters">
             <li v-for="deadLetter in deadLetters" :key="deadLetter.id" :data-testid="`dead-letter-${deadLetter.id}`">
               <strong :data-testid="`dead-letter-label-${deadLetter.id}`">{{ deadLetterErrorLabel(deadLetter) }}</strong>
@@ -1602,6 +1641,13 @@ const flowSteps = [
 ]
 const auth = useAuth()
 const { locale } = useLocale()
+
+// IU-6a: bilingual guidance copy helper — same locale pattern as the IU-1 error labels elsewhere in
+// this file (deadLetterErrorLabel/deadLetterErrorHint read `locale.value`); safe to call directly from
+// the template without a dedicated computed per string.
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
 
 const stagingDatasetCopy: Record<string, { area: string; name: string; description: string }> = {
   plm_raw_items: {
@@ -5029,6 +5075,14 @@ watch(selectedTableActionId, (actionId) => {
 
 .integration-workbench__header {
   margin-bottom: 18px;
+}
+
+/* IU-6c: header help-center link — new wrapper styling only, tokens per UF-1. */
+.integration-workbench__header-links {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-2);
+  flex-wrap: wrap;
 }
 
 .integration-workbench__flow {

--- a/apps/web/tests/IntegrationHelpView.spec.ts
+++ b/apps/web/tests/IntegrationHelpView.spec.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp } from 'vue'
+
+// IU-6c (design-lock docs/development/integration-ux-workbench-redesign-design-lock-20260706.md,
+// #3739): the /help/integration center page. Three sections (when-to-use, error-code table, FAQ);
+// the error-code table is the single-source tripwire — it must be driven by the IU-1 label module's
+// own registered entries, not a hand-copied list, so a future label add/remove needs zero edits here.
+
+const pushSpy = vi.fn()
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: pushSpy }),
+  }
+})
+
+import IntegrationHelpView from '../src/views/IntegrationHelpView.vue'
+import { integrationErrorCodeEntries } from '../src/services/integration/errorCodeLabels'
+
+async function flushUi(cycles = 3): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('IntegrationHelpView (IU-6c)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  async function mountView(): Promise<HTMLDivElement> {
+    app = createApp(IntegrationHelpView)
+    app.mount(container!)
+    await flushUi()
+    return container!
+  }
+
+  it('renders all three sections', async () => {
+    const root = await mountView()
+    expect(root.querySelector('[data-testid="help-section-when-to-use"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="help-section-error-codes"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="help-section-faq"]')).not.toBeNull()
+  })
+
+  it('when-to-use section explains single-hop read source vs two-hop composition, values-free', async () => {
+    const root = await mountView()
+    const section = root.querySelector('[data-testid="help-section-when-to-use"]') as HTMLElement
+    expect(section.textContent).toMatch(/single hop|read source/i)
+    expect(section.textContent).toMatch(/two.hop|composition/i)
+    // values-free: no digit-run > 4 anywhere in this section's copy (no real material/BOM numbers).
+    expect(section.textContent).not.toMatch(/\d{5,}/)
+  })
+
+  // Single-source tripwire: the rendered error-code row count must equal the label module's OWN
+  // registered entry count. This proves the view iterates the module rather than hand-copying a list
+  // — if a future label is added/removed in errorCodeLabels.ts, this test (not a hand-maintained
+  // count) stays in sync automatically.
+  it('error-code table row count equals the label module registered code count (single-source tripwire)', async () => {
+    const root = await mountView()
+    const expectedEntries = integrationErrorCodeEntries()
+    expect(expectedEntries.length).toBeGreaterThan(0)
+
+    const rows = root.querySelectorAll('[data-testid="help-section-error-codes"] tbody tr')
+    expect(rows.length).toBe(expectedEntries.length)
+
+    // Spot-check a couple of known codes actually appear with their label text rendered.
+    const ambiguousRow = root.querySelector(
+      '[data-testid="help-error-code-row-READ_SOURCE_RESOLVER_AMBIGUOUS"]',
+    ) as HTMLElement | null
+    expect(ambiguousRow).not.toBeNull()
+    expect(ambiguousRow!.textContent).toContain('READ_SOURCE_RESOLVER_AMBIGUOUS')
+  })
+
+  it('a planted fake code does NOT appear anywhere in the rendered table', async () => {
+    const root = await mountView()
+    const table = root.querySelector('[data-testid="help-section-error-codes"]') as HTMLElement
+    expect(table.textContent).not.toContain('TOTALLY_MADE_UP_ERROR_CODE_NOT_REAL')
+    expect(root.querySelector('[data-testid="help-error-code-row-TOTALLY_MADE_UP_ERROR_CODE_NOT_REAL"]')).toBeNull()
+  })
+
+  it('FAQ section renders 5-8 values-free Q&A entries', async () => {
+    const root = await mountView()
+    const items = root.querySelectorAll('[data-testid="help-section-faq"] [data-testid^="help-faq-question-"]')
+    expect(items.length).toBeGreaterThanOrEqual(5)
+    expect(items.length).toBeLessThanOrEqual(8)
+    const faqSection = root.querySelector('[data-testid="help-section-faq"]') as HTMLElement
+    for (const item of Array.from(items)) {
+      expect(item.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    }
+    // values-free: no digit-run > 4 anywhere in the FAQ copy.
+    expect(faqSection.textContent).not.toMatch(/\d{5,}/)
+    // The two design-lock-named FAQ examples must be present.
+    expect(faqSection.textContent).toMatch(/container/i)
+    expect(faqSection.textContent).toMatch(/ambiguous|multiple BOMs/i)
+  })
+
+  it('has a back-to-workbench link in the page header', async () => {
+    const root = await mountView()
+    const back = root.querySelector('.ms-page-header__back') as HTMLElement | null
+    expect(back).not.toBeNull()
+  })
+})

--- a/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
 import { createApp, h, nextTick, type App as VueApp } from 'vue'
 
 const apiFetchMock = vi.fn()
@@ -444,6 +445,23 @@ describe('IntegrationReadSourceConfigPanel', () => {
     // mentions the concrete first action (probe → save), not a generic "no data" placeholder.
     expect(firstStep.textContent).toMatch(/probe/i)
     expect(firstStep.textContent).toMatch(/save version/i)
+
+    // zh variant coverage (quality-gate finding on IU-6: the en assertions above never see the zh
+    // copy, so it could rot to a generic placeholder unnoticed). Switch locale via the composable's
+    // setter (the module-level ref is resolved once at import — localStorage alone won't flip it),
+    // remount, and assert the concrete first action is mentioned in zh too.
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      mockListOnly([])
+      const zhRoot = mountPanel()
+      await flushUi()
+      const zhFirstStep = q(zhRoot, 'rsc-empty-first-step')
+      expect(zhFirstStep.textContent).toContain('定位容器探测')
+      expect(zhFirstStep.textContent).toContain('保存版本')
+    } finally {
+      setLocale('en')
+    }
   })
 
   it('gates fields per mode and blocks probe/save until required fields are present', async () => {

--- a/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
@@ -426,6 +426,26 @@ describe('IntegrationReadSourceConfigPanel', () => {
     expect(root.querySelector('[data-testid="rsc-retire-cfg_ret"]')).toBeNull()
   })
 
+  // IU-6a (design-lock docs/development/integration-ux-workbench-redesign-design-lock-20260706.md
+  // #3739): the saved-configs empty state must guide, not just say "nothing here" — one line for
+  // "what is this list" and one line for "what's the first step".
+  it('renders a guided empty state (what-this-is + first-step) when there are no saved configs', async () => {
+    mockListOnly([])
+    const root = mountPanel()
+    await flushUi()
+
+    const empty = q(root, 'rsc-empty')
+    expect(empty).not.toBeNull()
+    const what = q(root, 'rsc-empty-what')
+    const firstStep = q(root, 'rsc-empty-first-step')
+    expect(what.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    expect(firstStep.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    // Default test-env locale is 'en' (see localstorage.ts setup) — assert the guidance actually
+    // mentions the concrete first action (probe → save), not a generic "no data" placeholder.
+    expect(firstStep.textContent).toMatch(/probe/i)
+    expect(firstStep.textContent).toMatch(/save version/i)
+  })
+
   it('gates fields per mode and blocks probe/save until required fields are present', async () => {
     mockListOnly()
     const root = mountPanel()

--- a/apps/web/tests/fieldHints.spec.ts
+++ b/apps/web/tests/fieldHints.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INTEGRATION_FIELD_HINTS,
+  integrationFieldHint,
+  type IntegrationFieldHintKey,
+} from '../src/services/integration/fieldHints'
+
+// IU-6b (design-lock docs/development/integration-ux-workbench-redesign-design-lock-20260706.md,
+// #3739): field-level hint copy module. Mirrors the discipline already enforced on
+// errorCodeLabels.ts / integrationErrorCodeLabels.spec.ts — exact-key, non-empty zh+en, values-free.
+
+const ALL_KEYS = Object.keys(INTEGRATION_FIELD_HINTS) as IntegrationFieldHintKey[]
+
+// values-free scan: no digit-run longer than 4 (a proxy for "looks like a real business code/number")
+// and no raw URL scheme anywhere in the copy.
+const DIGIT_RUN_TOO_LONG = /\d{5,}/
+const HAS_URL_SCHEME = /https?:\/\//i
+
+describe('fieldHints (IU-6b)', () => {
+  it('has at least the ~15 highest-confusion fields covered', () => {
+    expect(ALL_KEYS.length).toBeGreaterThanOrEqual(15)
+  })
+
+  it.each(ALL_KEYS)('%s has a non-empty zh AND en entry', (key) => {
+    const entry = INTEGRATION_FIELD_HINTS[key]
+    expect(entry).toBeTruthy()
+    expect(entry.zh.trim().length).toBeGreaterThan(0)
+    expect(entry.en.trim().length).toBeGreaterThan(0)
+  })
+
+  it.each(ALL_KEYS)('%s is values-free (no digit-run > 4, no http(s):// scheme)', (key) => {
+    const entry = INTEGRATION_FIELD_HINTS[key]
+    expect(entry.zh).not.toMatch(DIGIT_RUN_TOO_LONG)
+    expect(entry.en).not.toMatch(DIGIT_RUN_TOO_LONG)
+    expect(entry.zh).not.toMatch(HAS_URL_SCHEME)
+    expect(entry.en).not.toMatch(HAS_URL_SCHEME)
+  })
+
+  it('integrationFieldHint returns the zh text for zh-CN and the en text for en, per exact key', () => {
+    expect(integrationFieldHint('readSource.keyField', 'zh-CN')).toBe(INTEGRATION_FIELD_HINTS['readSource.keyField'].zh)
+    expect(integrationFieldHint('readSource.keyField', 'en')).toBe(INTEGRATION_FIELD_HINTS['readSource.keyField'].en)
+    expect(integrationFieldHint('composition.sourceTarget', 'zh-CN')).toBe(
+      INTEGRATION_FIELD_HINTS['composition.sourceTarget'].zh,
+    )
+    expect(integrationFieldHint('composition.sourceTarget', 'en')).toBe(
+      INTEGRATION_FIELD_HINTS['composition.sourceTarget'].en,
+    )
+  })
+
+  it('covers every read-source config panel field this slice wires a tooltip to', () => {
+    const expectedReadSourceKeys: IntegrationFieldHintKey[] = [
+      'readSource.requiredKind',
+      'readSource.mode',
+      'readSource.readPath',
+      'readSource.keyField',
+      'readSource.keyEncoding',
+      'readSource.resolverRule',
+      'readSource.resolverSortField',
+      'readSource.resolverSortDirection',
+      'readSource.resolverDiscriminatorField',
+      'readSource.resolverDiscriminatorValue',
+      'readSource.containerPaths',
+      'readSource.headerContainerPaths',
+      'readSource.lineContainerPaths',
+      'readSource.fieldMap',
+      'readSource.boundedSmoke',
+    ]
+    for (const key of expectedReadSourceKeys) {
+      expect(ALL_KEYS).toContain(key)
+    }
+  })
+
+  it('covers every composition-authoring step-wiring field this slice wires a tooltip to', () => {
+    const expectedCompositionKeys: IntegrationFieldHintKey[] = [
+      'composition.step1ConfigId',
+      'composition.step2ConfigId',
+      'composition.name',
+      'composition.sourceTarget',
+    ]
+    for (const key of expectedCompositionKeys) {
+      expect(ALL_KEYS).toContain(key)
+    }
+  })
+})

--- a/docs/development/integration-iu6-embedded-help-dev-verification-20260707.md
+++ b/docs/development/integration-iu6-embedded-help-dev-verification-20260707.md
@@ -1,0 +1,198 @@
+# IU-6: Integration embedded help (three layers) — dev verification (2026-07-07)
+
+Scope: design-lock `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md`
+(RATIFIED, #3739) §2 IU-6 (a/b/c) + §3 hard locks. Pure frontend, **zero behavior change**: one new
+copy module, one new read-only view + route, guidance-only edits to existing empty states, tooltip
+wrappers on existing field labels, tests, CI path-filter additions, this MD. Base = origin/main
+including IU-1 #3743 (`errorCodeLabels.ts` label module).
+
+## Three-layer coverage table
+
+### IU-6a 空状态即引导 (guided empty states: 这是什么 + 第一步做什么, zh+en)
+
+| Surface | Empty state | Before | After |
+|---|---|---|---|
+| Workbench · 连接管理 | `systems.length === 0` inventory list | one-line "暂无连接…" | what-is (`connections-empty-what`) + first-step (`connections-empty-first-step`) |
+| Workbench · 参数化表动作 | `tableActions.length === 0` | one-line "当前部署没有暴露表动作。" | what-is + first-step (`table-action-empty-what/-first-step`) |
+| Workbench · 运行监控/最近运行 | `pipelineRuns.length === 0` | one-line "暂无运行记录。" | what-is + first-step (`pipeline-runs-empty-what/-first-step`) |
+| Workbench · 运行监控/dead letters | `deadLetters.length === 0` | one-line "暂无 open dead letters。" | what-is + first-step (`dead-letters-empty-what/-first-step`) |
+| 读取源配置 panel · saved-configs list | `configs.length === 0` (`rsc-empty`) | one-line "暂无读取源配置。" | what-is + first-step (`rsc-empty-what/-first-step`) |
+| 组合 authoring panel · resolver picker | `resolverConfigs.length === 0` (`rscauth-empty`) | one-line prose | what-is + first-step (`rscauth-empty-what/-first-step`) |
+| 组合运行 panel · approved list | `compositions.length === 0` (`rscomp-empty`) | one-line "暂无已审批组合。" | what-is + first-step (`rscomp-empty-what/-first-step`) |
+
+Deliberately NOT touched (stated per task "state your skips"):
+
+- Workbench `source-empty-state` (还没有可读取的数据源) and `staging-empty` (暂未加载 staging 契约) —
+  these two were **already** guided/actionable empty states (strong what-is line + CTA buttons,
+  `integration-workbench__empty--actionable`); rewriting them would be churn, not a gap fill. Existing
+  specs assert their exact copy (`IntegrationWorkbenchView.spec.ts:1495/1563/1612-1616`).
+- `data-source-bridge-object-empty` ("没有可选表 / 视图…") — already tells the user exactly what to do
+  next (回 /data-sources 检查权限或 schema); it is a hint line, not a bare empty state.
+- `dead-letter-provenance-empty-*` ("暂无血缘事件。") — nested per-row expert detail inside an already
+  guided dead-letter card, not a section-level list empty state.
+- `IntegrationK3WiseSetupView.vue` — not named in the IU-6a scope list (workbench sections + the two
+  read-source panels); its mini dead-letter list mirrors the Workbench one and can pick the same copy up
+  in IU-2.
+
+All empty-state copy is zh-primary + en via the same `locale.value === 'zh-CN'` pattern the surface
+already uses (a small `bi(zh, en)` helper per component — same idiom as the IU-1 label helpers), and all
+NEW styling uses `var(--ms-*)` tokens only (zero new hex; verified by grep over the diff).
+
+### IU-6b 字段级 hint (el-tooltip, values-free, zh+en)
+
+New module **`apps/web/src/services/integration/fieldHints.ts`** — exact-key map
+`INTEGRATION_FIELD_HINTS: Record<IntegrationFieldHintKey, {zh, en}>` + `integrationFieldHint(key,
+locale)`, same style as `errorCodeLabels.ts`, deliberately Vue-free/DOM-free so IU-2's restructure can
+re-consume it. 19 keys wired to `el-tooltip` wrappers (existing native controls untouched — only the
+label `<span>` is wrapped, per the "do not convert native controls" instruction):
+
+| Panel | Fields (hint key) |
+|---|---|
+| `IntegrationReadSourceConfigPanel.vue` (15) | requiredKind, mode, readPath, keyField, keyEncoding, resolverRule, resolverSortField (multiplicityRuleField/sorted), resolverSortDirection, resolverDiscriminatorField (multiplicityRuleField/equals), resolverDiscriminatorValue, containerPaths, headerContainerPaths, lineContainerPaths, fieldMap, boundedSmoke |
+| `IntegrationReadSourceCompositionAuthoringPanel.vue` (4) | step1ConfigId, step2ConfigId, name, sourceTarget |
+
+Each tooltip carrier has a `data-testid` (`rsc-hint-*` / `rscauth-hint-*`). Copy is one sentence,
+values-free (placeholder-form only — the module spec enforces "no digit-run > 4, no http(s)://" over
+every entry). Skipped fields (stated): `object` (self-explanatory, its placeholder suffices),
+`version` (labeled "正整数" inline already), `operations` (read-only/disabled, label already says
+本线只读), the probe-key input (its label already explains it fully), and everything in
+`IntegrationWorkbenchView.vue` / `IntegrationK3WiseSetupView.vue` (those two views already carry
+`__field-help` inline help lines per field; adding tooltips there is IU-2/IU-5 territory).
+
+### IU-6c 帮助中心页 `/help/integration`
+
+New view **`apps/web/src/views/IntegrationHelpView.vue`** — standard chrome (`PageShell width="default"`
++ `PageHeader` with back-to-workbench + `el-card` sections, mirroring
+`src/views/approval/TemplateAuthoringView.vue`), tokens only. Three sections:
+
+1. **何时用读取源 vs 组合** (`help-section-when-to-use`) — one-screen single-hop vs two-hop chain
+   explanation + a choose-when compare list; values-free (no business values, no real identifiers).
+2. **错误码对照表** (`help-section-error-codes`) — **SINGLE SOURCE**: rendered by iterating
+   `integrationErrorCodeEntries()` (a new export on the IU-1 module that maps
+   `INTEGRATION_ERROR_CODE_LABELS`' own keys — the map itself is now exported too). ZERO label strings
+   are copied into the view; a future label addition/removal appears in the table with no edit to this
+   page. Each row = raw code (`<code>`) + zh/en label + optional hint.
+3. **常见排障 FAQ** (`help-section-faq`) — 7 entries distilled from
+   `docs/development/integration-composition-entity-e2e-runbook-20260705.md` and
+   `docs/development/integration-core-external-api-read-self-service-entity-e2e-runbook-20260702.md`
+   (not invented): container-not-found probe triage; multi-BOM AMBIGUOUS = correct uniqueness-policy
+   behavior (design-lock-named example); credentials are backend-registered (design-lock-named example);
+   save-version 500 = migration gap first; STEP_NOT_RUN = fail-closed by design; generic STEP_FAILED
+   triage (requiredKind mismatch / credentials / network); keyField+containerPaths probe-before-save
+   rationale. All values-free (placeholders only, spec-enforced no digit-run > 4).
+
+**Route** (`apps/web/src/router/appRoutes.ts`): `/help/integration`, name `integration-help`, lazy
+component, `meta: { requiresAuth: true }` — **no `integration:write` gate**. Choice + rationale (task
+asked to state it): the route follows the `/data-sources` info-page pattern (requiresAuth only) rather
+than the workbench's write-tier gate, because the content (when-to-use, error-code reference, FAQ) is
+exactly what a user who HITS an error wants to read, including read-tier users without
+`integration:write`; the page has no service calls and no write path, so there is nothing to fence.
+
+**Entry link**: one `router-link` "帮助/Help" (`integration-help-link`) added beside the existing K3
+WISE preset link in the Workbench header, reusing the existing `integration-workbench__k3-link` class
+(no new visual style) inside a minimal token-styled flex wrapper.
+
+## Single-source tripwire (explanation)
+
+The help center's error-code table MUST stay a projection of the IU-1 label module, never a copy.
+Enforced twice:
+
+1. **Construction**: `IntegrationHelpView.vue` contains no error-label strings at all — the table
+   `v-for`s over `integrationErrorCodeEntries()`, whose implementation is
+   `Object.keys(INTEGRATION_ERROR_CODE_LABELS).map(...)` inside `errorCodeLabels.ts` itself.
+2. **Test** (`IntegrationHelpView.spec.ts`): the rendered `tbody tr` count is asserted `===`
+   `integrationErrorCodeEntries().length` (the module's own registered-code count — not a hand-written
+   number, so adding/removing a label keeps the spec green while proving the table tracked it), a known
+   code's row is spot-checked, and a **planted fake code** (`TOTALLY_MADE_UP_ERROR_CODE_NOT_REAL`) is
+   asserted absent — a hand-copied table could drift to include stale/invented codes; a projected one
+   cannot.
+
+## Zero-behavior-change statement
+
+- No service-layer/wire-shape changes: `fieldHints.ts` is a pure data+lookup module;
+  `errorCodeLabels.ts` gains only two additive exports (`INTEGRATION_ERROR_CODE_LABELS` made `export`,
+  new `integrationErrorCodeEntries()`/`IntegrationErrorCodeEntry`) — no existing export's signature or
+  semantics changed, and the IU-1 spec passes unmodified.
+- No permission changes: the workbench/K3 routes keep `integration:write`; the ONE new route is
+  additive and read-only (rationale above).
+- No backend changes of any kind; no new network calls anywhere (the help view performs zero requests).
+- Existing empty-state conditions (`v-if`s) unchanged — only the markup INSIDE them enriched; existing
+  `data-testid`s (`rsc-empty`, `rscomp-empty`, `rscauth-empty`, `table-action-empty`) preserved.
+- el-tooltip wraps label `<span>`s only; every native input/select/checkbox and its
+  `v-model`/`data-testid` is byte-identical.
+- Token-only styling: every new CSS declaration uses `var(--ms-*)`; grep over the full diff shows zero
+  added hex literals.
+- Values-free discipline: enforced by spec on the fieldHints module (all 19 entries) and on the help
+  view's when-to-use + FAQ sections (no digit-run > 4, no URLs); FAQ examples are placeholder-form.
+- `pnpm exec vue-tsc -b` clean (exit 0).
+
+## Test evidence
+
+Guard command exactly as now in `.github/workflows/integration-guard.yml` (spec list extended with
+`fieldHints` + `IntegrationHelpView`), run on **both** Node 20.20.2 (CI's major, via nvm — new view
+tests use only synchronous flushes + the panel spec's existing condition-based `waitUntil`, no
+microtask-only flushing) and the default local Node 25.9.0:
+
+```
+pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror \
+  integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel \
+  IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel \
+  readSourceCompositions.service IntegrationWorkbenchView IntegrationK3WiseSetupView \
+  IntegrationHelpView --reporter=dot
+
+✓ tests/fieldHints.spec.ts                                      (42 tests)  ← new
+✓ tests/IntegrationHelpView.spec.ts                             (6 tests)   ← new
+✓ tests/integrationErrorCodeLabels.spec.ts                      (13 tests)
+✓ tests/composition-vocab-mirror.spec.ts                        (3 tests)
+✓ tests/multitable-resolver-vocab-mirror.spec.ts                (4 tests)
+✓ tests/readSourceCompositions.service.spec.ts                  (24 tests)
+✓ tests/IntegrationReadSourceCompositionPanel.spec.ts           (6 tests)
+✓ tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts  (7 tests)
+✓ tests/IntegrationReadSourceConfigPanel.spec.ts                (20 tests)  ← +1 guided-empty-state
+✓ tests/IntegrationK3WiseSetupView.spec.ts                      (7 tests)
+✓ tests/IntegrationWorkbenchView.spec.ts                        (49 tests)
+
+Test Files  11 passed (11) · Tests  181 passed (181)   [Node 20.20.2 AND Node 25.9.0]
+```
+
+Also ran the guard's first leg `pnpm --filter plugin-integration-core test` on Node 20 — all suites OK
+(no server-side contract this slice mirrors changed).
+
+New specs:
+
+- `apps/web/tests/fieldHints.spec.ts` — exact-key coverage (every wired key present), non-empty zh+en
+  for every entry, values-free scan (no digit-run > 4, no `http(s)://`), locale selection, and explicit
+  key-lists for both panels so removing a wired key fails RED.
+- `apps/web/tests/IntegrationHelpView.spec.ts` — renders all three sections; when-to-use values-free +
+  mentions both concepts; **single-source tripwire** (row count === module count, spot-checked row,
+  planted fake code absent); FAQ 5-8 entries, values-free, includes the two design-lock-named examples;
+  back-link present.
+- `apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts` — new `it`: empty saved-configs list renders
+  the guided empty state (what-is + first-step both non-empty; first-step names the concrete probe→save
+  action, asserted in the test env's default `en` locale).
+
+Known noise, pre-existing: the panel specs' jsdom mounts log "Failed to resolve component: el-tooltip"
+warnings because those specs mount components bare (no ElementPlus plugin). Warning-only — the label
+`<span>` still renders (assertions on label text keep passing) and the real app registers ElementPlus
+globally in `main.ts`. Same situation as other el-* usage in bare-mounted specs.
+
+Known-failing spec NOT related to this slice: `k3WiseSetup.spec.ts` "route guard" test fails identically
+on the unmodified base commit (asserts `main.ts` contains `to.meta?.permissions`, which drifted before
+this branch) — verified by stash/run/pop; it is not in the integration-guard spec list and untouched
+here.
+
+## Files touched
+
+- `apps/web/src/services/integration/fieldHints.ts` (new)
+- `apps/web/src/views/IntegrationHelpView.vue` (new)
+- `apps/web/src/services/integration/errorCodeLabels.ts` (additive exports only)
+- `apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue`
+- `apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue`
+- `apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue`
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/tests/fieldHints.spec.ts` (new)
+- `apps/web/tests/IntegrationHelpView.spec.ts` (new)
+- `apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts`
+- `.github/workflows/integration-guard.yml`
+- `docs/development/integration-iu6-embedded-help-dev-verification-20260707.md` (this file)


### PR DESCRIPTION
## Scope

Slice **IU-6 嵌入式帮助三层** of the integration UX ladder, per RATIFIED design-lock `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md` (§2 IU-6, §3 hard locks). **Zero behavior change**: no service/wire/permission/backend changes — one new copy module, one new read-only view + route, guidance-only markup enrichments, tooltip wrappers, tests, CI spec-list extension, verification MD.

## IU-6a 空状态即引导 (7 empty states enriched in place)

Every enriched empty state = one line 这是什么 + one line 第一步做什么, zh primary + en via the surface's existing `locale.value` pattern; existing `v-if` conditions and `data-testid`s untouched; all new styling `var(--ms-*)` tokens only (zero new hex in the diff):

| Surface | testids |
|---|---|
| Workbench 连接管理 | `connections-empty-what/-first-step` |
| Workbench 参数化表动作 | `table-action-empty-what/-first-step` |
| Workbench 最近运行 | `pipeline-runs-empty-what/-first-step` |
| Workbench dead letters | `dead-letters-empty-what/-first-step` |
| 读取源配置 saved list | `rsc-empty-what/-first-step` |
| 组合 authoring picker | `rscauth-empty-what/-first-step` |
| 组合运行 approved list | `rscomp-empty-what/-first-step` |

Deliberately skipped (already guided/actionable, or nested expert detail — details in verification MD): `source-empty-state`, `staging-empty`, `data-source-bridge-object-empty`, `dead-letter-provenance-empty-*`, K3 WISE setup view.

## IU-6b 字段级 hint (19 el-tooltip hints, dedicated module)

- New `apps/web/src/services/integration/fieldHints.ts` — exact-key `{zh,en}` map + `integrationFieldHint(key, locale)`, same style as `errorCodeLabels.ts`, Vue-free so IU-2 can re-consume it.
- 15 fields in `IntegrationReadSourceConfigPanel.vue` (requiredKind/mode/readPath/keyField/keyEncoding/resolverRule + 4 resolver sub-fields/containerPaths/header+lineContainerPaths/fieldMap/boundedSmoke) + 4 in `IntegrationReadSourceCompositionAuthoringPanel.vue` (step1/step2/name/sourceTarget).
- Only the label `<span>` is wrapped — native controls, v-models, and testids byte-identical. Copy is one sentence each, values-free (spec-enforced: no digit-run > 4, no URLs).

## IU-6c 帮助中心 `/help/integration`

- New `IntegrationHelpView.vue` — standard chrome (`PageShell` + `PageHeader` + `el-card`, mirroring `TemplateAuthoringView.vue`; tokens only). Sections:
  1. 何时用读取源 vs 组合 — 单跳取数 vs 两跳链, values-free.
  2. 错误码对照表 — **single source**: iterates new additive export `integrationErrorCodeEntries()` on the IU-1 label module (`INTEGRATION_ERROR_CODE_LABELS` now exported); zero label strings copied into the view, future labels appear automatically.
  3. 常见排障 FAQ — 7 entries distilled from the composition + read-self-service entity e2e runbooks (incl. the design-lock-named examples: 探测"未找到数据容器"排查 / 多 BOM AMBIGUOUS 是唯一性策略的正确行为 / 凭证后端注册不在页面填).
- **Route gating choice (stating per task)**: `requiresAuth: true` only, NO `integration:write` — follows the `/data-sources` info-page pattern in `appRoutes.ts`. Rationale: the page is read-only with zero service calls; its content (error-code reference + FAQ) is precisely what a read-tier user who hits an error needs, so fencing it behind write would defeat the purpose.
- One 帮助 link (`integration-help-link`) added next to the K3 WISE preset link in the Workbench header (reuses the existing link class; minimal token-styled flex wrapper).

## Tests / CI

- `fieldHints.spec.ts` (42): exact-key coverage incl. explicit per-panel wired-key lists, non-empty zh+en, values-free scan (digit-runs > 4 / `http(s)://` forbidden), locale selection.
- `IntegrationHelpView.spec.ts` (6): all three sections render; **single-source tripwire** — error-code table row count `===` `integrationErrorCodeEntries().length` (module's own count, not a hand-written number) + spot-checked row + planted fake code (`TOTALLY_MADE_UP_ERROR_CODE_NOT_REAL`) asserted absent; FAQ 5–8 entries values-free incl. both design-lock-named examples; back-link present.
- `IntegrationReadSourceConfigPanel.spec.ts` +1: empty saved-configs list renders guided what-is + first-step (asserts concrete probe→save action in default `en` test locale).
- `.github/workflows/integration-guard.yml`: path filters (PR + push) and the vitest spec list extended with `fieldHints` / `IntegrationHelpView` / the new source files.

**Evidence** — full guard command run locally on **Node 20.20.2** (CI major, via nvm) **and** Node 25.9.0:

```
Test Files  11 passed (11) · Tests  181 passed (181)   [both Node versions]
```

Plus `pnpm --filter plugin-integration-core test` all OK (Node 20) and `pnpm exec vue-tsc -b` clean (exit 0). New view specs use synchronous flushes / the existing condition-based `waitUntil` — no microtask-only flushing (Node-20 lesson applied). Known pre-existing unrelated failure: `k3WiseSetup.spec.ts` route-guard test fails identically on the unmodified base (verified via stash/run/pop); not in the guard list, untouched.

Verification MD: `docs/development/integration-iu6-embedded-help-dev-verification-20260707.md` (three-layer coverage table, single-source tripwire explanation, zero-behavior-change statement, skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)