### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaPersonPicker footer buttons to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaPersonPicker.vue
+++ b/apps/web/src/multitable/components/MetaPersonPicker.vue
@@ -33,8 +33,8 @@
       <div class="meta-person-picker__footer">
         <span class="meta-person-picker__count">{{ selectedCountText }}</span>
         <div class="meta-person-picker__actions">
-          <button class="meta-person-picker__cancel" @click="emit('close')">{{ pp('personPicker.cancel') }}</button>
-          <button class="meta-person-picker__confirm" data-test="person-picker-confirm" @click="onConfirm">{{ pp('personPicker.confirm') }}</button>
+          <MtButton class="meta-person-picker__cancel" @click="emit('close')">{{ pp('personPicker.cancel') }}</MtButton>
+          <MtButton variant="primary" class="meta-person-picker__confirm" data-test="person-picker-confirm" @click="onConfirm">{{ pp('personPicker.confirm') }}</MtButton>
         </div>
       </div>
     </div>
@@ -44,6 +44,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
+import { MtButton } from '../ui'
 import type { MetaField, PersonSummary } from '../types'
 import { multitableClient } from '../api/client'
 import { isPersonSingleRecordField } from '../utils/person-fields'
@@ -203,7 +204,6 @@ function onConfirm() {
 .meta-person-picker__footer { display: flex; justify-content: space-between; align-items: center; padding: 10px 16px; border-top: 1px solid #eee; }
 .meta-person-picker__count { font-size: 12px; color: #666; }
 .meta-person-picker__actions { display: flex; gap: 8px; }
-.meta-person-picker__cancel { padding: 6px 12px; background: #fff; color: #606266; border: 1px solid #dcdfe6; border-radius: 4px; cursor: pointer; font-size: 13px; }
-.meta-person-picker__confirm { padding: 6px 18px; background: #409eff; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 13px; }
-.meta-person-picker__confirm:hover { background: #66b1ff; }
+/* .meta-person-picker__cancel / __confirm: the footer action controls are now <MtButton>
+   (token-styled; confirm = variant="primary"). Bespoke button rules removed in UI-P2-1c. */
 </style>

--- a/apps/web/tests/meta-meta-person-picker-migration.spec.ts
+++ b/apps/web/tests/meta-meta-person-picker-migration.spec.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaPersonPicker from '../src/multitable/components/MetaPersonPicker.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaPersonPicker's two footer action controls (cancel / confirm) were migrated from
+// bespoke <button>s to the shared MtButton primitive (confirm = variant="primary", matching the
+// #409eff filled-blue precedent landed for MetaBulkEditDialog in #3826). Behavior-preservation
+// proof: they stay native, keyboard-operable <button>s; clicking cancel still emits `close`; and
+// clicking confirm still emits `confirm` with the SAME { userIds, summaries } payload as the
+// pre-migration onConfirm. The `watch(() => props.visible, …)` is non-immediate, so mounting with
+// visible:true does NOT trigger loadMembers() — no directory API to stub, selection stays empty.
+// The dialog is an inline v-if overlay (not teleported), but we query `document` for robustness.
+// Left untouched per the classifier: the close-× glyph, chip-remove × glyphs, and the Clear button.
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-person-picker__overlay').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaPersonPicker, { ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+}
+
+const baseProps = () => ({ visible: true, sheetId: 's1' })
+const cancelBtn = () => document.querySelector('.meta-person-picker__cancel') as HTMLButtonElement
+const confirmBtn = () => document.querySelector('.meta-person-picker__confirm') as HTMLButtonElement
+
+describe('MetaPersonPicker — MtButton migration (UI-P2-1c)', () => {
+  it('renders cancel + confirm as native, enabled <button>s (keyboard-operable, not bare divs)', () => {
+    mount(baseProps())
+    expect(cancelBtn().tagName).toBe('BUTTON')
+    expect(confirmBtn().tagName).toBe('BUTTON')
+    // no :disabled binding on either footer control — both are active on initial mount
+    expect(cancelBtn().disabled).toBe(false)
+    expect(confirmBtn().disabled).toBe(false)
+    // data-test hook survives the migration (existing person-picker suite queries it)
+    expect(confirmBtn().getAttribute('data-test')).toBe('person-picker-confirm')
+  })
+
+  it('clicking cancel emits `close` (unchanged from pre-migration @click="emit(\'close\')")', () => {
+    const onClose = vi.fn()
+    mount(baseProps(), { onClose })
+    cancelBtn().click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking confirm emits `confirm` with the same { userIds, summaries } payload (onConfirm intact)', () => {
+    const onConfirm = vi.fn()
+    mount(baseProps(), { onConfirm })
+    confirmBtn().click()
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    // selection empty (loadMembers never ran) → onConfirm emits empty arrays, exactly as before
+    expect(onConfirm).toHaveBeenCalledWith({ userIds: [], summaries: [] })
+  })
+})


### PR DESCRIPTION
## What

UI-P2-1c presentation-only migration: MetaPersonPicker's two footer action controls move from bespoke `<button>`s to the shared **MtButton** primitive.

| Control | Before (bespoke) | After |
|---|---|---|
| Cancel (`.meta-person-picker__cancel`) | white bg / `#606266` text / border | `MtButton` default (ghost) |
| Confirm (`.meta-person-picker__confirm`) | `#409eff` filled / `#fff` text / `#66b1ff` hover | `MtButton variant="primary"` |

**Why confirm → `primary`:** its bespoke bg `#409eff` (Element-Plus filled blue) is the primary-action button, mapped to `variant="primary"` exactly per the landed precedent for MetaBulkEditDialog's identical `#409eff` apply button (**#3826**). `--ms-color-primary` (`#2563eb`) is the site-wide primary token the variant renders.

## Behavior preservation
- `@click="emit('close')"` and `@click="onConfirm"` kept **byte-identical** — no emit call-site or handler touched. (The emit-grep matches only the cancel `button`→`MtButton` rename; the `emit('close')` substring is identical on both sides.)
- Classes + `data-test="person-picker-confirm"` retained for selector stability (the existing `multitable-person-picker.spec.ts` still passes).
- Dead bespoke button CSS removed (incl. `#409eff` / `#66b1ff`); **no new hardcoded hex** introduced.
- Left untouched per classifier: the close-× glyph, chip-remove × glyphs, and the selection-gated Clear button.

## Test
`apps/web/tests/meta-meta-person-picker-migration.spec.ts` — mounts the dialog (mounts-array + afterEach unmount-all + `.meta-person-picker__overlay` residue guard), asserts both controls render native `<button>`s, and clicking them fires `close` / `confirm` with the same `{ userIds, summaries }` payload. Verified it goes **red** if the confirm `@click` is dropped.

## Checks
- `pnpm --filter @metasheet/web run type-check` ✅
- new spec + existing `multitable-person-picker.spec.ts` (8 tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)