### PR TITLE
feat(approval): G-B2-11 — 新待办到达刷新 pill（不自动刷新，保护批量勾选）

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -33,6 +33,17 @@ on:
       - 'apps/web/src/approvals/newTodoPill.ts'
       - 'apps/web/src/approvals/urgeButtonState.ts'
       - 'apps/web/src/views/approval/ApprovalCenterView.vue'
+      # Previously UNGATED approval specs (verified green before wiring): route-preview FE,
+      # wave-A helpers, template center, and the approval-center list surfaces. NOTE: the guard is
+      # NOT a required check — see the PR body. approvalStaticPicker is deliberately excluded: it
+      # carries two failures already on main and would red the guard for everyone.
+      - 'apps/web/src/approvals/routePreviewController.ts'
+      - 'apps/web/src/approvals/routePreviewSummary.ts'
+      - 'apps/web/src/approvals/formDraft.ts'
+      - 'apps/web/src/approvals/amountInWords.ts'
+      - 'apps/web/src/approvals/conditionSummary.ts'
+      - 'apps/web/src/approvals/templateGalleryFilter.ts'
+      - 'apps/web/src/views/approval/TemplateCenterView.vue'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
@@ -354,4 +365,4 @@ jobs:
         # files and asserts zero static style= attributes and zero hex/rgb() literals inside
         # <style> blocks (var() references + transparent/inherit/currentColor/none allowed);
         # had no gate before this wiring.
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words approval-form-draft lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView newTodoPill approval-urge-button-state ui-foundation-style-guard uiFoundationTexture --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words approval-form-draft lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView newTodoPill approval-urge-button-state approval-route-preview-controller approval-route-preview-summary approval-form-draft approval-amount-in-words approval-number-field-props approval-condition-summary approval-prefill-from-snapshot approval-upcoming-nodes approval-assignee-source approval-field-visibility templateGalleryFilter approvalTemplateCenterCategory approval-center approvalCenterRemindBadge approvalCenterUnreadBadge approvalCenterSourceFilter approval-graph-summary ui-foundation-style-guard uiFoundationTexture --reporter=dot

--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -29,6 +29,10 @@ on:
       - 'apps/web/src/approvals/amountAutoSum.ts'
       - 'apps/web/src/approvals/useAutoSumTotal.ts'
       - 'apps/web/src/approvals/lineDerivation.ts'
+      # G-B2-11 / G-B2-12: the 待办 list's pill re-baseline choke point + per-row 催办 state.
+      - 'apps/web/src/approvals/newTodoPill.ts'
+      - 'apps/web/src/approvals/urgeButtonState.ts'
+      - 'apps/web/src/views/approval/ApprovalCenterView.vue'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
@@ -350,4 +354,4 @@ jobs:
         # files and asserts zero static style= attributes and zero hex/rgb() literals inside
         # <style> blocks (var() references + transparent/inherit/currentColor/none allowed);
         # had no gate before this wiring.
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words approval-form-draft lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView ui-foundation-style-guard uiFoundationTexture --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words approval-form-draft lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView newTodoPill approval-urge-button-state ui-foundation-style-guard uiFoundationTexture --reporter=dot

