### PR TITLE
feat(dingtalk): persist integration_id on approval-card deliveries + per-corp deep-link secret (DT-R2)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260709133000_add_integration_id_to_dingtalk_approval_card_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260709133000_add_integration_id_to_dingtalk_approval_card_deliveries.ts
@@ -1,0 +1,29 @@
+/**
+ * Migration: pin the approval-card delivery to the corp it was sent through (DT-R2).
+ *
+ * The send path resolves the assignee's DingTalk integration (directory_account_links lateral)
+ * and uses it for the outbound credentials, but the ledger row never recorded WHICH integration —
+ * so the approve/reject callback path could only fall back to a global "one stored dingtalk
+ * integration" pick (unstable under multi-corp). `integration_id` makes the delivery row the
+ * authoritative anchor for credential/secret resolution on the callback side.
+ *
+ * Nullable by design: legacy rows predate the column, and env-only single-corp deploys can send
+ * without a linked integration. ON DELETE SET NULL — deleting an integration must not delete the
+ * approval audit trail; verify then falls back to the legacy resolver.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE dingtalk_approval_card_deliveries
+    ADD COLUMN IF NOT EXISTS integration_id UUID NULL
+      REFERENCES directory_integrations(id) ON DELETE SET NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE dingtalk_approval_card_deliveries
+    DROP COLUMN IF EXISTS integration_id
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260709133000_add_integration_id_to_dingtalk_approval_card_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260709133000_add_integration_id_to_dingtalk_approval_card_deliveries.ts
@@ -19,9 +19,18 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     ADD COLUMN IF NOT EXISTS integration_id UUID NULL
       REFERENCES directory_integrations(id) ON DELETE SET NULL
   `.execute(db)
+
+  // Without this, every `DELETE FROM directory_integrations` seq-scans this table to enforce
+  // the ON DELETE SET NULL above, and future per-corp ops queries (B-2/B-3) filtering by
+  // integration_id would too. Same naming convention as the sibling idx_dacd_* indexes.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dacd_integration
+    ON dingtalk_approval_card_deliveries(integration_id)
+  `.execute(db)
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_dacd_integration`.execute(db)
   await sql`
     ALTER TABLE dingtalk_approval_card_deliveries
     DROP COLUMN IF EXISTS integration_id

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1547,6 +1547,8 @@ export interface DingTalkApprovalCardDeliveriesTable {
   recipient_dingtalk_user_id: string
   delivery_kind: 'work_notice_action_card' | 'interactive_card'
   task_id: string | null
+  /** DT-R2: directory integration (corp) the card was sent through; NULL on legacy/env-only rows. */
+  integration_id: string | null
   card_state: 'sent' | 'acted' | 'superseded' | 'expired' | 'revoked'
   acted_action: string | null
   acted_by: string | null

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-config.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-config.ts
@@ -77,6 +77,35 @@ export async function resolveApprovalCardLinkSecret(queryFn: QueryFn = query): P
 }
 
 /**
+ * DT-R2 per-corp variant: the deep-link HMAC secret of ONE SPECIFIC integration — env
+ * `APPROVAL_CARD_LINK_SECRET` still wins (global override, unchanged), else THAT integration's
+ * stored (encrypted-at-rest) `approvalCardLinkSecret`, else '' (fail-closed).
+ *
+ * Deliberately NO fallback to the legacy "one stored dingtalk integration" pick: a token pinned
+ * to corp A must never sign or verify with corp B's secret. Callers with no integration id
+ * (legacy NULL delivery rows) use `resolveApprovalCardLinkSecret` instead — same source the
+ * legacy rows were signed with, preserving the sign/verify same-source invariant per population.
+ */
+export async function resolveApprovalCardLinkSecretForIntegration(
+  integrationId: string,
+  queryFn: QueryFn = query,
+): Promise<string> {
+  const fromEnv = (process.env.APPROVAL_CARD_LINK_SECRET ?? '').trim()
+  if (fromEnv) return fromEnv
+  try {
+    const row = await loadIntegrationById(queryFn, integrationId)
+    if (!row) return ''
+    const config = parseJsonRecord(row.config)
+    const stored = normalizeText(config[APPROVAL_CARD_LINK_SECRET_CONFIG_KEY])
+    if (!stored) return ''
+    return decryptStoredSecretValue(stored).trim()
+  } catch {
+    // Fail-closed: an unreadable/undecryptable stored secret must never sign or verify.
+    return ''
+  }
+}
+
+/**
  * Public base URL for the decision deep link: env (`PUBLIC_APP_URL` / `APP_BASE_URL`) first,
  * else the stored `approvalCardPublicAppUrl` (plaintext — not a secret), else null.
  * Normalized to a trailing slash exactly like resolveAutomationAppBaseUrl.

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-config.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-config.ts
@@ -9,8 +9,11 @@
  *
  * Invariants:
  * - SAME-SOURCE: the card sender (sign) and the card-delivery wrapper (verify) must both call
- *   these resolvers so a token signed on send always verifies on decision — guaranteed by
- *   "env first, else the one stored dingtalk integration".
+ *   these resolvers so a token signed on send always verifies on decision — guaranteed per
+ *   population: rows with a persisted `integration_id` (DT-R2) sign/verify through
+ *   `resolveApprovalCardLinkSecretForIntegration` pinned to THAT integration (env still wins,
+ *   never a cross-corp rescue); legacy rows with `integration_id IS NULL` sign/verify through
+ *   `resolveApprovalCardLinkSecret`'s env-first / LIMIT-1-stored fallback, same as before DT-R2.
  * - FAIL-CLOSED: any miss (no env, no row, decrypt failure, query failure) resolves to '' —
  *   the card action refuses to send and the wrapper refuses to verify. Never a fallback secret.
  */

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -31,6 +31,12 @@ export interface DingTalkApprovalCardDeliveryRow {
   recipient_dingtalk_user_id: string
   delivery_kind: DingTalkApprovalCardDeliveryKind
   task_id: string | null
+  /**
+   * DT-R2: the directory integration (corp) the card was sent through — the callback path's
+   * credential/secret anchor. NULL on legacy rows and env-only sends (verify falls back to the
+   * legacy single-integration resolver for those).
+   */
+  integration_id: string | null
   card_state: DingTalkApprovalCardState
   acted_action: string | null
   acted_by: string | null
@@ -44,7 +50,7 @@ export interface DingTalkApprovalCardDeliveryRow {
 type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
 
 const RETURNING_COLUMNS =
-  'id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, card_state, acted_action, acted_by, acted_at, send_status, send_error, created_at, updated_at'
+  'id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, integration_id, card_state, acted_action, acted_by, acted_at, send_status, send_error, created_at, updated_at'
 
 export interface InsertDingTalkApprovalCardDeliveryInput {
   /** Optional caller-supplied id; defaults to a fresh UUID. Doubles as the interactive-card outTrackId (Slice B). */
@@ -56,6 +62,8 @@ export interface InsertDingTalkApprovalCardDeliveryInput {
   deliveryKind: DingTalkApprovalCardDeliveryKind
   /** asyncsend_v2 task id — recorded after the send call returns (Slice A). */
   taskId?: string | null
+  /** DT-R2: the assignee's directory integration id (uuid) — null/omitted for env-only sends. */
+  integrationId?: string | null
 }
 
 export async function insertDingTalkApprovalCardDelivery(
@@ -63,10 +71,14 @@ export async function insertDingTalkApprovalCardDelivery(
   input: InsertDingTalkApprovalCardDeliveryInput,
 ): Promise<DingTalkApprovalCardDeliveryRow> {
   const id = input.id && input.id.trim().length > 0 ? input.id.trim() : randomUUID()
+  const integrationId =
+    typeof input.integrationId === 'string' && input.integrationId.trim().length > 0
+      ? input.integrationId.trim()
+      : null
   const result = await query(
     `INSERT INTO dingtalk_approval_card_deliveries
-       (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
+       (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, integration_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
      RETURNING ${RETURNING_COLUMNS}`,
     [
       id,
@@ -76,6 +88,7 @@ export async function insertDingTalkApprovalCardDelivery(
       input.recipientDingTalkUserId,
       input.deliveryKind,
       input.taskId ?? null,
+      integrationId,
     ],
   )
   return result.rows[0] as DingTalkApprovalCardDeliveryRow

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -25,6 +25,7 @@ import {
 import { readDingTalkMessageConfigFromRuntime } from '../integrations/dingtalk/work-notification-settings'
 import {
   resolveApprovalCardLinkSecret,
+  resolveApprovalCardLinkSecretForIntegration,
   resolveApprovalCardPublicAppUrl,
 } from '../integrations/dingtalk/approval-card-config'
 import {
@@ -2642,10 +2643,6 @@ export class AutomationExecutor {
     if (!baseUrl) {
       return { actionType, status: 'failed', error: 'PUBLIC_APP_URL or APP_BASE_URL (or the stored approval-card public app URL) is required for the approval decision link' }
     }
-    const linkSecret = await resolveApprovalCardLinkSecret(this.deps.queryFn)
-    if (!linkSecret) {
-      return { actionType, status: 'failed', error: 'APPROVAL_CARD_LINK_SECRET (env or stored approval-card link secret) is required for signed approval decision links' }
-    }
 
     // Instance metadata for the card summary — ids/title/request_no only, NO form values.
     const instanceResult = await this.deps.queryFn(
@@ -2682,9 +2679,10 @@ export class AutomationExecutor {
     )
     const recipientRow = (recipientResult.rows[0] ?? null) as { local_user_active?: boolean; dingtalk_user_id?: string | null; integration_id?: string | null } | null
     const dingtalkUserId = typeof recipientRow?.dingtalk_user_id === 'string' ? recipientRow.dingtalk_user_id.trim() : ''
-    // DT-OPS-04: send the card with the assignee's own corp credentials. (Persisting the
-    // integration on the delivery row — so the approve/reject callback can resolve it too —
-    // needs a migration and is tracked separately.)
+    // DT-OPS-04: send the card with the assignee's own corp credentials. DT-R2 closed the
+    // remainder: the integration is persisted on the delivery row (integration_id) so the
+    // approve/reject callback resolves the SAME corp's secret; the deep-link token is signed
+    // with that integration's secret below (env override unchanged).
     const assigneeIntegrationId = typeof recipientRow?.integration_id === 'string' ? recipientRow.integration_id.trim() : ''
     if (!recipientRow || recipientRow.local_user_active !== true || !dingtalkUserId) {
       await recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
@@ -2702,6 +2700,23 @@ export class AutomationExecutor {
       return { actionType, status: 'failed', error: 'Recipient has no linked, active DingTalk account (skipped — mappings are never guessed)' }
     }
 
+    // DT-R2 same-source signing: the deep-link token is signed with the ASSIGNEE integration's
+    // secret (env `APPROVAL_CARD_LINK_SECRET` still wins) and the integration is persisted on
+    // the delivery row, so the wrapper's verify resolves the identical source. No cross-corp
+    // fallback: a missing per-corp secret fail-closes the send BEFORE any ledger row is written.
+    const linkSecret = assigneeIntegrationId
+      ? await resolveApprovalCardLinkSecretForIntegration(assigneeIntegrationId, this.deps.queryFn)
+      : await resolveApprovalCardLinkSecret(this.deps.queryFn)
+    if (!linkSecret) {
+      return {
+        actionType,
+        status: 'failed',
+        error: assigneeIntegrationId
+          ? `APPROVAL_CARD_LINK_SECRET (env) or a stored approval-card link secret on the assignee's DingTalk integration (${assigneeIntegrationId}) is required for signed approval decision links`
+          : 'APPROVAL_CARD_LINK_SECRET (env or stored approval-card link secret) is required for signed approval decision links',
+      }
+    }
+
     // Ledger FIRST — the row is the only legitimate delivery → instance anchor.
     const entryEpochRaw = event.task?.entryEpoch
     const sourceStepRaw = event.task?.sourceStep
@@ -2711,6 +2726,7 @@ export class AutomationExecutor {
       recipientUserId: assigneeUserId,
       recipientDingTalkUserId: dingtalkUserId,
       deliveryKind: 'work_notice_action_card',
+      integrationId: assigneeIntegrationId || null,
     })
 
     const token = createHmac('sha256', linkSecret).update(delivery.id).digest('hex').slice(0, 32)

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -15,7 +15,10 @@
 import { createHmac, timingSafeEqual } from 'crypto'
 
 import type { ApprovalProductService } from './ApprovalProductService'
-import { resolveApprovalCardLinkSecret } from '../integrations/dingtalk/approval-card-config'
+import {
+  resolveApprovalCardLinkSecret,
+  resolveApprovalCardLinkSecretForIntegration,
+} from '../integrations/dingtalk/approval-card-config'
 import {
   claimDingTalkApprovalCardDeliveryActed,
   findDingTalkApprovalCardDeliveryById,
@@ -59,14 +62,23 @@ export type ApprovalCardActionOutcome =
  * matches the executor's link composition exactly. CFG-1: the secret resolves env-first with the
  * stored (encrypted) directory-integration config as fallback — the SAME source the executor signs
  * with. Fail-closed without the secret.
+ *
+ * DT-R2 per-corp verify: when the delivery row carries an `integration_id`, the token verifies
+ * against THAT integration's secret ONLY (env override still wins) — a token signed under corp A
+ * must never verify against a delivery pinned to corp B (fail-closed, no LIMIT-1 fallback).
+ * Legacy rows (`integration_id` NULL) keep the original single-integration resolver — the same
+ * source they were signed with, so in-flight links survive the rollout.
  */
 export async function verifyApprovalCardLinkToken(
   deliveryId: string,
   token: string,
   queryFn?: QueryFn,
+  integrationId?: string | null,
 ): Promise<boolean> {
   if (!deliveryId || !token || token.length !== 32) return false
-  const secret = await resolveApprovalCardLinkSecret(queryFn)
+  const secret = integrationId
+    ? await resolveApprovalCardLinkSecretForIntegration(integrationId, queryFn)
+    : await resolveApprovalCardLinkSecret(queryFn)
   if (!secret) return false
   const expected = createHmac('sha256', secret).update(deliveryId).digest('hex').slice(0, 32)
   const a = Buffer.from(expected, 'utf8')
@@ -132,9 +144,11 @@ export async function getApprovalCardDeliverySummary(
   deps: { query: QueryFn },
   input: { deliveryId: string; token: string; viewerUserId: string },
 ): Promise<{ status: 'ok'; summary: ApprovalCardDeliverySummary } | { status: 'not_found' }> {
-  if (!(await verifyApprovalCardLinkToken(input.deliveryId, input.token, deps.query))) return { status: 'not_found' }
+  // DT-R2: the row is loaded before verify so the token checks against the DELIVERY's own
+  // integration secret. Both failure orders collapse to the same not_found — no existence oracle.
   const delivery = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
   if (!delivery) return { status: 'not_found' }
+  if (!(await verifyApprovalCardLinkToken(input.deliveryId, input.token, deps.query, delivery.integration_id))) return { status: 'not_found' }
   const summary = await buildSummary(deps.query, delivery, input.viewerUserId)
   if (!summary) return { status: 'not_found' }
   return { status: 'ok', summary }
@@ -150,9 +164,10 @@ export async function executeApprovalActionFromCardDelivery(
     actor: { userId: string; userName: string; roles?: string[]; ip?: string | null; userAgent?: string | null }
   },
 ): Promise<ApprovalCardActionOutcome> {
-  if (!(await verifyApprovalCardLinkToken(input.deliveryId, input.token, deps.query))) return { status: 'not_found' }
+  // DT-R2: row first, then verify against the row's own integration secret (see summary path).
   const delivery = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
   if (!delivery) return { status: 'not_found' }
+  if (!(await verifyApprovalCardLinkToken(input.deliveryId, input.token, deps.query, delivery.integration_id))) return { status: 'not_found' }
 
   const preSummary = await buildSummary(deps.query, delivery, input.actor.userId)
   if (!preSummary) return { status: 'not_found' }

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -225,17 +225,22 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     delete process.env.APPROVAL_CARD_LINK_SECRET
     const secretA = `cdw-r2-corp-a-secret-${TS}`
     const secretB = `cdw-r2-corp-b-secret-${TS}`
-    const mkIntegration = async (label: string, secret: string): Promise<string> => {
+    const mkIntegration = async (label: string, secret: string, updatedAtSql: string): Promise<string> => {
       const inserted = await q(
         `INSERT INTO directory_integrations (name, provider, status, corp_id, config, updated_at)
-         VALUES ($1, 'dingtalk', 'active', $2, $3::jsonb, now())
+         VALUES ($1, 'dingtalk', 'active', $2, $3::jsonb, ${updatedAtSql})
          RETURNING id`,
         [`cdw-r2-${label}-${TS}`, `corp_cdw_r2_${label}_${TS}`, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(secret) })],
       )
       return (inserted.rows[0] as { id: string }).id
     }
-    const corpA = await mkIntegration('a', secretA)
-    const corpB = await mkIntegration('b', secretB)
+    // Anti-shadowing: corp A is deliberately the FRESHEST integration, so the legacy LIMIT-1
+    // global pick (active-first, updated_at DESC) lands on corp A — if verify ever fell back to
+    // that pick instead of the DELIVERY row's pinned corp B, corp A's token would verify and
+    // corp B's would fail, turning every assertion below red. now()-1min on corp B keeps both
+    // rows behind any real integration if a crash skips the finally.
+    const corpA = await mkIntegration('a', secretA, `now()`)
+    const corpB = await mkIntegration('b', secretB, `now() - interval '1 minute'`)
     try {
       const row = await insertDingTalkApprovalCardDelivery(q, {
         instanceId,

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -219,6 +219,66 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     }
   })
 
+  test('DT-R2 per-corp verify: a token signed under corp A fail-closes against a delivery pinned to corp B; the pinned corp verifies; env override still wins', async () => {
+    const instanceId = await newInstance()
+    const prev = process.env.APPROVAL_CARD_LINK_SECRET
+    delete process.env.APPROVAL_CARD_LINK_SECRET
+    const secretA = `cdw-r2-corp-a-secret-${TS}`
+    const secretB = `cdw-r2-corp-b-secret-${TS}`
+    const mkIntegration = async (label: string, secret: string): Promise<string> => {
+      const inserted = await q(
+        `INSERT INTO directory_integrations (name, provider, status, corp_id, config, updated_at)
+         VALUES ($1, 'dingtalk', 'active', $2, $3::jsonb, now())
+         RETURNING id`,
+        [`cdw-r2-${label}-${TS}`, `corp_cdw_r2_${label}_${TS}`, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(secret) })],
+      )
+      return (inserted.rows[0] as { id: string }).id
+    }
+    const corpA = await mkIntegration('a', secretA)
+    const corpB = await mkIntegration('b', secretB)
+    try {
+      const row = await insertDingTalkApprovalCardDelivery(q, {
+        instanceId,
+        nodeKey: 'approval_1',
+        recipientUserId: APPROVER,
+        recipientDingTalkUserId: `dd_${APPROVER}`,
+        deliveryKind: 'work_notice_action_card',
+        integrationId: corpB,
+      })
+      await markDingTalkApprovalCardDeliverySent(q, row.id, 'task_r2')
+      expect(row.integration_id).toBe(corpB)
+
+      const signWith = (secret: string) => createHmac('sha256', secret).update(row.id).digest('hex').slice(0, 32)
+
+      // Fail-closed cross-corp: corp A's secret must never open a corp-B delivery.
+      expect(await verifyApprovalCardLinkToken(row.id, signWith(secretA), q, corpB)).toBe(false)
+      expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId: row.id, token: signWith(secretA), viewerUserId: APPROVER })).status).toBe('not_found')
+      const crossCorpAction = await executeApprovalActionFromCardDelivery(
+        { query: q, approvals },
+        { deliveryId: row.id, token: signWith(secretA), decision: 'approve', comment: '越权', actor: approverActor },
+      )
+      expect(crossCorpAction.status).toBe('not_found')
+
+      // Same-source: the DELIVERY row's own integration secret verifies through the real wrapper.
+      expect(await verifyApprovalCardLinkToken(row.id, signWith(secretB), q, corpB)).toBe(true)
+      expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId: row.id, token: signWith(secretB), viewerUserId: APPROVER })).status).toBe('ok')
+
+      // Env override is global and unchanged: with env set, the env-signed token wins even on a pinned row.
+      process.env.APPROVAL_CARD_LINK_SECRET = SECRET
+      expect((await getApprovalCardDeliverySummary({ query: q }, { deliveryId: row.id, token: tokenFor(row.id), viewerUserId: APPROVER })).status).toBe('ok')
+      delete process.env.APPROVAL_CARD_LINK_SECRET
+
+      // A pinned integration with NO stored secret fail-closes (no LIMIT-1 fallback, no cross-corp rescue).
+      await q(`UPDATE directory_integrations SET config = COALESCE(config, '{}'::jsonb) - 'approvalCardLinkSecret' WHERE id = $1`, [corpB])
+      expect(await verifyApprovalCardLinkToken(row.id, signWith(secretB), q, corpB)).toBe(false)
+      expect(await verifyApprovalCardLinkToken(row.id, signWith(secretA), q, corpB)).toBe(false)
+    } finally {
+      await q('DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])', [[corpA, corpB]]).catch(() => {})
+      if (prev === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET
+      else process.env.APPROVAL_CARD_LINK_SECRET = prev
+    }
+  })
+
   test('undelivered card (send_status=pending) is stale — never actionable', async () => {
     const instanceId = await newInstance()
     const row = await insertDingTalkApprovalCardDelivery(q, {

--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -24,7 +24,8 @@ const SHEET_ID = `sheet_card_${TS}`
 const CREATOR = `u_card_creator_${TS}`
 const REQUESTER = `u_card_req_${TS}`
 const APPROVER = `u_card_appr_${TS}`
-import { randomUUID } from 'crypto'
+import { createHmac, randomUUID } from 'crypto'
+import { normalizeStoredSecretValue } from '../../src/security/encrypted-secrets'
 const DD_INTEGRATION = randomUUID()
 const DD_ACCOUNT = randomUUID()
 const DD_USER_ID = `dd_ext_${TS}`
@@ -345,5 +346,70 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     expect(rows[0].send_status).toBe('pending')
 
     await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('DT-R2: the ledger row carries the assignee integration_id resolved via the directory-link lateral', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'card r2 integration-id', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+    try {
+      const dto = await approvals.createApproval({ templateId, formData: { summary: 'r2 anchor run' } }, { userId: REQUESTER, userName: REQUESTER })
+      const instanceId = (dto as { id: string }).id
+      const rows = await waitFor(() => cardRows(instanceId))
+      expect(rows).toHaveLength(1)
+      // The callback credential anchor: the row is pinned to the corp the card went through.
+      expect(rows[0].integration_id).toBe(DD_INTEGRATION)
+      expect(rows[0].send_status).toBe('sent')
+    } finally {
+      await svc.deleteRule(rule.id, SHEET_ID)
+    }
+  })
+
+  test('DT-R2 same-source signing: env unset → the deep-link token is HMAC-signed with the ASSIGNEE integration\'s stored secret', async () => {
+    const prevSecret = process.env.APPROVAL_CARD_LINK_SECRET
+    delete process.env.APPROVAL_CARD_LINK_SECRET
+    const corpSecret = `r2-corp-stored-secret-${TS}`
+    await q(
+      `UPDATE directory_integrations
+          SET config = jsonb_set(COALESCE(config, '{}'::jsonb), '{approvalCardLinkSecret}', to_jsonb($2::text), true)
+        WHERE id = $1`,
+      [DD_INTEGRATION, normalizeStoredSecretValue(corpSecret)],
+    )
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'card r2 corp secret', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+    try {
+      sentBodies.length = 0
+      const dto = await approvals.createApproval({ templateId, formData: { summary: 'r2 corp secret run' } }, { userId: REQUESTER, userName: REQUESTER })
+      const instanceId = (dto as { id: string }).id
+      const rows = await waitFor(() => cardRows(instanceId))
+      expect(rows).toHaveLength(1)
+      const row = rows[0]
+      expect(row.integration_id).toBe(DD_INTEGRATION)
+      expect(row.send_status).toBe('sent')
+
+      // Same-source proof at the real call site: the token in the sent deep link must be
+      // HMAC-SHA256(deliveryId, THAT integration's stored secret) — never a global LIMIT-1 pick.
+      expect(sentBodies).toHaveLength(1)
+      const msg = sentBodies[0].msg as { action_card: { single_url: string } }
+      const tokenMatch = /[?&]t=([0-9a-f]{32})/.exec(msg.action_card.single_url)
+      expect(tokenMatch).not.toBeNull()
+      const expected = createHmac('sha256', corpSecret).update(String(row.id)).digest('hex').slice(0, 32)
+      expect(tokenMatch?.[1]).toBe(expected)
+    } finally {
+      await svc.deleteRule(rule.id, SHEET_ID).catch(() => {})
+      await q(
+        `UPDATE directory_integrations
+            SET config = COALESCE(config, '{}'::jsonb) - 'approvalCardLinkSecret'
+          WHERE id = $1`,
+        [DD_INTEGRATION],
+      ).catch(() => {})
+      if (prevSecret === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET
+      else process.env.APPROVAL_CARD_LINK_SECRET = prevSecret
+    }
   })
 })

--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -377,6 +377,16 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
         WHERE id = $1`,
       [DD_INTEGRATION, normalizeStoredSecretValue(corpSecret)],
     )
+    // Anti-shadowing decoy: a FRESHER active dingtalk integration with a different secret, so the
+    // legacy LIMIT-1 global pick (active-first, updated_at DESC) lands on the DECOY — if the
+    // executor ever signed with that pick instead of the ASSIGNEE's integration, the token
+    // assertion below would go red. Deleted in finally; now() cannot permanently shadow.
+    const DECOY = randomUUID()
+    await q(
+      `INSERT INTO directory_integrations (id, name, provider, status, corp_id, config, updated_at)
+       VALUES ($1, $2, 'dingtalk', 'active', $3, $4::jsonb, now())`,
+      [DECOY, `card-r2-decoy-${TS}`, `corp_card_r2_decoy_${TS}`, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(`r2-decoy-secret-${TS}`) })],
+    )
     const rule = await svc.createRule(SHEET_ID, {
       name: 'card r2 corp secret', triggerType: 'approval.task_created', triggerConfig: { templateId },
       actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
@@ -402,6 +412,7 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
       expect(tokenMatch?.[1]).toBe(expected)
     } finally {
       await svc.deleteRule(rule.id, SHEET_ID).catch(() => {})
+      await q('DELETE FROM directory_integrations WHERE id = $1', [DECOY]).catch(() => {})
       await q(
         `UPDATE directory_integrations
             SET config = COALESCE(config, '{}'::jsonb) - 'approvalCardLinkSecret'

--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -59,8 +59,10 @@ let templateId = ''
 const ruleIds: string[] = []
 const sentBodies: Array<Record<string, unknown>> = []
 let failNextSend = false
+let fetchCallCount = 0
 
 const fakeFetch: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  fetchCallCount += 1
   const url = String(input)
   if (url.includes('/gettoken')) {
     return new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'tok_test' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
@@ -419,6 +421,68 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
           WHERE id = $1`,
         [DD_INTEGRATION],
       ).catch(() => {})
+      if (prevSecret === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET
+      else process.env.APPROVAL_CARD_LINK_SECRET = prevSecret
+    }
+  })
+
+  test('DT-R2 fail-close: assignee integration with no stored secret errors BEFORE any DingTalk call, writes NO card row, and the execution ledger records the actionable per-integration error', async () => {
+    const prevSecret = process.env.APPROVAL_CARD_LINK_SECRET
+    delete process.env.APPROVAL_CARD_LINK_SECRET
+    // Belt-and-suspenders: guarantee DD_INTEGRATION has no stored secret regardless of prior
+    // test ordering (the "same-source signing" test clears its own in `finally`, but this must
+    // not depend on that).
+    await q(
+      `UPDATE directory_integrations
+          SET config = COALESCE(config, '{}'::jsonb) - 'approvalCardLinkSecret'
+        WHERE id = $1`,
+      [DD_INTEGRATION],
+    )
+    // Anti-shadowing decoy: a FRESHER active integration WITH a secret. `resolveApprovalCardLinkSecretForIntegration`
+    // is scoped by id (no LIMIT-1 rescue — see approval-card-config.ts), so this proves the
+    // fail-close does NOT silently succeed by falling back to some other corp's secret: if a
+    // future regression reintroduced that rescue, this run would send successfully instead of
+    // failing, and the assertions below would go red.
+    const DECOY = randomUUID()
+    await q(
+      `INSERT INTO directory_integrations (id, name, provider, status, corp_id, config, updated_at)
+       VALUES ($1, $2, 'dingtalk', 'active', $3, $4::jsonb, now())`,
+      [DECOY, `card-r2-failclose-decoy-${TS}`, `corp_card_r2_failclose_decoy_${TS}`, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(`r2-failclose-decoy-secret-${TS}`) })],
+    )
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'card r2 fail-close', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+    try {
+      sentBodies.length = 0
+      const fetchCountBefore = fetchCallCount
+      const dto = await approvals.createApproval({ templateId, formData: { summary: 'r2 fail-close run' } }, { userId: REQUESTER, userName: REQUESTER })
+      const instanceId = (dto as { id: string }).id
+
+      const executions = await waitFor(async () => {
+        const r = await q(
+          `SELECT status, error FROM multitable_automation_executions WHERE rule_id = $1 AND status = 'failed' ORDER BY triggered_at DESC`,
+          [rule.id],
+        )
+        return r.rows as Array<{ status: string; error: string | null }>
+      })
+      expect(executions).toHaveLength(1)
+      expect(String(executions[0].error)).toContain(
+        `stored approval-card link secret on the assignee's DingTalk integration (${DD_INTEGRATION})`,
+      )
+
+      // No ledger (delivery) row for this instance — the fail-close must fire BEFORE
+      // insertDingTalkApprovalCardDelivery, never a "sent" row with an unsignable link.
+      expect(await cardRows(instanceId)).toHaveLength(0)
+
+      // No outbound DingTalk call at all — not even /gettoken — since the fail-close short-circuits
+      // before token-fetch/send.
+      expect(fetchCallCount).toBe(fetchCountBefore)
+      expect(sentBodies).toHaveLength(0)
+    } finally {
+      await svc.deleteRule(rule.id, SHEET_ID).catch(() => {})
+      await q('DELETE FROM directory_integrations WHERE id = $1', [DECOY]).catch(() => {})
       if (prevSecret === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET
       else process.env.APPROVAL_CARD_LINK_SECRET = prevSecret
     }

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
@@ -7,6 +7,8 @@
  *   - supersede sweeps only still-`sent` rows of the instance,
  *   - the DB CHECKs reject invalid states and acted-audit inconsistencies.
  */
+import { randomUUID } from 'crypto'
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { pool } from '../../src/db/pg'
 import {
@@ -192,6 +194,57 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
         deliveryKind: 'interactive_card',
       }),
     ).rejects.toThrow()
+  })
+
+  it('DT-R2: integration_id persists through insert + RETURNING, null passes through, and deleting the integration SET NULLs without touching the audit row', async () => {
+    const integrationId = randomUUID()
+    await q(
+      `INSERT INTO directory_integrations (id, name, provider, corp_id) VALUES ($1, $2, 'dingtalk', $3)`,
+      [integrationId, `dacd-r2-${Date.now()}`, `corp_dacd_r2_${Date.now()}`],
+    )
+    try {
+      // Linked row: the column round-trips through INSERT + RETURNING and findById.
+      const linked = await insertDingTalkApprovalCardDelivery(q, {
+        instanceId: INSTANCE,
+        nodeKey: 'approval_1',
+        recipientUserId: 'user_r2a',
+        recipientDingTalkUserId: 'dd_user_r2a',
+        deliveryKind: 'work_notice_action_card',
+        integrationId,
+      })
+      expect(linked.integration_id).toBe(integrationId)
+      expect((await findDingTalkApprovalCardDeliveryById(q, linked.id))?.integration_id).toBe(integrationId)
+
+      // Unlinked row (env-only / legacy shape): null passthrough, never a guessed integration.
+      const unlinked = await insertDingTalkApprovalCardDelivery(q, {
+        instanceId: INSTANCE,
+        nodeKey: 'approval_1',
+        recipientUserId: 'user_r2b',
+        recipientDingTalkUserId: 'dd_user_r2b',
+        deliveryKind: 'work_notice_action_card',
+      })
+      expect(unlinked.integration_id).toBeNull()
+
+      // FK rejects an unknown integration — the anchor is never dangling.
+      await expect(
+        insertDingTalkApprovalCardDelivery(q, {
+          instanceId: INSTANCE,
+          nodeKey: 'approval_1',
+          recipientUserId: 'user_r2c',
+          recipientDingTalkUserId: 'dd_user_r2c',
+          deliveryKind: 'work_notice_action_card',
+          integrationId: randomUUID(),
+        }),
+      ).rejects.toThrow()
+
+      // ON DELETE SET NULL: removing the integration must NOT delete the approval audit row.
+      await q(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      const survivor = await findDingTalkApprovalCardDeliveryById(q, linked.id)
+      expect(survivor).not.toBeNull()
+      expect(survivor?.integration_id).toBeNull()
+    } finally {
+      await q(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId]).catch(() => {})
+    }
   })
 
   it('ON DELETE CASCADE removes ledger rows with their instance', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-approval-card-config.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-approval-card-config.test.ts
@@ -17,6 +17,7 @@ import {
   generateApprovalCardLinkSecret,
   getApprovalCardConfigStatus,
   resolveApprovalCardLinkSecret,
+  resolveApprovalCardLinkSecretForIntegration,
   resolveApprovalCardPublicAppUrl,
   saveApprovalCardPublicAppUrl,
 } from '../../src/integrations/dingtalk/approval-card-config'
@@ -93,6 +94,56 @@ describe('approval card config resolvers (CFG-1)', () => {
       // Even a token forged with an EMPTY HMAC key must be rejected — no secret means no verify.
       const emptyKeyForgery = createHmac('sha256', '').update('card-delivery-1').digest('hex').slice(0, 32)
       await expect(verifyApprovalCardLinkToken('card-delivery-1', emptyKeyForgery)).resolves.toBe(false)
+    })
+  })
+
+  describe('DT-R2 resolveApprovalCardLinkSecretForIntegration', () => {
+    it('env wins and skips the store entirely', async () => {
+      vi.stubEnv('APPROVAL_CARD_LINK_SECRET', 'env-secret')
+      await expect(resolveApprovalCardLinkSecretForIntegration('dir-a')).resolves.toBe('env-secret')
+      expect(dbMocks.query).not.toHaveBeenCalled()
+    })
+
+    it('resolves the SPECIFIC integration by id (never the LIMIT-1 global pick)', async () => {
+      dbMocks.query.mockResolvedValueOnce({
+        rows: [{ id: 'dir-a', name: 'Corp A', status: 'active', config: { [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('corp-a-secret') } }],
+      })
+      await expect(resolveApprovalCardLinkSecretForIntegration('dir-a')).resolves.toBe('corp-a-secret')
+      const [sql, params] = dbMocks.query.mock.calls[0] as [string, unknown[]]
+      expect(sql).toContain('WHERE id = $1 AND provider = $2')
+      expect(params).toEqual(['dir-a', 'dingtalk'])
+    })
+
+    it('fail-closes ("") on unknown integration, missing key, undecryptable value, or query failure — NO fallback secret', async () => {
+      dbMocks.query.mockResolvedValueOnce({ rows: [] })
+      await expect(resolveApprovalCardLinkSecretForIntegration('ghost')).resolves.toBe('')
+      dbMocks.query.mockResolvedValueOnce({ rows: [{ id: 'dir-a', name: 'n', status: 'active', config: {} }] })
+      await expect(resolveApprovalCardLinkSecretForIntegration('dir-a')).resolves.toBe('')
+      dbMocks.query.mockResolvedValueOnce({ rows: [{ id: 'dir-a', name: 'n', status: 'active', config: { [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: 'enc:not-a-real-ciphertext' } }] })
+      await expect(resolveApprovalCardLinkSecretForIntegration('dir-a')).resolves.toBe('')
+      dbMocks.query.mockRejectedValueOnce(new Error('db down'))
+      await expect(resolveApprovalCardLinkSecretForIntegration('dir-a')).resolves.toBe('')
+    })
+
+    it('verify pinned to corp B rejects a token signed under corp A (fail-closed cross-corp)', async () => {
+      // Every lookup for corp B yields corp B's secret; the token below is signed with corp A's.
+      dbMocks.query.mockResolvedValue({
+        rows: [{ id: 'dir-b', name: 'Corp B', status: 'active', config: { [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('corp-b-secret') } }],
+      })
+      const deliveryId = 'card-delivery-r2'
+      const tokenA = createHmac('sha256', 'corp-a-secret').update(deliveryId).digest('hex').slice(0, 32)
+      const tokenB = createHmac('sha256', 'corp-b-secret').update(deliveryId).digest('hex').slice(0, 32)
+      await expect(verifyApprovalCardLinkToken(deliveryId, tokenA, undefined, 'dir-b')).resolves.toBe(false)
+      await expect(verifyApprovalCardLinkToken(deliveryId, tokenB, undefined, 'dir-b')).resolves.toBe(true)
+    })
+
+    it('verify without an integration id keeps the legacy resolver (NULL delivery rows stay verifiable)', async () => {
+      dbMocks.query.mockResolvedValue({
+        rows: [{ config: { [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('legacy-secret') } }],
+      })
+      const deliveryId = 'card-delivery-legacy'
+      const token = createHmac('sha256', 'legacy-secret').update(deliveryId).digest('hex').slice(0, 32)
+      await expect(verifyApprovalCardLinkToken(deliveryId, token, undefined, null)).resolves.toBe(true)
     })
   })
 

--- a/packages/core-backend/tests/unit/dingtalk-approval-card-config.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-approval-card-config.test.ts
@@ -126,9 +126,14 @@ describe('approval card config resolvers (CFG-1)', () => {
     })
 
     it('verify pinned to corp B rejects a token signed under corp A (fail-closed cross-corp)', async () => {
-      // Every lookup for corp B yields corp B's secret; the token below is signed with corp A's.
-      dbMocks.query.mockResolvedValue({
-        rows: [{ id: 'dir-b', name: 'Corp B', status: 'active', config: { [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('corp-b-secret') } }],
+      // Anti-shadowing mock: the by-id lookup yields corp B, while the legacy LIMIT-1 global
+      // pick yields CORP A — if verify ever ignored the pinned integration and fell back to the
+      // global pick, tokenA would verify and tokenB would fail, flipping both assertions red.
+      dbMocks.query.mockImplementation(async (sql: string) => {
+        if (sql.includes('WHERE id = $1')) {
+          return { rows: [{ id: 'dir-b', name: 'Corp B', status: 'active', config: { [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('corp-b-secret') } }] }
+        }
+        return { rows: [{ config: { [APPROVAL_CARD_LINK_SECRET_CONFIG_KEY]: normalizeStoredSecretValue('corp-a-secret') } }] }
       })
       const deliveryId = 'card-delivery-r2'
       const tokenA = createHmac('sha256', 'corp-a-secret').update(deliveryId).digest('hex').slice(0, 32)


### PR DESCRIPTION
## What / Why (DT-R2)

`dingtalk_approval_card_deliveries` never recorded WHICH DingTalk integration a card went through. The send path resolves the assignee's integration (directory-link lateral) and uses it for outbound credentials (#3910), but dropped it at the ledger insert — the in-code DT-OPS-04 comment explicitly tracked this remainder. The approve/reject callback path therefore resolved the deep-link HMAC secret via a global "one stored dingtalk integration" pick (`ORDER BY active-first, updated_at DESC LIMIT 1`):

- **Unstable under multi-corp**: any config write to another integration flips the pick and fail-closes every in-flight card link.
- **CFG-2 rotation silently inert**: per-integration secret generation writes to a specific integration row while runtime read only the LIMIT-1 pick.
- **Slice-B blocker**: the future Stream callback (B-3) cannot resolve the acting corp from the ledger row at all.

## Changes

1. **Migration** (`zzzz20260709133000…`): additive `integration_id UUID NULL REFERENCES directory_integrations(id) ON DELETE SET NULL`. Nullable: legacy rows + env-only single-corp deploys. SET NULL: deleting an integration must not delete approval audit rows.
2. **Write side**: `insertDingTalkApprovalCardDelivery` threads `integrationId` through INSERT/RETURNING/row type (+ `db/types.ts`); the executor passes the assignee integration id, closing the DT-OPS-04 tracked remainder (comment updated).
3. **Sign side** (see honesty note below): new `resolveApprovalCardLinkSecretForIntegration(id)` — env `APPROVAL_CARD_LINK_SECRET` still wins; else THAT integration's stored (encrypted) `approvalCardLinkSecret`; else `''` fail-closed **before the ledger insert**. No LIMIT-1 fallback, ever.
4. **Verify side**: the wrapper loads the delivery row first and verifies the token against **the row's** integration secret when `integration_id` is set; legacy NULL rows keep the original LIMIT-1 resolver (the same source they were signed with). Both failure orders collapse to the same `not_found` — no existence oracle.

## Honesty note: the brief's premise was FALSE — sign did NOT use the per-assignee secret

The lane brief suggested verify could flip alone because "sign already uses the assignee integration's secret via the #3910 fix". **Verified in code: false.** #3910 only moved the outbound *message credentials* (`readDingTalkMessageConfigFromRuntime(assigneeIntegrationId)`, automation-executor.ts) to the assignee integration; the deep-link HMAC secret was still the global LIMIT-1 resolver at sign. Flipping verify alone would have broken same-source. Therefore this PR flips **sign and verify together, atomically**:

- New rows: signed per-assignee-integration + `integration_id` persisted → verified per-row-integration. Same-source ✅
- Legacy NULL rows: were signed with the LIMIT-1/env source → still verified with it. Same-source ✅
- Env-set deploys: env wins on both sides everywhere. Same-source ✅
- Single-integration deploys: per-integration pick ≡ LIMIT-1 pick. Behavior identical ✅

## Behavior changes flagged for ops

- **Multi-corp with a secret on only one integration**: sends to assignees of a *secret-less* corp now **fail-closed with an actionable error** (configure via CFG-2) instead of signing with another corp's secret and producing unstably-verifiable links. This is the intended R2 semantics.
- **Rolling-deploy window**: a card sent by NEW code (per-corp signed, row pinned) verified by OLD code (LIMIT-1) fails verify until the deploy completes (fail-closed, transient, only when the per-corp secret differs from the LIMIT-1 pick). Old-code-sent rows have `integration_id` NULL and keep verifying forever.
- Secret-missing error at send now surfaces AFTER recipient resolution (it needs the assignee's integration), so an unbound recipient reports the unbound skip rather than the missing-secret error.

## Coordination note (Slice-B line)

**B-2 (interactive-card send) must write `integration_id` from day one** — the column and the insert input ship here, so B-2 has no excuse for a second backfill. B-3's stream callback can call `readDingTalkMessageConfigFromRuntime(row.integration_id)` for DingTalk-side card updates. #3999 (B-1 skeleton) is untouched by this PR; its single global env credential triple remains a separate B-slice design item.

## Tests (all against real Postgres through the real call sites; fresh lane DB, full migration chain)

Extended three ALREADY-whitelisted suites (no new two-point wiring):

- `tests/integration/dingtalk-approval-card-deliveries.db.test.ts` (+1): insert persists + RETURNs `integration_id`; null passthrough; FK rejects unknown integration; ON DELETE SET NULL keeps the audit row.
- `tests/integration/automation-dingtalk-approval-card-action.test.ts` (+2, appended as new cases — lane D is adding a case to this file; no existing case restructured): executor ledger row carries the assignee's `integration_id` via the directory-link lateral; env unset → the sent deep-link token is HMAC-signed with the ASSIGNEE integration's stored secret (with a fresher **decoy** integration proving the LIMIT-1 pick is NOT the source).
- `tests/integration/approval-card-delivery-wrapper.db.test.ts` (+1): token signed under corp A fail-closes (`not_found`) against a delivery pinned to corp B through both `getApprovalCardDeliverySummary` and `executeApprovalActionFromCardDelivery`; the pinned corp verifies; env override wins; a pinned corp with no stored secret fail-closes (no LIMIT-1 rescue). Corp A is deliberately the freshest integration so any fallback to the global pick flips the assertions red.
- `tests/unit/dingtalk-approval-card-config.test.ts` (+5): per-integration resolver env-wins/by-id/fail-closed matrix; cross-corp verify fail-closed with a split mock (by-id → corp B, LIMIT-1 → corp A); NULL keeps the legacy resolver.

Runs: 3 integration suites = 25/25 pass (fresh DB `lane_r2card_*`, migrations green, column+FK verified via `\d`); full unit suite 341 files / 4550 tests pass; `tsc --noEmit` clean.

## Mutation table (implementation committed first; each mutant applied, run, reverted)

| # | Mutation | Result |
|---|----------|--------|
| M1 | Drop `integration_id` from the INSERT column list (revert to 7-column) | RED × 3: deliveries suite persist test + both executor DT-R2 tests |
| M2 | Verify ignores the row's integration (always global LIMIT-1 resolver) | **First run GREEN — fixtures shadowed the predicate** (global pick coincided with corp B). Hardened fixtures (corp A freshest / split mock), re-run: RED in wrapper db test + unit cross-corp test. Restored: GREEN |
| M3 | Executor signs with the global resolver instead of per-assignee | **First run would shadow too** (assignee integration was the only/freshest row) — added fresher decoy integration; RED in executor same-source test. Restored: GREEN |
| M4 | Remove the legacy NULL fallback (always per-integration, `'' `for NULL) | RED × 4: existing CFG-1 stored-fallback + CFG-2 closed-loop wrapper tests, existing unit same-source test, new unit NULL-fallback test |

## Not proven

- No live multi-corp DingTalk environment was exercised; the LIMIT-1 instability is read from the SQL, and DingTalk HTTP is faked (`gettoken`/`asyncsend_v2`) as in the existing suite.
- The rolling-deploy transient (new-signed link vs old verify code) is reasoned, not tested — no two-version harness exists.
- Interaction with lane D's pending `deliveryStuckPending` test in the same file is untested until rebase (my cases are appended, additive-only).
- `down()` migration exercised only implicitly (same pattern as the sibling `send_columns` migration); not run against populated data.
