### PR TITLE
feat(web): IU-3 read-source config wizard — four-step el-steps, preset cards, expert-mode retention (design-lock #3797)

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -26,6 +26,8 @@ on:
       - 'apps/web/src/services/integration/errorCodeLabels.ts'
       - 'apps/web/src/services/integration/fieldHints.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
+      - 'apps/web/src/components/integration/IntegrationReadSourceWizard.vue'
+      - 'apps/web/src/services/integration/readSourceModePresets.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
       - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
@@ -50,6 +52,8 @@ on:
       - 'apps/web/tests/integrationErrorCodeLabels.spec.ts'
       - 'apps/web/tests/fieldHints.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts'
+      - 'apps/web/tests/IntegrationReadSourceWizard.spec.ts'
+      - 'apps/web/tests/readSourceModePresets.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
@@ -79,6 +83,8 @@ on:
       - 'apps/web/src/services/integration/errorCodeLabels.ts'
       - 'apps/web/src/services/integration/fieldHints.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
+      - 'apps/web/src/components/integration/IntegrationReadSourceWizard.vue'
+      - 'apps/web/src/services/integration/readSourceModePresets.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
       - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
@@ -103,6 +109,8 @@ on:
       - 'apps/web/tests/integrationErrorCodeLabels.spec.ts'
       - 'apps/web/tests/fieldHints.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts'
+      - 'apps/web/tests/IntegrationReadSourceWizard.spec.ts'
+      - 'apps/web/tests/readSourceModePresets.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
@@ -169,3 +177,4 @@ jobs:
       - name: Run integration web guard specs (targeted)
         run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot
         run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints readSourceModePresets IntegrationReadSourceConfigPanel IntegrationReadSourceWizard IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot

--- a/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
@@ -9,6 +9,41 @@
       <div class="integration-read-source__form" data-testid="read-source-form">
         <h3>新建 / 试配读取源</h3>
 
+        <!-- IU-3 (design-lock docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md):
+             the wizard is the DEFAULT surface; this toggle switches to the untouched full flat form
+             below (折叠≠删除 — expert mode is retained, never removed). Native <button>, not an
+             el-switch/el-radio-group: those Element Plus controls only toggle via their OWN internal
+             JS, which is a no-op when EP isn't globally registered (e.g. this file's existing spec's
+             bare `createApp()`) — a native button works identically everywhere. -->
+        <div class="integration-read-source__mode-toggle">
+          <button
+            type="button"
+            class="integration-read-source__mode-toggle-button"
+            data-testid="rsc-mode-toggle"
+            @click="toggleViewMode"
+          >
+            <el-icon><component :is="viewMode === 'wizard' ? Setting : MagicStick" /></el-icon>
+            {{ viewMode === 'wizard' ? bi('专家表单', 'Expert form') : bi('返回向导', 'Back to wizard') }}
+          </button>
+        </div>
+
+        <IntegrationReadSourceWizard
+          v-if="viewMode === 'wizard'"
+          :draft="draft"
+          :systems="systems"
+          :probing="probing"
+          :saving="saving"
+          :action-error="actionError"
+          :probe-evidence="probeEvidence"
+          :save-result="saveResult"
+          v-model:bounded-smoke="boundedSmoke"
+          v-model:probe-key="probeKey"
+          @run-probe="runProbe"
+          @save-version="saveVersion"
+          @approve-saved="approveSavedResult"
+        />
+
+        <template v-else>
         <label class="integration-read-source__field">
           <span>外部系统(systemId)</span>
           <select v-model="draft.systemId" data-testid="rsc-system" @change="onSystemChange">
@@ -244,6 +279,7 @@
         <p v-if="saveResult" class="integration-read-source__save-result" data-testid="rsc-save-result">
           {{ saveResult.reused ? `已复用现有版本 v${saveResult.version}` : `已保存新版本 v${saveResult.version}` }}(status: {{ saveResult.status }})
         </p>
+        </template>
       </div>
 
       <div class="integration-read-source__list" data-testid="read-source-list">
@@ -333,6 +369,7 @@
 // The probe evidence path is allowlist-normalized in the service layer, so row values or
 // field keys can never reach this template even from a malformed response.
 import { computed, reactive, ref, watch } from 'vue'
+import { MagicStick, Setting } from '@element-plus/icons-vue'
 import { useLocale } from '../../composables/useLocale'
 import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../../services/integration/errorCodeLabels'
 import { integrationFieldHint, type IntegrationFieldHintKey } from '../../services/integration/fieldHints'
@@ -344,6 +381,7 @@ import {
   approveReadSourceConfig,
   buildReadSourceConfigPayload,
   createReadSourceConfigDraft,
+  deriveReadSourceProbeEvidenceContainers,
   listReadSourceConfigAudit,
   listReadSourceConfigs,
   probeReadSourceConfig,
@@ -356,11 +394,22 @@ import {
   type ReadSourceSaveResult,
   type ReadSourceStatus,
 } from '../../services/integration/readSourceConfigs'
+import IntegrationReadSourceWizard from './IntegrationReadSourceWizard.vue'
 
+// IU-3 (design-lock docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md):
+// the wizard is the DEFAULT new-config surface; `initialViewMode` lets a caller (incl. this file's
+// own spec, which targets the pre-existing flat-form testids) pin the panel to 'expert' so it renders
+// today's full field-flat form with ZERO wizard indirection — no existing assertion had to change.
 const props = defineProps<{
   scope: IntegrationScope
   systems: WorkbenchExternalSystem[]
+  initialViewMode?: 'wizard' | 'expert'
 }>()
+
+const viewMode = ref<'wizard' | 'expert'>(props.initialViewMode ?? 'wizard')
+function toggleViewMode(): void {
+  viewMode.value = viewMode.value === 'wizard' ? 'expert' : 'wizard'
+}
 
 const { locale } = useLocale()
 
@@ -379,14 +428,7 @@ const auditConfigId = ref('')
 const auditRows = ref<ReadSourceAuditRow[]>([])
 
 const validationProblems = computed(() => validateReadSourceDraft(draft))
-const evidenceContainers = computed(() => {
-  const containers = probeEvidence.value?.containers
-  if (!containers) return []
-  return (['primary', 'header', 'lines'] as const).flatMap((alias) => {
-    const shape = containers[alias]
-    return shape ? [{ alias, shape }] : []
-  })
-})
+const evidenceContainers = computed(() => deriveReadSourceProbeEvidenceContainers(probeEvidence.value?.containers))
 // IU-1: humanized probe evidence errorCode label (+ optional hint). The raw code stays visible in a
 // demoted/secondary spot (data-testid="rsc-evidence-error-code") for expert troubleshooting — only the
 // backend's free-text errorMessage (which does not exist on this evidence shape) would be unsafe to
@@ -512,6 +554,23 @@ async function approve(row: ReadSourceConfigRow): Promise<void> {
   }
 }
 
