### PR TITLE
feat(web): BA-APPLY-3 Bridge Agent post-apply auto re-probe confirmation — read-only, completes controlled-apply line (design-lock #3876, refs #3746)

### DIFF
--- a/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
+++ b/apps/web/src/components/integration/IntegrationBridgeAgentSection.vue
@@ -511,6 +511,67 @@
               </div>
             </template>
           </div>
+
+          <div class="bridge-agent__reprobe-confirm">
+            <button
+              type="button"
+              class="integration-workbench__button"
+              data-testid="bridge-agent-reprobe-toggle"
+              @click="toggleConfirm"
+            >
+              <el-icon><Refresh /></el-icon>
+              {{ confirmVisible ? bi('收起生效确认', 'Hide apply confirmation') : bi('复探测确认是否生效', 'Re-probe to confirm applied') }}
+            </button>
+
+            <template v-if="confirmVisible">
+              <p class="integration-workbench__hint">{{ bi(
+                '运维按上方清单在受控后端/脚本手工应用后，点此用只读探测复查预期的只读对象/字段是否已出现；本操作只重新读取（复用上方“刷新对象”探测），不写入任何配置、不启停 Agent、不改凭据——Agent 始终只读。请先在上方“刷新对象”并展开相关对象 schema，再看下方逐项结果。',
+                'After operations manually apply the checklist above via the controlled backend/script, click here to re-check whether the expected readonly objects/fields now appear, using a read-only probe only; this merely re-reads (reusing the “Refresh objects” probe above) — it writes no config, does not start/stop the Agent, and never touches credentials; the Agent stays read-only. Refresh objects above (and expand the relevant object schema) first, then read the per-item results below.',
+              ) }}</p>
+
+              <div
+                v-if="reProbeConfirmation.total === 0"
+                class="integration-workbench__empty"
+                data-testid="bridge-agent-reprobe-empty"
+              >
+                <strong>{{ bi(
+                  '暂无待确认项：先在上方填写至少一个对象名，生成实施清单后再复探测确认。',
+                  'Nothing to confirm yet: enter at least one object name above to build a checklist, then re-probe.',
+                ) }}</strong>
+              </div>
+              <div v-else class="bridge-agent__suggestion-output" data-testid="bridge-agent-reprobe-output">
+                <p
+                  class="bridge-agent__reprobe-overall"
+                  data-testid="bridge-agent-reprobe-status"
+                  :data-status="reProbeConfirmation.status"
+                >{{ reProbeStatusLabel(reProbeConfirmation.status) }}
+                  <span class="integration-workbench__hint">({{ reProbeConfirmation.present }}/{{ reProbeConfirmation.total }})</span>
+                </p>
+                <ul class="bridge-agent__reprobe-list">
+                  <li
+                    v-for="row in reProbeConfirmation.rows"
+                    :key="row.objectName"
+                    data-testid="bridge-agent-reprobe-object"
+                    :data-object-present="row.objectPresent ? 'yes' : 'no'"
+                  >
+                    <span class="bridge-agent__reprobe-name">{{ row.objectName }}</span>
+                    <span class="bridge-agent__reprobe-flag">{{ reProbePresenceLabel(row.objectPresent) }}</span>
+                    <ul v-if="row.fields.length > 0" class="bridge-agent__reprobe-fields">
+                      <li
+                        v-for="field in row.fields"
+                        :key="field.key"
+                        data-testid="bridge-agent-reprobe-field"
+                        :data-field-present="field.present ? 'yes' : 'no'"
+                      >
+                        <span class="bridge-agent__reprobe-name">{{ field.key }}</span>
+                        <span class="bridge-agent__reprobe-flag">{{ reProbePresenceLabel(field.present) }}</span>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </div>
+            </template>
+          </div>
         </div>
       </template>
     </el-card>
@@ -1160,6 +1221,73 @@ function downloadChecklistJson(): void {
   if (typeof URL.revokeObjectURL === 'function') {
     window.setTimeout(() => URL.revokeObjectURL(url), 0)
   }
+}
+
+// --- BA-APPLY-3 (docs/development/bridge-agent-controlled-apply-design-lock-20260708.md §7 terminal
+// state, refs #3746): "复探测确认" — the FINAL rung. After an OPERATOR has MANUALLY applied the
+// exported checklist (form-A handoff, outside this platform — a human runbook step, NOT this page),
+// this card lets the admin confirm it took effect by RE-READING the connector via the SAME read-only
+// object/schema probe the page already uses (loadObjects / toggleSchema). It performs NO apply, NO
+// config write, NO start/stop, NO credential handling, NO raw-config edit, and adds NO new fetch or
+// backend route — the Agent stays readonly:true. It reads `implementationChecklist.checklist.operations`
+// (the SAME safe-identifier-filtered operations the export emits — single source, no re-filtering) and
+// intersects each EXPECTED name with the CURRENTLY-LOADED read-only `objects` / `schemaByObject`.
+// Confirmation is DERIVED from that probed state (expected-name ∈ probed names), never hardcoded.
+// Values-free by construction: object/field-key NAMES + present/absent booleans + a coarse status only.
+interface ReProbeFieldConfirmation {
+  key: string
+  present: boolean
+}
+interface ReProbeObjectConfirmation {
+  objectName: string
+  objectPresent: boolean
+  fields: ReProbeFieldConfirmation[]
+}
+type ReProbeStatus = 'applied' | 'partial' | 'absent' | 'empty'
+const reProbeConfirmation = computed(() => {
+  const operations = implementationChecklist.value.checklist.operations
+  const probedObjectNames = new Set(objects.value.map((object) => object.name))
+  const rows: ReProbeObjectConfirmation[] = operations.map((operation) => {
+    const objectPresent = probedObjectNames.has(operation.objectName)
+    const probedFieldNames = new Set((schemaByObject.value[operation.objectName] ?? []).map((field) => field.name))
+    const fields: ReProbeFieldConfirmation[] = operation.fieldKeys.map((key) => ({
+      key,
+      // a field is confirmed only if its parent object is present AND that object's schema (re-)probe
+      // has actually surfaced the key — both facts come from the read-only probe, never assumed
+      present: objectPresent && probedFieldNames.has(key),
+    }))
+    return { objectName: operation.objectName, objectPresent, fields }
+  })
+  const checks: boolean[] = []
+  for (const row of rows) {
+    checks.push(row.objectPresent)
+    for (const field of row.fields) checks.push(field.present)
+  }
+  const total = checks.length
+  const present = checks.filter(Boolean).length
+  const status: ReProbeStatus =
+    total === 0 ? 'empty' : present === total ? 'applied' : present === 0 ? 'absent' : 'partial'
+  return { rows, total, present, status }
+})
+
+const confirmVisible = ref(false)
+function toggleConfirm(): void {
+  confirmVisible.value = !confirmVisible.value
+}
+function reProbeStatusLabel(status: ReProbeStatus): string {
+  switch (status) {
+    case 'applied':
+      return bi('已生效', 'Applied')
+    case 'partial':
+      return bi('部分生效', 'Partially applied')
+    case 'absent':
+      return bi('未生效', 'Not applied')
+    default:
+      return bi('无待确认项', 'Nothing to confirm')
+  }
+}
+function reProbePresenceLabel(present: boolean): string {
+  return present ? bi('已出现', 'Present') : bi('未出现', 'Absent')
 }
 
 watch(suggestionDrafts, () => {

--- a/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
+++ b/apps/web/tests/IntegrationBridgeAgentSection.spec.ts
@@ -1229,4 +1229,120 @@ describe('IntegrationBridgeAgentSection', () => {
       setLocale('en')
     }
   })
+
+  // --- BA-APPLY-3: post-apply auto re-probe confirmation (design-lock §7 terminal state, refs #3746).
+  // The FINAL rung. After an operator manually applies the exported checklist (form-A handoff), this
+  // card re-reads the connector via the SAME read-only object/schema probe and confirms the expected
+  // readonly objects/fields now appear. Read-only: no apply, no write, no start/stop, no credentials,
+  // no new fetch. Confirmation is DERIVED from the probe (expected-name ∈ probed names), never assumed.
+  it('BA-APPLY-3 re-probe confirm: an object present in the probe shows 已出现; a field absent from the probed schema shows 未出现; overall partial', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+    // objects auto-load (material, bom); expand material so its schema (FItemID/FNumber/FName) is probed
+    q<HTMLButtonElement>(root, 'bridge-agent-object-schema-toggle-material').click()
+    await flushUi()
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = 'material'
+    objectInput.dispatchEvent(new Event('input'))
+    const fieldsInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-fields-0')
+    fieldsInput.value = 'FItemID, ghost_field'
+    fieldsInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-reprobe-toggle').click()
+    await flushUi()
+
+    expect(q(root, 'bridge-agent-reprobe-status').getAttribute('data-status')).toBe('partial')
+    expect(q(root, 'bridge-agent-reprobe-object').getAttribute('data-object-present')).toBe('yes')
+    const fields = root.querySelectorAll('[data-testid="bridge-agent-reprobe-field"]')
+    expect(fields.length).toBe(2)
+    const present = Array.from(fields).find((f) => f.textContent?.includes('FItemID'))!
+    const absent = Array.from(fields).find((f) => f.textContent?.includes('ghost_field'))!
+    expect(present.getAttribute('data-field-present')).toBe('yes')
+    expect(absent.getAttribute('data-field-present')).toBe('no')
+  })
+
+  it('BA-APPLY-3 re-probe confirm: an expected object NOT in the probe reports 未生效 (absent) — derived from the probe, never assumed applied', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = 'ghost_object' // absent from OBJECTS_PAYLOAD (material, bom)
+    objectInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-reprobe-toggle').click()
+    await flushUi()
+
+    expect(q(root, 'bridge-agent-reprobe-status').getAttribute('data-status')).toBe('absent')
+    expect(q(root, 'bridge-agent-reprobe-object').getAttribute('data-object-present')).toBe('no')
+  })
+
+  it('BA-APPLY-3 re-probe confirm: renders object/field names + present/absent only — no probe-payload SENTINEL value leaks', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+    q<HTMLButtonElement>(root, 'bridge-agent-object-schema-toggle-material').click()
+    await flushUi()
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = 'material'
+    objectInput.dispatchEvent(new Event('input'))
+    const fieldsInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-fields-0')
+    fieldsInput.value = 'FItemID'
+    fieldsInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    q<HTMLButtonElement>(root, 'bridge-agent-reprobe-toggle').click()
+    await flushUi()
+
+    const output = q(root, 'bridge-agent-reprobe-output')
+    expect(output.textContent).toContain('material')
+    expect(output.textContent).toContain('FItemID')
+    expect(output.innerHTML).not.toContain(SENTINEL.objectExtra)
+    expect(output.innerHTML).not.toContain(SENTINEL.schemaExtra)
+  })
+
+  it('BA-APPLY-3 re-probe confirm: pure client-side read of already-probed state — issues no apply/list/write/start-stop route and the confirm card exposes no action button', async () => {
+    mockRoutes()
+    const root = mountSection([bridgeSystem()])
+    await flushUi()
+    const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+    objectInput.value = 'material'
+    objectInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    apiFetchMock.mockClear()
+    q<HTMLButtonElement>(root, 'bridge-agent-reprobe-toggle').click()
+    await flushUi()
+
+    const urls = apiFetchMock.mock.calls.map((call) => String(call[0]))
+    expect(urls.some((u) => /apply|checklist|write|start|stop|config/i.test(u))).toBe(false)
+    const output = q(root, 'bridge-agent-reprobe-output')
+    expect(output.querySelectorAll('button, input[type="button"], input[type="submit"]').length).toBe(0)
+  })
+
+  it('BA-APPLY-3 re-probe confirm: zh-CN renders Chinese apply-confirmation labels', async () => {
+    const { setLocale } = useLocale()
+    setLocale('zh-CN')
+    try {
+      mockRoutes()
+      const root = mountSection([bridgeSystem()])
+      await flushUi()
+      const objectInput = q<HTMLInputElement>(root, 'bridge-agent-suggestion-object-0')
+      objectInput.value = 'ghost_object'
+      objectInput.dispatchEvent(new Event('input'))
+      await flushUi()
+
+      const toggle = q<HTMLButtonElement>(root, 'bridge-agent-reprobe-toggle')
+      expect(toggle.textContent).toContain('复探测确认')
+      toggle.click()
+      await flushUi()
+
+      expect(q(root, 'bridge-agent-reprobe-status').textContent).toContain('未生效')
+      expect(q(root, 'bridge-agent-reprobe-object').textContent).toContain('未出现')
+    } finally {
+      setLocale('en')
+    }
+  })
 })

