### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaAutomationGroupDeliveryViewer Refresh to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
@@ -13,7 +13,7 @@
             <option value="success">{{ automationStatusLabel('success', isZh) }}</option>
             <option value="failed">{{ automationStatusLabel('failed', isZh) }}</option>
           </select>
-          <button class="meta-group-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">{{ automationLabel('log.refresh', isZh) }}</button>
+          <MtButton class="meta-group-delivery__btn" data-action="refresh" :disabled="loading" @click="loadData">{{ automationLabel('log.refresh', isZh) }}</MtButton>
         </div>
 
         <div v-if="loading" class="meta-group-delivery__empty">{{ automationLabel('delivery.loading', isZh) }}</div>
@@ -55,6 +55,7 @@ import { useLocale } from '../../composables/useLocale'
 import type { DingTalkGroupDelivery } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import { automationLabel, automationStatusLabel } from '../utils/meta-automation-labels'
+import { MtButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -188,15 +189,9 @@ watch(
   background: #fff;
 }
 
-.meta-group-delivery__btn {
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 6px 14px;
-  background: #fff;
-  color: #0f172a;
-  font-size: 13px;
-  cursor: pointer;
-}
+/* .meta-group-delivery__btn: the Refresh control is now <MtButton> (ghost, token-styled — it was a neutral
+   bordered-white secondary action). Its bespoke hex CSS was removed to avoid double-styling the MtButton
+   root; class + data-action kept for selector stability. The header close-× glyph stays bespoke. */
 
 .meta-group-delivery__empty {
   padding: 10px 12px;

--- a/apps/web/tests/meta-group-delivery-viewer-migration.spec.ts
+++ b/apps/web/tests/meta-group-delivery-viewer-migration.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaAutomationGroupDeliveryViewer from '../src/multitable/components/MetaAutomationGroupDeliveryViewer.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaAutomationGroupDeliveryViewer's toolbar Refresh control was migrated from a bespoke <button>
+// to the shared MtButton primitive (ghost — it was a neutral bordered-white secondary action). Its class is
+// unique, so the bespoke hex CSS was removed. Behavior-preservation proof: it stays a native <button>; the
+// :disabled binding survives; clicking it still runs loadData → props.client.getAutomationDingTalkGroupDeliveries.
+// The header close-× glyph stays bespoke.
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+let app: App | null = null; let container: HTMLDivElement | null = null
+afterEach(() => {
+  app?.unmount(); container?.remove(); app = null; container = null
+  expect(document.querySelectorAll('.meta-group-delivery__overlay').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(client: Record<string, unknown>) {
+  container = document.createElement('div'); document.body.appendChild(container)
+  app = createApp({ render: () => h(MetaAutomationGroupDeliveryViewer, { visible: true, sheetId: 's1', ruleId: 'r1', client }) })
+  app.mount(container)
+}
+const refreshBtn = () => container!.querySelector('[data-action="refresh"]') as HTMLButtonElement
+
+describe('MetaAutomationGroupDeliveryViewer — MtButton migration (UI-P2-1c)', () => {
+  it('renders Refresh as a native <button> (MtButton)', async () => {
+    mount({ getAutomationDingTalkGroupDeliveries: vi.fn().mockResolvedValue([]) })
+    await flush()
+    expect(refreshBtn().tagName).toBe('BUTTON') // keyboard-operable, not a bare div
+  })
+
+  it('clicking Refresh re-runs loadData → client.getAutomationDingTalkGroupDeliveries (@click unchanged)', async () => {
+    const get = vi.fn().mockResolvedValue([])
+    mount({ getAutomationDingTalkGroupDeliveries: get })
+    await flush() // the on-show watch already called it once
+    get.mockClear()
+    refreshBtn().click()
+    await flush()
+    expect(get).toHaveBeenCalledTimes(1) // the click, post-clear
+    expect(get).toHaveBeenCalledWith('s1', 'r1', 50)
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, unique-class; corrects a component I skipped at the 16-count). Refresh → MtButton ghost (was neutral bordered #cbd5e1); bespoke hex removed. `@click=loadData`/`:disabled`/data-action byte-identical; close-× glyph stays bespoke. Mount test (2/2, client-stubbed): native button + click-re-invokes-getAutomationDingTalkGroupDeliveries('s1','r1',50). vue-tsc clean; no new hex; existing delivery-viewers-i18n (4) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)