### PR TITLE
feat(web): multitable UI P2-1c — migrate ResetToPointPicker Refresh to MtButton

### DIFF
--- a/apps/web/src/multitable/components/ResetToPointPicker.vue
+++ b/apps/web/src/multitable/components/ResetToPointPicker.vue
@@ -32,15 +32,14 @@
             </option>
           </select>
         </label>
-        <button
-          type="button"
+        <MtButton
           class="reset-picker__refresh"
           data-test="reset-picker-history-refresh"
           :disabled="historyLoading || !canLoadHistory"
           @click="loadHistoryBatches"
         >
           Refresh
-        </button>
+        </MtButton>
       </div>
       <p v-if="historyLoading" class="reset-picker__hint" data-test="reset-picker-history-loading">Loading history points...</p>
       <p v-else-if="historyError" class="reset-picker__hint reset-picker__hint--warn" data-test="reset-picker-history-error">{{ historyError }}</p>
@@ -89,6 +88,7 @@
 import { computed, ref, watch } from 'vue'
 
 import ResetConfirmDialog from './ResetConfirmDialog.vue'
+import { MtButton } from '../ui'
 import type { ResetPreview, ResetResult } from '../api/client'
 import type { HistoryBatchSummary } from '../types'
 
@@ -216,8 +216,9 @@ const boundExecute = (a: string, identity: string): Promise<ResetResult> => prop
 .reset-picker__label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: #912018; }
 .reset-picker__input { padding: 6px 8px; border: 1px solid #d0d5dd; border-radius: 6px; max-width: 240px; }
 .reset-picker__select { min-width: min(520px, 100%); max-width: min(640px, 100%); }
-.reset-picker__refresh { padding: 6px 10px; border: 1px solid #d0d5dd; border-radius: 6px; background: #fff; color: #912018; cursor: pointer; }
-.reset-picker__refresh:disabled { cursor: default; opacity: 0.6; }
+/* .reset-picker__refresh: the Refresh control is now <MtButton> (ghost, token-styled); its bespoke
+   hardcoded-hex CSS was removed to avoid double-styling the MtButton root. Class + data-test kept for
+   selector stability. */
 .reset-picker__manual { color: #912018; font-size: 12px; }
 .reset-picker__manual > summary { cursor: pointer; }
 .reset-picker__manual .reset-picker__label { margin-top: 6px; }

--- a/apps/web/tests/reset-to-point-picker-migration.spec.ts
+++ b/apps/web/tests/reset-to-point-picker-migration.spec.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import ResetToPointPicker from '../src/multitable/components/ResetToPointPicker.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: ResetToPointPicker's Refresh control was migrated from a bespoke <button> to the shared
+// MtButton primitive (ghost). Its class `reset-picker__refresh` is unique, so the bespoke hex CSS was
+// removed. Behavior-preservation proof: it stays a native, keyboard-operable <button>; the :disabled
+// binding survives; clicking it still runs loadHistoryBatches → props.listHistoryEvents (same handler).
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.reset-picker').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ setup: () => () => h(ResetToPointPicker, props) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const enablingProps = (listHistoryEvents: unknown) => ({
+  pitResetEnabled: true,
+  baseId: 'b1',
+  sheetId: 's1',
+  listHistoryEvents,
+  resetPreview: vi.fn(),
+  resetExecute: vi.fn(),
+})
+const refreshBtn = (r: HTMLElement) => r.querySelector('[data-test="reset-picker-history-refresh"]') as HTMLButtonElement
+
+describe('ResetToPointPicker — MtButton migration (UI-P2-1c)', () => {
+  it('renders Refresh as a native <button> and enables it once history can load', async () => {
+    const listHistoryEvents = vi.fn().mockResolvedValue({ batches: [] })
+    const root = mount(enablingProps(listHistoryEvents))
+    await flush()
+    const btn = refreshBtn(root)
+    expect(btn).toBeTruthy()
+    expect(btn.tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+    expect(btn.disabled).toBe(false) // :disabled="historyLoading || !canLoadHistory" — enabled after load settles
+  })
+
+  it('clicking Refresh re-runs loadHistoryBatches → props.listHistoryEvents (handler unchanged)', async () => {
+    const listHistoryEvents = vi.fn().mockResolvedValue({ batches: [] })
+    const root = mount(enablingProps(listHistoryEvents))
+    await flush() // the immediate watch already called it once on mount
+    listHistoryEvents.mockClear()
+    refreshBtn(root).click()
+    await flush()
+    expect(listHistoryEvents).toHaveBeenCalledTimes(1) // the click, post-clear
+    expect(listHistoryEvents).toHaveBeenCalledWith('b1', expect.objectContaining({ sheetId: 's1' }))
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, unique-class). Refresh → MtButton ghost; bespoke hex CSS removed. `@click=loadHistoryBatches` + `:disabled` + data-test byte-identical (no emit — calls props.listHistoryEvents). Mount test (2/2): native button + enabled-once-loadable + click-re-invokes-listHistoryEvents. vue-tsc clean; no new hex; existing reset-tsource-picker (6) green.

Main-loop migration; gated by adversarial-reviewer next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)