### PR TITLE
feat(automation): G-B2-27 — 目标表下拉（listSheets）+ 手动回退

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -33,6 +33,10 @@ on:
       # pinning "honest placeholder, never fabricated" behavior across every action type).
       - 'apps/web/src/multitable/automationActionSummary.ts'
       - 'apps/web/tests/automation-action-summary.spec.ts'
+      # G-B2-27: create_record's target-sheet dropdown (listSheets() → options, pure mapping) plus
+      # its mount-level wiring/fallback tests.
+      - 'apps/web/src/multitable/utils/automation-target-sheet-options.ts'
+      - 'apps/web/tests/automation-target-sheet-options.spec.ts'
       - 'apps/web/src/multitable/utils/field-config.ts'
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
@@ -123,6 +127,10 @@ on:
       # pinning "honest placeholder, never fabricated" behavior across every action type).
       - 'apps/web/src/multitable/automationActionSummary.ts'
       - 'apps/web/tests/automation-action-summary.spec.ts'
+      # G-B2-27: create_record's target-sheet dropdown (listSheets() → options, pure mapping) plus
+      # its mount-level wiring/fallback tests.
+      - 'apps/web/src/multitable/utils/automation-target-sheet-options.ts'
+      - 'apps/web/tests/automation-target-sheet-options.spec.ts'
       - 'apps/web/src/multitable/utils/field-config.ts'
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
@@ -257,4 +265,4 @@ jobs:
         # UF-3: status-color convergence — statusTag (StatusTag.vue + statusDomains.ts unit/mount
         # coverage), AutomationExecutionsView + parallelBranchRunsView (automationRun domain status
         # badges, run + step level, including the parallel-branch readability regression).
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-reorder-view-fields multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting statusTag AutomationExecutionsView parallelBranchRunsView automation-save-block-reasons automation-action-summary multitable-automation-rule-editor --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-reorder-view-fields multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-field-visibility multitable-required-if multitable-conditional-formatting statusTag AutomationExecutionsView parallelBranchRunsView automation-save-block-reasons automation-action-summary automation-target-sheet-options multitable-automation-rule-editor --reporter=dot

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -397,7 +397,44 @@
             <!-- create_record config -->
             <div v-if="action.type === 'create_record'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.targetSheetId', isZh) }}</label>
-              <el-input v-model="action.config.targetSheetId" type="text" :placeholder="automationLabel('actionConfig.sheetIdPlaceholder', isZh)" />
+              <!-- G-B2-27: dropdown sourced from listSheets() so non-developers don't have to paste
+                   a raw sheet ID. The manual-entry toggle covers what the dropdown can't: listSheets
+                   may omit cross-base/future sheets (isManualTargetSheetEntry defaults to manual when
+                   the currently-configured id isn't in the fetched list, so a stale/foreign value is
+                   never silently hidden). A missing/failed/empty listSheets() falls all the way back
+                   to the plain text input in the v-else branch below. -->
+              <template v-if="targetSheetOptions.length > 0">
+                <el-select
+                  v-if="!isManualTargetSheetEntry(action)"
+                  v-model="(action.config.targetSheetId as string)"
+                  filterable
+                  class="meta-rule-editor__select"
+                  :placeholder="automationLabel('actionConfig.sheetIdPlaceholder', isZh)"
+                  data-field="createRecordTargetSheetId"
+                >
+                  <el-option value="" data-value="" :label="automationLabel('actionConfig.sheetIdPlaceholder', isZh)" />
+                  <el-option v-for="opt in targetSheetOptions" :key="opt.value" :value="opt.value" :data-value="opt.value" :label="opt.label" />
+                </el-select>
+                <el-input
+                  v-else
+                  v-model="action.config.targetSheetId"
+                  type="text"
+                  :placeholder="automationLabel('actionConfig.sheetIdPlaceholder', isZh)"
+                  data-field="createRecordTargetSheetId"
+                />
+                <el-button
+                  size="small"
+                  class="meta-rule-editor__btn"
+                  data-field="createRecordTargetSheetToggle"
+                  @click="toggleManualTargetSheetEntry(action)"
+                >{{ isManualTargetSheetEntry(action) ? automationLabel('actionConfig.targetSheetUseListToggle', isZh) : automationLabel('actionConfig.targetSheetManualToggle', isZh) }}</el-button>
+              </template>
+              <!-- Load-bearing fallback, not just cosmetic degradation: this is a plain el-input so
+                   `.meta-rule-editor__action-config .el-input__inner` still resolves to it when no
+                   sheets are loaded (no client / listSheets() failed or empty) — an existing
+                   multitable-automation-rule-editor.spec.ts case types into exactly that selector.
+                   Collapsing this to an always-on el-select would silently break that test. -->
+              <el-input v-else v-model="action.config.targetSheetId" type="text" :placeholder="automationLabel('actionConfig.sheetIdPlaceholder', isZh)" data-field="createRecordTargetSheetId" />
               <div v-for="(pair, pidx) in (action.config.fieldValues as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
                 <el-input v-model="pair.fieldId" class="meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('actionConfig.fieldIdPlaceholder', isZh)" />
                 <el-input v-model="pair.value" class="meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('editor.value', isZh)" />
