### PR TITLE
feat(web): stock-preparation workspace shell + per-view service modules + nav

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -35,6 +35,7 @@
             <router-link v-if="canManageUsers" to="/admin/automation-executions" class="nav-link">{{ navLabels.automationRuns }}</router-link>
             <router-link v-if="canManageUsers" to="/approvals/metrics" class="nav-link">{{ navLabels.approvalMetrics }}</router-link>
             <router-link v-if="canUseIntegration" to="/integrations/workbench" class="nav-link">{{ navLabels.systemIntegration }}</router-link>
+            <router-link v-if="canUseIntegration" to="/stock-prep" class="nav-link">{{ navLabels.stockPreparation }}</router-link>
             <router-link v-if="canUseIntegration" to="/data-sources" class="nav-link">{{ navLabels.dataSources }}</router-link>
             <router-link v-if="isAdmin" to="/admin/plugins" class="nav-link">{{ navLabels.plugins }}</router-link>
             <router-link v-if="canUsePlm" to="/plm" class="nav-link">{{ navLabels.plm }}</router-link>
@@ -133,6 +134,7 @@ const navLabels = computed(() => {
       automationRuns: '自动化运行',
       approvalMetrics: '审批 SLA',
       systemIntegration: '数据工厂',
+      stockPreparation: '备料工作台',
       dataSources: '外接数据源',
       plugins: '插件',
       plm: 'PLM',
@@ -156,6 +158,7 @@ const navLabels = computed(() => {
     automationRuns: 'Automation Runs',
     approvalMetrics: 'Approval SLA',
     systemIntegration: 'Data Factory',
+    stockPreparation: 'Stock Preparation',
     dataSources: 'Data Sources',
     plugins: 'Plugins',
     plm: 'PLM',

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationWorkspace.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationWorkspace.vue
@@ -1,0 +1,245 @@
+<template>
+  <PageShell width="wide">
+    <PageHeader
+      :title="bi('备料工作台', 'Stock Preparation')"
+      :subtitle="bi(
+        '只读优先的备料 MVP:PLM 项目 / BOM 与 ERP·K3 物料只读同步,人工确认映射与单位,再生成备料行。',
+        'Readonly-first stock preparation MVP: readonly sync of PLM project/BOM and ERP/K3 material, human-confirmed mapping and units, then prep-line generation.',
+      )"
+    />
+
+    <p class="stock-prep__boundary" data-testid="stock-prep-boundary">
+      {{ bi(
+        '本工作台只读:不做 ERP/K3 写入,不触发 K3 Save / Submit / Audit,不自动创建 ERP 物料,不提供原始 SQL 入口。生成/写回仅为 multitable 内部表操作。',
+        'This workspace is readonly: no ERP/K3 write, no K3 Save / Submit / Audit, no automatic ERP material creation, no raw SQL entry point. Any generate/write is a multitable-internal table op only.',
+      ) }}
+    </p>
+
+    <!-- Tabbed container placeholder. Each tab is one of the six MVP views (design §"Frontend MVP");
+         they land later in their own DISJOINT files and get mounted here in place of the placeholder. -->
+    <nav class="stock-prep__tabs" role="tablist" data-testid="stock-prep-tabs" :aria-label="bi('备料视图', 'Stock preparation views')">
+      <button
+        v-for="view in views"
+        :key="view.key"
+        type="button"
+        role="tab"
+        class="stock-prep__tab"
+        :class="{ 'stock-prep__tab--active': view.key === activeKey }"
+        :data-testid="`stock-prep-tab-${view.key}`"
+        :aria-selected="view.key === activeKey ? 'true' : 'false'"
+        @click="activeKey = view.key"
+      >
+        {{ bi(view.zh, view.en) }}
+      </button>
+    </nav>
+
+    <section
+      v-if="activeView"
+      class="stock-prep__panel"
+      role="tabpanel"
+      data-testid="stock-prep-panel"
+      :data-active="activeKey"
+    >
+      <h2 class="stock-prep__panel-title">{{ bi(activeView.zh, activeView.en) }}</h2>
+      <p class="stock-prep__panel-desc" :data-testid="`stock-prep-desc-${activeKey}`">
+        {{ bi(activeView.zhDesc, activeView.enDesc) }}
+      </p>
+      <p class="stock-prep__panel-endpoint" data-testid="stock-prep-panel-endpoint">
+        <span class="stock-prep__badge">{{ bi('只读', 'readonly') }} · GET</span>
+        <code>{{ activeView.endpoint }}</code>
+      </p>
+      <p class="stock-prep__panel-pending" data-testid="stock-prep-panel-pending">
+        {{ bi('该视图将在后续 wave 落地,当前为容器占位。', 'This view lands in a later wave; this is a container placeholder for now.') }}
+      </p>
+    </section>
+  </PageShell>
+</template>
+
+<script setup lang="ts">
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md).
+// A routed, tabbed workspace SHELL. It is deliberately a thin container: the six MVP operator views
+// (project workspace / BOM snapshot-batch & diff / material-mapping confirm / unit-conversion confirm
+// / prep-line / exception queue) each land later in their own DISJOINT files (parallel-lane merge
+// safety) and mount into this shell in place of the placeholder panel.
+//
+// Boundary (mutation-tested gates): READONLY-FIRST — this shell has no write path, calls no service,
+// and only renders values-free copy. NAMING — the snapshot surface uses 快照批次 / "snapshot batch"
+// to avoid colliding with PLM view-state "snapshot" and k3WiseSetup "mapping" vocabularies.
+import { computed, ref } from 'vue'
+import { useLocale } from '../../../composables/useLocale'
+import PageShell from '../../layout/PageShell.vue'
+import PageHeader from '../../layout/PageHeader.vue'
+
+const { locale } = useLocale()
+
+// Same synchronous locale pattern as the rest of the integration surface (IntegrationHelpView /
+// errorCodeLabels): read `locale.value` directly in the template.
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+type StockPreparationViewKey =
+  | 'project-workspace'
+  | 'bom-snapshot-diff'
+  | 'material-mapping'
+  | 'unit-conversion'
+  | 'prep-line'
+  | 'exception-queue'
+
+interface StockPreparationViewTab {
+  key: StockPreparationViewKey
+  zh: string
+  en: string
+  zhDesc: string
+  enDesc: string
+  /** The readonly (GET) summary endpoint the future view reads. Values-free path only. */
+  endpoint: string
+}
+
+// Tab order follows the MVP business loop (design §"MVP Goal"). Descriptions are values-free — they
+// name fields/statuses, never customer drawing numbers, material codes, or quantities.
+const views: StockPreparationViewTab[] = [
+  {
+    key: 'project-workspace',
+    zh: '项目工作台',
+    en: 'Project Workspace',
+    zhDesc: '按项目查看备料概览:快照批次数、待处理异常数、就绪与暂挂的备料行数。',
+    enDesc: 'Per-project stock-preparation overview: snapshot-batch count, open exception count, ready vs held prep-line counts.',
+    endpoint: '/api/integration/stock-preparation/projects',
+  },
+  {
+    key: 'bom-snapshot-diff',
+    zh: 'BOM 快照批次与差异',
+    en: 'BOM Snapshot Batch & Diff',
+    zhDesc: '每次同步生成不可变的快照批次;旧批次保留,与前一批次按新增/删除/数量/单位/版本等差异对比。',
+    enDesc: 'Each sync creates an immutable snapshot batch; older batches are kept and diffed against the predecessor by added/removed/quantity/unit/version change.',
+    endpoint: '/api/integration/stock-preparation/snapshot-batches',
+  },
+  {
+    key: 'material-mapping',
+    zh: '物料映射确认',
+    en: 'Material Mapping Confirm',
+    zhDesc: '将 PLM 图号/版本映射到 ERP 物料编码/内部 id;歧义或未匹配的行进入人工确认,不自动创建 ERP 物料。',
+    enDesc: 'Map PLM drawing/version to ERP material code/internal id; ambiguous or unmatched rows go to manual confirmation, never auto-create ERP material.',
+    endpoint: '/api/integration/stock-preparation/material-mappings/summary',
+  },
+  {
+    key: 'unit-conversion',
+    zh: '单位换算确认',
+    en: 'Unit Conversion Confirm',
+    zhDesc: '将设计单位换算为 ERP 领用单位;无唯一有效规则时进入异常队列,不做静默猜测。',
+    enDesc: 'Convert the design unit to the ERP issue unit; with no unique active rule the line enters the exception queue rather than a silent guess.',
+    endpoint: '/api/integration/stock-preparation/unit-conversions/summary',
+  },
+  {
+    key: 'prep-line',
+    zh: '备料行',
+    en: 'Prep Lines',
+    zhDesc: '仅由已确认的快照、映射与单位规则生成备料行;未解决的映射/单位冲突不会产出就绪行。',
+    enDesc: 'Prep lines generated only from confirmed snapshots, mappings, and unit rules; unresolved mapping/unit conflicts never produce ready lines.',
+    endpoint: '/api/integration/stock-preparation/prep-lines/summary',
+  },
+  {
+    key: 'exception-queue',
+    zh: '异常队列',
+    en: 'Exception Queue',
+    zhDesc: '所有不确定的行都可见、可处理;阻断级异常保持可见并阻止最终确认。',
+    enDesc: 'Every uncertain row is visible and actionable; blocking exceptions stay visible and prevent final confirmation.',
+    endpoint: '/api/integration/stock-preparation/exceptions/summary',
+  },
+]
+
+const activeKey = ref<StockPreparationViewKey>(views[0].key)
+const activeView = computed(() => views.find((view) => view.key === activeKey.value) ?? null)
+</script>
+
+<style scoped>
+.stock-prep__boundary {
+  margin: 0 0 var(--ms-space-4);
+  padding: var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-page);
+  color: var(--ms-text-2);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.stock-prep__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ms-space-2);
+  border-bottom: 1px solid var(--ms-border-light);
+  margin-bottom: var(--ms-space-4);
+}
+
+.stock-prep__tab {
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  padding: var(--ms-space-2) var(--ms-space-3);
+  color: var(--ms-text-2);
+  font: inherit;
+  font-weight: var(--ms-font-weight-title);
+  cursor: pointer;
+}
+
+.stock-prep__tab:hover {
+  color: var(--ms-text-1);
+}
+
+.stock-prep__tab--active {
+  color: var(--ms-color-primary);
+  border-bottom-color: var(--ms-color-primary);
+}
+
+.stock-prep__panel {
+  padding: var(--ms-space-4);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-card);
+}
+
+.stock-prep__panel-title {
+  margin: 0 0 var(--ms-space-2);
+  font-size: var(--ms-font-size-section-title);
+  color: var(--ms-text-1);
+}
+
+.stock-prep__panel-desc {
+  margin: 0 0 var(--ms-space-3);
+  color: var(--ms-text-2);
+  line-height: 1.6;
+}
+
+.stock-prep__panel-endpoint {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--ms-space-2);
+  margin: 0 0 var(--ms-space-3);
+  font-size: 12px;
+  color: var(--ms-text-3);
+}
+
+.stock-prep__panel-endpoint code {
+  font-size: 12px;
+  color: var(--ms-text-2);
+}
+
+.stock-prep__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.stock-prep__panel-pending {
+  margin: 0;
+  color: var(--ms-text-3);
+  font-size: 13px;
+}
+</style>

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -247,6 +247,16 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'K3 WISE Preset', titleZh: 'K3 WISE 预设', requiresAuth: true, permissions: ['integration:write'] }
   },
   {
+    // Stock Preparation MVP (#3751, docs/development/stock-preparation-mvp-design-20260707.md):
+    // readonly-first, tabbed operator workspace. Deliberately a SEPARATE routed shell (not crammed
+    // into the admin IntegrationWorkbenchView) so the six MVP views land later in disjoint files.
+    // Reuses the integration:write gate (same as the Data Factory workbench) — no broader access.
+    path: '/stock-prep',
+    name: AppRouteNames.INTEGRATION_STOCK_PREPARATION,
+    component: () => import('../components/integration/stockPreparation/StockPreparationWorkspace.vue'),
+    meta: { title: 'Stock Preparation', titleZh: '备料工作台', requiresAuth: true, permissions: ['integration:write'] }
+  },
+  {
     path: '/workflows',
     name: 'workflow-list',
     component: () => import('../views/WorkflowHubView.vue'),

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -98,6 +98,7 @@ export const AppRouteNames = {
   ADMIN_LOGS: 'admin-logs',
   INTEGRATION_WORKBENCH: 'integration-workbench',
   INTEGRATION_K3_WISE: 'integration-k3-wise',
+  INTEGRATION_STOCK_PREPARATION: 'integration-stock-preparation',
 
   // Error routes
   NOT_FOUND: 'not-found',
@@ -172,6 +173,7 @@ export interface AppRouteParams {
   'admin-logs': Record<string, never>
   'integration-workbench': Record<string, never>
   'integration-k3-wise': Record<string, never>
+  'integration-stock-preparation': Record<string, never>
   'not-found': Record<string, never>
   'forbidden': Record<string, never>
   'server-error': Record<string, never>

--- a/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
+++ b/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
@@ -1,0 +1,84 @@
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md)
+// per-view service stub: BOM SNAPSHOT BATCH & DIFF (design §"Frontend MVP" view 2).
+//
+// NAMING: this surface uses 快照批次 / "snapshot batch" (`snapshotBatchId`) deliberately, to avoid
+// colliding with the PLM view-state "snapshot" vocabulary and the k3WiseSetup "mapping" vocabulary.
+//
+// READONLY-FIRST: GET-only, values-free. No overwrite of prior snapshots (design: "Keep old
+// snapshots immutable"). No external write, no apply/generate — snapshot/diff read only.
+//
+// VALUES-FREE contract: only change COUNTS by category, status enums, booleans, and internal
+// MetaSheet handles (snapshotBatchId / syncRunId / projectId). No PLM parent/child drawing numbers,
+// versions, quantities, path keys, fingerprints, or raw source rows.
+import { apiFetch } from '../../../utils/api'
+import { buildQueryString, parseIntegrationResponse, type IntegrationScope } from '../workbench'
+
+export type StockPreparationSnapshotBatchStatus = 'draft' | 'active' | 'superseded' | 'rejected'
+
+export interface StockPreparationSnapshotBatchSummary {
+  snapshotBatchId: string
+  snapshotVersion: number
+  snapshotStatus: StockPreparationSnapshotBatchStatus | string
+  syncRunId: string | null
+  lineCount: number
+  createdAtPresent: boolean
+}
+
+export interface StockPreparationSnapshotBatchListResult {
+  projectId: string
+  batchCount: number
+  batches: StockPreparationSnapshotBatchSummary[]
+}
+
+/** Values-free per-change-kind counts between a batch and its immutable predecessor. */
+export interface StockPreparationSnapshotDiffSummary {
+  snapshotBatchId: string
+  baseSnapshotBatchId: string | null
+  changeCounts: {
+    added: number
+    removed: number
+    quantityChanged: number
+    unitChanged: number
+    versionChanged: number
+    pathChanged: number
+    missingChildBom: number
+    fingerprintChanged: number
+  }
+  blockingExceptionCount: number
+}
+
+/**
+ * List the immutable BOM snapshot batches for a project (newest batch does not overwrite older ones).
+ * GET /api/integration/stock-preparation/snapshot-batches
+ */
+export async function listStockPreparationSnapshotBatches(
+  scope: IntegrationScope & { projectId?: string | null } = {},
+): Promise<StockPreparationSnapshotBatchListResult> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/snapshot-batches${query ? `?${query}` : ''}`,
+  )
+  return parseIntegrationResponse<StockPreparationSnapshotBatchListResult>(response)
+}
+
+/**
+ * Values-free diff of a snapshot batch against its immutable predecessor batch.
+ * GET /api/integration/stock-preparation/snapshot-batches/:snapshotBatchId/diff
+ */
+export async function getStockPreparationSnapshotDiff(
+  snapshotBatchId: string,
+  scope: IntegrationScope = {},
+): Promise<StockPreparationSnapshotDiffSummary> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/snapshot-batches/${encodeURIComponent(snapshotBatchId)}/diff${query ? `?${query}` : ''}`,
+  )
+  return parseIntegrationResponse<StockPreparationSnapshotDiffSummary>(response)
+}

