### PR TITLE
docs(approval): as-built reconciliation — five checklist drifts flipped with PR provenance

### DIFF
--- a/docs/development/approval-automation-third-batch-ballot-20260702.md
+++ b/docs/development/approval-automation-third-batch-ballot-20260702.md
@@ -125,7 +125,7 @@ turning anything on.
 | Q9 | Non-approved outcomes | Project all terminal outcomes to the neutral read-model; source-record W7 semantics stay separate. | ⏸ |
 | Q10 | Base placement | One system-owned base/sheet per template family, provisioned lazily; cross-base projection is a non-goal in the first slice. | ⏸ |
 
-**T3-6 — HELD 2026-07-05 (owner vote): all lines ⏸ hold.** The S-band "approval as first-class multitable records"
+**T3-6 — HELD 2026-07-05 (owner vote at the time); SUPERSEDED by later owner decisions（2026-07-07 对账）**: 投影 base+admin fence #3537（A-lock as-built）→ per-row 锁 #3687 RATIFIED-Plan-A → T36-1 #3758 + T36-2 #3779 落地。现行唯一 🔒 = T36-3（中间审批人/cc）。原文保留如下供溯源：**all lines ⏸ hold.** The S-band "approval as first-class multitable records"
 strategic line is deliberately NOT started — no projection work begins until the owner explicitly un-holds. Held to
 keep the broadest data-model line from being opened prematurely by an autonomous loop or a session.
 

--- a/docs/development/approval-complex-graph-author-ui-todo-20260623.md
+++ b/docs/development/approval-complex-graph-author-ui-todo-20260623.md
@@ -112,8 +112,8 @@
   pending a concrete scenario).
 - ⚠️ **`joinMode='any'` authoring was listed here / in design-lock §7 as deferred, but G-3 SHIPS it**
   because the empirical backend pre-check (above) shows `'any'` is accepted + runtime-executed; the
