### PR TITLE
fix(auth): whitelist DingTalk container login

### DIFF
--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -15,6 +15,7 @@ const AUTH_WHITELIST = [
   '/api/auth/dev-token',
   '/api/auth/dingtalk/launch',
   '/api/auth/dingtalk/callback',
+  '/api/auth/dingtalk/container',
   '/api/plugins',
   '/api/v2/hello',
   '/api/v2/rpc-test',

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -35,6 +35,10 @@ describe('jwt auth whitelist', () => {
     expect(isWhitelisted('/api/auth/dingtalk/callback')).toBe(true)
   })
 
+  it('allows DingTalk container login without a bearer token', () => {
+    expect(isWhitelisted('/api/auth/dingtalk/container')).toBe(true)
+  })
+
   it('allows public form context when a public token is present', () => {
     expect(isPublicFormAuthBypass({
       method: 'GET',


### PR DESCRIPTION
## Summary
- allow `/api/auth/dingtalk/container` through the global JWT whitelist, matching the E1 container-login route's unauthenticated authCode exchange contract
- add a whitelist unit test so the route cannot regress behind the bearer-token gate again

## Why
During E4 HTTPS/tunnel setup, `DINGTALK_CONTAINER_LOGIN_ENABLED=true` was present in the backend container, but `POST /api/auth/dingtalk/container` returned `401 Missing Bearer token` before reaching the E1 route. The route implementation exists and is flag-gated, but the global whitelist only covered DingTalk launch/callback.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/jwt-middleware.test.ts --reporter=dot` → 18/18
- `pnpm --filter @metasheet/core-backend type-check`
