### PR TITLE
feat(approval): G-B2-17 — 模板中心普通员工卡片画廊（管理员表格不变）

### DIFF
--- a/apps/web/src/approvals/templateGalleryFilter.ts
+++ b/apps/web/src/approvals/templateGalleryFilter.ts
@@ -4,19 +4,31 @@
  * 「给定模板列表 + 分类筛选 + 搜索词 → 可见模板」这条逻辑被抽到这里，独立于
  * TemplateCenterView.vue 之外，理由：
  *   1. 卡片画廊（!canManageTemplates 分支）需要即时过滤反馈 —— 用户每敲一个字符就重算可见
- *      集合，不必等 Enter/blur 触发后端请求（后端请求仍然发生，只是画廊不等它）。
- *   2. 覆盖范围比后端 `search` 参数更宽：同时命中模板名称与描述（参见
- *      approvals/api.ts 里 `listTemplates` 的 mock 实现，目前只按名称过滤），画廊要对普通
- *      员工诚实 —— 描述里的关键词也应该能被搜到。
- *   3. 管理员表格视图完全不消费这个函数，继续直接渲染 `store.templates`（后端过滤），行为
+ *      集合，不必等 Enter 触发后端请求。
+ *   2. 管理员表格视图完全不消费这个函数，继续直接渲染 `store.templates`（后端过滤），行为
  *      不变 —— 这是分叉设计的一部分，不是遗漏。
+ *
+ * **谓词必须与服务端一致**（这是本模块最重要的约束）。服务端 `listTemplates` 的实际 SQL 是：
+ *
+ *     (name ILIKE '%q%' OR key ILIKE '%q%')   AND   category = $n
+ *
+ * 因此这里也只匹配 **name 或 key**，且分类是**精确相等**：
+ *   - 若这里额外匹配 `description`：用户边打字时能看到一张「描述命中」的卡，一按 Enter
+ *     服务端重新过滤（不看 description）→ 卡片**凭空消失**。让人看见一个按下回车就不存在的
+ *     结果，比不给即时反馈更糟。
+ *   - 若这里**漏掉** `key`：服务端明明按 key 命中并返回了该模板，画廊却把它**过滤掉**
+ *     —— 用户按 key 搜索得到一片空白。（这正是本函数最初的缺陷。）
+ *
+ * 即：本地过滤是「服务端会返回什么」的忠实预览（分页范围内），不是一套更宽或更窄的平行语义。
+ * 若将来希望描述可搜，正确的做法是**改服务端谓词**，而不是让前端单方面放宽。
  *
  * 保持零依赖（不碰 store / API / Vue），方便用矩阵单测钉死行为，而不必挂载整个视图组件。
  */
 
 export interface GalleryFilterableTemplate {
   name: string
-  description?: string | null
+  /** 与服务端 `key ILIKE` 对齐；模板列表 DTO 一定带它。 */
+  key?: string | null
   category?: string | null
 }
 
