### PR TITLE
feat(plm-collab): ECO Phase 3 — locked-BOM revision-intent consumer CTA + pact at the callsite

### DIFF
--- a/apps/web/src/components/integration/IntegrationObjectTemplateSection.vue
+++ b/apps/web/src/components/integration/IntegrationObjectTemplateSection.vue
@@ -69,6 +69,7 @@
           <PlmBomReviewPanel
             v-if="selectedPlmBomMultitableCapabilityEntry.state === 'enabled' && selectedSourcePlmDataSourceId"
             :data-source-id="selectedSourcePlmDataSourceId"
+            :eco-intent-enabled="selectedPlmBomEcoIntentEnabled"
           />
         </div>
         <div v-if="!hasRunnableSourceSystem" class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="source-empty-state">
@@ -209,6 +210,9 @@ defineProps<{
   sourceSelectorExplanation: string
   selectedPlmApprovalCapabilityEntry: PlmApprovalCapabilityEntry | null
   selectedPlmBomMultitableCapabilityEntry: PlmBomCapabilityEntry | null
+  // ECO Phase 3: capability-advisory pre-gate for the locked-BOM ECO-revision CTA (computed by
+  // the workbench view from features.bom_eco_revision; the panel never fetches capabilities).
+  selectedPlmBomEcoIntentEnabled: boolean
   selectedSourcePlmDataSourceId: string
   hasRunnableSourceSystem: boolean
   showStagingSetup: () => void

--- a/apps/web/src/components/plm/PlmBomReviewPanel.vue
+++ b/apps/web/src/components/plm/PlmBomReviewPanel.vue
@@ -53,6 +53,33 @@
           该 Part 处于锁定状态（{{ context.part.state }}），已暂停行内编辑；修改需通过 PLM 的 ECO
           变更流程。
         </p>
+        <!-- ECO Phase 3 CTA: the governed door the locked state points at. Shown for BOTH lock
+             sites (the advisory pre-gate above AND the reactive write-back lifecycle_locked 409),
+             pre-gated on the capabilities advisory (bom_eco_revision + eco_revision_intent). -->
+        <div
+          v-if="ecoIntentRelevant"
+          class="bom-review__eco-intent"
+          data-testid="plm-bom-review-eco-intent"
+        >
+          <button
+            v-if="advisoryLocked || writebackLocked"
+            type="button"
+            class="bom-review__button"
+            data-testid="plm-bom-review-eco-intent-cta"
+            :disabled="ecoIntentStatus !== 'idle'"
+            @click="requestEcoIntent"
+          >
+            {{ ecoIntentStatus === 'requesting' ? '正在发起 ECO 修订…' : '发起 ECO 修订' }}
+          </button>
+          <p
+            v-if="ecoIntentMessage"
+            class="bom-review__hint"
+            :class="{ 'bom-review__hint--strong': ecoIntentStatus === 'done' }"
+            data-testid="plm-bom-review-eco-intent-message"
+          >
+            {{ ecoIntentMessage }}
+          </p>
+        </div>
         <PlmBomReviewTable
           :context="context"
           :editable="!advisoryLocked"
@@ -69,6 +96,7 @@
 import { computed, ref } from 'vue'
 import {
   getPlmBomMultitableContext,
+  requestPlmBomEcoRevisionIntent,
   updatePlmBomMultitableLine,
   type PlmBomMultitableLine,
   type PlmBomMultitableLinePatch,
@@ -76,7 +104,11 @@ import {
 } from '../../services/integration/workbench'
 import PlmBomReviewTable from './PlmBomReviewTable.vue'
 
-const props = defineProps<{ dataSourceId: string }>()
+// ecoIntentEnabled: the ECO Phase 3 CTA pre-gate, computed by the WORKBENCH view from the
+// capabilities advisory (features.bom_eco_revision supported+entitled+actions includes
+// eco_revision_intent) and passed down — the panel itself never fetches capabilities
+// (P3-C invariant: mounting the panel triggers no PLM call).
+const props = defineProps<{ dataSourceId: string; ecoIntentEnabled?: boolean }>()
 
 const partId = ref('')
 const loading = ref(false)
@@ -84,6 +116,11 @@ const result = ref<PlmBomMultitableResult | null>(null)
 const submittingLineId = ref<string | null>(null)
 const lineMessages = ref<Record<string, string>>({})
 const retryKeys = ref<Record<string, string>>({})
+// ECO Phase 3 CTA state. writebackLocked = the REACTIVE lock site (a write-back came back
+// 409 lifecycle_locked even though the advisory pre-gate missed it — custom lock state or race).
+const writebackLocked = ref(false)
+const ecoIntentStatus = ref<'idle' | 'requesting' | 'done'>('idle')
+const ecoIntentMessage = ref('')
 
 const context = computed(() =>
   result.value && result.value.available ? result.value.context : null,
@@ -102,6 +139,52 @@ const advisoryLocked = computed(() => {
   const state = context.value?.part.state
   return typeof state === 'string' && ADVISORY_LOCKED_STATES.has(state)
 })
+
+// The CTA renders only when the capability advertises the intent action AND the part is locked
+// by EITHER site (advisory pre-gate or the reactive write-back 409). Part-scoped: the intent
+// targets the ROOT part, not a line. A lingering message keeps the block visible even after a
+// not_locked reset clears the lock flags (else the explanation would vanish with the button).
+const ecoIntentRelevant = computed(() =>
+  props.ecoIntentEnabled === true
+  && (advisoryLocked.value || writebackLocked.value || ecoIntentMessage.value !== ''),
+)
+
+async function requestEcoIntent(): Promise<void> {
+  const part = context.value?.part.part_id
+  if (!part || ecoIntentStatus.value !== 'idle') return
+  ecoIntentStatus.value = 'requesting'
+  ecoIntentMessage.value = ''
+  try {
+    const outcome = await requestPlmBomEcoRevisionIntent(props.dataSourceId, part)
+    if (outcome.ok) {
+      ecoIntentStatus.value = 'done'
+      ecoIntentMessage.value = outcome.attached
+        ? `已挂接到该 Part 现有的开放 ECO（${outcome.eco_id}）；请在 PLM 中继续该 ECO 的修订与审批。`
+        : `已发起 ECO 修订（${outcome.eco_id}）；修订分支已创建，请在 PLM 中完成变更与审批。`
+      return
+    }
+    ecoIntentStatus.value = 'idle'
+    if (outcome.reason === 'not_locked') {
+      // The provider says the part is editable — the reactive lock was stale. Reset it so the
+      // CTA hides (advisory permitting) and the user goes back to the direct edit path.
+      writebackLocked.value = false
+      ecoIntentMessage.value = '该 Part 当前未处于锁定状态，可直接编辑写回，无需 ECO 修订。'
+      return
+    }
+    if (outcome.reason === 'eco_intent_rejected') {
+      ecoIntentMessage.value = '发起 ECO 修订被拒（可能存在并发变更或该 Part 不可修订），请稍后重试。'
+      return
+    }
+    if (outcome.status === 403) {
+      ecoIntentMessage.value = '当前租户未开通 ECO 修订通道，或权限不足。'
+      return
+    }
+    ecoIntentMessage.value = '发起 ECO 修订失败，请稍后重试。'
+  } catch {
+    ecoIntentStatus.value = 'idle'
+    ecoIntentMessage.value = '发起 ECO 修订失败，请稍后重试。'
+  }
+}
 
 // idle (nothing loaded) -> loading -> one of: unavailable (no support / degraded), upgrade
 // (supported but not entitled), error (entitled but the provider fetch failed transiently),
@@ -127,6 +210,10 @@ async function load(): Promise<void> {
   loading.value = true
   lineMessages.value = {}
   retryKeys.value = {}
+  // A fresh load is a fresh part/context: reset the ECO-intent CTA state machine.
+  writebackLocked.value = false
+  ecoIntentStatus.value = 'idle'
+  ecoIntentMessage.value = ''
   try {
     result.value = await getPlmBomMultitableContext(props.dataSourceId, pid)
   } catch {
@@ -210,6 +297,17 @@ async function submitLinePatch(payload: { line: PlmBomMultitableLine; patch: Plm
       }
       return
     }
+    if (outcome.status === 409 && outcome.reason === 'lifecycle_locked') {
+      // ECO Phase 3: the REACTIVE lock site — the advisory pre-gate missed this lock (custom
+      // lock state or a race), the provider's discriminated 409 is authoritative. Flip the
+      // part-level flag so the ECO-revision CTA surfaces (capability permitting).
+      writebackLocked.value = true
+      lineMessages.value = {
+        ...lineMessages.value,
+        [lineId]: writebackMessage(outcome.status, outcome.reason),
+      }
+      return
+    }
     lineMessages.value = {
       ...lineMessages.value,
       [lineId]: writebackMessage(outcome.status, outcome.reason),
@@ -230,4 +328,5 @@ async function submitLinePatch(payload: { line: PlmBomMultitableLine; patch: Plm
 .bom-review__button { white-space: nowrap; }
 .bom-review__hint--muted { opacity: 0.6; }
 .bom-review__hint--strong { font-weight: 600; }
+.bom-review__eco-intent { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 </style>

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -149,6 +149,23 @@ export type PlmBomMultitableLineUpdateResult =
     message: string
   }
 
+// ECO Phase 3: result of the locked-BOM revision-intent CTA. `attached: true` = an already-open
+// bom-ECO for this part was reused (provider attach-before-create; a repeat click attaches
+// instead of spawning a second ECO — that is the idempotency story, no Idempotency-Key).
+export type PlmBomEcoRevisionIntentResult =
+  | {
+    ok: true
+    eco_id: string
+    state: string
+    attached: boolean
+  }
+  | {
+    ok: false
+    status: number
+    reason: string
+    message: string
+  }
+
 export interface WorkbenchExternalSystemUpsertRequest extends IntegrationScope {
   id?: string
   projectId?: string | null
@@ -874,6 +891,52 @@ export async function updatePlmBomMultitableLine(
     status: 502,
     reason: 'malformed-response',
     message: 'BOM write-back returned a malformed response',
+  }
+}
+
+// ECO Phase 3 consumer CTA: request an ECO revision intent for a lifecycle-locked part.
+// Bare relay object (NOT parseIntegrationResponse — /api/plm-workbench/* returns bare, like
+// getPlmBomMultitableContext). Actionable errors return {ok:false, status, reason, message}
+// instead of throwing; reason surfaces the relay's vocabulary (not_locked / eco_intent_rejected /
+// unsupported / not-entitled / unavailable / provider-rejected / malformed-response).
+export async function requestPlmBomEcoRevisionIntent(
+  dataSourceId: string,
+  partId: string,
+): Promise<PlmBomEcoRevisionIntentResult> {
+  const dsId = dataSourceId.trim()
+  const pid = partId.trim()
+  if (!dsId || !pid) {
+    return { ok: false, status: 400, reason: 'invalid-request', message: 'ECO revision request is incomplete' }
+  }
+  const response = await apiFetch(
+    `/api/plm-workbench/data-sources/${encodeURIComponent(dsId)}/bom-multitable/${encodeURIComponent(pid)}/eco-intent`,
+    {
+      method: 'POST',
+      suppressUnauthorizedRedirect: true,
+    },
+  )
+  const body = await response.json().catch(() => null) as Record<string, unknown> | null
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      reason: typeof body?.reason === 'string' && body.reason.trim() ? body.reason.trim() : 'intent-failed',
+      message: typeof body?.error === 'string' && body.error.trim() ? body.error.trim() : `ECO revision intent failed (${response.status})`,
+    }
+  }
+  if (
+    body
+    && typeof body.eco_id === 'string' && body.eco_id.trim()
+    && typeof body.state === 'string'
+    && typeof body.attached === 'boolean'
+  ) {
+    return { ok: true, eco_id: body.eco_id.trim(), state: body.state, attached: body.attached }
+  }
+  return {
+    ok: false,
+    status: 502,
+    reason: 'malformed-response',
+    message: 'ECO revision intent returned a malformed response',
   }
 }
 

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -132,6 +132,7 @@
       :source-selector-explanation="sourceSelectorExplanation"
       :selected-plm-approval-capability-entry="selectedPlmApprovalCapabilityEntry"
       :selected-plm-bom-multitable-capability-entry="selectedPlmBomMultitableCapabilityEntry"
+      :selected-plm-bom-eco-intent-enabled="selectedPlmBomEcoIntentEnabled"
       :selected-source-plm-data-source-id="selectedSourcePlmDataSourceId"
       :has-runnable-source-system="hasRunnableSourceSystem"
       :show-staging-setup="showStagingSetup"
@@ -1517,6 +1518,19 @@ const selectedBomMultitableFeature = computed<PlmIntegrationCapabilityFeature | 
   if (!result?.available) return null
   const feature = result.manifest.features[PLM_BOM_MULTITABLE_FEATURE_KEY]
   return feature && typeof feature === 'object' ? feature : null
+})
+// ECO Phase 3: advisory pre-gate for the locked-BOM ECO-revision CTA. True iff the provider's
+// capabilities manifest advertises bom_eco_revision as supported + entitled AND its actions
+// include eco_revision_intent (Phase-0 Lock 3: availability discovery is the advisory, never
+// the error payload). Advisory only — the relay + provider re-gate authoritatively.
+const selectedPlmBomEcoIntentEnabled = computed<boolean>(() => {
+  const result = selectedSourcePlmCapabilities.value
+  if (!result?.available) return false
+  const feature = result.manifest.features.bom_eco_revision
+  if (!feature || typeof feature !== 'object') return false
+  if (feature.supported !== true || feature.entitled !== true) return false
+  const actions = Array.isArray(feature.actions) ? feature.actions : []
+  return actions.includes('eco_revision_intent')
 })
 const selectedPlmBomMultitableCapabilityEntry = computed<PlmBomCapabilityEntry | null>(() => {
   if (!selectedSourcePlmDataSourceId.value) return null

--- a/apps/web/tests/PlmBomReviewPanel.spec.ts
+++ b/apps/web/tests/PlmBomReviewPanel.spec.ts
@@ -3,9 +3,11 @@ import { createApp, nextTick, type App as VueApp } from 'vue'
 
 const getContextMock = vi.fn()
 const updateLineMock = vi.fn()
+const ecoIntentMock = vi.fn()
 vi.mock('../src/services/integration/workbench', () => ({
   getPlmBomMultitableContext: (...args: unknown[]) => getContextMock(...args),
   updatePlmBomMultitableLine: (...args: unknown[]) => updateLineMock(...args),
+  requestPlmBomEcoRevisionIntent: (...args: unknown[]) => ecoIntentMock(...args),
 }))
 
 import PlmBomReviewPanel from '../src/components/plm/PlmBomReviewPanel.vue'
@@ -36,10 +38,10 @@ async function flushUi(cycles = 6): Promise<void> {
 let app: VueApp | null = null
 let container: HTMLDivElement
 
-function mountPanel(dataSourceId = 'plm-ds'): void {
+function mountPanel(dataSourceId = 'plm-ds', extraProps: Record<string, unknown> = {}): void {
   container = document.createElement('div')
   document.body.appendChild(container)
-  app = createApp(PlmBomReviewPanel, { dataSourceId })
+  app = createApp(PlmBomReviewPanel, { dataSourceId, ...extraProps })
   app.mount(container)
 }
 
@@ -62,6 +64,7 @@ afterEach(() => {
   container?.remove()
   getContextMock.mockReset()
   updateLineMock.mockReset()
+  ecoIntentMock.mockReset()
   vi.unstubAllGlobals()
 })
 
@@ -316,5 +319,130 @@ describe('PlmBomReviewPanel (P3-C BOM review + governed write-back)', () => {
     await setPartAndLoad('P1')
     expect(stateOf()).toBe('error')
     expect(container.querySelector('[data-testid="plm-bom-review-error"]')).not.toBeNull()
+  })
+})
+
+describe('ECO Phase 3: locked-BOM revision-intent CTA', () => {
+  function lockedContextResult() {
+    const locked = cloneContext()
+    locked.part.state = 'Released'
+    return { data_source_id: 'plm-ds', available: true, entitled: true, context: locked }
+  }
+
+  it('CTA hidden on a locked part when the capability pre-gate is OFF (prop absent)', async () => {
+    getContextMock.mockResolvedValue(lockedContextResult())
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+    expect(container.querySelector('[data-testid="plm-bom-review-locked-hint"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="plm-bom-review-eco-intent"]')).toBeNull()
+  })
+
+  it('CTA shown at the advisory-locked banner when the capability pre-gate is ON', async () => {
+    getContextMock.mockResolvedValue(lockedContextResult())
+    mountPanel('plm-ds', { ecoIntentEnabled: true })
+    await flushUi()
+    await setPartAndLoad('P1')
+    expect(container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]')).not.toBeNull()
+  })
+
+  it('CTA surfaces REACTIVELY after a write-back lifecycle_locked 409 (advisory gate missed the lock)', async () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'submit-key-1' })
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
+    updateLineMock.mockResolvedValue({ ok: false, status: 409, reason: 'lifecycle_locked', message: 'locked' })
+    mountPanel('plm-ds', { ecoIntentEnabled: true })
+    await flushUi()
+    await setPartAndLoad('P1')
+    // root is Draft -> no CTA up front
+    expect(container.querySelector('[data-testid="plm-bom-review-eco-intent"]')).toBeNull()
+
+    const refdes = container.querySelector('[data-testid="plm-bom-review-refdes-input"]') as HTMLInputElement
+    refdes.value = 'R9'
+    refdes.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]')).not.toBeNull()
+  })
+
+  it('create outcome: done message carries the new ECO id and the button disables', async () => {
+    getContextMock.mockResolvedValue(lockedContextResult())
+    ecoIntentMock.mockResolvedValue({ ok: true, eco_id: 'ECO-77', state: 'progress', attached: false })
+    mountPanel('plm-ds', { ecoIntentEnabled: true })
+    await flushUi()
+    await setPartAndLoad('P1')
+    ;(container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(ecoIntentMock).toHaveBeenCalledWith('plm-ds', 'P1')
+    const msg = container.querySelector('[data-testid="plm-bom-review-eco-intent-message"]')
+    expect(msg?.textContent).toContain('ECO-77')
+    expect(msg?.textContent).toContain('已发起 ECO 修订')
+    expect((container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('attach outcome: message names the EXISTING open ECO (anti-sprawl surfaced honestly)', async () => {
+    getContextMock.mockResolvedValue(lockedContextResult())
+    ecoIntentMock.mockResolvedValue({ ok: true, eco_id: 'ECO-OLD', state: 'draft', attached: true })
+    mountPanel('plm-ds', { ecoIntentEnabled: true })
+    await flushUi()
+    await setPartAndLoad('P1')
+    ;(container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const msg = container.querySelector('[data-testid="plm-bom-review-eco-intent-message"]')
+    expect(msg?.textContent).toContain('ECO-OLD')
+    expect(msg?.textContent).toContain('已挂接')
+  })
+
+  it('not_locked outcome: resets the reactive lock, hides the button, KEEPS the explanation visible', async () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'submit-key-1' })
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: cloneContext() })
+    updateLineMock.mockResolvedValue({ ok: false, status: 409, reason: 'lifecycle_locked', message: 'locked' })
+    ecoIntentMock.mockResolvedValue({ ok: false, status: 409, reason: 'not_locked', message: 'editable' })
+    mountPanel('plm-ds', { ecoIntentEnabled: true })
+    await flushUi()
+    await setPartAndLoad('P1')
+    const refdes = container.querySelector('[data-testid="plm-bom-review-refdes-input"]') as HTMLInputElement
+    refdes.value = 'R9'
+    refdes.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="plm-bom-review-save"]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]')).toBeNull()
+    const msg = container.querySelector('[data-testid="plm-bom-review-eco-intent-message"]')
+    expect(msg?.textContent).toContain('未处于锁定状态')
+  })
+
+  it('eco_intent_rejected outcome: retry-able message, button back to idle', async () => {
+    getContextMock.mockResolvedValue(lockedContextResult())
+    ecoIntentMock.mockResolvedValue({ ok: false, status: 409, reason: 'eco_intent_rejected', message: 'race' })
+    mountPanel('plm-ds', { ecoIntentEnabled: true })
+    await flushUi()
+    await setPartAndLoad('P1')
+    ;(container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="plm-bom-review-eco-intent-message"]')?.textContent).toContain('被拒')
+    expect((container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('a fresh load resets the CTA state machine (message + done state cleared)', async () => {
+    getContextMock.mockResolvedValue(lockedContextResult())
+    ecoIntentMock.mockResolvedValue({ ok: true, eco_id: 'ECO-77', state: 'progress', attached: false })
+    mountPanel('plm-ds', { ecoIntentEnabled: true })
+    await flushUi()
+    await setPartAndLoad('P1')
+    ;(container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(container.querySelector('[data-testid="plm-bom-review-eco-intent-message"]')).not.toBeNull()
+
+    await setPartAndLoad('P1')
+    expect(container.querySelector('[data-testid="plm-bom-review-eco-intent-message"]')).toBeNull()
+    expect((container.querySelector('[data-testid="plm-bom-review-eco-intent-cta"]') as HTMLButtonElement).disabled).toBe(false)
   })
 })

--- a/apps/web/tests/plm-bom-review-service.spec.ts
+++ b/apps/web/tests/plm-bom-review-service.spec.ts
@@ -116,3 +116,60 @@ describe('updatePlmBomMultitableLine (Phase 7 consumer write-back service)', () 
     expect(apiFetchMock).not.toHaveBeenCalled()
   })
 })
+
+describe('requestPlmBomEcoRevisionIntent (ECO Phase 3 consumer service)', () => {
+  beforeEach(() => apiFetchMock.mockReset())
+
+  it('does not fetch when dataSourceId or partId is empty', async () => {
+    const { requestPlmBomEcoRevisionIntent } = await import('../src/services/integration/workbench')
+    const r = await requestPlmBomEcoRevisionIntent('ds-1', '  ')
+    expect(r).toEqual({ ok: false, status: 400, reason: 'invalid-request', message: 'ECO revision request is incomplete' })
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('POSTs the intent relay with suppressUnauthorizedRedirect and NO body', async () => {
+    const { requestPlmBomEcoRevisionIntent } = await import('../src/services/integration/workbench')
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ eco_id: 'ECO-1', state: 'progress', attached: false }))
+    const r = await requestPlmBomEcoRevisionIntent('ds-1', 'P1')
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/plm-workbench/data-sources/ds-1/bom-multitable/P1/eco-intent',
+      { method: 'POST', suppressUnauthorizedRedirect: true },
+    )
+    expect(r).toEqual({ ok: true, eco_id: 'ECO-1', state: 'progress', attached: false })
+  })
+
+  it('relays the attach outcome (attached: true)', async () => {
+    const { requestPlmBomEcoRevisionIntent } = await import('../src/services/integration/workbench')
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ eco_id: 'ECO-OLD', state: 'draft', attached: true }))
+    const r = await requestPlmBomEcoRevisionIntent('ds-1', 'P1')
+    expect(r).toEqual({ ok: true, eco_id: 'ECO-OLD', state: 'draft', attached: true })
+  })
+
+  it('surfaces the relayed reason on a non-ok status (not_locked)', async () => {
+    const { requestPlmBomEcoRevisionIntent } = await import('../src/services/integration/workbench')
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ error: 'conflict', reason: 'not_locked' }, 409))
+    const r = await requestPlmBomEcoRevisionIntent('ds-1', 'P1')
+    expect(r).toEqual({ ok: false, status: 409, reason: 'not_locked', message: 'conflict' })
+  })
+
+  it('falls back to intent-failed when the error body carries no reason', async () => {
+    const { requestPlmBomEcoRevisionIntent } = await import('../src/services/integration/workbench')
+    apiFetchMock.mockResolvedValue(new Response('oops', { status: 503 }))
+    const r = await requestPlmBomEcoRevisionIntent('ds-1', 'P1')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.status).toBe(503)
+      expect(r.reason).toBe('intent-failed')
+    }
+  })
+
+  it('502 malformed-response when a 200 body lacks the contract keys', async () => {
+    const { requestPlmBomEcoRevisionIntent } = await import('../src/services/integration/workbench')
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ eco_id: 'ECO-1' }))
+    const r = await requestPlmBomEcoRevisionIntent('ds-1', 'P1')
+    expect(r).toEqual({
+      ok: false, status: 502, reason: 'malformed-response',
+      message: 'ECO revision intent returned a malformed response',
+    })
+  })
+})

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -752,6 +752,19 @@ export interface BomMultitableLineUpdateOptions {
   ifMatch?: string;
 }
 
