### PR TITLE
docs(approval): record DingTalk A5 UAT and Slice B lock

### DIFF
--- a/docs/development/approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md
+++ b/docs/development/approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md
@@ -1,0 +1,202 @@
+# 审批钉钉互动卡 Slice B · DESIGN-LOCK — 2026-07-09
+
+> Status: **PROPOSED**. This document is a runtime design lock, not an implementation PR.
+> It opens only because Slice A A-5 has PASS evidence in
+> `approval-dingtalk-one-tap-a5-verification-20260705.md` §4.1.
+> Runtime B-1..B-4 still require owner ratification of this design-lock.
+
+## 1. Goal
+
+Slice A proved the action-card path:
+
+`approval.task_created -> send_dingtalk_approval_card -> /m/approval-decision -> card-delivery wrapper -> approval action`.
+
+Slice B removes the remaining extra page hop for the common happy path:
+
+- Approve from the DingTalk card itself.
+- Keep reject on the Slice A decision page, because reject comment is mandatory and card input widgets are not a discipline we want to bet on for v1.
+- Update the same card to a terminal state after action, so repeated clicks converge to the current truth instead of creating parallel UI states.
+
+## 2. Non-negotiable invariants inherited from Slice A
+
+| Invariant | Slice B rule |
+|---|---|
+| Ledger-only anchor | `outTrackId` is exactly `dingtalk_approval_card_deliveries.id`; callback payload instance ids, sheet ids, form values, or amounts are ignored. |
+| Unified action path | Callback execution must call `executeApprovalActionFromCardDelivery`; it must not call raw `/api/approvals/:id/actions` or duplicate approval-engine gates. |
+| Identity fail-closed | DingTalk callback actor is accepted only after platform verification and active local-user mapping. Unmapped users get no action. |
+| Values-free cards | Card body and callback handling must not carry form field values. Summary stays title/request/node/status level. |
+| Idempotency | `card_state='sent' AND send_status='sent'` remains the only actionable ledger state. Duplicate callbacks re-read and return the real terminal state. |
+| Audit | Successful actions still write `approval_records.metadata.channel='dingtalk_card'` and `cardDeliveryId=<delivery id>`. |
+
+## 3. Scope
+
+### In scope
+
+1. Stream-mode DingTalk interactive-card worker, env-gated and disabled by default.
+2. Interactive-card send/update helpers for approval cards only.
+3. Callback adapter from DingTalk Stream event to `executeApprovalActionFromCardDelivery`.
+4. Terminal card update after success, stale, duplicate, and fail-closed outcomes.
+5. Real-DB and mocked-Stream verification matrix.
+
+### Out of scope
+
+1. HTTP callback mode. Stream mode is the v1 channel because it avoids public inbound endpoints and IP allowlists.
+2. Inline reject comment collection. Reject button links to the existing Slice A page.
+3. Group approval cards.
+4. Feishu / WeCom adapters.
+5. Conversational keyword replies such as "agree".
+6. JSAPI `requestAuthCode` A-6 enhancement.
+
+## 4. Runtime shape
+
+### B-1 Stream worker
+
+Add an optional worker registered only when all required Stream settings are present and the explicit enable flag is on.
+
+Recommended env names:
+
+| Env | Meaning |
+|---|---|
+| `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=1` | Explicit opt-in. Missing or false means no worker registration and no noisy warning loop. |
+| `DINGTALK_INTERACTIVE_CARD_CLIENT_ID` | DingTalk Stream app client id, if distinct from the existing app key. |
+| `DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET` | DingTalk Stream app secret, read from env or secret store only. |
+| `DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID` | Interactive-card template id used by B-2 sends. |
+
+If the existing DingTalk internal app credentials are sufficient for the Stream SDK in the deployed environment, B-1 may resolve these from the current DingTalk config store. That must be an explicit implementation choice in the PR body, not an implicit fallback.
+
+Worker failure policy:
+
+- Missing config: disabled, values-free info log at startup.
+- SDK reconnects: delegated to DingTalk SDK.
+- Callback handler throw: values-free error log with reason code and delivery id only; no card payload, no form data.
+- Process shutdown: close Stream client if SDK exposes a close method.
+
+### B-2 Interactive-card send
+
+Add delivery kind `interactive_card` using the existing `dingtalk_approval_card_deliveries` table.
+
+Send flow:
+
+1. Resolve assignee DingTalk user id exactly as Slice A does.
+2. Insert ledger row first with `delivery_kind='interactive_card'`.
+3. Send interactive card with `outTrackId = delivery.id`.
+4. Store provider card/task identifiers if the API returns them. If no stable provider id exists, the ledger id remains the only internal anchor.
+5. On send failure, mark `send_status='failed'` with a redacted reason and leave `card_state='sent'` unreachable by `claimActed` because `send_status!='sent'`.
+
+Card content:
+
+- Title: approval title/request number.
+- Body: node name/status level only.
+- Buttons:
+  - `同意`: Stream callback action, decision `approve`.
+  - `驳回`: URL action to Slice A decision page, same signed `d`/`t` link shape.
+
+The card must not include form field values in v1.
+
+### B-3 Callback adapter
+
+Callback input accepted by business logic:
+
+```ts
+type DingTalkApprovalCardCallback = {
+  outTrackId: string
+  action: 'approve'
+  operatorDingTalkUserId: string
+}
+```
+
+Everything else in the DingTalk event is transport metadata. It may be logged only as values-free reason/category fields.
+
+Execution:
+
+1. Validate `outTrackId` is a UUID-shaped delivery id.
+2. Validate action is exactly `approve`; any other action is ignored with a terminal or no-op card update, never mapped heuristically.
+3. Resolve `operatorDingTalkUserId` to active linked local user.
+4. Call `executeApprovalActionFromCardDelivery(deliveryId, 'approve', { kind: 'dingtalk', dingtalkUserId })`.
+5. Convert the wrapper result to a card update.
+
+No raw `/actions` call is permitted. Add the same kind of static tripwire used by Slice A.
+
+### B-4 Card terminal update
+
+Card update is a presentation follow-up, not the source of truth. The source of truth remains the approval engine + ledger.
+
+Update outcomes:
+
+| Wrapper result | Card update |
+|---|---|
+| success approve | `已由 <display name> 同意 · <time>` |
+| stale / duplicate | current true terminal state from summary |
+| unmapped DingTalk user | `请先在网页端绑定钉钉后再处理` |
+| non-recipient / permission denied | `当前账号无权处理该审批` |
+| engine validation error | reason-coded failure copy, no values |
+| card update API failure after successful action | do not roll back the approval; log values-free error and let duplicate clicks converge through stale summary |
+
+Display names must come from server-side local user data, never from callback payload display text.
+
+## 5. Security and privacy fences
+
+1. **No payload trust**: Callback payload is not a source of instance, sheet, record, amount, or form data.
+2. **No existence oracle beyond card ownership**: Unknown delivery and invalid/unsupported callback should not disclose whether an approval instance exists.
+3. **No secret logging**: Stream credentials, signed deep-link tokens, and raw card payloads must not enter logs or docs.
+4. **No mixed-channel actor spoofing**: HTTP sessions cannot set `{ kind:'dingtalk' }`; Stream callbacks cannot set a local user id directly.
+5. **No state before engine success**: The ledger can be claimed only through the wrapper's action result discipline. If the approval action fails, the delivery must remain retryable unless the wrapper returns a true stale/terminal state.
+
+## 6. Verification plan
+
+### Unit / pure tests
+
+- Callback parser accepts only `approve` and UUID-shaped `outTrackId`.
+- Callback parser rejects unsupported actions without guessing.
+- Card renderer is values-free and omits form fields.
+- Static tripwire: callback code and card renderer do not import or contain raw `/api/approvals/:id/actions` path.
+
+### Real-DB tests
+
+- Linked recipient callback approves and writes `metadata.channel='dingtalk_card'` with the delivery id.
+- Duplicate callback returns terminal summary and writes exactly one approve record.
+- Unmapped DingTalk user fails closed and writes no approval record.
+- Mapped but non-assignee user is rejected by the approval engine and writes no approval record.
+- Pending/failed send rows are not actionable.
+- Reject button path remains Slice A URL and does not attempt inline callback execution.
+
+### Mocked Stream tests
+
+- Worker disabled when env flag is absent.
+- Worker registers when flag + credentials + template id are present.
+- SDK event is converted to the callback adapter once.
+- Handler error logs only reason code + delivery id.
+
+### UAT
+
+After B-1..B-4 merge behind the env gate:
+
+1. Enable Stream env on the same DingTalk test app used by A-5.
+2. Send an approval interactive card to a linked test recipient.
+3. Tap `同意` in DingTalk.
+4. Confirm approval record, ledger acted state, and in-place card terminal update.
+5. Tap again and confirm the card stays terminal with no duplicate approval record.
+6. Tap `驳回` on a fresh card and confirm it opens the Slice A decision page with comment-required behavior.
+
+## 7. Owner decisions before runtime
+
+Recommended defaults are marked `RECOMMENDED`; changing any of these is a product/security choice, not an implementation detail.
+
+| Decision | Recommended default |
+|---|---|
+| B1 env shape | `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=1` plus explicit Stream credentials/template id. |
+| B2 reject handling | `同意` inline; `驳回` jumps to Slice A page. |
+| B2 card body | values-free title/request/node/status only. |
+| B3 callback action set | approve-only in v1. |
+| B4 card update failure | action remains committed; log and allow stale refresh on next click. |
+| UAT gate | real DingTalk Stream UAT required before declaring Slice B shipped. |
+
+## 8. Implementation order
+
+1. **B-1** Stream worker skeleton + env gate, no business action.
+2. **B-2** interactive-card send path, ledger kind `interactive_card`, no callback execution yet.
+3. **B-3** callback adapter -> wrapper -> engine action.
+4. **B-4** terminal card update + duplicate/stale convergence.
+5. Closeout MD with CI evidence and real DingTalk Stream UAT result.
+
+Do not combine this with unrelated approval UX work. This slice touches an external callback channel and must stay narrow.

