### PR TITLE
feat(attendance-web): UI-P1 768px — touch-friendly self-service surface

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -30981,5 +30981,19 @@ const holidaySectionBindings = {
     flex-direction: column;
     align-items: stretch;
   }
+
+  /* UI-P1 768px 紧凑自助面 (ui-p1-768 design-lock): touch-friendly landing for
+     the mobile/container self-service surface. */
+  .attendance__filters .attendance__field {
+    width: 100%;
+  }
+
+  .attendance__summary--stat {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .attendance__hero-timeline {
+    flex-wrap: wrap;
+  }
 }
 </style>

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -1630,4 +1630,17 @@ describe('Attendance self-service dashboard', () => {
 
     expect(container!.querySelector('[data-testid="attendance-hero-timeline"]')).toBeNull()
   })
+
+  it('UI-P1 768px targets exist: stat-card container class + filter fields (selector-preservation guard)', async () => {
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    // The 768px media rules key off these; assert the selectors' DOM targets
+    // survive (the media query itself is verified on-device per E4).
+    expect(container!.querySelector('.attendance__summary--stat'), 'stat-card container').toBeTruthy()
+    const filterFields = container!.querySelectorAll('.attendance__filters .attendance__field')
+    expect(filterFields.length, 'filter fields present').toBeGreaterThan(0)
+    expect(container!.querySelector('.attendance__hero-timeline'), 'hero timeline present').toBeTruthy()
+  })
 })

--- a/docs/development/attendance-ui-p1-768-design-lock-20260707.md
+++ b/docs/development/attendance-ui-p1-768-design-lock-20260707.md
@@ -1,0 +1,36 @@
+# 考勤 UI-P1 余量：768px 紧凑自助面 design-lock — 2026-07-07
+
+> **Status: RATIFIED（UI uplift 计划 P1「768px 紧凑打卡」;owner 2026-07-07「请继续 UI-P1 余量」;
+> E2 移动 landing 依赖此项——嵌入方向锁 E2 行）。** display-only CSS-only,零逻辑/接口/模板结构改动。
+
+## 1. 现状与缺口
+
+`AttendanceView.vue` 已有 768px 块覆盖大头（container padding / header 堆叠 / actions·btn 全宽 /
+focus·callout 堆叠 / hero-punch 堆叠 #3788）。移动/容器 landing 剩余触屏缺口:
+- **filters**（日期区间/组织/用户/刷新）:`flex-wrap` 会换行但字段**不全宽** → 手机上日期输入拥挤。
+- **stat 卡**（`--stat`,#3788 大数字四卡）:继承 `.attendance__summary` 的 `auto-fit minmax(120px)` →
+  ~700px 宽挤成一排窄卡,大数字可读性差 → 应 **2×2**。
+- hero 时间线（#3788）窄屏可换行。
+
+## 2. 修法（仅扩现有 768px 块,纯 CSS）
+
+- `.attendance__filters .attendance__field { width: 100% }`（字段全宽,触屏友好）。
+- `.attendance__summary--stat { grid-template-columns: repeat(2, 1fr) }`（大数字卡 2×2）。
+- `.attendance__hero-timeline { flex-wrap: wrap }`（窄屏节点换行不溢出）。
+- 全部落在既有 `@media (max-width: 768px)` 块内,值用 UF `--ms-*`（宽度/百分比除外）。
+
+## 3. 保全
+
+零模板/testid/copy/逻辑改动;既有测试（selfservice/hero）不受影响（CSS media 不改 DOM/断言）。
+非 overview 面（admin/reports）本媒体块已有规则,本刀只加 overview 自助相关三选择器,不动其余。
+
+## 4. 测试契约
+
+CSS-only 媒体查询无法在 jsdom 断言计算样式（既有惯例:CSS 改动靠 data-testid/类保全 + 人工/真机）。
+本刀加**存在性守卫**:selfservice 挂载测试断言 stat 卡容器带 `attendance__summary--stat` 类、
+filters 字段存在（确保选择器目标未被误删）——媒体规则本身随 E4 真机 smoke 目视验收。
+不新增可 mutation 的运行时守卫（纯 CSS）;验证 MD 记明"响应式目视验收留 E4"。
+
+## 5. 完成口径
+
+实现 → opus 对抗审阅 0 P1/P2（display/CSS-only）→ 三红线 → 验证 MD。FE 串行车道。


### PR DESCRIPTION
UI 计划 P1「768px 紧凑打卡」收尾——E2 移动 landing 依赖的自助面触屏适配。既有 768px 块已堆叠 header/actions/focus/hero(#3788),本刀补剩余触屏缺口(全落该 media 块,纯 CSS):filters 字段全宽、大数字 stat 卡 2×2、hero 时间线换行。

display-only 零模板/testid/copy/逻辑改动;选择器保全守卫测试断言三个 CSS 目标 DOM 存在(media 规则本身随 E4 真机目视验收,jsdom 无法断言计算媒体样式);selfservice 40/40 绿;tsc 清。设计锁随 PR。

审阅:opus 对抗审阅过 0 P1/P2 再合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)