### PR TITLE
feat(multitable): 4c-1 lossy retype revert (RATIFIED impl, full-read gate, flags default-off)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -240,6 +240,7 @@ jobs:
             tests/integration/multitable-config-restore-realdb.test.ts \
             tests/integration/multitable-sheet-config-revert-realdb.test.ts \
             tests/integration/multitable-field-retype-revert-realdb.test.ts \
+            tests/integration/multitable-lossy-retype-revert-realdb.test.ts \
             tests/integration/multitable-uncreate-config-realdb.test.ts \
             tests/integration/multitable-undelete-config-realdb.test.ts \
             tests/integration/multitable-permission-revert-realdb.test.ts \

--- a/docs/development/multitable-global-history-4c1-lossy-retype-revert-design-lock-20260707.md
+++ b/docs/development/multitable-global-history-4c1-lossy-retype-revert-design-lock-20260707.md
@@ -21,6 +21,8 @@
 
 ### 2.1 范围信封(fail-closed)
 - v1 仅覆盖:**scalar↔scalar 之外的 type revert 中,目标(before)type 仍为 plain scalar 的情形**,以及**同 type 的 property 变换会改变值解释的情形**(currency/percent/duration/dateTime 等 Batch-1 类型的 property revert)。
+- **impl 期澄清(2026-07-08,收窄非扩张;由 #3922 对抗审阅 P1-1 触发)**:「**同 type**」意为 **field 的 type 自该 revision 以来未曾变更**(type-era 一致),由 preview 与 execute **双侧 era guard** 强制;任何 type 时代不一致的 property revert 一律 **422**。
+  必要性:property-only revert 的 `changed_keys` 恒为 `['property']`,而 `driftConflict`(`config-restore.ts` `computeRevertPreview`)与 `baselineHash`(`configBaselineHash`)**都只比对 `changed_keys`** ⇒ 中途发生的 `type` 变更对两者**完全不可见**;又因 `sanitizeFieldProperty` 对 `url/email/phone/barcode/qrcode/location` 是**恒等函数**,一次 type-only PATCH 会把 `property` 逐字节保留,老 revision 因此不 drift。若不加此 guard,revert 会按**新 type** 重解释全部 cell —— 等于从 revert 侧偷渡一次 §7 明令出界的「前向 lossy retype」。
 - 仍然排除(维持 422):目标 type ∈ `FIELD_RETYPE_EXCLUDED_TYPES`(formula/lookup/rollup/link/attachment/button/autoNumber/created*/modified*)——这些是派生/物化语义,revert 值变换无意义且有独立副作用面(`univer-meta.ts:10670-10684`)。
 - flag:新增 `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY`,默认 **off**;**且要求基础 flag `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT` 同时 on**(基础 flag 关则本面整体 403,双闸串联)。off 时一切现状逐字节不变。
 
@@ -37,7 +39,7 @@
 ### 2.4 写对称 cap 与执行语义
 - cap:复用 `SHEET_REVERT_MAX_RECORDS`(默认 5000;**impl 注**:该常量目前是 reset handler 内的 route-local const(约 `:9410`),复用前须先提为共享读取)——待扫描/变换行数超限 → 413 fail-closed(preview 与 execute 双侧),不静默截断、不 partial。
 - execute 单事务:`UPDATE meta_fields` 套回 before 定义 + 按 oracle 结果批量改写 cell 值;每条被 coerce/drop 的 cell **记 record revision**(现有 recorder,`record-history-service.ts:45-78`)——Global History 完整,且 lossy revert 自身可经**记录版本回退(restore-to-prior-version)撤销**(coerce/drop 是 UPDATE revision,非 trash undelete)。
-- typed confirm:execute 须 `confirm: 'revert-retype-lossy'`(镜像 uncreate/undelete 模式,`univer-meta.ts:8259/:8313`)。
+- typed confirm:execute 须 `confirm: 'revert-retype-lossy'`(镜像 uncreate/undelete 模式,`univer-meta.ts:8259/:8313`)。**失败码 = 400 `CONFIRM_REQUIRED`**(与被镜像的三个破坏性 tier 实测一致;§4 表格原写「422」系笔误,已订正 —— 本路由的 422 已被 `RESTORE_NOT_SUPPORTED`「良构但形态出界」占据,混用会把两类正交失败塞进同一个码)。
 - gate:沿用 config-restore 面的既有 capability 门,**不触碰中央 rbac/auth**。
 
 ## 3. 与 4c-2 的关系(pre-image preference)
@@ -59,7 +61,7 @@
 | L6 | cap | 超 `SHEET_REVERT_MAX_RECORDS` → 413,preview/execute 双侧,库零变化 |
 | L7 | 原子性 | execute 中途注入失败 → 定义与值全部回滚 |
 | L8 | revision 完整性 | 每个被 coerce/drop 的 cell 有 record revision;changedFieldIds 正确;masking parity 与 history 读面一致 |
-| L9 | typed confirm | 缺失/错误 confirm → 422,库零变化 |
+| L9 | typed confirm | 缺失/错误 confirm → **400 `CONFIRM_REQUIRED`**,库零变化 |
 | L10 | mutation | neuter oracle 重算(2.3)→ L5 必红;neuter cap → L6 必红;neuter 桶判定 → L3 必红 |
 | L11 | (双 ratify 后)pre-image preference | 有锚走真值 `restored`;无锚走 coerce 且文案区分 |
 

--- a/packages/core-backend/src/multitable/lossy-retype-oracle.ts
+++ b/packages/core-backend/src/multitable/lossy-retype-oracle.ts
@@ -1,0 +1,192 @@
+/**
+ * 4c-1 lossy / value-transform retype revert — LOSS ORACLE (design-lock 2026-07-07 #3812 §2.2; owner-ratified
+ * 2026-07-08, R6 decision record §1/§2).
+ *
+ * The load-bearing fact the design-lock rests on: **today's runtime has NO value-level lossy/lossless judgement
+ * anywhere.** The forward `PATCH /fields` retype does not migrate cell values at all (raw `UPDATE meta_fields`),
+ * and the shipped Tier-2 retype revert is symmetric with it — schema-only, provably lossless. This module is the
+ * net-new thing: a PURE, READ-ONLY dry run that answers "if we set this field's config back to `before`, what
+ * happens to every stored cell?" by replaying the SAME codec the record write path uses (`coerceBatch1Value`),
+ * and bucketing each cell into `unchanged` / `coerced` / `dropped`. It writes nothing.
+ *
+ * ── ENVELOPE (fail-closed; see /tmp/4c1-envelope-ambiguity.md and the PR body's "信封歧义与所取读法") ──────────
+ * §2.1's first clause ("type reverts other than scalar↔scalar whose TARGET (`before`) type is still a plain
+ * scalar") is ambiguous: read literally it admits reverts whose CURRENT (`after`) type is an EXCLUDED type
+ * (formula, lookup, rollup, link, attachment, button, autoNumber, createdTime/modifiedTime/createdBy/modifiedBy).
+ * That reading is unsafe on two independent counts, so it is REFUSED here:
+ *
+ *   (1) `applyConfigRevert` is a raw `UPDATE meta_fields`. It skips the forward PATCH's type-transition
+ *       side-effect handlers (auto-number sequence teardown, `meta_links` join-table, formula dependency graph),
+ *       which is exactly why the shipped `isSupportedFieldRetypeRevert` requires BOTH endpoints to be plain
+ *       scalars (`config-restore.ts` — "it needs those handlers — a separate slice"). The design-lock's own
+ *       justification for excluding the target side ("派生/物化语义 … 有独立副作用面") applies verbatim to the
+ *       SOURCE side; the lock simply does not say so.
+ *   (2) `coerceBatch1Value` is the IDENTITY function for every non-Batch-1 type. So a `link → text` revert would
+ *       have the oracle report "zero loss" while execute leaves link-object arrays sitting in a text column —
+ *       silent corruption that the safety device itself would have signed off on.
+ *
+ * So the v1 envelope is §2.1's SECOND clause only, narrowed to the types the oracle can actually reason about:
+ *
+ *     entity_type='field' ∧ action='update'
+ *   ∧ changed_keys ⊆ {name, order, property} ∧ 'property' ∈ changed_keys   (i.e. NO 'type' key)
+ *   ∧ the field's LIVE type ∈ BATCH1_FIELD_TYPES                            (⇒ ∉ FIELD_RETYPE_EXCLUDED_TYPES)
+ *
+ * This is DISJOINT from the shipped Tier-2 predicate (`isSupportedFieldRetypeRevert` requires a `type` change),
+ * so a scalar-safe type revert keeps its schema-only, zero-value-rewrite path even with the lossy flag on
+ * (design-lock §4 L2, regression protection). Everything else keeps today's behavior byte-for-byte: `gated`
+ * preview + 422 execute (property-only reverts are explicitly deferred by `config-restore.ts`), or 403 when the
+ * base Tier-2 flag is off.
+ *
+ * Widening the envelope (source-side excluded types; coercing within the scalar-safe subset; non-Batch-1 property
+ * reverts such as a `singleSelect` option removal) each require a SEPARATE owner sign-off and additional
+ * engineering — see the PR body §"若 owner 想放宽".
+ *
+ * ── NO-ORACLE (U-L8) ────────────────────────────────────────────────────────────────────────────────────────
+ * This module deliberately has NO notion of actor, permission, or visibility. Per the owner's 2026-07-08 ruling
+ * the caller applies a FULL-READ GATE: an actor who cannot read every record × field of the sheet gets a blanket
+ * 403 on both preview and execute. There is therefore no scoped counting mode and no `undisclosedPresent` marker
+ * (the design-lock's alternative (ii) is void) — a count computed here is always over the whole table.
+ */
+import { BATCH1_FIELD_TYPES, coerceBatch1Value } from './field-codecs'
+import type { ConfigRevisionRow } from './config-restore'
+
+export type LossBucket = 'unchanged' | 'coerced' | 'dropped'
+
+/** The three-bucket loss magnitude. Over the WHOLE table (the caller's full-read gate guarantees it). */
+export interface LossSummary {
+  unchanged: number
+  coerced: number
+  dropped: number
+}
+
+export interface CellLossOutcome {
+  recordId: string
+  bucket: LossBucket
+  /** the cell's CURRENT stored value (the pre-image 4c-2 captures when the bucket is coerced/dropped). */
+  before: unknown
+  /** the value the revert would write. `null` for `dropped`. */
+  after: unknown
+}
+
+/** Keys a property-only field revert may touch. `type` is deliberately absent — see the envelope note above. */
+const LOSSY_RETYPE_REVERT_KEYS: ReadonlySet<string> = new Set(['name', 'order', 'property'])
+
+/**
+ * STRUCTURAL half of the envelope (pure on `rev`, mirrors the Tier-1/2/3/4 predicate pattern; `classifyRevert`
+ * stays untouched and keeps returning `gated` for these — the ROUTE opens the window). Disjoint from
+ * `isSupportedFieldRetypeRevert` by construction: that one REQUIRES a `type` change, this one FORBIDS it.
+ */
+export function isLossyPropertyRetypeRevertShape(rev: Pick<ConfigRevisionRow, 'entity_type' | 'action' | 'changed_keys'>): boolean {
+  return (
+    rev.entity_type === 'field' &&
+    rev.action === 'update' &&
+    Array.isArray(rev.changed_keys) &&
+    rev.changed_keys.length > 0 &&
+    rev.changed_keys.every((k) => LOSSY_RETYPE_REVERT_KEYS.has(k)) &&
+    rev.changed_keys.includes('property')
+  )
+}
+
+/**
+ * TYPE half of the envelope: only the Batch-1 codec types have a real per-type loss oracle. For any other type
+ * `coerceBatch1Value` is the identity function, so admitting them would mean reporting "zero loss" for genuinely
+ * lossy property changes (a `singleSelect` option removal, a rich-`longText` toggle). Fail-closed → they stay 422.
+ */
+export function isLossyRetypeSupportedFieldType(liveType: string): boolean {
+  return BATCH1_FIELD_TYPES.has(liveType)
+}
+
+/**
+ * DOUBLE GATE (§2.1): the lossy surface needs BOTH its own flag AND the base Tier-2 flag. Encoding both here is
+ * defense-in-depth — the route also 403s the whole surface when the base flag is off, BEFORE this is consulted,
+ * which is what makes "base off ⇒ 403 (not 422)" hold. Both default OFF ⇒ this returns false ⇒ the lossy branch
+ * is never entered ⇒ every pre-existing response is byte-for-byte unchanged (C1).
+ */
+export function isLossyRetypeRevertEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (
+    env.MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY === 'true' &&
+    env.MULTITABLE_ENABLE_FIELD_RETYPE_REVERT === 'true'
+  )
+}
+
+/**
+ * Canonical, key-order-independent serialization for the unchanged/changed decision. Postgres hands back jsonb
+ * object keys in ITS order while the codec rebuilds objects in JS insertion order (`location` is the live case:
+ * `{address, latitude, longitude}`), so a plain `JSON.stringify` compare would spuriously call an identical value
+ * `coerced` and inflate the loss magnitude bound into the preview token.
+ */
+function canonicalize(value: unknown): string {
+  const norm = (v: unknown): unknown => {
+    if (v === undefined) return null
+    if (Array.isArray(v)) return v.map(norm)
+    if (v !== null && typeof v === 'object') {
+      const src = v as Record<string, unknown>
+      const out: Record<string, unknown> = {}
+      for (const k of Object.keys(src).sort()) out[k] = norm(src[k])
+      return out
+    }
+    return v
+  }
+  return JSON.stringify(norm(value) ?? null)
+}
+
+/**
+ * The per-cell oracle. Replays the record-write-path codec with the config being RESTORED (`before`):
+ *   • the codec throws           → `dropped` (value not representable under the reverted-to property → emptied)
+ *   • the codec empties a value  → `dropped` (e.g. `''`/whitespace → null: the cell ends up empty though it wasn't)
+ *   • the result is canonically equal to the stored value → `unchanged`
+ *   • otherwise                  → `coerced` (representable, but rewritten)
+ * The "empties a value" arm is deliberately classified `dropped` rather than `coerced`: the preview's scary
+ * number should count every cell that ends up empty, whichever way it got there (fail-closed messaging).
+ */
+export function classifyCellLoss(
+  fieldType: string,
+  property: Record<string, unknown> | undefined,
+  fieldId: string,
+  value: unknown,
+): { bucket: LossBucket; next: unknown } {
+  let next: unknown
+  try {
+    next = coerceBatch1Value(fieldType, property, fieldId, value)
+  } catch {
+    return { bucket: 'dropped', next: null }
+  }
+  if (canonicalize(next) === canonicalize(value)) return { bucket: 'unchanged', next: value }
+  const emptied = (next === null || next === undefined) && value !== null && value !== undefined
+  return { bucket: emptied ? 'dropped' : 'coerced', next: next ?? null }
+}
+
+/**
+ * Dry-run every cell. `cells` must be exactly the records whose `data` CARRIES the field's key — a record with no
+ * cell for this field has nothing to lose and is not counted in any bucket (it is still counted against the
+ * write-symmetric record cap by the caller, which bounds the SCAN, not the transform).
+ */
+export function computeLossOutcomes(
+  cells: ReadonlyArray<{ recordId: string; value: unknown }>,
+  fieldType: string,
+  property: Record<string, unknown> | undefined,
+  fieldId: string,
+): CellLossOutcome[] {
+  return cells.map((cell) => {
+    const { bucket, next } = classifyCellLoss(fieldType, property, fieldId, cell.value)
+    return { recordId: cell.recordId, bucket, before: cell.value, after: next }
+  })
+}
+
+export function summarizeLoss(outcomes: ReadonlyArray<CellLossOutcome>): LossSummary {
+  const summary: LossSummary = { unchanged: 0, coerced: 0, dropped: 0 }
+  for (const outcome of outcomes) summary[outcome.bucket] += 1
+  return summary
+}
+
+/**
+ * §3 honesty clause: with no 4c-2 pre-image anchored to a PRIOR lossy revert of this field, the value transform is
+ * a RE-COERCION under the restored config, NOT a recovery of the values that existed before the forward change.
+ * The preview must say so. (The pre-image this execute captures is what lets a LATER revert-of-revert recover the
+ * true values — the first lossy revert always faces the current values.)
+ */
+export const LOSSY_RETYPE_PREVIEW_NOTE =
+  'Reverting this field configuration RE-INTERPRETS every stored cell under the restored configuration: ' +
+  'values that cannot be represented are emptied, and values that can be are rewritten in the restored format. ' +
+  'This is an approximate restore (a re-formatting), NOT a recovery of the original values. ' +
+  'Each changed cell is written as a record revision, so this revert can itself be undone per record.'