+// ECO Phase 3: response of the provider's locked-BOM revision-intent seam
+// (POST /api/v1/bom/multitable/{part_id}/eco-intent). `attached: true` means an already-open
+// bom-ECO for this part was reused (the provider's attach-before-create anti-sprawl — that is
+// also the idempotency story: a double-click attaches instead of spawning a second ECO, so the
+// request deliberately carries NO Idempotency-Key header and NO body).
+export interface BomEcoRevisionIntentResult {
+  eco_id: string;
+  state: string;
+  attached: boolean;
+  source_version_id?: string | null;
+  target_version_id?: string | null;
+}
+
 // Field guard for the governed BOM multi-table context. Validates EVERY field declared on
 // BomMultitableLine / BomMultitablePart / BomMultitableContext — both the structural keys
 // (bom_line_id, part_id, level, path, ...) AND the displayed cells (item_number, name, state,
@@ -1215,6 +1228,18 @@ export class PLMAdapter extends HTTPAdapter {
               entitled: true,
               cache_scope: { supported: 'global', entitled: 'tenant' },
               scenarios: ['bom_review'],
+            },
+            // ECO Phase 3: mock the lit bom_eco_revision SKU so mock-mode dev can exercise the
+            // locked-BOM "发起 ECO 修订" CTA end to end (the CTA pre-gates on this descriptor,
+            // per Phase-0 Lock 3: availability discovery is the capabilities advisory).
+            bom_eco_revision: {
+              supported: true,
+              api_version: 'v1',
+              entitled: true,
+              cache_scope: { supported: 'global', entitled: 'tenant' },
+              scenarios: ['bom_review'],
+              actions: ['eco_revision_intent'],
+              action_status: 'governed',
             },
           },
         },
