### PR TITLE
feat(web): multitable UI P2-1c slice-6 — MetaToolbar group picker → MtPopover (last toolbar dropdown)

### DIFF
--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -115,13 +115,20 @@
         </div>
       </MtPopover>
 
-      <!-- Group By (nested / multi-level: ordered 1-3 levels) -->
-      <div class="meta-toolbar__dropdown">
-        <button class="meta-toolbar__btn" @click="showGroupPanel = !showGroupPanel">
-          <el-icon class="meta-toolbar__btn-icon"><component :is="ICON.group" /></el-icon> {{ l('toolbar.group') }}
-          <span v-if="activeGroupFieldIds.length" class="meta-toolbar__badge">{{ activeGroupFieldIds.length }}</span>
-        </button>
-        <div v-if="showGroupPanel" class="meta-toolbar__panel meta-toolbar__panel--group" @keydown.escape="showGroupPanel = false">
+      <!-- Group By (nested / multi-level: ordered 1-3 levels) — UI-P2-1c slice-6: migrated to shared
+           MtPopover (the LAST MetaToolbar dropdown). Inner controls are native <select>/<button> (no
+           Teleport), so MtPopover's `panelRef.contains(target)` treats edits as inside → the panel
+           stays open during multi-level editing. The panel's own `@keydown.escape` is dropped;
+           MtPopover's document-level Escape + click-outside now cover it. -->
+      <MtPopover v-model:open="showGroupPanel">
+        <template #trigger>
+          <MtButton :title="l('toolbar.group')" :aria-label="l('toolbar.group')">
+            <template #icon><el-icon><component :is="ICON.group" /></el-icon></template>
+            {{ l('toolbar.group') }}
+            <span v-if="activeGroupFieldIds.length" class="meta-toolbar__badge">{{ activeGroupFieldIds.length }}</span>
+          </MtButton>
+        </template>
+        <div class="meta-toolbar__group-panel meta-toolbar__panel--group">
           <div v-for="(levelId, levelIndex) in groupLevels" :key="levelIndex" class="meta-toolbar__group-level">
             <span class="meta-toolbar__group-level-prefix">{{ levelIndex === 0 ? l('toolbar.group') : l('toolbar.groupThenBy') }}</span>
             <select
@@ -149,7 +156,7 @@
             @click="onAddGroupLevel"
           >{{ l('toolbar.groupAddLevel') }}</button>
         </div>
-      </div>
+      </MtPopover>
 
       <!-- Undo/Redo (UI-P2-1c: migrated to shared MtIconButton — ghost, icon-only) -->
       <span class="meta-toolbar__divider" aria-hidden="true"></span>
