### PR TITLE
feat(web): G-B2-23 — 规则卡「上次运行」chip + 统计并行加载

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -697,6 +697,15 @@
             <span class="meta-automation__stat meta-automation__stat--failed">{{ automationCardStats(ruleStats[rule.id].failed, 'fail', isZh) }}</span>
           </div>
           <div
+            v-if="ruleLastRun[rule.id]"
+            class="meta-automation__last-run-chip"
+            :class="`meta-automation__last-run-chip--${ruleLastRunChipFor(rule.id).status}`"
+            :data-automation-last-run="rule.id"
+            :data-status="ruleLastRunChipFor(rule.id).status"
+          >
+            {{ ruleLastRunChipFor(rule.id).text }}
+          </div>
+          <div
             v-if="ruleTestRunStates[rule.id]"
             class="meta-automation__test-run-status"
             :class="`meta-automation__test-run-status--${ruleTestRunStates[rule.id].status}`"
@@ -824,13 +833,16 @@ import {
   automationDingTalkPersonSubjectLabel,
   automationDingTalkPresetLabel,
   automationLabel,
+  automationLastRunChip,
   automationTestRunFailed,
   automationTestRunRequestFailed,
   automationTestRunSkipped,
   automationTestRunSucceeded,
   automationTriggerTypeLabel,
   type AutomationLabelKey,
+  type AutomationLastRunChip,
 } from '../utils/meta-automation-labels'
