### PR TITLE
fix(dingtalk): fence auto-provision behind non-empty corp allowlist (DT-HARDEN-09)

### DIFF
--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -14,6 +14,7 @@ import {
 import {
   assertDingTalkCorpAllowed,
   DingTalkCorpNotAllowedError,
+  isCorpAllowlistConfigured,
   readDingTalkAllowedCorpIds,
 } from '../integrations/dingtalk/runtime-policy'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
@@ -656,6 +657,31 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
   }
 
   if (!shouldAutoProvision()) {
+    throw createPolicyError(
+      dtUser.email
+        ? `DingTalk account ${dtUser.email} is not linked to a local user`
+        : 'DingTalk account is not linked to a local user',
+      {
+        statusCode: 403,
+        code: 'unlinked_local_user',
+      },
+    )
+  }
+
+  // DT-HARDEN-09: auto-provision + an empty DINGTALK_ALLOWED_CORP_IDS is an
+  // unscoped "any DingTalk corp can self-register a local account" hole —
+  // isDingTalkCorpAllowed/assertDingTalkCorpAllowed are permissive when the
+  // allowlist is empty, so without this fence any corp's OAuth user would be
+  // silently auto-provisioned. Require an explicit non-empty allowlist before
+  // auto-provision is allowed to create anything; fall back to the same
+  // unlinked/403 path used when auto-provision is disabled outright.
+  if (!isCorpAllowlistConfigured()) {
+    logger.warn(
+      'DingTalk auto-provision blocked: DINGTALK_AUTH_AUTO_PROVISION is enabled but ' +
+      'DINGTALK_ALLOWED_CORP_IDS is empty (unscoped allowlist) — refusing to auto-create ' +
+      'a local user; configure DINGTALK_ALLOWED_CORP_IDS to enable auto-provision',
+      { email: dtUser.email || null, unionId: dtUser.unionId || null },
+    )
     throw createPolicyError(
       dtUser.email
         ? `DingTalk account ${dtUser.email} is not linked to a local user`

--- a/packages/core-backend/src/integrations/dingtalk/runtime-policy.ts
+++ b/packages/core-backend/src/integrations/dingtalk/runtime-policy.ts
@@ -25,6 +25,18 @@ export function readDingTalkAllowedCorpIds(): string[] {
   ))
 }
 
