### PR TITLE
feat(web): IU-2b integration workbench section extraction — child components, zero behavior change (design-lock #3739)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -102,8 +102,13 @@ on:
       - 'apps/web/src/multitable/components/MetaAutomationManager.vue'
       - 'apps/web/src/multitable/components/MetaAutomationRuleEditor.vue'
       # IU-2a — Workbench chrome slice added to the UF-6 hex/rgb + static-style= guard set.
+      # IU-2b — the three extracted section components copy CSS verbatim from the (already
+      # token-only) parent, so they join the same guard set from day one.
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
+      - 'apps/web/src/components/integration/IntegrationMonitoringSection.vue'
+      - 'apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue'
+      - 'apps/web/src/components/integration/IntegrationMappingRulesSection.vue'
       - 'apps/web/src/styles/form-layout-utilities.css'
       - 'apps/web/.eslintrc.cjs'
       - 'apps/web/tests/ui-foundation-style-guard.spec.ts'
@@ -201,8 +206,13 @@ on:
       - 'apps/web/src/multitable/components/MetaAutomationManager.vue'
       - 'apps/web/src/multitable/components/MetaAutomationRuleEditor.vue'
       # IU-2a — Workbench chrome slice added to the UF-6 hex/rgb + static-style= guard set.
+      # IU-2b — the three extracted section components copy CSS verbatim from the (already
+      # token-only) parent, so they join the same guard set from day one.
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
+      - 'apps/web/src/components/integration/IntegrationMonitoringSection.vue'
+      - 'apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue'
+      - 'apps/web/src/components/integration/IntegrationMappingRulesSection.vue'
       - 'apps/web/src/styles/form-layout-utilities.css'
       - 'apps/web/.eslintrc.cjs'
       - 'apps/web/tests/ui-foundation-style-guard.spec.ts'

--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -29,6 +29,10 @@ on:
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
       - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
+      - 'apps/web/src/components/integration/IntegrationMonitoringSection.vue'
+      - 'apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue'
+      - 'apps/web/src/components/integration/IntegrationMappingRulesSection.vue'
+      - 'apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts'
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
       - 'apps/web/src/views/IntegrationHelpView.vue'
@@ -42,6 +46,9 @@ on:
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchRail.spec.ts'
+      - 'apps/web/tests/IntegrationMonitoringSection.spec.ts'
+      - 'apps/web/tests/IntegrationCleaningDatasetSection.spec.ts'
+      - 'apps/web/tests/IntegrationMappingRulesSection.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - '.github/workflows/integration-guard.yml'
@@ -57,6 +64,10 @@ on:
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
       - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
+      - 'apps/web/src/components/integration/IntegrationMonitoringSection.vue'
+      - 'apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue'
+      - 'apps/web/src/components/integration/IntegrationMappingRulesSection.vue'
+      - 'apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts'
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
       - 'apps/web/src/views/IntegrationHelpView.vue'
@@ -70,6 +81,9 @@ on:
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchRail.spec.ts'
+      - 'apps/web/tests/IntegrationMonitoringSection.spec.ts'
+      - 'apps/web/tests/IntegrationCleaningDatasetSection.spec.ts'
+      - 'apps/web/tests/IntegrationMappingRulesSection.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - '.github/workflows/integration-guard.yml'
@@ -117,4 +131,4 @@ jobs:
         run: pnpm --filter plugin-integration-core test
 
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot

--- a/apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue
+++ b/apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue
@@ -1,0 +1,423 @@
+<template>
+  <section id="int-sec-cleaning-dataset" class="integration-workbench__panel">
+    <el-card shadow="never">
+      <template #header>
+        <div class="integration-workbench__panel-head">
+          <div>
+            <h2>数据集与多维表清洗</h2>
+        <p>数据源和目标系统只负责读写；业务清洗、审核、修正发生在多维表里。未安装清洗表时，可在这里创建 staging 多维表。</p>
+      </div>
+    </div>
+      </template>
+
+
+    <div class="integration-workbench__dataset-grid" data-testid="dataset-cards">
+      <article class="integration-workbench__dataset-card" data-testid="source-dataset-card">
+        <div class="integration-workbench__dataset-head">
+          <span class="integration-workbench__dataset-kind">数据源</span>
+          <strong>{{ sourceDatasetTitle }}</strong>
+        </div>
+        <p>{{ sourceDatasetDescription }}</p>
+        <div class="integration-workbench__metric-row">
+          <span>{{ sourceSchema.fields.length }} 个字段</span>
+          <span>{{ sourceConnectionLabel }}</span>
+        </div>
+      </article>
+
+      <article class="integration-workbench__dataset-card" data-testid="staging-dataset-card">
+        <div class="integration-workbench__dataset-head">
+          <span class="integration-workbench__dataset-kind">多维表清洗区</span>
+          <strong>{{ selectedStagingDescriptor?.name || '未绑定 staging 表' }}</strong>
+        </div>
+        <p>原始区、清洗区和回写区都在多维表中呈现，业务人员不需要直接维护 JSON。</p>
+        <div class="integration-workbench__metric-row">
+          <span>{{ stagingDescriptors.length }} 张表</span>
+          <span>{{ selectedStagingDescriptor ? getStagingAreaLabel(selectedStagingDescriptor.id) : '待选择' }}</span>
+        </div>
+      </article>
+
+      <article class="integration-workbench__dataset-card" data-testid="target-dataset-card">
+        <div class="integration-workbench__dataset-head">
+          <span class="integration-workbench__dataset-kind">目标系统</span>
+          <strong>{{ targetDatasetTitle }}</strong>
+        </div>
+        <p>{{ targetDatasetDescription }}</p>
+        <div class="integration-workbench__metric-row">
+          <span>{{ targetSchema.fields.length }} 个字段</span>
+          <span>{{ requiredTargetFieldCount }} 个必填</span>
+        </div>
+      </article>
+    </div>
+
+    <div v-if="stagingDescriptors.length" class="integration-workbench__staging-list" data-testid="staging-dataset-list">
+      <article v-for="descriptor in stagingDatasetCards" :key="descriptor.id" class="integration-workbench__staging-card">
+        <div>
+          <strong>{{ descriptor.name }}</strong>
+          <p>{{ descriptor.description }}</p>
+          <small>{{ descriptor.id }} · {{ descriptor.fieldCount }} 个字段 · {{ descriptor.area }}</small>
+        </div>
+        <div class="integration-workbench__actions integration-workbench__actions--inline">
+          <a
+            v-if="descriptor.openLink"
+            class="integration-workbench__button"
+            :href="descriptor.openLink"
+            target="_blank"
+            rel="noopener noreferrer"
+            :data-testid="`open-staging-${descriptor.id}`"
+          >
+            打开多维表（新建记录入口）
+          </a>
+          <button
+            v-else
+            type="button"
+            class="integration-workbench__button"
+            :disabled="installingStaging"
+            :data-testid="`refresh-staging-link-${descriptor.id}`"
+            @click="installStagingTables"
+          >
+            {{ installingStaging ? '生成中' : '生成打开链接' }}
+          </button>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            :disabled="!descriptor.openLink"
+            :data-testid="`use-staging-source-${descriptor.id}`"
+            @click="useStagingAsSource(descriptor.id)"
+          >
+            作为 Dry-run 来源
+          </button>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            :disabled="!descriptor.openLink"
+            :data-testid="`use-multitable-target-${descriptor.id}`"
+            @click="useStagingAsTarget(descriptor.id)"
+          >
+            作为目标多维表
+          </button>
+        </div>
+        <small v-if="descriptor.openLink" class="integration-workbench__staging-note">
+          使用此 /multitable 链接进入真正的多维表工具栏，再点击 + New Record 验证必填字段 toast。
+        </small>
+        <small v-else class="integration-workbench__staging-note integration-workbench__staging-note--warning">
+          不要手写 /grid 或 /spreadsheets/{{ descriptor.id }}；先生成后端返回的 /multitable sheet/view 打开链接。
+        </small>
+      </article>
+    </div>
+    <div v-else class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="staging-empty">
+      <strong>暂未加载 staging 契约。</strong>
+      <p>点击「创建清洗表」即可生成 staging 多维表；创建完成后可在 staging 卡片上「作为 Dry-run 来源」。</p>
+      <div class="integration-workbench__actions">
+        <button type="button" class="integration-workbench__button" data-testid="staging-empty-focus-install" @click="focusStagingInstall">创建清洗表</button>
+      </div>
+    </div>
+
+    <div class="integration-workbench__grid integration-workbench__grid--compact">
+      <label>
+        <span>Project ID（高级，可选）</span>
+        <input
+          :value="stagingProjectId"
+          data-testid="staging-project-id"
+          placeholder="留空自动使用 tenant:integration-core"
+          @input="onStagingProjectIdInput"
+          @change="onStagingProjectIdInput"
+          @blur="onStagingProjectIdInput"
+        />
+        <small class="integration-workbench__staging-note" data-testid="staging-project-id-scope-status">
+          {{ stagingProjectIdScopeStatus }}
+        </small>
+      </label>
+      <label>
+        <span>Base ID（可选）</span>
+        <input v-model="stagingBaseId" data-testid="staging-base-id" placeholder="留空使用默认 base" />
+      </label>
+    </div>
+    <div v-if="stagingProjectIdScopeWarning" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="staging-project-id-scope-warning">
+      {{ stagingProjectIdScopeWarning }}
+      <button type="button" class="integration-workbench__button" data-testid="normalize-staging-project-id" @click="normalizeStagingProjectIdToScope">
+        规范化为 integration 作用域
+      </button>
+    </div>
+    <div class="integration-workbench__actions">
+      <button type="button" class="integration-workbench__button" data-testid="install-staging" :disabled="installingStaging" @click="installStagingTables">
+        {{ installingStaging ? '创建中' : '创建清洗表' }}
+      </button>
+    </div>
+    <pre v-if="stagingInstallResultText" data-testid="staging-install-result">{{ stagingInstallResultText }}</pre>
+    </el-card>
+  </section>
+</template>
+
+<script setup lang="ts">
+// IU-2b (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+// stage B): extracted verbatim from IntegrationWorkbenchView.vue's `int-sec-cleaning-dataset`
+// section (pure template/markup move — no state or service-call logic lives here). The parent
+// view owns every ref/computed/service-call; this component only renders them and forwards user
+// actions back up via the exact same function references it is handed as props.
+//
+// `stagingBaseId` is the one field with native `v-model` two-way binding in this section, so it
+// uses `defineModel` (the parent binds `v-model:staging-base-id="stagingBaseId"`) instead of a
+// plain prop + manual input handler — same net effect as before extraction, idiomatic Vue 3.4+.
+import type {
+  IntegrationObjectSchema,
+  IntegrationStagingDescriptor,
+} from '../../services/integration/workbench'
+import type { StagingDatasetCard } from './integrationWorkbenchSectionTypes'
+
+defineProps<{
+  sourceDatasetTitle: string
+  sourceDatasetDescription: string
+  sourceSchema: IntegrationObjectSchema
+  sourceConnectionLabel: string
+  selectedStagingDescriptor: IntegrationStagingDescriptor | null
+  stagingDescriptors: IntegrationStagingDescriptor[]
+  getStagingAreaLabel: (id: string) => string
+  targetDatasetTitle: string
+  targetDatasetDescription: string
+  targetSchema: IntegrationObjectSchema
+  requiredTargetFieldCount: number
+  stagingDatasetCards: StagingDatasetCard[]
+  installingStaging: boolean
+  stagingProjectId: string
+  stagingProjectIdScopeStatus: string
+  stagingProjectIdScopeWarning: string
+  stagingInstallResultText: string
+  installStagingTables: () => Promise<void>
+  useStagingAsSource: (objectId: string) => Promise<void>
+  useStagingAsTarget: (objectId: string) => Promise<void>
+  focusStagingInstall: () => void
+  onStagingProjectIdInput: (event: Event) => void
+  normalizeStagingProjectIdToScope: () => void
+}>()
+
+const stagingBaseId = defineModel<string>('stagingBaseId', { default: '' })
+</script>
+
+<style scoped>
+/* Verbatim copies of the rules in IntegrationWorkbenchView.vue's <style scoped> block that
+   target markup now rendered by this component — see IntegrationMonitoringSection.vue's style
+   block comment for why duplication (not relocation) is the correct approach here. */
+.integration-workbench label {
+  display: grid;
+  gap: 6px;
+  color: var(--ms-text-1);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.integration-workbench input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: var(--ms-text-1);
+  font: inherit;
+}
+
+.integration-workbench pre {
+  min-height: 260px;
+  max-height: 420px;
+  overflow: auto;
+  margin: 12px 0 0;
+  padding: 12px;
+  border: 1px solid var(--ms-border-light);
+  border-radius: 6px;
+  background: var(--ms-text-1);
+  color: var(--el-color-primary-light-9);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.integration-workbench__panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.integration-workbench__dataset-card,
+.integration-workbench__staging-card {
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-card);
+}
+
+.integration-workbench__panel p {
+  margin: 8px 0 0;
+  color: var(--ms-text-2);
+  line-height: 1.5;
+}
+
+.integration-workbench__button {
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  cursor: pointer;
+  font-weight: 700;
+  text-decoration: none;
+  padding: 8px 12px;
+}
+
+.integration-workbench__button:hover {
+  border-color: var(--ms-color-primary);
+}
+
+.integration-workbench__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.integration-workbench__panel {
+  margin-bottom: 16px;
+  padding: 16px;
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-card);
+}
+
+.integration-workbench__hint {
+  margin-top: 10px;
+  color: var(--ms-text-2);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.integration-workbench__hint--strong {
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
+}
+
+.integration-workbench__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.integration-workbench__grid--compact {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.integration-workbench__dataset-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.integration-workbench__dataset-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+}
+
+.integration-workbench__dataset-head {
+  display: grid;
+  gap: 4px;
+}
+
+.integration-workbench__dataset-kind {
+  color: var(--ms-text-2);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.integration-workbench__dataset-card strong,
+.integration-workbench__staging-card strong {
+  color: var(--ms-text-1);
+}
+
+.integration-workbench__dataset-card p,
+.integration-workbench__staging-card p {
+  margin: 0;
+  color: var(--ms-text-2);
+  line-height: 1.5;
+}
+
+.integration-workbench__metric-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.integration-workbench__metric-row span,
+.integration-workbench__staging-card small {
+  display: inline-flex;
+  color: var(--ms-text-2);
+  font-size: 12px;
+}
+
+.integration-workbench__staging-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.integration-workbench__staging-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+}
+
+.integration-workbench__staging-note {
+  grid-column: 1 / -1;
+  display: block;
+  color: var(--ms-text-2);
+  line-height: 1.45;
+}
+
+.integration-workbench__staging-note--warning {
+  color: var(--el-color-warning-dark-2);
+}
+
+.integration-workbench__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.integration-workbench__actions--inline {
+  justify-content: flex-end;
+  margin-top: 0;
+}
+
+.integration-workbench__empty {
+  padding: 12px;
+  border: 1px dashed var(--ms-border);
+  border-radius: 6px;
+  color: var(--ms-text-2);
+}
+
+.integration-workbench__empty--actionable {
+  margin-top: 10px;
+}
+
+.integration-workbench__empty strong {
+  color: var(--ms-text-1);
+}
+
+.integration-workbench__empty p {
+  margin: 6px 0 0;
+}
+
+@media (max-width: 900px) {
+  .integration-workbench__panel-head,
+  .integration-workbench__dataset-grid,
+  .integration-workbench__staging-list,
+  .integration-workbench__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .integration-workbench__panel-head {
+    display: grid;
+  }
+}
+</style>

--- a/apps/web/src/components/integration/IntegrationMappingRulesSection.vue
+++ b/apps/web/src/components/integration/IntegrationMappingRulesSection.vue
@@ -1,0 +1,261 @@
+<template>
+  <section id="int-sec-cleaning-rules" class="integration-workbench__panel">
+    <el-card shadow="never">
+      <template #header>
+        <div class="integration-workbench__panel-head">
+          <div>
+            <h2>清洗映射规则</h2>
+        <p>一行就是一条清洗内容：从来源字段取值，经过白名单转换后写入目标字段。默认映射可直接用，也允许新增自定义清洗项。</p>
+      </div>
+      <button type="button" class="integration-workbench__button" data-testid="add-mapping" @click="addMapping">
+        新增自定义清洗项
+      </button>
+    </div>
+      </template>
+
+
+    <div class="integration-workbench__mapping-list" data-testid="mapping-rule-list">
+      <details v-for="(mapping, index) in mappings" :key="mapping.id" class="integration-workbench__mapping-card" open>
+        <summary :data-testid="`mapping-summary-${index}`">
+          <span>{{ mappingSummary(mapping, index) }}</span>
+          <small>{{ mappingDetail(mapping) }}</small>
+        </summary>
+        <div class="integration-workbench__mapping-editor">
+          <label>
+            <span>源字段</span>
+            <select
+              v-if="hasSourceFieldOptions"
+              v-model="mapping.sourceField"
+              :data-testid="`source-field-${index}`"
+            >
+              <option value="">请选择来源字段</option>
+              <option
+                v-for="option in sourceFieldOptionsForMapping(mapping)"
+                :key="`${option.stale ? 'stale' : 'schema'}:${option.value}`"
+                :value="option.value"
+              >
+                {{ sourceFieldOptionText(option) }}
+              </option>
+            </select>
+            <input v-else v-model="mapping.sourceField" :data-testid="`source-field-${index}`" placeholder="例如 code" />
+            <small v-if="hasSourceFieldOptions" class="integration-workbench__field-help" :data-testid="`source-field-picker-help-${index}`">
+              字段来自来源 schema；这里只保存字段名，不显示行值。
+            </small>
+          </label>
+          <label>
+            <span>目标字段</span>
+            <input v-model="mapping.targetField" :data-testid="`target-field-${index}`" placeholder="例如 FNumber" />
+          </label>
+          <label>
+            <span>转换</span>
+            <select v-model="mapping.transformFn" :data-testid="`transform-fn-${index}`">
+              <option v-for="option in transformOptions" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+            <small class="integration-workbench__field-help">只允许 trim、upper、lower、toNumber、dictMap；不允许用户脚本或 raw SQL。</small>
+            <textarea
+              v-if="mapping.transformFn === 'dictMap'"
+              v-model="mapping.dictMapText"
+              :data-testid="`dict-map-${index}`"
+              placeholder="EA=Pcs&#10;KG=Kg"
+            ></textarea>
+          </label>
+          <div>
+            <label class="integration-workbench__mapping-check">
+              <input v-model="mapping.required" type="checkbox" :data-testid="`required-${index}`" />
+              <span>必填；缺值会进入 dead letter，不中断整批。</span>
+            </label>
+            <div class="integration-workbench__mapping-rules">
+              <input v-model="mapping.minValueText" :data-testid="`validation-min-${index}`" placeholder="最小值 min" />
+              <input v-model="mapping.maxValueText" :data-testid="`validation-max-${index}`" placeholder="最大值 max" />
+            </div>
+          </div>
+          <button type="button" class="integration-workbench__icon-button" @click="removeMapping(index)">删除</button>
+        </div>
+      </details>
+    </div>
+    </el-card>
+  </section>
+</template>
+
+<script setup lang="ts">
+// IU-2b (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+// stage B): extracted verbatim from IntegrationWorkbenchView.vue's `int-sec-cleaning-rules`
+// section (pure template/markup move — no state or service-call logic lives here).
+//
+// `mappings` keeps its original nested-`v-model` editing pattern (`v-model="mapping.sourceField"`
+// etc. on items pulled from the prop array via `v-for`): the parent passes down the *same*
+// `EditableMapping[]` array reference it already owns (a `ref<EditableMapping[]>` in the view),
+// so mutating a nested field here mutates the identical object the parent's `ref` points at —
+// no different from the pre-extraction behavior where the same array was rendered inline. This
+// file is not part of `apps/web`'s lint file list (see `package.json`'s `lint` script), so the
+// nested-prop-mutation pattern carries no lint-gate risk either.
+import type { EditableMapping, SourceFieldOption, TransformFn } from './integrationWorkbenchSectionTypes'
+
+defineProps<{
+  mappings: EditableMapping[]
+  hasSourceFieldOptions: boolean
+  sourceFieldOptionsForMapping: (mapping: EditableMapping) => SourceFieldOption[]
+  sourceFieldOptionText: (option: SourceFieldOption) => string
+  transformOptions: Array<{ value: TransformFn, label: string }>
+  mappingSummary: (mapping: EditableMapping, index: number) => string
+  mappingDetail: (mapping: EditableMapping) => string
+  addMapping: () => void
+  removeMapping: (index: number) => void
+}>()
+</script>
+
+<style scoped>
+/* Verbatim copies of the rules in IntegrationWorkbenchView.vue's <style scoped> block that
+   target markup now rendered by this component — see IntegrationMonitoringSection.vue's style
+   block comment for why duplication (not relocation) is the correct approach here. */
+.integration-workbench label {
+  display: grid;
+  gap: 6px;
+  color: var(--ms-text-1);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.integration-workbench input,
+.integration-workbench select,
+.integration-workbench textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: var(--ms-text-1);
+  font: inherit;
+}
+
+.integration-workbench textarea {
+  min-height: 260px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.integration-workbench__panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.integration-workbench__panel p {
+  margin: 8px 0 0;
+  color: var(--ms-text-2);
+  line-height: 1.5;
+}
+
+.integration-workbench__button,
+.integration-workbench__icon-button {
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  cursor: pointer;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.integration-workbench__button {
+  padding: 8px 12px;
+}
+
+.integration-workbench__icon-button {
+  padding: 6px 8px;
+}
+
+.integration-workbench__button:hover,
+.integration-workbench__icon-button:hover {
+  border-color: var(--ms-color-primary);
+}
+
+.integration-workbench__button:disabled,
+.integration-workbench__icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.integration-workbench__panel {
+  margin-bottom: 16px;
+  padding: 16px;
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-card);
+}
+
+.integration-workbench__mapping-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.integration-workbench__mapping-card {
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-card);
+}
+
+.integration-workbench__mapping-card summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 10px 12px;
+  color: var(--ms-text-1);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.integration-workbench__mapping-card summary small {
+  color: var(--ms-text-2);
+  font-weight: 600;
+}
+
+.integration-workbench__mapping-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(180px, 0.8fr) minmax(180px, 0.8fr) auto;
+  gap: 10px;
+  padding: 0 12px 12px;
+  align-items: start;
+}
+
+.integration-workbench__mapping-editor textarea {
+  min-height: 68px;
+  margin-top: 6px;
+}
+
+.integration-workbench__mapping-check {
+  display: flex;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 6px;
+}
+
+.integration-workbench__mapping-rules {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(72px, 1fr));
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.integration-workbench__field-help {
+  color: var(--ms-text-2);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+@media (max-width: 900px) {
+  .integration-workbench__panel-head,
+  .integration-workbench__mapping-editor {
+    grid-template-columns: 1fr;
+  }
+
+  .integration-workbench__panel-head {
+    display: grid;
+  }
+}
+</style>

--- a/apps/web/src/components/integration/IntegrationMonitoringSection.vue
+++ b/apps/web/src/components/integration/IntegrationMonitoringSection.vue
@@ -1,0 +1,492 @@
+<template>
+  <section id="int-sec-monitoring" class="integration-workbench__panel">
+    <el-card shadow="never">
+      <template #header>
+        <div class="integration-workbench__panel-head">
+          <div>
+            <h2>运行监控</h2>
+        <p>{{ observationSummary }}。展示最近 5 条 run（状态 / 写入 / 失败 + 行级结果）与 open dead letters（可重放），便于清洗后回看失败原因。</p>
+      </div>
+      <button type="button" class="integration-workbench__button" data-testid="refresh-observation" :disabled="observingPipeline" @click="refreshPipelineObservation(false)">
+        {{ observingPipeline ? '刷新中' : '刷新监控' }}
+      </button>
+    </div>
+      </template>
+
+
+    <div class="integration-workbench__observation">
+      <div>
+        <h3>最近运行</h3>
+        <div v-if="pipelineRuns.length === 0" class="integration-workbench__empty" data-testid="pipeline-runs-empty">
+          <strong data-testid="pipeline-runs-empty-what">{{ bi(
+            '这里展示最近的清洗流程运行记录（状态 / 读取 / 清洗 / 写入 / 失败行数）。',
+            'This shows recent pipeline run records (status / rows read / cleaned / written / failed).',
+          ) }}</strong>
+          <p data-testid="pipeline-runs-empty-first-step">{{ bi(
+            '第一步：在上方"运行与推送"区保存清洗流程后执行一次 Dry-run 或 Save-only 推送，运行记录会出现在这里。',
+            'First step: save the pipeline above, then run a Dry-run or Save-only push — the run record will then appear here.',
+          ) }}</p>
+        </div>
+        <ol v-else class="integration-workbench__record-list" data-testid="pipeline-runs">
+          <li v-for="run in pipelineRuns" :key="run.id" :data-testid="`pipeline-run-${run.id}`">
+            <div class="integration-workbench__run-head">
+              <strong :class="`integration-workbench__run-status integration-workbench__run-status--${run.status}`" :data-testid="`run-status-${run.id}`">{{ run.status }}</strong>
+              <span>{{ run.mode }}</span>
+              <span v-if="run.triggeredBy">by {{ run.triggeredBy }}</span>
+            </div>
+            <div class="integration-workbench__run-metrics">
+              <span>read {{ run.rowsRead }}</span>
+              <span>clean {{ run.rowsCleaned }}</span>
+              <span class="integration-workbench__run-metric--write">write {{ run.rowsWritten }}</span>
+              <span class="integration-workbench__run-metric--fail">fail {{ run.rowsFailed }}</span>
+              <span v-if="run.durationMs != null">{{ run.durationMs }}ms</span>
+            </div>
+            <small>{{ run.startedAt || run.createdAt || run.id }}<template v-if="run.finishedAt"> → {{ run.finishedAt }}</template></small>
+            <p v-if="run.errorSummary" class="integration-workbench__run-error" :data-testid="`run-error-${run.id}`">{{ run.errorSummary }}</p>
+            <div v-if="runRowSummaries(run).length > 0" class="integration-workbench__run-summaries">
+              <button type="button" class="integration-workbench__link-button" :data-testid="`toggle-run-summaries-${run.id}`" @click="toggleRunSummaries(run.id)">
+                {{ isRunExpanded(run.id) ? '收起行级结果' : `展开行级结果（${runRowSummaries(run).length}）` }}
+              </button>
+              <pre v-if="isRunExpanded(run.id)" :data-testid="`run-row-summaries-${run.id}`">{{ JSON.stringify(runRowSummaries(run), null, 2) }}</pre>
+            </div>
+          </li>
+        </ol>
+      </div>
+      <div>
+        <h3>Open Dead Letters</h3>
+        <div v-if="deadLetters.length === 0" class="integration-workbench__empty" data-testid="dead-letters-empty">
+          <strong data-testid="dead-letters-empty-what">{{ bi(
+            'Dead letter 是清洗流程运行中未能成功写入的行，按原因分组，便于排查后再决定是否重放。',
+            'Dead letters are rows that failed to write during a pipeline run, grouped by reason so you can investigate before deciding whether to replay.',
+          ) }}</strong>
+          <p data-testid="dead-letters-empty-first-step">{{ bi(
+            '当前没有 open dead letters；出现失败行时会自动列在这里，可点击"准备 Replay"重跑。',
+            'There are no open dead letters right now; failed rows will be listed here automatically, and you can click "prepare replay" to re-run them.',
+          ) }}</p>
+        </div>
+        <ol v-else class="integration-workbench__record-list" data-testid="dead-letters">
+          <li v-for="deadLetter in deadLetters" :key="deadLetter.id" :data-testid="`dead-letter-${deadLetter.id}`">
+            <strong :data-testid="`dead-letter-label-${deadLetter.id}`">{{ deadLetterErrorLabel(deadLetter) }}</strong>
+            <span v-if="deadLetterErrorHint(deadLetter)">{{ deadLetterErrorHint(deadLetter) }}</span>
+            <small :data-testid="`dead-letter-code-${deadLetter.id}`">errorCode: {{ deadLetter.errorCode }}</small>
+            <small>
+              {{ deadLetter.status }} · {{ deadLetter.createdAt || deadLetter.id }}<template v-if="deadLetter.retryCount"> · retries {{ deadLetter.retryCount }}</template><template v-if="deadLetter.idempotencyKey"> · key {{ deadLetter.idempotencyKey }}</template>
+            </small>
+            <div class="integration-workbench__dead-letter-actions">
+              <span
+                :class="['integration-workbench__badge', isDeadLetterReplayable(deadLetter) ? 'integration-workbench__badge--retryable' : '']"
+                :data-testid="`dead-letter-retryable-${deadLetter.id}`"
+              >{{ isDeadLetterReplayable(deadLetter) ? '可重放' : '不可重放' }}</span>
+              <template v-if="isDeadLetterReplayable(deadLetter)">
+                <button
+                  v-if="confirmReplayDeadLetterId !== deadLetter.id"
+                  type="button"
+                  class="integration-workbench__button integration-workbench__button--ghost"
+                  :data-testid="`replay-dead-letter-${deadLetter.id}`"
+                  :disabled="replayingDeadLetterId === deadLetter.id"
+                  @click="requestReplay(deadLetter.id)"
+                >准备 Replay</button>
+                <template v-else>
+                  <button
+                    type="button"
+                    class="integration-workbench__button integration-workbench__button--danger"
+                    :data-testid="`confirm-replay-dead-letter-${deadLetter.id}`"
+                    :disabled="replayingDeadLetterId === deadLetter.id"
+                    @click="replayDeadLetter(deadLetter)"
+                  >{{ replayingDeadLetterId === deadLetter.id ? 'Replay 中…' : '确认 Replay（会真实写入）' }}</button>
+                  <button
+                    type="button"
+                    class="integration-workbench__link-button"
+                    :data-testid="`cancel-replay-dead-letter-${deadLetter.id}`"
+                    :disabled="replayingDeadLetterId === deadLetter.id"
+                    @click="cancelReplay"
+                  >取消</button>
+                </template>
+              </template>
+            </div>
+            <div class="integration-workbench__dead-letter-provenance">
+              <button
+                type="button"
+                class="integration-workbench__link-button"
+                :data-testid="`toggle-dead-letter-provenance-${deadLetter.id}`"
+                :disabled="!canViewRowProvenance(deadLetter)"
+                :title="canViewRowProvenance(deadLetter) ? '查看该行(rowId)跨 run 的写入血缘（只读）' : '该 dead letter 无 idempotency key（rowId），无法查询血缘'"
+                @click="toggleDeadLetterProvenance(deadLetter)"
+              >{{ isRowProvenanceExpanded(deadLetter.id) ? '收起血缘' : '查看跨-run 血缘' }}</button>
+              <span
+                v-if="!canViewRowProvenance(deadLetter)"
+                class="integration-workbench__hint"
+                :data-testid="`dead-letter-provenance-unavailable-${deadLetter.id}`"
+              >无 rowId（idempotency key），不可查血缘</span>
+              <div
+                v-if="isRowProvenanceExpanded(deadLetter.id)"
+                class="integration-workbench__provenance-timeline"
+                :data-testid="`dead-letter-provenance-${deadLetter.id}`"
+              >
+                <div
+                  v-if="isRowProvenanceLoading(deadLetter.id)"
+                  class="integration-workbench__hint"
+                  :data-testid="`dead-letter-provenance-loading-${deadLetter.id}`"
+                >血缘加载中…</div>
+                <div
+                  v-else-if="rowProvenanceError(deadLetter.id)"
+                  class="integration-workbench__hint integration-workbench__hint--strong"
+                  :data-testid="`dead-letter-provenance-error-${deadLetter.id}`"
+                >{{ rowProvenanceError(deadLetter.id) }}</div>
+                <ol
+                  v-else-if="rowProvenanceTimeline(deadLetter.id).length > 0"
+                  class="integration-workbench__record-list"
+                  :data-testid="`dead-letter-provenance-timeline-${deadLetter.id}`"
+                >
+                  <li
+                    v-for="(entry, index) in rowProvenanceTimeline(deadLetter.id)"
+                    :key="`${entry.runId}-${entry.eventIndex}`"
+                    :data-testid="`provenance-entry-${deadLetter.id}-${index}`"
+                  >
+                    <div class="integration-workbench__provenance-event-head">
+                      <strong>{{ entry.eventType }}</strong>
+                      <span
+                        class="integration-workbench__run-status"
+                        :class="`integration-workbench__run-status--${entry.runStatus}`"
+                      >run {{ entry.runStatus }}</span>
+                      <span>{{ entry.runCreatedAt || entry.at }}</span>
+                    </div>
+                    <small>runId {{ entry.runId }} · pipeline {{ entry.pipelineId }} · {{ entry.runMode }}</small>
+                    <p
+                      v-if="rowProvenanceAttrsSummary(entry.attrs)"
+                      class="integration-workbench__provenance-attrs"
+                    >{{ rowProvenanceAttrsSummary(entry.attrs) }}</p>
+                  </li>
+                </ol>
+                <div
+                  v-else
+                  class="integration-workbench__empty"
+                  :data-testid="`dead-letter-provenance-empty-${deadLetter.id}`"
+                >暂无血缘事件。</div>
+                <p class="integration-workbench__hint">只读：仅展示脱敏后的事件，不含 payload 原文，不触发任何写入/重放。</p>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </div>
+    </el-card>
+  </section>
+</template>
+
+<script setup lang="ts">
+// IU-2b (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+// stage B): extracted verbatim from IntegrationWorkbenchView.vue's `int-sec-monitoring` section
+// (pure template/markup move — no state or service-call logic lives here). The parent view owns
+// every ref/computed/service-call; this component only renders them and forwards user actions
+// back up by calling the exact same function references it is handed as props (mirrors the
+// `tr` function-prop pattern already established by IntegrationWorkbenchRail.vue in IU-2a).
+import type {
+  IntegrationDeadLetter,
+  IntegrationPipelineRun,
+  IntegrationProvenanceTimelineEntry,
+  IntegrationTargetWriteSummary,
+} from '../../services/integration/workbench'
+
+defineProps<{
+  observationSummary: string
+  observingPipeline: boolean
+  pipelineRuns: IntegrationPipelineRun[]
+  deadLetters: IntegrationDeadLetter[]
+  /** Bilingual copy helper — same shape as the view's local `bi(zh, en)` function. */
+  bi: (zh: string, en: string) => string
+  runRowSummaries: (run: IntegrationPipelineRun) => IntegrationTargetWriteSummary[]
+  isRunExpanded: (runId: string) => boolean
+  deadLetterErrorLabel: (deadLetter: IntegrationDeadLetter) => string
+  deadLetterErrorHint: (deadLetter: IntegrationDeadLetter) => string | null
+  isDeadLetterReplayable: (deadLetter: IntegrationDeadLetter) => boolean
+  confirmReplayDeadLetterId: string
+  replayingDeadLetterId: string
+  canViewRowProvenance: (deadLetter: IntegrationDeadLetter) => boolean
+  isRowProvenanceExpanded: (deadLetterId: string) => boolean
+  isRowProvenanceLoading: (deadLetterId: string) => boolean
+  rowProvenanceError: (deadLetterId: string) => string
+  rowProvenanceTimeline: (deadLetterId: string) => IntegrationProvenanceTimelineEntry[]
+  rowProvenanceAttrsSummary: (attrs: Record<string, unknown> | undefined) => string
+  refreshPipelineObservation: (silent?: boolean) => Promise<void>
+  toggleRunSummaries: (runId: string) => void
+  requestReplay: (deadLetterId: string) => void
+  cancelReplay: () => void
+  replayDeadLetter: (deadLetter: IntegrationDeadLetter) => Promise<void>
+  toggleDeadLetterProvenance: (deadLetter: IntegrationDeadLetter) => Promise<void>
+}>()
+</script>
+
+<style scoped>
+/* Verbatim copies of the rules in IntegrationWorkbenchView.vue's <style scoped> block that
+   target markup now rendered by this component. Duplication (not relocation) is intentional:
+   Vue's scoped CSS only reaches a component's OWN template output, not a child component's
+   inner DOM, so classes shared with sections still living in the parent (e.g. `__button`,
+   `__hint`, `__panel`) must keep their rule in the parent AND get a copy here. Selectors that
+   have an ancestor class outside this component's own root (e.g. `.integration-workbench h3`,
+   `.integration-workbench pre`) still work: Vue's scoped-css compiler only appends the
+   `[data-v-hash]` attribute to the rightmost compound selector, so the unscoped ancestor part
+   keeps matching the real DOM regardless of which component rendered it. */
+.integration-workbench h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.integration-workbench pre {
+  min-height: 260px;
+  max-height: 420px;
+  overflow: auto;
+  margin: 12px 0 0;
+  padding: 12px;
+  border: 1px solid var(--ms-border-light);
+  border-radius: 6px;
+  background: var(--ms-text-1);
+  color: var(--el-color-primary-light-9);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.integration-workbench__panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.integration-workbench__panel p {
+  margin: 8px 0 0;
+  color: var(--ms-text-2);
+  line-height: 1.5;
+}
+
+.integration-workbench__button,
+.integration-workbench__icon-button {
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  cursor: pointer;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.integration-workbench__button {
+  padding: 8px 12px;
+}
+
+.integration-workbench__button:hover,
+.integration-workbench__icon-button:hover {
+  border-color: var(--ms-color-primary);
+}
+
+.integration-workbench__button:disabled,
+.integration-workbench__icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.integration-workbench__button--danger {
+  border-color: var(--el-color-danger-light-3);
+  color: var(--el-color-danger);
+}
+
+.integration-workbench__panel {
+  margin-bottom: 16px;
+  padding: 16px;
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-card);
+}
+
+.integration-workbench__hint {
+  margin-top: 10px;
+  color: var(--ms-text-2);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.integration-workbench__hint--strong {
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
+}
+
+.integration-workbench__badge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.integration-workbench__badge--retryable {
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
+}
+
+.integration-workbench__observation {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 14px;
+}
+
+.integration-workbench__empty {
+  padding: 12px;
+  border: 1px dashed var(--ms-border);
+  border-radius: 6px;
+  color: var(--ms-text-2);
+}
+
+.integration-workbench__empty strong {
+  color: var(--ms-text-1);
+}
+
+.integration-workbench__empty p {
+  margin: 6px 0 0;
+}
+
+.integration-workbench__record-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.integration-workbench__record-list li {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  background: var(--ms-bg-page);
+}
+
+.integration-workbench__record-list small {
+  color: var(--ms-text-2);
+}
+
+.integration-workbench__run-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.integration-workbench__run-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--ms-text-2);
+}
+
+.integration-workbench__run-metric--write {
+  color: var(--el-color-success-dark-2);
+  font-weight: 600;
+}
+
+.integration-workbench__run-metric--fail {
+  color: var(--el-color-danger);
+  font-weight: 600;
+}
+
+.integration-workbench__run-status {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--el-color-primary-light-9);
+  color: var(--ms-text-1);
+}
+
+.integration-workbench__run-error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--el-color-danger);
+}
+
+.integration-workbench__run-summaries {
+  display: grid;
+  gap: 4px;
+}
+
+/* Inline row-level results: override the global tall/dark `pre` so each
+   expanded run stays compact within the record list. */
+.integration-workbench__run-summaries pre {
+  min-height: 0;
+  max-height: 200px;
+  margin: 4px 0 0;
+}
+
+.integration-workbench__dead-letter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+/* DF-N2-3 (read-only): cross-run provenance timeline (per dead-letter row). */
+.integration-workbench__dead-letter-provenance {
+  margin-top: 6px;
+  display: grid;
+  gap: 4px;
+}
+
+.integration-workbench__provenance-timeline {
+  display: grid;
+  gap: 6px;
+  padding: 6px 0 0;
+}
+
+.integration-workbench__provenance-event-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.integration-workbench__provenance-attrs {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: var(--ms-text-2);
+  word-break: break-word;
+}
+
+.integration-workbench__button--ghost {
+  background: transparent;
+}
+
+.integration-workbench__link-button {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--ms-color-primary);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.integration-workbench__link-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+@media (max-width: 900px) {
+  .integration-workbench__panel-head,
+  .integration-workbench__observation {
+    grid-template-columns: 1fr;
+  }
+
+  .integration-workbench__panel-head {
+    display: grid;
+  }
+}
+</style>

