### PR TITLE
feat(auth): show password requirements on setup pages

### DIFF
--- a/apps/web/src/utils/passwordRequirements.ts
+++ b/apps/web/src/utils/passwordRequirements.ts
@@ -1,0 +1,32 @@
+export type PasswordRequirementLocale = 'zh' | 'en'
+
+export type PasswordRequirementCopy = {
+  title: string
+  items: string[]
+}
+
+const PASSWORD_REQUIREMENTS_ZH: PasswordRequirementCopy = {
+  title: '密码要求',
+  items: [
+    '8-128 位字符',
+    '至少包含 1 个小写字母',
+    '至少包含 1 个大写字母',
+    '至少包含 1 个数字',
+    '不要包含 password、123456、qwerty、abc123、letmein、admin 等常见弱口令片段',
+  ],
+}
+
+const PASSWORD_REQUIREMENTS_EN: PasswordRequirementCopy = {
+  title: 'Password requirements',
+  items: [
+    '8-128 characters',
+    'At least 1 lowercase letter',
+    'At least 1 uppercase letter',
+    'At least 1 number',
+    'Do not include common weak patterns such as password, 123456, qwerty, abc123, letmein, or admin',
+  ],
+}
+
+export function getPasswordRequirementCopy(locale: PasswordRequirementLocale): PasswordRequirementCopy {
+  return locale === 'zh' ? PASSWORD_REQUIREMENTS_ZH : PASSWORD_REQUIREMENTS_EN
+}

--- a/apps/web/src/views/AcceptInviteView.vue
+++ b/apps/web/src/views/AcceptInviteView.vue
@@ -44,13 +44,22 @@
           <label class="invite-field">
             <span>新密码</span>
             <input
+              id="invite-new-password"
               v-model="password"
               type="password"
               autocomplete="new-password"
+              aria-describedby="invite-password-requirements"
               placeholder="至少 8 位，包含大小写字母和数字"
               required
             />
           </label>
+
+          <div id="invite-password-requirements" class="invite-password-requirements" data-testid="password-requirements">
+            <strong>{{ passwordRequirementCopy.title }}</strong>
+            <ul>
+              <li v-for="item in passwordRequirementCopy.items" :key="item">{{ item }}</li>
+            </ul>
+          </div>
 
           <label class="invite-field">
             <span>确认密码</span>
@@ -85,6 +94,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '../composables/useAuth'
 import { useFeatureFlags } from '../stores/featureFlags'
 import { getApiBase } from '../utils/api'
+import { getPasswordRequirementCopy } from '../utils/passwordRequirements'
 
 type InvitePreview = {
   user: {
@@ -119,6 +129,7 @@ const preview = ref<InvitePreview | null>(null)
 const name = ref('')
 const password = ref('')
 const confirmPassword = ref('')
+const passwordRequirementCopy = getPasswordRequirementCopy('zh')
 
 function currentInviteToken(): string {
   const token = Array.isArray(route.query.token) ? route.query.token[0] : route.query.token
@@ -327,6 +338,24 @@ onMounted(() => {
   border-radius: 10px;
   padding: 0 12px;
   font-size: 14px;
+}
+
+.invite-password-requirements {
+  border: 1px solid #dbeafe;
+  border-radius: 10px;
+  background: #eff6ff;
+  color: #1e3a8a;
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.invite-password-requirements ul {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 4px;
 }
 
 .invite-submit {

--- a/apps/web/src/views/ForcePasswordChangeView.vue
+++ b/apps/web/src/views/ForcePasswordChangeView.vue
@@ -14,13 +14,22 @@
         <label class="force-password-field">
           <span>{{ isZh ? '新密码' : 'New password' }}</span>
           <input
+            id="force-password-new"
             v-model="password"
             type="password"
             autocomplete="new-password"
+            aria-describedby="force-password-requirements"
             :placeholder="isZh ? '至少 8 位，包含大小写字母和数字' : 'At least 8 characters with upper/lowercase letters and numbers'"
             required
           />
         </label>
+
+        <div id="force-password-requirements" class="force-password-requirements" data-testid="password-requirements">
+          <strong>{{ passwordRequirementCopy.title }}</strong>
+          <ul>
+            <li v-for="item in passwordRequirementCopy.items" :key="item">{{ item }}</li>
+          </ul>
+        </div>
 
         <label class="force-password-field">
           <span>{{ isZh ? '确认密码' : 'Confirm password' }}</span>
@@ -55,6 +64,7 @@ import { useLocale } from '../composables/useLocale'
 import { useFeatureFlags } from '../stores/featureFlags'
 import { ROUTE_PATHS } from '../router/types'
 import { apiFetch, clearStoredAuthState } from '../utils/api'
+import { getPasswordRequirementCopy } from '../utils/passwordRequirements'
 
 type AuthUserRecord = {
   email?: unknown
@@ -73,6 +83,7 @@ const submitting = ref(false)
 const loggingOut = ref(false)
 const error = ref('')
 const accountEmail = ref('')
+const passwordRequirementCopy = computed(() => getPasswordRequirementCopy(isZh.value ? 'zh' : 'en'))
 
 function requiresPasswordChange(user: unknown): boolean {
   if (!user || typeof user !== 'object') return false
@@ -241,6 +252,27 @@ onMounted(() => {
   outline: none;
   border-color: #3b82f6;
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.16);
+}
+
+.force-password-requirements {
+  border: 1px solid #dbeafe;
+  border-radius: 10px;
+  background: #eff6ff;
+  padding: 10px 12px;
+  color: #1e3a8a;
+  font-size: 13px;
+}
+
+.force-password-requirements strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.force-password-requirements ul {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 4px;
 }
 
 .force-password-submit {

--- a/apps/web/tests/ForcePasswordChangeView.spec.ts
+++ b/apps/web/tests/ForcePasswordChangeView.spec.ts
@@ -182,6 +182,23 @@ describe('ForcePasswordChangeView', () => {
     expect(mocks.routerReplace).toHaveBeenCalledWith('/attendance')
   })
 
+  it('shows the full password requirements before submission', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp(ForcePasswordChangeViewComponent)
+    app.mount(container)
+    await flushUi(6)
+
+    const requirements = container.querySelector('[data-testid="password-requirements"]')
+    expect(requirements?.textContent).toContain('密码要求')
+    expect(requirements?.textContent).toContain('8-128 位字符')
+    expect(requirements?.textContent).toContain('至少包含 1 个小写字母')
+    expect(requirements?.textContent).toContain('至少包含 1 个大写字母')
+    expect(requirements?.textContent).toContain('至少包含 1 个数字')
+    expect(requirements?.textContent).toContain('常见弱口令片段')
+  })
+
   it('allows signing out from the forced password change page', async () => {
     container = document.createElement('div')
     document.body.appendChild(container)


### PR DESCRIPTION
## Summary
- show the backend password policy on the forced password-change page
- show the same requirements on the invite first-password setup page
- keep the requirement copy in one frontend helper so the two setup surfaces stay aligned

## Verification
- `git diff --check`
- `pnpm --filter @metasheet/web exec vitest run tests/ForcePasswordChangeView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc -b`
