### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaConditionalRuleBuilder Add/Save to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaConditionalRuleBuilder.vue
+++ b/apps/web/src/multitable/components/MetaConditionalRuleBuilder.vue
@@ -48,15 +48,15 @@
         :placeholder="p('condRule.value')"
         :aria-label="p('condRule.value')"
       />
-      <button type="button" class="meta-cond-rule__add-btn" data-testid="cond-rule-add" :disabled="!canAdd" @click="addRule">
+      <MtButton class="meta-cond-rule__add-btn" data-testid="cond-rule-add" :disabled="!canAdd" @click="addRule">
         {{ p('condRule.add') }}
-      </button>
+      </MtButton>
     </div>
 
     <div class="meta-cond-rule__actions">
-      <button type="button" class="meta-cond-rule__save" data-testid="cond-rule-save" :disabled="saving" @click="save">
+      <MtButton class="meta-cond-rule__save" data-testid="cond-rule-save" :disabled="saving" @click="save">
         {{ p('condRule.save') }}
-      </button>
+      </MtButton>
       <span v-if="savedFlash" class="meta-cond-rule__saved" data-testid="cond-rule-saved">{{ p('condRule.saved') }}</span>
       <span v-if="error" class="meta-cond-rule__error" role="alert" data-testid="cond-rule-error">{{ error }}</span>
     </div>
@@ -69,6 +69,7 @@ import { useLocale } from '../../composables/useLocale'
 import type { MultitableApiClient } from '../api/client'
 import type { MetaField } from '../types'
 import { permissionLabel, type MetaPermissionLabelKey } from '../utils/meta-permission-labels'
+import { MtButton } from '../ui'
 import {
   coerceRuleValue,
   fieldTypeSupportsRule,
@@ -194,8 +195,10 @@ watch(() => props.sheetId, load)
 .meta-cond-rule__remove { border: none; background: none; color: var(--meta-danger, #dc2626); cursor: pointer; font-size: 12px; }
 .meta-cond-rule__add { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-bottom: 8px; }
 .meta-cond-rule__select, .meta-cond-rule__input { font-size: 12px; padding: 4px 6px; border: 1px solid var(--meta-border, #d1d5db); border-radius: 6px; }
-.meta-cond-rule__add-btn, .meta-cond-rule__save { font-size: 12px; padding: 4px 10px; border: 1px solid var(--meta-border, #d1d5db); border-radius: 6px; cursor: pointer; background: var(--meta-surface, #fff); }
-.meta-cond-rule__add-btn:disabled, .meta-cond-rule__save:disabled { opacity: 0.5; cursor: not-allowed; }
+/* .meta-cond-rule__add-btn / __save: both are now <MtButton> (ghost, token-styled — they were neutral
+   bordered-white secondary actions, no primary/soft fill). Their bespoke CSS (+ shared :disabled) was
+   removed; MtButton provides styling + disabled state. Classes + data-testid kept for selector stability.
+   The per-rule __remove button stays bespoke. */
 .meta-cond-rule__actions { display: flex; align-items: center; gap: 12px; }
 .meta-cond-rule__saved { font-size: 12px; color: var(--meta-success, #059669); }
 .meta-cond-rule__error { font-size: 12px; color: var(--meta-danger, #dc2626); }

--- a/apps/web/tests/meta-cond-rule-builder-migration.spec.ts
+++ b/apps/web/tests/meta-cond-rule-builder-migration.spec.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, type App } from 'vue'
+import MetaConditionalRuleBuilder from '../src/multitable/components/MetaConditionalRuleBuilder.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaConditionalRuleBuilder's Add + Save controls were migrated from bespoke <button>s to the
+// shared MtButton primitive (ghost — they were neutral bordered-white secondary actions, not primary/soft).
+// Their bespoke CSS (+ shared :disabled rule) was removed. Behavior-preservation proof: both stay native,
+// keyboard-operable <button>s; :disabled bindings survive; clicking Save still runs save →
+// client.setConditionalRules. The per-rule Remove stays bespoke.
+
+const flush = (n = 5) => { let p = Promise.resolve(); for (let i = 0; i < n; i++) p = p.then(() => new Promise((r) => setTimeout(r))); return p }
+const fields = [{ id: 'fld_amount', name: 'Amount', type: 'number' as const }]
+
+let app: App | null = null
+let container: HTMLDivElement | null = null
+afterEach(() => { app?.unmount(); container?.remove(); app = null; container = null; useLocale().setLocale('en') })
+
+function mount(client: Record<string, unknown>) {
+  container = document.createElement('div'); document.body.appendChild(container)
+  app = createApp(MetaConditionalRuleBuilder, { sheetId: 's1', fields, client } as never)
+  app.mount(container)
+}
+const q = (sel: string) => container!.querySelector(sel) as HTMLButtonElement | null
+
+describe('MetaConditionalRuleBuilder — MtButton migration (UI-P2-1c)', () => {
+  it('renders Add + Save as native <button>s (MtButton)', async () => {
+    mount({ getConditionalRules: vi.fn().mockResolvedValue({ rules: [], rejected: [] }), setConditionalRules: vi.fn().mockResolvedValue([]) })
+    await flush()
+    expect(q('[data-testid="cond-rule-add"]')!.tagName).toBe('BUTTON') // keyboard-operable
+    expect(q('[data-testid="cond-rule-save"]')!.tagName).toBe('BUTTON')
+  })
+
+  it('clicking Save runs save → client.setConditionalRules (@click unchanged)', async () => {
+    const set = vi.fn().mockResolvedValue([])
+    mount({ getConditionalRules: vi.fn().mockResolvedValue({ rules: [], rejected: [] }), setConditionalRules: set })
+    await flush()
+    q('[data-testid="cond-rule-save"]')!.click()
+    await flush()
+    expect(set).toHaveBeenCalledTimes(1) // @click="save" load-bearing
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, neutral→ghost). Add + Save → MtButton ghost (were neutral bordered-white using --meta-* vars); bespoke CSS + shared :disabled removed. `@click`/`:disabled`/data-testid byte-identical; per-rule Remove stays bespoke. Mount test (2/2, client-stubbed): native buttons + Save→client.setConditionalRules. vue-tsc clean; no new hex; existing conditional-rule-builder+ops (7) green.

Main-loop migration; gated by adversarial-reviewer next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)