--- a/packages/core-backend/src/multitable/restore-caps.ts
+++ b/packages/core-backend/src/multitable/restore-caps.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared restore-surface ceilings.
+ *
+ * `SHEET_REVERT_MAX_RECORDS` was a route-local `const` inside the T8 PIT block of `univer-meta.ts` (D3/PIT-6:
+ * a whole-sheet revert/reset above this many records is REFUSED fail-closed, never truncated, never processed
+ * async). The 4c-1 lossy retype revert (design-lock 2026-07-07 §2.4 / C4) reuses the SAME ceiling as its
+ * write-symmetric cap — "the number of records preview can scan == the number execute can write" — so the
+ * value must live in ONE place rather than being re-derived from the env var at a second call site.
+ *
+ * Read-at-call-time (not module-load-time) so a test / an operator flipping `MULTITABLE_SHEET_REVERT_MAX_RECORDS`
+ * takes effect without a process restart. The T8 PIT block still resolves it ONCE at router construction — an
+ * intentional, byte-for-byte preservation of its pre-extraction behavior; only the 4c-1 surface resolves per
+ * request (its goldens flip the cap between cases).
+ */
+export const SHEET_REVERT_DEFAULT_MAX_RECORDS = 5000
+
+export function resolveSheetRevertMaxRecords(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number(env.MULTITABLE_SHEET_REVERT_MAX_RECORDS)
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : SHEET_REVERT_DEFAULT_MAX_RECORDS
+}

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -239,6 +239,34 @@ export interface ConfigRestorePreviewIdentityClaims {
   baselineHash: string
   /** the actor the preview was minted for — a preview minted for A is unusable by B. */
   actorId: string
+  /**
+   * 4c-1 (design-lock §2.3): the LOSS-MAGNITUDE binding. Present ONLY on a lossy retype-revert preview
+   * (`hashLossSummary`); `undefined` on every pre-existing Tier-1/Tier-2 preview, whose token bytes are therefore
+   * unchanged. Execute RE-COMPUTES the loss summary inside the txn (after `FOR UPDATE`) and re-hashes: a divergence
+   * means the cell values moved since preview, so the loss the actor confirmed is not the loss about to happen →
+   * 409 PLAN_DRIFT. Absence is itself bound (an `undefined` claim must match an `undefined` expectation), so a lossy
+   * token can never drive a non-lossy execute and vice versa.
+   */
+  lossHash?: string
+}
+
+/**
+ * 4c-1 §2.3: opaque, SERVER-KEYED digest of the loss magnitude. HMAC (not the plain sha256 `configBaselineHash`
+ * uses) for the same reason `hashUncreatePlan` is keyed: the inputs are three small integers in a client-decodable
+ * JWT, so a plain hash would be trivially brute-forceable into an exact "how many cells will be dropped" oracle for
+ * a token holder. The keyed PRF makes the claim opaque. `fieldId` is folded in so a token minted for one field's
+ * loss can never satisfy another field's execute even at identical counts. The raw summary IS returned in the
+ * preview response body — but only to an actor the full-read gate has already proven can read the whole table.
+ */
+export function hashLossSummary(fieldId: string, summary: { unchanged: number; coerced: number; dropped: number }): string {
+  const n = (v: number): number => (Number.isFinite(v) ? Math.trunc(v) : 0)
+  const canon = {
+    fieldId: String(fieldId),
+    unchanged: n(summary.unchanged),
+    coerced: n(summary.coerced),
+    dropped: n(summary.dropped),
+  }
+  return createHmac('sha256', getSecret()).update(JSON.stringify(canon)).digest('hex')
 }
 
 export function mintConfigRestorePreviewIdentity(claims: ConfigRestorePreviewIdentityClaims, expiresIn: SignOptions['expiresIn'] = DEFAULT_TTL): string {
@@ -247,7 +275,10 @@ export function mintConfigRestorePreviewIdentity(claims: ConfigRestorePreviewIde
 
 export interface ConfigRestoreVerifyResult {
   valid: boolean
-  reason?: 'invalid' | 'expired' | 'wrong_type' | 'mismatch_sheetId' | 'mismatch_revisionId' | 'mismatch_entityType' | 'mismatch_entityId' | 'mismatch_baselineHash' | 'mismatch_actorId'
+  // `loss_drift` (4c-1) = the opaque lossHash diverged (cell values moved since preview, so the loss magnitude the
+  // actor confirmed is stale) OR the token's lossy-ness does not match the execute path's. The route maps it to ONE
+  // generic 409 PLAN_DRIFT — the keyed hash cannot reveal WHICH bucket moved, which would itself be an oracle.
+  reason?: 'invalid' | 'expired' | 'wrong_type' | 'mismatch_sheetId' | 'mismatch_revisionId' | 'mismatch_entityType' | 'mismatch_entityId' | 'mismatch_baselineHash' | 'loss_drift' | 'mismatch_actorId'
 }
 
 export function verifyConfigRestorePreviewIdentity(token: string, expected: ConfigRestorePreviewIdentityClaims): ConfigRestoreVerifyResult {
@@ -263,6 +294,10 @@ export function verifyConfigRestorePreviewIdentity(token: string, expected: Conf
   if (payload.entityType !== expected.entityType) return { valid: false, reason: 'mismatch_entityType' }
   if (payload.entityId !== expected.entityId) return { valid: false, reason: 'mismatch_entityId' }
   if (payload.baselineHash !== expected.baselineHash) return { valid: false, reason: 'mismatch_baselineHash' }
+  // 4c-1: bind the loss magnitude, INCLUDING its absence (`undefined` ↔ `undefined`). `jwt.sign` drops undefined
+  // claims, so a pre-4c-1 token carries no `lossHash` and matches a non-lossy expectation; a lossy token presented
+  // to the non-lossy branch (or vice versa) diverges here rather than silently executing the wrong contract.
+  if ((payload.lossHash ?? null) !== (expected.lossHash ?? null)) return { valid: false, reason: 'loss_drift' }
   if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
   return { valid: true }
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -74,7 +74,7 @@ import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssign
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail, estimateHistoryHasMore } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
-import { hashPreviewChanges, hashScope, hashResurrectSet, hashDeleteSet, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity, mintPitResetPreviewIdentity, verifyPitResetPreviewIdentity, mintConfigRestorePreviewIdentity, verifyConfigRestorePreviewIdentity, type UncreatePlan, hashUncreatePlan, mintConfigUncreatePreviewIdentity, verifyConfigUncreatePreviewIdentity, type UndeletePlan, hashUndeletePlan, mintConfigUndeletePreviewIdentity, verifyConfigUndeletePreviewIdentity, hashPermissionGrant, mintConfigPermissionRevertPreviewIdentity, verifyConfigPermissionRevertPreviewIdentity } from '../multitable/restore-preview-identity'
+import { hashPreviewChanges, hashScope, hashResurrectSet, hashDeleteSet, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity, mintPitResetPreviewIdentity, verifyPitResetPreviewIdentity, mintConfigRestorePreviewIdentity, verifyConfigRestorePreviewIdentity, hashLossSummary, type UncreatePlan, hashUncreatePlan, mintConfigUncreatePreviewIdentity, verifyConfigUncreatePreviewIdentity, type UndeletePlan, hashUndeletePlan, mintConfigUndeletePreviewIdentity, verifyConfigUndeletePreviewIdentity, hashPermissionGrant, mintConfigPermissionRevertPreviewIdentity, verifyConfigPermissionRevertPreviewIdentity } from '../multitable/restore-preview-identity'
 import {
   recordConfigRevision,
   recordFieldOrderShifts,
@@ -93,8 +93,20 @@ import {
   insertFieldValueTombstones,
   insertFieldLinkTombstones,
   readAutoNumberNextValue,
+  captureLossyRetypePreImageRows,
   TombstoneCaptureCapExceededError,
 } from '../multitable/tombstone-capture'
+import { resolveSheetRevertMaxRecords } from '../multitable/restore-caps'
+import {
+  type CellLossOutcome,
+  type LossSummary,
+  computeLossOutcomes,
+  isLossyPropertyRetypeRevertShape,
+  isLossyRetypeRevertEnabled,
+  isLossyRetypeSupportedFieldType,
+  summarizeLoss,
+  LOSSY_RETYPE_PREVIEW_NOTE,
+} from '../multitable/lossy-retype-oracle'
 import {
   type ConfigRevisionRow,
   classifyRevert,
@@ -6211,6 +6223,171 @@ async function computeUndeletePlan(query: TxnQuery, rev: ConfigRevisionRow): Pro
   return { idFree: !occupied, insertOrder, trailingShiftIds, targetConfigHash }
 }
 
+// ── 4c-1 lossy / value-transform retype revert helpers (design-lock 2026-07-07 #3812; ratified 2026-07-08) ─────
+
+interface LossyRetypeFieldRow { id: string; sheetId: string; type: string }
+
+/** The live field row the loss oracle reasons about. `FOR UPDATE` only inside the execute txn (caller decides). */
+async function loadLossyRetypeFieldRow(query: TxnQuery, fieldId: string, forUpdate: boolean): Promise<LossyRetypeFieldRow | null> {
+  const res = (await query(`SELECT id, sheet_id, type FROM meta_fields WHERE id = $1${forUpdate ? ' FOR UPDATE' : ''}`, [fieldId])) as any
+  const row = res.rows[0] as { id: unknown; sheet_id: unknown; type: unknown } | undefined
+  if (!row) return null
+  return { id: String(row.id), sheetId: String(row.sheet_id), type: String(row.type ?? '') }
+}
+
+/**
+ * The property the oracle coerces AGAINST: the revision's `before.property` — the config this revert restores.
+ * (`configUpdateDiff` records only the CHANGED keys, and `'property'` is in `changed_keys` by the envelope
+ * predicate, so `before.property` is always present; a `null` property normalizes to `undefined` for the codec,
+ * which is what `coerceBatch1Value`'s `property ?? {}` arms expect.)
+ */
+function lossyRetypeTargetProperty(rev: ConfigRevisionRow): Record<string, unknown> | undefined {
+  const raw = (rev.before ?? {}).property
+  return isPlainObject(raw) ? raw : undefined
+}
+
+/**
+ * 4c-1 U-L8 — the FULL-READ GATE (owner ratification 2026-07-08 §2, overriding the design-lock's alternative (ii)).
+ *
+ * An actor who cannot read EVERY record × field of this sheet is refused the whole surface (403 on preview AND
+ * execute); no scoped loss counts, no `undisclosedPresent` marker, hence NO oracle surface at all — C2 is satisfied
+ * by a gate rather than by a marker, which is the strongest available reading.
+ *
+ * CRITICAL: every input here is CONFIG-derived, never DATA-derived. `loadDeniedRecordIds` would have been the
+ * obvious row-axis primitive, but its rule-deny arm evaluates predicates against LIVE record data — so gating on
+ * "the denied set happens to be empty right now" would turn the 403/200 boundary into exactly the 1-bit data probe
+ * U-L8 forbids. We gate on the sheet's row-level-read SWITCH instead (`loadRowLevelReadDenyEnabled`, plus the same
+ * admin bypass every read surface applies): constant with respect to the data, conservative (a sheet with the switch
+ * on but zero effective denials is still refused), and impossible to use as a probe.
+ *
+ * Three axes, all of which must be clean — reusing the multitable-local permission primitives only (C7: the central
+ * rbac/auth is not touched):
+ *   1. ROW: the sheet's row-level read-deny switch is off for this actor (or the actor is an admin role).
+ *   2. FIELD: the actor's field_permissions scope masks nothing — the allowed set with the per-subject scope applied
+ *      equals the set with that axis lifted.
+ *   3. FORMULA TAINT: no allowed field is dropped by the §2a.3 stored-data taint mask.
+ */
+async function hasFullTableReadAccess(
+  req: Request,
+  query: QueryFn,
+  sheetId: string,
+  access: { userId: string | null; isAdminRole: boolean },
+  capabilities: MultitableCapabilities,
+): Promise<boolean> {
+  if (!access.userId) return false // anonymous/unscoped → fail closed
+  if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(query, sheetId))) return false
+  const fields = (await loadFieldsForSheet(query, sheetId)) as UniverMetaField[]
+  const scopeMap = await loadFieldPermissionScopeMap(query, sheetId, access.userId)
+  const scoped = computeAllowedFieldIds(fields, capabilities, scopeMap)
+  const unscoped = computeAllowedFieldIds(fields, capabilities, new Map<string, FieldPermissionScope>())
+  if (scoped.size !== unscoped.size) return false
+  for (const id of unscoped) if (!scoped.has(id)) return false
+  const masked = await maskStoredRecordFieldIds(req, query, sheetId, undefined, scoped)
+  return masked.size === scoped.size
+}
+
+/**
+ * Live cells for one field: exactly the records whose `data` CARRIES the key (a missing key has nothing to lose).
+ * `FOR UPDATE` (execute only) locks the exact rows the oracle is about to judge, so the loss magnitude verified
+ * against the token cannot change between the re-computation and the rewrite (§2.3).
+ */
+async function loadLossyRetypeCells(query: TxnQuery, sheetId: string, fieldId: string, forUpdate: boolean): Promise<Array<{ recordId: string; value: unknown; data: Record<string, unknown> }>> {
+  const res = (await query(
+    `SELECT id, data FROM meta_records WHERE sheet_id = $1 AND data ? $2 ORDER BY id${forUpdate ? ' FOR UPDATE' : ''}`,
+    [sheetId, fieldId],
+  )) as any
+  return (res.rows as Array<{ id: unknown; data: unknown }>).map((r) => {
+    const data = normalizeJson(r.data)
+    return { recordId: String(r.id), value: data[fieldId], data }
+  })
+}
+
+/** C4 write-symmetric cap input: the rows the oracle must SCAN = the sheet's live records (not just cells present). */
+async function countLossyRetypeScanRows(query: TxnQuery, sheetId: string): Promise<number> {
+  const res = (await query('SELECT count(*)::int AS c FROM meta_records WHERE sheet_id = $1', [sheetId])) as any
+  return Number((res.rows[0] as { c?: number } | undefined)?.c ?? 0)
+}
+
+const lossyRetypeTooLargeMessage = (recordCount: number, cap: number): string =>
+  `This sheet has ${recordCount} records, above the ${cap}-record ceiling for a value-transforming field revert; a revert of this size is refused.`
+
+/**
+ * The lossy revert's WRITE half: capture the pre-image (4c-2 seam), then rewrite every coerced/dropped cell in ONE
+ * batched statement, then record ONE record revision per changed cell. Same txn as the `meta_fields` config revert.
+ */
+async function applyLossyRetypeCellRewrite(query: TxnQuery, opts: {
+  sheetId: string
+  fieldId: string
+  /** THIS revert's own config-revision id — the 4c-2 "回指触发行" anchor (§2 capture point 3 / 4c-1 §3). */
+  lossyRevisionId: string
+  changed: ReadonlyArray<CellLossOutcome>
+  cellByRecordId: ReadonlyMap<string, { data: Record<string, unknown> }>
+  actorId: string | null
+}): Promise<void> {
+  const { sheetId, fieldId, lossyRevisionId, changed, cellByRecordId, actorId } = opts
+  if (changed.length === 0) return
+
+  // 4c-2 pre-image capture (double-ratify linkage, design-lock §3 / C6). Same txn, BEFORE the overwrite, anchored to
+  // THIS revert's own config revision so a later revert-of-revert can recover the TRUE pre-coerce values rather than
+  // re-coercing. Gated by MULTITABLE_TOMBSTONE_CAPTURE_ENABLED; over its cap the capture THROWS and the whole revert
+  // rolls back (fail-closed: "capture on ⇒ every destruction is already captured" is never violated).
+  // `value jsonb NOT NULL` on meta_field_value_tombstones: a null pre-image is impossible here (coerce(null)===null
+  // ⇒ `unchanged` ⇒ never in `changed`), but filter defensively rather than trip a constraint at runtime.
+  if (isTombstoneCaptureEnabled()) {
+    const preImages = changed
+      .filter((c) => c.before !== null && c.before !== undefined)
+      .map((c) => ({ recordId: c.recordId, value: c.before }))
+    assertWithinCaptureCap(preImages.length)
+    await captureLossyRetypePreImageRows(query, preImages, { sheetId, fieldId, configRevisionId: lossyRevisionId })
+  }
+
+  // `COALESCE(item.value, 'null'::jsonb)` below is load-bearing: `jsonb_to_recordset` maps a JSON `null` to SQL NULL,
+  // and `jsonb_set(data, path, NULL)` returns NULL for the WHOLE `data` column — a dropped cell would wipe the record.
+  // A single batched statement (never a per-row round trip), matching the tombstone-capture module's discipline.
+  const payload = changed.map((c) => ({ record_id: c.recordId, value: c.after ?? null }))
+  // lock-exempt: 4c-1 lossy retype revert — schema op rewriting the reverted field's key sheet-wide under the
+  // config-restore canManageFields gate (mirrors the field-delete column strip / field-undelete rehydration);
+  const rewritten = (await query(
+    `UPDATE meta_records AS m
+     SET data = jsonb_set(m.data, ARRAY[$2::text], COALESCE(item.value, 'null'::jsonb), true),
+         version = m.version + 1,
+         updated_at = now()
+     FROM jsonb_to_recordset($3::jsonb) AS item(record_id text, value jsonb)
+     WHERE m.sheet_id = $1 AND m.id = item.record_id
+     RETURNING m.id, m.version`,
+    [sheetId, fieldId, JSON.stringify(payload)],
+  )) as any
+  const updatedRows = rewritten.rows as Array<{ id: unknown; version: unknown }>
+  // The cells were locked FOR UPDATE before the oracle ran, so a short write is a real invariant break, not a race.
+  if (updatedRows.length !== changed.length) {
+    throw new Error(`lossy retype revert rewrote ${updatedRows.length} of ${changed.length} cells; aborting`)
+  }
+
+  // C5 history completeness: ONE record revision per changed cell, sharing one batchId (LOCK-12 — one user action =
+  // one batch). This is what makes the lossy revert itself undoable through the ordinary record-version restore.
+  const outcomeByRecordId = new Map(changed.map((c) => [c.recordId, c]))
+  const recordBatchId = randomUUID()
+  for (const row of updatedRows) {
+    const recordId = String(row.id)
+    const outcome = outcomeByRecordId.get(recordId)
+    const previous = cellByRecordId.get(recordId)
+    if (!outcome || !previous) throw new Error(`lossy retype revert lost track of record ${recordId}; aborting`)
+    const nextValue = outcome.after ?? null
+    await recordRecordRevision(query, {
+      sheetId,
+      recordId,
+      version: Number(row.version) || 0,
+      action: 'update',
+      source: 'restore',
+      actorId,
+      changedFieldIds: [fieldId],
+      patch: { [fieldId]: nextValue },
+      snapshot: { ...previous.data, [fieldId]: nextValue },
+      batchId: recordBatchId,
+    })
+  }
+}
+
 /**
  * U4-L2/L3: recreate a deleted FIELD from its `before` at its original order (trailing shift +1).
  * 4c-2 R1: when the delete that produced `before` has a matching tombstone set (`opts.deleteRevisionId` —
@@ -8410,6 +8587,43 @@ export function univerMetaRouter(): Router {
       if (isFieldRetypeRevert(rev) && process.env.MULTITABLE_ENABLE_FIELD_RETYPE_REVERT !== 'true') {
         return res.status(403).json({ ok: false, error: { code: 'FIELD_RETYPE_REVERT_DISABLED', message: 'field type/property revert is disabled (MULTITABLE_ENABLE_FIELD_RETYPE_REVERT off).' } })
       }
+      // ── 4c-1 LOSSY / value-transform retype revert PREVIEW (design-lock #3812; owner-ratified 2026-07-08) ────
+      // Second flag, default off, AND requires the base Tier-2 flag (403'd immediately above ⇒ base off = 403 for
+      // the whole surface, the "双闸串联" of §2.1). Flag off ⇒ this branch is never entered ⇒ a property-only field
+      // revert keeps today's behavior byte-for-byte (gated preview here, 422 at execute). Envelope = property-only
+      // reverts on a Batch-1-typed field; see lossy-retype-oracle.ts for why the type-changing arm of §2.1 is read
+      // fail-closed. Preview is a PURE READ: it writes nothing and only re-plays the record-write codec.
+      if (isLossyPropertyRetypeRevertShape(rev) && isLossyRetypeRevertEnabled()) {
+        const fieldRow = await loadLossyRetypeFieldRow(pool.query.bind(pool), rev.entity_id, false)
+        if (!fieldRow) return res.status(409).json({ ok: false, error: { code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot preview a revert.' } })
+        if (fieldRow.sheetId !== sheetId) return res.status(400).json({ ok: false, error: { code: 'INVALID_REVISION', message: 'field revision entity does not belong to this sheet.' } })
+        // Outside the Batch-1 type envelope → fall through to the pre-existing gated preview (execute 422s it).
+        if (isLossyRetypeSupportedFieldType(fieldRow.type)) {
+          // U-L8 FULL-READ GATE (owner ruling): no full-table read ⇒ 403 for the whole surface. Runs BEFORE any
+          // counting, so no response on this path can ever carry a scoped count or an undisclosed marker.
+          if (!(await hasFullTableReadAccess(req, pool.query.bind(pool), sheetId, access, capabilities))) {
+            return res.status(403).json({ ok: false, error: { code: 'FULL_TABLE_READ_REQUIRED', message: 'A value-transforming field revert requires unrestricted read access to every record and field of this sheet.' } })
+          }
+          // C4 write-symmetric cap — the SAME ceiling the sheet-wide revert uses, checked on BOTH sides, fail-closed
+          // (never a silent truncation, never a partial transform).
+          const cap = resolveSheetRevertMaxRecords()
+          const scanRows = await countLossyRetypeScanRows(pool.query.bind(pool), sheetId)
+          if (scanRows > cap) return res.status(413).json({ ok: false, error: { code: 'SHEET_TOO_LARGE', message: lossyRetypeTooLargeMessage(scanRows, cap) } })
+          const snapshot = await loadEntityConfigSnapshot(pool.query.bind(pool), rev)
+          if (!snapshot) return res.status(409).json({ ok: false, error: { code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot preview a revert.' } })
+          const cells = await loadLossyRetypeCells(pool.query.bind(pool), sheetId, rev.entity_id, false)
+          const lossSummary = summarizeLoss(computeLossOutcomes(cells, fieldRow.type, lossyRetypeTargetProperty(rev), rev.entity_id))
+          const preview = computeRevertPreview(rev, snapshot)
+          // classifyRevert stays PURE (it gates every field property revert); the flag opens exactly this subset.
+          preview.opKind = 'safe'
+          delete preview.gatedReason
+          const previewToken = mintConfigRestorePreviewIdentity({
+            sheetId, revisionId, entityType: rev.entity_type, entityId: rev.entity_id,
+            baselineHash: preview.baselineHash, lossHash: hashLossSummary(rev.entity_id, lossSummary), actorId: access.userId,
+          })
+          return res.json({ ok: true, data: { preview, previewToken, lossSummary, lossNote: LOSSY_RETYPE_PREVIEW_NOTE, confirm: 'revert-retype-lossy' } })
+        }
+      }
       // T9-W Tier 1 (U-L1): sheet_config revert is behind a per-tier flag (default off) — refuse preview AND execute.
       if (rev.entity_type === 'sheet_config') {
         if (process.env.MULTITABLE_ENABLE_SHEET_CONFIG_REVERT !== 'true') {
@@ -8643,6 +8857,82 @@ export function univerMetaRouter(): Router {
         })
         if (failure) return res.status(failure.status).json({ ok: false, error: { code: failure.code, message: failure.message } })
         return res.json({ ok: true, data: { permissionReverted: { scope: parsedPerm.scope, entityId: rev.entity_id } } })
+      }
+      // ── 4c-1 LOSSY / value-transform retype revert EXECUTE (design-lock #3812; owner-ratified 2026-07-08) ────
+      // ONE txn: lock the field + its cells (FOR UPDATE) → re-check the envelope, the U-L8 full-read gate and the
+      // write-symmetric cap → RE-COMPUTE the loss magnitude and verify the token's opaque lossHash (divergence ⇒ 409
+      // PLAN_DRIFT) → capture the 4c-2 pre-image → apply the config revert → rewrite the coerced/dropped cells →
+      // one record revision per changed cell → the source='restore' config revision (whose id anchors the pre-image).
+      // Any guard returns the failure object with ZERO writes; any throw rolls the whole thing back (C5/L7 atomicity).
+      if (isLossyPropertyRetypeRevertShape(rev) && isLossyRetypeRevertEnabled()) {
+        const liveField = await loadLossyRetypeFieldRow(pool.query.bind(pool), rev.entity_id, false)
+        if (!liveField) return res.status(409).json({ ok: false, error: { code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot restore.' } })
+        if (liveField.sheetId !== sheetId) return res.status(400).json({ ok: false, error: { code: 'INVALID_REVISION', message: 'field revision entity does not belong to this sheet.' } })
+        // Outside the Batch-1 type envelope → fall through to the generic gated 422 below (fail-closed, C1).
+        if (isLossyRetypeSupportedFieldType(liveField.type)) {
+          // Typed confirm — mirrors the uncreate / undelete / permission-revert destructive tiers on THIS route,
+          // which all answer a missing/incorrect confirm with 400 CONFIRM_REQUIRED (design-lock §2.4 "镜像
+          // uncreate/undelete 模式"). See the PR body: §4's L9 table shorthand says 422; the normative §2.4 mirror
+          // instruction and same-endpoint consistency win, and this is a one-line change if the owner rules otherwise.
+          const confirm = typeof req.body?.confirm === 'string' ? req.body.confirm : ''
+          if (confirm.trim() !== 'revert-retype-lossy') {
+            return res.status(400).json({ ok: false, error: { code: 'CONFIRM_REQUIRED', message: 'Type "revert-retype-lossy" to confirm a value-transforming field revert (cells may be rewritten or emptied).' } })
+          }
+          const lossyRevisionId = randomUUID() // pre-generated: the 4c-2 pre-image anchors to THIS revert's revision
+          let lossyExecuteSummary: LossSummary = { unchanged: 0, coerced: 0, dropped: 0 }
+          const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {
+            const fieldRow = await loadLossyRetypeFieldRow(query, rev.entity_id, true)
+            if (!fieldRow) return { status: 409, code: 'ENTITY_GONE', message: 'The field no longer exists; cannot restore.' }
+            if (fieldRow.sheetId !== sheetId) return { status: 400, code: 'INVALID_REVISION', message: 'field revision entity does not belong to this sheet.' }
+            // Re-check inside the lock: the field could have been retyped out of the envelope since the preview.
+            if (!isLossyRetypeSupportedFieldType(fieldRow.type)) return { status: 422, code: 'RESTORE_NOT_SUPPORTED', message: 'This field revert is not a supported value-transforming revert.' }
+            if (!(await hasFullTableReadAccess(req, query as unknown as QueryFn, sheetId, access, capabilities))) {
+              return { status: 403, code: 'FULL_TABLE_READ_REQUIRED', message: 'A value-transforming field revert requires unrestricted read access to every record and field of this sheet.' }
+            }
+            const cap = resolveSheetRevertMaxRecords()
+            const scanRows = await countLossyRetypeScanRows(query, sheetId)
+            if (scanRows > cap) return { status: 413, code: 'SHEET_TOO_LARGE', message: lossyRetypeTooLargeMessage(scanRows, cap) }
+            const snapshot = await loadEntityConfigSnapshot(query, rev)
+            if (!snapshot) return { status: 409, code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot restore.' }
+            const cells = await loadLossyRetypeCells(query, sheetId, rev.entity_id, true)
+            const outcomes = computeLossOutcomes(cells, fieldRow.type, lossyRetypeTargetProperty(rev), rev.entity_id)
+            const lossSummary = summarizeLoss(outcomes)
+            const preview = computeRevertPreview(rev, snapshot)
+            // §2.3: the token binds BOTH the config baseline AND the loss magnitude. The full-read gate makes the
+            // re-computation range identical to the preview's (the whole table), so this is a like-for-like compare.
+            const verdict = verifyConfigRestorePreviewIdentity(previewToken, {
+              sheetId, revisionId, entityType: rev.entity_type, entityId: rev.entity_id,
+              baselineHash: preview.baselineHash, lossHash: hashLossSummary(rev.entity_id, lossSummary), actorId: access.userId,
+            })
+            if (!verdict.valid) {
+              if (verdict.reason === 'loss_drift') return { status: 409, code: 'PLAN_DRIFT', message: 'The values this revert would transform changed since preview; re-preview before reverting.' }
+              if (verdict.reason === 'mismatch_baselineHash') return { status: 409, code: 'PREVIEW_STALE', message: 'The config changed since preview; re-preview before restoring.' }
+              if (verdict.reason === 'expired') return { status: 410, code: 'PREVIEW_EXPIRED', message: 'The preview identity expired; re-preview.' }
+              return { status: 401, code: 'PREVIEW_IDENTITY_INVALID', message: 'A valid server-minted preview identity is required; preview before restoring.' }
+            }
+            if (preview.driftConflict) return { status: 409, code: 'CONFIG_DRIFT', message: 'The config was changed after this revision; cannot safely revert without re-previewing.' }
+            await applyConfigRevert(query, rev)
+            await applyLossyRetypeCellRewrite(query, {
+              sheetId,
+              fieldId: rev.entity_id,
+              lossyRevisionId,
+              changed: outcomes.filter((o) => o.bucket !== 'unchanged'),
+              cellByRecordId: new Map(cells.map((c) => [c.recordId, c])),
+              actorId: getRequestActorId(req),
+            })
+            await recordConfigRevision(query, {
+              sheetId, entityType: 'field', entityId: rev.entity_id, action: 'update',
+              before: preview.current, after: preview.target, changedKeys: rev.changed_keys,
+              batchId: randomUUID(), actorId: getRequestActorId(req), source: 'restore', restoredFromId: rev.id,
+              id: lossyRevisionId,
+            })
+            lossyExecuteSummary = lossSummary
+            return null
+          })
+          if (failure) return res.status(failure.status).json({ ok: false, error: { code: failure.code, message: failure.message } })
+          invalidateFieldCache(sheetId)
+          return res.json({ ok: true, data: { restored: { revisionId, entityType: rev.entity_type, entityId: rev.entity_id, changedKeys: rev.changed_keys }, lossSummary: lossyExecuteSummary } })
+        }
       }
       const classify = classifyRevert(rev)
       // classifyRevert stays PURE; the route SUPPORTS only the flag-opened supported subsets — Tier-1 sheet_config
@@ -9530,8 +9820,9 @@ export function univerMetaRouter(): Router {
   type RevertSheetCaps = Awaited<ReturnType<typeof resolveSheetCapabilities>>
   // D3 / PIT-6 hard ceiling: a whole-sheet revert above this many records is REFUSED fail-closed (not processed
   // synchronously, never truncated). Async-above-threshold is a follow-up; v1 hard-refuses. Env-overridable.
-  const SHEET_REVERT_MAX_RECORDS = Number(process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS) > 0
-    ? Math.floor(Number(process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS)) : 5000
+  // Resolved ONCE here (router construction), exactly as the pre-extraction route-local const did; the shared
+  // resolver now also backs the 4c-1 lossy-retype write-symmetric cap (C4 — same ceiling, one definition).
+  const SHEET_REVERT_MAX_RECORDS = resolveSheetRevertMaxRecords()
   type SheetRevertTooLarge = { tooLarge: true; recordCount: number; scope: 'live_sheet' | 'effective_write_set' }
   const sheetRevertTooLargeMessage = (computed: SheetRevertTooLarge) => {
     if (computed.scope === 'effective_write_set') return `This revert would touch ${computed.recordCount} records, above the ${SHEET_REVERT_MAX_RECORDS}-record revert ceiling; a sheet-wide revert of this size is refused.`

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6236,11 +6236,67 @@ async function loadLossyRetypeFieldRow(query: TxnQuery, fieldId: string, forUpda
 }
 
 /**
- * The property the oracle coerces AGAINST: the revision's `before.property` — the config this revert restores.
- * (`configUpdateDiff` records only the CHANGED keys, and `'property'` is in `changed_keys` by the envelope
- * predicate, so `before.property` is always present; a `null` property normalizes to `undefined` for the codec,
- * which is what `coerceBatch1Value`'s `property ?? {}` arms expect.)
+ * 4c-1 P1-1 — TYPE-ERA GUARD. `changed_keys` for a property-only revert is `['property']`, and BOTH drift controls
+ * key off `changed_keys` alone (`computeRevertPreview`'s `driftConflict` and `configBaselineHash`), so a `type`
+ * change landing BETWEEN the reverted revision and now is invisible to them. That matters because
+ * `sanitizeFieldProperty` is the IDENTITY for url/email/phone/barcode/qrcode/location, so a `string → url`
+ * type-only PATCH preserves `property` byte-for-byte and a stale `string`-era property revert does NOT drift.
+ * Reverting it would then coerce every cell under the NEW type — a forward `text → url` value migration smuggled
+ * in through the revert door, which lock §7 puts explicitly OUT OF BOUNDS.
+ *
+ * Lock §2.1 says "同 type 的 property 变换" — SAME type. This enforces it: if the field's `type` changed at any
+ * point strictly AFTER the revision being reverted, the revision belongs to a different type era and the revert is
+ * refused (422). Ordering uses this table's EXISTING deterministic order — `(created_at, id)`, the ascending twin
+ * of the `ORDER BY created_at DESC, id DESC` the config-history read surface uses — not a home-grown one.
+ *
+ * Also catches a delete→undelete cycle that recreated the field at a different type: `fieldDeleteDiff` /
+ * `fieldCreateDiff` both put `type` in `changed_keys`. A type change that was later changed BACK still trips this
+ * (the era is "unbroken", not "endpoint-equal") — deliberately fail-closed, and it only ever refuses.
  */
+async function hasFieldTypeChangeSince(query: TxnQuery, sheetId: string, fieldId: string, revisionId: string): Promise<boolean> {
+  const res = (await query(
+    `SELECT 1 FROM meta_config_revisions r
+     WHERE r.sheet_id = $1 AND r.entity_type = 'field' AND r.entity_id = $2
+       AND 'type' = ANY(r.changed_keys)
+       AND (r.created_at, r.id) > (SELECT a.created_at, a.id FROM meta_config_revisions a WHERE a.id = $3)
+     LIMIT 1`,
+    [sheetId, fieldId, revisionId],
+  )) as any
+  return res.rows.length > 0
+}
+
+const FIELD_TYPE_ERA_MISMATCH = {
+  code: 'FIELD_TYPE_ERA_MISMATCH',
+  // No counts, no bucket names, no record/value information — the same no-oracle discipline as every other
+  // refusal on this surface (and it is reached only AFTER the full-read gate has already passed).
+  message: "This field's type changed after the revision being reverted, so restoring its old configuration would re-interpret every cell under a different type. Refused.",
+} as const
+
+/**
+ * 4c-1 defense-in-depth: normalize the `before.property` this revert is about to write THROUGH the live type's
+ * sanitizer, and use that same normalized value for the oracle, the preview's `target`, and the write. Reasons:
+ *   • `applyConfigRevert` writes `before[k]` RAW. It is shared with Tier-1/Tier-2, so it is NOT changed here — we
+ *     hand the lossy branch (and only the lossy branch) a derived revision instead. Other tiers are untouched.
+ *   • On real data this is a NO-OP: every stored property was written through `normalizeFieldWriteInput`, so a
+ *     recorded `before.property` is already sanitizer-shaped, and `sanitizeFieldProperty` is idempotent. It only
+ *     bites on a hand-crafted / legacy / plugin-written property, where writing it raw would leave the field
+ *     holding a malformed property for its type.
+ *   • Because `preview.target` is derived from the SAME value, whatever normalization happens is DISCLOSED to the
+ *     actor in the preview rather than applied silently.
+ * Safe by construction: `driftConflict` compares `current` against `after` (untouched) and `baselineHash` hashes
+ * the CURRENT snapshot (untouched), so neither drift control is perturbed.
+ *
+ * Uses the ROUTE-LOCAL `sanitizeFieldProperty` (with the same `as UniverMetaField['type']` cast the forward
+ * `normalizeFieldWriteInput` uses) rather than field-codecs' — write-path parity: it is the route-local one that
+ * shapes every property the forward PATCH stores, and it additionally applies `applyFieldValidationNormalisation`.
+ * The cast is sound: the caller has already proven `liveType ∈ BATCH1_FIELD_TYPES ⊂ UniverMetaField['type']`.
+ */
+function lossyRetypeDerivedRevision(rev: ConfigRevisionRow, liveType: string): ConfigRevisionRow {
+  const before = rev.before ?? {}
+  return { ...rev, before: { ...before, property: sanitizeFieldProperty(liveType as UniverMetaField['type'], before.property) } }
+}
+
+/** The property the oracle coerces AGAINST: the (normalized) `before.property` this revert restores. */
 function lossyRetypeTargetProperty(rev: ConfigRevisionRow): Record<string, unknown> | undefined {
   const raw = (rev.before ?? {}).property
   return isPlainObject(raw) ? raw : undefined
@@ -8604,6 +8660,11 @@ export function univerMetaRouter(): Router {
           if (!(await hasFullTableReadAccess(req, pool.query.bind(pool), sheetId, access, capabilities))) {
             return res.status(403).json({ ok: false, error: { code: 'FULL_TABLE_READ_REQUIRED', message: 'A value-transforming field revert requires unrestricted read access to every record and field of this sheet.' } })
           }
+          // P1-1 TYPE-ERA GUARD (§2.1 "同 type"): a `type` change after this revision puts it in a different era,
+          // and neither driftConflict nor baselineHash can see it (both key off `changed_keys` = ['property']).
+          if (await hasFieldTypeChangeSince(pool.query.bind(pool), sheetId, rev.entity_id, rev.id)) {
+            return res.status(422).json({ ok: false, error: { ...FIELD_TYPE_ERA_MISMATCH } })
+          }
           // C4 write-symmetric cap — the SAME ceiling the sheet-wide revert uses, checked on BOTH sides, fail-closed
           // (never a silent truncation, never a partial transform).
           const cap = resolveSheetRevertMaxRecords()
@@ -8612,8 +8673,9 @@ export function univerMetaRouter(): Router {
           const snapshot = await loadEntityConfigSnapshot(pool.query.bind(pool), rev)
           if (!snapshot) return res.status(409).json({ ok: false, error: { code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot preview a revert.' } })
           const cells = await loadLossyRetypeCells(pool.query.bind(pool), sheetId, rev.entity_id, false)
-          const lossSummary = summarizeLoss(computeLossOutcomes(cells, fieldRow.type, lossyRetypeTargetProperty(rev), rev.entity_id))
-          const preview = computeRevertPreview(rev, snapshot)
+          const derived = lossyRetypeDerivedRevision(rev, fieldRow.type)
+          const lossSummary = summarizeLoss(computeLossOutcomes(cells, fieldRow.type, lossyRetypeTargetProperty(derived), rev.entity_id))
+          const preview = computeRevertPreview(derived, snapshot)
           // classifyRevert stays PURE (it gates every field property revert); the flag opens exactly this subset.
           preview.opKind = 'safe'
           delete preview.gatedReason
@@ -8889,15 +8951,21 @@ export function univerMetaRouter(): Router {
             if (!(await hasFullTableReadAccess(req, query as unknown as QueryFn, sheetId, access, capabilities))) {
               return { status: 403, code: 'FULL_TABLE_READ_REQUIRED', message: 'A value-transforming field revert requires unrestricted read access to every record and field of this sheet.' }
             }
+            // P1-1 TYPE-ERA GUARD, re-checked INSIDE the lock alongside the lossSummary recompute: a `type` change
+            // could have landed between preview and execute, and no other control on this path can see it.
+            if (await hasFieldTypeChangeSince(query, sheetId, rev.entity_id, rev.id)) {
+              return { status: 422, ...FIELD_TYPE_ERA_MISMATCH }
+            }
             const cap = resolveSheetRevertMaxRecords()
             const scanRows = await countLossyRetypeScanRows(query, sheetId)
             if (scanRows > cap) return { status: 413, code: 'SHEET_TOO_LARGE', message: lossyRetypeTooLargeMessage(scanRows, cap) }
             const snapshot = await loadEntityConfigSnapshot(query, rev)
             if (!snapshot) return { status: 409, code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot restore.' }
             const cells = await loadLossyRetypeCells(query, sheetId, rev.entity_id, true)
-            const outcomes = computeLossOutcomes(cells, fieldRow.type, lossyRetypeTargetProperty(rev), rev.entity_id)
+            const derived = lossyRetypeDerivedRevision(rev, fieldRow.type)
+            const outcomes = computeLossOutcomes(cells, fieldRow.type, lossyRetypeTargetProperty(derived), rev.entity_id)
             const lossSummary = summarizeLoss(outcomes)
-            const preview = computeRevertPreview(rev, snapshot)
+            const preview = computeRevertPreview(derived, snapshot)
             // §2.3: the token binds BOTH the config baseline AND the loss magnitude. The full-read gate makes the
             // re-computation range identical to the preview's (the whole table), so this is a like-for-like compare.
             const verdict = verifyConfigRestorePreviewIdentity(previewToken, {
@@ -8911,7 +8979,9 @@ export function univerMetaRouter(): Router {
               return { status: 401, code: 'PREVIEW_IDENTITY_INVALID', message: 'A valid server-minted preview identity is required; preview before restoring.' }
             }
             if (preview.driftConflict) return { status: 409, code: 'CONFIG_DRIFT', message: 'The config was changed after this revision; cannot safely revert without re-previewing.' }
-            await applyConfigRevert(query, rev)
+            // `derived` (not `rev`): the property written is the sanitizer-normalized one the preview disclosed.
+            // `applyConfigRevert` itself is UNCHANGED — Tier-1/Tier-2 keep passing their raw revision.
+            await applyConfigRevert(query, derived)
             await applyLossyRetypeCellRewrite(query, {
               sheetId,
               fieldId: rev.entity_id,

--- a/packages/core-backend/tests/integration/multitable-lossy-retype-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lossy-retype-revert-realdb.test.ts
@@ -40,6 +40,7 @@ const BASE = `base_lrr_${TS}`
 const SHEET = `sheet_lrr_${TS}`
 const FIELD = `fld_lrr_${TS}`
 const OTHER_FIELD = `fld_lrr_other_${TS}`
+const ERA_FIELD = `fld_lrr_era_${TS}`
 const U_FULL = `u_lrr_full_${TS}` // multitable:write -> canManageFields
 const BASE_FLAG = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT'
 const LOSSY_FLAG = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY'
@@ -432,6 +433,118 @@ describeIfDatabase('4c-1 lossy retype revert (real DB)', () => {
     expect(restores).toHaveLength(1)
     expect(new Set(rows.map((r) => r.config_revision_id))).toEqual(new Set([restores[0].id]))
     expect(rows.every((r) => r.config_revision_id !== rev)).toBe(true)
+  })
+
+  // ── P1-1 TYPE-ERA GUARD (adversarial-review finding: a real, end-to-end data-destruction path) ─────────────
+  // Built ENTIRELY through the normal forward pipeline (POST /fields, PATCH /fields) — no hand-crafted revision.
+  // The exploit: `changed_keys` for a property-only revert is ['property'], and BOTH drift controls key off
+  // `changed_keys` (driftConflict compares current vs `after`; baselineHash hashes only those keys). A `type`
+  // change in between is therefore invisible to them. It is REACHABLE because sanitizeFieldProperty is the
+  // identity for url/email/phone/barcode/qrcode/location, so a `string -> url` type-only PATCH preserves
+  // `property` byte-for-byte and the stale `string`-era property revision does not drift. Reverting it would
+  // coerce every cell under the NEW type = a forward `text -> url` value migration smuggled in through the
+  // revert door, which lock §7 puts explicitly out of bounds.
+  const eraQ = {
+    type: async (): Promise<string> => ((await q('SELECT type FROM meta_fields WHERE id=$1', [ERA_FIELD])).rows[0] as { type: string }).type,
+    property: async (): Promise<unknown> => ((await q('SELECT property FROM meta_fields WHERE id=$1', [ERA_FIELD])).rows[0] as { property: unknown }).property,
+    cells: async (): Promise<Record<string, unknown>> => Object.fromEntries(((await q('SELECT id, data->$2 AS v FROM meta_records WHERE sheet_id=$1 ORDER BY id', [SHEET, ERA_FIELD])).rows as Array<{ id: string; v: unknown }>).map((r) => [r.id, r.v])),
+  }
+  /** Drives the REAL forward routes so the revision chain is exactly what production would record. */
+  const seedTypeEraExploit = async (): Promise<{ propertyRevisionId: string; typeRevisionKeys: string[] }> => {
+    actor = FULL
+    await request(app).post('/api/multitable/fields').send({ id: ERA_FIELD, sheetId: SHEET, name: 'EraF', type: 'string', property: {} }).expect(201)
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid(11), SHEET, JSON.stringify({ [ERA_FIELD]: 'hello world' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid(12), SHEET, JSON.stringify({ [ERA_FIELD]: 'https://ok.example' })])
+    // (1) a plain property edit while the field is still `string` -> revision with changed_keys = ['property']
+    await request(app).patch(`/api/multitable/fields/${ERA_FIELD}`).send({ property: { note: 'a' } }).expect(200)
+    // (2) a type-only PATCH -> `url`. The url sanitizer is the identity, so `property` survives byte-for-byte
+    //     and this revision's changed_keys is ['type'] ALONE.
+    await request(app).patch(`/api/multitable/fields/${ERA_FIELD}`).send({ type: 'url' }).expect(200)
+    const revs = (await q(`SELECT id, changed_keys FROM meta_config_revisions WHERE sheet_id=$1 AND entity_id=$2 AND action='update' ORDER BY created_at ASC, id ASC`, [SHEET, ERA_FIELD])).rows as Array<{ id: string; changed_keys: string[] }>
+    const propertyRev = revs.find((r) => r.changed_keys.length === 1 && r.changed_keys[0] === 'property')
+    const typeRev = revs.find((r) => r.changed_keys.includes('type'))
+    if (!propertyRev || !typeRev) throw new Error(`fixture did not produce the expected revisions: ${JSON.stringify(revs)}`)
+    return { propertyRevisionId: propertyRev.id, typeRevisionKeys: typeRev.changed_keys }
+  }
+
+  test('P1-1 a property revert from an EARLIER type era -> 422 on preview AND execute, DB untouched', async () => {
+    bothFlagsOn()
+    process.env[CAPTURE_FLAG] = 'true'
+    const { propertyRevisionId, typeRevisionKeys } = await seedTypeEraExploit()
+
+    // the exploit's premise, asserted: the type change is invisible to `changed_keys`-based drift control
+    expect(typeRevisionKeys).toEqual(['type'])
+    expect(await eraQ.type()).toBe('url')
+    expect(await eraQ.property()).toEqual({ note: 'a' }) // preserved byte-for-byte across the type PATCH
+
+    const beforeCells = await eraQ.cells()
+    expect(beforeCells).toEqual({ [rid(11)]: 'hello world', [rid(12)]: 'https://ok.example' })
+
+    const p = await preview(propertyRevisionId)
+    expect(p.status).toBe(422)
+    expect(p.body?.error?.code).toBe('FIELD_TYPE_ERA_MISMATCH')
+    expectNoLeak(p.body)
+    const x = await execute(propertyRevisionId, 'tok')
+    expect(x.status).toBe(422)
+    expect(x.body?.error?.code).toBe('FIELD_TYPE_ERA_MISMATCH')
+    expectNoLeak(x.body)
+
+    // zero destruction: 'hello world' (an invalid url) is NOT dropped, and nothing else moved
+    expect(await eraQ.cells()).toEqual(beforeCells)
+    expect(await eraQ.type()).toBe('url')
+    expect(await eraQ.property()).toEqual({ note: 'a' })
+    expect(await restoreConfigRevisions()).toEqual([])
+    expect(await recordRevisions()).toEqual([])
+    expect(await tombstones()).toEqual([])
+  })
+
+  test('P1-1b a SAME-era property revert is unaffected by the guard (the guard refuses eras, not property reverts)', async () => {
+    bothFlagsOn()
+    actor = FULL
+    await request(app).post('/api/multitable/fields').send({ id: ERA_FIELD, sheetId: SHEET, name: 'EraF', type: 'url', property: {} }).expect(201)
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid(11), SHEET, JSON.stringify({ [ERA_FIELD]: 'https://ok.example' })])
+    await request(app).patch(`/api/multitable/fields/${ERA_FIELD}`).send({ property: { note: 'a' } }).expect(200)
+    const propertyRev = ((await q(`SELECT id FROM meta_config_revisions WHERE sheet_id=$1 AND entity_id=$2 AND changed_keys = ARRAY['property']::text[] LIMIT 1`, [SHEET, ERA_FIELD])).rows[0] as { id: string }).id
+    const p = await preview(propertyRev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.lossSummary).toEqual({ unchanged: 1, coerced: 0, dropped: 0 })
+  })
+
+  test('P1-1c the property written is the sanitizer-normalized one the preview DISCLOSED (no silent downgrade)', async () => {
+    bothFlagsOn()
+    // A hand-crafted revision whose `before.property` carries a MALFORMED cross-cutting rule. `applyConfigRevert`
+    // writes `before[k]` raw, so without the derived-revision normalization the field would end up holding it.
+    await seedField('url', { note: 'a' }, [[1, 'https://ok.example']])
+    const rev = await craftPropertyRev({ visibilityRule: { bogus: 1 } }, { note: 'a' })
+    const p = await preview(rev)
+    expect(p.status).toBe(200)
+    const disclosedTarget = p.body?.data?.preview?.target?.property
+    expect(disclosedTarget).toEqual({}) // the malformed rule is stripped, and the actor SEES the stripped target
+    const x = await execute(rev, p.body.data.previewToken)
+    expect(x.status).toBe(200)
+    expect(await fieldProperty()).toEqual(disclosedTarget) // written === disclosed
+  })
+
+  // ── P2-1 route-level Batch-1 type gate (was behaviourally correct but had ZERO wire coverage) ──────────────
+  test('P2-1 a property revert on a NON-Batch-1 field (select) stays gated: no lossSummary + execute 422', async () => {
+    bothFlagsOn()
+    // `select`'s lossiness (an option removal) is invisible to coerceBatch1Value, which is the identity for it —
+    // admitting it would preview "zero loss" and then leave orphaned values. Fail-closed: it must stay 422.
+    await seedField('select', { options: [{ value: 'a' }, { value: 'b' }] }, [[1, 'b']])
+    const rev = await craftPropertyRev({ options: [{ value: 'a' }] }, { options: [{ value: 'a' }, { value: 'b' }] })
+    const before = await cellValues()
+    const p = await preview(rev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.preview?.opKind).toBe('gated')
+    expect(p.body?.data).not.toHaveProperty('lossSummary')
+    expect(p.body?.data).not.toHaveProperty('lossNote')
+    const x = await execute(rev, p.body.data.previewToken)
+    expect(x.status).toBe(422)
+    expect(x.body?.error?.code).toBe('RESTORE_NOT_SUPPORTED')
+    expect(await cellValues()).toEqual(before)
+    expect(await fieldProperty()).toEqual({ options: [{ value: 'a' }, { value: 'b' }] })
+    expect(await restoreConfigRevisions()).toEqual([])
+    expect(await recordRevisions()).toEqual([])
   })
 
   test('L11b capture flag OFF -> zero tombstones captured, and the revert still succeeds', async () => {

--- a/packages/core-backend/tests/integration/multitable-lossy-retype-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lossy-retype-revert-realdb.test.ts
@@ -1,0 +1,466 @@
+/**
+ * 4c-1 LOSSY / value-transform field retype revert (real DB) — golden matrix L1..L11 of the design-lock
+ * (`multitable-global-history-4c1-lossy-retype-revert-design-lock-20260707.md`), as amended by the owner's
+ * R6 ratification decision (`…-r6-ratification-decision-record-20260708.md` §2: **U-L8 = full-read gate**;
+ * the lock's scoped-oracle alternative (ii) is void, so there are no scoped counts and no `undisclosedPresent`).
+ *
+ * ENVELOPE (fail-closed — see lossy-retype-oracle.ts's header and the PR body): the lossy path opens ONLY
+ * property-only field reverts (`changed_keys ⊆ {name,order,property}` ∋ `property`, NO `type`) on a field whose
+ * LIVE type is a Batch-1 codec type. A scalar-safe TYPE revert keeps its shipped schema-only, zero-value-rewrite
+ * path even with the lossy flag on (L2). Everything else stays 422 / 403 exactly as today (L1).
+ *
+ * | # | scenario                                                                             |
+ * |---|--------------------------------------------------------------------------------------|
+ * | L1 | both flags off / lossy-only / base-only → 403 · 403 · today's gated-preview + 422    |
+ * | L2 | scalar-safe type revert with BOTH flags on → schema-only, ZERO value rewrite         |
+ * | L3 | oracle three buckets exact (incl. a rating case that pins `before.property` as input)|
+ * | L4 | no full-table read (row-deny switch OR field mask) → 403 preview AND execute, 0 leak |
+ * | L5 | a cell moves bucket after preview → execute 409 PLAN_DRIFT, DB untouched             |
+ * | L5b| a cell moves WITHIN its bucket → no drift (the token binds MAGNITUDE, §2.3) — regression |
+ * | L6 | over `SHEET_REVERT_MAX_RECORDS` → 413 on BOTH sides, DB untouched                    |
+ * | L7 | injected mid-execute failure → field config AND cell values fully rolled back        |
+ * | L8 | one record revision per coerced/dropped cell; unchanged cells get none; changedFieldIds exact |
+ * | L9 | missing / wrong typed confirm → refused, DB untouched                                |
+ * | L10| (mutation, run out-of-band — see PR body) neuter oracle/cap/bucket/gate → L5/L6/L3/L4 red |
+ * | L11| 4c-2 pre-image: reason='lossy_retype' rows anchored to THIS revert's own config revision |
+ *
+ * Runs only with DATABASE_URL. All fixture ids are file-namespaced (`lrr_`) per the shared-DB bundle rule, and
+ * afterAll deletes every child row this file creates.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_lrr_${TS}`
+const SHEET = `sheet_lrr_${TS}`
+const FIELD = `fld_lrr_${TS}`
+const OTHER_FIELD = `fld_lrr_other_${TS}`
+const U_FULL = `u_lrr_full_${TS}` // multitable:write -> canManageFields
+const BASE_FLAG = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT'
+const LOSSY_FLAG = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY'
+const CAP_ENV = 'MULTITABLE_SHEET_REVERT_MAX_RECORDS'
+const CAPTURE_FLAG = 'MULTITABLE_TOMBSTONE_CAPTURE_ENABLED'
+const CONFIRM = 'revert-retype-lossy'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let actor: { id: string; roles: string[]; perms: string[] }
+const FULL = { id: U_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+
+const rid = (n: number) => `rec_lrr_${TS}_${n}`
+
+const preview = (revisionId: string) => { actor = FULL; return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-preview`).send({ revisionId }) }
+/** `confirm: null` OMITS the key entirely (an explicit `undefined` would re-trigger the default parameter). */
+const execute = (revisionId: string, previewToken: string, confirm: string | null = CONFIRM) => {
+  actor = FULL
+  const body: Record<string, unknown> = { revisionId, previewToken }
+  if (confirm !== null) body.confirm = confirm
+  return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-execute`).send(body)
+}
+
+const fieldProperty = async (): Promise<Record<string, unknown>> => ((await q('SELECT property FROM meta_fields WHERE id=$1', [FIELD])).rows[0] as { property: Record<string, unknown> }).property
+const cellValues = async (): Promise<Record<string, unknown>> => {
+  const rows = (await q('SELECT id, data->$2 AS v FROM meta_records WHERE sheet_id=$1 ORDER BY id', [SHEET, FIELD])).rows as Array<{ id: string; v: unknown }>
+  return Object.fromEntries(rows.map((r) => [r.id, r.v]))
+}
+const versions = async (): Promise<Record<string, number>> => {
+  const rows = (await q('SELECT id, version FROM meta_records WHERE sheet_id=$1 ORDER BY id', [SHEET])).rows as Array<{ id: string; version: number }>
+  return Object.fromEntries(rows.map((r) => [r.id, Number(r.version)]))
+}
+const restoreConfigRevisions = async () => (await q(`SELECT id, source, restored_from_id FROM meta_config_revisions WHERE sheet_id=$1 AND source='restore'`, [SHEET])).rows as Array<{ id: string; source: string; restored_from_id: string | null }>
+const recordRevisions = async () => (await q(`SELECT record_id, version, action, source, changed_field_ids, patch, snapshot, batch_id FROM meta_record_revisions WHERE sheet_id=$1 ORDER BY record_id`, [SHEET])).rows as Array<{ record_id: string; version: number; action: string; source: string; changed_field_ids: string[]; patch: Record<string, unknown>; snapshot: Record<string, unknown>; batch_id: string }>
+const tombstones = async () => (await q(`SELECT record_id, value, reason, config_revision_id FROM meta_field_value_tombstones WHERE sheet_id=$1 ORDER BY record_id`, [SHEET])).rows as Array<{ record_id: string; value: unknown; reason: string; config_revision_id: string | null }>
+
+/** A field config revision. `source` defaults to 'mutation'. */
+const craftRev = async (changedKeys: string[], before: unknown, after: unknown): Promise<string> =>
+  ((await q(
+    `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, actor_id)
+     VALUES ($1,'field',$2,'update',$3::jsonb,$4::jsonb,$5,$6) RETURNING id`,
+    [SHEET, FIELD, JSON.stringify(before), JSON.stringify(after), changedKeys, U_FULL],
+  )).rows[0] as { id: string }).id
+
+/** The property-only revert this slice opens: live property === `after.property`, revert restores `before.property`. */
+const craftPropertyRev = (beforeProperty: unknown, afterProperty: unknown) =>
+  craftRev(['property'], { property: beforeProperty }, { property: afterProperty })
+
+const seedField = async (type: string, liveProperty: unknown, values: Array<[number, unknown]>) => {
+  await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FIELD, SHEET, 'F', type, JSON.stringify(liveProperty), 1])
+  for (const [n, value] of values) {
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid(n), SHEET, JSON.stringify({ [FIELD]: value })])
+  }
+}
+/** A record that has NO cell for the field — nothing to lose, so it must not land in any bucket. */
+const seedKeylessRecord = async (n: number) => q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid(n), SHEET, JSON.stringify({ someOtherKey: 1 })])
+
+const setCell = (n: number, value: unknown) => q('UPDATE meta_records SET data = jsonb_set(data, ARRAY[$2::text], $3::jsonb, true) WHERE id=$1', [rid(n), FIELD, JSON.stringify(value)])
+
+describeIfDatabase('4c-1 lossy retype revert (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as { user?: unknown }).user = actor; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'LRR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, SHEET])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [U_FULL])
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_field_value_tombstones WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [U_FULL]).catch(() => {})
+  })
+  afterEach(async () => {
+    delete process.env[BASE_FLAG]
+    delete process.env[LOSSY_FLAG]
+    delete process.env[CAP_ENV]
+    delete process.env[CAPTURE_FLAG]
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+  })
+  beforeEach(async () => {
+    await q('DELETE FROM meta_field_value_tombstones WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+  })
+
+  const bothFlagsOn = () => { process.env[BASE_FLAG] = 'true'; process.env[LOSSY_FLAG] = 'true' }
+  /** The canonical L3 fixture: one cell per bucket (+ a null cell and a keyless record). */
+  const seedCurrencyFixture = async () => {
+    await seedField('currency', { precision: 0 }, [[1, 9], [2, '12.5'], [3, 'abc'], [4, ''], [5, null]])
+    await seedKeylessRecord(6)
+    return craftPropertyRev({ precision: 2 }, { precision: 0 })
+  }
+  const EXPECTED_SUMMARY = { unchanged: 2, coerced: 1, dropped: 2 } // 9 & null · '12.5'→12.5 · 'abc' throws & '' empties
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── L1 ────────────────────────────────────────────────────────────────────────────────────────────────────
+  test('L1a both flags off -> preview AND execute 403 (base-tier flag governs the whole surface)', async () => {
+    const rev = await seedCurrencyFixture()
+    const before = await cellValues()
+    const p = await preview(rev)
+    expect(p.status).toBe(403)
+    expect(p.body?.error?.code).toBe('FIELD_RETYPE_REVERT_DISABLED')
+    const x = await execute(rev, 'tok')
+    expect(x.status).toBe(403)
+    expect(x.body?.error?.code).toBe('FIELD_RETYPE_REVERT_DISABLED')
+    expect(await cellValues()).toEqual(before)
+    expect(await restoreConfigRevisions()).toEqual([])
+  })
+
+  test('L1b lossy flag ON but base flag OFF -> 403 (double gate, series-wired: base off = whole surface off)', async () => {
+    process.env[LOSSY_FLAG] = 'true'
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    expect(p.status).toBe(403)
+    expect(p.body?.error?.code).toBe('FIELD_RETYPE_REVERT_DISABLED')
+    const x = await execute(rev, 'tok')
+    expect(x.status).toBe(403)
+    expect(x.body?.error?.code).toBe('FIELD_RETYPE_REVERT_DISABLED')
+  })
+
+  test('L1c base flag ON, lossy flag OFF -> byte-for-byte today: gated preview (no lossSummary) + execute 422', async () => {
+    process.env[BASE_FLAG] = 'true'
+    const rev = await seedCurrencyFixture()
+    const before = await cellValues()
+    const p = await preview(rev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.preview?.opKind).toBe('gated')
+    expect(typeof p.body?.data?.preview?.gatedReason).toBe('string')
+    expect(p.body?.data).not.toHaveProperty('lossSummary')
+    expect(p.body?.data).not.toHaveProperty('lossNote')
+    const x = await execute(rev, p.body.data.previewToken)
+    expect(x.status).toBe(422)
+    expect(x.body?.error?.code).toBe('RESTORE_NOT_SUPPORTED')
+    expect(await cellValues()).toEqual(before)
+    expect(await fieldProperty()).toEqual({ precision: 0 })
+    expect(await restoreConfigRevisions()).toEqual([])
+  })
+
+  // ── L2 ────────────────────────────────────────────────────────────────────────────────────────────────────
+  test('L2 scalar-safe TYPE revert with BOTH flags on -> existing schema-only path, ZERO value rewrite', async () => {
+    bothFlagsOn()
+    await seedField('number', {}, [[1, 'hello']])
+    const rev = await craftRev(['type'], { type: 'string' }, { type: 'number' })
+    const p = await preview(rev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.preview?.opKind).toBe('safe')
+    expect(p.body?.data).not.toHaveProperty('lossSummary') // the lossy branch must not claim a type revert
+    const x = await execute(rev, p.body.data.previewToken, null) // no typed confirm on the schema-only tier
+    expect(x.status).toBe(200)
+    expect(((await q('SELECT type FROM meta_fields WHERE id=$1', [FIELD])).rows[0] as { type: string }).type).toBe('string')
+    expect(await cellValues()).toEqual({ [rid(1)]: 'hello' }) // the value that does NOT fit `string`… is kept raw
+    expect(await recordRevisions()).toEqual([]) // ZERO value rewrite ⇒ zero record revisions
+  })
+
+  // ── L3 ────────────────────────────────────────────────────────────────────────────────────────────────────
+  test('L3a oracle three buckets exact; a keyless record is in no bucket', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.lossSummary).toEqual(EXPECTED_SUMMARY)
+    expect(p.body?.data?.preview?.opKind).toBe('safe')
+    expect(p.body?.data?.confirm).toBe(CONFIRM)
+    expect(typeof p.body?.data?.lossNote).toBe('string')
+    // preview is a pure read
+    expect(await fieldProperty()).toEqual({ precision: 0 })
+    expect(await recordRevisions()).toEqual([])
+  })
+
+  test('L3b oracle coerces against the REVISION\'s before.property, not the live property (rating max 10 -> 5)', async () => {
+    bothFlagsOn()
+    // live max=10 (8 is legal); the revert restores max=5, under which 8 is NOT representable -> dropped.
+    await seedField('rating', { max: 10 }, [[1, 8], [2, 3]])
+    const rev = await craftPropertyRev({ max: 5 }, { max: 10 })
+    const p = await preview(rev)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.lossSummary).toEqual({ unchanged: 1, coerced: 0, dropped: 1 })
+  })
+
+  // ── L4 (U-L8 full-read gate, owner ruling) ────────────────────────────────────────────────────────────────
+  const expectNoLeak = (body: unknown) => {
+    const serialized = JSON.stringify(body)
+    expect(serialized).not.toContain('lossSummary')
+    expect(serialized).not.toContain('undisclosed')
+    expect(serialized).not.toMatch(/\b(unchanged|coerced|dropped)\b/)
+  }
+
+  test('L4a row-level read-deny switch on (non-admin) -> 403 on preview AND execute, zero count leakage', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const before = await cellValues()
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = true WHERE id = $1', [SHEET])
+    const p = await preview(rev)
+    expect(p.status).toBe(403)
+    expect(p.body?.error?.code).toBe('FULL_TABLE_READ_REQUIRED')
+    expectNoLeak(p.body)
+    const x = await execute(rev, 'tok')
+    expect(x.status).toBe(403)
+    expect(x.body?.error?.code).toBe('FULL_TABLE_READ_REQUIRED')
+    expectNoLeak(x.body)
+    expect(await cellValues()).toEqual(before)
+    expect(await fieldProperty()).toEqual({ precision: 0 })
+    expect(await restoreConfigRevisions()).toEqual([])
+  })
+
+  test('L4b a field-permission mask on ANY field of the sheet -> 403 on preview AND execute', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [OTHER_FIELD, SHEET, 'Other', 'string', '{}', 2])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,false,false)', [SHEET, OTHER_FIELD, 'user', U_FULL])
+    const p = await preview(rev)
+    expect(p.status).toBe(403)
+    expect(p.body?.error?.code).toBe('FULL_TABLE_READ_REQUIRED')
+    expectNoLeak(p.body)
+    const x = await execute(rev, 'tok')
+    expect(x.status).toBe(403)
+    expect(x.body?.error?.code).toBe('FULL_TABLE_READ_REQUIRED')
+    expect(await restoreConfigRevisions()).toEqual([])
+  })
+
+  // ── L5 / L5b ──────────────────────────────────────────────────────────────────────────────────────────────
+  test('L5 a cell CHANGES BUCKET after preview -> execute 409 PLAN_DRIFT, DB untouched', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    expect(p.body?.data?.lossSummary).toEqual(EXPECTED_SUMMARY)
+    await setCell(3, '7') // 'abc' (dropped) -> '7' (coerced): the magnitude the actor confirmed is now stale
+    const before = await cellValues()
+    const x = await execute(rev, p.body.data.previewToken)
+    expect(x.status).toBe(409)
+    expect(x.body?.error?.code).toBe('PLAN_DRIFT')
+    expect(await cellValues()).toEqual(before)
+    expect(await fieldProperty()).toEqual({ precision: 0 })
+    expect(await restoreConfigRevisions()).toEqual([])
+    expect(await recordRevisions()).toEqual([])
+  })
+
+  test('L5b a cell moves WITHIN its bucket -> no drift (§2.3 binds the loss MAGNITUDE, not per-cell values)', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    await setCell(3, 'xyz') // 'abc' -> 'xyz': still `dropped`, so the magnitude is unchanged
+    const x = await execute(rev, p.body.data.previewToken)
+    expect(x.status).toBe(200)
+    expect(x.body?.data?.lossSummary).toEqual(EXPECTED_SUMMARY)
+  })
+
+  // ── L6 ────────────────────────────────────────────────────────────────────────────────────────────────────
+  test('L6 over the write-symmetric cap -> 413 on preview AND execute, DB untouched', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture() // 6 records
+    process.env[CAP_ENV] = '2'
+    const before = await cellValues()
+    const p = await preview(rev)
+    expect(p.status).toBe(413)
+    expect(p.body?.error?.code).toBe('SHEET_TOO_LARGE')
+    const x = await execute(rev, 'tok')
+    expect(x.status).toBe(413)
+    expect(x.body?.error?.code).toBe('SHEET_TOO_LARGE')
+    expect(await cellValues()).toEqual(before)
+    expect(await fieldProperty()).toEqual({ precision: 0 })
+    expect(await restoreConfigRevisions()).toEqual([])
+  })
+
+  // ── L7 ────────────────────────────────────────────────────────────────────────────────────────────────────
+  test('L7 atomicity: a failure injected mid-execute rolls back BOTH the field config and every cell value', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    const before = await cellValues()
+    const beforeVersions = await versions()
+    // Sheet-scoped so a shared-DB bundle's other test files are unaffected.
+    await q(`CREATE OR REPLACE FUNCTION ms_lrr_boom_${TS}() RETURNS trigger AS $fn$ BEGIN IF NEW.sheet_id = '${SHEET}' THEN RAISE EXCEPTION 'ms-4c1 injected failure'; END IF; RETURN NEW; END; $fn$ LANGUAGE plpgsql`, [])
+    await q(`CREATE TRIGGER ms_lrr_boom_trg_${TS} BEFORE INSERT ON meta_record_revisions FOR EACH ROW EXECUTE FUNCTION ms_lrr_boom_${TS}()`, [])
+    try {
+      const x = await execute(rev, p.body.data.previewToken)
+      expect(x.status).toBe(500)
+      expect(await fieldProperty()).toEqual({ precision: 0 }) // NOT reverted to {precision:2}
+      expect(await cellValues()).toEqual(before)
+      expect(await versions()).toEqual(beforeVersions)
+      expect(await recordRevisions()).toEqual([])
+      expect(await restoreConfigRevisions()).toEqual([])
+      expect(await tombstones()).toEqual([])
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ms_lrr_boom_trg_${TS} ON meta_record_revisions`, [])
+      await q(`DROP FUNCTION IF EXISTS ms_lrr_boom_${TS}()`, [])
+    }
+  })
+
+  // ── L8 ────────────────────────────────────────────────────────────────────────────────────────────────────
+  test('L8 happy path: config reverted, cells transformed, ONE record revision per coerced/dropped cell', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    const x = await execute(rev, p.body.data.previewToken)
+    expect(x.status).toBe(200)
+    expect(x.body?.data?.lossSummary).toEqual(EXPECTED_SUMMARY)
+
+    expect(await fieldProperty()).toEqual({ precision: 2 }) // the reverted-to config
+    expect(await cellValues()).toEqual({
+      [rid(1)]: 9,      // unchanged
+      [rid(2)]: 12.5,   // coerced: the string was re-formatted by the codec
+      [rid(3)]: null,   // dropped: not representable
+      [rid(4)]: null,   // dropped: emptied
+      [rid(5)]: null,   // unchanged (was already null)
+      [rid(6)]: null,   // keyless record: `data->field` is SQL NULL — never touched
+    })
+    // versions bumped ONLY on rewritten records
+    expect(await versions()).toEqual({ [rid(1)]: 1, [rid(2)]: 2, [rid(3)]: 2, [rid(4)]: 2, [rid(5)]: 1, [rid(6)]: 1 })
+
+    const revisions = await recordRevisions()
+    expect(revisions.map((r) => r.record_id)).toEqual([rid(2), rid(3), rid(4)]) // exactly the changed cells
+    expect(new Set(revisions.map((r) => r.batch_id)).size).toBe(1) // LOCK-12: one user action = one batch
+    for (const r of revisions) {
+      expect(r.action).toBe('update')
+      expect(r.source).toBe('restore')
+      expect(r.changed_field_ids).toEqual([FIELD]) // exact — no over-reporting of untouched fields
+      expect(Object.keys(r.patch)).toEqual([FIELD])
+    }
+    expect(revisions.find((r) => r.record_id === rid(2))?.patch).toEqual({ [FIELD]: 12.5 })
+    expect(revisions.find((r) => r.record_id === rid(2))?.snapshot).toEqual({ [FIELD]: 12.5 })
+    expect(revisions.find((r) => r.record_id === rid(3))?.patch).toEqual({ [FIELD]: null })
+    expect(revisions.find((r) => r.record_id === rid(2))?.version).toBe(2)
+
+    const restores = await restoreConfigRevisions()
+    expect(restores).toHaveLength(1)
+    expect(restores[0].restored_from_id).toBe(rev)
+  })
+
+  // ── L9 ────────────────────────────────────────────────────────────────────────────────────────────────────
+  // NOTE the design-lock's §4 table shorthand says 422 for a bad confirm; §2.4's normative text says "mirror
+  // uncreate/undelete", and BOTH of those (plus permission-revert) answer 400 CONFIRM_REQUIRED on this very
+  // endpoint. Same-endpoint consistency wins; see the PR body. What the golden truly locks is: refused, 0 writes.
+  test('L9 missing / wrong typed confirm -> refused with CONFIRM_REQUIRED, DB untouched', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    const before = await cellValues()
+    for (const confirm of [null, '', 'uncreate', 'revert-retype', 'REVERT-RETYPE-LOSSY']) {
+      const x = await execute(rev, p.body.data.previewToken, confirm)
+      expect(x.status).toBe(400)
+      expect(x.body?.error?.code).toBe('CONFIRM_REQUIRED')
+    }
+    expect(await cellValues()).toEqual(before)
+    expect(await fieldProperty()).toEqual({ precision: 0 })
+    expect(await restoreConfigRevisions()).toEqual([])
+    expect(await recordRevisions()).toEqual([])
+  })
+
+  test('L9b a preview token minted for a DIFFERENT field cannot drive this execute (401), DB untouched', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const x = await execute(rev, 'not-a-server-minted-token')
+    expect(x.status).toBe(401)
+    expect(x.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID')
+    expect(await restoreConfigRevisions()).toEqual([])
+  })
+
+  // ── L11 (4c-2 pre-image linkage) ──────────────────────────────────────────────────────────────────────────
+  test('L11a capture flag ON -> one lossy_retype tombstone per coerced/dropped cell, anchored to THIS revert\'s revision', async () => {
+    bothFlagsOn()
+    process.env[CAPTURE_FLAG] = 'true'
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    const x = await execute(rev, p.body.data.previewToken)
+    expect(x.status).toBe(200)
+
+    const rows = await tombstones()
+    expect(rows.map((r) => r.record_id)).toEqual([rid(2), rid(3), rid(4)]) // only the cells that lost something
+    expect(rows.every((r) => r.reason === 'lossy_retype')).toBe(true)
+    // the PRE-image (the true value), not the coerced result — this is what a revert-of-revert recovers
+    expect(rows.find((r) => r.record_id === rid(2))?.value).toBe('12.5')
+    expect(rows.find((r) => r.record_id === rid(3))?.value).toBe('abc')
+    expect(rows.find((r) => r.record_id === rid(4))?.value).toBe('')
+    // the anchor is THIS lossy revert's OWN config revision ("回指触发行"), not the reverted-from revision
+    const restores = await restoreConfigRevisions()
+    expect(restores).toHaveLength(1)
+    expect(new Set(rows.map((r) => r.config_revision_id))).toEqual(new Set([restores[0].id]))
+    expect(rows.every((r) => r.config_revision_id !== rev)).toBe(true)
+  })
+
+  test('L11b capture flag OFF -> zero tombstones captured, and the revert still succeeds', async () => {
+    bothFlagsOn()
+    const rev = await seedCurrencyFixture()
+    const p = await preview(rev)
+    const x = await execute(rev, p.body.data.previewToken)
+    expect(x.status).toBe(200)
+    expect(await tombstones()).toEqual([])
+    expect(await fieldProperty()).toEqual({ precision: 2 })
+  })
+
+  test('L11c capture flag ON but over the tombstone cap -> the REVERT ITSELF is refused (422), DB untouched', async () => {
+    bothFlagsOn()
+    process.env[CAPTURE_FLAG] = 'true'
+    process.env.MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS = '1' // 3 cells would be captured
+    try {
+      const rev = await seedCurrencyFixture()
+      const p = await preview(rev)
+      const before = await cellValues()
+      const x = await execute(rev, p.body.data.previewToken)
+      expect(x.status).toBe(422)
+      expect(x.body?.error?.code).toBe('TOMBSTONE_CAPTURE_CAP_EXCEEDED')
+      expect(await cellValues()).toEqual(before)
+      expect(await fieldProperty()).toEqual({ precision: 0 })
+      expect(await tombstones()).toEqual([])
+      expect(await restoreConfigRevisions()).toEqual([])
+    } finally {
+      delete process.env.MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-lossy-retype-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lossy-retype-revert-realdb.test.ts
@@ -525,6 +525,51 @@ describeIfDatabase('4c-1 lossy retype revert (real DB)', () => {
     expect(await fieldProperty()).toEqual(disclosedTarget) // written === disclosed
   })
 
+  test('P1-1d TOCTOU: a type change AFTER a passing preview is caught by the EXECUTE-side guard, with a REAL token', async () => {
+    // Fixing the review's NIT-1 (P1-1 used a fake 'tok' so it only exercised the preview guard) and P3-B (the
+    // execute guard's IN-LOCK position was untested). Here the preview passes and mints a genuine token BEFORE
+    // any type change exists; the type-only PATCH lands in the window between preview and execute. Only the
+    // execute-side re-check (inside the FOR UPDATE txn) can catch this — the preview guard already passed, and it
+    // surfaces as FIELD_TYPE_ERA_MISMATCH rather than PLAN_DRIFT precisely because the era guard runs BEFORE the
+    // lossSummary recompute, i.e. it is the first line of defence for this whole class, not a drift side-effect.
+    // (Mutation-confirmed: neuter the execute-side guard and this returns 409 PLAN_DRIFT here — the lossHash
+    // recompute is a genuine second line for the *drifting* case. The reviewer separately proved the era guard is
+    // the SOLE defence for the count-conserving email<->url case, where lossHash is blind — see
+    // /tmp/pr3922-4c1-fix-review-claude-20260708.md MB. This golden pins the guard's existence + ordering.)
+    bothFlagsOn()
+    process.env[CAPTURE_FLAG] = 'true'
+    actor = FULL
+    await request(app).post('/api/multitable/fields').send({ id: ERA_FIELD, sheetId: SHEET, name: 'EraF', type: 'string', property: {} }).expect(201)
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid(11), SHEET, JSON.stringify({ [ERA_FIELD]: 'hello world' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid(12), SHEET, JSON.stringify({ [ERA_FIELD]: 'https://ok.example' })])
+    // A plain property edit while the field is still `string` -> the revision we will try to revert.
+    await request(app).patch(`/api/multitable/fields/${ERA_FIELD}`).send({ property: { note: 'a' } }).expect(200)
+    const propertyRev = ((await q(`SELECT id FROM meta_config_revisions WHERE sheet_id=$1 AND entity_id=$2 AND changed_keys = ARRAY['property']::text[] ORDER BY created_at DESC, id DESC LIMIT 1`, [SHEET, ERA_FIELD])).rows[0] as { id: string }).id
+
+    // (1) preview passes NOW (field is still `string`, no later type change) and mints a genuine token.
+    const p = await preview(propertyRev)
+    expect(p.status).toBe(200)
+    const realToken = p.body?.data?.previewToken as string
+    expect(typeof realToken).toBe('string')
+    const beforeCells = await eraQ.cells()
+
+    // (2) TOCTOU: a type-only PATCH -> `url` lands in the window. The url sanitizer is the identity, so `property`
+    //     survives byte-for-byte and this type revision is invisible to the changed_keys-based drift controls.
+    await request(app).patch(`/api/multitable/fields/${ERA_FIELD}`).send({ type: 'url' }).expect(200)
+
+    // (3) execute with the REAL token -> the execute-side era guard refuses, and nothing is coerced under `url`.
+    const x = await execute(propertyRev, realToken)
+    expect(x.status).toBe(422)
+    expect(x.body?.error?.code).toBe('FIELD_TYPE_ERA_MISMATCH')
+    expectNoLeak(x.body)
+    expect(await eraQ.cells()).toEqual(beforeCells) // 'hello world' NOT dropped
+    expect(await eraQ.type()).toBe('url')
+    expect(await eraQ.property()).toEqual({ note: 'a' })
+    expect(await restoreConfigRevisions()).toEqual([])
+    expect(await recordRevisions()).toEqual([])
+    expect(await tombstones()).toEqual([])
+  })
+
   // ── P2-1 route-level Batch-1 type gate (was behaviourally correct but had ZERO wire coverage) ──────────────
   test('P2-1 a property revert on a NON-Batch-1 field (select) stays gated: no lossSummary + execute 422', async () => {
     bothFlagsOn()

--- a/packages/core-backend/tests/unit/lossy-retype-oracle.test.ts
+++ b/packages/core-backend/tests/unit/lossy-retype-oracle.test.ts
@@ -1,0 +1,145 @@
+/**
+ * 4c-1 loss oracle + envelope predicate — pure unit coverage (no DB). The real-DB golden matrix L1..L11 lives in
+ * `tests/integration/multitable-lossy-retype-revert-realdb.test.ts`; this file pins the PURE contract the route
+ * depends on: the fail-closed envelope (which is the whole safety story — see the module header for the §2.1
+ * ambiguity), the double flag gate, and the three-bucket classification including its property-sensitivity.
+ */
+import { afterEach, describe, expect, test } from 'vitest'
+
+import {
+  classifyCellLoss,
+  computeLossOutcomes,
+  isLossyPropertyRetypeRevertShape,
+  isLossyRetypeRevertEnabled,
+  isLossyRetypeSupportedFieldType,
+  summarizeLoss,
+} from '../../src/multitable/lossy-retype-oracle'
+import { isSupportedFieldRetypeRevert, type ConfigRevisionRow } from '../../src/multitable/config-restore'
+
+const rev = (over: Partial<ConfigRevisionRow>): ConfigRevisionRow => ({
+  id: 'r1', sheet_id: 's1', entity_type: 'field', entity_id: 'f1', action: 'update',
+  before: null, after: null, changed_keys: [], ...over,
+})
+
+describe('4c-1 envelope predicate (fail-closed)', () => {
+  test('admits a property-only field update revert', () => {
+    expect(isLossyPropertyRetypeRevertShape(rev({ changed_keys: ['property'] }))).toBe(true)
+    expect(isLossyPropertyRetypeRevertShape(rev({ changed_keys: ['name', 'property'] }))).toBe(true)
+    expect(isLossyPropertyRetypeRevertShape(rev({ changed_keys: ['property', 'order'] }))).toBe(true)
+  })
+
+  test('REFUSES anything carrying a `type` change — that is the shipped schema-only tier, not this one', () => {
+    expect(isLossyPropertyRetypeRevertShape(rev({ changed_keys: ['type'] }))).toBe(false)
+    expect(isLossyPropertyRetypeRevertShape(rev({ changed_keys: ['type', 'property'] }))).toBe(false)
+  })
+
+  test('REFUSES non-field entities, non-update actions, unknown keys, and empty changed_keys', () => {
+    expect(isLossyPropertyRetypeRevertShape(rev({ entity_type: 'view', changed_keys: ['property'] }))).toBe(false)
+    expect(isLossyPropertyRetypeRevertShape(rev({ entity_type: 'sheet_config', changed_keys: ['property'] }))).toBe(false)
+    expect(isLossyPropertyRetypeRevertShape(rev({ action: 'create', changed_keys: ['property'] }))).toBe(false)
+    expect(isLossyPropertyRetypeRevertShape(rev({ action: 'delete', changed_keys: ['property'] }))).toBe(false)
+    expect(isLossyPropertyRetypeRevertShape(rev({ changed_keys: ['property', 'somethingElse'] }))).toBe(false)
+    expect(isLossyPropertyRetypeRevertShape(rev({ changed_keys: ['name'] }))).toBe(false) // no property → not ours
+    expect(isLossyPropertyRetypeRevertShape(rev({ changed_keys: [] }))).toBe(false)
+  })
+
+  test('is DISJOINT from the shipped Tier-2 predicate — no revision can take both paths', () => {
+    const candidates: string[][] = [['type'], ['property'], ['type', 'property'], ['name', 'property'], ['name', 'order'], ['name', 'order', 'type', 'property']]
+    for (const changed_keys of candidates) {
+      const r = rev({ changed_keys, before: { type: 'string', property: {} }, after: { type: 'number', property: {} } })
+      expect(isLossyPropertyRetypeRevertShape(r) && isSupportedFieldRetypeRevert(r)).toBe(false)
+    }
+  })
+
+  test('the TYPE half admits exactly the Batch-1 codec types (and no excluded/derived type)', () => {
+    for (const t of ['currency', 'percent', 'rating', 'duration', 'url', 'email', 'phone', 'barcode', 'qrcode', 'location', 'dateTime']) {
+      expect(isLossyRetypeSupportedFieldType(t)).toBe(true)
+    }
+    // excluded / derived / materialized types — a raw meta_fields UPDATE cannot safely leave these
+    for (const t of ['formula', 'lookup', 'rollup', 'link', 'attachment', 'button', 'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy']) {
+      expect(isLossyRetypeSupportedFieldType(t)).toBe(false)
+    }
+    // plain scalars the oracle cannot reason about (coerceBatch1Value is the identity for them) stay out
+    for (const t of ['string', 'number', 'boolean', 'date', 'select', 'multiSelect', 'longText', '']) {
+      expect(isLossyRetypeSupportedFieldType(t)).toBe(false)
+    }
+  })
+})
+
+describe('4c-1 double flag gate', () => {
+  const BASE = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT'
+  const LOSSY = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY'
+  afterEach(() => { delete process.env[BASE]; delete process.env[LOSSY] })
+
+  test('needs BOTH flags; default off; only the exact string "true" counts', () => {
+    expect(isLossyRetypeRevertEnabled({})).toBe(false)
+    expect(isLossyRetypeRevertEnabled({ [BASE]: 'true' })).toBe(false)
+    expect(isLossyRetypeRevertEnabled({ [LOSSY]: 'true' })).toBe(false)
+    expect(isLossyRetypeRevertEnabled({ [BASE]: 'true', [LOSSY]: 'true' })).toBe(true)
+    expect(isLossyRetypeRevertEnabled({ [BASE]: 'true', [LOSSY]: '1' })).toBe(false)
+    expect(isLossyRetypeRevertEnabled({ [BASE]: 'true', [LOSSY]: 'TRUE' })).toBe(false)
+    expect(isLossyRetypeRevertEnabled({ [BASE]: 'yes', [LOSSY]: 'true' })).toBe(false)
+  })
+
+  test('reads process.env by default and is off in a clean environment', () => {
+    expect(isLossyRetypeRevertEnabled()).toBe(false)
+  })
+})
+
+describe('4c-1 three-bucket cell oracle', () => {
+  const bucket = (type: string, property: Record<string, unknown> | undefined, value: unknown) => classifyCellLoss(type, property, 'f1', value)
+
+  test('unchanged: a value the restored config already represents', () => {
+    expect(bucket('currency', {}, 9)).toEqual({ bucket: 'unchanged', next: 9 })
+    expect(bucket('currency', {}, null)).toEqual({ bucket: 'unchanged', next: null })
+    expect(bucket('rating', { max: 5 }, 3)).toEqual({ bucket: 'unchanged', next: 3 })
+    expect(bucket('email', {}, 'a@b.com')).toEqual({ bucket: 'unchanged', next: 'a@b.com' })
+  })
+
+  test('coerced: representable but rewritten by the codec', () => {
+    expect(bucket('currency', {}, '12.5')).toEqual({ bucket: 'coerced', next: 12.5 })
+    expect(bucket('duration', {}, '3600')).toEqual({ bucket: 'coerced', next: 3600 })
+    expect(bucket('url', {}, '  https://x.test  ')).toEqual({ bucket: 'coerced', next: 'https://x.test' })
+  })
+
+  test('dropped: the codec throws (not representable)', () => {
+    expect(bucket('currency', {}, 'abc')).toEqual({ bucket: 'dropped', next: null })
+    expect(bucket('rating', { max: 5 }, 8)).toEqual({ bucket: 'dropped', next: null })
+    expect(bucket('duration', {}, -5)).toEqual({ bucket: 'dropped', next: null })
+    expect(bucket('email', {}, 'not-an-email')).toEqual({ bucket: 'dropped', next: null })
+  })
+
+  test('dropped: the codec EMPTIES a non-empty value (a cell that ends up blank is a loss, not a coercion)', () => {
+    expect(bucket('currency', {}, '')).toEqual({ bucket: 'dropped', next: null })
+    expect(bucket('url', {}, '   ')).toEqual({ bucket: 'dropped', next: null })
+  })
+
+  test('the RESTORED property is load-bearing: the same value buckets differently under a different property', () => {
+    expect(bucket('rating', { max: 10 }, 8).bucket).toBe('unchanged')
+    expect(bucket('rating', { max: 5 }, 8).bucket).toBe('dropped')
+  })
+
+  test('object values compare canonically — a jsonb key-order difference is NOT a coercion', () => {
+    const stored = { longitude: 2, latitude: 1, address: 'x' } // Postgres jsonb order
+    expect(bucket('location', {}, stored).bucket).toBe('unchanged')
+    // an extra key the codec drops IS a coercion
+    expect(bucket('location', {}, { address: 'x', latitude: 1, longitude: 2, stray: 'y' }).bucket).toBe('coerced')
+  })
+
+  test('summarizeLoss counts every outcome exactly once', () => {
+    const outcomes = computeLossOutcomes(
+      [
+        { recordId: 'a', value: 9 },
+        { recordId: 'b', value: '12.5' },
+        { recordId: 'c', value: 'abc' },
+        { recordId: 'd', value: '' },
+        { recordId: 'e', value: null },
+      ],
+      'currency', {}, 'f1',
+    )
+    expect(summarizeLoss(outcomes)).toEqual({ unchanged: 2, coerced: 1, dropped: 2 })
+    expect(outcomes.find((o) => o.recordId === 'c')).toEqual({ recordId: 'c', bucket: 'dropped', before: 'abc', after: null })
+    expect(outcomes.find((o) => o.recordId === 'b')).toEqual({ recordId: 'b', bucket: 'coerced', before: '12.5', after: 12.5 })
+    expect(summarizeLoss([])).toEqual({ unchanged: 0, coerced: 0, dropped: 0 })
+  })
+})

--- a/packages/core-backend/tests/unit/restore-preview-identity.test.ts
+++ b/packages/core-backend/tests/unit/restore-preview-identity.test.ts
@@ -5,11 +5,13 @@
  * T6-1 is the mint/verify module ONLY — verified here against SYNTHETIC expected claims; the execute computing
  * the real diff → expected → verify → write is T6-2.
  */
-import { describe, expect, it } from 'vitest'
+import { createHash, createHmac } from 'node:crypto'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   hashDeleteSet,
   hashPermissionGrant,
+  hashLossSummary,
   hashPreviewChanges,
   hashResurrectSet,
   hashScope,
@@ -244,5 +246,55 @@ describe('restore preview identity — cross-strategy disjointness (all discrimi
     const result = verifier.verifyAsSelf(token)
     expect(result.valid).toBe(false)
     expect(result.reason).toBe('wrong_type')
+  })
+})
+
+// ── 4c-1: hashLossSummary must be KEYED (HMAC), never a plain digest ───────────────────────────────────────────
+// LOAD-BEARING, and previously untested: `lossHash` rides in a JWT payload the token holder can base64-decode, and
+// `entityId` (the fieldId) is a sibling claim in that same payload. Its only other inputs are three small integers.
+// A plain `sha256` would therefore be brute-forceable in milliseconds — turning ONE leaked preview token into an
+// exact "how many cells of that table get dropped" oracle for a table the holder may have no read access to. That
+// is precisely the counting oracle U-L8's full-read gate exists to eliminate, so the server key is what makes the
+// claim opaque (identical reasoning to hashUncreatePlan's `columnDataPresent` ~1-bit input).
+describe('4c-1 hashLossSummary — keyed HMAC, not a plain digest', () => {
+  const SECRET_ENV = 'RESTORE_PREVIEW_SECRET'
+  const original = process.env[SECRET_ENV]
+  afterEach(() => {
+    if (original === undefined) delete process.env[SECRET_ENV]
+    else process.env[SECRET_ENV] = original
+  })
+
+  const summary = { unchanged: 2, coerced: 1, dropped: 2 }
+
+  it('is a function of the SERVER SECRET — rotating the key changes the digest', () => {
+    process.env[SECRET_ENV] = 'secret-alpha-0123456789abcdef'
+    const a = hashLossSummary('fld_1', summary)
+    process.env[SECRET_ENV] = 'secret-bravo-0123456789abcdef'
+    const b = hashLossSummary('fld_1', summary)
+    expect(a).not.toBe(b)
+    process.env[SECRET_ENV] = 'secret-alpha-0123456789abcdef'
+    expect(hashLossSummary('fld_1', summary)).toBe(a) // deterministic under a fixed key
+  })
+
+  it('is NOT the unkeyed sha256 of its own canonical input (a swap to createHash must fail here)', () => {
+    process.env[SECRET_ENV] = 'secret-alpha-0123456789abcdef'
+    const canonical = JSON.stringify({ fieldId: 'fld_1', unchanged: 2, coerced: 1, dropped: 2 })
+    const plain = createHash('sha256').update(canonical).digest('hex')
+    expect(hashLossSummary('fld_1', summary)).not.toBe(plain)
+    // and the keyed digest IS reproducible only with the key
+    expect(hashLossSummary('fld_1', summary)).toBe(createHmac('sha256', 'secret-alpha-0123456789abcdef').update(canonical).digest('hex'))
+  })
+
+  it('binds the fieldId — the same counts on another field yield a different digest', () => {
+    process.env[SECRET_ENV] = 'secret-alpha-0123456789abcdef'
+    expect(hashLossSummary('fld_1', summary)).not.toBe(hashLossSummary('fld_2', summary))
+  })
+
+  it('binds every bucket — moving one cell between buckets changes the digest', () => {
+    process.env[SECRET_ENV] = 'secret-alpha-0123456789abcdef'
+    const base = hashLossSummary('fld_1', summary)
+    expect(hashLossSummary('fld_1', { unchanged: 3, coerced: 1, dropped: 2 })).not.toBe(base)
+    expect(hashLossSummary('fld_1', { unchanged: 2, coerced: 2, dropped: 2 })).not.toBe(base)
+    expect(hashLossSummary('fld_1', { unchanged: 2, coerced: 1, dropped: 3 })).not.toBe(base)
   })
 })


### PR DESCRIPTION
## 4c-1 — lossy / value-transform field retype revert (RATIFIED impl)

Implements `docs/development/multitable-global-history-4c1-lossy-retype-revert-design-lock-20260707.md` (incl. the #3830 correction) under the owner's **R6 ratification decision** (`…-r6-ratification-decision-record-20260708.md`).

**Both flags default OFF.** Production enablement is the separate **O-2 operator ladder** — *this PR enables nothing*.
**U-L8 = full-read gate**, per the owner's ruling: the lock's scoped-oracle alternative (ii) is void — **no scoped counts, no `undisclosedPresent` marker** anywhere in the code.

---

## 信封歧义与所取读法 (envelope ambiguity + the reading taken)

Full write-up: `/tmp/4c1-envelope-ambiguity.md` (also reproduced in `lossy-retype-oracle.ts`'s module header, which is the durable copy).

**The ambiguity.** Lock §2.1 constrains only the **target (`before`) type**: it opens *"type reverts other than scalar↔scalar whose target (`before`) type is still a plain scalar"*, and excludes *"target type ∈ `FIELD_RETYPE_EXCLUDED_TYPES`"*. Neither clause says anything about the **current (`after`) type**. The set "type reverts other than scalar↔scalar with a scalar target" therefore has exactly one member: **`after.type ∈ EXCLUDED` ∧ `before.type` scalar** — i.e. reverting a field that was forward-retyped *into* formula/link/attachment/autoNumber back to a scalar.

**Reading A (literal / wide)** — admit those. Two independent failure modes, both silent data corruption:
1. `applyConfigRevert` is a raw `UPDATE meta_fields`; it **skips** the forward PATCH's type-transition handlers (auto-number sequence teardown at `currentType==='autoNumber' && nextType!=='autoNumber'`, the `meta_links` join table, the formula dependency graph). Reverting *out of* an excluded type leaves orphan sequences / orphan `meta_links` rows / dangling formula deps. This is precisely why the shipped `isSupportedFieldRetypeRevert` (`config-restore.ts`) already requires **both** endpoints to be plain scalars.
2. `coerceBatch1Value` is the **identity function** for every non-Batch-1 type. A `link → text` revert would have the loss-oracle report *zero loss* while execute leaves link-object arrays sitting in a text column — the safety device itself signing off on the corruption.

**Reading B (fail-closed / narrow) — TAKEN.** Both endpoints must be non-excluded. Since the shipped `isSupportedFieldRetypeRevert` already covers **every** scalar↔scalar *type* revert, and **§4 L2 mandates those keep the schema-only, zero-value-rewrite path**, type-changing reverts never enter the lossy path. What remains is §2.1's **second** clause, narrowed to the types the oracle can actually reason about:

```
lossy path ⟺  entity_type='field' ∧ action='update'
            ∧ changed_keys ⊆ {name, order, property} ∧ 'property' ∈ changed_keys   (NO 'type')
            ∧ live field type ∈ BATCH1_FIELD_TYPES                                  (⇒ ∉ EXCLUDED)
            ∧ both flags on
otherwise → today's behavior byte-for-byte (403 / gated preview / 422)
```

The extra `BATCH1_FIELD_TYPES` narrowing is the same argument as (2) above: a `singleSelect` option-removal or a rich-`longText` toggle is genuinely lossy but invisible to `coerceBatch1Value`, so admitting it would preview "zero loss" and then destroy data. Those stay 422 (as they are today ⇒ zero regression).

All three buckets remain reachable inside this envelope, because the **forward** PATCH never migrates values — a `currency` column can legitimately hold `9`, `'12.5'`, `'abc'`, `''`.

**Why fail-closed is right, not just obedient:** Reading A's cost is silent corruption; Reading B's cost is "one case stays 422 — exactly as it does today, zero user-visible change". A destructive envelope can only be widened (with sign-off), never retracted.

**若 owner 想放宽 — 需单独签核 (each needs its own owner sign-off; none is in this PR):**
- **R1** open `after.type ∈ EXCLUDED → before.type` scalar. Prereq: the revert must reuse the forward route's type-transition side-effect handlers instead of a raw `UPDATE meta_fields`, **and** the oracle must be able to bucket materialized link/attachment/formula values.
- **R2** make the lossy flag also rewrite cells for the *existing* scalar-safe type revert. This **overturns §4 L2** (turning a shipped, golden-proven-lossless tier destructive). Needs explicit owner override of L2.
- **R3** admit non-Batch-1 property reverts (`singleSelect` option removal, rich-`longText` toggle). Prereq: real per-type loss oracles.

---

## 逐 § → 实现映射

| Lock § | Implementation |
|---|---|
| **§2.1 envelope, fail-closed** | `isLossyPropertyRetypeRevertShape` + `isLossyRetypeSupportedFieldType` (`lossy-retype-oracle.ts`). `classifyRevert` **untouched** — the "classify pure, route opens the window" pattern, identical to Tier-1/2/3/4. Unit-proved **disjoint** from `isSupportedFieldRetypeRevert`. |
| **§2.1 double gate** | New `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY` (default off) **and** requires the base `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT`. Base off ⇒ the pre-existing 403 fires first ⇒ whole surface 403. Lossy off ⇒ the branch is never entered ⇒ byte-for-byte today. |
| **§2.2 loss oracle** | `computeLossOutcomes` / `classifyCellLoss` replay `coerceBatch1Value(beforeType, before.property, …)` → `unchanged` / `coerced` / `dropped`. Pure, read-only, writes nothing. Preview returns `lossSummary { unchanged, coerced, dropped }` + `lossNote` (§3 honesty: "approximate restore, not a recovery of original values"). Canonical (key-order-independent) equality so a jsonb key-order difference is not miscounted as a coercion. |
| **§2.2 U-L8 (owner: full-read gate)** | `hasFullTableReadAccess` → **403 `FULL_TABLE_READ_REQUIRED` on preview AND execute**. Three axes, all **config-derived, never data-derived**: the sheet's row-level read-deny switch (+ the same admin bypass every read surface uses), the field-permission scope mask, the §2a.3 formula-taint mask. Deliberately **not** `loadDeniedRecordIds` — its rule-deny arm evaluates predicates against live data, so gating on "the denied set is empty right now" would itself be the 1-bit probe U-L8 forbids. Reuses multitable-local primitives only; **central rbac/auth untouched (C7)**. No scoped counting mode exists in the code. |
| **§2.3 loss-magnitude binding** | `hashLossSummary(fieldId, summary)` = **server-key HMAC** (mirroring `hashUncreatePlan`'s rationale: three small ints in a client-decodable JWT would be brute-forceable into an exact "how many cells drop" oracle). Folded into the **existing** config-restore preview token as `lossHash`. Execute re-computes inside the txn **after `FOR UPDATE`** and verifies → new `loss_drift` reason → **409 `PLAN_DRIFT`**. 410 `PREVIEW_EXPIRED` / 401 `PREVIEW_IDENTITY_INVALID` / 409 `PREVIEW_STALE` semantics preserved. **Absence is bound too** (`undefined ↔ undefined`), so a lossy token can never drive a non-lossy execute or vice versa. Under the full-read gate the recompute range is always the whole table — no undisclosed corner. |
| **§2.4 write-symmetric cap** | `SHEET_REVERT_MAX_RECORDS` was a **route-local const**; lifted into `restore-caps.ts` (`resolveSheetRevertMaxRecords`) and reused. Over cap → **413 `SHEET_TOO_LARGE` on both sides**, fail-closed, never truncated, never partial. The T8 PIT block still resolves once at router construction (byte-for-byte preserved); the 4c-1 surface resolves per request. |
| **§2.4 execute, single txn** | One `pool.transaction`: field `FOR UPDATE` → envelope re-check → gate → cap → cells `FOR UPDATE` → recompute + verify → capture → `applyConfigRevert` → batched cell rewrite → record revisions → `source='restore'` config revision. Any guard returns the failure object with **zero writes**; any throw rolls everything back. |
| **§2.4 record revisions (C5)** | One `meta_record_revisions` row per coerced/dropped cell (`action='update'`, `source='restore'`, `changedFieldIds=[fieldId]`, exact `patch`/`snapshot`), all sharing one `batchId` (LOCK-12). Unchanged cells get none. ⇒ the lossy revert is itself undoable via ordinary record-version restore. |
| **§2.4 typed confirm** | `confirm: 'revert-retype-lossy'`. See "口径偏离" below. |
| **§2.4 gate** | The existing config-restore `canManageFields` capability. No new capability, no central rbac/auth touched. |
| **§3 / C6 pre-image (4c-2 linkage)** | Same txn, **before** the overwrite: `captureLossyRetypePreImageRows(reason='lossy_retype')` with `config_revision_id` = **this revert's own** pre-generated config-revision id ("回指触发行"). Gated by `MULTITABLE_TOMBSTONE_CAPTURE_ENABLED`; over its cap the capture throws ⇒ **the revert itself is refused (422)**, never a half-captured destroy. Flag off ⇒ no capture, revert still succeeds. |

### 口径偏离 (recorded, one-line revert if overruled)
**Typed-confirm failure status: 400 `CONFIRM_REQUIRED`, not 422.** Lock §4's L9 table cell says 422; lock §2.4's *normative* text says "镜像 uncreate/undelete 模式" citing `univer-meta.ts:8259/:8313` — and **all three** existing destructive tiers on *this same endpoint* (un-create, undelete, permission-revert) answer **400 `CONFIRM_REQUIRED`**. A third destructive tier returning a different status for the same class of error on the same route is an inconsistency bug, and the R5 audit locked "400 CONFIRM_REQUIRED" as the destructive-tier server-authority contract. Golden L9 pins **refused + zero writes**; flipping to 422 is a one-line change if the owner rules otherwise.

---

## L1–L11 evidence

Real DB: disposable `postgres:16` (fresh container, high port), full migration chain, container removed after.
`tests/integration/multitable-lossy-retype-revert-realdb.test.ts` — **19 passed / 0 failed**.
`tests/unit/lossy-retype-oracle.test.ts` — **14 passed / 0 failed**.

| # | Golden | Result |
|---|---|---|
| **L1a** | both flags off → preview **403** + execute **403** `FIELD_RETYPE_REVERT_DISABLED`; cells + config revisions unchanged | ✅ |
| **L1b** | lossy on, base off → **403** both sides (series-wired double gate) | ✅ |
| **L1c** | base on, lossy off → preview `opKind:'gated'` + `gatedReason`, **no `lossSummary` / `lossNote` keys**; execute **422 `RESTORE_NOT_SUPPORTED`**; DB byte-identical | ✅ |
| **L2** | scalar-safe **type** revert with BOTH flags on → existing schema-only path; `'hello'` survives in the `string` field; **zero record revisions**; no `lossSummary` in the response | ✅ |
| **L3a** | buckets exact: `{unchanged:2, coerced:1, dropped:2}` over `9 / '12.5' / 'abc' / '' / null`; the **keyless record is in no bucket**; preview writes nothing | ✅ |
| **L3b** | oracle coerces against the **revision's `before.property`**, not the live property (`rating` live max 10, revert to max 5 ⇒ `8` is `dropped`) | ✅ |
| **L4a** | row-level read-deny switch on (non-admin) → **403 `FULL_TABLE_READ_REQUIRED`** on preview **and** execute; body contains no `lossSummary` / `undisclosed` / bucket words; DB untouched | ✅ |
| **L4b** | a field-permission mask on **any** field of the sheet → **403** both sides | ✅ |
| **L5** | a cell moves **bucket** after preview (`'abc'`→`'7'`) → execute **409 `PLAN_DRIFT`**; cells, field property, record revisions, restore revisions all unchanged | ✅ |
| **L5b** | a cell moves **within** its bucket (`'abc'`→`'xyz'`) → **no drift**, execute 200. Kept as a regression: §2.3 binds the loss **magnitude**, not per-cell values. Unreachable-as-an-oracle under the full-read gate. | ✅ |
| **L6** | 6 records, cap = 2 → **413 `SHEET_TOO_LARGE`** on preview **and** execute; DB untouched | ✅ |
| **L7** | sheet-scoped `BEFORE INSERT` trigger on `meta_record_revisions` raises mid-execute → **500**, and field property, all cell values, all versions, record revisions, restore revisions, tombstones **all rolled back** | ✅ |
| **L8** | happy path: property reverted to `{precision:2}`; cells → `9 / 12.5 / null / null / null`; versions bumped **only** on the 3 rewritten records; exactly 3 record revisions (`update`/`restore`/`changed_field_ids=[FIELD]`/exact `patch`+`snapshot`), **one shared `batch_id`**; exactly one `source='restore'` config revision with `restored_from_id = rev` | ✅ |
| **L9** | `confirm` absent / `''` / `'uncreate'` / `'revert-retype'` / `'REVERT-RETYPE-LOSSY'` → **400 `CONFIRM_REQUIRED`**, DB untouched (5 cases) | ✅ |
| **L9b** | forged / non-server-minted token → **401 `PREVIEW_IDENTITY_INVALID`**, DB untouched | ✅ |
| **L11a** | capture on → one `meta_field_value_tombstones` row per coerced/dropped cell, `reason='lossy_retype'`, **pre-image** values (`'12.5'`,`'abc'`,`''` — not the coerced results), `config_revision_id` = **this revert's own** restore revision (and `!== rev`) | ✅ |
| **L11b** | capture off → zero tombstones, revert still succeeds | ✅ |
| **L11c** | capture on, tombstone cap = 1, 3 cells → **422 `TOMBSTONE_CAPTURE_CAP_EXCEEDED`**, revert refused, DB untouched | ✅ |

### L10 — mutation isolation proofs
Each mutant applied to a clean tree, target golden run, tree restored (`git checkout -- <exact path>`); tree verified clean afterwards.

| Mutant | Change | Target | Observed |
|---|---|---|---|
| **M1** | delete the `lossHash` comparison in `verifyConfigRestorePreviewIdentity` (neuters the §2.3 recompute+verify) | L5 | **RED** — `1 failed \| 18 skipped` |
| **M2** | delete both `scanRows > cap` guards (preview + execute) | L6 | **RED** — `1 failed \| 18 skipped` |
| **M3** | `classifyCellLoss` always returns `unchanged` | L3a | **RED** — `1 failed \| 18 skipped` (unit: `4 failed \| 10 passed`) |
| **M4** | `hasFullTableReadAccess` returns `true` unconditionally | L4a, L4b | **RED** — both, `1 failed \| 18 skipped` each |
| **M5** *(bonus)* | drop the `COALESCE(item.value,'null'::jsonb)` null-guard in the batched cell rewrite | L8, L11a | **RED** — `null value in column "data" … violates not-null constraint` → 500. (Proves the guard is load-bearing: `jsonb_to_recordset` maps JSON `null` → SQL NULL, and `jsonb_set(data, path, NULL)` nulls the **whole** `data` column.) |

*M5 note:* the first attempt mutated the doc-comment that quotes the SQL verbatim and was a silent no-op (`L8` stayed green). Re-run against the real statement.

---

## Regression + gates

- **rank-8 record-lock structural guard** (`tests/unit/multitable-record-lock-guard.guard.test.ts`): **4 passed**. The new `meta_records` rewrite site carries `// lock-exempt: 4c-1 lossy retype revert — schema op …` **within the 3-line marker window** (it initially failed at 4 lines; fixed). Precedent: the field-delete column strip and the field-undelete rehydration.
- **§2a.3 stored-data taint chokepoint guard**: **3 passed**.
- `tsc --noEmit`: **clean** (no `any`, no dead helpers).
- Real-DB neighbours sharing this route / preview identity — `lossy-retype-revert`, `field-retype-revert`, `config-restore`, `sheet-config-revert`, `uncreate-config`, `undelete-config`, `permission-revert`, `config-revisions`: **8 files / 111 tests passed**.
- PIT revert / reset / undelete (they consume the extracted `SHEET_REVERT_MAX_RECORDS`): **3 files / 36 tests passed**.
- `restore-preview-identity` + `tombstone-capture` + `lossy-retype-oracle` + both structural guards: **5 files / 98 tests passed**.
- Full backend unit suite: **326 files / 4375 tests passed**.
- CI: the new realdb file is **UNION-appended** to `plugin-tests.yml`'s multitable realdb list (nothing removed). Fixture ids are file-namespaced (`lrr_`); `afterAll` deletes every child row; the L7 failure-injection trigger is **sheet-scoped** and dropped in a `finally`, so a shared-DB bundle's other files are unaffected.

## 未做 / 需裁量

1. **Envelope widening R1 / R2 / R3** (above) — each needs a separate owner sign-off + extra engineering. Not attempted.
2. **Typed-confirm status 400 vs 422** — deliberate, argued above; one-line change.
3. **§2.3 binds loss *magnitude*, not per-cell values** (L5b): a value edit that stays in the same bucket does not trigger `PLAN_DRIFT`. This follows the lock's text verbatim ("重算 lossSummary 并 verify"). Binding a per-cell digest instead would be strictly stronger and is still no-oracle (HMAC) — flagging it as a possible hardening, not shipped.
4. **FE surface** — out of scope per lock §7.
5. **Forward lossy retype / 4d** — out of scope per lock §7.
6. **`invalidateFieldCache(sheetId)`** is called after a successful lossy execute. The *pre-existing* Tier-1/Tier-2 config-restore execute path does **not** invalidate on success — that looks like a latent bug, but it is out of this slice's blast radius and untouched.

## 我没验证的事 (not verified)

- **Nothing was run on staging or against the shared CI Postgres.** All real-DB evidence is from a local disposable `postgres:16`, one file at a time (no cross-file scheduling exercised) — the known shared-bundle flake surface is untested here.
- **No FE / browser verification** (no FE surface in this PR).
- **Concurrency under real contention** was not load-tested; the `FOR UPDATE` serialization is argued + covered by L5/L7, not by a racing-clients harness.
- **Performance at the 5000-record cap** was not measured (goldens run ≤ 6 records). The rewrite is a single batched statement, but the per-cell `recordRecordRevision` loop is O(changed) round trips.
- **Flags were never enabled anywhere outside the test process.** No O-2 ladder step performed.

---

# 🔴→🟢 Adversarial review round 1 (CHANGES-REQUESTED) — all findings addressed

Review verdict: the six load-bearing devices (oracle / full-read gate / HMAC binding / two-sided cap / atomicity / pre-image) were each independently mutation-proved to be real guards — but **one P1 was driven end-to-end into real data destruction**. Fixed in `66a8cca`.

## P1-1 — property-only revert was not bound to its type era (**REAL DESTRUCTION**, fixed)

**Mechanism.** `changed_keys` for a property-only revert is `['property']`. Both drift controls key off `changed_keys` alone — `computeRevertPreview`'s `driftConflict` compares `current[k]` vs `after[k]` over those keys, and `configBaselineHash` hashes only those keys. **A `type` change landing in between is invisible to both.** It is *reachable* because `sanitizeFieldProperty` is the **identity** for `url|email|phone|barcode|qrcode|location`, so a type-only PATCH preserves `property` byte-for-byte and the stale revision does not drift. (`currency` is accidentally protected — its field-codecs sanitizer injects `code`/`decimals`, so it *does* drift. The identity arms are the hole.)

**Reproduced at HEAD-before-fix**, entirely through the real forward routes (`POST /fields`, `PATCH /fields`), then re-run against the fix and against the mutant:

```
revision chain : property  ->  type            (the type revision's changed_keys == ['type'] alone)
live type      : url
cells BEFORE   : ["hello world", "https://ok.example"]

# with the era guard (HEAD)
preview        : 422 "FIELD_TYPE_ERA_MISMATCH"
cells AFTER    : ["hello world", "https://ok.example"]        ← intact

# MUTANT M6 (era guard removed) — the destruction the guard prevents
preview        : 200 {"unchanged":1,"coerced":0,"dropped":1}
execute        : 200 {"unchanged":1,"coerced":0,"dropped":1}
cells AFTER    : [null, "https://ok.example"]                 ← 'hello world' DESTROYED
```

The actor believes they are undoing a property edit; what actually runs is a `text → url` **forward value migration** — which lock **§7 puts explicitly out of bounds**. C1: "未列入 §2.1 的形态永远 422".

**Fix (review's option A — no owner discretion needed; lock §2.1 already says "同 type").**
1. **Type-era guard, both sides.** `hasFieldTypeChangeSince()` — any field config revision with `'type' = ANY(changed_keys)` strictly **after** the reverted revision ⇒ **422 `FIELD_TYPE_ERA_MISMATCH`**. Ordering uses this table's **existing** deterministic order `(created_at, id)` (the ascending twin of the `ORDER BY created_at DESC, id DESC` the config-history read surface uses) — not a home-grown one. The **execute** side re-checks **inside the txn, after `FOR UPDATE`**, in the same batch as the `lossSummary` recompute. Error body carries no counts / bucket names / record data, and is reached only *after* the full-read gate has passed. Also catches a delete→undelete cycle that recreated the field at another type (`fieldDeleteDiff` / `fieldCreateDiff` both put `type` in `changed_keys`). A type change later changed *back* still trips it — deliberately fail-closed; it only ever refuses.
2. **Defense-in-depth, lossy branch only.** `applyConfigRevert` writes `before[k]` **raw** and is shared with Tier-1/2, so it is **unchanged**. Instead the lossy branch passes a *derived* revision whose `before.property` is normalized through the **route-local** `sanitizeFieldProperty` — the same normalizer the forward `normalizeFieldWriteInput` uses (write-path parity; it also applies `applyFieldValidationNormalisation`, which field-codecs' copy does not). Because `preview.target` is derived from the same value, any normalization is **disclosed** to the actor rather than applied silently — closing the review's "附带的 config 降级对 actor 完全未披露" sub-finding. On real data it is a **no-op** (stored properties are already sanitizer-shaped; `sanitizeFieldProperty` is idempotent — verified for all Batch-1 types). `driftConflict` (compares `after`) and `baselineHash` (hashes the *current* snapshot) are provably unperturbed. L2 and flag-off byte-equivalence still hold (goldens re-run green).
3. **Goldens** (realdb, replicating the review's repro):
   - `P1-1` — the full forward-pipeline exploit → **preview 422 + execute 422**, and *zero* DB change (cells, type, property, record revisions, restore revisions, tombstones all asserted). Also asserts the exploit's premise: the type revision's `changed_keys == ['type']` and `property` survived byte-for-byte.
   - `P1-1b` — a **same-era** property revert is unaffected (the guard refuses eras, not property reverts).
   - `P1-1c` — the property written **equals** the `preview.target.property` the actor saw (malformed `visibilityRule` stripped, disclosed, not silently downgraded).
4. **Mutation:** see M6 / M7 below.

## P2-1 — route-level Batch-1 type gate had zero wire coverage (test added)
Review's M8b: deleting all three `isLossyRetypeSupportedFieldType` consults left **19/19 green**. Behaviour was right; nothing watched it.
Added realdb golden **P2-1**: a property revert on a `select` field (this repo's stored type name; there is no `singleSelect`) with both flags on → preview `opKind:'gated'`, **no `lossSummary` / `lossNote` keys**, execute **422 `RESTORE_NOT_SUPPORTED`**, DB untouched.

## P2-2 — `hashLossSummary`'s HMAC keying had zero coverage (tests added)
Review's M9: swapping HMAC → plain `sha256` left realdb 19/19 **and** unit 14/14 green; `grep hashLossSummary tests/` = 0.
Why load-bearing: `lossHash` rides in a JWT payload the holder can base64-decode, and `entityId` is a sibling claim there. Its only other inputs are three small integers ⇒ a plain digest is brute-forceable in milliseconds, turning **one leaked token into an exact "how many cells get dropped" oracle** for a table the holder may not be able to read — exactly what U-L8's full-read gate exists to eliminate.
Added to `tests/unit/restore-preview-identity.test.ts` (4 tests): ① rotating the server secret changes the digest (and it is deterministic under a fixed key); ② the digest is **not** the unkeyed `sha256` of its own canonical input, **and** equals `createHmac(secret, canonical)`; ③ `fieldId` is bound; ④ every bucket is bound.

## Design-lock revised in this PR
- **§4 golden matrix, L9 cell: "422" → `400 CONFIRM_REQUIRED`.** Rationale (accepted from review): §2.4 — the *normative, "锁定"-marked* text — says "镜像 uncreate/undelete", and all three of those destructive tiers answer 400 `CONFIRM_REQUIRED`; on this route 422 is already taken by `RESTORE_NOT_SUPPORTED` ("well-formed but out of envelope"), so mixing would collapse two orthogonal failure classes into one code. **No code change** — L9 already asserted `400` / `CONFIRM_REQUIRED`. §2.4 also gained the explicit failure code.
- **§2.1 impl-era clarification (narrowing, not widening):** "同 type" means **the field's type has not changed since that revision** (type-era consistency), enforced by the two-sided era guard; any type-era-inconsistent property revert is 422.

## Deliberately NOT done (per review)
- The pre-existing `invalidateFieldCache` latent bug (Tier-1/2 execute success path does not invalidate) is **not** touched here — confirmed real, but it gets its own rung rather than riding a destructive surface.
- The `after.type ∈ EXCLUDED` interception is untouched (`config-restore.ts`'s two-endpoint exclusion structurally forbids type-changing reverts such as `link → text`).

## Mutation evidence — round 2 (all nine mutants)
Each mutant applied to a clean tree, target golden run, tree restored via `git checkout -- <exact path>`; `git status` verified clean after each. RealDB always via CI's `vitest.integration.config.ts` (`fileParallelism: false` — confirmed at line 26), one disposable `postgres:16`.

| Mutant | Change | Target | Observed |
|---|---|---|---|
| **M1** | delete the `lossHash` comparison in `verifyConfigRestorePreviewIdentity` | L5 | **RED** `1 failed \| 22 skipped` |
| **M2** | delete both `scanRows > cap` guards | L6 | **RED** `1 failed \| 22 skipped` |
| **M3** | `classifyCellLoss` always returns `unchanged` | L3a | **RED** `1 failed \| 22 skipped` |
| **M4** | `hasFullTableReadAccess` returns `true` unconditionally | L4a, L4b | **RED** both |
| **M5** | drop `COALESCE(item.value,'null'::jsonb)` in the batched rewrite | L8 | **RED** — `null value in column "data" … violates not-null` |
| **M6** *(new)* | delete the type-era guard on **both** sides | **P1-1** | **RED** `expected 200 to be 422` — and the standalone repro shows `'hello world' → null` (real destruction) |
| **M7** *(new)* | `lossyRetypeDerivedRevision` returns `rev` (no sanitization) | **P1-1c** | **RED** — `expected { visibilityRule: { bogus: 1 } } to deeply equal {}` (the malformed rule would be written raw) |
| **M8b** *(new)* | delete **all three** `isLossyRetypeSupportedFieldType` consults | **P2-1** | **RED** — `expected 'safe' to be 'gated'` |
| **M9** *(new)* | `hashLossSummary`: `createHmac` → `createHash` | **unit** | **RED** `2 failed \| 74 passed`. RealDB matrix stays **23/23 green** — confirming the review's point that only the new unit tests catch it. |

M1–M5 were **re-run after** the P1-1 fix; all still red.

## Round-2 green proof
- `multitable-lossy-retype-revert-realdb.test.ts`: **23 passed** (was 19; +P1-1, +P1-1b, +P1-1c, +P2-1).
- 4c-1 realdb + all 7 config-restore neighbours + 3 PIT files, one CI-config run: **11 files / 151 tests passed**.
- rank-8 record-lock guard + taint chokepoint + oracle unit + preview-identity unit + tombstone unit: **5 files / 102 tests passed**.
- Full backend unit suite: **326 files / 4379 tests passed**.
- `tsc --noEmit`: **clean**.
- `grep -rc hashLossSummary tests/` → `restore-preview-identity.test.ts:13` (was 0).

## Still not verified (unchanged from round 1)
Nothing on staging or the shared CI Postgres; no browser/FE; no racing-clients concurrency harness; no perf measurement near the 5000-record cap; **no flag enabled anywhere outside the test process** (O-2 ladder untouched).

**Do not merge / do not arm auto-merge.**

---
**Do not merge / do not arm auto-merge** — for main-session Opus adversarial review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
