### PR TITLE
fix(comments): scope inbox realtime activity per user

### DIFF
--- a/packages/core-backend/src/di/identifiers.ts
+++ b/packages/core-backend/src/di/identifiers.ts
@@ -64,6 +64,8 @@ export interface ICollabService {
   onConnection(handler: (socket: Socket) => void): void;
   /** Return user IDs currently present in the given Socket.IO room. */
   getRoomMembers(room: string): Promise<string[]>;
+  /** Return user IDs that currently joined the comment inbox stream. */
+  getCommentInboxSubscriberIds(): string[];
 }
 
 export interface ICollectionManager {

--- a/packages/core-backend/src/services/CollabService.ts
+++ b/packages/core-backend/src/services/CollabService.ts
@@ -27,6 +27,8 @@ export class CollabService {
   private io: SocketServer | null = null
   private sheetPresenceBySheet = new Map<string, Map<string, Set<string>>>()
   private sheetMembershipBySocket = new Map<string, Set<string>>()
+  private commentInboxUserBySocket = new Map<string, string>()
+  private commentInboxSocketsByUser = new Map<string, Set<string>>()
   private tokenVerifier: SocketTokenVerifier = async (token) => {
     // AuthService pulls in RBAC/metrics modules; keep it lazy so importing CollabService
     // does not register global metrics during parallel unit-test collection.
@@ -331,19 +333,37 @@ export class CollabService {
 
   private async handleJoinCommentInbox(socket: Socket): Promise<void> {
     // The comment inbox is a cross-sheet activity stream (metadata: ids/authorId, no bodies). It requires
-    // a verified identity to join — closing unauthenticated access to the stream. Per-user activity
-    // routing (so an authed user only sees activity for sheets they can read) is a broadcast-semantics
-    // change tracked as a follow-up; this gate is the security-critical part (no anonymous access).
+    // a verified identity and joins a per-user room; publishers still re-check target read access before
+    // emitting to that room.
     const userId = await this.resolveTrustedUserId(socket)
     if (!socket.connected) return
     if (!userId) {
       this.denyCommentJoin(socket, 'comment-inbox', 'unauthorized')
       return
     }
-    const room = buildCommentInboxRoom()
+    const room = buildCommentInboxRoom({ userId })
     socket.join(room)
+    this.trackCommentInboxMembership(socket.id, userId)
     this.logger.info(`Client ${socket.id} joined ${room}`)
     socket.emit('joined-comment-inbox')
+  }
+
+  private trackCommentInboxMembership(socketId: string, userId: string): void {
+    this.untrackCommentInboxMembership(socketId)
+    this.commentInboxUserBySocket.set(socketId, userId)
+    const socketIds = this.commentInboxSocketsByUser.get(userId) ?? new Set<string>()
+    socketIds.add(socketId)
+    this.commentInboxSocketsByUser.set(userId, socketIds)
+  }
+
+  private untrackCommentInboxMembership(socketId: string): string | undefined {
+    const userId = this.commentInboxUserBySocket.get(socketId)
+    if (!userId) return undefined
+    this.commentInboxUserBySocket.delete(socketId)
+    const socketIds = this.commentInboxSocketsByUser.get(userId)
+    socketIds?.delete(socketId)
+    if (!socketIds || socketIds.size === 0) this.commentInboxSocketsByUser.delete(userId)
+    return userId
   }
 
   initialize(httpServer: HttpServer): void {
@@ -372,6 +392,7 @@ export class CollabService {
           this.untrackSocketSheetMembership(socket.id, sheetId)
           this.emitSheetPresence(sheetId)
         }
+        this.untrackCommentInboxMembership(socket.id)
         this.logger.info(`WebSocket client disconnected: ${socket.id}`)
       })
 
@@ -432,7 +453,9 @@ export class CollabService {
       })
 
       socket.on('leave-comment-inbox', () => {
-        const room = buildCommentInboxRoom()
+        const userId = this.untrackCommentInboxMembership(socket.id) ?? this.getTrustedUserId(socket)
+        if (!userId) return
+        const room = buildCommentInboxRoom({ userId })
         socket.leave(room)
         this.logger.info(`Client ${socket.id} left ${room}`)
       })
@@ -524,5 +547,9 @@ export class CollabService {
     } catch {
       return []
     }
+  }
+
+  getCommentInboxSubscriberIds(): string[] {
+    return [...this.commentInboxSocketsByUser.keys()]
   }
 }

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -220,7 +220,7 @@ export class CommentService {
       throw new Error('Updated comment could not be reloaded')
     }
 
