### PR TITLE
feat(approval): RP-3 — template authoring route-preview endpoint (B3-06)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -324,6 +324,7 @@ jobs:
             tests/integration/approval-projection-participant-read.db.test.ts \
             tests/integration/approval-route-preview-substrate.db.test.ts \
             tests/integration/approval-route-preview-api.db.test.ts \
+            tests/integration/approval-template-route-preview-api.db.test.ts \
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \

--- a/docs/development/approval-route-preview-design-lock-20260707.md
+++ b/docs/development/approval-route-preview-design-lock-20260707.md
@@ -78,7 +78,9 @@
   - **对账修正（gate ③ 语义诚实化）**：owner 硬门③的「白名单」在实现里位于 `pruneHiddenFormData` 之后，而后者已把 formData 收敛到「可见的模板声明字段」——故白名单是**冗余的纵深防御**而非唯一闸。安全性质（未声明/组织探测键不进走图）在 create+preview 两路都成立；证明用一个「条件节点按未声明字段 `route_secret` 分支」的判别式金测：任一层生效即 low 臂，**两层同时移除**才漂到 high 臂（已 mutation 验证 RED）。原「移除白名单即漂路由」的说法不成立，已在代码注释与测试注释更正。
   - **§3 输出契约对齐**：端点线响应严格等于 §3 的 `{ route, truncated }`——底座内部返回的 `totalSteps` 不上线（不转发），并有金测断言 `Object.keys(body)===['route','truncated']` 锁死防漂移。
 - 🟦 **RP-3 端点 as-built（本 PR，backend）**：POST `/api/approval-templates/:id/route-preview`，守卫 `approvalTemplateAdminGuard`（canManageTemplates）——**唯一接受 `sampleRequesterId` 的面**（owner 硬门③：组织探测面仅管理端点可达；B3-05 面永不接受 requester 覆盖）。复用 B3-05 同一只读走图+姓名充实（抽 `walkPreviewRoute` 私有helper，`previewApprovalRoute`/`previewTemplateRoute` 共享——无平行实现）。两处扩展只在 preview 侧生效、create/B3-05 字节不变：①`previewSource:'draft'` 用 publish 同一 `buildRuntimeGraph` 编译 LATEST/草稿版本（作者可试运行未发布编辑，跳过 409 published 门）；②`requesterOverride` 只从 sampleRequesterId 的 userId 现查 org 关系/目录角色（客户端不可喂 roles/dept）。入口 `actor` 仍负责模板可见性鉴权。真库测试 8/8（401/403非管理/400/404/草稿预览+样例发起人驱动路由A≠B/省略回退actor/§3+零写scope）；突变 RED（draft-compile 关→409；sampleRequester 断线→A/B 失效）；create 路径回归 14/14（requester role/dept/title/manager-chain/delegation）。
-- ⬜ **RP-3 FE 试运行面板** —— authoring 页消费上端点：样例发起人 picker（复用 directory/users）+ 样例表单 → 高亮命中路径 + 各节点解析人 + 条件人话（复用 G-B2-19 `conditionSummary`）。可交 Sonnet。
+  - **wedge 契约钉死**：模板按 `requester.department/title/role` 路由而样例发起人缺该属性时，底座 wedge guard **fail-closed 422/503**（与真实 create 同）——preview **不**优雅降级到默认分支（那会显示一条 create 实际会拒绝的假路由，违背 preview===create 保真）。FE 面板据此提示「此样例发起人缺少部门，真实提交会被拒」。已金测钉死（dept-routing 草稿 + 无部门样例 → 422 APPROVAL_REQUESTER_DEPARTMENT_REQUIRED）。
+  - **两处已知背离（记录，非缺陷）**：①草稿 preview **不跑** RA-1b 已策展角色门（publish 与 formula-condition/dry-run 会跑）——依 §4「preview 不重复校验」，故作者可能预览到一条 publish 会拒的未策展角色路由；FE 面板应提示「以发布校验为准」。②`previewSource:'draft'` 载入**最后保存**的版本，非编辑器未保存改动——面板流程是「保存后试运行」。
+- ⬜ **RP-3 FE 试运行面板** —— authoring 页消费上端点：样例发起人 picker（复用 directory/users）+ 样例表单 → 高亮命中路径 + 各节点解析人 + 条件人话（复用 G-B2-19 `conditionSummary`）；wedge 422/未策展角色/保存后预览三态提示如上。可交 Sonnet。
 
 ## 7. Out of scope
 

--- a/docs/development/approval-route-preview-design-lock-20260707.md
+++ b/docs/development/approval-route-preview-design-lock-20260707.md
@@ -77,8 +77,8 @@
 - ✅ **RP-2** B3-05 端点 + ApprovalNewView 预览条 —— as-built：POST `/api/approvals/preview`（与 create 同门链 authenticate+rbacGuard approvals:write，body 仅进只读底座），服务端批量姓名充实（users/roles 单次只读查询，缺行诚实回退 id），发起页流程卡内「按当前表单预览路径」（compute-at-click；race-guard 抽为 `routePreviewController`——飞行中改表单/连点均按 generation 作废旧响应，陈旧路径永不回填；未解析节点渲染「（审批人待定）」）；路由级真库测试（401/403/400/404/200+零写入按模板 scope）+ FE 摘要矩阵 + controller race 单测；守卫突变验证 RED（门链 write→read、充实回退、preview 偷换 create）
   - **对账修正（gate ③ 语义诚实化）**：owner 硬门③的「白名单」在实现里位于 `pruneHiddenFormData` 之后，而后者已把 formData 收敛到「可见的模板声明字段」——故白名单是**冗余的纵深防御**而非唯一闸。安全性质（未声明/组织探测键不进走图）在 create+preview 两路都成立；证明用一个「条件节点按未声明字段 `route_secret` 分支」的判别式金测：任一层生效即 low 臂，**两层同时移除**才漂到 high 臂（已 mutation 验证 RED）。原「移除白名单即漂路由」的说法不成立，已在代码注释与测试注释更正。
   - **§3 输出契约对齐**：端点线响应严格等于 §3 的 `{ route, truncated }`——底座内部返回的 `totalSteps` 不上线（不转发），并有金测断言 `Object.keys(body)===['route','truncated']` 锁死防漂移。
