### PR TITLE
fix(dingtalk): let the OAuth state store fail closed instead of degrading to memory (DT-OPS-05)

### DIFF
--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -105,6 +105,34 @@ export class DingTalkLoginPolicyError extends Error {
 }
 
 const pendingStates = new Map<string, StateRecord>()
+
+/**
+ * DT-OPS-05 — the OAuth `state` store and multi-replica deployments.
+ *
+ * `state` proves the callback belongs to a launch we issued, and is single-use. It lives
+ * in Redis when configured and otherwise in an in-process Map. That Map is fine for a
+ * single replica and quietly wrong for more than one: the callback can land on a
+ * different instance than the launch (valid state rejected → login fails), one-time-use
+ * is only guaranteed per process, and a transient Redis outage silently degrades to it.
+ *
+ * Deployments that run more than one replica set this flag and fail closed instead.
+ * Default off: single-replica behavior is unchanged.
+ */
+export function isDingTalkOAuthSharedStateStoreRequired(): boolean {
+  return ['true', '1', 'yes'].includes(
+    String(process.env.DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE ?? '').trim().toLowerCase(),
+  )
+}
+
+export class DingTalkOAuthStateStoreUnavailableError extends Error {
+  readonly statusCode = 503
+  readonly code = 'DINGTALK_STATE_STORE_UNAVAILABLE'
+
+  constructor() {
+    super('DingTalk OAuth state store (Redis) is unavailable and a shared store is required')
+    this.name = 'DingTalkOAuthStateStoreUnavailableError'
+  }
+}
 let redisStateClient: Redis | null = null
 let redisStateClientPromise: Promise<Redis | null> | null = null
 let redisFallbackLogged = false
