### PR TITLE
fix(dingtalk): batch bind/unbind keeps the audit trail of committed items (DT-HARDEN-04)

### DIFF
--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3261,24 +3261,46 @@ export async function getDirectoryReviewItem(
   return summarizeReviewItem(row, recommendationsByAccount.get(row.directory_account_id) ?? null)
 }
 
+/**
+ * DT-HARDEN-04: batch bind/unbind commit one account per transaction. A fail-fast loop
+ * threw on the first bad item, so the caller never learned which items had already
+ * COMMITTED — and the route, which wrote its audit entries only after the whole batch
+ * returned, silently dropped the audit trail for every one of them. Compliance gap.
+ *
+ * Each item is now isolated: a failure is a per-item outcome, never a lost success.
+ * Partial failure is a normal batch result, so callers can audit every success and
+ * report exactly which items failed and why.
+ */
+export type DirectoryAccountBatchOutcome = {
+  succeeded: DirectoryAccountMutationResult[]
+  failed: Array<{ accountId: string; error: string }>
+}
+
 export async function batchUnbindDirectoryAccounts(
   directoryAccountIds: string[],
   input: DirectoryAccountUnbindInput,
-): Promise<DirectoryAccountMutationResult[]> {
+): Promise<DirectoryAccountBatchOutcome> {
   const normalizedIds = Array.from(new Set(directoryAccountIds.map((item) => normalizeText(item)).filter(Boolean)))
   if (normalizedIds.length === 0) throw new Error('accountIds are required')
 
-  const results: DirectoryAccountMutationResult[] = []
+  const outcome: DirectoryAccountBatchOutcome = { succeeded: [], failed: [] }
   for (const directoryAccountId of normalizedIds) {
-    results.push(await unbindDirectoryAccount(directoryAccountId, input))
+    try {
+      outcome.succeeded.push(await unbindDirectoryAccount(directoryAccountId, input))
+    } catch (error) {
+      outcome.failed.push({
+        accountId: directoryAccountId,
+        error: readErrorMessage(error, 'Failed to unbind directory account'),
+      })
+    }
   }
-  return results
+  return outcome
 }
 
 export async function batchBindDirectoryAccounts(
   entries: DirectoryAccountBatchBindEntry[],
   input: { adminUserId: string },
-): Promise<DirectoryAccountMutationResult[]> {
+): Promise<DirectoryAccountBatchOutcome> {
   const normalizedEntries = entries
     .map((entry) => ({
       accountId: normalizeText(entry.accountId),
@@ -3289,15 +3311,23 @@ export async function batchBindDirectoryAccounts(
 
   if (normalizedEntries.length === 0) throw new Error('bindings are required')
 
-  const results: DirectoryAccountMutationResult[] = []
+  // DT-HARDEN-04: per-item isolation — see DirectoryAccountBatchOutcome.
+  const outcome: DirectoryAccountBatchOutcome = { succeeded: [], failed: [] }
   for (const entry of normalizedEntries) {
-    results.push(await bindDirectoryAccount(entry.accountId, {
-      localUserRef: entry.localUserRef,
-      adminUserId: input.adminUserId,
-      enableDingTalkGrant: entry.enableDingTalkGrant,
-    }))
+    try {
+      outcome.succeeded.push(await bindDirectoryAccount(entry.accountId, {
+        localUserRef: entry.localUserRef,
+        adminUserId: input.adminUserId,
+        enableDingTalkGrant: entry.enableDingTalkGrant,
+      }))
+    } catch (error) {
+      outcome.failed.push({
+        accountId: entry.accountId,
+        error: readErrorMessage(error, 'Failed to bind directory account'),
+      })
+    }
   }
-  return results
+  return outcome
 }
 
 async function applyDirectoryAccountBindInTransaction(

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -615,8 +615,10 @@ export function adminDirectoryRouter(): Router {
           enableDingTalkGrant: typeof entry.enableDingTalkGrant === 'boolean' ? entry.enableDingTalkGrant : true,
         }))
 
-      const results = await batchBindDirectoryAccounts(bindings, { adminUserId })
-      await Promise.all(results.map((result) => auditLog({
+      const outcome = await batchBindDirectoryAccounts(bindings, { adminUserId })
+      // DT-HARDEN-04: audit every COMMITTED item, even when a later item failed. The
+      // batch used to fail fast, so items already committed lost their audit trail.
+      await Promise.all(outcome.succeeded.map((result) => auditLog({
         actorId: adminUserId,
         actorType: 'user',
         action: 'bind',
@@ -636,9 +638,18 @@ export function adminDirectoryRouter(): Router {
           selectionSize: bindings.length,
         },
       })))
+
+      // Nothing committed → keep the historical error mapping. Otherwise a partial
+      // failure is a normal batch result the caller can act on per item.
+      if (outcome.succeeded.length === 0 && outcome.failed.length > 0) {
+        throw new Error(outcome.failed[0].error)
+      }
+
       jsonOk(res, {
-        items: results.map((result) => result.account),
-        updatedCount: results.length,
+        items: outcome.succeeded.map((result) => result.account),
+        updatedCount: outcome.succeeded.length,
+        failedCount: outcome.failed.length,
+        failed: outcome.failed,
       })
     } catch (error) {
       const message = readErrorMessage(error, 'Failed to batch bind directory accounts')
@@ -700,11 +711,12 @@ export function adminDirectoryRouter(): Router {
       const rawAccountIds = Array.isArray(req.body?.accountIds) ? req.body.accountIds : []
       const accountIds = rawAccountIds.filter((value): value is string => typeof value === 'string')
       const disableDingTalkGrant = req.body?.disableDingTalkGrant === true
-      const results = await batchUnbindDirectoryAccounts(accountIds, {
+      const outcome = await batchUnbindDirectoryAccounts(accountIds, {
         adminUserId,
         disableDingTalkGrant,
       })
-      await Promise.all(results.map((result) => auditLog({
+      // DT-HARDEN-04: audit every COMMITTED item, even when a later item failed.
+      await Promise.all(outcome.succeeded.map((result) => auditLog({
         actorId: adminUserId,
         actorType: 'user',
         action: 'unbind',
@@ -723,9 +735,16 @@ export function adminDirectoryRouter(): Router {
           selectionSize: accountIds.length,
         },
       })))
+
+      if (outcome.succeeded.length === 0 && outcome.failed.length > 0) {
+        throw new Error(outcome.failed[0].error)
+      }
+
       jsonOk(res, {
-        items: results.map((result) => result.account),
-        updatedCount: results.length,
+        items: outcome.succeeded.map((result) => result.account),
+        updatedCount: outcome.succeeded.length,
+        failedCount: outcome.failed.length,
+        failed: outcome.failed,
         disableDingTalkGrant,
       })
     } catch (error) {

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -1066,7 +1066,7 @@ describe('adminDirectoryRouter', () => {
   })
 
   it('batch binds directory accounts', async () => {
-    directoryMocks.batchBindDirectoryAccounts.mockResolvedValue([
+    directoryMocks.batchBindDirectoryAccounts.mockResolvedValue({ failed: [], succeeded: [
       {
         account: {
           id: 'account-1',
@@ -1093,7 +1093,7 @@ describe('adminDirectoryRouter', () => {
         },
         previousLocalUser: null,
       },
-    ])
+    ] })
 
     const response = await invokeRoute('post', '/accounts/batch-bind', {
       body: {
@@ -1140,6 +1140,89 @@ describe('adminDirectoryRouter', () => {
     })
   })
 
+  // DT-HARDEN-04: the batch used to fail fast. Items already COMMITTED never got their
+  // audit entry (the route audited only after the whole batch returned) and the caller
+  // got one error instead of per-item results.
+  it('audits committed items and reports per-item failures when part of a batch-bind fails', async () => {
+    directoryMocks.batchBindDirectoryAccounts.mockResolvedValue({
+      succeeded: [
+        {
+          account: { id: 'account-1', integrationId: 'dir-1', corpId: 'dingcorp', externalUserId: 'ext-1', localUser: { id: 'u1', email: 'alpha@example.com' } },
+          previousLocalUser: null,
+        },
+      ],
+      failed: [{ accountId: 'account-2', error: 'DingTalk account is already bound to another local user' }],
+    })
+
+    const response = await invokeRoute('post', '/accounts/batch-bind', {
+      body: {
+        bindings: [
+          { accountId: 'account-1', localUserRef: 'alpha@example.com' },
+          { accountId: 'account-2', localUserRef: 'beta@example.com' },
+        ],
+      },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    // Partial failure is a normal batch result, not a total HTTP failure.
+    expect(response.statusCode).toBe(200)
+    // The load-bearing assertion: the committed item still produced an audit entry.
+    expect(auditMocks.auditLog).toHaveBeenCalledTimes(1)
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'bind',
+      resourceId: 'account-1',
+    }))
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        items: [{ id: 'account-1' }],
+        updatedCount: 1,
+        failedCount: 1,
+        failed: [{ accountId: 'account-2', error: expect.stringContaining('already bound') }],
+      },
+    })
+  })
+
+  it('keeps the historical error mapping when a batch-bind commits nothing', async () => {
+    directoryMocks.batchBindDirectoryAccounts.mockResolvedValue({
+      succeeded: [],
+      failed: [{ accountId: 'account-1', error: 'DingTalk account is already bound to another local user' }],
+    })
+
+    const response = await invokeRoute('post', '/accounts/batch-bind', {
+      body: { bindings: [{ accountId: 'account-1', localUserRef: 'alpha@example.com' }] },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('audits committed items when part of a batch-unbind fails', async () => {
+    directoryMocks.batchUnbindDirectoryAccounts.mockResolvedValue({
+      succeeded: [
+        {
+          account: { id: 'account-1', integrationId: 'dir-1', corpId: 'dingcorp', externalUserId: 'ext-1', localUser: null },
+          previousLocalUser: { id: 'u1', email: 'alpha@example.com', name: 'Alpha' },
+        },
+      ],
+      failed: [{ accountId: 'account-2', error: 'Directory account not found' }],
+    })
+
+    const response = await invokeRoute('post', '/accounts/batch-unbind', {
+      body: { accountIds: ['account-1', 'account-2'] },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(auditMocks.auditLog).toHaveBeenCalledTimes(1)
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'unbind', resourceId: 'account-1' }))
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: { updatedCount: 1, failedCount: 1, failed: [{ accountId: 'account-2' }] },
+    })
+  })
+
   it('unbinds a directory account', async () => {
     directoryMocks.unbindDirectoryAccount.mockResolvedValue({
       account: {
@@ -1178,7 +1261,7 @@ describe('adminDirectoryRouter', () => {
   })
 
   it('batch unbinds directory accounts', async () => {
-    directoryMocks.batchUnbindDirectoryAccounts.mockResolvedValue([
+    directoryMocks.batchUnbindDirectoryAccounts.mockResolvedValue({ failed: [], succeeded: [
       {
         account: {
           id: 'account-1',
@@ -1207,7 +1290,7 @@ describe('adminDirectoryRouter', () => {
           name: 'Beta',
         },
       },
-    ])
+    ] })
 
     const response = await invokeRoute('post', '/accounts/batch-unbind', {
       body: {

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -34,7 +34,7 @@ vi.mock('../../src/auth/invite-tokens', () => ({
   issueInviteToken: inviteTokenMocks.issueInviteToken,
 }))
 
-import { admitDirectoryAccountUser, bindDirectoryAccount, unbindDirectoryAccount } from '../../src/directory/directory-sync'
+import { admitDirectoryAccountUser, batchUnbindDirectoryAccounts, bindDirectoryAccount, unbindDirectoryAccount } from '../../src/directory/directory-sync'
 
 describe('bindDirectoryAccount', () => {
   beforeEach(() => {
@@ -987,5 +987,73 @@ describe('bindDirectoryAccount', () => {
       expect.stringContaining('INSERT INTO user_external_auth_grants'),
       ['dingtalk', 'user-1', 'admin-1'],
     )
+  })
+
+  // DT-HARDEN-04: each account commits in its own transaction. A fail-fast loop threw on
+  // the first bad item, so the caller never learned which items had already COMMITTED —
+  // and the route, auditing only after the whole batch returned, dropped their audit trail.
+  it('isolates a failing item so already-committed items are still returned (batch unbind)', async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      // account-1 loads, unbinds, and reloads its summary
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: 'ext-1',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: null,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ local_user_id: 'user-1', local_user_email: 'alpha@example.com', local_user_name: 'Alpha' }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: 'ext-1',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '林岚',
+          account_email: null,
+          account_mobile: null,
+          account_is_active: true,
+          account_updated_at: '2026-07-08T00:00:00.000Z',
+          link_status: 'unmatched',
+          match_strategy: 'manual_unbound',
+          reviewed_by: null,
+          review_note: null,
+          link_updated_at: '2026-07-08T00:00:00.000Z',
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+          department_paths: [],
+        }],
+      })
+      // account-2 does not exist → unbindDirectoryAccount throws
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const outcome = await batchUnbindDirectoryAccounts(['account-1', 'account-2'], {
+      adminUserId: 'admin-1',
+    })
+
+    // The load-bearing invariant: the committed item survives the later failure.
+    expect(outcome.succeeded).toHaveLength(1)
+    expect(outcome.succeeded[0].account.id).toBe('account-1')
+    expect(outcome.failed).toEqual([
+      { accountId: 'account-2', error: expect.stringMatching(/not found/i) },
+    ])
+    // account-1 really did commit (its transaction ran).
+    expect(pgMocks.transaction).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -34,7 +34,7 @@ vi.mock('../../src/auth/invite-tokens', () => ({
   issueInviteToken: inviteTokenMocks.issueInviteToken,
 }))
 
-import { admitDirectoryAccountUser, batchUnbindDirectoryAccounts, bindDirectoryAccount, unbindDirectoryAccount } from '../../src/directory/directory-sync'
+import { admitDirectoryAccountUser, batchBindDirectoryAccounts, batchUnbindDirectoryAccounts, bindDirectoryAccount, unbindDirectoryAccount } from '../../src/directory/directory-sync'
 
 describe('bindDirectoryAccount', () => {
   beforeEach(() => {
@@ -1054,6 +1054,90 @@ describe('bindDirectoryAccount', () => {
       { accountId: 'account-2', error: expect.stringMatching(/not found/i) },
     ])
     // account-1 really did commit (its transaction ran).
+    expect(pgMocks.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  // DT-HARDEN-04: symmetric to the batch-unbind isolation test above. A fail-fast bind
+  // loop would abort the whole batch on the first bad item, so a valid bind earlier in
+  // the batch would never be reported (or even attempted, once the batch is reordered).
+  it('isolates a failing item so already-committed items are still returned (batch bind)', async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      // account-1: loads with no previous link, resolves the local user, binds, and reloads its summary
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: '13900001234',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          account_name: '林岚',
+          account_email: null,
+          account_mobile: '13900001234',
+          account_is_active: true,
+          account_updated_at: '2026-07-08T00:00:00.000Z',
+          link_status: 'linked',
+          match_strategy: 'manual_admin',
+          reviewed_by: 'admin-1',
+          review_note: null,
+          link_updated_at: '2026-07-08T00:00:00.000Z',
+          local_user_id: 'user-1',
+          local_user_email: 'alpha@example.com',
+          local_user_name: 'Alpha',
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+      // account-2 does not exist → bindDirectoryAccount throws before ever opening a transaction
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const outcome = await batchBindDirectoryAccounts([
+      { accountId: 'account-1', localUserRef: 'alpha@example.com', enableDingTalkGrant: true },
+      { accountId: 'account-2', localUserRef: 'beta@example.com', enableDingTalkGrant: true },
+    ], { adminUserId: 'admin-1' })
+
+    // The load-bearing invariant: the committed bind survives the later failure.
+    expect(outcome.succeeded).toHaveLength(1)
+    expect(outcome.succeeded[0].account.id).toBe('account-1')
+    expect(outcome.failed).toEqual([
+      { accountId: 'account-2', error: expect.stringMatching(/not found/i) },
+    ])
+    // account-1 really did commit (its transaction ran); account-2 never opened one.
     expect(pgMocks.transaction).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Batch bind/unbind commit **one account per transaction**, but the loop failed fast: the first bad item threw, so the caller never learned which items had already **committed** — and the route, which wrote its audit entries only *after* the whole batch returned, silently dropped the audit trail for every one of them. A compliance gap, not a cosmetic one.

- `batchBind/batchUnbindDirectoryAccounts` isolate each item and return `{ succeeded, failed }` instead of throwing on one item;
- the routes audit **every committed item**, even when a later item fails;
- partial failure is a normal `200` batch result carrying per-item errors (`failedCount`, `failed[]`);
- when **nothing** commits, the historical error mapping (404/409/400) is preserved, so single-item failures behave exactly as before.

**Web compatibility**: `DirectoryManagementView` reads `data.items` (now the succeeded set) and throws on `!response.ok` — unchanged behavior. Surfacing `failedCount`/`failed` in the UI is a follow-up.

**Verification**: 49 unit tests pass (35 route + 14 service); `tsc --noEmit` clean. **Mutation-proven twice**: (a) reverting the service to fail-fast turns the new service isolation test red; (b) making the route throw whenever anything failed turns the committed-item audit test red.

Roadmap: DT-HARDEN-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)