### PR TITLE
feat(integration): stock-prep W5a — values-free exception queue + prep-line summary reads [stacked on #4024]

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-confirm-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-confirm-reads.test.cjs
@@ -25,6 +25,8 @@ const {
   listMaterialMappingCandidates,
   getUnitConversionSummary,
   listUnitConversionCandidates,
+  listStockPreparationExceptions,
+  listStockPreparationPrepLines,
   StockPreparationConfirmReadError,
   MAPPING_OBJECT_ID,
   RULE_OBJECT_ID,
@@ -46,7 +48,11 @@ const BUSINESS_PROJECT_ID = 'proj_1'
 const OPERATOR = 'user_admin_1'
 const SECRET = 'SECRET_W3C_e2a9'
 
+const EXCEPTION_OBJECT_ID = objectIdByRole('exception_confirmation')
+const PREP_LINE_OBJECT_ID = objectIdByRole('stock_preparation_line')
 const SHEET = {
+  exception: `sheet_${EXCEPTION_OBJECT_ID}`,
+  prepLine: `sheet_${PREP_LINE_OBJECT_ID}`,
   batch: `sheet_${BATCH_OBJECT_ID}`,
   line: `sheet_${LINE_OBJECT_ID}`,
   run: `sheet_${RUN_OBJECT_ID}`,
@@ -349,6 +355,72 @@ async function main() {
     api.seed(SHEET.mapping, { mappingId: 'm1', plmDrawingNo: 'D', matchStatus: 'matched', versionPolicy: 'manual', isActive: true })
     const result = await getMaterialMappingSummary(baseInput(api, makeProvisioning(), { targetProjectId: BUSINESS_PROJECT_ID }))
     assert.equal(result.totalMappingCount, 0, 'sheet lookup under the business project misses')
+  })
+
+  // ---- W5a: exception queue list ----
+  await run('exception list: values-free rows (message never crosses), filters, unresolved-blocking count', async () => {
+    const api = makeReadOnlyRecordsApi()
+    api.seed(SHEET.exception, { exceptionId: 'e1', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1', snapshotLineId: 'l1', stockPrepLineId: 'p1', exceptionType: 'missing_mapping', severity: 'blocking', status: 'open', message: `secret msg ${SECRET}` })
+    api.seed(SHEET.exception, { exceptionId: 'e2', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1', exceptionType: 'unit_missing', severity: 'blocking', status: 'resolved', resolutionAction: 'unit_rule_confirmed', resolvedBy: OPERATOR, resolvedAt: 'x', message: `m2_${SECRET}` })
+    api.seed(SHEET.exception, { exceptionId: 'e3', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b2', exceptionType: `junk_${SECRET}`, severity: 'warning', status: 'open', message: 'x' })
+    api.seed(SHEET.exception, { exceptionId: 'e4', projectId: 'proj_other', snapshotBatchId: 'bx', exceptionType: 'invalid_qty', severity: 'blocking', status: 'open', message: 'x' })
+    const result = await listStockPreparationExceptions(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID }))
+    assert.equal(result.rowCount, 3, 'other-project rows never surface')
+    assert.equal(result.unresolvedBlockingCount, 1, 'resolved blocking row excluded; warning excluded')
+    assert.equal(result.byType.missing_mapping, 1)
+    assert.equal(result.byType.unknown, 1, 'junk type folds')
+    const resolvedRow = result.rows.find((row) => row.exceptionId === 'e2')
+    assert.equal(resolvedRow.resolved, true)
+    assert.equal(resolvedRow.resolvedByPresent, true)
+    assert.equal(resolvedRow.resolutionAction, 'unit_rule_confirmed')
+    for (const row of result.rows) {
+      assert.ok(!('message' in row), 'message cell never crosses')
+    }
+    assert.equal(JSON.stringify(result).includes(SECRET), false, 'no business text or junk string leaks')
+    // filters + enum gates
+    const openOnly = await listStockPreparationExceptions(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID, status: 'open' }))
+    assert.ok(openOnly.rows.every((row) => row.status === 'open'))
+    const batchOnly = await listStockPreparationExceptions(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1' }))
+    assert.equal(batchOnly.rowCount, 2)
+    await expectError(
+      listStockPreparationExceptions(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID, status: 'bogus' })),
+      { status: 422, code: 'CONFIRM_READS_CONFIG_INVALID' },
+    )
+    await expectError(
+      listStockPreparationExceptions(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID, exceptionType: 'nope' })),
+      { status: 422, code: 'CONFIRM_READS_CONFIG_INVALID' },
+    )
+  })
+
+  // ---- W5a: prep-line list ----
+  await run('prep-line list: values-free summary rows (no drawing/qty/unit values), filters, enum folds', async () => {
+    const api = makeReadOnlyRecordsApi()
+    api.seed(SHEET.prepLine, { stockPrepLineId: 'p1', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1', snapshotLineId: 'l1', childDrawingNo: `D_${SECRET}`, designQty: 3, designUnit: `u_${SECRET}`, issueQtyFinal: 3, issueUnit: `u_${SECRET}`, erpMaterialCode: 'C1', erpMaterialInternalId: 'I1', prepStatus: 'draft', mappingStatus: 'matched', unitStatus: 'converted', exceptionCount: 0, createdFromRunId: 'run_x' })
+    api.seed(SHEET.prepLine, { stockPrepLineId: 'p2', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1', snapshotLineId: 'l2', childDrawingNo: 'D2', prepStatus: 'held', mappingStatus: 'not_found', unitStatus: 'missing_rule', exceptionCount: 2 })
+    api.seed(SHEET.prepLine, { stockPrepLineId: 'p3', projectId: 'proj_other', snapshotBatchId: 'bx', prepStatus: 'draft' })
+    const result = await listStockPreparationPrepLines(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID }))
+    assert.equal(result.rowCount, 2, 'other-project rows never surface')
+    assert.equal(result.byPrepStatus.draft, 1)
+    assert.equal(result.byPrepStatus.held, 1)
+    const first = result.rows.find((row) => row.stockPrepLineId === 'p1')
+    assert.equal(first.hasIssueQty, true)
+    assert.equal(first.hasErpTarget, true)
+    assert.equal(first.createdFromRunId, 'run_x')
+    const second = result.rows.find((row) => row.stockPrepLineId === 'p2')
+    assert.equal(second.hasIssueQty, false)
+    assert.equal(second.exceptionCount, 2)
+    for (const row of result.rows) {
+      for (const key of Object.keys(row)) {
+        assert.ok(!['childDrawingNo', 'designQty', 'designUnit', 'issueQtyFinal', 'issueQtyRaw', 'issueUnit', 'conversionFactor', 'lossRate', 'erpMaterialCode', 'erpMaterialInternalId'].includes(key), `value-bearing key ${key} must never cross (owner-gated)`)
+      }
+    }
+    assert.equal(JSON.stringify(result).includes(SECRET), false)
+    const heldOnly = await listStockPreparationPrepLines(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID, prepStatus: 'held' }))
+    assert.equal(heldOnly.rowCount, 1)
+    await expectError(
+      listStockPreparationPrepLines(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID, prepStatus: 'bogus' })),
+      { status: 422, code: 'CONFIRM_READS_CONFIG_INVALID' },
+    )
   })
 
   const total = passed + failed

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-confirm-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-confirm-reads.test.cjs
@@ -169,6 +169,8 @@ async function main() {
       (api, prov) => listMaterialMappingCandidates({ permission: 'read', recordsApi: api, provisioning: prov, targetProjectId: STAGING_PROJECT_ID }),
       (api, prov) => getUnitConversionSummary({ permission: 'read', recordsApi: api, provisioning: prov, targetProjectId: STAGING_PROJECT_ID, projectId: BUSINESS_PROJECT_ID }),
       (api, prov) => listUnitConversionCandidates({ permission: 'read', recordsApi: api, provisioning: prov, targetProjectId: STAGING_PROJECT_ID, projectId: BUSINESS_PROJECT_ID }),
+      (api, prov) => listStockPreparationExceptions({ permission: 'read', recordsApi: api, provisioning: prov, targetProjectId: STAGING_PROJECT_ID, projectId: BUSINESS_PROJECT_ID }),
+      (api, prov) => listStockPreparationPrepLines({ permission: 'read', recordsApi: api, provisioning: prov, targetProjectId: STAGING_PROJECT_ID, projectId: BUSINESS_PROJECT_ID }),
     ]) {
       const api = makeReadOnlyRecordsApi()
       const provisioning = makeProvisioning()
@@ -364,9 +366,12 @@ async function main() {
     api.seed(SHEET.exception, { exceptionId: 'e2', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1', exceptionType: 'unit_missing', severity: 'blocking', status: 'resolved', resolutionAction: 'unit_rule_confirmed', resolvedBy: OPERATOR, resolvedAt: 'x', message: `m2_${SECRET}` })
     api.seed(SHEET.exception, { exceptionId: 'e3', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b2', exceptionType: `junk_${SECRET}`, severity: 'warning', status: 'open', message: 'x' })
     api.seed(SHEET.exception, { exceptionId: 'e4', projectId: 'proj_other', snapshotBatchId: 'bx', exceptionType: 'invalid_qty', severity: 'blocking', status: 'open', message: 'x' })
+    // F1 (review #4027): a SECOND blocking+open row makes the count asymmetric (2 vs the resolved
+    // row's 1) so inverting the status predicate can no longer produce the same number.
+    api.seed(SHEET.exception, { exceptionId: 'e5', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b2', exceptionType: 'unit_conflict', severity: 'blocking', status: 'open', message: 'x' })
     const result = await listStockPreparationExceptions(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID }))
-    assert.equal(result.rowCount, 3, 'other-project rows never surface')
-    assert.equal(result.unresolvedBlockingCount, 1, 'resolved blocking row excluded; warning excluded')
+    assert.equal(result.rowCount, 4, 'other-project rows never surface')
+    assert.equal(result.unresolvedBlockingCount, 2, 'exactly the blocking+unresolved rows (resolved blocking excluded, warning excluded)')
     assert.equal(result.byType.missing_mapping, 1)
     assert.equal(result.byType.unknown, 1, 'junk type folds')
     const resolvedRow = result.rows.find((row) => row.exceptionId === 'e2')
@@ -382,6 +387,7 @@ async function main() {
     assert.ok(openOnly.rows.every((row) => row.status === 'open'))
     const batchOnly = await listStockPreparationExceptions(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1' }))
     assert.equal(batchOnly.rowCount, 2)
+    assert.equal(batchOnly.unresolvedBlockingCount, 1, 'batch-scoped count follows the batch filter')
     await expectError(
       listStockPreparationExceptions(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID, status: 'bogus' })),
       { status: 422, code: 'CONFIRM_READS_CONFIG_INVALID' },
@@ -397,11 +403,14 @@ async function main() {
     const api = makeReadOnlyRecordsApi()
     api.seed(SHEET.prepLine, { stockPrepLineId: 'p1', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1', snapshotLineId: 'l1', childDrawingNo: `D_${SECRET}`, designQty: 3, designUnit: `u_${SECRET}`, issueQtyFinal: 3, issueUnit: `u_${SECRET}`, erpMaterialCode: 'C1', erpMaterialInternalId: 'I1', prepStatus: 'draft', mappingStatus: 'matched', unitStatus: 'converted', exceptionCount: 0, createdFromRunId: 'run_x' })
     api.seed(SHEET.prepLine, { stockPrepLineId: 'p2', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1', snapshotLineId: 'l2', childDrawingNo: 'D2', prepStatus: 'held', mappingStatus: 'not_found', unitStatus: 'missing_rule', exceptionCount: 2 })
+    // F4 (review #4027): a row with ONLY the code (no internal id) pins hasErpTarget's AND semantics.
+    api.seed(SHEET.prepLine, { stockPrepLineId: 'p2b', projectId: BUSINESS_PROJECT_ID, snapshotBatchId: 'b1', erpMaterialCode: 'C_ONLY', prepStatus: 'draft', mappingStatus: 'pending_confirm', unitStatus: 'missing_rule' })
     api.seed(SHEET.prepLine, { stockPrepLineId: 'p3', projectId: 'proj_other', snapshotBatchId: 'bx', prepStatus: 'draft' })
     const result = await listStockPreparationPrepLines(baseInput(api, makeProvisioning(), { projectId: BUSINESS_PROJECT_ID }))
-    assert.equal(result.rowCount, 2, 'other-project rows never surface')
-    assert.equal(result.byPrepStatus.draft, 1)
+    assert.equal(result.rowCount, 3, 'other-project rows never surface')
+    assert.equal(result.byPrepStatus.draft, 2)
     assert.equal(result.byPrepStatus.held, 1)
+    assert.equal(result.rows.find((row) => row.stockPrepLineId === 'p2b').hasErpTarget, false, 'code without internal id is NOT a full ERP target (AND semantics)')
     const first = result.rows.find((row) => row.stockPrepLineId === 'p1')
     assert.equal(first.hasIssueQty, true)
     assert.equal(first.hasErpTarget, true)

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -104,6 +104,10 @@ const ROUTES = [
   ['POST', '/api/integration/stock-preparation/generation/run', 'stockPreparationGenerationRun'],
   ['POST', '/api/integration/stock-preparation/exceptions/resolve', 'stockPreparationExceptionResolve'],
   ['POST', '/api/integration/stock-preparation/exceptions/bulk-resolve', 'stockPreparationExceptionBulkResolve'],
+  // #3751 MVP W5 (queue reads): values-free exception queue (view 6) + prep-line summary (view 5).
+  // Value-bearing detail reads (drawing numbers / quantities / unit symbols) stay OWNER-GATED.
+  ['GET', '/api/integration/stock-preparation/exceptions', 'stockPreparationExceptionList'],
+  ['GET', '/api/integration/stock-preparation/prep-lines', 'stockPreparationPrepLineList'],
   // FOS-2: generic field-option-sync (preset-driven). Stock-prep route above is a compat alias.
   ['POST', '/api/integration/field-options/sync', 'fieldOptionsSync'],
   ['GET', '/api/integration/templates', 'templatesList'],
@@ -305,6 +309,8 @@ const {
   listMaterialMappingCandidates,
   getUnitConversionSummary,
   listUnitConversionCandidates,
+  listStockPreparationExceptions,
+  listStockPreparationPrepLines,
 } = require('./stock-preparation-confirm-reads.cjs')
 // #3751 MVP W4: generation run + human exception resolution. resolvedBy is the route user identity;
 // resolvedAt is stamped in the module — the body can carry neither (closed allowlists).
@@ -746,6 +752,22 @@ const VALID_STOCK_PREPARATION_EXCEPTION_BULK_RESOLVE_REQUEST_KEYS = new Set([
   'projectId',
   'exceptionIds',
   'resolutionAction',
+])
+const VALID_STOCK_PREPARATION_EXCEPTION_LIST_QUERY_KEYS = new Set([
+  'tenantId',
+  'workspaceId',
+  'projectId',
+  'snapshotBatchId',
+  'status',
+  'exceptionType',
+  'severity',
+])
+const VALID_STOCK_PREPARATION_PREP_LINE_LIST_QUERY_KEYS = new Set([
+  'tenantId',
+  'workspaceId',
+  'projectId',
+  'snapshotBatchId',
+  'prepStatus',
 ])
 // FOS-2: generic field-option-sync request — closed allowlist. Operator names a preset (FOS-1
 // catalog) + supplies option sets keyed by the preset's source keys. No sheetId / credentials.
@@ -3797,6 +3819,52 @@ function createHandlers(services, options = {}) {
         exceptionIds: input.exceptionIds,
         resolutionAction: input.resolutionAction,
         resolvedBy: user.id || user.email,
+      })
+      return sendOk(res, result)
+    },
+
+    // #3751 MVP W5: values-free exception queue for view 6 (message text never crosses).
+    async stockPreparationExceptionList(req, res) {
+      requireAccess(req, 'admin')
+      const input = stockPreparationConfirmReadInput(req, requestQuery(req), VALID_STOCK_PREPARATION_EXCEPTION_LIST_QUERY_KEYS, 'STOCK_PREPARATION_EXCEPTION_LIST_REQUEST_INVALID')
+      const provisioning = context && context.api && context.api.multitable
+        ? context.api.multitable.provisioning
+        : undefined
+      if (!provisioning) {
+        throw new HttpRouteError(501, 'CONFIRM_READS_PROVISIONING_API_UNAVAILABLE', 'multitable provisioning API is not available')
+      }
+      const result = await listStockPreparationExceptions({
+        recordsApi: getMultitableRecordsApi(),
+        provisioning,
+        targetProjectId: input.targetProjectId,
+        projectId: input.projectId,
+        snapshotBatchId: input.snapshotBatchId,
+        status: input.status,
+        exceptionType: input.exceptionType,
+        severity: input.severity,
+        permission: 'admin',
+      })
+      return sendOk(res, result)
+    },
+
+    // #3751 MVP W5: values-free prep-line summary for view 5 (value-bearing detail stays owner-gated).
+    async stockPreparationPrepLineList(req, res) {
+      requireAccess(req, 'admin')
+      const input = stockPreparationConfirmReadInput(req, requestQuery(req), VALID_STOCK_PREPARATION_PREP_LINE_LIST_QUERY_KEYS, 'STOCK_PREPARATION_PREP_LINE_LIST_REQUEST_INVALID')
+      const provisioning = context && context.api && context.api.multitable
+        ? context.api.multitable.provisioning
+        : undefined
+      if (!provisioning) {
+        throw new HttpRouteError(501, 'CONFIRM_READS_PROVISIONING_API_UNAVAILABLE', 'multitable provisioning API is not available')
+      }
+      const result = await listStockPreparationPrepLines({
+        recordsApi: getMultitableRecordsApi(),
+        provisioning,
+        targetProjectId: input.targetProjectId,
+        projectId: input.projectId,
+        snapshotBatchId: input.snapshotBatchId,
+        prepStatus: input.prepStatus,
+        permission: 'admin',
       })
       return sendOk(res, result)
     },

--- a/plugins/plugin-integration-core/lib/stock-preparation-confirm-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-confirm-reads.cjs
@@ -447,6 +447,9 @@ async function listStockPreparationExceptions({ recordsApi, provisioning, target
   if (rows.length > MAX_LIST_ROWS) {
     throw new StockPreparationConfirmReadError(422, 'CONFIRM_READS_ROWS_TOO_LARGE', 'exception queue read exceeded the row bound', { maxRows: MAX_LIST_ROWS })
   }
+  // Count scope follows the ACTIVE filters (post-filter subset): it equals the W4a ready-invariant
+  // count only for a batch-scoped, unfiltered read — display context, never the enforcement point
+  // (enforcement lives in the generation run route).
   const unresolvedBlockingCount = rows.filter((data) => optionalString(data.severity) === 'blocking' && optionalString(data.status) !== 'resolved').length
   return {
     rowCount: rows.length,

--- a/plugins/plugin-integration-core/lib/stock-preparation-confirm-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-confirm-reads.cjs
@@ -30,7 +30,7 @@ const {
   HELD_REASONS,
 } = require('./stock-preparation-unit-rule-match.cjs')
 const { MATCH_STATUSES, MATCH_METHODS, VERSION_POLICIES: MATCH_VERSION_POLICIES } = require('./stock-preparation-material-match.cjs')
-const { VERSION_POLICIES } = require('./stock-preparation-mvp-generation.cjs')
+const { VERSION_POLICIES, EXCEPTION_TYPES, PREP_STATUSES, UNIT_STATUSES } = require('./stock-preparation-mvp-generation.cjs')
 const { optionalString, isPlainObject } = require('./stock-preparation-common.cjs')
 
 const REQUIRED_PERMISSION = 'admin'
@@ -46,6 +46,13 @@ const MATCH_STATUS_VALUES = Object.freeze(Object.values(MATCH_STATUSES))
 const MATCH_METHOD_VALUES = Object.freeze([...Object.values(MATCH_METHODS), 'manual_confirm'])
 const VERSION_POLICY_VALUES = Object.freeze([...new Set([...Object.values(VERSION_POLICIES), ...Object.values(MATCH_VERSION_POLICIES)])])
 const SCOPE_TYPE_VALUES = Object.freeze(['material', 'category', 'generic'])
+// W5 queue-read vocabularies (engine + design §8 closed sets; same fold-to-unknown discipline).
+const EXCEPTION_TYPE_VALUES = Object.freeze(Object.values(EXCEPTION_TYPES))
+const EXCEPTION_SEVERITY_VALUES = Object.freeze(['info', 'warning', 'blocking'])
+const EXCEPTION_STATUS_VALUES = Object.freeze(['open', 'resolved', 'ignored', 'deferred'])
+const RESOLUTION_ACTION_VALUES = Object.freeze(['mapping_confirmed', 'unit_rule_confirmed', 'accepted_change', 'manual_hold'])
+const PREP_STATUS_VALUES = Object.freeze(Object.values(PREP_STATUSES))
+const UNIT_STATUS_VALUES = Object.freeze(Object.values(UNIT_STATUSES))
 const ROUNDING_RULE_VALUES = Object.freeze(['none', 'ceil', 'floor', 'nearest', 'pack_size'])
 // A mapping row awaits a human decision when it is ACTIVE and in any non-matched status.
 const PENDING_CONFIRM_STATUSES = Object.freeze([
@@ -88,6 +95,8 @@ const BATCH_OBJECT_ID = templateByRole('bom_snapshot_batch').objectId
 const LINE_OBJECT_ID = templateByRole('bom_snapshot_line').objectId
 const RUN_OBJECT_ID = templateByRole('run_record').objectId
 const MATERIAL_OBJECT_ID = templateByRole('erp_material_master').objectId
+const EXCEPTION_OBJECT_ID = templateByRole('exception_confirmation').objectId
+const PREP_LINE_OBJECT_ID = templateByRole('stock_preparation_line').objectId
 
 function assertAdminPermission(permission) {
   if (permission !== REQUIRED_PERMISSION) {
@@ -397,6 +406,111 @@ async function listUnitConversionCandidates({ recordsApi, provisioning, targetPr
   }
 }
 
+// helper: validate an optional enum filter (422 with the field NAME only).
+function optionalEnumFilter(value, enumValues, field) {
+  const normalized = optionalString(value)
+  if (normalized && !enumValues.includes(normalized)) {
+    throw new StockPreparationConfirmReadError(422, 'CONFIRM_READS_CONFIG_INVALID', `${field} must be one of the ${field} vocabulary`, { field })
+  }
+  return normalized
+}
+
+function foldEnum(value, enumValues) {
+  const normalized = optionalString(value)
+  if (!normalized) return undefined
+  return enumValues.includes(normalized) ? normalized : 'unknown'
+}
+
+// ── W5: exception queue list (FE view 6) ──────────────────────────────────────────────────────────
+// VALUES-FREE rows: handles + enums + booleans only — the `message` cell (human-readable business
+// text) NEVER crosses; resolver identity surfaces as a presence boolean.
+async function listStockPreparationExceptions({ recordsApi, provisioning, targetProjectId, projectId, snapshotBatchId, status, exceptionType, severity, permission } = {}) {
+  assertAdminPermission(permission)
+  const api = ensureReadOnlyRecordsApi(recordsApi)
+  const prov = ensureProvisioningApi(provisioning)
+  const stagingProjectId = requiredString(targetProjectId, 'targetProjectId')
+  const businessProjectId = requiredString(projectId, 'projectId')
+  const statusFilter = optionalEnumFilter(status, EXCEPTION_STATUS_VALUES, 'status')
+  const typeFilter = optionalEnumFilter(exceptionType, EXCEPTION_TYPE_VALUES, 'exceptionType')
+  const severityFilter = optionalEnumFilter(severity, EXCEPTION_SEVERITY_VALUES, 'severity')
+  const batchFilter = optionalString(snapshotBatchId)
+
+  const exceptionSheet = await findMvpSheet(prov, stagingProjectId, EXCEPTION_OBJECT_ID)
+  let rows = exceptionSheet
+    ? (await queryAllRecords(api, exceptionSheet.id, batchFilter
+        ? { projectId: businessProjectId, snapshotBatchId: batchFilter }
+        : { projectId: businessProjectId })).map(recordData)
+    : []
+  if (statusFilter) rows = rows.filter((data) => optionalString(data.status) === statusFilter)
+  if (typeFilter) rows = rows.filter((data) => optionalString(data.exceptionType) === typeFilter)
+  if (severityFilter) rows = rows.filter((data) => optionalString(data.severity) === severityFilter)
+  if (rows.length > MAX_LIST_ROWS) {
+    throw new StockPreparationConfirmReadError(422, 'CONFIRM_READS_ROWS_TOO_LARGE', 'exception queue read exceeded the row bound', { maxRows: MAX_LIST_ROWS })
+  }
+  const unresolvedBlockingCount = rows.filter((data) => optionalString(data.severity) === 'blocking' && optionalString(data.status) !== 'resolved').length
+  return {
+    rowCount: rows.length,
+    unresolvedBlockingCount,
+    byType: enumCounts(rows, 'exceptionType', EXCEPTION_TYPE_VALUES),
+    byStatus: enumCounts(rows, 'status', EXCEPTION_STATUS_VALUES),
+    bySeverity: enumCounts(rows, 'severity', EXCEPTION_SEVERITY_VALUES),
+    rows: rows.map((data) => ({
+      exceptionId: optionalString(data.exceptionId),
+      snapshotBatchId: optionalString(data.snapshotBatchId) || undefined,
+      snapshotLineId: optionalString(data.snapshotLineId) || undefined,
+      stockPrepLineId: optionalString(data.stockPrepLineId) || undefined,
+      exceptionType: foldEnum(data.exceptionType, EXCEPTION_TYPE_VALUES),
+      severity: foldEnum(data.severity, EXCEPTION_SEVERITY_VALUES),
+      status: foldEnum(data.status, EXCEPTION_STATUS_VALUES),
+      resolutionAction: foldEnum(data.resolutionAction, RESOLUTION_ACTION_VALUES),
+      resolved: optionalString(data.status) === 'resolved',
+      resolvedByPresent: optionalString(data.resolvedBy) !== null,
+    })),
+  }
+}
+
+// ── W5: prep-line list (FE view 5) ────────────────────────────────────────────────────────────────
+// VALUES-FREE summary rows: handles + status enums + counts + presence booleans. Drawing numbers,
+// quantities, and unit symbols are value-bearing operator reads — OWNER-GATED (OD-W3-1), not served.
+async function listStockPreparationPrepLines({ recordsApi, provisioning, targetProjectId, projectId, snapshotBatchId, prepStatus, permission } = {}) {
+  assertAdminPermission(permission)
+  const api = ensureReadOnlyRecordsApi(recordsApi)
+  const prov = ensureProvisioningApi(provisioning)
+  const stagingProjectId = requiredString(targetProjectId, 'targetProjectId')
+  const businessProjectId = requiredString(projectId, 'projectId')
+  const prepStatusFilter = optionalEnumFilter(prepStatus, PREP_STATUS_VALUES, 'prepStatus')
+  const batchFilter = optionalString(snapshotBatchId)
+
+  const prepLineSheet = await findMvpSheet(prov, stagingProjectId, PREP_LINE_OBJECT_ID)
+  let rows = prepLineSheet
+    ? (await queryAllRecords(api, prepLineSheet.id, batchFilter
+        ? { projectId: businessProjectId, snapshotBatchId: batchFilter }
+        : { projectId: businessProjectId })).map(recordData)
+    : []
+  if (prepStatusFilter) rows = rows.filter((data) => optionalString(data.prepStatus) === prepStatusFilter)
+  if (rows.length > MAX_LIST_ROWS) {
+    throw new StockPreparationConfirmReadError(422, 'CONFIRM_READS_ROWS_TOO_LARGE', 'prep-line read exceeded the row bound', { maxRows: MAX_LIST_ROWS })
+  }
+  return {
+    rowCount: rows.length,
+    byPrepStatus: enumCounts(rows, 'prepStatus', PREP_STATUS_VALUES),
+    byMappingStatus: enumCounts(rows, 'mappingStatus', MATCH_STATUS_VALUES),
+    byUnitStatus: enumCounts(rows, 'unitStatus', UNIT_STATUS_VALUES),
+    rows: rows.map((data) => ({
+      stockPrepLineId: optionalString(data.stockPrepLineId),
+      snapshotBatchId: optionalString(data.snapshotBatchId) || undefined,
+      snapshotLineId: optionalString(data.snapshotLineId) || undefined,
+      prepStatus: foldEnum(data.prepStatus, PREP_STATUS_VALUES),
+      mappingStatus: foldEnum(data.mappingStatus, MATCH_STATUS_VALUES),
+      unitStatus: foldEnum(data.unitStatus, UNIT_STATUS_VALUES),
+      exceptionCount: toNumber(data.exceptionCount) || 0,
+      hasIssueQty: toNumber(data.issueQtyFinal) !== null,
+      hasErpTarget: Boolean(optionalString(data.erpMaterialCode) && optionalString(data.erpMaterialInternalId)),
+      createdFromRunId: optionalString(data.createdFromRunId) || undefined,
+    })),
+  }
+}
+
 module.exports = {
   REQUIRED_PERMISSION,
   MAPPING_OBJECT_ID,
@@ -406,6 +520,8 @@ module.exports = {
   listMaterialMappingCandidates,
   getUnitConversionSummary,
   listUnitConversionCandidates,
+  listStockPreparationExceptions,
+  listStockPreparationPrepLines,
   __internals: {
     assertAdminPermission,
     ensureReadOnlyRecordsApi,


### PR DESCRIPTION
## What

Wave-5 read half (stacked on #4024 — retarget to main after it lands): the two queryRecords-only list routes backing FE views 5/6.

| Route | Notes |
|---|---|
| `GET …/stock-preparation/exceptions` | view-6 typed queue — handles + folded enums + booleans; **`message` never crosses**; `resolvedByPresent` boolean; per-project filter + batch/status/type/severity enum gates; `unresolvedBlockingCount` mirrors the W4 server-side ready invariant |
| `GET …/stock-preparation/prep-lines` | view-5 values-free summary — status enums, `exceptionCount`, `hasIssueQty`/`hasErpTarget` presence booleans. **Drawing numbers / quantities / unit symbols stay OWNER-GATED (OD-W3-1)** — deliberately not served |

Junk stored enums fold to `unknown` (junk string never crosses); 2000-row fail-closed cap; staging/business split preserved; 403-before-IO.

## Tests

⚠️ plugin-integration-core tests run in NO CI workflow — verify locally:

```bash
cd plugins/plugin-integration-core
npm run test:stock-preparation-confirm-reads   # 10 cases (2 new)
npm test                                       # full chain green
```

W5 ladder: this (backend reads) → FE views 5/6 (apps/web lane) → module-scoped audit gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)