### PR TITLE
feat(web): multitable UI P2-1c — migrate ConditionalFormattingDialog buttons to MtButton

### DIFF
--- a/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
@@ -108,33 +108,31 @@
               </label>
             </div>
             <div class="cf-dlg__rule-row cf-dlg__rule-row--actions">
-              <button
-                type="button"
+              <MtButton
                 class="cf-dlg__btn cf-dlg__btn--ghost"
                 :disabled="index === 0"
                 @click="moveRule(index, -1)"
-              >{{ ml('formatting.up') }}</button>
-              <button
-                type="button"
+              >{{ ml('formatting.up') }}</MtButton>
+              <MtButton
                 class="cf-dlg__btn cf-dlg__btn--ghost"
                 :disabled="index === draftRules.length - 1"
                 @click="moveRule(index, 1)"
-              >{{ ml('formatting.down') }}</button>
-              <button type="button" class="cf-dlg__btn cf-dlg__btn--danger" @click="removeRule(index)">{{ ml('action.remove') }}</button>
+              >{{ ml('formatting.down') }}</MtButton>
+              <MtButton variant="danger" class="cf-dlg__btn cf-dlg__btn--danger" @click="removeRule(index)">{{ ml('action.remove') }}</MtButton>
             </div>
           </div>
         </div>
-        <button
-          type="button"
+        <MtButton
+          variant="primary"
           class="cf-dlg__btn cf-dlg__btn--primary"
           :disabled="draftRules.length >= ruleLimit || !selectableFields.length"
           @click="addRule"
-        >{{ ml('formatting.addRule') }}</button>
+        >{{ ml('formatting.addRule') }}</MtButton>
         <p v-if="!selectableFields.length" class="cf-dlg__hint">{{ ml('formatting.noFieldsHint') }}</p>
       </div>
       <div class="cf-dlg__footer">
-        <button type="button" class="cf-dlg__btn" @click="close">{{ ml('action.cancel') }}</button>
-        <button type="button" class="cf-dlg__btn cf-dlg__btn--primary" :disabled="!dirty" @click="save">{{ ml('formatting.saveRules') }}</button>
+        <MtButton class="cf-dlg__btn" @click="close">{{ ml('action.cancel') }}</MtButton>
+        <MtButton variant="primary" class="cf-dlg__btn cf-dlg__btn--primary" :disabled="!dirty" @click="save">{{ ml('formatting.saveRules') }}</MtButton>
       </div>
     </div>
   </div>
@@ -155,6 +153,7 @@ import {
   formattingPickColor,
   managerLabel,
 } from '../utils/meta-manager-labels'
