### PR TITLE
refactor(multitable): R5b — ResetToPointPicker strings → typed label modules (strict-zero closeout)

### DIFF
--- a/apps/web/src/multitable/components/ResetToPointPicker.vue
+++ b/apps/web/src/multitable/components/ResetToPointPicker.vue
@@ -11,14 +11,21 @@
   "Target" line is derived FROM `asOf` (not the raw input), so what the user sees can never diverge from what the
   destructive op uses. Gated on `pitResetEnabled` ALONE (it already encodes flag ∧ canManageSheetAccess); the
   dialog is mounted only once T is valid & past, so the dialog's own "Reset to {asOf}…" button never fires empty.
+
+  i18n (R5b strict-zero closeout): strings routed through `l()` → meta-record-labels.ts `record.resetPicker*`.
+  The stray `{{ ' ' }}` mustaches around some labels are NOT decorative — a whitespace-only static text node that
+  is the first/last child of its element is unconditionally stripped by Vue's template whitespace-condense pass
+  (unlike a mixed text+space node, which only gets collapsed), so a literal-string-space would silently vanish
+  where the original hardcoded copy had a leading/trailing space. Wrapping the space in its own interpolation
+  keeps it immune to that pass — do not "clean this up" without re-diffing rendered output byte-for-byte.
 -->
 <template>
   <div v-if="pitResetEnabled" class="reset-picker" data-test="reset-picker">
     <div class="reset-picker__history" data-test="reset-picker-history">
-      <div class="reset-picker__heading">Reset this sheet to a Global History point</div>
+      <div class="reset-picker__heading">{{ l('record.resetPickerHeading') }}</div>
       <div class="reset-picker__history-row">
         <label class="reset-picker__label">
-          <span>History point</span>
+          <span>{{ l('record.resetPickerHistoryLabel') }}</span>
           <select
             class="reset-picker__input reset-picker__select"
             data-test="reset-picker-history-select"
@@ -26,7 +33,7 @@
             :disabled="historyLoading || historyOptions.length === 0"
             @change="mode = 'history'"
           >
-            <option value="">Select a recent history batch</option>
+            <option value="">{{ l('record.resetPickerHistoryPlaceholder') }}</option>
             <option v-for="batch in historyOptions" :key="batch.batchId" :value="batch.batchId">
               {{ historyBatchLabel(batch) }}
             </option>
@@ -37,20 +44,18 @@
           data-test="reset-picker-history-refresh"
           :disabled="historyLoading || !canLoadHistory"
           @click="loadHistoryBatches"
-        >
-          Refresh
-        </MtButton>
+        >{{ ' ' }}{{ l('record.resetPickerRefresh') }}{{ ' ' }}</MtButton>
       </div>
-      <p v-if="historyLoading" class="reset-picker__hint" data-test="reset-picker-history-loading">Loading history points...</p>
+      <p v-if="historyLoading" class="reset-picker__hint" data-test="reset-picker-history-loading">{{ l('record.resetPickerHistoryLoading') }}</p>
       <p v-else-if="historyError" class="reset-picker__hint reset-picker__hint--warn" data-test="reset-picker-history-error">{{ historyError }}</p>
-      <p v-else-if="canLoadHistory && historyOptions.length === 0" class="reset-picker__hint" data-test="reset-picker-history-empty">No recent history batches found.</p>
-      <p v-else-if="!canLoadHistory" class="reset-picker__hint" data-test="reset-picker-history-unavailable">History points unavailable.</p>
+      <p v-else-if="canLoadHistory && historyOptions.length === 0" class="reset-picker__hint" data-test="reset-picker-history-empty">{{ l('record.resetPickerHistoryEmpty') }}</p>
+      <p v-else-if="!canLoadHistory" class="reset-picker__hint" data-test="reset-picker-history-unavailable">{{ l('record.resetPickerHistoryUnavailable') }}</p>
     </div>
 
     <details class="reset-picker__manual" data-test="reset-picker-manual">
