### PR TITLE
feat(web): multitable UI P2-1b — MtMenu/MtPopover/MtPanel + primitive tests + P2 lock→RATIFIED

### DIFF
--- a/apps/web/src/multitable/ui/MtMenu.vue
+++ b/apps/web/src/multitable/ui/MtMenu.vue
@@ -1,0 +1,48 @@
+<template>
+  <MtPopover v-model:open="isOpen" :placement="placement">
+    <template #trigger="slotProps">
+      <slot name="trigger" v-bind="slotProps" />
+    </template>
+    <div class="mt-menu" role="menu">
+      <slot />
+    </div>
+  </MtPopover>
+</template>
+
+<script setup lang="ts">
+// MtMenu — P2-1b shared UI primitive (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1).
+// A trigger + dropdown list of <MtMenuItem> children, built on <MtPopover> so it inherits its
+// Teleport-safety, click-outside, and Escape-to-close for free (rather than re-implementing the
+// existing `ContextMenu.vue` idiom a second time). Presentation-only: no business logic, no data
+// fetching. Consumes ONLY UF-1 `--ms-*` tokens (design-lock §8 / §3.1).
+//
+// Composition is slot-based, not a data-driven `items` array: put <MtMenuItem>/dividers as
+// children, same as any other menu-of-rows component. Selecting an item (its `select` emit)
+// closes the menu automatically via the MT_MENU_CLOSE_KEY provide/inject contract in
+// `menuContext.ts` — MtMenu never inspects its slotted vnodes to do this.
+import { provide, ref } from 'vue'
+import MtPopover, { type MtPopoverPlacement } from './MtPopover.vue'
+import { MT_MENU_CLOSE_KEY } from './menuContext'
+
+withDefaults(defineProps<{
+  placement?: MtPopoverPlacement
+}>(), {
+  placement: 'bottom-start',
+})
+
+const isOpen = ref(false)
+
+provide(MT_MENU_CLOSE_KEY, () => {
+  isOpen.value = false
+})
+
+defineExpose({ isOpen })
+</script>
+
+<style scoped>
+.mt-menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 160px;
+}
+</style>

--- a/apps/web/src/multitable/ui/MtMenuItem.vue
+++ b/apps/web/src/multitable/ui/MtMenuItem.vue
@@ -1,20 +1,26 @@
 <template>
-  <div
+  <button
+    type="button"
     class="mt-menu-item"
-    :class="{ 'is-disabled': disabled }"
     role="menuitem"
-    :aria-disabled="disabled || undefined"
+    :disabled="disabled"
     @click="handleClick"
   >
     <span v-if="$slots.icon" class="mt-menu-item__icon"><slot name="icon" /></span>
     <span class="mt-menu-item__label"><slot /></span>
-  </div>
+  </button>
 </template>
 
 <script setup lang="ts">
 // MtMenuItem — P2-1b shared UI primitive, a single row inside <MtMenu>. Presentation-only: emits
 // `select` and (when hosted inside an <MtMenu>) asks the menu to close itself; it never runs
 // business logic of its own. Consumes ONLY UF-1 `--ms-*` tokens (design-lock §8 / §3.1).
+//
+// A NATIVE <button> (not a div) so the declared role="menuitem" is honestly keyboard-operable:
+// the browser gives focusability, Enter/Space → click activation, and real `disabled` semantics
+// (removed from the tab order, activation suppressed) for free — no hand-rolled keydown handling,
+// no double-fire risk. This matters because P2-1c migrates existing menus onto this primitive; a
+// keyboard-inoperable "menu" would otherwise propagate.
 import { inject } from 'vue'
 import { MT_MENU_CLOSE_KEY } from './menuContext'
 