+import { MtButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -420,14 +419,10 @@ function save() {
 .cf-dlg__swatch--active { box-shadow: 0 0 0 2px #1d4ed8; }
 .cf-dlg__hex { width: 90px; padding: 3px 6px; border: 1px solid #d0d5dc; border-radius: 4px; font-size: 12px; }
 .cf-dlg__check-inline { display: flex; align-items: center; gap: 4px; font-size: 12px; color: #444; cursor: pointer; }
-.cf-dlg__btn { padding: 5px 12px; border: 1px solid #d0d5dc; border-radius: 4px; background: #fff; cursor: pointer; font-size: 12px; color: #333; }
-.cf-dlg__btn:hover:not(:disabled) { background: #f3f4f6; }
-.cf-dlg__btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.cf-dlg__btn--primary { background: #2563eb; border-color: #2563eb; color: #fff; }
-.cf-dlg__btn--primary:hover:not(:disabled) { background: #1d4ed8; }
-.cf-dlg__btn--danger { color: #b91c1c; border-color: #fecaca; }
-.cf-dlg__btn--danger:hover:not(:disabled) { background: #fef2f2; }
-.cf-dlg__btn--ghost { border-color: transparent; }
+/* .cf-dlg__btn / --primary / --danger / --ghost: all six action controls (up/down/remove/addRule/cancel/save)
+   are now <MtButton> (token-styled, variant primary/danger/ghost). The bespoke hardcoded-hex button CSS was
+   removed to avoid double-styling the MtButton root; the classes are kept on the elements only for selector
+   stability. --primary was #2563eb == --ms-color-primary, so MtButton variant="primary" is an exact match. */
 .cf-dlg__hint { font-size: 12px; color: #888; margin: 0; }
 .cf-dlg__footer { display: flex; gap: 8px; justify-content: flex-end; padding: 12px 16px; border-top: 1px solid #eee; }
 </style>

--- a/apps/web/tests/conditional-formatting-dialog-migration.spec.ts
+++ b/apps/web/tests/conditional-formatting-dialog-migration.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import ConditionalFormattingDialog from '../src/multitable/components/ConditionalFormattingDialog.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: ConditionalFormattingDialog's six SHARED-class `cf-dlg__btn` action controls
+// (per-rule up/down/remove, addRule, footer cancel/save) were migrated from bespoke <button>s to the
+// shared MtButton primitive (variant primary/danger/ghost). Because the class was shared across migrated
+// AND would-be-left buttons, ALL sharers were migrated at once and the bespoke hex CSS removed — so the
+// token primitive is not double-styled. Behavior-preservation proof: they stay native, keyboard-operable
+// <button>s; :disabled bindings survive; clicking still runs the same handlers / emits the same events.
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.cf-dlg__overlay').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(ConditionalFormattingDialog, { ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const baseProps = () => ({ visible: true, fields: [{ id: 'f1', name: 'Status', type: 'singleLineText' }], viewConfig: {} })
+const footerCancel = (r: HTMLElement) =>
+  Array.from(r.querySelectorAll('.cf-dlg__footer .cf-dlg__btn')).find((b) => !b.classList.contains('cf-dlg__btn--primary')) as HTMLButtonElement
+const footerSave = (r: HTMLElement) => r.querySelector('.cf-dlg__footer .cf-dlg__btn--primary') as HTMLButtonElement
+const addRule = (r: HTMLElement) =>
+  Array.from(r.querySelectorAll('.cf-dlg__btn--primary')).find((b) => !b.closest('.cf-dlg__footer')) as HTMLButtonElement
+
+describe('ConditionalFormattingDialog — MtButton migration (UI-P2-1c)', () => {
+  it('renders footer cancel/save + addRule as native <button>s; save disabled until dirty', () => {
+    const root = mount(baseProps())
+    expect(footerCancel(root).tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+    expect(footerSave(root).tagName).toBe('BUTTON')
+    expect(addRule(root).tagName).toBe('BUTTON')
+    expect(footerSave(root).disabled).toBe(true) // :disabled="!dirty" — clean baseline
+  })
+
+  it('clicking cancel on a clean (non-dirty) dialog emits `close` (unchanged)', () => {
+    const onClose = vi.fn()
+    const root = mount(baseProps(), { onClose })
+    footerCancel(root).click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('addRule → per-rule up/down/remove render as native buttons; save emits `save`; remove drops the rule', async () => {
+    const onSave = vi.fn()
+    const root = mount(baseProps(), { onSave })
+    addRule(root).click()
+    await nextTick()
+    const removeBtn = root.querySelector('.cf-dlg__btn--danger') as HTMLButtonElement
+    const moveBtns = root.querySelectorAll('.cf-dlg__rule-row--actions .cf-dlg__btn--ghost')
+    expect(removeBtn?.tagName).toBe('BUTTON') // danger MtButton
+    expect(moveBtns.length).toBe(2) // up + down ghost MtButtons
+    expect(Array.from(moveBtns).every((b) => b.tagName === 'BUTTON')).toBe(true)
+    expect(footerSave(root).disabled).toBe(false) // adding a rule made it dirty → :disabled binding preserved
+    footerSave(root).click()
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(Array.isArray(onSave.mock.calls[0][0])).toBe(true)
+    expect(onSave.mock.calls[0][0].length).toBe(1) // the rule we added
+    removeBtn.click() // @click="removeRule(index)" preserved
+    await nextTick()
+    expect(root.querySelector('.cf-dlg__btn--danger')).toBeNull() // rule row gone
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only; SHARED-class → migrate all sharers at once). All six `cf-dlg__btn` controls (up/down=ghost, remove=danger, addRule/save=primary, cancel=ghost) → MtButton; bespoke hex CSS removed (no double-styling; `--primary` was #2563eb == `--ms-color-primary`). `@click`/`:disabled` + `emit('close'/'save')` byte-identical. Mount test (3/3): native buttons + save-disabled-until-dirty + cancel-emits-close + addRule/remove flow + save-emits-rules. vue-tsc clean; no new hex; existing CF specs (25+i18n) green.

Done in the main loop (workflow migrate agents were hitting API stalls). Gated by adversarial-reviewer next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)