### PR TITLE
feat(web): BA-APPLY-1 Bridge Agent change-suggestion → machine-readable implementation checklist export (design-lock #3876, refs #3746)

### DIFF
--- a/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
+++ b/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
@@ -435,6 +435,82 @@
               class="bridge-agent__error"
             >{{ bi('复制失败，请手动选择文本复制。', 'Copy failed; select the text manually to copy.') }}</span>
           </div>
+
+          <!-- BA-APPLY-1 (docs/development/bridge-agent-controlled-apply-design-lock-20260708.md §2
+               形态 A, #3876): export the SAME drafts as a machine-readable, values-free implementation
+               checklist. Independently gated (own guided-empty state), sibling to the prose suggestion
+               above rather than nested inside it. EXPORT/render only — no apply endpoint, no write, no
+               Agent write. -->
+          <div class="bridge-agent__checklist-export">
+            <button
+              type="button"
+              class="integration-workbench__button"
+              data-testid="bridge-agent-checklist-export"
+              @click="toggleChecklist"
+            >
+              <el-icon><DocumentCopy /></el-icon>
+              {{ checklistVisible ? bi('收起实施清单', 'Hide implementation checklist') : bi('导出实施清单', 'Export implementation checklist') }}
+            </button>
+
+            <template v-if="checklistVisible">
+              <p class="integration-workbench__hint">{{ bi(
+                '机读格式：仅含对象名、字段键名与固定操作枚举（add_readonly_object / add_readonly_field），不含取值/host/凭据/自由文本；本导出不会调用任何写入接口，也不会做任何直接修改——供人工确认后交由受控后端或运维脚本按既有 runbook 应用。',
+                'Machine-readable: object names, field-key names, and a fixed operation enum only (add_readonly_object / add_readonly_field) — never a value/host/credential/free-form text; this export calls no write endpoint and makes no direct change — a human hands it to the controlled backend or an ops script to apply per the existing runbook.',
+              ) }}</p>
+
+              <div
+                v-if="implementationChecklist.checklist.operations.length === 0"
+                class="integration-workbench__empty"
+                data-testid="bridge-agent-checklist-empty"
+              >
+                <strong data-testid="bridge-agent-checklist-empty-what">{{ bi(
+                  '这里会把上面填写的对象/字段名整理成一份机读的实施清单（JSON）。',
+                  'This turns the object/field names you enter above into a machine-readable implementation checklist (JSON).',
+                ) }}</strong>
+                <p data-testid="bridge-agent-checklist-empty-first-step">{{ bi(
+                  '第一步：在上方填写至少一个对象名（可选填字段名），清单会自动生成。',
+                  'First step: enter at least one object name above (field names are optional); the checklist is generated automatically.',
+                ) }}</p>
+              </div>
+              <div v-else class="bridge-agent__suggestion-output" data-testid="bridge-agent-checklist-output">
+                <h4>{{ bi('机读实施清单（JSON，可复制/下载）', 'Machine-readable implementation checklist (JSON; copyable/downloadable)') }}</h4>
+                <textarea
+                  class="bridge-agent__suggestion-text"
+                  data-testid="bridge-agent-checklist-text"
+                  readonly
+                  :value="checklistText"
+                />
+                <button
+                  type="button"
+                  class="integration-workbench__button"
+                  data-testid="bridge-agent-checklist-copy"
+                  @click="copyChecklistText"
+                >
+                  <el-icon><DocumentCopy /></el-icon>
+                  {{ bi('复制清单 JSON', 'Copy checklist JSON') }}
+                </button>
+                <button
+                  type="button"
+                  class="integration-workbench__button"
+                  data-testid="bridge-agent-checklist-download"
+                  @click="downloadChecklistJson"
+                >
+                  <el-icon><DocumentCopy /></el-icon>
+                  {{ bi('下载清单 JSON', 'Download checklist JSON') }}
+                </button>
+                <span
+                  v-if="checklistCopyState === 'copied'"
+                  data-testid="bridge-agent-checklist-copy-state"
+                  class="integration-workbench__hint"
+                >{{ bi('已复制', 'Copied') }}</span>
+                <span
+                  v-else-if="checklistCopyState === 'failed'"
+                  data-testid="bridge-agent-checklist-copy-state"
+                  class="bridge-agent__error"
+                >{{ bi('复制失败，请手动选择文本复制。', 'Copy failed; select the text manually to copy.') }}</span>
+              </div>
+            </template>
+          </div>
         </div>
       </template>
     </el-card>
@@ -479,6 +555,7 @@ import { useLocale } from '../../composables/useLocale'
 import {
   bridgeAgentConfigCheckLabel,
   buildBridgeAgentChangeSuggestion,
+  buildImplementationChecklist,
   computeBridgeAgentConfigCheck,
   type BridgeAgentConfigCheckItem,
   type BridgeAgentConfigCheckStatus,
@@ -1021,6 +1098,72 @@ async function copySuggestionText(): Promise<void> {
 
 watch(suggestionDrafts, () => {
   copyState.value = 'idle'
+}, { deep: true })
+
+// --- BA-APPLY-1 (docs/development/bridge-agent-controlled-apply-design-lock-20260708.md §2 形态 A,
+// #3876): "导出实施清单" — renders the SAME operator-typed drafts above as a machine-readable, values-
+// free implementation checklist (`buildImplementationChecklist`), instead of the prose suggestion text.
+// This is an EXPORT/render only: no apply endpoint, no local-config write, no .ps1 invocation, no Agent
+// write — the JSON below is handed to a controlled backend or ops script by a human (a LATER, unopened
+// rung). `implementationChecklist` recomputes from `suggestionDrafts` directly (not from
+// `suggestionResult.entries`) so this surface independently re-applies the safe-identifier gate rather
+// than trusting the sibling suggestion builder's output.
+const implementationChecklist = computed(() => {
+  const drafts: BridgeAgentSuggestionObjectDraft[] = suggestionDrafts.value.map((row) => ({
+    objectName: row.objectName,
+    fieldKeys: row.fieldKeysText.split(',').map((key) => key.trim()).filter(Boolean),
+  }))
+  return buildImplementationChecklist(drafts)
+})
+
+// The exact serialized artifact — `{ schemaVersion, operations }` only, no counts/labels/free text —
+// is what gets previewed, copied, and downloaded.
+const checklistText = computed(() => JSON.stringify(implementationChecklist.value.checklist, null, 2))
+
+const checklistVisible = ref(false)
+
+function toggleChecklist(): void {
+  checklistVisible.value = !checklistVisible.value
+}
+
+const checklistCopyState = ref<'idle' | 'copied' | 'failed'>('idle')
+
+async function copyChecklistText(): Promise<void> {
+  checklistCopyState.value = 'idle'
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      await navigator.clipboard.writeText(checklistText.value)
+      checklistCopyState.value = 'copied'
+      return
+    }
+  } catch {
+    // fall through to the failed state below
+  }
+  checklistCopyState.value = 'failed'
+}
+
+// Values-free by construction: the downloaded file's own content is `checklistText` (object names/
+// field-key names/op enum only — see the module header) and its filename carries nothing but a
+// client-side timestamp, never a system name or config value.
+function downloadChecklistJson(): void {
+  if (typeof document === 'undefined' || typeof URL.createObjectURL !== 'function') return
+  const blob = new Blob([checklistText.value], { type: 'application/json;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `bridge-agent-implementation-checklist-${Date.now()}.json`
+  anchor.rel = 'noopener'
+  anchor.style.display = 'none'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  if (typeof URL.revokeObjectURL === 'function') {
+    window.setTimeout(() => URL.revokeObjectURL(url), 0)
+  }
+}
+
+watch(suggestionDrafts, () => {
+  checklistCopyState.value = 'idle'
 }, { deep: true })
 </script>
 

--- a/apps/web/src/services/integration/bridgeAgentConfigCheck.ts
+++ b/apps/web/src/services/integration/bridgeAgentConfigCheck.ts
@@ -1,10 +1,13 @@
 // Bridge Agent config validation + change-suggestion checklist (BA-UI-3, design-lock
-// docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-3). Predecessors: BA-UI-1
-// (#3824, observability) + BA-UI-2 (#3840, values-free probe). This slice is READ-ONLY + SUGGESTIONS
-// ONLY — no controlled apply, no backend write (lock §3: "由受控后端或运维脚本应用" — the controlled
-// backend or an ops script applies any change, never this page).
+// docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-3) + BA-APPLY-1's
+// machine-readable implementation-checklist export (design-lock
+// docs/development/bridge-agent-controlled-apply-design-lock-20260708.md §2 形态 A). Predecessors:
+// BA-UI-1 (#3824, observability) + BA-UI-2 (#3840, values-free probe). This slice is READ-ONLY +
+// SUGGESTIONS/EXPORT ONLY — no controlled apply, no backend write, no Agent write (lock §3 / BA-APPLY
+// lock §1-§2: "由受控后端或运维脚本应用" — the controlled backend or an ops script applies any change,
+// never this page).
 //
-// Pure, framework-free module: no Vue import, no DOM, no `fetch`/apiFetch. Two independent surfaces:
+// Pure, framework-free module: no Vue import, no DOM, no `fetch`/apiFetch. Three independent surfaces:
 //
 //   1. computeBridgeAgentConfigCheck(input) — a fixed 6-item values-free checklist over a bridge-agent
 //      system's PUBLIC config (the same `system.config` shape BA-UI-1 already receives on the wire —
@@ -26,6 +29,13 @@
 //      shapes a secret, connection string, or host would carry) is dropped and only COUNTED, never
 //      echoed, so a stray secret-shaped string pasted into a name field can never ride along into the
 //      generated text.
+//
+//   3. buildImplementationChecklist(drafts) — BA-APPLY-1: the SAME safe-identifier gate (shared helper
+//      `filterSafeSuggestionDrafts`, used by both #2 and #3) applied to the same OPERATOR-SPECIFIED
+//      drafts, rendered as a fixed-schema, machine-readable object (`{ schemaVersion, operations }`)
+//      instead of prose — object names, field-key names, and a closed operation enum only, never a
+//      value/host/credential/free-form string. This is an EXPORT/render only: apply is a later,
+//      unopened rung (BA-APPLY-2+).
 
 import type { AppLocale } from '../../composables/useLocale'
 
@@ -322,20 +332,17 @@ export interface BridgeAgentChangeSuggestionResult {
   text: string
 }
 
-/**
- * Builds a values-free "变更建议 / 实施清单" from OPERATOR-SPECIFIED new object/field-key names (never
- * values). Every name is validated against `SAFE_IDENTIFIER_PATTERN`; anything that fails is dropped
- * from the rendered text and only counted (`invalidObjectCount` / `invalidFieldKeyCount`), so a
- * secret/host/connection-string-shaped string pasted into a name field can never appear in `text`.
- * `targetLabel` (optional) is a plain system NAME for a documentation header line — the same trust
- * boundary BA-UI-1 already extends to `system.name` elsewhere in this section (never a config value).
- */
-export function buildBridgeAgentChangeSuggestion(
-  drafts: BridgeAgentSuggestionObjectDraft[],
-  locale: AppLocale,
-  targetLabel?: string | null,
-): BridgeAgentChangeSuggestionResult {
-  const isZh = locale === 'zh-CN'
+interface FilteredSuggestionDrafts {
+  entries: BridgeAgentSuggestionEntryResult[]
+  invalidObjectCount: number
+  invalidFieldKeyCount: number
+}
+
+// Single shared gate: BOTH `buildBridgeAgentChangeSuggestion` (below) and `buildImplementationChecklist`
+// (BA-APPLY-1, further below) filter OPERATOR-SPECIFIED drafts through this one function, so there is
+// exactly one place that decides which object/field-key names are safe to echo anywhere. Anything not
+// identifier-shaped is dropped and only counted — never returned in `entries`.
+function filterSafeSuggestionDrafts(drafts: BridgeAgentSuggestionObjectDraft[]): FilteredSuggestionDrafts {
   const safeDrafts = Array.isArray(drafts) ? drafts : []
 
   let invalidObjectCount = 0
@@ -359,6 +366,25 @@ export function buildBridgeAgentChangeSuggestion(
     }
     entries.push({ objectName: rawObjectName, fieldKeys })
   }
+
+  return { entries, invalidObjectCount, invalidFieldKeyCount }
+}
+
+/**
+ * Builds a values-free "变更建议 / 实施清单" from OPERATOR-SPECIFIED new object/field-key names (never
+ * values). Every name is validated against `SAFE_IDENTIFIER_PATTERN`; anything that fails is dropped
+ * from the rendered text and only counted (`invalidObjectCount` / `invalidFieldKeyCount`), so a
+ * secret/host/connection-string-shaped string pasted into a name field can never appear in `text`.
+ * `targetLabel` (optional) is a plain system NAME for a documentation header line — the same trust
+ * boundary BA-UI-1 already extends to `system.name` elsewhere in this section (never a config value).
+ */
+export function buildBridgeAgentChangeSuggestion(
+  drafts: BridgeAgentSuggestionObjectDraft[],
+  locale: AppLocale,
+  targetLabel?: string | null,
+): BridgeAgentChangeSuggestionResult {
+  const isZh = locale === 'zh-CN'
+  const { entries, invalidObjectCount, invalidFieldKeyCount } = filterSafeSuggestionDrafts(drafts)
 
   const lines: string[] = []
   lines.push(isZh
@@ -393,4 +419,73 @@ export function buildBridgeAgentChangeSuggestion(
   }
 
   return { entries, invalidObjectCount, invalidFieldKeyCount, text: lines.join('\n') }
+}
+
+// #### 3. Implementation-checklist builder (BA-APPLY-1) #############################################
+//
+// docs/development/bridge-agent-controlled-apply-design-lock-20260708.md §2 形态 A ("运维脚本
+// handoff, 风险最低, 建议 v1"): BA-UI-3's change suggestion above is prose for a human to read; this
+// builder renders the SAME already-identifier-gated drafts as a machine-readable, values-free
+// "implementation checklist" — a fixed-schema object whose ONLY content is object names, field-key
+// names, and a closed operation enum. It is an EXPORT/render only: nothing in this module (or its
+// caller) writes local config, calls a backend endpoint, or touches the Agent — apply is a LATER,
+// unopened rung (BA-APPLY-2+), done by a human handing this checklist to the controlled backend or the
+// existing scripts/ops/bridge-agent-readonly.ps1 script.
+
+// Exact-registered, closed operation enum (design-lock §4 hard lock — "只读不变式": the checklist can
+// only ever describe EXPANDING readonly exposure, never a write/delete/make-writable operation). Adding
+// a third literal to this union — or any write/delete/make-writable-shaped op — is NOT authorized by
+// this slice; it would require its own owner-ratified design-lock rung.
+export type BridgeAgentChecklistOperationKind = 'add_readonly_object' | 'add_readonly_field'
+
+export interface BridgeAgentChecklistOperation {
+  op: BridgeAgentChecklistOperationKind
+  objectName: string
+  fieldKeys: string[]
+}
+
+// The serialized/exported artifact shape — copy/download output is exactly this object (no counts, no
+// targetLabel/system name, no free-form text): `{ schemaVersion, operations }`.
+export interface BridgeAgentImplementationChecklist {
+  schemaVersion: 1
+  operations: BridgeAgentChecklistOperation[]
+}
+
+export interface BridgeAgentImplementationChecklistResult {
+  checklist: BridgeAgentImplementationChecklist
+  invalidObjectCount: number
+  invalidFieldKeyCount: number
+}
+
+const CHECKLIST_SCHEMA_VERSION = 1 as const
+
+/**
+ * Builds a machine-readable, values-free implementation checklist from OPERATOR-SPECIFIED new
+ * object/field-key names (never values) — form A of the BA-APPLY line. Independently re-applies
+ * `filterSafeSuggestionDrafts` (the same gate `buildBridgeAgentChangeSuggestion` uses): this function
+ * does not trust its caller to have already filtered `drafts`, so a non-conforming name is dropped and
+ * only counted, never emitted into `checklist.operations`.
+ *
+ * One operation per valid draft row (never per field key) — `op` is DERIVED, never read off caller
+ * input (there is no `op` field on `BridgeAgentSuggestionObjectDraft`), so a caller can never smuggle a
+ * write/delete/make-writable op string through: a row with zero valid field keys yields
+ * `add_readonly_object`; a row with >=1 valid field keys yields `add_readonly_field` (its `fieldKeys`
+ * carries every valid key from that row).
+ */
+export function buildImplementationChecklist(
+  drafts: BridgeAgentSuggestionObjectDraft[],
+): BridgeAgentImplementationChecklistResult {
+  const { entries, invalidObjectCount, invalidFieldKeyCount } = filterSafeSuggestionDrafts(drafts)
+
+  const operations: BridgeAgentChecklistOperation[] = entries.map((entry) => ({
+    op: entry.fieldKeys.length > 0 ? 'add_readonly_field' : 'add_readonly_object',
+    objectName: entry.objectName,
+    fieldKeys: entry.fieldKeys,
+  }))
+
+  return {
+    checklist: { schemaVersion: CHECKLIST_SCHEMA_VERSION, operations },
+    invalidObjectCount,
+    invalidFieldKeyCount,
+  }
 }

--- a/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
+++ b/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
@@ -40,6 +40,18 @@ async function flushUi(cycles = 6): Promise<void> {
   }
 }
 
+// jsdom's Blob does not always implement `.text()` — same fallback pattern as
+// IntegrationWorkbenchView.spec.ts's readBlobText helper (BA-APPLY-1 checklist download test, below).
+async function readBlobText(blob: Blob): Promise<string> {
+  if (typeof blob.text === 'function') return blob.text()
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result ?? ''))
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(blob)
+  })
+}
+
 // ElCard stub — same pattern as IntegrationMonitoringSection.spec.ts (real Element Plus is not
 // globally installed in this createApp() instance).
 const ElCard = defineComponent({
@@ -826,6 +838,240 @@ describe('IntegrationBridgeAgentSection', () => {
     expect(q(root, 'bridge-agent-suggestion-copy-state').textContent).toMatch(/copy failed/i)
   })
 
+  // --- BA-APPLY-1 (docs/development/bridge-agent-controlled-apply-design-lock-20260708.md §2 形态 A,
+  // #3876): "导出实施清单" — an ADD-ONLY export button on the suggestion card. Component spec covers:
+  // toggle visibility, guided empty state, live JSON generation, add/remove-row reflection, the
+  // SENTINEL discipline (independent of the sibling suggestion text), copy + a missing-clipboard
+  // fallback, and download (createObjectURL/anchor/revoke). Zero apply endpoint, zero write — the
+  // component test setup below never registers a route beyond the existing test/objects/schema mocks.
+
+  it('checklist export: hidden until the export button is clicked; toggling flips the button label', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    expect(root.querySelector('[data-testid="bridge-agent-checklist-output"]')).toBeNull()
+    expect(root.querySelector('[data-testid="bridge-agent-checklist-empty"]')).toBeNull()
+    const exportButton = q<HTMLButtonElement>(root, 'bridge-agent-checklist-export')
+    expect(exportButton.textContent).toMatch(/export implementation checklist/i)
+
+    exportButton.click()
+    await flushUi()
+    expect(exportButton.textContent).toMatch(/hide implementation checklist/i)
+    // no object name typed yet -> the guided empty state, not the JSON preview
+    q(root, 'bridge-agent-checklist-empty')
+    expect(root.querySelector('[data-testid="bridge-agent-checklist-output"]')).toBeNull()
+
+    exportButton.click()
+    await flushUi()
+    expect(exportButton.textContent).toMatch(/export implementation checklist/i)
+    expect(root.querySelector('[data-testid="bridge-agent-checklist-empty"]')).toBeNull()
+  })
+
+  it('checklist export: typing an object + field names renders the exact { schemaVersion, operations } JSON', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    const fieldsInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-fields-0')
+    objectInput.value = 'material_extra'
+    objectInput.dispatchEvent(new Event('input'))
+    fieldsInput.value = 'field_a, field_b'
+    fieldsInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-checklist-export').click()
+    await flushUi()
+
+    const text = q<HTMLTextAreaElement>(root, 'bridge-agent-checklist-text')
+    const parsed = JSON.parse(text.value)
+    expect(parsed).toEqual({
+      schemaVersion: 1,
+      operations: [{ op: 'add_readonly_field', objectName: 'material_extra', fieldKeys: ['field_a', 'field_b'] }],
+    })
+    // no targetLabel/system-name, no free text, no counts — exactly the two keys
+    expect(Object.keys(parsed).sort()).toEqual(['operations', 'schemaVersion'])
+    expect(text.value).not.toContain(bridgeSystem().name)
+  })
+
+  it('checklist export: an object-only row (no field names) yields op=add_readonly_object', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = 'material_extra'
+    objectInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-checklist-export').click()
+    await flushUi()
+
+    const text = q<HTMLTextAreaElement>(root, 'bridge-agent-checklist-text')
+    expect(JSON.parse(text.value)).toEqual({
+      schemaVersion: 1,
+      operations: [{ op: 'add_readonly_object', objectName: 'material_extra', fieldKeys: [] }],
+    })
+  })
+
+  it('checklist export: add row / remove row are reflected in the live JSON, in order', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-suggestion-add-row').click()
+    await flushUi()
+
+    const object0 = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    object0.value = 'material_extra'
+    object0.dispatchEvent(new Event('input'))
+    const object1 = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-1')
+    object1.value = 'bom_child_extra'
+    object1.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-checklist-export').click()
+    await flushUi()
+
+    let parsed = JSON.parse(q<HTMLTextAreaElement>(root, 'bridge-agent-checklist-text').value)
+    expect(parsed.operations.map((op: { objectName: string }) => op.objectName)).toEqual(['material_extra', 'bom_child_extra'])
+
+    q<HTMLButtonElement>(root, 'bridge-agent-suggestion-remove-0').click()
+    await flushUi()
+    parsed = JSON.parse(q<HTMLTextAreaElement>(root, 'bridge-agent-checklist-text').value)
+    expect(parsed.operations.map((op: { objectName: string }) => op.objectName)).toEqual(['bom_child_extra'])
+  })
+
+  it('SENTINEL (BA-APPLY-1 checklist export): a secret/host-shaped object or field name is dropped, never echoed into the JSON', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = `password=${SENTINEL.configSecret}`
+    objectInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-checklist-export').click()
+    await flushUi()
+    // the hostile-named row is dropped entirely -> back to the guided empty state, not a JSON preview
+    q(root, 'bridge-agent-checklist-empty')
+    expect(root.querySelector('[data-testid="bridge-agent-checklist-text"]')).toBeNull()
+    expect(root.textContent).not.toContain(SENTINEL.configSecret)
+
+    q<HTMLButtonElement>(root, 'bridge-agent-suggestion-add-row').click()
+    await flushUi()
+    const object1 = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-1')
+    object1.value = 'material_extra'
+    object1.dispatchEvent(new Event('input'))
+    const fields1 = q<HTMLInputElement>(root, 'bridge-agent-suggestion-fields-1')
+    fields1.value = `token=${SENTINEL.configSecret}, field_a`
+    fields1.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    const text = q<HTMLTextAreaElement>(root, 'bridge-agent-checklist-text')
+    expect(text.value).not.toContain(SENTINEL.configSecret)
+    expect(text.value).not.toContain('password=')
+    expect(text.value).not.toContain('token=')
+    expect(JSON.parse(text.value)).toEqual({
+      schemaVersion: 1,
+      operations: [{ op: 'add_readonly_field', objectName: 'material_extra', fieldKeys: ['field_a'] }],
+    })
+  })
+
+  it('checklist export: copy button writes the exact JSON to the clipboard and shows a copied state', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    try {
+      const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+      objectInput.value = 'material_extra'
+      objectInput.dispatchEvent(new Event('input'))
+      await flushUi()
+
+      q<HTMLButtonElement>(root, 'bridge-agent-checklist-export').click()
+      await flushUi()
+      q<HTMLButtonElement>(root, 'bridge-agent-checklist-copy').click()
+      await flushUi()
+
+      expect(writeText).toHaveBeenCalledTimes(1)
+      const copiedText = String(writeText.mock.calls[0][0])
+      expect(JSON.parse(copiedText)).toEqual({
+        schemaVersion: 1,
+        operations: [{ op: 'add_readonly_object', objectName: 'material_extra', fieldKeys: [] }],
+      })
+      expect(q(root, 'bridge-agent-checklist-copy-state').textContent).toMatch(/copied/i)
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (navigator as any).clipboard
+    }
+  })
+
+  it('checklist export: a missing/non-functional clipboard API renders a failed-copy fallback message, never throwing', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = 'material_extra'
+    objectInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-checklist-export').click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'bridge-agent-checklist-copy').click()
+    await flushUi()
+
+    expect(q(root, 'bridge-agent-checklist-copy-state').textContent).toMatch(/copy failed/i)
+  })
+
+  it('checklist export: download button creates an object URL for a values-free JSON blob, clicks a hidden anchor, and revokes the URL', async () => {
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const originalAnchorClick = HTMLAnchorElement.prototype.click
+    const createObjectURLMock = vi.fn(() => 'blob:bridge-agent-checklist')
+    const revokeObjectURLMock = vi.fn()
+    const anchorClickMock = vi.fn()
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURLMock })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURLMock })
+    Object.defineProperty(HTMLAnchorElement.prototype, 'click', { configurable: true, value: anchorClickMock })
+    try {
+      mockRoutes()
+      const root = mountSection([bridgeSystem()])
+      await flushUi()
+
+      const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+      objectInput.value = 'material_extra'
+      objectInput.dispatchEvent(new Event('input'))
+      await flushUi()
+
+      q<HTMLButtonElement>(root, 'bridge-agent-checklist-export').click()
+      await flushUi()
+      q<HTMLButtonElement>(root, 'bridge-agent-checklist-download').click()
+      await flushUi()
+
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+      expect(anchorClickMock).toHaveBeenCalledTimes(1)
+      const downloadedBlob = createObjectURLMock.mock.calls[0]?.[0] as Blob
+      expect(downloadedBlob.type).toContain('application/json')
+      const downloadedText = await readBlobText(downloadedBlob)
+      expect(JSON.parse(downloadedText)).toEqual({
+        schemaVersion: 1,
+        operations: [{ op: 'add_readonly_object', objectName: 'material_extra', fieldKeys: [] }],
+      })
+      await new Promise((resolve) => window.setTimeout(resolve, 0))
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:bridge-agent-checklist')
+    } finally {
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+      Object.defineProperty(HTMLAnchorElement.prototype, 'click', { configurable: true, value: originalAnchorClick })
+    }
+  })
+
   it('zh copy: config-check card + suggestion builder render Chinese labels under zh-CN', async () => {
     const { setLocale } = useLocale()
     setLocale('zh-CN')
@@ -845,6 +1091,19 @@ describe('IntegrationBridgeAgentSection', () => {
       await flushUi()
       const text = q<HTMLTextAreaElement>(root, 'bridge-agent-suggestion-text')
       expect(text.value).toContain('1. 对象：material_extra')
+
+      // BA-APPLY-1: zh label for the export button + the JSON preview content is locale-agnostic
+      // (values are identifier strings, not translated copy) but the surrounding hint text is zh.
+      const exportButton = q<HTMLButtonElement>(root, 'bridge-agent-checklist-export')
+      expect(exportButton.textContent).toContain('导出实施清单')
+      exportButton.click()
+      await flushUi()
+      expect(root.textContent).toContain('机读实施清单')
+      const checklistText = q<HTMLTextAreaElement>(root, 'bridge-agent-checklist-text')
+      expect(JSON.parse(checklistText.value)).toEqual({
+        schemaVersion: 1,
+        operations: [{ op: 'add_readonly_object', objectName: 'material_extra', fieldKeys: [] }],
+      })
     } finally {
       setLocale('en')
     }

--- a/apps/web/tests/bridgeAgentConfigCheck.spec.ts
+++ b/apps/web/tests/bridgeAgentConfigCheck.spec.ts
@@ -3,9 +3,11 @@ import {
   BRIDGE_AGENT_CONFIG_CHECK_LABELS,
   bridgeAgentConfigCheckLabel,
   buildBridgeAgentChangeSuggestion,
+  buildImplementationChecklist,
   computeBridgeAgentConfigCheck,
   type BridgeAgentConfigCheckItem,
   type BridgeAgentConfigCheckLabelKey,
+  type BridgeAgentSuggestionObjectDraft,
 } from '../src/services/integration/bridgeAgentConfigCheck'
 
 // BA-UI-3 (docs/development/bridge-agent-admin-page-design-lock-20260707.md §3 BA-UI-3): pure-util
@@ -311,5 +313,121 @@ describe('buildBridgeAgentChangeSuggestion', () => {
     expect(() => buildBridgeAgentChangeSuggestion(drafts, 'en')).not.toThrow()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(() => buildBridgeAgentChangeSuggestion('not-an-array' as any, 'en')).not.toThrow()
+  })
+})
+
+// BA-APPLY-1 (docs/development/bridge-agent-controlled-apply-design-lock-20260708.md §2 形态 A): the
+// change-suggestion drafts above rendered as a fixed-schema, machine-readable checklist instead of
+// prose. This is form A's entire scope — an EXPORT/render only, zero platform write, zero Agent write.
+// ALLOWED_OPS is hardcoded HERE (not imported from source) so that a source mutation adding a third —
+// or a write/delete/make-writable-shaped — operation literal is caught by these tests even though the
+// mutated code still "type-checks" against its own (mutated) union.
+describe('buildImplementationChecklist (BA-APPLY-1)', () => {
+  const ALLOWED_OPS = ['add_readonly_object', 'add_readonly_field']
+
+  function allOpsAreAllowlisted(checklist: { operations: { op: string }[] }): boolean {
+    return checklist.operations.every((operation) => ALLOWED_OPS.includes(operation.op))
+  }
+
+  it('serializes to exactly { schemaVersion, operations } — no counts, no targetLabel/system-name, no free text', () => {
+    const result = buildImplementationChecklist([{ objectName: 'material_extra', fieldKeys: ['field_a'] }])
+    expect(Object.keys(result.checklist).sort()).toEqual(['operations', 'schemaVersion'])
+    expect(result.checklist.schemaVersion).toBe(1)
+    expect(JSON.parse(JSON.stringify(result.checklist))).toEqual({
+      schemaVersion: 1,
+      operations: [{ op: 'add_readonly_field', objectName: 'material_extra', fieldKeys: ['field_a'] }],
+    })
+  })
+
+  it('empty/no-valid-draft input yields an empty operations array, never throwing', () => {
+    expect(buildImplementationChecklist([]).checklist).toEqual({ schemaVersion: 1, operations: [] })
+    expect(buildImplementationChecklist([{ objectName: '   ', fieldKeys: [] }]).checklist.operations).toEqual([])
+  })
+
+  // --- op-derivation branches (the literal that a mutant flipping the derived op would break) -----
+  it('object-only draft (zero valid field keys) yields exactly op=add_readonly_object', () => {
+    const result = buildImplementationChecklist([{ objectName: 'material_extra', fieldKeys: [] }])
+    expect(result.checklist.operations).toEqual([
+      { op: 'add_readonly_object', objectName: 'material_extra', fieldKeys: [] },
+    ])
+  })
+
+  it('draft with >=1 valid field key yields exactly op=add_readonly_field, carrying every valid key', () => {
+    const result = buildImplementationChecklist([{ objectName: 'bom_child', fieldKeys: ['child_qty', 'child_uom'] }])
+    expect(result.checklist.operations).toEqual([
+      { op: 'add_readonly_field', objectName: 'bom_child', fieldKeys: ['child_qty', 'child_uom'] },
+    ])
+  })
+
+  it('one operation per row (never per field key) — multiple rows preserve order', () => {
+    const result = buildImplementationChecklist([
+      { objectName: 'material_extra', fieldKeys: [] },
+      { objectName: 'bom_child', fieldKeys: ['child_qty'] },
+    ])
+    expect(result.checklist.operations).toEqual([
+      { op: 'add_readonly_object', objectName: 'material_extra', fieldKeys: [] },
+      { op: 'add_readonly_field', objectName: 'bom_child', fieldKeys: ['child_qty'] },
+    ])
+  })
+
+  // --- exact-registered enum lock ------------------------------------------------------------------
+  it('every produced op is in the hardcoded ALLOWED_OPS allowlist (mutation gate: a 3rd/write-shaped op fails this)', () => {
+    const result = buildImplementationChecklist([
+      { objectName: 'material_extra', fieldKeys: [] },
+      { objectName: 'bom_child', fieldKeys: ['child_qty'] },
+    ])
+    expect(result.checklist.operations.length).toBeGreaterThan(0)
+    expect(allOpsAreAllowlisted(result.checklist)).toBe(true)
+  })
+
+  it('a draft with an injected op-like field cannot smuggle a write/delete-shaped op — output op is always derived', () => {
+    const hostileDraft = { objectName: 'material_extra', fieldKeys: [], op: 'delete_object' } as unknown as BridgeAgentSuggestionObjectDraft
+    const result = buildImplementationChecklist([hostileDraft])
+    expect(result.checklist.operations).toEqual([
+      { op: 'add_readonly_object', objectName: 'material_extra', fieldKeys: [] },
+    ])
+    expect(allOpsAreAllowlisted(result.checklist)).toBe(true)
+  })
+
+  // --- SAFE_IDENTIFIER gate reuse (independent of buildBridgeAgentChangeSuggestion) ------------------
+  it('reuses the safe-identifier gate independently: invalid object/field names are dropped, only counted', () => {
+    const result = buildImplementationChecklist([
+      { objectName: `password=${SENTINEL_SECRET}`, fieldKeys: [] },
+      { objectName: 'material_extra', fieldKeys: ['field_a', `token=${SENTINEL_SECRET}`] },
+    ])
+    expect(result.invalidObjectCount).toBe(1)
+    expect(result.invalidFieldKeyCount).toBe(1)
+    expect(result.checklist.operations).toEqual([
+      { op: 'add_readonly_field', objectName: 'material_extra', fieldKeys: ['field_a'] },
+    ])
+  })
+
+  // --- SENTINEL: full serialized artifact scan ------------------------------------------------------
+  it('SENTINEL: a secret/host/connection-string planted in a draft name never appears anywhere in the serialized checklist', () => {
+    const result = buildImplementationChecklist([
+      { objectName: SENTINEL_CONNECTION_STRING, fieldKeys: [] },
+      { objectName: SENTINEL_HOST_URL, fieldKeys: [SENTINEL_SECRET] },
+      { objectName: 'material_extra', fieldKeys: ['field_a', SENTINEL_SECRET, SENTINEL_HOST_URL] },
+    ])
+    const serialized = JSON.stringify(result.checklist)
+    expect(serialized).not.toContain(SENTINEL_SECRET)
+    expect(serialized).not.toContain('SENTINEL-PW')
+    expect(serialized).not.toContain('10.0.0.9')
+    expect(serialized).not.toContain(SENTINEL_CONNECTION_STRING)
+    // the two hostile rows (bad object name / bad field keys) are dropped entirely; the one surviving
+    // row is exactly the sanitized entry — no partial/mangled leakage.
+    expect(result.checklist.operations).toEqual([
+      { op: 'add_readonly_field', objectName: 'material_extra', fieldKeys: ['field_a'] },
+    ])
+    expect(result.invalidObjectCount).toBe(2)
+    expect(result.invalidFieldKeyCount).toBe(2)
+  })
+
+  it('never throws on malformed drafts (non-array fieldKeys, non-string names, non-array input)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const drafts = [{ objectName: 123 as any, fieldKeys: 'not-an-array' as any }, null as any, undefined as any]
+    expect(() => buildImplementationChecklist(drafts)).not.toThrow()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => buildImplementationChecklist('not-an-array' as any)).not.toThrow()
   })
 })

