### PR TITLE
feat(web): G-B2-22 — 规则编辑器保存禁用原因可视化（canSave 单一真源）

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -23,6 +23,12 @@ on:
       - 'apps/web/src/multitable/utils/personal-config-write.ts'
       - 'apps/web/tests/multitable-reorder-view-fields.spec.ts'
       - 'apps/web/tests/multitable-grid-personal-additive-write.spec.ts'
+      # G-B2-22: the save-block reason aggregator is the SINGLE SOURCE for `canSave` in the
+      # automation rule editor — a dropped conjunct there lets an invalid rule be saved. Its
+      # exhaustive guard harness must fire whenever either file changes.
+      - 'apps/web/src/multitable/automationSaveBlockReasons.ts'
+      - 'apps/web/src/multitable/components/MetaAutomationRuleEditor.vue'
+      - 'apps/web/tests/automation-save-block-reasons.spec.ts'
       - 'apps/web/src/multitable/utils/field-config.ts'
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
@@ -243,4 +249,4 @@ jobs:
         # UF-3: status-color convergence — statusTag (StatusTag.vue + statusDomains.ts unit/mount
         # coverage), AutomationExecutionsView + parallelBranchRunsView (automationRun domain status
         # badges, run + step level, including the parallel-branch readability regression).
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-reorder-view-fields multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting statusTag AutomationExecutionsView parallelBranchRunsView --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-reorder-view-fields multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting statusTag AutomationExecutionsView parallelBranchRunsView automation-save-block-reasons multitable-automation-rule-editor --reporter=dot