@@ -33,6 +39,8 @@ const emit = defineEmits<{
 const closeMenu = inject(MT_MENU_CLOSE_KEY, null)
 
 function handleClick(evt: MouseEvent) {
+  // The native `disabled` attribute already suppresses activation (mouse and keyboard); this guard
+  // is belt-and-suspenders for programmatic dispatch.
   if (props.disabled) return
   emit('select', evt)
   closeMenu?.()
@@ -44,21 +52,34 @@ function handleClick(evt: MouseEvent) {
   display: flex;
   align-items: center;
   gap: var(--ms-space-2);
+  width: 100%;
   min-height: var(--ms-control-height);
   padding: 0 var(--ms-space-3);
+  /* reset native <button> chrome so the row matches the menu surface */
+  border: none;
+  background: transparent;
+  font: inherit;
   font-size: 13px;
+  text-align: left;
   color: var(--ms-text-2);
   cursor: pointer;
   white-space: nowrap;
   user-select: none;
 }
 
-.mt-menu-item:hover:not(.is-disabled) {
+.mt-menu-item:hover:not(:disabled),
+.mt-menu-item:focus-visible {
   background: var(--ms-bg-page);
   color: var(--ms-text-1);
 }
 
-.mt-menu-item.is-disabled {
+/* keyboard focus ring (focus-visible only, so mouse clicks don't show it) */
+.mt-menu-item:focus-visible {
+  outline: 2px solid var(--ms-color-primary);
+  outline-offset: -2px;
+}
+
+.mt-menu-item:disabled {
   color: var(--ms-text-3);
   cursor: not-allowed;
 }

--- a/apps/web/src/multitable/ui/MtMenuItem.vue
+++ b/apps/web/src/multitable/ui/MtMenuItem.vue
@@ -1,0 +1,77 @@
+<template>
+  <div
+    class="mt-menu-item"
+    :class="{ 'is-disabled': disabled }"
+    role="menuitem"
+    :aria-disabled="disabled || undefined"
+    @click="handleClick"
+  >
+    <span v-if="$slots.icon" class="mt-menu-item__icon"><slot name="icon" /></span>
+    <span class="mt-menu-item__label"><slot /></span>
+  </div>
+</template>
+
+<script setup lang="ts">
+// MtMenuItem — P2-1b shared UI primitive, a single row inside <MtMenu>. Presentation-only: emits
+// `select` and (when hosted inside an <MtMenu>) asks the menu to close itself; it never runs
+// business logic of its own. Consumes ONLY UF-1 `--ms-*` tokens (design-lock §8 / §3.1).
+import { inject } from 'vue'
+import { MT_MENU_CLOSE_KEY } from './menuContext'
+
+const props = withDefaults(defineProps<{
+  disabled?: boolean
+}>(), {
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  (e: 'select', evt: MouseEvent): void
+}>()
+
+// Optional — MtMenuItem also renders sensibly standalone (e.g. inside a hand-rolled popover)
+// where there is no ancestor <MtMenu> providing a close callback.
+const closeMenu = inject(MT_MENU_CLOSE_KEY, null)
+
+function handleClick(evt: MouseEvent) {
+  if (props.disabled) return
+  emit('select', evt)
+  closeMenu?.()
+}
+</script>
+
+<style scoped>
+.mt-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-2);
+  min-height: var(--ms-control-height);
+  padding: 0 var(--ms-space-3);
+  font-size: 13px;
+  color: var(--ms-text-2);
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.mt-menu-item:hover:not(.is-disabled) {
+  background: var(--ms-bg-page);
+  color: var(--ms-text-1);
+}
+
+.mt-menu-item.is-disabled {
+  color: var(--ms-text-3);
+  cursor: not-allowed;
+}
+
+.mt-menu-item__icon {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+}
+
+.mt-menu-item__label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/apps/web/src/multitable/ui/MtPanel.vue
+++ b/apps/web/src/multitable/ui/MtPanel.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="mt-panel" :class="[`mt-panel--${padding}`, { 'mt-panel--shadow': shadow }]">
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+// MtPanel — P2-1b shared UI primitive (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1).
+// A simple token-styled container card for grouping content (border/radius/bg, optional shadow).
+// Presentation-only: no business logic, no data fetching. Consumes ONLY UF-1 `--ms-*` tokens
+// (design-lock §8 / §3.1) — never introduce a new hardcoded hex here.
+export type MtPanelPadding = 'none' | 'sm' | 'md'
+
+withDefaults(defineProps<{
+  padding?: MtPanelPadding
+  shadow?: boolean
+}>(), {
+  padding: 'md',
+  shadow: false,
+})
+</script>
+
+<style scoped>
+.mt-panel {
+  box-sizing: border-box;
+  background: var(--ms-bg-card);
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-md);
+}
+
+.mt-panel--shadow {
+  box-shadow: var(--ms-shadow-card);
+}
+
+.mt-panel--none {
+  padding: 0;
+}
+
+.mt-panel--sm {
+  padding: var(--ms-space-2);
+}
+
+.mt-panel--md {
+  padding: var(--ms-space-4);
+}
+</style>

--- a/apps/web/src/multitable/ui/MtPopover.vue
+++ b/apps/web/src/multitable/ui/MtPopover.vue
@@ -1,0 +1,134 @@
+<template>
+  <span ref="triggerRef" class="mt-popover__trigger" @click="handleTriggerClick">
+    <slot name="trigger" :open="open" />
+  </span>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      ref="panelRef"
+      class="mt-popover"
+      :style="panelStyle"
+      @click.stop
+    >
+      <slot />
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+// MtPopover — P2-1b shared UI primitive (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1).
+// A token-styled floating panel anchored to a trigger slot, Teleport-safe (renders its content to
+// `body` so it is never clipped by an ancestor's `overflow: hidden`, matching the existing
+// `ContextMenu.vue` idiom — see its `Teleport to="body"` + click-outside/Escape handling, which
+// this mirrors). Presentation-only: no business logic, no data fetching. Consumes ONLY UF-1
+// `--ms-*` tokens (design-lock §8 / §3.1) — never introduce a new hardcoded hex here.
+//
+// Controlled via `open` + `update:open` (usable as `v-model:open`). Clicking the trigger toggles
+// `open`; clicking outside the trigger+panel or pressing Escape while open closes it. MtMenu builds
+// on top of this for its trigger+dropdown-list composition.
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+
+export type MtPopoverPlacement = 'bottom-start' | 'bottom-end' | 'top-start' | 'top-end'
+
+const props = withDefaults(defineProps<{
+  open?: boolean
+  placement?: MtPopoverPlacement
+}>(), {
+  open: false,
+  placement: 'bottom-start',
+})
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void
+}>()
+
+const triggerRef = ref<HTMLElement | null>(null)
+const panelRef = ref<HTMLElement | null>(null)
+const panelStyle = ref<Record<string, string>>({ top: '0px', left: '0px' })
+
+function handleTriggerClick(evt: MouseEvent) {
+  evt.stopPropagation()
+  emit('update:open', !props.open)
+}
+
+function close() {
+  if (props.open) emit('update:open', false)
+}
+
+function computePosition() {
+  const trigger = triggerRef.value
+  if (!trigger) return
+  const rect = trigger.getBoundingClientRect()
+  const panelRect = panelRef.value?.getBoundingClientRect()
+  const panelWidth = panelRect?.width ?? 0
+  const panelHeight = panelRect?.height ?? 0
+
+  let top = props.placement.startsWith('top') ? rect.top - panelHeight - 4 : rect.bottom + 4
+  let left = props.placement.endsWith('end') ? rect.right - panelWidth : rect.left
+
+  // Clamp to the viewport the same way ContextMenu.vue does, so the panel never renders
+  // partially off-screen near an edge.
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+  if (left + panelWidth > viewportWidth) left = Math.max(0, viewportWidth - panelWidth - 8)
+  if (left < 0) left = 8
+  if (top + panelHeight > viewportHeight) top = Math.max(0, viewportHeight - panelHeight - 8)
+
+  panelStyle.value = { top: `${top}px`, left: `${left}px` }
+}
+
+function handleClickOutside(evt: MouseEvent) {
+  const target = evt.target as Node
+  if (triggerRef.value?.contains(target)) return
+  if (panelRef.value?.contains(target)) return
+  close()
+}
+
+function handleEscape(evt: KeyboardEvent) {
+  if (evt.key === 'Escape') close()
+}
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (isOpen) {
+      // Attach the outside-click/Escape listeners synchronously — they don't need the panel to
+      // be in the DOM yet, and a test (or a very fast real interaction) dispatching an event right
+      // after `open` flips true must not race an `await nextTick()` here. Only the position
+      // calculation, which reads the panel's rendered layout, needs to wait a tick.
+      document.addEventListener('mousedown', handleClickOutside)
+      document.addEventListener('keydown', handleEscape)
+      nextTick(() => computePosition())
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  },
+  { immediate: true },
+)
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', handleClickOutside)
+  document.removeEventListener('keydown', handleEscape)
+})
+
+defineExpose({ close })
+</script>
+
+<style scoped>
+.mt-popover__trigger {
+  display: inline-flex;
+}
+
+.mt-popover {
+  position: fixed;
+  z-index: 2000;
+  min-width: 160px;
+  box-sizing: border-box;
+  background: var(--ms-bg-card);
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-md);
+  box-shadow: var(--ms-shadow-pop);
+  padding: var(--ms-space-1) 0;
+}
+</style>

