### PR TITLE
feat(web): multitable UI P2-1c slice-3 — MetaToolbar hide-fields dropdown → MtPopover (multi-toggle)

### DIFF
--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -1,19 +1,27 @@
 <template>
   <div class="meta-toolbar" role="toolbar" :aria-label="l('toolbar.aria')">
     <div class="meta-toolbar__left">
-      <!-- Hide Fields -->
-      <div class="meta-toolbar__dropdown">
-        <button class="meta-toolbar__btn" @click="showFieldPicker = !showFieldPicker">
-          <el-icon class="meta-toolbar__btn-icon"><component :is="ICON.fields" /></el-icon> {{ l('toolbar.fields') }}
-          <span v-if="hiddenCount" class="meta-toolbar__badge">{{ hiddenCount }}</span>
-        </button>
-        <div v-if="showFieldPicker" class="meta-toolbar__panel" @keydown.escape="showFieldPicker = false">
+      <!--
+        Hide Fields (UI-P2-1c slice-3: migrated to shared MtPopover, NOT MtMenu — this is a
+        multi-toggle field list, so toggling one field must NOT close the panel, unlike MtMenu's
+        select-and-close row semantics). Open/close + click-outside/Escape now come from MtPopover;
+        the toggle rows stay native <label>/<input type="checkbox"> (not MtMenuItem).
+      -->
+      <MtPopover v-model:open="showFieldPicker">
+        <template #trigger>
+          <MtButton :title="l('toolbar.fields')" :aria-label="l('toolbar.fields')">
+            <template #icon><el-icon><component :is="ICON.fields" /></el-icon></template>
+            {{ l('toolbar.fields') }}
+            <span v-if="hiddenCount" class="meta-toolbar__badge">{{ hiddenCount }}</span>
+          </MtButton>
+        </template>
+        <div class="meta-toolbar__field-panel">
           <label v-for="field in fields" :key="field.id" class="meta-toolbar__field-toggle">
             <input type="checkbox" :checked="!hiddenFieldIds.includes(field.id)" @change="emit('toggle-field', field.id)" />
             <span>{{ field.name }}</span>
           </label>
         </div>
-      </div>
+      </MtPopover>
 
       <!-- Sort -->
       <div class="meta-toolbar__dropdown">
@@ -199,10 +207,12 @@ import MetaFilterGroup from './MetaFilterGroup.vue'
 // UI-P2-1c: migrate standalone action buttons (undo/redo/fit/print/import/export/new-record) onto
 // the shared UI primitives (multitable-ui-p2-structure-designlock-20260706.md §2 P2-1). Slice-2
 // additionally migrates the row-density dropdown onto MtMenu/MtMenuItem (built on MtPopover), so
