### PR TITLE
perf(dingtalk): batch the account-department upsert into one statement (DT-PERF-01)

### DIFF
--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -957,6 +957,64 @@ export type DirectoryAccountDepartmentWriteSummary = {
  * drive it directly — and any future rewrite of this body (a bulk `unnest` insert, say) has
  * to keep that golden passing rather than silently reverting to `departmentIds[0]`.
  */
+/**
+ * DT-PERF-01 — flatten (employee × department) membership into three parallel arrays for a
+ * single `unnest` upsert. Exported because the per-row loop it replaced was the sync's largest
+ * source of round trips, and its semantics — which pair exists, which one is primary, how a
+ * repeated pair collapses — must be pinned by tests rather than re-derived by a reader.
+ *
+ * `isPrimary` comes from `resolveDirectoryPrimaryDepartmentId`, NOT from `departmentIds[0]`.
+ * Reintroducing the array index here would silently revert DT-HARDEN-07's approval-routing fix,
+ * which is why the real-DB golden drives the writer rather than this builder.
+ */
+export function buildDirectoryAccountDepartmentRows(
+  users: Iterable<{ userId: string; departmentIds: string[]; source?: unknown }>,
+  accountIdByExternalUserId: Map<string, { id: string }>,
+  departmentIdByExternalDepartmentId: Map<string, string>,
+): { accountIds: string[]; departmentIds: string[]; isPrimary: boolean[]; summary: DirectoryAccountDepartmentWriteSummary } {
+  const accountIds: string[] = []
+  const departmentIds: string[] = []
+  const isPrimary: boolean[] = []
+  const seen = new Set<string>()
+  const summary: DirectoryAccountDepartmentWriteSummary = {
+    membershipsWritten: 0,
+    accountsWithPrimary: 0,
+    accountsWithoutKnownDepartment: 0,
+  }
+
+  for (const user of users) {
+    const account = accountIdByExternalUserId.get(user.userId)
+    if (!account) continue
+
+    // An explicit, deterministic primary department — approval manager routing anchors on
+    // is_primary, so this must not be an accident of array order.
+    const primaryDepartmentId = resolveDirectoryPrimaryDepartmentId(user)
+    let wrotePrimary = false
+    let wroteAny = false
+
+    for (const departmentId of user.departmentIds) {
+      const directoryDepartmentId = departmentIdByExternalDepartmentId.get(departmentId)
+      if (!directoryDepartmentId) continue
+      const pairKey = `${account.id}:${directoryDepartmentId}`
+      if (seen.has(pairKey)) continue
+      seen.add(pairKey)
+
+      const primary = departmentId === primaryDepartmentId
+      accountIds.push(account.id)
+      departmentIds.push(directoryDepartmentId)
+      isPrimary.push(primary)
+      summary.membershipsWritten += 1
+      wroteAny = true
+      wrotePrimary = wrotePrimary || primary
+    }
+
+    if (!wroteAny) summary.accountsWithoutKnownDepartment += 1
+    else if (wrotePrimary) summary.accountsWithPrimary += 1
+  }
+
+  return { accountIds, departmentIds, isPrimary, summary }
+}
+
 export async function upsertDirectoryAccountDepartments(
   client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> },
   input: {
@@ -967,45 +1025,27 @@ export async function upsertDirectoryAccountDepartments(
     departmentIdMap: Map<string, string>
   },
 ): Promise<DirectoryAccountDepartmentWriteSummary> {
-  const summary: DirectoryAccountDepartmentWriteSummary = {
-    membershipsWritten: 0,
-    accountsWithPrimary: 0,
-    accountsWithoutKnownDepartment: 0,
+  const rows = buildDirectoryAccountDepartmentRows(input.users, input.accountIdMap, input.departmentIdMap)
+
+  // DT-PERF-01: this is the highest-cardinality write in the sync — one row per
+  // (employee × department), so a 2,000-employee tenant issued thousands of single-row round
+  // trips inside the apply transaction, holding its locks open for the whole walk. One `unnest`
+  // statement writes them all with identical semantics.
+  if (rows.accountIds.length > 0) {
+    await client.query(
+      `INSERT INTO directory_account_departments (
+         directory_account_id, directory_department_id, is_primary, created_at
+       )
+       SELECT account_id, department_id, is_primary, NOW()
+         FROM unnest($1::uuid[], $2::uuid[], $3::boolean[])
+           AS t(account_id, department_id, is_primary)
+       ON CONFLICT (directory_account_id, directory_department_id)
+       DO UPDATE SET is_primary = EXCLUDED.is_primary`,
+      [rows.accountIds, rows.departmentIds, rows.isPrimary],
+    )
   }
 
-  for (const user of input.users) {
-    const account = input.accountIdMap.get(user.userId)
-    if (!account) continue
-
-    // An explicit, deterministic primary department — approval manager routing anchors on
-    // is_primary, so this must not be an accident of array order.
-    const primaryDepartmentId = resolveDirectoryPrimaryDepartmentId(user)
-    let wrotePrimary = false
-    let wroteAny = false
-
-    for (const departmentId of user.departmentIds) {
-      const directoryDepartmentId = input.departmentIdMap.get(departmentId)
-      if (!directoryDepartmentId) continue
-      const isPrimary = departmentId === primaryDepartmentId
-      await client.query(
-        `INSERT INTO directory_account_departments (
-           directory_account_id, directory_department_id, is_primary, created_at
-         )
-         VALUES ($1, $2, $3, NOW())
-         ON CONFLICT (directory_account_id, directory_department_id)
-         DO UPDATE SET is_primary = EXCLUDED.is_primary`,
-        [account.id, directoryDepartmentId, isPrimary],
-      )
-      summary.membershipsWritten += 1
-      wroteAny = true
-      wrotePrimary = wrotePrimary || isPrimary
-    }
-
-    if (!wroteAny) summary.accountsWithoutKnownDepartment += 1
-    else if (wrotePrimary) summary.accountsWithPrimary += 1
-  }
-
-  return summary
+  return rows.summary
 }
 
 /**

--- a/packages/core-backend/tests/unit/directory-sync-account-department-batch.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-account-department-batch.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildDirectoryAccountDepartmentRows } from '../../src/directory/directory-sync'
+
+/**
+ * DT-PERF-01 — (employee × department) is the highest-cardinality write in the sync. A
+ * 2,000-employee tenant issued thousands of single-row round trips inside the apply
+ * transaction, holding its locks open for the duration. One `unnest` statement replaces
+ * them; this pins the semantics the old loop had, so the rewrite cannot drift.
+ *
+ * `isPrimary` comes from the DT-HARDEN-07 resolver, never from `departmentIds[0]`. Putting the
+ * array index back here would silently revert approval routing — the real-DB golden in
+ * `tests/integration/directory-primary-department-write.db.test.ts` is what actually catches
+ * that, because it drives the writer this builder feeds.
+ */
+describe('DT-PERF-01 directory account-department batch rows', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  const accounts = new Map([
+    ['ext-1', { id: 'acct-1' }],
+    ['ext-2', { id: 'acct-2' }],
+  ])
+  const departments = new Map([
+    ['d10', 'dept-10'],
+    ['d20', 'dept-20'],
+  ])
+
+  it('flattens membership into three parallel arrays', () => {
+    const rows = buildDirectoryAccountDepartmentRows(
+      [{ userId: 'ext-1', departmentIds: ['d10', 'd20'] }],
+      accounts,
+      departments,
+    )
+    expect(rows).toEqual({
+      accountIds: ['acct-1', 'acct-1'],
+      departmentIds: ['dept-10', 'dept-20'],
+      isPrimary: [true, false],
+      summary: { membershipsWritten: 2, accountsWithPrimary: 1, accountsWithoutKnownDepartment: 0 },
+    })
+  })
+
+  it('keeps the arrays index-aligned across multiple users', () => {
+    const rows = buildDirectoryAccountDepartmentRows(
+      [
+        { userId: 'ext-1', departmentIds: ['d20'] },
+        { userId: 'ext-2', departmentIds: ['d10', 'd20'] },
+      ],
+      accounts,
+      departments,
+    )
+    expect(rows.accountIds).toEqual(['acct-1', 'acct-2', 'acct-2'])
+    expect(rows.departmentIds).toEqual(['dept-20', 'dept-10', 'dept-20'])
+    expect(rows.isPrimary).toEqual([true, true, false])
+    expect(rows.accountIds).toHaveLength(rows.departmentIds.length)
+    expect(rows.accountIds).toHaveLength(rows.isPrimary.length)
+  })
+
+  // Flag off: the resolver's fallback IS dept_id_list[0], so this is still the shipped default.
+  it('marks exactly the first department of each user primary (order signal off)', () => {
+    const rows = buildDirectoryAccountDepartmentRows(
+      [{ userId: 'ext-2', departmentIds: ['d20', 'd10'] }],
+      accounts,
+      departments,
+    )
+    expect(rows.departmentIds).toEqual(['dept-20', 'dept-10'])
+    expect(rows.isPrimary).toEqual([true, false])
+    expect(rows.isPrimary.filter(Boolean)).toHaveLength(1)
+  })
+
+  it('skips users without a synced account and departments the sync did not see', () => {
+    const rows = buildDirectoryAccountDepartmentRows(
+      [
+        { userId: 'ext-unknown', departmentIds: ['d10'] },
+        { userId: 'ext-1', departmentIds: ['d10', 'd-missing'] },
+      ],
+      accounts,
+      departments,
+    )
+    expect(rows).toEqual({
+      accountIds: ['acct-1'],
+      departmentIds: ['dept-10'],
+      isPrimary: [true],
+      summary: { membershipsWritten: 1, accountsWithPrimary: 1, accountsWithoutKnownDepartment: 0 },
+    })
+  })
+
+  it('collapses a repeated pair to one row (the ON CONFLICT the old loop relied on)', () => {
+    const rows = buildDirectoryAccountDepartmentRows(
+      [{ userId: 'ext-1', departmentIds: ['d10', 'd10'] }],
+      accounts,
+      departments,
+    )
+    expect(rows.accountIds).toEqual(['acct-1'])
+    expect(rows.isPrimary).toEqual([true])
+  })
+
+  it('produces empty arrays when there is nothing to write (the statement is skipped)', () => {
+    expect(buildDirectoryAccountDepartmentRows([], accounts, departments)).toEqual({
+      accountIds: [],
+      departmentIds: [],
+      isPrimary: [],
+      summary: { membershipsWritten: 0, accountsWithPrimary: 0, accountsWithoutKnownDepartment: 0 },
+    })
+  })
+
+  // The anti-revert guard. `departmentIds[0]` is `d20` here; the order signal says `d10`.
+  it('takes is_primary from the DT-HARDEN-07 resolver, not from departmentIds[0]', () => {
+    vi.stubEnv('DIRECTORY_PRIMARY_DEPT_FROM_ORDER', 'true')
+    const rows = buildDirectoryAccountDepartmentRows(
+      [{
+        userId: 'ext-1',
+        departmentIds: ['d20', 'd10'],
+        source: { dept_order_list: [{ dept_id: 'd10', order: 1 }, { dept_id: 'd20', order: 9 }] },
+      }],
+      accounts,
+      departments,
+    )
+    expect(rows.departmentIds).toEqual(['dept-20', 'dept-10'])
+    expect(rows.isPrimary).toEqual([false, true]) // d10 is primary, though d20 is first
+    expect(rows.summary.accountsWithPrimary).toBe(1)
+  })
+
+  it('reports an account whose departments are all unknown to the integration', () => {
+    const rows = buildDirectoryAccountDepartmentRows(
+      [{ userId: 'ext-1', departmentIds: ['d-missing'] }],
+      accounts,
+      departments,
+    )
+    expect(rows.accountIds).toEqual([])
+    expect(rows.summary).toEqual({ membershipsWritten: 0, accountsWithPrimary: 0, accountsWithoutKnownDepartment: 1 })
+  })
+})


### PR DESCRIPTION
`(employee × department)` is the **highest-cardinality write in the sync**: a 2,000-employee tenant issued thousands of single-row round trips *inside the apply transaction*, holding its locks open for the whole walk. One `unnest` statement writes them all with identical semantics — same `ON CONFLICT DO UPDATE`, same "first department is primary", same skipping of departments the sync did not see, same collapse of a repeated pair to one row.

**Verification**: 6 unit tests pin the row-builder semantics the old loop had; `tsc --noEmit` clean. **Real-Postgres proof** of the batched statement: batch insert, `ON CONFLICT DO UPDATE` flipping `is_primary`, and empty arrays as a no-op (not an error). **Mutation-proven**: breaking the primary flag turns the alignment test red.

## Scoped out — deliberately, with reasons

- **Removing the per-user `user/get` N+1 is not safe to do blind.** `ApprovalDirectoryOrg` reads `leader_in_dept` out of `directory_accounts.raw`, which *is* the user-detail payload. Whether `user/list` carries that field is exactly the staging check roadmap §7.7 asks for — dropping the detail call without it would **silently destroy manager routing**.
- **Hoisting bcrypt out of the transaction** would require pre-hashing every in-scope candidate before knowing which actually need admission, which costs more than it saves.

Both remain open, with their reasons recorded rather than silently skipped.

Roadmap: DT-PERF-01 (partial, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)