### PR TITLE
feat(automation): G-B2-25 — 动作步骤折叠卡片 + 句式摘要

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -29,6 +29,10 @@ on:
       - 'apps/web/src/multitable/automationSaveBlockReasons.ts'
       - 'apps/web/src/multitable/components/MetaAutomationRuleEditor.vue'
       - 'apps/web/tests/automation-save-block-reasons.spec.ts'
+      # G-B2-25: the per-action collapse-card one-line summary (its matrix spec is the only thing
+      # pinning "honest placeholder, never fabricated" behavior across every action type).
+      - 'apps/web/src/multitable/automationActionSummary.ts'
+      - 'apps/web/tests/automation-action-summary.spec.ts'
       - 'apps/web/src/multitable/utils/field-config.ts'
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
@@ -115,6 +119,10 @@ on:
       - 'apps/web/src/multitable/utils/personal-config-write.ts'
       - 'apps/web/tests/multitable-reorder-view-fields.spec.ts'
       - 'apps/web/tests/multitable-grid-personal-additive-write.spec.ts'
+      # G-B2-25: the per-action collapse-card one-line summary (its matrix spec is the only thing
+      # pinning "honest placeholder, never fabricated" behavior across every action type).
+      - 'apps/web/src/multitable/automationActionSummary.ts'
+      - 'apps/web/tests/automation-action-summary.spec.ts'
       - 'apps/web/src/multitable/utils/field-config.ts'
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
@@ -249,4 +257,4 @@ jobs:
         # UF-3: status-color convergence — statusTag (StatusTag.vue + statusDomains.ts unit/mount
         # coverage), AutomationExecutionsView + parallelBranchRunsView (automationRun domain status
         # badges, run + step level, including the parallel-branch readability regression).
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-reorder-view-fields multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting statusTag AutomationExecutionsView parallelBranchRunsView automation-save-block-reasons multitable-automation-rule-editor --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-reorder-view-fields multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting statusTag AutomationExecutionsView parallelBranchRunsView automation-save-block-reasons automation-action-summary multitable-automation-rule-editor --reporter=dot

