### PR TITLE
feat(web): approval UX tails — StatusTag forceLocale (UF-7b) + admin delegation user pickers (B3-04-tail)

### DIFF
--- a/apps/web/src/components/status/StatusTag.vue
+++ b/apps/web/src/components/status/StatusTag.vue
@@ -25,6 +25,14 @@ const props = withDefaults(
     domain: StatusDomain
     status: string
     size?: 'sm' | 'md'
+    // UF-7b: escape hatch for the handful of admin views whose OTHER chrome is
+    // hardcoded-Chinese (never localized) — a StatusTag that follows the global useLocale()
+    // toggle would show an English badge inside an otherwise-monolingual-Chinese page under
+    // locale=en. Setting this pins the resolved label/tone to the given locale regardless of
+    // useLocale(); leaving it unset (the default) keeps following useLocale() exactly as
+    // before — bilingual views (ApprovalCenterView/ApprovalInboxView/AutomationExecutionsView/
+    // ApprovalMobileList/WorkflowHubView) must NOT set this.
+    forceLocale?: 'zh' | 'en'
   }>(),
   {
     size: 'md',
@@ -33,7 +41,9 @@ const props = withDefaults(
 
 const { isZh } = useLocale()
 
-const display = computed(() => resolveStatusDisplay(props.domain, props.status, isZh.value))
+const effectiveIsZh = computed(() => (props.forceLocale ? props.forceLocale === 'zh' : isZh.value))
+
+const display = computed(() => resolveStatusDisplay(props.domain, props.status, effectiveIsZh.value))
 
 function toneColors(tone: StatusTone): { background: string; color: string } {
   if (tone === 'neutral') {

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -8,7 +8,7 @@
       @back="goBack"
     >
       <template v-if="approval" #meta>
-        <StatusTag domain="approvalInstance" :status="approval.status" />
+        <StatusTag domain="approvalInstance" :status="approval.status" force-locale="zh" />
         <!-- B1-03: 已等待 aging — glanceable next to the status tag, only while still pending. -->
         <el-tag
           v-if="approval.status === 'pending'"

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -29,7 +29,7 @@
           <template #header>
             <div class="approval-new__info-header">
               <h2>{{ template.name }}</h2>
-              <StatusTag domain="approvalTemplate" :status="template.status" size="sm" />
+              <StatusTag domain="approvalTemplate" :status="template.status" size="sm" force-locale="zh" />
             </div>
           </template>
           <p v-if="template.description" class="approval-new__info-desc">{{ template.description }}</p>

--- a/apps/web/src/views/approval/DelegationSettingsView.vue
+++ b/apps/web/src/views/approval/DelegationSettingsView.vue
@@ -37,7 +37,7 @@
       </el-table-column>
       <el-table-column label="状态" width="150">
         <template #default="{ row }">
-          <StatusTag domain="delegation" :status="delegationDisplayStatus(row).status" />
+          <StatusTag domain="delegation" :status="delegationDisplayStatus(row).status" force-locale="zh" />
           <span v-if="delegationDisplayStatus(row).expiringSoon" class="expiring-soon-hint">即将到期</span>
         </template>
       </el-table-column>
@@ -53,13 +53,29 @@
       </el-table-column>
     </el-table>
 
+    <!-- B3-04-tail — this ADMIN dialog's 委托人/被委托人 fields now use the same real
+         ApprovalUserPicker MyDelegationView's 被委托人 field got in B3-04 D-2, replacing the raw
+         user-id text inputs. Unlike MyDelegationView (delegatee-only — delegator is forced to the
+         caller server-side), the admin can legitimately pick ANY user as delegator, so both
+         fields are pickable here. `data-testid` is overridden per-field (fallthrough onto the
+         picker's root el-select) since both pickers render in the same dialog and the component's
+         own default testid ("approval-user-picker") would collide between them; the override
+         reuses this dialog's PRE-EXISTING testids so no downstream selector needs to change. -->
     <el-dialog v-model="dialogOpen" title="新建委托" width="480px">
       <el-form label-width="92px">
         <el-form-item label="委托人">
-          <el-input v-model="form.delegatorUserId" placeholder="委托人用户 ID" data-testid="delegation-delegator" />
+          <ApprovalUserPicker
+            data-testid="delegation-delegator"
+            :model-value="form.delegatorUserId || null"
+            @update:model-value="form.delegatorUserId = $event ?? ''"
+          />
         </el-form-item>
         <el-form-item label="被委托人">
-          <el-input v-model="form.delegateeUserId" placeholder="被委托人用户 ID" data-testid="delegation-delegatee" />
+          <ApprovalUserPicker
+            data-testid="delegation-delegatee"
+            :model-value="form.delegateeUserId || null"
+            @update:model-value="form.delegateeUserId = $event ?? ''"
+          />
         </el-form-item>
         <el-form-item label="范围">
           <el-select v-model="form.scope" data-testid="delegation-scope">
@@ -91,6 +107,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
 import { useApprovalPermissions } from '../../approvals/permissions'
+import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
 import {
   listDelegations,
   createDelegation,

--- a/apps/web/src/views/approval/MyDelegationView.vue
+++ b/apps/web/src/views/approval/MyDelegationView.vue
@@ -19,7 +19,7 @@
       </el-table-column>
       <el-table-column label="状态" width="150">
         <template #default="{ row }">
-          <StatusTag domain="delegation" :status="delegationDisplayStatus(row).status" />
+          <StatusTag domain="delegation" :status="delegationDisplayStatus(row).status" force-locale="zh" />
           <span v-if="delegationDisplayStatus(row).expiringSoon" class="expiring-soon-hint">即将到期</span>
         </template>
       </el-table-column>

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -130,7 +130,7 @@
       </el-table-column>
       <el-table-column label="状态" width="100">
         <template #default="{ row }">
-          <StatusTag domain="approvalTemplate" :status="row.status" size="sm" />
+          <StatusTag domain="approvalTemplate" :status="row.status" size="sm" force-locale="zh" />
         </template>
       </el-table-column>
       <el-table-column label="最近更新" width="180">

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -8,7 +8,7 @@
       @back="goBack"
     >
       <template v-if="template" #meta>
-        <StatusTag domain="approvalTemplate" :status="template.status" />
+        <StatusTag domain="approvalTemplate" :status="template.status" force-locale="zh" />
       </template>
       <template v-if="template" #actions>
         <el-button

--- a/apps/web/tests/approvalDelegationView.spec.ts
+++ b/apps/web/tests/approvalDelegationView.spec.ts
@@ -39,6 +39,19 @@ vi.mock('element-plus', () => ({
   ElMessageBox: { confirm: (...a: unknown[]) => confirmSpy(...a) },
 }))
 
+// B3-04-tail — the 新建委托 dialog's 委托人/被委托人 fields now use the real ApprovalUserPicker
+// (participant directory), replacing the manual free-text id inputs. Mirrors the mock
+// myDelegationView.spec.ts uses for its (delegatee-only) picker. `vi.importActual` keeps every
+// other export of `../src/approvals/api` real.
+const searchApprovalDirectoryUsersSpy = vi.fn().mockResolvedValue([])
+vi.mock('../src/approvals/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/approvals/api')>('../src/approvals/api')
+  return {
+    ...actual,
+    searchApprovalDirectoryUsers: (...args: unknown[]) => searchApprovalDirectoryUsersSpy(...args),
+  }
+})
+
 type ColumnRegistryEntry = { key: string; prop?: string; label?: string; defaultSlot?: Slot }
 type ColumnRegistry = { columns: ColumnRegistryEntry[]; register: (entry: ColumnRegistryEntry) => void }
 const COLUMN_REGISTRY_KEY = Symbol('delegation-table-columns')
@@ -138,9 +151,48 @@ function passthrough(name: string, tag = 'div') {
 const ElForm = passthrough('ElForm', 'form')
 const ElFormItem = passthrough('ElFormItem', 'label')
 const ElInput = passthrough('ElInput', 'input')
-const ElSelect = passthrough('ElSelect', 'select')
-const ElOption = passthrough('ElOption', 'option')
-const ElDatePicker = passthrough('ElDatePicker', 'input')
+
+// B3-04-tail — unlike the other dialog fields (never interacted with pre-tail, since the dialog
+// itself was never opened by this spec), the new ApprovalUserPicker call sites need a REAL v-model
+// round trip to prove "selection writes the id into the form model" end-to-end, so ElSelect/
+// ElOption/ElDatePicker are upgraded here from inert passthroughs to minimal interactive stubs
+// (native <select>/<option>/<input> with actual value + change/input wiring). This also makes the
+// pre-existing 范围 (scope) select interactive, which is a strict capability superset — no
+// existing assertion in this file exercises it, so behavior for them is unchanged.
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: { modelValue: { type: [String, Number], default: undefined } },
+  emits: ['update:modelValue', 'visible-change'],
+  render() {
+    const attrs = this.$attrs as Record<string, unknown>
+    return h('select', {
+      'data-testid': attrs['data-testid'],
+      value: this.modelValue ?? '',
+      onChange: (e: Event) => {
+        const v = (e.target as HTMLSelectElement).value
+        this.$emit('update:modelValue', v || null)
+      },
+    }, this.$slots.default?.())
+  },
+})
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: { type: [String, Number], default: undefined } },
+  render() {
+    return h('option', { value: this.value }, this.label)
+  },
+})
+const ElDatePicker = defineComponent({
+  name: 'ElDatePicker',
+  props: { modelValue: String },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      value: this.modelValue ?? '',
+      onInput: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLInputElement).value),
+    })
+  },
+})
 
 // Visibility-gated, matching the real component: content only renders while open (the 新建委托
 // dialog is never opened in these tests, so its inner ElForm/ElInput/etc. never need stubs).
