### PR TITLE
feat(web): TC-1 connector/experience template catalog — seed-the-wizard, zero backend (design-lock #3879)

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -35,6 +35,8 @@ on:
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
       - 'apps/web/src/components/integration/IntegrationCompositionWizard.vue'
+      - 'apps/web/src/services/integration/readSourceTemplateCatalog.ts'
+      - 'apps/web/src/components/integration/IntegrationTemplateCatalogPicker.vue'
       - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
       - 'apps/web/src/components/integration/IntegrationMonitoringSection.vue'
       - 'apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue'
@@ -73,6 +75,8 @@ on:
       - 'apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/IntegrationCompositionWizard.spec.ts'
+      - 'apps/web/tests/readSourceTemplateCatalog.spec.ts'
+      - 'apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchRail.spec.ts'
@@ -110,6 +114,8 @@ on:
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionPanel.vue'
       - 'apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue'
       - 'apps/web/src/components/integration/IntegrationCompositionWizard.vue'
+      - 'apps/web/src/services/integration/readSourceTemplateCatalog.ts'
+      - 'apps/web/src/components/integration/IntegrationTemplateCatalogPicker.vue'
       - 'apps/web/src/components/integration/IntegrationWorkbenchRail.vue'
       - 'apps/web/src/components/integration/IntegrationMonitoringSection.vue'
       - 'apps/web/src/components/integration/IntegrationCleaningDatasetSection.vue'
@@ -148,6 +154,8 @@ on:
       - 'apps/web/tests/IntegrationReadSourceCompositionPanel.spec.ts'
       - 'apps/web/tests/IntegrationReadSourceCompositionAuthoringPanel.spec.ts'
       - 'apps/web/tests/IntegrationCompositionWizard.spec.ts'
+      - 'apps/web/tests/readSourceTemplateCatalog.spec.ts'
+      - 'apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts'
       - 'apps/web/tests/readSourceCompositions.service.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchView.spec.ts'
       - 'apps/web/tests/IntegrationWorkbenchRail.spec.ts'
@@ -221,4 +229,4 @@ jobs:
       # Consolidated here into the SINGLE unioned list (verified green on both Node 20 and this repo's
       # default Node before landing) — do not reintroduce a second `run:` key; add new specs to this one.
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck IntegrationOptionSetsStructuredEditor optionSetsStructured integrationWorkbench MetaIntegrationFieldRuleAuthoring --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck IntegrationOptionSetsStructuredEditor optionSetsStructured integrationWorkbench MetaIntegrationFieldRuleAuthoring readSourceTemplateCatalog IntegrationTemplateCatalogPicker --reporter=dot

--- a/apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
@@ -10,6 +10,17 @@
       <div class="integration-read-source-composition-authoring__form" data-testid="rscauth-form">
         <h3>新建组合</h3>
 
+        <!-- TC-1 (design-lock docs/development/integration-connector-template-catalog-design-lock-20260708.md,
+             #3879): ADD-ONLY alternative entry point, collapsed by default — the pre-existing
+             wizard/flat-form default surface and every existing assertion about it are untouched.
+             Selecting a card seeds `draft.sourceTarget` (mirrors this panel's own pre-existing default
+             assignment below) and forces the view back to the wizard. -->
+        <IntegrationTemplateCatalogPicker
+          seeds-wizard="composition"
+          testid-prefix="rscauth"
+          @select="applyCompositionTemplate"
+        />
+
         <!-- IU-4 (design-lock docs/development/integration-iu4-composition-wizard-design-lock-20260707.md,
              #3803, sibling of IU-3): the wizard is the DEFAULT surface; this toggle switches to the
              untouched full flat form below (折叠≠删除 — expert mode is retained, never removed).
@@ -207,7 +218,13 @@ import {
   type ReadSourceCompositionFieldError,
   type ReadSourceCompositionSaveResult,
 } from '../../services/integration/readSourceCompositions'
+import {
+  isCompositionTemplateEntry,
+  seedCompositionDraft,
+  type IntegrationTemplateCatalogEntry,
+} from '../../services/integration/readSourceTemplateCatalog'
 import IntegrationCompositionWizard from './IntegrationCompositionWizard.vue'
+import IntegrationTemplateCatalogPicker from './IntegrationTemplateCatalogPicker.vue'
 
 // IU-4 (design-lock docs/development/integration-iu4-composition-wizard-design-lock-20260707.md,
 // #3803): the wizard is the DEFAULT new-composition surface; `initialViewMode` lets a caller (incl.
@@ -280,6 +297,17 @@ watch(savedRow, () => {
   auditOpen.value = false
   auditRows.value = []
 })
+
+// TC-1 (design-lock docs/development/integration-connector-template-catalog-design-lock-20260708.md):
+// same seed-then-present pattern as the read-source panel's applyReadSourceTemplate — mutates only
+// `sourceTarget` on the SAME shared draft, then forces the view back to 'wizard'. The picker is wired
+// with seeds-wizard="composition" so only CompositionTemplateCatalogEntry values are ever emitted here;
+// the type guard is a defensive narrowing, not a behavior branch.
+function applyCompositionTemplate(entry: IntegrationTemplateCatalogEntry): void {
+  if (!isCompositionTemplateEntry(entry)) return
+  seedCompositionDraft(draft, entry)
+  viewMode.value = 'wizard'
+}
 
 function statusLabel(status: CompositionStatus): string {
   if (status === 'approved') return '已审批'

--- a/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
+++ b/apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
@@ -9,6 +9,18 @@
       <div class="integration-read-source__form" data-testid="read-source-form">
         <h3>新建 / 试配读取源</h3>
 
+        <!-- TC-1 (design-lock docs/development/integration-connector-template-catalog-design-lock-20260708.md,
+             #3879): an ADD-ONLY alternative entry point — collapsed by default, so the pre-existing
+             wizard/flat-form default surface and every existing assertion about it are untouched.
+             Selecting a card seeds `draft.mode` (the exact field IntegrationReadSourceWizard.vue's own
+             `selectMode()` sets) and forces the view back to the wizard, then falls through to the
+             SAME step-1/2/3/4 flow — no new state, no new path. -->
+        <IntegrationTemplateCatalogPicker
+          seeds-wizard="read-source"
+          testid-prefix="rsc"
+          @select="applyReadSourceTemplate"
+        />
+
         <!-- IU-3 (design-lock docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md):
              the wizard is the DEFAULT surface; this toggle switches to the untouched full flat form
              below (折叠≠删除 — expert mode is retained, never removed). Native <button>, not an
@@ -394,7 +406,13 @@ import {
   type ReadSourceSaveResult,
   type ReadSourceStatus,
 } from '../../services/integration/readSourceConfigs'
+import {
+  isReadSourceTemplateEntry,
+  seedReadSourceDraft,
+  type IntegrationTemplateCatalogEntry,
+} from '../../services/integration/readSourceTemplateCatalog'
 import IntegrationReadSourceWizard from './IntegrationReadSourceWizard.vue'
+import IntegrationTemplateCatalogPicker from './IntegrationTemplateCatalogPicker.vue'
 
 // IU-3 (design-lock docs/development/integration-iu3-read-source-wizard-design-lock-20260707.md):
 // the wizard is the DEFAULT new-config surface; `initialViewMode` lets a caller (incl. this file's
@@ -476,6 +494,18 @@ function addFieldMapRow(): void {
 
 function removeFieldMapRow(index: number): void {
   draft.fieldMap.splice(index, 1)
+}
+
+// TC-1 (design-lock docs/development/integration-connector-template-catalog-design-lock-20260708.md):
+// seed-then-present — the SAME shared `draft` the wizard/flat-form already bind to, mutated by exactly
+// one field (`seedReadSourceDraft` mirrors the wizard's own `selectMode()`), then the view is forced
+// back to 'wizard' so the pre-filled state is immediately visible on the surface it was seeded for.
+// The picker is wired with seeds-wizard="read-source" so only ReadSourceTemplateCatalogEntry values are
+// ever emitted here; the type guard is a defensive narrowing, not a behavior branch.
+function applyReadSourceTemplate(entry: IntegrationTemplateCatalogEntry): void {
+  if (!isReadSourceTemplateEntry(entry)) return
+  seedReadSourceDraft(draft, entry)
+  viewMode.value = 'wizard'
 }
 
 function statusLabel(status: ReadSourceStatus): string {

--- a/apps/web/src/components/integration/IntegrationTemplateCatalogPicker.vue
+++ b/apps/web/src/components/integration/IntegrationTemplateCatalogPicker.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="template-catalog" :data-testid="`${testidPrefix}-template-catalog`">
+    <!-- Collapsed by default (design-lock: ADD-ONLY, the blank-form path stays the default surface —
+         see IntegrationReadSourceWizard.spec.ts / IntegrationCompositionWizard.spec.ts, whose existing
+         assertions must not change). Native <button>, same rationale as every other toggle in this
+         component family: Element Plus is not globally registered in every host that mounts these
+         panels in tests. -->
+    <button
+      type="button"
+      class="template-catalog__toggle"
+      :data-testid="`${testidPrefix}-template-catalog-toggle`"
+      :aria-expanded="expanded ? 'true' : 'false'"
+      @click="expanded = !expanded"
+    >
+      <el-icon><ArrowDown v-if="expanded" /><ArrowRight v-else /></el-icon>
+      {{ bi('从模板开始', 'Start from a template') }}
+    </button>
+
+    <div v-show="expanded" class="template-catalog__body" :data-testid="`${testidPrefix}-template-catalog-body`">
+      <p class="template-catalog__desc">{{ bi(
+        '选一个已验证的接入场景，预填下面向导的初始状态；你仍然只需要补充少量必填的真实值。',
+        'Pick a validated connection scenario to pre-fill the wizard below — you still only need to fill in a few required real values.',
+      ) }}</p>
+      <div class="template-catalog__grid" :data-testid="`${testidPrefix}-template-catalog-grid`">
+        <button
+          v-for="entry in entries"
+          :key="entry.id"
+          type="button"
+          class="template-catalog__card"
+          :data-testid="`${testidPrefix}-template-catalog-card-${entry.id}`"
+          @click="selectEntry(entry)"
+        >
+          <span class="template-catalog__card-title">{{ bi(entry.title.zh, entry.title.en) }}</span>
+          <span class="template-catalog__card-subtitle">{{ bi(entry.oneLiner.zh, entry.oneLiner.en) }}</span>
+        </button>
+      </div>
+      <p v-if="entries.length === 0" class="template-catalog__empty" :data-testid="`${testidPrefix}-template-catalog-empty`">
+        {{ bi('暂无可用模板。', 'No templates available yet.') }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// TC-1 connector/experience template catalog picker (design-lock
+// docs/development/integration-connector-template-catalog-design-lock-20260708.md, #3879, §1-§3).
+//
+// Presentation shell ONLY: it lists `INTEGRATION_TEMPLATE_CATALOG` entries filtered to the
+// `seedsWizard` kind the host panel owns, and emits the chosen entry — it owns no service call, no
+// draft, no validation, and does not itself apply the seed (the host panel calls
+// `seedReadSourceDraft`/`seedCompositionDraft` in its own `@select` handler, on its own existing
+// `draft`). This mirrors IU-3/IU-4's own wizard shells: a REORDERING/PRESENTATION layer over state the
+// parent owns, never a second state or a second code path (design-lock §2 hard lock).
+//
+// Card visuals are copied verbatim from IntegrationReadSourceWizard.vue's `.iu3-wizard__card` (scoped
+// styles cannot be shared across SFCs — see that file's own precedent, where IU-4's
+// IntegrationCompositionWizard.vue does the same), renamed to `.template-catalog__card`; token-only
+// (UF-1 hard lock), zero hex/rgb literals.
+import { computed, ref } from 'vue'
+import { ArrowDown, ArrowRight } from '@element-plus/icons-vue'
+import { useLocale } from '../../composables/useLocale'
+import {
+  integrationTemplateCatalogEntriesFor,
+  type IntegrationTemplateCatalogEntry,
+  type IntegrationTemplateSeedsWizard,
+} from '../../services/integration/readSourceTemplateCatalog'
+
+const props = defineProps<{
+  // Which wizard this picker instance seeds — the host panel only ever wants the subset of the catalog
+  // relevant to the draft IT owns (a read-source panel cannot meaningfully seed a composition draft,
+  // and vice versa), so filtering happens here rather than pushing "pick the right entries" logic onto
+  // every caller.
+  seedsWizard: IntegrationTemplateSeedsWizard
+  // Distinguishes data-testids between the two host panels (`rsc-*` / `rscauth-*` — the codebase's
+  // existing per-panel testid prefix convention) so mounting both in the same page never collides.
+  testidPrefix: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', entry: IntegrationTemplateCatalogEntry): void
+}>()
+
+const { locale } = useLocale()
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+const expanded = ref(false)
+
+const entries = computed(() => integrationTemplateCatalogEntriesFor(props.seedsWizard))
+
+function selectEntry(entry: IntegrationTemplateCatalogEntry): void {
+  emit('select', entry)
+}
+</script>
+
+<style scoped>
+/* Token-only (UF-1 / design-lock §3 hard lock) — every style in this file uses var(--ms-*), zero
+   hex/rgb literals; card class values copied verbatim from IntegrationReadSourceWizard.vue's
+   .iu3-wizard__card family (see script header). */
+.template-catalog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-2);
+  margin-bottom: var(--ms-space-3);
+}
+.template-catalog__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ms-space-1);
+  align-self: flex-start;
+  border: none;
+  background: none;
+  color: var(--ms-color-primary);
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0;
+}
+.template-catalog__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-md);
+  padding: var(--ms-space-3);
+}
+.template-catalog__desc {
+  margin: 0;
+  color: var(--ms-text-2);
+  font-size: 13px;
+}
+.template-catalog__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--ms-space-3);
+}
+.template-catalog__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--ms-space-1);
+  padding: var(--ms-space-3);
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-md);
+  background: var(--ms-bg-card);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+.template-catalog__card:hover {
+  border-color: var(--ms-color-primary);
+}
+.template-catalog__card-title {
+  font-size: 14px;
+  font-weight: var(--ms-font-weight-title);
+  color: var(--ms-text-1);
+}
+.template-catalog__card-subtitle {
+  font-size: 12px;
+  color: var(--ms-text-2);
+}
+.template-catalog__empty {
+  color: var(--ms-text-3);
+  font-size: 13px;
+  margin: 0;
+}
+</style>

