### PR TITLE
docs(multitable): 4c-2 wave verification + destruction-path gap audit (C2 covers 1 of 4 delete paths; PIT pollution defect)

### DIFF
--- a/docs/development/multitable-global-history-4c2-forward-tombstone-capture-design-lock-20260707.md
+++ b/docs/development/multitable-global-history-4c2-forward-tombstone-capture-design-lock-20260707.md
@@ -21,6 +21,17 @@
 | 记录硬删:行值+出边 | `record-service.ts:804` snapshot + `:835-840` trash | ✅ `meta_records_trash` + delete revision |
 | 记录硬删:**入边** | `record-service.ts:808` `DELETE FROM meta_links WHERE record_id=$1 OR foreign_record_id=$1` | **无**(4c-3 record-undelete 2b 的阻塞缺口) |
 
+> **⚠️ impl 期审计修订(2026-07-08):上表只列了「治理路径」,现补齐全部四条 `DELETE FROM meta_records` 路径的实情。** C2「flag on ⇒ 凡销毁必已捕获」**仅对第 1 条成立**:
+
+| # | 记录硬删路径 | delete revision | trash | tombstone(flag-on) | PIT as-of-T |
+|---|---|---|---|---|---|
+| 1 | `record-service.ts` `deleteRecord`(本锁覆盖) | ✓ | ✓ | ✓ inbound | ✅ |
+| 2 | `univer-meta.ts:10066` PIT-reset 内联删除 | ✓ | ✓ | **✗**(无 anchor;拟由 4c-3 补) | ✅ |
+| 3 | `records.ts:565` plugin-SDK | **✗** | **✗** | ✗ | ❌ 谎报存活 |
+| 4 | `automation-executor.ts:2269` automation `delete_record` | **✗** | **✗** | **✗** | ❌ 谎报存活 |
+
+第 3、4 条不写 delete revision,而 `reconstructRecordsAtT` 纯从 `meta_record_revisions` 派生存在性 ⇒ **被它们删除的记录在任意 T 都被 PIT 判为「仍存在」**。这是本线核心承诺的缺陷,详见 `…destruction-path-coverage-gap-audit-20260708.md`(含 owner 决策菜单 D-1..D-5)。**本锁不修第 2/3/4 条**;4c-3 的可达边界因此如实收窄为「路径 1(+ 若 D-3 采纳则含路径 2)」。
+
 可照抄蓝本 = `meta_records_trash`(migration `zzzz20260617120000_create_meta_records_trash.ts:19-46`):独立表(零热读路径改动)、same-txn INSERT-before-DELETE、`isUndefinedTableError` 兼容守卫、surrogate PK、original timestamps、retention 默认关。
 
 ## 2. 捕获模型(锁定)
@@ -82,6 +93,12 @@
 
 sheet 删除级联(`univer-meta.ts:11927`)、跨 base、任何 FE 面(独立 gated 项)、`meta_records_trash` 的 retention 接入、4d(不可能项,永不承诺)。
 