@@ -28,9 +40,9 @@ export interface GalleryFilterOptions {
 }
 
 /**
- * 过滤规则：
- *   - category 非空时，只保留 `category` 精确相等的模板（未分组模板在筛了具体分类时不出现）。
- *   - search 非空时，大小写不敏感地匹配 name 或 description 任一命中即保留。
+ * 过滤规则（与服务端 SQL 谓词一一对应）：
+ *   - category 非空 → 只保留 `category` 精确相等的模板（未分组模板在筛了具体分类时不出现）。
+ *   - search 非空 → 大小写不敏感地匹配 `name` 或 `key`，任一命中即保留。**不匹配 description**。
  *   - 两个条件都提供时取交集（AND）。
  *   - 两者都为空 → 原样返回全量（不筛）。
  *   - 无命中 → 返回空数组。
@@ -46,7 +58,7 @@ export function filterGalleryTemplates<T extends GalleryFilterableTemplate>(
     if (category && tpl.category !== category) return false
     if (!query) return true
     const name = tpl.name?.toLowerCase() ?? ''
-    const description = tpl.description?.toLowerCase() ?? ''
-    return name.includes(query) || description.includes(query)
+    const key = tpl.key?.toLowerCase() ?? ''
+    return name.includes(query) || key.includes(query)
   })
 }

--- a/apps/web/src/approvals/templateGalleryFilter.ts
+++ b/apps/web/src/approvals/templateGalleryFilter.ts
@@ -1,0 +1,52 @@
+/**
+ * G-B2-17: 模板中心 requester 卡片画廊 — 纯过滤函数。
+ *
+ * 「给定模板列表 + 分类筛选 + 搜索词 → 可见模板」这条逻辑被抽到这里，独立于
+ * TemplateCenterView.vue 之外，理由：
+ *   1. 卡片画廊（!canManageTemplates 分支）需要即时过滤反馈 —— 用户每敲一个字符就重算可见
+ *      集合，不必等 Enter/blur 触发后端请求（后端请求仍然发生，只是画廊不等它）。
+ *   2. 覆盖范围比后端 `search` 参数更宽：同时命中模板名称与描述（参见
+ *      approvals/api.ts 里 `listTemplates` 的 mock 实现，目前只按名称过滤），画廊要对普通
+ *      员工诚实 —— 描述里的关键词也应该能被搜到。
+ *   3. 管理员表格视图完全不消费这个函数，继续直接渲染 `store.templates`（后端过滤），行为
+ *      不变 —— 这是分叉设计的一部分，不是遗漏。
+ *
+ * 保持零依赖（不碰 store / API / Vue），方便用矩阵单测钉死行为，而不必挂载整个视图组件。
+ */
+
+export interface GalleryFilterableTemplate {
+  name: string
+  description?: string | null
+  category?: string | null
+}
+
+export interface GalleryFilterOptions {
+  /** 空字符串 / undefined / null = 不按分类过滤（全部分类）。 */
+  category?: string | null
+  /** 空字符串 / undefined / null = 不按搜索词过滤（全部模板）。 */
+  search?: string | null
+}
+
+/**
+ * 过滤规则：
+ *   - category 非空时，只保留 `category` 精确相等的模板（未分组模板在筛了具体分类时不出现）。
+ *   - search 非空时，大小写不敏感地匹配 name 或 description 任一命中即保留。
+ *   - 两个条件都提供时取交集（AND）。
+ *   - 两者都为空 → 原样返回全量（不筛）。
+ *   - 无命中 → 返回空数组。
+ */
+export function filterGalleryTemplates<T extends GalleryFilterableTemplate>(
+  templates: readonly T[],
+  options: GalleryFilterOptions = {},
+): T[] {
+  const category = options.category?.trim() || ''
+  const query = options.search?.trim().toLowerCase() || ''
+
+  return templates.filter((tpl) => {
+    if (category && tpl.category !== category) return false
+    if (!query) return true
+    const name = tpl.name?.toLowerCase() ?? ''
+    const description = tpl.description?.toLowerCase() ?? ''
+    return name.includes(query) || description.includes(query)
+  })
+}

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -92,7 +92,9 @@
       <el-tab-pane label="已归档" name="archived" />
     </el-tabs>
 
+    <!-- G-B2-17: admin path unchanged — the management table stays exactly as before. -->
     <el-table
+      v-if="canManageTemplates"
       v-loading="store.loading"
       :data="store.templates"
       class="ms-w-100pct"
@@ -172,6 +174,61 @@
       </template>
     </el-table>
 