--- a/apps/web/src/services/integration/bridgeAgentConfigCheck.ts
+++ b/apps/web/src/services/integration/bridgeAgentConfigCheck.ts
@@ -157,11 +157,25 @@ export function bridgeAgentConfigCheckLabel(labelKey: BridgeAgentConfigCheckLabe
   return locale === 'zh-CN' ? entry.zh : entry.en
 }
 
+// The adapter kind this whole module is scoped to (mirrors
+// plugins/plugin-integration-core/index.cjs's `.registerAdapter('bridge:legacy-sql-readonly', ...)`).
+// Exported so a consumer needing to reference this kind (e.g. the connector/experience template
+// catalog, TC-1) reads it from here rather than hand-typing the literal a second time.
+export const BRIDGE_AGENT_KIND = 'bridge:legacy-sql-readonly'
+
+// The connection-field precedence `firstBaseUrlLike` checks, in order — mirrors
+// bridge-agent-readonly-adapter.cjs's normalizeBaseUrl() input precedence. Exported as the single
+// source of truth for "which config keys satisfy the requiredFields check" so a consumer (e.g. the
+// template catalog's requiredFieldKeys for a bridge template) reads the real list instead of a
+// hand-copied one.
+export const BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS: string[] = ['baseUrl', 'bridgeUrl', 'url']
+
 // Mirrors bridge-agent-readonly-adapter.cjs's normalizeBaseUrl() input precedence.
 function firstBaseUrlLike(config: Record<string, unknown>): string | null {
-  if (isNonEmptyString(config.baseUrl)) return config.baseUrl
-  if (isNonEmptyString(config.bridgeUrl)) return config.bridgeUrl
-  if (isNonEmptyString(config.url)) return config.url
+  for (const key of BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS) {
+    const value = config[key]
+    if (isNonEmptyString(value)) return value
+  }
   return null
 }
 