--- a/apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts
+++ b/apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts
@@ -1,0 +1,41 @@
+// IU-2b (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+// stage B — per-section component extraction): shared prop types for the Workbench section
+// child components under this directory.
+//
+// These are intentionally *duplicated* shapes of local (non-exported) types declared inside
+// `../../views/IntegrationWorkbenchView.vue`'s `<script setup>` (`EditableMapping`,
+// `SourceFieldOption`, `StagingDatasetCard`, `TransformFn`) rather than imported from the view.
+// Rationale: IU-2b is a pure template/markup move — the view keeps 100% of its state and
+// script logic untouched, including these type declarations. Duplicating the (small, stable)
+// shapes here avoids a cross-file type import from a `.vue` SFC and avoids touching the view's
+// script block at all. If either the view's shape or this file's shape drifts, TypeScript will
+// fail the prop-type check at the call site in the view (structural typing), so drift cannot go
+// unnoticed silently.
+export type TransformFn = '' | 'trim' | 'upper' | 'lower' | 'toNumber' | 'dictMap'
+
+export interface EditableMapping {
+  id: string
+  sourceField: string
+  targetField: string
+  transformFn: TransformFn
+  dictMapText: string
+  required: boolean
+  minValueText: string
+  maxValueText: string
+}
+
+export interface SourceFieldOption {
+  value: string
+  label: string
+  type: string
+  stale: boolean
+}
+
+export interface StagingDatasetCard {
+  id: string
+  name: string
+  area: string
+  description: string
+  fieldCount: number
+  openLink: string
+}

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -494,232 +494,44 @@
       </el-card>
     </section>
 
