### PR TITLE
refactor(multitable): R5c — ResetConfirmDialog strings → typed label modules (strict-zero closeout, final)

### DIFF
--- a/apps/web/src/multitable/components/ResetConfirmDialog.vue
+++ b/apps/web/src/multitable/components/ResetConfirmDialog.vue
@@ -2,23 +2,21 @@
   <!-- Entry: rendered ONLY when the flag-derived capability is on (true flag-off hidden — the FE half of
        "inert until enabled"; pitResetEnabled already encodes canManageSheetAccess). Destructive styling, distinct
        from any Revert affordance. -->
-  <button v-if="pitResetEnabled" class="reset-entry" data-test="reset-entry" @click="openDialog">
-    Reset to {{ asOf }}…
-  </button>
+  <button v-if="pitResetEnabled" class="reset-entry" data-test="reset-entry" @click="openDialog">{{ ' ' }}{{ resetConfirmEntryLabel(asOf, isZh) }}{{ ' ' }}</button>
 
   <teleport to="body">
     <div v-if="open" class="reset-confirm-overlay" data-test="reset-confirm" @click.self="onCancel">
-      <div class="reset-confirm-modal reset-confirm-modal--destructive" role="dialog" aria-label="Reset sheet to a point in time">
+      <div class="reset-confirm-modal reset-confirm-modal--destructive" role="dialog" :aria-label="l('record.resetConfirmDialogAria')">
         <div class="reset-confirm__header">
-          <h3 class="reset-confirm__title">Reset sheet to {{ asOf }}</h3>
-          <button class="reset-confirm__close" aria-label="Cancel" @click="onCancel">&times;</button>
+          <h3 class="reset-confirm__title">{{ resetConfirmTitle(asOf, isZh) }}</h3>
+          <button class="reset-confirm__close" :aria-label="l('record.resetConfirmCancelAria')" @click="onCancel">&times;</button>
         </div>
         <div class="reset-confirm__body">
-          <p v-if="loading" class="reset-confirm__hint" data-test="reset-confirm-loading">Loading preview…</p>
+          <p v-if="loading" class="reset-confirm__hint" data-test="reset-confirm-loading">{{ l('record.resetConfirmLoading') }}</p>
 
           <p v-else-if="result" class="reset-confirm__hint" data-test="reset-confirm-result">
-            {{ deletedCount }} record(s) moved to the recycle bin · {{ result.revertedCount ?? 0 }} reverted to {{ asOf }}.
-            <a href="#trash" class="reset-confirm__trash-link" data-test="reset-confirm-trash-link">View in Trash</a>
+            {{ resetConfirmResultSummary(deletedCount, result.revertedCount ?? 0, asOf, isZh) }}
+            <a href="#trash" class="reset-confirm__trash-link" data-test="reset-confirm-trash-link">{{ l('record.resetConfirmViewInTrash') }}</a>
           </p>
 
           <p v-else-if="error" class="reset-confirm__hint reset-confirm__hint--warn" role="alert" data-test="reset-confirm-error">{{ errorCopy }}</p>
@@ -26,35 +24,22 @@
           <template v-else-if="preview">
             <!-- Non-destructive path: nothing created after T → plain Revert-equivalent, no typed confirm. -->
             <template v-if="deleteCount === 0">
-              <p class="reset-confirm__hint" data-test="reset-confirm-revert-equiv">
-                Nothing was created after {{ asOf }}. This reverts {{ revertCount }} record(s) to their state at
-                {{ asOf }} — non-destructive, the same as <strong>Revert</strong>.
-              </p>
-              <button class="reset-confirm__btn" data-test="reset-confirm-btn" :disabled="!hasIdentity" @click="onConfirm">
-                Revert to {{ asOf }}
-              </button>
+              <p class="reset-confirm__hint" data-test="reset-confirm-revert-equiv">{{ ' ' }}{{ resetConfirmRevertEquivIntro(asOf, revertCount, isZh) }} <strong>{{ l('record.resetConfirmRevertWord') }}</strong>.{{ ' ' }}</p>
+              <button class="reset-confirm__btn" data-test="reset-confirm-btn" :disabled="!hasIdentity" @click="onConfirm">{{ ' ' }}{{ resetConfirmRevertButtonLabel(asOf, isZh) }}</button>
             </template>
 
             <!-- Destructive path: typed two-step confirm (type `reset` AND acknowledge the deleted-count). -->
             <template v-else>
