### PR TITLE
test+docs(multitable): O-2 前置 — resurrect 锚金测（P3-2）+ operator flag ladder（P3-3）

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -231,6 +231,7 @@ jobs:
             tests/integration/multitable-record-reconstructor-realdb.test.ts \
             tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts \
             tests/integration/multitable-undelete-inbound-replay-realdb.test.ts \
+            tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts \
             tests/integration/multitable-pit-view-realdb.test.ts \
             tests/integration/multitable-restore-preview-realdb.test.ts \
             tests/integration/multitable-restore-execute-realdb.test.ts \

--- a/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
+++ b/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
@@ -1,0 +1,67 @@
+# Multitable Global History — O-2 Operator Flag Ladder（决策就绪材料，2026-07-09）
+
+> **性质：operator enablement 的决策就绪材料，不是决策。** 开启哪些 flag、何时开、开到哪个环境，
+> 均为 owner/operator 决定（O-2）。本文把散落在各设计锁里的 flag、耦合与验证步骤收拢为一份
+> 可执行的阶梯清单。代码侧前置已全部落地（见 §4 台账）。
+
+## 1. Flag 清单（本线相关，全部默认 OFF）
+
+| Flag | 激活值 | 作用 | 出处 |
+|---|---|---|---|
+| `MULTITABLE_TOMBSTONE_CAPTURE_ENABLED` | `'true'` | 捕获层：record/field 销毁时写 tombstone（4c-2 + 4c-3 D-3 的 PIT-reset 点） | 4c-2 锁 |
+| `MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS` | 数字（默认 50000） | 单次销毁的捕获上限；超限 **fail-closed 拒绝该次销毁**（delete 422 / reset 422） | 4c-2 锁 |
+| `MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND` | `'true'` | 4c-3 重放层：restore / PIT-resurrect 重建 inbound 边（Option A 邻居同意） | 4c-3 锁 |
+| `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT` | `'true'` | 4c-1 lossy retype revert | 4c-1 锁 |
+| `MULTITABLE_ENABLE_PIT_UNDELETE` | `'true'` | T8-1 PIT undelete-execute（resurrect 面；4c-3 的第二重放面挂在它之下） | T8-1 锁 |
+| `MULTITABLE_META_REVISION_RETENTION_ENABLED` | **`'1'`**（⚠ 非 `'true'`） | retention janitor：revisions/config-revisions/tombstones 老化 | T9/4c-2 |
+| `MULTITABLE_META_REVISION_RETENTION_POLICY / _KEEP_N / _DAYS / _BATCH / _INTERVAL_MS` | 见代码默认 | retention 细节旋钮 | 同上 |
+
+**⚠ 激活值不一致（operator footgun）**：capture/replay 系 flag 用 `'true'`，retention 开关用 `'1'`。
+照抄错值 = 静默不生效。核对点：`tombstone-capture.ts:39` vs `meta-revision-retention.ts:60`。
+
+## 2. 耦合与顺序约束（这是本文存在的原因）
+
+1. **capture 先于 replay**：`RECORD_UNDELETE_INBOUND` 只能重放 **capture 开启期间** 删除的记录
+   （forward-only 红线，C1）。先开 capture、让 tombstone 积累，replay 才有东西可放。
+   **建议间隔**：capture 稳定运行 ≥1 个业务周期后再开 replay。
+2. **retention 单旋钮耦合（gap-audit 残差#2）**：`RETENTION_ENABLED` 同时老化
+   record-revisions、config-revisions **与 tombstones**。开 retention = 给 4c-1/4c-3 的恢复力
+   加了时间上限（keep-days 之外的删除不可再重放）。**地板已内建**：仍被存活 trash 行引用的
+   link-tombstone 组永不被清（4c-3 c5），但 field-value tombstones（4c-1 依赖）无此地板。
+3. **retention batch 语义已变（review P3-3）**：tombstone 清理的 `_BATCH` 现在按
+   **anchor 组/趟** 计，不是行/趟——单趟 DELETE 行数上限 = batch × capture-cap。
+   给 `_BATCH` 设值时按组理解；默认值在组语义下依然安全，但监控 janitor 时长时要知道这一点。
+4. **cap 是销毁的 fail-closed 闸**：capture 开启后，inbound 边数超过 `_MAX_ROWS` 的记录删除 /
+   PIT-reset 会**被拒绝**（422）。大扇入记录（被数万行引用）删除失败属预期行为，不是 bug；
+   处置：临时调大 cap 或先摘引用。
+
+## 3. 建议阶梯（staging → prod，每级有验证步骤）
+
+| 级 | 动作 | 验证 |
+|---|---|---|
+| L1 | staging 开 `TOMBSTONE_CAPTURE_ENABLED='true'` | 删一条被引用记录 → `meta_link_tombstones` 出现 `reason='record_delete'` 组；trash 行带 `delete_revision_id` |
+| L2 | staging 开 `RECORD_UNDELETE_INBOUND='true'` | 回收站恢复该记录 → 响应带 `inbound.replayed≥1`；邻居单元格重新显示该记录；trash 列表出现 `inboundEdgesRecoverable:true` |
+| L3 | staging 开 `ENABLE_PIT_UNDELETE='true'`（若走 PIT 面） | revert-execute confirm:'undelete' → 响应带 `undeleteInbound`；真库金测同形状（P3-2a/b/c） |
+| L4 | （可选）staging 开 retention（值=**'1'**）并设 `_DAYS` | 观察 janitor 日志；确认地板：有存活 trash 引用的组不被清（RB10 同形状） |
+| L5 | prod 逐级重复 L1→L3（retention 是否上 prod 独立决定） | 同上 + 观察 cap 拒绝率（若出现 422 频发→调 cap 或审视扇入） |
+
+**回滚**：任意级出问题，关掉对应 flag 即回到关闭前行为（全部 flag-off 路径有金测钉死逐字节不变：RB1、P3-2a）。
+tombstone 数据是惰性的——关 flag 不删数据，重开后继续可用（受 retention 影响除外）。
+
+## 4. 代码侧前置台账（O-2 开启前已全部落地）
+
+| 前置 | 状态 |
+|---|---|
+| 4c-3 实现 + 对抗审 APPROVE（0 P1/P2） | ✅ #3975 merged |
+| review P3-1：reset 路径 cap 超限 422（非 500） | ✅ #3975 内修复 |
+| review P3-2：resurrect 锚选择 golden（此前可 neuter 而全绿） | ✅ 本 PR：P3-2a/b/c 三金测 + 锚突变精确命中 b/c |
+| review P3-3：batch=组/趟语义 operator 文档 | ✅ 本文 §2.3 |
+| gap-audit 残差#2：retention 单旋钮耦合入 checklist | ✅ 本文 §2.2 |
+| D-1（PIT 谎报存活修复，独立于 flag，已生效） | ✅ #3969 merged |
+
+## 5. 未做/边界（如实）
+
+- field-value tombstones（4c-1 恢复力）**无 retention 地板**（link 侧才有）——若 retention 上线且
+  4c-1 恢复窗口重要，需单独补地板（新 rung，不在本文）。
+- automation / plugin-SDK 删除仍**无捕获**（不可恢复=D-2，owner-gated）；4c-3 可达边界不含它们。
+- 4d 红线不变：已删字段列值的值级恢复永不承诺。

