### PR TITLE
feat(web): BA-UI-3 Bridge Agent config validation + change-suggestion checklist (design-lock #3792, refs #3746)

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -28,6 +28,7 @@ on:
       - 'apps/web/src/services/integration/readSourceCompositions.ts'
       - 'apps/web/src/services/integration/errorCodeLabels.ts'
       - 'apps/web/src/services/integration/fieldHints.ts'
+      - 'apps/web/src/services/integration/bridgeAgentConfigCheck.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceWizard.vue'
       - 'apps/web/src/services/integration/readSourceModePresets.ts'
@@ -57,6 +58,7 @@ on:
       - 'apps/web/tests/multitable-resolver-vocab-mirror.spec.ts'
       - 'apps/web/tests/integrationErrorCodeLabels.spec.ts'
       - 'apps/web/tests/fieldHints.spec.ts'
+      - 'apps/web/tests/bridgeAgentConfigCheck.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceWizard.spec.ts'
       - 'apps/web/tests/readSourceModePresets.spec.ts'
@@ -91,6 +93,7 @@ on:
       - 'apps/web/src/services/integration/readSourceCompositions.ts'
       - 'apps/web/src/services/integration/errorCodeLabels.ts'
       - 'apps/web/src/services/integration/fieldHints.ts'
+      - 'apps/web/src/services/integration/bridgeAgentConfigCheck.ts'
       - 'apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceWizard.vue'
       - 'apps/web/src/services/integration/readSourceModePresets.ts'
@@ -120,6 +123,7 @@ on:
       - 'apps/web/tests/multitable-resolver-vocab-mirror.spec.ts'
       - 'apps/web/tests/integrationErrorCodeLabels.spec.ts'
       - 'apps/web/tests/fieldHints.spec.ts'
+      - 'apps/web/tests/bridgeAgentConfigCheck.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceWizard.spec.ts'
       - 'apps/web/tests/readSourceModePresets.spec.ts'
@@ -197,4 +201,4 @@ jobs:
       # Consolidated here into the SINGLE unioned list (verified green on both Node 20 and this repo's
       # default Node before landing) — do not reintroduce a second `run:` key; add new specs to this one.
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck --reporter=dot

--- a/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
+++ b/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
@@ -275,6 +275,143 @@
             </tbody>
           </table>
         </div>
+
+        <!-- BA-UI-3 (docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-3):
+             values-free config-validation checklist, scoped to the instance selected above (reuses
+             `selectedSystemId` + the already-fetched `objects` — zero new network calls). -->
+        <div class="bridge-agent__config-check" data-testid="bridge-agent-config-check">
+          <h3>
+            <el-icon class="bridge-agent__card-icon"><List /></el-icon>
+            {{ bi('配置校验', 'Config validation') }}
+          </h3>
+          <p class="integration-workbench__hint">{{ bi(
+            '针对当前选中实例的公开配置形状与已加载的对象列表做只读校验；只显示通过/提示/未通过状态与固定说明文字，不回显任何具体配置值。',
+            "Read-only checklist against the selected instance's public config shape and the already-loaded object list; only a pass/attention/fail status and fixed copy are shown — no configuration value is ever echoed.",
+          ) }}</p>
+          <ul class="bridge-agent__checklist" data-testid="bridge-agent-config-check-list">
+            <li
+              v-for="item in configCheckItems"
+              :key="item.id"
+              class="bridge-agent__checklist-item"
+              :data-testid="`bridge-agent-config-check-item-${item.id}`"
+              :data-status="item.status"
+            >
+              <el-icon
+                class="bridge-agent__checklist-icon"
+                :class="`bridge-agent__checklist-icon--${item.status}`"
+              >
+                <CircleCheck v-if="item.status === 'pass'" />
+                <Warning v-else-if="item.status === 'warn'" />
+                <CircleClose v-else />
+              </el-icon>
+              <span class="bridge-agent__checklist-title">{{ configCheckTitleLabel(item.id) }}</span>
+              <span
+                class="bridge-agent__badge"
+                :class="`bridge-agent__badge--check-${item.status}`"
+              >{{ configCheckStatusLabel(item.status) }}</span>
+              <span
+                class="bridge-agent__checklist-text"
+                :data-testid="`bridge-agent-config-check-item-label-${item.id}`"
+              >{{ configCheckItemLabel(item) }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <!-- BA-UI-3: change-suggestion / implementation checklist builder — operator-typed object/
+             field-KEY names (never values) -> a values-free, copyable suggestion text. Purely local:
+             no apply endpoint, no local-config write, no .ps1 invocation (lock §3). -->
+        <div class="bridge-agent__suggestion" data-testid="bridge-agent-suggestion-builder">
+          <h3>
+            <el-icon class="bridge-agent__card-icon"><DocumentCopy /></el-icon>
+            {{ bi('变更建议 / 实施清单', 'Change suggestion / implementation checklist') }}
+          </h3>
+          <p class="integration-workbench__hint">{{ bi(
+            '在此列出你希望新增暴露的对象与字段名（仅名称，不涉及任何取值）；生成的建议文本供人工确认后，由受控后端或运维脚本落地——本页不会据此做任何直接修改，也不会调用任何写入接口。',
+            'List the objects and field-key names you want to newly expose here (names only, never values); the generated suggestion text is for a human to hand to the controlled backend or ops script to apply — this page never makes any direct change or calls any write endpoint from it.',
+          ) }}</p>
+
+          <div
+            v-for="(row, index) in suggestionDrafts"
+            :key="index"
+            class="bridge-agent__suggestion-row"
+            :data-testid="`bridge-agent-suggestion-row-${index}`"
+          >
+            <label class="bridge-agent__suggestion-field">
+              <span>{{ bi('对象名', 'Object name') }}</span>
+              <input
+                v-model="row.objectName"
+                type="text"
+                :data-testid="`bridge-agent-suggestion-object-${index}`"
+                :placeholder="bi('例如 material_extra', 'e.g. material_extra')"
+              >
+            </label>
+            <label class="bridge-agent__suggestion-field">
+              <span>{{ bi('字段名（逗号分隔）', 'Field names (comma-separated)') }}</span>
+              <input
+                v-model="row.fieldKeysText"
+                type="text"
+                :data-testid="`bridge-agent-suggestion-fields-${index}`"
+                :placeholder="bi('例如 field_a, field_b', 'e.g. field_a, field_b')"
+              >
+            </label>
+            <button
+              type="button"
+              class="integration-workbench__link-button"
+              :data-testid="`bridge-agent-suggestion-remove-${index}`"
+              :disabled="suggestionDrafts.length <= 1"
+              @click="removeSuggestionDraftRow(index)"
+            >{{ bi('删除', 'Remove') }}</button>
+          </div>
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="bridge-agent-suggestion-add-row"
+            @click="addSuggestionDraftRow"
+          >{{ bi('添加一行', 'Add row') }}</button>
+
+          <div
+            v-if="suggestionResult.entries.length === 0"
+            class="integration-workbench__empty"
+            data-testid="bridge-agent-suggestion-empty"
+          >
+            <strong data-testid="bridge-agent-suggestion-empty-what">{{ bi(
+              '这里会把上面填写的对象/字段名整理成一份可复制的变更建议文本。',
+              'This turns the object/field names you enter above into a copyable change-suggestion text.',
+            ) }}</strong>
+            <p data-testid="bridge-agent-suggestion-empty-first-step">{{ bi(
+              '第一步：在上方填写至少一个对象名（可选填字段名），建议文本会自动生成。',
+              'First step: enter at least one object name above (field names are optional); the suggestion text is generated automatically.',
+            ) }}</p>
+          </div>
+          <div v-else class="bridge-agent__suggestion-output">
+            <h4>{{ bi('生成的建议文本（可复制）', 'Generated suggestion text (copyable)') }}</h4>
+            <textarea
+              class="bridge-agent__suggestion-text"
+              data-testid="bridge-agent-suggestion-text"
+              readonly
+              :value="suggestionResult.text"
+            />
+            <button
+              type="button"
+              class="integration-workbench__button"
+              data-testid="bridge-agent-suggestion-copy"
+              @click="copySuggestionText"
+            >
+              <el-icon><DocumentCopy /></el-icon>
+              {{ bi('复制建议文本', 'Copy suggestion text') }}
+            </button>
+            <span
+              v-if="copyState === 'copied'"
+              data-testid="bridge-agent-suggestion-copy-state"
+              class="integration-workbench__hint"
+            >{{ bi('已复制', 'Copied') }}</span>
+            <span
+              v-else-if="copyState === 'failed'"
+              data-testid="bridge-agent-suggestion-copy-state"
+              class="bridge-agent__error"
+            >{{ bi('复制失败，请手动选择文本复制。', 'Copy failed; select the text manually to copy.') }}</span>
+          </div>
+        </div>
       </template>
     </el-card>
   </section>
@@ -291,8 +428,13 @@
 // `POST /query/:object` (the data-plane read) is never called here either (design-lock §4).
 //
 // Security bounds (lock §2.1, binding):
-//   - No credential/host/connection-string/config is ever rendered — only the coarse
-//     `system.hasCredentials` boolean ("已配置/未配置"), never `system.config`/`system.credentials`.
+//   - No credential/host/connection-string is ever rendered — only the coarse `system.hasCredentials`
+//     boolean ("已配置/未配置"), never `system.credentials`. BA-UI-3 (below) is a lock-authorized,
+//     narrower exception for `system.config`: its pure checklist (bridgeAgentConfigCheck.ts) reads a
+//     handful of `system.config` KEY NAMES for PRESENCE/SHAPE only (is baseUrl set? is its hostname
+//     loopback-shaped? is authMode declared? …) — no config VALUE is ever placed into the DOM, only a
+//     fixed pass/warn/fail status + a non-interpolated `labelKey` string. `system.config` itself is
+//     still never read directly by THIS file — only handed, opaque, to the pure util below.
 //   - No raw error text is ever rendered. Every failure surface routes through the IU-1
 //     `integrationErrorCodeDisplayLabel` helper (label-only). Unlike the closed, backend-owned code
 //     families IU-1 already labels, a Bridge Agent HTTP error body can carry an operator-supplied
@@ -301,9 +443,23 @@
 //     unregistered/dynamic code safely degrades to the generic "unknown error" label). Object/schema
 //     load failures carry no code at all (the shared `parseIntegrationResponse` helper does not
 //     preserve one), so those use a fixed, values-free bilingual string.
+//   - BA-UI-3's change-suggestion builder (buildBridgeAgentChangeSuggestion) never calls any apply
+//     endpoint, never edits local config, never touches the .ps1 script — it is a pure, local text
+//     generator from OPERATOR-TYPED object/field-KEY names (never values), gated by an identifier-safe
+//     pattern so a secret/host/connection-string-shaped string typed into a name field is dropped
+//     (counted, never echoed) rather than rendered (lock §3: applied only by a controlled backend or
+//     ops script, never this page).
 import { computed, reactive, ref, watch } from 'vue'
-import { Connection, Lock, Refresh } from '@element-plus/icons-vue'
+import { CircleCheck, CircleClose, Connection, DocumentCopy, List, Lock, Refresh, Warning } from '@element-plus/icons-vue'
 import { useLocale } from '../../composables/useLocale'
+import {
+  bridgeAgentConfigCheckLabel,
+  buildBridgeAgentChangeSuggestion,
+  computeBridgeAgentConfigCheck,
+  type BridgeAgentConfigCheckItem,
+  type BridgeAgentConfigCheckStatus,
+  type BridgeAgentSuggestionObjectDraft,
+} from '../../services/integration/bridgeAgentConfigCheck'
 import { integrationErrorCodeDisplayLabel, integrationErrorCodeHint } from '../../services/integration/errorCodeLabels'
 import { integrationFieldHint, type IntegrationFieldHintKey } from '../../services/integration/fieldHints'
 import {
@@ -719,6 +875,96 @@ watch(
   },
   { immediate: true },
 )
+
+// --- BA-UI-3 (docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-3): config
+// validation + change-suggestion checklist. Both cards are purely DERIVED/LOCAL — zero new network
+// calls: the checklist is computed off state this section already holds (the selected instance's
+// `system.config` + the already-fetched `objects` name list), and the suggestion builder is a local
+// text generator over operator-typed drafts. Neither ever calls an apply endpoint, edits local config,
+// or touches the .ps1 script (lock §3: applied only by a controlled backend or ops script).
+
+const selectedBridgeSystem = computed(() => bridgeSystems.value.find((system) => system.id === selectedSystemId.value) || null)
+
+// Values-free by construction: computeBridgeAgentConfigCheck() never returns a config value, only a
+// fixed status + labelKey per item (see bridgeAgentConfigCheck.ts's module header).
+const configCheckItems = computed<BridgeAgentConfigCheckItem[]>(() => {
+  const system = selectedBridgeSystem.value
+  if (!system) return []
+  return computeBridgeAgentConfigCheck({
+    config: system.config,
+    objectNames: objects.value.map((object) => object.name),
+  })
+})
+
+function configCheckItemLabel(item: BridgeAgentConfigCheckItem): string {
+  return bridgeAgentConfigCheckLabel(item.labelKey, locale.value)
+}
+
+function configCheckStatusLabel(status: BridgeAgentConfigCheckStatus): string {
+  if (status === 'pass') return bi('通过', 'Pass')
+  if (status === 'warn') return bi('提示', 'Attention')
+  return bi('未通过', 'Fail')
+}
+
+function configCheckTitleLabel(id: BridgeAgentConfigCheckItem['id']): string {
+  if (id === 'requiredFields') return bi('必填字段', 'Required fields')
+  if (id === 'limits') return bi('Limits', 'Limits')
+  if (id === 'authMode') return bi('Auth mode', 'Auth mode')
+  if (id === 'localhostBoundary') return bi('本机边界', 'Localhost boundary')
+  if (id === 'rawSqlForbidden') return bi('禁止 raw SQL', 'Raw SQL forbidden')
+  return bi('对象 allowlist 完整性', 'Object allowlist completeness')
+}
+
+// --- Change-suggestion builder: operator-typed object/field-KEY names (never values) -> a values-free
+// copyable suggestion text. Row state stays as raw strings (comma-separated field keys) so the input
+// controls are simple text fields; parsing/validation happens in the pure util on every recompute.
+interface SuggestionDraftRow {
+  objectName: string
+  fieldKeysText: string
+}
+
+function newSuggestionDraftRow(): SuggestionDraftRow {
+  return { objectName: '', fieldKeysText: '' }
+}
+
+const suggestionDrafts = ref<SuggestionDraftRow[]>([newSuggestionDraftRow()])
+
+function addSuggestionDraftRow(): void {
+  suggestionDrafts.value = [...suggestionDrafts.value, newSuggestionDraftRow()]
+}
+
+function removeSuggestionDraftRow(index: number): void {
+  if (suggestionDrafts.value.length <= 1) return
+  suggestionDrafts.value = suggestionDrafts.value.filter((_, i) => i !== index)
+}
+
+const suggestionResult = computed(() => {
+  const drafts: BridgeAgentSuggestionObjectDraft[] = suggestionDrafts.value.map((row) => ({
+    objectName: row.objectName,
+    fieldKeys: row.fieldKeysText.split(',').map((key) => key.trim()).filter(Boolean),
+  }))
+  return buildBridgeAgentChangeSuggestion(drafts, locale.value, selectedBridgeSystem.value?.name ?? null)
+})
+
+const copyState = ref<'idle' | 'copied' | 'failed'>('idle')
+
+async function copySuggestionText(): Promise<void> {
+  copyState.value = 'idle'
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      await navigator.clipboard.writeText(suggestionResult.value.text)
+      copyState.value = 'copied'
+      return
+    }
+  } catch {
+    // fall through to the failed state below
+  }
+  copyState.value = 'failed'
+}
+
+watch(suggestionDrafts, () => {
+  copyState.value = 'idle'
+}, { deep: true })
 </script>
 
 <style scoped>