--- a/docs/development/approval-dingtalk-one-tap-a5-verification-20260705.md
+++ b/docs/development/approval-dingtalk-one-tap-a5-verification-20260705.md
@@ -3,8 +3,8 @@
 > design-lock `approval-dingtalk-one-tap-action-design-lock-20260705.md` 的 **A-5 验收档**。
 > Slice A（A-1..A-4-core）实现已于 #3610（A-1）+ #3647（A-2a/A-2b/A-3+A-4-core）落地。
 > 本 MD = 「已做什么 + 自动化验证结论 + 真钉钉 UAT 剧本 + 验收判据」。
-> **一处待填**：真钉钉 UAT *运行结果*（① CI-green SHA 已补，见 §2）；
-> 待 owner 侧 env 就绪后按 §4 剧本实跑填入——在此之前本档为验收*计划*，非验收*结论*。
+> **2026-07-09 更新**：owner 侧 env 已就绪，并完成 Slice A 主链 UAT。§4.1 记录实跑证据；
+> 本档从验收*计划*翻为验收*结论*。敏感深链 token、钉钉 userId、corpId、taskId 原值不写入本文。
 
 ## 1. As-built（三提交，锁 checklist A-1..A-4-core）
 
@@ -52,12 +52,60 @@
 - ⬜ **U7 未绑定**：以一个**未做钉钉绑定**的受理人跑 U1 → 无 action_card；台账**无**该受理人卡片行；`dingtalk_person_deliveries` 有一条 `status=skipped`（不猜映射）。
 - ⬜ **U8 并发**（可选压测）：同一卡片快速双击 → 仅一次生效，`approval_records` 无双 approve。
 
