### PR TITLE
feat(web): IU-2a integration workbench chrome — PageShell + rail anchors + el-card sections + full tokenization (design-lock #3739)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -101,6 +101,9 @@ on:
       - 'apps/web/src/views/WorkflowDesigner.vue'
       - 'apps/web/src/multitable/components/MetaAutomationManager.vue'
       - 'apps/web/src/multitable/components/MetaAutomationRuleEditor.vue'
+      # IU-2a — Workbench chrome slice added to the UF-6 hex/rgb + static-style= guard set.
+      - 'apps/web/src/views/IntegrationWorkbenchView.vue'
+      - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
       - 'apps/web/src/styles/form-layout-utilities.css'
       - 'apps/web/.eslintrc.cjs'
       - 'apps/web/tests/ui-foundation-style-guard.spec.ts'
@@ -197,6 +200,9 @@ on:
       - 'apps/web/src/views/WorkflowDesigner.vue'
       - 'apps/web/src/multitable/components/MetaAutomationManager.vue'
       - 'apps/web/src/multitable/components/MetaAutomationRuleEditor.vue'
+      # IU-2a — Workbench chrome slice added to the UF-6 hex/rgb + static-style= guard set.
+      - 'apps/web/src/views/IntegrationWorkbenchView.vue'
+      - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
       - 'apps/web/src/styles/form-layout-utilities.css'
       - 'apps/web/.eslintrc.cjs'
       - 'apps/web/tests/ui-foundation-style-guard.spec.ts'

--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -28,6 +28,7 @@ on:
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
+      - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
       - 'apps/web/src/views/IntegrationHelpView.vue'
@@ -40,6 +41,7 @@ on:
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
+      - 'apps/web/tests/IntegrationWorkbenchRail.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - '.github/workflows/integration-guard.yml'
@@ -54,6 +56,7 @@ on:
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
+      - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
       - 'apps/web/src/views/IntegrationHelpView.vue'
@@ -66,6 +69,7 @@ on:
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
+      - 'apps/web/tests/IntegrationWorkbenchRail.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - '.github/workflows/integration-guard.yml'
@@ -113,4 +117,4 @@ jobs:
         run: pnpm --filter plugin-integration-core test
 
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -35,6 +35,7 @@
             <router-link v-if="canManageUsers" to="/admin/automation-executions" class="nav-link">{{ navLabels.automationRuns }}</router-link>
             <router-link v-if="canManageUsers" to="/approvals/metrics" class="nav-link">{{ navLabels.approvalMetrics }}</router-link>
             <router-link v-if="canUseIntegration" to="/integrations/workbench" class="nav-link">{{ navLabels.systemIntegration }}</router-link>
+            <router-link v-if="canUseIntegration" to="/data-sources" class="nav-link">{{ navLabels.dataSources }}</router-link>
             <router-link v-if="isAdmin" to="/admin/plugins" class="nav-link">{{ navLabels.plugins }}</router-link>
             <router-link v-if="canUsePlm" to="/plm" class="nav-link">{{ navLabels.plm }}</router-link>
             <router-link v-if="canUsePlm" to="/plm/audit" class="nav-link">{{ navLabels.audit }}</router-link>
@@ -132,6 +133,7 @@ const navLabels = computed(() => {
       automationRuns: '自动化运行',
       approvalMetrics: '审批 SLA',
       systemIntegration: '数据工厂',
+      dataSources: '外接数据源',
       plugins: '插件',
       plm: 'PLM',
       audit: '审计',
@@ -154,6 +156,7 @@ const navLabels = computed(() => {
     automationRuns: 'Automation Runs',
     approvalMetrics: 'Approval SLA',
     systemIntegration: 'Data Factory',
+    dataSources: 'Data Sources',
     plugins: 'Plugins',
     plm: 'PLM',
     audit: 'Audit',

--- a/apps/web/src/components/integration/IntegrationWorkbenchRail.vue
+++ b/apps/web/src/components/integration/IntegrationWorkbenchRail.vue
@@ -1,0 +1,127 @@
+<template>
+  <aside class="integration-workbench-rail" :aria-label="tr('数据工厂分区导航', 'Data Factory section navigation')">
+    <div class="integration-workbench-rail__header">
+      <strong>{{ tr('跳转区块', 'Jump to section') }}</strong>
+    </div>
+    <nav class="integration-workbench-rail__nav">
+      <button
+        v-for="group in groups"
+        :key="group.id"
+        type="button"
+        class="integration-workbench-rail__item"
+        :class="{ 'integration-workbench-rail__item--active': activeGroupId === group.id }"
+        :aria-current="activeGroupId === group.id ? 'true' : undefined"
+        :data-testid="`integration-rail-${group.id}`"
+        @click="emit('select', group)"
+      >
+        {{ group.label }}
+      </button>
+    </nav>
+  </aside>
+</template>
+
+<script setup lang="ts">
+// IU-2a (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2):
+// sticky left rail for the Data Factory workbench. Structural mirror of
+// src/views/attendance/AttendanceAdminRail.vue, simplified to this slice's scope — six FIXED
+// groups (no filter/expand/compact-toggle machinery, since IU-2a is chrome + anchor navigation
+// only; per-section component extraction + active-section switching is IU-2b). Presentational
+// only: the parent view owns section refs, the IntersectionObserver, and the scroll behavior;
+// this component just renders the group buttons and reports clicks via `select`.
+export interface IntegrationWorkbenchRailGroup {
+  /** Stable group id (e.g. "connection", "read-source") — also the active-highlight key. */
+  id: string
+  /** Bilingual display label (already resolved by the parent via its `tr`/`bi` helper). */
+  label: string
+  /** DOM id of the first section belonging to this group — the scroll target. */
+  targetId: string
+}
+
+withDefaults(
+  defineProps<{
+    groups: IntegrationWorkbenchRailGroup[]
+    activeGroupId?: string
+    /** Bilingual copy helper — same shape as the view's local `bi(zh, en)` function. */
+    tr: (zh: string, en: string) => string
+  }>(),
+  {
+    groups: () => [],
+    activeGroupId: '',
+  },
+)
+
+const emit = defineEmits<{
+  (event: 'select', group: IntegrationWorkbenchRailGroup): void
+}>()
+</script>
+
+<style scoped>
+.integration-workbench-rail {
+  position: sticky;
+  top: var(--ms-space-5);
+  align-self: flex-start;
+  min-width: 180px;
+  max-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+  padding: var(--ms-space-4);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  background: var(--ms-bg-card);
+}
+
+.integration-workbench-rail__header {
+  font-size: 12px;
+  color: var(--ms-text-3);
+}
+
+.integration-workbench-rail__nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-2);
+}
+
+.integration-workbench-rail__item {
+  width: 100%;
+  padding: var(--ms-space-2) var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-md);
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
+  text-align: left;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.integration-workbench-rail__item:hover {
+  border-color: var(--ms-color-primary);
+  color: var(--ms-color-primary);
+}
+
+.integration-workbench-rail__item--active {
+  border-color: var(--ms-color-primary);
+  background: var(--el-color-primary-light-9);
+  color: var(--ms-color-primary);
+  font-weight: 700;
+}
+
+@media (max-width: 960px) {
+  .integration-workbench-rail {
+    position: static;
+    max-width: none;
+    width: 100%;
+  }
+
+  .integration-workbench-rail__nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .integration-workbench-rail__item {
+    width: auto;
+  }
+}
+</style>

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -1,44 +1,56 @@
 <template>
-  <section class="integration-workbench">
-    <header class="integration-workbench__header">
-      <div>
-        <p class="integration-workbench__eyebrow">Data Factory</p>
-        <h1>数据工厂</h1>
-        <p class="integration-workbench__lead">连接任意 CRM / PLM / ERP / SRM / HTTP / SQL 系统，把数据落到多维表清洗后，先 dry-run，再导出或 Save-only 推送。</p>
-      </div>
-      <div class="integration-workbench__header-links">
-        <router-link class="integration-workbench__k3-link" to="/integrations/k3-wise">K3 WISE 预设模板</router-link>
-        <router-link class="integration-workbench__k3-link" to="/help/integration" data-testid="integration-help-link">
-          {{ bi('帮助', 'Help') }}
-        </router-link>
-      </div>
-    </header>
+  <PageShell width="wide">
+    <section class="integration-workbench">
+      <p class="integration-workbench__eyebrow">Data Factory</p>
+      <PageHeader title="数据工厂" subtitle="连接任意 CRM / PLM / ERP / SRM / HTTP / SQL 系统，把数据落到多维表清洗后，先 dry-run，再导出或 Save-only 推送。">
+        <template #actions>
+          <div class="integration-workbench__header-links">
+            <router-link class="integration-workbench__k3-link" to="/integrations/k3-wise">K3 WISE 预设模板</router-link>
+            <router-link class="integration-workbench__k3-link" to="/help/integration" data-testid="integration-help-link">
+              {{ bi('帮助', 'Help') }}
+            </router-link>
+          </div>
+        </template>
+      </PageHeader>
 
-    <nav class="integration-workbench__flow" aria-label="data factory flow" data-testid="data-factory-flow">
-      <div v-for="step in flowSteps" :key="step.title" class="integration-workbench__flow-step">
-        <strong>{{ step.title }}</strong>
-        <span>{{ step.description }}</span>
+      <nav class="integration-workbench__flow" aria-label="data factory flow" data-testid="data-factory-flow">
+        <div v-for="step in flowSteps" :key="step.title" class="integration-workbench__flow-step">
+          <strong>{{ step.title }}</strong>
+          <span>{{ step.description }}</span>
+        </div>
+      </nav>
+      <div class="integration-workbench__quick-flow" data-testid="data-factory-quick-flow">
+        <strong>操作路径</strong>
+        <span>1. 选来源系统 -> 2. 选来源数据集 -> 3. 选目标系统 -> 4. 选目标数据集 -> 5. 配映射 -> 6. Dry-run -> 7. 推送</span>
       </div>
-    </nav>
-    <div class="integration-workbench__quick-flow" data-testid="data-factory-quick-flow">
-      <strong>操作路径</strong>
-      <span>1. 选来源系统 -> 2. 选来源数据集 -> 3. 选目标系统 -> 4. 选目标数据集 -> 5. 配映射 -> 6. Dry-run -> 7. 推送</span>
-    </div>
 
-    <div v-if="statusMessage" class="integration-workbench__status" :data-kind="statusKind">
-      {{ statusMessage }}
-    </div>
+      <div v-if="statusMessage" class="integration-workbench__status" :data-kind="statusKind">
+        {{ statusMessage }}
+      </div>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>连接系统 / 数据源</h2>
+      <div class="integration-workbench__body">
+        <IntegrationWorkbenchRail
+          :groups="railGroups"
+          :active-group-id="activeRailGroupId"
+          :tr="bi"
+          @select="scrollToRailGroup"
+        />
+        <div class="integration-workbench__sections">
+
+    <section id="int-sec-connection" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>连接系统 / 数据源</h2>
           <p>普通用户选择已配置连接；SQL 通道是高级连接，只用于 allowlist 表、视图或中间表。</p>
         </div>
         <button type="button" class="integration-workbench__button" data-testid="refresh-systems" @click="refreshBootstrap">
           刷新连接
         </button>
       </div>
+        </template>
+
 
       <div class="integration-workbench__onboarding" data-testid="connection-onboarding">
         <div>
@@ -258,45 +270,65 @@
           <input v-model="workspaceInput" data-testid="workspace-id" placeholder="可选" />
         </label>
       </div>
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>读取源配置(顾问自助)</h2>
+    <section id="int-sec-read-source" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>读取源配置(顾问自助)</h2>
           <p>标准化第三方 API 只读读取源:S1 结构校验 → 定位容器探测 → 内容寻址保存版本 → 审批。运行时只消费已审批版本;本面板不含写入 / 删除。</p>
         </div>
       </div>
+        </template>
+
       <IntegrationReadSourceConfigPanel :scope="currentScope()" :systems="systems" />
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>读取源组合配置(顾问/管理员自助)</h2>
+    <section id="int-sec-combination-config" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>读取源组合配置(顾问/管理员自助)</h2>
           <p>选择两个已审批的 resolver_lookup 读取源,组装成两跳组合:保存版本(内容寻址,幂等)→ 审批后运行时才可选用。本面板不含写入外部系统的能力。</p>
         </div>
       </div>
+        </template>
+
       <IntegrationReadSourceCompositionAuthoringPanel :scope="currentScope()" />
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>读取源组合运行(顾问/操作员自助)</h2>
+    <section id="int-sec-combination-run" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>读取源组合运行(顾问/操作员自助)</h2>
           <p>选择已审批的组合链,提供首个业务 key 后运行:中间键由平台派生,证据 values-free,数据仅末跳输出。本面板不含配置编写或写入。</p>
         </div>
       </div>
+        </template>
+
       <IntegrationReadSourceCompositionPanel :scope="currentScope()" />
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>选择系统与数据集</h2>
+    <section id="int-sec-object-template" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>选择系统与数据集</h2>
           <p>来源对象决定从哪里取数，目标模板决定写到哪里。先选系统，再加载可选数据集或模板。</p>
         </div>
       </div>
+        </template>
+
       <div class="integration-workbench__grid integration-workbench__grid--systems">
         <div class="integration-workbench__system-column">
           <h2>1. 来源对象选择</h2>
@@ -459,15 +491,20 @@
           切换到 {{ stagingDatasetCopy[recommendedStagingSourceObject]?.name || recommendedStagingSourceObject }}
         </button>
       </div>
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>数据集与多维表清洗</h2>
+    <section id="int-sec-cleaning-dataset" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>数据集与多维表清洗</h2>
           <p>数据源和目标系统只负责读写；业务清洗、审核、修正发生在多维表里。未安装清洗表时，可在这里创建 staging 多维表。</p>
         </div>
       </div>
+        </template>
+
 
       <div class="integration-workbench__dataset-grid" data-testid="dataset-cards">
         <article class="integration-workbench__dataset-card" data-testid="source-dataset-card">
@@ -602,18 +639,23 @@
         </button>
       </div>
       <pre v-if="stagingInstallResultText" data-testid="staging-install-result">{{ stagingInstallResultText }}</pre>
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>清洗映射规则</h2>
+    <section id="int-sec-cleaning-rules" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>清洗映射规则</h2>
           <p>一行就是一条清洗内容：从来源字段取值，经过白名单转换后写入目标字段。默认映射可直接用，也允许新增自定义清洗项。</p>
         </div>
         <button type="button" class="integration-workbench__button" data-testid="add-mapping" @click="addMapping">
           新增自定义清洗项
         </button>
       </div>
+        </template>
+
 
       <div class="integration-workbench__mapping-list" data-testid="mapping-rule-list">
         <details v-for="(mapping, index) in mappings" :key="mapping.id" class="integration-workbench__mapping-card" open>
@@ -676,18 +718,23 @@
           </div>
         </details>
       </div>
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>运行与推送</h2>
+    <section id="int-sec-run-push" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>运行与推送</h2>
           <p>先保存清洗流程，再做 dry-run；确认无误后才 Save-only 推送到目标系统。默认不会 Submit / Audit。</p>
         </div>
         <button type="button" class="integration-workbench__button" data-testid="save-pipeline" :disabled="savingPipeline || !canSavePipeline" @click="savePipeline">
           {{ savingPipeline ? '保存中' : '保存清洗流程' }}
         </button>
       </div>
+        </template>
+
 
       <div class="integration-workbench__grid">
         <label>
@@ -1179,18 +1226,23 @@
       </div>
 
       <pre data-testid="pipeline-result">{{ pipelineResultText }}</pre>
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel">
-      <div class="integration-workbench__panel-head">
-        <div>
-          <h2>运行监控</h2>
+    <section id="int-sec-monitoring" class="integration-workbench__panel">
+      <el-card shadow="never">
+        <template #header>
+          <div class="integration-workbench__panel-head">
+            <div>
+              <h2>运行监控</h2>
           <p>{{ observationSummary }}。展示最近 5 条 run（状态 / 写入 / 失败 + 行级结果）与 open dead letters（可重放），便于清洗后回看失败原因。</p>
         </div>
         <button type="button" class="integration-workbench__button" data-testid="refresh-observation" :disabled="observingPipeline" @click="refreshPipelineObservation(false)">
           {{ observingPipeline ? '刷新中' : '刷新监控' }}
         </button>
       </div>
+        </template>
+
 
       <div class="integration-workbench__observation">
         <div>
@@ -1348,9 +1400,11 @@
           </ol>
         </div>
       </div>
+      </el-card>
     </section>
 
-    <section class="integration-workbench__panel integration-workbench__preview">
+    <section id="int-sec-preview" class="integration-workbench__panel integration-workbench__preview">
+      <el-card shadow="never">
       <div>
         <h2>样例记录</h2>
         <textarea v-model="sampleRecordText" data-testid="sample-record" spellcheck="false"></textarea>
@@ -1443,14 +1497,20 @@
           <p class="integration-workbench__hint">仅显示字段名与来源，不含字段值。</p>
         </div>
       </div>
+      </el-card>
     </section>
-  </section>
+        </div>
+      </div>
+    </section>
+  </PageShell>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { useAuth } from '../composables/useAuth'
 import { useLocale } from '../composables/useLocale'
+import PageShell from '../components/layout/PageShell.vue'
+import PageHeader from '../components/layout/PageHeader.vue'
 import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../services/integration/errorCodeLabels'
 import { buildXlsxBuffer } from '../multitable/import/xlsx-mapping'
 import { getDataSourceSchema, listDataSources } from '../data-sources/api'
@@ -1528,6 +1588,9 @@ import IntegrationReadSourceConfigPanel from '../components/integration/Integrat
 import IntegrationReadSourceCompositionPanel from '../components/integration/IntegrationReadSourceCompositionPanel.vue'
 import IntegrationReadSourceCompositionAuthoringPanel from '../components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
 import PlmBomReviewPanel from '../components/plm/PlmBomReviewPanel.vue'
+import IntegrationWorkbenchRail, {
+  type IntegrationWorkbenchRailGroup,
+} from '../components/integration/IntegrationWorkbenchRail.vue'
 
 type WorkbenchSide = 'source' | 'target'
 type TransformFn = '' | 'trim' | 'upper' | 'lower' | 'toNumber' | 'dictMap'
@@ -1648,6 +1711,73 @@ const { locale } = useLocale()
 function bi(zh: string, en: string): string {
   return locale.value === 'zh-CN' ? zh : en
 }
+
+// IU-2a (design-lock §2 IU-2): sticky left rail — six fixed groups mirroring the design-lock's
+// 连接管理/读取源/组合/清洗映射/运行与推送/监控与死信 taxonomy. Anchor-navigation only in this slice:
+// clicking scrolls the target section into view; the active highlight tracks scroll position via
+// IntersectionObserver (feature-detected below — jsdom/older browsers without it simply never
+// update the highlight, no crash). Every section stays rendered (no v-if/show-hide) — that is the
+// zero-behavior-change invariant this slice is built on.
+//
+// Some rail groups cover more than one physical <section> (e.g. "组合" spans the composition
+// config + run panels; "清洗映射" spans object/template selection, dataset cleaning, mapping
+// rules, and the JSON/field-rule/payload-preview panel at the very end of the DOM). The rail
+// button scrolls to the FIRST section id in its group; `sectionGroupIds` below drives the active
+// highlight for every section id that belongs to a group, regardless of DOM position.
+const railGroups = computed<IntegrationWorkbenchRailGroup[]>(() => [
+  { id: 'connection', label: bi('连接管理', 'Connections'), targetId: 'int-sec-connection' },
+  { id: 'read-source', label: bi('读取源', 'Read Sources'), targetId: 'int-sec-read-source' },
+  { id: 'combination', label: bi('组合', 'Composition'), targetId: 'int-sec-combination-config' },
+  { id: 'cleaning-mapping', label: bi('清洗映射', 'Cleansing & Mapping'), targetId: 'int-sec-object-template' },
+  { id: 'run-push', label: bi('运行与推送', 'Run & Push'), targetId: 'int-sec-run-push' },
+  { id: 'monitoring', label: bi('监控与死信', 'Monitoring & Dead Letters'), targetId: 'int-sec-monitoring' },
+])
+
+const sectionGroupIds: Record<string, string> = {
+  'int-sec-connection': 'connection',
+  'int-sec-read-source': 'read-source',
+  'int-sec-combination-config': 'combination',
+  'int-sec-combination-run': 'combination',
+  'int-sec-object-template': 'cleaning-mapping',
+  'int-sec-cleaning-dataset': 'cleaning-mapping',
+  'int-sec-cleaning-rules': 'cleaning-mapping',
+  'int-sec-run-push': 'run-push',
+  'int-sec-monitoring': 'monitoring',
+  'int-sec-preview': 'cleaning-mapping',
+}
+
+const activeRailGroupId = ref('connection')
+let workbenchSectionObserver: IntersectionObserver | null = null
+
+function scrollToRailGroup(group: IntegrationWorkbenchRailGroup): void {
+  activeRailGroupId.value = group.id
+  if (typeof document === 'undefined') return
+  document.getElementById(group.targetId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+onMounted(() => {
+  if (typeof document === 'undefined' || typeof IntersectionObserver === 'undefined') return
+  const elements = Object.keys(sectionGroupIds)
+    .map((id) => document.getElementById(id))
+    .filter((el): el is HTMLElement => el !== null)
+  if (elements.length === 0) return
+  workbenchSectionObserver = new IntersectionObserver(
+    (entries) => {
+      const visible = entries.filter((entry) => entry.isIntersecting)
+      if (visible.length === 0) return
+      const mostVisible = visible.reduce((a, b) => (a.intersectionRatio >= b.intersectionRatio ? a : b))
+      const groupId = sectionGroupIds[mostVisible.target.id]
+      if (groupId) activeRailGroupId.value = groupId
+    },
+    { rootMargin: '-96px 0px -60% 0px', threshold: [0, 0.25, 0.5, 0.75, 1] },
+  )
+  elements.forEach((el) => workbenchSectionObserver?.observe(el))
+})
+
+onBeforeUnmount(() => {
+  workbenchSectionObserver?.disconnect()
+  workbenchSectionObserver = null
+})
 
 const stagingDatasetCopy: Record<string, { area: string; name: string; description: string }> = {
   plm_raw_items: {
@@ -4963,16 +5093,16 @@ watch(selectedTableActionId, (actionId) => {
   padding: 1px 8px;
   border-radius: 10px;
   font-size: 12px;
-  background: #eef2ff;
-  color: #3730a3;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
 }
 
 .integration-workbench__table-action {
   margin: 16px 0;
   padding: 14px;
-  border: 1px solid #d8e0e8;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #f8fbff;
+  background: var(--ms-bg-page);
 }
 
 .integration-workbench__table-action h3 {
@@ -4988,9 +5118,9 @@ watch(selectedTableActionId, (actionId) => {
   display: grid;
   gap: 6px;
   padding: 12px;
-  border: 1px solid #d7deea;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #f8fbff;
+  background: var(--ms-bg-page);
 }
 
 .integration-workbench__capability-entry > div {
@@ -5001,13 +5131,13 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__capability-entry strong {
-  color: #1f3551;
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__capability-entry p,
 .integration-workbench__capability-entry small {
   margin: 0;
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 13px;
   line-height: 1.45;
 }
@@ -5023,9 +5153,9 @@ watch(selectedTableActionId, (actionId) => {
   display: grid;
   gap: 8px;
   padding: 10px;
-  border: 1px solid #f3c8a8;
+  border: 1px solid var(--el-color-warning-light-7);
   border-radius: 6px;
-  background: #fff7ed;
+  background: var(--el-color-warning-light-9);
 }
 
 .integration-workbench__bounded-preview > div:first-child {
@@ -5036,7 +5166,7 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__bounded-preview strong {
-  color: #7c2d12;
+  color: var(--el-color-warning-dark-2);
 }
 
 .integration-workbench__mini-list {
@@ -5049,32 +5179,27 @@ watch(selectedTableActionId, (actionId) => {
 
 .integration-workbench__mini-list li {
   padding: 8px;
-  border: 1px solid #f3d8bd;
+  border: 1px solid var(--el-color-warning-light-7);
   border-radius: 6px;
-  background: #fffaf5;
-  color: #5b3417;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
   font-size: 12px;
   line-height: 1.45;
   overflow-wrap: anywhere;
 }
 
+/* IU-2a: outer container box model (max-width/margin/padding) now lives on PageShell
+   (width="wide"); this class stays as the descendant-selector scope for h2/input/select/
+   textarea/code/pre/panel rules below. */
 .integration-workbench {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 24px;
-  color: #17202a;
+  color: var(--ms-text-1);
 }
 
-.integration-workbench__header,
 .integration-workbench__panel-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-}
-
-.integration-workbench__header {
-  margin-bottom: 18px;
 }
 
 /* IU-6c: header help-center link — new wrapper styling only, tokens per UF-1. */
@@ -5083,6 +5208,25 @@ watch(selectedTableActionId, (actionId) => {
   align-items: center;
   gap: var(--ms-space-2);
   flex-wrap: wrap;
+}
+
+/* IU-2a: rail + sections layout — the workbench body now splits into a sticky left rail
+   (IntegrationWorkbenchRail.vue) and the scrollable section stack. */
+.integration-workbench__body {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ms-space-5);
+}
+
+.integration-workbench__sections {
+  flex: 1;
+  min-width: 0;
+}
+
+@media (max-width: 960px) {
+  .integration-workbench__body {
+    flex-direction: column;
+  }
 }
 
 .integration-workbench__flow {
@@ -5095,9 +5239,9 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__flow-step,
 .integration-workbench__dataset-card,
 .integration-workbench__staging-card {
-  border: 1px solid #d8e0e8;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--ms-bg-card);
 }
 
 .integration-workbench__flow-step {
@@ -5107,12 +5251,12 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__flow-step strong {
-  color: #1f3551;
+  color: var(--ms-text-1);
   font-size: 13px;
 }
 
 .integration-workbench__flow-step span {
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -5124,16 +5268,16 @@ watch(selectedTableActionId, (actionId) => {
   gap: 8px;
   margin: -4px 0 16px;
   padding: 10px 12px;
-  border: 1px solid #d8e0e8;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #f8fbff;
-  color: #3c4b60;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
   font-size: 13px;
   line-height: 1.45;
 }
 
 .integration-workbench__quick-flow strong {
-  color: #1f3551;
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__quick-flow span {
@@ -5142,39 +5286,30 @@ watch(selectedTableActionId, (actionId) => {
 
 .integration-workbench__eyebrow {
   margin: 0 0 6px;
-  color: #54637a;
+  color: var(--ms-text-2);
   font-size: 13px;
   font-weight: 700;
   text-transform: uppercase;
 }
 
-.integration-workbench h1,
 .integration-workbench h2 {
   margin: 0;
-}
-
-.integration-workbench h1 {
-  font-size: 28px;
-}
-
-.integration-workbench h2 {
   font-size: 17px;
 }
 
-.integration-workbench__lead,
 .integration-workbench__panel p {
   margin: 8px 0 0;
-  color: #5c6878;
+  color: var(--ms-text-2);
   line-height: 1.5;
 }
 
 .integration-workbench__k3-link,
 .integration-workbench__button,
 .integration-workbench__icon-button {
-  border: 1px solid #bfccd9;
+  border: 1px solid var(--ms-border);
   border-radius: 6px;
-  background: #ffffff;
-  color: #233246;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
   cursor: pointer;
   font-weight: 700;
   text-decoration: none;
@@ -5192,7 +5327,7 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__button:hover,
 .integration-workbench__icon-button:hover,
 .integration-workbench__k3-link:hover {
-  border-color: #357abd;
+  border-color: var(--ms-color-primary);
 }
 
 .integration-workbench__button:disabled,
@@ -5202,34 +5337,34 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__button--danger {
-  border-color: #c77777;
-  color: #8f1d1d;
+  border-color: var(--el-color-danger-light-3);
+  color: var(--el-color-danger);
 }
 
 .integration-workbench__status {
   margin-bottom: 14px;
   padding: 10px 12px;
   border-radius: 6px;
-  background: #eef4fb;
-  color: #24476b;
+  background: var(--el-color-primary-light-9);
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__status[data-kind="error"] {
-  background: #fff0f0;
-  color: #9b1c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger);
 }
 
 .integration-workbench__status[data-kind="success"] {
-  background: #edf7ef;
-  color: #17622f;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .integration-workbench__panel {
   margin-bottom: 16px;
   padding: 16px;
-  border: 1px solid #d8e0e8;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--ms-bg-card);
 }
 
 .integration-workbench__adapter-list {
@@ -5247,20 +5382,20 @@ watch(selectedTableActionId, (actionId) => {
   gap: 16px;
   margin-top: 14px;
   padding: 12px;
-  border: 1px solid #d7deea;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .integration-workbench__onboarding strong,
 .integration-workbench__readiness strong {
-  color: #1f3551;
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__onboarding p,
 .integration-workbench__readiness p {
   margin: 4px 0 0;
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 13px;
   line-height: 1.5;
 }
@@ -5277,30 +5412,30 @@ watch(selectedTableActionId, (actionId) => {
   gap: 12px;
   margin-top: 14px;
   padding: 12px;
-  border: 1px solid #d7deea;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #fbfcfe;
+  background: var(--ms-bg-card);
 }
 
 .integration-workbench__connection-manager strong {
-  color: #1f3551;
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__connection-manager p {
   margin: 4px 0 0;
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 13px;
   line-height: 1.5;
 }
 
 .integration-workbench__details {
-  border-top: 1px solid #e4ebf2;
+  border-top: 1px solid var(--el-border-color-lighter);
   padding-top: 10px;
 }
 
 .integration-workbench__details summary {
   cursor: pointer;
-  color: #1f3551;
+  color: var(--ms-text-1);
   font-weight: 700;
 }
 
@@ -5312,10 +5447,10 @@ watch(selectedTableActionId, (actionId) => {
   gap: 12px;
   margin-top: 14px;
   padding: 10px 12px;
-  border: 1px solid #d8e0e8;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #ffffff;
-  color: #233246;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
   cursor: pointer;
   font: inherit;
   font-weight: 700;
@@ -5323,7 +5458,7 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__inventory-toggle span {
-  color: #357abd;
+  color: var(--ms-color-primary);
   font-size: 13px;
 }
 
@@ -5346,14 +5481,14 @@ watch(selectedTableActionId, (actionId) => {
   display: grid;
   gap: 4px;
   padding: 10px;
-  border: 1px solid #e4ebf2;
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 6px;
-  background: #ffffff;
+  background: var(--ms-bg-card);
 }
 
 .integration-workbench__inventory-list span,
 .integration-workbench__inventory-list small {
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -5363,14 +5498,14 @@ watch(selectedTableActionId, (actionId) => {
   align-items: center;
   gap: 6px;
   padding: 5px 8px;
-  border: 1px solid #d8e0e8;
+  border: 1px solid var(--ms-border-light);
   border-radius: 999px;
-  color: #35465c;
+  color: var(--ms-text-1);
   font-size: 13px;
 }
 
 .integration-workbench__adapter small {
-  color: #8a4d00;
+  color: var(--el-color-warning-dark-2);
   font-weight: 700;
 }
 
@@ -5388,7 +5523,7 @@ watch(selectedTableActionId, (actionId) => {
 
 .integration-workbench__hint {
   margin-top: 10px;
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 13px;
   line-height: 1.5;
 }
@@ -5396,8 +5531,8 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__hint--strong {
   padding: 10px 12px;
   border-radius: 6px;
-  background: #fff8e8;
-  color: #744600;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
 }
 
 .integration-workbench__connection-row {
@@ -5413,40 +5548,40 @@ watch(selectedTableActionId, (actionId) => {
   max-width: 100%;
   padding: 5px 8px;
   border-radius: 999px;
-  background: #eef2f7;
-  color: #3c4b60;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
   font-size: 12px;
   font-weight: 700;
 }
 
 .integration-workbench__badge[data-status="active"] {
-  background: #edf7ef;
-  color: #17622f;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .integration-workbench__badge[data-status="error"] {
-  background: #fff0f0;
-  color: #9b1c1c;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger);
 }
 
 .integration-workbench__badge[data-status="warning"] {
-  background: #fff8e8;
-  color: #744600;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
 }
 
 .integration-workbench__badge[data-status="enabled"] {
-  background: #edf7ef;
-  color: #17622f;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .integration-workbench__badge[data-status="upgrade"] {
-  background: #fff8e8;
-  color: #744600;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
 }
 
 .integration-workbench__badge[data-status="loading"] {
-  background: #eef2f7;
-  color: #3c4b60;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
 }
 
 .integration-workbench__grid {
@@ -5467,9 +5602,9 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__watermark-config {
   grid-column: 1 / -1;
   padding: 12px;
-  border: 1px solid #d7deea;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .integration-workbench__dataset-grid {
@@ -5491,20 +5626,20 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__dataset-kind {
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 12px;
   font-weight: 700;
 }
 
 .integration-workbench__dataset-card strong,
 .integration-workbench__staging-card strong {
-  color: #1f3551;
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__dataset-card p,
 .integration-workbench__staging-card p {
   margin: 0;
-  color: #5c6878;
+  color: var(--ms-text-2);
   line-height: 1.5;
 }
 
@@ -5517,7 +5652,7 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__metric-row span,
 .integration-workbench__staging-card small {
   display: inline-flex;
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 12px;
 }
 
@@ -5539,12 +5674,12 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__staging-note {
   grid-column: 1 / -1;
   display: block;
-  color: #5c6878;
+  color: var(--ms-text-2);
   line-height: 1.45;
 }
 
 .integration-workbench__staging-note--warning {
-  color: #92400e;
+  color: var(--el-color-warning-dark-2);
 }
 
 .integration-workbench__system-column {
@@ -5555,7 +5690,7 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench label {
   display: grid;
   gap: 6px;
-  color: #35465c;
+  color: var(--ms-text-1);
   font-size: 13px;
   font-weight: 700;
 }
@@ -5565,10 +5700,10 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench textarea {
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid #bfccd9;
+  border: 1px solid var(--ms-border);
   border-radius: 6px;
   padding: 8px 10px;
-  color: #17202a;
+  color: var(--ms-text-1);
   font: inherit;
 }
 
@@ -5582,9 +5717,9 @@ watch(selectedTableActionId, (actionId) => {
   min-height: 84px;
   margin: 0;
   padding: 10px 12px;
-  border: 1px solid #e4ebf2;
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 6px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
   list-style: none;
 }
 
@@ -5594,16 +5729,16 @@ watch(selectedTableActionId, (actionId) => {
   justify-content: space-between;
   gap: 8px;
   padding: 4px 0;
-  color: #42536a;
+  color: var(--ms-text-2);
 }
 
 .integration-workbench code {
-  color: #1f5f99;
+  color: var(--ms-color-primary);
   font-size: 12px;
 }
 
 .integration-workbench__schema-list strong {
-  color: #9b1c1c;
+  color: var(--el-color-danger);
   font-size: 12px;
 }
 
@@ -5620,9 +5755,9 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__mapping-card {
-  border: 1px solid #d8e0e8;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #fbfcfe;
+  background: var(--ms-bg-card);
 }
 
 .integration-workbench__mapping-card summary {
@@ -5630,13 +5765,13 @@ watch(selectedTableActionId, (actionId) => {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   padding: 10px 12px;
-  color: #1f3551;
+  color: var(--ms-text-1);
   cursor: pointer;
   font-weight: 700;
 }
 
 .integration-workbench__mapping-card summary small {
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-weight: 600;
 }
 
@@ -5651,12 +5786,12 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__mapping-table th,
 .integration-workbench__mapping-table td {
   padding: 8px;
-  border-bottom: 1px solid #e4ebf2;
+  border-bottom: 1px solid var(--el-border-color-lighter);
   text-align: left;
 }
 
 .integration-workbench__mapping-table th {
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 12px;
 }
 
@@ -5704,7 +5839,7 @@ watch(selectedTableActionId, (actionId) => {
   width: max-content;
   border: 0;
   background: transparent;
-  color: #1f5f99;
+  color: var(--ms-color-primary);
   cursor: pointer;
   font: inherit;
   font-weight: 700;
@@ -5713,7 +5848,7 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__field-help {
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 12px;
   font-weight: 500;
   line-height: 1.45;
@@ -5722,13 +5857,13 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__run-explainer {
   margin-top: 14px;
   padding: 12px;
-  border: 1px solid #d7deea;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .integration-workbench__run-explainer strong {
-  color: #1f3551;
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__run-explainer ul {
@@ -5736,7 +5871,7 @@ watch(selectedTableActionId, (actionId) => {
   gap: 6px;
   margin: 8px 0 0;
   padding-left: 18px;
-  color: #5c6878;
+  color: var(--ms-text-2);
   line-height: 1.5;
 }
 
@@ -5770,28 +5905,28 @@ watch(selectedTableActionId, (actionId) => {
   display: grid;
   gap: 4px;
   padding: 8px;
-  border: 1px solid #e4ebf2;
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 6px;
-  background: #ffffff;
+  background: var(--ms-bg-card);
 }
 
 .integration-workbench__readiness li[data-ready="true"] {
-  border-color: #b9dfc4;
-  background: #f3fbf5;
+  border-color: var(--el-color-success-light-7);
+  background: var(--el-color-success-light-9);
 }
 
 .integration-workbench__readiness li > span {
-  color: #7a4a00;
+  color: var(--el-color-warning-dark-2);
   font-size: 12px;
   font-weight: 700;
 }
 
 .integration-workbench__readiness li[data-ready="true"] > span {
-  color: #17622f;
+  color: var(--el-color-success-dark-2);
 }
 
 .integration-workbench__readiness small {
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -5803,9 +5938,9 @@ watch(selectedTableActionId, (actionId) => {
   gap: 12px;
   margin-top: 14px;
   padding: 12px;
-  border: 1px solid #d7deea;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .integration-workbench__export strong,
@@ -5815,7 +5950,7 @@ watch(selectedTableActionId, (actionId) => {
 
 .integration-workbench__export p {
   margin-top: 4px;
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 13px;
   line-height: 1.5;
 }
@@ -5834,16 +5969,16 @@ watch(selectedTableActionId, (actionId) => {
 
 .integration-workbench__muted {
   margin: -4px 0 10px;
-  color: #5c6878;
+  color: var(--ms-text-2);
   font-size: 13px;
   line-height: 1.5;
 }
 
 .integration-workbench__empty {
   padding: 12px;
-  border: 1px dashed #cbd5e1;
+  border: 1px dashed var(--ms-border);
   border-radius: 6px;
-  color: #5c6878;
+  color: var(--ms-text-2);
 }
 
 .integration-workbench__empty--actionable {
@@ -5851,7 +5986,7 @@ watch(selectedTableActionId, (actionId) => {
 }
 
 .integration-workbench__empty strong {
-  color: #1f3551;
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__empty p {
@@ -5870,13 +6005,13 @@ watch(selectedTableActionId, (actionId) => {
   display: grid;
   gap: 4px;
   padding: 10px;
-  border: 1px solid #e4ebf2;
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 6px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .integration-workbench__record-list small {
-  color: #5c6878;
+  color: var(--ms-text-2);
 }
 
 .integration-workbench__run-head {
@@ -5891,16 +6026,16 @@ watch(selectedTableActionId, (actionId) => {
   flex-wrap: wrap;
   gap: 8px;
   font-size: 12px;
-  color: #5c6878;
+  color: var(--ms-text-2);
 }
 
 .integration-workbench__run-metric--write {
-  color: #1f6f43;
+  color: var(--el-color-success-dark-2);
   font-weight: 600;
 }
 
 .integration-workbench__run-metric--fail {
-  color: #8f1d1d;
+  color: var(--el-color-danger);
   font-weight: 600;
 }
 
@@ -5910,30 +6045,30 @@ watch(selectedTableActionId, (actionId) => {
   letter-spacing: 0.04em;
   padding: 1px 6px;
   border-radius: 4px;
-  background: #e7eef6;
-  color: #24476b;
+  background: var(--el-color-primary-light-9);
+  color: var(--ms-text-1);
 }
 
 .integration-workbench__run-status--succeeded {
-  background: #e3f3e8;
-  color: #1f6f43;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .integration-workbench__run-status--partial {
-  background: #fdf3e0;
-  color: #8a5a12;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
 }
 
 .integration-workbench__run-status--failed,
 .integration-workbench__run-status--cancelled {
-  background: #fbe7e7;
-  color: #8f1d1d;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger);
 }
 
 .integration-workbench__run-error {
   margin: 0;
   font-size: 12px;
-  color: #8f1d1d;
+  color: var(--el-color-danger);
 }
 
 .integration-workbench__run-summaries {
@@ -5979,13 +6114,13 @@ watch(selectedTableActionId, (actionId) => {
 .integration-workbench__provenance-attrs {
   margin: 2px 0 0;
   font-size: 12px;
-  color: #5a6473;
+  color: var(--ms-text-2);
   word-break: break-word;
 }
 
 .integration-workbench__badge--retryable {
-  background: #e3f3e8;
-  color: #1f6f43;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .integration-workbench__button--ghost {
@@ -5996,7 +6131,7 @@ watch(selectedTableActionId, (actionId) => {
   border: none;
   background: none;
   padding: 0;
-  color: #357abd;
+  color: var(--ms-color-primary);
   cursor: pointer;
   font: inherit;
   text-decoration: underline;
@@ -6019,16 +6154,15 @@ watch(selectedTableActionId, (actionId) => {
   overflow: auto;
   margin: 12px 0 0;
   padding: 12px;
-  border: 1px solid #d8e0e8;
+  border: 1px solid var(--ms-border-light);
   border-radius: 6px;
-  background: #111827;
-  color: #e5edf7;
+  background: var(--ms-text-1);
+  color: var(--el-color-primary-light-9);
   font-size: 12px;
   line-height: 1.5;
 }
 
 @media (max-width: 900px) {
-  .integration-workbench__header,
   .integration-workbench__panel-head,
   .integration-workbench__preview,
   .integration-workbench__observation,
@@ -6045,7 +6179,6 @@ watch(selectedTableActionId, (actionId) => {
     grid-template-columns: 1fr;
   }
 
-  .integration-workbench__header,
   .integration-workbench__panel-head {
     display: grid;
   }

--- a/apps/web/tests/IntegrationWorkbenchRail.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchRail.spec.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp, type Component } from 'vue'
+import IntegrationWorkbenchRail, {
+  type IntegrationWorkbenchRailGroup,
+} from '../src/components/integration/IntegrationWorkbenchRail.vue'
+
+// IU-2a (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2):
+// Workbench chrome — PageShell + sticky left rail + anchor navigation, zero behavior/logic
+// migration. This spec covers what tests/IntegrationWorkbenchView.spec.ts's existing 49 tests
+// don't: the rail component's own rendering/emit contract, and a light integration check that
+// the view actually wires PageShell/PageHeader/the rail/all ten section ids, that a rail click
+// drives `scrollIntoView` on the right section, and that mounting never crashes when
+// IntersectionObserver is unavailable (the jsdom default — no polyfill is installed anywhere in
+// this test file, unlike some browser-shimmed suites elsewhere in the repo).
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const apiFetchMock = vi.fn()
+const apiGetMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: (...args: unknown[]) => apiGetMock(...args),
+}))
+
+async function flushUi(cycles = 5): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    // Macrotask hop (same pattern as tests/IntegrationWorkbenchView.spec.ts's flushUi): a
+    // microtask-only flush is not enough on Node 20's scheduler for the fetch-mock chains this
+    // view drives on mount.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+}
+
+const bi = (zh: string, _en: string): string => zh
+
+const railGroups: IntegrationWorkbenchRailGroup[] = [
+  { id: 'connection', label: '连接管理', targetId: 'int-sec-connection' },
+  { id: 'read-source', label: '读取源', targetId: 'int-sec-read-source' },
+  { id: 'combination', label: '组合', targetId: 'int-sec-combination-config' },
+  { id: 'cleaning-mapping', label: '清洗映射', targetId: 'int-sec-object-template' },
+  { id: 'run-push', label: '运行与推送', targetId: 'int-sec-run-push' },
+  { id: 'monitoring', label: '监控与死信', targetId: 'int-sec-monitoring' },
+]
+
+describe('IntegrationWorkbenchRail (unit)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  async function mountRail(extraProps: Record<string, unknown> = {}): Promise<void> {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const Host = defineComponent({
+      setup() {
+        return () => h(IntegrationWorkbenchRail as unknown as Component, {
+          groups: railGroups,
+          activeGroupId: 'connection',
+          tr: bi,
+          ...extraProps,
+        })
+      },
+    })
+    app = createApp(Host)
+    app.mount(container)
+    await flushUi(1)
+  }
+
+  it('renders all six design-lock groups', async () => {
+    await mountRail()
+    const items = container!.querySelectorAll('.integration-workbench-rail__item')
+    expect(items.length).toBe(6)
+    expect(container!.textContent).toContain('连接管理')
+    expect(container!.textContent).toContain('读取源')
+    expect(container!.textContent).toContain('组合')
+    expect(container!.textContent).toContain('清洗映射')
+    expect(container!.textContent).toContain('运行与推送')
+    expect(container!.textContent).toContain('监控与死信')
+  })
+
+  it('marks the active group via aria-current and the active class', async () => {
+    await mountRail({ activeGroupId: 'run-push' })
+    const active = container!.querySelector('[data-testid="integration-rail-run-push"]')
+    expect(active?.getAttribute('aria-current')).toBe('true')
+    expect(active?.classList.contains('integration-workbench-rail__item--active')).toBe(true)
+    const inactive = container!.querySelector('[data-testid="integration-rail-connection"]')
+    expect(inactive?.getAttribute('aria-current')).toBeNull()
+    expect(inactive?.classList.contains('integration-workbench-rail__item--active')).toBe(false)
+  })
+
+  it('emits select with the full clicked group object', async () => {
+    const selected: IntegrationWorkbenchRailGroup[] = []
+    await mountRail({ onSelect: (group: IntegrationWorkbenchRailGroup) => selected.push(group) })
+    ;(container!.querySelector('[data-testid="integration-rail-monitoring"]') as HTMLElement).click()
+    await flushUi(1)
+    expect(selected).toHaveLength(1)
+    expect(selected[0]).toEqual(railGroups.find((g) => g.id === 'monitoring'))
+  })
+})
+
+describe('IntegrationWorkbenchView — IU-2a chrome integration', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    apiGetMock.mockReset()
+    // Blanket empty-list response: this describe block only asserts chrome/DOM wiring
+    // (PageShell/PageHeader/rail/section ids/scroll behavior), not data-dependent rendering,
+    // so every endpoint the view's onMounted bootstrap calls can safely resolve to an empty list.
+    apiFetchMock.mockImplementation(async () => jsonResponse([]))
+    apiGetMock.mockImplementation(async () => jsonResponse([]))
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  async function mountView(): Promise<void> {
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.component('ElCard', defineComponent({
+      name: 'ElCard',
+      props: { shadow: { type: String, required: false, default: undefined } },
+      setup(_props, { slots }) {
+        return () => h('div', { class: 'el-card' }, [
+          slots.header ? h('div', { class: 'el-card__header' }, slots.header()) : null,
+          h('div', { class: 'el-card__body' }, slots.default?.()),
+        ])
+      },
+    }))
+    app.mount(container)
+    await flushUi()
+  }
+
+  const sectionIds = [
+    'int-sec-connection',
+    'int-sec-read-source',
+    'int-sec-combination-config',
+    'int-sec-combination-run',
+    'int-sec-object-template',
+    'int-sec-cleaning-dataset',
+    'int-sec-cleaning-rules',
+    'int-sec-run-push',
+    'int-sec-monitoring',
+    'int-sec-preview',
+  ]
+
+  it('renders PageShell (wide) + PageHeader chrome, the rail, and all ten section anchors', async () => {
+    await mountView()
+    expect(container!.querySelector('.ms-page-shell')).toBeTruthy()
+    expect(container!.querySelector('.ms-page-shell--wide')).toBeTruthy()
+    expect(container!.querySelector('.ms-page-header__title')?.textContent).toBe('数据工厂')
+    expect(container!.querySelector('[data-testid="integration-help-link"]')).toBeTruthy()
+    for (const groupId of ['connection', 'read-source', 'combination', 'cleaning-mapping', 'run-push', 'monitoring']) {
+      expect(container!.querySelector(`[data-testid="integration-rail-${groupId}"]`)).toBeTruthy()
+    }
+    for (const id of sectionIds) {
+      expect(container!.querySelector(`#${id}`)).toBeTruthy()
+    }
+  })
+
+  it('clicking a rail item scrolls its target section into view', async () => {
+    await mountView()
+    const target = container!.querySelector('#int-sec-monitoring') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+    ;(container!.querySelector('[data-testid="integration-rail-monitoring"]') as HTMLElement).click()
+    await flushUi(1)
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('mounts cleanly with no active-highlight crash when IntersectionObserver is unavailable', async () => {
+    // jsdom (this project's test environment) does not implement IntersectionObserver at all —
+    // no polyfill is registered anywhere in this test file. This asserts the view's feature-detect
+    // guard, not a simulated absence.
+    expect(typeof (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver).toBe('undefined')
+    await expect(mountView()).resolves.toBeUndefined()
+    expect(container!.querySelector('.integration-workbench-rail')).toBeTruthy()
+  })
+})

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -113,6 +113,43 @@ describe('IntegrationWorkbenchView', () => {
     container = null
   })
 
+  // IU-2a quality gate: the rail↔view WIRING is pinned here (the rail component's own spec uses
+  // fixture groups, so without this a dropped group — or the whole rail — in the view would pass
+  // every existing test). Six groups, each anchoring an existing section id.
+  it('wires the six rail groups to real section anchors', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      throw new Error(`unexpected URL ${url}`)
+    })
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('ElCard', ElCard)
+    app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+    const root = container
+    const expected: Array<[string, string]> = [
+      ['connection', 'int-sec-connection'],
+      ['read-source', 'int-sec-read-source'],
+      ['combination', 'int-sec-combination-config'],
+      ['cleaning-mapping', 'int-sec-object-template'],
+      ['run-push', 'int-sec-run-push'],
+      ['monitoring', 'int-sec-monitoring'],
+    ]
+    for (const [groupId, sectionId] of expected) {
+      const item = root.querySelector(`[data-testid="integration-rail-${groupId}"]`)
+      expect(item, `rail group ${groupId} must render`).not.toBeNull()
+      expect(root.querySelector(`#${sectionId}`), `section ${sectionId} must exist for ${groupId}`).not.toBeNull()
+    }
+    expect(root.querySelectorAll('[data-testid^="integration-rail-"]').length).toBe(6)
+  })
+
   it('loads systems, object schemas, and previews a template payload', async () => {
     const previewBodies: Array<Record<string, unknown>> = []
     const pipelineBodies: Array<Record<string, unknown>> = []

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1,5 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
+import { createApp, defineComponent, h, nextTick, type App as VueApp, type Component } from 'vue'
+
+// IU-2a: minimal ElCard stub — IntegrationWorkbenchView.vue now wraps each section in
+// `<el-card shadow="never">` with the panel-head (title/description/action button) in the
+// `#header` slot. Real Element Plus is not globally installed in this test's `createApp()`
+// instances, so `<el-card>` needs a local stub registered as `ElCard` (Vue resolves the
+// kebab-case template tag against the PascalCase component name) that renders both slots —
+// dropping the header slot would silently delete every panel's title/description/action
+// button from the test DOM.
+const ElCard = defineComponent({
+  name: 'ElCard',
+  props: { shadow: { type: String, required: false, default: undefined } },
+  setup(_props, { slots }) {
+    return () => h('div', { class: 'el-card' }, [
+      slots.header ? h('div', { class: 'el-card__header' }, slots.header()) : null,
+      h('div', { class: 'el-card__body' }, slots.default?.()),
+    ])
+  },
+})
 
 const apiFetchMock = vi.fn()
 const apiGetMock = vi.fn()
@@ -424,6 +442,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -856,6 +875,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -972,6 +992,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', {
       props: {
@@ -1116,6 +1137,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1156,6 +1178,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1260,6 +1283,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1354,6 +1378,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1413,6 +1438,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1475,6 +1501,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1542,6 +1569,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1598,6 +1626,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1644,6 +1673,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1756,6 +1786,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1860,6 +1891,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -1954,6 +1986,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -2038,6 +2071,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -2094,6 +2128,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -2142,6 +2177,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -2189,6 +2225,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -2240,6 +2277,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -2318,6 +2356,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -2459,6 +2498,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', {
       props: { to: { type: [String, Object], required: false, default: '' } },
@@ -2558,6 +2598,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
@@ -2622,6 +2663,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
@@ -2698,6 +2740,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
@@ -2791,6 +2834,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
@@ -2851,6 +2895,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
@@ -2911,6 +2956,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
@@ -2978,6 +3024,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     // eslint-disable-next-line vue/one-component-per-file
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
@@ -3087,6 +3134,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
     await flushUi(8)
@@ -3221,6 +3269,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
     await flushUi(8)
@@ -3364,6 +3413,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) { return () => h('a', slots.default?.()) },
@@ -3428,6 +3478,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
     await flushUi(8)
@@ -3499,6 +3550,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) { return () => h('a', slots.default?.()) },
@@ -3569,6 +3621,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) { return () => h('a', slots.default?.()) },
@@ -3621,6 +3674,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
     await flushUi(8)
@@ -3686,6 +3740,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
     await flushUi(8)
@@ -3748,6 +3803,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
     await flushUi(8)
@@ -3796,6 +3852,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
     await flushUi(8)
@@ -3852,6 +3909,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
     app.mount(container)
     await flushUi(8)
@@ -3935,6 +3993,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -4047,6 +4106,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -4202,6 +4262,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -4376,6 +4437,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -4548,6 +4610,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -4664,6 +4727,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -4746,6 +4810,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -4843,6 +4908,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {
@@ -4913,6 +4979,7 @@ describe('IntegrationWorkbenchView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    app.component('ElCard', ElCard)
     app.component('router-link', {
       props: ['to'],
       setup(_props, { slots }) {

--- a/apps/web/tests/ui-foundation-style-guard.spec.ts
+++ b/apps/web/tests/ui-foundation-style-guard.spec.ts
@@ -38,6 +38,11 @@ const TARGET_FILES = [
   'src/components/status/EmptyState.vue',
   'src/multitable/components/MetaAutomationManager.vue',
   'src/multitable/components/MetaAutomationRuleEditor.vue',
+  // IU-2a (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+  // §3 hard locks "token-only"): Workbench chrome slice tokenized its 142 hardcoded hex/rgb
+  // literals onto var(--ms-*)/--el-* and adds the new rail component clean from the start.
+  'src/views/IntegrationWorkbenchView.vue',
+  'src/components/integration/IntegrationWorkbenchRail.vue',
 ] as const
 
 // Per-file allowlist for counts that are legitimately un-clearable. Keep this EMPTY unless a

--- a/docs/development/integration-iu2a-workbench-chrome-dev-verification-20260707.md
+++ b/docs/development/integration-iu2a-workbench-chrome-dev-verification-20260707.md
@@ -1,0 +1,240 @@
+# IU-2a: Workbench chrome — PageShell + rail anchors + el-card sections + full tokenization — dev verification (2026-07-07)
+
+Scope: design-lock `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md`
+(RATIFIED, #3739) §2 IU-2 stage A ("解构第一段:壳与导航,零逻辑搬移") + §3 hard locks. Stage B
+(per-section component extraction + active-section switching) is a later slice, out of scope here.
+Base = origin/main including IU-1 #3743 (`errorCodeLabels.ts`) and IU-6 #3750
+(`IntegrationHelpView.vue` + `/help/integration` link).
+
+**Zero-behavior-change discipline**: no script logic moved, no `data-testid` renamed/removed, no
+service call / route contract / `v-if`/`v-model` semantics changed. The 49 pre-existing
+`IntegrationWorkbenchView.spec.ts` tests pass **unchanged** — that is this slice's proof.
+
+## What changed
+
+### 1. PageShell + PageHeader chrome
+
+`IntegrationWorkbenchView.vue`'s root is now wrapped in `<PageShell width="wide">` (mirroring
+`src/views/approval/TemplateAuthoringView.vue`'s adoption pattern). **Width tier choice: `wide`**
+(100%, not `default`'s 1200px) — the workbench is a six-group, multi-panel data-pipeline builder
+with a 5-column mapping-editor grid and a 2-column preview pane; `default`'s 1200px cap would
+force those grids into cramped columns, and the new sticky left rail needs its own horizontal
+budget alongside the section stack.
+
+The former hand-rolled `<header class="integration-workbench__header">` (eyebrow + h1 + lead +
+K3/help links) is replaced by:
+- `<p class="integration-workbench__eyebrow">Data Factory</p>` kept verbatim (same class, same
+  text), now positioned just above `<PageHeader>` instead of above the old raw `<h1>`.
+- `<PageHeader title="数据工厂" subtitle="连接任意 CRM / …">` — the original lead paragraph text
+  becomes the subtitle (same position/role: one line directly under the title).
+- The K3 WISE preset link + `/help/integration` link (`integration-help-link`, IU-6) move into
+  `PageHeader`'s `#actions` slot, verbatim (same router-links, same classes, same testid) — this is
+  the "keep/relocate the help link into PageHeader" instruction fulfilled.
+
+Dead CSS pruned as a direct consequence (no longer any element to select): `.integration-workbench
+h1`, `.integration-workbench__header` (both the flex rule and the two mobile media-query
+references), and the `.integration-workbench__lead` selector (merged away, `.integration-workbench__panel p`
+kept). `.integration-workbench`'s own `max-width/margin/padding` box-model rules were removed —
+PageShell now owns the outer container; the class stays only as the descendant-selector scope for
+`h2`/`input`/`select`/`textarea`/`code`/`pre`/`.panel` rules, which is why it wasn't deleted outright.
+
+### 2. Sticky left rail — `IntegrationWorkbenchRail.vue` (new)
+
+Structural mirror of `src/views/attendance/AttendanceAdminRail.vue`, deliberately simplified to
+this slice's scope: **six fixed groups**, no filter/expand/compact-toggle machinery (that rail
+manages a much larger admin surface; IU-2a is chrome + anchor navigation only). Presentational —
+props `groups: IntegrationWorkbenchRailGroup[]`, `activeGroupId`, `tr` (bilingual helper); emits
+`select(group)`. The view owns all state and DOM behavior.
+
+Groups (design-lock §2 IU-2 taxonomy) map onto the ten existing `<section>` blocks as follows —
+documented here because the mapping is not 1:1 and one group's sections are not DOM-contiguous:
+
+| Rail group | Section id(s) | Original `<h2>` |
+|---|---|---|
+| 连接管理 (connection) | `int-sec-connection` | 连接系统 / 数据源 |
+| 读取源 (read-source) | `int-sec-read-source` | 读取源配置(顾问自助) |
+| 组合 (combination) | `int-sec-combination-config`, `int-sec-combination-run` | 读取源组合配置 / 读取源组合运行 |
+| 清洗映射 (cleaning-mapping) | `int-sec-object-template`, `int-sec-cleaning-dataset`, `int-sec-cleaning-rules`, `int-sec-preview` | 选择系统与数据集 / 数据集与多维表清洗 / 清洗映射规则 / (样例记录+目标模板JSON+引用映射来源+Payload预览) |
+| 运行与推送 (run-push) | `int-sec-run-push` | 运行与推送 |
+| 监控与死信 (monitoring) | `int-sec-monitoring` | 运行监控 |
+
+Note: `int-sec-preview` (the JSON/field-rule-authoring/payload-preview panel) is the very last
+`<section>` in the DOM — physically after `int-sec-monitoring` — but assigned to 清洗映射 because
+its content (target-template JSON, reference-mapping bindings, field-rule authoring) is
+mapping-authoring work, not execution monitoring. Markup order could not change (zero-behavior-change
+constraint), so the rail's active-highlight will jump back to "清洗映射" if a user scrolls past
+monitoring to the very bottom — a documented, accepted quirk of a chrome-only slice, not a bug.
+
+**Behavior in this slice (anchor navigation only, no show/hide)**: clicking a rail button calls
+`document.getElementById(targetId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })` and
+optimistically sets the active group; a feature-detected `IntersectionObserver`
+(`typeof IntersectionObserver === 'undefined'` guard — true in this project's jsdom test
+environment, no polyfill installed) tracks scroll position across all ten section ids and updates
+the active highlight to whichever section has the highest `intersectionRatio`. All ten sections
+stay rendered unconditionally (no `v-if`) — that is what keeps the 49 tests green.
+
+### 3. Section chrome — `el-card shadow="never"` wrapping
+
+Each of the ten `<section class="integration-workbench__panel">` blocks got a stable `id` and is
+now wrapped in `<el-card shadow="never">`; the original `panel-head` div (title `<h2>` + description
+`<p>` + optional action button, e.g. `refresh-systems`/`add-mapping`/`save-pipeline`/
+`refresh-observation`) moved verbatim into the card's `#header` slot, with the rest of the
+section's original content in the default slot. This is a markup-wrapper-only change — no
+attribute, testid, `v-if`, or `v-model` inside any moved block was touched. The tenth section
+(`int-sec-preview`) has no single title (it contains four `<h2>`s across a two-column preview
+layout) so it is wrapped in `el-card` without using the header slot — its content stays in the
+default slot as-is.
+
+### 4. Tokenization — 142 → 0
+
+Style-block audit before this slice: **140** hex literals in `IntegrationWorkbenchView.vue`'s
+`<style scoped>` block (the design-lock's "142" audit figure is close enough — likely counted
+before/after an intervening one-line UF-6-era edit; the two other `#`-prefixed matches in the file,
+`#2232`/`#1970`, are GitHub issue references in comments, not colors, confirmed by inspection).
+Every literal mapped onto an existing `--ms-*`/`--el-*` token (mapping table below); **zero**
+hex/rgb literals remain (`grep -c` verified, and the file is now in `ui-foundation-style-guard.spec.ts`'s
+`TARGET_FILES`, so this is CI-enforced going forward, not just a one-time grep).
+
+Representative mappings (full set is 52 distinct source values → the token below; convergence of
+several near-identical legacy shades onto one token is intentional design-system consolidation):
+
+| Legacy hex family | Token |
+|---|---|
+| `#5c6878`/`#3c4b60`/`#54637a`/`#42536a`/`#5a6473` (secondary/body text) | `var(--ms-text-2)` |
+| `#1f3551`/`#17202a`/`#233246`/`#35465c`/`#24476b`/`#111827` (dark title/label text) | `var(--ms-text-1)` |
+| `#d8e0e8`/`#d7deea` (panel border) | `var(--ms-border-light)` |
+| `#e4ebf2` (thin dividers, table borders) | `var(--el-border-color-lighter)` |
+| `#bfccd9`/`#cbd5e1` (input/button border) | `var(--ms-border)` |
+| `#ffffff`/`#fbfcfe` (card background) | `var(--ms-bg-card)` |
+| `#f8fafc`/`#f8fbff` (subtle panel background) | `var(--ms-bg-page)` |
+| `#8f1d1d`/`#9b1c1c` (danger text) | `var(--el-color-danger)` |
+| `#fff0f0`/`#fbe7e7` (danger background) | `var(--el-color-danger-light-9)` |
+| `#17622f`/`#1f6f43` (success text) | `var(--el-color-success-dark-2)` |
+| `#edf7ef`/`#e3f3e8`/`#f3fbf5` (success background) | `var(--el-color-success-light-9)` |
+| `#744600`/`#92400e`/`#8a5a12`/`#8a4d00`/`#7c2d12`/`#7a4a00`/`#5b3417` (warning/brown text) | `var(--el-color-warning-dark-2)` |
+| `#fff8e8`/`#fffaf5`/`#fff7ed`/`#fdf3e0` (warning background) | `var(--el-color-warning-light-9)` |
+| `#f3d8bd`/`#f3c8a8` (warning border) | `var(--el-color-warning-light-7)` |
+| `#357abd`/`#1f5f99` (link/action blue) | `var(--ms-color-primary)` |
+| `#eef4fb`/`#eef2ff`/`#e7eef6`/`#e5edf7` (info/primary tint background) | `var(--el-color-primary-light-9)` |
+| `#111827` (dark `pre` background) | `var(--ms-text-1)` — this is an **exact** value match (tokens.css defines `--ms-text-1: #111827`) |
+| `#3730a3` | `var(--el-color-primary-dark-2)` |
+| `#b9dfc4` | `var(--el-color-success-light-7)` |
+| `#c77777` | `var(--el-color-danger-light-3)` |
+| `#eef2f7` | `var(--el-fill-color-light)` |
+
+All static `style="..."` attributes: zero before, zero after (none were ever present in this file).
+
+### 5. Nav orphan fix — `/data-sources`
+
+`apps/web/src/App.vue`: added one `router-link` to `/data-sources`, gated by the same
+`canUseIntegration` computed (`hasPermission('integration:write')`) as the existing 数据工厂 entry,
+placed immediately after it. New `navLabels.dataSources` key (`外接数据源` / `Data Sources`),
+matching the route's own `meta.titleZh`. No other nav restructuring.
+
+### 6. Help link
+
+Already present from IU-6 (`data-testid="integration-help-link"`, `to="/help/integration"`) —
+relocated into `PageHeader`'s `#actions` slot per item 1 above, text/route/testid unchanged.
+
+## Zero-behavior-change statement
+
+- No `services/integration/*.ts` file touched; no wire shape, route contract, or permission gate
+  changed.
+- No `data-testid` renamed or removed anywhere in `IntegrationWorkbenchView.vue`.
+- No `v-if`/`v-model` semantics changed — every conditional and binding is byte-identical to before,
+  only re-parented one level deeper (into `el-card`'s slots) where sections were wrapped.
+- `App.vue`: purely additive nav entry; existing entries/order otherwise unchanged.
+- `pnpm exec vue-tsc -b` clean (exit 0) on both Node 20.20.2 and the default local Node 25.9.0.
+
+## Test evidence
+
+**Baseline (before this slice, unmodified origin/main HEAD `ea62caaf8`)**, confirmed via
+`git stash` / run / `git stash pop` (not just "tests pass" — actually re-ran against the pristine
+file):
+
+```
+pnpm exec vitest run IntegrationWorkbenchView --reporter=dot
+✓ tests/IntegrationWorkbenchView.spec.ts  (49 tests)
+Test Files  1 passed (1) · Tests  49 passed (49)
+```
+
+**After this slice — the same 49 tests, unchanged assertions, still green** (only test-harness
+plumbing added: a local `ElCard` stub registered on each test's `createApp()` instance, since real
+Element Plus is not globally installed in this spec's test harness and the view now renders
+`<el-card>`; this is infrastructure, not a change to what any of the 49 tests assert):
+
+```
+pnpm exec vitest run IntegrationWorkbenchView --reporter=dot
+✓ tests/IntegrationWorkbenchView.spec.ts  (49 tests)
+Test Files  1 passed (1) · Tests  49 passed (49)
+```
+
+**New spec** `apps/web/tests/IntegrationWorkbenchRail.spec.ts` (6 tests): rail unit tests (renders
+all six groups, active-group `aria-current`/class, `select` emit carries the full group object) +
+a light Workbench integration check (PageShell `wide` + PageHeader title present, rail + all ten
+section ids present, a rail click calls `scrollIntoView` on the right section element, and the view
+mounts with no crash when `IntersectionObserver` is unavailable — jsdom's actual default, not
+simulated).
+
+**Style guard**: `IntegrationWorkbenchView.vue` and the new `IntegrationWorkbenchRail.vue` added to
+`ui-foundation-style-guard.spec.ts`'s `TARGET_FILES` (ADDED to the existing UF-6 mechanism, not
+duplicated — no new style-scan spec file was written).
+
+Full integration-guard list, extended with `IntegrationWorkbenchRail`, run on **both** runtimes:
+
+```
+pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror \
+  integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel \
+  IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel \
+  readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail \
+  IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot
+
+Test Files  12 passed (12) · Tests  187 passed (187)   [Node 20.20.2 AND Node 25.9.0]
+```
+
+Also ran, both runtimes:
+- `apps/web/tests/ui-foundation-style-guard.spec.ts` — 53 passed (was 47; +2 files × 2 axes + net
+  helper-test parity — style guard is green with both new files at zero hex/rgb and zero static
+  `style=`).
+- The full `approval-web-guard.yml` vitest filter list (which runs `ui-foundation-style-guard` and
+  `pageShell`) — 523 passed (29 files), confirming the `App.vue`/`PageShell`/`PageHeader` reuse
+  didn't regress the approval surface.
+- `apps/web/tests/App.spec.ts` — 2 passed (nav change doesn't touch anything it asserts).
+- `pnpm exec vue-tsc -b` — clean.
+
+Known noise, pre-existing and unrelated: `apps/web/tests/approvalStaticPicker.spec.ts` has 2 failing
+tests (`ensureUserOptionVisible` hydration assertions) — confirmed identical on unmodified
+origin/main via stash/run/pop; unrelated to this slice, not in any guard list this PR touches, left
+untouched. Console noise: `[Vue warn] Failed to resolve component: el-tooltip` (pre-existing, same
+as IU-6's note) and two new-but-harmless warnings from `PageHeader` in the bare test harness
+(`injection "Symbol(router)" not found`, `Failed to resolve component: el-icon/el-button` — both
+from `PageHeader`'s unconditional `useRouter()` call and its `v-if="showBack"`-gated back button,
+neither of which this view exercises since no `back`/`backTo` prop is passed); assertions are
+unaffected.
+
+## IU-2b remainder (explicitly NOT in this slice)
+
+- Per-section component extraction (splitting the six/ten-section monolith's script logic into
+  dedicated components) — this slice is chrome-only, zero script migration.
+- Active-section switching with show/hide (this slice keeps all ten sections permanently rendered;
+  only the rail highlight changes on scroll).
+- `IntegrationK3WiseSetupView.vue` tokenization (0/107 hex per the design-lock's audit baseline) —
+  out of IU-2a's named scope (`IntegrationWorkbenchView.vue` + nav wiring only).
+- IU-3/IU-4/IU-5 (read-source wizard, composition wizard, JSON-textarea structuring) remain
+  gated on IU-2 landing per the design-lock's slice ladder.
+
+## Files touched
+
+- `apps/web/src/views/IntegrationWorkbenchView.vue` (PageShell/PageHeader/rail wiring, ten
+  `el-card`-wrapped sections with stable ids, full style-block tokenization, dead-CSS pruning)
+- `apps/web/src/components/integration/IntegrationWorkbenchRail.vue` (new)
+- `apps/web/src/App.vue` (`/data-sources` nav entry + `navLabels.dataSources`)
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts` (ElCard test-harness stub only — no assertion
+  changes)
+- `apps/web/tests/IntegrationWorkbenchRail.spec.ts` (new)
+- `apps/web/tests/ui-foundation-style-guard.spec.ts` (`TARGET_FILES` +2)
+- `.github/workflows/integration-guard.yml` (path triggers + vitest run list +
+  `IntegrationWorkbenchRail`)
+- `.github/workflows/approval-web-guard.yml` (path triggers for the two files now covered by
+  `ui-foundation-style-guard.spec.ts`)
+- `docs/development/integration-iu2a-workbench-chrome-dev-verification-20260707.md` (this file)


### PR DESCRIPTION
## Summary

Stage A ("解构第一段:壳与导航,零逻辑搬移") of the Workbench decomposition per design-lock `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md` §2 IU-2, §3 hard locks. Zero-logic-migration chrome pass over `IntegrationWorkbenchView.vue` (5992→6236 lines):

- **PageShell + PageHeader**: wraps the view in `PageShell width="wide"` (chosen over `default`'s 1200px cap — this is a six-group multi-panel workbench with a 5-column mapping editor and a 2-column preview grid) + `PageHeader`, mirroring `approval/TemplateAuthoringView.vue`. Eyebrow/K3-link/help-link relocated verbatim.
- **Sticky rail** (`IntegrationWorkbenchRail.vue`, new): six design-lock groups (连接管理/读取源/组合/清洗映射/运行与推送/监控与死信), anchor navigation only — `scrollIntoView` + `IntersectionObserver`-driven active highlight, feature-detected/guarded where absent (jsdom's actual default). All ten sections stay rendered unconditionally.
- **Section chrome**: each of the ten `<section>` panels wrapped in `el-card shadow="never"`, panel-head (title+description+action button) moved into the `#header` slot verbatim, stable `id`s added for the rail's scroll targets.
- **Tokenization**: 140 hardcoded hex literals in the `<style>` block → `var(--ms-*)`/`var(--el-*)`, zero remaining. File added to `ui-foundation-style-guard.spec.ts`'s `TARGET_FILES` (CI-enforced going forward).
- **Nav orphan fix**: `/data-sources` added to `App.vue`'s global nav, gated by the same `canUseIntegration` permission as the existing 数据工厂 entry.
- CI: extended `integration-guard.yml` + `approval-web-guard.yml` path triggers and vitest run lists for the new spec/component.

**Zero behavior change**: no service/wire/route/permission changes; no `data-testid` renamed/removed; no `v-if`/`v-model` semantics touched.

## Test plan

- [x] Baseline: 49 pre-existing `IntegrationWorkbenchView.spec.ts` tests confirmed green on unmodified `origin/main` (via `git stash`/run/pop).
- [x] After: same 49 tests pass **unchanged** (only a local `ElCard` test-harness stub added, since real Element Plus isn't globally installed in that spec's `createApp()` instances).
- [x] New `apps/web/tests/IntegrationWorkbenchRail.spec.ts` (6 tests): rail unit tests + Workbench chrome/scroll/IntersectionObserver-absent integration checks.
- [x] `ui-foundation-style-guard.spec.ts` green with the two new files at zero hex/rgb and zero static `style=`.
- [x] Full `integration-guard.yml` vitest list (12 files / 187 tests) green on **both** Node 20.20.2 (via nvm) and default local Node 25.9.0.
- [x] Full `approval-web-guard.yml` vitest list (29 files / 523 tests) green — confirms PageShell/PageHeader reuse doesn't regress the approval surface.
- [x] `apps/web/tests/App.spec.ts` green.
- [x] `pnpm exec vue-tsc -b` clean.
- [x] `pnpm --filter @metasheet/web build` succeeds.
- [x] Dev-verification MD: `docs/development/integration-iu2a-workbench-chrome-dev-verification-20260707.md` (hex 140→0 mapping table, zero-behavior-change statement, IU-2b remainder note).

Known pre-existing/unrelated failure (confirmed identical on unmodified `origin/main`, not in any guard list this PR touches): `apps/web/tests/approvalStaticPicker.spec.ts` — 2 `ensureUserOptionVisible` hydration assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)