### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaImportModal <buttons> to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaImportModal.vue
+++ b/apps/web/src/multitable/components/MetaImportModal.vue
@@ -30,8 +30,8 @@
           ></textarea>
           <div v-if="parseError" class="meta-import__error">{{ parseError }}</div>
           <div class="meta-import__actions">
-            <button class="meta-import__btn" :disabled="isImporting" @click="requestClose">{{ l('import.cancel') }}</button>
-            <button class="meta-import__btn meta-import__btn--primary" :disabled="!rawText.trim()" @click="parseAndPreview">{{ l('import.preview') }}</button>
+            <MtButton class="meta-import__btn" :disabled="isImporting" @click="requestClose">{{ l('import.cancel') }}</MtButton>
+            <MtButton class="meta-import__btn meta-import__btn--primary" variant="primary" :disabled="!rawText.trim()" @click="parseAndPreview">{{ l('import.preview') }}</MtButton>
           </div>
         </div>
 
@@ -173,6 +173,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import MetaLinkPicker from './MetaLinkPicker.vue'
+import { MtButton } from '../ui'
 import { useLocale } from '../../composables/useLocale'
 import type { LinkedRecordSummary, MetaField } from '../types'
 import { buildImportedRecords, parseDelimitedText } from '../import/delimited'

--- a/apps/web/tests/meta-meta-import-modal-migration.spec.ts
+++ b/apps/web/tests/meta-meta-import-modal-migration.spec.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaImportModal from '../src/multitable/components/MetaImportModal.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaImportModal's paste-step footer Cancel + Preview controls were migrated from
+// bespoke <button>s to the shared MtButton primitive (Preview = variant="primary"). Behavior-
+// preservation proof: they stay native, keyboard-operable <button>s; the `:disabled="isImporting"`
+// (cancel) and `:disabled="!rawText.trim()"` (preview) bindings survive; and clicking them still
+// drives the SAME handlers — requestClose() -> emits `close`, and parseAndPreview() -> transitions
+// the modal into the preview step with the parsed rows/headers. The modal teleports to <body>, so
+// queries hit `document`, not the mount container. Every other step's buttons (back, import,
+// cancelImport, backToMapping, retry, applyFixes, close, reconcile, per-failure picker) and the
+// close-× glyph stay bespoke (untouched) — they share the `.meta-import__btn` / `--primary` classes
+// as sibling bespoke controls, so that CSS is intentionally left in place.
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-import-overlay').length).toBe(0) // teleport residue guard
+  useLocale().setLocale('en')
+  window.localStorage.clear()
+})
+
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaImportModal, { ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+}
+
+const baseProps = () => ({
+  visible: true,
+  sheetId: 'sheet_migration_test',
+  fields: [{ id: 'fld_name', name: 'Name', type: 'string' }],
+  importing: false,
+  result: null,
+})
+
+const pasteActions = () =>
+  Array.from(document.querySelectorAll('.meta-import__body .meta-import__actions .meta-import__btn')) as HTMLButtonElement[]
+const cancelBtn = () => pasteActions().find((b) => !b.classList.contains('meta-import__btn--primary')) as HTMLButtonElement
+const previewBtn = () => pasteActions().find((b) => b.classList.contains('meta-import__btn--primary')) as HTMLButtonElement
+
+async function flushUi() {
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('MetaImportModal — MtButton migration (UI-P2-1c)', () => {
+  it('renders paste-step Cancel + Preview as native <button>s on initial mount', () => {
+    mount(baseProps())
+    const btns = pasteActions()
+    expect(btns.length).toBe(2)
+    expect(btns.every((b) => b.tagName === 'BUTTON')).toBe(true) // keyboard-operable, not bare divs
+    // Cancel enabled while not importing; Preview disabled until rawText has content.
+    expect(cancelBtn().disabled).toBe(false)
+    expect(previewBtn().disabled).toBe(true)
+  })
+
+  it('preview becomes enabled once rawText is populated (:disabled="!rawText.trim()" survives)', async () => {
+    mount(baseProps())
+    const textarea = document.querySelector('.meta-import__textarea') as HTMLTextAreaElement
+    textarea.value = 'Name\nAlice'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(previewBtn().disabled).toBe(false)
+  })
+
+  it('clicking cancel emits `close` (unchanged from pre-migration requestClose)', async () => {
+    const onClose = vi.fn()
+    mount(baseProps(), { onClose, onImport: vi.fn() })
+    cancelBtn().click()
+    await flushUi()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking preview drives the SAME parseAndPreview handler: transitions into the preview step with parsed headers/rows', async () => {
+    mount(baseProps(), { onClose: vi.fn(), onImport: vi.fn() })
+    const textarea = document.querySelector('.meta-import__textarea') as HTMLTextAreaElement
+    textarea.value = 'Name\nAlice'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(previewBtn().disabled).toBe(false)
+
+    previewBtn().click()
+    await flushUi()
+
+    // If @click had been dropped, parseAndPreview() never runs and the paste-step footer (with a
+    // disabled preview button) would still be showing instead of the mapping/preview UI below.
+    expect(document.querySelector('.meta-import__mapping')).not.toBeNull()
+    expect(document.querySelector('.meta-import__col-name')?.textContent).toBe('Name')
+    expect(document.body.textContent).toContain('1 record(s) detected')
+    // Paste-step body (textarea + migrated footer) is gone now that step === 'preview'.
+    expect(document.querySelector('.meta-import__textarea')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Migrate MetaImportModal's paste-step footer **Cancel** + **Preview** buttons from bespoke `<button>`s to the shared `MtButton` primitive (Preview → `variant="primary"`; Cancel → default ghost).
- Behavior byte-identical: `@click` bindings (`requestClose` / `parseAndPreview`) and `:disabled` expressions (`isImporting` / `!rawText.trim()`) unchanged; no `emit(...)` call-site touched.
- **Divergence from sibling P2-1c migrations (call this out for review):** the `.meta-import__btn` / `.meta-import__btn--primary` bespoke CSS is intentionally **kept**, not removed. Those classes are shared by 6+ sibling bespoke buttons in the preview/importing/result steps (back, import, cancelImport, backToMapping, retry, applyFixes, close, per-failure picker) that are out of scope for this slice — so the rules are not dead. This is the migration standard's "keep the sibling's part" case. The migrated buttons keep their original classes for selector stability; since the bespoke CSS still applies at equal specificity, they retain their existing visual look (accepted trade-off, not a defect).
- Close-× glyph and every other step's buttons (behind the multi-step import pipeline) stay bespoke, untouched.

## Test plan
- [x] Added `apps/web/tests/meta-meta-import-modal-migration.spec.ts`: real mount/Teleport (`document`-scoped) interaction test, 4 cases — native `<button>` rendering, `:disabled` bindings on both controls, Cancel click still emits `close`, Preview click still drives `parseAndPreview()` into the mapping/preview step (would go red if either `@click` were dropped).
- [x] `git diff origin/main -- ...MetaImportModal.vue | grep emit(` → empty (no handler changes).
- [x] `git diff origin/main -- ...MetaImportModal.vue` new-line hex scan → empty (no new hardcoded hex).
- [x] `pnpm --filter @metasheet/web run type-check` → passes.
- [x] `pnpm --filter @metasheet/web exec vitest run tests/meta-meta-import-modal-migration.spec.ts` → 4/4 pass.
- Note: `tests/multitable-workbench-import-flow.spec.ts` has 7 failures reproducible identically on `origin/main` (pre-existing `scaleStatsKey`/`filterGroups.value` bug), unrelated to this change — not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>