### PR TITLE
feat(web): multitable UI P2-1c — migrate MetaAutomationPersonDeliveryViewer Refresh to MtButton

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
@@ -14,7 +14,7 @@
             <option value="failed">{{ automationStatusLabel('failed', isZh) }}</option>
             <option value="skipped">{{ automationLabel('delivery.statusSkippedUnbound', isZh) }}</option>
           </select>
-          <button class="meta-person-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">{{ automationLabel('log.refresh', isZh) }}</button>
+          <MtButton class="meta-person-delivery__btn" data-action="refresh" :disabled="loading" @click="loadData">{{ automationLabel('log.refresh', isZh) }}</MtButton>
         </div>
 
         <div v-if="loading" class="meta-person-delivery__empty">{{ automationLabel('delivery.loading', isZh) }}</div>
@@ -65,6 +65,7 @@ import { useLocale } from '../../composables/useLocale'
 import type { DingTalkPersonDelivery } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import { automationLabel, automationStatusLabel } from '../utils/meta-automation-labels'
+import { MtButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -222,15 +223,9 @@ watch(
   background: #fff;
 }
 
-.meta-person-delivery__btn {
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 6px 14px;
-  background: #fff;
-  color: #0f172a;
-  font-size: 13px;
-  cursor: pointer;
-}
+/* .meta-person-delivery__btn: the Refresh control is now <MtButton> (ghost, token-styled — it was a neutral
+   bordered-white secondary action). Bespoke hex CSS removed to avoid double-styling the MtButton root; class
+   + data-action kept for selector stability. The header close-× glyph stays bespoke. */
 
 .meta-person-delivery__empty {
   padding: 10px 12px;

--- a/apps/web/tests/meta-person-delivery-viewer-migration.spec.ts
+++ b/apps/web/tests/meta-person-delivery-viewer-migration.spec.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaAutomationPersonDeliveryViewer from '../src/multitable/components/MetaAutomationPersonDeliveryViewer.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+// UI-P2-1c: MetaAutomationPersonDeliveryViewer's toolbar Refresh control was migrated from a bespoke <button>
+// to the shared MtButton primitive (ghost — neutral bordered-white secondary). Unique class → bespoke hex CSS
+// removed. Behavior-preservation proof: native <button>; :disabled survives; clicking still runs loadData →
+// props.client.getAutomationDingTalkPersonDeliveries. The header close-× glyph stays bespoke.
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+let app: App | null = null; let container: HTMLDivElement | null = null
+afterEach(() => {
+  app?.unmount(); container?.remove(); app = null; container = null
+  expect(document.querySelectorAll('.meta-person-delivery__overlay').length).toBe(0) // residue guard
+  useLocale().setLocale('en')
+})
+
+function mount(client: Record<string, unknown>) {
+  container = document.createElement('div'); document.body.appendChild(container)
+  app = createApp({ render: () => h(MetaAutomationPersonDeliveryViewer, { visible: true, sheetId: 's1', ruleId: 'r1', client }) })
+  app.mount(container)
+}
+const refreshBtn = () => container!.querySelector('[data-action="refresh"]') as HTMLButtonElement
+
+describe('MetaAutomationPersonDeliveryViewer — MtButton migration (UI-P2-1c)', () => {
+  it('renders Refresh as a native <button> (MtButton)', async () => {
+    mount({ getAutomationDingTalkPersonDeliveries: vi.fn().mockResolvedValue([]) })
+    await flush()
+    expect(refreshBtn().tagName).toBe('BUTTON') // keyboard-operable
+  })
+
+  it('clicking Refresh re-runs loadData → client.getAutomationDingTalkPersonDeliveries (@click unchanged)', async () => {
+    const get = vi.fn().mockResolvedValue([])
+    mount({ getAutomationDingTalkPersonDeliveries: get })
+    await flush()
+    get.mockClear()
+    refreshBtn().click()
+    await flush()
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(get).toHaveBeenCalledWith('s1', 'r1', 50)
+  })
+})


### PR DESCRIPTION
Lane A migration (presentation-only, unique-class; mirrors Group viewer #3869). Refresh → MtButton ghost; bespoke hex removed; `@click=loadData`/`:disabled`/data-action byte-identical; close-× stays bespoke. Mount test (2/2, client-stubbed): native button + click-re-invokes-getAutomationDingTalkPersonDeliveries. vue-tsc clean; no new hex; existing delivery-viewers-i18n (4) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)