+// IU-3 step 4 (审批): the wizard's "save version → submit for approval" flow saves via the SAME
+// `saveVersion()` above, then approves the just-saved id via the SAME `approveReadSourceConfig` +
+// `refresh()` service path the list-row `approve()` button already uses below — existing service
+// paths only, no new route/call shape (design-lock §2 hard lock).
+async function approveSavedResult(): Promise<void> {
+  const result = saveResult.value
+  if (!result) return
+  if (!window.confirm(`审批后运行时即可选用该读取源(${draft.object} v${result.version})。确认审批?`)) return
+  actionError.value = ''
+  try {
+    await approveReadSourceConfig(result.id, props.scope)
+    await refresh()
+  } catch (error) {
+    actionError.value = coarseErrorMessage(error)
+  }
+}
+
 async function retire(row: ReadSourceConfigRow): Promise<void> {
   actionError.value = ''
   try {
@@ -545,6 +604,29 @@ void refresh()
   color: #666;
   font-size: 13px;
   margin: 0 0 12px;
+}
+/* IU-3 (design-lock docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md):
+   new markup only — token-only per §3 hard lock (the rules above/below this block are the
+   pre-existing IU-2-scope styles and are left untouched, hex and all). */
+.integration-read-source__mode-toggle {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--ms-space-3);
+}
+.integration-read-source__mode-toggle-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ms-space-1);
+  padding: var(--ms-space-1) var(--ms-space-3);
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+  background: var(--ms-bg-card);
+  color: var(--ms-color-primary);
+  font-size: 13px;
+  cursor: pointer;
+}
+.integration-read-source__mode-toggle-button:hover {
+  background: var(--ms-bg-page);
 }
 .integration-read-source__columns {
   display: grid;

--- a/apps/web/src/components/integration/IntegrationReadSourceWizard.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceWizard.vue
@@ -1,0 +1,616 @@
+<template>
+  <div class="iu3-wizard" data-testid="read-source-wizard">
+    <!-- Decorative step indicator only — Element Plus is NOT globally registered in every host that
+         mounts this component in tests, and el-steps's own visuals are irrelevant to correctness.
+         All real navigation/gating below is driven by plain <button data-testid> + currentStep,
+         never by clicking an el-step header. -->
+    <el-steps :active="currentStep - 1" align-center class="iu3-wizard__steps" data-testid="rsc-wizard-steps">
+      <el-step :title="bi('①选系统', '① Pick system')" />
+      <el-step :title="bi('②定形状', '② Define shape')" />
+      <el-step :title="bi('③探测', '③ Probe')" />
+      <el-step :title="bi('④审批', '④ Approve')" />
+    </el-steps>
+
+    <section v-if="currentStep === 1" class="iu3-wizard__step" data-testid="rsc-wizard-step-1">
+      <p class="iu3-wizard__step-desc">{{ bi(
+        '从已注册的外部系统中选择一个作为本次读取源的来源系统；选定后自动带出兼容的 requiredKind。',
+        'Pick a registered external system as the source for this read source; the compatible requiredKind is filled in automatically.',
+      ) }}</p>
+      <div class="iu3-wizard__card-grid" data-testid="rsc-wizard-system-grid">
+        <button
+          v-for="system in systems"
+          :key="system.id"
+          type="button"
+          class="iu3-wizard__card"
+          :class="{ 'iu3-wizard__card--selected': draft.systemId === system.id }"
+          :data-testid="`rsc-wizard-system-${system.id}`"
+          @click="selectSystem(system)"
+        >
+          <el-icon v-if="draft.systemId === system.id" class="iu3-wizard__card-check"><Check /></el-icon>
+          <span class="iu3-wizard__card-title">{{ system.name }}</span>
+          <span class="iu3-wizard__card-subtitle">{{ system.kind }}</span>
+        </button>
+      </div>
+      <p v-if="systems.length === 0" class="iu3-wizard__empty-hint" data-testid="rsc-wizard-no-systems">
+        {{ bi(
+          '尚无已注册的外部系统，请先在连接管理里添加一个。',
+          'No external systems are registered yet — add one in connection management first.',
+        ) }}
+      </p>
+    </section>
+
+    <section v-else-if="currentStep === 2" class="iu3-wizard__step" data-testid="rsc-wizard-step-2">
+      <p class="iu3-wizard__step-desc">{{ bi(
+        '选择这次读取的形状；只展开该形状必填的字段，其余可选字段收进下面的「高级」区。',
+        "Choose the shape of this read; only that shape's required fields are shown — the rest are optional and live in the Advanced section below.",
+      ) }}</p>
+      <div class="iu3-wizard__card-grid" data-testid="rsc-wizard-preset-grid">
+        <button
+          v-for="preset in READ_SOURCE_MODE_PRESETS"
+          :key="preset.id"
+          type="button"
+          class="iu3-wizard__card"
+          :class="{ 'iu3-wizard__card--selected': draft.mode === preset.id }"
+          :data-testid="`rsc-wizard-mode-${preset.id}`"
+          @click="selectMode(preset.id)"
+        >
+          <el-icon v-if="draft.mode === preset.id" class="iu3-wizard__card-check"><Check /></el-icon>
+          <span class="iu3-wizard__card-title">{{ bi(preset.title.zh, preset.title.en) }}</span>
+          <span class="iu3-wizard__card-subtitle">{{ bi(preset.oneLiner.zh, preset.oneLiner.en) }}</span>
+        </button>
+      </div>
+
+      <label class="iu3-wizard__field">
+        <span>object</span>
+        <input v-model="draft.object" data-testid="rsc-wizard-object" placeholder="material" />
+      </label>
+      <label class="iu3-wizard__field">
+        <span>readPath</span>
+        <input v-model="draft.readPath" data-testid="rsc-wizard-read-path" placeholder="/K3API/Material/GetDetail" />
+      </label>
+
+      <label v-if="requiredKeys.includes('keyField')" class="iu3-wizard__field">
+        <span>keyField（{{ bi('必填', 'required') }}）</span>
+        <input v-model="draft.keyField" data-testid="rsc-wizard-key-field" placeholder="FNumber" />
+      </label>
+
+      <label v-if="requiredKeys.includes('containerPaths')" class="iu3-wizard__field">
+        <span>containerPaths（{{ bi('必填', 'required') }}）</span>
+        <input v-model="draft.containerPaths" data-testid="rsc-wizard-container-paths" placeholder="Data.Data, Data.DATA" />
+      </label>
+
+      <template v-if="requiredKeys.includes('headerContainerPaths')">
+        <label class="iu3-wizard__field">
+          <span>headerContainerPaths（{{ bi('必填', 'required') }}）</span>
+          <input v-model="draft.headerContainerPaths" data-testid="rsc-wizard-header-container-paths" placeholder="Data.Page1" />
+        </label>
+      </template>
+      <template v-if="requiredKeys.includes('lineContainerPaths')">
+        <label class="iu3-wizard__field">
+          <span>lineContainerPaths（{{ bi('必填', 'required') }}）</span>
+          <input v-model="draft.lineContainerPaths" data-testid="rsc-wizard-line-container-paths" placeholder="Data.Page2" />
+        </label>
+      </template>
+
+      <label v-if="requiredKeys.includes('resolverRule')" class="iu3-wizard__field">
+        <span>resolverRule（{{ bi('必填', 'required') }}）</span>
+        <select v-model="draft.resolverRule" data-testid="rsc-wizard-resolver-rule">
+          <option value="">{{ bi('选择解析规则…', 'Choose a resolver rule…') }}</option>
+          <option v-for="rule in RESOLVER_RULES" :key="rule" :value="rule">{{ rule }}</option>
+        </select>
+      </label>
+
+      <ul v-if="validationProblems.length > 0" class="iu3-wizard__problems" data-testid="rsc-wizard-validation">
+        <li v-for="problem in validationProblems" :key="problem">{{ problem }}</li>
+      </ul>
+
+      <!-- Advanced/optional fields (design-lock §2: keyEncoding / resolver rule detail / multi-fieldMap)
+           — a plain toggled <div>, not <el-collapse>: that component's open/close-on-click behavior
+           is Element Plus's own internal JS, which is a no-op when EP isn't globally registered
+           (this component's own spec stubs only what it needs — see spec header). A native button +
+           v-show works identically in every host. -->
+      <div class="iu3-wizard__advanced">
+        <button
+          type="button"
+          class="iu3-wizard__advanced-toggle"
+          data-testid="rsc-wizard-advanced-toggle"
+          @click="advancedOpen = !advancedOpen"
+        >
+          <el-icon><ArrowDown v-if="advancedOpen" /><ArrowRight v-else /></el-icon>
+          {{ bi('高级(可选字段)', 'Advanced (optional fields)') }}
+        </button>
+        <div v-show="advancedOpen" class="iu3-wizard__advanced-body" data-testid="rsc-wizard-advanced-panel">
+          <!-- Full capability parity with the expert flat form (design-lock §2 专家不降级 + byte-equal
+               output): every optional field the flat form can set is reachable here too — an optional
+               keyField (detail_with_lines only; it is REQUIRED and rendered in the main step-2 section
+               for single_record / resolver_lookup), keyEncoding for any keyed mode (mirrors the flat
+               form's `showKeyField` = mode !== 'list_page'), readMethod, and version. -->
+          <label v-if="showOptionalKeyField" class="iu3-wizard__field">
+            <span>keyField（{{ bi('可选', 'optional') }}）</span>
+            <input v-model="draft.keyField" data-testid="rsc-wizard-key-field-optional" placeholder="FBillNo" />
+          </label>
+          <label v-if="showKeyField" class="iu3-wizard__field">
+            <span>keyEncoding（{{ bi('可选', 'optional') }}）</span>
+            <select v-model="draft.keyEncoding" data-testid="rsc-wizard-key-encoding">
+              <option value="">{{ bi('（不指定）', '(unspecified)') }}</option>
+              <option v-for="encoding in READ_SOURCE_KEY_ENCODINGS" :key="encoding" :value="encoding">{{ encoding }}</option>
+            </select>
+          </label>
+          <label class="iu3-wizard__field">
+            <span>readMethod（{{ bi('默认 POST', 'defaults to POST') }}）</span>
+            <select v-model="draft.readMethod" data-testid="rsc-wizard-read-method">
+              <option v-for="method in READ_SOURCE_METHODS" :key="method" :value="method">{{ method }}</option>
+            </select>
+          </label>
+          <label class="iu3-wizard__field">
+            <span>version（{{ bi('正整数,默认 1', 'positive integer, defaults to 1') }}）</span>
+            <input v-model.number="draft.version" type="number" min="1" data-testid="rsc-wizard-version" />
+          </label>
+
+          <template v-if="draft.resolverRule === 'first_when_sorted'">
+            <label class="iu3-wizard__field">
+              <span>multiplicityRuleField（{{ bi('排序字段,必填', 'sort field, required') }}）</span>
+              <input v-model="draft.multiplicityRuleField" data-testid="rsc-wizard-resolver-sort-field" placeholder="FVersion" />
+            </label>
+            <label class="iu3-wizard__field">
+              <span>resolverSortDirection（{{ bi('必填', 'required') }}）</span>
+              <select v-model="draft.resolverSortDirection" data-testid="rsc-wizard-resolver-sort-direction">
+                <option value="">{{ bi('选择方向…', 'Choose a direction…') }}</option>
+                <option v-for="direction in RESOLVER_SORT_DIRECTIONS" :key="direction" :value="direction">{{ direction }}</option>
+              </select>
+            </label>
+          </template>
+          <template v-if="draft.resolverRule === 'field_equals'">
+            <label class="iu3-wizard__field">
+              <span>multiplicityRuleField（{{ bi('判别字段,必填', 'discriminator field, required') }}）</span>
+              <input v-model="draft.multiplicityRuleField" data-testid="rsc-wizard-resolver-discriminator-field" placeholder="FIsCurrent" />
+            </label>
+            <label class="iu3-wizard__field">
+              <span>resolverDiscriminatorValue（{{ bi('必填', 'required') }}）</span>
+              <input v-model="draft.resolverDiscriminatorValue" data-testid="rsc-wizard-resolver-discriminator-value" placeholder="Y" />
+            </label>
+          </template>
+
+          <div class="iu3-wizard__field-map">
+            <div class="iu3-wizard__field-map-head">
+              <span>fieldMap（{{ bi('可选', 'optional') }}）</span>
+              <button type="button" class="iu3-wizard__button" data-testid="rsc-wizard-field-map-add" @click="addFieldMapRow">
+                {{ bi('添加映射行', 'Add mapping row') }}
+              </button>
+            </div>
+            <div v-for="(entry, index) in draft.fieldMap" :key="index" class="iu3-wizard__field-map-row">
+              <input v-model="entry.source" :data-testid="`rsc-wizard-field-map-source-${index}`" placeholder="FName" />
+              <span>→</span>
+              <input v-model="entry.target" :data-testid="`rsc-wizard-field-map-target-${index}`" placeholder="material_name" />
+              <button
+                type="button"
+                class="iu3-wizard__button"
+                :data-testid="`rsc-wizard-field-map-remove-${index}`"
+                @click="removeFieldMapRow(index)"
+              >{{ bi('删除', 'Remove') }}</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section v-else-if="currentStep === 3" class="iu3-wizard__step" data-testid="rsc-wizard-step-3">
+      <p class="iu3-wizard__step-desc">{{ bi(
+        '定位容器探测：values-free，只验证容器形状是否符合预期，从不读取或展示行值。',
+        'Locate-container probe: values-free — it only verifies the container shape, never reads or displays row values.',
+      ) }}</p>
+      <label class="iu3-wizard__inline">
+        <input v-model="boundedSmoke" type="checkbox" data-testid="rsc-wizard-bounded-smoke" />
+        <span>{{ bi('bounded smoke(受平台上限约束的试读计数)', 'bounded smoke (a platform-capped sample read)') }}</span>
+      </label>
+      <label v-if="probeNeedsKey" class="iu3-wizard__inline">
+        <span>{{ bi('探测 key(仅用于本次探测,不会保存)', 'probe key (used only for this probe, never saved)') }}</span>
+        <input v-model="probeKey" data-testid="rsc-wizard-probe-key" placeholder="MAT-001" />
+      </label>
+      <div class="iu3-wizard__actions">
+        <button
+          type="button"
+          class="iu3-wizard__button iu3-wizard__button--primary"
+          data-testid="rsc-wizard-probe-run"
+          :disabled="probing || validationProblems.length > 0"
+          @click="emit('run-probe')"
+        >{{ probing ? bi('探测中…', 'Probing…') : bi('定位容器探测', 'Run probe') }}</button>
+      </div>
+      <p v-if="actionError" class="iu3-wizard__error" data-testid="rsc-wizard-error">{{ actionError }}</p>
+      <div v-if="probeEvidence" class="iu3-wizard__evidence" data-testid="rsc-wizard-evidence">
+        <p class="iu3-wizard__evidence-summary" data-testid="rsc-wizard-evidence-summary">
+          <el-icon v-if="probeEvidence.ok" class="iu3-wizard__evidence-icon--ok"><CircleCheck /></el-icon>
+          <el-icon v-else class="iu3-wizard__evidence-icon--fail"><WarningFilled /></el-icon>
+          {{ probeEvidence.ok
+            ? bi('探测成功：容器形状符合预期。', 'Probe succeeded: the container shape matches expectations.')
+            : evidenceErrorLabel }}<template v-if="!probeEvidence.ok && evidenceErrorHint"> — {{ evidenceErrorHint }}</template>
+        </p>
+        <ul class="iu3-wizard__evidence-list">
+          <li
+            v-for="entry in evidenceContainers"
+            :key="entry.alias"
+            :data-testid="`rsc-wizard-evidence-container-${entry.alias}`"
+          >
+            {{ entry.alias }}: {{ entry.shape.type }}<template v-if="entry.shape.arrayLength !== undefined">, arrayLength={{ entry.shape.arrayLength === null ? 'null' : entry.shape.arrayLength }}</template>
+          </li>
+        </ul>
+        <!-- 机器码折叠详情 (design-lock §2/§3): raw codes stay reachable for expert troubleshooting,
+             never in the prominent slot. -->
+        <details class="iu3-wizard__evidence-raw" data-testid="rsc-wizard-evidence-raw">
+          <summary>{{ bi('原始机器码(排障用)', 'Raw codes (for troubleshooting)') }}</summary>
+          <p v-if="probeEvidence.errorCode" data-testid="rsc-wizard-evidence-error-code">errorCode: {{ probeEvidence.errorCode }}</p>
+          <p v-if="probeEvidence.errorType" data-testid="rsc-wizard-evidence-error-type">errorType: {{ probeEvidence.errorType }}</p>
+        </details>
+      </div>
+    </section>
+
+    <section v-else class="iu3-wizard__step" data-testid="rsc-wizard-step-4">
+      <p class="iu3-wizard__step-desc">{{ bi(
+        '保存这次的配置版本，然后提交审批；审批通过后运行时才能选用该读取源。',
+        'Save this configuration version, then submit it for approval; only after approval can runtime select this read source.',
+      ) }}</p>
+      <div class="iu3-wizard__actions">
+        <button
+          type="button"
+          class="iu3-wizard__button iu3-wizard__button--primary"
+          data-testid="rsc-wizard-save"
+          :disabled="saving || validationProblems.length > 0"
+          @click="emit('save-version')"
+        >{{ saving ? bi('保存中…', 'Saving…') : bi('保存版本', 'Save version') }}</button>
+        <button
+          v-if="saveResult"
+          type="button"
+          class="iu3-wizard__button"
+          data-testid="rsc-wizard-approve"
+          @click="emit('approve-saved')"
+        >{{ bi('提交审批', 'Submit for approval') }}</button>
+      </div>
+      <p v-if="actionError" class="iu3-wizard__error" data-testid="rsc-wizard-error-step4">{{ actionError }}</p>
+      <p v-if="saveResult" class="iu3-wizard__save-result" data-testid="rsc-wizard-save-result">
+        {{ saveResult.reused
+          ? bi(`已复用现有版本 v${saveResult.version}`, `Reused existing version v${saveResult.version}`)
+          : bi(`已保存新版本 v${saveResult.version}`, `Saved new version v${saveResult.version}`) }}
+        (status: {{ saveResult.status }})
+      </p>
+    </section>
+
+    <div class="iu3-wizard__nav">
+      <button
+        type="button"
+        class="iu3-wizard__button"
+        data-testid="rsc-wizard-back"
+        :disabled="currentStep === 1"
+        @click="goBack"
+      >{{ bi('上一步', 'Back') }}</button>
+      <button
+        v-if="currentStep < 4"
+        type="button"
+        class="iu3-wizard__button iu3-wizard__button--primary"
+        data-testid="rsc-wizard-next"
+        :disabled="(currentStep === 1 && !canAdvanceStep1) || (currentStep === 2 && !canAdvanceStep2)"
+        @click="goNext"
+      >{{ bi('下一步', 'Next') }}</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// IU-3 read-source config wizard (design-lock
+// docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md, #3797).
+//
+// This is a REORDERING SHELL over the existing `IntegrationReadSourceConfigPanel.vue` state — it owns
+// NO service calls and NO independent config model. `draft` is the exact same reactive object the
+// parent panel's expert flat-form binds to (passed through as a plain prop and mutated in place via
+// v-model on its nested fields, the same "shared reactive slice" pattern already used by
+// IntegrationConnectionSection.vue's `connectionDraft` — see that file's header comment). Because both
+// surfaces write into ONE shared draft and both funnel it through the SAME
+// `buildReadSourceConfigPayload` (called only in the parent, itself unchanged), the wizard's output is
+// byte-equal to the expert form's by construction — proven empirically (not just by this argument) in
+// IntegrationReadSourceWizard.spec.ts's byte-equality test, which drives real DOM inputs through both
+// surfaces and diffs the captured wire body.
+//
+// probe/save/approve are EMITTED to the parent, which runs the exact same `runProbe` / `saveVersion` /
+// `approveSavedResult` functions the expert form's own buttons call — one function per action, two UI
+// entry points. No new route, no new validator, no new approve path (design-lock §2 hard lock).
+import { computed, ref } from 'vue'
+import { ArrowDown, ArrowRight, Check, CircleCheck, WarningFilled } from '@element-plus/icons-vue'
+import { useLocale } from '../../composables/useLocale'
+import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../../services/integration/errorCodeLabels'
+import { READ_SOURCE_MODE_PRESETS, readSourceModePreset } from '../../services/integration/readSourceModePresets'
+import {
+  READ_SOURCE_KEY_ENCODINGS,
+  READ_SOURCE_METHODS,
+  RESOLVER_RULES,
+  RESOLVER_SORT_DIRECTIONS,
+  deriveReadSourceProbeEvidenceContainers,
+  validateReadSourceDraft,
+  type ReadSourceConfigDraft,
+  type ReadSourceMode,
+  type ReadSourceProbeEvidence,
+  type ReadSourceSaveResult,
+} from '../../services/integration/readSourceConfigs'
+import type { WorkbenchExternalSystem } from '../../services/integration/workbench'
+
+const props = defineProps<{
+  draft: ReadSourceConfigDraft
+  systems: WorkbenchExternalSystem[]
+  probing: boolean
+  saving: boolean
+  actionError: string
+  probeEvidence: ReadSourceProbeEvidence | null
+  saveResult: ReadSourceSaveResult | null
+}>()
+
+// Two standalone primitives — the codebase's established `defineModel` pattern for a plain two-way
+// bind (same as IU-2b's `stagingBaseId` / IU-2c's `sourceSystemId` etc.). `draft` above is NOT a
+// defineModel — it is a shared nested object, not a primitive being reassigned; see the header
+// comment for why plain-prop-plus-nested-mutation is the correct (and precedented) shape for it.
+const boundedSmoke = defineModel<boolean>('boundedSmoke', { default: false })
+const probeKey = defineModel<string>('probeKey', { default: '' })
+
+const emit = defineEmits<{
+  (e: 'run-probe'): void
+  (e: 'save-version'): void
+  (e: 'approve-saved'): void
+}>()
+
+const { locale } = useLocale()
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+const currentStep = ref<1 | 2 | 3 | 4>(1)
+const advancedOpen = ref(false)
+
+const currentPreset = computed(() => readSourceModePreset(props.draft.mode))
+// The SAME requiredFieldKeys the step-2 preset card displays drives which fields step 2 actually
+// shows — the card's promise ("this mode needs these fields") and the form's behavior can't drift
+// apart, because both read off one computed.
+const requiredKeys = computed(() => currentPreset.value.requiredFieldKeys)
+const validationProblems = computed(() => validateReadSourceDraft(props.draft))
+const canAdvanceStep1 = computed(() => props.draft.systemId.trim().length > 0)
+const canAdvanceStep2 = computed(() => validationProblems.value.length === 0)
+// EXACT mirrors of the expert flat form's `showKeyField` / `probeNeedsKey` computeds — the S2-b
+// runtime requires inputs.key precisely when the config declares a keyField, regardless of which
+// surface authored it, so the two surfaces must agree on when to ask for a probe key.
+const showKeyField = computed(() => props.draft.mode !== 'list_page')
+// detail_with_lines: keyField is optional (not in MODE_REQUIRED_FIELDS) but settable in the expert
+// form — surfaced in the Advanced area so wizard capability matches the flat form's.
+const showOptionalKeyField = computed(() => showKeyField.value && !requiredKeys.value.includes('keyField'))
+const probeNeedsKey = computed(() => showKeyField.value && props.draft.keyField.trim().length > 0)
+const evidenceContainers = computed(() => deriveReadSourceProbeEvidenceContainers(props.probeEvidence?.containers))
+const evidenceErrorLabel = computed(() => integrationErrorCodeDisplayLabel(props.probeEvidence?.errorCode, locale.value))
+const evidenceErrorHint = computed(() => integrationErrorCodeHint(props.probeEvidence?.errorCode, locale.value))
+
+function selectSystem(system: WorkbenchExternalSystem): void {
+  // Mirrors the expert form's `onSystemChange` (native <select> @change) — same two-field mapping,
+  // duplicated here because the wizard's input is a card click rather than a <select> change event.
+  props.draft.systemId = system.id
+  props.draft.requiredKind = system.kind
+}
+
+function selectMode(mode: ReadSourceMode): void {
+  props.draft.mode = mode
+}
+
+function addFieldMapRow(): void {
+  props.draft.fieldMap.push({ source: '', target: '' })
+}
+
+function removeFieldMapRow(index: number): void {
+  props.draft.fieldMap.splice(index, 1)
+}
+
+function goNext(): void {
+  if (currentStep.value === 1 && !canAdvanceStep1.value) return
+  if (currentStep.value === 2 && !canAdvanceStep2.value) return
+  if (currentStep.value === 1) currentStep.value = 2
+  else if (currentStep.value === 2) currentStep.value = 3
+  else if (currentStep.value === 3) currentStep.value = 4
+}
+
+function goBack(): void {
+  if (currentStep.value === 4) currentStep.value = 3
+  else if (currentStep.value === 3) currentStep.value = 2
+  else if (currentStep.value === 2) currentStep.value = 1
+}
+</script>
+
+<style scoped>
+/* Token-only (UF-1 / design-lock §3 hard lock) — every new style in this file uses var(--ms-*), zero
+   hex/rgb literals; enforced by ui-foundation-style-guard.spec.ts (this file is in TARGET_FILES). */
+.iu3-wizard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-4);
+}
+.iu3-wizard__steps {
+  margin-bottom: var(--ms-space-2);
+}
+.iu3-wizard__step {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+}
+.iu3-wizard__step-desc {
+  margin: 0;
+  color: var(--ms-text-2);
+  font-size: 13px;
+}
+.iu3-wizard__card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--ms-space-3);
+}
+.iu3-wizard__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--ms-space-1);
+  padding: var(--ms-space-3);
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-md);
+  background: var(--ms-bg-card);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+.iu3-wizard__card:hover {
+  border-color: var(--ms-color-primary);
+}
+.iu3-wizard__card--selected {
+  border-color: var(--ms-color-primary);
+  box-shadow: var(--ms-shadow-card);
+}
+.iu3-wizard__card-check {
+  position: absolute;
+  top: var(--ms-space-2);
+  right: var(--ms-space-2);
+  color: var(--ms-color-primary);
+}
+.iu3-wizard__card-title {
+  font-size: 14px;
+  font-weight: var(--ms-font-weight-title);
+  color: var(--ms-text-1);
+}
+.iu3-wizard__card-subtitle {
+  font-size: 12px;
+  color: var(--ms-text-2);
+}
+.iu3-wizard__empty-hint {
+  color: var(--ms-text-3);
+  font-size: 13px;
+}
+.iu3-wizard__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+  font-size: 13px;
+}
+.iu3-wizard__field input,
+.iu3-wizard__field select {
+  padding: var(--ms-space-1) var(--ms-space-2);
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+}
+.iu3-wizard__inline {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-2);
+  font-size: 13px;
+}
+.iu3-wizard__problems {
+  margin: 0;
+  padding-left: var(--ms-space-4);
+  color: var(--ms-color-warning);
+  font-size: 12px;
+}
+.iu3-wizard__advanced {
+  border-top: 1px solid var(--ms-border-light);
+  padding-top: var(--ms-space-3);
+}
+.iu3-wizard__advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ms-space-1);
+  border: none;
+  background: none;
+  color: var(--ms-color-primary);
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0;
+}
+.iu3-wizard__advanced-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+  margin-top: var(--ms-space-3);
+}
+.iu3-wizard__field-map-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ms-space-2);
+  font-size: 13px;
+}
+.iu3-wizard__field-map-row {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-2);
+  margin-top: var(--ms-space-2);
+}
+.iu3-wizard__field-map-row input {
+  padding: var(--ms-space-1) var(--ms-space-2);
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+}
+.iu3-wizard__actions {
+  display: flex;
+  gap: var(--ms-space-2);
+}
+.iu3-wizard__button {
+  padding: var(--ms-space-1) var(--ms-space-3);
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  cursor: pointer;
+  font-size: 13px;
+}
+.iu3-wizard__button:disabled {
+  cursor: not-allowed;
+  color: var(--ms-text-3);
+}
+.iu3-wizard__button--primary {
+  border-color: var(--ms-color-primary);
+  background: var(--ms-color-primary);
+  color: var(--ms-bg-card);
+}
+.iu3-wizard__button--primary:disabled {
+  background: var(--ms-border);
+  border-color: var(--ms-border);
+  color: var(--ms-bg-card);
+}
+.iu3-wizard__error {
+  color: var(--ms-color-danger);
+  font-size: 13px;
+}
+.iu3-wizard__evidence {
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-md);
+  padding: var(--ms-space-3);
+  font-size: 13px;
+}
+.iu3-wizard__evidence-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-1);
+  margin: 0;
+}
+.iu3-wizard__evidence-icon--ok {
+  color: var(--ms-color-success);
+}
+.iu3-wizard__evidence-icon--fail {
+  color: var(--ms-color-danger);
+}
+.iu3-wizard__evidence-list {
+  margin: var(--ms-space-2) 0 0;
+  padding-left: var(--ms-space-4);
+}
+.iu3-wizard__evidence-raw {
+  margin-top: var(--ms-space-2);
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+.iu3-wizard__save-result {
+  color: var(--ms-color-success);
+  font-size: 13px;
+}
+.iu3-wizard__nav {
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid var(--ms-border-light);
+  padding-top: var(--ms-space-3);
+}
+</style>

--- a/apps/web/src/services/integration/readSourceConfigs.ts
+++ b/apps/web/src/services/integration/readSourceConfigs.ts
@@ -507,6 +507,20 @@ export function normalizeReadSourceProbeEvidence(value: unknown): ReadSourceProb
   return evidence
 }
 