--- a/docs/development/bridge-agent-apply3-reprobe-dev-verification-20260708.md
+++ b/docs/development/bridge-agent-apply3-reprobe-dev-verification-20260708.md
@@ -1,0 +1,69 @@
+# BA-APPLY-3 — Bridge Agent 应用后自动复探测确认 · 开发与验证（2026-07-08）
+
+> 上位设计锁：`docs/development/bridge-agent-controlled-apply-design-lock-20260708.md`（§7 Disposition 终态表）。
+> 需求锚：#3746（保留 OPEN，最终口径已回贴）。这是 **Bridge Agent 受控 apply 线的最后一根 rung**，落地后该线终态定型。
+
+## 1. 它是什么（一句话）
+
+运维**手工**按导出的实施清单在受控后端/脚本应用变更后（form-A handoff，人类 runbook 步骤，**不经本平台**），
+管理员在 Bridge Agent 页点“复探测确认是否生效”，页面用**既有的只读对象/schema 探测**重新读取连接器，
+逐项核对**预期的只读对象/字段是否已出现**，给出 `已生效 / 部分生效 / 未生效` 的粗粒度确认。
+
+## 2. 终态阶梯（BA 受控 apply 线，本 rung 收官）
+
+```
+看得见(BA-UI-1 #3824) → 查得清(BA-UI-2 探测 #3840) → 变更建议(BA-UI-3 #3858)
+  → 可导出机读清单(BA-APPLY-1 #3894) → 后端审批门+审计+values-free 暂存(BA-APPLY-2a #3938)
+  → 运维 handoff(人工执行只读 allowlist/config 变更 = 人类把关点)
+  → 自动复探测确认(BA-APPLY-3 本 PR) ✅ 终态
+```
+
+**Agent 恒 `readonly:true`。** 全线无任何环节让本平台或页面向 Agent / 客户机器写入配置。
+BA-APPLY-2b（给 Agent 加 config-write 端点）= **WONTFIX by design**（安全模型级决定，非缺功能；见 disposition #3936）。
+
+## 3. 契约（confirm-card）
+
+输入（全部来自已在页面上的只读状态，**零新 fetch**）：
+- `implementationChecklist.checklist.operations` —— 与“导出实施清单”**同一份**经 safe-identifier 过滤的 operations（单一来源，不重复过滤）。每项 `{ op, objectName, fieldKeys }`。
+- `objects` —— 挂载时自动加载的只读对象列表（复用既有 `loadObjects` 探测）。
+- `schemaByObject` —— 展开对象时按需加载的只读字段列表（复用既有 `toggleSchema` 探测）。
+
+派生（`reProbeConfirmation` computed）：
+- 每个 operation 的 `objectPresent = 已探测对象名集合.has(objectName)`（**派生自探测，非假定**）。
+- 每个字段 `present = objectPresent && 已探测字段名集合.has(key)`（字段只在其父对象在场**且**该对象 schema 复探已出该键时才确认）。
+- 粗状态：`total===0 → empty`；`全present → applied`；`全absent → absent`；`否则 partial`。
+
+渲染（**values-free**）：只输出**对象名 / 字段键名 + 已出现/未出现 布尔 + 粗状态 + present/total 计数**。
+永不渲染业务行值 / host / 凭据 / 原始 config。
+
+## 4. 硬锁与证明
+
+| 锁 | 手段 | 结果 |
+|---|---|---|
+| **只读 / 零写**（无 apply、无 config write、无 start/stop、无凭据、无 raw-config 改、无新 fetch/route） | 结构性 grep 全 diff 的 `apps/**` SOURCE 面无 `apiFetch`/`POST`/`fetch(`/`.ps1`/`Set-Content`/`apply`/`start`/`stop`/`reload` 写原语（命中全在测试代码）；Test D 断言 toggle 复探测**不发任何路由**且 confirm 卡无 action 按钮 | ✅ 零写 |
+| **Confirm 派生自探测，非硬编码** | M1：`objectPresent = probedObjectNames.has(...)` → `true` | ✅ KILLED（2 failed：ghost_object 应 absent、zh 未生效） |
+| 同上（字段层） | M2：`present: objectPresent && probedFieldNames.has(key)` → `true` | ✅ KILLED（1 failed：ghost_field 应 未出现） |
+| **Values-free** | Test C：SENTINEL（objectExtra/schemaExtra 敌意键）注入探测 payload → confirm 输出 `innerHTML` 不含任一 SENTINEL | ✅ 无泄漏 |
+| **Consumer-面 非 browse-面**（owner 2026-07-08） | 本 PR **不新增** list/search/browse 路由或通用清单画廊；复探测只消费页面既有只读对象/schema 状态 + 单一份 operations | ✅ 无扩面 |
+| kill-then-green sanity | M1/M2 restore 后全绿 | ✅ 45 passed |
+
+## 5. 测试（+5，共 45 全绿；vue-tsc 0 error）
+
+`apps/web/tests/IntegrationBridgeAgentSection.spec.ts`（扩展既有 spec，**无新文件** → 无 CI 过滤/yml 改动）：
+1. 对象在探测中 → `已出现`；字段不在探测 schema → `未出现`；整体 `partial`，逐项 flag 正确。
+2. 预期对象**不在**探测 → `未生效`（absent，派生非假定）。
+3. SENTINEL 无泄漏（只名 + 布尔）。
+4. toggle 复探测**零路由** + confirm 卡零 action 按钮。
+5. zh-CN 中文标签（复探测确认 / 未生效 / 未出现）。
+
+## 6. 边界（本 rung 不做）
+
+不做：任何写路径 / apply 端点 / config 直改 / start-stop / 凭据处理 / 新 fetch 或后端 route /
+list-browse 面 / 自动标记 checklist 为已应用（那是运维手工步骤或独立关注点）/ 递归。
+2b（Agent config-write 端点）不复活，除非 owner 未来显式重新 ratify Agent 安全模型。
+
+## 7. 收官声明
+
+BA-APPLY-3 落地后，Bridge Agent 受控 apply 线**终态定型**：页面具备只读诊断、values-free 探测、变更建议、
+可导出机读清单、后端审批暂存/审计、运维 handoff、自动复探测确认；**Agent 仍 readonly**。闭环靠“系统自动复确认生效”，
+低频高后果的 allowlist/config 变更**刻意保留运维手工把关点**（不是缺功能）。


