### PR TITLE
feat(web): IU-5b optionSets structured editor — repeatable rows + expert-JSON fallback (design-lock #3739)

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -48,6 +48,10 @@ on:
       - 'apps/web/src/components/integration/IntegrationExternalWritePanel.vue'
       - 'apps/web/src/components/integration/IntegrationTableActionsPanel.vue'
       - 'apps/web/src/components/integration/IntegrationFieldOptionSyncPanel.vue'
+      - 'apps/web/src/components/integration/IntegrationOptionSetsStructuredEditor.vue'
+      - 'apps/web/src/components/integration/JsonAssist.vue'
+      - 'apps/web/src/utils/jsonAssist.ts'
+      - 'apps/web/src/utils/optionSetsStructured.ts'
       - 'apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts'
       - 'apps/web/src/components/integration/JsonAssist.vue'
       - 'apps/web/src/utils/jsonAssist.ts'
@@ -80,6 +84,8 @@ on:
       - 'apps/web/tests/IntegrationExternalWritePanel.spec.ts'
       - 'apps/web/tests/IntegrationTableActionsPanel.spec.ts'
       - 'apps/web/tests/IntegrationFieldOptionSyncPanel.spec.ts'
+      - 'apps/web/tests/IntegrationOptionSetsStructuredEditor.spec.ts'
+      - 'apps/web/tests/utils/optionSetsStructured.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - 'apps/web/tests/JsonAssist.spec.ts'
@@ -113,6 +119,10 @@ on:
       - 'apps/web/src/components/integration/IntegrationExternalWritePanel.vue'
       - 'apps/web/src/components/integration/IntegrationTableActionsPanel.vue'
       - 'apps/web/src/components/integration/IntegrationFieldOptionSyncPanel.vue'
+      - 'apps/web/src/components/integration/IntegrationOptionSetsStructuredEditor.vue'
+      - 'apps/web/src/components/integration/JsonAssist.vue'
+      - 'apps/web/src/utils/jsonAssist.ts'
+      - 'apps/web/src/utils/optionSetsStructured.ts'
       - 'apps/web/src/components/integration/integrationWorkbenchSectionTypes.ts'
       - 'apps/web/src/components/integration/JsonAssist.vue'
       - 'apps/web/src/utils/jsonAssist.ts'
@@ -145,6 +155,8 @@ on:
       - 'apps/web/tests/IntegrationExternalWritePanel.spec.ts'
       - 'apps/web/tests/IntegrationTableActionsPanel.spec.ts'
       - 'apps/web/tests/IntegrationFieldOptionSyncPanel.spec.ts'
+      - 'apps/web/tests/IntegrationOptionSetsStructuredEditor.spec.ts'
+      - 'apps/web/tests/utils/optionSetsStructured.spec.ts'
       - 'apps/web/tests/IntegrationK3WiseSetupView.spec.ts'
       - 'apps/web/tests/IntegrationHelpView.spec.ts'
       - 'apps/web/tests/JsonAssist.spec.ts'
@@ -201,4 +213,4 @@ jobs:
       # Consolidated here into the SINGLE unioned list (verified green on both Node 20 and this repo's
       # default Node before landing) — do not reintroduce a second `run:` key; add new specs to this one.
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck IntegrationOptionSetsStructuredEditor optionSetsStructured --reporter=dot

--- a/apps/web/src/components/integration/IntegrationFieldOptionSyncPanel.vue
+++ b/apps/web/src/components/integration/IntegrationFieldOptionSyncPanel.vue
@@ -15,13 +15,46 @@
         </option>
       </select>
     </label>
-    <label>
+    <div class="integration-workbench__inline-field integration-workbench__mode-toggle">
+      <span>{{ bi('编辑模式', 'Edit mode') }}</span>
+      <button
+        type="button"
+        class="integration-workbench__button"
+        data-testid="field-options-mode-toggle"
+        :disabled="mode === 'expert' && !isCurrentTextStructurable"
+        @click="toggleMode"
+      >
+        {{ mode === 'structured'
+          ? bi('切换到专家 JSON', 'Switch to expert JSON')
+          : bi('切换到结构化编辑', 'Switch to structured editor') }}
+      </button>
+    </div>
+    <p
+      v-if="mode === 'expert' && !isCurrentTextStructurable"
+      class="integration-workbench__hint"
+      data-testid="field-options-structured-unavailable-hint"
+    >
+      {{ bi(
+        '当前内容不是结构化编辑器支持的字段选项形状（例如包含 optionSources/configInfo，或选项缺少 value/label），已使用专家 JSON 模式；修正为受支持的形状后可切换回结构化编辑。',
+        'The current content is not a shape the structured editor supports (e.g. it carries optionSources/configInfo, or an option is missing value/label) — using expert JSON mode; fix it to a supported shape to switch back to the structured editor.',
+      ) }}
+    </p>
+    <IntegrationOptionSetsStructuredEditor
+      v-if="mode === 'structured'"
+      v-model="stockPreparationOptionSyncText"
+    />
+    <label v-show="mode === 'expert'">
       <span>optionSets JSON</span>
       <textarea
         v-model="stockPreparationOptionSyncText"
         data-testid="stock-option-sync-json"
         rows="8"
         :placeholder="stockPreparationOptionSyncPlaceholder"
+      />
+      <JsonAssist
+        v-model="stockPreparationOptionSyncText"
+        test-id="stock-option-sync-json"
+        :placeholder-example="stockPreparationOptionSyncPlaceholder"
       />
     </label>
     <p class="integration-workbench__hint" data-testid="stock-option-sync-boundary">
@@ -54,8 +87,30 @@
 // stage D — `int-sec-run-push` decomposition): field-option-sync panel, one of five focused
 // sub-panels the prior monolithic `int-sec-run-push` section bundled. Pure template/markup move —
 // no state or service-call logic lives here. The `optionSets JSON` textarea
-// (`data-testid="stock-option-sync-json"`) is kept exactly as a raw JSON textarea — structuring it
-// is IU-5's job (§2 IU-5, gated on IU-2 landing), not this slice's.
+// (`data-testid="stock-option-sync-json"`) was originally kept exactly as a raw JSON textarea —
+// structuring it was IU-5's job (§2 IU-5, gated on IU-2 landing); D2 (below) is that slice.
+//
+// D2 (site 5 of IU-5, gated on IU-2 landing + this panel's own landing #3822): the raw textarea
+// is now the EXPERT fallback (`mode === 'expert'`) beside a default structured
+// (repeatable-row) editor (`mode === 'structured'`). Zero backend/service change either way — both
+// modes write the SAME `stockPreparationOptionSyncText` model the parent already owns and
+// `syncFieldOptions` already reads; see `../../utils/optionSetsStructured.ts` for the
+// structured<->JSON contract and closed-shape rules.
+//
+// The expert-mode `<label>` block uses `v-show` (not `v-if`) — the textarea and its
+// `data-testid="stock-option-sync-json"` must stay reachable in the DOM at all times (an existing
+// spec pins `querySelector(...)` finding it as a `TEXTAREA` unconditionally; `v-show` only toggles
+// CSS display, so that assertion needed zero changes). The structured editor uses `v-if` instead
+// (cheaper: it only needs to parse the current text once, at the moment the user switches into
+// structured mode — see that component's own header comment on why a remount-on-toggle beats a
+// reactive text->rows watcher for avoiding an edit feedback loop).
+//
+// Mode defaults to `structured` unless the initial text isn't structurable (`parseOptionSets`
+// fails), in which case it starts in `expert` so nothing existing is ever hidden behind a broken
+// toggle. Switching FROM expert TO structured re-checks structurability live (the user may have
+// hand-edited the textarea) and is blocked (button disabled + a values-free hint) when the current
+// text doesn't parse into the closed shape — switching FROM structured TO expert is always
+// allowed (structured edits always produce valid, structurable JSON).
 //
 // Same permission-gate note as `IntegrationStockPrepPanel.vue`: the `integration:admin` gate
 // stays on this block's own root `v-if` exactly where the pre-extraction markup had it, driven by
@@ -65,6 +120,12 @@
 //
 // FOS-3: only the stock-preparation preset is wired today (see the view's own comment above
 // `fieldOptionSyncPresets`); this local type mirrors that `as const` array's element shape.
+import { computed, ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import { parseOptionSets } from '../../utils/optionSetsStructured'
+import JsonAssist from './JsonAssist.vue'
+import IntegrationOptionSetsStructuredEditor from './IntegrationOptionSetsStructuredEditor.vue'
+
 interface FieldOptionSyncPreset {
   presetId: string
   label: string
@@ -83,11 +144,51 @@ defineProps<{
 
 const fieldOptionSyncPresetId = defineModel<string>('fieldOptionSyncPresetId', { default: '' })
 const stockPreparationOptionSyncText = defineModel<string>('stockPreparationOptionSyncText', { default: '' })
+
+const { locale } = useLocale()
+
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+// Initial mode is decided ONCE, from the model's value at mount — never re-derived reactively off
+// `stockPreparationOptionSyncText` (that would fight in-progress structured-mode edits). Defaults
+// to structured unless the starting text isn't structurable, so nothing existing lands behind a
+// broken toggle.
+const mode = ref<'structured' | 'expert'>(
+  parseOptionSets(stockPreparationOptionSyncText.value).ok ? 'structured' : 'expert',
+)
+
+// Read live only while in expert mode, to gate the toggle button (whether switching BACK to
+// structured is currently safe) and the unavailable hint — this is a read-only status check, not
+// a rebuild of any editor state, so it carries none of the text->rows loop risk.
+const isCurrentTextStructurable = computed(() => parseOptionSets(stockPreparationOptionSyncText.value).ok)
+
+function toggleMode(): void {
+  if (mode.value === 'structured') {
+    mode.value = 'expert'
+    return
+  }
+  if (!isCurrentTextStructurable.value) return
+  mode.value = 'structured'
+}
 </script>
 
 <style scoped>
 /* Verbatim copies (selectively trimmed to the tags/classes this component actually renders) of
    the rules in IntegrationWorkbenchView.vue's <style scoped> block that target this markup. */
+
+/* D2: mode-toggle row (new, not carried over from the pre-D2 markup). */
+.integration-workbench__mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-2);
+  margin-top: var(--ms-space-2);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ms-text-1);
+}
+
 .integration-workbench__table-action {
   margin: 16px 0;
   padding: 14px;

--- a/apps/web/src/components/integration/IntegrationOptionSetsStructuredEditor.vue
+++ b/apps/web/src/components/integration/IntegrationOptionSetsStructuredEditor.vue
@@ -1,0 +1,329 @@
+<template>
+  <div class="option-sets-editor" data-testid="option-sets-structured-editor">
+    <p v-if="rows.length === 0" class="option-sets-editor__hint" data-testid="option-sets-empty-hint">
+      {{ bi('还没有字段；点击"新增字段"开始（示例：字段名 material_type，选项 value=plate / label=Plate）。',
+            'No fields yet — click "Add field" to start (example: field material_type, option value=plate / label=Plate).') }}
+    </p>
+    <p v-if="duplicateFieldKeys.length > 0" class="option-sets-editor__hint option-sets-editor__hint--warning" data-testid="option-sets-duplicate-warning">
+      {{ bi('存在重复字段名，序列化时只会保留同名的最后一行；请修改字段名以避免遗漏数据。',
+            'Duplicate field names detected — only the last row with a given name is kept on serialize; rename to avoid losing data.') }}
+    </p>
+    <div class="option-sets-editor__rows">
+      <div v-for="(row, rowIndex) in rows" :key="row.id" class="option-sets-editor__row" :data-testid="`option-sets-row-${rowIndex}`">
+        <div class="option-sets-editor__row-head">
+          <label class="option-sets-editor__field-key">
+            <span>{{ bi('字段名', 'Field key') }}</span>
+            <input
+              :value="row.fieldKey"
+              type="text"
+              :placeholder="bi('例如 material_type', 'e.g. material_type')"
+              :data-testid="`option-sets-row-key-${rowIndex}`"
+              @input="onFieldKeyInput(row, $event)"
+            />
+          </label>
+          <button
+            type="button"
+            class="integration-workbench__icon-button"
+            :data-testid="`option-sets-row-remove-${rowIndex}`"
+            @click="removeRow(rowIndex)"
+          >
+            {{ bi('删除字段', 'Remove field') }}
+          </button>
+        </div>
+        <div class="option-sets-editor__options">
+          <div
+            v-for="(option, optionIndex) in row.options"
+            :key="option.id"
+            class="option-sets-editor__option"
+            :data-testid="`option-sets-option-${rowIndex}-${optionIndex}`"
+          >
+            <label>
+              <span>value</span>
+              <input
+                :value="option.entry.value"
+                type="text"
+                :placeholder="bi('例如 plate', 'e.g. plate')"
+                :data-testid="`option-sets-option-value-${rowIndex}-${optionIndex}`"
+                @input="onOptionFieldInput(option, 'value', $event)"
+              />
+            </label>
+            <label>
+              <span>label</span>
+              <input
+                :value="option.entry.label"
+                type="text"
+                :placeholder="bi('例如 Plate', 'e.g. Plate')"
+                :data-testid="`option-sets-option-label-${rowIndex}-${optionIndex}`"
+                @input="onOptionFieldInput(option, 'label', $event)"
+              />
+            </label>
+            <button
+              type="button"
+              class="integration-workbench__icon-button"
+              :data-testid="`option-sets-option-remove-${rowIndex}-${optionIndex}`"
+              @click="removeOption(row, optionIndex)"
+            >
+              {{ bi('删除选项', 'Remove') }}
+            </button>
+          </div>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            :data-testid="`option-sets-option-add-${rowIndex}`"
+            @click="addOption(row)"
+          >
+            {{ bi('新增选项', 'Add option') }}
+          </button>
+        </div>
+      </div>
+    </div>
+    <button type="button" class="integration-workbench__button" data-testid="option-sets-add-row" @click="addRow">
+      {{ bi('新增字段', 'Add field') }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+// D2 (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-5, site 5):
+// repeatable-row structured editor for the `optionSets JSON` textarea in
+// `IntegrationFieldOptionSyncPanel.vue`. Mounted with `v-if` (not `v-show`) by the parent — every
+// time the parent switches INTO structured mode this component is freshly created, so parsing the
+// current model text happens exactly once, at setup, from the parent's live text at that moment
+// (never via a reactive text->rows watcher, which would fight in-progress row edits / create an
+// update loop). The parent is responsible for only mounting this component when
+// `parseOptionSets` on the current text succeeds (`ok: true`) — see that module's header comment
+// for the closed-shape contract this editor structures.
+//
+// Data flow is one-way-at-a-time: user edits (add/remove row, add/remove option, or an input's
+// own `@input`) synchronously rebuild the JSON text via `serializeOptionSets` and emit
+// `update:modelValue` — the parent's shared model (and therefore the sibling expert-mode textarea,
+// the run button's can-run gate, etc.) stays live-in-sync exactly like the plain textarea used to
+// behave. This component never reads `props.modelValue` again after the initial parse — the
+// parent owns "is the current text still structurable" via its own `parseOptionSets` check for
+// the mode-toggle gate.
+//
+// Existing option entries are carried through by REFERENCE (not cloned) and mutated in place
+// (`option.entry.value = ...`) so any key beyond `value`/`label` (e.g. `actionBindings`) and the
+// original per-entry key order survive edits untouched — see optionSetsStructured.ts's header.
+import { reactive, ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import {
+  findDuplicateFieldKeys,
+  parseOptionSets,
+  serializeOptionSets,
+  type OptionSetsOptionEntry,
+} from '../../utils/optionSetsStructured'
+
+const props = defineProps<{
+  modelValue: string
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const { locale } = useLocale()
+
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+interface UiOption {
+  id: number
+  entry: OptionSetsOptionEntry
+}
+
+interface UiRow {
+  id: number
+  fieldKey: string
+  options: UiOption[]
+}
+
+let nextId = 0
+
+// Defensive fallback only — the parent gates mounting on `parseOptionSets(...).ok === true`, so
+// this branch should be unreachable in normal use. Never throw on unexpected input; degrade to a
+// fresh empty wrapped document instead (an empty structured editor is a safe, visible state; a
+// thrown error would blank the whole panel).
+const initialParse = parseOptionSets(props.modelValue)
+const wrapped = initialParse.ok ? initialParse.wrapped : true
+const originalRecord = initialParse.ok ? initialParse.originalRecord : {}
+const initialRows = initialParse.ok ? initialParse.rows : []
+
+const rows = reactive<UiRow[]>(
+  initialRows.map((row) => ({
+    id: nextId++,
+    fieldKey: row.fieldKey,
+    options: row.options.map((entry) => ({ id: nextId++, entry })),
+  })),
+)
+
+const duplicateFieldKeys = ref<string[]>(findDuplicateFieldKeys(toFieldRows()))
+
+function toFieldRows() {
+  return rows.map((row) => ({
+    fieldKey: row.fieldKey,
+    options: row.options.map((option) => option.entry),
+  }))
+}
+
+function handleEdit(): void {
+  duplicateFieldKeys.value = findDuplicateFieldKeys(toFieldRows())
+  emit('update:modelValue', serializeOptionSets(toFieldRows(), wrapped, originalRecord))
+}
+
+function addRow(): void {
+  rows.push({ id: nextId++, fieldKey: '', options: [] })
+  handleEdit()
+}
+
+function removeRow(index: number): void {
+  rows.splice(index, 1)
+  handleEdit()
+}
+
+function addOption(row: UiRow): void {
+  row.options.push({ id: nextId++, entry: { value: '', label: '' } })
+  handleEdit()
+}
+
+function removeOption(row: UiRow, index: number): void {
+  row.options.splice(index, 1)
+  handleEdit()
+}
+
+// Explicit `:value` + `@input` (rather than `v-model` alongside a second `@input` listener on the
+// same element) so the mutate-then-serialize ordering is unambiguous — a single handler mutates
+// the reactive field and THEN reads `rows` to serialize, with no dependency on how Vue would merge
+// two separate `input` listeners on one element.
+function onFieldKeyInput(row: UiRow, event: Event): void {
+  row.fieldKey = (event.target as HTMLInputElement).value
+  handleEdit()
+}
+
+function onOptionFieldInput(option: UiOption, field: 'value' | 'label', event: Event): void {
+  option.entry[field] = (event.target as HTMLInputElement).value
+  handleEdit()
+}
+</script>
+
+<style scoped>
+.option-sets-editor {
+  display: grid;
+  gap: var(--ms-space-2);
+  margin-top: var(--ms-space-2);
+}
+
+.option-sets-editor__hint {
+  margin: 0;
+  color: var(--ms-text-2);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.option-sets-editor__hint--warning {
+  color: var(--ms-color-danger);
+  font-weight: 700;
+}
+
+.option-sets-editor__rows {
+  display: grid;
+  gap: 10px;
+}
+
+.option-sets-editor__row {
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-sm);
+  background: var(--ms-bg-card);
+  padding: 10px 12px;
+}
+
+.option-sets-editor__row-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.option-sets-editor__field-key {
+  display: grid;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--ms-text-1);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.option-sets-editor__field-key input {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+  padding: 6px 8px;
+  color: var(--ms-text-1);
+  font: inherit;
+  font-weight: 700;
+}
+
+.option-sets-editor__options {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.option-sets-editor__option {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 8px;
+}
+
+.option-sets-editor__option label {
+  display: grid;
+  gap: 4px;
+  color: var(--ms-text-2);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.option-sets-editor__option input {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+  padding: 6px 8px;
+  color: var(--ms-text-1);
+  font: inherit;
+}
+
+.integration-workbench__button,
+.integration-workbench__icon-button {
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  cursor: pointer;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.integration-workbench__button {
+  padding: 8px 12px;
+  justify-self: start;
+}
+
+.integration-workbench__icon-button {
+  padding: 6px 8px;
+  flex-shrink: 0;
+}
+
+.integration-workbench__button:hover,
+.integration-workbench__icon-button:hover {
+  border-color: var(--ms-color-primary);
+}
+
+@media (max-width: 900px) {
+  .option-sets-editor__option {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/apps/web/src/utils/optionSetsStructured.ts
+++ b/apps/web/src/utils/optionSetsStructured.ts
@@ -1,0 +1,146 @@
+// D2 (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-5, site 5
+// — "结构化编辑器" disposition, gated on IU-2 landing + IntegrationFieldOptionSyncPanel landing
+// (#3822)): pure parse/serialize logic for the `optionSets JSON` textarea's structured
+// (repeatable-row) view. Kept framework-agnostic and separate from the Vue component so the
+// structured<->JSON contract is directly unit-testable without mounting anything — this is the
+// module the byte-equivalence tests exercise.
+//
+// CLOSED-SHAPE contract this module structures (the "closed shape" the design-lock's main-loop
+// disposition calls out, unlike sites 1-4's open/free-form JSON):
+//   { [fieldKey: string]: Array<{ value: string; label: string; ...extra }> }
+// optionally wrapped as `{ optionSets: <that map>, ...otherTopLevelKeys }` (the shape
+// `IntegrationWorkbenchView.vue`'s `stockPreparationOptionSyncPlaceholder` and
+// `buildStockPreparationOptionSyncPayload` already recognize — see that view's
+// `payloadCarriesActionBindings` for why per-option `actionBindings` must round-trip untouched:
+// they are a real, supported field this editor does not offer row UI for, but must never drop).
+//
+// Anything outside this closed shape — invalid JSON, a non-object document, the legacy
+// `optionSources`/`configInfo` alias keys (a different data model the stock-preparation
+// compatibility route still accepts), a field whose value isn't an array, or an array element
+// that isn't a plain `{ value: string, label: string, ... }` object — is deliberately NOT
+// structurable: `parseOptionSets` returns `{ ok: false }` and the caller must fall back to the
+// expert JSON textarea, verbatim, rather than guess/coerce/drop anything (never silent data loss).
+//
+// Byte-equivalence design: `parseOptionSets` never clones option entries — it hands back the
+// SAME parsed objects (`OptionSetsOptionEntry`), so any keys beyond `value`/`label` (e.g.
+// `actionBindings`) and their original key order survive untouched as long as the caller mutates
+// `.value`/`.label` in place instead of rebuilding entries. `serializeOptionSets` reproduces the
+// original top-level key order for the wrapped shape by spreading `originalRecord` before
+// re-assigning `optionSets` (a JS object-literal duplicate-key re-assignment keeps the key's
+// FIRST position, only updating its value — see the module's own test file for a pinned case).
+
+export interface OptionSetsOptionEntry {
+  value: string
+  label: string
+  // Preserved-but-not-editable-here extra keys (e.g. `actionBindings`). Indexed access is typed
+  // `unknown` deliberately — this module never inspects or interprets extra keys, only carries
+  // them through.
+  [key: string]: unknown
+}
+
+export interface OptionSetsFieldRow {
+  fieldKey: string
+  options: OptionSetsOptionEntry[]
+}
+
+export interface OptionSetsParseSuccess {
+  ok: true
+  /** Whether the source document used the `{ optionSets: {...} }` wrapper (true) or was a bare
+   *  `{ [fieldKey]: [...] }` map at the top level (false). Preserved across serialize so editing
+   *  never changes which shape the user originally chose. Blank/empty source text defaults to
+   *  wrapped (matches the view's own placeholder / canonical new-document shape). */
+  wrapped: boolean
+  rows: OptionSetsFieldRow[]
+  /** The raw parsed top-level object when `wrapped` (used to preserve sibling keys, e.g. a
+   *  `projectId` alongside `optionSets`, and their original relative key order). Empty for bare
+   *  documents (the map itself IS the whole document — no room for siblings) and for blank/fresh
+   *  source text. */
+  originalRecord: Record<string, unknown>
+}
+
+export interface OptionSetsParseFailure {
+  ok: false
+}
+
+export type OptionSetsParseResult = OptionSetsParseSuccess | OptionSetsParseFailure
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Parse optionSets JSON text into the structured (repeatable-row) shape. Returns `{ ok: false }`
+ * for anything outside the closed shape this editor supports — callers must treat that as
+ * "not structurable" and fall back to the expert JSON textarea WITHOUT altering the source text.
+ */
+export function parseOptionSets(text: string): OptionSetsParseResult {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) {
+    return { ok: true, wrapped: true, rows: [], originalRecord: {} }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return { ok: false }
+  }
+  if (!isPlainObject(parsed)) return { ok: false }
+  if ('optionSources' in parsed || 'configInfo' in parsed) return { ok: false }
+
+  let mapSource: Record<string, unknown>
+  let wrapped: boolean
+  if ('optionSets' in parsed) {
+    if (!isPlainObject(parsed.optionSets)) return { ok: false }
+    mapSource = parsed.optionSets
+    wrapped = true
+  } else {
+    mapSource = parsed
+    wrapped = false
+  }
+
+  const rows: OptionSetsFieldRow[] = []
+  for (const [fieldKey, rawOptions] of Object.entries(mapSource)) {
+    if (!Array.isArray(rawOptions)) return { ok: false }
+    const options: OptionSetsOptionEntry[] = []
+    for (const rawOption of rawOptions) {
+      if (!isPlainObject(rawOption)) return { ok: false }
+      if (typeof rawOption.value !== 'string' || typeof rawOption.label !== 'string') return { ok: false }
+      options.push(rawOption as OptionSetsOptionEntry)
+    }
+    rows.push({ fieldKey, options })
+  }
+
+  return { ok: true, wrapped, rows, originalRecord: wrapped ? parsed : {} }
+}
+
+/**
+ * Serialize structured rows back to the SAME JSON text shape the raw textarea would hold
+ * (2-space indent, `wrapped`/`originalRecord` preserved from the matching `parseOptionSets`
+ * call). Byte-identical to the source text when called with zero row edits (idempotent).
+ */
+export function serializeOptionSets(
+  rows: OptionSetsFieldRow[],
+  wrapped: boolean,
+  originalRecord: Record<string, unknown> = {},
+): string {
+  const map: Record<string, unknown> = {}
+  for (const row of rows) {
+    map[row.fieldKey] = row.options
+  }
+  const doc: Record<string, unknown> = wrapped ? { ...originalRecord, optionSets: map } : map
+  return JSON.stringify(doc, null, 2)
+}
+
+/** Field keys that appear on more than one row — serializing silently keeps only the LAST one
+ *  (plain JS object keys can't hold duplicates). Callers surface this as a visible, values-free
+ *  warning (never silently drop without telling the user) rather than blocking the edit. */
+export function findDuplicateFieldKeys(rows: OptionSetsFieldRow[]): string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+  for (const row of rows) {
+    if (seen.has(row.fieldKey)) duplicates.add(row.fieldKey)
+    seen.add(row.fieldKey)
+  }
+  return Array.from(duplicates)
+}

--- a/apps/web/tests/IntegrationFieldOptionSyncPanel.spec.ts
+++ b/apps/web/tests/IntegrationFieldOptionSyncPanel.spec.ts
@@ -1,11 +1,16 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, nextTick, type App as VueApp, type Component } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp, type Component } from 'vue'
 import IntegrationFieldOptionSyncPanel from '../src/components/integration/IntegrationFieldOptionSyncPanel.vue'
+import { useLocale } from '../src/composables/useLocale'
 
 // IU-2d (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-2,
 // stage D — run-push decomposition): structural smoke test for the extracted field-option-sync
 // admin panel. The raw `optionSets JSON` textarea (`stock-option-sync-json`) is deliberately kept
-// as-is — structuring it is IU-5's gated job — so this spec pins that it stays a plain <textarea>.
+// as-is — structuring it was IU-5's gated job. D2 below is that slice (site 5, structured editor);
+// its own tests are appended after the pre-existing (ADD-ONLY, zero-assertion-change) block. The
+// four pre-existing tests above the D2 `describe` still pass exactly as written, byte-for-byte
+// unmodified: `v-show` (not `v-if`) keeps the textarea reachable/queryable regardless of which
+// edit mode is active.
 
 describe('IntegrationFieldOptionSyncPanel (unit)', () => {
   let app: VueApp<Element> | null = null
@@ -29,6 +34,30 @@ describe('IntegrationFieldOptionSyncPanel (unit)', () => {
     app = createApp(Host)
     app.mount(container)
     await nextTick()
+  }
+
+  // Only for tests that need a REAL two-way `stockPreparationOptionSyncText` round trip (edit the
+  // textarea -> parent ref updates -> child prop reflects it on next render), mirroring how
+  // `IntegrationWorkbenchView.vue`'s actual `v-model:stock-preparation-option-sync-text` binds a
+  // real ref (unlike `mountPanel`'s static-props + spy harness, which only records emitted calls
+  // without feeding them back into the prop).
+  async function mountPanelReactive(props: Record<string, unknown>, initialText: string): Promise<{ text: ReturnType<typeof ref<string>> }> {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const text = ref(initialText)
+    const Host = defineComponent({
+      setup() {
+        return () => h(IntegrationFieldOptionSyncPanel as unknown as Component, {
+          ...props,
+          stockPreparationOptionSyncText: text.value,
+          'onUpdate:stockPreparationOptionSyncText': (value: string) => { text.value = value },
+        })
+      },
+    })
+    app = createApp(Host)
+    app.mount(container)
+    await nextTick()
+    return { text }
   }
 
   const noopFn = (..._args: unknown[]): unknown => undefined
@@ -91,5 +120,109 @@ describe('IntegrationFieldOptionSyncPanel (unit)', () => {
     }
     await nextTick()
     expect(onUpdateSyncText).toHaveBeenCalledWith('{"optionSets":{}}')
+  })
+
+  // D2 (site 5 of IU-5): structured editor default + expert-JSON toggle. ADD-ONLY — nothing above
+  // this line was changed.
+  describe('D2 structured editor + expert toggle', () => {
+    // useLocale()'s jsdom-resolved default is 'en' (no `metasheet_locale` in localStorage, no
+    // zh-ish `navigator.language`) — pin zh-CN explicitly for this describe block's zh-text
+    // assertions, same convention as approvalMobileI18n.spec.ts's `useLocale().setLocale(...)`.
+    // Reset afterward so it can't leak into other spec files sharing the same module-level state.
+    beforeEach(() => {
+      useLocale().setLocale('zh-CN')
+    })
+    afterEach(() => {
+      useLocale().setLocale('en')
+    })
+
+    it('defaults to structured mode with a structurable (blank) starting document', async () => {
+      await mountPanel(baseProps())
+      expect(container?.querySelector('[data-testid="option-sets-structured-editor"]')).toBeTruthy()
+      expect(container?.querySelector('[data-testid="field-options-mode-toggle"]')?.textContent).toContain('切换到专家 JSON')
+      // the expert textarea is still reachable (v-show), just not the active mode
+      expect(container?.querySelector('[data-testid="stock-option-sync-json"]')?.tagName).toBe('TEXTAREA')
+    })
+
+    it('toggles to expert mode and shows the JsonAssist strip beside the textarea', async () => {
+      await mountPanel(baseProps())
+      const toggle = container?.querySelector<HTMLButtonElement>('[data-testid="field-options-mode-toggle"]')
+      expect(toggle?.disabled).toBe(false)
+      toggle?.click()
+      await nextTick()
+      expect(container?.querySelector('[data-testid="option-sets-structured-editor"]')).toBeNull()
+      expect(container?.querySelector('[data-testid="stock-option-sync-json-json-assist"]')).toBeTruthy()
+      expect(toggle?.textContent).toContain('切换到结构化编辑')
+    })
+
+    it('toggling structured -> expert -> structured round-trips a well-formed edit', async () => {
+      const source = JSON.stringify({ optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] } }, null, 2)
+      await mountPanel(baseProps({ stockPreparationOptionSyncText: source }))
+      const toggle = container?.querySelector<HTMLButtonElement>('[data-testid="field-options-mode-toggle"]')
+      toggle?.click() // -> expert
+      await nextTick()
+      toggle?.click() // -> structured again (current text is still the same structurable source)
+      await nextTick()
+      expect(container?.querySelector('[data-testid="option-sets-structured-editor"]')).toBeTruthy()
+      expect(container?.querySelector('[data-testid="option-sets-row-key-0"]')).toHaveProperty('value', 'material_type')
+    })
+
+    it('starts in expert mode (forced) when the initial document is not structurable, and disables switching back', async () => {
+      await mountPanel(baseProps({ stockPreparationOptionSyncText: '{ not valid json' }))
+      expect(container?.querySelector('[data-testid="option-sets-structured-editor"]')).toBeNull()
+      expect(container?.querySelector('[data-testid="stock-option-sync-json"]')?.tagName).toBe('TEXTAREA')
+      const toggle = container?.querySelector<HTMLButtonElement>('[data-testid="field-options-mode-toggle"]')
+      expect(toggle?.disabled).toBe(true)
+      expect(container?.querySelector('[data-testid="field-options-structured-unavailable-hint"]')).toBeTruthy()
+    })
+
+    it('does not silently drop the malformed text: it stays exactly in the model/textarea', async () => {
+      const malformed = '{ "optionSets": { "material_type": [ { "value": "plate" '
+      const onUpdateSyncText = vi.fn(noopFn)
+      await mountPanel(baseProps({ stockPreparationOptionSyncText: malformed, 'onUpdate:stockPreparationOptionSyncText': onUpdateSyncText }))
+      const textarea = container?.querySelector<HTMLTextAreaElement>('[data-testid="stock-option-sync-json"]')
+      expect(textarea?.value).toBe(malformed)
+      // no forced rewrite of the model on mount
+      expect(onUpdateSyncText).not.toHaveBeenCalled()
+    })
+
+    it('re-enables the toggle once the expert-mode text is fixed into a structurable shape', async () => {
+      // Needs a REAL two-way model round trip (edit -> parent ref updates -> child prop reflects
+      // it), which `mountPanel`'s static-props harness doesn't simulate — see
+      // `mountPanelReactive`'s own comment.
+      await mountPanelReactive(baseProps(), '{ not valid json')
+      const textarea = container?.querySelector<HTMLTextAreaElement>('[data-testid="stock-option-sync-json"]')
+      const fixed = JSON.stringify({ optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] } })
+      if (textarea) {
+        textarea.value = fixed
+        textarea.dispatchEvent(new Event('input'))
+      }
+      await nextTick()
+      await nextTick()
+      const toggle = container?.querySelector<HTMLButtonElement>('[data-testid="field-options-mode-toggle"]')
+      expect(toggle?.disabled).toBe(false)
+      expect(container?.querySelector('[data-testid="field-options-structured-unavailable-hint"]')).toBeNull()
+    })
+
+    it('SENTINEL: a secret-shaped value in malformed JSON never leaks into the unavailable-mode hint', async () => {
+      const secret = 'sk-SECRET-TOKEN-do-not-leak-9f8e7d6c5b4a'
+      await mountPanel(baseProps({ stockPreparationOptionSyncText: `{"optionSets": ${secret}}` }))
+      const hint = container?.querySelector('[data-testid="field-options-structured-unavailable-hint"]')
+      expect(hint).toBeTruthy()
+      expect(hint?.textContent ?? '').not.toContain(secret)
+      // No other rendered hint/label text surface (the textarea's own .value DOM property is
+      // intentionally excluded — that's the field itself echoing the user's own input back at
+      // them, not a leak into a *validation/error* line) echoes the secret either.
+      const toggle = container?.querySelector('[data-testid="field-options-mode-toggle"]')
+      const boundary = container?.querySelector('[data-testid="stock-option-sync-boundary"]')
+      expect(toggle?.textContent ?? '').not.toContain(secret)
+      expect(boundary?.textContent ?? '').not.toContain(secret)
+    })
+
+    it('zh: the mode toggle and unavailable hint render zh-CN copy by default', async () => {
+      await mountPanel(baseProps({ stockPreparationOptionSyncText: '{ not valid json' }))
+      expect(container?.querySelector('[data-testid="field-options-mode-toggle"]')?.textContent).toContain('切换到结构化编辑')
+      expect(container?.querySelector('[data-testid="field-options-structured-unavailable-hint"]')?.textContent).toContain('结构化编辑器')
+    })
   })
 })

--- a/apps/web/tests/IntegrationOptionSetsStructuredEditor.spec.ts
+++ b/apps/web/tests/IntegrationOptionSetsStructuredEditor.spec.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp, type Component } from 'vue'
+import IntegrationOptionSetsStructuredEditor from '../src/components/integration/IntegrationOptionSetsStructuredEditor.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// D2 (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-5, site 5):
+// isolation tests for the optionSets repeatable-row structured editor. Same light createApp/h
+// harness pattern as JsonAssist.spec.ts / IntegrationFieldOptionSyncPanel.spec.ts. Pure
+// parse/serialize contract coverage lives in tests/utils/optionSetsStructured.spec.ts — these
+// tests exercise the same contract through real DOM interactions (typing, clicking add/remove).
+describe('IntegrationOptionSetsStructuredEditor (unit)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    // useLocale()'s locale is module-level singleton state shared across spec files in the same
+    // worker — reset after every test so only the dedicated zh test (below) opts into zh-CN.
+    useLocale().setLocale('en')
+  })
+
+  async function mount(props: Record<string, unknown>): Promise<void> {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const Host = defineComponent({
+      setup() {
+        return () => h(IntegrationOptionSetsStructuredEditor as unknown as Component, props)
+      },
+    })
+    app = createApp(Host)
+    app.mount(container)
+    await nextTick()
+  }
+
+  function baseProps(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      modelValue: '',
+      'onUpdate:modelValue': vi.fn(),
+      ...overrides,
+    }
+  }
+
+  function typeInto(testId: string, value: string): void {
+    const input = container?.querySelector<HTMLInputElement>(`[data-testid="${testId}"]`)
+    expect(input, `expected input ${testId} to exist`).toBeTruthy()
+    if (!input) return
+    input.value = value
+    input.dispatchEvent(new Event('input'))
+  }
+
+  it('renders the empty-state hint with zero rows on a fresh (blank) document', async () => {
+    await mount(baseProps())
+    expect(container?.querySelector('[data-testid="option-sets-structured-editor"]')).toBeTruthy()
+    expect(container?.querySelector('[data-testid="option-sets-empty-hint"]')).toBeTruthy()
+    expect(container?.querySelector('[data-testid="option-sets-row-0"]')).toBeNull()
+  })
+
+  it('BYTE-EQUALITY: add field + add option + fill value/label serializes to the SAME JSON the raw textarea would hold', async () => {
+    const onUpdate = vi.fn()
+    await mount(baseProps({ 'onUpdate:modelValue': onUpdate }))
+
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-add-row"]')?.click()
+    await nextTick()
+    typeInto('option-sets-row-key-0', 'material_type')
+    await nextTick()
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-option-add-0"]')?.click()
+    await nextTick()
+    typeInto('option-sets-option-value-0-0', 'plate')
+    await nextTick()
+    typeInto('option-sets-option-label-0-0', 'Plate')
+    await nextTick()
+
+    const finalText = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0] as string
+    // What a user directly typing the same shape into the raw textarea (and formatting it via
+    // JsonAssist / JSON.stringify(_, null, 2), the canonical form used app-wide) would hold.
+    const expected = JSON.stringify({ optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] } }, null, 2)
+    expect(finalText).toBe(expected)
+  })
+
+  it('adds a second field row and a second option on an existing row', async () => {
+    const source = JSON.stringify({ optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] } }, null, 2)
+    const onUpdate = vi.fn()
+    await mount(baseProps({ modelValue: source, 'onUpdate:modelValue': onUpdate }))
+
+    expect(container?.querySelector('[data-testid="option-sets-row-0"]')).toBeTruthy()
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-option-add-0"]')?.click()
+    await nextTick()
+    typeInto('option-sets-option-value-0-1', 'bar')
+    await nextTick()
+    typeInto('option-sets-option-label-0-1', 'Bar')
+    await nextTick()
+
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-add-row"]')?.click()
+    await nextTick()
+    typeInto('option-sets-row-key-1', 'blank_type')
+    await nextTick()
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-option-add-1"]')?.click()
+    await nextTick()
+    typeInto('option-sets-option-value-1-0', 'casting')
+    await nextTick()
+    typeInto('option-sets-option-label-1-0', 'Casting')
+    await nextTick()
+
+    const finalText = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0] as string
+    expect(JSON.parse(finalText)).toEqual({
+      optionSets: {
+        material_type: [{ value: 'plate', label: 'Plate' }, { value: 'bar', label: 'Bar' }],
+        blank_type: [{ value: 'casting', label: 'Casting' }],
+      },
+    })
+  })
+
+  it('removes an option and removes a field row', async () => {
+    const source = JSON.stringify({
+      optionSets: {
+        material_type: [{ value: 'plate', label: 'Plate' }, { value: 'bar', label: 'Bar' }],
+        blank_type: [{ value: 'casting', label: 'Casting' }],
+      },
+    }, null, 2)
+    const onUpdate = vi.fn()
+    await mount(baseProps({ modelValue: source, 'onUpdate:modelValue': onUpdate }))
+
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-option-remove-0-1"]')?.click()
+    await nextTick()
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-row-remove-1"]')?.click()
+    await nextTick()
+
+    const finalText = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0] as string
+    expect(JSON.parse(finalText)).toEqual({
+      optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] },
+    })
+  })
+
+  it('preserves unmodeled extra option keys (actionBindings) through an unrelated edit', async () => {
+    const source = JSON.stringify({
+      optionSets: {
+        stock_preparation_status: [
+          { value: 'pending', label: 'Pending', actionBindings: [{ actionId: 'plm.stock-preparation.pull-bom.v1' }] },
+        ],
+      },
+    }, null, 2)
+    const onUpdate = vi.fn()
+    await mount(baseProps({ modelValue: source, 'onUpdate:modelValue': onUpdate }))
+
+    // Add an unrelated second field row — the untouched entry's actionBindings must survive.
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-add-row"]')?.click()
+    await nextTick()
+    typeInto('option-sets-row-key-1', 'material_type')
+    await nextTick()
+
+    const finalText = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0] as string
+    const parsed = JSON.parse(finalText)
+    expect(parsed.optionSets.stock_preparation_status[0]).toEqual({
+      value: 'pending',
+      label: 'Pending',
+      actionBindings: [{ actionId: 'plm.stock-preparation.pull-bom.v1' }],
+    })
+  })
+
+  it('shows a duplicate-field-key warning without blocking edits, and clears it once renamed', async () => {
+    await mount(baseProps())
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-add-row"]')?.click()
+    await nextTick()
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-add-row"]')?.click()
+    await nextTick()
+    typeInto('option-sets-row-key-0', 'material_type')
+    await nextTick()
+    typeInto('option-sets-row-key-1', 'material_type')
+    await nextTick()
+    expect(container?.querySelector('[data-testid="option-sets-duplicate-warning"]')).toBeTruthy()
+
+    typeInto('option-sets-row-key-1', 'blank_type')
+    await nextTick()
+    expect(container?.querySelector('[data-testid="option-sets-duplicate-warning"]')).toBeNull()
+  })
+
+  it('SENTINEL: a secret-shaped option value never leaks into the duplicate-warning hint text', async () => {
+    const secret = 'sk-SECRET-TOKEN-do-not-leak-9f8e7d6c5b4a'
+    await mount(baseProps())
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-add-row"]')?.click()
+    await nextTick()
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-add-row"]')?.click()
+    await nextTick()
+    typeInto('option-sets-row-key-0', 'material_type')
+    await nextTick()
+    typeInto('option-sets-row-key-1', 'material_type')
+    await nextTick()
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-option-add-0"]')?.click()
+    await nextTick()
+    typeInto('option-sets-option-value-0-0', secret)
+    await nextTick()
+
+    const warning = container?.querySelector('[data-testid="option-sets-duplicate-warning"]')
+    expect(warning).toBeTruthy()
+    expect(warning?.textContent ?? '').not.toContain(secret)
+  })
+
+  it('zh: renders zh-CN copy when the locale is zh-CN', async () => {
+    // useLocale()'s jsdom-resolved default is 'en' (no `metasheet_locale` in localStorage, no
+    // zh-ish `navigator.language`) — pin zh-CN explicitly, same convention as
+    // approvalMobileI18n.spec.ts's `useLocale().setLocale(...)`. Reset in this file's shared
+    // afterEach.
+    useLocale().setLocale('zh-CN')
+    await mount(baseProps())
+    expect(container?.querySelector('[data-testid="option-sets-empty-hint"]')?.textContent).toContain('还没有字段')
+    container?.querySelector<HTMLButtonElement>('[data-testid="option-sets-add-row"]')?.click()
+    await nextTick()
+    expect(container?.querySelector('[data-testid="option-sets-row-remove-0"]')?.textContent).toContain('删除字段')
+  })
+})