-      <summary>Advanced manual time</summary>
+      <summary>{{ l('record.resetPickerManualSummary') }}</summary>
       <label class="reset-picker__label">
-        <span>Manual point in time</span>
+        <span>{{ l('record.resetPickerManualLabel') }}</span>
         <input
           type="datetime-local"
           class="reset-picker__input"
@@ -64,14 +69,11 @@
 
     <!-- datetime-local coerces invalid text to '' so a non-empty-unparseable value can't occur; if `asOf` is somehow
          null it simply renders nothing below (fail-safe: no dialog), so no separate invalid branch is needed. -->
-    <p v-if="asOf && isFuture" class="reset-picker__hint reset-picker__hint--warn" data-test="reset-picker-future">
-      Pick a time in the past — you can only reset to an earlier state.
-    </p>
+    <p v-if="asOf && isFuture" class="reset-picker__hint reset-picker__hint--warn" data-test="reset-picker-future">{{ ' ' }}{{ l('record.resetPickerFutureWarn') }}{{ ' ' }}</p>
 
     <template v-else-if="asOf">
-      <p class="reset-picker__target" data-test="reset-picker-target">
-        Target: <strong>{{ targetDisplay }}</strong> (your local time)
-        <span v-if="selectedHistoryBatch && mode === 'history'"> from history batch {{ shortSelectedBatchId }}</span>
+      <p class="reset-picker__target" data-test="reset-picker-target">{{ ' ' }}{{ l('record.resetPickerTargetPrefix') }} <strong>{{ targetDisplay }}</strong> {{ l('record.resetPickerTargetSuffix') }}
+        <span v-if="selectedHistoryBatch && mode === 'history'">{{ ' ' }}{{ l('record.resetPickerFromBatch') }} {{ shortSelectedBatchId }}</span>
       </p>
       <ResetConfirmDialog
         :pit-reset-enabled="true"
@@ -91,6 +93,8 @@ import ResetConfirmDialog from './ResetConfirmDialog.vue'
 import { MtButton } from '../ui'
 import type { ResetPreview, ResetResult } from '../api/client'
 import type { HistoryBatchSummary } from '../types'
