### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaChartLoadError retry button to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaChartLoadError.vue
+++ b/apps/web/src/multitable/components/MetaChartLoadError.vue
@@ -3,18 +3,18 @@
        (or timeout) would otherwise leave the panel silently empty; this surfaces it + offers retry. -->
   <div class="meta-chart-load-error" data-chart-load-error="true">
     <span class="meta-chart-load-error__msg">{{ viewRenderLabel('dashboard.chartLoadFailed', isZh) }}</span>
-    <button
-      type="button"
+    <MtButton
       class="meta-chart-load-error__retry"
       data-action="retry-chart-load"
       @click="onRetry"
-    >{{ viewRenderLabel('dashboard.retry', isZh) }}</button>
+    >{{ viewRenderLabel('dashboard.retry', isZh) }}</MtButton>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useLocale } from '../../composables/useLocale'
 import { viewRenderLabel } from '../utils/meta-view-render-labels'
+import { MtButton } from '../ui'
 
 const { isZh } = useLocale()
 
@@ -46,17 +46,9 @@ function onRetry(): void {
   min-height: 120px;
   padding: 16px;
   font-size: 12px;
-  color: #b91c1c;
+  color: var(--ms-color-danger, #b91c1c);
   text-align: center;
 }
-
-.meta-chart-load-error__retry {
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 4px 12px;
-  background: #fff;
-  color: #0f172a;
-  font-size: 12px;
-  cursor: pointer;
-}
+/* .meta-chart-load-error__retry: the retry control is now <MtButton> (token-styled); its bespoke
+   button CSS was removed (P2-1c). The class is kept on the element only for selector stability. */
 </style>

--- a/apps/web/tests/meta-chart-load-error-migration.spec.ts
+++ b/apps/web/tests/meta-chart-load-error-migration.spec.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaChartLoadError from '../src/multitable/components/MetaChartLoadError.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaChartLoadError's retry control was migrated from a bespoke <button> to the shared
+// MtButton primitive. Interaction-preservation proof: the retry control is still a real, keyboard-
+// operable <button> that invokes the `retry` prop callback on click; data-action preserved.
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-chart-load-error').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaChartLoadError, props) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const retryBtn = (root: HTMLElement) =>
+  root.querySelector('[data-action="retry-chart-load"]') as HTMLButtonElement | null
+
+describe('MetaChartLoadError — MtButton migration (UI-P2-1c)', () => {
+  it('renders the retry control as a native <button> with data-action preserved', () => {
+    const root = mount({ retry: () => {} })
+    const btn = retryBtn(root)
+    expect(btn).toBeTruthy()
+    expect(btn!.tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+    expect(btn!.getAttribute('data-action')).toBe('retry-chart-load')
+  })
+
+  it('clicking retry invokes the `retry` prop callback (unchanged from pre-migration onRetry)', () => {
+    const retry = vi.fn()
+    const root = mount({ retry })
+    retryBtn(root)!.click()
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, self-merge bar). Retry control → MtButton; `data-action`/`@click=onRetry` preserved (onRetry logic unchanged); bespoke hex CSS removed, message → `--ms-color-danger`. Mount test (2/2): native `<button>` + data-action + retry-callback-on-click. vue-tsc clean; no new hex; residue guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)