+## 4.1 2026-07-09 真钉钉 UAT 结果（PASS evidence）
+
+**环境**
+
+- Public URL: `https://demonstration-postings-nashville-premises.trycloudflare.com`
+- Server IP: `23.254.236.11`
+- Runtime image / health commit: `9ac55cba0cac8c0d2224a5f46ec6564bf6864d15`
+- Health observed at: `2026-07-09T13:09:58Z`
+- Runtime: production build, real backend, real DingTalk work-notification app channel; DB/Redis/plugins healthy.
+
+**Config evidence**
+
+- DingTalk directory integration existed and the work-notification Agent ID was saved through the settings UI.
+- A stored one-tap card secret was generated through the settings UI; no secret value is recorded here.
+- `PUBLIC_APP_URL` / `APP_BASE_URL` pointed at the public Cloudflare URL above.
+- Staging-only RBAC bootstrap was applied for the two linked test users:
+  - rule creator: `approvals:read`
+  - card actors: `approvals:act`
+  This was necessary because the save/fire gates trust DB permissions, and the card delivery action endpoint requires `approvals:act`.
+
+**Run A — endpoint-path guard run, linked Li test account**
+
+- Request: `AP-100043`, title `A5 钉钉一键审批 UAT 20260709131825`
+- Delivery: `d9b18cb2-47fc-41f0-9f2f-7880c1145148`
+- U1/send: card delivery reached `card_state='sent', send_status='sent'`; DingTalk API returned a task id (not recorded).
+- U2/summary: `GET /api/approval-card-deliveries/:id` returned the decision summary with `viewerIsRecipient=true` and `actionable=true`.
+- U4 guard: reject without comment returned `REJECT_COMMENT_REQUIRED`; the delivery was not claimed.
+- U3 action: approve through the card-delivery endpoint returned success.
+- U6 duplicate: a second approve returned `409 APPROVAL_CARD_DELIVERY_STALE` and the true terminal state.
+- DB terminal evidence: instance approved; delivery became `card_state='acted', send_status='sent', acted_action='approve'`; the approval record metadata included `channel='dingtalk_card'` and the delivery id.
+
+**Run B — in-app browser live decision-page run, linked zhouhua test account**
+
+- Request: `AP-100044`, title `A5 钉钉一键审批 zhouhua 20260709133030`
+- Delivery: `d98b83e3-9d36-4fcc-bd1d-a18049cb63b9`
+- U1/send: card delivery reached `card_state='sent', send_status='sent'`; DingTalk API returned a task id (not recorded).
+- U5 deep-link discipline: page was opened with the expected shape `...?d=<deliveryId>&t=<32hex>`. The token value is intentionally omitted from this document; no instance id or form value appeared in the URL.
+- U2/page summary: the decision page rendered title, request number, node key, comment box, approve button, reject button, and the reject-required hint.
+- U3 live approve: owner authorized clicking `同意` in the Codex in-app browser. The page changed to terminal copy: `该待办已处理（同意）。`
+- DB terminal evidence: instance `AP-100044` became `approved`; delivery became `card_state='acted', send_status='sent', acted_action='approve'`; the approval record metadata included `channel='dingtalk_card'`, the delivery id, `nodeEntryEpoch=1`, and `aggregateComplete=true`.
+
+**Coverage split**
+
+- Live UAT covered the production send path, real DingTalk API acceptance, values-free deep-link shape, decision page rendering, approve action, ledger claim, channel metadata injection, and duplicate/stale behavior.
+- Negative paths that were not repeated as a manual mobile click in this run remain covered by the §2 automated suites: unbound-user skip, token discipline, undelivered stale, reject-comment retry, non-recipient engine rejection, and concurrent double-click.
+- Operator evidence should keep the two UAT records until this closeout is accepted. Optional cleanup can remove the dedicated UAT bases/sheets afterward.
+
 ## 5. 验收判据（PASS 定义）
 
