### PR TITLE
fix(multitable): D-1 — automation/plugin-SDK 删除补发 delete revision（PIT 不再谎报存活）

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -229,6 +229,7 @@ jobs:
             tests/integration/multitable-history-audit-log-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-taint-realdb.test.ts \
             tests/integration/multitable-record-reconstructor-realdb.test.ts \
+            tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts \
             tests/integration/multitable-pit-view-realdb.test.ts \
             tests/integration/multitable-restore-preview-realdb.test.ts \
             tests/integration/multitable-restore-execute-realdb.test.ts \

--- a/docs/development/multitable-global-history-destruction-path-coverage-gap-audit-20260708.md
+++ b/docs/development/multitable-global-history-destruction-path-coverage-gap-audit-20260708.md
@@ -8,8 +8,8 @@
 |---|---|---|---|---|---|---|---|
 | 1 | `record-service.ts:867` `deleteRecord`(治理路径) | ✓ | ✓ | ✓ | ✓ inbound | 完整(2a;inbound 待 4c-3) | ✅ 正确 |
 | 2 | `univer-meta.ts:10066` **PIT-reset 内联删除** | ✓ | ✓(`action:'delete'`) | ✓ | **✗** | 记录可恢复,**inbound 边永久丢失** | ✅ 正确 |
-| 3 | `records.ts:565` plugin-SDK `deleteRecord` | ✓ | **✗** | **✗** | ✗ | **不可恢复** | ❌ **错误** |
-| 4 | `automation-executor.ts:2269` automation `delete_record` | ✓ | **✗** | **✗** | **✗** | **不可恢复** | ❌ **错误** |
+| 3 | `records.ts:565` plugin-SDK `deleteRecord` | ✓ | ✓ **(D-1, source:'plugin')** | **✗** | ✗ | **不可恢复**(=D-2, owner-gated) | ✅ 正确 **(D-1 修复)** |
+| 4 | `automation-executor.ts:2269` automation `delete_record` | ✓ | ✓ **(D-1, source:'automation')** | **✗** | **✗** | **不可恢复**(=D-2, owner-gated) | ✅ 正确 **(D-1 修复)** |
 
 核实点:`meta_links` 的 `record_id` 有 FK(`ON DELETE CASCADE`)、`foreign_record_id` **无 FK**,故四条路径都必须显式 `DELETE FROM meta_links WHERE record_id=$1 OR foreign_record_id=$1`——**四条都清掉了 inbound 边**,只有路径 1 在清之前捕获。
 
@@ -42,7 +42,7 @@ SELECT DISTINCT ON (record_id) record_id, action, snapshot, version
 
 ## 4. owner 决策菜单(本文不实现任何一项)
 
-- **D-1(推荐,纯缺陷修复):** 让 automation / plugin-SDK 的删除**发射 delete revision**(`source:'automation'` / `'plugin'`,枚举位已存在)。**只修 PIT 正确性,不改可恢复性**(不加 trash)。用户可见行为变化仅为「Global History 如实记录该删除、PIT 不再谎报记录存活」。难度中(automation 走 raw-SQL 车道)。**属跨车道改动**(automation-executor 归自动化线),需路由到该线会话或 owner 点名。
+- **D-1(推荐,纯缺陷修复)— ✅ 已落地(owner ratify 2026-07-09,最小版:只补 revision,不开 recoverability;真库金测双向 PIT + mutation 证明:multitable-d1-delete-revision-parity-realdb.test.ts):** 让 automation / plugin-SDK 的删除**发射 delete revision**(`source:'automation'` / `'plugin'`,枚举位已存在)。**只修 PIT 正确性,不改可恢复性**(不加 trash)。用户可见行为变化仅为「Global History 如实记录该删除、PIT 不再谎报记录存活」。难度中(automation 走 raw-SQL 车道)。**属跨车道改动**(automation-executor 归自动化线),需路由到该线会话或 owner 点名。
 - **D-2(更大,产品决定):** 再给这两条路径补 `meta_records_trash` + tombstone 捕获 ⇒ 删除变为可恢复、并进回收站。**改变产品语义**,需 owner 签核。
 - **D-3(4c-3 内解决,已在 4c-3 锁提案):** 给 PIT-reset 内联删除(路径 2)补 tombstone 捕获(它已写 trash+revision,只差 anchor 与捕获调用)。
 - **D-4(文档诚实,已随本轮执行):** 4c-2 锁 §1/§8 补齐四条路径实情——**已在同批 PR 落地**,C2 口径明确限定为路径 1(+ 4c-3 后含路径 2)。

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -4,6 +4,7 @@
  */
 
 import { randomUUID } from 'crypto'
