### PR TITLE
feat(web): multitable UI P2-1c — migrate ScaleFormattingDialog buttons to MtButton

### DIFF
--- a/apps/web/src/multitable/components/ScaleFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ScaleFormattingDialog.vue
@@ -133,7 +133,7 @@
                     maxlength="9"
                   />
                 </div>
-                <button type="button" class="scf-dlg__btn scf-dlg__btn--ghost" @click="rule.hasMid = false">{{ ml('formatting.scaleDropMidStop') }}</button>
+                <MtButton class="scf-dlg__btn scf-dlg__btn--ghost" @click="rule.hasMid = false">{{ ml('formatting.scaleDropMidStop') }}</MtButton>
               </div>
               <div class="scf-dlg__rule-row">
                 <span class="scf-dlg__label">{{ ml('formatting.scaleStopMax') }}</span>
@@ -159,7 +159,7 @@
                 </div>
               </div>
               <div v-if="!rule.hasMid" class="scf-dlg__rule-row">
-                <button type="button" class="scf-dlg__btn scf-dlg__btn--ghost" @click="rule.hasMid = true">{{ ml('formatting.scaleAddMidStop') }}</button>
+                <MtButton class="scf-dlg__btn scf-dlg__btn--ghost" @click="rule.hasMid = true">{{ ml('formatting.scaleAddMidStop') }}</MtButton>
               </div>
               <div class="scf-dlg__rule-row">
                 <span class="scf-dlg__label">{{ ml('formatting.scalePreview') }}</span>
@@ -247,22 +247,22 @@
             <p v-else-if="rule.rangeMode === 'auto'" class="scf-dlg__hint">{{ ml('formatting.scaleAutoRangeHint') }}</p>
 
             <div class="scf-dlg__rule-row scf-dlg__rule-row--actions">
-              <button type="button" class="scf-dlg__btn scf-dlg__btn--danger" @click="removeRule(index)">{{ ml('action.remove') }}</button>
+              <MtButton variant="danger" class="scf-dlg__btn scf-dlg__btn--danger" @click="removeRule(index)">{{ ml('action.remove') }}</MtButton>
             </div>
           </div>
         </div>
-        <button
-          type="button"
+        <MtButton
+          variant="primary"
           class="scf-dlg__btn scf-dlg__btn--primary"
           :disabled="!canAddRule"
           @click="addRule"
-        >{{ ml('formatting.scaleAddRule') }}</button>
+        >{{ ml('formatting.scaleAddRule') }}</MtButton>
         <p v-if="!numericFields.length" class="scf-dlg__hint">{{ ml('formatting.scaleNoFieldsHint') }}</p>
         <p v-else-if="!availableFields.length" class="scf-dlg__hint">{{ ml('formatting.scaleAllFieldsUsedHint') }}</p>
       </div>
       <div class="scf-dlg__footer">
-        <button type="button" class="scf-dlg__btn" @click="close">{{ ml('action.cancel') }}</button>
-        <button type="button" class="scf-dlg__btn scf-dlg__btn--primary" :disabled="!dirty || hasInvalidRule" @click="save">{{ ml('formatting.saveRules') }}</button>
+        <MtButton class="scf-dlg__btn" @click="close">{{ ml('action.cancel') }}</MtButton>
+        <MtButton variant="primary" class="scf-dlg__btn scf-dlg__btn--primary" :disabled="!dirty || hasInvalidRule" @click="save">{{ ml('formatting.saveRules') }}</MtButton>
       </div>
     </div>
   </div>
@@ -282,6 +282,7 @@ import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../types'
 import { HEX_COLOR_RE, extractScaleRulesFromConfig, lerpHexColor } from '../utils/conditional-formatting'
 import { SCALE_ICON_GLYPHS, type ScaleIconGlyph } from '../utils/scale-icons'
 import { formattingPickColor, managerLabel } from '../utils/meta-manager-labels'