-    <section id="int-sec-cleaning-dataset" class="integration-workbench__panel">
-      <el-card shadow="never">
-        <template #header>
-          <div class="integration-workbench__panel-head">
-            <div>
-              <h2>数据集与多维表清洗</h2>
-          <p>数据源和目标系统只负责读写；业务清洗、审核、修正发生在多维表里。未安装清洗表时，可在这里创建 staging 多维表。</p>
-        </div>
-      </div>
-        </template>
+    <IntegrationCleaningDatasetSection
+      :source-dataset-title="sourceDatasetTitle"
+      :source-dataset-description="sourceDatasetDescription"
+      :source-schema="sourceSchema"
+      :source-connection-label="sourceConnectionLabel"
+      :selected-staging-descriptor="selectedStagingDescriptor"
+      :staging-descriptors="stagingDescriptors"
+      :get-staging-area-label="getStagingAreaLabel"
+      :target-dataset-title="targetDatasetTitle"
+      :target-dataset-description="targetDatasetDescription"
+      :target-schema="targetSchema"
+      :required-target-field-count="requiredTargetFieldCount"
+      :staging-dataset-cards="stagingDatasetCards"
+      :installing-staging="installingStaging"
+      :staging-project-id="stagingProjectId"
+      :staging-project-id-scope-status="stagingProjectIdScopeStatus"
+      :staging-project-id-scope-warning="stagingProjectIdScopeWarning"
+      :staging-install-result-text="stagingInstallResultText"
+      :install-staging-tables="installStagingTables"
+      :use-staging-as-source="useStagingAsSource"
+      :use-staging-as-target="useStagingAsTarget"
+      :focus-staging-install="focusStagingInstall"
+      :on-staging-project-id-input="onStagingProjectIdInput"
+      :normalize-staging-project-id-to-scope="normalizeStagingProjectIdToScope"
+      v-model:staging-base-id="stagingBaseId"
+    />
 