@@ -997,5 +1243,129 @@ watch(
   .bridge-agent__objects-head {
     display: grid;
   }
+}
+
+/* BA-UI-3 own classes below (docs/development/bridge-agent-admin-page-design-lock-20260707.md §3
+   BA-UI-3) — fresh prefixes, token-only colors, same discipline as the BA-UI-1 classes above. */
+
+.bridge-agent__config-check,
+.bridge-agent__suggestion {
+  margin-top: 20px;
+}
+
+.bridge-agent__config-check h3,
+.bridge-agent__suggestion h3 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bridge-agent__checklist {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.bridge-agent__checklist-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--ms-text-1);
+}
+
+.bridge-agent__checklist-icon--pass {
+  color: var(--el-color-success);
+}
+
+.bridge-agent__checklist-icon--warn {
+  color: var(--el-color-warning);
+}
+
+.bridge-agent__checklist-icon--fail {
+  color: var(--el-color-danger);
+}
+
+.bridge-agent__checklist-title {
+  font-weight: 700;
+  min-width: 140px;
+}
+
+.bridge-agent__checklist-text {
+  color: var(--ms-text-2);
+  flex: 1;
+  min-width: 200px;
+}
+
+.bridge-agent__badge--check-pass {
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
+}
+
+.bridge-agent__badge--check-warn {
+  background: var(--el-color-warning-light-9);
+  color: var(--el-color-warning-dark-2);
+}
+
+.bridge-agent__badge--check-fail {
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger);
+}
+
+.bridge-agent__suggestion-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.bridge-agent__suggestion-field {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--ms-text-2);
+  flex: 1;
+  min-width: 180px;
+}
+
+.bridge-agent__suggestion-field input {
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  color: var(--ms-text-1);
+  font: inherit;
+}
+
+.bridge-agent__suggestion-output {
+  margin-top: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.bridge-agent__suggestion-output h4 {
+  margin: 0;
+  font-size: 12px;
+  color: var(--ms-text-1);
+}
+
+.bridge-agent__suggestion-text {
+  width: 100%;
+  min-height: 120px;
+  border: 1px solid var(--ms-border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: var(--ms-text-1);
+  background: var(--ms-bg-page);
+  font: inherit;
+  font-family: inherit;
+  white-space: pre-wrap;
+  resize: vertical;
 }
 </style>

--- a/apps/web/src/services/integration/bridgeAgentConfigCheck.ts
+++ b/apps/web/src/services/integration/bridgeAgentConfigCheck.ts
@@ -1,0 +1,396 @@
+// Bridge Agent config validation + change-suggestion checklist (BA-UI-3, design-lock
+// docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-3). Predecessors: BA-UI-1
+// (#3824, observability) + BA-UI-2 (#3840, values-free probe). This slice is READ-ONLY + SUGGESTIONS
+// ONLY — no controlled apply, no backend write (lock §3: "由受控后端或运维脚本应用" — the controlled
+// backend or an ops script applies any change, never this page).
+//
+// Pure, framework-free module: no Vue import, no DOM, no `fetch`/apiFetch. Two independent surfaces:
+//
+//   1. computeBridgeAgentConfigCheck(input) — a fixed 6-item values-free checklist over a bridge-agent
+//      system's PUBLIC config (the same `system.config` shape BA-UI-1 already receives on the wire —
+//      server-redacted via sanitizeIntegrationPayload, see plugins/plugin-integration-core/lib/
+//      external-systems.cjs rowToPublicExternalSystem) plus the already-fetched /objects name list.
+//      Every check reads specific KEY NAMES for PRESENCE/SHAPE only; no config VALUE is ever placed
+//      into an output field — every item's `labelKey` is a fixed, non-interpolated string looked up in
+//      BRIDGE_AGENT_CONFIG_CHECK_LABELS below. (The one exception: `config.baseUrl`/`bridgeUrl`/`url`
+//      is parsed internally, via `new URL()`, purely to test whether its HOSTNAME is loopback-shaped —
+//      the parsed value itself never escapes that boolean test.)
+//
+//   2. buildBridgeAgentChangeSuggestion(drafts, locale, targetLabel?) — given OPERATOR-SPECIFIED new
+//      object/field-KEY names (never values — the operator is naming things to add, the same trust
+//      boundary BA-UI-1 already extends to `system.name`), renders a values-free, copyable "变更建议 /
+//      实施清单" string an admin can hand to the controlled backend or the existing
+//      scripts/ops/bridge-agent-readonly.ps1 script. Every candidate name is checked against a safe
+//      identifier pattern (mirrors bridge-agent-readonly-adapter.cjs's SAFE_OBJECT_NAME_PATTERN) —
+//      anything not identifier-shaped (contains `=`, `;`, `:`, `.`, whitespace, etc. — exactly the
+//      shapes a secret, connection string, or host would carry) is dropped and only COUNTED, never
+//      echoed, so a stray secret-shaped string pasted into a name field can never ride along into the
+//      generated text.
+
+import type { AppLocale } from '../../composables/useLocale'
+
+// --- shared helpers ------------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+// #### 1. Config checklist ##########################################################################
+
+export type BridgeAgentConfigCheckStatus = 'pass' | 'warn' | 'fail'
+
+export type BridgeAgentConfigCheckItemId =
+  | 'requiredFields'
+  | 'limits'
+  | 'authMode'
+  | 'localhostBoundary'
+  | 'rawSqlForbidden'
+  | 'objectAllowlist'
+
+export type BridgeAgentConfigCheckLabelKey =
+  | 'requiredFields.present'
+  | 'requiredFields.missing'
+  | 'limits.pass'
+  | 'limits.fail'
+  | 'authMode.declared'
+  | 'authMode.undeclared'
+  | 'localhostBoundary.pass'
+  | 'localhostBoundary.unknown'
+  | 'localhostBoundary.fail'
+  | 'rawSqlForbidden.pass'
+  | 'rawSqlForbidden.fail'
+  | 'objectAllowlist.complete'
+  | 'objectAllowlist.partial'
+  | 'objectAllowlist.empty'
+
+export interface BridgeAgentConfigCheckItem {
+  id: BridgeAgentConfigCheckItemId
+  status: BridgeAgentConfigCheckStatus
+  labelKey: BridgeAgentConfigCheckLabelKey
+}
+
+export interface BridgeAgentConfigCheckInput {
+  // The system's PUBLIC config (already server-redacted; see module header). May be absent/null.
+  config?: Record<string, unknown> | null
+  // Object NAMES only, from the already-fetched /objects list — never a full object/schema payload.
+  objectNames?: string[] | null
+}
+
+// Values-free, exact-key label map — same shape/discipline as errorCodeLabels.ts / fieldHints.ts.
+// Every entry is a fixed, non-interpolated sentence: no config value, host, or object/field name is
+// ever substituted into these strings.
+export const BRIDGE_AGENT_CONFIG_CHECK_LABELS: Record<BridgeAgentConfigCheckLabelKey, { zh: string; en: string }> = {
+  'requiredFields.present': {
+    zh: '必填连接字段已配置（baseUrl / bridgeUrl / url 之一）。',
+    en: 'A required connection field is configured (one of baseUrl / bridgeUrl / url).',
+  },
+  'requiredFields.missing': {
+    zh: '缺少必填连接字段：未找到 baseUrl / bridgeUrl / url。',
+    en: 'A required connection field is missing: no baseUrl / bridgeUrl / url was found.',
+  },
+  'limits.pass': {
+    zh: 'sampleLimit / maxLimit 未配置或在合理范围内。',
+    en: 'sampleLimit / maxLimit are unset or within a sane range.',
+  },
+  'limits.fail': {
+    zh: 'sampleLimit / maxLimit 配置无效，或超出允许范围。',
+    en: 'sampleLimit / maxLimit are invalid, or exceed the allowed range.',
+  },
+  'authMode.declared': {
+    zh: '已显式声明 auth mode。',
+    en: 'An auth mode is explicitly declared.',
+  },
+  'authMode.undeclared': {
+    zh: '未显式声明 auth mode，将按隐式默认行为处理。',
+    en: 'No auth mode is explicitly declared; the implicit default behavior applies.',
+  },
+  'localhostBoundary.pass': {
+    zh: '连接地址的形状是本机回环地址（127.0.0.1 / localhost）。',
+    en: 'The connection address is loopback-shaped (127.0.0.1 / localhost).',
+  },
+  'localhostBoundary.unknown': {
+    zh: '缺少连接地址，暂无法核实本机边界。',
+    en: 'No connection address is present, so the localhost boundary cannot be verified yet.',
+  },
+  'localhostBoundary.fail': {
+    zh: '连接地址的形状不是本机回环地址。',
+    en: 'The connection address is not loopback-shaped.',
+  },
+  'rawSqlForbidden.pass': {
+    zh: '配置中未出现 raw SQL 相关键。',
+    en: 'No raw-SQL-shaped key is present in the config.',
+  },
+  'rawSqlForbidden.fail': {
+    zh: '配置中出现了 raw SQL 相关键，应予以移除。',
+    en: 'A raw-SQL-shaped key is present in the config and should be removed.',
+  },
+  'objectAllowlist.complete': {
+    zh: '预期的 material / bom / bom_child 风格对象均已出现在 allowlist 中。',
+    en: 'The expected material / bom / bom_child-style objects are all present in the allowlist.',
+  },
+  'objectAllowlist.partial': {
+    zh: '部分预期对象尚未出现在 allowlist 中。',
+    en: 'Some expected objects are not yet present in the allowlist.',
+  },
+  'objectAllowlist.empty': {
+    zh: 'allowlist 当前为空，暂无法评估完整性。',
+    en: 'The allowlist is currently empty, so completeness cannot be assessed yet.',
+  },
+}
+
+export function bridgeAgentConfigCheckLabel(labelKey: BridgeAgentConfigCheckLabelKey, locale: AppLocale): string {
+  const entry = BRIDGE_AGENT_CONFIG_CHECK_LABELS[labelKey]
+  return locale === 'zh-CN' ? entry.zh : entry.en
+}
+
+// Mirrors bridge-agent-readonly-adapter.cjs's normalizeBaseUrl() input precedence.
+function firstBaseUrlLike(config: Record<string, unknown>): string | null {
+  if (isNonEmptyString(config.baseUrl)) return config.baseUrl
+  if (isNonEmptyString(config.bridgeUrl)) return config.bridgeUrl
+  if (isNonEmptyString(config.url)) return config.url
+  return null
+}
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+
+// Returns a boolean ONLY — the parsed URL/hostname is never retained past this call.
+function isLoopbackBaseUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw)
+    return LOOPBACK_HOSTNAMES.has(url.hostname.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+function requiredFieldsCheck(config: Record<string, unknown>): BridgeAgentConfigCheckItem {
+  return firstBaseUrlLike(config)
+    ? { id: 'requiredFields', status: 'pass', labelKey: 'requiredFields.present' }
+    : { id: 'requiredFields', status: 'fail', labelKey: 'requiredFields.missing' }
+}
+
+// Mirrors bridge-agent-readonly-adapter.cjs's normalizeLimits() defaults/ceiling.
+const DEFAULT_SAMPLE_LIMIT = 3
+const DEFAULT_MAX_LIMIT = 20
+const MAX_ADAPTER_LIMIT = 500
+
+function isConfiguredPositiveInteger(value: unknown): boolean {
+  const numeric = Number(value)
+  return Number.isInteger(numeric) && numeric > 0
+}
+
+function limitsCheck(config: Record<string, unknown>): BridgeAgentConfigCheckItem {
+  const sampleRaw = config.sampleLimit
+  const maxRaw = config.maxLimit
+  const sampleConfigured = sampleRaw !== undefined && sampleRaw !== null && sampleRaw !== ''
+  const maxConfigured = maxRaw !== undefined && maxRaw !== null && maxRaw !== ''
+
+  if (sampleConfigured && !isConfiguredPositiveInteger(sampleRaw)) {
+    return { id: 'limits', status: 'fail', labelKey: 'limits.fail' }
+  }
+  if (maxConfigured && !isConfiguredPositiveInteger(maxRaw)) {
+    return { id: 'limits', status: 'fail', labelKey: 'limits.fail' }
+  }
+
+  const effectiveSample = sampleConfigured ? Number(sampleRaw) : DEFAULT_SAMPLE_LIMIT
+  const effectiveMax = maxConfigured ? Number(maxRaw) : DEFAULT_MAX_LIMIT
+
+  if (effectiveSample > effectiveMax) {
+    return { id: 'limits', status: 'fail', labelKey: 'limits.fail' }
+  }
+  if (effectiveMax > MAX_ADAPTER_LIMIT) {
+    return { id: 'limits', status: 'fail', labelKey: 'limits.fail' }
+  }
+  return { id: 'limits', status: 'pass', labelKey: 'limits.pass' }
+}
+
+function authModeCheck(config: Record<string, unknown>): BridgeAgentConfigCheckItem {
+  return isNonEmptyString(config.authMode)
+    ? { id: 'authMode', status: 'pass', labelKey: 'authMode.declared' }
+    : { id: 'authMode', status: 'warn', labelKey: 'authMode.undeclared' }
+}
+
+function localhostBoundaryCheck(config: Record<string, unknown>): BridgeAgentConfigCheckItem {
+  const raw = firstBaseUrlLike(config)
+  if (!raw) return { id: 'localhostBoundary', status: 'warn', labelKey: 'localhostBoundary.unknown' }
+  return isLoopbackBaseUrl(raw)
+    ? { id: 'localhostBoundary', status: 'pass', labelKey: 'localhostBoundary.pass' }
+    : { id: 'localhostBoundary', status: 'fail', labelKey: 'localhostBoundary.fail' }
+}
+
+// Mirrors bridge-agent-readonly-adapter.cjs's RAW_SQL_KEYS. This is a config-HYGIENE check (does the
+// stored config itself carry a raw-SQL-shaped key an operator may have added) — distinct from, and a
+// meaningful complement to, the adapter's `guardrails.read.noRawSql` flag, which is a STRUCTURAL
+// property of the `bridge:legacy-sql-readonly` kind (always `true` for every instance of this kind, so
+// it carries no per-system signal and is not itself checked here).
+const RAW_SQL_KEYS = ['sql', 'rawSql', 'rawSQL', 'queryText', 'statement'] as const
+
+function hasRawSqlKey(container: Record<string, unknown>): boolean {
+  return RAW_SQL_KEYS.some((key) => Object.prototype.hasOwnProperty.call(container, key))
+}
+
+function rawSqlForbiddenCheck(config: Record<string, unknown>): BridgeAgentConfigCheckItem {
+  const nestedOptions = isPlainObject(config.options) ? config.options : null
+  const offending = hasRawSqlKey(config) || (nestedOptions !== null && hasRawSqlKey(nestedOptions))
+  return offending
+    ? { id: 'rawSqlForbidden', status: 'fail', labelKey: 'rawSqlForbidden.fail' }
+    : { id: 'rawSqlForbidden', status: 'pass', labelKey: 'rawSqlForbidden.pass' }
+}
+
+// Expected object-name TOKENS for a material/BOM-style legacy-SQL bridge (the demand anchor, #3746).
+// Matching is case-insensitive substring on a normalized (alphanumeric-only) form of each object name,
+// so real-world prefixed names (e.g. "T_BOM_CHILD", "t-bom-child") still match. This is deliberately a
+// coarse, advisory heuristic (never a hard gate) — a bridge legitimately exposing only "material" is
+// not wrong, it is simply flagged 'partial' so an admin can decide whether to extend it.
+const EXPECTED_OBJECT_TOKENS = [
+  { id: 'material', token: 'material' },
+  { id: 'bom', token: 'bom' },
+  { id: 'bomChild', token: 'bomchild' },
+] as const
+
+function normalizeObjectNameForMatch(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function objectAllowlistCheck(objectNames: string[]): BridgeAgentConfigCheckItem {
+  if (objectNames.length === 0) {
+    return { id: 'objectAllowlist', status: 'warn', labelKey: 'objectAllowlist.empty' }
+  }
+  const normalized = objectNames.map(normalizeObjectNameForMatch)
+  const allPresent = EXPECTED_OBJECT_TOKENS.every(({ token }) => normalized.some((name) => name.includes(token)))
+  return allPresent
+    ? { id: 'objectAllowlist', status: 'pass', labelKey: 'objectAllowlist.complete' }
+    : { id: 'objectAllowlist', status: 'warn', labelKey: 'objectAllowlist.partial' }
+}
+
+/**
+ * Fixed 6-item, deterministically-ordered checklist (lock §2.1 / §3): required fields / limits /
+ * auth mode declared / localhost boundary / raw-SQL forbidden / object-allowlist completeness. Never
+ * throws — an absent/malformed `config` is treated as `{}`, an absent/malformed `objectNames` as `[]`.
+ */
+export function computeBridgeAgentConfigCheck(input: BridgeAgentConfigCheckInput): BridgeAgentConfigCheckItem[] {
+  const config = isPlainObject(input?.config) ? input.config : {}
+  const objectNames = Array.isArray(input?.objectNames)
+    ? input.objectNames.filter((name): name is string => typeof name === 'string')
+    : []
+  return [
+    requiredFieldsCheck(config),
+    limitsCheck(config),
+    authModeCheck(config),
+    localhostBoundaryCheck(config),
+    rawSqlForbiddenCheck(config),
+    objectAllowlistCheck(objectNames),
+  ]
+}
+
+// #### 2. Change-suggestion builder #################################################################
+
+// Mirrors bridge-agent-readonly-adapter.cjs's SAFE_OBJECT_NAME_PATTERN — applied to BOTH object names
+// and field-key names here. This is the values-free gate on operator input: a secret, host, connection
+// string, or token is essentially guaranteed to contain a character outside `[A-Za-z0-9_]` (`=`, `;`,
+// `:`, `.`, whitespace, …), so it fails this pattern and is dropped rather than echoed.
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+const MAX_IDENTIFIER_LENGTH = 64
+
+function isSafeIdentifier(value: string): boolean {
+  return value.length > 0 && value.length <= MAX_IDENTIFIER_LENGTH && SAFE_IDENTIFIER_PATTERN.test(value)
+}
+
+export interface BridgeAgentSuggestionObjectDraft {
+  objectName: string
+  fieldKeys: string[]
+}
+
+export interface BridgeAgentSuggestionEntryResult {
+  // Present only when the object name itself was identifier-safe (an invalid object name drops the
+  // whole entry — see `invalidObjectCount` below — so every entry in `entries` has a valid name).
+  objectName: string
+  // Only the VALID field keys (identifier-safe ones); invalid ones are dropped and merely counted.
+  fieldKeys: string[]
+}
+
+export interface BridgeAgentChangeSuggestionResult {
+  entries: BridgeAgentSuggestionEntryResult[]
+  invalidObjectCount: number
+  invalidFieldKeyCount: number
+  // The full copyable values-free suggestion text (zh or en per `locale`) — this is a SUGGESTION only;
+  // nothing here is applied by this page (lock §3: applied by the controlled backend or ops script).
+  text: string
+}
+
+/**
+ * Builds a values-free "变更建议 / 实施清单" from OPERATOR-SPECIFIED new object/field-key names (never
+ * values). Every name is validated against `SAFE_IDENTIFIER_PATTERN`; anything that fails is dropped
+ * from the rendered text and only counted (`invalidObjectCount` / `invalidFieldKeyCount`), so a
+ * secret/host/connection-string-shaped string pasted into a name field can never appear in `text`.
+ * `targetLabel` (optional) is a plain system NAME for a documentation header line — the same trust
+ * boundary BA-UI-1 already extends to `system.name` elsewhere in this section (never a config value).
+ */
+export function buildBridgeAgentChangeSuggestion(
+  drafts: BridgeAgentSuggestionObjectDraft[],
+  locale: AppLocale,
+  targetLabel?: string | null,
+): BridgeAgentChangeSuggestionResult {
+  const isZh = locale === 'zh-CN'
+  const safeDrafts = Array.isArray(drafts) ? drafts : []
+
+  let invalidObjectCount = 0
+  let invalidFieldKeyCount = 0
+  const entries: BridgeAgentSuggestionEntryResult[] = []
+
+  for (const draft of safeDrafts) {
+    const rawObjectName = typeof draft?.objectName === 'string' ? draft.objectName.trim() : ''
+    if (!rawObjectName) continue
+    if (!isSafeIdentifier(rawObjectName)) {
+      invalidObjectCount += 1
+      continue
+    }
+    const rawFieldKeys = Array.isArray(draft?.fieldKeys) ? draft.fieldKeys : []
+    const fieldKeys: string[] = []
+    for (const key of rawFieldKeys) {
+      const trimmed = typeof key === 'string' ? key.trim() : ''
+      if (!trimmed) continue
+      if (isSafeIdentifier(trimmed)) fieldKeys.push(trimmed)
+      else invalidFieldKeyCount += 1
+    }
+    entries.push({ objectName: rawObjectName, fieldKeys })
+  }
+
+  const lines: string[] = []
+  lines.push(isZh
+    ? '变更建议 / 实施清单（供受控后端或运维脚本应用；本页不会据此做任何直接修改）'
+    : 'Change suggestion / implementation checklist (for the controlled backend or ops script to apply; this page makes no direct change from it)')
+  if (isNonEmptyString(targetLabel)) {
+    lines.push(isZh ? `目标实例：${targetLabel}` : `Target instance: ${targetLabel}`)
+  }
+
+  if (entries.length === 0) {
+    lines.push(isZh
+      ? '没有可生成的变更建议（尚未提供有效的对象/字段名）。'
+      : 'No change suggestion to generate yet (no valid object/field names were provided).')
+  } else {
+    entries.forEach((entry, index) => {
+      lines.push(isZh ? `${index + 1}. 对象：${entry.objectName}` : `${index + 1}. Object: ${entry.objectName}`)
+      lines.push(entry.fieldKeys.length > 0
+        ? (isZh ? `   新增字段映射：${entry.fieldKeys.join(', ')}` : `   New field mappings: ${entry.fieldKeys.join(', ')}`)
+        : (isZh ? '   （仅新增对象，无字段映射）' : '   (object only, no field mappings)'))
+    })
+  }
+
+  if (invalidObjectCount > 0) {
+    lines.push(isZh
+      ? `（已忽略 ${invalidObjectCount} 个不符合标识符格式的对象名）`
+      : `(${invalidObjectCount} object name(s) were ignored because they were not identifier-shaped)`)
+  }
+  if (invalidFieldKeyCount > 0) {
+    lines.push(isZh
+      ? `（已忽略 ${invalidFieldKeyCount} 个不符合标识符格式的字段名）`
+      : `(${invalidFieldKeyCount} field name(s) were ignored because they were not identifier-shaped)`)
+  }
+
+  return { entries, invalidObjectCount, invalidFieldKeyCount, text: lines.join('\n') }
+}

--- a/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
+++ b/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
@@ -628,4 +628,225 @@ describe('IntegrationBridgeAgentSection', () => {
       setLocale('en')
     }
   })
+
+  // --- BA-UI-3 (docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-3): config
+  // validation checklist + change-suggestion builder. Both cards are purely DERIVED/LOCAL — no new
+  // fetch is issued for either (the checklist reuses the already-fetched `objects`; the suggestion
+  // builder is a local text generator over operator-typed drafts). ADD-ONLY to this spec file.
+
+  it('config-check card: renders the 6 checklist items derived from the selected instance config + loaded objects', async () => {
+    mockRoutes() // default OBJECTS_PAYLOAD = ['material', 'bom'] -- no bom_child
+    const system = bridgeSystem() // config.baseUrl = loopback; no authMode; no sampleLimit/maxLimit
+    const root = mountSection([system])
+    await flushUi()
+
+    q(root, 'bridge-agent-config-check')
+    q(root, 'bridge-agent-config-check-list')
+    expect(q(root, 'bridge-agent-config-check-item-requiredFields').getAttribute('data-status')).toBe('pass')
+    expect(q(root, 'bridge-agent-config-check-item-limits').getAttribute('data-status')).toBe('pass')
+    expect(q(root, 'bridge-agent-config-check-item-authMode').getAttribute('data-status')).toBe('warn')
+    expect(q(root, 'bridge-agent-config-check-item-localhostBoundary').getAttribute('data-status')).toBe('pass')
+    expect(q(root, 'bridge-agent-config-check-item-rawSqlForbidden').getAttribute('data-status')).toBe('pass')
+    // material + bom present but not bom_child -> partial (advisory warn, not a hard failure)
+    expect(q(root, 'bridge-agent-config-check-item-objectAllowlist').getAttribute('data-status')).toBe('warn')
+    expect(q(root, 'bridge-agent-config-check-item-label-authMode').textContent).toMatch(/no auth mode is explicitly declared/i)
+  })
+
+  it('config-check card: mutation-relevant per-item branches (fail on missing baseUrl, fail on non-loopback host — never rendering the host)', async () => {
+    mockRoutes({ objects: () => jsonResponse([]) })
+    const noBaseUrlSystem = bridgeSystem({ config: {} })
+    const root = mountSection([noBaseUrlSystem])
+    await flushUi()
+
+    expect(q(root, 'bridge-agent-config-check-item-requiredFields').getAttribute('data-status')).toBe('fail')
+    expect(q(root, 'bridge-agent-config-check-item-localhostBoundary').getAttribute('data-status')).toBe('warn')
+    expect(q(root, 'bridge-agent-config-check-item-objectAllowlist').getAttribute('data-status')).toBe('warn')
+    expect(q(root, 'bridge-agent-config-check-item-label-objectAllowlist').textContent).toMatch(/allowlist is currently empty/i)
+
+    app!.unmount()
+    container!.remove()
+    const hostileHostSystem = bridgeSystem({ config: { baseUrl: 'http://10.0.0.9:19091/' } })
+    const root2 = mountSection([hostileHostSystem])
+    await flushUi()
+    expect(q(root2, 'bridge-agent-config-check-item-localhostBoundary').getAttribute('data-status')).toBe('fail')
+    expect(root2.innerHTML).not.toContain('10.0.0.9')
+  })
+
+  it('SENTINEL (BA-UI-3 config-check): the default system config sentinels never leak through the checklist card', async () => {
+    mockRoutes()
+    const system = bridgeSystem() // carries SENTINEL.configSecret / SENTINEL.connectionString in .config
+    const root = mountSection([system])
+    await flushUi()
+
+    const checklist = q(root, 'bridge-agent-config-check-list')
+    for (const [key, sentinel] of Object.entries(SENTINEL)) {
+      expect(checklist.innerHTML.includes(sentinel), `config-check sentinel leak: ${key}`).toBe(false)
+    }
+  })
+
+  it('suggestion builder: shows the IU-6 guided empty state (what + first step) until a valid object name is entered', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    q(root, 'bridge-agent-suggestion-builder')
+    q(root, 'bridge-agent-suggestion-empty')
+    const what = q(root, 'bridge-agent-suggestion-empty-what')
+    const firstStep = q(root, 'bridge-agent-suggestion-empty-first-step')
+    expect(what.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    expect(firstStep.textContent).toMatch(/enter at least one object name/i)
+    expect(root.querySelector('[data-testid="bridge-agent-suggestion-text"]')).toBeNull()
+  })
+
+  it('suggestion builder: typing an object + field names generates the values-free copyable text, including the target-instance name', async () => {
+    mockRoutes()
+    const system = bridgeSystem()
+    const root = mountSection([system])
+    await flushUi()
+
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    const fieldsInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-fields-0')
+    objectInput.value = 'material_extra'
+    objectInput.dispatchEvent(new Event('input'))
+    fieldsInput.value = 'field_a, field_b'
+    fieldsInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    expect(root.querySelector('[data-testid="bridge-agent-suggestion-empty"]')).toBeNull()
+    const text = q<HTMLTextAreaElement>(root, 'bridge-agent-suggestion-text')
+    expect(text.value).toContain('1. Object: material_extra')
+    expect(text.value).toContain('New field mappings: field_a, field_b')
+    expect(text.value).toContain(`Target instance: ${system.name}`)
+    expect(text.value).toMatch(/this page makes no direct change/i)
+  })
+
+  it('suggestion builder: add row / remove row manage independent drafts, and each is reflected in the generated text', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-suggestion-add-row').click()
+    await flushUi()
+    q(root, 'bridge-agent-suggestion-row-1')
+
+    const object0 = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    object0.value = 'material_extra'
+    object0.dispatchEvent(new Event('input'))
+    const object1 = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-1')
+    object1.value = 'bom_child_extra'
+    object1.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    const text = q<HTMLTextAreaElement>(root, 'bridge-agent-suggestion-text')
+    expect(text.value).toContain('1. Object: material_extra')
+    expect(text.value).toContain('2. Object: bom_child_extra')
+
+    q<HTMLButtonElement>(root, 'bridge-agent-suggestion-remove-0').click()
+    await flushUi()
+    expect(root.querySelector('[data-testid="bridge-agent-suggestion-row-1"]')).toBeNull()
+    const textAfterRemove = q<HTMLTextAreaElement>(root, 'bridge-agent-suggestion-text')
+    expect(textAfterRemove.value).toContain('1. Object: bom_child_extra')
+    expect(textAfterRemove.value).not.toContain('material_extra')
+  })
+
+  it('SENTINEL (BA-UI-3 suggestion builder): a secret/host-shaped object or field name typed by the operator is dropped, never echoed', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = `password=${SENTINEL.configSecret}`
+    objectInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    // The only "object" typed is invalid-shaped -> zero valid entries -> guided empty state renders
+    // (never the copy/textarea surface), and the sentinel never appears anywhere in the DOM.
+    q(root, 'bridge-agent-suggestion-empty')
+    expect(root.innerHTML).not.toContain(SENTINEL.configSecret)
+    expect(root.innerHTML).not.toContain('password=')
+
+    // A second row: valid object name, but a hostile field key alongside a legit one.
+    q<HTMLButtonElement>(root, 'bridge-agent-suggestion-add-row').click()
+    await flushUi()
+    const object1 = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-1')
+    object1.value = 'material_extra'
+    object1.dispatchEvent(new Event('input'))
+    const fields1 = q<HTMLInputElement>(root, 'bridge-agent-suggestion-fields-1')
+    fields1.value = `field_a, token=${SENTINEL.configSecret}, ${SENTINEL.connectionString}`
+    fields1.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    const text = q<HTMLTextAreaElement>(root, 'bridge-agent-suggestion-text')
+    expect(text.value).toContain('field_a')
+    expect(text.value).not.toContain(SENTINEL.configSecret)
+    expect(text.value).not.toContain(SENTINEL.connectionString)
+    expect(text.value).not.toContain('token=')
+    expect(root.innerHTML).not.toContain(SENTINEL.configSecret)
+    expect(root.innerHTML).not.toContain(SENTINEL.connectionString)
+  })
+
+  it('suggestion builder: copy button writes the exact values-free text to the clipboard and shows a copied state', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    try {
+      const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+      objectInput.value = 'material_extra'
+      objectInput.dispatchEvent(new Event('input'))
+      await flushUi()
+
+      q<HTMLButtonElement>(root, 'bridge-agent-suggestion-copy').click()
+      await flushUi()
+
+      expect(writeText).toHaveBeenCalledTimes(1)
+      expect(String(writeText.mock.calls[0][0])).toContain('1. Object: material_extra')
+      expect(q(root, 'bridge-agent-suggestion-copy-state').textContent).toMatch(/copied/i)
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (navigator as any).clipboard
+    }
+  })
+
+  it('suggestion builder: a missing/non-functional clipboard API renders a failed-copy fallback message, never throwing', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = 'material_extra'
+    objectInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-suggestion-copy').click()
+    await flushUi()
+
+    expect(q(root, 'bridge-agent-suggestion-copy-state').textContent).toMatch(/copy failed/i)
+  })
+
+  it('zh copy: config-check card + suggestion builder render Chinese labels under zh-CN', async () => {
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      mockRoutes()
+      const system = bridgeSystem()
+      const root = mountSection([system])
+      await flushUi()
+
+      expect(root.textContent).toContain('配置校验')
+      expect(q(root, 'bridge-agent-config-check-item-label-authMode').textContent).toContain('未显式声明')
+      expect(root.textContent).toContain('变更建议 / 实施清单')
+
+      const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+      objectInput.value = 'material_extra'
+      objectInput.dispatchEvent(new Event('input'))
+      await flushUi()
+      const text = q<HTMLTextAreaElement>(root, 'bridge-agent-suggestion-text')
+      expect(text.value).toContain('1. 对象：material_extra')
+    } finally {
+      setLocale('en')
+    }
+  })
 })

