### PR TITLE
feat(automation): G-B2-24 — 执行模式折叠进「高级」（移出首屏）

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -18,17 +18,31 @@
         <label class="meta-rule-editor__label">{{ automationLabel('editor.name', isZh) }}</label>
         <el-input v-model="draft.name" type="text" :placeholder="automationLabel('editor.namePlaceholder', isZh)" data-field="name" />
 
-        <!-- Execution mode (A6-1 opt-in): persist a per-action WorkflowJob plane -->
-        <el-checkbox
-          class="meta-rule-editor__label"
-          data-field="executionModeToggle"
-          :model-value="draft.executionMode === 'workflow_job_v1' || requiresJobMode"
-          :disabled="requiresJobMode"
-          @change="setExecutionMode($event === true)"
-        >
-          {{ automationLabel('editor.executionModeLabel', isZh) }}
-        </el-checkbox>
-        <div class="meta-rule-editor__hint" data-field="executionModeHint">{{ requiresJobMode ? automationLabel('editor.executionModeRequiredHint', isZh) : automationLabel('editor.executionModeHint', isZh) }}</div>
+        <!-- G-B2-24: the execution-mode toggle is an ENGINE-TERM concern (persist per-action
+             WorkflowJob records) that used to sit second on the form, dominating the first screen.
+             Collapsed into an "Advanced" section so the first screen reads trigger → condition →
+             action. It auto-expands when the rule REQUIRES job mode (e.g. start_approval) so the
+             forced-on state is never hidden. The toggle keeps its data-field/behavior unchanged. -->
+        <el-collapse v-model="advancedSectionOpen" class="meta-rule-editor__advanced">
+          <el-collapse-item name="advanced" data-field="advancedSection">
+            <!-- Header via slot (not the `title` prop) so no HTML title attribute is added — the
+                 a11y guard asserts the authored surface introduces no [title] noise. -->
+            <template #title>
+              <span class="meta-rule-editor__advanced-title">{{ automationLabel('editor.advancedSection', isZh) }}</span>
+            </template>
+            <!-- Execution mode (A6-1 opt-in): persist a per-action WorkflowJob plane -->
+            <el-checkbox
+              class="meta-rule-editor__label"
+              data-field="executionModeToggle"
+              :model-value="draft.executionMode === 'workflow_job_v1' || requiresJobMode"
+              :disabled="requiresJobMode"
+              @change="setExecutionMode($event === true)"
+            >
+              {{ automationLabel('editor.executionModeLabel', isZh) }}
+            </el-checkbox>
+            <div class="meta-rule-editor__hint" data-field="executionModeHint">{{ requiresJobMode ? automationLabel('editor.executionModeRequiredHint', isZh) : automationLabel('editor.executionModeHint', isZh) }}</div>
+          </el-collapse-item>
+        </el-collapse>
 
         <!-- 1. Trigger selector -->
         <section class="meta-rule-editor__section">
