### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaTemplateCard detail/install to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaTemplateCard.vue
+++ b/apps/web/src/multitable/components/MetaTemplateCard.vue
@@ -20,22 +20,21 @@
     <div class="meta-template-card__actions">
       <!-- S2: opt-in detail entry (template center only); other consumers
            (home view, workbench modal) keep the install-only card. -->
-      <button
+      <MtButton
         v-if="showDetail"
-        type="button"
         class="meta-template-card__detail"
         @click="emit('detail', template)"
       >
         {{ workbenchLabel('card.viewDetail', isZh) }}
-      </button>
-      <button
-        type="button"
+      </MtButton>
+      <MtButton
+        variant="primary"
         class="meta-template-card__install"
         :disabled="installing"
         @click="emit('install', template)"
       >
         {{ installing ? workbenchLabel('card.installing', isZh) : workbenchLabel('card.install', isZh) }}
-      </button>
+      </MtButton>
     </div>
   </article>
 </template>
@@ -51,6 +50,7 @@ import {
   cardViews,
   workbenchLabel,
 } from '../utils/workbench-labels'
+import { MtButton } from '../ui'
 
 const props = defineProps<{
   template: MetaTemplate
@@ -145,40 +145,12 @@ const viewCount = computed(() => {
   gap: 0.5rem;
 }
 
-.meta-template-card__detail {
-  border: 1px solid #cbd5e1;
-  background: #ffffff;
-  color: #0f172a;
-  border-radius: 8px;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.meta-template-card__detail:hover {
-  border-color: #94a3b8;
-}
-
+/* .meta-template-card__detail / __install: the two action controls are now <MtButton> (detail = ghost,
+   install = variant="primary"; the bespoke #2563eb == --ms-color-primary). Their bespoke hardcoded-hex
+   button CSS was removed to avoid double-styling the MtButton root. Only the install control's LAYOUT
+   property (flex: it stretches to fill the actions row) is kept — MtButton doesn't provide it. Classes
+   kept for selector stability. */
 .meta-template-card__install {
   flex: 1 1 auto;
-  border: 1px solid #2563eb;
-  background: #2563eb;
-  color: #ffffff;
-  border-radius: 8px;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.meta-template-card__install:disabled {
-  opacity: 0.6;
-  cursor: progress;
-}
-
-.meta-template-card__install:hover:not(:disabled) {
-  background: #1d4ed8;
-  border-color: #1d4ed8;
 }
 </style>

--- a/apps/web/tests/meta-template-card-migration.spec.ts
+++ b/apps/web/tests/meta-template-card-migration.spec.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaTemplateCard from '../src/multitable/components/MetaTemplateCard.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaTemplateCard's two card action controls (detail = ghost, install = variant="primary")
+// were migrated from bespoke <button>s to the shared MtButton primitive. Their classes are unique (not
+// shared), so the bespoke hex CSS was removed; only the install control's layout `flex: 1 1 auto` is kept.
+// Behavior-preservation proof: both stay native, keyboard-operable <button>s; the install :disabled binding
+// survives; clicking still emits the SAME detail/install events with the SAME template payload.
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-template-card').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+const template = {
+  id: 't1', name: 'CRM Template', description: 'A CRM starter', category: 'sales', icon: '📊', color: '#2563eb',
+  sheets: [{ id: 's1', name: 'Contacts', fields: [], views: [] }],
+}
+
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(MetaTemplateCard, { template, ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const detailBtn = (r: HTMLElement) => r.querySelector('.meta-template-card__detail') as HTMLButtonElement | null
+const installBtn = (r: HTMLElement) => r.querySelector('.meta-template-card__install') as HTMLButtonElement
+
+describe('MetaTemplateCard — MtButton migration (UI-P2-1c)', () => {
+  it('renders detail + install as native <button>s; install disabled while installing', () => {
+    const root = mount({ showDetail: true, installing: true })
+    expect(detailBtn(root)!.tagName).toBe('BUTTON') // keyboard-operable
+    expect(installBtn(root).tagName).toBe('BUTTON')
+    expect(installBtn(root).disabled).toBe(true) // :disabled="installing" preserved
+  })
+
+  it('clicking detail emits `detail` with the template (unchanged)', () => {
+    const onDetail = vi.fn()
+    const root = mount({ showDetail: true }, { onDetail })
+    detailBtn(root)!.click()
+    expect(onDetail).toHaveBeenCalledTimes(1)
+    expect(onDetail.mock.calls[0][0]).toBe(template)
+  })
+
+  it('clicking install emits `install` with the template (unchanged)', () => {
+    const onInstall = vi.fn()
+    const root = mount({}, { onInstall }) // showDetail defaults falsy → detail hidden, install always present
+    expect(detailBtn(root)).toBeNull()
+    installBtn(root).click()
+    expect(onInstall).toHaveBeenCalledTimes(1)
+    expect(onInstall.mock.calls[0][0]).toBe(template)
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, unique-class). detail → MtButton ghost, install → variant=primary (#2563eb == --ms-color-primary). Bespoke hex CSS removed; kept only install's `flex: 1 1 auto` layout. `@click=emit(detail/install, template)` + `:disabled=installing` byte-identical. Mount test (3/3): native buttons + install-disabled + detail/install emit-payload parity. vue-tsc clean; no new hex.

Done in the main loop (workflow migrate agents hitting API stalls). Gated by adversarial-reviewer next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)