### PR TITLE
feat(web): stock-prep MVP views 3+4 — material-mapping + unit-conversion confirmation [stacked on #4021]

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -103,6 +103,8 @@ on:
       - 'apps/web/tests/StockPreparationWorkspace.spec.ts'
       - 'apps/web/tests/StockPreparationProjectWorkspaceView.spec.ts'
       - 'apps/web/tests/StockPreparationSnapshotDiffView.spec.ts'
+      - 'apps/web/tests/StockPreparationMappingConfirmView.spec.ts'
+      - 'apps/web/tests/StockPreparationUnitConfirmView.spec.ts'
       - '.github/workflows/integration-guard.yml'
   push:
     branches: [main]
@@ -187,6 +189,8 @@ on:
       - 'apps/web/tests/StockPreparationWorkspace.spec.ts'
       - 'apps/web/tests/StockPreparationProjectWorkspaceView.spec.ts'
       - 'apps/web/tests/StockPreparationSnapshotDiffView.spec.ts'
+      - 'apps/web/tests/StockPreparationMappingConfirmView.spec.ts'
+      - 'apps/web/tests/StockPreparationUnitConfirmView.spec.ts'
       - '.github/workflows/integration-guard.yml'
 
 jobs:
@@ -239,4 +243,4 @@ jobs:
       # Consolidated here into the SINGLE unioned list (verified green on both Node 20 and this repo's
       # default Node before landing) — do not reintroduce a second `run:` key; add new specs to this one.
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck IntegrationOptionSetsStructuredEditor optionSetsStructured integrationWorkbench MetaIntegrationFieldRuleAuthoring readSourceTemplateCatalog IntegrationTemplateCatalogPicker StockPreparationWorkspace StockPreparationProjectWorkspaceView StockPreparationSnapshotDiffView --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck IntegrationOptionSetsStructuredEditor optionSetsStructured integrationWorkbench MetaIntegrationFieldRuleAuthoring readSourceTemplateCatalog IntegrationTemplateCatalogPicker StockPreparationWorkspace StockPreparationProjectWorkspaceView StockPreparationSnapshotDiffView StockPreparationMappingConfirmView StockPreparationUnitConfirmView --reporter=dot

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationMappingConfirmView.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationMappingConfirmView.vue
@@ -1,0 +1,725 @@
+<template>
+  <div class="sp-map" data-testid="stock-prep-mapping-view">
+    <!-- No project selected: this slice has no project picker, so we simply ask for one. -->
+    <p
+      v-if="!hasProject"
+      class="sp-map__state sp-map__state--muted"
+      data-testid="stock-prep-mapping-no-project"
+      role="status"
+    >
+      {{ bi('请选择一个项目以查看物料映射确认队列。', 'Select a project to see the material-mapping confirmation queue.') }}
+    </p>
+
+    <!-- Loading: values-free spinner copy only. -->
+    <p
+      v-else-if="loading"
+      class="sp-map__state sp-map__state--muted"
+      data-testid="stock-prep-mapping-loading"
+      role="status"
+    >
+      {{ bi('正在加载映射确认状态…', 'Loading mapping confirmation state…') }}
+    </p>
+
+    <!-- Error / endpoint-not-ready (GET rejects or 404s): neutral, never the raw body. -->
+    <p
+      v-else-if="errored"
+      class="sp-map__state sp-map__state--muted"
+      data-testid="stock-prep-mapping-error"
+      role="status"
+    >
+      {{ bi('同步后端尚未就绪,稍后再试。', 'Backend read not ready yet — try again later.') }}
+    </p>
+
+    <div v-else-if="summary && queue" class="sp-map__overview" data-testid="stock-prep-mapping-overview">
+      <!-- Summary header card: the five values-free summary indicators. -->
+      <header class="sp-map__summary" data-testid="stock-prep-mapping-summary">
+        <div class="sp-map__metric" data-testid="stock-prep-mapping-metric" data-kind="total">
+          <span class="sp-map__metric-label">{{ bi('映射总数', 'Total mappings') }}</span>
+          <span class="sp-map__metric-value">{{ summary.totalMappingCount }}</span>
+        </div>
+        <div class="sp-map__metric" data-testid="stock-prep-mapping-metric" data-kind="active">
+          <span class="sp-map__metric-label">{{ bi('生效映射', 'Active mappings') }}</span>
+          <span class="sp-map__metric-value">{{ summary.activeMappingCount }}</span>
+        </div>
+        <div class="sp-map__metric" data-testid="stock-prep-mapping-metric" data-kind="pending-confirm">
+          <span class="sp-map__metric-label">{{ bi('待人工确认', 'Pending confirmation') }}</span>
+          <span class="sp-map__metric-value">{{ summary.pendingConfirmCount }}</span>
+        </div>
+        <div class="sp-map__metric sp-map__metric--chips" data-testid="stock-prep-mapping-metric" data-kind="match-status">
+          <span class="sp-map__metric-label">{{ bi('按匹配状态', 'By match status') }}</span>
+          <span class="sp-map__chips">
+            <span
+              v-for="entry in summaryStatusEntries"
+              :key="entry.key"
+              class="sp-map__chip"
+              data-testid="stock-prep-mapping-status-count"
+              :data-status="entry.key"
+            >{{ entry.key }}: {{ entry.count }}</span>
+          </span>
+        </div>
+        <div class="sp-map__metric sp-map__metric--chips" data-testid="stock-prep-mapping-metric" data-kind="version-policy">
+          <span class="sp-map__metric-label">{{ bi('按版本策略', 'By version policy') }}</span>
+          <span class="sp-map__chips">
+            <span
+              v-for="entry in summaryPolicyEntries"
+              :key="entry.key"
+              class="sp-map__chip"
+              data-testid="stock-prep-mapping-policy-count"
+              :data-policy="entry.key"
+            >{{ entry.key }}: {{ entry.count }}</span>
+          </span>
+        </div>
+      </header>
+
+      <!-- Candidate sync: feeds the review queue. defaultVersionPolicy is REQUIRED with NO default
+           (OD2) — the sync entry stays disabled until the operator picks one. -->
+      <div class="sp-map__sync" data-testid="stock-prep-mapping-sync-block">
+        <label class="sp-map__field">
+          <span class="sp-map__field-label">{{ bi('候选默认版本策略(必选)', 'Default version policy (required)') }}</span>
+          <select v-model="syncPolicy" data-testid="stock-prep-mapping-sync-policy">
+            <option value="" disabled>{{ bi('请选择版本策略', 'Select a version policy') }}</option>
+            <option v-for="policy in versionPolicies" :key="policy" :value="policy">{{ policy }}</option>
+          </select>
+        </label>
+        <button
+          type="button"
+          class="sp-map__action"
+          data-testid="stock-prep-mapping-sync"
+          :disabled="!syncPolicy || busy"
+          @click="runCandidateSync"
+        >
+          {{ bi('同步候选', 'Sync candidates') }}
+        </button>
+        <span v-if="syncResult" class="sp-map__note" data-testid="stock-prep-mapping-sync-result">
+          {{ bi('同步完成', 'Sync done') }}: {{ syncResult.mode }} · {{ bi('新建', 'created') }} {{ syncResult.created.mappings }}
+        </span>
+      </div>
+
+      <!-- Row-action feedback (values-free: clamped code / field NAME / mode enums only). -->
+      <p v-if="actionNotice" class="sp-map__state sp-map__state--ok" data-testid="stock-prep-mapping-action-notice">
+        {{ bi('操作完成', 'Action done') }}: {{ actionNotice.mode }}
+        <code v-if="actionNotice.handle" class="sp-map__handle">{{ actionNotice.handle }}</code>
+      </p>
+      <p v-if="actionError" class="sp-map__state sp-map__state--warn" data-testid="stock-prep-mapping-action-error" role="alert">
+        {{ bi('操作失败', 'Action failed') }} ({{ actionError.code }}<template v-if="actionError.field">/{{ actionError.field }}</template>)
+      </p>
+
+      <!-- Review queue: matchStatus filter + values-free candidate rows. -->
+      <div class="sp-map__queue-head">
+        <span class="sp-map__queue-count" data-testid="stock-prep-mapping-queue-count">
+          {{ bi('候选行', 'Candidate rows') }}: {{ queue.rowCount }}
+        </span>
+        <label class="sp-map__field sp-map__field--inline">
+          <span class="sp-map__field-label">{{ bi('匹配状态过滤', 'Match-status filter') }}</span>
+          <select v-model="statusFilter" data-testid="stock-prep-mapping-filter">
+            <option value="">{{ bi('全部', 'all') }}</option>
+            <option v-for="status in matchStatuses" :key="status" :value="status">{{ status }}</option>
+          </select>
+        </label>
+      </div>
+
+      <p v-if="queue.rowCount === 0" class="sp-map__state sp-map__state--muted" data-testid="stock-prep-mapping-empty">
+        {{ bi('当前无候选映射行。', 'No candidate mapping rows.') }}
+      </p>
+      <div v-else class="sp-map__table-wrap">
+        <table class="sp-map__table" data-testid="stock-prep-mapping-queue">
+          <thead>
+            <tr>
+              <th scope="col">{{ bi('映射标识', 'Mapping handle') }}</th>
+              <th scope="col">{{ bi('匹配状态', 'Match status') }}</th>
+              <th scope="col">{{ bi('匹配方法', 'Match method') }}</th>
+              <th scope="col">{{ bi('置信度', 'Confidence') }}</th>
+              <th scope="col">{{ bi('版本策略', 'Version policy') }}</th>
+              <th scope="col">{{ bi('ERP 目标齐备', 'ERP target') }}</th>
+              <th scope="col">{{ bi('PLM 版本', 'PLM version') }}</th>
+              <th scope="col">{{ bi('已确认', 'Confirmed') }}</th>
+              <th scope="col" class="sp-map__col-action">{{ bi('操作', 'Actions') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(row, index) in queue.rows"
+              :key="row.mappingId ?? `row-${index}`"
+              class="sp-map__row"
+              data-testid="stock-prep-mapping-row"
+            >
+              <td><code class="sp-map__handle" data-testid="stock-prep-mapping-row-handle">{{ row.mappingId ?? '—' }}</code></td>
+              <td>
+                <span class="sp-map__badge" data-testid="stock-prep-mapping-row-status" :data-status="row.matchStatus">
+                  {{ row.matchStatus }}
+                </span>
+              </td>
+              <td data-testid="stock-prep-mapping-row-method">{{ row.matchMethod ?? '—' }}</td>
+              <td class="sp-map__num" data-testid="stock-prep-mapping-row-confidence">{{ row.confidence ?? '—' }}</td>
+              <td data-testid="stock-prep-mapping-row-policy">{{ row.versionPolicy }}</td>
+              <td data-testid="stock-prep-mapping-row-erp-target" :data-flag="String(row.hasErpTarget)">
+                {{ row.hasErpTarget ? bi('齐备', 'complete') : bi('缺失', 'missing') }}
+              </td>
+              <td data-testid="stock-prep-mapping-row-version-present" :data-flag="String(row.plmVersionPresent)">
+                {{ row.plmVersionPresent ? bi('有', 'present') : bi('无', 'absent') }}
+              </td>
+              <td data-testid="stock-prep-mapping-row-confirmed" :data-flag="String(row.confirmed)">
+                {{ row.confirmed ? bi('已确认', 'confirmed') : bi('未确认', 'unconfirmed') }}
+              </td>
+              <td class="sp-map__col-action">
+                <!-- Confirm (mappingId mode): only a row with BOTH ERP identifiers is confirmable —
+                     the server 409s otherwise (a poisoned matched row would block generation). -->
+                <button
+                  type="button"
+                  class="sp-map__action"
+                  data-testid="stock-prep-mapping-row-confirm"
+                  :disabled="!row.hasErpTarget || !row.mappingId || busy"
+                  @click="confirmRow(row)"
+                >
+                  {{ bi('确认', 'Confirm') }}
+                </button>
+                <button
+                  type="button"
+                  class="sp-map__action sp-map__action--muted"
+                  data-testid="stock-prep-mapping-row-retire"
+                  :disabled="!row.mappingId || busy"
+                  @click="retireRow(row)"
+                >
+                  {{ bi('退役', 'Retire') }}
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Manual create-confirm form (create mode): fully operator-specified mapping. Client
+           validation MIRRORS the server rules, but the server's {field} error stays authoritative. -->
+      <form class="sp-map__form" data-testid="stock-prep-mapping-create-form" @submit.prevent="submitCreate">
+        <h3 class="sp-map__form-title">{{ bi('手工新建已确认映射', 'Create a confirmed mapping manually') }}</h3>
+        <div class="sp-map__form-grid">
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('PLM 图号(必填)', 'PLM drawing no (required)') }}</span>
+            <input v-model.trim="form.plmDrawingNo" type="text" data-testid="stock-prep-mapping-form-drawing" />
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('PLM 版本', 'PLM version') }}</span>
+            <input v-model.trim="form.plmVersion" type="text" data-testid="stock-prep-mapping-form-version" />
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('PLM 物料名称', 'PLM material name') }}</span>
+            <input v-model.trim="form.plmMaterialName" type="text" data-testid="stock-prep-mapping-form-name" />
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('PLM 规格', 'PLM spec') }}</span>
+            <input v-model.trim="form.plmSpec" type="text" data-testid="stock-prep-mapping-form-spec" />
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('ERP 物料编码(必填)', 'ERP material code (required)') }}</span>
+            <input v-model.trim="form.erpMaterialCode" type="text" data-testid="stock-prep-mapping-form-erp-code" />
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('ERP 内部 ID(必填)', 'ERP internal id (required)') }}</span>
+            <input v-model.trim="form.erpMaterialInternalId" type="text" data-testid="stock-prep-mapping-form-erp-internal" />
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('ERP 物料名称', 'ERP material name') }}</span>
+            <input v-model.trim="form.erpMaterialName" type="text" data-testid="stock-prep-mapping-form-erp-name" />
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('ERP 规格', 'ERP spec') }}</span>
+            <input v-model.trim="form.erpSpec" type="text" data-testid="stock-prep-mapping-form-erp-spec" />
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('版本策略(必选)', 'Version policy (required)') }}</span>
+            <select v-model="form.versionPolicy" data-testid="stock-prep-mapping-form-policy">
+              <option value="" disabled>{{ bi('请选择版本策略', 'Select a version policy') }}</option>
+              <option v-for="policy in versionPolicies" :key="policy" :value="policy">{{ policy }}</option>
+            </select>
+          </label>
+          <label class="sp-map__field">
+            <span class="sp-map__field-label">{{ bi('备注', 'Notes') }}</span>
+            <input v-model.trim="form.notes" type="text" data-testid="stock-prep-mapping-form-notes" />
+          </label>
+        </div>
+        <!-- Field error: the offending field NAME only — never a submitted value. -->
+        <p v-if="formErrorField" class="sp-map__state sp-map__state--warn" data-testid="stock-prep-mapping-form-error" role="alert">
+          {{ bi('字段无效', 'Invalid field') }}: {{ formErrorField }}
+        </p>
+        <button type="submit" class="sp-map__action" data-testid="stock-prep-mapping-form-submit" :disabled="busy">
+          {{ bi('新建并确认', 'Create confirmed') }}
+        </button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md),
+// Frontend MVP view 3: MATERIAL MAPPING CONFIRMATION, rendered inside the workspace shell's third
+// tab. Reads = W3c confirm reads (summary + review queue); writes = W3b human confirm writes
+// (candidate sync / confirm XOR modes / retire) — all MULTITABLE-INTERNAL, no external ERP/K3 write.
+//
+// VALUES-FREE: the template reads a fixed whitelist of fields — counts, status/method/policy enums,
+// booleans, confidence scores, and the sha16 mappingId handle. It never renders a PLM drawing
+// number, material name, spec, or ERP identifier FROM the server (the read shapes carry none), and
+// error surfaces render only the clamped code / field NAME. Operator-entered form values flow only
+// UPWARD through the closed create-mode allowlist; confirmedBy / confirmedAt never enter any body.
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useLocale } from '../../../composables/useLocale'
+import type { IntegrationScope } from '../../../services/integration/workbench'
+import { StockPreparationConfirmApiError } from '../../../services/integration/stockPreparation/confirmApi'
+import {
+  STOCK_PREPARATION_MATCH_STATUSES,
+  STOCK_PREPARATION_VERSION_POLICIES,
+  confirmStockPreparationMaterialMapping,
+  getStockPreparationMaterialMappingSummary,
+  listStockPreparationMaterialMappingCandidates,
+  retireStockPreparationMaterialMapping,
+  syncStockPreparationMaterialMappingCandidates,
+  type StockPreparationMaterialMappingCandidateList,
+  type StockPreparationMaterialMappingCandidateRow,
+  type StockPreparationMaterialMappingDraft,
+  type StockPreparationMaterialMappingSummary,
+  type StockPreparationMaterialMappingSyncResult,
+  type StockPreparationMatchStatus,
+  type StockPreparationVersionPolicy,
+} from '../../../services/integration/stockPreparation/materialMapping'
+
+const props = withDefaults(
+  defineProps<{
+    /** Internal MetaSheet project handle (shell-owned shared context). Absent → select-a-project. */
+    projectId?: string
+    /** Optional tenant/workspace scope passed straight through to every request. */
+    scope?: IntegrationScope
+  }>(),
+  { projectId: undefined, scope: () => ({}) },
+)
+
+const { locale } = useLocale()
+
+// Same synchronous locale idiom as the shell / views 1-2 / the rest of the integration surface.
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+const matchStatuses = STOCK_PREPARATION_MATCH_STATUSES
+const versionPolicies = STOCK_PREPARATION_VERSION_POLICIES
+
+const hasProject = computed(() => Boolean(props.projectId))
+
+const loading = ref(Boolean(props.projectId))
+const errored = ref(false)
+const summary = ref<StockPreparationMaterialMappingSummary | null>(null)
+const queue = ref<StockPreparationMaterialMappingCandidateList | null>(null)
+
+const statusFilter = ref<'' | StockPreparationMatchStatus>('')
+const syncPolicy = ref<'' | StockPreparationVersionPolicy>('')
+const syncResult = ref<StockPreparationMaterialMappingSyncResult | null>(null)
+
+const busy = ref(false)
+const actionNotice = ref<{ mode: string; handle: string | null } | null>(null)
+const actionError = ref<{ code: string; field: string | null } | null>(null)
+const formErrorField = ref<string | null>(null)
+
+const form = reactive({
+  plmDrawingNo: '',
+  plmVersion: '',
+  plmMaterialName: '',
+  plmSpec: '',
+  erpMaterialCode: '',
+  erpMaterialInternalId: '',
+  erpMaterialName: '',
+  erpSpec: '',
+  versionPolicy: '' as '' | StockPreparationVersionPolicy,
+  notes: '',
+})
+
+const summaryStatusEntries = computed(() =>
+  Object.entries(summary.value?.matchStatusCounts ?? {}).map(([key, count]) => ({ key, count })),
+)
+const summaryPolicyEntries = computed(() =>
+  Object.entries(summary.value?.versionPolicyCounts ?? {}).map(([key, count]) => ({ key, count })),
+)
+
+function requestScope(): IntegrationScope & { projectId: string } {
+  return { ...props.scope, projectId: props.projectId as string }
+}
+
+async function loadAll(): Promise<void> {
+  if (!props.projectId) {
+    loading.value = false
+    errored.value = false
+    summary.value = null
+    queue.value = null
+    return
+  }
+  loading.value = true
+  errored.value = false
+  try {
+    const [summaryResult, queueResult] = await Promise.all([
+      getStockPreparationMaterialMappingSummary(requestScope()),
+      listStockPreparationMaterialMappingCandidates({
+        ...requestScope(),
+        matchStatus: statusFilter.value || undefined,
+      }),
+    ])
+    summary.value = summaryResult
+    queue.value = queueResult
+  } catch {
+    // 404-soft: neutral state, NEVER the raw error body.
+    errored.value = true
+    summary.value = null
+    queue.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+async function reloadQueue(): Promise<void> {
+  if (!props.projectId) return
+  try {
+    queue.value = await listStockPreparationMaterialMappingCandidates({
+      ...requestScope(),
+      matchStatus: statusFilter.value || undefined,
+    })
+  } catch {
+    errored.value = true
+    queue.value = null
+  }
+}
+
+function captureActionError(error: unknown): void {
+  if (error instanceof StockPreparationConfirmApiError) {
+    actionError.value = { code: error.code, field: error.field }
+  } else {
+    actionError.value = { code: 'STOCK_PREPARATION_CONFIRM_REQUEST_FAILED', field: null }
+  }
+}
+
+function resetFeedback(): void {
+  actionNotice.value = null
+  actionError.value = null
+}
+
+async function confirmRow(row: StockPreparationMaterialMappingCandidateRow): Promise<void> {
+  if (!row.mappingId || !row.hasErpTarget || busy.value) return
+  resetFeedback()
+  busy.value = true
+  try {
+    const result = await confirmStockPreparationMaterialMapping({ mappingId: row.mappingId }, requestScope())
+    actionNotice.value = { mode: result.mode, handle: result.mappingId }
+    await loadAll()
+  } catch (error) {
+    captureActionError(error)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function retireRow(row: StockPreparationMaterialMappingCandidateRow): Promise<void> {
+  if (!row.mappingId || busy.value) return
+  resetFeedback()
+  busy.value = true
+  try {
+    const result = await retireStockPreparationMaterialMapping({ mappingId: row.mappingId }, requestScope())
+    actionNotice.value = { mode: result.mode, handle: result.mappingId }
+    await loadAll()
+  } catch (error) {
+    captureActionError(error)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function runCandidateSync(): Promise<void> {
+  // OD2: no default — the entry is disabled until a policy is chosen; this guard is layer B.
+  if (!syncPolicy.value || busy.value) return
+  resetFeedback()
+  syncResult.value = null
+  busy.value = true
+  try {
+    syncResult.value = await syncStockPreparationMaterialMappingCandidates(
+      { defaultVersionPolicy: syncPolicy.value },
+      requestScope(),
+    )
+    await loadAll()
+  } catch (error) {
+    captureActionError(error)
+  } finally {
+    busy.value = false
+  }
+}
+
+// Client-side MIRROR of the server's create-mode rules (both ERP identifiers required; plmVersion
+// required under drawing_and_version). The server's {field} error remains authoritative — a server
+// 400 lands in the same field-error surface.
+function clientValidateDraft(): string | null {
+  if (!form.plmDrawingNo) return 'plmDrawingNo'
+  if (!form.erpMaterialCode) return 'erpMaterialCode'
+  if (!form.erpMaterialInternalId) return 'erpMaterialInternalId'
+  if (!form.versionPolicy) return 'versionPolicy'
+  if (form.versionPolicy === 'drawing_and_version' && !form.plmVersion) return 'plmVersion'
+  return null
+}
+
+async function submitCreate(): Promise<void> {
+  if (busy.value) return
+  resetFeedback()
+  formErrorField.value = clientValidateDraft()
+  if (formErrorField.value) return
+  const draft: StockPreparationMaterialMappingDraft = {
+    plmDrawingNo: form.plmDrawingNo,
+    ...(form.plmVersion ? { plmVersion: form.plmVersion } : {}),
+    ...(form.plmMaterialName ? { plmMaterialName: form.plmMaterialName } : {}),
+    ...(form.plmSpec ? { plmSpec: form.plmSpec } : {}),
+    erpMaterialCode: form.erpMaterialCode,
+    erpMaterialInternalId: form.erpMaterialInternalId,
+    ...(form.erpMaterialName ? { erpMaterialName: form.erpMaterialName } : {}),
+    ...(form.erpSpec ? { erpSpec: form.erpSpec } : {}),
+    versionPolicy: form.versionPolicy as StockPreparationVersionPolicy,
+    ...(form.notes ? { notes: form.notes } : {}),
+  }
+  busy.value = true
+  try {
+    const result = await confirmStockPreparationMaterialMapping({ mapping: draft }, requestScope())
+    actionNotice.value = { mode: result.mode, handle: result.mappingId }
+    Object.assign(form, {
+      plmDrawingNo: '',
+      plmVersion: '',
+      plmMaterialName: '',
+      plmSpec: '',
+      erpMaterialCode: '',
+      erpMaterialInternalId: '',
+      erpMaterialName: '',
+      erpSpec: '',
+      versionPolicy: '',
+      notes: '',
+    })
+    await loadAll()
+  } catch (error) {
+    // Server {field} error → the form's field-error surface (authoritative over the client mirror).
+    if (error instanceof StockPreparationConfirmApiError && error.field) {
+      formErrorField.value = error.field
+    } else {
+      captureActionError(error)
+    }
+  } finally {
+    busy.value = false
+  }
+}
+
+onMounted(loadAll)
+watch(() => props.projectId, loadAll)
+// watch (not @change) so the reload always sees the UPDATED filter value — v-model's own change
+// handler and a template @change handler have no guaranteed relative order.
+watch(statusFilter, reloadQueue)
+</script>
+
+<style scoped>
+.sp-map {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+}
+
+.sp-map__state {
+  margin: 0;
+  padding: var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-page);
+  line-height: 1.6;
+}
+
+.sp-map__state--muted {
+  color: var(--ms-text-3);
+}
+
+.sp-map__state--ok {
+  color: var(--ms-text-2);
+}
+
+.sp-map__state--warn {
+  color: var(--ms-color-danger, #c45656);
+}
+
+.sp-map__overview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+}
+
+.sp-map__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--ms-space-2);
+}
+
+.sp-map__metric {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+  padding: var(--ms-space-2) var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-page);
+}
+
+.sp-map__metric-label {
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+
+.sp-map__metric-value {
+  color: var(--ms-text-1);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--ms-font-weight-title);
+  font-size: 18px;
+}
+
+.sp-map__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ms-space-1);
+}
+
+.sp-map__chip,
+.sp-map__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+  font-size: 12px;
+}
+
+.sp-map__sync,
+.sp-map__queue-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ms-space-3);
+}
+
+.sp-map__queue-count {
+  color: var(--ms-text-1);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.sp-map__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+  font-size: 13px;
+  color: var(--ms-text-2);
+}
+
+.sp-map__field--inline {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--ms-space-2);
+}
+
+.sp-map__field-label {
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+
+.sp-map__field input,
+.sp-map__field select {
+  border: 1px solid var(--ms-border-light);
+  border-radius: 6px;
+  padding: 4px 8px;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  font: inherit;
+  font-size: 13px;
+}
+
+.sp-map__note {
+  color: var(--ms-text-2);
+  font-size: 13px;
+}
+
+.sp-map__table-wrap {
+  overflow-x: auto;
+}
+
+.sp-map__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.sp-map__table th,
+.sp-map__table td {
+  padding: var(--ms-space-2) var(--ms-space-3);
+  border-bottom: 1px solid var(--ms-border-light);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.sp-map__table th {
+  color: var(--ms-text-3);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.sp-map__num {
+  color: var(--ms-text-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.sp-map__handle {
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+
+.sp-map__col-action {
+  text-align: right;
+}
+
+.sp-map__action {
+  border: 1px solid var(--ms-border-light);
+  border-radius: 6px;
+  background: transparent;
+  padding: 2px 10px;
+  color: var(--ms-color-primary);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.sp-map__action:disabled {
+  color: var(--ms-text-3);
+  cursor: not-allowed;
+}
+
+.sp-map__action--muted {
+  color: var(--ms-text-2);
+}
+
+.sp-map__action:hover:not(:disabled) {
+  background: var(--el-fill-color-light);
+}
+
+.sp-map__form {
+  border-top: 1px solid var(--ms-border-light);
+  padding-top: var(--ms-space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+}
+
+.sp-map__form-title {
+  margin: 0;
+  font-size: 14px;
+  color: var(--ms-text-1);
+}
+
+.sp-map__form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--ms-space-2) var(--ms-space-3);
+}
+
+.sp-map__form .sp-map__action {
+  align-self: flex-start;
+}
+</style>

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationUnitConfirmView.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationUnitConfirmView.vue
@@ -1,0 +1,771 @@
+<template>
+  <div class="sp-unit" data-testid="stock-prep-unit-view">
+    <!-- No project selected: this slice has no project picker, so we simply ask for one. -->
+    <p
+      v-if="!hasProject"
+      class="sp-unit__state sp-unit__state--muted"
+      data-testid="stock-prep-unit-no-project"
+      role="status"
+    >
+      {{ bi('请选择一个项目以查看单位换算确认。', 'Select a project to see unit-conversion confirmation.') }}
+    </p>
+
+    <!-- Loading: values-free spinner copy only. -->
+    <p
+      v-else-if="loading"
+      class="sp-unit__state sp-unit__state--muted"
+      data-testid="stock-prep-unit-loading"
+      role="status"
+    >
+      {{ bi('正在加载单位换算确认状态…', 'Loading unit-conversion confirmation state…') }}
+    </p>
+
+    <!-- Summary error / endpoint-not-ready: neutral, never the raw body. -->
+    <p
+      v-else-if="errored"
+      class="sp-unit__state sp-unit__state--muted"
+      data-testid="stock-prep-unit-error"
+      role="status"
+    >
+      {{ bi('同步后端尚未就绪,稍后再试。', 'Backend read not ready yet — try again later.') }}
+    </p>
+
+    <div v-else-if="summary" class="sp-unit__overview" data-testid="stock-prep-unit-overview">
+      <!-- Summary header card: the six values-free summary indicators. -->
+      <header class="sp-unit__summary" data-testid="stock-prep-unit-summary">
+        <div class="sp-unit__metric" data-testid="stock-prep-unit-metric" data-kind="total">
+          <span class="sp-unit__metric-label">{{ bi('规则总数', 'Total rules') }}</span>
+          <span class="sp-unit__metric-value">{{ summary.totalRuleCount }}</span>
+        </div>
+        <div class="sp-unit__metric" data-testid="stock-prep-unit-metric" data-kind="active">
+          <span class="sp-unit__metric-label">{{ bi('生效规则', 'Active rules') }}</span>
+          <span class="sp-unit__metric-value">{{ summary.activeRuleCount }}</span>
+        </div>
+        <div class="sp-unit__metric" data-testid="stock-prep-unit-metric" data-kind="requires-confirmation">
+          <span class="sp-unit__metric-label">{{ bi('待确认规则', 'Rules pending confirmation') }}</span>
+          <span class="sp-unit__metric-value">{{ summary.requiresConfirmationCount }}</span>
+        </div>
+        <div class="sp-unit__metric" data-testid="stock-prep-unit-metric" data-kind="pending-lines">
+          <span class="sp-unit__metric-label">{{ bi('待处理单位行', 'Pending unit lines') }}</span>
+          <span class="sp-unit__metric-value">{{ summary.pendingUnitLineCount }}</span>
+        </div>
+        <div class="sp-unit__metric sp-unit__metric--chips" data-testid="stock-prep-unit-metric" data-kind="scope-type">
+          <span class="sp-unit__metric-label">{{ bi('按作用域', 'By scope type') }}</span>
+          <span class="sp-unit__chips">
+            <span
+              v-for="entry in summaryScopeEntries"
+              :key="entry.key"
+              class="sp-unit__chip"
+              data-testid="stock-prep-unit-scope-count"
+              :data-scope="entry.key"
+            >{{ entry.key }}: {{ entry.count }}</span>
+          </span>
+        </div>
+        <div class="sp-unit__metric sp-unit__metric--chips" data-testid="stock-prep-unit-metric" data-kind="rounding-rule">
+          <span class="sp-unit__metric-label">{{ bi('按取整规则', 'By rounding rule') }}</span>
+          <span class="sp-unit__chips">
+            <span
+              v-for="entry in summaryRoundingEntries"
+              :key="entry.key"
+              class="sp-unit__chip"
+              data-testid="stock-prep-unit-rounding-count"
+              :data-rounding="entry.key"
+            >{{ entry.key }}: {{ entry.count }}</span>
+          </span>
+        </div>
+      </header>
+
+      <!-- Stale-candidate notice (409 CONFIRM_UNIT_CANDIDATE_NOT_FOUND): the computed view drifted
+           (snapshot changed / a rule landed meanwhile) — the operator must re-read before confirming. -->
+      <p v-if="staleCandidates" class="sp-unit__state sp-unit__state--warn" data-testid="stock-prep-unit-stale" role="alert">
+        {{ bi('候选已过期(快照或规则已变化),请刷新重读后再确认。', 'Candidates are stale (snapshot or rules changed) — refresh and re-read before confirming.') }}
+        <button type="button" class="sp-unit__action" data-testid="stock-prep-unit-stale-refresh" @click="refreshCandidates">
+          {{ bi('刷新重读', 'Refresh') }}
+        </button>
+      </p>
+
+      <!-- Action feedback (values-free: clamped code / field NAME / mode enums only). -->
+      <p v-if="actionNotice" class="sp-unit__state sp-unit__state--ok" data-testid="stock-prep-unit-action-notice">
+        {{ bi('操作完成', 'Action done') }}: {{ actionNotice.mode }}
+        <code v-if="actionNotice.handle" class="sp-unit__handle">{{ actionNotice.handle }}</code>
+      </p>
+      <p v-if="actionError" class="sp-unit__state sp-unit__state--warn" data-testid="stock-prep-unit-action-error" role="alert">
+        {{ bi('操作失败', 'Action failed') }} ({{ actionError.code }}<template v-if="actionError.field">/{{ actionError.field }}</template>)
+      </p>
+
+      <!-- Computed candidate list (server recomputes per read; candidate values never cross). -->
+      <p
+        v-if="noCompleteBatch"
+        class="sp-unit__state sp-unit__state--muted"
+        data-testid="stock-prep-unit-no-batch"
+      >
+        {{ bi('该项目尚无完整快照批次,无法计算单位候选。', 'No complete snapshot batch for this project yet — unit candidates cannot be computed.') }}
+      </p>
+      <p
+        v-else-if="candidatesErrored"
+        class="sp-unit__state sp-unit__state--muted"
+        data-testid="stock-prep-unit-candidates-error"
+        role="status"
+      >
+        {{ bi('候选读取尚未就绪,稍后再试。', 'Candidate read not ready yet — try again later.') }}
+      </p>
+      <div v-else-if="candidates" class="sp-unit__candidates">
+        <div class="sp-unit__queue-head">
+          <span class="sp-unit__queue-count" data-testid="stock-prep-unit-queue-count">
+            {{ bi('计算候选行', 'Computed rows') }}: {{ candidates.rowCount }}
+          </span>
+          <span class="sp-unit__badge" data-testid="stock-prep-unit-status" :data-status="candidates.status">
+            {{ candidates.status }}
+          </span>
+          <span class="sp-unit__batch" data-testid="stock-prep-unit-batch-handle">
+            {{ bi('快照批次', 'Snapshot batch') }}: <code class="sp-unit__handle">{{ candidates.snapshotBatchId }}</code>
+          </span>
+          <span class="sp-unit__chips">
+            <span
+              v-for="entry in outcomeEntries"
+              :key="entry.key"
+              class="sp-unit__chip"
+              data-testid="stock-prep-unit-outcome-count"
+              :data-outcome="entry.key"
+            >{{ entry.key }}: {{ entry.count }}</span>
+          </span>
+        </div>
+
+        <p v-if="candidates.rowCount === 0" class="sp-unit__state sp-unit__state--muted" data-testid="stock-prep-unit-empty">
+          {{ bi('当前批次没有需要单位换算的上下文。', 'No unit-conversion contexts in this batch.') }}
+        </p>
+        <div v-else class="sp-unit__table-wrap">
+          <table class="sp-unit__table" data-testid="stock-prep-unit-queue">
+            <thead>
+              <tr>
+                <th scope="col">{{ bi('上下文指纹', 'Context fingerprint') }}</th>
+                <th scope="col">{{ bi('结果', 'Outcome') }}</th>
+                <th scope="col">{{ bi('原因', 'Reason') }}</th>
+                <th scope="col">{{ bi('复用规则', 'Reused rule') }}</th>
+                <th scope="col">{{ bi('有候选', 'Has candidate') }}</th>
+                <th scope="col" class="sp-unit__col-action">{{ bi('操作', 'Actions') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="(row, index) in candidates.rows"
+                :key="row.contextFingerprint ?? `row-${index}`"
+                class="sp-unit__row"
+                data-testid="stock-prep-unit-row"
+                :data-outcome="row.outcome ?? 'unknown'"
+              >
+                <td><code class="sp-unit__handle" data-testid="stock-prep-unit-row-fingerprint">{{ row.contextFingerprint ?? '—' }}</code></td>
+                <td>
+                  <span class="sp-unit__badge" data-testid="stock-prep-unit-row-outcome" :data-outcome="row.outcome ?? 'unknown'">
+                    {{ row.outcome ?? '—' }}
+                  </span>
+                </td>
+                <td data-testid="stock-prep-unit-row-reason">{{ row.reason ?? '—' }}</td>
+                <!-- reused rows: READ-ONLY display of the covering rule's handle. -->
+                <td><code class="sp-unit__handle" data-testid="stock-prep-unit-row-rule-handle">{{ row.conversionRuleId ?? '—' }}</code></td>
+                <td data-testid="stock-prep-unit-row-candidate" :data-flag="String(row.hasCandidate)">
+                  {{ row.hasCandidate ? bi('有', 'yes') : bi('无', 'no') }}
+                </td>
+                <td class="sp-unit__col-action">
+                  <!-- Fingerprint confirm: only a computed 1:1 candidate row is confirmable — the
+                       server re-derives the rule values (they never crossed the wire). -->
+                  <button
+                    v-if="row.outcome === 'candidate' && row.hasCandidate && row.contextFingerprint"
+                    type="button"
+                    class="sp-unit__action"
+                    data-testid="stock-prep-unit-row-confirm"
+                    :disabled="busy"
+                    @click="confirmCandidate(row)"
+                  >
+                    {{ bi('确认', 'Confirm') }}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Rule retire entry: required before re-creating a same-scope rule with a different factor. -->
+      <div class="sp-unit__retire" data-testid="stock-prep-unit-retire-block">
+        <label class="sp-unit__field sp-unit__field--inline">
+          <span class="sp-unit__field-label">{{ bi('退役规则(规则标识)', 'Retire rule (rule handle)') }}</span>
+          <input v-model.trim="retireRuleId" type="text" data-testid="stock-prep-unit-retire-input" />
+        </label>
+        <button
+          type="button"
+          class="sp-unit__action sp-unit__action--muted"
+          data-testid="stock-prep-unit-retire-submit"
+          :disabled="!retireRuleId || busy"
+          @click="retireRule"
+        >
+          {{ bi('退役', 'Retire') }}
+        </button>
+      </div>
+
+      <!-- Manual rule form (rule mode): fully user-entered (OD3/OD4). Client validation MIRRORS the
+           server rules, but the server's {field} error stays authoritative. -->
+      <form class="sp-unit__form" data-testid="stock-prep-unit-rule-form" @submit.prevent="submitRule">
+        <h3 class="sp-unit__form-title">{{ bi('手工新建换算规则', 'Create a conversion rule manually') }}</h3>
+        <div class="sp-unit__form-grid">
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('PLM 设计单位(必填)', 'PLM design unit (required)') }}</span>
+            <input v-model.trim="form.plmUnit" type="text" data-testid="stock-prep-unit-form-plm-unit" />
+          </label>
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('ERP 领用单位(必填)', 'ERP issue unit (required)') }}</span>
+            <input v-model.trim="form.erpIssueUnit" type="text" data-testid="stock-prep-unit-form-erp-unit" />
+          </label>
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('换算系数(必填,>0)', 'Conversion factor (required, >0)') }}</span>
+            <input v-model.trim="form.conversionFactor" type="text" inputmode="decimal" data-testid="stock-prep-unit-form-factor" />
+          </label>
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('作用域(必选)', 'Scope type (required)') }}</span>
+            <select v-model="form.scopeType" data-testid="stock-prep-unit-form-scope-type">
+              <option value="" disabled>{{ bi('请选择作用域', 'Select a scope type') }}</option>
+              <option v-for="scope in scopeTypes" :key="scope" :value="scope">{{ scope }}</option>
+            </select>
+          </label>
+          <label v-if="form.scopeType !== 'generic'" class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('作用域键(material/category 必填)', 'Scope key (required for material/category)') }}</span>
+            <input v-model.trim="form.scopeKey" type="text" data-testid="stock-prep-unit-form-scope-key" />
+          </label>
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('损耗率(≥0,可选)', 'Loss rate (≥0, optional)') }}</span>
+            <input v-model.trim="form.lossRate" type="text" inputmode="decimal" data-testid="stock-prep-unit-form-loss" />
+          </label>
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('取整规则', 'Rounding rule') }}</span>
+            <select v-model="form.roundingRule" data-testid="stock-prep-unit-form-rounding">
+              <option v-for="rule in roundingRules" :key="rule" :value="rule">{{ rule }}</option>
+            </select>
+          </label>
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('最小领用量(≥0,可选)', 'Minimum issue qty (≥0, optional)') }}</span>
+            <input v-model.trim="form.minimumIssueQty" type="text" inputmode="decimal" data-testid="stock-prep-unit-form-min-qty" />
+          </label>
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('生效起(可选)', 'Effective from (optional)') }}</span>
+            <input v-model.trim="form.effectiveFrom" type="text" data-testid="stock-prep-unit-form-from" />
+          </label>
+          <label class="sp-unit__field">
+            <span class="sp-unit__field-label">{{ bi('生效止(可选)', 'Effective to (optional)') }}</span>
+            <input v-model.trim="form.effectiveTo" type="text" data-testid="stock-prep-unit-form-to" />
+          </label>
+        </div>
+        <!-- Field error: the offending field NAME only — never a submitted value. -->
+        <p v-if="formErrorField" class="sp-unit__state sp-unit__state--warn" data-testid="stock-prep-unit-form-error" role="alert">
+          {{ bi('字段无效', 'Invalid field') }}: {{ formErrorField }}
+        </p>
+        <button type="submit" class="sp-unit__action" data-testid="stock-prep-unit-form-submit" :disabled="busy">
+          {{ bi('新建并确认规则', 'Create confirmed rule') }}
+        </button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md),
+// Frontend MVP view 4: UNIT CONVERSION CONFIRMATION, rendered inside the workspace shell's fourth
+// tab. Reads = W3c confirm reads (summary + COMPUTED candidate list); writes = W3b human confirm
+// writes (tri-XOR confirm / retire) — all MULTITABLE-INTERNAL, no external ERP/K3 write.
+//
+// CANDIDATES ARE COMPUTED, NEVER PERSISTED: the list is re-derived per read, so a fingerprint
+// confirm can race a snapshot/rule change — the server answers 409 CONFIRM_UNIT_CANDIDATE_NOT_FOUND
+// and this view surfaces a STALE notice with a refresh entry (never a blind retry).
+//
+// VALUES-FREE: the template reads a fixed whitelist — counts, outcome/reason/scope/rounding enums,
+// booleans, and sha16 handles (contextFingerprint / conversionRuleId / snapshotBatchId). It never
+// renders a unit symbol, conversion factor, loss rate, or quantity FROM the server (the read shapes
+// carry none), and error surfaces render only the clamped code / field NAME. Operator-entered rule
+// values flow only UPWARD through the closed rule allowlist; confirmedBy / confirmedAt never enter
+// any body.
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useLocale } from '../../../composables/useLocale'
+import type { IntegrationScope } from '../../../services/integration/workbench'
+import { StockPreparationConfirmApiError } from '../../../services/integration/stockPreparation/confirmApi'
+import {
+  STOCK_PREPARATION_ROUNDING_RULES,
+  STOCK_PREPARATION_UNIT_SCOPE_TYPES,
+  confirmStockPreparationUnitConversionRule,
+  getStockPreparationUnitConversionSummary,
+  listStockPreparationUnitConversionCandidates,
+  retireStockPreparationUnitConversionRule,
+  type StockPreparationRoundingRule,
+  type StockPreparationUnitConversionCandidateList,
+  type StockPreparationUnitConversionCandidateRow,
+  type StockPreparationUnitConversionRuleDraft,
+  type StockPreparationUnitConversionSummary,
+  type StockPreparationUnitScopeType,
+} from '../../../services/integration/stockPreparation/unitConversion'
+
+const props = withDefaults(
+  defineProps<{
+    /** Internal MetaSheet project handle (shell-owned shared context). Absent → select-a-project. */
+    projectId?: string
+    /** Optional tenant/workspace scope passed straight through to every request. */
+    scope?: IntegrationScope
+  }>(),
+  { projectId: undefined, scope: () => ({}) },
+)
+
+const { locale } = useLocale()
+
+// Same synchronous locale idiom as the shell / views 1-3 / the rest of the integration surface.
+function bi(zh: string, en: string): string {
+  return locale.value === 'zh-CN' ? zh : en
+}
+
+const scopeTypes = STOCK_PREPARATION_UNIT_SCOPE_TYPES
+const roundingRules = STOCK_PREPARATION_ROUNDING_RULES
+
+const hasProject = computed(() => Boolean(props.projectId))
+
+const loading = ref(Boolean(props.projectId))
+const errored = ref(false)
+const summary = ref<StockPreparationUnitConversionSummary | null>(null)
+const candidates = ref<StockPreparationUnitConversionCandidateList | null>(null)
+const candidatesErrored = ref(false)
+const noCompleteBatch = ref(false)
+const staleCandidates = ref(false)
+
+const busy = ref(false)
+const actionNotice = ref<{ mode: string; handle: string | null } | null>(null)
+const actionError = ref<{ code: string; field: string | null } | null>(null)
+const formErrorField = ref<string | null>(null)
+const retireRuleId = ref('')
+
+const form = reactive({
+  plmUnit: '',
+  erpIssueUnit: '',
+  conversionFactor: '',
+  scopeType: '' as '' | StockPreparationUnitScopeType,
+  scopeKey: '',
+  lossRate: '',
+  roundingRule: 'none' as StockPreparationRoundingRule,
+  minimumIssueQty: '',
+  effectiveFrom: '',
+  effectiveTo: '',
+})
+
+const summaryScopeEntries = computed(() =>
+  Object.entries(summary.value?.scopeTypeCounts ?? {}).map(([key, count]) => ({ key, count })),
+)
+const summaryRoundingEntries = computed(() =>
+  Object.entries(summary.value?.roundingRuleCounts ?? {}).map(([key, count]) => ({ key, count })),
+)
+const outcomeEntries = computed(() =>
+  Object.entries(candidates.value?.byOutcome ?? {}).map(([key, count]) => ({ key, count })),
+)
+
+function requestScope(): IntegrationScope & { projectId: string } {
+  return { ...props.scope, projectId: props.projectId as string }
+}
+
+async function loadCandidates(): Promise<void> {
+  candidatesErrored.value = false
+  noCompleteBatch.value = false
+  try {
+    candidates.value = await listStockPreparationUnitConversionCandidates(requestScope())
+  } catch (error) {
+    candidates.value = null
+    // No COMPLETE batch is an expected empty condition, not a failure (values-free neutral state).
+    if (error instanceof StockPreparationConfirmApiError && error.code === 'CONFIRM_READS_BATCH_NOT_FOUND') {
+      noCompleteBatch.value = true
+    } else {
+      candidatesErrored.value = true
+    }
+  }
+}
+
+async function loadAll(): Promise<void> {
+  staleCandidates.value = false
+  if (!props.projectId) {
+    loading.value = false
+    errored.value = false
+    summary.value = null
+    candidates.value = null
+    return
+  }
+  loading.value = true
+  errored.value = false
+  try {
+    const [summaryResult] = await Promise.all([
+      getStockPreparationUnitConversionSummary(requestScope()),
+      loadCandidates(),
+    ])
+    summary.value = summaryResult
+  } catch {
+    // 404-soft: neutral state, NEVER the raw error body.
+    errored.value = true
+    summary.value = null
+    candidates.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+async function refreshCandidates(): Promise<void> {
+  staleCandidates.value = false
+  await loadCandidates()
+}
+
+function captureActionError(error: unknown): void {
+  if (error instanceof StockPreparationConfirmApiError) {
+    actionError.value = { code: error.code, field: error.field }
+  } else {
+    actionError.value = { code: 'STOCK_PREPARATION_CONFIRM_REQUEST_FAILED', field: null }
+  }
+}
+
+function resetFeedback(): void {
+  actionNotice.value = null
+  actionError.value = null
+  staleCandidates.value = false
+}
+
+async function confirmCandidate(row: StockPreparationUnitConversionCandidateRow): Promise<void> {
+  if (!row.contextFingerprint || busy.value || !candidates.value) return
+  resetFeedback()
+  busy.value = true
+  try {
+    const result = await confirmStockPreparationUnitConversionRule(
+      {
+        contextFingerprint: row.contextFingerprint,
+        projectId: props.projectId as string,
+        // Pin the confirm to the batch the operator is LOOKING AT (the list's batch handle).
+        snapshotBatchId: candidates.value.snapshotBatchId,
+      },
+      requestScope(),
+    )
+    actionNotice.value = { mode: result.mode, handle: result.conversionRuleId }
+    await loadAll()
+  } catch (error) {
+    if (error instanceof StockPreparationConfirmApiError && error.code === 'CONFIRM_UNIT_CANDIDATE_NOT_FOUND') {
+      // Stale computed view → prompt a refresh + re-read; never blind-retry the confirm.
+      staleCandidates.value = true
+    } else {
+      captureActionError(error)
+    }
+  } finally {
+    busy.value = false
+  }
+}
+
+async function retireRule(): Promise<void> {
+  if (!retireRuleId.value || busy.value) return
+  resetFeedback()
+  busy.value = true
+  try {
+    const result = await retireStockPreparationUnitConversionRule(
+      { conversionRuleId: retireRuleId.value },
+      requestScope(),
+    )
+    actionNotice.value = { mode: result.mode, handle: result.conversionRuleId }
+    retireRuleId.value = ''
+    await loadAll()
+  } catch (error) {
+    captureActionError(error)
+  } finally {
+    busy.value = false
+  }
+}
+
+// Mirror the server rule: scopeKey is FORBIDDEN for the generic scope — clear it on switch so a
+// leftover key can never reach the wire. (watch, not @change: v-model's own change handler and a
+// template @change handler have no guaranteed relative order.)
+watch(() => form.scopeType, (scopeType) => {
+  if (scopeType === 'generic') form.scopeKey = ''
+})
+
+function parseOptionalNumber(raw: string): number | null | undefined {
+  if (raw === '') return undefined
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+// Client-side MIRROR of the server's rule-mode checks (required units, factor > 0, scopeKey
+// required for material/category and forbidden for generic, non-negative optionals). The server's
+// {field} error remains authoritative — a server 400 lands in the same field-error surface.
+function clientValidateRule(): string | null {
+  if (!form.plmUnit) return 'plmUnit'
+  if (!form.erpIssueUnit) return 'erpIssueUnit'
+  const factor = parseOptionalNumber(form.conversionFactor)
+  if (factor === undefined || factor === null || factor <= 0) return 'conversionFactor'
+  if (!form.scopeType) return 'scopeType'
+  if ((form.scopeType === 'material' || form.scopeType === 'category') && !form.scopeKey) return 'scopeKey'
+  const lossRate = parseOptionalNumber(form.lossRate)
+  if (lossRate === null || (lossRate !== undefined && lossRate < 0)) return 'lossRate'
+  const minimumIssueQty = parseOptionalNumber(form.minimumIssueQty)
+  if (minimumIssueQty === null || (minimumIssueQty !== undefined && minimumIssueQty < 0)) return 'minimumIssueQty'
+  return null
+}
+
+async function submitRule(): Promise<void> {
+  if (busy.value) return
+  resetFeedback()
+  formErrorField.value = clientValidateRule()
+  if (formErrorField.value) return
+  const draft: StockPreparationUnitConversionRuleDraft = {
+    plmUnit: form.plmUnit,
+    erpIssueUnit: form.erpIssueUnit,
+    conversionFactor: Number(form.conversionFactor),
+    scopeType: form.scopeType as StockPreparationUnitScopeType,
+    ...(form.scopeType !== 'generic' && form.scopeKey ? { scopeKey: form.scopeKey } : {}),
+    ...(form.lossRate !== '' ? { lossRate: Number(form.lossRate) } : {}),
+    roundingRule: form.roundingRule,
+    ...(form.minimumIssueQty !== '' ? { minimumIssueQty: Number(form.minimumIssueQty) } : {}),
+    ...(form.effectiveFrom ? { effectiveFrom: form.effectiveFrom } : {}),
+    ...(form.effectiveTo ? { effectiveTo: form.effectiveTo } : {}),
+  }
+  busy.value = true
+  try {
+    const result = await confirmStockPreparationUnitConversionRule({ rule: draft }, requestScope())
+    actionNotice.value = { mode: result.mode, handle: result.conversionRuleId }
+    Object.assign(form, {
+      plmUnit: '',
+      erpIssueUnit: '',
+      conversionFactor: '',
+      scopeType: '',
+      scopeKey: '',
+      lossRate: '',
+      roundingRule: 'none',
+      minimumIssueQty: '',
+      effectiveFrom: '',
+      effectiveTo: '',
+    })
+    await loadAll()
+  } catch (error) {
+    // Server {field} error → the form's field-error surface (authoritative over the client mirror).
+    if (error instanceof StockPreparationConfirmApiError && error.field) {
+      formErrorField.value = error.field
+    } else {
+      captureActionError(error)
+    }
+  } finally {
+    busy.value = false
+  }
+}
+
+onMounted(loadAll)
+watch(() => props.projectId, loadAll)
+</script>
+
+<style scoped>
+.sp-unit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+}
+
+.sp-unit__state {
+  margin: 0;
+  padding: var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-page);
+  line-height: 1.6;
+}
+
+.sp-unit__state--muted {
+  color: var(--ms-text-3);
+}
+
+.sp-unit__state--ok {
+  color: var(--ms-text-2);
+}
+
+.sp-unit__state--warn {
+  color: var(--ms-color-danger, #c45656);
+}
+
+.sp-unit__overview,
+.sp-unit__candidates {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+}
+
+.sp-unit__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--ms-space-2);
+}
+
+.sp-unit__metric {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+  padding: var(--ms-space-2) var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 8px;
+  background: var(--ms-bg-page);
+}
+
+.sp-unit__metric-label {
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+
+.sp-unit__metric-value {
+  color: var(--ms-text-1);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--ms-font-weight-title);
+  font-size: 18px;
+}
+
+.sp-unit__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ms-space-1);
+}
+
+.sp-unit__chip,
+.sp-unit__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+  font-size: 12px;
+}
+
+.sp-unit__queue-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ms-space-3);
+}
+
+.sp-unit__queue-count {
+  color: var(--ms-text-1);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.sp-unit__batch {
+  color: var(--ms-text-2);
+  font-size: 13px;
+}
+
+.sp-unit__table-wrap {
+  overflow-x: auto;
+}
+
+.sp-unit__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.sp-unit__table th,
+.sp-unit__table td {
+  padding: var(--ms-space-2) var(--ms-space-3);
+  border-bottom: 1px solid var(--ms-border-light);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.sp-unit__table th {
+  color: var(--ms-text-3);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.sp-unit__handle {
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+
+.sp-unit__col-action {
+  text-align: right;
+}
+
+.sp-unit__action {
+  border: 1px solid var(--ms-border-light);
+  border-radius: 6px;
+  background: transparent;
+  padding: 2px 10px;
+  color: var(--ms-color-primary);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.sp-unit__action:disabled {
+  color: var(--ms-text-3);
+  cursor: not-allowed;
+}
+
+.sp-unit__action--muted {
+  color: var(--ms-text-2);
+}
+
+.sp-unit__action:hover:not(:disabled) {
+  background: var(--el-fill-color-light);
+}
+
+.sp-unit__retire {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ms-space-3);
+  border-top: 1px solid var(--ms-border-light);
+  padding-top: var(--ms-space-3);
+}
+
+.sp-unit__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+  font-size: 13px;
+  color: var(--ms-text-2);
+}
+
+.sp-unit__field--inline {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--ms-space-2);
+}
+
+.sp-unit__field-label {
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+
+.sp-unit__field input,
+.sp-unit__field select {
+  border: 1px solid var(--ms-border-light);
+  border-radius: 6px;
+  padding: 4px 8px;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  font: inherit;
+  font-size: 13px;
+}
+
+.sp-unit__form {
+  border-top: 1px solid var(--ms-border-light);
+  padding-top: var(--ms-space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-3);
+}
+
+.sp-unit__form-title {
+  margin: 0;
+  font-size: 14px;
+  color: var(--ms-text-1);
+}
+
+.sp-unit__form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--ms-space-2) var(--ms-space-3);
+}
+
+.sp-unit__form .sp-unit__action {
+  align-self: flex-start;
+}
+</style>

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationWorkspace.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationWorkspace.vue
@@ -45,16 +45,27 @@
         {{ bi(activeView.zhDesc, activeView.enDesc) }}
       </p>
       <p class="stock-prep__panel-endpoint" data-testid="stock-prep-panel-endpoint">
-        <span class="stock-prep__badge">{{ bi('只读', 'readonly') }} · GET</span>
+        <span class="stock-prep__badge">{{
+          activeView.confirmWrites ? bi('只读 + 人工确认', 'readonly + human confirm') : `${bi('只读', 'readonly')} · GET`
+        }}</span>
         <code>{{ activeView.endpoint }}</code>
       </p>
-      <!-- Views 1-2 are real readonly views; the other four tabs keep the placeholder. -->
+      <!-- Views 1-4 are real views; the remaining tabs keep the placeholder. Views 2-4 share the
+           shell-owned projectId context selected in view 1 (#4017 pattern). -->
       <StockPreparationProjectWorkspaceView
         v-if="activeKey === 'project-workspace'"
         @select-project="handleProjectSelect"
       />
       <StockPreparationSnapshotDiffView
         v-else-if="activeKey === 'bom-snapshot-diff'"
+        :project-id="selectedProjectId"
+      />
+      <StockPreparationMappingConfirmView
+        v-else-if="activeKey === 'material-mapping'"
+        :project-id="selectedProjectId"
+      />
+      <StockPreparationUnitConfirmView
+        v-else-if="activeKey === 'unit-conversion'"
         :project-id="selectedProjectId"
       />
       <p v-else class="stock-prep__panel-pending" data-testid="stock-prep-panel-pending">
@@ -81,6 +92,8 @@ import PageShell from '../../layout/PageShell.vue'
 import PageHeader from '../../layout/PageHeader.vue'
 import StockPreparationProjectWorkspaceView from './StockPreparationProjectWorkspaceView.vue'
 import StockPreparationSnapshotDiffView from './StockPreparationSnapshotDiffView.vue'
+import StockPreparationMappingConfirmView from './StockPreparationMappingConfirmView.vue'
+import StockPreparationUnitConfirmView from './StockPreparationUnitConfirmView.vue'
 
 const { locale } = useLocale()
 
@@ -104,8 +117,13 @@ interface StockPreparationViewTab {
   en: string
   zhDesc: string
   enDesc: string
-  /** The readonly (GET) summary endpoint the future view reads. Values-free path only. */
+  /** The readonly (GET) summary endpoint the view reads. Values-free path only. */
   endpoint: string
+  /**
+   * True for the two confirmation views whose row actions issue MULTITABLE-INTERNAL human-confirm
+   * writes (W3b). Still no external ERP/K3 write — the badge copy reflects the human-confirm nature.
+   */
+  confirmWrites?: boolean
 }
 
 // Tab order follows the MVP business loop (design §"MVP Goal"). Descriptions are values-free — they
@@ -134,6 +152,7 @@ const views: StockPreparationViewTab[] = [
     zhDesc: '将 PLM 图号/版本映射到 ERP 物料编码/内部 id;歧义或未匹配的行进入人工确认,不自动创建 ERP 物料。',
     enDesc: 'Map PLM drawing/version to ERP material code/internal id; ambiguous or unmatched rows go to manual confirmation, never auto-create ERP material.',
     endpoint: '/api/integration/stock-preparation/material-mappings/summary',
+    confirmWrites: true,
   },
   {
     key: 'unit-conversion',
@@ -142,6 +161,7 @@ const views: StockPreparationViewTab[] = [
     zhDesc: '将设计单位换算为 ERP 领用单位;无唯一有效规则时进入异常队列,不做静默猜测。',
     enDesc: 'Convert the design unit to the ERP issue unit; with no unique active rule the line enters the exception queue rather than a silent guess.',
     endpoint: '/api/integration/stock-preparation/unit-conversions/summary',
+    confirmWrites: true,
   },
   {
     key: 'prep-line',

--- a/apps/web/src/services/integration/stockPreparation/confirmApi.ts
+++ b/apps/web/src/services/integration/stockPreparation/confirmApi.ts
@@ -1,0 +1,59 @@
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md).
+// Shared response parser for the W3 confirmation endpoints (material-mapping / unit-conversion
+// confirm reads + human confirm writes, FE views 3/4).
+//
+// Why not parseIntegrationResponse (workbench.ts): it collapses an error body into Error.message and
+// DROPS the machine-readable code, but views 3/4 must branch on specific server codes —
+// 409 CONFIRM_UNIT_CANDIDATE_NOT_FOUND means the candidate view is STALE (refresh + re-read), and the
+// 400 *_FIELDS_INVALID family carries the offending field NAME in error.details.field.
+//
+// VALUES-FREE error surface (same discipline as readSourceConfigs.ts ReadSourceApiError): everything
+// lifted from the response body into the error object is CLAMPED to an enum-shaped pattern first, so
+// a value-carrying string (a drawing number, a unit symbol, a connection string) can never reach the
+// DOM through the error path. The raw error message is deliberately NOT propagated.
+import type { IntegrationApiEnvelope } from '../workbench'
+
+const ERROR_CODE_PATTERN = /^[A-Z0-9_]{1,80}$/
+const ERROR_FIELD_PATTERN = /^[A-Za-z0-9_.-]{1,64}$/
+
+export class StockPreparationConfirmApiError extends Error {
+  /** HTTP status of the failed request (e.g. 409 for a stale unit candidate). */
+  status: number
+  /** Clamped server error code (falls back to a fixed local code when absent/non-enum-shaped). */
+  code: string
+  /** Clamped offending field NAME from error.details.field — null when the error names no field. */
+  field: string | null
+
+  constructor(status: number, code: string, field: string | null) {
+    super(`stock-preparation confirm request failed (${code}${field ? `/${field}` : ''})`)
+    this.name = 'StockPreparationConfirmApiError'
+    this.status = status
+    this.code = code
+    this.field = field
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+export async function parseStockPreparationConfirmResponse<T>(response: Response): Promise<T> {
+  let payload: IntegrationApiEnvelope<T> | null = null
+  try {
+    payload = await response.json() as IntegrationApiEnvelope<T>
+  } catch {
+    payload = null
+  }
+  if (!response.ok || payload?.ok === false) {
+    const error: Record<string, unknown> = isPlainObject(payload?.error) ? payload.error : {}
+    const details: Record<string, unknown> = isPlainObject(error.details) ? error.details : {}
+    const code = typeof error.code === 'string' && ERROR_CODE_PATTERN.test(error.code)
+      ? error.code
+      : 'STOCK_PREPARATION_CONFIRM_REQUEST_FAILED'
+    const field = typeof details.field === 'string' && ERROR_FIELD_PATTERN.test(details.field)
+      ? details.field
+      : null
+    throw new StockPreparationConfirmApiError(response.status, code, field)
+  }
+  return payload?.data as T
+}

--- a/apps/web/src/services/integration/stockPreparation/materialMapping.ts
+++ b/apps/web/src/services/integration/stockPreparation/materialMapping.ts
@@ -1,18 +1,26 @@
 // Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md)
-// per-view service stub: MATERIAL MAPPING CONFIRMATION (design §"Frontend MVP" view 3).
+// per-view service module: MATERIAL MAPPING CONFIRMATION (design §"Frontend MVP" view 3).
 //
 // Maps PLM drawing/version -> ERP material code/internal id. The MVP NEVER auto-creates ERP material
 // codes and NEVER generates final lines from ambiguous candidates — unresolved rows stay pending for
 // human confirmation.
 //
-// READONLY-FIRST: GET-only summary. No external ERP/K3 write, no auto material create. When a
-// confirm action lands in a later wave it is a MULTITABLE-INTERNAL row write behind its own gate,
-// never an external write, and never in this stub.
+// INTERNAL-ONLY writes: the confirm / retire / candidate-sync POSTs below are MULTITABLE-INTERNAL
+// row writes against the frozen MVP mapping table (W3b, plugin-integration-core
+// stock-preparation-confirm-writes.cjs). No external ERP/K3 write, no auto material create.
 //
-// VALUES-FREE contract: counts by match_status / version_policy / match_method only. No PLM drawing
-// numbers, versions, material names, specs, ERP material codes, or internal ids as VALUES.
+// SERVER-STAMPED confirmation: confirmedBy / confirmedAt are NEVER in any request body — the route
+// derives the operator identity and the module stamps the time; a body that carries either is
+// rejected as an unknown field. Every body below is built from a CLOSED key set mirroring the
+// route's per-endpoint allowlist (mock-is-not-the-contract: both directions pinned in the specs).
+//
+// VALUES-FREE contract: counts by match_status / version_policy / match_method, booleans, confidence
+// scores, and sha16 mappingId handles only. No PLM drawing numbers, versions, material names, specs,
+// ERP material codes, or internal ids ever cross FROM the server; user-ENTERED values flow only
+// upward through the closed create-mode allowlist.
 import { apiFetch } from '../../../utils/api'
 import { buildQueryString, parseIntegrationResponse, type IntegrationScope } from '../workbench'
+import { parseStockPreparationConfirmResponse } from './confirmApi'
 
 export type StockPreparationMatchStatus =
   | 'matched'
@@ -26,6 +34,34 @@ export type StockPreparationVersionPolicy =
   | 'drawing_only'
   | 'category_rule'
   | 'manual'
+
+// Fixed FE whitelists mirroring the server's frozen vocabularies (stock-preparation-material-match /
+// -mvp-generation .cjs). The candidates read zero-fills byMatchStatus over exactly the five statuses
+// (+ an optional `unknown` fold), and the sync route validates defaultVersionPolicy against exactly
+// these four policies (OD2: required per request, no server default).
+export const STOCK_PREPARATION_MATCH_STATUSES: readonly StockPreparationMatchStatus[] = [
+  'matched',
+  'pending_confirm',
+  'multi_candidate',
+  'not_found',
+  'version_conflict',
+]
+
+export const STOCK_PREPARATION_VERSION_POLICIES: readonly StockPreparationVersionPolicy[] = [
+  'drawing_and_version',
+  'drawing_only',
+  'category_rule',
+  'manual',
+]
+
+// Engine match methods + the confirm-writes manual marker; a junk stored value folds to `unknown`.
+export type StockPreparationMatchMethod =
+  | 'historical_confirmed'
+  | 'exact_code_candidate'
+  | 'normalized_code_candidate'
+  | 'name_spec_candidate'
+  | 'none'
+  | 'manual_confirm'
 
 export interface StockPreparationMaterialMappingSummary {
   totalMappingCount: number
@@ -51,4 +87,200 @@ export async function getStockPreparationMaterialMappingSummary(
     `/api/integration/stock-preparation/material-mappings/summary${query ? `?${query}` : ''}`,
   )
   return parseIntegrationResponse<StockPreparationMaterialMappingSummary>(response)
+}
+
+// ── candidates read (W3c R4) ──────────────────────────────────────────────────────────────────────
+
+/** One review-queue row: sha16 handle + enums + booleans + confidence score ONLY (values-free). */
+export interface StockPreparationMaterialMappingCandidateRow {
+  /** sha16 handle — the only row identity the FE ever holds; used for confirm/retire actions. */
+  mappingId: string | null
+  matchStatus: StockPreparationMatchStatus | 'unknown'
+  /** Absent when the stored row carries no method; junk stored values fold to `unknown`. */
+  matchMethod?: StockPreparationMatchMethod | 'unknown'
+  versionPolicy: StockPreparationVersionPolicy | 'unknown'
+  confidence: number | null
+  isActive: boolean
+  confirmed: boolean
+  /** BOTH ERP identifiers present — the precondition for the mappingId confirm mode. */
+  hasErpTarget: boolean
+  plmVersionPresent: boolean
+}
+
+export interface StockPreparationMaterialMappingCandidateList {
+  rowCount: number
+  /** Zero-filled over the five match statuses; an extra `unknown` key appears only when junk exists. */
+  byMatchStatus: Record<string, number>
+  rows: StockPreparationMaterialMappingCandidateRow[]
+}
+
+/**
+ * Values-free mapping review queue (active rows; optional server-side matchStatus filter).
+ * GET /api/integration/stock-preparation/material-mappings/candidates
+ */
+export async function listStockPreparationMaterialMappingCandidates(
+  scope: IntegrationScope & { projectId: string; matchStatus?: StockPreparationMatchStatus | null },
+): Promise<StockPreparationMaterialMappingCandidateList> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+    matchStatus: scope.matchStatus,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/material-mappings/candidates${query ? `?${query}` : ''}`,
+  )
+  return parseStockPreparationConfirmResponse<StockPreparationMaterialMappingCandidateList>(response)
+}
+
+// ── human confirm writes (W3b R5-R7; multitable-internal only) ────────────────────────────────────
+
+/** Values-free per-op evidence: subject kind + mode + target identity (objectId / key-field NAME). */
+export interface StockPreparationConfirmEvidence {
+  subject: string
+  mode: string
+  target: { objectId: string; keyField: string }
+  valuesFree: boolean
+}
+
+// Closed create-mode key set — EXACT mirror of the route module's MAPPING_CREATE_ALLOWED_KEYS
+// (stock-preparation-confirm-writes.cjs). The body's `mapping` object is grounded to these keys so
+// an accidental extra property (above all confirmedBy / confirmedAt) can never reach the wire.
+const MAPPING_DRAFT_KEYS = [
+  'plmDrawingNo',
+  'plmVersion',
+  'plmMaterialName',
+  'plmSpec',
+  'erpMaterialCode',
+  'erpMaterialInternalId',
+  'erpMaterialName',
+  'erpSpec',
+  'versionPolicy',
+  'notes',
+] as const
+
+/** Fully operator-specified confirmed mapping (create mode). User-ENTERED values only. */
+export interface StockPreparationMaterialMappingDraft {
+  plmDrawingNo: string
+  plmVersion?: string
+  plmMaterialName?: string
+  plmSpec?: string
+  erpMaterialCode: string
+  erpMaterialInternalId: string
+  erpMaterialName?: string
+  erpSpec?: string
+  versionPolicy: StockPreparationVersionPolicy
+  notes?: string
+}
+
+/** XOR: confirm an EXISTING candidate by handle, or create a fully operator-specified mapping. */
+export type StockPreparationMaterialMappingConfirmInput =
+  | { mappingId: string; mapping?: undefined; notes?: string }
+  | { mapping: StockPreparationMaterialMappingDraft; mappingId?: undefined; notes?: string }
+
+export interface StockPreparationMaterialMappingConfirmResult {
+  persisted: boolean
+  mode: 'confirmed' | 'created' | 'skipped_already_confirmed' | 'skipped_existing'
+  mappingId: string | null
+  evidence: StockPreparationConfirmEvidence
+}
+
+function groundDraft(keys: readonly string[], draft: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of keys) {
+    const value = draft[key]
+    if (value === undefined || value === null || value === '') continue
+    out[key] = value
+  }
+  return out
+}
+
+function scopeBodyFields(scope: IntegrationScope & { projectId?: string | null }): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (scope.tenantId) out.tenantId = scope.tenantId
+  if (scope.workspaceId) out.workspaceId = scope.workspaceId
+  if (scope.projectId) out.projectId = scope.projectId
+  return out
+}
+
+/**
+ * Human mapping confirm — XOR body modes per the route allowlist. confirmedBy / confirmedAt are
+ * server-derived and NEVER in the body (the route rejects them as unknown fields).
+ * POST /api/integration/stock-preparation/material-mappings/confirm
+ */
+export async function confirmStockPreparationMaterialMapping(
+  input: StockPreparationMaterialMappingConfirmInput,
+  scope: IntegrationScope & { projectId?: string | null } = {},
+): Promise<StockPreparationMaterialMappingConfirmResult> {
+  const body: Record<string, unknown> = {
+    ...scopeBodyFields(scope),
+    ...(input.mappingId !== undefined ? { mappingId: input.mappingId } : {}),
+    ...(input.mapping !== undefined
+      ? { mapping: groundDraft(MAPPING_DRAFT_KEYS, input.mapping as unknown as Record<string, unknown>) }
+      : {}),
+    ...(input.notes ? { notes: input.notes } : {}),
+  }
+  const response = await apiFetch('/api/integration/stock-preparation/material-mappings/confirm', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+  return parseStockPreparationConfirmResponse<StockPreparationMaterialMappingConfirmResult>(response)
+}
+
+export interface StockPreparationMaterialMappingRetireResult {
+  persisted: boolean
+  mode: 'retired' | 'skipped_inactive'
+  mappingId: string
+  evidence: StockPreparationConfirmEvidence
+}
+
+/**
+ * Retire a mapping (server patches EXACTLY isActive:false) — the recovery path for a wrong confirm.
+ * POST /api/integration/stock-preparation/material-mappings/retire
+ */
+export async function retireStockPreparationMaterialMapping(
+  input: { mappingId: string },
+  scope: IntegrationScope & { projectId?: string | null } = {},
+): Promise<StockPreparationMaterialMappingRetireResult> {
+  const body: Record<string, unknown> = {
+    ...scopeBodyFields(scope),
+    mappingId: input.mappingId,
+  }
+  const response = await apiFetch('/api/integration/stock-preparation/material-mappings/retire', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+  return parseStockPreparationConfirmResponse<StockPreparationMaterialMappingRetireResult>(response)
+}
+
+export interface StockPreparationMaterialMappingSyncResult {
+  persisted: boolean
+  mode: 'created' | 'skipped_existing'
+  created: { mappings: number }
+  skipped: { existing: number; matched: number }
+  status: string
+  snapshotBatchId: string
+  evidence: Record<string, unknown>
+}
+
+/**
+ * System candidate sync feeding the review queue (CREATE-ONLY for new mappingIds; a confirmed row is
+ * never auto-unconfirmed). defaultVersionPolicy is REQUIRED per request — OD2: no server default,
+ * and this service deliberately supplies none either.
+ * POST /api/integration/stock-preparation/material-mappings/candidates/sync
+ */
+export async function syncStockPreparationMaterialMappingCandidates(
+  input: { defaultVersionPolicy: StockPreparationVersionPolicy; snapshotBatchId?: string | null },
+  scope: IntegrationScope & { projectId: string },
+): Promise<StockPreparationMaterialMappingSyncResult> {
+  const body: Record<string, unknown> = {
+    ...scopeBodyFields(scope),
+    ...(input.snapshotBatchId ? { snapshotBatchId: input.snapshotBatchId } : {}),
+    defaultVersionPolicy: input.defaultVersionPolicy,
+  }
+  const response = await apiFetch('/api/integration/stock-preparation/material-mappings/candidates/sync', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+  return parseStockPreparationConfirmResponse<StockPreparationMaterialMappingSyncResult>(response)
 }

--- a/apps/web/src/services/integration/stockPreparation/unitConversion.ts
+++ b/apps/web/src/services/integration/stockPreparation/unitConversion.ts
@@ -1,20 +1,58 @@
 // Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md)
-// per-view service stub: UNIT CONVERSION CONFIRMATION (design §"Frontend MVP" view 4).
+// per-view service module: UNIT CONVERSION CONFIRMATION (design §"Frontend MVP" view 4).
 //
 // Converts a PLM design unit into an ERP production-issue unit via a confirmed rule. If no unique
 // active rule exists the line enters the exception queue (never a silent guess).
 //
-// READONLY-FIRST: GET-only summary. No external write. A later "confirm rule" action is a
-// MULTITABLE-INTERNAL row write behind its own gate, not part of this stub.
+// INTERNAL-ONLY writes: the confirm / retire POSTs below are MULTITABLE-INTERNAL row writes against
+// the frozen MVP rule table (W3b, plugin-integration-core stock-preparation-confirm-writes.cjs).
+// No external ERP/K3 write. Candidates are COMPUTED server-side per read, never bulk-persisted —
+// a fingerprint confirm persists the SERVER-derived 1:1 candidate (its values never cross the wire),
+// and a manual rule is fully user-entered (OD3/OD4: the server never invents factors).
 //
-// VALUES-FREE contract: counts by scope_type / rounding_rule and pending counts only. No unit
-// symbols-as-data rows, conversion factors, loss rates, minimum quantities, or raw rule rows.
+// SERVER-STAMPED confirmation: confirmedBy / confirmedAt are NEVER in any request body — the route
+// derives the operator identity and the module stamps the time; a body that carries either is
+// rejected as an unknown field. Every body below is built from a CLOSED key set mirroring the
+// route's per-endpoint allowlist (mock-is-not-the-contract: both directions pinned in the specs).
+//
+// VALUES-FREE contract: counts by scope_type / rounding_rule / outcome / reason, booleans, and sha16
+// handles (contextFingerprint / conversionRuleId / snapshotBatchId) only. No unit symbols-as-data
+// rows, conversion factors, loss rates, or minimum quantities ever cross FROM the server;
+// user-ENTERED rule values flow only upward through the closed rule allowlist.
 import { apiFetch } from '../../../utils/api'
 import { buildQueryString, parseIntegrationResponse, type IntegrationScope } from '../workbench'
+import { parseStockPreparationConfirmResponse } from './confirmApi'
 
 export type StockPreparationUnitScopeType = 'material' | 'category' | 'generic'
 
 export type StockPreparationRoundingRule = 'none' | 'ceil' | 'floor' | 'nearest' | 'pack_size'
+
+// Fixed FE whitelists mirroring the server's frozen vocabularies
+// (stock-preparation-confirm-writes.cjs SCOPE_TYPES / ROUNDING_RULES).
+export const STOCK_PREPARATION_UNIT_SCOPE_TYPES: readonly StockPreparationUnitScopeType[] = [
+  'material',
+  'category',
+  'generic',
+]
+
+export const STOCK_PREPARATION_ROUNDING_RULES: readonly StockPreparationRoundingRule[] = [
+  'none',
+  'ceil',
+  'floor',
+  'nearest',
+  'pack_size',
+]
+
+// Engine outcome / held-reason vocabularies (stock-preparation-unit-rule-match.cjs).
+export type StockPreparationUnitRuleOutcome = 'reused' | 'candidate' | 'held'
+
+export type StockPreparationUnitHeldReason =
+  | 'missing_mapping'
+  | 'missing_material'
+  | 'missing_design_unit'
+  | 'missing_issue_unit'
+  | 'rule_missing'
+  | 'rule_conflict'
 
 export interface StockPreparationUnitConversionSummary {
   totalRuleCount: number
@@ -41,4 +79,185 @@ export async function getStockPreparationUnitConversionSummary(
     `/api/integration/stock-preparation/unit-conversions/summary${query ? `?${query}` : ''}`,
   )
   return parseIntegrationResponse<StockPreparationUnitConversionSummary>(response)
+}
+
+// ── candidates read (W3c R9 — COMPUTED per read, never persisted) ─────────────────────────────────
+
+/**
+ * One computed unit-rule context row. The server STRIPS candidate rule values (unit symbols /
+ * factor) — only `hasCandidate` crosses; a candidate row is confirmable via the fingerprint mode.
+ */
+export interface StockPreparationUnitConversionCandidateRow {
+  /** sha16 handle for the computed unit context — the fingerprint confirm mode's identity. */
+  contextFingerprint: string | null
+  outcome: StockPreparationUnitRuleOutcome | string | null
+  reason?: StockPreparationUnitHeldReason | string
+  /** Present on `reused` rows: the sha16 handle of the active rule that already covers the context. */
+  conversionRuleId?: string
+  hasCandidate: boolean
+}
+
+export interface StockPreparationUnitConversionCandidateList {
+  status: 'ready' | 'pending_confirmation' | 'held' | string
+  snapshotBatchId: string
+  rowCount: number
+  byOutcome: Record<string, number>
+  byReason: Record<string, number>
+  rows: StockPreparationUnitConversionCandidateRow[]
+}
+
+/**
+ * Values-free COMPUTED unit-rule candidate list over the latest complete snapshot batch (404 with
+ * code CONFIRM_READS_BATCH_NOT_FOUND when the project has no complete batch).
+ * GET /api/integration/stock-preparation/unit-conversions/candidates
+ */
+export async function listStockPreparationUnitConversionCandidates(
+  scope: IntegrationScope & { projectId: string; snapshotBatchId?: string | null },
+): Promise<StockPreparationUnitConversionCandidateList> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+    snapshotBatchId: scope.snapshotBatchId,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/unit-conversions/candidates${query ? `?${query}` : ''}`,
+  )
+  return parseStockPreparationConfirmResponse<StockPreparationUnitConversionCandidateList>(response)
+}
+
+// ── human confirm writes (W3b R10-R11; multitable-internal only) ──────────────────────────────────
+
+/** Values-free per-op evidence: subject kind + mode + target identity (objectId / key-field NAME). */
+export interface StockPreparationUnitConfirmEvidence {
+  subject: string
+  mode: string
+  target: { objectId: string; keyField: string }
+  valuesFree: boolean
+}
+
+// Closed rule-mode key set — EXACT mirror of the route module's RULE_CREATE_ALLOWED_KEYS
+// (stock-preparation-confirm-writes.cjs). The body's `rule` object is grounded to these keys so an
+// accidental extra property (above all confirmedBy / confirmedAt) can never reach the wire.
+const RULE_DRAFT_KEYS = [
+  'plmUnit',
+  'erpIssueUnit',
+  'conversionFactor',
+  'scopeType',
+  'scopeKey',
+  'lossRate',
+  'roundingRule',
+  'minimumIssueQty',
+  'effectiveFrom',
+  'effectiveTo',
+] as const
+
+/** Fully user-entered rule (OD3/OD4: operators enter values, the server never invents them). */
+export interface StockPreparationUnitConversionRuleDraft {
+  plmUnit: string
+  erpIssueUnit: string
+  conversionFactor: number
+  scopeType: StockPreparationUnitScopeType
+  /** Required for material/category scope; FORBIDDEN for generic scope (server rejects it). */
+  scopeKey?: string
+  lossRate?: number
+  roundingRule?: StockPreparationRoundingRule
+  minimumIssueQty?: number
+  effectiveFrom?: string
+  effectiveTo?: string
+}
+
+/**
+ * Tri-XOR confirm modes (exactly one of):
+ *  - conversionRuleId   — stamp an EXISTING manual-provenance rule row;
+ *  - contextFingerprint — persist the SERVER-derived 1:1 candidate for a computed context
+ *                         (projectId required: the server recomputes over that project's batch);
+ *  - rule               — create a fully user-entered rule.
+ */
+export type StockPreparationUnitConversionConfirmInput =
+  | { conversionRuleId: string; contextFingerprint?: undefined; rule?: undefined }
+  | { contextFingerprint: string; projectId: string; snapshotBatchId?: string | null; conversionRuleId?: undefined; rule?: undefined }
+  | { rule: StockPreparationUnitConversionRuleDraft; conversionRuleId?: undefined; contextFingerprint?: undefined }
+
+export interface StockPreparationUnitConversionConfirmResult {
+  persisted: boolean
+  mode: 'confirmed' | 'created' | 'skipped_already_confirmed' | 'skipped_existing'
+  conversionRuleId: string | null
+  evidence: StockPreparationUnitConfirmEvidence
+}
+
+function unitScopeBodyFields(scope: IntegrationScope & { projectId?: string | null }): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (scope.tenantId) out.tenantId = scope.tenantId
+  if (scope.workspaceId) out.workspaceId = scope.workspaceId
+  if (scope.projectId) out.projectId = scope.projectId
+  return out
+}
+
+function groundRuleDraft(draft: StockPreparationUnitConversionRuleDraft): Record<string, unknown> {
+  const source = draft as unknown as Record<string, unknown>
+  const out: Record<string, unknown> = {}
+  for (const key of RULE_DRAFT_KEYS) {
+    const value = source[key]
+    if (value === undefined || value === null || value === '') continue
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Human unit-rule confirm — tri-XOR body modes per the route allowlist. confirmedBy / confirmedAt
+ * are server-derived and NEVER in the body (the route rejects them as unknown fields). A 409 with
+ * code CONFIRM_UNIT_CANDIDATE_NOT_FOUND on the fingerprint mode means the candidate view is STALE
+ * (snapshot changed / a rule landed meanwhile) — re-read before confirming.
+ * POST /api/integration/stock-preparation/unit-conversions/confirm
+ */
+export async function confirmStockPreparationUnitConversionRule(
+  input: StockPreparationUnitConversionConfirmInput,
+  scope: IntegrationScope & { projectId?: string | null } = {},
+): Promise<StockPreparationUnitConversionConfirmResult> {
+  const body: Record<string, unknown> = {
+    ...unitScopeBodyFields(scope),
+    ...(input.conversionRuleId !== undefined ? { conversionRuleId: input.conversionRuleId } : {}),
+    ...(input.contextFingerprint !== undefined
+      ? {
+          contextFingerprint: input.contextFingerprint,
+          projectId: input.projectId,
+          ...(input.snapshotBatchId ? { snapshotBatchId: input.snapshotBatchId } : {}),
+        }
+      : {}),
+    ...(input.rule !== undefined ? { rule: groundRuleDraft(input.rule) } : {}),
+  }
+  const response = await apiFetch('/api/integration/stock-preparation/unit-conversions/confirm', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+  return parseStockPreparationConfirmResponse<StockPreparationUnitConversionConfirmResult>(response)
+}
+
+export interface StockPreparationUnitConversionRetireResult {
+  persisted: boolean
+  mode: 'retired' | 'skipped_inactive'
+  conversionRuleId: string
+  evidence: StockPreparationUnitConfirmEvidence
+}
+
+/**
+ * Retire a unit rule (server patches EXACTLY isActive:false) — required before re-creating a
+ * same-scope rule with a different factor (two active same-scope rules fail closed as a conflict).
+ * POST /api/integration/stock-preparation/unit-conversions/retire
+ */
+export async function retireStockPreparationUnitConversionRule(
+  input: { conversionRuleId: string },
+  scope: IntegrationScope & { projectId?: string | null } = {},
+): Promise<StockPreparationUnitConversionRetireResult> {
+  const body: Record<string, unknown> = {
+    ...unitScopeBodyFields(scope),
+    conversionRuleId: input.conversionRuleId,
+  }
+  const response = await apiFetch('/api/integration/stock-preparation/unit-conversions/retire', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+  return parseStockPreparationConfirmResponse<StockPreparationUnitConversionRetireResult>(response)
 }

--- a/apps/web/tests/StockPreparationMappingConfirmView.spec.ts
+++ b/apps/web/tests/StockPreparationMappingConfirmView.spec.ts
@@ -1,0 +1,497 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, ref, type App as VueApp, type Component } from 'vue'
+
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md).
+// Frontend MVP view 3: MATERIAL MAPPING CONFIRMATION. This spec mocks ONLY apiFetch and drives the
+// REAL service module (materialMapping.ts + confirmApi.ts) through the view, so it pins BOTH
+// directions of the wire contract (mock-is-not-the-contract):
+//   - requests: exact URL paths, exact query key sets, exact POST body key sets — and above all
+//     that confirmedBy / confirmedAt NEVER appear anywhere in a request body (server-stamped);
+//   - responses: the view renders only the values-free projection — planted business values
+//     (drawing numbers / material names / ERP codes) never reach the DOM, and error surfaces render
+//     the clamped code / field NAME, never the raw error body.
+
+const h = vi.hoisted(() => ({
+  locale: 'zh-CN' as string,
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('../src/composables/useLocale', () => ({
+  useLocale: () => ({
+    locale: ref(h.locale),
+    isZh: ref(h.locale === 'zh-CN'),
+    setLocale: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/utils/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/utils/api')>('../src/utils/api')
+  return {
+    ...actual,
+    apiFetch: h.apiFetch,
+  }
+})
+
+import StockPreparationMappingConfirmView from '../src/components/integration/stockPreparation/StockPreparationMappingConfirmView.vue'
+
+// Planted business values — the view must render NONE of them (fixed-whitelist rendering).
+const PLANTED_DRAWING_NO = 'DWG-88472-A'
+const PLANTED_MATERIAL_NAME = '涡轮叶片总成'
+const PLANTED_ERP_CODE = 'MAT-ZX9911'
+const PLANTED_RAW_ERROR = 'connectionString=host=erp;pwd=secret-42007;drawing=DWG-LEAK-9'
+const FORBIDDEN = [PLANTED_DRAWING_NO, PLANTED_MATERIAL_NAME, PLANTED_ERP_CODE, 'secret-42007', 'DWG-LEAK-9']
+
+function ok(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ ok: true, data }), { status })
+}
+
+function fail(status: number, code: string, field?: string): Response {
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      error: { code, message: PLANTED_RAW_ERROR, details: field ? { field } : {} },
+    }),
+    { status },
+  )
+}
+
+function summaryData(): Record<string, unknown> {
+  return {
+    totalMappingCount: 6,
+    activeMappingCount: 5,
+    matchStatusCounts: { matched: 2, pending_confirm: 1, multi_candidate: 1, not_found: 1, version_conflict: 0 },
+    versionPolicyCounts: { drawing_and_version: 3, drawing_only: 1, category_rule: 0, manual: 1 },
+    pendingConfirmCount: 3,
+  }
+}
+
+function candidatesData(): Record<string, unknown> {
+  return {
+    rowCount: 2,
+    byMatchStatus: { matched: 0, pending_confirm: 1, multi_candidate: 0, not_found: 1, version_conflict: 0 },
+    rows: [
+      {
+        mappingId: 'map-handle-alpha',
+        matchStatus: 'pending_confirm',
+        matchMethod: 'exact_code_candidate',
+        versionPolicy: 'drawing_and_version',
+        confidence: 0.9,
+        isActive: true,
+        confirmed: false,
+        hasErpTarget: true,
+        plmVersionPresent: true,
+        // Planted business values (NOT part of the wire shape) — must never reach the DOM.
+        plmDrawingNo: PLANTED_DRAWING_NO,
+        plmMaterialName: PLANTED_MATERIAL_NAME,
+        erpMaterialCode: PLANTED_ERP_CODE,
+      },
+      {
+        mappingId: 'map-handle-beta',
+        matchStatus: 'not_found',
+        versionPolicy: 'drawing_only',
+        confidence: null,
+        isActive: true,
+        confirmed: false,
+        hasErpTarget: false,
+        plmVersionPresent: false,
+      },
+    ],
+  }
+}
+
+interface MockOverrides {
+  confirm?: () => Response
+  sync?: () => Response
+  retire?: () => Response
+}
+
+function mockRoutes(overrides: MockOverrides = {}): void {
+  h.apiFetch.mockImplementation(async (url: string) => {
+    // Order matters: /candidates/sync must be matched BEFORE /candidates.
+    if (url.includes('/material-mappings/candidates/sync')) {
+      return overrides.sync
+        ? overrides.sync()
+        : ok({
+            persisted: true,
+            mode: 'created',
+            created: { mappings: 3 },
+            skipped: { existing: 1, matched: 0 },
+            status: 'pending_confirmation',
+            snapshotBatchId: 'batch-handle-alpha',
+            evidence: { valuesFree: true },
+          }, 201)
+    }
+    if (url.includes('/material-mappings/candidates')) return ok(candidatesData())
+    if (url.includes('/material-mappings/summary')) return ok(summaryData())
+    if (url.includes('/material-mappings/confirm')) {
+      return overrides.confirm
+        ? overrides.confirm()
+        : ok({
+            persisted: true,
+            mode: 'confirmed',
+            mappingId: 'map-handle-alpha',
+            evidence: { subject: 'mapping', mode: 'confirmed', target: { objectId: 'obj', keyField: 'mappingId' }, valuesFree: true },
+          })
+    }
+    if (url.includes('/material-mappings/retire')) {
+      return overrides.retire
+        ? overrides.retire()
+        : ok({
+            persisted: true,
+            mode: 'retired',
+            mappingId: 'map-handle-alpha',
+            evidence: { subject: 'mapping', mode: 'retired', target: { objectId: 'obj', keyField: 'mappingId' }, valuesFree: true },
+          })
+    }
+    return ok({})
+  })
+}
+
+// Bounded polling wait (#4017 idiom): real Response.json() can take macrotask turns, so
+// microtask-only flushes are timing-fragile on slower CI runners. Throws on timeout.
+async function waitForSelector(container: HTMLElement, selector: string, cycles = 40): Promise<Element> {
+  for (let i = 0; i < cycles; i += 1) {
+    const el = container.querySelector(selector)
+    if (el) return el
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+  throw new Error(`Timed out waiting for selector: ${selector}`)
+}
+
+async function waitForCondition(check: () => boolean, cycles = 40): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    if (check()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+  throw new Error('Timed out waiting for condition')
+}
+
+function urlsMatching(fragment: string): string[] {
+  return h.apiFetch.mock.calls.map((call) => String(call[0])).filter((url) => url.includes(fragment))
+}
+
+function postCalls(fragment: string): Array<{ url: string; body: Record<string, unknown> }> {
+  return h.apiFetch.mock.calls
+    .filter((call) => String(call[0]).includes(fragment) && (call[1] as { method?: string } | undefined)?.method === 'POST')
+    .map((call) => ({ url: String(call[0]), body: JSON.parse(String((call[1] as { body?: string }).body)) as Record<string, unknown> }))
+}
+
+function queryKeys(url: string): { path: string; params: URLSearchParams } {
+  const [path, query = ''] = url.split('?')
+  return { path, params: new URLSearchParams(query) }
+}
+
+function setInput(root: HTMLElement, testid: string, value: string): void {
+  const input = root.querySelector(`[data-testid="${testid}"]`) as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+function setSelect(root: HTMLElement, testid: string, value: string): void {
+  const select = root.querySelector(`[data-testid="${testid}"]`) as HTMLSelectElement
+  select.value = value
+  select.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+describe('StockPreparationMappingConfirmView (view 3: confirm reads + human confirm writes)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    h.locale = 'zh-CN'
+    h.apiFetch.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  function mountView(props: Record<string, unknown> = { projectId: 'proj-alpha' }): HTMLDivElement {
+    app = createApp(StockPreparationMappingConfirmView as Component, props)
+    app.mount(container!)
+    return container!
+  }
+
+  it('shows the select-a-project state and issues NO request when no projectId is provided', async () => {
+    mockRoutes()
+    const root = mountView({})
+    await nextTick()
+    expect(root.querySelector('[data-testid="stock-prep-mapping-no-project"]')).not.toBeNull()
+    expect(h.apiFetch).not.toHaveBeenCalled()
+  })
+
+  it('loads summary + queue via exact readonly GETs and renders the values-free projection', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+
+    // Direction pin (request): exact paths, exact query key sets, and NO write options on the GETs.
+    const summaryUrls = urlsMatching('/material-mappings/summary')
+    expect(summaryUrls.length).toBe(1)
+    const summaryParts = queryKeys(summaryUrls[0])
+    expect(summaryParts.path).toBe('/api/integration/stock-preparation/material-mappings/summary')
+    expect([...summaryParts.params.keys()].sort()).toEqual(['projectId'])
+    expect(summaryParts.params.get('projectId')).toBe('proj-alpha')
+
+    const candidateUrls = urlsMatching('/material-mappings/candidates')
+    expect(candidateUrls.length).toBe(1)
+    const candidateParts = queryKeys(candidateUrls[0])
+    expect(candidateParts.path).toBe('/api/integration/stock-preparation/material-mappings/candidates')
+    expect([...candidateParts.params.keys()].sort()).toEqual(['projectId'])
+    for (const call of h.apiFetch.mock.calls) {
+      expect((call[1] as { method?: string } | undefined)?.method).toBeUndefined()
+    }
+
+    // Summary header: the five indicators.
+    const metrics = root.querySelectorAll('[data-testid="stock-prep-mapping-metric"]')
+    expect(metrics.length).toBe(5)
+    expect(root.querySelector('[data-testid="stock-prep-mapping-metric"][data-kind="total"]')?.textContent).toContain('6')
+    expect(root.querySelector('[data-testid="stock-prep-mapping-metric"][data-kind="active"]')?.textContent).toContain('5')
+    expect(root.querySelector('[data-testid="stock-prep-mapping-metric"][data-kind="pending-confirm"]')?.textContent).toContain('3')
+    expect(root.querySelectorAll('[data-testid="stock-prep-mapping-status-count"]').length).toBe(5)
+    expect(root.querySelectorAll('[data-testid="stock-prep-mapping-policy-count"]').length).toBe(4)
+
+    // Queue rows render enum/boolean/handle whitelist only.
+    const rows = root.querySelectorAll('[data-testid="stock-prep-mapping-row"]')
+    expect(rows.length).toBe(2)
+    expect(rows[0].querySelector('[data-testid="stock-prep-mapping-row-handle"]')?.textContent).toBe('map-handle-alpha')
+    expect(rows[0].querySelector('[data-testid="stock-prep-mapping-row-status"]')?.textContent?.trim()).toBe('pending_confirm')
+    expect(rows[0].querySelector('[data-testid="stock-prep-mapping-row-method"]')?.textContent).toContain('exact_code_candidate')
+    expect(rows[1].querySelector('[data-testid="stock-prep-mapping-row-method"]')?.textContent).toContain('—')
+    expect(rows[1].querySelector('[data-testid="stock-prep-mapping-row-confidence"]')?.textContent).toContain('—')
+    expect(rows[0].querySelector('[data-testid="stock-prep-mapping-row-erp-target"]')?.getAttribute('data-flag')).toBe('true')
+    expect(rows[1].querySelector('[data-testid="stock-prep-mapping-row-erp-target"]')?.getAttribute('data-flag')).toBe('false')
+
+    // Values-free guard: no planted business value ever reaches the DOM.
+    const text = root.textContent || ''
+    for (const forbidden of FORBIDDEN) {
+      expect(text).not.toContain(forbidden)
+    }
+  })
+
+  it('re-reads the queue with the exact matchStatus filter key set when the filter changes', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+
+    setSelect(root, 'stock-prep-mapping-filter', 'not_found')
+    await waitForCondition(() => urlsMatching('/material-mappings/candidates').length === 2)
+
+    const parts = queryKeys(urlsMatching('/material-mappings/candidates')[1])
+    expect([...parts.params.keys()].sort()).toEqual(['matchStatus', 'projectId'])
+    expect(parts.params.get('matchStatus')).toBe('not_found')
+  })
+
+  it('confirms a candidate in mappingId mode with the EXACT body key set, then refreshes both reads', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+
+    const rows = root.querySelectorAll('[data-testid="stock-prep-mapping-row"]')
+    // Only the row with BOTH ERP identifiers is confirmable (server 409s otherwise).
+    const confirmAlpha = rows[0].querySelector('[data-testid="stock-prep-mapping-row-confirm"]') as HTMLButtonElement
+    const confirmBeta = rows[1].querySelector('[data-testid="stock-prep-mapping-row-confirm"]') as HTMLButtonElement
+    expect(confirmAlpha.disabled).toBe(false)
+    expect(confirmBeta.disabled).toBe(true)
+
+    confirmAlpha.click()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-action-notice"]')
+
+    const posts = postCalls('/material-mappings/confirm')
+    expect(posts.length).toBe(1)
+    expect(posts[0].url).toBe('/api/integration/stock-preparation/material-mappings/confirm')
+    // XOR pin: mappingId mode carries mappingId and NOT mapping; server-stamped fields NEVER cross.
+    expect(Object.keys(posts[0].body).sort()).toEqual(['mappingId', 'projectId'])
+    expect(posts[0].body.mappingId).toBe('map-handle-alpha')
+    expect(posts[0].body.projectId).toBe('proj-alpha')
+    const rawBody = JSON.stringify(posts[0].body)
+    expect(rawBody).not.toContain('confirmedBy')
+    expect(rawBody).not.toContain('confirmedAt')
+
+    // Confirm → both reads re-issued (summary + candidates twice each).
+    await waitForCondition(() => urlsMatching('/material-mappings/summary').length === 2)
+    expect(urlsMatching('/material-mappings/candidates').length).toBe(2)
+    expect(root.querySelector('[data-testid="stock-prep-mapping-action-notice"]')?.textContent).toContain('confirmed')
+  })
+
+  it('renders a values-free action error (clamped code, never the raw body) on a 409 confirm', async () => {
+    mockRoutes({ confirm: () => fail(409, 'CONFIRM_MAPPING_TARGET_INCOMPLETE') })
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+    ;(root.querySelector('[data-testid="stock-prep-mapping-row-confirm"]') as HTMLButtonElement).click()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-action-error"]')
+
+    const text = root.textContent || ''
+    expect(text).toContain('CONFIRM_MAPPING_TARGET_INCOMPLETE')
+    for (const forbidden of FORBIDDEN) {
+      expect(text).not.toContain(forbidden)
+    }
+  })
+
+  it('retires a row with the EXACT body key set', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+    ;(root.querySelector('[data-testid="stock-prep-mapping-row-retire"]') as HTMLButtonElement).click()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-action-notice"]')
+
+    const posts = postCalls('/material-mappings/retire')
+    expect(posts.length).toBe(1)
+    expect(posts[0].url).toBe('/api/integration/stock-preparation/material-mappings/retire')
+    expect(Object.keys(posts[0].body).sort()).toEqual(['mappingId', 'projectId'])
+    expect(JSON.stringify(posts[0].body)).not.toContain('confirmed')
+  })
+
+  it('gates candidate sync on an explicit defaultVersionPolicy (OD2: no default) and posts the exact keys', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+
+    // No policy chosen → sync entry disabled and no POST possible.
+    const syncButton = root.querySelector('[data-testid="stock-prep-mapping-sync"]') as HTMLButtonElement
+    expect(syncButton.disabled).toBe(true)
+    syncButton.click()
+    await nextTick()
+    expect(postCalls('/material-mappings/candidates/sync').length).toBe(0)
+
+    setSelect(root, 'stock-prep-mapping-sync-policy', 'drawing_only')
+    await waitForCondition(() => !(root.querySelector('[data-testid="stock-prep-mapping-sync"]') as HTMLButtonElement).disabled)
+    ;(root.querySelector('[data-testid="stock-prep-mapping-sync"]') as HTMLButtonElement).click()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-sync-result"]')
+
+    const posts = postCalls('/material-mappings/candidates/sync')
+    expect(posts.length).toBe(1)
+    expect(posts[0].url).toBe('/api/integration/stock-preparation/material-mappings/candidates/sync')
+    expect(Object.keys(posts[0].body).sort()).toEqual(['defaultVersionPolicy', 'projectId'])
+    expect(posts[0].body.defaultVersionPolicy).toBe('drawing_only')
+
+    // Values-free sync note: mode + created count only; reads refreshed.
+    const note = root.querySelector('[data-testid="stock-prep-mapping-sync-result"]') as HTMLElement
+    expect(note.textContent).toContain('created')
+    expect(note.textContent).toContain('3')
+    await waitForCondition(() => urlsMatching('/material-mappings/summary').length === 2)
+  })
+
+  it('mirrors the server create-mode rules client-side ({field} errors, NO premature POST)', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+    const form = root.querySelector('[data-testid="stock-prep-mapping-create-form"]') as HTMLFormElement
+
+    // Empty form → first missing required field, by NAME.
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-form-error"]')
+    expect(root.querySelector('[data-testid="stock-prep-mapping-form-error"]')?.textContent).toContain('plmDrawingNo')
+
+    // Both ERP identifiers are required.
+    setInput(root, 'stock-prep-mapping-form-drawing', 'OPERATOR-DRAWING-1')
+    setInput(root, 'stock-prep-mapping-form-erp-code', 'OPERATOR-CODE-1')
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForCondition(() =>
+      (root.querySelector('[data-testid="stock-prep-mapping-form-error"]')?.textContent || '').includes('erpMaterialInternalId'))
+
+    // drawing_and_version requires a plmVersion.
+    setInput(root, 'stock-prep-mapping-form-erp-internal', 'OPERATOR-INTERNAL-1')
+    setSelect(root, 'stock-prep-mapping-form-policy', 'drawing_and_version')
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForCondition(() =>
+      (root.querySelector('[data-testid="stock-prep-mapping-form-error"]')?.textContent || '').includes('plmVersion'))
+
+    // No confirm POST was ever issued by the client mirror.
+    expect(postCalls('/material-mappings/confirm').length).toBe(0)
+  })
+
+  it('creates a confirmed mapping with the EXACT nested key set (grounded to the server allowlist)', async () => {
+    mockRoutes({
+      confirm: () => ok({
+        persisted: true,
+        mode: 'created',
+        mappingId: 'map-handle-created',
+        evidence: { subject: 'mapping', mode: 'created', target: { objectId: 'obj', keyField: 'mappingId' }, valuesFree: true },
+      }, 201),
+    })
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+
+    setInput(root, 'stock-prep-mapping-form-drawing', 'OPERATOR-DRAWING-1')
+    setInput(root, 'stock-prep-mapping-form-version', 'B')
+    setInput(root, 'stock-prep-mapping-form-erp-code', 'OPERATOR-CODE-1')
+    setInput(root, 'stock-prep-mapping-form-erp-internal', 'OPERATOR-INTERNAL-1')
+    setSelect(root, 'stock-prep-mapping-form-policy', 'drawing_and_version')
+    setInput(root, 'stock-prep-mapping-form-notes', 'operator note')
+    const form = root.querySelector('[data-testid="stock-prep-mapping-create-form"]') as HTMLFormElement
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-action-notice"]')
+
+    const posts = postCalls('/material-mappings/confirm')
+    expect(posts.length).toBe(1)
+    // XOR pin: create mode carries mapping and NOT mappingId.
+    expect(Object.keys(posts[0].body).sort()).toEqual(['mapping', 'projectId'])
+    const mapping = posts[0].body.mapping as Record<string, unknown>
+    expect(Object.keys(mapping).sort()).toEqual([
+      'erpMaterialCode',
+      'erpMaterialInternalId',
+      'notes',
+      'plmDrawingNo',
+      'plmVersion',
+      'versionPolicy',
+    ])
+    expect(mapping.versionPolicy).toBe('drawing_and_version')
+    const rawBody = JSON.stringify(posts[0].body)
+    expect(rawBody).not.toContain('confirmedBy')
+    expect(rawBody).not.toContain('confirmedAt')
+
+    // Success → notice + form cleared + reads refreshed.
+    expect(root.querySelector('[data-testid="stock-prep-mapping-action-notice"]')?.textContent).toContain('created')
+    expect((root.querySelector('[data-testid="stock-prep-mapping-form-drawing"]') as HTMLInputElement).value).toBe('')
+    await waitForCondition(() => urlsMatching('/material-mappings/summary').length === 2)
+  })
+
+  it('routes a server {field} error into the form field-error surface (server stays authoritative)', async () => {
+    mockRoutes({ confirm: () => fail(400, 'CONFIRM_MAPPING_FIELDS_INVALID', 'plmVersion') })
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+
+    // Client mirror passes (drawing_only needs no version) — the server error must still land.
+    setInput(root, 'stock-prep-mapping-form-drawing', 'OPERATOR-DRAWING-1')
+    setInput(root, 'stock-prep-mapping-form-erp-code', 'OPERATOR-CODE-1')
+    setInput(root, 'stock-prep-mapping-form-erp-internal', 'OPERATOR-INTERNAL-1')
+    setSelect(root, 'stock-prep-mapping-form-policy', 'drawing_only')
+    const form = root.querySelector('[data-testid="stock-prep-mapping-create-form"]') as HTMLFormElement
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-form-error"]')
+
+    const text = root.querySelector('[data-testid="stock-prep-mapping-form-error"]')?.textContent || ''
+    expect(text).toContain('plmVersion')
+    // The raw error body (message with values) never reaches the DOM.
+    expect(root.textContent || '').not.toContain('secret-42007')
+    expect(root.textContent || '').not.toContain('DWG-LEAK-9')
+  })
+
+  it('renders a neutral error state when a read rejects (404-soft), never the raw body', async () => {
+    h.apiFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/material-mappings/summary')) return fail(404, 'NOT_FOUND')
+      return ok(candidatesData())
+    })
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-error"]')
+    expect(root.querySelector('[data-testid="stock-prep-mapping-overview"]')).toBeNull()
+    expect(root.textContent || '').not.toContain('secret-42007')
+  })
+
+  it('renders the English copy when locale is not zh-CN', async () => {
+    h.locale = 'en'
+    mockRoutes()
+    const root = mountView({})
+    await nextTick()
+    expect(root.querySelector('[data-testid="stock-prep-mapping-no-project"]')?.textContent).toMatch(/select a project/i)
+  })
+})