+/**
+ * Whether an explicit, non-empty DINGTALK_ALLOWED_CORP_IDS allowlist is
+ * configured for this deployment. An empty allowlist makes
+ * `isDingTalkCorpAllowed`/`assertDingTalkCorpAllowed` permissive (any corp),
+ * which is fine for read-only login gating but unsafe to pair with
+ * auto-provisioning — callers that create local accounts on first login
+ * should require this to be true before doing so (DT-HARDEN-09).
+ */
+export function isCorpAllowlistConfigured(): boolean {
+  return readDingTalkAllowedCorpIds().length > 0
+}
+
 export function isDingTalkCorpAllowed(corpId: string | null | undefined): boolean {
   const allowedCorpIds = readDingTalkAllowedCorpIds()
   if (allowedCorpIds.length === 0) return true

--- a/packages/core-backend/tests/integration/dingtalk-container-login.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-container-login.db.test.ts
@@ -146,6 +146,8 @@ describeIfDb('E1 — dingtalk container login (real DB)', () => {
 
   it('gate: auto-provision creates a local user and a union-keyed identity (no fake openId)', async () => {
     vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    // Auto-provision requires a non-empty corp allowlist (DT-HARDEN-09).
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', CORP)
     primeContainerChain(UNION_PROVISION)
     const result = await exchangeEnterpriseAuthCodeForUser('code-provision')
     expect(result.isNewUser).toBe(true)
@@ -163,6 +165,8 @@ describeIfDb('E1 — dingtalk container login (real DB)', () => {
 
   it('golden (§2): container → web → container logins upgrade the identity key exactly once', async () => {
     vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    // Auto-provision requires a non-empty corp allowlist (DT-HARDEN-09).
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', CORP)
 
     // 1) container first: identity lands union-keyed, no openId
     primeContainerChain(UNION_GOLDEN)
@@ -211,6 +215,8 @@ describeIfDb('E1 — dingtalk container login (real DB)', () => {
 
   it('P2-1 (#3771): two emailless container users provision with distinct placeholder emails', async () => {
     vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    // Auto-provision requires a non-empty corp allowlist (DT-HARDEN-09).
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', CORP)
     const UNION_A = `union_${RUN}_noeml_a`
     const UNION_B = `union_${RUN}_noeml_b`
 

--- a/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
@@ -174,6 +174,49 @@ describe('dingtalk oauth login gates', () => {
     })
   })
 
+  it('refuses auto-provision when DINGTALK_ALLOWED_CORP_IDS is unset (unscoped allowlist guard, DT-HARDEN-09)', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    // DINGTALK_ALLOWED_CORP_IDS deliberately left unset: isDingTalkCorpAllowed
+    // is permissive when empty, so auto-provision must refuse to create a
+    // local user rather than silently onboard any corp's OAuth user.
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // findIdentityUser: no existing identity link
+
+    await expect(exchangeCodeForUser('code-4')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 403,
+      code: 'unlinked_local_user',
+      message: 'DingTalk account alpha@example.com is not linked to a local user',
+    })
+    expect(pgMocks.query.mock.calls.some((call) => String(call[0]).includes('INSERT INTO users'))).toBe(false)
+  })
+
+  it('auto-provisions a local user when DINGTALK_ALLOWED_CORP_IDS is configured (existing behavior unaffected)', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', 'ding-corp')
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // findIdentityUser: no existing identity link
+      .mockResolvedValueOnce({ rows: [] }) // findUserByEmail: no conflicting local account
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-new',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+        }],
+      }) // INSERT INTO users
+
+    const result = await exchangeCodeForUser('code-5')
+
+    expect(result).toMatchObject({
+      localUserId: 'user-new',
+      localUserEmail: 'alpha@example.com',
+      isNewUser: true,
+    })
+    expect(pgMocks.query.mock.calls.some((call) => String(call[0]).includes('INSERT INTO users'))).toBe(true)
+  })
+
   it('reports runtime status with grant mode and allowlist details', () => {
     vi.stubEnv('DINGTALK_CLIENT_ID', 'dt-client')
     vi.stubEnv('DINGTALK_CLIENT_SECRET', 'dt-secret')

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -286,6 +286,9 @@ describe('DingTalk OAuth state store', () => {
   it('refuses auto-provision when a local account already exists with the same email', async () => {
     vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '0')
     vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    // Auto-provision requires a non-empty corp allowlist (DT-HARDEN-09); this
+    // test exercises the email-conflict guard downstream of that gate.
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', 'ding-corp-1')
     vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
       accessToken: 'access-token',
     })
@@ -411,6 +414,8 @@ describe('DingTalk OAuth state store', () => {
 
   it('writes a password hash when auto-provisioning a new DingTalk user', async () => {
     vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    // Auto-provision requires a non-empty corp allowlist (DT-HARDEN-09).
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', 'ding-corp-1')
     vi.mocked(exchangeCodeForUserAccessToken).mockResolvedValue({
       accessToken: 'access-token',
     })


### PR DESCRIPTION
When `DINGTALK_AUTH_AUTO_PROVISION=true` and `DINGTALK_ALLOWED_CORP_IDS` is empty (allow-all), any DingTalk user from any org auto-created a local account. Adds an `isCorpAllowlistConfigured()` guard at the single auto-provision choke point in `resolveLocalUser` (covers web OAuth + E1); reuses the existing `unlinked_local_user`/403. No change when the allowlist is configured.

Roadmap: DT-HARDEN-09. Verify: oauth-login-gates 12 pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ⚠️ Operational impact (read before deploying)

This is a deliberate **tightening**, ratified as roadmap §6.1b. A deployment running `DINGTALK_AUTH_AUTO_PROVISION=true` **without** `DINGTALK_ALLOWED_CORP_IDS` will stop auto-creating local users (those logins now return the existing `unlinked_local_user`/403, exactly as if auto-provision were off).

**Migration path**: set `DINGTALK_ALLOWED_CORP_IDS` to the intended corp id(s) — auto-provision then behaves exactly as before. `DINGTALK_AUTH_AUTO_PROVISION` defaults to `false`, so only deployments that explicitly opted into the insecure combination are affected. Already-bound users are unaffected (the fence only guards the new-user creation path).