### PR TITLE
feat(web): G-B2-14 + G-B2-16 — form draft autosave/restore + 金额大写回显 (G-B2-02 found already landed)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -57,6 +57,10 @@ on:
       - 'apps/web/src/approvals/conditionSummary.ts'
       - 'apps/web/tests/approval-condition-summary.test.ts'
       - 'apps/web/tests/amountAutoSum.test.ts'
+      # G-B2-16: 金额大写回显 — amountInWords.ts pure util + the declared-total caption in
+      # ApprovalNewView (same rounding family as amountAutoSum).
+      - 'apps/web/src/approvals/amountInWords.ts'
+      - 'apps/web/tests/approval-amount-in-words.test.ts'
       - 'apps/web/tests/useAutoSumTotal.test.ts'
       - 'apps/web/tests/lineDerivation.test.ts'
       - 'apps/web/src/views/approval/ApprovalMobileList.vue'
@@ -175,6 +179,10 @@ on:
       - 'apps/web/src/approvals/conditionSummary.ts'
       - 'apps/web/tests/approval-condition-summary.test.ts'
       - 'apps/web/tests/amountAutoSum.test.ts'
+      # G-B2-16: 金额大写回显 — amountInWords.ts pure util + the declared-total caption in
+      # ApprovalNewView (same rounding family as amountAutoSum).
+      - 'apps/web/src/approvals/amountInWords.ts'
+      - 'apps/web/tests/approval-amount-in-words.test.ts'
       - 'apps/web/tests/useAutoSumTotal.test.ts'
       - 'apps/web/tests/lineDerivation.test.ts'
       - 'apps/web/src/views/approval/ApprovalMobileList.vue'
@@ -336,4 +344,4 @@ jobs:
         # files and asserts zero static style= attributes and zero hex/rgb() literals inside
         # <style> blocks (var() references + transparent/inherit/currentColor/none allowed);
         # had no gate before this wiring.
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView ui-foundation-style-guard uiFoundationTexture --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView ui-foundation-style-guard uiFoundationTexture --reporter=dot

--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -61,6 +61,9 @@ on:
       # ApprovalNewView (same rounding family as amountAutoSum).
       - 'apps/web/src/approvals/amountInWords.ts'
       - 'apps/web/tests/approval-amount-in-words.test.ts'
+      # G-B2-14: 填单草稿自动保存 — formDraft.ts pure helpers + ApprovalNewView restore alert.
+      - 'apps/web/src/approvals/formDraft.ts'
+      - 'apps/web/tests/approval-form-draft.test.ts'
       - 'apps/web/tests/useAutoSumTotal.test.ts'
       - 'apps/web/tests/lineDerivation.test.ts'
       - 'apps/web/src/views/approval/ApprovalMobileList.vue'
@@ -183,6 +186,9 @@ on:
       # ApprovalNewView (same rounding family as amountAutoSum).
       - 'apps/web/src/approvals/amountInWords.ts'
       - 'apps/web/tests/approval-amount-in-words.test.ts'
+      # G-B2-14: 填单草稿自动保存 — formDraft.ts pure helpers + ApprovalNewView restore alert.
+      - 'apps/web/src/approvals/formDraft.ts'
+      - 'apps/web/tests/approval-form-draft.test.ts'
       - 'apps/web/tests/useAutoSumTotal.test.ts'
       - 'apps/web/tests/lineDerivation.test.ts'
       - 'apps/web/src/views/approval/ApprovalMobileList.vue'
@@ -344,4 +350,4 @@ jobs:
         # files and asserts zero static style= attributes and zero hex/rgb() literals inside
         # <style> blocks (var() references + transparent/inherit/currentColor/none allowed);
         # had no gate before this wiring.
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView ui-foundation-style-guard uiFoundationTexture --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words approval-form-draft lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView ui-foundation-style-guard uiFoundationTexture --reporter=dot

