### PR TITLE
fix(collab): fail closed Yjs sync for field-masked actors

### DIFF
--- a/packages/core-backend/src/collab/yjs-field-read-access.ts
+++ b/packages/core-backend/src/collab/yjs-field-read-access.ts
@@ -1,0 +1,57 @@
+import {
+  deriveFieldPermissions,
+  type MultitableCapabilities as FieldPermissionCapabilities,
+} from '../multitable/permission-derivation'
+import {
+  loadFieldPermissionScopeMap,
+  type QueryFn,
+} from '../multitable/permission-service'
+
+type YjsFieldRow = {
+  id: string
+  type: string
+  property: unknown
+}
+
+function normalizeFieldRow(row: YjsFieldRow): {
+  id: string
+  type: string
+  property: Record<string, unknown>
+} {
+  const property = row.property && typeof row.property === 'object' && !Array.isArray(row.property)
+    ? row.property as Record<string, unknown>
+    : {}
+  return {
+    id: String(row.id),
+    type: String(row.type),
+    property,
+  }
+}
+
+/**
+ * Yjs sync sends a whole record-level Y.Doc, not a field-scoped payload. If the
+ * actor cannot read even one field on the sheet, serving that shared document
+ * would let denied field values travel over the realtime channel. In that case
+ * callers must fail closed and let the client fall back to REST reads, where
+ * field-level masking is already applied per response.
+ */
+export async function canReadEveryYjsFieldForUser(
+  query: QueryFn,
+  sheetId: string,
+  userId: string,
+  capabilities: Pick<FieldPermissionCapabilities, 'canEditRecord' | 'canCreateRecord'>,
+): Promise<boolean> {
+  if (!sheetId || !userId) return false
+
+  const fieldResult = await query(
+    'SELECT id, type, property FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC',
+    [sheetId],
+  )
+  const fields = (fieldResult.rows as YjsFieldRow[]).map(normalizeFieldRow)
+  if (fields.length === 0) return true
+  if (fields.some((field) => field.property.permissionHidden === true)) return false
+
+  const fieldScopeMap = await loadFieldPermissionScopeMap(query, sheetId, userId)
+  const fieldPermissions = deriveFieldPermissions(fields, capabilities, { fieldScopeMap })
+  return fields.every((field) => fieldPermissions[field.id]?.visible !== false)
+}

