### PR TITLE
feat(approval): T36-1 — projection per-row participant read (Plan A, ratified)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -320,6 +320,8 @@ jobs:
             tests/integration/automation-approval-task-created-trigger.test.ts \
             tests/integration/automation-dingtalk-approval-card-action.test.ts \
             tests/integration/approval-card-delivery-wrapper.db.test.ts \
+            tests/integration/approval-projection-visibility.db.test.ts \
+            tests/integration/approval-projection-participant-read.db.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2355,6 +2355,7 @@ export class MetaSheetServer {
         // Auth gate: uses the same sheet + record-level capability resolution as REST
         const sheetCaps = await import('./multitable/sheet-capabilities')
         const { resolveSheetCapabilitiesForUser, canWriteRecord } = sheetCaps
+        const { isRecordReadDeniedForUser } = await import('./multitable/permission-service')
         yjsWsAdapter.setAuthChecker(async (userId, recordId) => {
           try {
             const pool = poolManager.get()
@@ -2372,6 +2373,13 @@ export class MetaSheetServer {
               sheetId,
               userId,
             )
+            // T36-1 review P1: sheet-level canRead is not enough — the doc seeder loads the
+            // record's FULL data, so a row-level-denied record (projection non-participant row,
+            // or any row-deny-flagged sheet) must not be subscribable at all. DENY-WINS.
+            if (!isAdminRole && capabilities.canRead
+              && (await isRecordReadDeniedForUser(pool.query.bind(pool), sheetId, recordId, userId))) {
+              return { canRead: false, canWrite: false }
+            }
             const canWrite = canWriteRecord(capabilities, sheetScope, isAdminRole, userId, createdBy)
             return { canRead: capabilities.canRead, canWrite }
           } catch {

--- a/packages/core-backend/src/multitable/approval-projection-constants.ts
+++ b/packages/core-backend/src/multitable/approval-projection-constants.ts
@@ -56,3 +56,33 @@ export function restrictApprovalProjectionCapabilities<T extends { canRead: bool
   }
   return denied as T
 }
+
+/**
+ * T36-1 (per-row visibility lock, RATIFIED Plan A): the read-plane capability keys a PARTICIPANT
+ * (projection row carries their id as requesterId or approverId) keeps on a projection sheet.
+ * Export stays read-parity (the W1-2 G-7 export⊆read differential holds because export rides the
+ * same row-deny choke). Everything else — write / fields / views / comments / automation — stays
+ * denied for every non-admin: the projection is a system-owned read model.
+ */
+const PROJECTION_PARTICIPANT_READ_KEYS = new Set(['canRead', 'canExport'])
+
+/**
+ * Participant-aware variant of the fence: admins unaffected; non-admin PARTICIPANTS keep the
+ * read plane (rows are then narrowed to their own by the row-deny choke); non-admin
+ * NON-participants get the original full fence (no drift from the ratified admin-only behavior —
+ * they never learn the sheet exists). Pure — the caller decides participant status (via
+ * `loadApprovalProjectionParticipantSheetIds`, fail-closed to non-participant on any error).
+ */
+export function restrictApprovalProjectionCapabilitiesPerRow<T extends { canRead: boolean }>(
+  capabilities: T,
+  isProjectionSheet: boolean,
+  isAdminRole: boolean,
+  isParticipant: boolean,
+): T {
+  if (!isProjectionSheet || isAdminRole) return capabilities
+  const denied: Record<string, unknown> = { ...capabilities }
+  for (const key of PROJECTION_DENY_CAPABILITY_KEYS) {
+    if (key in denied) denied[key] = isParticipant && PROJECTION_PARTICIPANT_READ_KEYS.has(key) ? denied[key] : false
+  }
+  return denied as T
+}

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -46,7 +46,8 @@ import {
 import { filterPermissionCodesByNamespaceAdmission } from '../rbac/namespace-admission'
 import {
   APPROVAL_PROJECTION_BASE_ID,
-  restrictApprovalProjectionCapabilities,
+  restrictApprovalProjectionCapabilitiesPerRow,
+  isApprovalProjectionBaseId,
 } from './approval-projection-constants'
 import {
   parseConditionalRules,
@@ -916,11 +917,83 @@ export async function loadFieldPermissionScopeMap(
 export async function loadRowLevelReadDenyEnabled(query: QueryFn, sheetId: string): Promise<boolean> {
   if (!sheetId) return false
   try {
-    const r = await query('SELECT row_level_read_permissions_enabled AS enabled FROM meta_sheets WHERE id = $1', [sheetId])
-    return (r.rows[0] as { enabled?: boolean } | undefined)?.enabled === true
+    // T36-1 (per-row visibility lock, Plan A): projection sheets are ALWAYS row-level-read-gated —
+    // participants read only their own rows via loadDeniedRecordIds' projection branch. Folding the
+    // switch into this single predicate activates the deny choke on EVERY read surface the W1-2
+    // permission-matrix goldens already lock to it (5 records:read routes, export, history), with
+    // the existing admin bypass at each call site untouched.
+    const r = await query(
+      'SELECT row_level_read_permissions_enabled AS enabled, base_id FROM meta_sheets WHERE id = $1',
+      [sheetId],
+    )
+    const row = r.rows[0] as { enabled?: boolean; base_id?: string } | undefined
+    if (isApprovalProjectionBaseId(row?.base_id)) return true
+    return row?.enabled === true
   } catch {
     return false
   }
+}
+
+/**
+ * T36-1 (Plan A): of the given sheet ids, the approval-projection sheets where `userId` is a
+ * PARTICIPANT in ≥1 row (row's own requesterId/approverId — zero new storage). Fail-closed: any
+ * error → empty set → the caller treats the actor as a non-participant (full fence).
+ */
+export async function loadApprovalProjectionParticipantSheetIds(
+  query: QueryFn,
+  sheetIds: string[],
+  userId: string,
+): Promise<Set<string>> {
+  if (sheetIds.length === 0 || !userId) return new Set()
+  try {
+    const result = await query(
+      `SELECT DISTINCT s.id
+         FROM meta_sheets s
+         JOIN meta_records r ON r.sheet_id = s.id
+        WHERE s.id = ANY($1::text[])
+          AND s.base_id = $2
+          AND (r.data->>'requesterId' = $3 OR r.data->>'approverId' = $3)`,
+      [sheetIds, APPROVAL_PROJECTION_BASE_ID, userId],
+    )
+    return new Set((result.rows as Array<{ id: string }>).map((row) => row.id))
+  } catch {
+    return new Set()
+  }
+}
+
+/**
+ * T36-1 (Plan A): for a projection sheet, the record ids `userId` may NOT read — every row where
+ * they are neither the requester nor the terminal decider. NULL/missing participant fields never
+ * match the actor, so corrupt rows land in the denied set (fail-closed, lock §3). Returns empty
+ * for non-projection sheets so the generic deny paths are untouched. On an unexpected query error
+ * this THROWS (matching loadDeniedRecordIds' rethrow contract) — the whole read fails rather than
+ * ever serving unfiltered projection rows (fail-closed, lock §3).
+ */
+export async function loadApprovalProjectionDeniedRecordIds(
+  query: QueryFn,
+  sheetId: string,
+  userId: string,
+): Promise<{ isProjection: boolean; denied: Set<string> }> {
+  if (!sheetId) return { isProjection: false, denied: new Set() }
+  const projectionIds = await loadApprovalProjectionSheetIds(query, [sheetId])
+  if (!projectionIds.has(sheetId)) return { isProjection: false, denied: new Set() }
+  // COALESCE closes the SQL three-valued-logic hole: a row with a MISSING participant field
+  // yields NULL comparisons, and `NOT (NULL OR NULL)` is NULL — the corrupt row would silently
+  // escape the denied set (fail-OPEN). With COALESCE to '' it can never equal a real user id, so
+  // corrupt rows are always denied (lock §3 fail-closed). An empty/absent actor id denies every
+  // row for the same reason ('' is matched against COALESCE'd '' explicitly guarded out below).
+  const normalizedUserId = typeof userId === 'string' ? userId.trim() : ''
+  if (!normalizedUserId) {
+    const all = await query('SELECT id FROM meta_records WHERE sheet_id = $1', [sheetId])
+    return { isProjection: true, denied: new Set((all.rows as Array<{ id: string }>).map((row) => row.id)) }
+  }
+  const result = await query(
+    `SELECT id FROM meta_records
+      WHERE sheet_id = $1
+        AND NOT (COALESCE(data->>'requesterId', '') = $2 OR COALESCE(data->>'approverId', '') = $2)`,
+    [sheetId, normalizedUserId],
+  )
+  return { isProjection: true, denied: new Set((result.rows as Array<{ id: string }>).map((row) => row.id)) }
 }
 
 export async function loadRecordPermissionScopeMap(
@@ -999,6 +1072,21 @@ export async function loadRecordPermissionScopeMap(
         scopes.set(rid, { recordId: rid, accessLevel: 'none' })
       }
     }
+    // T36-1 (Plan A): on a projection sheet, non-participant rows get a synthetic 'none' scope
+    // (DENY-WINS, same shape as rule-deny). Admins bypass at the call sites, unchanged.
+    const projection = await loadApprovalProjectionDeniedRecordIds(query, sheetId, userId)
+    if (projection.isProjection) {
+      const requested = new Set(recordIds)
+      for (const rid of projection.denied) {
+        if (!requested.has(rid)) continue
+        const existing = scopes.get(rid)
+        if (existing) {
+          if (rank.none > rank[existing.accessLevel]) existing.accessLevel = 'none'
+        } else {
+          scopes.set(rid, { recordId: rid, accessLevel: 'none' })
+        }
+      }
+    }
   }
   return scopes
 }
@@ -1055,6 +1143,13 @@ export async function loadDeniedRecordIds(query: QueryFn, sheetId: string, userI
   // rule-denied record is masked/excluded EXACTLY like a grant-denied one by every surface that
   // consumes this set (admin-bypass + no-cardinality-leak inherited from #18). DENY-WINS by union.
   for (const id of await loadRuleDeniedRecordIds(query, sheetId)) denied.add(id)
+  // (c) T36-1 projection per-row (Plan A): on a projection sheet, every row where the actor is
+  // neither requester nor terminal decider is denied — unioned in like (a)/(b), so all W1-2-locked
+  // consumers (records:read routes, export, history) narrow participants to their own rows.
+  const projection = await loadApprovalProjectionDeniedRecordIds(query, sheetId, userId)
+  if (projection.isProjection) {
+    for (const id of projection.denied) denied.add(id)
+  }
   return denied
 }
 
@@ -1445,9 +1540,16 @@ export async function filterReadableSheetRowsForAccess<T extends { id: string }>
   // A: exclude approval projection sheets from a non-admin's readable/listing set (admins returned above).
   // This is the shared sheet-listing gate (base list + sheet lists), so it also hides the projection BASE
   // from a non-admin's base list (a base surfaces only if it has ≥1 readable sheet).
+  // T36-1 (Plan A): PARTICIPANTS (≥1 projection row carrying their id) keep their sheets in the
+  // listing — their rows are then narrowed by the row-deny choke. Non-participants keep the full
+  // fence: the sheet (and hence the base) never surfaces. Fail-closed: participant lookup errors
+  // resolve to non-participant.
   const projectionSheetIds = await loadApprovalProjectionSheetIds(query, sheetRows.map((row) => String(row.id)))
+  const participantSheetIds = projectionSheetIds.size > 0
+    ? await loadApprovalProjectionParticipantSheetIds(query, Array.from(projectionSheetIds), access.userId)
+    : new Set<string>()
   return sheetRows.filter((row) =>
-    !projectionSheetIds.has(String(row.id)) &&
+    (!projectionSheetIds.has(String(row.id)) || participantSheetIds.has(String(row.id))) &&
     canReadWithSheetGrant(
       effectiveCapabilities,
       scopeMap.get(String(row.id)),
@@ -1484,10 +1586,12 @@ export async function resolveSheetCapabilities(
   const scopeMap = await loadSheetPermissionScopeMap(query, [sheetId], access.userId)
   const sheetScope = scopeMap.get(sheetId)
   let capabilities = applyContextSheetSchemaWriteGrant(baseCapabilities, sheetScope, access.isAdminRole)
-  // A: the approval projection base is admin-only — a non-admin with global `multitable:read` is denied
-  // read/export/write on its sheets + records (fail-closed at this shared read choke).
+  // A + T36-1 (Plan A): the approval projection base stays admin-only on the write/manage plane;
+  // a non-admin PARTICIPANT keeps the read plane (rows narrowed to their own by the row-deny
+  // choke), any other non-admin keeps the original full fence (fail-closed on lookup errors).
   if (!access.isAdminRole && (await loadApprovalProjectionSheetIds(query, [sheetId])).has(sheetId)) {
-    capabilities = restrictApprovalProjectionCapabilities(capabilities, true, false)
+    const isParticipant = (await loadApprovalProjectionParticipantSheetIds(query, [sheetId], access.userId)).has(sheetId)
+    capabilities = restrictApprovalProjectionCapabilitiesPerRow(capabilities, true, false, isParticipant)
   }
   return {
     access,

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -962,6 +962,25 @@ export async function loadApprovalProjectionParticipantSheetIds(
 }
 
 /**
+ * T36-1 review P1: record-level read deny for the Yjs auth gate. Sheet-level `canRead` is not
+ * enough once participants exist — a participant on ONE projection row must not subscribe to
+ * OTHER rows' Y.Docs (the doc seeder loads the record's full `data`). Gates internally on
+ * `loadRowLevelReadDenyEnabled` so generic flag-off sheets pay zero extra queries; callers pass
+ * non-admin actors only (admins bypass at the call site, same convention as every deny consumer).
+ * DENY-WINS: any unexpected error propagates (the adapter's auth check fails closed to no-access).
+ */
+export async function isRecordReadDeniedForUser(
+  query: QueryFn,
+  sheetId: string,
+  recordId: string,
+  userId: string,
+): Promise<boolean> {
+  if (!sheetId || !recordId) return true
+  if (!(await loadRowLevelReadDenyEnabled(query, sheetId))) return false
+  return (await loadDeniedRecordIds(query, sheetId, userId)).has(recordId)
+}
+
+/**
  * T36-1 (Plan A): for a projection sheet, the record ids `userId` may NOT read — every row where
  * they are neither the requester nor the terminal decider. NULL/missing participant fields never
  * match the actor, so corrupt rows land in the denied set (fail-closed, lock §3). Returns empty
@@ -1279,6 +1298,13 @@ export async function hasRecordPermissionAssignments(
   // (never a 500). record_permissions above stays unconditional (it is not flag-gated); only the 2b rule
   // check is gated here.
   if (!(await loadRowLevelReadDenyEnabled(query, sheetId))) return false
+  // T36-1 review P1: the MAIN record-read surfaces (view/list/single-GET/record-history/AI
+  // preview) gate their row filtering on THIS predicate — and a projection sheet has neither
+  // record_permissions rows nor conditional rules, so without this branch the entire filter
+  // block is skipped and a participant reads every other user's projection rows. Projection
+  // sheets therefore ALWAYS report assignments (their per-row participant scopes are synthesized
+  // by loadRecordPermissionScopeMap / loadDeniedRecordIds).
+  if ((await loadApprovalProjectionSheetIds(query, [sheetId])).has(sheetId)) return true
   try {
     const r = await query(
       `SELECT 1 FROM meta_sheets WHERE id = $1 AND jsonb_array_length(COALESCE(conditional_read_rules, '[]'::jsonb)) > 0 LIMIT 1`,

--- a/packages/core-backend/src/multitable/sheet-capabilities.ts
+++ b/packages/core-backend/src/multitable/sheet-capabilities.ts
@@ -5,7 +5,7 @@
  */
 
 import { listUserPermissions, isAdmin } from '../rbac/service'
-import { APPROVAL_PROJECTION_BASE_ID, restrictApprovalProjectionCapabilities } from './approval-projection-constants'
+import { APPROVAL_PROJECTION_BASE_ID, restrictApprovalProjectionCapabilitiesPerRow } from './approval-projection-constants'
 
 // ── Permission code sets ────────────────────────────────────────────
 
@@ -254,7 +254,23 @@ export async function resolveSheetCapabilitiesForUser(
       [[sheetId], APPROVAL_PROJECTION_BASE_ID],
     )
     if ((proj.rows as Array<{ id: string }>).length > 0) {
-      capabilities = restrictApprovalProjectionCapabilities(capabilities, true, false)
+      // T36-1 (Plan A): participants keep the read plane here too (this choke serves the Yjs
+      // bridge + OAPI tokens — read parity with the REST choke, W1-2 G-4). Fail-closed: any
+      // participant-lookup error → full fence.
+      let isParticipant = false
+      try {
+        const participant = await query(
+          `SELECT 1 FROM meta_records
+            WHERE sheet_id = $1
+              AND (data->>'requesterId' = $2 OR data->>'approverId' = $2)
+            LIMIT 1`,
+          [sheetId, userId],
+        )
+        isParticipant = participant.rows.length > 0
+      } catch {
+        isParticipant = false
+      }
+      capabilities = restrictApprovalProjectionCapabilitiesPerRow(capabilities, true, false, isParticipant)
     }
   }
   return {

--- a/packages/core-backend/tests/integration/approval-projection-participant-read.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-projection-participant-read.db.test.ts
@@ -1,0 +1,137 @@
+/**
+ * T36-1 — approval projection per-row participant read (design-lock RATIFIED Plan A, 2026-07-07).
+ *
+ * The #3537 fence made the projection base admin-only at three chokes. Plan A opens the READ plane
+ * per-row to PARTICIPANTS (a row carries their id as requesterId or approverId) while keeping:
+ * the full fence for non-participants (no drift), the write/manage denial for every non-admin, and
+ * fail-closed handling of rows with missing/corrupt participant fields. Row narrowing rides the
+ * W1-2-locked deny choke (loadRowLevelReadDenyEnabled + loadDeniedRecordIds), so every consumer
+ * surface (records:read routes, export, history) inherits it.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { Request } from 'express'
+import { pool } from '../../src/db/pg'
+import {
+  resolveSheetCapabilities,
+  filterReadableSheetRowsForAccess,
+  loadRowLevelReadDenyEnabled,
+  loadDeniedRecordIds,
+  loadRecordPermissionScopeMap,
+  loadApprovalProjectionParticipantSheetIds,
+} from '../../src/multitable/permission-service'
+import { resolveSheetCapabilitiesForUser } from '../../src/multitable/sheet-capabilities'
+import { resolveRequestAccess } from '../../src/multitable/access'
+import { APPROVAL_PROJECTION_BASE_ID } from '../../src/multitable/approval-projection-constants'
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => pool.query(sql, params)
+
+const TS = Date.now()
+const PROJ_SHEET = `sheet_apr_proj_t361_${TS}`
+const REC_MINE_REQ = `rec_t361_mine_req_${TS}` // requester = participant actor
+const REC_MINE_DEC = `rec_t361_mine_dec_${TS}` // terminal decider = participant actor
+const REC_OTHER = `rec_t361_other_${TS}` // someone else's row
+const REC_CORRUPT = `rec_t361_corrupt_${TS}` // no participant fields at all (fail-closed)
+
+const PARTICIPANT = `u_t361_part_${TS}`
+const STRANGER = `u_t361_stranger_${TS}`
+
+const participantReq = { user: { id: PARTICIPANT, perms: ['multitable:read'] } } as unknown as Request
+const strangerReq = { user: { id: STRANGER, perms: ['multitable:read'] } } as unknown as Request
+const adminReq = { user: { id: `u_t361_admin_${TS}`, roles: ['admin'] } } as unknown as Request
+// A participant who ALSO holds write perms — write/manage must still be denied (system read-model).
+const writerParticipantReq = { user: { id: PARTICIPANT, perms: ['multitable:write', 'workflow:write'] } } as unknown as Request
+
+describeIfDb('T36-1 — projection per-row participant read (Plan A)', () => {
+  beforeAll(async () => {
+    await q(`INSERT INTO meta_bases (id, name, icon, color, owner_id, workspace_id)
+             VALUES ($1,'Approval Projection','','', 'system:approval-projection', NULL) ON CONFLICT (id) DO NOTHING`,
+      [APPROVAL_PROJECTION_BASE_ID])
+    await q(`INSERT INTO meta_sheets (id, base_id, name, description) VALUES ($1,$2,'ProjT361','') ON CONFLICT (id) DO NOTHING`,
+      [PROJ_SHEET, APPROVAL_PROJECTION_BASE_ID])
+    const insert = (id: string, data: Record<string, unknown>) =>
+      q(`INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
+         VALUES ($1,$2,$3::jsonb,1,'system:approval-projection','system:approval-projection') ON CONFLICT (id) DO NOTHING`,
+        [id, PROJ_SHEET, JSON.stringify(data)])
+    await insert(REC_MINE_REQ, { status: 'approved', requesterId: PARTICIPANT, approverId: 'someone_else' })
+    await insert(REC_MINE_DEC, { status: 'rejected', requesterId: 'someone_else', approverId: PARTICIPANT })
+    await insert(REC_OTHER, { status: 'approved', requesterId: 'someone_else', approverId: 'another_one' })
+    await insert(REC_CORRUPT, { status: 'approved' })
+    // The Yjs/OAPI choke (resolveSheetCapabilitiesForUser) loads permissions from rbac, not from a
+    // req mock — seed REAL users + multitable:read grants for both actors (file-namespaced ids).
+    for (const uid of [PARTICIPANT, STRANGER]) {
+      await q(`INSERT INTO users (id, name, password_hash, role) VALUES ($1,$1,'x','user') ON CONFLICT (id) DO NOTHING`, [uid])
+      await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'multitable:read') ON CONFLICT DO NOTHING`, [uid])
+    }
+  })
+
+  afterAll(async () => {
+    await q(`DELETE FROM meta_records WHERE sheet_id = $1`, [PROJ_SHEET]).catch(() => {})
+    await q(`DELETE FROM meta_sheets WHERE id = $1`, [PROJ_SHEET]).catch(() => {})
+    await q(`DELETE FROM user_permissions WHERE user_id = ANY($1::text[])`, [[PARTICIPANT, STRANGER]]).catch(() => {})
+    await q(`DELETE FROM users WHERE id = ANY($1::text[])`, [[PARTICIPANT, STRANGER]]).catch(() => {})
+  })
+
+  it('sentinel: DATABASE_URL is set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  it('participant helper: participant detected, stranger not, fail-closed on empty user', async () => {
+    expect((await loadApprovalProjectionParticipantSheetIds(q, [PROJ_SHEET], PARTICIPANT)).has(PROJ_SHEET)).toBe(true)
+    expect((await loadApprovalProjectionParticipantSheetIds(q, [PROJ_SHEET], STRANGER)).has(PROJ_SHEET)).toBe(false)
+    expect((await loadApprovalProjectionParticipantSheetIds(q, [PROJ_SHEET], '')).size).toBe(0)
+  })
+
+  it('capabilities: participant gets READ (+export) only; stranger keeps the full #3537 fence', async () => {
+    const part = await resolveSheetCapabilities(participantReq, q, PROJ_SHEET)
+    expect(part.capabilities.canRead).toBe(true)
+    expect(part.capabilities.canExport).toBe(true)
+    const stranger = await resolveSheetCapabilities(strangerReq, q, PROJ_SHEET)
+    expect(stranger.capabilities.canRead).toBe(false) // RED-before: flipping the predicate off must restore this
+    expect(stranger.capabilities.canExport).toBe(false)
+  })
+
+  it('capabilities: a PARTICIPANT with write perms still has zero write/manage plane (#3537 not weakened)', async () => {
+    const cap = await resolveSheetCapabilities(writerParticipantReq, q, PROJ_SHEET)
+    for (const key of ['canCreateRecord', 'canEditRecord', 'canDeleteRecord', 'canManageFields', 'canManageSheetAccess', 'canManageViews', 'canManageAutomation', 'canSendNotification'] as const) {
+      expect(cap.capabilities[key]).toBe(false)
+    }
+    expect(cap.capabilities.canRead).toBe(true)
+  })
+
+  it('row-deny choke: projection sheet is ALWAYS row-level gated; denied set = every non-participant row', async () => {
+    expect(await loadRowLevelReadDenyEnabled(q, PROJ_SHEET)).toBe(true)
+    const denied = await loadDeniedRecordIds(q, PROJ_SHEET, PARTICIPANT)
+    expect(denied.has(REC_MINE_REQ)).toBe(false) // my request — readable
+    expect(denied.has(REC_MINE_DEC)).toBe(false) // my terminal decision — readable
+    expect(denied.has(REC_OTHER)).toBe(true) // someone else's — denied
+    expect(denied.has(REC_CORRUPT)).toBe(true) // missing participant fields — fail-closed denied
+  })
+
+  it('scope map: non-participant rows carry a synthetic none (DENY-WINS) for the derive read paths', async () => {
+    const scopes = await loadRecordPermissionScopeMap(q, PROJ_SHEET, [REC_MINE_REQ, REC_OTHER, REC_CORRUPT], PARTICIPANT)
+    expect(scopes.get(REC_OTHER)?.accessLevel).toBe('none')
+    expect(scopes.get(REC_CORRUPT)?.accessLevel).toBe('none')
+    expect(scopes.get(REC_MINE_REQ)?.accessLevel ?? 'unset').not.toBe('none')
+  })
+
+  it('listing: participant sees the projection sheet (base surfaces); stranger does not', async () => {
+    const rows = [{ id: PROJ_SHEET, base_id: APPROVAL_PROJECTION_BASE_ID }]
+    const partVisible = await filterReadableSheetRowsForAccess(q, rows, await resolveRequestAccess(participantReq))
+    expect(partVisible.map((r) => r.id)).toEqual([PROJ_SHEET])
+    const strangerVisible = await filterReadableSheetRowsForAccess(q, rows, await resolveRequestAccess(strangerReq))
+    expect(strangerVisible).toEqual([])
+  })
+
+  it('Yjs/OAPI choke (resolveSheetCapabilitiesForUser): read parity with the REST choke', async () => {
+    const part = await resolveSheetCapabilitiesForUser(q, PROJ_SHEET, PARTICIPANT)
+    expect(part.capabilities.canRead).toBe(true)
+    expect(part.capabilities.canEditRecord).toBe(false)
+    const stranger = await resolveSheetCapabilitiesForUser(q, PROJ_SHEET, STRANGER)
+    expect(stranger.capabilities.canRead).toBe(false)
+  })
+
+  it('admin: full read, no row denial (regression of the #3537 admin path)', async () => {
+    const cap = await resolveSheetCapabilities(adminReq, q, PROJ_SHEET)
+    expect(cap.capabilities.canRead).toBe(true)
+    // Admin bypass happens at the choke call sites; the raw denied set is actor-relative by design.
+  })
+})

--- a/packages/core-backend/tests/integration/approval-projection-participant-read.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-projection-participant-read.db.test.ts
@@ -11,6 +11,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import type { Request } from 'express'
 import { pool } from '../../src/db/pg'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import {
   resolveSheetCapabilities,
   filterReadableSheetRowsForAccess,
@@ -18,8 +20,11 @@ import {
   loadDeniedRecordIds,
   loadRecordPermissionScopeMap,
   loadApprovalProjectionParticipantSheetIds,
+  isRecordReadDeniedForUser,
 } from '../../src/multitable/permission-service'
 import { resolveSheetCapabilitiesForUser } from '../../src/multitable/sheet-capabilities'
+import { hasRecordPermissionAssignments } from '../../src/multitable/permission-service'
+import { requireRecordReadable } from '../../src/routes/univer-meta'
 import { resolveRequestAccess } from '../../src/multitable/access'
 import { APPROVAL_PROJECTION_BASE_ID } from '../../src/multitable/approval-projection-constants'
 
@@ -113,12 +118,20 @@ describeIfDb('T36-1 — projection per-row participant read (Plan A)', () => {
     expect(scopes.get(REC_MINE_REQ)?.accessLevel ?? 'unset').not.toBe('none')
   })
 
-  it('listing: participant sees the projection sheet (base surfaces); stranger does not', async () => {
-    const rows = [{ id: PROJ_SHEET, base_id: APPROVAL_PROJECTION_BASE_ID }]
-    const partVisible = await filterReadableSheetRowsForAccess(q, rows, await resolveRequestAccess(participantReq))
-    expect(partVisible.map((r) => r.id)).toEqual([PROJ_SHEET])
-    const strangerVisible = await filterReadableSheetRowsForAccess(q, rows, await resolveRequestAccess(strangerReq))
-    expect(strangerVisible).toEqual([])
+  it('listing: participant sees the projection sheet (base surfaces); stranger does not; sibling projection sheet without their rows stays hidden', async () => {
+    const SIBLING = `${PROJ_SHEET}_sibling`
+    await q(`INSERT INTO meta_sheets (id, base_id, name, description) VALUES ($1,$2,'ProjT361Sib','') ON CONFLICT (id) DO NOTHING`,
+      [SIBLING, APPROVAL_PROJECTION_BASE_ID])
+    try {
+      const rows = [{ id: PROJ_SHEET, base_id: APPROVAL_PROJECTION_BASE_ID }, { id: SIBLING, base_id: APPROVAL_PROJECTION_BASE_ID }]
+      const partVisible = await filterReadableSheetRowsForAccess(q, rows, await resolveRequestAccess(participantReq))
+      // Participant status is PER-SHEET: sheet B of the same base without their rows stays hidden.
+      expect(partVisible.map((r) => r.id)).toEqual([PROJ_SHEET])
+      const strangerVisible = await filterReadableSheetRowsForAccess(q, rows, await resolveRequestAccess(strangerReq))
+      expect(strangerVisible).toEqual([])
+    } finally {
+      await q(`DELETE FROM meta_sheets WHERE id = $1`, [SIBLING]).catch(() => {})
+    }
   })
 
   it('Yjs/OAPI choke (resolveSheetCapabilitiesForUser): read parity with the REST choke', async () => {
@@ -127,6 +140,51 @@ describeIfDb('T36-1 — projection per-row participant read (Plan A)', () => {
     expect(part.capabilities.canEditRecord).toBe(false)
     const stranger = await resolveSheetCapabilitiesForUser(q, PROJ_SHEET, STRANGER)
     expect(stranger.capabilities.canRead).toBe(false)
+  })
+
+  it('WIRE (review P1): the main record-read gate row-filters projection sheets — participant reads own record, 403 on others', async () => {
+    // The view/list/single-GET surfaces gate their row filtering on hasRecordPermissionAssignments,
+    // which is false for projection sheets by nature (no record_permissions rows, no conditional
+    // rules) — without the projection branch the whole filter block is skipped and this test's
+    // 403 assertions go RED (the exact fake-green the choke-only tests missed).
+    expect(await hasRecordPermissionAssignments(q, PROJ_SHEET)).toBe(true)
+
+    const own = await requireRecordReadable(participantReq, q, PROJ_SHEET, REC_MINE_REQ)
+    expect('status' in own).toBe(false) // readable — no error envelope
+
+    const other = await requireRecordReadable(participantReq, q, PROJ_SHEET, REC_OTHER)
+    expect('status' in other && (other as { status: number }).status).toBe(403)
+
+    const corrupt = await requireRecordReadable(participantReq, q, PROJ_SHEET, REC_CORRUPT)
+    expect('status' in corrupt && (corrupt as { status: number }).status).toBe(403)
+
+    const stranger = await requireRecordReadable(strangerReq, q, PROJ_SHEET, REC_OTHER)
+    expect('status' in stranger && (stranger as { status: number }).status).toBe(403)
+
+    const admin = await requireRecordReadable(adminReq, q, PROJ_SHEET, REC_OTHER)
+    expect('status' in admin).toBe(false) // admin unaffected
+  })
+
+  it('Yjs record auth (review P1): own record subscribable, others/corrupt records denied at record level', async () => {
+    // The Yjs doc seeder loads a record's FULL data — sheet-level canRead is not sufficient.
+    expect(await isRecordReadDeniedForUser(q, PROJ_SHEET, REC_MINE_REQ, PARTICIPANT)).toBe(false)
+    expect(await isRecordReadDeniedForUser(q, PROJ_SHEET, REC_MINE_DEC, PARTICIPANT)).toBe(false)
+    expect(await isRecordReadDeniedForUser(q, PROJ_SHEET, REC_OTHER, PARTICIPANT)).toBe(true)
+    expect(await isRecordReadDeniedForUser(q, PROJ_SHEET, REC_CORRUPT, PARTICIPANT)).toBe(true)
+    // Missing ids fail closed.
+    expect(await isRecordReadDeniedForUser(q, PROJ_SHEET, '', PARTICIPANT)).toBe(true)
+    expect(await isRecordReadDeniedForUser(q, '', REC_OTHER, PARTICIPANT)).toBe(true)
+  })
+
+  it('Yjs record auth (review P1): index.ts authChecker wires the record-level deny (source tripwire)', () => {
+    // The authChecker is a closure inside the server bootstrap — pin the wiring statically so a
+    // refactor cannot silently drop the record-level rung while sheet-level canRead stays green.
+    const src = readFileSync(resolve(__dirname, '../../src/index.ts'), 'utf8')
+    const checkerStart = src.indexOf('setAuthChecker')
+    expect(checkerStart).toBeGreaterThan(-1)
+    const checkerBody = src.slice(checkerStart, checkerStart + 2400)
+    expect(checkerBody).toContain('isRecordReadDeniedForUser')
+    expect(checkerBody).toContain("canRead: false, canWrite: false")
   })
 
   it('admin: full read, no row denial (regression of the #3537 admin path)', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
       'tests/integration/automation-dingtalk-approval-card-action.test.ts',
       // A-4 card-delivery wrapper: DATABASE_URL-gated. Same two-point wiring (no skip-green).
       'tests/integration/approval-card-delivery-wrapper.db.test.ts',
+      // T36-1: projection per-row participant read + the #3537 fence goldens (both were previously
+      // wired into NO workflow — skip-green; now run in plugin-tests' approval real-DB step).
+      'tests/integration/approval-projection-visibility.db.test.ts',
+      'tests/integration/approval-projection-participant-read.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
Implements **T36-1** of the ratified per-row visibility lock (#3687, Plan A — owner 2026-07-07). Ordinary users now see THEIR approval outcomes (我发起的 + 我做终态决策的) as multitable rows; everyone else keeps the #3537 admin-only fence bit-for-bit.

## Mechanism (single-choke, all surfaces inherit)
- **Row narrowing rides the W1-2-locked deny choke**: `loadRowLevelReadDenyEnabled` always-on for projection sheets + `loadDeniedRecordIds`/`loadRecordPermissionScopeMap` union in non-participant rows (DENY-WINS) → the 5 records:read routes, export and history inherit narrowing with zero per-surface edits (their choke coverage is already golden-locked).
- **Capabilities**: participants keep `canRead`/`canExport` ONLY; write/fields/views/automation stay denied for every non-admin at all three chokes (REST, Yjs/OAPI `resolveSheetCapabilitiesForUser`, sheet-listing filter). Strangers: full fence, sheet/base never surfaces.
- **Fail-closed hardening the tests caught**: SQL three-valued logic let corrupt rows (missing participant fields) ESCAPE the denied set — `NOT(NULL OR NULL)` is NULL. Closed with COALESCE; empty actor denies all; lookup errors → non-participant; unexpected denied-query errors THROW (read fails, never serves unfiltered rows).

## Verification (fresh DB, migrations from zero)
- New participant suite **9/9** + **#3537 fence goldens 7/7 in the same run** (combined correctness)
- **RED-before mutation**: neutering the participant predicate → exactly the 4 participant tests red, fence stays green (additive, not replacement); reverted
- Generic deny-choke regressions **24/24** (conditional-rule enforce/trash + W1-2 B4 G-7 export⊆read)
- `tsc` 0 · two-point CI wiring — **including the #3537 fence file itself, which was previously wired into NO workflow (skip-green)**

Adversarial review running before merge (security slice). T36-2 (as-built flip + combined regression doc) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)