### PR TITLE
feat(web): BA-UI-1 Bridge Agent read-only observability section (design-lock #3792, refs #3746)

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -35,6 +35,7 @@ on:
       - 'apps/web/src/components/integration/IntegrationObjectTemplateSection.vue'
       - 'apps/web/src/components/integration/IntegrationPayloadPreviewSection.vue'
       - 'apps/web/src/components/integration/IntegrationConnectionSection.vue'
+      - 'apps/web/src/components/integration/IntegrationBridgeAgentSection.vue'
       - 'apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts'
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
@@ -55,6 +56,7 @@ on:
       - 'apps/web/tests/IntegrationObjectTemplateSection.spec.ts'
       - 'apps/web/tests/IntegrationPayloadPreviewSection.spec.ts'
       - 'apps/web/tests/IntegrationConnectionSection.spec.ts'
+      - 'apps/web/tests/IntegrationBridgeAgentSection.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - '.github/workflows/integration-guard.yml'
@@ -76,6 +78,7 @@ on:
       - 'apps/web/src/components/integration/IntegrationObjectTemplateSection.vue'
       - 'apps/web/src/components/integration/IntegrationPayloadPreviewSection.vue'
       - 'apps/web/src/components/integration/IntegrationConnectionSection.vue'
+      - 'apps/web/src/components/integration/IntegrationBridgeAgentSection.vue'
       - 'apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts'
       - 'apps/web/src/views/IntegrationWorkbenchView.vue'
       - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
@@ -96,6 +99,7 @@ on:
       - 'apps/web/tests/IntegrationObjectTemplateSection.spec.ts'
       - 'apps/web/tests/IntegrationPayloadPreviewSection.spec.ts'
       - 'apps/web/tests/IntegrationConnectionSection.spec.ts'
+      - 'apps/web/tests/IntegrationBridgeAgentSection.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - '.github/workflows/integration-guard.yml'
@@ -143,4 +147,4 @@ jobs:
         run: pnpm --filter plugin-integration-core test
 
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView --reporter=dot

--- a/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
+++ b/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
@@ -1,0 +1,741 @@
+<template>
+  <section id="int-sec-bridge-agent" class="integration-workbench__panel" data-testid="bridge-agent-section">
+    <el-card shadow="never">
+      <template #header>
+        <div class="integration-workbench__panel-head">
+          <div>
+            <h2>{{ bi('Bridge Agent 观测', 'Bridge Agent Observability') }}</h2>
+            <p>{{ bi(
+              '只读可观测：查看已注册 Bridge Agent 实例的连通状态、暴露对象与 schema 形状。本区没有写入路径、没有本机 config 编辑入口，也不会触发计划任务的启停。',
+              'Read-only observability: check the reachability, exposed objects, and schema shape of registered Bridge Agent instances. This section has no write path, no local-config editing, and never starts or stops a scheduled task.',
+            ) }}</p>
+          </div>
+          <button
+            v-if="bridgeSystems.length > 0"
+            type="button"
+            class="integration-workbench__button"
+            data-testid="bridge-agent-check-all"
+            :disabled="checkingAll"
+            @click="checkAll"
+          >
+            <el-icon><Refresh /></el-icon>
+            {{ checkingAll ? bi('检查中…', 'Checking…') : bi('全部检查', 'Check all') }}
+          </button>
+        </div>
+      </template>
+
+      <div v-if="bridgeSystems.length === 0" class="integration-workbench__empty" data-testid="bridge-agent-empty-state">
+        <strong data-testid="bridge-agent-empty-what">{{ bi(
+          '这里展示已注册的 Bridge Agent 实例（kind = bridge:legacy-sql-readonly）的在线状态、暴露对象与 schema 预览。',
+          'This shows the online status, exposed objects, and schema preview of registered Bridge Agent instances (kind = bridge:legacy-sql-readonly).',
+        ) }}</strong>
+        <p data-testid="bridge-agent-empty-first-step">{{ bi(
+          '第一步：在上方“连接管理”区新增一个连接，类型选择只读 Bridge Agent；本机 Agent 通常由实施人员按 runbook 部署后再在此注册。',
+          'First step: add a connection in the “Connections” area above and choose the read-only Bridge Agent type — the local agent is usually deployed per the runbook by an implementer before it is registered here.',
+        ) }}</p>
+      </div>
+
+      <template v-else>
+        <div class="bridge-agent__cards" data-testid="bridge-agent-cards">
+          <div
+            v-for="system in bridgeSystems"
+            :key="system.id"
+            class="bridge-agent__card"
+            :data-testid="`bridge-agent-card-${system.id}`"
+          >
+            <div class="bridge-agent__card-head">
+              <el-icon class="bridge-agent__card-icon"><Connection /></el-icon>
+              <strong :data-testid="`bridge-agent-card-name-${system.id}`">{{ system.name }}</strong>
+              <span class="bridge-agent__badge bridge-agent__badge--readonly" :data-testid="`bridge-agent-card-readonly-${system.id}`">
+                <el-icon><Lock /></el-icon>{{ bi('只读', 'Read-only') }}
+              </span>
+            </div>
+            <div class="bridge-agent__card-body">
+              <span
+                class="bridge-agent__badge"
+                :class="statusBadgeClass(system.id)"
+                :data-status="statusDataAttr(system.id)"
+                :data-testid="`bridge-agent-card-status-${system.id}`"
+              >{{ statusLabel(system.id) }}</span>
+              <span class="bridge-agent__meta" :data-testid="`bridge-agent-card-checked-at-${system.id}`">
+                {{ bi('最近检查：', 'Last checked: ') }}{{ formatCheckedAt(system.id) }}
+              </span>
+            </div>
+            <p v-if="statusErrorLabel(system.id)" class="bridge-agent__error" :data-testid="`bridge-agent-card-error-${system.id}`">
+              {{ statusErrorLabel(system.id) }}
+            </p>
+            <button
+              type="button"
+              class="integration-workbench__button"
+              :data-testid="`bridge-agent-card-check-${system.id}`"
+              :disabled="isChecking(system.id)"
+              @click="checkSystem(system)"
+            >
+              <el-icon><Refresh /></el-icon>
+              {{ isChecking(system.id) ? bi('检查中…', 'Checking…') : bi('检查连接', 'Check connection') }}
+            </button>
+          </div>
+        </div>
+
+        <div class="bridge-agent__instances">
+          <h3>{{ bi('实例列表', 'Instances') }}</h3>
+          <table class="bridge-agent__table" data-testid="bridge-agent-instance-list">
+            <thead>
+              <tr>
+                <th>{{ bi('名称', 'Name') }}</th>
+                <th>
+                  <el-tooltip :content="fieldHint('bridgeAgent.instancePicker')" placement="top">
+                    <span>{{ bi('用途', 'Role') }}</span>
+                  </el-tooltip>
+                </th>
+                <th>{{ bi('状态', 'Status') }}</th>
+                <th>
+                  <el-tooltip :content="fieldHint('bridgeAgent.credentialStatus')" placement="top">
+                    <span>{{ bi('凭据', 'Credentials') }}</span>
+                  </el-tooltip>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="system in bridgeSystems" :key="system.id" :data-testid="`bridge-agent-instance-row-${system.id}`">
+                <td :data-testid="`bridge-agent-instance-name-${system.id}`">{{ system.name }}</td>
+                <td>{{ roleLabel(system) }}</td>
+                <td :data-testid="`bridge-agent-instance-status-${system.id}`">{{ coarseStatusLabel(system) }}</td>
+                <td :data-testid="`bridge-agent-instance-credential-${system.id}`">{{ credentialLabel(system) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="bridge-agent__objects">
+          <div class="bridge-agent__objects-head">
+            <h3>{{ bi('对象列表', 'Objects') }}</h3>
+            <label class="bridge-agent__instance-picker">
+              <span>{{ bi('实例', 'Instance') }}</span>
+              <select v-model="selectedSystemId" data-testid="bridge-agent-instance-picker">
+                <option v-for="system in bridgeSystems" :key="system.id" :value="system.id">{{ system.name }}</option>
+              </select>
+            </label>
+            <button
+              type="button"
+              class="integration-workbench__button"
+              data-testid="bridge-agent-objects-refresh"
+              :disabled="objectsLoading"
+              @click="loadObjects"
+            >
+              <el-icon><Refresh /></el-icon>
+              {{ objectsLoading ? bi('加载中…', 'Loading…') : bi('刷新对象列表', 'Reload objects') }}
+            </button>
+          </div>
+
+          <p v-if="objectsErrored" class="bridge-agent__error" data-testid="bridge-agent-objects-error">
+            {{ bi('对象列表加载失败，请检查连接状态后重试。', 'Failed to load the object list; check the connection status and retry.') }}
+          </p>
+
+          <div v-if="objectsLoading" class="integration-workbench__hint" data-testid="bridge-agent-objects-loading">
+            {{ bi('加载中…', 'Loading…') }}
+          </div>
+
+          <div
+            v-else-if="objectsLoaded && objects.length === 0 && !objectsErrored"
+            class="integration-workbench__empty"
+            data-testid="bridge-agent-objects-empty"
+          >
+            <strong data-testid="bridge-agent-objects-empty-what">{{ bi(
+              '该实例当前没有可读对象（本机 allowlist 为空）。',
+              'This instance currently has no readable objects (the local allowlist is empty).',
+            ) }}</strong>
+            <p data-testid="bridge-agent-objects-empty-first-step">{{ bi(
+              '第一步：在本机 Bridge Agent 配置中为该 endpoint 添加至少一个 allowlist 对象，再点击“刷新对象列表”。',
+              'First step: add at least one allowlisted object to this endpoint in the local Bridge Agent config, then click “Reload objects”.',
+            ) }}</p>
+          </div>
+
+          <table v-else-if="objects.length > 0" class="bridge-agent__table" data-testid="bridge-agent-objects-list">
+            <thead>
+              <tr>
+                <th>{{ bi('对象', 'Object') }}</th>
+                <th>Label</th>
+                <th>
+                  <el-tooltip :content="fieldHint('bridgeAgent.objectAllowlist')" placement="top">
+                    <span>{{ bi('字段数', 'Fields') }}</span>
+                  </el-tooltip>
+                </th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <template v-for="object in objects" :key="object.name">
+                <tr :data-testid="`bridge-agent-object-row-${object.name}`">
+                  <td>{{ object.name }}</td>
+                  <td>{{ object.label || object.name }}</td>
+                  <td :data-testid="`bridge-agent-object-field-count-${object.name}`">{{ formatFieldCount(object) }}</td>
+                  <td>
+                    <button
+                      type="button"
+                      class="integration-workbench__link-button"
+                      :data-testid="`bridge-agent-object-schema-toggle-${object.name}`"
+                      @click="toggleSchema(object.name)"
+                    >{{ expandedObject === object.name ? bi('收起 schema', 'Hide schema') : bi('查看 schema', 'View schema') }}</button>
+                  </td>
+                </tr>
+                <tr v-if="expandedObject === object.name" :data-testid="`bridge-agent-schema-row-${object.name}`">
+                  <td colspan="4">
+                    <div
+                      v-if="schemaLoading[object.name]"
+                      class="integration-workbench__hint"
+                      :data-testid="`bridge-agent-schema-loading-${object.name}`"
+                    >{{ bi('Schema 加载中…', 'Loading schema…') }}</div>
+                    <p
+                      v-else-if="schemaErrored[object.name]"
+                      class="bridge-agent__error"
+                      :data-testid="`bridge-agent-schema-error-${object.name}`"
+                    >{{ bi('Schema 加载失败，请重试。', 'Failed to load the schema; retry.') }}</p>
+                    <table
+                      v-else-if="schemaByObject[object.name]"
+                      class="bridge-agent__table"
+                      :data-testid="`bridge-agent-schema-${object.name}`"
+                    >
+                      <thead>
+                        <tr>
+                          <th>{{ bi('字段', 'Field') }}</th>
+                          <th>{{ bi('类型', 'Type') }}</th>
+                          <th>
+                            <el-tooltip :content="fieldHint('bridgeAgent.schemaPreview')" placement="top">
+                              <span>{{ bi('必填', 'Required') }}</span>
+                            </el-tooltip>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr
+                          v-for="field in schemaByObject[object.name]"
+                          :key="field.name"
+                          :data-testid="`bridge-agent-schema-field-${object.name}-${field.name}`"
+                        >
+                          <td>{{ field.name }}</td>
+                          <td>{{ field.type || bi('未提供', 'N/A') }}</td>
+                          <td>{{ field.required ? bi('是', 'Yes') : bi('否', 'No') }}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+      </template>
+    </el-card>
+  </section>
+</template>
+
+<script setup lang="ts">
+// BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md): Bridge Agent read-only
+// observability section. Self-contained (same shape as IntegrationReadSourceConfigPanel.vue) — the
+// parent view hands down the already-fetched `systems` list + `scope`; this component owns its own
+// local state/service calls for the three READ-ONLY generic routes it consumes: POST
+// /external-systems/:id/test, GET /external-systems/:id/objects, GET /external-systems/:id/schema.
+// ZERO new backend routes (see the BA-UI-1 verification MD's scout findings) and ZERO write path —
+// this file never references an upsert/delete/pipeline/dead-letter/staging service function, and
+// `POST /query/:object` (the data-plane read) is never called here either (design-lock §4).
+//
+// Security bounds (lock §2.1, binding):
+//   - No credential/host/connection-string/config is ever rendered — only the coarse
+//     `system.hasCredentials` boolean ("已配置/未配置"), never `system.config`/`system.credentials`.
+//   - No raw error text is ever rendered. Every failure surface routes through the IU-1
+//     `integrationErrorCodeDisplayLabel` helper (label-only). Unlike the closed, backend-owned code
+//     families IU-1 already labels, a Bridge Agent HTTP error body can carry an operator-supplied
+//     `error.code` (see errorCodeLabels.ts's BRIDGE_AGENT_* comment) — so even the registered CODE
+//     STRING itself is never interpolated into the DOM here, only its mapped display label (an
+//     unregistered/dynamic code safely degrades to the generic "unknown error" label). Object/schema
+//     load failures carry no code at all (the shared `parseIntegrationResponse` helper does not
+//     preserve one), so those use a fixed, values-free bilingual string.
+import { computed, reactive, ref, watch } from 'vue'
+import { Connection, Lock, Refresh } from '@element-plus/icons-vue'
+import { useLocale } from '../../composables/useLocale'
+import { integrationErrorCodeDisplayLabel } from '../../services/integration/errorCodeLabels'
+import { integrationFieldHint, type IntegrationFieldHintKey } from '../../services/integration/fieldHints'
+import {
+  getExternalSystemSchema,
+  listExternalSystemObjects,
+  testExternalSystemConnection,
+  type IntegrationObjectSchemaField,
+  type IntegrationScope,
+  type IntegrationSystemObject,
+  type WorkbenchExternalSystem,
+} from '../../services/integration/workbench'
+
+// The one external-system kind this section observes — mirrors
+// plugins/plugin-integration-core/index.cjs's `.registerAdapter('bridge:legacy-sql-readonly', ...)`.
+const BRIDGE_AGENT_KIND = 'bridge:legacy-sql-readonly'
+
+const props = defineProps<{
+  systems: WorkbenchExternalSystem[]
+  scope: IntegrationScope
+}>()
+
+const { locale } = useLocale()
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+function fieldHint(key: IntegrationFieldHintKey): string {
+  return integrationFieldHint(key, locale.value)
+}
+
+const bridgeSystems = computed(() => props.systems.filter((system) => system.kind === BRIDGE_AGENT_KIND))
+
+// --- Agent status cards (testConnection) -------------------------------------------------------
+
+interface CheckState {
+  checking: boolean
+  hasChecked: boolean
+  ok: boolean
+  code: string | null
+  checkedAt: string | null
+}
+
+// Read-only default for render-time lookups: the template helpers below must NEVER create/mutate
+// reactive entries during render (that would schedule a redundant re-render pass); only
+// checkSystem writes into checkStates.
+const UNCHECKED_STATE: Readonly<CheckState> = Object.freeze({
+  checking: false,
+  hasChecked: false,
+  ok: false,
+  code: null,
+  checkedAt: null,
+})
+
+const checkStates = reactive<Record<string, CheckState>>({})
+const checkingAll = ref(false)
+
+function stateFor(systemId: string): Readonly<CheckState> {
+  return checkStates[systemId] || UNCHECKED_STATE
+}
+
+function isChecking(systemId: string): boolean {
+  return stateFor(systemId).checking
+}
+
+async function checkSystem(system: WorkbenchExternalSystem): Promise<void> {
+  checkStates[system.id] = { ...stateFor(system.id), checking: true }
+  let ok = false
+  let code: string | null = null
+  try {
+    const result = await testExternalSystemConnection(system.id, props.scope)
+    ok = result.ok === true
+    code = typeof result.code === 'string' ? result.code : null
+  } catch {
+    ok = false
+    code = null
+  }
+  checkStates[system.id] = {
+    checking: false,
+    hasChecked: true,
+    ok,
+    code,
+    // Client-side "most recent check" timestamp — the platform's clock, not a value read off the wire.
+    checkedAt: new Date().toISOString(),
+  }
+}
+
+async function checkAll(): Promise<void> {
+  checkingAll.value = true
+  try {
+    for (const system of bridgeSystems.value) {
+      // Sequential, one instance at a time: a gentle probe cadence rather than a concurrent burst
+      // against what is typically a single localhost Bridge Agent process per instance.
+      // eslint-disable-next-line no-await-in-loop
+      await checkSystem(system)
+    }
+  } finally {
+    checkingAll.value = false
+  }
+}
+
+function statusLabel(systemId: string): string {
+  const state = stateFor(systemId)
+  if (state.checking) return bi('检查中…', 'Checking…')
+  if (!state.hasChecked) return bi('尚未检查', 'Not checked yet')
+  return state.ok ? bi('在线', 'Online') : bi('离线', 'Offline')
+}
+
+function statusDataAttr(systemId: string): 'unknown' | 'online' | 'offline' {
+  const state = stateFor(systemId)
+  if (!state.hasChecked) return 'unknown'
+  return state.ok ? 'online' : 'offline'
+}
+
+function statusBadgeClass(systemId: string): string {
+  const attr = statusDataAttr(systemId)
+  if (attr === 'online') return 'bridge-agent__badge--online'
+  if (attr === 'offline') return 'bridge-agent__badge--offline'
+  return ''
+}
+
+// Label-only — see the script-block security-bounds note: neither the raw code nor the raw message
+// is ever interpolated into the template, only this mapped, closed-vocabulary display string.
+function statusErrorLabel(systemId: string): string | null {
+  const state = stateFor(systemId)
+  if (!state.hasChecked || state.ok) return null
+  return integrationErrorCodeDisplayLabel(state.code, locale.value)
+}
+
+function formatCheckedAt(systemId: string): string {
+  const iso = stateFor(systemId).checkedAt
+  if (!iso) return bi('从未', 'Never')
+  const parsed = new Date(iso)
+  if (Number.isNaN(parsed.getTime())) return iso
+  return parsed.toLocaleString(locale.value === 'zh-CN' ? 'zh-CN' : 'en-US')
+}
+
+// --- Instance list (values-free: name / role / coarse status / credential boolean only) --------
+
+function roleLabel(system: WorkbenchExternalSystem): string {
+  if (system.role === 'target') return bi('目标', 'Target')
+  if (system.role === 'bidirectional') return bi('双向', 'Bidirectional')
+  return bi('数据源', 'Source')
+}
+
+function coarseStatusLabel(system: WorkbenchExternalSystem): string {
+  if (system.status === 'active') return bi('启用', 'Active')
+  if (system.status === 'inactive') return bi('停用', 'Inactive')
+  return bi('异常', 'Error')
+}
+
+// Lock §2.1: "凭据状态最多'已配置/未配置'布尔" — never anything more specific than this boolean
+// (never system.config, never system.credentials, never system.lastError).
+function credentialLabel(system: WorkbenchExternalSystem): string {
+  return system.hasCredentials ? bi('已配置', 'Configured') : bi('未配置', 'Not configured')
+}
+
+// --- Selected instance -> objects ---------------------------------------------------------------
+
+const selectedSystemId = ref('')
+
+const objects = ref<IntegrationSystemObject[]>([])
+const objectsLoading = ref(false)
+const objectsLoaded = ref(false)
+const objectsErrored = ref(false)
+
+async function loadObjects(): Promise<void> {
+  const systemId = selectedSystemId.value
+  if (!systemId) {
+    objects.value = []
+    objectsLoaded.value = false
+    return
+  }
+  objectsLoading.value = true
+  objectsErrored.value = false
+  try {
+    objects.value = await listExternalSystemObjects(systemId, props.scope)
+  } catch {
+    // Fixed, values-free copy only — never the thrown error's message (see security-bounds note).
+    objects.value = []
+    objectsErrored.value = true
+  } finally {
+    objectsLoading.value = false
+    objectsLoaded.value = true
+  }
+}
+
+// keyField is not currently part of the /objects wire shape (see the BA-UI-1 verification MD's
+// backend-scout finding) — render fieldCount when present, an explicit N/A otherwise, never a guess.
+function formatFieldCount(object: IntegrationSystemObject): string {
+  return typeof object.fieldCount === 'number' ? String(object.fieldCount) : bi('未提供', 'N/A')
+}
+
+// --- Per-object schema preview (fetched on demand, cached per object name) ----------------------
+
+const expandedObject = ref('')
+const schemaLoading = reactive<Record<string, boolean>>({})
+const schemaErrored = ref<Record<string, boolean>>({})
+const schemaByObject = ref<Record<string, IntegrationObjectSchemaField[]>>({})
+
+async function toggleSchema(objectName: string): Promise<void> {
+  if (expandedObject.value === objectName) {
+    expandedObject.value = ''
+    return
+  }
+  expandedObject.value = objectName
+  if (schemaByObject.value[objectName] || !selectedSystemId.value) return
+  schemaLoading[objectName] = true
+  schemaErrored.value = { ...schemaErrored.value, [objectName]: false }
+  try {
+    const schema = await getExternalSystemSchema(selectedSystemId.value, { ...props.scope, object: objectName })
+    // Explicit field mapping (name/type/required) only — never a spread of unknown keys, so an
+    // unexpected extra key on the wire response can never ride along into the DOM.
+    schemaByObject.value = {
+      ...schemaByObject.value,
+      [objectName]: schema.fields.map((field) => ({ name: field.name, type: field.type, required: field.required })),
+    }
+  } catch {
+    schemaErrored.value = { ...schemaErrored.value, [objectName]: true }
+  } finally {
+    schemaLoading[objectName] = false
+  }
+}
+
+watch(
+  bridgeSystems,
+  (list) => {
+    if (list.length === 0) {
+      selectedSystemId.value = ''
+      return
+    }
+    if (!list.some((system) => system.id === selectedSystemId.value)) {
+      selectedSystemId.value = list[0].id
+    }
+  },
+  { immediate: true },
+)
+
+watch(
+  selectedSystemId,
+  () => {
+    expandedObject.value = ''
+    schemaByObject.value = {}
+    schemaErrored.value = {}
+    void loadObjects()
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+/* Verbatim copies of the base rules from IntegrationWorkbenchView.vue's <style scoped> block that
+   this new section's markup also needs — see IntegrationMonitoringSection.vue's style block comment
+   for why duplication (not relocation) is correct: Vue's scoped CSS only reaches elements rendered by
+   the SAME SFC that declared the rule. */
+.integration-workbench h2 {
+  margin: 0;
+  font-size: 17px;
+}
+
+.integration-workbench h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.integration-workbench__panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.integration-workbench__panel p {
+  margin: 8px 0 0;
+  color: var(--ms-text-2);
+  line-height: 1.5;
+}
+
+.integration-workbench__panel {
+  margin-bottom: 16px;
+  padding: 16px;
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-card);
+}
+
+.integration-workbench__button,
+.integration-workbench__link-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.integration-workbench__button {
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  cursor: pointer;
+  font-weight: 700;
+  padding: 8px 12px;
+}
+
+.integration-workbench__button:hover {
+  border-color: var(--ms-color-primary);
+}
+
+.integration-workbench__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.integration-workbench__link-button {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--ms-color-primary);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.integration-workbench__hint {
+  margin-top: 10px;
+  color: var(--ms-text-2);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.integration-workbench__empty {
+  padding: 12px;
+  border: 1px dashed var(--ms-border);
+  border-radius: 6px;
+  color: var(--ms-text-2);
+}
+
+.integration-workbench__empty strong {
+  color: var(--ms-text-1);
+}
+
+.integration-workbench__empty p {
+  margin: 6px 0 0;
+}
+
+/* BA-UI-1 own classes below (fresh prefix — not extracted from the parent view). */
+
+.bridge-agent__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.bridge-agent__card {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: var(--ms-bg-page);
+}
+
+.bridge-agent__card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ms-text-1);
+}
+
+.bridge-agent__card-icon {
+  color: var(--ms-text-3);
+}
+
+.bridge-agent__card-head strong {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bridge-agent__card-body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--ms-text-2);
+}
+
+.bridge-agent__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.bridge-agent__badge--readonly {
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+}
+
+.bridge-agent__badge--online {
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
+}
+
+.bridge-agent__badge--offline {
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger);
+}
+
+.bridge-agent__meta {
+  color: var(--ms-text-3);
+}
+
+.bridge-agent__error {
+  margin: 0;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger);
+  font-size: 12px;
+}
+
+.bridge-agent__instances,
+.bridge-agent__objects {
+  margin-top: 20px;
+}
+
+.bridge-agent__objects-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.bridge-agent__instance-picker {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--ms-text-2);
+}
+
+.bridge-agent__instance-picker select {
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  color: var(--ms-text-1);
+  font: inherit;
+}
+
+.bridge-agent__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.bridge-agent__table th,
+.bridge-agent__table td {
+  border-bottom: 1px solid var(--el-border-color-lighter);
+  padding: 6px 8px;
+  text-align: left;
+  color: var(--ms-text-1);
+}
+
+.bridge-agent__table th {
+  color: var(--ms-text-2);
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .integration-workbench__panel-head {
+    display: grid;
+  }
+
+  .bridge-agent__objects-head {
+    display: grid;
+  }
+}
+</style>

