### PR TITLE
feat(web): multitable UI P2-1c slice-2 — MetaToolbar density dropdown → MtPopover/MtMenu

### DIFF
--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -142,16 +142,26 @@
       </div>
       <span v-if="totalRows !== undefined" class="meta-toolbar__row-count">{{ rowCount(totalRows, isZh) }}</span>
       <span class="meta-toolbar__divider" aria-hidden="true"></span>
-      <!-- Row density -->
-      <div class="meta-toolbar__dropdown">
-        <button class="meta-toolbar__btn" :title="l('toolbar.rowHeight')" :aria-label="l('toolbar.rowHeight')" @click="showDensityPanel = !showDensityPanel"><el-icon class="meta-toolbar__btn-icon"><component :is="ICON.rowHeight" /></el-icon> {{ l('toolbar.rows') }}</button>
-        <div v-if="showDensityPanel" class="meta-toolbar__panel meta-toolbar__panel--density" @keydown.escape="showDensityPanel = false">
-          <label v-for="d in DENSITIES" :key="d.value" class="meta-toolbar__field-toggle">
-            <input type="radio" name="density" :checked="rowDensity === d.value" @change="emit('set-row-density', d.value); showDensityPanel = false" />
-            <span>{{ l(d.labelKey) }}</span>
-          </label>
-        </div>
-      </div>
+      <!-- Row density (UI-P2-1c slice-2: migrated to shared MtMenu/MtMenuItem, built on MtPopover) -->
+      <MtMenu>
+        <template #trigger>
+          <MtButton :title="l('toolbar.rowHeight')" :aria-label="l('toolbar.rowHeight')">
+            <template #icon><el-icon><component :is="ICON.rowHeight" /></el-icon></template>
+            {{ l('toolbar.rows') }}
+          </MtButton>
+        </template>
+        <MtMenuItem
+          v-for="d in DENSITIES"
+          :key="d.value"
+          class="meta-toolbar__density-item"
+          :class="{ 'meta-toolbar__density-item--active': rowDensity === d.value }"
+          :aria-current="rowDensity === d.value ? 'true' : undefined"
+          @select="emit('set-row-density', d.value)"
+        >
+          <template #icon><el-icon v-if="rowDensity === d.value"><component :is="ICON.check" /></el-icon></template>
+          {{ l(d.labelKey) }}
+        </MtMenuItem>
+      </MtMenu>
       <!-- UI-P2-1c: standalone action buttons (icon+label) migrated to shared MtButton (ghost). -->
       <MtButton :title="l('toolbar.autoFitColumns')" :aria-label="l('toolbar.autoFitColumns')" @click="emit('auto-fit-columns')">
         <template #icon><el-icon><component :is="ICON.fit" /></el-icon></template>
@@ -187,10 +197,12 @@ import { useLocale } from '../../composables/useLocale'
 import MetaFilterConditionRow from './MetaFilterConditionRow.vue'
 import MetaFilterGroup from './MetaFilterGroup.vue'
 // UI-P2-1c: migrate standalone action buttons (undo/redo/fit/print/import/export/new-record) onto
