### PR TITLE
feat(web): multitable UI P2-1c slice-1 — migrate MetaToolbar action buttons to shared MtButton/MtIconButton

### DIFF
--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -116,10 +116,10 @@
         </div>
       </div>
 
-      <!-- Undo/Redo -->
+      <!-- Undo/Redo (UI-P2-1c: migrated to shared MtIconButton — ghost, icon-only) -->
       <span class="meta-toolbar__divider" aria-hidden="true"></span>
-      <button class="meta-toolbar__btn" :disabled="!canUndo" :title="l('toolbar.undoTitle')" :aria-label="l('toolbar.undo')" @click="emit('undo')"><el-icon class="meta-toolbar__btn-icon"><component :is="ICON.undo" /></el-icon></button>
-      <button class="meta-toolbar__btn" :disabled="!canRedo" :title="l('toolbar.redoTitle')" :aria-label="l('toolbar.redo')" @click="emit('redo')"><el-icon class="meta-toolbar__btn-icon"><component :is="ICON.redo" /></el-icon></button>
+      <MtIconButton :icon="ICON.undo" :disabled="!canUndo" :title="l('toolbar.undoTitle')" :aria-label="l('toolbar.undo')" @click="emit('undo')" />
+      <MtIconButton :icon="ICON.redo" :disabled="!canRedo" :title="l('toolbar.redoTitle')" :aria-label="l('toolbar.redo')" @click="emit('redo')" />
       <!--
         Slice 3 personal-views "reset to shared" (design-lock multitable-personal-views-slice3-fe-toggle-
         design-lock-20260706.md §3 P1 + G-FE-3 / G-FE-4): rendered ONLY while the personal toggle is ON for
@@ -152,12 +152,29 @@
           </label>
         </div>
       </div>
-      <button class="meta-toolbar__btn" :title="l('toolbar.autoFitColumns')" :aria-label="l('toolbar.autoFitColumns')" @click="emit('auto-fit-columns')"><el-icon class="meta-toolbar__btn-icon"><component :is="ICON.fit" /></el-icon> {{ l('toolbar.fit') }}</button>
-      <button class="meta-toolbar__btn" :title="l('toolbar.print')" :aria-label="l('toolbar.printGrid')" @click="emit('print')"><el-icon class="meta-toolbar__btn-icon"><component :is="ICON.print" /></el-icon> {{ l('toolbar.print') }}</button>
-      <button v-if="canCreateRecord" class="meta-toolbar__btn" :title="l('toolbar.importRecords')" :aria-label="l('toolbar.importRecords')" @click="emit('import')"><el-icon class="meta-toolbar__btn-icon"><component :is="ICON.import" /></el-icon> {{ l('toolbar.import') }}</button>
-      <button v-if="canExport" class="meta-toolbar__btn" :title="l('toolbar.exportCsv')" :aria-label="l('toolbar.exportCsv')" @click="emit('export-csv')"><el-icon class="meta-toolbar__btn-icon"><component :is="ICON.export" /></el-icon> {{ l('toolbar.exportCsv') }}</button>
-      <button v-if="canExport" class="meta-toolbar__btn" :title="l('toolbar.exportExcelXlsx')" :aria-label="l('toolbar.exportExcel')" @click="emit('export-xlsx')"><el-icon class="meta-toolbar__btn-icon"><component :is="ICON.export" /></el-icon> {{ l('toolbar.exportXlsx') }}</button>
-      <button v-if="canCreateRecord" class="meta-toolbar__btn meta-toolbar__btn--primary" @click="emit('add-record')">{{ l('toolbar.newRecord') }}</button>
+      <!-- UI-P2-1c: standalone action buttons (icon+label) migrated to shared MtButton (ghost). -->
+      <MtButton :title="l('toolbar.autoFitColumns')" :aria-label="l('toolbar.autoFitColumns')" @click="emit('auto-fit-columns')">
+        <template #icon><el-icon><component :is="ICON.fit" /></el-icon></template>
+        {{ l('toolbar.fit') }}
+      </MtButton>
+      <MtButton :title="l('toolbar.print')" :aria-label="l('toolbar.printGrid')" @click="emit('print')">
+        <template #icon><el-icon><component :is="ICON.print" /></el-icon></template>
+        {{ l('toolbar.print') }}
+      </MtButton>
+      <MtButton v-if="canCreateRecord" :title="l('toolbar.importRecords')" :aria-label="l('toolbar.importRecords')" @click="emit('import')">
+        <template #icon><el-icon><component :is="ICON.import" /></el-icon></template>
+        {{ l('toolbar.import') }}
+      </MtButton>
+      <MtButton v-if="canExport" :title="l('toolbar.exportCsv')" :aria-label="l('toolbar.exportCsv')" @click="emit('export-csv')">
+        <template #icon><el-icon><component :is="ICON.export" /></el-icon></template>
+        {{ l('toolbar.exportCsv') }}
+      </MtButton>
+      <MtButton v-if="canExport" :title="l('toolbar.exportExcelXlsx')" :aria-label="l('toolbar.exportExcel')" @click="emit('export-xlsx')">
+        <template #icon><el-icon><component :is="ICON.export" /></el-icon></template>
+        {{ l('toolbar.exportXlsx') }}
+      </MtButton>
+      <!-- UI-P2-1c: primary CTA migrated to shared MtButton variant="primary". -->
+      <MtButton v-if="canCreateRecord" variant="primary" @click="emit('add-record')">{{ l('toolbar.newRecord') }}</MtButton>
     </div>
   </div>
 </template>