--- a/apps/web/src/approvals/newTodoPill.ts
+++ b/apps/web/src/approvals/newTodoPill.ts
@@ -1,0 +1,56 @@
+/**
+ * G-B2-11 (approval-automation-operation-ux-benchmark §B2-11) — "新待办到达刷新 pill".
+ *
+ * The audited gap: the tab-label badge polls the server and can show a fresh unread count while
+ * the list underneath it is still the page that was loaded a while ago (badge 5 / list 3). The fix
+ * is NOT to auto-refresh the list the moment the server count changes — an unannounced reload would
+ * silently wipe out whatever rows the operator currently has checked in the 操作台 batch
+ * approve/reject multi-select (`selectedPending` in ApprovalCenterView), and the operator would have
+ * no idea why their selection vanished mid-triage. Instead we surface an explicit, dismissable pill
+ * ("N 条新待办 · 点击刷新") and only reload on the operator's own click.
+ *
+ * The one trap this module exists to avoid: comparing the server's pending `count` against the
+ * number of rows currently loaded on screen. That comparison is wrong because the list is PAGED —
+ * moving to page 2 of a 30-row pending queue would make "count (30) > rows-on-this-page (10)" true
+ * forever, permanently misreporting pagination as new arrivals. The correct comparison is against a
+ * snapshot of `count` taken at the moment the list was last (re)loaded — `pendingCountAtLoad` — so a
+ * subsequent rise in `count` above that snapshot is unambiguously new server-side arrivals, not
+ * paging or a stale local read.
+ */
+
+export type ApprovalCenterTabName = 'pending' | 'mine' | 'cc' | 'completed'
+
+export interface NewTodoPillInput {
+  /** The view's currently active tab; the pill is 待我处理-only by design (only that tab has the
+   * batch multi-select this feature protects). */
+  activeTab: ApprovalCenterTabName | string
+  /** Snapshot of the server's pending `count` taken at the last explicit list (re)load.
+   * `null` means "no load has completed yet" — must never show a pill before that. */
+  pendingCountAtLoad: number | null
+  /** The latest known server pending `count` (the total, NOT the unread badge count and NOT the
+   * number of rows currently rendered on the page). */
+  currentPendingCount: number
+}
+
+export interface NewTodoPillState {
+  visible: boolean
+  /** Always >= 0. Never negative — a count that shrank (someone else actioned a row) is simply
+   * not "new todos" and must not render as "-2 条新待办". */
+  delta: number
+}
+
+const HIDDEN: NewTodoPillState = { visible: false, delta: 0 }
+
+export function newTodoPillState({
+  activeTab,
+  pendingCountAtLoad,
+  currentPendingCount,
+}: NewTodoPillInput): NewTodoPillState {
+  if (activeTab !== 'pending') return HIDDEN
+  if (pendingCountAtLoad === null || !Number.isFinite(pendingCountAtLoad)) return HIDDEN
+  if (!Number.isFinite(currentPendingCount)) return HIDDEN
+
+  const delta = currentPendingCount - pendingCountAtLoad
+  if (delta <= 0) return HIDDEN
+  return { visible: true, delta }
+}

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -89,6 +89,22 @@
             </el-tooltip>
           </span>
         </template>
+        <!-- G-B2-11 (新待办到达刷新 pill): the badge above can go stale relative to the list below
+             it (badge 5 / list 3) once new pending items land server-side after the list was last
+             loaded. We deliberately do NOT auto-refresh the list when that happens — a silent
+             reload would clear the operator's in-progress 批量通过/批量驳回 selection with no
+             warning. Instead this pill only appears here (待我处理 only) once `newTodoPill.visible`
+             flips true, and reloads solely on the operator's own click. See
+             src/approvals/newTodoPill.ts for the count-vs-loaded-rows pitfall this avoids. -->
+        <button
+          v-if="newTodoPill.visible"
+          type="button"
+          class="approval-center__new-todo-pill"
+          data-testid="approval-new-todo-pill"
+          @click="handleNewTodoPillClick"
+        >
+          {{ newTodoPill.delta }} 条新待办 · 点击刷新
+        </button>
         <!-- Wave 2 WP3 slice 2 — bulk 全部标记已读. Disabled until the server
              reports at least one unread row for the current filter so clicking
              never issues a no-op round-trip.
@@ -463,6 +479,7 @@ import { urgeButtonState } from '../../approvals/urgeButtonState'
 import { runApprovalBatchAction, type ApprovalBatchActionResult } from '../../approvals/useApprovalBatchActions'
 import { useApprovalCountsRealtime, type ApprovalCountsUpdatedPayload } from '../../approvals/useApprovalCountsRealtime'
 import { useApprovalListFieldSummary } from '../../approvals/useApprovalListFieldSummary'
