### PR TITLE
fix(directory): case-insensitive admission uniqueness + server-side batch-admit eligibility (#3972 P2-1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -396,6 +396,7 @@ jobs:
             tests/integration/approval-node-signature-policy.api.test.ts \
             tests/integration/dingtalk-approval-card-deliveries.db.test.ts \
             tests/integration/dingtalk-container-login.db.test.ts \
+            tests/integration/directory-admission-case-insensitive-uniqueness.db.test.ts \
             tests/integration/directory-primary-department-write.db.test.ts \
             tests/integration/directory-primary-department-backfill.db.test.ts \
             tests/integration/directory-sync-preview-apply-parity.db.test.ts \

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3951,6 +3951,52 @@ export async function batchBindDirectoryAccounts(
   return outcome
 }
 
+/**
+ * P2-1 (post-#3972 review): "only admit pending items with no local user and no
+ * recommendation candidate" is enforced ONLY in the Vue computed
+ * (`selectedReviewAdmissionIds` in DirectoryManagementView.vue) — a direct POST to
+ * batch-admit-users bypasses it entirely. This mirrors that rule at the minimum-safe
+ * level for the server: reject an account that is already linked to a local user, or
+ * whose email/mobile (case-insensitively — recommendations themselves are built from a
+ * case-insensitive email match, see loadDirectoryReviewRecommendations) already maps to
+ * an existing active user, instead of silently admitting a duplicate or overwriting an
+ * existing link.
+ */
+async function assertDirectoryAccountEligibleForBatchAdmission(
+  account: Pick<DirectoryBindingTargetAccountRow, 'id' | 'email' | 'mobile'>,
+): Promise<void> {
+  const linkResult = await query<{ link_status: string | null; local_user_id: string | null }>(
+    `SELECT link_status, local_user_id
+     FROM directory_account_links
+     WHERE directory_account_id = $1::uuid
+     LIMIT 1`,
+    [account.id],
+  )
+  const link = linkResult.rows[0]
+  if (link?.link_status === 'linked' && normalizeText(link.local_user_id)) {
+    throw new Error('Directory account is already linked to a local user')
+  }
+
+  const normalizedEmail = normalizeText(account.email).toLowerCase()
+  const normalizedMobile = normalizeText(account.mobile)
+  if (!normalizedEmail && !normalizedMobile) return
+
+  const matchResult = await query<{ id: string }>(
+    `SELECT id
+     FROM users
+     WHERE COALESCE(is_active, TRUE) = TRUE
+       AND (
+         ($1::text <> '' AND lower(email) = $1::text)
+         OR ($2::text <> '' AND mobile = $2::text)
+       )
+     LIMIT 1`,
+    [normalizedEmail, normalizedMobile],
+  )
+  if (matchResult.rows.length > 0) {
+    throw new Error('A local user with this email or mobile already exists; confirm the recommended binding instead of admitting a new account')
+  }
+}
+
 export async function batchAdmitDirectoryAccountUsers(
   directoryAccountIds: string[],
   input: DirectoryAccountBatchAdmissionInput,
@@ -3965,6 +4011,7 @@ export async function batchAdmitDirectoryAccountUsers(
     try {
       const account = await loadDirectoryBindingTargetAccount(accountId)
       if (!account) throw new Error('Directory account not found')
+      await assertDirectoryAccountEligibleForBatchAdmission(account)
       const fallbackName = normalizeText(account.external_user_id) || account.id
       const admissionName = normalizeText(account.name).length >= 2 ? account.name : fallbackName
       outcome.succeeded.push(await admitDirectoryAccountUser(account.id, {
@@ -4175,10 +4222,19 @@ async function createDirectoryAdmittedUserInTransaction(
   }
 
   if (options.email) {
+    // Case-insensitive on purpose: directory sync's own account↔user matching (see
+    // loadDirectoryReviewRecommendations, LOWER(email) = ANY(...)) and AuthService's login
+    // lookup (lower(email) = $1) both treat email identity as case-insensitive, but
+    // AuthService.register stores the raw-case value and the `idx_users_email` unique index is
+    // ALSO case-sensitive — so it does not backstop this at the DB layer. A case-sensitive
+    // check here let a differently-cased admission (e.g. `alice@x.com` vs a stored
+    // `Alice@x.com`) slip past and create a second `users` row for the same person. Matches
+    // the users_email_lower_idx (lower(email)) index already in place for this exact lookup
+    // shape.
     const existingUserResult = await client.query(
       `SELECT id
        FROM users
-       WHERE email = $1::text
+       WHERE lower(email) = lower($1::text)
        LIMIT 1`,
       [options.email],
     )

--- a/packages/core-backend/tests/integration/directory-admission-case-insensitive-uniqueness.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-admission-case-insensitive-uniqueness.db.test.ts
@@ -1,0 +1,238 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { query, transaction } from '../../src/db/pg'
+import {
+  batchAdmitDirectoryAccountUsers,
+  __directorySyncInternalsForTests,
+} from '../../src/directory/directory-sync'
+
+/**
+ * P2-1 (post-#3972 review) — proved on real Postgres by the review.
+ *
+ * Directory admission's create-time uniqueness backstop was CASE-SENSITIVE
+ * (`WHERE email = $1`, in `createDirectoryAdmittedUserInTransaction`), but directory sync's own
+ * account<->user matching is CASE-INSENSITIVE (`LOWER(email)`, see
+ * loadDirectoryReviewRecommendations), and AuthService.register stores raw-case emails. A stored
+ * `Alice@x.com` + an admission of `alice@x.com` therefore slipped past the existence check and
+ * created a SECOND `users` row for the same person — the review drove
+ * `batchAdmitDirectoryAccountUsers` on real PG and watched the user count go 1->2. The DB's own
+ * `idx_users_email` unique index is ALSO case-sensitive, so it does not backstop this either —
+ * only an app-level case-insensitive check closes it (see users_email_lower_idx).
+ *
+ * Additionally, the "only admit accounts with no local user and no recommendation candidate"
+ * eligibility gate lived ONLY in the Vue computed (`selectedReviewAdmissionIds` in
+ * DirectoryManagementView.vue) — never enforced server-side — so a direct POST to
+ * /api/admin/directory/accounts/batch-admit-users could bypass it.
+ *
+ * These tests exercise the real admission path against real Postgres and prove both fixes,
+ * isolated from each other so a regression in either one is independently detectable:
+ *  1. The create-time email check is now case-insensitive. Proved via
+ *     `batchAdmitDirectoryAccountUsers` with an account that has NO existing directory_account_links
+ *     row (so the batch-admit eligibility gate's "already linked" branch cannot be what rejects
+ *     it) but whose email case-insensitively collides with an existing user — the email/mobile
+ *     branch of the eligibility gate and the create-time check both key off the SAME
+ *     lower(email) semantics, so this also exercises the create-time backstop's own fix
+ *     directly via the unit-style real-DB call below.
+ *  2. batchAdmitDirectoryAccountUsers now rejects an ineligible account server-side BEFORE it
+ *     would ever reach the create-time check — proved via a scenario the create-time check
+ *     alone would not catch (an account already linked to a local user, no email/mobile at
+ *     all).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const { createDirectoryAdmittedUserInTransaction } = __directorySyncInternalsForTests
+
+const TS = Date.now()
+
+describeIfDatabase('P2-1 directory admission case-insensitive uniqueness + batch-admit eligibility (real DB)', () => {
+  let integrationId = ''
+
+  async function seedIntegrationAccount(opts: {
+    email: string | null
+    mobile: string | null
+    unionId: string | null
+    tag: string
+  }) {
+    const external = `oa-p21-${opts.tag}-${TS}`
+    const externalKey = opts.unionId || external
+    const id = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, email, mobile, is_active)
+       VALUES ($1, 'dingtalk', 'corpP21', $2, $3, NULL, $4, 'Fixture P2-1', $5, $6, true) RETURNING id::text AS id`,
+      [integrationId, external, opts.unionId, externalKey, opts.email, opts.mobile],
+    )).rows[0].id
+    return {
+      id,
+      integration_id: integrationId,
+      provider: 'dingtalk',
+      corp_id: 'corpP21',
+      external_user_id: external,
+      union_id: opts.unionId,
+      open_id: null as string | null,
+      external_key: externalKey,
+      name: 'Fixture P2-1',
+      email: opts.email,
+      mobile: opts.mobile,
+    }
+  }
+
+  const userCountByEmailCI = async (email: string) =>
+    (await query<{ n: number }>(`SELECT count(*)::int AS n FROM users WHERE lower(email) = lower($1)`, [email])).rows[0].n
+
+  const userCountByUsername = async (username: string) =>
+    (await query<{ n: number }>(`SELECT count(*)::int AS n FROM users WHERE username = $1`, [username])).rows[0].n
+
+  beforeAll(async () => {
+    integrationId = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id::text AS id`,
+      [`p21-uniq-${TS}`, `p21-corp-${TS}`],
+    )).rows[0].id
+  })
+
+  // The control test admits via the email path, which leaves username NULL (see
+  // batchAdmitDirectoryAccountUsers: username is only synthesized when the account has no
+  // email) — so cleanup must also match by this suite's TS-tagged email, not just username.
+  const testUserMatchClause = `(username LIKE $1 OR lower(email) LIKE $2)`
+  const testUserMatchParams = [`p21-%-${TS}`, `%-${TS}@x.com`]
+
+  afterEach(async () => {
+    // Each test owns its usernames/emails; clean any admitted/orphaned rows between tests.
+    await query(`DELETE FROM directory_account_links WHERE local_user_id IN (SELECT id FROM users WHERE ${testUserMatchClause})`, testUserMatchParams)
+    await query(`DELETE FROM user_external_identities WHERE local_user_id IN (SELECT id FROM users WHERE ${testUserMatchClause})`, testUserMatchParams)
+    await query(`DELETE FROM users WHERE ${testUserMatchClause}`, testUserMatchParams)
+  })
+
+  afterAll(async () => {
+    if (!integrationId) return
+    await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+    await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+  })
+
+  // Part 1, isolated: createDirectoryAdmittedUserInTransaction's create-time existence check
+  // must reject a differently-cased email match, not just an exact one — the review's exact
+  // finding (user count 1 -> 2). Driven directly (not through batchAdmitDirectoryAccountUsers)
+  // so a regression here is detectable even if the batch-admit eligibility gate (Part 2) is
+  // independently broken or bypassed via the single-admit route.
+  it('createDirectoryAdmittedUserInTransaction rejects a case-differently-cased email match (no duplicate)', async () => {
+    const email = `Alice-${TS}@x.com`
+    const username = `p21-alice-${TS}`
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, is_active) VALUES ($1, $2, $1, 'Alice', 'x', true)`,
+      [username, email],
+    )
+    await expect(userCountByEmailCI(email)).resolves.toBe(1)
+
+    const account = await seedIntegrationAccount({
+      email: email.toLowerCase(),
+      mobile: null,
+      unionId: `union-p21-a-${TS}`,
+      tag: 'a',
+    })
+
+    let threw = false
+    let message = ''
+    await transaction(async (client) => {
+      try {
+        await createDirectoryAdmittedUserInTransaction(client, {
+          account,
+          adminUserId: 'system:test',
+          name: 'Alice Admitted',
+          email: email.toLowerCase(),
+          username: null,
+          mobile: null,
+          passwordHash: 'hashed',
+          mustChangePassword: true,
+          enableDingTalkGrant: false,
+        })
+      } catch (error) {
+        threw = true
+        message = error instanceof Error ? error.message : String(error)
+      }
+    })
+
+    expect(threw).toBe(true)
+    expect(message).toMatch(/already exists/i)
+    // The review's exact finding was count going 1 -> 2. It must stay 1.
+    await expect(userCountByEmailCI(email)).resolves.toBe(1)
+  })
+
+  // Primary scenario, end to end: drive the actual vulnerable route's service function
+  // (batchAdmitDirectoryAccountUsers) with the review's exact case-mismatch setup and assert no
+  // second user is created.
+  it('batchAdmitDirectoryAccountUsers rejects an account whose email case-insensitively matches an existing user', async () => {
+    const email = `Bob-${TS}@x.com`
+    const username = `p21-bob-${TS}`
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, is_active) VALUES ($1, $2, $1, 'Bob', 'x', true)`,
+      [username, email],
+    )
+
+    const account = await seedIntegrationAccount({
+      email: email.toLowerCase(),
+      mobile: null,
+      unionId: `union-p21-b-${TS}`,
+      tag: 'b',
+    })
+
+    const outcome = await batchAdmitDirectoryAccountUsers([account.id], { adminUserId: 'system:test' })
+
+    expect(outcome.succeeded).toEqual([])
+    expect(outcome.failed).toEqual([
+      { accountId: account.id, error: expect.stringMatching(/already exists/i) },
+    ])
+    await expect(userCountByEmailCI(email)).resolves.toBe(1) // NOT 2
+  })
+
+  // Part 2, isolated: an account already linked to a local user, with NO email/mobile at all,
+  // so Part 1's email check could never be what rejects it. Only the batch-admit eligibility
+  // gate's "already linked" branch protects this vector — re-admitting would otherwise create a
+  // brand new `users` row and silently repoint (orphan) the existing link.
+  it('batchAdmitDirectoryAccountUsers rejects an account already linked to a local user', async () => {
+    const boundUsername = `p21-bound-${TS}`
+    const boundUserId = (await query<{ id: string }>(
+      `INSERT INTO users (id, username, name, password_hash, is_active) VALUES ($1, $1, 'Bound Owner', 'x', true) RETURNING id`,
+      [boundUsername],
+    )).rows[0].id
+
+    const account = await seedIntegrationAccount({
+      email: null,
+      mobile: null,
+      unionId: `union-p21-c-${TS}`,
+      tag: 'c',
+    })
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at)
+       VALUES ($1::uuid, $2, 'linked', 'manual_admin', NOW(), NOW())`,
+      [account.id, boundUserId],
+    )
+
+    const outcome = await batchAdmitDirectoryAccountUsers([account.id], { adminUserId: 'system:test' })
+
+    expect(outcome.succeeded).toEqual([])
+    expect(outcome.failed).toEqual([
+      { accountId: account.id, error: expect.stringMatching(/already linked/i) },
+    ])
+    // No second user was created for this account, and the original link is untouched.
+    await expect(userCountByUsername(boundUsername)).resolves.toBe(1)
+    const link = await query<{ local_user_id: string }>(
+      `SELECT local_user_id FROM directory_account_links WHERE directory_account_id = $1::uuid`,
+      [account.id],
+    )
+    expect(link.rows[0]?.local_user_id).toBe(boundUserId)
+  })
+
+  // Control: a genuinely fresh account (no email/mobile collision, not linked) is still
+  // admitted normally — the new gate must not be overly broad.
+  it('admits a fresh, non-colliding account (control)', async () => {
+    const email = `Carol-${TS}@x.com`
+    const account = await seedIntegrationAccount({
+      email: email.toLowerCase(),
+      mobile: null,
+      unionId: `union-p21-d-${TS}`,
+      tag: 'd',
+    })
+
+    const outcome = await batchAdmitDirectoryAccountUsers([account.id], { adminUserId: 'system:test' })
+
+    expect(outcome.failed).toEqual([])
+    expect(outcome.succeeded).toHaveLength(1)
+    await expect(userCountByEmailCI(email)).resolves.toBe(1)
+  })
+})

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -1084,6 +1084,10 @@ describe('bindDirectoryAccount', () => {
           mobile: '13900001234',
         }],
       })
+      // P2-1 eligibility gate: no existing directory_account_links row for account-bulk-1
+      .mockResolvedValueOnce({ rows: [] })
+      // P2-1 eligibility gate: no active user matches account-bulk-1's mobile
+      .mockResolvedValueOnce({ rows: [] })
       // admitDirectoryAccountUser reloads account-1 + previous link
       .mockResolvedValueOnce({
         rows: [{
@@ -1165,6 +1169,81 @@ describe('bindDirectoryAccount', () => {
     expect(outcome.succeeded[0].temporaryPassword).toMatch(/^Tmp-/)
     expect(pgMocks.transaction).toHaveBeenCalledTimes(1)
     expect(inviteLedgerMocks.recordInvite).not.toHaveBeenCalled()
+  })
+
+  // P2-1 (post-#3972 review): a direct batch-admit call bypasses the UI's "no recommendation
+  // candidate" filter. The server must reject an account whose email case-insensitively
+  // matches an existing active user, instead of creating a duplicate `users` row.
+  it('rejects batch-admit for an account whose email case-insensitively matches an existing user', async () => {
+    pgMocks.transaction.mockImplementation(async () => {
+      throw new Error('transaction should not open for an ineligible account')
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-case-mismatch',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691175',
+          union_id: 'union-2',
+          open_id: null,
+          external_key: 'union-2',
+          name: 'Alice',
+          email: 'alice@x.com',
+          mobile: null,
+        }],
+      })
+      // P2-1 eligibility gate: no existing directory_account_links row
+      .mockResolvedValueOnce({ rows: [] })
+      // P2-1 eligibility gate: an active user already matches this email case-insensitively
+      .mockResolvedValueOnce({ rows: [{ id: 'user-existing' }] })
+
+    const outcome = await batchAdmitDirectoryAccountUsers(['account-case-mismatch'], {
+      adminUserId: 'admin-1',
+    })
+
+    expect(outcome.succeeded).toEqual([])
+    expect(outcome.failed).toEqual([
+      { accountId: 'account-case-mismatch', error: expect.stringMatching(/already exists/i) },
+    ])
+    expect(pgMocks.transaction).not.toHaveBeenCalled()
+  })
+
+  // P2-1: an account already linked to a local user must not be silently re-admitted into a
+  // brand new user (which would orphan the existing link).
+  it('rejects batch-admit for an account already linked to a local user', async () => {
+    pgMocks.transaction.mockImplementation(async () => {
+      throw new Error('transaction should not open for an ineligible account')
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-already-linked',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691176',
+          union_id: 'union-3',
+          open_id: null,
+          external_key: 'union-3',
+          name: 'Bob',
+          email: null,
+          mobile: null,
+        }],
+      })
+      // P2-1 eligibility gate: this account is already linked
+      .mockResolvedValueOnce({ rows: [{ link_status: 'linked', local_user_id: 'user-existing' }] })
+
+    const outcome = await batchAdmitDirectoryAccountUsers(['account-already-linked'], {
+      adminUserId: 'admin-1',
+    })
+
+    expect(outcome.succeeded).toEqual([])
+    expect(outcome.failed).toEqual([
+      { accountId: 'account-already-linked', error: expect.stringMatching(/already linked/i) },
+    ])
+    expect(pgMocks.transaction).not.toHaveBeenCalled()
   })
 
   // DT-HARDEN-04: symmetric to the batch-unbind isolation test above. A fail-fast bind

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -31,6 +31,12 @@ export default defineConfig({
       // INSERT when the bind throws after it. DATABASE_URL-gated; excluded here so the no-DB job
       // cannot skip-green it, and wired as a WHOLE FILE into the approval real-DB step.
       'tests/integration/directory-sync-admission-orphan-guard.db.test.ts',
+      // P2-1 (post-#3972 review): proves the create-time email existence check is
+      // case-insensitive and that batchAdmitDirectoryAccountUsers enforces server-side
+      // eligibility (no duplicate `users` row for a differently-cased email; no silent
+      // re-admission of an already-linked account). DATABASE_URL-gated; excluded here so the
+      // no-DB job cannot skip-green it, and wired as a WHOLE FILE into the approval real-DB step.
+      'tests/integration/directory-admission-case-insensitive-uniqueness.db.test.ts',
       'tests/integration/approval-manager-chain.db.test.ts',
       'tests/integration/approval-requester-department.db.test.ts',
       'tests/integration/approval-requester-title.db.test.ts',


### PR DESCRIPTION
## Summary

The #3972 review found — and proved on real Postgres — a P2 correctness defect in DingTalk directory admission: the create-time uniqueness backstop was case-sensitive while directory sync's own matching (and login) is case-insensitive, so a stored `Alice@x.com` plus an admission of `alice@x.com` slips past the check and creates a **second** `users` row for the same person. The review drove `batchAdmitDirectoryAccountUsers` on real PG and watched the user count go 1→2. This is bounded today only because the live DB happens to have zero mixed-case emails — it is a live, unbounded defect, not a hypothetical.

The review also flagged that the "no local user / no recommendation candidate" eligibility gate for batch-admit lives only in the Vue computed (`selectedReviewAdmissionIds` in `DirectoryManagementView.vue`) and is never enforced server-side, so a direct `POST /api/admin/directory/accounts/batch-admit-users` can bypass it.

This PR fixes both, minimally and locally within `packages/core-backend/src/directory/directory-sync.ts`:

1. **Case-insensitive uniqueness** — `createDirectoryAdmittedUserInTransaction`'s email existence check now uses `lower(email) = lower($1::text)` (matching the existing case-insensitive username check right below it, and the `users_email_lower_idx` index already in place). The `idx_users_email` unique index in Postgres is *also* case-sensitive, so it does not backstop this at the DB layer — the app-level check is the only guard. Username was already case-insensitive; mobile is digits-only and needed no change.
2. **Server-side batch-admit eligibility** — a new `assertDirectoryAccountEligibleForBatchAdmission` helper rejects an account that (a) is already linked to a local user, or (b) has an email/mobile that (case-insensitively) already matches an existing active user — mirroring the UI's eligibility rule at the minimum-safe level, so a direct API call can no longer create a duplicate or silently repoint an existing link.

## Real-DB proof

New file `packages/core-backend/tests/integration/directory-admission-case-insensitive-uniqueness.db.test.ts` (`describeIfDatabase`, real Postgres) reproduces the review's exact scenario and both fixes, isolated from each other:

- `createDirectoryAdmittedUserInTransaction rejects a case-differently-cased email match (no duplicate)` — drives the create-time check directly (bypassing the batch-admit gate), seeding `Alice@x.com` then admitting `alice@x.com`. Asserts it throws and the user count for that email stays **1**, not 2.
- `batchAdmitDirectoryAccountUsers rejects an account whose email case-insensitively matches an existing user` — end-to-end through the actual vulnerable route's service function.
- `batchAdmitDirectoryAccountUsers rejects an account already linked to a local user` — isolates the new eligibility gate (no email/mobile at all, so only the "already linked" branch can be what rejects it).
- `admits a fresh, non-colliding account (control)` — proves the new gate isn't overly broad.

**Mutation-proof (both parts, isolated):**
- Reverted `lower(email) = lower($1::text)` → `email = $1::text` → only the isolated create-time test went RED (`expected false to be true` — the check no longer threw); the other 3 stayed green. Restored, all 4 green again.
- Neutered the "already linked" branch of the new eligibility gate (`if (false && ...)`) → only the isolated eligibility test went RED, and it caught the actual vulnerability directly: `batchAdmitDirectoryAccountUsers` created a **second** `users` row for the already-linked account instead of rejecting it. The other 3 tests stayed green. Restored, all 4 green again.

## CI wiring (two-point, no skip-green)

- `packages/core-backend/vitest.config.ts` — added to the no-DB default job's `exclude` list (DATABASE_URL-gated, would otherwise skip-green).
- `.github/workflows/plugin-tests.yml` — wired as a **whole file** into the existing `Run approval real-DB integration` step (line ~399, alongside `directory-sync-admission-orphan-guard.db.test.ts`), so it runs against real Postgres every PR.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — exit 0
- [x] `npx vitest run tests/unit` — 338 files / 4520 tests passed
- [x] Real-DB: `directory-admission-case-insensitive-uniqueness.db.test.ts` — 4/4 passed (and alongside the other directory `.db.test.ts` files — 48/48 passed together)
- [x] Updated `directory-sync-bind-account.test.ts` (mock-based) for the two new query calls in the batch-admit success path, plus two new negative-path unit tests for the eligibility gate — 18/18 passed
- [x] `admin-directory-routes.test.ts` (mocks the whole `directory-sync` module) — unaffected, 44/44 passed

Refs the #3972 review's real-DB finding. Not opened against #3972 (already merged) — this is a follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
