### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaCommentComposer submit button to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaCommentComposer.vue
+++ b/apps/web/src/multitable/components/MetaCommentComposer.vue
@@ -51,9 +51,9 @@
     </div>
     <div class="meta-comment-composer__footer">
       <span class="meta-comment-composer__hint">{{ composerHint }}</span>
-      <button class="meta-comment-composer__submit" :disabled="submitting || disabled || !modelValue.trim()" type="button" @click="submit">
+      <MtButton variant="primary" class="meta-comment-composer__submit" :disabled="submitting || disabled || !modelValue.trim()" @click="submit">
         {{ submitButtonLabel }}
-      </button>
+      </MtButton>
     </div>
   </div>
 </template>
@@ -63,6 +63,7 @@ import { computed, nextTick, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import type { MetaCommentMentionSuggestion } from '../types'
 import { commentLabel, type MetaCommentLabelKey } from '../utils/meta-comment-labels'
+import { MtButton } from '../ui'
 
 const props = withDefaults(defineProps<{
   modelValue: string
@@ -295,15 +296,8 @@ function submit() {
 .meta-comment-composer__suggestion small { color: #64748b; }
 .meta-comment-composer__footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .meta-comment-composer__hint { color: #6b7280; font-size: 12px; }
-.meta-comment-composer__submit {
-  padding: 6px 14px;
-  background: #2563eb;
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 12px;
-}
-.meta-comment-composer__submit:disabled,
+/* .meta-comment-composer__submit: the submit control is now <MtButton variant="primary"> (token-styled
+   via --ms-color-primary); its bespoke hardcoded-hex CSS was removed (P2-1c). Class kept for selector
+   stability. mention-chip stays bespoke (a domain chip, not a generic action button). */
 .meta-comment-composer__mention-chip:disabled { opacity: 0.5; cursor: not-allowed; }
 </style>

--- a/apps/web/tests/meta-comment-composer-migration.spec.ts
+++ b/apps/web/tests/meta-comment-composer-migration.spec.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaCommentComposer from '../src/multitable/components/MetaCommentComposer.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaCommentComposer's submit control was migrated from a bespoke <button> to the shared
+// MtButton primitive (variant="primary" = --ms-color-primary). Behavior-preservation proof: it stays a
+// native, keyboard-operable <button>; the disabled binding (empty / submitting / disabled) survives; and
+// clicking it still emits `submit` with the SAME { content, mentions } payload. The two other controls
+// (mention-chip removal, @-suggestion item) are domain chips and stay bespoke (curated migration).
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-comment-composer').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaCommentComposer, { ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const submitBtn = (root: HTMLElement) => root.querySelector('.meta-comment-composer__submit') as HTMLButtonElement
+
+describe('MetaCommentComposer — MtButton migration (UI-P2-1c)', () => {
+  it('renders submit as a native <button>; disabled when the draft is empty', () => {
+    const root = mount({ modelValue: '' })
+    const btn = submitBtn(root)
+    expect(btn).toBeTruthy()
+    expect(btn.tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+    expect(btn.disabled).toBe(true) // :disabled="... || !modelValue.trim()"
+  })
+
+  it('clicking submit with a non-empty draft emits `submit` with { content, mentions } (unchanged)', () => {
+    const onSubmit = vi.fn()
+    const root = mount({ modelValue: 'hello world' }, { onSubmit })
+    const btn = submitBtn(root)
+    expect(btn.disabled).toBe(false)
+    btn.click()
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    const payload = onSubmit.mock.calls[0][0]
+    expect(typeof payload.content).toBe('string')
+    expect(payload.content.length).toBeGreaterThan(0)
+    expect(payload.mentions).toEqual([]) // no @-mentions selected
+  })
+
+  it('stays disabled (no emit) while submitting — disabled binding preserved through the migration', () => {
+    const onSubmit = vi.fn()
+    const root = mount({ modelValue: 'hello', submitting: true }, { onSubmit })
+    const btn = submitBtn(root)
+    expect(btn.disabled).toBe(true)
+    btn.click()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, self-merge bar; curated — only the generic submit action button, mention-chip/suggestion stay bespoke). Submit → MtButton variant=primary (bespoke #2563eb == --ms-color-primary); `@click=submit`/`:disabled` preserved; `emit('submit',{content,mentions})` byte-identical; bespoke hex CSS removed. Mount test (3/3): native button + empty-draft-disabled + emit-payload parity + submitting-disabled. vue-tsc clean; no new hex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)