### PR TITLE
fix(approval): G-B2-12 — 催办 gates per row, with session 已催办 memory

### DIFF
--- a/apps/web/src/approvals/urgeButtonState.ts
+++ b/apps/web/src/approvals/urgeButtonState.ts
@@ -1,0 +1,37 @@
+/**
+ * G-B2-12 — per-row 催办 button state.
+ *
+ * The old rule gated EVERY row's button on a single in-flight id, so nudging one request froze the
+ * button on every other row. 催办 is a low-risk nudge (the server rate-limits it to 1 per
+ * instance/user/hour), so unlike the inline approve/reject hot path — where racing two rows mutates
+ * two approvals — concurrent per-row reminds are safe. Each row is therefore gated only by its OWN
+ * in-flight request, plus a session memory of rows already nudged.
+ *
+ * `reminded` is deliberately session-scoped (not persisted): the authoritative "you already nudged
+ * this" lives server-side as an hourly window. A localStorage copy would keep claiming 已催办 long
+ * after that window expired — a stale claim is worse than no claim.
+ */
+export interface UrgeButtonState {
+  disabled: boolean
+  loading: boolean
+  label: string
+  /** Native tooltip; empty when there is nothing honest to add. */
+  title: string
+}
+
+export function urgeButtonState(
+  rowId: string,
+  remindingIds: ReadonlySet<string>,
+  remindedIds: ReadonlySet<string>,
+): UrgeButtonState {
+  const loading = remindingIds.has(rowId)
+  // While this row's own request is in flight, it renders as loading — not as 已催办 — even though
+  // a success may have already recorded it (the two sets overlap for one synchronous tick).
+  const reminded = !loading && remindedIds.has(rowId)
+  return {
+    loading,
+    disabled: loading || reminded,
+    label: reminded ? '已催办' : '催办',
+    title: reminded ? '本次已催办（服务端每小时限一次）' : '',
+  }
+}

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -254,12 +254,13 @@
               v-if="row.status === 'pending'"
               type="primary"
               link
-              :loading="remindingId === row.id"
-              :disabled="remindingId !== null"
+              :loading="urgeState(row.id).loading"
+              :disabled="urgeState(row.id).disabled"
+              :title="urgeState(row.id).title"
               :data-testid="`approval-urge-${row.id}`"
               @click.stop="handleUrge(row)"
             >
-              催办
+              {{ urgeState(row.id).label }}
             </el-button>
           </template>
         </ApprovalCenterTable>
@@ -458,6 +459,7 @@ import type { UnifiedApprovalDTO, ApprovalStatus } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { dispatchAction, getPendingCount, markAllApprovalsRead, remindApproval } from '../../approvals/api'
+import { urgeButtonState } from '../../approvals/urgeButtonState'
 import { runApprovalBatchAction, type ApprovalBatchActionResult } from '../../approvals/useApprovalBatchActions'
 import { useApprovalCountsRealtime, type ApprovalCountsUpdatedPayload } from '../../approvals/useApprovalCountsRealtime'
 import { useApprovalListFieldSummary } from '../../approvals/useApprovalListFieldSummary'
@@ -532,7 +534,16 @@ const batchRunning = ref(false)
 const batchAction = ref<'approve' | 'reject' | null>(null)
 const batchRejectDialogVisible = ref(false)
 const batchRejectComment = ref('')
-const remindingId = ref<string | null>(null)
+// G-B2-12: 催办 is gated PER ROW (a nudge on one request must not freeze every other row's button).
+// `remindingIds` = this row's own request is in flight; `remindedIds` = session memory of rows
+// already nudged. Both are reactive Sets; see urgeButtonState for the precedence + why the memory
+// is deliberately not persisted.
+const remindingIds = ref<Set<string>>(new Set())
+const remindedIds = ref<Set<string>>(new Set())
+
+function urgeState(rowId: string) {
+  return urgeButtonState(rowId, remindingIds.value, remindedIds.value)
+}
 
 // B1-03: 已等待 aging severity class — the 我发起的 tab's inline hint next to 催办 (same
 // warn/urgent palette as ApprovalCenterTable's own internal 已等待 column, kept separate since
