### PR TITLE
feat(dingtalk): deliver sync-failure alerts and expose manager-binding coverage (DT-OPS-03)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -392,6 +392,7 @@ jobs:
             tests/integration/directory-primary-department-write.db.test.ts \
             tests/integration/directory-primary-department-backfill.db.test.ts \
             tests/integration/directory-sync-preview-apply-parity.db.test.ts \
+            tests/integration/directory-sync-alert-coverage.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/src/directory/directory-sync-alert-delivery.ts
+++ b/packages/core-backend/src/directory/directory-sync-alert-delivery.ts
@@ -1,0 +1,222 @@
+/**
+ * DT-OPS-03 — deliver directory-sync failure alerts somewhere a human will see them.
+ *
+ * `directory_sync_alerts` has carried a `sent_to_webhook` column since it was created and
+ * nothing ever sent anything: a nightly sync that fails because the app secret rotated
+ * simply accumulates rows in a table nobody opens. The irony is that the product already
+ * owns the channel — a DingTalk group robot — so "the DingTalk sync broke" can be
+ * announced over DingTalk.
+ *
+ * Discipline, matching `breach-channels`:
+ *  - the channel exists only when its env is configured (no channel, no noise, no
+ *    per-tick warnings under retry);
+ *  - delivery is best-effort and NEVER fails the sync. A sync that succeeded must not be
+ *    reported as failed because a webhook was down;
+ *  - the webhook URL is SSRF-pinned and HMAC-signed by the same `robot.ts` primitives the
+ *    automation line uses, and it is masked in every log line.
+ */
+import { Logger } from '../core/logger'
+import { query } from '../db/pg'
+import {
+  buildDingTalkMarkdown,
+  buildSignedDingTalkWebhookUrl,
+  normalizeDingTalkRobotSecret,
+  normalizeDingTalkRobotWebhookUrl,
+  validateDingTalkRobotResponse,
+} from '../integrations/dingtalk/robot'
+import { maskDingTalkWebhookUrl } from '../integrations/dingtalk/runtime-policy'
+
+const logger = new Logger('DirectorySyncAlertDelivery')
+
+export type DirectorySyncAlertDeliveryConfig = {
+  webhookUrl: string
+  secret?: string
+}
+
+export function readDirectorySyncAlertWebhookConfig(): DirectorySyncAlertDeliveryConfig | null {
+  const rawUrl = String(process.env.DIRECTORY_SYNC_ALERT_WEBHOOK ?? '').trim()
+  if (!rawUrl) return null
+  try {
+    return {
+      webhookUrl: normalizeDingTalkRobotWebhookUrl(rawUrl),
+      secret: normalizeDingTalkRobotSecret(process.env.DIRECTORY_SYNC_ALERT_WEBHOOK_SECRET),
+    }
+  } catch (error) {
+    // A malformed webhook must not be retried on every failure; say so once, loudly.
+    logger.warn(
+      `DIRECTORY_SYNC_ALERT_WEBHOOK is set but not a valid DingTalk robot URL: ${error instanceof Error ? error.message : String(error)}`,
+    )
+    return null
+  }
+}
+
+/**
+ * How many consecutive failed runs this integration has now had. Repeated failure is the
+ * signal worth escalating — a single blip is noise, three nights in a row is an outage.
+ */
+export async function countConsecutiveFailedRuns(
+  integrationId: string,
+  queryFn: typeof query = query,
+): Promise<number> {
+  const result = await queryFn<{ status: string }>(
+    `SELECT status
+       FROM directory_sync_runs
+      WHERE integration_id = $1 AND status IN ('completed', 'failed')
+      ORDER BY started_at DESC
+      LIMIT 20`,
+    [integrationId],
+  )
+  let streak = 0
+  for (const row of result.rows) {
+    if (row.status !== 'failed') break
+    streak += 1
+  }
+  return streak
+}
+
+export function buildDirectorySyncAlertMessage(options: {
+  integrationName: string
+  runId: string
+  message: string
+  consecutiveFailures: number
+}): { subject: string; content: string } {
+  const subject = options.consecutiveFailures > 1
+    ? `钉钉目录同步连续失败 ${options.consecutiveFailures} 次`
+    : '钉钉目录同步失败'
+  const content = [
+    `- 集成：${options.integrationName}`,
+    `- 运行：${options.runId}`,
+    `- 连续失败：${options.consecutiveFailures} 次`,
+    `- 原因：${options.message}`,
+  ].join('\n')
+  return { subject, content }
+}
+
+/**
+ * Best-effort delivery. Returns whether the alert actually went out, so the caller can
+ * flip `sent_to_webhook`. Never throws.
+ */
+export async function deliverDirectorySyncFailureAlert(
+  options: {
+    integrationId: string
+    integrationName: string
+    runId: string
+    message: string
+  },
+  deps: {
+    config?: DirectorySyncAlertDeliveryConfig | null
+    fetchFn?: typeof fetch
+    queryFn?: typeof query
+  } = {},
+): Promise<boolean> {
+  const config = deps.config !== undefined ? deps.config : readDirectorySyncAlertWebhookConfig()
+  if (!config) return false
+
+  const fetchFn = deps.fetchFn ?? fetch
+  const queryFn = deps.queryFn ?? query
+
+  try {
+    const consecutiveFailures = await countConsecutiveFailedRuns(options.integrationId, queryFn)
+    const { subject, content } = buildDirectorySyncAlertMessage({
+      integrationName: options.integrationName,
+      runId: options.runId,
+      message: options.message,
+      consecutiveFailures,
+    })
+
+    const signedUrl = buildSignedDingTalkWebhookUrl(config.webhookUrl, config.secret)
+    const response = await fetchFn(signedUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildDingTalkMarkdown(subject, content)),
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!response.ok) {
+      logger.warn(`Directory sync alert webhook returned HTTP ${response.status} (${maskDingTalkWebhookUrl(config.webhookUrl)})`)
+      return false
+    }
+    validateDingTalkRobotResponse(await response.json().catch(() => null))
+
+    await queryFn(
+      `UPDATE directory_sync_alerts
+          SET sent_to_webhook = TRUE, updated_at = NOW()
+        WHERE run_id = $1 AND code = 'sync_failed'`,
+      [options.runId],
+    )
+    logger.info(`Directory sync failure alert delivered for run ${options.runId}`)
+    return true
+  } catch (error) {
+    // A failed sync must never be made worse by a failed alert.
+    logger.warn(
+      `Failed to deliver directory sync alert for run ${options.runId}: ${error instanceof Error ? error.message : String(error)}`,
+    )
+    return false
+  }
+}
+
+export type DirectoryManagerBindingCoverage = {
+  managerCount: number
+  linkedManagerCount: number
+  coverage: number
+}
+
+/**
+ * DT-OPS-03 — approval-routing health.
+ *
+ * `ApprovalDirectoryOrg` can only resolve a manager that is LINKED to a local user:
+ * unlinked managers are skipped (dept head) or walked through (manager chain). So the
+ * share of managers that are bound is a direct upper bound on approval-routing success,
+ * and it is invisible today. Managers are the union of the department heads named in
+ * `directory_departments.raw.dept_manager_userid_list` and the accounts flagged
+ * `leader_in_dept` in their own raw.
+ */
+export async function getDirectoryManagerBindingCoverage(
+  integrationId: string,
+  queryFn: typeof query = query,
+): Promise<DirectoryManagerBindingCoverage> {
+  const result = await queryFn<{ manager_count: number; linked_manager_count: number }>(
+    `WITH dept_heads AS (
+       SELECT DISTINCT jsonb_array_elements_text(
+                CASE WHEN jsonb_typeof(d.raw->'dept_manager_userid_list') = 'array'
+                     THEN d.raw->'dept_manager_userid_list'
+                     ELSE '[]'::jsonb END
+              ) AS external_user_id
+         FROM directory_departments d
+        WHERE d.integration_id = $1 AND d.is_active = true
+     ),
+     dept_leaders AS (
+       SELECT DISTINCT a.external_user_id
+         FROM directory_accounts a
+        WHERE a.integration_id = $1
+          AND a.is_active = true
+          AND jsonb_typeof(a.raw->'leader_in_dept') = 'array'
+          AND EXISTS (
+            SELECT 1
+              FROM jsonb_array_elements(a.raw->'leader_in_dept') AS entry
+             WHERE entry->>'leader' = 'true'
+          )
+     ),
+     managers AS (
+       SELECT external_user_id FROM dept_heads
+       UNION
+       SELECT external_user_id FROM dept_leaders
+     )
+     SELECT COUNT(*)::int AS manager_count,
+            COUNT(*) FILTER (WHERE l.local_user_id IS NOT NULL)::int AS linked_manager_count
+       FROM managers m
+       LEFT JOIN directory_accounts a
+         ON a.integration_id = $1 AND a.external_user_id = m.external_user_id AND a.is_active = true
+       LEFT JOIN directory_account_links l
+         ON l.directory_account_id = a.id AND l.link_status = 'linked' AND l.local_user_id IS NOT NULL`,
+    [integrationId],
+  )
+
+  const managerCount = Number(result.rows[0]?.manager_count ?? 0)
+  const linkedManagerCount = Number(result.rows[0]?.linked_manager_count ?? 0)
+  return {
+    managerCount,
+    linkedManagerCount,
+    coverage: managerCount === 0 ? 1 : linkedManagerCount / managerCount,
+  }
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -31,6 +31,7 @@ import { invalidateUserPerms } from '../rbac/service'
 import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../security/encrypted-secrets'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 import { SimpleCronExpression } from '../services/SchedulerService'
+import { deliverDirectorySyncFailureAlert } from './directory-sync-alert-delivery'
 
 const logger = new Logger('DirectorySync')
 const DEFAULT_ORG_ID = 'default'
@@ -2253,6 +2254,18 @@ function buildDepartmentPathMap(departments: Map<string, DingTalkDepartment>): M
   return cache
 }
 