--- a/apps/web/src/services/integration/readSourceTemplateCatalog.ts
+++ b/apps/web/src/services/integration/readSourceTemplateCatalog.ts
@@ -1,0 +1,255 @@
+// Connector / experience template catalog — TC-1 "seed-the-wizard" v1 (design-lock
+// docs/development/integration-connector-template-catalog-design-lock-20260708.md, #3879, §1-§3).
+//
+// A curated, platform-maintained catalog of named "connection + read-source + composition" templates.
+// Each entry is a values-free, presentation-layer config SEED over an EXISTING wizard/preset — this
+// module invents NO new connector kind, NO new read-source mode, NO new composition shape, and owns
+// no service call of its own (zero backend, zero runtime — design-lock §2 hard lock). Selecting a
+// template pre-fills the SAME wizard state (`ReadSourceConfigDraft` / `ReadSourceCompositionDraft`)
+// a user reaches by manually clicking the corresponding preset/mode card — see `seedReadSourceDraft` /
+// `seedCompositionDraft` below, each a one-field assignment mirroring the wizard's own
+// `selectMode()`/manual-edit effect exactly (IntegrationReadSourceWizard.vue / the composition
+// authoring panel's `draft.sourceTarget` default), so the seed round-trip is provably a single
+// initial-state injection, not a second configuration path.
+//
+// Single-source discipline (design-lock §2/§3, same range as readSourceModePresets.ts's own header):
+// `requiredFieldKeys` for a read-source template is read straight off `readSourceModePreset(mode)` —
+// itself sourced from `READ_SOURCE_MODE_REQUIRED_FIELDS` in readSourceConfigs.ts — never a hand-copied
+// list. Calling `readSourceModePreset()` also means a template referencing a mode with no registered
+// preset card throws at import time (readSourceModePresets.ts's own tripwire), so this module can never
+// silently drift from the real mode/required-field vocabulary. The bridge template's
+// `requiredFieldKeys` and `seed.kind` are read off `BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS` /
+// `BRIDGE_AGENT_KIND` (bridgeAgentConfigCheck.ts) for the same reason. The composition template's
+// `requiredFieldKeys` is derived from `Object.keys(createReadSourceCompositionDraft())` — the real
+// draft factory's own field set, not a hand-typed list.
+//
+// values-free (design-lock §3 hard lock): every title/oneLiner/seed value here is placeholder-shaped
+// only — no real material/host/tenant/database/credential value, not even as an "example". Where the
+// design-lock's own prose gives an example shape ("示例：单据编号形如 XX-000000"), copy here stays at
+// that same level of abstraction. `readSourceTemplateCatalog.spec.ts` sentinel-scans every string field
+// for digit-run>4 / URL-scheme / credential-shaped keywords as a standing tripwire.
+//
+// Non-goals (design-lock §6): this is NOT a marketplace (no third-party entries, no rating/install),
+// NOT customer-authored (no "save as template" in v1), and does NOT touch the wizard's own interaction
+// skeleton, byte-equal invariants, or approval/probe paths — those all stay exactly as IU-3/IU-4 left
+// them. TC-2+ (onboarding flow riding probe/BA-UI-2, additional template batches, in-catalog search) are
+// separate, later, explicit opt-ins (design-lock §4) — out of scope here.
+
+import {
+  BRIDGE_AGENT_KIND,
+  BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS,
+} from './bridgeAgentConfigCheck'
+import {
+  createReadSourceCompositionDraft,
+  type ReadSourceCompositionDraft,
+} from './readSourceCompositions'
+import type { ReadSourceConfigDraft, ReadSourceMode } from './readSourceConfigs'
+import { readSourceModePreset } from './readSourceModePresets'
+
+export type IntegrationTemplateCatalogCopy = { zh: string; en: string }
+
+export const INTEGRATION_TEMPLATE_SEEDS_WIZARD = ['read-source', 'composition', 'bridge'] as const
+export type IntegrationTemplateSeedsWizard = typeof INTEGRATION_TEMPLATE_SEEDS_WIZARD[number]
+
+interface IntegrationTemplateCatalogEntryBase {
+  // Stable kebab-case identifier (design-lock §3).
+  id: string
+  title: IntegrationTemplateCatalogCopy
+  oneLiner: IntegrationTemplateCatalogCopy
+  // Descriptive metadata ONLY — which existing connector kind this template suits. Never applied to a
+  // draft (a real systemId/requiredKind always comes from picking an actual registered external system,
+  // which is tenant data, not template data); it exists purely to label the card / drive the catalog's
+  // "kind/mode exists in the real source set" coverage tripwire.
+  targetKind: string
+  requiredFieldKeys: string[]
+}
+
+export interface ReadSourceTemplateCatalogEntry extends IntegrationTemplateCatalogEntryBase {
+  seedsWizard: 'read-source'
+  // The ENTIRE seed: exactly the one field IntegrationReadSourceWizard.vue's own `selectMode()` sets.
+  // Anything wider (readMethod, keyEncoding, requiredKind, …) would make the seeded draft diverge from
+  // what manual preset-card selection reaches — the design-lock §5.1 round-trip golden depends on this
+  // seed staying exactly this narrow.
+  seed: { mode: ReadSourceMode }
+}
+
+export interface CompositionTemplateCatalogEntry extends IntegrationTemplateCatalogEntryBase {
+  seedsWizard: 'composition'
+  // sourceTarget only — step1ConfigId/step2ConfigId are always an ACTUAL approved resolver_lookup read
+  // source id (tenant runtime data), so a template can never pre-select them without ceasing to be
+  // values-free. 'internal_id' mirrors the authoring panel's own pre-existing default
+  // (IntegrationReadSourceCompositionAuthoringPanel.vue `draft.sourceTarget = 'internal_id'`), so this
+  // seed is — by design — a no-op against a fresh panel: proof that the template is initial-state
+  // injection, not a second path (design-lock §2).
+  seed: { sourceTarget: string }
+}
+
+export interface BridgeTemplateCatalogEntry extends IntegrationTemplateCatalogEntryBase {
+  seedsWizard: 'bridge'
+  // No interactive wizard exists for this entry point in v1: the Bridge-Agent section (BA-UI-1..3) is
+  // read-only observability/probe over an ALREADY-connected instance, with no authoring draft to seed.
+  // The entry is catalog-DATA-complete (covers `bridge:legacy-sql-readonly` per the design-lock's v1
+  // candidate set) but has no interactive picker wiring in TC-1 — see readSourceTemplateCatalog.spec.ts
+  // and the TC-1 verification MD for the explicit scoping note. `seed.kind` is carried for forward
+  // compatibility with a later TC that deep-links into that section.
+  seed: { kind: string }
+}
+
+export type IntegrationTemplateCatalogEntry =
+  | ReadSourceTemplateCatalogEntry
+  | CompositionTemplateCatalogEntry
+  | BridgeTemplateCatalogEntry
+
+function readSourceEntry(
+  id: string,
+  targetKindLabel: IntegrationTemplateCatalogCopy,
+  targetKind: string,
+  mode: ReadSourceMode,
+): ReadSourceTemplateCatalogEntry {
+  // Reads the REAL preset (readSourceModePresets.ts) rather than re-describing the mode's shape from
+  // scratch — "消费既有 typed 模块, 不得另建一套重复的标题/说明词汇" (design-lock §2/§3). Composing the
+  // catalog's copy from `preset.title`/`preset.oneLiner` also means a future edit to the preset copy
+  // propagates here automatically instead of drifting.
+  const preset = readSourceModePreset(mode)
+  return {
+    id,
+    title: {
+      zh: `${targetKindLabel.zh} · ${preset.title.zh}`,
+      en: `${targetKindLabel.en} · ${preset.title.en}`,
+    },
+    oneLiner: {
+      zh: `${targetKindLabel.zh}：${preset.oneLiner.zh}`,
+      en: `${targetKindLabel.en}: ${preset.oneLiner.en}`,
+    },
+    targetKind,
+    seedsWizard: 'read-source',
+    seed: { mode },
+    // Real source of truth, not a copy — see module header.
+    requiredFieldKeys: preset.requiredFieldKeys,
+  }
+}
+
+// v1 candidate set (design-lock §1 table): K3 WISE WebAPI read-source, K3 WISE SQL read-source
+// (advanced connector — 2026-05-12 advanced-connectors lock's "高级连接默认隐藏" convention: this
+// template is still catalog-listed, the UI decides whether/where to surface "advanced" entries), the
+// legacy-SQL Bridge-Agent read-only kind, generic HTTP read-source across all four existing
+// `READ_SOURCE_MODES`, and the fixed two-hop composition shape. The catalog is a SUBSET projection of
+// whatever kind/mode set exists on main — never a superset (design-lock §1): if main ever adds a mode
+// this file doesn't enumerate, nothing here goes red (a template is opt-in curation, not exhaustive
+// coverage); if this file ever references a mode/kind that does NOT exist on main, `readSourceModePreset`
+// (or the direct BRIDGE_AGENT_* import) throws at import time instead.
+export const INTEGRATION_TEMPLATE_CATALOG: readonly IntegrationTemplateCatalogEntry[] = [
+  readSourceEntry(
+    'k3-wise-webapi-single-record',
+    { zh: 'K3 WISE WebAPI', en: 'K3 WISE WebAPI' },
+    'erp:k3-wise-webapi',
+    'single_record',
+  ),
+  readSourceEntry(
+    'k3-wise-sqlserver-list-page',
+    { zh: 'K3 WISE SQL 读取通道（高级）', en: 'K3 WISE SQL channel (advanced)' },
+    'erp:k3-wise-sqlserver',
+    'list_page',
+  ),
+  {
+    id: 'bridge-legacy-sql-readonly',
+    title: { zh: '遗留 SQL 库（Bridge-Agent 只读）', en: 'Legacy SQL database (Bridge-Agent, read-only)' },
+    oneLiner: {
+      zh: '经由本机 Bridge-Agent 只读暴露白名单表/视图，不接受任意 SQL、不做写入。',
+      en: 'Exposes an allowlisted set of tables/views read-only via the local Bridge-Agent — no free-form SQL, no writes.',
+    },
+    targetKind: BRIDGE_AGENT_KIND,
+    seedsWizard: 'bridge',
+    seed: { kind: BRIDGE_AGENT_KIND },
+    // Real source of truth, not a copy — see module header.
+    requiredFieldKeys: [...BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS],
+  },
+  readSourceEntry(
+    'http-read-single-record',
+    { zh: '通用 HTTP 读取源', en: 'Generic HTTP read source' },
+    'http',
+    'single_record',
+  ),
+  readSourceEntry(
+    'http-read-list-page',
+    { zh: '通用 HTTP 读取源', en: 'Generic HTTP read source' },
+    'http',
+    'list_page',
+  ),
+  readSourceEntry(
+    'http-read-detail-with-lines',
+    { zh: '通用 HTTP 读取源', en: 'Generic HTTP read source' },
+    'http',
+    'detail_with_lines',
+  ),
+  readSourceEntry(
+    'http-read-resolver-lookup',
+    { zh: '通用 HTTP 读取源', en: 'Generic HTTP read source' },
+    'http',
+    'resolver_lookup',
+  ),
+  {
+    id: 'two-hop-composition',
+    title: { zh: '两跳组合（读→解析→读）', en: 'Two-hop composition (read → resolve → read)' },
+    oneLiner: {
+      zh: '固定的两跳读取组合：第一跳的解析输出作为第二跳的业务 key，形状与向导手动搭建的完全一致。',
+      en: 'A fixed two-hop read composition: hop 1\'s resolved output becomes hop 2\'s business key — the exact same shape the wizard builds manually.',
+    },
+    targetKind: 'composition:two-hop',
+    seedsWizard: 'composition',
+    // Mirrors the authoring panel's own pre-existing default — see the interface doc comment above.
+    seed: { sourceTarget: 'internal_id' },
+    // Derived from the real draft factory's field set, not a hand-typed list — see module header.
+    requiredFieldKeys: Object.keys(createReadSourceCompositionDraft()),
+  },
+] as const
+
+const CATALOG_BY_ID = new Map<string, IntegrationTemplateCatalogEntry>(
+  INTEGRATION_TEMPLATE_CATALOG.map((entry) => [entry.id, entry]),
+)
+
+export function integrationTemplateCatalogEntry(id: string): IntegrationTemplateCatalogEntry | null {
+  return CATALOG_BY_ID.get(id) ?? null
+}
+
+export function integrationTemplateCatalogEntriesFor(
+  seedsWizard: IntegrationTemplateSeedsWizard,
+): IntegrationTemplateCatalogEntry[] {
+  return INTEGRATION_TEMPLATE_CATALOG.filter((entry) => entry.seedsWizard === seedsWizard)
+}
+
+export function isReadSourceTemplateEntry(
+  entry: IntegrationTemplateCatalogEntry,
+): entry is ReadSourceTemplateCatalogEntry {
+  return entry.seedsWizard === 'read-source'
+}
+
+export function isCompositionTemplateEntry(
+  entry: IntegrationTemplateCatalogEntry,
+): entry is CompositionTemplateCatalogEntry {
+  return entry.seedsWizard === 'composition'
+}
+
+export function isBridgeTemplateEntry(
+  entry: IntegrationTemplateCatalogEntry,
+): entry is BridgeTemplateCatalogEntry {
+  return entry.seedsWizard === 'bridge'
+}
+
+// --- seed application (pure — no Vue, no DOM) ------------------------------------------------------
+//
+// Each function mutates ONLY the field the corresponding wizard's own manual-selection path would set,
+// so calling it on a fresh draft reaches byte-for-byte the same state manual selection reaches
+// (design-lock §5.1 round-trip golden). Neither function saves, probes, validates, or navigates —
+// selection is initial-state injection only; every downstream action still flows through the existing
+// wizard/panel/service code, untouched.
+
+// Mirrors IntegrationReadSourceWizard.vue's `selectMode()` exactly (one field, no side effects).
+export function seedReadSourceDraft(draft: ReadSourceConfigDraft, entry: ReadSourceTemplateCatalogEntry): void {
+  draft.mode = entry.seed.mode
+}
+
+// Mirrors IntegrationReadSourceCompositionAuthoringPanel.vue's own `sourceTarget` default assignment.
+export function seedCompositionDraft(draft: ReadSourceCompositionDraft, entry: CompositionTemplateCatalogEntry): void {
+  draft.sourceTarget = entry.seed.sourceTarget
+}

