### PR TITLE
chore(dingtalk): env-template hygiene + default-off staging smoke checklist (DT-HARDEN-11)

### DIFF
--- a/docker/app.staging.env.example
+++ b/docker/app.staging.env.example
@@ -7,6 +7,10 @@ PORT=8900
 PRODUCT_MODE=platform
 DEPLOYMENT_MODEL=onprem
 
+# PUBLIC_APP_URL (APP_BASE_URL is the fallback) is the public base URL used to build
+# DingTalk deep links: approval-card decision links and automation links
+# (integrations/dingtalk/approval-card-config.ts, multitable/automation-executor.ts).
+# Keep it pointed at the externally reachable staging URL.
 PUBLIC_APP_URL=http://23.254.236.11:8082
 CORS_ORIGIN=http://23.254.236.11:8082
 
@@ -30,14 +34,32 @@ ATTENDANCE_IMPORT_UPLOAD_DIR=/app/uploads/attendance-import
 ATTENDANCE_IMPORT_CSV_MAX_ROWS=20000
 ATTENDANCE_IMPORT_HEAVY_QUERY_TIMEOUT_MS=180000
 
-DINGTALK_AUTH_ENABLED=true
 DINGTALK_CLIENT_ID=replace-me
 DINGTALK_CLIENT_SECRET=replace-me
 DINGTALK_CORP_ID=replace-me
+# Corp allowlist for both web OAuth and E1 container login (runtime-policy.ts
+# isDingTalkCorpAllowed). Empty = allow ANY corpId. Set this before turning on
+# DINGTALK_AUTH_AUTO_PROVISION below, otherwise auto-provision is unscoped.
 DINGTALK_ALLOWED_CORP_IDS=replace-me
 DINGTALK_REDIRECT_URI=http://23.254.236.11:8082/login/dingtalk/callback
-DINGTALK_SCOPE=openid corpid Contact.User.Read
 DINGTALK_AUTH_AUTO_LINK_EMAIL=1
+# Auto-create a local account on first DingTalk login. Only enable once
+# DINGTALK_ALLOWED_CORP_IDS above is non-empty — with an empty allowlist this
+# would let any corp's DingTalk users self-provision accounts.
 DINGTALK_AUTH_AUTO_PROVISION=0
 DINGTALK_AUTH_REQUIRE_GRANT=0
-DINGTALK_STATE_SECRET=replace-me
+
+# E1 container login (免登): exchanges an in-container DingTalk authCode for a
+# JWT via POST /auth/dingtalk/container. Default-off; see routes/auth.ts.
+DINGTALK_CONTAINER_LOGIN_ENABLED=false
+
+# Work-notification agent. DINGTALK_AGENT_ID is checked first, then
+# DINGTALK_NOTIFY_AGENT_ID (integrations/dingtalk/client.ts,
+# integrations/dingtalk/work-notification-settings.ts). Only one is required.
+DINGTALK_AGENT_ID=replace-me
+DINGTALK_NOTIFY_AGENT_ID=replace-me
+
+# HMAC signing secret for approval-card decision deep links
+# (integrations/dingtalk/approval-card-config.ts). Falls back to a stored
+# per-directory secret if unset; required for signed approval decision links.
+APPROVAL_CARD_LINK_SECRET=replace-me

--- a/docs/development/dingtalk-default-off-staging-smoke-20260708.md
+++ b/docs/development/dingtalk-default-off-staging-smoke-20260708.md
@@ -1,0 +1,58 @@
+# DingTalk default-off staging smoke checklist
+
+**Date:** 2026-07-08
+
+**Status:** CHECKLIST only. No staging run recorded here. Companion to the
+`docker/app.staging.env.example` hygiene pass (DT-HARDEN-11) and roadmap
+§6.10 (`dingtalk-sync-integrated-roadmap-20260708.md`).
+
+**Why:** the four features below are all default-off (flag or unset secret).
+Unit tests exercise the enabled and disabled code paths in isolation, but a
+real deploy can still ship with a feature silently mis-wired end to end (env
+key not passed through compose, wrong corp/agent id, etc.). Run each check
+once per deploy that changes DingTalk-related env or code, before signing
+off the release.
+
+## 1. E1 container login (`DINGTALK_CONTAINER_LOGIN_ENABLED`)
+
+- [ ] With the flag unset/`false`: `POST /auth/dingtalk/container` returns
+  `404 container_login_disabled`.
+- [ ] With the flag `true` and a real in-container `authCode`: the route
+  exchanges it for a session JWT via the same `resolveLocalUser` policy
+  gates as web OAuth (corp allowlist from `DINGTALK_ALLOWED_CORP_IDS`
+  applies here too).
+
+## 2. Work notification (`DINGTALK_AGENT_ID` / `DINGTALK_NOTIFY_AGENT_ID`)
+
+- [ ] With both unset: a triggered work-notification send fails closed with
+  `DINGTALK_AGENT_ID, DINGTALK_NOTIFY_AGENT_ID, or directory
+  workNotificationAgentId is not configured` (no silent no-op).
+- [ ] With one of the two set: a real work notification is delivered to a
+  test DingTalk user via the configured agent.
+
+## 3. Approval card (`APPROVAL_CARD_LINK_SECRET`, `PUBLIC_APP_URL`)
+
+- [ ] With the secret and public URL unset (and no stored per-directory
+  secret/URL): the approval-card send action fails with the documented
+  `APPROVAL_CARD_LINK_SECRET (...) is required` / `PUBLIC_APP_URL or
+  APP_BASE_URL (...) is required` error — not a silently unsigned link.
+- [ ] With both configured: an approval triggers a card whose decision deep
+  link resolves through `$PUBLIC_APP_URL` and validates its HMAC signature
+  on click-through.
+
+## 4. Directory sync
+
+- [ ] A manual sync run against a real DingTalk corp (`DINGTALK_CORP_ID`,
+  `DINGTALK_ALLOWED_CORP_IDS` containing it) completes and reflects
+  department/user changes in the local directory.
+- [ ] A sync attempt against a corp NOT in `DINGTALK_ALLOWED_CORP_IDS` is
+  rejected (`DingTalkCorpNotAllowedError`) — confirms the allowlist fence is
+  live before trusting auto-provision or sync writes.
+
+## Notes
+
+- `DINGTALK_ALLOWED_CORP_IDS` empty means allow-ALL corp ids (see
+  `runtime-policy.ts`). Do not enable `DINGTALK_AUTH_AUTO_PROVISION` on a
+  deploy where this checklist has not confirmed the allowlist is populated.
+- This checklist does not gate a release by itself; treat it as a manual
+  operator pass alongside the existing attendance staging-smoke runbooks.


### PR DESCRIPTION
Removes dead `app.staging.env.example` keys (DINGTALK_AUTH_ENABLED/SCOPE/STATE_SECRET, zero code reads), adds the missing active keys (CONTAINER_LOGIN_ENABLED/AGENT_ID/APPROVAL_CARD_LINK_SECRET), annotates the auto-provision×allowlist coupling, and adds a default-off staging smoke checklist doc. Consistency check: every template key has a live code read.

Roadmap: DT-HARDEN-11. Doc/config only, no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)