### PR TITLE
fix(dingtalk): request timeout + honest partial-failure delivery semantics (DT-HARDEN-06)

### DIFF
--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -73,6 +73,8 @@ export interface DingTalkWorkNotificationResult {
 
 interface DingTalkRequestOptions {
   fetchFn?: typeof fetch
+  /** Override the default per-request timeout (DT-HARDEN-06). */
+  timeoutMs?: number
 }
 
 export interface DingTalkDepartment {
@@ -191,13 +193,55 @@ async function readJson(response: Response): Promise<Record<string, unknown> | n
   }
 }
 
+/**
+ * DT-HARDEN-06: every DingTalk call that is not the group-robot webhook goes through
+ * here — gettoken, directory sync, work notifications, approval cards, container
+ * login. They used a naked `fetch` with no timeout, so a hung connection blocked an
+ * inline automation execution or a whole directory sync for as long as undici's
+ * default (~300s). Bound them, and surface the timeout as a typed operational error
+ * so callers record a failed run/delivery instead of hanging.
+ */
+export const DINGTALK_REQUEST_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.DINGTALK_REQUEST_TIMEOUT_MS)
+  return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 10_000
+})()
+
+export class DingTalkTimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super(`DingTalk request timed out after ${timeoutMs}ms`)
+    this.name = 'DingTalkTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')
+}
+
 async function requestDingTalkJson(
   input: string,
   init: RequestInit,
   fallbackError: string,
   options?: DingTalkRequestOptions,
 ): Promise<Record<string, unknown>> {
-  const response = await (options?.fetchFn ?? fetch)(input, init)
+  const timeoutMs = options?.timeoutMs ?? DINGTALK_REQUEST_TIMEOUT_MS
+  let response: Response
+  try {
+    response = await (options?.fetchFn ?? fetch)(input, {
+      ...init,
+      // Spread first: an explicit `signal: undefined` in `init` would otherwise
+      // clobber the timeout. A caller-supplied signal still wins.
+      signal: init.signal ?? AbortSignal.timeout(timeoutMs),
+    })
+  } catch (error) {
+    if (isAbortError(error)) {
+      logger.warn(`DingTalk request timed out after ${timeoutMs}ms`)
+      throw new DingTalkTimeoutError(timeoutMs)
+    }
+    throw error
+  }
   const payload = await readJson(response)
 
   if (!response.ok) {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2672,8 +2672,29 @@ export class AutomationExecutor {
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
-      await markDingTalkApprovalCardDeliverySendFailed(this.deps.queryFn, delivery.id, errorMessage).catch(() => null)
-      return { actionType, status: 'failed', error: errorMessage, output: { deliveryId: delivery.id } }
+      // DT-HARDEN-06: if the ledger row cannot be flipped out of `pending`, the card is
+      // fail-closed but invisible — no sweeper, no admin listing. Swallowing that
+      // silently (`.catch(() => null)`) hid the only signal an operator would ever get.
+      // The send failure is still what we report; the bookkeeping failure is surfaced.
+      let ledgerError: string | null = null
+      try {
+        await markDingTalkApprovalCardDeliverySendFailed(this.deps.queryFn, delivery.id, errorMessage)
+      } catch (markError) {
+        ledgerError = markError instanceof Error ? markError.message : String(markError)
+        logger.error(
+          `DingTalk approval-card delivery ${delivery.id} is stuck pending: failed to record the send failure`,
+          markError instanceof Error ? markError : new Error(ledgerError),
+        )
+      }
+      return {
+        actionType,
+        status: 'failed',
+        error: errorMessage,
+        output: {
+          deliveryId: delivery.id,
+          ...(ledgerError ? { deliveryLedgerError: ledgerError, deliveryStuckPending: true } : {}),
+        },
+      }
     }
   }
 
@@ -2925,6 +2946,11 @@ export class AutomationExecutor {
     }
     const batches = chunkItems(resolvedRecipients, DINGTALK_PERSON_BATCH_SIZE)
 
+    // DT-HARDEN-06: recipients whose batch already reached DingTalk. A later batch
+    // throwing must not re-mark them failed — that used to write BOTH a success and a
+    // failed delivery row for the same recipient in the same send attempt.
+    const sentRecipients = new Set<(typeof resolvedRecipients)[number]>()
+
     try {
       const messageConfig = await readDingTalkMessageConfigFromRuntime()
       const accessToken = await fetchDingTalkAppAccessToken(messageConfig, { fetchFn: this.deps.fetchFn })
@@ -2958,6 +2984,7 @@ export class AutomationExecutor {
           recordId: context.recordId,
           initiatedBy: context.actorId ?? null,
         })))