-// its open/close + click-outside/Escape no longer need a hand-rolled `showDensityPanel` ref. The
-// remaining dropdown triggers that open a `.meta-toolbar__panel` (fields/sort/filter/group) are NOT
-// touched in this slice — each is a more complex builder deferred to a later slice.
-import { MtButton, MtIconButton, MtMenu, MtMenuItem } from '../ui'
+// its open/close + click-outside/Escape no longer need a hand-rolled `showDensityPanel` ref.
+// Slice-3 migrates the hide-fields dropdown onto MtPopover directly (NOT MtMenu — it's a
+// multi-toggle list, so selecting a row must not auto-close it). The remaining dropdown triggers
+// that open a `.meta-toolbar__panel` (sort/filter/group) are NOT touched in this slice — each is a
+// more complex builder deferred to a later slice.
+import { MtButton, MtIconButton, MtMenu, MtMenuItem, MtPopover } from '../ui'
 import { seedFilterCondition } from '../utils/filter-condition-seed'
 import {
   metaCoreLabel,
@@ -406,6 +416,10 @@ function onAddFilterGroup() {
 .meta-toolbar__dropdown { position: relative; }
 .meta-toolbar__panel { position: absolute; top: 100%; left: 0; z-index: 20; min-width: 200px; background: var(--ms-bg-card, #fff); border: 1px solid var(--ms-border-light, #e7e8ec); border-radius: var(--ms-radius-sm, 6px); box-shadow: var(--ms-shadow-pop, 0 4px 12px rgba(0,0,0,.1)); padding: 8px; margin-top: 4px; }
 .meta-toolbar__panel--filter { min-width: 420px; }
+/* Hide-fields panel (UI-P2-1c slice-3): hosted inside MtPopover's own `.mt-popover` surface (which
+   only pads top/bottom), so this class supplies the horizontal breathing room the old
+   `.meta-toolbar__panel { padding: 8px }` gave the toggle rows — same 8px, all sides. */
+.meta-toolbar__field-panel { padding: var(--ms-space-2); min-width: 200px; box-sizing: border-box; }
 .meta-toolbar__field-toggle { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 13px; cursor: pointer; }
 .meta-toolbar__sort-rule, .meta-toolbar__filter-rule { display: flex; gap: 4px; margin-bottom: 4px; align-items: center; }
 .meta-toolbar__sort-rule select, .meta-toolbar__filter-rule select { padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }

--- a/apps/web/tests/meta-toolbar-hide-fields-mtpopover-migration.spec.ts
+++ b/apps/web/tests/meta-toolbar-hide-fields-mtpopover-migration.spec.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaToolbar from '../src/multitable/components/MetaToolbar.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c slice-3: MetaToolbar's field-visibility ("字段" / hide-fields) dropdown was migrated
+// from a hand-rolled `showFieldPicker` ref + `.meta-toolbar__dropdown`/`.meta-toolbar__panel`
+// field-toggle list to the shared MtPopover primitive (NOT MtMenu — this is a multi-toggle list,
+// so toggling one field row must NOT close the panel, unlike the row-density menu's
+// select-and-close semantics from slice-2). This is an interaction-preservation proof: the trigger
+// must open the popover, the field toggle rows must still render as real
+// <label>/<input type="checkbox"> rows, toggling one must still emit the exact same
+// `toggle-field(fieldId)` event it emitted before migration AND leave the popover open, and
+// Escape / click-outside must still close it.
+
+// Track EVERY mount, not a single shared app/container (see meta-toolbar-density-menu-migration
+// .spec.ts): a shared global would leave a stale tree — and, here, stale Teleported `.mt-popover`
+// content on document.body — after teardown. afterEach unmounts ALL of them and asserts no
+// toolbar DOM, and no leaked popover Teleport content, survives.
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+
+beforeEach(() => { useLocale().setLocale('en') })
+afterEach(() => {
+  while (mounts.length) {
+    const m = mounts.pop()!
+    m.app.unmount()
+    m.container.remove()
+  }
+  expect(document.querySelectorAll('.meta-toolbar').length).toBe(0) // residue guard: no leaked toolbar
+  expect(document.querySelectorAll('.mt-popover').length).toBe(0) // no leaked Teleported popover content
+  useLocale().setLocale('en')
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'status', name: 'Status', type: 'select', options: [{ value: 'a' }] },
+  { id: 'owner', name: 'Owner', type: 'string' },
+]
+
+function mountToolbar(props: Record<string, unknown>) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaToolbar, {
+    fields: FIELDS, hiddenFieldIds: [], sortRules: [], filterRules: [], filterConjunction: 'and',
+    canCreateRecord: true, canExport: true, canUndo: true, canRedo: true, sortFilterDirty: false,
+    ...props,
+  }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+function fieldsTrigger(root: HTMLElement): HTMLButtonElement {
+  const btn = root.querySelector('button[title="Fields"]') as HTMLButtonElement | null
+  expect(btn, 'expected a <button title="Fields"> trigger').toBeTruthy()
+  return btn as HTMLButtonElement
+}
+
+function fieldToggleRows(): HTMLLabelElement[] {
+  return Array.from(document.querySelectorAll('.meta-toolbar__field-toggle')) as HTMLLabelElement[]
+}
+
+describe('MetaToolbar hide-fields dropdown — MtPopover migration (UI-P2-1c slice-3)', () => {
+  it('is closed until the trigger is clicked; clicking it opens the popover with one row per field', async () => {
+    const root = mountToolbar({ hiddenFieldIds: [] })
+    expect(document.querySelector('.mt-popover')).toBeNull()
+
+    const trigger = fieldsTrigger(root)
+    expect(trigger.tagName).toBe('BUTTON')
+    expect(trigger.getAttribute('aria-label')).toBe('Fields')
+    trigger.click()
+    await nextTick()
+
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    const rows = fieldToggleRows()
+    expect(rows.length).toBe(2)
+    expect(rows.map((r) => r.textContent?.trim())).toEqual(['Status', 'Owner'])
+  })
+
+  it('a checkbox reflects hiddenFieldIds (checked = visible, i.e. NOT hidden)', async () => {
+    const root = mountToolbar({ hiddenFieldIds: ['owner'] })
+    fieldsTrigger(root).click()
+    await nextTick()
+
+    const rows = fieldToggleRows()
+    const statusCheckbox = rows[0].querySelector('input[type="checkbox"]') as HTMLInputElement
+    const ownerCheckbox = rows[1].querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(statusCheckbox.checked).toBe(true) // 'status' not in hiddenFieldIds → visible → checked
+    expect(ownerCheckbox.checked).toBe(false) // 'owner' IS hidden → unchecked
+  })
+
+  it('toggling a field emits toggle-field(fieldId) — same event name + payload as before migration — AND keeps the popover OPEN', async () => {
+    const onToggleField = vi.fn()
+    const root = mountToolbar({ hiddenFieldIds: [], onToggleField })
+    fieldsTrigger(root).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    const rows = fieldToggleRows()
+    const ownerCheckbox = rows[1].querySelector('input[type="checkbox"]') as HTMLInputElement
+    ownerCheckbox.click() // real user interaction: toggles native checked state + fires 'change'
+    await nextTick()
+
+    expect(onToggleField).toHaveBeenCalledTimes(1)
+    expect(onToggleField).toHaveBeenCalledWith('owner')
+    // The key multi-toggle behavior (unlike MtMenu's select-and-close row): the popover must still
+    // be open after a toggle, so a second/third field can be toggled without reopening it.
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    expect(fieldToggleRows().length).toBe(2) // rows still rendered, nothing torn down
+
+    // Toggle a second field to further confirm the panel survives repeated toggles.
+    const statusCheckbox = fieldToggleRows()[0].querySelector('input[type="checkbox"]') as HTMLInputElement
+    statusCheckbox.click()
+    await nextTick()
+    expect(onToggleField).toHaveBeenCalledTimes(2)
+    expect(onToggleField).toHaveBeenNthCalledWith(2, 'status')
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('pressing Escape closes the popover', async () => {
+    const root = mountToolbar({ hiddenFieldIds: [] })
+    fieldsTrigger(root).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+  })
+
+  it('a click outside the trigger and panel closes the popover', async () => {
+    const root = mountToolbar({ hiddenFieldIds: [] })
+    fieldsTrigger(root).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+    expect(root).toBeTruthy() // root/toolbar itself is untouched by the close
+  })
+
+  it('a second click on the trigger closes the popover again (no field toggled, no emit)', async () => {
+    const onToggleField = vi.fn()
+    const root = mountToolbar({ hiddenFieldIds: [], onToggleField })
+    const trigger = fieldsTrigger(root)
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+    expect(onToggleField).not.toHaveBeenCalled()
+  })
+
+  it('shows the hidden-field-count badge on the trigger, same as before migration', async () => {
+    const root = mountToolbar({ hiddenFieldIds: ['owner'] })
+    const trigger = fieldsTrigger(root)
+    const badge = trigger.querySelector('.meta-toolbar__badge')
+    expect(badge, 'expected the hidden-count badge inside the trigger button').toBeTruthy()
+    expect(badge?.textContent?.trim()).toBe('1')
+  })
+})


### PR DESCRIPTION
Third P2-1c migration (serial after #3777; behavior-adjacent — NOT self-merged). Migrates the field-visibility ("字段") dropdown to **MtPopover** — deliberately NOT MtMenu, because it's a **multi-toggle** list (toggling a field must NOT close the panel).

## Change (hide-fields dropdown only)
- Trigger → `MtButton` (same `title`/`aria-label`, hidden-count badge kept). Panel → MtPopover `v-model:open` default slot, checkbox toggle rows **preserved as-is** (`@change` → `emit('toggle-field', field.id)`).
- Removed the dropdown's manual `@keydown.escape` — MtPopover supplies Esc + click-outside. `showFieldPicker` now drives `v-model:open`. Sort/filter/group dropdowns + the density menu untouched.
- Added a token-only `.meta-toolbar__field-panel` padding rule (MtPopover pads top/bottom only).

## Invariant proof + tests (the key behavior: STAYS OPEN on toggle)
- **emit() call-site set byte-identical vs main** (verified by script); `emit('toggle-field', field.id)` unchanged.
- New `meta-toolbar-hide-fields-mtpopover-migration.spec.ts` (7 tests): trigger opens the popover with the field rows; checkbox `checked` reflects `hiddenFieldIds`; **toggling two fields in sequence emits each time AND the `.mt-popover` stays in the DOM** (the defining difference from MtMenu's select-and-close); Esc closes; click-outside closes; second trigger-click closes with no emit; hidden-count badge renders. Uses the mounts-array + residue-guard + `.mt-popover` leak-guard hygiene.
- 26/26 across hide-fields + density + overlay specs; group-picker (8) + filter-builder (22) also pass (55/55 total earlier). vue-tsc clean; token-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)