--- a/apps/web/tests/StockPreparationUnitConfirmView.spec.ts
+++ b/apps/web/tests/StockPreparationUnitConfirmView.spec.ts
@@ -1,0 +1,462 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, ref, type App as VueApp, type Component } from 'vue'
+
+// Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md).
+// Frontend MVP view 4: UNIT CONVERSION CONFIRMATION. This spec mocks ONLY apiFetch and drives the
+// REAL service module (unitConversion.ts + confirmApi.ts) through the view, pinning BOTH directions
+// of the wire contract (mock-is-not-the-contract):
+//   - requests: exact URL paths, exact query key sets, exact POST body key sets (tri-XOR modes) —
+//     and that confirmedBy / confirmedAt NEVER appear anywhere in a request body (server-stamped);
+//   - responses: only the values-free projection renders — planted candidate values (unit symbols /
+//     factors) never reach the DOM; 404 CONFIRM_READS_BATCH_NOT_FOUND is a neutral no-batch state;
+//     409 CONFIRM_UNIT_CANDIDATE_NOT_FOUND surfaces the STALE notice with a re-read entry.
+
+const h = vi.hoisted(() => ({
+  locale: 'zh-CN' as string,
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('../src/composables/useLocale', () => ({
+  useLocale: () => ({
+    locale: ref(h.locale),
+    isZh: ref(h.locale === 'zh-CN'),
+    setLocale: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/utils/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/utils/api')>('../src/utils/api')
+  return {
+    ...actual,
+    apiFetch: h.apiFetch,
+  }
+})
+
+import StockPreparationUnitConfirmView from '../src/components/integration/stockPreparation/StockPreparationUnitConfirmView.vue'
+
+// Planted business values — the view must render NONE of them (fixed-whitelist rendering).
+const PLANTED_UNIT = 'KG-SENTINEL'
+const PLANTED_FACTOR = '73991'
+const PLANTED_RAW_ERROR = 'connectionString=host=erp;pwd=secret-42007;unit=PCS-LEAK'
+const FORBIDDEN = [PLANTED_UNIT, PLANTED_FACTOR, 'secret-42007', 'PCS-LEAK']
+
+function ok(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ ok: true, data }), { status })
+}
+
+function fail(status: number, code: string, field?: string): Response {
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      error: { code, message: PLANTED_RAW_ERROR, details: field ? { field } : {} },
+    }),
+    { status },
+  )
+}
+
+function summaryData(): Record<string, unknown> {
+  return {
+    totalRuleCount: 4,
+    activeRuleCount: 3,
+    requiresConfirmationCount: 1,
+    scopeTypeCounts: { material: 2, category: 0, generic: 1 },
+    roundingRuleCounts: { none: 2, ceil: 1, floor: 0, nearest: 0, pack_size: 0 },
+    pendingUnitLineCount: 2,
+  }
+}
+
+function candidatesData(): Record<string, unknown> {
+  return {
+    status: 'pending_confirmation',
+    snapshotBatchId: 'batch-handle-alpha',
+    rowCount: 3,
+    byOutcome: { reused: 1, candidate: 1, held: 1 },
+    byReason: { unknown: 2, rule_missing: 1 },
+    rows: [
+      {
+        contextFingerprint: 'fp-handle-alpha',
+        outcome: 'candidate',
+        hasCandidate: true,
+        // Planted candidate values (the REAL server strips these) — must never reach the DOM.
+        candidateRule: { plmUnit: PLANTED_UNIT, conversionFactor: PLANTED_FACTOR },
+        plmUnit: PLANTED_UNIT,
+      },
+      {
+        contextFingerprint: 'fp-handle-beta',
+        outcome: 'reused',
+        conversionRuleId: 'rule-handle-gamma',
+        hasCandidate: false,
+      },
+      {
+        contextFingerprint: 'fp-handle-delta',
+        outcome: 'held',
+        reason: 'rule_missing',
+        hasCandidate: false,
+      },
+    ],
+  }
+}
+
+interface MockOverrides {
+  candidates?: () => Response
+  confirm?: () => Response
+  retire?: () => Response
+}
+
+function mockRoutes(overrides: MockOverrides = {}): void {
+  h.apiFetch.mockImplementation(async (url: string) => {
+    if (url.includes('/unit-conversions/candidates')) {
+      return overrides.candidates ? overrides.candidates() : ok(candidatesData())
+    }
+    if (url.includes('/unit-conversions/summary')) return ok(summaryData())
+    if (url.includes('/unit-conversions/confirm')) {
+      return overrides.confirm
+        ? overrides.confirm()
+        : ok({
+            persisted: true,
+            mode: 'created',
+            conversionRuleId: 'rule-handle-created',
+            evidence: { subject: 'unit_rule', mode: 'created', target: { objectId: 'obj', keyField: 'conversionRuleId' }, valuesFree: true },
+          }, 201)
+    }
+    if (url.includes('/unit-conversions/retire')) {
+      return overrides.retire
+        ? overrides.retire()
+        : ok({
+            persisted: true,
+            mode: 'retired',
+            conversionRuleId: 'rule-handle-gamma',
+            evidence: { subject: 'unit_rule', mode: 'retired', target: { objectId: 'obj', keyField: 'conversionRuleId' }, valuesFree: true },
+          })
+    }
+    return ok({})
+  })
+}
+
+// Bounded polling wait (#4017 idiom): real Response.json() can take macrotask turns, so
+// microtask-only flushes are timing-fragile on slower CI runners. Throws on timeout.
+async function waitForSelector(container: HTMLElement, selector: string, cycles = 40): Promise<Element> {
+  for (let i = 0; i < cycles; i += 1) {
+    const el = container.querySelector(selector)
+    if (el) return el
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+  throw new Error(`Timed out waiting for selector: ${selector}`)
+}
+
+async function waitForCondition(check: () => boolean, cycles = 40): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    if (check()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+  throw new Error('Timed out waiting for condition')
+}
+
+function urlsMatching(fragment: string): string[] {
+  return h.apiFetch.mock.calls.map((call) => String(call[0])).filter((url) => url.includes(fragment))
+}
+
+function postCalls(fragment: string): Array<{ url: string; body: Record<string, unknown> }> {
+  return h.apiFetch.mock.calls
+    .filter((call) => String(call[0]).includes(fragment) && (call[1] as { method?: string } | undefined)?.method === 'POST')
+    .map((call) => ({ url: String(call[0]), body: JSON.parse(String((call[1] as { body?: string }).body)) as Record<string, unknown> }))
+}
+
+function queryKeys(url: string): { path: string; params: URLSearchParams } {
+  const [path, query = ''] = url.split('?')
+  return { path, params: new URLSearchParams(query) }
+}
+
+function setInput(root: HTMLElement, testid: string, value: string): void {
+  const input = root.querySelector(`[data-testid="${testid}"]`) as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+function setSelect(root: HTMLElement, testid: string, value: string): void {
+  const select = root.querySelector(`[data-testid="${testid}"]`) as HTMLSelectElement
+  select.value = value
+  select.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+describe('StockPreparationUnitConfirmView (view 4: confirm reads + human confirm writes)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    h.locale = 'zh-CN'
+    h.apiFetch.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  function mountView(props: Record<string, unknown> = { projectId: 'proj-alpha' }): HTMLDivElement {
+    app = createApp(StockPreparationUnitConfirmView as Component, props)
+    app.mount(container!)
+    return container!
+  }
+
+  it('shows the select-a-project state and issues NO request when no projectId is provided', async () => {
+    mockRoutes()
+    const root = mountView({})
+    await nextTick()
+    expect(root.querySelector('[data-testid="stock-prep-unit-no-project"]')).not.toBeNull()
+    expect(h.apiFetch).not.toHaveBeenCalled()
+  })
+
+  it('loads summary + computed candidates via exact readonly GETs and renders the values-free projection', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-queue"]')
+
+    // Direction pin (request): exact paths, exact query key sets, and NO write options on the GETs.
+    const summaryParts = queryKeys(urlsMatching('/unit-conversions/summary')[0])
+    expect(summaryParts.path).toBe('/api/integration/stock-preparation/unit-conversions/summary')
+    expect([...summaryParts.params.keys()].sort()).toEqual(['projectId'])
+    expect(summaryParts.params.get('projectId')).toBe('proj-alpha')
+    const candidateParts = queryKeys(urlsMatching('/unit-conversions/candidates')[0])
+    expect(candidateParts.path).toBe('/api/integration/stock-preparation/unit-conversions/candidates')
+    expect([...candidateParts.params.keys()].sort()).toEqual(['projectId'])
+    for (const call of h.apiFetch.mock.calls) {
+      expect((call[1] as { method?: string } | undefined)?.method).toBeUndefined()
+    }
+
+    // Summary header: the six indicators.
+    const metrics = root.querySelectorAll('[data-testid="stock-prep-unit-metric"]')
+    expect(metrics.length).toBe(6)
+    expect(root.querySelector('[data-testid="stock-prep-unit-metric"][data-kind="total"]')?.textContent).toContain('4')
+    expect(root.querySelector('[data-testid="stock-prep-unit-metric"][data-kind="active"]')?.textContent).toContain('3')
+    expect(root.querySelector('[data-testid="stock-prep-unit-metric"][data-kind="requires-confirmation"]')?.textContent).toContain('1')
+    expect(root.querySelector('[data-testid="stock-prep-unit-metric"][data-kind="pending-lines"]')?.textContent).toContain('2')
+    expect(root.querySelectorAll('[data-testid="stock-prep-unit-scope-count"]').length).toBe(3)
+    expect(root.querySelectorAll('[data-testid="stock-prep-unit-rounding-count"]').length).toBe(5)
+
+    // Candidate list header + rows: handles / outcome enums / reason / booleans only.
+    expect(root.querySelector('[data-testid="stock-prep-unit-status"]')?.getAttribute('data-status')).toBe('pending_confirmation')
+    expect(root.querySelector('[data-testid="stock-prep-unit-batch-handle"]')?.textContent).toContain('batch-handle-alpha')
+    const rows = root.querySelectorAll('[data-testid="stock-prep-unit-row"]')
+    expect(rows.length).toBe(3)
+    expect(rows[0].querySelector('[data-testid="stock-prep-unit-row-fingerprint"]')?.textContent).toBe('fp-handle-alpha')
+    expect(rows[1].querySelector('[data-testid="stock-prep-unit-row-rule-handle"]')?.textContent).toBe('rule-handle-gamma')
+    expect(rows[2].querySelector('[data-testid="stock-prep-unit-row-reason"]')?.textContent).toContain('rule_missing')
+
+    // ONLY the computed 1:1 candidate row is confirmable; reused/held rows carry no confirm entry.
+    expect(root.querySelectorAll('[data-testid="stock-prep-unit-row-confirm"]').length).toBe(1)
+    expect(rows[0].querySelector('[data-testid="stock-prep-unit-row-confirm"]')).not.toBeNull()
+
+    // Values-free guard: no planted candidate value ever reaches the DOM.
+    const text = root.textContent || ''
+    for (const forbidden of FORBIDDEN) {
+      expect(text).not.toContain(forbidden)
+    }
+  })
+
+  it('renders the neutral no-complete-batch state on 404 CONFIRM_READS_BATCH_NOT_FOUND (summary intact)', async () => {
+    mockRoutes({ candidates: () => fail(404, 'CONFIRM_READS_BATCH_NOT_FOUND') })
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-no-batch"]')
+
+    expect(root.querySelector('[data-testid="stock-prep-unit-summary"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-unit-candidates-error"]')).toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-unit-queue"]')).toBeNull()
+    expect(root.textContent || '').not.toContain('secret-42007')
+  })
+
+  it('confirms a computed candidate in fingerprint mode with the EXACT body key set, then refreshes', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-queue"]')
+    ;(root.querySelector('[data-testid="stock-prep-unit-row-confirm"]') as HTMLButtonElement).click()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-action-notice"]')
+
+    const posts = postCalls('/unit-conversions/confirm')
+    expect(posts.length).toBe(1)
+    expect(posts[0].url).toBe('/api/integration/stock-preparation/unit-conversions/confirm')
+    // Tri-XOR pin: fingerprint mode carries contextFingerprint (+ the batch the operator SAW) and
+    // neither conversionRuleId nor rule; server-stamped fields NEVER cross.
+    expect(Object.keys(posts[0].body).sort()).toEqual(['contextFingerprint', 'projectId', 'snapshotBatchId'])
+    expect(posts[0].body.contextFingerprint).toBe('fp-handle-alpha')
+    expect(posts[0].body.projectId).toBe('proj-alpha')
+    expect(posts[0].body.snapshotBatchId).toBe('batch-handle-alpha')
+    const rawBody = JSON.stringify(posts[0].body)
+    expect(rawBody).not.toContain('confirmedBy')
+    expect(rawBody).not.toContain('confirmedAt')
+
+    // Confirm → both reads re-issued.
+    await waitForCondition(() => urlsMatching('/unit-conversions/summary').length === 2)
+    expect(urlsMatching('/unit-conversions/candidates').length).toBe(2)
+    expect(root.querySelector('[data-testid="stock-prep-unit-action-notice"]')?.textContent).toContain('created')
+  })
+
+  it('surfaces the STALE notice on 409 CONFIRM_UNIT_CANDIDATE_NOT_FOUND and re-reads on refresh', async () => {
+    mockRoutes({ confirm: () => fail(409, 'CONFIRM_UNIT_CANDIDATE_NOT_FOUND') })
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-queue"]')
+    ;(root.querySelector('[data-testid="stock-prep-unit-row-confirm"]') as HTMLButtonElement).click()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-stale"]')
+
+    // Stale is its own surface (a refresh prompt), not the generic action error.
+    expect(root.querySelector('[data-testid="stock-prep-unit-action-error"]')).toBeNull()
+    expect(root.textContent || '').not.toContain('secret-42007')
+
+    // The refresh entry re-issues the candidates GET and clears the notice.
+    ;(root.querySelector('[data-testid="stock-prep-unit-stale-refresh"]') as HTMLButtonElement).click()
+    await waitForCondition(() => urlsMatching('/unit-conversions/candidates').length === 2)
+    await waitForCondition(() => root.querySelector('[data-testid="stock-prep-unit-stale"]') === null)
+  })
+
+  it('mirrors the server rule-mode checks client-side ({field} errors, NO premature POST)', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-rule-form"]')
+    const form = root.querySelector('[data-testid="stock-prep-unit-rule-form"]') as HTMLFormElement
+
+    // Empty form → first missing required field, by NAME.
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForSelector(root, '[data-testid="stock-prep-unit-form-error"]')
+    expect(root.querySelector('[data-testid="stock-prep-unit-form-error"]')?.textContent).toContain('plmUnit')
+
+    // conversionFactor must be a finite number > 0.
+    setInput(root, 'stock-prep-unit-form-plm-unit', 'sheet')
+    setInput(root, 'stock-prep-unit-form-erp-unit', 'roll')
+    setInput(root, 'stock-prep-unit-form-factor', '0')
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForCondition(() =>
+      (root.querySelector('[data-testid="stock-prep-unit-form-error"]')?.textContent || '').includes('conversionFactor'))
+
+    // material/category scope requires a scopeKey.
+    setInput(root, 'stock-prep-unit-form-factor', '2.5')
+    setSelect(root, 'stock-prep-unit-form-scope-type', 'material')
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForCondition(() =>
+      (root.querySelector('[data-testid="stock-prep-unit-form-error"]')?.textContent || '').includes('scopeKey'))
+
+    // No confirm POST was ever issued by the client mirror.
+    expect(postCalls('/unit-conversions/confirm').length).toBe(0)
+  })
+
+  it('creates a manual rule with the EXACT nested key set (grounded to the server allowlist)', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-rule-form"]')
+
+    setInput(root, 'stock-prep-unit-form-plm-unit', 'sheet')
+    setInput(root, 'stock-prep-unit-form-erp-unit', 'roll')
+    setInput(root, 'stock-prep-unit-form-factor', '2.5')
+    setSelect(root, 'stock-prep-unit-form-scope-type', 'material')
+    await nextTick()
+    setInput(root, 'stock-prep-unit-form-scope-key', 'OPERATOR-SCOPE-1')
+    const form = root.querySelector('[data-testid="stock-prep-unit-rule-form"]') as HTMLFormElement
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForSelector(root, '[data-testid="stock-prep-unit-action-notice"]')
+
+    const posts = postCalls('/unit-conversions/confirm')
+    expect(posts.length).toBe(1)
+    // Tri-XOR pin: rule mode carries rule and neither conversionRuleId nor contextFingerprint.
+    expect(Object.keys(posts[0].body).sort()).toEqual(['projectId', 'rule'])
+    const rule = posts[0].body.rule as Record<string, unknown>
+    expect(Object.keys(rule).sort()).toEqual([
+      'conversionFactor',
+      'erpIssueUnit',
+      'plmUnit',
+      'roundingRule',
+      'scopeKey',
+      'scopeType',
+    ])
+    // Numbers cross as numbers (the server validates > 0 on a numeric parse).
+    expect(rule.conversionFactor).toBe(2.5)
+    expect(rule.roundingRule).toBe('none')
+    const rawBody = JSON.stringify(posts[0].body)
+    expect(rawBody).not.toContain('confirmedBy')
+    expect(rawBody).not.toContain('confirmedAt')
+
+    // Success → notice + form cleared + reads refreshed.
+    expect(root.querySelector('[data-testid="stock-prep-unit-action-notice"]')?.textContent).toContain('created')
+    expect((root.querySelector('[data-testid="stock-prep-unit-form-plm-unit"]') as HTMLInputElement).value).toBe('')
+    await waitForCondition(() => urlsMatching('/unit-conversions/summary').length === 2)
+  })
+
+  it('clears scopeKey when switching to the generic scope (scopeKey is forbidden there)', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-rule-form"]')
+
+    setInput(root, 'stock-prep-unit-form-plm-unit', 'sheet')
+    setInput(root, 'stock-prep-unit-form-erp-unit', 'roll')
+    setInput(root, 'stock-prep-unit-form-factor', '4')
+    setSelect(root, 'stock-prep-unit-form-scope-type', 'material')
+    await nextTick()
+    setInput(root, 'stock-prep-unit-form-scope-key', 'LEFTOVER-KEY')
+    setSelect(root, 'stock-prep-unit-form-scope-type', 'generic')
+    await nextTick()
+    const form = root.querySelector('[data-testid="stock-prep-unit-rule-form"]') as HTMLFormElement
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForSelector(root, '[data-testid="stock-prep-unit-action-notice"]')
+
+    const rule = postCalls('/unit-conversions/confirm')[0].body.rule as Record<string, unknown>
+    expect(Object.keys(rule).sort()).toEqual([
+      'conversionFactor',
+      'erpIssueUnit',
+      'plmUnit',
+      'roundingRule',
+      'scopeType',
+    ])
+    expect(rule.scopeType).toBe('generic')
+    expect(JSON.stringify(rule)).not.toContain('LEFTOVER-KEY')
+  })
+
+  it('routes a server {field} error into the form field-error surface (server stays authoritative)', async () => {
+    mockRoutes({ confirm: () => fail(400, 'CONFIRM_UNIT_RULE_FIELDS_INVALID', 'roundingRule') })
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-rule-form"]')
+
+    setInput(root, 'stock-prep-unit-form-plm-unit', 'sheet')
+    setInput(root, 'stock-prep-unit-form-erp-unit', 'roll')
+    setInput(root, 'stock-prep-unit-form-factor', '2')
+    setSelect(root, 'stock-prep-unit-form-scope-type', 'generic')
+    const form = root.querySelector('[data-testid="stock-prep-unit-rule-form"]') as HTMLFormElement
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await waitForSelector(root, '[data-testid="stock-prep-unit-form-error"]')
+
+    expect(root.querySelector('[data-testid="stock-prep-unit-form-error"]')?.textContent).toContain('roundingRule')
+    expect(root.textContent || '').not.toContain('secret-42007')
+    expect(root.textContent || '').not.toContain('PCS-LEAK')
+  })
+
+  it('retires a rule by handle with the EXACT body key set', async () => {
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-retire-block"]')
+
+    const retireButton = root.querySelector('[data-testid="stock-prep-unit-retire-submit"]') as HTMLButtonElement
+    expect(retireButton.disabled).toBe(true)
+    setInput(root, 'stock-prep-unit-retire-input', 'rule-handle-gamma')
+    await waitForCondition(() => !(root.querySelector('[data-testid="stock-prep-unit-retire-submit"]') as HTMLButtonElement).disabled)
+    ;(root.querySelector('[data-testid="stock-prep-unit-retire-submit"]') as HTMLButtonElement).click()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-action-notice"]')
+
+    const posts = postCalls('/unit-conversions/retire')
+    expect(posts.length).toBe(1)
+    expect(posts[0].url).toBe('/api/integration/stock-preparation/unit-conversions/retire')
+    expect(Object.keys(posts[0].body).sort()).toEqual(['conversionRuleId', 'projectId'])
+    expect(posts[0].body.conversionRuleId).toBe('rule-handle-gamma')
+  })
+
+  it('renders the English copy when locale is not zh-CN', async () => {
+    h.locale = 'en'
+    mockRoutes()
+    const root = mountView({})
+    await nextTick()
+    expect(root.querySelector('[data-testid="stock-prep-unit-no-project"]')?.textContent).toMatch(/select a project/i)
+  })
+})

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -295,6 +295,80 @@ describe('StockPreparationWorkspace shell', () => {
           { status: 200 },
         )
       }