--- a/apps/web/src/multitable/automationActionSummary.ts
+++ b/apps/web/src/multitable/automationActionSummary.ts
@@ -1,0 +1,262 @@
+// G-B2-25 — rule-editor per-action one-line summary (docs/research/approval-automation-operation-
+// ux-benchmark-20260704.md, B2-25: "3 动作 ≈700 行控件长墙；渐进披露是关键").
+//
+// MetaSheet principle: progressive disclosure. Three fully-authored actions in the rule editor
+// render ~700 lines of controls — a wall that hides the one thing an author wants at a glance:
+// "what does this step actually do". This module owns ONLY that one sentence. Given a plain
+// snapshot of an action's config (no Vue reactivity, no component state, no live field/template
+// lookups), it returns a short, human-readable description.
+//
+// Honesty rule: a missing or unfilled field renders an explicit placeholder ("(not configured)",
+// "(no field selected)", …) — this module NEVER guesses or fabricates a value that wasn't
+// authored. The snapshot is assembled in MetaAutomationRuleEditor.vue (which already has the
+// field-name / approval-template-name lookups this needs) and handed in pre-resolved, mirroring
+// the automationSaveBlockReasons.ts precedent: aggregation/formatting of a UI sentence lives in
+// its own pure, unit-testable module; the live lookups that produce the snapshot stay in the
+// component.
+//
+// Scope note: this is a display-layer summary, NOT a save-gate. A "configured enough to render a
+// meaningful sentence" action can still be missing something automationSaveBlockReasons.ts would
+// block Save on (e.g. a group-message action with a destination but no body template) — that is
+// intentional; the two modules answer different questions ("what would this do" vs "why can't I
+// save").
+
+import type { AutomationActionType } from './types'
+import { automationActionTypeLabel } from './utils/meta-automation-labels'
+
+export interface ActionSummaryFieldUpdate {
+  /** Resolved field display name; '' when the pair has no field chosen yet. */
+  fieldLabel: string
+  /** Authored value text; '' when left blank. */
+  value: string
+}
+
+export interface ActionSummaryUpdateRecord {
+  fieldUpdates: ActionSummaryFieldUpdate[]
+}
+
+export interface ActionSummaryCreateRecord {
+  targetSheetId: string
+  fieldValueCount: number
+}
+
+export interface ActionSummaryWebhook {
+  url: string
+  method: string
+}
+
+export interface ActionSummaryNotification {
+  userId: string
+  message: string
+}
+
+export interface ActionSummaryStartApproval {
+  /** Resolved template name, falling back to the raw template id; '' when nothing is chosen. */
+  templateLabel: string
+  mappingCount: number
+}
+
+export interface ActionSummaryEmail {
+  recipientCount: number
+  subjectTemplate: string
+}
+
+export interface ActionSummaryDingTalkGroupMessage {
+  /** Explicit group destinations + record-field destination paths — a total reach COUNT, not a claim about which groups. */
+  destinationCount: number
+  titleTemplate: string
+}
+
+export interface ActionSummaryDingTalkPersonMessage {
+  /** Users + member groups + recipient field paths + member-group field paths, summed. */
+  recipientCount: number
+  titleTemplate: string
+}
+
+export interface ActionSummaryLockRecord {
+  locked: boolean
+}
+
+export interface ActionSummaryDeleteRecord {
+  acknowledged: boolean
+}
+
+export interface ActionSummaryConditionBranch {
+  branchCount: number
+  hasDefaultBranch: boolean
+}
+
+export interface ActionSummaryParallelBranch {
+  branchCount: number
+}
+
+export interface ActionSummarySnapshot {
+  type: AutomationActionType
+  updateRecord?: ActionSummaryUpdateRecord
+  createRecord?: ActionSummaryCreateRecord
+  webhook?: ActionSummaryWebhook
+  notification?: ActionSummaryNotification
+  startApproval?: ActionSummaryStartApproval
+  email?: ActionSummaryEmail
+  dingTalkGroupMessage?: ActionSummaryDingTalkGroupMessage
+  dingTalkPersonMessage?: ActionSummaryDingTalkPersonMessage
+  lockRecord?: ActionSummaryLockRecord
+  deleteRecord?: ActionSummaryDeleteRecord
+  conditionBranch?: ActionSummaryConditionBranch
+  parallelBranch?: ActionSummaryParallelBranch
+}
+
+function pick(isZh: boolean, zh: string, en: string): string {
+  return isZh ? zh : en
+}
+
+function sep(isZh: boolean): string {
+  return isZh ? '：' : ': '
+}
+
+function notConfigured(isZh: boolean): string {
+  return pick(isZh, '（未配置）', ' (not configured)')
+}
+
+function noField(isZh: boolean): string {
+  return pick(isZh, '(未选字段)', '(no field selected)')
+}
+
+function noValue(isZh: boolean): string {
+  return pick(isZh, '(未填值)', '(empty value)')
+}
+
+function plural(count: number, singular: string, pluralWord: string): string {
+  return count === 1 ? singular : pluralWord
+}
+
+/** Keeps the summary a genuine ONE-LINER — long template/value text is truncated, never wrapped. */
+function truncate(text: string, max = 32): string {
+  const trimmed = text.trim()
+  if (trimmed.length <= max) return trimmed
+  return `${trimmed.slice(0, Math.max(0, max - 1))}…`
+}
+
+export function summarizeAutomationAction(snapshot: ActionSummarySnapshot, isZh: boolean): string {
+  const label = automationActionTypeLabel(snapshot.type, isZh)
+
+  switch (snapshot.type) {
+    case 'update_record': {
+      const pairs = snapshot.updateRecord?.fieldUpdates ?? []
+      if (pairs.length === 0) return `${label}${notConfigured(isZh)}`
+      const first = pairs[0]
+      const fieldText = first.fieldLabel.trim() || noField(isZh)
+      const valueText = first.value.trim() ? truncate(first.value) : noValue(isZh)
+      const base = `${label}${sep(isZh)}${fieldText} ← ${valueText}`
+      if (pairs.length === 1) return base
+      const extra = pairs.length - 1
+      return pick(isZh, `${base} 等 ${pairs.length} 项`, `${base} and ${extra} more`)
+    }
+
+    case 'create_record': {
+      const c = snapshot.createRecord
+      const sheet = c?.targetSheetId.trim()
+      if (!sheet) return `${label}${notConfigured(isZh)}`
+      const count = c?.fieldValueCount ?? 0
+      const countText = count > 0
+        ? pick(isZh, `，${count} 个字段值`, `, ${count} field ${plural(count, 'value', 'values')}`)
+        : pick(isZh, '（未填字段值）', ' (no field values)')
+      return `${label}${sep(isZh)}${pick(isZh, '目标表', 'target sheet')} ${sheet}${countText}`
+    }
+
+    case 'send_webhook': {
+      const w = snapshot.webhook
+      const url = w?.url.trim()
+      if (!url) return `${label}${notConfigured(isZh)}`
+      const method = w?.method.trim() || 'POST'
+      return `${label}${sep(isZh)}${method} ${truncate(url)}`
+    }
+
+    case 'send_notification': {
+      const n = snapshot.notification
+      const userId = n?.userId.trim()
+      if (!userId) return `${label}${notConfigured(isZh)}`
+      const msgText = n?.message.trim() ? truncate(n.message) : pick(isZh, '(未填写内容)', '(no message)')
+      return pick(isZh, `发送通知给 ${userId}：${msgText}`, `Send notification to ${userId}: ${msgText}`)
+    }
+
+    case 'start_approval': {
+      const s = snapshot.startApproval
+      const templateText = s?.templateLabel.trim()
+      if (!templateText) return `${label}${notConfigured(isZh)}`
+      const mappingCount = s?.mappingCount ?? 0
+      const mappingText = mappingCount > 0
+        ? pick(isZh, `，${mappingCount} 项字段映射`, `, ${mappingCount} field ${plural(mappingCount, 'mapping', 'mappings')}`)
+        : ''
+      return `${label}${sep(isZh)}${pick(isZh, '模板', 'template')} ${truncate(templateText)}${mappingText}`
+    }
+
+    case 'send_email': {
+      const e = snapshot.email
+      const count = e?.recipientCount ?? 0
+      if (count === 0) return `${label}${notConfigured(isZh)}`
+      const base = pick(isZh, `发送邮件给 ${count} 人`, `Send email to ${count} ${plural(count, 'recipient', 'recipients')}`)
+      const subjectText = e?.subjectTemplate.trim() ? truncate(e.subjectTemplate) : pick(isZh, '(未填写主题)', '(no subject)')
+      return `${base}${sep(isZh)}${subjectText}`
+    }
+
+    case 'send_dingtalk_group_message': {
+      const g = snapshot.dingTalkGroupMessage
+      const count = g?.destinationCount ?? 0
+      if (count === 0) return `${label}${notConfigured(isZh)}`
+      const base = pick(isZh, `发送群消息给 ${count} 个群`, `Send group message to ${count} ${plural(count, 'group', 'groups')}`)
+      const titleText = g?.titleTemplate.trim() ? truncate(g.titleTemplate) : pick(isZh, '(未填写标题)', '(no title)')
+      return `${base}${sep(isZh)}${titleText}`
+    }
+
+    case 'send_dingtalk_person_message': {
+      const p = snapshot.dingTalkPersonMessage
+      const count = p?.recipientCount ?? 0
+      if (count === 0) return `${label}${notConfigured(isZh)}`
+      const base = pick(isZh, `发送个人消息给 ${count} 人`, `Send person message to ${count} ${plural(count, 'recipient', 'recipients')}`)
+      const titleText = p?.titleTemplate.trim() ? truncate(p.titleTemplate) : pick(isZh, '(未填写标题)', '(no title)')
+      return `${base}${sep(isZh)}${titleText}`
+    }
+
+    case 'send_dingtalk_approval_card': {
+      // Zero-config action: the recipient is fixed from the approval-task event (never
+      // author-supplied), so there is nothing authored to summarize beyond that fact.
+      return `${label}${sep(isZh)}${pick(isZh, '收件人固定（来自待办事件）', 'fixed recipient (from the pending-task event)')}`
+    }
+
+    case 'lock_record': {
+      const locked = snapshot.lockRecord?.locked === true
+      return pick(isZh, locked ? '锁定记录' : '解锁记录', locked ? 'Lock record' : 'Unlock record')
+    }
+
+    case 'delete_record': {
+      const acknowledged = snapshot.deleteRecord?.acknowledged === true
+      return acknowledged ? label : `${label}${pick(isZh, '（未确认）', ' (not confirmed)')}`
+    }
+
+    case 'wait_for_callback': {
+      // Zero-param suspend point by design (A6-2) — the type label is already the full story.
+      return label
+    }
+
+    case 'condition_branch': {
+      const cb = snapshot.conditionBranch
+      const count = cb?.branchCount ?? 0
+      if (count === 0) return `${label}${notConfigured(isZh)}`
+      const base = `${label}${sep(isZh)}${count} ${pick(isZh, '个分支', plural(count, 'branch', 'branches'))}`
+      return cb?.hasDefaultBranch ? `${base}${pick(isZh, ' + 默认分支', ' + default branch')}` : base
+    }
+
+    case 'parallel_branch': {
+      const pb = snapshot.parallelBranch
+      const count = pb?.branchCount ?? 0
+      if (count === 0) return `${label}${notConfigured(isZh)}`
+      return `${label}${sep(isZh)}${count} ${pick(isZh, '路并行', plural(count, 'parallel branch', 'parallel branches'))}`
+    }
+
+    default:
+      // Legacy aliases ('notify' / 'update_field') and any future/unknown action type: the type
+      // label is the only thing we can say honestly without a dedicated snapshot shape.
+      return label
+  }
+}

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -362,6 +362,25 @@
               </div>
             </div>
 