+import { MtButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -573,13 +574,10 @@ function save() {
 .scf-dlg__icon-glyph { font-size: 16px; font-weight: 700; }
 .scf-dlg__error { font-size: 12px; color: #b91c1c; margin: 0; }
 .scf-dlg__hint { font-size: 12px; color: #888; margin: 0; }
-.scf-dlg__btn { padding: 5px 12px; border: 1px solid #d0d5dc; border-radius: 4px; background: #fff; cursor: pointer; font-size: 12px; color: #333; }
-.scf-dlg__btn:hover:not(:disabled) { background: #f3f4f6; }
-.scf-dlg__btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.scf-dlg__btn--primary { background: #2563eb; border-color: #2563eb; color: #fff; }
-.scf-dlg__btn--primary:hover:not(:disabled) { background: #1d4ed8; }
-.scf-dlg__btn--danger { color: #b91c1c; border-color: #fecaca; }
-.scf-dlg__btn--danger:hover:not(:disabled) { background: #fef2f2; }
-.scf-dlg__btn--ghost { border-color: transparent; }
+/* .scf-dlg__btn / --primary / --danger / --ghost: all six action controls (per-rule drop/add-mid-stop,
+   remove, addRule, footer cancel/save) are now <MtButton> (token-styled, variant primary/danger/ghost).
+   The bespoke hardcoded-hex button CSS was removed to avoid double-styling the MtButton root; classes kept
+   for selector stability. --primary was #2563eb == --ms-color-primary (exact match). Mirrors the
+   ConditionalFormattingDialog shared-class migration. */
 .scf-dlg__footer { display: flex; gap: 8px; justify-content: flex-end; padding: 12px 16px; border-top: 1px solid #eee; }
 </style>

--- a/apps/web/tests/scale-formatting-dialog-migration.spec.ts
+++ b/apps/web/tests/scale-formatting-dialog-migration.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import ScaleFormattingDialog from '../src/multitable/components/ScaleFormattingDialog.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: ScaleFormattingDialog's six SHARED-class `scf-dlg__btn` action controls (per-rule
+// drop/add-mid-stop + remove, addRule, footer cancel/save) were migrated from bespoke <button>s to the
+// shared MtButton primitive (variant primary/danger/ghost). Because the class was shared, ALL sharers were
+// migrated at once and the bespoke hex CSS removed (no double-styling) — mirrors ConditionalFormattingDialog.
+// Behavior-preservation proof: they stay native, keyboard-operable <button>s; :disabled bindings survive;
+// clicking still runs the same handlers / emits the same events.
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.scf-dlg__overlay').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+const baseProps = () => ({ visible: true, fields: [{ id: 'f1', name: 'Score', type: 'number' }], viewConfig: {} })
+function mount(props: Record<string, unknown>, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(ScaleFormattingDialog, { ...props, ...handlers }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+const footerCancel = (r: HTMLElement) =>
+  Array.from(r.querySelectorAll('.scf-dlg__footer .scf-dlg__btn')).find((b) => !b.classList.contains('scf-dlg__btn--primary')) as HTMLButtonElement
+const footerSave = (r: HTMLElement) => r.querySelector('.scf-dlg__footer .scf-dlg__btn--primary') as HTMLButtonElement
+const addRuleBtn = (r: HTMLElement) =>
+  Array.from(r.querySelectorAll('.scf-dlg__btn--primary')).find((b) => !b.closest('.scf-dlg__footer')) as HTMLButtonElement
+
+describe('ScaleFormattingDialog — MtButton migration (UI-P2-1c)', () => {
+  it('renders footer cancel/save + addRule as native <button>s; save disabled until a valid dirty rule', () => {
+    const root = mount(baseProps())
+    expect(footerCancel(root).tagName).toBe('BUTTON') // keyboard-operable
+    expect(footerSave(root).tagName).toBe('BUTTON')
+    expect(addRuleBtn(root).tagName).toBe('BUTTON')
+    expect(footerSave(root).disabled).toBe(true) // :disabled="!dirty || hasInvalidRule" — clean baseline
+  })
+
+  it('clicking cancel on a clean (non-dirty) dialog emits `close` (unchanged)', () => {
+    const onClose = vi.fn()
+    const root = mount(baseProps(), { onClose })
+    footerCancel(root).click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('addRule → per-rule remove renders as a native button; save emits `save`; remove drops the rule', async () => {
+    const onSave = vi.fn()
+    const root = mount(baseProps(), { onSave })
+    addRuleBtn(root).click() // pushes a valid default dataBar rule → dirty, not invalid
+    await nextTick()
+    const removeBtn = root.querySelector('.scf-dlg__btn--danger') as HTMLButtonElement
+    expect(removeBtn?.tagName).toBe('BUTTON') // danger MtButton
+    expect(footerSave(root).disabled).toBe(false) // dirty + valid → :disabled binding preserved
+    footerSave(root).click()
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(Array.isArray(onSave.mock.calls[0][0])).toBe(true)
+    expect(onSave.mock.calls[0][0].length).toBe(1)
+    removeBtn.click() // @click="removeRule(index)" preserved
+    await nextTick()
+    expect(root.querySelector('.scf-dlg__btn--danger')).toBeNull() // rule row gone
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only; SHARED-class → migrate all sharers, mirrors CF #3842). All six `scf-dlg__btn` controls → MtButton (drop/add-mid + cancel = ghost, remove = danger, addRule/save = primary); bespoke hex CSS removed (no double-styling; `--primary` == `--ms-color-primary`). `@click`/`:disabled` + `emit('close'/'save')` byte-identical. Mount test (3/3): native buttons + save-disabled-until-valid-dirty + cancel-emits-close + addRule/remove flow + save-emits-rules. vue-tsc clean; no new hex; existing scale-formatting-dialog (14) green.

Main-loop migration (workflow agents were API-stalling). Gated by adversarial-reviewer next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)