### PR TITLE
fix(multitable): enforce read gates on attachment downloads

### DIFF
--- a/packages/core-backend/src/multitable/attachment-service.ts
+++ b/packages/core-backend/src/multitable/attachment-service.ts
@@ -95,6 +95,8 @@ export type ReadAttachmentMetadataInput = {
 export type ReadAttachmentMetadataResult = {
   id: string
   sheetId: string
+  recordId: string | null
+  fieldId: string | null
   storageFileId: string
   filename: string | null
   originalName: string | null
@@ -469,7 +471,7 @@ export async function readAttachmentMetadata(
 ): Promise<ReadAttachmentMetadataResult | null> {
   const { query, attachmentId } = input
   const result = await query(
-    `SELECT id, sheet_id, storage_file_id, filename, original_name, mime_type, size
+    `SELECT id, sheet_id, record_id, field_id, storage_file_id, filename, original_name, mime_type, size
      FROM multitable_attachments
      WHERE id = $1 AND deleted_at IS NULL`,
     [attachmentId],
@@ -478,10 +480,11 @@ export async function readAttachmentMetadata(
   if (!row) return null
   return {
     id: String(row.id),
-    // Matches the route's pre-extraction behavior: non-string sheet_id is
-    // normalized to '' so the auth block is short-circuited (see
-    // `GET /attachments/:attachmentId` usage).
+    // Non-string sheet_id is normalized to '' so the route can fail closed
+    // before any storage read.
     sheetId: typeof row.sheet_id === 'string' ? row.sheet_id : '',
+    recordId: typeof row.record_id === 'string' ? row.record_id : null,
+    fieldId: typeof row.field_id === 'string' ? row.field_id : null,
     storageFileId: String(row.storage_file_id),
     filename: typeof row.filename === 'string' ? row.filename : null,
     originalName: typeof row.original_name === 'string' ? row.original_name : null,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -15325,6 +15325,51 @@ export function univerMetaRouter(): Router {
     }
   })
 
+  async function ensureAttachmentDownloadReadable(
+    req: Request,
+    res: Response,
+    query: QueryFn,
+    metadata: {
+      id: string
+      sheetId: string
+      recordId: string | null
+      fieldId: string | null
+    },
+  ): Promise<boolean> {
+    if (!metadata.sheetId) {
+      res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Attachment not found: ${metadata.id}` } })
+      return false
+    }
+
+    const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, metadata.sheetId)
+    if (!access.userId) {
+      res.status(401).json({ error: 'Authentication required' })
+      return false
+    }
+    if (!capabilities.canRead) {
+      sendForbidden(res)
+      return false
+    }
+
+    if (metadata.recordId && !access.isAdminRole && await loadRowLevelReadDenyEnabled(query, metadata.sheetId)) {
+      const denied = await loadDeniedRecordIds(query, metadata.sheetId, access.userId)
+      if (denied.has(metadata.recordId)) {
+        res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Attachment not found: ${metadata.id}` } })
+        return false
+      }
+    }
+
+    if (metadata.fieldId) {
+      const allowedFieldIds = await loadAllowedFieldIds(query, metadata.sheetId, access.userId, capabilities)
+      if (!allowedFieldIds.has(metadata.fieldId)) {
+        res.status(403).json({ ok: false, error: { code: 'FIELD_FORBIDDEN', message: 'Attachment field is not readable' } })
+        return false
+      }
+    }
+
+    return true
+  }
+
   router.post('/attachments', async (req: Request, res: Response) => {
     try {
       if (!multitableUpload) {
@@ -15444,13 +15489,8 @@ export function univerMetaRouter(): Router {
       if (!metadata) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Attachment not found: ${attachmentId}` } })
       }
-      if (metadata.sheetId) {
-        const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), metadata.sheetId)
-        if (!access.userId) {
-          return res.status(401).json({ error: 'Authentication required' })
-        }
-        if (!capabilities.canRead) return sendForbidden(res)
-      }
+      const query = pool.query.bind(pool)
+      if (!await ensureAttachmentDownloadReadable(req, res, query, metadata)) return
 
       const storage = getAttachmentStorageService()
       const buffer = await readAttachmentBinaryShared({ storage, storageFileId: metadata.storageFileId })

