### PR TITLE
feat(directory): batch admit synced DingTalk users

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -140,6 +140,60 @@
       </article>
     </article>
 
+    <article v-if="batchAdmissionOnboardingPackets.length > 0" class="directory-admin__progress-card">
+      <div class="directory-admin__section-head">
+        <div>
+          <h2>批量创建临时凭据</h2>
+          <p class="directory-admin__hint">以下目录成员已批量创建本地用户并完成绑定。扫码登录授权默认未开启，请先通过安全渠道下发登录账号与临时密码。</p>
+        </div>
+        <div class="directory-admin__actions">
+          <button class="directory-admin__button directory-admin__button--secondary" type="button" @click="clearBatchAdmissionOnboardingPackets()">
+            关闭结果
+          </button>
+        </div>
+      </div>
+
+      <article
+        v-for="packet in batchAdmissionOnboardingPackets"
+        :key="packet.userId"
+        class="directory-admin__review-admission"
+      >
+        <div class="directory-admin__account-grid">
+          <div>
+            <strong>本地用户</strong>
+            <div>{{ packet.name || packet.email || packet.username || packet.mobile || packet.userId }}</div>
+          </div>
+          <div>
+            <strong>登录账号</strong>
+            <div>{{ packet.email || packet.username || packet.mobile || packet.userId }}</div>
+          </div>
+          <div>
+            <strong>用户 ID</strong>
+            <div>{{ packet.userId }}</div>
+          </div>
+          <div>
+            <strong>手机号</strong>
+            <div>{{ packet.mobile || '未填写' }}</div>
+          </div>
+        </div>
+        <p class="directory-admin__status">
+          临时密码：{{ packet.temporaryPassword }}
+        </p>
+        <p v-if="packet.onboarding?.acceptInviteUrl" class="directory-admin__hint">
+          邀请链接：
+          <a :href="packet.onboarding.acceptInviteUrl" target="_blank" rel="noreferrer">
+            {{ packet.onboarding.acceptInviteUrl }}
+          </a>
+        </p>
+        <p v-else class="directory-admin__hint">
+          该账号未生成邀请链接，请直接分发登录账号和临时密码。
+        </p>
+        <pre v-if="packet.onboarding?.inviteMessage" class="directory-admin__invite">
+{{ packet.onboarding.inviteMessage }}
+        </pre>
+      </article>
+    </article>
+
     <div class="directory-admin__layout">
       <aside class="directory-admin__panel directory-admin__panel--list">
         <div class="directory-admin__section-head">
@@ -1017,6 +1071,14 @@
               @click="void batchBindReviewItems()"
             >
               {{ reviewBatchProcessing ? '处理中...' : `批量绑定 (${selectedReviewBindEntries.length})` }}
+            </button>
+            <button
+              class="directory-admin__button"
+              type="button"
+              :disabled="reviewBatchProcessing || selectedReviewAdmissionIds.length === 0"
+              @click="void batchAdmitReviewItems()"
+            >
+              {{ reviewBatchProcessing ? '处理中...' : `批量创建并绑定 (${selectedReviewAdmissionIds.length})` }}
             </button>
             <label class="directory-admin__toggle directory-admin__toggle--compact">
               <input v-model="reviewDisableDingTalkGrant" type="checkbox" />
@@ -1977,7 +2039,7 @@ type DirectoryBindingRecommendationStatusCode =
 
 type PendingBindingView = 'all' | 'recommended' | 'manual'
 type PendingBindingManualReasonFilter = 'all' | 'no_exact_match' | 'conflict'