--- a/apps/web/src/services/integration/errorCodeLabels.ts
+++ b/apps/web/src/services/integration/errorCodeLabels.ts
@@ -25,6 +25,14 @@
 //     NOT YET WIRED to any UI display site (no BOM-list-by-material UI exists yet as of IU-1) — labeled
 //     here for completeness/future use per design-lock IU-1 scope. Mirrored locally (below) rather than
 //     added to readSourceConfigs.ts, since nothing there references it today.
+//   - Bridge Agent readonly adapter (4): plugins/plugin-integration-core/lib/adapters/
+//     bridge-agent-readonly-adapter.cjs BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES. Wired to
+//     IntegrationBridgeAgentSection.vue (BA-UI-1, docs/development/
+//     bridge-agent-admin-page-design-lock-20260707.md) — the ONLY adapter-owned codes this family
+//     covers; an operator's own Bridge Agent HTTP response body may carry an arbitrary `error.code`
+//     (e.g. a custom allowlist/validation code from scripts/ops/bridge-agent-readonly.ps1), and that
+//     is DELIBERATELY left unregistered so it degrades to the generic unknown-error label rather than
+//     rendering dynamic, agent-supplied text.
 //   - Dead-letter mainline (10): plugins/plugin-integration-core/lib/pipeline-runner.cjs (the mainline
 //     pipeline path) plus generic fallbacks used there and in external-write-dry-run.cjs. Dead-letter
 //     `errorCode` is fed from multiple origins and is NOT one closed server-exported array, so only the
