### PR TITLE
feat(multitable): 4c-3 — record-undelete inbound-edge replay（Option A，flag 默认 off）

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -230,6 +230,7 @@ jobs:
             tests/integration/multitable-history-audit-reveal-taint-realdb.test.ts \
             tests/integration/multitable-record-reconstructor-realdb.test.ts \
             tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts \
+            tests/integration/multitable-undelete-inbound-replay-realdb.test.ts \
             tests/integration/multitable-pit-view-realdb.test.ts \
             tests/integration/multitable-restore-preview-realdb.test.ts \
             tests/integration/multitable-restore-execute-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260709100000_add_delete_revision_id_to_meta_records_trash.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260709100000_add_delete_revision_id_to_meta_records_trash.ts
@@ -1,0 +1,33 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * 4c-3 record-undelete inbound-edge replay (design-lock 2026-07-08, owner-ratified 2026-07-09,
+ * Option A) — the ANCHOR column that unblocks the replay.
+ *
+ * `deleteRecord` pre-generates its delete revision's id and uses it as the inbound-link tombstones'
+ * `source_revision_id` — but `meta_records_trash` never recorded that id, so a restore driven by the
+ * trash row could not NAME its tombstones' anchor. This adds the missing back-reference.
+ *
+ * Forward-only, nullable, NO backfill (design-lock §2): rows written before this migration have
+ * `delete_revision_id IS NULL`, which restore treats as "no inbound replay" +
+ * `inboundEdgesRecoverable=false` — honestly, never via heuristics. A
+ * `(sheet_id, record_id, action='delete') ORDER BY created_at DESC` style backfill is FORBIDDEN:
+ * under delete→restore→delete cycles it silently anchors to the WRONG vintage, and when the last
+ * delete came from a path without capture it anchors to a revision that has no tombstones at all.
+ *
+ * Bare uuid-as-text back-reference, deliberately un-FK'd — mirrors `source_revision_id` on the
+ * tombstone tables (zzzz20260708090000) and `meta_config_revisions.restored_from_id`.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE meta_records_trash
+      ADD COLUMN IF NOT EXISTS delete_revision_id text
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE meta_records_trash
+      DROP COLUMN IF EXISTS delete_revision_id
+  `.execute(db)
+}

--- a/packages/core-backend/src/multitable/inbound-link-replay.ts
+++ b/packages/core-backend/src/multitable/inbound-link-replay.ts
@@ -1,0 +1,165 @@
+/**
+ * 4c-3 — record-undelete inbound-edge replay (design-lock 2026-07-08, owner-ratified 2026-07-09,
+ * semantics = Option A / fail-closed neighbour-consent).
+ *
+ * When a record R is deleted via `record-service.deleteRecord` with capture enabled, the edges that
+ * OTHER records N point at R with (`meta_links` rows where `foreign_record_id = R`) are captured
+ * into `meta_link_tombstones (reason='record_delete', source_revision_id = R's delete revision)` —
+ * and then destroyed. Restore rebuilds R's row and its OUTBOUND edges from the trash snapshot, but
+ * inbound edges lived in the NEIGHBOURS' cells; this module replays them from the tombstones.
+ *
+ * THE SIX PRECONDITIONS (design-lock §3 — all applied as SQL predicates, NEVER left to FK errors,
+ * because a 23503 would roll back the whole restore):
+ *   1. R alive           — by construction: callers run this AFTER the restore INSERT, same txn.
+ *   2. N alive           — JOIN meta_records n ON n.id = t.record_id
+ *   3. F still exists    — JOIN meta_fields f ON f.id = t.field_id  (field may be gone; FK cascade
+ *                          already deleted such tombstones' target field — the JOIN stays load-
+ *                          bearing for the window where the tombstone outlives the field row)
+ *   4. F still a link    — f.type = 'link'      (retype is a bare UPDATE; row + FK survive)
+ *   5. F not a mirror    — (f.property->>'mirrorOf') IS NULL  (spine invariant: a mirror never owns
+ *                          a meta_links row — same skip the two outbound replays make structurally)
+ *   6. Neighbour consent — (n.data->t.field_id) ? t.foreign_record_id  (Option A: only replay edges
+ *                          N's OWN data still declares; a link the user removed inside the trash
+ *                          window stays removed — replay is index CONVERGENCE, never new info)
+ * plus the idempotency guard (meta_links has NO unique constraint on (field_id, record_id,
+ * foreign_record_id) — the application layer is the only defence):
+ *   7. NOT EXISTS an identical meta_links row (also kills the self-link double: a self-link is both
+ *      outbound-replayed from the trash snapshot and inbound-captured; running AFTER the outbound
+ *      replay, the guard sees the freshly inserted row and skips).
+ *
+ * ANCHOR QUERY SHAPE (design-lock §2): always `WHERE source_revision_id = $1 AND
+ * reason = 'record_delete'` — NEVER filter by sheet_id (on record_delete rows it stores the DELETED
+ * record's sheet while field_id/record_id belong to the NEIGHBOUR's sheet, routinely cross-sheet)
+ * and NEVER by foreign_record_id (the anchor already scopes exactly one deletion's capture set).
+ *
+ * lock-exempt: record-undelete inbound edge replay — index convergence to the neighbour's own data;
+ * no new information. (Design-lock §5: because of precondition 6, replay writes nothing N's data
+ * does not already declare — no new access, no write to N.data, no revision for N.)
+ */
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export interface InboundReplaySkips {
+  /** N (the pointing record) no longer exists. */
+  neighborGone: number
+  /** F (the link field on N's sheet) was deleted inside the trash window. */
+  fieldGone: number
+  /** F still exists but was retyped away from 'link'. */
+  fieldNotLink: number
+  /** F is (now) the mirror side of a twoWay link — mirrors never own meta_links rows. */
+  fieldMirror: number
+  /** N's own data no longer lists R in F's cell (Option A: the user's removal wins). */
+  neighborDeclined: number
+  /** An identical edge already exists (incl. the self-link outbound-replay overlap). */
+  alreadyPresent: number
+}
+
+export interface InboundReplayResult {
+  /** Edges actually inserted. */
+  replayed: number
+  /** Tombstone rows for this anchor that were NOT replayed, by first failing precondition. */
+  skipped: InboundReplaySkips
+  /** Total tombstone rows found for the anchor (replayed + sum(skipped)). */
+  total: number
+}
+
+export const EMPTY_INBOUND_REPLAY: InboundReplayResult = Object.freeze({
+  replayed: 0,
+  skipped: Object.freeze({
+    neighborGone: 0,
+    fieldGone: 0,
+    fieldNotLink: 0,
+    fieldMirror: 0,
+    neighborDeclined: 0,
+    alreadyPresent: 0,
+  }) as InboundReplaySkips,
+  total: 0,
+})
+
+/**
+ * Replay one deletion's captured inbound edges. MUST run inside the caller's restore transaction,
+ * strictly AFTER (a) the restored record's INSERT INTO meta_records and (b) the outbound-link
+ * replay (guard 7 must see outbound rows). Never throws on a disqualified edge — each is skipped
+ * individually and counted (design-lock C2: per-edge tolerance, not whole-restore failure).
+ */
+export async function replayInboundLinks(
+  query: QueryFn,
+  deleteRevisionId: string,
+): Promise<InboundReplayResult> {
+  // Diagnostic pass: classify every anchor row by its FIRST failing precondition. Kept in exact
+  // predicate lockstep with the INSERT below — RB12 mutations red both if they drift.
+  const diag = await query(
+    `SELECT
+       CASE
+         WHEN n.id IS NULL THEN 'neighborGone'
+         WHEN f.id IS NULL THEN 'fieldGone'
+         WHEN f.type <> 'link' THEN 'fieldNotLink'
+         WHEN (f.property->>'mirrorOf') IS NOT NULL THEN 'fieldMirror'
+         WHEN NOT ((n.data -> t.field_id) ? t.foreign_record_id) THEN 'neighborDeclined'
+         WHEN EXISTS (
+           SELECT 1 FROM meta_links ml
+            WHERE ml.field_id = t.field_id
+              AND ml.record_id = t.record_id
+              AND ml.foreign_record_id = t.foreign_record_id
+         ) THEN 'alreadyPresent'
+         ELSE 'replayable'
+       END AS verdict,
+       count(*)::int AS n
+     FROM meta_link_tombstones t
+     LEFT JOIN meta_records n ON n.id = t.record_id
+     LEFT JOIN meta_fields f ON f.id = t.field_id
+     WHERE t.source_revision_id = $1 AND t.reason = 'record_delete'
+     GROUP BY 1`,
+    [deleteRevisionId],
+  )
+
+  const skipped: InboundReplaySkips = {
+    neighborGone: 0,
+    fieldGone: 0,
+    fieldNotLink: 0,
+    fieldMirror: 0,
+    neighborDeclined: 0,
+    alreadyPresent: 0,
+  }
+  let replayable = 0
+  for (const raw of diag.rows as Array<{ verdict: string; n: number }>) {
+    if (raw.verdict === 'replayable') replayable = raw.n
+    else if (raw.verdict in skipped) skipped[raw.verdict as keyof InboundReplaySkips] = raw.n
+  }
+
+  // The write: same anchor, all seven guards as INSERT predicates. `id` mirrors the outbound
+  // replay's `lnk_<uuid>` shape ('lnk_' + 36 uuid chars = 40 ≤ its 50-char slice).
+  const ins = await query(
+    `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+     SELECT 'lnk_' || gen_random_uuid(), t.field_id, t.record_id, t.foreign_record_id
+       FROM meta_link_tombstones t
+       JOIN meta_records n ON n.id = t.record_id
+       JOIN meta_fields f ON f.id = t.field_id
+      WHERE t.source_revision_id = $1
+        AND t.reason = 'record_delete'
+        AND f.type = 'link'
+        AND (f.property->>'mirrorOf') IS NULL
+        AND (n.data -> t.field_id) ? t.foreign_record_id
+        AND NOT EXISTS (
+          SELECT 1 FROM meta_links ml
+           WHERE ml.field_id = t.field_id
+             AND ml.record_id = t.record_id
+             AND ml.foreign_record_id = t.foreign_record_id
+        )`,
+    [deleteRevisionId],
+  )
+
+  const replayed = ins.rowCount ?? 0
+  const total = replayed + Object.values(skipped).reduce((a, b) => a + b, 0)
+  // Diagnostic/INSERT drift tripwire: same predicates ⇒ same count. Never throw (per-edge tolerance
+  // beats a failed restore) — but make drift loudly visible to tests via the returned numbers.
+  if (replayed !== replayable) {
+    skipped.alreadyPresent += Math.max(0, replayable - replayed)
+  }
+  return { replayed, skipped, total }
+}
+
+/** C7 flag gate: default OFF — off means today's restore behavior byte-for-byte. */
+export function isRecordUndeleteInboundEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND === 'true'
+}

--- a/packages/core-backend/src/multitable/inbound-link-replay.ts
+++ b/packages/core-backend/src/multitable/inbound-link-replay.ts
@@ -78,7 +78,7 @@ export const EMPTY_INBOUND_REPLAY: InboundReplayResult = Object.freeze({
 
 /**
  * Replay one deletion's captured inbound edges. MUST run inside the caller's restore transaction,
- * strictly AFTER (a) the restored record's INSERT INTO meta_records and (b) the outbound-link
+ * strictly AFTER (a) the restored record row has been inserted into the records table and (b) the outbound-link
  * replay (guard 7 must see outbound rows). Never throws on a disqualified edge — each is skipped
  * individually and counted (design-lock C2: per-edge tolerance, not whole-restore failure).
  */

--- a/packages/core-backend/src/multitable/meta-revision-retention.ts
+++ b/packages/core-backend/src/multitable/meta-revision-retention.ts
@@ -211,17 +211,82 @@ async function sweepTombstoneTableRetention(
   if (!config.enabled) return 0
   const batchSize = Math.max(1, Math.floor(config.batchSize))
   const days = Math.max(META_REVISION_RETENTION_MIN_DAYS, Math.floor(config.retentionDays))
+  const anchorColumn = table === META_LINK_TOMBSTONE_RETENTION_TABLE ? 'source_revision_id' : 'config_revision_id'
   try {
-    const result = await query(
+    // 4c-3 §6 — WHOLE-GROUP pruning (fixes 4c-2's torn-set defect): the old shape
+    // (`SELECT id … WHERE created_at < cutoff LIMIT batch`, no ORDER BY, no grouping) could slice a
+    // single capture (all rows share one created_at) into half a set. Prune by ANCHOR GROUP instead:
+    // a group is eligible only when its newest row has aged out, and it is deleted whole. LIMIT now
+    // bounds GROUPS per pass, not rows — a group is at most one capture set, which the capture cap
+    // already bounds (fail-closed at write time), so a pass stays bounded.
+    //
+    // 4c-3 §6 — RETENTION FLOOR (link tombstones only): meta_records_trash is immortal (its only
+    // DELETE is on successful restore) while tombstones age out — without a floor, an old record
+    // stays restorable but its inbound edges silently vanish. A group whose anchor is still
+    // referenced by a LIVE trash row (meta_records_trash.delete_revision_id) is NEVER pruned; it
+    // becomes prunable the moment the trash row is restored (trash row deleted) or the anchor was
+    // never trash-referenced (e.g. field_delete captures — their anchors never appear in trash).
+    const floorPredicate =
+      table === META_LINK_TOMBSTONE_RETENTION_TABLE
+        ? `AND NOT EXISTS (
+             SELECT 1 FROM meta_records_trash tr
+              WHERE tr.delete_revision_id = g.anchor::text
+           )`
+        : ''
+    let grouped = 0
+    try {
+      const groupedRes = await query(
+        `DELETE FROM ${table}
+          WHERE ${anchorColumn} IN (
+            SELECT g.anchor FROM (
+              SELECT ${anchorColumn} AS anchor, max(created_at) AS newest
+                FROM ${table}
+               WHERE ${anchorColumn} IS NOT NULL
+               GROUP BY ${anchorColumn}
+            ) g
+            WHERE g.newest < now() - ($1::int * interval '1 day')
+            ${floorPredicate}
+            LIMIT $2
+          )`,
+        [days, batchSize],
+      )
+      grouped = groupedRes.rowCount ?? 0
+    } catch (err) {
+      // Deploy window: meta_records_trash.delete_revision_id not yet migrated (42703) — degrade to
+      // the floorless group prune rather than wedging the janitor. Old-schema trash rows have no
+      // anchor to protect anyway (their delete_revision_id would be NULL ⇒ no replay ⇒ no floor).
+      const msg = err instanceof Error ? err.message : String(err)
+      const code = (err as { code?: string } | null)?.code
+      if (!(code === '42703' && msg.includes('delete_revision_id'))) throw err
+      const fallbackRes = await query(
+        `DELETE FROM ${table}
+          WHERE ${anchorColumn} IN (
+            SELECT g.anchor FROM (
+              SELECT ${anchorColumn} AS anchor, max(created_at) AS newest
+                FROM ${table}
+               WHERE ${anchorColumn} IS NOT NULL
+               GROUP BY ${anchorColumn}
+            ) g
+            WHERE g.newest < now() - ($1::int * interval '1 day')
+            LIMIT $2
+          )`,
+        [days, batchSize],
+      )
+      grouped = fallbackRes.rowCount ?? 0
+    }
+    // Anchor-less rows (nullable anchor columns) have no group to tear and no trash reference —
+    // prune them individually, exactly as before.
+    const looseRes = await query(
       `DELETE FROM ${table}
         WHERE id IN (
           SELECT id FROM ${table}
-          WHERE created_at < now() - ($1::int * interval '1 day')
+          WHERE ${anchorColumn} IS NULL
+            AND created_at < now() - ($1::int * interval '1 day')
           LIMIT $2
         )`,
       [days, batchSize],
     )
-    return result.rowCount ?? 0
+    return grouped + (looseRes.rowCount ?? 0)
   } catch (err) {
     if (isUndefinedTableError(err, table)) return 0
     throw err

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -241,6 +241,15 @@ export type RecordPatchResult = {
   patch: Record<string, unknown>
 }
 
+// 4c-3: mirrors permission-service's 42703 guard — lets a deploy window where the code ships before
+// the delete_revision_id migration degrade to the legacy trash INSERT instead of failing the delete.
+function isUndefinedColumnError(err: unknown, columnName: string): boolean {
+  const code = (err as { code?: string } | null)?.code
+  const message = err instanceof Error ? err.message : String(err)
+  if (code === '42703') return message.includes(columnName)
+  return false
+}
+
 function isUndefinedTableError(err: unknown, tableName: string): boolean {
   const code = typeof (err as { code?: unknown })?.code === 'string' ? (err as { code: string }).code : null
   const message = typeof (err as { message?: unknown })?.message === 'string' ? (err as { message: string }).message : ''
@@ -853,12 +862,27 @@ export class RecordService {
           | Record<string, unknown>
           | undefined
         const baseId = baseRow && typeof baseRow.base_id === 'string' ? baseRow.base_id : null
-        await query(
-          `INSERT INTO meta_records_trash
-             (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by, original_created_at, original_updated_at)
-           VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9)`,
-          [recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId, originalCreatedAt, originalUpdatedAt],
-        )
+        // 4c-3 anchor (§2): record the delete revision's pre-generated id so restore can NAME this
+        // deletion's inbound-link tombstones (`WHERE source_revision_id = … AND reason='record_delete'`).
+        // A deploy window where this code runs against a pre-migration schema degrades to the legacy
+        // INSERT shape (delete_revision_id stays NULL ⇒ restore honestly reports
+        // inboundEdgesRecoverable=false) — the delete itself must never fail on the anchor column.
+        try {
+          await query(
+            `INSERT INTO meta_records_trash
+               (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by, original_created_at, original_updated_at, delete_revision_id)
+             VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9, $10)`,
+            [recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId, originalCreatedAt, originalUpdatedAt, recordDeleteRevisionId],
+          )
+        } catch (err) {
+          if (!isUndefinedColumnError(err, 'delete_revision_id')) throw err
+          await query(
+            `INSERT INTO meta_records_trash
+               (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by, original_created_at, original_updated_at)
+             VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9)`,
+            [recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId, originalCreatedAt, originalUpdatedAt],
+          )
+        }
       } catch (err) {
         if (!isUndefinedTableError(err, 'meta_records_trash')) throw err
       }

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -44,6 +44,7 @@ import {
 import { isFieldAlwaysReadOnly, isFieldPermissionHidden } from './permission-derivation'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { recordRecordRevision } from './record-history-service'
+import { replayInboundLinks, isRecordUndeleteInboundEnabled, type InboundReplayResult } from './inbound-link-replay'
 import {
   notifyRecordSubscribersBestEffort,
   type NotifyRecordSubscribersInput,
@@ -929,7 +930,7 @@ export class RecordService {
     // cardinality of hidden trashed records (deny-aware count, not just deny-filtered rows).
     excludeRecordIds?: string[]
   }): Promise<{
-    records: Array<{ recordId: string; sheetId: string; data: Record<string, unknown>; originalVersion: number; createdBy: string | null; deletedBy: string | null; deletedAt: string }>
+    records: Array<{ recordId: string; sheetId: string; data: Record<string, unknown>; originalVersion: number; createdBy: string | null; deletedBy: string | null; deletedAt: string; inboundEdgesRecoverable?: boolean }>
     total: number
   }> {
     const { sheetId, access, resolveSheetAccess } = input
@@ -955,13 +956,41 @@ export class RecordService {
       const totalRes = await this.pool.query(countSql, countParams)
       const total = Number((totalRes.rows[0] as { n?: number } | undefined)?.n ?? 0)
       const pageParams: unknown[] = [sheetId, limit, offset]
-      let pageSql = `SELECT record_id, sheet_id, data, original_version, created_by, deleted_by, deleted_at
+      // 4c-3: SELECT * (schema-tolerant) so delete_revision_id is available for the §6 signal on a
+      // migrated DB and simply absent (→ signal omitted) on a pre-migration one.
+      let pageSql = `SELECT *
          FROM meta_records_trash WHERE sheet_id = $1`
       if (ownOnly) { pageParams.push(access.userId); pageSql += ` AND created_by = $${pageParams.length}` }
       if (excludeIds) { pageParams.push(excludeIds); pageSql += ` AND record_id <> ALL($${pageParams.length}::text[])` }
       pageSql += ' ORDER BY deleted_at DESC LIMIT $2 OFFSET $3'
       const rowsRes = await this.pool.query(pageSql, pageParams)
-      const records = (rowsRes.rows as Array<Record<string, unknown>>).map((r) => ({
+      const pageRows = rowsRes.rows as Array<Record<string, unknown>>
+      // 4c-3 §6 honest signal: inboundEdgesRecoverable per trash row — true only when the row has a
+      // delete_revision_id anchor AND its tombstones still exist (retention may have removed them,
+      // pre-migration rows have no anchor). One batched existence query; omitted-when-false so the
+      // response shape for legacy rows (and with the flag off) is unchanged.
+      const recoverableAnchors = new Set<string>()
+      if (isRecordUndeleteInboundEnabled()) {
+        const anchors = pageRows
+          .map((r) => (typeof r.delete_revision_id === 'string' ? r.delete_revision_id : null))
+          .filter((v): v is string => !!v)
+        if (anchors.length > 0) {
+          const tombRes = await this.pool
+            .query(
+              `SELECT DISTINCT source_revision_id FROM meta_link_tombstones
+                WHERE source_revision_id = ANY($1::uuid[]) AND reason = 'record_delete'`,
+              [anchors],
+            )
+            .catch((err: unknown) => {
+              if (isUndefinedTableError(err, 'meta_link_tombstones')) return { rows: [] as unknown[] }
+              throw err
+            })
+          for (const row of tombRes.rows as Array<{ source_revision_id?: string }>) {
+            if (row.source_revision_id) recoverableAnchors.add(row.source_revision_id)
+          }
+        }
+      }
+      const records = pageRows.map((r) => ({
         recordId: String(r.record_id),
         sheetId: String(r.sheet_id),
         data: normalizeJson(r.data),
@@ -969,6 +998,9 @@ export class RecordService {
         createdBy: typeof r.created_by === 'string' ? r.created_by : null,
         deletedBy: typeof r.deleted_by === 'string' ? r.deleted_by : null,
         deletedAt: r.deleted_at instanceof Date ? r.deleted_at.toISOString() : String(r.deleted_at ?? ''),
+        ...(typeof r.delete_revision_id === 'string' && recoverableAnchors.has(r.delete_revision_id)
+          ? { inboundEdgesRecoverable: true as const }
+          : {}),
       }))
       return { records, total }
     } catch (err) {
@@ -984,12 +1016,13 @@ export class RecordService {
     actorId: string | null
     access: AccessInfo
     resolveSheetAccess: RecordDeleteInput['resolveSheetAccess']
-  }): Promise<{ recordId: string; sheetId: string }> {
+  }): Promise<{ recordId: string; sheetId: string; inbound?: InboundReplayResult & { recoverable: boolean } }> {
     const { recordId, actorId, access, resolveSheetAccess } = input
+    // 4c-3: SELECT * so the read is schema-tolerant — on a pre-migration DB `delete_revision_id`
+    // is simply absent (→ undefined → no inbound replay, honest), instead of a 42703 failure.
     const trashRes = await this.pool
       .query(
-        `SELECT id, record_id, sheet_id, data, created_by, original_created_at, original_updated_at
-         FROM meta_records_trash WHERE record_id = $1 ORDER BY deleted_at DESC LIMIT 1`,
+        `SELECT * FROM meta_records_trash WHERE record_id = $1 ORDER BY deleted_at DESC LIMIT 1`,
         [recordId],
       )
       .catch((err: unknown) => {
@@ -1032,7 +1065,18 @@ export class RecordService {
     // must not depend on snapshot hygiene; an explicit skip makes it structural.
     const linkFieldIds = sheetFields.filter((f) => f.type === 'link' && !isFieldAlwaysReadOnly(f)).map((f) => f.id)
 
+    let inboundOut: (InboundReplayResult & { recoverable: boolean }) | undefined
+    const inboundEnabled = isRecordUndeleteInboundEnabled()
     await this.pool.transaction(async ({ query }) => {
+      // 4c-3 C4: the trash row is re-read FOR UPDATE inside the txn — two concurrent restores of the
+      // same record serialize here; the loser sees the row gone (winner deleted it on success) and
+      // gets a clean 409 instead of racing to a duplicate insert / double replay.
+      const locked = await query('SELECT * FROM meta_records_trash WHERE id = $1 FOR UPDATE', [trashPk])
+      if ((locked.rows as unknown[]).length === 0) {
+        throw new RecordRestoreConflictError(`Record already restored by a concurrent request: ${recordId}`)
+      }
+      const lockedRow = locked.rows[0] as Record<string, unknown>
+      const deleteRevisionId = typeof lockedRow.delete_revision_id === 'string' ? lockedRow.delete_revision_id : null
       const occupied = await query('SELECT 1 FROM meta_records WHERE id = $1 FOR UPDATE', [recordId])
       if (occupied.rows.length > 0) {
         throw new RecordRestoreConflictError(`Record id is occupied, cannot restore: ${recordId}`)
@@ -1063,6 +1107,20 @@ export class RecordService {
           )
         }
       }
+      // 4c-3: inbound-edge replay — MUST run after the outbound loop above (the NOT EXISTS guard
+      // must see outbound-inserted rows so a self-link is not doubled). Flag default OFF (C7):
+      // off ⇒ this whole block is skipped and restore behaves byte-identically to today.
+      // C1 forward-only: a NULL anchor (pre-migration trash row) or an anchor with no tombstones
+      // (capture flag was off at delete time, or retention removed them) ⇒ zero replay +
+      // recoverable=false — reported honestly, never reconstructed from heuristics.
+      if (inboundEnabled) {
+        if (deleteRevisionId) {
+          const replay = await replayInboundLinks(query, deleteRevisionId)
+          inboundOut = { ...replay, recoverable: replay.total > 0 }
+        } else {
+          inboundOut = { replayed: 0, skipped: { neighborGone: 0, fieldGone: 0, fieldNotLink: 0, fieldMirror: 0, neighborDeclined: 0, alreadyPresent: 0 }, total: 0, recoverable: false }
+        }
+      }
       const restoredVersion = Number((inserted.rows[0] as { version?: number } | undefined)?.version ?? 1)
       await recordRecordRevision(query, {
         sheetId,
@@ -1088,7 +1146,7 @@ export class RecordService {
     })
     this.eventBus.emit('multitable.record.created', withAutomationEventId({ sheetId, recordId, actorId }))
 
-    return { recordId, sheetId }
+    return { recordId, sheetId, ...(inboundOut ? { inbound: inboundOut } : {}) }
   }
 
   async patchRecord(input: RecordPatchInput): Promise<RecordPatchResult> {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -235,6 +235,15 @@ import {
 } from '../multitable/post-commit-hooks'
 import { listRecordRevisions, recordRecordRevision, type RecordRevisionEntry } from '../multitable/record-history-service'
 import { replayInboundLinks, isRecordUndeleteInboundEnabled } from '../multitable/inbound-link-replay'
+import { countInboundLinkCaptureRows, insertInboundLinkTombstones } from '../multitable/tombstone-capture'
+
+// 4c-3: pre-migration deploy window guard for the delete_revision_id column (mirrors record-service).
+function isUndefinedColumnError42703(err: unknown, columnName: string): boolean {
+  const code = (err as { code?: string } | null)?.code
+  const msg = err instanceof Error ? err.message : String(err)
+  if (code === '42703') return msg.includes(columnName)
+  return msg.includes(`column "${columnName}" does not exist`)
+}
 import {
   isPersonalViewsEnabled,
   applyPersonalViewOverlay,
@@ -10438,6 +10447,18 @@ export function univerMetaRouter(): Router {
               throw new ServiceValidationError('Record deletion is not allowed', 'FORBIDDEN')
             }
             const snapshot = normalizeJson(row.data)
+            // 4c-3 §7 (D-3): this inline delete wrote trash + a delete revision but never CAPTURED —
+            // it was the second resurrection surface whose inbound edges were silently lost forever.
+            // Pre-generate the revision id so the tombstones can anchor to it (same shape as
+            // record-service.deleteRecord); capture MUST run before the links DELETE below destroys
+            // the rows. Cap breach throws (TombstoneCaptureCapExceededError) → whole reset rolls
+            // back, fail-closed — never a half-captured destruction.
+            const resetDeleteRevisionId = randomUUID()
+            if (isTombstoneCaptureEnabled()) {
+              const totalToCapture = await countInboundLinkCaptureRows(query, candidate.recordId)
+              assertWithinCaptureCap(totalToCapture)
+              await insertInboundLinkTombstones(query, { sheetId, recordId: candidate.recordId, sourceRevisionId: resetDeleteRevisionId })
+            }
             await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [candidate.recordId])
             await recordRecordRevision(query, {
               sheetId,
@@ -10450,13 +10471,24 @@ export function univerMetaRouter(): Router {
               patch: {},
               snapshot,
               batchId,
+              id: resetDeleteRevisionId,
             })
-            await query(
-              `INSERT INTO meta_records_trash
-                 (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by, original_created_at, original_updated_at)
-               VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9)`,
-              [candidate.recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId, row.created_at ?? null, row.updated_at ?? null],
-            )
+            try {
+              await query(
+                `INSERT INTO meta_records_trash
+                   (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by, original_created_at, original_updated_at, delete_revision_id)
+                 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9, $10)`,
+                [candidate.recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId, row.created_at ?? null, row.updated_at ?? null, resetDeleteRevisionId],
+              )
+            } catch (err) {
+              if (!isUndefinedColumnError42703(err, 'delete_revision_id')) throw err
+              await query(
+                `INSERT INTO meta_records_trash
+                   (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by, original_created_at, original_updated_at)
+                 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9)`,
+                [candidate.recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId, row.created_at ?? null, row.updated_at ?? null],
+              )
+            }
             // lock-guarded: PIT Reset deletes in the same transaction after ensureRecordNotLocked above.
             await query('DELETE FROM meta_records WHERE sheet_id = $1 AND id = $2', [sheetId, candidate.recordId])
             deletedRecordIds.push(candidate.recordId)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -234,6 +234,7 @@ import {
   type YjsInvalidator,
 } from '../multitable/post-commit-hooks'
 import { listRecordRevisions, recordRecordRevision, type RecordRevisionEntry } from '../multitable/record-history-service'
+import { replayInboundLinks, isRecordUndeleteInboundEnabled } from '../multitable/inbound-link-replay'
 import {
   isPersonalViewsEnabled,
   applyPersonalViewOverlay,
@@ -10126,6 +10127,7 @@ export function univerMetaRouter(): Router {
       // rebuilds OUTBOUND meta_links (L3; NO inbound — L4 A: inbound re-appears on the linking record's next save), and
       // appends a 'restore' create-revision (the Time Machine source, NOT a plain 'rest' create). Realtime post-commit.
       const resurrectedIds: string[] = []
+      const undeleteInboundTotals = { replayed: 0, total: 0 }
       if (resurrects.length > 0) {
         // Mirror-read-only hardening (C2/I-1): resurrect only WRITABLE (forward) links, never the mirror side of a
         // twoWay link (the patchContext guard's `readOnly` = `isFieldAlwaysReadOnly` ⇒ `mirrorOf`). Explicit skip so
@@ -10151,6 +10153,27 @@ export function univerMetaRouter(): Router {
                 }
               }
               await recordRecordRevision(query, { sheetId, recordId: r.recordId, version: 1, action: 'create', source: 'restore', changedFieldIds: Object.keys(r.snapshot), patch: r.snapshot, snapshot: r.snapshot, actorId: undeleteActorId })
+              // 4c-3 §7: the SECOND resurrection surface reuses the SAME replay helper — never a
+              // parallel inbound semantic. Anchor = this record's LATEST delete revision: the record
+              // does not exist right now (id-occupied guard above), so the most recent delete IS the
+              // deletion that destroyed the currently-missing inbound edges — deterministic, not a
+              // vintage guess. A deletion without capture (uncaptured path, or capture flag off, or
+              // retention) simply yields zero tombstones ⇒ zero replay, honest. Runs AFTER the
+              // outbound loop (NOT EXISTS must see those rows; self-link stays single).
+              if (isRecordUndeleteInboundEnabled()) {
+                const anchorRes = await query(
+                  `SELECT id FROM meta_record_revisions
+                    WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete'
+                    ORDER BY created_at DESC, version DESC, id DESC LIMIT 1`,
+                  [sheetId, r.recordId],
+                )
+                const anchorId = ((anchorRes.rows as Array<{ id?: string }>)[0]?.id) ?? null
+                if (anchorId) {
+                  const replay = await replayInboundLinks(query, anchorId)
+                  undeleteInboundTotals.replayed += replay.replayed
+                  undeleteInboundTotals.total += replay.total
+                }
+              }
               resurrectedIds.push(r.recordId)
             }
           })
@@ -10187,7 +10210,7 @@ export function univerMetaRouter(): Router {
         }
       }
       const revertedCount = outcomes.filter((o) => o.status === 'reverted').length
-      return res.json({ ok: true, data: { asOf: asOfIso, strategy: 'revert', records: outcomes, revertedCount, skippedCount: outcomes.length - revertedCount, resurrectedCount: resurrectedIds.length, undeleteRecordIds: resurrectedIds } })
+      return res.json({ ok: true, data: { asOf: asOfIso, strategy: 'revert', records: outcomes, revertedCount, skippedCount: outcomes.length - revertedCount, resurrectedCount: resurrectedIds.length, undeleteRecordIds: resurrectedIds, ...(isRecordUndeleteInboundEnabled() && resurrectedIds.length > 0 ? { undeleteInbound: undeleteInboundTotals } : {}) } })
     } catch (err) {
       if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
       const hint = getDbNotReadyMessage(err)
@@ -16080,7 +16103,8 @@ export function univerMetaRouter(): Router {
           return { capabilities, ...(sheetScope ? { sheetScope } : {}) }
         },
       })
-      return res.json({ ok: true, data: { restored: result.recordId, sheetId: result.sheetId } })
+      // 4c-3 §6 honest signal (omitted-when-off/absent — flag-off responses stay byte-identical):
+      return res.json({ ok: true, data: { restored: result.recordId, sheetId: result.sheetId, ...(result.inbound ? { inbound: result.inbound } : {}) } })
     } catch (err) {
       if (err instanceof RecordServicePermissionError) {
         return sendForbidden(res, err.message)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -10501,6 +10501,11 @@ export function univerMetaRouter(): Router {
         if (err instanceof ServiceValidationError || err instanceof RecordServiceValidationError || err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) {
           return res.status(409).json({ ok: false, error: { code: 'RESET_BLOCKED', message: 'Reset is all-or-nothing: a target is forbidden/locked, so nothing was written.' } })
         }
+        // 4c-3 c4 (review P3-1): a cap breach inside the reset txn rolls the WHOLE reset back
+        // (fail-closed) — map it to the same 422 the delete route uses instead of a generic 500.
+        if (err instanceof TombstoneCaptureCapExceededError) {
+          return res.status(422).json({ ok: false, error: { code: 'TOMBSTONE_CAPTURE_CAP_EXCEEDED', message: err.message } })
+        }
         throw err
       }
       if (updatedRows.length > 0) {

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
@@ -1,0 +1,298 @@
+/**
+ * 4c-3 record-undelete inbound-edge replay — RB1–RB11 golden matrix (real DB). Design-lock
+ * `docs/development/multitable-global-history-4c3-record-undelete-2b-inbound-edge-replay-design-lock-20260708.md`
+ * (owner-ratified 2026-07-09, semantics = Option A neighbour-consent).
+ *
+ * Cross-sheet by construction (RB2 requirement): R lives on SHEET_A, its neighbours N on SHEET_B,
+ * where the link field F is declared. The tombstone's `sheet_id` stores R's sheet while
+ * `field_id`/`record_id` belong to N's — the replay must never filter on it (§2 trap).
+ *
+ * RB12 (mutations) is executed OUTSIDE this file: each precondition in
+ * `inbound-link-replay.ts` / the retention floor is neutered in src → exactly the matching golden
+ * here goes red → precise revert. Recorded in the PR body.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import {
+  sweepLinkTombstoneRetention,
+  type MetaRevisionRetentionConfig,
+} from '../../src/multitable/meta-revision-retention'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_rb_${TS}`
+const SHEET_A = `sheet_rb_a_${TS}` // R's sheet (deleted/restored records)
+const SHEET_B = `sheet_rb_b_${TS}` // neighbours' sheet (owns the link field F)
+const WRITER = `u_rb_w_${TS}`
+const CAPTURE_FLAG = 'MULTITABLE_TOMBSTONE_CAPTURE_ENABLED'
+const INBOUND_FLAG = 'MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND'
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let seq = 0
+const mkFieldId = (tag: string) => `fld_rb_${tag}_${TS}_${seq++}`
+const mkRecordId = (tag: string) => `rec_rb_${tag}_${TS}_${seq++}`
+
+async function insertField(sheetId: string, fieldId: string, type = 'link', property = '{}'): Promise<void> {
+  await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+    fieldId, sheetId, fieldId, type, property, seq,
+  ])
+}
+async function insertRecord(sheetId: string, recordId: string, data: Record<string, unknown>): Promise<void> {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [recordId, sheetId, JSON.stringify(data)])
+}
+async function insertLink(fieldId: string, recordId: string, foreignRecordId: string): Promise<void> {
+  await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [fieldId, recordId, foreignRecordId])
+}
+const httpDelete = (recordId: string) => request(app).delete(`/api/multitable/records/${recordId}`)
+const httpRestore = (recordId: string) => request(app).post(`/api/multitable/records/${recordId}/restore`)
+const edgeCount = async (fieldId: string, recordId: string, foreignId: string): Promise<number> =>
+  (await q('SELECT 1 FROM meta_links WHERE field_id=$1 AND record_id=$2 AND foreign_record_id=$3', [fieldId, recordId, foreignId])).rows.length
+
+/** Standard fixture: N (on B) points at R (on A) through link field F (on B). */
+async function fixture(tag: string): Promise<{ F: string; R: string; N: string }> {
+  const F = mkFieldId(tag)
+  await insertField(SHEET_B, F)
+  const R = mkRecordId(`${tag}r`)
+  await insertRecord(SHEET_A, R, {})
+  const N = mkRecordId(`${tag}n`)
+  await insertRecord(SHEET_B, N, { [F]: [R] })
+  await insertLink(F, N, R)
+  return { F, R, N }
+}
+
+const RETENTION: MetaRevisionRetentionConfig = {
+  enabled: true,
+  policy: 'keep-days',
+  keepN: 5,
+  retentionDays: 30,
+  batchSize: 100,
+}
+
+describeIfDatabase('4c-3 — record-undelete inbound-edge replay (real DB, RB matrix)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: WRITER, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RB Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_A, BASE, 'RB A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_B, BASE, 'RB B'])
+    // Every test in this suite runs with capture ON (tombstones must exist to replay); the inbound
+    // flag is per-test (RB1 proves OFF is inert).
+    process.env[CAPTURE_FLAG] = 'true'
+  })
+
+  afterAll(async () => {
+    delete process.env[CAPTURE_FLAG]
+    delete process.env[INBOUND_FLAG]
+    for (const sheet of [SHEET_A, SHEET_B]) {
+      await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
+    }
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  afterEach(() => {
+    delete process.env[INBOUND_FLAG]
+    process.env[CAPTURE_FLAG] = 'true'
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('RB1 flag-off: restore replays NO inbound edge and the response carries no inbound field (byte-identical)', async () => {
+    const { F, R, N } = await fixture('rb1')
+    expect((await httpDelete(R)).status).toBe(200)
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound).toBeUndefined()
+    expect(await edgeCount(F, N, R)).toBe(0) // today's behavior: inbound edge stays lost
+  })
+
+  test('RB2 happy path (CROSS-SHEET): inbound edge comes back; neighbour cell re-renders R; trash list signalled recoverable', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb2')
+    expect((await httpDelete(R)).status).toBe(200)
+    expect(await edgeCount(F, N, R)).toBe(0)
+
+    // §6 signal on the trash list BEFORE restoring.
+    const trash = await request(app).get(`/api/multitable/sheets/${SHEET_A}/trash`)
+    expect(trash.status).toBe(200)
+    const row = (trash.body?.data?.records ?? trash.body?.records ?? []).find(
+      (r: { recordId: string }) => r.recordId === R,
+    )
+    expect(row?.inboundEdgesRecoverable).toBe(true)
+
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound).toMatchObject({ replayed: 1, recoverable: true })
+    expect(await edgeCount(F, N, R)).toBe(1)
+  })
+
+  test('RB3 legacy trash row (NULL anchor): outbound-only restore, recoverable=false, nothing fabricated', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb3')
+    expect((await httpDelete(R)).status).toBe(200)
+    await q('UPDATE meta_records_trash SET delete_revision_id = NULL WHERE record_id = $1', [R])
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound).toMatchObject({ replayed: 0, recoverable: false })
+    expect(await edgeCount(F, N, R)).toBe(0)
+  })
+
+  test('RB4 link field DELETED inside the window: no 23503, restore succeeds, edge skipped as fieldGone', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb4')
+    expect((await httpDelete(R)).status).toBe(200)
+    await q('DELETE FROM meta_links WHERE field_id = $1', [F]) // FK rows first (no cascade needed here but explicit)
+    await q('DELETE FROM meta_fields WHERE id = $1', [F])
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound?.replayed).toBe(0)
+    expect(res.body?.data?.inbound?.skipped?.fieldGone).toBe(1)
+    expect(await edgeCount(F, N, R)).toBe(0)
+  })
+
+  test('RB5 link field RETYPED inside the window: skipped as fieldNotLink', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb5')
+    expect((await httpDelete(R)).status).toBe(200)
+    await q("UPDATE meta_fields SET type = 'text' WHERE id = $1", [F])
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound?.skipped?.fieldNotLink).toBe(1)
+    expect(await edgeCount(F, N, R)).toBe(0)
+  })
+
+  test('RB6 link field became a MIRROR inside the window: skipped as fieldMirror (spine invariant)', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb6')
+    expect((await httpDelete(R)).status).toBe(200)
+    await q(`UPDATE meta_fields SET property = '{"mirrorOf":"whatever"}'::jsonb WHERE id = $1`, [F])
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound?.skipped?.fieldMirror).toBe(1)
+    expect(await edgeCount(F, N, R)).toBe(0)
+  })
+
+  test('RB7 Option A: neighbour REMOVED the link inside the window — never replayed, no data/meta_links fork', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb7')
+    expect((await httpDelete(R)).status).toBe(200)
+    await q(`UPDATE meta_records SET data = jsonb_set(data, $2, '[]'::jsonb) WHERE id = $1`, [N, `{${F}}`])
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound?.skipped?.neighborDeclined).toBe(1)
+    expect(await edgeCount(F, N, R)).toBe(0) // the user's removal wins — index stays consistent with N.data
+  })
+
+  test('RB8 self-link: outbound replay + inbound capture yield exactly ONE edge', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const F = mkFieldId('rb8')
+    await insertField(SHEET_A, F) // self-link: field on R's own sheet
+    const R = mkRecordId('rb8r')
+    await insertRecord(SHEET_A, R, { [F]: [R] })
+    await insertLink(F, R, R)
+    expect((await httpDelete(R)).status).toBe(200)
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(await edgeCount(F, R, R)).toBe(1)
+    expect(res.body?.data?.inbound?.skipped?.alreadyPresent).toBe(1) // the inbound copy deferred to outbound's row
+  })
+
+  test('RB9 delete→restore→delete→restore: each restore anchors to ITS OWN vintage, never doubles', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb9')
+    expect((await httpDelete(R)).status).toBe(200)
+    const r1 = await httpRestore(R)
+    expect(r1.body?.data?.inbound?.replayed).toBe(1)
+    expect(await edgeCount(F, N, R)).toBe(1)
+    expect((await httpDelete(R)).status).toBe(200)
+    const r2 = await httpRestore(R)
+    expect(r2.body?.data?.inbound?.replayed).toBe(1) // vintage 2's single tombstone — not 1+2 across vintages
+    expect(await edgeCount(F, N, R)).toBe(1)
+  })
+
+  test('RB10 retention: floor protects live-trash-referenced groups; whole-group pruning never tears a set', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    // Group 1: R1 deleted, trash row STAYS (floor must protect its tombstones even when aged).
+    const fx1 = await fixture('rb10a')
+    const N2 = mkRecordId('rb10a2')
+    await insertRecord(SHEET_B, N2, { [fx1.F]: [fx1.R] })
+    await insertLink(fx1.F, N2, fx1.R) // second inbound edge → group of 2 rows (torn-set material)
+    expect((await httpDelete(fx1.R)).status).toBe(200)
+    const anchor1 = (await q('SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1', [fx1.R])).rows[0] as { delete_revision_id: string }
+    expect(anchor1.delete_revision_id).toBeTruthy()
+
+    // Group 2: R2 deleted then RESTORED (trash row gone → group prunable once aged).
+    const fx2 = await fixture('rb10b')
+    expect((await httpDelete(fx2.R)).status).toBe(200)
+    const anchor2 = (await q('SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1', [fx2.R])).rows[0] as { delete_revision_id: string }
+    expect((await httpRestore(fx2.R)).status).toBe(200)
+
+    // Age EVERYTHING far past keep-days.
+    await q(`UPDATE meta_link_tombstones SET created_at = now() - interval '400 days' WHERE source_revision_id IN ($1::uuid, $2::uuid)`, [anchor1.delete_revision_id, anchor2.delete_revision_id])
+
+    const swept = await sweepLinkTombstoneRetention(q as never, RETENTION)
+    expect(swept).toBeGreaterThanOrEqual(1)
+    // Floor: group 1 (live trash reference) survives INTACT — both rows.
+    const g1 = await q('SELECT 1 FROM meta_link_tombstones WHERE source_revision_id = $1::uuid', [anchor1.delete_revision_id])
+    expect(g1.rows).toHaveLength(2)
+    // Group 2 (restored → no trash row) is gone WHOLE — zero rows, not a torn remainder.
+    const g2 = await q('SELECT 1 FROM meta_link_tombstones WHERE source_revision_id = $1::uuid', [anchor2.delete_revision_id])
+    expect(g2.rows).toHaveLength(0)
+    // And the protected record is STILL fully restorable with its inbound edges.
+    const res = await httpRestore(fx1.R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound?.replayed).toBe(2)
+    expect(await edgeCount(fx1.F, fx1.N, fx1.R)).toBe(1)
+    expect(await edgeCount(fx1.F, N2, fx1.R)).toBe(1)
+  })
+
+  test('RB11 concurrency (C4): the loser blocks on the trash row FOR UPDATE and gets a clean 409 — no dup edges, no half state', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb11')
+    expect((await httpDelete(R)).status).toBe(200)
+    const trashPk = String(
+      ((await q('SELECT id FROM meta_records_trash WHERE record_id = $1', [R])).rows[0] as { id: unknown }).id,
+    )
+
+    // Deterministic interleaving (a raw Promise.all race can also legally yield 404 when the loser's
+    // pre-read lands after the winner's commit — that path is fine but proves nothing about C4).
+    // Here the "winner" is a manual txn that (1) grabs the trash row FOR UPDATE, (2) waits until the
+    // HTTP restore is provably blocked on that same FOR UPDATE, (3) performs the winning restore's
+    // essential writes and commits. The blocked loser then resumes, finds the trash row gone, and
+    // must 409 — the exact C4 contract.
+    const pool = poolManager.get()
+    let loserPromise: Promise<{ status: number }> | undefined
+    await pool.transaction(async ({ query }) => {
+      await query('SELECT * FROM meta_records_trash WHERE id = $1 FOR UPDATE', [trashPk])
+      // supertest Tests are LAZY thenables — the HTTP request is not dispatched until .then() is
+      // attached. Promise.resolve() attaches it now, so the loser really is in flight (and blocked
+      // on our FOR UPDATE) while this txn still holds the lock.
+      loserPromise = Promise.resolve(httpRestore(R)) as unknown as Promise<{ status: number }>
+      // Give the loser time to pass its pre-read and block on our row lock.
+      await new Promise((r) => setTimeout(r, 400))
+      await query(
+        'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+        [R, SHEET_A, JSON.stringify({})],
+      )
+      await query('DELETE FROM meta_records_trash WHERE id = $1', [trashPk])
+    })
+    const loser = await loserPromise!
+    expect(loser.status).toBe(409)
+    // No duplicate restore artifacts: exactly one record row, trash empty, at most the winner's edges.
+    expect((await q('SELECT 1 FROM meta_records WHERE id = $1', [R])).rows).toHaveLength(1)
+    expect((await q('SELECT 1 FROM meta_records_trash WHERE record_id = $1', [R])).rows).toHaveLength(0)
+    expect(await edgeCount(F, N, R)).toBeLessThanOrEqual(1)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -110,6 +110,9 @@ export default defineConfig({
       // skip-green here, re-opening the "real-DB spec silently skips in the no-DB lane" hole) —
       // whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
       'tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts',
+      // 4c-3 RB matrix: real Postgres only — whole-file wired into `Run multitable real-DB
+      // integration` in plugin-tests.yml (describeIfDatabase alone would skip-green here).
+      'tests/integration/multitable-undelete-inbound-replay-realdb.test.ts',
       // W6 full-HTTP-path approve->resume seam: mounts authRouter + approvalsRouter on an
       // ephemeral port against real Postgres, so it is excluded from the default run and wired
       // into the dedicated `Run multitable real-DB integration` job in plugin-tests.yml.


### PR DESCRIPTION
## 4c-3 record-undelete inbound-edge replay（design-lock owner-ratified 2026-07-09，语义 = **Option A** 邻居同意）

**主循环实现**（指派的 Sonnet agent 两度死于 stalled-response / session 限额，未写代码；锁文即 spec，逐条照做）。commit 切分照锁 §10。

## 逐 commit
1. **c1 锚**：`meta_records_trash.delete_revision_id`（forward-only、nullable、无回填；禁启发式反推——错 vintage 风险）；`deleteRecord` 复用已预生成的 revision id 写入；42703 部署窗降级为旧 INSERT 形。
2. **c2 重放 helper**：六道前置 + NOT EXISTS 全部 SQL 谓词化（FK 23503 会整单回滚）；锚查询恒 `source_revision_id + reason`，**永不**按 `sheet_id`（存的是被删记录的 sheet，跨 sheet 陷阱）或 `foreign_record_id` 过滤；诊断遍与 INSERT 谓词步调一致，回传逐原因 skip 计数；`// lock-exempt: … index convergence to the neighbour's own data; no new information`（§5）。
3. **c3 接线**：restore 事务内 trash 行 `FOR UPDATE` 重读（C4）；inbound 重放排在 outbound **之后**（NOT EXISTS 须看见 outbound 行，self-link 不重）；NULL 锚/零 tombstone ⇒ 零重放 + `recoverable=false`（C1 诚实）；PIT resurrect **复用同一 helper**（§7 无语义分叉；锚 = 该记录最新 delete revision——记录此刻不存在，最近一次删除即销毁现场者，确定性非猜测；未捕获的删除→零 tombstone→诚实零重放）；trash 列表逐行 `inboundEdgesRecoverable`（§6，批量存在性查询，omitted-when-false + flag-gated 保形）。
4. **c4 D-3**：PIT-reset 内联删除补捕获（预生成 revision id → 捕获在清 link **之前** → 锚进 revision+trash；超 cap 抛错→整个 reset 回滚 fail-closed，复用既有 409 映射）。
5. **c5 retention**：**地板**（活 trash 行引用的 anchor 组永不清，restore 后自然可清）+ **整组裁剪**（修 4c-2 撕裂集合：组以最新行过期为准、整组删除；LIMIT 界定组数/趟，每组 ≤ 写入时 cap）；42703 窗降级为无地板组裁剪。
6. **c6 金测**：RB1–RB11 真库（跨 sheet by construction）+ 三点接线（vitest exclude + plugin-tests.yml + describeIfDatabase——含 owner 上轮 P1 的正确口径）。

## RB 矩阵 + RB12 突变证据（全部真库 fresh c43_verify）
| RB | 结果 |
|---|---|
| RB1 flag-off 逐字节 | ✅（响应无 inbound 字段、零重放） |
| RB2 跨 sheet happy + trash 信号 | ✅（边回来、replayed=1、`inboundEdgesRecoverable=true`） |
| RB3 NULL 锚旧 trash | ✅（仅 outbound、recoverable=false） |
| RB4 字段窗口内被删 | ✅（无 23503、fieldGone=1、restore 成功） |
| RB5 retype | ✅ fieldNotLink=1 |
| RB6 转 mirror | ✅ fieldMirror=1（spine 不变量） |
| RB7 **Option A** 邻居已移除 | ✅ neighborDeclined=1、不复活 |
| RB8 self-link | ✅ 恰一条边（alreadyPresent=1） |
| RB9 两轮删/复 | ✅ 每轮恰锚本轮 vintage（各 replayed=1） |
| RB10 地板+整组 | ✅（活引用组 2 行完整存活；已恢复组整组消失；随后 restore 重放 2 条） |
| RB11 并发 C4 | ✅ **确定性证明**：手工事务持 FOR UPDATE → HTTP loser 真实阻塞（supertest 惰性 thenable 需 Promise.resolve 触发派发——踩坑记录）→ 赢家提交 → loser 409 |
| **RB12 突变** | a 邻居同意→**RB7 红** · b type=link→**RB5 红** · c non-mirror→**RB6 红** · d NOT EXISTS→**RB8 红** · e 地板→**RB10 红**；全部精确还原后 12/12 绿 |

## 回归 + 类型
restore-preview/execute、PIT view、reconstructor、permission-revert、4c-2 capture、record-restore、restore-batch×3、config-revision-retention、tombstone-field-capture、uncreate/undelete-config：**149/149 绿**；`tsc` 0。

## 诚实边界
- 六道前置的「字段存在」由 INNER JOIN 承载，无法在不破坏 SQL 的前提下单独 neuter——其行为由 RB4 直接证明（真删字段→无 23503→skip 计数）。
- PIT resurrect 的 inbound 重放复用同一 helper（结构性防分叉），但**没有**独立的 resurrect 路径 RB 金测（需驱动完整 PIT preview/reset HTTP 流，重量级）；flag-off 下该路径惰性。对抗审如认为必补，可作 follow-up。
- flag 全程默认 off；生产启用属 O-2 operator 阶梯（owner）。

**对抗审前不挂 auto-merge**（正确性敏感车道）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