@@ -462,6 +469,7 @@ function onAddFilterGroup() {
    builder rows. Combined with the pre-existing `.meta-toolbar__panel--filter` class (kept for its
    `min-width: 420px`, and so it stays a stable selector for the filter-builder tests). */
 .meta-toolbar__filter-panel { padding: var(--ms-space-2); box-sizing: border-box; }
+.meta-toolbar__group-panel { padding: var(--ms-space-2); box-sizing: border-box; }
 .meta-toolbar__sort-rule, .meta-toolbar__filter-rule { display: flex; gap: 4px; margin-bottom: 4px; align-items: center; }
 .meta-toolbar__sort-rule select, .meta-toolbar__filter-rule select { padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }
 .meta-toolbar__filter-value { flex: 1; min-width: 80px; padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }

--- a/apps/web/tests/meta-toolbar-group-picker-mtpopover-migration.spec.ts
+++ b/apps/web/tests/meta-toolbar-group-picker-mtpopover-migration.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaToolbar from '../src/multitable/components/MetaToolbar.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c slice-6: the group ("分组") dropdown — the LAST MetaToolbar dropdown — was migrated from a
+// hand-rolled `showGroupPanel` toggle + `.meta-toolbar__panel--group` markup to the shared MtPopover.
+// Its inner controls are native <select>/<button> (no Teleport), so MtPopover treats edits as "inside"
+// and the panel STAYS OPEN during multi-level editing. This proves: same `set-group-fields` emit +
+// payload, stays-open-on-edit, Esc/outside/second-click close — behaviour preserved, not a snapshot.
+
+// Track EVERY mount (some tests mount twice); afterEach unmounts all + asserts no leaked toolbar OR
+// teleported popover survives — the DOM-pollution guard the owner enforced in slice-1.
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+
+afterEach(() => {
+  while (mounts.length) {
+    const m = mounts.pop()!
+    m.app.unmount()
+    m.container.remove()
+  }
+  expect(document.querySelectorAll('.meta-toolbar').length).toBe(0)
+  expect(document.querySelectorAll('.mt-popover').length).toBe(0) // Teleport residue guard
+  useLocale().setLocale('en')
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'status', name: 'Status', type: 'select', options: [{ value: 'a' }] },
+  { id: 'amount', name: 'Amount', type: 'number' },
+  { id: 'city', name: 'City', type: 'string' },
+]
+
+function mountToolbar(props: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaToolbar, {
+    fields: FIELDS, hiddenFieldIds: [], sortRules: [], filterRules: [], filterConjunction: 'and',
+    canCreateRecord: true, canExport: true, canUndo: false, canRedo: false, sortFilterDirty: false,
+    ...props,
+  }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const groupTrigger = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll('button')).find((b) => b.textContent?.includes('Group')) as HTMLButtonElement
+const panel = () => document.querySelector('.meta-toolbar__panel--group') as HTMLElement | null
+
+describe('MetaToolbar group picker — MtPopover migration (UI-P2-1c slice-6)', () => {
+  it('is closed by default; clicking the trigger opens the teleported MtPopover with the group-select', async () => {
+    const root = mountToolbar()
+    expect(panel()).toBeNull()
+    expect(document.querySelector('.mt-popover')).toBeNull()
+    groupTrigger(root).click(); await nextTick()
+    expect(panel()).toBeTruthy()
+    expect(panel()!.querySelector('.meta-toolbar__group-select')).toBeTruthy()
+  })
+
+  it('trigger is a native <button> (MtButton) and carries the group title/aria-label', async () => {
+    const root = mountToolbar()
+    const btn = groupTrigger(root)
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.getAttribute('aria-label')).toBe('Group')
+    expect(btn.getAttribute('title')).toBe('Group')
+  })
+
+  it('selecting a group field emits set-group-fields with the deduped payload AND keeps the popover open', async () => {
+    const onSetGroupFields = vi.fn()
+    const root = mountToolbar({ onSetGroupFields })
+    groupTrigger(root).click(); await nextTick()
+    const select = panel()!.querySelector('.meta-toolbar__group-select') as HTMLSelectElement
+    select.value = 'status'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+    expect(onSetGroupFields).toHaveBeenCalledTimes(1)
+    expect(onSetGroupFields).toHaveBeenCalledWith(['status'])
+    // the defining multi-level behaviour: the panel must NOT close after a selection
+    expect(document.querySelector('.mt-popover')).toBeTruthy()
+    expect(panel()).toBeTruthy()
+  })
+
+  it('Escape closes the popover', async () => {
+    const root = mountToolbar()
+    groupTrigger(root).click(); await nextTick()
+    expect(panel()).toBeTruthy()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+    expect(panel()).toBeNull()
+  })
+
+  it('outside click closes the popover', async () => {
+    const root = mountToolbar()
+    groupTrigger(root).click(); await nextTick()
+    expect(panel()).toBeTruthy()
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    await nextTick()
+    expect(panel()).toBeNull()
+  })
+
+  it('second trigger click closes the popover with no set-group-fields emit', async () => {
+    const onSetGroupFields = vi.fn()
+    const root = mountToolbar({ onSetGroupFields })
+    const btn = groupTrigger(root)
+    btn.click(); await nextTick()
+    expect(panel()).toBeTruthy()
+    btn.click(); await nextTick()
+    expect(panel()).toBeNull()
+    expect(onSetGroupFields).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/meta-toolbar-group-picker.spec.ts
+++ b/apps/web/tests/meta-toolbar-group-picker.spec.ts
@@ -32,7 +32,10 @@ async function openGroupPanel(root: HTMLElement): Promise<HTMLElement> {
   const button = Array.from(root.querySelectorAll('button')).find((b) => b.textContent?.includes('Group')) as HTMLButtonElement
   button.click()
   await nextTick()
-  const panel = root.querySelector('.meta-toolbar__panel--group') as HTMLElement
+  // UI-P2-1c slice-6: the group panel now renders inside MtPopover, which Teleports its content to
+  // `document.body` (a sibling of the toolbar's own mount container). Look it up via `document`, not
+  // `root` (the trigger button itself is still inside `root`). Assertions below are unchanged.
+  const panel = document.querySelector('.meta-toolbar__panel--group') as HTMLElement
   expect(panel).toBeTruthy()
   return panel
 }


### PR DESCRIPTION
Sixth & final MetaToolbar P2-1c migration (serial after #3783; behavior-adjacent — NOT self-merged). **Completes all 5 MetaToolbar dropdowns (fields/sort/filter/group/density) + action buttons on the shared UI primitives.**

## Change (group dropdown only)
Group ("分组") multi-level picker → MtPopover (`v-model:open`), `MtButton` trigger (title/aria/count-badge). Picker markup (level rows: field `<select>` + remove, add-level) preserved verbatim under a token-only `.meta-toolbar__group-panel` wrapper (kept `.meta-toolbar__panel--group` for min-width). Removed the panel's own `@keydown.escape` — MtPopover supplies Esc + click-outside.

## Nested-overlay: SAFE (native)
Inner controls are native `<select>`/`<button>` (no Teleport) → MtPopover's `panelRef.contains(target)` treats multi-level edits as inside → panel stays open. Asserted per-interaction.

## Invariant proof + tests
- **emit() set byte-identical vs main**; `set-group-fields` payload (deduped `string[]`) unchanged.
- New `meta-toolbar-group-picker-mtpopover-migration.spec.ts` (6 tests): open; native-button trigger with group title/aria; selecting a field emits `set-group-fields` **and the popover stays open**; Esc/outside/second-click close. mounts-array + `.meta-toolbar`/`.mt-popover` residue guards.
- Existing `meta-toolbar-group-picker.spec.ts` (8): **only** change is the panel lookup `root.querySelector` → `document.querySelector` (MtPopover Teleports the panel to body) — assertions unchanged, 8/8.
- Full suite **99/99** across 9 MetaToolbar + overlay specs. vue-tsc clean; token-only.

Note: implemented in the main loop (the P2-1c-6 subagent hit a session usage limit); same rigor as the agent-run slices — emit-diff + 99/99 + hygiene verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)