### PR TITLE
fix(dingtalk): encrypt group-robot credentials at rest (DT-HARDEN-03)

### DIFF
--- a/packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts
+++ b/packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts
@@ -46,6 +46,8 @@ export interface BackfillOptions {
 export interface BackfillResult {
   encrypted: number
   alreadyEncrypted: number
+  /** Rows whose value changed between this script's SELECT and its UPDATE — left untouched. */
+  skippedConcurrent: number
   total: number
 }
 
@@ -106,6 +108,7 @@ export async function runBackfill(pool: QueryablePool, options: BackfillOptions)
 
   let encrypted = 0
   let alreadyEncrypted = 0
+  let skippedConcurrent = 0
 
   for (const row of rows) {
     const webhookNeedsEncrypting = !isEncryptedSecretValue(row.webhook_url)
@@ -118,27 +121,42 @@ export async function runBackfill(pool: QueryablePool, options: BackfillOptions)
       continue
     }
 
-    encrypted += 1
     if (options.dryRun) {
+      encrypted += 1
       console.log(`[dry-run] would encrypt destination ${row.id} (webhook=${webhookNeedsEncrypting}, secret=${secretNeedsEncrypting})`)
       continue
     }
 
-    await pool.query(
+    // Compare-and-swap on the exact values this run read: a credential rotated by an
+    // admin between the SELECT and this UPDATE must NOT be overwritten with the
+    // re-encryption of the stale value we are holding. (Encrypt-on-write means the
+    // concurrent writer already stored ciphertext — the row no longer needs us.)
+    const updated = await pool.query<{ id: string }>(
       `UPDATE dingtalk_group_destinations
           SET webhook_url = $2,
               secret = $3
-        WHERE id = $1`,
+        WHERE id = $1
+          AND webhook_url = $4
+          AND secret IS NOT DISTINCT FROM $5
+        RETURNING id`,
       [
         row.id,
         normalizeStoredSecretValue(row.webhook_url),
         row.secret ? normalizeStoredSecretValue(row.secret) : null,
+        row.webhook_url,
+        row.secret,
       ],
     )
+    if (updated.rows.length === 0) {
+      skippedConcurrent += 1
+      console.log(`skipped destination ${row.id}: concurrently modified since this run read it`)
+      continue
+    }
+    encrypted += 1
     console.log(`encrypted destination ${row.id}`)
   }
 
-  return { encrypted, alreadyEncrypted, total: rows.length }
+  return { encrypted, alreadyEncrypted, skippedConcurrent, total: rows.length }
 }
 
 async function main(): Promise<void> {
@@ -154,7 +172,8 @@ async function main(): Promise<void> {
     const result = await runBackfill(pool, { dryRun, allowFirstRun })
     console.log(
       `${dryRun ? '[dry-run] ' : ''}done: ${result.encrypted} row(s) ${dryRun ? 'would be' : ''} encrypted, ` +
-      `${result.alreadyEncrypted} already encrypted, ${result.total} total`,
+      `${result.alreadyEncrypted} already encrypted, ${result.skippedConcurrent} skipped (concurrently modified — re-run to re-check), ` +
+      `${result.total} total`,
     )
   } finally {
     await pool.end()

--- a/packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts
+++ b/packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts
@@ -7,75 +7,165 @@
  * rows that are never edited again.
  *
  * MUST run with the same ENCRYPTION_KEY / ENCRYPTION_SALT as the application, or
- * the values it writes cannot be decrypted at runtime. Idempotent: values already
- * carrying the `enc:` prefix are left untouched (normalizeStoredSecretValue is a
- * no-op on them), so a re-run is safe.
+ * the values it writes cannot be decrypted at runtime. The derived key is
+ * `pbkdf2(ENCRYPTION_KEY, ENCRYPTION_SALT)` — presence of ENCRYPTION_KEY alone does
+ * NOT prove the pair matches the application: a correct key with the wrong (or
+ * default) salt derives a *different* key and still "succeeds" at encrypting, just
+ * with ciphertext the application can never decrypt again. Before touching any row
+ * this script therefore runs a pre-flight: it decrypts an already-`enc:`-prefixed
+ * value that some previous run of the application wrote, using the KEY/SALT this
+ * invocation holds. A round-trip failure means the pair is wrong and the script
+ * aborts with zero writes. (A fresh encrypt+decrypt "sentinel" cannot catch this —
+ * it always round-trips against whatever key happens to be derived, right or
+ * wrong; the check has to reuse ciphertext the *application* actually produced.)
+ * If every row is still plaintext (first run ever), there is no such value to
+ * check against — pass --confirm-first-run once you have independently confirmed
+ * ENCRYPTION_KEY/ENCRYPTION_SALT match the application's env.
+ *
+ * Idempotent: values already carrying the `enc:` prefix are left untouched
+ * (normalizeStoredSecretValue is a no-op on them), so a re-run is safe.
  *
  * Usage:
  *   DATABASE_URL=… ENCRYPTION_KEY=… ENCRYPTION_SALT=… pnpm dlx tsx \
- *     packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts [--dry-run]
+ *     packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts [--dry-run] [--confirm-first-run]
  */
 import pg from 'pg'
-import { isEncryptedSecretValue, normalizeStoredSecretValue } from '../src/security/encrypted-secrets'
+import { decryptStoredSecretValue, isEncryptedSecretValue, normalizeStoredSecretValue } from '../src/security/encrypted-secrets'
 
-const dryRun = process.argv.includes('--dry-run')
+export type DestinationSecretRow = { id: string; webhook_url: string; secret: string | null }
 
-async function main(): Promise<void> {
-  const databaseUrl = process.env.DATABASE_URL
-  if (!databaseUrl) throw new Error('DATABASE_URL is required')
-  if (!process.env.ENCRYPTION_KEY) {
+export interface QueryablePool {
+  query: <T = unknown>(text: string, params?: unknown[]) => Promise<{ rows: T[] }>
+}
+
+export interface BackfillOptions {
+  dryRun: boolean
+  allowFirstRun: boolean
+}
+
+export interface BackfillResult {
+  encrypted: number
+  alreadyEncrypted: number
+  total: number
+}
+
+/** Both halves of the KDF input must be explicit — presence of ENCRYPTION_KEY alone is not the invariant that matters. */
+export function assertEncryptionConfigPresent(env: NodeJS.ProcessEnv = process.env): void {
+  if (!env.ENCRYPTION_KEY) {
     throw new Error('ENCRYPTION_KEY is required — running with the default dev key would write values production cannot decrypt')
   }
+  if (!env.ENCRYPTION_SALT) {
+    throw new Error(
+      'ENCRYPTION_SALT is required — the derived key is pbkdf2(ENCRYPTION_KEY, ENCRYPTION_SALT); running with ' +
+      'the default salt while the application uses a different one would write values production cannot decrypt',
+    )
+  }
+}
+
+/** Finds an already-`enc:`-prefixed value in the current row set to verify the running KEY/SALT against. */
+export function findCanary(rows: DestinationSecretRow[]): string | undefined {
+  for (const row of rows) {
+    if (isEncryptedSecretValue(row.webhook_url)) return row.webhook_url
+    if (isEncryptedSecretValue(row.secret)) return row.secret as string
+  }
+  return undefined
+}
+
+/**
+ * Pre-flight, BEFORE any UPDATE: prove this invocation's ENCRYPTION_KEY/ENCRYPTION_SALT
+ * are the same pair that encrypted rows already at rest, by decrypting one of them.
+ * Throws (writes nothing) on mismatch or on an unacknowledged first run.
+ */
+export function verifyEncryptionConfig(rows: DestinationSecretRow[], allowFirstRun: boolean): void {
+  const canary = findCanary(rows)
+  if (!canary) {
+    if (allowFirstRun) return
+    throw new Error(
+      'No already-encrypted row found to verify ENCRYPTION_KEY/ENCRYPTION_SALT against, so this run cannot prove ' +
+      'they match the application. If every row really is still plaintext (first run ever), re-run with ' +
+      '--confirm-first-run after independently confirming ENCRYPTION_KEY/ENCRYPTION_SALT match the application env.',
+    )
+  }
+  try {
+    decryptStoredSecretValue(canary)
+  } catch (error) {
+    throw new Error(
+      'ENCRYPTION_KEY/ENCRYPTION_SALT do not match the pair that encrypted the existing rows ' +
+      `(decrypting a known-good row failed: ${error instanceof Error ? error.message : String(error)}). ` +
+      'Refusing to write — this would overwrite recoverable ciphertext with ciphertext nobody can decrypt.',
+    )
+  }
+}
+
+export async function runBackfill(pool: QueryablePool, options: BackfillOptions): Promise<BackfillResult> {
+  const { rows } = await pool.query<DestinationSecretRow>(
+    `SELECT id, webhook_url, secret FROM dingtalk_group_destinations`,
+  )
+
+  verifyEncryptionConfig(rows, options.allowFirstRun)
+
+  let encrypted = 0
+  let alreadyEncrypted = 0
+
+  for (const row of rows) {
+    const webhookNeedsEncrypting = !isEncryptedSecretValue(row.webhook_url)
+    const secretNeedsEncrypting = typeof row.secret === 'string'
+      && row.secret.length > 0
+      && !isEncryptedSecretValue(row.secret)
+
+    if (!webhookNeedsEncrypting && !secretNeedsEncrypting) {
+      alreadyEncrypted += 1
+      continue
+    }
+
+    encrypted += 1
+    if (options.dryRun) {
+      console.log(`[dry-run] would encrypt destination ${row.id} (webhook=${webhookNeedsEncrypting}, secret=${secretNeedsEncrypting})`)
+      continue
+    }
+
+    await pool.query(
+      `UPDATE dingtalk_group_destinations
+          SET webhook_url = $2,
+              secret = $3
+        WHERE id = $1`,
+      [
+        row.id,
+        normalizeStoredSecretValue(row.webhook_url),
+        row.secret ? normalizeStoredSecretValue(row.secret) : null,
+      ],
+    )
+    console.log(`encrypted destination ${row.id}`)
+  }
+
+  return { encrypted, alreadyEncrypted, total: rows.length }
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run')
+  const allowFirstRun = process.argv.includes('--confirm-first-run')
+
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL is required')
+  assertEncryptionConfigPresent()
 
   const pool = new pg.Pool({ connectionString: databaseUrl, max: 2 })
   try {
-    const { rows } = await pool.query<{ id: string; webhook_url: string; secret: string | null }>(
-      `SELECT id, webhook_url, secret FROM dingtalk_group_destinations`,
-    )
-
-    let encrypted = 0
-    let alreadyEncrypted = 0
-
-    for (const row of rows) {
-      const webhookNeedsEncrypting = !isEncryptedSecretValue(row.webhook_url)
-      const secretNeedsEncrypting = typeof row.secret === 'string'
-        && row.secret.length > 0
-        && !isEncryptedSecretValue(row.secret)
-
-      if (!webhookNeedsEncrypting && !secretNeedsEncrypting) {
-        alreadyEncrypted += 1
-        continue
-      }
-
-      encrypted += 1
-      if (dryRun) {
-        console.log(`[dry-run] would encrypt destination ${row.id} (webhook=${webhookNeedsEncrypting}, secret=${secretNeedsEncrypting})`)
-        continue
-      }
-
-      await pool.query(
-        `UPDATE dingtalk_group_destinations
-            SET webhook_url = $2,
-                secret = $3
-          WHERE id = $1`,
-        [
-          row.id,
-          normalizeStoredSecretValue(row.webhook_url),
-          row.secret ? normalizeStoredSecretValue(row.secret) : null,
-        ],
-      )
-      console.log(`encrypted destination ${row.id}`)
-    }
-
+    const result = await runBackfill(pool, { dryRun, allowFirstRun })
     console.log(
-      `${dryRun ? '[dry-run] ' : ''}done: ${encrypted} row(s) ${dryRun ? 'would be' : ''} encrypted, ${alreadyEncrypted} already encrypted, ${rows.length} total`,
+      `${dryRun ? '[dry-run] ' : ''}done: ${result.encrypted} row(s) ${dryRun ? 'would be' : ''} encrypted, ` +
+      `${result.alreadyEncrypted} already encrypted, ${result.total} total`,
     )
   } finally {
     await pool.end()
   }
 }
 
-main().catch((err) => {
-  console.error('backfill failed:', err instanceof Error ? err.message : String(err))
-  process.exit(1)
-})
+// Run only when invoked directly (tsx scripts/encrypt-dingtalk-destination-secrets.ts) — NOT
+// when imported by the test, so importing the pure helpers never opens a DB connection.
+if (process.argv[1]?.includes('encrypt-dingtalk-destination-secrets')) {
+  main().catch((err) => {
+    console.error('backfill failed:', err instanceof Error ? err.message : String(err))
+    process.exit(1)
+  })
+}

--- a/packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts
+++ b/packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts
@@ -1,0 +1,81 @@
+/**
+ * DT-HARDEN-03 — backfill: encrypt any plaintext DingTalk group-destination
+ * credentials left in `dingtalk_group_destinations`.
+ *
+ * Encrypt-on-write + decrypt-on-read means new and updated rows are already
+ * encrypted and legacy plaintext rows keep working. This script closes the gap for
+ * rows that are never edited again.
+ *
+ * MUST run with the same ENCRYPTION_KEY / ENCRYPTION_SALT as the application, or
+ * the values it writes cannot be decrypted at runtime. Idempotent: values already
+ * carrying the `enc:` prefix are left untouched (normalizeStoredSecretValue is a
+ * no-op on them), so a re-run is safe.
+ *
+ * Usage:
+ *   DATABASE_URL=… ENCRYPTION_KEY=… ENCRYPTION_SALT=… pnpm dlx tsx \
+ *     packages/core-backend/scripts/encrypt-dingtalk-destination-secrets.ts [--dry-run]
+ */
+import pg from 'pg'
+import { isEncryptedSecretValue, normalizeStoredSecretValue } from '../src/security/encrypted-secrets'
+
+const dryRun = process.argv.includes('--dry-run')
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL is required')
+  if (!process.env.ENCRYPTION_KEY) {
+    throw new Error('ENCRYPTION_KEY is required — running with the default dev key would write values production cannot decrypt')
+  }
+
+  const pool = new pg.Pool({ connectionString: databaseUrl, max: 2 })
+  try {
+    const { rows } = await pool.query<{ id: string; webhook_url: string; secret: string | null }>(
+      `SELECT id, webhook_url, secret FROM dingtalk_group_destinations`,
+    )
+
+    let encrypted = 0
+    let alreadyEncrypted = 0
+
+    for (const row of rows) {
+      const webhookNeedsEncrypting = !isEncryptedSecretValue(row.webhook_url)
+      const secretNeedsEncrypting = typeof row.secret === 'string'
+        && row.secret.length > 0
+        && !isEncryptedSecretValue(row.secret)
+
+      if (!webhookNeedsEncrypting && !secretNeedsEncrypting) {
+        alreadyEncrypted += 1
+        continue
+      }
+
+      encrypted += 1
+      if (dryRun) {
+        console.log(`[dry-run] would encrypt destination ${row.id} (webhook=${webhookNeedsEncrypting}, secret=${secretNeedsEncrypting})`)
+        continue
+      }
+
+      await pool.query(
+        `UPDATE dingtalk_group_destinations
+            SET webhook_url = $2,
+                secret = $3
+          WHERE id = $1`,
+        [
+          row.id,
+          normalizeStoredSecretValue(row.webhook_url),
+          row.secret ? normalizeStoredSecretValue(row.secret) : null,
+        ],
+      )
+      console.log(`encrypted destination ${row.id}`)
+    }
+
+    console.log(
+      `${dryRun ? '[dry-run] ' : ''}done: ${encrypted} row(s) ${dryRun ? 'would be' : ''} encrypted, ${alreadyEncrypted} already encrypted, ${rows.length} total`,
+    )
+  } finally {
+    await pool.end()
+  }
+}
+
+main().catch((err) => {
+  console.error('backfill failed:', err instanceof Error ? err.message : String(err))
+  process.exit(1)
+})

--- a/packages/core-backend/scripts/encrypt-dingtalk-integration-secrets.ts
+++ b/packages/core-backend/scripts/encrypt-dingtalk-integration-secrets.ts
@@ -1,15 +1,49 @@
 #!/usr/bin/env tsx
+/**
+ * DT-HARDEN-03 — backfill: encrypt plaintext `config.appSecret` values on
+ * `directory_integrations` and `attendance_integrations`.
+ *
+ * Shares the destination-backfill's safety posture (see
+ * encrypt-dingtalk-destination-secrets.ts for the full rationale):
+ *
+ * - PRE-FLIGHT before any write: both halves of the KDF input must be present
+ *   (pbkdf2(ENCRYPTION_KEY, ENCRYPTION_SALT)), and the pair is proven against a
+ *   canary — an already-`enc:`-prefixed appSecret the application itself wrote.
+ *   A wrong-salt run otherwise "succeeds" while writing ciphertext nobody can
+ *   ever decrypt, and this script overwrites the WHOLE config JSON. If no
+ *   encrypted row exists yet (first run ever), pass --confirm-first-run after
+ *   independently confirming the env pair matches the application's.
+ * - CAS on the config: the UPDATE applies only if `config` is still exactly what
+ *   this run read (jsonb equality), so a concurrent admin save is never clobbered
+ *   with a stale re-encrypted copy. Skipped rows are reported; re-run to re-check.
+ * - Idempotent: `enc:`-prefixed values are left untouched.
+ *
+ * Usage:
+ *   DATABASE_URL=… ENCRYPTION_KEY=… ENCRYPTION_SALT=… pnpm dlx tsx \
+ *     packages/core-backend/scripts/encrypt-dingtalk-integration-secrets.ts [--dry-run] [--confirm-first-run]
+ */
 import pg from 'pg'
-import { normalizeStoredSecretValue } from '../src/security/encrypted-secrets'
+import { decryptStoredSecretValue, isEncryptedSecretValue, normalizeStoredSecretValue } from '../src/security/encrypted-secrets'
+import { assertEncryptionConfigPresent, type QueryablePool } from './encrypt-dingtalk-destination-secrets'
 
-const { Pool } = pg as any
-
-type IntegrationRow = {
+export type IntegrationConfigRow = {
   id: string
   config: Record<string, unknown> | null
 }
 
-function normalizeConfig(value: unknown): Record<string, unknown> {
+export interface IntegrationBackfillOptions {
+  dryRun: boolean
+  allowFirstRun: boolean
+}
+
+export interface TableBackfillResult {
+  encrypted: number
+  alreadyEncrypted: number
+  skippedConcurrent: number
+  total: number
+}
+
+export function normalizeConfig(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? { ...(value as Record<string, unknown>) }
     : {}
@@ -19,78 +53,145 @@ function readSecret(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-async function rewriteDirectoryIntegrations(pool: any): Promise<number> {
-  const { rows } = await pool.query<IntegrationRow>('SELECT id, config FROM directory_integrations')
-  let updated = 0
+const SECRET_KEYS = ['appSecret', 'appsecret', 'app_secret'] as const
 
-  for (const row of rows) {
-    const config = normalizeConfig(row.config)
-    const appSecret = readSecret(config.appSecret)
-    if (!appSecret) continue
-
-    const nextSecret = normalizeStoredSecretValue(appSecret)
-    if (nextSecret === appSecret) continue
-
-    config.appSecret = nextSecret
-    await pool.query(
-      'UPDATE directory_integrations SET config = $2::jsonb, updated_at = NOW() WHERE id = $1',
-      [row.id, JSON.stringify(config)],
-    )
-    updated += 1
+function readAnySecret(config: Record<string, unknown>): string {
+  for (const key of SECRET_KEYS) {
+    const value = readSecret(config[key])
+    if (value) return value
   }
-
-  return updated
+  return ''
 }
 
-async function rewriteAttendanceIntegrations(pool: any): Promise<number> {
-  const { rows } = await pool.query<IntegrationRow>('SELECT id, config FROM attendance_integrations')
-  let updated = 0
+/** An already-`enc:` appSecret from either table proves the running KEY/SALT pair. */
+export function findIntegrationCanary(rowSets: IntegrationConfigRow[][]): string | undefined {
+  for (const rows of rowSets) {
+    for (const row of rows) {
+      const secret = readAnySecret(normalizeConfig(row.config))
+      if (isEncryptedSecretValue(secret)) return secret
+    }
+  }
+  return undefined
+}
+
+/**
+ * Pre-flight, BEFORE any UPDATE on either table — same contract as the destination
+ * backfill's verifyEncryptionConfig: throw (write nothing) on a KEY/SALT mismatch or an
+ * unacknowledged first run.
+ */
+export function verifyIntegrationEncryptionConfig(rowSets: IntegrationConfigRow[][], allowFirstRun: boolean): void {
+  const canary = findIntegrationCanary(rowSets)
+  if (!canary) {
+    if (allowFirstRun) return
+    throw new Error(
+      'No already-encrypted appSecret found to verify ENCRYPTION_KEY/ENCRYPTION_SALT against, so this run cannot ' +
+      'prove they match the application. If every appSecret really is still plaintext (first run ever), re-run with ' +
+      '--confirm-first-run after independently confirming ENCRYPTION_KEY/ENCRYPTION_SALT match the application env.',
+    )
+  }
+  try {
+    decryptStoredSecretValue(canary)
+  } catch (error) {
+    throw new Error(
+      'ENCRYPTION_KEY/ENCRYPTION_SALT do not match the pair that encrypted the existing rows ' +
+      `(decrypting a known-good appSecret failed: ${error instanceof Error ? error.message : String(error)}). ` +
+      'Refusing to write — this would overwrite recoverable ciphertext with ciphertext nobody can decrypt.',
+    )
+  }
+}
+
+export async function rewriteIntegrationTable(
+  pool: QueryablePool,
+  table: 'directory_integrations' | 'attendance_integrations',
+  rows: IntegrationConfigRow[],
+  options: IntegrationBackfillOptions,
+): Promise<TableBackfillResult> {
+  let encrypted = 0
+  let alreadyEncrypted = 0
+  let skippedConcurrent = 0
 
   for (const row of rows) {
     const config = normalizeConfig(row.config)
-    const appSecret = readSecret(config.appSecret ?? config.appsecret ?? config.app_secret)
+    const appSecret = readAnySecret(config)
     if (!appSecret) continue
 
-    const nextSecret = normalizeStoredSecretValue(appSecret)
-    if (nextSecret === appSecret) continue
+    if (isEncryptedSecretValue(appSecret)) {
+      alreadyEncrypted += 1
+      continue
+    }
 
-    config.appSecret = nextSecret
-    delete config.appsecret
-    delete config.app_secret
+    if (options.dryRun) {
+      encrypted += 1
+      console.log(`[dry-run] would encrypt ${table} ${row.id}`)
+      continue
+    }
 
-    await pool.query(
-      'UPDATE attendance_integrations SET config = $2::jsonb, updated_at = NOW() WHERE id = $1',
-      [row.id, JSON.stringify(config)],
+    const nextConfig = { ...config, appSecret: normalizeStoredSecretValue(appSecret) }
+    delete (nextConfig as Record<string, unknown>).appsecret
+    delete (nextConfig as Record<string, unknown>).app_secret
+
+    // CAS on the whole config (jsonb equality is semantic): a concurrent admin save —
+    // which under encrypt-on-write already stored ciphertext — must never be replaced
+    // by this run's stale re-encrypted copy of the ENTIRE config object.
+    const updated = await pool.query<{ id: string }>(
+      `UPDATE ${table}
+          SET config = $2::jsonb,
+              updated_at = NOW()
+        WHERE id = $1
+          AND config = $3::jsonb
+        RETURNING id`,
+      [row.id, JSON.stringify(nextConfig), JSON.stringify(row.config ?? {})],
     )
-    updated += 1
+    if (updated.rows.length === 0) {
+      skippedConcurrent += 1
+      console.log(`skipped ${table} ${row.id}: concurrently modified since this run read it`)
+      continue
+    }
+    encrypted += 1
+    console.log(`encrypted ${table} ${row.id}`)
   }
 
-  return updated
+  return { encrypted, alreadyEncrypted, skippedConcurrent, total: rows.length }
+}
+
+export async function runIntegrationBackfill(
+  pool: QueryablePool,
+  options: IntegrationBackfillOptions,
+): Promise<{ directory: TableBackfillResult; attendance: TableBackfillResult }> {
+  const [directoryRows, attendanceRows] = await Promise.all([
+    pool.query<IntegrationConfigRow>('SELECT id, config FROM directory_integrations').then((r) => r.rows),
+    pool.query<IntegrationConfigRow>('SELECT id, config FROM attendance_integrations').then((r) => r.rows),
+  ])
+
+  verifyIntegrationEncryptionConfig([directoryRows, attendanceRows], options.allowFirstRun)
+
+  const directory = await rewriteIntegrationTable(pool, 'directory_integrations', directoryRows, options)
+  const attendance = await rewriteIntegrationTable(pool, 'attendance_integrations', attendanceRows, options)
+  return { directory, attendance }
 }
 
 async function main(): Promise<void> {
-  const databaseUrl = process.env.DATABASE_URL
-  if (!databaseUrl) {
-    throw new Error('DATABASE_URL is required')
-  }
+  const dryRun = process.argv.includes('--dry-run')
+  const allowFirstRun = process.argv.includes('--confirm-first-run')
 
-  const pool = new Pool({ connectionString: databaseUrl })
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL is required')
+  assertEncryptionConfigPresent()
+
+  const pool = new pg.Pool({ connectionString: databaseUrl, max: 2 })
   try {
-    const [directoryUpdated, attendanceUpdated] = await Promise.all([
-      rewriteDirectoryIntegrations(pool),
-      rewriteAttendanceIntegrations(pool),
-    ])
-    console.log(JSON.stringify({
-      ok: true,
-      directoryUpdated,
-      attendanceUpdated,
-    }))
+    const { directory, attendance } = await runIntegrationBackfill(pool, { dryRun, allowFirstRun })
+    console.log(JSON.stringify({ ok: true, dryRun, directory, attendance }))
   } finally {
     await pool.end()
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error))
-  process.exit(1)
-})
+// Run only when invoked directly — NOT when imported by the test, so importing the pure
+// helpers never opens a DB connection.
+if (process.argv[1]?.includes('encrypt-dingtalk-integration-secrets')) {
+  main().catch((err) => {
+    console.error('backfill failed:', err instanceof Error ? err.message : String(err))
+    process.exit(1)
+  })
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -41,6 +41,10 @@ import {
   normalizeDingTalkRobotWebhookUrl,
   validateDingTalkRobotResponse,
 } from '../integrations/dingtalk/robot'
+import {
+  decryptDingTalkDestinationSecret,
+  decryptDingTalkDestinationWebhookUrl,
+} from './dingtalk-group-destinations'
 import type {
   AutomationAction,
   AutomationActionType,
@@ -3438,9 +3442,14 @@ export class AutomationExecutor {
 
     for (const destination of orderedDestinations) {
       try {
+        // DT-HARDEN-03: destinations are stored encrypted; decrypt before URL
+        // validation and HMAC signing. Reading the raw column here would feed an
+        // `enc:` blob to normalizeDingTalkRobotWebhookUrl and fail every send.
         runtimeWebhookByDestinationId.set(destination.id, {
-          webhookUrl: normalizeDingTalkRobotWebhookUrl(destination.webhook_url),
-          secret: normalizeDingTalkRobotSecret(destination.secret ?? undefined),
+          webhookUrl: normalizeDingTalkRobotWebhookUrl(
+            decryptDingTalkDestinationWebhookUrl(destination.webhook_url),
+          ),
+          secret: normalizeDingTalkRobotSecret(decryptDingTalkDestinationSecret(destination.secret)),
         })
       } catch (err) {
         failedDestinations.push({

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-response.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-response.ts
@@ -11,6 +11,9 @@ export function toDingTalkGroupDestinationResponse(
   const { secret: _secret, ...rest } = destination
   return {
     ...rest,
+    // DT-HARDEN-03 P3: an unreadable row's webhookUrl is the empty-string placeholder
+    // set in rowToDestination, never the raw `enc:` ciphertext — maskDingTalkWebhookUrl
+    // passes non-URL strings through verbatim, so masking alone would leak it.
     webhookUrl: maskDingTalkWebhookUrl(destination.webhookUrl),
     hasSecret: Boolean(destination.secret),
   }

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -49,13 +49,36 @@ function generateId(): string {
 
 function rowToDestination(row: DingTalkGroupDestinationRow): DingTalkGroupDestination {
   const scope = row.org_id ? 'org' : row.sheet_id ? 'sheet' : 'private'
+  // DT-HARDEN-03 P3: decrypt failures (wrong-key backfill, key rotation, corruption)
+  // must not throw here — this runs inside Array.map for list/get, and the routes that
+  // call it (GET /dingtalk-groups, GET /dingtalk-groups/:id/deliveries) have no
+  // try/catch, so an uncaught throw on ANY row hangs the whole response with none of
+  // the OTHER (readable) rows ever reaching the client. Flag the row instead; never
+  // fall back to the raw stored value (it would leak the `enc:` ciphertext blob as a
+  // "webhook URL" through the masking layer, which passes non-URLs through verbatim).
+  let webhookUrl: string
+  let secret: string | undefined
+  let credentialUnreadable = false
+  try {
+    webhookUrl = decryptDingTalkDestinationWebhookUrl(row.webhook_url)
+    secret = decryptDingTalkDestinationSecret(row.secret)
+  } catch (error) {
+    credentialUnreadable = true
+    webhookUrl = ''
+    secret = undefined
+    logger.error(
+      `DingTalk group destination ${row.id} has unreadable credentials (decrypt failed): ` +
+      `${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
   return {
     id: row.id,
     name: row.name,
     // DT-HARDEN-03: stored encrypted; the domain object always carries plaintext so
     // masking, signing and validation downstream keep working unchanged.
-    webhookUrl: decryptDingTalkDestinationWebhookUrl(row.webhook_url),
-    secret: decryptDingTalkDestinationSecret(row.secret),
+    webhookUrl,
+    secret,
+    ...(credentialUnreadable ? { credentialUnreadable: true as const } : {}),
     enabled: row.enabled,
     scope,
     sheetId: row.sheet_id ?? undefined,

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -11,6 +11,11 @@ import {
   validateDingTalkRobotResponse,
 } from '../integrations/dingtalk/robot'
 import { maskDingTalkWebhookUrl } from '../integrations/dingtalk/runtime-policy'
+import {
+  decryptDingTalkDestinationSecret,
+  decryptDingTalkDestinationWebhookUrl,
+  encryptDingTalkDestinationValue,
+} from './dingtalk-group-destinations'
 import type {
   DingTalkGroupDelivery,
   DingTalkGroupDestination,
@@ -47,8 +52,10 @@ function rowToDestination(row: DingTalkGroupDestinationRow): DingTalkGroupDestin
   return {
     id: row.id,
     name: row.name,
-    webhookUrl: row.webhook_url,
-    secret: row.secret ?? undefined,
+    // DT-HARDEN-03: stored encrypted; the domain object always carries plaintext so
+    // masking, signing and validation downstream keep working unchanged.
+    webhookUrl: decryptDingTalkDestinationWebhookUrl(row.webhook_url),
+    secret: decryptDingTalkDestinationSecret(row.secret),
     enabled: row.enabled,
     scope,
     sheetId: row.sheet_id ?? undefined,
@@ -135,8 +142,9 @@ export class DingTalkGroupDestinationService {
     await this.db.insertInto('dingtalk_group_destinations').values({
       id,
       name,
-      webhook_url: webhookUrl,
-      secret: secret ?? null,
+      // DT-HARDEN-03: validated as plaintext above, persisted encrypted.
+      webhook_url: encryptDingTalkDestinationValue(webhookUrl),
+      secret: secret ? encryptDingTalkDestinationValue(secret) : null,
       enabled,
       sheet_id: sheetId,
       org_id: orgId,
@@ -272,9 +280,13 @@ export class DingTalkGroupDestinationService {
       updates.name = name
     }
     if (input.webhookUrl !== undefined) {
-      updates.webhook_url = normalizeDingTalkRobotWebhookUrl(input.webhookUrl)
+      // DT-HARDEN-03: validate the plaintext, persist encrypted.
+      updates.webhook_url = encryptDingTalkDestinationValue(normalizeDingTalkRobotWebhookUrl(input.webhookUrl))
     }
-    if (input.secret !== undefined) updates.secret = normalizeDingTalkRobotSecret(input.secret) ?? null
+    if (input.secret !== undefined) {
+      const nextSecret = normalizeDingTalkRobotSecret(input.secret)
+      updates.secret = nextSecret ? encryptDingTalkDestinationValue(nextSecret) : null
+    }
     if (input.enabled !== undefined) updates.enabled = input.enabled
 
     await this.db.updateTable('dingtalk_group_destinations')
@@ -313,9 +325,10 @@ export class DingTalkGroupDestinationService {
     let responseBody: string | null = null
 
     try {
+      // DT-HARDEN-03: decrypt at rest → plaintext before validation/signing.
       const signedUrl = buildSignedDingTalkWebhookUrl(
-        normalizeDingTalkRobotWebhookUrl(row.webhook_url),
-        normalizeDingTalkRobotSecret(row.secret ?? undefined),
+        normalizeDingTalkRobotWebhookUrl(decryptDingTalkDestinationWebhookUrl(row.webhook_url)),
+        normalizeDingTalkRobotSecret(decryptDingTalkDestinationSecret(row.secret)),
       )
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), DINGTALK_REQUEST_TIMEOUT_MS)
@@ -391,7 +404,9 @@ export class DingTalkGroupDestinationService {
         .where('id', '=', id)
         .execute()
 
-      logger.info(`DingTalk group destination test sent to ${maskDingTalkWebhookUrl(row.webhook_url)}`)
+      logger.info(
+        `DingTalk group destination test sent to ${maskDingTalkWebhookUrl(decryptDingTalkDestinationWebhookUrl(row.webhook_url))}`,
+      )
       return { ok: true }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'

--- a/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
@@ -37,6 +37,12 @@ export interface DingTalkGroupDestination {
   webhookUrl: string
   secret?: string
   hasSecret?: boolean
+  // DT-HARDEN-03 P3: set when the stored ciphertext could not be decrypted with the
+  // running ENCRYPTION_KEY/ENCRYPTION_SALT (wrong-key backfill, key rotation, or
+  // corruption). webhookUrl/secret are then unusable placeholders — callers must not
+  // sign, send, or trust them; the row still surfaces so list/read endpoints respond
+  // instead of throwing for every other (readable) row in the same result set.
+  credentialUnreadable?: boolean
   enabled: boolean
   scope: 'private' | 'sheet' | 'org'
   sheetId?: string

--- a/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
@@ -1,3 +1,36 @@
+import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../security/encrypted-secrets'
+
+/**
+ * DT-HARDEN-03 — at-rest boundary for DingTalk group-robot credentials.
+ *
+ * `dingtalk_group_destinations.webhook_url` embeds the robot's `access_token` and
+ * `secret` is the HMAC signing key: together they are enough to inject messages
+ * into a customer's group. They were stored as plain text while every other
+ * DingTalk credential in this repo (appSecret, agentId, approvalCardLinkSecret)
+ * goes through `encrypted-secrets`, so a database dump leaked live send capability.
+ *
+ * Encrypt on write, decrypt on read. `decryptStoredSecretValue` passes non-`enc:`
+ * values through unchanged, so pre-existing plaintext rows keep working and get
+ * re-encrypted the next time they are written (or by the backfill script,
+ * scripts/encrypt-dingtalk-destination-secrets.ts).
+ *
+ * Storage-shaped values MUST NOT reach URL validation, signing, masking, logs, or
+ * API responses — every read site decrypts first.
+ */
+export function encryptDingTalkDestinationValue(plaintext: string): string {
+  return normalizeStoredSecretValue(plaintext)
+}
+
+export function decryptDingTalkDestinationWebhookUrl(stored: string): string {
+  return decryptStoredSecretValue(stored)
+}
+
+export function decryptDingTalkDestinationSecret(stored: string | null | undefined): string | undefined {
+  if (typeof stored !== 'string' || stored.length === 0) return undefined
+  const plaintext = decryptStoredSecretValue(stored)
+  return plaintext.length > 0 ? plaintext : undefined
+}
+
 export interface DingTalkGroupDestination {
   id: string
   name: string

--- a/packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts
@@ -212,6 +212,47 @@ describe('DingTalk group destination routes', () => {
     expect(response.body.data.destinations.map((item: { id: string }) => item.id)).toEqual(['dt_private', 'dt_org_1'])
   })
 
+  it(
+    'DT-HARDEN-03 P3: responds 200 with a corrupt row flagged instead of hanging when one ' +
+    'destination has undecryptable credentials',
+    async () => {
+      // Mirrors what DingTalkGroupDestinationService.listDestinations now returns for a row
+      // whose ciphertext fails to decrypt (wrong-key backfill / key rotation / corruption):
+      // rowToDestination flags it rather than throwing, so this shape reaching the route is
+      // the real contract, not a hypothetical. Before the P3 fix the route had no try/catch
+      // and a throwing decrypt inside Array.map hung the response entirely — this proves the
+      // route still answers, the corrupt row is flagged, and the good row is untouched.
+      const { app, service } = await createApp({
+        serviceOverrides: {
+          listDestinations: vi.fn(async () => [
+            makeDestination({ id: 'dt_good' }),
+            makeDestination({
+              id: 'dt_corrupt',
+              webhookUrl: '',
+              secret: undefined,
+              credentialUnreadable: true,
+            }),
+          ]),
+        },
+      })
+
+      const response = await request(app)
+        .get('/api/multitable/dingtalk-groups')
+        .query({ sheetId: SHEET_ID })
+        .expect(200)
+
+      expect(service.listDestinations).toHaveBeenCalled()
+      const byId = Object.fromEntries(
+        (response.body.data.destinations as Array<Record<string, unknown>>).map((d) => [d.id, d]),
+      )
+      expect(byId.dt_good.credentialUnreadable).toBeUndefined()
+      expect(byId.dt_good.webhookUrl).toContain('access_token=***')
+      expect(byId.dt_corrupt.credentialUnreadable).toBe(true)
+      expect(byId.dt_corrupt.hasSecret).toBe(false)
+      expect(String(byId.dt_corrupt.webhookUrl)).not.toContain('enc:')
+    },
+  )
+
   it.each([
     ['PATCH', `/api/multitable/dingtalk-groups/${DESTINATION_ID}`, 'updateDestination'],
     ['DELETE', `/api/multitable/dingtalk-groups/${DESTINATION_ID}`, 'deleteDestination'],

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -6,6 +6,7 @@ import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, ALL_TRIGGER_TYPES } from '../../
 import type { AutomationTrigger, AutomationTriggerType } from '../../src/multitable/automation-triggers'
 import { EventBus } from '../../src/integration/events/event-bus'
 import { __resetDingTalkAppAccessTokenCacheForTests } from '../../src/integrations/dingtalk/client'
+import { encryptStoredSecretValue } from '../../src/security/encrypted-secrets'
 import { ALL_ACTION_TYPES, type AutomationAction } from '../../src/multitable/automation-actions'
 
 // ── DB mock for AutomationLogService ──────────────────────────────────────
@@ -644,6 +645,51 @@ describe('AutomationExecutor', () => {
     expect(payload.markdown.text).toContain('/multitable/sheet_1/view_grid?recordId=r1')
     expect(payload.markdown.text).toContain('处理权限：需登录系统并具备该表格/视图访问权限')
     expect((queryFn.mock.calls[3]?.[0] as string) ?? '').toContain('INSERT INTO dingtalk_group_deliveries')
+  })
+
+  // DT-HARDEN-03: destinations are stored encrypted. The send path must decrypt before
+  // URL validation + HMAC signing — reading the raw column would feed an `enc:` blob to
+  // normalizeDingTalkRobotWebhookUrl and break every group delivery in production.
+  it('decrypts an encrypted destination before signing and sending (DT-HARDEN-03)', async () => {
+    process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'unit-test-key'
+    process.env.ENCRYPTION_SALT = process.env.ENCRYPTION_SALT || 'unit-test-salt'
+    const plainWebhook = 'https://oapi.dingtalk.com/robot/send?access_token=secret-token'
+    const encryptedWebhook = encryptStoredSecretValue(plainWebhook)
+    const encryptedSecret = encryptStoredSecretValue('SECunit0123456789')
+    expect(encryptedWebhook).not.toContain('secret-token')
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: encryptedWebhook, secret: encryptedSecret, enabled: true }],
+      })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: { destinationId: 'dt_1', titleTemplate: 'T', bodyTemplate: 'B' },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    const [url] = fetchFn.mock.calls[0] as [string, RequestInit]
+    // Sent to the decrypted URL, signed with the decrypted secret.
+    expect(url).toContain('https://oapi.dingtalk.com/robot/send?access_token=secret-token')
+    expect(url).not.toContain('enc:')
+    expect(url).toContain('sign=')
+    expect(url).toContain('timestamp=')
   })
 
   it('fails send_dingtalk_group_message when the internal processing view is not in the sheet', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-destination-secret-encryption.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-destination-secret-encryption.test.ts
@@ -1,0 +1,99 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  decryptDingTalkDestinationSecret,
+  decryptDingTalkDestinationWebhookUrl,
+  encryptDingTalkDestinationValue,
+} from '../../src/multitable/dingtalk-group-destinations'
+import { isEncryptedSecretValue } from '../../src/security/encrypted-secrets'
+import { toDingTalkGroupDestinationResponse } from '../../src/multitable/dingtalk-group-destination-response'
+
+const PLAIN_WEBHOOK = 'https://oapi.dingtalk.com/robot/send?access_token=abc123def456'
+const PLAIN_SECRET = 'SECabcdef0123456789'
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'unit-test-key'
+  process.env.ENCRYPTION_SALT = process.env.ENCRYPTION_SALT || 'unit-test-salt'
+})
+
+/**
+ * DT-HARDEN-03 — group-robot credentials at rest.
+ *
+ * webhook_url embeds the robot access_token and secret is the HMAC signing key:
+ * together they let anyone inject messages into a customer group. They must not sit
+ * in the database as plain text.
+ */
+describe('DT-HARDEN-03 DingTalk destination credential encryption', () => {
+  it('encrypts the webhook URL at rest and never stores the access_token verbatim', () => {
+    const stored = encryptDingTalkDestinationValue(PLAIN_WEBHOOK)
+    expect(isEncryptedSecretValue(stored)).toBe(true)
+    expect(stored).not.toContain('access_token')
+    expect(stored).not.toContain('abc123def456')
+  })
+
+  it('encrypts the signing secret at rest', () => {
+    const stored = encryptDingTalkDestinationValue(PLAIN_SECRET)
+    expect(isEncryptedSecretValue(stored)).toBe(true)
+    expect(stored).not.toContain(PLAIN_SECRET)
+  })
+
+  it('round-trips both values back to plaintext for signing and sending', () => {
+    expect(decryptDingTalkDestinationWebhookUrl(encryptDingTalkDestinationValue(PLAIN_WEBHOOK))).toBe(PLAIN_WEBHOOK)
+    expect(decryptDingTalkDestinationSecret(encryptDingTalkDestinationValue(PLAIN_SECRET))).toBe(PLAIN_SECRET)
+  })
+
+  it('is idempotent — re-encrypting an already-encrypted value is a no-op', () => {
+    const once = encryptDingTalkDestinationValue(PLAIN_WEBHOOK)
+    expect(encryptDingTalkDestinationValue(once)).toBe(once)
+  })
+
+  describe('compatibility reader for legacy plaintext rows', () => {
+    it('passes a pre-existing plaintext webhook URL through unchanged', () => {
+      expect(decryptDingTalkDestinationWebhookUrl(PLAIN_WEBHOOK)).toBe(PLAIN_WEBHOOK)
+    })
+
+    it('passes a pre-existing plaintext secret through unchanged', () => {
+      expect(decryptDingTalkDestinationSecret(PLAIN_SECRET)).toBe(PLAIN_SECRET)
+    })
+
+    it('treats absent/empty secrets as undefined', () => {
+      expect(decryptDingTalkDestinationSecret(null)).toBeUndefined()
+      expect(decryptDingTalkDestinationSecret(undefined)).toBeUndefined()
+      expect(decryptDingTalkDestinationSecret('')).toBeUndefined()
+    })
+  })
+
+  describe('API responses never leak credentials', () => {
+    it('masks the access_token and reduces the secret to a boolean', () => {
+      const response = toDingTalkGroupDestinationResponse({
+        id: 'dst_1',
+        name: 'ops group',
+        // rowToDestination decrypts, so the domain object carries plaintext.
+        webhookUrl: PLAIN_WEBHOOK,
+        secret: PLAIN_SECRET,
+        enabled: true,
+        scope: 'private',
+        createdBy: 'user-1',
+        createdAt: '2026-07-08T00:00:00.000Z',
+      })
+
+      expect(response.webhookUrl).toContain('access_token=***')
+      expect(response.webhookUrl).not.toContain('abc123def456')
+      expect(response.hasSecret).toBe(true)
+      expect((response as Record<string, unknown>).secret).toBeUndefined()
+    })
+
+    it('reports hasSecret=false when no secret is configured', () => {
+      const response = toDingTalkGroupDestinationResponse({
+        id: 'dst_2',
+        name: 'no secret',
+        webhookUrl: PLAIN_WEBHOOK,
+        enabled: true,
+        scope: 'private',
+        createdBy: 'user-1',
+        createdAt: '2026-07-08T00:00:00.000Z',
+      })
+      expect(response.hasSecret).toBe(false)
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -283,6 +283,35 @@ describe('DingTalkGroupDestinationService', () => {
     expect(updated.webhookUrl).toContain('access_token=next')
   })
 
+  test('persists rotated credentials encrypted at rest on update (DT-HARDEN-03)', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeTakeFirstQueue.push(destinationRow())
+    executeTakeFirstQueue.push(destinationRow({
+      webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=rotated',
+      secret: 'SEC_ROTATED',
+    }))
+
+    await service.updateDestination('dt_1', 'user_1', {
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=rotated',
+      secret: 'SEC_ROTATED',
+    })
+
+    // The returned domain object always carries plaintext by design; what matters is
+    // that the row written to `dingtalk_group_destinations` is ciphertext, never the
+    // plaintext webhook token / secret. Guards the encrypt-on-update path against a
+    // regression that would leave credentials at rest in the clear (DT-HARDEN-03 P2-2).
+    const updateChain = roots.updateTable.mock.results[0]?.value as MockChain | undefined
+    const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(isEncryptedSecretValue(setArg?.webhook_url)).toBe(true)
+    expect(decryptStoredSecretValue(setArg?.webhook_url as string)).toBe(
+      'https://oapi.dingtalk.com/robot/send?access_token=rotated',
+    )
+    expect(isEncryptedSecretValue(setArg?.secret)).toBe(true)
+    expect(decryptStoredSecretValue(setArg?.secret as string)).toBe('SEC_ROTATED')
+  })
+
   test('rejects invalid DingTalk robot webhook URL on update', async () => {
     const { db, roots } = createMockDb()
     const service = new DingTalkGroupDestinationService(db, vi.fn())

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -1,8 +1,14 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { Kysely } from 'kysely'
 import type { Database } from '../../src/db/types'
 import { DingTalkGroupDestinationService } from '../../src/multitable/dingtalk-group-destination-service'
-import { decryptStoredSecretValue, isEncryptedSecretValue } from '../../src/security/encrypted-secrets'
+import { toDingTalkGroupDestinationResponse } from '../../src/multitable/dingtalk-group-destination-response'
+import { decryptStoredSecretValue, encryptStoredSecretValue, isEncryptedSecretValue } from '../../src/security/encrypted-secrets'
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'unit-test-key'
+  process.env.ENCRYPTION_SALT = process.env.ENCRYPTION_SALT || 'unit-test-salt'
+})
 
 let executeQueue: unknown[]
 let executeTakeFirstQueue: unknown[]
@@ -78,6 +84,27 @@ function destinationRow(overrides: Record<string, unknown> = {}) {
     last_test_error: null,
     ...overrides,
   }
+}
+
+/**
+ * DT-HARDEN-03 P2-2 fixture-shadowing fix: `destinationRow()` above stores PLAINTEXT
+ * `webhook_url`/`secret`, so `decryptDingTalkDestination*` is a pass-through no-op on
+ * it and never actually exercises the decrypt path. Surfaces that read stored
+ * credentials (list/get, test-send) must be tested against a row that carries the
+ * SAME `enc:` ciphertext shape production data has, or a regression that reads the
+ * raw column instead of decrypting it would still pass.
+ */
+function encryptedDestinationRow(overrides: Record<string, unknown> = {}) {
+  const plainWebhookUrl = typeof overrides.plainWebhookUrl === 'string'
+    ? overrides.plainWebhookUrl
+    : 'https://oapi.dingtalk.com/robot/send?access_token=cipher-token'
+  const plainSecret = 'plainSecret' in overrides ? (overrides.plainSecret as string | null) : 'SECCIPHERTEST'
+  const { plainWebhookUrl: _pw, plainSecret: _ps, ...rest } = overrides
+  return destinationRow({
+    webhook_url: encryptStoredSecretValue(plainWebhookUrl),
+    secret: plainSecret ? encryptStoredSecretValue(plainSecret) : null,
+    ...rest,
+  })
 }
 
 function deliveryRow(overrides: Record<string, unknown> = {}) {
@@ -463,5 +490,109 @@ describe('DingTalkGroupDestinationService', () => {
     const updateChain = roots.updateTable.mock.results[0]?.value as MockChain | undefined
     const setArg = updateChain?.set?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
     expect(setArg?.last_test_status).toBe('success')
+  })
+
+  // DT-HARDEN-03 P2-2 — roadmap §6.3 names 5 surfaces (create, update, list, test-send,
+  // delivery send). create/update/delivery-send were already covered with real ciphertext;
+  // these two close list and test-send, against `encryptedDestinationRow()` (real `enc:`
+  // ciphertext), not the plaintext `destinationRow()` fixture that makes decrypt a no-op.
+
+  test('listDestinations decrypts real ciphertext at rest (DT-HARDEN-03 list surface)', async () => {
+    const { db } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeQueue.push([
+      encryptedDestinationRow({
+        id: 'dt_cipher',
+        plainWebhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=list-surface-token',
+        plainSecret: 'SECLISTSURFACE',
+      }),
+    ])
+    const listed = await service.listDestinations('user_1')
+
+    expect(listed).toHaveLength(1)
+    // Guards against reading the raw `enc:` column: a regression that drops the decrypt
+    // in rowToDestination would leave this ciphertext (starts with `enc:`), never the
+    // plaintext access_token/secret asserted below.
+    expect(listed[0].webhookUrl).toBe('https://oapi.dingtalk.com/robot/send?access_token=list-surface-token')
+    expect(listed[0].secret).toBe('SECLISTSURFACE')
+    expect(listed[0].credentialUnreadable).toBeUndefined()
+  })
+
+  test('testSend decrypts real ciphertext before signing and sending (DT-HARDEN-03 test-send surface)', async () => {
+    const { db } = createMockDb()
+    const fetchFn = vi.fn(async () => new Response(
+      JSON.stringify({ errcode: 0, errmsg: 'ok' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    const service = new DingTalkGroupDestinationService(db, fetchFn as typeof fetch)
+
+    executeTakeFirstQueue.push(encryptedDestinationRow({
+      plainWebhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-send-surface-token',
+      plainSecret: 'SECTESTSENDSURFACE',
+    }))
+    // A regression that reads the raw stored (ciphertext) webhook_url instead of
+    // decrypting it would fail DingTalk-URL validation before fetch is ever called —
+    // resolving {ok:true} + a signed plaintext token in the request URL is only
+    // possible if both webhook_url and secret were correctly decrypted first.
+    await expect(service.testSend('dt_1', 'user_1', {})).resolves.toEqual({ ok: true })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const calledUrl = fetchFn.mock.calls[0]?.[0] as string
+    expect(calledUrl).toContain('access_token=test-send-surface-token')
+    expect(calledUrl).toContain('&sign=')
+    expect(calledUrl).toContain('&timestamp=')
+  })
+
+  // DT-HARDEN-03 P3 — one undecryptable ciphertext row must not take down the whole
+  // response. rowToDestination is called from Array.map in listDestinations/
+  // getDestinationById, and the routes that call them (GET /dingtalk-groups, GET
+  // /dingtalk-groups/:id/deliveries) have no try/catch — an uncaught throw on ANY row
+  // hangs the request with no response, corrupt row or not.
+  test('listDestinations flags an undecryptable row instead of throwing, and leaves good rows intact', async () => {
+    const { db } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeQueue.push([
+      encryptedDestinationRow({
+        id: 'dt_good',
+        plainWebhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=good-token',
+        plainSecret: 'SECGOOD',
+      }),
+      destinationRow({
+        id: 'dt_corrupt',
+        // Well-formed `enc:` prefix, but the payload cannot round-trip — simulates a
+        // wrong-key backfill, a key rotation, or on-disk corruption.
+        webhook_url: 'enc:not-valid-ciphertext-data',
+        secret: 'enc:also-not-valid-ciphertext-data',
+      }),
+    ])
+
+    const listed = await service.listDestinations('user_1')
+
+    expect(listed).toHaveLength(2)
+    const good = listed.find((d) => d.id === 'dt_good')
+    const corrupt = listed.find((d) => d.id === 'dt_corrupt')
+
+    expect(good?.webhookUrl).toBe('https://oapi.dingtalk.com/robot/send?access_token=good-token')
+    expect(good?.secret).toBe('SECGOOD')
+    expect(good?.credentialUnreadable).toBeUndefined()
+
+    expect(corrupt?.credentialUnreadable).toBe(true)
+    expect(corrupt?.secret).toBeUndefined()
+    // Must never fall back to the raw stored value — maskDingTalkWebhookUrl passes
+    // non-URL strings through VERBATIM, so leaking the `enc:` blob here would leak the
+    // ciphertext through what is meant to be a masked display field.
+    expect(corrupt?.webhookUrl).not.toContain('enc:')
+
+    // The API-facing shape must carry the flag too, and must never surface `enc:`.
+    const responses = listed.map((d) => toDingTalkGroupDestinationResponse(d))
+    const corruptResponse = responses.find((r) => r.id === 'dt_corrupt')
+    expect(corruptResponse?.credentialUnreadable).toBe(true)
+    expect(corruptResponse?.webhookUrl).not.toContain('enc:')
+    expect(corruptResponse?.hasSecret).toBe(false)
+    const goodResponse = responses.find((r) => r.id === 'dt_good')
+    expect(goodResponse?.webhookUrl).toContain('access_token=***')
+    expect(goodResponse?.credentialUnreadable).toBeUndefined()
   })
 })

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { Kysely } from 'kysely'
 import type { Database } from '../../src/db/types'
 import { DingTalkGroupDestinationService } from '../../src/multitable/dingtalk-group-destination-service'
+import { decryptStoredSecretValue, isEncryptedSecretValue } from '../../src/security/encrypted-secrets'
 
 let executeQueue: unknown[]
 let executeTakeFirstQueue: unknown[]
@@ -123,7 +124,17 @@ describe('DingTalkGroupDestinationService', () => {
     expect(created.sheetId).toBe('sheet_1')
     const insertChain = roots.insertInto.mock.results[0]?.value as MockChain | undefined
     const values = insertChain?.values?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
-    expect(values?.secret).toBe('SEC123')
+    // DT-HARDEN-03: credentials are persisted encrypted, never as plain text. The
+    // returned domain object still carries plaintext (asserted above) so signing and
+    // sending keep working.
+    expect(isEncryptedSecretValue(values?.secret)).toBe(true)
+    expect(values?.secret).not.toBe('SEC123')
+    expect(decryptStoredSecretValue(values?.secret as string)).toBe('SEC123')
+    expect(isEncryptedSecretValue(values?.webhook_url)).toBe(true)
+    expect(String(values?.webhook_url)).not.toContain('test-token')
+    expect(decryptStoredSecretValue(values?.webhook_url as string)).toBe(
+      'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+    )
     expect(values?.org_id).toBeNull()
 
     executeQueue.push([destinationRow({ sheet_id: 'sheet_1' }), destinationRow({ id: 'dt_legacy', sheet_id: null })])

--- a/packages/core-backend/tests/unit/encrypt-dingtalk-destination-secrets.test.ts
+++ b/packages/core-backend/tests/unit/encrypt-dingtalk-destination-secrets.test.ts
@@ -213,6 +213,25 @@ describe('DT-HARDEN-03 backfill — runBackfill', () => {
     expect(state.find((row) => row.id === 'victim')?.webhook_url).toBe(rotatedByAdmin)
   })
 
+  it('P3-1 CAS: the UPDATE itself carries the compare — SQL pins the WHERE, params carry the previous values', async () => {
+    // The fixture enforces CAS from the params, so it cannot see a WHERE-only revert;
+    // Postgres enforces it from the SQL, which cannot see a params-only revert. Pinning
+    // BOTH halves makes either revert red at unit level (the real-DB semantics of this
+    // exact clause shape are Postgres's own contract).
+    const { pool, queries } = makeFakePool([
+      { id: 'plain', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=old', secret: 'SECplain' },
+    ])
+
+    await runBackfill(pool, { dryRun: false, allowFirstRun: true })
+
+    const update = queries.find((q) => /^\s*UPDATE/i.test(q.text))
+    expect(update).toBeDefined()
+    expect(update!.text).toContain('AND webhook_url = $4')
+    expect(update!.text).toContain('AND secret IS NOT DISTINCT FROM $5')
+    expect(update!.params?.[3]).toBe('https://oapi.dingtalk.com/robot/send?access_token=old')
+    expect(update!.params?.[4]).toBe('SECplain')
+  })
+
   it('dry-run performs zero writes', async () => {
     const canary = encryptStoredSecretValue('https://oapi.dingtalk.com/robot/send?access_token=already')
     const { pool, queries } = makeFakePool([

--- a/packages/core-backend/tests/unit/encrypt-dingtalk-destination-secrets.test.ts
+++ b/packages/core-backend/tests/unit/encrypt-dingtalk-destination-secrets.test.ts
@@ -27,26 +27,67 @@ function withEnv<T>(vars: Record<string, string | undefined>, fn: () => T): T {
     if (value === undefined) delete process.env[key]
     else process.env[key] = value
   }
-  try {
-    return fn()
-  } finally {
+  const restore = () => {
     for (const [key, value] of Object.entries(prev)) {
       if (value === undefined) delete process.env[key]
       else process.env[key] = value
     }
   }
+  // Promise-aware: encrypted-secrets derives its key from process.env AT CALL TIME, so an
+  // async callback must keep the staged env alive until it settles — a plain finally would
+  // restore the moment fn() RETURNS the promise, and everything past the callback's first
+  // await would run under the outer env (making e.g. the catastrophe test pass for the
+  // wrong reason: decrypt fails under the restored env too).
+  let result: T
+  try {
+    result = fn()
+  } catch (error) {
+    restore()
+    throw error
+  }
+  if (result instanceof Promise) {
+    return result.finally(restore) as unknown as T
+  }
+  restore()
+  return result
 }
 
-function makeFakePool(rows: DestinationSecretRow[]): { pool: QueryablePool; queries: { text: string; params?: unknown[] }[] } {
+/**
+ * Honest fixture: UPDATEs are applied against in-memory state and the CAS WHERE is
+ * ENFORCED (id + exact previous webhook_url/secret), returning the RETURNING row only on
+ * a real match — a fake that ignored the WHERE would shadow exactly the guard the
+ * concurrent-rotation test exists to prove. `afterSelect` simulates a writer that lands
+ * between the script's SELECT and its UPDATE.
+ */
+function makeFakePool(
+  rows: DestinationSecretRow[],
+  opts: { afterSelect?: (state: DestinationSecretRow[]) => void } = {},
+): { pool: QueryablePool; queries: { text: string; params?: unknown[] }[]; state: DestinationSecretRow[] } {
+  const state = rows.map((row) => ({ ...row }))
   const queries: { text: string; params?: unknown[] }[] = []
   const pool: QueryablePool = {
     query: vi.fn(async (text: string, params?: unknown[]) => {
       queries.push({ text, params })
-      if (/^\s*SELECT/i.test(text)) return { rows: rows as unknown[] }
+      if (/^\s*SELECT/i.test(text)) {
+        const snapshot = state.map((row) => ({ ...row }))
+        opts.afterSelect?.(state)
+        return { rows: snapshot as unknown[] }
+      }
+      if (/^\s*UPDATE/i.test(text)) {
+        const [id, nextUrl, nextSecret, prevUrl, prevSecret] = params ?? []
+        const row = state.find((candidate) => candidate.id === id)
+        const casMatches = row
+          && row.webhook_url === prevUrl
+          && (row.secret ?? null) === ((prevSecret as string | null) ?? null)
+        if (!casMatches || !row) return { rows: [] }
+        row.webhook_url = nextUrl as string
+        row.secret = (nextSecret as string | null) ?? null
+        return { rows: [{ id }] as unknown[] }
+      }
       return { rows: [] }
     }),
   }
-  return { pool, queries }
+  return { pool, queries, state }
 }
 
 describe('DT-HARDEN-03 backfill — assertEncryptionConfigPresent', () => {
@@ -143,12 +184,33 @@ describe('DT-HARDEN-03 backfill — runBackfill', () => {
 
     const result = await runBackfill(pool, { dryRun: false, allowFirstRun: false })
 
-    expect(result).toEqual({ encrypted: 1, alreadyEncrypted: 1, total: 2 })
+    expect(result).toEqual({ encrypted: 1, alreadyEncrypted: 1, skippedConcurrent: 0, total: 2 })
     const updates = queries.filter((q) => /^\s*UPDATE/i.test(q.text))
     expect(updates).toHaveLength(1)
     expect(updates[0].params?.[0]).toBe('needs-both')
     expect(isEncryptedSecretValue(updates[0].params?.[1] as string)).toBe(true)
     expect(isEncryptedSecretValue(updates[0].params?.[2] as string)).toBe(true)
+  })
+
+  it('P3-1 CAS: a credential rotated between the SELECT and the UPDATE is skipped, never overwritten with the stale re-encryption', async () => {
+    const rotatedByAdmin = encryptStoredSecretValue('https://oapi.dingtalk.com/robot/send?access_token=rotated')
+    const { pool, state } = makeFakePool(
+      [{ id: 'victim', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=stale-plain', secret: null }],
+      {
+        // Admin saves a NEW credential (encrypt-on-write stores ciphertext) right after
+        // the script read the old plaintext.
+        afterSelect: (rows) => {
+          const victim = rows.find((row) => row.id === 'victim')
+          if (victim) victim.webhook_url = rotatedByAdmin
+        },
+      },
+    )
+
+    const result = await runBackfill(pool, { dryRun: false, allowFirstRun: true })
+
+    expect(result).toEqual({ encrypted: 0, alreadyEncrypted: 0, skippedConcurrent: 1, total: 1 })
+    // The admin's rotation survived — not clobbered by re-encrypted stale plaintext.
+    expect(state.find((row) => row.id === 'victim')?.webhook_url).toBe(rotatedByAdmin)
   })
 
   it('dry-run performs zero writes', async () => {
@@ -160,7 +222,7 @@ describe('DT-HARDEN-03 backfill — runBackfill', () => {
 
     const result = await runBackfill(pool, { dryRun: true, allowFirstRun: false })
 
-    expect(result).toEqual({ encrypted: 1, alreadyEncrypted: 1, total: 2 })
+    expect(result).toEqual({ encrypted: 1, alreadyEncrypted: 1, skippedConcurrent: 0, total: 2 })
     expect(queries.filter((q) => /^\s*UPDATE/i.test(q.text))).toHaveLength(0)
   })
 
@@ -173,7 +235,7 @@ describe('DT-HARDEN-03 backfill — runBackfill', () => {
 
     const result = await runBackfill(pool, { dryRun: false, allowFirstRun: false })
 
-    expect(result).toEqual({ encrypted: 0, alreadyEncrypted: 1, total: 1 })
+    expect(result).toEqual({ encrypted: 0, alreadyEncrypted: 1, skippedConcurrent: 0, total: 1 })
     expect(queries.filter((q) => /^\s*UPDATE/i.test(q.text))).toHaveLength(0)
   })
 

--- a/packages/core-backend/tests/unit/encrypt-dingtalk-destination-secrets.test.ts
+++ b/packages/core-backend/tests/unit/encrypt-dingtalk-destination-secrets.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  assertEncryptionConfigPresent,
+  findCanary,
+  runBackfill,
+  verifyEncryptionConfig,
+  type DestinationSecretRow,
+  type QueryablePool,
+} from '../../scripts/encrypt-dingtalk-destination-secrets'
+import { encryptStoredSecretValue, isEncryptedSecretValue } from '../../src/security/encrypted-secrets'
+
+/**
+ * DT-HARDEN-03 P2-1 — backfill pre-flight.
+ *
+ * The derived key is pbkdf2(ENCRYPTION_KEY, ENCRYPTION_SALT). A fresh
+ * "encrypt+decrypt a sentinel" round-trips against WHATEVER key happens to be
+ * derived — right or wrong — so it cannot catch a wrong-salt run. The only check
+ * that discriminates is decrypting ciphertext the application already wrote with
+ * the KEY/SALT this invocation holds: proven below by round-tripping a canary
+ * encrypted under one salt while the process env holds a DIFFERENT salt.
+ */
+function withEnv<T>(vars: Record<string, string | undefined>, fn: () => T): T {
+  const prev: Record<string, string | undefined> = {}
+  for (const key of Object.keys(vars)) prev[key] = process.env[key]
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  try {
+    return fn()
+  } finally {
+    for (const [key, value] of Object.entries(prev)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }
+}
+
+function makeFakePool(rows: DestinationSecretRow[]): { pool: QueryablePool; queries: { text: string; params?: unknown[] }[] } {
+  const queries: { text: string; params?: unknown[] }[] = []
+  const pool: QueryablePool = {
+    query: vi.fn(async (text: string, params?: unknown[]) => {
+      queries.push({ text, params })
+      if (/^\s*SELECT/i.test(text)) return { rows: rows as unknown[] }
+      return { rows: [] }
+    }),
+  }
+  return { pool, queries }
+}
+
+describe('DT-HARDEN-03 backfill — assertEncryptionConfigPresent', () => {
+  it('requires ENCRYPTION_KEY', () => {
+    withEnv({ ENCRYPTION_KEY: undefined, ENCRYPTION_SALT: 'salt-a' }, () => {
+      expect(() => assertEncryptionConfigPresent()).toThrow('ENCRYPTION_KEY is required')
+    })
+  })
+
+  it('requires ENCRYPTION_SALT even when ENCRYPTION_KEY is set (asymmetry P2-1)', () => {
+    withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: undefined }, () => {
+      expect(() => assertEncryptionConfigPresent()).toThrow('ENCRYPTION_SALT is required')
+    })
+  })
+
+  it('passes when both are set', () => {
+    withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, () => {
+      expect(() => assertEncryptionConfigPresent()).not.toThrow()
+    })
+  })
+})
+
+describe('DT-HARDEN-03 backfill — findCanary', () => {
+  it('finds an already-encrypted webhook_url', () => {
+    const rows: DestinationSecretRow[] = [
+      { id: '1', webhook_url: 'plain', secret: null },
+      { id: '2', webhook_url: 'enc:abc', secret: null },
+    ]
+    expect(findCanary(rows)).toBe('enc:abc')
+  })
+
+  it('finds an already-encrypted secret when webhook_url is plaintext', () => {
+    const rows: DestinationSecretRow[] = [
+      { id: '1', webhook_url: 'plain', secret: 'enc:xyz' },
+    ]
+    expect(findCanary(rows)).toBe('enc:xyz')
+  })
+
+  it('returns undefined when every row is plaintext', () => {
+    const rows: DestinationSecretRow[] = [
+      { id: '1', webhook_url: 'plain', secret: 'plainsecret' },
+    ]
+    expect(findCanary(rows)).toBeUndefined()
+  })
+})
+
+describe('DT-HARDEN-03 backfill — verifyEncryptionConfig (P2-1 pre-flight)', () => {
+  it('passes when the canary decrypts under the current KEY/SALT', () => {
+    withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, () => {
+      const canary = encryptStoredSecretValue('https://oapi.dingtalk.com/robot/send?access_token=live')
+      expect(isEncryptedSecretValue(canary)).toBe(true)
+      expect(() => verifyEncryptionConfig([{ id: '1', webhook_url: canary, secret: null }], false)).not.toThrow()
+    })
+  })
+
+  it('THE catastrophe case: aborts when the canary was encrypted under a DIFFERENT salt', () => {
+    const canary = withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, () =>
+      encryptStoredSecretValue('https://oapi.dingtalk.com/robot/send?access_token=live'),
+    )
+    // Same key, WRONG salt — the exact scenario the review flagged: presence of
+    // ENCRYPTION_KEY alone does not prove the pair matches production.
+    withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-b' }, () => {
+      expect(() => verifyEncryptionConfig([{ id: '1', webhook_url: canary, secret: null }], false))
+        .toThrow(/do not match the pair that encrypted the existing rows/)
+    })
+  })
+
+  it('aborts when every row is plaintext and --confirm-first-run was not passed', () => {
+    withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, () => {
+      expect(() => verifyEncryptionConfig([{ id: '1', webhook_url: 'plain', secret: null }], false))
+        .toThrow(/--confirm-first-run/)
+    })
+  })
+
+  it('allows a plaintext-only run when --confirm-first-run is explicit', () => {
+    withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, () => {
+      expect(() => verifyEncryptionConfig([{ id: '1', webhook_url: 'plain', secret: null }], true)).not.toThrow()
+    })
+  })
+})
+
+describe('DT-HARDEN-03 backfill — runBackfill', () => {
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'unit-test-key'
+    process.env.ENCRYPTION_SALT = process.env.ENCRYPTION_SALT || 'unit-test-salt'
+  })
+
+  it('encrypts plaintext rows, skips already-encrypted rows, and reports counts', async () => {
+    const canary = encryptStoredSecretValue('https://oapi.dingtalk.com/robot/send?access_token=already')
+    const { pool, queries } = makeFakePool([
+      { id: 'already', webhook_url: canary, secret: null },
+      { id: 'needs-both', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=new', secret: 'SECplain' },
+    ])
+
+    const result = await runBackfill(pool, { dryRun: false, allowFirstRun: false })
+
+    expect(result).toEqual({ encrypted: 1, alreadyEncrypted: 1, total: 2 })
+    const updates = queries.filter((q) => /^\s*UPDATE/i.test(q.text))
+    expect(updates).toHaveLength(1)
+    expect(updates[0].params?.[0]).toBe('needs-both')
+    expect(isEncryptedSecretValue(updates[0].params?.[1] as string)).toBe(true)
+    expect(isEncryptedSecretValue(updates[0].params?.[2] as string)).toBe(true)
+  })
+
+  it('dry-run performs zero writes', async () => {
+    const canary = encryptStoredSecretValue('https://oapi.dingtalk.com/robot/send?access_token=already')
+    const { pool, queries } = makeFakePool([
+      { id: 'already', webhook_url: canary, secret: null },
+      { id: 'needs-encrypting', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=new', secret: null },
+    ])
+
+    const result = await runBackfill(pool, { dryRun: true, allowFirstRun: false })
+
+    expect(result).toEqual({ encrypted: 1, alreadyEncrypted: 1, total: 2 })
+    expect(queries.filter((q) => /^\s*UPDATE/i.test(q.text))).toHaveLength(0)
+  })
+
+  it('idempotent re-run: nothing left to encrypt writes zero UPDATEs', async () => {
+    const canaryUrl = encryptStoredSecretValue('https://oapi.dingtalk.com/robot/send?access_token=x')
+    const canarySecret = encryptStoredSecretValue('SECalready')
+    const { pool, queries } = makeFakePool([
+      { id: 'already', webhook_url: canaryUrl, secret: canarySecret },
+    ])
+
+    const result = await runBackfill(pool, { dryRun: false, allowFirstRun: false })
+
+    expect(result).toEqual({ encrypted: 0, alreadyEncrypted: 1, total: 1 })
+    expect(queries.filter((q) => /^\s*UPDATE/i.test(q.text))).toHaveLength(0)
+  })
+
+  it(
+    'CATASTROPHE GUARD: wrong ENCRYPTION_SALT aborts with ZERO writes instead of overwriting recoverable ' +
+    'ciphertext with unrecoverable ciphertext',
+    async () => {
+      const canary = withEnv({ ENCRYPTION_KEY: 'prod-key', ENCRYPTION_SALT: 'prod-salt' }, () =>
+        encryptStoredSecretValue('https://oapi.dingtalk.com/robot/send?access_token=prod-live'),
+      )
+
+      await withEnv({ ENCRYPTION_KEY: 'prod-key', ENCRYPTION_SALT: 'wrong-salt' }, async () => {
+        const { pool, queries } = makeFakePool([
+          { id: 'good', webhook_url: canary, secret: null },
+          { id: 'plaintext-victim', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=victim', secret: null },
+        ])
+
+        await expect(runBackfill(pool, { dryRun: false, allowFirstRun: false })).rejects.toThrow(
+          /do not match the pair that encrypted the existing rows/,
+        )
+        expect(queries.filter((q) => /^\s*UPDATE/i.test(q.text))).toHaveLength(0)
+      })
+    },
+  )
+})

--- a/packages/core-backend/tests/unit/encrypt-dingtalk-integration-secrets.test.ts
+++ b/packages/core-backend/tests/unit/encrypt-dingtalk-integration-secrets.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  findIntegrationCanary,
+  runIntegrationBackfill,
+  verifyIntegrationEncryptionConfig,
+  type IntegrationConfigRow,
+} from '../../scripts/encrypt-dingtalk-integration-secrets'
+import type { QueryablePool } from '../../scripts/encrypt-dingtalk-destination-secrets'
+import { encryptStoredSecretValue, isEncryptedSecretValue } from '../../src/security/encrypted-secrets'
+
+/**
+ * DT-HARDEN-03 P3-3 — the sibling backfill (integration appSecrets) gets the same safety
+ * posture the destination backfill was reviewed into: canary pre-flight before any write
+ * (a wrong-salt run here overwrites the WHOLE config JSON irreversibly) and a CAS so a
+ * concurrent admin save is never clobbered with a stale re-encrypted copy.
+ */
+function withEnv<T>(vars: Record<string, string | undefined>, fn: () => T): T {
+  const prev: Record<string, string | undefined> = {}
+  for (const key of Object.keys(vars)) prev[key] = process.env[key]
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  const restore = () => {
+    for (const [key, value] of Object.entries(prev)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }
+  let result: T
+  try {
+    result = fn()
+  } catch (error) {
+    restore()
+    throw error
+  }
+  if (result instanceof Promise) {
+    return result.finally(restore) as unknown as T
+  }
+  restore()
+  return result
+}
+
+type Tables = { directory: IntegrationConfigRow[]; attendance: IntegrationConfigRow[] }
+
+/** Honest fixture: enforces the jsonb-equality CAS against in-memory state. */
+function makeFakePool(
+  tables: Tables,
+  opts: { afterSelect?: (state: Tables) => void } = {},
+): { pool: QueryablePool; queries: { text: string; params?: unknown[] }[]; state: Tables } {
+  const state: Tables = {
+    directory: tables.directory.map((row) => ({ ...row, config: row.config ? { ...row.config } : row.config })),
+    attendance: tables.attendance.map((row) => ({ ...row, config: row.config ? { ...row.config } : row.config })),
+  }
+  const queries: { text: string; params?: unknown[] }[] = []
+  let selects = 0
+  const tableOf = (text: string): IntegrationConfigRow[] =>
+    /attendance_integrations/.test(text) ? state.attendance : state.directory
+
+  const pool: QueryablePool = {
+    query: vi.fn(async (text: string, params?: unknown[]) => {
+      queries.push({ text, params })
+      if (/^\s*SELECT/i.test(text)) {
+        const snapshot = tableOf(text).map((row) => ({ ...row, config: row.config ? { ...row.config } : row.config }))
+        selects += 1
+        if (selects === 2) opts.afterSelect?.(state)
+        return { rows: snapshot as unknown[] }
+      }
+      if (/^\s*UPDATE/i.test(text)) {
+        const [id, nextJson, prevJson] = params ?? []
+        const row = tableOf(text).find((candidate) => candidate.id === id)
+        // jsonb equality is semantic — compare parsed values, not strings.
+        const matches = row && JSON.stringify(row.config ?? {}) === JSON.stringify(JSON.parse(prevJson as string))
+        if (!matches || !row) return { rows: [] }
+        row.config = JSON.parse(nextJson as string)
+        return { rows: [{ id }] as unknown[] }
+      }
+      return { rows: [] }
+    }),
+  }
+  return { pool, queries, state }
+}
+
+describe('DT-HARDEN-03 sibling backfill — canary pre-flight', () => {
+  it('finds a canary in either table', () => {
+    withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, () => {
+      const enc = encryptStoredSecretValue('secret-live')
+      expect(findIntegrationCanary([[], [{ id: 'a', config: { appSecret: enc } }]])).toBe(enc)
+      expect(findIntegrationCanary([[{ id: 'b', config: { appsecret: enc } }], []])).toBe(enc)
+      expect(findIntegrationCanary([[{ id: 'c', config: { appSecret: 'plain' } }], []])).toBeUndefined()
+    })
+  })
+
+  it('THE catastrophe case: aborts when the canary was encrypted under a DIFFERENT salt', async () => {
+    const canary = withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, () =>
+      encryptStoredSecretValue('secret-live'),
+    )
+    await withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-b' }, async () => {
+      const { pool, queries } = makeFakePool({
+        directory: [
+          { id: 'good', config: { appSecret: canary } },
+          { id: 'victim', config: { appSecret: 'plain-live-secret' } },
+        ],
+        attendance: [],
+      })
+      await expect(runIntegrationBackfill(pool, { dryRun: false, allowFirstRun: false }))
+        .rejects.toThrow(/do not match the pair that encrypted the existing rows/)
+      expect(queries.filter((q) => /^\s*UPDATE/i.test(q.text))).toHaveLength(0)
+    })
+  })
+
+  it('aborts a plaintext-only run without --confirm-first-run', () => {
+    withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, () => {
+      expect(() => verifyIntegrationEncryptionConfig([[{ id: 'a', config: { appSecret: 'plain' } }], []], false))
+        .toThrow(/--confirm-first-run/)
+      expect(() => verifyIntegrationEncryptionConfig([[{ id: 'a', config: { appSecret: 'plain' } }], []], true))
+        .not.toThrow()
+    })
+  })
+})
+
+describe('DT-HARDEN-03 sibling backfill — rewrite + CAS', () => {
+  it('encrypts plaintext appSecrets in both tables, normalizes legacy keys, reports counts', async () => {
+    await withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, async () => {
+      const already = encryptStoredSecretValue('done')
+      const { pool, state } = makeFakePool({
+        directory: [
+          { id: 'd-plain', config: { appSecret: 'dir-secret', corpId: 'c1' } },
+          { id: 'd-done', config: { appSecret: already } },
+          { id: 'd-none', config: { corpId: 'c2' } },
+        ],
+        attendance: [{ id: 'a-legacy', config: { app_secret: 'att-secret' } }],
+      })
+
+      const result = await runIntegrationBackfill(pool, { dryRun: false, allowFirstRun: false })
+
+      expect(result.directory).toEqual({ encrypted: 1, alreadyEncrypted: 1, skippedConcurrent: 0, total: 3 })
+      expect(result.attendance).toEqual({ encrypted: 1, alreadyEncrypted: 0, skippedConcurrent: 0, total: 1 })
+      const dPlain = state.directory.find((row) => row.id === 'd-plain')!.config!
+      expect(isEncryptedSecretValue(dPlain.appSecret as string)).toBe(true)
+      expect(dPlain.corpId).toBe('c1')
+      const aLegacy = state.attendance.find((row) => row.id === 'a-legacy')!.config!
+      expect(isEncryptedSecretValue(aLegacy.appSecret as string)).toBe(true)
+      expect(aLegacy).not.toHaveProperty('app_secret')
+    })
+  })
+
+  it('dry-run writes nothing', async () => {
+    await withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, async () => {
+      const { pool, queries } = makeFakePool({
+        directory: [{ id: 'd-plain', config: { appSecret: 'dir-secret' } }],
+        attendance: [],
+      })
+      const result = await runIntegrationBackfill(pool, { dryRun: true, allowFirstRun: true })
+      expect(result.directory.encrypted).toBe(1)
+      expect(queries.filter((q) => /^\s*UPDATE/i.test(q.text))).toHaveLength(0)
+    })
+  })
+
+  it('P3-1 CAS: a config saved concurrently by an admin is skipped, never clobbered', async () => {
+    await withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, async () => {
+      const rotated = encryptStoredSecretValue('rotated-by-admin')
+      const { pool, state } = makeFakePool(
+        {
+          directory: [{ id: 'victim', config: { appSecret: 'stale-plain' } }],
+          attendance: [],
+        },
+        {
+          afterSelect: (tables) => {
+            tables.directory[0].config = { appSecret: rotated, note: 'admin edit' }
+          },
+        },
+      )
+
+      const result = await runIntegrationBackfill(pool, { dryRun: false, allowFirstRun: true })
+
+      expect(result.directory).toEqual({ encrypted: 0, alreadyEncrypted: 0, skippedConcurrent: 1, total: 1 })
+      expect(state.directory[0].config).toEqual({ appSecret: rotated, note: 'admin edit' })
+    })
+  })
+
+  it('CAS shape: the UPDATE pins jsonb equality in SQL and carries the previous config as a param', async () => {
+    await withEnv({ ENCRYPTION_KEY: 'key-a', ENCRYPTION_SALT: 'salt-a' }, async () => {
+      const { pool, queries } = makeFakePool({
+        directory: [{ id: 'd-plain', config: { appSecret: 'dir-secret' } }],
+        attendance: [],
+      })
+      await runIntegrationBackfill(pool, { dryRun: false, allowFirstRun: true })
+      const update = queries.find((q) => /^\s*UPDATE/i.test(q.text))
+      expect(update).toBeDefined()
+      expect(update!.text).toContain('AND config = $3::jsonb')
+      expect(JSON.parse(update!.params?.[2] as string)).toEqual({ appSecret: 'dir-secret' })
+    })
+  })
+})

--- a/packages/core-backend/tsconfig.json
+++ b/packages/core-backend/tsconfig.json
@@ -24,7 +24,8 @@
     "src/**/*",
     "core/**/*",
     "types/**/*",
-    "scripts/encrypt-dingtalk-destination-secrets.ts"
+    "scripts/encrypt-dingtalk-destination-secrets.ts",
+    "scripts/encrypt-dingtalk-integration-secrets.ts"
   ],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
 }

--- a/packages/core-backend/tsconfig.json
+++ b/packages/core-backend/tsconfig.json
@@ -20,6 +20,11 @@
     "lib": ["ES2022"],
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*", "core/**/*", "types/**/*"],
+  "include": [
+    "src/**/*",
+    "core/**/*",
+    "types/**/*",
+    "scripts/encrypt-dingtalk-destination-secrets.ts"
+  ],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
 }


### PR DESCRIPTION
`dingtalk_group_destinations.webhook_url` embeds the robot `access_token` and `.secret` is the HMAC signing key — together, enough to inject messages into a customer's group. Both were stored as **plain text**, while every other DingTalk credential here (appSecret, agentId, approvalCardLinkSecret) already goes through `security/encrypted-secrets`. A DB dump leaked live send capability.

**One boundary** (`dingtalk-group-destinations.ts`): encrypt on write, decrypt on read.
- create/update validate the plaintext, persist `enc:` ciphertext;
- `rowToDestination`, test-send, the masked log line, and **the automation executor's send path** all decrypt before validation / HMAC signing / masking;
- `decryptStoredSecretValue` passes non-`enc:` values through → pre-existing plaintext rows keep working and re-encrypt on next write (compatibility reader, per roadmap §6.3);
- `scripts/encrypt-dingtalk-destination-secrets.ts` backfills untouched legacy rows — idempotent, and refuses to run without an explicit `ENCRYPTION_KEY` (running with the dev default would write values production cannot decrypt).

API responses unchanged: URL masked, secret presence-only.

**Verification**: 245 unit tests pass; `tsc --noEmit` clean. **Mutation-proven twice**: (a) making the executor read the raw column turns the new send-path test red — that is the production-outage failure mode; (b) making `create()` store plaintext turns the service test red — that is the P1 itself.

No schema migration: `text` columns hold the `enc:` form.

Roadmap: DT-HARDEN-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)