### PR TITLE
fix(dingtalk): delivery hygiene — strict robot response, rule indexes, length guards (DT-HARDEN-08)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260708090000_add_delivery_rule_indexes.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260708090000_add_delivery_rule_indexes.ts
@@ -1,0 +1,28 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * DT-HARDEN-08 — delivery telemetry indexes.
+ *
+ * Both dingtalk-group-delivery-service.ts and dingtalk-person-delivery-service.ts
+ * list deliveries with `WHERE automation_rule_id = $1 ORDER BY created_at DESC
+ * LIMIT $2`. Neither dingtalk_group_deliveries nor dingtalk_person_deliveries has
+ * an index covering that filter+sort shape (only destination_id/local_user_id and
+ * source_type are indexed), so those list queries fall back to a sequential scan
+ * as delivery history grows. Add the missing composite indexes.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_group_deliveries_rule_created_at
+    ON dingtalk_group_deliveries(automation_rule_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_person_deliveries_rule_created_at
+    ON dingtalk_person_deliveries(automation_rule_id, created_at DESC)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_person_deliveries_rule_created_at`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_group_deliveries_rule_created_at`.execute(db)
+}

--- a/packages/core-backend/src/integrations/dingtalk/robot.ts
+++ b/packages/core-backend/src/integrations/dingtalk/robot.ts
@@ -75,12 +75,19 @@ export function buildSignedDingTalkWebhookUrl(baseUrl: string, secret?: string):
 }
 
 export function validateDingTalkRobotResponse(payload: unknown): void {
-  const data = payload as DingTalkRobotResponse | null
-  if (!data || typeof data !== 'object') return
-  const errcode = typeof data.errcode === 'number' ? data.errcode : 0
-  if (errcode === 0) return
+  // A malformed/unparseable body (e.g. a proxy intercepting the webhook and
+  // returning a 200 HTML page instead of DingTalk's JSON) must NOT be treated
+  // as success — require a real object with a numeric errcode of exactly 0.
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new DingTalkRobotResponseError('DingTalk robot response was not a valid JSON object')
+  }
+  const data = payload as DingTalkRobotResponse
+  if (typeof data.errcode === 'number' && data.errcode === 0) return
   const errmsg = typeof data.errmsg === 'string' && data.errmsg.trim().length > 0
     ? data.errmsg.trim()
     : 'DingTalk robot request failed'
-  throw new DingTalkRobotResponseError(`DingTalk errcode ${errcode}: ${errmsg}`)
+  const errcodeDisplay = typeof data.errcode === 'number'
+    ? String(data.errcode)
+    : JSON.stringify((data as Record<string, unknown>).errcode)
+  throw new DingTalkRobotResponseError(`DingTalk errcode ${errcodeDisplay}: ${errmsg}`)
 }

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -87,6 +87,13 @@ function maxWebhookRetries(): number {
 }
 const DINGTALK_PERSON_BATCH_SIZE = 100
 const DINGTALK_FAILURE_ALERT_CONTENT_LIMIT = 1_000
+// DingTalk group/person message limits: robot markdown title tops out around
+// 128 chars and markdown body around 20000 chars upstream. A rendered
+// template that exceeds either would otherwise be rejected (or silently
+// mangled) by DingTalk outright; truncate with an ellipsis so delivery still
+// goes through instead of failing on oversized input.
+const DINGTALK_MESSAGE_TITLE_MAX_LENGTH = 128
+const DINGTALK_MESSAGE_BODY_MAX_LENGTH = 20_000
 const SAFE_PARALLEL_BRANCH_KEY = /^[A-Za-z0-9_-]{1,64}$/
 const MAX_PARALLEL_BRANCHES = 10
 const MAX_PARALLEL_BRANCH_ACTIONS = 20
@@ -339,6 +346,27 @@ function stringifyResponseBody(payload: unknown, fallback: string | null = null)
   } catch {
     return fallback
   }
