### PR TITLE
test(multitable): R8 — 4c-3 absorption-audit hardening (P3-1..3, NIT goldens, as-built docs)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -232,6 +232,7 @@ jobs:
             tests/integration/multitable-d1-delete-revision-parity-realdb.test.ts \
             tests/integration/multitable-undelete-inbound-replay-realdb.test.ts \
             tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts \
+            tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts \
             tests/integration/multitable-pit-view-realdb.test.ts \
             tests/integration/multitable-restore-preview-realdb.test.ts \
             tests/integration/multitable-restore-execute-realdb.test.ts \
@@ -252,6 +253,7 @@ jobs:
             tests/integration/multitable-revert-pit-realdb.test.ts \
             tests/integration/multitable-undelete-pit-realdb.test.ts \
             tests/integration/multitable-reset-pit-realdb.test.ts \
+            tests/integration/multitable-reset-pit-inbound-capture-realdb.test.ts \
             tests/integration/multitable-config-revision-retention-realdb.test.ts \
             tests/integration/multitable-config-history-api-realdb.test.ts \
             tests/integration/multitable-config-history-view-redaction-realdb.test.ts \

--- a/docs/development/multitable-global-history-4c3-impl-wave-verification-20260709.md
+++ b/docs/development/multitable-global-history-4c3-impl-wave-verification-20260709.md
@@ -3,6 +3,8 @@
 **性质:** 每 wave 设计+验证 MD(4c-2 先例:`…4c2-impl-wave-verification-20260708.md`)。本文对应 **4c-3 record-undelete inbound-edge replay(Option A)的 RATIFIED + AS-BUILT 实现**(PR #3975,merged `100b6dd59`,flag 默认 off)+ **R8 车道对该 PR 的吸收性对抗审计的无裁量硬化轮**(本轮,test-only,不改产品行为)。
 **上游:** design-lock `…4c3-record-undelete-2b-inbound-edge-replay-design-lock-20260708.md`(owner ratify 2026-07-09,路由 Codex 车道实现)。**前置 gap-audit:** `…destruction-path-coverage-gap-audit-20260708.md`(D-1 已于同日经独立 PR #3969/#3977 落地;本文不重复其记录)。
 
+**⚠️ 与并行 PR #3983 的关系(rebase 期发现,记录以防未来读者困惑):** 本 PR 开发期间,主线并行落地了 `test+docs(multitable): O-2 preconditions — resurrect-path goldens (P3-2) + operator flag ladder (P3-3) (#3983)`,来自**同一 PR #3975 的另一条对抗审(其自身的 review,而非本文引用的独立吸收性审计 `/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`)**,该 PR 的 P3-2/P3-3 编号与本文引用的审计**编号不同但同源**(都指向 PIT-resurrect 锚定这同一个覆盖缺口)。#3983 新增 `multitable-undelete-pit-inbound-replay-realdb.test.ts`(单-vintage happy replay + Option A 邻居拒绝 + flag-off)与 `…o2-operator-flag-ladder-20260709.md`(O-2 启用阶梯)。本 PR 的 `multitable-undelete-inbound-resurrect-realdb.test.ts` 与之**部分重叠**(均含 flag-off 字节级不变一测)但**互补,非重复**:本 PR 独有多-vintage 锚定精度(只放最新 vintage、不串代)+ 未捕获-vintage 静默零重放两条 golden,以及把 resurrect 锚注释的 "deterministic" 措辞改诚实。两份 PR 已在 `origin/main` 上 rebase 兼容,9 个相关 realdb 文件(含 #3983 的新文件)同跑 75/75 绿,无 fixture 冲突。
+
 ## 1. 落地内容(逐 § 对锁)
 
 | 锁 § | 实现 | 位置 |

--- a/docs/development/multitable-global-history-4c3-impl-wave-verification-20260709.md
+++ b/docs/development/multitable-global-history-4c3-impl-wave-verification-20260709.md
@@ -1,0 +1,89 @@
+# Multitable Global History — 4c-3 impl wave 设计+验证记录(2026-07-09)
+
+**性质:** 每 wave 设计+验证 MD(4c-2 先例:`…4c2-impl-wave-verification-20260708.md`)。本文对应 **4c-3 record-undelete inbound-edge replay(Option A)的 RATIFIED + AS-BUILT 实现**(PR #3975,merged `100b6dd59`,flag 默认 off)+ **R8 车道对该 PR 的吸收性对抗审计的无裁量硬化轮**(本轮,test-only,不改产品行为)。
+**上游:** design-lock `…4c3-record-undelete-2b-inbound-edge-replay-design-lock-20260708.md`(owner ratify 2026-07-09,路由 Codex 车道实现)。**前置 gap-audit:** `…destruction-path-coverage-gap-audit-20260708.md`(D-1 已于同日经独立 PR #3969/#3977 落地;本文不重复其记录)。
+
+## 1. 落地内容(逐 § 对锁)
+
+| 锁 § | 实现 | 位置 |
+|---|---|---|
+| §2 anchor 列 | `meta_records_trash.delete_revision_id text NULL`(forward-only,nullable,无回填) | migration `zzzz20260709100000_add_delete_revision_id_to_meta_records_trash.ts` |
+| §2 写入点 | `deleteRecord` 预生成 `recordDeleteRevisionId`,同一 id 兼作 tombstone `source_revision_id` + trash 行 `delete_revision_id` + revision `id` | `record-service.ts:829/833/854/876` |
+| §2 restore 读锚 | 严格 `trash.delete_revision_id`;NULL ⇒ else 分支 `recoverable=false, replayed=0`,无启发式 | `record-service.ts:1079/1120-1122` |
+| §3 六道前置 + §4 Option A + 幂等 | `replayInboundLinks`:诊断 CASE + INSERT…SELECT 同谓词锁步(R alive / N alive / F exists / F=link / F non-mirror / 邻居同意 / NOT EXISTS) | `inbound-link-replay.ts` |
+| §5 授权 | 仅 `INSERT INTO meta_links`,`// lock-exempt` 标注;guard 实跑绿 | `inbound-link-replay.ts:35,133` |
+| §6 retention 地板 + 撕裂修复 | `tr.delete_revision_id = g.anchor::text` 地板;按 anchor 整组裁剪 | `meta-revision-retention.ts:229-252` |
+| §6 诚实信号 | `inboundEdgesRecoverable`(trash 列表)/ `recoverable: replay.total > 0`(restore 结果) | `record-service.ts:972-1002,1119` |
+| §7 D-3(PIT-reset 捕获) | 预生成 `resetDeleteRevisionId` → `assertWithinCaptureCap` + `insertInboundLinkTombstones`(在 `DELETE meta_links` 之前)→ trash 锚同值;cap 超限 ⇒ 整单 reset 回滚 + 422 `TOMBSTONE_CAPTURE_CAP_EXCEEDED` | `univer-meta.ts:10456-10461,10504-10508` |
+| §7 PIT-resurrect 复用 | 同一 `replayInboundLinks`;锚 = 该记录**最新** `action='delete'` revision(启发式,见 §1.1) | `univer-meta.ts:10165-10193` |
+| §7 resurrect 信号 | 批量聚合 `undeleteInbound: { replayed, total }`(镜像 restore 侧,resurrect 无 per-edge skip 明细) | `univer-meta.ts:10139,10233` |
+| §9 RB1–RB11 | 真库 golden 矩阵,CI 三点接线 | `multitable-undelete-inbound-replay-realdb.test.ts` |
+| §9 RB12(mutation) | 六道谓词 + 地板独立 neuter → 逐一恰红(非提交测试,见 §2.2) | 审计 + R8 手工复证 |
+
+### 1.1 承重正确性事实(本 wave 最重要的一条)
+
+**resurrect 侧的锚不是 `restore` 侧那种存储列,是一条查询启发式**:`SELECT id FROM meta_record_revisions WHERE … action='delete' ORDER BY created_at DESC … LIMIT 1`。这在设计锁 §2 明文警告的形状之列("绝不用 `ORDER BY created_at DESC` 之类的启发式反推"),但该警告针对的是 **restore** 路径(那里有 `trash.delete_revision_id` 真锚,没有理由退化为启发式)。resurrect **没有 trash 行**(记录已被硬删且 T8-1 undelete 是从 revision 快照直接重建,不经过 trash 表),所以启发式是这个复活面**唯一可行**的锚来源,design-lock §7 本身也预见到"若 impl 期证明代价过大,允许拆为 4c-3b……必须显式记录分叉"——impl 选择不拆分,复用同一 helper,但锚来源不同这一点此前被代码注释里的"deterministic"措辞掩盖了。R8 已将该注释改为诚实版本(见 §2.3),并补齐多-vintage / 未捕获-最近删除两条 golden 把**实际行为**钉死,而不是让文档继续暗示一个不存在的精确性保证。**过放在两种复活面下都不可能**——precondition 6(邻居同意,读 `N` 自己的 `data`)独立于锚的选取为每条边把关,启发式唯一能造成的失效模式是**欠放**(某个 vintage 的边没被这次复活捡回来),不是错放。
+
+## 2. 验证(独立复跑,不采信 PR 自证)
+
+**独立吸收性对抗审计判定:APPROVE(post-hoc)— 0 P1 / 0 P2**(`/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`)。
+
+审阅方独立执行:
+- migration 实跑:`\d meta_records_trash` 确认 `delete_revision_id text` 列存在;forward-only nullable,无回填。
+- realdb RB1–RB11:12/12 绿(含 sentinel)。
+- **独立 mutation 矩阵 6/6 恰红**(见 §2.2)。
+- 逐门核对 design-lock §1–§9 + C1–C8 不变量,全部 PASS(C4 golden 判 "弱见 NIT"——见 NIT-4)。
+- 邻居回归:`multitable-record-reconstructor-realdb.test.ts` 8/8。
+
+R8 车道(本轮,2026-07-09)在审计判定之上补齐全部可无裁量修复的 P3/NIT 覆盖缺口,**未改动任何产品行为**(仅 1 处代码注释重写,见 §2.3)。
+
+### 2.1 判定表(C1–C8,审计原文)
+
+| 不变量 | 判定 | 证据 |
+|---|---|---|
+| C1 forward-only | PASS | RB3 绿 |
+| C2 六道前置 | PASS | M3–M7 mutation 各自对应 golden 红 |
+| C3 幂等 | PASS | RB8 绿 + M7 红 |
+| C4 原子+并发 | PASS(golden 弱,见 NIT-4) | RB11 绿;`FOR UPDATE` |
+| C5 无新权面 | PASS | §5 证 |
+| C6 retention 地板 + 诚实信号 | PASS | RB10 绿 + M-floor 红 |
+| C7 flag 默认 off | PASS | RB1 绿 |
+| C8 写对称 | PASS | cap fail-closed + rank-8 标注 |
+
+### 2.2 独立 mutation 矩阵(6/6,审计 + R8 两轮复证,每次还原后 `git diff` 空)
+
+| Mutation(neuter 对象) | 对应 golden | 结果 |
+|---|---|---|
+| M3 field-exists `JOIN meta_fields`(改 LEFT JOIN + 放行 null-field) | RB4(fieldGone/23503) | **RED** ✓ |
+| M4 `AND f.type='link'` → `AND TRUE` | RB5(fieldNotLink) | **RED** ✓ |
+| M5 `AND (f.property->>'mirrorOf') IS NULL` → `AND TRUE` | RB6(fieldMirror) | **RED** ✓ |
+| M6 `AND (n.data->F) ? R` → `AND TRUE` | RB7(neighborDeclined / Option A) | **RED** ✓ |
+| M7 `AND NOT EXISTS(...)` → `AND TRUE` | RB8(self-link 双写) | **RED** ✓ |
+| M-floor 地板谓词禁用(`table===LINK` → `false`) | RB10(retention 地板) | **RED** ✓ |
+
+**结论:六道写谓词守卫 + 地板全部 load-bearing,无假绿。** RB12 本身此前**未固化为提交测试**(仅审计 PR-body 手工复证)——这正是 NIT-4 点名的缺口。R8 未新增一个"批量 mutation runner"文件,而是确认 **RB4/RB5/RB6/RB7/RB8/RB10 六个既有 golden 本身就是「结构守卫」形状**(每个 golden 的断言只在对应谓词在位时才绿,已在 §2.2 逐一独立复证),并核实它们已提交(`multitable-undelete-inbound-replay-realdb.test.ts`)且在 CI 名单(`plugin-tests.yml` real-DB 运行块 + `vitest.config.ts` exclude 名单)——**无需新增代码即满足 NIT-4 的实质要求**。
+
+### 2.3 R8 本轮新增覆盖(P3/NIT 硬化,test-only)
+
+| 项 | 覆盖 | 文件 | Mutation 证据 |
+|---|---|---|---|
+| P3-3 | neighborGone(邻居窗口内被硬删)⇒ 该边跳过,R 正常恢复 | `multitable-undelete-inbound-replay-realdb.test.ts` RB13 | 移除诊断 CASE 的 `neighborGone` 分支 → RB13 恰红 |
+| NIT-3 | anchor 非空 + 零 tombstone(capture flag 对该次删除关闭)⇒ `recoverable=false`,零重放,无错误 | 同上 RB14 | `record-service.ts` 把 `recoverable: replay.total > 0` 硬编码为 `true` → RB14 恰红(其余 13 条不受影响) |
+| P3-2 | D-3 PIT-reset 捕获:happy path(锚一致 + restore 回放全链路)+ cap 超限 → 422 + 整单回滚(含无关 revert 候选也被回滚,证明是全事务回滚而非仅该条) | `multitable-reset-pit-inbound-capture-realdb.test.ts` (a)(b) | 注释掉 `insertInboundLinkTombstones` 调用 → (a) 恰红、(b) 不受影响;注释掉 `assertWithinCaptureCap` → (b) 恰红、(a) 不受影响 |
+| P3-1 | PIT-resurrect 多-vintage:锚定最新 delete revision,只重放对应 vintage,不串代;最近删除未捕获 → 静默零重放;flag-off 字节级不变 | `multitable-undelete-inbound-resurrect-realdb.test.ts` (A)(B)(C) | 锚查询 `ORDER BY … DESC` 改 `ASC` → (A) 恰红(B/C 不受影响);response 拼接去掉 `isRecordUndeleteInboundEnabled() &&` 门控 → (C) 恰红(A/B 不受影响) |
+| P3-1(注释) | `univer-meta.ts` resurrect 锚注释的 "deterministic" 改为诚实描述(启发式来源、多-vintage 行为、未捕获行为、过放不可能的机理) | `univer-meta.ts:10165-10182` | 纯注释,无行为差异(comment-only diff 已核对) |
+
+全部新增 golden 均在同一次性 docker `postgres:16` 实跑绿,且与既有邻居文件(`multitable-reset-pit-realdb.test.ts`、`multitable-undelete-pit-realdb.test.ts`、`multitable-d1-delete-revision-parity-realdb.test.ts`)同跑无 fixture 冲突(fixture id 均按文件前缀 + 时间戳命名空间化)。
+
+## 3. 可达边界与 flag 状态(不虚构)
+
+- **可达边界不变:** 只重放经 `record-service.deleteRecord`(捕获 flag 开启期间)或 PIT-reset 内联删除(同一 flag)销毁的 inbound 边。automation / plugin-SDK 硬删路径**仍不产生 tombstone**(= gap-audit D-2,owner 决策,出界)。4d 红线不动摇。
+- **三个独立 flag,均默认 off:** `MULTITABLE_TOMBSTONE_CAPTURE_ENABLED`(捕获总闸)、`MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND`(inbound 重放闸,restore + resurrect 共用)、`MULTITABLE_ENABLE_PIT_RESET` / `MULTITABLE_ENABLE_PIT_UNDELETE`(各自复活面的既有闸,4c-3 未新增)。任一组合 off ⇒ 对应路径逐字节不变(RB1、resurrect (C) 均实证)。
+- **production 启用** 属独立 O-2 operator 阶梯,不在本锁/本 wave 范围。
+
+## 4. 诚实缺口(本 wave 未做/需裁量,记录不隐瞒)
+
+1. **resurrect 侧的精确 vintage 锚定未做**(P3-1 遗留的"改代码"半句)——把启发式换成精确锚(例如给 resurrect 也提供一个可靠的 per-vintage 锚,或在响应里暴露"此次复活可能遗漏更早 vintage 的边"的显式信号)需要新的存储或响应 schema 决策,**超出"补 golden/诚实注释"的一行级改动**,记录为**未做/需裁量**,不在本轮触碰。当前行为(欠放、不错放)已被 golden 钉死为诚实的已知限度。
+2. **resurrect 响应的 per-edge skip 明细未做**(镜像 restore 侧的 `skipped.{fieldGone,fieldNotLink,...}`)——resurrect 目前只聚合 `{replayed, total}`,不像 restore 那样按跳过原因分桶。这同样是响应 shape 的产品裁量(会改变多条已合并调用方可能依赖的 JSON 形状假设),记录为未做,不在本轮触碰。
+3. **NIT-1(drift-tripwire 精度)/ NIT-2(单语句 NOT EXISTS 对同批重复 tombstone 三元组的理论双放)/ NIT-5(`listDeletedRecords` 全列 SELECT + tombstone-capture.ts 文档枚举未列 PIT-reset 路由)** —— 审计原文即标注为低风险/理论可达,本轮未新增 golden(超出本轮授权的"补 P3/NIT golden"清单;若后续需要,按同一 mutation-verified 方法论补齐)。
+4. 50k 捕获 cap 的规模/性能特征、on-prem 包构建路径未验(与 4c-2 wave 的诚实缺口 4 一致,未随本 wave 复测)。

--- a/docs/development/multitable-global-history-4c3-record-undelete-2b-inbound-edge-replay-design-lock-20260708.md
+++ b/docs/development/multitable-global-history-4c3-record-undelete-2b-inbound-edge-replay-design-lock-20260708.md
@@ -1,6 +1,6 @@
-# Multitable Global History — 4c-3 Record-Undelete Slice 2b(inbound 边重放)— DESIGN-LOCK(PROPOSED)(2026-07-08)
+# Multitable Global History — 4c-3 Record-Undelete Slice 2b(inbound 边重放)— DESIGN-LOCK(RATIFIED — AS-BUILT)(2026-07-08)
 
-**状态:PROPOSED,待 owner ratify。** 起草于线级 /goal 授权下(pre-gate 工作,与 4c-1/4c-2 同法:design-lock-first)。**起草 ≠ 开工;impl 仅在 owner 单项签核后排期。**
+**状态:RATIFIED(owner 2026-07-09,路由 Codex 车道实现)+ AS-BUILT #3975(merge commit `100b6dd59`,已在 `origin/main`)。** 起草于线级 /goal 授权下(pre-gate 工作,与 4c-1/4c-2 同法:design-lock-first)。**独立吸收性对抗审计(2026-07-09,`/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`)判定 APPROVE(0 P1、0 P2;3 条 P3 + 5 条 NIT,均为 flag-gated-dormant 面的覆盖硬化,不涉及产品裁量)。** R8 车道(本轮)已补齐全部可无裁量修复的 P3/NIT 缺口(goldens + 文档诚实化);逐条对锁见 `docs/development/multitable-global-history-4c3-impl-wave-verification-20260709.md`。
 **前置(已满足):** 4c-2 forward tombstone-capture impl 已落 main(`023385499`)——inbound 边在 `record-service.deleteRecord` 里已被捕获进 `meta_link_tombstones(reason='record_delete')`,但**明确不重放**(4c-2 把重放留给本锁)。
 
 ## 0. 一句话与可达边界(诚实收窄)
@@ -118,6 +118,12 @@ inbound 边在语义上属于**别的 sheet(乃至别的 base)上的 `N`**;而 r
 | RB10 | retention 地板 | 存活 trash 行引用的 tombstone 不被 sweep 清;整组裁剪(不撕裂) |
 | RB11 | 并发两个 restore | trash 行 `FOR UPDATE` ⇒ 一个成功一个 409,无重复边、无半态 |
 | RB12 | **mutation** | neuter 每道前置(字段存在 / type=link / non-mirror / 邻居同意 / NOT EXISTS)→ 恰好对应 golden 变红;neuter 地板 → RB10 红 |
+
+**AS-BUILT 追记(forward-only,不改上表,只追加事实):** #3975 交付 RB1–RB11(`multitable-undelete-inbound-replay-realdb.test.ts`,CI 三点接线,real DB 12/12 绿);RB12(mutation)由审计与 R8 车道**独立复现 6/6 红**(§2/§4/§6 各道谓词 + retention 地板),但矩阵本身**未列 D-3(PIT-reset 捕获)与 PIT-resurrect 侧**的端到端 golden——这不是 impl 偏离(锁文原表确实没写这两项),而是覆盖缺口。R8 吸收审计(2026-07-09,APPROVE 0P1/0P2)补齐:
+- `multitable-undelete-inbound-replay-realdb.test.ts` 追加 **RB13**(neighborGone)与 **RB14**(anchor 非空+零 tombstone ⇒ `recoverable=false`)。
+- 新文件 `multitable-reset-pit-inbound-capture-realdb.test.ts`:D-3 捕获接线happy path(锚一致 + restore 回放)+ cap 超限 → 422 + 整单回滚。
+- 新文件 `multitable-undelete-inbound-resurrect-realdb.test.ts`:PIT-resurrect 侧多-vintage(只重放最新锚定 vintage,不串代)+ 未捕获 vintage 静默零重放 + flag-off 字节级不变;并把 `univer-meta.ts` 里原先"deterministic"措辞的代码注释改诚实(resurrect 无 trash 行,锚定用启发式,过放不可能因邻居同意谓词兜底)。
+全部 6 个文件均真库 mutation-verified(fail-first→revert),详见 `docs/development/multitable-global-history-4c3-impl-wave-verification-20260709.md`。
 
 ## 10. 实施排布(ratify 后才排)
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -10163,12 +10163,23 @@ export function univerMetaRouter(): Router {
               }
               await recordRecordRevision(query, { sheetId, recordId: r.recordId, version: 1, action: 'create', source: 'restore', changedFieldIds: Object.keys(r.snapshot), patch: r.snapshot, snapshot: r.snapshot, actorId: undeleteActorId })
               // 4c-3 §7: the SECOND resurrection surface reuses the SAME replay helper — never a
-              // parallel inbound semantic. Anchor = this record's LATEST delete revision: the record
-              // does not exist right now (id-occupied guard above), so the most recent delete IS the
-              // deletion that destroyed the currently-missing inbound edges — deterministic, not a
-              // vintage guess. A deletion without capture (uncaptured path, or capture flag off, or
-              // retention) simply yields zero tombstones ⇒ zero replay, honest. Runs AFTER the
-              // outbound loop (NOT EXISTS must see those rows; self-link stays single).
+              // parallel inbound semantic. HONEST NOTE (R8 absorption-audit P3-1, reworded from an
+              // earlier "deterministic" claim that overstated this): resurrect has no trash row to
+              // read an anchor off (unlike restoreRecord's `meta_records_trash.delete_revision_id`),
+              // so it falls back to a HEURISTIC — the record's MOST RECENT 'delete' revision, by
+              // `created_at DESC`. Under multi-vintage churn (delete → restore → delete → resurrect
+              // an OLDER vintage via PIT asOf) this anchors to the LATEST deletion even when the
+              // snapshot being resurrected is an older one — it replays that one vintage's captured
+              // edges only, never strings multiple anchors together. If the most recent deletion
+              // happened while capture was off (or its tombstones already aged out via retention),
+              // the anchor still resolves but carries zero tombstones ⇒ zero replay — silent and
+              // honest, never fabricated. Under-replay (missing a vintage's edges) is the only
+              // failure mode this heuristic can produce; OVER-replay stays impossible regardless of
+              // which delete revision is picked, because precondition 6 (neighbour consent — replay
+              // only what N's OWN live `data` still declares) gates every edge independently of the
+              // anchor. See `multitable-undelete-inbound-resurrect-realdb.test.ts` for the pinned
+              // multi-vintage + uncaptured-vintage goldens. Runs AFTER the outbound loop (NOT EXISTS
+              // must see those rows; self-link stays single).
               if (isRecordUndeleteInboundEnabled()) {
                 const anchorRes = await query(
                   `SELECT id FROM meta_record_revisions

--- a/packages/core-backend/tests/integration/multitable-reset-pit-inbound-capture-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-reset-pit-inbound-capture-realdb.test.ts
@@ -1,0 +1,199 @@
+/**
+ * 4c-3 §7 (D-3) — PIT-reset inline delete gains inbound-link tombstone capture (real DB).
+ *
+ * R8 absorption-audit hardening (P3-2, post-hoc — no product behaviour changed). PR #3975 wired
+ * `univer-meta.ts`'s reset-execute delete loop to pre-generate a `resetDeleteRevisionId`, capture
+ * inbound-link tombstones BEFORE destroying the edges (same shape as `record-service.deleteRecord`),
+ * write it into `meta_records_trash.delete_revision_id`, and map a cap breach to the same 422
+ * `TOMBSTONE_CAPTURE_CAP_EXCEEDED` the DELETE-record route uses — but shipped with no dedicated
+ * golden. Design-lock: `docs/development/multitable-global-history-4c3-record-undelete-2b-inbound-
+ * edge-replay-design-lock-20260708.md` §7. Audit: `/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`.
+ *
+ * Cross-sheet fixture: the reset TARGET D lives on SHEET_A; its neighbour N (which owns the link
+ * field F pointing at D) lives on SHEET_B — same trap as the RB matrix (tombstone's sheet_id stores
+ * D's sheet, field_id/record_id belong to N's).
+ *
+ * (a) happy path: reset-execute captures the inbound tombstone anchored to the SAME delete revision
+ *     id it writes into the trash row; a subsequent restore (record-service.restoreRecord, flag on)
+ *     replays the edge — full round trip through the D-3 capture point.
+ * (b) cap breach: MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS forced to 0 with capture ON → reset-execute
+ *     422 TOMBSTONE_CAPTURE_CAP_EXCEEDED, and the WHOLE reset rolls back — the delete target stays
+ *     live, the unrelated revert candidate stays unreverted, and the neighbour's edge is untouched
+ *     (fail-closed, never a half-captured destruction).
+ *
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_ric_${TS}`
+const SHEET_A = `sheet_ric_a_${TS}` // reset target's sheet
+const SHEET_B = `sheet_ric_b_${TS}` // neighbour's sheet (owns link field F)
+const NAME = `fld_ric_name_${TS}`
+const ACTOR = `user_ric_${TS}`
+const RESET_FLAG = 'MULTITABLE_ENABLE_PIT_RESET'
+const CAPTURE_FLAG = 'MULTITABLE_TOMBSTONE_CAPTURE_ENABLED'
+const INBOUND_FLAG = 'MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND'
+const CAP_ROWS_FLAG = 'MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS'
+const T0 = '2026-01-01T00:00:00.000Z', T1 = '2026-01-02T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let seq = 0
+const mkFieldId = (tag: string) => `fld_ric_${tag}_${TS}_${seq++}`
+const mkRecordId = (tag: string) => `rec_ric_${tag}_${TS}_${seq++}`
+
+const resetPreview = () => request(app).post(`/api/multitable/sheets/${SHEET_A}/reset-preview`).send({ asOf: T1 })
+const resetExecute = (previewIdentity: string) => request(app).post(`/api/multitable/sheets/${SHEET_A}/reset-execute`).send({ asOf: T1, previewIdentity, confirm: 'reset' })
+const httpRestore = (recordId: string) => request(app).post(`/api/multitable/records/${recordId}/restore`)
+const recordRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const edgeCount = async (fieldId: string, recordId: string, foreignId: string): Promise<number> =>
+  (await q('SELECT 1 FROM meta_links WHERE field_id=$1 AND record_id=$2 AND foreign_record_id=$3', [fieldId, recordId, foreignId])).rows.length
+const rev = (sheetId: string, id: string, version: number, action: string, snap: Record<string, unknown>, at: string) =>
+  q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6)`, [sheetId, id, version, action, JSON.stringify(snap), at])
+
+async function insertField(sheetId: string, fieldId: string, type = 'link', property = '{}'): Promise<void> {
+  await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+    fieldId, sheetId, fieldId, type, property, seq,
+  ])
+}
+async function insertRecord(sheetId: string, recordId: string, data: Record<string, unknown>, version = 1): Promise<void> {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [recordId, sheetId, JSON.stringify(data), version])
+}
+async function insertLink(fieldId: string, recordId: string, foreignRecordId: string): Promise<void> {
+  await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [fieldId, recordId, foreignRecordId])
+}
+
+/** D is a delete-candidate under reset-to-T1 (created at T2, after T1): live row + a lone create
+ * revision after T1. N (on SHEET_B) points at D through link field F. */
+async function fixture(tag: string): Promise<{ F: string; D: string; N: string }> {
+  const F = mkFieldId(tag)
+  await insertField(SHEET_B, F)
+  const D = mkRecordId(`${tag}d`)
+  await insertRecord(SHEET_A, D, { [NAME]: 'newbie' })
+  await rev(SHEET_A, D, 1, 'create', { [NAME]: 'newbie' }, T2)
+  const N = mkRecordId(`${tag}n`)
+  await insertRecord(SHEET_B, N, { [F]: [D] })
+  await insertLink(F, N, D)
+  return { F, D, N }
+}
+
+describeIfDatabase('4c-3 §7 (D-3) — PIT-reset inline delete inbound-link capture (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
+    process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS = '50'
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RIC Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_A, BASE, 'RIC A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_B, BASE, 'RIC B'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET_A, 'Name', 'string', '{}', 0])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    process.env[RESET_FLAG] = 'true'
+    process.env[CAPTURE_FLAG] = 'true'
+  })
+
+  afterAll(async () => {
+    delete process.env[RESET_FLAG]
+    delete process.env[CAPTURE_FLAG]
+    delete process.env[INBOUND_FLAG]
+    delete process.env[CAP_ROWS_FLAG]
+    delete process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS
+    for (const sheet of [SHEET_A, SHEET_B]) {
+      await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
+    }
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  afterEach(() => {
+    delete process.env[INBOUND_FLAG]
+    delete process.env[CAP_ROWS_FLAG]
+    process.env[CAPTURE_FLAG] = 'true'
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('(a) happy path: reset-execute captures the inbound tombstone anchored to the trash delete_revision_id; restore replays it', async () => {
+    const { F, D, N } = await fixture('a')
+    expect(await edgeCount(F, N, D)).toBe(1) // baseline: the edge exists before reset
+
+    const pv = await resetPreview()
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.deleteRecordIds).toEqual([D])
+    const ex = await resetExecute(pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200)
+    expect(ex.body?.data?.deletedCount).toBe(1)
+
+    // D is soft-deleted (recycle bin), edge destroyed, tombstone captured under the SAME anchor.
+    expect(await recordRow(D)).toBeUndefined()
+    expect(await edgeCount(F, N, D)).toBe(0)
+    const trashRow = (await q('SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1', [D])).rows[0] as { delete_revision_id: string | null }
+    expect(trashRow.delete_revision_id).toBeTruthy()
+    const tombstone = await q(
+      `SELECT field_id, record_id, foreign_record_id FROM meta_link_tombstones
+        WHERE source_revision_id = $1::uuid AND reason = 'record_delete'`,
+      [trashRow.delete_revision_id],
+    )
+    expect(tombstone.rows).toEqual([{ field_id: F, record_id: N, foreign_record_id: D }])
+
+    // Full round trip: restore (flag on) replays the captured edge.
+    process.env[INBOUND_FLAG] = 'true'
+    const restore = await httpRestore(D)
+    expect(restore.status).toBe(200)
+    expect(restore.body?.data?.inbound).toMatchObject({ replayed: 1, recoverable: true })
+    expect(await edgeCount(F, N, D)).toBe(1)
+  })
+
+  test('(b) cap breach: 2 inbound edges > MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS=1 → 422 TOMBSTONE_CAPTURE_CAP_EXCEEDED, WHOLE reset rolled back', async () => {
+    const { F, D, N } = await fixture('b')
+    // A second neighbour pointing at D — 2 inbound edges total, exceeding the forced cap of 1.
+    // (resolveTombstoneCaptureMaxRows treats a non-positive override as "unset" and falls back to the
+    // 50000 default, so the cap must be crossed by row COUNT, not by a zero/negative override.)
+    const N2 = mkRecordId('b_n2')
+    await insertRecord(SHEET_B, N2, { [F]: [D] })
+    await insertLink(F, N2, D)
+    expect(await edgeCount(F, N, D)).toBe(1)
+    expect(await edgeCount(F, N2, D)).toBe(1)
+
+    // An unrelated revert candidate in the SAME sheet — proves the rollback is transaction-wide, not
+    // just the failing delete's own row.
+    const A = mkRecordId('b_a')
+    await insertRecord(SHEET_A, A, { [NAME]: 'new' }, 2)
+    await rev(SHEET_A, A, 1, 'create', { [NAME]: 'old' }, T0)
+    await rev(SHEET_A, A, 2, 'update', { [NAME]: 'new' }, T2)
+
+    const pv = await resetPreview()
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.deleteRecordIds).toEqual(expect.arrayContaining([D]))
+
+    process.env[CAP_ROWS_FLAG] = '1' // D would capture 2 inbound rows > cap 1 → assertWithinCaptureCap throws
+    const ex = await resetExecute(pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(422)
+    expect(ex.body?.error?.code).toBe('TOMBSTONE_CAPTURE_CAP_EXCEEDED')
+
+    // Fail-closed, all-or-nothing: NOTHING written.
+    expect(await recordRow(D)).toBeTruthy() // D still LIVE, never soft-deleted
+    expect((await q('SELECT 1 FROM meta_records_trash WHERE record_id = $1', [D])).rows).toHaveLength(0)
+    expect(await edgeCount(F, N, D)).toBe(1) // the edges the cap-check was protecting are UNTOUCHED
+    expect(await edgeCount(F, N2, D)).toBe(1)
+    expect((await q("SELECT 1 FROM meta_link_tombstones WHERE reason = 'record_delete' AND foreign_record_id = $1", [D])).rows).toHaveLength(0) // no half-capture
+    const a = await recordRow(A)
+    expect(a?.data?.[NAME]).toBe('new') // the unrelated revert candidate was NOT reverted either — whole-txn rollback
+    expect(a?.version).toBe(2)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
@@ -10,6 +10,11 @@
  * RB12 (mutations) is executed OUTSIDE this file: each precondition in
  * `inbound-link-replay.ts` / the retention floor is neutered in src → exactly the matching golden
  * here goes red → precise revert. Recorded in the PR body.
+ *
+ * RB13/RB14 (R8 absorption-audit hardening, P3-3/NIT-3 — post-hoc, no product behaviour changed):
+ * both preconditions were ALREADY correctly implemented (precondition 2's `JOIN meta_records n` and
+ * the `recoverable: replay.total > 0` computation in record-service.ts) but had no dedicated golden.
+ * See `/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`.
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
@@ -294,5 +299,35 @@ describeIfDatabase('4c-3 — record-undelete inbound-edge replay (real DB, RB ma
     expect((await q('SELECT 1 FROM meta_records WHERE id = $1', [R])).rows).toHaveLength(1)
     expect((await q('SELECT 1 FROM meta_records_trash WHERE record_id = $1', [R])).rows).toHaveLength(0)
     expect(await edgeCount(F, N, R)).toBeLessThanOrEqual(1)
+  })
+
+  test('RB13 neighborGone: N hard-deleted inside the window — that edge is skipped (not a 23503/FK surprise), R restore still succeeds', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb13')
+    expect((await httpDelete(R)).status).toBe(200)
+    // Hard-delete the neighbour itself (no cascade concern: its inbound-owning meta_links row was
+    // already destroyed by R's delete above — this only removes N's own meta_records row).
+    await q('DELETE FROM meta_records WHERE id = $1', [N])
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound?.replayed).toBe(0)
+    expect(res.body?.data?.inbound?.skipped?.neighborGone).toBe(1)
+    expect(await edgeCount(F, N, R)).toBe(0) // N no longer exists — nothing to point at it
+  })
+
+  test('RB14 anchor present but ZERO tombstones (capture was OFF for this one delete): recoverable=false, zero replay, no error', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    process.env[CAPTURE_FLAG] = 'false' // capture off for THIS delete only — anchor still gets written (record-service always pre-generates it)
+    const { F, R, N } = await fixture('rb14')
+    expect((await httpDelete(R)).status).toBe(200)
+    process.env[CAPTURE_FLAG] = 'true' // restore the suite default before the restore call below
+    const trashRow = (await q('SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1', [R])).rows[0] as { delete_revision_id: string | null }
+    expect(trashRow.delete_revision_id).toBeTruthy() // anchor is unconditional — NOT gated by the capture flag
+    const tombstones = await q('SELECT 1 FROM meta_link_tombstones WHERE source_revision_id = $1::uuid', [trashRow.delete_revision_id])
+    expect(tombstones.rows).toHaveLength(0) // nothing was captured — capture was off at delete time
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.inbound).toMatchObject({ replayed: 0, recoverable: false }) // honest, not fabricated
+    expect(await edgeCount(F, N, R)).toBe(0)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
@@ -1,0 +1,201 @@
+/**
+ * 4c-3 §7 — PIT-resurrect (`POST /sheets/:id/revert-execute`, T8-1 undelete) inbound-edge replay (real
+ * DB). R8 absorption-audit hardening (P3-1, post-hoc — no product behaviour changed). PR #3975 wired
+ * resurrect to reuse the SAME `replayInboundLinks` helper restore uses (design-lock §7: "never a
+ * parallel inbound semantic"), but shipped with no dedicated golden for its anchor derivation, which
+ * — unlike restore's `meta_records_trash.delete_revision_id` column — is a HEURISTIC: resurrect has no
+ * trash row, so it anchors to the record's MOST RECENT 'delete' revision (`ORDER BY created_at DESC`).
+ *
+ * This file pins the two honest consequences of that heuristic (see the reworded comment at
+ * `univer-meta.ts` ~10165, which used to overclaim "deterministic"):
+ *   (A) multi-vintage: resurrecting an OLDER vintage's snapshot still anchors to the LATEST delete
+ *       revision — replaying only that vintage's captured edges, never stringing multiple anchors'
+ *       tombstones together (no cross-vintage double-replay).
+ *   (B) the most recent deletion happened while capture was off (zero tombstones for that anchor) →
+ *       silent zero replay, honest, never an error and never fabricated.
+ * Over-replay stays impossible in both cases regardless of which delete revision the heuristic picks,
+ * because precondition 6 (neighbour consent — replay only what N's OWN live data still declares) gates
+ * every edge independently of the anchor.
+ *
+ * Design-lock: `docs/development/multitable-global-history-4c3-record-undelete-2b-inbound-edge-replay-
+ * design-lock-20260708.md` §7. Audit: `/tmp/pr3975-4c3-absorption-audit-claude-20260709.md` (P3-1).
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { randomUUID } from 'node:crypto'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_rvi_${TS}`
+const SHEET_A = `sheet_rvi_a_${TS}` // resurrect target's sheet
+const SHEET_B = `sheet_rvi_b_${TS}` // neighbours' sheet (owns link field F)
+const NAME = `fld_rvi_name_${TS}`
+const ACTOR = `user_rvi_${TS}`
+const UNDELETE_FLAG = 'MULTITABLE_ENABLE_PIT_UNDELETE'
+const INBOUND_FLAG = 'MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND'
+const T0 = '2026-01-01T00:00:00.000Z'
+const T0_5 = '2026-01-01T12:00:00.000Z'
+const T1 = '2026-01-02T00:00:00.000Z'
+const T1_5 = '2026-01-02T12:00:00.000Z'
+const T2 = '2026-01-03T00:00:00.000Z'
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let seq = 0
+const mkFieldId = (tag: string) => `fld_rvi_${tag}_${TS}_${seq++}`
+const mkRecordId = (tag: string) => `rec_rvi_${tag}_${TS}_${seq++}`
+
+const preview = (asOf: string) => request(app).post(`/api/multitable/sheets/${SHEET_A}/revert-preview`).send({ asOf })
+const execute = (asOf: string, previewIdentity: string) => request(app).post(`/api/multitable/sheets/${SHEET_A}/revert-execute`).send({ asOf, previewIdentity, confirm: 'undelete' })
+const liveRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const edgeCount = async (fieldId: string, recordId: string, foreignId: string): Promise<number> =>
+  (await q('SELECT 1 FROM meta_links WHERE field_id=$1 AND record_id=$2 AND foreign_record_id=$3', [fieldId, recordId, foreignId])).rows.length
+async function insertField(sheetId: string, fieldId: string, type = 'link', property = '{}'): Promise<void> {
+  await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fieldId, sheetId, fieldId, type, property, seq])
+}
+async function insertRecord(sheetId: string, recordId: string, data: Record<string, unknown>): Promise<void> {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [recordId, sheetId, JSON.stringify(data)])
+}
+/** Records a revision AND (optionally) returns its freshly-minted id so a tombstone can anchor to it. */
+async function rev(sheetId: string, id: string, version: number, action: string, snap: Record<string, unknown>, at: string): Promise<string> {
+  const revId = randomUUID()
+  await q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES ($1,$2,$3,$4,$5,'rest',ARRAY[$6]::text[],'{}'::jsonb,$7::jsonb,$8)`,
+    [revId, sheetId, id, version, action, NAME, JSON.stringify(snap), at],
+  )
+  return revId
+}
+async function insertTombstone(sheetId: string, fieldId: string, neighborId: string, foreignId: string, sourceRevisionId: string): Promise<void> {
+  await q(
+    `INSERT INTO meta_link_tombstones (id, sheet_id, field_id, record_id, foreign_record_id, reason, source_revision_id, created_at)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, 'record_delete', $5::uuid, now())`,
+    [sheetId, fieldId, neighborId, foreignId, sourceRevisionId],
+  )
+}
+
+describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anchor (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
+    process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS = '50'
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RVI Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_A, BASE, 'RVI A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_B, BASE, 'RVI B'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET_A, 'Name', 'string', '{}', 0])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    process.env[UNDELETE_FLAG] = 'true'
+  })
+
+  afterAll(async () => {
+    delete process.env[UNDELETE_FLAG]
+    delete process.env[INBOUND_FLAG]
+    delete process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS
+    for (const sheet of [SHEET_A, SHEET_B]) {
+      await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
+    }
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  afterEach(() => { delete process.env[INBOUND_FLAG] })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('(A) multi-vintage: resurrecting an OLDER vintage anchors to the LATEST delete revision — replays ONLY that vintage, never strings anchors together', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const F = mkFieldId('a')
+    await insertField(SHEET_B, F)
+    const R = mkRecordId('a_r')
+    const N1 = mkRecordId('a_n1') // vintage-1 neighbour
+    const N2 = mkRecordId('a_n2') // vintage-2 neighbour
+    await insertRecord(SHEET_B, N1, { [F]: [R] })
+    await insertRecord(SHEET_B, N2, { [F]: [R] })
+
+    const SNAP_V1 = { [NAME]: 'vintage-1' }
+    const SNAP_V2 = { [NAME]: 'vintage-2' }
+    await rev(SHEET_A, R, 1, 'create', SNAP_V1, T0)
+    const del1 = await rev(SHEET_A, R, 2, 'delete', SNAP_V1, T1)
+    await insertTombstone(SHEET_A, F, N1, R, del1) // vintage-1's captured edge
+    await rev(SHEET_A, R, 3, 'create', SNAP_V2, T1_5) // "restore" — vintage 2 begins
+    const del2 = await rev(SHEET_A, R, 4, 'delete', SNAP_V2, T2)
+    await insertTombstone(SHEET_A, F, N2, R, del2) // vintage-2's captured edge
+
+    // Resurrect at T0_5 (between vintage-1's create and delete) → the OLD vintage's snapshot.
+    const pv = await preview(T0_5)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.undeleteRecordIds).toEqual([R])
+    const ex = await execute(T0_5, pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200)
+    expect(ex.body?.data?.resurrectedCount).toBe(1)
+
+    const live = await liveRow(R)
+    expect(live?.data?.[NAME]).toBe('vintage-1') // the OLD vintage's snapshot was indeed resurrected
+
+    // Anchor = latest delete revision (del2, vintage-2) — so vintage-2's neighbour replays...
+    expect(await edgeCount(F, N2, R)).toBe(1)
+    expect(ex.body?.data?.undeleteInbound).toMatchObject({ replayed: 1 })
+    // ...but vintage-1's neighbour does NOT — its tombstone lives under a DIFFERENT anchor (del1) that
+    // this resurrect never queries. This is the honest, pinned consequence of the heuristic: exactly
+    // one vintage's edges replay, never a cross-vintage union.
+    expect(await edgeCount(F, N1, R)).toBe(0)
+  })
+
+  test('(B) most recent deletion was uncaptured (zero tombstones for its anchor): silent zero replay, no error, resurrect still succeeds', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const F = mkFieldId('b')
+    await insertField(SHEET_B, F)
+    const R = mkRecordId('b_r')
+    const N = mkRecordId('b_n')
+    await insertRecord(SHEET_B, N, { [F]: [R] })
+
+    const SNAP = { [NAME]: 'uncaptured' }
+    await rev(SHEET_A, R, 1, 'create', SNAP, T0)
+    await rev(SHEET_A, R, 2, 'delete', SNAP, T2) // delete revision exists (anchor resolves)...
+    // ...but NO tombstone was ever inserted for it (simulates capture being OFF at delete time).
+
+    const pv = await preview(T1)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.undeleteRecordIds).toEqual([R])
+    const ex = await execute(T1, pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200) // resurrect itself is NOT blocked by an uncaptured/absent tombstone set
+    expect(ex.body?.data?.resurrectedCount).toBe(1)
+    expect(ex.body?.data?.undeleteInbound).toEqual({ replayed: 0, total: 0 }) // honest zero, not fabricated
+
+    const live = await liveRow(R)
+    expect(live?.data?.[NAME]).toBe('uncaptured')
+    expect(await edgeCount(F, N, R)).toBe(0) // nothing to replay — never invented
+  })
+
+  test('(C) flag OFF: resurrect succeeds but the response carries no undeleteInbound field at all (byte-identical to pre-4c-3)', async () => {
+    delete process.env[INBOUND_FLAG]
+    const F = mkFieldId('c')
+    await insertField(SHEET_B, F)
+    const R = mkRecordId('c_r')
+    const N = mkRecordId('c_n')
+    await insertRecord(SHEET_B, N, { [F]: [R] })
+    const SNAP = { [NAME]: 'flagoff' }
+    const del = await rev(SHEET_A, R, 1, 'create', SNAP, T0)
+    const delRev = await rev(SHEET_A, R, 2, 'delete', SNAP, T2)
+    await insertTombstone(SHEET_A, F, N, R, delRev)
+    void del
+
+    const pv = await preview(T1)
+    const ex = await execute(T1, pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200)
+    expect(ex.body?.data?.undeleteInbound).toBeUndefined()
+    expect(await edgeCount(F, N, R)).toBe(0) // today's (pre-4c-3) behavior: inbound stays lost on resurrect
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -125,6 +125,11 @@ export default defineConfig({
       // integration` in plugin-tests.yml (describeIfDatabase alone would skip-green here).
       'tests/integration/multitable-undelete-inbound-replay-realdb.test.ts',
       'tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts',
+      // 4c-3 §7 R8 absorption-audit hardening (P3-1/P3-2): PIT-resurrect inbound-replay anchor
+      // heuristic goldens + PIT-reset inline-delete inbound-capture goldens. Real Postgres only —
+      // whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
+      'tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts',
+      'tests/integration/multitable-reset-pit-inbound-capture-realdb.test.ts',
       // W6 full-HTTP-path approve->resume seam: mounts authRouter + approvalsRouter on an
       // ephemeral port against real Postgres, so it is excluded from the default run and wired
       // into the dedicated `Run multitable real-DB integration` job in plugin-tests.yml.


### PR DESCRIPTION
## Summary

Absorption-audit judgment for PR #3975 (4c-3 record-undelete inbound-edge replay, Option A) was **APPROVE, 0 P1 / 0 P2** (`/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`). This PR closes the remaining P3/NIT coverage gaps the audit flagged — **test-only + one comment reword, no product behaviour changed**. Baseline = `origin/main` at `100b6dd59` (#3975 merged) + D-1 (#3969/#3977, already landed).

## Per-item mapping + evidence

1. **P3-2 (D-3 PIT-reset capture golden)** — `multitable-reset-pit-inbound-capture-realdb.test.ts`: (a) happy path — reset-execute captures the inbound tombstone under the SAME pre-generated `delete_revision_id` written to `meta_records_trash`; a subsequent restore replays it (full round trip). (b) cap breach (2 inbound edges > `MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS=1`) → 422 `TOMBSTONE_CAPTURE_CAP_EXCEEDED`, WHOLE reset rolled back (delete target stays live, an unrelated revert candidate in the same sheet stays unreverted, neighbour edges untouched). Mutation-verified: commenting out `insertInboundLinkTombstones` reds (a) only; commenting out `assertWithinCaptureCap` reds (b) only.

2. **P3-1 (PIT-resurrect golden + honesty, no behaviour change)** — `multitable-undelete-inbound-resurrect-realdb.test.ts`: (A) multi-vintage — resurrecting an OLDER vintage's snapshot still anchors to the LATEST delete revision, replaying only that one vintage's edges, never stringing anchors together. (B) most recent deletion uncaptured → silent zero replay, honest, no error. (C) flag off → no `undeleteInbound` field at all. The resurrect response's aggregate `undeleteInbound: { replayed, total }` signal **already existed** in #3975 (`univer-meta.ts:10139,10233`) — this PR only adds the golden asserting on it, per the "if cheap, add" instruction; no response-shape change was needed. Also reworded the "deterministic" code comment (`univer-meta.ts:10165-10182`) to honestly describe the heuristic (no trash row for resurrect → anchors to the record's most-recent delete revision; under-replay possible on multi-vintage/uncaptured churn; over-replay impossible because precondition 6 gates independently of the anchor). Mutation-verified: flipping the anchor `ORDER BY` to ASC reds (A) only; dropping the flag guard on the response field reds (C) only.

3. **P3-3 (neighborGone golden)** — RB13 in `multitable-undelete-inbound-replay-realdb.test.ts`: neighbour hard-deleted inside the trash window → edge skipped (not a 23503 surprise), restore succeeds. Mutation-verified: removing the diag CASE's `neighborGone` branch reds RB13.

4. **NIT-3 (anchor-present-zero-tombstone golden)** — RB14 in the same file: `delete_revision_id` non-null but zero captured tombstones (capture flag off for that one delete) → `recoverable=false`, zero replay, no error. Mutation-verified: hardcoding `recoverable: true` in `record-service.ts` reds RB14 only (RB2/RB9 stay green).

5. **NIT-4 (mutation matrix as committed tests)** — verified RB4/RB5/RB6/RB7/RB8/RB10 are already committed, already CI-wired (`plugin-tests.yml` real-DB run + `vitest.config.ts` exclude), and are already "structural guard" shaped (each golden's assertion only holds with its predicate in place) — independently re-confirmed all 6 mutations still red the matching golden. Nothing was missing; documented in the new as-built wave MD instead of adding a redundant mutation-runner file.

6. **NIT-doc** — design-lock flipped `PROPOSED` → `RATIFIED (owner 2026-07-09) + AS-BUILT #3975 100b6dd59`, forward-only §9 addendum recording the R8 additions without rewriting the original RB1-RB12 table. New `docs/development/multitable-global-history-4c3-impl-wave-verification-20260709.md`: landed content per §, audit's 6/6 mutation table, R8 hardening closure table, reachable boundary/flag state, honest remaining gaps.

7. **D-1 gap-audit row** — checked: already marked landed (#3969/#3977) in `…destruction-path-coverage-gap-audit-20260708.md`; no change needed.

## Rebase note: parallel PR #3983 (merged during this PR's development)

While this branch was in progress, PR #3983 (`test+docs(multitable): O-2 preconditions — resurrect-path goldens (P3-2) + operator flag ladder (P3-3)`) merged to main. It closes an **overlapping-but-complementary** gap from a *different* review of #3975 (its own adversarial review, using its own P3-2/P3-3 numbering — not the independent post-hoc absorption audit this PR is based on). Both target the same underlying hole (PIT-resurrect anchor-selection coverage), but the goldens are not duplicates: #3983 covers single-vintage happy replay + Option A neighbour-declined on the resurrect surface; this PR covers multi-vintage anchor precision (only the latest vintage replays, never strung together) + an uncaptured-vintage silent-zero case, and reworks the "deterministic" comment. One test scenario (flag-off byte-identical) is now covered by both files — harmless overlap, not removed. Rebased onto the post-#3983 `origin/main`; the only conflicts were two trivial same-line insertions in `plugin-tests.yml` / `vitest.config.ts` (both entries kept). Full detail + evidence that both PRs are rebase-compatible (9 related real-DB files, 75/75 green together) is in the updated `docs/development/multitable-global-history-4c3-impl-wave-verification-20260709.md`.

## Not done (needs product-shape decision — recorded, not touched)

- Precise per-vintage resurrect anchoring (replacing the heuristic with a real anchor) — needs new storage/response schema.
- Per-edge resurrect skip detail (mirroring restore's `skipped.{fieldGone,...}`) — resurrect only aggregates `{replayed,total}` today; adding per-reason buckets changes response shape for existing callers.
- NIT-1/NIT-2/NIT-5 (drift-tripwire precision, single-statement NOT EXISTS theoretical double, `listDeletedRecords` SELECT * / doc-comment enumeration) — audit-labelled low-risk/theoretical, outside this round's P3/NIT golden list.

## Verification

- realdb (one-off docker `postgres:16`, ephemeral high port, removed after use): all new + neighbour files green together — `multitable-undelete-inbound-replay-realdb` (14/14), `multitable-reset-pit-inbound-capture-realdb` (3/3), `multitable-undelete-inbound-resurrect-realdb` (4/4), plus 7 neighbour real-DB files (reset-pit, undelete-pit, revert-pit, d1-delete-revision-parity, record-reconstructor, tombstone-record-capture, tombstone-retention) — 83/83 total, no fixture collisions (namespaced by file prefix + timestamp).
- Every new golden is mutation-verified fail-first (neuter → red → revert → green), evidence in commit messages.
- `tsc --noEmit`: clean.
- rank-8 structural guards (`multitable-record-lock-guard.guard.test.ts`, `multitable-cross-base-write-guard.guard.test.ts`): 9/9 green.
- CI: both new realdb files UNION'd into `plugin-tests.yml`'s real-DB run + `vitest.config.ts` exclude list (same precedent as the existing 4c-3 RB matrix file).
- `git diff origin/main...HEAD -- packages/core-backend/src` shows exactly one production-source diff: the comment reword in `univer-meta.ts` (no logic change).

## Test plan

- [x] realdb goldens green (see above)
- [x] mutation fail-first evidence for every new golden
- [x] tsc --noEmit clean
- [x] rank-8 guards green
- [x] CI wiring (plugin-tests.yml + vitest.config.ts)
- [ ] Not merging / not arming auto-merge — main session reviews and lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
