### PR TITLE
feat(integration): stock-prep W3a — blocking-policy export + diff base override + per-row diff browse [stacked on #4015]

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-diff.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-diff.test.cjs
@@ -9,6 +9,7 @@ const path = require('node:path')
 const {
   CHANGE_TYPES,
   DIFF_TYPES,
+  BLOCKING_CHANGE_TYPES,
   REVIEW_STATUSES,
   StockPreparationSnapshotDiffError,
   planBomSnapshotDiff,
@@ -187,6 +188,38 @@ function main() {
     StockPreparationSnapshotDiffError,
     'array contract is enforced',
   )
+
+  // W3a: BLOCKING_CHANGE_TYPES is the exported single policy source — frozen, and (currently) the
+  // FULL change-type vocabulary: every single change type alone yields a HELD row; no changes => ready.
+  assert.ok(Object.isFrozen(BLOCKING_CHANGE_TYPES), 'blocking policy array is frozen')
+  assert.deepEqual(
+    [...BLOCKING_CHANGE_TYPES].sort(),
+    Object.values(CHANGE_TYPES).sort(),
+    'blocking policy currently blocks on every change type',
+  )
+  for (const changeType of [CHANGE_TYPES.QUANTITY_CHANGED, CHANGE_TYPES.VERSION_CHANGED, CHANGE_TYPES.UNIT_CHANGED]) {
+    const previousLine = { snapshotLineId: 'bp1', childDrawingNo: 'BLK', childVersion: 'V1', pathKey: '/root/BLK', designQty: 1, designUnit: 'pcs' }
+    const currentLine = { ...previousLine, snapshotLineId: 'bc1' }
+    if (changeType === CHANGE_TYPES.QUANTITY_CHANGED) currentLine.designQty = 2
+    if (changeType === CHANGE_TYPES.VERSION_CHANGED) currentLine.childVersion = 'V2'
+    if (changeType === CHANGE_TYPES.UNIT_CHANGED) currentLine.designUnit = 'kg'
+    const plan = planBomSnapshotDiff({
+      previousSnapshotBatchId: 'bb1',
+      currentSnapshotBatchId: 'bb2',
+      previousLines: [previousLine],
+      currentLines: [currentLine],
+    })
+    const changed = plan.diffs.find((diff) => diff.changeTypes.includes(changeType))
+    assert.ok(changed, `a ${changeType} diff row surfaces`)
+    assert.equal(changed.reviewStatus, REVIEW_STATUSES.HELD, `${changeType} alone holds the row`)
+  }
+  const unchangedPlan = planBomSnapshotDiff({
+    previousSnapshotBatchId: 'bb1',
+    currentSnapshotBatchId: 'bb2',
+    previousLines: [{ snapshotLineId: 'u1', childDrawingNo: 'BLK', childVersion: 'V1', pathKey: '/root/BLK', designQty: 1 }],
+    currentLines: [{ snapshotLineId: 'u2', childDrawingNo: 'BLK', childVersion: 'V1', pathKey: '/root/BLK', designQty: 1 }],
+  })
+  assert.ok(unchangedPlan.diffs.every((diff) => diff.reviewStatus === REVIEW_STATUSES.READY), 'no change types => ready')
 
   console.log('stock-preparation-snapshot-diff.test.cjs OK')
 }

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
@@ -20,6 +20,7 @@ const path = require('node:path')
 const {
   listSnapshotBatches,
   getSnapshotDiff,
+  listSnapshotDiffRows,
   BATCH_OBJECT_ID,
   LINE_OBJECT_ID,
   RUN_OBJECT_ID,
@@ -346,6 +347,161 @@ async function main() {
     // The version/unit change between /root/S c1->c2 still counts, values-free.
     assert.equal(diffResult.baseSnapshotBatchId, 'c1')
     assert.ok(diffResult.changeCounts.versionChanged >= 1)
+  })
+
+  // ---- W3a: caller-chosen base pair on the counts diff ----
+  await run('diff base-override: valid pair honored; unknown 404; cross-project 409; self 400', async () => {
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: 'b1', projectId: BUSINESS_PROJECT, snapshotVersion: 1, syncRunId: 'r1' },
+        { snapshotBatchId: 'b2', projectId: BUSINESS_PROJECT, snapshotVersion: 2, syncRunId: 'r2' },
+        { snapshotBatchId: 'b3', projectId: BUSINESS_PROJECT, snapshotVersion: 3, syncRunId: 'r3' },
+        { snapshotBatchId: 'bx', projectId: OTHER_PROJECT, snapshotVersion: 1, syncRunId: 'rx' },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [
+        { snapshotLineId: 'l1', snapshotBatchId: 'b1', childDrawingNo: 'A', childVersion: 'V1', pathKey: '/root/A', designQty: 1 },
+        { snapshotLineId: 'l3', snapshotBatchId: 'b3', childDrawingNo: 'A', childVersion: 'V3', pathKey: '/root/A', designQty: 1 },
+      ],
+    }
+    // Explicit base b1 (predecessor auto-pick would choose b2): version change A V1 -> V3 counts.
+    const result = await getSnapshotDiff({
+      recordsApi: makeRecordsApi(rows),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'b3',
+      baseSnapshotBatchId: 'b1',
+      permission: 'admin',
+    })
+    assert.equal(result.baseSnapshotBatchId, 'b1', 'explicit base echoes back')
+    assert.ok(result.changeCounts.versionChanged >= 1)
+    const expectDiffError = async (base, status, code) => {
+      let caught = null
+      try {
+        await getSnapshotDiff({
+          recordsApi: makeRecordsApi(rows),
+          provisioning: makeProvisioning(),
+          targetProjectId: STAGING_PROJECT,
+          snapshotBatchId: 'b3',
+          baseSnapshotBatchId: base,
+          permission: 'admin',
+        })
+      } catch (error) {
+        caught = error
+      }
+      assert.ok(caught, `expected error for base ${base}`)
+      assert.equal(caught.status, status)
+      assert.equal(caught.code, code)
+    }
+    await expectDiffError('nope', 404, 'SNAPSHOT_DIFF_BASE_NOT_FOUND')
+    await expectDiffError('bx', 409, 'SNAPSHOT_DIFF_BASE_PROJECT_MISMATCH')
+    await expectDiffError('b3', 400, 'SNAPSHOT_DIFF_BASE_INVALID')
+  })
+
+  // ---- W3a: per-row diff browse ----
+  await run('diff rows: 11-key whitelist projection, heldRowCount, filters, values-free', async () => {
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: 'd1', projectId: BUSINESS_PROJECT, snapshotVersion: 1, syncRunId: 'r1' },
+        { snapshotBatchId: 'd2', projectId: BUSINESS_PROJECT, snapshotVersion: 2, syncRunId: 'r2' },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [
+        // unchanged row + version-changed row + added row => mixed ready/held statuses.
+        { snapshotLineId: 'p1', snapshotBatchId: 'd1', childDrawingNo: `S_${SECRET}`, childVersion: 'V1', pathKey: '/root/same', designQty: 1, designUnit: `u_${SECRET}` },
+        { snapshotLineId: 'p2', snapshotBatchId: 'd1', childDrawingNo: 'B', childVersion: 'V1', pathKey: '/root/B', designQty: 1 },
+        { snapshotLineId: 'c1', snapshotBatchId: 'd2', childDrawingNo: `S_${SECRET}`, childVersion: 'V1', pathKey: '/root/same', designQty: 1, designUnit: `u_${SECRET}` },
+        { snapshotLineId: 'c2', snapshotBatchId: 'd2', childDrawingNo: 'B', childVersion: 'V2', pathKey: '/root/B', designQty: 1 },
+        { snapshotLineId: 'c3', snapshotBatchId: 'd2', childDrawingNo: 'C', childVersion: 'V1', pathKey: '/root/C', designQty: 1 },
+      ],
+    }
+    const DIFF_ROW_KEY_SET = new Set([
+      'diffId', 'diffType', 'reviewStatus', 'changeTypes', 'reason', 'rowCount',
+      'previousSnapshotLineId', 'currentSnapshotLineId', 'keyFingerprint',
+      'previousPathKeyFingerprint', 'currentPathKeyFingerprint',
+    ])
+    const result = await listSnapshotDiffRows({
+      recordsApi: makeRecordsApi(rows),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'd2',
+      permission: 'admin',
+    })
+    assert.equal(result.baseSnapshotBatchId, 'd1')
+    assert.ok(result.rowCount >= 3, 'unchanged + changed + added rows surface')
+    assert.ok(result.heldRowCount >= 2, 'version change + added are held under the all-blocking policy')
+    for (const row of result.rows) {
+      for (const key of Object.keys(row)) {
+        assert.ok(DIFF_ROW_KEY_SET.has(key), `row key ${key} must be whitelisted`)
+      }
+      assert.ok(row.diffId && row.diffType && row.reviewStatus)
+      assert.ok(Array.isArray(row.changeTypes))
+    }
+    assert.equal(JSON.stringify(result).includes(SECRET), false, 'no secret leaks through a diff row')
+
+    // filters narrow by enum; held filter drops the unchanged row.
+    const held = await listSnapshotDiffRows({
+      recordsApi: makeRecordsApi(rows),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'd2',
+      reviewStatus: 'held',
+      permission: 'admin',
+    })
+    assert.equal(held.rowCount, held.rows.length)
+    assert.ok(held.rows.every((row) => row.reviewStatus === 'held'))
+    assert.ok(held.rowCount < result.rowCount, 'held filter narrows the unchanged row away')
+    assert.equal(held.heldRowCount, result.heldRowCount, 'heldRowCount stays pre-filter context')
+    const added = await listSnapshotDiffRows({
+      recordsApi: makeRecordsApi(rows),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'd2',
+      diffType: 'added',
+      permission: 'admin',
+    })
+    assert.ok(added.rows.every((row) => row.diffType === 'added'))
+
+    // bogus enum fails closed at the module belt-and-braces gate too.
+    let caught = null
+    try {
+      await listSnapshotDiffRows({
+        recordsApi: makeRecordsApi(rows),
+        provisioning: makeProvisioning(),
+        targetProjectId: STAGING_PROJECT,
+        snapshotBatchId: 'd2',
+        reviewStatus: 'bogus',
+        permission: 'admin',
+      })
+    } catch (error) {
+      caught = error
+    }
+    assert.equal(caught && caught.code, 'SNAPSHOT_READS_CONFIG_INVALID')
+  })
+
+  await run('diff rows: result row cap fails closed at 2000', async () => {
+    const manyLines = []
+    for (let index = 0; index < 2001; index += 1) {
+      manyLines.push({ snapshotLineId: `m${index}`, snapshotBatchId: 'big1', childDrawingNo: `D${index}`, childVersion: 'V1', pathKey: `/root/D${index}`, designQty: 1 })
+    }
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: 'big1', projectId: BUSINESS_PROJECT, snapshotVersion: 1, syncRunId: 'r1' },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: manyLines,
+    }
+    let caught = null
+    try {
+      await listSnapshotDiffRows({
+        recordsApi: makeRecordsApi(rows),
+        provisioning: makeProvisioning(),
+        targetProjectId: STAGING_PROJECT,
+        snapshotBatchId: 'big1',
+        permission: 'admin',
+      })
+    } catch (error) {
+      caught = error
+    }
+    assert.equal(caught && caught.status, 422)
+    assert.equal(caught && caught.code, 'SNAPSHOT_READS_ROWS_TOO_LARGE')
   })
 
   console.log(`\nstock-preparation-snapshot-reads.test.cjs: ${passed} passed, ${failed} failed`)

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
@@ -395,6 +395,38 @@ async function main() {
     await expectDiffError('nope', 404, 'SNAPSHOT_DIFF_BASE_NOT_FOUND')
     await expectDiffError('bx', 409, 'SNAPSHOT_DIFF_BASE_PROJECT_MISMATCH')
     await expectDiffError('b3', 400, 'SNAPSHOT_DIFF_BASE_INVALID')
+    // P2-A1 (review): a GHOST current batch with a caller-chosen base must fail closed 404 — never
+    // skip the project gate and never fabricate an all-removed diff of the base project's rows.
+    const expectGhostError = async (fn, base) => {
+      let caught = null
+      try {
+        await fn({
+          recordsApi: makeRecordsApi(rows),
+          provisioning: makeProvisioning(),
+          targetProjectId: STAGING_PROJECT,
+          snapshotBatchId: 'ghost_current',
+          baseSnapshotBatchId: base,
+          permission: 'admin',
+        })
+      } catch (error) {
+        caught = error
+      }
+      assert.ok(caught, 'ghost current + explicit base must not answer')
+      assert.equal(caught.status, 404)
+      assert.equal(caught.code, 'SNAPSHOT_DIFF_BASE_NOT_FOUND')
+    }
+    await expectGhostError(getSnapshotDiff, 'bx')
+    await expectGhostError(getSnapshotDiff, 'b1')
+    await expectGhostError(listSnapshotDiffRows, 'bx')
+    // Predecessor auto-pick path for a ghost current stays the #4002 graceful shape (no throw).
+    const ghostAuto = await getSnapshotDiff({
+      recordsApi: makeRecordsApi(rows),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'ghost_current',
+      permission: 'admin',
+    })
+    assert.equal(ghostAuto.baseSnapshotBatchId, null)
   })
 
   // ---- W3a: per-row diff browse ----

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -80,6 +80,9 @@ const ROUTES = [
   // values-free). List is exact-path; diff carries the batch id in the path.
   ['GET', '/api/integration/stock-preparation/snapshot-batches', 'stockPreparationSnapshotBatchList'],
   ['GET', '/api/integration/stock-preparation/snapshot-batches/:snapshotBatchId/diff', 'stockPreparationSnapshotDiff'],
+  // #3751 MVP W3 (diff rows): per-row diffType/changeTypes/reviewStatus browse for view 2 — closed
+  // 11-key projection, optional caller-chosen base pair, optional enum filters, capped fail-closed.
+  ['GET', '/api/integration/stock-preparation/snapshot-batches/:snapshotBatchId/diff/rows', 'stockPreparationSnapshotDiffRows'],
   // #3751 MVP W3 (confirm writes): candidate-sync feeds the mapping review queue; confirm/retire are
   // the human confirmation surface over the two confirmation tables (multitable-internal only,
   // admin-gated, server-stamped confirmedBy/confirmedAt, values-free).
@@ -266,7 +269,11 @@ const { persistStockPreparationSyncRun } = require('./stock-preparation-sync-run
 const {
   listSnapshotBatches,
   getSnapshotDiff,
+  listSnapshotDiffRows,
 } = require('./stock-preparation-snapshot-reads.cjs')
+// #3751 MVP W3 (diff rows): route-level enum gates for the diff-row filters come from the SAME frozen
+// vocabularies the engine exports (never re-typed literals).
+const { DIFF_TYPES: STOCK_PREPARATION_DIFF_TYPES, REVIEW_STATUSES: STOCK_PREPARATION_REVIEW_STATUSES } = require('./stock-preparation-snapshot-diff.cjs')
 // #3751 MVP W3: HUMAN CONFIRM writes for the material-mapping / unit-conversion-rule tables (plus the
 // candidate-sync that feeds the review queue). Multitable-internal only (target-scoped records API
 // over the frozen MVP sheets under the STAGING project); confirmedBy is the route user identity and
@@ -609,6 +616,22 @@ const VALID_STOCK_PREPARATION_SNAPSHOT_READ_QUERY_KEYS = new Set([
   'tenantId',
   'workspaceId',
   'projectId',
+])
+// #3751 MVP W3: the DIFF route additionally accepts a caller-chosen base batch id; the DIFF/ROWS
+// route adds the two enum filters. Separate Sets per route — extending DIFF must not widen LIST.
+const VALID_STOCK_PREPARATION_SNAPSHOT_DIFF_QUERY_KEYS = new Set([
+  'tenantId',
+  'workspaceId',
+  'projectId',
+  'baseSnapshotBatchId',
+])
+const VALID_STOCK_PREPARATION_SNAPSHOT_DIFF_ROWS_QUERY_KEYS = new Set([
+  'tenantId',
+  'workspaceId',
+  'projectId',
+  'baseSnapshotBatchId',
+  'reviewStatus',
+  'diffType',
 ])
 // #3751 MVP W3: closed request allowlists for the confirm-write routes — one Set per route (no
 // sharing that would widen a sibling parser). The confirmation stamps (confirmedBy / confirmedAt)
@@ -1015,20 +1038,20 @@ function stockPreparationMvpSyncPersistInput(rawInput = {}) {
 
 // #3751 MVP view 2: parse the readonly snapshot-read query against the CLOSED allowlist. Rejects any
 // unknown query field; returns only the tenant/workspace scope + the raw (business) projectId.
-function normalizeStockPreparationSnapshotReadQuery(input = {}, code) {
+function normalizeStockPreparationSnapshotReadQuery(input = {}, code, allowedKeys = VALID_STOCK_PREPARATION_SNAPSHOT_READ_QUERY_KEYS) {
   if (!isPlainObject(input)) {
     throw new HttpRouteError(400, code, 'request must be an object')
   }
   for (const key of Object.keys(input)) {
-    if (!VALID_STOCK_PREPARATION_SNAPSHOT_READ_QUERY_KEYS.has(key)) {
+    if (!allowedKeys.has(key)) {
       throw new HttpRouteError(400, code, `unsupported request field: ${key}`, { field: key })
     }
   }
-  return {
-    tenantId: firstString(input.tenantId),
-    workspaceId: firstString(input.workspaceId),
-    projectId: firstString(input.projectId),
+  const out = {}
+  for (const key of allowedKeys) {
+    out[key] = firstString(input[key])
   }
+  return out
 }
 
 // LIST: `projectId` is the PLM business project (REQUIRED — it filters + is echoed). `targetProjectId`
@@ -1053,7 +1076,7 @@ function stockPreparationSnapshotBatchListInput(req, rawQuery = {}) {
 // business project is read from the batch row server-side); `targetProjectId` is the STAGING locator
 // derived from the auth tenant.
 function stockPreparationSnapshotDiffInput(req, rawQuery = {}) {
-  const input = normalizeStockPreparationSnapshotReadQuery(rawQuery, 'STOCK_PREPARATION_SNAPSHOT_DIFF_REQUEST_INVALID')
+  const input = normalizeStockPreparationSnapshotReadQuery(rawQuery, 'STOCK_PREPARATION_SNAPSHOT_DIFF_REQUEST_INVALID', VALID_STOCK_PREPARATION_SNAPSHOT_DIFF_QUERY_KEYS)
   const tenantId = resolveTenantId(req, input)
   const snapshotBatchId = firstString(requestParams(req).snapshotBatchId)
   if (!snapshotBatchId) {
@@ -1064,6 +1087,34 @@ function stockPreparationSnapshotDiffInput(req, rawQuery = {}) {
     workspaceId: input.workspaceId,
     businessProjectId: input.projectId,
     snapshotBatchId,
+    baseSnapshotBatchId: input.baseSnapshotBatchId,
+    targetProjectId: resolveIntegrationStagingProjectId(tenantId, input.projectId),
+  }
+}
+
+// #3751 MVP W3: diff/rows query — DIFF keys + the two ENUM filters, gated against the engine's frozen
+// vocabularies at the route (values-free 400 with the field name only).
+function stockPreparationSnapshotDiffRowsInput(req, rawQuery = {}) {
+  const input = normalizeStockPreparationSnapshotReadQuery(rawQuery, 'STOCK_PREPARATION_SNAPSHOT_DIFF_ROWS_REQUEST_INVALID', VALID_STOCK_PREPARATION_SNAPSHOT_DIFF_ROWS_QUERY_KEYS)
+  const tenantId = resolveTenantId(req, input)
+  const snapshotBatchId = firstString(requestParams(req).snapshotBatchId)
+  if (!snapshotBatchId) {
+    throw new HttpRouteError(400, 'STOCK_PREPARATION_SNAPSHOT_DIFF_ROWS_REQUEST_INVALID', 'snapshotBatchId is required', { field: 'snapshotBatchId' })
+  }
+  if (input.reviewStatus && !Object.values(STOCK_PREPARATION_REVIEW_STATUSES).includes(input.reviewStatus)) {
+    throw new HttpRouteError(400, 'STOCK_PREPARATION_SNAPSHOT_DIFF_ROWS_REQUEST_INVALID', 'reviewStatus must be one of the review-status vocabulary', { field: 'reviewStatus' })
+  }
+  if (input.diffType && !Object.values(STOCK_PREPARATION_DIFF_TYPES).includes(input.diffType)) {
+    throw new HttpRouteError(400, 'STOCK_PREPARATION_SNAPSHOT_DIFF_ROWS_REQUEST_INVALID', 'diffType must be one of the diff-type vocabulary', { field: 'diffType' })
+  }
+  return {
+    tenantId,
+    workspaceId: input.workspaceId,
+    businessProjectId: input.projectId,
+    snapshotBatchId,
+    baseSnapshotBatchId: input.baseSnapshotBatchId,
+    reviewStatus: input.reviewStatus,
+    diffType: input.diffType,
     targetProjectId: resolveIntegrationStagingProjectId(tenantId, input.projectId),
   }
 }
@@ -3389,6 +3440,33 @@ function createHandlers(services, options = {}) {
         targetProjectId: input.targetProjectId,
         businessProjectId: input.businessProjectId,
         snapshotBatchId: input.snapshotBatchId,
+        baseSnapshotBatchId: input.baseSnapshotBatchId,
+        permission: 'admin',
+      })
+      return sendOk(res, result)
+    },
+
+    // #3751 MVP W3: values-free PER-ROW diff browse (view 2 rows: diffType / changeTypes /
+    // reviewStatus per row). Same read flow + base semantics as the counts diff; closed 11-key
+    // projection; optional enum filters; capped fail-closed.
+    async stockPreparationSnapshotDiffRows(req, res) {
+      requireAccess(req, 'admin')
+      const input = stockPreparationSnapshotDiffRowsInput(req, requestQuery(req))
+      const provisioning = context && context.api && context.api.multitable
+        ? context.api.multitable.provisioning
+        : undefined
+      if (!provisioning) {
+        throw new HttpRouteError(501, 'SNAPSHOT_READS_PROVISIONING_API_UNAVAILABLE', 'multitable provisioning API is not available')
+      }
+      const result = await listSnapshotDiffRows({
+        recordsApi: getMultitableRecordsApi(),
+        provisioning,
+        targetProjectId: input.targetProjectId,
+        businessProjectId: input.businessProjectId,
+        snapshotBatchId: input.snapshotBatchId,
+        baseSnapshotBatchId: input.baseSnapshotBatchId,
+        reviewStatus: input.reviewStatus,
+        diffType: input.diffType,
         permission: 'admin',
       })
       return sendOk(res, result)

--- a/plugins/plugin-integration-core/lib/stock-preparation-snapshot-diff.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-snapshot-diff.cjs
@@ -541,6 +541,9 @@ function summarizeSnapshotDiffForEvidence(plan = {}) {
 module.exports = {
   DIFF_TYPES,
   CHANGE_TYPES,
+  // The single held/ready policy source (currently: EVERY change type blocks). Exported so the diff
+  // read surface / generation / FE consume THIS array instead of forking the policy.
+  BLOCKING_CHANGE_TYPES,
   REVIEW_STATUSES,
   StockPreparationSnapshotDiffError,
   planBomSnapshotDiff,

--- a/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
@@ -27,7 +27,7 @@ const {
   STOCK_PREPARATION_MVP_TABLE_TEMPLATES,
   STOCK_PREPARATION_MVP_REQUIRED_OBJECT_IDS,
 } = require('./stock-preparation-templates.cjs')
-const { planBomSnapshotDiff, CHANGE_TYPES } = require('./stock-preparation-snapshot-diff.cjs')
+const { planBomSnapshotDiff, CHANGE_TYPES, DIFF_TYPES, REVIEW_STATUSES } = require('./stock-preparation-snapshot-diff.cjs')
 const { optionalString, isPlainObject } = require('./stock-preparation-common.cjs')
 const {
   StockPreparationTargetProvisioningError,
@@ -274,24 +274,58 @@ function pickPredecessor(batchRows, currentSnapshotBatchId, currentVersion) {
   return best
 }
 
+// Resolve the diff BASE batch id. An EXPLICIT `requestedBase` is a caller-chosen pair and must be
+// validated (differ from current -> 400; exist -> 404; same business project -> 409). Without it the
+// predecessor rule applies unchanged (highest version strictly below current, same business project).
+async function resolveDiffBase(api, batchSheet, { currentSnapshotBatchId, projectId, currentVersion, requestedBase }) {
+  if (requestedBase) {
+    if (requestedBase === currentSnapshotBatchId) {
+      throw new StockPreparationTargetProvisioningError(400, 'SNAPSHOT_DIFF_BASE_INVALID', 'baseSnapshotBatchId must differ from the diffed batch', { field: 'baseSnapshotBatchId' })
+    }
+    const baseRows = batchSheet ? await queryAllRecords(api, batchSheet.id, { snapshotBatchId: requestedBase }) : []
+    const baseRow = baseRows[0] || null
+    if (!baseRow) {
+      throw new StockPreparationTargetProvisioningError(404, 'SNAPSHOT_DIFF_BASE_NOT_FOUND', 'base snapshot batch was not found', { field: 'baseSnapshotBatchId' })
+    }
+    const baseProjectId = optionalString(readCell(baseRow, 'projectId'))
+    if (projectId && baseProjectId && baseProjectId !== projectId) {
+      throw new StockPreparationTargetProvisioningError(409, 'SNAPSHOT_DIFF_BASE_PROJECT_MISMATCH', 'base snapshot batch belongs to a different business project', { field: 'baseSnapshotBatchId' })
+    }
+    return requestedBase
+  }
+  if (batchSheet && projectId) {
+    const projectBatchRows = await queryAllRecords(api, batchSheet.id, { projectId })
+    return pickPredecessor(projectBatchRows, currentSnapshotBatchId, currentVersion)
+  }
+  return null
+}
+
 /**
  * Values-free diff of a snapshot batch against its immutable predecessor batch.
  * The batch id arrives from the route PATH. `targetProjectId` (STAGING) locates the MVP tables; the
  * business project used to scope the predecessor search is read from the current batch row itself (the
  * FE diff call carries no projectId), falling back to `businessProjectId` when the batch row is absent.
+ * An optional `baseSnapshotBatchId` overrides the predecessor auto-pick with a validated caller-chosen
+ * pair; when absent the original predecessor semantics are preserved unchanged.
  */
-async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, businessProjectId, snapshotBatchId, permission } = {}) {
+async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, businessProjectId, snapshotBatchId, baseSnapshotBatchId: baseOverride, permission } = {}) {
   assertAdminPermission(permission)
   const api = ensureReadOnlyRecordsApi(recordsApi)
   const prov = ensureProvisioningApi(provisioning)
   const currentSnapshotBatchId = requiredString(snapshotBatchId, 'snapshotBatchId')
   const stagingProjectId = requiredString(targetProjectId, 'targetProjectId')
+  const requestedBase = optionalString(baseOverride)
 
   const batchSheet = await findMvpSheet(prov, stagingProjectId, BATCH_OBJECT_ID)
   const lineSheet = await findMvpSheet(prov, stagingProjectId, LINE_OBJECT_ID)
   const exceptionSheet = await findMvpSheet(prov, stagingProjectId, EXCEPTION_OBJECT_ID)
 
   if (!batchSheet && !lineSheet && !exceptionSheet) {
+    // An explicit base cannot be verified against an unprovisioned substrate — fail closed instead of
+    // silently answering with the empty-diff shape.
+    if (requestedBase) {
+      throw new StockPreparationTargetProvisioningError(404, 'SNAPSHOT_DIFF_BASE_NOT_FOUND', 'base snapshot batch was not found', { field: 'baseSnapshotBatchId' })
+    }
     return {
       snapshotBatchId: currentSnapshotBatchId,
       baseSnapshotBatchId: null,
@@ -313,12 +347,12 @@ async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, busi
     }
   }
 
-  // Predecessor = highest version strictly below the current, within the same business project.
-  let baseSnapshotBatchId = null
-  if (batchSheet && projectId) {
-    const projectBatchRows = await queryAllRecords(api, batchSheet.id, { projectId })
-    baseSnapshotBatchId = pickPredecessor(projectBatchRows, currentSnapshotBatchId, currentVersion)
-  }
+  const baseSnapshotBatchId = await resolveDiffBase(api, batchSheet, {
+    currentSnapshotBatchId,
+    projectId,
+    currentVersion,
+    requestedBase,
+  })
 
   // Lines for the current + predecessor batches (never mutated; passed straight to the diff engine).
   const currentLines = lineSheet
@@ -354,15 +388,131 @@ async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, busi
   }
 }
 
+// Per-row projection whitelist: EXACTLY the engine's values-free diff-row keys. makeDiff's output is
+// already values-free (handles + sha16 fingerprints + enums), but projecting through this closed list
+// means a FUTURE engine key can never leak through this route unreviewed.
+const DIFF_ROW_KEYS = Object.freeze([
+  'diffId',
+  'diffType',
+  'reviewStatus',
+  'changeTypes',
+  'reason',
+  'rowCount',
+  'previousSnapshotLineId',
+  'currentSnapshotLineId',
+  'keyFingerprint',
+  'previousPathKeyFingerprint',
+  'currentPathKeyFingerprint',
+])
+const MAX_DIFF_ROWS = 2000
+const REVIEW_STATUS_VALUES = new Set(Object.values(REVIEW_STATUSES))
+const DIFF_TYPE_VALUES = new Set(Object.values(DIFF_TYPES))
+
+function projectDiffRow(diff) {
+  const out = {}
+  for (const key of DIFF_ROW_KEYS) {
+    const value = diff ? diff[key] : undefined
+    if (value !== undefined) out[key] = Array.isArray(value) ? value.slice() : value
+  }
+  return out
+}
+
+/**
+ * Values-free PER-ROW diff of a snapshot batch (view 2's row browse: diffType / changeTypes /
+ * reviewStatus per diff row). Same read flow + base semantics as getSnapshotDiff; each row passes the
+ * closed DIFF_ROW_KEYS projection; optional reviewStatus / diffType filters; result capped fail-closed.
+ * `heldRowCount` counts held rows over the WHOLE pair (pre-filter) so a filtered read keeps context.
+ */
+async function listSnapshotDiffRows({ recordsApi, provisioning, targetProjectId, businessProjectId, snapshotBatchId, baseSnapshotBatchId: baseOverride, reviewStatus, diffType, permission } = {}) {
+  assertAdminPermission(permission)
+  const api = ensureReadOnlyRecordsApi(recordsApi)
+  const prov = ensureProvisioningApi(provisioning)
+  const currentSnapshotBatchId = requiredString(snapshotBatchId, 'snapshotBatchId')
+  const stagingProjectId = requiredString(targetProjectId, 'targetProjectId')
+  const requestedBase = optionalString(baseOverride)
+  // Belt-and-braces enum gates (the route allowlist rejects these first with its own 400 code).
+  const reviewStatusFilter = optionalString(reviewStatus)
+  if (reviewStatusFilter && !REVIEW_STATUS_VALUES.has(reviewStatusFilter)) {
+    throw new StockPreparationTargetProvisioningError(422, 'SNAPSHOT_READS_CONFIG_INVALID', 'reviewStatus must be one of the review-status vocabulary', { field: 'reviewStatus' })
+  }
+  const diffTypeFilter = optionalString(diffType)
+  if (diffTypeFilter && !DIFF_TYPE_VALUES.has(diffTypeFilter)) {
+    throw new StockPreparationTargetProvisioningError(422, 'SNAPSHOT_READS_CONFIG_INVALID', 'diffType must be one of the diff-type vocabulary', { field: 'diffType' })
+  }
+
+  const batchSheet = await findMvpSheet(prov, stagingProjectId, BATCH_OBJECT_ID)
+  const lineSheet = await findMvpSheet(prov, stagingProjectId, LINE_OBJECT_ID)
+
+  if (!batchSheet && !lineSheet) {
+    if (requestedBase) {
+      throw new StockPreparationTargetProvisioningError(404, 'SNAPSHOT_DIFF_BASE_NOT_FOUND', 'base snapshot batch was not found', { field: 'baseSnapshotBatchId' })
+    }
+    return { snapshotBatchId: currentSnapshotBatchId, baseSnapshotBatchId: null, rowCount: 0, heldRowCount: 0, rows: [] }
+  }
+
+  let projectId = optionalString(businessProjectId)
+  let currentVersion = null
+  if (batchSheet) {
+    const currentRows = await queryAllRecords(api, batchSheet.id, { snapshotBatchId: currentSnapshotBatchId })
+    const currentBatchRow = currentRows[0] || null
+    if (currentBatchRow) {
+      projectId = optionalString(readCell(currentBatchRow, 'projectId')) || projectId
+      currentVersion = toNumber(readCell(currentBatchRow, 'snapshotVersion'))
+    }
+  }
+
+  const baseSnapshotBatchId = await resolveDiffBase(api, batchSheet, {
+    currentSnapshotBatchId,
+    projectId,
+    currentVersion,
+    requestedBase,
+  })
+
+  const currentLines = lineSheet
+    ? (await queryAllRecords(api, lineSheet.id, { snapshotBatchId: currentSnapshotBatchId })).map(recordData)
+    : []
+  const previousLines = lineSheet && baseSnapshotBatchId
+    ? (await queryAllRecords(api, lineSheet.id, { snapshotBatchId: baseSnapshotBatchId })).map(recordData)
+    : []
+
+  const plan = planBomSnapshotDiff({
+    previousSnapshotBatchId: baseSnapshotBatchId || NO_PREDECESSOR_SENTINEL,
+    currentSnapshotBatchId,
+    previousLines,
+    currentLines,
+  })
+
+  const heldRowCount = plan.diffs.filter((diff) => diff.reviewStatus === REVIEW_STATUSES.HELD).length
+  let rows = plan.diffs
+  if (reviewStatusFilter) rows = rows.filter((diff) => diff.reviewStatus === reviewStatusFilter)
+  if (diffTypeFilter) rows = rows.filter((diff) => diff.diffType === diffTypeFilter)
+  if (rows.length > MAX_DIFF_ROWS) {
+    throw new StockPreparationTargetProvisioningError(422, 'SNAPSHOT_READS_ROWS_TOO_LARGE', 'snapshot diff row read exceeded the row bound', { maxRows: MAX_DIFF_ROWS })
+  }
+
+  return {
+    snapshotBatchId: currentSnapshotBatchId,
+    baseSnapshotBatchId,
+    rowCount: rows.length,
+    heldRowCount,
+    rows: rows.map(projectDiffRow),
+  }
+}
+
 module.exports = {
   listSnapshotBatches,
   getSnapshotDiff,
+  listSnapshotDiffRows,
   BATCH_OBJECT_ID,
   LINE_OBJECT_ID,
   RUN_OBJECT_ID,
   EXCEPTION_OBJECT_ID,
   BLOCKING_EXCEPTION_SEVERITY,
   __internals: {
+    resolveDiffBase,
+    projectDiffRow,
+    DIFF_ROW_KEYS,
+    MAX_DIFF_ROWS,
     templateByRole,
     assertMvpObjectId,
     ensureReadOnlyRecordsApi,

--- a/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
@@ -277,8 +277,14 @@ function pickPredecessor(batchRows, currentSnapshotBatchId, currentVersion) {
 // Resolve the diff BASE batch id. An EXPLICIT `requestedBase` is a caller-chosen pair and must be
 // validated (differ from current -> 400; exist -> 404; same business project -> 409). Without it the
 // predecessor rule applies unchanged (highest version strictly below current, same business project).
-async function resolveDiffBase(api, batchSheet, { currentSnapshotBatchId, projectId, currentVersion, requestedBase }) {
+async function resolveDiffBase(api, batchSheet, { currentSnapshotBatchId, projectId, currentVersion, requestedBase, currentBatchRowPresent }) {
   if (requestedBase) {
+    // P2-A1 (review #4019): a caller-chosen pair is only verifiable when the DIFFED batch row exists.
+    // Without this gate a ghost/stale current id skips the project-mismatch check entirely (projectId
+    // is empty) and another project's rows would surface as a fabricated all-removed diff.
+    if (!currentBatchRowPresent) {
+      throw new StockPreparationTargetProvisioningError(404, 'SNAPSHOT_DIFF_BASE_NOT_FOUND', 'a caller-chosen base pair requires an existing diffed batch', { field: 'snapshotBatchId' })
+    }
     if (requestedBase === currentSnapshotBatchId) {
       throw new StockPreparationTargetProvisioningError(400, 'SNAPSHOT_DIFF_BASE_INVALID', 'baseSnapshotBatchId must differ from the diffed batch', { field: 'baseSnapshotBatchId' })
     }
@@ -352,6 +358,7 @@ async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, busi
     projectId,
     currentVersion,
     requestedBase,
+    currentBatchRowPresent: Boolean(currentBatchRow),
   })
 
   // Lines for the current + predecessor batches (never mutated; passed straight to the diff engine).
@@ -452,10 +459,12 @@ async function listSnapshotDiffRows({ recordsApi, provisioning, targetProjectId,
 
   let projectId = optionalString(businessProjectId)
   let currentVersion = null
+  let currentBatchRowPresent = false
   if (batchSheet) {
     const currentRows = await queryAllRecords(api, batchSheet.id, { snapshotBatchId: currentSnapshotBatchId })
     const currentBatchRow = currentRows[0] || null
     if (currentBatchRow) {
+      currentBatchRowPresent = true
       projectId = optionalString(readCell(currentBatchRow, 'projectId')) || projectId
       currentVersion = toNumber(readCell(currentBatchRow, 'snapshotVersion'))
     }
@@ -466,6 +475,7 @@ async function listSnapshotDiffRows({ recordsApi, provisioning, targetProjectId,
     projectId,
     currentVersion,
     requestedBase,
+    currentBatchRowPresent,
   })
 
   const currentLines = lineSheet


### PR DESCRIPTION
## What

Wave-3 read half (stacked on #4015 — retarget to main after it lands):

1. **`BLOCKING_CHANGE_TYPES` export** from `stock-preparation-snapshot-diff.cjs` — the single held/ready policy source; R2 / W4 generation / FE consume the array instead of forking policy.
2. **R1 — caller-chosen diff base**: `GET …/snapshot-batches/:id/diff?baseSnapshotBatchId=` — validated pair (unknown → 404 `SNAPSHOT_DIFF_BASE_NOT_FOUND`, cross-project → 409 `SNAPSHOT_DIFF_BASE_PROJECT_MISMATCH`, self → 400 `SNAPSHOT_DIFF_BASE_INVALID`); absent ⇒ #4002 predecessor auto-pick **byte-identical** (existing tests lock the regression).
3. **R2 — `GET …/snapshot-batches/:id/diff/rows`**: per-row `diffType`/`changeTypes`/`reviewStatus` browse for view 2. Closed **11-key whitelist projection** (a future engine key can never leak unreviewed), optional enum filters (route 400 + module belt-and-braces 422), `heldRowCount` pre-filter, capped fail-closed at 2000 rows → 422. Separate query allowlist Sets per route — DIFF's new key does not widen LIST.

queryRecords-only (read module untouched in write capability), admin-gated, values-free (planted-secret scans).

## Tests

plugin-integration-core tests run in CI via `integration-guard.yml` (`pnpm --filter plugin-integration-core test`). Local re-run for convenience:

```bash
cd plugins/plugin-integration-core
npm run test:stock-preparation-snapshot-reads   # 12 cases (3 new)
npm run test:stock-preparation-snapshot-diff    # + export/policy guards
npm test                                        # full chain, green
```

Part of the W3 ladder (#4015 = W3b confirm writes; W3c confirm reads follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