--- a/apps/web/src/multitable/ui/README.md
+++ b/apps/web/src/multitable/ui/README.md
@@ -1,15 +1,15 @@
-# multitable/ui — shared UI primitives (P2-1a)
+# multitable/ui — shared UI primitives (P2-1a + P2-1b)
 
 Design-lock: `docs/development/multitable-ui-p2-structure-designlock-20260706.md` §2 P2-1.
 
 These are stateless, presentation-only primitives meant to replace the per-SFC bespoke-CSS
-buttons/badges scattered across `apps/web/src/multitable/components/` and `views/`. They consume
-**only** UF-1 design tokens (`apps/web/src/styles/tokens.css`, `--ms-*` / `--el-*`) — never a new
-hardcoded hex, never a new token vocabulary.
+buttons/badges/menus/panels scattered across `apps/web/src/multitable/components/` and `views/`.
+They consume **only** UF-1 design tokens (`apps/web/src/styles/tokens.css`, `--ms-*` / `--el-*`) —
+never a new hardcoded hex, never a new token vocabulary.
 
-This slice (P2-1a) is **additive only**: no existing component has been migrated to use these yet.
-Migration is a separate, later slice (P2-1c), one SFC's buttons/badges at a time, presentation-only
-and click/emit-count-preserving.
+Both slices are **additive only**: no existing component has been migrated to use these yet.
+Migration is a separate, later slice (P2-1c), one SFC's buttons/badges/panels at a time,
+presentation-only and click/emit-count-preserving.
 
 ## MtButton
 
@@ -114,9 +114,110 @@ Props:
 | `dot` | `boolean` | `false` | renders a small solid dot instead of the count |
 | `tone` | `'info' \| 'primary' \| 'success' \| 'warning' \| 'danger'` | `'info'` | maps to `--ms-color-*` / `--el-color-*-light-9` |
 
