### PR TITLE
feat(multitable): History Center record titles + type-aware link/person diff values (PR-B)

### DIFF
--- a/apps/web/src/multitable/components/HistoryBatchChangesList.vue
+++ b/apps/web/src/multitable/components/HistoryBatchChangesList.vue
@@ -115,13 +115,27 @@ function formatDiffValue(v: unknown): string {
 // resolve to display names via the grid's already-fetched summary caches, with formatFieldDisplay's own
 // count/id fallbacks on cache miss (historical/deleted/off-page rows). Fields known only by id/name
 // (e.g. non-active sheets in all-tables mode) keep the legacy plain-text path above.
+//
+// Owner P2 (link sides): the cached link summaries describe the record's CURRENT cell, and
+// formatFieldDisplay renders the summaries VERBATIM when present — ignoring `value`. A history diff
+// renders two DIFFERENT values (before vs after) for the same cell, so each side must get only the
+// summaries for ITS OWN ids, in value order; otherwise before=[A] and after=[A,B] both display "A, B".
+// Full coverage of this side's ids → value-ordered summaries; any miss → null (formatFieldDisplay's
+// honest count fallback) rather than an under-counted name list.
+function linkSummariesForSide(c: HistoryChange, fieldId: string, v: unknown): LinkedRecordSummary[] | null {
+  const cached = props.linkSummaries?.[c.recordId]?.[fieldId]
+  if (!cached?.length || !Array.isArray(v)) return null
+  const byId = new Map(cached.map((s) => [s.id, s]))
+  const matched = v.map((id) => byId.get(String(id)))
+  return matched.every((s): s is LinkedRecordSummary => s !== undefined) ? matched : null
+}
 function formatDiffValueFor(c: HistoryChange, fieldId: string, v: unknown): string {
   const f = props.fields?.find((x) => x.id === fieldId)
   if (!f || typeof f.type !== 'string') return formatDiffValue(v)
   return formatFieldDisplay({
     field: f as MetaField,
     value: v,
-    linkSummaries: props.linkSummaries?.[c.recordId]?.[fieldId] ?? null,
+    linkSummaries: f.type === 'link' ? linkSummariesForSide(c, fieldId, v) : null,
     personSummaries: props.personSummaries?.[c.recordId]?.[fieldId] ?? null,
     isZh: isZh.value,
   })

--- a/apps/web/src/multitable/components/HistoryBatchChangesList.vue
+++ b/apps/web/src/multitable/components/HistoryBatchChangesList.vue
@@ -11,7 +11,7 @@
     <li v-for="(c, i) in changes" :key="`${c.recordId}-${i}`" class="meta-hist__change" data-test="hist-change">
       <div class="meta-hist__change-summary">
         <span class="meta-hist__change-action" :data-action="c.action">{{ actionLabel(c.action) }}</span>
-        <span class="meta-hist__change-rec" :title="c.recordId">{{ shortRecordId(c.recordId) }}</span>
+        <span class="meta-hist__change-rec" :title="c.recordId" data-test="hist-rec-label">{{ recordDisplay(c) }}</span>
         <span class="meta-hist__change-fields">{{ fieldsLabel(c.changedFieldIds.length) }}</span>
       </div>
       <ul v-if="c.changedFieldIds.length" class="meta-hist__diff" data-test="hist-diff">
@@ -45,11 +45,20 @@
 <script setup lang="ts">
 import { useLocale } from '../../composables/useLocale'
 import { recordLabel } from '../utils/meta-record-labels'
-import type { HistoryChange } from '../types'
+import { formatFieldDisplay, pickRecordTitle } from '../utils/field-display'
+import type { HistoryChange, LinkedRecordSummary, MetaField, PersonSummary } from '../types'
 
 const props = defineProps<{
   changes: HistoryChange[]
-  fields?: Array<{ id: string; name: string }>
+  /** Field metadata for label/type-aware rendering. `type`/`order`/`property` are optional so legacy
+   *  callers that only carry {id,name} keep the plain-text rendering path; typed entries additionally
+   *  unlock record titles (pickRecordTitle) and type-aware diff values (formatFieldDisplay). */
+  fields?: Array<{ id: string; name: string; type?: string; order?: number; property?: Record<string, unknown> }>
+  /** Best-effort display caches, keyed recordId → fieldId → summaries (the grid's already-fetched maps).
+   *  Rows absent from the cache (historical/deleted/off-page records) fall back to formatFieldDisplay's
+   *  own count/id fallbacks — never a fetch, never un-masking. */
+  linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
+  personSummaries?: Record<string, Record<string, PersonSummary[]>>
   /** Reuses the caller's own action-label map (kept as a single source of truth in HistoryCenterModal.vue —
    *  this is prop-drilling, not a shared-module extraction, per the AI-fields S1 design-lock's constraint
    *  on `sourceLabel` NOT applying here since this is a distinct map (per-change action, not source)). */
@@ -64,6 +73,23 @@ function fieldsLabel(n: number): string {
 function shortRecordId(id: string): string {
   const trimmed = id.startsWith('rec_') ? id.slice(4) : id
   return `#${trimmed.slice(0, 8)}`
+}
+
+// Record label: human title when one is derivable from the change's OWN already-masked payload
+// (after = full post-change snapshot; before = prior/pre-delete snapshot — so deleted records title
+// from `before`), else the short record id. Reuses pickRecordTitle (TrashModal's heuristic: first
+// field in column order whose value renders non-empty; masked/unreadable fields render '—' and are
+// skipped) — leak-safe by construction, no fetch, no un-masking, full id stays in the title attr.
+const typedFields = (): MetaField[] =>
+  ((props.fields ?? []).filter((f) => typeof f.type === 'string') as MetaField[])
+function recordDisplay(c: HistoryChange): string {
+  const fields = typedFields()
+  const data = c.after ?? c.before
+  if (fields.length && data) {
+    const title = pickRecordTitle({ fields, data, isZh: isZh.value })
+    if (title) return title
+  }
+  return shortRecordId(c.recordId)
 }
 
 // --- Inline per-field diff (read-only detail expansion) ---
@@ -84,6 +110,22 @@ function formatDiffValue(v: unknown): string {
   }
   return String(v)
 }
+// Type-aware diff value: when the field's metadata (incl. `type`) is available, render through the
+// shared formatFieldDisplay (same renderer as the record drawer's history diffs) — link/person values
+// resolve to display names via the grid's already-fetched summary caches, with formatFieldDisplay's own
+// count/id fallbacks on cache miss (historical/deleted/off-page rows). Fields known only by id/name
+// (e.g. non-active sheets in all-tables mode) keep the legacy plain-text path above.
+function formatDiffValueFor(c: HistoryChange, fieldId: string, v: unknown): string {
+  const f = props.fields?.find((x) => x.id === fieldId)
+  if (!f || typeof f.type !== 'string') return formatDiffValue(v)
+  return formatFieldDisplay({
+    field: f as MetaField,
+    value: v,
+    linkSummaries: props.linkSummaries?.[c.recordId]?.[fieldId] ?? null,
+    personSummaries: props.personSummaries?.[c.recordId]?.[fieldId] ?? null,
+    isZh: isZh.value,
+  })
+}
 // Shape rule (per changed field id):
 //  - present on both sides           → 'changed' (normal before→after diff)
 //  - present only on the after side  → 'set'      (no prior value — e.g. a create, or a field just added)
@@ -98,8 +140,8 @@ function changeFieldDiffs(c: HistoryChange): FieldDiffRow[] {
     return {
       fieldId,
       shape,
-      before: beforeHas ? formatDiffValue((c.before as Record<string, unknown>)[fieldId]) : '',
-      after: afterHas ? formatDiffValue((c.after as Record<string, unknown>)[fieldId]) : '',
+      before: beforeHas ? formatDiffValueFor(c, fieldId, (c.before as Record<string, unknown>)[fieldId]) : '',
+      after: afterHas ? formatDiffValueFor(c, fieldId, (c.after as Record<string, unknown>)[fieldId]) : '',
     }
   })
 }

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -26,7 +26,7 @@
             <span class="meta-hist__when">{{ formatTime(pinnedDetail.createdAt) }}</span>
             <span class="meta-hist__counts" data-test="hist-pinned-counts">{{ countLabel(pinnedDetail) }}</span>
           </div>
-          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :action-label="actionLabel" />
+          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" />
         </template>
       </div>
 
@@ -68,7 +68,7 @@
           <div v-if="expandedId === b.batchId" class="meta-hist__detail" data-test="hist-detail">
             <p v-if="detailLoading" class="meta-hist__hint">{{ t('加载中…', 'Loading…') }}</p>
             <p v-else-if="!detail" class="meta-hist__hint">{{ t('无法打开该批次', 'This batch is unavailable') }}</p>
-            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :action-label="actionLabel" />
+            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" />
           </div>
         </li>
       </ul>
@@ -91,12 +91,18 @@ import { useLocale } from '../../composables/useLocale'
 import { useHistoryCenter } from '../composables/useHistoryCenter'
 import { historyActor } from '../utils/meta-record-labels'
 import HistoryBatchChangesList from './HistoryBatchChangesList.vue'
+import type { LinkedRecordSummary, PersonSummary } from '../types'
 
 const props = defineProps<{
   open: boolean
   baseId: string
   sheetId?: string
-  fields?: Array<{ id: string; name: string }>
+  /** `type`/`order`/`property` are optional extras consumed by HistoryBatchChangesList for record
+   *  titles + type-aware diff values; the modal itself only reads id/name (filter options). */
+  fields?: Array<{ id: string; name: string; type?: string; order?: number; property?: Record<string, unknown> }>
+  /** Best-effort grid display caches (recordId → fieldId → summaries), passed through to the change list. */
+  linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
+  personSummaries?: Record<string, Record<string, PersonSummary[]>>
   /**
    * W3-5/W3-5b: a commit toast's "view in history" deep-link sets this to the batch it just wrote. On open,
    * the modal loads the normal (unfiltered) list AND ALSO fetches this one batch's own detail via the SAME

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -535,6 +535,8 @@
       :base-id="activeBaseId || ''"
       :sheet-id="workbench.activeSheetId.value"
       :fields="historyVisibleFields"
+      :link-summaries="grid.linkSummaries.value"
+      :person-summaries="grid.personSummaries.value"
       :initial-batch-id="historyDeepLinkBatchId"
       @close="closeHistory"
     />

--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -261,3 +261,159 @@ describe('HistoryCenterModal — inline masked per-field diff (detail expansion)
     }
   })
 })
+
+// ─── PR-B: record titles + type-aware link/person diff values ────────────────────────────────────────
+// Titles come from the change's OWN already-masked payload (after = full post-change snapshot, before =
+// pre-delete snapshot) via pickRecordTitle (TrashModal's heuristic); link/person diff values render
+// through the shared formatFieldDisplay fed by the grid's summary caches, with count/id fallbacks on
+// cache miss. Legacy {id,name}-only fields (all earlier tests above) keep the plain-text path — those
+// tests passing unchanged IS the regression proof for the legacy branch.
+
+function mountModalWithProps(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp(HistoryCenterModal, { open: true, baseId: 'base_1', ...props })
+  app.mount(container)
+  return { app, container }
+}
+
+const TYPED_FIELDS = [
+  { id: 'fld_title', name: 'Title', type: 'string', order: 0 },
+  { id: 'fld_link', name: 'Related', type: 'link', order: 1 },
+  { id: 'fld_person', name: 'Owner', type: 'person', order: 2 },
+]
+
+function detailWith(changes: HistoryBatchDetail['changes']): HistoryBatchDetail {
+  return {
+    batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+    visibleAffectedRecordCount: changes.length, visibleAffectedFieldCount: 1, changes,
+  }
+}
+
+describe('HistoryCenterModal — record titles from the masked payload (PR-B)', () => {
+  it('renders the record title from the after-snapshot and keeps the full id in the title attr', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_1', recordId: 'rec_abc12345', action: 'update', version: 2,
+      changedFieldIds: ['fld_title'],
+      before: { fld_title: 'Old' },
+      after: { fld_title: 'Quarterly Report', fld_link: ['rec_x'] },
+    }]))
+    const { app, container } = mountModalWithProps({ fields: TYPED_FIELDS })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const label = container.querySelector<HTMLElement>('[data-test="hist-rec-label"]')!
+      expect(label.textContent).toBe('Quarterly Report')
+      expect(label.getAttribute('title')).toBe('rec_abc12345')
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('a DELETED record titles from its pre-delete before-snapshot', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch({ action: 'delete' })], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_1', recordId: 'rec_gone1234', action: 'delete', version: 3,
+      changedFieldIds: [],
+      before: { fld_title: 'Doomed Row' },
+      after: null,
+    }]))
+    const { app, container } = mountModalWithProps({ fields: TYPED_FIELDS })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      expect(container.querySelector('[data-test="hist-rec-label"]')?.textContent).toBe('Doomed Row')
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('falls back to the short record id when nothing in the masked payload is readable', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_1', recordId: 'rec_abcdefgh1234', action: 'update', version: 2,
+      changedFieldIds: ['fld_title'],
+      before: {},
+      after: {}, // LOCK-3 masked everything — title must NOT be derivable
+    }]))
+    const { app, container } = mountModalWithProps({ fields: TYPED_FIELDS })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      expect(container.querySelector('[data-test="hist-rec-label"]')?.textContent).toBe('#abcdefgh')
+    } finally { app.unmount(); container.remove() }
+  })
+})
+
+describe('HistoryCenterModal — type-aware link/person diff values (PR-B)', () => {
+  it('link diffs render resolved display names from the summary cache, never raw JSON', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+      changedFieldIds: ['fld_link'],
+      before: { fld_link: ['rec_a'] },
+      after: { fld_link: ['rec_a', 'rec_b'] },
+    }]))
+    const { app, container } = mountModalWithProps({
+      fields: TYPED_FIELDS,
+      linkSummaries: { rec_1: { fld_link: [
+        { id: 'rec_a', display: 'Alpha Task' },
+        { id: 'rec_b', display: 'Beta Task' },
+      ] } },
+    })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const row = container.querySelector<HTMLElement>('[data-test="hist-diff-row"]')!
+      const after = row.querySelector('.meta-hist__diff-after')?.textContent ?? ''
+      expect(after).toContain('Alpha Task')
+      expect(after).toContain('Beta Task')
+      expect(after).not.toContain('[') // no JSON dump
+      expect(after).not.toContain('rec_a')
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('link diff cache-miss falls back to a count summary — still no JSON dump', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_1', recordId: 'rec_offpage', action: 'update', version: 2,
+      changedFieldIds: ['fld_link'],
+      before: null,
+      after: { fld_link: ['rec_a', 'rec_b'] },
+    }]))
+    const { app, container } = mountModalWithProps({ fields: TYPED_FIELDS, linkSummaries: {} })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const after = container.querySelector('.meta-hist__diff-after')?.textContent ?? ''
+      expect(after).not.toContain('[')
+      expect(after).not.toContain('rec_a')
+      expect(after.length).toBeGreaterThan(0) // count-summary text from formatFieldDisplay
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('person diffs resolve display names from the cache and fall back to the raw id on miss', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+      changedFieldIds: ['fld_person'],
+      before: { fld_person: ['user_known'] },
+      after: { fld_person: ['user_known', 'user_unknown'] },
+    }]))
+    const { app, container } = mountModalWithProps({
+      fields: TYPED_FIELDS,
+      personSummaries: { rec_1: { fld_person: [{ id: 'user_known', display: 'Zhang San' }] } },
+    })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const after = container.querySelector('.meta-hist__diff-after')?.textContent ?? ''
+      expect(after).toContain('Zhang San')
+      expect(after).toContain('user_unknown') // cache miss → raw id, not JSON
+      expect(after).not.toContain('[')
+    } finally { app.unmount(); container.remove() }
+  })
+})

--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -346,7 +346,7 @@ describe('HistoryCenterModal — record titles from the masked payload (PR-B)', 
 })
 
 describe('HistoryCenterModal — type-aware link/person diff values (PR-B)', () => {
-  it('link diffs render resolved display names from the summary cache, never raw JSON', async () => {
+  it('link diffs render EACH SIDE from its own value ids (owner P2): before=[A] vs after=[A,B] differ', async () => {
     mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
     mockGetHistoryBatch.mockResolvedValue(detailWith([{
       sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
@@ -356,6 +356,8 @@ describe('HistoryCenterModal — type-aware link/person diff values (PR-B)', () 
     }]))
     const { app, container } = mountModalWithProps({
       fields: TYPED_FIELDS,
+      // The cache describes the CURRENT cell ([A,B]); each side must be filtered to its own ids —
+      // an unfiltered pass-through renders "Alpha Task, Beta Task" on BOTH sides.
       linkSummaries: { rec_1: { fld_link: [
         { id: 'rec_a', display: 'Alpha Task' },
         { id: 'rec_b', display: 'Beta Task' },
@@ -366,11 +368,37 @@ describe('HistoryCenterModal — type-aware link/person diff values (PR-B)', () 
       container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
       await flushPromises()
       const row = container.querySelector<HTMLElement>('[data-test="hist-diff-row"]')!
+      const before = row.querySelector('.meta-hist__diff-before')?.textContent ?? ''
       const after = row.querySelector('.meta-hist__diff-after')?.textContent ?? ''
+      expect(before).toContain('Alpha Task')
+      expect(before).not.toContain('Beta Task') // before=[rec_a] only — the P2 regression
       expect(after).toContain('Alpha Task')
       expect(after).toContain('Beta Task')
       expect(after).not.toContain('[') // no JSON dump
       expect(after).not.toContain('rec_a')
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('link diff PARTIAL cache coverage falls back to the count summary, never an under-counted name list', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+      changedFieldIds: ['fld_link'],
+      before: null,
+      after: { fld_link: ['rec_a', 'rec_gone'] }, // rec_gone is NOT in the cache
+    }]))
+    const { app, container } = mountModalWithProps({
+      fields: TYPED_FIELDS,
+      linkSummaries: { rec_1: { fld_link: [{ id: 'rec_a', display: 'Alpha Task' }] } },
+    })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const after = container.querySelector('.meta-hist__diff-after')?.textContent ?? ''
+      expect(after).not.toContain('Alpha Task') // "Alpha Task" alone would misread as a 1-link value
+      expect(after).not.toContain('[')
+      expect(after.length).toBeGreaterThan(0) // honest count-summary text
     } finally { app.unmount(); container.remove() }
   })
 


### PR DESCRIPTION
**Stacked on #4007 (PR-A)** — retarget to main after #4007 lands, land bottom-up per stacked-PR discipline.

R9 UX-parity audit findings (b)(h)(i): the History Center rendered only short raw record ids and JSON.stringify'd link/person diff values, even though everything needed is already on the wire.

### What
1. **Record titles** — `pickRecordTitle` (the TrashModal heuristic: first field in column order whose value renders non-empty; masked fields render '—' and are skipped) over the change's OWN permission-masked payload: `after` = full post-change snapshot; `before` = pre-delete snapshot, so **deleted records title from `before`**. Fallback = short id; full id kept in the `title` attr. Leak-safe by construction: no fetch, no un-masking, masked-everything payloads fall back to the id.
2. **Type-aware diff values** — `fields` prop widened (optional `type/order/property`); values route through the shared `formatFieldDisplay` (exact same renderer as MetaRecordDrawer's history diffs) fed by the grid's `linkSummaries`/`personSummaries` caches plumbed workbench→modal→list. Cache miss (historical/deleted/off-page rows) → formatFieldDisplay's own count/id fallbacks. Unknown-type fields keep the legacy plain-text path — the 6 pre-existing spec cases passing unchanged is the regression proof.

### Verification
- 6 new spec cases (titles ×3, link ×2, person ×1) in the CI-wired `multitable-history-center-inline-diff.spec.ts` (gate wiring = #4006).
- **Mutation-verified**: neuter title path → exactly 2 red; force legacy value path → exactly 3 red.
- Neighbor sweep: 7 files / 48 tests green (all 3 history-center specs + history-fe + field-scope wiring + restore-wiring + trash-fe). `vue-tsc` clean.

### Not covered / honest limitations
- All-tables mode: batches from NON-active sheets still have no field metadata threaded in → id-fallback labels there (pre-existing; separate candidate in the R9 audit).
- Link/person resolution is best-effort from currently-loaded grid caches; fully resolving arbitrary historical ids would need a new batched lookup endpoint (gated, owner menu).
- pickRecordTitle without summaries can pick a link-count text as 'title' if a link field is the first column (house-consistent with TrashModal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)