--- a/apps/web/tests/utils/optionSetsStructured.spec.ts
+++ b/apps/web/tests/utils/optionSetsStructured.spec.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import { findDuplicateFieldKeys, parseOptionSets, serializeOptionSets } from '../../src/utils/optionSetsStructured'
+
+// D2 (docs/development/integration-ux-workbench-redesign-design-lock-20260706.md §2 IU-5, site 5):
+// pure-function coverage for the structured<->JSON contract behind
+// `IntegrationOptionSetsStructuredEditor.vue`. These are the tests that pin the byte-equivalence
+// guarantee ("edit in structured -> serialize to the SAME JSON the textarea would hold, and vice
+// versa") without mounting any component.
+describe('parseOptionSets', () => {
+  it('treats blank/whitespace-only text as an empty, wrapped, zero-row document', () => {
+    expect(parseOptionSets('')).toEqual({ ok: true, wrapped: true, rows: [], originalRecord: {} })
+    expect(parseOptionSets('   \n ')).toEqual({ ok: true, wrapped: true, rows: [], originalRecord: {} })
+  })
+
+  it('structures a wrapped { optionSets: {...} } document', () => {
+    const source = { optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] } }
+    const text = JSON.stringify(source, null, 2)
+    const result = parseOptionSets(text)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.wrapped).toBe(true)
+    expect(result.rows).toEqual([{ fieldKey: 'material_type', options: [{ value: 'plate', label: 'Plate' }] }])
+  })
+
+  it('structures a bare { fieldKey: [...] } document (no optionSets wrapper)', () => {
+    const source = { material_type: [{ value: 'plate', label: 'Plate' }] }
+    const text = JSON.stringify(source, null, 2)
+    const result = parseOptionSets(text)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.wrapped).toBe(false)
+    expect(result.rows).toEqual([{ fieldKey: 'material_type', options: [{ value: 'plate', label: 'Plate' }] }])
+  })
+
+  it('preserves multiple field rows in source order', () => {
+    const source = {
+      optionSets: {
+        material_type: [{ value: 'plate', label: 'Plate' }],
+        blank_type: [{ value: 'casting', label: 'Casting' }],
+      },
+    }
+    const result = parseOptionSets(JSON.stringify(source, null, 2))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.rows.map((r) => r.fieldKey)).toEqual(['material_type', 'blank_type'])
+  })
+
+  it('preserves unmodeled extra option keys (e.g. actionBindings) and their key order', () => {
+    const source = {
+      optionSets: {
+        stock_preparation_status: [
+          { value: 'pending', label: 'Pending', actionBindings: [{ actionId: 'plm.stock-preparation.pull-bom.v1' }] },
+        ],
+      },
+    }
+    const result = parseOptionSets(JSON.stringify(source, null, 2))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.rows[0].options[0]).toEqual(source.optionSets.stock_preparation_status[0])
+    expect(Object.keys(result.rows[0].options[0])).toEqual(['value', 'label', 'actionBindings'])
+  })
+
+  it('rejects invalid JSON', () => {
+    expect(parseOptionSets('{ not valid')).toEqual({ ok: false })
+  })
+
+  it('rejects a non-object top-level document', () => {
+    expect(parseOptionSets('[1,2,3]')).toEqual({ ok: false })
+    expect(parseOptionSets('"a string"')).toEqual({ ok: false })
+    expect(parseOptionSets('42')).toEqual({ ok: false })
+  })
+
+  it('rejects the legacy optionSources/configInfo alias shape (a different data model)', () => {
+    expect(parseOptionSets(JSON.stringify({ optionSources: [], configInfo: {} }))).toEqual({ ok: false })
+    expect(parseOptionSets(JSON.stringify({ optionSets: {}, configInfo: {} }))).toEqual({ ok: false })
+  })
+
+  it('rejects a field whose value is not an array', () => {
+    expect(parseOptionSets(JSON.stringify({ optionSets: { material_type: 'not-an-array' } }))).toEqual({ ok: false })
+  })
+
+  it('rejects an option entry missing value or label', () => {
+    expect(parseOptionSets(JSON.stringify({ optionSets: { material_type: [{ value: 'plate' }] } }))).toEqual({ ok: false })
+    expect(parseOptionSets(JSON.stringify({ optionSets: { material_type: [{ label: 'Plate' }] } }))).toEqual({ ok: false })
+    expect(parseOptionSets(JSON.stringify({ optionSets: { material_type: ['plate'] } }))).toEqual({ ok: false })
+  })
+
+  it('rejects non-string value/label (closed shape is strict about types)', () => {
+    expect(parseOptionSets(JSON.stringify({ optionSets: { material_type: [{ value: 1, label: 'Plate' }] } }))).toEqual({ ok: false })
+  })
+})
+
+describe('serializeOptionSets', () => {
+  it('is byte-identical to the raw textarea path for a fresh document (structured -> JSON)', () => {
+    const rows = [{ fieldKey: 'material_type', options: [{ value: 'plate', label: 'Plate' }] }]
+    const result = serializeOptionSets(rows, true, {})
+    // What a user directly typing the same shape into the raw textarea would produce.
+    const expected = JSON.stringify({ optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] } }, null, 2)
+    expect(result).toBe(expected)
+  })
+
+  it('round-trips a wrapped document with zero edits (idempotent, canonical formatting)', () => {
+    const source = { optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] } }
+    const text = JSON.stringify(source, null, 2)
+    const parsed = parseOptionSets(text)
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(serializeOptionSets(parsed.rows, parsed.wrapped, parsed.originalRecord)).toBe(text)
+  })
+
+  it('round-trips a bare document with zero edits', () => {
+    const source = { material_type: [{ value: 'plate', label: 'Plate' }], blank_type: [{ value: 'casting', label: 'Casting' }] }
+    const text = JSON.stringify(source, null, 2)
+    const parsed = parseOptionSets(text)
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(serializeOptionSets(parsed.rows, parsed.wrapped, parsed.originalRecord)).toBe(text)
+  })
+
+  it('preserves sibling top-level keys AND their original relative order around optionSets', () => {
+    // `optionSets` sits BETWEEN two sibling keys in the source — a naive `{ ...extra, optionSets }`
+    // rebuild that always appends `optionSets` last would silently reorder this on a zero-edit
+    // round trip. Pin the correct behavior: JS object-literal semantics keep a duplicate key's
+    // FIRST position (the spread's) and only update its value.
+    const source = { alpha: 1, optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] }, zeta: 2 }
+    const text = JSON.stringify(source, null, 2)
+    const parsed = parseOptionSets(text)
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(serializeOptionSets(parsed.rows, parsed.wrapped, parsed.originalRecord)).toBe(text)
+    expect(Object.keys(JSON.parse(serializeOptionSets(parsed.rows, parsed.wrapped, parsed.originalRecord)))).toEqual(['alpha', 'optionSets', 'zeta'])
+  })
+
+  it('reflects row edits (add field / add option / rename) in the serialized JSON', () => {
+    const rows = [
+      { fieldKey: 'material_type', options: [{ value: 'plate', label: 'Plate' }, { value: 'bar', label: 'Bar' }] },
+      { fieldKey: 'blank_type', options: [{ value: 'casting', label: 'Casting' }] },
+    ]
+    const result = serializeOptionSets(rows, true, {})
+    expect(JSON.parse(result)).toEqual({
+      optionSets: {
+        material_type: [{ value: 'plate', label: 'Plate' }, { value: 'bar', label: 'Bar' }],
+        blank_type: [{ value: 'casting', label: 'Casting' }],
+      },
+    })
+  })
+
+  it('produces a minimal wrapped document for zero rows ({ "optionSets": {} })', () => {
+    expect(serializeOptionSets([], true, {})).toBe('{\n  "optionSets": {}\n}')
+  })
+})
+
+describe('findDuplicateFieldKeys', () => {
+  it('returns an empty list when all field keys are unique', () => {
+    expect(findDuplicateFieldKeys([
+      { fieldKey: 'a', options: [] },
+      { fieldKey: 'b', options: [] },
+    ])).toEqual([])
+  })
+
+  it('flags a field key that appears on more than one row', () => {
+    expect(findDuplicateFieldKeys([
+      { fieldKey: 'a', options: [] },
+      { fieldKey: 'a', options: [] },
+      { fieldKey: 'b', options: [] },
+    ])).toEqual(['a'])
+  })
+
+  it('SENTINEL: duplicate-key detection never echoes option value/label content, only structural facts', () => {
+    const secret = 'sk-SECRET-TOKEN-do-not-leak-9f8e7d6c5b4a'
+    const duplicates = findDuplicateFieldKeys([
+      { fieldKey: 'a', options: [{ value: secret, label: secret }] },
+      { fieldKey: 'a', options: [{ value: secret, label: secret }] },
+    ])
+    expect(duplicates).toEqual(['a'])
+    expect(JSON.stringify(duplicates)).not.toContain(secret)
+  })
+})