@@ -765,6 +793,14 @@ export async function generateState(options: {
 
   const storedInRedis = await writeStateToRedis(state, record)
   if (!storedInRedis) {
+    // DT-OPS-05: the in-process Map is only a single-replica convenience. Behind more
+    // than one replica the callback can land on a different instance than the launch, so
+    // a valid state is rejected and the login fails; one-time-use is also only guaranteed
+    // per process. Deployments that require a shared store fail closed instead of
+    // silently degrading to memory.
+    if (isDingTalkOAuthSharedStateStoreRequired()) {
+      throw new DingTalkOAuthStateStoreUnavailableError()
+    }
     writeStateToMemory(state, record)
   }
 
@@ -775,6 +811,17 @@ export async function validateState(state: string): Promise<StateValidationResul
   if (!state) return { valid: false, error: 'Missing required parameter: state' }
 
   const redisResult = await validateStateFromRedis(state)
+
+  // DT-OPS-05: when a shared store is required, NEVER consult the per-process Map — a
+  // transient Redis outage must fail the login rather than quietly fall through to a
+  // store the other replicas cannot see. `null` here means the store was unavailable
+  // (a real miss returns an explicit invalid result).
+  if (isDingTalkOAuthSharedStateStoreRequired()) {
+    if (redisResult) return redisResult
+    logger.error('DingTalk OAuth state store is unavailable and a shared store is required; refusing the login')
+    return { valid: false, error: 'DingTalk login is temporarily unavailable. Please try again.' }
+  }
+
   if (redisResult?.valid) return redisResult
   if (redisResult?.error === 'State parameter has expired') return redisResult
 

--- a/packages/core-backend/tests/unit/dingtalk-oauth-shared-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-shared-state-store.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DingTalkOAuthStateStoreUnavailableError,
+  __resetDingTalkOAuthStateStoreForTests,
+  generateState,
+  isDingTalkOAuthSharedStateStoreRequired,
+  validateState,
+} from '../../src/auth/dingtalk-oauth'
+
+/**
+ * DT-OPS-05 — no Redis is configured in this suite, so the state store is the in-process
+ * Map. That is exactly the situation the flag exists to reject: behind more than one
+ * replica, a callback can land on a different instance than the launch, so a valid state
+ * is rejected and a legitimate login fails; one-time-use is also only guaranteed per
+ * process. A transient Redis outage degrades to the same place, silently.
+ */
+describe('DT-OPS-05 DingTalk OAuth shared state store requirement', () => {
+  beforeEach(async () => {
+    await __resetDingTalkOAuthStateStoreForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('is off unless explicitly enabled', () => {
+    expect(isDingTalkOAuthSharedStateStoreRequired()).toBe(false)
+    vi.stubEnv('DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE', 'maybe')
+    expect(isDingTalkOAuthSharedStateStoreRequired()).toBe(false)
+    vi.stubEnv('DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE', 'true')
+    expect(isDingTalkOAuthSharedStateStoreRequired()).toBe(true)
+  })
+
+  describe('default (single replica) — behavior unchanged', () => {
+    it('falls back to the in-process store and round-trips a state', async () => {
+      const state = await generateState({ redirectPath: '/inbox' })
+      expect(state).toBeTruthy()
+      await expect(validateState(state)).resolves.toMatchObject({ valid: true, redirectPath: '/inbox' })
+    })
+
+    it('still enforces one-time use within the process', async () => {
+      const state = await generateState({})
+      await expect(validateState(state)).resolves.toMatchObject({ valid: true })
+      await expect(validateState(state)).resolves.toMatchObject({ valid: false })
+    })
+  })
+
+  describe('with a shared store required and Redis unavailable', () => {
+    beforeEach(() => {
+      vi.stubEnv('DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE', 'true')
+    })
+
+    it('refuses to issue a state rather than writing it somewhere the other replicas cannot see', async () => {
+      await expect(generateState({ redirectPath: '/inbox' }))
+        .rejects.toBeInstanceOf(DingTalkOAuthStateStoreUnavailableError)
+    })
+
+    it('refuses to validate rather than silently consulting the per-process store', async () => {
+      // Seed the in-process store the way the legacy path would have.
+      vi.stubEnv('DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE', 'false')
+      const state = await generateState({})
+      vi.stubEnv('DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE', 'true')
+
+      // The load-bearing assertion: the memory store is NOT consulted, so the login is
+      // refused instead of succeeding on one replica and failing on the others.
+      const result = await validateState(state)
+      expect(result.valid).toBe(false)
+      expect(result.error).toMatch(/temporarily unavailable/i)
+    })
+
+    it('reports a 503-shaped error for the launch path', async () => {
+      const error = await generateState({}).catch((err) => err)
+      expect(error).toBeInstanceOf(DingTalkOAuthStateStoreUnavailableError)
+      expect((error as DingTalkOAuthStateStoreUnavailableError).statusCode).toBe(503)
+      expect((error as DingTalkOAuthStateStoreUnavailableError).code).toBe('DINGTALK_STATE_STORE_UNAVAILABLE')
+    })
+
+    it('still rejects an empty state before touching any store', async () => {
+      await expect(validateState('')).resolves.toMatchObject({ valid: false })
+    })
+  })
+})


### PR DESCRIPTION
The OAuth `state` proves a callback belongs to a launch we issued, and is single-use. It lives in Redis when configured and otherwise in an **in-process Map**. That Map is fine for a single replica and quietly wrong for more than one:
- the callback can land on a different instance than the launch → a *valid* state is rejected and a legitimate login fails;
- one-time-use is only guaranteed **per process**;
- a transient Redis outage silently degrades to it — the one case where the degradation also breaks the login it was meant to rescue.

`DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE` (**default off**, single-replica behavior unchanged) makes multi-replica deployments fail closed:
- `generateState` throws `DingTalkOAuthStateStoreUnavailableError` (503) rather than writing a state the other replicas cannot see;
- `validateState` **never** consults the per-process Map — a store outage refuses the login instead of succeeding on one replica and failing on the rest.

**Verification**: 29 unit tests pass (7 new + the two existing OAuth suites); `tsc --noEmit` clean. **Mutation-proven**: removing the fail-closed branch lets `validateState` fall back to memory and turns the "refuses to validate rather than silently consulting the per-process store" test red.

Roadmap: DT-OPS-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)