@@ -295,5 +347,79 @@ describe('DelegationSettingsView (admin 委托设置) — B2-05 status tag + dis
     expect(confirmSpy).toHaveBeenCalledTimes(1)
     expect(disableDelegationSpy).not.toHaveBeenCalled()
     expect(listDelegationsSpy).toHaveBeenCalledTimes(1) // no reload — disable never ran
+  })
+
+  // ---------------------------------------------------------------------------
+  // B3-04-tail — the 新建委托 dialog's 委托人/被委托人 fields now use the real ApprovalUserPicker
+  // instead of manual free-text id inputs (mirrors MyDelegationView's B3-04 D-2 delegatee field;
+  // this admin view additionally makes the delegator field pickable, since an admin may
+  // legitimately pick ANY user as delegator).
+  // ---------------------------------------------------------------------------
+  it('the 新建委托 dialog renders TWO distinct real ApprovalUserPickers (delegator + delegatee), not manual id inputs', async () => {
+    await mountView([])
+
+    const newButton = container!.querySelector('[data-testid="delegation-new"]') as HTMLButtonElement
+    newButton.click()
+    await flushUi()
+
+    const delegator = container!.querySelector('[data-testid="delegation-delegator"]')
+    const delegatee = container!.querySelector('[data-testid="delegation-delegatee"]')
+    expect(delegator).not.toBeNull()
+    expect(delegatee).not.toBeNull()
+    expect(delegator).not.toBe(delegatee)
+    // The old manual inputs were plain <input> elements; the picker's root is the (stubbed)
+    // <select> — this distinguishes "picker swapped in" from "same testid, still a text input".
+    expect(delegator!.tagName).toBe('SELECT')
+    expect(delegatee!.tagName).toBe('SELECT')
+  })
+
+  it('picking a delegator/delegatee writes the id into the form model; submit sends the unchanged CreateDelegationPayload shape (ids, not names)', async () => {
+    const users = [
+      { id: 'alice-id', name: 'Alice', email: 'alice@example.com' },
+      { id: 'bob-id', name: 'Bob', email: 'bob@example.com' },
+    ]
+    searchApprovalDirectoryUsersSpy.mockResolvedValue(users)
+    await mountView([])
+
+    const newButton = container!.querySelector('[data-testid="delegation-new"]') as HTMLButtonElement
+    newButton.click()
+    await flushUi()
+
+    const delegatorSelect = container!.querySelector('[data-testid="delegation-delegator"]') as HTMLSelectElement
+    const delegateeSelect = container!.querySelector('[data-testid="delegation-delegatee"]') as HTMLSelectElement
+
+    delegatorSelect.value = 'alice-id'
+    delegatorSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    delegateeSelect.value = 'bob-id'
+    delegateeSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    // Scope stays the default ('all'), so only the start/end date pickers remain to fill — they
+    // are the only plain <input> elements left inside the dialog (the pickers render as <select>).
+    const dateInputs = container!.querySelectorAll('[data-el-dialog] input') as NodeListOf<HTMLInputElement>
+    expect(dateInputs.length).toBe(2)
+    const startAt = '2026-07-01T09:00'
+    const endAt = '2026-07-02T09:00'
+    dateInputs[0].value = startAt
+    dateInputs[0].dispatchEvent(new Event('input'))
+    dateInputs[1].value = endAt
+    dateInputs[1].dispatchEvent(new Event('input'))
+    await flushUi()
+
+    const submitButton = container!.querySelector('[data-testid="delegation-submit"]') as HTMLButtonElement
+    submitButton.click()
+    await flushUi()
+
+    expect(createDelegationSpy).toHaveBeenCalledTimes(1)
+    expect(createDelegationSpy).toHaveBeenCalledWith({
+      delegatorUserId: 'alice-id',
+      delegateeUserId: 'bob-id',
+      scope: 'all',
+      scopeTemplateId: null,
+      startAt: new Date(startAt).toISOString(),
+      endAt: new Date(endAt).toISOString(),
+    })
   })
 })

