### PR TITLE
feat(approval): add DingTalk interactive card stream gate

### DIFF
--- a/docs/development/approval-dingtalk-interactive-card-b1-development-verification-20260709.md
+++ b/docs/development/approval-dingtalk-interactive-card-b1-development-verification-20260709.md
@@ -1,0 +1,59 @@
+# 审批钉钉互动卡 · B-1 Stream worker skeleton 开发与验证 — 2026-07-09
+
+> Parent lock: `approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md`.
+> Owner said "请继续" after A-5 PASS and B-0 design-lock merge; this PR implements only **B-1**.
+
+## 1. Scope
+
+B-1 establishes the optional DingTalk interactive-card Stream worker boundary:
+
+- env-gated startup;
+- explicit Stream config resolver;
+- injectable SDK/client adapter seam;
+- server lifecycle startup/shutdown wiring;
+- values-free failure logs.
+
+It deliberately does **not** send interactive cards, parse approval callback payloads, call
+`executeApprovalActionFromCardDelivery`, or update cards in place. Those stay B-2/B-3/B-4.
+
+## 2. As-built
+
+| Piece | File | Behavior |
+|---|---|---|
+| Config resolver | `packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts` | Requires explicit `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=1`/`true` plus client id, client secret, and template id. Missing anything returns disabled with a reason code. |
+| Worker skeleton | same file | Calls an injected `clientFactory` only when fully configured; otherwise no Stream registration and no warning loop. |
+| Default factory | same file | Throws `DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED`; this is intentional until the real SDK adapter lands. If an operator enables B-1 early, startup fails closed with reason `client_start_failed`. |
+| Event handler | same file | Logs a values-free "ignored by B-1 skeleton" message. No business callback parsing. |
+| Server lifecycle | `packages/core-backend/src/index.ts` | Instantiates the worker during startup and shuts it down with the other optional services. Default env keeps it disabled. |
+
+## 3. Env contract
+
+| Env | B-1 behavior |
+|---|---|
+| `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` | Only `1` or `true` enables registration. Missing/other values disable the worker. |
+| `DINGTALK_INTERACTIVE_CARD_CLIENT_ID` | Required when enabled. |
+| `DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET` | Required when enabled; never logged. |
+| `DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID` | Required when enabled. |
+
+This PR does not reuse the existing work-notification app credentials implicitly. The parent lock allows that as a future explicit implementation choice, but B-1 keeps the boundary narrow and reviewable.
+
+## 4. Verification
+
+Unit tests: `packages/core-backend/tests/unit/dingtalk-interactive-card-stream.test.ts`
+
+Covered cases:
+
+1. default disabled state reports `env_disabled` and does not call the client factory;
+2. enabled flag with partial config fails closed by missing setting reason;
+3. full config calls the injected client factory and starts the client;
+4. B-1 event handler ignores events without invoking any approval action path;
+5. shutdown closes the injected client;
+6. client-factory failure returns `client_start_failed` and logs only a reason code, not SDK error text or secrets.
+
+## 5. Next slices
+
+- **B-2**: interactive-card send path + `delivery_kind='interactive_card'`.
+- **B-3**: callback adapter -> `executeApprovalActionFromCardDelivery`.
+- **B-4**: card terminal update + duplicate/stale convergence.
+
+Do not declare Slice B shipped until B-1..B-4 plus real DingTalk Stream UAT pass.

--- a/docs/development/approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md
+++ b/docs/development/approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md
@@ -1,9 +1,10 @@
 # 审批钉钉互动卡 Slice B · DESIGN-LOCK — 2026-07-09
 
-> Status: **PROPOSED**. This document is a runtime design lock, not an implementation PR.
+> Status: **RATIFIED FOR B-1**. This document is a runtime design lock, not an implementation PR.
 > It opens only because Slice A A-5 has PASS evidence in
 > `approval-dingtalk-one-tap-a5-verification-20260705.md` §4.1.