-
-      <div class="integration-workbench__dataset-grid" data-testid="dataset-cards">
-        <article class="integration-workbench__dataset-card" data-testid="source-dataset-card">
-          <div class="integration-workbench__dataset-head">
-            <span class="integration-workbench__dataset-kind">数据源</span>
-            <strong>{{ sourceDatasetTitle }}</strong>
-          </div>
-          <p>{{ sourceDatasetDescription }}</p>
-          <div class="integration-workbench__metric-row">
-            <span>{{ sourceSchema.fields.length }} 个字段</span>
-            <span>{{ sourceConnectionLabel }}</span>
-          </div>
-        </article>
-
-        <article class="integration-workbench__dataset-card" data-testid="staging-dataset-card">
-          <div class="integration-workbench__dataset-head">
-            <span class="integration-workbench__dataset-kind">多维表清洗区</span>
-            <strong>{{ selectedStagingDescriptor?.name || '未绑定 staging 表' }}</strong>
-          </div>
-          <p>原始区、清洗区和回写区都在多维表中呈现，业务人员不需要直接维护 JSON。</p>
-          <div class="integration-workbench__metric-row">
-            <span>{{ stagingDescriptors.length }} 张表</span>
-            <span>{{ selectedStagingDescriptor ? getStagingAreaLabel(selectedStagingDescriptor.id) : '待选择' }}</span>
-          </div>
-        </article>
-
-        <article class="integration-workbench__dataset-card" data-testid="target-dataset-card">
-          <div class="integration-workbench__dataset-head">
-            <span class="integration-workbench__dataset-kind">目标系统</span>
-            <strong>{{ targetDatasetTitle }}</strong>
-          </div>
-          <p>{{ targetDatasetDescription }}</p>
-          <div class="integration-workbench__metric-row">
-            <span>{{ targetSchema.fields.length }} 个字段</span>
-            <span>{{ requiredTargetFieldCount }} 个必填</span>
-          </div>
-        </article>
-      </div>
-
-      <div v-if="stagingDescriptors.length" class="integration-workbench__staging-list" data-testid="staging-dataset-list">
-        <article v-for="descriptor in stagingDatasetCards" :key="descriptor.id" class="integration-workbench__staging-card">
-          <div>
-            <strong>{{ descriptor.name }}</strong>
-            <p>{{ descriptor.description }}</p>
-            <small>{{ descriptor.id }} · {{ descriptor.fieldCount }} 个字段 · {{ descriptor.area }}</small>
-          </div>
-          <div class="integration-workbench__actions integration-workbench__actions--inline">
-            <a
-              v-if="descriptor.openLink"
-              class="integration-workbench__button"
-              :href="descriptor.openLink"
-              target="_blank"
-              rel="noopener noreferrer"
-              :data-testid="`open-staging-${descriptor.id}`"
-            >
-              打开多维表（新建记录入口）
-            </a>
-            <button
-              v-else
-              type="button"
-              class="integration-workbench__button"
-              :disabled="installingStaging"
-              :data-testid="`refresh-staging-link-${descriptor.id}`"
-              @click="installStagingTables"
-            >
-              {{ installingStaging ? '生成中' : '生成打开链接' }}
-            </button>
-            <button
-              type="button"
-              class="integration-workbench__button"
-              :disabled="!descriptor.openLink"
-              :data-testid="`use-staging-source-${descriptor.id}`"
-              @click="useStagingAsSource(descriptor.id)"
-            >
-              作为 Dry-run 来源
-            </button>
-            <button
-              type="button"
-              class="integration-workbench__button"
-              :disabled="!descriptor.openLink"
-              :data-testid="`use-multitable-target-${descriptor.id}`"
-              @click="useStagingAsTarget(descriptor.id)"
-            >
-              作为目标多维表
-            </button>
-          </div>
-          <small v-if="descriptor.openLink" class="integration-workbench__staging-note">
-            使用此 /multitable 链接进入真正的多维表工具栏，再点击 + New Record 验证必填字段 toast。
-          </small>
-          <small v-else class="integration-workbench__staging-note integration-workbench__staging-note--warning">
-            不要手写 /grid 或 /spreadsheets/{{ descriptor.id }}；先生成后端返回的 /multitable sheet/view 打开链接。
-          </small>
-        </article>
-      </div>
-      <div v-else class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="staging-empty">
-        <strong>暂未加载 staging 契约。</strong>
-        <p>点击「创建清洗表」即可生成 staging 多维表；创建完成后可在 staging 卡片上「作为 Dry-run 来源」。</p>
-        <div class="integration-workbench__actions">
-          <button type="button" class="integration-workbench__button" data-testid="staging-empty-focus-install" @click="focusStagingInstall">创建清洗表</button>
-        </div>
-      </div>
-
-      <div class="integration-workbench__grid integration-workbench__grid--compact">
-        <label>
-          <span>Project ID（高级，可选）</span>
-          <input
-            :value="stagingProjectId"
-            data-testid="staging-project-id"
-            placeholder="留空自动使用 tenant:integration-core"
-            @input="onStagingProjectIdInput"
-            @change="onStagingProjectIdInput"
-            @blur="onStagingProjectIdInput"
-          />
-          <small class="integration-workbench__staging-note" data-testid="staging-project-id-scope-status">
-            {{ stagingProjectIdScopeStatus }}
-          </small>
-        </label>
-        <label>
-          <span>Base ID（可选）</span>
-          <input v-model="stagingBaseId" data-testid="staging-base-id" placeholder="留空使用默认 base" />
-        </label>
-      </div>
-      <div v-if="stagingProjectIdScopeWarning" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="staging-project-id-scope-warning">
-        {{ stagingProjectIdScopeWarning }}
-        <button type="button" class="integration-workbench__button" data-testid="normalize-staging-project-id" @click="normalizeStagingProjectIdToScope">
-          规范化为 integration 作用域
-        </button>
-      </div>
-      <div class="integration-workbench__actions">
-        <button type="button" class="integration-workbench__button" data-testid="install-staging" :disabled="installingStaging" @click="installStagingTables">
-          {{ installingStaging ? '创建中' : '创建清洗表' }}
-        </button>
-      </div>
-      <pre v-if="stagingInstallResultText" data-testid="staging-install-result">{{ stagingInstallResultText }}</pre>
-      </el-card>
-    </section>
-
-    <section id="int-sec-cleaning-rules" class="integration-workbench__panel">
-      <el-card shadow="never">
-        <template #header>
-          <div class="integration-workbench__panel-head">
-            <div>
-              <h2>清洗映射规则</h2>
-          <p>一行就是一条清洗内容：从来源字段取值，经过白名单转换后写入目标字段。默认映射可直接用，也允许新增自定义清洗项。</p>
-        </div>
-        <button type="button" class="integration-workbench__button" data-testid="add-mapping" @click="addMapping">
-          新增自定义清洗项
-        </button>
-      </div>
-        </template>
-
-
-      <div class="integration-workbench__mapping-list" data-testid="mapping-rule-list">
-        <details v-for="(mapping, index) in mappings" :key="mapping.id" class="integration-workbench__mapping-card" open>
-          <summary :data-testid="`mapping-summary-${index}`">
-            <span>{{ mappingSummary(mapping, index) }}</span>
-            <small>{{ mappingDetail(mapping) }}</small>
-          </summary>
-          <div class="integration-workbench__mapping-editor">
-            <label>
-              <span>源字段</span>
-              <select
-                v-if="hasSourceFieldOptions"
-                v-model="mapping.sourceField"
-                :data-testid="`source-field-${index}`"
-              >
-                <option value="">请选择来源字段</option>
-                <option
-                  v-for="option in sourceFieldOptionsForMapping(mapping)"
-                  :key="`${option.stale ? 'stale' : 'schema'}:${option.value}`"
-                  :value="option.value"
-                >
-                  {{ sourceFieldOptionText(option) }}
-                </option>
-              </select>
-              <input v-else v-model="mapping.sourceField" :data-testid="`source-field-${index}`" placeholder="例如 code" />
-              <small v-if="hasSourceFieldOptions" class="integration-workbench__field-help" :data-testid="`source-field-picker-help-${index}`">
-                字段来自来源 schema；这里只保存字段名，不显示行值。
-              </small>
-            </label>
-            <label>
-              <span>目标字段</span>
-              <input v-model="mapping.targetField" :data-testid="`target-field-${index}`" placeholder="例如 FNumber" />
-            </label>
-            <label>
-              <span>转换</span>
-              <select v-model="mapping.transformFn" :data-testid="`transform-fn-${index}`">
-                <option v-for="option in transformOptions" :key="option.value" :value="option.value">
-                  {{ option.label }}
-                </option>
-              </select>
-              <small class="integration-workbench__field-help">只允许 trim、upper、lower、toNumber、dictMap；不允许用户脚本或 raw SQL。</small>
-              <textarea
-                v-if="mapping.transformFn === 'dictMap'"
-                v-model="mapping.dictMapText"
-                :data-testid="`dict-map-${index}`"
-                placeholder="EA=Pcs&#10;KG=Kg"
-              ></textarea>
-            </label>
-            <div>
-              <label class="integration-workbench__mapping-check">
-                <input v-model="mapping.required" type="checkbox" :data-testid="`required-${index}`" />
-                <span>必填；缺值会进入 dead letter，不中断整批。</span>
-              </label>
-              <div class="integration-workbench__mapping-rules">
-                <input v-model="mapping.minValueText" :data-testid="`validation-min-${index}`" placeholder="最小值 min" />
-                <input v-model="mapping.maxValueText" :data-testid="`validation-max-${index}`" placeholder="最大值 max" />
-              </div>
-            </div>
-            <button type="button" class="integration-workbench__icon-button" @click="removeMapping(index)">删除</button>
-          </div>
-        </details>
-      </div>
-      </el-card>
-    </section>
+    <IntegrationMappingRulesSection
+      :mappings="mappings"
+      :has-source-field-options="hasSourceFieldOptions"
+      :source-field-options-for-mapping="sourceFieldOptionsForMapping"
+      :source-field-option-text="sourceFieldOptionText"
+      :transform-options="transformOptions"
+      :mapping-summary="mappingSummary"
+      :mapping-detail="mappingDetail"
+      :add-mapping="addMapping"
+      :remove-mapping="removeMapping"
+    />
 
     <section id="int-sec-run-push" class="integration-workbench__panel">
       <el-card shadow="never">