--- a/apps/web/src/multitable/automationSaveBlockReasons.ts
+++ b/apps/web/src/multitable/automationSaveBlockReasons.ts
@@ -1,0 +1,317 @@
+// G-B2-22 — rule-editor "why is Save disabled" list.
+//
+// MetaSheet principle: a disabled control must be able to say why. Folding many independent
+// guard conditions into a single boolean (the historic `canSave`) is silent by construction —
+// the author sees a greyed-out button and nothing else. This module is the single place that
+// turns the editor's full set of save-blocking guards into a human-readable, anchorable list.
+//
+// It owns ONLY the aggregation: each guard's own decision logic (whether a trigger config, a
+// condition-branch, or a parallel-branch is valid) is evaluated elsewhere (MetaAutomationRuleEditor.vue,
+// which already has the field/view context those checks need) and handed in here pre-evaluated as
+// plain data. Counts and raw strings — not pre-combined booleans — are passed through for the
+// checks that combine more than one signal (a destination made of several optional sources, the
+// "keep the stored webhook secret" rule), so this module performs the AND/OR/negation itself and a
+// test can exercise that combination directly instead of trusting a hidden reduction upstream.
+//
+// `anchor` is a CSS selector (evaluated against the editor's own root, never the whole document)
+// that locates the control the reason is about, for scroll-to-reason navigation. A reason is only
+// given an anchor when a real, always-rendered element exists for it — no invented anchors.
+
+import { automationActionTypeLabel } from './utils/meta-automation-labels'
+import type { AutomationActionType } from './types'
+
+export interface SaveBlockReason {
+  key: string
+  message: string
+  anchor?: string
+}
+
+export interface SaveBlockGroupMessageSnapshot {
+  destinationIdCount: number
+  destinationFieldPathCount: number
+  titleTemplate: string
+  bodyTemplate: string
+  publicFormBlockingErrorCount: number
+  internalViewBlockingErrorCount: number
+}
+
+export interface SaveBlockPersonMessageSnapshot {
+  userIdCount: number
+  memberGroupIdCount: number
+  recipientFieldPathCount: number
+  memberGroupRecipientFieldPathCount: number
+  titleTemplate: string
+  bodyTemplate: string
+  publicFormBlockingErrorCount: number
+  internalViewBlockingErrorCount: number
+}
+
+export interface SaveBlockEmailSnapshot {
+  recipientCount: number
+  subjectTemplate: string
+  bodyTemplate: string
+}
+
+export interface SaveBlockDeleteRecordSnapshot {
+  acknowledged: boolean
+}
+
+export interface SaveBlockActionSnapshot {
+  index: number
+  type: AutomationActionType
+  groupMessage?: SaveBlockGroupMessageSnapshot
+  personMessage?: SaveBlockPersonMessageSnapshot
+  email?: SaveBlockEmailSnapshot
+  deleteRecord?: SaveBlockDeleteRecordSnapshot
+}
+
+export interface SaveBlockReasonsInput {
+  isZh: boolean
+  name: string
+  actionsCount: number
+  triggerType: string
+  /** '' when the current trigger isn't approval.completed, or that trigger has no block reason. */
+  approvalCompletedBlockReason: string
+  /** '' when the current trigger isn't approval.task_created, or that trigger has no block reason. */
+  approvalTaskCreatedBlockReason: string
+  webhookSecretPresent: boolean
+  ruleHasId: boolean
+  savedWebhookSecretConfigured: boolean
+  conditionBranchReadOnlyReason: string | null
+  conditionBranchKeyError: string | null
+  parallelBranchReadOnlyReason: string | null
+  parallelBranchKeyError: string | null
+  parallelBranchActionError: string | null
+  conditionsComplete: boolean
+  /** Selector for the first incomplete condition/group, when one can be identified. */
+  firstIncompleteConditionAnchor?: string
+  actions: SaveBlockActionSnapshot[]
+}
+
+export function computeSaveBlockReasons(input: SaveBlockReasonsInput): SaveBlockReason[] {
+  const zh = input.isZh
+  const reasons: SaveBlockReason[] = []
+
+  if (!input.name.trim()) {
+    reasons.push({ key: 'name', message: zh ? '请填写规则名称。' : 'Enter a rule name.', anchor: '[data-field="name"]' })
+  }
+
+  if (input.actionsCount < 1) {
+    reasons.push({
+      key: 'actionsEmpty',
+      message: zh ? '请至少添加一个动作。' : 'Add at least one action.',
+      anchor: '[data-action="add-action"]',
+    })
+  }
+
+  if (input.triggerType === 'approval.completed' && input.approvalCompletedBlockReason) {
+    reasons.push({
+      key: 'approvalCompletedBlockReason',
+      message: input.approvalCompletedBlockReason,
+      anchor: '[data-field="approvalCompletedBlockReason"]',
+    })
+  }
+
+  if (input.triggerType === 'approval.task_created' && input.approvalTaskCreatedBlockReason) {
+    reasons.push({
+      key: 'approvalTaskCreatedBlockReason',
+      message: input.approvalTaskCreatedBlockReason,
+      anchor: '[data-field="approvalTaskCreatedBlockReason"]',
+    })
+  }
+
+  if (
+    input.triggerType === 'webhook.received'
+    && !input.webhookSecretPresent
+    && !(input.ruleHasId && input.savedWebhookSecretConfigured)
+  ) {
+    reasons.push({
+      key: 'webhookSecret',
+      message: zh ? '请填写签名密钥（Secret）。' : 'Enter a signing secret.',
+      anchor: '[data-field="webhookSecret"]',
+    })
+  }
+
+  if (input.conditionBranchReadOnlyReason) {
+    reasons.push({
+      key: 'conditionBranchReadOnly',
+      message: input.conditionBranchReadOnlyReason,
+      anchor: '[data-field="condition-branch-readonly"]',
+    })
+  }
+  if (input.conditionBranchKeyError) {
+    reasons.push({
+      key: 'conditionBranchKeyError',
+      message: input.conditionBranchKeyError,
+      anchor: '[data-field="branch-key-error"]',
+    })
+  }
+  if (input.parallelBranchReadOnlyReason) {
+    reasons.push({
+      key: 'parallelBranchReadOnly',
+      message: input.parallelBranchReadOnlyReason,
+      anchor: '[data-field="parallel-branch-readonly"]',
+    })
+  }
+  if (input.parallelBranchKeyError) {
+    reasons.push({
+      key: 'parallelBranchKeyError',
+      message: input.parallelBranchKeyError,
+      anchor: '[data-field="parallel-branch-key-error"]',
+    })
+  }
+  if (input.parallelBranchActionError) {
+    reasons.push({
+      key: 'parallelBranchActionError',
+      message: input.parallelBranchActionError,
+      anchor: '[data-field="parallel-branch-action-error"]',
+    })
+  }
+
+  if (!input.conditionsComplete) {
+    reasons.push({
+      key: 'conditionsIncomplete',
+      message: zh
+        ? '请完善所有筛选条件（字段与取值均为必填）。'
+        : 'Complete all filter conditions (field and value are required).',
+      anchor: input.firstIncompleteConditionAnchor,
+    })
+  }
+
+  for (const action of input.actions) {
+    const label = automationActionTypeLabel(action.type, zh)
+    const scope = `[data-action-index="${action.index}"]`
+
+    if (action.groupMessage) {
+      const m = action.groupMessage
+      if (m.destinationIdCount === 0 && m.destinationFieldPathCount === 0) {
+        reasons.push({
+          key: `action-${action.index}-destination`,
+          message: zh
+            ? `「${label}」未设置接收群组，请至少选择一个群或填写接收人字段路径。`
+            : `"${label}" has no destination — select at least one group or a recipient field path.`,
+          anchor: `${scope} [data-field="dingtalkDestinationPickerId"]`,
+        })
+      }
+      if (!m.titleTemplate.trim()) {
+        reasons.push({
+          key: `action-${action.index}-title`,
+          message: zh ? `「${label}」标题模板为空，请填写标题。` : `"${label}" is missing a title template.`,
+          anchor: `${scope} [data-field="dingtalkTitleTemplate"]`,
+        })
+      }
+      if (!m.bodyTemplate.trim()) {
+        reasons.push({
+          key: `action-${action.index}-body`,
+          message: zh ? `「${label}」正文模板为空，请填写正文。` : `"${label}" is missing a body template.`,
+          anchor: `${scope} [data-field="dingtalkBodyTemplate"]`,
+        })
+      }
+      if (m.publicFormBlockingErrorCount > 0) {
+        reasons.push({
+          key: `action-${action.index}-publicFormLink`,
+          message: zh
+            ? `「${label}」引用的公开表单存在阻断性问题，请修正表单链接设置。`
+            : `"${label}" references a public form with blocking issues — fix the form link settings.`,
+          anchor: `${scope} [data-field="publicFormViewId"]`,
+        })
+      }
+      if (m.internalViewBlockingErrorCount > 0) {
+        reasons.push({
+          key: `action-${action.index}-internalViewLink`,
+          message: zh
+            ? `「${label}」引用的内部视图存在阻断性问题，请修正视图链接设置。`
+            : `"${label}" references an internal view with blocking issues — fix the view link settings.`,
+          anchor: `${scope} [data-field="internalViewId"]`,
+        })
+      }
+    }
+
+    if (action.personMessage) {
+      const m = action.personMessage
+      if (
+        m.userIdCount === 0
+        && m.memberGroupIdCount === 0
+        && m.recipientFieldPathCount === 0
+        && m.memberGroupRecipientFieldPathCount === 0
+      ) {
+        reasons.push({
+          key: `action-${action.index}-destination`,
+          message: zh
+            ? `「${label}」未设置接收人，请至少指定一个用户、成员组或接收人字段路径。`
+            : `"${label}" has no recipient — specify at least one user, member group, or recipient field path.`,
+          anchor: `${scope} [data-field="dingtalkPersonUserIds"]`,
+        })
+      }
+      if (!m.titleTemplate.trim()) {
+        reasons.push({
+          key: `action-${action.index}-title`,
+          message: zh ? `「${label}」标题模板为空，请填写标题。` : `"${label}" is missing a title template.`,
+          anchor: `${scope} [data-field="dingtalkPersonTitleTemplate"]`,
+        })
+      }
+      if (!m.bodyTemplate.trim()) {
+        reasons.push({
+          key: `action-${action.index}-body`,
+          message: zh ? `「${label}」正文模板为空，请填写正文。` : `"${label}" is missing a body template.`,
+          anchor: `${scope} [data-field="dingtalkPersonBodyTemplate"]`,
+        })
+      }
+      if (m.publicFormBlockingErrorCount > 0) {
+        reasons.push({
+          key: `action-${action.index}-publicFormLink`,
+          message: zh
+            ? `「${label}」引用的公开表单存在阻断性问题，请修正表单链接设置。`
+            : `"${label}" references a public form with blocking issues — fix the form link settings.`,
+          anchor: `${scope} [data-field="dingtalkPersonPublicFormViewId"]`,
+        })
+      }
+      if (m.internalViewBlockingErrorCount > 0) {
+        reasons.push({
+          key: `action-${action.index}-internalViewLink`,
+          message: zh
+            ? `「${label}」引用的内部视图存在阻断性问题，请修正视图链接设置。`
+            : `"${label}" references an internal view with blocking issues — fix the view link settings.`,
+          anchor: `${scope} [data-field="dingtalkPersonInternalViewId"]`,
+        })
+      }
+    }
+
+    if (action.email) {
+      const m = action.email
+      if (m.recipientCount === 0) {
+        reasons.push({
+          key: `action-${action.index}-recipients`,
+          message: zh ? `「${label}」未填写收件人。` : `"${label}" has no recipients.`,
+          anchor: `${scope} [data-field="emailRecipients"]`,
+        })
+      }
+      if (!m.subjectTemplate.trim()) {
+        reasons.push({
+          key: `action-${action.index}-subject`,
+          message: zh ? `「${label}」主题模板为空。` : `"${label}" is missing a subject template.`,
+          anchor: `${scope} [data-field="emailSubjectTemplate"]`,
+        })
+      }
+      if (!m.bodyTemplate.trim()) {
+        reasons.push({
+          key: `action-${action.index}-body`,
+          message: zh ? `「${label}」正文模板为空。` : `"${label}" is missing a body template.`,
+          anchor: `${scope} [data-field="emailBodyTemplate"]`,
+        })
+      }
+    }
+
+    if (action.deleteRecord && !action.deleteRecord.acknowledged) {
+      reasons.push({
+        key: `action-${action.index}-deleteAck`,
+        message: zh
+          ? `「${label}」需要勾选删除确认才能保存。`
+          : `"${label}" requires the delete-confirmation checkbox before saving.`,
+        anchor: `${scope} [data-field="deleteRecordAck"]`,
+      })
+    }
+  }
+
+  return reasons
+}

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -11,7 +11,7 @@
       <h4 class="meta-rule-editor__title">{{ rule ? automationLabel('editor.titleEdit', isZh) : automationLabel('editor.titleNew', isZh) }}</h4>
     </template>
 