@@ -1286,7 +1300,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
-import { ElButton, ElCheckbox, ElCheckboxGroup, ElDrawer, ElInput, ElMessageBox, ElOption, ElSelect } from 'element-plus'
+import { ElButton, ElCheckbox, ElCheckboxGroup, ElCollapse, ElCollapseItem, ElDrawer, ElInput, ElMessageBox, ElOption, ElSelect } from 'element-plus'
 import { useLocale } from '../../composables/useLocale'
 import type { MultitableApiClient } from '../api/client'
 import type {
@@ -2186,6 +2200,16 @@ const JOB_MODE_REQUIRING_ACTION_TYPES: AutomationActionType[] = ['wait_for_callb
 const requiresJobMode = computed(() =>
   draft.value.actions.some((a) => JOB_MODE_REQUIRING_ACTION_TYPES.includes(a.type)),
 )
+// G-B2-24: the Advanced section is collapsed by default (keeps the engine-term execution-mode
+// toggle off the first screen) but force-opens when job mode is REQUIRED, so a forced-on toggle is
+// never hidden behind a collapsed panel. Modeled as a writable computed rather than a watched ref
+// so expansion is a pure reactive dependency of requiresJobMode (no load-order/tick races): until
+// the user manually toggles it, "open" == requiresJobMode; a manual toggle then takes over.
+const advancedManualOpen = ref<string[] | null>(null)
+const advancedSectionOpen = computed<string[]>({
+  get: () => advancedManualOpen.value ?? (requiresJobMode.value ? ['advanced'] : []),
+  set: (value) => { advancedManualOpen.value = value },
+})
 const hasDeleteRecordAction = computed(() => draft.value.actions.some((a) => a.type === 'delete_record'))
 
 // A6-3-2a: empty drafts for a fresh condition_branch action.

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -97,6 +97,7 @@ export type AutomationLabelKey =
   | 'editor.executionModeLabel'
   | 'editor.executionModeHint'
   | 'editor.executionModeRequiredHint'
+  | 'editor.advancedSection'
   | 'editor.saveBlockedTitle'
   | 'trigger.title'
   | 'trigger.watchField'
@@ -361,6 +362,7 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'editor.executionModeLabel',
   'editor.executionModeHint',
   'editor.executionModeRequiredHint',
+  'editor.advancedSection',
   'editor.saveBlockedTitle',
   'trigger.title',
   'trigger.watchField',
@@ -622,6 +624,10 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'editor.moveUpTitle': { en: 'Move up', zh: '上移' },
   'editor.moveDownTitle': { en: 'Move down', zh: '下移' },
   'editor.removeActionTitle': { en: 'Remove action', zh: '移除动作' },
+  'editor.advancedSection': {
+    en: 'Advanced',
+    zh: '高级设置',
+  },
   'editor.executionModeLabel': {
     en: 'Persist a per-action run record (advanced)',
     zh: '持久化每步运行记录（高级）',

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -742,6 +742,26 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1')
   })
 
+  it('G-B2-24: the execution-mode toggle starts COLLAPSED in Advanced for a plain rule (off the first screen)', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+    // The toggle still exists (queryable), but its Advanced panel is not expanded by default.
+    expect(container.querySelector('[data-field="executionModeToggle"]')).toBeTruthy()
+    expect(container.querySelectorAll('.meta-rule-editor__advanced .el-collapse-item.is-active')).toHaveLength(0)
+  })
+
+  it('G-B2-24: Advanced AUTO-EXPANDS when the rule requires job mode, so the forced-on toggle is never hidden', async () => {
+    const rule = {
+      id: 'atr_sa_expand', sheetId: 'sheet_1', name: 'sa', triggerType: 'form.submitted',
+      triggerConfig: {}, actionType: 'start_approval',
+      actionConfig: { templateId: 'tmpl_9', formDataMapping: { amount: 'fld_2' } },
+      enabled: true, executionMode: 'workflow_job_v1',
+    } as unknown as AutomationRule
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule })
+    await flushPromises()
+    expect(container.querySelectorAll('.meta-rule-editor__advanced .el-collapse-item.is-active')).toHaveLength(1)
+  })
+
   it('force-corrects a loaded LEGACY start_approval rule (executionMode: null) to workflow_job_v1 on save', async () => {
     const saved = vi.fn()
     const rule = {


### PR DESCRIPTION
## 审计项 G-B2-24
> 首屏第二个控件是「workflow_job_v1 作业面」引擎术语；后端已 fail-close，纯展示重排零风险

## 做了什么
- 执行模式 toggle（持久化每步 WorkflowJob 记录，属**引擎术语**）原本排在表单**第二位**，首屏一上来就是 `workflow_job_v1 作业面`。折叠进「高级设置」，首屏改为**触发优先**。
- **需要作业模式时自动展开**（start_approval / wait_for_callback / condition_branch / parallel_branch）—— 强制开启且禁用的 toggle 绝不藏在收起的面板后。实现为 `requiresJobMode` 的**可写 computed**（非 watch ref），展开与否是纯响应式依赖，无加载时序竞态。toggle 的 data-field / 行为不变。
- 表头用 slot（非 `title` prop），不引入 HTML title 属性 —— a11y 守卫断言授权界面不新增 `[title]` 噪声。
- `ElCollapse` / `ElCollapseItem` 加进组件显式 element-plus import（该测试壳只渲染已 import 的 EP 组件；不加则折叠渲染成无 class 的未知元素，测试根本看不到它 —— 这是本切片最花时间的一处）。

## 验证
- 2 个新测试钉住行为（普通规则默认折叠 / 需作业模式时自动展开）。**突变验证**：去掉 `requiresJobMode` 那一支 → 自动展开用例变红。
- 完整 mount spec **117/117**；labels + style guard 合计 **215**；`vue-tsc --noEmit` 0。
- 无新 CI 接线：改的是**已 gated** 的 rule-editor + labels spec（B2-22 已把它们接进 multitable-web-guard）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