--- a/packages/core-backend/src/collab/yjs-websocket-adapter.ts
+++ b/packages/core-backend/src/collab/yjs-websocket-adapter.ts
@@ -17,7 +17,7 @@ const MSG_SYNC = 0
 export type YjsAuthChecker = (
   userId: string,
   recordId: string,
-) => Promise<{ canRead: boolean; canWrite: boolean } | null>
+) => Promise<{ canRead: boolean; canWrite: boolean; canReadAllFields?: boolean } | null>
 
 /**
  * Callback to verify a JWT token and return the trusted userId.
@@ -199,6 +199,13 @@ export class YjsWebSocketAdapter {
             return
           }
           if (!access.canRead) {
+            socket.emit('yjs:error', { recordId, code: 'FORBIDDEN', message: 'No read access' })
+            return
+          }
+          // Yjs sync is record-wide. A field-masked actor cannot safely receive
+          // a partial doc here, so the realtime path fails closed and the client
+          // falls back to REST reads where field masking is response-scoped.
+          if (access.canReadAllFields === false) {
             socket.emit('yjs:error', { recordId, code: 'FORBIDDEN', message: 'No read access' })
             return
           }

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2311,6 +2311,7 @@ export class MetaSheetServer {
       const { YjsSyncService } = await import('./collab/yjs-sync-service')
       const { YjsWebSocketAdapter } = await import('./collab/yjs-websocket-adapter')
       const { YjsRecordBridge } = await import('./collab/yjs-record-bridge')
+      const { canReadEveryYjsFieldForUser } = await import('./collab/yjs-field-read-access')
       const { RecordWriteService } = await import('./multitable/record-write-service')
       const { loadSheetMemberUserIdSet, loadFieldPermissionScopeMap } = await import('./multitable/permission-service')
       const { createYjsInvalidationPostCommitHook } = await import('./multitable/post-commit-hooks')
@@ -2380,8 +2381,11 @@ export class MetaSheetServer {
               && (await isRecordReadDeniedForUser(pool.query.bind(pool), sheetId, recordId, userId))) {
               return { canRead: false, canWrite: false }
             }
+            const canReadAllFields = capabilities.canRead
+              ? await canReadEveryYjsFieldForUser(pool.query.bind(pool), sheetId, userId, capabilities)
+              : false
             const canWrite = canWriteRecord(capabilities, sheetScope, isAdminRole, userId, createdBy)
-            return { canRead: capabilities.canRead, canWrite }
+            return { canRead: capabilities.canRead, canWrite, canReadAllFields }
           } catch {
             return null
           }

--- a/packages/core-backend/tests/unit/yjs-awareness.test.ts
+++ b/packages/core-backend/tests/unit/yjs-awareness.test.ts
@@ -106,6 +106,13 @@ describe('Yjs awareness presence socket protocol', () => {
       return token.slice('token-'.length)
     })
     adapter.setAuthChecker(async (userId, recordId) => {
+      if (recordId === 'rec_masked') {
+        return {
+          canRead: true,
+          canWrite: userId !== 'user_readonly',
+          canReadAllFields: false,
+        }
+      }
       if (recordId !== 'rec_presence') return null
       return {
         canRead: true,
@@ -194,6 +201,30 @@ describe('Yjs awareness presence socket protocol', () => {
         recordId: 'rec_presence',
         code: 'FORBIDDEN',
       })
+    } finally {
+      client.disconnect()
+    }
+  })
+
+  it('rejects record-wide Yjs sync when the actor cannot read every field', async () => {
+    const client = await connectClient(baseUrl, 'token-user_alice')
+
+    try {
+      const error = waitForEvent(client, 'yjs:error', (payload: any) => (
+        payload.recordId === 'rec_masked'
+        && payload.code === 'FORBIDDEN'
+      ))
+      const noSync = waitForNoEvent(client, 'yjs:message')
+      const noPresence = waitForNoEvent(client, 'yjs:presence')
+
+      client.emit('yjs:subscribe', { recordId: 'rec_masked' })
+
+      await expect(error).resolves.toMatchObject({
+        recordId: 'rec_masked',
+        code: 'FORBIDDEN',
+      })
+      await expect(noSync).resolves.toBeUndefined()
+      await expect(noPresence).resolves.toBeUndefined()
     } finally {
       client.disconnect()
     }

--- a/packages/core-backend/tests/unit/yjs-field-read-access.test.ts
+++ b/packages/core-backend/tests/unit/yjs-field-read-access.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+import { canReadEveryYjsFieldForUser } from '../../src/collab/yjs-field-read-access'
+import type { QueryFn } from '../../src/multitable/permission-service'
+
+const capabilities = {
+  canEditRecord: false,
+  canCreateRecord: false,
+}
+
+function makeQuery(input: {
+  fields: Array<{ id: string; type?: string; property?: Record<string, unknown> }>
+  fieldScopes?: Array<{ field_id: string; visible: boolean; read_only: boolean }>
+}): QueryFn {
+  return vi.fn(async (sql: string) => {
+    if (sql.includes('FROM meta_fields')) {
+      return {
+        rows: input.fields.map((field, index) => ({
+          id: field.id,
+          type: field.type ?? 'string',
+          property: field.property ?? {},
+          order: index + 1,
+        })),
+      }
+    }
+    if (sql.includes('FROM field_permissions')) {
+      return { rows: input.fieldScopes ?? [] }
+    }
+    return { rows: [] }
+  }) as unknown as QueryFn
+}
+
+describe('canReadEveryYjsFieldForUser', () => {
+  it('allows Yjs when every field is readable', async () => {
+    const query = makeQuery({
+      fields: [
+        { id: 'fld_public' },
+        { id: 'fld_readonly' },
+      ],
+      fieldScopes: [
+        { field_id: 'fld_readonly', visible: true, read_only: true },
+      ],
+    })
+
+    await expect(canReadEveryYjsFieldForUser(query, 'sheet_1', 'user_1', capabilities))
+      .resolves.toBe(true)
+  })
+
+  it('fails closed when a subject-scoped field permission hides any field', async () => {
+    const query = makeQuery({
+      fields: [
+        { id: 'fld_public' },
+        { id: 'fld_secret' },
+      ],
+      fieldScopes: [
+        { field_id: 'fld_secret', visible: false, read_only: false },
+      ],
+    })
+
+    await expect(canReadEveryYjsFieldForUser(query, 'sheet_1', 'user_1', capabilities))
+      .resolves.toBe(false)
+  })
+
+  it('fails closed when a static hidden field exists on the sheet', async () => {
+    const query = makeQuery({
+      fields: [
+        { id: 'fld_public' },
+        { id: 'fld_static_secret', property: { hidden: true } },
+      ],
+    })
+
+    await expect(canReadEveryYjsFieldForUser(query, 'sheet_1', 'user_1', capabilities))
+      .resolves.toBe(false)
+  })
+
+  it('fails closed for the Yjs bridge permissionHidden marker', async () => {
+    const query = makeQuery({
+      fields: [
+        { id: 'fld_public' },
+        { id: 'fld_permission_hidden', property: { permissionHidden: true } },
+      ],
+    })
+
+    await expect(canReadEveryYjsFieldForUser(query, 'sheet_1', 'user_1', capabilities))
+      .resolves.toBe(false)
+  })
+
+  it('fails closed without a trusted user or sheet id', async () => {
+    const query = makeQuery({ fields: [{ id: 'fld_public' }] })
+
+    await expect(canReadEveryYjsFieldForUser(query, '', 'user_1', capabilities))
+      .resolves.toBe(false)
+    await expect(canReadEveryYjsFieldForUser(query, 'sheet_1', '', capabilities))
+      .resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add a Yjs read-access check that disables record-wide realtime sync when the actor cannot read every field on the sheet.
- Wire the check into the production Yjs auth gate before a socket joins the record room or receives sync data.
- Add regression tests for the field-read guard and the socket-level fail-closed behavior.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/yjs-field-read-access.test.ts tests/unit/yjs-awareness.test.ts
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/yjs-field-read-access.test.ts tests/unit/yjs-awareness.test.ts tests/unit/yjs-sync-seed.test.ts tests/unit/yjs-hardening.test.ts tests/unit/yjs-rest-invalidation.test.ts
- pnpm --filter @metasheet/core-backend type-check
- git diff --check

## Notes
- Scoped to the Yjs realtime read surface. No REST route, write path, comment, attachment, or permission schema changes.
- The realtime path fails closed and lets clients fall back to REST reads, where response-scoped field masking already applies.
