### PR TITLE
fix(dingtalk): claim a sync run lease before the DingTalk API pull (DT-HARDEN-05)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -402,6 +402,7 @@ jobs:
             tests/integration/directory-sync-preview-apply-parity.db.test.ts \
             tests/integration/directory-sync-alert-coverage.db.test.ts \
             tests/integration/directory-deprovision-selection.db.test.ts \
+            tests/integration/directory-sync-run-lease.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/src/db/migrations/zzzz20260708100000_directory_sync_run_lease.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260708100000_directory_sync_run_lease.ts
@@ -18,6 +18,12 @@ import { sql, type Kysely } from 'kysely'
  * Backfill: any `running` row on deploy is by definition orphaned — the process that
  * owned it is being replaced — so it is closed out first, which also clears the
  * pre-existing zombie rows that had no recovery path at all.
+ *
+ * Liveness: `last_heartbeat_at` is the owner's proof of life. The sync beats it on an
+ * interval while it runs, and reclaim treats a run as dead only when the heartbeat
+ * (falling back to `started_at` for a run that died before its first beat) has gone
+ * stale — a wall-clock age on `started_at` alone would steal the lease from a live
+ * long-running sync on a large tenant.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
@@ -34,8 +40,14 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     ON directory_sync_runs(integration_id)
     WHERE status = 'running'
   `.execute(db)
+
+  await sql`
+    ALTER TABLE directory_sync_runs
+    ADD COLUMN IF NOT EXISTS last_heartbeat_at TIMESTAMPTZ
+  `.execute(db)
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE directory_sync_runs DROP COLUMN IF EXISTS last_heartbeat_at`.execute(db)
   await sql`DROP INDEX IF EXISTS uq_directory_sync_runs_one_running_per_integration`.execute(db)
 }

--- a/packages/core-backend/src/db/migrations/zzzz20260708100000_directory_sync_run_lease.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260708100000_directory_sync_run_lease.ts
@@ -1,0 +1,41 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * DT-HARDEN-05 — directory sync run lease.
+ *
+ * `syncDirectoryIntegration` inserts its `directory_sync_runs` row and then pulls the
+ * entire DingTalk directory (departments + users) before opening its apply
+ * transaction. Nothing stopped a manual sync, the scheduler, and a second app replica
+ * from doing that concurrently: double consumption of the shared DingTalk API quota,
+ * two big apply transactions lock-waiting on the same integration, and a `last_seen_at
+ * < syncTimestamp` sweep that can deactivate rows the other run just wrote.
+ *
+ * A partial unique index on the run row makes "at most one running run per
+ * integration" a database invariant, enforced BEFORE the first outbound API call
+ * (the run row already predates it). The second caller hits a unique violation and is
+ * told a run is already in flight.
+ *
+ * Backfill: any `running` row on deploy is by definition orphaned — the process that
+ * owned it is being replaced — so it is closed out first, which also clears the
+ * pre-existing zombie rows that had no recovery path at all.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE directory_sync_runs
+       SET status = 'failed',
+           finished_at = COALESCE(finished_at, NOW()),
+           error_message = COALESCE(error_message, 'orphaned by restart (DT-HARDEN-05 backfill)'),
+           updated_at = NOW()
+     WHERE status = 'running'
+  `.execute(db)
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_directory_sync_runs_one_running_per_integration
+    ON directory_sync_runs(integration_id)
+    WHERE status = 'running'
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS uq_directory_sync_runs_one_running_per_integration`.execute(db)
+}

--- a/packages/core-backend/src/directory/directory-sync-scheduler.ts
+++ b/packages/core-backend/src/directory/directory-sync-scheduler.ts
@@ -1,7 +1,7 @@
 import { Logger } from '../core/logger'
 import { query } from '../db/pg'
 import { SchedulerServiceImpl } from '../services/SchedulerService'
