### PR TITLE
fix(attendance): H1 — org-without-active-integration terminates retryable, not skipped (review #3920 P3-1)

### DIFF
--- a/docs/development/attendance-r4-p31-org-integration-retryable-design-lock-20260710.md
+++ b/docs/development/attendance-r4-p31-org-integration-retryable-design-lock-20260710.md
@@ -1,0 +1,33 @@
+# 考勤通知 DingTalk/WeCom 渠道 — org 无 active integration 终态改 retryable（H1，review #3920 P3-1）design-lock — 2026-07-10
+> Status: RATIFIED（口径由 #3920 R4 review 的 P3-1 精确给定，视同已锁；本轮为实现，不含设计裁量）。
+
+## 缺陷
+`AttendanceNotificationDeliveryWorker.ts` 的 `DingTalkAttendanceDeliveryChannel.resolveRecipient` / `WeComAttendanceDeliveryChannel.resolveRecipient` 三表 JOIN 0 行分支，把两种不同情形都终态成 `skipped`：
+1. 用户未在该 org 下与该 provider 建立 `linked+active` 绑定（`directory_account_links` 缺行）——**正确**，结构性、非故障，重试无意义。
+2. 该 org 对该 provider **整体没有** `status='active'` 的 `directory_integrations` 行（被 suspend/重配/删除）——**org 级、通常可恢复的故障**。因为 `skipped` 是终态（`claimDueDeliveries` 只 claim `pending`/`retrying`/过期 `sending`，从不 reclaim `skipped`），该窗口内该 org 的**每一条**通知都会被永久丢弃；即使集成之后恢复 active，已 skip 的行也不会自愈。
+
+## 修法
+0 行分支内二次判定——对 `(org_id, provider)` 做一次 `SELECT EXISTS(... status='active' ...)`（仅参数化 `org_id`，provider/status 与主查询一致地用字面量）：
+- **存在** active integration → 维持既有行为：`skip: true`，`{dingtalk|wecom}_recipient_not_bound`（byte-identical，未加参数化的字段/含义变化）。
+- **不存在** → 返回 `{ ok: false, retryable: true, error: '{dingtalk|wecom}_org_integration_inactive' }`（**不设 `skip`**），worker 按既有 `!failure.retryable && failure.skip` 门禁走 `markRetrying`（未耗尽 `maxAttempts`）→ 集成恢复后下一次轮询自动重新解析、自愈；耗尽后落 `failed`（可见的 dead-letter，而非静默 `skipped`）。
+- 二次查询只在 0 行冷路径触发，绑定命中（热路径）不受影响、零额外查询。
+- 两个 channel（DingTalk + WeCom）逐字 parity 修改——WeCom 三表 JOIN 是 DingTalk 的字面复制（S4 design-lock G5 既定惯例），此处沿用同一 parity 纪律。
+
+## 四分支表（每 channel）
+| 0 行 | org 有 active integration | 结果 | 备注 |
+|---|---|---|---|
+| 用户未绑定 | 是 | `skip: true`, `retryable: false`, `error='{provider}_recipient_not_bound'` | 行为不变（既有用例覆盖） |
+| 用户未绑定 | 否（suspend/删除） | `skip` 不设, `retryable: true`, `error='{provider}_org_integration_inactive'` | **本次新增**：H1 硬化 |
+| >1 行（ambiguous） | n/a | `retryable: false`，不 skip，`error='{provider}_recipient_ambiguous'` | 不动（OUT） |
+| external_user_id 为空 | n/a | `skip: true`, `retryable: false`，`error='{provider}_recipient_external_user_id_missing'` | 不动（OUT） |
+
+## 测试
+- 单测（`tests/unit/attendance-scheduler.test.ts` DingTalk / `tests/unit/attendance-wecom-delivery-channel.test.ts` WeCom）：query stub 按 SQL 内容（含 `directory_account_links` vs 否）判别调用序，覆盖 not_bound(有集成,行为不变) / org_integration_inactive(无集成,新增) 两态；新增用例精确 pin 第二条查询的 SQL 谓词（`provider = '...'`、`status = 'active'`）与参数（仅 `[orgId]`）。
+- 集成测试（`tests/integration/attendance-notification-deliveries.test.ts`，真 DB）：新增一条覆盖 DingTalk+WeCom 双 channel，用 `status='suspended'`（非缺行）证明谓词按 status 过滤而非仅存在性；`runBatch()` 精确断言 `{claimed, sent:0, retrying:2, failed:0, skipped:0}`，逐行断言 `status='retrying'`、`last_error='{provider}_org_integration_inactive'`、`claim_worker_id=null`、`next_attempt_at` 非空；两 channel 的 readConfig/fetchAccessToken/send 均断言从未被调用。
+- 既有 C5-3（DingTalk）/ S4（WeCom）真实-DB not_bound 用例本就在 org 内插入 `status='active'` integration 行，未做任何改动即继续绿——这是「行为不变」的真实证明，而非重写后再断言。
+
+## OUT（本切片不做）
+- `ambiguous`（>1 行）与 `external_user_id_missing` 分支不动——review 原文明确排除。
+- 不加 per-org 健康门/告警/仪表盘；本修法只解决终态是否可恢复，不新增可观测性面。
+- Email 渠道（`EmailAttendanceDeliveryChannel`）不在本次 review finding 范围内，不动。
+- 不改变 `maxAttempts`/backoff 曲线；耗尽重试后仍落既有 `failed` 桶（dead-letter），不新增第三终态。

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -369,10 +369,39 @@ export class DingTalkAttendanceDeliveryChannel implements AttendanceDeliveryChan
       [message.recipientUserId, message.orgId],
     )
     if (rows.length === 0) {
-      // No linked+active DingTalk binding at all — the ordinary "not onboarded to DingTalk yet" state
-      // for a partially-adopted org. Nothing about retrying (or alerting on this specific delivery)
-      // would help; the fix is a directory sync/linking action outside this worker's scope. Structural,
-      // not a fault: terminate as `skipped`, not `failed`.
+      // 0 rows conflates two different situations (H1 hardening — review #3920 P3-1): the ordinary
+      // "this user is not onboarded to DingTalk yet" gap for a partially-adopted org (SKIP — correct,
+      // unchanged), and "the org itself has no active DingTalk integration at all" because it was
+      // suspended/reconfigured/removed (directory_integrations has no status='active' row for this
+      // org). The latter is an org-level, typically RECOVERABLE outage: every delivery for that org
+      // would otherwise be silently and PERMANENTLY dropped via the `skipped` terminal state, and
+      // integration recovery would not self-heal anything already skipped. Disambiguate with one
+      // extra existence check — only reached on this cold 0-row path, never on the hot bound-recipient
+      // path.
+      const { rows: orgIntegrationRows } = await this.query<{ org_has_active_integration: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1
+             FROM directory_integrations
+            WHERE org_id = $1
+              AND provider = 'dingtalk'
+              AND status = 'active'
+         ) AS org_has_active_integration`,
+        [message.orgId],
+      )
+      const orgHasActiveIntegration = Boolean(orgIntegrationRows[0]?.org_has_active_integration)
+      if (!orgHasActiveIntegration) {
+        // No active DingTalk integration exists for this org at all — not this one user's onboarding
+        // gap. Return a retryable failure (NOT skip) so the worker's normal backoff keeps retrying;
+        // if/when the integration is re-activated, the delivery self-heals instead of staying dropped.
+        return {
+          ok: false,
+          result: { ok: false, retryable: true, error: 'dingtalk_org_integration_inactive' },
+        }
+      }
+      // The org DOES have an active DingTalk integration — this really is just "this user is not
+      // onboarded yet". Nothing about retrying (or alerting on this specific delivery) would help; the
+      // fix is a directory sync/linking action outside this worker's scope. Structural, not a fault:
+      // terminate as `skipped`, not `failed`.
       return {
         ok: false,
         result: { ok: false, retryable: false, skip: true, error: 'dingtalk_recipient_not_bound' },
@@ -566,9 +595,37 @@ export class WeComAttendanceDeliveryChannel implements AttendanceDeliveryChannel
       [message.recipientUserId, message.orgId],
     )
     if (rows.length === 0) {
-      // No linked+active WeCom binding at all — the ordinary "not onboarded to WeCom yet" state for a
-      // partially-adopted org (WeCom directory population is a named prerequisite outside this
-      // channel's scope — S4 design-lock G7). Structural, not a fault: terminate as `skipped`.
+      // 0 rows conflates two different situations (H1 hardening — review #3920 P3-1, applied here for
+      // parity with the DingTalk channel — same shape, same fix): the ordinary "this user is not
+      // onboarded to WeCom yet" gap for a partially-adopted org (SKIP — correct, unchanged; WeCom
+      // directory population is a named prerequisite outside this channel's scope — S4 design-lock
+      // G7), and "the org itself has no active WeCom integration at all" because it was
+      // suspended/reconfigured/removed. The latter is an org-level, typically RECOVERABLE outage:
+      // every delivery for that org would otherwise be silently and PERMANENTLY dropped via the
+      // `skipped` terminal state. Disambiguate with one extra existence check — only reached on this
+      // cold 0-row path, never on the hot bound-recipient path.
+      const { rows: orgIntegrationRows } = await this.query<{ org_has_active_integration: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1
+             FROM directory_integrations
+            WHERE org_id = $1
+              AND provider = 'wecom'
+              AND status = 'active'
+         ) AS org_has_active_integration`,
+        [message.orgId],
+      )
+      const orgHasActiveIntegration = Boolean(orgIntegrationRows[0]?.org_has_active_integration)
+      if (!orgHasActiveIntegration) {
+        // No active WeCom integration exists for this org at all — not this one user's onboarding
+        // gap. Return a retryable failure (NOT skip) so the worker's normal backoff keeps retrying;
+        // if/when the integration is re-activated, the delivery self-heals instead of staying dropped.
+        return {
+          ok: false,
+          result: { ok: false, retryable: true, error: 'wecom_org_integration_inactive' },
+        }
+      }
+      // The org DOES have an active WeCom integration — this really is just "this user is not
+      // onboarded yet". Structural, not a fault: terminate as `skipped`.
       return {
         ok: false,
         result: { ok: false, retryable: false, skip: true, error: 'wecom_recipient_not_bound' },

--- a/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
@@ -605,6 +605,158 @@ describeIfDatabase('Attendance C5 notification delivery outbox', () => {
     }
   })
 