+async function readIntegrationNameForAlert(integrationId: string): Promise<string> {
+  try {
+    const result = await query<{ name: string }>(
+      `SELECT name FROM directory_integrations WHERE id = $1`,
+      [integrationId],
+    )
+    return result.rows[0]?.name || integrationId
+  } catch {
+    return integrationId
+  }
+}
+
 async function markSyncFailure(integrationId: string, runId: string, message: string): Promise<void> {
   await query(
     `UPDATE directory_integrations
@@ -2280,6 +2293,12 @@ async function markSyncFailure(integrationId: string, runId: string, message: st
   } catch (error) {
     logger.warn(`Failed to persist directory alert: ${readErrorMessage(error, 'unknown error')}`)
   }
+
+  // DT-OPS-03: the alert row is useless if nobody opens the table. Deliver it over the
+  // channel the product already owns. Best-effort by construction — a failed sync must
+  // never be made worse by a failed webhook.
+  const integrationName = await readIntegrationNameForAlert(integrationId)
+  await deliverDirectorySyncFailureAlert({ integrationId, integrationName, runId, message })
 }
 
 export function buildUniqueLocalUserMatchMap(

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -25,6 +25,7 @@ import {
   unbindDirectoryAccount,
   updateDirectoryIntegration,
 } from '../directory/directory-sync'
+import { getDirectoryManagerBindingCoverage } from '../directory/directory-sync-alert-delivery'
 import {
   getDingTalkWorkNotificationRuntimeStatusFromStore,
   saveDingTalkWorkNotificationAgentId,
@@ -486,6 +487,21 @@ export function adminDirectoryRouter(): Router {
     } catch (error) {
       const message = readErrorMessage(error, 'Failed to load directory departments')
       jsonError(res, /required|invalid/i.test(message) ? 400 : 500, 'DIRECTORY_DEPARTMENTS_FAILED', message)
+    }
+  })
+
+  // DT-OPS-03 (§7.4): approval-routing health. Coverage is a read-only derived metric —
+  // no write path, same admin gate and error-handling shape as the sibling GET routes above.
+  router.get('/integrations/:integrationId/manager-coverage', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const coverage = await getDirectoryManagerBindingCoverage(req.params.integrationId)
+      jsonOk(res, { coverage })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory manager binding coverage')
+      jsonError(res, /required|invalid/i.test(message) ? 400 : 500, 'DIRECTORY_MANAGER_COVERAGE_FAILED', message)
     }
   })
 

--- a/packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts
@@ -1,0 +1,218 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import {
+  countConsecutiveFailedRuns,
+  getDirectoryManagerBindingCoverage,
+} from '../../src/directory/directory-sync-alert-delivery'
+
+/**
+ * DT-OPS-03 P2-2 — REAL DB coverage. The unit test (directory-sync-alert-delivery.test.ts)
+ * drives both `getDirectoryManagerBindingCoverage` and `countConsecutiveFailedRuns` against a
+ * fake `queryFn` that just echoes back whatever rows the test hands it — so it proves the
+ * TypeScript plumbing but cannot catch a malformed or semantically-wrong SQL string. This file
+ * proves the actual SQL against real Postgres: the leader/dept-head UNION + LEFT JOIN chain in
+ * the coverage CTE, and the ORDER BY direction in the failure-streak query (mutating either one
+ * leaves every unit test green — that is the gap this file closes).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+describeIfDatabase('DT-OPS-03 manager binding coverage + failure streak (real DB)', () => {
+  describe('getDirectoryManagerBindingCoverage', () => {
+    let integrationId = ''
+    let deptAId = ''
+    const DEPT_A = `dsac-deptA-${TS}`
+    const DEPT_B = `dsac-deptB-${TS}`
+    const U_HEAD = `dsac-uhead-${TS}`
+    const U_LEADER = `dsac-uleader-${TS}`
+
+    beforeAll(async () => {
+      integrationId = (await query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+        [`dsac-cov-${TS}`, `dsac-cov-corp-${TS}`],
+      )).rows[0].id
+
+      await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x'), ($3, $4, 'x')`, [
+        U_HEAD, `${U_HEAD}@example.test`, U_LEADER, `${U_LEADER}@example.test`,
+      ])
+
+      // Dept A names its manager via dept_manager_userid_list (the "department head" path).
+      deptAId = (await query<{ id: string }>(
+        `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+         VALUES ($1, $2, 'DeptA', true, $3::jsonb) RETURNING id`,
+        [integrationId, DEPT_A, JSON.stringify({ dept_manager_userid_list: [`ext-head-${TS}`] })],
+      )).rows[0].id
+
+      // Dept B has NO manager configured at all (absent key) — must not blow up the CTE, and must
+      // not contribute any manager to the aggregate.
+      await query(
+        `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+         VALUES ($1, $2, 'DeptB', true, '{}'::jsonb)`,
+        [integrationId, DEPT_B],
+      )
+
+      // Manager 1: named as DeptA's head, LINKED to a local user -> counts + bound.
+      const accHead = (await query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active, raw)
+         VALUES ($1, $2, $3, 'Head', true, '{}'::jsonb) RETURNING id`,
+        [integrationId, `ext-head-${TS}`, `key-head-${TS}`],
+      )).rows[0].id
+
+      // Manager 2: flagged leader:true of DeptA in its own raw, LINKED -> distinct manager, bound.
+      const accLeaderTrue = (await query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active, raw)
+         VALUES ($1, $2, $3, 'LeaderTrue', true, $4::jsonb) RETURNING id`,
+        [integrationId, `ext-leadertrue-${TS}`, `key-leadertrue-${TS}`,
+          JSON.stringify({ leader_in_dept: [{ dept_id: DEPT_A, leader: true }] })],
+      )).rows[0].id
+
+      // Manager candidate that is explicitly leader:false — must NOT be counted as a manager at all.
+      await query(
+        `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active, raw)
+         VALUES ($1, $2, $3, 'LeaderFalse', true, $4::jsonb)`,
+        [integrationId, `ext-leaderfalse-${TS}`, `key-leaderfalse-${TS}`,
+          JSON.stringify({ leader_in_dept: [{ dept_id: DEPT_A, leader: false }] })],
+      )
+
+      // Manager 3: named as DeptA's head via a SECOND dept_manager_userid_list entry, but never
+      // synced as a directory_account and never linked -> counts toward manager_count, not linked.
+      await query(
+        `UPDATE directory_departments SET raw = $2::jsonb WHERE id = $1`,
+        [deptAId, JSON.stringify({ dept_manager_userid_list: [`ext-head-${TS}`, `ext-unlinked-${TS}`] })],
+      )
+      await query(
+        `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active, raw)
+         VALUES ($1, $2, $3, 'Unlinked', true, '{}'::jsonb)`,
+        [integrationId, `ext-unlinked-${TS}`, `key-unlinked-${TS}`],
+      )
+
+      // A plain employee — never named as a manager anywhere — must not leak into the count.
+      await query(
+        `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active, raw)
+         VALUES ($1, $2, $3, 'Employee', true, '{}'::jsonb)`,
+        [integrationId, `ext-employee-${TS}`, `key-employee-${TS}`],
+      )
+
+      await query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+         VALUES ($1, $2, 'linked', 'manual'), ($3, $4, 'linked', 'manual')`,
+        [accHead, U_HEAD, accLeaderTrue, U_LEADER],
+      )
+    })
+
+    afterAll(async () => {
+      if (integrationId) {
+        await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+        await query(`DELETE FROM users WHERE id = ANY($1)`, [[U_HEAD, U_LEADER]])
+      }
+    })
+
+    it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+      expect(process.env.DATABASE_URL).toBeTruthy()
+    })
+
+    it('counts dept-head + leader:true managers once each, excludes leader:false, and tracks link status per manager (real SQL)', async () => {
+      const result = await getDirectoryManagerBindingCoverage(integrationId)
+      // Managers: Head (dept-head, linked), LeaderTrue (leader:true, linked), Unlinked (dept-head, not linked).
+      // LeaderFalse and Employee must not appear.
+      expect(result).toEqual({ managerCount: 3, linkedManagerCount: 2, coverage: 2 / 3 })
+    })
+
+    it('does not divide by zero for an integration whose accounts never name a manager', async () => {
+      const emptyIntegrationId = (await query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+        [`dsac-cov-empty-${TS}`, `dsac-cov-empty-corp-${TS}`],
+      )).rows[0].id
+      try {
+        // A wholly separate integration where NOTHING is ever named a manager — the aggregate
+        // manager_count is genuinely 0, proving `managerCount === 0 ? 1 : ...` behaves against
+        // a real empty result set rather than a hand-built mock row.
+        await query(
+          `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+           VALUES ($1, $2, 'EmptyDept', true, '{}'::jsonb)`,
+          [emptyIntegrationId, `dsac-emptydept-${TS}`],
+        )
+        await query(
+          `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active, raw)
+           VALUES ($1, $2, $3, 'NotAManager', true, '{}'::jsonb)`,
+          [emptyIntegrationId, `ext-notamanager-${TS}`, `key-notamanager-${TS}`],
+        )
+
+        const result = await getDirectoryManagerBindingCoverage(emptyIntegrationId)
+        expect(result).toEqual({ managerCount: 0, linkedManagerCount: 0, coverage: 1 })
+      } finally {
+        await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [emptyIntegrationId])
+        await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [emptyIntegrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [emptyIntegrationId])
+      }
+    })
+  })
+
+  describe('countConsecutiveFailedRuns', () => {
+    let integrationId = ''
+    const runIds: string[] = []
+
+    beforeAll(async () => {
+      integrationId = (await query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+        [`dsac-streak-${TS}`, `dsac-streak-corp-${TS}`],
+      )).rows[0].id
+
+      const base = new Date('2026-01-01T00:00:00.000Z').getTime()
+      const at = (offsetMinutes: number) => new Date(base + offsetMinutes * 60_000).toISOString()
+
+      // Chronological order (oldest -> newest): completed, failed, running, failed, failed(latest).
+      // The trailing streak (from the latest run backward) is: failed, failed — then the `running`
+      // row is skipped by the WHERE clause — then failed, then it hits `completed` and stops: streak=3.
+      const seeds: Array<{ status: string; offset: number }> = [
+        { status: 'completed', offset: 0 },
+        { status: 'failed', offset: 10 },
+        { status: 'running', offset: 20 },
+        { status: 'failed', offset: 30 },
+        { status: 'failed', offset: 40 },
+      ]
+      for (const seed of seeds) {
+        const row = await query<{ id: string }>(
+          `INSERT INTO directory_sync_runs (integration_id, status, started_at, trigger_source)
+           VALUES ($1, $2, $3, 'manual') RETURNING id`,
+          [integrationId, seed.status, at(seed.offset)],
+        )
+        runIds.push(row.rows[0].id)
+      }
+    })
+
+    afterAll(async () => {
+      if (integrationId) {
+        await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      }
+    })
+
+    it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+      expect(process.env.DATABASE_URL).toBeTruthy()
+    })
+
+    it('counts the trailing failure streak from the most recent run backward, skipping running and stopping at completed (real SQL, proves ORDER BY DESC)', async () => {
+      const streak = await countConsecutiveFailedRuns(integrationId)
+      expect(streak).toBe(3)
+    })
+
+    it('is zero when the most recent completed/failed run succeeded', async () => {
+      // Append a completed run after the existing seeds — now the latest completed/failed row is
+      // itself a success, so the streak collapses to zero regardless of the earlier failures.
+      const base = new Date('2026-01-01T00:00:00.000Z').getTime()
+      const latest = new Date(base + 50 * 60_000).toISOString()
+      const row = await query<{ id: string }>(
+        `INSERT INTO directory_sync_runs (integration_id, status, started_at, trigger_source)
+         VALUES ($1, 'completed', $2, 'manual') RETURNING id`,
+        [integrationId, latest],
+      )
+      runIds.push(row.rows[0].id)
+
+      const streak = await countConsecutiveFailedRuns(integrationId)
+      expect(streak).toBe(0)
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -79,6 +79,14 @@ vi.mock('../../src/directory/directory-sync-scheduler', () => ({
   refreshDirectoryIntegrationSchedule: schedulerMocks.refreshDirectoryIntegrationSchedule,
 }))
 
+const alertDeliveryMocks = vi.hoisted(() => ({
+  getDirectoryManagerBindingCoverage: vi.fn(),
+}))
+
+vi.mock('../../src/directory/directory-sync-alert-delivery', () => ({
+  getDirectoryManagerBindingCoverage: alertDeliveryMocks.getDirectoryManagerBindingCoverage,
+}))
+
 const approvalCardConfigMocks = vi.hoisted(() => ({
   generateApprovalCardLinkSecret: vi.fn(),
   getApprovalCardConfigStatus: vi.fn(),
@@ -192,6 +200,7 @@ describe('adminDirectoryRouter', () => {
     directoryMocks.unbindDirectoryAccount.mockReset()
     directoryMocks.updateDirectoryIntegration.mockReset()
     schedulerMocks.refreshDirectoryIntegrationSchedule.mockReset()
+    alertDeliveryMocks.getDirectoryManagerBindingCoverage.mockReset()
     workNotificationMocks.getDingTalkWorkNotificationRuntimeStatusFromStore.mockReset()
     workNotificationMocks.saveDingTalkWorkNotificationAgentId.mockReset()
     workNotificationMocks.testDingTalkWorkNotificationAgentId.mockReset()
@@ -831,6 +840,55 @@ describe('adminDirectoryRouter', () => {
           },
         ],
       },
+    })
+  })
+
+  it('returns directory manager binding coverage for an integration (DT-OPS-03)', async () => {
+    alertDeliveryMocks.getDirectoryManagerBindingCoverage.mockResolvedValue({
+      managerCount: 4,
+      linkedManagerCount: 3,
+      coverage: 0.75,
+    })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/manager-coverage', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(alertDeliveryMocks.getDirectoryManagerBindingCoverage).toHaveBeenCalledWith('dir-1')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        coverage: { managerCount: 4, linkedManagerCount: 3, coverage: 0.75 },
+      },
+    })
+  })
+
+  it('admin-gates the manager binding coverage route (403 for non-admin)', async () => {
+    rbacMocks.isRbacAdmin.mockResolvedValue(false)
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/manager-coverage', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'user-1', role: 'user' },
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect(alertDeliveryMocks.getDirectoryManagerBindingCoverage).not.toHaveBeenCalled()
+  })
+
+  it('surfaces manager binding coverage failures as 500', async () => {
+    alertDeliveryMocks.getDirectoryManagerBindingCoverage.mockRejectedValue(new Error('db unreachable'))
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/manager-coverage', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'DIRECTORY_MANAGER_COVERAGE_FAILED', message: 'db unreachable' },
     })
   })
 

--- a/packages/core-backend/tests/unit/directory-sync-alert-delivery.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-alert-delivery.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildDirectorySyncAlertMessage,
+  countConsecutiveFailedRuns,
+  deliverDirectorySyncFailureAlert,
+  getDirectoryManagerBindingCoverage,
+  readDirectorySyncAlertWebhookConfig,
+} from '../../src/directory/directory-sync-alert-delivery'
+
+/**
+ * DT-OPS-03 — approval-routing health. ApprovalDirectoryOrg can only resolve a manager
+ * that is LINKED to a local user, so the share of bound managers is a direct upper bound
+ * on approval-routing success — and it is invisible today.
+ */
+describe('DT-OPS-03 manager binding coverage', () => {
+  const coverageQuery = (managerCount: number, linkedManagerCount: number) =>
+    (async () => ({ rows: [{ manager_count: managerCount, linked_manager_count: linkedManagerCount }] })) as never
+
+  it('reports the bound share of managers', async () => {
+    await expect(getDirectoryManagerBindingCoverage('dir-1', coverageQuery(4, 3)))
+      .resolves.toEqual({ managerCount: 4, linkedManagerCount: 3, coverage: 0.75 })
+  })
+
+  it('reports zero coverage when no manager is bound — every chain would dead-end', async () => {
+    await expect(getDirectoryManagerBindingCoverage('dir-1', coverageQuery(4, 0)))
+      .resolves.toMatchObject({ coverage: 0 })
+  })
+
+  it('treats "no managers at all" as full coverage rather than dividing by zero', async () => {
+    await expect(getDirectoryManagerBindingCoverage('dir-1', coverageQuery(0, 0)))
+      .resolves.toEqual({ managerCount: 0, linkedManagerCount: 0, coverage: 1 })
+  })
+})
+
+const WEBHOOK = 'https://oapi.dingtalk.com/robot/send?access_token=alerttoken'
+
+function okResponse(body: unknown = { errcode: 0, errmsg: 'ok' }) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+}
+
+/**
+ * DT-OPS-03 — `directory_sync_alerts.sent_to_webhook` has existed since the table was
+ * created and nothing ever sent anything. A nightly sync that fails because the app secret
+ * rotated just accumulates rows in a table nobody opens.
+ */
+describe('DT-OPS-03 directory sync alert delivery', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('channel registration', () => {
+    it('does not exist unless the webhook env is configured', () => {
+      expect(readDirectorySyncAlertWebhookConfig()).toBeNull()
+    })
+
+    it('rejects a non-DingTalk webhook rather than exfiltrating alerts to it (SSRF pinning)', () => {
+      vi.stubEnv('DIRECTORY_SYNC_ALERT_WEBHOOK', 'https://evil.example.com/collect')
+      expect(readDirectorySyncAlertWebhookConfig()).toBeNull()
+    })
+
+    it('accepts a pinned DingTalk robot URL', () => {
+      vi.stubEnv('DIRECTORY_SYNC_ALERT_WEBHOOK', WEBHOOK)
+      expect(readDirectorySyncAlertWebhookConfig()).toMatchObject({ webhookUrl: WEBHOOK })
+    })
+  })
+
+  describe('consecutive failure streak', () => {
+    const runs = (...statuses: string[]) => (async () => ({ rows: statuses.map((status) => ({ status })) })) as never
+
+    it('counts only the leading run of failures', async () => {
+      await expect(countConsecutiveFailedRuns('dir-1', runs('failed', 'failed', 'completed', 'failed'))).resolves.toBe(2)
+    })
+
+    it('is zero when the latest run succeeded', async () => {
+      await expect(countConsecutiveFailedRuns('dir-1', runs('completed', 'failed'))).resolves.toBe(0)
+    })
+  })
+
+  it('escalates the subject once the failure repeats', () => {
+    const single = buildDirectorySyncAlertMessage({ integrationName: 'CN', runId: 'r1', message: 'boom', consecutiveFailures: 1 })
+    const repeated = buildDirectorySyncAlertMessage({ integrationName: 'CN', runId: 'r1', message: 'boom', consecutiveFailures: 3 })
+    expect(single.subject).not.toMatch(/连续/)
+    expect(repeated.subject).toMatch(/连续失败 3 次/)
+    expect(repeated.content).toContain('boom')
+    expect(repeated.content).toContain('r1')
+  })
+
+  describe('delivery', () => {
+    it('sends nothing and reports false when no channel is configured', async () => {
+      const fetchFn = vi.fn() as unknown as typeof fetch
+      const delivered = await deliverDirectorySyncFailureAlert(
+        { integrationId: 'dir-1', integrationName: 'CN', runId: 'r1', message: 'boom' },
+        { config: null, fetchFn },
+      )
+      expect(delivered).toBe(false)
+      expect(fetchFn).not.toHaveBeenCalled()
+    })
+
+    it('signs the webhook, posts markdown, and flips sent_to_webhook', async () => {
+      const fetchFn = vi.fn(async () => okResponse()) as unknown as typeof fetch
+      const queryFn = vi.fn(async () => ({ rows: [{ status: 'failed' }] })) as never
+
+      const delivered = await deliverDirectorySyncFailureAlert(
+        { integrationId: 'dir-1', integrationName: 'CN', runId: 'r1', message: 'app secret rotated' },
+        { config: { webhookUrl: WEBHOOK, secret: 'SECabc123' }, fetchFn, queryFn },
+      )
+
+      expect(delivered).toBe(true)
+      const [url, init] = (fetchFn as unknown as { mock: { calls: Array<[string, RequestInit]> } }).mock.calls[0]
+      expect(url).toContain('sign=')
+      expect(url).toContain('timestamp=')
+      expect(init.signal).toBeTruthy()
+      const payload = JSON.parse(init.body as string)
+      expect(payload.msgtype).toBe('markdown')
+      expect(payload.markdown.text).toContain('app secret rotated')
+
+      const updates = (queryFn as unknown as { mock: { calls: Array<[string]> } }).mock.calls
+        .filter(([sql]) => /UPDATE directory_sync_alerts/.test(sql))
+      expect(updates).toHaveLength(1)
+    })
+
+    it('NEVER lets a webhook failure escape — a failed sync must not be made worse', async () => {
+      const fetchFn = vi.fn(async () => {
+        throw new Error('webhook unreachable')
+      }) as unknown as typeof fetch
+      const queryFn = vi.fn(async () => ({ rows: [] })) as never
+
+      // The load-bearing property: resolves false, does not throw.
+      await expect(deliverDirectorySyncFailureAlert(
+        { integrationId: 'dir-1', integrationName: 'CN', runId: 'r1', message: 'boom' },
+        { config: { webhookUrl: WEBHOOK }, fetchFn, queryFn },
+      )).resolves.toBe(false)
+    })
+
+    it('treats a DingTalk business error as undelivered rather than marking it sent', async () => {
+      const fetchFn = vi.fn(async () => okResponse({ errcode: 130101, errmsg: 'flow control' })) as unknown as typeof fetch
+      const queryFn = vi.fn(async () => ({ rows: [{ status: 'failed' }] })) as never
+
+      await expect(deliverDirectorySyncFailureAlert(
+        { integrationId: 'dir-1', integrationName: 'CN', runId: 'r1', message: 'boom' },
+        { config: { webhookUrl: WEBHOOK }, fetchFn, queryFn },
+      )).resolves.toBe(false)
+
+      const updates = (queryFn as unknown as { mock: { calls: Array<[string]> } }).mock.calls
+        .filter(([sql]) => /UPDATE directory_sync_alerts/.test(sql))
+      expect(updates).toHaveLength(0)
+    })
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -95,6 +95,12 @@ export default defineConfig({
       'tests/integration/approval-route-preview-substrate.db.test.ts',
       'tests/integration/approval-route-preview-api.db.test.ts',
       'tests/integration/approval-template-route-preview-api.db.test.ts',
+      // DT-OPS-03 P2-2: manager-binding coverage CTE + failure-streak ORDER BY are mock-only in
+      // every unit test (corrupting either leaves all 13 unit tests green). DATABASE_URL-gated
+      // (describeIfDatabase). Excluded from the no-DB default job so it doesn't skip-green, and
+      // wired as a WHOLE FILE into the `Run approval real-DB integration` step in
+      // plugin-tests.yml where it runs against real Postgres every PR.
+      'tests/integration/directory-sync-alert-coverage.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
`directory_sync_alerts.sent_to_webhook` has existed since the table was created and **nothing ever sent anything**. A nightly sync that fails because the app secret rotated simply accumulates rows in a table nobody opens. The product already owns the channel — a DingTalk group robot — so *"the DingTalk sync broke"* is now announced over DingTalk.

- the channel exists **only when `DIRECTORY_SYNC_ALERT_WEBHOOK` is configured** (no channel, no noise — matching the `breach-channels` discipline), and the URL is SSRF-pinned + HMAC-signed by the same `robot.ts` primitives the automation line uses, masked in every log;
- delivery is best-effort and **never throws**: a sync that already failed must not be made worse because a webhook was down, and a DingTalk business error leaves `sent_to_webhook` false rather than lying about delivery;
- the subject escalates once failures repeat — one blip is noise, three nights in a row is an outage.

`getDirectoryManagerBindingCoverage()` exposes **approval-routing health**: `ApprovalDirectoryOrg` can only resolve a manager that is *linked* to a local user (unlinked dept heads are skipped, unlinked chain hops are walked through). So the bound share of managers — department heads named on the department, plus accounts flagged `leader_in_dept` — is a direct upper bound on approval-routing success, and it was invisible.

**Verification**: 13 unit tests pass; `tsc --noEmit` clean. **Real-Postgres proof** of the coverage CTE: a dept head and a `leader_in_dept` account count as managers, a `leader:false` account does not, a department with no managers is tolerated, and only the bound one counts as linked. **Mutation-proven twice**: removing the SSRF pinning turns the "rejects a non-DingTalk webhook" test red; letting a webhook failure escape turns the "never made worse" test red.

**Scoped out**: rendering alert `details` and the per-run change diff in the admin UI (a 5,735-line SFC) — backend-only here.

Roadmap: DT-OPS-03 (backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)