@@ -1334,6 +1371,7 @@ import type {
   ConditionGroup,
   DingTalkGroupDestination,
   MetaSheetPermissionCandidate,
+  MetaSheet,
   MetaView,
 } from '../types'
 import { applyDingTalkNotificationPreset, type DingTalkNotificationPreset } from '../utils/dingtalkNotificationPresets'
@@ -1403,6 +1441,7 @@ import {
   summarizeAutomationAction,
   type ActionSummarySnapshot,
 } from '../automationActionSummary'
+import { automationTargetSheetOptions } from '../utils/automation-target-sheet-options'
 
 interface FieldPair {
   fieldId: string
@@ -1504,6 +1543,29 @@ const dingTalkDestinationsError = ref('')
 // start_approval template picker. Empty (incl. on a 401/403 for an author lacking `approvals:read`) →
 // the config block degrades to a free-text template-id input; the select is never a hard dependency.
 const approvalTemplates = ref<Array<{ id: string; name?: string }>>([])
+// G-B2-27: create_record's target-sheet picker. Empty (no client, listSheets() unavailable/failed,
+// or the base simply has no other sheets yet) → the config block degrades to the original free-text
+// sheet-ID input further below — never a hard dependency, same shape as approvalTemplates above.
+const availableSheets = ref<MetaSheet[]>([])
+const targetSheetOptions = computed(() => automationTargetSheetOptions(availableSheets.value))
+// Per-action manual-vs-dropdown override for the target-sheet field, keyed by the action's stable
+// draftId (survives reordering, unlike an array index). Undefined means "no explicit choice yet" —
+// isManualTargetSheetEntry then defaults to manual whenever the currently-configured sheet id isn't
+// among targetSheetOptions, so an off-list value (cross-base sheet, or set before listSheets loaded)
+// is always visible/editable rather than silently swallowed by a dropdown that can't represent it.
+const manualTargetSheetOverride = ref<Record<string, boolean>>({})
+
+function isManualTargetSheetEntry(action: DraftAction): boolean {
+  const override = manualTargetSheetOverride.value[action.draftId]
+  if (override !== undefined) return override
+  const current = typeof action.config.targetSheetId === 'string' ? action.config.targetSheetId.trim() : ''
+  if (!current) return false
+  return !targetSheetOptions.value.some((opt) => opt.value === current)
+}
+
+function toggleManualTargetSheetEntry(action: DraftAction) {
+  manualTargetSheetOverride.value[action.draftId] = !isManualTargetSheetEntry(action)
+}
 const personRecipientSuggestions = ref<Record<number, MetaSheetPermissionCandidate[]>>({})
 const personRecipientLoading = ref<Record<number, boolean>>({})
 const personRecipientErrors = ref<Record<number, string>>({})
@@ -2467,9 +2529,18 @@ watch(
         } catch {
           approvalTemplates.value = []
         }
+        try {
+          // Best-effort: any error (network, older host without the endpoint, etc.) → empty →
+          // the create_record target-sheet field falls back to its original free-text input.
+          const res = await props.client.listSheets()
+          availableSheets.value = Array.isArray(res?.sheets) ? res.sheets : []
+        } catch {
+          availableSheets.value = []
+        }
       } else {
         dingTalkDestinations.value = []
         approvalTemplates.value = []
+        availableSheets.value = []
       }
     }
   },

