### PR TITLE
fix(multitable): record delete revisions for hard-delete side doors

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -229,6 +229,7 @@ jobs:
             tests/integration/multitable-history-audit-log-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-taint-realdb.test.ts \
             tests/integration/multitable-record-reconstructor-realdb.test.ts \
+            tests/integration/multitable-d1-delete-revisions-realdb.test.ts \
             tests/integration/multitable-pit-view-realdb.test.ts \
             tests/integration/multitable-restore-preview-realdb.test.ts \
             tests/integration/multitable-restore-execute-realdb.test.ts \

--- a/docs/development/multitable-global-history-d1-delete-revisions-dev-verification-20260709.md
+++ b/docs/development/multitable-global-history-d1-delete-revisions-dev-verification-20260709.md
@@ -1,0 +1,56 @@
+# Multitable Global History — D-1 Delete Revision PIT-Correctness — Dev/Verification (2026-07-09)
+
+Status: implemented as the owner-ratified D-1 revision-only slice. This document records what changed and how it was verified; it does not authorize D-2 trash/tombstone recovery or any production flag.
+
+## 1. Scope
+
+D-1 fixes the point-in-time correctness gap where two hard-delete side doors removed `meta_records` rows without appending an `action='delete'` row to `meta_record_revisions`:
+
+- automation `delete_record`
+- plugin-SDK `deleteRecord`
+
+The shipped behavior before this slice could make `reconstructRecordsAtT` treat an automation/plugin-deleted record as alive forever, because the last revision stayed at create/update. D-1 only adds append-only delete revisions. It does not add trash, tombstone capture, recoverability, public-form create revision coverage, or any new flag.
+
+## 2. Runtime Changes
+
+- `AutomationExecutor.executeDeleteRecord` now selects `locked`, `version`, and `data` with `FOR UPDATE`, records a `source='automation'` delete revision with the pre-delete snapshot, then hard-deletes the record inside one transaction.
+- `AutomationService` supplies the executor a transaction dependency backed by the main pool.
+- The button route's executor entry now supplies the same transaction dependency for non-transactional action dispatch; the already-transactional button update path continues to run on its existing transaction client.
+- Plugin-SDK `deleteRecord` now selects the current row with `FOR UPDATE`, records a `source='plugin'` delete revision with the pre-delete snapshot, then hard-deletes the record inside the caller's transaction.
+- The plugin real-DB CI allowlist now includes `multitable-d1-delete-revisions-realdb.test.ts`, so the new DATABASE_URL-gated goldens cannot skip silently in the real-DB job.
+
+## 3. Verification
+
+Local verification on `/private/tmp/ms2-d1-delete-revisions`:
+
+- `pnpm --filter @metasheet/core-backend run type-check` — pass.
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-records.test.ts tests/unit/automation-v1.test.ts --reporter=dot` — 228/228 pass.
+- `DATABASE_URL='postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_test' METASHEET_REAL_DB_TEST_STEP=1 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-d1-delete-revisions-realdb.test.ts --reporter=dot` — 5/5 pass.
+- `DATABASE_URL='postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_test' METASHEET_REAL_DB_TEST_STEP=1 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-record-reconstructor-realdb.test.ts --reporter=dot` — 8/8 pass.
+- `git diff --check` — pass.
+
+The D-1 real-DB suite covers:
+
+- automation delete writes `action='delete', source='automation'`, preserves the pre-delete snapshot, and makes PIT after the delete report non-existence while PIT before the delete still reports existence.
+- plugin-SDK delete writes `action='delete', source='plugin'`, preserves the pre-delete snapshot, and has the same PIT before/after behavior.
+- forced delete-revision insert failure rolls back the hard delete for both automation and plugin-SDK paths, leaving the record present and no delete revision written.
+
+## 4. Mutation Evidence
+
+Neuter probe: temporarily changed both D-1 runtime emitters from `action: 'delete'` to `action: 'update'`, then reran the D-1 real-DB suite.
+
+Expected RED observed:
+
+- automation latest revision assertion failed (`update` vs `delete`).
+- plugin latest revision assertion failed (`update` vs `delete`).
+- automation atomicity golden failed because the trigger no longer fired and the delete committed.
+- plugin atomicity golden failed because the trigger no longer fired and the delete committed.
+
+The probe was reverted and the same D-1 real-DB suite returned to 5/5 pass.
+
+## 5. Explicitly Out Of Scope
+
+- D-2 recoverability: no `meta_records_trash`, no tombstone capture, no record undelete semantics.
+- Public-form create revision coverage.
+- Any new environment flag or rollout ladder.
+- Any change to PIT Reset/Revert semantics beyond fixing the revision stream that they consume.

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -9,10 +9,11 @@ import { withAutomationEventId } from './automation-event-dedup'
 import { redactString } from './automation-log-redact'
 import { computeActionFingerprint } from './automation-suspension-service'
 import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
-import { isRichLongTextProperty, sanitizeRichLongText } from './field-codecs'
+import { isRichLongTextProperty, normalizeJson, sanitizeRichLongText } from './field-codecs'
 import { ensureRecordNotLocked } from './record-lock'
 import { resolveCrossBaseWriteAuthority } from './cross-base-write-authority'
 import { publishMultitableSheetRealtime } from './realtime-publish'
+import { recordRecordRevision } from './record-history-service'
 import { MemoryRateLimitStore, type RateLimitStore } from '../middleware/rate-limiter'
 import {
   DingTalkBusinessError,
@@ -789,6 +790,9 @@ export async function consumeSharedCrossBaseWriteQuota(
 export interface AutomationDeps {
   eventBus: EventBus
   queryFn: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+  transaction?: <T>(
+    handler: (client: { query: AutomationDeps['queryFn'] }) => Promise<T>,
+  ) => Promise<T>
   fetchFn?: typeof fetch
   notificationService?: Pick<NotificationService, 'send'>
   /** Optional cross-base write quota override (limit/window/store). Omit → process-global default. */
@@ -2223,52 +2227,79 @@ export class AutomationExecutor {
         effectiveRecordId = targetRecordId
       }
 
-      // Record-lock guard: you cannot delete a record locked by someone you can't unlock. The SELECT and
-      // the DELETE below BOTH read `effectiveSheetId`/`effectiveRecordId`, so a cross-base delete checks
-      // the TARGET record's lock (not the trigger record's) — lock priority over base-write.
-      const lockRes = await this.deps.queryFn(
-        'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
-        [effectiveRecordId, effectiveSheetId],
-      )
-      const lockRow = lockRes.rows[0] as
-        | { locked?: unknown; locked_by?: unknown; created_by?: unknown }
-        | undefined
-      // ②b claim==truth for the record: a cross-base delete must address a record that ACTUALLY lives in
-      // `targetSheetId`. No row → the targetRecordId does not exist there → fail-closed (never a silent
-      // no-op success). Same-base keeps its leniency (a missing trigger record yields a 0-row DELETE
-      // reported as success) to avoid any behavior regression vs the other same-base sinks.
-      if (gate.crossBase && !lockRow) {
-        return {
-          actionType: 'delete_record',
-          status: 'failed',
-          error: `Cross-base delete_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
+      const step = await this.withTransaction(async (query) => {
+        // Record-lock guard: you cannot delete a record locked by someone you can't unlock. The SELECT and
+        // the DELETE below BOTH read `effectiveSheetId`/`effectiveRecordId`, so a cross-base delete checks
+        // the TARGET record's lock (not the trigger record's) — lock priority over base-write.
+        //
+        // D-1: lock the row and capture version+data inside the SAME transaction as the hard delete and
+        // delete revision. Without the delete revision, point-in-time reconstruction kept treating
+        // automation-deleted records as alive forever.
+        const lockRes = await query(
+          `SELECT locked, locked_by, created_by, version, data
+             FROM meta_records
+            WHERE id = $1 AND sheet_id = $2
+            FOR UPDATE`,
+          [effectiveRecordId, effectiveSheetId],
+        )
+        const lockRow = lockRes.rows[0] as
+          | { locked?: unknown; locked_by?: unknown; created_by?: unknown; version?: unknown; data?: unknown }
+          | undefined
+        // ②b claim==truth for the record: a cross-base delete must address a record that ACTUALLY lives in
+        // `targetSheetId`. No row → the targetRecordId does not exist there → fail-closed (never a silent
+        // no-op success). Same-base keeps its leniency (a missing trigger record yields a 0-row DELETE
+        // reported as success) to avoid any behavior regression vs the other same-base sinks.
+        if (gate.crossBase && !lockRow) {
+          return {
+            actionType: 'delete_record',
+            status: 'failed',
+            error: `Cross-base delete_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
+          } satisfies AutomationStepResult
         }
-      }
-      if (lockRow) {
-        ensureRecordNotLocked(context.actorId ?? null, lockRow, () => new Error('Record is locked'))
-      }
+        if (lockRow) {
+          ensureRecordNotLocked(context.actorId ?? null, lockRow, () => new Error('Record is locked'))
+        }
 
-      // Clean up links FIRST (mirrors the same-base delete sinks `records.deleteRecord` /
-      // `RecordService.deleteRecord`): the FK cascade only covers the `record_id` side, so the
-      // `foreign_record_id` side must be deleted explicitly or it dangles. (This statement touches
-      // meta_links, NOT meta_records, so the cross-base write-guard regex does not match it.)
-      await this.deps.queryFn(
-        'DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1',
-        [effectiveRecordId],
-      )
+        // Clean up links FIRST (mirrors the same-base delete sinks `records.deleteRecord` /
+        // `RecordService.deleteRecord`): the FK cascade only covers the `record_id` side, so the
+        // `foreign_record_id` side must be deleted explicitly or it dangles. (This statement touches
+        // meta_links, NOT meta_records, so the cross-base write-guard regex does not match it.)
+        await query(
+          'DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1',
+          [effectiveRecordId],
+        )
 
-      // HARD delete — the system has NO soft-delete for records: `meta_records` has no `deleted_at`
-      // column and both same-base delete sinks (`records.ts`, `record-service.ts`) hard-`DELETE`. A
-      // soft-delete here would target a non-existent column AND would be a silent no-op (no read path
-      // filters `deleted_at`). So this mirrors the proven sinks. No `version = version + 1` (the row is
-      // gone); `sheet_id` scoping matches the update template.
-      // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
-      // delete is rejected before this DELETE unless claim==truth + trigger-actor base-write.
-      // lock-guarded: automation delete_record (C2a) — ensureRecordNotLocked enforced just above.
-      await this.deps.queryFn(
-        'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2',
-        [effectiveRecordId, effectiveSheetId],
-      )
+        if (lockRow) {
+          const version = Number(lockRow.version ?? 1)
+          await recordRecordRevision(query, {
+            sheetId: effectiveSheetId,
+            recordId: effectiveRecordId,
+            version: Number.isFinite(version) ? version : 1,
+            action: 'delete',
+            source: 'automation',
+            actorId: context.actorId ?? null,
+            changedFieldIds: [],
+            patch: {},
+            snapshot: normalizeJson(lockRow.data),
+          })
+        }
+
+        // HARD delete — the system has NO soft-delete for records: `meta_records` has no `deleted_at`
+        // column and both same-base delete sinks (`records.ts`, `record-service.ts`) hard-`DELETE`. A
+        // soft-delete here would target a non-existent column AND would be a silent no-op (no read path
+        // filters `deleted_at`). So this mirrors the proven sinks. No `version = version + 1` (the row is
+        // gone); `sheet_id` scoping matches the update template.
+        // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
+        // delete is rejected before this DELETE unless claim==truth + trigger-actor base-write.
+        // lock-guarded: automation delete_record (C2a) — ensureRecordNotLocked enforced just above.
+        await query(
+          'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2',
+          [effectiveRecordId, effectiveSheetId],
+        )
+
+        return null
+      })
+      if (step) return step
 
       // Emit event for chaining (mirrors the updated/created emits + the same-base delete sink's
       // `multitable.record.deleted` shape). C1 real-time invalidation fan-out to the target base's room
@@ -2287,6 +2318,15 @@ export class AutomationExecutor {
     } catch (err) {
       return { actionType: 'delete_record', status: 'failed', error: err instanceof Error ? err.message : String(err) }
     }
+  }
+
+  private async withTransaction<T>(
+    handler: (query: AutomationDeps['queryFn']) => Promise<T>,
+  ): Promise<T> {
+    if (this.deps.transaction) {
+      return this.deps.transaction(async ({ query }) => handler(query))
+    }
+    return handler(this.deps.queryFn)
   }
 
   private async executeCreateRecord(

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -52,6 +52,7 @@ import {
 } from './automation-scheduler'
 import { RedisLeaderLock, type RedisLeaderLockClient } from './redis-leader-lock'
 import { getRedisClient } from '../db/redis'
+import { poolManager } from '../integration/db/connection-pool'
 import { randomBytes } from 'crypto'
 import { AutomationLogService } from './automation-log-service'
 import { AutomationJobService } from './automation-job-service'
@@ -836,6 +837,20 @@ export class AutomationService {
     const deps: AutomationDeps = {
       eventBus,
       queryFn,
+      transaction: async (handler) => poolManager.get().transaction(async ({ query }) => {
+        const txQuery: AutomationQueryFn = async (sqlText, params) => {
+          const result = await query(sqlText, params)
+          return {
+            rows: Array.isArray((result as { rows?: unknown[] }).rows)
+              ? (result as { rows: unknown[] }).rows
+              : [],
+            rowCount: typeof (result as { rowCount?: number }).rowCount === 'number'
+              ? (result as { rowCount: number }).rowCount
+              : undefined,
+          }
+        }
+        return handler({ query: txQuery })
+      }),
       fetchFn,
       notificationService,
     }

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -4,11 +4,12 @@ import {
   acquireAutoNumberSheetWriteLock,
   allocateAutoNumberValues,
 } from './auto-number-service'
-import { validateLongTextValue } from './field-codecs'
+import { normalizeJson, validateLongTextValue } from './field-codecs'
 import { fieldTypeRegistry } from './field-type-registry'
 import { loadFieldsForSheet, loadSheetRow } from './loaders'
 import { MultitableRecordLockedError, MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
 import { ensureRecordNotLocked, mapRecordLockState } from './record-lock'
+import { recordRecordRevision } from './record-history-service'
 import { isFieldAlwaysReadOnly } from './permission-derivation'
 import {
   listRecords as listRecordsViaQueryService,
@@ -553,12 +554,36 @@ export async function deleteRecord(
   // be deleted via the SDK (it must be unlocked first through the explicit unlock action).
   await guardRecordNotLockedForPlugin(query, input.sheetId, input.recordId)
 
+  const current = await query(
+    `SELECT version, data
+       FROM meta_records
+      WHERE id = $1 AND sheet_id = $2
+      FOR UPDATE`,
+    [input.recordId, input.sheetId],
+  )
+  const currentRow = (current.rows as Array<{ version?: unknown; data?: unknown }>)[0]
+  if (!currentRow) {
+    throw new MultitableRecordNotFoundError(`Record not found: ${input.recordId}`)
+  }
+
   // 4c-2 scope boundary (design-lock §8, out-of-scope): this plugin-SDK delete path is intentionally
-  // NOT wired to tombstone-capture (nor to meta_records_trash / meta_record_revisions). It already
-  // destroys the row irrecoverably today, independent of MULTITABLE_TOMBSTONE_CAPTURE_ENABLED — the
-  // flag's "every destruction is captured" guarantee covers only record-service.deleteRecord and
-  // dropFieldCascade. Giving this path trash+capture parity is a separate follow-up rung, not 4c-2.
+  // NOT wired to tombstone-capture (nor to meta_records_trash). It still destroys the row irrecoverably
+  // today, independent of MULTITABLE_TOMBSTONE_CAPTURE_ENABLED — the flag's "every destruction is
+  // captured" guarantee covers only record-service.deleteRecord and dropFieldCascade. D-1 only adds the
+  // append-only delete revision needed for point-in-time correctness; trash+capture parity is D-2.
   await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [input.recordId])
+
+  const version = Number(currentRow.version ?? 1)
+  await recordRecordRevision(query, {
+    sheetId: input.sheetId,
+    recordId: input.recordId,
+    version: Number.isFinite(version) ? version : 1,
+    action: 'delete',
+    source: 'plugin',
+    changedFieldIds: [],
+    patch: {},
+    snapshot: normalizeJson(currentRow.data),
+  })
 
   // lock-guarded: plugin-SDK deleteRecord (M1) — guardRecordNotLockedForPlugin(actor=null) rejected above.
   const deleted = await query(
@@ -574,6 +599,6 @@ export async function deleteRecord(
   return {
     id: input.recordId,
     sheetId: input.sheetId,
-    version: Number(row.version ?? 1),
+    version: Number(row.version ?? version),
   }
 }

--- a/packages/core-backend/src/routes/multitable-button.ts
+++ b/packages/core-backend/src/routes/multitable-button.ts
@@ -62,6 +62,18 @@ import { Logger } from '../core/logger'
 type PoolLike = ConnectionPool & { query: QueryFn }
 const logger = new Logger('MultitableButton')
 
+function asExecutorQuery(
+  query: (sql: string, params?: unknown[]) => Promise<{ rows?: unknown[]; rowCount?: number | null }>,
+): QueryFn {
+  return async (sql, params) => {
+    const result = await query(sql, params)
+    return {
+      rows: Array.isArray(result.rows) ? result.rows : [],
+      rowCount: typeof result.rowCount === 'number' ? result.rowCount : result.rowCount ?? undefined,
+    }
+  }
+}
+
 // B1-S1 D0-A enabled actions. `record_click` = executor-owned INERT (read-gated,
 // requestId-optional, NO confirm). `send_notification` = first side-effecting
 // action (notify-gated via canSendNotification, durable + deduped + audited in one route transaction).
@@ -626,7 +638,11 @@ export function createMultitableButtonRoutes(): Router {
         actorId: access.userId,
         triggerEvent: { _trigger: 'button', fieldId, requestId },
       }
-      const executor = new AutomationExecutor({ eventBus, queryFn: query })
+      const executor = new AutomationExecutor({
+        eventBus,
+        queryFn: query,
+        transaction: async (handler) => pool.transaction(async ({ query: txq }) => handler({ query: asExecutorQuery(txq) })),
+      })
       const step = await executor.runSingleAction(
         { type: policy.dispatchType, config: normalizeJson(property.actionConfig) },
         context,

--- a/packages/core-backend/tests/integration/multitable-d1-delete-revisions-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-d1-delete-revisions-realdb.test.ts
@@ -109,6 +109,14 @@ async function afterDeleteState(recordId: string) {
   return reconstructRecordsAtT(q, SHEET, new Date(Date.now() + 1_000).toISOString(), [recordId])
 }
 
+async function linkCount(recordId: string): Promise<number> {
+  const res = await q(
+    'SELECT COUNT(*)::int AS n FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1',
+    [recordId],
+  )
+  return Number((res.rows[0] as { n?: number } | undefined)?.n ?? 0)
+}
+
 describeIfDatabase('Global History D-1 uncaptured hard-delete revisions (real DB)', () => {
   beforeAll(async () => {
     await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE, 'D1 Delete Base', ACTOR])
@@ -138,6 +146,30 @@ describeIfDatabase('Global History D-1 uncaptured hard-delete revisions (real DB
        BEFORE INSERT ON meta_record_revisions
        FOR EACH ROW EXECUTE FUNCTION d1_delete_revision_fail_${TS}()`,
     )
+    // D1-5b (review P2-1): fail the RECORD DELETE step itself — the LAST statement of the delete flow —
+    // so the earlier same-flow writes (link purge + delete revision) MUST roll back for the golden to
+    // pass. The original D1-5 pair injects at the revision INSERT, which precedes the DELETE: nothing
+    // after it has run yet, so those tests pass with or without a transaction. This trigger is what makes
+    // the withTransaction plumbing observable: neuter it into a sequential fallback and these goldens go
+    // red (a delete revision committed for a record that still exists = the exact half-state D-1 must
+    // never produce, plus the seeded inbound link vanishes).
+    await q(
+      `CREATE OR REPLACE FUNCTION d1_record_delete_fail_${TS}()
+       RETURNS trigger AS $$
+       BEGIN
+         IF OLD.id LIKE 'rec_d1_${TS}_txfail_%' THEN
+           RAISE EXCEPTION 'forced D1 record delete failure';
+         END IF;
+         RETURN OLD;
+       END;
+       $$ LANGUAGE plpgsql`,
+    )
+    await q('DROP TRIGGER IF EXISTS d1_record_delete_fail_trigger ON meta_records')
+    await q(
+      `CREATE TRIGGER d1_record_delete_fail_trigger
+       BEFORE DELETE ON meta_records
+       FOR EACH ROW EXECUTE FUNCTION d1_record_delete_fail_${TS}()`,
+    )
   })
 
   afterEach(async () => {
@@ -149,6 +181,8 @@ describeIfDatabase('Global History D-1 uncaptured hard-delete revisions (real DB
   afterAll(async () => {
     await q('DROP TRIGGER IF EXISTS d1_delete_revision_fail_trigger ON meta_record_revisions').catch(() => {})
     await q(`DROP FUNCTION IF EXISTS d1_delete_revision_fail_${TS}()`).catch(() => {})
+    await q('DROP TRIGGER IF EXISTS d1_record_delete_fail_trigger ON meta_records').catch(() => {})
+    await q(`DROP FUNCTION IF EXISTS d1_record_delete_fail_${TS}()`).catch(() => {})
     await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
@@ -232,5 +266,59 @@ describeIfDatabase('Global History D-1 uncaptured hard-delete revisions (real DB
     await expect(transaction(({ query }) => deleteRecord({ query, sheetId: SHEET, recordId }))).rejects.toThrow('forced D1 delete revision failure')
     expect(await recordExists(recordId)).toBe(true)
     expect(await deleteRevisionCount(recordId)).toBe(0)
+  })
+
+  // ── D1-5b (adversarial-review P2-1): the DELETE step itself fails ───────────────────────────────────
+  // The D1-5 pair above injects at the revision INSERT, which runs BEFORE the record DELETE — nothing
+  // later has executed, so those goldens pass with or without a transaction (mutation-verified: neutering
+  // withTransaction left the whole suite green). These two pin the transaction plumbing itself: the
+  // failure fires at the LAST statement, so the earlier link purge and delete revision MUST roll back.
+  // A sequential (non-transactional) implementation commits both → deleteRevisionCount===1 for a record
+  // that still exists (a PIT "record is dead" lie, worse than the original defect) and the link vanishes.
+
+  test('D1-5b: automation record-DELETE failure rolls back the delete revision AND the link purge (true atomicity)', async () => {
+    const recordId = `rec_d1_${TS}_txfail_auto`
+    const neighborId = `rec_d1_${TS}_nb_auto`
+    const snapshot = { name: 'automation-tx-atomicity' }
+    await insertRecord(recordId, snapshot, 1)
+    await insertRecord(neighborId, { name: 'neighbor' }, 1)
+    await seedCreateRevision(recordId, snapshot, 1)
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [
+      `lnk_d1_${TS}_auto`,
+      FIELD_NAME,
+      neighborId,
+      recordId,
+    ])
+    expect(await linkCount(recordId)).toBe(1)
+
+    const execution = await makeExecutor().execute(deleteRule(), { sheetId: SHEET, recordId, actorId: ACTOR, data: snapshot })
+    expect(execution.steps[0]?.status).toBe('failed')
+    expect(execution.steps[0]?.error).toContain('forced D1 record delete failure')
+
+    expect(await recordExists(recordId)).toBe(true)
+    expect(await deleteRevisionCount(recordId)).toBe(0) // revision rolled back with the txn
+    expect(await linkCount(recordId)).toBe(1) // link purge rolled back with the txn
+  })
+
+  test('D1-5b: plugin-SDK record-DELETE failure rolls back the delete revision AND the link purge (true atomicity)', async () => {
+    const recordId = `rec_d1_${TS}_txfail_plugin`
+    const neighborId = `rec_d1_${TS}_nb_plugin`
+    const snapshot = { name: 'plugin-tx-atomicity' }
+    await insertRecord(recordId, snapshot, 1)
+    await insertRecord(neighborId, { name: 'neighbor' }, 1)
+    await seedCreateRevision(recordId, snapshot, 1)
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [
+      `lnk_d1_${TS}_plugin`,
+      FIELD_NAME,
+      neighborId,
+      recordId,
+    ])
+    expect(await linkCount(recordId)).toBe(1)
+
+    await expect(transaction(({ query }) => deleteRecord({ query, sheetId: SHEET, recordId }))).rejects.toThrow('forced D1 record delete failure')
+
+    expect(await recordExists(recordId)).toBe(true)
+    expect(await deleteRevisionCount(recordId)).toBe(0)
+    expect(await linkCount(recordId)).toBe(1)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-d1-delete-revisions-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-d1-delete-revisions-realdb.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Global History D-1 — automation/plugin-SDK hard deletes must append delete revisions (real DB).
+ *
+ * D-1 is revision-only: it fixes point-in-time correctness for the two hard-delete side doors that
+ * previously removed `meta_records` rows without an `action='delete'` row in `meta_record_revisions`.
+ * It deliberately does NOT add trash, tombstone capture, or recoverability (those are D-2).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus } from '../../src/integration/events/event-bus'
+import {
+  AutomationExecutor,
+  type AutomationDeps,
+  type AutomationRule,
+} from '../../src/multitable/automation-executor'
+import { deleteRecord, type MultitableRecordsQueryFn } from '../../src/multitable/records'
+import { reconstructRecordsAtT } from '../../src/multitable/record-reconstructor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_d1_del_${TS}`
+const SHEET = `sheet_d1_del_${TS}`
+const FIELD_NAME = `field_d1_del_${TS}_name`
+const ACTOR = `u_d1_del_${TS}`
+const CREATE_T = '2026-01-01T00:00:00.000Z'
+const BEFORE_DELETE_T = '2026-01-02T00:00:00.000Z'
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+
+function wrapQuery(query: (sqlText: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>): MultitableRecordsQueryFn {
+  return async (sqlText, params) => {
+    const result = await query(sqlText, params)
+    return {
+      rows: Array.isArray((result as { rows?: unknown[] }).rows) ? (result as { rows: unknown[] }).rows : [],
+      rowCount: typeof (result as { rowCount?: number }).rowCount === 'number' ? (result as { rowCount: number }).rowCount : undefined,
+    }
+  }
+}
+
+function transaction<T>(handler: (client: { query: MultitableRecordsQueryFn }) => Promise<T>): Promise<T> {
+  return poolManager.get().transaction(async ({ query }) => handler({ query: wrapQuery(query) }))
+}
+
+function makeExecutor(): AutomationExecutor {
+  const deps: AutomationDeps = {
+    eventBus: new EventBus(),
+    queryFn: (sqlText, params) => q(sqlText, params),
+    transaction: async (handler) => transaction(handler),
+  }
+  return new AutomationExecutor(deps)
+}
+
+function deleteRule(): AutomationRule {
+  return {
+    id: `rule_d1_del_${TS}_${Math.random().toString(36).slice(2)}`,
+    name: 'D1 delete',
+    sheetId: SHEET,
+    trigger: { type: 'record.updated', config: {} },
+    actions: [{ type: 'delete_record', config: {} }],
+    enabled: true,
+    createdBy: ACTOR,
+    createdAt: new Date().toISOString(),
+  } as unknown as AutomationRule
+}
+
+async function insertRecord(recordId: string, data: Record<string, unknown>, version = 1): Promise<void> {
+  await q(
+    'INSERT INTO meta_records (id, sheet_id, data, version, locked) VALUES ($1,$2,$3::jsonb,$4,false)',
+    [recordId, SHEET, JSON.stringify(data), version],
+  )
+}
+
+async function seedCreateRevision(recordId: string, data: Record<string, unknown>, version = 1): Promise<void> {
+  await q(
+    `INSERT INTO meta_record_revisions
+       (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(), $1, $2, $3, 'create', 'rest', ARRAY['name']::text[], '{}'::jsonb, $4::jsonb, $5)`,
+    [SHEET, recordId, version, JSON.stringify(data), CREATE_T],
+  )
+}
+
+async function latestRevision(recordId: string): Promise<{ action: string; source: string; version: number; snapshot: Record<string, unknown> | null } | undefined> {
+  const res = await q(
+    `SELECT action, source, version, snapshot
+       FROM meta_record_revisions
+      WHERE sheet_id = $1 AND record_id = $2
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1`,
+    [SHEET, recordId],
+  )
+  return res.rows[0] as { action: string; source: string; version: number; snapshot: Record<string, unknown> | null } | undefined
+}
+
+async function recordExists(recordId: string): Promise<boolean> {
+  const res = await q('SELECT 1 FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, SHEET])
+  return Boolean(res.rows[0])
+}
+
+async function deleteRevisionCount(recordId: string): Promise<number> {
+  const res = await q(
+    "SELECT COUNT(*)::int AS n FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete'",
+    [SHEET, recordId],
+  )
+  return Number((res.rows[0] as { n?: number } | undefined)?.n ?? 0)
+}
+
+async function afterDeleteState(recordId: string) {
+  return reconstructRecordsAtT(q, SHEET, new Date(Date.now() + 1_000).toISOString(), [recordId])
+}
+
+describeIfDatabase('Global History D-1 uncaptured hard-delete revisions (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE, 'D1 Delete Base', ACTOR])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'D1 Delete Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+      FIELD_NAME,
+      SHEET,
+      'Name',
+      'string',
+      '{}',
+      1,
+    ])
+    await q(
+      `CREATE OR REPLACE FUNCTION d1_delete_revision_fail_${TS}()
+       RETURNS trigger AS $$
+       BEGIN
+         IF NEW.action = 'delete' AND NEW.record_id LIKE 'rec_d1_${TS}_fail_%' THEN
+           RAISE EXCEPTION 'forced D1 delete revision failure';
+         END IF;
+         RETURN NEW;
+       END;
+       $$ LANGUAGE plpgsql`,
+    )
+    await q('DROP TRIGGER IF EXISTS d1_delete_revision_fail_trigger ON meta_record_revisions')
+    await q(
+      `CREATE TRIGGER d1_delete_revision_fail_trigger
+       BEFORE INSERT ON meta_record_revisions
+       FOR EACH ROW EXECUTE FUNCTION d1_delete_revision_fail_${TS}()`,
+    )
+  })
+
+  afterEach(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE record_id LIKE $1 OR foreign_record_id LIKE $1', [`rec_d1_${TS}_%`]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+  })
+
+  afterAll(async () => {
+    await q('DROP TRIGGER IF EXISTS d1_delete_revision_fail_trigger ON meta_record_revisions').catch(() => {})
+    await q(`DROP FUNCTION IF EXISTS d1_delete_revision_fail_${TS}()`).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+      throw new Error('real-DB allowlist step is missing DATABASE_URL')
+    }
+    expect(true).toBe(true)
+  })
+
+  test('D1-1/D1-3/D1-4: automation delete_record writes source=automation delete revision and PIT excludes it after delete only', async () => {
+    const recordId = `rec_d1_${TS}_auto`
+    const snapshot = { name: 'automation-delete', value: 7 }
+    await insertRecord(recordId, snapshot, 3)
+    await seedCreateRevision(recordId, snapshot, 3)
+
+    expect((await reconstructRecordsAtT(q, SHEET, BEFORE_DELETE_T, [recordId])).get(recordId)).toMatchObject({
+      exists: true,
+      data: snapshot,
+    })
+
+    const execution = await makeExecutor().execute(deleteRule(), { sheetId: SHEET, recordId, actorId: ACTOR, data: snapshot })
+    expect(execution.steps[0]?.status).toBe('success')
+    expect(await recordExists(recordId)).toBe(false)
+
+    expect(await latestRevision(recordId)).toMatchObject({
+      action: 'delete',
+      source: 'automation',
+      version: 3,
+      snapshot,
+    })
+    expect((await afterDeleteState(recordId)).get(recordId)).toMatchObject({ exists: false, data: null })
+  })
+
+  test('D1-2/D1-3/D1-4: plugin-SDK deleteRecord writes source=plugin delete revision and PIT excludes it after delete only', async () => {
+    const recordId = `rec_d1_${TS}_plugin`
+    const snapshot = { name: 'plugin-delete', nested: { ok: true } }
+    await insertRecord(recordId, snapshot, 2)
+    await seedCreateRevision(recordId, snapshot, 2)
+
+    expect((await reconstructRecordsAtT(q, SHEET, BEFORE_DELETE_T, [recordId])).get(recordId)).toMatchObject({
+      exists: true,
+      data: snapshot,
+    })
+
+    await transaction(({ query }) => deleteRecord({ query, sheetId: SHEET, recordId }))
+    expect(await recordExists(recordId)).toBe(false)
+
+    expect(await latestRevision(recordId)).toMatchObject({
+      action: 'delete',
+      source: 'plugin',
+      version: 2,
+      snapshot,
+    })
+    expect((await afterDeleteState(recordId)).get(recordId)).toMatchObject({ exists: false, data: null })
+  })
+
+  test('D1-5: automation revision failure rolls back the hard delete and writes no delete revision', async () => {
+    const recordId = `rec_d1_${TS}_fail_auto`
+    const snapshot = { name: 'automation-atomicity' }
+    await insertRecord(recordId, snapshot, 1)
+    await seedCreateRevision(recordId, snapshot, 1)
+
+    const execution = await makeExecutor().execute(deleteRule(), { sheetId: SHEET, recordId, actorId: ACTOR, data: snapshot })
+    expect(execution.steps[0]?.status).toBe('failed')
+    expect(execution.steps[0]?.error).toContain('forced D1 delete revision failure')
+    expect(await recordExists(recordId)).toBe(true)
+    expect(await deleteRevisionCount(recordId)).toBe(0)
+  })
+
+  test('D1-5: plugin-SDK revision failure rolls back the hard delete and writes no delete revision', async () => {
+    const recordId = `rec_d1_${TS}_fail_plugin`
+    const snapshot = { name: 'plugin-atomicity' }
+    await insertRecord(recordId, snapshot, 1)
+    await seedCreateRevision(recordId, snapshot, 1)
+
+    await expect(transaction(({ query }) => deleteRecord({ query, sheetId: SHEET, recordId }))).rejects.toThrow('forced D1 delete revision failure')
+    expect(await recordExists(recordId)).toBe(true)
+    expect(await deleteRevisionCount(recordId)).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-records.test.ts
+++ b/packages/core-backend/tests/unit/multitable-records.test.ts
@@ -41,12 +41,22 @@ type FakeLink = {
   foreign_record_id: string
 }
 
+type FakeRevision = {
+  sheet_id: string
+  record_id: string
+  version: number
+  action: string
+  source: string
+  snapshot: Record<string, unknown> | null
+}
+
 function createQuery(): {
   query: MultitableRecordsQueryFn
   sheets: FakeSheet[]
   fields: FakeField[]
   records: FakeRecord[]
   links: FakeLink[]
+  revisions: FakeRevision[]
 } {
   const sheets: FakeSheet[] = [
     {
@@ -124,6 +134,7 @@ function createQuery(): {
   ]
   const records: FakeRecord[] = []
   const links: FakeLink[] = []
+  const revisions: FakeRevision[] = []
   const autoNumberNextByField = new Map<string, number>()
 
   const query: MultitableRecordsQueryFn = async (sql, params = []) => {
@@ -185,6 +196,19 @@ function createQuery(): {
       const [recordId, sheetId] = params as [string, string]
       return {
         rows: records.filter((record) => record.id === recordId && record.sheet_id === sheetId),
+      }
+    }
+
+    if (
+      normalized.includes('FROM meta_records') &&
+      normalized.includes('WHERE id = $1 AND sheet_id = $2') &&
+      normalized.includes('SELECT version, data')
+    ) {
+      const [recordId, sheetId] = params as [string, string]
+      return {
+        rows: records
+          .filter((record) => record.id === recordId && record.sheet_id === sheetId)
+          .map((record) => ({ version: record.version, data: record.data })),
       }
     }
 
@@ -325,6 +349,31 @@ function createQuery(): {
       return { rows: [], rowCount: 1 }
     }
 
+    if (normalized.startsWith('INSERT INTO meta_record_revisions')) {
+      const [, sheetId, recordId, version, action, source, , , , snapshotJson] = params as [
+        string,
+        string,
+        string,
+        number,
+        string,
+        string,
+        string | null,
+        string[],
+        string,
+        string | null,
+        string | null,
+      ]
+      revisions.push({
+        sheet_id: sheetId,
+        record_id: recordId,
+        version,
+        action,
+        source,
+        snapshot: snapshotJson ? JSON.parse(snapshotJson) : null,
+      })
+      return { rows: [], rowCount: 1 }
+    }
+
     if (normalized.startsWith('DELETE FROM meta_records')) {
       const [recordId, sheetId] = params as [string, string]
       const index = records.findIndex((record) => record.id === recordId && record.sheet_id === sheetId)
@@ -341,7 +390,7 @@ function createQuery(): {
     return { rows: [] }
   }
 
-  return { query, sheets, fields, records, links }
+  return { query, sheets, fields, records, links, revisions }
 }
 
 describe('multitable records helper', () => {
@@ -753,7 +802,7 @@ describe('multitable records helper', () => {
   })
 
   it('deletes an existing record', async () => {
-    const { query, records, links } = createQuery()
+    const { query, records, links, revisions } = createQuery()
     records.push({
       id: 'rec_existing',
       sheet_id: 'sheet_service_ticket',
@@ -781,6 +830,20 @@ describe('multitable records helper', () => {
     })
     expect(records).toHaveLength(0)
     expect(links).toHaveLength(0)
+    expect(revisions).toEqual([
+      expect.objectContaining({
+        sheet_id: 'sheet_service_ticket',
+        record_id: 'rec_existing',
+        version: 2,
+        action: 'delete',
+        source: 'plugin',
+        snapshot: {
+          ticketNo: 'TK-1001',
+          title: 'Broken compressor',
+          priority: 'urgent',
+        },
+      }),
+    ])
   })
 
   it('throws when deleting a missing record', async () => {


### PR DESCRIPTION
## Summary
- add D-1 delete-revision emission for automation delete_record and plugin-SDK deleteRecord
- keep scope revision-only: no trash, no tombstone capture, no recovery semantics, no flag
- wire the new real-DB golden into plugin-tests so it cannot skip silently
- add a dated dev/verification MD with mutation evidence

## Verification
- pnpm --filter @metasheet/core-backend run type-check
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-records.test.ts tests/unit/automation-v1.test.ts --reporter=dot
- DATABASE_URL='postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_test' METASHEET_REAL_DB_TEST_STEP=1 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-d1-delete-revisions-realdb.test.ts --reporter=dot
- DATABASE_URL='postgres://metasheet:metasheet@127.0.0.1:5435/metasheet_test' METASHEET_REAL_DB_TEST_STEP=1 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-record-reconstructor-realdb.test.ts --reporter=dot
- git diff --check

## Mutation evidence
Temporarily changed both D-1 emitters from action='delete' to action='update'. The D-1 real-DB suite failed 4/5 as expected: automation/plugin action assertions and both atomicity rollback cases went red. Reverted and reran to 5/5 green.

## Out of scope
D-2 recoverability, public-form create revisions, any feature flag, and any PIT Reset/Revert behavior change beyond correcting the revision stream they consume.