+}
+
+export function truncateDingTalkMessageText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value
+  if (maxLength <= 1) return value.slice(0, maxLength)
+  return `${value.slice(0, maxLength - 1)}…`
+}
+
+/**
+ * Assemble the message body + its 快捷入口 link block within DingTalk's body limit.
+ * The link block is the actionable part of the message, so it gets its budget first
+ * and the rendered body absorbs the truncation — truncating the assembled string
+ * instead would silently drop the links whenever a template body ran long.
+ */
+export function composeDingTalkBodyWithLinks(renderedBody: string, linkLines: string[]): string {
+  const linkSection = linkLines.length > 0 ? ['**快捷入口**', ...linkLines].join('\n') : ''
+  const separatorLength = linkSection && renderedBody ? 2 : 0
+  const bodyBudget = Math.max(0, DINGTALK_MESSAGE_BODY_MAX_LENGTH - linkSection.length - separatorLength)
+  return [truncateDingTalkMessageText(renderedBody, bodyBudget), linkSection]
+    .filter(Boolean)
+    .join('\n\n')
 }
 
 function redactDingTalkFailureAlertText(value: unknown): string {
@@ -2831,12 +2859,12 @@ export class AutomationExecutor {
       actorId: context.actorId ?? '',
       record: context.recordData,
     }
-    const renderedTitle = renderAutomationTemplate(titleTemplate, templateData).trim()
+    const renderedTitle = truncateDingTalkMessageText(
+      renderAutomationTemplate(titleTemplate, templateData).trim(),
+      DINGTALK_MESSAGE_TITLE_MAX_LENGTH,
+    )
     const renderedBody = renderAutomationTemplate(bodyTemplate, templateData).trim()
-    const bodyWithLinks = [
-      renderedBody,
-      linkLines.length > 0 ? ['**快捷入口**', ...linkLines].join('\n') : '',
-    ].filter(Boolean).join('\n\n')
+    const bodyWithLinks = composeDingTalkBodyWithLinks(renderedBody, linkLines)
 
     let memberGroupUserIds: string[] = []
     if (memberGroupIds.length > 0) {
@@ -3336,12 +3364,12 @@ export class AutomationExecutor {
       actorId: context.actorId ?? '',
       record: context.recordData,
     }
-    const renderedTitle = renderAutomationTemplate(titleTemplate, templateData).trim()
+    const renderedTitle = truncateDingTalkMessageText(
+      renderAutomationTemplate(titleTemplate, templateData).trim(),
+      DINGTALK_MESSAGE_TITLE_MAX_LENGTH,
+    )
     const renderedBody = renderAutomationTemplate(bodyTemplate, templateData).trim()
-    const bodyWithLinks = [
-      renderedBody,
-      linkLines.length > 0 ? ['**快捷入口**', ...linkLines].join('\n') : '',
-    ].filter(Boolean).join('\n\n')
+    const bodyWithLinks = composeDingTalkBodyWithLinks(renderedBody, linkLines)
     const orderedDestinations = destinationIds
       .map((id) => destinationsById.get(id))
       .filter((destination): destination is NonNullable<typeof destination> => Boolean(destination))

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { evaluateCondition, evaluateConditions, type AutomationCondition, type ConditionGroup } from '../../src/multitable/automation-conditions'
-import { AutomationExecutor, type AutomationRule, type AutomationDeps, type AutomationExecution } from '../../src/multitable/automation-executor'
+import { AutomationExecutor, truncateDingTalkMessageText, type AutomationRule, type AutomationDeps, type AutomationExecution } from '../../src/multitable/automation-executor'
 import { AutomationScheduler, cronHasNoMatchingDay, nextCronOccurrenceMs, parseCronToIntervalMs } from '../../src/multitable/automation-scheduler'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, ALL_TRIGGER_TYPES } from '../../src/multitable/automation-triggers'
 import type { AutomationTrigger, AutomationTriggerType } from '../../src/multitable/automation-triggers'
@@ -1089,6 +1089,53 @@ describe('AutomationExecutor', () => {
     expect(payload.markdown.text).toContain('允许范围：所有已绑定钉钉的本地用户可填写')
   })
 
+  it('truncates an oversized title/body before sending a group message instead of failing delivery', async () => {
+    process.env.APP_BASE_URL = 'https://app.example.com'
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const oversizedTitle = 'T'.repeat(200)
+    const oversizedBody = 'B'.repeat(25_000)
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: oversizedTitle,
+          bodyTemplate: oversizedBody,
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    const [, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    const payload = JSON.parse(init.body as string)
+    // 128-char title cap, ellipsis-terminated (never the raw 200-char input).
+    expect(payload.markdown.title.length).toBe(128)
+    expect(payload.markdown.title.endsWith('…')).toBe(true)
+    expect(payload.markdown.title).not.toBe(oversizedTitle)
+    // 20000-char body cap, ellipsis-terminated (never the raw 25000-char input).
+    expect(payload.markdown.text.endsWith('…')).toBe(true)
+    expect(payload.markdown.text.length).toBeLessThan(oversizedBody.length)
+    expect(payload.markdown.text.length).toBeLessThan(20_200)
+  })
+
   it('fails send_dingtalk_group_message when destination is missing', async () => {
     const queryFn = vi.fn(async () => ({ rows: [] }))
     deps = createMockDeps({ queryFn })
@@ -1382,6 +1429,62 @@ describe('AutomationExecutor', () => {
 
     // Partial success is reported as a partial result.
     expect(result.steps[0]?.output).toMatchObject({ notifiedUsers: 100, failedRecipientCount: 50 })
+  })
+
+  it('truncates an oversized title/body before sending a person message instead of failing delivery', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+    process.env.APP_BASE_URL = 'https://app.example.com'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ local_user_id: 'user_1', local_user_active: true, dingtalk_user_id: 'dt-user-1' }],
+      })
+      .mockResolvedValue({ rows: [] })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const oversizedTitle = 'T'.repeat(200)
+    const oversizedBody = 'B'.repeat(25_000)
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: ['user_1'],
+          titleTemplate: oversizedTitle,
+          bodyTemplate: oversizedBody,
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    const [, sendInit] = findDingTalkPersonSend(fetchFn)
+    const payload = JSON.parse(sendInit.body as string)
+    // 128-char title cap, ellipsis-terminated (never the raw 200-char input).
+    expect(payload.msg.markdown.title.length).toBe(128)
+    expect(payload.msg.markdown.title.endsWith('…')).toBe(true)
+    expect(payload.msg.markdown.title).not.toBe(oversizedTitle)
+    // 20000-char body cap, ellipsis-terminated (never the raw 25000-char input).
+    expect(payload.msg.markdown.text.endsWith('…')).toBe(true)
+    expect(payload.msg.markdown.text.length).toBeLessThan(oversizedBody.length)
+    expect(payload.msg.markdown.text.length).toBeLessThan(20_200)
   })
 
   it('fails send_dingtalk_person_message when the internal processing view is not in the sheet', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-breach-channel.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-breach-channel.test.ts
@@ -99,6 +99,34 @@ describe('ApprovalBreachDingTalkChannel', () => {
     expect(result.error).toContain('keyword not in content')
   })
 
+  it('treats a malformed 200 response (e.g. proxy-hijacked HTML) as a failure, not success', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '<html><head><title>Captive Portal</title></head><body>Sign in to continue</body></html>',
+    } as unknown as Response) as unknown as typeof fetch
+
+    const channel = new ApprovalBreachDingTalkChannel({ webhookUrl: VALID_WEBHOOK, fetchFn })
+    const result = await channel.send(sampleMessage())
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+
+  it('treats a string errcode (not a number) as a failure', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '{"errcode":"0","errmsg":"ok"}',
+    } as unknown as Response) as unknown as typeof fetch
+
+    const channel = new ApprovalBreachDingTalkChannel({ webhookUrl: VALID_WEBHOOK, fetchFn })
+    const result = await channel.send(sampleMessage())
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+
   it('captures network errors without throwing', async () => {
     const fetchFn = vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')) as unknown as typeof fetch
     const channel = new ApprovalBreachDingTalkChannel({ webhookUrl: VALID_WEBHOOK, fetchFn })

--- a/packages/core-backend/tests/unit/dingtalk-delivery-rule-indexes-migration.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-delivery-rule-indexes-migration.test.ts
@@ -1,0 +1,35 @@
+import * as path from 'path'
+import { promises as fs } from 'fs'
+import { describe, expect, it } from 'vitest'
+import * as migration from '../../src/db/migrations/zzzz20260708090000_add_delivery_rule_indexes'
+
+const MIGRATION_PATH = path.join(
+  __dirname,
+  '../../src/db/migrations/zzzz20260708090000_add_delivery_rule_indexes.ts',
+)
+
+describe('zzzz20260708090000_add_delivery_rule_indexes migration', () => {
+  it('exports reversible up/down functions taking a single db argument', () => {
+    expect(typeof migration.up).toBe('function')
+    expect(typeof migration.down).toBe('function')
+    expect(migration.up.length).toBe(1)
+    expect(migration.down.length).toBe(1)
+  })
+
+  it('up() creates a composite (automation_rule_id, created_at DESC) index on each delivery table', async () => {
+    const content = await fs.readFile(MIGRATION_PATH, 'utf-8')
+
+    expect(content).toContain('idx_dingtalk_group_deliveries_rule_created_at')
+    expect(content).toContain('ON dingtalk_group_deliveries(automation_rule_id, created_at DESC)')
+    expect(content).toContain('idx_dingtalk_person_deliveries_rule_created_at')
+    expect(content).toContain('ON dingtalk_person_deliveries(automation_rule_id, created_at DESC)')
+    expect(content).toContain('CREATE INDEX IF NOT EXISTS')
+  })
+
+  it('down() drops both indexes with IF EXISTS', async () => {
+    const content = await fs.readFile(MIGRATION_PATH, 'utf-8')
+
+    expect(content).toContain('DROP INDEX IF EXISTS idx_dingtalk_group_deliveries_rule_created_at')
+    expect(content).toContain('DROP INDEX IF EXISTS idx_dingtalk_person_deliveries_rule_created_at')
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-message-length-guard.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-message-length-guard.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  composeDingTalkBodyWithLinks,
+  truncateDingTalkMessageText,
+} from '../../src/multitable/automation-executor'
+
+const BODY_MAX = 20_000
+
+describe('DT-HARDEN-08 DingTalk message length guards', () => {
+  describe('truncateDingTalkMessageText', () => {
+    it('leaves text within the limit untouched', () => {
+      expect(truncateDingTalkMessageText('hello', 10)).toBe('hello')
+      expect(truncateDingTalkMessageText('hello', 5)).toBe('hello')
+    })
+
+    it('truncates with an ellipsis and never exceeds the limit', () => {
+      const out = truncateDingTalkMessageText('abcdefghij', 5)
+      expect(out).toBe('abcd…')
+      expect(out.length).toBe(5)
+    })
+
+    it('degrades safely at pathological limits', () => {
+      expect(truncateDingTalkMessageText('abc', 1)).toBe('a')
+      expect(truncateDingTalkMessageText('abc', 0)).toBe('')
+    })
+  })
+
+  describe('composeDingTalkBodyWithLinks', () => {
+    const links = ['[打开记录](https://example.test/r/1)', '[查看视图](https://example.test/v/2)']
+
+    it('keeps body and links intact when within the limit', () => {
+      const out = composeDingTalkBodyWithLinks('short body', links)
+      expect(out).toContain('short body')
+      expect(out).toContain('**快捷入口**')
+      for (const link of links) expect(out).toContain(link)
+    })
+
+    it('preserves the link block when the body overflows (links are the actionable part)', () => {
+      // Truncating the ASSEMBLED string — the pre-fix behavior — would have cut the
+      // links off entirely, silently shipping a card nobody can act on.
+      const out = composeDingTalkBodyWithLinks('x'.repeat(BODY_MAX + 5_000), links)
+      expect(out.length).toBeLessThanOrEqual(BODY_MAX)
+      expect(out).toContain('**快捷入口**')
+      for (const link of links) expect(out).toContain(link)
+      expect(out).toContain('…')
+    })
+
+    it('emits body only when there are no links', () => {
+      expect(composeDingTalkBodyWithLinks('just body', [])).toBe('just body')
+    })
+
+    it('emits the link block alone when the body is empty', () => {
+      const out = composeDingTalkBodyWithLinks('', links)
+      expect(out.startsWith('**快捷入口**')).toBe(true)
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-robot-response.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-robot-response.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DingTalkRobotResponseError,
+  validateDingTalkRobotResponse,
+} from '../../src/integrations/dingtalk/robot'
+
+describe('validateDingTalkRobotResponse', () => {
+  it('accepts a genuine success body (numeric errcode 0)', () => {
+    expect(() => validateDingTalkRobotResponse({ errcode: 0, errmsg: 'ok' })).not.toThrow()
+  })
+
+  it('accepts a success body with no errmsg', () => {
+    expect(() => validateDingTalkRobotResponse({ errcode: 0 })).not.toThrow()
+  })
+
+  it('rejects a non-zero numeric errcode', () => {
+    expect(() => validateDingTalkRobotResponse({ errcode: 310000, errmsg: 'keyword not in content' }))
+      .toThrow(DingTalkRobotResponseError)
+    expect(() => validateDingTalkRobotResponse({ errcode: 310000, errmsg: 'keyword not in content' }))
+      .toThrow(/310000/)
+  })
+
+  it('rejects null (e.g. a 200 HTML page from a hijacking proxy that failed JSON parsing)', () => {
+    expect(() => validateDingTalkRobotResponse(null)).toThrow(DingTalkRobotResponseError)
+  })
+
+  it('rejects undefined', () => {
+    expect(() => validateDingTalkRobotResponse(undefined)).toThrow(DingTalkRobotResponseError)
+  })
+
+  it('rejects a raw string body (unparsed HTML/text, not a JSON object)', () => {
+    expect(() => validateDingTalkRobotResponse('<html><body>captive portal</body></html>')).toThrow(DingTalkRobotResponseError)
+  })
+
+  it('rejects a JSON array body', () => {
+    expect(() => validateDingTalkRobotResponse([])).toThrow(DingTalkRobotResponseError)
+  })
+
+  it('rejects a body with a string errcode instead of a number', () => {
+    expect(() => validateDingTalkRobotResponse({ errcode: '0', errmsg: 'ok' })).toThrow(DingTalkRobotResponseError)
+  })
+
+  it('rejects a body with no errcode field at all', () => {
+    expect(() => validateDingTalkRobotResponse({ errmsg: 'ok' })).toThrow(DingTalkRobotResponseError)
+  })
+
+  it('rejects an empty object body', () => {
+    expect(() => validateDingTalkRobotResponse({})).toThrow(DingTalkRobotResponseError)
+  })
+})


### PR DESCRIPTION
Three independent delivery-hygiene fixes.

1. **Robot response validation**: a malformed 200 (proxy-hijacked HTML, non-object body) or a *string* `errcode` was recorded as a **successful send**. Now requires a real object with numeric `errcode === 0`.
2. **Delivery telemetry indexes**: both list services do `WHERE automation_rule_id = $1 ORDER BY created_at DESC` with no covering index → sequential scans as history grows. Adds `(automation_rule_id, created_at DESC)` on `dingtalk_group_deliveries` and `dingtalk_person_deliveries` (additive, `IF NOT EXISTS`, reversible).
3. **Message length guards**: titles/bodies are truncated with an ellipsis. The 快捷入口 link block is budgeted **first** (`composeDingTalkBodyWithLinks`) — truncating the assembled string would have silently dropped the links, i.e. shipped a card nobody can act on.

**Verification**: 248 unit tests pass across automation-v1, breach-channel, robot-response, migration, both delivery services, and the new length-guard suite; `tsc --noEmit` clean.

Retention sweep deliberately out of this slice (needs scheduler wiring).

Roadmap: DT-HARDEN-08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)