+import { loadRuleEntriesConcurrently, mergeRuleEntries } from '../utils/automation-rule-concurrent-merge'
 
 const props = defineProps<{
   visible: boolean
@@ -1521,6 +1533,12 @@ const groupDeliveryViewerRuleId = ref('')
 const showPersonDeliveryViewer = ref(false)
 const personDeliveryViewerRuleId = ref('')
 const ruleStats = ref<Record<string, AutomationStats>>({})
+// G-B2-23: most-recent-first execution page (0 or 1 entries) per rule, feeding the card's
+// "last run" chip. Absent key = not fetched yet (component v-ifs the chip away); a rule
+// whose fetch failed is simply omitted this round rather than recorded as an error state,
+// same "skip on failure" semantics `ruleStats` already had (a stale/missing chip is an
+// honest degrade — see `loadRuleLastRuns` below — not a rendering error for the whole list).
+const ruleLastRun = ref<Record<string, AutomationExecution[]>>({})
 const ruleTestRunStates = ref<Record<string, AutomationTestRunState>>({})
 const activeRuleTestRunState = computed(() => {
   const ruleId = editingRule.value?.id
@@ -1573,7 +1591,7 @@ async function onTestRule(ruleId: string) {
   try {
     const execution = await props.client.testAutomationRule(props.sheetId, ruleId)
     setRuleTestRunState(ruleId, describeTestRunExecution(execution))
-    await loadRuleStatsForRule(ruleId)
+    await refreshRuleCardData(ruleId)
   } catch (err: unknown) {
     setRuleTestRunState(ruleId, {
       status: 'failed',
@@ -1627,20 +1645,67 @@ function describeTestRunExecution(execution: AutomationExecution): AutomationTes
   }
 }
 
-async function loadRuleStatsForRule(ruleId: string) {
-  if (!props.client) return
-  try {
-    const st = await props.client.getAutomationStats(props.sheetId, ruleId)
-    ruleStats.value = { ...ruleStats.value, [ruleId]: st }
-  } catch {
-    // skip
-  }
-}
-
+// G-B2-23: stats used to load one rule at a time (`for (const rule of rules.value) await
+// loadRuleStatsForRule(rule.id)`), paying every rule's request round-trip serially — N
+// rules meant N sequential network waits before the last card's stats appeared. Fetching
+// concurrently and folding the results into `ruleStats` in a single assignment (via
+// `loadRuleEntriesConcurrently` / `mergeRuleEntries`, see automation-rule-concurrent-merge.ts
+// for why the merge must happen in one pass) removes that serial tax without reintroducing
+// the "N separate `ruleStats.value = {...ruleStats.value, [id]: st}` writes" shape that
+// function is built to avoid. A rule whose stats fetch fails is simply left out of this
+// round's merge — matches the previous per-rule try/catch's "skip on failure" behavior.
 async function loadRuleStats() {
   if (!props.client) return
-  for (const rule of rules.value) {
-    await loadRuleStatsForRule(rule.id)
+  const client = props.client
+  const sheetId = props.sheetId
+  ruleStats.value = await loadRuleEntriesConcurrently(
+    ruleStats.value,
+    rules.value.map((rule) => rule.id),
+    (ruleId) => client.getAutomationStats(sheetId, ruleId),
+  )
+}
+
+// G-B2-23: "last run" chip data — same concurrent-fetch-then-one-shot-merge shape as
+// `loadRuleStats` above, requesting just the newest execution per rule
+// (`getAutomationLogs(sheetId, ruleId, 1)`, newest-first per the backend contract) rather
+// than the full log page the log viewer needs.
+async function loadRuleLastRuns() {
+  if (!props.client) return
+  const client = props.client
+  const sheetId = props.sheetId
+  ruleLastRun.value = await loadRuleEntriesConcurrently(
+    ruleLastRun.value,
+    rules.value.map((rule) => rule.id),
+    (ruleId) => client.getAutomationLogs(sheetId, ruleId, 1),
+  )
+}
+
+function ruleLastRunChipFor(ruleId: string): AutomationLastRunChip {
+  return automationLastRunChip(ruleLastRun.value[ruleId] ?? [], new Date(), isZh.value)
+}
+
+/**
+ * Refresh a single rule's stats + last-run chip after a manual test run creates a fresh
+ * execution for it. Each fetch is independently merged with `mergeRuleEntries` (a plain
+ * one-entry batch) and independently swallowed on failure, so a stats-fetch failure can't
+ * suppress the last-run chip update or vice versa — same "one bad fetch doesn't blank
+ * data we already have" rule the concurrent multi-rule loaders follow.
+ */
+async function refreshRuleCardData(ruleId: string) {
+  if (!props.client) return
+  const client = props.client
+  const sheetId = props.sheetId
+  try {
+    const st = await client.getAutomationStats(sheetId, ruleId)
+    ruleStats.value = mergeRuleEntries(ruleStats.value, [[ruleId, st]])
+  } catch {
+    // skip — leave whatever stats we already had for this rule in place
+  }
+  try {
+    const executions = await client.getAutomationLogs(sheetId, ruleId, 1)
+    ruleLastRun.value = mergeRuleEntries(ruleLastRun.value, [[ruleId, executions]])
+  } catch {
+    // skip — leave whatever last-run chip we already had for this rule in place
   }
 }
 
@@ -1937,6 +2002,7 @@ watch(
       await loadRules(props.sheetId)
       cancelForm()
       void loadRuleStats()
+      void loadRuleLastRuns()
     }
   },
   { immediate: true },
@@ -2229,6 +2295,21 @@ watch(
 .meta-automation__stat { font-weight: 600; }
 .meta-automation__stat--success { color: var(--ms-color-success); }
 .meta-automation__stat--failed { color: var(--ms-color-danger); }
+
+/* G-B2-23: rule card "last run" chip — same pill shape as .meta-automation__card-link-access. */
+.meta-automation__last-run-chip {
+  display: inline-flex;
+  align-self: flex-start;
+  border-radius: 999px;
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 8px;
+}
+
+.meta-automation__last-run-chip--success { background: var(--el-color-success-light-9); color: var(--el-color-success-dark-2); }
+.meta-automation__last-run-chip--failed { background: var(--el-color-danger-light-9); color: var(--el-color-danger-dark-2); }
+.meta-automation__last-run-chip--skipped { background: var(--el-color-warning-light-9); color: var(--el-color-warning-dark-2); }
+.meta-automation__last-run-chip--none { background: var(--ms-bg-page); color: var(--ms-text-2); }
 
 .meta-automation__test-run-status {
   font-size: 12px;

--- a/apps/web/src/multitable/utils/automation-rule-concurrent-merge.ts
+++ b/apps/web/src/multitable/utils/automation-rule-concurrent-merge.ts
@@ -1,0 +1,57 @@
+// G-B2-23: shared "fetch N rules' data concurrently, write the ref once" helpers for
+// MetaAutomationManager.vue (rule stats + rule last-run chips). Framework-free and
+// state-free so both call sites — and their unit tests — exercise the exact same merge
+// logic instead of each hand-rolling their own accumulation.
+
+/**
+ * Fold a batch of `[ruleId, value]` entries into a previous snapshot in a single pass.
+ *
+ * The bug this guards against: applying entries one at a time by re-spreading the SAME
+ * base — e.g. `entries.forEach(([id, v]) => { next = { ...prev, [id]: v } })`, or
+ * equivalently issuing one `ruleStats.value = { ...prev, [id]: v }` assignment per
+ * resolved fetch where `prev` was captured once up front — recomputes from the same
+ * stale snapshot every time. Each write clobbers the one before it instead of building
+ * on it, so only the LAST entry in the batch survives; every earlier one is silently
+ * dropped. `mergeRuleEntries` spreads `prev` exactly once into a single accumulator and
+ * folds every entry into THAT accumulator, so entries never overwrite each other and the
+ * order they arrive in doesn't matter. Do not "simplify" this back into a per-entry
+ * re-spread — the matrix test below (`loses none of N entries...`) is written to catch
+ * exactly that regression.
+ */
+export function mergeRuleEntries<T>(
+  prev: Readonly<Record<string, T>>,
+  entries: ReadonlyArray<readonly [ruleId: string, value: T]>,
+): Record<string, T> {
+  const next: Record<string, T> = { ...prev }
+  for (const [ruleId, value] of entries) {
+    next[ruleId] = value
+  }
+  return next
+}
+
+/**
+ * Fetch `fetchOne(ruleId)` for every id in `ruleIds` concurrently (not the previous
+ * serial `for (const rule of rules) await loadOne(rule.id)` loop, which paid one
+ * request's round-trip latency per rule) and fold the results into `prev` via
+ * `mergeRuleEntries` in one final assignment.
+ *
+ * A rejecting fetch is swallowed and simply excluded from the result — matches the
+ * previous per-rule try/catch semantics ("one bad rule's stats/logs fetch must not
+ * blank out data already fetched for the others"). Uses `Promise.allSettled` rather
+ * than `Promise.all` for exactly this reason: `Promise.all` would reject the whole
+ * batch (and thus write nothing) the moment any single rule's fetch fails.
+ */
+export async function loadRuleEntriesConcurrently<T>(
+  prev: Readonly<Record<string, T>>,
+  ruleIds: readonly string[],
+  fetchOne: (ruleId: string) => Promise<T>,
+): Promise<Record<string, T>> {
+  const settled = await Promise.allSettled(ruleIds.map((ruleId) => fetchOne(ruleId)))
+  const entries: Array<readonly [string, T]> = []
+  settled.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      entries.push([ruleIds[index], result.value] as const)
+    }
+  })
+  return mergeRuleEntries(prev, entries)
+}

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -181,6 +181,7 @@ export type AutomationLabelKey =
   | 'manager.allowedAudiencePrefix'
   | 'manager.statOk'
   | 'manager.statFail'
+  | 'manager.lastRunNone'
   | 'manager.edit'
   | 'manager.viewLogs'
   | 'manager.viewDeliveries'
@@ -440,6 +441,7 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'manager.allowedAudiencePrefix',
   'manager.statOk',
   'manager.statFail',
+  'manager.lastRunNone',
   'manager.edit',
   'manager.viewLogs',
   'manager.viewDeliveries',
@@ -738,6 +740,7 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'manager.allowedAudiencePrefix': { en: 'Allowed audience:', zh: '允许范围：' },
   'manager.statOk': { en: 'ok', zh: '成功' },
   'manager.statFail': { en: 'fail', zh: '失败' },
+  'manager.lastRunNone': { en: 'Not run yet', zh: '尚未运行' },
   'manager.edit': { en: 'Edit', zh: '编辑' },
   'manager.viewLogs': { en: 'View Logs', zh: '查看日志' },
   'manager.viewDeliveries': { en: 'View Deliveries', zh: '查看投递记录' },
@@ -1075,6 +1078,67 @@ export function automationCardLinkSummary(variant: AutomationCardLinkVariant, vi
 export function automationCardStats(count: number, status: AutomationCardStatType, isZh: boolean): string {
   const key = status === 'ok' ? 'manager.statOk' : 'manager.statFail'
   return `${count} ${automationLabel(key, isZh)}`
+}
+
+const LAST_RUN_MINUTE_MS = 60 * 1000
+const LAST_RUN_HOUR_MS = 60 * LAST_RUN_MINUTE_MS
+const LAST_RUN_DAY_MS = 24 * LAST_RUN_HOUR_MS
+
+/**
+ * G-B2-23: relative-time text for a rule card's "last run" chip, e.g. "3 分钟前" /
+ * "3 minutes ago". Returns '' for an unparseable `iso` timestamp so callers can fail
+ * quiet instead of rendering "NaN minutes ago". A timestamp slightly in the future
+ * (clock skew between browser and backend) clamps to "just now" rather than a negative
+ * duration.
+ */
+export function automationLastRunRelativeTime(iso: string, now: Date, isZh: boolean): string {
+  const thenMs = new Date(iso).getTime()
+  if (Number.isNaN(thenMs)) return ''
+  const elapsedMs = Math.max(0, now.getTime() - thenMs)
+  if (elapsedMs < LAST_RUN_MINUTE_MS) return isZh ? '刚刚' : 'just now'
+  if (elapsedMs < LAST_RUN_HOUR_MS) {
+    const minutes = Math.floor(elapsedMs / LAST_RUN_MINUTE_MS)
+    return isZh ? `${minutes} 分钟前` : `${minutes} ${minutes === 1 ? 'minute' : 'minutes'} ago`
+  }
+  if (elapsedMs < LAST_RUN_DAY_MS) {
+    const hours = Math.floor(elapsedMs / LAST_RUN_HOUR_MS)
+    return isZh ? `${hours} 小时前` : `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`
+  }
+  const days = Math.floor(elapsedMs / LAST_RUN_DAY_MS)
+  return isZh ? `${days} 天前` : `${days} ${days === 1 ? 'day' : 'days'} ago`
+}
+
+/** Which status color a rule card's "last run" chip keys off of; `'none'` = never run. */
+export type AutomationLastRunChipStatus = AutomationExecution['status'] | 'none'
+
+export interface AutomationLastRunChip {
+  status: AutomationLastRunChipStatus
+  text: string
+}
+
+/**
+ * G-B2-23: rule card "last run" chip — glanceable status + relative time, without a
+ * separate serial round-trip per rule (see `automation-rule-concurrent-merge.ts` for the
+ * concurrent fetch/merge that feeds this).
+ *
+ * `executions` is the most-recent-first page from `getAutomationLogs(sheetId, ruleId, 1)`
+ * (0 or 1 entries — this function only ever looks at index 0). An empty array is a
+ * *confirmed* "this rule has never run" — distinct from "we haven't fetched yet", which
+ * is the caller's `v-if` concern before this function is ever invoked — so it renders the
+ * honest "Not run yet" copy rather than a blank chip or a fabricated timestamp.
+ */
+export function automationLastRunChip(
+  executions: readonly AutomationExecution[],
+  now: Date,
+  isZh: boolean,
+): AutomationLastRunChip {
+  const latest = executions[0]
+  if (!latest) {
+    return { status: 'none', text: automationLabel('manager.lastRunNone', isZh) }
+  }
+  const statusText = automationStatusLabel(latest.status, isZh)
+  const relative = automationLastRunRelativeTime(latest.triggeredAt, now, isZh)
+  return { status: latest.status, text: relative ? `${statusText} · ${relative}` : statusText }
 }
 
 /**

--- a/apps/web/tests/automation-rule-concurrent-merge.spec.ts
+++ b/apps/web/tests/automation-rule-concurrent-merge.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  loadRuleEntriesConcurrently,
+  mergeRuleEntries,
+} from '../src/multitable/utils/automation-rule-concurrent-merge'
+
+describe('mergeRuleEntries', () => {
+  it('returns prev unchanged (new object) when entries is empty', () => {
+    const prev = { a: 1 }
+    const next = mergeRuleEntries(prev, [])
+    expect(next).toEqual({ a: 1 })
+    expect(next).not.toBe(prev)
+  })
+
+  it('adds new ruleIds without disturbing existing ones', () => {
+    const prev = { a: 1 }
+    const next = mergeRuleEntries(prev, [['b', 2], ['c', 3]])
+    expect(next).toEqual({ a: 1, b: 2, c: 3 })
+  })
+
+  it('overwrites an existing ruleId with a newly fetched value', () => {
+    const prev = { a: 1 }
+    const next = mergeRuleEntries(prev, [['a', 99]])
+    expect(next).toEqual({ a: 99 })
+  })
+
+  it('last entry wins when the same ruleId appears twice in one batch', () => {
+    const next = mergeRuleEntries({}, [['a', 1], ['a', 2]])
+    expect(next).toEqual({ a: 2 })
+  })
+
+  it('does not mutate the prev snapshot passed in', () => {
+    const prev = { a: 1 }
+    mergeRuleEntries(prev, [['b', 2]])
+    expect(prev).toEqual({ a: 1 })
+  })
+
+  // Anchor regression case (G-B2-23): concurrently-resolved fetches must all survive a
+  // one-shot merge. This is written to go RED if `mergeRuleEntries` is ever "simplified"
+  // back into a per-entry re-spread against the same stale `prev` (e.g. `entries.forEach(
+  // ([id, v]) => { next = { ...prev, [id]: v } })`) — that shape keeps only the LAST
+  // entry applied and silently drops every earlier one.
+  it('loses none of N entries resolved together, even alongside a pre-existing prev key', () => {
+    const prev = { existing: 'kept' }
+    const entries: Array<readonly [string, string]> = Array.from({ length: 10 }, (_, i) => [
+      `rule-${i}`,
+      `stats-${i}`,
+    ] as const)
+    const next = mergeRuleEntries(prev, entries)
+    expect(next.existing).toBe('kept')
+    for (let i = 0; i < 10; i++) {
+      expect(next[`rule-${i}`]).toBe(`stats-${i}`)
+    }
+    expect(Object.keys(next)).toHaveLength(11)
+  })
+})
+
+describe('loadRuleEntriesConcurrently', () => {
+  it('fetches every ruleId and merges all successes into prev', async () => {
+    const calls: string[] = []
+    const result = await loadRuleEntriesConcurrently({ existing: 0 }, ['r1', 'r2', 'r3'], async (ruleId) => {
+      calls.push(ruleId)
+      return ruleId.length
+    })
+    expect(calls.sort()).toEqual(['r1', 'r2', 'r3'])
+    expect(result).toEqual({ existing: 0, r1: 2, r2: 2, r3: 2 })
+  })
+
+  it('runs fetches concurrently, not serially (total time ~= slowest single fetch)', async () => {
+    const delays = [30, 30, 30, 30, 30]
+    const start = Date.now()
+    await loadRuleEntriesConcurrently(
+      {},
+      delays.map((_, i) => `r${i}`),
+      (ruleId) => new Promise((resolve) => setTimeout(() => resolve(ruleId), delays[Number(ruleId.slice(1))])),
+    )
+    const elapsed = Date.now() - start
+    // Serial would take ~150ms (5 * 30ms); concurrent should stay well under that.
+    expect(elapsed).toBeLessThan(120)
+  })
+
+  it('isolates a single rejecting fetch — the rest are still merged in (failure does not blank the batch)', async () => {
+    const result = await loadRuleEntriesConcurrently({}, ['ok-1', 'bad', 'ok-2'], async (ruleId) => {
+      if (ruleId === 'bad') throw new Error('boom')
+      return `stats-for-${ruleId}`
+    })
+    expect(result).toEqual({ 'ok-1': 'stats-for-ok-1', 'ok-2': 'stats-for-ok-2' })
+    expect(result).not.toHaveProperty('bad')
+  })
+
+  it('a rule missing from this fetch keeps its previously-merged value (partial refresh does not wipe prior data)', async () => {
+    const result = await loadRuleEntriesConcurrently({ stale: 'old', fresh: 'old' }, ['fresh'], async () => 'new')
+    expect(result).toEqual({ stale: 'old', fresh: 'new' })
+  })
+
+  it('returns prev unchanged for an empty ruleIds list', async () => {
+    const result = await loadRuleEntriesConcurrently({ a: 1 }, [], async () => 0)
+    expect(result).toEqual({ a: 1 })
+  })
+})

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -21,6 +21,8 @@ import {
   automationDingTalkPresetLabel,
   automationDingTalkTemplateTokenLabel,
   automationLabel,
+  automationLastRunChip,
+  automationLastRunRelativeTime,
   automationStatusLabel,
   automationTestRunFailed,
   automationTestRunRequestFailed,
@@ -163,6 +165,58 @@ describe('meta-automation-labels', () => {
 
     expect(automationCardStats(1, 'ok', false)).toBe('1 ok')
     expect(automationCardStats(3, 'fail', true)).toBe('3 失败')
+  })
+
+  it('G-B2-23: formats last-run relative time in minute/hour/day buckets with EN pluralization', () => {
+    const now = new Date('2026-07-08T12:00:00.000Z')
+    expect(automationLastRunRelativeTime('2026-07-08T11:59:59.500Z', now, false)).toBe('just now')
+    expect(automationLastRunRelativeTime('2026-07-08T11:59:59.500Z', now, true)).toBe('刚刚')
+    // Clock skew: a timestamp slightly in the future clamps to "just now" instead of negative.
+    expect(automationLastRunRelativeTime('2026-07-08T12:00:05.000Z', now, false)).toBe('just now')
+
+    expect(automationLastRunRelativeTime('2026-07-08T11:59:00.000Z', now, false)).toBe('1 minute ago')
+    expect(automationLastRunRelativeTime('2026-07-08T11:57:00.000Z', now, false)).toBe('3 minutes ago')
+    expect(automationLastRunRelativeTime('2026-07-08T11:57:00.000Z', now, true)).toBe('3 分钟前')
+
+    expect(automationLastRunRelativeTime('2026-07-08T11:00:00.000Z', now, false)).toBe('1 hour ago')
+    expect(automationLastRunRelativeTime('2026-07-08T09:00:00.000Z', now, false)).toBe('3 hours ago')
+    expect(automationLastRunRelativeTime('2026-07-08T09:00:00.000Z', now, true)).toBe('3 小时前')
+
+    expect(automationLastRunRelativeTime('2026-07-07T12:00:00.000Z', now, false)).toBe('1 day ago')
+    expect(automationLastRunRelativeTime('2026-07-05T12:00:00.000Z', now, false)).toBe('3 days ago')
+    expect(automationLastRunRelativeTime('2026-07-05T12:00:00.000Z', now, true)).toBe('3 天前')
+
+    // Unparseable timestamp fails quiet rather than rendering "NaN ... ago".
+    expect(automationLastRunRelativeTime('not-a-date', now, false)).toBe('')
+  })
+
+  it('G-B2-23: rule-card last-run chip covers none / success / failed / skipped', () => {
+    const now = new Date('2026-07-08T12:00:00.000Z')
+
+    expect(automationLastRunChip([], now, false)).toEqual({ status: 'none', text: 'Not run yet' })
+    expect(automationLastRunChip([], now, true)).toEqual({ status: 'none', text: '尚未运行' })
+
+    const success = {
+      id: 'e1', ruleId: 'r1', status: 'success' as const, triggeredBy: 'event',
+      triggeredAt: '2026-07-08T11:57:00.000Z',
+    }
+    expect(automationLastRunChip([success], now, false)).toEqual({ status: 'success', text: 'success · 3 minutes ago' })
+    expect(automationLastRunChip([success], now, true)).toEqual({ status: 'success', text: '成功 · 3 分钟前' })
+
+    const failed = { ...success, id: 'e2', status: 'failed' as const, triggeredAt: '2026-07-08T09:00:00.000Z' }
+    expect(automationLastRunChip([failed], now, false)).toEqual({ status: 'failed', text: 'failed · 3 hours ago' })
+
+    const skipped = { ...success, id: 'e3', status: 'skipped' as const, triggeredAt: '2026-07-05T12:00:00.000Z' }
+    expect(automationLastRunChip([skipped], now, true)).toEqual({ status: 'skipped', text: '跳过 · 3 天前' })
+
+    // Only the most-recent (index 0) execution is consulted, matching
+    // `getAutomationLogs(sheetId, ruleId, 1)`'s newest-first contract.
+    expect(automationLastRunChip([success, failed], now, false).status).toBe('success')
+
+    // Unparseable triggeredAt: status still renders, relative-time segment is dropped
+    // rather than showing "success · " with a dangling separator.
+    const badTimestamp = { ...success, triggeredAt: 'not-a-date' }
+    expect(automationLastRunChip([badTimestamp], now, false)).toEqual({ status: 'success', text: 'success' })
   })
 
   it('B1-06: composes delete-rule confirm copy with optional run-count blast radius', () => {


### PR DESCRIPTION
## 审计项 G-B2-23
> glanceable status 核心缺失；统计串行改并行 + 最近一条日志

## 做了什么
- `loadRuleStats()` 原本**串行** `for (const rule of rules) await loadOne(rule.id)` —— 每条规则付一次往返延迟。改为并发拉取 + **一次性合并写入**。
- 新增「上次运行」chip：每条规则取最近一条执行记录（`getAutomationLogs(sheetId, ruleId, 1)`），渲染状态色 + 相对时间。
  - **从未运行** → 诚实显示「尚未运行」，不留空、不显示假时间。
  - 单条拉取失败 → 该 chip 降级，**不拖垮整个列表**（用 `Promise.allSettled`，而非 `Promise.all`——后者任一失败就整批不写）。
- 抽出 `automation-rule-concurrent-merge.ts`：`mergeRuleEntries` + `loadRuleEntriesConcurrently`，stats 与 last-run 两个调用点共用同一套合并逻辑。

## 一处**值得记录的更正**（agent 用实证反驳了我给的前提）
我在任务书里断言：把串行改并行后，`ruleStats.value = {...ruleStats.value, [id]: st}` 会因 read-modify-write 竞态丢条目。
**这是错的**，agent 拒绝把这条假设写成注释，并做了实证。我独立复验（Node 脚本）确认：

| 写法 | 7 条并发下保留 |
|---|---|
| 原写法（await **之后**读+写，同一同步表达式） | **7 / 7**（不丢——JS 单线程，读写之间没有 await，continuation 不会交错） |
| **stale-base** 写法（await **之前**捕获 `prev`） | **1 / 7**（这才是真正的 lost-update） |

因此模块注释与回归测试都锚定**真实**的 stale-base 缺陷，而不是我的假命题。
一次性合并仍然是对的设计，理由是**独立**的：O(n²) 展开 → O(n)，n 次响应式触发 → 1 次。

## 验证
- 新测试 `automation-rule-concurrent-merge.spec.ts` 11 例 + `meta-automation-labels.spec.ts` 新增相对时间/chip 矩阵。
- **突变验证**：把合并改回 stale-base re-spread → **4 条**用例变红（含「N 条一起合并不丢条目」锚点）；还原 → 全绿。
- 相关六套 **321/321**（含 mount 组件的 manager/editor spec 与 `ui-foundation-style-guard` —— 零内联 style、零裸色值）。
- `vue-tsc --noEmit` **0 error**。新增文案走 typed label module 三处扩展点；无新增品牌文案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)