### PR TITLE
fix(multitable): accept partial permission revert snapshots

### DIFF
--- a/packages/core-backend/src/multitable/config-restore.ts
+++ b/packages/core-backend/src/multitable/config-restore.ts
@@ -184,17 +184,18 @@ export function parsePermissionEntityId(entityId: string): { scope: PermissionSc
 }
 
 /**
- * Fail-closed identity guard: a permission revision's `before` snapshot MUST describe the SAME subject/entity as the
- * entity_id (`parts`) the apply writes to. The apply already keys off `parts` (not the snapshot's embedded subject),
- * so a mismatch can't laundry an escalation onto another subject — but a mismatched snapshot is a malformed/forged
- * revision and is refused (analogous to the sheet_config `entity_id ≡ sheet_id` guard).
+ * Fail-closed identity guard: `entity_id` (`parts`) is the authoritative apply target, and permission UPDATE
+ * revisions may record only changed keys (for example `{ accessLevel: 'read' }`) without embedding subject/entity
+ * identity. Accept those partial snapshots, but refuse any snapshot that DOES embed a target key contradicting
+ * `entity_id` (analogous to the sheet_config `entity_id ≡ sheet_id` guard).
  */
 export function permissionTargetMatchesParts(scope: PermissionScope, target: Record<string, unknown> | null | undefined, parts: string[]): boolean {
   if (!target) return true // revoke (before=null) has no embedded subject to disagree
   const s = (v: unknown) => String(v ?? '')
-  if (scope === 'field') return s(target.fieldId) === parts[0] && s(target.subjectType) === parts[1] && s(target.subjectId) === parts[2]
-  if (scope === 'view') return s(target.viewId) === parts[0] && s(target.subjectType) === parts[1] && s(target.subjectId) === parts[2]
-  return s(target.subjectType) === parts[0] && s(target.subjectId) === parts[1]
+  const keyMatches = (key: string, expected: string) => !Object.prototype.hasOwnProperty.call(target, key) || s(target[key]) === expected
+  if (scope === 'field') return keyMatches('fieldId', parts[0]) && keyMatches('subjectType', parts[1]) && keyMatches('subjectId', parts[2])
+  if (scope === 'view') return keyMatches('viewId', parts[0]) && keyMatches('subjectType', parts[1]) && keyMatches('subjectId', parts[2])
+  return keyMatches('subjectType', parts[0]) && keyMatches('subjectId', parts[1])
 }
 
 const stable = (v: unknown): string => JSON.stringify(v ?? null)

--- a/packages/core-backend/tests/integration/multitable-permission-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-permission-revert-realdb.test.ts
@@ -13,8 +13,9 @@
  * BEFORE the direction re-check). Apply mirrors the forward grant write (target=null ⇒ revoke) and records a
  * source='restore' permission revision (live → target).
  *
- * Goldens (a)-(l): (a) flag-off 403 (preview+execute) · (b) canManageSheetAccess floor 403 · (c) happy SHEET
- * de-escalation (admin→read + restore revision) · (d) happy REVOKE (revert a `create`, before=null) · (e) escalation
+ * Goldens (a)-(m) + (c2): (a) flag-off 403 (preview+execute) · (b) canManageSheetAccess floor 403 · (c) happy SHEET
+ * de-escalation (admin→read + restore revision) · (c2) partial UPDATE snapshot accepted (entity_id is authoritative)
+ * · (d) happy REVOKE (revert a `create`, before=null) · (e) escalation
  * refused 422 · (f) noop refused 422 · (g) LIVE re-check load-bearing 422 (uses live, not recorded after) · (h) grant
  * drift 409 · (i) FIELD de-escalation (read-write→read-only) · (j) VIEW de-escalation (admin→read) · (k) typed-confirm
  * 400/200 · (l) no-oracle preview shape. Runs only with DATABASE_URL.