@@ -57,6 +65,15 @@ export const K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES = [
   'K3_WISE_BOM_LIST_BY_MATERIAL_NOT_FOUND',
   'K3_WISE_BOM_LIST_BY_MATERIAL_AMBIGUOUS',
   'K3_WISE_BOM_LIST_BY_MATERIAL_FIELD_MISSING',
+] as const
+
+// Bridge Agent readonly adapter — local mirror of the server's exported
+// BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES (bridge-agent-readonly-adapter.cjs). See module header.
+export const BRIDGE_AGENT_ERROR_CODES = [
+  'BRIDGE_AGENT_UNREACHABLE',
+  'BRIDGE_AGENT_TIMEOUT',
+  'BRIDGE_AGENT_REQUEST_FAILED',
+  'BRIDGE_AGENT_TEST_FAILED',
 ] as const
 
 // Dead-letter "known mainline" codes — not a single server-exported array (dead-letter `errorCode` is
@@ -109,6 +126,8 @@ export type IntegrationErrorCode =
   | 'READ_SOURCE_COMPOSITION_STEP_OUTPUT_NOT_SCALAR'
   // K3 WISE BOM-list-by-material (8) — see K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES above
   | (typeof K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES)[number]
+  // Bridge Agent readonly adapter (4) — see BRIDGE_AGENT_ERROR_CODES above
+  | (typeof BRIDGE_AGENT_ERROR_CODES)[number]
   // Dead-letter known mainline (10) — see DEAD_LETTER_MAINLINE_ERROR_CODES above
   | (typeof DEAD_LETTER_MAINLINE_ERROR_CODES)[number]
 
@@ -282,6 +301,29 @@ export const INTEGRATION_ERROR_CODE_LABELS: Record<IntegrationErrorCode, Integra
   K3_WISE_BOM_LIST_BY_MATERIAL_FIELD_MISSING: {
     zh: '所需字段缺失',
     en: 'A required field is missing.',
+  },
+
+  // --- Bridge Agent readonly adapter (4) ---
+  BRIDGE_AGENT_UNREACHABLE: {
+    zh: '无法连接到 Bridge Agent',
+    en: 'Cannot reach the Bridge Agent.',
+    hint: {
+      zh: '本机 Bridge Agent 服务可能未启动；请检查其计划任务/进程后重新检查连接。',
+      en: 'The local Bridge Agent service may not be running; check its scheduled task or process, then re-check the connection.',
+    },
+  },
+  BRIDGE_AGENT_TIMEOUT: {
+    zh: '连接 Bridge Agent 超时',
+    en: 'The connection to the Bridge Agent timed out.',
+    hint: { zh: '本机服务可能繁忙或无响应，可稍后重试。', en: 'The local service may be busy or unresponsive; retry later.' },
+  },
+  BRIDGE_AGENT_REQUEST_FAILED: {
+    zh: 'Bridge Agent 请求失败',
+    en: 'The Bridge Agent request failed.',
+  },
+  BRIDGE_AGENT_TEST_FAILED: {
+    zh: '连接测试执行失败',
+    en: 'The connection test failed to execute.',
   },
 
   // --- Dead-letter known mainline (10) ---

--- a/apps/web/src/services/integration/fieldHints.ts
+++ b/apps/web/src/services/integration/fieldHints.ts
@@ -48,6 +48,11 @@ export type IntegrationFieldHintKey =
   | 'composition.step2ConfigId'
   | 'composition.name'
   | 'composition.sourceTarget'
+  // --- BA-UI-1 Bridge Agent read-only observability section ---
+  | 'bridgeAgent.instancePicker'
+  | 'bridgeAgent.credentialStatus'
+  | 'bridgeAgent.objectAllowlist'
+  | 'bridgeAgent.schemaPreview'
 
 export type IntegrationFieldHintEntry = { zh: string; en: string }
 