+            <!-- G-B2-25: the config below (update_record .. parallel_branch, ~700 lines across 3
+                 actions per the operation-UX benchmark) is wrapped in a collapse so an author sees
+                 a one-line summary instead of a control wall. Only the config collapses — the
+                 header above (type select / reorder / remove) stays outside it and always visible.
+                 el-collapse-item keeps its content in the DOM when collapsed (v-show, not v-if —
+                 same as the G-B2-24 Advanced section), so every data-field selector below still
+                 resolves and every existing assertion in multitable-automation-rule-editor.spec.ts
+                 keeps working unchanged. See isActionExpanded()/setActionExpanded() for the default
+                 policy (persisted vs. freshly-added/type-changed actions). -->
+            <el-collapse
+              :model-value="isActionExpanded(action) ? ['config'] : []"
+              class="meta-rule-editor__action-collapse"
+              @update:model-value="(value) => setActionExpanded(action, Array.isArray(value) ? value.includes('config') : value === 'config')"
+            >
+              <el-collapse-item name="config" data-field="actionConfigSection">
+                <template #title>
+                  <span class="meta-rule-editor__action-summary" data-field="actionSummary">{{ actionSummaries[idx] }}</span>
+                </template>
+
             <!-- update_record config -->
             <div v-if="action.type === 'update_record'" class="meta-rule-editor__action-config">
               <div v-for="(pair, pidx) in (action.config.fieldUpdates as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
@@ -1228,6 +1247,8 @@
                 <div v-if="parallelBranchActionError" class="meta-rule-editor__error" data-field="parallel-branch-action-error">{{ parallelBranchActionError }}</div>
               </template>
             </div>
+              </el-collapse-item>
+            </el-collapse>
           </div>
           <el-button
             v-if="draft.actions.length < 3"