+// IU-3 (design-lock docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md):
+// pure shaping helper extracted from IntegrationReadSourceConfigPanel.vue's `evidenceContainers`
+// computed so both the expert form and the new wizard's step-3 evidence card render the exact same
+// {alias, shape}[] list from the same allowlisted evidence — zero behavior change, single source.
+export function deriveReadSourceProbeEvidenceContainers(
+  containers: ReadSourceProbeEvidence['containers'] | undefined,
+): Array<{ alias: 'primary' | 'header' | 'lines'; shape: ReadSourceProbeContainerShape }> {
+  if (!containers) return []
+  return EVIDENCE_CONTAINER_ALIASES.flatMap((alias) => {
+    const shape = containers[alias]
+    return shape ? [{ alias, shape }] : []
+  })
+}
+
 export function normalizeReadSourceConfigRow(value: unknown): ReadSourceConfigRow | null {
   if (!isPlainObject(value)) return null
   if (typeof value.id !== 'string' || !value.id) return null

--- a/apps/web/src/services/integration/readSourceModePresets.ts
+++ b/apps/web/src/services/integration/readSourceModePresets.ts
@@ -1,0 +1,91 @@
+// IU-3 read-source config wizard — preset card metadata (design-lock
+// docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md, #3797, §2).
+//
+// Presentation-layer mapping ONLY, over the four EXISTING `READ_SOURCE_MODES` values — this module
+// invents NO new mode and NO new required-field vocabulary. `requiredFieldKeys` is read straight off
+// the real source of truth (`readSourceConfigs.ts` `READ_SOURCE_MODE_REQUIRED_FIELDS`), never a
+// hand-copied list, so a future change to that constant cannot silently drift from what the wizard
+// displays as "the fields this mode needs".
+//
+// The preset array is BUILT FROM `READ_SOURCE_MODES` (not `Object.keys(PRESET_COPY)`) so a future mode
+// added there with no matching card throws here at import time — fails loudly in dev/build rather
+// than silently rendering an incomplete card deck. `readSourceModePresets.spec.ts` also asserts this
+// as an explicit tripwire (mode-set coverage + requiredFieldKeys deep-equality against the real
+// constant), per the design-lock's "未来加 mode 未配卡片则红" acceptance clause.
+//
+// values-free (design-lock §2/§3): titles/one-liners describe the SHAPE of a read (single record /
+// paged list / header-with-lines / rule-resolved lookup) only — no business value example (material
+// number, BOM number, etc.) ever appears here. Same zh+en discipline as errorCodeLabels.ts/fieldHints.ts.
+
+import { READ_SOURCE_MODE_REQUIRED_FIELDS, READ_SOURCE_MODES, type ReadSourceMode } from './readSourceConfigs'
+
+export type ReadSourceModePresetCopy = { zh: string; en: string }
+
+export interface ReadSourceModePreset {
+  id: ReadSourceMode
+  title: ReadSourceModePresetCopy
+  oneLiner: ReadSourceModePresetCopy
+  requiredFieldKeys: string[]
+}
+
+const PRESET_COPY: Record<ReadSourceMode, { title: ReadSourceModePresetCopy; oneLiner: ReadSourceModePresetCopy }> = {
+  single_record: {
+    title: { zh: '单记录读', en: 'Single record' },
+    oneLiner: {
+      zh: '按业务键定位并读取单条记录。',
+      en: 'Locates and reads exactly one record by its business key.',
+    },
+  },
+  list_page: {
+    title: { zh: '列表分页读', en: 'Paged list' },
+    oneLiner: {
+      zh: '按分页读取一组记录列表，不按单个业务键定位。',
+      en: 'Reads a paged list of records, without locating by a single business key.',
+    },
+  },
+  detail_with_lines: {
+    title: { zh: '主从明细读', en: 'Header with lines' },
+    oneLiner: {
+      zh: '同时读取一条表头记录与其对应的明细行数组。',
+      en: 'Reads one header record together with its associated line-item array.',
+    },
+  },
+  resolver_lookup: {
+    title: { zh: '解析定位读', en: 'Resolver lookup' },
+    oneLiner: {
+      zh: '候选记录可能不止一条时，按规则解析定位出唯一一条。',
+      en: 'When more than one candidate record may match, resolves a single one by rule.',
+    },
+  },
+}
+
+// Exported (not just internal) so the wizard/tests can iterate cards in the canonical mode order
+// without re-deriving it from `Object.keys`.
+export const READ_SOURCE_MODE_PRESETS: readonly ReadSourceModePreset[] = READ_SOURCE_MODES.map((mode) => {
+  const copy = PRESET_COPY[mode]
+  if (!copy) {
+    // Fails loudly at import time — see module header. A future mode must get a PRESET_COPY entry
+    // in the same change that adds it to READ_SOURCE_MODES, or every consumer of this module breaks
+    // immediately (not silently).
+    throw new Error(`readSourceModePresets: no preset copy registered for read-source mode "${mode}"`)
+  }
+  return {
+    id: mode,
+    title: copy.title,
+    oneLiner: copy.oneLiner,
+    // Real source of truth, not a copy — see module header.
+    requiredFieldKeys: READ_SOURCE_MODE_REQUIRED_FIELDS[mode],
+  }
+})
+
+const PRESETS_BY_ID = new Map<ReadSourceMode, ReadSourceModePreset>(
+  READ_SOURCE_MODE_PRESETS.map((preset) => [preset.id, preset]),
+)
+
+export function readSourceModePreset(mode: ReadSourceMode): ReadSourceModePreset {
+  const preset = PRESETS_BY_ID.get(mode)
+  if (!preset) {
+    throw new Error(`readSourceModePresets: unknown read-source mode "${mode}"`)
+  }
+  return preset
+}

--- a/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts
@@ -364,6 +364,13 @@ describe('IntegrationReadSourceConfigPanel', () => {
       render: () => h(IntegrationReadSourceConfigPanel, {
         scope: { tenantId: 'default', workspaceId: null },
         systems: SYSTEMS,
+        // IU-3 (design-lock integration-iu3-read-source-wizard-design-lock-20260707.md): the panel
+        // now defaults its new-config surface to the four-step wizard; every assertion in this file
+        // targets the pre-existing expert flat form's testids, so pin the panel to expert mode via
+        // the new prop. PROP ADDITION ONLY — no existing assertion in this file changed (design-lock
+        // §2 既有测试不变量). The wizard surface + the wizard↔expert toggle are covered by
+        // IntegrationReadSourceWizard.spec.ts, which mounts this same panel in its default mode.
+        initialViewMode: 'expert' as const,
       }),
     })
     app.mount(container)

--- a/apps/web/tests/IntegrationReadSourceWizard.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceWizard.spec.ts
@@ -1,0 +1,627 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: vi.fn(),
+}))
+
+import IntegrationReadSourceConfigPanel from '../src/components/integration/IntegrationReadSourceConfigPanel.vue'
+import type { WorkbenchExternalSystem } from '../src/services/integration/workbench'
+
+// IU-3 four-step read-source wizard (design-lock
+// docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md, #3797).
+//
+// Every test here mounts the REAL IntegrationReadSourceConfigPanel in its DEFAULT mode (wizard) —
+// not the wizard component in isolation — so the parent↔wizard wiring (shared draft, v-model
+// bounded-smoke / probe-key, emitted run-probe / save-version / approve-saved landing on the SAME
+// panel functions the expert buttons call) is exercised end-to-end against the same apiFetch mock
+// discipline as IntegrationReadSourceConfigPanel.spec.ts. That sibling spec pins the panel to
+// expert mode and is unchanged assertion-for-assertion (design-lock §2 既有测试不变量).
+//
+// el-steps / el-step / el-icon stubs: same approach as IU-2a's ElCard stub in
+// IntegrationWorkbenchView.spec.ts — real Element Plus is not globally installed in these bare
+// `createApp()` instances, so the tags the wizard template uses get minimal local stubs that render
+// their slot/title content (dropping them would delete the step header titles from the test DOM).
+// All step NAVIGATION in the component is plain <button> + internal state — nothing in these tests
+// (or the component) relies on Element Plus behavior.
+const ElSteps = defineComponent({
+  name: 'ElSteps',
+  props: { active: { type: Number, required: false, default: 0 }, alignCenter: { type: Boolean, required: false, default: false } },
+  setup(props, { slots }) {
+    return () => h('div', { class: 'el-steps', 'data-active-step': String(props.active) }, slots.default?.())
+  },
+})
+const ElStep = defineComponent({
+  name: 'ElStep',
+  props: { title: { type: String, required: false, default: '' } },
+  setup(props) {
+    return () => h('div', { class: 'el-step' }, props.title)
+  },
+})
+const ElIcon = defineComponent({
+  name: 'ElIcon',
+  setup(_props, { slots }) {
+    return () => h('span', { class: 'el-icon' }, slots.default?.())
+  },
+})
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// Macrotask-hop flush (same rationale as IntegrationWorkbenchView.spec.ts): microtask+nextTick alone
+// is not enough on Node 20's scheduler for fetch-mock chains — hop a timer turn each cycle.
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+}
+
+const SYSTEMS: WorkbenchExternalSystem[] = [
+  { id: 'sys_1', tenantId: 'default', workspaceId: null, name: 'K3 WISE', kind: 'erp:k3-wise-webapi', role: 'target', status: 'active' },
+  { id: 'sys_http', tenantId: 'default', workspaceId: null, name: 'Generic HTTP', kind: 'http', role: 'source', status: 'active' },
+]
+
+describe('IntegrationReadSourceWizard (via IntegrationReadSourceConfigPanel default surface)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+  let originalConfirm: typeof window.confirm | undefined
+  let confirmMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    originalConfirm = window.confirm
+    confirmMock = vi.fn(() => true)
+    Object.defineProperty(window, 'confirm', { configurable: true, value: confirmMock })
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    Object.defineProperty(window, 'confirm', { configurable: true, value: originalConfirm })
+    app = null
+    container = null
+  })
+
+  function mountPanel(initialViewMode?: 'wizard' | 'expert'): HTMLDivElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () => h(IntegrationReadSourceConfigPanel, {
+        scope: { tenantId: 'default', workspaceId: null },
+        systems: SYSTEMS,
+        ...(initialViewMode ? { initialViewMode } : {}),
+      }),
+    })
+    app.component('ElSteps', ElSteps)
+    app.component('ElStep', ElStep)
+    app.component('ElIcon', ElIcon)
+    app.mount(container)
+    return container
+  }
+
+  function unmountPanel(): void {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  }
+
+  function q<T extends HTMLElement>(root: HTMLElement, testid: string): T {
+    const el = root.querySelector<T>(`[data-testid="${testid}"]`)
+    if (!el) throw new Error(`missing [data-testid=${testid}]`)
+    return el
+  }
+
+  function maybe(root: HTMLElement, testid: string): HTMLElement | null {
+    return root.querySelector<HTMLElement>(`[data-testid="${testid}"]`)
+  }
+
+  function setInput(root: HTMLElement, testid: string, value: string): void {
+    const input = q<HTMLInputElement>(root, testid)
+    input.value = value
+    input.dispatchEvent(new Event('input'))
+  }
+
+  function setSelect(root: HTMLElement, testid: string, value: string): void {
+    const select = q<HTMLSelectElement>(root, testid)
+    select.value = value
+    select.dispatchEvent(new Event('change'))
+  }
+
+  function mockListOnly(rows: unknown[] = []): void {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.startsWith('/api/integration/read-source-configs')) {
+        return jsonResponse(rows)
+      }
+      return jsonResponse(null)
+    })
+  }
+
+  // Drives the wizard to step 2 with sys_1 selected (step-1 happy path).
+  async function toStep2(root: HTMLElement): Promise<void> {
+    q<HTMLButtonElement>(root, 'rsc-wizard-system-sys_1').click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+  }
+
+  async function fillValidSingleRecordStep2(root: HTMLElement): Promise<void> {
+    setInput(root, 'rsc-wizard-object', 'material')
+    setInput(root, 'rsc-wizard-read-path', 'K3API/Material/GetDetail')
+    setInput(root, 'rsc-wizard-key-field', 'FNumber')
+    setInput(root, 'rsc-wizard-container-paths', 'Data')
+    await flushUi()
+  }
+
+  it('wizard is the DEFAULT new-config surface: four steps render, flat form is not mounted', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+
+    expect(maybe(root, 'read-source-wizard')).not.toBeNull()
+    // The expert flat form's own controls are absent by default (wizard replaces, not duplicates).
+    expect(maybe(root, 'rsc-system')).toBeNull()
+    expect(maybe(root, 'rsc-mode')).toBeNull()
+    // Four step titles render through the ElSteps/ElStep stubs (en default locale).
+    const stepsText = q(root, 'rsc-wizard-steps').textContent ?? ''
+    for (const title of ['① Pick system', '② Define shape', '③ Probe', '④ Approve']) {
+      expect(stepsText).toContain(title)
+    }
+    // Step 1 active; the saved-configs list column still renders beside the wizard.
+    expect(maybe(root, 'rsc-wizard-step-1')).not.toBeNull()
+    expect(maybe(root, 'read-source-list')).not.toBeNull()
+  })
+
+  it('step-1 gating: next disabled until a system card is picked; picking fills requiredKind', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+
+    expect(q<HTMLButtonElement>(root, 'rsc-wizard-next').disabled).toBe(true)
+    expect(maybe(root, 'rsc-wizard-system-sys_1')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-system-sys_http')).not.toBeNull()
+
+    q<HTMLButtonElement>(root, 'rsc-wizard-system-sys_1').click()
+    await flushUi()
+    expect(q<HTMLButtonElement>(root, 'rsc-wizard-next').disabled).toBe(false)
+
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-step-2')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-step-1')).toBeNull()
+  })
+
+  it('step-2 gating: cannot advance past ② until the selected mode\'s required fields validate', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+    await toStep2(root)
+
+    // single_record default: missing object/readPath/keyField/containerPaths → validation list + gated next.
+    expect(q<HTMLButtonElement>(root, 'rsc-wizard-next').disabled).toBe(true)
+    expect(q(root, 'rsc-wizard-validation').textContent).toContain('keyField')
+
+    await fillValidSingleRecordStep2(root)
+    expect(maybe(root, 'rsc-wizard-validation')).toBeNull()
+    expect(q<HTMLButtonElement>(root, 'rsc-wizard-next').disabled).toBe(false)
+
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-step-3')).not.toBeNull()
+  })
+
+  it('preset card selection expands exactly that mode\'s MODE_REQUIRED_FIELDS field set (all four modes)', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+    await toStep2(root)
+
+    // All four cards render.
+    for (const mode of ['single_record', 'list_page', 'detail_with_lines', 'resolver_lookup']) {
+      expect(maybe(root, `rsc-wizard-mode-${mode}`), mode).not.toBeNull()
+    }
+
+    // single_record (default selected): keyField + containerPaths; no header/lines/resolverRule.
+    expect(maybe(root, 'rsc-wizard-key-field')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-container-paths')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-header-container-paths')).toBeNull()
+    expect(maybe(root, 'rsc-wizard-line-container-paths')).toBeNull()
+    expect(maybe(root, 'rsc-wizard-resolver-rule')).toBeNull()
+
+    // list_page: containerPaths only.
+    q<HTMLButtonElement>(root, 'rsc-wizard-mode-list_page').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-key-field')).toBeNull()
+    expect(maybe(root, 'rsc-wizard-container-paths')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-resolver-rule')).toBeNull()
+
+    // detail_with_lines: header + lines replace containerPaths; keyField only as Advanced optional.
+    q<HTMLButtonElement>(root, 'rsc-wizard-mode-detail_with_lines').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-container-paths')).toBeNull()
+    expect(maybe(root, 'rsc-wizard-header-container-paths')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-line-container-paths')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-key-field')).toBeNull()
+    q<HTMLButtonElement>(root, 'rsc-wizard-advanced-toggle').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-key-field-optional')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-key-encoding')).not.toBeNull()
+
+    // resolver_lookup: keyField + containerPaths + resolverRule; rule detail fields live in Advanced.
+    q<HTMLButtonElement>(root, 'rsc-wizard-mode-resolver_lookup').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-key-field')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-container-paths')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-resolver-rule')).not.toBeNull()
+    setSelect(root, 'rsc-wizard-resolver-rule', 'first_when_sorted')
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-resolver-sort-field')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-resolver-sort-direction')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-resolver-discriminator-value')).toBeNull()
+    setSelect(root, 'rsc-wizard-resolver-rule', 'field_equals')
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-resolver-discriminator-field')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-resolver-discriminator-value')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-resolver-sort-direction')).toBeNull()
+  })
+
+  it('back-navigation returns through earlier steps with state preserved', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+    await toStep2(root)
+    await fillValidSingleRecordStep2(root)
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-step-3')).not.toBeNull()
+
+    q<HTMLButtonElement>(root, 'rsc-wizard-back').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-step-2')).not.toBeNull()
+    expect(q<HTMLInputElement>(root, 'rsc-wizard-object').value).toBe('material')
+
+    q<HTMLButtonElement>(root, 'rsc-wizard-back').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-step-1')).not.toBeNull()
+    expect(q<HTMLButtonElement>(root, 'rsc-wizard-back').disabled).toBe(true)
+  })
+
+  it('step-3 probe posts the SAME contract body as the expert form and renders a humanized evidence card with collapsed raw codes', async () => {
+    const probeBodies: Array<string> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems/sys_1/read-source-probe')) {
+        probeBodies.push(String(init?.body ?? ''))
+        return jsonResponse({
+          ok: false,
+          object: 'material',
+          mode: 'single_record',
+          boundedSmoke: true,
+          errorCode: 'READ_SOURCE_PROBE_CONTAINER_NOT_FOUND',
+          errorType: 'ReadSourceProbeRuntimeError',
+          containers: { primary: { type: 'missing', arrayLength: null } },
+          containerLocated: false,
+        })
+      }
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await toStep2(root)
+    await fillValidSingleRecordStep2(root)
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+
+    // keyField declared → the probe-key input shows (same S2-b rule as the expert form).
+    const smoke = q<HTMLInputElement>(root, 'rsc-wizard-bounded-smoke')
+    smoke.checked = true
+    smoke.dispatchEvent(new Event('change'))
+    await flushUi()
+    setInput(root, 'rsc-wizard-probe-key', ' M-001 ')
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'rsc-wizard-probe-run').click()
+    await flushUi()
+
+    expect(probeBodies).toHaveLength(1)
+    expect(JSON.parse(probeBodies[0])).toEqual({
+      config: {
+        version: 1,
+        systemId: 'sys_1',
+        requiredKind: 'erp:k3-wise-webapi',
+        object: 'material',
+        mode: 'single_record',
+        readPath: '/K3API/Material/GetDetail',
+        readMethod: 'POST',
+        operations: ['read'],
+        keyField: 'FNumber',
+        containerPaths: ['Data'],
+      },
+      boundedSmoke: true,
+      inputs: { key: 'M-001' },
+    })
+
+    // Humanized conclusion in the prominent slot (IU-1 label module, en default locale)…
+    expect(q(root, 'rsc-wizard-evidence-summary').textContent).toContain('The target data container could not be found.')
+    // …container shape visible…
+    expect(q(root, 'rsc-wizard-evidence-container-primary').textContent).toContain('missing')
+    // …and raw machine codes demoted into a collapsed <details> block.
+    const raw = q<HTMLDetailsElement>(root, 'rsc-wizard-evidence-raw')
+    expect(raw.hasAttribute('open')).toBe(false)
+    expect(q(root, 'rsc-wizard-evidence-error-code').textContent).toContain('READ_SOURCE_PROBE_CONTAINER_NOT_FOUND')
+    expect(q(root, 'rsc-wizard-evidence-error-type').textContent).toContain('ReadSourceProbeRuntimeError')
+    // The raw code never appears in the prominent summary slot.
+    expect(q(root, 'rsc-wizard-evidence-summary').textContent).not.toContain('READ_SOURCE_PROBE_CONTAINER_NOT_FOUND')
+  })
+
+  it('step-4 saves via the existing service path, then approves the saved id via the existing approve path', async () => {
+    const saveBodies: string[] = []
+    const approveCalls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/approve') && init?.method === 'POST') {
+        approveCalls.push(url)
+        return jsonResponse({ id: 'cfg_wiz', systemId: 'sys_1', object: 'material', mode: 'single_record', version: 1, status: 'approved', contentKey: 'ck' })
+      }
+      if (url.startsWith('/api/integration/read-source-configs') && init?.method === 'POST') {
+        saveBodies.push(String(init?.body ?? ''))
+        return jsonResponse({ id: 'cfg_wiz', version: 1, status: 'draft', reused: false, contentKey: 'ck' })
+      }
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await toStep2(root)
+    await fillValidSingleRecordStep2(root)
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-wizard-step-4')).not.toBeNull()
+
+    // No approve affordance before a save result exists.
+    expect(maybe(root, 'rsc-wizard-approve')).toBeNull()
+
+    q<HTMLButtonElement>(root, 'rsc-wizard-save').click()
+    await flushUi()
+    expect(saveBodies).toHaveLength(1)
+    expect(q(root, 'rsc-wizard-save-result').textContent).toContain('v1')
+
+    // Approve requires confirm (same guard as the expert list-row approve); cancel = no call.
+    confirmMock.mockReturnValueOnce(false)
+    q<HTMLButtonElement>(root, 'rsc-wizard-approve').click()
+    await flushUi()
+    expect(approveCalls).toHaveLength(0)
+
+    confirmMock.mockReturnValueOnce(true)
+    q<HTMLButtonElement>(root, 'rsc-wizard-approve').click()
+    await flushUi()
+    expect(approveCalls).toHaveLength(1)
+    expect(approveCalls[0]).toContain('/api/integration/read-source-configs/cfg_wiz/approve')
+  })
+
+  // THE byte-equality hard-lock test (design-lock §2): the same inputs driven through the wizard
+  // surface and through the expert flat form must serialize to the IDENTICAL wire body — compared
+  // as raw strings (byte equality), not just deep equality.
+  async function captureWizardSaveBody(fill: (root: HTMLElement) => Promise<void>): Promise<string> {
+    const bodies: string[] = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/integration/read-source-configs') && init?.method === 'POST') {
+        bodies.push(String(init?.body ?? ''))
+        return jsonResponse({ id: 'cfg_a', version: 1, status: 'draft', reused: false, contentKey: 'ck' })
+      }
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      return jsonResponse(null)
+    })
+    const root = mountPanel()
+    await flushUi()
+    await fill(root)
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rsc-wizard-next').click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rsc-wizard-save').click()
+    await flushUi()
+    unmountPanel()
+    expect(bodies).toHaveLength(1)
+    return bodies[0]
+  }
+
+  async function captureExpertSaveBody(fill: (root: HTMLElement) => Promise<void>): Promise<string> {
+    const bodies: string[] = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/integration/read-source-configs') && init?.method === 'POST') {
+        bodies.push(String(init?.body ?? ''))
+        return jsonResponse({ id: 'cfg_b', version: 1, status: 'draft', reused: false, contentKey: 'ck' })
+      }
+      if (url.startsWith('/api/integration/read-source-configs')) return jsonResponse([])
+      return jsonResponse(null)
+    })
+    const root = mountPanel('expert')
+    await flushUi()
+    await fill(root)
+    q<HTMLButtonElement>(root, 'rsc-save').click()
+    await flushUi()
+    unmountPanel()
+    expect(bodies).toHaveLength(1)
+    return bodies[0]
+  }
+
+  it('BYTE-EQUALITY: wizard output === expert-form output for the same single_record inputs (incl. advanced fields)', async () => {
+    const wizardBody = await captureWizardSaveBody(async (root) => {
+      await toStep2(root)
+      await fillValidSingleRecordStep2(root)
+      // Advanced fields too: keyEncoding + readMethod + fieldMap (with whitespace to exercise trimming).
+      q<HTMLButtonElement>(root, 'rsc-wizard-advanced-toggle').click()
+      await flushUi()
+      setSelect(root, 'rsc-wizard-key-encoding', 'numeric_id')
+      setSelect(root, 'rsc-wizard-read-method', 'GET')
+      q<HTMLButtonElement>(root, 'rsc-wizard-field-map-add').click()
+      await flushUi()
+      setInput(root, 'rsc-wizard-field-map-source-0', ' FName ')
+      setInput(root, 'rsc-wizard-field-map-target-0', ' material_name ')
+      await flushUi()
+    })
+
+    const expertBody = await captureExpertSaveBody(async (root) => {
+      setSelect(root, 'rsc-system', 'sys_1')
+      await flushUi()
+      setInput(root, 'rsc-object', 'material')
+      setInput(root, 'rsc-read-path', 'K3API/Material/GetDetail')
+      setInput(root, 'rsc-key-field', 'FNumber')
+      setInput(root, 'rsc-container-paths', 'Data')
+      setSelect(root, 'rsc-key-encoding', 'numeric_id')
+      setSelect(root, 'rsc-read-method', 'GET')
+      q<HTMLButtonElement>(root, 'rsc-field-map-add').click()
+      await flushUi()
+      setInput(root, 'rsc-field-map-source-0', ' FName ')
+      setInput(root, 'rsc-field-map-target-0', ' material_name ')
+      await flushUi()
+    })
+
+    expect(wizardBody).toBe(expertBody) // byte-for-byte identical wire body
+    // Sanity: the shared body really is the fully-normalized S1 config (not two matching empties).
+    expect(JSON.parse(wizardBody)).toEqual({
+      config: {
+        version: 1,
+        systemId: 'sys_1',
+        requiredKind: 'erp:k3-wise-webapi',
+        object: 'material',
+        mode: 'single_record',
+        readPath: '/K3API/Material/GetDetail',
+        readMethod: 'GET',
+        operations: ['read'],
+        keyField: 'FNumber',
+        keyEncoding: 'numeric_id',
+        containerPaths: ['Data'],
+        fieldMap: [{ source: 'FName', target: 'material_name' }],
+      },
+    })
+  })
+
+  it('BYTE-EQUALITY: wizard output === expert-form output for resolver_lookup / field_equals', async () => {
+    const wizardBody = await captureWizardSaveBody(async (root) => {
+      await toStep2(root)
+      q<HTMLButtonElement>(root, 'rsc-wizard-mode-resolver_lookup').click()
+      await flushUi()
+      setInput(root, 'rsc-wizard-object', 'material')
+      setInput(root, 'rsc-wizard-read-path', '/K3API/Material/GetList')
+      setInput(root, 'rsc-wizard-key-field', 'FNumber')
+      setInput(root, 'rsc-wizard-container-paths', 'Data')
+      setSelect(root, 'rsc-wizard-resolver-rule', 'field_equals')
+      await flushUi()
+      q<HTMLButtonElement>(root, 'rsc-wizard-advanced-toggle').click()
+      await flushUi()
+      setInput(root, 'rsc-wizard-resolver-discriminator-field', 'FIsCurrent')
+      setInput(root, 'rsc-wizard-resolver-discriminator-value', 'Y')
+      q<HTMLButtonElement>(root, 'rsc-wizard-field-map-add').click()
+      await flushUi()
+      setInput(root, 'rsc-wizard-field-map-source-0', 'FItemID')
+      setInput(root, 'rsc-wizard-field-map-target-0', 'item_id')
+      await flushUi()
+    })
+
+    const expertBody = await captureExpertSaveBody(async (root) => {
+      setSelect(root, 'rsc-system', 'sys_1')
+      await flushUi()
+      setSelect(root, 'rsc-mode', 'resolver_lookup')
+      await flushUi()
+      setInput(root, 'rsc-object', 'material')
+      setInput(root, 'rsc-read-path', '/K3API/Material/GetList')
+      setInput(root, 'rsc-key-field', 'FNumber')
+      setInput(root, 'rsc-container-paths', 'Data')
+      setSelect(root, 'rsc-resolver-rule', 'field_equals')
+      await flushUi()
+      setInput(root, 'rsc-resolver-discriminator-field', 'FIsCurrent')
+      setInput(root, 'rsc-resolver-discriminator-value', 'Y')
+      q<HTMLButtonElement>(root, 'rsc-field-map-add').click()
+      await flushUi()
+      setInput(root, 'rsc-field-map-source-0', 'FItemID')
+      setInput(root, 'rsc-field-map-target-0', 'item_id')
+      await flushUi()
+    })
+
+    expect(wizardBody).toBe(expertBody)
+    expect(JSON.parse(wizardBody)).toEqual({
+      config: {
+        version: 1,
+        systemId: 'sys_1',
+        requiredKind: 'erp:k3-wise-webapi',
+        object: 'material',
+        mode: 'resolver_lookup',
+        readPath: '/K3API/Material/GetList',
+        readMethod: 'POST',
+        operations: ['read'],
+        keyField: 'FNumber',
+        resolverRule: 'field_equals',
+        multiplicityRuleField: 'FIsCurrent',
+        resolverDiscriminatorValue: 'Y',
+        containerPaths: ['Data'],
+        fieldMap: [{ source: 'FItemID', target: 'item_id' }],
+      },
+    })
+  })
+
+  it('expert-mode toggle: switches to the intact flat form and back (折叠≠删除)', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+
+    expect(maybe(root, 'read-source-wizard')).not.toBeNull()
+    expect(q(root, 'rsc-mode-toggle').textContent).toContain('Expert form')
+
+    q<HTMLButtonElement>(root, 'rsc-mode-toggle').click()
+    await flushUi()
+    // The full flat form is back, untouched — spot-check its signature controls (the exhaustive
+    // flat-form behavior suite is IntegrationReadSourceConfigPanel.spec.ts, unchanged).
+    expect(maybe(root, 'read-source-wizard')).toBeNull()
+    for (const testid of ['rsc-system', 'rsc-required-kind', 'rsc-object', 'rsc-mode', 'rsc-read-path', 'rsc-read-method', 'rsc-operations', 'rsc-version', 'rsc-key-field', 'rsc-key-encoding', 'rsc-container-paths', 'rsc-field-map-add', 'rsc-probe', 'rsc-save']) {
+      expect(maybe(root, testid), testid).not.toBeNull()
+    }
+    expect(q(root, 'rsc-mode-toggle').textContent).toContain('Back to wizard')
+
+    q<HTMLButtonElement>(root, 'rsc-mode-toggle').click()
+    await flushUi()
+    expect(maybe(root, 'read-source-wizard')).not.toBeNull()
+    expect(maybe(root, 'rsc-system')).toBeNull()
+  })
+
+  it('zh copy renders through useLocale for step titles, preset cards, nav, and toggle', async () => {
+    // Test-env default locale is 'en'; flip via the composable's setter (module-level ref — a
+    // localStorage write alone would not re-resolve it), same pattern as the panel spec's zh test.
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      mockListOnly()
+      const root = mountPanel()
+      await flushUi()
+
+      const stepsText = q(root, 'rsc-wizard-steps').textContent ?? ''
+      for (const title of ['①选系统', '②定形状', '③探测', '④审批']) {
+        expect(stepsText).toContain(title)
+      }
+      expect(q(root, 'rsc-mode-toggle').textContent).toContain('专家表单')
+      expect(q(root, 'rsc-wizard-next').textContent).toContain('下一步')
+      expect(q(root, 'rsc-wizard-back').textContent).toContain('上一步')
+
+      await toStep2(root)
+      const presetGrid = q(root, 'rsc-wizard-preset-grid').textContent ?? ''
+      for (const title of ['单记录读', '列表分页读', '主从明细读', '解析定位读']) {
+        expect(presetGrid).toContain(title)
+      }
+      expect(q(root, 'rsc-wizard-advanced-toggle').textContent).toContain('高级')
+    } finally {
+      setLocale('en')
+    }
+  })
+})