--- a/apps/web/src/approvals/amountInWords.ts
+++ b/apps/web/src/approvals/amountInWords.ts
@@ -1,0 +1,90 @@
+// G-B2-16 (benchmark §7.2) — 金额大写回显. PURE util (no .vue / Element Plus import) so it runs
+// under the approval-web-guard vitest gate. Words are ALWAYS derived from the same rounding the
+// backend total-check uses (round-half-up at the field's declared scale via `numberFieldScale`'s
+// contract — the caller passes the already-scale-rounded value); the words layer additionally
+// rounds to 2 decimals (角/分 is inherently a 2-decimal vocabulary) — when the field scale
+// exceeds 2 the caption is therefore an approximation of the stored value, which is why the view
+// only renders it for the template-declared amount total (scale ≤ 2 in practice).
+
+const DIGITS = ['零', '壹', '贰', '叁', '肆', '伍', '陆', '柒', '捌', '玖'] as const
+const UNIT_IN_GROUP = ['', '拾', '佰', '仟'] as const
+const GROUP_UNITS = ['', '万', '亿', '万亿'] as const
+
+/** 0..9999 → words within one 万-group; '' for 0. Collapses inner zero runs to a single 零. */
+function groupToWords(group: number): string {
+  let out = ''
+  let pendingZero = false
+  for (let pos = 3; pos >= 0; pos -= 1) {
+    const digit = Math.floor(group / 10 ** pos) % 10
+    if (digit === 0) {
+      if (out) pendingZero = true
+      continue
+    }
+    if (pendingZero) {
+      out += '零'
+      pendingZero = false
+    }
+    out += DIGITS[digit] + UNIT_IN_GROUP[pos]
+  }
+  return out
+}
+
+/**
+ * Number → Chinese uppercase currency words（人民币大写）.
+ * - NaN / non-finite / non-number → '' (caller renders nothing).
+ * - |value| ≥ 1e13 → '' (beyond the supported 万亿 vocabulary; honest omission beats a wrong caption).
+ * - Negatives carry a 负 prefix. 0 → 零圆整. Fraction rounds half-up to 角/分.
+ */
+export function amountToChineseWords(value: unknown): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return ''
+  const negative = value < 0
+  const abs = Math.abs(value)
+  if (abs >= 1e13) return ''
+  // Work in 分 (integer minor units) to dodge float artifacts: 10.10 → 1010分.
+  const totalFen = Math.round(abs * 100)
+  const yuan = Math.floor(totalFen / 100)
+  const jiao = Math.floor((totalFen % 100) / 10)
+  const fen = totalFen % 10
+
+  let yuanWords = ''
+  if (yuan > 0) {
+    const groups: number[] = []
+    let rest = yuan
+    while (rest > 0) {
+      groups.push(rest % 10000)
+      rest = Math.floor(rest / 10000)
+    }
+    let needZeroJoin = false
+    for (let gi = groups.length - 1; gi >= 0; gi -= 1) {
+      const group = groups[gi]!
+      if (group === 0) {
+        // An all-zero middle group means the NEXT non-zero lower group needs a 零 join.
+        if (yuanWords) needZeroJoin = true
+        continue
+      }
+      const words = groupToWords(group)
+      // A lower group starting under 仟 (i.e. < 1000) after content needs a 零 join: 1000500 →
+      // 壹佰万零伍佰. So does any content after an all-zero group.
+      if (yuanWords && (needZeroJoin || group < 1000)) yuanWords += '零'
+      needZeroJoin = false
+      yuanWords += words + GROUP_UNITS[gi]
+    }
+    yuanWords += '圆'
+  }
+
+  let fraction = ''
+  if (jiao > 0) fraction += DIGITS[jiao] + '角'
+  if (fen > 0) {
+    // 角位为零但有分：零分 needs the explicit 零 only when 圆 exists (壹圆零伍分), not for 伍分 alone.
+    if (jiao === 0 && yuan > 0) fraction += '零'
+    fraction += DIGITS[fen] + '分'
+  }
+
+  let out: string
+  if (yuan === 0 && !fraction) out = '零圆整'
+  else if (!fraction) out = yuanWords + '整'
+  else if (yuan === 0) out = fraction
+  else out = yuanWords + fraction
+
+  return (negative ? '负' : '') + out
+}