+      // Views 3/4 confirmation reads (values-free minimal fixtures) — order: sync/candidates
+      // fragments are all distinct from the summary fragments, so plain includes() is safe.
+      if (url.includes('/api/integration/stock-preparation/material-mappings/summary')) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              totalMappingCount: 1,
+              activeMappingCount: 1,
+              matchStatusCounts: { matched: 0, pending_confirm: 1, multi_candidate: 0, not_found: 0, version_conflict: 0 },
+              versionPolicyCounts: { drawing_and_version: 1, drawing_only: 0, category_rule: 0, manual: 0 },
+              pendingConfirmCount: 1,
+            },
+          }),
+          { status: 200 },
+        )
+      }
+      if (url.includes('/api/integration/stock-preparation/material-mappings/candidates')) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              rowCount: 1,
+              byMatchStatus: { matched: 0, pending_confirm: 1, multi_candidate: 0, not_found: 0, version_conflict: 0 },
+              rows: [
+                {
+                  mappingId: 'map-handle-alpha',
+                  matchStatus: 'pending_confirm',
+                  matchMethod: 'exact_code_candidate',
+                  versionPolicy: 'drawing_and_version',
+                  confidence: 0.9,
+                  isActive: true,
+                  confirmed: false,
+                  hasErpTarget: true,
+                  plmVersionPresent: true,
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        )
+      }
+      if (url.includes('/api/integration/stock-preparation/unit-conversions/summary')) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              totalRuleCount: 1,
+              activeRuleCount: 1,
+              requiresConfirmationCount: 0,
+              scopeTypeCounts: { material: 1, category: 0, generic: 0 },
+              roundingRuleCounts: { none: 1, ceil: 0, floor: 0, nearest: 0, pack_size: 0 },
+              pendingUnitLineCount: 1,
+            },
+          }),
+          { status: 200 },
+        )
+      }
+      if (url.includes('/api/integration/stock-preparation/unit-conversions/candidates')) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              status: 'pending_confirmation',
+              snapshotBatchId: 'batch-alpha',
+              rowCount: 1,
+              byOutcome: { candidate: 1 },
+              byReason: { unknown: 1 },
+              rows: [{ contextFingerprint: 'fp-handle-alpha', outcome: 'candidate', hasCandidate: true }],
+            },
+          }),
+          { status: 200 },
+        )
+      }
       return new Response(JSON.stringify({ ok: true, data: {} }), { status: 200 })
     })
   }