-> Runtime B-1..B-4 still require owner ratification of this design-lock.
+> 2026-07-09 owner said "请继续"; B-1 may ship on the recommended defaults below.
+> Runtime B-2..B-4 still ship as separate reviewed slices.
 
 ## 1. Goal
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -170,6 +170,7 @@ import { createMultitableButtonRoutes } from './routes/multitable-button'
 import { apiTokensRouter } from './routes/api-tokens'
 import { SnapshotService } from './services/SnapshotService'
 import { MetricsStreamService } from './services/MetricsStreamService'
+import { DingTalkInteractiveCardStreamWorker } from './integrations/dingtalk/interactive-card-stream'
 import { notificationService } from './services/NotificationService'
 import { AfterSalesApprovalBridgeService } from './services/AfterSalesApprovalBridgeService'
 import {
@@ -257,6 +258,7 @@ export class MetaSheetServer {
   private disableWorkflow = process.env.DISABLE_WORKFLOW === 'true'
   private disableEventBus = process.env.DISABLE_EVENT_BUS === 'true'
   private metricsStreamService?: MetricsStreamService
+  private dingtalkInteractiveCardStreamWorker?: DingTalkInteractiveCardStreamWorker
   
   // IoC Container
   private injector: Injector
@@ -1868,6 +1870,15 @@ export class MetaSheetServer {
       )
     }
 
+    // 0c. Shut down optional DingTalk interactive-card Stream worker
+    if (this.dingtalkInteractiveCardStreamWorker) {
+      shutdownTasks.push(
+        this.dingtalkInteractiveCardStreamWorker.shutdown().catch((err) => {
+          this.logger.warn(`DingTalk interactive-card Stream shutdown error: ${err instanceof Error ? err.message : String(err)}`)
+        }) as Promise<void>,
+      )
+    }
+
     // 1. Close HTTP server
     shutdownTasks.push(new Promise<void>((resolve) => {
       try {
@@ -2644,6 +2655,14 @@ export class MetaSheetServer {
       this.metricsStreamService.initialize(this.httpServer)
     } catch (e) {
       this.logger.error('Failed to initialize MetricsStreamService', e as Error)
+    }
+
+    // Initialize optional DingTalk interactive-card Stream worker (B-1 skeleton; default disabled).
+    try {
+      this.dingtalkInteractiveCardStreamWorker = new DingTalkInteractiveCardStreamWorker()
+      await this.dingtalkInteractiveCardStreamWorker.initialize()
+    } catch (e) {
+      this.logger.error('Failed to initialize DingTalkInteractiveCardStreamWorker', e as Error)
     }
 
     this.installGlobalErrorHandler()

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts
@@ -1,0 +1,178 @@
+/**
+ * B-1 (DingTalk interactive approval cards): env-gated Stream worker skeleton.
+ *
+ * This slice deliberately does not execute approval actions. It establishes the
+ * optional worker boundary and SDK adapter seam so B-2/B-3 can add send/callback
+ * behavior without changing startup/shutdown discipline.
+ */
+import { Logger } from '../../core/logger'
+
+export const DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV = 'DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED'
+export const DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV = 'DINGTALK_INTERACTIVE_CARD_CLIENT_ID'
+export const DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV = 'DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET'
+export const DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV = 'DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID'
+
+export type DingTalkInteractiveCardStreamDisabledReason =
+  | 'env_disabled'
+  | 'missing_client_id'
+  | 'missing_client_secret'
+  | 'missing_template_id'
+
+export type DingTalkInteractiveCardStreamConfig =
+  | {
+    enabled: false
+    reason: DingTalkInteractiveCardStreamDisabledReason
+    requirements: {
+      clientId: boolean
+      clientSecret: boolean
+      templateId: boolean
+    }
+  }
+  | {
+    enabled: true
+    clientId: string
+    clientSecret: string
+    templateId: string
+    requirements: {
+      clientId: true
+      clientSecret: true
+      templateId: true
+    }
+  }
+
+export type DingTalkInteractiveCardStreamEvent = {
+  /** Transport-level event type, values-free. B-3 owns semantic callback parsing. */
+  eventType?: string
+  /** Provider/card event id if present. Do not trust this as a business identifier. */
+  eventId?: string
+}
+
+export type DingTalkInteractiveCardStreamHandlers = {
+  onEvent(event: DingTalkInteractiveCardStreamEvent): Promise<void>
+}
+
+export type DingTalkInteractiveCardStreamClient = {
+  start(): Promise<void>
+  close(): Promise<void>
+}
+
+export type DingTalkInteractiveCardStreamClientFactory = (
+  config: Extract<DingTalkInteractiveCardStreamConfig, { enabled: true }>,
+  handlers: DingTalkInteractiveCardStreamHandlers,
+) => Promise<DingTalkInteractiveCardStreamClient> | DingTalkInteractiveCardStreamClient
+
+export type DingTalkInteractiveCardStreamWorkerStatus =
+  | { state: 'disabled'; reason: DingTalkInteractiveCardStreamDisabledReason }
+  | { state: 'active' }
+  | { state: 'failed'; reason: 'client_start_failed' | 'client_stop_failed' }
+
+function readEnv(env: NodeJS.ProcessEnv, key: string): string {
+  return typeof env[key] === 'string' ? env[key]!.trim() : ''
+}
+
+function isEnabledFlag(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+  return normalized === '1' || normalized === 'true'
+}
+
+export function resolveDingTalkInteractiveCardStreamConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): DingTalkInteractiveCardStreamConfig {
+  const enabled = isEnabledFlag(readEnv(env, DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV))
+  const clientId = readEnv(env, DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV)
+  const clientSecret = readEnv(env, DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV)
+  const templateId = readEnv(env, DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV)
+  const requirements = {
+    clientId: Boolean(clientId),
+    clientSecret: Boolean(clientSecret),
+    templateId: Boolean(templateId),
+  }
+
+  if (!enabled) return { enabled: false, reason: 'env_disabled', requirements }
+  if (!clientId) return { enabled: false, reason: 'missing_client_id', requirements }
+  if (!clientSecret) return { enabled: false, reason: 'missing_client_secret', requirements }
+  if (!templateId) return { enabled: false, reason: 'missing_template_id', requirements }
+
+  return {
+    enabled: true,
+    clientId,
+    clientSecret,
+    templateId,
+    requirements: {
+      clientId: true,
+      clientSecret: true,
+      templateId: true,
+    },
+  }
+}
+
+export const unwiredDingTalkInteractiveCardStreamClientFactory: DingTalkInteractiveCardStreamClientFactory = async () => {
+  throw new Error('DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED')
+}
+
+export class DingTalkInteractiveCardStreamWorker {
+  private readonly logger: Pick<Logger, 'info' | 'warn'>
+  private readonly clientFactory: DingTalkInteractiveCardStreamClientFactory
+  private client: DingTalkInteractiveCardStreamClient | null = null
+  private status: DingTalkInteractiveCardStreamWorkerStatus = { state: 'disabled', reason: 'env_disabled' }
+
+  constructor(options: {
+    logger?: Pick<Logger, 'info' | 'warn'>
+    clientFactory?: DingTalkInteractiveCardStreamClientFactory
+  } = {}) {
+    this.logger = options.logger ?? new Logger('DingTalkInteractiveCardStreamWorker')
+    this.clientFactory = options.clientFactory ?? unwiredDingTalkInteractiveCardStreamClientFactory
+  }
+
+  getStatus(): DingTalkInteractiveCardStreamWorkerStatus {
+    return this.status
+  }
+
+  async initialize(env: NodeJS.ProcessEnv = process.env): Promise<DingTalkInteractiveCardStreamWorkerStatus> {
+    const config = resolveDingTalkInteractiveCardStreamConfig(env)
+    if (config.enabled === false) {
+      this.status = { state: 'disabled', reason: config.reason }
+      this.logger.info(`DingTalk interactive-card Stream worker disabled (${config.reason})`)
+      return this.status
+    }
+
+    try {
+      const client = await this.clientFactory(config, {
+        onEvent: async (event) => {
+          await this.handleEvent(event)
+        },
+      })
+      await client.start()
+      this.client = client
+      this.status = { state: 'active' }
+      this.logger.info('DingTalk interactive-card Stream worker started')
+      return this.status
+    } catch {
+      this.client = null
+      this.status = { state: 'failed', reason: 'client_start_failed' }
+      // Values-free: do not log SDK error messages because they may include transport payloads or credentials.
+      this.logger.warn('DingTalk interactive-card Stream worker failed to start (client_start_failed)')
+      return this.status
+    }
+  }
+
+  async shutdown(): Promise<DingTalkInteractiveCardStreamWorkerStatus> {
+    if (!this.client) return this.status
+    try {
+      await this.client.close()
+      this.client = null
+      this.status = { state: 'disabled', reason: 'env_disabled' }
+      this.logger.info('DingTalk interactive-card Stream worker shut down')
+      return this.status
+    } catch {
+      this.status = { state: 'failed', reason: 'client_stop_failed' }
+      this.logger.warn('DingTalk interactive-card Stream worker failed to stop (client_stop_failed)')
+      return this.status
+    }
+  }
+
+  private async handleEvent(_event: DingTalkInteractiveCardStreamEvent): Promise<void> {
+    // B-1 owns only the worker boundary. B-3 will parse callbacks and call the card-delivery wrapper.
+    this.logger.info('DingTalk interactive-card Stream event received (ignored by B-1 skeleton)')
+  }
+}

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-stream.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-stream.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV,
+  DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV,
+  DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV,
+  DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV,
+  DingTalkInteractiveCardStreamWorker,
+  resolveDingTalkInteractiveCardStreamConfig,
+  type DingTalkInteractiveCardStreamClient,
+  type DingTalkInteractiveCardStreamClientFactory,
+  type DingTalkInteractiveCardStreamHandlers,
+} from '../../src/integrations/dingtalk/interactive-card-stream'
+
+function env(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  return {
+    ...overrides,
+  } as NodeJS.ProcessEnv
+}
+
+function logger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+  }
+}
+
+describe('DingTalk interactive-card Stream worker (B-1)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('resolveDingTalkInteractiveCardStreamConfig', () => {
+    it('is disabled by default and reports requirements without reading secrets into logs', () => {
+      const config = resolveDingTalkInteractiveCardStreamConfig(env())
+      expect(config).toEqual({
+        enabled: false,
+        reason: 'env_disabled',
+        requirements: {
+          clientId: false,
+          clientSecret: false,
+          templateId: false,
+        },
+      })
+    })
+
+    it('requires explicit enable plus all three Stream settings', () => {
+      expect(resolveDingTalkInteractiveCardStreamConfig(env({
+        [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+      }))).toMatchObject({ enabled: false, reason: 'missing_client_id' })
+
+      expect(resolveDingTalkInteractiveCardStreamConfig(env({
+        [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: 'true',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+      }))).toMatchObject({ enabled: false, reason: 'missing_client_secret' })
+
+      expect(resolveDingTalkInteractiveCardStreamConfig(env({
+        [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: 'secret-1',
+      }))).toMatchObject({ enabled: false, reason: 'missing_template_id' })
+    })
+
+    it('resolves active config only when the flag and all settings are present', () => {
+      const config = resolveDingTalkInteractiveCardStreamConfig(env({
+        [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: ' client-1 ',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: ' secret-1 ',
+        [DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]: ' template-1 ',
+      }))
+      expect(config).toEqual({
+        enabled: true,
+        clientId: 'client-1',
+        clientSecret: 'secret-1',
+        templateId: 'template-1',
+        requirements: {
+          clientId: true,
+          clientSecret: true,
+          templateId: true,
+        },
+      })
+    })
+  })
+
+  describe('DingTalkInteractiveCardStreamWorker', () => {
+    it('does not call the Stream client factory when disabled', async () => {
+      const log = logger()
+      const factory = vi.fn<DingTalkInteractiveCardStreamClientFactory>()
+      const worker = new DingTalkInteractiveCardStreamWorker({ logger: log, clientFactory: factory })
+
+      await expect(worker.initialize(env())).resolves.toEqual({ state: 'disabled', reason: 'env_disabled' })
+      expect(factory).not.toHaveBeenCalled()
+      expect(log.info).toHaveBeenCalledWith('DingTalk interactive-card Stream worker disabled (env_disabled)')
+    })
+
+    it('starts the injected Stream client when fully configured and ignores events in B-1', async () => {
+      const log = logger()
+      const client: DingTalkInteractiveCardStreamClient = {
+        start: vi.fn(async () => {}),
+        close: vi.fn(async () => {}),
+      }
+      let handlers: DingTalkInteractiveCardStreamHandlers | null = null
+      const factory = vi.fn<DingTalkInteractiveCardStreamClientFactory>(async (_config, h) => {
+        handlers = h
+        return client
+      })
+      const worker = new DingTalkInteractiveCardStreamWorker({ logger: log, clientFactory: factory })
+
+      await expect(worker.initialize(env({
+        [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: 'secret-1',
+        [DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]: 'template-1',
+      }))).resolves.toEqual({ state: 'active' })
+
+      expect(factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          clientId: 'client-1',
+          clientSecret: 'secret-1',
+          templateId: 'template-1',
+        }),
+        expect.objectContaining({ onEvent: expect.any(Function) }),
+      )
+      expect(client.start).toHaveBeenCalledTimes(1)
+
+      await handlers?.onEvent({ eventType: 'approval-card-click', eventId: 'evt-1' })
+      expect(log.info).toHaveBeenCalledWith('DingTalk interactive-card Stream event received (ignored by B-1 skeleton)')
+
+      await expect(worker.shutdown()).resolves.toEqual({ state: 'disabled', reason: 'env_disabled' })
+      expect(client.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails closed and logs only a reason code when the client factory throws', async () => {
+      const log = logger()
+      const factory = vi.fn<DingTalkInteractiveCardStreamClientFactory>(async () => {
+        throw new Error('secret-1 raw payload leaked by SDK')
+      })
+      const worker = new DingTalkInteractiveCardStreamWorker({ logger: log, clientFactory: factory })
+
+      await expect(worker.initialize(env({
+        [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: 'secret-1',
+        [DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]: 'template-1',
+      }))).resolves.toEqual({ state: 'failed', reason: 'client_start_failed' })
+
+      expect(log.warn).toHaveBeenCalledWith('DingTalk interactive-card Stream worker failed to start (client_start_failed)')
+      expect(JSON.stringify(log.warn.mock.calls)).not.toContain('secret-1')
+      expect(JSON.stringify(log.warn.mock.calls)).not.toContain('raw payload')
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- Implements B-1 from the DingTalk interactive-card design lock: an env-gated Stream worker skeleton.
- Adds `resolveDingTalkInteractiveCardStreamConfig` and `DingTalkInteractiveCardStreamWorker`.
- Wires the worker into backend startup/shutdown; default env keeps it disabled.
- Keeps the real SDK as an injected adapter seam. The default factory fails closed if someone enables the worker before B-2/B-3 wire the SDK.
- Adds B-1 development/verification notes and marks the parent lock ratified for B-1 only.

## What this does not do

- No interactive-card send path.
- No callback parsing.
- No approval action execution.
- No card terminal update.
- No new dependency or DingTalk SDK package.

## Verification

- `pnpm install --frozen-lockfile` in the isolated worktree; lockfile unchanged.
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-interactive-card-stream.test.ts --reporter=dot` — 6/6 pass.
- `pnpm --filter @metasheet/core-backend type-check` — pass.
- `git diff --cached --check` — pass.
- Sensitive-string grep for live A-5 token/user/corp patterns and secret assignment patterns — no matches.

## Review focus

- Default-off behavior: no env means no Stream registration.
- Values-free failure behavior: factory/SDK failure logs only reason codes.
- Scope boundary: B-1 ignores events; B-3 owns callback-to-wrapper execution.
