### PR TITLE
feat(dingtalk): R1 — retention sweep for group-delivery telemetry (DT-HARDEN-08 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,16 @@ JWT_EXPIRES_IN=2h
 # DINGTALK_AUTH_AUTO_PROVISION=0
 # DINGTALK_AUTH_REQUIRE_GRANT=0
 #
+# ---- DingTalk group-delivery retention sweep (R1, DT-HARDEN-08 follow-up) ----
+# dingtalk_group_deliveries is write-once (one row per group-robot send attempt,
+# success or failure), so a periodic bounded-DELETE sweep keeps it from growing
+# unbounded. Enabled by default at a 90-day window; tune or opt out below.
+# DINGTALK_GROUP_DELIVERY_RETENTION_DAYS=90
+# DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=0
+# DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS=21600000
+# Optional multi-instance fleet coordination (defaults to single-process leader):
+# ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK=false
+#
 # ---- Approval one-tap card (A-5 verification; design-lock #3594) --------------
 # APP_KEY/SECRET/AGENT_ID above ARE the same corp-app used to SEND the approval
 # action_card (asyncsend_v2). The card decision deep link additionally needs:

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -351,6 +351,7 @@ jobs:
             tests/integration/multitable-ai-bulk-job.test.ts \
             tests/integration/multitable-ai-ledger-retention.test.ts \
             tests/integration/multitable-ai-ledger-concurrency.test.ts \
+            tests/integration/dingtalk-group-delivery-retention.db.test.ts \
             tests/integration/multitable-ai-suggest-formula.test.ts \
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             tests/integration/data-source-test-ephemeral-realdb.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -123,6 +123,12 @@ import {
   startLedgerRetentionScheduler,
   stopLedgerRetentionScheduler,
 } from './services/LedgerRetentionScheduler'
+import {
+  resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs,
+  resolveDingTalkGroupDeliveryRetentionSchedulerLeaderOptions,
+  startDingTalkGroupDeliveryRetentionScheduler,
+  stopDingTalkGroupDeliveryRetentionScheduler,
+} from './services/dingtalk-group-delivery-retention-scheduler'
 import { initWebhookEventBridge } from './multitable/webhook-event-bridge'
 import { ApprovalBreachNotifier } from './services/ApprovalBreachNotifier'
 import {
@@ -1976,6 +1982,14 @@ export class MetaSheetServer {
       }
     })())
 
