### PR TITLE
feat(attendance): R8 — quiet-hours window for DingTalk notification delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,10 @@ JWT_EXPIRES_IN=2h
 #   notifications simply wait (no event loss, no retry/lease interaction) until the
 #   window ends. Unset/empty = off (unchanged behavior). Malformed value = off + one
 #   warn log, never a crash. Supports cross-midnight windows, e.g. "22:00-08:00".
+#   Both endpoints are INCLUSIVE of the whole minute (e.g. "22:00-08:00" still defers at
+#   08:00:59). start === end (e.g. "22:00-22:00") is INVALID, not a zero-length or
+#   full-day window — it is rejected the same as a malformed value (off + one warn); use
+#   two distinct HH:MM values.
 #   v1 is deployment-wide (all orgs) AND channel-agnostic: the gate sits BEFORE the worker
 #   claims any outbox row, so it applies to EVERY channel this worker dispatches — DingTalk,
 #   WeCom, and email_smtp alike — with no per-channel opt-out. Per-org quiet hours is a

--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,20 @@ JWT_EXPIRES_IN=2h
 # WECOM_AGENT_ID=1000002
 # Optional override (defaults to https://qyapi.weixin.qq.com):
 # WECOM_BASE_URL=https://qyapi.weixin.qq.com
+#
+# ATTENDANCE_NOTIFICATION_QUIET_HOURS (R8) — "HH:MM-HH:MM" (24h clock, local to the TZ
+#   below); gates the C5-2 delivery worker BEFORE it claims outbox rows, so due
+#   notifications simply wait (no event loss, no retry/lease interaction) until the
+#   window ends. Unset/empty = off (unchanged behavior). Malformed value = off + one
+#   warn log, never a crash. Supports cross-midnight windows, e.g. "22:00-08:00".
+#   v1 is deployment-wide (all orgs) AND channel-agnostic: the gate sits BEFORE the worker
+#   claims any outbox row, so it applies to EVERY channel this worker dispatches — DingTalk,
+#   WeCom, and email_smtp alike — with no per-channel opt-out. Per-org quiet hours is a
+#   follow-up, not v1.
+# ATTENDANCE_NOTIFICATION_QUIET_HOURS=22:00-08:00
+# ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ — IANA zone for the window above. Defaults to
+#   Asia/Shanghai when ATTENDANCE_NOTIFICATION_QUIET_HOURS is set but this is not.
+# ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ=Asia/Shanghai
 
 # =============================================================================
 # REDIS CACHE (Optional)

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -243,6 +243,13 @@ const DEFAULT_QUIET_HOURS_TZ = 'Asia/Shanghai'
  * Malformed input (bad "HH:MM-HH:MM" shape, or a TZ Intl does not recognize) never throws: it logs a
  * single warn and disables the gate (off), exactly like unset — a typo in ops config must not crash the
  * scheduler tick or start silently dropping notifications outside a window nobody intended.
+ *
+ * Channel-agnostic by construction: this config is consumed only by AttendanceNotificationDeliveryWorker
+ * .runBatch()'s pre-claim gate (see the R8 comment there), which runs BEFORE claimDueDeliveries() and
+ * therefore BEFORE any per-row channel dispatch. It applies to every channel this worker dispatches —
+ * DingTalk, WeCom, and email alike — with no per-channel opt-out; there is no separate claim/send path
+ * for any registered channel that could bypass it (verified for WeCom's S4 adapter, which routes through
+ * the same channelsByName / deliver() call site as DingTalk and email).
  */
 export function resolveAttendanceNotificationQuietHours(
   env: NodeJS.ProcessEnv = process.env,
@@ -257,6 +264,19 @@ export function resolveAttendanceNotificationQuietHours(
     )
     return null
   }
