### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaHierarchyView Add-root to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaHierarchyView.vue
+++ b/apps/web/src/multitable/components/MetaHierarchyView.vue
@@ -33,7 +33,7 @@
           <option value="hidden">{{ viewRenderLabel('hierarchy.hide', isZh) }}</option>
         </select>
       </label>
-      <button v-if="canCreate" class="meta-hierarchy__create" @click="emit('create-record', {})">{{ viewRenderLabel('hierarchy.addRoot', isZh) }}</button>
+      <MtButton v-if="canCreate" variant="primary" class="meta-hierarchy__create" @click="emit('create-record', {})">{{ viewRenderLabel('hierarchy.addRoot', isZh) }}</MtButton>
     </div>
 
     <div v-if="!parentField" class="meta-hierarchy__placeholder">
@@ -99,6 +99,7 @@ import {
 } from '../utils/comment-affordance'
 import { commentLabel } from '../utils/meta-comment-labels'
 import { managerLabel } from '../utils/meta-manager-labels'
+import { MtButton } from '../ui'
 import {
   openRecordCommentsAria,
   viewRenderLabel,
@@ -536,7 +537,9 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
 .meta-hierarchy__toolbar { display: flex; flex-wrap: wrap; gap: 10px; align-items: end; padding: 12px 16px; border-bottom: 1px solid #e2e8f0; background: #fff; }
 .meta-hierarchy__control { display: flex; flex-direction: column; gap: 4px; min-width: 130px; font-size: 11px; color: #64748b; }
 .meta-hierarchy__control select, .meta-hierarchy__control input { padding: 6px 8px; border: 1px solid #cbd5e1; border-radius: 6px; background: #fff; color: #334155; }
-.meta-hierarchy__create { padding: 7px 12px; border: 1px solid #2563eb; border-radius: 6px; background: #2563eb; color: #fff; cursor: pointer; }
+/* .meta-hierarchy__create: the Add-root control is now <MtButton variant="primary"> (bespoke #2563eb ==
+   --ms-color-primary); its bespoke hex CSS was removed to avoid double-styling the MtButton root. Class kept
+   for selector stability. The h()-rendered per-node controls (toggle/child-add/comment) stay bespoke. */
 .meta-hierarchy__placeholder, .meta-hierarchy__empty { margin: 24px; padding: 28px; border: 1px dashed #cbd5e1; border-radius: 10px; background: #fff; color: #64748b; text-align: center; display: flex; flex-direction: column; gap: 6px; }
 .meta-hierarchy__body { flex: 1; min-height: 0; overflow: auto; padding: 14px 16px 24px; }
 .meta-hierarchy__notice { margin-bottom: 10px; padding: 8px 10px; border: 1px solid #fde68a; border-radius: 8px; background: #fffbeb; color: #92400e; font-size: 12px; }

--- a/apps/web/tests/meta-hierarchy-view-migration.spec.ts
+++ b/apps/web/tests/meta-hierarchy-view-migration.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaHierarchyView from '../src/multitable/components/MetaHierarchyView.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaHierarchyView's toolbar "Add root" control was migrated from a bespoke <button> to the
+// shared MtButton primitive (variant="primary"; the bespoke #2563eb == --ms-color-primary). Its class is
+// unique, so the bespoke hex CSS was removed. The h()-rendered per-node controls (toggle/child-add/comment)
+// stay bespoke. Behavior-preservation proof: it stays a native, keyboard-operable <button> gated by
+// canCreate; clicking it still emits `create-record` with the SAME `{}` payload.
+
+const fields: MetaField[] = [
+  { id: 'fld_title', name: 'Title', type: 'string' },
+  { id: 'fld_parent', name: 'Parent', type: 'link' },
+]
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-hierarchy').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaHierarchyView, { fields, loading: false, rows: [], ...props }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const addRoot = (r: HTMLElement) => r.querySelector('.meta-hierarchy__create') as HTMLButtonElement | null
+
+describe('MetaHierarchyView — MtButton migration (UI-P2-1c)', () => {
+  it('renders Add-root as a native <button> only when canCreate', () => {
+    expect(addRoot(mount({ canCreate: false }))).toBeNull() // v-if="canCreate" preserved
+    const root = mount({ canCreate: true })
+    expect(addRoot(root)!.tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+  })
+
+  it('clicking Add-root emits `create-record` with {} (unchanged)', () => {
+    const onCreateRecord = vi.fn()
+    const root = mount({ canCreate: true, onCreateRecord })
+    addRoot(root)!.click()
+    expect(onCreateRecord).toHaveBeenCalledTimes(1)
+    expect(onCreateRecord).toHaveBeenCalledWith({})
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, unique-class). Toolbar 'Add root' → MtButton variant=primary (#2563eb == --ms-color-primary); bespoke hex CSS removed. `v-if=canCreate` + `@click=emit('create-record', {})` byte-identical; per-node h() controls stay bespoke. Mount test (2/2): native button gated by canCreate + create-record({}) emit. vue-tsc clean; no new hex; existing multitable-hierarchy-view (9) green.

Main-loop migration; gated by adversarial-reviewer next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)