@@ -127,6 +132,22 @@ export const INTEGRATION_FIELD_HINTS: Record<IntegrationFieldHintKey, Integratio
   'composition.sourceTarget': {
     zh: '第一跳输出字段名，将作为第二跳读取源的业务键输入；两跳之间的交接完全由平台完成，不经过浏览器。',
     en: "The first hop's output field name, used as the business-key input to the second hop's read source; the handoff between hops happens entirely on the platform, never through the browser.",
+  },
+  'bridgeAgent.instancePicker': {
+    zh: '一个实例对应一个已注册的 Bridge Agent 连接（endpoint）；选择后下方对象列表与 schema 预览针对该实例查询。',
+    en: 'An instance is one registered Bridge Agent connection (endpoint); the object list and schema preview below query the selected instance.',
+  },
+  'bridgeAgent.credentialStatus': {
+    zh: '仅显示"已配置/未配置"布尔状态；实际的 host、鉴权密钥等凭据始终由后端持有，前端从不回显。',
+    en: 'Shows only a configured/not-configured boolean; the actual host, auth secret, and other credentials are always held by the backend and never echoed to the browser.',
+  },
+  'bridgeAgent.objectAllowlist': {
+    zh: '这里列出的对象即 Bridge Agent 本机配置里的 allowlist；不在此列表中的对象无法被读取，也没有编辑入口。',
+    en: 'The objects listed here are exactly the Bridge Agent host config\'s allowlist; objects outside this list cannot be read and have no edit entry point.',
+  },
+  'bridgeAgent.schemaPreview': {
+    zh: 'schema 预览只展示字段名、类型与是否必填；本页不发起任何取数请求，永远不会显示业务行数据。',
+    en: 'The schema preview shows only field name, type, and required — this page never issues a data-read request and never displays business row data.',
   },
 }
 

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -194,6 +194,12 @@ export interface IntegrationSystemObject {
   schema?: IntegrationObjectSchemaField[]
   template?: Record<string, unknown>
   advanced?: boolean
+  // BA-UI-1 (additive TYPING of the existing wire shape — not a wire change): the readonly Bridge
+  // Agent adapter's listObjects() has always emitted fieldCount/readonly
+  // (bridge-agent-readonly-adapter.cjs normalizeObjectsResponse); the observability section renders
+  // fieldCount. Optional — other adapters' object lists don't carry them.
+  fieldCount?: number
+  readonly?: boolean
 }
 
 export interface IntegrationObjectSchema {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -758,6 +758,11 @@
       v-model:payload-template-text="payloadTemplateText"
       v-model:authored-field-rules="authoredFieldRules"
     />
+
+    <!-- BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md): read-only
+         Bridge Agent observability. Self-contained section (owns its own service calls to the three
+         existing read-only generic routes); the view only hands down the shared systems list + scope. -->
+    <IntegrationBridgeAgentSection :systems="systems" :scope="currentScope()" />
         </div>
       </div>
     </section>
@@ -856,6 +861,7 @@ import IntegrationMappingRulesSection from '../components/integration/Integratio
 import IntegrationObjectTemplateSection from '../components/integration/IntegrationObjectTemplateSection.vue'
 import IntegrationPayloadPreviewSection from '../components/integration/IntegrationPayloadPreviewSection.vue'
 import IntegrationConnectionSection from '../components/integration/IntegrationConnectionSection.vue'
+import IntegrationBridgeAgentSection from '../components/integration/IntegrationBridgeAgentSection.vue'
 
 type WorkbenchSide = 'source' | 'target'
 type TransformFn = '' | 'trim' | 'upper' | 'lower' | 'toNumber' | 'dictMap'