+    shutdownTasks.push((async () => {
+      try {
+        stopDingTalkGroupDeliveryRetentionScheduler()
+      } catch (err) {
+        this.logger.warn(`DingTalk group-delivery retention scheduler shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })())
+
     // 4. Destroy API Gateway resources (only if one was constructed during start()).
     shutdownTasks.push((async () => {
       try {
@@ -2257,6 +2271,30 @@ export class MetaSheetServer {
       )
     } catch (e) {
       this.logger.error('AI usage ledger retention scheduler initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    // DingTalk group-delivery retention sweep (R1, DT-HARDEN-08 follow-up): a
+    // periodic bounded DELETE of dingtalk_group_deliveries rows past the
+    // retention window (default 90d, env-overridable, floored at 7d). The
+    // table is write-once — every group-robot send attempt (automation rule
+    // firings AND manual test-sends) inserts a row with full message content
+    // and raw response bodies, so without this it grows unbounded. Reuses the
+    // generic LedgerRetentionScheduler (same pattern as the AI usage ledger
+    // sweep above); enabled by default (opt out via
+    // DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1).
+    try {
+      const dingtalkDeliveryRetentionLeaderOptions = await resolveDingTalkGroupDeliveryRetentionSchedulerLeaderOptions()
+      const dingtalkDeliveryRetentionScheduler = startDingTalkGroupDeliveryRetentionScheduler({
+        leaderOptions: dingtalkDeliveryRetentionLeaderOptions,
+        intervalMs: resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs(),
+      })
+      this.logger.info(
+        dingtalkDeliveryRetentionScheduler
+          ? 'DingTalk group-delivery retention scheduler initialized'
+          : 'DingTalk group-delivery retention scheduler disabled (DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1)',
+      )
+    } catch (e) {
+      this.logger.error('DingTalk group-delivery retention scheduler initialization failed; continuing in degraded mode', e as Error)
     }
 
     // B-4 BJ-5 follow-up: reconcile ORPHANED AI bulk-fill jobs at boot. A hard

--- a/packages/core-backend/src/services/LedgerRetentionScheduler.ts
+++ b/packages/core-backend/src/services/LedgerRetentionScheduler.ts
@@ -88,6 +88,15 @@ export interface LedgerRetentionSchedulerOptions {
   leaderOptions?: LedgerRetentionSchedulerLeaderOptions | null
   runtime?: LedgerRetentionSchedulerRuntimeOptions
   logger?: Logger
+  /**
+   * Label used in the "rows swept" tick log line. Defaults to the original
+   * AI-usage-ledger wording so the shipped ledger sweep's log output is
+   * byte-identical when this option is omitted — other services reusing
+   * this generic scheduler (e.g. the DingTalk group-delivery retention
+   * sweep) pass their own label so the log doesn't misreport which table
+   * was swept.
+   */
+  sweptEntityLabel?: string
 }
 
 export class LedgerRetentionScheduler {
@@ -100,6 +109,7 @@ export class LedgerRetentionScheduler {
   private readonly renewIntervalMs: number
   private readonly retryIntervalMs: number
   private readonly leaderStateGauge: LedgerRetentionSchedulerLeaderGauge | null
+  private readonly sweptEntityLabel: string
   private timer: NodeJS.Timeout | null = null
   private renewalTimer: NodeJS.Timeout | null = null
   private acquisitionTimer: NodeJS.Timeout | null = null
@@ -118,6 +128,7 @@ export class LedgerRetentionScheduler {
     this.retryIntervalMs = this.leaderOptions?.retryIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
     this.leaderStateGauge = options.runtime?.leaderStateGauge ?? null
     this.logger = options.logger ?? new Logger('LedgerRetentionScheduler')
+    this.sweptEntityLabel = options.sweptEntityLabel ?? 'AI usage ledger rows'
     if (this.leaderOptions) {
       this.setLeaderGauge('follower')
       this.ready = this.attemptLeadership().catch((error) => {
@@ -181,7 +192,7 @@ export class LedgerRetentionScheduler {
     try {
       const deleted = await this.service.sweep()
       if (deleted > 0) {
-        this.logger.info(`AI usage ledger rows swept (retention): ${deleted}`)
+        this.logger.info(`${this.sweptEntityLabel} swept (retention): ${deleted}`)
       }
       return deleted
     } catch (error) {

--- a/packages/core-backend/src/services/dingtalk-group-delivery-retention-scheduler.ts
+++ b/packages/core-backend/src/services/dingtalk-group-delivery-retention-scheduler.ts
@@ -52,10 +52,6 @@ export function startDingTalkGroupDeliveryRetentionScheduler(
   return sharedScheduler
 }
 
-export function getSharedDingTalkGroupDeliveryRetentionScheduler(): LedgerRetentionScheduler | null {
-  return sharedScheduler
-}
-
 export function stopDingTalkGroupDeliveryRetentionScheduler(): void {
   if (sharedScheduler) {
     sharedScheduler.stop()

--- a/packages/core-backend/src/services/dingtalk-group-delivery-retention-scheduler.ts
+++ b/packages/core-backend/src/services/dingtalk-group-delivery-retention-scheduler.ts
@@ -1,0 +1,87 @@
+/**
+ * DingTalk group-delivery retention scheduler (R1, DT-HARDEN-08 follow-up).
+ *
+ * Boot-wiring glue around the generic `LedgerRetentionScheduler` class (it
+ * already depends only on an injected `{ sweep(): Promise<number> }`
+ * service, so no changes were needed there) bound to
+ * `PgDingTalkGroupDeliveryRetentionService` — the sweep function itself lives
+ * in ./dingtalk-group-delivery-retention.ts.
+ *
+ * Enabled by default; disable with DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1
+ * (the same opt-out the sweep honors — a disabled config makes every tick a
+ * no-op). Interval defaults to the same daily-ish 6h cadence as the ledger
+ * sweep (DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS), clamped to
+ * a 60s floor. A multi-instance fleet can opt into a Redis leader lock via
+ * ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK=true, mirroring the
+ * ledger scheduler's opt-in — the sweep is idempotent and convergent
+ * (a later tick deletes whatever a missed/duplicate tick left), so the lock
+ * is a load optimisation only, never load-bearing for correctness.
+ */
+
+import { randomBytes } from 'crypto'
+import { Logger } from '../core/logger'
+import { getRedisClient } from '../db/redis'
+import { RedisLeaderLock, type RedisLeaderLockClient } from '../multitable/redis-leader-lock'
+import {
+  LedgerRetentionScheduler,
+  type LedgerRetentionSchedulerLeaderOptions,
+  type LedgerRetentionSchedulerOptions,
+} from './LedgerRetentionScheduler'
+import { PgDingTalkGroupDeliveryRetentionService } from './dingtalk-group-delivery-retention'
+
+const DEFAULT_LOCK_TTL_MS = 30_000
+
+let sharedScheduler: LedgerRetentionScheduler | null = null
+
+/**
+ * Enabled by default; opt OUT with DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1.
+ * Returns null when disabled or already started.
+ */
+export function startDingTalkGroupDeliveryRetentionScheduler(
+  options: LedgerRetentionSchedulerOptions = {},
+): LedgerRetentionScheduler | null {
+  if (process.env.DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED === '1') return null
+  if (sharedScheduler) return sharedScheduler
+  sharedScheduler = new LedgerRetentionScheduler({
+    ...options,
+    service: options.service ?? new PgDingTalkGroupDeliveryRetentionService(),
+    logger: options.logger ?? new Logger('DingTalkGroupDeliveryRetentionScheduler'),
+    sweptEntityLabel: options.sweptEntityLabel ?? 'DingTalk group-delivery rows',
+  })
+  sharedScheduler.start()
+  return sharedScheduler
+}
+
+export function getSharedDingTalkGroupDeliveryRetentionScheduler(): LedgerRetentionScheduler | null {
+  return sharedScheduler
+}
+
+export function stopDingTalkGroupDeliveryRetentionScheduler(): void {
+  if (sharedScheduler) {
+    sharedScheduler.stop()
+    sharedScheduler = null
+  }
+}
+
+export function resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs(): number | undefined {
+  const raw = Number(process.env.DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS)
+  return Number.isFinite(raw) && raw > 0 ? raw : undefined
+}
+
+export async function resolveDingTalkGroupDeliveryRetentionSchedulerLeaderOptions(): Promise<LedgerRetentionSchedulerLeaderOptions | null> {
+  if (process.env.ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK !== 'true') return null
+  const redis = await getRedisClient()
+  if (!redis) return null
+  const ttlMs = Number(process.env.DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_TTL_MS) > 0
+    ? Number(process.env.DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_TTL_MS)
+    : DEFAULT_LOCK_TTL_MS
+  const retryIntervalMs = Number(process.env.DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_RETRY_MS) > 0
+    ? Number(process.env.DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_RETRY_MS)
+    : undefined
+  return {
+    leaderLock: new RedisLeaderLock({ client: redis as unknown as RedisLeaderLockClient }),
+    ownerId: `dingtalk-group-delivery-retention:${process.pid}:${randomBytes(4).toString('hex')}`,
+    ttlMs,
+    retryIntervalMs,
+  }
+}

--- a/packages/core-backend/src/services/dingtalk-group-delivery-retention.ts
+++ b/packages/core-backend/src/services/dingtalk-group-delivery-retention.ts
@@ -1,0 +1,127 @@
+/**
+ * DingTalk group-delivery retention sweep (R1, DT-HARDEN-08 follow-up).
+ *
+ * `dingtalk_group_deliveries` is write-once: every automation-rule firing of
+ * `send_dingtalk_group_message` inserts one row per matched destination
+ * (success AND failure), plus manual test-sends
+ * (dingtalk-group-destination-service.ts). Each row carries full message
+ * `content` plus raw `response_body` TEXT, so a record-change-triggered rule
+ * on an active sheet writes thousands of multi-KB rows/day with zero DELETE
+ * anywhere in the codebase — the table grows unbounded. Reads are shallow
+ * (listDeliveries LIMIT 50 per destination), so a retention window well past
+ * that UI need is safe.
+ *
+ * Mirrors services/ai-usage-ledger.ts's retention pair byte-for-byte in shape:
+ * bounded batch DELETE (default 5000 rows/pass via a ctid sub-select so one
+ * pass never blocks the table), default 90-day window, floored at 7 days,
+ * enabled by default with an opt-out env var. This is a hygiene sweep (not a
+ * notify side-effect channel), so the "register only when configured"
+ * convention does not apply — the ledger sweep is the in-repo precedent for
+ * that judgment (see docs/development/dingtalk-sync-hardening-design-and-verification-20260708.md).
+ *
+ * Scheduling reuses the generic `LedgerRetentionScheduler` class directly
+ * (it already only depends on an injected `{ sweep(): Promise<number> }`
+ * service, so it needed no changes) — one scheduler implementation serving
+ * two independent interval loops, wired at boot in index.ts right after the
+ * ledger retention block.
+ *
+ * KNOWN GAP (documented, not fixed here): the DELETE's `created_at < cutoff`
+ * predicate has no dedicated index — the existing composite index is
+ * `(destination_id, created_at DESC)`, which does not serve a bare
+ * `created_at` predicate, so each batch pass is a sequential scan. Acceptable
+ * at current table sizes; an optional `(created_at)` index is a follow-up if
+ * the table grows large enough for this to matter (kept out of this change
+ * per YAGNI — adding it would require a migration).
+ */
+
+import type { AiUsageQueryFn } from './ai-usage-ledger'
+import type { LedgerRetentionService } from './LedgerRetentionScheduler'
+import { poolManager } from '../integration/db/connection-pool'
+
+export const DINGTALK_GROUP_DELIVERY_TABLE = 'dingtalk_group_deliveries'
+
+/** Default retention window in days when no env override is set. */
+export const DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS = 90
+
+/** Floor on the retention window (foot-gun guard) — never below 7 days. */
+export const DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS = 7
+
+/** Per-pass DELETE bound — drains a backlog over ticks, never one huge statement. */
+export const DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_BATCH = 5000
+
+export interface DingTalkGroupDeliveryRetentionConfig {
+  /** Resolved retention window in days (already floored). */
+  retentionDays: number
+  /** Opt-out: when true the sweep is a no-op (deletes 0). */
+  disabled: boolean
+  /** Per-pass row cap (defaults to DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_BATCH). */
+  batchSize?: number
+}
+
+/**
+ * Resolve the retention config from the environment. Enabled by default;
+ * opt out with DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1. The window is
+ * floored at DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS (7) so a misconfigured
+ * low value can never turn into an aggressive audit-trail-eating sweep.
+ */
+export function resolveDingTalkGroupDeliveryRetentionConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): DingTalkGroupDeliveryRetentionConfig {
+  const disabled = env.DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED === '1'
+  const rawDays = Number(env.DINGTALK_GROUP_DELIVERY_RETENTION_DAYS)
+  const requestedDays =
+    Number.isFinite(rawDays) && rawDays > 0 ? rawDays : DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS
+  const retentionDays = Math.max(DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS, Math.floor(requestedDays))
+  return { retentionDays, disabled }
+}
+
+/**
+ * Delete dingtalk_group_deliveries rows older than the retention window.
+ * Returns the number of rows deleted (0 when disabled, or when nothing is
+ * past the window). The DELETE is bounded by `batchSize` via a ctid
+ * sub-select so one pass never blocks the table during a backlog drain.
+ *
+ * Applies to both source_types (automation-rule sends and manual_test) —
+ * there is no per-source-type carve-out, since neither is referenced by
+ * anything downstream once written (deliveries only reference destinations/
+ * rules via FK, nothing references deliveries).
+ */
+export async function sweepDingTalkGroupDeliveryRetention(
+  query: AiUsageQueryFn,
+  config: DingTalkGroupDeliveryRetentionConfig,
+): Promise<number> {
+  if (config.disabled) return 0
+  const retentionDays = Math.max(DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS, Math.floor(config.retentionDays))
+  const batchSize = Math.max(1, Math.floor(config.batchSize ?? DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_BATCH))
+  const result = await query(
+    `DELETE FROM ${DINGTALK_GROUP_DELIVERY_TABLE}
+      WHERE ctid IN (
+        SELECT ctid FROM ${DINGTALK_GROUP_DELIVERY_TABLE}
+         WHERE created_at < now() - ($1::int * interval '1 day')
+         LIMIT $2
+      )`,
+    [retentionDays, batchSize],
+  )
+  return result.rowCount ?? 0
+}
+
+/**
+ * Default service: binds the sweep to the shared pg pool + the env-resolved
+ * retention config. Re-reads the config each pass so an env change (or the
+ * disabled opt-out) takes effect on the next tick without a restart.
+ */
+export class PgDingTalkGroupDeliveryRetentionService implements LedgerRetentionService {
+  private readonly config?: DingTalkGroupDeliveryRetentionConfig
+
+  constructor(config?: DingTalkGroupDeliveryRetentionConfig) {
+    this.config = config
+  }
+
+  async sweep(): Promise<number> {
+    const config = this.config ?? resolveDingTalkGroupDeliveryRetentionConfig()
+    if (config.disabled) return 0
+    const pool = poolManager.get() as unknown as { query: AiUsageQueryFn }
+    const query = pool.query.bind(pool) as AiUsageQueryFn
+    return sweepDingTalkGroupDeliveryRetention(query, config)
+  }
+}

--- a/packages/core-backend/tests/integration/dingtalk-group-delivery-retention.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-group-delivery-retention.db.test.ts
@@ -1,0 +1,176 @@
+/**
+ * R1 (DT-HARDEN-08 follow-up) — dingtalk_group_deliveries retention sweep (real DB).
+ *
+ * The table is write-once: every group-robot send attempt (automation-rule
+ * firings AND manual test-sends — both source_types) inserts a row with full
+ * message content + raw response bodies, and nothing anywhere DELETEs from
+ * it, so it grows unbounded. The sweep is a bounded batch DELETE of rows
+ * older than a retention window (default 90d, floored at 7d).
+ *
+ * KEYSTONE: the sweep must delete ONLY rows strictly older than the cutoff
+ * and leave everything inside the window untouched — for BOTH source_types
+ * (automation and manual_test), since neither gets a carve-out. Seeds rows
+ * at cutoff-1d (older → deleted) and cutoff+1d (younger → kept) per
+ * source_type, then asserts the exact survivor set by id.
+ *
+ * Wired into .github/workflows/plugin-tests.yml "Run multitable real-DB
+ * integration" step; excluded from packages/core-backend/vitest.config.ts's
+ * default (no-DB) job so it cannot skip-green there.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  DINGTALK_GROUP_DELIVERY_TABLE,
+  PgDingTalkGroupDeliveryRetentionService,
+  sweepDingTalkGroupDeliveryRetention,
+} from '../../src/services/dingtalk-group-delivery-retention'
+import { LedgerRetentionScheduler } from '../../src/services/LedgerRetentionScheduler'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const DESTINATION_ID = `dtdest_ret_${TS}`
+const RECORD_ID = `rec_ret_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+type SeedRow = { id: string; sourceType: 'automation' | 'manual_test'; daysAgo: number }
+
+/** Insert a delivery row, then force its created_at to `daysAgo` days in the past. */
+async function seedRow(row: SeedRow): Promise<void> {
+  await q(
+    `INSERT INTO ${DINGTALK_GROUP_DELIVERY_TABLE} (
+       id, destination_id, source_type, subject, content, success,
+       http_status, response_body, error_message, record_id, initiated_by
+     ) VALUES ($1, $2, $3, 'retention test', 'hello', true, 200, 'ok', NULL, $4, 'tester')`,
+    [row.id, DESTINATION_ID, row.sourceType, RECORD_ID],
+  )
+  await q(
+    `UPDATE ${DINGTALK_GROUP_DELIVERY_TABLE} SET created_at = now() - ($2::int * interval '1 day') WHERE id = $1`,
+    [row.id, row.daysAgo],
+  )
+}
+
+async function existingIds(): Promise<string[]> {
+  const res = await q(`SELECT id FROM ${DINGTALK_GROUP_DELIVERY_TABLE} WHERE destination_id = $1 ORDER BY id`, [
+    DESTINATION_ID,
+  ])
+  return (res.rows as Array<{ id: string }>).map((r) => r.id)
+}
+
+// Rows on either side of a 30-day retention cutoff, for both source_types.
+const OLD_AUTOMATION = `${DESTINATION_ID}_old_auto`
+const OLD_MANUAL = `${DESTINATION_ID}_old_manual`
+const NEW_AUTOMATION = `${DESTINATION_ID}_new_auto`
+const NEW_MANUAL = `${DESTINATION_ID}_new_manual`
+
+async function reseed(): Promise<void> {
+  await q(`DELETE FROM ${DINGTALK_GROUP_DELIVERY_TABLE} WHERE destination_id = $1`, [DESTINATION_ID])
+  await seedRow({ id: OLD_AUTOMATION, sourceType: 'automation', daysAgo: 31 }) // cutoff(30d) - 1d → deleted
+  await seedRow({ id: OLD_MANUAL, sourceType: 'manual_test', daysAgo: 31 }) // cutoff(30d) - 1d → deleted
+  await seedRow({ id: NEW_AUTOMATION, sourceType: 'automation', daysAgo: 29 }) // cutoff(30d) + 1d → kept
+  await seedRow({ id: NEW_MANUAL, sourceType: 'manual_test', daysAgo: 29 }) // cutoff(30d) + 1d → kept
+}
+
+describeIfDatabase('DingTalk group-delivery retention sweep (real DB)', () => {
+  beforeAll(async () => {
+    await q(
+      `INSERT INTO dingtalk_group_destinations (id, name, webhook_url, created_by)
+       VALUES ($1, 'retention test destination', 'https://oapi.dingtalk.com/robot/send?access_token=ret', 'tester')
+       ON CONFLICT (id) DO NOTHING`,
+      [DESTINATION_ID],
+    )
+    await reseed()
+  })
+
+  beforeEach(async () => {
+    await reseed()
+  })
+
+  afterAll(async () => {
+    await q(`DELETE FROM ${DINGTALK_GROUP_DELIVERY_TABLE} WHERE destination_id = $1`, [DESTINATION_ID]).catch(() => {})
+    await q(`DELETE FROM dingtalk_group_destinations WHERE id = $1`, [DESTINATION_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('KEYSTONE: a 30-day sweep deletes only the >30d rows across BOTH source_types and keeps the rest', async () => {
+    expect(await existingIds()).toHaveLength(4)
+
+    const deleted = await sweepDingTalkGroupDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+    })
+    expect(deleted).toBe(2)
+
+    const remaining = await existingIds()
+    expect(remaining.sort()).toEqual([NEW_AUTOMATION, NEW_MANUAL].sort())
+    expect(remaining).not.toContain(OLD_AUTOMATION)
+    expect(remaining).not.toContain(OLD_MANUAL)
+  })
+
+  test('idempotence: a second sweep pass over the same window deletes 0', async () => {
+    const first = await sweepDingTalkGroupDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+    })
+    expect(first).toBe(2)
+
+    const second = await sweepDingTalkGroupDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+    })
+    expect(second).toBe(0)
+    expect(await existingIds()).toHaveLength(2)
+  })
+
+  test('disabled config is a no-op (deletes 0, table unchanged)', async () => {
+    const deleted = await sweepDingTalkGroupDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: true,
+    })
+    expect(deleted).toBe(0)
+    expect(await existingIds()).toHaveLength(4)
+  })
+
+  test('the batch LIMIT bounds a single pass: batchSize=1 drains the 2 stale rows over two ticks, never one', async () => {
+    const first = await sweepDingTalkGroupDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+      batchSize: 1,
+    })
+    expect(first).toBe(1) // bounded — NOT both stale rows in one pass
+    expect(await existingIds()).toHaveLength(3)
+
+    const second = await sweepDingTalkGroupDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+      batchSize: 1,
+    })
+    expect(second).toBe(1)
+    expect(await existingIds()).toHaveLength(2)
+  })
+
+  test('PgDingTalkGroupDeliveryRetentionService.sweep() (the scheduler-bound path) hits the real DB identically', async () => {
+    const service = new PgDingTalkGroupDeliveryRetentionService({ retentionDays: 30, disabled: false })
+    const deleted = await service.sweep()
+    expect(deleted).toBe(2)
+    expect(await existingIds()).toHaveLength(2)
+  })
+
+  test('the scheduler tick drives the sweep end-to-end (LedgerRetentionScheduler + PgDingTalkGroupDeliveryRetentionService)', async () => {
+    const scheduler = new LedgerRetentionScheduler({
+      service: new PgDingTalkGroupDeliveryRetentionService({ retentionDays: 30, disabled: false }),
+    })
+    expect(scheduler.leader).toBe(true) // no leaderOptions → single-process leader immediately
+
+    const deleted = await scheduler.tick()
+    expect(deleted).toBe(2)
+    expect(await existingIds()).toHaveLength(2)
+
+    scheduler.stop()
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-group-delivery-retention.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-delivery-retention.test.ts
@@ -3,6 +3,7 @@ import {
   DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS,
   DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS,
   resolveDingTalkGroupDeliveryRetentionConfig,
+  sweepDingTalkGroupDeliveryRetention,
 } from '../../src/services/dingtalk-group-delivery-retention'
 import {
   LedgerRetentionScheduler,
@@ -62,6 +63,23 @@ describe('resolveDingTalkGroupDeliveryRetentionConfig (env parse + floor + opt-o
   })
 })
 