+## MtPopover
+
+A token-styled floating panel anchored to a trigger slot, Teleport'd to `body` (never clipped by
+an ancestor's `overflow: hidden`) — mirrors the existing `ContextMenu.vue` idiom (Teleport +
+click-outside + Escape) but anchors to a trigger element instead of raw `x`/`y` coordinates.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { MtPopover, MtButton } from '@/multitable/ui'
+
+const open = ref(false)
+</script>
+
+<template>
+  <MtPopover v-model:open="open">
+    <template #trigger>
+      <MtButton>Open</MtButton>
+    </template>
+    <div style="padding: 8px 12px;">Popover content</div>
+  </MtPopover>
+</template>
+```
+
+Props:
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `open` | `boolean` | `false` | controlled — pair with `v-model:open` |
+| `placement` | `'bottom-start' \| 'bottom-end' \| 'top-start' \| 'top-end'` | `'bottom-start'` | anchor corner relative to the trigger |
+
+Slots: `trigger` (scoped with `{ open }`), default (panel content).
+Emits: `update:open(value: boolean)` — fired when the trigger is clicked (toggles), a click lands
+outside both the trigger and the panel, or Escape is pressed while open.
+
+## MtMenu / MtMenuItem
+
+A trigger + dropdown list of `MtMenuItem` rows, built on `MtPopover` (so it inherits Teleport-safety
++ click-outside + Escape for free instead of re-implementing `ContextMenu.vue`'s mechanics a second
+time). Composition is **slot-based**, not a data-driven `items` array — put `MtMenuItem`s (and any
+dividers you want) directly in the default slot, same as any other menu-of-rows component.
+Selecting an item closes the menu automatically (via an internal provide/inject contract in
+`menuContext.ts` — MtMenu never inspects its slotted vnodes to do this).
+
+```vue
+<script setup lang="ts">
+import { MtMenu, MtMenuItem, MtIconButton } from '@/multitable/ui'
+import { Delete, Edit } from '@element-plus/icons-vue'
+</script>
+
+<template>
+  <MtMenu>
+    <template #trigger>
+      <MtIconButton title="More actions" :icon="MoreFilled" />
+    </template>
+    <MtMenuItem @select="onRename">
+      <template #icon><el-icon><Edit /></el-icon></template>
+      Rename
+    </MtMenuItem>
+    <MtMenuItem disabled @select="onDelete">
+      <template #icon><el-icon><Delete /></el-icon></template>
+      Delete
+    </MtMenuItem>
+  </MtMenu>
+</template>
+```
+
+`MtMenu` props: `placement` (same type as `MtPopover`, default `'bottom-start'`).
+`MtMenu` slots: `trigger`, default (menu items).
+
+`MtMenuItem` props: `disabled?: boolean` (default `false`) — a disabled item never emits `select`
+and never closes the menu.
+`MtMenuItem` slots: default (label), `icon` (optional, leading).
+`MtMenuItem` emits: `select(evt: MouseEvent)`.
+
+## MtPanel
+
+A small token-styled container card for grouping content — border/radius/background, optional
+shadow.
+
+```vue
+<script setup lang="ts">
+import { MtPanel } from '@/multitable/ui'
+</script>
+
+<template>
+  <MtPanel shadow padding="sm">
+    <div>Grouped content</div>
+  </MtPanel>
+</template>
+```
+
+Props:
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `padding` | `'none' \| 'sm' \| 'md'` | `'md'` | inner padding, from the `--ms-space-*` scale |
+| `shadow` | `boolean` | `false` | adds `--ms-shadow-card` |
+
+Slots: default (content).
+
 ## Token discipline
 
-Every color declaration in these three components is a `var(--ms-*)` or `var(--el-*)` reference —
+Every color declaration in these components is a `var(--ms-*)` or `var(--el-*)` reference —
 no hex/rgb literals, including as `var(..., #fallback)` fallbacks (the UF-6 style guard closes that
 exact escape hatch for its target file set; these new files hold to the same discipline even though
 they are not yet in that guard's list). Non-color sizing (font-size, gap) that has no dedicated token

--- a/apps/web/src/multitable/ui/README.md
+++ b/apps/web/src/multitable/ui/README.md
@@ -189,6 +189,10 @@ and never closes the menu.
 `MtMenuItem` slots: default (label), `icon` (optional, leading).
 `MtMenuItem` emits: `select(evt: MouseEvent)`.
 
+**A11y:** `MtMenuItem` renders a native `<button type="button" role="menuitem">`, so it is genuinely
+keyboard-operable — focusable, activated by Enter/Space, and `disabled` uses the native attribute
+(tab-skipped, activation suppressed). Do not swap it for a `<div>` when migrating.
+
 ## MtPanel
 
 A small token-styled container card for grouping content — border/radius/background, optional

--- a/apps/web/src/multitable/ui/index.ts
+++ b/apps/web/src/multitable/ui/index.ts
@@ -1,8 +1,16 @@
-// Barrel for the P2-1a shared UI primitives (multitable-ui-p2-structure-designlock-20260706.md §2
-// P2-1). Additive only — nothing here changes any existing component's behavior; migration of
+// Barrel for the P2-1a/P2-1b shared UI primitives (multitable-ui-p2-structure-designlock-20260706.md
+// §2 P2-1). Additive only — nothing here changes any existing component's behavior; migration of
 // existing SFCs onto these primitives is a separate, later slice (P2-1c).
 export { default as MtButton } from './MtButton.vue'
 export type { MtButtonVariant, MtButtonSize } from './MtButton.vue'
 export { default as MtIconButton } from './MtIconButton.vue'
 export { default as MtBadge } from './MtBadge.vue'
 export type { MtBadgeTone } from './MtBadge.vue'
+
+// P2-1b — overlay primitives (Teleport-safe: MtPopover / MtMenu render into `body`).
+export { default as MtPopover } from './MtPopover.vue'
+export type { MtPopoverPlacement } from './MtPopover.vue'
+export { default as MtMenu } from './MtMenu.vue'
+export { default as MtMenuItem } from './MtMenuItem.vue'
+export { default as MtPanel } from './MtPanel.vue'
+export type { MtPanelPadding } from './MtPanel.vue'

--- a/apps/web/src/multitable/ui/menuContext.ts
+++ b/apps/web/src/multitable/ui/menuContext.ts
@@ -1,0 +1,6 @@
+// Shared provide/inject key linking <MtMenu> to its <MtMenuItem> children so selecting an item
+// closes the menu, without MtMenu needing to walk/patch its slotted vnodes. Kept in its own
+// module (not a .vue file) so both components can import the same InjectionKey instance.
+import type { InjectionKey } from 'vue'
+
+export const MT_MENU_CLOSE_KEY: InjectionKey<() => void> = Symbol('mt-menu-close')

--- a/apps/web/tests/multitable-ui-p2-1-primitives.spec.ts
+++ b/apps/web/tests/multitable-ui-p2-1-primitives.spec.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import { Delete } from '@element-plus/icons-vue'
+import MtButton from '../src/multitable/ui/MtButton.vue'
+import MtIconButton from '../src/multitable/ui/MtIconButton.vue'
+import MtBadge from '../src/multitable/ui/MtBadge.vue'
+
+// multitable-ui-p2-structure-designlock-20260706.md §2 P2-1 — runnable interaction/behavior
+// coverage for the shared UI primitives (owner finding: README usage samples alone don't prove
+// the components actually behave; these assert real emit counts + DOM state, not snapshots).
+// P2-1a (MtButton/MtIconButton/MtBadge) landed via #3744 with no component specs of their own —
+// this file is that missing coverage, plus the new P2-1b overlay primitives in the sibling spec.
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+function mount(vnode: Parameters<typeof h>[0], props?: Record<string, unknown>, slots?: Record<string, unknown>) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({ render: () => h(vnode as any, props, slots) })
+  app.mount(container)
+  return container
+}
+
+afterEach(() => {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+})
+
+describe('MtButton', () => {
+  it('renders its label slot', () => {
+    const c = mount(MtButton, {}, { default: () => 'Save' })
+    expect(c.querySelector('.mt-button__label')?.textContent).toBe('Save')
+  })
+
+  it('emits click when enabled', async () => {
+    let clicks = 0
+    const c = mount(MtButton, { onClick: () => { clicks += 1 } }, { default: () => 'Go' })
+    const btn = c.querySelector('button.mt-button') as HTMLButtonElement
+    btn.click()
+    await nextTick()
+    expect(clicks).toBe(1)
+  })
+
+  it('does NOT emit click when disabled', async () => {
+    let clicks = 0
+    const c = mount(MtButton, { disabled: true, onClick: () => { clicks += 1 } }, { default: () => 'Go' })
+    const btn = c.querySelector('button.mt-button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    btn.click()
+    await nextTick()
+    expect(clicks).toBe(0)
+  })
+
+  it('does NOT emit click when loading (loading implies disabled)', async () => {
+    let clicks = 0
+    const c = mount(MtButton, { loading: true, onClick: () => { clicks += 1 } }, { default: () => 'Go' })
+    const btn = c.querySelector('button.mt-button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(c.querySelector('.mt-button__icon--spinner')).not.toBeNull()
+    btn.click()
+    await nextTick()
+    expect(clicks).toBe(0)
+  })
+
+  it('applies the variant and size classes', () => {
+    const c = mount(MtButton, { variant: 'danger', size: 'sm' }, { default: () => 'Delete' })
+    const btn = c.querySelector('button.mt-button') as HTMLButtonElement
+    expect(btn.classList.contains('mt-button--danger')).toBe(true)
+    expect(btn.classList.contains('mt-button--sm')).toBe(true)
+  })
+
+  it('defaults to the ghost variant and md size', () => {
+    const c = mount(MtButton, {}, { default: () => 'Cancel' })
+    const btn = c.querySelector('button.mt-button') as HTMLButtonElement
+    expect(btn.classList.contains('mt-button--ghost')).toBe(true)
+    expect(btn.classList.contains('mt-button--md')).toBe(true)
+  })
+})
+
+describe('MtIconButton', () => {
+  it('renders an icon passed via the `icon` prop', () => {
+    const c = mount(MtIconButton, { icon: Delete, title: 'Delete row' })
+    expect(c.querySelector('.mt-button__icon .el-icon')).not.toBeNull()
+  })
+
+  it('renders an icon passed via the `icon` slot', () => {
+    const c = mount(MtIconButton, { title: 'More' }, { icon: () => h('span', { class: 'my-icon' }) })
+    expect(c.querySelector('.mt-button__icon .my-icon')).not.toBeNull()
+  })
+
+  it('passes title/aria-label through to the rendered <button> (attrs fallthrough)', () => {
+    const c = mount(MtIconButton, { icon: Delete, title: 'Delete row' })
+    const btn = c.querySelector('button.mt-button') as HTMLButtonElement
+    expect(btn.getAttribute('title')).toBe('Delete row')
+    expect(btn.getAttribute('aria-label')).toBe('Delete row')
+  })
+
+  it('ariaLabel overrides title for aria-label specifically', () => {
+    const c = mount(MtIconButton, { icon: Delete, title: 'Delete row', ariaLabel: 'Remove this row' })
+    const btn = c.querySelector('button.mt-button') as HTMLButtonElement
+    expect(btn.getAttribute('title')).toBe('Delete row')
+    expect(btn.getAttribute('aria-label')).toBe('Remove this row')
+  })
+
+  it('emits click when enabled, not when disabled (same gating as MtButton)', async () => {
+    let clicks = 0
+    const c = mount(MtIconButton, { icon: Delete, title: 'Delete', onClick: () => { clicks += 1 } })
+    const btn = c.querySelector('button.mt-button') as HTMLButtonElement
+    btn.click()
+    await nextTick()
+    expect(clicks).toBe(1)
+
+    clicks = 0
+    app?.unmount()
+    container?.remove()
+    const c2 = mount(MtIconButton, { icon: Delete, title: 'Delete', disabled: true, onClick: () => { clicks += 1 } })
+    const btn2 = c2.querySelector('button.mt-button') as HTMLButtonElement
+    btn2.click()
+    await nextTick()
+    expect(clicks).toBe(0)
+  })
+})
+
+describe('MtBadge', () => {
+  it('is hidden when count is 0 and showZero is false (default)', () => {
+    const c = mount(MtBadge, { count: 0 })
+    expect(c.querySelector('.mt-badge')).toBeNull()
+  })
+
+  it('shows a 0 badge when showZero is true', () => {
+    const c = mount(MtBadge, { count: 0, showZero: true })
+    expect(c.querySelector('.mt-badge')?.textContent).toBe('0')
+  })
+
+  it('shows the numeric count', () => {
+    const c = mount(MtBadge, { count: 7, tone: 'danger' })
+    const el = c.querySelector('.mt-badge') as HTMLElement
+    expect(el.textContent).toBe('7')
+    expect(el.classList.contains('mt-badge--danger')).toBe(true)
+  })
+
+  it('caps the displayed count at 99+', () => {
+    const c = mount(MtBadge, { count: 142 })
+    expect(c.querySelector('.mt-badge')?.textContent).toBe('99+')
+  })
+
+  it('renders a dot instead of a count when dot is true (even at count 0)', () => {
+    const c = mount(MtBadge, { dot: true, count: 0, tone: 'success' })
+    const el = c.querySelector('.mt-badge') as HTMLElement
+    expect(el).not.toBeNull()
+    expect(el.classList.contains('mt-badge--dot')).toBe(true)
+    expect(el.classList.contains('mt-badge--success')).toBe(true)
+    expect(el.textContent).toBe('')
+  })
+
+  it.each(['info', 'primary', 'success', 'warning', 'danger'] as const)(
+    'maps tone "%s" to its own modifier class',
+    (tone) => {
+      const c = mount(MtBadge, { count: 1, tone })
+      expect(c.querySelector(`.mt-badge--${tone}`)).not.toBeNull()
+    },
+  )
+})

--- a/apps/web/tests/multitable-ui-p2-1b-overlays.spec.ts
+++ b/apps/web/tests/multitable-ui-p2-1b-overlays.spec.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, ref, type App } from 'vue'
+import MtPopover from '../src/multitable/ui/MtPopover.vue'
+import MtMenu from '../src/multitable/ui/MtMenu.vue'
+import MtMenuItem from '../src/multitable/ui/MtMenuItem.vue'
+import MtPanel from '../src/multitable/ui/MtPanel.vue'
+
+// multitable-ui-p2-structure-designlock-20260706.md §2 P2-1b — runnable interaction/behavior
+// coverage for the new overlay primitives (MtPopover / MtMenu / MtMenuItem / MtPanel). Both
+// MtPopover and MtMenu Teleport their floating content to `document.body`, so assertions query
+// `document` rather than the mount container for that content (mirrors ContextMenu.vue's own
+// Teleport-to-body shape).
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+  // Belt-and-suspenders: nothing Teleported should survive unmount, but guard against a leak
+  // masking a real bug in one test from failing the next.
+  document.querySelectorAll('.mt-popover').forEach((el) => el.remove())
+})
+
+function dispatchOutsideMousedown() {
+  const outside = document.createElement('div')
+  outside.className = 'outside-target'
+  document.body.appendChild(outside)
+  outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+  outside.remove()
+}
+
+describe('MtPopover', () => {
+  it('opens on trigger click and closes again on a second trigger click (v-model:open)', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      setup() {
+        const open = ref(false)
+        return () =>
+          h(
+            MtPopover,
+            { open: open.value, 'onUpdate:open': (v: boolean) => { open.value = v } },
+            {
+              trigger: () => h('button', { class: 'trigger-btn' }, 'Open'),
+              default: () => h('div', { class: 'content' }, 'Popover content'),
+            },
+          )
+      },
+    })
+    app.mount(container)
+    await nextTick()
+
+    expect(document.querySelector('.mt-popover')).toBeNull()
+
+    const trigger = container.querySelector('.trigger-btn') as HTMLButtonElement
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    expect(document.querySelector('.mt-popover .content')?.textContent).toBe('Popover content')
+
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+  })
+
+  it('closes on Escape while open', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      setup() {
+        const open = ref(false)
+        return () =>
+          h(
+            MtPopover,
+            { open: open.value, 'onUpdate:open': (v: boolean) => { open.value = v } },
+            {
+              trigger: () => h('button', { class: 'trigger-btn' }, 'Open'),
+              default: () => h('div', { class: 'content' }, 'Content'),
+            },
+          )
+      },
+    })
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.trigger-btn') as HTMLButtonElement).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+  })
+
+  it('closes on a click outside the trigger and panel', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      setup() {
+        const open = ref(false)
+        return () =>
+          h(
+            MtPopover,
+            { open: open.value, 'onUpdate:open': (v: boolean) => { open.value = v } },
+            {
+              trigger: () => h('button', { class: 'trigger-btn' }, 'Open'),
+              default: () => h('div', { class: 'content' }, 'Content'),
+            },
+          )
+      },
+    })
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.trigger-btn') as HTMLButtonElement).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    dispatchOutsideMousedown()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+  })
+
+  it('a click INSIDE the panel does not close it', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      setup() {
+        const open = ref(false)
+        return () =>
+          h(
+            MtPopover,
+            { open: open.value, 'onUpdate:open': (v: boolean) => { open.value = v } },
+            {
+              trigger: () => h('button', { class: 'trigger-btn' }, 'Open'),
+              default: () => h('div', { class: 'content' }, 'Content'),
+            },
+          )
+      },
+    })
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.trigger-btn') as HTMLButtonElement).click()
+    await nextTick()
+    const content = document.querySelector('.mt-popover .content') as HTMLElement
+    content.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+})
+
+describe('MtMenu / MtMenuItem', () => {
+  function mountMenu(onSelect: () => void, onDisabledSelect: () => void) {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () =>
+        h(
+          MtMenu,
+          {},
+          {
+            trigger: () => h('button', { class: 'trigger-btn' }, 'Actions'),
+            default: () => [
+              h(MtMenuItem, { onSelect }, { default: () => 'Rename' }),
+              h(MtMenuItem, { disabled: true, onSelect: onDisabledSelect }, { default: () => 'Delete' }),
+            ],
+          },
+        ),
+    })
+    app.mount(container!)
+    return container!
+  }
+
+  it('is closed until the trigger is clicked, then shows its MtMenuItem rows', async () => {
+    const c = mountMenu(() => {}, () => {})
+    await nextTick()
+    expect(document.querySelector('.mt-menu')).toBeNull()
+
+    ;(c.querySelector('.trigger-btn') as HTMLButtonElement).click()
+    await nextTick()
+    const menu = document.querySelector('.mt-menu')
+    expect(menu).not.toBeNull()
+    const items = document.querySelectorAll('.mt-menu-item')
+    expect(items.length).toBe(2)
+    expect(items[0].textContent).toContain('Rename')
+    expect(items[1].textContent).toContain('Delete')
+  })
+
+  it('emits select on an enabled item and closes the menu', async () => {
+    let selectCount = 0
+    const c = mountMenu(() => { selectCount += 1 }, () => {})
+    ;(c.querySelector('.trigger-btn') as HTMLButtonElement).click()
+    await nextTick()
+
+    const renameItem = document.querySelectorAll('.mt-menu-item')[0] as HTMLElement
+    renameItem.click()
+    await nextTick()
+
+    expect(selectCount).toBe(1)
+    expect(document.querySelector('.mt-menu')).toBeNull()
+  })
+
+  it('does NOT emit select on a disabled item, and the menu stays open', async () => {
+    let disabledSelectCount = 0
+    const c = mountMenu(() => {}, () => { disabledSelectCount += 1 })
+    ;(c.querySelector('.trigger-btn') as HTMLButtonElement).click()
+    await nextTick()
+
+    const deleteItem = document.querySelectorAll('.mt-menu-item')[1] as HTMLElement
+    expect(deleteItem.classList.contains('is-disabled')).toBe(true)
+    deleteItem.click()
+    await nextTick()
+
+    expect(disabledSelectCount).toBe(0)
+    expect(document.querySelector('.mt-menu')).not.toBeNull()
+  })
+})
+
+describe('MtPanel', () => {
+  it('renders its default slot content inside a .mt-panel container', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({ render: () => h(MtPanel, {}, { default: () => h('div', { class: 'inner' }, 'Grouped') }) })
+    app.mount(container)
+    const panel = container.querySelector('.mt-panel') as HTMLElement
+    expect(panel).not.toBeNull()
+    expect(panel.querySelector('.inner')?.textContent).toBe('Grouped')
+  })
+
+  it('applies the padding and shadow modifier classes', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({ render: () => h(MtPanel, { padding: 'sm', shadow: true }, { default: () => 'x' }) })
+    app.mount(container)
+    const panel = container.querySelector('.mt-panel') as HTMLElement
+    expect(panel.classList.contains('mt-panel--sm')).toBe(true)
+    expect(panel.classList.contains('mt-panel--shadow')).toBe(true)
+  })
+
+  it('defaults to md padding and no shadow', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({ render: () => h(MtPanel, {}, { default: () => 'x' }) })
+    app.mount(container)
+    const panel = container.querySelector('.mt-panel') as HTMLElement
+    expect(panel.classList.contains('mt-panel--md')).toBe(true)
+    expect(panel.classList.contains('mt-panel--shadow')).toBe(false)
+  })
+})

