### PR TITLE
fix(comments): enforce row-level read-deny on comment surfaces

### DIFF
--- a/packages/core-backend/src/di/identifiers.ts
+++ b/packages/core-backend/src/di/identifiers.ts
@@ -55,6 +55,7 @@ export interface ICollabService {
   initialize(httpServer: HttpServer): void;
   setTokenVerifier(verifier: (token: string) => Promise<string | null>): void;
   setSheetRoomAuthChecker(checker: (input: { sheetId: string; userId: string; socketId: string }) => Promise<boolean>): void;
+  setCommentRoomAuthChecker(checker: (input: { spreadsheetId: string; rowId?: string; userId: string; socketId: string }) => Promise<boolean>): void;
   broadcast(event: string, data: unknown): void;
   broadcastTo(room: string, event: string, data: unknown): void;
   sendTo(userId: string, event: string, data: unknown): void;
@@ -187,6 +188,12 @@ export interface CommentQueryOptions {
      * reaction summary. Omitted → `reactedByMe` is false for all reactions.
      */
     viewerId?: string;
+    /**
+     * Internal row-level read-deny filter. Route/service callers pass row IDs the
+     * actor cannot read; comment queries must exclude them before counting or
+     * paging. This is not a public API query parameter.
+     */
+    excludeRowIds?: string[];
 }
 
 /** Aggregated emoji-reaction summary attached to a comment (B6). */
@@ -376,6 +383,7 @@ export interface CommentUnreadSummary {
 }
 
 export interface ICommentService {
+    setCommentTargetReadChecker(checker: (input: { spreadsheetId: string; rowId: string; userId: string }) => Promise<boolean>): void;
     /**
      * Create a comment.
      *
@@ -423,9 +431,10 @@ export interface ICommentService {
       spreadsheetId: string,
       rowIds?: string[],
       mentionUserId?: string,
+      excludeRowIds?: string[],
     ): Promise<{ items: CommentPresenceSummaryRecord[]; total: number }>;
-    getMentionSummary(spreadsheetId: string, mentionUserId: string): Promise<CommentMentionSummary>;
-    markMentionsRead(spreadsheetId: string, userId: string): Promise<void>;
+    getMentionSummary(spreadsheetId: string, mentionUserId: string, excludeRowIds?: string[]): Promise<CommentMentionSummary>;
+    markMentionsRead(spreadsheetId: string, userId: string, excludeRowIds?: string[]): Promise<void>;
     resolveComment(commentId: string): Promise<void>;
     /**
      * Mark every unread comment in a spreadsheet as read for the given user.
@@ -433,7 +442,7 @@ export interface ICommentService {
      *
      * @returns The number of comments that were newly marked as read.
      */
-    markAllCommentsRead(spreadsheetId: string, userId: string): Promise<number>;
+    markAllCommentsRead(spreadsheetId: string, userId: string, excludeRowIds?: string[]): Promise<number>;
     /**
      * Return comment presence summary, optionally enriched with current room
      * viewers when `includeViewers` is true.
@@ -443,6 +452,7 @@ export interface ICommentService {
       rowIds?: string[],
       mentionUserId?: string,
       includeViewers?: boolean,
+      excludeRowIds?: string[],
     ): Promise<{ items: CommentPresenceSummaryRecord[]; total: number; viewers?: CommentPresenceViewer[] }>;
 }
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -13,7 +13,7 @@ import crypto from 'crypto'
 import { EventEmitter } from 'eventemitter3'
 import { Injector } from '@wendellhu/redi' // IoC Container
 import { createContainer } from './di/container'
-import { IConfigService, ILogger, ICollabService, ICoreAPI, IPluginLoader, ICollectionManager, IPLMAdapter, IAthenaAdapter, IDedupCADAdapter, ICADMLAdapter, IVisionAdapter, IFormulaService } from './di/identifiers'
+import { IConfigService, ILogger, ICollabService, ICoreAPI, IPluginLoader, ICollectionManager, IPLMAdapter, IAthenaAdapter, IDedupCADAdapter, ICADMLAdapter, IVisionAdapter, IFormulaService, ICommentService } from './di/identifiers'
 import { PluginLoader, type LoadedPlugin } from './core/plugin-loader'
 import { Logger, setLogContext } from './core/logger'
 import {
@@ -65,6 +65,7 @@ import {
   type MultitableRecordsQueryFn,
 } from './multitable/records'
 import { resolveSheetCapabilitiesForUser } from './multitable/sheet-capabilities'
+import { isRecordReadDeniedForUser, loadRowLevelReadDenyEnabled } from './multitable/permission-service'
 import {
   assertPluginOwnsObject,
   assertPluginOwnsSheet,
@@ -2292,6 +2293,44 @@ export class MetaSheetServer {
             userId,
           )
           return capabilities.canRead
+        } catch {
+          return false
+        }
+      })
+      collabService.setCommentRoomAuthChecker(async ({ spreadsheetId, rowId, userId }) => {
+        try {
+          const pool = poolManager.get()
+          const query = pool.query.bind(pool)
+          const { capabilities, isAdminRole } = await resolveSheetCapabilitiesForUser(
+            query,
+            spreadsheetId,
+            userId,
+          )
+          if (!capabilities.canRead) return false
+          if (isAdminRole) return true
+          if (rowId) {
+            return !(await isRecordReadDeniedForUser(query, spreadsheetId, rowId, userId))
+          }
+          // Sheet-wide comment rooms receive unfilterable full-comment broadcasts.
+          // Under row-level deny, non-admin users must subscribe to row rooms only.
+          return !(await loadRowLevelReadDenyEnabled(query, spreadsheetId))
+        } catch {
+          return false
+        }
+      })
+      const commentService = this.injector.get(ICommentService)
+      commentService.setCommentTargetReadChecker(async ({ spreadsheetId, rowId, userId }) => {
+        try {
+          const pool = poolManager.get()
+          const query = pool.query.bind(pool)
+          const { capabilities, isAdminRole } = await resolveSheetCapabilitiesForUser(
+            query,
+            spreadsheetId,
+            userId,
+          )
+          if (!capabilities.canRead) return false
+          if (isAdminRole) return true
+          return !(await isRecordReadDeniedForUser(query, spreadsheetId, rowId, userId))
         } catch {
           return false
         }

--- a/packages/core-backend/src/routes/comments.ts
+++ b/packages/core-backend/src/routes/comments.ts
@@ -9,7 +9,7 @@ import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
 import { apiTokenWriteRateLimit } from '../middleware/rate-limiter'
 import { buildOapiAuditContext, oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
 import { poolManager } from '../integration/db/connection-pool'
-import { resolveSheetReadableCapabilities } from '../multitable/permission-service'
+import { loadDeniedRecordIds, loadRowLevelReadDenyEnabled, resolveSheetReadableCapabilities } from '../multitable/permission-service'
 import {
   CommentAccessError,
   CommentConflictError,
@@ -120,7 +120,8 @@ function respondCommentError(res: Response, error: unknown, fallbackMessage: str
  * sheet, so the comments surface carries no existence oracle beyond what the interactive read path
  * already exposes. Fail-closed (a resolver throw propagates to the route catch → 500, never a serve).
  *
- * Every gated call site is `if (!(await ensureSheetReadable(req, res, spreadsheetId))) return`.
+ * Every gated call site resolves `resolveCommentReadContext(req, res, spreadsheetId)` and returns when it
+ * fails. That context carries both sheet-read and row-deny state for read surfaces.
  *
  * SCOPE: this gates the routes that take an explicit `spreadsheetId`/`containerId` (the enumerable,
  * attacker-supplied surface — list/summary/presence/mention-candidates/mention-summary read + create/
@@ -129,14 +130,40 @@ function respondCommentError(res: Response, error: unknown, fallbackMessage: str
  * sheet-id lookup) and the user-scoped cross-sheet `inbox`/`unread-count` aggregates (would need result
  * filtering by the actor's readable-sheet set, not a single-sheet 403).
  */
-async function ensureSheetReadable(req: Request, res: Response, spreadsheetId: string): Promise<boolean> {
+type CommentReadContext = {
+  userId: string
+  deniedRowIds: Set<string>
+}
+
+async function resolveCommentReadContext(req: Request, res: Response, spreadsheetId: string): Promise<CommentReadContext | null> {
   const pool = poolManager.get()
-  const { capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), spreadsheetId)
+  const query = pool.query.bind(pool)
+  const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, spreadsheetId)
   if (!capabilities.canRead) {
     res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Not permitted to access comments on this sheet' } })
-    return false
+    return null
   }
-  return true
+
+  const deniedRowIds = new Set<string>()
+  if (!access.isAdminRole && await loadRowLevelReadDenyEnabled(query, spreadsheetId)) {
+    for (const rowId of await loadDeniedRecordIds(query, spreadsheetId, access.userId)) {
+      deniedRowIds.add(rowId)
+    }
+  }
+  return { userId: access.userId || getUserId(req), deniedRowIds }
+}
+
+function isRowDenied(context: CommentReadContext, rowId?: string): boolean {
+  return typeof rowId === 'string' && rowId.trim().length > 0 && context.deniedRowIds.has(rowId.trim())
+}
+
+function deniedRows(context: CommentReadContext): string[] {
+  return [...context.deniedRowIds]
+}
+
+function filterDeniedRows(rowIds: string[] | undefined, context: CommentReadContext): string[] | undefined {
+  if (!rowIds) return undefined
+  return rowIds.filter((rowId) => !isRowDenied(context, rowId))
 }
 
 export function commentsRouter(injector?: Injector): Router {
@@ -185,7 +212,14 @@ export function commentsRouter(injector?: Injector): Router {
       if (!spreadsheetId) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'spreadsheetId or containerId required' } })
       }