--- a/packages/core-backend/tests/integration/multitable-attachments.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-attachments.api.test.ts
@@ -29,6 +29,7 @@ async function createApp(args: {
   vi.resetModules()
   process.env.ATTACHMENT_PATH = args.attachmentPath
   const publishSpy = vi.fn()
+  let downloadSpy: ReturnType<typeof vi.fn> | null = null
 
   vi.doMock('../../src/rbac/service', () => ({
     isAdmin: vi.fn().mockResolvedValue(false),
@@ -41,7 +42,7 @@ async function createApp(args: {
     eventBus: { publish: publishSpy },
   }))
   if (args.mockStorageDownload) {
-    const downloadSpy = vi.fn(async () => args.mockStorageDownload as Buffer)
+    downloadSpy = vi.fn(async () => args.mockStorageDownload as Buffer)
     vi.doMock('../../src/services/StorageService', async () => {
       const actual = await vi.importActual<any>('../../src/services/StorageService')
       return {
@@ -75,7 +76,7 @@ async function createApp(args: {
   })
   app.use('/api/multitable', univerMetaRouter())
 
-  return { app, mockPool, publishSpy }
+  return { app, mockPool, publishSpy, downloadSpy }
 }
 
 describe('Multitable attachment API', () => {
@@ -431,6 +432,146 @@ describe('Multitable attachment API', () => {
     }
   })
 
+  test('F2: rejects attachment download when the attachment field is field-masked', async () => {
+    const attachmentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'multitable-attachment-field-mask-'))
+
+    try {
+      const { app, downloadSpy } = await createApp({
+        attachmentPath,
+        mockStorageDownload: Buffer.from('SECRET ATTACHMENT BYTES'),
+        queryHandler: async (sql, params) => {
+          if (sql.includes('FROM multitable_attachments') && sql.includes('storage_file_id')) {
+            expect(params).toEqual(['att_field_masked'])
+            return {
+              rows: [{
+                id: 'att_field_masked',
+                sheet_id: 'sheet_acl',
+                record_id: 'rec_visible',
+                field_id: 'fld_secret_files',
+                storage_file_id: 'storage_att_field_masked',
+                filename: 'secret.txt',
+                original_name: 'secret.txt',
+                mime_type: 'text/plain',
+                size: 23,
+              }],
+            }
+          }
+          if (sql.includes('FROM spreadsheet_permissions')) {
+            expect(params).toEqual(['user_multitable_attachments', ['sheet_acl']])
+            return {
+              rows: [{ sheet_id: 'sheet_acl', perm_code: 'spreadsheet:read', subject_type: 'user' }],
+            }
+          }
+          if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+          if (sql.includes('SELECT row_level_read_permissions_enabled AS enabled, base_id FROM meta_sheets')) {
+            expect(params).toEqual(['sheet_acl'])
+            return { rows: [{ enabled: false, base_id: null }] }
+          }
+          if (sql.includes('FROM meta_fields') && sql.includes('ORDER BY "order" ASC')) {
+            expect(params).toEqual(['sheet_acl'])
+            return {
+              rows: [{
+                id: 'fld_secret_files',
+                name: 'Secret files',
+                type: 'attachment',
+                property: {},
+                order: 1,
+              }],
+            }
+          }
+          if (sql.includes('FROM field_permissions fp')) {
+            expect(params).toEqual(['user_multitable_attachments', 'sheet_acl'])
+            return {
+              rows: [{
+                field_id: 'fld_secret_files',
+                visible: false,
+                read_only: false,
+              }],
+            }
+          }
+          throw new Error(`Unhandled SQL in test: ${sql}`)
+        },
+      })
+
+      const response = await request(app)
+        .get('/api/multitable/attachments/att_field_masked')
+        .expect(403)
+
+      expect(response.body).toEqual({
+        ok: false,
+        error: { code: 'FIELD_FORBIDDEN', message: 'Attachment field is not readable' },
+      })
+      expect(downloadSpy).toHaveBeenCalledTimes(0)
+      expect(JSON.stringify(response.body)).not.toContain('SECRET ATTACHMENT BYTES')
+      expect(JSON.stringify(response.body)).not.toContain('secret.txt')
+    } finally {
+      await fs.rm(attachmentPath, { recursive: true, force: true })
+    }
+  })
+
+  test('F2: rejects attachment download when the owning record is row-denied', async () => {
+    const attachmentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'multitable-attachment-row-deny-'))
+
+    try {
+      const { app, downloadSpy } = await createApp({
+        attachmentPath,
+        mockStorageDownload: Buffer.from('ROW DENIED ATTACHMENT BYTES'),
+        queryHandler: async (sql, params) => {
+          if (sql.includes('FROM multitable_attachments') && sql.includes('storage_file_id')) {
+            expect(params).toEqual(['att_row_denied'])
+            return {
+              rows: [{
+                id: 'att_row_denied',
+                sheet_id: 'sheet_acl',
+                record_id: 'rec_secret',
+                field_id: 'fld_files',
+                storage_file_id: 'storage_att_row_denied',
+                filename: 'row-secret.txt',
+                original_name: 'row-secret.txt',
+                mime_type: 'text/plain',
+                size: 27,
+              }],
+            }
+          }
+          if (sql.includes('FROM spreadsheet_permissions')) {
+            expect(params).toEqual(['user_multitable_attachments', ['sheet_acl']])
+            return {
+              rows: [{ sheet_id: 'sheet_acl', perm_code: 'spreadsheet:read', subject_type: 'user' }],
+            }
+          }
+          if (/FROM meta_sheets WHERE id = ANY[\s\S]*base_id/i.test(sql)) return { rows: [] }
+          if (sql.includes('SELECT row_level_read_permissions_enabled AS enabled, base_id FROM meta_sheets')) {
+            expect(params).toEqual(['sheet_acl'])
+            return { rows: [{ enabled: true, base_id: null }] }
+          }
+          if (sql.includes('SELECT DISTINCT rp.record_id')) {
+            expect(params).toEqual(['user_multitable_attachments', 'sheet_acl'])
+            return { rows: [{ record_id: 'rec_secret' }] }
+          }
+          if (sql.includes('SELECT conditional_read_rules AS rules FROM meta_sheets')) {
+            expect(params).toEqual(['sheet_acl'])
+            return { rows: [{ rules: [] }] }
+          }
+          throw new Error(`Unhandled SQL in test: ${sql}`)
+        },
+      })
+
+      const response = await request(app)
+        .get('/api/multitable/attachments/att_row_denied')
+        .expect(404)
+
+      expect(response.body).toEqual({
+        ok: false,
+        error: { code: 'NOT_FOUND', message: 'Attachment not found: att_row_denied' },
+      })
+      expect(downloadSpy).toHaveBeenCalledTimes(0)
+      expect(JSON.stringify(response.body)).not.toContain('ROW DENIED ATTACHMENT BYTES')
+      expect(JSON.stringify(response.body)).not.toContain('row-secret.txt')
+    } finally {
+      await fs.rm(attachmentPath, { recursive: true, force: true })
+    }
+  })
+
   test('deletes an attachment and removes it from the owning record field', async () => {
     const attachmentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'multitable-attachment-delete-'))
     let storedPath = ''
@@ -501,6 +642,10 @@ describe('Multitable attachment API', () => {
             return {
               rows: [{ id: 'rec_ops_1', created_by: 'user_multitable_attachments' }],
             }
+          }
+          if (sql.includes('SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+            expect(params).toEqual(['rec_ops_1', 'sheet_ops'])
+            return { rows: [{ locked: false, locked_by: null, created_by: 'user_multitable_attachments' }] }
           }
           if (sql.includes('UPDATE meta_records') && sql.includes('version = version + 1')) {
             expect(params).toEqual([
@@ -588,6 +733,10 @@ describe('Multitable attachment API', () => {
             return {
               rows: [{ id: 'rec_acl_1', created_by: 'other_user' }],
             }
+          }
+          if (sql.includes('SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+            expect(params).toEqual(['rec_acl_1', 'sheet_acl'])
+            return { rows: [{ locked: false, locked_by: null, created_by: 'other_user' }] }
           }
           if (sql.includes('SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
             expect(params).toEqual(['rec_acl_1', 'sheet_acl'])

--- a/packages/core-backend/tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts
@@ -89,6 +89,19 @@ async function deleteRevisionsOf(recordId: string): Promise<Array<{ source: stri
   return res.rows as never[]
 }
 
+async function revisionCutoffAfter(recordId: string, action: 'create' | 'delete'): Promise<string> {
+  const res = await q(
+    `SELECT (created_at + interval '1 microsecond')::text AS as_of
+       FROM meta_record_revisions
+      WHERE sheet_id = $1 AND record_id = $2 AND action = $3
+      ORDER BY created_at DESC, version DESC, id DESC
+      LIMIT 1`,
+    [SHEET, recordId, action],
+  )
+  expect(res.rows).toHaveLength(1)
+  return String((res.rows[0] as { as_of: string }).as_of)
+}
+
 async function pitAlive(recordId: string, asOfIso: string): Promise<boolean> {
   const state = await reconstructRecordsAtT(q, SHEET, asOfIso, [recordId])
   return state.get(recordId)?.exists === true
@@ -120,8 +133,7 @@ describeIfDatabase('D-1 — delete-revision parity for plugin-SDK + automation h
   test('PLUGIN path: delete emits action=delete source=plugin with the final snapshot — and PIT stops lying', async () => {
     const recId = `rec_d1_plugin_${TS}`
     await insertRecord(recId, { title: 'plugin victim' })
-    const beforeDelete = new Date().toISOString()
-    await new Promise((r) => setTimeout(r, 25))
+    const beforeDelete = await revisionCutoffAfter(recId, 'create')
 
     await pluginDeleteRecord({ query: q as never, sheetId: SHEET, recordId: recId } as never)
 
@@ -132,8 +144,7 @@ describeIfDatabase('D-1 — delete-revision parity for plugin-SDK + automation h
     expect(revs[0]!.version).toBe(3)
     expect(revs[0]!.snapshot).toMatchObject({ title: 'plugin victim' })
 
-    await new Promise((r) => setTimeout(r, 25))
-    const afterDelete = new Date().toISOString()
+    const afterDelete = await revisionCutoffAfter(recId, 'delete')
 
     // PIT GOLDEN both directions: alive before the delete, dead after it. Before D-1 the second
     // assertion failed forever — the record's last revision was the create.
@@ -144,8 +155,7 @@ describeIfDatabase('D-1 — delete-revision parity for plugin-SDK + automation h
   test('AUTOMATION path: delete_record emits action=delete source=automation with actor + snapshot — and PIT stops lying', async () => {
     const recId = `rec_d1_auto_${TS}`
     await insertRecord(recId, { title: 'automation victim' })
-    const beforeDelete = new Date().toISOString()
-    await new Promise((r) => setTimeout(r, 25))
+    const beforeDelete = await revisionCutoffAfter(recId, 'create')
 
     const exec = await makeExecutor().execute(deleteRuleFor(recId), {
       recordId: recId,
@@ -161,8 +171,7 @@ describeIfDatabase('D-1 — delete-revision parity for plugin-SDK + automation h
     expect(revs[0]!.source).toBe('automation')
     expect(revs[0]!.snapshot).toMatchObject({ title: 'automation victim' })
 
-    await new Promise((r) => setTimeout(r, 25))
-    const afterDelete = new Date().toISOString()
+    const afterDelete = await revisionCutoffAfter(recId, 'delete')
     expect(await pitAlive(recId, beforeDelete)).toBe(true)
     expect(await pitAlive(recId, afterDelete)).toBe(false)
   })

--- a/packages/core-backend/tests/unit/multitable-attachment-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-attachment-service.test.ts
@@ -335,6 +335,8 @@ describe('attachment-service: readAttachmentMetadata & readAttachmentBinary', ()
       {
         id: 'att_1',
         sheet_id: 's1',
+        record_id: 'rec_1',
+        field_id: 'fld_files',
         storage_file_id: 'file_42',
         filename: 'report.pdf',
         original_name: 'Report.pdf',
@@ -346,6 +348,8 @@ describe('attachment-service: readAttachmentMetadata & readAttachmentBinary', ()
     expect(result).toEqual({
       id: 'att_1',
       sheetId: 's1',
+      recordId: 'rec_1',
+      fieldId: 'fld_files',
       storageFileId: 'file_42',
       filename: 'report.pdf',
       originalName: 'Report.pdf',


### PR DESCRIPTION
## Summary
- extend multitable attachment metadata with owning record/field ids for download authorization
- require sheet read, row-read visibility, and field-read visibility before serving attachment bytes
- add focused attachment API coverage proving denied field/row cases do not touch storage

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-attachment-service.test.ts
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-attachments.api.test.ts
- pnpm --filter @metasheet/core-backend type-check
- git diff --check

## Notes
- scoped to attachment download read gates only
- no attachment upload/delete behavior changes intended