-    <div class="meta-rule-editor__body">
+    <div class="meta-rule-editor__body" ref="editorBodyRef">
         <div v-if="error" class="meta-rule-editor__error" role="alert">{{ error }}</div>
 
         <!-- Name -->
@@ -1223,6 +1223,25 @@
             @click="addAction"
           >{{ automationLabel('editor.addAction', isZh) }}</el-button>
         </section>
+
+        <!-- G-B2-22: why Save is disabled, in place of a silent grey button. Each reason is its
+             own clickable line — clicking scrolls the editor to the control it's about. A reason
+             with no anchor (honestly) does nothing on click instead of pointing somewhere wrong. -->
+        <div v-if="saveBlockReasons.length > 0" class="meta-rule-editor__save-block-alert" data-field="saveBlockReasons">
+          <div class="meta-rule-editor__save-block-title">{{ automationLabel('editor.saveBlockedTitle', isZh) }}</div>
+          <ul class="meta-rule-editor__save-block-list">
+            <li v-for="reason in saveBlockReasons" :key="reason.key">
+              <button
+                type="button"
+                class="meta-rule-editor__save-block-reason"
+                :disabled="!reason.anchor"
+                data-action="save-block-reason"
+                :data-reason-key="reason.key"
+                @click="scrollToSaveBlockAnchor(reason.anchor)"
+              >{{ reason.message }}</button>
+            </li>
+          </ul>
+        </div>
     </div>
 
     <!-- Footer -->
@@ -1340,6 +1359,11 @@ import {
   validateParallelBranchActions,
   validateParallelBranchKeys,
 } from '../utils/parallelBranchAuthoring'
+import {
+  computeSaveBlockReasons,
+  type SaveBlockActionSnapshot,
+  type SaveBlockReason,
+} from '../automationSaveBlockReasons'
 
 interface FieldPair {
   fieldId: string
@@ -1432,6 +1456,9 @@ const emit = defineEmits<{
 
 const error = ref('')
 const saving = ref(false)
+// G-B2-22: root of the drawer's scrollable body, scoped so scroll-to-reason navigation never
+// reaches outside this editor instance.
+const editorBodyRef = ref<HTMLElement | null>(null)
 const cronPreset = ref('0 * * * *')
 const dingTalkDestinations = ref<DingTalkGroupDestination[]>([])
 const dingTalkDestinationsError = ref('')
@@ -2443,55 +2470,112 @@ function setDeleteRecordAcknowledged(action: DraftAction, checked: boolean): voi
   }
 }
 
-const canSave = computed(() => {
-  if (!draft.value.name.trim()) return false
-  if (draft.value.actions.length < 1) return false
-  // T1-3: mirror the backend save gate (templateId / no-conditions / notification-only actions).
-  if (draft.value.triggerType === 'approval.completed' && approvalCompletedBlockReason.value) return false
-  if (draft.value.triggerType === 'approval.task_created' && approvalTaskCreatedBlockReason.value) return false
-  // T1-2: a signing secret is required; an existing rule with a stored (redacted-on-read) secret may
-  // leave the field blank to keep it.
-  if (draft.value.triggerType === 'webhook.received') {
-    const secret = typeof draft.value.triggerConfig.secret === 'string' ? draft.value.triggerConfig.secret.trim() : ''
-    if (!secret && !(props.rule?.id && savedWebhookSecretConfigured.value)) return false
-  }
-  if (conditionBranchReadOnlyReason.value) return false // A6-3-2a point #3: never save a non-round-trippable loaded branch
-  if (conditionBranchKeyError.value) return false // A6-3-2a point #1: branch key safe/unique mirror
-  if (parallelBranchReadOnlyReason.value) return false // A6-3-4/W3-2a: never save a non-round-trippable loaded join
-  if (parallelBranchKeyError.value) return false // W3-2a: frontend mirror of backend branch bounds/keys
-  if (parallelBranchActionError.value) return false // W3-2a: nested branch actions must be executable, not executor-failing shells
-  if (!draft.value.conditions.conditions.every(areConditionsComplete)) return false
-  for (const action of draft.value.actions) {
+// G-B2-22: per-action data needed by saveBlockReasons, captured as plain snapshots (counts + raw
+// template strings, not pre-combined booleans) so the AND/OR/negation for "is this action
+// configured" lives in computeSaveBlockReasons (automationSaveBlockReasons.ts) — the one place
+// that can be unit-tested without this 3000+ line component. The parsing calls themselves
+// (parseGroupDestinationIds etc.) stay here unchanged: this is exactly what canSave read before,
+// just captured instead of immediately branching on it.
+const saveBlockActionSnapshots = computed<SaveBlockActionSnapshot[]>(() => {
+  return draft.value.actions.map((action, index) => {
+    const snapshot: SaveBlockActionSnapshot = { index, type: action.type }
     if (action.type === 'send_dingtalk_group_message') {
       const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
       const destinationFieldPaths = parseRecipientFieldPathsText(action.config.destinationFieldPath)
-      const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
-      const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!destinationIds.length && !destinationFieldPaths.length) || !titleTemplate || !bodyTemplate) return false
-      if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
-      if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
+      snapshot.groupMessage = {
+        destinationIdCount: destinationIds.length,
+        destinationFieldPathCount: destinationFieldPaths.length,
+        titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate : '',
+        bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate : '',
+        publicFormBlockingErrorCount: publicFormLinkBlockingErrors(action.config.publicFormViewId).length,
+        internalViewBlockingErrorCount: internalViewLinkBlockingErrors(action.config.internalViewId).length,
+      }
     }
     if (action.type === 'send_dingtalk_person_message') {
       const userIds = parseUserIdsText(action.config.userIdsText)
       const memberGroupIds = parseMemberGroupIdsText(action.config.memberGroupIdsText)
       const recipientFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
       const memberGroupRecipientFieldPaths = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
-      const titleTemplate = typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate.trim() : ''
-      const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if ((!userIds.length && !memberGroupIds.length && !recipientFieldPaths.length && !memberGroupRecipientFieldPaths.length) || !titleTemplate || !bodyTemplate) return false
-      if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
-      if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
+      snapshot.personMessage = {
+        userIdCount: userIds.length,
+        memberGroupIdCount: memberGroupIds.length,
+        recipientFieldPathCount: recipientFieldPaths.length,
+        memberGroupRecipientFieldPathCount: memberGroupRecipientFieldPaths.length,
+        titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate : '',
+        bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate : '',
+        publicFormBlockingErrorCount: publicFormLinkBlockingErrors(action.config.publicFormViewId).length,
+        internalViewBlockingErrorCount: internalViewLinkBlockingErrors(action.config.internalViewId).length,
+      }
     }
     if (action.type === 'send_email') {
       const recipients = parseEmailRecipientsText(action.config.recipientsText)
-      const subjectTemplate = typeof action.config.subjectTemplate === 'string' ? action.config.subjectTemplate.trim() : ''
-      const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
-      if (!recipients.length || !subjectTemplate || !bodyTemplate) return false
+      snapshot.email = {
+        recipientCount: recipients.length,
+        subjectTemplate: typeof action.config.subjectTemplate === 'string' ? action.config.subjectTemplate : '',
+        bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate : '',
+      }
     }
-    if (action.type === 'delete_record' && !isDeleteRecordAcknowledged(action)) return false
-  }
-  return true
+    if (action.type === 'delete_record') {
+      snapshot.deleteRecord = { acknowledged: isDeleteRecordAcknowledged(action) }
+    }
+    return snapshot
+  })
 })