--- a/apps/web/tests/readSourceModePresets.spec.ts
+++ b/apps/web/tests/readSourceModePresets.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  READ_SOURCE_MODE_PRESETS,
+  readSourceModePreset,
+} from '../src/services/integration/readSourceModePresets'
+import {
+  READ_SOURCE_MODE_REQUIRED_FIELDS,
+  READ_SOURCE_MODES,
+} from '../src/services/integration/readSourceConfigs'
+
+// IU-3 preset-module tripwire (design-lock
+// docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md §2/§3, #3797):
+// the preset cards are a PRESENTATION mapping over the four existing READ_SOURCE_MODES values —
+// this spec is the anti-drift gate. If a future change adds a mode to READ_SOURCE_MODES without a
+// preset card, or lets a card's requiredFieldKeys diverge from the REAL
+// READ_SOURCE_MODE_REQUIRED_FIELDS constant, these tests go red.
+
+describe('readSourceModePresets (IU-3 tripwire)', () => {
+  it('every mode in READ_SOURCE_MODES has exactly one preset card, in the same canonical order', () => {
+    // Set-equality in BOTH directions: a mode without a card fails, and a card whose id is not a
+    // registered mode fails. Order preserved so wizards/tests can rely on the canonical sequence.
+    expect(READ_SOURCE_MODE_PRESETS.map((preset) => preset.id)).toEqual([...READ_SOURCE_MODES])
+  })
+
+  it('every card requiredFieldKeys === READ_SOURCE_MODE_REQUIRED_FIELDS[mode] (the real constant, not a copy)', () => {
+    for (const preset of READ_SOURCE_MODE_PRESETS) {
+      // toBe (identity), not just toEqual: the module must expose the REAL constant's array — a
+      // hand-maintained copy that happens to match today would still fail here, by design.
+      expect(preset.requiredFieldKeys, preset.id).toBe(READ_SOURCE_MODE_REQUIRED_FIELDS[preset.id])
+      expect(preset.requiredFieldKeys, preset.id).toEqual(READ_SOURCE_MODE_REQUIRED_FIELDS[preset.id])
+    }
+  })
+
+  it('every card carries non-empty zh+en title and one-liner (values-free presentation copy)', () => {
+    for (const preset of READ_SOURCE_MODE_PRESETS) {
+      expect(preset.title.zh.trim().length, `${preset.id} title.zh`).toBeGreaterThan(0)
+      expect(preset.title.en.trim().length, `${preset.id} title.en`).toBeGreaterThan(0)
+      expect(preset.oneLiner.zh.trim().length, `${preset.id} oneLiner.zh`).toBeGreaterThan(0)
+      expect(preset.oneLiner.en.trim().length, `${preset.id} oneLiner.en`).toBeGreaterThan(0)
+    }
+  })
+
+  it('readSourceModePreset() resolves each registered mode and throws on an unknown one', () => {
+    for (const mode of READ_SOURCE_MODES) {
+      expect(readSourceModePreset(mode).id).toBe(mode)
+    }
+    expect(() => readSourceModePreset('bulk_export' as (typeof READ_SOURCE_MODES)[number])).toThrow(/unknown read-source mode/)
+  })
+})