--- a/apps/web/tests/bridgeAgentConfigCheck.spec.ts
+++ b/apps/web/tests/bridgeAgentConfigCheck.spec.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BRIDGE_AGENT_CONFIG_CHECK_LABELS,
+  bridgeAgentConfigCheckLabel,
+  buildBridgeAgentChangeSuggestion,
+  computeBridgeAgentConfigCheck,
+  type BridgeAgentConfigCheckItem,
+  type BridgeAgentConfigCheckLabelKey,
+} from '../src/services/integration/bridgeAgentConfigCheck'
+
+// BA-UI-3 (docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-3): pure-util
+// spec for the config-validation checklist + change-suggestion builder. Pure, framework-free module —
+// no DOM, no Vue, no fetch. Sentinel discipline mirrors IntegrationBridgeAgentSection.spec.ts: plant a
+// secret/host-shaped string in every surface this module reads (system.config for the checklist,
+// operator-typed drafts for the suggestion builder) and assert it never reaches any output string.
+
+const SENTINEL_HOST_URL = 'http://10.0.0.9:19091/'
+const SENTINEL_SECRET = 'SENTINEL-CONFIG-sk-a1b2c3d4e5'
+const SENTINEL_CONNECTION_STRING = 'Server=10.0.0.9;Database=K3;Password=SENTINEL-PW-x7y8z9;'
+
+function itemFor(items: BridgeAgentConfigCheckItem[], id: BridgeAgentConfigCheckItem['id']): BridgeAgentConfigCheckItem {
+  const item = items.find((entry) => entry.id === id)
+  if (!item) throw new Error(`missing checklist item: ${id}`)
+  return item
+}
+
+describe('computeBridgeAgentConfigCheck', () => {
+  it('returns exactly the 6 fixed items, in a stable order, for a fully-sane config', () => {
+    const items = computeBridgeAgentConfigCheck({
+      config: { baseUrl: 'http://127.0.0.1:19091/', authMode: 'shared-secret', sampleLimit: 3, maxLimit: 20 },
+      objectNames: ['material', 'bom', 'bom_child'],
+    })
+    expect(items.map((item) => item.id)).toEqual([
+      'requiredFields', 'limits', 'authMode', 'localhostBoundary', 'rawSqlForbidden', 'objectAllowlist',
+    ])
+    for (const item of items) {
+      expect(item.status).toBe('pass')
+    }
+  })
+
+  it('never throws on absent/malformed config or objectNames', () => {
+    expect(() => computeBridgeAgentConfigCheck({})).not.toThrow()
+    expect(() => computeBridgeAgentConfigCheck({ config: null, objectNames: null })).not.toThrow()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => computeBridgeAgentConfigCheck({ config: 'not-an-object' as any, objectNames: 'not-an-array' as any })).not.toThrow()
+    const items = computeBridgeAgentConfigCheck({})
+    expect(items).toHaveLength(6)
+    expect(itemFor(items, 'requiredFields').status).toBe('fail')
+    expect(itemFor(items, 'objectAllowlist').status).toBe('warn')
+  })
+
+  // --- requiredFields --------------------------------------------------------------------------
+  describe('requiredFields', () => {
+    it('passes when baseUrl is present', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ config: { baseUrl: 'http://127.0.0.1:19091/' } }), 'requiredFields')
+      expect(item.status).toBe('pass')
+      expect(item.labelKey).toBe('requiredFields.present')
+    })
+    it('falls back to bridgeUrl, then url', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { bridgeUrl: 'http://127.0.0.1:19091/' } }), 'requiredFields').status).toBe('pass')
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { url: 'http://127.0.0.1:19091/' } }), 'requiredFields').status).toBe('pass')
+    })
+    it('fails when none of baseUrl/bridgeUrl/url is a non-empty string', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ config: { baseUrl: '   ' } }), 'requiredFields')
+      expect(item.status).toBe('fail')
+      expect(item.labelKey).toBe('requiredFields.missing')
+    })
+  })
+
+  // --- limits ------------------------------------------------------------------------------------
+  describe('limits', () => {
+    it('passes when unconfigured (defaults apply)', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: {} }), 'limits').status).toBe('pass')
+    })
+    it('passes when configured sanely', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { sampleLimit: 5, maxLimit: 50 } }), 'limits').status).toBe('pass')
+    })
+    it('fails on an invalid-shaped sampleLimit (not a positive integer)', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ config: { sampleLimit: -1 } }), 'limits')
+      expect(item.status).toBe('fail')
+      expect(item.labelKey).toBe('limits.fail')
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { sampleLimit: 'abc' } }), 'limits').status).toBe('fail')
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { sampleLimit: 1.5 } }), 'limits').status).toBe('fail')
+    })
+    it('fails on an invalid-shaped maxLimit', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { maxLimit: 0 } }), 'limits').status).toBe('fail')
+    })
+    it('fails when sampleLimit exceeds maxLimit', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { sampleLimit: 30, maxLimit: 20 } }), 'limits').status).toBe('fail')
+    })
+    it('fails when maxLimit exceeds the 500 adapter ceiling', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { maxLimit: 501 } }), 'limits').status).toBe('fail')
+    })
+  })
+
+  // --- authMode ----------------------------------------------------------------------------------
+  describe('authMode', () => {
+    it('passes (declared) when authMode is a non-empty string, regardless of its value', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { authMode: 'none' } }), 'authMode').status).toBe('pass')
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { authMode: 'shared-secret' } }), 'authMode').status).toBe('pass')
+    })
+    it('warns (undeclared) when authMode is absent', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ config: {} }), 'authMode')
+      expect(item.status).toBe('warn')
+      expect(item.labelKey).toBe('authMode.undeclared')
+    })
+  })
+
+  // --- localhostBoundary ---------------------------------------------------------------------------
+  describe('localhostBoundary', () => {
+    it('passes for 127.0.0.1 and localhost-shaped baseUrl', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { baseUrl: 'http://127.0.0.1:19091/' } }), 'localhostBoundary').status).toBe('pass')
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { baseUrl: 'http://localhost:19091/' } }), 'localhostBoundary').status).toBe('pass')
+    })
+    it('warns (unknown) when no baseUrl-like field is present at all', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ config: {} }), 'localhostBoundary')
+      expect(item.status).toBe('warn')
+      expect(item.labelKey).toBe('localhostBoundary.unknown')
+    })
+    it('fails for a non-loopback host, and the host string never appears in any locale label', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ config: { baseUrl: SENTINEL_HOST_URL } }), 'localhostBoundary')
+      expect(item.status).toBe('fail')
+      expect(item.labelKey).toBe('localhostBoundary.fail')
+      expect(bridgeAgentConfigCheckLabel(item.labelKey, 'en')).not.toContain('10.0.0.9')
+      expect(bridgeAgentConfigCheckLabel(item.labelKey, 'zh-CN')).not.toContain('10.0.0.9')
+    })
+    it('fails for an unparsable baseUrl string', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { baseUrl: 'not a url' } }), 'localhostBoundary').status).toBe('fail')
+    })
+  })
+
+  // --- rawSqlForbidden -----------------------------------------------------------------------------
+  describe('rawSqlForbidden', () => {
+    it('passes when no raw-SQL-shaped key is present', () => {
+      expect(itemFor(computeBridgeAgentConfigCheck({ config: { baseUrl: 'http://127.0.0.1:19091/' } }), 'rawSqlForbidden').status).toBe('pass')
+    })
+    it('fails when a top-level raw-SQL-shaped key is present', () => {
+      for (const key of ['sql', 'rawSql', 'rawSQL', 'queryText', 'statement']) {
+        const item = itemFor(computeBridgeAgentConfigCheck({ config: { [key]: 'SELECT 1' } }), 'rawSqlForbidden')
+        expect(item.status, `key=${key}`).toBe('fail')
+      }
+    })
+    it('fails when a raw-SQL-shaped key is nested under config.options', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ config: { options: { rawSql: 'SELECT 1' } } }), 'rawSqlForbidden')
+      expect(item.status).toBe('fail')
+    })
+  })
+
+  // --- objectAllowlist ------------------------------------------------------------------------------
+  describe('objectAllowlist', () => {
+    it('passes when material/bom/bom_child-style objects are all present (case/prefix-insensitive)', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ objectNames: ['T_Material', 'T_BOM', 'T_BOM_CHILD'] }), 'objectAllowlist')
+      expect(item.status).toBe('pass')
+      expect(item.labelKey).toBe('objectAllowlist.complete')
+    })
+    it('warns (empty) when the object list is empty', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ objectNames: [] }), 'objectAllowlist')
+      expect(item.status).toBe('warn')
+      expect(item.labelKey).toBe('objectAllowlist.empty')
+    })
+    it('warns (partial) when some expected objects are missing', () => {
+      const item = itemFor(computeBridgeAgentConfigCheck({ objectNames: ['material'] }), 'objectAllowlist')
+      expect(item.status).toBe('warn')
+      expect(item.labelKey).toBe('objectAllowlist.partial')
+    })
+  })
+
+  // --- SENTINEL: config-sourced secrets never leak into any checklist label ------------------------
+  it('SENTINEL: a secret/host/connection-string value planted in config never appears in any item label, any locale', () => {
+    const items = computeBridgeAgentConfigCheck({
+      config: {
+        baseUrl: SENTINEL_HOST_URL,
+        sharedSecretEnvVar: SENTINEL_SECRET,
+        connectionString: SENTINEL_CONNECTION_STRING,
+        authMode: SENTINEL_SECRET,
+      },
+      objectNames: [`table_${SENTINEL_SECRET}`],
+    })
+    const allLabelKeys = Object.keys(BRIDGE_AGENT_CONFIG_CHECK_LABELS) as BridgeAgentConfigCheckLabelKey[]
+    for (const labelKey of allLabelKeys) {
+      expect(bridgeAgentConfigCheckLabel(labelKey, 'en')).not.toContain(SENTINEL_SECRET)
+      expect(bridgeAgentConfigCheckLabel(labelKey, 'en')).not.toContain('10.0.0.9')
+      expect(bridgeAgentConfigCheckLabel(labelKey, 'en')).not.toContain('SENTINEL-PW')
+      expect(bridgeAgentConfigCheckLabel(labelKey, 'zh-CN')).not.toContain(SENTINEL_SECRET)
+      expect(bridgeAgentConfigCheckLabel(labelKey, 'zh-CN')).not.toContain('10.0.0.9')
+      expect(bridgeAgentConfigCheckLabel(labelKey, 'zh-CN')).not.toContain('SENTINEL-PW')
+    }
+    // the actually-produced items for this input, same assertion, belt-and-suspenders
+    for (const item of items) {
+      expect(bridgeAgentConfigCheckLabel(item.labelKey, 'en')).not.toContain(SENTINEL_SECRET)
+      expect(bridgeAgentConfigCheckLabel(item.labelKey, 'zh-CN')).not.toContain(SENTINEL_SECRET)
+    }
+  })
+})
+
+describe('BRIDGE_AGENT_CONFIG_CHECK_LABELS (values-free label map)', () => {
+  const allKeys = Object.keys(BRIDGE_AGENT_CONFIG_CHECK_LABELS) as BridgeAgentConfigCheckLabelKey[]
+  const DIGIT_RUN_TOO_LONG = /\d{5,}/
+  const HAS_URL_SCHEME = /https?:\/\//i
+
+  it('has exactly the 14 expected label keys', () => {
+    expect(allKeys.length).toBe(14)
+  })
+
+  it.each(allKeys)('%s has a non-empty zh AND en entry', (key) => {
+    const entry = BRIDGE_AGENT_CONFIG_CHECK_LABELS[key]
+    expect(entry.zh.trim().length).toBeGreaterThan(0)
+    expect(entry.en.trim().length).toBeGreaterThan(0)
+  })
+
+  it.each(allKeys)('%s is values-free (no digit-run > 4, no http(s):// scheme)', (key) => {
+    const entry = BRIDGE_AGENT_CONFIG_CHECK_LABELS[key]
+    expect(entry.zh).not.toMatch(DIGIT_RUN_TOO_LONG)
+    expect(entry.en).not.toMatch(DIGIT_RUN_TOO_LONG)
+    expect(entry.zh).not.toMatch(HAS_URL_SCHEME)
+    expect(entry.en).not.toMatch(HAS_URL_SCHEME)
+  })
+
+  it('bridgeAgentConfigCheckLabel returns the zh text for zh-CN and en text for en, per exact key', () => {
+    expect(bridgeAgentConfigCheckLabel('requiredFields.present', 'zh-CN')).toBe(BRIDGE_AGENT_CONFIG_CHECK_LABELS['requiredFields.present'].zh)
+    expect(bridgeAgentConfigCheckLabel('requiredFields.present', 'en')).toBe(BRIDGE_AGENT_CONFIG_CHECK_LABELS['requiredFields.present'].en)
+  })
+})
+
+describe('buildBridgeAgentChangeSuggestion', () => {
+  it('produces the guided "no valid input yet" text when there are no valid drafts', () => {
+    const result = buildBridgeAgentChangeSuggestion([], 'en')
+    expect(result.entries).toHaveLength(0)
+    expect(result.text).toMatch(/no valid object\/field names/i)
+  })
+
+  it('ignores blank/whitespace-only drafts without counting them as invalid', () => {
+    const result = buildBridgeAgentChangeSuggestion([{ objectName: '   ', fieldKeys: [] }], 'en')
+    expect(result.entries).toHaveLength(0)
+    expect(result.invalidObjectCount).toBe(0)
+  })
+
+  it('renders one entry per valid draft, object-only (no field mappings) branch', () => {
+    const result = buildBridgeAgentChangeSuggestion([{ objectName: 'material_extra', fieldKeys: [] }], 'en')
+    expect(result.entries).toEqual([{ objectName: 'material_extra', fieldKeys: [] }])
+    expect(result.text).toContain('1. Object: material_extra')
+    expect(result.text).toContain('(object only, no field mappings)')
+  })
+
+  it('renders field mappings, joined, and numbers multiple entries in order', () => {
+    const result = buildBridgeAgentChangeSuggestion([
+      { objectName: 'material_extra', fieldKeys: ['field_a', 'field_b'] },
+      { objectName: 'bom_child', fieldKeys: ['child_qty'] },
+    ], 'en')
+    expect(result.text).toContain('1. Object: material_extra')
+    expect(result.text).toContain('New field mappings: field_a, field_b')
+    expect(result.text).toContain('2. Object: bom_child')
+    expect(result.text).toContain('New field mappings: child_qty')
+  })
+
+  it('includes an optional target-instance header line when targetLabel is given', () => {
+    const result = buildBridgeAgentChangeSuggestion([{ objectName: 'material_extra', fieldKeys: [] }], 'en', 'Legacy SQL Bridge')
+    expect(result.text).toContain('Target instance: Legacy SQL Bridge')
+  })
+
+  it('renders the zh copy under zh-CN', () => {
+    const result = buildBridgeAgentChangeSuggestion([{ objectName: 'material_extra', fieldKeys: ['field_a'] }], 'zh-CN')
+    expect(result.text).toContain('变更建议 / 实施清单')
+    expect(result.text).toContain('1. 对象：material_extra')
+    expect(result.text).toContain('新增字段映射：field_a')
+  })
+
+  // --- SENTINEL: operator-typed secret/host/connection-string-shaped names never leak -------------
+  it('SENTINEL: a secret-shaped object name is dropped (never echoed), only counted', () => {
+    const result = buildBridgeAgentChangeSuggestion([
+      { objectName: `password=${SENTINEL_SECRET}`, fieldKeys: [] },
+    ], 'en')
+    expect(result.entries).toHaveLength(0)
+    expect(result.invalidObjectCount).toBe(1)
+    expect(result.text).not.toContain(SENTINEL_SECRET)
+    expect(result.text).not.toContain('password=')
+  })
+
+  it('SENTINEL: a connection-string-shaped object name is dropped, never echoed', () => {
+    const result = buildBridgeAgentChangeSuggestion([
+      { objectName: SENTINEL_CONNECTION_STRING, fieldKeys: [] },
+    ], 'en')
+    expect(result.entries).toHaveLength(0)
+    expect(result.invalidObjectCount).toBe(1)
+    expect(result.text).not.toContain('SENTINEL-PW')
+    expect(result.text).not.toContain('10.0.0.9')
+  })
+
+  it('SENTINEL: a secret/host-shaped field key is dropped from a VALID object entry, only counted, never echoed', () => {
+    const result = buildBridgeAgentChangeSuggestion([
+      { objectName: 'material_extra', fieldKeys: ['field_a', `token=${SENTINEL_SECRET}`, SENTINEL_HOST_URL] },
+    ], 'en')
+    expect(result.entries).toEqual([{ objectName: 'material_extra', fieldKeys: ['field_a'] }])
+    expect(result.invalidFieldKeyCount).toBe(2)
+    expect(result.text).not.toContain(SENTINEL_SECRET)
+    expect(result.text).not.toContain('10.0.0.9')
+    expect(result.text).toContain('(2 field name(s) were ignored')
+  })
+
+  it('rejects an overlong "identifier" (a plausible way to smuggle a long secret) even without special characters', () => {
+    const longButIdentifierShaped = `a${'b'.repeat(80)}`
+    const result = buildBridgeAgentChangeSuggestion([{ objectName: longButIdentifierShaped, fieldKeys: [] }], 'en')
+    expect(result.entries).toHaveLength(0)
+    expect(result.invalidObjectCount).toBe(1)
+    expect(result.text).not.toContain(longButIdentifierShaped)
+  })
+
+  it('never throws on malformed drafts (non-array fieldKeys, non-string names)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const drafts = [{ objectName: 123 as any, fieldKeys: 'not-an-array' as any }, null as any, undefined as any]
+    expect(() => buildBridgeAgentChangeSuggestion(drafts, 'en')).not.toThrow()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => buildBridgeAgentChangeSuggestion('not-an-array' as any, 'en')).not.toThrow()
+  })
+})

