### PR TITLE
feat(approval): G-B2-06 — 线性模板流程脊柱（只读）+ 步骤间插入

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -29,6 +29,10 @@ on:
       - 'apps/web/src/approvals/amountAutoSum.ts'
       - 'apps/web/src/approvals/useAutoSumTotal.ts'
       - 'apps/web/src/approvals/lineDerivation.ts'
+      # G-B2-06: 线性模板流程脊柱 + 步骤间插入 — linearStepSpine.ts pure chip-descriptor helper
+      # (consumed by TemplateAuthoringView's read-only linear spine) + its matrix spec.
+      - 'apps/web/src/approvals/linearStepSpine.ts'
+      - 'apps/web/tests/approval-template-authoring-linear-step-spine.test.ts'
       # G-B2-11 / G-B2-12: the 待办 list's pill re-baseline choke point + per-row 催办 state.
       - 'apps/web/src/approvals/newTodoPill.ts'
       - 'apps/web/src/approvals/urgeButtonState.ts'
@@ -170,6 +174,10 @@ on:
       - 'apps/web/src/approvals/amountAutoSum.ts'
       - 'apps/web/src/approvals/useAutoSumTotal.ts'
       - 'apps/web/src/approvals/lineDerivation.ts'
+      # G-B2-06: 线性模板流程脊柱 + 步骤间插入 — linearStepSpine.ts pure chip-descriptor helper
+      # (consumed by TemplateAuthoringView's read-only linear spine) + its matrix spec.
+      - 'apps/web/src/approvals/linearStepSpine.ts'
+      - 'apps/web/tests/approval-template-authoring-linear-step-spine.test.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
@@ -366,4 +374,4 @@ jobs:
         # files and asserts zero static style= attributes and zero hex/rgb() literals inside
         # <style> blocks (var() references + transparent/inherit/currentColor/none allowed);
         # had no gate before this wiring.
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words approval-form-draft lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView newTodoPill approval-urge-button-state approval-route-preview-controller approval-route-preview-summary approval-form-draft approval-amount-in-words approval-number-field-props approval-condition-summary approval-prefill-from-snapshot approval-upcoming-nodes approval-assignee-source approval-field-visibility templateGalleryFilter approvalTemplateCenterCategory approval-center approvalCenterRemindBadge approvalCenterUnreadBadge approvalCenterSourceFilter approval-graph-summary requesterPreviewFields ui-foundation-style-guard uiFoundationTexture --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout approval-condition-summary amountAutoSum useAutoSumTotal approval-amount-in-words approval-form-draft lineDerivation approvalMobileI18n approvalMobileResponsive pageShell statusTag approval-e2e-lifecycle approval-inbox-auth-guard myDelegationView approvalDelegationView approvalDelegationStatus approval-e2e-permissions approvalCenterTable workflowHubView newTodoPill approval-urge-button-state approval-route-preview-controller approval-route-preview-summary approval-form-draft approval-amount-in-words approval-number-field-props approval-condition-summary approval-prefill-from-snapshot approval-upcoming-nodes approval-assignee-source approval-field-visibility templateGalleryFilter approvalTemplateCenterCategory approval-center approvalCenterRemindBadge approvalCenterUnreadBadge approvalCenterSourceFilter approval-graph-summary requesterPreviewFields ui-foundation-style-guard uiFoundationTexture approval-template-authoring-linear-step-spine --reporter=dot