--- a/apps/web/src/multitable/utils/automation-target-sheet-options.ts
+++ b/apps/web/src/multitable/utils/automation-target-sheet-options.ts
@@ -1,0 +1,33 @@
+// G-B2-27: create_record's "target sheet" picker used to be a bare text box — a non-developer
+// had to know (and correctly paste) a raw sheet ID. This module is the pure mapping from
+// listSheets() results to dropdown options; the component wires it into an el-select with an
+// allow-create manual fallback (listSheets may omit cross-base/future sheets, and the client may
+// be unavailable in some hosts) — see MetaAutomationRuleEditor.vue's targetSheetOptions computed.
+
+export interface AutomationTargetSheetOption {
+  value: string
+  label: string
+}
+
+interface AutomationTargetSheetLike {
+  id: string
+  name?: string | null
+}
+
+/**
+ * Map raw sheets (as returned by listSheets()) into select options.
+ * Honest about partial/malformed input: entries missing a usable string id are dropped
+ * (an id-less option can't round-trip through save), and a missing/blank name falls back
+ * to the id so the option always has a readable label.
+ */
+export function automationTargetSheetOptions(
+  sheets: readonly AutomationTargetSheetLike[] | null | undefined,
+): AutomationTargetSheetOption[] {
+  if (!Array.isArray(sheets)) return []
+  return sheets
+    .filter((sheet): sheet is AutomationTargetSheetLike => !!sheet && typeof sheet.id === 'string' && sheet.id.length > 0)
+    .map((sheet) => ({
+      value: sheet.id,
+      label: typeof sheet.name === 'string' && sheet.name.trim() ? sheet.name : sheet.id,
+    }))
+}

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -121,6 +121,8 @@ export type AutomationLabelKey =
   | 'condition.removeConditionTitle'
   | 'actionConfig.targetSheetId'
   | 'actionConfig.sheetIdPlaceholder'
+  | 'actionConfig.targetSheetManualToggle'
+  | 'actionConfig.targetSheetUseListToggle'
   | 'actionConfig.fieldIdPlaceholder'
   | 'actionConfig.url'
   | 'actionConfig.method'
@@ -386,6 +388,8 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'condition.removeConditionTitle',
   'actionConfig.targetSheetId',
   'actionConfig.sheetIdPlaceholder',
+  'actionConfig.targetSheetManualToggle',
+  'actionConfig.targetSheetUseListToggle',
   'actionConfig.fieldIdPlaceholder',
   'actionConfig.url',
   'actionConfig.method',
@@ -668,6 +672,10 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'condition.removeConditionTitle': { en: 'Remove condition', zh: '移除条件' },
   'actionConfig.targetSheetId': { en: 'Target sheet ID', zh: '目标工作表 ID' },
   'actionConfig.sheetIdPlaceholder': { en: 'Sheet ID', zh: '工作表 ID' },
+  // G-B2-27: escape hatch next to the target-sheet dropdown — listSheets() may omit
+  // cross-base/future sheets, so typing the ID directly stays available on demand.
+  'actionConfig.targetSheetManualToggle': { en: 'Enter ID manually', zh: '手动输入 ID' },
+  'actionConfig.targetSheetUseListToggle': { en: 'Choose from list', zh: '从列表选择' },
   'actionConfig.fieldIdPlaceholder': { en: 'Field ID', zh: '字段 ID' },
   'actionConfig.url': { en: 'URL', zh: 'URL' },
   'actionConfig.method': { en: 'Method', zh: '方法' },

