### PR TITLE
docs(multitable): R4 post-hoc corrections — T-source premise (A2 shipped in #3749) + 4c-2 review fixes

### DIFF
--- a/docs/development/multitable-global-history-4c2-forward-tombstone-capture-design-lock-20260707.md
+++ b/docs/development/multitable-global-history-4c2-forward-tombstone-capture-design-lock-20260707.md
@@ -2,6 +2,8 @@
 
 **状态:PROPOSED,待 owner ratify。** 本锁在线级全自动授权下起草;forward-plan(#3633)中 4c-2 的解锁词是「owner 单项签核」——**起草 ≠ 开工,impl 仅在 ratify 后排期**。姊妹锁:4c-1 lossy retype revert(同日起草,可并行 ratify;两锁互引见 §4 R2)。
 
+> **行号注(post-hoc 审阅修正):** 初版 `univer-meta.ts` 行号取自过时快照(`cdd716049`);本版已按 `origin/main@4bb668fa5`(2026-07-07)刷新。该文件行号漂移快,impl 前请以函数/符号定位。其余文件引用经审阅逐一核对为准确。
+
 ## 0. 一句话与红线
 
 让**未来的**破坏性操作(字段删除 / lossy retype 的 coerce 写 / 记录硬删的入边)在销毁瞬间于同事务内捕获值级 tombstone,使其可恢复。
@@ -11,11 +13,11 @@
 
 | 破坏面 | 销毁语句 | 今日捕获 |
 |---|---|---|
-| 字段删除:列值 | `packages/core-backend/src/routes/univer-meta.ts:5983` `UPDATE meta_records SET data = data - $1` | **无** |
-| 字段删除:link 边 | `:5978` `DELETE FROM meta_links WHERE field_id = $1` | **无** |
-| 字段删除:auto-number 序列 | `:5970` | **无** |
-| 字段删除:定义 | `:5971-5976` `fieldDeleteDiff`(仅 name/type/property/order) | ✅ config revision |
-| lossy retype pre-image | 前向 PATCH 无值迁移(`:10660-10666`);4c-1 落地后其 coerce 写成为新破坏点 | **无** |
+| 字段删除:列值 | `packages/core-backend/src/routes/univer-meta.ts:6086` `UPDATE meta_records SET data = data - $1` | **无** |
+| 字段删除:link 边 | `:6081` `DELETE FROM meta_links WHERE field_id = $1` | **无** |
+| 字段删除:auto-number 序列 | `:6073` | **无** |
+| 字段删除:定义 | `fieldDeleteDiff`(`dropFieldCascade` 内;仅 name/type/property/order) | ✅ config revision |
+| lossy retype pre-image | 前向 PATCH 无值迁移(field-PATCH 裸 `UPDATE meta_fields`);4c-1 落地后其 coerce 写成为新破坏点 | **无** |
 | 记录硬删:行值+出边 | `record-service.ts:804` snapshot + `:835-840` trash | ✅ `meta_records_trash` + delete revision |
 | 记录硬删:**入边** | `record-service.ts:808` `DELETE FROM meta_links WHERE record_id=$1 OR foreign_record_id=$1` | **无**(4c-3 record-undelete 2b 的阻塞缺口) |
 
@@ -31,20 +33,20 @@
 
 捕获点(全部 same-txn、置于破坏语句**之前**、单条 `INSERT … SELECT` 批量,不逐行往返):
 
-1. `dropFieldCascade`(`univer-meta.ts:5957-6017`)内:列值(`SELECT … FROM meta_records WHERE sheet_id=$2 AND data ? $fieldId`)、该 field 全部边、序列 `last_value`。
-2. `deleteRecord`(`record-service.ts:790-846`)内:**入边**(`foreign_record_id = $1` 的行)。出边已由 trash `data` 覆盖并在 restore 重放(`:1011-1020`),**不重复捕获**。
-3. 4c-1 lossy revert 的 coerce 写(若其 ratify):被 coerce/drop 的 cell pre-image → `meta_field_value_tombstones(reason='lossy_retype')`。
+1. `dropFieldCascade`(`univer-meta.ts:6061-6120`)内:列值(`SELECT … FROM meta_records WHERE sheet_id=$2 AND data ? $fieldId`)、该 field 全部边、序列 `last_value`。**注**:cascade 内的字段 order-shift 与视图 config 清理**不需要**值级捕获——它们已被记为 config revision 并经既有 config-restore 可逆(审阅核实 `recordFieldOrderShifts` :6088 / `recordConfigRevision` :6113)。
+2. `deleteRecord`(`record-service.ts:790-846`)内:**入边**(`foreign_record_id = $1` 的行)。出边已由 trash `data` 覆盖并在 restore 重放(`:1011-1020`,mirror 侧跳过 `:988`),**不重复捕获**;twoWay link 的 `meta_links` 行只归前向侧所有(spine 不变量),入/出划分干净不重叠。自链(`record_id = foreign_record_id`)会被双覆盖,restore 侧 `ON CONFLICT DO NOTHING` 免疫,无害。
+3. 4c-1 lossy revert 的 coerce 写(若其 ratify):被 coerce/drop 的 cell pre-image → `meta_field_value_tombstones(reason='lossy_retype')`,**锚(`config_revision_id`)= 该次 lossy revert 自身的 config revision**(即「回指触发行」;前向 retype 不迁移值,不产生也不需要 pre-image)——与 4c-1 锁 §3 同语义(post-hoc 审阅 P2 已两侧对齐)。
 
 ## 3. Flag 与 cap(锁定)
 
 - 捕获 flag:`MULTITABLE_TOMBSTONE_CAPTURE_ENABLED`,默认 **off**;off = 今日行为逐字节不变。
-- 捕获 cap:`MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS`(默认 50000)。flag on 且待捕获行数超 cap → **拒绝破坏操作本身**(422,提示调高 cap 或关捕获),**绝不静默跳过捕获后照删**——保住「flag on ⇒ 凡销毁必已捕获」。(写对称 cap 纪律;先例 `SHEET_REVERT_MAX_RECORDS` `univer-meta.ts:9276-9277`)
+- 捕获 cap:`MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS`(默认 50000)。flag on 且待捕获行数超 cap → **拒绝破坏操作本身**(422,提示调高 cap 或关捕获),**绝不静默跳过捕获后照删**——保住「flag on ⇒ 凡销毁必已捕获」。(写对称 cap 纪律;先例 `SHEET_REVERT_MAX_RECORDS` `univer-meta.ts:9410-9411`。**口径注**:此处有意用 422 而非先例的 413——413 语义是「恢复范围过大」,这里拒绝的是**前向破坏操作自身**因捕获预算不足;双 ratify 路径上 413(5000)先于本 cap(50000)触发,实践无歧义。)
 - 捕获 INSERT 失败 = 整事务回滚,破坏操作不发生(fail-closed)。
 
 ## 4. 恢复面(本锁只锁两个最小恢复 + 一个显式不做)
 
-- **R1 字段 undelete 升级**:现 definition-only recreate(`recreateFieldFromConfig` `univer-meta.ts:6081-6107`,注释明言 values/links/auto-number NOT recovered)在 tombstone 存在时补水:值批量写回(仅 `data ? $fieldId` 为假的行——不覆盖 recreate 后用户新写的值)、边重建(仅两端记录均存活者)、序列 `last_value` 恢复。tombstone 不存在(前 flag 期数据)→ 保持今日 definition-only + 既有诚实文案。
-- **R2 lossy retype revert 的真值恢复**:pre-image 存在时,4c-1 的 revert 优先用真值而非再-coerce——具体契约在 4c-1 锁 §5(pre-image-preference);本锁只保证捕获物与因果锚可用。
+- **R1 字段 undelete 升级**:现 definition-only recreate(`recreateFieldFromConfig` `univer-meta.ts:6184` 起,注释明言 values/links/auto-number NOT recovered)在 tombstone 存在时补水:值批量写回(仅 `data ? $fieldId` 为假的行——不覆盖 recreate 后用户新写的值)、边重建(仅两端记录均存活者)、序列 `last_value` 恢复。tombstone 不存在(前 flag 期数据)→ 保持今日 definition-only + 既有诚实文案。
+- **R2 lossy retype revert 的真值恢复**:pre-image 由 4c-1 的 coerce 写捕获、**锚定该次 revert 自身的 revision**(§2 捕获点 3);其后的**再逆操作**(revert-of-revert)按锚取回真值而非再-coerce——具体契约在 4c-1 锁 §3(pre-image-preference);本锁只保证捕获物与因果锚可用。
 - **❌ 不做**:record undelete 2b 的入边重建语义(= 4c-3,独立 owner 签核;本锁只捕边、不重建)。
 
 ## 5. 不变量(C1–C7)
@@ -78,6 +80,6 @@
 
 ## 8. 出界(记录在案)
 
-sheet 删除级联(`univer-meta.ts:11548`)、跨 base、任何 FE 面(独立 gated 项)、`meta_records_trash` 的 retention 接入、4d(不可能项,永不承诺)。
+sheet 删除级联(`univer-meta.ts:11927`)、跨 base、任何 FE 面(独立 gated 项)、`meta_records_trash` 的 retention 接入、4d(不可能项,永不承诺)。
 
 **解锁词示例:「ratify 4c-2」(可附修改意见)。**

--- a/docs/development/multitable-global-history-t-source-history-anchored-direction-20260707.md
+++ b/docs/development/multitable-global-history-t-source-history-anchored-direction-20260707.md
@@ -2,11 +2,13 @@
 
 **性质:** 产品方向提案(PROPOSED)。本文**不是** design-lock,也不授权任何开工;forward-plan(#3633)中 T-source 的解锁词仍是「owner 对产品方向的明确点头」。本文的唯一目的:把这个点头压缩成一句话。
 
-## 1. 现状(primary-source 已核)
+> **⚠️ 更正(2026-07-07 同日 post-hoc 对抗审阅发现,P1):** 本文初版的「现状」基于过时快照(park-neutral @ `cdd716049`,落后 origin/main 155 commits)调研,漏看了当日 06:02 已合入的 **#3749**(codex/global-history-final-code-dev)——**A2 形态当时已经上线**。初版 §1「唯一控件 = 自由 datetime-local」为伪;真实决策点不是「A1 vs A2 点头开工」,而是下方 §4 的「**保持 A2(已上线)vs 简化为 A1**」。§2 rationale 与 §3 语义边界不受影响。(教训归档:gap-analysis 必须对 fresh origin/main,勿信「park-neutral≈origin/main」的口头前提。)
 
-- 用户选 T 的唯一控件 = 自由 `datetime-local` 输入(`apps/web/src/multitable/components/ResetToPointPicker.vue:19-25`)。`asOf` 派生处是作者预留的 **single swappable seam**(`:67-74`;头注 `:6-8` 明确写了 deferred 替代方案就是「把 HistoryCenterModal 最近批次时间戳做成可选项」)。
-- 后端 reset-preview/execute 只收 `asOf` 时间戳(`packages/core-backend/src/routes/univer-meta.ts:9580-9586` / `:9620-9627`),per-record 解析到 `created_at <= T` 的最近 revision(`record-reconstructor.ts:34-68`,PIT-4 确定序)。
-- HistoryCenter batch 行已具备全部锚点素材:`batchId`/`createdAt`/`actorName`/`source`/`action`/counts(`apps/web/src/multitable/types.ts:338-350`;`HistoryCenterModal.vue:44-50`)。
+## 1. 现状(更正后;以 `origin/main@4bb668fa5` 为准)
+
+- **history-anchored 主路径已上线(#3749)**:`apps/web/src/multitable/components/ResetToPointPicker.vue:19-25` 是「History point」批次 `<select>`(`selectedBatchId`,由最近 Global History 批次填充);自由 `datetime-local` 已降级为「Advanced manual time」`<details>` 兜底(`:51-64`);`mode` 默认 `'history'`(`:120`)。
+- 后端 reset-preview/execute 只收 `asOf` 时间戳(`packages/core-backend/src/routes/univer-meta.ts:9723-9749` / `:9764-9786`),per-record 解析到 `created_at <= T` 的最近 revision(`record-reconstructor.ts:34-68`,PIT-4 确定序)——锚定路径与手动路径共用同一 `asOf` 契约,后端零分叉。
+- HistoryCenter batch 行字段即锚点素材:`batchId`/`createdAt`/`actorName`/`source`/`action`/counts(`apps/web/src/multitable/types.ts:338-350`)。
 
 ## 2. 为什么 history-anchored(而非自由时间)
 
@@ -16,17 +18,17 @@
 
 ## 3. V1 语义边界(建议随点头一并锁死)
 
-- 锚点语义 = **「恢复到该批次完成后的状态」**(`asOf = batch.createdAt`,含该批次;与 `created_at <= T` 完全一致,零语义偏移)。
-- 「恢复到该批次**之前**」不进 V1:需要排他界,且同一时间戳多批次(批量导入)存在边界并列。将来若要精确批次排除,现成 prior art = config-restore 的 `revisionId` 锚定(`univer-meta.ts:8085-8091`)与 record-restore 的 `targetVersion`(`client.ts:2158`)。
+- 锚点语义 = **「恢复到该批次完成后的状态」**(`asOf = batch.createdAt`,含该批次;与 `created_at <= T` 完全一致,零语义偏移)。注:同一毫秒存在**兄弟批次**时,锚定其一会把并列批次一并含入(两者都 `<= T`)——该措辞在此情形下是近似,精确到批次的排除属 V2。
+- 「恢复到该批次**之前**」不进 V1:需要排他界,且同一时间戳多批次(批量导入)存在边界并列。将来若要精确批次排除,现成 prior art = config-restore 的 `revisionId` 锚定(`univer-meta.ts:8219-8225`)与 record-restore 的 `targetVersion`(`client.ts:2158`)。
 - retention 削薄后锚点只列幸存批次——与重建现实(只能基于幸存 revision)一致,反而消除自由时间戳在已清历史区间上的假象。
 
-## 4. 两个可点头的选项
+## 4. 决策点(更正后)
 
-- **A1(推荐):anchored-only** — 移除自由 datetime 输入,picker = HistoryCenter 最近批次列表(复用既有游标 loadMore)。理由:自由时间戳语义冗余(§2.1),保留只增加误用面与双路测试面。
-- **A2(保守):anchored 默认 + 自由 datetime 收进「高级」折叠** — 保底逃生口,代价是保留伪精度入口,且两条 T 路径都要长期养测试。
+- **B1(维持现状):保持 A2** — 锚定默认 + Advanced 手动兜底(#3749 已上线形态,含 29 个 FE 测试)。兜底留给「历史被 retention 清薄后想指定更早时点」等边角;代价是双 T 路径测试面长期存在。
+- **B2:简化为 A1(anchored-only)** — 移除 Advanced 兜底(§2.1 语义冗余论仍成立);减一条 T 路径与其测试面;代价是失去逃生口。
 
 ## 5. 点头后的执行承诺(不点头不动)
 
-单车道单轮:Sonnet 5 建 + Fable 5 审;FE-only + 少量 wiring;golden 覆盖(锚点选择→`asOf` 传参→preview 摘要一致性;空历史 / retention 削薄 / 同时间戳并列边角);验证 MD 随轮交付。
+若择 **B1**:零工作,本文即闭。若择 **B2**:单车道小 slice(Sonnet 5 建 + Fable 5 审;FE-only 移除 + 测试收敛;验证 MD 随轮交付)。
 
-**解锁词示例:「T-source 按 A1 做」或「按 A2 做」。**
+**解锁词示例:「保持 A2」或「简化为 A1」。**


### PR DESCRIPTION
对 R4 已合的两份文档做 post-hoc 对抗审阅(Opus,refute-first)后的修正(审阅 MD:/tmp/pr3809-pr3812-pr3807-review-claude-20260707.md;#3812 的同批 fixes 已直接推该 PR):

**#3807 T-source 一页纸 — P1 前提为伪:**
- 初版「唯一控件=自由 datetime-local」基于过时快照(cdd716049,落后 155 commits)调研,漏看当日 06:02 已合入的 **#3749**——A2 形态(锚定 select 主路径 + Advanced 手动兜底,mode 默认 history)**当时已上线**。
- 修正:显著更正块 + §1 重写(以 origin/main@4bb668fa5 为准)+ §4 决策点重构为「**保持 A2 vs 简化为 A1**」+ 同毫秒兄弟批次的诚实注 + 行号刷新。

**#3809 4c-2 锁 — APPROVE-with-fixes 的 fixes:**
- P2(两锁联动锚):捕获点 3 明确锚 = **该次 lossy revert 自身的 revision**(前向 retype 不产生 pre-image);§4 R2 改为「再逆操作按锚取真值」——与 #3812 修正后的 §3 两侧对齐。
- P3:cap 422 vs 先例 413 的口径注(一句话辩护);univer-meta.ts 行号全部刷新到 origin/main@4bb668fa5 + 行号注。
- NIT:order-shift/视图清理为何不需捕获(已 config-revision 可逆)、自链双覆盖无害注。

🤖 Generated with [Claude Code](https://claude.com/claude-code)