--- a/apps/web/src/services/integration/readSourceTemplateCatalog.ts
+++ b/apps/web/src/services/integration/readSourceTemplateCatalog.ts
@@ -92,6 +92,13 @@ export interface BridgeTemplateCatalogEntry extends IntegrationTemplateCatalogEn
   // candidate set) but has no interactive picker wiring in TC-1 — see readSourceTemplateCatalog.spec.ts
   // and the TC-1 verification MD for the explicit scoping note. `seed.kind` is carried for forward
   // compatibility with a later TC that deep-links into that section.
+  //
+  // Note on requiredFieldKeys for this entry: `BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS` is a ONE-OF
+  // precedence list (bridgeAgentConfigCheck.ts's requiredFieldsCheck passes if ANY one of
+  // baseUrl/bridgeUrl/url is present — the real Bridge-Agent adapter accepts exactly one connection
+  // field, not all three), unlike a read-source template's requiredFieldKeys, which IS an all-required
+  // set. The field name is shared across the union purely for a uniform catalog entry shape; the
+  // single-source discipline (real constant, never hand-copied) is what's being verified either way.
   seed: { kind: string }
 }
 

--- a/apps/web/tests/IntegrationCompositionWizard.spec.ts
+++ b/apps/web/tests/IntegrationCompositionWizard.spec.ts
@@ -485,4 +485,77 @@ describe('IntegrationCompositionWizard (via IntegrationReadSourceCompositionAuth
       setLocale('en')
     }
   })
+
+  // --- TC-1 connector/experience template catalog (design-lock
+  // docs/development/integration-connector-template-catalog-design-lock-20260708.md, #3879) ---------
+  // ADD-ONLY: every test above this point is unchanged. The template catalog picker is a NEW,
+  // collapsed-by-default entry point rendered by the parent panel
+  // (IntegrationReadSourceCompositionAuthoringPanel.vue) above the wizard.
+
+  it('TC-1: template catalog picker is collapsed by default — the blank-form wizard path is unaffected', async () => {
+    apiFetchMock.mockImplementation(routeApiFetch())
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('[data-testid="iu4-wizard-hop1-rsc_material_lookup"]') !== null, 'hop cards load')
+
+    expect(maybe(root, 'rscauth-template-catalog-toggle')).not.toBeNull()
+    const body = maybe(root, 'rscauth-template-catalog-body')
+    expect(body).not.toBeNull()
+    expect((body as HTMLElement).style.display).toBe('none')
+
+    await toStep2(root)
+    expect(q(root, 'iu4-wizard-wiring-output').textContent).toContain('internal_id')
+  })
+
+  it('TC-1: selecting the two-hop composition template seeds sourceTarget back to the EXACT default a fresh panel starts with, even after a manual edit', async () => {
+    apiFetchMock.mockImplementation(routeApiFetch())
+    const root = mountPanel()
+    await waitUntil(() => root.querySelector('[data-testid="iu4-wizard-hop1-rsc_material_lookup"]') !== null, 'hop cards load')
+    await toStep2(root)
+
+    // Diverge from the seed first, so selecting the template afterwards is a REAL, observable change —
+    // not a no-op that happens to match an already-untouched default.
+    setInput(root, 'iu4-wizard-source-target', 'diverged_value')
+    await flushUi()
+    expect(q(root, 'iu4-wizard-wiring-output').textContent).toContain('diverged_value')
+
+    q<HTMLButtonElement>(root, 'rscauth-template-catalog-toggle').click()
+    await flushUi()
+    expect(maybe(root, 'rscauth-template-catalog-card-two-hop-composition')).not.toBeNull()
+    q<HTMLButtonElement>(root, 'rscauth-template-catalog-card-two-hop-composition').click()
+    await flushUi()
+
+    expect(q(root, 'iu4-wizard-wiring-output').textContent).toContain('internal_id')
+    expect(q(root, 'iu4-wizard-wiring-output').textContent).not.toContain('diverged_value')
+  })
+
+  it('TC-1: selecting a template forces the panel back to wizard view even from expert mode', async () => {
+    apiFetchMock.mockImplementation(routeApiFetch())
+    const root = mountPanel('expert')
+    await waitUntil(() => root.querySelector('[data-testid="rscauth-step1"]') !== null, 'expert form loads')
+    expect(maybe(root, 'composition-wizard')).toBeNull()
+
+    q<HTMLButtonElement>(root, 'rscauth-template-catalog-toggle').click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rscauth-template-catalog-card-two-hop-composition').click()
+    await flushUi()
+
+    expect(maybe(root, 'composition-wizard')).not.toBeNull()
+    expect(maybe(root, 'rscauth-step1')).toBeNull()
+  })
+
+  it('TC-1: template catalog card copy renders bilingually via useLocale', async () => {
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      apiFetchMock.mockImplementation(routeApiFetch())
+      const root = mountPanel()
+      await waitUntil(() => root.querySelector('[data-testid="iu4-wizard-hop1-rsc_material_lookup"]') !== null, 'hop cards load')
+      expect(q(root, 'rscauth-template-catalog-toggle').textContent).toContain('从模板开始')
+      q<HTMLButtonElement>(root, 'rscauth-template-catalog-toggle').click()
+      await flushUi()
+      expect(q(root, 'rscauth-template-catalog-card-two-hop-composition').textContent).toContain('两跳组合')
+    } finally {
+      setLocale('en')
+    }
+  })
 })

--- a/apps/web/tests/IntegrationReadSourceWizard.spec.ts
+++ b/apps/web/tests/IntegrationReadSourceWizard.spec.ts
@@ -624,4 +624,83 @@ describe('IntegrationReadSourceWizard (via IntegrationReadSourceConfigPanel defa
       setLocale('en')
     }
   })
+
+  // --- TC-1 connector/experience template catalog (design-lock
+  // docs/development/integration-connector-template-catalog-design-lock-20260708.md, #3879) ---------
+  // ADD-ONLY: every test above this point is unchanged. The template catalog picker is a NEW,
+  // collapsed-by-default entry point rendered by the parent panel (IntegrationReadSourceConfigPanel.vue)
+  // above the wizard; these tests exercise it end-to-end through the same real panel this file already
+  // mounts, never a standalone stub of the picker.
+
+  it('TC-1: template catalog picker is collapsed by default — the blank-form wizard path is unaffected', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+
+    expect(maybe(root, 'rsc-template-catalog-toggle')).not.toBeNull()
+    const body = maybe(root, 'rsc-template-catalog-body')
+    expect(body).not.toBeNull()
+    expect((body as HTMLElement).style.display).toBe('none')
+
+    // Blank-form entry still works exactly as before: default mode is single_record (existing
+    // 'preset card selection' test already proves the full field set; this just re-confirms the
+    // default survives the picker's presence).
+    await toStep2(root)
+    expect(q(root, 'rsc-wizard-mode-single_record').className).toContain('iu3-wizard__card--selected')
+    expect(maybe(root, 'rsc-wizard-key-field')).not.toBeNull()
+  })
+
+  it('TC-1: selecting a read-source template card seeds draft.mode to EXACTLY what manually clicking that mode\'s preset card would', async () => {
+    mockListOnly()
+    const root = mountPanel()
+    await flushUi()
+
+    // Expand the picker and select the "generic HTTP · list_page" template BEFORE even picking a
+    // system — the seed only ever touches `mode`, so it must survive step-1's system selection
+    // untouched and land on step 2 exactly as if the user had clicked the list_page card there.
+    q<HTMLButtonElement>(root, 'rsc-template-catalog-toggle').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-template-catalog-card-http-read-list-page')).not.toBeNull()
+    q<HTMLButtonElement>(root, 'rsc-template-catalog-card-http-read-list-page').click()
+    await flushUi()
+
+    await toStep2(root)
+    expect(q(root, 'rsc-wizard-mode-list_page').className).toContain('iu3-wizard__card--selected')
+    // Same field set the manual-selection test asserts for list_page: containerPaths only, no keyField.
+    expect(maybe(root, 'rsc-wizard-key-field')).toBeNull()
+    expect(maybe(root, 'rsc-wizard-container-paths')).not.toBeNull()
+    expect(maybe(root, 'rsc-wizard-resolver-rule')).toBeNull()
+  })
+
+  it('TC-1: selecting a template forces the panel back to wizard view even from expert mode', async () => {
+    mockListOnly()
+    const root = mountPanel('expert')
+    await flushUi()
+    expect(maybe(root, 'read-source-wizard')).toBeNull()
+    expect(maybe(root, 'rsc-system')).not.toBeNull()
+
+    q<HTMLButtonElement>(root, 'rsc-template-catalog-toggle').click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rsc-template-catalog-card-k3-wise-webapi-single-record').click()
+    await flushUi()
+
+    expect(maybe(root, 'read-source-wizard')).not.toBeNull()
+    expect(maybe(root, 'rsc-system')).toBeNull()
+  })
+
+  it('TC-1: template catalog card copy renders bilingually via useLocale', async () => {
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      mockListOnly()
+      const root = mountPanel()
+      await flushUi()
+      expect(q(root, 'rsc-template-catalog-toggle').textContent).toContain('从模板开始')
+      q<HTMLButtonElement>(root, 'rsc-template-catalog-toggle').click()
+      await flushUi()
+      expect(q(root, 'rsc-template-catalog-card-http-read-single-record').textContent).toContain('通用 HTTP 读取源')
+    } finally {
+      setLocale('en')
+    }
+  })
 })