--- a/docs/development/integration-iu5b-optionsets-editor-dev-verification-20260707.md
+++ b/docs/development/integration-iu5b-optionsets-editor-dev-verification-20260707.md
@@ -1,0 +1,198 @@
+# IU-5b optionSets 结构化编辑器(集成 JSON textarea 站点 5)— 开发验证 — 2026-07-07
+
+> 上位锁:`integration-ux-workbench-redesign-design-lock-20260706.md`(RATIFIED)§2 IU-5
+> "JSON textarea 逐处结构化(门:IU-2 落地;**每处单独评估**);专家 JSON 模式保留切换"
+> + 主循环对 5 处裸 JSON textarea 的逐处处置:站点 5(optionSets)= **真结构化编辑器**
+> (闭形状,不同于站点 1-4 的开放/自由形 JSON-assist 处置)。
+> D1(lane D part 1,#3838,IU-5a)落了站点 1-4 的 JSON-assist 形态,并把站点 5 DEFERRED
+> 到本片(D2/IU-5b)——其宿主 panel(`IntegrationFieldOptionSyncPanel.vue`)当时在
+> in-flight 未合并 PR #3822 中。#3822(IU-2d)已合并 main,门开;owner 2026-07-07 授权
+> 本片。
+
+## 0. 前提偏差说明(owner 应知)
+
+任务前提写"D1 的 helper `jsonAssist.ts`/`JsonAssist.vue` 已随 #3838 落地"——**核实为
+不准确**:开发时 `gh pr view 3838` 显示该 PR 仍是 **OPEN**(`mergedAt: null`),且与
+当前 main **CONFLICTING**(`mergeable: CONFLICTING`,大概率因 #3838 与其他并行 PR
+都改了 `IntegrationConnectionSection.vue`/`IntegrationPayloadPreviewSection.vue`)。
+`IntegrationFieldOptionSyncPanel.vue`/`IntegrationWorkbenchView.vue` 两处 `#3838`
+分支相对 origin/main **零 diff**(已核实),所以那两个共享 helper 文件本身与本片的
+改动面无冲突——但它们物理上还不在 main 上。
+
+处置(与 advisor 核对一致):**将 `jsonAssist.ts`(`apps/web/src/utils/`)与
+`JsonAssist.vue`(`apps/web/src/components/integration/`)按字节复制**到本分支(取自
+`claude/integration-iu5a-json-assist-20260707` 分支 tip,ff239cbdf),而不是把本分支
+stack 在那个不稳定/冲突中的分支上。两个文件顶部各加了一段 D2 NOTE 注释,说明其为
+#3838 的字节级复制。**结果**:#3838 与本 PR 无论谁先合并,另一个在落地时会在这两个
+文件路径上遇到一次"双方都新增同一文件"的冲突——**内容完全相同,是纯机械 no-op
+冲突**,直接保留任一份即可,不需要人工比对内容差异。这一排序留给 owner 决定;本片
+的职责只是把这个依赖显著标注出来(此处 + PR 描述 + commit 消息)。
+
+## 1. 结构化编辑器覆盖的"闭形状"契约
+
+`apps/web/src/utils/optionSetsStructured.ts`(纯函数层,独立于 Vue,可直接单测):
+
+```ts
+interface OptionSetsOptionEntry { value: string; label: string; [key: string]: unknown }
+interface OptionSetsFieldRow { fieldKey: string; options: OptionSetsOptionEntry[] }
+
+parseOptionSets(text: string):
+  | { ok: true; wrapped: boolean; rows: OptionSetsFieldRow[]; originalRecord: Record<string, unknown> }
+  | { ok: false }
+
+serializeOptionSets(rows, wrapped, originalRecord = {}): string   // JSON.stringify(_, null, 2)
+findDuplicateFieldKeys(rows): string[]
+```
+
+**闭形状**(能被结构化编辑器接管的唯一形态):顶层是一个 JSON 对象,要么直接是
+`{ [fieldKey]: OptionEntry[] }`(bare,无 `optionSets` 包装,匹配
+`buildStockPreparationOptionSyncPayload` 现有的自动包装规则),要么是
+`{ optionSets: { [fieldKey]: OptionEntry[] }, ...其他顶层键 }`(wrapped,匹配现有
+`stockPreparationOptionSyncPlaceholder` 的形状)。每个 `OptionEntry` **必须**同时有
+字符串类型的 `value`/`label`;`actionBindings` 等其他键允许存在但结构化编辑器不提供
+行内编辑 UI——只保证透传不丢。
+
+**不可结构化(判定 `{ ok: false }`,回落专家 JSON,不改动/不丢原文本)**:
+- 非法 JSON(`JSON.parse` 抛错);
+- 顶层不是对象(数组/字符串/数字/null);
+- 顶层含 `optionSources` 或 `configInfo`(legacy alias 形态——是备料兼容路由认的另一
+  套数据模型,不是本编辑器的形状,`syncFieldOptions` 里 `usesLegacyAliases` 分支就是
+  为这套形态存在的);
+- 某字段的值不是数组;
+- 数组里某项不是纯对象,或 `value`/`label` 缺失/非字符串。
+
+## 2. 结构化⇄JSON 映射与字节等价证明
+
+- **序列化格式统一为** `JSON.stringify(doc, null, 2)`(与既有 placeholder /
+  `formatJsonText` 同一规范格式)。
+- **结构化 → JSON**:`serializeOptionSets(rows, wrapped, originalRecord)` —
+  `map[row.fieldKey] = row.options`(数组引用不变,顺序=行数组顺序)→
+  `wrapped ? { ...originalRecord, optionSets: map } : map`。
+  `tests/utils/optionSetsStructured.spec.ts`(`is byte-identical to the raw textarea
+  path for a fresh document`)与 `tests/IntegrationOptionSetsStructuredEditor.spec.ts`
+  (`BYTE-EQUALITY: ...`,走真实 DOM 交互:点新增字段→填字段名→点新增选项→填
+  value/label)都直接断言:结构化编辑产出的最终字符串与
+  `JSON.stringify({ optionSets: { material_type: [{ value: 'plate', label: 'Plate' }] } }, null, 2)`
+  **完全相等**——即用户直接在 textarea 里手打同样内容会得到的字节。
+- **JSON → 结构化(幂等往返)**:`parseOptionSets(text)` 拿到的 `rows`/`options`
+  条目**是原 `JSON.parse` 输出对象的引用,不克隆**——零编辑时
+  `serializeOptionSets(parsed.rows, parsed.wrapped, parsed.originalRecord)` 与源
+  文本逐字节相等(`round-trips a wrapped/bare document with zero edits` 两个测试)。
+  边界情形(易错点,已专门钉住):`optionSets` 键**夹在两个 sibling 键中间**
+  (`{ alpha, optionSets, zeta }`)时,朴素的 `{ ...extra, optionSets }` 重建会把
+  `optionSets` 挪到最后,悄悄改变顶层键序——`serializeOptionSets` 用
+  `{ ...originalRecord, optionSets: map }` 是安全的,因为 JS 对象字面量里**重复键
+  取第一次出现的位置,只更新其值**;`preserves sibling top-level keys AND their
+  original relative order` 测试直接断言重建结果的 `Object.keys(...)` 顺序仍是
+  `['alpha', 'optionSets', 'zeta']`。
+- **未建模的 option 额外键(如 `actionBindings`)**:`parseOptionSets` 不克隆条目对象,
+  编辑时只 mutate `.value`/`.label` 两个已知键——所以 `actionBindings` 及其原始键序
+  在任何"编辑其他行/其他字段"的操作后原样存活(`preserves unmodeled extra option
+  keys` 测试:改了一个不相关字段后,`stock_preparation_status` 行的
+  `actionBindings` 与键序 `['value','label','actionBindings']` 不变)。
+
+## 3. 恶意/畸形 JSON 回落行为(不静默丢数据)
+
+`IntegrationFieldOptionSyncPanel.vue` 挂载时用 `parseOptionSets(初始文本).ok` 一次性
+(非响应式)决定初始 `mode`:能结构化 → `structured`(默认);不能 → 强制 `expert`,
+且专家文本框显示的**就是原始文本本身,一个字节都不改**(`does not silently drop
+the malformed text: it stays exactly in the model/textarea` 测试:mount 后
+`textarea.value === malformed` 且 `onUpdate:...` 从未被调用过——没有"进入面板就悄悄
+重写模型"这回事)。
+
+从专家模式想切回结构化时(用户可能直接手改了 textarea),`isCurrentTextStructurable`
+(只读 computed,读当前模型文本跑一次 `parseOptionSets`)门控切换按钮:不可结构化则
+按钮 `disabled` + 显示 values-free 的
+`field-options-structured-unavailable-hint`("当前内容不是结构化编辑器支持的字段
+选项形状……");文本被修正为合法形状后按钮自动重新可点(`re-enables the toggle once
+the expert-mode text is fixed into a structurable shape` 测试)。**从结构化切到专家
+永远允许**(结构化编辑必然产出合法、可结构化的 JSON)。
+
+结构化编辑器组件本身用 `v-if`(不是 `v-show`)挂载——每次真正"切进"结构化模式都是
+全新实例、在 `setup()` 里对当时的模型文本解析一次;**没有"文本→行"的响应式
+watcher**(避免与正在进行的行编辑互相打架、形成更新环——参考组件头注释与
+advisor 复核意见)。反方向(行编辑→文本)则是每次 add/remove/输入操作后同步调用
+`serializeOptionSets` 并 emit,模型与"能否运行同步"的 `stockPreparationOptionSyncCanRun`
+等既有 computed 保持实时一致,和原始纯 textarea 的行为等价。
+
+## 4. 专家模式保留(零降级)
+
+- 原始 `<textarea data-testid="stock-option-sync-json">` **markup 原样保留**,只是
+  外层 `<label>` 从"始终渲染"改成 `v-show="mode === 'expert'"`——**只切 CSS
+  display,不摘出/重建 DOM 节点**,`data-testid`、`v-model` 绑定、既有 4 个测试全部
+  **零改动通过**(`IntegrationFieldOptionSyncPanel.spec.ts` 既有断言逐字节未动;
+  详见下方"既有断言"小节)。
+- textarea 旁新挂了 D1 的 `<JsonAssist>`(格式化按钮 + 校验状态行),复用同一个
+  `stockPreparationOptionSyncPlaceholder` 作为 values-free 占位示例——专家用户在
+  这条路径上比 D1 之前更方便(能一键格式化),不是降级。
+- 重复字段名(两行填了同一个 `fieldKey`)不阻断编辑,但会显示
+  `option-sets-duplicate-warning`(values-free,不点名具体字段名/值)提示
+  "序列化时只保留同名最后一行",避免用户以为两行都保存了却悄悄丢了一行——不是
+  必需项,但延续本仓"不静默丢数据"的一贯纪律,成本很低就加上了。
+
+## 5. SENTINEL(no-echo 安全线)
+
+沿用 D1 建立的不变量:任何"校验/回落说明"文案都不得渲染用户输入内容本身。
+- 组件层面从不消费 `error.message`(`parseOptionSets` 内部 `JSON.parse` 的 catch
+  分支只返回 `{ ok: false }`,不转发任何 message 文本);
+- `field-options-structured-unavailable-hint` 是固定文案,不插值任何解析出的字段名
+  /值;`SENTINEL: a secret-shaped value in malformed JSON never leaks into the
+  unavailable-mode hint` 测试用 `sk-SECRET-TOKEN-...` 构造畸形 JSON,断言该 hint、
+  toggle 按钮文案、boundary 提示文案均不含该 secret;
+  - 说明:测试**特意排除**了 textarea 自身的 `.value` DOM 属性——那是字段把用户
+    自己输入的内容原样显示回给他自己,不是"泄漏进一条校验/错误提示行",这两者是
+    本仓一贯区分的(与 JsonAssist 的 no-echo 哨兵同一原则,该组件本身也从不在状态
+    行里回显 secret)。
+- `option-sets-duplicate-warning` 同理:哪怕重复的字段行里塞了 secret 形文本,警告
+  文案本身也是固定的、不插值任何 value/label 内容
+  (`SENTINEL: a secret-shaped option value never leaks into the duplicate-warning
+  hint text` + 纯函数层 `findDuplicateFieldKeys` 的同名哨兵测试)。
+
+## 6. 测试证据(全部本地双 Node 跑绿)
+
+| 面 | 内容 | 结果 |
+| --- | --- | --- |
+| 纯函数层 `tests/utils/optionSetsStructured.spec.ts` | `parseOptionSets`(空/wrapped/bare/多字段顺序/actionBindings 保留/非法 JSON/非对象/legacy alias/非数组/缺 value-label/非字符串)11 + `serializeOptionSets`(字节等价/wrapped 幂等/bare 幂等/sibling 键序/行编辑反映/零行文档)6 + `findDuplicateFieldKeys`(唯一/重复/SENTINEL)3 | 20/20 ✅ |
+| 组件层 `tests/IntegrationOptionSetsStructuredEditor.spec.ts` | 空态提示/BYTE-EQUALITY/加字段加选项/删选项删字段/actionBindings 保留/重复警告+改名后清除/SENTINEL/zh | 8/8 ✅ |
+| 宿主 panel `tests/IntegrationFieldOptionSyncPanel.spec.ts` | **既有 4 个测试逐字节未改**,新增 8 个(默认结构化/切专家显示 JsonAssist/来回切换往返/畸形强制专家+禁用切换/不静默丢畸形文本/修正后重新启用切换/SENTINEL/zh) | 4(existing)+ 8(D2 new)= 12/12 ✅ |
+| integration-guard.yml 全清单(含本片 3 个新增 spec 名) | 26 个 spec 文件,default Node(v25)与 Node 20(nvm)双跑 | 277/277 ×2 ✅ |
+| `plugin-integration-core` CJS 链 | guard 另一腿(本片零后端改动,回归确认) | 全绿 ✅ |
+| UF-6 style guard(`ui-foundation-style-guard.spec.ts`) | `IntegrationFieldOptionSyncPanel.vue` 已在既有 ratchet 清单里;改动后仍 0 hex/rgb | 77/77 ✅(未新增文件到该 ratchet——不在本片 CI 面内,后续如需可另开) |
+| `vue-tsc -b` | 全仓 web typecheck | 0 错误 ✅(default Node + Node 20) |
+| `vite build` | 生产构建 | ✅(default Node + Node 20) |
+
+CI 面:`integration-guard.yml` 修复了一处既存的 YAML **重复 `run:` key** bug(#3822
+落地时的一次并发合并遗留——两条 `run:` 行只有后一条生效,前一条列表里的
+`IntegrationBridgeAgentSection` 曾经"看起来在跑但其实没跑"),收敛为两条清单的
+**并集** + 本片新增的 3 个 spec 名(`IntegrationOptionSetsStructuredEditor`
+`optionSetsStructured` 已验证一个 token 同时命中两个新 spec 文件路径)。path filter
+新增 4 个文件(`IntegrationOptionSetsStructuredEditor.vue` / `optionSetsStructured.ts`
++ 复制来的 `JsonAssist.vue` / `jsonAssist.ts`)。
+
+## 7. 既有断言(#3822 遗留)未受影响的原因
+
+`IntegrationFieldOptionSyncPanel.spec.ts` 既有 4 个测试**逐字节未修改**:
+1. `renders the panel...RAW optionSets JSON textarea` —— `querySelector` 找 textarea
+   + 断言 `tagName === 'TEXTAREA'`:`v-show`(非 `v-if`)保证元素**始终在 DOM 里**,
+   查询不受当前 mode 影响,继续通过。
+2. `renders NOTHING without integration:admin` —— 根 `v-if` 未动,继续通过。
+3. `honours the can-run disable gate...` —— 与本片改动的 testid 无交集,继续通过。
+4. `forwards textarea edits through update:...(defineModel wiring)` ——
+   直接对 textarea dispatch 原生 `input` 事件;`v-show` 不摘监听器,`v-model` 仍然
+   活着,继续通过。
+
+**没有任何既有断言需要改成"专家模式默认"或其他妥协**——结构化默认 + 专家可达两个
+目标同时满足,零冲突。
+
+## 8. 边界与后续
+
+- 不做:per-option `actionBindings` 的行内编辑 UI(仍需专家 JSON 编辑;结构化编辑器
+  只保证透传不丢——泛化到 UI 属于 FOS-4 范畴,不是本片目标);字段级/kind 级 schema
+  校验(与站点 1-4 一致,后端/save 路径判定不变);`optionSources`/`configInfo`
+  legacy alias 的结构化(仍走专家 JSON,兼容路由本身零改动)。
+- **零后端/service 改动**:`syncFieldOptions`/`buildStockPreparationOptionSyncPayload`
+  /两条路由分派逻辑一个字节未碰;结构化编辑器只是把
+  `stockPreparationOptionSyncText` 这个既有字符串模型的另一种编辑入口。
+- IU-5 五个站点(1-4 由 D1/#3838 JSON-assist,5 由本片/D2 结构化编辑器)至此**全部
+  处置完毕**——design-lock §2 IU-5 这一条切片阶梯收口,前提是 #3838 落地(见 §0
+  偏差说明,排序留给 owner)。


### PR DESCRIPTION
## Summary

- D2 (design-lock `integration-ux-workbench-redesign-design-lock-20260706.md` §2 IU-5, site 5 — the one closed-shape site D1/#3838 deferred because its host panel was in-flight in #3822; #3822 has since landed): adds a repeatable-row **structured editor** (add/remove field, add/remove option) for the `optionSets JSON` textarea in `IntegrationFieldOptionSyncPanel.vue`. Structured is the default; the raw textarea is kept verbatim as an expert-JSON fallback (toggle button), with D1's `JsonAssist` (format/validate) mounted beside it.
- Structured⇄JSON contract lives in `apps/web/src/utils/optionSetsStructured.ts` — byte-equivalent round trips (parse never clones entries; edits mutate `value`/`label` in place so unmodeled keys like `actionBindings` and sibling top-level key order survive untouched). Malformed/unrecognized JSON (invalid syntax, `optionSources`/`configInfo` legacy alias shape, missing `value`/`label`) is never silently rewritten — the panel forces expert mode and disables the toggle back until the text is fixed.
- Zero backend/service change — both modes write the same `stockPreparationOptionSyncText` string model `syncFieldOptions` already reads.

## Important: dependency / merge-order flag

D1's shared helper (`apps/web/src/utils/jsonAssist.ts` + `.../JsonAssist.vue`, PR **#3838**) was briefed as "already landed" but at the time of this work **#3838 is still OPEN and `mergeable: CONFLICTING` against main** — not merged. This PR copies those two files byte-identical onto this branch (rather than stacking on #3838's unstable/conflicting branch) so it can build and test standalone off `main`. Consequence: **whichever of #3838 or this PR merges second will hit a trivial "both added this file" conflict** on exactly those two paths (`apps/web/src/utils/jsonAssist.ts`, `apps/web/src/components/integration/JsonAssist.vue`) — content is identical, keep either copy, no real reconciliation needed. I deliberately did **not** copy #3838's own `jsonAssist`/`JsonAssist` unit specs (to shrink that conflict surface further) — the shared helper's behavior is still exercised transitively through this PR's own `IntegrationFieldOptionSyncPanel.spec.ts` (JsonAssist is mounted and interacted with in expert mode), it just won't have its dedicated sentinel/format unit-test file until #3838 also lands. Owner: please sequence #3838 vs. this PR with that in mind.

## Incidental fix

`.github/workflows/integration-guard.yml` had a **pre-existing duplicate `run:` key** on the "Run integration web guard specs" step (two `run:` lines under one step — a #3822-era merge artifact where only the second silently took effect, meaning `IntegrationBridgeAgentSection`'s spec name from the first list looked wired but wasn't actually being deduped correctly). Collapsed to the union of both lists plus this slice's 3 new spec names.

## Existing-assertion check (explicitly requested)

`IntegrationFieldOptionSyncPanel.spec.ts`'s 4 pre-existing tests (from #3822) needed **zero changes** — they pass byte-for-byte as originally written. The expert-mode block uses `v-show` (not `v-if`), so the textarea (`data-testid="stock-option-sync-json"`) stays DOM-reachable and queryable regardless of which mode is active, satisfying the "must stay a plain textarea" assertion without touching it.

## Test plan

- [x] New pure-function suite `tests/utils/optionSetsStructured.spec.ts` (20 tests): parse (bare/wrapped/blank/multi-field-order/actionBindings-preserved/invalid-JSON/non-object/legacy-alias-rejected/non-array-rejected/missing-value-label-rejected/non-string-rejected) + serialize (byte-identical to raw-textarea path, wrapped/bare idempotent round trip, sibling-key-order preservation, edit reflection, minimal empty doc) + duplicate-key detection (incl. SENTINEL).
- [x] New component suite `tests/IntegrationOptionSetsStructuredEditor.spec.ts` (8 tests): empty state, BYTE-EQUALITY (UI add row/option → same JSON.stringify(_, null, 2) a hand-typed textarea would hold), multi-row/option add, remove row/option, actionBindings preserved through an unrelated edit, duplicate-field warning (non-blocking, clears on rename), SENTINEL (secret-shaped value never leaks into the warning), zh copy.
- [x] `IntegrationFieldOptionSyncPanel.spec.ts`: 4 pre-existing tests unchanged/green + 8 new (default-structured, toggle→expert shows JsonAssist, toggle round trip, forced-expert + disabled-toggle on malformed JSON, malformed text never silently rewritten, toggle re-enables once fixed, SENTINEL, zh).
- [x] Full `integration-guard.yml` targeted spec list (26 files / 277 tests) green on default Node and Node 20 (nvm).
- [x] `plugin-integration-core` CJS chain green (zero backend touch, regression-checked).
- [x] `vue-tsc -b` clean, `vite build` OK (both Node versions).
- [x] UF-6 style-guard (`ui-foundation-style-guard.spec.ts`) unaffected — 77/77, `IntegrationFieldOptionSyncPanel.vue` (already in its ratchet) still 0 hex/rgb.
- [x] Verification MD: `docs/development/integration-iu5b-optionsets-editor-dev-verification-20260707.md` (structured⇄JSON mapping, byte-equality proof, malformed-fallback behavior, expert-retention, sentinel notes, the #3838 dependency writeup above).

Completes design-lock §2 IU-5's slice ladder (sites 1-4 via D1/#3838, site 5 via this PR) — modulo #3838 actually landing (see dependency flag above).

Do not merge — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)