-**PASS** = U1–U7 全部符合预期（U8 可选）+ §2 自动化验证全绿（CI-green SHA 已补 ✅）。剩余唯一门 = owner env 就绪后按 §4 实跑 U1–U7。
+**PASS** = §2 自动化验证全绿 + §4.1 live UAT 主链通过 + 负向门有自动化/端点证据。2026-07-09 已满足。
+若后续要求“每个负向项均在钉钉容器里人工点一遍”，可按 §4 继续补跑；那是更强验收，不再阻塞 Slice B design-lock。
 任一 U 项偏差即 **HOLD**，记录现象 → 定位（台账状态 / 免登 redirect / channel 注入 / 引擎门）→ 修复后重跑该项。
 
 ## 6. A-5 之后
 
 - **A-6**（可选增强）：钉钉容器内 JSAPI `requestAuthCode` 静默免登（当前 A-3 用 redirect launch，已可用；A-6 只是省一次授权点击）。
-- **B-0..B-4**（Slice B，🔒）：互动卡片 + Stream 回调 + 原地终态——**锁定在 A-5 验收 PASS + owner 显式 opt-in 之后**，不得提前开。
+- **B-0..B-4**（Slice B）：互动卡片 + Stream 回调 + 原地终态。A-5 PASS 门已满足；runtime 仍需 owner 对 B-0 design-lock 单独 ratify 后再开。