+
+// G-B2-22: locates the first entry collectConditionEditorEntries would flag as incomplete, in the
+// same depth-first order areConditionsComplete's recursive `.every()` short-circuits on — so this
+// always names the same condition/group the boolean check would have failed on first.
+const firstIncompleteConditionAnchor = computed<string | undefined>(() => {
+  for (const entry of conditionEditorEntries.value) {
+    if (entry.kind === 'group') {
+      if (entry.group.conditions.length === 0) return `[data-condition-group-path="${entry.pathKey}"]`
+      continue
+    }
+    if (!isConditionLeafComplete(entry.condition)) return `[data-condition-path="${entry.pathKey}"]`
+  }
+  return undefined
+})
+
+// G-B2-22: saveBlockReasons is the single source of truth for "why can't I save" — canSave is
+// derived from it below so the button's disabled state and the reasons shown to the author can
+// never disagree. See automationSaveBlockReasons.ts for the aggregation itself; every condition
+// here is the exact condition the old canSave silently checked (kept in the same order).
+const saveBlockReasons = computed<SaveBlockReason[]>(() => {
+  const secret = typeof draft.value.triggerConfig.secret === 'string' ? draft.value.triggerConfig.secret.trim() : ''
+  return computeSaveBlockReasons({
+    isZh: isZh.value,
+    name: draft.value.name,
+    actionsCount: draft.value.actions.length,
+    triggerType: draft.value.triggerType,
+    // T1-3: mirror the backend save gate (templateId / no-conditions / notification-only actions).
+    approvalCompletedBlockReason: approvalCompletedBlockReason.value,
+    approvalTaskCreatedBlockReason: approvalTaskCreatedBlockReason.value,
+    // T1-2: a signing secret is required; an existing rule with a stored (redacted-on-read) secret
+    // may leave the field blank to keep it.
+    webhookSecretPresent: !!secret,
+    ruleHasId: !!props.rule?.id,
+    savedWebhookSecretConfigured: savedWebhookSecretConfigured.value,
+    conditionBranchReadOnlyReason: conditionBranchReadOnlyReason.value, // A6-3-2a #3: never save a non-round-trippable loaded branch
+    conditionBranchKeyError: conditionBranchKeyError.value, // A6-3-2a #1: branch key safe/unique mirror
+    parallelBranchReadOnlyReason: parallelBranchReadOnlyReason.value, // A6-3-4/W3-2a: never save a non-round-trippable loaded join
+    parallelBranchKeyError: parallelBranchKeyError.value, // W3-2a: frontend mirror of backend branch bounds/keys
+    parallelBranchActionError: parallelBranchActionError.value, // W3-2a: nested branch actions must be executable, not executor-failing shells
+    conditionsComplete: draft.value.conditions.conditions.every(areConditionsComplete),
+    firstIncompleteConditionAnchor: firstIncompleteConditionAnchor.value,
+    actions: saveBlockActionSnapshots.value,
+  })
+})
+
+const canSave = computed(() => saveBlockReasons.value.length === 0)
+
+// G-B2-22: click-to-scroll for a save-block reason. Scoped to this drawer's own body so it can
+// never jump to a same-named element in some other open surface. A reason without an anchor (see
+// automationSaveBlockReasons.ts) is a no-op here rather than a guess.
+function scrollToSaveBlockAnchor(anchor?: string): void {
+  if (!anchor) return
+  const target = editorBodyRef.value?.querySelector(anchor)
+  if (target instanceof HTMLElement) target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+}
 
 function addCondition() {
   addConditionToGroup([])
@@ -3706,5 +3790,48 @@ async function onTestRun(): Promise<void> {
   align-items: center;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+/* G-B2-22: reuses the same danger-alert coloring as .meta-rule-editor__error above. */
+.meta-rule-editor__save-block-alert {
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-rule-editor__save-block-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.meta-rule-editor__save-block-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.meta-rule-editor__save-block-reason {
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 2px 0;
+  font-size: 12px;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.meta-rule-editor__save-block-reason:disabled {
+  cursor: default;
+  text-decoration: none;
+  opacity: 0.85;
 }
 </style>

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -97,6 +97,7 @@ export type AutomationLabelKey =
   | 'editor.executionModeLabel'
   | 'editor.executionModeHint'
   | 'editor.executionModeRequiredHint'
+  | 'editor.saveBlockedTitle'
   | 'trigger.title'
   | 'trigger.watchField'
   | 'trigger.selectField'
@@ -360,6 +361,7 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'editor.executionModeLabel',
   'editor.executionModeHint',
   'editor.executionModeRequiredHint',
+  'editor.saveBlockedTitle',
   'trigger.title',
   'trigger.watchField',
   'trigger.selectField',
@@ -631,6 +633,12 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'editor.executionModeRequiredHint': {
     en: 'Required and locked on: this rule has an action that requires durable WorkflowJob records (wait for callback, condition branch, or parallel branch).',
     zh: '已强制开启并锁定：本规则包含需要持久 WorkflowJob 记录的动作（等待回调、条件分支或并行分支），无法关闭。',
+  },
+  // G-B2-22: title above the save-block reasons list — shown only while Save is disabled by a
+  // validation guard, never while merely mid-save.
+  'editor.saveBlockedTitle': {
+    en: "Can't save yet — fix the following:",
+    zh: '暂时无法保存，请先解决以下问题：',
   },
   'trigger.title': { en: 'Trigger', zh: '触发器' },
   'trigger.watchField': { en: 'Watch field', zh: '监听字段' },

--- a/apps/web/tests/automation-save-block-reasons.spec.ts
+++ b/apps/web/tests/automation-save-block-reasons.spec.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeSaveBlockReasons,
+  type SaveBlockActionSnapshot,
+  type SaveBlockReasonsInput,
+} from '../src/multitable/automationSaveBlockReasons'
+
+// ---------------------------------------------------------------------------
+// Independent oracle — a second, hand-transcribed copy of the ORIGINAL
+// MetaAutomationRuleEditor.vue `canSave` boolean chain (as it read before G-B2-22),
+// re-expressed over the same snapshot type. This is deliberately NOT derived from
+// computeSaveBlockReasons: its only job is to catch a transcription bug that the
+// aggregator and the "reasons" list could otherwise share silently. Every test below
+// asserts `computeSaveBlockReasons(input).length === 0` agrees with `originalCanSave(input)`.
+// ---------------------------------------------------------------------------
+function originalCanSave(input: SaveBlockReasonsInput): boolean {
+  if (!input.name.trim()) return false
+  if (input.actionsCount < 1) return false
+  if (input.triggerType === 'approval.completed' && input.approvalCompletedBlockReason) return false
+  if (input.triggerType === 'approval.task_created' && input.approvalTaskCreatedBlockReason) return false
+  if (input.triggerType === 'webhook.received') {
+    if (!input.webhookSecretPresent && !(input.ruleHasId && input.savedWebhookSecretConfigured)) return false
+  }
+  if (input.conditionBranchReadOnlyReason) return false
+  if (input.conditionBranchKeyError) return false
+  if (input.parallelBranchReadOnlyReason) return false
+  if (input.parallelBranchKeyError) return false
+  if (input.parallelBranchActionError) return false
+  if (!input.conditionsComplete) return false
+  for (const action of input.actions) {
+    if (action.groupMessage) {
+      const m = action.groupMessage
+      if ((m.destinationIdCount === 0 && m.destinationFieldPathCount === 0) || !m.titleTemplate.trim() || !m.bodyTemplate.trim()) return false
+      if (m.publicFormBlockingErrorCount > 0) return false
+      if (m.internalViewBlockingErrorCount > 0) return false
+    }
+    if (action.personMessage) {
+      const m = action.personMessage
+      if (
+        (m.userIdCount === 0 && m.memberGroupIdCount === 0 && m.recipientFieldPathCount === 0 && m.memberGroupRecipientFieldPathCount === 0)
+        || !m.titleTemplate.trim()
+        || !m.bodyTemplate.trim()
+      ) return false
+      if (m.publicFormBlockingErrorCount > 0) return false
+      if (m.internalViewBlockingErrorCount > 0) return false
+    }
+    if (action.email) {
+      const m = action.email
+      if (m.recipientCount === 0 || !m.subjectTemplate.trim() || !m.bodyTemplate.trim()) return false
+    }
+    if (action.deleteRecord && !action.deleteRecord.acknowledged) return false
+  }
+  return true
+}
+
+function baseInput(): SaveBlockReasonsInput {
+  return {
+    isZh: false,
+    name: 'My rule',
+    actionsCount: 1,
+    triggerType: 'record.created',
+    approvalCompletedBlockReason: '',
+    approvalTaskCreatedBlockReason: '',
+    webhookSecretPresent: false,
+    ruleHasId: false,
+    savedWebhookSecretConfigured: false,
+    conditionBranchReadOnlyReason: null,
+    conditionBranchKeyError: null,
+    parallelBranchReadOnlyReason: null,
+    parallelBranchKeyError: null,
+    parallelBranchActionError: null,
+    conditionsComplete: true,
+    firstIncompleteConditionAnchor: undefined,
+    actions: [{ index: 0, type: 'update_record' }],
+  }
+}
+
+function validGroupMessageAction(index = 0): SaveBlockActionSnapshot {
+  return {
+    index,
+    type: 'send_dingtalk_group_message',
+    groupMessage: {
+      destinationIdCount: 1,
+      destinationFieldPathCount: 0,
+      titleTemplate: 'Title',
+      bodyTemplate: 'Body',
+      publicFormBlockingErrorCount: 0,
+      internalViewBlockingErrorCount: 0,
+    },
+  }
+}
+
+function validPersonMessageAction(index = 0): SaveBlockActionSnapshot {
+  return {
+    index,
+    type: 'send_dingtalk_person_message',
+    personMessage: {
+      userIdCount: 1,
+      memberGroupIdCount: 0,
+      recipientFieldPathCount: 0,
+      memberGroupRecipientFieldPathCount: 0,
+      titleTemplate: 'Title',
+      bodyTemplate: 'Body',
+      publicFormBlockingErrorCount: 0,
+      internalViewBlockingErrorCount: 0,
+    },
+  }
+}
+
+function validEmailAction(index = 0): SaveBlockActionSnapshot {
+  return {
+    index,
+    type: 'send_email',
+    email: { recipientCount: 1, subjectTemplate: 'Subject', bodyTemplate: 'Body' },
+  }
+}
+
+function validDeleteRecordAction(index = 0): SaveBlockActionSnapshot {
+  return { index, type: 'delete_record', deleteRecord: { acknowledged: true } }
+}
+
+/** Asserts a single input against both implementations and returns the reasons for further checks. */
+function expectBlocked(input: SaveBlockReasonsInput, expectedKey: string) {
+  const reasons = computeSaveBlockReasons(input)
+  expect(reasons.some((r) => r.key === expectedKey), JSON.stringify(reasons)).toBe(true)
+  expect(originalCanSave(input)).toBe(false)
+  expect(reasons.length === 0).toBe(originalCanSave(input))
+  return reasons
+}
+
+function expectSaveable(input: SaveBlockReasonsInput) {
+  const reasons = computeSaveBlockReasons(input)
+  expect(reasons, JSON.stringify(reasons)).toEqual([])
+  expect(originalCanSave(input)).toBe(true)
+  expect(reasons.length === 0).toBe(originalCanSave(input))
+}
+
+describe('automationSaveBlockReasons', () => {
+  it('reports no reasons (and canSave true) when every guard is satisfied', () => {
+    expectSaveable(baseInput())
+  })
+
+  it('blocks on an empty rule name', () => {
+    const input = { ...baseInput(), name: '   ' }
+    const reasons = expectBlocked(input, 'name')
+    expect(reasons.find((r) => r.key === 'name')?.anchor).toBe('[data-field="name"]')
+  })
+
+  it('blocks when there are no actions', () => {
+    const input = { ...baseInput(), actionsCount: 0, actions: [] }
+    const reasons = expectBlocked(input, 'actionsEmpty')
+    expect(reasons.find((r) => r.key === 'actionsEmpty')?.anchor).toBe('[data-action="add-action"]')
+  })
+
+  it('blocks approval.completed triggers with an unmet trigger-level requirement', () => {
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      triggerType: 'approval.completed',
+      approvalCompletedBlockReason: 'Select an approval template.',
+    }
+    const reasons = expectBlocked(input, 'approvalCompletedBlockReason')
+    expect(reasons.find((r) => r.key === 'approvalCompletedBlockReason')?.message).toBe('Select an approval template.')
+  })
+
+  it('ignores a stale approvalCompletedBlockReason when the trigger type has moved on', () => {
+    // Guards against a regression where the reason-string guard alone (without the triggerType
+    // re-check) would wrongly re-block a rule that switched away from approval.completed.
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      triggerType: 'record.created',
+      approvalCompletedBlockReason: 'Select an approval template.',
+    }
+    expectSaveable(input)
+  })
+
+  it('blocks approval.task_created triggers with an unmet trigger-level requirement', () => {
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      triggerType: 'approval.task_created',
+      approvalTaskCreatedBlockReason: 'Remove all conditions.',
+    }
+    expectBlocked(input, 'approvalTaskCreatedBlockReason')
+  })
+
+  it('blocks a webhook trigger with no secret typed and no stored secret to keep', () => {
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      triggerType: 'webhook.received',
+      webhookSecretPresent: false,
+      ruleHasId: false,
+      savedWebhookSecretConfigured: false,
+    }
+    expectBlocked(input, 'webhookSecret')
+  })
+
+  it('allows a webhook trigger with a blank secret when an existing rule keeps its stored secret', () => {
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      triggerType: 'webhook.received',
+      webhookSecretPresent: false,
+      ruleHasId: true,
+      savedWebhookSecretConfigured: true,
+    }
+    expectSaveable(input)
+  })
+
+  it('blocks a non-round-trippable loaded condition_branch', () => {
+    const input: SaveBlockReasonsInput = { ...baseInput(), conditionBranchReadOnlyReason: 'Unsupported branch shape.' }
+    expectBlocked(input, 'conditionBranchReadOnly')
+  })
+
+  it('blocks an unsafe/duplicate condition_branch key', () => {
+    const input: SaveBlockReasonsInput = { ...baseInput(), conditionBranchKeyError: 'Duplicate branch key.' }
+    expectBlocked(input, 'conditionBranchKeyError')
+  })
+
+  it('blocks a non-round-trippable loaded parallel_branch', () => {
+    const input: SaveBlockReasonsInput = { ...baseInput(), parallelBranchReadOnlyReason: 'Unsupported join shape.' }
+    expectBlocked(input, 'parallelBranchReadOnly')
+  })
+
+  it('blocks an unsafe/duplicate parallel_branch key', () => {
+    const input: SaveBlockReasonsInput = { ...baseInput(), parallelBranchKeyError: 'Duplicate branch key.' }
+    expectBlocked(input, 'parallelBranchKeyError')
+  })
+
+  it('blocks a parallel_branch with a non-executable nested action', () => {
+    const input: SaveBlockReasonsInput = { ...baseInput(), parallelBranchActionError: 'Nested action cannot run.' }
+    expectBlocked(input, 'parallelBranchActionError')
+  })
+
+  it('blocks incomplete filter conditions and passes through the first-incomplete anchor', () => {
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      conditionsComplete: false,
+      firstIncompleteConditionAnchor: '[data-condition-path="0"]',
+    }
+    const reasons = expectBlocked(input, 'conditionsIncomplete')
+    expect(reasons.find((r) => r.key === 'conditionsIncomplete')?.anchor).toBe('[data-condition-path="0"]')
+  })
+
+  it('never fabricates an anchor for incomplete conditions when one cannot be identified', () => {
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      conditionsComplete: false,
+      firstIncompleteConditionAnchor: undefined,
+    }
+    const reasons = expectBlocked(input, 'conditionsIncomplete')
+    expect(reasons.find((r) => r.key === 'conditionsIncomplete')?.anchor).toBeUndefined()
+  })
+
+  it('passes with a fully-configured group-message action', () => {
+    expectSaveable({ ...baseInput(), actionsCount: 1, actions: [validGroupMessageAction()] })
+  })
+
+  it('blocks a group-message action with no destination', () => {
+    const action = validGroupMessageAction()
+    action.groupMessage!.destinationIdCount = 0
+    action.groupMessage!.destinationFieldPathCount = 0
+    const reasons = expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-destination')
+    expect(reasons.find((r) => r.key === 'action-0-destination')?.anchor).toBe('[data-action-index="0"] [data-field="dingtalkDestinationPickerId"]')
+  })
+
+  it('blocks a group-message action with a blank title template', () => {
+    const action = validGroupMessageAction()
+    action.groupMessage!.titleTemplate = '   '
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-title')
+  })
+
+  it('blocks a group-message action with a blank body template', () => {
+    const action = validGroupMessageAction()
+    action.groupMessage!.bodyTemplate = ''
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-body')
+  })
+
+  it('blocks a group-message action whose public-form link has blocking errors', () => {
+    const action = validGroupMessageAction()
+    action.groupMessage!.publicFormBlockingErrorCount = 2
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-publicFormLink')
+  })
+
+  it('blocks a group-message action whose internal-view link has blocking errors', () => {
+    const action = validGroupMessageAction()
+    action.groupMessage!.internalViewBlockingErrorCount = 1
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-internalViewLink')
+  })
+
+  it('passes with a fully-configured person-message action', () => {
+    expectSaveable({ ...baseInput(), actions: [validPersonMessageAction()] })
+  })
+
+  it('blocks a person-message action with no recipient of any kind', () => {
+    const action = validPersonMessageAction()
+    action.personMessage!.userIdCount = 0
+    const reasons = expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-destination')
+    expect(reasons.find((r) => r.key === 'action-0-destination')?.anchor).toBe('[data-action-index="0"] [data-field="dingtalkPersonUserIds"]')
+  })
+
+  it('blocks a person-message action with a blank title template', () => {
+    const action = validPersonMessageAction()
+    action.personMessage!.titleTemplate = ''
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-title')
+  })
+
+  it('blocks a person-message action with a blank body template', () => {
+    const action = validPersonMessageAction()
+    action.personMessage!.bodyTemplate = '  '
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-body')
+  })
+
+  it('blocks a person-message action whose public-form link has blocking errors', () => {
+    const action = validPersonMessageAction()
+    action.personMessage!.publicFormBlockingErrorCount = 1
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-publicFormLink')
+  })
+
+  it('blocks a person-message action whose internal-view link has blocking errors', () => {
+    const action = validPersonMessageAction()
+    action.personMessage!.internalViewBlockingErrorCount = 1
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-internalViewLink')
+  })
+
+  it('passes with a fully-configured email action', () => {
+    expectSaveable({ ...baseInput(), actions: [validEmailAction()] })
+  })
+
+  it('blocks an email action with no recipients', () => {
+    const action = validEmailAction()
+    action.email!.recipientCount = 0
+    const reasons = expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-recipients')
+    expect(reasons.find((r) => r.key === 'action-0-recipients')?.anchor).toBe('[data-action-index="0"] [data-field="emailRecipients"]')
+  })
+
+  it('blocks an email action with a blank subject template', () => {
+    const action = validEmailAction()
+    action.email!.subjectTemplate = ''
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-subject')
+  })
+
+  it('blocks an email action with a blank body template', () => {
+    const action = validEmailAction()
+    action.email!.bodyTemplate = '   '
+    expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-body')
+  })
+
+  it('passes with an acknowledged delete_record action', () => {
+    expectSaveable({ ...baseInput(), actions: [validDeleteRecordAction()] })
+  })
+
+  it('blocks an unacknowledged delete_record action', () => {
+    const action = validDeleteRecordAction()
+    action.deleteRecord!.acknowledged = false
+    const reasons = expectBlocked({ ...baseInput(), actions: [action] }, 'action-0-deleteAck')
+    expect(reasons.find((r) => r.key === 'action-0-deleteAck')?.anchor).toBe('[data-action-index="0"] [data-field="deleteRecordAck"]')
+  })
+
+  it('scopes per-action anchors to the failing action index among several actions', () => {
+    const good = validEmailAction(0)
+    const bad = validGroupMessageAction(1)
+    bad.groupMessage!.titleTemplate = ''
+    const reasons = computeSaveBlockReasons({ ...baseInput(), actionsCount: 2, actions: [good, bad] })
+    expect(reasons).toHaveLength(1)
+    expect(reasons[0].key).toBe('action-1-title')
+    expect(reasons[0].anchor).toBe('[data-action-index="1"] [data-field="dingtalkTitleTemplate"]')
+  })
+
+  it('aggregates multiple simultaneous failures without losing any of them', () => {
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      name: '',
+      conditionBranchKeyError: 'Duplicate key.',
+      actions: [],
+      actionsCount: 0,
+    }
+    const reasons = computeSaveBlockReasons(input)
+    const keys = reasons.map((r) => r.key)
+    expect(keys).toEqual(expect.arrayContaining(['name', 'actionsEmpty', 'conditionBranchKeyError']))
+    expect(originalCanSave(input)).toBe(false)
+    expect(reasons.length === 0).toBe(originalCanSave(input))
+  })
+
+  it('produces localized (zh) messages when isZh is true', () => {
+    const input = { ...baseInput(), name: '' , isZh: true }
+    const reasons = computeSaveBlockReasons(input)
+    expect(reasons[0].message).toBe('请填写规则名称。')
+  })
+})

