### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaBulkEditDialog action buttons to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaBulkEditDialog.vue
+++ b/apps/web/src/multitable/components/MetaBulkEditDialog.vue
@@ -58,14 +58,15 @@
         </div>
 
         <div class="meta-bulk-edit__actions">
-          <button class="meta-bulk-edit__btn" :disabled="busy" @click="onCancel">{{ b('bulk.cancel') }}</button>
-          <button
+          <MtButton class="meta-bulk-edit__btn" :disabled="busy" @click="onCancel">{{ b('bulk.cancel') }}</MtButton>
+          <MtButton
+            variant="primary"
             class="meta-bulk-edit__btn meta-bulk-edit__btn--primary"
             :disabled="!canSubmit || busy"
             @click="onApply"
           >
             {{ submitLabel }}
-          </button>
+          </MtButton>
         </div>
       </div>
     </div>
@@ -75,6 +76,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
+import { MtButton } from '../ui'
 import type { MetaField } from '../types'
 import {
   bulkClearHintPrefix,
@@ -181,10 +183,8 @@ function onCancel() {
 .meta-bulk-edit__value-wrap { border: 1px solid #dcdfe6; border-radius: 4px; padding: 4px; min-height: 36px; }
 .meta-bulk-edit__error { color: #f56c6c; background: #fef0f0; padding: 8px 10px; border-radius: 4px; font-size: 13px; }
 .meta-bulk-edit__success { color: #67c23a; background: #f0f9eb; padding: 8px 10px; border-radius: 4px; font-size: 13px; }
-.meta-bulk-edit__actions { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid #ebedf0; }
-.meta-bulk-edit__btn { background: #fff; border: 1px solid #dcdfe6; padding: 6px 14px; border-radius: 4px; cursor: pointer; font-size: 14px; }
-.meta-bulk-edit__btn:hover:not(:disabled) { border-color: #c0c4cc; }
-.meta-bulk-edit__btn:disabled { opacity: .55; cursor: not-allowed; }
-.meta-bulk-edit__btn--primary { background: #409eff; color: #fff; border-color: #409eff; }
-.meta-bulk-edit__btn--primary:hover:not(:disabled) { background: #66b1ff; border-color: #66b1ff; }
+.meta-bulk-edit__actions { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--ms-border-light, #ebedf0); }
+/* .meta-bulk-edit__btn / --primary: the action controls are now <MtButton> (token-styled, variant="primary"
+   for apply); their bespoke hardcoded-hex button CSS was removed (P2-1c). Classes kept on the elements
+   only for selector stability. */
 </style>

--- a/apps/web/tests/meta-bulk-edit-dialog-migration.spec.ts
+++ b/apps/web/tests/meta-bulk-edit-dialog-migration.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaBulkEditDialog from '../src/multitable/components/MetaBulkEditDialog.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaBulkEditDialog's two action controls (cancel / apply) were migrated from bespoke
+// <button>s to the shared MtButton primitive (apply = variant="primary"). Behavior-preservation
+// proof: they stay native, keyboard-operable <button>s; the disabled binding survives; and clicking
+// them still emits the SAME `cancel` / `apply` events with the SAME payload. The dialog teleports to
+// <body>, so queries hit `document`, not the mount container.
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-bulk-edit-overlay').length).toBe(0) // teleport residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaBulkEditDialog, { ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+}
+
+// clear mode: canSubmit only needs a chosen field (no cell value), so the apply path is exercisable
+// without mounting MetaCellEditor. `text` is bulk-editable (not system / not a NON_BULK_EDITABLE type).
+const baseProps = () => ({
+  visible: true,
+  mode: 'clear' as const,
+  fields: [{ id: 'f1', name: 'Notes', type: 'text' }],
+  canEdit: true,
+  recordIds: ['r1', 'r2'],
+})
+
+const actionBtns = () =>
+  Array.from(document.querySelectorAll('.meta-bulk-edit__actions .meta-bulk-edit__btn')) as HTMLElement[]
+const applyBtn = () => document.querySelector('.meta-bulk-edit__btn--primary') as HTMLButtonElement
+
+describe('MetaBulkEditDialog — MtButton migration (UI-P2-1c)', () => {
+  it('renders cancel + apply as native <button>s; apply disabled until a field is chosen', () => {
+    mount(baseProps())
+    const btns = actionBtns()
+    expect(btns.length).toBe(2)
+    expect(btns.every((b) => b.tagName === 'BUTTON')).toBe(true) // keyboard-operable, not bare divs
+    expect(applyBtn().disabled).toBe(true) // :disabled="!canSubmit || busy" — no field selected yet
+  })
+
+  it('clicking cancel emits `cancel` (unchanged from pre-migration onCancel)', () => {
+    const onCancel = vi.fn()
+    mount(baseProps(), { onCancel })
+    const cancel = actionBtns().find((b) => !b.classList.contains('meta-bulk-edit__btn--primary')) as HTMLButtonElement
+    cancel.click()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('choosing a field then clicking apply emits `apply` with the same payload (unchanged)', async () => {
+    const onApply = vi.fn()
+    mount(baseProps(), { onApply })
+    const select = document.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    select.value = 'f1'
+    select.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(applyBtn().disabled).toBe(false)
+    applyBtn().click()
+    expect(onApply).toHaveBeenCalledTimes(1)
+    expect(onApply).toHaveBeenCalledWith({ mode: 'clear', fieldId: 'f1', value: null, recordIds: ['r1', 'r2'] })
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, self-merge bar). cancel/apply → MtButton (apply=primary); `@click`/`:disabled` preserved; emit call-sites (apply payload / cancel) byte-identical; bespoke hex CSS removed, actions border → `--ms-border-light`; close × left for a separate MtIconButton slice. Teleport-aware mount test (3/3): native buttons + disabled binding + cancel-emit + apply-emit-payload parity. vue-tsc clean; no new hex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)