@@ -1299,7 +1320,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onBeforeUnmount, nextTick } from 'vue'
 import { ElButton, ElCheckbox, ElCheckboxGroup, ElCollapse, ElCollapseItem, ElDrawer, ElInput, ElMessageBox, ElOption, ElSelect } from 'element-plus'
 import { useLocale } from '../../composables/useLocale'
 import type { MultitableApiClient } from '../api/client'
@@ -1378,6 +1399,10 @@ import {
   type SaveBlockActionSnapshot,
   type SaveBlockReason,
 } from '../automationSaveBlockReasons'
+import {
+  summarizeAutomationAction,
+  type ActionSummarySnapshot,
+} from '../automationActionSummary'
 
 interface FieldPair {
   fieldId: string
@@ -2546,6 +2571,128 @@ const saveBlockActionSnapshots = computed<SaveBlockActionSnapshot[]>(() => {
   })
 })
 
+// G-B2-25: resolves a field id authored in an action's config to its display name, for the
+// one-line summary only (never used for save/validation — buildPayload keeps working off raw
+// fieldIds). '' input or an id no longer present in `fields` falls back to the raw id itself, so
+// the summary still shows SOMETHING real instead of silently blanking a valid reference.
+function fieldLabelById(fieldId: unknown): string {
+  const trimmed = typeof fieldId === 'string' ? fieldId.trim() : ''
+  if (!trimmed) return ''
+  return props.fields.find((f) => f.id === trimmed)?.name ?? trimmed
+}
+
+function countAuthoredFieldPairs(pairs: unknown): number {
+  if (!Array.isArray(pairs)) return 0
+  return pairs.filter((pair) => isPlainRecord(pair) && typeof pair.fieldId === 'string' && pair.fieldId.trim()).length
+}
+
+// G-B2-25: builds the plain, Vue-free snapshot automationActionSummary.ts turns into a sentence.
+// Only the field/approval-template NAME lookups happen here (this component already has them);
+// everything else is a pass-through of the same config/parse-helper values saveBlockActionSnapshots
+// uses above, so the summary and the save-block reasons can never silently disagree about counts.
+function buildActionSummarySnapshot(action: DraftAction): ActionSummarySnapshot {
+  const snapshot: ActionSummarySnapshot = { type: action.type }
+  if (action.type === 'update_record') {
+    const pairs = (action.config.fieldUpdates as FieldPair[] | undefined) ?? []
+    snapshot.updateRecord = {
+      fieldUpdates: pairs.map((pair) => ({
+        fieldLabel: fieldLabelById(pair.fieldId),
+        value: typeof pair.value === 'string' ? pair.value : '',
+      })),
+    }
+  } else if (action.type === 'create_record') {
+    snapshot.createRecord = {
+      targetSheetId: typeof action.config.targetSheetId === 'string' ? action.config.targetSheetId : '',
+      fieldValueCount: countAuthoredFieldPairs(action.config.fieldValues),
+    }
+  } else if (action.type === 'send_webhook') {
+    snapshot.webhook = {
+      url: typeof action.config.url === 'string' ? action.config.url : '',
+      method: typeof action.config.method === 'string' ? action.config.method : '',
+    }
+  } else if (action.type === 'send_notification') {
+    snapshot.notification = {
+      userId: typeof action.config.userId === 'string' ? action.config.userId : '',
+      message: typeof action.config.message === 'string' ? action.config.message : '',
+    }
+  } else if (action.type === 'start_approval') {
+    const templateId = typeof action.config.templateId === 'string' ? action.config.templateId.trim() : ''
+    const templateName = approvalTemplates.value.find((t) => t.id === templateId)?.name
+    snapshot.startApproval = {
+      templateLabel: templateName || templateId,
+      mappingCount: countAuthoredFieldPairs(action.config.formDataMappingPairs),
+    }
+  } else if (action.type === 'send_email') {
+    snapshot.email = {
+      recipientCount: parseEmailRecipientsText(action.config.recipientsText).length,
+      subjectTemplate: typeof action.config.subjectTemplate === 'string' ? action.config.subjectTemplate : '',
+    }
+  } else if (action.type === 'send_dingtalk_group_message') {
+    const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
+    const destinationFieldPaths = parseRecipientFieldPathsText(action.config.destinationFieldPath)
+    snapshot.dingTalkGroupMessage = {
+      destinationCount: destinationIds.length + destinationFieldPaths.length,
+      titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate : '',
+    }
+  } else if (action.type === 'send_dingtalk_person_message') {
+    const userIds = parseUserIdsText(action.config.userIdsText)
+    const memberGroupIds = parseMemberGroupIdsText(action.config.memberGroupIdsText)
+    const recipientFieldPaths = parseRecipientFieldPathsText(action.config.recipientFieldPath)
+    const memberGroupRecipientFieldPaths = parseRecipientFieldPathsText(action.config.memberGroupRecipientFieldPath)
+    snapshot.dingTalkPersonMessage = {
+      recipientCount: userIds.length + memberGroupIds.length + recipientFieldPaths.length + memberGroupRecipientFieldPaths.length,
+      titleTemplate: typeof action.config.titleTemplate === 'string' ? action.config.titleTemplate : '',
+    }
+  } else if (action.type === 'lock_record') {
+    snapshot.lockRecord = { locked: action.config.locked === true }
+  } else if (action.type === 'delete_record') {
+    snapshot.deleteRecord = { acknowledged: isDeleteRecordAcknowledged(action) }
+  } else if (action.type === 'condition_branch') {
+    snapshot.conditionBranch = {
+      branchCount: (action.config.branches as BranchDraft[] | undefined)?.length ?? 0,
+      hasDefaultBranch: !!action.config.defaultBranch,
+    }
+  } else if (action.type === 'parallel_branch') {
+    snapshot.parallelBranch = {
+      branchCount: (action.config.parallelBranches as ParallelBranchDraft[] | undefined)?.length ?? 0,
+    }
+  }
+  return snapshot
+}
+
+const actionSummaries = computed<string[]>(() =>
+  draft.value.actions.map((action) => summarizeAutomationAction(buildActionSummarySnapshot(action), isZh.value)),
+)
+
+// G-B2-25: per-action collapse state. DEFAULT policy: an action loaded from an already-saved rule
+// (action.persisted === true) starts COLLAPSED behind its one-line summary; a brand-new action
+// (the starter action in a fresh rule, or one pushed by addAction()) starts EXPANDED so its config
+// is visible immediately. onDraftActionTypeChange() already flips `persisted` back to false on a
+// type change (pre-existing, used for the delete-record-ack reset) — reused here as-is, so
+// switching an existing action's type also re-expands it (the old config is gone; the author needs
+// to see the new one) with zero extra bookkeeping. A manual toggle always overrides this default
+// for THAT action from then on, mirroring the advancedSectionOpen precedent (G-B2-24): once the
+// author has interacted with a card's collapse state directly, the heuristic stops fighting them.
+const actionManualExpandOverrides = ref<Record<string, boolean>>({})
+
+function isActionExpanded(action: DraftAction): boolean {
+  const override = actionManualExpandOverrides.value[action.draftId]
+  if (override === true) return true
+  if (override === false) return false
+  return action.persisted !== true
+}
+
+function setActionExpanded(action: DraftAction, expanded: boolean): void {
+  actionManualExpandOverrides.value = { ...actionManualExpandOverrides.value, [action.draftId]: expanded }
+}
+
+function clearActionExpandOverride(draftId: string): void {
+  if (actionManualExpandOverrides.value[draftId] === undefined) return
+  const next = { ...actionManualExpandOverrides.value }
+  delete next[draftId]
+  actionManualExpandOverrides.value = next
+}
+
 // G-B2-22: locates the first entry collectConditionEditorEntries would flag as incomplete, in the
 // same depth-first order areConditionsComplete's recursive `.every()` short-circuits on — so this
 // always names the same condition/group the boolean check would have failed on first.