--- a/apps/web/tests/automation-save-block-reasons.spec.ts
+++ b/apps/web/tests/automation-save-block-reasons.spec.ts
@@ -386,3 +386,112 @@ describe('automationSaveBlockReasons', () => {
     expect(reasons[0].message).toBe('请填写规则名称。')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Exhaustive top-level guard harness (added on adversarial review).
+//
+// The hand-written cases above left FOUR top-level guards neuterable: you could
+// delete a conjunct and every one of them stayed green. One of those was reachable
+// in production — dropping `savedWebhookSecretConfigured` from the webhook guard
+// would let "edit an existing non-webhook rule → switch trigger to webhook.received
+// → leave the secret blank → save" through, persisting a webhook rule with no secret.
+//
+// Rather than bolt on five more fixtures (which only pins the holes we happened to
+// notice), this walks the full cartesian product of every top-level guard input and
+// asserts the exact reason-key SET for each of the 32,768 combinations. Any guard
+// that is removed, or has a conjunct dropped, changes some combination's key set and
+// turns this red. `expectedKeys` is transcribed independently from the guard
+// semantics, so it does not move when the implementation does.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('computeSaveBlockReasons — exhaustive top-level guard coverage', () => {
+  const BLOCK_MSG = 'blocked'
+
+  function expectedTopLevelKeys(i: SaveBlockReasonsInput): string[] {
+    const keys: string[] = []
+    if (!i.name.trim()) keys.push('name')
+    if (i.actionsCount < 1) keys.push('actionsEmpty')
+    if (i.triggerType === 'approval.completed' && i.approvalCompletedBlockReason) keys.push('approvalCompletedBlockReason')
+    if (i.triggerType === 'approval.task_created' && i.approvalTaskCreatedBlockReason) keys.push('approvalTaskCreatedBlockReason')
+    if (i.triggerType === 'webhook.received' && !i.webhookSecretPresent && !(i.ruleHasId && i.savedWebhookSecretConfigured)) keys.push('webhookSecret')
+    if (i.conditionBranchReadOnlyReason) keys.push('conditionBranchReadOnly')
+    if (i.conditionBranchKeyError) keys.push('conditionBranchKeyError')
+    if (i.parallelBranchReadOnlyReason) keys.push('parallelBranchReadOnly')
+    if (i.parallelBranchKeyError) keys.push('parallelBranchKeyError')
+    if (i.parallelBranchActionError) keys.push('parallelBranchActionError')
+    if (!i.conditionsComplete) keys.push('conditionsIncomplete')
+    return keys
+  }
+
+  it('pins the reason-key set across the full cartesian product of top-level guards', () => {
+    const names = ['', 'My rule']
+    const actionCounts = [0, 1]
+    const triggers = ['record.created', 'approval.completed', 'approval.task_created', 'webhook.received']
+    const bools = [false, true]
+    const strs = ['', BLOCK_MSG]
+    const nulls = [null, BLOCK_MSG]
+
+    let checked = 0
+    let mismatches = 0
+    for (const name of names)
+    for (const actionsCount of actionCounts)
+    for (const triggerType of triggers)
+    for (const approvalCompletedBlockReason of strs)
+    for (const approvalTaskCreatedBlockReason of strs)
+    for (const webhookSecretPresent of bools)
+    for (const ruleHasId of bools)
+    for (const savedWebhookSecretConfigured of bools)
+    for (const conditionBranchReadOnlyReason of nulls)
+    for (const conditionBranchKeyError of nulls)
+    for (const parallelBranchReadOnlyReason of nulls)
+    for (const parallelBranchKeyError of nulls)
+    for (const parallelBranchActionError of nulls)
+    for (const conditionsComplete of bools) {
+      const input: SaveBlockReasonsInput = {
+        ...baseInput(),
+        name,
+        actionsCount,
+        triggerType,
+        approvalCompletedBlockReason,
+        approvalTaskCreatedBlockReason,
+        webhookSecretPresent,
+        ruleHasId,
+        savedWebhookSecretConfigured,
+        conditionBranchReadOnlyReason,
+        conditionBranchKeyError,
+        parallelBranchReadOnlyReason,
+        parallelBranchKeyError,
+        parallelBranchActionError,
+        conditionsComplete,
+        actions: [],
+      }
+      const actual = computeSaveBlockReasons(input).map((r) => r.key)
+      const expected = expectedTopLevelKeys(input)
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        mismatches += 1
+        if (mismatches === 1) {
+          expect({ input, actual, expected }).toEqual({ input, actual: expected, expected })
+        }
+      }
+      // canSave is derived from the reason list — the two can never disagree.
+      expect(computeSaveBlockReasons(input).length === 0).toBe(originalCanSave({ ...input, actions: [] }))
+      checked += 1
+    }
+    expect(mismatches).toBe(0)
+    expect(checked).toBe(32768)
+  })
+
+  it('REACHABLE HOLE: an existing rule switched to webhook trigger with no stored secret still blocks', () => {
+    // ruleHasId=true but savedWebhookSecretConfigured=false → the `&& savedWebhookSecretConfigured`
+    // conjunct is the only thing standing between the user and a secretless webhook rule.
+    const input: SaveBlockReasonsInput = {
+      ...baseInput(),
+      triggerType: 'webhook.received',
+      webhookSecretPresent: false,
+      ruleHasId: true,
+      savedWebhookSecretConfigured: false,
+      actions: [],
+      actionsCount: 1,
+    }
+    expect(computeSaveBlockReasons(input).map((r) => r.key)).toContain('webhookSecret')
+  })
+})