+import { useLocale } from '../../composables/useLocale'
+import { recordLabel, resetPickerRecordCount, type MetaRecordLabelKey } from '../utils/meta-record-labels'
 
 type ListHistoryEvents = (
   baseId: string,
@@ -111,6 +115,9 @@ const props = defineProps<{
 }>()
 
 const RECENT_HISTORY_LIMIT = 20
+
+const { isZh } = useLocale()
+const l = (key: MetaRecordLabelKey): string => recordLabel(key, isZh.value)
 
 const localValue = ref('')
 const selectedBatchId = ref('')
@@ -133,9 +140,9 @@ function hasUsableCreatedAt(batch: HistoryBatchSummary): boolean {
 
 function historyBatchLabel(batch: HistoryBatchSummary): string {
   const when = new Date(batch.createdAt).toLocaleString()
-  const actor = batch.actorName || batch.actorId || 'System'
-  const action = batch.action || 'update'
-  const records = batch.visibleAffectedRecordCount === 1 ? '1 record' : `${batch.visibleAffectedRecordCount} records`
+  const actor = batch.actorName || batch.actorId || l('record.resetPickerSystemActor')
+  const action = batch.action || l('record.resetPickerDefaultAction')
+  const records = resetPickerRecordCount(batch.visibleAffectedRecordCount, isZh.value)
   return `${when} - ${action} - ${actor} - ${records}`
 }
 
@@ -190,7 +197,7 @@ async function loadHistoryBatches(): Promise<void> {
     if (loadSeq !== historyLoadSeq) return
     historyBatches.value = []
     selectedBatchId.value = ''
-    historyError.value = err instanceof Error ? err.message : 'Failed to load history points'
+    historyError.value = err instanceof Error ? err.message : l('record.resetPickerErrorLoad')
   } finally {
     if (loadSeq === historyLoadSeq) historyLoading.value = false
   }

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -90,6 +90,13 @@ export type MetaRecordLabelKey =
   | 'notification.eventNotificationSent'
   // --- MetaFormView multi-page nav chrome (A4) ---
   | 'form.previousPage' | 'form.nextPage'
+  // --- T8-2 Reset UI T-source picker (R5b strict-zero closeout) ---
+  | 'record.resetPickerHeading' | 'record.resetPickerHistoryLabel' | 'record.resetPickerHistoryPlaceholder'
+  | 'record.resetPickerRefresh' | 'record.resetPickerHistoryLoading'
+  | 'record.resetPickerHistoryEmpty' | 'record.resetPickerHistoryUnavailable'
+  | 'record.resetPickerManualSummary' | 'record.resetPickerManualLabel' | 'record.resetPickerFutureWarn'
+  | 'record.resetPickerTargetPrefix' | 'record.resetPickerTargetSuffix' | 'record.resetPickerFromBatch'
+  | 'record.resetPickerErrorLoad' | 'record.resetPickerSystemActor' | 'record.resetPickerDefaultAction'
 
 const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }> = {
   'notification.bell': { en: 'Notifications', zh: '通知' },
@@ -229,6 +236,26 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'form.reset': { en: 'Reset', zh: '重置' },
   'form.previousPage': { en: 'Previous', zh: '上一页' },
   'form.nextPage': { en: 'Next', zh: '下一页' },
+
+  // T8-2 Reset UI T-source picker (ResetToPointPicker.vue, R5b strict-zero closeout — the component was born
+  // after the i18n line closed and shipped all-English; flag (pitResetEnabled) is dormant by default so this
+  // is a shape-only migration, no behavior change).
+  'record.resetPickerHeading': { en: 'Reset this sheet to a Global History point', zh: '将此表重置到某个全局历史点' },
+  'record.resetPickerHistoryLabel': { en: 'History point', zh: '历史点' },
+  'record.resetPickerHistoryPlaceholder': { en: 'Select a recent history batch', zh: '选择一个最近的历史批次' },
+  'record.resetPickerRefresh': { en: 'Refresh', zh: '刷新' },
+  'record.resetPickerHistoryLoading': { en: 'Loading history points...', zh: '正在加载历史点...' },
+  'record.resetPickerHistoryEmpty': { en: 'No recent history batches found.', zh: '未找到最近的历史批次。' },
+  'record.resetPickerHistoryUnavailable': { en: 'History points unavailable.', zh: '历史点不可用。' },
+  'record.resetPickerManualSummary': { en: 'Advanced manual time', zh: '高级：手动指定时间' },
+  'record.resetPickerManualLabel': { en: 'Manual point in time', zh: '手动指定时间点' },
+  'record.resetPickerFutureWarn': { en: 'Pick a time in the past — you can only reset to an earlier state.', zh: '请选择过去的时间——只能重置到更早的状态。' },
+  'record.resetPickerTargetPrefix': { en: 'Target:', zh: '目标：' },
+  'record.resetPickerTargetSuffix': { en: '(your local time)', zh: '（你的本地时间）' },
+  'record.resetPickerFromBatch': { en: 'from history batch', zh: '来自历史批次' },
+  'record.resetPickerErrorLoad': { en: 'Failed to load history points', zh: '加载历史点失败' },
+  'record.resetPickerSystemActor': { en: 'System', zh: '系统' },
+  'record.resetPickerDefaultAction': { en: 'update', zh: '更新' },
 }
 
 export function recordLabel(key: MetaRecordLabelKey, isZh: boolean): string {
@@ -293,4 +320,12 @@ export function formPageIndicator(current: number, total: number, isZh: boolean)
 // never translated; only the surrounding copy is.
 export function configRestoreTypedConfirm(confirmToken: string, isZh: boolean): string {
   return isZh ? `输入 ${confirmToken} 以确认：` : `Type ${confirmToken} to confirm:`
+}
+
+// resetPickerRecordCount: the affected-record count fragment of a Global History batch label
+// (ResetToPointPicker's historyBatchLabel, R5b). EN keeps the original singular/plural literal
+// ('1 record' / 'N records'); zh uses the measure-word form. The number itself is never translated.
+export function resetPickerRecordCount(count: number, isZh: boolean): string {
+  if (isZh) return `${count} 条记录`
+  return count === 1 ? '1 record' : `${count} records`
 }

--- a/apps/web/tests/multitable-reset-tsource-picker.spec.ts
+++ b/apps/web/tests/multitable-reset-tsource-picker.spec.ts
@@ -10,6 +10,7 @@ import { createApp, nextTick } from 'vue'
 
 import ResetToPointPicker from '../src/multitable/components/ResetToPointPicker.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
+import { useLocale } from '../src/composables/useLocale'
 import type { HistoryBatchSummary } from '../src/multitable/types'
 
 const mounted: Array<{ unmount: () => void }> = []
@@ -50,7 +51,7 @@ const waitUntil = async (pred: () => boolean, tries = 100): Promise<void> => {
 }
 const setInput = (sel: string, val: string) => { const el = q(sel) as HTMLInputElement; el.value = val; el.dispatchEvent(new Event('input')) }
 const setSelect = (sel: string, val: string) => { const el = q(sel) as HTMLSelectElement; el.value = val; el.dispatchEvent(new Event('change')) }
-afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
+afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = ''; useLocale().setLocale('en') })
 
 describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
   it('(a) whole entry HIDDEN when pitResetEnabled false / absent (fail-closed)', async () => {
@@ -177,5 +178,46 @@ describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
     expect(String(fetchFn.mock.calls[1][0])).toContain('/reset-execute')
     expect(JSON.parse((fetchFn.mock.calls[1][1] as RequestInit).body as string).asOf).toBe(batchCreatedAt)
     await waitUntil(() => onDone.mock.calls.length >= 1) // the seam back to the workbench (grid refresh) fired
+  })
+
+  it('(h) R5b i18n: zh locale renders the typed zh labels (strings live in meta-record-labels, not inline)', async () => {
+    useLocale().setLocale('zh-CN')
+    mount(); await nextTick()
+    await waitUntil(() => (q('[data-test="reset-picker-history-select"]') as HTMLSelectElement | null)?.options.length === 3)
+    expect(q('.reset-picker__heading')?.textContent).toBe('将此表重置到某个全局历史点')
+    expect(q('[data-test="reset-picker-history"] .reset-picker__label > span')?.textContent).toBe('历史点')
+    expect((q('[data-test="reset-picker-history-select"]') as HTMLSelectElement).options[0].textContent).toBe('选择一个最近的历史批次')
+    // history option zh: record count uses the measure-word form; the wire `action` value and actor 'Ada'
+    // are data, rendered raw (only the missing-action/missing-actor FALLBACK literals are typed labels)
+    expect((q('[data-test="reset-picker-history-select"]') as HTMLSelectElement).options[1].textContent?.trim()).toContain('update - Ada - 1 条记录')
+    expect(q('[data-test="reset-picker-history-refresh"]')?.textContent?.trim()).toBe('刷新')
+    expect(q('[data-test="reset-picker-manual"] summary')?.textContent).toBe('高级：手动指定时间')
+    expect(q('[data-test="reset-picker-manual"] .reset-picker__label > span')?.textContent).toBe('手动指定时间点')
+    // future warn (manual T in the future)
+    setInput('[data-test="reset-picker-input"]', '2099-01-01T00:00'); await flush()
+    expect(q('[data-test="reset-picker-future"]')?.textContent?.trim()).toBe('请选择过去的时间——只能重置到更早的状态。')
+    // valid history T → zh target line
+    setSelect('[data-test="reset-picker-history-select"]', 'batch_new'); await flush()
+    const target = q('[data-test="reset-picker-target"]')?.textContent ?? ''
+    expect(target).toContain('目标：')
+    expect(target).toContain('（你的本地时间）')
+    expect(target).toContain('来自历史批次 batch_ne')
+  })
+
+  it('(h2) R5b i18n: zh empty/unavailable/loading-error hints render the typed zh labels', async () => {
+    useLocale().setLocale('zh-CN')
+    // empty
+    mount({ listHistoryEvents: vi.fn(async () => ({ batches: [], total: 0, nextCursor: null, searchTruncated: false })) }); await nextTick()
+    await waitUntil(() => !!q('[data-test="reset-picker-history-empty"]'))
+    expect(q('[data-test="reset-picker-history-empty"]')?.textContent).toBe('未找到最近的历史批次。')
+    mounted.pop()!.unmount(); document.body.innerHTML = ''
+    // unavailable (no baseId → history source off, fail-closed on this source only)
+    mount({ baseId: '' }); await nextTick(); await flush()
+    expect(q('[data-test="reset-picker-history-unavailable"]')?.textContent).toBe('历史点不可用。')
+    mounted.pop()!.unmount(); document.body.innerHTML = ''
+    // non-Error rejection → typed zh fallback copy (an Error's own message stays raw — covered by (d1))
+    mount({ listHistoryEvents: vi.fn(async () => { throw 'not-an-error' }) }); await nextTick()
+    await waitUntil(() => !!q('[data-test="reset-picker-history-error"]'))
+    expect(q('[data-test="reset-picker-history-error"]')?.textContent).toBe('加载历史点失败')
   })
 })