-  doc's deferral premise was factually wrong. Re-scoped OUT of "out of scope" — pending owner
-  ratification (see the G-3 PR body). The OTHER parallel limits (nested parallel, editing
+  doc's deferral premise was factually wrong. Re-scoped OUT of "out of scope"; **G-3 已发货（as-built）**，
+  owner 对该 re-scope 的追认仍挂账（owner 菜单项，见 G-3 PR body；2026-07-07 对账标注）. The OTHER parallel limits (nested parallel, editing
   branches/joinNodeKey topology) remain out of scope.
 - ✅ **FOLLOW-UP DONE — cc / condition / parallel config unknown-key fail-closed.**
   `complexNodeConfigHasBackendDrop` generalises the approval shape-check to EVERY node type: cc →

--- a/docs/development/approval-dingtalk-one-tap-action-design-lock-20260705.md
+++ b/docs/development/approval-dingtalk-one-tap-action-design-lock-20260705.md
@@ -131,17 +131,20 @@ find-then-patch 同族纪律）。台账行不存在或 `card_state != 'sent'` �
 ## 8. Gated TODO checklist
 
 - ✅ **A-0** 本 design-lock 评审定稿（owner 三处承重修正已吸收）
-- ⬜ **A-1** 台账迁移 + 模型（`dingtalk_approval_card_deliveries`，含状态机约束与索引）
-- ⬜ **A-2** `action_card` 发送路径 + 深链 token + 写台账（automation 动作配置沿用既有
+- ✅ **A-1** 台账迁移 + 模型（#3610）（`dingtalk_approval_card_deliveries`，含状态机约束与索引）
+- ✅ **A-2** `action_card` 发送路径（#3647） + 深链 token + 写台账（automation 动作配置沿用既有
   meta-automation 编辑面，新增「审批卡片」投递形态）
-- ⬜ **A-3** 移动极简决策页 + `/launch` 登录/绑定接入（含未绑定 fail-closed 引导）
-- ⬜ **A-4** card-delivery 动作端点 `POST /api/approval-card-deliveries/:deliveryId/actions` +
+- ✅ **A-3** 移动极简决策页（#3647） + `/launch` 登录/绑定接入（含未绑定 fail-closed 引导）
+- ✅ **A-4** card-delivery 动作端点（#3647） `POST /api/approval-card-deliveries/:deliveryId/actions` +
   channel 注入 wrapper（§4）+ 台账状态回写（raw `/actions` 直连禁令的 tripwire 测试随此项落）
-- ⬜ **A-5** 验证：单测（token/台账状态机/wrapper fail-closed 矩阵）+ 集成（伪造 instanceId 回调
-  被忽略的 tripwire）+ 生产构建真钉钉 UAT
+- 🟡 **A-5** 验证：CI 可测部分已收口（#3665/#3669：单测/台账状态机/wrapper fail-closed 矩阵/伪造
+  instanceId tripwire 全绿；配置面已页面自助化 #3690/#3693/#3698/#3707）；**真钉钉 UAT 仍 ⬜ =
+  owner 实跑（跑通前不写「已验收」）**
 - ⬜ **A-6**（增强，可后置）钉钉容器内 JSAPI 免登
 - 🔒 **B-0** Slice B opt-in gate（A-5 验收 + owner 点名解锁）
 - 🔒 **B-1** Stream worker 基建（env-gate 注册 / 重连 / 消费幂等）
 - 🔒 **B-2** 互动卡片模板注册 + 投放（outTrackId=台账 id）
 - 🔒 **B-3** 回调 → wrapper → 卡片原地终态更新（含冲突刷新真实状态）
 - 🔒 **B-4** 并发/重放/陈旧节点矩阵测试 + 生产构建真钉钉 UAT
+
+> **as-built 对账（2026-07-07）**：A-1..A-4 于 #3610/#3647 落地时未同步翻转本清单（收官口径纪律漏扫），随本对账 PR 补翻。

--- a/docs/development/approval-participant-directory-endpoint-design-lock-20260705.md
+++ b/docs/development/approval-participant-directory-endpoint-design-lock-20260705.md
@@ -42,5 +42,7 @@
 ## Checklist
 
 - ✅ D-0 本锁（owner 权限口径修正已并入）
-- ⬜ D-1 端点 + 守卫 + 测试
-- ⬜ D-2 四处前端接线 + tripwire
+- ✅ D-1 端点 + 守卫 + 测试（#3664）
+- ✅ D-2 四处前端接线 + tripwire（#3672；含 rbacGuardAny read/write/act 三权任一的 owner 修正）
+
+> **as-built 对账（2026-07-07）**：D-1/D-2 落地时未翻转，随对账 PR 补翻（见 approval-ux-parity-completion-verification-20260706.md）。

--- a/docs/development/approval-visual-authoring-canvas-todo-20260624.md
+++ b/docs/development/approval-visual-authoring-canvas-todo-20260624.md
@@ -5,7 +5,7 @@ Discipline: each phase is a SEPARATE opt-in. 🔒 = gated (needs explicit go); �
 predecessor lands; ✅ = shipped. Nothing past D-0 starts without the design-lock RATIFIED + a per-phase go.
 
 ## D-0 — design-lock
-- ⬜ Ratify scope / principles / phasing (this doc + the design-lock). **Awaiting owner ratification.**
+- ✅ Ratify scope / principles / phasing — **ratified-in-effect**: D-1..D-6 全部按 per-phase go 实建落地（本文件下方各阶段 ✅ 即证）；D-0 勾选栏漏翻，2026-07-07 对账补翻。
 
 ## D-1 — visual canvas render  ✅ (bespoke SVG/HTML; library spike decided = bespoke for testability)
 - ✅ `graphLayout.ts` longest-path layered layout (pure) → positioned node boxes + SVG edges, topology


### PR DESCRIPTION
Pool-inventory sweep found five landed-but-unflipped checklist records on the approval line (the exact closeout-drift class the owner flagged on #3690). Each flipped with dated notes + PR provenance, originals preserved:

1. **one-tap lock** A-1..A-4 → ✅ (#3610/#3647); A-5 → 🟡 split (CI-testable portion closed #3665/#3669 + config self-service #3690-#3707; **real-DingTalk UAT stays ⬜ owner-open**)
2. **participant-directory lock** D-1/D-2 → ✅ (#3664/#3672)
3. **canvas TODO** D-0 → ratified-in-effect (D-1..D-6 all shipped under per-phase goes)
4. **T3-6 ballot** HELD → superseded note (#3537 → #3687 RATIFIED-A → #3758/#3779; only T36-3 stays 🔒), original vote preserved
5. **complex-graph** joinMode='any' → shipped-as-built, owner retro-ack kept visible as open menu item

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)