### PR TITLE
feat(web): integration K3 setup view — full tokenization + errorSummary sanitization (UF-1 / IU-1 P2 discipline)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -121,6 +121,8 @@ on:
       - 'apps/web/src/components/integration/IntegrationExternalWritePanel.vue'
       - 'apps/web/src/components/integration/IntegrationTableActionsPanel.vue'
       - 'apps/web/src/components/integration/IntegrationFieldOptionSyncPanel.vue'
+      # Integration lane F — K3 WISE setup view fully tokenized (107 hex -> 0), joins the guard set.
+      - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
       - 'apps/web/src/styles/form-layout-utilities.css'
       - 'apps/web/.eslintrc.cjs'
       - 'apps/web/tests/ui-foundation-style-guard.spec.ts'
@@ -237,6 +239,8 @@ on:
       - 'apps/web/src/components/integration/IntegrationExternalWritePanel.vue'
       - 'apps/web/src/components/integration/IntegrationTableActionsPanel.vue'
       - 'apps/web/src/components/integration/IntegrationFieldOptionSyncPanel.vue'
+      # Integration lane F — K3 WISE setup view fully tokenized (107 hex -> 0), joins the guard set.
+      - 'apps/web/src/views/IntegrationK3WiseSetupView.vue'
       - 'apps/web/src/styles/form-layout-utilities.css'
       - 'apps/web/.eslintrc.cjs'
       - 'apps/web/tests/ui-foundation-style-guard.spec.ts'

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -82,7 +82,11 @@
               <span>{{ system.name }}</span>
               <small>{{ system.kind }} · {{ system.status }}</small>
               <small v-if="system.lastTestedAt">Last test: {{ formatTimestamp(system.lastTestedAt) }}</small>
-              <small v-if="system.lastError" class="k3-setup__saved-error">{{ system.lastError }}</small>
+              <small
+                v-if="system.lastError"
+                class="k3-setup__saved-error"
+                :data-testid="`k3-saved-system-error-${system.id}`"
+              >{{ savedSystemErrorDisplay(system) }}</small>
             </button>
           </div>
         </div>
@@ -373,7 +377,11 @@
                 </div>
                 <small>{{ formatRunMetrics(run) }}</small>
                 <small>{{ formatTimestamp(run.startedAt || run.createdAt || '') }}</small>
-                <small v-if="run.errorSummary" class="k3-setup__saved-error">{{ run.errorSummary }}</small>
+                <small
+                  v-if="run.errorSummary"
+                  class="k3-setup__saved-error"
+                  :data-testid="`k3-run-error-${run.id}`"
+                >{{ runErrorDisplay(run) }}</small>
               </div>
             </template>
           </div>
@@ -926,7 +934,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
 import { useLocale } from '../composables/useLocale'
-import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../services/integration/errorCodeLabels'
+import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint, integrationErrorCodeLabel } from '../services/integration/errorCodeLabels'
 import {
   K3_WISE_SQLSERVER_KIND,
   K3_WISE_WEBAPI_KIND,
@@ -1026,6 +1034,78 @@ function deadLetterErrorLabel(deadLetter: IntegrationDeadLetter): string {
 }
 function deadLetterErrorHint(deadLetter: IntegrationDeadLetter): string | null {
   return integrationErrorCodeHint(deadLetter.errorCode, locale.value)
+}
+
+// Lane F (design-lock §3 values-free 展示纪律, ratified P2: "raw errorMessage 一律不渲染(任何层,
+// 含折叠),只允许映射为安全原因/固定文案"): `run.errorSummary`, `system.lastError` and thrown API
+// `Error.message` (the server envelope's `error.message` passes straight through
+// parseIntegrationResponse) are backend FREE TEXT and must never be interpolated into the DOM.
+// Display is limited to (a) the humanized label of an exactly-registered errorCode
+// (integrationErrorCodeLabels closed vocabulary), or (b) the FIXED values-free copy below.
+// Raw strings stay in component state for programmatic use (regex safe-reason tests, logs).
+const RUN_FAILURE_FALLBACK_COPY = {
+  zh: '运行失败，详情见服务端日志/诊断。',
+  en: 'Run failed — see server logs/diagnostics for details.',
+} as const
+
+const CONNECTION_FAILURE_FALLBACK_COPY = {
+  zh: '上次连接测试失败，详情见服务端日志与排障 JSON。',
+  en: 'Last connection test failed — see server logs and the diagnostics JSON.',
+} as const
+
+// Same safe-reason pattern test as summarizeConnectionTestResult: raw text is only pattern-TESTED
+// to pick a fixed copy; it is never embedded in the returned string.
+const SQLSERVER_EXECUTOR_MISSING_RE = /SQLSERVER_EXECUTOR_MISSING|queryExecutor|executor|执行器|注入/i
+const SQLSERVER_EXECUTOR_MISSING_COPY =
+  'SQLSERVER_EXECUTOR_MISSING：当前部署未注入 SQL 执行器，SQL 只读通道暂不能作为数据源。'
+
+function runErrorDisplay(run: IntegrationPipelineRun): string {
+  // "Paired errorCode if one exists on the run object": the wire type carries no errorCode field
+  // today, but tolerate one on the run row or inside details — only EXACT registered codes get a
+  // label (unregistered/absent → fixed values-free fallback, never the raw code or summary).
+  const candidate = (run as { errorCode?: unknown }).errorCode ?? run.details?.errorCode
+  const code = typeof candidate === 'string' ? candidate : null
+  if (code && integrationErrorCodeLabel(code, locale.value)) {
+    return integrationErrorCodeDisplayLabel(code, locale.value)
+  }
+  return locale.value === 'zh-CN' ? RUN_FAILURE_FALLBACK_COPY.zh : RUN_FAILURE_FALLBACK_COPY.en
+}
+
+function connectionFailureFallbackCopy(): string {
+  return locale.value === 'zh-CN' ? CONNECTION_FAILURE_FALLBACK_COPY.zh : CONNECTION_FAILURE_FALLBACK_COPY.en
+}
+
+function savedSystemErrorDisplay(system: IntegrationExternalSystem): string {
+  if (system.lastError && SQLSERVER_EXECUTOR_MISSING_RE.test(system.lastError)) {
+    return SQLSERVER_EXECUTOR_MISSING_COPY
+  }
+  return connectionFailureFallbackCopy()
+}
+
+// Deep display-time scrub for the collapsed "expert" JSON panels: the JSON structure (codes,
+// status flags, diagnostics keys) is preserved per the design-lock's 专家能力不降级 hard lock, but
+// values of error-free-text keys are replaced with a fixed placeholder so no raw backend message
+// reaches the DOM — including collapsed <details>. State keeps the raw envelope untouched.
+const RAW_ERROR_TEXT_KEYS = new Set(['message', 'errorMessage', 'lastError', 'errorSummary'])
+const REDACTED_ERROR_TEXT_PLACEHOLDER = '[已按 values-free 纪律隐藏；原文见服务端日志]'
+
+function sanitizeErrorTextForDisplay(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => sanitizeErrorTextForDisplay(item))
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => {
+        if (RAW_ERROR_TEXT_KEYS.has(key) && typeof entry === 'string' && entry.trim().length > 0) {
+          return [key, REDACTED_ERROR_TEXT_PLACEHOLDER]
+        }
+        return [key, sanitizeErrorTextForDisplay(entry)]
+      }),
+    )
+  }
+  return value
+}
+
+function stringifyForDisplay(value: unknown): string {
+  return JSON.stringify(sanitizeErrorTextForDisplay(value), null, 2)
 }
 const stagingDescriptors = ref<IntegrationStagingDescriptor[]>([])
 const templatePreviewTarget = ref<K3WisePipelineTarget>('material')