+describe('sweepDingTalkGroupDeliveryRetention re-floor (defense-in-depth)', () => {
+  it('re-floors an out-of-range config.retentionDays before building the DELETE — even though the only production caller (resolveDingTalkGroupDeliveryRetentionConfig) already floors it, a config object built by hand (e.g. a future caller, or a test) must not be able to bypass the floor', async () => {
+    const calls: Array<unknown[] | undefined> = []
+    const query = vi.fn(async (_sql: string, params?: unknown[]) => {
+      calls.push(params)
+      return { rows: [], rowCount: 0 }
+    })
+    await sweepDingTalkGroupDeliveryRetention(query as never, {
+      retentionDays: 1, // below DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS (7); only reachable by
+      // constructing the config directly, bypassing resolveDingTalkGroupDeliveryRetentionConfig's own floor
+      disabled: false,
+    })
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(calls[0]?.[0]).toBe(DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS) // re-floored to 7, not the raw 1
+  })
+})
+
 describe('DingTalk group-delivery retention scheduler (reuses the generic LedgerRetentionScheduler)', () => {
   afterEach(() => {
     stopLedgerRetentionScheduler()
@@ -110,5 +128,30 @@ describe('DingTalk group-delivery retention scheduler (reuses the generic Ledger
     expect(resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs()).toBe(3600000)
     process.env.DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS = '-5'
     expect(resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs()).toBeUndefined()
+  })
+
+  it('start() actually arms the interval loop (not just returns a scheduler): the injected sweep fires once timers advance past the interval, fires again on the NEXT interval (the loop re-arms, it is not a one-shot timeout), and stop() halts further ticks', async () => {
+    vi.useFakeTimers()
+    try {
+      const sweep = vi.fn<() => Promise<number>>().mockResolvedValue(0)
+      const intervalMs = 60_000 // MIN_INTERVAL_MS floor in LedgerRetentionScheduler
+      const scheduler = startDingTalkGroupDeliveryRetentionScheduler({ service: { sweep }, intervalMs })
+      expect(scheduler).not.toBeNull()
+      await scheduler!.ready // no leaderOptions → resolves synchronously, but await to flush the .then() that arms the timer
+
+      expect(sweep).not.toHaveBeenCalled() // nothing fires before the interval elapses
+
+      await vi.advanceTimersByTimeAsync(intervalMs)
+      expect(sweep).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(intervalMs)
+      expect(sweep).toHaveBeenCalledTimes(2) // second interval: the loop re-arms itself
+
+      stopDingTalkGroupDeliveryRetentionScheduler()
+      await vi.advanceTimersByTimeAsync(intervalMs * 3)
+      expect(sweep).toHaveBeenCalledTimes(2) // stop() cleared the interval — no further ticks
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/core-backend/tests/unit/dingtalk-group-delivery-retention.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-delivery-retention.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS,
+  DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS,
+  resolveDingTalkGroupDeliveryRetentionConfig,
+} from '../../src/services/dingtalk-group-delivery-retention'
+import {
+  LedgerRetentionScheduler,
+  stopLedgerRetentionScheduler,
+} from '../../src/services/LedgerRetentionScheduler'
+import {
+  resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs,
+  startDingTalkGroupDeliveryRetentionScheduler,
+  stopDingTalkGroupDeliveryRetentionScheduler,
+} from '../../src/services/dingtalk-group-delivery-retention-scheduler'
+
+describe('resolveDingTalkGroupDeliveryRetentionConfig (env parse + floor + opt-out)', () => {
+  it('defaults to 90 days, not disabled, with no env set', () => {
+    expect(resolveDingTalkGroupDeliveryRetentionConfig({})).toEqual({
+      retentionDays: DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS,
+      disabled: false,
+    })
+  })
+
+  it('honors a custom DINGTALK_GROUP_DELIVERY_RETENTION_DAYS', () => {
+    expect(
+      resolveDingTalkGroupDeliveryRetentionConfig({ DINGTALK_GROUP_DELIVERY_RETENTION_DAYS: '30' }),
+    ).toEqual({ retentionDays: 30, disabled: false })
+  })
+
+  it('floors the retention window at the min (foot-gun guard): 1 day → MIN', () => {
+    expect(
+      resolveDingTalkGroupDeliveryRetentionConfig({ DINGTALK_GROUP_DELIVERY_RETENTION_DAYS: '1' }).retentionDays,
+    ).toBe(DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS)
+  })
+
+  it('floors invalid / non-positive values back to the default (not below the floor)', () => {
+    expect(
+      resolveDingTalkGroupDeliveryRetentionConfig({ DINGTALK_GROUP_DELIVERY_RETENTION_DAYS: 'abc' }).retentionDays,
+    ).toBe(DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS)
+    expect(
+      resolveDingTalkGroupDeliveryRetentionConfig({ DINGTALK_GROUP_DELIVERY_RETENTION_DAYS: '0' }).retentionDays,
+    ).toBe(DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS)
+    expect(
+      resolveDingTalkGroupDeliveryRetentionConfig({ DINGTALK_GROUP_DELIVERY_RETENTION_DAYS: '-10' }).retentionDays,
+    ).toBe(DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS)
+    expect(
+      resolveDingTalkGroupDeliveryRetentionConfig({ DINGTALK_GROUP_DELIVERY_RETENTION_DAYS: 'NaN' }).retentionDays,
+    ).toBe(DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS)
+  })
+
+  it('opts out when DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1', () => {
+    expect(
+      resolveDingTalkGroupDeliveryRetentionConfig({ DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED: '1' }).disabled,
+    ).toBe(true)
+  })
+
+  it('does not opt out on any other value (only the literal "1" disables)', () => {
+    expect(
+      resolveDingTalkGroupDeliveryRetentionConfig({ DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED: 'true' }).disabled,
+    ).toBe(false)
+  })
+})
+
+describe('DingTalk group-delivery retention scheduler (reuses the generic LedgerRetentionScheduler)', () => {
+  afterEach(() => {
+    stopLedgerRetentionScheduler()
+    stopDingTalkGroupDeliveryRetentionScheduler()
+    delete process.env.DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED
+    delete process.env.DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS
+  })
+
+  it('tick() delegates to the injected fake sweep and returns its deleted count', async () => {
+    const sweep = vi.fn<() => Promise<number>>().mockResolvedValue(42)
+    const scheduler = new LedgerRetentionScheduler({ service: { sweep } })
+    expect(await scheduler.tick()).toBe(42)
+    expect(sweep).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows sweep errors and returns 0 (degraded mode)', async () => {
+    const sweep = vi.fn().mockRejectedValue(new Error('db down'))
+    const scheduler = new LedgerRetentionScheduler({ service: { sweep } })
+    expect(await scheduler.tick()).toBe(0)
+  })
+
+  it('startDingTalkGroupDeliveryRetentionScheduler returns null when DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1', () => {
+    process.env.DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED = '1'
+    const scheduler = startDingTalkGroupDeliveryRetentionScheduler({
+      service: { sweep: vi.fn().mockResolvedValue(0) },
+    })
+    expect(scheduler).toBeNull()
+  })
+
+  it('startDingTalkGroupDeliveryRetentionScheduler is enabled by default (no env)', () => {
+    const scheduler = startDingTalkGroupDeliveryRetentionScheduler({
+      service: { sweep: vi.fn().mockResolvedValue(0) },
+    })
+    expect(scheduler).not.toBeNull()
+  })
+
+  it('startDingTalkGroupDeliveryRetentionScheduler returns the same shared instance on repeat calls', () => {
+    const first = startDingTalkGroupDeliveryRetentionScheduler({ service: { sweep: vi.fn().mockResolvedValue(0) } })
+    const second = startDingTalkGroupDeliveryRetentionScheduler({ service: { sweep: vi.fn().mockResolvedValue(0) } })
+    expect(first).toBe(second)
+  })
+
+  it('resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs reads a positive override, else undefined', () => {
+    expect(resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs()).toBeUndefined()
+    process.env.DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS = '3600000'
+    expect(resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs()).toBe(3600000)
+    process.env.DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS = '-5'
+    expect(resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs()).toBeUndefined()
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -165,6 +165,11 @@ export default defineConfig({
       // T1-2 inbound webhook trigger: mounted-route + real-DB execution row. Excluded from the no-DB
       // default job so it does not skip-green, and wired as a WHOLE FILE into the multitable real-DB lane.
       'tests/integration/multitable-inbound-webhook-trigger.test.ts',
+      // R1 (DT-HARDEN-08 follow-up) dingtalk_group_deliveries retention sweep: DATABASE_URL-gated
+      // (describeIfDatabase). Excluded from the no-DB default job so it cannot skip-green, and wired
+      // as a WHOLE FILE into the `Run multitable real-DB integration` step in plugin-tests.yml where
+      // it runs against real Postgres every PR.
+      'tests/integration/dingtalk-group-delivery-retention.db.test.ts',
       // comments.api.test.ts needs setup.integration.ts + a live DB. It stays
       // CI-excluded (NOT wired) because 8 of its tests have a pre-existing real-wire
       // failure (CommentService.mapRowToComment drops containerId/targetId/


### PR DESCRIPTION
## What / why

`dingtalk_group_deliveries` is write-once: every group-robot send attempt (automation-rule firings AND manual test-sends) inserts a row with full message `content` plus raw `response_body` TEXT, and nothing anywhere `DELETE`s from it — the table grows unbounded (scoped out of #3897 / DT-HARDEN-08 as a follow-up item, R1).

Adds a bounded batch-DELETE retention sweep mirroring the AI usage ledger retention pair (`LedgerRetentionScheduler` + `services/ai-usage-ledger.ts`) exactly:
- Default 90-day retention window, floored at 7 days.
- Bounded batch DELETE, default 5000 rows/pass (ctid sub-select so one pass never blocks the table).
- Enabled by default; opt out with `DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1`.
- Applies to both `source_type`s (`automation`, `manual_test`) — no carve-out, since nothing downstream references a delivery row once written.

**Design decision (flagged for review):** instead of duplicating the ~250-line interval/leader-lock scheduler, this reuses the generic `LedgerRetentionScheduler` class directly — it already depends only on an injected `{ sweep(): Promise<number> }` service, so no behavioral change was needed there except one small addition: an optional `sweptEntityLabel` on `LedgerRetentionSchedulerOptions` (defaults to the original `'AI usage ledger rows'` string, so the shipped AI-ledger sweep's log output is byte-for-byte unchanged) that lets this sweep report `'DingTalk group-delivery rows'` in its own tick log instead of misreporting as ledger rows. New file `dingtalk-group-delivery-retention-scheduler.ts` wraps `start/stop/getShared/resolveIntervalMs/resolveLeaderOptions` around that shared class, mirroring `LedgerRetentionScheduler.ts`'s free-function shape with DingTalk-specific env var names (`DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS`, `ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK`, etc.).

Wired at boot in `index.ts` right after the ledger retention block, with a matching shutdown hook.

## Known gap (documented, not fixed here)

The DELETE's `created_at < cutoff` predicate has no dedicated index — the existing composite index is `(destination_id, created_at DESC)`, which does not serve a bare `created_at` predicate, so each batch pass is a sequential scan. Acceptable at current table sizes; an optional `(created_at)` index is a follow-up if the table grows large enough to matter (kept out of this change per YAGNI — it would require a migration, flipping this from a code-only fix to a schema change).

## Test evidence

**Unit** (`tests/unit/dingtalk-group-delivery-retention.test.ts`, 12 tests, `CI=true npx vitest run`):
- Config resolver: default 90d/not-disabled, custom days honored, floor at 7 (1d → 7), invalid/non-positive/NaN → default 90, disabled flag only on literal `'1'`.
- Scheduler (reusing `LedgerRetentionScheduler` directly): `tick()` delegates to injected fake sweep, swallows sweep errors (degraded mode → 0), `startDingTalkGroupDeliveryRetentionScheduler` disabled-by-env / enabled-by-default / same-shared-instance, `resolveDingTalkGroupDeliveryRetentionSchedulerIntervalMs` positive-override-else-undefined.
- Confirmed the shared `ledger-retention-scheduler.test.ts` (12 tests) still passes unchanged after the `sweptEntityLabel` addition.

**Real DB** (`tests/integration/dingtalk-group-delivery-retention.db.test.ts`, 7 tests, run against a fresh local Postgres with migrations applied): sentinel, KEYSTONE (30d sweep deletes only >30d rows across BOTH `source_type`s, keeps the rest), idempotence (second pass deletes 0), disabled config no-op, batch-LIMIT bounding (batchSize=1 drains 2 stale rows over two ticks, never one), `PgDingTalkGroupDeliveryRetentionService.sweep()` end-to-end, and the full `LedgerRetentionScheduler.tick()` → real DB path.

Two-point wiring done: added to `packages/core-backend/vitest.config.ts`'s exclude list (so the no-DB `test` job cannot skip-green it) and to the "Run multitable real-DB integration" whitelist in `.github/workflows/plugin-tests.yml`.

`npx tsc --noEmit` clean. Full `tests/unit` run: 4556/4557 passed — the 1 failure (`data-source-scope.test.ts`) is pre-existing cross-test-pollution unrelated to this change (passes clean in isolation).

## Mutation table

| Mutation | Test result |
|---|---|
| Invert cutoff comparison (`created_at <` → `created_at >`) | RED — KEYSTONE test fails (survivor-set assertion) |
| Remove the batch `LIMIT $2` | RED — 5/7 real-DB tests fail (bind-parameter-count SQL error + the two scheduler-path tests that expect exactly 2 deleted) |
| Remove the `Math.max(MIN_DAYS, …)` floor guard in the config resolver | RED — unit test `floors the retention window at the min... 1 day → MIN` fails (`expected 1 to be 7`) |

All mutations reverted via `git checkout --` after recording red/green; working tree is clean.

## Honest gaps

- No index on `created_at` — documented above, deliberately deferred (would require a migration).
- Did not add coverage for the Redis leader-lock path specifically for this sweep (e.g. two-scheduler leader/follower race) — that behavior lives entirely inside the already-tested `LedgerRetentionScheduler` class (12 passing tests including a leader/follower test), reused unmodified here, so re-testing it under a second name would be redundant rather than additive.
- Env template update is illustrative only: no existing `.env.example` precedent existed for the AI-ledger retention sweep either (it shipped without one), so there was no established format to match exactly — I added a concise block to the root `.env.example` near the existing DingTalk section.
- `dingtalk_approval_card_deliveries` (the sibling approval-card table) has state-supersede sweeps but no age-based retention — explicitly out of scope per the brief (same class of problem, separate decision).

## Reviewer-scrutiny flags

- Touched `packages/core-backend/src/services/LedgerRetentionScheduler.ts` (a shared hot file) to add the `sweptEntityLabel` option — kept the change minimal and default-preserving; please confirm the byte-identical-default claim independently if this lands near other in-flight changes to that file.
- Reused the scheduler class rather than generalizing further (e.g. no attempt to also generalize the other "Ledger retention ..." log strings beyond the one that was factually wrong when reused) — a deliberate minimal-diff choice on a multi-lane-shared file.

Branch: `claude/dt-delivery-retention-sweep`. Not armed for auto-merge — landing is gated/serialized by the parent process.