@@ -996,6 +1002,10 @@ const railGroups = computed<IntegrationWorkbenchRailGroup[]>(() => [
   { id: 'cleaning-mapping', label: bi('清洗映射', 'Cleansing & Mapping'), targetId: 'int-sec-object-template' },
   { id: 'run-push', label: bi('运行与推送', 'Run & Push'), targetId: 'int-sec-run-push' },
   { id: 'monitoring', label: bi('监控与死信', 'Monitoring & Dead Letters'), targetId: 'int-sec-monitoring' },
+  // BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md): 7th rail group —
+  // ADD-ONLY extension of the IU-2a six (the design-lock says the observability page rides the
+  // IU-2 skeleton as a new section, not a separate shell).
+  { id: 'bridge-agent', label: bi('Bridge Agent 观测', 'Bridge Agent'), targetId: 'int-sec-bridge-agent' },
 ])
 
 const sectionGroupIds: Record<string, string> = {
@@ -1009,6 +1019,7 @@ const sectionGroupIds: Record<string, string> = {
   'int-sec-run-push': 'run-push',
   'int-sec-monitoring': 'monitoring',
   'int-sec-preview': 'cleaning-mapping',
+  'int-sec-bridge-agent': 'bridge-agent',
 }
 
 const activeRailGroupId = ref('connection')

--- a/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
+++ b/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
@@ -1,0 +1,440 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp, type Component } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+import type { WorkbenchExternalSystem } from '../src/services/integration/workbench'
+
+// BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md): structural spec for
+// the read-only Bridge Agent observability section + the lock §2.1 SENTINEL test — plant
+// secret-shaped strings in every backend-supplied surface the component receives (system config /
+// credentials / lastError, test-connection message/code, objects/schema payload extras, error
+// bodies) and assert none of them ever reaches the rendered DOM.
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: vi.fn(),
+}))
+
+import IntegrationBridgeAgentSection from '../src/components/integration/IntegrationBridgeAgentSection.vue'
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function errorResponse(status: number, code: string, message: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: { code, message } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+}
+
+// ElCard stub — same pattern as IntegrationMonitoringSection.spec.ts (real Element Plus is not
+// globally installed in this createApp() instance).
+const ElCard = defineComponent({
+  name: 'ElCard',
+  props: { shadow: { type: String, required: false, default: undefined } },
+  setup(_props, { slots }) {
+    return () => h('div', { class: 'el-card' }, [
+      slots.header ? h('div', { class: 'el-card__header' }, slots.header()) : null,
+      h('div', { class: 'el-card__body' }, slots.default?.()),
+    ])
+  },
+})
+
+// --- sentinel vocabulary (secret-shaped strings that must NEVER render) -------------------------
+const SENTINEL = {
+  configSecret: 'SENTINEL-CONFIG-sk-a1b2c3d4e5',
+  credentialSecret: 'SENTINEL-CRED-sharedsecret-9f8e7d',
+  connectionString: 'Server=10.0.0.9;Database=K3;Password=SENTINEL-PW-x7y8z9;',
+  lastError: 'connect failed: token=SENTINEL-TOKEN-11aa22bb host=192.168.77.66',
+  testMessage: 'Bridge secret SENTINEL-MSG-deadbeef rejected at http://127.0.0.1:19091',
+  hostileCode: 'FAILED secret=SENTINEL-CODE-cafe0001',
+  objectExtra: 'SENTINEL-OBJECT-EXTRA-3355',
+  schemaExtra: 'SENTINEL-SCHEMA-EXTRA-7788',
+  errorBody: 'schema blew up: authorityCode=SENTINEL-AUTH-4433',
+} as const
+
+const BRIDGE_KIND = 'bridge:legacy-sql-readonly'
+
+function bridgeSystem(overrides: Partial<WorkbenchExternalSystem> = {}): WorkbenchExternalSystem {
+  return {
+    id: 'sys_bridge_1',
+    tenantId: 'default',
+    workspaceId: null,
+    name: 'Legacy SQL Bridge',
+    kind: BRIDGE_KIND,
+    role: 'source',
+    status: 'active',
+    // Secret-shaped values a hostile/legacy backend response could carry — the component must
+    // never render ANY of config/credentials/lastError (lock §2.1).
+    config: {
+      baseUrl: 'http://127.0.0.1:19091/',
+      sharedSecretEnvVar: SENTINEL.configSecret,
+      connectionString: SENTINEL.connectionString,
+    },
+    hasCredentials: true,
+    lastTestedAt: null,
+    lastError: SENTINEL.lastError,
+    ...overrides,
+  } as WorkbenchExternalSystem
+}
+
+function httpSystem(): WorkbenchExternalSystem {
+  return {
+    id: 'sys_http_1',
+    tenantId: 'default',
+    workspaceId: null,
+    name: 'Plain HTTP System',
+    kind: 'http',
+    role: 'source',
+    status: 'active',
+  } as WorkbenchExternalSystem
+}
+
+const OBJECTS_PAYLOAD = [
+  {
+    name: 'material',
+    label: 'Material',
+    operations: ['read'],
+    source: 'bridge:legacy-sql-readonly',
+    readonly: true,
+    fieldCount: 4,
+    // hostile extra key — must not render
+    connectionString: SENTINEL.objectExtra,
+  },
+  { name: 'bom', label: 'BOM Header', operations: ['read'], readonly: true, fieldCount: 3 },
+]
+
+const SCHEMA_PAYLOAD = {
+  object: 'material',
+  fields: [
+    { name: 'FItemID', type: 'number', required: false, defaultValue: SENTINEL.schemaExtra },
+    { name: 'FNumber', type: 'string', required: true },
+    { name: 'FName', type: 'string', required: true },
+  ],
+  raw: { source: 'bridge:legacy-sql-readonly', leaked: SENTINEL.schemaExtra },
+}
+
+type RouteOverrides = {
+  test?: () => Response
+  objects?: () => Response
+  schema?: () => Response
+}
+
+function mockRoutes(overrides: RouteOverrides = {}): void {
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (typeof url !== 'string') return jsonResponse(null)
+    if (url.includes('/test')) {
+      return overrides.test
+        ? overrides.test()
+        : jsonResponse({ ok: true, connected: true, authenticated: true, message: SENTINEL.testMessage })
+    }
+    if (url.includes('/objects')) {
+      return overrides.objects ? overrides.objects() : jsonResponse(OBJECTS_PAYLOAD)
+    }
+    if (url.includes('/schema')) {
+      return overrides.schema ? overrides.schema() : jsonResponse(SCHEMA_PAYLOAD)
+    }
+    return jsonResponse(null)
+  })
+}
+
+describe('IntegrationBridgeAgentSection', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  function mountSection(systems: WorkbenchExternalSystem[]): HTMLDivElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () => h(IntegrationBridgeAgentSection as unknown as Component, {
+        systems,
+        scope: { tenantId: 'default', workspaceId: null },
+      }),
+    })
+    app.component('ElCard', ElCard)
+    app.mount(container)
+    return container
+  }
+
+  function q<T extends HTMLElement>(root: HTMLElement, testid: string): T {
+    const el = root.querySelector<T>(`[data-testid="${testid}"]`)
+    if (!el) throw new Error(`missing [data-testid=${testid}]`)
+    return el
+  }
+
+  it('renders the guided empty state (what-this-is + first-step) when no bridge-agent system is registered', async () => {
+    mockRoutes()
+    const root = mountSection([httpSystem()])
+    await flushUi()
+
+    expect(root.querySelector('#int-sec-bridge-agent')).not.toBeNull()
+    q(root, 'bridge-agent-empty-state')
+    const what = q(root, 'bridge-agent-empty-what')
+    const firstStep = q(root, 'bridge-agent-empty-first-step')
+    expect(what.textContent).toContain(BRIDGE_KIND)
+    expect(firstStep.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    // Default test-env locale is 'en' — the first step names the concrete action (add a connection).
+    expect(firstStep.textContent).toMatch(/add a connection/i)
+    // No status card / instance table for a non-bridge kind (the section filters by kind).
+    expect(root.querySelector('[data-testid="bridge-agent-cards"]')).toBeNull()
+    // Filtering also means no objects fetch was issued for the http system.
+    expect(apiFetchMock).not.toHaveBeenCalled()
+
+    // zh variant coverage — flip via the composable setter, remount, assert the zh copy.
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      app!.unmount()
+      container!.remove()
+      const zhRoot = mountSection([httpSystem()])
+      await flushUi()
+      expect(q(zhRoot, 'bridge-agent-empty-first-step').textContent).toContain('连接管理')
+      expect(q(zhRoot, 'bridge-agent-empty-what').textContent).toContain('在线状态')
+    } finally {
+      setLocale('en')
+    }
+  })
+
+  it('status card: renders online after a successful mocked testConnection, with readonly badge and client-side timestamp', async () => {
+    mockRoutes()
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    // Pre-check state
+    expect(q(root, `bridge-agent-card-status-${system.id}`).getAttribute('data-status')).toBe('unknown')
+    expect(q(root, `bridge-agent-card-checked-at-${system.id}`).textContent).toMatch(/never/i)
+    // Read-only badge is unconditional (lock: the page must carry the 只读 mark).
+    expect(q(root, `bridge-agent-card-readonly-${system.id}`).textContent?.trim().length ?? 0).toBeGreaterThan(0)
+
+    q<HTMLButtonElement>(root, `bridge-agent-card-check-${system.id}`).click()
+    await flushUi()
+
+    const status = q(root, `bridge-agent-card-status-${system.id}`)
+    expect(status.getAttribute('data-status')).toBe('online')
+    expect(status.textContent).toMatch(/online/i)
+    expect(q(root, `bridge-agent-card-checked-at-${system.id}`).textContent).not.toMatch(/never/i)
+    // The POST hit the existing generic test route — no new backend route.
+    const testCall = apiFetchMock.mock.calls.find(([url]) => typeof url === 'string' && (url as string).includes('/test'))
+    expect(testCall?.[0]).toContain(`/api/integration/external-systems/${system.id}/test`)
+  })
+
+  it('status card: a failed check renders offline + the IU-1 display label — never the raw code, never the raw message', async () => {
+    mockRoutes({
+      test: () => jsonResponse({
+        ok: false,
+        connected: false,
+        code: 'BRIDGE_AGENT_UNREACHABLE',
+        message: SENTINEL.testMessage,
+      }),
+    })
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    q<HTMLButtonElement>(root, `bridge-agent-card-check-${system.id}`).click()
+    await flushUi()
+
+    expect(q(root, `bridge-agent-card-status-${system.id}`).getAttribute('data-status')).toBe('offline')
+    const error = q(root, `bridge-agent-card-error-${system.id}`)
+    // IU-1 label for the registered code (en) — the human label, not the enum.
+    expect(error.textContent).toContain('Cannot reach the Bridge Agent.')
+    const html = root.innerHTML
+    expect(html).not.toContain('BRIDGE_AGENT_UNREACHABLE')
+    expect(html).not.toContain(SENTINEL.testMessage)
+  })
+
+  it('status card: an UNREGISTERED (agent-supplied) code degrades to the generic unknown label, never rendering the code text', async () => {
+    mockRoutes({
+      test: () => jsonResponse({ ok: false, connected: false, code: SENTINEL.hostileCode }),
+    })
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    q<HTMLButtonElement>(root, `bridge-agent-card-check-${system.id}`).click()
+    await flushUi()
+
+    const error = q(root, `bridge-agent-card-error-${system.id}`)
+    expect(error.textContent).toContain('Unknown error')
+    expect(root.innerHTML).not.toContain(SENTINEL.hostileCode)
+  })
+
+  it('instance list: name + role + coarse status + credential BOOLEAN only', async () => {
+    mockRoutes()
+    const configured = bridgeSystem()
+    const unconfigured = bridgeSystem({ id: 'sys_bridge_2', name: 'Second Bridge', hasCredentials: false, status: 'inactive' })
+    const root = mountSection([configured, unconfigured, httpSystem()])
+    await flushUi()
+
+    q(root, 'bridge-agent-instance-list')
+    // Only the two bridge-kind systems appear.
+    expect(root.querySelectorAll('[data-testid^="bridge-agent-instance-row-"]').length).toBe(2)
+    expect(root.innerHTML).not.toContain('Plain HTTP System')
+
+    expect(q(root, `bridge-agent-instance-name-${configured.id}`).textContent).toBe('Legacy SQL Bridge')
+    expect(q(root, `bridge-agent-instance-credential-${configured.id}`).textContent).toMatch(/configured/i)
+    expect(q(root, 'bridge-agent-instance-credential-sys_bridge_2').textContent).toMatch(/not configured/i)
+    expect(q(root, 'bridge-agent-instance-status-sys_bridge_2').textContent).toMatch(/inactive/i)
+  })
+
+  it('objects + schema: renders the mocked listObjects result and, on toggle, the getSchema field shapes', async () => {
+    mockRoutes()
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    // objects auto-load for the selected instance via the existing generic objects route
+    const objectsCall = apiFetchMock.mock.calls.find(([url]) => typeof url === 'string' && (url as string).includes('/objects'))
+    expect(objectsCall?.[0]).toContain(`/api/integration/external-systems/${system.id}/objects`)
+
+    q(root, 'bridge-agent-objects-list')
+    expect(q(root, 'bridge-agent-object-row-material').textContent).toContain('material')
+    expect(q(root, 'bridge-agent-object-field-count-material').textContent).toBe('4')
+    expect(q(root, 'bridge-agent-object-row-bom').textContent).toContain('BOM Header')
+
+    // schema preview on demand
+    q<HTMLButtonElement>(root, 'bridge-agent-object-schema-toggle-material').click()
+    await flushUi()
+
+    const schemaCall = apiFetchMock.mock.calls.find(([url]) => typeof url === 'string' && (url as string).includes('/schema'))
+    expect(schemaCall?.[0]).toContain(`/api/integration/external-systems/${system.id}/schema`)
+    expect(schemaCall?.[0]).toContain('object=material')
+
+    const schemaTable = q(root, 'bridge-agent-schema-material')
+    expect(q(root, 'bridge-agent-schema-field-material-FNumber').textContent).toContain('FNumber')
+    expect(q(root, 'bridge-agent-schema-field-material-FNumber').textContent).toMatch(/yes/i)
+    expect(q(root, 'bridge-agent-schema-field-material-FItemID').textContent).toMatch(/no/i)
+    expect(schemaTable.textContent).toContain('number')
+
+    // Lock §4: the data plane is NEVER touched — no /query call, and every call the section made is
+    // one of the three read-only generic endpoints.
+    for (const [url] of apiFetchMock.mock.calls) {
+      expect(String(url)).not.toContain('/query')
+      expect(String(url)).toMatch(/\/api\/integration\/external-systems\/[^/]+\/(test|objects|schema)/)
+    }
+  })
+
+  it('objects: renders the guided allowlist-empty state when the agent exposes zero objects', async () => {
+    mockRoutes({ objects: () => jsonResponse([]) })
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    q(root, 'bridge-agent-objects-empty')
+    const what = q(root, 'bridge-agent-objects-empty-what')
+    const firstStep = q(root, 'bridge-agent-objects-empty-first-step')
+    expect(what.textContent).toMatch(/allowlist/i)
+    expect(firstStep.textContent).toMatch(/reload objects/i)
+  })
+
+  it('objects/schema failures render fixed values-free copy — never the backend error body', async () => {
+    mockRoutes({
+      objects: () => errorResponse(500, 'BRIDGE_AGENT_REQUEST_FAILED', SENTINEL.errorBody),
+    })
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    q(root, 'bridge-agent-objects-error')
+    expect(root.innerHTML).not.toContain(SENTINEL.errorBody)
+    expect(root.innerHTML).not.toContain('SENTINEL-AUTH-4433')
+
+    // schema failure branch, same discipline
+    apiFetchMock.mockReset()
+    mockRoutes({
+      schema: () => errorResponse(500, 'BRIDGE_AGENT_REQUEST_FAILED', SENTINEL.errorBody),
+    })
+    app!.unmount()
+    container!.remove()
+    const root2 = mountSection([bridgeSystem()])
+    await flushUi()
+    q<HTMLButtonElement>(root2, 'bridge-agent-object-schema-toggle-material').click()
+    await flushUi()
+    q(root2, 'bridge-agent-schema-error-material')
+    expect(root2.innerHTML).not.toContain(SENTINEL.errorBody)
+  })
+
+  it('SENTINEL (lock §2.1): no secret-shaped string from system config/credentials/lastError/test message/payload extras ever reaches the DOM', async () => {
+    mockRoutes({
+      test: () => jsonResponse({
+        ok: false,
+        connected: false,
+        code: 'BRIDGE_AGENT_UNREACHABLE',
+        message: SENTINEL.testMessage,
+        system: {
+          ...bridgeSystem(),
+          config: { sharedSecret: SENTINEL.credentialSecret },
+        },
+      }),
+    })
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    // exercise every render path: check + objects (auto) + schema
+    q<HTMLButtonElement>(root, `bridge-agent-card-check-${system.id}`).click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'bridge-agent-object-schema-toggle-material').click()
+    await flushUi()
+
+    const html = root.innerHTML
+    const text = root.textContent || ''
+    for (const [key, sentinel] of Object.entries(SENTINEL)) {
+      expect(html.includes(sentinel), `sentinel leaked into DOM html: ${key}`).toBe(false)
+      expect(text.includes(sentinel), `sentinel leaked into DOM text: ${key}`).toBe(false)
+    }
+    // Sub-fragments too (a partial render of a connection string is still a leak).
+    for (const fragment of ['SENTINEL-', 'Password=', 'token=', 'authorityCode=', '192.168.77.66', 'sharedsecret']) {
+      expect(html.includes(fragment), `sentinel fragment leaked into DOM: ${fragment}`).toBe(false)
+    }
+    // The coarse credential boolean is the ONLY credential-adjacent output.
+    expect(q(root, `bridge-agent-instance-credential-${system.id}`).textContent).toMatch(/configured/i)
+  })
+
+  it('zh copy: section heading + core labels render in Chinese under zh-CN', async () => {
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      mockRoutes()
+      const system = bridgeSystem()
+      const root = mountSection([system])
+      await flushUi()
+
+      expect(root.textContent).toContain('Bridge Agent 观测')
+      expect(root.textContent).toContain('只读')
+      expect(root.textContent).toContain('实例列表')
+      expect(root.textContent).toContain('对象列表')
+      expect(q(root, `bridge-agent-card-status-${system.id}`).textContent).toContain('尚未检查')
+      expect(q(root, `bridge-agent-instance-credential-${system.id}`).textContent).toContain('已配置')
+
+      q<HTMLButtonElement>(root, `bridge-agent-card-check-${system.id}`).click()
+      await flushUi()
+      expect(q(root, `bridge-agent-card-status-${system.id}`).textContent).toContain('在线')
+    } finally {
+      setLocale('en')
+    }
+  })
+})

