### PR TITLE
feat(approval): RP-1 route-preview shared substrate — one assembly for create and preview (lock RATIFIED)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -322,6 +322,7 @@ jobs:
             tests/integration/approval-card-delivery-wrapper.db.test.ts \
             tests/integration/approval-projection-visibility.db.test.ts \
             tests/integration/approval-projection-participant-read.db.test.ts \
+            tests/integration/approval-route-preview-substrate.db.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/docs/development/approval-route-preview-design-lock-20260707.md
+++ b/docs/development/approval-route-preview-design-lock-20260707.md
@@ -1,6 +1,8 @@
-# 审批路由预览（B3-05 审批人解析预览 + B3-06 模板整流程试运行）· DESIGN-LOCK（PROPOSED）— 2026-07-07
+# 审批路由预览（B3-05 审批人解析预览 + B3-06 模板整流程试运行）· DESIGN-LOCK（RATIFIED）— 2026-07-07
 
-> **状态：PROPOSED，待 owner ratify。** 未 ratify 前不实现（staged-opt-in）。
+> **状态：RATIFIED（owner 2026-07-07，RP-0 通过）。** owner 执行口令：RP-1 只做底座+只读走图+
+> 一致性金测（不碰 UI 面）；RP-2/RP-3 分 PR、均依赖 RP-1；实现硬门=B3-05 formData 只按模板字段
+> 白名单解释、sampleRequesterId 只出现在 B3-06 管理端点。
 > 出处：benchmark §7.4 将本两项定位为「服务 fusion、优先级高于纯打磨」的 batch-3 对
 > （approval-automation-operation-ux-benchmark-20260704.md:108-109,132）；两项共享一个只读底座、
 > **分开 opt-in**。
@@ -70,8 +72,8 @@
 
 ## 6. 切片阶梯（ratify 后各自独立 opt-in）
 
-- ⬜ **RP-0** 本锁 ratify
-- ⬜ **RP-1** 共享底座抽取（快照装配共享化 + 只读走图函数 + 一致性金测）——后端，强模型
+- ✅ **RP-0** ratify（owner 2026-07-07）
+- ✅ **RP-1** 共享底座抽取——本 PR：assembleCreationContext（create 前缀原文抽取，preview 永不漂移）+ previewApprovalRoute 只读走图（逐节点容错/诚实截断）+ formData 白名单硬门（仅 preview 路径）+ 真库金测 6/6（preview===create/零写 RED-before/委托一致/容错/白名单）
 - ⬜ **RP-2** B3-05 端点 + ApprovalNewView 预览条 —— RP-1 后
 - ⬜ **RP-3** B3-06 端点 + authoring 试运行面板 —— RP-1 后，可与 RP-2 并行
 - 🔒 依赖提醒：RP-3 的条件人话展示消费 G-B2-19 `conditionSummary`（在飞）

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3249,7 +3249,25 @@ export class ApprovalProductService {
     )
   }
 
