### PR TITLE
feat(attendance-web): PR-B — field-picker restores per-user saved selection (server-backed)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -13184,10 +13184,17 @@ const importTemplateHeaderPreview = computed(() =>
 // open (intersected with the current vocabulary so ghost keys drop out),
 // save on change, clear on reset. All calls are silent — prefs must never
 // block the picker.
+// Review #3782 P3-1: any user interaction (or a newer restore) bumps the
+// generation, so a late-arriving GET can never overwrite what the user just
+// clicked. P3-2: PUTs are serialized last-write-wins, so rapid toggles cannot
+// persist a stale selection via HTTP reordering.
+let importTemplatePrefsGeneration = 0
 async function restoreImportTemplateFieldPrefs() {
+  const generation = ++importTemplatePrefsGeneration
   try {
     const response = await apiFetch(`/api/attendance/import/template-prefs?orgId=${encodeURIComponent(normalizedOrgId() ?? '')}`)
     const data = await response.json().catch(() => ({} as any))
+    if (generation !== importTemplatePrefsGeneration) return
     const saved = Array.isArray(data?.data?.selectedKeys) ? data.data.selectedKeys : []
     if (!response.ok || saved.length === 0) return
     const available = new Set(allSelectableImportFieldKeys(importFieldGroups.value))
@@ -13197,12 +13204,35 @@ async function restoreImportTemplateFieldPrefs() {
     // silent — defaults stay
   }
 }
+let importTemplatePrefsPutInFlight = false
+let importTemplatePrefsPutQueued: string[] | null = null
+async function flushImportTemplatePrefsPut(payload: string[]): Promise<void> {
+  importTemplatePrefsPutInFlight = true
+  try {
+    await apiFetch('/api/attendance/import/template-prefs', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: normalizedOrgId(), selectedKeys: payload }),
+    })
+  } catch {
+    // silent — prefs must never block the picker
+  } finally {
+    importTemplatePrefsPutInFlight = false
+    if (importTemplatePrefsPutQueued) {
+      const next = importTemplatePrefsPutQueued
+      importTemplatePrefsPutQueued = null
+      void flushImportTemplatePrefsPut(next)
+    }
+  }
+}
 function persistImportTemplateFieldPrefs(keys: ReadonlySet<string>) {
-  void apiFetch('/api/attendance/import/template-prefs', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ orgId: normalizedOrgId(), selectedKeys: Array.from(keys) }),
-  }).catch(() => undefined)
+  importTemplatePrefsGeneration += 1
+  const payload = Array.from(keys)
+  if (importTemplatePrefsPutInFlight) {
+    importTemplatePrefsPutQueued = payload
+    return
+  }
+  void flushImportTemplatePrefsPut(payload)
 }
 function toggleImportTemplateField(key: string) {
   const next = new Set(importTemplateFieldKeys.value)

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -13180,17 +13180,47 @@ const importFieldGroups = computed(() => groupSupportedImportColumns(importMappi
 const importTemplateFieldKeys = ref<Set<string>>(new Set(IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS))
 const importTemplateHeaderPreview = computed(() =>
   buildTemplateHeaderFromSelection(importFieldGroups.value, importTemplateFieldKeys.value))
+// Per-user picker memory (template-prefs design-lock §3, PR-B): restore on
+// open (intersected with the current vocabulary so ghost keys drop out),
+// save on change, clear on reset. All calls are silent — prefs must never
+// block the picker.
+async function restoreImportTemplateFieldPrefs() {
+  try {
+    const response = await apiFetch(`/api/attendance/import/template-prefs?orgId=${encodeURIComponent(normalizedOrgId() ?? '')}`)
+    const data = await response.json().catch(() => ({} as any))
+    const saved = Array.isArray(data?.data?.selectedKeys) ? data.data.selectedKeys : []
+    if (!response.ok || saved.length === 0) return
+    const available = new Set(allSelectableImportFieldKeys(importFieldGroups.value))
+    const restored = saved.filter((key: unknown): key is string => typeof key === 'string' && available.has(key))
+    if (restored.length > 0) importTemplateFieldKeys.value = new Set(restored)
+  } catch {
+    // silent — defaults stay
+  }
+}
+function persistImportTemplateFieldPrefs(keys: ReadonlySet<string>) {
+  void apiFetch('/api/attendance/import/template-prefs', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ orgId: normalizedOrgId(), selectedKeys: Array.from(keys) }),
+  }).catch(() => undefined)
+}
 function toggleImportTemplateField(key: string) {
   const next = new Set(importTemplateFieldKeys.value)
   if (next.has(key)) next.delete(key)
   else next.add(key)
   importTemplateFieldKeys.value = next
+  persistImportTemplateFieldPrefs(next)
 }
 function selectAllImportTemplateFields() {
-  importTemplateFieldKeys.value = new Set(allSelectableImportFieldKeys(importFieldGroups.value))
+  const next = new Set(allSelectableImportFieldKeys(importFieldGroups.value))
+  importTemplateFieldKeys.value = next
+  persistImportTemplateFieldPrefs(next)
 }
 function resetImportTemplateFields() {
   importTemplateFieldKeys.value = new Set(IMPORT_TEMPLATE_DEFAULT_SELECTED_KEYS)
+  // Clear semantics: [] drops the server row so future default-set upgrades
+  // flow to the user instead of being pinned by an old save.
+  persistImportTemplateFieldPrefs(new Set())
 }
 const selectedImportProfile = computed(() => {
   if (!importProfileId.value) return null
@@ -18109,6 +18139,7 @@ async function loadImportTemplate() {
     importForm.payload = JSON.stringify(payloadExample, null, 2)
     importMappingProfiles.value = Array.isArray(data.data?.mappingProfiles) ? data.data.mappingProfiles : []
     importMappingColumnsRaw.value = Array.isArray(data.data?.mapping?.columns) ? data.data.mapping.columns : []
+    void restoreImportTemplateFieldPrefs()
     setStatus(tr('Import template loaded.', '导入模板已加载。'))
   } catch (error) {
     setStatus(readErrorMessage(error, tr('Failed to load import template', '加载导入模板失败')), 'error')

--- a/apps/web/tests/attendance-import-preview-regression.spec.ts
+++ b/apps/web/tests/attendance-import-preview-regression.spec.ts
@@ -703,4 +703,103 @@ describe('Attendance import preview regression', () => {
     await flushUi(2)
     expect(prefsPuts.at(-1)?.selectedKeys).toEqual([])
   })
+
+  it('PR-B hardening: a late restore cannot overwrite what the user just clicked (generation guard)', async () => {
+    const apiFetchMock = vi.mocked(apiFetch)
+    let releasePrefs!: (value: unknown) => void
+    apiFetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
+      const url = String(path)
+      if (url.startsWith('/api/attendance/import/template-prefs')) {
+        if (init?.method === 'PUT') return jsonResponse(200, { ok: true, data: { selectedKeys: [] } })
+        return new Promise((resolve) => { releasePrefs = resolve }) as Promise<Response>
+      }
+      if (url.startsWith('/api/attendance/import/template')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            payloadExample: { source: 'dingtalk_csv', mode: 'override', columns: ['日期', '工号', '姓名'], requiredFields: ['日期'] },
+            mappingProfiles: [],
+            mapping: { columns: [
+              { sourceField: '上班1打卡时间', targetField: 'firstInAt' },
+              { sourceField: '加班小时', targetField: 'overtimeHours' },
+            ] },
+          },
+        })
+      }
+      return jsonResponse(200, { ok: true, data: { items: [], summary: null } })
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    const vm = app.mount(container!)
+    await flushUi(6)
+    findButton(findImportSection(container!), 'Load template').click()
+    await flushUi(6)
+
+    // GET is still pending; the user toggles a field now.
+    const setupState = (vm as any).$?.setupState as Record<string, any>
+    setupState.toggleImportTemplateField('overtimeHours')
+    await flushUi(2)
+    const before = Array.from(unwrapRef<Set<string>>(setupState.importTemplateFieldKeys)).sort()
+
+    // Late restore arrives with a different server-side selection — must be dropped.
+    releasePrefs(jsonResponse(200, { ok: true, data: { selectedKeys: ['firstInAt'] } }))
+    await flushUi(4)
+    const after = Array.from(unwrapRef<Set<string>>(setupState.importTemplateFieldKeys)).sort()
+    expect(after).toEqual(before)
+    expect(after).toContain('overtimeHours')
+  })
+
+  it('PR-B hardening: rapid toggles serialize PUTs last-write-wins (no reorder persistence)', async () => {
+    const puts: Array<{ payload: Record<string, unknown>; release: (v: unknown) => void }> = []
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
+      const url = String(path)
+      if (url.startsWith('/api/attendance/import/template-prefs')) {
+        if (init?.method === 'PUT') {
+          return new Promise((resolve) => {
+            puts.push({ payload: JSON.parse(String(init.body ?? '{}')), release: resolve })
+          }) as Promise<Response>
+        }
+        return jsonResponse(200, { ok: true, data: { selectedKeys: [] } })
+      }
+      if (url.startsWith('/api/attendance/import/template')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            payloadExample: { source: 'dingtalk_csv', mode: 'override', columns: ['日期'], requiredFields: ['日期'] },
+            mappingProfiles: [],
+            mapping: { columns: [
+              { sourceField: '上班1打卡时间', targetField: 'firstInAt' },
+              { sourceField: '下班1打卡时间', targetField: 'lastOutAt' },
+              { sourceField: '加班小时', targetField: 'overtimeHours' },
+            ] },
+          },
+        })
+      }
+      return jsonResponse(200, { ok: true, data: { items: [], summary: null } })
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    const vm = app.mount(container!)
+    await flushUi(6)
+    findButton(findImportSection(container!), 'Load template').click()
+    await flushUi(6)
+    const setupState = (vm as any).$?.setupState as Record<string, any>
+
+    // three rapid changes while the first PUT is held open
+    setupState.toggleImportTemplateField('overtimeHours')
+    setupState.toggleImportTemplateField('firstInAt')
+    setupState.toggleImportTemplateField('lastOutAt')
+    await flushUi(2)
+
+    expect(puts).toHaveLength(1)
+    puts[0].release(jsonResponse(200, { ok: true, data: { selectedKeys: [] } }))
+    await flushUi(4)
+
+    // queued last-write-wins: exactly one follow-up PUT carrying the FINAL set
+    expect(puts).toHaveLength(2)
+    const finalSet = Array.from(unwrapRef<Set<string>>(setupState.importTemplateFieldKeys)).sort()
+    expect((puts[1].payload.selectedKeys as string[]).slice().sort()).toEqual(finalSet)
+    puts[1].release(jsonResponse(200, { ok: true, data: { selectedKeys: [] } }))
+  })
 })