-import { syncDirectoryIntegration } from './directory-sync'
+import { DirectorySyncInProgressError, reclaimStaleDirectorySyncRuns, syncDirectoryIntegration } from './directory-sync'
 
 type DirectoryScheduleRow = {
   id: string
@@ -53,7 +53,18 @@ async function getScheduleRow(integrationId: string): Promise<DirectoryScheduleR
 }
 
 async function runScheduledSync(integrationId: string): Promise<void> {
-  await syncDirectoryIntegration(integrationId, SYSTEM_TRIGGERED_BY, 'scheduler')
+  try {
+    await syncDirectoryIntegration(integrationId, SYSTEM_TRIGGERED_BY, 'scheduler')
+  } catch (error) {
+    // DT-HARDEN-05: a manual sync (or another replica's scheduler) already holds the
+    // lease. Skipping is the correct outcome — the directory is being refreshed. Any
+    // other failure stays an error so the job reports it.
+    if (error instanceof DirectorySyncInProgressError) {
+      logger.info(`Skipped scheduled directory sync for ${integrationId}: ${error.message}`)
+      return
+    }
+    throw error
+  }
 }
 
 async function applySchedule(row: DirectoryScheduleRow | null): Promise<void> {
@@ -98,6 +109,15 @@ export async function startDirectorySyncScheduler(
 
   scheduler = options.scheduler ?? new SchedulerServiceImpl()
   started = true
+
+  try {
+    // DT-HARDEN-05: a crash or redeploy leaves `running` run rows nobody owns, which
+    // would hold the lease until it expires. Sweep them once at boot so an integration
+    // is never wedged waiting for a process that no longer exists.
+    await reclaimStaleDirectorySyncRuns()
+  } catch (error) {
+    logger.warn(`Failed to reclaim stale directory sync runs: ${error instanceof Error ? error.message : String(error)}`)
+  }
 
   try {
     const rows = await listScheduleRows()

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -2682,6 +2682,107 @@ async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
   }
 }
 
+/**
+ * DT-HARDEN-05 — how long a `running` run row may sit before another caller may assume
+ * its owner died and reclaim the lease. Deliberately generous: a large-tenant sync is
+ * a long serial walk over the DingTalk directory API.
+ */
+export const DIRECTORY_SYNC_LEASE_TTL_MINUTES = (() => {
+  const raw = Number(process.env.DIRECTORY_SYNC_LEASE_TTL_MINUTES)
+  return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 120
+})()
+
+/** Thrown when another sync already holds the lease for this integration. */
+export class DirectorySyncInProgressError extends Error {
+  readonly statusCode = 409
+  readonly code = 'DIRECTORY_SYNC_IN_PROGRESS'
+  readonly activeRunId: string | null
+
+  constructor(activeRunId: string | null) {
+    super(
+      activeRunId
+        ? `A directory sync is already running for this integration (run ${activeRunId})`
+        : 'A directory sync is already running for this integration',
+    )
+    this.name = 'DirectorySyncInProgressError'
+    this.activeRunId = activeRunId
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === '23505'
+}
+
+/**
+ * Close out `running` rows whose owner is gone (crash, redeploy, killed pod). Without
+ * this a single crash would wedge the integration behind a lease nobody holds.
+ * Exported so the scheduler can sweep once at boot rather than waiting for the next
+ * manual trigger to unstick it.
+ */
+export async function reclaimStaleDirectorySyncRuns(integrationId?: string): Promise<number> {
+  const params: unknown[] = [DIRECTORY_SYNC_LEASE_TTL_MINUTES]
+  let scope = ''
+  if (integrationId && normalizeText(integrationId)) {
+    params.push(normalizeText(integrationId))
+    scope = ` AND integration_id = $${params.length}`
+  }
+
+  const result = await query<{ id: string }>(
+    `UPDATE directory_sync_runs
+        SET status = 'failed',
+            finished_at = NOW(),
+            error_message = COALESCE(error_message, 'orphaned: sync lease expired'),
+            updated_at = NOW()
+      WHERE status = 'running'
+        AND started_at < NOW() - ($1::int * INTERVAL '1 minute')${scope}
+      RETURNING id`,
+    params,
+  )
+  if (result.rows.length > 0) {
+    logger.warn(`Reclaimed ${result.rows.length} stale directory sync run(s)`)
+  }
+  return result.rows.length
+}
+
+async function findActiveDirectorySyncRunId(integrationId: string): Promise<string | null> {
+  const result = await query<{ id: string }>(
+    `SELECT id
+       FROM directory_sync_runs
+      WHERE integration_id = $1 AND status = 'running'
+      ORDER BY started_at DESC
+      LIMIT 1`,
+    [integrationId],
+  )
+  return result.rows[0]?.id ?? null
+}
+
+/**
+ * Atomic lease claim: the partial unique index on (integration_id) WHERE status='running'
+ * makes a concurrent second claim a unique violation, so exactly one caller proceeds.
+ * A plain "SELECT then INSERT" check would race under READ COMMITTED.
+ */
+async function claimDirectorySyncRun(
+  integrationId: string,
+  triggeredBy: string,
+  triggerSource: 'manual' | 'scheduler',
+): Promise<{ rows: DirectoryRunRow[] }> {
+  try {
+    return await query<DirectoryRunRow>(
+      `INSERT INTO directory_sync_runs (
+         integration_id, status, started_at, stats, meta, triggered_by, trigger_source, created_at, updated_at
+       )
+       VALUES ($1, 'running', NOW(), '{}'::jsonb, '{}'::jsonb, $2, $3, NOW(), NOW())
+       RETURNING id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at`,
+      [integrationId, triggeredBy, triggerSource],
+    )
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new DirectorySyncInProgressError(await findActiveDirectorySyncRunId(integrationId))
+    }
+    throw error
+  }
+}
+
 export async function syncDirectoryIntegration(
   integrationId: string,
   triggeredBy: string,
@@ -2703,14 +2804,12 @@ export async function syncDirectoryIntegration(
 
   const config = parseIntegrationConfig(integration)
   let deprovisionOutcome: DirectoryDeprovisionOutcome | null = null
-  const runResult = await query<DirectoryRunRow>(
-    `INSERT INTO directory_sync_runs (
-       integration_id, status, started_at, stats, meta, triggered_by, trigger_source, created_at, updated_at
-     )
-     VALUES ($1, 'running', NOW(), '{}'::jsonb, '{}'::jsonb, $2, $3, NOW(), NOW())
-     RETURNING id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at`,
-    [integrationId, triggeredBy, triggerSource],
-  )
+  // DT-HARDEN-05: claim the run lease BEFORE the first DingTalk call. The API pull that
+  // follows is the expensive, quota-consuming part; a transaction-scoped lock around the
+  // later apply would not protect it. Expired leases are reclaimed first so a crashed
+  // run cannot wedge an integration forever.
+  await reclaimStaleDirectorySyncRuns(integrationId)
+  const runResult = await claimDirectorySyncRun(integrationId, triggeredBy, triggerSource)
   const runId = runResult.rows[0].id
   hooks.onRunStarted?.(runId)
 

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -2693,8 +2693,10 @@ async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
 
 /**
  * DT-HARDEN-05 — how often a running sync proves it is alive by touching
- * `last_heartbeat_at` on its run row. Env-tunable, floored at 5 seconds so a
- * misconfiguration cannot hammer the pool.
+ * `last_heartbeat_at` on its run row. Env-tunable; any value that is not a finite
+ * number of at least 5000ms is IGNORED and the 60-second default applies (a sub-5s
+ * request is not floored up to 5s — it falls back entirely), so a misconfiguration
+ * cannot hammer the pool.
  */
 export const DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS = (() => {
   const raw = Number(process.env.DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS)

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -2539,23 +2539,32 @@ async function readIntegrationNameForAlert(integrationId: string): Promise<strin
 }
 
 async function markSyncFailure(integrationId: string, runId: string, message: string): Promise<void> {
-  await query(
-    `UPDATE directory_integrations
-     SET last_sync_at = NOW(),
-         last_error = $2,
-         updated_at = NOW()
-     WHERE id = $1`,
-    [integrationId, message],
-  )
-  await query(
-    `UPDATE directory_sync_runs
-     SET status = 'failed',
-         finished_at = NOW(),
-         error_message = $2,
-         updated_at = NOW()
-     WHERE id = $1`,
-    [runId, message],
-  )
+  // DT-HARDEN-05: one transaction, run-row (lease release) first. As two bare
+  // statements, a crash between them left the lease held until it went stale while
+  // the integration already recorded the failure. No status guard on the run row on
+  // purpose: if the lease was reclaimed while this run was alive, overwriting the
+  // reclaimer's generic orphaned message with the real failure (e.g. the lease-lost
+  // rollback) is the more truthful record — and the row is already 'failed', so no
+  // state regresses.
+  await transaction(async (client) => {
+    await client.query(
+      `UPDATE directory_sync_runs
+       SET status = 'failed',
+           finished_at = NOW(),
+           error_message = $2,
+           updated_at = NOW()
+       WHERE id = $1`,
+      [runId, message],
+    )
+    await client.query(
+      `UPDATE directory_integrations
+       SET last_sync_at = NOW(),
+           last_error = $2,
+           updated_at = NOW()
+       WHERE id = $1`,
+      [integrationId, message],
+    )
+  })
   try {
     await query(
       `INSERT INTO directory_sync_alerts (integration_id, run_id, level, code, message, details, created_at, updated_at)
@@ -2683,13 +2692,29 @@ async function loadMatchMaps(accounts: DirectoryAccountRow[]) {
 }
 
 /**
- * DT-HARDEN-05 — how long a `running` run row may sit before another caller may assume
- * its owner died and reclaim the lease. Deliberately generous: a large-tenant sync is
- * a long serial walk over the DingTalk directory API.
+ * DT-HARDEN-05 — how often a running sync proves it is alive by touching
+ * `last_heartbeat_at` on its run row. Env-tunable, floored at 5 seconds so a
+ * misconfiguration cannot hammer the pool.
  */
-export const DIRECTORY_SYNC_LEASE_TTL_MINUTES = (() => {
-  const raw = Number(process.env.DIRECTORY_SYNC_LEASE_TTL_MINUTES)
-  return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 120
+export const DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS = (() => {
+  const raw = Number(process.env.DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS)
+  return Number.isFinite(raw) && raw >= 5_000 ? Math.trunc(raw) : 60_000
+})()
+
+/**
+ * DT-HARDEN-05 — how long a `running` run may go without a heartbeat before another
+ * caller may assume its owner died and reclaim the lease. This keys off liveness
+ * (`last_heartbeat_at`, falling back to `started_at` for a run that died before its
+ * first beat), NOT total run age — a live large-tenant sync beats indefinitely and is
+ * never reclaimed, while a crashed one is reclaimed within minutes instead of hours.
+ * Clamped to at least 5x the heartbeat interval so a GC pause or one slow beat write
+ * cannot cause a false reclaim in a multi-replica deployment.
+ */
+export const DIRECTORY_SYNC_LEASE_STALE_MINUTES = (() => {
+  const raw = Number(process.env.DIRECTORY_SYNC_LEASE_STALE_MINUTES)
+  const requested = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 10
+  const floorMinutes = Math.ceil((DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS * 5) / 60_000)
+  return Math.max(requested, floorMinutes)
 })()
 
 /** Thrown when another sync already holds the lease for this integration. */
@@ -2709,6 +2734,24 @@ export class DirectorySyncInProgressError extends Error {
   }
 }
 
+/**
+ * Thrown when a run reaches its completion write only to find its row is no longer
+ * `running` — the lease was reclaimed as stale while this process was still alive
+ * (heartbeat starved: event-loop stall, saturated pool, network partition). Thrown
+ * INSIDE the apply transaction so the zombie's writes roll back instead of racing
+ * the new claimant's.
+ */
+export class DirectorySyncLeaseLostError extends Error {
+  readonly code = 'DIRECTORY_SYNC_LEASE_LOST'
+
+  constructor(runId: string) {
+    super(
+      `Directory sync run ${runId} lost its lease while still alive (reclaimed as stale by a newer trigger); its apply was rolled back`,
+    )
+    this.name = 'DirectorySyncLeaseLostError'
+  }
+}
+
 function isUniqueViolation(error: unknown): boolean {
   return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === '23505'
 }
@@ -2720,7 +2763,7 @@ function isUniqueViolation(error: unknown): boolean {
  * manual trigger to unstick it.
  */
 export async function reclaimStaleDirectorySyncRuns(integrationId?: string): Promise<number> {
-  const params: unknown[] = [DIRECTORY_SYNC_LEASE_TTL_MINUTES]
+  const params: unknown[] = [DIRECTORY_SYNC_LEASE_STALE_MINUTES]
   let scope = ''
   if (integrationId && normalizeText(integrationId)) {
     params.push(normalizeText(integrationId))
@@ -2731,10 +2774,10 @@ export async function reclaimStaleDirectorySyncRuns(integrationId?: string): Pro
     `UPDATE directory_sync_runs
         SET status = 'failed',
             finished_at = NOW(),
-            error_message = COALESCE(error_message, 'orphaned: sync lease expired'),
+            error_message = COALESCE(error_message, 'orphaned: sync lease heartbeat went stale; owner presumed crashed'),
             updated_at = NOW()
       WHERE status = 'running'
-        AND started_at < NOW() - ($1::int * INTERVAL '1 minute')${scope}
+        AND COALESCE(last_heartbeat_at, started_at) < NOW() - ($1::int * INTERVAL '1 minute')${scope}
       RETURNING id`,
     params,
   )
@@ -2812,6 +2855,27 @@ export async function syncDirectoryIntegration(
   const runResult = await claimDirectorySyncRun(integrationId, triggeredBy, triggerSource)
   const runId = runResult.rows[0].id
   hooks.onRunStarted?.(runId)
+
+  // DT-HARDEN-05 heartbeat: prove this run is alive for as long as it holds the lease.
+  // A timer (rather than beats threaded through fetchAllDepartments/fetchAllUsers) also
+  // covers the long apply transaction, and keeps runId out of the fetch helpers' scope.
+  // The `status = 'running'` predicate keeps a late beat from resurrecting a row the
+  // reclaimer already flipped. unref'd so a beat never keeps the process alive.
+  const heartbeat = setInterval(() => {
+    query(
+      `UPDATE directory_sync_runs
+          SET last_heartbeat_at = NOW(),
+              updated_at = NOW()
+        WHERE id = $1
+          AND status = 'running'`,
+      [runId],
+    ).catch((error) => {
+      // Best-effort by design: a missed beat only matters if EVERY beat inside the
+      // staleness window misses, and reclaim then treats the run as dead — safe, loud.
+      logger.warn(`Directory sync heartbeat failed for run ${runId}: ${readErrorMessage(error, 'unknown error')}`)
+    })
+  }, DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS)
+  heartbeat.unref?.()
 
   try {
     const departments = await fetchAllDepartments(config, integration.name)
@@ -3291,15 +3355,24 @@ export async function syncDirectoryIntegration(
          WHERE id = $1`,
         [integrationId],
       )
-      await client.query(
+      // The lease may have been reclaimed while this run was alive-but-silent (starved
+      // heartbeat). Completing unconditionally would resurrect the reclaimed row AND
+      // commit an apply that races the new claimant's — so the guard is on status, and
+      // a miss aborts the whole transaction.
+      const completion = await client.query(
         `UPDATE directory_sync_runs
          SET status = 'completed',
              finished_at = NOW(),
              stats = $2::jsonb,
              updated_at = NOW()
-         WHERE id = $1`,
+         WHERE id = $1
+           AND status = 'running'
+         RETURNING id`,
         [runId, JSON.stringify(stats)],
       )
+      if (completion.rows.length === 0) {
+        throw new DirectorySyncLeaseLostError(runId)
+      }
     })
 
     for (const invite of autoAdmissionInvites) {
@@ -3380,6 +3453,8 @@ export async function syncDirectoryIntegration(
     const message = readErrorMessage(error, 'Directory sync failed')
     await markSyncFailure(integrationId, runId, message)
     throw error
+  } finally {
+    clearInterval(heartbeat)
   }
 }
 

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -320,6 +320,14 @@ export function adminDirectoryRouter(): Router {
         jsonOk(res, { accepted: true, runId, integrationId: req.params.integrationId })
         return
       } catch (error) {
+        // DT-HARDEN-05: the lease conflict is thrown by the claim, BEFORE onRunStarted
+        // ever fires, so it always lands in this catch — and it is the same benign
+        // "already running" state as in the non-async branch below. Map it identically:
+        // 409 with the active runId, never a 500 "sync failed" that monitoring pages on.
+        if (error instanceof DirectorySyncInProgressError) {
+          jsonError(res, error.statusCode, error.code, error.message, { activeRunId: error.activeRunId })
+          return
+        }
         const message = readErrorMessage(error, 'Failed to start directory sync')
         jsonError(res, /not found/i.test(message) ? 404 : 500, 'DIRECTORY_SYNC_FAILED', message)
         return

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -3,6 +3,7 @@ import { Router } from 'express'
 import { auditLog } from '../audit/audit'
 import { Logger } from '../core/logger'
 import {
+  DirectorySyncInProgressError,
   acknowledgeDirectorySyncAlert,
   admitDirectoryAccountUser,
   batchAdmitDirectoryAccountUsers,
@@ -329,6 +330,12 @@ export function adminDirectoryRouter(): Router {
       const result = await syncDirectoryIntegration(req.params.integrationId, adminUserId)
       jsonOk(res, result)
     } catch (error) {
+      // DT-HARDEN-05: another sync already holds the lease. Return the active run so the
+      // admin UI can jump straight to it instead of re-triggering a duplicate API pull.
+      if (error instanceof DirectorySyncInProgressError) {
+        jsonError(res, error.statusCode, error.code, error.message, { activeRunId: error.activeRunId })
+        return
+      }
       const message = readErrorMessage(error, 'Failed to sync directory integration')
       jsonError(res, /not found/i.test(message) ? 404 : 500, 'DIRECTORY_SYNC_FAILED', message)
     }

--- a/packages/core-backend/tests/integration/directory-sync-run-lease.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-run-lease.db.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { reclaimStaleDirectorySyncRuns } from '../../src/directory/directory-sync'
+
+/**
+ * DT-HARDEN-05 — the lease itself and the liveness predicate, proved against the REAL
+ * migrated tables.
+ *
+ * The unit suite pins the reclaim SQL as a string through a mocked pg; that guards the
+ * text, not the semantics. These goldens prove the two things only Postgres can:
+ *
+ *   1. `uq_directory_sync_runs_one_running_per_integration` (partial unique ON
+ *      (integration_id) WHERE status='running') makes "at most one running run per
+ *      integration" a database invariant — a concurrent second claim is a 23505,
+ *      not a race.
+ *   2. `COALESCE(last_heartbeat_at, started_at)` staleness on real timestamps: a LIVE
+ *      long run (old started_at, fresh beat) is never reclaimed — the exact case a
+ *      started_at-only predicate got wrong — while a stale beat or a never-beat crash
+ *      is reclaimed once past the threshold.
+ *
+ * Deliberately NOT replicated here: the completion UPDATE's `AND status = 'running'`
+ * guard lives inside syncDirectoryIntegration and is pinned at unit level — re-writing
+ * that SQL by hand in a test would reintroduce the drift these goldens exist to kill.
+ *
+ * Reclaim is always called SCOPED to this suite's integrations: the plugin-tests job
+ * runs many suites against ONE database, and an unscoped sweep would eat a sibling
+ * suite's running fixtures.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+
+async function seedIntegration(name: string): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (name, corp_id, status)
+     VALUES ($1, $2, 'active')
+     RETURNING id`,
+    [`lease-golden ${name} ${STAMP}`, `lease-corp-${name}-${STAMP}`],
+  )
+  return result.rows[0].id
+}
+
+async function seedRun(opts: {
+  integrationId: string
+  status?: string
+  startedAgoMinutes: number
+  heartbeatAgoMinutes?: number | null
+}): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO directory_sync_runs (integration_id, status, started_at, last_heartbeat_at, triggered_by)
+     VALUES (
+       $1,
+       $2,
+       NOW() - ($3::int * INTERVAL '1 minute'),
+       CASE WHEN $4::int IS NULL THEN NULL ELSE NOW() - ($4::int * INTERVAL '1 minute') END,
+       'lease-golden'
+     )
+     RETURNING id`,
+    [opts.integrationId, opts.status ?? 'running', opts.startedAgoMinutes, opts.heartbeatAgoMinutes ?? null],
+  )
+  return result.rows[0].id
+}
+
+async function runStatus(runId: string): Promise<{ status: string; error_message: string | null }> {
+  const result = await query<{ status: string; error_message: string | null }>(
+    `SELECT status, error_message FROM directory_sync_runs WHERE id = $1`,
+    [runId],
+  )
+  return result.rows[0]
+}
+
+describeIfDatabase('DT-HARDEN-05 sync-run lease (real DB)', () => {
+  const integrationIds: string[] = []
+
+  async function integration(name: string): Promise<string> {
+    const id = await seedIntegration(name)
+    integrationIds.push(id)
+    return id
+  }
+
+  afterAll(async () => {
+    for (const id of integrationIds) {
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+    }
+  })
+
+  it('enforces at most one running run per integration via the partial unique index', async () => {
+    const a = await integration('uniq-a')
+    const b = await integration('uniq-b')
+
+    await seedRun({ integrationId: a, startedAgoMinutes: 1, heartbeatAgoMinutes: 0 })
+
+    // Second concurrent claim on the SAME integration: unique violation, not a race.
+    await expect(
+      seedRun({ integrationId: a, startedAgoMinutes: 0, heartbeatAgoMinutes: 0 }),
+    ).rejects.toMatchObject({ code: '23505' })
+
+    // A different integration claims freely.
+    await expect(
+      seedRun({ integrationId: b, startedAgoMinutes: 0, heartbeatAgoMinutes: 0 }),
+    ).resolves.toBeTruthy()
+
+    // The index is partial: terminal rows do not block a new claim.
+    await query(
+      `UPDATE directory_sync_runs SET status = 'failed', finished_at = NOW() WHERE integration_id = $1`,
+      [a],
+    )
+    await expect(
+      seedRun({ integrationId: a, startedAgoMinutes: 0, heartbeatAgoMinutes: 0 }),
+    ).resolves.toBeTruthy()
+  })
+
+  it('never reclaims a live long run: old started_at with a fresh heartbeat survives', async () => {
+    const id = await integration('live-long')
+    const runId = await seedRun({ integrationId: id, startedAgoMinutes: 180, heartbeatAgoMinutes: 0 })
+
+    const reclaimed = await reclaimStaleDirectorySyncRuns(id)
+
+    expect(reclaimed).toBe(0)
+    expect((await runStatus(runId)).status).toBe('running')
+  })
+
+  it('reclaims a run whose heartbeat went stale, marking it orphaned', async () => {
+    const id = await integration('stale-beat')
+    const runId = await seedRun({ integrationId: id, startedAgoMinutes: 180, heartbeatAgoMinutes: 30 })
+
+    const reclaimed = await reclaimStaleDirectorySyncRuns(id)
+
+    expect(reclaimed).toBe(1)
+    const row = await runStatus(runId)
+    expect(row.status).toBe('failed')
+    expect(row.error_message).toContain('orphaned')
+  })
+
+  it('falls back to started_at for a run that died before its first beat — but only once stale', async () => {
+    const id = await integration('never-beat')
+    const dead = await seedRun({ integrationId: id, startedAgoMinutes: 30, heartbeatAgoMinutes: null })
+
+    expect(await reclaimStaleDirectorySyncRuns(id)).toBe(1)
+    expect((await runStatus(dead)).status).toBe('failed')
+
+    const young = await seedRun({ integrationId: id, startedAgoMinutes: 2, heartbeatAgoMinutes: null })
+    expect(await reclaimStaleDirectorySyncRuns(id)).toBe(0)
+    expect((await runStatus(young)).status).toBe('running')
+  })
+})

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -51,7 +51,15 @@ vi.mock('../../src/audit/audit', () => ({
   auditLog: auditMocks.auditLog,
 }))
 
-vi.mock('../../src/directory/directory-sync', () => ({
+vi.mock('../../src/directory/directory-sync', async (importOriginal) => ({
+  // DT-HARDEN-05: the sync route discriminates lease conflicts with
+  // `error instanceof DirectorySyncInProgressError`. That check only works if this
+  // factory re-exports the REAL class — a factory that omits it leaves the route
+  // holding `undefined` (instanceof then THROWS a TypeError), and a factory-local
+  // stand-in class would make `instanceof` silently false for real errors. Both
+  // failure modes neuter exactly the mapping the 409 tests below pin.
+  DirectorySyncInProgressError: (await importOriginal<typeof import('../../src/directory/directory-sync')>())
+    .DirectorySyncInProgressError,
   acknowledgeDirectorySyncAlert: directoryMocks.acknowledgeDirectorySyncAlert,
   admitDirectoryAccountUser: directoryMocks.admitDirectoryAccountUser,
   batchAdmitDirectoryAccountUsers: directoryMocks.batchAdmitDirectoryAccountUsers,

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -1,5 +1,9 @@
 import type { Request, Response } from 'express'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+// Resolves through the vi.mock factory below, which re-exports the REAL class —
+// so `new DirectorySyncInProgressError(...)` here is the same constructor the
+// route's `instanceof` discriminates against in production.
+import { DirectorySyncInProgressError } from '../../src/directory/directory-sync'
 
 const rbacMocks = vi.hoisted(() => ({
   isRbacAdmin: vi.fn(),
@@ -545,6 +549,41 @@ describe('adminDirectoryRouter', () => {
     })
 
     expect(response.statusCode).toBe(404)
+  })
+
+  // DT-HARDEN-05 gate P2-1: a lease conflict is a benign "already running" state and must
+  // map to 409 + the active runId on BOTH trigger paths — never a 500 that monitoring
+  // pages on. The async branch regressed exactly this way once (its catch knew only
+  // /not found/→404, else 500), so each branch gets its own pin.
+  it('maps a lease conflict to 409 with the active runId on the synchronous path', async () => {
+    directoryMocks.syncDirectoryIntegration.mockRejectedValue(new DirectorySyncInProgressError('run-live-1'))
+
+    const response = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'DIRECTORY_SYNC_IN_PROGRESS', details: { activeRunId: 'run-live-1' } },
+    })
+  })
+
+  it('maps a lease conflict to 409 with the active runId on the async path too', async () => {
+    directoryMocks.syncDirectoryIntegration.mockRejectedValue(new DirectorySyncInProgressError('run-live-2'))
+
+    const response = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      body: { async: true },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'DIRECTORY_SYNC_IN_PROGRESS', details: { activeRunId: 'run-live-2' } },
+    })
   })
 
   it('previews a sync without applying it', async () => {

--- a/packages/core-backend/tests/unit/directory-sync-env-knobs.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-env-knobs.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// DT-HARDEN-05 — the two lease knobs are module-load IIFEs, so each case reloads the
+// real module with the env staged first. Invalid values must fall back to defaults
+// (never NaN/zero intervals into setInterval or SQL), and the staleness threshold must
+// clamp to >=5x the heartbeat interval so a mis-tuned pair cannot reclaim a live run.
+
+const HEARTBEAT_ENV = 'DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS'
+const STALE_ENV = 'DIRECTORY_SYNC_LEASE_STALE_MINUTES'
+
+const originalHeartbeat = process.env[HEARTBEAT_ENV]
+const originalStale = process.env[STALE_ENV]
+
+async function loadKnobs(env: { heartbeat?: string; stale?: string }) {
+  vi.resetModules()
+  if (env.heartbeat === undefined) delete process.env[HEARTBEAT_ENV]
+  else process.env[HEARTBEAT_ENV] = env.heartbeat
+  if (env.stale === undefined) delete process.env[STALE_ENV]
+  else process.env[STALE_ENV] = env.stale
+  const mod = await import('../../src/directory/directory-sync')
+  return {
+    heartbeatMs: mod.DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS,
+    staleMinutes: mod.DIRECTORY_SYNC_LEASE_STALE_MINUTES,
+  }
+}
+
+afterEach(() => {
+  if (originalHeartbeat === undefined) delete process.env[HEARTBEAT_ENV]
+  else process.env[HEARTBEAT_ENV] = originalHeartbeat
+  if (originalStale === undefined) delete process.env[STALE_ENV]
+  else process.env[STALE_ENV] = originalStale
+  vi.resetModules()
+})
+
+describe('DT-HARDEN-05 lease env knobs', () => {
+  it('heartbeat interval falls back to 60s for unset/NaN/zero/negative/sub-5s values', async () => {
+    for (const heartbeat of [undefined, 'abc', '0', '-5000', '4999']) {
+      const { heartbeatMs } = await loadKnobs({ heartbeat })
+      expect(heartbeatMs, `heartbeat=${String(heartbeat)}`).toBe(60_000)
+    }
+  })
+
+  it('heartbeat interval honors a valid override and truncates fractions', async () => {
+    expect((await loadKnobs({ heartbeat: '5000' })).heartbeatMs).toBe(5_000)
+    expect((await loadKnobs({ heartbeat: '90000.7' })).heartbeatMs).toBe(90_000)
+  })
+
+  it('staleness falls back to 10min for unset/NaN/zero/negative values', async () => {
+    for (const stale of [undefined, 'abc', '0', '-3']) {
+      const { staleMinutes } = await loadKnobs({ stale })
+      expect(staleMinutes, `stale=${String(stale)}`).toBe(10)
+    }
+  })
+
+  it('staleness clamps to >=5x the heartbeat interval, including across both knobs', async () => {
+    // Default 60s beat → 5min floor beats a 2min request.
+    expect((await loadKnobs({ stale: '2' })).staleMinutes).toBe(5)
+    // 2min beat → 10min floor beats a 5min request.
+    expect((await loadKnobs({ heartbeat: '120000', stale: '5' })).staleMinutes).toBe(10)
+    // A request above the floor is honored as-is.
+    expect((await loadKnobs({ stale: '30' })).staleMinutes).toBe(30)
+  })
+})

--- a/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const pgMocks = vi.hoisted(() => ({
   query: vi.fn(),
@@ -27,8 +27,10 @@ vi.mock('../../src/integrations/dingtalk/client', () => ({
 }))
 
 import {
-  DIRECTORY_SYNC_LEASE_TTL_MINUTES,
+  DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS,
+  DIRECTORY_SYNC_LEASE_STALE_MINUTES,
   DirectorySyncInProgressError,
+  DirectorySyncLeaseLostError,
   reclaimStaleDirectorySyncRuns,
   syncDirectoryIntegration,
 } from '../../src/directory/directory-sync'
@@ -51,10 +53,77 @@ const INTEGRATION_ROW = {
   updated_at: '2026-07-08T00:00:00.000Z',
 }
 
+const RUN_ID = 'run-1'
+
+function runRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RUN_ID,
+    integration_id: 'dir-1',
+    status: 'running',
+    started_at: '2026-07-09T00:00:00.000Z',
+    finished_at: null,
+    stats: {},
+    error_message: null,
+    triggered_by: 'admin-1',
+    trigger_source: 'scheduler',
+    created_at: '2026-07-09T00:00:00.000Z',
+    updated_at: '2026-07-09T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
 function uniqueViolation() {
   const error = new Error('duplicate key value violates unique constraint') as Error & { code: string }
   error.code = '23505'
   return error
+}
+
+type LoggedCall = { text: string; params: unknown[] | undefined }
+
+/**
+ * Full-run harness: an SQL-shape dispatcher instead of a positional mock chain, because
+ * the heartbeat timer interleaves nondeterministically with the sync's own queries.
+ * Everything not recognized answers empty rows — with zero users/departments every
+ * loop in the apply body is a no-op, which is exactly the point: these tests pin the
+ * lease machinery, not the apply.
+ */
+function installFullRunMocks(options: { completionRows?: Array<{ id: string }> } = {}) {
+  const bareCalls: LoggedCall[] = []
+  const beats: LoggedCall[] = []
+  const txCalls: LoggedCall[] = []
+  const completionRows = options.completionRows ?? [{ id: RUN_ID }]
+
+  pgMocks.query.mockImplementation(async (sql: unknown, params?: unknown[]) => {
+    const text = String(sql)
+    bareCalls.push({ text, params })
+    if (text.includes('SET last_heartbeat_at')) {
+      beats.push({ text, params })
+      return { rows: [] }
+    }
+    if (text.includes('INSERT INTO directory_sync_runs')) return { rows: [runRow()] }
+    if (text.includes('FROM directory_integrations')) return { rows: [INTEGRATION_ROW] }
+    if (text.includes('FROM directory_sync_runs')) return { rows: [runRow({ status: 'completed' })] }
+    return { rows: [] }
+  })
+
+  pgMocks.transaction.mockImplementation(async (fn: (client: unknown) => Promise<unknown>) => {
+    const client = {
+      query: async (sql: unknown, params?: unknown[]) => {
+        const text = String(sql)
+        txCalls.push({ text, params })
+        if (text.includes("SET status = 'completed'")) return { rows: completionRows }
+        return { rows: [] }
+      },
+    }
+    return fn(client)
+  })
+
+  dingtalkMocks.fetchDingTalkAppAccessToken.mockResolvedValue('token')
+  dingtalkMocks.listDingTalkDepartments.mockResolvedValue([])
+  dingtalkMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+  dingtalkMocks.listDingTalkDepartmentUsers.mockResolvedValue({ users: [], hasMore: false, nextCursor: null })
+
+  return { bareCalls, beats, txCalls }
 }
 
 /**
@@ -63,7 +132,8 @@ function uniqueViolation() {
  * syncDirectoryIntegration inserts its run row and then pulls the entire DingTalk
  * directory before opening its apply transaction. A transaction-scoped lock around the
  * apply would not protect that pull. The lease is therefore claimed on the run row,
- * BEFORE the first outbound call.
+ * BEFORE the first outbound call, and the owner proves it is still alive by beating
+ * last_heartbeat_at while it holds the lease.
  */
 describe('DT-HARDEN-05 directory sync run lease', () => {
   beforeEach(() => {
@@ -72,8 +142,17 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
     for (const mock of Object.values(dingtalkMocks)) mock.mockReset()
   })
 
-  it('has a bounded, positive lease TTL', () => {
-    expect(DIRECTORY_SYNC_LEASE_TTL_MINUTES).toBeGreaterThan(0)
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('has a positive staleness window of at least five heartbeat intervals', () => {
+    expect(DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS).toBeGreaterThanOrEqual(5_000)
+    expect(DIRECTORY_SYNC_LEASE_STALE_MINUTES).toBeGreaterThan(0)
+    // A single missed beat (GC pause, slow pool) must never look like a death.
+    expect(DIRECTORY_SYNC_LEASE_STALE_MINUTES * 60_000).toBeGreaterThanOrEqual(
+      5 * DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS,
+    )
   })
 
   it('refuses a concurrent sync and never touches the DingTalk API', async () => {
@@ -120,7 +199,6 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
     const reclaimCall = pgMocks.query.mock.calls[1]
     expect(String(reclaimCall[0])).toContain('UPDATE directory_sync_runs')
     expect(String(reclaimCall[0])).toContain("status = 'running'")
-    expect(String(reclaimCall[0])).toContain('started_at <')
     // Reclaim strictly precedes the claim.
     expect(String(pgMocks.query.mock.calls[2][0])).toContain('INSERT INTO directory_sync_runs')
   })
@@ -135,13 +213,24 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
   })
 
   describe('reclaimStaleDirectorySyncRuns', () => {
+    it('judges staleness by heartbeat (falling back to started_at), never by run age alone', async () => {
+      pgMocks.query.mockResolvedValueOnce({ rows: [] })
+      await reclaimStaleDirectorySyncRuns('dir-1')
+      const [sql] = pgMocks.query.mock.calls[0]
+      // The exact predicate is the contract: a live long run keeps beating and is
+      // never reclaimed; a run that died before its first beat falls back to
+      // started_at and still gets swept.
+      expect(String(sql)).toContain("COALESCE(last_heartbeat_at, started_at) < NOW() - ($1::int * INTERVAL '1 minute')")
+      expect(String(sql)).not.toMatch(/AND\s+started_at\s*</)
+    })
+
     it('scopes to a single integration when asked', async () => {
       pgMocks.query.mockResolvedValueOnce({ rows: [{ id: 'r1' }] })
       const reclaimed = await reclaimStaleDirectorySyncRuns('dir-1')
       expect(reclaimed).toBe(1)
       const [sql, params] = pgMocks.query.mock.calls[0]
       expect(String(sql)).toContain('integration_id = $2')
-      expect(params).toEqual([DIRECTORY_SYNC_LEASE_TTL_MINUTES, 'dir-1'])
+      expect(params).toEqual([DIRECTORY_SYNC_LEASE_STALE_MINUTES, 'dir-1'])
     })
 
     it('sweeps every integration at boot when unscoped', async () => {
@@ -150,7 +239,123 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
       expect(reclaimed).toBe(0)
       const [sql, params] = pgMocks.query.mock.calls[0]
       expect(String(sql)).not.toContain('integration_id = $2')
-      expect(params).toEqual([DIRECTORY_SYNC_LEASE_TTL_MINUTES])
+      expect(params).toEqual([DIRECTORY_SYNC_LEASE_STALE_MINUTES])
+    })
+  })
+
+  describe('heartbeat', () => {
+    it('beats last_heartbeat_at mid-run and stops once the run finishes', async () => {
+      vi.useFakeTimers()
+      const { beats } = installFullRunMocks()
+      // Hold the sync inside the DingTalk pull for two heartbeat intervals.
+      dingtalkMocks.listDingTalkDepartments.mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS * 2 + 5_000))
+        return []
+      })
+
+      const pending = syncDirectoryIntegration('dir-1', 'admin-1', 'scheduler')
+      await vi.advanceTimersByTimeAsync(DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS * 2)
+
+      // At least one beat while the pull is still in flight, carrying the claimed
+      // run id and refusing to touch a row the reclaimer already flipped.
+      expect(beats.length).toBeGreaterThanOrEqual(1)
+      for (const beat of beats) {
+        expect(beat.text).toContain('SET last_heartbeat_at = NOW()')
+        expect(beat.text).toContain("AND status = 'running'")
+        expect(beat.params).toEqual([RUN_ID])
+      }
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      await pending
+
+      // Interval is cleared in finally: no beats after completion.
+      const beatsAtFinish = beats.length
+      await vi.advanceTimersByTimeAsync(DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS * 10)
+      expect(beats.length).toBe(beatsAtFinish)
+    })
+
+    it('stops beating after a failed run too', async () => {
+      vi.useFakeTimers()
+      const { beats } = installFullRunMocks()
+      dingtalkMocks.listDingTalkDepartments.mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS + 5_000))
+        throw new Error('dingtalk exploded')
+      })
+
+      const pending = syncDirectoryIntegration('dir-1', 'admin-1', 'scheduler')
+      const outcome = pending.catch((err) => err)
+      await vi.advanceTimersByTimeAsync(DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS + 10_000)
+      expect((await outcome) instanceof Error).toBe(true)
+
+      const beatsAtFailure = beats.length
+      expect(beatsAtFailure).toBeGreaterThanOrEqual(1)
+      await vi.advanceTimersByTimeAsync(DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS * 10)
+      expect(beats.length).toBe(beatsAtFailure)
+    })
+  })
+
+  describe('markSyncFailure atomicity', () => {
+    it('releases the lease and records the integration failure in ONE transaction, lease first', async () => {
+      const { bareCalls, txCalls } = installFullRunMocks()
+      dingtalkMocks.listDingTalkDepartments.mockRejectedValue(new Error('dingtalk exploded'))
+
+      await expect(syncDirectoryIntegration('dir-1', 'admin-1', 'scheduler')).rejects.toThrow('dingtalk exploded')
+
+      // Both failure UPDATEs travel through the transaction client...
+      expect(pgMocks.transaction).toHaveBeenCalledTimes(1)
+      const runRelease = txCalls.findIndex(
+        (call) => call.text.includes('UPDATE directory_sync_runs') && call.text.includes("'failed'"),
+      )
+      const integrationMark = txCalls.findIndex((call) => call.text.includes('UPDATE directory_integrations'))
+      expect(runRelease).toBeGreaterThanOrEqual(0)
+      expect(integrationMark).toBeGreaterThanOrEqual(0)
+      // ...with the lease release ordered first, so even a mid-transaction crash
+      // under a non-transactional driver would still have freed the lease.
+      expect(runRelease).toBeLessThan(integrationMark)
+      expect(txCalls[runRelease].params).toEqual([RUN_ID, 'dingtalk exploded'])
+      expect(txCalls[integrationMark].params).toEqual(['dir-1', 'dingtalk exploded'])
+
+      // ...and neither goes out as a bare, non-transactional statement. (The reclaim
+      // sweep also flips rows to 'failed' outside a transaction — that one is a single
+      // statement and is excluded by its parameterless error_message.)
+      const bareFailureWrites = bareCalls.filter(
+        (call) =>
+          (call.text.includes('UPDATE directory_integrations') && call.text.includes('last_error')) ||
+          (call.text.includes('UPDATE directory_sync_runs') && call.text.includes('error_message = $2')),
+      )
+      expect(bareFailureWrites).toEqual([])
+    })
+  })
+
+  describe('completion status guard', () => {
+    it('completes the run row only while it is still running', async () => {
+      const { txCalls } = installFullRunMocks()
+
+      await syncDirectoryIntegration('dir-1', 'admin-1', 'scheduler')
+
+      const completion = txCalls.find((call) => call.text.includes("SET status = 'completed'"))
+      expect(completion).toBeDefined()
+      // The guard: a reclaimed (now 'failed') row must not be resurrected.
+      expect(completion?.text).toContain("AND status = 'running'")
+      expect(completion?.text).toContain('RETURNING id')
+      expect(completion?.params?.[0]).toBe(RUN_ID)
+    })
+
+    it('rolls back a zombie whose lease was reclaimed while it was alive, and says so', async () => {
+      // Zero rows from the guarded completion UPDATE = someone reclaimed the lease.
+      const { txCalls } = installFullRunMocks({ completionRows: [] })
+
+      await expect(syncDirectoryIntegration('dir-1', 'admin-1', 'scheduler'))
+        .rejects.toBeInstanceOf(DirectorySyncLeaseLostError)
+
+      // The failure record distinguishes reclaimed-while-alive from a crash: the
+      // run row carries the lease-lost message, not the reclaimer's orphaned one.
+      const failureWrite = txCalls.find(
+        (call) => call.text.includes('UPDATE directory_sync_runs') && call.text.includes("'failed'"),
+      )
+      expect(failureWrite).toBeDefined()
+      expect(failureWrite?.params?.[0]).toBe(RUN_ID)
+      expect(String(failureWrite?.params?.[1])).toContain('lost its lease while still alive')
     })
   })
 })

--- a/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+const dingtalkMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: dingtalkMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: dingtalkMocks.listDingTalkDepartments,
+  listDingTalkDepartmentUsers: dingtalkMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: dingtalkMocks.getDingTalkUserDetail,
+  getDingTalkDepartmentDetail: dingtalkMocks.getDingTalkDepartmentDetail,
+}))
+
+import {
+  DIRECTORY_SYNC_LEASE_TTL_MINUTES,
+  DirectorySyncInProgressError,
+  reclaimStaleDirectorySyncRuns,
+  syncDirectoryIntegration,
+} from '../../src/directory/directory-sync'
+
+const INTEGRATION_ROW = {
+  id: 'dir-1',
+  org_id: 'default',
+  provider: 'dingtalk',
+  name: 'DingTalk CN',
+  status: 'active',
+  corp_id: 'dingcorp',
+  config: { appKey: 'k', appSecret: 's' },
+  sync_enabled: true,
+  schedule_cron: null,
+  default_deprovision_policy: 'mark_inactive',
+  last_sync_at: null,
+  last_success_at: null,
+  last_error: null,
+  created_at: '2026-07-08T00:00:00.000Z',
+  updated_at: '2026-07-08T00:00:00.000Z',
+}
+
+function uniqueViolation() {
+  const error = new Error('duplicate key value violates unique constraint') as Error & { code: string }
+  error.code = '23505'
+  return error
+}
+
+/**
+ * DT-HARDEN-05 — the sync lease.
+ *
+ * syncDirectoryIntegration inserts its run row and then pulls the entire DingTalk
+ * directory before opening its apply transaction. A transaction-scoped lock around the
+ * apply would not protect that pull. The lease is therefore claimed on the run row,
+ * BEFORE the first outbound call.
+ */
+describe('DT-HARDEN-05 directory sync run lease', () => {
+  beforeEach(() => {
+    pgMocks.query.mockReset()
+    pgMocks.transaction.mockReset()
+    for (const mock of Object.values(dingtalkMocks)) mock.mockReset()
+  })
+
+  it('has a bounded, positive lease TTL', () => {
+    expect(DIRECTORY_SYNC_LEASE_TTL_MINUTES).toBeGreaterThan(0)
+  })
+
+  it('refuses a concurrent sync and never touches the DingTalk API', async () => {
+    pgMocks.query
+      // getIntegrationRow
+      .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      // reclaimStaleDirectorySyncRuns → nothing stale
+      .mockResolvedValueOnce({ rows: [] })
+      // claimDirectorySyncRun → another run holds the lease
+      .mockRejectedValueOnce(uniqueViolation())
+      // findActiveDirectorySyncRunId
+      .mockResolvedValueOnce({ rows: [{ id: 'run-active' }] })
+
+    await expect(syncDirectoryIntegration('dir-1', 'admin-1', 'manual'))
+      .rejects.toBeInstanceOf(DirectorySyncInProgressError)
+
+    // The load-bearing assertion: the expensive, quota-consuming pull never started.
+    expect(dingtalkMocks.fetchDingTalkAppAccessToken).not.toHaveBeenCalled()
+    expect(dingtalkMocks.listDingTalkDepartments).not.toHaveBeenCalled()
+  })
+
+  it('carries the active run id so the caller can observe the run in flight', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(uniqueViolation())
+      .mockResolvedValueOnce({ rows: [{ id: 'run-active' }] })
+
+    const error = await syncDirectoryIntegration('dir-1', 'admin-1', 'manual').catch((err) => err)
+    expect(error).toBeInstanceOf(DirectorySyncInProgressError)
+    expect((error as DirectorySyncInProgressError).activeRunId).toBe('run-active')
+    expect((error as DirectorySyncInProgressError).statusCode).toBe(409)
+  })
+
+  it('reclaims the lease before claiming it, so a crashed run cannot wedge an integration', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      .mockResolvedValueOnce({ rows: [{ id: 'stale-run' }] }) // reclaim
+      .mockRejectedValueOnce(uniqueViolation())
+      .mockResolvedValueOnce({ rows: [{ id: 'run-active' }] })
+
+    await expect(syncDirectoryIntegration('dir-1', 'admin-1', 'manual')).rejects.toBeInstanceOf(DirectorySyncInProgressError)
+
+    const reclaimCall = pgMocks.query.mock.calls[1]
+    expect(String(reclaimCall[0])).toContain('UPDATE directory_sync_runs')
+    expect(String(reclaimCall[0])).toContain("status = 'running'")
+    expect(String(reclaimCall[0])).toContain('started_at <')
+    // Reclaim strictly precedes the claim.
+    expect(String(pgMocks.query.mock.calls[2][0])).toContain('INSERT INTO directory_sync_runs')
+  })
+
+  it('propagates a non-unique-violation insert error unchanged', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(new Error('connection reset'))
+
+    await expect(syncDirectoryIntegration('dir-1', 'admin-1', 'manual')).rejects.toThrow('connection reset')
+  })
+
+  describe('reclaimStaleDirectorySyncRuns', () => {
+    it('scopes to a single integration when asked', async () => {
+      pgMocks.query.mockResolvedValueOnce({ rows: [{ id: 'r1' }] })
+      const reclaimed = await reclaimStaleDirectorySyncRuns('dir-1')
+      expect(reclaimed).toBe(1)
+      const [sql, params] = pgMocks.query.mock.calls[0]
+      expect(String(sql)).toContain('integration_id = $2')
+      expect(params).toEqual([DIRECTORY_SYNC_LEASE_TTL_MINUTES, 'dir-1'])
+    })
+
+    it('sweeps every integration at boot when unscoped', async () => {
+      pgMocks.query.mockResolvedValueOnce({ rows: [] })
+      const reclaimed = await reclaimStaleDirectorySyncRuns()
+      expect(reclaimed).toBe(0)
+      const [sql, params] = pgMocks.query.mock.calls[0]
+      expect(String(sql)).not.toContain('integration_id = $2')
+      expect(params).toEqual([DIRECTORY_SYNC_LEASE_TTL_MINUTES])
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
@@ -6,16 +6,30 @@ const pgMocks = vi.hoisted(() => ({
 
 const directoryMocks = vi.hoisted(() => ({
   syncDirectoryIntegration: vi.fn(),
+  reclaimStaleDirectorySyncRuns: vi.fn(),
 }))
 
 vi.mock('../../src/db/pg', () => ({
   query: pgMocks.query,
+  // The real directory-sync (loaded below via importOriginal for its error class)
+  // imports { query, transaction }; a factory missing either export fails at load.
+  transaction: vi.fn(),
 }))
 
-vi.mock('../../src/directory/directory-sync', () => ({
+vi.mock('../../src/directory/directory-sync', async (importOriginal) => ({
+  // DT-HARDEN-05: runScheduledSync discriminates lease conflicts with
+  // `error instanceof DirectorySyncInProgressError`. Re-export the REAL class so the
+  // skip test below exercises the same discrimination production performs. The old
+  // factory omitted it (and reclaimStaleDirectorySyncRuns), leaving the module under
+  // test holding `undefined` — the boot sweep threw into its own catch and every
+  // DT-HARDEN-05 guard in this file was unfalsifiable.
+  DirectorySyncInProgressError: (await importOriginal<typeof import('../../src/directory/directory-sync')>())
+    .DirectorySyncInProgressError,
   syncDirectoryIntegration: directoryMocks.syncDirectoryIntegration,
+  reclaimStaleDirectorySyncRuns: directoryMocks.reclaimStaleDirectorySyncRuns,
 }))
 
+import { DirectorySyncInProgressError } from '../../src/directory/directory-sync'
 import {
   refreshDirectoryIntegrationSchedule,
   resetDirectorySyncSchedulerForTests,
@@ -36,6 +50,8 @@ describe('directory-sync-scheduler', () => {
   beforeEach(() => {
     pgMocks.query.mockReset()
     directoryMocks.syncDirectoryIntegration.mockReset()
+    directoryMocks.reclaimStaleDirectorySyncRuns.mockReset()
+    directoryMocks.reclaimStaleDirectorySyncRuns.mockResolvedValue(0)
     resetDirectorySyncSchedulerForTests()
   })
 
@@ -138,5 +154,37 @@ describe('directory-sync-scheduler', () => {
     expect(scheduler.unschedule).toHaveBeenCalledWith(`directory-sync:${row.id}`)
     expect(scheduler.schedule).not.toHaveBeenCalled()
     expect(scheduler.reschedule).not.toHaveBeenCalled()
+  })
+
+  // DT-HARDEN-05 gate P2-2: the boot sweep and the in-progress skip are the scheduler's
+  // two consumer-side lease guards. Each gets its own pin so a refactor that drops
+  // either one goes red instead of degrading silently.
+  it('sweeps stale runs once at boot', async () => {
+    const scheduler = createSchedulerMock()
+    scheduler.getJob.mockResolvedValue(null)
+    pgMocks.query.mockResolvedValueOnce({ rows: [] })
+
+    await startDirectorySyncScheduler({ scheduler: scheduler as never })
+
+    expect(directoryMocks.reclaimStaleDirectorySyncRuns).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a scheduled tick on a lease conflict but keeps any other failure a job error', async () => {
+    const scheduler = createSchedulerMock()
+    scheduler.getJob.mockResolvedValue(null)
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [
+        { id: 'dir-1', name: 'DingTalk CN', status: 'active', sync_enabled: true, schedule_cron: '*/5 * * * *' },
+      ],
+    })
+
+    await startDirectorySyncScheduler({ scheduler: scheduler as never })
+    const scheduleHandler = scheduler.schedule.mock.calls[0][2] as () => Promise<void>
+
+    directoryMocks.syncDirectoryIntegration.mockRejectedValueOnce(new DirectorySyncInProgressError('run-held'))
+    await expect(scheduleHandler()).resolves.toBeUndefined()
+
+    directoryMocks.syncDirectoryIntegration.mockRejectedValueOnce(new Error('DingTalk 500'))
+    await expect(scheduleHandler()).rejects.toThrow('DingTalk 500')
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -37,6 +37,11 @@ export default defineConfig({
       // re-admission of an already-linked account). DATABASE_URL-gated; excluded here so the
       // no-DB job cannot skip-green it, and wired as a WHOLE FILE into the approval real-DB step.
       'tests/integration/directory-admission-case-insensitive-uniqueness.db.test.ts',
+      // DT-HARDEN-05 lease golden (real DB): proves the partial unique index makes the lease
+      // a database invariant and that COALESCE(last_heartbeat_at, started_at) staleness never
+      // reclaims a live long run. DATABASE_URL-gated; excluded here so the no-DB job cannot
+      // skip-green it, and wired as a WHOLE FILE into the approval real-DB step.
+      'tests/integration/directory-sync-run-lease.db.test.ts',
       'tests/integration/approval-manager-chain.db.test.ts',
       'tests/integration/approval-requester-department.db.test.ts',
       'tests/integration/approval-requester-title.db.test.ts',


### PR DESCRIPTION
`syncDirectoryIntegration` inserts its run row and then walks the **entire DingTalk directory** before opening its apply transaction. Nothing stopped a manual sync, the scheduler, and a second replica from doing that at once: double consumption of the shared DingTalk API quota, two large apply transactions lock-waiting on the same integration, and a `last_seen_at < syncTimestamp` sweep that can deactivate rows the other run just wrote. **A transaction-scoped advisory lock around the apply would not protect the pull** — the expensive part happens before it. (A session advisory lock is also unsafe here: `query()` draws from a pool, so lock and unlock could land on different connections.)

The lease therefore lives on the run row, which already predates the first outbound call:
- a **partial unique index** on `(integration_id) WHERE status='running'` makes "at most one running run per integration" a *database* invariant — the second claim is a unique violation, not a lost race under READ COMMITTED;
- the loser gets `DirectorySyncInProgressError` → the route answers **409 with the active runId on BOTH trigger paths (sync and `{async:true}`)**, the scheduler logs a **skip**;
- **liveness is a heartbeat, not run age**: the sync beats `last_heartbeat_at` every `DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS` (default 60s; invalid/sub-5s values fall back), and reclaim fires only when `COALESCE(last_heartbeat_at, started_at)` is older than `DIRECTORY_SYNC_LEASE_STALE_MINUTES` (default 10, clamped to ≥5× the beat interval). A live long pull on a large tenant is never reclaimed; a crashed run is reclaimed within minutes — before each claim and once at scheduler boot;
- completion **and** failure release the lease, in **one transaction** (lease first), and the completion `UPDATE` is guarded `AND status='running'`.

Two deliberate behavior changes (ops-visible):
- a **reclaimed zombie that later finishes rolls back its entire apply** (`DirectorySyncLeaseLostError` inside the apply transaction) instead of silently completing over the new claimant's writes;
- `error_message` distinguishes *reclaimed-while-presumed-crashed* (`orphaned: sync lease heartbeat went stale…`) from a run's own failure.

The migration closes out any `running` row first — on deploy those are orphaned by definition — which also clears the pre-existing zombie rows that had no recovery path at all (roadmap's stale-run cleanup). `DIRECTORY_SYNC_LEASE_TTL_MINUTES` from the first revision of this PR **no longer exists** — the staleness knob fully supersedes it (never shipped, zero refs on main).

**Verification**: 46 route + 5 scheduler + 13 lease + 4 env-knob unit tests pass inside the full 343-file/4566-test suite; `tsc --noEmit` clean. **Real-DB golden committed** (`tests/integration/directory-sync-run-lease.db.test.ts`, two-point wired): partial unique index (23505 on concurrent claim, partial on terminal rows), heartbeat staleness 3-way (live-long-run survives / stale beat reclaimed / never-beat falls back to `started_at`). **Mutation-proven** (each restored after RED): predicate→`started_at`-only (real-DB red ×1: live run stolen), heartbeat writer deleted, `markSyncFailure` de-transactionalized, completion guard dropped, async-catch 409 mapping removed, scheduler boot sweep removed, scheduler skip removed.

Roadmap: DT-HARDEN-05. Gate: APPROVE-with-hardening → all P2/P3/NIT findings closed on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