--- a/apps/web/tests/ui-foundation-style-guard.spec.ts
+++ b/apps/web/tests/ui-foundation-style-guard.spec.ts
@@ -65,6 +65,9 @@ const TARGET_FILES = [
   'src/components/integration/IntegrationExternalWritePanel.vue',
   'src/components/integration/IntegrationTableActionsPanel.vue',
   'src/components/integration/IntegrationFieldOptionSyncPanel.vue',
+  // IU-3 (docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md, #3797):
+  // brand-new wizard component, clean from the start (no legacy hex to migrate).
+  'src/components/integration/IntegrationReadSourceWizard.vue',
 ] as const
 
 // Per-file allowlist for counts that are legitimately un-clearable. Keep this EMPTY unless a

--- a/docs/development/integration-iu3-read-source-wizard-dev-verification-20260707.md
+++ b/docs/development/integration-iu3-read-source-wizard-dev-verification-20260707.md
@@ -1,0 +1,113 @@
+# IU-3 读取源配置四步向导 — DEV VERIFICATION — 2026-07-07
+
+> Design-lock: `integration-iu3-read-source-wizard-design-lock-20260707.md`（#3797 merged, owner
+> granted implementation 2026-07-07）。Umbrella: `integration-ux-workbench-redesign-design-lock-20260706.md`
+> (RATIFIED) §2 IU-3。本 MD 按锁 §3 的验收清单交付证据。
+
+## 1. 改动清单
+
+| 文件 | 变化 |
+| --- | --- |
+| `apps/web/src/services/integration/readSourceModePresets.ts` | **新增**：四张 preset 卡片元数据模块（errorCodeLabels 同风格，zh+en，values-free） |
+| `apps/web/src/components/integration/IntegrationReadSourceWizard.vue` | **新增**：el-steps 四步向导组件（纯重排壳，零 service 调用） |
+| `apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue` | 向导设为默认新建面 + `专家表单` 切换；新 `initialViewMode` prop；`evidenceContainers` 计算逻辑抽为共享纯 helper；新增 `approveSavedResult()`（复用既有 `approveReadSourceConfig`+`refresh`）。**平铺表单本体一行未动** |
+| `apps/web/src/services/integration/readSourceConfigs.ts` | 仅新增导出 `deriveReadSourceProbeEvidenceContainers`（从 panel 抽出的纯 shaping helper，行为逐字节相同）；其余全部不动 |
+| `apps/web/tests/readSourceModePresets.spec.ts` | **新增**：preset↔mode tripwire 测试 |
+| `apps/web/tests/IntegrationReadSourceWizard.spec.ts` | **新增**：向导 11 条组件测试（含两条字节等价） |
+| `apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts` | 仅 `mountPanel()` 增加 `initialViewMode: 'expert'` prop（注释说明）；**零断言变化**（锁 §2 既有测试不变量）— diff 全文只有该 helper 一处 |
+| `apps/web/tests/ui-foundation-style-guard.spec.ts` | TARGET_FILES += 向导组件（token-only 门覆盖新文件） |
+| `.github/workflows/integration-guard.yml` | path filters + vitest 名单加入新 source/spec 文件 |
+
+## 2. 四步向导 step map（锁 §1 交互骨架 → 实现）
+
+| 锁定步骤 | 实现 | 关键 testid |
+| --- | --- | --- |
+| ① 选系统 | 已注册 external-system 卡片点选；选中即把 `systemId` + `requiredKind`（=该系统 `kind`，即兼容适配器过滤的机制——config 只能消费所选系统的 kind，与专家表单 `onSystemChange` 完全同映射）写入共享 draft；未选不可下一步 | `rsc-wizard-system-<id>`、`rsc-wizard-next` |
+| ② 定形状 | 四张 preset 卡片（非裸 mode 下拉）；选定后**只展开该 mode `MODE_REQUIRED_FIELDS` 的必填字段**（卡片展示的 requiredFieldKeys 与实际渲染字段读同一个 computed，不可能漂移）；可选字段全部折叠进「高级」区：keyEncoding / resolver 多重性细项（排序字段/方向、判别字段/值）/ 多 fieldMap / detail_with_lines 的可选 keyField / readMethod / version（后两者为专家面能力对齐，保证向导可表达专家面全配置空间→字节等价普适成立）；校验不清零不可下一步 | `rsc-wizard-mode-<mode>`、`rsc-wizard-advanced-toggle`、`rsc-wizard-validation` |
+| ③ 探测 | 复用面板既有 `runProbe()`（emit 上抛，同一函数）；证据卡片化：人话结论（IU-1 `integrationErrorCodeDisplayLabel`/`integrationErrorCodeHint`）+ 容器/形状可视 + 机器码折叠进 `<details>`（默认收起，排障可展开）；失败时 hint 即下一步建议（IU-1 模块自带） | `rsc-wizard-probe-run`、`rsc-wizard-evidence-summary`、`rsc-wizard-evidence-raw` |
+| ④ 审批 | 复用面板既有 `saveVersion()`；保存成功后出现「提交审批」按钮 → `approveSavedResult()` 走既有 `approveReadSourceConfig` + `refresh()`（与列表行审批按钮同一 service 调用、同 confirm 守卫）；提交只在末步 | `rsc-wizard-save`、`rsc-wizard-approve` |
+
+上一步可回改（`rsc-wizard-back`，状态保留，golden 覆盖）；步进指示用 `el-steps`（装饰层；导航由原生按钮驱动，测试环境无 EP 也全功能）。
+
+## 3. preset 模块契约（锁 §2 "展示层映射，非新契约"）
+
+- 卡片 id 集 = `READ_SOURCE_MODES` 原样四值（`single_record`/`list_page`/`detail_with_lines`/`resolver_lookup`），**不新增 mode**。
+- 每张卡 `requiredFieldKeys` **就是** `READ_SOURCE_MODE_REQUIRED_FIELDS[mode]` 的同一数组引用（import 真源，非手抄副本），**不改 MODE_REQUIRED_FIELDS**。
+- 数组由 `READ_SOURCE_MODES.map(...)` 构建，缺卡片在 **import 时 throw**（dev/build 立红）。
+- 文案 zh+en、values-free（只描述读形状，零业务值示例）。
+
+## 4. tripwire 说明 + mutation 证明
+
+`readSourceModePresets.spec.ts` 三道闸：
+
+1. **mode 集合 tripwire**：`READ_SOURCE_MODE_PRESETS.map(id) toEqual [...READ_SOURCE_MODES]`（双向集合等价 + 顺序）——未来加 mode 未配卡片 → 红。
+2. **requiredFieldKeys 恒等 tripwire**：逐 mode `toBe`（引用恒等，非仅 deep-equal）——换成手抄副本即红，漂移在结构上不可能。
+3. 文案非空（zh+en 四字段）。
+
+Mutation 证明（每次单独注入 → 跑测 → revert，工作**先提交后做实验**）：
+
+| # | 注入 | 结果 |
+| --- | --- | --- |
+| M1 | `requiredFieldKeys: [...REAL[mode]]`（改为拷贝） | 恒等 tripwire 红（1 failed） |
+| M2 | preset 构建 `slice(0, 3)`（丢一张卡） | 集合 tripwire 红（2 failed） |
+| M3 | 向导 `selectSystem` 写 `kind.toUpperCase()`（与专家面分叉） | 字节等价 ×2 + probe-body 断言红（3 failed） |
+| M4 | 向导 style 块注入 `#4b5563` | ui-foundation-style-guard 红（1 failed） |
+
+## 5. 字节等价证明（锁 §2 首条硬锁）
+
+`IntegrationReadSourceWizard.spec.ts` 两条 `BYTE-EQUALITY` 测试：同一组输入分别**从真实 DOM** 驱动
+(a) 默认向导面（四步走完 → 保存）与 (b) `initialViewMode='expert'` 平铺面（同字段 → 保存），
+在 apiFetch mock 层截获两次 POST 的 **raw body 字符串**，断言 `wizardBody === expertBody`
+（字符串逐字节相等，非 deep-equal），再对 body 做整体形状断言防"两个空对象相等"假阳性。
+
+- 场景 1：`single_record` 含高级字段（keyEncoding=numeric_id、readMethod=GET、带空白的 fieldMap → 验证 trim 归一同路）。
+- 场景 2：`resolver_lookup`/`field_equals`（判别字段/值 + 单 fieldMap）。
+
+结构上的因：两面共写**同一个** reactive draft、共走**同一个** `buildReadSourceConfigPayload`（仅在
+panel 调用，本身未改）——测试把这个论证钉成经验事实（M3 证明测试确实咬人）。
+
+## 6. 零后端/契约变化声明
+
+- 本 PR **不含任何** `plugins/`、路由、validator、wire 形状改动：`readSourceConfigs.ts` 的 API 函数
+  （list/save/approve/retire/audit/probe）、S1 validator（`validateReadSourceDraft` + server 侧）、
+  probe 路由、审批路径全部原样；唯一 service 层 diff 是新增导出的纯 shaping helper（§1）。
+- 向导所有动作 emit 到 panel 的**既有**函数（`runProbe`/`saveVersion`/`approveReadSourceConfig`）；
+  没有新 fetch 调用点。
+- 探测证据仍全部经由既有 allowlist normalizer（`normalizeReadSourceProbeEvidence`）后才进模板；
+  人话层只消费 IU-1 注册闭词表；raw errorMessage 依旧无渲染路径。
+
+## 7. 专家模式保留证明（折叠≠删除）
+
+- 平铺表单 DOM/逻辑**逐行未动**（diff 上只被 `<template v-else>` 包裹 + 顶部加 toggle）；
+- 既有 `IntegrationReadSourceConfigPanel.spec.ts` 的**全部断言原文通过**（唯一 diff = mount helper 加
+  `initialViewMode: 'expert'` prop，锁明示允许的 stub/prop 附加，注释注明）；
+- 向导 spec 的 expert-toggle golden：默认向导 → 点 `rsc-mode-toggle` → 14 个平铺面签名 testid 全在 →
+  再点回向导。
+
+## 8. el-*/token 覆盖 + 图标
+
+- 新组件样式 **零 hex/零 rgb()**，全部 `var(--ms-*)`；已加入 `ui-foundation-style-guard.spec.ts`
+  TARGET_FILES（M4 证明闸有效）。panel 内新增 toggle 样式同样 token-only（该文件存量 hex 属 IU-2
+  范围，未触碰）。
+- 图标全走 Element Plus SVG（`@element-plus/icons-vue`：Check/ArrowDown/ArrowRight/CircleCheck/
+  WarningFilled/Setting/MagicStick）。
+- `el-steps`/`el-step` 测试 stub 走 IU-2a ElCard stub 同法（spec 头注释说明）。
+
+## 9. 测试与双 Node 结果
+
+| 检查 | Node 20 (v20.20.2) | 默认 (v25.9.0) |
+| --- | --- | --- |
+| integration-guard web 名单（20 spec files，含新 2 个） | **219/219 绿** | **219/219 绿** |
+| `pnpm --filter plugin-integration-core test`（35 CJS suites） | 全 OK | 全 OK |
+| `vue-tsc -b` | — | clean |
+| `vite build`（`pnpm build`） | — | 成功 |
+
+新增测试：`readSourceModePresets.spec.ts` 4 条；`IntegrationReadSourceWizard.spec.ts` 11 条
+（默认面 golden、步进门 ×2、四模式字段展开、回退保态、探测人话证据+折叠机器码+probe 契约体、
+save→approve 既有路径+confirm 守卫、字节等价 ×2、expert 切换、zh 文案——zh 走
+`useLocale().setLocale` 模式，与 panel spec 同法）。
+
+## 10. 边界内自查
+
+不含：新读取模式、后端/契约/审批路径改动、组合向导（IU-4）、JSON 结构化（IU-5）、移动端。
+锁外未加能力；锁内无未满足条款。


