### PR TITLE
fix(attendance): H2 photo-evidence hardening — magic-byte sniff (P3-1) + orphan-row cleanup (P3-2)

### DIFF
--- a/docs/development/attendance-h2-photo-evidence-hardening-design-lock-20260710.md
+++ b/docs/development/attendance-h2-photo-evidence-hardening-design-lock-20260710.md
@@ -1,0 +1,136 @@
+# Attendance H2 — Photo-Evidence Hardening (P3-1 magic-byte sniffing + P3-2 orphan-row cleanup) — Design Lock
+
+- Date: 2026-07-10
+- Status: **RATIFIED** (coordinator decision recorded below; this doc is the implementation-landing record)
+- Scope: two review-driven hardening fixes to the S2 outdoor-punch photo-evidence contract
+  (`attendance-outdoor-require-photo-s2-design-lock-20260710.md` / #4016). Both close gaps in the `files`
+  table substrate that S2 introduced — neither changes `punchPolicy.outdoor.requirePhoto` semantics, G1/G3/G4
+  wire contracts, or default-off posture.
+
+---
+
+## P3-1 — photo evidence magic-byte sniffing
+
+**Defect**: the `files` row's `meta.contentType` is client-asserted — `POST /api/files/upload` (multer) trusts
+whatever the multipart part's `Content-Type` header claims, with no verification against the actual bytes.
+S2's G2 check (`plugins/plugin-attendance/index.cjs` punch handler, outdoor branch) reads that same
+client-asserted value and accepts anything starting with `image/`. A client can declare `Content-Type:
+image/png` on an arbitrary non-image body and pass G2 — the "photo evidence" contract has no evidence that
+the uploaded bytes are actually a photo.
+
+**Fix — sniff on upload, consume the sniffed value in G2**:
+
+| Site | Change |
+|---|---|
+| `packages/core-backend/src/services/imageMagicBytes.ts` (new, pure module) | `sniffImageContentType(buffer)` — ~20-line inline magic-byte match against PNG (`89 50 4E 47`), JPEG (`FF D8 FF`), GIF (`GIF8`), WEBP (`RIFF….WEBP`), BMP (`BM`). No new dependency. Returns the detected `image/*` string, or `undefined` on no match (including short/empty buffers — never throws). |
+| `packages/core-backend/src/routes/files.ts` upload success path | Sniffs `file.buffer` before the `files` INSERT and writes into `meta`: `sniffed: true` **unconditionally** (a path marker — see AMENDMENT below) and `sniffedContentType: <detected mime>` **only on a magic-byte hit**. `meta.contentType` (the client-asserted value) is unchanged. The route does **not** reject a sniff miss — `POST /api/files/upload` is a general-purpose upload endpoint (attachments, exports, etc. all flow through it); rejecting non-image uploads here would change its existing semantics for every caller, not just attendance evidence. |
+| `plugins/plugin-attendance/index.cjs` punch handler, G2 (`~L24852`) | Consumption is now conditioned on the path marker: **`meta.sniffed === true`** → the row went through the sniff-aware upload path → the check requires `meta.sniffedContentType` to be present **and** start with `image/`, else `422 OUTDOOR_PHOTO_INVALID`. **`meta.sniffed` absent** → the row predates this slice (or was written by some other path) → falls back to the pre-existing `meta.contentType` check, byte-for-byte. Old evidence is never retroactively invalidated. |
+
+---
+
+## AMENDMENT — the sniff-write / G2-fallback contradiction found during implementation, and the coordinator's ruling
+
+While implementing, a direct contradiction surfaced between two clauses of the original decree, both applied
+to the exact same scenario the deliverable's own test matrix requires:
+
+- **Sniff-write rule** (as originally worded): "a magic-byte miss on a new upload writes no `sniffedContentType`
+  key."
+- **G2 fallback rule** (as originally worded): "no sniff value present → fall back to `meta.contentType`
+  (old-row-compat behavior)."
+
+Walking the required forged-MIME test (multipart declares `image/png`, body is plain text) through both rules
+literally: the sniff misses (rule 1) → no `sniffedContentType` written → G2 sees no sniff value (rule 2) →
+falls back to `meta.contentType` = `'image/png'` (client-asserted, untouched) → **passes**. That is byte-for-
+byte the same `meta` shape as the required old-row-compat test (a directly-inserted legacy row with only
+`contentType` set, no `sniffedContentType`). One test demands `422`, the other demands pass-through, and — as
+originally worded — there was no way to tell "this row went through the new sniff path and missed" apart from
+"this row predates sniffing entirely," because both leave exactly the same absence of `sniffedContentType`.
+
+**Two candidate resolutions were raised, both a controlled deviation from "a miss writes no key":**
+
+- **(A) Path-marker field** (chosen): write `meta.sniffed = true` unconditionally on every upload through the
+  new path; `meta.sniffedContentType` keeps its original pure meaning (present + `image/*` only on an actual
+  hit). G2 branches on `sniffed`, not on `sniffedContentType`'s presence.
+- **(B) Sentinel value**: write `meta.sniffedContentType` on every upload — the detected type on a hit, `null`
+  (key present with a null value) on a miss — and have G2 branch on key-presence-including-null.
+
+**Coordinator ruling: (A).** Reasons recorded for the record: (B)'s "key present but value `null`" is a
+classic JSON-wire footgun — `'k' in obj`, `obj.k !== undefined`, and `obj.k != null` disagree with each other
+across serialization boundaries (a driver or intermediate layer that drops null-valued keys silently turns it
+back into (A)'s ambiguity), whereas (A)'s boolean path marker is unambiguous under any JSON round-trip and is
+explicit enough for a future consumer of the `files` table to reuse without re-deriving this reasoning. (A)
+also keeps `sniffedContentType`'s own meaning pure ("what did we detect," nothing else), which the original
+decree's own wording for that field already committed to.
+
+---
+
+## P3-2 — `DELETE /api/files/:id` orphan row
+
+**Defect**: `DELETE /api/files/:id` deleted only the storage object (`storage.delete(id)`); the `files` row
+(written on upload since S2 #4016 — `id`/`url`/`owner_id`/`meta`/`created_at`) was left behind. Besides
+accumulating orphan rows, this meant a punch could cite a `photoFileId` whose underlying storage object no
+longer existed but whose `files` row — and therefore G2's existence/ownership/content-type check — still
+looked valid: **dangling evidence** that G2 could not detect.
+
+**Fix**: after `storage.delete(id)` succeeds, `DELETE FROM files WHERE id = $1` (parameterized via Kysely's
+`sql` tag, consistent with the existing INSERT in the same file). A missing row is not an error — the delete
+route is a no-op on a row that doesn't exist (an object that predates the S2 writer, or a second delete of the
+same id) — matching SQL `DELETE`'s natural semantics; no new error branch was added.
+
+**Out of scope (unchanged)**: no ownership check was added to the delete route (none existed before this
+slice; adding one is a separate authorization decision, not a photo-evidence-hardening concern) and no
+approval-time fault tolerance was added — historical `photoFileId` values already embedded in
+`attendance_requests.metadata` are point-in-time audit records and are never rewritten by a later delete.
+
+---
+
+## OUT of scope (explicit)
+
+- **Does not reject non-image uploads.** `POST /api/files/upload` remains a general-purpose file-upload route;
+  a sniff miss is recorded, not enforced, at the upload layer. Enforcement is entirely on the attendance G2
+  consumer side.
+- **Does not retroactively rewrite or invalidate historical evidence.** Rows written before this slice (no
+  `sniffed` key) and `photoFileId` values already embedded in past `attendance_requests.metadata` are left
+  exactly as they were.
+- **No new dependency.** The sniffing module is ~40 lines of hand-written byte comparisons; no `file-type` (or
+  similar) package was added, and `pnpm-lock.yaml` is untouched by this slice.
+- **No delete-route ownership/authorization change.** Pre-existing behavior (any authenticated caller may
+  delete any file by id) is unchanged; this slice only makes the delete also remove the substrate row G2 reads.
+
+---
+
+## Test evidence (local, real DB)
+
+`packages/core-backend/tests/integration/attendance-outdoor-punch.test.ts` — **29/29 pass** on a freshly
+migrated DB (`db:migrate` against an empty Postgres, same migration set CI uses). New/changed cases:
+
+- `S2-photo E2E` (existing, extended): real PNG upload asserts `meta.sniffed === true` and
+  `meta.sniffedContentType === 'image/png'` in addition to the pre-existing owner/contentType assertions —
+  regression coverage for the sniff-write path on a genuine image.
+- `H2 P3-1: forged Content-Type` (new): multipart declares `image/png`, body is plain text → uploaded row has
+  `meta.contentType === 'image/png'` (client claim, untouched) + `meta.sniffed === true` + no
+  `sniffedContentType` key → punch with that `photoFileId` → `422 OUTDOOR_PHOTO_INVALID`.
+- `H2 P3-1: legacy files row` (new): directly-inserted row (`meta = {contentType:'image/png'}`, no `sniffed`
+  key) → punch passes (`202`), `metadata.outdoorPunch.photoFileId` set — proves the fallback path is intact.
+- `H2 P3-2: delete removes the files row` (new): upload → `DELETE /api/files/:id` (`200`) → direct `SELECT`
+  confirms the row is gone → punching with that now-deleted `photoFileId` → `422 OUTDOOR_PHOTO_INVALID`
+  (dangling evidence rejected, not silently accepted).
+
+Typecheck: `packages/core-backend` `tsc --noEmit` clean.
+
+No FE surface in this slice (no UI change) — nothing new needed in `attendance-web-guard.yml`;
+`attendance-outdoor-punch.test.ts` is already wired into `plugin-tests.yml`'s attendance integration gate.
+
+## Mutation self-check (3 cuts, each reverted after observing red)
+
+1. **G2 sniff-marker consumption removed** (`photoMeta.sniffed === true` branch deleted, always falls back to
+   `meta.contentType`) → `H2 P3-1: forged Content-Type` turns **red** (`422` expected, upload's client-claimed
+   `image/png` now passes → `202` observed).
+2. **`DELETE FROM files` removed** from the delete route → `H2 P3-2: delete removes the files row` turns
+   **red** at the post-delete `SELECT` assertion (row still present).
+3. **Sniff-write removed** (`sniffImageContentType` call / `meta.sniffed`+`meta.sniffedContentType` deleted
+   from the INSERT) → `S2-photo E2E`'s new `fileRow.meta.sniffed`/`sniffedContentType` assertions turn **red**
+   (both `undefined`).
+
+Each cut was applied to the working tree, the corresponding test observed red, then reverted before the next
+cut (see PR body for the exact commands/output).

--- a/docs/development/attendance-h2-photo-evidence-hardening-design-lock-20260710.md
+++ b/docs/development/attendance-h2-photo-evidence-hardening-design-lock-20260710.md
@@ -96,6 +96,10 @@ approval-time fault tolerance was added — historical `photoFileId` values alre
   similar) package was added, and `pnpm-lock.yaml` is untouched by this slice.
 - **No delete-route ownership/authorization change.** Pre-existing behavior (any authenticated caller may
   delete any file by id) is unchanged; this slice only makes the delete also remove the substrate row G2 reads.
+- **SVG (and any signature-less/text format) is deliberately NOT accepted as photo evidence.** The sniff list is
+  PNG/JPEG/GIF/WEBP/BMP only; an SVG upload gets `sniffed:true` with no `sniffedContentType` and is 422-rejected
+  by G2. This is an intentional tightening for the punch-photo threat model (SVG is scriptable text, not a
+  camera output), recorded here per adversarial review #4044 so it reads as a decision, not an omission.
 
 ---
 

--- a/packages/core-backend/src/routes/files.ts
+++ b/packages/core-backend/src/routes/files.ts
@@ -10,6 +10,7 @@ import { authenticate } from '../middleware/auth'
 import { Logger } from '../core/logger'
 import { StorageServiceImpl } from '../services/StorageService'
 import { db } from '../db/db'
+import { sniffImageContentType } from '../services/imageMagicBytes'
 import * as path from 'path'
 import { loadMulter, createUploadMiddleware } from '../types/multer'
 import type { RequestWithFiles } from '../types/multer'
@@ -80,6 +81,18 @@ export function filesRouter(): Router {
           // success with no corresponding row, which would make every downstream fileId
           // ownership/content-type check either wrongly reject a real upload or be unable to
           // tell a real id from a forged one.
+          //
+          // H2 photo-evidence-hardening design-lock (2026-07-10), P3-1: `contentType` above is
+          // client-asserted (the multipart part's Content-Type header, trusted as-is by multer).
+          // `sniffed: true` is written unconditionally on this path — it is a PATH MARKER, not a
+          // content-type value: it tells a consumer "this row went through magic-byte sniffing",
+          // distinguishing it from rows written before this slice (which never carry the key).
+          // `sniffedContentType` is written ONLY when a magic-byte signature actually matched —
+          // its own presence/absence still means exactly "did we detect an image", kept pure.
+          // Never rejects the upload on a miss (this route is general-purpose; a resume PDF or a
+          // CSV export is a legitimate non-image upload) — sniffing is advisory for downstream
+          // consumers (attendance G2) to decide what a miss means in their own domain.
+          const sniffedContentType = sniffImageContentType(file.buffer)
           try {
             await sql`
               INSERT INTO files (id, url, owner_id, meta, created_at)
@@ -90,7 +103,9 @@ export function filesRouter(): Router {
                 ${JSON.stringify({
                   contentType: result.contentType,
                   filename: result.filename,
-                  size: result.size
+                  size: result.size,
+                  sniffed: true,
+                  ...(sniffedContentType ? { sniffedContentType } : {})
                 })}::jsonb,
                 now()
               )
@@ -200,6 +215,14 @@ export function filesRouter(): Router {
       }
 
       await storage.delete(id)
+      // H2 photo-evidence-hardening design-lock (2026-07-10), P3-2: the storage object was the
+      // only thing this route ever deleted — the `files` row (owner_id + meta, written on upload
+      // since S2 #4016) was left behind as an orphan, and attendance's G2 photo-evidence check
+      // reads that row, not the storage object, so a punch could still cite "evidence" whose
+      // underlying file no longer exists. Delete the row too. Parameterized; a missing row (an
+      // object that predates the S2 writer, or a second delete of the same id) is not an error —
+      // `DELETE ... WHERE id = $1` is a no-op when no row matches.
+      await sql`DELETE FROM files WHERE id = ${id}`.execute(db)
       const userId = req.user?.id ?? req.user?.userId ?? req.user?.sub ?? 'anonymous'
 
       logger.info(`File deleted: ${id} by user ${userId}`)

--- a/packages/core-backend/src/services/imageMagicBytes.ts
+++ b/packages/core-backend/src/services/imageMagicBytes.ts
@@ -1,0 +1,49 @@
+/**
+ * Inline image magic-byte sniffing — no new dependency (H2 photo-evidence-hardening
+ * design-lock, 2026-07-10, P3-1).
+ *
+ * Defect this closes: a `files` row's `meta.contentType` is client-asserted (multer
+ * trusts whatever the multipart `Content-Type` part header claims), so a forged
+ * `image/png` declaration on a non-image body previously sailed through attendance's
+ * G2 outdoor-punch photo-evidence check (`image/*` string match against the
+ * self-reported value). This sniffs the first bytes of the uploaded buffer against a
+ * handful of well-known image signatures and returns the *detected* content-type —
+ * independent of whatever the client claimed.
+ *
+ * This module does NOT reject anything — `POST /api/files/upload` is a general-purpose
+ * file-upload route (attachments, exports, etc. all flow through it), and changing it
+ * to refuse non-image uploads would change its existing semantics for every caller.
+ * The sniff result is advisory: callers (here, the attendance G2 gate) decide what a
+ * miss means for their own domain.
+ */
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47]
+const JPEG_SIGNATURE = [0xff, 0xd8, 0xff]
+const GIF_SIGNATURE = [0x47, 0x49, 0x46, 0x38] // "GIF8" (covers GIF87a + GIF89a)
+const BMP_SIGNATURE = [0x42, 0x4d] // "BM"
+const RIFF_SIGNATURE = [0x52, 0x49, 0x46, 0x46] // "RIFF"
+const WEBP_SIGNATURE = [0x57, 0x45, 0x42, 0x50] // "WEBP" (bytes 8-11 of a RIFF container)
+
+function matchesAt(buffer: Buffer, offset: number, signature: number[]): boolean {
+  if (buffer.length < offset + signature.length) return false
+  for (let i = 0; i < signature.length; i++) {
+    if (buffer[offset + i] !== signature[i]) return false
+  }
+  return true
+}
+
+/**
+ * Returns the detected image content-type for `buffer`'s leading bytes, or
+ * `undefined` when no known image signature matches (including when the buffer is
+ * too short to hold any signature — never throws, never indexes out of bounds).
+ */
+export function sniffImageContentType(buffer: Buffer | undefined | null): string | undefined {
+  if (!buffer || buffer.length === 0) return undefined
+  if (matchesAt(buffer, 0, PNG_SIGNATURE)) return 'image/png'
+  if (matchesAt(buffer, 0, JPEG_SIGNATURE)) return 'image/jpeg'
+  if (matchesAt(buffer, 0, GIF_SIGNATURE)) return 'image/gif'
+  if (matchesAt(buffer, 0, BMP_SIGNATURE)) return 'image/bmp'
+  // WEBP is a RIFF container: bytes 0-3 "RIFF", bytes 4-7 file size (ignored), bytes 8-11 "WEBP".
+  if (matchesAt(buffer, 0, RIFF_SIGNATURE) && matchesAt(buffer, 8, WEBP_SIGNATURE)) return 'image/webp'
+  return undefined
+}

--- a/packages/core-backend/tests/integration/attendance-outdoor-punch.test.ts
+++ b/packages/core-backend/tests/integration/attendance-outdoor-punch.test.ts
@@ -795,10 +795,13 @@ describeDb('② S3 outdoor punch approval (real DB, route-level)', () => {
       const fileId = uploadedFileId(up)
       expect(fileId).toBeTruthy()
       // the upload wrote a real files row owned by the uploader (Fix 1 resolution + Option-A INSERT + Fix 2 table)
-      const fileRow = (await pool.query(`SELECT owner_id, meta ->> 'contentType' AS content_type FROM files WHERE id = $1`, [fileId])).rows[0]
+      const fileRow = (await pool.query(`SELECT owner_id, meta FROM files WHERE id = $1`, [fileId])).rows[0]
       expect(fileRow).toBeTruthy()
       expect(fileRow.owner_id).toBe(u)
-      expect(fileRow.content_type).toBe('image/png')
+      expect(fileRow.meta.contentType).toBe('image/png')
+      // H2 P3-1: a real PNG buffer is magic-byte sniffed on upload — path marker + detected type both land
+      expect(fileRow.meta.sniffed).toBe(true)
+      expect(fileRow.meta.sniffedContentType).toBe('image/png')
       const r = await punch(t, { eventType: 'check_in', location: OUTSIDE, photoFileId: fileId })
       expect(r.status).toBe(202)
       expect((r.body as { data?: { pendingApproval?: boolean } })?.data?.pendingApproval).toBe(true)
@@ -829,6 +832,90 @@ describeDb('② S3 outdoor punch approval (real DB, route-level)', () => {
       )
       expect('photoFileId' in (op as Record<string, unknown>)).toBe(false)
     } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  // ────────────────────────────────────────────────────────────────────────────────────────────────
+  // H2 photo-evidence-hardening design-lock (2026-07-10): P3-1 magic-byte sniffing (closes the
+  // forged-MIME gap where a client could declare `image/png` on a non-image body and pass G2's
+  // content-type check) + P3-2 orphan-row cleanup on delete (closes the dangling-evidence gap where
+  // a punch could cite a `photoFileId` whose underlying storage object was already deleted).
+
+  it('H2 P3-1: forged Content-Type — client declares image/png, body is non-image bytes → sniff misses on the new row → 422 OUTDOOR_PHOTO_INVALID', async () => {
+    await createOutdoorFlow()
+    await setOutdoorPhoto({ requireApproval: true, requirePhoto: true })
+    const u = photoUid('forgedmime')
+    const t = await mintToken(u, 'attendance:read,attendance:write')
+    try {
+      const up = await uploadFile(t, { filename: 'shot.png', contentType: 'image/png', content: Buffer.from('this is not actually a png, just text') })
+      expect(up.status).toBe(200)
+      const fileId = uploadedFileId(up)
+      expect(fileId).toBeTruthy()
+      // the client's forged declaration survives untouched in meta.contentType (the upload route never
+      // rejects a mismatched Content-Type — it stays a general-purpose upload) — but the sniff path
+      // marker is what G2 now trusts for a row written through this path, and the sniff missed.
+      const fileRow = (await pool.query(`SELECT meta FROM files WHERE id = $1`, [fileId])).rows[0]
+      expect(fileRow.meta.contentType).toBe('image/png')
+      expect(fileRow.meta.sniffed).toBe(true)
+      expect('sniffedContentType' in fileRow.meta).toBe(false)
+      const r = await punch(t, { eventType: 'check_in', location: OUTSIDE, photoFileId: fileId })
+      expect(r.status).toBe(422)
+      expect((r.body as { error?: { code?: string } })?.error?.code).toBe('OUTDOOR_PHOTO_INVALID')
+      expect((await counts(u)).outdoorReqs).toHaveLength(0)
+    } finally {
+      await cleanupPhotos(u)
+      await cleanupUser(u)
+    }
+  })
+
+  it('H2 P3-1: legacy files row (no `sniffed` key, only contentType asserted) → G2 falls back to the pre-slice check (punch passes)', async () => {
+    await createOutdoorFlow()
+    await setOutdoorPhoto({ requireApproval: true, requirePhoto: true })
+    const u = photoUid('legacyrow')
+    const t = await mintToken(u, 'attendance:read,attendance:write')
+    const legacyId = photoUid('legacy-id')
+    try {
+      await pool.query(
+        `INSERT INTO files (id, url, owner_id, meta, created_at) VALUES ($1, $2, $3, $4::jsonb, now())`,
+        [legacyId, 'https://example.invalid/legacy.png', u, JSON.stringify({ contentType: 'image/png', filename: 'legacy.png', size: 42 })],
+      )
+      const r = await punch(t, { eventType: 'check_in', location: OUTSIDE, photoFileId: legacyId })
+      expect(r.status).toBe(202)
+      const reqId = (r.body as { data?: { request?: { id?: string } } })?.data?.request?.id as string
+      expect(reqId).toBeTruthy()
+      const op = await outdoorPunchMeta(reqId)
+      expect(op?.photoFileId).toBe(legacyId)
+    } finally {
+      await pool.query(`DELETE FROM files WHERE id = $1`, [legacyId]).catch(() => undefined)
+      await cleanupUser(u)
+    }
+  })
+
+  it('H2 P3-2: delete removes the files row (orphan-row cleanup) and the id is no longer usable as evidence', async () => {
+    await createOutdoorFlow()
+    await setOutdoorPhoto({ requireApproval: true, requirePhoto: true })
+    const u = photoUid('delrow')
+    const t = await mintToken(u, 'attendance:read,attendance:write')
+    try {
+      const up = await uploadFile(t, { filename: 'evidence.png', contentType: 'image/png', content: PHOTO_PNG })
+      expect(up.status).toBe(200)
+      const fileId = uploadedFileId(up)
+      expect(fileId).toBeTruthy()
+      const before = (await pool.query(`SELECT id FROM files WHERE id = $1`, [fileId])).rows[0]
+      expect(before).toBeTruthy()
+      const del = await requestJson(`${baseUrl}/api/files/${fileId}`, { method: 'DELETE', headers: authHeaders(t) })
+      expect(del.status).toBe(200)
+      // P3-2: the files row is gone, not just the storage object
+      const after = (await pool.query(`SELECT id FROM files WHERE id = $1`, [fileId])).rows[0]
+      expect(after).toBeUndefined()
+      // dangling evidence: punching with the now-deleted fileId is rejected, not silently accepted
+      const r = await punch(t, { eventType: 'check_in', location: OUTSIDE, photoFileId: fileId })
+      expect(r.status).toBe(422)
+      expect((r.body as { error?: { code?: string } })?.error?.code).toBe('OUTDOOR_PHOTO_INVALID')
+      expect((await counts(u)).outdoorReqs).toHaveLength(0)
+    } finally {
+      await cleanupPhotos(u)
       await cleanupUser(u)
     }
   })

--- a/packages/core-backend/tests/unit/image-magic-bytes.test.ts
+++ b/packages/core-backend/tests/unit/image-magic-bytes.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { sniffImageContentType } from '../../src/services/imageMagicBytes'
+
+// Adversarial review #4044 P2-1: every signature branch and edge guard gets a direct
+// unit test — the E2E outdoor-punch path only exercises PNG-hit and text-miss, so a
+// regression in any other branch (JPEG being the dominant phone-camera format) would
+// 422 every genuine outdoor photo with zero test signal.
+describe('sniffImageContentType — signature branches', () => {
+  it('detects PNG', () => {
+    expect(sniffImageContentType(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toBe('image/png')
+  })
+
+  it('detects JPEG', () => {
+    expect(sniffImageContentType(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]))).toBe('image/jpeg')
+  })
+
+  it('detects GIF (87a and 89a share the GIF8 prefix)', () => {
+    expect(sniffImageContentType(Buffer.from('GIF87a', 'ascii'))).toBe('image/gif')
+    expect(sniffImageContentType(Buffer.from('GIF89a', 'ascii'))).toBe('image/gif')
+  })
+
+  it('detects BMP', () => {
+    expect(sniffImageContentType(Buffer.from('BM\x00\x00\x00\x00', 'ascii'))).toBe('image/bmp')
+  })
+
+  it('detects WEBP (RIFF at 0 AND WEBP at offset 8)', () => {
+    const webp = Buffer.concat([Buffer.from('RIFF', 'ascii'), Buffer.from([0x24, 0x00, 0x00, 0x00]), Buffer.from('WEBPVP8 ', 'ascii')])
+    expect(sniffImageContentType(webp)).toBe('image/webp')
+  })
+
+  it('does NOT treat a non-WEBP RIFF container (e.g. WAVE audio) as an image — offset-8 discrimination', () => {
+    const wave = Buffer.concat([Buffer.from('RIFF', 'ascii'), Buffer.from([0x24, 0x00, 0x00, 0x00]), Buffer.from('WAVEfmt ', 'ascii')])
+    expect(sniffImageContentType(wave)).toBeUndefined()
+  })
+})
+
+describe('sniffImageContentType — edge guards (never throws, never indexes out of bounds)', () => {
+  it('misses on plain text', () => {
+    expect(sniffImageContentType(Buffer.from('not an image', 'utf8'))).toBeUndefined()
+  })
+
+  it('misses on a truncated signature (shorter than any full match)', () => {
+    expect(sniffImageContentType(Buffer.from([0x89, 0x50]))).toBeUndefined()
+    expect(sniffImageContentType(Buffer.from('RIFF', 'ascii'))).toBeUndefined() // RIFF but nothing at offset 8
+  })
+
+  it('misses on empty / null / undefined input', () => {
+    expect(sniffImageContentType(Buffer.alloc(0))).toBeUndefined()
+    expect(sniffImageContentType(null)).toBeUndefined()
+    expect(sniffImageContentType(undefined)).toBeUndefined()
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -24854,8 +24854,28 @@ module.exports = {
               const photoRows = await db.query('SELECT id, owner_id, meta FROM files WHERE id = $1 LIMIT 1', [rawPhotoFileId])
               const photoRow = photoRows[0] ?? null
               const photoMeta = normalizeMetadata(photoRow?.meta)
-              const photoContentType = typeof photoMeta.contentType === 'string' ? photoMeta.contentType : ''
-              if (!photoRow || photoRow.owner_id !== userId || !photoContentType.startsWith('image/')) {
+              // H2 photo-evidence-hardening design-lock (2026-07-10) P3-1 AMENDMENT: `meta.contentType`
+              // is client-asserted (multer trusts the multipart part's Content-Type header as-is), so a
+              // forged `image/png` declaration on a non-image body previously passed this check. Rows
+              // written by the sniff-aware upload path (core routes/files.ts) carry `meta.sniffed ===
+              // true` — a PATH MARKER, not a content-type value — and ONLY those rows are held to the
+              // sniffed verdict: `meta.sniffedContentType` must be present and start with `image/`, else
+              // invalid (a magic-byte miss on a real upload is rejected here — this is what closes the
+              // forged-MIME gap). Rows with no `sniffed` key predate this slice and fall back to the
+              // pre-existing `meta.contentType` check byte-for-byte — old evidence is not retroactively
+              // invalidated. (Considered writing `sniffedContentType` unconditionally with a null
+              // sentinel on a miss instead of this separate marker — rejected: JSON key-present-but-null
+              // vs key-absent is a classic wire-format footgun, and a plain boolean path marker is more
+              // explicit and reusable by any future consumer of this table.)
+              let photoContentTypeValid
+              if (photoMeta.sniffed === true) {
+                const sniffedContentType = typeof photoMeta.sniffedContentType === 'string' ? photoMeta.sniffedContentType : ''
+                photoContentTypeValid = sniffedContentType.startsWith('image/')
+              } else {
+                const photoContentType = typeof photoMeta.contentType === 'string' ? photoMeta.contentType : ''
+                photoContentTypeValid = photoContentType.startsWith('image/')
+              }
+              if (!photoRow || photoRow.owner_id !== userId || !photoContentTypeValid) {
                 res.status(422).json({ ok: false, error: { code: 'OUTDOOR_PHOTO_INVALID', message: '照片证据无效' } })
                 return
               }


### PR DESCRIPTION
## Summary

Two review-driven hardening fixes to the S2 outdoor-punch photo-evidence contract (#4016), per the ratified design lock:

- **P3-1 (magic-byte sniffing)**: `files.meta.contentType` was client-asserted only (multer trusts the multipart Content-Type header as-is), so a forged `image/png` declaration on a non-image body previously passed the attendance G2 image/* check. Adds an inline ~20-line magic-byte sniff (no new dependency) on the upload success path in `packages/core-backend/src/routes/files.ts`, and updates G2 in `plugins/plugin-attendance/index.cjs` to consume the sniffed value first, falling back to the old client-asserted check only for rows that predate this slice.
- **P3-2 (orphan-row cleanup)**: `DELETE /api/files/:id` deleted only the storage object, leaving the `files` row behind — so a punch could cite `photoFileId` evidence whose underlying file no longer existed. Adds `DELETE FROM files WHERE id = $1` to the delete route.

## AMENDMENT — contradiction found + coordinator ruling

While implementing, the original decree's two P3-1 rules ("a sniff miss writes no `sniffedContentType` key" + "no sniff value present → fall back to the client-asserted `contentType`") were found to collide on the exact forged-MIME scenario the test matrix requires: both leave the identical absent-key shape as a legacy row, so the fallback rule would wave the forged upload through. Flagged back to the coordinator before implementing; ruling was **Option A — a dedicated boolean path marker** (`meta.sniffed = true`, written unconditionally on every new-path upload) as the G2 branch condition, rather than branching on `sniffedContentType`'s own presence (Option B, rejected — JSON key-present-but-null is a wire-format footgun). Full writeup: `docs/development/attendance-h2-photo-evidence-hardening-design-lock-20260710.md` AMENDMENT section.

## Design lock

`docs/development/attendance-h2-photo-evidence-hardening-design-lock-20260710.md` — gates, fix sites, AMENDMENT, OUT-of-scope, test/mutation evidence.

## Test plan

- [x] `packages/core-backend/tests/integration/attendance-outdoor-punch.test.ts` — **29/29 pass** on a freshly migrated DB (`db:migrate` against an empty Postgres). New/changed cases:
  - `S2-photo E2E` (extended): real PNG upload asserts `meta.sniffed === true` + `meta.sniffedContentType === 'image/png'` (regression).
  - `H2 P3-1: forged Content-Type`: declared `image/png`, text body → sniff misses on the new row → `422 OUTDOOR_PHOTO_INVALID`.
  - `H2 P3-1: legacy files row`: direct-inserted row, no `sniffed` key → falls back to old check → punch passes (`202`).
  - `H2 P3-2: delete removes the files row`: upload → delete → `SELECT` confirms row gone → punch with that id → `422 OUTDOOR_PHOTO_INVALID` (dangling evidence rejected).
- [x] `packages/core-backend` `tsc --noEmit` — clean.
- [x] Full attendance integration gate group (11 files, 268 tests) — all pass, no collateral damage.
- [x] Mutation self-check (3 cuts, each reverted after observing red; empty `git diff` confirmed after each revert):
  1. G2 `sniffed` branch neutered (`if (false)`) → `H2 P3-1: forged Content-Type` turns red (28/29).
  2. `DELETE FROM files` commented out → `H2 P3-2: delete removes the files row` turns red at the post-delete SELECT (28/29).
  3. Sniff-write removed from the INSERT → `S2-photo E2E`'s new sniff assertions turn red (also collaterally reddens the forged-MIME test, as expected — without sniffing, forgery can't be detected) (27/29).

No FE surface in this slice — nothing added to `attendance-web-guard.yml`; `attendance-outdoor-punch.test.ts` is already wired into `plugin-tests.yml`'s attendance integration gate.

refs #4016 (P3-1/P3-2 hardening follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