@@ -1229,179 +1041,32 @@
       </el-card>
     </section>
 
-    <section id="int-sec-monitoring" class="integration-workbench__panel">
-      <el-card shadow="never">
-        <template #header>
-          <div class="integration-workbench__panel-head">
-            <div>
-              <h2>运行监控</h2>
-          <p>{{ observationSummary }}。展示最近 5 条 run（状态 / 写入 / 失败 + 行级结果）与 open dead letters（可重放），便于清洗后回看失败原因。</p>
-        </div>
-        <button type="button" class="integration-workbench__button" data-testid="refresh-observation" :disabled="observingPipeline" @click="refreshPipelineObservation(false)">
-          {{ observingPipeline ? '刷新中' : '刷新监控' }}
-        </button>
-      </div>
-        </template>
-
-
-      <div class="integration-workbench__observation">
-        <div>
-          <h3>最近运行</h3>
-          <div v-if="pipelineRuns.length === 0" class="integration-workbench__empty" data-testid="pipeline-runs-empty">
-            <strong data-testid="pipeline-runs-empty-what">{{ bi(
-              '这里展示最近的清洗流程运行记录（状态 / 读取 / 清洗 / 写入 / 失败行数）。',
-              'This shows recent pipeline run records (status / rows read / cleaned / written / failed).',
-            ) }}</strong>
-            <p data-testid="pipeline-runs-empty-first-step">{{ bi(
-              '第一步：在上方"运行与推送"区保存清洗流程后执行一次 Dry-run 或 Save-only 推送，运行记录会出现在这里。',
-              'First step: save the pipeline above, then run a Dry-run or Save-only push — the run record will then appear here.',
-            ) }}</p>
-          </div>
-          <ol v-else class="integration-workbench__record-list" data-testid="pipeline-runs">
-            <li v-for="run in pipelineRuns" :key="run.id" :data-testid="`pipeline-run-${run.id}`">
-              <div class="integration-workbench__run-head">
-                <strong :class="`integration-workbench__run-status integration-workbench__run-status--${run.status}`" :data-testid="`run-status-${run.id}`">{{ run.status }}</strong>
-                <span>{{ run.mode }}</span>
-                <span v-if="run.triggeredBy">by {{ run.triggeredBy }}</span>
-              </div>
-              <div class="integration-workbench__run-metrics">
-                <span>read {{ run.rowsRead }}</span>
-                <span>clean {{ run.rowsCleaned }}</span>
-                <span class="integration-workbench__run-metric--write">write {{ run.rowsWritten }}</span>
-                <span class="integration-workbench__run-metric--fail">fail {{ run.rowsFailed }}</span>
-                <span v-if="run.durationMs != null">{{ run.durationMs }}ms</span>
-              </div>
-              <small>{{ run.startedAt || run.createdAt || run.id }}<template v-if="run.finishedAt"> → {{ run.finishedAt }}</template></small>
-              <p v-if="run.errorSummary" class="integration-workbench__run-error" :data-testid="`run-error-${run.id}`">{{ run.errorSummary }}</p>
-              <div v-if="runRowSummaries(run).length > 0" class="integration-workbench__run-summaries">
-                <button type="button" class="integration-workbench__link-button" :data-testid="`toggle-run-summaries-${run.id}`" @click="toggleRunSummaries(run.id)">
-                  {{ isRunExpanded(run.id) ? '收起行级结果' : `展开行级结果（${runRowSummaries(run).length}）` }}
-                </button>
-                <pre v-if="isRunExpanded(run.id)" :data-testid="`run-row-summaries-${run.id}`">{{ JSON.stringify(runRowSummaries(run), null, 2) }}</pre>
-              </div>
-            </li>
-          </ol>
-        </div>
-        <div>
-          <h3>Open Dead Letters</h3>
-          <div v-if="deadLetters.length === 0" class="integration-workbench__empty" data-testid="dead-letters-empty">
-            <strong data-testid="dead-letters-empty-what">{{ bi(
-              'Dead letter 是清洗流程运行中未能成功写入的行，按原因分组，便于排查后再决定是否重放。',
-              'Dead letters are rows that failed to write during a pipeline run, grouped by reason so you can investigate before deciding whether to replay.',
-            ) }}</strong>
-            <p data-testid="dead-letters-empty-first-step">{{ bi(
-              '当前没有 open dead letters；出现失败行时会自动列在这里，可点击"准备 Replay"重跑。',
-              'There are no open dead letters right now; failed rows will be listed here automatically, and you can click "prepare replay" to re-run them.',
-            ) }}</p>
-          </div>
-          <ol v-else class="integration-workbench__record-list" data-testid="dead-letters">
-            <li v-for="deadLetter in deadLetters" :key="deadLetter.id" :data-testid="`dead-letter-${deadLetter.id}`">
-              <strong :data-testid="`dead-letter-label-${deadLetter.id}`">{{ deadLetterErrorLabel(deadLetter) }}</strong>
-              <span v-if="deadLetterErrorHint(deadLetter)">{{ deadLetterErrorHint(deadLetter) }}</span>
-              <small :data-testid="`dead-letter-code-${deadLetter.id}`">errorCode: {{ deadLetter.errorCode }}</small>
-              <small>
-                {{ deadLetter.status }} · {{ deadLetter.createdAt || deadLetter.id }}<template v-if="deadLetter.retryCount"> · retries {{ deadLetter.retryCount }}</template><template v-if="deadLetter.idempotencyKey"> · key {{ deadLetter.idempotencyKey }}</template>
-              </small>
-              <div class="integration-workbench__dead-letter-actions">
-                <span
-                  :class="['integration-workbench__badge', isDeadLetterReplayable(deadLetter) ? 'integration-workbench__badge--retryable' : '']"
-                  :data-testid="`dead-letter-retryable-${deadLetter.id}`"
-                >{{ isDeadLetterReplayable(deadLetter) ? '可重放' : '不可重放' }}</span>
-                <template v-if="isDeadLetterReplayable(deadLetter)">
-                  <button
-                    v-if="confirmReplayDeadLetterId !== deadLetter.id"
-                    type="button"
-                    class="integration-workbench__button integration-workbench__button--ghost"
-                    :data-testid="`replay-dead-letter-${deadLetter.id}`"
-                    :disabled="replayingDeadLetterId === deadLetter.id"
-                    @click="requestReplay(deadLetter.id)"
-                  >准备 Replay</button>
-                  <template v-else>
-                    <button
-                      type="button"
-                      class="integration-workbench__button integration-workbench__button--danger"
-                      :data-testid="`confirm-replay-dead-letter-${deadLetter.id}`"
-                      :disabled="replayingDeadLetterId === deadLetter.id"
-                      @click="replayDeadLetter(deadLetter)"
-                    >{{ replayingDeadLetterId === deadLetter.id ? 'Replay 中…' : '确认 Replay（会真实写入）' }}</button>
-                    <button
-                      type="button"
-                      class="integration-workbench__link-button"
-                      :data-testid="`cancel-replay-dead-letter-${deadLetter.id}`"
-                      :disabled="replayingDeadLetterId === deadLetter.id"
-                      @click="cancelReplay"
-                    >取消</button>
-                  </template>
-                </template>
-              </div>
-              <div class="integration-workbench__dead-letter-provenance">
-                <button
-                  type="button"
-                  class="integration-workbench__link-button"
-                  :data-testid="`toggle-dead-letter-provenance-${deadLetter.id}`"
-                  :disabled="!canViewRowProvenance(deadLetter)"
-                  :title="canViewRowProvenance(deadLetter) ? '查看该行(rowId)跨 run 的写入血缘（只读）' : '该 dead letter 无 idempotency key（rowId），无法查询血缘'"
-                  @click="toggleDeadLetterProvenance(deadLetter)"
-                >{{ isRowProvenanceExpanded(deadLetter.id) ? '收起血缘' : '查看跨-run 血缘' }}</button>
-                <span
-                  v-if="!canViewRowProvenance(deadLetter)"
-                  class="integration-workbench__hint"
-                  :data-testid="`dead-letter-provenance-unavailable-${deadLetter.id}`"
-                >无 rowId（idempotency key），不可查血缘</span>
-                <div
-                  v-if="isRowProvenanceExpanded(deadLetter.id)"
-                  class="integration-workbench__provenance-timeline"
-                  :data-testid="`dead-letter-provenance-${deadLetter.id}`"
-                >
-                  <div
-                    v-if="isRowProvenanceLoading(deadLetter.id)"
-                    class="integration-workbench__hint"
-                    :data-testid="`dead-letter-provenance-loading-${deadLetter.id}`"
-                  >血缘加载中…</div>
-                  <div
-                    v-else-if="rowProvenanceError(deadLetter.id)"
-                    class="integration-workbench__hint integration-workbench__hint--strong"
-                    :data-testid="`dead-letter-provenance-error-${deadLetter.id}`"
-                  >{{ rowProvenanceError(deadLetter.id) }}</div>
-                  <ol
-                    v-else-if="rowProvenanceTimeline(deadLetter.id).length > 0"
-                    class="integration-workbench__record-list"
-                    :data-testid="`dead-letter-provenance-timeline-${deadLetter.id}`"
-                  >
-                    <li
-                      v-for="(entry, index) in rowProvenanceTimeline(deadLetter.id)"
-                      :key="`${entry.runId}-${entry.eventIndex}`"
-                      :data-testid="`provenance-entry-${deadLetter.id}-${index}`"
-                    >
-                      <div class="integration-workbench__provenance-event-head">
-                        <strong>{{ entry.eventType }}</strong>
-                        <span
-                          class="integration-workbench__run-status"
-                          :class="`integration-workbench__run-status--${entry.runStatus}`"
-                        >run {{ entry.runStatus }}</span>
-                        <span>{{ entry.runCreatedAt || entry.at }}</span>
-                      </div>
-                      <small>runId {{ entry.runId }} · pipeline {{ entry.pipelineId }} · {{ entry.runMode }}</small>
-                      <p
-                        v-if="rowProvenanceAttrsSummary(entry.attrs)"
-                        class="integration-workbench__provenance-attrs"
-                      >{{ rowProvenanceAttrsSummary(entry.attrs) }}</p>
-                    </li>
-                  </ol>
-                  <div
-                    v-else
-                    class="integration-workbench__empty"
-                    :data-testid="`dead-letter-provenance-empty-${deadLetter.id}`"
-                  >暂无血缘事件。</div>
-                  <p class="integration-workbench__hint">只读：仅展示脱敏后的事件，不含 payload 原文，不触发任何写入/重放。</p>
-                </div>
-              </div>
-            </li>
-          </ol>
-        </div>
-      </div>
-      </el-card>
-    </section>
+    <IntegrationMonitoringSection
+      :observation-summary="observationSummary"
+      :observing-pipeline="observingPipeline"
+      :pipeline-runs="pipelineRuns"
+      :dead-letters="deadLetters"
+      :bi="bi"
+      :run-row-summaries="runRowSummaries"
+      :is-run-expanded="isRunExpanded"
+      :dead-letter-error-label="deadLetterErrorLabel"
+      :dead-letter-error-hint="deadLetterErrorHint"
+      :is-dead-letter-replayable="isDeadLetterReplayable"
+      :confirm-replay-dead-letter-id="confirmReplayDeadLetterId"
+      :replaying-dead-letter-id="replayingDeadLetterId"
+      :can-view-row-provenance="canViewRowProvenance"
+      :is-row-provenance-expanded="isRowProvenanceExpanded"
+      :is-row-provenance-loading="isRowProvenanceLoading"
+      :row-provenance-error="rowProvenanceError"
+      :row-provenance-timeline="rowProvenanceTimeline"
+      :row-provenance-attrs-summary="rowProvenanceAttrsSummary"
+      :refresh-pipeline-observation="refreshPipelineObservation"
+      :toggle-run-summaries="toggleRunSummaries"
+      :request-replay="requestReplay"
+      :cancel-replay="cancelReplay"
+      :replay-dead-letter="replayDeadLetter"
+      :toggle-dead-letter-provenance="toggleDeadLetterProvenance"
+    />
 
     <section id="int-sec-preview" class="integration-workbench__panel integration-workbench__preview">
       <el-card shadow="never">