-      if (!(await ensureSheetReadable(req, res, spreadsheetId))) return // G-8 sheet-visibility gate
+      const context = await resolveCommentReadContext(req, res, spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate
+      const requestedRowId = pickFirstNonEmpty(parsed.data.targetId, parsed.data.rowId)
+      if (isRowDenied(context, requestedRowId)) {
+        const limit = clampLimit(parsed.data.limit)
+        const offset = clampOffset(parsed.data.offset)
+        return res.json({ ok: true, data: { items: [], total: 0, limit, offset } })
+      }
       const limit = clampLimit(parsed.data.limit)
       const offset = clampOffset(parsed.data.offset)
       const options: CommentQueryOptions = {
@@ -197,7 +231,8 @@ export function commentsRouter(injector?: Injector): Router {
         limit,
         offset,
         // B6: lets getComments compute reactedByMe on each comment's reactions.
-        viewerId: getUserId(req),
+        viewerId: context.userId,
+        excludeRowIds: deniedRows(context),
       }
       const result = await commentService.getComments(spreadsheetId, options)
       return res.json({ ok: true, data: { items: result.items, total: result.total, limit, offset } })
@@ -223,7 +258,8 @@ export function commentsRouter(injector?: Injector): Router {
     }
 
     try {
-      if (!(await ensureSheetReadable(req, res, parsed.data.spreadsheetId))) return // G-8 sheet-visibility gate
+      const context = await resolveCommentReadContext(req, res, parsed.data.spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate
       const limit = clampLimit(parsed.data.limit)
       const result = await commentService.listMentionCandidates(parsed.data.spreadsheetId, {
         q: parsed.data.q,
@@ -296,8 +332,9 @@ export function commentsRouter(injector?: Injector): Router {
       if (!spreadsheetId) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'spreadsheetId or containerId required' } })
       }
-      if (!(await ensureSheetReadable(req, res, spreadsheetId))) return // G-8 sheet-visibility gate
-      const result = await commentService.getMentionSummary(spreadsheetId, getUserId(req))
+      const context = await resolveCommentReadContext(req, res, spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate
+      const result = await commentService.getMentionSummary(spreadsheetId, context.userId, deniedRows(context))
       return res.json({ ok: true, data: result })
     } catch (error) {
       logger.error('Failed to load mention summary', error as Error)
@@ -327,12 +364,14 @@ export function commentsRouter(injector?: Injector): Router {
       if (!spreadsheetId) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'spreadsheetId or containerId required' } })
       }
-      if (!(await ensureSheetReadable(req, res, spreadsheetId))) return // G-8 sheet-visibility gate
-      const rowIds = parsed.data.targetIds ?? parsed.data.rowIds
+      const context = await resolveCommentReadContext(req, res, spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate
+      const rowIds = filterDeniedRows(parsed.data.targetIds ?? parsed.data.rowIds, context)
       const result = await commentService.getCommentPresenceSummary(
         spreadsheetId,
         rowIds,
-        getUserId(req),
+        context.userId,
+        deniedRows(context),
       )
       return res.json({ ok: true, data: { items: result.items, total: result.total } })
     } catch (error) {
@@ -368,7 +407,11 @@ export function commentsRouter(injector?: Injector): Router {
       if (!rowId) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'rowId or targetId required' } })
       }