+import { newTodoPillState } from '../../approvals/newTodoPill'
 import { useFeatureFlags } from '../../stores/featureFlags'
 import { useMobileViewport } from '../../composables/useMobileViewport'
 import { useLocale } from '../../composables/useLocale'
@@ -635,7 +652,7 @@ async function dispatchBatchAndHandleResult(
   }
   clearPendingSelection()
   loadCurrentTab()
-  void refreshPendingBadgeCount()
+  void refreshPendingBadgeCount({ resnapshot: true })
 }
 
 async function runBatch(action: 'approve' | 'reject', comment: string): Promise<void> {
@@ -711,7 +728,7 @@ async function handleInlineApprove(row: UnifiedApprovalDTO): Promise<void> {
     await dispatchAction(row.id, { action: 'approve' })
     ElMessage.success('审批已通过')
     loadCurrentTab()
-    void refreshPendingBadgeCount()
+    void refreshPendingBadgeCount({ resnapshot: true })
   } catch (error) {
     ElMessage.error(error instanceof Error && error.message ? error.message : '操作失败，请重试')
   } finally {
@@ -750,7 +767,7 @@ async function submitRowReject(): Promise<void> {
     ElMessage.success('审批已驳回')
     rowRejectDialogVisible.value = false
     loadCurrentTab()
-    void refreshPendingBadgeCount()
+    void refreshPendingBadgeCount({ resnapshot: true })
   } catch (error) {
     // Mirrors B1-04's dialog-scoped inline error: keep the dialog open with the server's own
     // reason instead of a toast, so the typed comment is never lost on a retry-in-place.
@@ -796,10 +813,16 @@ function applyPendingBadgeCount(count: number, unreadCount: number): void {
   pendingTotalCount.value = Number.isFinite(count) ? count : 0
 }
 
-async function refreshPendingBadgeCount(): Promise<void> {
+// G-B2-11: `resnapshot` ties a fresh server count to "the list was just (re)loaded" — see
+// `pendingCountAtLoad` below. Only call sites that ALSO reload the pending list (or are the very
+// first load) pass this; a bare badge poll must never move the baseline the pill compares against.
+async function refreshPendingBadgeCount(options?: { resnapshot?: boolean }): Promise<void> {
   try {
     const result = await getPendingCount(sourceSystemFilter.value)
     applyPendingBadgeCount(result.count, result.unreadCount)
+    if (options?.resnapshot) {
+      pendingCountAtLoad.value = result.count
+    }
   } catch {
     // Badge is decorative — do not surface errors here; the tab itself
     // surfaces list-load failures via `store.error`.
@@ -810,12 +833,41 @@ async function refreshPendingBadgeCount(): Promise<void> {
 
 function handleRealtimeCountsUpdated(payload: ApprovalCountsUpdatedPayload): void {
   const scopedCounts = payload.countsBySourceSystem?.[sourceSystemFilter.value] ?? payload
+  // Deliberately NOT resnapshotted: a realtime push updates the live count (and can therefore
+  // surface the G-B2-11 pill below) without ever moving `pendingCountAtLoad` — the whole point of
+  // the pill is to notice this push happened while the list itself sat unrefreshed.
   applyPendingBadgeCount(scopedCounts.count, scopedCounts.unreadCount)
 }
 
 useApprovalCountsRealtime({
   onCountsUpdated: handleRealtimeCountsUpdated,
 })
+
+// G-B2-11 (新待办到达刷新 pill) — see src/approvals/newTodoPill.ts for the full design rationale.
+// `pendingCountAtLoad` is a snapshot of the server's pending `count`, taken at the moment the
+// pending list was last explicitly (re)loaded (mount / tab switch / source-system change / batch
+// action reload / the pill's own click). `null` until the very first load completes, so the pill
+// can never render before there is a baseline to compare against.
+//
+// This is intentionally compared against `pendingTotalCount` (the server's authoritative total),
+// NEVER against `store.pendingApprovals.length` (rows loaded on the current page) — the list is
+// paged, so "server total > rows on this page" would be true forever and misreport ordinary paging
+// as new arrivals.
+const pendingCountAtLoad = ref<number | null>(null)
+const newTodoPill = computed(() => newTodoPillState({
+  activeTab: activeTab.value,
+  pendingCountAtLoad: pendingCountAtLoad.value,
+  currentPendingCount: pendingTotalCount.value,
+}))
+
+// Deliberately NOT an automatic refresh: silently reloading the list out from under the operator
+// would clear whatever rows they currently have checked in the 批量通过/批量驳回 multi-select
+// (`selectedPending`) with no explanation. The pill only reloads when the operator clicks it.
+function handleNewTodoPillClick(): void {
+  clearPendingSelection()
+  loadCurrentTab()
+  void refreshPendingBadgeCount({ resnapshot: true })
+}
 
 // Wave 2 WP3 slice 2 — bulk 全部标记已读. Honours the current sourceSystem tab
 // so the button's effect matches the tooltip the user is looking at.
@@ -880,8 +932,10 @@ function handleTabChange() {
   clearPendingSelection()
   loadCurrentTab()
   // Refresh badge whenever the user re-enters the 待办 tab so recent actions
-  // reflect immediately.
-  void refreshPendingBadgeCount()
+  // reflect immediately. `resnapshot: true` also resets the G-B2-11 pill's baseline — switching
+  // INTO (or within) the tab counts as an explicit reload, so any pill from before this switch
+  // must clear rather than linger against a now-stale comparison.
+  void refreshPendingBadgeCount({ resnapshot: true })
 }
 
 function handleSearch() {
@@ -894,7 +948,9 @@ function handleSourceSystemChange() {
   currentPage.value = 1
   clearPendingSelection()
   loadCurrentTab()
-  void refreshPendingBadgeCount()
+  // resnapshot: true — the source-system switch changes what `count` even means (a different
+  // scope), so the G-B2-11 pill's baseline must reset here too.
+  void refreshPendingBadgeCount({ resnapshot: true })
 }
 
 function handlePageChange(page: number) {
@@ -946,7 +1002,9 @@ function openAttendanceApprovalQueue() {
 
 onMounted(() => {
   loadCurrentTab()
-  void refreshPendingBadgeCount()
+  // resnapshot: true — this is the very first load, so it establishes the G-B2-11 pill's initial
+  // baseline (no delta possible against itself).
+  void refreshPendingBadgeCount({ resnapshot: true })
 })
 </script>
 
@@ -995,6 +1053,26 @@ onMounted(() => {
 
 .approval-center__tab-badge {
   margin-left: 4px;
+}
+
+/* G-B2-11: 新待办到达刷新 pill — a deliberately clickable, un-missable affordance (not a passive
+   badge) since it is the ONLY way this new count ever reaches the list; there is no auto-refresh. */
+.approval-center__new-todo-pill {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 12px;
+  padding: 4px 12px;
+  border: 1px solid var(--el-color-primary-light-5);
+  border-radius: 999px;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary);
+  font-size: 13px;
+  line-height: 1.6;
+  cursor: pointer;
+}
+
+.approval-center__new-todo-pill:hover {
+  border-color: var(--el-color-primary);
 }
 
 .approval-center__tab-toolbar {

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -652,7 +652,6 @@ async function dispatchBatchAndHandleResult(
   }
   clearPendingSelection()
   loadCurrentTab()
-  void refreshPendingBadgeCount({ resnapshot: true })
 }
 
 async function runBatch(action: 'approve' | 'reject', comment: string): Promise<void> {
@@ -728,7 +727,6 @@ async function handleInlineApprove(row: UnifiedApprovalDTO): Promise<void> {
     await dispatchAction(row.id, { action: 'approve' })
     ElMessage.success('审批已通过')
     loadCurrentTab()
-    void refreshPendingBadgeCount({ resnapshot: true })
   } catch (error) {
     ElMessage.error(error instanceof Error && error.message ? error.message : '操作失败，请重试')
   } finally {
@@ -767,7 +765,6 @@ async function submitRowReject(): Promise<void> {
     ElMessage.success('审批已驳回')
     rowRejectDialogVisible.value = false
     loadCurrentTab()
-    void refreshPendingBadgeCount({ resnapshot: true })
   } catch (error) {
     // Mirrors B1-04's dialog-scoped inline error: keep the dialog open with the server's own
     // reason instead of a toast, so the typed comment is never lost on a retry-in-place.
@@ -866,7 +863,6 @@ const newTodoPill = computed(() => newTodoPillState({
 function handleNewTodoPillClick(): void {
   clearPendingSelection()
   loadCurrentTab()
-  void refreshPendingBadgeCount({ resnapshot: true })
 }
 
 // Wave 2 WP3 slice 2 — bulk 全部标记已读. Honours the current sourceSystem tab
@@ -925,17 +921,18 @@ function loadCurrentTab() {
     case 'cc': store.loadCc(query); break
     case 'completed': store.loadCompleted(query); break
   }
+  // G-B2-11: EVERY list reload re-baselines the pill, from the ONE place every reload passes
+  // through. Hanging this off individual call sites is precisely what let handleSearch() and
+  // handlePageChange() skip it — leaving a pill still urging "N 条新待办 · 点击刷新" for todos the
+  // reload had already fetched. A choke point cannot be forgotten by the next call site.
+  void refreshPendingBadgeCount({ resnapshot: true })
 }
 
 function handleTabChange() {
   currentPage.value = 1
   clearPendingSelection()
+  // loadCurrentTab() refreshes the badge and re-baselines the G-B2-11 pill (see its choke point).
   loadCurrentTab()
-  // Refresh badge whenever the user re-enters the 待办 tab so recent actions
-  // reflect immediately. `resnapshot: true` also resets the G-B2-11 pill's baseline — switching
-  // INTO (or within) the tab counts as an explicit reload, so any pill from before this switch
-  // must clear rather than linger against a now-stale comparison.
-  void refreshPendingBadgeCount({ resnapshot: true })
 }
 
 function handleSearch() {
@@ -947,10 +944,9 @@ function handleSearch() {
 function handleSourceSystemChange() {
   currentPage.value = 1
   clearPendingSelection()
+  // The source-system switch changes what `count` even means (a different scope); the reload's
+  // own re-baseline inside loadCurrentTab() handles it.
   loadCurrentTab()
-  // resnapshot: true — the source-system switch changes what `count` even means (a different
-  // scope), so the G-B2-11 pill's baseline must reset here too.
-  void refreshPendingBadgeCount({ resnapshot: true })
 }
 
 function handlePageChange(page: number) {
@@ -1001,10 +997,8 @@ function openAttendanceApprovalQueue() {
 }
 
 onMounted(() => {
+  // The first load establishes the pill's initial baseline (no delta possible against itself).
   loadCurrentTab()
-  // resnapshot: true — this is the very first load, so it establishes the G-B2-11 pill's initial
-  // baseline (no delta possible against itself).
-  void refreshPendingBadgeCount({ resnapshot: true })
 })
 </script>
 

--- a/apps/web/tests/newTodoPill.spec.ts
+++ b/apps/web/tests/newTodoPill.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * G-B2-11: pure `newTodoPillState` contract — "新待办到达刷新 pill".
+ *
+ * Deliberately does NOT mount ApprovalCenterView.vue (1100+ lines); this covers only the decision
+ * function that the view's computed wraps. See src/approvals/newTodoPill.ts for the design
+ * rationale (why comparing count-vs-loaded-rows is wrong, why no auto-refresh).
+ */
+import { describe, expect, it } from 'vitest'
+import { newTodoPillState } from '../src/approvals/newTodoPill'
+
+describe('approvals/newTodoPill', () => {
+  it('shows the pill with the correct delta when count rose since the load snapshot (pending tab)', () => {
+    expect(newTodoPillState({
+      activeTab: 'pending',
+      pendingCountAtLoad: 3,
+      currentPendingCount: 5,
+    })).toEqual({ visible: true, delta: 2 })
+  })
+
+  it('hides when count is unchanged since the snapshot (no new arrivals)', () => {
+    expect(newTodoPillState({
+      activeTab: 'pending',
+      pendingCountAtLoad: 3,
+      currentPendingCount: 3,
+    })).toEqual({ visible: false, delta: 0 })
+  })
+
+  it('hides — and never reports a negative delta — when count fell (someone else actioned a row)', () => {
+    expect(newTodoPillState({
+      activeTab: 'pending',
+      pendingCountAtLoad: 5,
+      currentPendingCount: 2,
+    })).toEqual({ visible: false, delta: 0 })
+  })
+
+  it('hides on a non-pending tab even if count rose — pill is 待我处理-only', () => {
+    for (const activeTab of ['mine', 'cc', 'completed'] as const) {
+      expect(newTodoPillState({
+        activeTab,
+        pendingCountAtLoad: 3,
+        currentPendingCount: 9,
+      })).toEqual({ visible: false, delta: 0 })
+    }
+  })
+
+  it('hides before the first load has ever completed (snapshot is null)', () => {
+    expect(newTodoPillState({
+      activeTab: 'pending',
+      pendingCountAtLoad: null,
+      currentPendingCount: 9,
+    })).toEqual({ visible: false, delta: 0 })
+  })
+
+  it('hides when the live count is not a finite number (defensive)', () => {
+    expect(newTodoPillState({
+      activeTab: 'pending',
+      pendingCountAtLoad: 3,
+      currentPendingCount: Number.NaN,
+    })).toEqual({ visible: false, delta: 0 })
+  })
+
+  it('does NOT compare against loaded-row counts — paging to a later page must never look like new arrivals', () => {
+    // Simulates: pending queue has 30 total, operator pages to page 3 (10 rows/page: only 10 rows
+    // rendered), no new server-side arrivals since the load. The snapshot IS the server total (30),
+    // not "10 rows on screen", so the delta is correctly zero regardless of page size/position.
+    expect(newTodoPillState({
+      activeTab: 'pending',
+      pendingCountAtLoad: 30,
+      currentPendingCount: 30,
+    })).toEqual({ visible: false, delta: 0 })
+  })
+
+  it('boundary: delta of exactly +1 is visible', () => {
+    expect(newTodoPillState({
+      activeTab: 'pending',
+      pendingCountAtLoad: 0,
+      currentPendingCount: 1,
+    })).toEqual({ visible: true, delta: 1 })
+  })
+})

--- a/apps/web/tests/newTodoPill.spec.ts
+++ b/apps/web/tests/newTodoPill.spec.ts
@@ -5,6 +5,8 @@
  * function that the view's computed wraps. See src/approvals/newTodoPill.ts for the design
  * rationale (why comparing count-vs-loaded-rows is wrong, why no auto-refresh).
  */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { newTodoPillState } from '../src/approvals/newTodoPill'
 
@@ -76,5 +78,30 @@ describe('approvals/newTodoPill', () => {
       pendingCountAtLoad: 0,
       currentPendingCount: 1,
     })).toEqual({ visible: true, delta: 1 })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static tripwire: the pill's re-baseline must live at the ONE place every list
+// reload passes through (`loadCurrentTab`), never at individual call sites.
+//
+// It originally sat at six call sites — and `handleSearch()` / `handlePageChange()`
+// were both missed, leaving a pill still urging "N 条新待办 · 点击刷新" for todos the
+// reload had already fetched. A choke point cannot be forgotten by the next caller.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('G-B2-11 re-baseline choke point (static tripwire)', () => {
+  const source = readFileSync(join(__dirname, '..', 'src/views/approval/ApprovalCenterView.vue'), 'utf8')
+
+  it('resnapshot is requested exactly once in the whole view', () => {
+    const occurrences = source.split('refreshPendingBadgeCount({ resnapshot: true })').length - 1
+    expect(occurrences).toBe(1)
+  })
+
+  it('that single occurrence sits inside loadCurrentTab()', () => {
+    const start = source.indexOf('function loadCurrentTab()')
+    expect(start).toBeGreaterThan(-1)
+    // end of the function = the first line that closes it at column 0 indent
+    const body = source.slice(start, source.indexOf('\n}', start) + 2)
+    expect(body).toContain('refreshPendingBadgeCount({ resnapshot: true })')
   })
 })


### PR DESCRIPTION
## 审计项 G-B2-11
> 徽标 5/列表 3 的脱节；**不自动刷新**以保护批量勾选

## 做了什么
- 列表加载那一刻给服务端 `count` 拍快照（`pendingCountAtLoad`）。之后实时通道（`useApprovalCountsRealtime`，与未读徽标同一条 wire）推来更高的 `count` → 出现 pill「N 条新待办 · 点击刷新」。
- **绝不自动刷新**：静默重载会清掉操作员正在勾选的批量选择 —— 这正是本项存在的理由。点击 pill 才重载。
- 信号取的是「快照 vs 服务端 count」，**不是**「服务端 count vs 当前页行数」—— 后者会把**翻页**误判成「有新待办」。
- count 变小（别人审掉了）→ delta ≤ 0 → 不显示 pill（不会出现「-2 条新待办」）。

## Review 中发现并修掉的真缺陷
agent 诚实地指出：`handleSearch()` / `handlePageChange()` **从不重置快照**。根因是「重置」被挂在 **6 个** `loadCurrentTab()` 调用点上，而这两个被漏掉了 —— 于是**搜索之后 pill 仍在催你「点击刷新」，可那次重载早已把新待办取回来了**。

修法不是补上这两个调用点（那只治标，下一个调用点还会漏），而是把重置搬进 **`loadCurrentTab()` 本身** —— 所有重载（挂载 / 切 tab / 搜索 / 翻页 / 批量操作 / 行内通过 / 行内驳回 / pill 自身）都必经此处。**7 处散落收敛为 1 处，下一个调用点无从遗漏。**

## 验证
- 纯函数 `newTodoPill.ts` 矩阵 8 例（上升/持平/下降不为负/非 pending tab/快照未初始化/NaN/翻页不误判/+1 边界）。
- **静态 tripwire**（沿用仓库 `ui-foundation-style-guard` 的先例）：断言 `resnapshot` 在整个视图里**恰好出现一次**，且**位于 `loadCurrentTab` 内**。**突变验证**：把它挪回调用点 → tripwire 变红。
- `vue-tsc --noEmit` 0 error；approval-center 六套 + 样式守卫 **147/147**。

## 顺手补的 CI 接线
`newTodoPill` 与 `urgeButtonState`（G-B2-12，**已合入**）此前**不在任何 workflow 里跑**。已按两点接线补进 `approval-web-guard.yml`（path 触发 + vitest filter）。
（更大的问题仍待你定夺：required 的 `test (20.x)` 只 build apps/web，从不跑其单测。）

## 诚实说明
- pill 的 delta 只能经实时通道转正（每次显式重载都会把快照对齐到当时的 count）——这正是「新待办到达」的本意。该 wiring 由读代码确认，未做挂载全视图的测试（按纪律不 mount 1100+ 行视图）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)