### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaViewManager __btn-add to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -400,7 +400,7 @@
 
         <div class="meta-view-mgr__config-actions">
           <button class="meta-view-mgr__btn-cancel" @click="closeConfig">{{ ml('action.cancel') }}</button>
-          <button class="meta-view-mgr__btn-add" :disabled="Boolean(viewConfigBlockingReason)" @click="saveConfig">{{ ml('view.saveSettings') }}</button>
+          <MtButton variant="primary" class="meta-view-mgr__btn-add" :disabled="Boolean(viewConfigBlockingReason)" @click="saveConfig">{{ ml('view.saveSettings') }}</MtButton>
         </div>
       </div>
 
@@ -415,7 +415,7 @@
           <select v-model="newViewType" class="meta-view-mgr__select">
             <option v-for="t in VIEW_TYPES" :key="t" :value="t">{{ viewTypeLabel(t, isZh) }}</option>
           </select>
-          <button class="meta-view-mgr__btn-add" :disabled="!newViewName.trim()" @click="onAddView">{{ ml('view.addButton') }}</button>
+          <MtButton variant="primary" class="meta-view-mgr__btn-add" :disabled="!newViewName.trim()" @click="onAddView">{{ ml('view.addButton') }}</MtButton>
         </div>
       </div>
 
@@ -499,6 +499,7 @@ import {
 } from '../utils/meta-manager-labels'
 import ConditionalFormattingDialog from './ConditionalFormattingDialog.vue'
 import ScaleFormattingDialog from './ScaleFormattingDialog.vue'
+import { MtButton } from '../ui'
 
 const VIEW_TYPES = ['grid', 'form', 'kanban', 'gallery', 'calendar', 'timeline', 'gantt', 'hierarchy'] as const
 const VIEW_ICONS: Record<string, string> = {
@@ -1449,9 +1450,11 @@ onBeforeUnmount(() => {
 .meta-view-mgr__add-row { display: flex; gap: 8px; }
 .meta-view-mgr__input, .meta-view-mgr__select { width: 100%; padding: 5px 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; background: #fff; }
 .meta-view-mgr__select--compact { width: auto; min-width: 130px; }
-.meta-view-mgr__btn-add { padding: 5px 14px; background: #409eff; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 12px; }
-.meta-view-mgr__btn-add:disabled { opacity: 0.4; cursor: not-allowed; }
-.meta-view-mgr__btn-add:hover:not(:disabled) { background: #66b1ff; }
+/* .meta-view-mgr__btn-add: both uses (add-section addView + config-panel saveConfig) are now <MtButton
+   variant="primary">; the bespoke #409eff fill is normalized to --ms-color-primary (intended UF-1 token
+   convergence). Bespoke CSS removed to avoid double-styling the MtButton root; class kept for selector
+   stability (existing spec queries .meta-view-mgr__btn-add). The separate-class cancel/delete/inline
+   buttons stay bespoke. */
 .meta-view-mgr__btn-inline { align-self: flex-start; padding: 4px 10px; border: 1px dashed #cbd5e1; border-radius: 4px; background: #fff; color: #475569; cursor: pointer; font-size: 12px; }
 .meta-view-mgr__confirm { padding: 12px 16px; border-top: 1px solid #eee; background: #fef0f0; }
 .meta-view-mgr__confirm p { margin: 0 0 8px; font-size: 13px; color: #333; }

--- a/apps/web/tests/meta-view-manager-migration.spec.ts
+++ b/apps/web/tests/meta-view-manager-migration.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaViewManager from '../src/multitable/components/MetaViewManager.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaViewManager's two `meta-view-mgr__btn-add` controls (add-section "Add view" + config-panel
+// "Save settings") were migrated from bespoke <button>s to MtButton variant="primary". Because the class is
+// shared across both, BOTH were migrated at once and the bespoke #409eff CSS removed (normalized to
+// --ms-color-primary; no double-styling). Separate-class cancel/delete/inline buttons stay bespoke.
+// Behavior-preservation proof: both stay native <button>s; :disabled survives; clicking Add view still emits
+// `create-view` with the same payload. (Save settings' click behavior is the existing multitable-view-manager
+// spec's regression anchor.)
+
+const fields = [{ id: 'fld_name', name: 'Name', type: 'string' as const }]
+const views = [{ id: 'view_1', sheetId: 'sheet_1', name: 'Grid', type: 'grid' }]
+
+let app: App | null = null; let container: HTMLDivElement | null = null
+afterEach(() => { app?.unmount(); container?.remove(); app = null; container = null; useLocale().setLocale('en') })
+
+function mount(handlers: Record<string, unknown> = {}) {
+  container = document.createElement('div'); document.body.appendChild(container)
+  app = createApp({ render: () => h(MetaViewManager, { visible: true, sheetId: 'sheet_1', activeViewId: 'view_1', fields, views, ...handlers } as never) })
+  app.mount(container)
+}
+const addView = () => container!.querySelector('.meta-view-mgr__btn-add') as HTMLButtonElement // only one on mount (config closed)
+const configBtn = () => container!.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null
+
+describe('MetaViewManager — MtButton migration (UI-P2-1c)', () => {
+  it('renders the add-section Add view as a native <button>; disabled until a name is typed', () => {
+    mount()
+    expect(addView().tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+    expect(addView().disabled).toBe(true) // :disabled="!newViewName.trim()"
+  })
+
+  it('typing a name then clicking Add view emits `create-view` with the same payload (unchanged)', async () => {
+    const onCreateView = vi.fn()
+    mount({ onCreateView })
+    const input = container!.querySelector('.meta-view-mgr__input') as HTMLInputElement
+    input.value = 'My View'; input.dispatchEvent(new Event('input'))
+    await nextTick()
+    expect(addView().disabled).toBe(false)
+    addView().click()
+    expect(onCreateView).toHaveBeenCalledTimes(1)
+    expect(onCreateView).toHaveBeenCalledWith(expect.objectContaining({ sheetId: 'sheet_1', name: 'My View', type: 'grid' }))
+  })
+
+  it('opening the config panel renders the Save-settings control as a native <button> too', async () => {
+    mount()
+    configBtn()!.click() // openConfig(view) → configTarget set → config panel renders
+    await nextTick()
+    const btns = Array.from(container!.querySelectorAll('.meta-view-mgr__config .meta-view-mgr__btn-add')) as HTMLElement[]
+    expect(btns.length).toBe(1)
+    expect(btns[0].tagName).toBe('BUTTON')
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only; SHARED-class → both __btn-add uses migrated). add-section 'Add view' + config-panel 'Save settings' → MtButton variant=primary; bespoke #409eff removed (normalized to --ms-color-primary, intended token convergence; no double-styling). `@click`/`:disabled` + `emit('create-view')` byte-identical; separate-class cancel/delete/inline stay bespoke. Mount test (3/3): Add view native + disabled-until-named + create-view payload; Save settings native when config open. vue-tsc clean; no new hex; existing view-manager+scale (23) green.

Main-loop migration; gated by adversarial-reviewer next. NOTE: #409eff→#2563eb is a slight primary-shade convergence (intended UF-1 normalization, not exact-match) — flagging for gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)