--- a/apps/web/src/approvals/formDraft.ts
+++ b/apps/web/src/approvals/formDraft.ts
@@ -1,0 +1,96 @@
+import type { FormSchema } from '../types/approval'
+
+// G-B2-14 (benchmark §7.2) — 填单草稿自动保存/恢复. PURE logic module (no .vue / EP import) so it
+// runs under the approval-web-guard vitest gate. Storage is INJECTED (any Storage-shaped object)
+// — the view passes window.localStorage; tests pass an in-memory fake. Server-side drafts are
+// explicitly out of scope at this stage (benchmark note).
+//
+// Fail-safe discipline: every entry point swallows storage/parse failures (quota, privacy mode,
+// corrupted JSON) — a broken draft layer must NEVER break the form itself. The schema signature
+// guards drift: a template whose field set/types changed since the draft was written treats the
+// draft as absent (and best-effort removes it) instead of restoring stale shapes.
+
+export interface StoredFormDraft {
+  signature: string
+  savedAt: string
+  data: Record<string, unknown>
+}
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+/** One draft per user+template. */
+export function formDraftKey(userId: string, templateId: string): string {
+  return `approval-form-draft:${userId}:${templateId}`
+}
+
+/** Drift guard: field ids + types, order-independent. Attachment fields are excluded — they are
+ *  never draft-persisted (no working uploader; refs would be meaningless across sessions). */
+export function formSchemaSignature(schema: FormSchema): string {
+  return (schema.fields ?? [])
+    .filter((field) => field.type !== 'attachment')
+    .map((field) => `${field.id}:${field.type}`)
+    .sort()
+    .join('|')
+}
+
+/** Persist a draft. `data` should already exclude attachment fields (caller strips). Empty-ish
+ *  data (no meaningful value) clears instead of saving — an untouched form leaves no residue. */
+export function saveFormDraft(
+  storage: StorageLike,
+  key: string,
+  signature: string,
+  data: Record<string, unknown>,
+): void {
+  try {
+    const meaningful = Object.values(data).some(
+      (value) => value !== undefined && value !== null && value !== '' && !(Array.isArray(value) && value.length === 0),
+    )
+    if (!meaningful) {
+      storage.removeItem(key)
+      return
+    }
+    const draft: StoredFormDraft = { signature, savedAt: new Date().toISOString(), data }
+    storage.setItem(key, JSON.stringify(draft))
+  } catch {
+    // quota / privacy mode — drafting silently unavailable.
+  }
+}
+
+/** Load a draft matching the CURRENT schema signature; anything else → null (+ best-effort GC). */
+export function loadFormDraft(
+  storage: StorageLike,
+  key: string,
+  expectedSignature: string,
+): Record<string, unknown> | null {
+  try {
+    const raw = storage.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<StoredFormDraft> | null
+    if (
+      !parsed
+      || typeof parsed !== 'object'
+      || parsed.signature !== expectedSignature
+      || !parsed.data
+      || typeof parsed.data !== 'object'
+      || Array.isArray(parsed.data)
+    ) {
+      try {
+        storage.removeItem(key)
+      } catch {
+        /* best-effort GC */
+      }
+      return null
+    }
+    return parsed.data as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+export function clearFormDraft(storage: StorageLike, key: string): void {
+  try {
+    storage.removeItem(key)
+  } catch {
+    /* fail-safe */
+  }
+}

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -40,6 +40,19 @@
              least one field (see `applyResubmitPrefill`) — a requester fixing a rejected/revoked/
              cancelled submission should know the form was pre-populated, not silently discover it. -->
         <el-alert
+          v-if="draftRestoreVisible"
+          type="info"
+          :closable="false"
+          class="approval-new__draft-alert"
+          data-testid="approval-draft-restore"
+        >
+          <template #title>
+            检测到上次未提交的草稿，是否恢复？
+            <el-button size="small" type="primary" data-testid="approval-draft-restore-apply" @click="applyDraftRestore">恢复草稿</el-button>
+            <el-button size="small" data-testid="approval-draft-restore-discard" @click="discardDraftRestore">丢弃</el-button>
+          </template>
+        </el-alert>
+        <el-alert
           v-if="prefillNoticeVisible"
           title="已从上一次申请预填，请检查后提交"
           type="info"
@@ -392,6 +405,7 @@ import { useAutoSumTotal } from '../../approvals/useAutoSumTotal'
 import { isRowDerivationActive } from '../../approvals/lineDerivation'
 import { numberFieldProps } from '../../approvals/numberFieldProps'
 import { amountToChineseWords } from '../../approvals/amountInWords'
+import { clearFormDraft, formDraftKey, formSchemaSignature, loadFormDraft, saveFormDraft } from '../../approvals/formDraft'
 import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
 import {
   createEmptyDetailRow,
@@ -414,6 +428,57 @@ const formData = reactive<Record<string, unknown>>({})
 // UX B2-13 (再次提交): true once a `?fromInstance=` prefill actually applied at least one field —
 // see `applyResubmitPrefill` below. Drives the "已从上一次申请预填" notice.
 const prefillNoticeVisible = ref(false)
+
+// G-B2-14: localStorage draft autosave/restore (per user+template; pure helpers in
+// approvals/formDraft.ts). The machinery arms only once BOTH the template and the user id are
+// known; a resubmit-prefill (B2-13) takes precedence — the restore offer is skipped entirely.
+const draftUserId = ref<string | null>(null)
+const draftRestoreVisible = ref(false)
+const pendingDraft = ref<Record<string, unknown> | null>(null)
+let draftSaveTimer: ReturnType<typeof setTimeout> | null = null
+let draftArmed = false
+
+function draftStorageKey(): string | null {
+  const templateId = route.params.templateId as string
+  if (!draftUserId.value || !templateId || !template.value) return null
+  return formDraftKey(draftUserId.value, templateId)
+}
+
+function offerDraftRestore(): void {
+  const key = draftStorageKey()
+  if (!key || !template.value) return
+  const draft = loadFormDraft(window.localStorage, key, formSchemaSignature(template.value.formSchema))
+  if (!draft) return
+  pendingDraft.value = draft
+  draftRestoreVisible.value = true
+}
+
+function applyDraftRestore(): void {
+  if (pendingDraft.value) Object.assign(formData, pendingDraft.value)
+  pendingDraft.value = null
+  draftRestoreVisible.value = false
+}
+
+function discardDraftRestore(): void {
+  const key = draftStorageKey()
+  if (key) clearFormDraft(window.localStorage, key)
+  pendingDraft.value = null
+  draftRestoreVisible.value = false
+}
+
+function scheduleDraftSave(): void {
+  if (!draftArmed) return
+  if (draftSaveTimer) clearTimeout(draftSaveTimer)
+  draftSaveTimer = setTimeout(() => {
+    const key = draftStorageKey()
+    if (!key || !template.value) return
+    // Same attachment-stripping the submit path uses — refs never persist.
+    const data = stripAttachmentFields(template.value.formSchema, { ...formData })
+    saveFormDraft(window.localStorage, key, formSchemaSignature(template.value.formSchema), data)
+  }, 800)
+}
+
+watch(formData, scheduleDraftSave, { deep: true })
 // UX B2-13: folded into the SAME `v-loading` overlay as the template/submit loads (below) so the
 // form can't be interacted with — and submitted un-prefilled — during the brief window between
 // the template finishing its own load and the source-instance prefill fetch resolving.
@@ -591,6 +656,11 @@ async function handleSubmit() {
       formData: buildSubmitFormData(),
     })
     ElMessage.success('审批已提交')
+    // G-B2-14: a successful submit consumes the draft.
+    {
+      const key = draftStorageKey()
+      if (key) clearFormDraft(window.localStorage, key)
+    }
     // B1-08: best-effort 最近使用 record — must never delay or fail the navigation.
     const submittedTemplate = template.value
     if (submittedTemplate) {
@@ -655,6 +725,15 @@ onMounted(async () => {
     }
   }
   await applyResubmitPrefill()
+  // G-B2-14: arm the draft machinery once user id resolves; the restore offer only appears when
+  // NO resubmit prefill claimed the form (prefill wins — it is an explicit user intent).
+  try {
+    draftUserId.value = await useAuth().getCurrentUserId()
+  } catch {
+    draftUserId.value = null // drafting silently unavailable without an identity
+  }
+  if (!prefillNoticeVisible.value) offerDraftRestore()
+  draftArmed = true
 })
 
 function syncVisibleFormState() {

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -130,6 +130,15 @@
               v-bind="numberFieldProps(field)"
               class="ms-w-100pct"
             />
+            <!-- G-B2-16: 大写回显 — ONLY under the template-declared amount total (no label
+                 guessing); derived from the same value the backend total-check sees. -->
+            <div
+              v-if="field.type === 'number' && isAutoSummedTotal(field.id) && amountWordsFor(field.id)"
+              class="approval-new__amount-words"
+              data-testid="approval-amount-words"
+            >
+              大写：{{ amountWordsFor(field.id) }}
+            </div>
 
             <!-- date -->
             <el-date-picker
@@ -382,6 +391,7 @@ import { useAuth } from '../../composables/useAuth'
 import { useAutoSumTotal } from '../../approvals/useAutoSumTotal'
 import { isRowDerivationActive } from '../../approvals/lineDerivation'
 import { numberFieldProps } from '../../approvals/numberFieldProps'
+import { amountToChineseWords } from '../../approvals/amountInWords'
 import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
 import {
   createEmptyDetailRow,
@@ -427,6 +437,11 @@ const flowPreviewSteps = computed<ApprovalFlowStep[]>(() => {
 // total field is derived from the detail rows (read-only) — auto-fill (UX) + backend total-check
 // (tamper-proof). FE-only. See useAutoSumTotal for the watch + the backend-identical mirror.
 const { isAutoSummedTotal } = useAutoSumTotal(template, formData)
+
+// G-B2-16: uppercase caption for the declared amount total.
+function amountWordsFor(fieldId: string): string {
+  return amountToChineseWords(formData[fieldId])
+}
 
 const formRules = computed<FormRules>(() => {
   const rules: FormRules = {}
@@ -763,6 +778,12 @@ watch([visibleFieldIds, template], () => {
   font-weight: 400;
   color: var(--el-text-color-secondary);
   margin-top: 2px;
+}
+
+.approval-new__amount-words {
+  margin-top: var(--ms-space-1);
+  font-size: 12px;
+  color: var(--ms-text-3);
 }
 
 .approval-new__form {

--- a/apps/web/tests/approval-amount-in-words.test.ts
+++ b/apps/web/tests/approval-amount-in-words.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { amountToChineseWords } from '../src/approvals/amountInWords'
+
+// G-B2-16 — 金额大写 matrix: boundary digits, 零 collapsing, 角/分 vocabulary, honest omissions.
+
+describe('amountToChineseWords', () => {
+  it('basic integers with 整 suffix', () => {
+    expect(amountToChineseWords(1)).toBe('壹圆整')
+    expect(amountToChineseWords(10)).toBe('壹拾圆整')
+    expect(amountToChineseWords(100)).toBe('壹佰圆整')
+    expect(amountToChineseWords(5000)).toBe('伍仟圆整')
+    expect(amountToChineseWords(100.0)).toBe('壹佰圆整')
+  })
+
+  it('零 collapsing inside a group and across groups', () => {
+    expect(amountToChineseWords(1005)).toBe('壹仟零伍圆整')
+    expect(amountToChineseWords(1050)).toBe('壹仟零伍拾圆整')
+    expect(amountToChineseWords(10005)).toBe('壹万零伍圆整')
+    expect(amountToChineseWords(100050000)).toBe('壹亿零伍万圆整')
+    expect(amountToChineseWords(1000500)).toBe('壹佰万零伍佰圆整')
+  })
+
+  it('万/亿 group units', () => {
+    expect(amountToChineseWords(12345)).toBe('壹万贰仟叁佰肆拾伍圆整')
+    expect(amountToChineseWords(100000000)).toBe('壹亿圆整')
+    expect(amountToChineseWords(500060007)).toBe('伍亿零陆万零柒圆整')
+  })
+
+  it('角/分 vocabulary incl. the 零-join rules', () => {
+    expect(amountToChineseWords(0.5)).toBe('伍角')
+    expect(amountToChineseWords(0.05)).toBe('伍分')
+    expect(amountToChineseWords(10.1)).toBe('壹拾圆壹角')
+    expect(amountToChineseWords(1005.06)).toBe('壹仟零伍圆零陆分')
+    expect(amountToChineseWords(3.45)).toBe('叁圆肆角伍分')
+  })
+
+  it('zero, negatives, rounding half-up in 分', () => {
+    expect(amountToChineseWords(0)).toBe('零圆整')
+    expect(amountToChineseWords(-12.3)).toBe('负壹拾贰圆叁角')
+    expect(amountToChineseWords(0.005)).toBe('壹分') // rounds up at the 分 boundary
+    expect(amountToChineseWords(0.004)).toBe('零圆整')
+  })
+
+  it('honest omissions: NaN / non-number / beyond 万亿 → empty string, never throws', () => {
+    expect(amountToChineseWords(Number.NaN)).toBe('')
+    expect(amountToChineseWords(Infinity)).toBe('')
+    expect(amountToChineseWords('12' as never)).toBe('')
+    expect(amountToChineseWords(1e13)).toBe('')
+    expect(amountToChineseWords(9999999999999)).not.toBe('') // just under the cap still works
+  })
+})

--- a/apps/web/tests/approval-form-draft.test.ts
+++ b/apps/web/tests/approval-form-draft.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clearFormDraft,
+  formDraftKey,
+  formSchemaSignature,
+  loadFormDraft,
+  saveFormDraft,
+} from '../src/approvals/formDraft'
+import type { FormSchema } from '../src/types/approval'
+
+// G-B2-14 — draft autosave helpers: per-user+template keying, schema-drift fail-safe,
+// attachment exclusion from the signature, empty-draft GC, corrupted-storage tolerance.
+
+function fakeStorage(): Storage & { dump: () => Record<string, string> } {
+  const map = new Map<string, string>()
+  return {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+    key: () => null,
+    get length() {
+      return map.size
+    },
+    dump: () => Object.fromEntries(map),
+  } as never
+}
+
+const SCHEMA: FormSchema = {
+  fields: [
+    { id: 'amount', type: 'number', label: '金额' },
+    { id: 'reason', type: 'text', label: '事由' },
+    { id: 'files', type: 'attachment', label: '附件' },
+  ],
+} as FormSchema
+
+describe('formDraft helpers', () => {
+  it('keys drafts per user+template', () => {
+    expect(formDraftKey('u1', 't1')).not.toBe(formDraftKey('u1', 't2'))
+    expect(formDraftKey('u1', 't1')).not.toBe(formDraftKey('u2', 't1'))
+  })
+
+  it('signature excludes attachment fields and is order-independent', () => {
+    const reordered = { fields: [...SCHEMA.fields].reverse() } as FormSchema
+    expect(formSchemaSignature(SCHEMA)).toBe(formSchemaSignature(reordered))
+    expect(formSchemaSignature(SCHEMA)).not.toContain('attachment')
+  })
+
+  it('save→load round-trips under the same signature', () => {
+    const storage = fakeStorage()
+    const key = formDraftKey('u1', 't1')
+    const sig = formSchemaSignature(SCHEMA)
+    saveFormDraft(storage, key, sig, { amount: 12, reason: '出差' })
+    expect(loadFormDraft(storage, key, sig)).toEqual({ amount: 12, reason: '出差' })
+  })
+
+  it('SCHEMA DRIFT fail-safe: signature mismatch → null AND the stale draft is GC-ed', () => {
+    const storage = fakeStorage()
+    const key = formDraftKey('u1', 't1')
+    saveFormDraft(storage, key, 'old-signature', { amount: 12 })
+    expect(loadFormDraft(storage, key, 'new-signature')).toBeNull()
+    expect(storage.getItem(key)).toBeNull() // removed, not left to rot
+  })
+
+  it('empty-ish data clears instead of saving (untouched form leaves no residue)', () => {
+    const storage = fakeStorage()
+    const key = formDraftKey('u1', 't1')
+    const sig = formSchemaSignature(SCHEMA)
+    saveFormDraft(storage, key, sig, { amount: 1 })
+    saveFormDraft(storage, key, sig, { amount: undefined, reason: '', list: [] })
+    expect(storage.getItem(key)).toBeNull()
+  })
+
+  it('corrupted JSON / throwing storage never throws out of the helpers', () => {
+    const storage = fakeStorage()
+    const key = formDraftKey('u1', 't1')
+    storage.setItem(key, '{not json')
+    expect(loadFormDraft(storage, key, 'sig')).toBeNull()
+    const bomb = {
+      getItem: () => {
+        throw new Error('quota')
+      },
+      setItem: () => {
+        throw new Error('quota')
+      },
+      removeItem: () => {
+        throw new Error('quota')
+      },
+    } as never
+    expect(() => saveFormDraft(bomb, key, 'sig', { a: 1 })).not.toThrow()
+    expect(loadFormDraft(bomb, key, 'sig')).toBeNull()
+    expect(() => clearFormDraft(bomb, key)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Final two batch-2 G slices of the FORM domain (§7.2, gate:none), main-loop implementation.

**G-B2-14 draft autosave/restore**: pure storage-injected `formDraft.ts` (per user+template key, schema-signature drift guard — mismatch → treated absent + GC'd, mutation-verified; attachments excluded; empty forms leave no residue; quota/privacy/corrupt storage all swallowed) + ApprovalNewView wiring (800ms debounced deep-watch armed after template+uid resolve; restore alert mirrors the B2-13 prefill idiom and YIELDS to it; submit/discard consume the draft).

**G-B2-16 金额大写回显**: pure `amountInWords.ts` (scaled-int 分 arithmetic, full 零-collapsing incl. cross-group joins, 角/分 vocabulary, 负 prefix, honest empty for NaN/≥1e13); caption only under the `amountConsistencyCheck`-declared total field — no label guessing.

**Grounding finding**: G-B2-02 (number min/step/precision) was ALREADY LANDED (#3640, `numberFieldProps` at both sites) — benchmark §7.2 row stale; pool ledger −1, no re-work.

Verification: draft 6/6 + words 6/6 + affected 104/104 · two mutations RED→revert · vue-tsc 0 · build green · lint clean · two-point wiring ×2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)