-              <p class="reset-confirm__warn" role="alert" data-test="reset-confirm-warn">
-                <strong>Reset</strong> reverts every record to its state at {{ asOf }}
-                <strong>and moves the {{ deleteCount }} record(s) created after {{ asOf }} to the recycle bin</strong>
-                — recoverable from Trash, but this is <strong>not</strong> a normal restore.
-                Need to keep records created after {{ asOf }}? Use <strong>Revert</strong> instead — it changes nothing destructively.
-              </p>
+              <p class="reset-confirm__warn" role="alert" data-test="reset-confirm-warn"><strong>{{ l('record.resetConfirmWarnResetWord') }}</strong> {{ resetConfirmWarnRevertsAt(asOf, isZh) }} <strong>{{ resetConfirmWarnDeleteClause(deleteCount, asOf, isZh) }}</strong> {{ l('record.resetConfirmWarnBeforeNot') }} <strong>{{ l('record.resetConfirmWarnNotWord') }}</strong> {{ resetConfirmWarnAfterNot(asOf, isZh) }} <strong>{{ l('record.resetConfirmRevertWord') }}</strong> {{ l('record.resetConfirmWarnInstead') }}{{ ' ' }}</p>
               <label class="reset-confirm__ack" data-test="reset-confirm-ack">
                 <input type="checkbox" v-model="ackCount" />
-                I understand {{ deleteCount }} record(s) will be moved to the recycle bin.
+                {{ resetConfirmAckLabel(deleteCount, isZh) }}{{ ' ' }}
               </label>
-              <label class="reset-confirm__type">
-                Type <code>reset</code> to confirm:
-                <input data-test="reset-confirm-type" v-model="typed" aria-label="type reset to confirm" />
+              <label class="reset-confirm__type">{{ ' ' }}{{ l('record.resetConfirmTypePrefix') }} <code>reset</code> {{ l('record.resetConfirmTypeSuffix') }}
+                <input data-test="reset-confirm-type" v-model="typed" :aria-label="l('record.resetConfirmTypeAria')" />
               </label>
               <button class="reset-confirm__btn reset-confirm__btn--destructive" data-test="reset-confirm-btn"
-                      :disabled="!canConfirm" @click="onConfirm">
-                Reset — move {{ deleteCount }} to recycle bin
-              </button>
+                      :disabled="!canConfirm" @click="onConfirm">{{ ' ' }}{{ resetConfirmDestructiveButtonLabel(deleteCount, isZh) }}{{ ' ' }}</button>
             </template>
           </template>
         </div>
@@ -67,6 +52,13 @@
 import { computed, ref } from 'vue'
 
 import type { ResetPreview, ResetResult } from '../api/client'