--- a/apps/web/tests/IntegrationWorkbenchRail.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchRail.spec.ts
@@ -48,6 +48,9 @@ const railGroups: IntegrationWorkbenchRailGroup[] = [
   { id: 'cleaning-mapping', label: '清洗映射', targetId: 'int-sec-object-template' },
   { id: 'run-push', label: '运行与推送', targetId: 'int-sec-run-push' },
   { id: 'monitoring', label: '监控与死信', targetId: 'int-sec-monitoring' },
+  // BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md): 7th group —
+  // ADD-ONLY extension; the six IU-2a groups above are untouched.
+  { id: 'bridge-agent', label: 'Bridge Agent 观测', targetId: 'int-sec-bridge-agent' },
 ]
 
 describe('IntegrationWorkbenchRail (unit)', () => {
@@ -79,16 +82,18 @@ describe('IntegrationWorkbenchRail (unit)', () => {
     await flushUi(1)
   }
 
-  it('renders all six design-lock groups', async () => {
+  it('renders all seven groups (six IU-2a design-lock groups + the BA-UI-1 bridge-agent group)', async () => {
     await mountRail()
     const items = container!.querySelectorAll('.integration-workbench-rail__item')
-    expect(items.length).toBe(6)
+    expect(items.length).toBe(7)
     expect(container!.textContent).toContain('连接管理')
     expect(container!.textContent).toContain('读取源')
     expect(container!.textContent).toContain('组合')
     expect(container!.textContent).toContain('清洗映射')
     expect(container!.textContent).toContain('运行与推送')
     expect(container!.textContent).toContain('监控与死信')
+    // BA-UI-1: 7th group (add-only — the six assertions above are unchanged).
+    expect(container!.textContent).toContain('Bridge Agent 观测')
   })
 
   it('marks the active group via aria-current and the active class', async () => {
@@ -168,15 +173,18 @@ describe('IntegrationWorkbenchView — IU-2a chrome integration', () => {
     'int-sec-run-push',
     'int-sec-monitoring',
     'int-sec-preview',
+    // BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md): 11th section
+    // anchor — add-only extension of the IU-2a ten.
+    'int-sec-bridge-agent',
   ]
 
-  it('renders PageShell (wide) + PageHeader chrome, the rail, and all ten section anchors', async () => {
+  it('renders PageShell (wide) + PageHeader chrome, the rail, and all eleven section anchors', async () => {
     await mountView()
     expect(container!.querySelector('.ms-page-shell')).toBeTruthy()
     expect(container!.querySelector('.ms-page-shell--wide')).toBeTruthy()
     expect(container!.querySelector('.ms-page-header__title')?.textContent).toBe('数据工厂')
     expect(container!.querySelector('[data-testid="integration-help-link"]')).toBeTruthy()
-    for (const groupId of ['connection', 'read-source', 'combination', 'cleaning-mapping', 'run-push', 'monitoring']) {
+    for (const groupId of ['connection', 'read-source', 'combination', 'cleaning-mapping', 'run-push', 'monitoring', 'bridge-agent']) {
       expect(container!.querySelector(`[data-testid="integration-rail-${groupId}"]`)).toBeTruthy()
     }
     for (const id of sectionIds) {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -115,8 +115,10 @@ describe('IntegrationWorkbenchView', () => {
 
   // IU-2a quality gate: the rail↔view WIRING is pinned here (the rail component's own spec uses
   // fixture groups, so without this a dropped group — or the whole rail — in the view would pass
-  // every existing test). Six groups, each anchoring an existing section id.
-  it('wires the six rail groups to real section anchors', async () => {
+  // every existing test). Six IU-2a groups + the BA-UI-1 bridge-agent group (add-only extension,
+  // docs/development/bridge-agent-admin-page-design-lock-20260707.md), each anchoring an existing
+  // section id.
+  it('wires the seven rail groups to real section anchors', async () => {
     localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url === '/api/integration/adapters') return jsonResponse([])
@@ -141,13 +143,15 @@ describe('IntegrationWorkbenchView', () => {
       ['cleaning-mapping', 'int-sec-object-template'],
       ['run-push', 'int-sec-run-push'],
       ['monitoring', 'int-sec-monitoring'],
+      // BA-UI-1: 7th group (add-only — the six IU-2a pairs above are unchanged).
+      ['bridge-agent', 'int-sec-bridge-agent'],
     ]
     for (const [groupId, sectionId] of expected) {
       const item = root.querySelector(`[data-testid="integration-rail-${groupId}"]`)
       expect(item, `rail group ${groupId} must render`).not.toBeNull()
       expect(root.querySelector(`#${sectionId}`), `section ${sectionId} must exist for ${groupId}`).not.toBeNull()
     }
-    expect(root.querySelectorAll('[data-testid^="integration-rail-"]').length).toBe(6)
+    expect(root.querySelectorAll('[data-testid^="integration-rail-"]').length).toBe(7)
   })
 
   it('loads systems, object schemas, and previews a template payload', async () => {

--- a/apps/web/tests/integrationErrorCodeLabels.spec.ts
+++ b/apps/web/tests/integrationErrorCodeLabels.spec.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest'
 // this module is not synced, this test fails RED — same discipline as
 // multitable-resolver-vocab-mirror.spec.ts / composition-vocab-mirror.spec.ts.
 import {
+  BRIDGE_AGENT_ERROR_CODES,
   DEAD_LETTER_MAINLINE_ERROR_CODES,
   K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES,
   integrationErrorCodeDisplayLabel,
@@ -25,6 +26,8 @@ const { READ_SOURCE_COMPOSITION_PLAN_ERROR_CODES: SERVER_COMPOSITION_ERROR_CODES
   require(path.join(pluginLib, 'read-source-composition-planner.cjs'))
 const { K3_WISE_BOM_LIST_BY_MATERIAL_ERROR_CODES: SERVER_BOM_LIST_ERROR_CODES } =
   require(path.join(pluginLib, 'read-source-bom-list-by-material-contract.cjs'))
+const { BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES: SERVER_BRIDGE_AGENT_ERROR_CODES } =
+  require(path.join(pluginLib, 'adapters', 'bridge-agent-readonly-adapter.cjs'))
 
 function expectLabeled(code: string): void {
   const label = integrationErrorCodeLabel(code, 'en')
@@ -71,6 +74,15 @@ describe('errorCodeLabels coverage (mirror tripwire)', () => {
   it('every dead-letter known-mainline code (10) has a label', () => {
     expect(DEAD_LETTER_MAINLINE_ERROR_CODES.length).toBe(10)
     for (const code of DEAD_LETTER_MAINLINE_ERROR_CODES) expectLabeled(code)
+  })
+
+  // BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md): the Bridge Agent
+  // readonly adapter's own error-code vocabulary (distinct from an operator's Bridge Agent HTTP
+  // response body, which may carry an arbitrary, unregistered `error.code`).
+  it('every server Bridge Agent adapter code (4) has a label, and the local mirror matches the server set', () => {
+    expect(SERVER_BRIDGE_AGENT_ERROR_CODES.length).toBe(4)
+    expect(new Set(BRIDGE_AGENT_ERROR_CODES)).toEqual(new Set(SERVER_BRIDGE_AGENT_ERROR_CODES))
+    for (const code of SERVER_BRIDGE_AGENT_ERROR_CODES) expectLabeled(code)
   })
 })
 

--- a/apps/web/tests/ui-foundation-style-guard.spec.ts
+++ b/apps/web/tests/ui-foundation-style-guard.spec.ts
@@ -54,6 +54,9 @@ const TARGET_FILES = [
   'src/components/integration/IntegrationObjectTemplateSection.vue',
   'src/components/integration/IntegrationPayloadPreviewSection.vue',
   'src/components/integration/IntegrationConnectionSection.vue',
+  // BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md): the Bridge Agent
+  // read-only observability section is born token-only (var(--ms-*)/--el-* exclusively).
+  'src/components/integration/IntegrationBridgeAgentSection.vue',
 ] as const
 
 // Per-file allowlist for counts that are legitimately un-clearable. Keep this EMPTY unless a

--- a/docs/development/bridge-agent-ui1-observability-dev-verification-20260707.md
+++ b/docs/development/bridge-agent-ui1-observability-dev-verification-20260707.md
@@ -1,0 +1,170 @@
+# BA-UI-1 — Bridge Agent 只读可观测页 · 开发/验证报告 — 2026-07-07
+
+> Design-lock: `docs/development/bridge-agent-admin-page-design-lock-20260707.md`(#3792,RATIFIED;
+> owner granted BA-UI-1 implementation 2026-07-07)。Demand anchor: #3746(保持 OPEN)。
+> 本片 = 纯只读可观测 UI:零写路径、零凭据路径变更、零 start/stop、零本机 config 编辑。
+
+## 1. Backend scout 结论(实现前对账)
+
+### 1.1 适配器面(`plugins/plugin-integration-core/lib/adapters/bridge-agent-readonly-adapter.cjs`)
+
+- 注册 kind:**`bridge:legacy-sql-readonly`**(`plugin-integration-core/index.cjs` L227
+  `.registerAdapter('bridge:legacy-sql-readonly', createBridgeAgentReadonlyAdapterFactory(), { metadata: BRIDGE_READONLY_ADAPTER_METADATA })`)。
+- 暴露操作:`testConnection` / `listObjects` / `getSchema` / `read`;`upsert` =
+  `unsupportedAdapterOperation`(写在合同层就不可能)。metadata `supports` 同列这四项,
+  `guardrails.write.supported=false`、`localhostOnly`、`noRawSql`。
+- `testConnection()` 打 Agent 的 `GET /health` + `GET /objects`,返回
+  `{ ok, status, connected, authenticated, code?, message }` —— message 已经过适配器内
+  `redactSecretText`(DSN 密码/`*token=`/`Bearer|Basic`/JWT 全部 `[redacted]`)。
+- `listObjects()` → `GET /objects` → 规格化为 `{ name, label, operations:['read'], source, readonly:true, fieldCount? }`。
+- `getSchema({object})` → `GET /schema/<object>` → `{ object, fields:[{name,label,type,required}], raw:{source} }`。
+- 协议版本:BA-M1 Agent(`scripts/ops/bridge-agent-readonly.ps1`)的 `/health` 不含 protocol/version
+  字段,适配器也不透传 —— 状态卡片因此**不渲染版本**(渲染不存在的字段=造假)。
+
+### 1.2 通用 HTTP 路由面(`plugins/plugin-integration-core/lib/http-routes.cjs`)
+
+Workbench 既有面板已在消费三条**通用**只读端点(前端调用点 = `apps/web/src/services/integration/workbench.ts`):
+
+| 需求 | 既有路由 | 前端 service 函数 | 权限 |
+| --- | --- | --- | --- |
+| health(在线/离线) | `POST /api/integration/external-systems/:id/test`(handlers.externalSystemsTest → adapter.testConnection) | `testExternalSystemConnection` | `integration:write`(探测=主动出网动作,沿用既有 tier) |
+| 对象列表 | `GET /api/integration/external-systems/:id/objects`(→ adapter.listObjects) | `listExternalSystemObjects` | `integration:read` |
+| schema 形状 | `GET /api/integration/external-systems/:id/schema?object=`(→ adapter.getSchema) | `getExternalSystemSchema` | `integration:read` |
+| 实例列表 | `GET /api/integration/external-systems`(公开形状已剥凭据,带 `hasCredentials` 布尔) | `listWorkbenchExternalSystems`(父视图已加载,`systems` prop 传入) | `integration:read` |
+
+后端在这些路由上已有的脱敏层(实现前逐一核对):
+
+- test 路由:`sanitizeTestConnectionResult` 白名单只保留 `ok/status/code/message/authenticated/connected`
+  且 string 值过 `redactSecretText`;回传的 `system` 经 `redactSystemForTest`(strip credentials)。
+- objects/schema 路由:响应过 `sanitizeIntegrationPayload`。
+- external-systems 列表:公开形状不含 credentials,凭据状态只有 `hasCredentials` 布尔。
+
+### 1.3 零新路由决定
+
+**采用:ZERO new backend routes。** 三条既有通用端点完整覆盖 BA-UI-1 的
+health≈testConnection / objects≈listObjects / schema≈getSchema 三个面;实例列表来自既有
+external-systems 公开形状。无新凭据路径、无写操作、无前端→Agent 直连(一切仍经 MetaSheet 后端代理,
+与 lock §4 一致)。
+
+**唯一后端改动 = 一个纯导出**(非路由、非行为):适配器新增导出
+`BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES`(4 码:`BRIDGE_AGENT_UNREACHABLE/TIMEOUT/REQUEST_FAILED/TEST_FAILED`),
+供 web 端 IU-1 label 模块做 require() 镜像 tripwire —— 与
+probe/resolver/composition/BOM 族既有纪律一致(单一来源,不手抄)。
+
+**已知不可达数据 = objects 列表的 keyField**:design-lock BA-UI-1 行写「对象名/label/keyField/字段数」,
+但 BA-M1 Agent 的 `GET /objects` 线上形状(ps1 L543-554)只回 `{id,label,readonly,fieldCount}`——
+keyField 只存在于 Agent 本机 config,**任何 HTTP 端点都不暴露它**(schema 端点也不含)。
+加后端路由无济于事(得改 BA-M1 Agent 协议,超出 UI 片授权范围)。
+决定:本片渲染 name/label/fieldCount,keyField 留待 Agent 协议演进(若有)再补;组件内有注释说明。
+同因,状态卡片的「协议版本」也不渲染(§1.1)。
+
+## 2. 组件契约
+
+`apps/web/src/components/integration/IntegrationBridgeAgentSection.vue`
+(section id `int-sec-bridge-agent`,骑 IU-2 骨架,第 7 个 rail 分组 `bridge-agent` —— add-only)
+
+- Props:`{ systems: WorkbenchExternalSystem[], scope: IntegrationScope }` —— 父视图只传共享的
+  systems 列表 + scope;组件自持三条只读 service 调用(自包含模式 = IntegrationReadSourceConfigPanel 同款,
+  区别于 IU-2b/2c 的纯模板抽取件)。
+- kind 过滤:`system.kind === 'bridge:legacy-sql-readonly'` 的系统才进入本区。
+- **状态卡片**:在线/离线(testConnection.ok)、只读标识(无条件渲染)、最近检查时间
+  (**客户端时钟** `new Date().toISOString()`,非 wire 值)、单卡「检查连接」+ 全部检查(串行,不并发轰本机 Agent)。
+- **实例列表**:name / 用途(role 人话)/ coarse status(启用/停用/异常)/ 凭据 =
+  `hasCredentials` 布尔 →「已配置/未配置」。**不渲染** host/tenant/config/credentials/lastError。
+- **对象列表**:选中实例 → `listExternalSystemObjects`;渲染 name/label/fieldCount
+  (fieldCount 缺失显式「未提供/N/A」,不猜)。
+- **Schema 预览**:按需 `getExternalSystemSchema`,显式逐字段映射 `{name,type,required}`
+  (白名单 copy,wire 上任何额外 key 都进不了 DOM);**永不**调用 read/query(lock §4)。
+- 空态:无实例(这是什么+第一步:去连接管理区新增)、allowlist 为空(第一步:本机 config 加对象)——
+  IU-6 what+first-step 双 testid 模式。
+- i18n:useLocale + 组件内 `bi(zh,en)`(read-source panel 同款);field hints 走 fieldHints.ts
+  新增 4 个 `bridgeAgent.*` key(el-tooltip);样式 token-only(UF-6 guard TARGET_FILES 已收编本文件)。
+- EP icons:`Connection`/`Lock`/`Refresh`(@element-plus/icons-vue)。
+
+### 错误展示纪律(比 IU-1 基线更紧一档)
+
+IU-1 基线允许 raw **code**(注册闭集)出现在折叠/次要位。本组件连 code 字符串也不渲染:
+Bridge Agent 的 HTTP error body 里 `error.code` 可以是**运营者自建 Agent 提供的任意字符串**
+(适配器 `bridgeErrorCode(data)` 原样透传),不属于闭集 —— 所以显著层与全部层都只渲染
+`integrationErrorCodeDisplayLabel` 的映射结果(未注册码→通用「未知错误」),objects/schema 失败
+渲染固定双语文案(shared `parseIntegrationResponse` 抛出的 Error.message 携带后端 error.message,
+组件 catch 后**不捕获不渲染**该文本)。
+
+## 3. Sentinel 测试说明(`apps/web/tests/IntegrationBridgeAgentSection.spec.ts`,10 tests)
+
+在组件能收到的**每个后端供给面**种入 secret 形状哨兵串:
+
+| 哨兵位置 | 载体 |
+| --- | --- |
+| `system.config.sharedSecretEnvVar` / `system.config.connectionString` | systems prop |
+| `system.lastError`(token=…、内网 IP) | systems prop |
+| testConnection 响应 `message`(secret+localhost URL)与嵌套 `system.config.sharedSecret` | POST /test mock |
+| testConnection 响应 `code`(敌意非闭集 code,内嵌 secret=) | POST /test mock |
+| objects 响应条目额外 key `connectionString` | GET /objects mock |
+| schema 响应 field 额外 key `defaultValue` + `raw.leaked` | GET /schema mock |
+| objects/schema 失败 body `error.message`(authorityCode=…) | 500 mock |
+
+驱动全部渲染路径(check + 自动 objects + schema 展开)后断言:每个哨兵串在 `innerHTML` 与
+`textContent` 双面均不出现,且子片段(`SENTINEL-`/`Password=`/`token=`/`authorityCode=`/内网 IP/
+`sharedsecret`)也不出现 —— 部分渲染同样算泄漏。同 spec 另有:未注册 code 降级断言、
+raw code 字符串不渲染断言、固定文案断言、凭据布尔是唯一凭据相邻输出断言、zh 文案断言。
+
+### Mutation 证明(每变体单独注入→跑→红→精确路径 revert;基线 commit 后执行)
+
+| # | 变体 | 结果 |
+| --- | --- | --- |
+| A | 状态卡错误行渲染 raw `state.code` 而非 label | RED(1 failed)✅ killed |
+| B | 实例列表 status 单元格追加 `{{ system.lastError }}` | RED(sentinel)✅ killed |
+| C | objects 失败 catch 捕获 error.message 并渲染 | RED(values-free 断言)✅ killed |
+| D | 客户端镜像删除 `BRIDGE_AGENT_TIMEOUT` | RED(mirror tripwire Set-equality)✅ killed |
+| E | 视图删除第 7 个 rail 分组 | RED(2 failed:view wiring + rail anchor)✅ killed |
+
+## 4. 安全边界 checklist(vs lock §2.1 逐条)
+
+| §2.1 锁条款 | 状态 | 证据 |
+| --- | --- | --- |
+| 禁前端显示/保存 password/token/secret/connection string/authorityCode/原始 payload rows/业务数据行 | ✅ | sentinel 测试(§3)全渲染路径覆盖;schema/objects 显式白名单字段映射;错误只出 label/固定文案 |
+| 凭据仅后端持有;前端最多「已配置/未配置」布尔 | ✅ | 唯一凭据相邻输出 = `hasCredentials` → 已配置/未配置;组件不读 `system.config`/`credentials` 任何键 |
+| 禁 raw SQL 编辑器;只能 allowlist 对象 | ✅ | 零输入框(除实例下拉);对象列表=Agent allowlist 只读回显;无任何 SQL 面 |
+| 默认只读;不得触发 K3 Save/Submit/Audit、ERP/PLM/生产写 | ✅ | 组件 import 面无任何写 service;`POST /query` 不消费(spec 断言每次 fetch 均属 test/objects/schema 三端点) |
+| 诊断/导出 values-free | ✅ | 展示面=count/布尔/coarse 状态/闭集 label;无导出功能(BA-UI-2+ 才有探测证据面) |
+| 无 start/stop、无本机 config 编辑(第一版 out 项) | ✅ | 无对应 UI/调用;计划任务运行态提示属 BA-UI-4(未开门) |
+| 代理走既有 external-system 权限门,不碰中央 rbac/auth | ✅ | 零新路由;test=integration:write、objects/schema/list=integration:read 全部沿用既有门 |
+
+## 5. 测试与构建矩阵
+
+| 面 | Node 25(默认) | Node 20(nvm,CI 同版) |
+| --- | --- | --- |
+| plugin-integration-core CJS 全链(`pnpm --filter plugin-integration-core test`) | ✅ | ✅ |
+| integration-guard 19-spec 全列表(含新 IntegrationBridgeAgentSection,223 tests) | ✅ 223/223 | ✅ 223/223 |
+| ui-foundation-style-guard(TARGET_FILES 收编新组件后 67 tests) | ✅ | —(纯 fs 扫描,版本无关) |
+| `vue-tsc -b` | ✅ clean | — |
+| `pnpm build`(apps/web) | ✅ | — |
+
+CI 面:integration-guard.yml 的 pull_request/push paths 与 vitest run 列表均已收编新组件+新 spec
+(workflow 自身也在自己的 paths 里,改动即触发)。
+注意(既有事实,非本片引入):plugin-integration-core 测试链在 integration-guard.yml 中运行,
+本 PR 触碰 `plugins/plugin-integration-core/**` 会触发。
+
+## 6. 改动清单
+
+| 文件 | 类型 |
+| --- | --- |
+| `apps/web/src/components/integration/IntegrationBridgeAgentSection.vue` | 新增(组件本体) |
+| `apps/web/src/views/IntegrationWorkbenchView.vue` | 挂载 + 第 7 rail 分组 + sectionGroupIds(add-only) |
+| `apps/web/src/services/integration/errorCodeLabels.ts` | BRIDGE_AGENT_* 族(4 码 label + 镜像数组) |
+| `apps/web/src/services/integration/fieldHints.ts` | 4 个 `bridgeAgent.*` hint |
+| `apps/web/src/services/integration/workbench.ts` | `IntegrationSystemObject` 增补 `fieldCount?/readonly?` 类型(对既有 wire 的 additive typing,非 wire 变更) |
+| `plugins/plugin-integration-core/lib/adapters/bridge-agent-readonly-adapter.cjs` | 导出错误码闭集常量(纯导出,零行为) |
+| `plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs` | 钉 4 码 + TIMEOUT/REQUEST_FAILED 兜底路径用例 |
+| `apps/web/tests/IntegrationBridgeAgentSection.spec.ts` | 新增(10 tests,含 sentinel) |
+| `apps/web/tests/IntegrationWorkbenchRail.spec.ts` | 7th group fixture + 11th anchor(add-only) |
+| `apps/web/tests/IntegrationWorkbenchView.spec.ts` | 7-group wiring(add-only) |
+| `apps/web/tests/integrationErrorCodeLabels.spec.ts` | BRIDGE_AGENT 镜像 tripwire |
+| `apps/web/tests/ui-foundation-style-guard.spec.ts` | TARGET_FILES 收编新组件 |
+| `.github/workflows/integration-guard.yml` | paths + run 列表收编 |
+
+## 7. 边界外(维持冻结)
+
+BA-UI-2(values-free 探测)/ BA-UI-3(配置校验+变更建议)/ BA-UI-4(计划任务运行态)各需独立
+opt-in;本片未实现其任何部分。

--- a/plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs
@@ -7,6 +7,7 @@ const {
   UnsupportedAdapterOperationError,
 } = require(path.join(__dirname, '..', 'lib', 'contracts.cjs'))
 const {
+  BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES,
   BridgeAgentReadonlyAdapterError,
   createBridgeAgentReadonlyAdapter,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'bridge-agent-readonly-adapter.cjs'))
@@ -283,6 +284,42 @@ async function main() {
     const httpErr = await http500.listObjects().then(() => null, (e) => e)
     assert.ok(httpErr, 'a 500 from a reachable agent still errors')
     assert.notEqual(httpErr.code, 'BRIDGE_AGENT_UNREACHABLE', 'a reachable-agent HTTP error is NOT labeled unreachable')
+  }
+
+  // --- 8. BA-UI-1: the exported adapter-owned error-code vocabulary is exactly the codes this
+  // adapter itself assigns (never a code an operator's own Bridge Agent HTTP body supplies via
+  // `error.code` — see step 5/7's 'BRIDGE_AGENT_ERROR'/'UNKNOWN_OBJECT' fixtures, which are NOT in
+  // this list). The web client mirrors this exact array in errorCodeLabels.ts with a require()-based
+  // tripwire test, so a future addition/removal here must be synced there before it goes green.
+  {
+    assert.deepEqual(
+      [...BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES].sort(),
+      ['BRIDGE_AGENT_REQUEST_FAILED', 'BRIDGE_AGENT_TEST_FAILED', 'BRIDGE_AGENT_TIMEOUT', 'BRIDGE_AGENT_UNREACHABLE'].sort(),
+    )
+
+    // BRIDGE_AGENT_TIMEOUT: an AbortError from the fetch layer (simulates the adapter's own
+    // AbortController firing on config.timeoutMs).
+    const timeoutAdapter = createBridgeAgentReadonlyAdapter({
+      system: createSystem(),
+      fetchImpl: async () => {
+        const err = new Error('The operation was aborted')
+        err.name = 'AbortError'
+        throw err
+      },
+    })
+    const timeoutResult = await timeoutAdapter.testConnection()
+    assert.equal(timeoutResult.ok, false)
+    assert.equal(timeoutResult.code, 'BRIDGE_AGENT_TIMEOUT')
+
+    // BRIDGE_AGENT_REQUEST_FAILED: a non-2xx response whose body carries no error.code at all (the
+    // adapter's own fallback default in bridgeErrorCode(), distinct from an agent-supplied code).
+    const noCodeAdapter = createBridgeAgentReadonlyAdapter({
+      system: createSystem(),
+      fetchImpl: async () => jsonResponse(500, { message: 'boom, no error.code here' }),
+    })
+    const noCodeErr = await noCodeAdapter.listObjects().then(() => null, (e) => e)
+    assert.ok(noCodeErr instanceof BridgeAgentReadonlyAdapterError)
+    assert.equal(noCodeErr.code, 'BRIDGE_AGENT_REQUEST_FAILED')
   }
 
   console.log('✓ bridge-agent-readonly-adapter: BA-M2 source contract tests passed')

--- a/plugins/plugin-integration-core/lib/adapters/bridge-agent-readonly-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/bridge-agent-readonly-adapter.cjs
@@ -25,6 +25,21 @@ class BridgeAgentReadonlyAdapterError extends Error {
   }
 }
 
+// BA-UI-1 (docs/development/bridge-agent-admin-page-design-lock-20260707.md §4): the closed set of
+// error CODES this adapter itself assigns (as opposed to a code an operator's own Bridge Agent HTTP
+// response body may supply via `bridgeErrorCode(data)` below, which is NOT closed/adapter-controlled).
+// Exported so the web client can mirror + label this exact vocabulary
+// (apps/web/src/services/integration/errorCodeLabels.ts BRIDGE_AGENT_ERROR_CODES) with the same
+// mirror-tripwire discipline used for the other adapter-owned code families in that module — never a
+// hand-typed guess. Any OTHER code (agent-supplied or a raw error.name) stays deliberately unregistered
+// there and degrades to the generic "unknown error" label client-side.
+const BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES = [
+  'BRIDGE_AGENT_UNREACHABLE',
+  'BRIDGE_AGENT_TIMEOUT',
+  'BRIDGE_AGENT_REQUEST_FAILED',
+  'BRIDGE_AGENT_TEST_FAILED',
+]
+
 const DEFAULT_BASE_URL = 'http://127.0.0.1:19091/'
 const DEFAULT_AUTH_HEADER = 'X-MetaSheet-Bridge-Secret'
 const DEFAULT_SAMPLE_LIMIT = 3
@@ -466,6 +481,7 @@ const BRIDGE_READONLY_ADAPTER_METADATA = {
 }
 
 module.exports = {
+  BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES,
   BRIDGE_READONLY_ADAPTER_METADATA,
   BridgeAgentReadonlyAdapterError,
   createBridgeAgentReadonlyAdapter,


### PR DESCRIPTION
## Summary

BA-UI-1 (first slice of the Bridge Agent admin-page ladder, design-lock `docs/development/bridge-agent-admin-page-design-lock-20260707.md`, merged in #3792; owner granted implementation 2026-07-07). Demand anchor: #3746 (stays OPEN — this is slice 1 of the ladder, not closure).

A **read-only** Bridge Agent observability section riding the IU-2 Workbench skeleton as the 7th rail-addressable section (`int-sec-bridge-agent`):

- **Status cards** — online/offline via `testConnection`, unconditional 只读 badge, client-side last-checked timestamp, per-card check + sequential check-all. (Protocol version is NOT rendered: the BA-M1 agent's `/health` doesn't carry one — see verification MD §1.1.)
- **Instance list** — name / role / coarse status / credential state as the `hasCredentials` boolean only (已配置/未配置). host/tenant/config/credentials/lastError never rendered.
- **Object list** — existing `/objects` shape (name/label/fieldCount; keyField is not on the BA-M1 wire at all — documented decision, MD §1.3).
- **Schema preview** — on-demand field name/type/required via explicit whitelist mapping; `POST /query` is never called (lock §4), and the spec asserts every fetch the section makes is one of the three read-only endpoints.
- **IU-6-style guided empty states** (what-this-is + first-step), 4 new `bridgeAgent.*` field hints, zh+en via useLocale, token-only styles (style-guard TARGET_FILES extended), EP icons.

## Zero new backend routes

The three existing generic external-system endpoints cover the whole surface (health≈`POST :id/test`, objects≈`GET :id/objects`, schema≈`GET :id/schema`), behind the existing `integration:read`/`integration:write` gates — no new credential path, no write op, no FE→Agent direct connection. The only backend change is a **pure export**: `BRIDGE_AGENT_READONLY_ADAPTER_ERROR_CODES` (4 codes) from the adapter, so the web IU-1 label module mirrors it via a require()-based tripwire instead of hand-typing.

## Error display — one notch stricter than the IU-1 baseline

A Bridge Agent HTTP error body can carry an **operator-supplied** `error.code` (not a closed registered set), so this section never interpolates even the code string into the DOM: prominent + all layers render only the mapped `integrationErrorCodeDisplayLabel` (unregistered → generic unknown label); objects/schema failures render fixed values-free bilingual copy (the thrown message is never captured).

## Tests

- New `IntegrationBridgeAgentSection.spec.ts` (10 tests) incl. the **SENTINEL test**: secret-shaped strings planted in system config / credentials / lastError / test message / hostile code / objects+schema payload extras / error bodies, asserted absent from `innerHTML` AND `textContent` (plus sub-fragments) after driving every render path.
- Rail wiring extended **add-only**: 7th group + 11th section anchor; all six IU-2a assertions intact.
- Mirror tripwire: client `BRIDGE_AGENT_ERROR_CODES` set-equal to the server export; adapter test pins the 4-code vocabulary + exercises the TIMEOUT/REQUEST_FAILED fallback paths.
- **Mutation evidence** (each injected → red → reverted, on a committed baseline): raw-code render / lastError leak / raw-error-message render / mirror drift / rail-group drop — 5/5 killed (MD §3).
- Green: plugin-integration-core CJS chain + full 19-spec integration-guard list (223 tests) on default Node **and** Node 20; `vue-tsc -b` clean; `pnpm build` OK; style-guard 67/67.

## Lock §2.1 checklist

Full per-clause table in `docs/development/bridge-agent-ui1-observability-dev-verification-20260707.md` §4 (all ✅). BA-UI-2/3/4 remain gated — nothing from them is implemented here.

refs #3746

🤖 Generated with [Claude Code](https://claude.com/claude-code)