+        for (const recipient of batch) sentRecipients.add(recipient)
       }
 
       return {
@@ -2990,7 +3017,12 @@ export class AutomationExecutor {
           : null
       const errorMessage = error instanceof Error ? error.message : String(error)
 
-      await Promise.all(resolvedRecipients.map((recipient) => recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
+      // DT-HARDEN-06: only recipients whose batch never reached DingTalk are failures.
+      // Recipients from earlier successful batches keep their success row — the send
+      // did happen for them, and a partial failure is a partial result, not a total one.
+      const unsentRecipients = resolvedRecipients.filter((recipient) => !sentRecipients.has(recipient))
+
+      await Promise.all(unsentRecipients.map((recipient) => recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
         localUserId: recipient.localUserId,
         dingtalkUserId: recipient.dingtalkUserId,
         sourceType: 'automation',
@@ -3010,6 +3042,11 @@ export class AutomationExecutor {
         actionType: 'send_dingtalk_person_message',
         status: 'failed',
         error: errorMessage,
+        output: {
+          notifiedUsers: sentRecipients.size,
+          failedRecipientCount: unsentRecipients.length,
+          batchCount: batches.length,
+        },
       }
     }
   }

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -1303,6 +1303,87 @@ describe('AutomationExecutor', () => {
     expect(insertCalls).toHaveLength(2)
   })
 
+  // DT-HARDEN-06: work notifications go out in batches of 100. When a later batch threw,
+  // the catch marked EVERY resolved recipient failed — including the earlier batches that
+  // had already been sent AND already had a success row written. The same recipient ended
+  // up with both a success and a failed delivery row for one send attempt.
+  it('records only unsent recipients as failed when a later batch throws (DT-HARDEN-06)', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const recipientCount = 150 // → two batches: 100 + 50
+    const recipientRows = Array.from({ length: recipientCount }, (_, i) => ({
+      local_user_id: `user_${i}`,
+      local_user_active: true,
+      dingtalk_user_id: `dt-user-${i}`,
+    }))
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({ rows: recipientRows })
+      .mockResolvedValue({ rows: [] })
+
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      // batch 1 (100 recipients) succeeds
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      // batch 2 (50 recipients) is rejected by DingTalk
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 88, errmsg: 'rate limited' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: recipientRows.map((row) => row.local_user_id),
+          titleTemplate: 'T',
+          bodyTemplate: 'B',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+
+    const deliveryInserts = queryFn.mock.calls
+      .filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
+      .map((call) => {
+        const params = call[1] as unknown[]
+        return { localUserId: String(params[1]), status: String(params[7]) }
+      })
+
+    const succeeded = deliveryInserts.filter((row) => row.status === 'success').map((row) => row.localUserId)
+    const failed = deliveryInserts.filter((row) => row.status === 'failed').map((row) => row.localUserId)
+
+    // Exactly one row per recipient — no double-recording.
+    expect(deliveryInserts).toHaveLength(recipientCount)
+    expect(succeeded).toHaveLength(100)
+    expect(failed).toHaveLength(50)
+
+    // The load-bearing invariant: nobody is both success and failed for one attempt.
+    const overlap = succeeded.filter((id) => failed.includes(id))
+    expect(overlap).toEqual([])
+
+    // Partial success is reported as a partial result.
+    expect(result.steps[0]?.output).toMatchObject({ notifiedUsers: 100, failedRecipientCount: 50 })
+  })
+
   it('fails send_dingtalk_person_message when the internal processing view is not in the sheet', async () => {
     process.env.DINGTALK_APP_KEY = 'dt-app-key'
     process.env.DINGTALK_APP_SECRET = 'dt-app-secret'

--- a/packages/core-backend/tests/unit/dingtalk-request-timeout.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-request-timeout.test.ts
@@ -62,18 +62,30 @@ describe('DT-HARDEN-06 DingTalk request timeout', () => {
     await expect(fetchDingTalkAppAccessToken(config, { fetchFn: ok })).resolves.toBe('fresh')
   })
 
-  it('lets a caller-supplied signal win over the default timeout', async () => {
-    const controller = new AbortController()
-    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0 }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })) as unknown as typeof fetch
+  it('hands the real fetch a live timeout AbortSignal (asserted on what production passes, not a re-implemented merge)', async () => {
+    let seenInit: RequestInit | undefined
+    const fetchFn = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      seenInit = init
+      return new Response(JSON.stringify({ errcode: 0, access_token: 'tok', expires_in: 7200 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as unknown as typeof fetch
 
-    // fetchDingTalkAppAccessToken does not expose init, so assert the precedence rule
-    // directly on the shape requestDingTalkJson builds: spread-then-signal.
-    const init: RequestInit = { method: 'GET', signal: controller.signal }
-    const merged = { ...init, signal: init.signal ?? AbortSignal.timeout(1) }
-    expect(merged.signal).toBe(controller.signal)
-    expect(fetchFn).not.toHaveBeenCalled()
+    await fetchDingTalkAppAccessToken(config, { fetchFn })
+
+    // The previous version re-implemented `{ ...init, signal: init.signal ?? AbortSignal.timeout() }`
+    // in the test and asserted on that local object — a tautology that stayed green even when
+    // production's merge dropped the signal or flipped the spread order. Assert instead on the
+    // init that actually reached fetch: production must hand it a live (un-aborted) AbortSignal —
+    // the timeout. A regression that omits or nulls the signal turns this red.
+    expect(seenInit?.signal).toBeInstanceOf(AbortSignal)
+    expect(seenInit?.signal?.aborted).toBe(false)
   })
+
+  // NOTE on the spread-order precedence (`{ ...init, signal: init.signal ?? … }` vs
+  // `{ signal: …, ...init }`): it cannot be exercised through the public surface because no
+  // in-repo caller passes an `init.signal`, and `requestDingTalkJson` is not exported. The order
+  // in client.ts is correct (spread-first, caller-signal-wins); it is left structurally correct
+  // rather than tested through a re-implemented merge, which proves nothing.
 })

--- a/packages/core-backend/tests/unit/dingtalk-request-timeout.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-request-timeout.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  DINGTALK_REQUEST_TIMEOUT_MS,
+  DingTalkTimeoutError,
+  __resetDingTalkAppAccessTokenCacheForTests,
+  fetchDingTalkAppAccessToken,
+} from '../../src/integrations/dingtalk/client'
+
+/**
+ * DT-HARDEN-06 — every DingTalk call except the group-robot webhook went through a
+ * naked `fetch` with no timeout, so a hung connection blocked an inline automation
+ * execution (or a whole directory sync) for undici's ~300s default.
+ */
+describe('DT-HARDEN-06 DingTalk request timeout', () => {
+  afterEach(() => {
+    __resetDingTalkAppAccessTokenCacheForTests()
+    vi.unstubAllEnvs()
+  })
+
+  const config = { appKey: 'key', appSecret: 'secret' }
+
+  it('has a bounded default timeout', () => {
+    expect(DINGTALK_REQUEST_TIMEOUT_MS).toBeGreaterThan(0)
+    expect(DINGTALK_REQUEST_TIMEOUT_MS).toBeLessThanOrEqual(60_000)
+  })
+
+  it('passes an abort signal to fetch so the request cannot hang', async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, access_token: 't', expires_in: 7200 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    await fetchDingTalkAppAccessToken(config, { fetchFn })
+
+    const [, init] = (fetchFn as unknown as { mock: { calls: Array<[string, RequestInit]> } }).mock.calls[0]
+    expect(init.signal).toBeTruthy()
+    expect(init.signal?.aborted).toBe(false)
+  })
+
+  it('surfaces an aborted request as a typed DingTalkTimeoutError', async () => {
+    const abortError = new Error('The operation was aborted')
+    abortError.name = 'TimeoutError'
+    const fetchFn = vi.fn(async () => {
+      throw abortError
+    }) as unknown as typeof fetch
+
+    await expect(fetchDingTalkAppAccessToken(config, { fetchFn })).rejects.toBeInstanceOf(DingTalkTimeoutError)
+  })
+
+  it('does not cache a token when the request timed out', async () => {
+    const abortError = new Error('aborted')
+    abortError.name = 'AbortError'
+    const failing = vi.fn(async () => {
+      throw abortError
+    }) as unknown as typeof fetch
+    await expect(fetchDingTalkAppAccessToken(config, { fetchFn: failing })).rejects.toBeInstanceOf(DingTalkTimeoutError)
+
+    const ok = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, access_token: 'fresh', expires_in: 7200 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+    await expect(fetchDingTalkAppAccessToken(config, { fetchFn: ok })).resolves.toBe('fresh')
+  })
+
+  it('lets a caller-supplied signal win over the default timeout', async () => {
+    const controller = new AbortController()
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    // fetchDingTalkAppAccessToken does not expose init, so assert the precedence rule
+    // directly on the shape requestDingTalkJson builds: spread-then-signal.
+    const init: RequestInit = { method: 'GET', signal: controller.signal }
+    const merged = { ...init, signal: init.signal ?? AbortSignal.timeout(1) }
+    expect(merged.signal).toBe(controller.signal)
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Three reliability fixes.

1. **Request timeout**: `requestDingTalkJson` used a naked `fetch` with no timeout — gettoken, directory sync, work notifications, approval cards and container login could hang for undici's ~300s default *inside an inline automation execution*. Bounded by `AbortSignal.timeout` (`DINGTALK_REQUEST_TIMEOUT_MS`, default 10s) and surfaced as a typed `DingTalkTimeoutError` so callers record a failed run/delivery instead of hanging. The spread order is deliberate: an explicit `signal: undefined` in a caller's init must not clobber the timeout.
2. **Partial-failure semantics**: work notifications batch by 100. When a later batch threw, the catch marked **every** resolved recipient failed — including earlier batches already sent *and already holding a success row*. One send attempt produced both a success and a failed row for the same recipient. Only unsent recipients are failed now; partial success is reported as a partial result.
3. **Card ledger visibility**: approval-card mark-send-failed swallowed its own error (`.catch(() => null)`), so a card stuck `pending` was fail-closed but invisible. Now logged and surfaced on the step output.

**Verification**: 235 unit tests pass; `tsc --noEmit` clean. **Mutation-proven twice**: (a) reverting the catch to mark all recipients turns the new 150-recipient/2-batch test red on the no-double-recording invariant; (b) dropping the abort signal turns the timeout test red.

Roadmap: DT-HARDEN-06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)