--- a/apps/web/src/services/integration/stockPreparation/exceptionQueue.ts
+++ b/apps/web/src/services/integration/stockPreparation/exceptionQueue.ts
@@ -1,0 +1,53 @@
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md)
+// per-view service stub: EXCEPTION QUEUE (design §"Frontend MVP" view 6).
+//
+// Every uncertain row is visible and actionable instead of being dropped. Blocking exceptions stay
+// visible and prevent final confirmation while mapping/unit status is unresolved.
+//
+// READONLY-FIRST: GET-only summary. Resolving an exception (later wave) is a MULTITABLE-INTERNAL row
+// write behind its own gate; no external ERP/K3 write, no auto-retry of write-like actions, not in
+// this stub.
+//
+// VALUES-FREE contract: counts by exception_type / severity / status only. No exception messages,
+// drawing numbers, material codes, quantities, or raw rows.
+import { apiFetch } from '../../../utils/api'
+import { buildQueryString, parseIntegrationResponse, type IntegrationScope } from '../workbench'
+
+export type StockPreparationExceptionType =
+  | 'missing_mapping'
+  | 'multi_candidate'
+  | 'unit_missing'
+  | 'unit_conflict'
+  | 'bom_changed'
+  | 'missing_child_bom'
+  | 'invalid_qty'
+
+export type StockPreparationExceptionSeverity = 'info' | 'warning' | 'blocking'
+
+export type StockPreparationExceptionStatus = 'open' | 'resolved' | 'ignored' | 'deferred'
+
+export interface StockPreparationExceptionQueueSummary {
+  totalExceptionCount: number
+  openBlockingCount: number
+  typeCounts: Record<StockPreparationExceptionType | string, number>
+  severityCounts: Record<StockPreparationExceptionSeverity | string, number>
+  statusCounts: Record<StockPreparationExceptionStatus | string, number>
+}
+
+/**
+ * Values-free summary of the exception-confirmation queue for a project.
+ * GET /api/integration/stock-preparation/exceptions/summary
+ */
+export async function getStockPreparationExceptionQueueSummary(
+  scope: IntegrationScope & { projectId?: string | null } = {},
+): Promise<StockPreparationExceptionQueueSummary> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/exceptions/summary${query ? `?${query}` : ''}`,
+  )
+  return parseIntegrationResponse<StockPreparationExceptionQueueSummary>(response)
+}

--- a/apps/web/src/services/integration/stockPreparation/materialMapping.ts
+++ b/apps/web/src/services/integration/stockPreparation/materialMapping.ts
@@ -1,0 +1,54 @@
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md)
+// per-view service stub: MATERIAL MAPPING CONFIRMATION (design §"Frontend MVP" view 3).
+//
+// Maps PLM drawing/version -> ERP material code/internal id. The MVP NEVER auto-creates ERP material
+// codes and NEVER generates final lines from ambiguous candidates — unresolved rows stay pending for
+// human confirmation.
+//
+// READONLY-FIRST: GET-only summary. No external ERP/K3 write, no auto material create. When a
+// confirm action lands in a later wave it is a MULTITABLE-INTERNAL row write behind its own gate,
+// never an external write, and never in this stub.
+//
+// VALUES-FREE contract: counts by match_status / version_policy / match_method only. No PLM drawing
+// numbers, versions, material names, specs, ERP material codes, or internal ids as VALUES.
+import { apiFetch } from '../../../utils/api'
+import { buildQueryString, parseIntegrationResponse, type IntegrationScope } from '../workbench'
+
+export type StockPreparationMatchStatus =
+  | 'matched'
+  | 'pending_confirm'
+  | 'multi_candidate'
+  | 'not_found'
+  | 'version_conflict'
+
+export type StockPreparationVersionPolicy =
+  | 'drawing_and_version'
+  | 'drawing_only'
+  | 'category_rule'
+  | 'manual'
+
+export interface StockPreparationMaterialMappingSummary {
+  totalMappingCount: number
+  activeMappingCount: number
+  matchStatusCounts: Record<StockPreparationMatchStatus | string, number>
+  versionPolicyCounts: Record<StockPreparationVersionPolicy | string, number>
+  pendingConfirmCount: number
+}
+
+/**
+ * Values-free summary of the material-mapping table's confirmation state.
+ * GET /api/integration/stock-preparation/material-mappings/summary
+ */
+export async function getStockPreparationMaterialMappingSummary(
+  scope: IntegrationScope & { projectId?: string | null } = {},
+): Promise<StockPreparationMaterialMappingSummary> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/material-mappings/summary${query ? `?${query}` : ''}`,
+  )
+  return parseIntegrationResponse<StockPreparationMaterialMappingSummary>(response)
+}