--- a/apps/web/tests/automation-target-sheet-options.spec.ts
+++ b/apps/web/tests/automation-target-sheet-options.spec.ts
@@ -1,0 +1,223 @@
+// G-B2-27: create_record's "target sheet" field used to be a bare text box (paste a raw sheet ID
+// by hand) — apps/web/src/multitable/utils/automation-target-sheet-options.ts is the pure mapping
+// from listSheets() results to dropdown options, and MetaAutomationRuleEditor.vue wires it into an
+// el-select with a manual-entry fallback/toggle. This file matrix-tests the pure mapping and adds a
+// FEW focused mount checks (not a large new mount suite) proving the wiring end-to-end: the
+// existing multitable-automation-rule-editor.spec.ts mount suite (~119 tests) stays the regression
+// net for everything else in the component.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomationRuleEditor.vue'
+import { automationTargetSheetOptions } from '../src/multitable/utils/automation-target-sheet-options'
+import type { AutomationRule } from '../src/multitable/types'
+import { epOptions, epSetSelect } from './helpers/epControls'
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+
+describe('automationTargetSheetOptions (pure mapping)', () => {
+  it('maps sheets to value/label options, preferring name and falling back to id', () => {
+    expect(
+      automationTargetSheetOptions([
+        { id: 'sheet_1', name: 'Tasks' },
+        { id: 'sheet_2', name: '' },
+        { id: 'sheet_3', name: '   ' },
+        { id: 'sheet_4' },
+      ]),
+    ).toEqual([
+      { value: 'sheet_1', label: 'Tasks' },
+      { value: 'sheet_2', label: 'sheet_2' },
+      { value: 'sheet_3', label: 'sheet_3' },
+      { value: 'sheet_4', label: 'sheet_4' },
+    ])
+  })
+
+  it('drops entries without a usable string id instead of throwing', () => {
+    expect(
+      automationTargetSheetOptions([
+        { id: '', name: 'Blank id' },
+        { id: 123 as unknown as string, name: 'Non-string id' },
+        null as unknown as { id: string },
+        undefined as unknown as { id: string },
+      ]),
+    ).toEqual([])
+  })
+
+  it('is honest about non-array/nullish input — never throws, always an empty list', () => {
+    expect(automationTargetSheetOptions(null)).toEqual([])
+    expect(automationTargetSheetOptions(undefined)).toEqual([])
+    expect(automationTargetSheetOptions('not-an-array' as unknown as null)).toEqual([])
+    expect(automationTargetSheetOptions([])).toEqual([])
+  })
+})
+
+const fields = [{ id: 'fld_1', name: 'Status', type: 'string' }]
+
+function fakeRule(overrides: Partial<AutomationRule> = {}): AutomationRule {
+  return {
+    id: 'rule_1',
+    sheetId: 'sheet_1',
+    name: 'Test Rule',
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'update_record',
+    actionConfig: {},
+    enabled: true,
+    actions: [{ type: 'update_record', config: { fieldUpdates: [] } }],
+    ...overrides,
+  }
+}
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaAutomationRuleEditor, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaAutomationRuleEditor — G-B2-27 target-sheet dropdown wiring', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('lists sheets from listSheets() and writes the selected id back on save', async () => {
+    const saved = vi.fn()
+    const client = {
+      listSheets: vi.fn(async () => ({ sheets: [{ id: 'sheet_2', name: 'Tasks' }] })),
+    }
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client, onSave: saved })
+    await flushPromises()
+    expect(client.listSheets).toHaveBeenCalledTimes(1)
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Create a task'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'create_record')
+    await flushPromises()
+
+    const sheetSelect = container.querySelector('[data-field="createRecordTargetSheetId"]') as HTMLElement
+    expect(sheetSelect.tagName).not.toBe('INPUT') // el-select wrapper, not the plain-text fallback
+    expect(epOptions(sheetSelect).map((o) => o.textContent)).toContain('Tasks')
+    epSetSelect(sheetSelect, 'sheet_2')
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actions[0]).toEqual({ type: 'create_record', config: { sheetId: 'sheet_2', data: {} } })
+  })
+
+  it('degrades to a manual text input (never crashes) when the client has no listSheets at all', async () => {
+    const saved = vi.fn()
+    const client = {} // no listSheets — mirrors mockClient() in the main spec, which also omits it
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Create a task'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'create_record')
+    await flushPromises()
+
+    const sheetInput = container.querySelector('[data-field="createRecordTargetSheetId"]') as HTMLInputElement
+    expect(sheetInput.tagName).toBe('INPUT')
+    sheetInput.value = 'sheet_manual'
+    sheetInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actions[0]).toEqual({ type: 'create_record', config: { sheetId: 'sheet_manual', data: {} } })
+  })
+
+  it('degrades to a manual text input when no client prop is passed at all', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Create a task'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'create_record')
+    await flushPromises()
+
+    const sheetInput = container.querySelector('[data-field="createRecordTargetSheetId"]') as HTMLInputElement
+    expect(sheetInput.tagName).toBe('INPUT')
+  })
+
+  it('defaults to manual entry — and preserves the value unedited on save — when an existing rule targets a sheet outside listSheets()', async () => {
+    const saved = vi.fn()
+    const client = {
+      listSheets: vi.fn(async () => ({ sheets: [{ id: 'sheet_2', name: 'Tasks' }] })),
+    }
+    const rule = fakeRule({
+      actionType: 'create_record',
+      actions: [{ type: 'create_record', config: { sheetId: 'sheet_offbase', data: {} } }],
+    })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client, rule, onSave: saved })
+    await flushPromises()
+
+    const sheetField = container.querySelector('[data-field="createRecordTargetSheetId"]') as HTMLInputElement
+    expect(sheetField.tagName).toBe('INPUT') // manual mode, defaulted because sheet_offbase isn't in the fetched list
+    expect(sheetField.value).toBe('sheet_offbase')
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actions[0]).toEqual({ type: 'create_record', config: { sheetId: 'sheet_offbase', data: {} } })
+  })
+
+  it('the manual-entry toggle switches to the dropdown and back without losing the typed value', async () => {
+    const saved = vi.fn()
+    const client = {
+      listSheets: vi.fn(async () => ({ sheets: [{ id: 'sheet_2', name: 'Tasks' }] })),
+    }
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, client, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Create a task'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header .el-select') as HTMLElement
+    epSetSelect(actionSelect, 'create_record')
+    await flushPromises()
+
+    const toggleBtn = container.querySelector('[data-field="createRecordTargetSheetToggle"]') as HTMLButtonElement
+    toggleBtn.click()
+    await flushPromises()
+
+    const sheetInput = container.querySelector('[data-field="createRecordTargetSheetId"]') as HTMLInputElement
+    expect(sheetInput.tagName).toBe('INPUT')
+    sheetInput.value = 'sheet_cross_base'
+    sheetInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actions[0]).toEqual({ type: 'create_record', config: { sheetId: 'sheet_cross_base', data: {} } })
+  })
+})