+    <!-- G-B2-17: requester (!canManageTemplates) card gallery. 普通员工's only real intent
+         here is "find a template → start a request" — the admin table's columns (visibility
+         scope, created/updated timestamps, clone) are management chrome they never act on, so
+         the gallery surfaces just name / description / category / the one primary action. -->
+    <div
+      v-else
+      v-loading="store.loading"
+      class="template-center__gallery-wrap"
+      data-testid="template-center-gallery"
+    >
+      <div v-if="visibleGalleryTemplates.length > 0" class="template-center__gallery">
+        <el-card
+          v-for="tpl in visibleGalleryTemplates"
+          :key="tpl.id"
+          class="template-center__gallery-card"
+          shadow="hover"
+          data-testid="template-center-gallery-card"
+        >
+          <div class="template-center__gallery-card-head">
+            <span class="template-center__gallery-card-name">{{ tpl.name }}</span>
+            <StatusTag domain="approvalTemplate" :status="tpl.status" size="sm" force-locale="zh" />
+          </div>
+          <p class="template-center__gallery-card-desc">
+            {{ tpl.description || '暂无描述' }}
+          </p>
+          <div class="template-center__gallery-card-footer">
+            <el-tag
+              v-if="tpl.category"
+              size="small"
+              type="info"
+              effect="plain"
+              data-testid="template-center-gallery-category"
+            >
+              {{ tpl.category }}
+            </el-tag>
+            <span v-else class="template-center__category-empty">未分组</span>
+            <el-button
+              v-if="tpl.status === 'published' && canWrite"
+              type="primary"
+              size="small"
+              data-testid="template-center-gallery-start-button"
+              @click="startApproval(tpl.id)"
+            >
+              发起申请
+            </el-button>
+          </div>
+        </el-card>
+      </div>
+      <EmptyState
+        v-else
+        data-testid="template-center-gallery-empty"
+        :title="searchText || categoryFilter ? '未找到匹配的模板' : '暂无可用的审批模板'"
+      />
+    </div>
+
     <el-pagination
       v-if="store.total > pageSize"
       class="template-center__pagination"
@@ -189,7 +246,8 @@
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
 import StatusTag from '../../components/status/StatusTag.vue'
-import { ref, onMounted } from 'vue'
+import EmptyState from '../../components/status/EmptyState.vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { Search } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
@@ -199,6 +257,7 @@ import { useApprovalPermissions } from '../../approvals/permissions'
 import { cloneTemplate, listTemplateCategories } from '../../approvals/api'
 import { listRecentTemplates, type RecentTemplateEntry } from '../../approvals/recentTemplates'
 import { useAuth } from '../../composables/useAuth'
+import { filterGalleryTemplates } from '../../approvals/templateGalleryFilter'
 
 const router = useRouter()
 const store = useApprovalTemplateStore()
@@ -213,6 +272,17 @@ const categories = ref<string[]>([])
 const cloningId = ref<string | null>(null)
 const currentPage = ref(1)
 const pageSize = ref(10)
+
+// G-B2-17 — the requester gallery re-filters the current page's templates instantly as
+// categoryFilter/searchText change (no need to wait for handleSearch's Enter/blur), on top of
+// whatever the backend already returned. The admin table below does NOT consume this: it keeps
+// rendering `store.templates` directly, unchanged.
+const visibleGalleryTemplates = computed(() =>
+  filterGalleryTemplates(store.templates, {
+    category: categoryFilter.value,
+    search: searchText.value,
+  }),
+)
 
 function visibilityScopeLabel(scope: ApprovalTemplateListItemDTO['visibilityScope']) {
   if (!scope || scope.type === 'all') return '全员可见'
@@ -355,5 +425,55 @@ onMounted(() => {
 
 .template-center__recent-chip {
   cursor: pointer;
+}
+
+/* G-B2-17: requester card gallery. */
+.template-center__gallery-wrap {
+  min-height: 160px;
+}
+
+.template-center__gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: var(--ms-space-4);
+}
+
+.template-center__gallery-card :deep(.el-card__body) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-2);
+}
+
+.template-center__gallery-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ms-space-2);
+}
+
+.template-center__gallery-card-name {
+  font-size: var(--ms-font-size-section-title);
+  font-weight: var(--ms-font-weight-title);
+  color: var(--ms-text-1);
+  line-height: 1.4;
+}
+
+.template-center__gallery-card-desc {
+  margin: 0;
+  min-height: 40px;
+  font-size: 13px;
+  color: var(--ms-text-2);
+  line-height: 1.5;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.template-center__gallery-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ms-space-2);
 }
 </style>

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -610,20 +610,23 @@ describe('Approval E2E Permissions', () => {
       expect(historyItems.length).toBe(2)
     })
 