-type ReviewBatchProgressKind = 'bind' | 'recommend' | 'unbind'
+type ReviewBatchProgressKind = 'bind' | 'recommend' | 'admit' | 'unbind'
 type ReviewBatchProgressPhase = 'submitting' | 'refreshing' | 'completed' | 'failed'
 
 type ReviewBatchProgress = {
@@ -2237,6 +2299,7 @@ const manualAdmissionDrafts = reactive<Record<string, ManualAdmissionDraft>>({})
 const manualAdmissionExpanded = reactive<Record<string, boolean>>({})
 const manualAdmissionResult = ref<ManualAdmissionResult | null>(null)
 const autoAdmissionOnboardingPackets = ref<AutoAdmissionOnboardingPacket[]>([])
+const batchAdmissionOnboardingPackets = ref<AutoAdmissionOnboardingPacket[]>([])
 const grantToggles = reactive<Record<string, boolean>>({})
 const selectedReviewIds = reactive<Record<string, boolean>>({})
 const reviewDisableDingTalkGrant = ref(true)
@@ -2572,6 +2635,16 @@ const selectedReviewBindEntries = computed(() => (
     }))
     .filter((item) => item.localUserRef.length > 0)
 ))
+const selectedReviewAdmissionIds = computed(() => (
+  filteredReviewItems.value
+    .filter((item) => (
+      item.kind === 'pending_binding'
+      && selectedReviewIds[item.account.id]
+      && !item.account.localUser
+      && !item.actionable.canConfirmRecommendation
+    ))
+    .map((item) => item.account.id)
+))
 const selectedReviewBatchIds = computed(() => (
   filteredReviewItems.value
     .filter((item) => item.actionable.canBatchUnbind && selectedReviewIds[item.account.id])
@@ -2679,6 +2752,7 @@ function resetDraft() {
   for (const key of Object.keys(grantToggles)) delete grantToggles[key]
   for (const key of Object.keys(selectedReviewIds)) delete selectedReviewIds[key]
   autoAdmissionOnboardingPackets.value = []
+  batchAdmissionOnboardingPackets.value = []
   draft.name = ''
   draft.corpId = ''
   draft.appKey = ''
@@ -3474,6 +3548,7 @@ async function selectIntegration(integrationId: string): Promise<void> {
   manualDepartmentId.value = ''
   manualDepartmentName.value = ''
   clearAutoAdmissionOnboardingPackets()
+  clearBatchAdmissionOnboardingPackets()
   clearFocusedAccount()
   accountPage.value = 1
   accountTotal.value = 0
@@ -3914,6 +3989,10 @@ function clearAutoAdmissionOnboardingPackets(): void {
   autoAdmissionOnboardingPackets.value = []
 }
 
+function clearBatchAdmissionOnboardingPackets(): void {
+  batchAdmissionOnboardingPackets.value = []
+}
+
 function readCreatedLocalUserOption(data: Record<string, unknown>, fallback: ManualAdmissionDraft): LocalUserOption {
   const user = data.user && typeof data.user === 'object' ? data.user as Record<string, unknown> : null
   const id = typeof user?.id === 'string' ? user.id.trim() : ''
@@ -3933,6 +4012,15 @@ function readCreatedLocalUserOption(data: Record<string, unknown>, fallback: Man
 
 function readAutoAdmissionOnboardingPackets(data: Record<string, unknown> | undefined): AutoAdmissionOnboardingPacket[] {
   const rawPackets = Array.isArray(data?.autoAdmissionOnboardingPackets) ? data.autoAdmissionOnboardingPackets : []
+  return readDirectoryOnboardingPackets(rawPackets)
+}
+
+function readBatchAdmissionOnboardingPackets(data: Record<string, unknown> | undefined): AutoAdmissionOnboardingPacket[] {
+  const rawPackets = Array.isArray(data?.onboardingPackets) ? data.onboardingPackets : []
+  return readDirectoryOnboardingPackets(rawPackets)
+}
+
+function readDirectoryOnboardingPackets(rawPackets: unknown[]): AutoAdmissionOnboardingPacket[] {
   return rawPackets.flatMap((entry) => {
     if (!entry || typeof entry !== 'object') return []
     const packet = entry as Record<string, unknown>
@@ -4525,6 +4613,7 @@ function clearReviewBatchProgress() {
 
 function readReviewBatchProgressKindLabel(kind: ReviewBatchProgressKind): string {
   if (kind === 'recommend') return '推荐绑定确认'
+  if (kind === 'admit') return '批量创建并绑定'
   if (kind === 'unbind') return '批量停权处理'
   return '批量绑定'
 }
@@ -5025,6 +5114,79 @@ async function retryBackfillUserMobileAndBindReviewItem(item: DirectoryReviewIte
   clearMobileConflictHint(item.account.id)
   clearMobileOverrideConfirmation(item.account.id)
   await backfillUserMobileAndBindReviewItem(item)
+}
+
+async function batchAdmitReviewItems() {
+  if (!selectedIntegration.value || selectedReviewAdmissionIds.value.length === 0) return
+  reviewBatchProcessing.value = true
+  let appliedCount = 0
+  const batchIds = [...selectedReviewAdmissionIds.value]
+  try {
+    clearBatchAdmissionOnboardingPackets()
+    setReviewBatchProgress({
+      kind: 'admit',
+      phase: 'submitting',
+      total: batchIds.length,
+      applied: 0,
+      message: '正在批量创建本地用户并绑定目录成员...',
+    })
+    const response = await apiFetch('/api/admin/directory/accounts/batch-admit-users', {
+      method: 'POST',
+      body: JSON.stringify({
+        accountIds: batchIds,
+        enableDingTalkGrant: false,
+      }),
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '批量创建并绑定失败'))
+    const data = body?.data as Record<string, unknown> | undefined
+    const processedItems = Array.isArray(data?.items) ? data.items : []
+    appliedCount = Number(data?.updatedCount ?? processedItems.length)
+    batchAdmissionOnboardingPackets.value = readBatchAdmissionOnboardingPackets(data)
+    setReviewBatchProgress({
+      kind: 'admit',
+      phase: 'refreshing',
+      total: batchIds.length,
+      applied: appliedCount,
+      message: `已创建并绑定 ${appliedCount} / ${batchIds.length}，正在刷新目录成员与待处理队列...`,
+    })
+    await refreshAfterReviewBindings()
+    const failedCount = Number(data?.failedCount ?? 0)
+    const failedItems = Array.isArray(data?.failed) ? data.failed : []
+    const failedPreview = failedItems
+      .slice(0, 2)
+      .map((entry) => {
+        if (!entry || typeof entry !== 'object') return ''
+        const item = entry as Record<string, unknown>
+        const accountId = typeof item.accountId === 'string' ? item.accountId : ''
+        const error = typeof item.error === 'string' ? item.error : ''
+        return [accountId, error].filter(Boolean).join(': ')
+      })
+      .filter(Boolean)
+      .join('；')
+    const message = failedCount > 0
+      ? `已创建并绑定 ${appliedCount} 个目录成员，另有 ${failedCount} 个失败${failedPreview ? `：${failedPreview}` : '，请重试'}`
+      : `已创建并绑定 ${appliedCount} 个目录成员`
+    setStatus(message, failedCount > 0 ? 'error' : 'info')
+    setReviewBatchProgress({
+      kind: 'admit',
+      phase: 'completed',
+      total: batchIds.length,
+      applied: appliedCount,
+      message,
+    })
+  } catch (error) {
+    setReviewBatchProgress({
+      kind: 'admit',
+      phase: 'failed',
+      total: batchIds.length,
+      applied: appliedCount,
+      message: error instanceof Error ? error.message : '批量创建并绑定失败',
+    })
+    setStatus(error instanceof Error ? error.message : '批量创建并绑定失败', 'error')
+  } finally {
+    reviewBatchProcessing.value = false
+  }
 }
 
 async function batchBindReviewItems() {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -5290,6 +5290,221 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('暂无待处理项')
   })
 
+  it('batch-creates local users for manual pending review items without enabling DingTalk grants', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-1',
+              name: '林岚',
+              email: null,
+              openId: null,
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: true,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: createAccount({
+              id: 'account-2',
+              externalUserId: '0447654442691175',
+              name: '次页成员',
+              email: null,
+              openId: null,
+            }),
+            recommendations: [],
+            recommendationStatus: {
+              code: 'no_exact_match',
+              message: '未命中唯一的邮箱或手机号精确匹配，请人工搜索本地用户。',
+            },
+            flags: {
+              missingUnionId: false,
+              missingOpenId: true,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: false,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({ id: 'account-1', openId: null }),
+          createAccount({ id: 'account-2', externalUserId: '0447654442691175', name: '次页成员', openId: null }),
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'account-1',
+              localUser: {
+                id: 'user-1',
+                username: 'dt_0447654442691174_account',
+              },
+            },
+            {
+              id: 'account-2',
+              localUser: {
+                id: 'user-2',
+                username: 'dt_0447654442691175_account',
+              },
+            },
+          ],
+          onboardingPackets: [
+            {
+              userId: 'user-1',
+              name: '林岚',
+              email: null,
+              username: 'dt_0447654442691174_account',
+              mobile: '13900001234',
+              temporaryPassword: 'Temp#123456',
+              onboarding: {
+                inviteMessage: '账号：dt_0447654442691174_account',
+              },
+            },
+            {
+              userId: 'user-2',
+              name: '次页成员',
+              email: null,
+              username: 'dt_0447654442691175_account',
+              mobile: '13900001235',
+              temporaryPassword: 'Temp#234567',
+              onboarding: {
+                inviteMessage: '账号：dt_0447654442691175_account',
+              },
+            },
+          ],
+          updatedCount: 2,
+          failedCount: 0,
+          failed: [],
+          enableDingTalkGrant: false,
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({
+            stats: {
+              departmentCount: 12,
+              accountCount: 98,
+              pendingLinkCount: 0,
+              linkedCount: 92,
+              lastRunStatus: 'completed',
+            },
+          })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([
+          createAccount({
+            id: 'account-1',
+            openId: null,
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              username: 'dt_0447654442691174_account',
+              email: null,
+              name: '林岚',
+            },
+          }),
+          createAccount({
+            id: 'account-2',
+            externalUserId: '0447654442691175',
+            name: '次页成员',
+            openId: null,
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-2',
+              username: 'dt_0447654442691175_account',
+              email: null,
+              name: '次页成员',
+            },
+          }),
+        ]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const manualButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('人工处理'))
+    expect(manualButton).toBeTruthy()
+    manualButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(2)
+
+    const reviewCheckboxes = Array.from(container!.querySelectorAll('.directory-admin__review-item .directory-admin__review-select input[type="checkbox"]')) as HTMLInputElement[]
+    expect(reviewCheckboxes).toHaveLength(2)
+    reviewCheckboxes[0].checked = true
+    reviewCheckboxes[0].dispatchEvent(new Event('change', { bubbles: true }))
+    reviewCheckboxes[1].checked = true
+    reviewCheckboxes[1].dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const batchAdmitButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('批量创建并绑定'))
+    expect(batchAdmitButton?.textContent).toContain('(2)')
+    batchAdmitButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/batch-admit-users',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          accountIds: ['account-1', 'account-2'],
+          enableDingTalkGrant: false,
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('批量创建临时凭据')
+    expect(container?.textContent).toContain('扫码登录授权默认未开启')
+    expect(container?.textContent).toContain('dt_0447654442691174_account')
+    expect(container?.textContent).toContain('Temp#123456')
+    expect(container?.textContent).toContain('批量创建并绑定')
+    expect(container?.textContent).toContain('已完成')
+    expect(container?.textContent).toContain('进度 2 / 2')
+    expect(container?.textContent).toContain('暂无待处理项')
+  })
+
   it('tests a saved integration with diagnostics and reuses the saved secret on the backend', async () => {
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -542,6 +542,11 @@ export type DirectoryAccountBatchBindEntry = {
   enableDingTalkGrant?: boolean
 }
 
+export type DirectoryAccountBatchAdmissionInput = {
+  adminUserId: string
+  enableDingTalkGrant?: boolean
+}
+
 export type DirectoryAccountUnbindInput = {
   adminUserId: string
   disableDingTalkGrant?: boolean
@@ -579,6 +584,11 @@ export type DirectoryAccountManualAdmissionResult = DirectoryAccountMutationResu
   temporaryPassword?: string
   inviteToken: string | null
   onboarding: ReturnType<typeof buildOnboardingPacket>
+}
+
+export type DirectoryAccountBatchAdmissionOutcome = {
+  succeeded: DirectoryAccountManualAdmissionResult[]
+  failed: Array<{ accountId: string; error: string }>
 }
 
 export type DirectoryAutoAdmissionOnboardingPacket = {
@@ -3324,6 +3334,47 @@ export async function batchBindDirectoryAccounts(
       outcome.failed.push({
         accountId: entry.accountId,
         error: readErrorMessage(error, 'Failed to bind directory account'),
+      })
+    }
+  }
+  return outcome
+}
+
+export async function batchAdmitDirectoryAccountUsers(
+  directoryAccountIds: string[],
+  input: DirectoryAccountBatchAdmissionInput,
+): Promise<DirectoryAccountBatchAdmissionOutcome> {
+  const normalizedIds = Array.from(new Set(directoryAccountIds.map((item) => normalizeText(item)).filter(Boolean)))
+  const normalizedAdminUserId = normalizeText(input.adminUserId)
+  if (normalizedIds.length === 0) throw new Error('accountIds are required')
+  if (!normalizedAdminUserId) throw new Error('adminUserId is required')
+
+  const outcome: DirectoryAccountBatchAdmissionOutcome = { succeeded: [], failed: [] }
+  for (const accountId of normalizedIds) {
+    try {
+      const account = await loadDirectoryBindingTargetAccount(accountId)
+      if (!account) throw new Error('Directory account not found')
+      const fallbackName = normalizeText(account.external_user_id) || account.id
+      const admissionName = normalizeText(account.name).length >= 2 ? account.name : fallbackName
+      outcome.succeeded.push(await admitDirectoryAccountUser(account.id, {
+        adminUserId: normalizedAdminUserId,
+        name: admissionName,
+        email: account.email ?? undefined,
+        username: account.email
+          ? undefined
+          : buildDirectoryAutoAdmissionUsername({
+            id: account.id,
+            external_user_id: account.external_user_id,
+            union_id: account.union_id,
+            open_id: account.open_id,
+          }),
+        mobile: account.mobile,
+        enableDingTalkGrant: input.enableDingTalkGrant === true,
+      }))
+    } catch (error) {
+      outcome.failed.push({
+        accountId,
+        error: readErrorMessage(error, 'Failed to create and bind local user for directory account'),
       })
     }
   }

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -4,6 +4,7 @@ import { auditLog } from '../audit/audit'
 import {
   acknowledgeDirectorySyncAlert,
   admitDirectoryAccountUser,
+  batchAdmitDirectoryAccountUsers,
   batchBindDirectoryAccounts,
   batchUnbindDirectoryAccounts,
   bindDirectoryAccount,
@@ -661,6 +662,98 @@ export function adminDirectoryRouter(): Router {
             ? 400
             : 500
       jsonError(res, statusCode, 'DIRECTORY_BATCH_BIND_FAILED', message)
+    }
+  })
+
+  router.post('/accounts/batch-admit-users', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const rawAccountIds = Array.isArray(req.body?.accountIds) ? req.body.accountIds : []
+      const accountIds = rawAccountIds.filter((value): value is string => typeof value === 'string')
+      const enableDingTalkGrant = req.body?.enableDingTalkGrant === true
+      const outcome = await batchAdmitDirectoryAccountUsers(accountIds, {
+        adminUserId,
+        enableDingTalkGrant,
+      })
+
+      await Promise.all(outcome.succeeded.flatMap((result) => [
+        auditLog({
+          actorId: adminUserId,
+          actorType: 'user',
+          action: 'create',
+          resourceType: 'user',
+          resourceId: result.user.id,
+          meta: {
+            adminUserId,
+            source: 'directory_bulk_manual_admission',
+            directoryAccountId: result.account.id,
+            integrationId: result.account.integrationId,
+            email: result.user.email,
+            username: result.user.username,
+            name: result.user.name,
+            mobile: result.user.mobile,
+            generatedPassword: typeof result.temporaryPassword === 'string',
+            mode: 'bulk_manual_admission',
+            selectionSize: accountIds.length,
+          },
+        }),
+        auditLog({
+          actorId: adminUserId,
+          actorType: 'user',
+          action: 'bind',
+          resourceType: 'directory-account-link',
+          resourceId: result.account.id,
+          meta: {
+            adminUserId,
+            directoryAccountId: result.account.id,
+            integrationId: result.account.integrationId,
+            previousLocalUserId: result.previousLocalUser?.id ?? null,
+            previousLocalUserEmail: result.previousLocalUser?.email ?? null,
+            localUserId: result.user.id,
+            localUserEmail: result.user.email,
+            localUserUsername: result.user.username,
+            externalUserId: result.account.externalUserId,
+            corpId: result.account.corpId,
+            enableDingTalkGrant,
+            mode: 'bulk_manual_admission',
+            selectionSize: accountIds.length,
+          },
+        }),
+      ]))
+
+      if (outcome.succeeded.length === 0 && outcome.failed.length > 0) {
+        throw new Error(outcome.failed[0].error)
+      }
+
+      jsonOk(res, {
+        items: outcome.succeeded.map((result) => result.account),
+        users: outcome.succeeded.map((result) => result.user),
+        onboardingPackets: outcome.succeeded.map((result) => ({
+          userId: result.user.id,
+          name: result.user.name,
+          email: result.user.email,
+          username: result.user.username,
+          mobile: result.user.mobile,
+          temporaryPassword: result.temporaryPassword ?? '',
+          onboarding: result.onboarding,
+        })),
+        updatedCount: outcome.succeeded.length,
+        failedCount: outcome.failed.length,
+        failed: outcome.failed,
+        enableDingTalkGrant,
+      })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to batch create and bind local users for directory accounts')
+      const statusCode = /not found/i.test(message)
+        ? 404
+        : /already exists|already bound|already linked/i.test(message)
+          ? 409
+          : /required|invalid|password|cannot be pre-bound|missing DingTalk openId/i.test(message)
+            ? 400
+            : 500
+      jsonError(res, statusCode, 'DIRECTORY_BATCH_ADMISSION_FAILED', message)
     }
   })
 

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -12,6 +12,7 @@ const auditMocks = vi.hoisted(() => ({
 const directoryMocks = vi.hoisted(() => ({
   acknowledgeDirectorySyncAlert: vi.fn(),
   admitDirectoryAccountUser: vi.fn(),
+  batchAdmitDirectoryAccountUsers: vi.fn(),
   batchBindDirectoryAccounts: vi.fn(),
   batchUnbindDirectoryAccounts: vi.fn(),
   bindDirectoryAccount: vi.fn(),
@@ -52,6 +53,7 @@ vi.mock('../../src/audit/audit', () => ({
 vi.mock('../../src/directory/directory-sync', () => ({
   acknowledgeDirectorySyncAlert: directoryMocks.acknowledgeDirectorySyncAlert,
   admitDirectoryAccountUser: directoryMocks.admitDirectoryAccountUser,
+  batchAdmitDirectoryAccountUsers: directoryMocks.batchAdmitDirectoryAccountUsers,
   batchBindDirectoryAccounts: directoryMocks.batchBindDirectoryAccounts,
   batchUnbindDirectoryAccounts: directoryMocks.batchUnbindDirectoryAccounts,
   bindDirectoryAccount: directoryMocks.bindDirectoryAccount,
@@ -1195,6 +1197,113 @@ describe('adminDirectoryRouter', () => {
     })
 
     expect(response.statusCode).toBe(409)
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('batch-creates and binds directory accounts with grant disabled by default', async () => {
+    directoryMocks.batchAdmitDirectoryAccountUsers.mockResolvedValue({
+      succeeded: [
+        {
+          account: {
+            id: 'account-1',
+            integrationId: 'dir-1',
+            corpId: 'dingcorp',
+            externalUserId: '0447654442691174',
+            localUser: {
+              id: 'user-1',
+              email: null,
+              username: 'dt_0447654442691174_account1',
+            },
+          },
+          previousLocalUser: null,
+          user: {
+            id: 'user-1',
+            email: null,
+            username: 'dt_0447654442691174_account1',
+            name: '林岚',
+            mobile: '13900001234',
+            role: 'user',
+            is_active: true,
+          },
+          temporaryPassword: 'Temp#123456',
+          inviteToken: null,
+          onboarding: {
+            accountLabel: 'dt_0447654442691174_account1',
+            acceptInviteUrl: '',
+            inviteMessage: '账号：dt_0447654442691174_account1',
+          },
+        },
+      ],
+      failed: [{ accountId: 'account-2', error: 'User with this username already exists' }],
+    })
+
+    const response = await invokeRoute('post', '/accounts/batch-admit-users', {
+      body: {
+        accountIds: ['account-1', 'account-2'],
+      },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.batchAdmitDirectoryAccountUsers).toHaveBeenCalledWith(['account-1', 'account-2'], {
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: false,
+    })
+    expect(auditMocks.auditLog).toHaveBeenCalledTimes(2)
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'create',
+      resourceType: 'user',
+      resourceId: 'user-1',
+      meta: expect.objectContaining({
+        source: 'directory_bulk_manual_admission',
+        mode: 'bulk_manual_admission',
+        selectionSize: 2,
+      }),
+    }))
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'bind',
+      resourceType: 'directory-account-link',
+      resourceId: 'account-1',
+      meta: expect.objectContaining({
+        enableDingTalkGrant: false,
+        mode: 'bulk_manual_admission',
+        selectionSize: 2,
+      }),
+    }))
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        items: [{ id: 'account-1' }],
+        users: [{ id: 'user-1', username: 'dt_0447654442691174_account1' }],
+        onboardingPackets: [{
+          userId: 'user-1',
+          username: 'dt_0447654442691174_account1',
+          temporaryPassword: 'Temp#123456',
+        }],
+        updatedCount: 1,
+        failedCount: 1,
+        failed: [{ accountId: 'account-2', error: expect.stringContaining('username') }],
+        enableDingTalkGrant: false,
+      },
+    })
+  })
+
+  it('keeps the historical error mapping when a batch admission commits nothing', async () => {
+    directoryMocks.batchAdmitDirectoryAccountUsers.mockResolvedValue({
+      succeeded: [],
+      failed: [{ accountId: 'account-1', error: 'User with this username already exists' }],
+    })
+
+    const response = await invokeRoute('post', '/accounts/batch-admit-users', {
+      body: { accountIds: ['account-1'] },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'DIRECTORY_BATCH_ADMISSION_FAILED' },
+    })
     expect(auditMocks.auditLog).not.toHaveBeenCalled()
   })
 

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -34,7 +34,14 @@ vi.mock('../../src/auth/invite-tokens', () => ({
   issueInviteToken: inviteTokenMocks.issueInviteToken,
 }))
 
-import { admitDirectoryAccountUser, batchBindDirectoryAccounts, batchUnbindDirectoryAccounts, bindDirectoryAccount, unbindDirectoryAccount } from '../../src/directory/directory-sync'
+import {
+  admitDirectoryAccountUser,
+  batchAdmitDirectoryAccountUsers,
+  batchBindDirectoryAccounts,
+  batchUnbindDirectoryAccounts,
+  bindDirectoryAccount,
+  unbindDirectoryAccount,
+} from '../../src/directory/directory-sync'
 
 describe('bindDirectoryAccount', () => {
   beforeEach(() => {
@@ -1055,6 +1062,109 @@ describe('bindDirectoryAccount', () => {
     ])
     // account-1 really did commit (its transaction ran).
     expect(pgMocks.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('batch-admits no-email directory accounts with generated usernames and grant disabled by default', async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      // batch service preloads account-1 to derive name/username
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-bulk-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: null,
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: '13900001234',
+        }],
+      })
+      // admitDirectoryAccountUser reloads account-1 + previous link
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-bulk-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: null,
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: '13900001234',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ local_user_id: null, local_user_email: null, local_user_username: null, local_user_name: null }] })
+      // summary reload
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-bulk-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: null,
+          external_key: 'union-1',
+          account_name: '林岚',
+          account_email: null,
+          account_mobile: '13900001234',
+          account_is_active: true,
+          account_updated_at: '2026-07-08T00:00:00.000Z',
+          link_status: 'linked',
+          match_strategy: 'manual_admin',
+          reviewed_by: 'admin-1',
+          review_note: null,
+          link_updated_at: '2026-07-08T00:00:00.000Z',
+          local_user_id: 'user-created',
+          local_user_email: null,
+          local_user_username: 'dt_0447654442691174_accountb',
+          local_user_name: '林岚',
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+      // account-2 does not exist → second item fails without affecting account-1
+      .mockResolvedValueOnce({ rows: [] })
+
+    const outcome = await batchAdmitDirectoryAccountUsers(['account-bulk-1', 'account-missing'], {
+      adminUserId: 'admin-1',
+    })
+
+    expect(outcome.succeeded).toHaveLength(1)
+    expect(outcome.failed).toEqual([
+      { accountId: 'account-missing', error: expect.stringMatching(/not found/i) },
+    ])
+    const createUserCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('INSERT INTO users'))
+    const createdUserId = Array.isArray(createUserCall?.[1]) ? String(createUserCall?.[1]?.[0] || '') : ''
+    expect(createUserCall?.[1]).toEqual(expect.arrayContaining([
+      null,
+      'dt_0447654442691174_accountb',
+      '林岚',
+      '13900001234',
+      JSON.stringify([]),
+    ]))
+    expect(clientQuery.mock.calls.some((entry) => String(entry[0]).includes('INSERT INTO user_external_auth_grants'))).toBe(false)
+    expect(outcome.succeeded[0]).toMatchObject({
+      account: {
+        id: 'account-bulk-1',
+      },
+      user: {
+        id: createdUserId,
+        email: null,
+        username: 'dt_0447654442691174_accountb',
+        mobile: '13900001234',
+      },
+      inviteToken: null,
+    })
+    expect(outcome.succeeded[0].temporaryPassword).toMatch(/^Tmp-/)
+    expect(pgMocks.transaction).toHaveBeenCalledTimes(1)
+    expect(inviteLedgerMocks.recordInvite).not.toHaveBeenCalled()
   })
 
   // DT-HARDEN-04: symmetric to the batch-unbind isolation test above. A fail-fast bind


### PR DESCRIPTION
## Summary

- Add a batch directory admission backend path for synced DingTalk accounts that need local users created in bulk.
- Default the batch path to DingTalk login grant OFF, so missing web-OAuth openId does not block creating local accounts.
- Add a directory review-queue action for manual pending items: batch create local users, bind them, and show temporary credentials for secure distribution.

## Behavior

- `POST /api/admin/directory/accounts/batch-admit-users` accepts `accountIds` and returns committed accounts, users, onboarding packets, and per-item failures.
- Each item is isolated like the existing batch bind/unbind paths: successes are preserved and audited even if a later item fails.
- The UI only enables the batch-create action for selected pending review items that have no local user and no direct recommendation candidate, so recommended matches still use the existing confirmation flow.
- The generated local username reuses the existing directory auto-admission username builder; scan login can be opened later after openId is available.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-bind-account.test.ts --watch=false` (53 passed)
- `pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --watch=false` (51 passed)
- `pnpm --filter @metasheet/web exec vue-tsc -b`
- `pnpm --filter @metasheet/core-backend build`

## Notes

This is the bulk local-account admission cut for directory-synced members. It does not bulk-enable DingTalk scan login; that remains a separate step after web-OAuth openId enrichment.
