### PR TITLE
fix(auth): bootstrap DingTalk openId before grant denial

### DIFF
--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -498,6 +498,54 @@ async function upsertExternalIdentity(localUserId: string, dtUser: DingTalkUserI
   })
 }
 
+// Directory-managed users can be found by unionId before their web-OAuth openId
+// is known. Enrich that missing openId without granting a rejected login.
+async function enrichMissingOpenIdForRejectedLogin(localUserId: string, dtUser: DingTalkUserInfo): Promise<void> {
+  if (!dtUser.openId) return
+
+  const config = readDingTalkOauthConfig()
+  const externalKey = buildExternalKey(dtUser)
+  const openId = dtUser.openId
+  const unionId = dtUser.unionId || ''
+  const profile = JSON.stringify(dtUser)
+
+  await transaction(async (client) => {
+    const conflictResult = await client.query(
+      `SELECT local_user_id
+       FROM user_external_identities
+       WHERE provider = $1
+         AND local_user_id <> $2
+         AND (
+           external_key = $3
+           OR ($4 <> '' AND provider_open_id = $4 AND corp_id IS NOT DISTINCT FROM $6)
+           OR ($5 <> '' AND provider_union_id = $5 AND corp_id IS NOT DISTINCT FROM $6)
+         )
+       LIMIT 1`,
+      [PROVIDER, localUserId, externalKey, openId, unionId, config.corpId || null],
+    )
+    if (conflictResult.rows.length > 0) {
+      throw createPolicyError('DingTalk identity is already bound to another local user', {
+        statusCode: 409,
+        code: 'identity_already_bound',
+      })
+    }
+
+    await client.query(
+      `UPDATE user_external_identities
+       SET external_key = $3,
+           provider_union_id = COALESCE($4, provider_union_id),
+           provider_open_id = $5,
+           corp_id = COALESCE($6, corp_id),
+           profile = $7::jsonb,
+           updated_at = NOW()
+       WHERE provider = $1
+         AND local_user_id = $2
+         AND COALESCE(provider_open_id, '') = ''`,
+      [PROVIDER, localUserId, externalKey, dtUser.unionId || null, openId, config.corpId || null, profile],
+    )
+  })
+}
+
 async function findUserByEmail(email: string): Promise<LocalUserRow | null> {
   const result = await query<LocalUserRow>(
     `SELECT id,
@@ -632,12 +680,14 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
     assertLocalUserLoginAllowed(identityUser)
     const grantEnabled = await readGrantEnabled(identityUser.id)
     if (requireGrant && grantEnabled !== true) {
+      await enrichMissingOpenIdForRejectedLogin(identityUser.id, dtUser)
       throw createPolicyError('DingTalk login is not enabled for this user', {
         statusCode: 403,
         code: 'grant_required',
       })
     }
     if (grantEnabled === false) {
+      await enrichMissingOpenIdForRejectedLogin(identityUser.id, dtUser)
       throw createPolicyError(DINGTALK_LOGIN_DISABLED_ERROR, {
         statusCode: 403,
         code: 'grant_disabled',

--- a/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
@@ -125,6 +125,86 @@ describe('dingtalk oauth login gates', () => {
     })
   })
 
+  it('bootstraps a missing openId for an existing union-linked identity before strict grant rejection', async () => {
+    vi.stubEnv('DINGTALK_AUTH_REQUIRE_GRANT', '1')
+    const txCalls: Array<{ sql: string; params: unknown[] }> = []
+    pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
+      const txQuery = vi.fn(async (sql: string, params: unknown[]) => {
+        txCalls.push({ sql: String(sql), params })
+        if (String(sql).includes('SELECT local_user_id')) return { rows: [] }
+        return { rows: [] }
+      })
+      return callback({ query: txQuery as unknown as typeof pgMocks.query })
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    await expect(exchangeCodeForUser('code-openid-bootstrap')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 403,
+      code: 'grant_required',
+      message: 'DingTalk login is not enabled for this user',
+    })
+
+    const update = txCalls.find(call => call.sql.includes('UPDATE user_external_identities'))
+    expect(update, 'expected rejected login to enrich the missing openId').toBeTruthy()
+    expect(update!.sql).toContain('provider_open_id = $5')
+    expect(update!.sql).not.toContain('last_login_at')
+    expect(update!.sql).toContain("COALESCE(provider_open_id, '') = ''")
+    expect(update!.params).toEqual([
+      'dingtalk',
+      'user-1',
+      'ding-corp:open-1',
+      'union-1',
+      'open-1',
+      'ding-corp',
+      expect.stringContaining('"openId":"open-1"'),
+    ])
+  })
+
+  it('does not bootstrap openId when the OAuth identity already belongs to another local user', async () => {
+    vi.stubEnv('DINGTALK_AUTH_REQUIRE_GRANT', '1')
+    const txCalls: Array<{ sql: string; params: unknown[] }> = []
+    pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
+      const txQuery = vi.fn(async (sql: string, params: unknown[]) => {
+        txCalls.push({ sql: String(sql), params })
+        if (String(sql).includes('SELECT local_user_id')) {
+          return { rows: [{ local_user_id: 'other-user' }] }
+        }
+        return { rows: [] }
+      })
+      return callback({ query: txQuery as unknown as typeof pgMocks.query })
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    await expect(exchangeCodeForUser('code-openid-conflict')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 409,
+      code: 'identity_already_bound',
+    })
+
+    expect(txCalls.some(call => call.sql.includes('UPDATE user_external_identities'))).toBe(false)
+  })
+
   it('allows email-linked login when strict grant mode is enabled and grant is present', async () => {
     vi.stubEnv('DINGTALK_AUTH_REQUIRE_GRANT', '1')
     vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1')


### PR DESCRIPTION
## Summary
- Enrich an existing union-linked DingTalk identity with a missing web-OAuth openId before strict grant denial.
- Keep the authorization gate intact: rejected users still receive grant_required / grant_disabled and no session token is issued.
- Guard against identity takeover by rejecting bootstrap when the returned openId/union identity already belongs to another local user.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-oauth-login-gates.test.ts --watch=false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-oauth-state-store.test.ts tests/unit/auth-login-routes.test.ts --watch=false
- pnpm --filter @metasheet/core-backend build
