### PR TITLE
feat(web): stock-prep MVP view 1 — readonly Project Workspace

### DIFF
--- a/apps/web/src/components/integration/stockPreparation/StockPreparationProjectWorkspaceView.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationProjectWorkspaceView.vue
@@ -1,0 +1,235 @@
+<template>
+  <div class="sp-project" data-testid="stock-prep-project-workspace">
+    <!-- Loading: values-free spinner copy only. -->
+    <p
+      v-if="loading"
+      class="sp-project__state sp-project__state--muted"
+      data-testid="stock-prep-project-loading"
+      role="status"
+    >
+      {{ bi('正在加载项目概览…', 'Loading project overview…') }}
+    </p>
+
+    <!-- Error / endpoint-not-ready (GET rejects or 404s): neutral, non-alarming, never the raw body. -->
+    <p
+      v-else-if="errored"
+      class="sp-project__state sp-project__state--muted"
+      data-testid="stock-prep-project-error"
+      role="status"
+    >
+      {{ bi('同步后端尚未就绪,稍后再试。', 'Backend read not ready yet — try again later.') }}
+    </p>
+
+    <!-- Empty: no projects have been synced yet. -->
+    <p
+      v-else-if="isEmpty"
+      class="sp-project__state sp-project__state--muted"
+      data-testid="stock-prep-project-empty"
+    >
+      {{ bi('尚无已同步项目。', 'No projects synced yet.') }}
+    </p>
+
+    <!-- Data: values-free summary + per-project rows. -->
+    <div v-else-if="overview" class="sp-project__overview" data-testid="stock-prep-project-overview">
+      <header class="sp-project__summary" data-testid="stock-prep-project-summary">
+        <span class="sp-project__summary-count">
+          {{ bi('已同步项目', 'Synced projects') }}: {{ overview.projectCount }}
+        </span>
+        <span
+          v-for="entry in statusEntries"
+          :key="entry.status"
+          class="sp-project__summary-chip"
+          data-testid="stock-prep-project-status-chip"
+        >
+          {{ entry.status }}: {{ entry.count }}
+        </span>
+      </header>
+
+      <div class="sp-project__table-wrap">
+        <table class="sp-project__table">
+          <thead>
+            <tr>
+              <th scope="col">{{ bi('项目状态', 'Project status') }}</th>
+              <th scope="col">{{ bi('快照批次数', 'Snapshot batches') }}</th>
+              <th scope="col">{{ bi('待处理异常', 'Open exceptions') }}</th>
+              <th scope="col">{{ bi('就绪备料行', 'Ready lines') }}</th>
+              <th scope="col">{{ bi('暂挂备料行', 'Held lines') }}</th>
+              <th scope="col">{{ bi('最近同步运行', 'Last sync run') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="project in overview.projects"
+              :key="project.projectId"
+              class="sp-project__row"
+              data-testid="stock-prep-project-row"
+            >
+              <td>
+                <span class="sp-project__status" data-testid="stock-prep-project-status">
+                  {{ project.projectStatus }}
+                </span>
+              </td>
+              <td class="sp-project__num">{{ project.snapshotBatchCount }}</td>
+              <td class="sp-project__num">{{ project.openExceptionCount }}</td>
+              <td class="sp-project__num">{{ project.readyLineCount }}</td>
+              <td class="sp-project__num">{{ project.heldLineCount }}</td>
+              <td>
+                <code class="sp-project__handle" data-testid="stock-prep-project-run-handle">{{
+                  project.lastSyncRunId ?? '—'
+                }}</code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md),
+// Frontend MVP view 1: PROJECT WORKSPACE, rendered inside the workspace shell's first tab.
+//
+// READONLY: this view only GETs the values-free per-project overview through the landed service
+// stub. It has no write path, issues no method override, and never triggers ERP/K3 writes.
+//
+// VALUES-FREE: it renders ONLY counts / status enums and an internal MetaSheet navigation handle
+// (lastSyncRunId). It deliberately does NOT render projectId as a visible column, nor any customer
+// business value — no drawing numbers, material codes, quantities, project names, hosts, tenants,
+// or credentials — because the overview shape carries none and the template reads a fixed whitelist.
+import { computed, onMounted, ref } from 'vue'
+import { useLocale } from '../../../composables/useLocale'
+import type { IntegrationScope } from '../../../services/integration/workbench'
+import {
+  getStockPreparationWorkspaceOverview,
+  type StockPreparationWorkspaceOverview,
+} from '../../../services/integration/stockPreparation/projectWorkspace'
+
+const props = withDefaults(
+  defineProps<{
+    /** Optional tenant/workspace scope passed straight through to the readonly GET. */
+    scope?: IntegrationScope
+  }>(),
+  { scope: () => ({}) },
+)
+
+const { locale } = useLocale()
+
+// Same synchronous locale idiom as the shell / the rest of the integration surface.
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+const loading = ref(true)
+const errored = ref(false)
+const overview = ref<StockPreparationWorkspaceOverview | null>(null)
+
+const isEmpty = computed(() => overview.value !== null && overview.value.projectCount === 0)
+
+const statusEntries = computed(() =>
+  Object.entries(overview.value?.statusCounts ?? {}).map(([status, count]) => ({ status, count })),
+)
+
+async function load(): Promise<void> {
+  loading.value = true
+  errored.value = false
+  try {
+    overview.value = await getStockPreparationWorkspaceOverview(props.scope)
+  } catch {
+    // 404-soft: the backend read route may not exist yet. Surface a neutral, non-alarming state
+    // and NEVER the raw error body.
+    errored.value = true
+    overview.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.sp-project {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+}
+
+.sp-project__state {
+  margin: 0;
+  padding: var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-page);
+  line-height: 1.6;
+}
+
+.sp-project__state--muted {
+  color: var(--ms-text-3);
+}
+
+.sp-project__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ms-space-2);
+}
+
+.sp-project__summary-count {
+  color: var(--ms-text-1);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.sp-project__summary-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+  font-size: 12px;
+}
+
+.sp-project__table-wrap {
+  overflow-x: auto;
+}
+
+.sp-project__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.sp-project__table th,
+.sp-project__table td {
+  padding: var(--ms-space-2) var(--ms-space-3);
+  border-bottom: 1px solid var(--ms-border-light);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.sp-project__table th {
+  color: var(--ms-text-3);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.sp-project__num {
+  color: var(--ms-text-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.sp-project__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+  font-size: 12px;
+}
+
+.sp-project__handle {
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+</style>

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationWorkspace.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationWorkspace.vue
@@ -48,7 +48,9 @@
         <span class="stock-prep__badge">{{ bi('只读', 'readonly') }} · GET</span>
         <code>{{ activeView.endpoint }}</code>
       </p>
-      <p class="stock-prep__panel-pending" data-testid="stock-prep-panel-pending">
+      <!-- View 1 (project-workspace) is a real readonly view; the other five tabs keep the placeholder. -->
+      <StockPreparationProjectWorkspaceView v-if="activeKey === 'project-workspace'" />
+      <p v-else class="stock-prep__panel-pending" data-testid="stock-prep-panel-pending">
         {{ bi('该视图将在后续 wave 落地,当前为容器占位。', 'This view lands in a later wave; this is a container placeholder for now.') }}
       </p>
     </section>
@@ -69,6 +71,7 @@ import { computed, ref } from 'vue'
 import { useLocale } from '../../../composables/useLocale'
 import PageShell from '../../layout/PageShell.vue'
 import PageHeader from '../../layout/PageHeader.vue'
+import StockPreparationProjectWorkspaceView from './StockPreparationProjectWorkspaceView.vue'
 
 const { locale } = useLocale()
 

--- a/apps/web/tests/StockPreparationProjectWorkspaceView.spec.ts
+++ b/apps/web/tests/StockPreparationProjectWorkspaceView.spec.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, ref, type App as VueApp, type Component } from 'vue'
+
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md).
+// Frontend MVP view 1: the readonly PROJECT WORKSPACE view. Covers the loading → data render,
+// empty, and error/404-soft states, and pins the values-free contract: the view renders only
+// counts / status enums / an internal run handle, never a customer business value, and never the
+// raw error body. Mirrors the shell spec's mocking idiom (vi.hoisted holder + mocked locale).
+
+const h = vi.hoisted(() => ({
+  locale: 'zh-CN' as string,
+  getOverview: vi.fn(),
+}))
+
+vi.mock('../src/composables/useLocale', () => ({
+  useLocale: () => ({
+    locale: ref(h.locale),
+    isZh: ref(h.locale === 'zh-CN'),
+    setLocale: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/services/integration/stockPreparation/projectWorkspace', () => ({
+  getStockPreparationWorkspaceOverview: h.getOverview,
+}))
+
+import StockPreparationProjectWorkspaceView from '../src/components/integration/stockPreparation/StockPreparationProjectWorkspaceView.vue'
+import type { StockPreparationWorkspaceOverview } from '../src/services/integration/stockPreparation/projectWorkspace'
+
+// Business values planted as EXTRA fields on the mocked rows. A values-free view must render NONE
+// of them — proving it reads a fixed whitelist rather than stringifying the row.
+const PLANTED_DRAWING_NO = 'DWG-88472-A'
+const PLANTED_MATERIAL_CODE = 'MAT-ZX9911'
+const PLANTED_PROJECT_NAME = '涡轮增压器总成'
+const PLANTED_QUANTITY = '73920'
+const FORBIDDEN = [PLANTED_DRAWING_NO, PLANTED_MATERIAL_CODE, PLANTED_PROJECT_NAME, PLANTED_QUANTITY]
+
+function overviewWithPlantedExtras(): StockPreparationWorkspaceOverview {
+  // lastSyncRunId is intentionally digit-free so a stray digit guard cannot false-positive on it.
+  return {
+    projectCount: 2,
+    statusCounts: { active: 1, paused: 1 },
+    projects: [
+      {
+        projectId: 'proj-alpha',
+        projectStatus: 'active',
+        lastSyncRunId: 'sync-run-alpha',
+        snapshotBatchCount: 4,
+        openExceptionCount: 1,
+        readyLineCount: 12,
+        heldLineCount: 3,
+        // Planted business values (not part of the type) — must never reach the DOM.
+        drawingNo: PLANTED_DRAWING_NO,
+        materialCode: PLANTED_MATERIAL_CODE,
+        projectName: PLANTED_PROJECT_NAME,
+        quantity: PLANTED_QUANTITY,
+      },
+      {
+        projectId: 'proj-beta',
+        projectStatus: 'paused',
+        lastSyncRunId: null,
+        snapshotBatchCount: 0,
+        openExceptionCount: 0,
+        readyLineCount: 0,
+        heldLineCount: 0,
+      },
+    ],
+  } as unknown as StockPreparationWorkspaceOverview
+}
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('StockPreparationProjectWorkspaceView (readonly, values-free)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    h.locale = 'zh-CN'
+    h.getOverview.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  function mountView(): HTMLDivElement {
+    app = createApp(StockPreparationProjectWorkspaceView as Component)
+    app.mount(container!)
+    return container!
+  }
+
+  it('shows the loading state before the readonly GET settles, then renders the data view', async () => {
+    let resolveOverview!: (value: StockPreparationWorkspaceOverview) => void
+    h.getOverview.mockReturnValue(
+      new Promise<StockPreparationWorkspaceOverview>((resolve) => {
+        resolveOverview = resolve
+      }),
+    )
+
+    const root = mountView()
+    await nextTick()
+    // Pending: loading indicator only, no data/empty/error.
+    expect(root.querySelector('[data-testid="stock-prep-project-loading"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-project-overview"]')).toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-project-error"]')).toBeNull()
+
+    resolveOverview(overviewWithPlantedExtras())
+    await flushUi()
+
+    // Settled: data view, loading gone.
+    expect(root.querySelector('[data-testid="stock-prep-project-loading"]')).toBeNull()
+    const overview = root.querySelector('[data-testid="stock-prep-project-overview"]')
+    expect(overview).not.toBeNull()
+
+    const rows = root.querySelectorAll('[data-testid="stock-prep-project-row"]')
+    expect(rows.length).toBe(2)
+
+    // Values-free fields DO render: status enum, counts, and the internal run handle.
+    const text = root.textContent || ''
+    expect(text).toContain('active')
+    expect(text).toContain('paused')
+    expect(text).toContain('sync-run-alpha')
+    expect(text).toContain('12') // readyLineCount
+    // Header summary carries projectCount + statusCounts.
+    expect(root.querySelector('[data-testid="stock-prep-project-summary"]')?.textContent).toContain('2')
+
+    // Values-free guard: no planted business value ever reaches the DOM.
+    for (const forbidden of FORBIDDEN) {
+      expect(text).not.toContain(forbidden)
+    }
+    // The GET was issued exactly once (readonly, no write retry loop).
+    expect(h.getOverview).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the empty state when no projects are synced yet', async () => {
+    h.getOverview.mockResolvedValue({ projectCount: 0, statusCounts: {}, projects: [] })
+    const root = mountView()
+    await flushUi()
+
+    expect(root.querySelector('[data-testid="stock-prep-project-empty"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-project-overview"]')).toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-project-error"]')).toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-project-loading"]')).toBeNull()
+  })
+
+  it('renders a neutral error state when the GET rejects (404-soft), never the raw error body', async () => {
+    const rawBody = 'connectionString=host=erp;pwd=secret-42007;'
+    h.getOverview.mockRejectedValue(new Error(`404 Not Found ${rawBody}`))
+    const root = mountView()
+    await flushUi()
+
+    const errorEl = root.querySelector('[data-testid="stock-prep-project-error"]')
+    expect(errorEl).not.toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-project-overview"]')).toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-project-loading"]')).toBeNull()
+
+    // The raw error body (status text, connection string, secret) must NOT be surfaced.
+    const text = root.textContent || ''
+    expect(text).not.toContain(rawBody)
+    expect(text).not.toContain('secret')
+    expect(text).not.toContain('404')
+    expect(text).not.toMatch(/\d{5,}/)
+  })
+
+  it('renders the English neutral error copy when locale is not zh-CN', async () => {
+    h.locale = 'en'
+    h.getOverview.mockRejectedValue(new Error('boom'))
+    const root = mountView()
+    await flushUi()
+    const errorEl = root.querySelector('[data-testid="stock-prep-project-error"]') as HTMLElement
+    expect(errorEl).not.toBeNull()
+    expect(errorEl.textContent).toMatch(/not ready/i)
+  })
+})


### PR DESCRIPTION
## What

Fleshes out the FIRST tab (`project-workspace`) of the stock-preparation MVP shell (#3751) into a real, **readonly** view. The other five tabs keep their generic placeholder.

New `StockPreparationProjectWorkspaceView.vue` GETs the values-free project overview on mount via the existing `getStockPreparationWorkspaceOverview` service stub and renders four states, all values-free:

- **loading** — `stock-prep-project-loading`
- **error / endpoint-not-ready** — neutral copy ("同步后端尚未就绪 / backend read not ready yet"), `stock-prep-project-error`. The backend read route may **404 until a later wave lands**, so the rejected GET is caught and shown as a soft, non-alarming state; the raw error body is never surfaced.
- **empty** (`projectCount === 0`) — `stock-prep-project-empty`
- **data** — a `projectCount` + `statusCounts` summary and one row per project (`stock-prep-project-row`) showing ONLY counts / status enums and the internal `lastSyncRunId` handle.

## Guarantees

- **Readonly only.** No write path, no POST/PUT/PATCH/DELETE, no method override on `apiFetch`. The view only GETs through the existing service.
- **Values-free.** Renders only counts / status enums / an internal run handle. No drawing numbers, material codes, quantities, project names, hosts, tenants, or credentials. `projectId` is used as the `v-for` key only, never rendered as a visible column.
- Shell mount is a **minimal additive edit** (`v-if="activeKey === 'project-workspace'"`); every existing test-id (`stock-prep-boundary`, `stock-prep-tabs`, `stock-prep-tab-*`, `stock-prep-panel`, `stock-prep-panel-endpoint`, `stock-prep-desc-*`) is preserved. Only the `project-workspace` tab's placeholder is replaced.

## Tests

- New `StockPreparationProjectWorkspaceView.spec.ts`: loading→data render, empty, error/404-soft (asserts no raw error body / secret leaks), plus a planted-business-value forbidden-substring guard proving the view reads a fixed whitelist rather than stringifying rows.
- Existing `StockPreparationWorkspace.spec.ts` stays green (17 tests). Combined: 21 passing.
- `vue-tsc -b` clean.

Mocked-service tested; endpoint is 404-soft until the backend read route lands. Refs #3751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)