@@ -687,8 +698,10 @@ async function handleBatchReject(): Promise<void> {
 
 // ── B1-03 (part 1): inline approve/reject hot path on the pending list ─────
 // `inlineApprovingId` gates every row's approve button (not just the clicked row) while a
-// request is in flight — mirrors the existing `remindingId`-gates-every-催办-button convention
-// below, so a slow request can't be raced by mashing a different row.
+// request is in flight, so a slow request can't be raced by mashing a different row. This global
+// gate is deliberate HERE and NOT shared with 催办 (G-B2-12): approve/reject MUTATES an approval,
+// so racing two rows is a correctness hazard, whereas 催办 is a server-rate-limited nudge and is
+// gated per row.
 const inlineApprovingId = ref<string | null>(null)
 
 async function handleInlineApprove(row: UnifiedApprovalDTO): Promise<void> {
@@ -748,13 +761,18 @@ async function submitRowReject(): Promise<void> {
 }
 
 async function handleUrge(row: UnifiedApprovalDTO): Promise<void> {
-  if (remindingId.value) return
-  remindingId.value = row.id
+  // Only this row's own state gates it — other rows may be nudged concurrently.
+  if (remindingIds.value.has(row.id) || remindedIds.value.has(row.id)) return
+  remindingIds.value.add(row.id)
   try {
     const result = await remindApproval(row.id)
     if (result.ok) {
+      remindedIds.value.add(row.id)
       ElMessage.success('已发送催办提醒')
     } else if (result.status === 429) {
+      // 429 means the server's hourly window already holds a nudge for this instance+user, so the
+      // row genuinely IS 已催办 — recording it stops the user re-clicking into the same rejection.
+      remindedIds.value.add(row.id)
       const retry = result.error.retryAfterSeconds
       ElMessage.warning(retry ? `催办过于频繁，请 ${Math.ceil(retry / 60)} 分钟后再试` : '催办过于频繁，请稍后再试')
     } else {
@@ -763,7 +781,7 @@ async function handleUrge(row: UnifiedApprovalDTO): Promise<void> {
   } catch {
     ElMessage.error('催办失败，请重试')
   } finally {
-    remindingId.value = null
+    remindingIds.value.delete(row.id)
   }
 }
 

--- a/apps/web/tests/approval-urge-button-state.test.ts
+++ b/apps/web/tests/approval-urge-button-state.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { urgeButtonState } from '../src/approvals/urgeButtonState'
+
+// G-B2-12 — the regression this matrix exists to catch: a request in flight on ONE row must not
+// disable any OTHER row's 催办 button (the old `remindingId !== null` gate did exactly that).
+
+const NONE: ReadonlySet<string> = new Set()
+
+describe('urgeButtonState', () => {
+  it('idle row: enabled, not loading, plain label', () => {
+    expect(urgeButtonState('r1', NONE, NONE)).toEqual({ disabled: false, loading: false, label: '催办', title: '' })
+  })
+
+  it('the in-flight row itself: loading + disabled', () => {
+    const state = urgeButtonState('r1', new Set(['r1']), NONE)
+    expect(state.loading).toBe(true)
+    expect(state.disabled).toBe(true)
+    expect(state.label).toBe('催办')
+  })
+
+  it('REGRESSION: another row stays ENABLED while a different row is in flight', () => {
+    const state = urgeButtonState('r2', new Set(['r1']), NONE)
+    expect(state.disabled).toBe(false)
+    expect(state.loading).toBe(false)
+  })
+
+  it('concurrent in-flight rows each render as loading, and a third stays enabled', () => {
+    const inFlight = new Set(['r1', 'r2'])
+    expect(urgeButtonState('r1', inFlight, NONE).loading).toBe(true)
+    expect(urgeButtonState('r2', inFlight, NONE).loading).toBe(true)
+    expect(urgeButtonState('r3', inFlight, NONE).disabled).toBe(false)
+  })
+
+  it('already-reminded row: disabled, relabelled, and says why', () => {
+    const state = urgeButtonState('r1', NONE, new Set(['r1']))
+    expect(state).toEqual({
+      disabled: true,
+      loading: false,
+      label: '已催办',
+      title: '本次已催办（服务端每小时限一次）',
+    })
+  })
+
+  it('a reminded row does not disable other rows', () => {
+    expect(urgeButtonState('r2', NONE, new Set(['r1'])).disabled).toBe(false)
+  })
+
+  it('in-flight wins over reminded during the overlapping tick (renders loading, not 已催办)', () => {
+    const state = urgeButtonState('r1', new Set(['r1']), new Set(['r1']))
+    expect(state.loading).toBe(true)
+    expect(state.label).toBe('催办')
+    expect(state.title).toBe('')
+  })
+})


### PR DESCRIPTION
## 缺陷（审计 G-B2-12：「一条在途禁用所有行属误伤」）

`ApprovalCenterView.vue:258` `:disabled="remindingId !== null"` —— 任意一行催办在途，**所有行**的按钮都被禁用。
更糟的是 `handleUrge` 还有全局单飞守卫 `if (remindingId.value) return`，所以哪怕把别的行放开，点了也会**静默无反应**。

## 修法
催办是服务端限流的**提醒**（1次/实例/用户/小时），与 inline approve/reject **不同**（后者会改审批状态，跨行竞态是正确性风险）。因此按行并发催办是安全的：

- 在途 id 用 Set 跟踪，每行只被**自己**的请求门住；
- 会话内记忆已催办行 → 「已催办」态 + 原因 tooltip；
- **429 也记入**：服务端小时窗口里确实已有一次催办，让用户反复点进同一个拒绝没有意义；
- 记忆**故意不持久化**：权威窗口在服务端，localStorage 副本会在窗口过期后继续谎称「已催办」——**过期的断言比没有断言更糟**；
- 顺手修正了那条用「催办的全局门约定」为 `inlineApprovingId` 全局门背书的注释——那个全局门在 approve 处是**刻意**的，现在明确不再共享。

## 验证
- 按钮态抽为纯函数 `urgeButtonState.ts` + **7 例矩阵**（在途行/他行/并发在途/已催办/已催办不影响他行/重叠 tick 优先级）。
- **突变验证**：把 `disabled` 改回全局语义 → REGRESSION 用例**变红**；还原 → 7/7 绿。（首次突变因替换未生效而假绿，已重做并校验文件确实被改。）
- vue-tsc 0 error；既有 approval-center 六套 **54/54** 绿。

移动端催办**不做**（ballot Q8 复议项）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)