### PR TITLE
ci: run required checks for merge queue

### DIFF
--- a/.github/workflows/attendance-gate-contract-matrix.yml
+++ b/.github/workflows/attendance-gate-contract-matrix.yml
@@ -2,6 +2,8 @@ name: Attendance Gate Contract Matrix
 
 on:
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
   schedule:
     # Nightly contract regression after attendance gates complete.
     - cron: '45 4 * * *'

--- a/.github/workflows/phase5-validate.yml
+++ b/.github/workflows/phase5-validate.yml
@@ -1,6 +1,8 @@
 name: Phase 5 PR Validation (External Metrics Gate)
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -2,6 +2,8 @@ name: Plugin System Tests
 
 on:
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main, develop]
     paths:

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -18,6 +18,8 @@
 name: Web Tests
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     branches: [main, develop]
   push:


### PR DESCRIPTION
## Summary
- add merge_group checks_requested triggers to every workflow that currently produces a required branch-protection context
- cover Plugin System Tests, Phase 5 PR Validation, Attendance Gate Contract Matrix, and Web Tests

## Why
Merge queue creates merge_group commits. Required checks must run for that event before the repository merge queue setting can be enabled safely; otherwise queued PRs can hang waiting for contexts that never appear.

## Verification
- ruby YAML load across the four touched workflows
- git diff --check