### PR TITLE
feat(web): G-B2-19 readable condition-branch summaries — one pure fn, four surfaces

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -52,6 +52,10 @@ on:
       - 'apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts'
       - 'apps/web/tests/approval-graph-topology-edit.test.ts'
       - 'apps/web/tests/approval-graph-layout.test.ts'
+      # G-B2-19: readable condition-branch summaries — conditionSummary.ts pure fn consumed by
+      # authoring nodeConfigSummary + editor branch heads + the upcomingNodes/graphSummary chain.
+      - 'apps/web/src/approvals/conditionSummary.ts'
+      - 'apps/web/tests/approval-condition-summary.test.ts'
       - 'apps/web/tests/amountAutoSum.test.ts'
       - 'apps/web/tests/useAutoSumTotal.test.ts'
       - 'apps/web/tests/lineDerivation.test.ts'
@@ -159,6 +163,10 @@ on:
       - 'apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts'
       - 'apps/web/tests/approval-graph-topology-edit.test.ts'
       - 'apps/web/tests/approval-graph-layout.test.ts'
+      # G-B2-19: readable condition-branch summaries — conditionSummary.ts pure fn consumed by
+      # authoring nodeConfigSummary + editor branch heads + the upcomingNodes/graphSummary chain.
+      - 'apps/web/src/approvals/conditionSummary.ts'
+      - 'apps/web/tests/approval-condition-summary.test.ts'
       - 'apps/web/tests/amountAutoSum.test.ts'
       - 'apps/web/tests/useAutoSumTotal.test.ts'
       - 'apps/web/tests/lineDerivation.test.ts'
@@ -314,4 +322,4 @@ jobs:
         # files and asserts zero static style= attributes and zero hex/rgb() literals inside
         # <style> blocks (var() references + transparent/inherit/currentColor/none allowed);
         # had no gate before this wiring.
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView ui-foundation-style-guard uiFoundationTexture --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView ui-foundation-style-guard uiFoundationTexture --reporter=dot