@@ -1591,6 +1256,9 @@ import PlmBomReviewPanel from '../components/plm/PlmBomReviewPanel.vue'
 import IntegrationWorkbenchRail, {
   type IntegrationWorkbenchRailGroup,
 } from '../components/integration/IntegrationWorkbenchRail.vue'
+import IntegrationMonitoringSection from '../components/integration/IntegrationMonitoringSection.vue'
+import IntegrationCleaningDatasetSection from '../components/integration/IntegrationCleaningDatasetSection.vue'
+import IntegrationMappingRulesSection from '../components/integration/IntegrationMappingRulesSection.vue'
 
 type WorkbenchSide = 'source' | 'target'
 type TransformFn = '' | 'trim' | 'upper' | 'lower' | 'toNumber' | 'dictMap'

--- a/apps/web/tests/IntegrationCleaningDatasetSection.spec.ts
+++ b/apps/web/tests/IntegrationCleaningDatasetSection.spec.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp, type Component } from 'vue'
+import IntegrationCleaningDatasetSection from '../src/components/integration/IntegrationCleaningDatasetSection.vue'
+import type { IntegrationObjectSchema, IntegrationStagingDescriptor } from '../src/services/integration/workbench'
+
+// IU-2b (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+// stage B): structural smoke test for the extracted cleaning-dataset section — see
+// IntegrationMonitoringSection.spec.ts's header comment for why this is a light isolation check,
+// not a re-test of behavior already covered via the parent's unchanged 50 tests.
+const ElCard = defineComponent({
+  name: 'ElCard',
+  props: { shadow: { type: String, required: false, default: undefined } },
+  setup(_props, { slots }) {
+    return () => h('div', { class: 'el-card' }, [
+      slots.header ? h('div', { class: 'el-card__header' }, slots.header()) : null,
+      h('div', { class: 'el-card__body' }, slots.default?.()),
+    ])
+  },
+})
+
+describe('IntegrationCleaningDatasetSection (unit)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  async function mountSection(props: Record<string, unknown>): Promise<void> {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const Host = defineComponent({
+      setup() {
+        return () => h(IntegrationCleaningDatasetSection as unknown as Component, props)
+      },
+    })
+    app = createApp(Host)
+    app.component('ElCard', ElCard)
+    app.mount(container)
+    await nextTick()
+  }
+
+  const emptySchema: IntegrationObjectSchema = { object: '', fields: [] }
+  const noopFn = (..._args: unknown[]): unknown => undefined
+
+  function baseProps(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      sourceDatasetTitle: '请选择来源数据集',
+      sourceDatasetDescription: '',
+      sourceSchema: emptySchema,
+      sourceConnectionLabel: '未测试',
+      selectedStagingDescriptor: null,
+      stagingDescriptors: [] as IntegrationStagingDescriptor[],
+      getStagingAreaLabel: () => '',
+      targetDatasetTitle: '请选择目标数据集',
+      targetDatasetDescription: '',
+      targetSchema: emptySchema,
+      requiredTargetFieldCount: 0,
+      stagingDatasetCards: [],
+      installingStaging: false,
+      stagingProjectId: '',
+      stagingProjectIdScopeStatus: '',
+      stagingProjectIdScopeWarning: '',
+      stagingInstallResultText: '',
+      installStagingTables: vi.fn(noopFn),
+      useStagingAsSource: vi.fn(noopFn),
+      useStagingAsTarget: vi.fn(noopFn),
+      focusStagingInstall: vi.fn(noopFn),
+      onStagingProjectIdInput: vi.fn(noopFn),
+      normalizeStagingProjectIdToScope: vi.fn(noopFn),
+      'onUpdate:stagingBaseId': vi.fn(noopFn),
+      stagingBaseId: '',
+      ...overrides,
+    }
+  }
+
+  it('renders the section id, dataset cards, and the staging-empty state', async () => {
+    await mountSection(baseProps())
+    expect(container?.querySelector('#int-sec-cleaning-dataset')).toBeTruthy()
+    expect(container?.querySelector('[data-testid="dataset-cards"]')).toBeTruthy()
+    expect(container?.querySelector('[data-testid="staging-empty"]')).toBeTruthy()
+  })
+
+  it('forwards the install-staging click to the prop function', async () => {
+    const installStagingTables = vi.fn(noopFn)
+    await mountSection(baseProps({ installStagingTables }))
+    const button = container?.querySelector<HTMLButtonElement>('[data-testid="install-staging"]')
+    button?.click()
+    await nextTick()
+    expect(installStagingTables).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/tests/IntegrationMappingRulesSection.spec.ts
+++ b/apps/web/tests/IntegrationMappingRulesSection.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp, type Component } from 'vue'
+import IntegrationMappingRulesSection from '../src/components/integration/IntegrationMappingRulesSection.vue'
+import type { EditableMapping } from '../src/components/integration/integrationWorkbenchSectionTypes'
+
+// IU-2b (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+// stage B): structural smoke test for the extracted mapping-rules section — see
+// IntegrationMonitoringSection.spec.ts's header comment for why this is a light isolation check,
+// not a re-test of behavior already covered via the parent's unchanged 50 tests.
+const ElCard = defineComponent({
+  name: 'ElCard',
+  props: { shadow: { type: String, required: false, default: undefined } },
+  setup(_props, { slots }) {
+    return () => h('div', { class: 'el-card' }, [
+      slots.header ? h('div', { class: 'el-card__header' }, slots.header()) : null,
+      h('div', { class: 'el-card__body' }, slots.default?.()),
+    ])
+  },
+})
+
+describe('IntegrationMappingRulesSection (unit)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  async function mountSection(props: Record<string, unknown>): Promise<void> {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const Host = defineComponent({
+      setup() {
+        return () => h(IntegrationMappingRulesSection as unknown as Component, props)
+      },
+    })
+    app = createApp(Host)
+    app.component('ElCard', ElCard)
+    app.mount(container)
+    await nextTick()
+  }
+
+  const noopFn = (..._args: unknown[]): unknown => undefined
+
+  function baseProps(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      mappings: [] as EditableMapping[],
+      hasSourceFieldOptions: false,
+      sourceFieldOptionsForMapping: () => [],
+      sourceFieldOptionText: (option: { label: string }) => option.label,
+      transformOptions: [{ value: '', label: '无转换' }],
+      mappingSummary: (mapping: EditableMapping, index: number) => `${mapping.sourceField || `来源字段 ${index + 1}`} -> ${mapping.targetField || `目标字段 ${index + 1}`}`,
+      mappingDetail: () => '',
+      addMapping: vi.fn(noopFn),
+      removeMapping: vi.fn(noopFn),
+      ...overrides,
+    }
+  }
+
+  it('renders the section id and one mapping card per mapping', async () => {
+    const mapping: EditableMapping = {
+      id: 'm1',
+      sourceField: 'code',
+      targetField: 'FNumber',
+      transformFn: 'trim',
+      dictMapText: '',
+      required: true,
+      minValueText: '',
+      maxValueText: '',
+    }
+    await mountSection(baseProps({ mappings: [mapping] }))
+    expect(container?.querySelector('#int-sec-cleaning-rules')).toBeTruthy()
+    expect(container?.querySelector('[data-testid="mapping-summary-0"]')?.textContent).toContain('code -> FNumber')
+  })
+
+  it('forwards add-mapping and remove-mapping clicks to their prop functions', async () => {
+    const addMapping = vi.fn(noopFn)
+    const removeMapping = vi.fn(noopFn)
+    const mapping: EditableMapping = {
+      id: 'm1',
+      sourceField: 'code',
+      targetField: 'FNumber',
+      transformFn: 'trim',
+      dictMapText: '',
+      required: false,
+      minValueText: '',
+      maxValueText: '',
+    }
+    await mountSection(baseProps({ mappings: [mapping], addMapping, removeMapping }))
+    container?.querySelector<HTMLButtonElement>('[data-testid="add-mapping"]')?.click()
+    await nextTick()
+    expect(addMapping).toHaveBeenCalledTimes(1)
+    const removeButton = Array.from(container?.querySelectorAll('button') ?? []).find((btn) => btn.textContent === '删除')
+    removeButton?.click()
+    await nextTick()
+    expect(removeMapping).toHaveBeenCalledWith(0)
+  })
+})