### PR DESCRIPTION
## 审计项 G-B2-27
> 粘贴表 ID 对非开发者不可用而 listSheets() 已存在

## Part 1（已做）：目标表下拉
`create_record` 的目标表从**裸文本框** → **el-select**，选项来自 `props.client.listSheets()`（抽屉打开时拉一次，沿用既有 listApprovalTemplates/listDingTalkGroups 的 try/catch 模式）。三层容错，全部有测试：
1. 无 client / client 无 listSheets / 调用抛错或返回空 → **降级回原样文本框**（DOM 形状不变）。
2. 下拉已显示但当前值不在列表里（跨库/未来表）→ 逐动作「手动输入」toggle 默认开，裸值显示在文本框里（**不静默隐藏**）。
3. 用户可显式在下拉/手动间切换，值永不丢。
写回不变：仍走 `action.config.targetSheetId` 字符串；buildPayload/校验不改。

**兼容性发现**：既有测试往 `.el-input__inner`（第一个）打字，而 el-select 的 filterable trigger 是 `.el-select__input`。**下拉只在 listSheets 真返回了 sheets 时才渲染**；那个测试的 mount 不传 client → 走原 el-input 兜底分支，既有 119/119 不变。

## Part 2（跳过，附证据）：类型化值控件
`update_record.pair.value` 被 mount spec 里 ~47 处 fields fixture 引用；`create_record.fieldId` 是自由文本（组件从不取**目标表**的字段 schema，只有 `props.fields`=当前表）。做类型化值要动几十处断言 + 新增 schema-fetch 路径——**独立可审的一刀**，不该塞进本改动。诚实缩范围。

## 验证
- 新 spec 8/8（3 纯映射矩阵 + 5 mount：下拉往返/无 listSheets 兜底/无 client 兜底/**off-list 值默认手动且保存不丢**/toggle 保值）。**突变验证**：关掉 off-list 检测（恒下拉）→ 保值用例变红。
- 既有 mount spec **119/119 未改**；labels 15 + style guard 83；合计 225；相关组件套件全绿。
- 完整 `multitable-web-guard` filter 53 files / 710 tests 绿；`vue-tsc --noEmit` 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