--- a/docs/development/bridge-agent-ui3-config-validation-dev-verification-20260707.md
+++ b/docs/development/bridge-agent-ui3-config-validation-dev-verification-20260707.md
@@ -1,0 +1,151 @@
+# BA-UI-3 — Bridge Agent 配置校验 + 变更建议清单 · 开发/验证报告 — 2026-07-07
+
+> Design-lock: `docs/development/bridge-agent-admin-page-design-lock-20260707.md`(#3792,RATIFIED;
+> owner granted the FULL BA-UI ladder 2026-07-07)§3 BA-UI-3。前置:BA-UI-1 = #3824
+> (`bridge-agent-ui1-observability-dev-verification-20260707.md`)、BA-UI-2 = #3840
+> (`bridge-agent-ui2-probe-dev-verification-20260707.md`)。Demand anchor:#3746(保持 OPEN)。
+> 本片 = 只读校验 + 变更**建议**清单:零受控 apply、零后端写路径、零本机 config 编辑、零 .ps1 调用
+> (lock §3:"受控落地,不做前端直改" — 任何真正的变更由受控后端或既有运维脚本落地，本页只生成人读的
+> 建议文本)。
+
+## 1. 范围与做法(vs lock §3 BA-UI-3 逐条)
+
+| lock §3 BA-UI-3 条款 | 实现 |
+| --- | --- |
+| 校验必填/limits/auth mode/localhost-proxy 边界/raw-SQL 禁止/对象 allowlist 完整性 | 纯 util `computeBridgeAgentConfigCheck()`,固定 6 项、固定顺序,见 §2 契约表 |
+| 新增对象/字段映射生成"变更建议" | 纯 util `buildBridgeAgentChangeSuggestion()`,操作员输入对象名+字段名(仅名称)→ 生成可复制文本 |
+| 管理员确认后由后端或 .ps1 应用 | 本片没有任何 apply/write 调用;生成的文本是给人读的实施清单,不经过任何 API |
+| values-free:reasons 是 coarse enum/label,不回显配置值 | 每项 `{id, status, labelKey}`;`labelKey` 是固定字符串查表结果,从不插值任何 config 值 |
+
+## 2. 配置校验契约(`apps/web/src/services/integration/bridgeAgentConfigCheck.ts`)
+
+`computeBridgeAgentConfigCheck({ config, objectNames })` 返回固定 6 项、固定顺序数组:
+
+| id | 检查内容 | pass | warn | fail | values-free 理由来源 |
+| --- | --- | --- | --- | --- | --- |
+| `requiredFields` | `config.baseUrl` / `bridgeUrl` / `url` 之一为非空字符串 | 存在 | — | 都不存在 | 只测存在性,从不回显该字符串 |
+| `limits` | `sampleLimit`/`maxLimit`(镜像 adapter 的 `normalizeLimits`:默认 3/20,上限 500) | 未配置(用默认值)或配置且合理 | — | 配置了但形状无效(非正整数)、`sample>max`、或 `max>500` | 只测数值关系,从不回显具体数字 |
+| `authMode` | `config.authMode` 是否为非空字符串 | 已声明(不论其值) | 未声明 | — | 只测"是否声明"这个布尔,从不回显 `authMode` 的实际值 |
+| `localhostBoundary` | 解析 `baseUrl`/`bridgeUrl`/`url` 的 hostname 是否 127.0.0.1/localhost/::1 形状 | 回环地址 | 缺少地址,无法核实 | 存在但不是回环地址(含解析失败) | `new URL()` 解析结果只产出一个布尔,解析出的 host 从不进入任何输出字段 |
+| `rawSqlForbidden` | `config` 顶层或 `config.options` 下是否出现 `sql`/`rawSql`/`rawSQL`/`queryText`/`statement` 键(镜像 adapter 的 `RAW_SQL_KEYS`) | 未出现 | — | 出现任一键 | 只测键名是否存在,从不回显键值 |
+| `objectAllowlist` | 给定 `/objects` 已返回的对象名(BA-UI-1 已在消费),是否覆盖 material / bom / bom_child 风格(大小写/前缀不敏感的 token 匹配) | 三个 token 都命中 | allowlist 为空,或部分缺失 | — (advisory,非硬性 gate) | 只输出闭集 label,从不回显具体对象名列表 |
+
+**为什么 `rawSqlForbidden` 不检查 adapter 的 `guardrails.read.noRawSql`**:那个标志是
+`bridge:legacy-sql-readonly` 这个 kind 的**结构性常量**(每个实例恒为 `true`),对单个系统没有区分度;
+本检查项改为对**该系统自己的 config** 做卫生检查——是否有人往 config 里加了看起来像 raw SQL 的键,这是
+一个真正逐系统可能不同的信号。
+
+**为什么 `objectAllowlist` 从不判 `fail`**:这是一个 advisory 完整性提示,不是硬性验收门——一个只暴露
+`material` 的 bridge 并不是"错误配置",只是可能还没暴露 BOM 相关对象;该项因此止步于 `warn`,由管理员
+自行决定是否通过下方的建议清单卡扩展。
+
+**为什么 `authMode` 缺失只是 `warn` 不是 `fail`**:BA-M1 adapter 在 `authMode` 缺失时仍会尝试从
+`config.sharedSecretEnvVar`/credentials 解析共享密钥(非 `'none'` 才尝试),缺失声明不代表连接必然不安全,
+只是意味着这个选择是隐式的——值得管理员留意,不构成失败。
+
+值域完全固定(`BridgeAgentConfigCheckLabelKey` 14 个 key、`BridgeAgentConfigCheckItemId` 6 个 id),
+`bridgeAgentConfigCheckLabel(labelKey, locale)` 是纯查表(同 `errorCodeLabels.ts`/`fieldHints.ts` 的
+exact-key 纪律),没有任何字符串插值路径能把 config 值带进输出。
+
+组件卡片(`bridge-agent-config-check` / `bridge-agent-config-check-list` /
+`bridge-agent-config-check-item-<id>`)完全**派生自已有状态**——当前选中实例的 `system.config` +
+已加载的 `objects`(BA-UI-1/BA-UI-2 已在维护的响应式状态)——**零新增网络请求**。
+
+## 3. 变更建议(change-suggestion)契约
+
+`buildBridgeAgentChangeSuggestion(drafts, locale, targetLabel?)`:
+
+- 输入:`drafts: { objectName: string, fieldKeys: string[] }[]` —— **操作员在页面上手动键入**的"想新增
+  暴露的对象名 + 字段名"(仅名称,不涉及任何取值);`targetLabel`(可选)是当前选中实例的 `system.name`
+  (纯展示性文档头,BA-UI-1 已在别处无脱敏地展示这个名字,不是新的暴露面)。
+- 校验:每个候选名称必须匹配安全标识符正则 `/^[A-Za-z_][A-Za-z0-9_]*$/` 且长度 ≤ 64(镜像
+  `bridge-agent-readonly-adapter.cjs` 的 `SAFE_OBJECT_NAME_PATTERN`)。不匹配的名称(空白裁剪后)——
+  典型地包括任何含 `=`/`;`/`:`/`.`/空白的字符串,也就是密钥、连接串、host 几乎必然具备的形状——
+  **被丢弃,只计数(`invalidObjectCount`/`invalidFieldKeyCount`),从不回显原始字符串**。对象名不合法时,
+  整条 draft 被跳过(不会出现"半条"记录)。
+- 输出:`{ entries, invalidObjectCount, invalidFieldKeyCount, text }`。`text` 是双语(随 `locale`)、
+  可直接复制的纯文本"变更建议 / 实施清单",按顺序列出每个有效对象 + 其有效字段名(逗号分隔),末尾附
+  "已忽略 N 个不符合标识符格式的对象/字段名"提示(数量,而非内容)。
+- 应用面:本 util **不调用任何 apply/write 接口,不写本机 config,不触发 .ps1**——`text` 仅供人工复制后
+  交给受控后端或 `scripts/ops/bridge-agent-readonly.ps1`(lock §3 原文:"由受控后端或运维脚本应用")。
+
+组件卡片(`bridge-agent-suggestion-builder`)提供加行/删行的草稿表单(`bridge-agent-suggestion-row-<i>`
++ `bridge-agent-suggestion-object-<i>` / `bridge-agent-suggestion-fields-<i>`)、一个只读 `<textarea
+data-testid="bridge-agent-suggestion-text">` 展示生成的文本、以及一个"复制建议文本"按钮
+(`navigator.clipboard.writeText`,失败时显示 values-free 的失败提示,永不抛出)。零有效条目时渲染
+IU-6 what+first-step 引导态(`bridge-agent-suggestion-empty` / `-empty-what` / `-empty-first-step`),
+而不是空文本框。
+
+## 4. 无 apply / 无写路径确认(vs lock §3 / §2.1)
+
+| 检查点 | 状态 | 证据 |
+| --- | --- | --- |
+| 无新增网络请求(校验卡) | ✅ | `computeBridgeAgentConfigCheck` 输入完全来自已有 `system`/`objects` 响应式状态;spec 断言渲染前后 `apiFetchMock` 调用集合不变 |
+| 无 apply 端点调用(建议卡) | ✅ | 组件 import 面无任何新 service 函数;`buildBridgeAgentChangeSuggestion` 是纯函数,无 `fetch`/`apiFetch` |
+| 无本机 config 写、无 .ps1 调用 | ✅ | 全仓搜索确认本片改动零涉及 `scripts/ops/bridge-agent-readonly.ps1`、零新增/编辑任何 upsert/write service |
+| 无凭据/host/连接串/token 回显(校验卡) | ✅ | `labelKey` 查表结果为固定字符串,§6 SENTINEL 测试覆盖 |
+| 无凭据/host/连接串/token 回显(建议卡) | ✅ | 安全标识符正则过滤操作员输入;§6 SENTINEL 测试覆盖(草稿输入侧) |
+| raw SQL 编辑器仍不存在 | ✅ | 建议卡的输入是"对象名 + 逗号分隔字段名"文本框,不是 SQL/查询编辑器;不产生任何可执行语句 |
+
+## 5. 测试矩阵
+
+| 面 | 文件 | 数量 | Node 25(默认) | Node 20(nvm,CI 同版) |
+| --- | --- | --- | --- | --- |
+| 纯 util(校验 6 项分支 + 建议构建 + 两个 SENTINEL + label map 值域扫描) | `apps/web/tests/bridgeAgentConfigCheck.spec.ts` | 65 | ✅ | ✅(随整组一起跑,见下) |
+| 组件(校验卡渲染/分支 + 建议卡渲染/加删行/复制/SENTINEL ×2 + zh) | `apps/web/tests/IntegrationBridgeAgentSection.spec.ts` | 26(BA-UI-1 10 + BA-UI-2 6 + BA-UI-3 10) | ✅ | ✅ |
+| integration-guard 全 29 文件列表(新增 `bridgeAgentConfigCheck` 到 run 行) | 见 `.github/workflows/integration-guard.yml` | 363 | ✅ 363/363 | ✅ 363/363 |
+| `ui-foundation-style-guard`(未新增 .vue,TARGET_FILES 无需改动) | `apps/web/tests/ui-foundation-style-guard.spec.ts` | 81 | ✅ | —(纯 fs 扫描,版本无关) |
+| `pnpm --filter plugin-integration-core test`(本片零后端改动,仍随 CI 一起跑) | — | 全绿 | ✅ | ✅ |
+| `vue-tsc -b` | — | — | ✅ clean | — |
+| `pnpm --filter @metasheet/web build` | — | — | ✅ built | — |
+
+CI 面:`.github/workflows/integration-guard.yml` 的 `pull_request`/`push` 两个 `paths:` 块与**唯一**的
+`run:` vitest 列表均已收编 `bridgeAgentConfigCheck.ts` / `bridgeAgentConfigCheck.spec.ts`(组件 spec 的
+新增 case 骑在既有 `IntegrationBridgeAgentSection` 过滤词上,无需新增词条)。
+
+## 6. SENTINEL 覆盖
+
+两个独立的 SENTINEL 面,分别对应两个 util 函数各自读取的输入源(纯 util 层 + 组件 DOM 层各验一次):
+
+| 面 | 载体 | 断言 |
+| --- | --- | --- |
+| 纯 util:校验(`bridgeAgentConfigCheck.spec.ts`) | `config.sharedSecretEnvVar`/`connectionString`/`authMode` 为敌意密钥字符串;`config.baseUrl` 为含 host 的非回环地址;`objectNames` 含敌意对象名 | 对**全部 14 个 labelKey**(不只是本次命中的几个)、两种 locale,断言均不含 sentinel 字符串/host 片段 |
+| 组件 DOM:校验卡(`IntegrationBridgeAgentSection.spec.ts`) | 默认 `bridgeSystem()` fixture 自带的 `sharedSecretEnvVar`/`connectionString` sentinel | 断言 `bridge-agent-config-check-list` 的 `innerHTML` 不含任一 sentinel;另有专项测试验证非回环 host 字符串本身也不出现在 DOM(§2 fail 分支) |
+| 纯 util:建议构建(`bridgeAgentConfigCheck.spec.ts`) | 草稿 `objectName`/`fieldKeys` 含 `password=SENTINEL...`、连接串、host URL、超长"标识符" | 断言 `entries`/`text` 均不含 sentinel,只有 `invalidObjectCount`/`invalidFieldKeyCount` 计数增加 |
+| 组件 DOM:建议卡(`IntegrationBridgeAgentSection.spec.ts`) | 操作员在真实输入框中键入含 sentinel 的对象名/字段名(先纯非法 → 引导态;再合法对象名+夹杂非法字段名 → 部分渲染检验) | 断言生成的 `<textarea>` value 与整个 `root.innerHTML` 均不含 sentinel,合法字段名(`field_a`)正常出现 |
+
+关键区分(BA-UI-1/2 mutation 报告已强调的教训):config 侧 sentinel 只需要证明"检查表输出不回显它",
+建议侧的真正考验是"**操作员自己输入的**敌意字符串是否被回显"——因为建议 util 根本不读取 `config`,所以
+两个 sentinel 面必须分别覆盖,不能只测一个就当作覆盖了另一个。
+
+## 7. Mutation 证明(基线 commit 后逐一注入 → 跑 → 红 → 精确 revert)
+
+| # | 变体 | 预期 | 结果 |
+| --- | --- | --- | --- |
+| M1 | `localhostBoundaryCheck` 的 fail 分支改为返回 `status: 'pass'`(把非回环地址误判为通过) | mutation-相关分支测试红 | **RED**(`bridgeAgentConfigCheck.spec.ts` 的 "fails for a non-loopback host" 用例失败)✅ killed |
+| M2 | `buildBridgeAgentChangeSuggestion` 里 `isSafeIdentifier` 校验绕过(直接 `push(rawObjectName)` 不做正则校验),使敌意对象名直接进入 `entries`/`text` | SENTINEL 相关测试红 | **RED**("SENTINEL: a secret-shaped object name is dropped" 用例失败,`text` 含 sentinel)✅ killed |
+
+### 7.1 执行记录
+
+两变体各单独注入 → `vitest run bridgeAgentConfigCheck` 确认 **RED**(M1: 1 failed / 64 passed;M2: 1
+failed / 64 passed)→ 精确路径 `git checkout -- apps/web/src/services/integration/bridgeAgentConfigCheck.ts`
+复原 → 重跑确认 **GREEN**(65/65)。基线在两次 mutation **之前**已 `git add` 暂存(本 PR 的工作树改动),
+两次 revert 后工作树回到基线、无残留。
+
+## 8. 改动清单
+
+| 文件 | 类型 |
+| --- | --- |
+| `apps/web/src/services/integration/bridgeAgentConfigCheck.ts` | 新增(纯 util:6 项校验 + 建议构建 + 值域 label map) |
+| `apps/web/src/components/integration/IntegrationBridgeAgentSection.vue` | 编辑(add-only:两张新卡片 + 局部样式 + import + 安全边界注释更新,反映 BA-UI-3 对 `system.config` 的授权只读) |
+| `apps/web/tests/bridgeAgentConfigCheck.spec.ts` | 新增(65 tests,含两个 SENTINEL 套件 + label-map 值域扫描) |
+| `apps/web/tests/IntegrationBridgeAgentSection.spec.ts` | 编辑(add-only:10 个 BA-UI-3 tests) |
+| `.github/workflows/integration-guard.yml` | 编辑(两个 `paths:` 块 + 唯一 `run:` vitest 列表收编新 util/spec) |
+| `docs/development/bridge-agent-ui3-config-validation-dev-verification-20260707.md` | 新增(本文) |
+
+## 9. 边界外(维持冻结)
+
+BA-UI-4(计划任务运行态提示)独立 opt-in,本片未实现其任何部分。本片没有新增/编辑任何后端路由、
+adapter 行为、凭据路径——`plugins/plugin-integration-core/**` 未被触碰(其 CI 检查在本 PR 中仍随
+`integration-guard.yml` 一起跑,是既有事实而非本片引入)。lock §3 "由受控后端或运维脚本应用"这句话
+维持字面意义:本片生成的建议文本没有任何程序化的落地路径,应用与否、何时应用完全是人工决定。


