### PR TITLE
feat(web): multitable UI P2-1c slice-4 — migrate MetaToolbar sort builder dropdown to MtPopover

### DIFF
--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -23,13 +23,23 @@
         </div>
       </MtPopover>
 
-      <!-- Sort -->
-      <div class="meta-toolbar__dropdown">
-        <button class="meta-toolbar__btn" @click="showSortPanel = !showSortPanel">
-          <el-icon class="meta-toolbar__btn-icon"><component :is="ICON.sort" /></el-icon> {{ l('toolbar.sort') }}
-          <span v-if="sortRules.length" class="meta-toolbar__badge">{{ sortRules.length }}</span>
-        </button>
-        <div v-if="showSortPanel" class="meta-toolbar__panel" @keydown.escape="showSortPanel = false">
+      <!--
+        Sort (UI-P2-1c slice-4: migrated to shared MtPopover — this is a COMPLEX BUILDER (add/remove/
+        update sort-rule rows + apply), not a simple toggle/menu, so the panel content is preserved
+        verbatim (native <select>s + add/remove/apply <button>s, NOT MtMenuItem rows); only the
+        open/close mechanics move from a hand-rolled `showSortPanel` ref + `.meta-toolbar__panel` to
+        MtPopover's `v-model:open` + built-in click-outside/Escape. The panel's own `@keydown.escape`
+        handler is dropped — MtPopover's document-level Escape listener now covers it.
+      -->
+      <MtPopover v-model:open="showSortPanel">
+        <template #trigger>
+          <MtButton :title="l('toolbar.sort')" :aria-label="l('toolbar.sort')">
+            <template #icon><el-icon><component :is="ICON.sort" /></el-icon></template>
+            {{ l('toolbar.sort') }}
+            <span v-if="sortRules.length" class="meta-toolbar__badge">{{ sortRules.length }}</span>
+          </MtButton>
+        </template>
+        <div class="meta-toolbar__sort-panel">
           <div v-for="(rule, idx) in sortRules" :key="idx" class="meta-toolbar__sort-rule">
             <select :value="rule.fieldId" @change="onSortFieldChange(idx, ($event.target as HTMLSelectElement).value)">
               <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
@@ -43,7 +53,7 @@
           <button v-if="fields.length" class="meta-toolbar__add" @click="emit('add-sort', { fieldId: fields[0].id, direction: 'asc' })">{{ l('toolbar.addSort') }}</button>
           <button v-if="sortRules.length" class="meta-toolbar__apply" @click="emit('apply-sort-filter')">{{ l('toolbar.apply') }}</button>
         </div>
-      </div>
+      </MtPopover>
 
       <!-- Filter -->
       <div class="meta-toolbar__dropdown">
@@ -209,9 +219,11 @@ import MetaFilterGroup from './MetaFilterGroup.vue'
 // additionally migrates the row-density dropdown onto MtMenu/MtMenuItem (built on MtPopover), so
 // its open/close + click-outside/Escape no longer need a hand-rolled `showDensityPanel` ref.
 // Slice-3 migrates the hide-fields dropdown onto MtPopover directly (NOT MtMenu — it's a
-// multi-toggle list, so selecting a row must not auto-close it). The remaining dropdown triggers
-// that open a `.meta-toolbar__panel` (sort/filter/group) are NOT touched in this slice — each is a
-// more complex builder deferred to a later slice.
+// multi-toggle list, so selecting a row must not auto-close it). Slice-4 migrates the sort dropdown
+// onto MtPopover the same way (NOT MtMenu — it's a complex add/remove/update/apply builder, so its
+// panel content is preserved verbatim). The remaining dropdown triggers that open a
+// `.meta-toolbar__panel` (filter/group) are NOT touched in this slice — each is a more complex
+// builder deferred to a later slice.
 import { MtButton, MtIconButton, MtMenu, MtMenuItem, MtPopover } from '../ui'
 import { seedFilterCondition } from '../utils/filter-condition-seed'
 import {
@@ -421,6 +433,10 @@ function onAddFilterGroup() {
    `.meta-toolbar__panel { padding: 8px }` gave the toggle rows — same 8px, all sides. */
 .meta-toolbar__field-panel { padding: var(--ms-space-2); min-width: 200px; box-sizing: border-box; }
 .meta-toolbar__field-toggle { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 13px; cursor: pointer; }
+/* Sort builder panel (UI-P2-1c slice-4): same rationale as the hide-fields panel above — hosted
+   inside MtPopover's own `.mt-popover` surface (which only pads top/bottom), so this class supplies
+   the horizontal breathing room the old `.meta-toolbar__panel { padding: 8px }` gave the rows. */
+.meta-toolbar__sort-panel { padding: var(--ms-space-2); min-width: 200px; box-sizing: border-box; }
 .meta-toolbar__sort-rule, .meta-toolbar__filter-rule { display: flex; gap: 4px; margin-bottom: 4px; align-items: center; }
 .meta-toolbar__sort-rule select, .meta-toolbar__filter-rule select { padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }
 .meta-toolbar__filter-value { flex: 1; min-width: 80px; padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }

--- a/apps/web/tests/meta-toolbar-sort-builder-mtpopover-migration.spec.ts
+++ b/apps/web/tests/meta-toolbar-sort-builder-mtpopover-migration.spec.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, reactive, type App } from 'vue'
+import MetaToolbar from '../src/multitable/components/MetaToolbar.vue'
+import type { SortRule } from '../src/multitable/composables/useMultitableGrid'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c slice-4: MetaToolbar's sort ("排序") dropdown was migrated from a hand-rolled
+// `showSortPanel` ref + `.meta-toolbar__dropdown`/`.meta-toolbar__panel` sort-rule BUILDER to the
+// shared MtPopover primitive (NOT MtMenu, NOT MtMenuItem rows — this is a complex builder with
+// add/remove/update sort-rule rows + apply, and its panel markup is preserved verbatim). This is an
+// interaction-preservation proof: the trigger must open the popover, the builder rows must still
+// render as native <select>/<button> controls, every add/remove/update/apply interaction must still
+// emit the exact same event name + payload it emitted before migration, the popover must stay OPEN
+// through builder interactions (a builder must not close mid-edit, unlike MtMenu's select-and-close
+// row semantics), and Escape / click-outside must still close it.
+
+// Track EVERY mount (see meta-toolbar-hide-fields-mtpopover-migration.spec.ts): a shared global app
+// would leave stale Teleported `.mt-popover` content on document.body after teardown. afterEach
+// unmounts ALL of them and asserts no toolbar DOM, and no leaked popover Teleport content, survives.
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+
+beforeEach(() => { useLocale().setLocale('en') })
+afterEach(() => {
+  while (mounts.length) {
+    const m = mounts.pop()!
+    m.app.unmount()
+    m.container.remove()
+  }
+  expect(document.querySelectorAll('.meta-toolbar').length).toBe(0) // residue guard: no leaked toolbar
+  expect(document.querySelectorAll('.mt-popover').length).toBe(0) // no leaked Teleported popover content
+  useLocale().setLocale('en')
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'status', name: 'Status', type: 'select', options: [{ value: 'a' }] },
+  { id: 'owner', name: 'Owner', type: 'string' },
+]
+
+function mountToolbar(initial: { sortRules?: SortRule[] } & Record<string, unknown> = {}) {
+  const state = reactive<{ sortRules: SortRule[] }>({
+    sortRules: initial.sortRules ?? [],
+  })
+  const { sortRules: _ignored, ...rest } = initial
+
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaToolbar, {
+    fields: FIELDS, hiddenFieldIds: [], filterRules: [], filterConjunction: 'and',
+    canCreateRecord: true, canExport: true, canUndo: true, canRedo: true, sortFilterDirty: false,
+    sortRules: state.sortRules,
+    onAddSort: (rule: SortRule) => { state.sortRules.push(rule) },
+    onRemoveSort: (fieldId: string) => { state.sortRules = state.sortRules.filter((r) => r.fieldId !== fieldId) },
+    onUpdateSort: (index: number, rule: SortRule) => { state.sortRules[index] = rule },
+    ...rest,
+  }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return { container, state }
+}
+
+function sortTrigger(root: HTMLElement): HTMLButtonElement {
+  const btn = root.querySelector('button[title="Sort"]') as HTMLButtonElement | null
+  expect(btn, 'expected a <button title="Sort"> trigger').toBeTruthy()
+  return btn as HTMLButtonElement
+}
+
+function sortRuleRows(): HTMLDivElement[] {
+  return Array.from(document.querySelectorAll('.meta-toolbar__sort-rule')) as HTMLDivElement[]
+}
+
+describe('MetaToolbar sort builder — MtPopover migration (UI-P2-1c slice-4)', () => {
+  it('is closed until the trigger is clicked; clicking it opens the popover with the builder content', async () => {
+    const { container: root } = mountToolbar({ sortRules: [{ fieldId: 'status', direction: 'asc' }] })
+    expect(document.querySelector('.mt-popover')).toBeNull()
+
+    const trigger = sortTrigger(root)
+    expect(trigger.tagName).toBe('BUTTON')
+    expect(trigger.getAttribute('aria-label')).toBe('Sort')
+    trigger.click()
+    await nextTick()
+
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    const rows = sortRuleRows()
+    expect(rows.length).toBe(1)
+    expect(rows[0].querySelectorAll('select').length).toBe(2) // field select + direction select
+    expect(document.querySelector('.meta-toolbar__add')).not.toBeNull() // "Add sort" button
+  })
+
+  it('shows the sort-rule-count badge on the trigger, same as before migration', async () => {
+    const { container: root } = mountToolbar({
+      sortRules: [{ fieldId: 'status', direction: 'asc' }, { fieldId: 'owner', direction: 'desc' }],
+    })
+    const trigger = sortTrigger(root)
+    const badge = trigger.querySelector('.meta-toolbar__badge')
+    expect(badge, 'expected the sort-rule-count badge inside the trigger button').toBeTruthy()
+    expect(badge?.textContent?.trim()).toBe('2')
+  })
+
+  it('"Add sort" emits add-sort(rule) — same event + payload as before migration — AND keeps the popover OPEN', async () => {
+    const { container: root, state } = mountToolbar({ sortRules: [] })
+    const trigger = sortTrigger(root)
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    const addBtn = document.querySelector('.meta-toolbar__add') as HTMLButtonElement
+    expect(addBtn).toBeTruthy()
+    addBtn.click()
+    await nextTick()
+
+    expect(state.sortRules).toEqual([{ fieldId: 'status', direction: 'asc' }])
+    // Key builder behavior (unlike MtMenu's select-and-close row): the popover must still be open
+    // after adding a rule, so the newly added row can be edited without reopening the panel.
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    expect(sortRuleRows().length).toBe(1)
+  })
+
+  it('changing the field select emits update-sort(index, rule) and keeps the popover open (inner control does not close it)', async () => {
+    const { container: root, state } = mountToolbar({ sortRules: [{ fieldId: 'status', direction: 'asc' }] })
+    sortTrigger(root).click()
+    await nextTick()
+
+    const fieldSelect = sortRuleRows()[0].querySelectorAll('select')[0] as HTMLSelectElement
+    fieldSelect.value = 'owner'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    expect(state.sortRules[0]).toEqual({ fieldId: 'owner', direction: 'asc' })
+    // Verifies the NESTED-OVERLAY risk called out in the migration brief: a click/change on an inner
+    // <select> inside the teleported panel must not be treated as an "outside click" that closes it.
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('changing the direction select emits update-sort(index, rule) and keeps the popover open', async () => {
+    const { container: root, state } = mountToolbar({ sortRules: [{ fieldId: 'status', direction: 'asc' }] })
+    sortTrigger(root).click()
+    await nextTick()
+
+    const dirSelect = sortRuleRows()[0].querySelectorAll('select')[1] as HTMLSelectElement
+    dirSelect.value = 'desc'
+    dirSelect.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    expect(state.sortRules[0]).toEqual({ fieldId: 'status', direction: 'desc' })
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('the remove (×) button emits remove-sort(fieldId) and keeps the popover open', async () => {
+    const { container: root, state } = mountToolbar({
+      sortRules: [{ fieldId: 'status', direction: 'asc' }, { fieldId: 'owner', direction: 'desc' }],
+    })
+    sortTrigger(root).click()
+    await nextTick()
+    expect(sortRuleRows().length).toBe(2)
+
+    const removeBtn = sortRuleRows()[0].querySelector('.meta-toolbar__remove') as HTMLButtonElement
+    removeBtn.click()
+    await nextTick()
+
+    expect(state.sortRules).toEqual([{ fieldId: 'owner', direction: 'desc' }])
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    expect(sortRuleRows().length).toBe(1)
+  })
+
+  it('"Apply" emits apply-sort-filter (no payload) — same as before migration — and clicking it does not close the popover', async () => {
+    const onApplySortFilter = vi.fn()
+    const { container: root } = mountToolbar({
+      sortRules: [{ fieldId: 'status', direction: 'asc' }],
+      onApplySortFilter,
+    })
+    sortTrigger(root).click()
+    await nextTick()
+
+    const applyBtn = document.querySelector('.meta-toolbar__apply') as HTMLButtonElement
+    expect(applyBtn).toBeTruthy()
+    applyBtn.click()
+    await nextTick()
+
+    expect(onApplySortFilter).toHaveBeenCalledTimes(1)
+    expect(onApplySortFilter).toHaveBeenCalledWith() // no payload
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('pressing Escape closes the popover', async () => {
+    const { container: root } = mountToolbar({ sortRules: [{ fieldId: 'status', direction: 'asc' }] })
+    sortTrigger(root).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+  })
+
+  it('a click outside the trigger and panel closes the popover', async () => {
+    const { container: root } = mountToolbar({ sortRules: [{ fieldId: 'status', direction: 'asc' }] })
+    sortTrigger(root).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+    expect(root).toBeTruthy() // root/toolbar itself is untouched by the close
+  })
+
+  it('a second click on the trigger closes the popover again (no sort mutation, no emit)', async () => {
+    const onAddSort = vi.fn()
+    const { container: root } = mountToolbar({ sortRules: [], onAddSort })
+    const trigger = sortTrigger(root)
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+    expect(onAddSort).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fourth P2-1c migration (serial after #3780; behavior-adjacent — NOT self-merged). The riskiest slice so far: the **sort ("排序") dropdown is a complex builder**, so this WRAPS the trigger+panel in MtPopover while preserving the entire builder markup + every emit — it does NOT restructure the builder.

## Change (sort dropdown only)
- Trigger → `MtButton` (same title/aria/dirty-badge). Builder panel (field/direction `<select>`s, add/remove rows, apply) → MtPopover `v-model:open` default slot, **markup verbatim**. Removed the panel's own `@keydown.escape` (MtPopover supplies Esc + click-outside). Filter/group/density/action buttons untouched.

## ⚠ Nested-overlay verification — PASSED
The builder's inner controls are plain **native `<select>`/`<button>`** rendered as real DOM descendants of MtPopover's `panelRef` (not teleported elsewhere). MtPopover's `handleClickOutside` gates on `panelRef.contains(target)`, so field-select / direction-select / add / remove / apply interactions are treated as "inside" and do NOT close the popover. Asserted explicitly (each interaction → `.mt-popover` still present). No nested-teleported overlay exists inside the sort builder.

## Invariant proof + tests
- **emit() set byte-identical vs main**: `add-sort` / `remove-sort` / `update-sort` / `apply-sort-filter` all unchanged (name + payload), full-file set identical.
- New `meta-toolbar-sort-builder-mtpopover-migration.spec.ts` (10 tests): open on trigger; badge; add/update(field & dir)/remove/apply each emits + **popover stays open during builder edits**; Esc closes; outside-click closes; second trigger-click closes with no spurious emit. mounts-array + `.meta-toolbar`/`.mt-popover` residue-guard hygiene.
- **77/77** across all 7 MetaToolbar + overlay specs (action 11 · density 7 · hide-fields 7 · sort 10 · group 8 · filter 22 · overlays 12). vue-tsc clean; token-only; diff = sort block + 1 CSS rule + the new spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)