--- a/apps/web/tests/IntegrationMonitoringSection.spec.ts
+++ b/apps/web/tests/IntegrationMonitoringSection.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp, type Component } from 'vue'
+import IntegrationMonitoringSection from '../src/components/integration/IntegrationMonitoringSection.vue'
+import type { IntegrationDeadLetter, IntegrationPipelineRun } from '../src/services/integration/workbench'
+
+// IU-2b (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+// stage B): structural smoke test for the extracted monitoring section — the bulk of its
+// behavior is already covered by tests/IntegrationWorkbenchView.spec.ts's unchanged 50 tests
+// (mounted through the parent, exercising the same DOM this component now renders). This spec
+// only proves the component renders correctly in isolation with a minimal prop contract.
+//
+// ElCard stub: mirrors the same pattern already used in IntegrationWorkbenchView.spec.ts /
+// IntegrationWorkbenchRail.spec.ts — real Element Plus is not globally installed in this test's
+// createApp() instance.
+const ElCard = defineComponent({
+  name: 'ElCard',
+  props: { shadow: { type: String, required: false, default: undefined } },
+  setup(_props, { slots }) {
+    return () => h('div', { class: 'el-card' }, [
+      slots.header ? h('div', { class: 'el-card__header' }, slots.header()) : null,
+      h('div', { class: 'el-card__body' }, slots.default?.()),
+    ])
+  },
+})
+
+const bi = (zh: string, _en: string): string => zh
+
+describe('IntegrationMonitoringSection (unit)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  async function mountSection(props: Record<string, unknown>): Promise<void> {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const Host = defineComponent({
+      setup() {
+        return () => h(IntegrationMonitoringSection as unknown as Component, props)
+      },
+    })
+    app = createApp(Host)
+    app.component('ElCard', ElCard)
+    app.mount(container)
+    await nextTick()
+  }
+
+  const noopFn = (..._args: unknown[]): unknown => undefined
+
+  function baseProps(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      observationSummary: '0 runs / 0 open dead letters',
+      observingPipeline: false,
+      pipelineRuns: [] as IntegrationPipelineRun[],
+      deadLetters: [] as IntegrationDeadLetter[],
+      bi,
+      runRowSummaries: () => [],
+      isRunExpanded: () => false,
+      deadLetterErrorLabel: () => '',
+      deadLetterErrorHint: () => null,
+      isDeadLetterReplayable: () => false,
+      confirmReplayDeadLetterId: '',
+      replayingDeadLetterId: '',
+      canViewRowProvenance: () => false,
+      isRowProvenanceExpanded: () => false,
+      isRowProvenanceLoading: () => false,
+      rowProvenanceError: () => '',
+      rowProvenanceTimeline: () => [],
+      rowProvenanceAttrsSummary: () => '',
+      refreshPipelineObservation: vi.fn(noopFn),
+      toggleRunSummaries: vi.fn(noopFn),
+      requestReplay: vi.fn(noopFn),
+      cancelReplay: vi.fn(noopFn),
+      replayDeadLetter: vi.fn(noopFn),
+      toggleDeadLetterProvenance: vi.fn(noopFn),
+      ...overrides,
+    }
+  }
+
+  it('renders the section id and both empty states when there is no data', async () => {
+    await mountSection(baseProps())
+    expect(container?.querySelector('#int-sec-monitoring')).toBeTruthy()
+    expect(container?.querySelector('[data-testid="pipeline-runs-empty"]')).toBeTruthy()
+    expect(container?.querySelector('[data-testid="dead-letters-empty"]')).toBeTruthy()
+  })
+
+  it('renders a pipeline run row and forwards the refresh click to the prop function', async () => {
+    const refreshPipelineObservation = vi.fn(noopFn)
+    const run: IntegrationPipelineRun = {
+      id: 'run-1',
+      status: 'success',
+      mode: 'manual',
+      rowsRead: 3,
+      rowsCleaned: 3,
+      rowsWritten: 3,
+      rowsFailed: 0,
+    } as IntegrationPipelineRun
+    await mountSection(baseProps({ pipelineRuns: [run], refreshPipelineObservation }))
+    expect(container?.querySelector('[data-testid="pipeline-run-run-1"]')).toBeTruthy()
+    expect(container?.querySelector('[data-testid="run-status-run-1"]')?.textContent).toContain('success')
+    const refreshButton = container?.querySelector<HTMLButtonElement>('[data-testid="refresh-observation"]')
+    refreshButton?.click()
+    await nextTick()
+    expect(refreshPipelineObservation).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/web/tests/IntegrationMonitoringSection.spec.ts
+++ b/apps/web/tests/IntegrationMonitoringSection.spec.ts
@@ -87,6 +87,11 @@ describe('IntegrationMonitoringSection (unit)', () => {
     expect(container?.querySelector('#int-sec-monitoring')).toBeTruthy()
     expect(container?.querySelector('[data-testid="pipeline-runs-empty"]')).toBeTruthy()
     expect(container?.querySelector('[data-testid="dead-letters-empty"]')).toBeTruthy()
+    // IU-6 guided empty-state copy (what-this-is + first-step) rides through the IU-2b extraction —
+    // pin both sub-testids here (the parent view spec doesn't assert them, so without this the
+    // extracted component could drop the guidance and stay green — quality-gate finding).
+    expect(container?.querySelector('[data-testid="dead-letters-empty-what"]')?.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    expect(container?.querySelector('[data-testid="dead-letters-empty-first-step"]')?.textContent?.trim().length ?? 0).toBeGreaterThan(0)
   })
 
   it('renders a pipeline run row and forwards the refresh click to the prop function', async () => {

--- a/apps/web/tests/ui-foundation-style-guard.spec.ts
+++ b/apps/web/tests/ui-foundation-style-guard.spec.ts
@@ -43,6 +43,12 @@ const TARGET_FILES = [
   // literals onto var(--ms-*)/--el-* and adds the new rail component clean from the start.
   'src/views/IntegrationWorkbenchView.vue',
   'src/components/integration/IntegrationWorkbenchRail.vue',
+  // IU-2b (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
+  // stage B — per-section extraction): the three new section components copy CSS rules verbatim
+  // from the (already token-only, UF-6-clean) parent, so they start clean too.
+  'src/components/integration/IntegrationMonitoringSection.vue',
+  'src/components/integration/IntegrationCleaningDatasetSection.vue',
+  'src/components/integration/IntegrationMappingRulesSection.vue',
 ] as const
 
 // Per-file allowlist for counts that are legitimately un-clearable. Keep this EMPTY unless a

--- a/docs/development/integration-iu2b-section-extraction-dev-verification-20260707.md
+++ b/docs/development/integration-iu2b-section-extraction-dev-verification-20260707.md
@@ -1,0 +1,271 @@
+# IU-2b: Workbench section extraction — child components, zero behavior change — dev verification (2026-07-07)
+
+Scope: design-lock `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md`
+(RATIFIED, #3739) §2 IU-2 stage B ("per-section component extraction... zero behavior change").
+Base = origin/main including IU-2a #3770 (PageShell/PageHeader/rail/el-card sections/tokenization,
+`IntegrationWorkbenchRail.vue`), IU-1 #3743, and IU-6 #3750.
+
+**Zero-behavior-change discipline**: no state or service-call logic was moved anywhere — the view
+keeps every `ref`/`computed`/`function`/service import it had before this slice. This is a pure
+template/markup extraction: three of the view's ten `<section>` blocks now render through a child
+component instead of inline, and the child receives every value/handler it needs as a prop (the
+exact same identifiers the inline template used to reference directly). `apps/web/tests/
+IntegrationWorkbenchView.spec.ts` — the file carrying the pre-existing 50 tests (49 landed by IU-2a
++ 1 added since) — is **not touched at all** in this PR (`git diff` shows zero changes to it); that
+absence of a diff is itself the strongest form of the "unchanged assertions" proof.
+
+## What changed
+
+### 1. Three new child components under `apps/web/src/components/integration/`
+
+Picked by reading all ten sections and choosing the ones with the cleanest, most literal
+prop/emit boundary (per the task's own candidate list: connection-management, monitoring,
+run-push, object-template/cleansing-mapping) — see "Deferred to IU-2c" below for why the other
+named candidates were *not* picked this round.
+
+#### `IntegrationMonitoringSection.vue` (section `int-sec-monitoring`, was ~172 template lines)
+
+Read-heavy display of recent pipeline runs + open dead letters + per-row cross-run provenance,
+with a handful of user actions (refresh / expand-collapse / replay / provenance toggle). Single
+concern, one direction of data flow (props down, the exact same function references invoked back
+up), the cleanest of the four named candidates.
+
+- **Data props**: `observationSummary`, `observingPipeline`, `pipelineRuns`
+  (`IntegrationPipelineRun[]`), `deadLetters` (`IntegrationDeadLetter[]`),
+  `confirmReplayDeadLetterId`, `replayingDeadLetterId`.
+- **Derivation function props** (called inline per row, same as before extraction):
+  `bi`, `runRowSummaries`, `isRunExpanded`, `deadLetterErrorLabel`, `deadLetterErrorHint`,
+  `isDeadLetterReplayable`, `canViewRowProvenance`, `isRowProvenanceExpanded`,
+  `isRowProvenanceLoading`, `rowProvenanceError`, `rowProvenanceTimeline`,
+  `rowProvenanceAttrsSummary`.
+- **Action function props**: `refreshPipelineObservation`, `toggleRunSummaries`, `requestReplay`,
+  `cancelReplay`, `replayDeadLetter`, `toggleDeadLetterProvenance`.
+- No emits — every prop is either data or a function reference owned and defined by the parent;
+  the child calls them exactly where the inline template used to (e.g.
+  `@click="refreshPipelineObservation(false)"` is now `@click="refreshPipelineObservation(false)"`
+  resolving `refreshPipelineObservation` from props via Vue 3.5's reactive-props-destructure,
+  identical call site).
+
+#### `IntegrationCleaningDatasetSection.vue` (section `int-sec-cleaning-dataset`, was ~146 lines)
+
+Dataset cards (source/staging/target summary) + staging-table install/link management.
+
+- **Data props**: `sourceDatasetTitle`, `sourceDatasetDescription`, `sourceSchema`
+  (`IntegrationObjectSchema`), `sourceConnectionLabel`, `selectedStagingDescriptor`
+  (`IntegrationStagingDescriptor | null`), `stagingDescriptors`, `targetDatasetTitle`,
+  `targetDatasetDescription`, `targetSchema`, `requiredTargetFieldCount`, `stagingDatasetCards`,
+  `installingStaging`, `stagingProjectId`, `stagingProjectIdScopeStatus`,
+  `stagingProjectIdScopeWarning`, `stagingInstallResultText`.
+- **Derivation function prop**: `getStagingAreaLabel`.
+- **Action function props**: `installStagingTables`, `useStagingAsSource`, `useStagingAsTarget`,
+  `focusStagingInstall`, `onStagingProjectIdInput`, `normalizeStagingProjectIdToScope`.
+- **One `defineModel`**: `stagingBaseId` — the single native-`v-model`-bound primitive in this
+  section, so the parent binds `v-model:staging-base-id="stagingBaseId"` instead of a plain prop +
+  manual input handler (same net effect, idiomatic Vue 3.4+, and the only field in this section
+  that needed two-way binding rather than a one-shot event handler).
+
+#### `IntegrationMappingRulesSection.vue` (section `int-sec-cleaning-rules`, was ~77 lines)
+
+The smallest and cleanest of the three: a list editor for `EditableMapping` rows.
+
+- **Data prop**: `mappings` (`EditableMapping[]`) — the parent's own `ref<EditableMapping[]>`
+  array is passed down by reference; the child's `v-model="mapping.sourceField"` (etc., pulled
+  from a `v-for` over the prop) mutates the *same* object the parent's ref points at, identical to
+  the pre-extraction behavior where this array was rendered inline. This file is not in
+  `apps/web/package.json`'s `lint` file list (an explicit named list, not a glob), so this
+  nested-prop-mutation pattern carries no ESLint (`vue/no-mutating-props`) gate risk either.
+- **Derivation function props**: `hasSourceFieldOptions` (data, not a function),
+  `sourceFieldOptionsForMapping`, `sourceFieldOptionText`, `transformOptions`, `mappingSummary`,
+  `mappingDetail`.
+- **Action function props**: `addMapping`, `removeMapping`.
+
+#### Shared types: `integrationWorkbenchSectionTypes.ts` (new)
+
+`EditableMapping`, `SourceFieldOption`, `StagingDatasetCard`, `TransformFn` — duplicated (not
+imported) from the view's local (non-exported) `<script setup>` type declarations. Rationale: this
+slice is a pure template move; touching the view's script block (even just adding `export` to a
+type) was avoidable, so the small, stable shapes are copied into a new file both child components
+import, and the view's script is untouched byte-for-byte except for the three new import lines and
+the three template replacements. All other types used by the new components
+(`IntegrationPipelineRun`, `IntegrationDeadLetter`, `IntegrationTargetWriteSummary`,
+`IntegrationProvenanceTimelineEntry`, `IntegrationObjectSchema`, `IntegrationStagingDescriptor`)
+were already exported from `services/integration/workbench.ts` and are imported directly from
+there — no duplication needed.
+
+### 2. CSS: verbatim duplication, not relocation
+
+Each child component's `<style scoped>` block contains a **verbatim copy** of every rule in
+`IntegrationWorkbenchView.vue`'s `<style scoped>` block whose selector targets a class name used
+in that section's markup — copied, not moved; the parent's `<style>` block is byte-for-byte
+unchanged (confirmed via `git diff`, which touches only the `<template>` and `<script setup>`
+import list).
+
+This is required, not optional: Vue's scoped CSS only reaches a component's *own* rendered
+template, not a child component's inner DOM. Since IU-2a's ten sections share a lot of "utility"
+classes (`__button`, `__hint`, `__panel`, `__empty`, `__actions`, `__grid`, generic `input`/
+`select`/`textarea`/`label`/`h2`/`h3`/`pre`/`code` element rules scoped under `.integration-
+workbench`) across sections that remain inline in the parent, those rules must stay in the parent
+*and* get a copy in each child — removing them from the parent would silently break the seven
+sections that are still inline.
+
+This still renders pixel-identical because of how Vue's scoped-CSS compiler works: it appends the
+`[data-v-hash]` scope attribute only to the **rightmost** compound selector in a rule (e.g.
+`.integration-workbench input { }` compiles to `.integration-workbench input[data-v-CHILDHASH]`),
+never to ancestor parts. The ancestor class (`.integration-workbench`, `.integration-
+workbench__panel`) still matches against the real DOM regardless of which component rendered that
+ancestor element, so a rule copied verbatim into a child's own `<style scoped>` block matches
+exactly the same elements it did when the whole section lived inline in the parent. Verified
+empirically too: all 50 pre-existing tests plus the new structural tests pass, and the production
+build succeeds with the same visual class/selector set.
+
+### 3. Parent view: three `<section>` blocks replaced with component invocations
+
+`IntegrationWorkbenchView.vue`'s `<script setup>` gained three import lines (`IntegrationMonitoring
+Section`, `IntegrationCleaningDatasetSection`, `IntegrationMappingRulesSection`); nothing else in
+the script changed. The rail's anchor-scroll and `IntersectionObserver` logic
+(`document.getElementById(id)` lookups keyed by the same ten stable section ids) needed **zero**
+changes — DOM `id` lookups don't care which component rendered the element, and Vue mounts child
+components before the parent's `onMounted` fires, so the observer setup still finds all ten ids on
+first mount, exactly as before.
+
+## Line count
+
+| File | Before | After |
+|---|---|---|
+| `apps/web/src/views/IntegrationWorkbenchView.vue` | 6195 | 5863 (**-332**, ~5.4%) |
+| `apps/web/src/components/integration/IntegrationMonitoringSection.vue` | — | 492 (new) |
+| `apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue` | — | 423 (new) |
+| `apps/web/src/components/integration/IntegrationMappingRulesSection.vue` | — | 261 (new) |
+| `apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts` | — | 41 (new) |
+
+(The new files are larger than the template chunks they replace because each carries its own
+duplicated `<style scoped>` block per §2 above — the monolith's *template* shrank by the full
+~395 lines the three sections occupied; the parent's `<style>` block itself is unchanged.)
+
+## The "50 unchanged" proof
+
+`apps/web/tests/IntegrationWorkbenchView.spec.ts` has **zero diff** in this PR (`git diff --stat`
+does not list it). Additionally, re-ran the exact same spec on the pristine pre-slice tree (`git
+stash` / run / `git stash pop`) and diffed the two runs' full test-name lists (Vitest verbose
+output, timings stripped): **identical set, 50/50**, both runs green:
+
+```
+pnpm exec vitest run IntegrationWorkbenchView --reporter=verbose
+# before this slice (git stash):  50 passed (50) — 50 test names captured
+# after this slice:               50 passed (50) — 50 test names captured
+diff before-notime.txt after-notime.txt && echo "IDENTICAL TEST NAME SET (50/50)"
+# → IDENTICAL TEST NAME SET (50/50)
+```
+
+Confirmed on **both** runtimes:
+
+```
+# Node 25.9.0 (default)
+✓ tests/IntegrationWorkbenchView.spec.ts  (50 tests)
+Test Files  1 passed (1) · Tests  50 passed (50)
+
+# Node 20.20.2 (via nvm)
+✓ tests/IntegrationWorkbenchView.spec.ts  (50 tests)
+Test Files  1 passed (1) · Tests  50 passed (50)
+```
+
+## New structural tests (small, optional per the task — added since cheap)
+
+One spec per extracted component, each a light isolation mount (own `ElCard` stub, same pattern
+as the existing specs) proving the section's key testid(s) render and that a representative click
+forwards to the exact prop-function reference passed in:
+
+- `tests/IntegrationMonitoringSection.spec.ts` (2 tests): empty states render; a pipeline run row
+  renders and clicking refresh calls `refreshPipelineObservation(false)`.
+- `tests/IntegrationCleaningDatasetSection.spec.ts` (2 tests): dataset cards + staging-empty state
+  render; clicking install-staging calls `installStagingTables()`.
+- `tests/IntegrationMappingRulesSection.spec.ts` (2 tests): a mapping row renders with the right
+  summary text; add/remove clicks call `addMapping()` / `removeMapping(0)`.
+
+## Full integration-guard list — both runtimes
+
+```
+pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror \
+  integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel \
+  IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel \
+  readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail \
+  IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection \
+  IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot
+
+Test Files  15 passed (15) · Tests  194 passed (194)   [Node 20.20.2 AND Node 25.9.0]
+```
+
+Also ran:
+- `apps/web/tests/ui-foundation-style-guard.spec.ts` — 59 passed (was 53 after IU-2a; +6 for the
+  three new files × 2 axes, all zero hex/rgb and zero static `style=`, since their CSS is copied
+  verbatim from the already-token-only parent).
+- The full `approval-web-guard.yml` vitest filter list — 529 passed (29 files; the same 29 files
+  as before, +6 tests from the `ui-foundation-style-guard` name match picking up the new
+  `TARGET_FILES` entries — no new file matched this filter's name list).
+- `pnpm exec vue-tsc -b` — clean (exit 0), both Node 20.20.2 and default Node 25.9.0.
+- `pnpm --filter @metasheet/web build` — succeeds (pre-existing >500kB chunk-size warning,
+  unrelated to this slice).
+
+## CI wiring
+
+- `.github/workflows/integration-guard.yml`: added the three new component files (+ the shared
+  types file) to both `pull_request`/`push` path triggers, added the three new spec files to the
+  path triggers, and added the three new spec names to the `vitest run` filter.
+- `.github/workflows/approval-web-guard.yml`: added the three new component files to the same
+  path-trigger block IU-2a added `IntegrationWorkbenchView.vue`/`IntegrationWorkbenchRail.vue` to
+  (the block gating `ui-foundation-style-guard.spec.ts` coverage).
+- `apps/web/tests/ui-foundation-style-guard.spec.ts`: `TARGET_FILES` +3 (the three new components).
+
+## IU-2c remainder (explicitly NOT in this slice, with reasons)
+
+- **`int-sec-connection`** (was ~234 lines) — one of the task's four named candidates, but reading
+  it in full showed it is not as clean as it first looks: a single `connectionDraft` object with
+  8 two-way-bound fields, a separate data-source-bridge sub-form (dataSourceId/dataSourceObject
+  pickers with their own loading/error state), an adapter list, a staging-card list shared with
+  the cleaning-dataset section, and ~15 distinct action handlers spanning connect/edit/copy/
+  deactivate/activate/delete. Extracting it cleanly would need either several `defineModel`s or a
+  bundled-object-prop approach for `connectionDraft` — doable, but a meaningfully bigger unit of
+  work than the three picked this round, and not obviously "the cleanest boundary" once read in
+  full. Deferred to IU-2c rather than forced in under time pressure.
+- **`int-sec-run-push`** (was ~506 lines, the single largest section) — read in full and confirmed
+  *not* a clean single concern: it bundles five materially distinct sub-features (pipeline
+  save/mode/watermark config, a `stock-preparation` S1 admin panel, an "external write C6" dry-
+  run/apply panel, a generic "parameterized table action" panel with its own duplicate-policy
+  sub-editor, a field-option-sync panel, and a CSV/Excel export control) behind one `<section>`,
+  each admin-gated differently (`integration:admin` checks appear twice) and each with its own
+  10-20-binding sub-contract. This is the textbook "don't force a messy one" case from the task
+  brief — a future IU-2c slice should split it into its own several components (one per
+  sub-feature) rather than one monolithic prop bag.
+- **`int-sec-object-template`** (~174 lines, source/target system+object pickers) — reasonably
+  clean on its own, but not picked this round simply to keep this slice to three components; a
+  good IU-2c candidate (it already delegates to `PlmBomReviewPanel` for one sub-panel, so the
+  extraction boundary is partly established).
+- **`int-sec-preview`** (~95 lines, sample record / target-template JSON / reference-mapping /
+  payload preview, embeds `MetaIntegrationFieldRuleAuthoring` via its own `v-model`) — mixed
+  concerns (raw JSON editing + a field-rule-authoring child + a read-only provenance display);
+  candidate for a future slice once IU-5 (JSON-textarea structuring) has a say in its shape, per
+  the design-lock's own slice ladder (IU-5 is gated on IU-2 landing).
+- **`int-sec-read-source`, `int-sec-combination-config`, `int-sec-combination-run`** — already
+  thin wrapper sections (~13 lines each) that just render an existing self-contained child
+  component (`IntegrationReadSourceConfigPanel`, `IntegrationReadSourceCompositionAuthoringPanel`,
+  `IntegrationReadSourceCompositionPanel`); nothing to extract, out of scope by construction.
+
+## Files touched
+
+- `apps/web/src/views/IntegrationWorkbenchView.vue` (three `<section>` blocks replaced with
+  component invocations; three new import lines; zero other script/style changes)
+- `apps/web/src/components/integration/IntegrationMonitoringSection.vue` (new)
+- `apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue` (new)
+- `apps/web/src/components/integration/IntegrationMappingRulesSection.vue` (new)
+- `apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts` (new)
+- `apps/web/tests/IntegrationMonitoringSection.spec.ts` (new)
+- `apps/web/tests/IntegrationCleaningDatasetSection.spec.ts` (new)
+- `apps/web/tests/IntegrationMappingRulesSection.spec.ts` (new)
+- `apps/web/tests/ui-foundation-style-guard.spec.ts` (`TARGET_FILES` +3)
+- `.github/workflows/integration-guard.yml` (path triggers + vitest run list, +3 components +3 specs)
+- `.github/workflows/approval-web-guard.yml` (path triggers, +3 components)
+- `docs/development/integration-iu2b-section-extraction-dev-verification-20260707.md` (this file)
+
+Not touched: `apps/web/tests/IntegrationWorkbenchView.spec.ts` (zero diff — the proof itself), any
+`services/integration/*.ts` file, `IntegrationWorkbenchRail.vue`, `PageShell.vue`/`PageHeader.vue`,
+routing, or any backend/plugin file.


### PR DESCRIPTION
## Summary
- IU-2 stage B (per §2 of `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md`, RATIFIED #3739): extracts the three cleanest-boundary sections out of the 6195-line `IntegrationWorkbenchView.vue` monolith into standalone components under `apps/web/src/components/integration/` — monitoring (`int-sec-monitoring`), cleaning-dataset (`int-sec-cleaning-dataset`), mapping-rules (`int-sec-cleaning-rules`).
- Pure template/markup move — zero state or service-call logic relocated. The parent keeps every `ref`/`computed`/`function`/service import; each child receives its data + the exact same function references as props (mirrors the `tr` function-prop pattern IU-2a's `IntegrationWorkbenchRail.vue` already established).
- Parent view: 6195 → 5863 lines (-332, ~5.4%).
- CSS: duplicated (not relocated) verbatim into each child's own `<style scoped>` block — required because Vue's scoped CSS only reaches a component's own rendered template, not a child's inner DOM, and several classes (`__button`, `__hint`, `__panel`, etc.) are still shared with sections that remain inline in the parent.
- `run-push` (largest section, 506 lines) and `connection` (234 lines, one of the task's named candidates) were read in full and deliberately **not** extracted this round — both bundle several materially distinct sub-concerns behind one `<section>` rather than one clean concern; deferred to IU-2c (see verification MD for the full reasoning).

## Test plan
- [x] `apps/web/tests/IntegrationWorkbenchView.spec.ts` has **zero diff** in this PR — the strongest form of "unchanged assertions."
- [x] Re-ran the same spec on the pristine pre-slice tree (`git stash`/run/pop) and diffed the full test-name list against the post-slice run: identical set, 50/50, both green, on Node 20.20.2 and default Node 25.9.0.
- [x] Added 3 small structural specs (2 tests each) for the new components — 6 new tests, all green.
- [x] Full `integration-guard.yml` vitest list: 15 files / 194 tests passed on both Node runtimes.
- [x] `ui-foundation-style-guard.spec.ts`: 59 passed (was 53; +6 for the 3 new files × 2 axes, all zero hex/rgb, zero static `style=`).
- [x] Full `approval-web-guard.yml` vitest filter: 529 passed (29 files).
- [x] `pnpm exec vue-tsc -b` clean on both Node runtimes.
- [x] `pnpm --filter @metasheet/web build` succeeds.
- [x] CI wiring: `integration-guard.yml` + `approval-web-guard.yml` path triggers and vitest lists updated for the 3 new components + specs.

Verification MD: `docs/development/integration-iu2b-section-extraction-dev-verification-20260707.md`

Not merging per instructions — leaving open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)