### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaLinkPicker footer cancel/confirm to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaLinkPicker.vue
+++ b/apps/web/src/multitable/components/MetaLinkPicker.vue
@@ -35,8 +35,8 @@
       <div class="meta-link-picker__footer">
         <span class="meta-link-picker__count">{{ selectedCountText }}</span>
         <div class="meta-link-picker__actions">
-          <button class="meta-link-picker__cancel" @click="emit('close')">{{ lp('linkPicker.cancel') }}</button>
-          <button class="meta-link-picker__confirm" @click="onConfirm">{{ lp('linkPicker.confirm') }}</button>
+          <MtButton class="meta-link-picker__cancel" @click="emit('close')">{{ lp('linkPicker.cancel') }}</MtButton>
+          <MtButton variant="primary" class="meta-link-picker__confirm" @click="onConfirm">{{ lp('linkPicker.confirm') }}</MtButton>
         </div>
       </div>
     </div>
@@ -46,6 +46,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
+import { MtButton } from '../ui'
 import type { LinkedRecordSummary, MetaField } from '../types'
 import { multitableClient } from '../api/client'
 import { linkPickerSearchPlaceholder, linkPickerTitle } from '../utils/link-fields'
@@ -189,7 +190,4 @@ function onConfirm() {
 .meta-link-picker__footer { display: flex; justify-content: space-between; align-items: center; padding: 10px 16px; border-top: 1px solid #eee; }
 .meta-link-picker__count { font-size: 12px; color: #666; }
 .meta-link-picker__actions { display: flex; gap: 8px; }
-.meta-link-picker__cancel { padding: 6px 12px; background: #fff; color: #606266; border: 1px solid #dcdfe6; border-radius: 4px; cursor: pointer; font-size: 13px; }
-.meta-link-picker__confirm { padding: 6px 18px; background: #409eff; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 13px; }
-.meta-link-picker__confirm:hover { background: #66b1ff; }
 </style>

--- a/apps/web/tests/meta-meta-link-picker-migration.spec.ts
+++ b/apps/web/tests/meta-meta-link-picker-migration.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import MetaLinkPicker from '../src/multitable/components/MetaLinkPicker.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaLinkPicker's two footer action controls (cancel / confirm) were migrated from
+// bespoke <button>s to the shared MtButton primitive (confirm = variant="primary", the filled
+// blue action; cancel = default ghost). Behavior-preservation proof: both stay native,
+// keyboard-operable <button>s carrying their original selector classes; the cancel @click still
+// emits `close`; and clicking confirm still invokes onConfirm and emits `confirm` with the SAME
+// { recordIds, summaries } payload as before. This picker renders its own overlay inline (no
+// Teleport), but the residue guard still queries `document` for robustness.
+
+const { mockListLinkOptions } = vi.hoisted(() => ({ mockListLinkOptions: vi.fn() }))
+vi.mock('../src/multitable/api/client', () => ({
+  multitableClient: { listLinkOptions: mockListLinkOptions },
+}))
+
+const linkField = { id: 'fld_vendor', name: 'Vendor', type: 'link' }
+
+async function flushPromises() {
+  await Promise.resolve(); await nextTick(); await Promise.resolve(); await nextTick()
+}
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-link-picker__overlay').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+  mockListLinkOptions.mockReset()
+})
+
+// Reactive `visible` ref so flipping false->true fires the picker's watcher (which loads records);
+// the watcher is NOT `immediate`, so records only appear once we drive visible.
+function mount(extraProps: Record<string, unknown> = {}, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const visible = ref(false)
+  const Harness = defineComponent({
+    setup: () => () => h(MetaLinkPicker, { visible: visible.value, field: linkField, ...extraProps, ...handlers }),
+  })
+  const app = createApp(Harness)
+  app.mount(container)
+  mounts.push({ app, container })
+  return { container, visible }
+}
+
+const cancelBtn = () => document.querySelector('.meta-link-picker__cancel') as HTMLButtonElement
+const confirmBtn = () => document.querySelector('.meta-link-picker__confirm') as HTMLButtonElement
+
+describe('MetaLinkPicker — MtButton migration (UI-P2-1c)', () => {
+  it('renders footer cancel + confirm as native <button>s (keyboard-operable, classes preserved)', async () => {
+    mockListLinkOptions.mockResolvedValue({ selected: [], records: [], page: { offset: 0, limit: 50, total: 0, hasMore: false } })
+    const { visible } = mount()
+    visible.value = true
+    await flushPromises()
+    expect(cancelBtn()).toBeTruthy()
+    expect(confirmBtn()).toBeTruthy()
+    expect(cancelBtn().tagName).toBe('BUTTON')
+    expect(confirmBtn().tagName).toBe('BUTTON')
+  })
+
+  it('clicking cancel emits `close` (handler unchanged from pre-migration)', async () => {
+    mockListLinkOptions.mockResolvedValue({ selected: [], records: [], page: { offset: 0, limit: 50, total: 0, hasMore: false } })
+    const onClose = vi.fn()
+    const { visible } = mount({}, { onClose })
+    visible.value = true
+    await flushPromises()
+    cancelBtn().click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('selecting a record then clicking confirm emits `confirm` with the same { recordIds, summaries } payload', async () => {
+    mockListLinkOptions.mockResolvedValue({
+      field: linkField,
+      selected: [],
+      records: [
+        { id: 'vendor_1', display: 'Acme Supply' },
+        { id: 'vendor_2', display: 'Beacon Labs' },
+      ],
+      page: { offset: 0, limit: 50, total: 2, hasMore: false },
+    })
+    const onConfirm = vi.fn()
+    const { container, visible } = mount({}, { onConfirm })
+    visible.value = true
+    await flushPromises()
+
+    const checkbox = container.querySelector('.meta-link-picker__item input[type="checkbox"]') as HTMLInputElement
+    expect(checkbox).toBeTruthy()
+    checkbox.click()
+    await nextTick()
+
+    confirmBtn().click()
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onConfirm).toHaveBeenCalledWith({
+      recordIds: ['vendor_1'],
+      summaries: [{ id: 'vendor_1', display: 'Acme Supply' }],
+    })
+  })
+})


### PR DESCRIPTION
## What

UI-P2-1c presentation-only migration: the two clean footer action buttons in `MetaLinkPicker.vue` (**Cancel** / **Confirm**) now render via the shared `MtButton` primitive.

- **Cancel** → default (ghost) variant.
- **Confirm** → `variant="primary"` (the filled blue action; bespoke `#409eff` bg → `--ms-color-primary` token).

## Behavior preservation (byte-identical)

- `@click` bindings kept exactly: `emit('close')` (cancel) and `onConfirm` (confirm). No `emit(...)` call-site or handler function changed — the `emit()` multiset is identical before/after (the raw `±emit(` line-grep only shows the cancel tag swap because that binding is inlined on the element).
- Original `.meta-link-picker__cancel` / `.meta-link-picker__confirm` classes preserved for selector stability, so the existing direct spec (`multitable-link-picker.spec.ts`) and the import flows (`multitable-import-modal.spec.ts`) still resolve them to native `<button>`s and confirm still fires with the same payload.
- Removed the now-dead bespoke button CSS (dropped the `#fff` / `#409eff` / `#66b1ff` hardcoded hex). **No new hex introduced.**

## Left untouched (per classifier)

close-× glyph, chip-remove ×, the selection-gated **Clear**, and the `hasMore` **Load-more** bespoke control — all out of scope for the generic-action-button migration.

## Test

Adds `tests/meta-meta-link-picker-migration.spec.ts` — mounts-array + `afterEach` unmount-all + overlay residue guard. Asserts both controls render native `<button>`s, cancel emits `close`, and selecting a record then clicking confirm emits `confirm` with the same `{ recordIds, summaries }` payload. Mutation-checked: dropping the confirm `@click` turns the confirm test red.

## Verification

- `emit()` multiset before/after: identical.
- No new hardcoded hex (only removals).
- `pnpm --filter @metasheet/web run type-check`: pass.
- `vitest run` new spec + `multitable-link-picker` + `multitable-import-modal`: 20/20 pass. (Pre-existing, unrelated `multitable-workbench-import-flow.spec.ts` failure reproduces identically on `origin/main` — a `MultitableWorkbench.vue` setup harness issue, not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)