@@ -169,6 +186,11 @@ import type { SortRule, FilterRule, FilterGroup, FilterConjunction } from '../co
 import { useLocale } from '../../composables/useLocale'
 import MetaFilterConditionRow from './MetaFilterConditionRow.vue'
 import MetaFilterGroup from './MetaFilterGroup.vue'
+// UI-P2-1c: migrate standalone action buttons (undo/redo/fit/print/import/export/new-record) onto
+// the shared UI primitives (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1). Dropdown
+// triggers that open a `.meta-toolbar__panel` (fields/sort/filter/group/row-density) are NOT touched
+// in this slice — that migration needs MtPopover/MtMenu and is a later slice.
+import { MtButton, MtIconButton } from '../ui'
 import { seedFilterCondition } from '../utils/filter-condition-seed'
 import {
   metaCoreLabel,

--- a/apps/web/tests/meta-toolbar-action-buttons-migration.spec.ts
+++ b/apps/web/tests/meta-toolbar-action-buttons-migration.spec.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaToolbar from '../src/multitable/components/MetaToolbar.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaToolbar's standalone action buttons (undo/redo/fit/print/import/export/new-record)
+// were migrated from bespoke `<button class="meta-toolbar__btn">` markup to the shared MtButton /
+// MtIconButton primitives (apps/web/src/multitable/ui). This is an interaction-preservation proof,
+// not a snapshot: every migrated control must still be a real, keyboard-operable <button> that
+// emits the exact same event (same name, same — absent — payload) it emitted before migration, and
+// disabled ones must still carry the native `disabled` attribute so a click never fires the emit.
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+beforeEach(() => { useLocale().setLocale('en') })
+afterEach(() => {
+  app?.unmount(); app = null
+  container?.remove(); container = null
+  useLocale().setLocale('en')
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'status', name: 'Status', type: 'select', options: [{ value: 'a' }] },
+]
+
+function mountToolbar(props: Record<string, unknown>) {
+  container = document.createElement('div'); document.body.appendChild(container)
+  app = createApp({ setup: () => () => h(MetaToolbar, {
+    fields: FIELDS, hiddenFieldIds: [], sortRules: [], filterRules: [], filterConjunction: 'and',
+    canCreateRecord: true, canExport: true, canUndo: true, canRedo: true, sortFilterDirty: false,
+    ...props,
+  }) })
+  app.mount(container)
+  return container
+}
+
+function byTitle(root: HTMLElement, title: string): HTMLButtonElement {
+  const btn = root.querySelector(`button[title="${title}"]`) as HTMLButtonElement | null
+  expect(btn, `expected a <button title="${title}">`).toBeTruthy()
+  return btn as HTMLButtonElement
+}
+
+describe('MetaToolbar action buttons — MtButton/MtIconButton migration (UI-P2-1c)', () => {
+  it('undo: is a native <button>, emits undo() when enabled, is disabled (and inert) when canUndo=false', () => {
+    const onUndo = vi.fn()
+    const root = mountToolbar({ canUndo: true, onUndo })
+    const btn = byTitle(root, 'Undo (Ctrl+Z)')
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.getAttribute('aria-label')).toBe('Undo')
+    expect(btn.disabled).toBe(false)
+    btn.click()
+    expect(onUndo).toHaveBeenCalledTimes(1)
+    expect(onUndo).toHaveBeenCalledWith() // no payload — matches pre-migration `emit('undo')`
+  })
+
+  it('undo: disabled when canUndo=false — native disabled attribute, click emits nothing', () => {
+    const onUndo = vi.fn()
+    const root = mountToolbar({ canUndo: false, onUndo })
+    const btn = byTitle(root, 'Undo (Ctrl+Z)')
+    expect(btn.disabled).toBe(true)
+    btn.click()
+    expect(onUndo).not.toHaveBeenCalled()
+  })
+
+  it('redo: is a native <button>, emits redo() when enabled, is disabled when canRedo=false', () => {
+    const onRedo = vi.fn()
+    const root = mountToolbar({ canRedo: true, onRedo })
+    const btn = byTitle(root, 'Redo (Ctrl+Y)')
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.getAttribute('aria-label')).toBe('Redo')
+    expect(btn.disabled).toBe(false)
+    btn.click()
+    expect(onRedo).toHaveBeenCalledTimes(1)
+    expect(onRedo).toHaveBeenCalledWith()
+  })
+
+  it('redo: disabled when canRedo=false — click emits nothing', () => {
+    const onRedo = vi.fn()
+    const root = mountToolbar({ canRedo: false, onRedo })
+    const btn = byTitle(root, 'Redo (Ctrl+Y)')
+    expect(btn.disabled).toBe(true)
+    btn.click()
+    expect(onRedo).not.toHaveBeenCalled()
+  })
+
+  it('fit: emits auto-fit-columns()', () => {
+    const onAutoFitColumns = vi.fn()
+    const root = mountToolbar({ onAutoFitColumns })
+    const btn = byTitle(root, 'Auto-fit columns')
+    expect(btn.tagName).toBe('BUTTON')
+    btn.click()
+    expect(onAutoFitColumns).toHaveBeenCalledTimes(1)
+    expect(onAutoFitColumns).toHaveBeenCalledWith()
+  })
+
+  it('print: emits print()', () => {
+    const onPrint = vi.fn()
+    const root = mountToolbar({ onPrint })
+    const btn = byTitle(root, 'Print')
+    expect(btn.tagName).toBe('BUTTON')
+    btn.click()
+    expect(onPrint).toHaveBeenCalledTimes(1)
+    expect(onPrint).toHaveBeenCalledWith()
+  })
+
+  it('import: emits import() when canCreateRecord=true, is absent when canCreateRecord=false', () => {
+    const onImport = vi.fn()
+    const root = mountToolbar({ canCreateRecord: true, onImport })
+    const btn = byTitle(root, 'Import records')
+    expect(btn.tagName).toBe('BUTTON')
+    btn.click()
+    expect(onImport).toHaveBeenCalledTimes(1)
+    expect(onImport).toHaveBeenCalledWith()
+
+    const root2 = mountToolbar({ canCreateRecord: false })
+    expect(root2.querySelector('button[title="Import records"]')).toBeNull()
+  })
+
+  it('export-csv: emits export-csv() when canExport=true, is absent when canExport=false', () => {
+    const onExportCsv = vi.fn()
+    const root = mountToolbar({ canExport: true, onExportCsv })
+    const btn = byTitle(root, 'Export CSV')
+    expect(btn.tagName).toBe('BUTTON')
+    btn.click()
+    expect(onExportCsv).toHaveBeenCalledTimes(1)
+    expect(onExportCsv).toHaveBeenCalledWith()
+
+    const root2 = mountToolbar({ canExport: false })
+    expect(root2.querySelector('button[title="Export CSV"]')).toBeNull()
+  })
+
+  it('export-xlsx: emits export-xlsx() when canExport=true, is absent when canExport=false', () => {
+    const onExportXlsx = vi.fn()
+    const root = mountToolbar({ canExport: true, onExportXlsx })
+    const btn = byTitle(root, 'Export Excel (.xlsx)')
+    expect(btn.tagName).toBe('BUTTON')
+    btn.click()
+    expect(onExportXlsx).toHaveBeenCalledTimes(1)
+    expect(onExportXlsx).toHaveBeenCalledWith()
+
+    const root2 = mountToolbar({ canExport: false })
+    expect(root2.querySelector('button[title="Export Excel (.xlsx)"]')).toBeNull()
+  })
+
+  it('new record: primary CTA emits add-record() when canCreateRecord=true, is absent when false', () => {
+    const onAddRecord = vi.fn()
+    const root = mountToolbar({ canCreateRecord: true, onAddRecord })
+    const btn = Array.from(root.querySelectorAll('button')).find((b) => b.textContent?.trim() === '+ New Record') as HTMLButtonElement
+    expect(btn, 'expected the "+ New Record" primary CTA button').toBeTruthy()
+    expect(btn.tagName).toBe('BUTTON')
+    btn.click()
+    expect(onAddRecord).toHaveBeenCalledTimes(1)
+    expect(onAddRecord).toHaveBeenCalledWith()
+
+    const root2 = mountToolbar({ canCreateRecord: false })
+    expect(Array.from(root2.querySelectorAll('button')).some((b) => b.textContent?.trim() === '+ New Record')).toBe(false)
+  })
+
+  it('reset-to-shared is untouched by this slice: still renders via data-testid, still a plain button', () => {
+    const onResetToShared = vi.fn()
+    const root = mountToolbar({ canResetToShared: true, onResetToShared })
+    const btn = root.querySelector('[data-testid="reset-to-shared"]') as HTMLButtonElement
+    expect(btn).toBeTruthy()
+    expect(btn.tagName).toBe('BUTTON')
+    btn.click()
+    expect(onResetToShared).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/tests/meta-toolbar-action-buttons-migration.spec.ts
+++ b/apps/web/tests/meta-toolbar-action-buttons-migration.spec.ts
@@ -11,13 +11,20 @@ import { useLocale } from '../src/composables/useLocale'
 // emits the exact same event (same name, same — absent — payload) it emitted before migration, and
 // disabled ones must still carry the native `disabled` attribute so a click never fires the emit.
 
-let app: App<Element> | null = null
-let container: HTMLDivElement | null = null
+// Track EVERY mount, not a single shared app/container: several tests mount the toolbar twice (the
+// present-vs-absent-by-prop cases), and a shared global would leave the first tree in document.body
+// after teardown — DOM pollution that risks false-pass / cross-talk once later slices migrate more
+// toolbar controls. afterEach unmounts ALL of them and asserts no toolbar DOM survives.
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
 
 beforeEach(() => { useLocale().setLocale('en') })
 afterEach(() => {
-  app?.unmount(); app = null
-  container?.remove(); container = null
+  while (mounts.length) {
+    const m = mounts.pop()!
+    m.app.unmount()
+    m.container.remove()
+  }
+  expect(document.querySelectorAll('.meta-toolbar').length).toBe(0) // residue guard: no leaked toolbar
   useLocale().setLocale('en')
 })
 
@@ -26,13 +33,14 @@ const FIELDS: MetaField[] = [
 ]
 
 function mountToolbar(props: Record<string, unknown>) {
-  container = document.createElement('div'); document.body.appendChild(container)
-  app = createApp({ setup: () => () => h(MetaToolbar, {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaToolbar, {
     fields: FIELDS, hiddenFieldIds: [], sortRules: [], filterRules: [], filterConjunction: 'and',
     canCreateRecord: true, canExport: true, canUndo: true, canRedo: true, sortFilterDirty: false,
     ...props,
   }) })
   app.mount(container)
+  mounts.push({ app, container })
   return container
 }
 


### PR DESCRIPTION
First **P2-1c migration** (behavior-adjacent — NOT self-merged; yours to review). Migrates MetaToolbar's standalone action buttons onto the shared primitives; no behavior change.

## Migrated (7)
undo/redo → MtIconButton (ghost); fit/print/import/export-csv/export-xlsx → MtButton (ghost, icon+label); 新建记录 → MtButton primary. Preserved every `:disabled`/`v-if`/`:title`/`:aria-label`/`@click` emit.

## Left as-is (deliberate)
- Dropdown triggers (字段/排序/筛选/分组) — need MtPopover/MtMenu = later slice.
- **Row density ("行高")** — FLAGGED: structurally a dropdown-trigger (toggles a `.meta-toolbar__panel--density`), so treated like the others and deferred, NOT migrated. (The task named it a candidate, but it opens a panel — I kept the panel-trigger rule consistent rather than guess. Say the word if you want it in this slice.)
- reset-to-shared — untouched (green styling; MtButton has no success variant; `data-testid` intact).

## Invariant proof + tests
- **emit() call-site set byte-identical vs main** (all 24 event types, same names + counts) — no emit drift.
- New `meta-toolbar-action-buttons-migration.spec.ts` (11 tests): each migrated button click → same emit; disabled → native `disabled` + no emit; gated buttons absent when prop false; all migrated controls are `<button>` (keyboard-operable). Real emit assertions, not snapshots.
- Regression: `meta-toolbar-group-picker` + `filter-builder` specs still pass → **41/41** across the 3 MetaToolbar specs. vue-tsc clean; token-only; diff = only MetaToolbar.vue + the new test.

Note: some `MultitableWorkbench`-mounting specs fail in a fresh worktree with a pre-existing `grid.filterGroups`/`auth.getToken` fixture gap — verified identical on unmodified main (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)