--- a/apps/web/src/approvals/assigneeSource.ts
+++ b/apps/web/src/approvals/assigneeSource.ts
@@ -1,4 +1,7 @@
+import { summarizeConditionBranch } from './conditionSummary'
 import type {
+  ConditionNodeConfig,
+  FormSchema,
   ApprovalAssigneeSource,
   ApprovalNode,
   ApprovalNodeConfig,
@@ -42,7 +45,7 @@ export function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
  * fixed one-line description; `start` (never an "upcoming" node in a valid DAG) falls through to
  * `''`.
  */
-export function nodeAssigneeSourceSummary(node: ApprovalNode): string {
+export function nodeAssigneeSourceSummary(node: ApprovalNode, schema?: FormSchema | null): string {
   if (node.type === 'approval') {
     const cfg = node.config as ApprovalNodeConfig
     const sources = cfg.assigneeSources ?? []
@@ -56,7 +59,17 @@ export function nodeAssigneeSourceSummary(node: ApprovalNode): string {
     const cfg = node.config as CcNodeConfig
     return `抄送${cfg.targetType === 'role' ? '角色' : '成员'}`
   }
-  if (node.type === 'condition') return '按条件进入后续分支'
+  if (node.type === 'condition') {
+    // G-B2-19: with a schema in hand, the honest generic line gains the readable branch
+    // predicates (capped at two — this is a one-line flow chip, not the authoring editor).
+    const branches = (node.config as ConditionNodeConfig | undefined)?.branches ?? []
+    if (schema && branches.length > 0) {
+      const shown = branches.slice(0, 2).map((branch) => summarizeConditionBranch(branch, schema))
+      const suffix = branches.length > 2 ? '；…' : ''
+      return `按条件进入后续分支：${shown.join('；')}${suffix}`
+    }
+    return '按条件进入后续分支'
+  }
   if (node.type === 'parallel') return '进入并行分支'
   if (node.type === 'end') return '流程结束'
   return ''

--- a/apps/web/src/approvals/conditionSummary.ts
+++ b/apps/web/src/approvals/conditionSummary.ts
@@ -1,0 +1,79 @@
+import type { ConditionBranch, ConditionNodeConfig, ConditionRule, FormSchema } from '../types/approval'
+
+// G-B2-19 (benchmark §7.2) — readable condition-branch summaries. PURE logic module (no .vue /
+// Element Plus import) so it runs under the approval-web-guard vitest gate, mirroring the sibling
+// approvals/*.ts helpers. One function family, consumed by every surface that previously rendered
+// raw `fieldId operator value` / bare edge keys:
+//   1. TemplateAuthoringView `nodeConfigSummary` (read-only per-node descriptor)
+//   2. TemplateAuthoringView condition-editor branch headers (live summary while editing)
+//   3. TemplateDetailView / detail-side node preview (via the same nodeConfigSummary idiom)
+//   4. `assigneeSource.nodeAssigneeSourceSummary`'s condition line (ApprovalNewView flow preview +
+//      ApprovalDetailView upcoming-nodes synthesis) — enriched only when a schema is available.
+// DISPLAY ONLY: never consumed by any graph write/normalize path (read-only-never-flatten floor).
+
+/** zh operator vocabulary — MUST cover the full ConditionRule['operator'] union. */
+const OPERATOR_ZH: Record<ConditionRule['operator'], string> = {
+  eq: '=',
+  neq: '≠',
+  gt: '>',
+  gte: '≥',
+  lt: '<',
+  lte: '≤',
+  in: '属于',
+  isEmpty: '为空',
+}
+
+function fieldLabel(fieldId: string, schema?: FormSchema | null): string {
+  const label = schema?.fields?.find((field) => field.id === fieldId)?.label
+  // Honest fallback: no schema / unknown field → the raw id (never blank, never throws).
+  return label && label.trim() ? label : fieldId
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined || value === null) return ''
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'boolean') return value ? '是' : '否'
+  if (Array.isArray(value)) return value.map((entry) => formatValue(entry)).join('、')
+  if (typeof value === 'string') return `「${value}」`
+  // Objects and anything exotic: JSON — still honest, still never throws.
+  try {
+    return JSON.stringify(value) ?? ''
+  } catch {
+    return String(value)
+  }
+}
+
+/** One rule → 「金额 > 5000」 /「状态 属于 「a」、「b」」 /「备注 为空」. */
+export function summarizeConditionRule(rule: ConditionRule, schema?: FormSchema | null): string {
+  const label = fieldLabel(rule.fieldId, schema)
+  // Unknown operator (forward-compat / malformed data): raw operator fallback, never throw.
+  const op = OPERATOR_ZH[rule.operator] ?? String(rule.operator)
+  if (rule.operator === 'isEmpty') return `${label} 为空`
+  const value = formatValue(rule.value)
+  return value ? `${label} ${op} ${value}` : `${label} ${op}`
+}
+
+/**
+ * One branch → its readable predicate. Rules joined 且/或 per the branch conjunction; a
+ * formula-mode branch shows its expression verbatim (公式 prefix); an empty branch is honest.
+ */
+export function summarizeConditionBranch(branch: ConditionBranch, schema?: FormSchema | null): string {
+  if (branch.formula?.expression) return `公式：${branch.formula.expression}`
+  const rules = branch.rules ?? []
+  if (rules.length === 0) return '（无规则）'
+  const joiner = (branch.conjunction ?? 'and') === 'or' ? ' 或 ' : ' 且 '
+  return rules.map((rule) => summarizeConditionRule(rule, schema)).join(joiner)
+}
+
+/**
+ * Whole condition node → one readable line per branch (+ the default fall-through). The edge key
+ * stays visible as secondary provenance — authors still need to correlate with topology — but the
+ * predicate leads.
+ */
+export function summarizeConditionNode(config: ConditionNodeConfig, schema?: FormSchema | null): string[] {
+  const lines = (config.branches ?? []).map(
+    (branch) => `分支「${summarizeConditionBranch(branch, schema)}」→ ${branch.edgeKey}`,
+  )
+  if (config.defaultEdgeKey) lines.push(`默认分支 → ${config.defaultEdgeKey}`)
+  return lines
+}

--- a/apps/web/src/approvals/graphSummary.ts
+++ b/apps/web/src/approvals/graphSummary.ts
@@ -1,4 +1,4 @@
-import type { ApprovalGraph } from '../types/approval'
+import type { ApprovalGraph , FormSchema } from '../types/approval'
 import { buildUpcomingNodes, type UpcomingApprovalNode } from './upcomingNodes'
 
 /**
@@ -31,8 +31,8 @@ export type ApprovalFlowStep = UpcomingApprovalNode
  * immediately (e.g. a single-node graph with no outgoing edge, or an empty graph) — never throws
  * on a malformed/empty graph.
  */
-export function summarizeApprovalFlow(graph: ApprovalGraph): ApprovalFlowStep[] {
+export function summarizeApprovalFlow(graph: ApprovalGraph, schema?: FormSchema | null): ApprovalFlowStep[] {
   const startKey = graph.nodes.find((node) => node.type === 'start')?.key
   if (!startKey) return []
-  return buildUpcomingNodes(graph, startKey)
+  return buildUpcomingNodes(graph, startKey, schema)
 }

--- a/apps/web/src/approvals/upcomingNodes.ts
+++ b/apps/web/src/approvals/upcomingNodes.ts
@@ -1,4 +1,4 @@
-import type { ApprovalGraph, ApprovalNode } from '../types/approval'
+import type { ApprovalGraph, ApprovalNode , FormSchema } from '../types/approval'
 import { nodeAssigneeSourceSummary } from './assigneeSource'
 
 export interface UpcomingApprovalNode {
@@ -26,7 +26,7 @@ export interface UpcomingApprovalNode {
  * authored/validated as DAGs (see `graphLayout.graphHasCycle`) — so this walk stays safe even
  * against a malformed one.
  */
-export function buildUpcomingNodes(graph: ApprovalGraph, currentNodeKey: string): UpcomingApprovalNode[] {
+export function buildUpcomingNodes(graph: ApprovalGraph, currentNodeKey: string, schema?: FormSchema | null): UpcomingApprovalNode[] {
   const nodesByKey = new Map(graph.nodes.map((node) => [node.key, node]))
   const outgoingByNode = new Map<string, string[]>()
   for (const edge of graph.edges) {
@@ -50,7 +50,7 @@ export function buildUpcomingNodes(graph: ApprovalGraph, currentNodeKey: string)
     result.push({
       key: node.key,
       name: node.name?.trim() || node.key,
-      assigneeSummary: nodeAssigneeSourceSummary(node),
+      assigneeSummary: nodeAssigneeSourceSummary(node, schema),
       isConditional: node.type === 'condition',
     })
     if (node.type === 'end') break

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -940,7 +940,7 @@ const upcomingTimelineNodes = computed<UpcomingApprovalNode[]>(() => {
   if (!currentNodeKey) return []
   const graph = pinnedGraph.value
   if (!graph) return []
-  return buildUpcomingNodes(graph, currentNodeKey)
+  return buildUpcomingNodes(graph, currentNodeKey, approval.value?.formSchema ?? null)
 })
 
 const actionDialogVisible = ref(false)

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -420,7 +420,7 @@ const visibleFieldIds = computed(() => visibleFields.value.map((field) => field.
 const flowPreviewSteps = computed<ApprovalFlowStep[]>(() => {
   const graph = template.value?.approvalGraph
   if (!graph) return []
-  return summarizeApprovalFlow(graph)
+  return summarizeApprovalFlow(graph, template.value?.formSchema ?? null)
 })
 
 // Detail-row auto-sum (design-lock #3189, Gate B): when the template declares amountConsistencyCheck the

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -545,7 +545,7 @@
                 data-testid="approval-condition-branch"
               >
                 <div class="template-authoring__condition-branch-head">
-                  <span>分支 → {{ branch.edgeKey }}</span>
+                  <span>分支「{{ liveBranchSummary(branch) }}」→ {{ branch.edgeKey }}</span>
                   <el-select
                     :model-value="branch.predicateMode"
                     size="small"
@@ -1157,6 +1157,7 @@ import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 import { Plus } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useApprovalPermissions } from '../../approvals/permissions'
+import { summarizeConditionBranch, summarizeConditionNode } from '../../approvals/conditionSummary'
 import {
   createTemplate,
   dryRunApprovalConditionFormula,
@@ -1293,14 +1294,8 @@ function nodeConfigSummary(node: ApprovalNode): string[] {
   const config = node.config as Record<string, unknown>
   if (node.type === 'condition') {
     const cfg = config as unknown as ConditionNodeConfig
-    const lines = (cfg.branches ?? []).map((branch) => {
-      const rules = (branch.rules ?? [])
-        .map((rule) => `${rule.fieldId} ${rule.operator}${rule.value === undefined ? '' : ` ${JSON.stringify(rule.value)}`}`)
-        .join(` ${branch.conjunction ?? 'and'} `)
-      return `分支 → ${branch.edgeKey}：${rules || '（无规则）'}`
-    })
-    if (cfg.defaultEdgeKey) lines.push(`默认分支 → ${cfg.defaultEdgeKey}`)
-    return lines
+    // G-B2-19: readable predicates（「金额 > 5000」）lead; edge keys stay as secondary provenance.
+    return summarizeConditionNode(cfg, buildFormSchema(draft.value))
   }
   if (node.type === 'parallel') {
     const cfg = config as unknown as ParallelNodeConfig
@@ -1328,6 +1323,20 @@ function nodeConfigSummary(node: ApprovalNode): string[] {
 // The editable model lives on `draft.conditionEdits[nodeKey]`, seeded 1:1 from the preserved
 // condition nodes. The controls below mutate ONLY rules / conjunction / defaultEdgeKey;
 // `buildApprovalGraph` re-applies them onto a COPY of the graph (all other nodes + edges untouched).
+// G-B2-19: live readable summary for a branch being edited (adapter from the edit model to the
+// persisted ConditionBranch shape; display only).
+function liveBranchSummary(branch: ConditionBranchEdit): string {
+  return summarizeConditionBranch(
+    {
+      edgeKey: branch.edgeKey,
+      rules: branch.rules.map((rule) => ({ fieldId: rule.fieldId, operator: rule.operator, ...(rule.value === undefined ? {} : { value: rule.value }) })),
+      conjunction: branch.conjunction,
+      ...(branch.predicateMode === 'formula' && branch.formulaExpression ? { formula: { expression: branch.formulaExpression } } : {}),
+    },
+    buildFormSchema(draft.value),
+  )
+}
+
 function conditionEditFor(nodeKey: string): ConditionNodeEdit | undefined {
   return draft.value.conditionEdits?.[nodeKey]
 }

--- a/apps/web/tests/approval-condition-summary.test.ts
+++ b/apps/web/tests/approval-condition-summary.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  summarizeConditionBranch,
+  summarizeConditionNode,
+  summarizeConditionRule,
+} from '../src/approvals/conditionSummary'
+import { CONDITION_RULE_OPERATORS } from '../src/approvals/conditionEdit'
+import type { ConditionRule, FormSchema } from '../src/types/approval'
+
+// G-B2-19 — readable condition summaries. Pure-logic matrix: every operator in the runtime
+// vocabulary, 且/或 joining, formula mode, label fallback, value formatting, never-throw.
+
+const SCHEMA: FormSchema = {
+  fields: [
+    { id: 'amount', type: 'number', label: '金额' },
+    { id: 'status', type: 'select', label: '状态' },
+    { id: 'urgent', type: 'switch', label: '加急' },
+  ],
+} as FormSchema
+
+describe('summarizeConditionRule', () => {
+  it('covers EVERY runtime operator (vocabulary lockstep with conditionEdit)', () => {
+    const rendered = CONDITION_RULE_OPERATORS.map((operator) =>
+      summarizeConditionRule({ fieldId: 'amount', operator, value: 5000 } as ConditionRule, SCHEMA),
+    )
+    expect(rendered).toEqual([
+      '金额 = 5000',
+      '金额 ≠ 5000',
+      '金额 > 5000',
+      '金额 ≥ 5000',
+      '金额 < 5000',
+      '金额 ≤ 5000',
+      '金额 属于 5000',
+      '金额 为空', // isEmpty ignores value
+    ])
+  })
+
+  it('formats values by type: string quoted, boolean 是/否, array joined', () => {
+    expect(summarizeConditionRule({ fieldId: 'status', operator: 'eq', value: 'approved' }, SCHEMA))
+      .toBe('状态 = 「approved」')
+    expect(summarizeConditionRule({ fieldId: 'urgent', operator: 'eq', value: true }, SCHEMA))
+      .toBe('加急 = 是')
+    expect(summarizeConditionRule({ fieldId: 'status', operator: 'in', value: ['a', 'b'] }, SCHEMA))
+      .toBe('状态 属于 「a」、「b」')
+  })
+
+  it('falls back honestly: unknown field → raw id; no schema → raw id; unknown operator → raw op; never throws', () => {
+    expect(summarizeConditionRule({ fieldId: 'ghost', operator: 'gt', value: 1 }, SCHEMA)).toBe('ghost > 1')
+    expect(summarizeConditionRule({ fieldId: 'amount', operator: 'gt', value: 1 }, null)).toBe('amount > 1')
+    expect(summarizeConditionRule({ fieldId: 'amount', operator: 'between' as never, value: 1 }, SCHEMA)).toBe('金额 between 1')
+    expect(summarizeConditionRule({ fieldId: 'amount', operator: 'eq', value: { odd: true } } as ConditionRule, SCHEMA))
+      .toBe('金额 = {"odd":true}')
+  })
+})
+
+describe('summarizeConditionBranch', () => {
+  it('joins rules with 且 (and, the default) and 或 (or)', () => {
+    const rules: ConditionRule[] = [
+      { fieldId: 'amount', operator: 'gt', value: 5000 },
+      { fieldId: 'urgent', operator: 'eq', value: true },
+    ]
+    expect(summarizeConditionBranch({ edgeKey: 'e1', rules }, SCHEMA)).toBe('金额 > 5000 且 加急 = 是')
+    expect(summarizeConditionBranch({ edgeKey: 'e1', rules, conjunction: 'or' }, SCHEMA)).toBe('金额 > 5000 或 加急 = 是')
+  })
+
+  it('formula mode shows the expression verbatim; empty branch is honest', () => {
+    expect(summarizeConditionBranch({ edgeKey: 'e1', rules: [], formula: { expression: 'amount * 2 > 100' } }, SCHEMA))
+      .toBe('公式：amount * 2 > 100')
+    expect(summarizeConditionBranch({ edgeKey: 'e1', rules: [] }, SCHEMA)).toBe('（无规则）')
+  })
+})
+
+describe('summarizeConditionNode', () => {
+  it('one line per branch (predicate leads, edge key stays as provenance) + default fall-through', () => {
+    const lines = summarizeConditionNode(
+      {
+        branches: [
+          { edgeKey: 'edge_1', rules: [{ fieldId: 'amount', operator: 'gt', value: 5000 }] },
+          { edgeKey: 'edge_2', rules: [] },
+        ],
+        defaultEdgeKey: 'edge_3',
+      },
+      SCHEMA,
+    )
+    expect(lines).toEqual([
+      '分支「金额 > 5000」→ edge_1',
+      '分支「（无规则）」→ edge_2',
+      '默认分支 → edge_3',
+    ])
+  })
+
+  it('empty/absent branches → only the default line (or nothing at all); never throws', () => {
+    expect(summarizeConditionNode({ branches: [] }, SCHEMA)).toEqual([])
+    expect(summarizeConditionNode({ branches: [], defaultEdgeKey: 'e9' }, SCHEMA)).toEqual(['默认分支 → e9'])
+  })
+})


### PR DESCRIPTION
First slice of the batch-2 G pool (§7.2, gate:none):「金额 > 5000」replaces raw `edge_2` / `amount gt 5000` renders.

- **`approvals/conditionSummary.ts`** (pure, guard-gate-compatible): full operator vocabulary in LOCKSTEP with `conditionEdit.CONDITION_RULE_OPERATORS` (drift fails the matrix test); 且/或 joining; formula branches verbatim; honest fallbacks (unknown field → raw id, unknown op → raw op, no schema → ids); never throws.
- **Four surfaces**: TemplateAuthoringView read-only node summaries + condition-editor live branch heads; `assigneeSource` condition line enriched (capped at 2 branches) with `schema?` threaded through `buildUpcomingNodes`/`summarizeApprovalFlow` — ApprovalNewView flow preview and ApprovalDetailView upcoming-nodes consume it. Param optional → all existing callers byte-compatible.
- **Display only** — zero graph write-path touch (read-only-never-flatten floor).

Verification: 161/161 across matrix + affected suites · 且/或-swap mutation → RED then precise revert · vue-tsc 0 · build green · lint clean · two-point CI wiring.

Main-loop implementation (agent lane died on session limit; resumed directly per the resurrection protocol — clean worktree, no salvage needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)