--- a/docs/development/multitable-global-history-r5-3749-absorption-round-record-20260707.md
+++ b/docs/development/multitable-global-history-r5-3749-absorption-round-record-20260707.md
@@ -30,3 +30,7 @@
 ## 3. 轮后状态
 
 线状态与 R4 收轮一致:**池空**;五个 owner 闸门不变(ratify 4c-1(U-L8 二择一)/ ratify 4c-2 / T-source 保持A2或简化A1 / O-1 staging 正式跑 / destructive-tier FE 闭合判定)。解锁哨兵在岗。
+
+## 4. R5b 追记(2026-07-07)
+
+§2 中 NIT-a(ResetToPointPicker 英文-only)原判「记录不修」,复判为**纪律归位**:strict-zero 收线后的规则是未来 UI 字符串一律进 typed label 模块,该组件生于收线之后,属规则内新债而非既有债扩展。R5b 微切片将其全部可见字符串收编 `meta-record-labels.ts`(`record.resetPicker*` 命名空间 + `resetPickerRecordCount` 插值 helper)并补 zh;EN 渲染逐字节保形(7 分支 before/after DOM diff 为空),flag(PIT_RESET)休眠零线上风险。


### PR DESCRIPTION
## R5b 微切片 — ResetToPointPicker 硬编码英文收编 typed label 模块(strict-zero closeout)