--- a/docs/development/bridge-agent-apply1-export-dev-verification-20260708.md
+++ b/docs/development/bridge-agent-apply1-export-dev-verification-20260708.md
@@ -1,0 +1,167 @@
+# BA-APPLY-1 — Bridge Agent 变更建议 → 机读实施清单导出 · 开发/验证报告 — 2026-07-08
+
+> Design-lock: `docs/development/bridge-agent-controlled-apply-design-lock-20260708.md`(#3876）§2 形态
+> A + §1 三条原则 + §4 硬锁。上位锁:`bridge-agent-admin-page-design-lock-20260707.md`(BA-UI-0
+> RATIFIED)。Demand anchor:#3746(保持 OPEN)。Owner 已于 2026-07-08 授权收官后 4 条独立线开发,
+> BA-APPLY-1 为其 #1 优先。
+>
+> **口径提醒**:design-lock 文档头写"状态:PROPOSED,等 owner ratify…authorizes NO RUNTIME"——该行是
+> design-lock 自身发布时的初始状态声明;本次开发的授权渠道是 owner 2026-07-08 的任务派工(4 条线之一,
+> BA-APPLY-1 优先),而非对 design-lock 文档本身的另一次 ratify 动作。本片严格落在 §2 形态 A 的范围内
+> (纯导出/render,零 runtime apply),不越界到形态 B(§2 后端受控 apply,门:BA-APPLY-1 落地 + owner
+> 单独 opt-in,未开)。
+>
+> 本片 = **纯导出/渲染**:把 BA-UI-3 已产出的、已经过 identifier 门控的变更建议草稿,额外渲染成一份
+> **机读**格式(JSON:`{ schemaVersion, operations }`),而不是（或者说,除了）人读的建议文本。**零平台
+> 写路径、零 Agent 写、零新增后端调用、零本机 config 写、零 apply**——这些都是 BA-APPLY-2+(形态 B)
+> 未开的 rung 才会引入的东西。
+
+## 1. 范围与做法(vs design-lock §1/§2/§4 逐条)
+
+| lock 条款 | 实现 |
+| --- | --- |
+| §1 原则 1:只扩只读暴露面,apply 后 Agent 仍 `readonly:true` | 本片不 apply 任何东西;清单的操作枚举本身即被限定为只读扩面动作(见 §3) |
+| §1 原则 2:前端只 PRODUCE 建议,apply 走后端受控通道/运维脚本 handoff | 清单是纯 client 端渲染产物(`buildImplementationChecklist`),无 `fetch`/`apiFetch`,无 service 调用 |
+| §1 原则 3:凭据后端持有,证据 values-free | 清单内容只含对象名/字段键名/操作枚举;不含 host/凭据/取值/自由文本 |
+| §2 形态 A:变更建议 → 机读实施清单导出(values-free);运维受控应用 | `buildImplementationChecklist(drafts) → { checklist: { schemaVersion, operations }, invalidObjectCount, invalidFieldKeyCount }`,组件新增"导出实施清单"按钮 + JSON 预览 + 复制/下载 |
+| §4 硬锁:只读不变式,操作枚举绝不含写/删/可写化 | 操作枚举闭集 `'add_readonly_object' \| 'add_readonly_field'`,`op` 完全由字段数量派生,从不读取调用方输入 |
+
+## 2. 机读实施清单契约(`apps/web/src/services/integration/bridgeAgentConfigCheck.ts`)
+
+```ts
+export type BridgeAgentChecklistOperationKind = 'add_readonly_object' | 'add_readonly_field'
+
+export interface BridgeAgentChecklistOperation {
+  op: BridgeAgentChecklistOperationKind
+  objectName: string
+  fieldKeys: string[]
+}
+
+export interface BridgeAgentImplementationChecklist {
+  schemaVersion: 1
+  operations: BridgeAgentChecklistOperation[]
+}
+
+export function buildImplementationChecklist(
+  drafts: BridgeAgentSuggestionObjectDraft[],
+): { checklist: BridgeAgentImplementationChecklist; invalidObjectCount: number; invalidFieldKeyCount: number }
+```
+
+- **输入**:与 `buildBridgeAgentChangeSuggestion` 完全相同的 `drafts: { objectName, fieldKeys }[]`
+  ——操作员键入的对象名 + 字段名(仅名称)。**不是**从 `buildBridgeAgentChangeSuggestion` 的输出接力
+  (即不吃已过滤的 `entries`),而是独立地重新应用同一个安全标识符门(`filterSafeSuggestionDrafts`,
+  下方"门复用"一节)——这样即便调用方误传未过滤的原始草稿,这个函数自己也不会把敌意名称带进清单。
+- **序列化/复制/下载出去的产物,精确等于** `result.checklist`(即 `{ schemaVersion, operations }`
+  两个字段),**不含** `invalidObjectCount`/`invalidFieldKeyCount`(那两个计数只留给调用方做 UI 判断,
+  从不进入导出内容),**不含**任何 `targetLabel`/`system.name`/自由文本——与人读建议文本
+  (`buildBridgeAgentChangeSuggestion` 的 `text`,含"目标实例:…"抬头行)刻意不同,机读清单更严格。
+- **操作枚举派生规则(exact-registered,精确到字面量)**:
+  - 一条草稿的有效字段名(经安全标识符过滤)数量为 0 → `op: 'add_readonly_object'`,
+    `fieldKeys: []`。
+  - 一条草稿的有效字段名数量 ≥ 1 → `op: 'add_readonly_field'`,`fieldKeys` 携带该行**全部**有效
+    字段名(不是每字段一条操作——一行草稿只产出一条操作,`fieldKeys` 是数组)。
+  - `op` **完全由"该行是否有有效字段名"这个布尔派生**,`BridgeAgentSuggestionObjectDraft` 本身没有
+    `op` 字段——调用方(包括恶意/被篡改的草稿对象)不可能通过输入注入第三种或写/删/可写化的操作字面量
+    (mutation 证明见 §7)。
+- **门复用**:新增私有辅助 `filterSafeSuggestionDrafts(drafts)` 从 `buildBridgeAgentChangeSuggestion`
+  的内联逻辑中提炼出来,现在是**唯一**一处安全标识符过滤实现,`buildBridgeAgentChangeSuggestion` 与
+  `buildImplementationChecklist` 都调用它——不再有两份重复的过滤逻辑各自维护。提炼后先跑一遍既有 65
+  个 `bridgeAgentConfigCheck.spec.ts` 测试确认逐字节行为不变,再在其上叠加清单相关测试。
+
+## 3. 组件接线(`apps/web/src/components/integration/IntegrationBridgeAgentSection.vue`)
+
+- 新增按钮 `data-testid="bridge-agent-checklist-export"`("导出实施清单"/"Export implementation
+  checklist"),点击切换 `checklistVisible`,按钮文案随之切换为"收起实施清单"/"Hide implementation
+  checklist"——与既有"查看/收起 schema"toggle 模式一致。
+- 该按钮 + 展开内容是**建议卡的兄弟节点**(不是嵌套在人读建议文本的 `v-else` 分支内),独立于
+  `suggestionResult.entries.length` 门控——有自己的 IU-6 guided-empty 态
+  (`bridge-agent-checklist-empty` / `-empty-what` / `-empty-first-step`),在
+  `implementationChecklist.checklist.operations.length === 0` 时渲染,而不是复用建议卡的空态。
+- 展开后:只读 `<textarea data-testid="bridge-agent-checklist-text">` 展示
+  `JSON.stringify(checklist, null, 2)`;"复制清单 JSON"按钮(`bridge-agent-checklist-copy`,复用
+  `navigator.clipboard.writeText` 同一套失败兜底模式,`bridge-agent-checklist-copy-state` 显示
+  已复制/复制失败);"下载清单 JSON"按钮(`bridge-agent-checklist-download`,`Blob` +
+  `URL.createObjectURL` + 隐藏 `<a download>` 点击 + `URL.revokeObjectURL`,文件名仅含固定前缀 +
+  客户端 `Date.now()` 时间戳,不含系统名/配置值)。
+- `implementationChecklist` computed 直接从 `suggestionDrafts`(与 `suggestionResult` 相同的输入源)
+  重新构建 `BridgeAgentSuggestionObjectDraft[]` 并调用 `buildImplementationChecklist`——不吃
+  `suggestionResult.value.entries`,保持"独立重新过滤"的纵深防御与纯 util 层的契约一致。
+- 样式:复用既有 `.integration-workbench__button` / `.integration-workbench__empty` /
+  `.integration-workbench__hint` / `.bridge-agent__suggestion-output` / `.bridge-agent__suggestion-text`
+  类(与人读建议卡的输出块外观一致),仅新增一个无样式规则的 `.bridge-agent__checklist-export` 包裹
+  div(布局用,不含新 CSS 声明)——`IntegrationBridgeAgentSection.vue` 已在
+  `ui-foundation-style-guard.spec.ts` 的 `TARGET_FILES` 中,本片未新增 `.vue` 文件,故无需改动该清单。
+
+## 4. 零写路径确认(vs design-lock §4 硬锁逐条)
+
+| 检查点 | 状态 | 证据 |
+| --- | --- | --- |
+| 无 apply 端点调用 | ✅ | `buildImplementationChecklist` 是纯函数,无 `fetch`/`apiFetch`;组件新增的三个按钮处理函数(`toggleChecklist`/`copyChecklistText`/`downloadChecklistJson`)均不调用任何 service 函数 |
+| 无 Agent 写 | ✅ | 全仓搜索确认本片零涉及 `bridge-agent-readonly-adapter.cjs`、`scripts/ops/bridge-agent-readonly*.ps1`、`plugins/plugin-integration-core/**`(本片零后端改动) |
+| 无本机 config 写 | ✅ | 下载/复制均为浏览器本地动作(Blob/clipboard),不写任何服务器状态;`downloadChecklistJson` 仅创建一个客户端 `<a>` 下载,不触达后端 |
+| 只读不变式(操作枚举绝不含写/删/可写化) | ✅ | 闭集类型 `'add_readonly_object' \| 'add_readonly_field'`;`op` 完全派生,mutation 证明见 §7 |
+| SAFE_IDENTIFIER 门复用(敌意名称不进清单) | ✅ | `filterSafeSuggestionDrafts` 单一实现,两个 builder 共用;§6 SENTINEL 覆盖清单序列化后的完整字符串 |
+| 序列化产物无 targetLabel/系统名/自由文本 | ✅ | `checklist` 只有 `schemaVersion`/`operations` 两个键(测试断言 `Object.keys(...).sort()`) |
+
+## 5. 测试矩阵
+
+| 面 | 文件 | 数量 | 备注 |
+| --- | --- | --- | --- |
+| 纯 util(既有 65 + 新增 10:契约形状/两个派生分支字面量/多行顺序/枚举白名单/注入 op 防御/门复用/SENTINEL 全序列化扫描/never-throws) | `apps/web/tests/bridgeAgentConfigCheck.spec.ts` | 75 | 既有 65 个测试逐字节不变(门提炼重构后先跑绿confirm,再叠加) |
+| 组件(既有 32 + 新增 8:toggle 可见性/JSON 精确渲染/object-only 分支/加删行反映/SENTINEL/复制成功/复制失败兜底/下载 Blob+anchor+revoke) | `apps/web/tests/IntegrationBridgeAgentSection.spec.ts` | 40 | 既有 32 个测试保持 ADD-ONLY 不变 |
+| integration-guard 全 34 文件已收编列表(两个源文件均已在既有 `run:` 行与两个 `paths:` 块中,零 workflow 改动) | `.github/workflows/integration-guard.yml` | 483 | 全绿(34 files / 483 tests) |
+| `ui-foundation-style-guard`(未新增 `.vue`,`TARGET_FILES` 无需改动) | `apps/web/tests/ui-foundation-style-guard.spec.ts` | 83 | ✅ |
+| `vue-tsc -b` | — | — | ✅ clean |
+| `pnpm --filter @metasheet/web build` | — | — | ✅ built |
+| `pnpm --filter @metasheet/web exec eslint <两个改动源文件>` | — | — | ✅ 0 errors(该两文件不在 `apps/web` 的 `lint` 脚本显式文件列表内,手动跑作为额外确认) |
+
+CI 面:`.github/workflows/integration-guard.yml` 的 `pull_request`/`push` 两个 `paths:` 块与**唯一**的
+`run:` vitest 列表**已经**包含 `bridgeAgentConfigCheck.ts`/`.spec.ts` 与
+`IntegrationBridgeAgentSection.vue`/`.spec.ts`(BA-UI-3 落地时收编)——本片只编辑既有文件、未新增文件,
+因此本次**零 workflow 改动**;新增的测试用例随既有文件名自动纳入 CI。
+
+## 6. SENTINEL 覆盖
+
+| 面 | 载体 | 断言 |
+| --- | --- | --- |
+| 纯 util:清单构建(`bridgeAgentConfigCheck.spec.ts`) | 草稿 `objectName` 为连接串/host URL,`fieldKeys` 含密钥字符串;混入一条合法草稿 | 对 `JSON.stringify(result.checklist)` 的**完整序列化字符串**断言不含 sentinel/host 片段/连接串,且存活的一行恰好是被净化后的合法条目(无部分/损坏残留) |
+| 纯 util:注入 op 防御(`bridgeAgentConfigCheck.spec.ts`) | 手工构造带 `op: 'delete_object'` 字段的敌意草稿对象(绕过 TS 类型用 `as unknown as`) | 输出的 `op` 依旧是派生值 `add_readonly_object`,证明调用方输入无法覆盖派生逻辑 |
+| 组件 DOM:导出面板(`IntegrationBridgeAgentSection.spec.ts`) | 操作员在真实输入框键入 `password=SENTINEL...` 作为对象名,以及合法对象名 + `token=SENTINEL...` 混入字段名 | 敌意对象名整行被丢弃(退回 guided-empty 态,`bridge-agent-checklist-text` 不存在);合法行的 JSON 精确等于净化后的期望值,`root.textContent` 全文不含 sentinel |
+| 组件 DOM:复制/下载载荷 | 复制到 mock 剪贴板、下载到 mock Blob 的内容 | 对 `writeText` 的调用参数与下载 Blob 的文本内容分别 `JSON.parse` 后做精确 `toEqual`,两处均只含派生后的 add_readonly_* 操作,不含任何 sentinel |
+
+## 7. Mutation 证明(操作枚举硬锁)
+
+| # | 变体 | 预期 | 结果 |
+| --- | --- | --- | --- |
+| M1 | 把 `buildImplementationChecklist` 内 `op` 派生表达式的 object-only 分支从 `'add_readonly_object'` 改为 `('delete_object' as BridgeAgentChecklistOperationKind)`(强制类型断言绕过 TS,模拟一次把只读扩面操作误改成写/删操作的回归) | 操作枚举白名单测试 + 派生分支字面量测试 + 注入防御测试均应变红 | **RED**:4 个测试失败——`every produced op is in the hardcoded ALLOWED_OPS allowlist`、`object-only draft … yields exactly op=add_readonly_object`、`a draft with an injected op-like field …`、`SENTINEL: …`(该 sentinel 测试的存活行恰好是 object-only 分支,因此也踩中)——ALLOWED_OPS 硬编码在测试文件里(不从源码 import),即使源码的类型联合也被一并改掉,测试依旧能感知字面量层面的漂移 ✅ killed |
+
+### 7.1 执行记录
+
+变体注入 → `pnpm --filter @metasheet/web exec vitest run bridgeAgentConfigCheck` 确认 **RED**(4
+failed / 71 passed)→ 用备份文件精确还原
+`apps/web/src/services/integration/bridgeAgentConfigCheck.ts`(未触碰同一提交里的任何其它文件)→
+重跑 `bridgeAgentConfigCheck` + `IntegrationBridgeAgentSection` 两个 spec 确认 **GREEN**(75 + 40 =
+115/115)。基线在 mutation **之前**已完成本次全部实现改动(工作树完整改动),mutation 与 revert 均只
+针对这一个文件,未使用任何整仓级 `checkout -- .`。
+
+## 8. 改动清单
+
+| 文件 | 类型 |
+| --- | --- |
+| `apps/web/src/services/integration/bridgeAgentConfigCheck.ts` | 编辑(提炼共享安全标识符门 `filterSafeSuggestionDrafts` + 新增 `buildImplementationChecklist`/操作枚举类型/清单类型) |
+| `apps/web/src/components/integration/IntegrationBridgeAgentSection.vue` | 编辑(ADD-ONLY:新增"导出实施清单"按钮 + JSON 预览 + 复制/下载,复用既有样式类;import 新增 `buildImplementationChecklist`) |
+| `apps/web/tests/bridgeAgentConfigCheck.spec.ts` | 编辑(ADD-ONLY:新增 `buildImplementationChecklist` describe 块,10 tests) |
+| `apps/web/tests/IntegrationBridgeAgentSection.spec.ts` | 编辑(ADD-ONLY:新增 8 个组件测试 + zh 断言追加到既有 zh 测试 + 新增 `readBlobText` 测试辅助函数) |
+| `docs/development/bridge-agent-apply1-export-dev-verification-20260708.md` | 新增(本文) |
+
+`.github/workflows/integration-guard.yml` **未改动**——两个源文件均已在既有 `paths:`/`run:` 收编中
+(BA-UI-3 落地时已收编)。
+
+## 9. 边界外(维持冻结)
+
+BA-APPLY-2(形态 B:后端受控 config-apply 端点、审批门、只读 allowlist 白名单写轨)与 BA-APPLY-3(apply
+后自动复探测)均未开,门:BA-APPLY-1 落地 + owner 单独 opt-in。本片没有新增/编辑任何后端路由、
+Agent/adapter 行为、凭据路径——`plugins/plugin-integration-core/**` 未被触碰。design-lock §2 形态 A
+"运维受控应用"这句话维持字面意义:本片生成的机读清单没有任何程序化的落地路径,复制/下载之后如何应用、
+何时应用完全是运维人工决定(交给受控后端或既有 `scripts/ops/bridge-agent-readonly.ps1` 的一个后续、
+未开的环节)。


### PR DESCRIPTION
## Summary

- Implements BA-APPLY-1 (form A, lowest risk) per `docs/development/bridge-agent-controlled-apply-design-lock-20260708.md` §2 形态 A: renders BA-UI-3's existing, already-identifier-gated change-suggestion drafts as a machine-readable, values-free implementation checklist — `buildImplementationChecklist(drafts) → { checklist: { schemaVersion, operations }, invalidObjectCount, invalidFieldKeyCount }`. Operation enum is exact-registered and closed: `add_readonly_object` / `add_readonly_field` only, derived purely from field-key presence (never read off caller input).
- Extracts a shared `filterSafeSuggestionDrafts` gate (the same safe-identifier logic `buildBridgeAgentChangeSuggestion` already used) so both the prose suggestion and the new JSON checklist independently re-apply the same drop-and-count discipline — no trust dependency between the two builders.
- Component (`IntegrationBridgeAgentSection.vue`): ADD-ONLY "导出实施清单" / "Export implementation checklist" toggle button on the existing suggestion card (sibling to the prose output, own guided-empty state), JSON preview textarea, copy button (reuses the existing clipboard pattern), and a download button (Blob + `createObjectURL` + hidden anchor, values-free filename).
- **Zero platform write / zero Agent write / zero backend endpoint / zero apply** — this is an export/render only. Apply is a later, unopened BA-APPLY-2+ rung (design-lock §2 形态 B).

## Test plan

- [x] Pure util spec (`bridgeAgentConfigCheck.spec.ts`, 65→75 tests): contract shape (`{schemaVersion, operations}` exactly, no counts/labels), both op-derivation branches asserted by literal, one-op-per-row ordering, hardcoded-in-test `ALLOWED_OPS` allowlist scan, injected-`op` smuggling defense, gate-reuse (independent re-filtering), SENTINEL scan of the full serialized JSON string, never-throws on malformed input.
- [x] Component spec (`IntegrationBridgeAgentSection.spec.ts`, 32→40 tests, ADD-ONLY): toggle visibility + label flip, guided empty state, live JSON generation matching input, add/remove-row reflection, SENTINEL (secret-shaped names dropped from DOM), copy success + clipboard-missing fallback, download (createObjectURL/anchor click/revoke + Blob content), zh-CN label + JSON assertions.
- [x] Refactor safety: ran `bridgeAgentConfigCheck.spec.ts` immediately after extracting the shared gate helper, before adding new code on top — byte-identical pass (65/65).
- [x] **Mutation proof**: hand-mutated the object-only op literal to a write-shaped `'delete_object'` — 4 tests went RED (allowlist scan, per-branch literal, injection-defense, sentinel-surviving-row), confirming the operation-enum lock is load-bearing; reverted, re-confirmed green (115/115).
- [x] Full `integration-guard.yml` unioned vitest list (both touched source files were already registered pre-existing — zero workflow diff needed): 34 files / 483 tests green.
- [x] `pnpm --filter plugin-integration-core test`: green (unaffected, zero backend changes).
- [x] `vue-tsc -b`: clean.
- [x] `pnpm --filter @metasheet/web build`: OK.
- [x] `eslint` on both touched source files (manual, since neither is in `apps/web`'s explicit lint file list): 0 errors.

Verification MD: `docs/development/bridge-agent-apply1-export-dev-verification-20260708.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)