--- a/apps/web/src/services/integration/stockPreparation/prepLine.ts
+++ b/apps/web/src/services/integration/stockPreparation/prepLine.ts
@@ -1,0 +1,46 @@
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md)
+// per-view service stub: STOCK PREPARATION LINE (design §"Frontend MVP" view 5).
+//
+// Preparation lines are generated ONLY from confirmed BOM snapshots, confirmed mappings, and
+// confirmed unit rules. Generation never produces final `ready` lines for unresolved mappings, unit
+// conflicts, missing child BOM, or invalid quantities — those stay `held`/exception.
+//
+// READONLY-FIRST: GET-only summary. "Generation" (when it lands in a later wave) is a
+// MULTITABLE-INTERNAL table op behind its own gate — it never writes to ERP/K3 and is not in this
+// stub. No K3 Save/Submit/Audit, no production write.
+//
+// VALUES-FREE contract: counts by prep_status / unit_status / mapping_status only. No drawing
+// numbers, ERP material codes, design/issue quantities, factors, or raw line rows.
+import { apiFetch } from '../../../utils/api'
+import { buildQueryString, parseIntegrationResponse, type IntegrationScope } from '../workbench'
+
+export type StockPreparationPrepStatus = 'draft' | 'ready' | 'held' | 'confirmed' | 'cancelled'
+
+export type StockPreparationUnitStatus = 'converted' | 'pending_confirm' | 'missing_rule' | 'conflict'
+
+export interface StockPreparationLineSummary {
+  totalLineCount: number
+  prepStatusCounts: Record<StockPreparationPrepStatus | string, number>
+  unitStatusCounts: Record<StockPreparationUnitStatus | string, number>
+  mappingStatusCounts: Record<string, number>
+  exceptionLinkedLineCount: number
+}
+
+/**
+ * Values-free summary of the stock-preparation-line table for a project/snapshot batch.
+ * GET /api/integration/stock-preparation/prep-lines/summary
+ */
+export async function getStockPreparationLineSummary(
+  scope: IntegrationScope & { projectId?: string | null; snapshotBatchId?: string | null } = {},
+): Promise<StockPreparationLineSummary> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+    snapshotBatchId: scope.snapshotBatchId,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/prep-lines/summary${query ? `?${query}` : ''}`,
+  )
+  return parseIntegrationResponse<StockPreparationLineSummary>(response)
+}

--- a/apps/web/src/services/integration/stockPreparation/projectWorkspace.ts
+++ b/apps/web/src/services/integration/stockPreparation/projectWorkspace.ts
@@ -1,0 +1,54 @@
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md)
+// per-view service stub: PROJECT WORKSPACE (design §"Frontend MVP" view 1).
+//
+// READONLY-FIRST: every function here issues a GET against a values-free summary endpoint.
+// There is NO write path in this module — no external ERP/K3 write, no K3 Save/Submit/Audit, no
+// apply/generate. Business-row writes (when they land in a later wave) are MULTITABLE-INTERNAL table
+// ops behind their own owner-gated ladder and never live in this stub.
+//
+// VALUES-FREE contract: the shapes below carry ONLY counts / status enums / booleans and internal
+// MetaSheet navigation handles (projectId / runId). They deliberately EXCLUDE customer business
+// values — no source_project_no, project_name, owner, PLM drawing numbers, ERP material codes,
+// quantities, host / tenant / connection strings, credentials, or raw PLM/K3/ERP rows.
+//
+// The backend routes may 404 until later stock-preparation waves land; these are type-safe stubs
+// that reuse the exact landed integration transport (apiFetch + parseIntegrationResponse +
+// buildQueryString from services/integration/workbench).
+import { apiFetch } from '../../../utils/api'
+import { buildQueryString, parseIntegrationResponse, type IntegrationScope } from '../workbench'
+
+export type StockPreparationProjectStatus = 'active' | 'paused' | 'closed' | 'archived'
+
+/** Values-free per-project summary. `projectId` is an internal MetaSheet handle used for routing. */
+export interface StockPreparationProjectSummary {
+  projectId: string
+  projectStatus: StockPreparationProjectStatus | string
+  lastSyncRunId: string | null
+  snapshotBatchCount: number
+  openExceptionCount: number
+  readyLineCount: number
+  heldLineCount: number
+}
+
+export interface StockPreparationWorkspaceOverview {
+  projectCount: number
+  statusCounts: Record<string, number>
+  projects: StockPreparationProjectSummary[]
+}
+
+/**
+ * List the projects that can produce stock-preparation lines, as a values-free summary.
+ * GET /api/integration/stock-preparation/projects
+ */
+export async function getStockPreparationWorkspaceOverview(
+  scope: IntegrationScope = {},
+): Promise<StockPreparationWorkspaceOverview> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/projects${query ? `?${query}` : ''}`,
+  )
+  return parseIntegrationResponse<StockPreparationWorkspaceOverview>(response)
+}