@@ -338,6 +412,42 @@ describe('StockPreparationWorkspace shell', () => {
       expect.objectContaining({ query: expect.objectContaining({ projectId: 'proj-alpha' }) }),
     )
     // …but stays values-free in the DOM: the internal handle is never rendered.
+    expect(root.textContent || '').not.toContain('proj-alpha')
+  })
+
+  it('shares the projectId with views 3 and 4 — confirmation views open already scoped', async () => {
+    mockStockPrepReads()
+    const root = await mountShell()
+
+    // Pick a project in view 1 (REAL wire), then enter the two confirmation tabs.
+    const selectButton = (await waitForSelector(
+      root,
+      '[data-testid="stock-prep-project-select"]',
+    )) as HTMLButtonElement
+    selectButton.click()
+    await waitForSelector(root, '[data-testid="stock-prep-snapshot-overview"]')
+
+    // View 3 (material mapping): opens scoped — no re-select, reads carry the SAME handle.
+    ;(root.querySelector('[data-testid="stock-prep-tab-material-mapping"]') as HTMLButtonElement).click()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+    expect(root.querySelector('[data-testid="stock-prep-mapping-no-project"]')).toBeNull()
+    const mappingSummaryCalls = h.apiFetch.mock.calls
+      .map((call) => String(call[0]))
+      .filter((url) => url.includes('/material-mappings/summary'))
+    expect(mappingSummaryCalls.length).toBe(1)
+    expect(mappingSummaryCalls[0]).toContain('projectId=proj-alpha')
+
+    // View 4 (unit conversion): same shared scope.
+    ;(root.querySelector('[data-testid="stock-prep-tab-unit-conversion"]') as HTMLButtonElement).click()
+    await waitForSelector(root, '[data-testid="stock-prep-unit-overview"]')
+    expect(root.querySelector('[data-testid="stock-prep-unit-no-project"]')).toBeNull()
+    const unitSummaryCalls = h.apiFetch.mock.calls
+      .map((call) => String(call[0]))
+      .filter((url) => url.includes('/unit-conversions/summary'))
+    expect(unitSummaryCalls.length).toBe(1)
+    expect(unitSummaryCalls[0]).toContain('projectId=proj-alpha')
+
+    // The internal handle stays values-free in the DOM across all tabs.
     expect(root.textContent || '').not.toContain('proj-alpha')
   })
 