-  async createApproval(request: CreateApprovalRequest, actor: CreateApprovalActor): Promise<UnifiedApprovalDTO> {
+  /**
+   * RP-1 (route-preview lock, RATIFIED — RP-0): the SINGLE assembly shared by createApproval and
+   * the read-only route preview. Everything from template-bundle load through executor
+   * construction lives here so preview can NEVER drift from create (the same normalization,
+   * wedge guards, org/role/delegation snapshot freezing and resolver wiring — one source).
+   * Persistence never happens here; the caller decides whether to write (create) or walk (preview).
+   */
+  private async assembleCreationContext(
+    request: { templateId: string; formData: Record<string, unknown> },
+    actor: CreateApprovalActor,
+    options: { whitelistFormDataToSchema?: boolean } = {},
+  ): Promise<{
+    bundle: NonNullable<Awaited<ReturnType<ApprovalProductService['loadTemplateBundle']>>>
+    formSchema: FormSchema
+    normalizedFormData: Record<string, unknown>
+    runtimeGraph: RuntimeGraph
+    requesterSnapshot: ApprovalRequesterSnapshot
+    executor: ApprovalGraphExecutor
+  }> {
     if (!pool) throw new Error('Database not available')
 
     const bundle = await this.loadTemplateBundle(request.templateId, undefined, 'active', {
@@ -3272,6 +3290,16 @@ export class ApprovalProductService {
 
     const formSchema = asFormSchema(bundle.version.form_schema)
     const normalizedFormData = pruneHiddenFormData(formSchema, request.formData)
+    // RP-1 hard gate (owner order, ratified lock): on the PREVIEW path formData is interpreted
+    // STRICTLY per the template field whitelist — unknown keys are dropped BEFORE validation,
+    // amount-check and graph evaluation, so a request body can never smuggle org-probing
+    // parameters through the read-only walk. The CREATE path never sets this flag (byte-identical).
+    if (options.whitelistFormDataToSchema) {
+      const allowedFieldIds = new Set((formSchema.fields ?? []).map((field) => field.id))
+      for (const key of Object.keys(normalizedFormData)) {
+        if (!allowedFieldIds.has(key)) delete normalizedFormData[key]
+      }
+    }
     const validationErrors = validateApprovalFormData(formSchema, normalizedFormData)
     if (validationErrors.length > 0) {
       throw new ServiceError(
@@ -3446,6 +3474,103 @@ export class ApprovalProductService {
         roles: requesterSnapshot.directoryRoles ?? [],
       },
     })
+    return { bundle, formSchema, normalizedFormData, runtimeGraph, requesterSnapshot, executor }
+  }
+
+  /**
+   * RP-1 (route-preview lock §3/§4, RATIFIED): read-only first-pass route walk over the SAME
+   * assembly createApproval uses. ZERO-WRITE BY CONSTRUCTION — this method touches no client,
+   * no INSERT, no epoch mint, no notification; it only iterates the pure executor. Per-node
+   * fault tolerance: a node whose assignment resolution yields nothing carries an
+   * `EMPTY_ASSIGNEES` marker instead of failing the call; a walk that cannot advance (or would
+   * exceed the node count) truncates honestly. Endpoints/UI arrive in RP-2/RP-3 — the B3-05
+   * consumer passes the SESSION actor as requester (never a caller-supplied one); the B3-06
+   * admin variant threads its sampleRequester through the same method under its own guard.
+   */
+  async previewApprovalRoute(
+    request: { templateId: string; formData: Record<string, unknown> },
+    actor: CreateApprovalActor,
+  ): Promise<{
+    route: Array<{
+      nodeKey: string
+      nodeLabel: string
+      assignees: Array<{ id: string; assignmentType: 'user' | 'role' }>
+      resolveError?: string
+    }>
+    totalSteps: number
+    truncated: boolean
+  }> {
+    const { runtimeGraph, executor } = await this.assembleCreationContext(request, actor, {
+      whitelistFormDataToSchema: true,
+    })
+
+    const nodeLabel = (key: string): string => {
+      const node = runtimeGraph.nodes.find((entry) => entry.key === key)
+      return (node?.name && String(node.name).trim()) || key
+    }
+    const route: Array<{
+      nodeKey: string
+      nodeLabel: string
+      assignees: Array<{ id: string; assignmentType: 'user' | 'role' }>
+      resolveError?: string
+    }> = []
+    let truncated = false
+    const visited = new Set<string>()
+    let resolution: ApprovalGraphResolution
+    try {
+      resolution = executor.resolveInitialState()
+    } catch {
+      // Per-node fault tolerance floor: a template whose FIRST resolution throws (e.g.
+      // emptyAssigneePolicy 'error' with a runtime-empty node) previews as an honest empty
+      // truncated route — the create path keeps its own throw semantics untouched.
+      return { route: [], totalSteps: executor.totalSteps, truncated: true }
+    }
+    // Bounded by node count: a healthy DAG first-pass can never revisit a node; anything else
+    // (cycle, resolver loop) stops the walk with an honest truncation flag instead of spinning.
+    const maxSteps = runtimeGraph.nodes.length + 1
+    for (let step = 0; step < maxSteps; step += 1) {
+      if (resolution.status === 'approved' || !resolution.currentNodeKey) break
+      const frontier = resolution.currentNodeKeys && resolution.currentNodeKeys.length > 0
+        ? resolution.currentNodeKeys
+        : [resolution.currentNodeKey]
+      for (const nodeKey of frontier) {
+        if (visited.has(nodeKey)) continue
+        visited.add(nodeKey)
+        const assignments = resolution.assignments.filter((entry) => entry.nodeKey === nodeKey)
+        route.push({
+          nodeKey,
+          nodeLabel: nodeLabel(nodeKey),
+          assignees: assignments.map((entry) => ({ id: entry.assigneeId, assignmentType: entry.assignmentType })),
+          ...(assignments.length === 0 ? { resolveError: 'EMPTY_ASSIGNEES' } : {}),
+        })
+      }
+      // Parallel frontier: advancing a multi-branch region node-by-node through
+      // resolveAfterApprove mirrors the runtime, but the preview only promises the FIRST-PASS
+      // node set — advance from the primary cursor; if the executor cannot advance, truncate.
+      try {
+        const next = executor.resolveAfterApprove(resolution.currentNodeKey)
+        if (next.currentNodeKey && visited.has(next.currentNodeKey) && next.status !== 'approved') {
+          truncated = true
+          break
+        }
+        resolution = next
+      } catch {
+        truncated = true
+        break
+      }
+    }
+    if (resolution.status !== 'approved' && !truncated && resolution.currentNodeKey) {
+      // Ran out of the step budget while still pending — cycle-shaped graph; honest flag.
+      truncated = true
+    }
+    return { route, totalSteps: executor.totalSteps, truncated }
+  }
+
+  async createApproval(request: CreateApprovalRequest, actor: CreateApprovalActor): Promise<UnifiedApprovalDTO> {
+    if (!pool) throw new Error('Database not available')
+    // RP-1: prefix extracted verbatim into assembleCreationContext (shared with previewApprovalRoute).
+    const { bundle, normalizedFormData, runtimeGraph, requesterSnapshot, executor } =
+      await this.assembleCreationContext(request, actor)
     const instanceId = crypto.randomUUID()
     const initialResolution = executor.resolveInitialState()
     const initial = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)

--- a/packages/core-backend/tests/integration/approval-route-preview-substrate.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-route-preview-substrate.db.test.ts
@@ -1,0 +1,163 @@
+/**
+ * RP-1 — route-preview shared substrate (route-preview lock, RATIFIED RP-0; owner order:
+ * substrate + read-only walk + consistency golden ONLY, no UI surfaces).
+ *
+ * The lock's hardest proof: preview === create on the SAME database at the SAME instant —
+ * because both consume ONE assembly (assembleCreationContext), per-node assignees the preview
+ * reports must equal the assignments createApproval then persists. Plus: delegation consistency,
+ * per-node fault tolerance (EMPTY_ASSIGNEES marker, no 500), the formData whitelist hard gate
+ * (owner order: no org-probing params through the read-only walk), and ZERO-WRITE proof
+ * (instances/assignments/records row counts unchanged by preview).
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { pool } from '../../src/db/pg'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => pool.query(sql, params)
+
+const TS = Date.now()
+const REQUESTER = `u_rp1_req_${TS}`
+const APPROVER = `u_rp1_appr_${TS}`
+const DELEGATEE = `u_rp1_dele_${TS}`
+
+let approvals: ApprovalProductService
+let templateId = ''
+let emptyTemplateId = ''
+
+const requesterActor = { userId: REQUESTER, userName: REQUESTER, roles: [] as string[], permissions: ['approvals:write'] }
+
+describeIfDatabase('RP-1 — route-preview substrate (real DB)', () => {
+  beforeAll(async () => {
+    await q(`INSERT INTO permissions (code, name, description) VALUES ('approvals:write','w','t'),('approvals:act','a','t') ON CONFLICT (code) DO NOTHING`)
+    for (const uid of [REQUESTER, APPROVER, DELEGATEE]) {
+      await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+               VALUES ($1,$2,$1,'x','user','[]'::jsonb,TRUE,FALSE) ON CONFLICT (id) DO UPDATE SET is_active = TRUE`, [uid, `${uid}@rp1.test`])
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+
+    approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate({
+      key: `rp1-${TS}`,
+      name: 'RP1 Preview Template',
+      formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          { key: 'approval_1', type: 'approval', name: '一级审批', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] } },
+          { key: 'approval_2', type: 'approval', name: '二级审批', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] } },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'approval_2' },
+          { key: 'e3', source: 'approval_2', target: 'end' },
+        ],
+      },
+    } as never, { userId: REQUESTER, userName: REQUESTER } as never)
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+
+    // A template whose approval node resolves NOBODY (empty static list) — the fault-tolerance
+    // fixture. skip-empty policy keeps publish/create legal where applicable; the preview must
+    // mark, not throw.
+    const emptyTemplate = await approvals.createTemplate({
+      key: `rp1e-${TS}`,
+      name: 'RP1 Empty Assignee Template',
+      formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          // Publish-legal but RUNTIME-empty: direct_manager for a requester with no manager row.
+          { key: 'approval_1', type: 'approval', name: '无人节点', config: { mode: 'any', assigneeSources: [{ kind: 'direct_manager' }], emptyAssigneePolicy: 'auto-approve' } },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'end' },
+        ],
+      },
+    } as never, { userId: REQUESTER, userName: REQUESTER } as never)
+    emptyTemplateId = (emptyTemplate as { id: string }).id
+    await approvals.publishTemplate(emptyTemplateId, { policy: { allowRevoke: true } } as never)
+  })
+
+  afterAll(async () => {
+    for (const tid of [templateId, emptyTemplateId]) {
+      const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [tid]).catch(() => ({ rows: [] as unknown[] }))
+      for (const row of instances.rows as Array<{ id: string }>) {
+        await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
+        await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
+        await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
+      }
+      await q('DELETE FROM approval_templates WHERE id = $1', [tid]).catch(() => {})
+    }
+    await q('DELETE FROM approval_delegations WHERE delegator_user_id = $1', [APPROVER]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[REQUESTER]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[REQUESTER, APPROVER, DELEGATEE]]).catch(() => {})
+  })
+
+  it('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  it('GOLDEN: preview === create — per-node assignees match the persisted assignments (same DB, same instant)', async () => {
+    const request = { templateId, formData: { summary: 'consistency run' } }
+    const preview = await approvals.previewApprovalRoute(request, requesterActor as never)
+    expect(preview.truncated).toBe(false)
+    expect(preview.route.map((n) => n.nodeKey)).toEqual(['approval_1', 'approval_2'])
+    expect(preview.route[0]!.nodeLabel).toBe('一级审批')
+
+    const created = await approvals.createApproval(request as never, requesterActor as never)
+    const persisted = await q(
+      `SELECT node_key, assignee_id, assignment_type FROM approval_assignments WHERE instance_id = $1 AND node_key = $2`,
+      [(created as { id: string }).id, 'approval_1'],
+    )
+    const persistedSet = (persisted.rows as Array<{ assignee_id: string; assignment_type: string }>)
+      .map((row) => `${row.assignment_type}:${row.assignee_id}`).sort()
+    const previewSet = preview.route[0]!.assignees.map((a) => `${a.assignmentType}:${a.id}`).sort()
+    expect(previewSet).toEqual(persistedSet)
+    expect(previewSet).toEqual([`user:${APPROVER}`])
+  })
+
+  it('ZERO-WRITE: preview leaves instances/assignments/records row counts untouched', async () => {
+    const count = async (table: string) => Number((await q(`SELECT count(*) AS c FROM ${table}`)).rows[0]!.c)
+    const before = [await count('approval_instances'), await count('approval_assignments'), await count('approval_records')]
+    await approvals.previewApprovalRoute({ templateId, formData: { summary: 'zero write' } }, requesterActor as never)
+    const after = [await count('approval_instances'), await count('approval_assignments'), await count('approval_records')]
+    // RED-before: plant any INSERT into the substrate/walk and this equality breaks.
+    expect(after).toEqual(before)
+  })
+
+  it('DELEGATION consistency: an active window shows the delegatee in preview (same substitution as create)', async () => {
+    await q(
+      `INSERT INTO approval_delegations (id, delegator_user_id, delegatee_user_id, scope, scope_template_id, start_at, end_at, active)
+       VALUES ($1,$2,$3,'all',NULL, now() - interval '1 hour', now() + interval '1 day', TRUE)`,
+      [`rp1-dele-${TS}`, APPROVER, DELEGATEE],
+    )
+    try {
+      const preview = await approvals.previewApprovalRoute({ templateId, formData: { summary: 'delegation run' } }, requesterActor as never)
+      expect(preview.route[0]!.assignees.map((a) => a.id)).toEqual([DELEGATEE])
+    } finally {
+      await q('DELETE FROM approval_delegations WHERE id = $1', [`rp1-dele-${TS}`]).catch(() => {})
+    }
+  })
+
+  it('FAULT TOLERANCE (auto-approve policy): runtime-empty node never 500s the preview', async () => {
+    const preview = await approvals.previewApprovalRoute({ templateId: emptyTemplateId, formData: { summary: 'empty node' } }, requesterActor as never)
+    // auto-approve either walks past the node (empty route) or surfaces it with the marker —
+    // both are honest; the contract under test is NO THROW + a well-formed result.
+    for (const node of preview.route) {
+      if (node.assignees.length === 0) expect(node.resolveError).toBe('EMPTY_ASSIGNEES')
+    }
+    expect(typeof preview.truncated).toBe('boolean')
+  })
+
+  it('HARD GATE: unknown formData keys are whitelisted OUT of the preview walk (no org-probing smuggling)', async () => {
+    const clean = await approvals.previewApprovalRoute({ templateId, formData: { summary: 'probe' } }, requesterActor as never)
+    const probed = await approvals.previewApprovalRoute(
+      { templateId, formData: { summary: 'probe', requesterId: 'someone_else', managerChainIds: ['x'], __proto__polluter: true } as never },
+      requesterActor as never,
+    )
+    expect(probed.route).toEqual(clean.route)
+    expect(probed.truncated).toBe(clean.truncated)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -75,6 +75,8 @@ export default defineConfig({
       // wired into NO workflow — skip-green; now run in plugin-tests' approval real-DB step).
       'tests/integration/approval-projection-visibility.db.test.ts',
       'tests/integration/approval-projection-participant-read.db.test.ts',
+      // RP-1: route-preview shared substrate goldens (preview===create, zero-write, whitelist gate).
+      'tests/integration/approval-route-preview-substrate.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
Implements **RP-1** per the owner's ratify orders on the route-preview lock (#3813, RP-0 通过): substrate + read-only walk + consistency goldens ONLY — no UI surfaces (RP-2/RP-3 follow as separate PRs).

## What
- **`assembleCreationContext`**: createApproval's ENTIRE prefix (bundle load → formData normalization → wedge guards → org/role/delegation snapshot freeze → executor construction) extracted **verbatim** into one private method consumed by both create and preview — drift is structurally impossible. createApproval is now a thin consumer; post-boundary code byte-identical.
- **`previewApprovalRoute`**: read-only first-pass walk (initialState + resolveAfterApprove, node-count bounded); zero-write by construction; per-node `EMPTY_ASSIGNEES` markers; an initial-resolution throw previews as honest `truncated` instead of a 500.
- **Owner hard gate**: preview-path formData is whitelisted to template field ids BEFORE validation/amount-check/graph eval; the create path never sets the flag (byte-identical). No requester override exists on this method — the session actor IS the requester (`sampleRequesterId` arrives only with RP-3's admin endpoint).

## Verification (fresh DB, migrations from zero)
- Substrate goldens **6/6**: **GOLDEN preview===create** (per-node assignees vs persisted assignments, same DB/instant — the lock's hardest same-substrate proof) · **ZERO-WRITE** row-count equality with RED-before (planted INSERT → red, reverted) · delegation-window consistency · fault tolerance · whitelist gate
- **Extraction equivalence**: delegation-seam + manager-chain + requester-department (wedge guards) + pack1a-lifecycle **11/11**
- tsc 0 · two-point CI wiring · lock checklist flipped RP-0/RP-1 as-built

Next (separate PRs, both on this substrate): **RP-2** B3-05 endpoint + ApprovalNewView preview bar · **RP-3** B3-06 admin endpoint + authoring dry-run panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)