--- a/docs/development/approval-dingtalk-one-tap-action-design-lock-20260705.md
+++ b/docs/development/approval-dingtalk-one-tap-action-design-lock-20260705.md
@@ -137,11 +137,12 @@ find-then-patch 同族纪律）。台账行不存在或 `card_state != 'sent'` �
 - ✅ **A-3** 移动极简决策页（#3647） + `/launch` 登录/绑定接入（含未绑定 fail-closed 引导）
 - ✅ **A-4** card-delivery 动作端点（#3647） `POST /api/approval-card-deliveries/:deliveryId/actions` +
   channel 注入 wrapper（§4）+ 台账状态回写（raw `/actions` 直连禁令的 tripwire 测试随此项落）
-- 🟡 **A-5** 验证：CI 可测部分已收口（#3665/#3669：单测/台账状态机/wrapper fail-closed 矩阵/伪造
-  instanceId tripwire 全绿；配置面已页面自助化 #3690/#3693/#3698/#3707）；**真钉钉 UAT 仍 ⬜ =
-  owner 实跑（跑通前不写「已验收」）**
+- ✅ **A-5** 验证：CI 可测部分已收口（#3665/#3669：单测/台账状态机/wrapper fail-closed 矩阵/伪造
+  instanceId tripwire 全绿；配置面已页面自助化 #3690/#3693/#3698/#3707）；2026-07-09 真钉钉 UAT
+  主链通过，证据见 `approval-dingtalk-one-tap-a5-verification-20260705.md` §4.1
 - ⬜ **A-6**（增强，可后置）钉钉容器内 JSAPI 免登
-- 🔒 **B-0** Slice B opt-in gate（A-5 验收 + owner 点名解锁）
+- 🟡 **B-0** Slice B opt-in gate（A-5 验收已满足；PROPOSED design-lock:
+  `approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md`，仍需 owner ratify 后才开 runtime）
 - 🔒 **B-1** Stream worker 基建（env-gate 注册 / 重连 / 消费幂等）
 - 🔒 **B-2** 互动卡片模板注册 + 投放（outTrackId=台账 id）
 - 🔒 **B-3** 回调 → wrapper → 卡片原地终态更新（含冲突刷新真实状态）


### PR DESCRIPTION
## What changed

- Flipped the A-5 DingTalk one-tap verification MD from plan to evidence, using the 2026-07-09 staging UAT run.
- Recorded the live Slice A path: real DingTalk work-notification send, values-free deep link, decision page approve, ledger acted state, and `approval_records.metadata.channel='dingtalk_card'`.
- Kept the evidence split honest: live UAT covers the main path; negative gates remain covered by the existing automated/endpoint suites.
- Added a PROPOSED Slice B design-lock for DingTalk interactive cards over Stream mode.
- Updated the original one-tap design-lock checklist so A-5 is no longer stale and B-0 points at the new proposed lock.

## Security notes

- No deep-link token values are recorded.
- No DingTalk userId, corpId, taskId, app secret, or card secret values are recorded.
- The B-0 lock keeps callback handling ledger-only: `outTrackId -> dingtalk_approval_card_deliveries -> instance`, with no callback-provided instance/form data accepted.

## Verification

- `git diff --check`
- Sensitive-string grep for the live deep-link token, raw tokenized URL, and secret assignment patterns returned no matches.

## Review focus

- A-5 PASS wording: live happy path + automated negative gates, not a claim that every negative case was manually clicked in DingTalk.
- B-0 decisions in §7: approve-only inline, reject jumps to Slice A page, Stream env gate, values-free card body, and real DingTalk Stream UAT before shipped status.