--- a/apps/web/src/approvals/linearStepSpine.ts
+++ b/apps/web/src/approvals/linearStepSpine.ts
@@ -1,0 +1,95 @@
+import { assigneeSourceSummary } from './assigneeSource'
+import { parseIdsText, sourceFromStep, type ApprovalStepDraft } from './templateAuthoring'
+
+/**
+ * G-B2-06 — read-only "flow spine" for a LINEAR template's steps: 发起人 → 步骤1 → 步骤2 → … one
+ * chip per hop. Pure derivation straight from `draft.value.steps` (`TemplateAuthoringView.vue`'s
+ * linear editor model) — no canvas, no `ApprovalGraph`, no Element Plus, no I/O. This is
+ * deliberately NOT the same code path as the preserved-complex-graph read-only preview
+ * (`graphPreviewNodes` / `nodeConfigSummary` in the view, backed by `graphSummary.ts` /
+ * `assigneeSource.ts`'s `nodeAssigneeSourceSummary` for an `ApprovalGraph`) — a linear draft has
+ * no graph to walk until save builds one, and 90% of authors only ever see the linear form-card
+ * stack, never the graph tooling. The two previews are allowed to diverge; this module only
+ * covers the linear shape.
+ *
+ * The per-source human text is NOT re-derived here: `sourceFromStep` (templateAuthoring.ts)
+ * builds the exact `ApprovalAssigneeSource` the saved graph would carry, and `assigneeSourceSummary`
+ * (assigneeSource.ts) is the SAME humanizer the preserved-complex-graph preview already uses — so a
+ * `static_role`/`continuous_managers`/etc. chip reads identically whether the template is linear or
+ * complex, and a wording change only has one place to land.
+ */
+export interface LinearStepSpineChip {
+  /** Stable key: the fixed sentinel for the leading chip, else the step's `localId`. */
+  key: string
+  role: 'requester' | 'step'
+  /** Chip headline — `发起人` for the leading chip, else the step's name (or its positional
+   * default `审批人 N`, mirroring `buildApprovalGraph`'s own empty-name fallback). */
+  label: string
+  /** One-line human summary of the approver source (`''` for the requester chip, which has none). */
+  sourceSummary: string
+  /** False when the step's source is missing required author input (see `isStepSourceResolvable`).
+   * Always `true` for the requester chip — there is nothing to configure. */
+  resolvable: boolean
+  /** 1-based position in the `steps` array; `null` for the requester chip. */
+  stepIndex: number | null
+}
+
+export const REQUESTER_SPINE_KEY = '__requester__'
+
+/**
+ * True when a step's `sourceKind` carries the author input it needs to resolve to anyone at
+ * save/run time: `static_user`/`static_role` need at least one id, `form_field_user` needs a
+ * chosen field. Every other kind (`requester`/`direct_manager`/`dept_head`/`continuous_managers`/
+ * `manager_at_level`) needs no additional author input beyond its own defaults, so it is always
+ * "resolvable" from the DRAFT's point of view — this is authoring-completeness, not a live
+ * directory/org lookup (this module does no I/O, matching every other pure `approvals/*` helper).
+ */
+export function isStepSourceResolvable(step: ApprovalStepDraft): boolean {
+  switch (step.sourceKind) {
+    case 'static_user':
+    case 'static_role':
+      return parseIdsText(step.idsText).length > 0
+    case 'form_field_user':
+      return step.fieldId.trim().length > 0
+    default:
+      return true
+  }
+}
+
+// `assigneeSourceSummary` already gives static_user/static_role an honest `（无）` placeholder
+// when their id array is empty. `form_field_user` is the one shape it does not already cover
+// (an unset fieldId renders as the bare `表单用户字段：`) — so that one case gets the same
+// honest-placeholder treatment here, in the SAME bracket convention, instead of a half-empty label.
+function stepSourceSummary(step: ApprovalStepDraft, resolvable: boolean): string {
+  if (step.sourceKind === 'form_field_user' && !resolvable) return '表单用户字段：（未选择）'
+  return assigneeSourceSummary(sourceFromStep(step))
+}
+
+/**
+ * Build the read-only spine chip list for a linear template's steps. The requester chip is
+ * ALWAYS first, even for an empty `steps` array — the flow always starts with whoever submits
+ * the form, regardless of how many approval steps follow.
+ */
+export function buildLinearStepSpine(steps: ApprovalStepDraft[]): LinearStepSpineChip[] {
+  const requesterChip: LinearStepSpineChip = {
+    key: REQUESTER_SPINE_KEY,
+    role: 'requester',
+    label: '发起人',
+    sourceSummary: '',
+    resolvable: true,
+    stepIndex: null,
+  }
+  const stepChips = steps.map((step, index) => {
+    const position = index + 1
+    const resolvable = isStepSourceResolvable(step)
+    return {
+      key: step.localId,
+      role: 'step' as const,
+      label: step.name.trim() || `审批人 ${position}`,
+      sourceSummary: stepSourceSummary(step, resolvable),
+      resolvable,
+      stepIndex: position,
+    }
+  })
+  return [requesterChip, ...stepChips]
+}

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -274,6 +274,34 @@ export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
   }
 }
 