--- a/apps/web/tests/statusTag.spec.ts
+++ b/apps/web/tests/statusTag.spec.ts
@@ -79,10 +79,10 @@ describe('StatusTag.vue (mounted)', () => {
     container = null
   })
 
-  function mount(domain: string, status: string, size?: 'sm' | 'md') {
+  function mount(domain: string, status: string, size?: 'sm' | 'md', forceLocale?: 'zh' | 'en') {
     container = document.createElement('div')
     document.body.appendChild(container)
-    app = createApp({ render: () => h(StatusTag, { domain, status, size }) })
+    app = createApp({ render: () => h(StatusTag, { domain, status, size, forceLocale }) })
     app.mount(container)
     return container
   }
@@ -122,6 +122,40 @@ describe('StatusTag.vue (mounted)', () => {
     setLocale('zh-CN')
     await nextTick()
     expect(el.textContent).toBe('生效中')
+  })
+
+  it('UF-7b: forceLocale="zh" renders the zh label even while the global locale is en', async () => {
+    const { setLocale } = useLocale()
+    setLocale('en')
+    const c = mount('delegation', '生效中', undefined, 'zh')
+    await nextTick()
+    const el = c.querySelector('.ms-status-tag') as HTMLElement
+    expect(el.textContent).toBe('生效中')
+    expect(el.getAttribute('data-tone')).toBe('success')
+    setLocale('zh-CN')
+  })
+
+  it('UF-7b: forceLocale="en" renders the en label even while the global locale is zh', async () => {
+    const c = mount('approvalInstance', 'approved', undefined, 'en')
+    await nextTick()
+    const el = c.querySelector('.ms-status-tag') as HTMLElement
+    expect(el.textContent).toBe('Approved')
+  })
+
+  it('UF-7b: leaving forceLocale unset keeps following useLocale() exactly as before', async () => {
+    const { setLocale } = useLocale()
+    const c = mount('approvalInstance', 'approved')
+    await nextTick()
+    const el = c.querySelector('.ms-status-tag') as HTMLElement
+    expect(el.textContent).toBe('已通过')
+
+    setLocale('en')
+    await nextTick()
+    expect(el.textContent).toBe('Approved')
+
+    setLocale('zh-CN')
+    await nextTick()
+    expect(el.textContent).toBe('已通过')
   })
 
   it('guard: the rendered inline style references only CSS custom properties, never a hardcoded hex', async () => {


### PR DESCRIPTION
Two owner-flagged follow-up tails from the approval line, both presentation-only:

**UF-7b**: `StatusTag` gains an optional `forceLocale` escape hatch — the 6 hardcoded-Chinese admin views (TemplateCenter/TemplateDetail/ApprovalNew/ApprovalDetail/MyDelegation/DelegationSettings) pin `force-locale="zh"` so an en-locale user no longer sees a lone English badge inside otherwise-Chinese chrome. Unset = follows `useLocale()` exactly as before; bilingual views untouched (call-site table in commit body).

**B3-04-tail**: the ADMIN delegation dialog's raw delegator/delegatee id inputs → real `ApprovalUserPicker`s (mirrors MyDelegationView's B3-04 D-2 wiring; both fields pickable in admin scope; form model/payload byte-identical; pre-existing testids preserved via attr-merge).

Verification: vue-tsc 0 · build green · 7 spec files / **180 tests** green (incl. UF-6 style guard) · lint clean · forceLocale mutation-check RED then reverted · push re-read verified.

Implemented by a Sonnet agent per model-split policy; reviewed by the main loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)