### PR DESCRIPTION
Stacked on #4021 (`claude/stock-prep-w3c-confirm-reads`, W3c readonly confirm reads) — review only the head commit; the base branch carries the W3c backend this FE reads against. **Pure `apps/web/**` + `integration-guard.yml` spec filter; no `plugins/**` change.**

## What

FE views 3 (物料映射确认) and 4 (单位换算确认) for the stock-preparation MVP (#3751), mounted into the existing `StockPreparationWorkspace` shell tabs using the #4017 shared-projectId pattern (view 1 row selection → shell-owned `projectId` prop → views 2/3/4).

### Service layer (`apps/web/src/services/integration/stockPreparation/`)

- `materialMapping.ts` — `listStockPreparationMaterialMappingCandidates` (GET candidates, optional `matchStatus` enum filter), `confirmStockPreparationMaterialMapping` (XOR `mappingId` | `mapping` create mode), `retireStockPreparationMaterialMapping`, `syncStockPreparationMaterialMappingCandidates` (OD2: `defaultVersionPolicy` required — no client default either).
- `unitConversion.ts` — `listStockPreparationUnitConversionCandidates` (COMPUTED list; 404 `CONFIRM_READS_BATCH_NOT_FOUND` handled as a neutral no-batch state), `confirmStockPreparationUnitConversionRule` (tri-XOR `conversionRuleId` | `contextFingerprint`+`projectId`(+`snapshotBatchId`) | `rule`), `retireStockPreparationUnitConversionRule`.
- `confirmApi.ts` — shared parse preserving the **clamped** error `code` + `field` NAME (enum-shaped patterns only); raw error messages never propagate.

### Views

- `StockPreparationMappingConfirmView.vue` — 5-indicator summary card; candidate queue (matchStatus badge / matchMethod / confidence / versionPolicy / hasErpTarget / plmVersionPresent / confirmed booleans; row identity = `mappingId` sha16 handle); matchStatus filter; row confirm (**enabled only when `hasErpTarget === true`**, mappingId mode) + retire; 「同步候选」 gated on an explicit versionPolicy pick; manual create-confirm form (both ERP ids required, `drawing_and_version` ⇒ `plmVersion` required, errors rendered by `{field}` name).
- `StockPreparationUnitConfirmView.vue` — 6-indicator summary card; computed candidate list (`contextFingerprint` handle / outcome / reason / hasCandidate; reused rows read-only display `conversionRuleId`); fingerprint confirm **pinned to the viewed `snapshotBatchId`**; 409 `CONFIRM_UNIT_CANDIDATE_NOT_FOUND` → stale notice + refresh/re-read entry (never a blind retry); manual rule form (factor>0, rounding enum, scope tri-select with conditional `scopeKey`, cleared when switching to `generic`); rule-retire entry.

## Contract discipline (mock-is-not-the-contract, both directions pinned)

- **Shapes are field-by-field off the server truth** — `plugins/plugin-integration-core/lib/stock-preparation-confirm-{reads,writes}.cjs` + the `http-routes.cjs` closed per-route allowlists (read on this branch; not modified).
- **Request direction:** specs assert exact URL paths, **exact query key sets**, and **exact POST body key sets per XOR/tri-XOR mode** (`Object.keys(body).sort()` equality); nested `mapping`/`rule` objects are grounded to the server's closed create allowlists; **`confirmedBy`/`confirmedAt` never appear anywhere in any body** (server-stamped; the route rejects them as unknown fields) — asserted on the raw JSON.
- **Response direction (values-free):** views render a fixed whitelist — counts / status/method/policy/outcome/reason enums / booleans / sha16 handles only. Specs plant sentinel business values (drawing no / material name / ERP code / unit symbol / factor / raw error body with secrets) on fixture rows and error messages and assert none reach the DOM. Error surfaces render only the clamped `code` / `{field}` name.
- Client-side form validation mirrors the server rules but the server `{field}` error stays authoritative (routed into the same field-error surface; tested).

## Tests

```
pnpm --filter @metasheet/web exec vitest run StockPreparationMappingConfirmView StockPreparationUnitConfirmView
pnpm --filter @metasheet/web exec vitest run StockPreparationWorkspace StockPreparationProjectWorkspaceView StockPreparationSnapshotDiffView
pnpm --filter @metasheet/web run type-check
```

- `StockPreparationMappingConfirmView.spec.ts` (12 tests) + `StockPreparationUnitConfirmView.spec.ts` (11 tests): mock ONLY `apiFetch` — the REAL service modules drive the wire; async DOM waits use the bounded `waitForSelector` polling idiom from #4017 (no fixed microtask flushes).
- Shell spec: +1 test — view 1 selection hands the scoped `projectId` to views 3/4 end-to-end over the real service wiring; handle never rendered.
- Full integration-guard vitest list: **41 files / 580 tests green** locally; `vue-tsc -b` clean.
- `integration-guard.yml`: the two new spec paths added to both `pull_request` and `push` path blocks + the single targeted run list (per the IU-4 single-`run:` note).

Refs #3751

🤖 Generated with [Claude Code](https://claude.com/claude-code)