+  it('H1 (review #3920 P3-1): org has NO active integration (suspended, not absent) -> retryable failure lands `retrying`, NOT `skipped` — DingTalk + WeCom parity', async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL is required for this integration test')
+    const publicPool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const orgId = `h1-org-inactive-${runSuffix}`
+    const dingTalkRecipientUserId = `u-h1-dingtalk-${runSuffix}`
+    const weComRecipientUserId = `u-h1-wecom-${runSuffix}`
+    const dingTalkIntegrationId = randomUUID()
+    const weComIntegrationId = randomUUID()
+    const dingTalkSourceId = randomUUID()
+    const weComSourceId = randomUUID()
+    let dingTalkDeliveryId = ''
+    let weComDeliveryId = ''
+    const dingTalkConfig: DingTalkMessageConfig = {
+      appKey: 'dt-app-key',
+      appSecret: 'dt-app-secret',
+      agentId: '123456789',
+      baseUrl: 'https://oapi.dingtalk.com',
+    }
+    const weComConfig: WeComMessageConfig = {
+      corpId: 'we-corp-h1',
+      corpSecret: 'we-corp-secret-h1',
+      agentId: '1000002',
+      baseUrl: 'https://qyapi.weixin.qq.com',
+    }
+    const query: AttendanceNotificationDeliveryQuery = async (sqlText, params) => {
+      const r = await publicPool.query(sqlText, params as unknown[])
+      return { rows: r.rows, rowCount: r.rowCount }
+    }
+    let dingTalkNetworkTouched = false
+    let weComNetworkTouched = false
+
+    try {
+      await requireTable(publicPool, 'directory_integrations')
+      await requireTable(publicPool, 'attendance_notification_deliveries')
+
+      // Both integration rows EXIST for this org but are `suspended`, not `active` — proves the
+      // EXISTS predicate filters on status, not mere row presence (stronger than an absent-row
+      // fixture, which would pass even against a bug that only checks "any row"). No
+      // directory_account_links row is created for either recipient (0-row cold path either way).
+      await publicPool.query(
+        `INSERT INTO directory_integrations (id, org_id, provider, name, status, corp_id, config)
+         VALUES ($1,$2,'dingtalk',$3,'suspended','corp-h1',$4::jsonb)`,
+        [dingTalkIntegrationId, orgId, `H1 DingTalk suspended ${runSuffix}`, JSON.stringify({})],
+      )
+      await publicPool.query(
+        `INSERT INTO directory_integrations (id, org_id, provider, name, status, corp_id, config)
+         VALUES ($1,$2,'wecom',$3,'suspended','we-corp-h1',$4::jsonb)`,
+        [weComIntegrationId, orgId, `H1 WeCom suspended ${runSuffix}`, JSON.stringify({})],
+      )
+
+      const dingTalkDelivery = await publicPool.query<{ id: string }>(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, payload)
+         VALUES ($1,'unscheduled_reminder',$2,$3,$4,'subject','dingtalk_work_notification',$5::jsonb)
+         RETURNING id::text AS id`,
+        [
+          orgId,
+          dingTalkSourceId,
+          `h1-dingtalk:${dingTalkSourceId}:recipient:${dingTalkRecipientUserId}:channel:dingtalk_work_notification`,
+          dingTalkRecipientUserId,
+          JSON.stringify({ title: 'H1 DingTalk org-inactive', body: 'Should never send.' }),
+        ],
+      )
+      dingTalkDeliveryId = dingTalkDelivery.rows[0].id
+
+      const weComDelivery = await publicPool.query<{ id: string }>(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, payload)
+         VALUES ($1,'unscheduled_reminder',$2,$3,$4,'subject','wecom_work_notification',$5::jsonb)
+         RETURNING id::text AS id`,
+        [
+          orgId,
+          weComSourceId,
+          `h1-wecom:${weComSourceId}:recipient:${weComRecipientUserId}:channel:wecom_work_notification`,
+          weComRecipientUserId,
+          JSON.stringify({ title: 'H1 WeCom org-inactive', body: 'Should never send.' }),
+        ],
+      )
+      weComDeliveryId = weComDelivery.rows[0].id
+
+      const dingTalkChannel = new DingTalkAttendanceDeliveryChannel({
+        query,
+        readConfig: async () => { dingTalkNetworkTouched = true; return dingTalkConfig },
+        fetchAccessToken: async () => { dingTalkNetworkTouched = true; return 'access-token' },
+        sendWorkNotification: async () => { dingTalkNetworkTouched = true; return { taskId: 'unused', raw: {} } },
+      })
+      const weComChannel = new WeComAttendanceDeliveryChannel({
+        query,
+        readConfig: async () => { weComNetworkTouched = true; return weComConfig },
+        fetchAccessToken: async () => { weComNetworkTouched = true; return 'access-token' },
+        sendTextMessage: async () => { weComNetworkTouched = true; return { errcode: 0, errmsg: 'ok', invalidUserIds: [], raw: {} } },
+      })
+      const worker = new AttendanceNotificationDeliveryWorker({
+        query,
+        channels: [dingTalkChannel, weComChannel],
+        now: () => new Date('2026-08-02T00:00:00.000Z'),
+        workerId: 'worker-h1-org-inactive',
+      })
+
+      // Neither recipient has a channel identity to resolve (0 recipient rows) AND neither org has an
+      // active integration (suspended, not active) — retryable:true, no skip: both land `retrying`,
+      // NOT `skipped`, and the worker's normal backoff will keep retrying rather than dropping them
+      // for good.
+      await expect(worker.runBatch()).resolves.toEqual({ claimed: 2, sent: 0, retrying: 2, failed: 0, skipped: 0 })
+      expect(dingTalkNetworkTouched).toBe(false)
+      expect(weComNetworkTouched).toBe(false)
+
+      const dingTalkRow = (await publicPool.query(
+        `SELECT status, delivered_at, last_error, attempt_count, claim_worker_id, claim_expires_at, next_attempt_at
+           FROM attendance_notification_deliveries
+          WHERE id = $1`,
+        [dingTalkDeliveryId],
+      )).rows[0]
+      expect(dingTalkRow).toMatchObject({
+        status: 'retrying',
+        delivered_at: null,
+        last_error: 'dingtalk_org_integration_inactive',
+        attempt_count: 1,
+        claim_worker_id: null,
+        claim_expires_at: null,
+      })
+      expect(dingTalkRow.next_attempt_at).toBeTruthy()
+
+      const weComRow = (await publicPool.query(
+        `SELECT status, delivered_at, last_error, attempt_count, claim_worker_id, claim_expires_at, next_attempt_at
+           FROM attendance_notification_deliveries
+          WHERE id = $1`,
+        [weComDeliveryId],
+      )).rows[0]
+      expect(weComRow).toMatchObject({
+        status: 'retrying',
+        delivered_at: null,
+        last_error: 'wecom_org_integration_inactive',
+        attempt_count: 1,
+        claim_worker_id: null,
+        claim_expires_at: null,
+      })
+      expect(weComRow.next_attempt_at).toBeTruthy()
+    } finally {
+      if (dingTalkDeliveryId) {
+        await publicPool.query('DELETE FROM attendance_notification_deliveries WHERE id = $1', [dingTalkDeliveryId]).catch(() => undefined)
+      }
+      if (weComDeliveryId) {
+        await publicPool.query('DELETE FROM attendance_notification_deliveries WHERE id = $1', [weComDeliveryId]).catch(() => undefined)
+      }
+      await publicPool.query('DELETE FROM directory_integrations WHERE id = $1', [dingTalkIntegrationId]).catch(() => undefined)
+      await publicPool.query('DELETE FROM directory_integrations WHERE id = $1', [weComIntegrationId]).catch(() => undefined)
+      await publicPool.end().catch(() => undefined)
+    }
+  })
+
   it('E3 deep-link: flag+base-URL send an actionCard whose button opens the container landing; missing URL falls back to text', async () => {
     if (!dbUrl) throw new Error('DATABASE_URL is required for this integration test')
     const publicPool = new Pool({ connectionString: dbUrl })

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -377,10 +377,17 @@ describe('Attendance C5 delivery worker primitives', () => {
       channel: 'dingtalk_work_notification',
       payload: {},
     }
-    // No linked+active binding at all: the ordinary "not onboarded to DingTalk yet" gap. Structural,
-    // not a fault — the worker must terminate this as `skipped`, so the channel flags skip: true.
+    // No linked+active binding at all, AND the org DOES have an active DingTalk integration (H1
+    // hardening — review #3920 P3-1: the 0-row cold path now runs a second EXISTS query before
+    // deciding skip vs retryable; content-discriminate the stub so both queries are answered
+    // correctly regardless of call order): the ordinary "not onboarded to DingTalk yet" gap.
+    // Structural, not a fault — the worker must terminate this as `skipped`, so the channel flags
+    // skip: true. This is the "behavior unchanged" case.
     const noBinding = new DingTalkAttendanceDeliveryChannel({
-      query: async () => ({ rows: [], rowCount: 0 }),
+      query: async (sql: string) => {
+        if (sql.includes('directory_account_links')) return { rows: [], rowCount: 0 }
+        return { rows: [{ org_has_active_integration: true }], rowCount: 1 }
+      },
       readConfig: async () => { throw new Error('should not read config') },
     })
     await expect(noBinding.send(base)).resolves.toEqual({
@@ -421,6 +428,43 @@ describe('Attendance C5 delivery worker primitives', () => {
       skip: true,
       error: 'dingtalk_recipient_external_user_id_missing',
     })
+  })
+
+  it('H1 (review #3920 P3-1): 0-row DingTalk recipient + org has NO active integration -> retryable failure, NOT skip (org-level recoverable outage)', async () => {
+    const base = {
+      id: 'delivery-1',
+      orgId: 'org-suspended',
+      sourceType: 'comp_time_expiry_reminder',
+      sourceId: 'balance-1',
+      sourceKey: 'balance-1:recipient:u1',
+      recipientUserId: 'u1',
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      payload: {},
+    }
+    const queryCalls: Array<{ sql: string; params: unknown[] | undefined }> = []
+    const noOrgIntegration = new DingTalkAttendanceDeliveryChannel({
+      query: async (sql: string, params?: unknown[]) => {
+        queryCalls.push({ sql, params })
+        if (sql.includes('directory_account_links')) return { rows: [], rowCount: 0 }
+        return { rows: [{ org_has_active_integration: false }], rowCount: 1 }
+      },
+      readConfig: async () => { throw new Error('should not read config') },
+    })
+    await expect(noOrgIntegration.send(base)).resolves.toEqual({
+      ok: false,
+      retryable: true,
+      error: 'dingtalk_org_integration_inactive',
+    })
+    // Pin both the recipient query AND the second existence-check query — the predicate scopes on
+    // provider='dingtalk' + status='active', parameterized by orgId only.
+    expect(queryCalls).toHaveLength(2)
+    expect(queryCalls[0].sql).toContain('directory_account_links')
+    expect(queryCalls[0].params).toEqual(['u1', 'org-suspended'])
+    expect(queryCalls[1].sql).toContain('FROM directory_integrations')
+    expect(queryCalls[1].sql).toContain("provider = 'dingtalk'")
+    expect(queryCalls[1].sql).toContain("status = 'active'")
+    expect(queryCalls[1].params).toEqual(['org-suspended'])
   })
 
   it('real DingTalk channel classifies config, network, and DingTalk business failures', async () => {

--- a/packages/core-backend/tests/unit/attendance-wecom-delivery-channel.test.ts
+++ b/packages/core-backend/tests/unit/attendance-wecom-delivery-channel.test.ts
@@ -46,14 +46,23 @@ function okResult(overrides: Partial<WeComSendMessageResult> = {}): WeComSendMes
 function makeChannel(opts: {
   rows?: Array<{ integration_id: string; external_user_id: string }>
   queryThrows?: boolean
+  // H1 hardening (review #3920 P3-1, parity slice): the 0-row cold path now issues a SECOND query
+  // (an EXISTS check against directory_integrations) before deciding skip vs retryable. Default true
+  // preserves every pre-H1 fixture's behavior (org has an active integration -> stays skip) without
+  // needing to touch them; only the new H1 tests below set this to false.
+  orgHasActiveIntegration?: boolean
   readConfig?: () => Promise<WeComMessageConfig>
   fetchAccessToken?: () => Promise<string>
   sendTextMessage?: ReturnType<typeof vi.fn>
   sendTextCardMessage?: ReturnType<typeof vi.fn>
 }) {
-  const query = vi.fn(async (_sql: string, _params?: unknown[]) => {
+  const query = vi.fn(async (sql: string, _params?: unknown[]) => {
     if (opts.queryThrows) throw new Error('db connection lost')
-    return { rows: opts.rows ?? [{ integration_id: 'integ-1', external_user_id: 'we-user-1' }] }
+    if (sql.includes('directory_account_links')) {
+      return { rows: opts.rows ?? [{ integration_id: 'integ-1', external_user_id: 'we-user-1' }] }
+    }
+    // The org-level EXISTS check (only reached from the 0-row recipient path).
+    return { rows: [{ org_has_active_integration: opts.orgHasActiveIntegration ?? true }] }
   })
   const sendTextMessage = opts.sendTextMessage ?? vi.fn(async () => okResult())
   const sendTextCardMessage = opts.sendTextCardMessage ?? vi.fn(async () => okResult())
@@ -68,13 +77,30 @@ function makeChannel(opts: {
 }
 
 describe('WeComAttendanceDeliveryChannel.resolveRecipient (via send) — three-table JOIN, provider=wecom', () => {
-  it('0 rows -> skip wecom_recipient_not_bound; provider=wecom scoped in the SQL', async () => {
-    const { channel, query, sendTextMessage } = makeChannel({ rows: [] })
+  it('0 rows + org HAS an active integration -> skip wecom_recipient_not_bound; provider=wecom scoped in the SQL', async () => {
+    // Behavior-unchanged case (H1 hardening — review #3920 P3-1): org-level integration exists, so
+    // this really is just "this one user is not onboarded yet".
+    const { channel, query, sendTextMessage } = makeChannel({ rows: [], orgHasActiveIntegration: true })
     const result = await channel.send(MESSAGE)
     expect(result).toEqual({ ok: false, retryable: false, skip: true, error: 'wecom_recipient_not_bound' })
     expect(query).toHaveBeenCalledWith(expect.stringContaining("a.provider = 'wecom'"), [MESSAGE.recipientUserId, MESSAGE.orgId])
     expect(query).toHaveBeenCalledWith(expect.stringContaining("i.provider = 'wecom'"), expect.anything())
     expect(sendTextMessage).not.toHaveBeenCalled()
+  })
+
+  it('H1 (review #3920 P3-1): 0 rows + org has NO active integration -> retryable failure, NOT skip (org-level recoverable outage)', async () => {
+    const { channel, query, sendTextMessage } = makeChannel({ rows: [], orgHasActiveIntegration: false })
+    const result = await channel.send(MESSAGE)
+    expect(result).toEqual({ ok: false, retryable: true, error: 'wecom_org_integration_inactive' })
+    expect(sendTextMessage).not.toHaveBeenCalled()
+    // Pin both queries: the recipient JOIN AND the org-level existence check, scoped by
+    // provider='wecom' + status='active', parameterized by orgId only.
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('directory_account_links'), [MESSAGE.recipientUserId, MESSAGE.orgId])
+    expect(query).toHaveBeenCalledWith(
+      expect.stringMatching(/FROM directory_integrations[\s\S]*provider = 'wecom'[\s\S]*status = 'active'/),
+      [MESSAGE.orgId],
+    )
+    expect(query).toHaveBeenCalledTimes(2)
   })
 
   it('>1 rows -> wecom_recipient_ambiguous, retryable:false, NOT skip (dead-letter, not skip)', async () => {


### PR DESCRIPTION
## Summary
- `DingTalkAttendanceDeliveryChannel.resolveRecipient` / `WeComAttendanceDeliveryChannel.resolveRecipient` 0-row branch conflated two different situations: "this user isn't onboarded yet" (correct `skip: true` → `skipped`) and "the org has no active integration at all" (suspended/removed) — the latter previously also silently landed `skipped`, a terminal state that never self-heals when the integration is reactivated.
- Fix: on the 0-row cold path, run one extra `EXISTS` check on `directory_integrations` scoped by `org_id` + `provider` + `status='active'`. If it exists, behavior is byte-identical (`skip: true`, `*_recipient_not_bound`). If it does not, return `retryable: true` (no skip) with a new error string (`dingtalk_org_integration_inactive` / `wecom_org_integration_inactive`), so the worker's normal backoff retries until the integration recovers, instead of permanently dropping the delivery.
- Both channels changed identically for parity (WeCom mirrors the DingTalk shape by existing convention). `ambiguous` (>1 row) and `external_user_id_missing` branches are untouched, matching the review finding's scope.
- Design-lock: `docs/development/attendance-r4-p31-org-integration-retryable-design-lock-20260710.md`.

refs #3920 (review finding P3-1 addressed here as a standalone hardening slice)

## Test plan
- [x] `pnpm --filter @metasheet/core-backend exec tsc --noEmit` — clean
- [x] Unit: `tests/unit/attendance-scheduler.test.ts` (DingTalk) + `tests/unit/attendance-wecom-delivery-channel.test.ts` (WeCom) — 64/64 passed; new cases pin both the recipient query and the new EXISTS query (SQL predicate + params)
- [x] Integration (real DB, fresh migration): `tests/integration/attendance-notification-deliveries.test.ts` — 9/9 passed, including a new case covering both channels with a `status='suspended'` (not absent) integration row, asserting `{claimed:2, sent:0, retrying:2, failed:0, skipped:0}` and that neither channel's network mocks were ever called
- [x] Full attendance integration gate (11 files matching `plugin-tests.yml`'s "Run attendance integration tests" step) — 266/266 passed on a freshly migrated DB
- [x] Full unit suite — 345 files / 4644 tests passed
- [x] Mutation 1 (inactive branch reverted to skip, both channels): new unit tests + new integration test flip red; all pre-existing tests stay green; restored via `git checkout --` (post-commit)
- [x] Mutation 2 (not_bound branch flipped to retryable, both channels): pre-existing "behavior unchanged" unit baselines AND the pre-existing real-DB C5-3 (DingTalk)/S4 (WeCom) unbound-recipient tests flip red; restored via `git checkout --`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