+import { recordRecordRevision } from './record-history-service'
 import { Logger } from '../core/logger'
 import { withAutomationEventId } from './automation-event-dedup'
 import { redactString } from './automation-log-redact'
@@ -2226,12 +2227,14 @@ export class AutomationExecutor {
       // Record-lock guard: you cannot delete a record locked by someone you can't unlock. The SELECT and
       // the DELETE below BOTH read `effectiveSheetId`/`effectiveRecordId`, so a cross-base delete checks
       // the TARGET record's lock (not the trigger record's) — lock priority over base-write.
+      // D-1: also fetch data+version here — same row, same predicate, zero extra query. The delete
+      // revision below needs the record's final snapshot, and after the DELETE the row is gone.
       const lockRes = await this.deps.queryFn(
-        'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        'SELECT locked, locked_by, created_by, data, version FROM meta_records WHERE id = $1 AND sheet_id = $2',
         [effectiveRecordId, effectiveSheetId],
       )
       const lockRow = lockRes.rows[0] as
-        | { locked?: unknown; locked_by?: unknown; created_by?: unknown }
+        | { locked?: unknown; locked_by?: unknown; created_by?: unknown; data?: Record<string, unknown>; version?: unknown }
         | undefined
       // ②b claim==truth for the record: a cross-base delete must address a record that ACTUALLY lives in
       // `targetSheetId`. No row → the targetRecordId does not exist there → fail-closed (never a silent
@@ -2265,10 +2268,33 @@ export class AutomationExecutor {
       // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
       // delete is rejected before this DELETE unless claim==truth + trigger-actor base-write.
       // lock-guarded: automation delete_record (C2a) — ensureRecordNotLocked enforced just above.
-      await this.deps.queryFn(
+      const deleteRes = await this.deps.queryFn(
         'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2',
         [effectiveRecordId, effectiveSheetId],
       )
+
+      // D-1 (destruction-path gap audit, owner-ratified): emit the delete revision. PIT/as-of-T
+      // existence is derived PURELY from meta_record_revisions — before this, an automation-deleted
+      // record's last revision stayed create/update, so Global History and every PIT consumer treated
+      // it as alive forever. Emitted AFTER the hard delete (this lane has no enclosing transaction):
+      // if this INSERT fails we degrade to the old missing-revision behavior for one record — never
+      // the reverse lie of a delete revision for a row that still exists. Gated on the row having
+      // actually existed AND the DELETE having removed it (same-base keeps its 0-row-success leniency
+      // WITHOUT fabricating a revision for a record that was never there). Recoverability (trash /
+      // tombstone) is deliberately NOT added — that is the owner-gated D-2 rung.
+      if (lockRow && (deleteRes.rowCount ?? 0) > 0) {
+        await recordRecordRevision(this.deps.queryFn, {
+          sheetId: effectiveSheetId,
+          recordId: effectiveRecordId,
+          version: Number(lockRow.version ?? 1),
+          action: 'delete',
+          source: 'automation',
+          actorId: context.actorId ?? null,
+          changedFieldIds: [],
+          patch: {},
+          snapshot: lockRow.data ?? null,
+        })
+      }
 
       // Emit event for chaining (mirrors the updated/created emits + the same-base delete sink's
       // `multitable.record.deleted` shape). C1 real-time invalidation fan-out to the target base's room

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto'
+import { recordRecordRevision } from './record-history-service'
 
 import {
   acquireAutoNumberSheetWriteLock,
@@ -553,11 +554,21 @@ export async function deleteRecord(
   // be deleted via the SDK (it must be unlocked first through the explicit unlock action).
   await guardRecordNotLockedForPlugin(query, input.sheetId, input.recordId)
 
-  // 4c-2 scope boundary (design-lock §8, out-of-scope): this plugin-SDK delete path is intentionally
-  // NOT wired to tombstone-capture (nor to meta_records_trash / meta_record_revisions). It already
-  // destroys the row irrecoverably today, independent of MULTITABLE_TOMBSTONE_CAPTURE_ENABLED — the
-  // flag's "every destruction is captured" guarantee covers only record-service.deleteRecord and
-  // dropFieldCascade. Giving this path trash+capture parity is a separate follow-up rung, not 4c-2.
+  // D-1 (destruction-path gap audit, owner-ratified): read the row BEFORE destroying anything so the
+  // delete revision below can carry the record's final snapshot. PIT/as-of-T existence is derived
+  // PURELY from meta_record_revisions — without a delete revision this path left the record "alive"
+  // in Global History and every PIT consumer forever.
+  const snapshotRes = await query(
+    'SELECT data, version FROM meta_records WHERE id = $1 AND sheet_id = $2',
+    [input.recordId, input.sheetId],
+  )
+  const snapshotRow = (snapshotRes.rows as any[])[0] as { data?: Record<string, unknown>; version?: unknown } | undefined
+
+  // 4c-2 scope boundary (design-lock §8) + D-1 update: this plugin-SDK delete path now EMITS the
+  // delete revision (source:'plugin' — PIT correctness, D-1) but remains intentionally NOT wired to
+  // tombstone-capture or meta_records_trash: the row is still irrecoverable, independent of
+  // MULTITABLE_TOMBSTONE_CAPTURE_ENABLED. Trash+capture parity (recoverability) is the separate
+  // owner-gated D-2 rung, not D-1.
   await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [input.recordId])
 
   // lock-guarded: plugin-SDK deleteRecord (M1) — guardRecordNotLockedForPlugin(actor=null) rejected above.
@@ -571,6 +582,22 @@ export async function deleteRecord(
   if (!row) {
     throw new MultitableRecordNotFoundError(`Record not found: ${input.recordId}`)
   }
+
+  // D-1: emit AFTER the hard delete (this path has no enclosing transaction guarantee): if this INSERT
+  // fails we degrade to today's missing-revision behavior for one record — never the reverse lie of a
+  // delete revision for a row that still exists. Gated on the DELETE having actually removed a row.
+  await recordRecordRevision(query, {
+    sheetId: input.sheetId,
+    recordId: input.recordId,
+    version: Number(row.version ?? 1),
+    action: 'delete',
+    source: 'plugin',
+    actorId: null,
+    changedFieldIds: [],
+    patch: {},
+    snapshot: snapshotRow?.data ?? null,
+  })
+
   return {
     id: input.recordId,
     sheetId: input.sheetId,

--- a/packages/core-backend/tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts
@@ -1,0 +1,205 @@
+/**
+ * D-1 (destruction-path coverage gap audit, owner-ratified 2026-07-09) — delete-revision parity
+ * for the two record hard-delete paths that emitted NO delete revision:
+ *
+ *   path 3: plugin-SDK `records.deleteRecord`        → now emits action:'delete' source:'plugin'
+ *   path 4: automation executor `delete_record`      → now emits action:'delete' source:'automation'
+ *
+ * Why this is a correctness bug and not a feature: `reconstructRecordsAtT` derives record existence
+ * PURELY from meta_record_revisions. Without a delete revision, a deleted record's last revision
+ * stays create/update, so Global History and every PIT consumer (PIT view / Reset preview / Reset
+ * execute / record reconstruction) treat it as ALIVE FOREVER and feed its stale snapshot onward.
+ *
+ * Scope is D-1 MINIMAL by owner order: PIT correctness only. Deliberately NOT asserted here (and
+ * NOT implemented): trash rows, tombstone capture, recoverability — that is the owner-gated D-2.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { MemoryRateLimitStore } from '../../src/middleware/rate-limiter'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus } from '../../src/integration/events/event-bus'
+import {
+  AutomationExecutor,
+  type AutomationDeps,
+  type AutomationRule,
+} from '../../src/multitable/automation-executor'
+import { deleteRecord as pluginDeleteRecord } from '../../src/multitable/records'
+import { reconstructRecordsAtT } from '../../src/multitable/record-reconstructor'
+import { recordRecordRevision } from '../../src/multitable/record-history-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const OWNER = `u_d1_owner_${TS}`
+const BASE = `base_d1_${TS}`
+const SHEET = `sheet_d1_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function makeExecutor(): AutomationExecutor {
+  const deps: AutomationDeps = {
+    eventBus: new EventBus(),
+    queryFn: (sql: string, params?: unknown[]) => q(sql, params),
+    crossBaseWriteQuota: { limit: 1000, windowMs: 60_000, store: new MemoryRateLimitStore() },
+  }
+  return new AutomationExecutor(deps)
+}
+
+function deleteRuleFor(recordId: string): AutomationRule {
+  return {
+    id: `axr_d1_${TS}_${Math.random().toString(36).slice(2, 8)}`,
+    name: 'D1 delete rule',
+    sheetId: SHEET,
+    trigger: { type: 'record.created', config: {} },
+    actions: [{ type: 'delete_record', config: {} } as never],
+    enabled: true,
+    createdBy: OWNER,
+    createdAt: new Date().toISOString(),
+  } as unknown as AutomationRule
+}
+
+async function insertRecord(recordId: string, data: Record<string, unknown>): Promise<void> {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,3)', [
+    recordId,
+    SHEET,
+    JSON.stringify(data),
+  ])
+  // Seed the create revision the same way the real write path does, so the PIT goldens below start
+  // from the exact revision stream shape production has (create → [delete]).
+  await recordRecordRevision(q, {
+    sheetId: SHEET,
+    recordId,
+    version: 3,
+    action: 'create',
+    source: 'rest',
+    actorId: OWNER,
+    changedFieldIds: [],
+    patch: {},
+    snapshot: data,
+  })
+}
+
+async function deleteRevisionsOf(recordId: string): Promise<Array<{ source: string; snapshot: Record<string, unknown> | null; version: number }>> {
+  const res = await q(
+    `SELECT source, snapshot, version FROM meta_record_revisions
+      WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete'
+      ORDER BY created_at DESC`,
+    [SHEET, recordId],
+  )
+  return res.rows as never[]
+}
+
+async function pitAlive(recordId: string, asOfIso: string): Promise<boolean> {
+  const state = await reconstructRecordsAtT(q, SHEET, asOfIso, [recordId])
+  return state.get(recordId)?.exists === true
+}
+
+describeIfDatabase('D-1 — delete-revision parity for plugin-SDK + automation hard deletes (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE, 'D1 Base', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET, BASE, 'D1 Sheet'])
+    // loadSheetAndFields (plugin path) requires at least one field on the sheet.
+    await q(
+      `INSERT INTO meta_fields (id, sheet_id, name, type, "order") VALUES ($1, $2, 'Title', 'text', 0)`,
+      [`fld_d1_${TS}`, SHEET],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('PLUGIN path: delete emits action=delete source=plugin with the final snapshot — and PIT stops lying', async () => {
+    const recId = `rec_d1_plugin_${TS}`
+    await insertRecord(recId, { title: 'plugin victim' })
+    const beforeDelete = new Date().toISOString()
+    await new Promise((r) => setTimeout(r, 25))
+
+    await pluginDeleteRecord({ query: q as never, sheetId: SHEET, recordId: recId } as never)
+
+    // The revision is the whole point of D-1.
+    const revs = await deleteRevisionsOf(recId)
+    expect(revs).toHaveLength(1)
+    expect(revs[0]!.source).toBe('plugin')
+    expect(revs[0]!.version).toBe(3)
+    expect(revs[0]!.snapshot).toMatchObject({ title: 'plugin victim' })
+
+    await new Promise((r) => setTimeout(r, 25))
+    const afterDelete = new Date().toISOString()
+
+    // PIT GOLDEN both directions: alive before the delete, dead after it. Before D-1 the second
+    // assertion failed forever — the record's last revision was the create.
+    expect(await pitAlive(recId, beforeDelete)).toBe(true)
+    expect(await pitAlive(recId, afterDelete)).toBe(false)
+  })
+
+  test('AUTOMATION path: delete_record emits action=delete source=automation with actor + snapshot — and PIT stops lying', async () => {
+    const recId = `rec_d1_auto_${TS}`
+    await insertRecord(recId, { title: 'automation victim' })
+    const beforeDelete = new Date().toISOString()
+    await new Promise((r) => setTimeout(r, 25))
+
+    const exec = await makeExecutor().execute(deleteRuleFor(recId), {
+      recordId: recId,
+      sheetId: SHEET,
+      actorId: OWNER,
+      data: {},
+    })
+    expect(exec.steps[0]?.status).toBe('success')
+    expect((await q('SELECT 1 FROM meta_records WHERE id = $1', [recId])).rows).toHaveLength(0)
+
+    const revs = await deleteRevisionsOf(recId)
+    expect(revs).toHaveLength(1)
+    expect(revs[0]!.source).toBe('automation')
+    expect(revs[0]!.snapshot).toMatchObject({ title: 'automation victim' })
+
+    await new Promise((r) => setTimeout(r, 25))
+    const afterDelete = new Date().toISOString()
+    expect(await pitAlive(recId, beforeDelete)).toBe(true)
+    expect(await pitAlive(recId, afterDelete)).toBe(false)
+  })
+
+  test('BEHAVIOR PRESERVED: plugin delete of a missing record still throws NotFound and emits NO revision', async () => {
+    const ghost = `rec_d1_ghost_${TS}`
+    await expect(
+      pluginDeleteRecord({ query: q as never, sheetId: SHEET, recordId: ghost } as never),
+    ).rejects.toThrow(/not found/i)
+    expect(await deleteRevisionsOf(ghost)).toHaveLength(0)
+  })
+
+  test('BEHAVIOR PRESERVED: same-base automation delete of a missing record keeps its 0-row success — and fabricates NO revision', async () => {
+    const ghost = `rec_d1_ghost2_${TS}`
+    const exec = await makeExecutor().execute(deleteRuleFor(ghost), {
+      recordId: ghost,
+      sheetId: SHEET,
+      actorId: OWNER,
+      data: {},
+    })
+    // Pre-existing same-base leniency: a missing trigger record yields a 0-row DELETE reported as
+    // success. D-1 must not change that — and must NOT invent a delete revision for a record that
+    // never existed.
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(await deleteRevisionsOf(ghost)).toHaveLength(0)
+  })
+
+  test('D-1 MINIMAL scope: neither path writes trash or tombstones (recoverability stays D-2)', async () => {
+    const recId = `rec_d1_scope_${TS}`
+    await insertRecord(recId, { title: 'scope check' })
+    await pluginDeleteRecord({ query: q as never, sheetId: SHEET, recordId: recId } as never)
+    const trash = await q('SELECT 1 FROM meta_records_trash WHERE record_id = $1', [recId]).catch(() => ({ rows: [] }))
+    expect(trash.rows).toHaveLength(0)
+    const tomb = await q(
+      "SELECT 1 FROM meta_link_tombstones WHERE record_id = $1 OR foreign_record_id = $1",
+      [recId],
+    ).catch(() => ({ rows: [] }))
+    expect(tomb.rows).toHaveLength(0)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -106,6 +106,10 @@ export default defineConfig({
       // re-add/self-scoped DELETE/reader-deny 403/cascade) is no longer invisible debt.
       'tests/integration/comment-reactions.api.test.ts',
       'tests/integration/multitable-oapi1-comments-read-realdb.test.ts',
+      // D-1 delete-revision parity goldens: real Postgres only (describeIfDatabase would merely
+      // skip-green here, re-opening the "real-DB spec silently skips in the no-DB lane" hole) —
+      // whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
+      'tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts',
       // W6 full-HTTP-path approve->resume seam: mounts authRouter + approvalsRouter on an
       // ephemeral port against real Postgres, so it is excluded from the default run and wired
       // into the dedicated `Run multitable real-DB integration` job in plugin-tests.yml.


### PR DESCRIPTION
## D-1（destruction-path gap audit · owner ratify 2026-07-09 · 最小版）

**缺陷（P1，live）**：四条记录硬删路径中，plugin-SDK `records.deleteRecord` 与 automation `delete_record` **不写 delete revision**。而 `reconstructRecordsAtT` **纯粹**从 `meta_record_revisions` 派生记录存在性 → 经这两条路径删除的记录在 Global History 与所有 PIT 消费面（PIT view / Reset preview / Reset execute / 记录重建）**永远"活着"**，旧快照被持续喂给下游。`RecordRevisionSource` 枚举自始声明了 `'automation' | 'plugin'`——发射点从未接线。

## 修法（只修 PIT 正确性，不改可恢复性）
- **plugin 路径**：删除前预读 `data, version`（行删后即失）；在硬删**之后**发射 `action:'delete' source:'plugin'`——该车道无外层事务，"删后发射"失败时退化回今日缺 revision 行为，**绝不**制造「行还活着却谎报已删」的反向谎言。
- **automation 路径**：既有 lock-check SELECT 顺带取 `data, version`（同行同谓词，**零额外查询**）；发射以「行确实存在 && DELETE rowCount>0」为门——保留 same-base 0-row-success 的既有宽容，**不为不存在的记录捏造 revision**。
- **刻意不做（owner-gated D-2）**：trash / tombstone / 可恢复性。有 scope golden 钉死「两路径均不写 trash/tombstone」。

## 验证（fresh d1_verify 全量迁移）
- 两路径各自金测：revision（source + 最终快照 + version）**且** PIT 双向翻转（T<delete 活、T>delete 死——后者在本修复前**永远失败**）。
- 行为保持金测：两路径对不存在记录的既有语义不变、零捏造 revision。
- **突变验证**：分别 neuter 两个发射点 → **恰好**对应路径的金测变红；还原全绿。
- 回归：automation 车道 5 套 69/69 + reconstructor/PIT/restore 21/21；tsc 0。
- realdb 家族接线：describeIfDatabase 自跳过（默认 job 无 DB）+ `plugin-tests.yml` 真库 step 列表。
- gap-audit 台账翻 as-built（路径 3/4 PIT ✅；可恢复性仍 D-2 owner-gated）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