@@ -1152,10 +1232,12 @@ const webApiConnectionStatus = computed(() => {
         message: `已连接 K3 WISE WebAPI；最近测试 ${formatTimestamp(webApiLastTest.value.lastTestedAt)}。`,
       }
     }
+    // Values-free display (design-lock §3 P2): the stored lastError free text never renders —
+    // only the fixed fallback copy (raw detail stays in server logs / the scrubbed JSON panel).
     return {
       status: 'failed',
       label: 'failed',
-      message: `上次连接测试失败：${webApiLastTest.value.lastError || 'K3 WISE WebAPI returned an unsuccessful test result'}`,
+      message: connectionFailureFallbackCopy(),
     }
   }
   const system = selectedWebApiSystem.value
@@ -1163,7 +1245,7 @@ const webApiConnectionStatus = computed(() => {
     return {
       status: 'failed',
       label: 'failed',
-      message: `上次连接测试失败：${system.lastError}`,
+      message: connectionFailureFallbackCopy(),
     }
   }
   if (system?.lastTestedAt) {
@@ -1296,8 +1378,10 @@ async function copyGateDraft(): Promise<void> {
   try {
     await navigator.clipboard.writeText(gateDraftText.value)
     setStatus('GATE JSON 已复制', 'success')
-  } catch (error) {
-    setStatus(formatError(error), 'error')
+  } catch {
+    // Browser clipboard errors are client-generated, but the same fixed-copy invariant keeps
+    // "Error.message never reaches the DOM" absolute across the whole view.
+    setStatus('复制失败，请手动选择文本复制。', 'error')
   }
 }
 
@@ -1305,8 +1389,8 @@ async function copyGateCommand(label: string, command: string): Promise<void> {
   try {
     await navigator.clipboard.writeText(command)
     setStatus(`${label} 命令已复制`, 'success')
-  } catch (error) {
-    setStatus(formatError(error), 'error')
+  } catch {
+    setStatus('复制失败，请手动选择文本复制。', 'error')
   }
 }
 
@@ -1340,6 +1424,9 @@ function importGateJson(): void {
     )
   } catch (error) {
     gateImportWarnings.value = []
+    // Audited (lane F): applyK3WiseGateJsonToForm is fully CLIENT-side and throws only our own
+    // fixed validation copy ('GATE JSON must be valid JSON' etc.) about the user's own paste —
+    // no backend text can flow through here, so surfacing the message is values-free and useful.
     setStatus(formatError(error), 'error')
   }
 }
@@ -1402,10 +1489,12 @@ function summarizeConnectionTestResult(result: Record<string, unknown>, label: s
   const testedSystem = getTestResultSystem(result)
   const lastError = typeof testedSystem?.lastError === 'string' ? testedSystem.lastError : ''
   if (ok) return `${label} 测试通过。原始响应已收起，可展开排障 JSON。`
-  const errorText = message || lastError || code || 'unknown error'
-  const concise = /SQLSERVER_EXECUTOR_MISSING|queryExecutor|executor|执行器|注入/i.test(errorText)
-    ? 'SQLSERVER_EXECUTOR_MISSING：当前部署未注入 SQL 执行器，SQL 只读通道暂不能作为数据源。'
-    : `${label} 测试失败：${errorText}`
+  // Values-free display (design-lock §3 P2): raw backend text is only pattern-TESTED here to pick
+  // a fixed safe-reason copy — it is never embedded in the returned string.
+  const errorText = message || lastError || code || ''
+  const concise = SQLSERVER_EXECUTOR_MISSING_RE.test(errorText)
+    ? SQLSERVER_EXECUTOR_MISSING_COPY
+    : `${label} 测试失败：服务端错误详情已按 values-free 纪律收起，见服务端日志。`
   return `${concise} 原始响应已收起，可展开排障 JSON。`
 }
 
@@ -1421,8 +1510,10 @@ async function loadSystems(silent = false): Promise<void> {
     if (!form.webApiSystemId && webApi[0]) loadSystemIntoForm(webApi[0])
     if (!form.sqlSystemId && sql[0]) loadSystemIntoForm(sql[0])
     if (!silent) setStatus('K3 WISE 配置已刷新', 'success')
-  } catch (error) {
-    if (!silent) setStatus(formatError(error), 'error')
+  } catch {
+    // Lane F values-free discipline: thrown Error.message carries the server envelope's free
+    // text (parseIntegrationResponse) — fixed copy only, never formatError(...) into the DOM.
+    if (!silent) setStatus('加载 K3 WISE 配置失败，详情见服务端日志。', 'error')
   } finally {
     loading.value = false
   }
@@ -1454,8 +1545,8 @@ async function saveConfiguration(): Promise<void> {
     }
     await loadSystems(true)
     setStatus('K3 WISE 预设配置已保存', 'success')
-  } catch (error) {
-    setStatus(formatError(error), 'error')
+  } catch {
+    setStatus('保存 K3 WISE 预设配置失败，详情见服务端日志。', 'error')
   } finally {
     saving.value = false
   }