--- a/apps/web/tests/multitable-ui-p2-1b-overlays.spec.ts
+++ b/apps/web/tests/multitable-ui-p2-1b-overlays.spec.ts
@@ -210,13 +210,46 @@ describe('MtMenu / MtMenuItem', () => {
     ;(c.querySelector('.trigger-btn') as HTMLButtonElement).click()
     await nextTick()
 
-    const deleteItem = document.querySelectorAll('.mt-menu-item')[1] as HTMLElement
-    expect(deleteItem.classList.contains('is-disabled')).toBe(true)
+    const deleteItem = document.querySelectorAll('.mt-menu-item')[1] as HTMLButtonElement
+    // native `disabled` (not a css class) → removed from tab order + activation suppressed by the browser
+    expect(deleteItem.disabled).toBe(true)
     deleteItem.click()
     await nextTick()
 
     expect(disabledSelectCount).toBe(0)
     expect(document.querySelector('.mt-menu')).not.toBeNull()
+  })
+
+  it('renders each item as a native <button type="button" role="menuitem"> — honestly keyboard-operable', async () => {
+    // A11y contract: role="menuitem" on a bare, non-focusable <div> would be a lie (keyboard users
+    // can't reach or activate it). A native <button> gives focusability + Enter/Space→click activation
+    // + real `disabled` for free. jsdom does not synthesize the browser's native Enter/Space→click, so
+    // the robust, non-flaky assertion of keyboard-operability here is structural: it IS a native button.
+    const c = mountMenu(() => {}, () => {})
+    ;(c.querySelector('.trigger-btn') as HTMLButtonElement).click()
+    await nextTick()
+
+    const items = document.querySelectorAll('.mt-menu-item')
+    const enabled = items[0] as HTMLButtonElement
+    const disabled = items[1] as HTMLButtonElement
+    expect(enabled.tagName).toBe('BUTTON')
+    expect(enabled.getAttribute('type')).toBe('button')
+    expect(enabled.getAttribute('role')).toBe('menuitem')
+    expect(enabled.disabled).toBe(false) // enabled item is focusable + activatable
+    expect(disabled.disabled).toBe(true)  // disabled item is natively inert (tab-skipped, no activation)
+  })
+
+  it('activating an item (the click a browser fires for Enter/Space on a button) emits select once', async () => {
+    // Native <button> maps Enter/Space to a click event; asserting the click path proves the same code
+    // path keyboard activation drives (jsdom cannot emit the native keyboard→click itself).
+    let selectCount = 0
+    const c = mountMenu(() => { selectCount += 1 }, () => {})
+    ;(c.querySelector('.trigger-btn') as HTMLButtonElement).click()
+    await nextTick()
+    const enabled = document.querySelectorAll('.mt-menu-item')[0] as HTMLButtonElement
+    enabled.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+    expect(selectCount).toBe(1)
   })
 })
 

