### PR TITLE
feat(multitable): History Center batch-detail click-through to the record drawer (PR-C)

### DIFF
--- a/apps/web/src/multitable/components/HistoryBatchChangesList.vue
+++ b/apps/web/src/multitable/components/HistoryBatchChangesList.vue
@@ -11,7 +11,15 @@
     <li v-for="(c, i) in changes" :key="`${c.recordId}-${i}`" class="meta-hist__change" data-test="hist-change">
       <div class="meta-hist__change-summary">
         <span class="meta-hist__change-action" :data-action="c.action">{{ actionLabel(c.action) }}</span>
-        <span class="meta-hist__change-rec" :title="c.recordId" data-test="hist-rec-label">{{ recordDisplay(c) }}</span>
+        <button
+          v-if="c.action !== 'delete'"
+          type="button"
+          class="meta-hist__change-rec meta-hist__change-rec--link"
+          :title="c.recordId"
+          data-test="hist-rec-label"
+          @click="emit('open-record', { sheetId: c.sheetId, recordId: c.recordId })"
+        >{{ recordDisplay(c) }}</button>
+        <span v-else class="meta-hist__change-rec" :title="c.recordId" data-test="hist-rec-label">{{ recordDisplay(c) }}</span>
         <span class="meta-hist__change-fields">{{ fieldsLabel(c.changedFieldIds.length) }}</span>
       </div>
       <ul v-if="c.changedFieldIds.length" class="meta-hist__diff" data-test="hist-diff">
@@ -64,6 +72,11 @@ const props = defineProps<{
    *  on `sourceLabel` NOT applying here since this is a distinct map (per-change action, not source)). */
   actionLabel: (action: string) => string
 }>()
+
+// PR-C click-through: a non-delete change's record label is a button that asks the host to open the
+// record drawer (delete rows stay plain text — the record is gone). The list only EMITS; sheet
+// switching / drawer opening / not-found feedback are the workbench's concern.
+const emit = defineEmits<{ (e: 'open-record', payload: { sheetId: string; recordId: string }): void }>()
 
 const { isZh } = useLocale()
 