@@ -2595,8 +2742,24 @@ const canSave = computed(() => saveBlockReasons.value.length === 0)
 // G-B2-22: click-to-scroll for a save-block reason. Scoped to this drawer's own body so it can
 // never jump to a same-named element in some other open surface. A reason without an anchor (see
 // automationSaveBlockReasons.ts) is a no-op here rather than a guess.
+//
+// G-B2-25 addendum: an action-scoped anchor (`[data-action-index="N"] ...`) can now live inside a
+// COLLAPSED action card. The element is still in the DOM (el-collapse-item keeps content mounted),
+// but scrollIntoView is a no-op on a display:none subtree — so a collapsed card would silently
+// swallow the click. Expand that action first (never re-collapse it automatically afterward — see
+// isActionExpanded/setActionExpanded) and scroll on the next tick once it has re-rendered.
 function scrollToSaveBlockAnchor(anchor?: string): void {
   if (!anchor) return
+  const actionIndexMatch = anchor.match(/data-action-index="(\d+)"/)
+  const action = actionIndexMatch ? draft.value.actions[Number(actionIndexMatch[1])] : undefined
+  if (action && !isActionExpanded(action)) {
+    setActionExpanded(action, true)
+    void nextTick().then(() => {
+      const target = editorBodyRef.value?.querySelector(anchor)
+      if (target instanceof HTMLElement) target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    })
+    return
+  }
   const target = editorBodyRef.value?.querySelector(anchor)
   if (target instanceof HTMLElement) target.scrollIntoView({ behavior: 'smooth', block: 'center' })
 }