-    it('template center renders without "发起审批" button for draft templates', async () => {
+    it('template center renders the requester card gallery (not the admin table), with no "发起申请" button for a draft template', async () => {
       setMockPermissions(['approvals:read'])
-      // Template center shows a table. Only published templates have a "发起审批" link button.
-      // Draft templates should not show it. We verify by providing only draft templates.
+      // G-B2-17: !canManageTemplates users get the requester card gallery instead of the admin
+      // table. A draft template is never actionable, so its card shows no "发起申请" button
+      // (mirrors the admin table's row.status === 'published' gate on "发起审批").
       mockTemplates.value = [
         { ...mockDraftTemplate(), id: 'tpl_d1', name: '草稿模板' },
       ]
       await mountTemplateCenterView()
 
-      // The table renders. Since the column uses scoped slots that are not invoked by our stub,
-      // we verify the table exists and loadTemplates was called.
       expect(loadTemplatesSpy).toHaveBeenCalled()
-      const table = container!.querySelector('[data-el-table]')
-      expect(table).toBeTruthy()
+      expect(container!.querySelector('[data-el-table]')).toBeFalsy()
+      expect(container!.querySelector('[data-testid="template-center-gallery"]')).toBeTruthy()
+
+      const startButtons = Array.from(container!.querySelectorAll('button'))
+        .filter((b) => b.textContent?.includes('发起申请'))
+      expect(startButtons.length).toBe(0)
     })
   })
 
