### PR TITLE
ci(web): always-on required-eligible web test gate（补 apps/web spec 从不进 required 的洞）

### DIFF
--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -1,0 +1,63 @@
+# Always-on web test gate — the missing required-eligible frontend check.
+#
+# The required `test (20.x)` job (plugin-tests.yml) only BUILDS apps/web; it never runs its vitest
+# specs. Web specs otherwise run only in the NON-required, path-filtered approval-web-guard /
+# multitable-web-guard — so a green PR did not mean any apps/web test passed.
+#
+# This job runs the curated, verified-stable union of those two guards' filters (104 files / 1537
+# tests, all green on main 2026-07-08) UNCONDITIONALLY — no path filter — so it can be added to
+# branch-protection required contexts WITHOUT the path-filtered-required footgun (a required check
+# that never triggers leaves PRs hanging forever). Job name is stable: `web-tests`.
+#
+# To make it required (owner action, after it proves green on a few real PRs):
+#   gh api -X PUT repos/zensgit/metasheet2/branches/main/protection/required_status_checks/contexts \
+#     --input - <<< '["web-tests"]'   # (append to the existing contexts, do not replace)
+name: Web Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+jobs:
+  web-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run the always-on web spec gate
+        run: bash apps/web/scripts/run-required-web-tests.sh

--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# G-CI (2026-07-08): the ALWAYS-ON, required-eligible web test gate.
+#
+# Why this exists: the required `test (20.x)` job only *builds* apps/web — it never runs its vitest
+# specs. Web specs otherwise run only in the NON-required, path-filtered approval-web-guard /
+# multitable-web-guard, so a green PR did not mean any frontend test passed. This script runs the
+# curated, verified-stable union of those two guards' filters UNCONDITIONALLY, so a single job can
+# be added to branch-protection required contexts without the path-filtered-required footgun
+# (a required check that never triggers leaves PRs hanging forever).
+#
+# Maintenance: when you add a web spec to approval-web-guard or multitable-web-guard, add it here
+# too (same two-point discipline). The 19 pre-existing red files (approvalStaticPicker,
+# approvalMobileDetailActions, several multitable-workbench/*, attendance/*, featureFlags,
+# k3WiseSetup, platform-app-launcher, …) are deliberately OUT of this set until fixed; broaden
+# toward full-suite-minus-quarantine once they are triaged.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec npx vitest run amountAutoSum approval-amount-in-words approval-assignee-source approval-center approval-common-template-presets approval-condition-summary approval-detail-field approval-e2e-lifecycle approval-e2e-permissions approval-field-visibility approval-form-draft approval-graph-layout approval-graph-summary approval-graph-topology-edit approval-inbox-auth-guard approval-number-field-props approval-prefill-from-snapshot approval-route-preview-controller approval-route-preview-summary approval-template-authoring-approval-node-edit approval-template-authoring-cc-edit approval-template-authoring-complex-node-config-allowlist approval-template-authoring-condition-edit approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-linear-step-spine approval-template-authoring-parallel-edit approval-upcoming-nodes approval-urge-button-state approvalCenterRemindBadge approvalCenterSourceFilter approvalCenterTable approvalCenterUnreadBadge approvalDelegationStatus approvalDelegationView approvalMobileI18n approvalMobileResponsive approvalTemplateAuthoring approvalTemplateCenterCategory automation-action-summary automation-recipes automation-save-block-reasons automation-target-sheet-options AutomationExecutionsView lineDerivation meta-filter-group meta-grid-table meta-toolbar-filter-builder multitable-automation-manager multitable-automation-rule-editor multitable-cell-renderer-person-inactive multitable-conditional-formatting multitable-conditional-rule multitable-config-history-modal multitable-config-revert-refresh multitable-field-manager multitable-field-visibility multitable-grid multitable-history-fe multitable-kanban-view multitable-person-picker multitable-record-permission-manager multitable-reorder-view-fields multitable-required-if multitable-reset-confirm-dialog multitable-reset-tsource-picker multitable-restore-batch-dialog multitable-restore-preview-dialog multitable-rollup-aggregation-fe multitable-sheet-cursor-state multitable-sheet-permission-manager multitable-trash-fe multitable-workbench-restore-wiring multitable-yjs-cell-editor multitable-yjs-scalar-cell myDelegationView newTodoPill pageShell parallelBranchRunsView requesterPreviewFields statusTag templateGalleryFilter ui-foundation-style-guard uiFoundationTexture useAutoSumTotal workflowHubView --reporter=dot


### PR DESCRIPTION
## 补齐缺失的「web 测试」required-eligible 闸门

**背景（贯穿本轮审批/自动化 UX 反复出现）**：required 的 `test (20.x)` 只 `build` apps/web，**从不跑其 vitest spec**。web spec 只在**非-required、path-filtered** 的 approval-web-guard / multitable-web-guard 里跑 → **绿 PR ≠ 任何前端测试通过**。

## 这个 PR 做什么
新增 `Web Tests` workflow（job 名 `web-tests`），**无 path filter**、跑两个 guard filter 的**去重并集**（**104 files / 1537 tests，main 上已验证全绿**）。filter 收在 `apps/web/scripts/run-required-web-tests.sh`（单一来源、本地可跑）。

**为什么无 path filter**：path-filtered 的 check 一旦设为 required，会让**不碰这些路径的 PR 永久挂起**（required check 从不触发）。所以 required-eligible 的闸门必须**每个 PR 都跑**。

**19 个先存红文件**（approvalStaticPicker / approvalMobileDetailActions / 多个 multitable-workbench / attendance / featureFlags / k3WiseSetup / platform-app-launcher 等）**刻意排除**，待各自修复后再纳入；后续可从「并集」放宽到「全量减隔离区」。

## 这是「把 web-spec gate 提进 required」的**使能件**（enabling piece）
本 PR 只加一个**加性、可回退**的绿 job，**不动 branch protection**。剩下两步是 **owner 分支保护操作**（见 workflow 头注释）：
1. 待本 job 在若干真实 PR 上稳定绿后，把 `web-tests` **追加**进 required contexts：
   `gh api -X POST repos/zensgit/metasheet2/branches/main/protection/required_status_checks/contexts -f 'contexts[]=web-tests'`（追加，勿覆盖既有 5 项）
2. 启用 merge queue（治本本轮反复的 BEHIND/rebase/filter-line 冲突成本）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