@@ -3216,6 +3379,10 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
 function onDraftActionTypeChange(action: DraftAction) {
   action.config = defaultConfigForActionType(action.type)
   action.persisted = false
+  // G-B2-25: a type change clears any manual collapse override so isActionExpanded() falls back
+  // to its persisted-based default — which just went false, so the card re-expands to show the
+  // (now empty) config for the newly-picked type instead of staying collapsed on stale text.
+  clearActionExpandOverride(action.draftId)
   if (action.type === 'delete_record') {
     setDeleteRecordAcknowledged(action, false)
   } else if (deleteRecordAcknowledgements.value[action.draftId] !== undefined) {
@@ -3228,6 +3395,7 @@ function onDraftActionTypeChange(action: DraftAction) {
 
 function removeAction(idx: number) {
   const [removed] = draft.value.actions.splice(idx, 1)
+  if (removed?.draftId) clearActionExpandOverride(removed.draftId)
   if (removed?.draftId && deleteRecordAcknowledgements.value[removed.draftId] !== undefined) {
     const next = { ...deleteRecordAcknowledgements.value }
     delete next[removed.draftId]
@@ -3714,6 +3882,14 @@ async function onTestRun(): Promise<void> {
   flex-direction: column;
   gap: 6px;
   padding-left: 20px;
+}
+
+/* G-B2-25: progressive disclosure wrapper around one action's config. No border/background
+   overrides — this reuses el-collapse's own default chrome (same as .meta-rule-editor__advanced
+   above), it just needs its title text styled as a muted one-line summary, not a section title. */
+.meta-rule-editor__action-summary {
+  color: var(--ms-text-2);
+  font-size: 13px;
 }
 
 .meta-rule-editor__preset-row {

--- a/apps/web/tests/automation-action-summary.spec.ts
+++ b/apps/web/tests/automation-action-summary.spec.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  summarizeAutomationAction,
+  type ActionSummarySnapshot,
+} from '../src/multitable/automationActionSummary'
+
+describe('automationActionSummary (G-B2-25)', () => {
+  describe('update_record', () => {
+    it('is honest about zero configured field updates', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'update_record', updateRecord: { fieldUpdates: [] } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Update record (not configured)')
+      expect(summarizeAutomationAction(snapshot, true)).toBe('更新记录（未配置）')
+    })
+
+    it('renders a single fully-authored field update', () => {
+      const snapshot: ActionSummarySnapshot = {
+        type: 'update_record',
+        updateRecord: { fieldUpdates: [{ fieldLabel: 'Status', value: 'Done' }] },
+      }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Update record: Status ← Done')
+      expect(summarizeAutomationAction(snapshot, true)).toBe('更新记录：Status ← Done')
+    })
+
+    it('placeholders a missing field and a missing value separately (never fabricates)', () => {
+      const missingField: ActionSummarySnapshot = {
+        type: 'update_record',
+        updateRecord: { fieldUpdates: [{ fieldLabel: '', value: 'Done' }] },
+      }
+      expect(summarizeAutomationAction(missingField, false)).toBe('Update record: (no field selected) ← Done')
+
+      const missingValue: ActionSummarySnapshot = {
+        type: 'update_record',
+        updateRecord: { fieldUpdates: [{ fieldLabel: 'Status', value: '' }] },
+      }
+      expect(summarizeAutomationAction(missingValue, false)).toBe('Update record: Status ← (empty value)')
+    })
+
+    it('counts additional pairs instead of listing them all (stays a one-liner)', () => {
+      const snapshot: ActionSummarySnapshot = {
+        type: 'update_record',
+        updateRecord: {
+          fieldUpdates: [
+            { fieldLabel: 'Status', value: 'Done' },
+            { fieldLabel: 'Owner', value: 'Alice' },
+            { fieldLabel: 'Priority', value: 'High' },
+          ],
+        },
+      }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Update record: Status ← Done and 2 more')
+      expect(summarizeAutomationAction(snapshot, true)).toBe('更新记录：Status ← Done 等 3 项')
+    })
+
+    it('truncates an overlong authored value so the summary stays one line', () => {
+      const snapshot: ActionSummarySnapshot = {
+        type: 'update_record',
+        updateRecord: { fieldUpdates: [{ fieldLabel: 'Notes', value: 'x'.repeat(80) }] },
+      }
+      const text = summarizeAutomationAction(snapshot, false)
+      expect(text).toContain('…')
+      expect(text.length).toBeLessThan(80)
+    })
+  })
+
+  describe('create_record', () => {
+    it('flags an unconfigured target sheet', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'create_record', createRecord: { targetSheetId: '', fieldValueCount: 3 } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Create record (not configured)')
+    })
+
+    it('reports the target sheet and field-value count', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'create_record', createRecord: { targetSheetId: 'sheet_2', fieldValueCount: 2 } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Create record: target sheet sheet_2, 2 field values')
+      expect(summarizeAutomationAction(snapshot, true)).toBe('创建记录：目标表 sheet_2，2 个字段值')
+    })
+
+    it('is honest when the target sheet is set but no field values are authored', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'create_record', createRecord: { targetSheetId: 'sheet_2', fieldValueCount: 0 } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Create record: target sheet sheet_2 (no field values)')
+    })
+  })
+
+  describe('send_webhook', () => {
+    it('flags a missing URL', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_webhook', webhook: { url: '', method: 'POST' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send webhook (not configured)')
+    })
+
+    it('reports method + URL', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_webhook', webhook: { url: 'https://example.com/hook', method: 'PUT' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send webhook: PUT https://example.com/hook')
+    })
+
+    it('defaults the method label to POST when unset (matches the config default)', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_webhook', webhook: { url: 'https://example.com/hook', method: '' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send webhook: POST https://example.com/hook')
+    })
+  })
+
+  describe('send_notification', () => {
+    it('flags a missing recipient', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_notification', notification: { userId: '', message: 'hi' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send notification (not configured)')
+    })
+
+    it('reports recipient + message, placeholdering a blank message', () => {
+      const withMessage: ActionSummarySnapshot = { type: 'send_notification', notification: { userId: 'user_1', message: 'Please review' } }
+      expect(summarizeAutomationAction(withMessage, false)).toBe('Send notification to user_1: Please review')
+
+      const noMessage: ActionSummarySnapshot = { type: 'send_notification', notification: { userId: 'user_1', message: '' } }
+      expect(summarizeAutomationAction(noMessage, false)).toBe('Send notification to user_1: (no message)')
+    })
+  })
+
+  describe('start_approval', () => {
+    it('flags a missing template', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'start_approval', startApproval: { templateLabel: '', mappingCount: 0 } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Start approval (not configured)')
+    })
+
+    it('reports the resolved template name and mapping count', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'start_approval', startApproval: { templateLabel: 'Expense Approval', mappingCount: 2 } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Start approval: template Expense Approval, 2 field mappings')
+      expect(summarizeAutomationAction(snapshot, true)).toBe('发起审批：模板 Expense Approval，2 项字段映射')
+    })
+
+    it('omits the mapping clause entirely when there are zero mappings', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'start_approval', startApproval: { templateLabel: 'tmpl_9', mappingCount: 0 } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Start approval: template tmpl_9')
+    })
+  })
+
+  describe('send_email', () => {
+    it('flags zero recipients', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_email', email: { recipientCount: 0, subjectTemplate: 'Hi' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send email (not configured)')
+    })
+
+    it('counts recipients and shows the subject, placeholdering a blank one', () => {
+      const withSubject: ActionSummarySnapshot = { type: 'send_email', email: { recipientCount: 2, subjectTemplate: 'Weekly digest' } }
+      expect(summarizeAutomationAction(withSubject, false)).toBe('Send email to 2 recipients: Weekly digest')
+
+      const singular: ActionSummarySnapshot = { type: 'send_email', email: { recipientCount: 1, subjectTemplate: '' } }
+      expect(summarizeAutomationAction(singular, false)).toBe('Send email to 1 recipient: (no subject)')
+    })
+  })
+
+  describe('send_dingtalk_group_message', () => {
+    it('flags zero destinations', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_dingtalk_group_message', dingTalkGroupMessage: { destinationCount: 0, titleTemplate: 'x' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send DingTalk group message (not configured)')
+    })
+
+    it('counts destinations (explicit groups + record-field paths) and shows the title', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_dingtalk_group_message', dingTalkGroupMessage: { destinationCount: 3, titleTemplate: 'Ticket {{recordId}}' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send group message to 3 groups: Ticket {{recordId}}')
+      expect(summarizeAutomationAction(snapshot, true)).toBe('发送群消息给 3 个群：Ticket {{recordId}}')
+    })
+
+    it('placeholders a blank title', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_dingtalk_group_message', dingTalkGroupMessage: { destinationCount: 1, titleTemplate: '' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send group message to 1 group: (no title)')
+    })
+  })
+
+  describe('send_dingtalk_person_message', () => {
+    it('flags zero recipients', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_dingtalk_person_message', dingTalkPersonMessage: { recipientCount: 0, titleTemplate: 'x' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send DingTalk person message (not configured)')
+    })
+
+    it('sums users + member groups + field paths into one recipient count', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_dingtalk_person_message', dingTalkPersonMessage: { recipientCount: 5, titleTemplate: 'Reminder' } }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send person message to 5 recipients: Reminder')
+    })
+  })
+
+  describe('send_dingtalk_approval_card', () => {
+    it('always reports the same fixed-recipient sentence (zero config surface)', () => {
+      const snapshot: ActionSummarySnapshot = { type: 'send_dingtalk_approval_card' }
+      expect(summarizeAutomationAction(snapshot, false)).toBe('Send approval card (DingTalk): fixed recipient (from the pending-task event)')
+      expect(summarizeAutomationAction(snapshot, true)).toBe('发送审批卡片（钉钉）：收件人固定（来自待办事件）')
+    })
+  })
+
+  describe('lock_record / delete_record (boolean-config actions)', () => {
+    it('reflects the locked flag both ways — false is a real state, not "unconfigured"', () => {
+      expect(summarizeAutomationAction({ type: 'lock_record', lockRecord: { locked: true } }, false)).toBe('Lock record')
+      expect(summarizeAutomationAction({ type: 'lock_record', lockRecord: { locked: false } }, false)).toBe('Unlock record')
+      expect(summarizeAutomationAction({ type: 'lock_record' }, true)).toBe('解锁记录')
+    })
+
+    it('flags an unacknowledged delete (a real save-blocking condition) without hiding the action type', () => {
+      expect(summarizeAutomationAction({ type: 'delete_record', deleteRecord: { acknowledged: true } }, false)).toBe('Delete record')
+      expect(summarizeAutomationAction({ type: 'delete_record', deleteRecord: { acknowledged: false } }, false)).toBe('Delete record (not confirmed)')
+      expect(summarizeAutomationAction({ type: 'delete_record' }, true)).toBe('删除记录（未确认）')
+    })
+  })
+
+  describe('wait_for_callback (zero-param suspend point)', () => {
+    it('is just the type label — there is nothing else authored to summarize', () => {
+      expect(summarizeAutomationAction({ type: 'wait_for_callback' }, false)).toBe('Wait for callback (suspend)')
+      expect(summarizeAutomationAction({ type: 'wait_for_callback' }, true)).toBe('等待回调（挂起）')
+    })
+  })
+
+  describe('condition_branch / parallel_branch', () => {
+    it('flags zero branches for condition_branch and counts branches + default', () => {
+      expect(summarizeAutomationAction({ type: 'condition_branch', conditionBranch: { branchCount: 0, hasDefaultBranch: false } }, false))
+        .toBe('Condition branch (not configured)')
+      expect(summarizeAutomationAction({ type: 'condition_branch', conditionBranch: { branchCount: 2, hasDefaultBranch: false } }, false))
+        .toBe('Condition branch: 2 branches')
+      expect(summarizeAutomationAction({ type: 'condition_branch', conditionBranch: { branchCount: 1, hasDefaultBranch: true } }, false))
+        .toBe('Condition branch: 1 branch + default branch')
+      expect(summarizeAutomationAction({ type: 'condition_branch', conditionBranch: { branchCount: 2, hasDefaultBranch: true } }, true))
+        .toBe('条件分支：2 个分支 + 默认分支')
+    })
+
+    it('flags zero branches for parallel_branch and counts branches', () => {
+      expect(summarizeAutomationAction({ type: 'parallel_branch', parallelBranch: { branchCount: 0 } }, false))
+        .toBe('Parallel branch (not configured)')
+      expect(summarizeAutomationAction({ type: 'parallel_branch', parallelBranch: { branchCount: 3 } }, false))
+        .toBe('Parallel branch: 3 parallel branches')
+      expect(summarizeAutomationAction({ type: 'parallel_branch', parallelBranch: { branchCount: 3 } }, true))
+        .toBe('并行分支：3 路并行')
+    })
+  })
+
+  describe('legacy aliases and unknown types', () => {
+    it('falls back to the plain type label for legacy action types (no dedicated snapshot shape)', () => {
+      expect(summarizeAutomationAction({ type: 'notify' }, false)).toBe('Send notification')
+      expect(summarizeAutomationAction({ type: 'update_field' }, true)).toBe('更新字段值')
+    })
+  })
+})

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1008,6 +1008,30 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1')
   })
 