@@ -176,6 +189,8 @@ function diffMaskedLabel(): string {
 .meta-hist__change-summary { display: flex; gap: 10px; align-items: center; }
 .meta-hist__change-action { font-weight: 500; min-width: 48px; }
 .meta-hist__change-rec { color: var(--meta-text-secondary, #888); }
+.meta-hist__change-rec--link { background: none; border: none; padding: 0; font: inherit; cursor: pointer; text-decoration: underline dotted; }
+.meta-hist__change-rec--link:hover { color: var(--meta-text, #0f172a); }
 .meta-hist__change-fields { color: var(--meta-text-secondary, #888); }
 .meta-hist__diff { list-style: none; margin: 4px 0 0; padding: 0; }
 .meta-hist__diff-row { display: flex; align-items: baseline; gap: 8px; padding: 2px 0; }

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -26,7 +26,7 @@
             <span class="meta-hist__when">{{ formatTime(pinnedDetail.createdAt) }}</span>
             <span class="meta-hist__counts" data-test="hist-pinned-counts">{{ countLabel(pinnedDetail) }}</span>
           </div>
-          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" />
+          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
         </template>
       </div>
 
@@ -68,7 +68,7 @@
           <div v-if="expandedId === b.batchId" class="meta-hist__detail" data-test="hist-detail">
             <p v-if="detailLoading" class="meta-hist__hint">{{ t('加载中…', 'Loading…') }}</p>
             <p v-else-if="!detail" class="meta-hist__hint">{{ t('无法打开该批次', 'This batch is unavailable') }}</p>
-            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" />
+            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
           </div>
         </li>
       </ul>
@@ -115,7 +115,11 @@ const props = defineProps<{
    */
   initialBatchId?: string | null
 }>()
-const emit = defineEmits<{ (e: 'close'): void }>()
+const emit = defineEmits<{
+  (e: 'close'): void
+  /** PR-C: relayed verbatim from HistoryBatchChangesList — the workbench owns drawer/sheet concerns. */
+  (e: 'open-record', payload: { sheetId: string; recordId: string }): void
+}>()
 
 const { isZh } = useLocale()
 const t = (zh: string, en: string) => (isZh.value ? zh : en)

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -539,6 +539,7 @@
       :person-summaries="grid.personSummaries.value"
       :initial-batch-id="historyDeepLinkBatchId"
       @close="closeHistory"
+      @open-record="onHistoryOpenRecord"
     />
     <MetaConfigHistoryModal
       :visible="configHistory.visible"
@@ -998,6 +999,19 @@ function openHistoryForBatch(batchId: string) {
   historyDeepLinkBatchId.value = batchId
   showHistory.value = true
 }
+// PR-C: click-through from a History Center change row to the record drawer — same shape as the
+// Notification Center's click-to-locate (onNotificationNavigate): switch to the change's sheet first
+// (resolveDeepLink resolves against the active sheet; a declined unsaved-changes discard aborts, so we
+// never look the record up in the wrong sheet), then locate via resolveDeepLink (loaded row → drawer;
+// off-page → getRecord fetch; gone/denied → the existing not-found toast).
+async function onHistoryOpenRecord(payload: { sheetId: string; recordId: string }) {
+  if (payload.sheetId && payload.sheetId !== workbench.activeSheetId.value) {
+    if (!onSelectSheet(payload.sheetId)) return
+  }
+  closeHistory()
+  await resolveDeepLink(payload.recordId)
+}
+
 function closeHistory() {
   showHistory.value = false
   historyDeepLinkBatchId.value = null

--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -445,3 +445,44 @@ describe('HistoryCenterModal — type-aware link/person diff values (PR-B)', () 
     } finally { app.unmount(); container.remove() }
   })
 })
+
+describe('HistoryCenterModal — record click-through emit (PR-C)', () => {
+  it('a non-delete change row renders a BUTTON chip that emits open-record with {sheetId, recordId}', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_9', recordId: 'rec_click', action: 'update', version: 2,
+      changedFieldIds: ['fld_title'], before: { fld_title: 'a' }, after: { fld_title: 'b' },
+    }]))
+    const onOpenRecord = vi.fn()
+    const { app, container } = mountModalWithProps({ fields: TYPED_FIELDS, onOpenRecord })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const chip = container.querySelector<HTMLElement>('[data-test="hist-rec-label"]')!
+      expect(chip.tagName).toBe('BUTTON')
+      chip.click()
+      expect(onOpenRecord).toHaveBeenCalledTimes(1)
+      expect(onOpenRecord).toHaveBeenCalledWith({ sheetId: 'sheet_9', recordId: 'rec_click' })
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('a DELETE change row renders plain text (no button — the record is gone)', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch({ action: 'delete' })], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detailWith([{
+      sheetId: 'sheet_1', recordId: 'rec_gone', action: 'delete', version: 3,
+      changedFieldIds: [], before: { fld_title: 'Doomed' }, after: null,
+    }]))
+    const onOpenRecord = vi.fn()
+    const { app, container } = mountModalWithProps({ fields: TYPED_FIELDS, onOpenRecord })
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const chip = container.querySelector<HTMLElement>('[data-test="hist-rec-label"]')!
+      expect(chip.tagName).toBe('SPAN')
+      chip.click()
+      expect(onOpenRecord).not.toHaveBeenCalled()
+    } finally { app.unmount(); container.remove() }
+  })
+})

--- a/apps/web/tests/multitable-workbench-history-field-scope-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-history-field-scope-wiring.spec.ts
@@ -91,8 +91,9 @@ vi.mock('../src/composables/useAuth', () => ({
     getAccessSnapshot: () => ({ userId: 'user_1', isAdmin: false, permissions: [] }),
   }),
 }))
+const { mockShowError, mockShowSuccess } = vi.hoisted(() => ({ mockShowError: vi.fn(), mockShowSuccess: vi.fn() }))
 vi.mock('../src/composables/useToast', () => ({
-  useToast: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
 }))
 
 // Stub heavy sub-components that aren't under test — HistoryCenterModal (and its child