@@ -2265,6 +2290,36 @@ export class PLMAdapter extends HTTPAdapter {
       method: 'PATCH',
       data: payload,
       headers,
+    })
+  }
+
+  // ECO Phase 3 consumer callsite: opt-in that opens (or attaches to) a PENDING ECO revision
+  // for a lifecycle-LOCKED part — the door the Phase-0 discriminated 409 (`eco_required: true`)
+  // points at. Provider contract (POST /api/v1/bom/multitable/{part_id}/eco-intent, no body):
+  // 200 {eco_id, state, attached, source_version_id, target_version_id};
+  // 409 {detail:{code: 'not_locked' | 'eco_intent_rejected', message}}; entitlement-first 403.
+  // Idempotency = the provider's attach-before-create (at most ONE open intent per part), so no
+  // Idempotency-Key header is minted here (mirrors the provider docstring, NOT the write PATCH).
+  async requestBomEcoRevisionIntent(partId: string): Promise<QueryResult<BomEcoRevisionIntentResult>> {
+    if (this.mockMode) {
+      return {
+        data: [
+          {
+            eco_id: `mock-eco-${partId}`,
+            state: 'progress',
+            attached: false,
+            source_version_id: 'mock-v1',
+            target_version_id: 'mock-v2',
+          },
+        ],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('BOM ECO revision intent is not supported for this PLM API mode') }
+    }
+    return this.select<BomEcoRevisionIntentResult>(`/api/v1/bom/multitable/${partId}/eco-intent`, {
+      method: 'POST',
     })
   }
 

