### PR TITLE
ci(multitable): web-guard path-filter covers reset/restore/history components + specs

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -51,6 +51,22 @@ on:
       - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
       - 'apps/web/tests/multitable-reset-tsource-picker.spec.ts'
       - 'apps/web/src/multitable/components/ResetToPointPicker.vue'
+      # R5c CI-residual fix: ResetConfirmDialog (destructive-reset gating: typed 'reset' + deleted-count ack
+      # before confirm enables) and its dedicated spec were already in the `vitest run` filter below but had
+      # NO path trigger — a PR touching only ResetConfirmDialog.vue ran no web-guard at all. Same gap found on
+      # sibling restore/revert specs: multitable-config-history-modal.spec.ts (MetaConfigHistoryModal.vue's own
+      # spec — the .vue source was covered but not this spec), multitable-restore-batch-dialog.spec.ts + the two
+      # narrowly-scoped utils it locks (buildBatchExpectedVersions preview-time-version safety,
+      # resolveSelectionLabels), and multitable-config-revert-refresh.spec.ts (T9-W-3 post-revert
+      # meta-then-grid reload contract).
+      - 'apps/web/src/multitable/components/ResetConfirmDialog.vue'
+      - 'apps/web/tests/multitable-reset-confirm-dialog.spec.ts'
+      - 'apps/web/tests/multitable-config-history-modal.spec.ts'
+      - 'apps/web/tests/multitable-restore-batch-dialog.spec.ts'
+      - 'apps/web/src/multitable/utils/batch-restore-expected-versions.ts'
+      - 'apps/web/src/multitable/utils/batch-restore-labels.ts'
+      - 'apps/web/src/multitable/views/config-revert-refresh.ts'
+      - 'apps/web/tests/multitable-config-revert-refresh.spec.ts'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
       - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
       - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
@@ -121,6 +137,22 @@ on:
       - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
       - 'apps/web/tests/multitable-reset-tsource-picker.spec.ts'
       - 'apps/web/src/multitable/components/ResetToPointPicker.vue'
+      # R5c CI-residual fix: ResetConfirmDialog (destructive-reset gating: typed 'reset' + deleted-count ack
+      # before confirm enables) and its dedicated spec were already in the `vitest run` filter below but had
+      # NO path trigger — a PR touching only ResetConfirmDialog.vue ran no web-guard at all. Same gap found on
+      # sibling restore/revert specs: multitable-config-history-modal.spec.ts (MetaConfigHistoryModal.vue's own
+      # spec — the .vue source was covered but not this spec), multitable-restore-batch-dialog.spec.ts + the two
+      # narrowly-scoped utils it locks (buildBatchExpectedVersions preview-time-version safety,
+      # resolveSelectionLabels), and multitable-config-revert-refresh.spec.ts (T9-W-3 post-revert
+      # meta-then-grid reload contract).
+      - 'apps/web/src/multitable/components/ResetConfirmDialog.vue'
+      - 'apps/web/tests/multitable-reset-confirm-dialog.spec.ts'
+      - 'apps/web/tests/multitable-config-history-modal.spec.ts'
+      - 'apps/web/tests/multitable-restore-batch-dialog.spec.ts'
+      - 'apps/web/src/multitable/utils/batch-restore-expected-versions.ts'
+      - 'apps/web/src/multitable/utils/batch-restore-labels.ts'
+      - 'apps/web/src/multitable/views/config-revert-refresh.ts'
+      - 'apps/web/tests/multitable-config-revert-refresh.spec.ts'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
       - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
       - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'


### PR DESCRIPTION
## Residual verified: real

R5c flagged that `ResetConfirmDialog.vue` + its spec weren't in `multitable-web-guard.yml`'s path-filter, so a PR touching only that dialog would not trigger the guard. Confirmed by direct grep against the current `on.pull_request.paths` / `on.push.paths` lists (both 0 matches for `ResetConfirmDialog.vue` and `multitable-reset-confirm-dialog.spec.ts`), even though the job's `vitest run` filter (the `run:` step) already includes `multitable-reset-confirm-dialog` as a test-name substring — i.e. the job was already *designed* to test this dialog, it just never gets invoked when only the dialog changes.

