### PR TITLE
test(multitable): 4c-3 absorption-audit NIT-1/NIT-2/NIT-5b — drift-tripwire + duplicate-triple goldens

### DIFF
--- a/packages/core-backend/src/multitable/inbound-link-replay.ts
+++ b/packages/core-backend/src/multitable/inbound-link-replay.ts
@@ -151,8 +151,24 @@ export async function replayInboundLinks(
 
   const replayed = ins.rowCount ?? 0
   const total = replayed + Object.values(skipped).reduce((a, b) => a + b, 0)
-  // Diagnostic/INSERT drift tripwire: same predicates ⇒ same count. Never throw (per-edge tolerance
-  // beats a failed restore) — but make drift loudly visible to tests via the returned numbers.
+  // Diagnostic/INSERT drift tripwire — HONEST SEMANTICS, not a correctness net (do not extend this to
+  // "fix" the count; it is deliberately a same-day characterization, see NIT-1 in the absorption audit):
+  // the diagnostic query above and the write below are two SEPARATE statements, each its own READ
+  // COMMITTED snapshot. The caller's transaction only holds a row lock on the deleted record's OWN
+  // trash row (serializing concurrent restores of THAT record) — it never locks the neighbour or field
+  // rows this function reads. So a genuinely concurrent write to a neighbour's cell (or a field
+  // retype/mirror flip) landing in the gap between the two statements can flip a row's classification:
+  // the diagnostic counts it one way, the write — evaluating every precondition fresh, at its own later
+  // instant — resolves it another way. `replayed` (this statement's actual row count) is always the
+  // truth for what got written; when it disagrees with the diagnostic's `replayable` count, the
+  // shortfall is folded into `alreadyPresent` as a catch-all "something changed between the two
+  // statements" bucket — it is a best-effort label, not necessarily the row's real disqualifying
+  // precondition. This can never cause a wrong WRITE (the write's own predicates are re-checked in that
+  // same statement against the then-current data, so it can never insert a row a live precondition
+  // disqualifies, and the NOT EXISTS guard still prevents any duplicate) — it only means the returned
+  // `skipped` breakdown, and `total` (already computed above from the pre-fold skip counts, and not
+  // recomputed after this adjustment), are advisory diagnostics in this narrow race window, not an
+  // exact ledger of every tombstone row's fate.
   if (replayed !== replayable) {
     skipped.alreadyPresent += Math.max(0, replayable - replayed)
   }

--- a/packages/core-backend/src/multitable/tombstone-capture.ts
+++ b/packages/core-backend/src/multitable/tombstone-capture.ts
@@ -1,6 +1,6 @@
 /**
  * 4c-2 forward tombstone-capture (design-lock 2026-07-07, #3809 + #3830 correction; owner-ratified
- * 2026-07-08). Shared capture helpers for the two ratified capture points:
+ * 2026-07-08). Shared capture helpers for the three ratified capture points:
  *   1. `dropFieldCascade` (univer-meta.ts) — column values + that field's link edges + auto-number
  *      sequence state, captured into `meta_field_value_tombstones` / `meta_link_tombstones`
  *      (reason='field_delete').
@@ -8,8 +8,13 @@
  *      `meta_link_tombstones` (reason='record_delete'). Outbound edges are already covered by
  *      `meta_records_trash` (the trashed row's `data` still carries the link-field arrays and
  *      `restoreRecord` replays them) — capturing them again here would be redundant.
+ *   3. The point-in-time RESET route's inline per-candidate record delete (`univer-meta.ts`, added by
+ *      4c-3 §7/D-3) — the second surface that can hard-delete a record and later resurrect it. Same
+ *      shape as point 2 (INBOUND edges only, `reason='record_delete'`), anchored to its own
+ *      pre-generated delete-revision id so a later resurrect of that candidate can name this
+ *      deletion's tombstones the same way `deleteRecord`'s restore does.
  *
- * Both capture points are same-txn, placed BEFORE the destructive statement(s) they shadow, and use a
+ * All three capture points are same-txn, placed BEFORE the destructive statement(s) they shadow, and use a
  * single batched `INSERT ... SELECT` (never a per-row round trip). Gated by
  * `MULTITABLE_TOMBSTONE_CAPTURE_ENABLED` (default OFF — off means today's behavior byte-for-byte,
  * §0/C1/C3). When on, a capture whose row count would exceed `MULTITABLE_TOMBSTONE_CAPTURE_MAX_ROWS`

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
@@ -15,6 +15,18 @@
  * both preconditions were ALREADY correctly implemented (precondition 2's `JOIN meta_records n` and
  * the `recoverable: replay.total > 0` computation in record-service.ts) but had no dedicated golden.
  * See `/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`.
+ *
+ * RB15/RB16 (2026-07-10 NIT-1/NIT-2 goldens — test + comment-precision only, no product behaviour
+ * changed; see `/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`):
+ *   RB15 pins the diag/INSERT drift tripwire's CURRENT honest semantics (a same-day characterization,
+ *   not a redesign) — calls `replayInboundLinks` directly with an instrumented query function that
+ *   injects a genuinely concurrent neighbour-side write into the gap between the function's two
+ *   statements, then asserts what IS guaranteed (no over-insert; `replayed` matches the DB) alongside
+ *   the current, imprecise skip-bucket fold this drift produces.
+ *   RB16 pins the single-statement write's NOT-EXISTS boundary: it cannot see sibling rows the SAME
+ *   statement is about to add, so pre-existing duplicate tombstone triples under one anchor (itself
+ *   only possible because neither `meta_links` nor `meta_link_tombstones` has a unique constraint on
+ *   the edge triple) replay as a faithful double, not a dedup.
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
@@ -22,6 +34,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { replayInboundLinks } from '../../src/multitable/inbound-link-replay'
 import {
   sweepLinkTombstoneRetention,
   type MetaRevisionRetentionConfig,
@@ -329,5 +342,78 @@ describeIfDatabase('4c-3 — record-undelete inbound-edge replay (real DB, RB ma
     expect(res.status).toBe(200)
     expect(res.body?.data?.inbound).toMatchObject({ replayed: 0, recoverable: false }) // honest, not fabricated
     expect(await edgeCount(F, N, R)).toBe(0)
+  })
+
+  test('RB15 diag/INSERT drift tripwire: a concurrent neighbour-side write between the two statements folds into alreadyPresent — no over-insert, replayed always matches the DB (counts are advisory, not exact)', async () => {
+    const { F, R, N } = await fixture('rb15')
+    expect((await httpDelete(R)).status).toBe(200)
+    const trashRow = (await q('SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1', [R])).rows[0] as { delete_revision_id: string }
+    const anchor = trashRow.delete_revision_id
+    expect(anchor).toBeTruthy()
+
+    // Instrumented query function: runs every statement normally, but the FIRST time it sees the
+    // diagnostic query (identified by its `GROUP BY 1`, unique among this function's two statements),
+    // it performs a genuinely separate, already-committed write — the neighbour un-declares the link —
+    // before returning. That write lands strictly BETWEEN the diagnostic statement and the one that
+    // follows, reproducing the race the tripwire comment now describes, deterministically.
+    let racedOnce = false
+    const racingQuery = async (sql: string, params?: unknown[]) => {
+      const res = await q(sql, params)
+      if (!racedOnce && sql.includes('GROUP BY 1')) {
+        racedOnce = true
+        await q(`UPDATE meta_records SET data = jsonb_set(data, $2, '[]'::jsonb) WHERE id = $1`, [N, `{${F}}`])
+      }
+      return res
+    }
+
+    const result = await replayInboundLinks(racingQuery, anchor)
+    expect(racedOnce).toBe(true) // sanity: the injected race actually fired
+
+    // GUARANTEED (what this NIT pins as safe): the write statement re-evaluates every precondition
+    // fresh, so the now-declined edge is never inserted — replayed matches DB reality exactly, no
+    // over-insert of stale-consent data.
+    expect(result.replayed).toBe(0)
+    expect(await edgeCount(F, N, R)).toBe(0)
+    // CURRENT (imprecise, pinned as-is — not redesigned): the diagnostic classified this row
+    // 'replayable' a moment before the race; the mismatch against the write's actual (0) count folds
+    // into `alreadyPresent`, not the row's true reason (`neighborDeclined`). `total` is computed BEFORE
+    // this fold and is not recomputed after — so it stays 0 here, undercounting the 1 real tombstone
+    // row for this anchor. Both are advisory diagnostics in this narrow race window, not a data-loss bug.
+    expect(result.skipped.alreadyPresent).toBe(1)
+    expect(result.skipped.neighborDeclined).toBe(0)
+    expect(result.total).toBe(0)
+  })
+
+  test('RB16 duplicate tombstone triples under one anchor: NOT EXISTS cannot see the sibling row the SAME statement is about to add — a pre-existing duplicate edge replays as a faithful double, not a dedup', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const F = mkFieldId('rb16')
+    await insertField(SHEET_B, F)
+    const R = mkRecordId('rb16r')
+    await insertRecord(SHEET_A, R, {})
+    const N = mkRecordId('rb16n')
+    await insertRecord(SHEET_B, N, { [F]: [R] })
+    // Pre-existing DUPLICATE edge: the edge triple carries no unique constraint on either table (design-
+    // lock §2/§4 boundary note), so two identical rows CAN already coexist before any delete happens —
+    // e.g. a legacy double-write. Both get captured as their own tombstone row on delete.
+    await insertLink(F, N, R)
+    await insertLink(F, N, R)
+    expect(await edgeCount(F, N, R)).toBe(2)
+
+    expect((await httpDelete(R)).status).toBe(200)
+    const tombstoneRows = await q(
+      'SELECT 1 FROM meta_link_tombstones WHERE record_id = $1 AND field_id = $2 AND foreign_record_id = $3',
+      [N, F, R],
+    )
+    expect(tombstoneRows.rows).toHaveLength(2) // both duplicate edges captured, one tombstone row each
+    expect(await edgeCount(F, N, R)).toBe(0) // both destroyed by the delete
+
+    const res = await httpRestore(R)
+    expect(res.status).toBe(200)
+    // The boundary being pinned: the write statement's guard only sees rows committed before THIS
+    // statement began — never the sibling row this same statement is concurrently adding — so both
+    // duplicate tombstones independently pass the guard and BOTH get inserted. This is a faithful
+    // replay of a pre-existing duplicate, not new duplication invented by restore.
+    expect(res.body?.data?.inbound?.replayed).toBe(2)
+    expect(await edgeCount(F, N, R)).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary

Closes the remaining NIT-1 / NIT-2 / NIT-5(b) items from the PR #3975 (4c-3 record-undelete inbound-edge replay) absorption audit (`/tmp/pr3975-4c3-absorption-audit-claude-20260709.md`). PR #3985 already closed P3-1/P3-2/P3-3/NIT-3/NIT-4 and explicitly parked NIT-1/NIT-2/NIT-5 as "outside this round's P3/NIT golden list" — this PR closes those three. **Tests + comment-wording only, zero behaviour diffs.**

Baseline = `origin/main` (post #3985, `17bc0f60e`). Fresh one-off `postgres:16-alpine` docker container (port 55980, migrated + removed after use) — real-DB per house rule (new DB, single run).

## Per-item mapping

### NIT-1 (drift-tripwire precision) — `inbound-link-replay.ts:154-158`

The audit's concern: `replayInboundLinks` issues two separate statements (a diagnostic `SELECT` classifying every tombstone row by its first failing precondition, then the write). Under READ COMMITTED, each is its own snapshot; a genuinely concurrent write to a neighbour's cell (or a field retype/mirror flip) landing in the gap can make the diagnostic's classification stale by the time the write runs. The existing code already folds any such shortfall into `skipped.alreadyPresent` — the audit asked to pin this **as-is** (not redesign it) with an honest comment and a golden for what IS guaranteed.

- **Comment reword** (`inbound-link-replay.ts:154-169`): explains precisely *why* drift is possible (two statements, only the deleted record's own trash row is locked — never the neighbour/field rows this function reads), what the fold does (best-effort catch-all label, not necessarily the row's true reason), and what is/isn't guaranteed. Also corrects a subtlety I found while writing the golden: `total` is computed **before** the tripwire's fold runs and is never recomputed after, so in the drift window `total` can under-count the anchor's real tombstone count — the reworded comment says so explicitly instead of implying `total == replayed + sum(skipped)` always holds.
- **Golden — RB15** (`multitable-undelete-inbound-replay-realdb.test.ts`): calls `replayInboundLinks` directly with an instrumented query function that, the first time it sees the diagnostic query (matched on its unique `GROUP BY 1`), performs a real, separately-committed write — the neighbour un-declares the link — before the write statement runs. Asserts the **guaranteed** part (no over-insert: `replayed === 0`, `edgeCount === 0`, matching DB reality exactly) and the **current, imprecise** part (`skipped.alreadyPresent === 1`, not `neighborDeclined`; `total === 0`, under-counting the 1 real tombstone row) — pinned honestly, not redesigned.

### NIT-2 (single-statement NOT EXISTS boundary) — golden

The write is a single `INSERT ... SELECT ... NOT EXISTS (...)`. Verified empirically (throwaway psql scratch test, two identical source rows) that this construct's `NOT EXISTS` guard cannot see a sibling row the *same* statement is about to add — both rows pass independently. Applied to production: if a duplicate tombstone triple exists under one anchor (possible because neither `meta_links` nor `meta_link_tombstones` has a unique constraint on the edge triple — itself only reachable via a pre-existing duplicate edge, e.g. a legacy double-write), replay double-inserts.

- **Golden — RB16**: seeds two identical `meta_links` rows (F, N, R) before deleting R — `deleteRecord`'s inbound capture is a straight per-row `SELECT` off `meta_links`, so it captures both as separate tombstone rows (asserted: 2 tombstone rows). Restoring R replays both independently, producing `replayed === 2` and `edgeCount === 2` — a faithful double-replay of the pre-existing duplicate, not new duplication invented by restore.

### NIT-5 — two independent halves

- **(a) `listDeletedRecords` `SELECT *`** — **deliberately SKIPPED.** Narrowing the column list is a code-change judgment carrying behaviour-diff risk (the audit itself calls it "schema-tolerant but pulls all columns" — the current `SELECT *` is intentional, per the adjacent code comment, for forward-compat with `delete_revision_id` across the migration boundary). Out of scope for a tests+comments-only lane. Noted here for the record, not touched.
- **(b) `tombstone-capture.ts:47-49` (module doc-comment)** — **FIXED.** The header enumerated only 2 "ratified capture points" (`dropFieldCascade` field-delete, `deleteRecord` record-delete) but a 3rd was already live and undocumented: the PIT-reset route's inline per-candidate delete (`univer-meta.ts` ~10461-10471, added by 4c-3 §7/D-3), which calls the same `insertInboundLinkTombstones` helper anchored to its own pre-generated delete-revision id. Added as enumeration point 3; updated "two"→"three" / "Both"→"All three" in the surrounding prose. No SQL-literal text was added to any comment (checked with a grep for `insert into meta_|update meta_|delete from meta_` across the diff — zero hits).

## Mutation evidence (house discipline — neuter → exactly the new golden reds → revert)

| Mutation | Target golden | Result |
|---|---|---|
| Removed the tripwire's `if (replayed !== replayable) { skipped.alreadyPresent += ... }` block entirely | RB15 | **RED** (`skipped.alreadyPresent` 1→0) — all other 15 tests (incl. RB1-RB14, RB16) stayed green |
| Reverted | — | full suite 16/16 green again (`diff` against pre-mutation backup: identical) |
| Changed the write's `SELECT` to `SELECT DISTINCT ON (field_id, record_id, foreign_record_id) ... ORDER BY ...` (added a dedup — there is no existing guard to *remove* for NIT-2, since removing NOT EXISTS still yields 2 identical rows; the discriminating mutation is adding dedup) | RB16 | **RED** (`edgeCount`/`replayed` 2→1) — all other 15 tests (incl. RB15) stayed green |
| Reverted | — | full suite 16/16 green again (`diff` against pre-mutation backup: identical) |

Both mutations were run against the SAME fresh docker postgres, full-file rerun each time (not just the target test), confirming precise, non-overlapping discrimination.

## Verification

- realdb (fresh one-off `postgres:16-alpine`, migrated clean, port 55980, removed after use):
  - `multitable-undelete-inbound-replay-realdb.test.ts`: **16/16** (14 pre-existing + RB15 + RB16, all green)
  - Neighbour real-DB files run together (fixture-collision / shared-bundle check per house rule): `multitable-undelete-pit-inbound-replay-realdb` (4), `multitable-undelete-inbound-resurrect-realdb` (4), `multitable-reset-pit-inbound-capture-realdb` (3), `multitable-record-reconstructor-realdb` (8) — **35/35 total**, no collisions.
- `tsc --noEmit`: clean.
- rank-8 structural guards (`multitable-record-lock-guard.guard.test.ts`, `multitable-cross-base-write-guard.guard.test.ts`): **9/9** green (no new `meta_records` UPDATE/DELETE sites introduced — these two edits touch only `meta_links`/`meta_link_tombstones` prose and a test file).
- `git diff origin/main...HEAD -- packages/core-backend/src`: exactly 2 files, both comment-only (`inbound-link-replay.ts` tripwire reword, `tombstone-capture.ts` capture-point enumeration) — no production logic changed.
- Ran the touched real-DB file exactly the way `plugin-tests.yml` does (`vitest --config vitest.integration.config.ts run <files>`, `fileParallelism: false`), against a genuinely fresh database (not a shared/dirty one).

## Not covered / honestly out of scope

- **NIT-5(a)** (`listDeletedRecords` `SELECT *` narrowing) — skipped by design (see above); code-change judgment carrying behaviour-diff risk, not a tests/comments fix.
- No other NITs/P3s were touched — P3-1/P3-2/P3-3/NIT-3/NIT-4 were already closed by #3985.

## Test plan

- [x] RB15/RB16 realdb goldens green
- [x] Mutation fail-first evidence for both new goldens (neuter → red → revert → green)
- [x] Neighbour real-DB files green together (no fixture collision)
- [x] `tsc --noEmit` clean
- [x] rank-8 guards green
- [x] Zero production-source behaviour diff (comment-only)
- [ ] Not merging / not arming auto-merge — main session reviews and lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)