--- a/apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts
+++ b/apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+import IntegrationTemplateCatalogPicker from '../src/components/integration/IntegrationTemplateCatalogPicker.vue'
+import {
+  INTEGRATION_TEMPLATE_CATALOG,
+  integrationTemplateCatalogEntriesFor,
+  type IntegrationTemplateCatalogEntry,
+} from '../src/services/integration/readSourceTemplateCatalog'
+
+// TC-1 connector/experience template catalog picker — standalone component spec (design-lock
+// docs/development/integration-connector-template-catalog-design-lock-20260708.md, #3879). The
+// end-to-end wiring (seeding a real panel's draft, forcing view mode back to wizard) is covered by the
+// ADD-ONLY tests appended to IntegrationReadSourceWizard.spec.ts / IntegrationCompositionWizard.spec.ts;
+// this spec is the picker's own contract in isolation — filtering, rendering, collapse/expand, emit.
+
+const ElIcon = defineComponent({
+  name: 'ElIcon',
+  setup(_props, { slots }) {
+    return () => h('span', { class: 'el-icon' }, slots.default?.())
+  },
+})
+
+async function flushUi(cycles = 3): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('IntegrationTemplateCatalogPicker', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+  let selected: IntegrationTemplateCatalogEntry[] = []
+
+  beforeEach(() => {
+    selected = []
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  function mount(seedsWizard: 'read-source' | 'composition' | 'bridge', testidPrefix = 'rsc'): HTMLDivElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () => h(IntegrationTemplateCatalogPicker, {
+        seedsWizard,
+        testidPrefix,
+        onSelect: (entry: IntegrationTemplateCatalogEntry) => selected.push(entry),
+      }),
+    })
+    app.component('ElIcon', ElIcon)
+    app.mount(container)
+    return container
+  }
+
+  function q<T extends HTMLElement>(root: HTMLElement, testid: string): T {
+    const el = root.querySelector<T>(`[data-testid="${testid}"]`)
+    if (!el) throw new Error(`missing [data-testid=${testid}]`)
+    return el
+  }
+
+  function maybe(root: HTMLElement, testid: string): HTMLElement | null {
+    return root.querySelector<HTMLElement>(`[data-testid="${testid}"]`)
+  }
+
+  it('renders collapsed by default and expands via the toggle', async () => {
+    const root = mount('read-source')
+    await flushUi()
+    expect((q(root, 'rsc-template-catalog-body')).style.display).toBe('none')
+    q<HTMLButtonElement>(root, 'rsc-template-catalog-toggle').click()
+    await flushUi()
+    expect((q(root, 'rsc-template-catalog-body')).style.display).not.toBe('none')
+  })
+
+  it('lists exactly the catalog entries matching the seedsWizard prop — no more, no fewer', async () => {
+    const root = mount('read-source')
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rsc-template-catalog-toggle').click()
+    await flushUi()
+
+    const expected = integrationTemplateCatalogEntriesFor('read-source')
+    for (const entry of expected) {
+      expect(maybe(root, `rsc-template-catalog-card-${entry.id}`), entry.id).not.toBeNull()
+    }
+    const nonMatching = INTEGRATION_TEMPLATE_CATALOG.filter((entry) => entry.seedsWizard !== 'read-source')
+    for (const entry of nonMatching) {
+      expect(maybe(root, `rsc-template-catalog-card-${entry.id}`), entry.id).toBeNull()
+    }
+  })
+
+  it('clicking a card emits select with the exact catalog entry object', async () => {
+    const root = mount('composition', 'rscauth')
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rscauth-template-catalog-toggle').click()
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rscauth-template-catalog-card-two-hop-composition').click()
+    await flushUi()
+
+    expect(selected).toHaveLength(1)
+    expect(selected[0].id).toBe('two-hop-composition')
+    expect(selected[0].seedsWizard).toBe('composition')
+  })
+
+  it('bridge templates render in a bridge-scoped picker (data-complete even with no interactive host wired in TC-1)', async () => {
+    const root = mount('bridge')
+    await flushUi()
+    q<HTMLButtonElement>(root, 'rsc-template-catalog-toggle').click()
+    await flushUi()
+    expect(maybe(root, 'rsc-template-catalog-card-bridge-legacy-sql-readonly')).not.toBeNull()
+  })
+
+  it('renders zh copy through useLocale', async () => {
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      const root = mount('read-source')
+      await flushUi()
+      expect(q(root, 'rsc-template-catalog-toggle').textContent).toContain('从模板开始')
+    } finally {
+      setLocale('en')
+    }
+  })
+})

--- a/apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts
+++ b/apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts
@@ -126,4 +126,38 @@ describe('IntegrationTemplateCatalogPicker', () => {
       setLocale('en')
     }
   })
+
+  // SENTINEL, DOM layer (design-lock §5.2: "sentinel 测试断言占位符形态,DOM 层复证" — the data-level
+  // scan already lives in readSourceTemplateCatalog.spec.ts; this re-verifies the same five patterns
+  // against the ACTUALLY RENDERED grid text, in both locales, mirroring the Bridge-Agent line's
+  // "double proof" discipline (data scan + DOM scan) rather than trusting the data-level scan alone.
+  const DIGIT_RUN_TOO_LONG = /\d{5,}/
+  const HAS_URL_SCHEME = /https?:\/\//i
+  const HAS_HOST_SHAPE = /\b(?:[a-z0-9-]+\.){2,}[a-z]{2,}\b/i
+  const HAS_IPV4_SHAPE = /\b\d{1,3}(?:\.\d{1,3}){3}\b/
+  const HAS_CREDENTIAL_KEYWORD = /(password|secret|token|apikey|api[_-]?key|authorization|credential)/i
+
+  it('SENTINEL (DOM layer): the rendered catalog grid never carries a digit-run/URL/host/IP/credential-shaped string, in either locale', async () => {
+    const { setLocale } = useLocale()
+    for (const locale of ['en', 'zh-CN'] as const) {
+      setLocale(locale)
+      for (const kind of ['read-source', 'composition', 'bridge'] as const) {
+        const root = mount(kind)
+        await flushUi()
+        q<HTMLButtonElement>(root, 'rsc-template-catalog-toggle').click()
+        await flushUi()
+        const gridText = q(root, 'rsc-template-catalog-grid').textContent ?? ''
+        expect(gridText, `${kind}/${locale}`).not.toMatch(DIGIT_RUN_TOO_LONG)
+        expect(gridText, `${kind}/${locale}`).not.toMatch(HAS_URL_SCHEME)
+        expect(gridText, `${kind}/${locale}`).not.toMatch(HAS_HOST_SHAPE)
+        expect(gridText, `${kind}/${locale}`).not.toMatch(HAS_IPV4_SHAPE)
+        expect(gridText, `${kind}/${locale}`).not.toMatch(HAS_CREDENTIAL_KEYWORD)
+        app?.unmount()
+        container?.remove()
+        app = null
+        container = null
+      }
+    }
+    setLocale('en')
+  })
 })