@@ -185,6 +186,30 @@ describeIfDatabase('multitable permission-revert — T9-W de-escalation-only (re
     // grant LOWERED admin → read (the single managed code is now spreadsheet:read = deriveSheetAccessLevel 'read').
     expect(await sheetCodes(s, subj)).toEqual(['spreadsheet:read'])
     // a source='restore' permission revision back-references the reverted revision (assert it so a silent no-diff regresses).
+    expect(await restoreRevCount(s, eid, rev)).toBe(1)
+  })
+
+  test('(c2) UPDATE revisions may store changed keys only: before lacks subject keys but execute still de-escalates via entity_id', async () => {
+    process.env[FLAG] = 'true'
+    const s = await freshSheet('c2')
+    const subj = mkSubject('c2')
+    await seedSheetGrant(s, subj, 'write') // LIVE = write (rank 3)
+    const eid = sheetEntityId(subj)
+    // Mirrors the forward recorder's update shape observed in staging: changed keys only, identity lives in entity_id.
+    const rev = await insertPermissionRev(s, eid, {
+      action: 'update',
+      before: { accessLevel: 'read' },
+      after: { accessLevel: 'write' },
+      changedKeys: ['accessLevel'],
+    })
+
+    const p = await preview(s, rev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.permissionRevert).toMatchObject({ scope: 'sheet', direction: 'de-escalation', supported: true })
+    const ok = await execute(s, { revisionId: rev, previewToken: p.body.data.previewToken, confirm: 'revert-permission' })
+    expect(ok.status).toBe(200)
+    expect(ok.body?.data?.permissionReverted).toMatchObject({ scope: 'sheet', entityId: eid })
+    expect(await sheetCodes(s, subj)).toEqual(['spreadsheet:read'])
     expect(await restoreRevCount(s, eid, rev)).toBe(1)
   })
 

--- a/packages/core-backend/tests/multitable-permission-revert-target-guard.test.ts
+++ b/packages/core-backend/tests/multitable-permission-revert-target-guard.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest'
+
+import { permissionTargetMatchesParts } from '../src/multitable/config-restore'
+
+describe('permissionTargetMatchesParts — permission revert target guard', () => {
+  test('accepts partial UPDATE snapshots that omit identity keys', () => {
+    expect(permissionTargetMatchesParts('sheet', { accessLevel: 'read' }, ['user', 'u1'])).toBe(true)
+    expect(permissionTargetMatchesParts('view', { permission: 'read' }, ['view1', 'user', 'u1'])).toBe(true)
+    expect(permissionTargetMatchesParts('field', { visible: true, readOnly: true }, ['field1', 'user', 'u1'])).toBe(true)
+  })
+
+  test('rejects explicit identity-key mismatches', () => {
+    expect(permissionTargetMatchesParts('sheet', { subjectType: 'user', subjectId: 'u2', accessLevel: 'read' }, ['user', 'u1'])).toBe(false)
+    expect(permissionTargetMatchesParts('view', { viewId: 'view2', permission: 'read' }, ['view1', 'user', 'u1'])).toBe(false)
+    expect(permissionTargetMatchesParts('field', { fieldId: 'field2', visible: true }, ['field1', 'user', 'u1'])).toBe(false)
+  })
+
+  test('accepts explicit matching identity keys', () => {
+    expect(permissionTargetMatchesParts('sheet', { subjectType: 'user', subjectId: 'u1', accessLevel: 'read' }, ['user', 'u1'])).toBe(true)
+    expect(permissionTargetMatchesParts('view', { viewId: 'view1', subjectType: 'user', subjectId: 'u1', permission: 'read' }, ['view1', 'user', 'u1'])).toBe(true)
+    expect(permissionTargetMatchesParts('field', { fieldId: 'field1', subjectType: 'user', subjectId: 'u1', visible: true }, ['field1', 'user', 'u1'])).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- fix permission-revert execute guard to accept real UPDATE revisions that store changed keys only while still rejecting explicit target mismatches
- add DB-free guard tests for partial/matching/mismatched snapshots
- add a real-DB golden for partial sheet permission UPDATE snapshots executing as de-escalation

## Verification
- cd packages/core-backend && npx vitest run tests/multitable-permission-revert-target-guard.test.ts
- cd packages/core-backend && npx tsc --noEmit
- cd packages/core-backend && npx vitest run tests/integration/multitable-permission-revert-realdb.test.ts --config vitest.integration.config.ts (skipped locally: no DATABASE_URL; expected to run in CI real-DB allowlist)

## Staging context
During Global History staging flag enablement, MULTITABLE_ENABLE_PERMISSION_REVERT exposed that forward permission UPDATE revisions store partial before/after snapshots such as { accessLevel }, with the identity held in entity_id. Preview accepted these revisions, but execute rejected them as INVALID_REVISION before reaching the de-escalation/drift guards.