### PR DESCRIPTION
## 审计项 G-B2-22
> ~15 条静默 false 只表现为置灰；saveBlockReasons 列表 + 滚动锚定

## 做了什么
- 新增纯模块 `automationSaveBlockReasons.ts`：把原 `canSave` 里 **25 条**原子阻断条件搬成人话 `reasons[] = {key, message, anchor?}`。
- **单一真源**：`canSave = computed(() => saveBlockReasons.value.length === 0)` —— 「按钮为何灰」与「能否保存」永远不会不一致。
- 禁用时内联列出全部原因；点击某条 → 滚动锚定到对应控件（**25 个锚点全部复用模板里已存在且必渲染的** `data-field`/`data-action`/`data-condition-*`，无捏造）。
- `onSave` 的 `if (!canSave.value) return` 提交防线**保留**（双闸门）。

## 对抗审阅结论：APPROVE，**0 P1 / 0 P2 语义漂移**
审阅者**未**复用作者的 oracle，而是从 merge-base 独立转录第三个 oracle 做穷举对拍：
**49,152** 顶层守卫笛卡尔积 + **748** 单动作快照 ×2 语种 + **559,504** 有序双动作组合 → **漂移 0，重复 key 0**，映射 **25/25**（缺失 0、多余 0）。放宽与收紧两个方向均无反例。