-    this.publishCommentUpdated(comment, normalizedUserId)
+    await this.publishCommentUpdated(comment, normalizedUserId)
 
     for (const mentionUserId of mentions) {
       if (!mentionUserId || mentionUserId === normalizedUserId || previousMentions.includes(mentionUserId)) continue
@@ -261,7 +261,7 @@ export class CommentService {
       await trx.deleteFrom('meta_comments').where('id', '=', commentId).execute()
     })
 
-    this.publishCommentDeleted(existing, normalizedUserId)
+    await this.publishCommentDeleted(existing, normalizedUserId)
   }
 
   /**
@@ -369,21 +369,17 @@ export class CommentService {
       'comment:created',
       createdPayload,
     )
-    this.collabService.broadcastTo(
-      buildCommentInboxRoom(),
-      'comment:activity',
-      {
-        kind: 'created',
-        containerId: data.spreadsheetId,
-        targetId: data.rowId,
-        targetFieldId: effectiveFieldId ?? null,
-        spreadsheetId: data.spreadsheetId,
-        rowId: data.rowId,
-        fieldId: effectiveFieldId,
-        commentId: comment.id,
-        authorId: data.authorId,
-      } satisfies CommentActivityPayload,
-    )
+    await this.publishCommentActivity({
+      kind: 'created',
+      containerId: data.spreadsheetId,
+      targetId: data.rowId,
+      targetFieldId: effectiveFieldId ?? null,
+      spreadsheetId: data.spreadsheetId,
+      rowId: data.rowId,
+      fieldId: effectiveFieldId,
+      commentId: comment.id,
+      authorId: data.authorId,
+    })
     for (const mentionUserId of mentions) {
       if (mentionUserId && mentionUserId !== data.authorId) {
         if (!(await this.canNotifyUserAboutCommentTarget(data.spreadsheetId, data.rowId, mentionUserId))) continue
@@ -1014,20 +1010,16 @@ export class CommentService {
         'comment:resolved',
         resolvedPayload,
       )
-      this.collabService.broadcastTo(
-        buildCommentInboxRoom(),
-        'comment:activity',
-        {
-          kind: 'resolved',
-          containerId: result.container_id,
-          targetId: result.target_id,
-          targetFieldId: result.target_field_id ?? null,
-          spreadsheetId: result.spreadsheet_id,
-          rowId: result.row_id,
-          fieldId: result.field_id ?? undefined,
-          commentId,
-        } satisfies CommentActivityPayload,
-      )
+      await this.publishCommentActivity({
+        kind: 'resolved',
+        containerId: result.container_id,
+        targetId: result.target_id,
+        targetFieldId: result.target_field_id ?? null,
+        spreadsheetId: result.spreadsheet_id,
+        rowId: result.row_id,
+        fieldId: result.field_id ?? undefined,
+        commentId,
+      })
     }
   }
 
@@ -1072,7 +1064,22 @@ export class CommentService {
     }
   }
 
-  private publishCommentUpdated(comment: Comment, authorId: string): void {
+  private async publishCommentActivity(payload: CommentActivityPayload): Promise<void> {
+    const getSubscriberIds = (this.collabService as { getCommentInboxSubscriberIds?: () => string[] })
+      .getCommentInboxSubscriberIds
+    if (!getSubscriberIds) return
+    const subscriberIds = getSubscriberIds.call(this.collabService)
+    for (const userId of subscriberIds) {
+      if (!(await this.canNotifyUserAboutCommentTarget(payload.spreadsheetId, payload.rowId, userId))) continue
+      this.collabService.broadcastTo(
+        buildCommentInboxRoom({ userId }),
+        'comment:activity',
+        payload,
+      )
+    }
+  }
+
+  private async publishCommentUpdated(comment: Comment, authorId: string): Promise<void> {
     const payload = {
       containerId: comment.containerId,
       targetId: comment.targetId,
@@ -1092,24 +1099,20 @@ export class CommentService {
       'comment:updated',
       payload,
     )
-    this.collabService.broadcastTo(
-      buildCommentInboxRoom(),
-      'comment:activity',
-      {
-        kind: 'updated',
-        containerId: comment.containerId,
-        targetId: comment.targetId,
-        targetFieldId: comment.targetFieldId,
-        spreadsheetId: comment.spreadsheetId,
-        rowId: comment.rowId,
-        fieldId: comment.fieldId,
-        commentId: comment.id,
-        authorId,
-      } satisfies CommentActivityPayload,
-    )
+    await this.publishCommentActivity({
+      kind: 'updated',
+      containerId: comment.containerId,
+      targetId: comment.targetId,
+      targetFieldId: comment.targetFieldId,
+      spreadsheetId: comment.spreadsheetId,
+      rowId: comment.rowId,
+      fieldId: comment.fieldId,
+      commentId: comment.id,
+      authorId,
+    })
   }
 
-  private publishCommentDeleted(row: CommentRow, authorId: string): void {
+  private async publishCommentDeleted(row: CommentRow, authorId: string): Promise<void> {
     const payload = {
       containerId: row.container_id,
       targetId: row.target_id,
@@ -1129,21 +1132,17 @@ export class CommentService {
       'comment:deleted',
       payload,
     )
-    this.collabService.broadcastTo(
-      buildCommentInboxRoom(),
-      'comment:activity',
-      {
-        kind: 'deleted',
-        containerId: row.container_id,
-        targetId: row.target_id,
-        targetFieldId: row.target_field_id ?? null,
-        spreadsheetId: row.spreadsheet_id,
-        rowId: row.row_id,
-        fieldId: row.field_id ?? undefined,
-        commentId: row.id,
-        authorId,
-      } satisfies CommentActivityPayload,
-    )
+    await this.publishCommentActivity({
+      kind: 'deleted',
+      containerId: row.container_id,
+      targetId: row.target_id,
+      targetFieldId: row.target_field_id ?? null,
+      spreadsheetId: row.spreadsheet_id,
+      rowId: row.row_id,
+      fieldId: row.field_id ?? undefined,
+      commentId: row.id,
+      authorId,
+    })
   }
 
   private async getComment(id: string): Promise<Comment | undefined> {

--- a/packages/core-backend/src/services/commentRooms.ts
+++ b/packages/core-backend/src/services/commentRooms.ts
@@ -15,6 +15,10 @@ export function buildCommentSheetRoom(scope: CommentSheetRoomScope): string {
   return `comments-sheet:${scope.spreadsheetId}`
 }
 
-export function buildCommentInboxRoom(): string {
-  return 'comments-inbox'
+export type CommentInboxRoomScope = {
+  userId: string
+}
+
+export function buildCommentInboxRoom(scope: CommentInboxRoomScope): string {
+  return `comments-inbox:${scope.userId}`
 }

--- a/packages/core-backend/tests/integration/comment-flow.test.ts
+++ b/packages/core-backend/tests/integration/comment-flow.test.ts
@@ -95,6 +95,7 @@ const mockCollab = {
   join: vi.fn(),
   leave: vi.fn(),
   onConnection: vi.fn(),
+  getCommentInboxSubscriberIds: vi.fn(() => ['user_inbox']),
 }
 
 const mockLogger: ILogger = {
@@ -195,6 +196,7 @@ describe('Week-1 collab semantics — comment-flow integration', () => {
     queueTakeFirst = dbMod.__takeFirstQueue
     queueExec.length = 0
     queueTakeFirst.length = 0
+    mockCollab.getCommentInboxSubscriberIds.mockReturnValue(['user_inbox'])
 
     svc = new CommentService(mockCollab as unknown as CollabService, mockLogger)
   })

--- a/packages/core-backend/tests/integration/rooms.basic.test.ts
+++ b/packages/core-backend/tests/integration/rooms.basic.test.ts
@@ -376,12 +376,12 @@ describe('WebSocket Rooms - basic flow', () => {
     b.close()
   })
 
-  it('join-comment-inbox scopes activity delivery to inbox subscribers', async () => {
+  it('join-comment-inbox scopes activity delivery to the authenticated user inbox room', async () => {
     if (!baseUrl || !server) return
 
-    // the comment inbox now requires an authenticated identity to join (no anonymous access to the stream)
+    // the comment inbox requires an authenticated identity and joins only that user's inbox room.
     const a = ioClient(baseUrl, { transports: ['websocket'], auth: { token: 'token:user_a' } })
-    const b = ioClient(baseUrl, { transports: ['websocket'] })
+    const b = ioClient(baseUrl, { transports: ['websocket'], auth: { token: 'token:user_b' } })
 
     await Promise.all([
       new Promise<void>((resolve, reject) => {
@@ -402,6 +402,14 @@ describe('WebSocket Rooms - basic flow', () => {
       })
       a.emit('join-comment-inbox')
     })
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('B inbox join timeout')), 3000)
+      b.on('joined-comment-inbox', () => {
+        clearTimeout(t)
+        resolve()
+      })
+      b.emit('join-comment-inbox')
+    })
 
     const gotA = new Promise<any>((resolve, reject) => {
       const t = setTimeout(() => reject(new Error('A did not receive inbox activity')), 3000)
@@ -412,7 +420,7 @@ describe('WebSocket Rooms - basic flow', () => {
     b.on('comment:activity', () => { gotB = true })
 
     // @ts-ignore
-    server['createCoreAPI']().websocket.broadcastTo('comments-inbox', 'comment:activity', {
+    server['createCoreAPI']().websocket.broadcastTo('comments-inbox:user_a', 'comment:activity', {
       kind: 'created',
       spreadsheetId: 'sheet_orders',
       rowId: 'rec_1',

--- a/packages/core-backend/tests/unit/comment-service.test.ts
+++ b/packages/core-backend/tests/unit/comment-service.test.ts
@@ -80,6 +80,7 @@ const mockCollabService = {
   join: vi.fn(),
   leave: vi.fn(),
   onConnection: vi.fn(),
+  getCommentInboxSubscriberIds: vi.fn(() => ['user-inbox']),
 }
 
 const mockLogger: ILogger = {
@@ -161,6 +162,7 @@ describe('CommentService', () => {
     queueExec.length = 0
     queueTakeFirst.length = 0
     mockNotifyRecordSubscribersWithKysely.mockResolvedValue({ inserted: 0, userIds: [] })
+    mockCollabService.getCommentInboxSubscriberIds.mockReturnValue(['user-inbox'])
     service = new CommentService(
       mockCollabService as unknown as CollabService,
       mockLogger,
@@ -499,6 +501,23 @@ describe('CommentService', () => {
       expect(activityCalls.length).toBeGreaterThanOrEqual(1)
       const payload = activityCalls[0][2] as { kind: string }
       expect(payload.kind).toBe('deleted')
+    })
+
+    it('only emits comment:activity to inbox subscribers that can read the target record', async () => {
+      mockCollabService.getCommentInboxSubscriberIds.mockReturnValue(['user-allowed', 'user-denied'])
+      service.setCommentTargetReadChecker(async ({ userId }) => userId === 'user-allowed')
+      const row = makeCommentRow({ id: 'cmt_del_acl', author_id: 'user-author' })
+      pushTakeFirst(row)
+      pushTakeFirst(undefined)
+
+      await service.deleteComment('cmt_del_acl', 'user-author')
+
+      const activityCalls = mockCollabService.broadcastTo.mock.calls.filter(
+        (call: unknown[]) => call[1] === 'comment:activity',
+      )
+      expect(activityCalls).toHaveLength(1)
+      expect(activityCalls[0][0]).toBe('comments-inbox:user-allowed')
+      expect(JSON.stringify(activityCalls)).not.toContain('user-denied')
     })
 
     it('rejects deletion by non-author', async () => {


### PR DESCRIPTION
## Summary
- move comment inbox realtime joins from a global room to per-user inbox rooms
- publish comment activity only to currently subscribed users that pass the comment target read check
- keep comment activity payload shape and frontend listener contract unchanged

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/comment-service.test.ts
- pnpm --filter @metasheet/core-backend exec vitest run tests/integration/comment-flow.test.ts
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/rooms.basic.test.ts
- pnpm --filter @metasheet/core-backend type-check
- git diff --check

## Notes
- Local comments.api focused run requires a real test database; this worktree has no DATABASE_URL, so that check stops at local DB bootstrap before running assertions.
