### PR TITLE
feat(plm): Discussion Phase 3 consumer slice-1 — read-only threads/comments [HELD — owner-word merge]

### DIFF
--- a/docs/development/plm-yuantus-discussion-phase3-read-consumer-slice1-20260709.md
+++ b/docs/development/plm-yuantus-discussion-phase3-read-consumer-slice1-20260709.md
@@ -1,0 +1,282 @@
+# PLM x MetaSheet — Discussion Phase 3 Consumer — Slice-1 (READ-ONLY) Dev & Verification
+
+Date: 2026-07-09
+Branch: `feat/plm-discussion-read-consumer`
+
+## 1. Scope
+
+This is the metasheet2-side **consumer** half of the Yuantus Discussion Phase 3 integration,
+staged per the Yuantus design-lock taskbook
+`docs/development/plm-collab-discussion-phase3-metasheet-consumer-taskbook-20260709.md`
+(Yuantus repo): **Slice-1 (1st impl) = READ-ONLY consumer**. It adds no PLM write channel and no
+new Yuantus provider route — the routes it calls already ship on Yuantus main (Discussion Core
+R1 + Phase-2 + Phase-6).
+
+Two new `PLMAdapter` read methods:
+
+- `getDiscussions(target, options?)` -> `GET /api/v1/discussions`
+- `getDiscussionThread(threadId, options?)` -> `GET /api/v1/discussions/{thread_id}`
+
+**Explicitly out of scope for this slice** (later slices per the taskbook):
+`GET /discussions/my`, `GET /discussions/mentionable-users`, and every write route (`POST
+/discussions`, `POST .../comments`, `PATCH/DELETE .../comments/{id}`, `resolve`/`reopen`). No
+capability/SKU gating was added either — the provider routes are bearer-JWT + target-permission
+gated only (not entitlement-gated), and the `discussion_core` capability-manifest key is a
+separate, not-yet-ratified owner fork (taskbook §4 M1).
+
+## 2. Provider surface consumed (read-only relevant, unchanged on Yuantus main)
+
+Confirmed directly against `origin/main` of the Yuantus repo
+(`src/yuantus/meta_engine/web/discussion_router.py`,
+`src/yuantus/meta_engine/discussion/service.py`,
+`src/yuantus/meta_engine/discussion/resolvers.py`):
+
+```
+GET /api/v1/discussions
+    ?target_type={item|item_version|file|eco|pdm_relationship}
+    &target_id={id}
+    &include_resolved={bool, default false}
+    &include_children={bool, default false — item targets only, Phase-6 one-level BOM-children aggregation}
+    &limit={1..200, default 50}
+    &cursor={opaque string}
+  -> 200 {"threads": [ThreadSummary...], "next_cursor": string|null}
+  -> 404 {"detail": "discussion target not found"}   (missing OR unreadable target — indistinguishable)
+
+GET /api/v1/discussions/{thread_id}
+    ?include_history={bool, default false — Phase-6 read-only lifecycle/version merge, item-backed only}
+  -> 200 ThreadDetail = ThreadSummary + {"comments": [Comment...], "history"?: [...] }
+  -> 404 {"detail": "discussion thread not found"}   (missing thread OR — via the same
+                                                        _resolve_target re-check — an
+                                                        unreadable target)
+```
+
+`ThreadSummary` (provider's `DiscussionService._thread_summary`):
+
+```json
+{
+  "id": "string",
+  "target_type": "string",
+  "target_id": "string",
+  "title": "string | null",
+  "status": "string",
+  "created_by_id": "number",
+  "created_at": "ISO-8601 string",
+  "resolved_by_id": "number | null",
+  "resolved_at": "ISO-8601 string | null",
+  "last_comment_at": "ISO-8601 string | null",
+  "comment_count": "number",
+  "anchor": "object | null"
+}
+```
+
+`Comment` (provider's `DiscussionService._thread_detail`; soft-deleted comments are redacted at
+the API surface — `body`/`anchor` -> `null`, `mentioned_user_ids` -> `[]`):
+
+```json
+{
+  "id": "string",
+  "parent_comment_id": "string | null",
+  "body": "string | null",
+  "body_format": "string",
+  "author_user_id": "number",
+  "mentioned_user_ids": "number[]",
+  "created_at": "ISO-8601 string",
+  "edited_at": "ISO-8601 string | null",
+  "deleted_at": "ISO-8601 string | null",
+  "anchor": "object | null"
+}
+```
+
+Auth: `get_current_user` (bearer JWT) only — no `is_entitled` / capability check on these two read
+routes. Permission is target-inherited via the discussion resolver registry (read = the target's
+AML `get`, ECO delegates to `EcoAuthzGate`, `pdm_relationship` requires both ends readable). A
+missing-or-unreadable target/thread is **deliberately indistinguishable** — always a plain 404,
+never a 403 or a distinguishing error body, so the consumer cannot infer existence of something it
+cannot read.
+
+## 3. Consumer adapter changes
+
+`packages/core-backend/src/data-adapters/PLMAdapter.ts`:
+
+- New exported types: `DiscussionTargetType`, `DiscussionTarget`, `DiscussionListOptions`,
+  `DiscussionThreadOptions`, `DiscussionThreadSummary`, `DiscussionThreadListResult`,
+  `DiscussionComment`, `DiscussionThreadDetail`.
+- `getDiscussions(target: DiscussionTarget, options?: DiscussionListOptions):
+  Promise<QueryResult<DiscussionThreadListResult>>` — builds `target_type`/`target_id` plus the
+  optional `include_resolved` / `include_children` / `limit` / `cursor` query params and calls
+  `this.query('/api/v1/discussions', [params])`, mirroring the existing `getWhereUsed` /
+  `getBomCompare` pattern (mock-mode branch, `apiMode !== 'yuantus'` branch, then a plain
+  `this.query(...)` pass-through — no extra field remapping, since the provider envelope already
+  matches the consumer type 1:1).
+- `getDiscussionThread(threadId: string, options?: DiscussionThreadOptions):
+  Promise<QueryResult<DiscussionThreadDetail>>` — same shape, calls
+  `` this.query(`/api/v1/discussions/${threadId}`, [params]) ``.
+- Both follow the adapter-wide error convention: the underlying `HTTPAdapter.query()` never
+  throws on a non-2xx response — it returns `{data: [], error}` — so a 404 (missing/unreadable
+  target or thread) surfaces as `result.error` (with `error.response.status === 404` on the real
+  axios error), never a thrown exception. This mirrors how the rest of `PLMAdapter` treats
+  provider errors and lets a degrading panel treat "no threads" and "target unreadable" the same
+  way without probing which one happened.
+- `'discussions'` added to `YUANTUS_SUPPORTED_OPERATIONS` (purely descriptive — `getRuntimeStatus()`
+  advertises it under `apiMode='yuantus'`; not used for any gating anywhere in the codebase).
+- Auth/tenant headers (`Authorization: Bearer <token>` via `getYuantusToken()`/`tokenProvider`,
+  `x-tenant-id` / `x-org-id` from `connect()`) are unchanged — both new methods go through the same
+  `this.query()` -> `HTTPAdapter` axios client as every other yuantus-mode read, so they inherit
+  the existing bearer-token refresh-on-401 and header wiring with no new code.
+
+## 4. Pact contract changes
+
+`packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json`: 3 new interactions
+inserted at the END of the adapter-owned interaction list (index 34, i.e. immediately before the
+V1.2 parent-host embed-token mint interaction, which is index 34 in the 38-interaction baseline).
+Total interaction count: **38 -> 41**.
+
+| # | Description | Provider state | Method + Path | Status |
+|---|---|---|---|---|
+| 1 | `list discussion threads bound to a readable PLM target` | `tenant-1 can read item 01H000000000000000000000T1 and it has an open discussion thread 01H000000000000000000000T2` | `GET /api/v1/discussions` | 200 |
+| 2 | `fetch a discussion thread and its comments, including the read-only history merge` | `tenant-1 can read discussion thread 01H000000000000000000000T2 on item 01H000000000000000000000T1 and it has one comment` | `GET /api/v1/discussions/01H000000000000000000000T2` | 200 |
+| 3 | `list discussion threads for a missing or unreadable target returns the no-leak 404` | `item 01H000000000000000000000T9 does not exist, or tenant-1 cannot read it (indistinguishable no-leak target)` | `GET /api/v1/discussions` | 404 |
+
+Fixture ids used (fresh, not reused from any other pact interaction): `01H000000000000000000000T1`
+(target item), `01H000000000000000000000T2` (thread), `01H000000000000000000000T3` (comment),
+`01H000000000000000000000T9` (missing/unreadable target).
+
+### Interaction 1 — thread-list success
+
+Request: `GET /api/v1/discussions`, query
+`{target_type: ["item"], target_id: ["01H000000000000000000000T1"], include_resolved: ["false"],
+limit: ["20"]}`, headers `{Authorization: "Bearer ...", x-tenant-id: "tenant-1"}`.
+
+Response `200`:
+
+```json
+{
+  "threads": [
+    {
+      "id": "01H000000000000000000000T2",
+      "target_type": "item",
+      "target_id": "01H000000000000000000000T1",
+      "title": "Check tolerance on mounting hole",
+      "status": "open",
+      "created_by_id": 1,
+      "created_at": "2026-07-09T00:00:00.000Z",
+      "resolved_by_id": null,
+      "resolved_at": null,
+      "last_comment_at": "2026-07-09T00:05:00.000Z",
+      "comment_count": 2,
+      "anchor": null
+    }
+  ],
+  "next_cursor": null
+}
+```
+
+### Interaction 2 — thread-detail success
+
+Request: `GET /api/v1/discussions/01H000000000000000000000T2`, query
+`{include_history: ["true"]}`, same auth headers.
+
+Response `200`: `ThreadSummary` fields for thread `T2` + `comments: [one Comment]` +
+`history: [one lifecycle_transition entry]` (demonstrates the Phase-6 `include_history` merge is
+wired through, even though this consumer slice treats `history` as an untyped passthrough —
+`DiscussionThreadDetail.history?: Array<Record<string, unknown>>`).
+
+### Interaction 3 — no-leak 404
+
+Request: `GET /api/v1/discussions`, query
+`{target_type: ["item"], target_id: ["01H000000000000000000000T9"], include_resolved: ["false"],
+limit: ["20"]}`, same auth headers.
+
+Response `404`: `{"detail": "discussion target not found"}` — the exact string the Yuantus
+`TargetNotFoundError("discussion target not found")` produces via FastAPI's default
+`HTTPException` body.
+
+### Drift guards updated
+
+- `PLM_ADAPTER_PACT_PATHS` (`plm-adapter-yuantus.pact.test.ts`) gained 3 entries at the end:
+  `GET /api/v1/discussions` (list success), `GET /api/v1/discussions/01H000000000000000000000T2`
+  (detail success), `GET /api/v1/discussions` (404) — the index-by-index order test enforces they
+  land at exactly this position in the JSON.
+- The `endpointsToFind` source-grounding array gained `/api/v1/discussions` and
+  `` /api/v1/discussions/${threadId} `` so the pact cannot silently drift from what
+  `PLMAdapter.ts` actually calls.
+- New dedicated test: `'Discussion Phase 3 slice-1: thread-list success, thread-detail success,
+  and the no-leak 404 are locked'` — asserts the exact request query shapes, the `{threads,
+  next_cursor}` envelope (NOT a bare array, unlike the ECO list endpoint), the comment envelope,
+  and the exact 404 body.
+
+## 5. Provider-states the Yuantus side needs to author
+
+For the broker provider-verify gate to go green, `Yuantus/src/yuantus/api/tests/
+test_pact_provider_yuantus_plm.py` needs fixture handlers for these 3 provider-state strings
+(verbatim, so they match the copied pact JSON):
+
+1. `tenant-1 can read item 01H000000000000000000000T1 and it has an open discussion thread
+   01H000000000000000000000T2`
+2. `tenant-1 can read discussion thread 01H000000000000000000000T2 on item
+   01H000000000000000000000T1 and it has one comment`
+3. `item 01H000000000000000000000T9 does not exist, or tenant-1 cannot read it (indistinguishable
+   no-leak target)`
+
+States 1 and 2 can most likely share one fixture (seed item `T1` + thread `T2` + one comment on
+`T2`, readable by `tenant-1`); state 3 seeds nothing for `T9` (or seeds it in a different tenant),
+so the resolver's `TargetNotFoundError` fires naturally. This mirrors the Wave 4 doc's "no-op
+provider-state handler, deterministic via distinct seeded fixtures" pattern.
+
+## 6. Test results
+
+Ran from `packages/core-backend/` (`pnpm install --frozen-lockfile` at the workspace root first;
+did not mutate the lockfile):
+
+```bash
+npx vitest run tests/contract/plm-adapter-yuantus.pact.test.ts tests/unit/plm-adapter-yuantus.test.ts
+```
+
+Result: **2 test files passed, 48 tests passed** (43 pre-existing + 1 new pact assertion test +
+5 new adapter unit tests, `omits optional list params`/`omits include_history` count as 2 of the
+5).
+
+```bash
+npx vitest run tests/contract --reporter=dot
+```
+
+Result: **2 test files passed, 23 tests passed**.
+
+```bash
+npx tsc --noEmit -p .
+```
+
+Result: exit code 0, no type errors.
+
+```bash
+npx vitest run tests/unit --reporter=dot
+```
+
+Result: **337 test files passed, 4520 tests passed** (full `core-backend` unit suite — confirms
+the `YUANTUS_SUPPORTED_OPERATIONS` addition and the new types did not regress any other adapter
+or federation test).
+
+## 7. Files changed
+
+- `packages/core-backend/src/data-adapters/PLMAdapter.ts`
+- `packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json`
+- `packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts`
+- `packages/core-backend/tests/contract/README.md`
+- `packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts`
+- `docs/development/plm-yuantus-discussion-phase3-read-consumer-slice1-20260709.md` (this file)
+
+## 8. Deferred to later slices
+
+- `GET /api/v1/discussions/my` (caller-scoped: created/commented/mentioned)
+- `GET /api/v1/discussions/mentionable-users` (mention-picker lookup)
+- `POST /api/v1/discussions` (create thread)
+- `POST /api/v1/discussions/{thread_id}/comments` (add comment)
+- `PATCH /api/v1/discussions/{thread_id}/comments/{comment_id}` (edit comment)
+- `DELETE /api/v1/discussions/{thread_id}/comments/{comment_id}` (soft-delete comment)
+- `POST /api/v1/discussions/{thread_id}/resolve` / `.../reopen`
+- Consumer UI panel wiring (threads rendered in BOM Review) — this taskbook slice is
+  adapter+pact only, per the "Build + verify locally" scope; no panel/route wiring was requested
+  or added.
+- Capability-manifest `discussion_core` entry (owner fork M1, not ratified) — no
+  `getIntegrationCapabilities()` change was made.
+- The write-session-credential design (taskbook §5) — required before any write-capable slice.

--- a/docs/development/plm-yuantus-discussion-phase3-read-consumer-slice1-20260709.md
+++ b/docs/development/plm-yuantus-discussion-phase3-read-consumer-slice1-20260709.md
@@ -107,7 +107,12 @@ cannot read.
   `this.query('/api/v1/discussions', [params])`, mirroring the existing `getWhereUsed` /
   `getBomCompare` pattern (mock-mode branch, `apiMode !== 'yuantus'` branch, then a plain
   `this.query(...)` pass-through — no extra field remapping, since the provider envelope already
-  matches the consumer type 1:1).
+  matches the consumer type 1:1). **Note the query-param guards are truthy-only**
+  (`` if (options?.includeResolved) params.include_resolved = ... ``), so `includeResolved: false`
+  / `includeChildren: false` (or omitted) are never put on the wire — only `true` is. This matches
+  the provider's own `false` defaults, so the two behave identically; the pact fixtures below
+  reflect this (no `include_resolved` key on the wire when the caller didn't ask for resolved
+  threads).
 - `getDiscussionThread(threadId: string, options?: DiscussionThreadOptions):
   Promise<QueryResult<DiscussionThreadDetail>>` — same shape, calls
   `` this.query(`/api/v1/discussions/${threadId}`, [params]) ``.