+/** True when `name` is still the untouched default `createEmptyStepDraft`/`buildApprovalGraph`
+ * would give a step at 1-based `position` (`审批人 <position>`) — used by `insertStepAt` to tell
+ * an author-renamed step apart from one that never got a custom name. */
+export function isDefaultStepName(name: string, position: number): boolean {
+  return name.trim() === `审批人 ${position}`
+}
+
+/**
+ * G-B2-06 — insert a fresh blank step AFTER the existing step at `index` (0-based, matching the
+ * `v-for="(step, index) in draft.steps"` position in `TemplateAuthoringView.vue`), instead of
+ * `createEmptyStepDraft` being reachable only via end-of-list `addStep`. Any step AFTER the
+ * insertion point whose `name` is still the untouched default for its OLD 1-based position gets
+ * renumbered to match its new position, so the `审批人 N` numbering stays self-consistent after a
+ * middle insert; a step the author has renamed is left untouched — insertion never overwrites
+ * author-authored text. `moveStep`/`removeStep` are unaffected (separate functions, unchanged).
+ */
+export function insertStepAt(steps: ApprovalStepDraft[], index: number): ApprovalStepDraft[] {
+  const insertAt = Math.min(Math.max(index + 1, 0), steps.length)
+  const before = steps.slice(0, insertAt)
+  const after = steps.slice(insertAt).map((step, offset) => {
+    const oldPosition = insertAt + offset + 1
+    const newPosition = oldPosition + 1
+    return isDefaultStepName(step.name, oldPosition) ? { ...step, name: `审批人 ${newPosition}` } : step
+  })
+  const inserted = createEmptyStepDraft(insertAt + 1)
+  return [...before, inserted, ...after]
+}
+
 export function createEmptyTemplateDraft(): TemplateAuthoringDraft {
   return {
     key: '',
@@ -871,7 +899,10 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
   }
 }
 
-function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
+/** Exported (G-B2-06) so `linearStepSpine.ts` can derive the same `ApprovalAssigneeSource` the
+ * saved graph would carry and feed it to the shared `assigneeSourceSummary` humanizer, instead of
+ * re-deriving a second sourceKind→text switch that could drift from this one. */
+export function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
   if (step.sourceKind === 'static_user') {
     return { kind: 'static_user', userIds: parseIdsText(step.idsText) }
   }

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -957,11 +957,46 @@
           </div>
         </div>
 