-**第二删除路径(impl 期审计 P3-1,显式出界):** plugin-SDK `records.ts` 的 `deleteRecord`(经 `plugin-scope.ts` 到达)硬删 `meta_links`+`meta_records`,**今天既无 trash/revision 也无 tombstone**,`MULTITABLE_TOMBSTONE_CAPTURE_ENABLED` 对其不生效。C2「flag on ⇒ 凡销毁必已捕获」的口径**仅覆盖** `record-service.deleteRecord` 与 `dropFieldCascade` 两条路由——该路由今日即不可恢复(非 4c-2 引入的回归)。给它 trash+capture 对等属**独立后续 rung**,非 4c-2。已在 `records.ts:556` 就地注释标注。
+**其余记录硬删路径(impl 期审计,显式出界):** C2「flag on ⇒ 凡销毁必已捕获」的口径**仅覆盖** `record-service.deleteRecord` 与 `dropFieldCascade`。另外三条路径均**不在**本锁范围(且均非 4c-2 引入的回归):
+
+- `records.ts:565` plugin-SDK `deleteRecord`(经 `plugin-scope.ts`):无 trash / 无 revision / 无 tombstone(已在 `records.ts` 就地注释)。
+- `automation-executor.ts:2269` automation `delete_record`:**已上线、无 flag、有授权 UI**,无 trash / 无 revision / 无 tombstone。
+- `univer-meta.ts:10066` PIT-reset 内联删除:有 trash + delete revision,**无 tombstone**(其 `recordRecordRevision` 未预生成 id,故无 anchor 可挂)。
+
+前两条不写 delete revision ⇒ 经它们删除的记录被 `reconstructRecordsAtT` 永久判为「仍存在」(PIT 污染)。三条的定性、后果与 owner 决策菜单见 `…destruction-path-coverage-gap-audit-20260708.md`。给它们 trash/capture/revision 对等属**独立 rung**,非 4c-2。
 
 **解锁词示例:「ratify 4c-2」(可附修改意见)。**