@@ -144,8 +149,10 @@ Fixture ids used (fresh, not reused from any other pact interaction): `01H000000
 ### Interaction 1 — thread-list success
 
 Request: `GET /api/v1/discussions`, query
-`{target_type: ["item"], target_id: ["01H000000000000000000000T1"], include_resolved: ["false"],
-limit: ["20"]}`, headers `{Authorization: "Bearer ...", x-tenant-id: "tenant-1"}`.
+`{target_type: ["item"], target_id: ["01H000000000000000000000T1"], limit: ["20"]}` (no
+`include_resolved` key — the caller didn't request resolved threads, and the adapter's guard is
+truthy-only so `false` is never put on the wire), headers `{Authorization: "Bearer ...",
+x-tenant-id: "tenant-1"}`.
 
 Response `200`:
 
@@ -184,8 +191,8 @@ wired through, even though this consumer slice treats `history` as an untyped pa
 ### Interaction 3 — no-leak 404
 
 Request: `GET /api/v1/discussions`, query
-`{target_type: ["item"], target_id: ["01H000000000000000000000T9"], include_resolved: ["false"],
-limit: ["20"]}`, same auth headers.
+`{target_type: ["item"], target_id: ["01H000000000000000000000T9"], limit: ["20"]}`, same auth
+headers.
 
 Response `404`: `{"detail": "discussion target not found"}` — the exact string the Yuantus
 `TargetNotFoundError("discussion target not found")` produces via FastAPI's default

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -632,6 +632,8 @@ const YUANTUS_SUPPORTED_OPERATIONS = [
   'cad_properties_update',
   'cad_view_state_update',
   'cad_review_update',
+  // PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY): getDiscussions/getDiscussionThread.
+  'discussions',
 ]
 
 /**
@@ -825,6 +827,83 @@ function isBomMultitableContext(value: unknown): value is BomMultitableContext {
   if (typeof c.sync_status !== 'string') return false;
   if (typeof c.template_key !== 'string') return false;
   return true;
+}
+
+/**
+ * PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY) consumer types: object-bound discussion
+ * threads/comments served by the provider's EXISTING `/api/v1/discussions` routes (Discussion
+ * Core R1 + Phase-2 + Phase-6, already shipped on Yuantus main -- this slice adds NO new
+ * provider route). Bearer-JWT (`get_current_user`) + target-inherited permission via the
+ * provider's closed resolver registry (item / item_version / file / eco / pdm_relationship) --
+ * NOT entitlement-gated: this slice deliberately does no capability/SKU check (the
+ * `discussion_core` manifest key is a separate, not-yet-ratified owner fork). A missing OR
+ * unreadable target/thread is the provider's INDISTINGUISHABLE 404 (no existence leak) --
+ * surfaced here as `QueryResult.error`, never thrown, so a degrading panel can treat "no
+ * threads" and "target unreadable" identically without probing which one happened. Write
+ * routes (create thread / add comment / edit / delete / resolve / reopen) are a LATER slice,
+ * gated on the write-session-credential design, and are deliberately NOT added here.
+ */
+export type DiscussionTargetType = 'item' | 'item_version' | 'file' | 'eco' | 'pdm_relationship';
+
+export interface DiscussionTarget {
+  targetType: DiscussionTargetType;
+  targetId: string;
+}
+
+export interface DiscussionListOptions {
+  includeResolved?: boolean;
+  // Phase-6: item targets only -- also aggregates one-level current-assembly BOM-children
+  // threads (provider's WP1.2 /pdm "ASSEMBLY" containment vocabulary).
+  includeChildren?: boolean;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface DiscussionThreadOptions {
+  // Phase-6: read-only lifecycle/version history merge, item-backed targets only; file/eco
+  // targets come back with no history entries.
+  includeHistory?: boolean;
+}
+
+export interface DiscussionThreadSummary {
+  id: string;
+  target_type: string;
+  target_id: string;
+  title: string | null;
+  status: string;
+  created_by_id: number;
+  created_at: string;
+  resolved_by_id: number | null;
+  resolved_at: string | null;
+  last_comment_at: string | null;
+  comment_count: number;
+  anchor: Record<string, unknown> | null;
+}
+
+export interface DiscussionThreadListResult {
+  threads: DiscussionThreadSummary[];
+  next_cursor: string | null;
+}
+
+export interface DiscussionComment {
+  id: string;
+  parent_comment_id: string | null;
+  // Soft-deleted comments keep their row (audit) but are redacted at the provider's API
+  // surface: body/anchor -> null, mentioned_user_ids -> [].
+  body: string | null;
+  body_format: string;
+  author_user_id: number;
+  mentioned_user_ids: number[];
+  created_at: string;
+  edited_at: string | null;
+  deleted_at: string | null;
+  anchor: Record<string, unknown> | null;
+}
+
+export interface DiscussionThreadDetail extends DiscussionThreadSummary {
+  comments: DiscussionComment[];
+  // Present only when include_history=true was requested (Phase-6 merge).
+  history?: Array<Record<string, unknown>>;
 }
 
 export class PLMAdapter extends HTTPAdapter {
@@ -2321,6 +2400,78 @@ export class PLMAdapter extends HTTPAdapter {
     return this.select<BomEcoRevisionIntentResult>(`/api/v1/bom/multitable/${partId}/eco-intent`, {
       method: 'POST',
     })
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY): list discussion threads bound to a PLM
+   * target (the provider's `GET /api/v1/discussions`). No capability/SKU gate on this read
+   * path -- see the type-block docstring above. A missing/unreadable target comes back as the
+   * provider's indistinguishable 404, surfaced as `result.error` (never thrown).
+   */
+  async getDiscussions(
+    target: DiscussionTarget,
+    options?: DiscussionListOptions
+  ): Promise<QueryResult<DiscussionThreadListResult>> {
+    if (this.mockMode) {
+      return {
+        data: [{ threads: [], next_cursor: null }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussions are not supported for this PLM API mode') }
+    }
+
+    const params: Record<string, unknown> = {
+      target_type: target.targetType,
+      target_id: target.targetId,
+    }
+    if (options?.includeResolved) params.include_resolved = options.includeResolved
+    if (options?.includeChildren) params.include_children = options.includeChildren
+    if (typeof options?.limit === 'number') params.limit = options.limit
+    if (options?.cursor) params.cursor = options.cursor
+
+    return this.query<DiscussionThreadListResult>('/api/v1/discussions', [params])
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY): fetch one discussion thread with its
+   * comments (the provider's `GET /api/v1/discussions/{thread_id}`). Same no-leak contract as
+   * getDiscussions -- an absent thread id and an unreadable target both come back as the
+   * provider's indistinguishable 404.
+   */
+  async getDiscussionThread(
+    threadId: string,
+    options?: DiscussionThreadOptions
+  ): Promise<QueryResult<DiscussionThreadDetail>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: threadId,
+          target_type: 'item',
+          target_id: 'mock-item-1',
+          title: 'Mock discussion thread',
+          status: 'open',
+          created_by_id: 1,
+          created_at: new Date().toISOString(),
+          resolved_by_id: null,
+          resolved_at: null,
+          last_comment_at: null,
+          comment_count: 0,
+          anchor: null,
+          comments: [],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussions are not supported for this PLM API mode') }
+    }
+
+    const params: Record<string, unknown> = {}
+    if (options?.includeHistory) params.include_history = options.includeHistory
+
+    return this.query<DiscussionThreadDetail>(`/api/v1/discussions/${threadId}`, [params])
   }
 
   async getApprovals(options?: ApprovalQueryOptions): Promise<QueryResult<ApprovalRequest>> {

--- a/packages/core-backend/tests/contract/README.md
+++ b/packages/core-backend/tests/contract/README.md
@@ -61,6 +61,33 @@ The `plm-adapter-yuantus.pact.test.ts` vitest test guards six things:
    response `embed_token`, `token_type`, `expires_in`, `jti`, `aud`, and
    `embed_origin`. Token and `jti` are matched by shape, never exact value.
 
+## PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY) (2026-07-09)
+
+Adds 3 interactions (38 -> 41) for `PLMAdapter.getDiscussions()` /
+`PLMAdapter.getDiscussionThread()` against the provider's EXISTING
+`/api/v1/discussions` routes (Discussion Core R1 + Phase-2 + Phase-6,
+already shipped on Yuantus main -- this slice adds **no new provider
+route**, only the consumer read callsites):
+
+- `GET /api/v1/discussions` -- thread-list success for a readable target.
+- `GET /api/v1/discussions/{thread_id}` -- thread-detail success (comments +
+  the Phase-6 `include_history` merge).
+- `GET /api/v1/discussions` -- the no-leak 404 for a missing/unreadable
+  target (`{"detail": "discussion target not found"}`).
+
+Bearer-JWT + target-inherited permission only -- **not entitlement-gated**;
+this slice does no capability/SKU check (the `discussion_core` manifest key
+is a separate, not-yet-ratified owner fork per the design-lock taskbook
+`plm-collab-discussion-phase3-metasheet-consumer-taskbook-20260709.md` on
+the Yuantus side). Write routes (create thread / add comment / edit /
+delete / resolve / reopen) are a later, write-capable-consumer slice and are
+deliberately not added here.
+
+The three interactions sit at the END of the adapter-owned interaction
+list, immediately before the V1.2 parent-host-mediated embed-token mint, so
+the concatenated `PACT_PATHS` order in `plm-adapter-yuantus.pact.test.ts`
+still matches the pact JSON placement.
+
 ## aml/metadata is now live on main
 
 `GET /api/v1/aml/metadata/{item_type_name}` was previously parked outside the

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3956,6 +3956,374 @@
       }
     },
     {
+      "description": "list discussion threads bound to a readable PLM target",
+      "providerStates": [
+        {
+          "name": "tenant-1 can read item 01H000000000000000000000T1 and it has an open discussion thread 01H000000000000000000000T2"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/discussions",
+        "query": {
+          "target_type": [
+            "item"
+          ],
+          "target_id": [
+            "01H000000000000000000000T1"
+          ],
+          "include_resolved": [
+            "false"
+          ],
+          "limit": [
+            "20"
+          ]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "threads": [
+            {
+              "id": "01H000000000000000000000T2",
+              "target_type": "item",
+              "target_id": "01H000000000000000000000T1",
+              "title": "Check tolerance on mounting hole",
+              "status": "open",
+              "created_by_id": 1,
+              "created_at": "2026-07-09T00:00:00.000Z",
+              "resolved_by_id": null,
+              "resolved_at": null,
+              "last_comment_at": "2026-07-09T00:05:00.000Z",
+              "comment_count": 2,
+              "anchor": null
+            }
+          ],
+          "next_cursor": null
+        },
+        "matchingRules": {
+          "body": {
+            "$.threads": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.threads[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.threads[*].target_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.threads[*].target_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.threads[*].status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.threads[*].created_by_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.threads[*].created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.threads[*].comment_count": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.next_cursor": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch a discussion thread and its comments, including the read-only history merge",
+      "providerStates": [
+        {
+          "name": "tenant-1 can read discussion thread 01H000000000000000000000T2 on item 01H000000000000000000000T1 and it has one comment"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/discussions/01H000000000000000000000T2",
+        "query": {
+          "include_history": [
+            "true"
+          ]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": "01H000000000000000000000T2",
+          "target_type": "item",
+          "target_id": "01H000000000000000000000T1",
+          "title": "Check tolerance on mounting hole",
+          "status": "open",
+          "created_by_id": 1,
+          "created_at": "2026-07-09T00:00:00.000Z",
+          "resolved_by_id": null,
+          "resolved_at": null,
+          "last_comment_at": "2026-07-09T00:05:00.000Z",
+          "comment_count": 1,
+          "anchor": null,
+          "comments": [
+            {
+              "id": "01H000000000000000000000T3",
+              "parent_comment_id": null,
+              "body": "Tolerance looks tight -- can we confirm with the vendor?",
+              "body_format": "text",
+              "author_user_id": 1,
+              "mentioned_user_ids": [],
+              "created_at": "2026-07-09T00:05:00.000Z",
+              "edited_at": null,
+              "deleted_at": null,
+              "anchor": null
+            }
+          ],
+          "history": [
+            {
+              "kind": "lifecycle_transition",
+              "at": "2026-07-08T00:00:00.000Z",
+              "actor_user_id": 1,
+              "from_state": "Draft",
+              "to_state": "Released",
+              "comment": null
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.target_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.target_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.created_by_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.comment_count": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 0
+                }
+              ]
+            },
+            "$.comments": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.comments[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.comments[*].body": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.comments[*].body_format": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.comments[*].author_user_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.comments[*].created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.history": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "list discussion threads for a missing or unreadable target returns the no-leak 404",
+      "providerStates": [
+        {
+          "name": "item 01H000000000000000000000T9 does not exist, or tenant-1 cannot read it (indistinguishable no-leak target)"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/discussions",
+        "query": {
+          "target_type": [
+            "item"
+          ],
+          "target_id": [
+            "01H000000000000000000000T9"
+          ],
+          "include_resolved": [
+            "false"
+          ],
+          "limit": [
+            "20"
+          ]
+        },
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "detail": "discussion target not found"
+        }
+      }
+    },
+    {
       "description": "mint a MetaSheet BOM review embed token for the Yuantus parent host",
       "providerStates": [
         {

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3972,9 +3972,6 @@
           "target_id": [
             "01H000000000000000000000T1"
           ],
-          "include_resolved": [
-            "false"
-          ],
           "limit": [
             "20"
           ]
@@ -4288,9 +4285,6 @@
           ],
           "target_id": [
             "01H000000000000000000000T9"
-          ],
-          "include_resolved": [
-            "false"
           ],
           "limit": [
             "20"

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -4083,6 +4083,13 @@
                   "match": "type"
                 }
               ]
+            },
+            "$.threads[*].last_comment_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
             }
           }
         }
@@ -4259,6 +4266,13 @@
               ]
             },
             "$.history": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.last_comment_at": {
               "matchers": [
                 {
                   "match": "type"

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -375,12 +375,14 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(detailSuccess).toBeDefined()
     expect(listNotFound).toBeDefined()
 
-    // thread-list request shape: target_type/target_id are required query params
+    // thread-list request shape: target_type/target_id are required query params.
+    // include_resolved/include_children are OMITTED here (not just "false") because the
+    // adapter's guard is truthy-only (`if (options?.includeResolved) ...`), matching the
+    // provider's own false defaults -- the pact must describe what the adapter actually sends.
     expect(listSuccess!.request.method).toBe('GET')
     expect(listSuccess!.request.query).toEqual({
       target_type: ['item'],
       target_id: ['01H000000000000000000000T1'],
-      include_resolved: ['false'],
       limit: ['20'],
     })
     expect(listSuccess!.providerStates![0].name).toContain('01H000000000000000000000T1')
@@ -413,7 +415,6 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(listNotFound!.request.query).toEqual({
       target_type: ['item'],
       target_id: ['01H000000000000000000000T9'],
-      include_resolved: ['false'],
       limit: ['20'],
     })
     expect(listNotFound!.response.status).toBe(404)

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -14,8 +14,9 @@
  *      interactions plus the release-readiness governance interaction plus
  *      the BOM-analysis / ECO-approval Wave 3 interactions plus the approval
  *      list/detail / BOM-substitute Wave 4 interactions plus the CAD
- *      review/workspace Wave 5 interactions that PLMAdapter currently calls
- *      are present, in the documented order.
+ *      review/workspace Wave 5 interactions plus the PLM-COLLAB Discussion
+ *      Phase 3 slice-1 (READ-ONLY) interactions that PLMAdapter currently
+ *      calls are present, in the documented order.
  *      including `aml/metadata`, now that PLMAdapter calls the dedicated
  *      metadata route for item-type schema discovery.
  *   3. PLMAdapter actually calls every adapter-owned endpoint declared in the
@@ -126,6 +127,16 @@ const PLM_ADAPTER_PACT_PATHS = [
   // It MUST sit at the END of the adapter-owned list — immediately before the V1.2 parent-host
   // embed-token — so the concatenated PACT_PATHS order matches the pact JSON placement.
   { method: 'POST', path: '/api/v1/bom/multitable/01H000000000000000000000L1/eco-intent' },
+  // PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY, design-lock taskbook
+  // plm-collab-discussion-phase3-metasheet-consumer-taskbook-20260709.md): the provider routes
+  // already exist on Yuantus main (Discussion Core R1 + Phase-2 + Phase-6) — this slice adds NO
+  // new provider route, only the consumer read callsites. Bearer-JWT + target-inherited
+  // permission only, NOT entitlement-gated. Per the taskbook's §3.4 template, these three sit at
+  // the END of the adapter-owned list: a representative thread-list success, a thread-detail
+  // success, and the no-leak 404 for a missing/unreadable target.
+  { method: 'GET', path: '/api/v1/discussions' },
+  { method: 'GET', path: '/api/v1/discussions/01H000000000000000000000T2' },
+  { method: 'GET', path: '/api/v1/discussions' },
 ] as const
 
 const PARENT_HOST_PACT_PATHS = [
@@ -231,6 +242,9 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       '/api/v1/bom/multitable/${partId}/context',
       '/api/v1/bom/multitable/${partId}/lines/${bomLineId}',
       '/api/v1/bom/multitable/${partId}/eco-intent',
+      // PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY)
+      '/api/v1/discussions',
+      '/api/v1/discussions/${threadId}',
     ]
     for (const ep of endpointsToFind) {
       expect(
@@ -333,6 +347,83 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
     expect(notLocked!.response.status).toBe(409)
     const detail = (notLocked!.response.body as { detail: Record<string, unknown> }).detail
     expect(detail.code).toBe('not_locked')
+  })
+
+  // PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY): the provider routes already exist on
+  // Yuantus main (Discussion Core R1 + Phase-2 + Phase-6); this slice adds no new provider
+  // route, only the consumer read callsites (getDiscussions / getDiscussionThread). Bearer-JWT
+  // + target-inherited permission only -- NOT entitlement-gated (no capability/SKU check).
+  it('Discussion Phase 3 slice-1: thread-list success, thread-detail success, and the no-leak 404 are locked', () => {
+    const pact = loadPact()
+    const discussionInteractions = pact.interactions.filter(
+      i => i.request.path === '/api/v1/discussions' || i.request.path === '/api/v1/discussions/01H000000000000000000000T2',
+    )
+    // exactly the three read interactions this slice adds (list success, detail success, 404)
+    expect(discussionInteractions).toHaveLength(3)
+
+    const listSuccess = pact.interactions.find(
+      i => i.request.path === '/api/v1/discussions' && i.response.status === 200,
+    )
+    const detailSuccess = pact.interactions.find(
+      i => i.request.path === '/api/v1/discussions/01H000000000000000000000T2',
+    )
+    const listNotFound = pact.interactions.find(
+      i => i.request.path === '/api/v1/discussions' && i.response.status === 404,
+    )
+
+    expect(listSuccess).toBeDefined()
+    expect(detailSuccess).toBeDefined()
+    expect(listNotFound).toBeDefined()
+
+    // thread-list request shape: target_type/target_id are required query params
+    expect(listSuccess!.request.method).toBe('GET')
+    expect(listSuccess!.request.query).toEqual({
+      target_type: ['item'],
+      target_id: ['01H000000000000000000000T1'],
+      include_resolved: ['false'],
+      limit: ['20'],
+    })
+    expect(listSuccess!.providerStates![0].name).toContain('01H000000000000000000000T1')
+    // envelope is {threads, next_cursor} -- NOT a bare array (unlike the ECO list endpoint)
+    const listBody = listSuccess!.response.body as { threads: unknown[]; next_cursor: unknown }
+    expect(Array.isArray(listBody.threads)).toBe(true)
+    expect(listBody.threads[0]).toMatchObject({
+      id: '01H000000000000000000000T2',
+      target_type: 'item',
+      target_id: '01H000000000000000000000T1',
+      status: 'open',
+    })
+    expect(listBody).toHaveProperty('next_cursor')
+
+    // thread-detail request shape + comment envelope
+    expect(detailSuccess!.request.method).toBe('GET')
+    expect(detailSuccess!.request.query).toEqual({ include_history: ['true'] })
+    const detailBody = detailSuccess!.response.body as Record<string, unknown> & { comments: unknown[] }
+    expect(detailBody.id).toBe('01H000000000000000000000T2')
+    expect(Array.isArray(detailBody.comments)).toBe(true)
+    expect(detailBody.comments[0]).toMatchObject({
+      id: expect.any(String),
+      author_user_id: expect.any(Number),
+      body: expect.any(String),
+    })
+    // Phase-6 include_history merge, present because include_history=true was requested
+    expect(Array.isArray(detailBody.history)).toBe(true)
+
+    // the no-leak 404: a missing/unreadable target is indistinguishable, no existence leak
+    expect(listNotFound!.request.query).toEqual({
+      target_type: ['item'],
+      target_id: ['01H000000000000000000000T9'],
+      include_resolved: ['false'],
+      limit: ['20'],
+    })
+    expect(listNotFound!.response.status).toBe(404)
+    expect(listNotFound!.response.body).toEqual({ detail: 'discussion target not found' })
+
+    // every discussion interaction is bearer-JWT authenticated (no entitlement/capability header)
+    for (const interaction of discussionInteractions) {
+      const headers = (interaction.request.headers ?? {}) as Record<string, string>
+      expect(headers.Authorization).toBeDefined()
+    }
   })
 
   // ECO Phase 0: the discriminated-409 error contract (Yuantus provider #968 taskbook + #969 impl).

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -1146,3 +1146,149 @@ describe('PLMAdapter Yuantus documents single-side failure + sources metadata', 
     expect(sources[1]).toMatchObject({ name: 'related_documents', ok: true, count: 1 })
   })
 })
+
+// PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY): getDiscussions / getDiscussionThread call
+// the provider's EXISTING /api/v1/discussions routes -- no capability/SKU gate on this read
+// path (see the PLMAdapter.ts type-block docstring). A missing/unreadable target comes back as
+// the provider's indistinguishable 404, surfaced as `result.error`, never thrown.
+describe('PLMAdapter Yuantus discussion reads', () => {
+  it('lists discussion threads for a target, forwarding target/list query params to /api/v1/discussions', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [{
+        threads: [{
+          id: 'thread-1',
+          target_type: 'item',
+          target_id: 'item-1',
+          title: 'Check tolerance',
+          status: 'open',
+          created_by_id: 1,
+          created_at: '2026-07-09T00:00:00.000Z',
+          resolved_by_id: null,
+          resolved_at: null,
+          last_comment_at: '2026-07-09T00:05:00.000Z',
+          comment_count: 2,
+          anchor: null,
+        }],
+        next_cursor: null,
+      }],
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getDiscussions(
+      { targetType: 'item', targetId: 'item-1' },
+      { includeResolved: true, includeChildren: true, limit: 20, cursor: 'cursor-abc' },
+    )
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/discussions', [{
+      target_type: 'item',
+      target_id: 'item-1',
+      include_resolved: true,
+      include_children: true,
+      limit: 20,
+      cursor: 'cursor-abc',
+    }])
+    expect(result.data[0]).toMatchObject({
+      threads: [expect.objectContaining({ id: 'thread-1', status: 'open', comment_count: 2 })],
+      next_cursor: null,
+    })
+    expect(result.error).toBeUndefined()
+  })
+
+  it('omits optional list params when not supplied', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({ data: [{ threads: [], next_cursor: null }] })
+    ;(adapter as any).query = queryMock
+
+    await adapter.getDiscussions({ targetType: 'eco', targetId: 'eco-1' })
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/discussions', [{
+      target_type: 'eco',
+      target_id: 'eco-1',
+    }])
+  })
+
+  it('fetches one discussion thread with its comments from /api/v1/discussions/{thread_id}', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({
+      data: [{
+        id: 'thread-1',
+        target_type: 'item',
+        target_id: 'item-1',
+        title: 'Check tolerance',
+        status: 'open',
+        created_by_id: 1,
+        created_at: '2026-07-09T00:00:00.000Z',
+        resolved_by_id: null,
+        resolved_at: null,
+        last_comment_at: '2026-07-09T00:05:00.000Z',
+        comment_count: 1,
+        anchor: null,
+        comments: [{
+          id: 'comment-1',
+          parent_comment_id: null,
+          body: 'Confirm with vendor',
+          body_format: 'text',
+          author_user_id: 1,
+          mentioned_user_ids: [],
+          created_at: '2026-07-09T00:05:00.000Z',
+          edited_at: null,
+          deleted_at: null,
+          anchor: null,
+        }],
+        history: [{ kind: 'lifecycle_transition', at: '2026-07-08T00:00:00.000Z' }],
+      }],
+    })
+
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getDiscussionThread('thread-1', { includeHistory: true })
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/discussions/thread-1', [{ include_history: true }])
+    expect(result.data[0]).toMatchObject({
+      id: 'thread-1',
+      comments: [expect.objectContaining({ id: 'comment-1', author_user_id: 1 })],
+      history: [expect.objectContaining({ kind: 'lifecycle_transition' })],
+    })
+    expect(result.error).toBeUndefined()
+  })
+
+  it('omits include_history when not requested', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({ data: [{ id: 'thread-1', comments: [] }] })
+    ;(adapter as any).query = queryMock
+
+    await adapter.getDiscussionThread('thread-1')
+
+    expect(queryMock).toHaveBeenCalledWith('/api/v1/discussions/thread-1', [{}])
+  })
+
+  it('surfaces the provider no-leak 404 as a QueryResult error, never a thrown exception, for a missing/unreadable target', async () => {
+    const adapter = createAdapter()
+    const notFoundError = Object.assign(new Error('Request failed with status code 404'), {
+      response: { status: 404, data: { detail: 'discussion target not found' } },
+    })
+    const queryMock = vi.fn().mockResolvedValue({ data: [], error: notFoundError })
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getDiscussions({ targetType: 'item', targetId: 'missing-item' })
+
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+    expect((result.error as any)?.response?.status).toBe(404)
+  })
+
+  it('is not gated by apiMode !== yuantus (legacy PLM has no discussion surface)', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).apiMode = 'legacy'
+
+    const result = await adapter.getDiscussions({ targetType: 'item', targetId: 'item-1' })
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+
+    const detailResult = await adapter.getDiscussionThread('thread-1')
+    expect(detailResult.data).toHaveLength(0)
+    expect(detailResult.error).toBeDefined()
+  })
+})


### PR DESCRIPTION
Consumer half of Discussion Phase-3 slice-1 (READ-ONLY). The Yuantus provider side is already merged (adharamans/yuantus-plm #1155, `309d3e4a`, main-push confirmed), so provider-first is satisfied.

- `PLMAdapter.getDiscussions(target, options?)` → `GET /api/v1/discussions`; `getDiscussionThread(threadId, options?)` → `GET /api/v1/discussions/{thread_id}` — mirrors the existing `getWhereUsed`/`getBomCompare` auth/pattern (Bearer + x-tenant-id).
- 3 consumer pact interactions (list / detail+history / no-leak 404), verified against the Yuantus provider (all green there).
- Tests: 48 adapter+pact + 4520 unit pass; `tsc --noEmit` clean.

**Read-only, no write channel, no capability/SKU gating** this slice (the discussion read routes are bearer-JWT + target-permission gated, not entitlement-gated). The `discussion_core` capability manifest + graceful-downgrade + a UI panel + the write channel are later slices per the Yuantus Phase-3 taskbook (#1153).

**HELD for your word to merge** (metasheet2 discipline). Merging publishes the consumer pact (push:main) against a provider that already speaks the states. DEV/V: `docs/development/plm-yuantus-discussion-phase3-read-consumer-slice1-20260709.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)