### PR DESCRIPTION
## BA-APPLY-3 — 应用后自动复探测确认（BA 受控 apply 线**最后一根 rung**）

上位锁 `docs/development/bridge-agent-controlled-apply-design-lock-20260708.md` §7 终态；需求锚 #3746。

### 它做什么
运维**手工**按导出清单在受控后端应用变更后（form-A handoff，人类 runbook，**不经本平台**），管理员点“复探测确认是否生效”，页面用**既有只读对象/schema 探测**重读连接器，逐项核对预期只读对象/字段是否已出现 → `已生效/部分/未生效`。

### 硬锁（全部证过）
- **只读/零写**：无 apply、无 config write、无 start/stop、无凭据、无 raw-config 改、无新 fetch/route。结构性 grep `apps/**` SOURCE 面零写原语；Test D 断言 toggle **零路由** + confirm 卡零 action 按钮。**Agent 恒 readonly:true。**
- **Confirm 派生自探测非硬编码**：M1（objectPresent→true）KILLED；M2（field present→true）KILLED。
- **Values-free**：Test C SENTINEL 注入探测 payload → confirm 输出无泄漏（只名+布尔+粗状态）。
- **Consumer-面非 browse-面**（owner 2026-07-08）：**不新增** list/browse 路由；只消费页面既有只读状态 + 单一份 operations。

### 测试
+5（共 **45 全绿**，vue-tsc 0 error）；扩展既有 `IntegrationBridgeAgentSection.spec.ts`，**无新文件** → 无 yml/过滤改动。

### 终态
落地后 BA 受控 apply 线定型：只读诊断 → values-free 探测 → 变更建议 → 机读清单导出 → 后端审批暂存/审计 → 运维 handoff（人类把关）→ **自动复探测确认**。2b（Agent config-write）= WONTFIX by design（#3936），不复活。

验证 MD：`docs/development/bridge-agent-apply3-reprobe-dev-verification-20260708.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)