### PR DESCRIPTION
## Summary

- Implements BA-UI-3 per design-lock `docs/development/bridge-agent-admin-page-design-lock-20260707.md` §3 (predecessors: BA-UI-1 #3824, BA-UI-2 #3840). Owner authorized the full BA ladder 2026-07-07.
- Adds a pure, framework-free util `apps/web/src/services/integration/bridgeAgentConfigCheck.ts`:
  - `computeBridgeAgentConfigCheck({config, objectNames})` — a fixed 6-item values-free checklist: required fields present / limits present-sane / auth mode declared (boolean only) / localhost boundary / raw-SQL-forbidden config hygiene / object-allowlist completeness (material/bom/bom_child-style). Every item is `{id, status: pass|warn|fail, labelKey}` — `labelKey` is a fixed, non-interpolated string, never a config value.
  - `buildBridgeAgentChangeSuggestion(drafts, locale, targetLabel?)` — given operator-typed new object/field-KEY names (never values), renders a values-free, copyable "变更建议/实施清单" text. Names are gated by a safe-identifier pattern (mirrors the backend adapter's `SAFE_OBJECT_NAME_PATTERN`); anything not identifier-shaped is dropped and only counted, never echoed.
- Wires two new ADD-ONLY cards into `IntegrationBridgeAgentSection.vue`: a config-check checklist card (derived from already-fetched state, zero new network calls) and a change-suggestion builder card (add/remove draft rows, copy-to-clipboard, IU-6 guided empty state).
- Zero new backend routes, zero apply/write endpoint calls, zero local-config edit, zero `.ps1` invocation — read-only + suggestions only, exactly as lock §3 requires ("由受控后端或运维脚本应用").

## Security bounds (mutation-tested)

- No credential/host/connection-string/config **value** is ever rendered — the checklist reads `system.config` key names for presence/shape only; every output is a fixed enum + label.
- The suggestion builder never calls an apply endpoint, never writes local config, never touches the `.ps1` script.
- Sentinel tests cover both surfaces independently (config-sourced secrets for the checklist; operator-typed secrets for the suggestion builder) — see verification MD §6.
- Two mutations manually injected → confirmed RED → precisely reverted → confirmed GREEN (verification MD §7).

## Test plan

- [x] `apps/web/tests/bridgeAgentConfigCheck.spec.ts` — 65 tests (6-item branch coverage, 2 SENTINEL suites, label-map values-free scan)
- [x] `apps/web/tests/IntegrationBridgeAgentSection.spec.ts` — 26 tests (16 pre-existing BA-UI-1/2 + 10 new BA-UI-3)
- [x] Full `integration-guard.yml` targeted list (29 files / 363 tests) green on Node 20 (nvm) and default Node
- [x] `pnpm --filter plugin-integration-core test` green (no backend files touched)
- [x] `vue-tsc -b` clean
- [x] `pnpm --filter @metasheet/web build` succeeds
- [x] `.github/workflows/integration-guard.yml` updated: both `paths:` blocks + the single `run:` vitest line include the new util/spec

See `docs/development/bridge-agent-ui3-config-validation-dev-verification-20260707.md` for the full checklist/suggestion contracts, security-bounds table, and mutation-test log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)