### PR DESCRIPTION
## Summary

Implements slice **IU-3 读取源配置四步向导** per design-lock `docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md` (#3797, owner-granted 2026-07-07). Umbrella: `integration-ux-workbench-redesign-design-lock-20260706.md` §2 IU-3.

- **`readSourceModePresets.ts`** (new): typed presentation-card metadata for the four existing `READ_SOURCE_MODES` — zh+en title/one-liner, values-free; `requiredFieldKeys` is the **identity reference** to the real `READ_SOURCE_MODE_REQUIRED_FIELDS[mode]` (never a copy), plus an import-time throw if a future mode lands without a card.
- **`IntegrationReadSourceWizard.vue`** (new): `el-steps` four-step wizard — ①选系统 (card pick, requiredKind auto-derived from the chosen system's kind, same mapping as the expert form) ②定形状 (preset cards, only that mode's MODE_REQUIRED_FIELDS fields rendered; keyEncoding / resolver rule details / fieldMap / optional keyField / readMethod / version folded into 高级) ③探测 (existing probe via emit; evidence card = IU-1 humanized label + container shape, raw codes in collapsed `<details>`) ④保存版本 → 提交审批 (existing save + approve service paths). Back-navigation preserved; submit only at step 4. Pure reordering shell: shares the panel's reactive draft, emits onto the panel's existing functions.
- **`IntegrationReadSourceConfigPanel.vue`**: wizard is the DEFAULT new-config surface, 专家表单 toggle returns to the intact flat form (折叠≠删除 — flat form body untouched, only wrapped in `v-else`). New `initialViewMode` prop lets the existing spec pin expert mode.

## Hard locks (design-lock §2) — evidence

- **零后端/契约变化**: no `plugins/` / route / validator / wire change; only service-layer diff is a pure shaping helper (`deriveReadSourceProbeEvidenceContainers`) extracted verbatim from the panel. All wizard actions emit to the panel's existing `runProbe`/`saveVersion`/`approveReadSourceConfig`.
- **Byte-equality**: two spec tests drive the same inputs through wizard DOM and expert-form DOM, capture both POST bodies at the fetch mock, and assert raw-string `===` (single_record + advanced fields; resolver_lookup/field_equals). Mutation-verified (requiredKind divergence → 3 tests red).
- **Preset tripwire**: `readSourceModePresets.spec.ts` asserts card-set ⇔ `READ_SOURCE_MODES` (both directions) and per-mode `toBe` identity with `READ_SOURCE_MODE_REQUIRED_FIELDS`. Mutation-verified (copy → red; dropped card → red).
- **既有测试不变量**: `IntegrationReadSourceConfigPanel.spec.ts` — the ONLY diff is `initialViewMode: 'expert'` in the mount helper (documented prop addition); **zero assertion changes**, all pass verbatim.
- **Token-only + EP icons**: wizard styles 100% `var(--ms-*)` (added to ui-foundation-style-guard TARGET_FILES; hex mutation → red); icons via `@element-plus/icons-vue` SVG.
- **values-free**: preset copy / wizard copy / evidence copy carry no business-value examples; zh+en via `useLocale`.

## Verification

- integration-guard full list (20 spec files incl. the 2 new): **219/219 green on Node 20.20.2 AND default Node 25.9.0**; `plugin-integration-core` CJS chain green on both.
- `vue-tsc -b` clean; `vite build` succeeds.
- 4 mutation experiments (module copy / dropped card / requiredKind divergence / hex literal) each proved the corresponding guard red, then reverted (work committed first).
- Verification MD: `docs/development/integration-iu3-read-source-wizard-dev-verification-20260707.md` (step map, preset contract, byte-equality proof, tripwire + mutation table, zero-backend statement, expert-retention proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)