### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaGanttView Add-task to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaGanttView.vue
+++ b/apps/web/src/multitable/components/MetaGanttView.vue
@@ -53,7 +53,7 @@
             <option value="month">{{ viewZoomLabel('month', isZh) }}</option>
           </select>
         </label>
-        <button v-if="canCreate" class="meta-gantt__create" @click="onQuickCreate">{{ viewRenderLabel('gantt.addTask', isZh) }}</button>
+        <MtButton v-if="canCreate" variant="primary" class="meta-gantt__create" @click="onQuickCreate">{{ viewRenderLabel('gantt.addTask', isZh) }}</MtButton>
       </div>
 
       <div v-if="!startFieldId || !endFieldId" class="meta-gantt__placeholder">
@@ -150,6 +150,7 @@ import { useLocale } from '../../composables/useLocale'
 import { formatFieldDisplay } from '../utils/field-display'
 import { isSelfTableLinkField, resolveGanttViewConfig } from '../utils/view-config'
 import { managerLabel } from '../utils/meta-manager-labels'
+import { MtButton } from '../ui'
 import {
   ganttResizeAria,
   unscheduledCount,
@@ -562,7 +563,10 @@ function onQuickCreate() {
 .meta-gantt__toolbar { display: flex; flex-wrap: wrap; gap: 10px; padding: 12px 16px; border-bottom: 1px solid #e2e8f0; background: #fff; }
 .meta-gantt__control { display: flex; flex-direction: column; gap: 4px; min-width: 118px; font-size: 11px; color: #64748b; }
 .meta-gantt__control select { padding: 6px 8px; border: 1px solid #cbd5e1; border-radius: 6px; background: #fff; color: #334155; }
-.meta-gantt__create { align-self: end; padding: 7px 12px; border: 1px solid #2563eb; border-radius: 6px; background: #2563eb; color: #fff; cursor: pointer; }
+/* .meta-gantt__create: the Add-task control is now <MtButton variant="primary"> (bespoke #2563eb ==
+   --ms-color-primary); its bespoke hex CSS was removed to avoid double-styling the MtButton root. Only the
+   toolbar LAYOUT property (align-self) is kept — MtButton doesn't provide it. Class kept for selectors. */
+.meta-gantt__create { align-self: end; }
 .meta-gantt__head { display: grid; grid-template-columns: 260px 1fr; min-height: 40px; border-bottom: 1px solid #e2e8f0; background: #f1f5f9; }
 .meta-gantt__task-col { padding: 8px 12px; border-right: 1px solid #e2e8f0; text-align: left; }
 .meta-gantt__task-col strong, .meta-gantt__task-col small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/apps/web/tests/meta-gantt-view-migration.spec.ts
+++ b/apps/web/tests/meta-gantt-view-migration.spec.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaGanttView from '../src/multitable/components/MetaGanttView.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaGanttView's toolbar "Add task" control was migrated from a bespoke <button> to the shared
+// MtButton primitive (variant="primary"; the bespoke #2563eb == --ms-color-primary). Its class is unique, so
+// the bespoke hex CSS was removed (only the toolbar `align-self` layout kept). Behavior-preservation proof:
+// it stays a native, keyboard-operable <button> gated by canCreate; clicking it still runs onQuickCreate →
+// emits `create-record` with the SAME date-field payload.
+
+const fields: MetaField[] = [
+  { id: 'fld_name', name: 'Name', type: 'string' },
+  { id: 'fld_start', name: 'Start', type: 'date' },
+  { id: 'fld_end', name: 'End', type: 'date' },
+]
+const viewConfig = { startFieldId: 'fld_start', endFieldId: 'fld_end', titleFieldId: 'fld_name' }
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  expect(document.querySelectorAll('.meta-gantt').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaGanttView, { fields, rows: [], loading: false, viewConfig, ...props }) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const createBtn = (r: HTMLElement) => r.querySelector('.meta-gantt__create') as HTMLButtonElement | null
+
+describe('MetaGanttView — MtButton migration (UI-P2-1c)', () => {
+  it('renders Add-task as a native <button> only when canCreate', () => {
+    expect(createBtn(mount({ canCreate: false }))).toBeNull() // v-if="canCreate" preserved
+    const root = mount({ canCreate: true })
+    expect(createBtn(root)!.tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+  })
+
+  it('clicking Add-task runs onQuickCreate → emits `create-record` with the date-field payload (unchanged)', () => {
+    const onCreateRecord = vi.fn()
+    const root = mount({ canCreate: true, onCreateRecord })
+    createBtn(root)!.click()
+    expect(onCreateRecord).toHaveBeenCalledTimes(1)
+    const payload = onCreateRecord.mock.calls[0][0]
+    expect(typeof payload).toBe('object')
+    expect(payload.fld_start).toBeTruthy() // startFieldId set → onQuickCreate seeds it (handler unchanged)
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, unique-class). Toolbar 'Add task' → MtButton variant=primary (#2563eb == --ms-color-primary); bespoke hex CSS removed, kept only align-self layout. `v-if=canCreate` + `@click=onQuickCreate` byte-identical (onQuickCreate→create-record). Mount test (2/2): native button gated by canCreate + create-record date-payload emit. vue-tsc clean; no new hex; existing multitable-gantt-view (17) green.

Main-loop migration; gated by adversarial-reviewer next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)