R5 吸收审计(#3860 记录)NIT-a:T8-2 T-source picker 生于 multitable i18n TRUE STRICT-ZERO 收线之后却全英硬编码。复判为**纪律归位**(strict-zero 未来字符串规则内的新债,非既有债扩展):全部可见字符串收编 `meta-record-labels.ts`(唯一扩展点之一),补 zh。沿用邻居 `ResetConfirmDialog`/`MetaConfigHistoryModal` 的 `useLocale().isZh` + `recordLabel`/`l()` 既有模式,不新建模块、不引入新 locale 机制。

**Flag 休眠(`MULTITABLE_ENABLE_PIT_RESET` 默认关)→ 零线上可见风险;EN 侧逐字节保形,zh 为新增侧。**

### 字符串清单(16 key + 1 插值 helper)

| Key | EN(逐字节原文) | zh(新增) |
|---|---|---|
| `record.resetPickerHeading` | `Reset this sheet to a Global History point` | 将此表重置到某个全局历史点 |
| `record.resetPickerHistoryLabel` | `History point` | 历史点 |
| `record.resetPickerHistoryPlaceholder` | `Select a recent history batch` | 选择一个最近的历史批次 |
| `record.resetPickerRefresh` | `Refresh` | 刷新 |
| `record.resetPickerHistoryLoading` | `Loading history points...` | 正在加载历史点... |
| `record.resetPickerHistoryEmpty` | `No recent history batches found.` | 未找到最近的历史批次。 |
| `record.resetPickerHistoryUnavailable` | `History points unavailable.` | 历史点不可用。 |
| `record.resetPickerManualSummary` | `Advanced manual time` | 高级：手动指定时间 |
| `record.resetPickerManualLabel` | `Manual point in time` | 手动指定时间点 |
| `record.resetPickerFutureWarn` | `Pick a time in the past — you can only reset to an earlier state.` | 请选择过去的时间——只能重置到更早的状态。 |
| `record.resetPickerTargetPrefix` | `Target:` | 目标： |
| `record.resetPickerTargetSuffix` | `(your local time)` | （你的本地时间） |
| `record.resetPickerFromBatch` | `from history batch` | 来自历史批次 |
| `record.resetPickerErrorLoad` | `Failed to load history points` | 加载历史点失败 |
| `record.resetPickerSystemActor` | `System` | 系统 |
| `record.resetPickerDefaultAction` | `update` | 更新 |
| helper `resetPickerRecordCount(n, isZh)` | `1 record` / `N records`(单复数保形) | `N 条记录` |

数据保持 raw 不翻译:wire `action` 值、actor 名、`Error.message`(仅 missing-action / missing-actor / 非 Error rejection 的 **fallback** 字面量走 typed label)——与 `configRestoreTypedConfirm`(confirm token 不翻译)同一先例。

### 保形证据(EN 渲染逐字节 diff 为空)

改前/改后各跑一次 7 分支 DOM 快照 harness(default / history-selected / future-warn / history-error / history-empty / history-unavailable / history-loading,`outerHTML` 全量),归一化与本改动无关的 `max="<当前时刻>"` 非确定性属性后 **`diff` 退出码 0(零差异)**。含前导/尾随空格文本节点:Vue 模板 whitespace-condense 会无条件剥掉「纯空白且为首/末子节点」的静态文本节点,故用 `{{ ' ' }}` 哨兵保住原空格(组件头注释已文档化,防未来"清理")。快照 harness 为临时 scratch spec,已删除,不入库。

### 测试与门

- `multitable-reset-tsource-picker.spec.ts`:原 9 条断言零改动全绿(EN 保形的第二重证明)+ 新增 2 条 zh 侧 golden((h) chrome/target/future-warn;(h2) empty/unavailable/非 Error fallback 文案)→ **11/11**
- `vue-tsc -b` 干净;eslint 3 个改动文件 0 报错
- multitable web-guard 全矩阵(与 `multitable-web-guard.yml` 同一目标集)本地实跑:**49 files / 513 tests 全绿**(含 meta-record-labels 全部既有消费面)

### 文档

同 PR 给 `docs/development/multitable-global-history-r5-3749-absorption-round-record-20260707.md` 追加「§4 R5b 追记」:NIT-a 从「记录不修」复判为纪律归位、改动保形、flag 休眠零风险。

### 未做(不在本切片)

- `ResetConfirmDialog.vue` 自身的英文硬编码(R5 审计口径中属另一组件、另判)
- picker 内 `toLocaleString()` 的日期格式本地化(browser-locale 行为,非字符串收编范畴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