--- a/apps/web/tests/readSourceTemplateCatalog.spec.ts
+++ b/apps/web/tests/readSourceTemplateCatalog.spec.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BRIDGE_AGENT_KIND,
+  BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS,
+} from '../src/services/integration/bridgeAgentConfigCheck'
+import {
+  createReadSourceCompositionDraft,
+  type ReadSourceCompositionDraft,
+} from '../src/services/integration/readSourceCompositions'
+import {
+  createReadSourceConfigDraft,
+  READ_SOURCE_MODE_REQUIRED_FIELDS,
+  READ_SOURCE_MODES,
+  type ReadSourceConfigDraft,
+} from '../src/services/integration/readSourceConfigs'
+import { readSourceModePreset } from '../src/services/integration/readSourceModePresets'
+import {
+  INTEGRATION_TEMPLATE_CATALOG,
+  INTEGRATION_TEMPLATE_SEEDS_WIZARD,
+  integrationTemplateCatalogEntriesFor,
+  integrationTemplateCatalogEntry,
+  isBridgeTemplateEntry,
+  isCompositionTemplateEntry,
+  isReadSourceTemplateEntry,
+  seedCompositionDraft,
+  seedReadSourceDraft,
+  type ReadSourceTemplateCatalogEntry,
+} from '../src/services/integration/readSourceTemplateCatalog'
+
+// TC-1 connector/experience template catalog (design-lock
+// docs/development/integration-connector-template-catalog-design-lock-20260708.md, #3879).
+//
+// This spec is the anti-drift gate mirroring readSourceModePresets.spec.ts's own discipline: catalog
+// entries are a curated PRESENTATION mapping over existing kind/mode/preset primitives — zero new
+// backend/runtime, zero hand-copied required-field vocabulary, zero real business values.
+
+const ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+// values-free scan (mirrors fieldHints.spec.ts's DIGIT_RUN_TOO_LONG/HAS_URL_SCHEME, extended with a
+// credential-shaped-keyword check per this design-lock's stricter "even as an example" bar).
+const DIGIT_RUN_TOO_LONG = /\d{5,}/
+const HAS_URL_SCHEME = /https?:\/\//i
+const HAS_HOST_SHAPE = /\b(?:[a-z0-9-]+\.){2,}[a-z]{2,}\b/i
+const HAS_IPV4_SHAPE = /\b\d{1,3}(?:\.\d{1,3}){3}\b/
+const HAS_CREDENTIAL_KEYWORD = /(password|secret|token|apikey|api[_-]?key|authorization|credential)/i
+
+function allStrings(value: unknown): string[] {
+  if (typeof value === 'string') return [value]
+  if (Array.isArray(value)) return value.flatMap(allStrings)
+  if (value && typeof value === 'object') return Object.values(value).flatMap(allStrings)
+  return []
+}
+
+describe('readSourceTemplateCatalog (TC-1 tripwire)', () => {
+  it('every entry declares a kebab-case id, unique across the catalog', () => {
+    const ids = INTEGRATION_TEMPLATE_CATALOG.map((entry) => entry.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const id of ids) {
+      expect(id, id).toMatch(ID_PATTERN)
+    }
+  })
+
+  it('every entry has non-empty zh+en title and one-liner', () => {
+    for (const entry of INTEGRATION_TEMPLATE_CATALOG) {
+      expect(entry.title.zh.trim().length, `${entry.id} title.zh`).toBeGreaterThan(0)
+      expect(entry.title.en.trim().length, `${entry.id} title.en`).toBeGreaterThan(0)
+      expect(entry.oneLiner.zh.trim().length, `${entry.id} oneLiner.zh`).toBeGreaterThan(0)
+      expect(entry.oneLiner.en.trim().length, `${entry.id} oneLiner.en`).toBeGreaterThan(0)
+    }
+  })
+
+  it('every entry declares seedsWizard in the closed enum', () => {
+    for (const entry of INTEGRATION_TEMPLATE_CATALOG) {
+      expect(INTEGRATION_TEMPLATE_SEEDS_WIZARD, entry.id).toContain(entry.seedsWizard)
+    }
+  })
+
+  it('covers the v1 candidate set named in the design-lock: both K3 WISE kinds, the bridge kind, all 4 generic-HTTP modes, and the two-hop composition', () => {
+    const targetKinds = INTEGRATION_TEMPLATE_CATALOG.map((entry) => entry.targetKind)
+    expect(targetKinds).toContain('erp:k3-wise-webapi')
+    expect(targetKinds).toContain('erp:k3-wise-sqlserver')
+    expect(targetKinds).toContain(BRIDGE_AGENT_KIND)
+
+    const httpModes = INTEGRATION_TEMPLATE_CATALOG
+      .filter((entry) => entry.targetKind === 'http' && isReadSourceTemplateEntry(entry))
+      .map((entry) => (entry as ReadSourceTemplateCatalogEntry).seed.mode)
+    expect(new Set(httpModes)).toEqual(new Set(READ_SOURCE_MODES))
+
+    const compositionEntries = integrationTemplateCatalogEntriesFor('composition')
+    expect(compositionEntries.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('SINGLE-SOURCE (read-source templates): requiredFieldKeys === the REAL READ_SOURCE_MODE_REQUIRED_FIELDS[mode], by identity — not a copy', () => {
+    for (const entry of INTEGRATION_TEMPLATE_CATALOG) {
+      if (!isReadSourceTemplateEntry(entry)) continue
+      const real = READ_SOURCE_MODE_REQUIRED_FIELDS[entry.seed.mode]
+      expect(entry.requiredFieldKeys, entry.id).toBe(real)
+      expect(entry.requiredFieldKeys, entry.id).toEqual(real)
+    }
+  })
+
+  it('SINGLE-SOURCE (read-source templates): title/oneLiner are composed from the REAL readSourceModePreset copy, not a re-described duplicate', () => {
+    for (const entry of INTEGRATION_TEMPLATE_CATALOG) {
+      if (!isReadSourceTemplateEntry(entry)) continue
+      const preset = readSourceModePreset(entry.seed.mode)
+      expect(entry.title.zh, entry.id).toContain(preset.title.zh)
+      expect(entry.title.en, entry.id).toContain(preset.title.en)
+      expect(entry.oneLiner.zh, entry.id).toContain(preset.oneLiner.zh)
+      expect(entry.oneLiner.en, entry.id).toContain(preset.oneLiner.en)
+    }
+  })
+
+  it('SINGLE-SOURCE (bridge template): requiredFieldKeys mirrors BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS and seed.kind === BRIDGE_AGENT_KIND', () => {
+    const bridgeEntries = INTEGRATION_TEMPLATE_CATALOG.filter(isBridgeTemplateEntry)
+    expect(bridgeEntries.length).toBeGreaterThanOrEqual(1)
+    for (const entry of bridgeEntries) {
+      expect(entry.requiredFieldKeys, entry.id).toEqual(BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS)
+      expect(entry.seed.kind, entry.id).toBe(BRIDGE_AGENT_KIND)
+      expect(entry.targetKind, entry.id).toBe(BRIDGE_AGENT_KIND)
+    }
+  })
+
+  it('SINGLE-SOURCE (composition template): requiredFieldKeys derives from the REAL createReadSourceCompositionDraft() field set', () => {
+    const compositionEntries = INTEGRATION_TEMPLATE_CATALOG.filter(isCompositionTemplateEntry)
+    expect(compositionEntries.length).toBeGreaterThanOrEqual(1)
+    const realKeys = Object.keys(createReadSourceCompositionDraft())
+    for (const entry of compositionEntries) {
+      expect(entry.requiredFieldKeys, entry.id).toEqual(realKeys)
+    }
+  })
+
+  it('VALUES-FREE: no digit-run>4, no URL scheme, no host/IP shape, no credential keyword anywhere in title/oneLiner/seed', () => {
+    for (const entry of INTEGRATION_TEMPLATE_CATALOG) {
+      const strings = [
+        ...allStrings(entry.title),
+        ...allStrings(entry.oneLiner),
+        ...allStrings(entry.seed),
+      ]
+      for (const value of strings) {
+        expect(value, `${entry.id}: ${value}`).not.toMatch(DIGIT_RUN_TOO_LONG)
+        expect(value, `${entry.id}: ${value}`).not.toMatch(HAS_URL_SCHEME)
+        expect(value, `${entry.id}: ${value}`).not.toMatch(HAS_HOST_SHAPE)
+        expect(value, `${entry.id}: ${value}`).not.toMatch(HAS_IPV4_SHAPE)
+        expect(value, `${entry.id}: ${value}`).not.toMatch(HAS_CREDENTIAL_KEYWORD)
+      }
+    }
+  })
+
+  it('integrationTemplateCatalogEntry() resolves a known id and returns null for an unknown one', () => {
+    expect(integrationTemplateCatalogEntry('k3-wise-webapi-single-record')?.id).toBe('k3-wise-webapi-single-record')
+    expect(integrationTemplateCatalogEntry('does-not-exist')).toBeNull()
+  })
+
+  it('integrationTemplateCatalogEntriesFor() filters by seedsWizard exactly', () => {
+    for (const kind of INTEGRATION_TEMPLATE_SEEDS_WIZARD) {
+      const entries = integrationTemplateCatalogEntriesFor(kind)
+      for (const entry of entries) {
+        expect(entry.seedsWizard).toBe(kind)
+      }
+    }
+    const total = INTEGRATION_TEMPLATE_SEEDS_WIZARD
+      .reduce((sum, kind) => sum + integrationTemplateCatalogEntriesFor(kind).length, 0)
+    expect(total).toBe(INTEGRATION_TEMPLATE_CATALOG.length)
+  })
+
+  // --- ROUND-TRIP GOLDEN (design-lock §5.1) ---------------------------------------------------------
+  // Selecting a template must reach EXACTLY the draft state a user reaches by manually performing the
+  // equivalent action — deep-equal against a fresh draft with only the manual action applied.
+
+  describe('round-trip golden: read-source templates', () => {
+    for (const entry of INTEGRATION_TEMPLATE_CATALOG.filter(isReadSourceTemplateEntry)) {
+      it(`${entry.id}: seedReadSourceDraft(fresh draft) === manually selecting mode "${entry.seed.mode}" on a fresh draft`, () => {
+        const seeded: ReadSourceConfigDraft = createReadSourceConfigDraft()
+        seedReadSourceDraft(seeded, entry)
+
+        // "Manual selection" = exactly what IntegrationReadSourceWizard.vue's selectMode() does: set
+        // draft.mode, touch nothing else.
+        const manual: ReadSourceConfigDraft = createReadSourceConfigDraft()
+        manual.mode = entry.seed.mode
+
+        expect(seeded).toEqual(manual)
+        expect(seeded.mode).toBe(entry.seed.mode)
+      })
+    }
+  })
+
+  describe('round-trip golden: composition template', () => {
+    for (const entry of INTEGRATION_TEMPLATE_CATALOG.filter(isCompositionTemplateEntry)) {
+      it(`${entry.id}: seedCompositionDraft(fresh draft) === the authoring panel's own pre-existing sourceTarget default`, () => {
+        const seeded: ReadSourceCompositionDraft = createReadSourceCompositionDraft()
+        seedCompositionDraft(seeded, entry)
+
+        // "Manual" baseline = the authoring panel's OWN default assignment
+        // (IntegrationReadSourceCompositionAuthoringPanel.vue: `draft.sourceTarget = 'internal_id'`),
+        // reproduced here rather than imported (that assignment lives inline in a .vue script setup
+        // block, not an exported function) — this is the exact behavior under test.
+        const manual: ReadSourceCompositionDraft = createReadSourceCompositionDraft()
+        manual.sourceTarget = 'internal_id'
+
+        expect(seeded).toEqual(manual)
+        expect(entry.seed.sourceTarget).toBe('internal_id')
+      })
+    }
+  })
+
+  it('ZERO NEW SHAPE: every read-source template seed.mode is a member of the real READ_SOURCE_MODES set', () => {
+    for (const entry of INTEGRATION_TEMPLATE_CATALOG.filter(isReadSourceTemplateEntry)) {
+      expect(READ_SOURCE_MODES, entry.id).toContain(entry.seed.mode)
+    }
+  })
+})

--- a/docs/development/integration-tc1-template-catalog-dev-verification-20260708.md
+++ b/docs/development/integration-tc1-template-catalog-dev-verification-20260708.md
@@ -1,0 +1,172 @@
+# TC-1 连接器/体验模板目录 — seed-the-wizard v1 — 开发验证 — 2026-07-08
+
+> 落地范围:governing design-lock `docs/development/integration-connector-template-catalog-design-lock-20260708.md`
+> (#3879)§4 阶梯的 **TC-1**。排序门(BA-apply 与 W2 均已落地)owner 于 2026-07-08 确认已满足
+> (`BA-APPLY-1` #3894 merged)。本文件是该 design-lock §5 要求的验证 MD。
+
+## 0. 一句话摘要
+
+新增一个 values-free 的模板目录模块(`readSourceTemplateCatalog.ts`,8 条目)+ 一个折叠默认的
+"从模板开始"选卡 UI(`IntegrationTemplateCatalogPicker.vue`),ADD-ONLY 接入既有读取源配置面板
+(`IntegrationReadSourceConfigPanel.vue`)与组合配置面板
+(`IntegrationReadSourceCompositionAuthoringPanel.vue`)。选中一张卡只做一件事:把既有向导 draft
+的**恰好一个字段**设为目标值(`mode` 或 `sourceTarget`),然后把视图切回向导 —— 不新增后端、不新增
+runtime、不新增连接种类/读取模式/组合形状、不改向导内部逻辑。
+
+## 1. 目录条目契约
+
+`apps/web/src/services/integration/readSourceTemplateCatalog.ts` 导出
+`INTEGRATION_TEMPLATE_CATALOG: readonly IntegrationTemplateCatalogEntry[]`(8 条),每条形状:
+
+```ts
+{
+  id: string                    // kebab-case,如 'k3-wise-webapi-single-record'
+  title: { zh, en }
+  oneLiner: { zh, en }
+  targetKind: string            // 描述性元数据 only —— 从不写入 draft
+  seedsWizard: 'read-source' | 'composition' | 'bridge'
+  seed: { mode } | { sourceTarget } | { kind }   // 按 seedsWizard 判别的种子形状
+  requiredFieldKeys: string[]   // 直读真源,见 §3
+}
+```
+
+v1 覆盖集合(design-lock §1 表 × 本次开发指示 "Cover: ..." 全覆盖):
+
+| id | seedsWizard | targetKind | seed |
+| --- | --- | --- | --- |
+| `k3-wise-webapi-single-record` | read-source | `erp:k3-wise-webapi` | `{ mode: 'single_record' }` |
+| `k3-wise-sqlserver-list-page` | read-source | `erp:k3-wise-sqlserver` | `{ mode: 'list_page' }` |
+| `bridge-legacy-sql-readonly` | bridge | `bridge:legacy-sql-readonly` | `{ kind: 'bridge:legacy-sql-readonly' }` |
+| `http-read-single-record` | read-source | `http` | `{ mode: 'single_record' }` |
+| `http-read-list-page` | read-source | `http` | `{ mode: 'list_page' }` |
+| `http-read-detail-with-lines` | read-source | `http` | `{ mode: 'detail_with_lines' }` |
+| `http-read-resolver-lookup` | read-source | `http` | `{ mode: 'resolver_lookup' }` |
+| `two-hop-composition` | composition | `composition:two-hop` | `{ sourceTarget: 'internal_id' }` |
+
+`targetKind` 是描述性字段(标注这个模板适配哪种既有连接 kind),**从不**写入 draft ——
+真实的 `systemId`/`requiredKind` 永远来自用户挑选一个已注册的外部系统(租户数据),模板不能、也
+不应该替用户预先决定"用哪个系统实例"。K3 WISE WebAPI 模板与通用 HTTP 的 `single_record` 模板
+seed 字段值相同(`{ mode: 'single_record' }`)—— 这是设计使然,不是疏漏:read-source 向导的种子
+被刻意收窄为向导 `selectMode()` 真正会设置的唯一字段,连接器差异只体现在 `title`/`oneLiner`/
+`targetKind` 这些展示层信息里,不体现在 seed 里(见 §2 round-trip 论证)。
+
+## 2. Seed round-trip golden(design-lock §5.1)
+
+`seedReadSourceDraft(draft, entry)` 的全部实现是:
+
+```ts
+draft.mode = entry.seed.mode
+```
+
+—— 与 `IntegrationReadSourceWizard.vue` 自己的 `selectMode()` **字面相同**的赋值。
+`seedCompositionDraft` 同理只赋 `draft.sourceTarget`,与
+`IntegrationReadSourceCompositionAuthoringPanel.vue` 面板级默认赋值(`draft.sourceTarget =
+'internal_id'`)一致。
+
+`apps/web/tests/readSourceTemplateCatalog.spec.ts` 的 `describe('round-trip golden: ...')`
+对**每一个** read-source 条目、以及 composition 条目做:
+
+```ts
+const seeded = createReadSourceConfigDraft(); seedReadSourceDraft(seeded, entry)
+const manual = createReadSourceConfigDraft(); manual.mode = entry.seed.mode
+expect(seeded).toEqual(manual)   // 深等价,不是子集比较
+```
+
+组件层再证一次、且是**非平凡**版本(design-lock 要求証明"预填"是真实可观察的变化,不是恰好等于
+默认值的假阳性):`IntegrationCompositionWizard.spec.ts` 的
+`'TC-1: selecting the two-hop composition template seeds sourceTarget back to the EXACT default...'`
+先手动把 `sourceTarget` 改成 `'diverged_value'`,再点模板卡,断言回到 `'internal_id'` 且不再包含
+`'diverged_value'` —— 证明这是一次真实的、可观察的状态注入,不是"本来就相等"的空转。
+`IntegrationReadSourceWizard.spec.ts` 的
+`'TC-1: selecting a read-source template card seeds draft.mode to EXACTLY what manually clicking...'`
+在**先点模板、后选系统**的顺序下断言到达 step 2 时 `list_page` 卡为 selected 且字段集
+(仅 containerPaths,无 keyField/resolverRule)与既有"手动点卡"用例断言的字段集完全一致。
+
+## 3. 单一真源(design-lock §2/§3 硬锁)
+
+- **read-source 条目**:`requiredFieldKeys` 直接是 `readSourceModePreset(mode).requiredFieldKeys`
+  的**同一个引用**(该值本身就是 `READ_SOURCE_MODE_REQUIRED_FIELDS[mode]`)。
+  `readSourceTemplateCatalog.spec.ts` 用 `toBe`(引用相等)断言,不是 `toEqual`(结构相等)——
+  一份"恰好长得一样"的手抄副本也会在这条测试下失败。`title`/`oneLiner` 同样从
+  `readSourceModePreset(mode).title`/`.oneLiner` 组合而来(测试用 `toContain` 断言目录文案
+  确实包含真源 preset 的文案),不是重新描述一遍"单记录读是什么"。
+- **bridge 条目**:新增 `BRIDGE_AGENT_KIND` / `BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS` 两个导出常量到
+  `bridgeAgentConfigCheck.ts`(纯前端模块,零后端),并把原先内联在 `firstBaseUrlLike` 里的三行
+  `if` 改写成对 `BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS` 的循环 —— **行为完全不变**
+  (`bridgeAgentConfigCheck.spec.ts` 75 个既有用例改动前后全绿,含 baseUrl/bridgeUrl/url 三路
+  fallback 的既有断言)。目录的 `seed.kind`/`targetKind`/`requiredFieldKeys` 现在读的是这两个真实
+  常量,不是手抄的字符串/数组。
+- **composition 条目**:`requiredFieldKeys` = `Object.keys(createReadSourceCompositionDraft())`
+  —— 派生自真实 draft 工厂函数自己的字段集,不是手写列表;工厂新增/删减字段会自动反映到这里。
+- **模式集合覆盖**:每个 read-source 条目的构造都要经过 `readSourceModePreset(mode)`——
+  该函数本身在 mode 未注册时 import 期即 throw(见 `readSourceModePresets.ts` 既有 tripwire)。
+  目录因此天然继承"引用了不存在的 mode 必须编译期红"这一硬约束,不需要重新发明一遍。
+  `readSourceTemplateCatalog.spec.ts` 额外断言每个 read-source 条目的 `seed.mode` ∈ 真实
+  `READ_SOURCE_MODES` 集合。目录是 main 能力集合的**子集投影**(design-lock §1):未来 main 新增
+  mode/kind 而目录未收录不会变红,只有目录引用不存在的值才会红。
+
+## 4. 零后端/runtime 变化
+
+```
+$ git status --porcelain（本分支相对 origin/main 的全部改动）
+ M .github/workflows/integration-guard.yml
+ M apps/web/src/components/integration/IntegrationReadSourceCompositionAuthoringPanel.vue
+ M apps/web/src/components/integration/IntegrationReadSourceConfigPanel.vue
+ M apps/web/src/services/integration/bridgeAgentConfigCheck.ts
+ M apps/web/tests/IntegrationCompositionWizard.spec.ts
+ M apps/web/tests/IntegrationReadSourceWizard.spec.ts
+?? apps/web/src/components/integration/IntegrationTemplateCatalogPicker.vue
+?? apps/web/src/services/integration/readSourceTemplateCatalog.ts
+?? apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts
+?? apps/web/tests/readSourceTemplateCatalog.spec.ts
+?? docs/development/integration-tc1-template-catalog-dev-verification-20260708.md
+```
+
+无 `plugins/**`、无路由、无 migration、无 adapter/kind/mode 改动。`bridgeAgentConfigCheck.ts` 的
+改动是纯前端模块内的常量导出 + 行为不变的重构(见 §3、既有 75 用例全绿)。
+
+**既有向导/面板 spec 存量断言零改动**(design-lock §5.4):在接入 picker 之前先跑通
+`IntegrationReadSourceWizard.spec.ts` / `IntegrationCompositionWizard.spec.ts` /
+`IntegrationReadSourceConfigPanel.spec.ts` / `IntegrationReadSourceCompositionAuthoringPanel.spec.ts`
+四个既有 spec(48 用例全绿),接入后**只追加**新的 `it(...)` 块(TC-1 前缀),未修改任何既有断言 ——
+picker 默认折叠(`display:none`),不占用任何既有 data-testid,不改变任何既有渲染顺序。
+
+## 5. values-free
+
+`readSourceTemplateCatalog.spec.ts` 的 `'VALUES-FREE: ...'` 用例对每个条目的
+`title`/`oneLiner`/`seed` 全部字符串字段做 5 类 sentinel 扫描:digit-run>4、`https?://`、
+类域名形状、IPv4 形状、凭据关键词(password/secret/token/apikey/authorization/credential)。
+目录文案全部停留在"形状"层面(如"单记录读"/"两跳组合"),从不出现具体 material/host/tenant/
+库名/URL/凭据 —— 连示例都不出现(design-lock §3:"连'示例凭据'都不允许")。composition 条目的
+`seed.sourceTarget = 'internal_id'` 与 bridge 条目的 `requiredFieldKeys =
+['baseUrl','bridgeUrl','url']` 都是字段**名**(标识符),不是字段**值**。
+
+## 6. 测试汇总
+
+| 文件 | 用例数 | 内容 |
+| --- | --- | --- |
+| `apps/web/tests/readSourceTemplateCatalog.spec.ts`(新) | 19 | 契约/单一真源(3 类)/values-free/round-trip golden(read-source × composition)/覆盖断言 |
+| `apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts`(新) | 5 | picker 独立契约:折叠默认、按 seedsWizard 过滤、emit、zh 文案 |
+| `apps/web/tests/IntegrationReadSourceWizard.spec.ts`(ADD-ONLY +4) | 15(11 既有 + 4 新) | picker 折叠默认不扰动既有默认路径、seed round-trip DOM 证明、expert→wizard 强制切回、zh 文案 |
+| `apps/web/tests/IntegrationCompositionWizard.spec.ts`(ADD-ONLY +4) | 14(10 既有 + 4 新) | 同上,组合向导侧;含"先手动改值再选模板"非平凡 round-trip |
+| `apps/web/tests/bridgeAgentConfigCheck.spec.ts`(未改动,重跑确认) | 75 | 确认 `firstBaseUrlLike` 重构后行为不变 |
+| `apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts` / `IntegrationReadSourceCompositionAuthoringPanel.spec.ts`(未改动,重跑确认) | 既有全部 | 确认 picker 接入未扰动 expert-mode 既有断言 |
+
+全量 targeted 集合(镜像 `integration-guard.yml` 的单一 `run:` 行)本地跑:36 test files / 515
+tests 全绿。`vue-tsc -b` 干净;`vite build` 成功。
+
+## 7. Bridge 模板的 v1 UI 范围说明(明确的作用域取舍)
+
+`bridge-legacy-sql-readonly` 条目在目录**数据**层完整(覆盖设计锁 v1 候选集的 bridge 行,
+requiredFieldKeys/kind 均单一真源),并在 `IntegrationTemplateCatalogPicker.spec.ts` 里以
+`seeds-wizard="bridge"` 的独立 picker 实例验证可渲染。但 **TC-1 没有把交互式选卡接入
+Bridge-Agent 分区**(`IntegrationBridgeAgentSection.vue`)—— 该分区是对已连接实例的只读观测/探测
+(BA-UI-1..3),没有一个"新建"authoring draft 可供预填;为它发明一个可预填的表单会违反
+"复用不重建"硬锁。这是一个明确的、有意的 v1 范围取舍,不是遗漏 —— 记录于此供 TC-2+ 参考
+(TC-2 若要做"选模板→深链到该分区"的引导流,可以复用本条目已有的 `seed.kind`)。
+
+## 8. 后续(design-lock §4,本文不授权任何一级)
+
+TC-2(onboarding 引导流,骑既有 probe / BA-UI-2)、TC-3+(新增模板批次、目录内搜索/分类)均为
+**各自独立、之后、显式的 opt-in**;marketplace / 客户自建模板不在 v1 范围内(design-lock §6)。
+本文件只覆盖 TC-1。

--- a/docs/development/integration-tc1-template-catalog-dev-verification-20260708.md
+++ b/docs/development/integration-tc1-template-catalog-dev-verification-20260708.md
@@ -95,7 +95,11 @@ expect(seeded).toEqual(manual)   // 深等价,不是子集比较
   `if` 改写成对 `BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS` 的循环 —— **行为完全不变**
   (`bridgeAgentConfigCheck.spec.ts` 75 个既有用例改动前后全绿,含 baseUrl/bridgeUrl/url 三路
   fallback 的既有断言)。目录的 `seed.kind`/`targetKind`/`requiredFieldKeys` 现在读的是这两个真实
-  常量,不是手抄的字符串/数组。
+  常量,不是手抄的字符串/数组。**口径说明**:`BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS` 是一个
+  "三选一"优先级列表(真实 adapter 只要求 baseUrl/bridgeUrl/url 三者之一存在,不是三者都必填)——
+  与 read-source 条目的 `requiredFieldKeys`(真正的全部必填集合)语义不同;字段名在两种条目形状间
+  共用只是为了目录条目结构统一,这里验证的核心不变量是"读真实常量、不手抄",而不是"required"
+  这个词本身的精确语义。
 - **composition 条目**:`requiredFieldKeys` = `Object.keys(createReadSourceCompositionDraft())`
   —— 派生自真实 draft 工厂函数自己的字段集,不是手写列表;工厂新增/删减字段会自动反映到这里。
 - **模式集合覆盖**:每个 read-source 条目的构造都要经过 `readSourceModePreset(mode)`——
@@ -146,13 +150,13 @@ picker 默认折叠(`display:none`),不占用任何既有 data-testid,不改变�
 | 文件 | 用例数 | 内容 |
 | --- | --- | --- |
 | `apps/web/tests/readSourceTemplateCatalog.spec.ts`(新) | 19 | 契约/单一真源(3 类)/values-free/round-trip golden(read-source × composition)/覆盖断言 |
-| `apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts`(新) | 5 | picker 独立契约:折叠默认、按 seedsWizard 过滤、emit、zh 文案 |
+| `apps/web/tests/IntegrationTemplateCatalogPicker.spec.ts`(新) | 6 | picker 独立契约:折叠默认、按 seedsWizard 过滤、emit、zh 文案、DOM 层 values-free sentinel 复证(design-lock §5.2) |
 | `apps/web/tests/IntegrationReadSourceWizard.spec.ts`(ADD-ONLY +4) | 15(11 既有 + 4 新) | picker 折叠默认不扰动既有默认路径、seed round-trip DOM 证明、expert→wizard 强制切回、zh 文案 |
 | `apps/web/tests/IntegrationCompositionWizard.spec.ts`(ADD-ONLY +4) | 14(10 既有 + 4 新) | 同上,组合向导侧;含"先手动改值再选模板"非平凡 round-trip |
 | `apps/web/tests/bridgeAgentConfigCheck.spec.ts`(未改动,重跑确认) | 75 | 确认 `firstBaseUrlLike` 重构后行为不变 |
 | `apps/web/tests/IntegrationReadSourceConfigPanel.spec.ts` / `IntegrationReadSourceCompositionAuthoringPanel.spec.ts`(未改动,重跑确认) | 既有全部 | 确认 picker 接入未扰动 expert-mode 既有断言 |
 
-全量 targeted 集合(镜像 `integration-guard.yml` 的单一 `run:` 行)本地跑:36 test files / 515
+全量 targeted 集合(镜像 `integration-guard.yml` 的单一 `run:` 行)本地跑:36 test files / 516
 tests 全绿。`vue-tsc -b` 干净;`vite build` 成功。
 
 ## 7. Bridge 模板的 v1 UI 范围说明(明确的作用域取舍)


### PR DESCRIPTION
## Summary

- Adds `readSourceTemplateCatalog.ts` — a curated, frozen, values-free catalog of 8 connector/experience templates (K3 WISE WebAPI, K3 WISE SQL (advanced), `bridge:legacy-sql-readonly`, all 4 generic-HTTP read-source modes, and the two-hop composition shape), per governing design-lock `docs/development/integration-connector-template-catalog-design-lock-20260708.md` (#3879), TC-1 rung. Sequencing gate (BA-apply + W2 both landed) is met per owner 2026-07-08.
- Adds a collapsed-by-default "从模板开始" picker (`IntegrationTemplateCatalogPicker.vue`) wired ADD-ONLY into `IntegrationReadSourceConfigPanel.vue` and `IntegrationReadSourceCompositionAuthoringPanel.vue`. Selecting a card seeds exactly the one field the wizard's own manual selection sets (`mode` / `sourceTarget`), then switches the view back to the wizard — no new state, no new path.
- `requiredFieldKeys` is read straight off real source-of-truth constants: `readSourceModePresets`/`READ_SOURCE_MODE_REQUIRED_FIELDS` for read-source templates; a new additive `BRIDGE_AGENT_KIND`/`BRIDGE_AGENT_REQUIRED_CONFIG_FIELDS` export in `bridgeAgentConfigCheck.ts` (behavior-preserving refactor of `firstBaseUrlLike`, all 75 existing tests green) for the bridge template; `Object.keys(createReadSourceCompositionDraft())` for the composition template. Never hand-copied.
- Zero backend/runtime/mode/kind change: diff is frontend service + component + tests + the CI workflow only — no `plugins/**`, no route, no adapter, no migration.

## Catalog contract

```ts
{
  id: string                    // kebab-case
  title: { zh, en }
  oneLiner: { zh, en }
  targetKind: string            // descriptive metadata only — never applied to a draft
  seedsWizard: 'read-source' | 'composition' | 'bridge'
  seed: { mode } | { sourceTarget } | { kind }
  requiredFieldKeys: string[]   // read off the real source constant, never hand-copied
}
```

The bridge template is catalog-data-complete but has **no interactive picker wiring** in TC-1 — the Bridge-Agent section (BA-UI-1..3) is read-only observability with no authoring draft to seed, so inventing one would violate reuse-not-rebuild. This is an explicit, documented v1 scoping decision (see verification MD §7), not an oversight.

## Seed round-trip proof

- `seedReadSourceDraft(draft, entry)` is literally `draft.mode = entry.seed.mode` — the same single-field assignment `IntegrationReadSourceWizard.vue`'s own `selectMode()` performs. `seedCompositionDraft` mirrors the composition panel's own pre-existing `sourceTarget` default.
- `readSourceTemplateCatalog.spec.ts`'s round-trip golden deep-equals a seeded fresh draft against a manually-mode-set fresh draft for every read-source entry, and against the panel's own default for the composition entry.
- DOM-level proof: `IntegrationReadSourceWizard.spec.ts` / `IntegrationCompositionWizard.spec.ts` (ADD-ONLY, existing assertions unchanged) drive the real panel end-to-end — including a non-vacuous case where `sourceTarget` is manually diverged first, then reset by the template selection.

## Test summary

- `readSourceTemplateCatalog.spec.ts` (new, 19 tests): contract, single-source tripwires (`toBe` identity for read-source, `toEqual` for composition/bridge), values-free data scan, round-trip golden, coverage.
- `IntegrationTemplateCatalogPicker.spec.ts` (new, 6 tests): collapse/expand, seedsWizard filtering, emit, zh copy, DOM-layer values-free sentinel re-verification (design-lock §5.2 double-proof).
- `IntegrationReadSourceWizard.spec.ts` / `IntegrationCompositionWizard.spec.ts`: ADD-ONLY, +4 tests each (11→15, 10→14) — zero existing assertions changed (verified by running both specs before wiring the picker, then again after, per the design-lock's §5.4 "existing wizard/panel spec assertions unchanged" hard lock).
- `bridgeAgentConfigCheck.spec.ts`: unchanged, re-run to confirm the additive constant-export refactor is behavior-preserving (75/75 green).
- Full `integration-guard.yml` targeted union (single `run:` key, both push/pull_request path-filter blocks updated): 36 files / 516 tests green locally. `vue-tsc -b` clean; `vite build` succeeds.

## Test plan

- [x] `pnpm --filter @metasheet/web exec vitest run <integration-guard union list>` — 36 files / 516 tests green
- [x] `vue-tsc -b` clean
- [x] `vite build` succeeds
- [x] `git status` diff confined to frontend service/component/tests/CI workflow — no `plugins/**`, route, or migration touched
- [ ] CI green on this PR (Node 20 + default, per integration-guard.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)