### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaExportDialog cancel/confirm to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaExportDialog.vue
+++ b/apps/web/src/multitable/components/MetaExportDialog.vue
@@ -67,14 +67,15 @@
         </div>
 
         <div class="meta-export__actions">
-          <button class="meta-export__btn" @click="onCancel">{{ l('export.cancel') }}</button>
-          <button
+          <MtButton class="meta-export__btn" @click="onCancel">{{ l('export.cancel') }}</MtButton>
+          <MtButton
             class="meta-export__btn meta-export__btn--primary"
+            variant="primary"
             :disabled="!canExport"
             @click="onConfirm"
           >
             {{ l('export.confirm') }}
-          </button>
+          </MtButton>
         </div>
       </div>
     </div>
@@ -85,6 +86,7 @@
 import { computed, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import { metaCoreLabel, selectedCount, type MetaCoreLabelKey } from '../utils/meta-core-labels'
+import { MtButton } from '../ui'
 
 export interface ExportColumn {
   id: string
@@ -185,9 +187,4 @@ function onCancel() {
 .meta-export__hint { font-size: 13px; margin: 0; }
 .meta-export__hint--warn { color: #e6a23c; }
 .meta-export__actions { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid #ebedf0; }
-.meta-export__btn { background: #fff; border: 1px solid #dcdfe6; padding: 6px 14px; border-radius: 4px; cursor: pointer; font-size: 14px; }
-.meta-export__btn:hover:not(:disabled) { border-color: #c0c4cc; }
-.meta-export__btn:disabled { opacity: .55; cursor: not-allowed; }
-.meta-export__btn--primary { background: #409eff; color: #fff; border-color: #409eff; }
-.meta-export__btn--primary:hover:not(:disabled) { background: #66b1ff; border-color: #66b1ff; }
 </style>

--- a/apps/web/tests/meta-meta-export-dialog-migration.spec.ts
+++ b/apps/web/tests/meta-meta-export-dialog-migration.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaExportDialog from '../src/multitable/components/MetaExportDialog.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaExportDialog's two footer action controls (cancel / confirm) were migrated from
+// bespoke <button>s to the shared MtButton primitive (confirm = variant="primary"). Behavior-
+// preservation proof: they stay native, keyboard-operable <button>s; the `:disabled="!canExport"`
+// binding survives on confirm; and clicking them still emits the SAME `cancel` / `confirm` events
+// with the SAME payload. The dialog teleports to <body>, so queries hit `document`, not the mount
+// container. The close-× glyph and the select-all / clear-all link buttons stay bespoke (untouched).
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-export-overlay').length).toBe(0) // teleport residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaExportDialog, { ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+}
+
+const baseProps = () => ({
+  visible: true,
+  fields: [
+    { id: 'f1', name: 'Name' },
+    { id: 'f2', name: 'Age' },
+  ],
+  selectedRowCount: 0,
+})
+
+const actionBtns = () =>
+  Array.from(document.querySelectorAll('.meta-export__actions .meta-export__btn')) as HTMLElement[]
+const confirmBtn = () => document.querySelector('.meta-export__btn--primary') as HTMLButtonElement
+const cancelBtn = () =>
+  actionBtns().find((b) => !b.classList.contains('meta-export__btn--primary')) as HTMLButtonElement
+
+describe('MetaExportDialog — MtButton migration (UI-P2-1c)', () => {
+  it('renders cancel + confirm as native <button>s; confirm enabled while columns are checked', () => {
+    mount(baseProps())
+    const btns = actionBtns()
+    expect(btns.length).toBe(2)
+    expect(btns.every((b) => b.tagName === 'BUTTON')).toBe(true) // keyboard-operable, not bare divs
+    // On mount every column is checked → canExport true → confirm enabled.
+    expect(confirmBtn().disabled).toBe(false)
+  })
+
+  it('confirm becomes disabled when no columns are checked (:disabled="!canExport" survives)', async () => {
+    mount(baseProps())
+    // Uncheck both columns via the bespoke "clear all" link → canExport false.
+    const clearAll = Array.from(document.querySelectorAll('.meta-export__link'))
+      .find((b) => (b.textContent || '').toLowerCase().includes('clear')) as HTMLButtonElement
+    clearAll.click()
+    await nextTick()
+    expect(confirmBtn().disabled).toBe(true)
+  })
+
+  it('clicking cancel emits `cancel` (unchanged from pre-migration onCancel)', () => {
+    const onCancel = vi.fn()
+    mount(baseProps(), { onCancel })
+    cancelBtn().click()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking confirm emits `confirm` with the same payload (unchanged from pre-migration onConfirm)', () => {
+    const onConfirm = vi.fn()
+    mount({ ...baseProps(), initialFormat: 'csv' }, { onConfirm })
+    expect(confirmBtn().disabled).toBe(false)
+    confirmBtn().click()
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onConfirm).toHaveBeenCalledWith({ fieldIds: ['f1', 'f2'], rowScope: 'all', format: 'csv' })
+  })
+})


### PR DESCRIPTION
## What

UI-P2-1c presentation-only migration of **MetaExportDialog**'s two footer action buttons from bespoke `<button>`s to the shared `MtButton` primitive.

- **Cancel** → `MtButton` (default **ghost**).
- **Confirm** → `MtButton variant="primary"` (primary action).

## Behavior preservation (byte-identical)

- `@click="onCancel"` / `@click="onConfirm"` bindings unchanged.
- `:disabled="!canExport"` on Confirm unchanged.
- No `emit(...)` call-site or handler function touched (`git diff origin/main | grep emit\\(` empty).
- Original classes (`meta-export__btn`, `meta-export__btn--primary`) kept on the elements for selector stability.

## CSS

Removed the now-dead bespoke `.meta-export__btn*` rules (hardcoded hex `#fff` / `#dcdfe6` / `#409eff` / `#66b1ff`). No sibling control used those classes. No new hardcoded hex introduced — MtButton is styled by `--ms-*` tokens.

## Left bespoke (per classifier / standard)

- The close-× **glyph** button.
- The borderless select-all / clear-all **link** buttons.

## Appearance delta (sanctioned normalization, not drift)

Cancel moves from a bordered white secondary to a transparent ghost; Confirm's blue shifts from `#409eff` to `--ms-color-primary` (the token). Both follow the standard's mapping rules (primary action → `variant="primary"`, otherwise ghost).

## Tests

`apps/web/tests/meta-meta-export-dialog-migration.spec.ts` — real mount interaction test (Teleport → queries `document`, residue guard + unmount-all):
- Cancel + Confirm render as native `<button>`s; Confirm enabled while columns checked.
- Confirm becomes disabled after clear-all (`:disabled="!canExport"` survives).
- Clicking Cancel emits `cancel`; clicking Confirm emits `confirm` with the same payload — goes red if either `@click` were dropped.

## Verification

- `git diff origin/main` on emit lines: empty.
- No new hardcoded hex on added lines.
- `pnpm --filter @metasheet/web run type-check`: passes.
- `pnpm --filter @metasheet/web exec vitest run tests/meta-meta-export-dialog-migration.spec.ts`: 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)