--- a/docs/development/multitable-ui-p2-structure-designlock-20260706.md
+++ b/docs/development/multitable-ui-p2-structure-designlock-20260706.md
@@ -1,6 +1,6 @@
-# 多维表 UI 升级 P2 — 结构与共享原语 · 设计锁（PROPOSED）
+# 多维表 UI 升级 P2 — 结构与共享原语 · 设计锁（RATIFIED）
 
-> 状态：**PROPOSED — 待 owner ratify**。本锁只定原则与分档边界，不含实现。
+> 状态：**RATIFIED 2026-07-07**（owner ratified via #3742; P2-1a primitives landed via #3744）。本锁只定原则与分档边界，不含实现。
 > 前置：UF-1 设计令牌（`apps/web/src/styles/tokens.css`，RATIFIED #3697）+ 多维表 UI P0/P1/P1b 已落 main（tokens/减负/全图标 SVG）。
 > 模型分档：设计裁量 = Fable 5；实现切片 = Sonnet 5；共享原语大重构的对抗审阅 = Opus。
 


### PR DESCRIPTION
UI-P2-1b (owner-authorized "go P2"), addressing both review findings.

## Deliverables
1. **Doc-status hotfix** (finding #1): `multitable-ui-p2-structure-designlock-20260706.md` PROPOSED → **RATIFIED 2026-07-07** (via #3742; P2-1a landed #3744).
2. **Overlay primitives** (additive, token-only, Teleport-safe): MtPopover (open/placement, click-outside + Esc), MtMenu/MtMenuItem (slot-composed, select emits + auto-close via provide/inject), MtPanel. Reuses ContextMenu.vue's Teleport/click-outside idiom without modifying it.
3. **Runnable component tests** (finding #2 — no README-only): 31/31 passing across `multitable-ui-p2-1-primitives.spec.ts` (21: MtButton/IconButton/Badge behavior + emit gating) and `multitable-ui-p2-1b-overlays.spec.ts` (10: popover toggle/Esc/outside-close, menu select/auto-close, disabled gating). **The tests caught a real bug** — MtPopover attached its Esc/click-outside listeners one microtask late (via `await nextTick`), racing ahead-of-attachment dispatches; fixed by attaching synchronously.

## Scope
Additive/presentation-only: only `ui/` (new files + barrel + README) + the design-lock doc-status lines changed; no existing component migrated (that's P2-1c) and ContextMenu.vue untouched. vue-tsc clean; grep confirms token-only (no hex/rgb in ui/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)