### PR TITLE
feat(web): multitable UI P2-1c slice-5 — migrate MetaToolbar filter builder dropdown to MtPopover

### DIFF
--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -55,13 +55,30 @@
         </div>
       </MtPopover>
 
-      <!-- Filter -->
-      <div class="meta-toolbar__dropdown">
-        <button class="meta-toolbar__btn" @click="showFilterPanel = !showFilterPanel">
-          <el-icon class="meta-toolbar__btn-icon"><component :is="ICON.filter" /></el-icon> {{ l('toolbar.filter') }}
-          <span v-if="filterRules.length + filterGroups.length" class="meta-toolbar__badge">{{ filterRules.length + filterGroups.length }}</span>
-        </button>
-        <div v-if="showFilterPanel" class="meta-toolbar__panel meta-toolbar__panel--filter" @keydown.escape="showFilterPanel = false">
+      <!--
+        Filter (UI-P2-1c slice-5: migrated to shared MtPopover — the MOST COMPLEX builder here
+        (nested field/operator/value controls, recursive AND/OR condition groups via
+        MetaFilterConditionRow/MetaFilterGroup), so the panel content is preserved verbatim (same
+        sub-components + same props/events, NOT MtMenuItem rows); only the open/close mechanics
+        move from a hand-rolled `showFilterPanel` ref + `.meta-toolbar__panel` to MtPopover's
+        `v-model:open` + built-in click-outside/Escape. The panel's own `@keydown.escape` handler is
+        dropped — MtPopover's document-level Escape listener now covers it.
+        NESTED-OVERLAY note: every inner field/operator/value control rendered by
+        MetaFilterConditionRow and MetaFilterGroup (recursively) is a native <select>/<input> — none
+        of them Teleports its own menu outside MtPopover's panel — so MtPopover's
+        `panelRef.contains(target)` outside-click check always sees these interactions as "inside"
+        and the popover safely stays open through editing (verified by
+        meta-toolbar-filter-builder-mtpopover-migration.spec.ts).
+      -->
+      <MtPopover v-model:open="showFilterPanel">
+        <template #trigger>
+          <MtButton :title="l('toolbar.filter')" :aria-label="l('toolbar.filter')">
+            <template #icon><el-icon><component :is="ICON.filter" /></el-icon></template>
+            {{ l('toolbar.filter') }}
+            <span v-if="filterRules.length + filterGroups.length" class="meta-toolbar__badge">{{ filterRules.length + filterGroups.length }}</span>
+          </MtButton>
+        </template>
+        <div class="meta-toolbar__filter-panel meta-toolbar__panel--filter">
           <div v-if="(filterRules.length + filterGroups.length) > 1" class="meta-toolbar__conjunction">
             <span>{{ l('toolbar.where') }}</span>
             <select :value="filterConjunction" @change="emit('set-conjunction', ($event.target as HTMLSelectElement).value as 'and'|'or')">
@@ -96,7 +113,7 @@
           <button v-if="filterRules.length || filterGroups.length" class="meta-toolbar__apply" @click="emit('apply-sort-filter')">{{ applyButtonLabel }}</button>
           <p v-if="filterRules.length && sortFilterDirty" class="meta-toolbar__apply-hint">{{ l('toolbar.stagedHint') }}</p>
         </div>
-      </div>
+      </MtPopover>
 
       <!-- Group By (nested / multi-level: ordered 1-3 levels) -->
       <div class="meta-toolbar__dropdown">
@@ -221,9 +238,11 @@ import MetaFilterGroup from './MetaFilterGroup.vue'
 // Slice-3 migrates the hide-fields dropdown onto MtPopover directly (NOT MtMenu — it's a
 // multi-toggle list, so selecting a row must not auto-close it). Slice-4 migrates the sort dropdown
 // onto MtPopover the same way (NOT MtMenu — it's a complex add/remove/update/apply builder, so its
-// panel content is preserved verbatim). The remaining dropdown triggers that open a
-// `.meta-toolbar__panel` (filter/group) are NOT touched in this slice — each is a more complex
-// builder deferred to a later slice.
+// panel content is preserved verbatim). Slice-5 migrates the filter dropdown the same way — the
+// most complex builder (nested field/operator/value controls + recursive AND/OR condition groups
+// via MetaFilterConditionRow/MetaFilterGroup), content preserved verbatim. The remaining dropdown
+// trigger that opens a `.meta-toolbar__panel` (group) is NOT touched in this slice — deferred to a
+// later slice.
 import { MtButton, MtIconButton, MtMenu, MtMenuItem, MtPopover } from '../ui'
 import { seedFilterCondition } from '../utils/filter-condition-seed'
 import {
@@ -437,6 +456,12 @@ function onAddFilterGroup() {
    inside MtPopover's own `.mt-popover` surface (which only pads top/bottom), so this class supplies
    the horizontal breathing room the old `.meta-toolbar__panel { padding: 8px }` gave the rows. */
 .meta-toolbar__sort-panel { padding: var(--ms-space-2); min-width: 200px; box-sizing: border-box; }
+/* Filter builder panel (UI-P2-1c slice-5): same rationale as the hide-fields/sort panels above —
+   hosted inside MtPopover's own `.mt-popover` surface (which only pads top/bottom), so this class
+   supplies the horizontal breathing room the old `.meta-toolbar__panel { padding: 8px }` gave the
+   builder rows. Combined with the pre-existing `.meta-toolbar__panel--filter` class (kept for its
+   `min-width: 420px`, and so it stays a stable selector for the filter-builder tests). */
+.meta-toolbar__filter-panel { padding: var(--ms-space-2); box-sizing: border-box; }
 .meta-toolbar__sort-rule, .meta-toolbar__filter-rule { display: flex; gap: 4px; margin-bottom: 4px; align-items: center; }
 .meta-toolbar__sort-rule select, .meta-toolbar__filter-rule select { padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }
 .meta-toolbar__filter-value { flex: 1; min-width: 80px; padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }

--- a/apps/web/tests/meta-toolbar-filter-builder-mtpopover-migration.spec.ts
+++ b/apps/web/tests/meta-toolbar-filter-builder-mtpopover-migration.spec.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, reactive, type App } from 'vue'
+import MetaToolbar from '../src/multitable/components/MetaToolbar.vue'
+import type { FilterConjunction, FilterGroup, FilterRule } from '../src/multitable/composables/useMultitableGrid'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c slice-5: MetaToolbar's filter ("筛选") dropdown — the MOST COMPLEX builder in the
+// toolbar (nested field/operator/value controls via MetaFilterConditionRow, recursive AND/OR
+// condition groups via MetaFilterGroup) — was migrated from a hand-rolled `showFilterPanel` ref +
+// `.meta-toolbar__dropdown`/`.meta-toolbar__panel--filter` to the shared MtPopover primitive (NOT
+// MtMenu, NOT MtMenuItem rows — the panel markup, including its sub-components, is preserved
+// verbatim). This is an interaction-preservation proof, and — because this builder is the highest
+// NESTED-OVERLAY risk in the migration (deeply nested selects/inputs through two levels of
+// sub-components) — it specifically re-proves that every inner control stays inside MtPopover's
+// panel (no Teleported sub-menu escapes it), so editing a field/operator/value never closes the
+// popover mid-edit.
+
+// Track EVERY mount (see meta-toolbar-sort-builder-mtpopover-migration.spec.ts): a shared global app
+// would leave stale Teleported `.mt-popover` content on document.body after teardown. afterEach
+// unmounts ALL of them and asserts no toolbar DOM, and no leaked popover Teleport content, survives.
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+
+beforeEach(() => { useLocale().setLocale('en') })
+afterEach(() => {
+  while (mounts.length) {
+    const m = mounts.pop()!
+    m.app.unmount()
+    m.container.remove()
+  }
+  expect(document.querySelectorAll('.meta-toolbar').length).toBe(0) // residue guard: no leaked toolbar
+  expect(document.querySelectorAll('.mt-popover').length).toBe(0) // no leaked Teleported popover content
+  useLocale().setLocale('en')
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'status', name: 'Status', type: 'select', options: [{ value: 'todo' }, { value: 'done' }] },
+  { id: 'owner', name: 'Owner', type: 'string' },
+]
+
+type ExtraState = {
+  filterRules?: FilterRule[]
+  filterGroups?: FilterGroup[]
+  filterConjunction?: FilterConjunction
+} & Record<string, unknown>
+
+function mountToolbar(initial: ExtraState = {}) {
+  const state = reactive<{ filterRules: FilterRule[]; filterGroups: FilterGroup[]; filterConjunction: FilterConjunction }>({
+    filterRules: initial.filterRules ?? [],
+    filterGroups: initial.filterGroups ?? [],
+    filterConjunction: initial.filterConjunction ?? 'and',
+  })
+  const { filterRules: _r, filterGroups: _g, filterConjunction: _c, ...rest } = initial
+
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaToolbar, {
+    fields: FIELDS, hiddenFieldIds: [], sortRules: [],
+    filterRules: state.filterRules, filterGroups: state.filterGroups, filterConjunction: state.filterConjunction,
+    canCreateRecord: true, canExport: true, canUndo: true, canRedo: true, sortFilterDirty: false,
+    onAddFilter: (rule: FilterRule) => { state.filterRules.push(rule) },
+    onUpdateFilter: (index: number, rule: FilterRule) => { state.filterRules[index] = rule },
+    onRemoveFilter: (index: number) => { state.filterRules.splice(index, 1) },
+    onAddFilterGroup: (group: FilterGroup) => { state.filterGroups.push(group) },
+    onUpdateFilterGroup: (index: number, group: FilterGroup) => { state.filterGroups[index] = group },
+    onRemoveFilterGroup: (index: number) => { state.filterGroups.splice(index, 1) },
+    onClearFilters: () => { state.filterRules = []; state.filterGroups = []; state.filterConjunction = 'and' },
+    onSetConjunction: (conj: FilterConjunction) => { state.filterConjunction = conj },
+    ...rest,
+  }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return { container, state }
+}
+
+function filterTrigger(root: HTMLElement): HTMLButtonElement {
+  const btn = root.querySelector('button[title="Filter"]') as HTMLButtonElement | null
+  expect(btn, 'expected a <button title="Filter"> trigger').toBeTruthy()
+  return btn as HTMLButtonElement
+}
+
+// The filter panel is Teleported to document.body by MtPopover (a sibling of the toolbar's own
+// mount container, not a descendant of it), so it's looked up via document once open.
+function filterPanel(): HTMLElement {
+  const panel = document.querySelector('.meta-toolbar__panel--filter') as HTMLElement | null
+  expect(panel, 'expected the filter builder panel inside the popover').toBeTruthy()
+  return panel!
+}
+
+function conditionRows(): HTMLDivElement[] {
+  return Array.from(document.querySelectorAll('.meta-toolbar__filter-rule')) as HTMLDivElement[]
+}
+
+describe('MetaToolbar filter builder — MtPopover migration (UI-P2-1c slice-5)', () => {
+  it('is closed until the trigger is clicked; clicking it opens the popover with the builder content', async () => {
+    const { container: root } = mountToolbar({ filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }] })
+    expect(document.querySelector('.mt-popover')).toBeNull()
+
+    const trigger = filterTrigger(root)
+    expect(trigger.tagName).toBe('BUTTON')
+    expect(trigger.getAttribute('aria-label')).toBe('Filter')
+    trigger.click()
+    await nextTick()
+
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    const panel = filterPanel()
+    const rows = conditionRows()
+    expect(rows.length).toBe(1)
+    expect(rows[0].querySelectorAll('select').length).toBeGreaterThanOrEqual(2) // field select + operator select (+ value select)
+    expect(panel.textContent).toContain('Add filter')
+    expect(panel.textContent).toContain('Add condition group')
+  })
+
+  it('shows the filter-rule+group-count badge on the trigger, same as before migration', async () => {
+    const { container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }],
+      filterGroups: [{ conjunction: 'and', conditions: [{ fieldId: 'owner', operator: 'is', value: '' }] }],
+    })
+    const trigger = filterTrigger(root)
+    const badge = trigger.querySelector('.meta-toolbar__badge')
+    expect(badge, 'expected the filter count badge inside the trigger button').toBeTruthy()
+    expect(badge?.textContent?.trim()).toBe('2')
+  })
+
+  it('"Add filter" emits add-filter(rule) — same event + payload as before migration — AND keeps the popover OPEN', async () => {
+    const { container: root, state } = mountToolbar({ filterRules: [] })
+    const trigger = filterTrigger(root)
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    const addBtn = Array.from(filterPanel().querySelectorAll('button'))
+      .find((b) => b.textContent?.includes('Add filter')) as HTMLButtonElement
+    expect(addBtn).toBeTruthy()
+    addBtn.click()
+    await nextTick()
+
+    expect(state.filterRules).toEqual([{ fieldId: 'status', operator: 'is', value: 'todo' }])
+    // Key builder behavior (unlike MtMenu's select-and-close row): the popover must still be open
+    // after adding a rule, so the newly added row can be edited without reopening the panel.
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    expect(conditionRows().length).toBe(1)
+  })
+
+  it('changing a condition row\'s field select emits update-filter(index, rule) and keeps the popover open (inner control does not close it)', async () => {
+    const { container: root, state } = mountToolbar({ filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }] })
+    filterTrigger(root).click()
+    await nextTick()
+
+    const fieldSelect = conditionRows()[0].querySelector('select[aria-label="Filter field"]') as HTMLSelectElement
+    fieldSelect.value = 'owner'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    expect(state.filterRules[0].fieldId).toBe('owner')
+    // Verifies the NESTED-OVERLAY risk called out in the migration brief: a click/change on an inner
+    // <select> nested TWO levels deep (toolbar -> MetaFilterConditionRow) inside the teleported panel
+    // must not be treated as an "outside click" that closes it.
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('changing a condition row\'s operator select emits update-filter(index, rule) and keeps the popover open', async () => {
+    const { container: root, state } = mountToolbar({ filterRules: [{ fieldId: 'owner', operator: 'is', value: 'alice' }] })
+    filterTrigger(root).click()
+    await nextTick()
+
+    const operatorSelect = conditionRows()[0].querySelector('select[aria-label="Filter operator"]') as HTMLSelectElement
+    operatorSelect.value = 'isEmpty'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    expect(state.filterRules[0]).toEqual({ fieldId: 'owner', operator: 'isEmpty', value: undefined })
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('changing a condition row\'s value control emits update-filter(index, rule) and keeps the popover open', async () => {
+    const { container: root, state } = mountToolbar({ filterRules: [{ fieldId: 'owner', operator: 'is', value: '' }] })
+    filterTrigger(root).click()
+    await nextTick()
+
+    const valueInput = conditionRows()[0].querySelector('input[aria-label="Filter value"]') as HTMLInputElement
+    valueInput.value = 'alice'
+    valueInput.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    expect(state.filterRules[0]).toEqual({ fieldId: 'owner', operator: 'is', value: 'alice' })
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('the remove (×) button on a condition row emits remove-filter(index) and keeps the popover open', async () => {
+    const { container: root, state } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }, { fieldId: 'owner', operator: 'is', value: 'alice' }],
+    })
+    filterTrigger(root).click()
+    await nextTick()
+    expect(conditionRows().length).toBe(2)
+
+    const removeBtn = conditionRows()[0].querySelector('.meta-toolbar__remove') as HTMLButtonElement
+    removeBtn.click()
+    await nextTick()
+
+    expect(state.filterRules).toEqual([{ fieldId: 'owner', operator: 'is', value: 'alice' }])
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    expect(conditionRows().length).toBe(1)
+  })
+
+  it('"Add group" emits add-filter-group(group) with a seeded one-condition group and keeps the popover open', async () => {
+    const { container: root, state } = mountToolbar()
+    filterTrigger(root).click()
+    await nextTick()
+
+    const addGroupBtn = filterPanel().querySelector('[data-add-filter-group="true"]') as HTMLButtonElement
+    expect(addGroupBtn).toBeTruthy()
+    addGroupBtn.click()
+    await nextTick()
+
+    expect(state.filterGroups.length).toBe(1)
+    expect(state.filterGroups[0].conjunction).toBe('and')
+    expect(state.filterGroups[0].conditions).toEqual([{ fieldId: 'status', operator: 'is', value: 'todo' }])
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+    expect(filterPanel().querySelector('.meta-filter-group')).toBeTruthy()
+  })
+
+  it('changing a rendered group\'s conjunction select emits update-filter-group(index, group) and keeps the popover open (2-level-deep inner control)', async () => {
+    const { container: root, state } = mountToolbar({
+      filterGroups: [{ conjunction: 'and', conditions: [{ fieldId: 'status', operator: 'is', value: 'todo' }] }],
+    })
+    filterTrigger(root).click()
+    await nextTick()
+
+    const conjSelect = filterPanel().querySelector('select[data-filter-group-conjunction="true"]') as HTMLSelectElement
+    expect(conjSelect).toBeTruthy()
+    conjSelect.value = 'or'
+    conjSelect.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    expect(state.filterGroups[0]).toEqual({ conjunction: 'or', conditions: [{ fieldId: 'status', operator: 'is', value: 'todo' }] })
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('the group\'s remove button emits remove-filter-group(index) and keeps the popover open', async () => {
+    const { container: root, state } = mountToolbar({
+      filterGroups: [{ conjunction: 'and', conditions: [{ fieldId: 'status', operator: 'is', value: 'todo' }] }],
+    })
+    filterTrigger(root).click()
+    await nextTick()
+
+    const removeGroupBtn = filterPanel().querySelector('[data-filter-group-remove="true"]') as HTMLButtonElement
+    expect(removeGroupBtn).toBeTruthy()
+    removeGroupBtn.click()
+    await nextTick()
+
+    expect(state.filterGroups).toEqual([])
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('the top-level conjunction select emits set-conjunction(conj) and keeps the popover open (rendered only when 2+ conditions)', async () => {
+    const { container: root, state } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }, { fieldId: 'owner', operator: 'is', value: 'alice' }],
+      filterConjunction: 'and',
+    })
+    filterTrigger(root).click()
+    await nextTick()
+
+    const conjSelect = filterPanel().querySelector('.meta-toolbar__conjunction select') as HTMLSelectElement
+    expect(conjSelect).toBeTruthy()
+    conjSelect.value = 'or'
+    conjSelect.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    expect(state.filterConjunction).toBe('or')
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('"Clear all" emits clear-filters (no payload) and keeps the popover open', async () => {
+    const onClearFilters = vi.fn()
+    const { container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }],
+      onClearFilters,
+    })
+    filterTrigger(root).click()
+    await nextTick()
+
+    const clearBtn = Array.from(filterPanel().querySelectorAll('button'))
+      .find((b) => b.textContent?.includes('Clear all')) as HTMLButtonElement
+    expect(clearBtn).toBeTruthy()
+    clearBtn.click()
+    await nextTick()
+
+    expect(onClearFilters).toHaveBeenCalledTimes(1)
+    expect(onClearFilters).toHaveBeenCalledWith()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('"Apply" emits apply-sort-filter (no payload) — same as before migration — and clicking it does not close the popover', async () => {
+    const onApplySortFilter = vi.fn()
+    const { container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }],
+      onApplySortFilter,
+    })
+    filterTrigger(root).click()
+    await nextTick()
+
+    const applyBtn = filterPanel().querySelector('.meta-toolbar__apply') as HTMLButtonElement
+    expect(applyBtn).toBeTruthy()
+    applyBtn.click()
+    await nextTick()
+
+    expect(onApplySortFilter).toHaveBeenCalledTimes(1)
+    expect(onApplySortFilter).toHaveBeenCalledWith() // no payload
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+  })
+
+  it('pressing Escape closes the popover', async () => {
+    const { container: root } = mountToolbar({ filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }] })
+    filterTrigger(root).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+  })
+
+  it('a click outside the trigger and panel closes the popover', async () => {
+    const { container: root } = mountToolbar({ filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }] })
+    filterTrigger(root).click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+    expect(root).toBeTruthy() // root/toolbar itself is untouched by the close
+  })
+
+  it('a second click on the trigger closes the popover again (no filter mutation, no emit)', async () => {
+    const onAddFilter = vi.fn()
+    const { container: root } = mountToolbar({ filterRules: [], onAddFilter })
+    const trigger = filterTrigger(root)
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).not.toBeNull()
+
+    trigger.click()
+    await nextTick()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+    expect(onAddFilter).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/meta-toolbar-filter-builder.spec.ts
+++ b/apps/web/tests/meta-toolbar-filter-builder.spec.ts
@@ -79,13 +79,17 @@ function mountToolbar(initial: Partial<ToolbarState> = {}) {
   return { state, container }
 }
 
+// UI-P2-1c slice-5: the filter panel now renders inside MtPopover, which Teleports its content to
+// `document.body` — a sibling of the toolbar's own mount container, not a descendant of it. So the
+// panel must be looked up via `document`, not `root`, once it's open (the trigger button itself is
+// still inside `root`).
 async function openFilterPanel(root: HTMLElement): Promise<HTMLElement> {
   const button = Array.from(root.querySelectorAll('button'))
     .find((candidate) => candidate.textContent?.includes('Filter')) as HTMLButtonElement | undefined
   expect(button).toBeTruthy()
   button?.click()
   await nextTick()
-  const panel = root.querySelector('.meta-toolbar__panel--filter') as HTMLElement | null
+  const panel = document.querySelector('.meta-toolbar__panel--filter') as HTMLElement | null
   expect(panel).toBeTruthy()
   return panel!
 }
@@ -246,7 +250,8 @@ async function openFilterPanelI18n(root: HTMLElement): Promise<HTMLElement> {
   expect(button).toBeTruthy()
   button?.click()
   await nextTick()
-  const panel = root.querySelector('.meta-toolbar__panel--filter') as HTMLElement | null
+  // Teleported by MtPopover to document.body (see openFilterPanel above) — look up via document.
+  const panel = document.querySelector('.meta-toolbar__panel--filter') as HTMLElement | null
   expect(panel).toBeTruthy()
   return panel!
 }


### PR DESCRIPTION
Fifth P2-1c migration (serial after #3781; behavior-adjacent — NOT self-merged). The most complex builder — filter ("筛选"), with nested condition rows / groups / AND-OR. Wraps trigger+panel in MtPopover, builder markup + all emits preserved verbatim.

## ⚠ Nested-overlay verification — SAFE (native, not teleported)
Read `MetaFilterConditionRow.vue` + `MetaFilterGroup.vue` (recursive) in full: every field/operator/value/conjunction control at every nesting depth is a native `<select>`/`<input>` — NO `Teleport` in either. So MtPopover's `panelRef.contains(target)` outside-click check always treats builder interactions as "inside" → the popover does NOT close mid-edit. Asserted per-interaction in tests.

## Change (filter dropdown only)
Trigger → `MtButton` (title/aria/badge). Panel (conjunction selector + `MetaFilterConditionRow` + `MetaFilterGroup` rows + add/clear/apply) → MtPopover `v-model:open` default slot, verbatim under a token-only `.meta-toolbar__filter-panel` wrapper (kept the `.meta-toolbar__panel--filter` selector class for min-width). Removed the panel's own Escape (MtPopover supplies Esc + click-outside). Sort/group/density/action untouched.

## Invariant proof + tests
- **emit() set byte-identical vs main**: all 8 filter emits (`add-filter`/`update-filter`/`remove-filter`/`add-filter-group`/`update-filter-group`/`remove-filter-group`/`set-conjunction`/`clear-filters`) + `apply-sort-filter` + everything else unchanged.
- New `meta-toolbar-filter-builder-mtpopover-migration.spec.ts` (16 tests): every mutating interaction (incl. a 2-levels-deep control) emits + **popover stays open**; Esc/outside/second-click close. mounts-array + `.meta-toolbar`/`.mt-popover` residue guards.
- Existing `meta-toolbar-filter-builder.spec.ts` (22): the **only** change is the panel lookup `root.querySelector` → `document.querySelector` in its two open-helpers — because MtPopover now Teleports the panel to `document.body` (a sibling of the mount container). **All 22 assertions unchanged; 22/22 still pass.**
- Full suite: **93/93** across 8 MetaToolbar + overlay specs. vue-tsc clean; token-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)