@@ -111,7 +112,17 @@ vi.mock('../src/multitable/components/MetaLinkPicker.vue', () => ({ default: stu
 vi.mock('../src/multitable/components/MetaFieldManager.vue', () => ({ default: stubComponent('MetaFieldManager') }))
 vi.mock('../src/multitable/components/MetaViewManager.vue', () => ({ default: stubComponent('MetaViewManager') }))
 vi.mock('../src/multitable/components/MetaImportModal.vue', () => ({ default: stubComponent('MetaImportModal') }))
-vi.mock('../src/multitable/components/MetaToast.vue', () => ({ default: stubComponent('MetaToast') }))
+// MetaToast must expose showError/showSuccess — the workbench's local showError() calls the TEMPLATE
+// REF's method (toastRef.value?.showError), not the useToast composable.
+vi.mock('../src/multitable/components/MetaToast.vue', () => ({
+  default: defineComponent({
+    name: 'MetaToast',
+    setup(_, { expose }) {
+      expose({ showError: mockShowError, showSuccess: mockShowSuccess })
+      return () => h('div', { 'data-stub-MetaToast': 'true' })
+    },
+  }),
+}))
 vi.mock('../src/multitable/components/MetaBasePicker.vue', () => ({ default: stubComponent('MetaBasePicker') }))
 
 vi.mock('../src/multitable/import/bulk-import', () => ({ bulkImportRecords: vi.fn() }))
@@ -179,6 +190,8 @@ function createWorkbenchMock() {
       updateFieldPermission: vi.fn().mockResolvedValue({}),
       listViewPermissions: vi.fn().mockResolvedValue({ items: [] }),
       updateViewPermission: vi.fn().mockResolvedValue({}),
+      getRecord: vi.fn().mockRejectedValue(new Error('not mocked')),
+      listCommentMentionSuggestions: vi.fn().mockResolvedValue({ items: [] }),
     },
   }
 }
@@ -263,6 +276,10 @@ describe('MultitableWorkbench -> HistoryCenterModal field-scope wiring', () => {
     }
     container = document.createElement('div')
     document.body.appendChild(container)
+    // The workbench mirrors the selected record into the URL hash (#recordId=…) and deep-link-
+    // bootstraps FROM it on mount — clear it so a prior test's selection can't auto-trigger
+    // resolveDeepLink in the next mount (jsdom shares one window across this file).
+    window.history.replaceState(null, '', window.location.pathname)
   })
 
   afterEach(() => {
@@ -306,5 +323,79 @@ describe('MultitableWorkbench -> HistoryCenterModal field-scope wiring', () => {
     await flushUi()
     const label = container!.querySelector('.meta-hist__diff-label')
     expect(label?.textContent).toContain('Title')
+  })
+
+  // ── PR-C: click-through from a batch-detail record chip to the record drawer ──
+  async function mountAndExpandBatch() {
+    const MultitableWorkbench = (await import('../src/multitable/views/MultitableWorkbench.vue')).default
+    app = createApp(defineComponent({
+      setup() { return () => h(MultitableWorkbench as Component) },
+    }))
+    app.mount(container!)
+    await flushUi()
+    container!.querySelector<HTMLButtonElement>('[data-action="open-history"]')!.click()
+    await flushUi()
+    container!.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+    await flushUi()
+    const chip = container!.querySelector<HTMLButtonElement>('button[data-test="hist-rec-label"]')
+    expect(chip).toBeTruthy()
+    return chip!
+  }
+
+  it('PR-C hit: clicking a record chip closes the History Center and selects the loaded record (no fetch, no toast)', async () => {
+    gridMock.rows.value = [{ id: 'rec_1', version: 2, data: { fld_1: 'New' } }]
+    const chip = await mountAndExpandBatch()
+    chip.click()
+    await flushUi()
+    expect(container!.querySelector('[data-test="hist-filter-field"]')).toBeNull() // modal closed
+    expect(mockShowError).not.toHaveBeenCalled()
+    expect(workbenchMock.client.getRecord).not.toHaveBeenCalled() // in-page → no deep-link fetch
+    expect(workbenchMock.selectSheet).not.toHaveBeenCalled() // same sheet — no switch
+  })
+
+  it('PR-C off-page record: resolveDeepLink fetches it via getRecord (no toast on success)', async () => {
+    gridMock.rows.value = [] // rec_1 is NOT loaded → deep-link fetch path
+    workbenchMock.client.getRecord.mockResolvedValue({
+      record: { id: 'rec_1', version: 2, data: { fld_1: 'New' } },
+      linkSummaries: {}, personSummaries: {}, attachmentSummaries: {},
+      commentsScope: null, fieldPermissions: {}, viewPermissions: {}, rowActions: null,
+    })
+    const chip = await mountAndExpandBatch()
+    chip.click()
+    await flushUi()
+    expect(container!.querySelector('[data-test="hist-filter-field"]')).toBeNull()
+    expect(workbenchMock.client.getRecord).toHaveBeenCalledWith('rec_1', expect.anything())
+    expect(mockShowError).not.toHaveBeenCalled()
+  })
+
+  it('PR-C gone/denied record: getRecord failure surfaces the existing not-found toast', async () => {
+    gridMock.rows.value = []
+    workbenchMock.client.getRecord.mockRejectedValue(new Error('404'))
+    const chip = await mountAndExpandBatch()
+    chip.click()
+    await flushUi()
+    expect(mockShowError).toHaveBeenCalledTimes(1)
+    expect(String(mockShowError.mock.calls[0][0])).toContain('Record not found')
+  })
+
+  it('PR-C cross-sheet: switches the active sheet BEFORE locating (all-tables mode)', async () => {
+    mockGetHistoryBatch.mockResolvedValue({
+      batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 1, visibleAffectedFieldCount: 1,
+      changes: [{
+        sheetId: 'sheet_2', recordId: 'rec_other', action: 'update', version: 1,
+        changedFieldIds: ['fld_1'], before: { fld_1: 'a' }, after: { fld_1: 'b' },
+      }],
+    } satisfies HistoryBatchDetail)
+    workbenchMock.client.getRecord.mockResolvedValue({
+      record: { id: 'rec_other', version: 1, data: { fld_1: 'b' } },
+      linkSummaries: {}, personSummaries: {}, attachmentSummaries: {},
+      commentsScope: null, fieldPermissions: {}, viewPermissions: {}, rowActions: null,
+    })
+    const chip = await mountAndExpandBatch()
+    chip.click()
+    await flushUi()
+    expect(workbenchMock.selectSheet).toHaveBeenCalledWith('sheet_2')
+    expect(mockShowError).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
**Stacked on #4012 (PR-B) → #4007 (PR-A).** Land bottom-up with base retargeting per stacked-PR discipline.

R9 UX-parity audit finding (d): no way to jump from a History Center change row to the record itself.

### What
Record labels on non-delete change rows become buttons → `('open-record', {sheetId, recordId})` emitted by `HistoryBatchChangesList`, relayed verbatim by `HistoryCenterModal`, handled by the workbench **exactly like the Notification Center's click-to-locate** (`onNotificationNavigate` shape): `onSelectSheet` first for cross-sheet batches (declined unsaved-changes discard aborts — never locates in the wrong sheet), close the modal, then `resolveDeepLink` — loaded row → drawer; off-page → `getRecord` fetch; gone/denied → the existing `Record not found` toast. Delete rows stay plain text. **Zero new endpoints, zero new i18n labels** — reuses shipped deep-link machinery.

### Verification
- Modal-level: BUTTON chip emits exactly once with payload; delete row renders SPAN and cannot emit.
- Workbench-level (real mount): in-page hit (no fetch, no toast) · off-page `getRecord` success (no toast) · `getRecord` failure → not-found toast · cross-sheet → `selectSheet('sheet_2')` before locating.
- **Mutation-verified**: neutering the emit → exactly 5 red across both layers.
- Neighbors 7 files / 54 tests green; `vue-tsc` clean.
- Spec-infra fix folded in: jsdom shares one window per spec file, and the workbench mirrors selection into `#recordId=…` and deep-link-bootstraps FROM it on mount — a prior test's hash auto-fired `resolveDeepLink` on the next mount (phantom double-toast). `beforeEach` now clears the hash.

### Not covered
- Restored-after-delete records still render as plain text in old delete rows (chip enablement is action-shaped, not liveness-checked).
- The pinned-banner list relays the same emit (shared component) but has no dedicated spec case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)