--- a/packages/core-backend/src/routes/plm-workbench.ts
+++ b/packages/core-backend/src/routes/plm-workbench.ts
@@ -32,6 +32,7 @@ import type {
   BomMultitableContextResult,
   BomMultitableLinePatch,
   BomMultitableLineUpdateResult,
+  BomEcoRevisionIntentResult,
 } from '../data-adapters/PLMAdapter'
 
 // Typed wrapper for temporary tables not yet in main Database interface
@@ -822,6 +823,52 @@ function isPlmBomWritebackAdapter(adapter: unknown): adapter is PlmBomWritebackA
   )
 }
 
+// ECO Phase 3: the locked-BOM revision-intent seam (attach-or-create a PENDING bom-ECO).
+interface PlmBomEcoIntentAdapter extends PlmBomReviewAdapter {
+  requestBomEcoRevisionIntent(
+    partId: string,
+  ): Promise<{ data?: BomEcoRevisionIntentResult[]; error?: Error }>
+}
+
+function isPlmBomEcoIntentAdapter(adapter: unknown): adapter is PlmBomEcoIntentAdapter {
+  const candidate = adapter as PlmBomEcoIntentAdapter | null
+  return (
+    isPlmBomReviewAdapter(adapter)
+    && typeof candidate?.requestBomEcoRevisionIntent === 'function'
+  )
+}
+
+// The intent endpoint's own discriminated-409 namespace (distinct from the write PATCH's
+// lifecycle_locked/idempotency_conflict): `not_locked` = the part is editable, use the direct
+// edit path; `eco_intent_rejected` = the provider declined (concurrent open ECO race /
+// non-versionable part). Unknown/absent code degrades to 'provider-rejected' (fail-closed,
+// same idiom as providerConflictReasonCode).
+const PROVIDER_ECO_INTENT_409_CODES = new Set(['not_locked', 'eco_intent_rejected'])
+
+function providerEcoIntentConflictCode(error: unknown): string | null {
+  const candidate = error as { response?: { data?: unknown } } | null
+  const data = candidate?.response?.data
+  if (!data || typeof data !== 'object') return null
+  const detail = (data as { detail?: unknown }).detail
+  if (!detail || typeof detail !== 'object') return null
+  const code = (detail as { code?: unknown }).code
+  return typeof code === 'string' && PROVIDER_ECO_INTENT_409_CODES.has(code) ? code : null
+}
+
+function relayProviderEcoIntentError(error: unknown): { status: number; reason: string } {
+  const status = providerErrorStatus(error)
+  // 409 = discriminated by the intent endpoint's own namespace: `not_locked` (editable part —
+  // use the direct edit path) vs `eco_intent_rejected` (provider declined). Unknown/absent code
+  // degrades to the legacy flattened reason (same fail-closed rule as the write PATCH).
+  if (status === 409) {
+    return { status: 409, reason: providerEcoIntentConflictCode(error) ?? 'provider-rejected' }
+  }
+  if (status && [400, 403, 404, 422].includes(status)) {
+    return { status, reason: 'provider-rejected' }
+  }
+  return { status: 502, reason: 'provider-unavailable' }
+}
+
 function normalizeBomLineWritebackPatch(value: unknown): BomMultitableLinePatch | null {
   const record = value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -1049,6 +1096,97 @@ router.patch(
     if (!payload || payload.ok !== true || typeof payload.bom_line_id !== 'string') {
       return res.status(502).json({
         error: 'BOM write-back returned a malformed response',
+        data_source_id: dataSourceId,
+        reason: 'malformed-response',
+      })
+    }
+    return res.json(payload)
+  },
+)
+
+// ECO Phase 3 consumer CTA relay: opt-in that opens/attaches a PENDING ECO revision for a
+// lifecycle-LOCKED part. Pre-gates on the capabilities advisory descriptor `bom_eco_revision`
+// (supported + entitled + actions includes `eco_revision_intent` — Phase-0 Lock 3: availability
+// discovery is the advisory, never the error payload). Provider owns idempotency
+// (attach-before-create), so no Idempotency-Key here. Never a raw 500.
+router.post(
+  '/api/plm-workbench/data-sources/:id/bom-multitable/:partId/eco-intent',
+  authenticate,
+  param('id').isString(),
+  param('partId').isString(),
+  validate,
+  async (req: Request, res: Response) => {
+    const dataSourceId = req.params.id
+    const partId = req.params.partId
+    let adapter: unknown
+    try {
+      adapter = getDataSourceManager().getDataSource(dataSourceId)
+    } catch {
+      return res
+        .status(404)
+        .json({ error: 'Data source not found', data_source_id: dataSourceId })
+    }
+    if (!isPlmBomEcoIntentAdapter(adapter)) {
+      return res.status(404).json({
+        error: 'BOM ECO revision intent is not supported for this data source',
+        data_source_id: dataSourceId,
+      })
+    }
+
+    let capabilities: IntegrationCapabilitiesResult
+    try {
+      capabilities = await adapter.getIntegrationCapabilities()
+    } catch {
+      return res.status(503).json({
+        error: 'PLM capabilities unavailable',
+        data_source_id: dataSourceId,
+        reason: 'unavailable',
+      })
+    }
+    const feature = capabilities.available ? capabilities.manifest.features.bom_eco_revision : undefined
+    if (!feature || feature.supported !== true) {
+      return res.status(404).json({
+        error: 'BOM ECO revision is not supported',
+        data_source_id: dataSourceId,
+        reason: 'unsupported',
+      })
+    }
+    if (feature.entitled !== true) {
+      return res.status(403).json({
+        error: 'BOM ECO revision is not entitled',
+        data_source_id: dataSourceId,
+        reason: 'not-entitled',
+      })
+    }
+    // Advisory action pre-gate: the descriptor must actually advertise the intent action
+    // (a provider that lights the SKU but withdraws the action must hide the CTA path).
+    const actions = Array.isArray(feature.actions) ? feature.actions : []
+    if (!actions.includes('eco_revision_intent')) {
+      return res.status(404).json({
+        error: 'ECO revision intent action is not advertised',
+        data_source_id: dataSourceId,
+        reason: 'unsupported',
+      })
+    }
+
+    const result = await adapter.requestBomEcoRevisionIntent(partId)
+    if (result.error) {
+      const relayed = relayProviderEcoIntentError(result.error)
+      return res.status(relayed.status).json({
+        error: result.error.message || 'ECO revision intent failed',
+        data_source_id: dataSourceId,
+        reason: relayed.reason,
+      })
+    }
+    const payload = result.data?.[0]
+    if (
+      !payload
+      || typeof payload.eco_id !== 'string'
+      || typeof payload.state !== 'string'
+      || typeof payload.attached !== 'boolean'
+    ) {
+      return res.status(502).json({
+        error: 'ECO revision intent returned a malformed response',
         data_source_id: dataSourceId,
         reason: 'malformed-response',
       })

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3904,6 +3904,58 @@
       }
     },
     {
+      "description": "request an ECO revision intent for a lifecycle-locked part (attach-before-create)",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_eco_revision license and part 01H000000000000000000000L1 is lifecycle-locked in state 'Released' with no open bom-ECO"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000L1/eco-intent",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "eco_id": "01H000000000000000000000E9",
+          "state": "progress",
+          "attached": false
+        },
+        "matchingRules": {
+          "body": {
+            "$.eco_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.attached": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "mint a MetaSheet BOM review embed token for the Yuantus parent host",
       "providerStates": [
         {
@@ -4155,6 +4207,45 @@
           "detail": {
             "code": "idempotency_conflict",
             "message": "Idempotency-Key reused for a different write"
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.detail.message": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "attempt an ECO revision intent for a part that is NOT lifecycle-locked",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_eco_revision license and part 01H000000000000000000000L2 is editable (Draft)"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000L2/eco-intent",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1"
+        }
+      },
+      "response": {
+        "status": 409,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "detail": {
+            "code": "not_locked",
+            "message": "Part is not lifecycle-locked (state 'Draft'); use the direct edit path"
           }
         },
         "matchingRules": {

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -118,10 +118,14 @@ const PLM_ADAPTER_PACT_PATHS = [
   { method: 'GET', path: '/api/v1/bom/multitable/01H000000000000000000000P1/context' },
   // PLM-COLLAB P3 (方案1) governed BOM multitable write-back: re-added in its AMENDED form now that
   // the Yuantus provider (#905) honors a GOVERNED, Idempotency-Key-gated write-back (entitlement
-  // plm.bom_multitable_writeback). It MUST sit at the END of the adapter-owned list — immediately
-  // before the V1.2 parent-host embed-token — so the concatenated PACT_PATHS order matches the
-  // corresponding placement of the interaction in the pact JSON. PLMAdapter.ts owns the callsite.
+  // plm.bom_multitable_writeback). PLMAdapter.ts owns the callsite.
   { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000W1/lines/01H000000000000000000000W3' },
+  // ECO Phase 3 (Yuantus provider #973): the locked-BOM revision-intent seam the Phase-0
+  // discriminated 409 (eco_required) points at. POST with NO body and NO Idempotency-Key —
+  // idempotency is the provider's attach-before-create (at most one open intent per part).
+  // It MUST sit at the END of the adapter-owned list — immediately before the V1.2 parent-host
+  // embed-token — so the concatenated PACT_PATHS order matches the pact JSON placement.
+  { method: 'POST', path: '/api/v1/bom/multitable/01H000000000000000000000L1/eco-intent' },
 ] as const
 
 const PARENT_HOST_PACT_PATHS = [
@@ -140,6 +144,11 @@ const ERROR_CONTRACT_PACT_PATHS = [
   // write-back — no new consumer callsite.
   { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000W4/lines/01H000000000000000000000W6' },
   { method: 'PATCH', path: '/api/v1/bom/multitable/01H000000000000000000000W7/lines/01H000000000000000000000W9' },
+  // ECO Phase 3: the intent seam's own discriminated 409 namespace, pinned via its most
+  // consumer-branched code — not_locked (the CTA resets to the direct-edit path on it). The
+  // sibling code eco_intent_rejected shares the same envelope and stays consumer-tested only
+  // (its recovery is a generic retry; pinning one code freezes the namespace shape).
+  { method: 'POST', path: '/api/v1/bom/multitable/01H000000000000000000000L2/eco-intent' },
 ] as const
 
 const PACT_PATHS = [
@@ -221,6 +230,7 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       '/api/v1/integrations/capabilities',
       '/api/v1/bom/multitable/${partId}/context',
       '/api/v1/bom/multitable/${partId}/lines/${bomLineId}',
+      '/api/v1/bom/multitable/${partId}/eco-intent',
     ]
     for (const ep of endpointsToFind) {
       expect(
@@ -287,6 +297,42 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       ok: true,
       bom_line_id: '01H000000000000000000000W3',
     })
+  })
+
+  // ECO Phase 3 (Yuantus provider #973): the locked-BOM revision-intent seam.
+  it('ECO Phase 3: the eco-intent contract is body-less, key-less, entitlement-stated, minimal-enveloped', () => {
+    const pact = loadPact()
+    const success = pact.interactions.find(
+      i => i.request.method === 'POST' && i.request.path === '/api/v1/bom/multitable/01H000000000000000000000L1/eco-intent',
+    )
+    expect(success).toBeDefined()
+
+    // provider state names the intent entitlement + the locked precondition
+    expect(success!.providerStates![0].name).toContain('plm.bom_eco_revision')
+    expect(success!.providerStates![0].name).toContain('lifecycle-locked')
+
+    // NO body, NO Idempotency-Key (provider attach-before-create owns idempotency), NO Content-Type
+    expect(success!.request.body).toBeUndefined()
+    const headers = (success!.request.headers ?? {}) as Record<string, string>
+    expect(Object.keys(headers)).not.toContain('Idempotency-Key')
+    expect(Object.keys(headers)).not.toContain('Content-Type')
+
+    // minimal success envelope: the three consumer-branched keys only (source/target_version_id
+    // stay provider-additive, deliberately unpinned)
+    expect(success!.response.status).toBe(200)
+    expect(Object.keys(success!.response.body as Record<string, unknown>).sort()).toEqual([
+      'attached', 'eco_id', 'state',
+    ])
+
+    // the intent seam's own 409 namespace: not_locked pinned as a dedicated error fixture,
+    // discriminated by detail.code alone (exact value, message type-matched)
+    const notLocked = pact.interactions.find(
+      i => i.request.method === 'POST' && i.request.path === '/api/v1/bom/multitable/01H000000000000000000000L2/eco-intent',
+    )
+    expect(notLocked).toBeDefined()
+    expect(notLocked!.response.status).toBe(409)
+    const detail = (notLocked!.response.body as { detail: Record<string, unknown> }).detail
+    expect(detail.code).toBe('not_locked')
   })
 
   // ECO Phase 0: the discriminated-409 error contract (Yuantus provider #968 taskbook + #969 impl).

--- a/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
@@ -319,3 +319,67 @@ describe('PLMAdapter.updateBomMultitableLine (PLM-COLLAB P3 — thin success-onl
     expect(select).not.toHaveBeenCalled()
   })
 })
+
+describe('PLMAdapter.requestBomEcoRevisionIntent (ECO Phase 3)', () => {
+  it('yuantus: POSTs the eco-intent endpoint with NO body and NO Idempotency-Key (provider owns idempotency)', async () => {
+    const adapter = createAdapter('yuantus')
+    const select = vi.fn().mockResolvedValue({
+      data: [{ eco_id: 'ECO-9', state: 'progress', attached: false, source_version_id: 'v1', target_version_id: 'v2' }],
+    })
+    ;(adapter as never as { select: unknown }).select = select
+
+    const result = await adapter.requestBomEcoRevisionIntent('P1')
+
+    expect(select).toHaveBeenCalledWith('/api/v1/bom/multitable/P1/eco-intent', { method: 'POST' })
+    // structural: no data payload, no headers key at all -> no Idempotency-Key can ride along
+    const options = select.mock.calls[0][1] as Record<string, unknown>
+    expect('data' in options).toBe(false)
+    expect('headers' in options).toBe(false)
+    expect(result.data?.[0]?.eco_id).toBe('ECO-9')
+    expect(result.data?.[0]?.attached).toBe(false)
+  })
+
+  it('yuantus: relays the attach outcome (attached: true) untouched', async () => {
+    const adapter = createAdapter('yuantus')
+    ;(adapter as never as { select: unknown }).select = vi.fn().mockResolvedValue({
+      data: [{ eco_id: 'ECO-EXISTING', state: 'draft', attached: true }],
+    })
+    const result = await adapter.requestBomEcoRevisionIntent('P1')
+    expect(result.data?.[0]).toEqual({ eco_id: 'ECO-EXISTING', state: 'draft', attached: true })
+  })
+
+  it('mock mode: canned success WITHOUT a request', async () => {
+    const adapter = createAdapter('mock')
+    const select = vi.fn()
+    ;(adapter as never as { select: unknown }).select = select
+
+    const result = await adapter.requestBomEcoRevisionIntent('P7')
+
+    expect(select).not.toHaveBeenCalled()
+    expect(result.data?.[0]?.eco_id).toBe('mock-eco-P7')
+    expect(result.data?.[0]?.attached).toBe(false)
+  })
+
+  it('mock manifest advertises bom_eco_revision with the eco_revision_intent action (CTA pre-gate demoable)', async () => {
+    const adapter = createAdapter('mock')
+    const capabilities = await adapter.getIntegrationCapabilities()
+    expect(capabilities.available).toBe(true)
+    if (!capabilities.available) return
+    const feature = capabilities.manifest.features.bom_eco_revision as Record<string, unknown>
+    expect(feature.supported).toBe(true)
+    expect(feature.entitled).toBe(true)
+    expect(feature.actions).toEqual(['eco_revision_intent'])
+  })
+
+  it('legacy mode: unsupported affordance WITHOUT a request', async () => {
+    const adapter = createAdapter('legacy')
+    const select = vi.fn()
+    ;(adapter as never as { select: unknown }).select = select
+
+    const result = await adapter.requestBomEcoRevisionIntent('P1')
+
+    expect(result.data).toEqual([])
+    expect(result.error).toBeInstanceOf(Error)
+    expect(select).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
@@ -432,3 +432,182 @@ describe('plm-workbench BOM multi-table review route (PLM-COLLAB P3-C)', () => {
     expect(res.body.reason).toBe('precondition-failed')
   })
 })
+
+// ── ECO Phase 3: locked-BOM revision-intent relay ────────────────────────────────────────────
+const INTENT_URL = '/api/plm-workbench/data-sources/ds-1/bom-multitable/P1/eco-intent'
+
+const BOM_ENTITLED = { supported: true, api_version: 'v1', entitled: true }
+const ECO_INTENT_FEATURE = {
+  supported: true,
+  api_version: 'v1',
+  entitled: true,
+  actions: ['eco_revision_intent'],
+  action_status: 'governed',
+}
+
+function intentAdapter(overrides: Record<string, unknown> = {}) {
+  return {
+    getIntegrationCapabilities: vi.fn().mockResolvedValue({
+      available: true,
+      manifest: manifest(BOM_ENTITLED, { bom_eco_revision: ECO_INTENT_FEATURE }),
+    }),
+    getBomMultitableContext: vi.fn(),
+    requestBomEcoRevisionIntent: vi.fn().mockResolvedValue({
+      data: [{ eco_id: 'ECO-1', state: 'progress', attached: false, source_version_id: 'v1', target_version_id: 'v2' }],
+    }),
+    ...overrides,
+  }
+}
+
+describe('plm-workbench BOM ECO revision-intent relay (ECO Phase 3)', () => {
+  const app = express()
+  app.use(express.json())
+  app.use(plmWorkbenchRouter)
+
+  beforeEach(() => {
+    dsMocks.getDataSource.mockReset()
+  })
+
+  it('404 when the data source does not exist', async () => {
+    dsMocks.getDataSource.mockImplementation(() => { throw new Error('nope') })
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(404)
+  })
+
+  it('404 for an adapter lacking requestBomEcoRevisionIntent (duck-type, no capability call)', async () => {
+    const getIntegrationCapabilities = vi.fn()
+    dsMocks.getDataSource.mockReturnValue({ getIntegrationCapabilities, getBomMultitableContext: vi.fn() })
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(404)
+    expect(getIntegrationCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('503 unavailable (never 500) when the capability call throws; intent never called', async () => {
+    const requestBomEcoRevisionIntent = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      getIntegrationCapabilities: vi.fn().mockRejectedValue(new Error('boom')),
+      requestBomEcoRevisionIntent,
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(503)
+    expect(res.body.reason).toBe('unavailable')
+    expect(requestBomEcoRevisionIntent).not.toHaveBeenCalled()
+  })
+
+  it('404 unsupported when bom_eco_revision is absent from the manifest; intent never called', async () => {
+    const requestBomEcoRevisionIntent = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({ available: true, manifest: manifest(BOM_ENTITLED) }),
+      requestBomEcoRevisionIntent,
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(404)
+    expect(res.body.reason).toBe('unsupported')
+    expect(requestBomEcoRevisionIntent).not.toHaveBeenCalled()
+  })
+
+  it('403 not-entitled when supported but unentitled; intent never called', async () => {
+    const requestBomEcoRevisionIntent = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(BOM_ENTITLED, { bom_eco_revision: { ...ECO_INTENT_FEATURE, entitled: false } }),
+      }),
+      requestBomEcoRevisionIntent,
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(403)
+    expect(res.body.reason).toBe('not-entitled')
+    expect(requestBomEcoRevisionIntent).not.toHaveBeenCalled()
+  })
+
+  it('404 unsupported when the descriptor omits the eco_revision_intent action; intent never called', async () => {
+    const requestBomEcoRevisionIntent = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest(BOM_ENTITLED, { bom_eco_revision: { ...ECO_INTENT_FEATURE, actions: [] } }),
+      }),
+      requestBomEcoRevisionIntent,
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(404)
+    expect(res.body.reason).toBe('unsupported')
+    expect(requestBomEcoRevisionIntent).not.toHaveBeenCalled()
+  })
+
+  it('relays the provider success envelope (eco_id/state/attached) verbatim', async () => {
+    const adapter = intentAdapter()
+    dsMocks.getDataSource.mockReturnValue(adapter)
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      eco_id: 'ECO-1', state: 'progress', attached: false, source_version_id: 'v1', target_version_id: 'v2',
+    })
+    expect(adapter.requestBomEcoRevisionIntent).toHaveBeenCalledWith('P1')
+  })
+
+  it('surfaces the discriminated not_locked 409 reason', async () => {
+    const notLocked = Object.assign(new Error('409'), {
+      response: { status: 409, data: { detail: { code: 'not_locked', message: 'editable' } } },
+    })
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      requestBomEcoRevisionIntent: vi.fn().mockResolvedValue({ data: [], error: notLocked }),
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(409)
+    expect(res.body.reason).toBe('not_locked')
+  })
+
+  it('surfaces the discriminated eco_intent_rejected 409 reason', async () => {
+    const rejected = Object.assign(new Error('409'), {
+      response: { status: 409, data: { detail: { code: 'eco_intent_rejected', message: 'race' } } },
+    })
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      requestBomEcoRevisionIntent: vi.fn().mockResolvedValue({ data: [], error: rejected }),
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(409)
+    expect(res.body.reason).toBe('eco_intent_rejected')
+  })
+
+  it('degrades an UNKNOWN 409 code to provider-rejected (fail-closed, never leaks raw)', async () => {
+    const weird = Object.assign(new Error('409'), {
+      response: { status: 409, data: { detail: { code: 'lifecycle_locked', message: 'wrong namespace' } } },
+    })
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      requestBomEcoRevisionIntent: vi.fn().mockResolvedValue({ data: [], error: weird }),
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(409)
+    expect(res.body.reason).toBe('provider-rejected')
+  })
+
+  it('passes through a provider 403 as provider-rejected (entitlement drift at the provider)', async () => {
+    const forbidden = Object.assign(new Error('403'), { response: { status: 403, data: { detail: 'nope' } } })
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      requestBomEcoRevisionIntent: vi.fn().mockResolvedValue({ data: [], error: forbidden }),
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(403)
+    expect(res.body.reason).toBe('provider-rejected')
+  })
+
+  it('502 provider-unavailable for a transport error with no response', async () => {
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      requestBomEcoRevisionIntent: vi.fn().mockResolvedValue({ data: [], error: new Error('ECONNREFUSED') }),
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(502)
+    expect(res.body.reason).toBe('provider-unavailable')
+  })
+
+  it('502 malformed-response when the provider payload lacks the contract keys', async () => {
+    dsMocks.getDataSource.mockReturnValue(intentAdapter({
+      requestBomEcoRevisionIntent: vi.fn().mockResolvedValue({ data: [{ eco_id: 'ECO-1' }] }),
+    }))
+    const res = await request(app).post(INTENT_URL)
+    expect(res.status).toBe(502)
+    expect(res.body.reason).toBe('malformed-response')
+  })
+})


### PR DESCRIPTION
## What

ECO Phase 3 of the locked-BOM ECO route (tracker-claimed; Yuantus provider seam shipped as #973 there): the BOM review panel can now **walk through the door the Phase-0 discriminated 409 points at** — a governed "发起 ECO 修订" CTA that opens/attaches a PENDING ECO for a lifecycle-locked part.

- **PLMAdapter.requestBomEcoRevisionIntent(partId)** — POST, **no body, no Idempotency-Key** (provider attach-before-create owns idempotency; a double-click attaches). Mock manifest advertises `bom_eco_revision` so mock mode demos the CTA.
- **New relay** `POST /api/plm-workbench/data-sources/:id/bom-multitable/:partId/eco-intent` — mirrors the write PATCH gate ladder + a NEW advisory **action** pre-gate (`actions` must include `eco_revision_intent`); relays the seam's own discriminated 409 namespace (`not_locked` | `eco_intent_rejected`, unknown → `provider-rejected`); never a raw 500.
- **Panel CTA at BOTH lock sites** — the advisory-locked banner AND the reactive write-back `lifecycle_locked` 409. Pre-gated by `ecoIntentEnabled` computed in the workbench view from the capabilities advisory (Phase-0 Lock 3: availability discovery is the advisory, never the error payload); the panel still never fetches capabilities. `not_locked` resets the reactive lock and keeps the explanation visible.
- **Pact: +2 interactions at the callsite** (Phase-1 taskbook L8 redeemed exactly here): body-less/key-less success (minimal envelope `eco_id/state/attached`) + a `not_locked` 409 fixture (freezes the namespace; `eco_intent_rejected` stays consumer-tested). Paths order + drift guard + assertions updated.

## Gates

Root type-check ✅ · lint ✅ · backend unit **4340 passed** (31 relay / 26 adapter) · web plm suites **21 panel / 16 service** ✅ · contract **22 passed** ✅. Full-web baseline failures (attendance/multitable-workbench/featureFlags) reproduce **identically without this diff** — pre-existing local-env, not introduced.

## Cross-repo order (load-bearing)

The Yuantus provider repo gets the byte-identical pact copy + the two provider states in its own PR, **merged first** — so when this merges to main and the consumer pact publishes, the provider broker gate already speaks the new states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)