+import { useLocale } from '../../composables/useLocale'
+import {
+  recordLabel, resetConfirmEntryLabel, resetConfirmTitle, resetConfirmResultSummary,
+  resetConfirmRevertEquivIntro, resetConfirmRevertButtonLabel, resetConfirmDestructiveButtonLabel,
+  resetConfirmAckLabel, resetConfirmWarnRevertsAt, resetConfirmWarnDeleteClause, resetConfirmWarnAfterNot,
+  type MetaRecordLabelKey,
+} from '../utils/meta-record-labels'
 
 const props = defineProps<{
   /** flag-derived capability (MULTITABLE_ENABLE_PIT_RESET on AND canManageSheetAccess). Off/absent ⇒ entry hidden. */
@@ -78,6 +70,9 @@ const props = defineProps<{
   resetExecute: (asOf: string, previewIdentity: string) => Promise<ResetResult>
   onDone?: () => void
 }>()
+
+const { isZh } = useLocale()
+const l = (key: MetaRecordLabelKey): string => recordLabel(key, isZh.value)
 
 const open = ref(false)
 const loading = ref(false)
@@ -96,13 +91,11 @@ const canConfirm = computed(() => hasIdentity.value && typed.value.trim() === 'r
 
 const errorCopy = computed(() => {
   const s = error.value?.status, c = error.value?.code
-  if (s === 403) return c === 'RESET_DISABLED' ? 'Reset is not enabled here.' : 'You do not have permission to reset this sheet.'
-  if (s === 409) return c === 'RESET_BLOCKED'
-    ? 'A target record is locked or denied — nothing was changed.'
-    : 'The sheet changed since the preview — please re-preview and try again.'
-  if (s === 413) return 'This sheet has too many records for a one-shot reset.'
-  if (s === 400) return 'Type "reset" to confirm.'
-  return 'Reset could not be completed. Please re-preview and try again.'
+  if (s === 403) return c === 'RESET_DISABLED' ? l('record.resetConfirmErrorDisabled') : l('record.resetConfirmErrorForbidden')
+  if (s === 409) return c === 'RESET_BLOCKED' ? l('record.resetConfirmErrorBlocked') : l('record.resetConfirmErrorStale')
+  if (s === 413) return l('record.resetConfirmErrorTooLarge')
+  if (s === 400) return l('record.resetConfirmErrorTypeMismatch')
+  return l('record.resetConfirmErrorGeneric')
 })
 
 const asErr = (e: unknown): { status?: number; code?: string } => ({

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -97,6 +97,15 @@ export type MetaRecordLabelKey =
   | 'record.resetPickerManualSummary' | 'record.resetPickerManualLabel' | 'record.resetPickerFutureWarn'
   | 'record.resetPickerTargetPrefix' | 'record.resetPickerTargetSuffix' | 'record.resetPickerFromBatch'
   | 'record.resetPickerErrorLoad' | 'record.resetPickerSystemActor' | 'record.resetPickerDefaultAction'
+  // --- T8-2 Reset UI confirm dialog (R5c strict-zero closeout, final microslice of this line) ---
+  | 'record.resetConfirmDialogAria' | 'record.resetConfirmCancelAria' | 'record.resetConfirmLoading'
+  | 'record.resetConfirmViewInTrash'
+  | 'record.resetConfirmErrorDisabled' | 'record.resetConfirmErrorForbidden' | 'record.resetConfirmErrorBlocked'
+  | 'record.resetConfirmErrorStale' | 'record.resetConfirmErrorTooLarge' | 'record.resetConfirmErrorTypeMismatch'
+  | 'record.resetConfirmErrorGeneric'
+  | 'record.resetConfirmWarnResetWord' | 'record.resetConfirmWarnNotWord' | 'record.resetConfirmRevertWord'
+  | 'record.resetConfirmWarnBeforeNot' | 'record.resetConfirmWarnInstead'
+  | 'record.resetConfirmTypePrefix' | 'record.resetConfirmTypeSuffix' | 'record.resetConfirmTypeAria'
 
 const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }> = {
   'notification.bell': { en: 'Notifications', zh: '通知' },
@@ -256,6 +265,35 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.resetPickerErrorLoad': { en: 'Failed to load history points', zh: '加载历史点失败' },
   'record.resetPickerSystemActor': { en: 'System', zh: '系统' },
   'record.resetPickerDefaultAction': { en: 'update', zh: '更新' },
+
+  // T8-2 Reset UI confirm dialog (ResetConfirmDialog.vue, R5c strict-zero closeout — the final microslice of
+  // this line; ResetToPointPicker/R5b was the other post-closure component, now landed). Static labels only;
+  // the asOf/count-interpolated strings live in the helper functions below.
+  'record.resetConfirmDialogAria': { en: 'Reset sheet to a point in time', zh: '将表重置到某个时间点' },
+  'record.resetConfirmCancelAria': { en: 'Cancel', zh: '取消' },
+  'record.resetConfirmLoading': { en: 'Loading preview…', zh: '正在加载预览…' },
+  'record.resetConfirmViewInTrash': { en: 'View in Trash', zh: '在回收站中查看' },
+  'record.resetConfirmErrorDisabled': { en: 'Reset is not enabled here.', zh: '此处未启用重置。' },
+  'record.resetConfirmErrorForbidden': { en: 'You do not have permission to reset this sheet.', zh: '你没有权限重置此表。' },
+  'record.resetConfirmErrorBlocked': { en: 'A target record is locked or denied — nothing was changed.', zh: '某条目标记录被锁定或拒绝 — 未做任何更改。' },
+  'record.resetConfirmErrorStale': { en: 'The sheet changed since the preview — please re-preview and try again.', zh: '表在预览之后已发生变化 — 请重新预览后再试。' },
+  'record.resetConfirmErrorTooLarge': { en: 'This sheet has too many records for a one-shot reset.', zh: '此表记录过多，无法一次性重置。' },
+  // The 400 (type-mismatch) response fires when the operator's typed confirm text didn't match the server's
+  // expected literal. `reset` is the same server-authoritative token as the type-to-confirm input below — kept
+  // untranslated in both locales.
+  'record.resetConfirmErrorTypeMismatch': { en: 'Type "reset" to confirm.', zh: '请输入 "reset" 以确认。' },
+  'record.resetConfirmErrorGeneric': { en: 'Reset could not be completed. Please re-preview and try again.', zh: '重置未能完成。请重新预览后再试。' },
+  // The three inline-bold words in the destructive warning paragraph. Word-for-word bold placement doesn't
+  // map 1:1 to Chinese, so the zh values are chosen so the concatenated sentence (built from these plus the
+  // resetConfirmWarn* helpers below, in the same fixed template slots) still reads naturally.
+  'record.resetConfirmWarnResetWord': { en: 'Reset', zh: '重置' },
+  'record.resetConfirmWarnNotWord': { en: 'not', zh: '并不是' },
+  'record.resetConfirmRevertWord': { en: 'Revert', zh: '回退' },
+  'record.resetConfirmWarnBeforeNot': { en: '— recoverable from Trash, but this is', zh: '——可从回收站中恢复，但这' },
+  'record.resetConfirmWarnInstead': { en: 'instead — it changes nothing destructively.', zh: '代替 — 它不会进行任何破坏性更改。' },
+  'record.resetConfirmTypePrefix': { en: 'Type', zh: '输入' },
+  'record.resetConfirmTypeSuffix': { en: 'to confirm:', zh: '以确认：' },
+  'record.resetConfirmTypeAria': { en: 'type reset to confirm', zh: '输入 reset 以确认' },
 }
 
 export function recordLabel(key: MetaRecordLabelKey, isZh: boolean): string {
@@ -328,4 +366,72 @@ export function configRestoreTypedConfirm(confirmToken: string, isZh: boolean): 
 export function resetPickerRecordCount(count: number, isZh: boolean): string {
   if (isZh) return `${count} 条记录`
   return count === 1 ? '1 record' : `${count} records`
+}
+
+// --- ResetConfirmDialog.vue interpolation helpers (R5c) ---
+// `asOf` is the wire point-in-time value (display + API `asOf`) and record counts are wire summary
+// numbers — both always interpolated raw, never translated. Each helper below reconstructs one
+// EN sentence byte-for-byte (verified against a before/after DOM snapshot diff) plus its zh counterpart.
+
+// resetConfirmEntryLabel: the destructive entry button ("Reset to <T>…").
+export function resetConfirmEntryLabel(asOf: string, isZh: boolean): string {
+  return isZh ? `重置到 ${asOf}…` : `Reset to ${asOf}…`
+}
+
+// resetConfirmTitle: the dialog header ("Reset sheet to <T>").
+export function resetConfirmTitle(asOf: string, isZh: boolean): string {
+  return isZh ? `将表重置到 ${asOf}` : `Reset sheet to ${asOf}`
+}
+
+// resetConfirmResultSummary: the post-execute result line (deleted + reverted counts + asOf).
+export function resetConfirmResultSummary(deletedCount: number, revertedCount: number, asOf: string, isZh: boolean): string {
+  return isZh
+    ? `${deletedCount} 条记录已移至回收站 · ${revertedCount} 条记录已回退到 ${asOf}。`
+    : `${deletedCount} record(s) moved to the recycle bin · ${revertedCount} reverted to ${asOf}.`
+}
+
+// resetConfirmRevertEquivIntro: the non-destructive (deleteCount===0) explanatory sentence, up to
+// (not including) the bolded "Revert" word that follows it in the template.
+export function resetConfirmRevertEquivIntro(asOf: string, revertCount: number, isZh: boolean): string {
+  return isZh
+    ? `${asOf} 之后没有新建任何记录。这会将 ${revertCount} 条记录回退到它们在 ${asOf} 时的状态 — 非破坏性操作，等同于`
+    : `Nothing was created after ${asOf}. This reverts ${revertCount} record(s) to their state at ${asOf} — non-destructive, the same as`
+}
+
+// resetConfirmRevertButtonLabel: the non-destructive confirm button ("Revert to <T>").
+export function resetConfirmRevertButtonLabel(asOf: string, isZh: boolean): string {
+  return isZh ? `回退到 ${asOf}` : `Revert to ${asOf}`
+}
+
+// resetConfirmDestructiveButtonLabel: the destructive confirm button ("Reset — move N to recycle bin").
+export function resetConfirmDestructiveButtonLabel(deleteCount: number, isZh: boolean): string {
+  return isZh ? `重置 — 将 ${deleteCount} 条记录移至回收站` : `Reset — move ${deleteCount} to recycle bin`
+}
+
+// resetConfirmAckLabel: the destructive-path acknowledgement checkbox copy.
+export function resetConfirmAckLabel(deleteCount: number, isZh: boolean): string {
+  return isZh
+    ? `我知道 ${deleteCount} 条记录将被移至回收站。`
+    : `I understand ${deleteCount} record(s) will be moved to the recycle bin.`
+}
+
+// resetConfirmWarnRevertsAt: destructive-warning clause 1, between the bolded "Reset" and the bolded
+// delete-clause below.
+export function resetConfirmWarnRevertsAt(asOf: string, isZh: boolean): string {
+  return isZh ? `会将每条记录回退到其在 ${asOf} 时的状态` : `reverts every record to its state at ${asOf}`
+}
+
+// resetConfirmWarnDeleteClause: the bolded delete clause inside the destructive warning paragraph.
+export function resetConfirmWarnDeleteClause(deleteCount: number, asOf: string, isZh: boolean): string {
+  return isZh
+    ? `并将 ${asOf} 之后新建的 ${deleteCount} 条记录移至回收站`
+    : `and moves the ${deleteCount} record(s) created after ${asOf} to the recycle bin`
+}
+
+// resetConfirmWarnAfterNot: destructive-warning clause between the bolded "not" and the bolded "Revert"
+// that follows (covers the asOf-embedded "Need to keep records created after <T>?" sub-clause).
+export function resetConfirmWarnAfterNot(asOf: string, isZh: boolean): string {
+  return isZh
+    ? `一次普通恢复。如果需要保留 ${asOf} 之后新建的记录，请使用`
+    : `a normal restore. Need to keep records created after ${asOf}? Use`
 }

--- a/apps/web/tests/multitable-reset-confirm-dialog.spec.ts
+++ b/apps/web/tests/multitable-reset-confirm-dialog.spec.ts
@@ -10,6 +10,7 @@ import { createApp, nextTick } from 'vue'
 
 import ResetConfirmDialog from '../src/multitable/components/ResetConfirmDialog.vue'
 import { MultitableApiClient, type ResetPreview, type ResetResult } from '../src/multitable/api/client'
+import { useLocale } from '../src/composables/useLocale'
 
 const previewOf = (over: Partial<ResetPreview>): ResetPreview => ({
   asOf: '2026-06-20T00:00:00Z', strategy: 'reset',
@@ -34,7 +35,7 @@ const waitUntil = async (pred: () => boolean, tries = 100): Promise<void> => {
 }
 const setInput = (sel: string, val: string) => { const el = q(sel) as HTMLInputElement; el.value = val; el.dispatchEvent(new Event('input')) }
 const setCheck = (sel: string, on: boolean) => { const el = q(sel) as HTMLInputElement; el.checked = on; el.dispatchEvent(new Event('change')) }
-afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
+afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = ''; useLocale().setLocale('en') })
 
 describe('ResetConfirmDialog — T8-2 Reset UI', () => {
   it('(a) entry is HIDDEN when pitResetEnabled is false', async () => {
@@ -102,5 +103,74 @@ describe('ResetConfirmDialog — T8-2 Reset UI', () => {
     await waitUntil(() => !!q('[data-test="reset-confirm-revert-equiv"]'))
     expect(q('[data-test="reset-confirm-type"]')).toBeFalsy() // no destructive typed gate
     expect(q('[data-test="reset-confirm-warn"]')).toBeFalsy()
+  })
+
+  it('(f) R5c i18n: zh locale renders the typed zh labels for the entry/dialog chrome + destructive path (strings live in meta-record-labels, not inline)', async () => {
+    useLocale().setLocale('zh-CN')
+    mount({}); await nextTick()
+    expect(q('[data-test="reset-entry"]')?.textContent?.trim()).toBe('重置到 2026-06-20T00:00:00Z…')
+    ;(q('[data-test="reset-entry"]') as HTMLButtonElement).click()
+    await waitUntil(() => !!q('[data-test="reset-confirm-warn"]'))
+    expect(q('.reset-confirm__title')?.textContent).toBe('将表重置到 2026-06-20T00:00:00Z')
+    expect(q('.reset-confirm-modal')?.getAttribute('aria-label')).toBe('将表重置到某个时间点')
+    expect(q('.reset-confirm__close')?.getAttribute('aria-label')).toBe('取消')
+    // destructive warn: 3 bolded words (重置/并不是/回退) + the deleteCount-embedded clause, all typed
+    const warn = q('[data-test="reset-confirm-warn"]')!.textContent ?? ''
+    expect(warn).toContain('重置')
+    expect(warn).toContain('并将 2026-06-20T00:00:00Z 之后新建的 3 条记录移至回收站')
+    expect(warn).toContain('并不是')
+    expect(warn).toContain('回退')
+    // ack + typed-confirm + destructive button
+    expect(q('[data-test="reset-confirm-ack"]')?.textContent?.trim()).toBe('我知道 3 条记录将被移至回收站。')
+    const typeLabel = q('.reset-confirm__type')!.textContent ?? ''
+    expect(typeLabel).toContain('输入')
+    expect(typeLabel).toContain('reset') // server-authoritative confirm token — never translated
+    expect(typeLabel).toContain('以确认：')
+    expect(q('[data-test="reset-confirm-type"]')?.getAttribute('aria-label')).toBe('输入 reset 以确认')
+    expect(q('[data-test="reset-confirm-btn"]')?.textContent?.trim()).toBe('重置 — 将 3 条记录移至回收站')
+  })
+
+  it('(g) R5c i18n: zh locale renders the typed zh labels for the revert-equivalent + result + error paths', async () => {
+    useLocale().setLocale('zh-CN')
+    // revert-equivalent (deleteCount===0)
+    mount({ resetPreview: vi.fn(async () => previewOf({ summary: { visibleRevertCount: 1, deleteCount: 0 }, deleteRecordIds: [] })) })
+    await nextTick()
+    ;(q('[data-test="reset-entry"]') as HTMLButtonElement).click()
+    await waitUntil(() => !!q('[data-test="reset-confirm-revert-equiv"]'))
+    const revertEquiv = q('[data-test="reset-confirm-revert-equiv"]')!.textContent ?? ''
+    expect(revertEquiv).toContain('2026-06-20T00:00:00Z 之后没有新建任何记录')
+    expect(revertEquiv).toContain('回退')
+    expect(q('[data-test="reset-confirm-btn"]')?.textContent?.trim()).toBe('回退到 2026-06-20T00:00:00Z')
+    mounted.pop()!.unmount(); document.body.innerHTML = ''
+
+    // result (post-execute)
+    mount({}); await nextTick()
+    ;(q('[data-test="reset-entry"]') as HTMLButtonElement).click()
+    await waitUntil(() => !!q('[data-test="reset-confirm-type"]'))
+    setInput('[data-test="reset-confirm-type"]', 'reset'); setCheck('[data-test="reset-confirm-ack"] input', true); await flush()
+    ;(q('[data-test="reset-confirm-btn"]') as HTMLButtonElement).click()
+    await waitUntil(() => !!q('[data-test="reset-confirm-result"]'))
+    const resultText = q('[data-test="reset-confirm-result"]')!.textContent ?? ''
+    expect(resultText).toContain('3 条记录已移至回收站')
+    expect(resultText).toContain('2 条记录已回退到 2026-06-20T00:00:00Z')
+    expect(q('[data-test="reset-confirm-trash-link"]')?.textContent).toBe('在回收站中查看')
+    mounted.pop()!.unmount(); document.body.innerHTML = ''
+
+    // error branches: one per status/code combo, including the 400 typed-confirm-mismatch (token stays raw)
+    const errCase = async (status: number, code: string | undefined, expected: string) => {
+      mount({ resetPreview: vi.fn(async () => { const e = new Error('boom') as Error & { status?: number; code?: string }; e.status = status; e.code = code; throw e }) })
+      await nextTick()
+      ;(q('[data-test="reset-entry"]') as HTMLButtonElement).click()
+      await waitUntil(() => !!q('[data-test="reset-confirm-error"]'))
+      expect(q('[data-test="reset-confirm-error"]')?.textContent).toBe(expected)
+      mounted.pop()!.unmount(); document.body.innerHTML = ''
+    }
+    await errCase(403, 'RESET_DISABLED', '此处未启用重置。')
+    await errCase(403, undefined, '你没有权限重置此表。')
+    await errCase(409, 'RESET_BLOCKED', '某条目标记录被锁定或拒绝 — 未做任何更改。')
+    await errCase(409, undefined, '表在预览之后已发生变化 — 请重新预览后再试。')
+    await errCase(413, undefined, '此表记录过多，无法一次性重置。')
+    await errCase(400, undefined, '请输入 "reset" 以确认。') // 'reset' literal preserved even in zh
+    await errCase(999, undefined, '重置未能完成。请重新预览后再试。')
   })
 })

--- a/docs/development/multitable-global-history-r5-3749-absorption-round-record-20260707.md
+++ b/docs/development/multitable-global-history-r5-3749-absorption-round-record-20260707.md
@@ -34,3 +34,11 @@
 ## 4. R5b 追记(2026-07-07)
 
 §2 中 NIT-a(ResetToPointPicker 英文-only)原判「记录不修」,复判为**纪律归位**:strict-zero 收线后的规则是未来 UI 字符串一律进 typed label 模块,该组件生于收线之后,属规则内新债而非既有债扩展。R5b 微切片将其全部可见字符串收编 `meta-record-labels.ts`(`record.resetPicker*` 命名空间 + `resetPickerRecordCount` 插值 helper)并补 zh;EN 渲染逐字节保形(7 分支 before/after DOM diff 为空),flag(PIT_RESET)休眠零线上风险。
+
+## 5. R5c 追记(2026-07-07)— 本线 strict-zero 穷尽的最后一件
+
+`ResetToPointPicker.vue` 的姊妹组件 `ResetConfirmDialog.vue`(同为 T8-2、同为收线后新生)此前未被 R5b 覆盖。R5c 微切片将其全部硬编码英文字符串(入口按钮 · 对话框 aria-label/标题/关闭按钮 · loading/结果/View-in-Trash · 7 条 `errorCopy` 错误分支 · 非破坏性 revert-等价路径 · 破坏性警告段落含 3 处内联加粗词 · ack 勾选文案 · 输入 `reset` 确认标签/aria-label · 破坏性确认按钮)收编进 `meta-record-labels.ts`:19 个 `record.resetConfirm*` 静态 key + 10 个 asOf/count 插值 helper(`resetConfirmEntryLabel`/`resetConfirmTitle`/`resetConfirmResultSummary`/`resetConfirmRevertEquivIntro`/`resetConfirmRevertButtonLabel`/`resetConfirmDestructiveButtonLabel`/`resetConfirmAckLabel`/`resetConfirmWarnRevertsAt`/`resetConfirmWarnDeleteClause`/`resetConfirmWarnAfterNot`),并补 zh。服务端权威确认字面 `reset`(输入框 + 400 错误文案内嵌)两侧均保持不译。
+
+EN 渲染逐字节保形:改前(现 main 状态)/改后各 17 分支(entry/dialog-chrome/destructive-warn/ack/type/btn/loading/result/revert-equiv×2/7 条 error)DOM 快照 diff 为空(`outerHTML`,归一化 `data-v-*` 编译期哈希后比对)。既有 6 条 spec 零改动全绿 + 补 2 条 zh golden(entry/chrome/destructive 全链路 + revert-equiv/result/7 错误分支)。`vue-tsc -b` 干净;multitable-web-guard 全矩阵本地跑 49 files / 515 tests 绿(511 R5 基线 + R5b 已并入的 2 + 本轮新增 2)。
+
+**strict-zero 穷尽声明:** 对 reset/restore/history/tombstone 相关全部组件(`HistoryBatchChangesList.vue`/`HistoryCenterModal.vue`/`MetaConfigHistoryModal.vue`/`RestoreBatchDialog.vue`/`RestorePreviewDialog.vue`/`TrashModal.vue`/`ResetToPointPicker.vue`/`ResetConfirmDialog.vue`)做静态扫描(aria-label 计入、data-test 不计入),ResetConfirmDialog.vue 收编前为本线最后一处残留;收编后全线**零**残留硬编码用户可见英文串(其余组件此前已各自收口于 `t()`/`l()`/`recordLabel`)。本线(reset/restore/history/tombstone)strict-zero 收编至此穷尽。


### PR DESCRIPTION
## Summary

`ResetConfirmDialog.vue` is `ResetToPointPicker.vue`'s (R5b, #3867, merged) sibling in the T8-2 Reset UI — both born after the multitable i18n TRUE STRICT-ZERO line closed, both shipped all-English inline strings. This is the last microslice of that line's strict-zero closeout.

- Route every user-visible string through `meta-record-labels.ts`: **19 new `record.resetConfirm*` static keys** + **10 asOf/count interpolation helpers** (`resetConfirmEntryLabel`/`Title`/`ResultSummary`/`RevertEquivIntro`/`RevertButtonLabel`/`DestructiveButtonLabel`/`AckLabel`/`WarnRevertsAt`/`WarnDeleteClause`/`WarnAfterNot`).
- Coverage: entry button · dialog chrome (aria-label / title / close button aria-label) · loading · result summary + "View in Trash" · all 7 `errorCopy` branches · non-destructive revert-equivalent path · destructive warning paragraph (3 inline-bold words: Reset/not/Revert) · ack checkbox copy · type-`reset`-to-confirm label + its input aria-label · destructive confirm button.
- The server-authoritative confirm token **`reset` stays untranslated** in both locales (the `<code>reset</code>` in the type-to-confirm label, the input's value comparison, and the embedded literal inside the 400 error copy) — it's what the server literally checks (`confirm:'reset'`), never UI copy.
- Consumption follows the established `useLocale().isZh` + `l()` pattern from the neighboring `ResetToPointPicker`/`MetaConfigHistoryModal` consumers. No new module, no new locale mechanism.

## Byte-for-byte EN preservation

Built a throwaway before/after DOM-snapshot harness (mounted the pre-edit and post-edit component across 17 branches — entry/dialog-chrome, destructive-warn, ack, type-label, destructive-btn, loading, result, revert-equiv ×2, and all 7 error-status/code combos — capturing `outerHTML` per `data-test` node). Diff is **empty** after normalizing the per-compile `data-v-*` scoped-style hash (expected to differ; unrelated to shape). The `{{ ' ' }}` sentinel mustaches guard leading/trailing spaces that Vue's whitespace-condense pass would otherwise strip from whitespace-only first/last text nodes once a multi-word phrase collapses into a single interpolation — same documented pattern as R5b, explained in the component's template header comment.

## Tests

- 6 existing EN specs in `multitable-reset-confirm-dialog.spec.ts` **untouched, all green** (zero assertion changes).
- +2 new zh golden tests:
  - **(f)** entry button, dialog title/aria-label, close-button aria-label, destructive warning paragraph (3 bolded words + embedded delete-clause), ack copy, type-to-confirm label + aria-label (confirm token `reset` verified to stay untranslated), destructive button.
  - **(g)** revert-equivalent path + its button, post-execute result summary + "View in Trash" link, and all 7 error branches (403×2, 409×2, 413, 400 — token preserved, default fallback).
- `vue-tsc -b`: clean.
- Full `multitable-web-guard` matrix run locally: **49 files / 515 tests green** (511 R5 baseline + R5b's +2 + this round's +2).

## Strict-zero exhaustion statement

Ran a static scan (aria-label counted; `data-test` excluded) over every reset/restore/history/tombstone-line component: `HistoryBatchChangesList.vue`, `HistoryCenterModal.vue`, `MetaConfigHistoryModal.vue`, `RestoreBatchDialog.vue`, `RestorePreviewDialog.vue`, `TrashModal.vue`, `ResetToPointPicker.vue`, `ResetConfirmDialog.vue`.

- **Before this PR:** `ResetConfirmDialog.vue` was the only residual (all others already route through `t()`/`l()`/`recordLabel`; `ResetToPointPicker.vue` was fixed by R5b, now on `main`).
- **After this PR:** zero residual hardcoded user-visible English across the whole line, with one intentional, documented exception — the server-authoritative `reset` confirm-token literal (not a miss; explicitly out of scope per the typed-confirm rule).

This closes strict-zero for the reset/restore/history/tombstone line.

## Known-cosmetic, not fixed

The destructive-warning paragraph's zh rendering has literal ASCII spaces between some Chinese phrase-fragments (an artifact of the fixed inline-`<strong>` template slots being shared across both locales — same accepted tradeoff R5b shipped for its "目标：X （你的本地时间）" line). Not treated as a defect; flagging so it doesn't read as an oversight.

## Not done / out of scope

- `ResetConfirmDialog.vue` and its spec file are **not** in `multitable-web-guard.yml`'s `paths:` trigger list (only `meta-record-labels.ts` is, which is why this PR's own guard run fires correctly). Pre-existing gap, not introduced or widened here — R5b's own PR didn't touch the workflow either, so leaving it matches that precedent rather than scope-creeping this microslice.
- No behavior change: `pitResetEnabled`/`PIT_RESET` remains flag-gated and dormant by default — zero live-surface risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)