+        <!-- G-B2-06 read-only flow spine (LINEAR templates only — a preserved complex graph keeps
+             its own structured/canvas views above, untouched): 发起人 → 步骤1 → 步骤2 → …, derived
+             straight from draft.steps (see linearStepSpine.ts). Not editable here; clicking a step
+             chip scrolls to and briefly highlights the matching card below. -->
+        <div
+          v-if="!graphReadOnly"
+          class="template-authoring__spine"
+          data-testid="approval-template-step-spine"
+        >
+          <template v-for="(chip, chipIndex) in linearStepSpine" :key="chip.key">
+            <button
+              type="button"
+              class="template-authoring__spine-chip"
+              :class="{
+                'template-authoring__spine-chip--requester': chip.role === 'requester',
+                'template-authoring__spine-chip--unresolved': !chip.resolvable,
+              }"
+              :data-testid="chip.role === 'requester' ? 'approval-spine-chip-requester' : 'approval-spine-chip-step'"
+              :data-step-index="chip.stepIndex ?? undefined"
+              :title="chip.stepIndex ? `第 ${chip.stepIndex} 步 · 点击定位到对应步骤卡` : '发起人：提交表单'"
+              @click="focusStepCard(chip)"
+            >
+              <strong>{{ chip.label }}</strong>
+              <span v-if="chip.sourceSummary" class="template-authoring__spine-chip-source">{{ chip.sourceSummary }}</span>
+            </button>
+            <span
+              v-if="chipIndex < linearStepSpine.length - 1"
+              class="template-authoring__spine-arrow"
+              aria-hidden="true"
+            >→</span>
+          </template>
+        </div>
+
         <div
           v-for="(step, index) in draft.steps"
           v-show="!graphReadOnly"
+          :id="`approval-step-card-${step.localId}`"
           :key="step.localId"
           class="template-authoring__item"
+          :class="{ 'template-authoring__item--highlighted': highlightedStepLocalId === step.localId }"
           data-testid="approval-template-step-row"
         >
           <div class="template-authoring__item-toolbar">
@@ -969,6 +1004,14 @@
             <div>
               <el-button size="small" :disabled="readOnly || index === 0" @click="moveStep(index, -1)">上移</el-button>
               <el-button size="small" :disabled="readOnly || index === draft.steps.length - 1" @click="moveStep(index, 1)">下移</el-button>
+              <el-button
+                size="small"
+                :disabled="readOnly"
+                :data-testid="`approval-step-insert-after-${step.localId}`"
+                @click="insertStep(index)"
+              >
+                在下方插入步骤
+              </el-button>
               <el-button size="small" type="danger" :disabled="readOnly || draft.steps.length === 1" @click="removeStep(index)">删除</el-button>
             </div>
           </div>
@@ -1416,6 +1459,7 @@ import { createRoutePreviewController } from '../../approvals/routePreviewContro
 import { routePreviewAssigneeSummary } from '../../approvals/routePreviewSummary'
 import { describeRoutePreviewError } from '../../approvals/routePreviewErrors'
 import { computeRequesterPreviewFields } from '../../approvals/requesterPreviewFields'