--- a/apps/web/tests/attendance-import-preview-regression.spec.ts
+++ b/apps/web/tests/attendance-import-preview-regression.spec.ts
@@ -623,4 +623,84 @@ describe('Attendance import preview regression', () => {
     expect(String(payload.csvText)).toContain('日期,工号,姓名,加班小时,自定义列')
     expect(String(payload.csvText)).toContain('2026-06-01,EMP001,张三,1,x')
   })
+
+  function mockTemplateEndpointWithPrefs(savedKeys: string[]) {
+    const prefsPuts: Array<Record<string, unknown>> = []
+    const apiFetchMock = vi.mocked(apiFetch)
+    apiFetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
+      const url = String(path)
+      if (url.startsWith('/api/attendance/import/template-prefs')) {
+        if (init?.method === 'PUT') {
+          prefsPuts.push(JSON.parse(String(init.body ?? '{}')))
+          return jsonResponse(200, { ok: true, data: { selectedKeys: [] } })
+        }
+        return jsonResponse(200, { ok: true, data: { selectedKeys: savedKeys } })
+      }
+      if (url.startsWith('/api/attendance/import/template')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            payloadExample: {
+              source: 'dingtalk_csv',
+              mode: 'override',
+              columns: ['日期', '工号', '姓名'],
+              requiredFields: ['日期'],
+            },
+            mappingProfiles: [],
+            mapping: {
+              columns: [
+                { sourceField: '上班1打卡时间', targetField: 'firstInAt' },
+                { sourceField: '下班1打卡时间', targetField: 'lastOutAt' },
+                { sourceField: '考勤结果', targetField: 'status' },
+                { sourceField: '加班小时', targetField: 'overtimeHours' },
+              ],
+            },
+          },
+        })
+      }
+      return jsonResponse(200, { ok: true, data: { items: [], summary: null } })
+    })
+    return { apiFetchMock, prefsPuts }
+  }
+
+  it('PR-B: saved picker prefs restore on template load, ghost keys dropped', async () => {
+    mockTemplateEndpointWithPrefs(['overtimeHours', 'ghostKey'])
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    const vm = app.mount(container!)
+    await flushUi(6)
+    findButton(findImportSection(container!), 'Load template').click()
+    await flushUi(8)
+
+    const preview = (container!.querySelector('[data-testid="attendance-import-header-preview"]') as HTMLElement).textContent ?? ''
+    expect(preview).toBe('日期,工号,姓名,加班小时')
+    // The header builder drops unknown keys anyway — the intersection guard is
+    // locked at the SELECTION-SET level, where a ghost key would otherwise hide.
+    const setupState = (vm as any).$?.setupState as Record<string, any>
+    const selected = Array.from(unwrapRef<Set<string>>(setupState.importTemplateFieldKeys))
+    expect(selected).toEqual(['overtimeHours'])
+  })
+
+  it('PR-B: toggling persists the selection; reset clears the server record', async () => {
+    const { prefsPuts } = mockTemplateEndpointWithPrefs([])
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(6)
+    findButton(findImportSection(container!), 'Load template').click()
+    await flushUi(8)
+
+    const picker = container!.querySelector('[data-testid="attendance-import-field-picker"]') as HTMLElement
+    const overtime = Array.from(picker.querySelectorAll('label')).find(
+      candidate => candidate.textContent?.trim() === '加班小时'
+    )
+    ;(overtime!.querySelector('input') as HTMLInputElement).click()
+    await flushUi(2)
+    expect(prefsPuts.length).toBeGreaterThan(0)
+    expect(prefsPuts.at(-1)?.selectedKeys).toContain('overtimeHours')
+
+    findButton(picker, 'Reset to default').click()
+    await flushUi(2)
+    expect(prefsPuts.at(-1)?.selectedKeys).toEqual([])
+  })
 })


### PR DESCRIPTION
PR-A #3778（已合）的前端闭环：加载模板即恢复用户上次勾选（**勾选状态集层面**与当前词汇求交集——幽灵键彻底丢弃而非隐形选中）；勾选/全选静默保存；恢复默认 PUT `[]` 清档（未来默认集升级自然流到用户）。prefs 调用全静默，永不阻塞勾选卡。

测试（真挂载）：存档子集+幽灵键 → 选择集恰恢复有效子集（mutation 揭穿过 preview 层弱守卫后改为 SET 层断言，摘交集 → 红）；toggle → PUT 载荷；恢复默认 → PUT []。rebase 到 main 后 14/14+ 全绿；tsc 清。

体验闭环：公司电脑勾好字段，回家换浏览器打开，勾选原样还原。

审阅：opus 对抗审阅后合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)