-      if (!(await ensureSheetReadable(req, res, spreadsheetId))) return // G-8 sheet-visibility gate (canComment && canRead)
+      const context = await resolveCommentReadContext(req, res, spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate (canComment && canRead)
+      if (isRowDenied(context, rowId)) {
+        return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Not permitted to comment on this record' } })
+      }
       const comment = await commentService.createComment({
         spreadsheetId,
         containerId: spreadsheetId,
@@ -379,7 +422,7 @@ export function commentsRouter(injector?: Injector): Router {
         content: parsed.data.content,
         parentId: parsed.data.parentId,
         mentions: parsed.data.mentions,
-        authorId: getUserId(req),
+        authorId: context.userId,
         oapiAudit: buildOapiAuditContext(req, 'create', 'comments:write'),
       })
       return res.status(201).json({ ok: true, data: { comment } })
@@ -495,8 +538,9 @@ export function commentsRouter(injector?: Injector): Router {
     }
 
     try {
-      if (!(await ensureSheetReadable(req, res, parsed.data.spreadsheetId))) return // G-8 sheet-visibility gate
-      await commentService.markMentionsRead(parsed.data.spreadsheetId, getUserId(req))
+      const context = await resolveCommentReadContext(req, res, parsed.data.spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate
+      await commentService.markMentionsRead(parsed.data.spreadsheetId, context.userId, deniedRows(context))
       return res.status(204).send()
     } catch (error) {
       logger.error('Failed to mark mentions read', error as Error)
@@ -546,7 +590,8 @@ export function commentsRouter(injector?: Injector): Router {
     }
 
     try {
-      if (!(await ensureSheetReadable(req, res, spreadsheetId))) return // G-8 sheet-visibility gate
+      const context = await resolveCommentReadContext(req, res, spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate
       const limit = clampLimit(parsed.data.limit ?? 10)
       const result = await commentService.listMentionCandidates(spreadsheetId, {
         q: parsed.data.q,
@@ -586,10 +631,11 @@ export function commentsRouter(injector?: Injector): Router {
     }
 
     try {
-      if (!(await ensureSheetReadable(req, res, spreadsheetId))) return // G-8 sheet-visibility gate
+      const context = await resolveCommentReadContext(req, res, spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate
       // Prefer body userId; fall back to authenticated user
-      const userId = parsed.data.userId?.trim() || getUserId(req)
-      const count = await commentService.markAllCommentsRead(spreadsheetId, userId)
+      const userId = parsed.data.userId?.trim() || context.userId
+      const count = await commentService.markAllCommentsRead(spreadsheetId, userId, deniedRows(context))
       return res.json({ ok: true, data: { markedRead: count } })
     } catch (error) {
       logger.error('Failed to mark all comments as read', error as Error)
@@ -623,15 +669,17 @@ export function commentsRouter(injector?: Injector): Router {
     }
 
     try {
-      if (!(await ensureSheetReadable(req, res, spreadsheetId))) return // G-8 sheet-visibility gate
+      const context = await resolveCommentReadContext(req, res, spreadsheetId)
+      if (!context) return // G-8 sheet-visibility gate
       const result = await commentService.getCommentPresenceSummaryWithViewers(
         spreadsheetId,
-        parsed.data.rowIds,
-        getUserId(req),
+        filterDeniedRows(parsed.data.rowIds, context),
+        context.userId,
         // OAPI-1 comments:read — a token request can read presence counts but MUST NOT egress viewer
         // identities (a creator-acting token shouldn't surface who-is-viewing). Force includeViewers=false
         // on the token path regardless of the query param; session requests are unchanged.
         req.apiTokenScopes ? false : (parsed.data.includeViewers ?? false),
+        deniedRows(context),
       )
       return res.json({ ok: true, data: result })
     } catch (error) {

--- a/packages/core-backend/src/services/CollabService.ts
+++ b/packages/core-backend/src/services/CollabService.ts
@@ -11,6 +11,12 @@ export function buildAuthenticatedUserRoom(userId: string): string {
 
 export type SocketTokenVerifier = (token: string) => Promise<string | null>
 export type SheetRoomAuthChecker = (input: { sheetId: string; userId: string; socketId: string }) => Promise<boolean>
+export type CommentRoomAuthChecker = (input: {
+  spreadsheetId: string
+  rowId?: string
+  userId: string
+  socketId: string
+}) => Promise<boolean>
 
 type AuthenticatedSocketData = {
   trustedUserId?: string | null
@@ -29,6 +35,7 @@ export class CollabService {
     return user?.id?.toString().trim() || null
   }
   private sheetRoomAuthChecker: SheetRoomAuthChecker = async () => false
+  private commentRoomAuthChecker: CommentRoomAuthChecker | null = null
 
   constructor(
     private logger: ILogger,
@@ -43,6 +50,10 @@ export class CollabService {
 
   setSheetRoomAuthChecker(checker: SheetRoomAuthChecker): void {
     this.sheetRoomAuthChecker = checker
+  }
+
+  setCommentRoomAuthChecker(checker: CommentRoomAuthChecker): void {
+    this.commentRoomAuthChecker = checker
   }
 
   private setupEventListeners() {
@@ -264,12 +275,10 @@ export class CollabService {
     this.emitSheetPresence(sheetId)
   }
 
-  // Shared auth+read gate for the comment rooms that expose a sheet's comment bodies (comment-sheet /
-  // comment-record broadcast full `comment:created` payloads): the socket must carry a verified identity
-  // AND that user must be allowed to read the target sheet — the SAME `sheetRoomAuthChecker` the live
-  // editing `join-sheet` path uses. Returns false (and denies the join) otherwise. Without this, any
-  // socket could join an arbitrary sheet's comment room and receive every comment body broadcast there.
-  private async authorizeCommentSheetAccess(socket: Socket, spreadsheetId: string): Promise<boolean> {
+  // Shared auth+read gate for comment rooms that expose comment bodies. Record rooms require row-level
+  // read access; sheet-wide rooms are delegated to `commentRoomAuthChecker` so row-deny-enabled sheets can
+  // fail closed instead of receiving unfilterable full-comment broadcasts.
+  private async authorizeCommentRoomAccess(socket: Socket, spreadsheetId: string, rowId?: string): Promise<boolean> {
     const userId = await this.resolveTrustedUserId(socket)
     if (!socket.connected) return false
     if (!userId) {
@@ -278,7 +287,11 @@ export class CollabService {
     }
     let allowed = false
     try {
-      allowed = await this.sheetRoomAuthChecker({ sheetId: spreadsheetId, userId, socketId: socket.id })
+      if (this.commentRoomAuthChecker) {
+        allowed = await this.commentRoomAuthChecker({ spreadsheetId, rowId, userId, socketId: socket.id })
+      } else {
+        allowed = await this.sheetRoomAuthChecker({ sheetId: spreadsheetId, userId, socketId: socket.id })
+      }
     } catch (error) {
       this.logger.warn('WebSocket comment room auth check failed', error instanceof Error ? error : undefined)
     }
@@ -298,7 +311,7 @@ export class CollabService {
   private async handleJoinCommentRecord(socket: Socket, payload: unknown): Promise<void> {
     const scope = this.parseCommentRecordScope(payload)
     if (!scope) return
-    if (!(await this.authorizeCommentSheetAccess(socket, scope.spreadsheetId))) return
+    if (!(await this.authorizeCommentRoomAccess(socket, scope.spreadsheetId, scope.rowId))) return
     if (!socket.connected) return
     const room = buildCommentRecordRoom(scope)
     socket.join(room)
@@ -309,7 +322,7 @@ export class CollabService {
   private async handleJoinCommentSheet(socket: Socket, payload: unknown): Promise<void> {
     const spreadsheetId = this.parseSheetScope(payload)
     if (!spreadsheetId) return
-    if (!(await this.authorizeCommentSheetAccess(socket, spreadsheetId))) return
+    if (!(await this.authorizeCommentRoomAccess(socket, spreadsheetId))) return
     if (!socket.connected) return
     const room = buildCommentSheetRoom({ spreadsheetId })
     socket.join(room)

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -164,6 +164,12 @@ type CommentActivityPayload = {
   authorId?: string
 }
 
+export type CommentTargetReadChecker = (input: {
+  spreadsheetId: string
+  rowId: string
+  userId: string
+}) => Promise<boolean>
+
 export class CommentService {
   static inject = [ICollabService, ILogger]
 
@@ -171,6 +177,12 @@ export class CommentService {
     private collabService: CollabService,
     private logger: ILogger,
   ) {}
+
+  private commentTargetReadChecker: CommentTargetReadChecker = async () => true
+
+  setCommentTargetReadChecker(checker: CommentTargetReadChecker): void {
+    this.commentTargetReadChecker = checker
+  }
 
   /**
    * Update a comment's content and optionally its mentions.
@@ -212,6 +224,7 @@ export class CommentService {
 
     for (const mentionUserId of mentions) {
       if (!mentionUserId || mentionUserId === normalizedUserId || previousMentions.includes(mentionUserId)) continue
+      if (!(await this.canNotifyUserAboutCommentTarget(comment.spreadsheetId, comment.rowId, mentionUserId))) continue
       this.collabService.sendTo(mentionUserId, 'comment:mention', {
         containerId: comment.containerId,
         targetId: comment.targetId,
@@ -373,6 +386,7 @@ export class CommentService {
     )
     for (const mentionUserId of mentions) {
       if (mentionUserId && mentionUserId !== data.authorId) {
+        if (!(await this.canNotifyUserAboutCommentTarget(data.spreadsheetId, data.rowId, mentionUserId))) continue
         this.collabService.sendTo(mentionUserId, 'comment:mention', createdPayload)
       }
     }
@@ -407,6 +421,10 @@ export class CommentService {
 
     if (typeof options?.resolved === 'boolean') {
       query = query.where('resolved', '=', options.resolved)
+    }
+    const excludedRowIds = this.normalizeRowIdList(options?.excludeRowIds)
+    if (excludedRowIds.length > 0) {
+      query = query.where('row_id', 'not in', excludedRowIds)
     }
 
     const limit = Math.min(200, Math.max(1, Number(options?.limit ?? 50)))
@@ -702,9 +720,11 @@ export class CommentService {
     spreadsheetId: string,
     rowIds?: string[],
     mentionUserId?: string,
+    excludeRowIds?: string[],
   ): Promise<{ items: CommentPresenceSummary[]; total: number }> {
     const normalizedRowIds = [...new Set((rowIds ?? []).map((rowId) => rowId.trim()).filter((rowId) => rowId.length > 0))]
     const normalizedMentionUserId = typeof mentionUserId === 'string' && mentionUserId.trim().length > 0 ? mentionUserId.trim() : null
+    const excludedRowIds = this.normalizeRowIdList(excludeRowIds)
 
     // Single combined query with conditional aggregation instead of two separate queries
     const mentionJsonb = normalizedMentionUserId
@@ -726,6 +746,9 @@ export class CommentService {
 
     if (normalizedRowIds.length > 0) {
       query = query.where('row_id', 'in', normalizedRowIds)
+    }
+    if (excludedRowIds.length > 0) {
+      query = query.where('row_id', 'not in', excludedRowIds)
     }
 
     const rows = (await query.groupBy(['row_id', 'field_id']).execute()) as Array<
@@ -784,6 +807,7 @@ export class CommentService {
   async getMentionSummary(
     spreadsheetId: string,
     mentionUserId: string,
+    excludeRowIds?: string[],
   ): Promise<{
     /** Canonical container alias for `spreadsheetId`. */
     containerId: string
@@ -804,6 +828,7 @@ export class CommentService {
     }>
   }> {
     const normalizedUserId = mentionUserId.trim()
+    const excludedRowIds = this.normalizeRowIdList(excludeRowIds)
     if (!normalizedUserId) {
       return {
         containerId: spreadsheetId,
@@ -816,7 +841,7 @@ export class CommentService {
       }
     }
 
-    const rows = (await db
+    let query = db
       .selectFrom('meta_comments as c')
       .leftJoin('meta_comment_reads as r', (join) => join.onRef('r.comment_id', '=', 'c.id').on('r.user_id', '=', normalizedUserId))
       .select([
@@ -829,8 +854,10 @@ export class CommentService {
       .where('c.resolved', '=', false)
       .where('c.author_id', '!=', normalizedUserId)
       .where(sql<boolean>`c.mentions @> ${JSON.stringify([normalizedUserId])}::jsonb`)
-      .groupBy(['c.row_id', 'c.field_id'])
-      .execute()) as MentionGroupedCountRow[]
+    if (excludedRowIds.length > 0) {
+      query = query.where('c.row_id', 'not in', excludedRowIds)
+    }
+    const rows = (await query.groupBy(['c.row_id', 'c.field_id']).execute()) as MentionGroupedCountRow[]
 
     const byRow = new Map<string, { count: number; unread: number; fieldIds: Set<string> }>()
     for (const row of rows) {
@@ -869,13 +896,14 @@ export class CommentService {
    *
    * @returns The number of read records that were inserted or updated.
    */
-  async markAllCommentsRead(spreadsheetId: string, userId: string): Promise<number> {
+  async markAllCommentsRead(spreadsheetId: string, userId: string, excludeRowIds?: string[]): Promise<number> {
     const normalizedUserId = userId.trim()
     const normalizedSheetId = spreadsheetId.trim()
     if (!normalizedUserId || !normalizedSheetId) return 0
+    const excludedRowIds = this.normalizeRowIdList(excludeRowIds)
 
     // Collect IDs of all unread comments (not authored by this user)
-    const unreadRows = await db
+    let query = db
       .selectFrom('meta_comments as c')
       .leftJoin('meta_comment_reads as r', (join) =>
         join.onRef('r.comment_id', '=', 'c.id').on('r.user_id', '=', normalizedUserId),
@@ -884,7 +912,10 @@ export class CommentService {
       .where('c.spreadsheet_id', '=', normalizedSheetId)
       .where('c.author_id', '!=', normalizedUserId)
       .where(sql<boolean>`r.comment_id is null`)
-      .execute()
+    if (excludedRowIds.length > 0) {
+      query = query.where('c.row_id', 'not in', excludedRowIds)
+    }
+    const unreadRows = await query.execute()
 
     if (unreadRows.length === 0) return 0
 
@@ -917,8 +948,9 @@ export class CommentService {
     rowIds?: string[],
     mentionUserId?: string,
     includeViewers?: boolean,
+    excludeRowIds?: string[],
   ): Promise<{ items: CommentPresenceSummary[]; total: number; viewers?: CommentPresenceViewer[] }> {
-    const base = await this.getCommentPresenceSummary(spreadsheetId, rowIds, mentionUserId)
+    const base = await this.getCommentPresenceSummary(spreadsheetId, rowIds, mentionUserId, excludeRowIds)
 
     if (!includeViewers) {
       return base
@@ -932,9 +964,13 @@ export class CommentService {
     return { ...base, viewers }
   }
 
-  async markMentionsRead(spreadsheetId: string, userId: string): Promise<void> {
+  async markMentionsRead(spreadsheetId: string, userId: string, excludeRowIds?: string[]): Promise<void> {
     const normalizedUserId = userId.trim()
     if (!normalizedUserId || !spreadsheetId) return
+    const excludedRowIds = this.normalizeRowIdList(excludeRowIds)
+    const rowDenyPredicate = excludedRowIds.length > 0
+      ? sql`and c.row_id <> all(${excludedRowIds}::text[])`
+      : sql``
 
     await sql`
       insert into meta_comment_reads (comment_id, user_id, read_at, created_at)
@@ -944,6 +980,7 @@ export class CommentService {
         and c.resolved = false
         and c.author_id <> ${normalizedUserId}
         and c.mentions @> ${JSON.stringify([normalizedUserId])}::jsonb
+        ${rowDenyPredicate}
       on conflict (comment_id, user_id)
       do update set read_at = excluded.read_at
     `.execute(db)
@@ -1019,6 +1056,19 @@ export class CommentService {
   private assertCommentAuthor(row: Pick<CommentRow, 'author_id'>, userId: string, message: string): void {
     if (row.author_id !== userId) {
       throw new CommentAccessError(message)
+    }
+  }
+
+  private normalizeRowIdList(rowIds?: string[]): string[] {
+    return [...new Set((rowIds ?? []).map((rowId) => rowId.trim()).filter((rowId) => rowId.length > 0))]
+  }
+
+  private async canNotifyUserAboutCommentTarget(spreadsheetId: string, rowId: string, userId: string): Promise<boolean> {
+    try {
+      return await this.commentTargetReadChecker({ spreadsheetId, rowId, userId })
+    } catch (error) {
+      this.logger.warn('Comment mention read-target check failed', error instanceof Error ? error : undefined)
+      return false
     }
   }
 

--- a/packages/core-backend/tests/integration/multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts
@@ -159,3 +159,127 @@ describeIfDatabase('W1-2 B4 G-8 — comments × sheet-visibility (real DB) — g
     expect(body).not.toContain(F_STATUS)
   })
 })
+
+describeIfDatabase('F1 — comments respect row-level read deny (real DB)', () => {
+  const ts = Date.now()
+  const baseId = `base_f1_comments_${ts}`
+  const sheetId = `sheet_f1_comments_${ts}`
+  const fieldId = `fld_f1_status_${ts}`
+  const visibleRecordId = `rec_f1_visible_${ts}`
+  const deniedRecordId = `rec_f1_denied_${ts}`
+  const visibleCommentId = `cmt_f1_visible_${ts}`
+  const deniedCommentId = `cmt_f1_denied_${ts}`
+  const actor = `user_f1_actor_${ts}`
+  const author = `user_f1_author_${ts}`
+  const visibleContent = 'F1_VISIBLE_COMMENT_CONTENT'
+  const deniedContent = 'F1_DENIED_COMMENT_CONTENT'
+
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x'), ($2,'x') ON CONFLICT (id) DO NOTHING", [actor, author])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [baseId, 'F1 Comments Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name, row_level_read_permissions_enabled) VALUES ($1,$2,$3,TRUE)', [sheetId, baseId, 'F1 Comments Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fieldId, sheetId, 'Status', 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1), ($4,$2,$5::jsonb,1)', [
+      visibleRecordId,
+      sheetId,
+      JSON.stringify({ [fieldId]: 'visible' }),
+      deniedRecordId,
+      JSON.stringify({ [fieldId]: 'denied' }),
+    ])
+    await q(
+      `INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level)
+       VALUES ($1,$2,'user',$3,'none')`,
+      [sheetId, deniedRecordId, actor],
+    )
+    await q(
+      `INSERT INTO meta_comments (
+         id, spreadsheet_id, row_id, field_id, container_id, target_id, target_field_id,
+         author_id, content, mentions, created_at, updated_at
+       )
+       VALUES
+         ($1,$3,$4,$6,$3,$4,$6,$7,$8,$10::jsonb, now(), now()),
+         ($2,$3,$5,$6,$3,$5,$6,$7,$9,$10::jsonb, now(), now())`,
+      [
+        visibleCommentId,
+        deniedCommentId,
+        sheetId,
+        visibleRecordId,
+        deniedRecordId,
+        fieldId,
+        author,
+        visibleContent,
+        deniedContent,
+        JSON.stringify([actor]),
+      ],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_comment_reads WHERE comment_id = ANY($1::text[])', [[visibleCommentId, deniedCommentId]]).catch(() => {})
+    await q('DELETE FROM meta_comments WHERE spreadsheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [baseId]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[actor, author]]).catch(() => {})
+  })
+
+  function actorApp(): Express {
+    return buildApp(actor, ['multitable:read', 'comments:read', 'comments:write'])
+  }
+
+  test('list comments filters row-denied comment bodies and row identifiers', async () => {
+    const res = await request(actorApp()).get('/api/comments').query({ spreadsheetId: sheetId })
+    expect(res.status).toBe(200)
+    const body = JSON.stringify(res.body)
+    expect(body).toContain(visibleContent)
+    expect(body).toContain(visibleRecordId)
+    expect(body).not.toContain(deniedContent)
+    expect(body).not.toContain(deniedRecordId)
+
+    const deniedRow = await request(actorApp()).get('/api/comments').query({ spreadsheetId: sheetId, rowId: deniedRecordId })
+    expect(deniedRow.status).toBe(200)
+    expect(deniedRow.body.data.items).toEqual([])
+    expect(deniedRow.body.data.total).toBe(0)
+    expect(JSON.stringify(deniedRow.body)).not.toContain(deniedContent)
+  })
+
+  test('summary, presence, and mention-summary exclude row-denied vectors', async () => {
+    const summary = await request(actorApp())
+      .get('/api/comments/summary')
+      .query({ spreadsheetId: sheetId, rowIds: [visibleRecordId, deniedRecordId] })
+    expect(summary.status).toBe(200)
+    expect(summary.body.data.items).toHaveLength(1)
+    expect(summary.body.data.items[0].rowId).toBe(visibleRecordId)
+    expect(JSON.stringify(summary.body)).not.toContain(deniedRecordId)
+
+    const presence = await request(actorApp())
+      .get(`/api/multitable/${sheetId}/comments/presence`)
+      .query({ rowIds: [visibleRecordId, deniedRecordId] })
+    expect(presence.status).toBe(200)
+    expect(presence.body.data.items).toHaveLength(1)
+    expect(presence.body.data.items[0].rowId).toBe(visibleRecordId)
+    expect(JSON.stringify(presence.body)).not.toContain(deniedRecordId)
+
+    const mentionSummary = await request(actorApp()).get('/api/comments/mention-summary').query({ spreadsheetId: sheetId })
+    expect(mentionSummary.status).toBe(200)
+    expect(mentionSummary.body.data.mentionedRecordCount).toBe(1)
+    expect(mentionSummary.body.data.unresolvedMentionCount).toBe(1)
+    expect(JSON.stringify(mentionSummary.body)).toContain(visibleRecordId)
+    expect(JSON.stringify(mentionSummary.body)).not.toContain(deniedRecordId)
+  })
+
+  test('create on a row-denied record is rejected and does not insert a comment', async () => {
+    const res = await request(actorApp())
+      .post('/api/comments')
+      .send({ spreadsheetId: sheetId, rowId: deniedRecordId, content: 'F1_DENIED_WRITE_SENTINEL' })
+    expect(res.status).toBe(403)
+
+    const inserted = await q(
+      "SELECT count(*)::int AS c FROM meta_comments WHERE spreadsheet_id = $1 AND content = 'F1_DENIED_WRITE_SENTINEL'",
+      [sheetId],
+    )
+    expect(Number((inserted.rows[0] as { c: number }).c)).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/integration/rooms.basic.test.ts
+++ b/packages/core-backend/tests/integration/rooms.basic.test.ts
@@ -90,6 +90,13 @@ describe('WebSocket Rooms - basic flow', () => {
     collabService.setSheetRoomAuthChecker(async ({ sheetId, userId }) => {
       return ['sheet_ops', 'sheet_orders'].includes(sheetId) && ['user_a', 'user_b', 'user_reader', 'a', 'b'].includes(userId)
     })
+    collabService.setCommentRoomAuthChecker(async ({ spreadsheetId, rowId, userId }) => {
+      const canReadSheet = ['sheet_ops', 'sheet_orders'].includes(spreadsheetId) && ['user_a', 'user_b', 'user_reader', 'a', 'b'].includes(userId)
+      if (!canReadSheet) return false
+      if (spreadsheetId === 'sheet_orders' && rowId === 'rec_secret') return false
+      if (spreadsheetId === 'sheet_orders' && !rowId) return false
+      return true
+    })
   })
 
   afterAll(async () => {
@@ -481,6 +488,46 @@ describe('WebSocket Rooms - basic flow', () => {
     const denied = waitForEvent(client, 'comment-join-denied', 'comment-sheet join forbidden')
     client.emit('join-comment-sheet', { spreadsheetId: 'sheet_orders' })
     await expect(denied).resolves.toEqual({ scope: 'sheet_orders', reason: 'forbidden' })
+
+    client.close()
+  })
+
+  it('SECURITY: rejects join-comment-record when the authenticated user is row-denied', async () => {
+    if (!baseUrl || !server) return
+    const client = ioClient(baseUrl, { transports: ['websocket'], auth: { token: 'token:user_a' } })
+    await waitForConnect(client, 'row-denied-comment-record')
+
+    const denied = waitForEvent(client, 'comment-join-denied', 'comment-record row denied')
+    client.emit('join-comment-record', { spreadsheetId: 'sheet_orders', rowId: 'rec_secret' })
+    await expect(denied).resolves.toEqual({ scope: 'sheet_orders', reason: 'forbidden' })
+
+    const noBody = expectNoEvent(client, 'comment:created', 'row-denied comment-record socket')
+    // @ts-ignore access private for test
+    server['createCoreAPI']().websocket.broadcastTo('comments:sheet_orders:rec_secret', 'comment:created', {
+      spreadsheetId: 'sheet_orders',
+      comment: { id: 'leak', rowId: 'rec_secret', body: 'secret' },
+    })
+    await noBody
+
+    client.close()
+  })
+
+  it('SECURITY: rejects join-comment-sheet when row-deny makes the sheet-wide comment room unfilterable', async () => {
+    if (!baseUrl || !server) return
+    const client = ioClient(baseUrl, { transports: ['websocket'], auth: { token: 'token:user_a' } })
+    await waitForConnect(client, 'row-denied-comment-sheet')
+
+    const denied = waitForEvent(client, 'comment-join-denied', 'comment-sheet row-deny forbidden')
+    client.emit('join-comment-sheet', { spreadsheetId: 'sheet_orders' })
+    await expect(denied).resolves.toEqual({ scope: 'sheet_orders', reason: 'forbidden' })
+
+    const noBody = expectNoEvent(client, 'comment:created', 'row-denied comment-sheet socket')
+    // @ts-ignore access private for test
+    server['createCoreAPI']().websocket.broadcastTo('comments-sheet:sheet_orders', 'comment:created', {
+      spreadsheetId: 'sheet_orders',
+      comment: { id: 'leak', rowId: 'rec_secret', body: 'secret' },
+    })
+    await noBody
 
     client.close()
   })

--- a/packages/core-backend/tests/unit/comment-routes-row-deny.test.ts
+++ b/packages/core-backend/tests/unit/comment-routes-row-deny.test.ts
@@ -1,0 +1,176 @@
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const query = vi.fn()
+  return {
+    query,
+    resolveSheetReadableCapabilities: vi.fn(),
+    loadRowLevelReadDenyEnabled: vi.fn(),
+    loadDeniedRecordIds: vi.fn(),
+  }
+})
+
+vi.mock('../../src/integration/db/connection-pool', () => ({
+  poolManager: {
+    get: () => ({ query: mocks.query }),
+  },
+}))
+
+vi.mock('../../src/multitable/permission-service', () => ({
+  resolveSheetReadableCapabilities: (...args: unknown[]) => mocks.resolveSheetReadableCapabilities(...args),
+  loadRowLevelReadDenyEnabled: (...args: unknown[]) => mocks.loadRowLevelReadDenyEnabled(...args),
+  loadDeniedRecordIds: (...args: unknown[]) => mocks.loadDeniedRecordIds(...args),
+}))
+
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}))
+
+vi.mock('../../src/middleware/api-token-auth', () => ({
+  apiTokenAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireScope: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}))
+
+vi.mock('../../src/middleware/rate-limiter', () => ({
+  apiTokenWriteRateLimit: (_req: unknown, _res: unknown, next: () => void) => next(),
+}))
+
+vi.mock('../../src/multitable/oapi-write-audit', () => ({
+  buildOapiAuditContext: () => undefined,
+  oapiWriteAuditBoundary: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}))
+
+vi.mock('../../src/services/CommentService', () => ({
+  CommentAccessError: class CommentAccessError extends Error {},
+  CommentConflictError: class CommentConflictError extends Error {},
+  CommentNotFoundError: class CommentNotFoundError extends Error {},
+  CommentValidationError: class CommentValidationError extends Error {},
+}))
+
+import { commentsRouter } from '../../src/routes/comments'
+
+function buildCommentService() {
+  return {
+    getComments: vi.fn(async () => ({ items: [{ id: 'visible-comment' }], total: 1 })),
+    listMentionCandidates: vi.fn(async () => ({ items: [], total: 0 })),
+    getInbox: vi.fn(),
+    getUnreadSummary: vi.fn(),
+    getMentionSummary: vi.fn(async () => ({ items: [], unresolvedMentionCount: 0, unreadMentionCount: 0, mentionedRecordCount: 0, unreadRecordCount: 0 })),
+    getCommentPresenceSummary: vi.fn(async () => ({ items: [], total: 0 })),
+    createComment: vi.fn(),
+    updateComment: vi.fn(),
+    deleteComment: vi.fn(),
+    markCommentRead: vi.fn(),
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    markMentionsRead: vi.fn(),
+    resolveComment: vi.fn(),
+    markAllCommentsRead: vi.fn(),
+    getCommentPresenceSummaryWithViewers: vi.fn(async () => ({ items: [], total: 0 })),
+    setCommentTargetReadChecker: vi.fn(),
+  }
+}
+
+function buildApp(commentService: ReturnType<typeof buildCommentService>): Express {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    ;(req as any).user = {
+      id: 'actor-row-denied',
+      roles: [],
+      perms: ['comments:read', 'comments:write', 'multitable:read'],
+      permissions: ['comments:read', 'comments:write', 'multitable:read'],
+    }
+    next()
+  })
+  app.use(commentsRouter({ get: () => commentService } as any))
+  return app
+}
+
+describe('comments routes row-deny gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolveSheetReadableCapabilities.mockResolvedValue({
+      access: { userId: 'actor-row-denied', isAdminRole: false },
+      capabilities: { canRead: true },
+    })
+    mocks.loadRowLevelReadDenyEnabled.mockResolvedValue(true)
+    mocks.loadDeniedRecordIds.mockResolvedValue(new Set(['row-denied']))
+  })
+
+  it('returns an empty comment page for a denied target row without calling the service reader', async () => {
+    const commentService = buildCommentService()
+    const res = await request(buildApp(commentService))
+      .get('/api/comments')
+      .query({ spreadsheetId: 'sheet-1', rowId: 'row-denied' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.items).toEqual([])
+    expect(res.body.data.total).toBe(0)
+    expect(commentService.getComments).not.toHaveBeenCalled()
+  })
+
+  it('passes filtered rowIds and denied-row exclusions to summary and mention surfaces', async () => {
+    const commentService = buildCommentService()
+    const app = buildApp(commentService)
+
+    await request(app)
+      .get('/api/comments/summary')
+      .query({ spreadsheetId: 'sheet-1', rowIds: ['row-visible', 'row-denied'] })
+      .expect(200)
+    expect(commentService.getCommentPresenceSummary).toHaveBeenCalledWith(
+      'sheet-1',
+      ['row-visible'],
+      'actor-row-denied',
+      ['row-denied'],
+    )
+
+    await request(app)
+      .get('/api/comments/mention-summary')
+      .query({ spreadsheetId: 'sheet-1' })
+      .expect(200)
+    expect(commentService.getMentionSummary).toHaveBeenCalledWith(
+      'sheet-1',
+      'actor-row-denied',
+      ['row-denied'],
+    )
+  })
+
+  it('passes denied-row exclusions to mark-read paths', async () => {
+    const commentService = buildCommentService()
+    commentService.markAllCommentsRead.mockResolvedValue(2)
+    const app = buildApp(commentService)
+
+    await request(app)
+      .post('/api/comments/mention-summary/mark-read')
+      .send({ spreadsheetId: 'sheet-1' })
+      .expect(204)
+    expect(commentService.markMentionsRead).toHaveBeenCalledWith(
+      'sheet-1',
+      'actor-row-denied',
+      ['row-denied'],
+    )
+
+    await request(app)
+      .post('/api/multitable/sheet-1/comments/mark-all-read')
+      .send({})
+      .expect(200)
+    expect(commentService.markAllCommentsRead).toHaveBeenCalledWith(
+      'sheet-1',
+      'actor-row-denied',
+      ['row-denied'],
+    )
+  })
+
+  it('rejects comment creation on a denied target row before service create', async () => {
+    const commentService = buildCommentService()
+    const res = await request(buildApp(commentService))
+      .post('/api/comments')
+      .send({ spreadsheetId: 'sheet-1', rowId: 'row-denied', content: 'secret write' })
+
+    expect(res.status).toBe(403)
+    expect(commentService.createComment).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-backend/tests/unit/comment-service.test.ts
+++ b/packages/core-backend/tests/unit/comment-service.test.ts
@@ -566,6 +566,36 @@ describe('CommentService', () => {
       expect(mentionedUserIds).toContain('user-new')
       expect(mentionedUserIds).not.toContain('user-old')
     })
+
+    it('does not send a new mention notification when the mentioned user cannot read the target row', async () => {
+      service.setCommentTargetReadChecker(async ({ userId }) => userId !== 'user-denied')
+      const existingRow = makeCommentRow({
+        id: 'cmt_up_denied',
+        author_id: 'user-author',
+        mentions: JSON.stringify([]),
+      })
+      const updatedRow = makeCommentRow({
+        id: 'cmt_up_denied',
+        author_id: 'user-author',
+        row_id: 'row-secret',
+        target_id: 'row-secret',
+        content: '@[Denied](user-denied)',
+        mentions: JSON.stringify(['user-denied']),
+      })
+
+      pushTakeFirst(existingRow) // getRequiredCommentRow
+      pushExec([])               // updateTable execute
+      pushTakeFirst(updatedRow)  // getComment reload
+
+      await service.updateComment('cmt_up_denied', 'user-author', {
+        content: '@[Denied](user-denied)',
+      })
+
+      const sendToCalls = mockCollabService.sendTo.mock.calls.filter(
+        (call: unknown[]) => call[1] === 'comment:mention',
+      )
+      expect(sendToCalls.map((call: unknown[]) => call[0])).not.toContain('user-denied')
+    })
   })
 
   // ── resolveComment ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- enforce row-level read-deny on explicit-sheet comment read surfaces by carrying denied row ids through list, summary, presence, mention-summary, and mark-read paths
- reject comment creation on a row the actor cannot read, and suppress comment mention realtime delivery when the mentioned user cannot read the target row
- add a comment-room auth checker so record rooms check row access and sheet-wide comment rooms fail closed when row-deny makes full-comment broadcasts unfilterable

## Verification
- pnpm --filter @metasheet/core-backend type-check
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/comment-service.test.ts tests/unit/comment-routes-row-deny.test.ts --watch=false
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/rooms.basic.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts --reporter=dot (local: skipped because DATABASE_URL is unset; CI real-DB lane runs this file)