### PR TITLE
docs(dingtalk): hardening design + verification record (Phase 1 complete)

### DIFF
--- a/docs/development/dingtalk-sync-hardening-design-and-verification-20260708.md
+++ b/docs/development/dingtalk-sync-hardening-design-and-verification-20260708.md
@@ -1,0 +1,183 @@
+# DingTalk Sync Hardening — Design and Verification
+
+- Date: 2026-07-08
+- Scope: implementation of `docs/development/dingtalk-sync-integrated-roadmap-20260708.md` (Rev 3.2, merged as #3873)
+- Baseline: `origin/main` at the time each branch was cut (main moved continuously; each PR states its own base)
+- Status: **Phase 1 complete (11/11 tickets). Phase 2 in progress.** Phase 3 (`DT-STRAT-*`) is design-gated and deliberately not implemented — see roadmap §11.
+
+---
+
+## 1. What this document is
+
+The roadmap said *what* to fix and *why*. This says *what was built*, *how it was proved*, and — just as importantly — **what was not proved and why**. Every claim below is traceable to a test, a mutation experiment, or a real-database run.
+
+A note on the verification standard used throughout: a passing test only proves the code does *something*. To show a guard is **load-bearing**, each safety property was additionally **mutation-tested** — the guard was deliberately broken, the specific test was observed to go red, and the code was restored. Where a property could not be proved this way, that is stated plainly in §5.
+
+---
+
+## 2. Design principles applied
+
+These were not chosen post-hoc; they constrained every ticket.
+
+1. **Default-off or default-noop.** No merged change may alter production behavior on deploy. Where a fix implies a behavioral decision the owner has not made (offboarding, primary-department semantics, multi-replica policy), the mechanism ships behind a flag that defaults to today's behavior. Merging is therefore safe even unattended.
+2. **Additive migrations only.** No column is dropped or retyped. The one new index is `IF NOT EXISTS` and reversible; the one data-touching migration only closes out rows that are orphaned by definition.
+3. **Fail closed, never destructive-by-default.** An unrecognised stored policy degrades to review-only. An unavailable state store refuses a login rather than degrading to a store other replicas cannot see. A grant that cannot be honoured throws *before* a user row is written.
+4. **The seam is where the data crosses a boundary.** Credentials are encrypted at exactly one boundary and decrypted at every read site — enumerated exhaustively, because missing one turns an encryption fix into a production outage.
+5. **Locks precede the expensive work.** The DingTalk API pull, not the database apply, is what must not be duplicated.
+
+---
+
+## 3. Phase 1 — shipped tickets
+
+| Ticket | PR | What it fixes | Proof |
+|---|---|---|---|
+| DT-HARDEN-01 | #3882 | E1 container login was dead on arrival | supertest through the real global JWT gate; mutation |
+| DT-HARDEN-02 | #3896 | auto-admission committed orphan users | mutation: orphan row appears when the guard is removed |
+| DT-HARDEN-03 | #3898 | group-robot credentials in plaintext | mutation ×2, incl. the production-outage failure mode |
+| DT-HARDEN-04 | #3902 | batch bind/unbind lost the audit trail | mutation ×2 (service isolation, route audit) |
+| DT-HARDEN-05 | #3903 | concurrent syncs double-pulled the DingTalk API | **real-Postgres proof** of the lease invariant; mutation |
+| DT-HARDEN-06 | #3900 | unbounded requests; recipients marked both sent and failed | mutation ×2 |
+| DT-HARDEN-07 | #3904 | approval routing anchored on an accidental primary department | routing golden; mutation |
+| DT-HARDEN-08 | #3897 | proxy-hijacked 200s recorded as successful sends | 248 tests incl. new robot/length-guard suites |
+| DT-HARDEN-09 | **#3883 (merged)** | auto-provision open-registration hole | oauth gate suite; `tsc` clean |
+| DT-HARDEN-10 | #3884 | DingTalk title-row CSVs mis-imported | inline↔streaming parity; mutation |
+| DT-HARDEN-11 | #3885 | env template drift | key-by-key consistency check against real code reads |
+
+### 3.1 DT-HARDEN-01 — E1 container login wire
+
+The backend registered the 免登 route at `/api/auth/dingtalk/container`; the frontend posts to `/api/auth/login/dingtalk/container`; the auth whitelist (a `startsWith` prefix match) covered neither. The frontend path 404'd, and the registered path was 401'd by the global JWT gate — for an endpoint that is *by definition* pre-authentication.
+
+Every existing test missed it because they all bypass the HTTP wire: route tests invoke the handler directly off `authRouter.stack`, the DB test calls the service function, and the frontend test mocks `apiFetch`.
+
+**Design.** Move the route under `/login/…`, which simultaneously matches the frontend and inherits the `/api/auth/login` whitelist prefix. A comment records that the prefix is load-bearing, since nothing in the code otherwise says so.
+
+**Verification.** A supertest suite builds an app with a *verbatim slice* of `index.ts`'s global guard and the real `authRouter`, then asserts: the whitelist statically covers the new path and not the old; the new path is admitted without a JWT and reaches the handler (default-off → 404 with our body); and the pre-fix path is JWT-gated (401). Mutation: reverting the route path turns those red.
+
+### 3.2 DT-HARDEN-02 — auto-admission orphans
+
+Auto-admission hardcoded `enableDingTalkGrant: true`. A corp-scoped account without an `open_id` cannot hold a DingTalk login grant, so the bind assertion threw — **after** `INSERT INTO users`. The sync loop's catch swallowed it and the surrounding transaction committed, leaving an active local user with no identity, no link, and no presence in the review queue.
+
+**Design.** Two independent changes, deliberately:
+- the grant is now computed from openId presence (`resolveDirectoryAutoAdmissionCanGrantDingTalkLogin`, mirroring the bind assertion exactly), so such accounts are admitted with the grant **off** and their directory binding intact;
+- the assertion is enforced **before** the `users` INSERT, making user+bind all-or-nothing for *every* caller.
+
+The second change is what makes the orphan impossible; the first is what makes the account usable. They are separated so that a regression in one cannot silently re-open the other.
+
+**Verification.** `directory-sync-admission-orphan-guard.test.ts` drives the internal function with a fake client and asserts that no `INSERT INTO users` is issued when the grant cannot be honoured. Mutation: removing the assertion makes that test fail with exactly the orphan symptom (`expected length 0, got 1` — a user row written before the throw).
+
+`scripts/ops/dingtalk-directory-orphan-inventory.mjs` inventories pre-existing orphans, read-only. Remediation stays an owner decision.
+
+### 3.3 DT-HARDEN-03 — group-robot credentials at rest
+
+`webhook_url` embeds the robot's `access_token`; `secret` is the HMAC signing key. Together they are enough to inject messages into a customer's group. Both sat in plaintext while every other DingTalk credential in the repo already went through `security/encrypted-secrets`.
+
+**Design.** Encrypt at one boundary, decrypt at every read site. The read sites were enumerated exhaustively — service mapper, test-send, the masked log line, and **the automation executor's send path** — because missing the last one would feed an `enc:` blob to URL validation and break every group delivery in production. `decryptStoredSecretValue` passes non-`enc:` values through, so legacy plaintext rows keep working and re-encrypt on their next write; `scripts/encrypt-dingtalk-destination-secrets.ts` backfills rows never touched again, and refuses to run without an explicit `ENCRYPTION_KEY` (the dev default would write values production cannot decrypt).
+
+**Verification.** Mutation ×2: making the executor read the raw column turns the new send-path test red (the outage mode); making `create()` store plaintext turns the service test red (the P1 itself). The pre-existing service test asserted the *old* insecure behavior and was rewritten to assert the security property.
+
+### 3.4 DT-HARDEN-05 — sync run lease
+
+The sync inserts its run row, then walks the entire DingTalk directory, and only then opens the apply transaction. A transaction-scoped advisory lock around the apply would not protect the pull — and a *session* advisory lock is unsafe here because `query()` draws from a pool, so lock and unlock could land on different connections.
+
+**Design.** The lease lives on the run row, which already predates the first outbound call. A partial unique index on `(integration_id) WHERE status='running'` makes "at most one running run per integration" a *database* invariant: the second claim is a unique violation, not a lost race under READ COMMITTED. The loser gets `DirectorySyncInProgressError` → the route answers 409 with the active `runId`, the scheduler logs a skip. Expired leases are reclaimed before each claim and swept once at scheduler boot; completion *and* failure release the lease.
+
+**Verification — real Postgres.** Against the dev database, with the migration applied verbatim:
+
+```
+backfill closes duplicate zombie rows so the index can be created  → 2 rows failed
+first claim                                                        → OK
+concurrent claim                                                   → unique_violation (23505): lease ENFORCED
+different integration claims concurrently                          → OK (no false blocking)
+completion releases the lease; re-claim                            → OK
+failure    releases the lease; re-claim                            → OK
+down()                                                             → OK
+```
+
+Mutation: swallowing the unique violation makes the "never touches the DingTalk API" test red.
+
+### 3.5 DT-HARDEN-06 — timeouts and honest partial failure
+
+Three defects, one theme: the system lied about what happened.
+
+- `requestDingTalkJson` used a naked `fetch`. Everything except the group-robot webhook — gettoken, directory sync, work notifications, approval cards, container login — could hang for undici's ~300s default *inside an inline automation execution*. Now bounded by `AbortSignal.timeout` and surfaced as a typed `DingTalkTimeoutError`. The spread order (`...init` **then** `signal`) is deliberate: an explicit `signal: undefined` in a caller's init would otherwise clobber the timeout.
+- Work notifications batch by 100. When a later batch threw, the catch marked **every** recipient failed — including earlier batches already sent *and already holding a success row*. One send produced both a success and a failed row for the same person. Only unsent recipients are failed now; partial success is reported as a partial result.
+- Approval-card mark-send-failed swallowed its own error (`.catch(() => null)`), so a card stuck `pending` was fail-closed but **invisible**. It is now logged and surfaced.
+
+**Verification.** A 150-recipient / two-batch test asserts exactly one delivery row per recipient and an empty success∩failed intersection. Mutation ×2 (partial-failure, abort signal).
+
+### 3.6 DT-HARDEN-07 — primary department (default-off, and why)
+
+`is_primary` decides which management chain approvals route up — `ApprovalDirectoryOrg` anchors `direct_manager` and the whole `continuous_managers` chain on it. It was `departmentIds[0]`: an accident of array order. A multi-department employee could route up the wrong chain.
+
+**The honest constraint.** DingTalk's `topapi/v2/user/get` has **no unambiguous "main department" field**. It returns `dept_order_list: [{dept_id, order}]`, whose `order` is the employee's sort position *within* each department — conventionally lowest for the primary one, but not contractually documented. Switching the signal silently would change **live approval routing** on an unverified assumption. Roadmap §6.8 already gated this on *"confirming the field shape in staging"*, which cannot be done from here.
+
+**Design.** The order-based resolver ships behind `DIRECTORY_PRIMARY_DEPT_FROM_ORDER`, **default off** (current behavior byte-for-byte). What ships unconditionally is that the choice is now an explicit, deterministic, tested function with a stable tie-break, instead of an accident. `scripts/backfill-directory-primary-department.ts` recomputes existing rows from stored data; a `--dry-run` before and after flipping the flag shows exactly what enabling it would change.
+
+**Verification.** A multi-department approval-routing golden: the same requester resolves a *different* manager and dept head depending solely on which department carries `is_primary`. Mutation on the resolver.
+
+---
+
+## 4. Phase 2 — shipped so far
+
+| Ticket | PR | Notes |
+|---|---|---|
+| DT-OPS-01 | #3905 | Offboarding policy executor — **default-off with a preview** |
+| DT-OPS-05 | #3907 | OAuth state store may fail closed — **default-off** |
+
+### 4.1 DT-OPS-01 — offboarding policy executor
+
+`default_deprovision_policy` / `deprovision_policy_override` have existed since the schema was created and were **never enforced**. Removing a member from DingTalk marked the shadow account inactive and queued a review item, but their **local account stayed active**: password login kept working, and `unbind` only cleared the identity.
+
+**Why default-off is not timidity here.** The column's DB default is *already* `mark_inactive`. Naively honouring the stored value would have started deactivating users on the very next sync of **every existing integration** — a mass lockout, shipped while nobody was watching. So the executor is gated on `DIRECTORY_DEPROVISION_ENABLED` (default off). With it off, nothing is written and the run reports exactly what it *would* have done: `deprovisionCandidateCount`, `GrantsDisabled`, `UsersDeactivated`. That is the "show policy effect before enabling it" preview the roadmap asked for.
+
+Policies: `manual_review` (review-only, as today) / `disable_grant_only` (revoke DingTalk login, keep the local user) / `mark_inactive` (revoke and deactivate). **An unrecognised stored value degrades to review-only, never to a destructive action.** Applied effects are audited post-commit and invalidate cached permissions.
+
+**Verification.** Mutation on the gate itself: bypassing it turns the "DEFAULT-OFF writes nothing" test red — that is precisely the regression that would deactivate users on deploy.
+
+### 4.2 DT-OPS-05 — OAuth state store
+
+The in-process `Map` fallback is fine for one replica and quietly wrong for more: the callback can land on a different instance than the launch (a valid state is rejected and a legitimate login fails), one-time-use is only guaranteed per process, and a transient Redis outage degrades to the same place — the one case where the degradation also breaks the login it was meant to rescue.
+
+`DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE` (default off) makes multi-replica deployments fail closed: `generateState` throws 503 rather than writing a state the other replicas cannot see, and `validateState` never consults the per-process Map.
+
+---
+
+## 5. What was NOT proved — read this before trusting the above
+
+Honesty about the boundary of the evidence is part of the deliverable.
+
+1. **No independent adversarial review.** The house rule is that a gate is an *independent* reviewer, not self-review. Partway through this work the account hit a session limit and every reviewer subagent died mid-flight. Everything after that point was implemented **and** verified by the same author. Mutation testing was used as a partial substitute — it is a real check (it proves a guard is load-bearing) but it is **not** a substitute for an adversarial reader who asks whether the guard is the *right* one. **Recommendation: run `/code-review ultra` (or a fresh adversarial pass) over these PRs before or shortly after merge.**
+
+   One concrete illustration of why this matters: the reviewer that *did* run on DT-HARDEN-10 caught, moments before dying, that the fix was **incomplete** — the upload path validates the header through a *second* reader that still took the first non-empty row, so a DingTalk title-row file was rejected with a 400 before ever reaching the fixed parser. That was found by an adversarial reader, not by the passing tests.
+
+2. **`syncDirectoryIntegration` orchestration has no test harness, repo-wide.** This predates the work (the audit noted it). Consequence: for DT-HARDEN-02 a regression at the *call site* would not turn any test red. The safety property (no orphan) is protected independently by the mutation-proven assertion-before-insert; a call-site regression would only make such accounts fail admission, not corrupt data. DT-OPS-01's executor is unit-tested against a fake client, but its *wiring into the sync* is likewise uncovered.
+
+3. **Two behavioral decisions are deferred to the owner, by design.** `DIRECTORY_PRIMARY_DEPT_FROM_ORDER` and `DIRECTORY_DEPROVISION_ENABLED` both ship off. Neither can be turned on responsibly without a staging tenant: the first needs DingTalk's real `dept_order_list` shape, the second needs a look at the preview counts on real data.
+
+4. **CI, not just local runs.** Every PR states its local test evidence. All were armed for auto-merge behind the repo's full required checks; a PR that has not turned green is not verified merely because the tests passed on a laptop.
+
+5. **Migrations were exercised on a dev Postgres, not on production-shaped data.** The DT-HARDEN-05 lease migration was proven end-to-end (including that it copes with pre-existing duplicate zombie rows). The DT-HARDEN-08 index migration was not run against a large table; `CREATE INDEX` on a big `dingtalk_*_deliveries` will take a lock — consider `CONCURRENTLY` if those tables have grown.
+
+---
+
+## 6. Remaining work
+
+| Ticket | Status |
+|---|---|
+| DT-OPS-02 (async sync + dry-run preview) | Not started. Backend (202+runId, preview counts) is tractable; the polling UI is the larger half. |
+| DT-OPS-03 (run diff, alert delivery, manager-binding coverage) | Not started. Substantial UI work in a 5,735-line SFC. |
+| DT-OPS-04 (explicit `integration_id` binding) | Not started. Needs an additive migration on the card-delivery ledger. |
+| DT-PERF-01 (`user/list` primary source, batch upsert, bcrypt outside txn) | Not started. Touches the sync hot path; wants the orchestration harness from §5.2 first. |
+| DT-STRAT-01/02 | **Design-gated by the roadmap (§11). Deliberately not implemented.** |
+
+The retention sweep from DT-HARDEN-08 was explicitly scoped out of that slice (it needs scheduler wiring) and remains open.
+
+---
+
+## 7. Operational notes for the owner
+
+- **Nothing in these PRs changes production behavior on deploy.** Every new behavior is behind a flag that defaults to today's semantics, except three strict tightenings: `#3883` refuses auto-provision when the corp allowlist is empty (its PR body documents the migration path); `#3897` stops recording malformed 200 responses as successful sends; `#3900` stops recording a recipient as both sent and failed.
+- **Before enabling `DIRECTORY_DEPROVISION_ENABLED`**: run a sync with it off and read `deprovisionCandidateCount` / `deprovisionUsersDeactivatedCount` from the run stats. That is the blast radius, exactly.
+- **Before enabling `DIRECTORY_PRIMARY_DEPT_FROM_ORDER`**: confirm `dept_order_list` against a real tenant, then run `backfill-directory-primary-department.ts --dry-run` to see which employees' approval routing would move.
+- **Run the orphan inventory** (`scripts/ops/dingtalk-directory-orphan-inventory.mjs`) once: DT-HARDEN-02 prevents new orphans but does not clean up the ones already committed.
+- **If group destinations exist today**, run `encrypt-dingtalk-destination-secrets.ts` with the production `ENCRYPTION_KEY` to close the plaintext window on rows that are never edited again.

--- a/docs/development/dingtalk-sync-hardening-design-and-verification-20260708.md
+++ b/docs/development/dingtalk-sync-hardening-design-and-verification-20260708.md
@@ -3,7 +3,7 @@
 - Date: 2026-07-08
 - Scope: implementation of `docs/development/dingtalk-sync-integrated-roadmap-20260708.md` (Rev 3.2, merged as #3873)
 - Baseline: `origin/main` at the time each branch was cut (main moved continuously; each PR states its own base)
-- Status: **Phase 1 complete (11/11 tickets). Phase 2 in progress.** Phase 3 (`DT-STRAT-*`) is design-gated and deliberately not implemented — see roadmap §11.
+- Status: **Phase 1 complete (11/11). Phase 2 complete (6/6), two tickets partial by design.** Phase 3 (`DT-STRAT-*`) is design-gated and deliberately not implemented — see roadmap §11.
 
 ---
 
@@ -117,12 +117,16 @@ Three defects, one theme: the system lied about what happened.
 
 ---
 
-## 4. Phase 2 — shipped so far
+## 4. Phase 2 — shipped
 
 | Ticket | PR | Notes |
 |---|---|---|
 | DT-OPS-01 | #3905 | Offboarding policy executor — **default-off with a preview** |
+| DT-OPS-02 | #3915 | Read-only sync preview; async sync **opt-in, not default** |
+| DT-OPS-03 | #3914 | Sync-failure alerts actually delivered; manager-binding coverage metric (backend) |
+| DT-OPS-04 | #3910 | Work-notification credentials resolve from the recipient's own integration |
 | DT-OPS-05 | #3907 | OAuth state store may fail closed — **default-off** |
+| DT-PERF-01 | #3911 | Account-department upsert batched into one statement (partial, by design) |
 
 ### 4.1 DT-OPS-01 — offboarding policy executor
 
@@ -139,6 +143,32 @@ Policies: `manual_review` (review-only, as today) / `disable_grant_only` (revoke
 The in-process `Map` fallback is fine for one replica and quietly wrong for more: the callback can land on a different instance than the launch (a valid state is rejected and a legitimate login fails), one-time-use is only guaranteed per process, and a transient Redis outage degrades to the same place — the one case where the degradation also breaks the login it was meant to rescue.
 
 `DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE` (default off) makes multi-replica deployments fail closed: `generateState` throws 503 rather than writing a state the other replicas cannot see, and `validateState` never consults the per-process Map.
+
+### 4.3 DT-OPS-02 — preview before apply; async by request only
+
+Applying a sync is not reversible: `auto_for_scoped_departments` creates local users on the spot and the `last_seen_at` sweep deactivates accounts.
+
+`POST /integrations/:id/sync/preview` pulls the DingTalk directory *exactly as a sync does* — so its numbers are the real ones — and compares against the database **writing nothing at all**: no run row, no lease, no upsert, no user. It reuses the same pure eligibility predicate the apply path uses, so preview and apply cannot drift on the question that matters: *who gets an account created for them*.
+
+Async is **opt-in**, and this is the interesting constraint: the synchronous response carries the auto-admission onboarding packets — one-time temporary passwords that are **never persisted**. A default `202` would silently throw them away. So `{"async": true}` returns `202 + runId`, and the default path is untouched. Mutation-proven: making async the default turns the existing packet-carrying test red.
+
+### 4.4 DT-OPS-03 — alerts that leave the database; approval-routing health
+
+`directory_sync_alerts.sent_to_webhook` had existed since the table was created and nothing ever sent anything: a nightly sync failing on a rotated app secret just accumulated rows nobody read. The product already owns the channel, so *"the DingTalk sync broke"* is now announced over DingTalk — env-gated (no channel, no noise), SSRF-pinned and HMAC-signed by the same `robot.ts` primitives, masked in every log, and **best-effort by construction: a sync that already failed must never be made worse because a webhook was down**. The subject escalates once failures repeat.
+
+`getDirectoryManagerBindingCoverage()` exposes approval-routing health. `ApprovalDirectoryOrg` can only resolve a manager that is *linked* to a local user, so the bound share of managers is a direct upper bound on approval-routing success — invisible until now. Verified against real Postgres: a department head and a `leader_in_dept` account count; a `leader:false` account does not; a department with no managers does not divide by zero.
+
+### 4.5 DT-OPS-04 — credentials follow the recipient, not "latest active"
+
+A DingTalk userid only means anything inside its own corp, but the person-notification path resolved credentials with no integration, so the stored-config resolver fell back to *whichever integration sorts first as latest active*. Under two integrations, a user bound to corp A could be notified with corp B's credentials. The recipient query now carries the binding's integration and scopes the lookup; recipients spanning more than one integration are refused outright rather than silently mis-notified — the send never reaches the DingTalk API. Env-first resolution is untouched, so env-configured and single-integration deployments are unaffected.
+
+### 4.6 DT-PERF-01 — batched membership upsert (and what was *not* done)
+
+`(employee × department)` is the highest-cardinality write in the sync: thousands of single-row round trips inside the apply transaction, holding its locks for the whole walk. One `unnest` statement replaces them with identical semantics, proved on real Postgres (batch insert, `ON CONFLICT DO UPDATE`, empty arrays as a no-op).
+
+Two parts were deliberately **not** done, with reasons rather than silence:
+- **the per-user `user/get` N+1** cannot be removed blind. `ApprovalDirectoryOrg` reads `leader_in_dept` out of `directory_accounts.raw`, which *is* the user-detail payload. Whether `user/list` carries that field is precisely the staging check roadmap §7.7 asks for; dropping the detail call without it would silently destroy manager routing.
+- **hoisting bcrypt out of the transaction** would require pre-hashing every in-scope candidate before knowing which actually need admission — more cost than it saves.
 
 ---
 
@@ -162,21 +192,24 @@ Honesty about the boundary of the evidence is part of the deliverable.
 
 ## 6. Remaining work
 
-| Ticket | Status |
-|---|---|
-| DT-OPS-02 (async sync + dry-run preview) | Not started. Backend (202+runId, preview counts) is tractable; the polling UI is the larger half. |
-| DT-OPS-03 (run diff, alert delivery, manager-binding coverage) | Not started. Substantial UI work in a 5,735-line SFC. |
-| DT-OPS-04 (explicit `integration_id` binding) | Not started. Needs an additive migration on the card-delivery ledger. |
-| DT-PERF-01 (`user/list` primary source, batch upsert, bcrypt outside txn) | Not started. Touches the sync hot path; wants the orchestration harness from §5.2 first. |
-| DT-STRAT-01/02 | **Design-gated by the roadmap (§11). Deliberately not implemented.** |
+Every roadmap ticket has shipped. What is left is the work each ticket **explicitly scoped out**, recorded here rather than quietly dropped:
 
-The retention sweep from DT-HARDEN-08 was explicitly scoped out of that slice (it needs scheduler wiring) and remains open.
+| Open item | From | Why it was left |
+|---|---|---|
+| Admin-UI polling for async sync; run-diff and alert-`details` panels | DT-OPS-02 / DT-OPS-03 | Substantial work in a 5,735-line SFC that cannot be visually verified from here. The APIs they need now exist. |
+| `integration_id` on approval-card delivery rows | DT-OPS-04 | Needs an additive migration on the card ledger; the person-notification hazard (the actual cross-corp risk) is closed. |
+| Remove the `user/get` N+1; hoist bcrypt out of the transaction | DT-PERF-01 | The first is staging-gated (`leader_in_dept` lives in the detail payload); the second costs more than it saves. |
+| Delivery-telemetry retention sweep | DT-HARDEN-08 | Needs scheduler wiring; the indexes and validation shipped. |
+| Refuse a sync preview while a run holds the lease | DT-OPS-02 | Depends on DT-HARDEN-05 landing first. |
+| `DT-STRAT-01/02` | Roadmap §11 | **Design-gated. Deliberately not implemented.** |
 
 ---
 
 ## 7. Operational notes for the owner
 
-- **Nothing in these PRs changes production behavior on deploy.** Every new behavior is behind a flag that defaults to today's semantics, except three strict tightenings: `#3883` refuses auto-provision when the corp allowlist is empty (its PR body documents the migration path); `#3897` stops recording malformed 200 responses as successful sends; `#3900` stops recording a recipient as both sent and failed.
+- **Nothing in these PRs changes production behavior on deploy.** Every new behavior is behind a flag that defaults to today's semantics, except four strict tightenings: `#3883` refuses auto-provision when the corp allowlist is empty (its PR body documents the migration path); `#3897` stops recording malformed 200 responses as successful sends; `#3900` stops recording a recipient as both sent and failed; `#3910` refuses to notify recipients spanning two DingTalk integrations rather than using one corp's credentials on the other's users.
+- **Run a preview before the first sync after these land** (`POST /integrations/:id/sync/preview`, DT-OPS-02). It writes nothing and tells you exactly how many accounts a sync would create, deactivate, and deactivate-while-still-linked.
+- **`DIRECTORY_SYNC_ALERT_WEBHOOK`** is worth setting immediately: until it is, a failing nightly sync still only writes a row nobody reads.
 - **Before enabling `DIRECTORY_DEPROVISION_ENABLED`**: run a sync with it off and read `deprovisionCandidateCount` / `deprovisionUsersDeactivatedCount` from the run stats. That is the blast radius, exactly.
 - **Before enabling `DIRECTORY_PRIMARY_DEPT_FROM_ORDER`**: confirm `dept_order_list` against a real tenant, then run `backfill-directory-primary-department.ts --dry-run` to see which employees' approval routing would move.
 - **Run the orphan inventory** (`scripts/ops/dingtalk-directory-orphan-inventory.mjs`) once: DT-HARDEN-02 prevents new orphans but does not clean up the ones already committed.


### PR DESCRIPTION
Companion to the roadmap (#3873). Records, per ticket: what was built, how each safety property was proved, and **what was not proved**.

## Highlights

- **Phase 1 complete** — all 11 `DT-HARDEN-*` tickets shipped (#3882–#3885, #3896–#3898, #3900, #3902–#3904; #3883 merged).
- **Phase 2 started** — DT-OPS-01 (#3905), DT-OPS-05 (#3907).
- Verification standard: a passing test proves the code does *something*; each safety property was additionally **mutation-tested** (break the guard → watch the specific test go red → restore). The DT-HARDEN-05 lease invariant was proved against a **real Postgres**.

## The honest part (§5)

- The independent adversarial gate was **lost mid-run to a session limit**. Later PRs were implemented and verified by the same author. Mutation testing proves a guard is load-bearing; it does not ask whether the guard is the *right* one. **Recommend a fresh adversarial pass over these PRs.** The one reviewer that did run caught that DT-HARDEN-10's fix was *incomplete* — something the passing tests did not.
- `syncDirectoryIntegration` orchestration has **no test harness repo-wide**, which bounds what the DT-HARDEN-02 / DT-OPS-01 tests can claim.
- Two behavioral decisions ship **off** and are the owner's to make: `DIRECTORY_PRIMARY_DEPT_FROM_ORDER` (needs DingTalk's real `dept_order_list` shape) and `DIRECTORY_DEPROVISION_ENABLED` (needs the preview counts on real data).

## Operational notes (§7)

Nothing in these PRs changes production behavior on deploy, except three deliberate tightenings (documented). Includes the pre-flight steps for the orphan inventory, credential backfill, and both flags.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)