### PR TITLE
fix(attendance): export resetAttendanceSettingsCacheForTests top-level so the harness reset runs

### DIFF
--- a/packages/core-backend/tests/unit/attendance-settings-cache-reset-export.spec.ts
+++ b/packages/core-backend/tests/unit/attendance-settings-cache-reset-export.spec.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// The attendance integration harness resets the plugin's 60s settings cache in
+// beforeEach via `getAttendancePluginForTest().resetAttendanceSettingsCacheForTests?.()`
+// (attendance-plugin.test.ts). That helper used to be exported ONLY nested under
+// __attendanceReportFieldCatalogForTests, so the TOP-LEVEL optional call silently
+// no-op'd and the 60s settings cache leaked across the shared attendance suite.
+// This locks the export at the top level of module.exports so the beforeEach
+// reset actually runs. A source assertion (not a module-load one) — the plugin
+// is a large CJS module and asserting its shape via require is flaky across the
+// forks pool's multi-file runs.
+const source = readFileSync(resolve(__dirname, '../../../../plugins/plugin-attendance/index.cjs'), 'utf8')
+
+describe('attendance settings-cache reset export (top-level, so the harness reset is not a no-op)', () => {
+  it('exports resetAttendanceSettingsCacheForTests at the top level of module.exports', () => {
+    const exportsStart = source.indexOf('module.exports = {')
+    expect(exportsStart, 'module.exports block').toBeGreaterThan(-1)
+    // the first nested test bag (a 2-space `  __attendance…ForTests: {` KEY, not a
+    // mention inside a comment) begins the nested region; the top-level entry must
+    // appear before it.
+    const firstNestedBag = source.indexOf('\n  __attendance', exportsStart)
+    const topLevelExport = source.indexOf('\n  resetAttendanceSettingsCacheForTests,', exportsStart)
+    expect(firstNestedBag, 'first nested __attendance…ForTests key').toBeGreaterThan(-1)
+    expect(topLevelExport, 'top-level `resetAttendanceSettingsCacheForTests,` in module.exports').toBeGreaterThan(-1)
+    expect(topLevelExport).toBeLessThan(firstNestedBag)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-settings-cache-reset-export.spec.ts
+++ b/packages/core-backend/tests/unit/attendance-settings-cache-reset-export.spec.ts
@@ -11,7 +11,9 @@ import { describe, expect, it } from 'vitest'
 // reset actually runs. A source assertion (not a module-load one) — the plugin
 // is a large CJS module and asserting its shape via require is flaky across the
 // forks pool's multi-file runs.
-const source = readFileSync(resolve(__dirname, '../../../../plugins/plugin-attendance/index.cjs'), 'utf8')
+// Normalize CRLF → LF so the '\n  …' anchors below hold regardless of the
+// checkout's line endings (review NIT).
+const source = readFileSync(resolve(__dirname, '../../../../plugins/plugin-attendance/index.cjs'), 'utf8').replace(/\r\n/g, '\n')
 
 describe('attendance settings-cache reset export (top-level, so the harness reset is not a no-op)', () => {
   it('exports resetAttendanceSettingsCacheForTests at the top level of module.exports', () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -20528,6 +20528,12 @@ async function isApproverAllowed(db, userId, step, logger) {
 }
 
 module.exports = {
+  // Top-level so the integration harness's
+  // getAttendancePluginForTest().resetAttendanceSettingsCacheForTests?.() (in
+  // attendance-plugin.test.ts beforeEach) actually runs — it was previously only
+  // exported nested one bag down, so the top-level optional call silently no-op'd
+  // and the 60s settings cache leaked across tests in the shared attendance suite.
+  resetAttendanceSettingsCacheForTests,
   __attendanceLeaveCancellationForTests: {
     reverseLeaveBalanceDeduction,
   },


### PR DESCRIPTION
owner-点名的单独一刀(#3982 审阅时你我都确认的 latent harness bug)。

`attendance-plugin.test.ts` 的 beforeEach 用 `getAttendancePluginForTest().resetAttendanceSettingsCacheForTests?.()` 重置插件 60s settings 缓存,但该 helper **只嵌套导出**在 `__attendanceReportFieldCatalogForTests` 下 → 顶层 optional call **静默 no-op**,settings 缓存跨 10-文件考勤套件泄漏(正是 beforeEach 想防的那个 flaky 来源;写 #3982 的 S1 legacy-row 测试时挖出)。

修 = 顶层加该导出(嵌套导出保留,comprehensive-hours 的 `helpers.*` 路径不变)。测试用**确定性 readFileSync 源码断言**(require-based shape 检查在 forks pool 多文件 run 下 flaky)锁"导出在顶层、位于首个 `__attendance…ForTests` 嵌套袋之前"。

验证:attendance-plugin **154/154** reset 现在真运行(无测试依赖泄漏)· comprehensive-hours 44/44 不受影响 · co-load 3 spec 56/56 无 flaky · mutation(删顶层导出→源码断言红)。

审阅:opus 对抗审阅过 0 P1/P2 再合(低风险:1 导出行 + 源码断言测试)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