+  it('G-B2-25: a LOADED (persisted) action starts COLLAPSED behind its one-line summary', async () => {
+    const rule: AutomationRule = {
+      id: 'atr_b225', sheetId: 'sheet_1', name: 'existing', triggerType: 'record.created',
+      triggerConfig: {}, actionType: 'update_record', actionConfig: { fieldUpdates: [] }, enabled: true,
+      executionMode: 'workflow_job_v1',
+    }
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule })
+    await flushPromises()
+    // The action config collapse is NOT active (folded) for a persisted action...
+    expect(container.querySelectorAll('.meta-rule-editor__action-collapse .el-collapse-item.is-active')).toHaveLength(0)
+    // ...but its one-line summary IS rendered (the whole point of folding).
+    const summary = container.querySelector('[data-field="actionSummary"]')
+    expect(summary).toBeTruthy()
+    expect((summary!.textContent || '').trim().length).toBeGreaterThan(0)
+    // ...and the config controls stay in the DOM (v-show), so existing selectors still resolve.
+    expect(container.querySelector('[data-field="actionConfigSection"]')).toBeTruthy()
+  })
+
+  it('G-B2-25: a FRESH rule\'s starter action starts EXPANDED (not hidden behind a summary)', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+    expect(container.querySelectorAll('.meta-rule-editor__action-collapse .el-collapse-item.is-active').length).toBeGreaterThanOrEqual(1)
+  })
+
   it('A6-1: reflects a saved opt-in rule (checked) and can toggle back to off (null)', async () => {
     const saved = vi.fn()
     const rule: AutomationRule = {


### PR DESCRIPTION
## 审计项 G-B2-25
> 3 动作 ≈700 行控件长墙；渐进披露是关键

## 做了什么
- 每个动作的 config 块（那面 ~700 行控件墙）包进 `el-collapse`/`el-collapse-item`，收起时标题 slot 显示**一句话摘要**；header（类型选择/上下移/删除）留在折叠**外**、始终可见。
- 折叠默认策略：**已保存的动作**（`action.persisted === true`）默认**折叠**；新加/刚改类型的动作默认**展开**（复用既有 `persisted` flag，零新状态）；手动切换后按动作记忆覆盖（沿用 G-B2-24 先例）。安全网：点「为何不能保存」的原因会先**强制展开**目标动作，保存阻断字段绝不隐身。
- 摘要抽为纯模块 `automationActionSummary.ts`，每种动作类型一句；缺字段给显式占位（`(未配置)` 等），**不编造**。

## 关键正确性
- 折叠内容用 **v-show 保留在 DOM**（非 v-if）→ 既有 mount spec 的每个 `data-field`/`data-action-index`/精确 `[title]`/`[aria-label]` 计数断言全部照常通过（117/117 未改）。
- 标题走 **slot**（非 `title` prop）→ 不新增 HTML title 属性。
- `ElCollapse`/`ElCollapseItem` 已在组件显式 element-plus import 内（否则测试壳渲染成无 class 未知元素）。

## Review 补强（本 PR 已含）
agent 诚实指出：折叠**行为**与摘要**渲染**只「by construction」验证——而 mount spec 通过**并不能**证明折叠真的生效（v-show 下内容无论折叠与否都可查）。补两个行为测试：已保存动作**默认折叠**且摘要非空、config 仍在 DOM；新规则起始动作**默认展开**。**突变验证**：让 `isActionExpanded` 忽略 `persisted`（恒展开）→ 折叠用例变红。

## 验证
- 摘要纯函数 30 例；mount spec **117/117 未改**（+2 行为测试）；labels + style guard；合计 **247**。
- 完整 `multitable-web-guard` filter（含新 `automation-action-summary`，两点接线）**700 tests 绿**。
- `vue-tsc --noEmit` 0；无裸 hex/rgb、无内联 style；无新品牌文案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