## Scope: same class of gap on 4 sibling files, fixed together

Walked every reset/restore/history related component named in the ask (`ResetToPointPicker.vue`, `HistoryCenterModal.vue`, `MetaConfigHistoryModal.vue`, `RestorePreviewDialog.vue`) plus their neighbors, cross-referencing three lists: (a) path-filter entries, (b) the job's fixed `vitest run` test-name filter, (c) what each spec actually `import`s. Found and fixed:

| File | Before | After |
|---|---|---|
| `apps/web/src/multitable/components/ResetConfirmDialog.vue` | not triggered | triggered |
| `apps/web/tests/multitable-reset-confirm-dialog.spec.ts` | not triggered | triggered |
| `apps/web/tests/multitable-config-history-modal.spec.ts` (MetaConfigHistoryModal.vue's own spec — the `.vue` was already covered, the spec wasn't) | not triggered | triggered |
| `apps/web/tests/multitable-restore-batch-dialog.spec.ts` | not triggered | triggered |
| `apps/web/src/multitable/utils/batch-restore-expected-versions.ts` (buildBatchExpectedVersions — preview-time-version safety, locked by the spec above) | not triggered | triggered |
| `apps/web/src/multitable/utils/batch-restore-labels.ts` (resolveSelectionLabels, same spec) | not triggered | triggered |
| `apps/web/src/multitable/views/config-revert-refresh.ts` (T9-W-3 post-revert meta-then-grid reload contract) | not triggered | triggered |
| `apps/web/tests/multitable-config-revert-refresh.spec.ts` | not triggered | triggered |

All 8 are **exact literal paths** (no glob wildcards) added identically to both the `pull_request.paths` and `push.paths` blocks (verified byte-identical before/after via diff + a YAML parse check confirming both lists still match and contain all 8 entries).

## Explicitly checked and NOT touched (to avoid noise / avoid job-step scope)

- **`ResetToPointPicker.vue` / `HistoryCenterModal.vue` / `RestorePreviewDialog.vue`** (source files): already covered by existing path entries — no action needed.
- **`HistoryCenterModal.vue`'s own dedicated specs** (`multitable-history-center-ai-shortcut-label.spec.ts`, `multitable-history-center-inline-diff.spec.ts`, `multitable-history-center-pinned-batch-deeplink.spec.ts` — the specs that actually `import HistoryCenterModal`) are **not** in the job's `vitest run` filter at all, so adding path triggers for them would fire the guard without running the relevant assertions (pure noise). Fixing that requires editing the job step's test filter, which is out of scope per the task instructions ("don't touch job steps/test content, only path-filter"). Flagging as a separate, deeper gap for a future PR.
- Same reasoning excludes the three `*-migration.spec.ts` files (`meta-restore-batch-dialog-migration.spec.ts`, `meta-restore-preview-dialog-migration.spec.ts`, `reset-to-point-picker-migration.spec.ts`): their components are already triggered via the primary specs, but these migration-specific specs aren't in the `vitest run` filter either.
- **`apps/web/composables/useLocale.ts`** (imported by `multitable-reset-confirm-dialog.spec.ts` and others): imported by 103 src files / 134 test files repo-wide — adding it would make this *targeted* guard fire on nearly every FE change, defeating the point of a scoped gate. Deliberately excluded, consistent with how the file already omits this composable from every other dialog's trigger list.

## Verification

- `python3 -c "import yaml; ..."` parse of the updated workflow: both `pull_request.paths` and `push.paths` lists have 70 entries and are still identical to each other; all 8 new paths present in both.
- `git ls-files --error-unmatch` confirms each of the 8 new literal paths exists exactly as written — no typos, no accidental directory-wide globs.
- No job steps, test filters, or run commands touched — diff is confined to the two `paths:` blocks.
- This PR itself touches `.github/workflows/multitable-web-guard.yml`, which is already in the filter, so the guard runs on this very PR — green here is live proof the additions don't break anything.

Not merging; not arming auto-merge — leaving for review per the standing PR review/merge model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)