@@ -1468,7 +1559,7 @@ async function testWebApi(): Promise<void> {
   testResultSummary.value = ''
   try {
     const result = await testIntegrationSystem(form.webApiSystemId, buildConnectionTestPayload())
-    testResult.value = JSON.stringify(result, null, 2)
+    testResult.value = stringifyForDisplay(result)
     testResultSummary.value = summarizeConnectionTestResult(result, 'WebAPI')
     const testedSystem = getTestResultSystem(result)
     if (testedSystem) upsertLocalWebApiSystem(testedSystem)
@@ -1484,14 +1575,15 @@ async function testWebApi(): Promise<void> {
     void loadSystems(true)
     setStatus(result.ok === true ? 'WebAPI 连接测试完成' : 'WebAPI 连接测试失败', result.ok === true ? 'success' : 'error')
   } catch (error) {
-    testResultSummary.value = `WebAPI 测试失败：${formatError(error)}`
+    testResultSummary.value = 'WebAPI 测试失败：网络或服务端异常，详情见服务端日志。'
     webApiLastTest.value = {
       systemId: form.webApiSystemId,
       ok: false,
       lastTestedAt: new Date().toISOString(),
+      // State keeps the raw text (never rendered — display goes through the fixed-copy layer).
       lastError: formatError(error),
     }
-    setStatus(formatError(error), 'error')
+    setStatus('WebAPI 连接测试失败，详情见服务端日志。', 'error')
   } finally {
     testingWebApi.value = false
   }
@@ -1504,13 +1596,13 @@ async function testSqlServer(): Promise<void> {
   testResultSummary.value = ''
   try {
     const result = await testIntegrationSystem(form.sqlSystemId, buildConnectionTestPayload())
-    testResult.value = JSON.stringify(result, null, 2)
+    testResult.value = stringifyForDisplay(result)
     testResultSummary.value = summarizeConnectionTestResult(result, 'SQL Server')
     await loadSystems(true)
     setStatus('SQL Server 通道测试完成', 'success')
-  } catch (error) {
-    testResultSummary.value = `SQL Server 测试失败：${formatError(error)}`
-    setStatus(formatError(error), 'error')
+  } catch {
+    testResultSummary.value = 'SQL Server 测试失败：网络或服务端异常，详情见服务端日志。'
+    setStatus('SQL Server 通道测试失败，详情见服务端日志。', 'error')
   } finally {
     testingSql.value = false
   }
@@ -1521,8 +1613,8 @@ async function loadStagingDescriptors(silent = false): Promise<void> {
   try {
     stagingDescriptors.value = await listIntegrationStagingDescriptors()
     if (!silent) setStatus('Staging 契约已刷新', 'success')
-  } catch (error) {
-    if (!silent) setStatus(formatError(error), 'error')
+  } catch {
+    if (!silent) setStatus('刷新 Staging 契约失败，详情见服务端日志。', 'error')
   } finally {
     loadingStagingDescriptors.value = false
   }
@@ -1541,11 +1633,11 @@ async function installStagingTables(): Promise<void> {
     const result = await installIntegrationStaging(buildK3WiseStagingInstallPayload(form))
     if (result.projectId) form.projectId = result.projectId
     stagingInstallResult.value = result
-    stagingResult.value = JSON.stringify(result, null, 2)
+    stagingResult.value = stringifyForDisplay(result)
     await loadStagingDescriptors(true)
     setStatus('Staging 多维表已安装或确认存在', result.warnings.length > 0 ? 'info' : 'success')
-  } catch (error) {
-    setStatus(formatError(error), 'error')
+  } catch {
+    setStatus('安装 Staging 多维表失败，详情见服务端日志。', 'error')
   } finally {
     installingStaging.value = false
   }
@@ -1572,8 +1664,8 @@ async function createPipelineTemplates(): Promise<void> {
       bom: { id: bom.id, name: bom.name, status: bom.status },
     }, null, 2)
     setStatus('PLM → K3 清洗 Pipeline 已创建为 draft', 'success')
-  } catch (error) {
-    setStatus(formatError(error), 'error')
+  } catch {
+    setStatus('创建清洗 Pipeline 失败，详情见服务端日志。', 'error')
   } finally {
     creatingPipelines.value = false
   }
@@ -1606,8 +1698,8 @@ async function refreshPipelineObservation(target: K3WisePipelineTarget, silent =
     if (!silent) {
       setStatus(`${target === 'material' ? '物料' : 'BOM'} Pipeline 运行状态已刷新`, 'success')
     }
-  } catch (error) {
-    if (!silent) setStatus(formatError(error), 'error')
+  } catch {
+    if (!silent) setStatus('刷新 Pipeline 运行状态失败，详情见服务端日志。', 'error')
   } finally {
     observingPipeline.value = ''
   }
@@ -1628,16 +1720,16 @@ async function executePipeline(target: K3WisePipelineTarget, dryRun: boolean): P
   try {
     const pipelineId = getK3WisePipelineId(form, target)
     const result = await runIntegrationPipeline(pipelineId, buildK3WisePipelineRunPayload(form, target), dryRun)
-    pipelineRunResult.value = JSON.stringify({
+    pipelineRunResult.value = stringifyForDisplay({
       target,
       dryRun,
       pipelineId,
       result,
-    }, null, 2)
+    })
     await refreshPipelineObservation(target, true)
     setStatus(`${target === 'material' ? '物料' : 'BOM'} Pipeline ${dryRun ? 'dry-run' : 'run'} 已提交`, 'success')
-  } catch (error) {
-    setStatus(formatError(error), 'error')
+  } catch {
+    setStatus('提交 Pipeline 运行失败，详情见服务端日志。', 'error')
   } finally {
     runningPipeline.value = ''
   }
@@ -1656,8 +1748,8 @@ onMounted(() => {
   gap: 16px;
   min-height: 100%;
   padding: 24px;
-  background: #f6f8fb;
-  color: #172033;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-1);
 }
 
 .k3-setup__header {
@@ -1666,12 +1758,12 @@ onMounted(() => {
   gap: 20px;
   align-items: flex-start;
   padding-bottom: 16px;
-  border-bottom: 1px solid #d9e1ec;
+  border-bottom: 1px solid var(--ms-border-light);
 }
 
 .k3-setup__eyebrow {
   margin: 0 0 4px;
-  color: #64748b;
+  color: var(--ms-text-2);
   font-size: 12px;
   text-transform: uppercase;
 }
@@ -1680,12 +1772,12 @@ onMounted(() => {
   margin: 0;
   font-size: 28px;
   line-height: 1.2;
-  color: #111827;
+  color: var(--ms-text-1);
 }
 
 .k3-setup__lead {
   margin: 8px 0 0;
-  color: #526072;
+  color: var(--ms-text-2);
 }
 
 .k3-setup__header-actions {
@@ -1704,9 +1796,9 @@ onMounted(() => {
 .k3-setup__journey-step {
   min-width: 0;
   padding: 12px;
-  border: 1px solid #d9e1ec;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #fff;
+  background: var(--ms-bg-card);
 }
 
 .k3-setup__journey-step strong,
@@ -1716,13 +1808,13 @@ onMounted(() => {
 }
 
 .k3-setup__journey-step strong {
-  color: #111827;
+  color: var(--ms-text-1);
   font-size: 14px;
 }
 
 .k3-setup__journey-step span {
   margin-top: 4px;
-  color: #64748b;
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -1744,17 +1836,17 @@ onMounted(() => {
 .k3-setup__panel,
 .k3-setup__section {
   padding: 16px;
-  border: 1px solid #d9e1ec;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
-  background: #fff;
+  background: var(--ms-bg-card);
 }
 
 .k3-setup__section--primary {
-  border-color: #99f6e4;
+  border-color: var(--el-color-primary-light-7);
 }
 
 .k3-setup__details[open] {
-  border-color: #cbd5e1;
+  border-color: var(--ms-border);
 }
 
 .k3-setup__collapsible-panel {
@@ -1781,7 +1873,7 @@ onMounted(() => {
 
 .k3-setup__collapsible-panel[open] .k3-setup__panel-summary {
   margin: 0 -16px 14px;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ms-border-light);
 }
 
 .k3-setup__section-summary {
@@ -1791,7 +1883,7 @@ onMounted(() => {
 .k3-setup__details[open] .k3-setup__section-summary {
   margin-bottom: 14px;
   padding-bottom: 12px;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ms-border-light);
 }
 
 .k3-setup__panel-summary::-webkit-details-marker,
@@ -1809,8 +1901,8 @@ onMounted(() => {
   width: 22px;
   height: 22px;
   border-radius: 999px;
-  background: #e2e8f0;
-  color: #334155;
+  background: var(--el-fill-color-dark);
+  color: var(--ms-text-2);
   font-weight: 700;
 }
 
@@ -1821,14 +1913,14 @@ onMounted(() => {
 
 .k3-setup__panel-summary span,
 .k3-setup__section-summary span {
-  color: #111827;
+  color: var(--ms-text-1);
   font-size: 16px;
   font-weight: 700;
 }
 
 .k3-setup__panel-summary small,
 .k3-setup__section-summary small {
-  color: #64748b;
+  color: var(--ms-text-2);
   font-size: 12px;
 }
 
@@ -1850,12 +1942,12 @@ onMounted(() => {
   margin: 0;
   font-size: 16px;
   line-height: 1.3;
-  color: #111827;
+  color: var(--ms-text-1);
 }
 
 .k3-setup__panel-head span,
 .k3-setup__section-head span {
-  color: #64748b;
+  color: var(--ms-text-2);
   font-size: 12px;
 }
 
@@ -1881,14 +1973,14 @@ onMounted(() => {
 .k3-setup__field span,
 .k3-setup__check span,
 .k3-setup__switch span {
-  color: #334155;
+  color: var(--ms-text-2);
   font-size: 13px;
   font-weight: 600;
 }
 
 .k3-setup__field small,
 .k3-setup__field-note {
-  color: #64748b;
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -1903,7 +1995,7 @@ onMounted(() => {
 
 .k3-setup__hint {
   margin: 6px 0 0;
-  color: #9a3412;
+  color: var(--el-color-warning-dark-2);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -1913,11 +2005,11 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  border: 1px solid #facc15;
+  border: 1px solid var(--el-color-warning-light-3);
   border-radius: 6px;
   padding: 10px;
-  background: #fefce8;
-  color: #744600;
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
 }
 
 .k3-setup__hint--strong span {
@@ -1926,7 +2018,7 @@ onMounted(() => {
 }
 
 .k3-setup__hint-warning {
-  color: #92400e;
+  color: var(--el-color-warning-dark-2);
 }
 
 .k3-setup__field input,
@@ -1934,17 +2026,17 @@ onMounted(() => {
 .k3-setup__field textarea {
   width: 100%;
   min-width: 0;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--ms-border);
   border-radius: 6px;
   padding: 9px 10px;
-  background: #fff;
-  color: #111827;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
   font: inherit;
 }
 
 .k3-setup__field input[readonly] {
-  background: #f8fafc;
-  color: #64748b;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
 }
 
 .k3-setup__field textarea {
@@ -1970,20 +2062,20 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--ms-border);
   border-radius: 6px;
   padding: 9px 12px;
-  background: #fff;
-  color: #172033;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
   font: inherit;
   cursor: pointer;
   text-decoration: none;
 }
 
 .k3-setup__btn--primary {
-  border-color: #0f766e;
-  background: #0f766e;
-  color: #fff;
+  border-color: var(--ms-color-primary);
+  background: var(--ms-color-primary);
+  color: var(--ms-bg-card);
 }
 
 .k3-setup__btn--full {
@@ -2004,21 +2096,21 @@ onMounted(() => {
 .k3-setup__status {
   margin: 0;
   padding: 10px 12px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--ms-border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--ms-bg-card);
 }
 
 .k3-setup__status[data-kind="success"] {
-  border-color: #99f6e4;
-  background: #f0fdfa;
-  color: #115e59;
+  border-color: var(--el-color-success-light-7);
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
 }
 
 .k3-setup__status[data-kind="error"] {
-  border-color: #fecaca;
-  background: #fff1f2;
-  color: #9f1239;
+  border-color: var(--el-color-danger-light-7);
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
 }
 
 .k3-setup__saved-list {
@@ -2032,21 +2124,21 @@ onMounted(() => {
   flex-direction: column;
   gap: 4px;
   width: 100%;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 6px;
   padding: 10px;
-  background: #f8fafc;
-  color: #172033;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-1);
   text-align: left;
   cursor: pointer;
 }
 
 .k3-setup__saved small {
-  color: #64748b;
+  color: var(--ms-text-2);
 }
 
 .k3-setup__saved-error {
-  color: #9f1239;
+  color: var(--el-color-danger-dark-2);
   overflow-wrap: anywhere;
 }
 
@@ -2055,21 +2147,21 @@ onMounted(() => {
   flex-direction: column;
   gap: 6px;
   min-width: 0;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 6px;
   padding: 10px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .k3-setup__connection-state small {
-  color: #64748b;
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1.45;
   overflow-wrap: anywhere;
 }
 
 .k3-setup__empty {
-  color: #64748b;
+  color: var(--ms-text-2);
 }
 
 .k3-setup__records {
@@ -2100,23 +2192,23 @@ onMounted(() => {
 }
 
 .k3-setup__command-head strong {
-  color: #334155;
+  color: var(--ms-text-2);
   font-size: 12px;
 }
 
 .k3-setup__command-copy {
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--ms-border);
   border-radius: 6px;
   padding: 3px 8px;
-  background: #fff;
-  color: #334155;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-2);
   font-size: 12px;
   cursor: pointer;
 }
 
 .k3-setup__command-copy:hover {
-  border-color: #94a3b8;
-  background: #f8fafc;
+  border-color: var(--ms-color-primary);
+  background: var(--ms-bg-page);
 }
 
 .k3-setup__commands code {
@@ -2124,8 +2216,8 @@ onMounted(() => {
   overflow-wrap: anywhere;
   border-radius: 6px;
   padding: 8px;
-  background: #f1f5f9;
-  color: #172033;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-1);
   font-size: 12px;
 }
 
@@ -2160,14 +2252,14 @@ onMounted(() => {
   flex-direction: column;
   gap: 6px;
   min-width: 0;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 6px;
   padding: 10px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .k3-setup__gate-item small {
-  color: #64748b;
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1.45;
   overflow-wrap: anywhere;
@@ -2178,10 +2270,10 @@ onMounted(() => {
   flex-direction: column;
   gap: 4px;
   min-width: 0;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 6px;
   padding: 10px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .k3-setup__descriptor strong,
@@ -2190,7 +2282,7 @@ onMounted(() => {
 }
 
 .k3-setup__descriptor small {
-  color: #64748b;
+  color: var(--ms-text-2);
   font-size: 12px;
 }
 
@@ -2207,10 +2299,10 @@ onMounted(() => {
   gap: 10px;
   align-items: center;
   min-width: 0;
-  border: 1px solid #ccfbf1;
+  border: 1px solid var(--el-color-primary-light-8);
   border-radius: 6px;
   padding: 10px;
-  background: #f0fdfa;
+  background: var(--el-color-primary-light-9);
 }
 
 .k3-setup__open-target div {
@@ -2226,12 +2318,12 @@ onMounted(() => {
 }
 
 .k3-setup__open-target strong {
-  color: #115e59;
+  color: var(--el-color-primary-dark-2);
   font-size: 13px;
 }
 
 .k3-setup__open-target small {
-  color: #475569;
+  color: var(--ms-text-2);
   font-size: 12px;
   line-height: 1.35;
 }
@@ -2245,13 +2337,13 @@ onMounted(() => {
 }
 
 .k3-setup__record-head span {
-  color: #334155;
+  color: var(--ms-text-2);
   font-size: 13px;
   font-weight: 700;
 }
 
 .k3-setup__record-head small {
-  color: #64748b;
+  color: var(--ms-text-2);
 }
 
 .k3-setup__record {
@@ -2259,47 +2351,47 @@ onMounted(() => {
   flex-direction: column;
   gap: 4px;
   min-width: 0;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 6px;
   padding: 10px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .k3-setup__record strong {
   overflow-wrap: anywhere;
-  color: #172033;
+  color: var(--ms-text-1);
   font-size: 13px;
 }
 
 .k3-setup__record small {
   overflow-wrap: anywhere;
-  color: #64748b;
+  color: var(--ms-text-2);
 }
 
 .k3-setup__badge {
   border-radius: 999px;
   padding: 2px 8px;
-  background: #e2e8f0;
-  color: #334155;
+  background: var(--el-fill-color-dark);
+  color: var(--ms-text-2);
   font-size: 12px;
   white-space: nowrap;
 }
 
 .k3-setup__badge[data-status="succeeded"],
 .k3-setup__badge[data-status="replayed"] {
-  background: #ccfbf1;
-  color: #115e59;
+  background: var(--el-color-success-light-8);
+  color: var(--el-color-success-dark-2);
 }
 
 .k3-setup__badge[data-status="partial"],
 .k3-setup__badge[data-status="open"] {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--el-color-warning-light-8);
+  color: var(--el-color-warning-dark-2);
 }
 
 .k3-setup__badge[data-status="failed"] {
-  background: #ffe4e6;
-  color: #9f1239;
+  background: var(--el-color-danger-light-8);
+  color: var(--el-color-danger-dark-2);
 }
 
 .k3-setup__test-result {
@@ -2308,8 +2400,8 @@ onMounted(() => {
   margin: 12px 0 0;
   padding: 10px;
   border-radius: 6px;
-  background: #0f172a;
-  color: #e2e8f0;
+  background: var(--ms-text-1);
+  color: var(--el-color-primary-light-9);
   font-size: 12px;
 }
 
@@ -2321,16 +2413,16 @@ onMounted(() => {
 }
 
 .k3-setup__test-summary {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 6px;
   padding: 8px;
-  background: #f8fafc;
-  color: #334155;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
   overflow-wrap: anywhere;
 }
 
 .k3-setup__diagnostics summary {
-  color: #475569;
+  color: var(--ms-text-2);
   cursor: pointer;
 }
 
@@ -2345,14 +2437,14 @@ onMounted(() => {
   flex-direction: column;
   gap: 10px;
   min-width: 0;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--ms-border-light);
   border-radius: 8px;
   padding: 12px;
-  background: #f8fafc;
+  background: var(--ms-bg-page);
 }
 
 .k3-setup__template-card small {
-  color: #64748b;
+  color: var(--ms-text-2);
   overflow-wrap: anywhere;
 }
 
@@ -2365,7 +2457,7 @@ onMounted(() => {
 
 .k3-setup__mapping-table th,
 .k3-setup__mapping-table td {
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--ms-border-light);
   padding: 7px 6px;
   text-align: left;
   vertical-align: top;
@@ -2373,7 +2465,7 @@ onMounted(() => {
 }
 
 .k3-setup__mapping-table th {
-  color: #475569;
+  color: var(--ms-text-2);
   font-weight: 700;
 }
 
@@ -2382,12 +2474,12 @@ onMounted(() => {
   justify-content: space-between;
   gap: 12px;
   margin-top: 14px;
-  color: #334155;
+  color: var(--ms-text-2);
   font-size: 13px;
 }
 
 .k3-setup__preview-head span {
-  color: #64748b;
+  color: var(--ms-text-2);
 }
 
 .k3-setup__json-preview {
@@ -2396,20 +2488,20 @@ onMounted(() => {
   margin: 8px 0 0;
   padding: 10px;
   border-radius: 6px;
-  background: #0f172a;
-  color: #e2e8f0;
+  background: var(--ms-text-1);
+  color: var(--el-color-primary-light-9);
   font-size: 12px;
 }
 
 .k3-setup__section--issues {
-  border-color: #fed7aa;
-  background: #fff7ed;
+  border-color: var(--el-color-warning-light-7);
+  background: var(--el-color-warning-light-9);
 }
 
 .k3-setup__issues {
   margin: 0;
   padding-left: 18px;
-  color: #9a3412;
+  color: var(--el-color-warning-dark-2);
 }
 
 .k3-setup__issues--compact {

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 
 const apiFetchMock = vi.fn()
 
@@ -129,6 +130,8 @@ describe('IntegrationK3WiseSetupView', () => {
     if (container) container.remove()
     app = null
     container = null
+    // Lane F zh assertions flip the shared locale singleton — always restore the jsdom default.
+    useLocale().setLocale('en')
   })
 
   it('keeps first-run K3 setup focused while folding expert controls', async () => {
@@ -495,5 +498,194 @@ describe('IntegrationK3WiseSetupView', () => {
     expect(unknownLabel.textContent).not.toContain('TOTALLY_UNKNOWN_CODE')
     expect(container.querySelector('[data-testid="k3-dead-letter-code-dl_k3_unknown"]')?.textContent).toContain('TOTALLY_UNKNOWN_CODE')
     expect(container.textContent).not.toContain('ANOTHER-SENTINEL-K3')
+  })
+
+  it('lane F: run.errorSummary never renders raw — registered errorCode label or fixed values-free fallback (zh+en)', async () => {
+    const runBase = {
+      tenantId: 'default',
+      workspaceId: null,
+      pipelineId: 'pipe_f',
+      mode: 'manual',
+      status: 'failed',
+      rowsRead: 3,
+      rowsCleaned: 2,
+      rowsWritten: 0,
+      rowsFailed: 3,
+      startedAt: '2026-07-07T01:00:00.000Z',
+    }
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/external-systems?')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url.startsWith('/api/integration/runs?') && url.includes('pipelineId=pipe_f')) {
+        return jsonResponse([
+          // No errorCode anywhere → the FIXED values-free fallback copy must render.
+          { ...runBase, id: 'run_f_fallback', errorSummary: 'SENTINEL-RAW-🙅 secret=hunter2' },
+          // Paired REGISTERED errorCode → its humanized label must render instead.
+          { ...runBase, id: 'run_f_coded', errorSummary: 'SENTINEL-RAW-🙅-COKED', errorCode: 'VALIDATION_FAILED' },
+        ])
+      }
+      if (url.startsWith('/api/integration/dead-letters?') && url.includes('pipelineId=pipe_f')) return jsonResponse([])
+      return jsonResponse({})
+    })
+
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    registerRouterLinkStub(app)
+    app.mount(container)
+    await flushUi()
+
+    const materialPipelineInput = inputByLabel(container, '物料 Pipeline ID')
+    materialPipelineInput.value = 'pipe_f'
+    materialPipelineInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const refreshButton = Array.from(container.querySelectorAll('button')).find((item) => item.textContent?.includes('刷新物料状态')) as HTMLButtonElement
+    refreshButton.click()
+    await flushUi(8)
+
+    // Sentinel must be absent from the ENTIRE rendered DOM (text and markup alike).
+    expect(container.textContent).not.toContain('SENTINEL-RAW-🙅')
+    expect(container.innerHTML).not.toContain('SENTINEL-RAW-🙅')
+    expect(container.textContent).not.toContain('hunter2')
+
+    // jsdom defaults useLocale() to 'en'.
+    const fallback = container.querySelector('[data-testid="k3-run-error-run_f_fallback"]') as HTMLElement
+    expect(fallback).not.toBeNull()
+    expect(fallback.textContent).toContain('Run failed — see server logs/diagnostics for details.')
+
+    const coded = container.querySelector('[data-testid="k3-run-error-run_f_coded"]') as HTMLElement
+    expect(coded).not.toBeNull()
+    expect(coded.textContent).toContain('Data validation failed.')
+    expect(coded.textContent).not.toContain('VALIDATION_FAILED')
+
+    // zh: same closed layer, zh copy (fixed fallback + zh label).
+    useLocale().setLocale('zh-CN')
+    await flushUi()
+    expect(fallback.textContent).toContain('运行失败，详情见服务端日志/诊断。')
+    expect(coded.textContent).toContain('数据校验未通过')
+    expect(container.textContent).not.toContain('SENTINEL-RAW-🙅')
+    useLocale().setLocale('en')
+  })
+
+  it('lane F: saved-system lastError and the WebAPI status line render only fixed values-free copy', async () => {
+    const sentinel = 'SENTINEL-RAW-🙅 Login failed for user sa'
+    const webApiSystem = {
+      id: 'k3_sys_leak',
+      tenantId: 'default',
+      workspaceId: null,
+      name: 'K3 WISE WebAPI',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'error',
+      hasCredentials: true,
+      config: { version: 'K3 WISE 15.x', baseUrl: 'http://k3.local' },
+      capabilities: {},
+      lastError: sentinel,
+    }
+    const sqlSystem = {
+      id: 'k3_sql_leak',
+      tenantId: 'default',
+      workspaceId: null,
+      name: 'K3 WISE SQL Server',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'source',
+      status: 'error',
+      hasCredentials: true,
+      config: { mode: 'readonly', server: 'sql.local', database: 'AIS', allowedTables: ['dbo.t_ICItem'] },
+      lastError: 'SQLSERVER_EXECUTOR_MISSING: inject queryExecutor SENTINEL-RAW-🙅',
+    }
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-webapi')) return jsonResponse([webApiSystem])
+      if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-sqlserver')) return jsonResponse([sqlSystem])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      return jsonResponse({})
+    })
+
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    registerRouterLinkStub(app)
+    app.mount(container)
+    await flushUi(8)
+
+    expect(container.textContent).not.toContain('SENTINEL-RAW-🙅')
+    expect(container.innerHTML).not.toContain('SENTINEL-RAW-🙅')
+    expect(container.textContent).not.toContain('Login failed for user')
+
+    // Generic backend lastError → fixed fallback copy (en default in jsdom).
+    const savedError = container.querySelector('[data-testid="k3-saved-system-error-k3_sys_leak"]') as HTMLElement
+    expect(savedError).not.toBeNull()
+    expect(savedError.textContent).toContain('Last connection test failed — see server logs and the diagnostics JSON.')
+
+    // Executor-missing lastError → the pre-existing fixed safe-reason copy (regex-mapped, not echoed).
+    const sqlSavedError = container.querySelector('[data-testid="k3-saved-system-error-k3_sql_leak"]') as HTMLElement
+    expect(sqlSavedError).not.toBeNull()
+    expect(sqlSavedError.textContent).toContain('当前部署未注入 SQL 执行器')
+    expect(sqlSavedError.textContent).not.toContain('inject queryExecutor')
+
+    // The WebAPI status line (failed branch keyed off system.lastError) is fixed copy too.
+    expect(container.textContent).toContain('Last connection test failed — see server logs and the diagnostics JSON.')
+  })
+
+  it('lane F: connection-test failure keeps the summary values-free and scrubs free-text keys from the diagnostics JSON', async () => {
+    const sentinel = 'SENTINEL-RAW-🙅 TLS handshake to 10.0.0.8 failed'
+    const system = {
+      id: 'k3_sys_t',
+      tenantId: 'default',
+      workspaceId: null,
+      name: 'K3 WISE WebAPI',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      hasCredentials: true,
+      config: { version: 'K3 WISE 15.x', baseUrl: 'http://k3.local' },
+      capabilities: {},
+    }
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-webapi')) return jsonResponse([system])
+      if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-sqlserver')) return jsonResponse([])
+      if (url === '/api/integration/external-systems/k3_sys_t/test?tenantId=default') {
+        return jsonResponse({
+          ok: false,
+          code: 'K3_WISE_TEST_FAILED',
+          message: sentinel,
+          diagnostics: { server: 'k3.local' },
+          system: { ...system, status: 'error', lastError: sentinel },
+        })
+      }
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      return jsonResponse({})
+    })
+
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    registerRouterLinkStub(app)
+    app.mount(container)
+    await flushUi()
+
+    const button = Array.from(container.querySelectorAll('button')).find((item) => item.textContent?.includes('测试 WebAPI')) as HTMLButtonElement
+    expect(button.disabled).toBe(false)
+    button.click()
+    await flushUi(8)
+
+    // Neither the prominent summary nor the collapsed diagnostics JSON may carry the raw message.
+    expect(container.textContent).not.toContain('SENTINEL-RAW-🙅')
+    expect(container.innerHTML).not.toContain('SENTINEL-RAW-🙅')
+    expect(container.textContent).not.toContain('TLS handshake')
+
+    const summary = container.querySelector('[data-testid="connection-test-summary"]') as HTMLElement
+    expect(summary).not.toBeNull()
+    expect(summary.textContent).toContain('WebAPI 测试失败：服务端错误详情已按 values-free 纪律收起')
+
+    // The expert JSON panel is retained (structure, codes) — free-text keys are placeholder-scrubbed.
+    const diagnostics = container.querySelector('[data-testid="connection-test-diagnostics"]') as HTMLDetailsElement
+    expect(diagnostics).not.toBeNull()
+    expect(diagnostics.textContent).toContain('K3_WISE_TEST_FAILED')
+    expect(diagnostics.textContent).toContain('已按 values-free 纪律隐藏')
   })
 })

--- a/apps/web/tests/ui-foundation-style-guard.spec.ts
+++ b/apps/web/tests/ui-foundation-style-guard.spec.ts
@@ -68,6 +68,9 @@ const TARGET_FILES = [
   // IU-3 (docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md, #3797):
   // brand-new wizard component, clean from the start (no legacy hex to migrate).
   'src/components/integration/IntegrationReadSourceWizard.vue',
+  // Integration lane F (same design-lock §3 hard locks, UF-1 token-only): the K3 WISE setup
+  // view's 107 hardcoded hex literals were mapped onto var(--ms-*)/--el-* tokens.
+  'src/views/IntegrationK3WiseSetupView.vue',
 ] as const
 
 // Per-file allowlist for counts that are legitimately un-clearable. Keep this EMPTY unless a

--- a/docs/development/integration-f-k3setup-tokens-dev-verification-20260707.md
+++ b/docs/development/integration-f-k3setup-tokens-dev-verification-20260707.md
@@ -1,0 +1,123 @@
+# Integration lane F: K3 WISE setup view — full tokenization + errorSummary sanitization — dev verification (2026-07-07)
+
+Scope: design-lock `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md`
+§3 hard locks — **token-only** (UF-1 `apps/web/src/styles/tokens.css` header: new hardcoded hex in
+views = DEFECTS) and **values-free 展示纪律** (ratified P2 clause: labels layer consumes the exact
+registered closed vocabulary only; **raw errorMessage 永不显示** — any layer, including collapsed).
+Display-only slice: zero route/service-wire/permission/backend changes; all existing spec
+assertions pass UNCHANGED (none pinned the raw errorSummary text).
+
+## 1. Tokenization — hex/rgb() count 107 → 0
+
+`apps/web/src/views/IntegrationK3WiseSetupView.vue` `<style scoped>` block:
+
+| Metric | Before | After |
+|---|---|---|
+| hex/rgb() literals in `<style>` | **107** (32 distinct values) | **0** |
+| `var(--ms-*)` consumptions | 0 | 77 |
+| `var(--el-*)` consumptions | 0 | 30 |
+| static `style="…"` attrs | 0 | 0 (nothing to purge) |
+
+Mapping follows the UF-6 (46303349b) / IU-2a (3e5570b47) patterns — semantic repaint onto the
+UF-1 palette, not色号複製:
+
+- Slate text scale `#111827/#172033` → `--ms-text-1`; `#334155/#475569/#526072/#64748b` → `--ms-text-2`.
+- Neutral chrome `#d9e1ec/#e2e8f0` borders → `--ms-border-light`; `#cbd5e1` → `--ms-border`;
+  `#fff` → `--ms-bg-card`; `#f6f8fb/#f8fafc` → `--ms-bg-page`; chip/badge neutral bg `#e2e8f0` →
+  `--el-fill-color-dark`; code-line bg `#f1f5f9` → `--el-fill-color-light`.
+- Old teal accent (`#0f766e` primary button, `#99f6e4` primary-section border, `#ccfbf1/#f0fdfa/#115e59`
+  open-target card) → primary family (`--ms-color-primary`, `--el-color-primary-light-7/-8/-9`,
+  `--el-color-primary-dark-2`) — the same teal→site-primary repaint IU-2a applied.
+- Status semantics keep their families: success (`#99f6e4/#f0fdfa/#115e59/#ccfbf1` in status/badge
+  success context → `--el-color-success-light-7/-8/-9/-dark-2`), warning (`#facc15/#fefce8/#744600/`
+  `#92400e/#9a3412/#fef3c7/#fed7aa/#fff7ed` → `--el-color-warning-light-3/-7/-8/-9/-dark-2`), danger
+  (`#fecaca/#fff1f2/#9f1239/#ffe4e6` → `--el-color-danger-light-7/-8/-9/-dark-2`).
+- Dark expert JSON panels `#0f172a` bg + `#e2e8f0` text → `background: var(--ms-text-1)` +
+  `color: var(--el-color-primary-light-9)` — byte-for-byte the IU-2a Workbench `pre` recipe.
+- Copy-button hover border `#94a3b8` → `--ms-color-primary` (Workbench hover precedent).
+
+CI enforcement: file added to `apps/web/tests/ui-foundation-style-guard.spec.ts` `TARGET_FILES`
+(hex/rgb-literal count pinned to 0, static-style= pinned to 0) and to both
+`.github/workflows/approval-web-guard.yml` path-filter lists (pull_request + push) so future edits
+to the view re-trigger the guard. Mutation-proof: re-adding a single `color: #ffffff` to the style
+block turns `ui-foundation-style-guard` RED (run recorded below), then reverted.
+
+## 2. errorSummary leak-hole closure + full error-render audit
+
+The IU-1 verification MD (`integration-iu1-error-code-labels-dev-verification-20260706.md`) had
+explicitly flagged `run.errorSummary` (~line 376) as the remaining raw-render gap. Per the ratified
+P2 clause, display of backend error text in this view is now limited to exactly two forms:
+(a) the humanized label of an **exactly registered** errorCode (`integrationErrorCodeLabels`
+closed vocabulary, exact-key lookup), or (b) **fixed values-free copy**. Raw strings stay in
+component state (regex safe-reason tests, programmatic use) — they never reach the DOM, including
+collapsed `<details>`.
+
+### Closed sites (raw backend text could reach the DOM)
+
+| # | Site (template/script) | Before | Disposition |
+|---|---|---|---|
+| 1 | `{{ run.errorSummary }}` (最近运行 list) | raw backend free text (`pipeline-runner.cjs` writes `error.message` into it) | **CLOSED** — `runErrorDisplay(run)`: registered `errorCode` on the run object/details → humanized label via `integrationErrorCodeDisplayLabel`; otherwise fixed fallback copy zh 「运行失败，详情见服务端日志/诊断。」/ en "Run failed — see server logs/diagnostics." `v-if` stays keyed on `errorSummary` presence (boolean use only). New testid `k3-run-error-<id>`. |
+| 2 | `{{ system.lastError }}` (已保存系统 list) | raw persisted backend text | **CLOSED** — `savedSystemErrorDisplay`: executor-missing pattern → pre-existing fixed safe-reason copy (raw is pattern-TESTED only, never echoed); otherwise fixed connection-failure fallback copy (zh+en). New testid `k3-saved-system-error-<id>`. |
+| 3 | `webApiConnectionStatus.message` failed branches (embedded `webApiLastTest.lastError` / `system.lastError`) | raw tail after 「上次连接测试失败：」 | **CLOSED** — both branches return the fixed connection-failure fallback copy. |
+| 4 | `testResultSummary` — `summarizeConnectionTestResult` generic failure branch embedded `message \|\| lastError \|\| code`; catch branches embedded `formatError(error)` | raw backend text | **CLOSED** — generic branch → fixed 「…测试失败：服务端错误详情已按 values-free 纪律收起，见服务端日志。」; catch branches → fixed copy. The SQLSERVER_EXECUTOR_MISSING safe-reason branch (already fixed copy, spec-pinned) kept byte-identical. |
+| 5 | `<pre>{{ testResult }}</pre>` (collapsed diagnostics JSON) | raw envelope incl. `message`/`system.lastError` free text | **CLOSED** — `stringifyForDisplay` deep-scrubs values of the free-text error keys `message`/`errorMessage`/`lastError`/`errorSummary` to a fixed placeholder before stringify. JSON structure, codes, status flags, diagnostics keys preserved (design-lock 专家能力不降级 — 折叠≠删除); state keeps the raw envelope. |
+| 6 | `<pre>{{ pipelineRunResult }}</pre>` (run envelope may carry `errorSummary`, row errors, dead-letter messages) | raw in expert JSON | **CLOSED** — same `stringifyForDisplay` scrub. |
+| 7 | `<pre>{{ stagingResult }}</pre>` (install envelope) | no error-text keys today | **CLOSED defensively** — same scrub applied (`warnings` key deliberately NOT scrubbed: server-composed operator guidance vocabulary, not an error free-text channel). |
+| 8 | `{{ statusMessage }}` catch paths ×9 (`loadSystems`/`saveConfiguration`/`testWebApi`/`testSqlServer`/`loadStagingDescriptors`/`installStagingTables`/`createPipelineTemplates`/`refreshPipelineObservation`/`executePipeline`) | `setStatus(formatError(error))` — `parseIntegrationResponse` throws `new Error(payload?.error?.message …)`, i.e. the server envelope's free text reached the DOM | **CLOSED** — each catch now sets a fixed, operation-scoped zh copy (「…失败，详情见服务端日志。」), matching the view's existing zh-hardcoded statusMessage style. |
+| 9 | `{{ statusMessage }}` clipboard catch paths ×2 (`copyGateDraft`/`copyGateCommand`) | browser-generated `Error.message` (not backend text) | **CLOSED for uniformity** — fixed 「复制失败，请手动选择文本复制。」 keeps the "Error.message never reaches the DOM" invariant absolute across the view. |
+
+### Audited and RETAINED (no backend free text can flow)
+
+| Site | Reason |
+|---|---|
+| `{{ deadLetterErrorLabel/Hint }}` + `errorCode: {{ deadLetter.errorCode }}` | IU-1 label layer (closed vocab); raw errorCode is a registered closed set — safe per the P2 clause itself. Unchanged. |
+| `importGateJson` catch → `setStatus(formatError(error))` | `applyK3WiseGateJsonToForm` is fully CLIENT-side; throws only our own fixed validation copy about the user's own paste ('GATE JSON must be valid JSON' etc.). Values-free and useful; inline comment added. |
+| `setStatus(issues[0].message)` ×5 + `stagingIssues`/`pipelineIssues`/`materialRunIssues`/`bomRunIssues`/`gateIssues` `<li>` lists | client-side validator copy from `k3WiseSetup.ts` (fixed strings). |
+| `deployGateChecklist` `item.message`/`item.status` | client-computed (`buildK3WiseDeployGateChecklist`). |
+| `gateImportWarnings` `<li>` list | client-generated by `applyK3WiseGateJsonToForm`. |
+| `{{ gateDraftText }}`, `{{ gateEnvTemplate }}`, gate command strings, `{{ templatePreviewJson }}` | client-built from the form (export path already uses placeholders for secrets). |
+| `referenceCompletenessPreview.error` / `entry.reason` / summary counts | client-side sample parsing of the user's own pasted JSON. |
+| `system.name/kind/status`, `run.id/status`, `deadLetter.id/status/retryCount`, descriptor `id/name/fields` | identifiers + closed enums + own-tenant config data — values-free machine vocab or user's own data, not error free-text channels (same treatment as Workbench/IU-1). |
+| `statusMessage` success/info paths (incl. `已载入 ${system.name}`, `Project ID 已规范化为 ${normalized}`) | fixed copy + own-input echo. |
+
+## 3. Tests
+
+`apps/web/tests/IntegrationK3WiseSetupView.spec.ts` (7 → 10 tests), all mounted-DOM:
+
+1. **run.errorSummary sentinel** — plants `SENTINEL-RAW-🙅 secret=hunter2` in `errorSummary`;
+   asserts sentinel absent from `container.textContent` AND `container.innerHTML`; fixed fallback
+   copy renders (en default); a run carrying registered `errorCode: 'VALIDATION_FAILED'` renders
+   the humanized label ("Data validation failed."), not the code, not the summary; then
+   `useLocale().setLocale('zh-CN')` → zh fallback 「运行失败，详情见服务端日志/诊断。」+ zh label
+   「数据校验未通过」 (locale restored in `afterEach`).
+2. **saved-system lastError sentinel** — generic backend `lastError` → fixed fallback copy;
+   executor-missing `lastError` → fixed safe-reason copy without echoing the raw tail; WebAPI
+   status line failed branch shows fixed copy; sentinel absent from text and innerHTML.
+3. **connection-test failure** — `ok:false` envelope with sentinel `message`/`system.lastError`:
+   prominent summary shows the fixed values-free failure copy; collapsed diagnostics JSON retains
+   the code (`K3_WISE_TEST_FAILED`) but shows the scrub placeholder in place of free text; sentinel
+   absent from the entire DOM.
+
+Existing 7 tests (incl. the IU-1 dead-letter sentinel test and the spec-pinned
+SQLSERVER_EXECUTOR_MISSING summary assertions) pass **unchanged** — no assertion pinned the raw
+`errorSummary` text, so none needed updating.
+
+### Runs
+
+- Default Node **v25.9.0**: full integration-guard web list (18 files / 207 tests) ✅ +
+  `ui-foundation-style-guard` (67 tests incl. new target file) ✅ + `pnpm --filter
+  plugin-integration-core test` (full CJS chain) ✅.
+- **Node v20.20.2** (nvm, CI runtime): same guard list + style guard = 19 files / 274 tests ✅ +
+  plugin CJS chain ✅.
+- `vue-tsc -b` clean; `pnpm --filter @metasheet/web run build` succeeds.
+- Mutation proofs (run after the real commit, then reverted):
+  1. style guard: re-added `color: #ffffff` to the view's style block → `ui-foundation-style-guard`
+     RED on `src/views/IntegrationK3WiseSetupView.vue` (expected 0, got 1);
+  2. sentinel: restored `{{ run.errorSummary }}` raw interpolation → lane-F run-sentinel test RED.
+
+## 4. Out of scope (unchanged)
+
+Routes, `services/integration/*.ts` wire shapes, permission gates, backend/plugin code, the
+Workbench view (IU-2 lanes), ReadSourceConfigPanel/wizard/bridge files (sibling PRs #3821/#3822/
+#3824 — zero file overlap with this slice), markup/behavior beyond the two sanitized `<small>`
+render sites and their new testids.


### PR DESCRIPTION
## Lane F — integration line completion (owner-authorized 2026-07-07)

Governing locks: `docs/development/integration-ux-workbench-redesign-design-lock-20260706.md` §3 hard locks (**token-only** per UF-1; **values-free display** incl. the ratified "raw errorMessage 永不显示" P2 clause) and UF-1 `apps/web/src/styles/tokens.css` (new hardcoded hex in views = DEFECTS).

Verification MD: `docs/development/integration-f-k3setup-tokens-dev-verification-20260707.md` (full closed/retained audit tables + mapping details).

### 1. Tokenization — `IntegrationK3WiseSetupView.vue` hex count **107 → 0**

- Every hex literal in the `<style>` block mapped onto `var(--ms-*)` (77 uses) / `var(--el-*)` (30 uses), following the UF-6 (46303349b) and IU-2a (3e5570b47) patterns: slate text scale → `--ms-text-1/2`, neutral chrome → `--ms-border(-light)/bg-page/bg-card/--el-fill-color-*`, old teal accent → site primary repaint, status colors stay in their success/warning/danger families, dark JSON panels use the Workbench `pre` recipe (`background: var(--ms-text-1); color: var(--el-color-primary-light-9)`).
- 0 static `style="…"` attrs before and after (nothing to purge).
- CI enforcement: view added to `ui-foundation-style-guard.spec.ts` `TARGET_FILES` + both `approval-web-guard.yml` path-filter lists. **Mutation-proven**: re-adding one `color: #ffffff` turns the guard RED (then reverted; real work committed first).

### 2. errorSummary leak-hole closure (IU-1 review-round P2 follow-through)

`run.errorSummary` (the gap explicitly flagged in the IU-1 verification MD) no longer renders raw: registered paired `errorCode` → humanized label via `integrationErrorCodeLabels` (exact-key closed vocab); otherwise a FIXED values-free fallback copy (zh 「运行失败，详情见服务端日志/诊断。」/ en), reactive to `useLocale`.

Full-view audit of free-text error renders — closed the same way:
- `system.lastError` (saved-systems list) → fixed fallback / executor-missing fixed safe-reason copy (raw is pattern-tested only, never echoed)
- WebAPI status line failed branches → fixed copy (raw `lastError` tail removed)
- `testResultSummary` generic-failure + catch branches → fixed copy (spec-pinned SQLSERVER_EXECUTOR_MISSING fixed branch kept byte-identical)
- the three expert JSON `<pre>` panels (`testResult`/`pipelineRunResult`/`stagingResult`) → display-time deep scrub of `message`/`errorMessage`/`lastError`/`errorSummary` values to a fixed placeholder; JSON structure/codes/diagnostics keys preserved (专家能力不降级 — raw text now unreachable **including collapsed details**)
- `statusMessage` catch paths ×9 (server envelope message flows through `parseIntegrationResponse` into `Error.message`) + clipboard catches ×2 → fixed operation-scoped copy

Audited-and-retained sites (client-generated validation copy, closed enums/identifiers, own-input echoes, IU-1 label layer) are tabulated with reasons in the verification MD.

**No existing assertion pinned the raw errorSummary text — all 7 pre-existing spec tests pass UNCHANGED.**

### 3. Tests

- 3 new mounted-DOM tests: sentinel (`SENTINEL-RAW-🙅` planted in `errorSummary` / `lastError` / test-envelope `message` → absent from `textContent` AND `innerHTML`), fixed-fallback copy render, registered-code label render, zh assertions via `useLocale().setLocale('zh-CN')`.
- **Mutation-proven**: restoring the raw `{{ run.errorSummary }}` interpolation turns the lane-F sentinel test RED (then reverted).
- Default Node v25.9.0 AND Node v20.20.2 (nvm): full integration-guard web list (18 files / 207 tests) + style guard + full `plugin-integration-core` CJS chain — all green. `vue-tsc -b` clean; web build succeeds.

### Boundaries

Display-only slice: zero route / service-wire / permission / backend changes. Does NOT touch `IntegrationWorkbenchView.vue`, `ReadSourceConfigPanel`, or the wizard/bridge files — zero file overlap with concurrent #3821/#3822/#3824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)