-- ⬜ **RP-3** B3-06 端点 + authoring 试运行面板 —— RP-1 后，可与 RP-2 并行
-- 🔒 依赖提醒：RP-3 的条件人话展示消费 G-B2-19 `conditionSummary`（在飞）
+- 🟦 **RP-3 端点 as-built（本 PR，backend）**：POST `/api/approval-templates/:id/route-preview`，守卫 `approvalTemplateAdminGuard`（canManageTemplates）——**唯一接受 `sampleRequesterId` 的面**（owner 硬门③：组织探测面仅管理端点可达；B3-05 面永不接受 requester 覆盖）。复用 B3-05 同一只读走图+姓名充实（抽 `walkPreviewRoute` 私有helper，`previewApprovalRoute`/`previewTemplateRoute` 共享——无平行实现）。两处扩展只在 preview 侧生效、create/B3-05 字节不变：①`previewSource:'draft'` 用 publish 同一 `buildRuntimeGraph` 编译 LATEST/草稿版本（作者可试运行未发布编辑，跳过 409 published 门）；②`requesterOverride` 只从 sampleRequesterId 的 userId 现查 org 关系/目录角色（客户端不可喂 roles/dept）。入口 `actor` 仍负责模板可见性鉴权。真库测试 8/8（401/403非管理/400/404/草稿预览+样例发起人驱动路由A≠B/省略回退actor/§3+零写scope）；突变 RED（draft-compile 关→409；sampleRequester 断线→A/B 失效）；create 路径回归 14/14（requester role/dept/title/manager-chain/delegation）。
+- ⬜ **RP-3 FE 试运行面板** —— authoring 页消费上端点：样例发起人 picker（复用 directory/users）+ 样例表单 → 高亮命中路径 + 各节点解析人 + 条件人话（复用 G-B2-19 `conditionSummary`）。可交 Sonnet。
 
 ## 7. Out of scope
 

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -491,6 +491,65 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
+  // RP-3 (B3-06 authoring 试运行): template author's read-only dry-run of the LATEST/draft version.
+  // Guarded by approvalTemplateAdminGuard (canManageTemplates) — this is the ONLY surface that
+  // accepts sampleRequesterId, the org-structure probe vector owner order ③ isolates here (the
+  // B3-05 requester surface never accepts a requester override). Zero writes (RP-1 substrate).
+  r.post('/api/approval-templates/:id/route-preview', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
+    try {
+      const actorId = resolveApprovalActorId(req)
+      if (!actorId) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
+
+      const templateId = typeof req.params.id === 'string' ? req.params.id.trim() : ''
+      const sampleFormData =
+        req.body?.sampleFormData && typeof req.body.sampleFormData === 'object' && !Array.isArray(req.body.sampleFormData)
+          ? req.body.sampleFormData as Record<string, unknown>
+          : null
+      const sampleRequesterId = typeof req.body?.sampleRequesterId === 'string' ? req.body.sampleRequesterId.trim() : ''
+
+      if (!templateId || !sampleFormData) {
+        return res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'templateId (path) and sampleFormData are required',
+          },
+        })
+      }
+
+      const preview = await productService.previewTemplateRoute(
+        { templateId, formData: sampleFormData },
+        {
+          userId: actorId,
+          userName: resolveApprovalActorName(req, actorId),
+          email: typeof req.user?.email === 'string' ? req.user.email : undefined,
+          tenantId: resolveApprovalTenantId(req),
+          department: typeof req.user?.department === 'string' ? req.user.department : undefined,
+          departmentIds: resolveApprovalActorDepartmentIds(req),
+          roles: resolveApprovalActorRoles(req),
+          permissions: resolveApprovalActorPermissions(req),
+        },
+        // The sample requester is identified by id only; org relations / directory roles / dept /
+        // title are resolved fresh from the DB by that id inside the substrate (never client-supplied).
+        sampleRequesterId ? { sampleRequester: { userId: sampleRequesterId } } : {},
+      )
+
+      // Conform to the ratified §3 output contract ({ route, truncated? }); the substrate's
+      // internal totalSteps is not part of the endpoint contract.
+      res.json({ route: preview.route, truncated: preview.truncated })
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_TEMPLATE_PREVIEW_FAILED',
+        'Failed to preview the approval template route',
+      )
+    }
+  })
+
   r.post('/api/approval-templates', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
     try {
       const template = await productService.createTemplate({

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3284,13 +3284,14 @@ export class ApprovalProductService {
       // RP-3 (B3-06): the admin caller may resolve the route AS a sample requester (owner order ③ —
       // sampleRequesterId only reachable on the canManageTemplates endpoint). The `actor` still
       // authorizes template access (visibility); only the requester SNAPSHOT is taken from here.
+      //
+      // IDENTITY ONLY, deliberately: every attribute routing actually consumes (directoryDepartment /
+      // directoryTitle / directoryRoles / manager chain) is re-resolved from the DB by this userId
+      // below. Widening this to accept department/roles/etc. would hand a caller an org-attribute
+      // injection channel — so the type structurally forbids it.
       requesterOverride?: {
         userId: string
         userName?: string
-        department?: string
-        departmentIds?: string[]
-        roles?: string[]
-        permissions?: string[]
       }
     } = {},
   ): Promise<{
@@ -3324,11 +3325,10 @@ export class ApprovalProductService {
     if (!previewFromDraft && (bundle.template.status !== 'published' || !bundle.publishedDefinition || !bundle.publishedDefinition.is_active)) {
       throw new ServiceError('Approval template is not published', 409, 'APPROVAL_TEMPLATE_NOT_PUBLISHED')
     }
-    // A draft version may have never been published (no runtime_graph row) — surface that as a clean
-    // 404-shaped error rather than letting the compile below dereference an empty authoring graph.
-    if (previewFromDraft && !bundle.version) {
-      throw new ServiceError('Approval template version not found', 404, 'APPROVAL_TEMPLATE_VERSION_NOT_FOUND')
-    }
+    // A never-published template has `publishedDefinition === null` — which the draft path
+    // deliberately tolerates (it compiles `bundle.version.approval_graph` below instead).
+    // `bundle.version` itself is always present: loadTemplateBundleWithClient returns null when it
+    // cannot resolve a version, and that already surfaced as the 404 above.
 
     const formSchema = asFormSchema(bundle.version.form_schema)
     // NOTE: pruneHiddenFormData already restricts formData to VISIBLE declared fields, so undeclared
@@ -3386,15 +3386,17 @@ export class ApprovalProductService {
     // The requester whose org attributes drive routing. Defaults to the actor (create + B3-05); the
     // B3-06 admin endpoint may override it with a sample requester (owner order ③). Template ACCESS
     // was already authorized against `actor` above — only routing identity changes here.
-    const effectiveRequester = options.requesterOverride
-      ? {
-          userId: options.requesterOverride.userId,
-          userName: options.requesterOverride.userName || options.requesterOverride.userId,
-          email: undefined as string | undefined,
-          department: options.requesterOverride.department,
-          roles: options.requesterOverride.roles,
-          permissions: options.requesterOverride.permissions,
-        }
+    const effectiveRequester: {
+      userId: string
+      userName?: string
+      email?: string
+      department?: string
+      roles?: string[]
+      permissions?: string[]
+    } = options.requesterOverride
+      // Identity only — the routing-authoritative attributes are re-resolved from the DB below, so
+      // the sample requester's org data can never be client-supplied (owner order ③).
+      ? { userId: options.requesterOverride.userId, userName: options.requesterOverride.userName || options.requesterOverride.userId }
       : { userId: actor.userId, userName: actor.userName, email: actor.email, department: actor.department, roles: actor.roles, permissions: actor.permissions }
     const needsManagerChain = runtimeGraphUsesManagerChain(runtimeGraph)
     let orgRelations: ApprovalRequesterOrgRelations = {}
@@ -3426,7 +3428,7 @@ export class ApprovalProductService {
       } catch (error) {
         roleReadFailed = true
         metricsLogger.warn(
-          `Failed to resolve requester roles for ${actor.userId}: ${
+          `Failed to resolve requester roles for ${effectiveRequester.userId}: ${
             error instanceof Error ? error.message : 'unknown error'
           }`,
         )
@@ -3575,14 +3577,9 @@ export class ApprovalProductService {
     request: { templateId: string; formData: Record<string, unknown> },
     actor: CreateApprovalActor,
     options: {
-      sampleRequester?: {
-        userId: string
-        userName?: string
-        department?: string
-        departmentIds?: string[]
-        roles?: string[]
-        permissions?: string[]
-      }
+      // Identity only — see assembleCreationContext.requesterOverride: the sample requester's org
+      // attributes are always re-resolved from the DB, never accepted from the caller.
+      sampleRequester?: { userId: string; userName?: string }
     } = {},
   ): Promise<ApprovalRoutePreviewResult> {
     const { runtimeGraph, executor } = await this.assembleCreationContext(request, actor, {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2402,6 +2402,21 @@ function buildApprovalAssignmentResolver(options: {
   })
 }
 
+/**
+ * Read-only route-preview result shared by B3-05 (previewApprovalRoute) and B3-06
+ * (previewTemplateRoute) — one walk implementation, one shape.
+ */
+export interface ApprovalRoutePreviewResult {
+  route: Array<{
+    nodeKey: string
+    nodeLabel: string
+    assignees: Array<{ id: string; name: string; assignmentType: 'user' | 'role' }>
+    resolveError?: string
+  }>
+  totalSteps: number
+  truncated: boolean
+}
+
 export class ApprovalProductService {
   /**
    * Wave 2 WP5 slice 1 — optional metrics service injection so tests can
@@ -3259,7 +3274,25 @@ export class ApprovalProductService {
   private async assembleCreationContext(
     request: { templateId: string; formData: Record<string, unknown> },
     actor: CreateApprovalActor,
-    options: { whitelistFormDataToSchema?: boolean } = {},
+    options: {
+      whitelistFormDataToSchema?: boolean
+      // RP-3 (B3-06 authoring 试运行): source the runtime graph from the LATEST (possibly draft)
+      // version, compiled on the fly with the SAME buildRuntimeGraph the publish path uses (no
+      // parallel impl) — lets an author dry-run un-published edits. Default 'active' = the
+      // published/active definition (create + B3-05, byte-identical).
+      previewSource?: 'active' | 'draft'
+      // RP-3 (B3-06): the admin caller may resolve the route AS a sample requester (owner order ③ —
+      // sampleRequesterId only reachable on the canManageTemplates endpoint). The `actor` still
+      // authorizes template access (visibility); only the requester SNAPSHOT is taken from here.
+      requesterOverride?: {
+        userId: string
+        userName?: string
+        department?: string
+        departmentIds?: string[]
+        roles?: string[]
+        permissions?: string[]
+      }
+    } = {},
   ): Promise<{
     bundle: NonNullable<Awaited<ReturnType<ApprovalProductService['loadTemplateBundle']>>>
     formSchema: FormSchema
@@ -3270,7 +3303,8 @@ export class ApprovalProductService {
   }> {
     if (!pool) throw new Error('Database not available')
 
-    const bundle = await this.loadTemplateBundle(request.templateId, undefined, 'active', {
+    const previewFromDraft = options.previewSource === 'draft'
+    const bundle = await this.loadTemplateBundle(request.templateId, undefined, previewFromDraft ? 'latest' : 'active', {
       userId: actor.userId,
       departmentIds: actor.departmentIds ?? (actor.department ? [actor.department] : []),
       roles: actor.roles ?? [],
@@ -3284,8 +3318,16 @@ export class ApprovalProductService {
     if (!bundle) {
       throw new ServiceError('Approval template not found', 404, 'APPROVAL_TEMPLATE_NOT_FOUND')
     }
-    if (bundle.template.status !== 'published' || !bundle.publishedDefinition || !bundle.publishedDefinition.is_active) {
+    // The published gate applies to the real create + B3-05 (which route on the frozen published
+    // runtime graph). A draft dry-run (B3-06) legitimately previews an un-published version, so it
+    // compiles the authoring graph below instead of requiring a published definition.
+    if (!previewFromDraft && (bundle.template.status !== 'published' || !bundle.publishedDefinition || !bundle.publishedDefinition.is_active)) {
       throw new ServiceError('Approval template is not published', 409, 'APPROVAL_TEMPLATE_NOT_PUBLISHED')
+    }
+    // A draft version may have never been published (no runtime_graph row) — surface that as a clean
+    // 404-shaped error rather than letting the compile below dereference an empty authoring graph.
+    if (previewFromDraft && !bundle.version) {
+      throw new ServiceError('Approval template version not found', 404, 'APPROVAL_TEMPLATE_VERSION_NOT_FOUND')
     }
 
     const formSchema = asFormSchema(bundle.version.form_schema)
@@ -3335,18 +3377,36 @@ export class ApprovalProductService {
     // walked only when the published graph uses a management-chain source
     // (continuous_managers or manager_at_level) — so the extra per-hop queries stay
     // off every approval. Absence falls through to the node's emptyAssigneePolicy.
-    const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
+    // Draft dry-run (B3-06) compiles the authoring graph with the SAME compiler the publish path
+    // uses; the default path reads the frozen published runtime graph (create + B3-05, unchanged).
+    // The `!` on the published branch is sound: the non-draft gate above already threw if absent.
+    const runtimeGraph = previewFromDraft
+      ? buildRuntimeGraph(asApprovalGraph(bundle.version.approval_graph), { allowRevoke: false })
+      : asRuntimeGraph(bundle.publishedDefinition!.runtime_graph)
+    // The requester whose org attributes drive routing. Defaults to the actor (create + B3-05); the
+    // B3-06 admin endpoint may override it with a sample requester (owner order ③). Template ACCESS
+    // was already authorized against `actor` above — only routing identity changes here.
+    const effectiveRequester = options.requesterOverride
+      ? {
+          userId: options.requesterOverride.userId,
+          userName: options.requesterOverride.userName || options.requesterOverride.userId,
+          email: undefined as string | undefined,
+          department: options.requesterOverride.department,
+          roles: options.requesterOverride.roles,
+          permissions: options.requesterOverride.permissions,
+        }
+      : { userId: actor.userId, userName: actor.userName, email: actor.email, department: actor.department, roles: actor.roles, permissions: actor.permissions }
     const needsManagerChain = runtimeGraphUsesManagerChain(runtimeGraph)
     let orgRelations: ApprovalRequesterOrgRelations = {}
     let orgReadFailed = false
     try {
-      orgRelations = await resolveApprovalRequesterOrgRelations(actor.userId, pool.query.bind(pool), {
+      orgRelations = await resolveApprovalRequesterOrgRelations(effectiveRequester.userId, pool.query.bind(pool), {
         includeManagerChain: needsManagerChain,
       })
     } catch (error) {
       orgReadFailed = true
       metricsLogger.warn(
-        `Failed to resolve requester org relations for ${actor.userId}: ${
+        `Failed to resolve requester org relations for ${effectiveRequester.userId}: ${
           error instanceof Error ? error.message : 'unknown error'
         }`,
       )
@@ -3362,7 +3422,7 @@ export class ApprovalProductService {
     let roleReadFailed = false
     if (needsRequesterRoles) {
       try {
-        requesterRoleIds = await resolveApprovalRequesterRoleIds(actor.userId, pool.query.bind(pool))
+        requesterRoleIds = await resolveApprovalRequesterRoleIds(effectiveRequester.userId, pool.query.bind(pool))
       } catch (error) {
         roleReadFailed = true
         metricsLogger.warn(
@@ -3449,18 +3509,18 @@ export class ApprovalProductService {
     }
 
     const requesterSnapshot: ApprovalRequesterSnapshot = {
-      id: actor.userId,
-      name: actor.userName || actor.userId,
-      email: actor.email,
-      department: actor.department,
+      id: effectiveRequester.userId,
+      name: effectiveRequester.userName || effectiveRequester.userId,
+      email: effectiveRequester.email,
+      department: effectiveRequester.department,
       ...(orgRelations.primaryDepartmentName ? { directoryDepartment: orgRelations.primaryDepartmentName } : {}),
       ...(orgRelations.primaryTitle ? { directoryTitle: orgRelations.primaryTitle } : {}),
       // RA-1b CURATED-VOCABULARY — FREEZE directoryRoles ALWAYS as an array, INCLUDING `[]`. Genuine-empty is
       // a valid predicate state (routes to DEFAULT), so it must NOT be omitted: an omitted field would thread
       // null at dispatch and fail-closed at eval instead of evaluating membership to false.
       directoryRoles: requesterRoleIds,
-      roles: actor.roles || [],
-      permissions: actor.permissions || [],
+      roles: effectiveRequester.roles || [],
+      permissions: effectiveRequester.permissions || [],
       ...(orgRelations.managerId ? { managerId: orgRelations.managerId } : {}),
       ...(orgRelations.deptHeadId ? { deptHeadId: orgRelations.deptHeadId } : {}),
       ...(orgRelations.managerChainIds ? { managerChainIds: orgRelations.managerChainIds } : {}),
@@ -3495,20 +3555,48 @@ export class ApprovalProductService {
   async previewApprovalRoute(
     request: { templateId: string; formData: Record<string, unknown> },
     actor: CreateApprovalActor,
-  ): Promise<{
-    route: Array<{
-      nodeKey: string
-      nodeLabel: string
-      assignees: Array<{ id: string; name: string; assignmentType: 'user' | 'role' }>
-      resolveError?: string
-    }>
-    totalSteps: number
-    truncated: boolean
-  }> {
+  ): Promise<ApprovalRoutePreviewResult> {
+    // B3-05: the requester IS the session actor; publish gate applies (active runtime graph).
     const { runtimeGraph, executor } = await this.assembleCreationContext(request, actor, {
       whitelistFormDataToSchema: true,
     })
+    return this.walkPreviewRoute(runtimeGraph, executor)
+  }
 
+  /**
+   * RP-3 (B3-06 authoring 试运行): the template author's dry-run. Identical read-only walk +
+   * name enrichment as B3-05 (shared substrate — NO parallel impl), but it (a) sources the runtime
+   * graph from the LATEST/draft version so un-published edits are testable, and (b) may resolve the
+   * route AS an optional sample requester. Guarded by canManageTemplates at the route so
+   * sampleRequesterId — the org-structure probe surface — is unreachable to ordinary users
+   * (owner order ③). `actor` still authorizes template visibility inside assembleCreationContext.
+   */
+  async previewTemplateRoute(
+    request: { templateId: string; formData: Record<string, unknown> },
+    actor: CreateApprovalActor,
+    options: {
+      sampleRequester?: {
+        userId: string
+        userName?: string
+        department?: string
+        departmentIds?: string[]
+        roles?: string[]
+        permissions?: string[]
+      }
+    } = {},
+  ): Promise<ApprovalRoutePreviewResult> {
+    const { runtimeGraph, executor } = await this.assembleCreationContext(request, actor, {
+      whitelistFormDataToSchema: true,
+      previewSource: 'draft',
+      ...(options.sampleRequester ? { requesterOverride: options.sampleRequester } : {}),
+    })
+    return this.walkPreviewRoute(runtimeGraph, executor)
+  }
+
+  private async walkPreviewRoute(
+    runtimeGraph: RuntimeGraph,
+    executor: ApprovalGraphExecutor,
+  ): Promise<ApprovalRoutePreviewResult> {
     const nodeLabel = (key: string): string => {
       const node = runtimeGraph.nodes.find((entry) => entry.key === key)
       return (node?.name && String(node.name).trim()) || key

--- a/packages/core-backend/tests/integration/approval-template-route-preview-api.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-template-route-preview-api.db.test.ts
@@ -1,0 +1,191 @@
+/**
+ * RP-3 — POST /api/approval-templates/:id/route-preview (route-preview lock, RATIFIED; B3-06
+ * 模板作者 authoring 试运行).
+ *
+ * The admin dry-run surface. Proves over real HTTP + real Postgres:
+ * - canManageTemplates guard (403 for a caller without it) — the sampleRequesterId org-probe
+ *   surface is unreachable to ordinary users (owner order ③);
+ * - DRAFT preview: an UN-published template is previewable (the substrate compiles the authoring
+ *   graph via the same buildRuntimeGraph publish uses, and skips the published gate);
+ * - sampleRequesterId DRIVES the resolved route (a `requester`-kind node resolves to the sample
+ *   requester → different sample id ⇒ different assignee), and falls back to the admin actor when
+ *   omitted;
+ * - zero writes (scoped to this test's template).
+ *
+ * The preview===create consistency golden + delegation/fault goldens live in the RP-1 substrate
+ * suite; this file owns the B3-06 wire surface.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const ADMIN = `u_rp3_admin_${TS}`
+const SAMPLE_A = `u_rp3_a_${TS}`
+const SAMPLE_A_NAME = `样例发起人甲-${TS}`
+const SAMPLE_B = `u_rp3_b_${TS}`
+const SAMPLE_B_NAME = `样例发起人乙-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tokWith(base: string, userId: string, roles: string, perms: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function post(base: string, path: string, token: string | null, body?: unknown): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: 'POST',
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  })
+}
+
+interface PreviewBody {
+  route: Array<{ nodeKey: string; nodeLabel: string; assignees: Array<{ id: string; name: string; assignmentType: string }>; resolveError?: string }>
+  truncated: boolean
+}
+
+describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (real-DB HTTP)', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let adminTok = ''
+  let draftTemplateId = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    const pool = poolManager.get()
+    for (const [uid, name] of [[SAMPLE_A, SAMPLE_A_NAME], [SAMPLE_B, SAMPLE_B_NAME], [ADMIN, ADMIN]] as const) {
+      await pool.query(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1, $2, $3, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+         ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, is_active = TRUE`,
+        [uid, `${uid}@rp3.test`, name],
+      )
+    }
+
+    // A DRAFT template — created but NEVER published. Its single approval node assigns to the
+    // `requester`, so the resolved assignee == whichever requester the preview runs as.
+    const approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate({
+      key: `rp3-${TS}`,
+      name: 'RP3 Authoring Preview Template',
+      formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          { key: 'approval_1', type: 'approval', name: '发起人自审', config: { mode: 'any', assigneeSources: [{ kind: 'requester' }] } },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'end' },
+        ],
+      },
+    } as never, { userId: ADMIN, userName: ADMIN } as never)
+    draftTemplateId = (template as { id: string }).id
+    // NOTE: deliberately NOT published — the whole point of B3-06 is previewing un-published edits.
+
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    adminTok = await tokWith(base, ADMIN, 'admin', '*:*')
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      if (draftTemplateId) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = $1`, [draftTemplateId])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = $1`, [draftTemplateId])
+        await pool.query(`DELETE FROM approval_templates WHERE id = $1`, [draftTemplateId])
+      }
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [[ADMIN, SAMPLE_A, SAMPLE_B]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  const PATH = () => `/api/approval-templates/${draftTemplateId}/route-preview`
+
+  it('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('401 without a token', async () => {
+    expect((await post(base, PATH(), null, { sampleFormData: { summary: 's' } })).status).toBe(401)
+  })
+
+  it('403 without canManageTemplates (owner order ③ — sampleRequesterId probe surface is admin-only)', async () => {
+    const reader = await tokWith(base, `u_rp3_reader_${TS}`, 'user', 'approvals:read')
+    const res = await post(base, PATH(), reader, { sampleFormData: { summary: 's' }, sampleRequesterId: SAMPLE_A })
+    expect(res.status).toBe(403)
+  })
+
+  it('400 when sampleFormData is missing/malformed', async () => {
+    expect((await post(base, PATH(), adminTok, { sampleRequesterId: SAMPLE_A })).status).toBe(400)
+    expect((await post(base, PATH(), adminTok, { sampleFormData: ['nope'] })).status).toBe(400)
+  })
+
+  it('404 for an unknown templateId', async () => {
+    const res = await post(base, `/api/approval-templates/00000000-0000-4000-8000-000000000000/route-preview`, adminTok, { sampleFormData: { summary: 's' } })
+    expect(res.status).toBe(404)
+  })
+
+  it('previews a DRAFT (never-published) template and resolves the route as the SAMPLE requester', async () => {
+    const resA = await post(base, PATH(), adminTok, { sampleFormData: { summary: 'draft run' }, sampleRequesterId: SAMPLE_A })
+    expect(resA.status, await resA.clone().text()).toBe(200)
+    const bodyA = (await resA.json()) as PreviewBody
+    // Draft compiled + walked; the requester-kind node resolved to sample A (with name enrichment).
+    expect(bodyA.route.map((n) => n.nodeKey)).toEqual(['approval_1'])
+    expect(bodyA.route[0]!.assignees).toEqual([{ id: SAMPLE_A, name: SAMPLE_A_NAME, assignmentType: 'user' }])
+
+    // A DIFFERENT sample requester ⇒ a different resolved assignee — proves sampleRequesterId drives
+    // the routing identity (the org-probe capability), not the admin caller.
+    const resB = await post(base, PATH(), adminTok, { sampleFormData: { summary: 'draft run' }, sampleRequesterId: SAMPLE_B })
+    const bodyB = (await resB.json()) as PreviewBody
+    expect(bodyB.route[0]!.assignees).toEqual([{ id: SAMPLE_B, name: SAMPLE_B_NAME, assignmentType: 'user' }])
+  })
+
+  it('falls back to the admin actor as requester when sampleRequesterId is omitted', async () => {
+    const res = await post(base, PATH(), adminTok, { sampleFormData: { summary: 'no sample' } })
+    expect(res.status, await res.clone().text()).toBe(200)
+    const body = (await res.json()) as PreviewBody
+    expect(body.route[0]!.assignees.map((a) => a.id)).toEqual([ADMIN])
+  })
+
+  it('§3 output-contract conformance + ZERO writes (scoped to this template)', async () => {
+    const pool = poolManager.get()
+    const countRows = async () => {
+      const [i, a] = await Promise.all([
+        pool.query('SELECT COUNT(*)::int AS c FROM approval_instances WHERE template_id = $1', [draftTemplateId]),
+        pool.query('SELECT COUNT(*)::int AS c FROM approval_assignments WHERE instance_id IN (SELECT id FROM approval_instances WHERE template_id = $1)', [draftTemplateId]),
+      ])
+      return { instances: i.rows[0].c as number, assignments: a.rows[0].c as number }
+    }
+    const before = await countRows()
+    const res = await post(base, PATH(), adminTok, { sampleFormData: { summary: 'zero write' }, sampleRequesterId: SAMPLE_A })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as PreviewBody
+    expect(Object.keys(body).sort()).toEqual(['route', 'truncated'])
+    expect(await countRows()).toEqual(before)
+  })
+})

--- a/packages/core-backend/tests/integration/approval-template-route-preview-api.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-template-route-preview-api.db.test.ts
@@ -63,6 +63,7 @@ describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (rea
   let adminTok = ''
   let draftTemplateId = ''
   let deptRoutingDraftId = ''
+  let titleRoutingDraftId = ''
 
   beforeAll(async () => {
     expect(await canListen()).toBe(true)
@@ -124,6 +125,33 @@ describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (rea
     } as never, { userId: ADMIN, userName: ADMIN } as never)
     deptRoutingDraftId = (deptTemplate as { id: string }).id
 
+    // Sibling wedge: routes on requester.title. Same guard block as department — pinned separately
+    // because the sample-requester surface makes BOTH constantly reachable for admins testing users
+    // with incomplete directory data. (The role wedge fails closed only on a TRANSIENT read failure,
+    // never on genuine-empty, so it has no equivalent deterministic fixture.)
+    const titleTemplate = await approvals.createTemplate({
+      key: `rp3title-${TS}`,
+      name: 'RP3 Title-Routing Draft',
+      formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          { key: 'cond_1', type: 'condition', name: 'route', config: { branches: [{ edgeKey: 'senior', rules: [], formula: { expression: 'requester.title == "总监"' } }], defaultEdgeKey: 'other' } },
+          { key: 'approval_senior', type: 'approval', name: '总监审批', config: { mode: 'any', assigneeSources: [{ kind: 'requester' }] } },
+          { key: 'approval_other', type: 'approval', name: '其他审批', config: { mode: 'any', assigneeSources: [{ kind: 'requester' }] } },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'e0', source: 'start', target: 'cond_1' },
+          { key: 'senior', source: 'cond_1', target: 'approval_senior' },
+          { key: 'other', source: 'cond_1', target: 'approval_other' },
+          { key: 'es', source: 'approval_senior', target: 'end' },
+          { key: 'eo', source: 'approval_other', target: 'end' },
+        ],
+      },
+    } as never, { userId: ADMIN, userName: ADMIN } as never)
+    titleRoutingDraftId = (titleTemplate as { id: string }).id
+
     server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
     await server.start()
     base = `http://127.0.0.1:${server.getAddress()!.port}`
@@ -133,7 +161,7 @@ describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (rea
   afterAll(async () => {
     try {
       const pool = poolManager.get()
-      for (const tid of [draftTemplateId, deptRoutingDraftId]) {
+      for (const tid of [draftTemplateId, deptRoutingDraftId, titleRoutingDraftId]) {
         if (!tid) continue
         const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = $1`, [tid])).rows.map((r) => r.id as string)
         if (iids.length > 0) {
@@ -211,6 +239,15 @@ describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (rea
     })
     expect(res.status).toBe(422)
     expect(((await res.json()) as { error?: { code?: string } }).error?.code).toBe('APPROVAL_REQUESTER_DEPARTMENT_REQUIRED')
+  })
+
+  it('PINNED CONTRACT: the title wedge also fails closed (422) for a title-less sample requester', async () => {
+    const res = await post(base, `/api/approval-templates/${titleRoutingDraftId}/route-preview`, adminTok, {
+      sampleFormData: { summary: 'title route' },
+      sampleRequesterId: SAMPLE_A,
+    })
+    expect(res.status).toBe(422)
+    expect(((await res.json()) as { error?: { code?: string } }).error?.code).toBe('APPROVAL_REQUESTER_TITLE_REQUIRED')
   })
 
   it('§3 output-contract conformance + ZERO writes (scoped to this template)', async () => {

--- a/packages/core-backend/tests/integration/approval-template-route-preview-api.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-template-route-preview-api.db.test.ts
@@ -62,6 +62,7 @@ describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (rea
   let base = ''
   let adminTok = ''
   let draftTemplateId = ''
+  let deptRoutingDraftId = ''
 
   beforeAll(async () => {
     expect(await canListen()).toBe(true)
@@ -98,6 +99,31 @@ describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (rea
     draftTemplateId = (template as { id: string }).id
     // NOTE: deliberately NOT published — the whole point of B3-06 is previewing un-published edits.
 
+    // A draft that ROUTES on requester.department — for pinning the wedge-guard contract when a
+    // sample requester lacks the department the graph needs.
+    const deptTemplate = await approvals.createTemplate({
+      key: `rp3dept-${TS}`,
+      name: 'RP3 Dept-Routing Draft',
+      formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          { key: 'cond_1', type: 'condition', name: 'route', config: { branches: [{ edgeKey: 'eng', rules: [], formula: { expression: 'requester.department == "工程部"' } }], defaultEdgeKey: 'other' } },
+          { key: 'approval_eng', type: 'approval', name: '工程审批', config: { mode: 'any', assigneeSources: [{ kind: 'requester' }] } },
+          { key: 'approval_other', type: 'approval', name: '其他审批', config: { mode: 'any', assigneeSources: [{ kind: 'requester' }] } },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'e0', source: 'start', target: 'cond_1' },
+          { key: 'eng', source: 'cond_1', target: 'approval_eng' },
+          { key: 'other', source: 'cond_1', target: 'approval_other' },
+          { key: 'ee', source: 'approval_eng', target: 'end' },
+          { key: 'eo', source: 'approval_other', target: 'end' },
+        ],
+      },
+    } as never, { userId: ADMIN, userName: ADMIN } as never)
+    deptRoutingDraftId = (deptTemplate as { id: string }).id
+
     server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
     await server.start()
     base = `http://127.0.0.1:${server.getAddress()!.port}`
@@ -107,15 +133,16 @@ describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (rea
   afterAll(async () => {
     try {
       const pool = poolManager.get()
-      if (draftTemplateId) {
-        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = $1`, [draftTemplateId])).rows.map((r) => r.id as string)
+      for (const tid of [draftTemplateId, deptRoutingDraftId]) {
+        if (!tid) continue
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = $1`, [tid])).rows.map((r) => r.id as string)
         if (iids.length > 0) {
           await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
           await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
           await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
         }
-        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = $1`, [draftTemplateId])
-        await pool.query(`DELETE FROM approval_templates WHERE id = $1`, [draftTemplateId])
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = $1`, [tid])
+        await pool.query(`DELETE FROM approval_templates WHERE id = $1`, [tid])
       }
       await pool.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [[ADMIN, SAMPLE_A, SAMPLE_B]])
     } catch {
@@ -170,6 +197,20 @@ describeIfDatabase('RP-3 — POST /api/approval-templates/:id/route-preview (rea
     expect(res.status, await res.clone().text()).toBe(200)
     const body = (await res.json()) as PreviewBody
     expect(body.route[0]!.assignees.map((a) => a.id)).toEqual([ADMIN])
+  })
+
+  it('PINNED CONTRACT: a requester-attribute wedge fails closed (422), same as create — NOT a fake default route', async () => {
+    // The template routes on requester.department; the sample requester has no department. The
+    // shared substrate's wedge guard fails closed (422) exactly as the real create would — preview
+    // must NOT gracefully show the default branch, because create would REJECT this requester, not
+    // route them to default. Fidelity (preview===create) over convenience. The FE surfaces this as
+    // "此样例发起人缺少部门，真实提交会被拒", not a misleading resolved path.
+    const res = await post(base, `/api/approval-templates/${deptRoutingDraftId}/route-preview`, adminTok, {
+      sampleFormData: { summary: 'dept route' },
+      sampleRequesterId: SAMPLE_A,
+    })
+    expect(res.status).toBe(422)
+    expect(((await res.json()) as { error?: { code?: string } }).error?.code).toBe('APPROVAL_REQUESTER_DEPARTMENT_REQUIRED')
   })
 
   it('§3 output-contract conformance + ZERO writes (scoped to this template)', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
       // RP-1: route-preview shared substrate goldens (preview===create, zero-write, whitelist gate).
       'tests/integration/approval-route-preview-substrate.db.test.ts',
       'tests/integration/approval-route-preview-api.db.test.ts',
+      'tests/integration/approval-template-route-preview-api.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## RP-3（route-preview lock RATIFIED · owner 口令②「RP-3 做模板 authoring 试运行面板」· 依赖 RP-1 #3863；与 RP-2 #3881 已并行落地）

后端端点切片（FE 试运行面板作为后续 slice，可交 Sonnet）。

### 端点（B3-06）
- `POST /api/approval-templates/:id/route-preview`，守卫 **`approvalTemplateAdminGuard`（canManageTemplates）** —— **唯一接受 `sampleRequesterId` 的面**（owner 硬门③：组织探测面仅管理端点可达；B3-05 `/api/approvals/preview` 永不接受 requester 覆盖）。
- 入参 `{ sampleFormData, sampleRequesterId? }`；出参严格 §3 `{ route, truncated }`。

### 底座复用（无平行实现）
- 抽 `walkPreviewRoute` 私有 helper，`previewApprovalRoute`(B3-05) 与 `previewTemplateRoute`(B3-06) 共享同一只读走图 + 姓名充实。
- 对共享 `assembleCreationContext` 两处 **preview-only** 扩展，create/B3-05 在选项缺省时**字节不变**：
  1. `previewSource:'draft'`：用 publish 同一 `buildRuntimeGraph` 编译 LATEST/草稿版本 → 作者可试运行**未发布**编辑（跳过 409 published 门）。
  2. `requesterOverride`：只从 `sampleRequesterId` 的 userId **现查** org 关系/目录角色（客户端不可喂 roles/dept）；入口 `actor` 仍负责模板可见性鉴权。

### 契约钉死 & 背离记录（adversarial + advisor 跟进）
- **wedge fail-closed 422**：模板按 requester.department 路由而样例发起人缺部门 → 422（与 create 同），preview **不**优雅降级到假默认路由（会违背 preview===create 保真）。已金测钉死。
- 已知背离（lock 记录）：草稿 preview 不跑 RA-1b 已策展角色门（依 §4「不重复校验」）；`draft` 载入最后**保存**版本（保存后试运行）。

### 验证
- 真库 9/9（401/403非管理/400/404/草稿预览+**样例发起人驱动路由 A≠B**/省略回退 actor/**wedge 422 钉死**/§3+零写 scope），两点 CI 接线。
- 突变 RED：draft-compile 关→409；sampleRequester 断线→A/B 断言失败。
- **create 路径回归本地全绿 83 项**：requester role/dept/title/manager-chain/delegation(14) + subform/threshold/parallel-gateway/amount-total/lifecycle(24) + timeout-effects(auto-approve cascade)/direct-manager/postgate(23) + preview 三套(22)。tsc 干净。

FE 试运行面板另开 slice。

🤖 Generated with [Claude Code](https://claude.com/claude-code)