### PR TITLE
feat(web): multitable UI P2-1c — migrate RestorePreviewDialog footer buttons to MtButton

### DIFF
--- a/apps/web/src/multitable/components/RestorePreviewDialog.vue
+++ b/apps/web/src/multitable/components/RestorePreviewDialog.vue
@@ -32,16 +32,16 @@
         </div>
 
         <div class="restore-preview__footer">
-          <button type="button" class="restore-preview__btn" @click="onCancel">{{ l('record.restorePreviewCancel') }}</button>
-          <button
-            type="button"
+          <MtButton class="restore-preview__btn" @click="onCancel">{{ l('record.restorePreviewCancel') }}</MtButton>
+          <MtButton
+            variant="primary"
             class="restore-preview__btn restore-preview__btn--primary"
             :disabled="!canConfirm"
             data-test="restore-preview-confirm"
             @click="onConfirm"
           >
             {{ l('record.restorePreviewExecute') }}
-          </button>
+          </MtButton>
         </div>
       </div>
     </div>
@@ -52,6 +52,7 @@
 import { computed } from 'vue'
 
 import type { RestorePreviewChange } from '../api/client'
+import { MtButton } from '../ui'
 import { recordLabel, type MetaRecordLabelKey } from '../utils/meta-record-labels'
 
 const props = defineProps<{
@@ -160,21 +161,5 @@ function onCancel(): void {
   gap: 8px;
   padding: 12px 16px;
   border-top: 1px solid var(--border, #e2e8f0);
-}
-.restore-preview__btn {
-  padding: 6px 14px;
-  border-radius: 6px;
-  border: 1px solid var(--border, #cbd5e1);
-  background: var(--surface, #fff);
-  cursor: pointer;
-}
-.restore-preview__btn--primary {
-  background: var(--primary, #2563eb);
-  color: #fff;
-  border-color: var(--primary, #2563eb);
-}
-.restore-preview__btn--primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 </style>

--- a/apps/web/tests/meta-restore-preview-dialog-migration.spec.ts
+++ b/apps/web/tests/meta-restore-preview-dialog-migration.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import RestorePreviewDialog from '../src/multitable/components/RestorePreviewDialog.vue'
+
+// UI-P2-1c: RestorePreviewDialog's two footer action controls (cancel / Execute-confirm) were
+// migrated from bespoke <button>s to the shared MtButton primitive (Execute = variant="primary").
+// Behavior-preservation proof: they stay native, keyboard-operable <button>s; the `:disabled` binding
+// on Execute survives; and clicking them still emits the SAME `cancel` / `confirm` events with no
+// change to payload. The dialog teleports to <body>, so queries hit `document`, not the mount
+// container. Locale comes from the `isZh` prop (not the useLocale composable), so no locale reset.
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.restore-preview-overlay').length).toBe(0) // teleport residue guard
+})
+
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(RestorePreviewDialog, { ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+}
+
+// canConfirm = !loading && executable && !schemaDrift && changes.length > 0 — this fixture makes the
+// Execute button enabled so the confirm click path is exercisable.
+const baseProps = () => ({
+  visible: true,
+  loading: false,
+  executable: true,
+  schemaDrift: false,
+  changes: [{ fieldId: 'f1', op: 'set', value: 'x' }],
+  fieldName: (id: string) => id,
+  isZh: false,
+})
+
+const cancelBtn = () =>
+  document.querySelector('.restore-preview__btn:not(.restore-preview__btn--primary)') as HTMLButtonElement
+const confirmBtn = () =>
+  document.querySelector('[data-test="restore-preview-confirm"]') as HTMLButtonElement
+
+describe('RestorePreviewDialog — MtButton migration (UI-P2-1c)', () => {
+  it('renders cancel + Execute as native <button>s', () => {
+    mount(baseProps())
+    expect(cancelBtn()).toBeTruthy()
+    expect(confirmBtn()).toBeTruthy()
+    expect(cancelBtn().tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+    expect(confirmBtn().tagName).toBe('BUTTON')
+  })
+
+  it('Execute is disabled when there is no executable change set (:disabled="!canConfirm" survives)', () => {
+    mount({ ...baseProps(), changes: [] }) // empty change set → canConfirm false
+    expect(confirmBtn().disabled).toBe(true)
+  })
+
+  it('clicking cancel emits `cancel` (unchanged from pre-migration onCancel)', () => {
+    const onCancel = vi.fn()
+    mount(baseProps(), { onCancel })
+    cancelBtn().click()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking Execute (enabled) emits `confirm` (unchanged from pre-migration onConfirm)', () => {
+    const onConfirm = vi.fn()
+    mount(baseProps(), { onConfirm })
+    expect(confirmBtn().disabled).toBe(false) // precondition driven enabled
+    confirmBtn().click()
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What

UI-P2-1c presentation-only migration of `RestorePreviewDialog.vue`'s two clean footer action buttons onto the shared `MtButton` primitive:

- **Cancel** (`.restore-preview__btn`, `@click=onCancel` emits `cancel`) → `MtButton` (default ghost)
- **Execute/confirm** (`.restore-preview__btn--primary`, `data-test=restore-preview-confirm`, `@click=onConfirm`, `:disabled=!canConfirm`) → `MtButton variant="primary"` (its bespoke bg was brand-blue `#2563eb`)

The header close-× glyph is left bespoke, per the migration standard.

## Behavior preservation (byte-identical)

- Every `@click` binding and the `:disabled="!canConfirm"` expression kept exactly as-is.
- `emit(...)` call-sites and the `onConfirm`/`onCancel` handlers untouched — `git diff origin/main` shows no `±` on any `emit(` line.
- Original `class` attributes retained for selector stability; `data-test` hook preserved.
- Dead bespoke button CSS removed (3 hardcoded-hex rules). No new hardcoded hex introduced (only `var(--ms-*)` via the primitive).

## Test

Adds `apps/web/tests/meta-restore-preview-dialog-migration.spec.ts` — a real mount interaction test (Teleport dialog → queries `document`, with an unmount-all + overlay-residue guard):

- Cancel + Execute render as native `<button>`s.
- Execute `:disabled` survives when there is no executable change set.
- Clicking Cancel emits `cancel`; clicking (enabled) Execute emits `confirm`.

The click→emit assertions were confirmed to go **red** when the `@click` is dropped (mutation-checked), so they are not vacuous.

## Verification

- `git diff origin/main` emit-line guard: empty
- new-hex guard: empty
- `pnpm --filter @metasheet/web run type-check`: passes
- `pnpm --filter @metasheet/web exec vitest run tests/meta-restore-preview-dialog-migration.spec.ts`: 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)