+  const start = `${match[1]}:${match[2]}`
+  const end = `${match[3]}:${match[4]}`
+  if (start === end) {
+    // start === end (e.g. "22:00-22:00") is treated as INVALID config, same tier as a malformed shape —
+    // NOT as a valid zero-length or full-day window. A zero-length window is almost certainly a config
+    // typo, not an intentional one-minute quiet period; and "fixing" it to mean full-day-quiet instead
+    // would let a typo silently stop ALL attendance notifications for 24h with no visible signal beyond
+    // this warn. Least-surprise is to refuse the config outright, exactly like a malformed shape.
+    logger.warn(
+      `Ignoring ATTENDANCE_NOTIFICATION_QUIET_HOURS="${raw}" (start equals end — a zero-length window is not a valid config; use two distinct HH:MM values); quiet hours disabled`,
+    )
+    return null
+  }
   const timeZone = (env.ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ ?? '').trim() || DEFAULT_QUIET_HOURS_TZ
   try {
     // Throws RangeError for a zone Intl does not recognize; this is the validation, the format result
@@ -266,7 +286,7 @@ export function resolveAttendanceNotificationQuietHours(
     logger.warn(`Ignoring invalid ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ="${timeZone}"; quiet hours disabled`)
     return null
   }
-  return { start: `${match[1]}:${match[2]}`, end: `${match[3]}:${match[4]}`, timeZone }
+  return { start, end, timeZone }
 }
 
 /**
@@ -275,10 +295,23 @@ export function resolveAttendanceNotificationQuietHours(
  * computed via Intl.DateTimeFormat in the CONFIGURED timezone — NotificationService uses
  * `toTimeString()` (server-local time) and silently ignores its own `timezone` field; that bug is not
  * repeated here.
+ *
+ * Both endpoints are INCLUSIVE: `current <= end` means the window covers the entire end minute (e.g.
+ * "22:00-08:00" still defers at 08:00:59), not up-to-but-excluding it. Intentional, documented here and
+ * in .env.example — not changed by this pass.
+ *
+ * Fail-OPEN on a broken Intl result: if formatToParts unexpectedly omits the hour/minute parts (should
+ * not happen given the options passed above, but a broken runtime ICU data set is not impossible), this
+ * returns `false` (outside the window) rather than defaulting to "00:00". Defaulting to midnight would
+ * silently land inside any cross-midnight window and could make notifications stop flowing permanently
+ * and invisibly on every tick. A late/deferred notification is recoverable (the next in-window tick
+ * sends it); a silent permanent quiet window is not — so an unparseable local time must not block
+ * delivery.
  */
 export function isAttendanceNotificationQuietHours(
   now: Date,
   config: AttendanceNotificationQuietHoursConfig,
+  logger: Pick<Logger, 'warn'> = new Logger('AttendanceNotificationDeliveryWorker'),
 ): boolean {
   const parts = new Intl.DateTimeFormat('en-US', {
     timeZone: config.timeZone,
@@ -286,8 +319,14 @@ export function isAttendanceNotificationQuietHours(
     minute: '2-digit',
     hourCycle: 'h23',
   }).formatToParts(now)
-  const hour = parts.find((p) => p.type === 'hour')?.value ?? '00'
-  const minute = parts.find((p) => p.type === 'minute')?.value ?? '00'
+  const hour = parts.find((p) => p.type === 'hour')?.value
+  const minute = parts.find((p) => p.type === 'minute')?.value
+  if (hour === undefined || minute === undefined) {
+    logger.warn(
+      `Could not determine local time for quiet-hours check (timeZone="${config.timeZone}"); treating as OUTSIDE the quiet window so notifications are not blocked`,
+    )
+    return false
+  }
   const current = `${hour}:${minute}`
   if (config.start <= config.end) {
     return current >= config.start && current <= config.end
@@ -824,7 +863,14 @@ export class AttendanceNotificationDeliveryWorker {
       // runBatch() call drains them oldest-first via claimDueDeliveries' ORDER BY. This must NOT be
       // expressed as a channel-level retryable failure — that would burn attempt_count toward
       // maxAttempts and could dead-letter a row via computeDeliveryBackoffMs's up-to-6h backoff.
-      if (this.quietHours && isAttendanceNotificationQuietHours(this.now(), this.quietHours)) {
+      //
+      // This gate fences the WHOLE batch, not any one channel: claimDueDeliveries() is the ONLY place
+      // outbox rows get claimed, and deliver() (the only caller of channel.send()) only runs over rows
+      // that claimDueDeliveries() returned. Every registered AttendanceDeliveryChannel — DingTalk, WeCom
+      // (S4), and email — is dispatched exclusively through that one claim -> deliver loop below, so
+      // quiet hours applies to every channel this worker dispatches with no per-channel opt-out. Ratified
+      // product decision (owner, 2026-07-10): "don't disturb at night" is channel-independent.
+      if (this.quietHours && isAttendanceNotificationQuietHours(this.now(), this.quietHours, this.logger)) {
         if (!this.quietHoursLogged) {
           this.logger.info(
             `Attendance notification dispatch deferred: quiet hours ${this.quietHours.start}-${this.quietHours.end} (${this.quietHours.timeZone})`,

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -93,6 +93,13 @@ export interface AttendanceNotificationDeliveryWorkerOptions {
   workerId?: string
   now?: () => Date
   logger?: Logger
+  /**
+   * R8 quiet hours gate. `undefined` (the default when the worker is constructed by
+   * resolveAttendanceNotificationDeliveryJob) resolves from ATTENDANCE_NOTIFICATION_QUIET_HOURS /
+   * ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ at construction time; pass `null` explicitly to force the
+   * gate off (e.g. tests), or a concrete config to bypass env parsing entirely (also tests).
+   */
+  quietHours?: AttendanceNotificationQuietHoursConfig | null
 }
 
 export interface DingTalkAttendanceDeliveryChannelOptions {
@@ -212,6 +219,80 @@ export function computeDeliveryBackoffMs(attemptCount: number): number {
   if (attemptCount === 3) return 15 * 60_000
   if (attemptCount === 4) return 60 * 60_000
   return 6 * 60 * 60_000
+}
+
+export interface AttendanceNotificationQuietHoursConfig {
+  /** 24h "HH:MM", local to `timeZone`. */
+  start: string
+  /** 24h "HH:MM", local to `timeZone`; may be < start (cross-midnight window, e.g. 22:00-08:00). */
+  end: string
+  /** IANA zone name, e.g. "Asia/Shanghai". */
+  timeZone: string
+}
+
+const QUIET_HOURS_ENV_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)-([01]\d|2[0-3]):([0-5]\d)$/
+const DEFAULT_QUIET_HOURS_TZ = 'Asia/Shanghai'
+
+/**
+ * R8 quiet-hours window (design decision: deployment-wide v1, consistent with every existing
+ * ATTENDANCE_NOTIFICATION_* knob — per-org config is a named follow-up, not v1).
+ *
+ * ATTENDANCE_NOTIFICATION_QUIET_HOURS="HH:MM-HH:MM" — unset/empty = off (unchanged behavior).
+ * ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ — IANA zone; defaults to Asia/Shanghai.
+ *
+ * Malformed input (bad "HH:MM-HH:MM" shape, or a TZ Intl does not recognize) never throws: it logs a
+ * single warn and disables the gate (off), exactly like unset — a typo in ops config must not crash the
+ * scheduler tick or start silently dropping notifications outside a window nobody intended.
+ */
+export function resolveAttendanceNotificationQuietHours(
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Pick<Logger, 'warn'> = new Logger('AttendanceNotificationDeliveryWorker'),
+): AttendanceNotificationQuietHoursConfig | null {
+  const raw = (env.ATTENDANCE_NOTIFICATION_QUIET_HOURS ?? '').trim()
+  if (!raw) return null
+  const match = QUIET_HOURS_ENV_PATTERN.exec(raw)
+  if (!match) {
+    logger.warn(
+      `Ignoring malformed ATTENDANCE_NOTIFICATION_QUIET_HOURS="${raw}" (expected "HH:MM-HH:MM", 24h clock); quiet hours disabled`,
+    )
+    return null
+  }
+  const timeZone = (env.ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ ?? '').trim() || DEFAULT_QUIET_HOURS_TZ
+  try {
+    // Throws RangeError for a zone Intl does not recognize; this is the validation, the format result
+    // itself is discarded.
+    new Intl.DateTimeFormat('en-US', { timeZone }).format(new Date())
+  } catch {
+    logger.warn(`Ignoring invalid ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ="${timeZone}"; quiet hours disabled`)
+    return null
+  }
+  return { start: `${match[1]}:${match[2]}`, end: `${match[3]}:${match[4]}`, timeZone }
+}
+
+/**
+ * Same cross-midnight wrap shape as NotificationService.isInQuietHours (start<=end → contiguous
+ * window; start>end → wraps past midnight, "inside" means >= start OR <= end), but the local HH:MM is
+ * computed via Intl.DateTimeFormat in the CONFIGURED timezone — NotificationService uses
+ * `toTimeString()` (server-local time) and silently ignores its own `timezone` field; that bug is not
+ * repeated here.
+ */
+export function isAttendanceNotificationQuietHours(
+  now: Date,
+  config: AttendanceNotificationQuietHoursConfig,
+): boolean {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: config.timeZone,
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(now)
+  const hour = parts.find((p) => p.type === 'hour')?.value ?? '00'
+  const minute = parts.find((p) => p.type === 'minute')?.value ?? '00'
+  const current = `${hour}:${minute}`
+  if (config.start <= config.end) {
+    return current >= config.start && current <= config.end
+  }
+  return current >= config.start || current <= config.end
 }
 
 export class DeterministicFakeAttendanceDeliveryChannel implements AttendanceDeliveryChannel {
@@ -664,6 +745,8 @@ export class AttendanceNotificationDeliveryWorker {
   private readonly workerId: string
   private readonly now: () => Date
   private readonly logger: Logger
+  private readonly quietHours: AttendanceNotificationQuietHoursConfig | null
+  private quietHoursLogged = false
   private running = false
 
   constructor(options: AttendanceNotificationDeliveryWorkerOptions = {}) {
@@ -677,6 +760,9 @@ export class AttendanceNotificationDeliveryWorker {
     this.workerId = options.workerId ?? `attendance-delivery:${process.pid}:${randomBytes(4).toString('hex')}`
     this.now = options.now ?? (() => new Date())
     this.logger = options.logger ?? new Logger('AttendanceNotificationDeliveryWorker')
+    this.quietHours = options.quietHours !== undefined
+      ? options.quietHours
+      : resolveAttendanceNotificationQuietHours(process.env, this.logger)
   }
 
   async claimDueDeliveries(): Promise<DeliveryRow[]> {
@@ -732,6 +818,22 @@ export class AttendanceNotificationDeliveryWorker {
     this.running = true
     const result: AttendanceNotificationDeliveryResult = { claimed: 0, sent: 0, retrying: 0, failed: 0, skipped: 0 }
     try {
+      // R8: quiet-hours gate sits BEFORE claimDueDeliveries — a zero-result return here touches no SQL
+      // at all, so due rows stay untouched (pending/retrying, next_attempt_at unchanged, attempt_count
+      // unchanged, no lease taken). They are not lost and not penalized; the very next in-window
+      // runBatch() call drains them oldest-first via claimDueDeliveries' ORDER BY. This must NOT be
+      // expressed as a channel-level retryable failure — that would burn attempt_count toward
+      // maxAttempts and could dead-letter a row via computeDeliveryBackoffMs's up-to-6h backoff.
+      if (this.quietHours && isAttendanceNotificationQuietHours(this.now(), this.quietHours)) {
+        if (!this.quietHoursLogged) {
+          this.logger.info(
+            `Attendance notification dispatch deferred: quiet hours ${this.quietHours.start}-${this.quietHours.end} (${this.quietHours.timeZone})`,
+          )
+          this.quietHoursLogged = true
+        }
+        return result
+      }
+      this.quietHoursLogged = false
       const rows = await this.claimDueDeliveries()
       result.claimed = rows.length
       let lostLease = 0

--- a/packages/core-backend/src/services/AttendanceScheduler.ts
+++ b/packages/core-backend/src/services/AttendanceScheduler.ts
@@ -31,6 +31,7 @@ import {
 import {
   AttendanceNotificationDeliveryWorker,
   createAttendanceDeliveryChannelsFromEnv,
+  resolveAttendanceNotificationQuietHours,
 } from './AttendanceNotificationDeliveryWorker'
 import { CompTimeExpiryReminderService } from './CompTimeExpiryReminderService'
 import { UnscheduledReminderService } from './UnscheduledReminderService'
@@ -390,6 +391,10 @@ export function resolveCompTimeExpiryReminderJob(): AttendanceSchedulerJob | nul
  * C5-2 opt-in: delivery worker job. It consumes C5 outbox rows and updates per-row delivery state.
  * Default OFF; C5-2 can use the deterministic fake channel via ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED=true.
  * Real DingTalk channel registration is C5-3.
+ *
+ * R8: ATTENDANCE_NOTIFICATION_QUIET_HOURS ("HH:MM-HH:MM", unset/malformed = off) + the optional
+ * ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ (default Asia/Shanghai) gate dispatch — deployment-wide v1,
+ * consistent with every other knob resolved here.
  */
 export function resolveAttendanceNotificationDeliveryJob(): AttendanceSchedulerJob | null {
   if (process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED !== 'true') return null
@@ -397,6 +402,7 @@ export function resolveAttendanceNotificationDeliveryJob(): AttendanceSchedulerJ
     batchSize: Number(process.env.ATTENDANCE_NOTIFICATION_DELIVERY_BATCH_SIZE),
     leaseMs: Number(process.env.ATTENDANCE_NOTIFICATION_DELIVERY_LEASE_MS),
     maxAttempts: Number(process.env.ATTENDANCE_NOTIFICATION_DELIVERY_MAX_ATTEMPTS),
+    quietHours: resolveAttendanceNotificationQuietHours(),
     channels: createAttendanceDeliveryChannelsFromEnv(),
   })
   return {

--- a/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
+++ b/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
@@ -10,10 +10,20 @@ import {
   AttendanceNotificationDeliveryWorker,
   resolveAttendanceNotificationQuietHours,
   isAttendanceNotificationQuietHours,
+  DingTalkAttendanceDeliveryChannel,
+  WeComAttendanceDeliveryChannel,
+  EmailAttendanceDeliveryChannel,
+  DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME,
+  WECOM_WORK_NOTIFICATION_CHANNEL_NAME,
+  EMAIL_SMTP_CHANNEL_NAME,
   type AttendanceNotificationQuietHoursConfig,
   type AttendanceNotificationDeliveryQuery,
+  type EmailDeliveryTransport,
 } from '../../src/services/AttendanceNotificationDeliveryWorker'
 import type { Logger } from '../../src/core/logger'
+import type { DingTalkMessageConfig } from '../../src/integrations/dingtalk/client'
+import type { WeComMessageConfig } from '../../src/integrations/wecom/client'
+import { EMAIL_TRANSPORT_ENV } from '../../src/services/email-transport-readiness'
 
 function makeQuery(rows: unknown[] = []): AttendanceNotificationDeliveryQuery {
   return vi.fn(async () => ({ rows, rowCount: rows.length })) as unknown as AttendanceNotificationDeliveryQuery
@@ -317,5 +327,177 @@ describe('AttendanceNotificationDeliveryWorker: quiet-hours env resolution at co
     await worker.runBatch()
 
     expect(query).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('R8 quiet-hours × the FULL channel roster (DingTalk + WeCom S4 + email) — owner-ratified 2026-07-10: ' +
+  'the pre-claim gate is channel-agnostic, not DingTalk-only', () => {
+  // Real channel instances (not the deterministic fake) with every I/O seam DI-injected, mirroring the
+  // patterns in attendance-wecom-delivery-channel.test.ts / attendance-email-delivery-channel.test.ts /
+  // attendance-scheduler.test.ts's "real DingTalk channel" case. This proves the combination end-to-end
+  // through the SAME channelsByName / deliver() call site the worker actually uses in production — not
+  // through a re-implementation of the gate.
+
+  const DT_CONFIG: DingTalkMessageConfig = {
+    appKey: 'dt-app-key',
+    appSecret: 'dt-app-secret',
+    agentId: '123456789',
+    baseUrl: 'https://oapi.dingtalk.com',
+  }
+  const WECOM_CONFIG: WeComMessageConfig = { corpId: 'corp-1', corpSecret: 'corpsecret-value', agentId: '1000002' }
+  const READY_SMTP_ENV = {
+    [EMAIL_TRANSPORT_ENV]: 'smtp',
+    MULTITABLE_EMAIL_SMTP_HOST: 'smtp.example.com',
+    MULTITABLE_EMAIL_SMTP_PORT: '587',
+    MULTITABLE_EMAIL_SMTP_USER: 'smtp-user',
+    MULTITABLE_EMAIL_SMTP_PASSWORD: 'smtp-password-secret',
+    MULTITABLE_EMAIL_SMTP_FROM: 'ops@example.com',
+  } as NodeJS.ProcessEnv
+
+  function makeRoster() {
+    const dtSendWorkNotification = vi.fn(async () => ({ taskId: 'dt-task-1', raw: {} }))
+    const dtSendActionCard = vi.fn(async () => ({ taskId: 'dt-task-2', raw: {} }))
+    const dingTalkChannel = new DingTalkAttendanceDeliveryChannel({
+      query: vi.fn(async () => ({ rows: [{ integration_id: 'dt-integ-1', external_user_id: 'dt-user-1' }] })) as never,
+      readConfig: async () => DT_CONFIG,
+      fetchAccessToken: async () => 'dt-access-token',
+      sendWorkNotification: dtSendWorkNotification,
+      sendWorkNotificationActionCard: dtSendActionCard,
+    })
+
+    const weComSendTextMessage = vi.fn(async () => ({ errcode: 0, errmsg: 'ok', invalidUserIds: [], raw: {} }))
+    const weComSendTextCardMessage = vi.fn(async () => ({ errcode: 0, errmsg: 'ok', invalidUserIds: [], raw: {} }))
+    const weComChannel = new WeComAttendanceDeliveryChannel({
+      query: vi.fn(async () => ({ rows: [{ integration_id: 'we-integ-1', external_user_id: 'we-user-1' }] })) as never,
+      readConfig: async () => WECOM_CONFIG,
+      fetchAccessToken: async () => 'we-access-token',
+      sendTextMessage: weComSendTextMessage,
+      sendTextCardMessage: weComSendTextCardMessage,
+    })
+
+    const emailSendMail = vi.fn(async () => ({ messageId: 'email-ok' }))
+    const emailTransport: EmailDeliveryTransport = { sendMail: emailSendMail }
+    const emailChannel = new EmailAttendanceDeliveryChannel({
+      env: READY_SMTP_ENV,
+      query: vi.fn(async () => ({ rows: [{ email: 'user@example.com' }] })) as never,
+      createTransport: () => emailTransport,
+    })
+
+    return {
+      channels: [dingTalkChannel, weComChannel, emailChannel],
+      dtSendWorkNotification,
+      dtSendActionCard,
+      weComSendTextMessage,
+      weComSendTextCardMessage,
+      emailSendMail,
+    }
+  }
+
+  function claimedRow(id: string, channel: string) {
+    return {
+      id,
+      org_id: 'org1',
+      source_type: 'unscheduled_reminder',
+      source_id: 'src1',
+      source_key: `key-${id}`,
+      recipient_user_id: 'u1',
+      recipient_role: 'member',
+      channel,
+      attempt_count: 0,
+      payload: { title: 'Punch reminder', body: 'You have an unscheduled shift today.' },
+    }
+  }
+
+  /** Worker-level `query`: claimDueDeliveries' claim SQL vs. every terminal-state UPDATE (mark*). */
+  function makeWorkerQuery(claimRows: ReturnType<typeof claimedRow>[]): AttendanceNotificationDeliveryQuery {
+    return vi.fn(async (sql: string) => {
+      if (sql.includes('FOR UPDATE SKIP LOCKED')) return { rows: claimRows, rowCount: claimRows.length }
+      // markSent/markFailed/markRetrying/markSkipped: CAS UPDATE — report exactly 1 row matched.
+      return { rows: [], rowCount: 1 }
+    }) as unknown as AttendanceNotificationDeliveryQuery
+  }
+
+  it('inside the window: ZERO claims AND ZERO sends on every channel (DingTalk, WeCom, email) — proves the ' +
+    'gate fences the whole batch, not a DingTalk-only path, and that WeCom has no separate claim/send path ' +
+    'that could bypass it', async () => {
+    const roster = makeRoster()
+    const claimQuery = makeWorkerQuery([
+      claimedRow('dlv-dt', DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME),
+      claimedRow('dlv-wecom', WECOM_WORK_NOTIFICATION_CHANNEL_NAME),
+      claimedRow('dlv-email', EMAIL_SMTP_CHANNEL_NAME),
+    ])
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '22:00', end: '08:00', timeZone: 'UTC' }
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: claimQuery,
+      channels: roster.channels,
+      quietHours,
+      now: () => new Date('2026-07-09T23:30:00Z'), // inside 22:00-08:00
+    })
+
+    const result = await worker.runBatch()
+
+    expect(result).toEqual(ZERO_RESULT)
+    // claimDueDeliveries never ran — no SQL at all, not even the claim SQL that WOULD have returned rows
+    // for all three channels above.
+    expect(claimQuery).not.toHaveBeenCalled()
+    // Every channel's real network/DB send seam: zero calls. If WeCom (or any channel) had a separate
+    // claim/send path that bypassed runBatch()'s pre-claim gate, its send spy would have fired here.
+    expect(roster.dtSendWorkNotification).not.toHaveBeenCalled()
+    expect(roster.dtSendActionCard).not.toHaveBeenCalled()
+    expect(roster.weComSendTextMessage).not.toHaveBeenCalled()
+    expect(roster.weComSendTextCardMessage).not.toHaveBeenCalled()
+    expect(roster.emailSendMail).not.toHaveBeenCalled()
+  })
+
+  it('outside the window: all three channels flow — claim SQL issued once, one send per channel, all sent', async () => {
+    const roster = makeRoster()
+    const claimQuery = makeWorkerQuery([
+      claimedRow('dlv-dt', DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME),
+      claimedRow('dlv-wecom', WECOM_WORK_NOTIFICATION_CHANNEL_NAME),
+      claimedRow('dlv-email', EMAIL_SMTP_CHANNEL_NAME),
+    ])
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '22:00', end: '08:00', timeZone: 'UTC' }
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: claimQuery,
+      channels: roster.channels,
+      quietHours,
+      now: () => new Date('2026-07-09T12:00:00Z'), // outside 22:00-08:00
+    })
+
+    const result = await worker.runBatch()
+
+    expect(result.claimed).toBe(3)
+    expect(result.sent).toBe(3)
+    expect(result.failed).toBe(0)
+    expect(result.skipped).toBe(0)
+    // Claim SQL fired exactly once; every mark* CAS-update call after it is on the SAME query mock, so
+    // this only asserts the claim itself was not skipped (mirrors the existing single-channel test above).
+    expect(claimQuery).toHaveBeenCalledWith(expect.stringContaining('FOR UPDATE SKIP LOCKED'), expect.any(Array))
+    expect(roster.dtSendWorkNotification).toHaveBeenCalledTimes(1)
+    expect(roster.weComSendTextMessage).toHaveBeenCalledTimes(1)
+    expect(roster.emailSendMail).toHaveBeenCalledTimes(1)
+  })
+
+  it('quiet hours OFF (no config): all three channels flow exactly as if the gate did not exist', async () => {
+    const roster = makeRoster()
+    const claimQuery = makeWorkerQuery([
+      claimedRow('dlv-dt', DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME),
+      claimedRow('dlv-wecom', WECOM_WORK_NOTIFICATION_CHANNEL_NAME),
+      claimedRow('dlv-email', EMAIL_SMTP_CHANNEL_NAME),
+    ])
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: claimQuery,
+      channels: roster.channels,
+      quietHours: null, // explicit off
+      now: () => new Date('2026-07-09T23:30:00Z'), // would be inside window if the gate were active
+    })
+
+    const result = await worker.runBatch()
+
+    expect(result.claimed).toBe(3)
+    expect(result.sent).toBe(3)
+    expect(roster.dtSendWorkNotification).toHaveBeenCalledTimes(1)
+    expect(roster.weComSendTextMessage).toHaveBeenCalledTimes(1)
+    expect(roster.emailSendMail).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
+++ b/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
@@ -102,6 +102,45 @@ describe('AttendanceNotificationDeliveryWorker.runBatch quiet-hours gate', () =>
 
     expect(info).toHaveBeenCalledTimes(1)
   })
+
+  it('quietHoursLogged reset on window-exit is load-bearing: re-entering the window after exiting logs a SECOND deferral message', async () => {
+    // Mutation guard for the `this.quietHoursLogged = false` reset in runBatch() (the non-deferral
+    // branch). If that reset is deleted, quietHoursLogged latches `true` forever after the first
+    // deferral and a later re-entry into the window never logs again — this test is RED under that
+    // mutation because `info` stops incrementing on tick 3 below.
+    const info = vi.fn()
+    const warn = vi.fn()
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '22:00', end: '08:00', timeZone: 'UTC' }
+    let current = new Date('2026-07-09T23:00:00Z') // inside window
+    const query = makeQuery()
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query,
+      quietHours,
+      now: () => current,
+      logger: { info, warn } as unknown as Logger,
+    })
+
+    // Tick 1: enter window → defer + first deferral log, zero SQL.
+    const tick1 = await worker.runBatch()
+    expect(tick1).toEqual(ZERO_RESULT)
+    expect(info).toHaveBeenCalledTimes(1)
+    expect(query).not.toHaveBeenCalled()
+
+    // Tick 2: exit window → claims normally (real SQL issued); no additional deferral log (mock query
+    // returns 0 rows, so the separate "claimed=N" summary log — gated on claimed>0 — does not fire).
+    current = new Date('2026-07-09T12:00:00Z') // outside window
+    await worker.runBatch()
+    expect(info).toHaveBeenCalledTimes(1)
+    expect(query).toHaveBeenCalledTimes(1)
+
+    // Tick 3: re-enter window → SECOND deferral log. Only fires if the exit tick reset
+    // quietHoursLogged back to false; proves the reset is load-bearing, not deletable.
+    current = new Date('2026-07-09T23:30:00Z') // inside window again
+    const tick3 = await worker.runBatch()
+    expect(tick3).toEqual(ZERO_RESULT)
+    expect(info).toHaveBeenCalledTimes(2)
+    expect(query).toHaveBeenCalledTimes(1) // still deferred: no new SQL on tick 3
+  })
 })
 
 describe('resolveAttendanceNotificationQuietHours env parsing', () => {
@@ -139,6 +178,20 @@ describe('resolveAttendanceNotificationQuietHours env parsing', () => {
     expect(warn).toHaveBeenCalledTimes(1)
   })
 
+  it('start === end (e.g. "22:00-22:00") → INVALID config: off + one warn, not a zero-length or full-day window', () => {
+    const warn = vi.fn()
+    const env = { ATTENDANCE_NOTIFICATION_QUIET_HOURS: '22:00-22:00' } as NodeJS.ProcessEnv
+    expect(resolveAttendanceNotificationQuietHours(env, { warn })).toBeNull()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('start === end at midnight ("00:00-00:00") is also rejected, not silently treated as full-day-quiet', () => {
+    const warn = vi.fn()
+    const env = { ATTENDANCE_NOTIFICATION_QUIET_HOURS: '00:00-00:00' } as NodeJS.ProcessEnv
+    expect(resolveAttendanceNotificationQuietHours(env, { warn })).toBeNull()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
   it('valid window, TZ unset → defaults to Asia/Shanghai', () => {
     const env = { ATTENDANCE_NOTIFICATION_QUIET_HOURS: '22:00-08:00' } as NodeJS.ProcessEnv
     expect(resolveAttendanceNotificationQuietHours(env, { warn: vi.fn() })).toEqual({
@@ -170,6 +223,62 @@ describe('isAttendanceNotificationQuietHours timezone correctness', () => {
 
     expect(isAttendanceNotificationQuietHours(now, shanghai)).toBe(true)
     expect(isAttendanceNotificationQuietHours(now, utc)).toBe(false)
+  })
+})
+
+describe('isAttendanceNotificationQuietHours: broken Intl fails OPEN, not toward midnight', () => {
+  // If formatToParts unexpectedly omits hour/minute (broken ICU data — should not happen given the
+  // options passed, but is not impossible), the OLD behavior defaulted both to '00', which — inside a
+  // cross-midnight window like 22:00-08:00 — reads as "00:00", i.e. INSIDE the window: notifications
+  // would silently and permanently stop. The fix must fail OPEN (outside the window) instead.
+  const OriginalDateTimeFormat = Intl.DateTimeFormat
+
+  function stubBrokenIntl() {
+    // @ts-expect-error test-only stub: garbage formatToParts result missing hour/minute part types.
+    Intl.DateTimeFormat = vi.fn().mockImplementation(() => ({
+      formatToParts: () => [{ type: 'literal', value: '' }],
+      format: () => '00:00',
+    }))
+  }
+
+  afterEach(() => {
+    Intl.DateTimeFormat = OriginalDateTimeFormat
+  })
+
+  it('missing hour/minute parts → returns false (OUTSIDE the window) and warns once, even at what would be midnight', () => {
+    stubBrokenIntl()
+    const warn = vi.fn()
+    // A cross-midnight window where the old '00' fallback would have read as "inside".
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '22:00', end: '08:00', timeZone: 'UTC' }
+
+    const result = isAttendanceNotificationQuietHours(
+      new Date('2026-07-09T00:00:00Z'),
+      quietHours,
+      { warn } as unknown as Pick<Logger, 'warn'>,
+    )
+
+    expect(result).toBe(false)
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('runBatch: broken Intl → claims normally (real SQL issued) and warns, instead of silently deferring forever', async () => {
+    stubBrokenIntl()
+    const info = vi.fn()
+    const warn = vi.fn()
+    const query = makeQuery()
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '22:00', end: '08:00', timeZone: 'UTC' }
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query,
+      quietHours,
+      now: () => new Date('2026-07-09T00:00:00Z'),
+      logger: { info, warn } as unknown as Logger,
+    })
+
+    const result = await worker.runBatch()
+
+    expect(query).toHaveBeenCalledTimes(1) // claimed normally — NOT deferred
+    expect(result.claimed).toBe(0) // mock returns no rows, but the claim WAS attempted
+    expect(warn).toHaveBeenCalled()
   })
 })
 

--- a/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
+++ b/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
@@ -346,7 +346,7 @@ describe('AttendanceNotificationDeliveryWorker: quiet-hours env resolution at co
 
     const result = await worker.runBatch()
 
-    expect(result).toEqual({ claimed: 0, sent: 0, retrying: 0, failed: 0 })
+    expect(result).toEqual({ claimed: 0, sent: 0, retrying: 0, failed: 0, skipped: 0 })
     expect(query).not.toHaveBeenCalled()
   })
 })

--- a/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
+++ b/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
@@ -1,0 +1,212 @@
+/**
+ * R8 — attendance DingTalk (and other outbox channel) notification quiet hours.
+ * Pure unit: the worker already injects `query` and `now()` (no real DB / no real clock needed).
+ * v1 = deployment-wide env config (ATTENDANCE_NOTIFICATION_QUIET_HOURS / _TZ); the gate sits BEFORE
+ * claimDueDeliveries() in runBatch() so an in-window tick issues ZERO SQL and leaves due rows untouched
+ * (no lease taken, no attempt_count burned) — see AttendanceNotificationDeliveryWorker.ts runBatch.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  AttendanceNotificationDeliveryWorker,
+  resolveAttendanceNotificationQuietHours,
+  isAttendanceNotificationQuietHours,
+  type AttendanceNotificationQuietHoursConfig,
+  type AttendanceNotificationDeliveryQuery,
+} from '../../src/services/AttendanceNotificationDeliveryWorker'
+import type { Logger } from '../../src/core/logger'
+
+function makeQuery(rows: unknown[] = []): AttendanceNotificationDeliveryQuery {
+  return vi.fn(async () => ({ rows, rowCount: rows.length })) as unknown as AttendanceNotificationDeliveryQuery
+}
+
+const ZERO_RESULT = { claimed: 0, sent: 0, retrying: 0, failed: 0, skipped: 0 }
+
+describe('AttendanceNotificationDeliveryWorker.runBatch quiet-hours gate', () => {
+  it('inside a non-wrapping window: returns the zero-result shape and issues ZERO SQL', async () => {
+    const query = makeQuery()
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '09:00', end: '17:00', timeZone: 'UTC' }
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query,
+      quietHours,
+      now: () => new Date('2026-07-09T12:00:00Z'),
+    })
+
+    const result = await worker.runBatch()
+
+    expect(result).toEqual(ZERO_RESULT)
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('outside the window: claims normally (the real claim SQL is actually issued)', async () => {
+    const query = makeQuery()
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '09:00', end: '17:00', timeZone: 'UTC' }
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query,
+      quietHours,
+      now: () => new Date('2026-07-09T20:00:00Z'),
+    })
+
+    const result = await worker.runBatch()
+
+    expect(result.claimed).toBe(0) // mock returns no rows, but the claim WAS attempted
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('FOR UPDATE SKIP LOCKED'), expect.any(Array))
+  })
+
+  it('cross-midnight window 22:00-08:00: 23:30 and 07:30 both defer, 12:00 sends', async () => {
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '22:00', end: '08:00', timeZone: 'UTC' }
+
+    const late = makeQuery()
+    const lateWorker = new AttendanceNotificationDeliveryWorker({
+      query: late,
+      quietHours,
+      now: () => new Date('2026-07-09T23:30:00Z'),
+    })
+    expect(await lateWorker.runBatch()).toEqual(ZERO_RESULT)
+    expect(late).not.toHaveBeenCalled()
+
+    const early = makeQuery()
+    const earlyWorker = new AttendanceNotificationDeliveryWorker({
+      query: early,
+      quietHours,
+      now: () => new Date('2026-07-09T07:30:00Z'),
+    })
+    expect(await earlyWorker.runBatch()).toEqual(ZERO_RESULT)
+    expect(early).not.toHaveBeenCalled()
+
+    const noon = makeQuery()
+    const noonWorker = new AttendanceNotificationDeliveryWorker({
+      query: noon,
+      quietHours,
+      now: () => new Date('2026-07-09T12:00:00Z'),
+    })
+    const noonResult = await noonWorker.runBatch()
+    expect(noonResult.claimed).toBe(0) // mock returns no rows, but dispatch was NOT gated
+    expect(noon).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs the deferral once per window entry, not on every tick', async () => {
+    const info = vi.fn()
+    const warn = vi.fn()
+    const quietHours: AttendanceNotificationQuietHoursConfig = { start: '22:00', end: '08:00', timeZone: 'UTC' }
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: makeQuery(),
+      quietHours,
+      now: () => new Date('2026-07-09T23:30:00Z'),
+      logger: { info, warn } as unknown as Logger,
+    })
+
+    await worker.runBatch()
+    await worker.runBatch()
+    await worker.runBatch()
+
+    expect(info).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('resolveAttendanceNotificationQuietHours env parsing', () => {
+  it('unset/empty ATTENDANCE_NOTIFICATION_QUIET_HOURS → off, no warn (unchanged behavior)', () => {
+    const warn = vi.fn()
+    expect(resolveAttendanceNotificationQuietHours({} as NodeJS.ProcessEnv, { warn })).toBeNull()
+    expect(resolveAttendanceNotificationQuietHours(
+      { ATTENDANCE_NOTIFICATION_QUIET_HOURS: '' } as NodeJS.ProcessEnv,
+      { warn },
+    )).toBeNull()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('malformed "HH:MM-HH:MM" shape → off + exactly one warn', () => {
+    const warn = vi.fn()
+    const env = { ATTENDANCE_NOTIFICATION_QUIET_HOURS: '22:00 to 08:00' } as NodeJS.ProcessEnv
+    expect(resolveAttendanceNotificationQuietHours(env, { warn })).toBeNull()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('out-of-range HH:MM (e.g. 25:00) → off + one warn', () => {
+    const warn = vi.fn()
+    const env = { ATTENDANCE_NOTIFICATION_QUIET_HOURS: '25:00-08:00' } as NodeJS.ProcessEnv
+    expect(resolveAttendanceNotificationQuietHours(env, { warn })).toBeNull()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('unrecognized IANA timezone → off + one warn', () => {
+    const warn = vi.fn()
+    const env = {
+      ATTENDANCE_NOTIFICATION_QUIET_HOURS: '22:00-08:00',
+      ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ: 'Not/AZone',
+    } as NodeJS.ProcessEnv
+    expect(resolveAttendanceNotificationQuietHours(env, { warn })).toBeNull()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('valid window, TZ unset → defaults to Asia/Shanghai', () => {
+    const env = { ATTENDANCE_NOTIFICATION_QUIET_HOURS: '22:00-08:00' } as NodeJS.ProcessEnv
+    expect(resolveAttendanceNotificationQuietHours(env, { warn: vi.fn() })).toEqual({
+      start: '22:00',
+      end: '08:00',
+      timeZone: 'Asia/Shanghai',
+    })
+  })
+
+  it('valid window + explicit TZ → both honored', () => {
+    const env = {
+      ATTENDANCE_NOTIFICATION_QUIET_HOURS: '21:15-06:45',
+      ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ: 'UTC',
+    } as NodeJS.ProcessEnv
+    expect(resolveAttendanceNotificationQuietHours(env, { warn: vi.fn() })).toEqual({
+      start: '21:15',
+      end: '06:45',
+      timeZone: 'UTC',
+    })
+  })
+})
+
+describe('isAttendanceNotificationQuietHours timezone correctness', () => {
+  it('computes local HH:MM in the CONFIGURED timezone, not the process/system default', () => {
+    // 2026-07-08T17:30:00Z is 2026-07-09 01:30 in Asia/Shanghai (UTC+8, no DST) and 17:30 in UTC.
+    const now = new Date('2026-07-08T17:30:00Z')
+    const shanghai: AttendanceNotificationQuietHoursConfig = { start: '00:00', end: '06:00', timeZone: 'Asia/Shanghai' }
+    const utc: AttendanceNotificationQuietHoursConfig = { start: '00:00', end: '06:00', timeZone: 'UTC' }
+
+    expect(isAttendanceNotificationQuietHours(now, shanghai)).toBe(true)
+    expect(isAttendanceNotificationQuietHours(now, utc)).toBe(false)
+  })
+})
+
+describe('AttendanceNotificationDeliveryWorker: quiet-hours env resolution at construction', () => {
+  const ORIGINAL_ENV = process.env
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('malformed ATTENDANCE_NOTIFICATION_QUIET_HOURS → gate off, worker claims normally', async () => {
+    process.env.ATTENDANCE_NOTIFICATION_QUIET_HOURS = 'garbage'
+    const query = makeQuery()
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query,
+      now: () => new Date('2026-07-09T23:30:00Z'),
+    })
+
+    await worker.runBatch()
+
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('unset ATTENDANCE_NOTIFICATION_QUIET_HOURS → gate off (default), worker claims normally', async () => {
+    delete process.env.ATTENDANCE_NOTIFICATION_QUIET_HOURS
+    const query = makeQuery()
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query,
+      now: () => new Date('2026-07-09T23:30:00Z'),
+    })
+
+    await worker.runBatch()
+
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
+++ b/packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts
@@ -328,6 +328,27 @@ describe('AttendanceNotificationDeliveryWorker: quiet-hours env resolution at co
 
     expect(query).toHaveBeenCalledTimes(1)
   })
+
+  // Re-gate P2-1: the env→gate-ON PRODUCTION wiring. Every other gate-ON test injects the
+  // config object directly, so neutering the constructor's env fallback (→ null) plus the
+  // scheduler's explicit wiring left the whole suite green while a production
+  // ATTENDANCE_NOTIFICATION_QUIET_HOURS silently did nothing. This is the one test where
+  // the gate turns ON purely from process.env through the real constructor default —
+  // no quietHours option passed.
+  it('valid env + NO quietHours option → gate ON from env alone: in-window runBatch issues ZERO SQL', async () => {
+    process.env.ATTENDANCE_NOTIFICATION_QUIET_HOURS = '22:00-08:00'
+    process.env.ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ = 'UTC'
+    const query = makeQuery()
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query,
+      now: () => new Date('2026-07-09T23:30:00Z'), // 23:30 UTC — inside the cross-midnight window
+    })
+
+    const result = await worker.runBatch()
+
+    expect(result).toEqual({ claimed: 0, sent: 0, retrying: 0, failed: 0 })
+    expect(query).not.toHaveBeenCalled()
+  })
 })
 
 describe('R8 quiet-hours × the FULL channel roster (DingTalk + WeCom S4 + email) — owner-ratified 2026-07-10: ' +


### PR DESCRIPTION
## What

Adds a quiet-hours window that defers the C5-2 attendance notification delivery
worker's dispatch rather than lose or misdate events.

- `ATTENDANCE_NOTIFICATION_QUIET_HOURS="HH:MM-HH:MM"` — 24h clock, cross-midnight
  aware (e.g. `22:00-08:00`). Unset/empty = off (unchanged behavior). Malformed →
  off + one `warn` log, never a crash.
- `ATTENDANCE_NOTIFICATION_QUIET_HOURS_TZ` — IANA zone, defaults to `Asia/Shanghai`.
  Invalid zone → off + one `warn` log.
- Gate sits in `AttendanceNotificationDeliveryWorker.runBatch()` **before**
  `claimDueDeliveries()`: an in-window tick returns the zero-result shape
  (`{claimed:0,sent:0,retrying:0,failed:0,skipped:0}`) without touching the DB.
  Due outbox rows stay `pending`/`retrying` with `next_attempt_at` unchanged, no
  lease taken, `attempt_count` not incremented — no event loss, no retry/lease
  interaction. Once the window ends, the existing `ORDER BY next_attempt_at`
  drains them oldest-first.
- Local `HH:MM` is computed via `Intl.DateTimeFormat` in the configured
  timezone (**not** `toTimeString()`), unlike the pre-existing
  `NotificationService.isInQuietHours` precedent (a separate, per-subscription
  in-app path) whose wrap-logic *shape* this borrows but whose TZ bug
  (ignoring its own `timezone` field, using server-local time) it does not repeat.
- Wired through `AttendanceScheduler.resolveAttendanceNotificationDeliveryJob`
  alongside the other `ATTENDANCE_NOTIFICATION_*` knobs (batch size, lease,
  max attempts) for consistency.
- `.env.example` documents both new vars next to the existing
  `ATTENDANCE_NOTIFICATION_DEEP_LINK_ENABLED` block.

## Why

Attendance DingTalk (and email) outbox notifications currently have no
time-of-day gate — producers insert rows with `next_attempt_at` defaulting to
`now()`, and the worker claims/sends any due row 24/7 whenever the scheduler
job is enabled. This adds an opt-in nighttime quiet window.

## Scope decision (flag for review)

**v1 is deployment-wide env config**, consistent with every other
`ATTENDANCE_NOTIFICATION_*` knob (batch size, lease ms, max attempts, default
channel) — the worker is org-agnostic and claims rows across all orgs in one
query, so per-org gating would need a per-row org lookup at claim time (a
bigger surface change). It also defers **all channels**, including
`email_smtp` — a single worker-level gate, not a per-channel one.

**Per-org and per-channel quiet hours are named follow-ups, not v1.**

## Test evidence

New pure-unit suite `packages/core-backend/tests/unit/attendance-notification-quiet-hours.test.ts`
(13 tests, all green) — the worker already injects `query` and `now()`, no
real-DB wiring needed:

- Inside a non-wrapping window → zero-result shape, `query` never called.
- Outside the window → claims normally, real claim SQL (`FOR UPDATE SKIP
  LOCKED`) actually issued.
- Cross-midnight `22:00-08:00`: `23:30` and `07:30` both defer, `12:00` sends.
- Deferral is logged once per window entry, not on every tick.
- `resolveAttendanceNotificationQuietHours`: unset/empty → off no warn;
  malformed shape / out-of-range HH:MM / unrecognized IANA TZ → off + exactly
  one warn each; valid window with TZ unset → defaults to `Asia/Shanghai`;
  valid window + explicit TZ → both honored.
- `isAttendanceNotificationQuietHours` timezone correctness: same UTC instant
  evaluated against `Asia/Shanghai` vs `UTC` configs disagrees as expected
  (proves the formatter actually consults `config.timeZone`).
- Worker-level env resolution at construction: malformed/unset env → gate off,
  worker claims normally.

Ran full existing `attendance-scheduler.test.ts` +
`attendance-email-delivery-channel.test.ts` alongside — 53/53 pass, no
regressions. `tsc --noEmit` clean.

### Mutation table

| Mutation | Result |
|---|---|
| Delete the pre-claim quiet-hours guard in `runBatch()` | 3 tests RED (zero-SQL assertion, cross-midnight defer, once-per-entry log) |
| Break the wrap logic (drop the `start<=end` branch, always use the non-wrapping comparison) | 2 tests RED (cross-midnight `23:30`/`07:30` no longer defer) |

Both mutations applied against the committed implementation, observed RED,
then reverted via `git checkout --` before pushing (implementation in this
PR is unmodified from what was tested green).

## Honest gaps / not proven

- No real-DB integration test asserting a pending row's `attempt_count`
  literally stays `0` across a quiet-window `runBatch()` against real
  Postgres — the unit-level "query never called" assertion is the
  intentionally chosen proof surface per the brief (this needs no
  `plugin-tests.yml` wiring as a result).
- Rows claimed seconds before the window starts still send — lease is
  already taken by claim time; inherent to a pre-claim gate, not a bug.
- Morning drain after a window ends is bounded by `batchSize` (default 50)
  per scheduler tick — unchanged from existing behavior, fine at current
  volumes.

## Ops note

Nothing changes for existing deployments unless
`ATTENDANCE_NOTIFICATION_QUIET_HOURS` is explicitly set — default behavior
(env unset) is byte-identical to before this PR.