--- a/apps/web/src/services/integration/stockPreparation/unitConversion.ts
+++ b/apps/web/src/services/integration/stockPreparation/unitConversion.ts
@@ -1,0 +1,44 @@
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md)
+// per-view service stub: UNIT CONVERSION CONFIRMATION (design §"Frontend MVP" view 4).
+//
+// Converts a PLM design unit into an ERP production-issue unit via a confirmed rule. If no unique
+// active rule exists the line enters the exception queue (never a silent guess).
+//
+// READONLY-FIRST: GET-only summary. No external write. A later "confirm rule" action is a
+// MULTITABLE-INTERNAL row write behind its own gate, not part of this stub.
+//
+// VALUES-FREE contract: counts by scope_type / rounding_rule and pending counts only. No unit
+// symbols-as-data rows, conversion factors, loss rates, minimum quantities, or raw rule rows.
+import { apiFetch } from '../../../utils/api'
+import { buildQueryString, parseIntegrationResponse, type IntegrationScope } from '../workbench'
+
+export type StockPreparationUnitScopeType = 'material' | 'category' | 'generic'
+
+export type StockPreparationRoundingRule = 'none' | 'ceil' | 'floor' | 'nearest' | 'pack_size'
+
+export interface StockPreparationUnitConversionSummary {
+  totalRuleCount: number
+  activeRuleCount: number
+  requiresConfirmationCount: number
+  scopeTypeCounts: Record<StockPreparationUnitScopeType | string, number>
+  roundingRuleCounts: Record<StockPreparationRoundingRule | string, number>
+  pendingUnitLineCount: number
+}
+
+/**
+ * Values-free summary of the unit-conversion-rule table's confirmation state.
+ * GET /api/integration/stock-preparation/unit-conversions/summary
+ */
+export async function getStockPreparationUnitConversionSummary(
+  scope: IntegrationScope & { projectId?: string | null } = {},
+): Promise<StockPreparationUnitConversionSummary> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/unit-conversions/summary${query ? `?${query}` : ''}`,
+  )
+  return parseIntegrationResponse<StockPreparationUnitConversionSummary>(response)
+}

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -644,7 +644,7 @@ export function summarizeFieldProvenance(
   return { entries, stats }
 }
 
-async function parseIntegrationResponse<T>(response: Response): Promise<T> {
+export async function parseIntegrationResponse<T>(response: Response): Promise<T> {
   let payload: IntegrationApiEnvelope<T> | null = null
   try {
     payload = await response.json() as IntegrationApiEnvelope<T>
@@ -733,7 +733,7 @@ function normalizePlmBomMultitableResult(
   return { data_source_id: resolvedId, available: true, entitled, context, ...(reason ? { reason } : {}) }
 }
 
-function buildQueryString(input: Record<string, unknown>): string {
+export function buildQueryString(input: Record<string, unknown>): string {
   const params = new URLSearchParams()
   for (const [key, value] of Object.entries(input)) {
     if (value === undefined || value === null || value === '') continue

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -1,0 +1,361 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h as vh, nextTick, ref, type App as VueApp, type Component } from 'vue'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md).
+// Covers ONLY the new sp-fe-shell surface: the routed tabbed workspace shell, its route
+// registration, the permission-gated App nav entry, and the six readonly per-view service stubs.
+// (Unrelated apps/web specs are red on main from api mocks — this spec asserts only its own surface.)
+
+// Shared mutable holder — vi.hoisted so the mock factories below can read it, and the test body can
+// flip locale / permission BEFORE each mount (useLocale/useAuth are invoked fresh per mount).
+const h = vi.hoisted(() => ({
+  locale: 'zh-CN' as string,
+  hasPerm: true,
+  route: { path: '/multitable', fullPath: '/multitable', meta: {} as Record<string, unknown> },
+  apiFetch: vi.fn(),
+  loadProductFeatures: vi.fn().mockResolvedValue(undefined),
+  fetchPlugins: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRoute: () => h.route,
+    useRouter: () => ({ push: vi.fn() }),
+  }
+})
+
+vi.mock('../src/composables/useLocale', () => ({
+  useLocale: () => ({
+    locale: ref(h.locale),
+    isZh: ref(h.locale === 'zh-CN'),
+    setLocale: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/composables/usePlugins', () => ({
+  usePlugins: () => ({ navItems: ref([]), fetchPlugins: h.fetchPlugins }),
+}))
+
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({
+    loadProductFeatures: h.loadProductFeatures,
+    isAttendanceFocused: () => false,
+    isPlmWorkbenchFocused: () => false,
+    hasFeature: () => false,
+  }),
+}))
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getToken: () => 'session-token',
+    clearToken: vi.fn(),
+    getAccessSnapshot: () => ({ isAdmin: false, email: '' }),
+    hasPermission: (permission: string) => permission === 'integration:write' && h.hasPerm,
+  }),
+}))
+
+vi.mock('../src/utils/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/utils/api')>('../src/utils/api')
+  return {
+    ...actual,
+    apiFetch: h.apiFetch,
+    clearStoredAuthState: vi.fn(),
+    getApiBase: () => 'https://api.example.com',
+  }
+})
+
+import App from '../src/App.vue'
+import StockPreparationWorkspace from '../src/components/integration/stockPreparation/StockPreparationWorkspace.vue'
+import { getStockPreparationWorkspaceOverview } from '../src/services/integration/stockPreparation/projectWorkspace'
+import {
+  getStockPreparationSnapshotDiff,
+  listStockPreparationSnapshotBatches,
+} from '../src/services/integration/stockPreparation/bomSnapshotDiff'
+import { getStockPreparationMaterialMappingSummary } from '../src/services/integration/stockPreparation/materialMapping'
+import { getStockPreparationUnitConversionSummary } from '../src/services/integration/stockPreparation/unitConversion'
+import { getStockPreparationLineSummary } from '../src/services/integration/stockPreparation/prepLine'
+import { getStockPreparationExceptionQueueSummary } from '../src/services/integration/stockPreparation/exceptionQueue'
+
+// Values-free forbidden-substring guard: rendered shell copy must never surface any of these.
+const FORBIDDEN_SUBSTRINGS = [
+  'password',
+  'token',
+  'authorityCode',
+  'connection-string',
+  'connectionString',
+  'secret',
+]
+
+async function flushUi(cycles = 3): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+const VIEW_KEYS = [
+  'project-workspace',
+  'bom-snapshot-diff',
+  'material-mapping',
+  'unit-conversion',
+  'prep-line',
+  'exception-queue',
+] as const
+
+// Source-level drift pin (matching the repo idiom in approvalTemplateRouteGuard.spec.ts): importing
+// appRoutes eagerly pulls every view + element-plus CSS into jsdom, so assert on the source text.
+describe('Stock Preparation route registration (source drift pin)', () => {
+  const SRC = readFileSync(join(__dirname, '../src/router/appRoutes.ts'), 'utf8')
+
+  function routeBlockByPath(path: string): string | null {
+    const i = SRC.indexOf(`path: '${path}'`)
+    if (i === -1) return null
+    const end = SRC.indexOf('\n  },', i)
+    return end === -1 ? SRC.slice(i) : SRC.slice(i, end)
+  }
+
+  it('registers /stock-prep bound to a lazy shell component and the integration:write gate', () => {
+    const block = routeBlockByPath('/stock-prep')
+    expect(block, 'route /stock-prep must exist in appRoutes.ts').toBeTruthy()
+    expect(block).toContain('AppRouteNames.INTEGRATION_STOCK_PREPARATION')
+    expect(block).toContain("import('../components/integration/stockPreparation/StockPreparationWorkspace.vue')")
+    expect(block).toMatch(/requiresAuth:\s*true/)
+    expect(block).toMatch(/permissions:\s*\[\s*'integration:write'\s*\]/)
+    expect(block).toContain("titleZh: '备料工作台'")
+  })
+
+  it('binds the route name constant to the string the router uses', () => {
+    const TYPES = readFileSync(join(__dirname, '../src/router/types.ts'), 'utf8')
+    expect(TYPES).toContain("INTEGRATION_STOCK_PREPARATION: 'integration-stock-preparation'")
+  })
+})
+
+describe('StockPreparationWorkspace shell', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    h.locale = 'zh-CN'
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountShell(): Promise<HTMLDivElement> {
+    app = createApp(StockPreparationWorkspace as Component)
+    app.mount(container!)
+    await flushUi()
+    return container!
+  }
+
+  it('renders the tablist with all six MVP view tabs', async () => {
+    const root = await mountShell()
+    const tablist = root.querySelector('[data-testid="stock-prep-tabs"]')
+    expect(tablist).not.toBeNull()
+    expect(tablist!.getAttribute('role')).toBe('tablist')
+    for (const key of VIEW_KEYS) {
+      expect(root.querySelector(`[data-testid="stock-prep-tab-${key}"]`)).not.toBeNull()
+    }
+    expect(root.querySelectorAll('[data-testid^="stock-prep-tab-"]').length).toBe(6)
+  })
+
+  it('renders Chinese labels + the readonly-boundary copy when locale is zh-CN', async () => {
+    h.locale = 'zh-CN'
+    const root = await mountShell()
+    const tabs = root.querySelector('[data-testid="stock-prep-tabs"]') as HTMLElement
+    expect(tabs.textContent).toContain('项目工作台')
+    // NAMING: snapshot uses 快照批次 / batch vocabulary (collision-avoidance requirement).
+    expect(tabs.textContent).toContain('BOM 快照批次与差异')
+    expect(tabs.textContent).toContain('异常队列')
+    const boundary = root.querySelector('[data-testid="stock-prep-boundary"]') as HTMLElement
+    expect(boundary.textContent).toContain('只读')
+    expect(boundary.textContent).toMatch(/K3 Save/)
+  })
+
+  it('renders English labels when locale is not zh-CN', async () => {
+    h.locale = 'en'
+    const root = await mountShell()
+    const tabs = root.querySelector('[data-testid="stock-prep-tabs"]') as HTMLElement
+    expect(tabs.textContent).toContain('Project Workspace')
+    expect(tabs.textContent).toContain('BOM Snapshot Batch & Diff')
+    expect(tabs.textContent).toContain('Exception Queue')
+    const boundary = root.querySelector('[data-testid="stock-prep-boundary"]') as HTMLElement
+    expect(boundary.textContent).toMatch(/readonly/i)
+  })
+
+  it('shows the active view panel as a readonly GET placeholder and switches on tab click', async () => {
+    const root = await mountShell()
+    const panel = root.querySelector('[data-testid="stock-prep-panel"]') as HTMLElement
+    expect(panel.getAttribute('data-active')).toBe('project-workspace')
+    const endpoint = root.querySelector('[data-testid="stock-prep-panel-endpoint"]') as HTMLElement
+    expect(endpoint.textContent).toMatch(/GET/)
+    expect(endpoint.textContent).toContain('/api/integration/stock-preparation/projects')
+
+    const exceptionTab = root.querySelector('[data-testid="stock-prep-tab-exception-queue"]') as HTMLButtonElement
+    exceptionTab.click()
+    await flushUi()
+    const panelAfter = root.querySelector('[data-testid="stock-prep-panel"]') as HTMLElement
+    expect(panelAfter.getAttribute('data-active')).toBe('exception-queue')
+    expect(panelAfter.querySelector('[data-testid="stock-prep-desc-exception-queue"]')).not.toBeNull()
+  })
+
+  it('shell copy is values-free (no secrets, no long numeric runs) in both locales', async () => {
+    for (const locale of ['zh-CN', 'en']) {
+      h.locale = locale
+      const root = await mountShell()
+      const text = (root.textContent || '').toLowerCase()
+      for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+        expect(text).not.toContain(forbidden.toLowerCase())
+      }
+      // No digit-run >= 5 (no real project/material/BOM identifiers in placeholder copy).
+      expect(root.textContent || '').not.toMatch(/\d{5,}/)
+      if (app) app.unmount()
+      app = null
+    }
+  })
+})
+
+describe('App nav entry for Stock Preparation', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  function mountApp(): void {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(App as Component)
+    app.component('router-view', { render: () => null })
+    // Anchor stub so each nav link's href + label text are queryable.
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        return vh('a', { href: this.$props.to }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+    app.mount(container)
+  }
+
+  beforeEach(() => {
+    h.locale = 'zh-CN'
+    h.hasPerm = true
+    h.route = { path: '/multitable', fullPath: '/multitable', meta: {} }
+    window.localStorage.clear()
+    window.localStorage.setItem('auth_token', 'session-token')
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  function findStockPrepLink(root: HTMLElement): HTMLAnchorElement | undefined {
+    return Array.from(root.querySelectorAll('a')).find((a) => a.getAttribute('href') === '/stock-prep')
+  }
+
+  it('renders a /stock-prep nav link with the zh label when the user has integration:write', async () => {
+    mountApp()
+    await flushUi()
+    const link = findStockPrepLink(container as HTMLElement)
+    expect(link).toBeTruthy()
+    expect(link!.textContent).toContain('备料工作台')
+  })
+
+  it('renders the English nav label when locale is not zh-CN', async () => {
+    h.locale = 'en'
+    mountApp()
+    await flushUi()
+    const link = findStockPrepLink(container as HTMLElement)
+    expect(link).toBeTruthy()
+    expect(link!.textContent).toContain('Stock Preparation')
+  })
+
+  it('hides the /stock-prep nav link when the user lacks integration:write', async () => {
+    h.hasPerm = false
+    mountApp()
+    await flushUi()
+    expect(findStockPrepLink(container as HTMLElement)).toBeUndefined()
+  })
+})
+
+describe('Stock Preparation per-view service stubs (readonly GET, values-free)', () => {
+  beforeEach(() => {
+    h.apiFetch.mockReset()
+    h.apiFetch.mockResolvedValue(new Response(JSON.stringify({ ok: true, data: {} }), { status: 200 }))
+  })
+
+  function lastCall(): [string, unknown?] {
+    const calls = h.apiFetch.mock.calls
+    return calls[calls.length - 1] as [string, unknown?]
+  }
+
+  it('projectWorkspace GETs the projects summary with no write options', async () => {
+    await getStockPreparationWorkspaceOverview({ tenantId: 't1' })
+    const [url, options] = lastCall()
+    expect(url).toContain('/api/integration/stock-preparation/projects')
+    expect(url).toContain('tenantId=t1')
+    expect(options).toBeUndefined() // no method/body → readonly GET
+  })
+
+  it('bomSnapshotDiff lists snapshot batches and diffs by batch id (readonly)', async () => {
+    await listStockPreparationSnapshotBatches({ projectId: 'p1' })
+    expect(lastCall()[0]).toContain('/api/integration/stock-preparation/snapshot-batches')
+    expect(lastCall()[0]).toContain('projectId=p1')
+    expect(lastCall()[1]).toBeUndefined()
+
+    await getStockPreparationSnapshotDiff('batch-1')
+    expect(lastCall()[0]).toContain('/api/integration/stock-preparation/snapshot-batches/batch-1/diff')
+    expect(lastCall()[1]).toBeUndefined()
+  })
+
+  it('materialMapping GETs the mapping summary (readonly)', async () => {
+    await getStockPreparationMaterialMappingSummary()
+    expect(lastCall()[0]).toContain('/api/integration/stock-preparation/material-mappings/summary')
+    expect(lastCall()[1]).toBeUndefined()
+  })
+
+  it('unitConversion GETs the unit-conversion summary (readonly)', async () => {
+    await getStockPreparationUnitConversionSummary()
+    expect(lastCall()[0]).toContain('/api/integration/stock-preparation/unit-conversions/summary')
+    expect(lastCall()[1]).toBeUndefined()
+  })
+
+  it('prepLine GETs the prep-line summary (readonly)', async () => {
+    await getStockPreparationLineSummary()
+    expect(lastCall()[0]).toContain('/api/integration/stock-preparation/prep-lines/summary')
+    expect(lastCall()[1]).toBeUndefined()
+  })
+
+  it('exceptionQueue GETs the exception summary (readonly)', async () => {
+    await getStockPreparationExceptionQueueSummary()
+    expect(lastCall()[0]).toContain('/api/integration/stock-preparation/exceptions/summary')
+    expect(lastCall()[1]).toBeUndefined()
+  })
+
+  it('NONE of the readonly stubs ever issues a write method (no POST/PUT/PATCH/DELETE)', async () => {
+    await Promise.all([
+      getStockPreparationWorkspaceOverview(),
+      listStockPreparationSnapshotBatches(),
+      getStockPreparationMaterialMappingSummary(),
+      getStockPreparationUnitConversionSummary(),
+      getStockPreparationLineSummary(),
+      getStockPreparationExceptionQueueSummary(),
+    ])
+    for (const call of h.apiFetch.mock.calls) {
+      const options = call[1] as { method?: string } | undefined
+      expect(options?.method).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
## What

Ships the **sp-fe-shell** for the stock-preparation MVP (#3751) frontend: a routed, tabbed workspace shell plus a per-view service directory, so the six later operator views each land in **disjoint files** (parallel-lane merge safety) instead of being crammed into the 6195-line admin `IntegrationWorkbenchView`.

Design: `docs/development/stock-preparation-mvp-design-20260707.md`.

## Surface

- **`StockPreparationWorkspace.vue`** — readonly, tabbed shell (`PageShell`/`PageHeader` + the integration surface's `bi()` zh/en locale pattern). Six placeholder tabs, one per MVP view: project workspace, BOM snapshot-batch & diff, material-mapping confirm, unit-conversion confirm, prep-line, exception queue. Each tab shows its readonly (GET) summary endpoint. The panel is a container placeholder; the real six views mount here in later waves.
- **`services/integration/stockPreparation/`** — six per-view service-module stubs (`projectWorkspace`, `bomSnapshotDiff`, `materialMapping`, `unitConversion`, `prepLine`, `exceptionQueue`). Each is a type-safe **readonly GET** to a values-free `/api/integration/stock-preparation/*` summary endpoint (may 404 until backend waves land — type-safe stubs). Reuses the landed integration transport: `apiFetch` + `parseIntegrationResponse` + `buildQueryString` (now exported) + `IntegrationScope`.
- **Route** `/stock-prep` (`integration:write` gate — same as the Data Factory workbench, no broader access) + **App nav entry** gated on `canUseIntegration`, with zh/en labels (`备料工作台` / `Stock Preparation`).

## Naming

Snapshot uses **快照批次 / "snapshot batch"** (`snapshotBatchId`) deliberately, to avoid colliding with the PLM view-state `snapshot` vocabulary and the k3WiseSetup `mapping` vocabulary. All new symbols are `StockPreparation*`-prefixed.

## Safety (mutation-tested gates)

- **Readonly-first (#3751):** no write path anywhere — no ERP/K3 write, no K3 Save/Submit/Audit, no auto ERP material create, no `stock-preparation-apply-writer` lane, no `stockPrepApplyProduction`, no raw SQL entry point. The spec asserts none of the six stubs ever issues a write method.
- **Values-free:** service shapes and shell copy carry counts / status enums / booleans / field-key names / internal navigation handles only — never passwords/tokens/authorityCode/connection-string/host/tenant/raw PLM·K3·ERP rows. The spec pins this in both locales (forbidden-substring + no digit-run ≥ 5).

## Tests

`apps/web/tests/StockPreparationWorkspace.spec.ts` — 17 tests: route + name-constant source-drift pin (importing `appRoutes` eagerly pulls element-plus CSS into jsdom, per the repo idiom), shell tab-nav + zh/en labels + values-free copy, permission-gated App nav link (present with `integration:write`, hidden without), and readonly-GET assertions across all six stubs.

- `vitest run tests/StockPreparationWorkspace.spec.ts` → 17/17 pass
- `vue-tsc -b` → clean
- Adjacent specs (`App`, `IntegrationHelpView`, `approvalTemplateRouteGuard`, `adminAccess`) → 19/19 pass, no regressions

Does NOT unlock any external-write lane; any future "generate/write" is multitable-internal table ops behind its own owner-gated ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)