@@ -704,6 +707,23 @@ describe('Approval E2E Permissions', () => {
       const visibleLabels = Array.from(container!.querySelectorAll('[data-el-form-item] label'))
         .map((label) => label.textContent?.trim())
       expect(visibleLabels).toContain('补充说明')
+    })
+
+    it('template center gallery shows "发起申请" for a published template and routes to the same start-approval path as the admin table', async () => {
+      // G-B2-17: writer (non-manager) sees the gallery; its primary action reuses the exact
+      // same `/approvals/new/:id` route the admin table's "发起审批" button pushes to.
+      setMockPermissions(['approvals:read', 'approvals:write'])
+      mockTemplates.value = [mockPublishedTemplate({ id: 'tpl_pub_1', name: '出差申请' })]
+      await mountTemplateCenterView()
+
+      const startBtn = Array.from(container!.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('发起申请'))
+      expect(startBtn).toBeTruthy()
+
+      startBtn!.click()
+      await flushUi()
+
+      expect(pushSpy).toHaveBeenCalledWith({ path: '/approvals/new/tpl_pub_1' })
     })
 
     it('writer viewing a pending approval with no assignment sees action buttons (view-level)', async () => {

--- a/apps/web/tests/approvalTemplateCenterCategory.spec.ts
+++ b/apps/web/tests/approvalTemplateCenterCategory.spec.ts
@@ -317,6 +317,21 @@ const ElIcon = defineComponent({
   },
 })
 
+// G-B2-17 — this spec always mocks canManageTemplates=true (admin table path), so the
+// !canManageTemplates gallery branch (which uses <el-card>) never actually renders here. The
+// stub is registered anyway so Vue doesn't warn about an unresolved component while resolving
+// the template's compiled component list.
+const ElCard = defineComponent({
+  name: 'ElCard',
+  props: { shadow: String },
+  render() {
+    return h('div', { class: 'el-card' }, [
+      this.$slots.header ? h('div', { class: 'el-card__header' }, this.$slots.header()) : null,
+      h('div', { class: 'el-card__body' }, this.$slots.default?.()),
+    ])
+  },
+})
+
 const stubDirective = { mounted() {}, updated() {} }
 
 async function flushUi(cycles = 4): Promise<void> {
@@ -408,6 +423,7 @@ describe('TemplateCenterView — WP4 slice 1 category filter + clone', () => {
     app.component('ElEmpty', ElEmpty)
     app.component('ElTooltip', ElTooltip)
     app.component('ElIcon', ElIcon)
+    app.component('ElCard', ElCard)
     app.directive('loading', stubDirective)
     app.mount(container!)
     await flushUi()

--- a/apps/web/tests/templateGalleryFilter.spec.ts
+++ b/apps/web/tests/templateGalleryFilter.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * G-B2-17 — matrix unit tests for the requester template gallery's pure filter function.
+ * See docs/research/approval-automation-operation-ux-benchmark-20260704.md line 87.
+ *
+ * Intentionally does NOT mount TemplateCenterView.vue — the filter logic is pure and
+ * independently testable, per the design lock's "no big component test for pure logic" rule.
+ */
+import { describe, expect, it } from 'vitest'
+import { filterGalleryTemplates, type GalleryFilterableTemplate } from '../src/approvals/templateGalleryFilter'
+
+function tpl(overrides: Partial<GalleryFilterableTemplate>): GalleryFilterableTemplate {
+  return {
+    name: '模板',
+    description: null,
+    category: null,
+    ...overrides,
+  }
+}
+
+describe('approvals/templateGalleryFilter', () => {
+  const fixtures: GalleryFilterableTemplate[] = [
+    tpl({ name: '出差申请', description: '因公出差报销申请', category: '差旅' }),
+    tpl({ name: '采购申请', description: '办公用品采购', category: '采购' }),
+    tpl({ name: '请假申请', description: null, category: '请假' }),
+    tpl({ name: '其他申请', description: '未归类的通用申请', category: null }),
+  ]
+
+  it('both filters empty → returns the full list unchanged', () => {
+    const result = filterGalleryTemplates(fixtures, {})
+    expect(result).toEqual(fixtures)
+  })
+
+  it('no options argument at all → also returns the full list', () => {
+    const result = filterGalleryTemplates(fixtures)
+    expect(result).toHaveLength(fixtures.length)
+  })
+
+  it('category hit — keeps only templates with an exact category match', () => {
+    const result = filterGalleryTemplates(fixtures, { category: '采购' })
+    expect(result.map((t) => t.name)).toEqual(['采购申请'])
+  })
+
+  it('category miss — a category with no matching templates returns empty', () => {
+    const result = filterGalleryTemplates(fixtures, { category: '财务' })
+    expect(result).toEqual([])
+  })
+
+  it('category filter excludes uncategorized (null-category) templates', () => {
+    const result = filterGalleryTemplates(fixtures, { category: '请假' })
+    expect(result.map((t) => t.name)).toEqual(['请假申请'])
+    expect(result.some((t) => t.category === null)).toBe(false)
+  })
+
+  it('search hits the template name', () => {
+    const result = filterGalleryTemplates(fixtures, { search: '出差' })
+    expect(result.map((t) => t.name)).toEqual(['出差申请'])
+  })
+
+  it('search hits the template description (not just the name)', () => {
+    const result = filterGalleryTemplates(fixtures, { search: '办公用品' })
+    expect(result.map((t) => t.name)).toEqual(['采购申请'])
+  })
+
+  it('search is case-insensitive', () => {
+    const englishFixtures: GalleryFilterableTemplate[] = [
+      tpl({ name: 'Travel Request', description: 'Business trip reimbursement' }),
+      tpl({ name: 'Purchase Request', description: 'Office supplies' }),
+    ]
+    const upper = filterGalleryTemplates(englishFixtures, { search: 'TRAVEL' })
+    const lower = filterGalleryTemplates(englishFixtures, { search: 'travel' })
+    const mixed = filterGalleryTemplates(englishFixtures, { search: 'TrAvEl' })
+    expect(upper.map((t) => t.name)).toEqual(['Travel Request'])
+    expect(lower).toEqual(upper)
+    expect(mixed).toEqual(upper)
+  })
+
+  it('search with no matches anywhere returns an empty array', () => {
+    const result = filterGalleryTemplates(fixtures, { search: '不存在的关键词' })
+    expect(result).toEqual([])
+  })
+
+  it('a template with a null description never throws and is excluded by an unmatched search', () => {
+    const result = filterGalleryTemplates(fixtures, { search: '请假' })
+    // '请假申请' matches on name even though its description is null.
+    expect(result.map((t) => t.name)).toEqual(['请假申请'])
+  })
+
+  it('category AND search combine (both must match)', () => {
+    const result = filterGalleryTemplates(fixtures, { category: '差旅', search: '报销' })
+    expect(result.map((t) => t.name)).toEqual(['出差申请'])
+  })
+
+  it('category AND search combine — category matches but search does not → empty', () => {
+    const result = filterGalleryTemplates(fixtures, { category: '差旅', search: '采购' })
+    expect(result).toEqual([])
+  })
+
+  it('whitespace-only category/search behave like empty (no filter)', () => {
+    const result = filterGalleryTemplates(fixtures, { category: '   ', search: '   ' })
+    expect(result).toEqual(fixtures)
+  })
+})

--- a/apps/web/tests/templateGalleryFilter.spec.ts
+++ b/apps/web/tests/templateGalleryFilter.spec.ts
@@ -11,7 +11,7 @@ import { filterGalleryTemplates, type GalleryFilterableTemplate } from '../src/a
 function tpl(overrides: Partial<GalleryFilterableTemplate>): GalleryFilterableTemplate {
   return {
     name: '模板',
-    description: null,
+    key: null,
     category: null,
     ...overrides,
   }
@@ -19,10 +19,10 @@ function tpl(overrides: Partial<GalleryFilterableTemplate>): GalleryFilterableTe
 
 describe('approvals/templateGalleryFilter', () => {
   const fixtures: GalleryFilterableTemplate[] = [
-    tpl({ name: '出差申请', description: '因公出差报销申请', category: '差旅' }),
-    tpl({ name: '采购申请', description: '办公用品采购', category: '采购' }),
-    tpl({ name: '请假申请', description: null, category: '请假' }),
-    tpl({ name: '其他申请', description: '未归类的通用申请', category: null }),
+    tpl({ name: '出差申请', key: 'travel-request', category: '差旅' }),
+    tpl({ name: '采购申请', key: 'purchase-request', category: '采购' }),
+    tpl({ name: '请假申请', key: null, category: '请假' }),
+    tpl({ name: '其他申请', key: 'misc-request', category: null }),
   ]
 
   it('both filters empty → returns the full list unchanged', () => {
@@ -56,15 +56,24 @@ describe('approvals/templateGalleryFilter', () => {
     expect(result.map((t) => t.name)).toEqual(['出差申请'])
   })
 
-  it('search hits the template description (not just the name)', () => {
-    const result = filterGalleryTemplates(fixtures, { search: '办公用品' })
+  // SERVER PARITY — the server predicate is `(name ILIKE %q% OR key ILIKE %q%)`. These two cases
+  // pin both directions of that contract.
+  it('search hits the template key, not just the name (a key-only match must NOT be hidden)', () => {
+    const result = filterGalleryTemplates(fixtures, { search: 'purchase-req' })
     expect(result.map((t) => t.name)).toEqual(['采购申请'])
+  })
+
+  it('search does NOT match description — the server never does, so a card must not vanish on Enter', () => {
+    const withDescription = [
+      { name: '出差申请', key: 'travel-request', category: null, description: '因公出差报销申请' },
+    ] as unknown as GalleryFilterableTemplate[]
+    expect(filterGalleryTemplates(withDescription, { search: '报销' })).toEqual([])
   })
 
   it('search is case-insensitive', () => {
     const englishFixtures: GalleryFilterableTemplate[] = [
-      tpl({ name: 'Travel Request', description: 'Business trip reimbursement' }),
-      tpl({ name: 'Purchase Request', description: 'Office supplies' }),
+      tpl({ name: 'Travel Request', key: 'TRAVEL-REQ' }),
+      tpl({ name: 'Purchase Request', key: 'purchase-req' }),
     ]
     const upper = filterGalleryTemplates(englishFixtures, { search: 'TRAVEL' })
     const lower = filterGalleryTemplates(englishFixtures, { search: 'travel' })
@@ -79,14 +88,19 @@ describe('approvals/templateGalleryFilter', () => {
     expect(result).toEqual([])
   })
 
-  it('a template with a null description never throws and is excluded by an unmatched search', () => {
+  it('a template with a null key never throws and is excluded by an unmatched search', () => {
     const result = filterGalleryTemplates(fixtures, { search: '请假' })
-    // '请假申请' matches on name even though its description is null.
+    // '请假申请' matches on name even though its key is null.
     expect(result.map((t) => t.name)).toEqual(['请假申请'])
   })
 
   it('category AND search combine (both must match)', () => {
-    const result = filterGalleryTemplates(fixtures, { category: '差旅', search: '报销' })
+    const result = filterGalleryTemplates(fixtures, { category: '差旅', search: '出差' })
+    expect(result.map((t) => t.name)).toEqual(['出差申请'])
+  })
+
+  it('category AND a key-only search combine', () => {
+    const result = filterGalleryTemplates(fixtures, { category: '差旅', search: 'travel' })
     expect(result.map((t) => t.name)).toEqual(['出差申请'])
   })
 


### PR DESCRIPTION
## 审计项 G-B2-17
> 普通员工现在看到的是管理员表格；按 `!canManageTemplates` 分叉

## 做了什么
- 按既有 `canManageTemplates`（`useApprovalPermissions()`，backed by `approval-templates:manage`）**分叉呈现**。
  管理员路径的 `<el-table>` **逐字未动**。
- 普通员工获得卡片画廊：名称 / 描述（无描述诚实占位）/ 分类标签 / StatusTag / 单一主操作「发起申请」，
  复用**完全相同**的 `startApproval(id)` → `/approvals/new/:id` 路由与同一 `status==='published' && canWrite` 门。
- 分类筛选、搜索、最近使用、错误态、状态页签、分页均在分叉之上/之下共享，两种视图都生效。空态复用 `EmptyState`。
  样式仅用 Element Plus + `--ms-*`/`--el-*` token（无裸 hex/rgb、无内联 style）。

## Review 中发现并修掉的真缺陷（**双向**谓词漂移）
过滤函数最初匹配 `name OR description` —— 依据是 `listTemplates` 的 **mock**。而服务端真实 SQL 是：
```sql
(name ILIKE '%q%' OR key ILIKE '%q%')  AND  category = $n
```
于是两个方向都错：
1. 匹配了 `description`（服务端从不匹配）→ 边打字看得见的卡片，**一按 Enter 就凭空消失**。
2. **漏掉了 `key`**（服务端会匹配）→ 用户按模板 key 搜索，服务端明明返回了，画廊却把它**过滤掉**，只剩空白。第 2 点危害更大，且未被披露。

现在本地过滤是「服务端会返回什么」的**忠实预览**（分页范围内），不是更宽/更窄的平行语义。
若将来要支持描述搜索，正确做法是**改服务端谓词**，而不是前端单方面放宽。

## 一处**刻意的行为变更**（非「改测试迁就代码」）
既有用例 `template center renders without "发起审批" button for draft templates` 曾断言
**非管理员会看到管理员表格** —— 那正是本项要消除的反行为（其注释也自承是弱断言「verify the table exists」）。
已改写为断言：不再渲染表格 / 渲染画廊 / 草稿卡片无「发起申请」。并**新增**一例：published 模板的「发起申请」
按钮 push 到与管理员表格**完全相同**的 `/approvals/new/:id`。断言比原来更强。

## 验证
- `templateGalleryFilter` 矩阵 **15 例**，含服务端谓词**双向**钉死（key 命中必须保留 / description 不得命中）。
- **突变验证**：去掉 `key.includes(query)` → 两条 parity 用例变红；还原 → 15/15。
- 所有挂载/引用 `TemplateCenterView.vue` 的套件 **208/208**（含 `ui-foundation-style-guard` 83/83：零内联 style、零裸色值）。
- `vue-tsc --noEmit` **0 error**。
- 先于本 PR 就红的无关用例：`approvalStaticPicker.spec.ts`(2) / `approvalMobileDetailActions.spec.ts`(2)，已在 origin/main 上复现比对，与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)