--- a/packages/core-backend/tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts
@@ -1,0 +1,140 @@
+/**
+ * 4c-3 §7 — PIT-resurrect INBOUND replay goldens (review P3-2 / O-2 precondition, real DB).
+ *
+ * PR #3975's adversarial review approved the line but flagged one uncovered seam: the resurrect
+ * surface reuses the SHARED replay helper (tested by the RB matrix), yet its resurrect-specific
+ * ANCHOR-SELECTION query (latest delete revision for the record, univer-meta revert-execute path)
+ * had no golden — it could be neutered with all 12 RB goldens staying green. These three goldens +
+ * the recorded mutation close that hole, and are a named precondition for enabling
+ * MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND in the O-2 operator ladder.
+ *
+ * Harness mirrors multitable-undelete-pit-realdb.test.ts (revision-seeded PIT undelete via
+ * revert-preview → revert-execute confirm:'undelete'), with one addition: the delete revision id is
+ * FIXED so inbound tombstones can be seeded anchored to it — exactly the shape
+ * record-service.deleteRecord's capture writes (reason='record_delete', source_revision_id = the
+ * delete revision's own id).
+ */
+import express, { type Express } from 'express'
+import { randomUUID } from 'crypto'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_uir_${TS}`, SHEET = `sheet_uir_${TS}`
+const NAME = `fld_uir_name_${TS}`, LINK = `fld_uir_link_${TS}`
+const U = `rec_uir_u_${TS}` // deleted record → undelete target
+const L = `rec_uir_l_${TS}` // LIVE neighbour whose data still declares U (inbound edge holder)
+const ACTOR = `user_uir_${TS}`
+const UNDELETE_FLAG = 'MULTITABLE_ENABLE_PIT_UNDELETE'
+const INBOUND_FLAG = 'MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND'
+const T0 = '2026-01-01T00:00:00.000Z', T1 = '2026-01-02T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
+const SNAP = { [NAME]: 'u-at-T1' } // no outbound links — this suite is about INBOUND only
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let deleteRevisionId = ''
+
+const preview = (asOf: string) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-preview`).send({ asOf })
+const execute = (asOf: string, previewIdentity: string) =>
+  request(app).post(`/api/multitable/sheets/${SHEET}/revert-execute`).send({ asOf, previewIdentity, confirm: 'undelete' })
+const inboundEdge = async () =>
+  (await q('SELECT 1 FROM meta_links WHERE field_id=$1 AND record_id=$2 AND foreign_record_id=$3', [LINK, L, U])).rows.length
+
+async function runUndelete(): Promise<{ status: number; body: Record<string, any> }> {
+  const pv = await preview(T1)
+  expect(pv.status).toBe(200)
+  const res = await execute(T1, pv.body?.data?.previewIdentity)
+  return { status: res.status, body: res.body }
+}
+
+async function seed(): Promise<void> {
+  deleteRevisionId = randomUUID()
+  await q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,1,'create','rest',ARRAY[$3]::text[],'{}'::jsonb,$4::jsonb,$5)`,
+    [SHEET, U, NAME, JSON.stringify(SNAP), T0],
+  )
+  // The delete revision with a KNOWN id — the resurrect anchor query must find THIS row.
+  await q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES ($6::uuid,$1,$2,2,'delete','rest',ARRAY[$3]::text[],'{}'::jsonb,$4::jsonb,$5)`,
+    [SHEET, U, NAME, JSON.stringify(SNAP), T2, deleteRevisionId],
+  )
+  // Live neighbour still declaring U in its link cell (Option A consent holds).
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+    L, SHEET, JSON.stringify({ [NAME]: 'L', [LINK]: [U] }),
+  ])
+  // The inbound tombstone exactly as record-service.deleteRecord's capture writes it.
+  await q(
+    `INSERT INTO meta_link_tombstones (id, sheet_id, field_id, record_id, foreign_record_id, reason, source_revision_id, created_at)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'record_delete',$5::uuid,$6)`,
+    [SHEET, LINK, L, U, deleteRevisionId, T2],
+  )
+}
+
+describeIfDatabase('4c-3 §7 — PIT-resurrect inbound replay (real DB, P3-2 goldens)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'UIR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'UIR Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [LINK, SHEET, 'Link', 'link', JSON.stringify({ foreignSheetId: SHEET }), 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [SHEET]).catch(() => {})
+    for (const t of ['meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+  beforeEach(async () => {
+    process.env[UNDELETE_FLAG] = 'true'
+    await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [SHEET])
+    for (const t of ['meta_record_revisions', 'meta_records']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET])
+    await seed()
+  })
+  afterEach(() => {
+    delete process.env[UNDELETE_FLAG]
+    delete process.env[INBOUND_FLAG]
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('P3-2a flag OFF: resurrect does NOT replay inbound and the response carries no undeleteInbound (byte-identical)', async () => {
+    const { status, body } = await runUndelete()
+    expect(status).toBe(200)
+    expect(body?.data?.undeleteRecordIds).toEqual([U])
+    expect(body?.data?.undeleteInbound).toBeUndefined()
+    expect(await inboundEdge()).toBe(0) // pre-4c-3 behavior preserved
+  })
+
+  test('P3-2b flag ON: resurrect anchors to the record\'s latest delete revision and replays the inbound edge', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { status, body } = await runUndelete()
+    expect(status).toBe(200)
+    expect(body?.data?.undeleteRecordIds).toEqual([U])
+    // The anchor-selection query (the P3-2 uncovered seam) found the delete revision, and the
+    // shared helper replayed the tombstoned edge.
+    expect(body?.data?.undeleteInbound).toMatchObject({ replayed: 1, total: 1 })
+    expect(await inboundEdge()).toBe(1)
+  })
+
+  test('P3-2c flag ON + neighbour declined: Option A consent holds on the resurrect surface too', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    await q(`UPDATE meta_records SET data = jsonb_set(data, $2, '[]'::jsonb) WHERE id = $1`, [L, `{${LINK}}`])
+    const { status, body } = await runUndelete()
+    expect(status).toBe(200)
+    expect(body?.data?.undeleteInbound).toMatchObject({ replayed: 0, total: 1 })
+    expect(await inboundEdge()).toBe(0)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -124,6 +124,7 @@ export default defineConfig({
       // 4c-3 RB matrix: real Postgres only — whole-file wired into `Run multitable real-DB
       // integration` in plugin-tests.yml (describeIfDatabase alone would skip-green here).
       'tests/integration/multitable-undelete-inbound-replay-realdb.test.ts',
+      'tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts',
       // W6 full-HTTP-path approve->resume seam: mounts authRouter + approvalsRouter on an
       // ephemeral port against real Postgres, so it is excluded from the default run and wired
       // into the dedicated `Run multitable real-DB integration` job in plugin-tests.yml.


### PR DESCRIPTION
## O-2 前置清扫（#3975 对抗审的 P3-2/P3-3 + gap-audit 残差#2）

把 O-2 operator 阶梯上仅剩的两件**代码侧**前置做完——owner 跑 O-2 时只剩纯开关决策。

### P3-2：resurrect 锚选择 golden（关闭审阅点名的未覆盖缝）
resurrect 面复用共享重放 helper（RB 矩阵已测），但其**专属的锚选择查询**（记录最新 delete revision）无金测——可被 neuter 而 12 个 RB 全绿。新增真库三金测（镜像 T8-1 PIT-undelete harness，delete revision id **固定**以便按真实捕获形状种 tombstone）：
- **P3-2a** flag-off：resurrect 不重放、响应无 `undeleteInbound` 字段（逐字节保形）；
- **P3-2b** flag-on：锚命中→重放（边回来、`undeleteInbound{replayed:1}`）；
- **P3-2c** flag-on+邻居已移除：**Option A 同意在 resurrect 面同样生效**。

**突变验证**：neuter 锚选择（`anchorId = null`）→ **恰好** P3-2b/c 两个 flag-on 金测红；还原 4/4 绿。三点接线（vitest exclude + plugin-tests.yml + describeIfDatabase；no-DB 裸跑 "No test files found" 已验）。

### P3-3 + gap-audit 残差#2：O-2 operator flag ladder 文档
`multitable-global-history-o2-operator-flag-ladder-20260709.md`——决策就绪材料（非决策）：
- flag 盘点含**激活值**（footgun：retention 用 `'1'`，capture/replay 用 `'true'`，抄错=静默不生效）；
- **capture 先于 replay** 的顺序约束（forward-only C1）；
- retention **单旋钮耦合**（一个开关同时老化 revisions+tombstones；link 侧有地板、**field-value 侧无**——如实记边界）；
- batch=**组/趟**语义（单趟 DELETE 上限 = batch × cap）；
- cap 拒绝=预期行为的处置指引；
- L1–L5 分级阶梯（staging→prod）每级带验证步骤 + 回滚说明（全 flag-off 路径有金测钉逐字节不变）。

### 台账
D-1 #3969 ✅ · 4c-3 #3975 ✅（对抗审 APPROVE 0 P1/P2，P3-1 已修）· P3-2 ✅本 PR · P3-3+残差#2 ✅本 PR → **O-2 阶梯代码侧无剩余前置**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