+import { buildLinearStepSpine, type LinearStepSpineChip } from '../../approvals/linearStepSpine'
 import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
 import {
   buildApprovalGraph,
@@ -1429,6 +1473,7 @@ import {
   DETAIL_LEAF_FIELD_TYPES,
   draftFromTemplate,
   graphReadOnlyReason,
+  insertStepAt,
   parseIdsText,
   stepFieldAccess,
   setStepFieldPermission,
@@ -1523,6 +1568,22 @@ const canSave = computed(() => canManageTemplates.value && !unsupportedReason.va
 // G-1 read-only structured render of a preserved complex graph: a per-node summary of the
 // config the v1 editor doesn't yet author, so authors can SEE the flow they're preserving.
 const graphPreviewNodes = computed<ApprovalNode[]>(() => draft.value.preservedGraph?.nodes ?? [])
+
+// G-B2-06 read-only flow spine for a LINEAR template (see `linearStepSpine.ts`) — 发起人 → 步骤1 →
+// 步骤2 → …, derived straight from `draft.value.steps`. Never used for a preserved complex graph
+// (rendered instead, unchanged, via `graphPreviewNodes` above): the view gates it on `!graphReadOnly`.
+const linearStepSpine = computed<LinearStepSpineChip[]>(() => buildLinearStepSpine(draft.value.steps))
+// Read-only-spine → step-card affordance: clicking a step chip briefly highlights (and scrolls to)
+// its matching card below. Purely cosmetic — no editing happens on the spine itself.
+const highlightedStepLocalId = ref<string | null>(null)
+let highlightStepTimer: ReturnType<typeof setTimeout> | undefined
+function focusStepCard(chip: LinearStepSpineChip): void {
+  if (chip.role !== 'step') return
+  highlightedStepLocalId.value = chip.key
+  if (highlightStepTimer) clearTimeout(highlightStepTimer)
+  highlightStepTimer = setTimeout(() => { highlightedStepLocalId.value = null }, 1600)
+  document.getElementById(`approval-step-card-${chip.key}`)?.scrollIntoView?.({ behavior: 'smooth', block: 'center' })
+}
 
 const NODE_TYPE_LABELS: Record<string, string> = {
   start: '发起',
@@ -2154,6 +2215,13 @@ function addStep() {
   draft.value.steps = [...draft.value.steps, createEmptyStepDraft(draft.value.steps.length + 1)]
 }
 
+// G-B2-06 — insert (not just append): a fresh blank step lands right after `index`, and any
+// STILL-DEFAULT-named trailing step is renumbered to stay self-consistent (see `insertStepAt`'s
+// own doc in templateAuthoring.ts for exactly what counts as "still default").
+function insertStep(index: number) {
+  draft.value.steps = insertStepAt(draft.value.steps, index)
+}
+
 function removeStep(index: number) {
   if (draft.value.steps.length === 1) return
   draft.value.steps = draft.value.steps.filter((_, i) => i !== index)
@@ -2405,6 +2473,7 @@ watch(isDraftDirty, (dirty) => {
 
 onUnmounted(() => {
   window.onbeforeunload = null
+  if (highlightStepTimer) clearTimeout(highlightStepTimer)
 })
 </script>
 
@@ -2513,10 +2582,71 @@ onUnmounted(() => {
   padding: 14px;
   border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .template-authoring__item + .template-authoring__item {
   margin-top: 12px;
+}
+
+/* G-B2-06 — brief highlight when a step card is reached via a flow-spine chip click. */
+.template-authoring__item--highlighted {
+  border-color: var(--el-color-primary);
+  box-shadow: 0 0 0 2px var(--el-color-primary-light-5);
+}
+
+/* G-B2-06 read-only linear flow spine. */
+.template-authoring__spine {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: var(--el-fill-color-light);
+}
+
+.template-authoring__spine-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 6px 10px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  background: var(--ms-bg-card);
+  color: var(--el-text-color-primary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.template-authoring__spine-chip:hover {
+  border-color: var(--el-color-primary);
+}
+
+.template-authoring__spine-chip--requester {
+  background: var(--el-fill-color);
+  cursor: default;
+}
+
+.template-authoring__spine-chip--requester:hover {
+  border-color: var(--el-border-color);
+}
+
+.template-authoring__spine-chip--unresolved {
+  border-style: dashed;
+  border-color: var(--el-color-warning);
+}
+
+.template-authoring__spine-chip-source {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+
+.template-authoring__spine-arrow {
+  color: var(--el-text-color-secondary);
 }
 
 .template-authoring__item-toolbar {

--- a/apps/web/tests/approval-template-authoring-linear-step-spine.test.ts
+++ b/apps/web/tests/approval-template-authoring-linear-step-spine.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLinearStepSpine,
+  isStepSourceResolvable,
+  REQUESTER_SPINE_KEY,
+  type LinearStepSpineChip,
+} from '../src/approvals/linearStepSpine'
+import {
+  createEmptyStepDraft,
+  insertStepAt,
+  isDefaultStepName,
+  type ApprovalStepDraft,
+} from '../src/approvals/templateAuthoring'
+
+// G-B2-06 — 线性模板流程脊柱 + 步骤间插入. PURE-LOGIC tests only (no .vue mount, no Element Plus),
+// mirroring every other approvals/*.ts helper spec in this suite. Covers:
+//   1. buildLinearStepSpine: one human-readable summary per sourceKind, an honest placeholder for
+//      an unconfigured source, a blank-name step falling back to its positional default label, and
+//      the requester chip always leading regardless of step count.
+//   2. insertStepAt: middle insertion renumbers only STILL-DEFAULT-named trailing steps, leaves
+//      author-renamed steps untouched, and end/empty-array edges behave like append.
+
+function makeStep(overrides: Partial<ApprovalStepDraft> = {}, index = 1): ApprovalStepDraft {
+  return { ...createEmptyStepDraft(index), ...overrides }
+}
+
+describe('linearStepSpine — buildLinearStepSpine', () => {
+  it('leads with the requester chip even when there are no steps', () => {
+    const spine = buildLinearStepSpine([])
+    expect(spine).toHaveLength(1)
+    expect(spine[0]).toMatchObject({
+      key: REQUESTER_SPINE_KEY,
+      role: 'requester',
+      label: '发起人',
+      sourceSummary: '',
+      resolvable: true,
+      stepIndex: null,
+    })
+  })
+
+  it('leads with the requester chip regardless of how many steps follow', () => {
+    const steps = [makeStep({}, 1), makeStep({}, 2), makeStep({}, 3)]
+    const spine = buildLinearStepSpine(steps)
+    expect(spine[0].role).toBe('requester')
+    expect(spine).toHaveLength(4)
+    expect(spine.slice(1).every((chip) => chip.role === 'step')).toBe(true)
+  })
+
+  it('gives every sourceKind its human-readable summary, matching assigneeSourceSummary wording', () => {
+    const cases: Array<{ step: Partial<ApprovalStepDraft>; expected: string }> = [
+      { step: { sourceKind: 'static_user', idsText: 'u1, u2' }, expected: '指定用户：u1、u2' },
+      { step: { sourceKind: 'static_role', idsText: 'mgr' }, expected: '指定角色：mgr' },
+      { step: { sourceKind: 'requester' }, expected: '发起人' },
+      { step: { sourceKind: 'direct_manager' }, expected: '直属上级' },
+      { step: { sourceKind: 'dept_head' }, expected: '部门主管' },
+      { step: { sourceKind: 'continuous_managers', levels: 3 }, expected: '连续多级上级（3 级）' },
+      { step: { sourceKind: 'manager_at_level', level: 2 }, expected: '指定层级上级（第 2 级）' },
+      { step: { sourceKind: 'form_field_user', fieldId: 'applicant' }, expected: '表单用户字段：applicant' },
+    ]
+    for (const { step, expected } of cases) {
+      const [, chip] = buildLinearStepSpine([makeStep(step)])
+      expect(chip.sourceSummary).toBe(expected)
+      expect(chip.resolvable).toBe(true)
+    }
+  })
+
+  it('marks an unconfigured static_user/static_role source unresolvable with the shared （无） placeholder', () => {
+    const [, userChip] = buildLinearStepSpine([makeStep({ sourceKind: 'static_user', idsText: '' })])
+    expect(userChip.resolvable).toBe(false)
+    expect(userChip.sourceSummary).toBe('指定用户：（无）')
+
+    const [, roleChip] = buildLinearStepSpine([makeStep({ sourceKind: 'static_role', idsText: '   ' })])
+    expect(roleChip.resolvable).toBe(false)
+    expect(roleChip.sourceSummary).toBe('指定角色：（无）')
+  })
+
+  it('gives form_field_user an honest placeholder when no field is chosen (assigneeSourceSummary itself has none)', () => {
+    const [, chip] = buildLinearStepSpine([makeStep({ sourceKind: 'form_field_user', fieldId: '' })])
+    expect(chip.resolvable).toBe(false)
+    expect(chip.sourceSummary).toBe('表单用户字段：（未选择）')
+  })
+
+  it('falls back to the positional default label for a blank step name (空步骤)', () => {
+    const steps = [makeStep({ name: '   ' }, 1), makeStep({ name: '' }, 2)]
+    const spine = buildLinearStepSpine(steps)
+    expect(spine[1].label).toBe('审批人 1')
+    expect(spine[2].label).toBe('审批人 2')
+  })
+
+  it('uses the author-given name verbatim when present', () => {
+    const [, chip] = buildLinearStepSpine([makeStep({ name: '部门经理审批' })])
+    expect(chip.label).toBe('部门经理审批')
+  })
+
+  it('keys step chips by localId so a caller can scroll/highlight the matching card', () => {
+    const step = makeStep({})
+    const [, chip] = buildLinearStepSpine([step])
+    expect(chip.key).toBe(step.localId)
+    expect(chip.stepIndex).toBe(1)
+  })
+})
+
+describe('linearStepSpine — isStepSourceResolvable', () => {
+  it('is false only for the three ids/field-dependent kinds when unset', () => {
+    expect(isStepSourceResolvable(makeStep({ sourceKind: 'static_user', idsText: '' }))).toBe(false)
+    expect(isStepSourceResolvable(makeStep({ sourceKind: 'static_role', idsText: '' }))).toBe(false)
+    expect(isStepSourceResolvable(makeStep({ sourceKind: 'form_field_user', fieldId: '' }))).toBe(false)
+    expect(isStepSourceResolvable(makeStep({ sourceKind: 'requester' }))).toBe(true)
+    expect(isStepSourceResolvable(makeStep({ sourceKind: 'direct_manager' }))).toBe(true)
+    expect(isStepSourceResolvable(makeStep({ sourceKind: 'dept_head' }))).toBe(true)
+    expect(isStepSourceResolvable(makeStep({ sourceKind: 'continuous_managers' }))).toBe(true)
+    expect(isStepSourceResolvable(makeStep({ sourceKind: 'manager_at_level' }))).toBe(true)
+  })
+})
+
+describe('templateAuthoring — insertStepAt', () => {
+  it('inserts a fresh step right after the given index', () => {
+    const steps = [makeStep({ name: '审批人 1' }, 1), makeStep({ name: '审批人 2' }, 2)]
+    const next = insertStepAt(steps, 0)
+    expect(next).toHaveLength(3)
+    expect(next[0].localId).toBe(steps[0].localId)
+    expect(next[1].localId).not.toBe(steps[0].localId)
+    expect(next[1].localId).not.toBe(steps[1].localId)
+    expect(next[2].localId).toBe(steps[1].localId)
+  })
+
+  it('renumbers the still-default name of a trailing step so numbering stays self-consistent', () => {
+    const steps = [makeStep({ name: '审批人 1' }, 1), makeStep({ name: '审批人 2' }, 2)]
+    const next = insertStepAt(steps, 0)
+    expect(next.map((s) => s.name)).toEqual(['审批人 1', '审批人 2', '审批人 3'])
+  })
+
+  it('never overwrites a step the author has renamed away from the default', () => {
+    const steps = [
+      makeStep({ name: '审批人 1' }, 1),
+      makeStep({ name: '财务复核' }, 2),
+      makeStep({ name: '审批人 3' }, 3),
+    ]
+    const next = insertStepAt(steps, 0)
+    // '财务复核' is untouched; '审批人 3' (still-default for its OLD position 3) becomes '审批人 4'.
+    expect(next.map((s) => s.name)).toEqual(['审批人 1', '审批人 2', '财务复核', '审批人 4'])
+  })
+
+  it('inserting at the last index behaves like an append', () => {
+    const steps = [makeStep({ name: '审批人 1' }, 1)]
+    const next = insertStepAt(steps, 0)
+    expect(next).toHaveLength(2)
+    expect(next[1].name).toBe('审批人 2')
+  })
+
+  it('inserting into an empty array yields a single fresh step', () => {
+    const next = insertStepAt([], 0)
+    expect(next).toHaveLength(1)
+    expect(next[0].name).toBe('审批人 1')
+  })
+
+  it('leaves the config of unrenamed later steps otherwise untouched (only .name may change)', () => {
+    const steps = [
+      makeStep({ name: '审批人 1' }, 1),
+      makeStep({ name: '审批人 2', sourceKind: 'static_role', idsText: 'mgr' }, 2),
+    ]
+    const next = insertStepAt(steps, 0)
+    const renamed = next[2]
+    expect(renamed.sourceKind).toBe('static_role')
+    expect(renamed.idsText).toBe('mgr')
+    expect(renamed.localId).toBe(steps[1].localId)
+  })
+})
+
+describe('templateAuthoring — isDefaultStepName', () => {
+  it('matches only the exact positional default', () => {
+    expect(isDefaultStepName('审批人 2', 2)).toBe(true)
+    expect(isDefaultStepName(' 审批人 2 ', 2)).toBe(true)
+    expect(isDefaultStepName('审批人 2', 3)).toBe(false)
+    expect(isDefaultStepName('财务复核', 2)).toBe(false)
+    expect(isDefaultStepName('', 2)).toBe(false)
+  })
+})
+
+// Type-only sanity: LinearStepSpineChip is importable/usable as a value type by view code.
+const _typeCheck: LinearStepSpineChip[] = []
+void _typeCheck


### PR DESCRIPTION
## 审计项 G-B2-06
> 画布地基已建但 v-if 只给复杂图；90% 用户只看到表单卡堆。**只读预览+插入，不做画布重写**

## 做了什么
### 1. 线性流程脊柱（只读）
线性模板步骤区加一条**只读**横向脊柱：`发起人 → 步骤1 → 步骤2 → …`，直接从 `draft.value.steps` 派生。每 chip = 步骤名（或 `审批人 N` 位置默认，与 buildApprovalGraph 同一 fallback）+ 审批人来源人话。**关键**：`sourceSummary` 复用**与复杂图只读预览同一个** `assigneeSourceSummary` humanizer → 线性/复杂措辞永不漂移。`form_field_user` 未选字段给显式占位（共享 humanizer 单独用会留裸冒号）。点 chip → 滚动+短暂高亮对应卡（纯装饰，timer onUnmounted 清）。复杂图分支不受影响——脊柱只给线性模板。

### 2. 步骤间插入
`insertStepAt(steps, index)`：在任意 index 后插入空步骤（不只末尾 addStep）。**序号自洽**：插入点之后、名字仍是旧位置默认 `审批人 <oldPos>` 的步骤才重排到新位置；作者改过名的**逐字保留**。moveStep/removeStep 不动。（UI 上是每行工具栏「在下方插入步骤」按钮，仿复杂图既有「下方插入审批」先例；不是浮在卡间的 + 控件——如需另说。）

## 明确不做（未触碰）
画布 / graphPreviewNodes / buildTemplatePayload / 保存 / 校验（除 steps 插入本身）。

## 验证
- 纯模块 `linearStepSpine.ts` + `insertStepAt`/`isDefaultStepName`，矩阵 16 例。**突变验证**：让 insertStepAt 恒重排（无视默认名）→「不覆盖已改名步骤」用例变红。
- 新 16/16 + authoring 套件；full CI-mirror filter **50 files / 755 tests** 绿；`vue-tsc` 0；style guard 83/83（token-only）。
- `approvalStaticPicker.spec.ts` 2 失败**先于本改动就红**（`directory.loadFormulaRoles`），stash 复核确认无关。

## 诚实注记
审计 line-76 的 sourceKind 列表漏了 `requester`（真实默认 sourceKind）——已正确处理，仅标注源文档不全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
