### PR TITLE
feat(web): BA-UI-2 Bridge Agent values-free one-click probe (design-lock #3792, refs #3746)

### DIFF
--- a/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
+++ b/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
@@ -74,6 +74,56 @@
               <el-icon><Refresh /></el-icon>
               {{ isChecking(system.id) ? bi('检查中…', 'Checking…') : bi('检查连接', 'Check connection') }}
             </button>
+            <button
+              type="button"
+              class="integration-workbench__button"
+              :data-testid="`bridge-agent-probe-${system.id}`"
+              :disabled="isProbing(system.id)"
+              @click="runProbe(system)"
+            >
+              <el-icon><Refresh /></el-icon>
+              {{ isProbing(system.id) ? bi('探测中…', 'Probing…') : bi('一键探测', 'One-click probe') }}
+            </button>
+
+            <div
+              v-if="probeResultFor(system.id)"
+              class="bridge-agent__probe-evidence"
+              :data-testid="`bridge-agent-probe-evidence-${system.id}`"
+            >
+              <h4>{{ bi('探测证据（values-free）', 'Probe evidence (values-free)') }}</h4>
+              <p
+                class="bridge-agent__probe-overall"
+                :data-result="probeResultFor(system.id)!.overallPass ? 'pass' : 'fail'"
+                :data-testid="`bridge-agent-probe-overall-${system.id}`"
+              >{{ overallLabel(probeResultFor(system.id)!) }}</p>
+              <ul>
+                <li
+                  v-for="step in probeResultFor(system.id)!.steps"
+                  :key="step.step"
+                  :data-testid="`bridge-agent-probe-step-${step.step}-${system.id}`"
+                  :data-ok="step.ok ? 'true' : 'false'"
+                >
+                  <strong>{{ probeStepLabel(step.step) }}</strong>
+                  <span> — ok: {{ step.ok ? 'true' : 'false' }}</span>
+                  <span v-if="step.durationBucket"> · durationBucket: {{ step.durationBucket }}</span>
+                  <span v-if="step.objectCount !== undefined"> · objectCount: {{ step.objectCount }}</span>
+                  <span v-if="step.fieldCount !== undefined"> · fieldCount: {{ step.fieldCount }}</span>
+                  <span v-if="step.skipped" :data-testid="`bridge-agent-probe-step-skipped-${system.id}`">
+                    · {{ bi('未采样对象（对象列表为空）', 'no object sampled (empty object list)') }}
+                  </span>
+                  <template v-if="!step.ok">
+                    <p
+                      class="bridge-agent__error"
+                      :data-testid="`bridge-agent-probe-step-error-${step.step}-${system.id}`"
+                    >{{ probeStepErrorLabel(step) }}</p>
+                    <p
+                      class="bridge-agent__probe-guidance"
+                      :data-testid="`bridge-agent-probe-step-guidance-${step.step}-${system.id}`"
+                    >{{ probeStepGuidance(step.step, step.code) }}</p>
+                  </template>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
 
@@ -254,7 +304,7 @@
 import { computed, reactive, ref, watch } from 'vue'
 import { Connection, Lock, Refresh } from '@element-plus/icons-vue'
 import { useLocale } from '../../composables/useLocale'
-import { integrationErrorCodeDisplayLabel } from '../../services/integration/errorCodeLabels'
+import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../../services/integration/errorCodeLabels'
 import { integrationFieldHint, type IntegrationFieldHintKey } from '../../services/integration/fieldHints'
 import {
   getExternalSystemSchema,
@@ -476,6 +526,175 @@ async function toggleSchema(objectName: string): Promise<void> {
   }
 }
 
+// --- BA-UI-2 (docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-2): values-
+// free one-click probe. Sequential health -> objects -> schema, early-stopping at the first step that
+// fails (a later step is simply never called — no partial/best-effort continuation). Reuses the exact
+// same three read-only generic service calls the rest of this section already consumes above
+// (testExternalSystemConnection / listExternalSystemObjects / getExternalSystemSchema) — ZERO new
+// backend routes, zero new credential path. Evidence is ephemeral component state only (no
+// persistence/backend storage; BA-UI-3's change-suggestion flow is a later, unopened slice).
+//
+// Evidence vocabulary (values-free, per lock §3): ok (boolean) / durationBucket (coarse bucket, never
+// a raw millisecond count that could fingerprint infra) / objectCount (objects step) / fieldCount of a
+// single SAMPLED object (schema step, never the object's name or any field value) / a humanized error
+// label + guidance line on failure, both routed through the IU-1 `errorCodeLabels` module (never a raw
+// code string, never a raw error message — see the script-block security-bounds note above, which this
+// slice does not relax).
+
+type ProbeStepKey = 'health' | 'objects' | 'schema'
+type DurationBucket = '<1s' | '1-5s' | '>5s'
+
+interface ProbeStepResult {
+  step: ProbeStepKey
+  ok: boolean
+  // Absent only for the schema step when it is SKIPPED (objects step returned zero objects — nothing
+  // to sample; this is not a failure, so no fetch/timing happened for this step).
+  durationBucket?: DurationBucket
+  objectCount?: number // objects step only
+  fieldCount?: number // schema step only — field count of the single sampled object
+  skipped?: boolean // schema step only
+  // Real registered code for a health failure (its response carries `.code`); ALWAYS null for
+  // objects/schema failures — their thrown Error carries no machine-readable code (BA-UI-1 scout
+  // finding: workbench.ts's parseIntegrationResponse only preserves `.message`). Routing a `null` code
+  // through the same IU-1 label helper still yields a coarse, values-free "unknown error" label — it is
+  // deliberately NOT a special-cased string here.
+  code: string | null
+}
+
+interface ProbeRunResult {
+  overallPass: boolean
+  failedStep: ProbeStepKey | null
+  steps: ProbeStepResult[]
+}
+
+const probing = reactive<Record<string, boolean>>({})
+const probeResults = reactive<Record<string, ProbeRunResult>>({})
+
+function isProbing(systemId: string): boolean {
+  return Boolean(probing[systemId])
+}
+
+function probeResultFor(systemId: string): ProbeRunResult | null {
+  return probeResults[systemId] || null
+}
+
+function bucketFor(durationMs: number): DurationBucket {
+  if (durationMs < 1000) return '<1s'
+  if (durationMs < 5000) return '1-5s'
+  return '>5s'
+}
+
+// Times a step and normalizes both the success and throw paths into one shape — `Date.now()` (not
+// `performance.now()`) so tests can pin exact deltas via `vi.spyOn(Date, 'now')` without needing fake
+// timers to cooperate with real microtask scheduling.
+async function measureStep<T>(
+  fn: () => Promise<T>,
+): Promise<{ durationBucket: DurationBucket; value: T | null; threw: boolean }> {
+  const start = Date.now()
+  try {
+    const value = await fn()
+    return { durationBucket: bucketFor(Date.now() - start), value, threw: false }
+  } catch {
+    return { durationBucket: bucketFor(Date.now() - start), value: null, threw: true }
+  }
+}
+
+function probeStepLabel(step: ProbeStepKey): string {
+  if (step === 'health') return bi('健康检查', 'Health check')
+  if (step === 'objects') return bi('对象列表', 'Objects')
+  return bi('Schema 预览', 'Schema preview')
+}
+
+// Always routed through the IU-1 module — see the `code` field comment on ProbeStepResult above for
+// why a `null` code (objects/schema) is expected and still renders a humanized, values-free label.
+function probeStepErrorLabel(step: ProbeStepResult): string {
+  return integrationErrorCodeDisplayLabel(step.code, locale.value)
+}
+
+const PROBE_STEP_FALLBACK_GUIDANCE: Record<ProbeStepKey, { zh: string; en: string }> = {
+  health: {
+    zh: '本机 Bridge Agent 可能未启动或不可达，请检查其计划任务/进程后重新探测。',
+    en: 'The local Bridge Agent may not be running or reachable; check its scheduled task or process, then re-probe.',
+  },
+  objects: {
+    zh: '请检查连接状态后重试对象列表探测。',
+    en: 'Check the connection status, then retry the objects probe.',
+  },
+  schema: {
+    zh: '请检查所采样对象是否仍在本机 allowlist 中后重试。',
+    en: 'Check whether the sampled object is still allowlisted locally, then retry.',
+  },
+}
+
+// A registered code's own hint (IU-6 hint style — e.g. BRIDGE_AGENT_UNREACHABLE/TIMEOUT already carry
+// one) takes precedence when present; otherwise this fixed, values-free per-step fallback guarantees a
+// guidance line always renders on failure, even for the codeless objects/schema routes.
+function probeStepGuidance(step: ProbeStepKey, code: string | null): string {
+  const hint = integrationErrorCodeHint(code, locale.value)
+  if (hint) return hint
+  return locale.value === 'zh-CN' ? PROBE_STEP_FALLBACK_GUIDANCE[step].zh : PROBE_STEP_FALLBACK_GUIDANCE[step].en
+}
+
+function overallLabel(result: ProbeRunResult): string {
+  if (result.overallPass) return 'PASS'
+  return `FAIL: ${probeStepLabel(result.failedStep as ProbeStepKey)}`
+}
+
+async function runProbe(system: WorkbenchExternalSystem): Promise<void> {
+  const systemId = system.id
+  probing[systemId] = true
+  const steps: ProbeStepResult[] = []
+  let failedStep: ProbeStepKey | null = null
+  try {
+    // Step 1/3: health — the SAME generic test route the status card above uses.
+    const health = await measureStep(() => testExternalSystemConnection(systemId, props.scope))
+    const healthOk = !health.threw && health.value?.ok === true
+    const healthCode = !healthOk && !health.threw && typeof health.value?.code === 'string' ? health.value.code : null
+    steps.push({ step: 'health', ok: healthOk, durationBucket: health.durationBucket, code: healthCode })
+    if (!healthOk) {
+      failedStep = 'health'
+      return
+    }
+
+    // Step 2/3: objects — early-stop here means schema (step 3) is NEVER called.
+    const objects = await measureStep(() => listExternalSystemObjects(systemId, props.scope))
+    const objectsOk = !objects.threw
+    steps.push({
+      step: 'objects',
+      ok: objectsOk,
+      durationBucket: objects.durationBucket,
+      objectCount: objectsOk ? (objects.value?.length ?? 0) : undefined,
+      code: null,
+    })
+    if (!objectsOk) {
+      failedStep = 'objects'
+      return
+    }
+
+    // Step 3/3: schema of a single sampled object (the first object returned). An empty allowlist
+    // (objectCount === 0) is NOT a failure — there is simply nothing to sample, so this step is marked
+    // skipped rather than run.
+    const sample = objects.value && objects.value.length > 0 ? objects.value[0] : null
+    if (!sample) {
+      steps.push({ step: 'schema', ok: true, skipped: true, code: null })
+      return
+    }
+    const schema = await measureStep(() => getExternalSystemSchema(systemId, { ...props.scope, object: sample.name }))
+    const schemaOk = !schema.threw
+    steps.push({
+      step: 'schema',
+      ok: schemaOk,
+      durationBucket: schema.durationBucket,
+      fieldCount: schemaOk ? (schema.value?.fields.length ?? 0) : undefined,
+      code: null,
+    })
+    if (!schemaOk) failedStep = 'schema'
+  } finally {
+    probeResults[systemId] = { overallPass: failedStep === null, failedStep, steps }
+    probing[systemId] = false
+  }
+}
+
 watch(
   bridgeSystems,
   (list) => {
@@ -679,6 +898,47 @@ watch(
   background: var(--el-color-danger-light-9);
   color: var(--el-color-danger);
   font-size: 12px;
+}
+
+.bridge-agent__probe-evidence {
+  margin-top: 4px;
+  padding: 8px 10px;
+  border: 1px dashed var(--ms-border);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--ms-text-2);
+}
+
+.bridge-agent__probe-evidence h4 {
+  margin: 0 0 6px;
+  font-size: 12px;
+  color: var(--ms-text-1);
+}
+
+.bridge-agent__probe-evidence ul {
+  margin: 0;
+  padding-left: 16px;
+  display: grid;
+  gap: 6px;
+}
+
+.bridge-agent__probe-overall {
+  margin: 0 0 6px;
+  font-weight: 700;
+  color: var(--ms-text-1);
+}
+
+.bridge-agent__probe-overall[data-result='fail'] {
+  color: var(--el-color-danger);
+}
+
+.bridge-agent__probe-overall[data-result='pass'] {
+  color: var(--el-color-success-dark-2);
+}
+
+.bridge-agent__probe-guidance {
+  margin: 2px 0 0;
+  color: var(--ms-text-3);
 }
 
 .bridge-agent__instances,

--- a/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
+++ b/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
@@ -437,4 +437,195 @@ describe('IntegrationBridgeAgentSection', () => {
       setLocale('en')
     }
   })
+
+  // --- BA-UI-2 (docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-2):
+  // values-free one-click probe — health -> objects -> schema, sequential, early-stop on first
+  // failure. Evidence card renders ok/durationBucket/counts/humanized-code per step + overall
+  // PASS/FAIL, all through the three EXISTING generic endpoints (zero new routes).
+
+  it('probe: happy path runs health -> objects -> schema sequentially and renders PASS with three ok steps', async () => {
+    mockRoutes()
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    expect(root.querySelector(`[data-testid="bridge-agent-probe-evidence-${system.id}"]`)).toBeNull()
+    apiFetchMock.mockClear() // isolate the calls the probe itself issues from mount-time auto-load
+
+    q<HTMLButtonElement>(root, `bridge-agent-probe-${system.id}`).click()
+    await flushUi()
+
+    const overall = q(root, `bridge-agent-probe-overall-${system.id}`)
+    expect(overall.getAttribute('data-result')).toBe('pass')
+    expect(overall.textContent).toBe('PASS')
+
+    const healthStep = q(root, `bridge-agent-probe-step-health-${system.id}`)
+    const objectsStep = q(root, `bridge-agent-probe-step-objects-${system.id}`)
+    const schemaStep = q(root, `bridge-agent-probe-step-schema-${system.id}`)
+    expect(healthStep.getAttribute('data-ok')).toBe('true')
+    expect(objectsStep.getAttribute('data-ok')).toBe('true')
+    expect(schemaStep.getAttribute('data-ok')).toBe('true')
+    expect(objectsStep.textContent).toContain('objectCount: 2')
+    expect(schemaStep.textContent).toContain('fieldCount: 3')
+
+    // Sequential order through the three EXISTING generic endpoints only, nothing else.
+    const orderedUrls = apiFetchMock.mock.calls.map(([url]) => String(url))
+    const testIdx = orderedUrls.findIndex((u) => u.includes('/test'))
+    const objectsIdx = orderedUrls.findIndex((u) => u.includes('/objects'))
+    const schemaIdx = orderedUrls.findIndex((u) => u.includes('/schema'))
+    expect(testIdx).toBe(0)
+    expect(objectsIdx).toBeGreaterThan(testIdx)
+    expect(schemaIdx).toBeGreaterThan(objectsIdx)
+    expect(orderedUrls[schemaIdx]).toContain('object=material')
+  })
+
+  it('probe: a failure at the objects step early-stops before schema (schema never called) — FAIL badge + step guidance + humanized code', async () => {
+    mockRoutes({ objects: () => errorResponse(500, 'BRIDGE_AGENT_REQUEST_FAILED', SENTINEL.errorBody) })
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+    apiFetchMock.mockClear()
+
+    q<HTMLButtonElement>(root, `bridge-agent-probe-${system.id}`).click()
+    await flushUi()
+
+    const overall = q(root, `bridge-agent-probe-overall-${system.id}`)
+    expect(overall.getAttribute('data-result')).toBe('fail')
+    expect(overall.textContent).toMatch(/FAIL: Objects/)
+
+    expect(q(root, `bridge-agent-probe-step-health-${system.id}`).getAttribute('data-ok')).toBe('true')
+    expect(q(root, `bridge-agent-probe-step-objects-${system.id}`).getAttribute('data-ok')).toBe('false')
+    // Early-stop: the schema step never even appears (it was never run), and its fetch never fired.
+    expect(root.querySelector(`[data-testid="bridge-agent-probe-step-schema-${system.id}"]`)).toBeNull()
+    expect(apiFetchMock.mock.calls.some(([url]) => typeof url === 'string' && url.includes('/schema'))).toBe(false)
+
+    // Humanized code: objects failures carry no code client-side, so this degrades to the generic
+    // IU-1 unknown-error label — never the raw backend code/message.
+    expect(q(root, `bridge-agent-probe-step-error-objects-${system.id}`).textContent).toContain('Unknown error')
+    expect(q(root, `bridge-agent-probe-step-guidance-objects-${system.id}`).textContent).toMatch(/retry the objects probe/i)
+    expect(root.innerHTML).not.toContain(SENTINEL.errorBody)
+    expect(root.innerHTML).not.toContain('BRIDGE_AGENT_REQUEST_FAILED')
+  })
+
+  it('probe: objects step returns zero objects -> schema step is SKIPPED (not a failure), overall still PASS', async () => {
+    mockRoutes({ objects: () => jsonResponse([]) })
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+    apiFetchMock.mockClear()
+
+    q<HTMLButtonElement>(root, `bridge-agent-probe-${system.id}`).click()
+    await flushUi()
+
+    expect(q(root, `bridge-agent-probe-overall-${system.id}`).getAttribute('data-result')).toBe('pass')
+    expect(q(root, `bridge-agent-probe-step-schema-${system.id}`).getAttribute('data-ok')).toBe('true')
+    q(root, `bridge-agent-probe-step-skipped-${system.id}`)
+    // Nothing to sample -> schema is never fetched (distinct from the early-stop-on-failure path).
+    expect(apiFetchMock.mock.calls.some(([url]) => typeof url === 'string' && url.includes('/schema'))).toBe(false)
+  })
+
+  it('probe: per-step duration buckets classify short/medium/long elapsed time (<1s / 1-5s / >5s)', async () => {
+    mockRoutes()
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    // Fake timers so each mocked fetch resolves after a controlled, real elapsed delay — the
+    // component measures with plain `Date.now()`, and vitest's fake-timer install fakes that too, so
+    // advancing the clock produces real, deterministic bucket boundaries (no brittle call-count
+    // stubbing of Date.now, which can be thrown off by incidental calls elsewhere in the stack).
+    vi.useFakeTimers()
+    try {
+      apiFetchMock.mockImplementation((url: unknown) => {
+        const u = String(url)
+        if (u.includes('/test')) {
+          return new Promise<Response>((resolve) => {
+            setTimeout(() => resolve(jsonResponse({ ok: true, connected: true, authenticated: true })), 200)
+          })
+        }
+        if (u.includes('/objects')) {
+          return new Promise<Response>((resolve) => {
+            setTimeout(() => resolve(jsonResponse(OBJECTS_PAYLOAD)), 1500)
+          })
+        }
+        if (u.includes('/schema')) {
+          return new Promise<Response>((resolve) => {
+            setTimeout(() => resolve(jsonResponse(SCHEMA_PAYLOAD)), 6000)
+          })
+        }
+        return Promise.resolve(jsonResponse(null))
+      })
+
+      q<HTMLButtonElement>(root, `bridge-agent-probe-${system.id}`).click()
+      await vi.advanceTimersByTimeAsync(200) // health resolves: 200ms -> <1s
+      await vi.advanceTimersByTimeAsync(1500) // objects resolves: 1500ms later -> 1-5s
+      await vi.advanceTimersByTimeAsync(6000) // schema resolves: 6000ms later -> >5s
+      await nextTick()
+      await nextTick()
+
+      expect(q(root, `bridge-agent-probe-step-health-${system.id}`).textContent).toContain('durationBucket: <1s')
+      expect(q(root, `bridge-agent-probe-step-objects-${system.id}`).textContent).toContain('durationBucket: 1-5s')
+      expect(q(root, `bridge-agent-probe-step-schema-${system.id}`).textContent).toContain('durationBucket: >5s')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('SENTINEL via probe (lock §3 BA-UI-2): no secret-shaped string leaks through the probe evidence path, success or failure', async () => {
+    // Success path: the default fixtures already carry hostile extras (OBJECTS_PAYLOAD connectionString
+    // key, SCHEMA_PAYLOAD defaultValue/raw.leaked, the test response's SENTINEL-laden message).
+    mockRoutes()
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    q<HTMLButtonElement>(root, `bridge-agent-probe-${system.id}`).click()
+    await flushUi()
+
+    q(root, `bridge-agent-probe-evidence-${system.id}`)
+    for (const [key, sentinel] of Object.entries(SENTINEL)) {
+      expect(root.innerHTML.includes(sentinel), `probe (success) sentinel leak html: ${key}`).toBe(false)
+      expect((root.textContent || '').includes(sentinel), `probe (success) sentinel leak text: ${key}`).toBe(false)
+    }
+
+    // Failure path: hostile/non-closed-set code + secret-laden message on the health step.
+    apiFetchMock.mockReset()
+    mockRoutes({
+      test: () => jsonResponse({ ok: false, connected: false, code: SENTINEL.hostileCode, message: SENTINEL.testMessage }),
+    })
+    app!.unmount()
+    container!.remove()
+    const root2 = mountSection([bridgeSystem()])
+    await flushUi()
+    q<HTMLButtonElement>(root2, `bridge-agent-probe-${system.id}`).click()
+    await flushUi()
+
+    for (const [key, sentinel] of Object.entries(SENTINEL)) {
+      expect(root2.innerHTML.includes(sentinel), `probe (failure) sentinel leak html: ${key}`).toBe(false)
+      expect((root2.textContent || '').includes(sentinel), `probe (failure) sentinel leak text: ${key}`).toBe(false)
+    }
+    expect(q(root2, `bridge-agent-probe-step-error-health-${system.id}`).textContent).toContain('Unknown error')
+  })
+
+  it('zh copy: probe evidence renders bilingual overall/step labels + guidance under zh-CN', async () => {
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      mockRoutes({ objects: () => errorResponse(500, 'BRIDGE_AGENT_REQUEST_FAILED', SENTINEL.errorBody) })
+      const system = bridgeSystem()
+      const root = mountSection([system])
+      await flushUi()
+
+      q<HTMLButtonElement>(root, `bridge-agent-probe-${system.id}`).click()
+      await flushUi()
+
+      expect(q(root, `bridge-agent-probe-overall-${system.id}`).textContent).toContain('对象列表')
+      expect(q(root, `bridge-agent-probe-step-health-${system.id}`).textContent).toContain('健康检查')
+      expect(q(root, `bridge-agent-probe-step-objects-${system.id}`).textContent).toContain('对象列表')
+      expect(q(root, `bridge-agent-probe-step-guidance-objects-${system.id}`).textContent).toContain('对象列表探测')
+      expect(root.querySelector(`[data-testid="bridge-agent-probe-step-schema-${system.id}"]`)).toBeNull()
+    } finally {
+      setLocale('en')
+    }
+  })
 })

--- a/docs/development/bridge-agent-ui2-probe-dev-verification-20260707.md
+++ b/docs/development/bridge-agent-ui2-probe-dev-verification-20260707.md
@@ -1,0 +1,119 @@
+# BA-UI-2 — Bridge Agent values-free 一键探测 · 开发/验证报告 — 2026-07-07
+
+> Design-lock: `docs/development/bridge-agent-admin-page-design-lock-20260707.md`(#3792,RATIFIED;
+> owner granted the full BA-UI ladder 2026-07-07)§3 BA-UI-2。前置:BA-UI-1 = #3824
+> (`bridge-agent-ui1-observability-dev-verification-20260707.md`)。Demand anchor:#3746(保持 OPEN)。
+> 本片 = 纯只读、用户触发、顺序 early-stop 的 values-free smoke:零写路径、零凭据路径变更、零新路由、
+> 零持久化(证据是组件短暂状态)。BA-UI-3(配置校验 + 变更建议清单)是后续独立切片,本片不实现其任何部分。
+
+## 1. 范围与做法(vs lock §3 BA-UI-2 逐条)
+
+| lock §3 BA-UI-2 条款 | 实现 |
+| --- | --- |
+| 每系统「一键探测」按钮 | 每张 Agent 状态卡新增 `bridge-agent-probe-<id>` 按钮(与既有「检查连接」并列),用户触发,无轮询/调度。 |
+| health→objects→schema 顺序执行 | `runProbe()` 顺序 `await`:step1 health、step2 objects、step3 schema-of-sampled-object;上一步不 ok 直接 `return`,后一步的 service 调用**根本不发生**。 |
+| 走 BA-UI-1 既有通用端点 | 复用同三个 service 函数:`testExternalSystemConnection`(POST `/:id/test`)、`listExternalSystemObjects`(GET `/:id/objects`)、`getExternalSystemSchema`(GET `/:id/schema?object=`)。**零新路由**(见 §2)。 |
+| 每步证据 = ok/durationBucket/counts/coarse code | 见 §3 证据词表。 |
+| overall PASS \| FAIL(哪一步) + 固定 values-free 指引 | `overallLabel()` → `PASS` 或 `FAIL: <失败步>`;失败步渲染 IU-1 label + 固定/IU-6-hint 指引行。 |
+| 复用既有 values-free evidence 词表,不另造词表 | 错误显示与指引全部经既有 `errorCodeLabels.ts`(`integrationErrorCodeDisplayLabel` / `integrationErrorCodeHint`);计数/布尔/桶为通用显示 idiom,无新词表模块。 |
+| raw errorMessage 永不渲染 | 沿用 BA-UI-1 纪律:step.code 只透传 health 的注册码;objects/schema 抛错**不捕获 message**(code 恒为 `null`→降级通用「未知错误」label)。 |
+
+## 2. 零新路由确认(zero-new-route)
+
+**采用:ZERO new backend routes,ZERO backend files touched。** 唯一改动文件 =
+`IntegrationBridgeAgentSection.vue` + 其 spec(add-only)。探测的三步全部落在 BA-UI-1 已在消费的三条**通用**
+只读端点上,无任何新 service 函数、无新 `apiFetch` URL 形状:
+
+| 探测步 | 复用的既有 service | 落到的既有路由 | BA-UI-1 已用? |
+| --- | --- | --- | --- |
+| health(step 1) | `testExternalSystemConnection` | `POST /api/integration/external-systems/:id/test` | ✅(状态卡「检查连接」) |
+| objects(step 2) | `listExternalSystemObjects` | `GET /api/integration/external-systems/:id/objects` | ✅(对象列表自动加载) |
+| schema(step 3) | `getExternalSystemSchema` | `GET /api/integration/external-systems/:id/schema?object=` | ✅(schema 预览按需) |
+
+`POST /query/:object`(数据面取数)**不被本片调用**(lock §4)——happy-path 测试断言探测发出的每个 URL 都
+匹配 `test|objects|schema` 三端点之一,且 `object=material`(采样对象名)。
+
+## 3. 证据词表(evidence vocabulary:key → type → source)
+
+全部 values-free:count / boolean / 粗粒度桶 / coarse label。无 host/credential/tenant/config-id/row 值,
+无 raw errorMessage。
+
+| 证据 key | 类型 | 来源(值从哪来) | 备注 |
+| --- | --- | --- | --- |
+| `overallPass` | boolean(`PASS`/`FAIL: <步>`) | 派生:所有步 ok 且无 failedStep | 渲染为 `data-result=pass\|fail` + 文本 |
+| `step` | 闭集枚举 `health\|objects\|schema` | 探测器自身流程 | 渲染为人话 label(`健康检查`/`对象列表`/`Schema 预览`) |
+| `ok` | boolean | health:`result.ok===true`;objects/schema:`!threw` | 渲染 `ok: true\|false` + `data-ok` |
+| `durationBucket` | 闭集 `<1s\|1-5s\|>5s` | `Date.now()` 差值经 `bucketFor()` 分桶 | **粗粒度桶,绝不渲染原始毫秒**(避免为 infra 指纹);skip 的 schema 步无此字段 |
+| `objectCount` | number | objects 步:`objects.value.length`(仅成功时) | 计数,非对象名/值 |
+| `fieldCount` | number | schema 步:采样对象的 `schema.fields.length`(仅成功时) | 单个**采样**对象的字段数;非字段名/值 |
+| `skipped` | boolean(schema 步专属) | objectCount===0 时置真 | 空 allowlist 无对象可采样 = **不是失败**,标记 skipped;overall 仍 PASS |
+| 失败步 error label | string(闭集 label) | `integrationErrorCodeDisplayLabel(step.code, locale)` | health 传注册码→其 label;objects/schema code 恒 `null`→通用「未知错误」 |
+| 失败步 guidance | string(闭集/固定文案) | 注册码有 hint 则取 `integrationErrorCodeHint`(IU-6 hint 风格),否则固定 per-step fallback | 保证失败必渲染一行 values-free 指引 |
+
+`step.code` 字段说明(纪律):只有 health 失败会带真实注册码(其响应含 `.code`);objects/schema 失败抛出的
+`Error` **不携带** machine-readable code(BA-UI-1 scout 结论:`workbench.ts` 的 `parseIntegrationResponse`
+只保留 `.message`),故 code 恒 `null`。把 `null` 经同一 IU-1 label helper 仍得到 coarse values-free
+「未知错误」label —— **刻意不特判**,复用既有降级路径。
+
+## 4. Early-stop 证明
+
+- **代码**:`runProbe()` 中 health 不 ok → `failedStep='health'; return`(objects/schema 的 `await` 从不到达);
+  objects 不 ok → `failedStep='objects'; return`(schema 的 `getExternalSystemSchema` 从不调用)。
+- **测试**(`probe: a failure at the objects step early-stops before schema`):objects mock 返回 500,断言
+  (a)overall = `FAIL: Objects`;(b)`bridge-agent-probe-step-schema-<id>` DOM 节点**不存在**(该步从未 push);
+  (c)`apiFetchMock.mock.calls` 中**无** `/schema` 调用。三条同时成立 = early-stop 证据。
+- **区分 skip vs 失败**:objects 返回 `[]`(空 allowlist)→ schema 步标 `skipped`、overall 仍 `PASS`、
+  且 `/schema` 同样不发(nothing to sample),与失败 early-stop 是两条不同路径(各有独立测试)。
+
+## 5. Sentinel 说明
+
+探测证据是新的渲染面,故新增两个 sentinel 断言(在 BA-UI-1 既有 sentinel 之上,ADD-ONLY):
+`SENTINEL via probe`(成功 + 失败双路径)与 `zh copy: probe evidence` 顺带覆盖。
+
+- **成功路径**:默认 fixtures 已带敌意载荷 —— objects payload 的 `connectionString` 额外 key
+  (`SENTINEL.objectExtra`)、schema payload 的 `defaultValue`/`raw.leaked`(`SENTINEL.schemaExtra`)、
+  test 响应的 secret-laden `message`(`SENTINEL.testMessage`)。跑完探测后断言 `SENTINEL` 全部 9 条在
+  `innerHTML` 与 `textContent` 双面均不出现。
+- **失败路径**:health mock 返回敌意非闭集 `code`(`SENTINEL.hostileCode`,内嵌 `secret=`)+ secret-laden
+  `message`,断言同样零泄漏,且 error label 降级为「Unknown error」。
+- 机制:计数/布尔/桶从不透传字符串值;objects/schema 抛错走 catch 但**不读 message**;error label 只出
+  IU-1 映射结果(`code=null`→「未知错误」);durationBucket 是闭集桶,非原始毫秒。
+
+## 6. Mutation 证明(基线 commit 后注入→跑→红→精确 revert)
+
+| # | 变体 | 预期 | 结果 |
+| --- | --- | --- | --- |
+| M1 | 删除 objects 步的 `return`(保留 `failedStep='objects'` 但去掉 early-stop,schema 步继续跑) | early-stop 测试红 | **RED**(1 failed:schema 步节点出现 + `/schema` 被调用)✅ killed |
+| M2 | objects 步 render 追加 `raw: {{ (objects[0] as any)?.connectionString }}`(把敌意额外 key 泄漏进 DOM) | SENTINEL-via-probe 测试红 | **RED**(1 failed:`SENTINEL.objectExtra` 出现在 DOM)✅ killed |
+
+### 6.1 执行记录
+
+两变体各单独注入 → `vitest run IntegrationBridgeAgentSection` 确认 **RED**(各 1 failed / 15 skipped)→
+精确路径 `git checkout -- IntegrationBridgeAgentSection.vue` 复原 → 重跑确认 **GREEN**(16/16)。基线在两次
+mutation **之前**已 commit(52f5f93cb),两次 revert 后工作树回到基线、无残留。
+
+## 7. 测试与构建矩阵
+
+| 面 | Node 25(默认) | Node 20(nvm,CI 同版) |
+| --- | --- | --- |
+| `IntegrationBridgeAgentSection` spec(BA-UI-1 10 + BA-UI-2 6 = 16 tests) | ✅ 16/16 | ✅ 16/16 |
+| integration-guard 19-spec 全列表 | ✅ 229/229 | ✅ 229/229 |
+| ui-foundation-style-guard(TARGET_FILES 已含本组件,token-only) | ✅ 77/77 | —(纯 fs 扫描,版本无关) |
+| `vue-tsc -b` | ✅ clean | — |
+| `pnpm build`(apps/web) | ✅ built | — |
+
+CI 面:`integration-guard.yml` 的 pull_request/push `paths` 与 vitest run 列表**在 BA-UI-1(#3824)已收编**本
+组件 + 本 spec —— 本片仅编辑既有文件(非新增),无需改 workflow/style-guard TARGET_FILES/新注册。
+
+## 8. 改动清单
+
+| 文件 | 类型 |
+| --- | --- |
+| `apps/web/src/components/integration/IntegrationBridgeAgentSection.vue` | 编辑(add-only:探测按钮 + 证据卡 + probe 逻辑 + import `integrationErrorCodeHint` + 局部样式) |
+| `apps/web/tests/IntegrationBridgeAgentSection.spec.ts` | 编辑(add-only:6 个 BA-UI-2 tests) |
+| `docs/development/bridge-agent-ui2-probe-dev-verification-20260707.md` | 新增(本文) |
+
+## 9. 边界外(维持冻结)
+
+BA-UI-3(配置校验 + 变更建议清单)/ BA-UI-4(计划任务运行态)各需独立 opt-in;本片未实现其任何部分。
+本片无导出、无持久化、无写路径、无凭据路径变更、无新路由(lock §6 零开门维持)。


### PR DESCRIPTION
## BA-UI-2 — Bridge Agent values-free 一键探测

Design-lock: `docs/development/bridge-agent-admin-page-design-lock-20260707.md` (#3792, RATIFIED; owner granted the full BA-UI ladder 2026-07-07) §3 BA-UI-2. Prior slice: BA-UI-1 = #3824. Demand anchor: #3746 (stays OPEN). Verification MD: `docs/development/bridge-agent-ui2-probe-dev-verification-20260707.md`.

Adds a per-system **一键探测 (one-click smoke)** button to the read-only Bridge Agent observability section. Runs `health → objects → schema` **sequentially** through the THREE EXISTING generic read-only endpoints BA-UI-1 already consumes — **zero new backend routes**, zero write path, zero credential-path change, zero persistence (evidence is ephemeral component state; BA-UI-3's change-suggestion flow is a later, unopened slice).

### What it does (lock §3)
- **Sequential + per-step early-stop on failure**: a failed step `return`s before the next step's service call is ever issued (a later step is simply never called).
- **Values-free evidence card**: per step `ok` (boolean) · `durationBucket` (coarse `<1s|1-5s|>5s`, never raw ms) · `objectCount` (objects step) · `fieldCount` of a single sampled object (schema step) · humanized error label + guidance line on failure. Overall `PASS | FAIL(step)`.
- **Reuses the existing values-free evidence idiom** — error label + guidance both route through the existing IU-1 `errorCodeLabels` module (`integrationErrorCodeDisplayLabel` / `integrationErrorCodeHint`); no new evidence-vocabulary module. Raw code / raw errorMessage are never rendered (BA-UI-1 discipline unchanged).
- Empty allowlist (`objectCount === 0`) → schema step marked **skipped** (not a failure), overall still PASS.

### Zero-new-route confirmation
Reuses `testExternalSystemConnection` (POST `/:id/test`), `listExternalSystemObjects` (GET `/:id/objects`), `getExternalSystemSchema` (GET `/:id/schema?object=`) — all already consumed by BA-UI-1. `POST /query/:object` (data plane) is never called (lock §4; asserted in tests). Only two files changed (component + spec) plus the verification MD; no backend, no workflow, no style-guard TARGET_FILES edits (BA-UI-1 already registered this file).

### Tests (ADD-ONLY, 6 new → 16 total)
- probe happy path: 3 ok steps + PASS + sequential endpoint order
- objects-step failure early-stops **before** schema (asserts schema fetch never fires + schema step node absent) + FAIL badge + step guidance + humanized (degraded) code
- zero-objects → schema SKIPPED, overall PASS, `/schema` never fetched
- duration buckets `<1s / 1-5s / >5s` via fake timers
- SENTINEL through the probe path (success **and** failure) — no secret-shaped string reaches the DOM
- zh copy of overall / step / guidance labels via `setLocale`

**Mutation-verified** (baseline committed first): M1 remove objects early-stop → RED; M2 leak hostile object extra key into DOM → RED. Both reverted, baseline green.

### Matrix
- `IntegrationBridgeAgentSection` spec 16/16 · integration-guard 19-spec list 229/229 · ui-foundation-style-guard 77/77 — all green on Node 25 (default) **and** Node 20 (nvm, CI version)
- `vue-tsc -b` clean · `pnpm build` (apps/web) OK

Boundary: BA-UI-3 / BA-UI-4 each need independent opt-in; not implemented here. **DO NOT MERGE** (owner review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)