--- a/docs/development/multitable-global-history-4c2-impl-wave-verification-20260708.md
+++ b/docs/development/multitable-global-history-4c2-impl-wave-verification-20260708.md
@@ -1,0 +1,52 @@
+# Multitable Global History — 4c-2 impl wave 设计+验证记录(2026-07-08)
+
+**性质:** R6 §5 承诺的「每 wave 设计+验证 MD」。本文对应 **4c-2 forward tombstone-capture 的 RATIFIED 实现**(PR #3901,merged `023385499`),flag 默认 off。
+**上游:** design-lock `…4c2-forward-tombstone-capture-design-lock-20260707.md`(owner ratify 2026-07-08,见 `…r6-ratification-decision-record-20260708.md` §1)。
+
+## 1. 落地内容(逐 § 对锁)
+
+| 锁 § | 实现 | 位置 |
+|---|---|---|
+| §2 两表 | `meta_field_value_tombstones` / `meta_link_tombstones`(append-only,surrogate uuid PK,reason CHECK,独立表零热读改动) | migration `zzzz20260708090000_create_meta_tombstone_tables.ts` |
+| §2 捕获点 1 | field-delete:列值 + 该 field 全部 link 边 + auto-number `last_value` | `dropFieldCascade`(`univer-meta.ts`) |
+| §2 捕获点 2 | record-delete:**仅 inbound 边**(`foreign_record_id=$1`) | `deleteRecord`(`record-service.ts`) |
+| §2 捕获点 3 | lossy-retype pre-image:**预留 seam,已单测、未接线**(4c-1 的活) | `captureLossyRetypePreImageRows`(`tombstone-capture.ts`) |
+| §3 flag + cap | `MULTITABLE_TOMBSTONE_CAPTURE_ENABLED`(默认 off)/ `MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS`(默认 50000)→ 超 cap **拒绝破坏操作本身**(422,fail-closed) | `tombstone-capture.ts` + 3 条路由 |
+| §4 R1 | field-undelete 补水:值(仅 `NOT (data ? key)` 的行)/ 边(两端记录均存活)/ 序列 | `recreateFieldFromConfig` |
+| §5 C6 | 两表接入 `meta-revision-retention.ts` 同一 knob,**keep-days**、bounded batch、默认 off | `meta-revision-retention.ts` |
+
+### 1.1 承重正确性事实(本 wave 最重要的一条)
+
+**field-delete 的捕获必须早于 `DELETE FROM meta_fields` 本身**,而不是早于其后那几条显式 DELETE:
+`meta_links.field_id` 与 `meta_field_auto_number_sequences.field_id` 都是 **`ON DELETE CASCADE`**(`zzzz20260404153000_repair_meta_core_schema.ts:34`),因此删字段行时数据库先把边与序列级联清掉。捕获若置于其后,**会静默捕获到空集**——表面成功、实际零恢复力。实现期由车道自身发现,审阅期以 mutation 独立复证(移除该前置捕获 → 值/边/序列全部丢失)。
+
+## 2. 验证(独立复跑,不采信 PR 自证)
+
+**对抗审阅判定:APPROVE-with-hardening — 0 P1 / 0 P2**(MD:`/tmp/pr3901-4c2-review-claude-20260708.md`)。
+
+审阅方独立执行:
+- 迁移:fresh bootstrap 干净 + **down→up 往返**干净 + 幂等(`IF NOT EXISTS`)。
+- 单测 16/16(`tombstone-capture` 5 + `meta-revision-retention` 11)。
+- realdb 23/23(field-capture 8 / field-rehydrate 3 / record-capture 6 / retention 6)。
+- 邻居回归 35/35(undelete-config + record-recycle-bin + config-restore)。
+- **独立 mutation ×5,每次还原后 `git diff` 空**:neuter `insertFieldValueTombstones` / `insertFieldLinkTombstones` / `readAutoNumberNextValue` / `insertInboundLinkTombstones` / **`assertWithinCaptureCap`**(审阅方自加,PR 未测)→ 每次恰好对应 golden 变红。**每个捕获 INSERT 与 fail-closed cap 守卫都被 golden 钉死。**
+
+主会话(Opus)闸门复核补充:
+- `tsc --noEmit` 干净;`multitable-record-lock-guard.guard.test.ts` 4/4;rehydrate golden 3/3(带新增 `NOT EXISTS` 后仍绿)。
+
+### 2.1 审阅后折入的加固(合并前)
+
+| 项 | 内容 |
+|---|---|
+| P3-2 | link 补水 INSERT 增加 **`NOT EXISTS`(edge triple)** 幂等守卫。`meta_links` 在 `(field_id, record_id, foreign_record_id)` 上**没有唯一约束**(PK 只是随机 `id`),既有 `ON CONFLICT DO NOTHING` 只守 PK。当前流程不可达,但 **4c-3 的 inbound 重放会让它成为真 bug**——故先行加固。 |
+| P3-1 | plugin-SDK `records.ts` 的 `deleteRecord` 就地注释为**不在 tombstone 范围**;锁 §8 同步点名。 |
+| NIT-2 | self-link 免疫机制注释更正:免疫来自「inbound 捕获从不被重放」,**不是** outbound 的 `ON CONFLICT`(它只守随机 PK)。 |
+| CI | rank-8 结构守卫要求每个 `meta_records` UPDATE/DELETE 站点带 lock disposition;R1 补水 UPDATE 补 `// lock-exempt: field-undelete schema op`(镜像 field-delete drop 先例)。 |
+
+## 3. 诚实缺口(本 wave 未做/未验)
+
+1. **G6(lossy-retype 捕获 golden)未做** —— 捕获点 3 是**预留未接线** seam,由 4c-1 接入并携带其 golden(L11)。
+2. **跨 sheet inbound 捕获未测** —— 唯一的 record-delete 捕获 golden 把 A/B/C 放在**同一 sheet**;而 link 字段的常态是跨 sheet。且 `meta_link_tombstones.sheet_id` 在 `reason='record_delete'` 行上存的是**被删记录的 sheet**,`field_id`/`record_id` 却属于**源记录的 sheet** —— 任何按 `sheet_id` 过滤/清理/鉴权的逻辑对跨 sheet 链接都是错的。**4c-3 必须只按 `source_revision_id` 锚定,永不按 `sheet_id` 过滤。**
+3. **C2 的真实覆盖面 = 4 条记录硬删路径中的 1 条** —— 见同批 `…destruction-path-coverage-gap-audit-20260708.md`;锁 §1/§8 已按实情修订。
+4. 50k cap 的规模/性能、on-prem 包构建未验。
+5. CI 噪声:共享 DB 大 bundle(单 vitest × ~40 文件 × 单 pg)出现过一次与本 PR **无关**的 `oapi2a-comments-write` 红。已判定为调度扰动 flake:该测试隔离下 4/4 绿、与本 PR 4 个新 realdb 文件同跑 27/27 绿、main 该 workflow 近 8 次全绿;重跑后消失。**教训:此 bundle 里与改动无关的红,先隔离复跑再归因。**

--- a/docs/development/multitable-global-history-destruction-path-coverage-gap-audit-20260708.md
+++ b/docs/development/multitable-global-history-destruction-path-coverage-gap-audit-20260708.md
@@ -47,6 +47,7 @@ SELECT DISTINCT ON (record_id) record_id, action, snapshot, version
 - **D-3(4c-3 内解决,已在 4c-3 锁提案):** 给 PIT-reset 内联删除(路径 2)补 tombstone 捕获(它已写 trash+revision,只差 anchor 与捕获调用)。
 - **D-4(文档诚实,已随本轮执行):** 4c-2 锁 §1/§8 补齐四条路径实情——**已在同批 PR 落地**,C2 口径明确限定为路径 1(+ 4c-3 后含路径 2)。
 - **D-5:** retention 地板 / 恢复面 `inboundEdgesRecoverable` 信号 —— 已写入 4c-3 锁,随 4c-3 impl 落地。
+- **D-6(4c-1 审阅期确证的既有 latent bug,建议单开 rung):** **Tier-1/2 config-restore execute 的成功路径从不调用 `invalidateFieldCache`**(命中数 = 0),而 uncreate / undelete / 4c-1 lossy 三条分支都调了。`metaFieldCache` **无 TTL、进程内常驻**,并经 `loadSheetFields` 喂给**记录写路径** ⇒ **一次 Tier-2 schema-only retype revert 之后,同一进程会继续用 revert 前的 type/property 去 coerce 后续写入。** 这是真实的缓存陈旧缺陷(非 4c-1 引入;4c-1 分支已自行失效)。**不塞进破坏性面的 PR**,建议单开修复 rung。
 
 **未取的默认:** 本文不替 owner 选择 D-1/D-2。在 owner 裁决前,4c-3 的锁文以「可达边界仅路径 1(+D-3 后含路径 2)」如实收窄,不虚构恢复力。
 

--- a/docs/development/multitable-global-history-destruction-path-coverage-gap-audit-20260708.md
+++ b/docs/development/multitable-global-history-destruction-path-coverage-gap-audit-20260708.md
@@ -1,0 +1,55 @@
+# Multitable Global History — 记录销毁路径覆盖 GAP AUDIT + owner 决策菜单(2026-07-08)
+
+**性质:** 审计发现 + 决策菜单。**不授权任何实现。** 本文起因:4c-3 design-lock 起草前的地基调研发现——**C2「flag on ⇒ 凡销毁必已捕获」在文档上看似完备,在代码上只覆盖 4 条记录硬删路径中的 1 条**;其中两条还导致 PIT/as-of-T 状态**长期错误**。全部结论由主会话逐条对 `origin/main` primary-source 核实(非调研代理转述)。
+
+## 1. 事实:四条 `DELETE FROM meta_records` 路径
+
+| # | 路径 | 清 link 双向 | delete revision | trash | tombstone(flag-on) | 可恢复性 | PIT as-of-T 正确性 |
+|---|---|---|---|---|---|---|---|
+| 1 | `record-service.ts:867` `deleteRecord`(治理路径) | ✓ | ✓ | ✓ | ✓ inbound | 完整(2a;inbound 待 4c-3) | ✅ 正确 |
+| 2 | `univer-meta.ts:10066` **PIT-reset 内联删除** | ✓ | ✓(`action:'delete'`) | ✓ | **✗** | 记录可恢复,**inbound 边永久丢失** | ✅ 正确 |
+| 3 | `records.ts:565` plugin-SDK `deleteRecord` | ✓ | **✗** | **✗** | ✗ | **不可恢复** | ❌ **错误** |
+| 4 | `automation-executor.ts:2269` automation `delete_record` | ✓ | **✗** | **✗** | **✗** | **不可恢复** | ❌ **错误** |
+
+核实点:`meta_links` 的 `record_id` 有 FK(`ON DELETE CASCADE`)、`foreign_record_id` **无 FK**,故四条路径都必须显式 `DELETE FROM meta_links WHERE record_id=$1 OR foreign_record_id=$1`——**四条都清掉了 inbound 边**,只有路径 1 在清之前捕获。
+
+## 2. 【P1 级缺陷】automation / plugin-SDK 删除污染 PIT as-of-T 状态
+
+`reconstructRecordsAtT`(`record-reconstructor.ts`)**纯粹从 `meta_record_revisions` 派生记录存在性**:
+
+```sql
+SELECT DISTINCT ON (record_id) record_id, action, snapshot, version
+  FROM meta_record_revisions
+ WHERE sheet_id = $1 AND created_at <= $2
+ ORDER BY record_id, created_at DESC, version DESC, id DESC
+```
+
+若某条删除路径**不写 delete revision**,该记录的最后一条 revision 仍是 create/update ⇒ **对任意 T,PIT 都判定它「仍然存在」并把旧快照喂给所有 PIT 消费者**(PIT view / Reset preview / Reset execute / 记录重建)。
+
+- **automation `delete_record` 是已上线、无 flag、有授权 UI 的一等公民动作**(automation action 注册 + 规则编辑器暴露)。用它删掉的记录:① 永久不可恢复(无 trash);② **在 Global History 与 PIT 里永远"活着"**。
+- plugin-SDK 删除同理(该路径已在 4c-2 锁 §8 记为出界,但**其 PIT 污染后果此前未被记录**)。
+- 设计意图旁证:`record-history-service.ts` 的 `RecordRevisionSource` 明确声明 `'automation' | 'public-form' | 'plugin'` 三个枚举位,**public-form 与 plugin 的发射点为 0**——原设计本就打算覆盖它们,从未落地。
+
+**定性:这不是"缺特性",是本线核心承诺(时点重建正确性)的缺陷。** 它同时**限定了 4c-3 的可达边界**:4c-3 只能为「经 `record-service.deleteRecord` 且捕获 flag 开启期间」删除的记录重建 inbound 边。
+
+## 3. 其余确凿残差
+
+1. **retention 不对称 → 静默部分恢复。** `meta_records_trash` **从不被清理**(唯一的 DELETE 在 restore 成功时,`record-service.ts:1054`),而两张 tombstone 表在同一个 `MULTITABLE_META_REVISION_RETENTION_ENABLED` 旋钮下按 keep-days 老化、**无地板**。后果:一条 trash 记录永远可恢复,但其 inbound tombstone 已被清 ⇒ **restore 成功、inbound 边静默缺失、无任何信号**。(4c-3 必须解决:给 sweep 加「不清理仍被 live trash 行引用的 tombstone」地板,或在恢复面显式暴露 `inboundEdgesRecoverable=false`。)
+2. **单旋钮耦合。** 开启 retention 会同时老化 4c-1 / 4c-3 恢复力所依赖的 tombstone;operator flag checklist 未列出新 flag 与该耦合。
+3. **撕裂的 tombstone 集合(结构性,低可达)。** retention sweep 的内层 `SELECT id … WHERE created_at < cutoff LIMIT batch` 无 `ORDER BY`、不按 anchor 分组;同一次捕获的所有行 `created_at` 相同,理论上可被部分裁剪 ⇒ 半个捕获集。
+4. **PIT resurrect 是第二个复活面**(`univer-meta.ts:9767` 附近),同样只重放 outbound。4c-3 若只改 `restoreRecord`,两个复活面语义将分叉。
+5. **`meta_records_trash` 无 `delete_revision_id`**(逐列核实),而 tombstone 以 `source_revision_id` 锚定 ⇒ 4c-3 的**硬阻塞**(见 4c-3 锁 §2 的解法)。
+
+## 4. owner 决策菜单(本文不实现任何一项)
+
+- **D-1(推荐,纯缺陷修复):** 让 automation / plugin-SDK 的删除**发射 delete revision**(`source:'automation'` / `'plugin'`,枚举位已存在)。**只修 PIT 正确性,不改可恢复性**(不加 trash)。用户可见行为变化仅为「Global History 如实记录该删除、PIT 不再谎报记录存活」。难度中(automation 走 raw-SQL 车道)。**属跨车道改动**(automation-executor 归自动化线),需路由到该线会话或 owner 点名。
+- **D-2(更大,产品决定):** 再给这两条路径补 `meta_records_trash` + tombstone 捕获 ⇒ 删除变为可恢复、并进回收站。**改变产品语义**,需 owner 签核。
+- **D-3(4c-3 内解决,已在 4c-3 锁提案):** 给 PIT-reset 内联删除(路径 2)补 tombstone 捕获(它已写 trash+revision,只差 anchor 与捕获调用)。
+- **D-4(文档诚实,已随本轮执行):** 4c-2 锁 §1/§8 补齐四条路径实情——**已在同批 PR 落地**,C2 口径明确限定为路径 1(+ 4c-3 后含路径 2)。
+- **D-5:** retention 地板 / 恢复面 `inboundEdgesRecoverable` 信号 —— 已写入 4c-3 锁,随 4c-3 impl 落地。
+
+**未取的默认:** 本文不替 owner 选择 D-1/D-2。在 owner 裁决前,4c-3 的锁文以「可达边界仅路径 1(+D-3 后含路径 2)」如实收窄,不虚构恢复力。
+
+## 5. 4d 红线复核
+
+逐文档 + 代码注释双向核验:**已删字段列值的值级恢复 = 永不承诺**,全仓无任何松动。本审计不改变该边界。


### PR DESCRIPTION
三件事,全部 docs-only、零 runtime 改动。

**1. 4c-2 impl wave 验证 MD**(R6 §5 承诺的每-wave 记录,此前缺席)——含承重事实:field-delete 捕获必须早于 `DELETE FROM meta_fields` 本身,因为 `meta_links.field_id` / auto-number 序列 FK 都是 `ON DELETE CASCADE`,置后会静默捕获空集。

**2. 【重要】销毁路径覆盖 GAP AUDIT(逐条 primary-source 核实)。** 仓库有 **4 条 `DELETE FROM meta_records`**,C2「flag on ⇒ 凡销毁必已捕获」**只对 1 条成立**:

| 路径 | delete revision | trash | tombstone | PIT as-of-T |
|---|---|---|---|---|
| record-service.deleteRecord | ✓ | ✓ | ✓ | ✅ |
| univer-meta.ts:10066 PIT-reset 内联 | ✓ | ✓ | ✗ | ✅ |
| records.ts:565 plugin-SDK | ✗ | ✗ | ✗ | ❌ |
| automation-executor.ts:2269 automation `delete_record` | ✗ | ✗ | ✗ | ❌ |

后两条**不写 delete revision**,而 `reconstructRecordsAtT` 纯从 `meta_record_revisions` 派生存在性 ⇒ **被它们删掉的记录在任意 T 都被 PIT 判为「仍然存在」**。automation `delete_record` 是**已上线、无 flag、有授权 UI** 的一等动作。`RecordRevisionSource` 早已声明 `'automation'|'public-form'|'plugin'` 三个从未发射的枚举位——原设计本就想覆盖。**这是本线核心承诺(时点重建正确性)的缺陷,不是缺特性。**

决策菜单 D-1..D-5(**本 PR 不实现任何一项**);D-1 = 让这两条路径发射 delete revision(只修 PIT 正确性,不改可恢复性)——属**跨车道**(automation 线),需 owner 点名或路由。

**3. 4c-2 锁 §1/§8 诚实修订** —— 原文读起来像完备,实则只覆盖 1 条路径。现补齐四条实情,并把 4c-3 的可达边界如实收窄。

🤖 Generated with [Claude Code](https://claude.com/claude-code)