-// the shared UI primitives (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1). Dropdown
-// triggers that open a `.meta-toolbar__panel` (fields/sort/filter/group/row-density) are NOT touched
-// in this slice — that migration needs MtPopover/MtMenu and is a later slice.
-import { MtButton, MtIconButton } from '../ui'
+// the shared UI primitives (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1). Slice-2
+// additionally migrates the row-density dropdown onto MtMenu/MtMenuItem (built on MtPopover), so
+// its open/close + click-outside/Escape no longer need a hand-rolled `showDensityPanel` ref. The
+// remaining dropdown triggers that open a `.meta-toolbar__panel` (fields/sort/filter/group) are NOT
+// touched in this slice — each is a more complex builder deferred to a later slice.
+import { MtButton, MtIconButton, MtMenu, MtMenuItem } from '../ui'
 import { seedFilterCondition } from '../utils/filter-condition-seed'
 import {
   metaCoreLabel,
@@ -211,6 +223,7 @@ import {
   Printer as IconPrint,
   Upload as IconImport,
   Download as IconExport,
+  Check as IconCheck,
 } from '@element-plus/icons-vue'
 
 // Reusable monochrome icon map for toolbar buttons (UI-P1 slice-1). Keyed by toolbar action so the
@@ -228,6 +241,7 @@ const ICON = {
   print: IconPrint,
   import: IconImport,
   export: IconExport,
+  check: IconCheck,
 } as const
 
 const props = withDefaults(defineProps<{
@@ -288,7 +302,6 @@ const showFieldPicker = ref(false)
 const showSortPanel = ref(false)
 const showFilterPanel = ref(false)
 const showGroupPanel = ref(false)
-const showDensityPanel = ref(false)
 const DENSITIES: Array<{ value: RowDensity; labelKey: MetaCoreLabelKey }> = [
   { value: 'compact', labelKey: 'density.compact' },
   { value: 'normal', labelKey: 'density.normal' },
@@ -393,7 +406,6 @@ function onAddFilterGroup() {
 .meta-toolbar__dropdown { position: relative; }
 .meta-toolbar__panel { position: absolute; top: 100%; left: 0; z-index: 20; min-width: 200px; background: var(--ms-bg-card, #fff); border: 1px solid var(--ms-border-light, #e7e8ec); border-radius: var(--ms-radius-sm, 6px); box-shadow: var(--ms-shadow-pop, 0 4px 12px rgba(0,0,0,.1)); padding: 8px; margin-top: 4px; }
 .meta-toolbar__panel--filter { min-width: 420px; }
-.meta-toolbar__panel--density { min-width: 120px; }
 .meta-toolbar__field-toggle { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 13px; cursor: pointer; }
 .meta-toolbar__sort-rule, .meta-toolbar__filter-rule { display: flex; gap: 4px; margin-bottom: 4px; align-items: center; }
 .meta-toolbar__sort-rule select, .meta-toolbar__filter-rule select { padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }
@@ -429,5 +441,7 @@ function onAddFilterGroup() {
 .meta-toolbar__search-clear { border: none; background: none; color: #999; cursor: pointer; font-size: 14px; padding: 0 2px; line-height: 1; }
 .meta-toolbar__search-clear:hover { color: #f56c6c; }
 .meta-toolbar__row-count { font-size: 11px; color: #999; white-space: nowrap; }
+/* Row-density menu (UI-P2-1c slice-2): current selection indicator, replaces the old radio `checked`. */
+.meta-toolbar__density-item--active { color: var(--ms-color-primary); font-weight: 600; }
 @media print { .meta-toolbar { display: none !important; } }
 </style>

--- a/apps/web/tests/meta-toolbar-density-menu-migration.spec.ts
+++ b/apps/web/tests/meta-toolbar-density-menu-migration.spec.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaToolbar from '../src/multitable/components/MetaToolbar.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c slice-2: MetaToolbar's row-density ("行高") dropdown was migrated from a hand-rolled
+// `.meta-toolbar__dropdown` + `showDensityPanel` ref + `.meta-toolbar__panel--density` radio-list
+// markup to the shared MtMenu/MtMenuItem primitives (built on MtPopover, Teleported to
+// `document.body`). This is an interaction-preservation proof, not a snapshot: the trigger must
+// open the menu, each option must still emit the exact same `set-row-density` event (same name,
+// same payload value) it emitted before migration, the option must be a real keyboard-operable
+// `<button role="menuitem">`, and selecting an option must close the menu.
+
+// Track EVERY mount, not a single shared app/container (see meta-toolbar-action-buttons-migration
+// .spec.ts): a shared global would leave a stale tree (and, here, stale Teleported `.mt-popover`
+// content on document.body) after teardown — DOM pollution that risks false-pass / cross-talk
+// across tests. afterEach unmounts ALL of them and asserts no toolbar DOM survives.
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+
+beforeEach(() => { useLocale().setLocale('en') })
+afterEach(() => {
+  while (mounts.length) {
+    const m = mounts.pop()!
+    m.app.unmount()
+    m.container.remove()
+  }
+  expect(document.querySelectorAll('.meta-toolbar').length).toBe(0) // residue guard: no leaked toolbar
+  // Belt-and-suspenders: the density menu Teleports its panel to document.body — nothing from it
+  // should survive unmount either.
+  expect(document.querySelectorAll('.mt-popover').length).toBe(0)
+  useLocale().setLocale('en')
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'status', name: 'Status', type: 'select', options: [{ value: 'a' }] },
+]
+
+function mountToolbar(props: Record<string, unknown>) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaToolbar, {
+    fields: FIELDS, hiddenFieldIds: [], sortRules: [], filterRules: [], filterConjunction: 'and',
+    canCreateRecord: true, canExport: true, canUndo: true, canRedo: true, sortFilterDirty: false,
+    ...props,
+  }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+function densityTrigger(root: HTMLElement): HTMLButtonElement {
+  const btn = root.querySelector('button[title="Row height"]') as HTMLButtonElement | null
+  expect(btn, 'expected a <button title="Row height"> trigger').toBeTruthy()
+  return btn as HTMLButtonElement
+}
+
+describe('MetaToolbar row-density dropdown — MtMenu/MtMenuItem migration (UI-P2-1c slice-2)', () => {
+  it('is closed until the trigger is clicked; clicking it opens the menu with the 3 density options', async () => {
+    const root = mountToolbar({ rowDensity: 'normal' })
+    expect(document.querySelector('.mt-menu')).toBeNull()
+
+    const trigger = densityTrigger(root)
+    expect(trigger.tagName).toBe('BUTTON')
+    expect(trigger.getAttribute('aria-label')).toBe('Row height')
+    trigger.click()
+    await nextTick()
+
+    const menu = document.querySelector('.mt-menu')
+    expect(menu).not.toBeNull()
+    const items = Array.from(document.querySelectorAll('.mt-menu-item')) as HTMLButtonElement[]
+    expect(items.map((i) => i.textContent?.trim())).toEqual(['Compact', 'Normal', 'Expanded'])
+  })
+
+  it('each density option is a native keyboard-operable <button role="menuitem">', async () => {
+    const root = mountToolbar({ rowDensity: 'normal' })
+    densityTrigger(root).click()
+    await nextTick()
+
+    const items = Array.from(document.querySelectorAll('.mt-menu-item')) as HTMLButtonElement[]
+    expect(items.length).toBe(3)
+    for (const item of items) {
+      expect(item.tagName).toBe('BUTTON')
+      expect(item.getAttribute('type')).toBe('button')
+      expect(item.getAttribute('role')).toBe('menuitem')
+      expect(item.disabled).toBe(false)
+    }
+  })
+
+  it.each([
+    ['Compact', 'compact'],
+    ['Normal', 'normal'],
+    ['Expanded', 'expanded'],
+  ])('clicking "%s" emits set-row-density(%j) — same event name + payload as before migration — and closes the menu', async (label, value) => {
+    const onSetRowDensity = vi.fn()
+    const root = mountToolbar({ rowDensity: 'normal', onSetRowDensity })
+    densityTrigger(root).click()
+    await nextTick()
+
+    const item = Array.from(document.querySelectorAll('.mt-menu-item'))
+      .find((el) => el.textContent?.trim() === label) as HTMLButtonElement
+    expect(item, `expected a density option labeled "${label}"`).toBeTruthy()
+    item.click()
+    await nextTick()
+
+    expect(onSetRowDensity).toHaveBeenCalledTimes(1)
+    expect(onSetRowDensity).toHaveBeenCalledWith(value)
+    expect(document.querySelector('.mt-menu')).toBeNull() // selecting an option closes the popover
+  })
+
+  it('marks the current density as active (aria-current + active class) among the rendered options', async () => {
+    const root = mountToolbar({ rowDensity: 'compact' })
+    densityTrigger(root).click()
+    await nextTick()
+
+    const items = Array.from(document.querySelectorAll('.mt-menu-item')) as HTMLButtonElement[]
+    const compact = items.find((i) => i.textContent?.trim() === 'Compact')!
+    const normal = items.find((i) => i.textContent?.trim() === 'Normal')!
+    expect(compact.getAttribute('aria-current')).toBe('true')
+    expect(compact.classList.contains('meta-toolbar__density-item--active')).toBe(true)
+    expect(normal.getAttribute('aria-current')).toBeNull()
+    expect(normal.classList.contains('meta-toolbar__density-item--active')).toBe(false)
+  })
+
+  it('a second click on the trigger closes the menu again (no option selected, no emit)', async () => {
+    const onSetRowDensity = vi.fn()
+    const root = mountToolbar({ rowDensity: 'normal', onSetRowDensity })
+    const trigger = densityTrigger(root)
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-menu')).not.toBeNull()
+
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-menu')).toBeNull()
+    expect(onSetRowDensity).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Second P2-1c migration (serial after #3773; behavior-adjacent — NOT self-merged). **First real use of the P2-1b overlay primitives.** Migrates MetaToolbar's row-density ("行高") dropdown from a hand-rolled `showDensityPanel` toggle + `.meta-toolbar__panel--density` radio panel to **MtMenu/MtMenuItem on MtPopover**.

## Change (density dropdown only)
- Trigger → `MtButton` (same `title`/`aria-label`). Options → `MtMenuItem`s (native `<button role=menuitem>`, keyboard-operable). Open/close now via MtPopover (Esc + click-outside for free); removed the dead `showDensityPanel` ref + `.meta-toolbar__panel--density` CSS.
- Current selection: `Check` icon + `aria-current="true"` + active class (replaces the radio `checked`).
- Other 4 dropdowns (字段/排序/筛选/分组) + all slice-1 buttons untouched.

## Invariant proof + tests
- **emit() call-site set byte-identical vs main** (24 events); `set-row-density` values `{compact, normal, expanded}` unchanged (driven by `@select` instead of `@change`). Diff scoped to the density block + `Check` icon import + active-indicator CSS.
- New `meta-toolbar-density-menu-migration.spec.ts` (7 tests): trigger closed by default → opens 3 options in order → each is a native `<button role=menuitem>` → click emits `set-row-density` with the same value + closes the menu → `aria-current` on the active one → second click closes with no emit. **Uses the mounts-array + residue-guard hygiene** (per the last slice's finding), incl. an `.mt-popover` Teleport-leak check.
- 30/30 across density + action-buttons + overlay specs; group-picker (8) + filter-builder (22) also pass. vue-tsc clean; token-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)