## Review 后补强（本 PR 已包含）
审阅指出：手写的 36 例让**四条顶层守卫可被 neuter 而全绿**。其中**一条生产可达**——
webhook 守卫 `webhook.received && !secretPresent && !(ruleHasId && savedWebhookSecretConfigured)` 中，
去掉 `savedWebhookSecretConfigured` 后，「**编辑一条已存在的非 webhook 规则 → 改触发器为 webhook.received → secret 留空 → 保存**」会被放行，落库一条**无 secret 的 webhook 规则**。

补强做法（采纳审阅建议，而非手补 5 个 fixture —— 那只能钉住我们恰好想到的洞）：
**穷举全部顶层守卫输入的笛卡尔积（32,768 组合，580ms）**，断言每组的 reason-key **精确集合**，并断言 `canSave` 与 reason 列表永不相悖。
**突变验证**：去掉 webhook 那个合取项 → 2 条用例红；关掉 `conditionsComplete` 守卫 → 3 条红；还原全绿。

## 另一处系统性发现（本 PR 顺手修）
该 spec **原本不在任何 workflow 里跑** —— `automationSaveBlockReasons.ts` 在整个 `.github/` 零出现。
即「PR 全绿 ≠ 这些测试通过了」。已按两点接线补进 `multitable-web-guard.yml`（path 触发 + vitest filter）。
⚠️ 更大的问题请你定夺：**required check 里的 `test (20.x)` 只 `build` apps/web，从不跑它的单测**；
web 单测只存在于**非 required** 的 guard 里。要真正上闸门，需要你决定是否新增/提升一个 required 的 web 测试 job。

## 验证
- `automation-save-block-reasons` 38 例（含穷举 harness）· `multitable-automation-rule-editor` **115/115 未修改** · `meta-automation-labels` 全绿 —— 合计 **166/166**。
- `vue-tsc --noEmit` **0 error**。新增文案走 typed label module 三处扩展点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)