### PR TITLE
feat(dingtalk): unified transport resilience — tiered retry/backoff/rate-limit at the client seam (roadmap §7.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,9 @@ JWT_EXPIRES_IN=2h
 # business semantics: safe reads retry on network errors / HTTP 429 / transient
 # 5xx / flow-control errcodes; one-shot code exchanges NEVER retry (single-use
 # codes); side-effect sends NEVER auto-resend (uncertain outcomes are surfaced
-# as outcome-unknown instead — no duplicate notifications).
+# as outcome-unknown instead — no duplicates introduced at the transport layer;
+# the attendance outbox may still resend on ambiguous failures until it consumes
+# the outcome-unknown marker — follow-up).
 # Exponential backoff + full jitter, honoring Retry-After (clamped to the cap).
 # In-process/best-effort only — replicas do not share a quota.
 # Invalid values fall back to the defaults shown.

--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,19 @@ JWT_EXPIRES_IN=2h
 # Optional multi-instance fleet coordination (defaults to single-process leader):
 # ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK=false
 #
+# ---- DingTalk transport resilience (roadmap §7.2) -----------------------------
+# Shared retry/backoff for every DingTalk API call in the core client: idempotent
+# reads retry on network errors / HTTP 429 / HTTP 5xx / flow-control errcodes;
+# sends and one-shot code exchanges retry ONLY on network-error-before-response
+# and HTTP 429 (never on an ambiguous 5xx — no duplicate notifications).
+# Exponential backoff + full jitter, honoring Retry-After (clamped to the cap).
+# Invalid values fall back to the defaults shown.
+# DINGTALK_TRANSPORT_MAX_ATTEMPTS=3
+# DINGTALK_TRANSPORT_BACKOFF_BASE_MS=300
+# DINGTALK_TRANSPORT_BACKOFF_CAP_MS=5000
+# Per-attempt request timeout in ms (DT-HARDEN-06; default 10000):
+# DINGTALK_REQUEST_TIMEOUT_MS=10000
+#
 # ---- Approval one-tap card (A-5 verification; design-lock #3594) --------------
 # APP_KEY/SECRET/AGENT_ID above ARE the same corp-app used to SEND the approval
 # action_card (asyncsend_v2). The card decision deep link additionally needs:

--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,8 @@ JWT_EXPIRES_IN=2h
 # 5xx / flow-control errcodes; one-shot code exchanges NEVER retry (single-use
 # codes); side-effect sends NEVER auto-resend (uncertain outcomes are surfaced
 # as outcome-unknown instead — no duplicates introduced at the transport layer;
-# the attendance outbox may still resend on ambiguous failures until it consumes
-# the outcome-unknown marker — follow-up).
+# Phase B: the approval-card ledger, person-delivery telemetry, and attendance
+# outbox all consume the marker and record 'outcome_unknown' without resending).
 # Exponential backoff + full jitter, honoring Retry-After (clamped to the cap).
 # In-process/best-effort only — replicas do not share a quota.
 # Invalid values fall back to the defaults shown.

--- a/.env.example
+++ b/.env.example
@@ -47,11 +47,13 @@ JWT_EXPIRES_IN=2h
 # ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK=false
 #
 # ---- DingTalk transport resilience (roadmap §7.2) -----------------------------
-# Shared retry/backoff for every DingTalk API call in the core client: idempotent
-# reads retry on network errors / HTTP 429 / HTTP 5xx / flow-control errcodes;
-# sends and one-shot code exchanges retry ONLY on network-error-before-response
-# and HTTP 429 (never on an ambiguous 5xx — no duplicate notifications).
+# Shared retry/backoff for every DingTalk API call in the core client, tiered by
+# business semantics: safe reads retry on network errors / HTTP 429 / transient
+# 5xx / flow-control errcodes; one-shot code exchanges NEVER retry (single-use
+# codes); side-effect sends NEVER auto-resend (uncertain outcomes are surfaced
+# as outcome-unknown instead — no duplicate notifications).
 # Exponential backoff + full jitter, honoring Retry-After (clamped to the cap).
+# In-process/best-effort only — replicas do not share a quota.
 # Invalid values fall back to the defaults shown.
 # DINGTALK_TRANSPORT_MAX_ATTEMPTS=3
 # DINGTALK_TRANSPORT_BACKOFF_BASE_MS=300

--- a/apps/web/src/approvals/cardDecision.ts
+++ b/apps/web/src/approvals/cardDecision.ts
@@ -10,7 +10,8 @@ import { apiFetch } from '../utils/api'
 export interface ApprovalCardSummary {
   deliveryId: string
   cardState: 'sent' | 'acted' | 'superseded' | 'expired' | 'revoked'
-  sendStatus: 'pending' | 'sent' | 'failed'
+  /** 'outcome_unknown' (PR #4046 Phase B): send attempted, response lost — the card MAY be delivered; the server keeps it actionable. */
+  sendStatus: 'pending' | 'sent' | 'failed' | 'outcome_unknown'
   nodeKey: string
   recipientUserId: string
   viewerIsRecipient: boolean

--- a/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
@@ -13,6 +13,7 @@
             <option value="success">{{ automationStatusLabel('success', isZh) }}</option>
             <option value="failed">{{ automationStatusLabel('failed', isZh) }}</option>
             <option value="skipped">{{ automationLabel('delivery.statusSkippedUnbound', isZh) }}</option>
+            <option value="outcome_unknown">{{ automationStatusLabel('outcome_unknown', isZh) }}</option>
           </select>
           <MtButton class="meta-person-delivery__btn" data-action="refresh" :disabled="loading" @click="loadData">{{ automationLabel('log.refresh', isZh) }}</MtButton>
         </div>
@@ -89,12 +90,15 @@ const filteredDeliveries = computed(() => {
   return deliveries.value.filter((delivery) => deliveryStatus(delivery) === statusFilter.value)
 })
 
-type DeliveryStatus = 'success' | 'failed' | 'skipped'
+// 'outcome_unknown' (PR #4046 Phase B): the send was attempted and the response lost — the
+// message MAY have been delivered. Distinct badge/filter value; folding it into 'failed' would
+// erase the reconciliation signal.
+type DeliveryStatus = 'success' | 'failed' | 'skipped' | 'outcome_unknown'
 
 const UNBOUND_DINGTALK_REASON = 'DingTalk account is not linked or user is inactive'
 
 function deliveryStatus(delivery: DingTalkPersonDelivery): DeliveryStatus {
-  if (delivery.status === 'success' || delivery.status === 'failed' || delivery.status === 'skipped') return delivery.status
+  if (delivery.status === 'success' || delivery.status === 'failed' || delivery.status === 'skipped' || delivery.status === 'outcome_unknown') return delivery.status
   if (delivery.success) return 'success'
   if (!delivery.dingtalkUserId && delivery.errorMessage === UNBOUND_DINGTALK_REASON) return 'skipped'
   return 'failed'
@@ -285,6 +289,11 @@ watch(
 .meta-person-delivery__badge--skipped {
   background: #fef3c7;
   color: #b45309;
+}
+
+.meta-person-delivery__badge--outcome_unknown {
+  background: #e2e8f0;
+  color: #475569;
 }
 
 .meta-person-delivery__time {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -1507,7 +1507,8 @@ export interface DingTalkPersonDelivery {
   subject: string
   content: string
   success: boolean
-  status?: 'success' | 'failed' | 'skipped'
+  /** `outcome_unknown` (PR #4046 Phase B): send attempted, response lost — maybe delivered, never auto-resent. */
+  status?: 'success' | 'failed' | 'skipped' | 'outcome_unknown'
   httpStatus?: number
   responseBody?: string
   errorMessage?: string

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -288,6 +288,7 @@ export type AutomationLabelKey =
   | 'status.success'
   | 'status.failed'
   | 'status.skipped'
+  | 'status.outcomeUnknown'
   | 'status.running'
   | 'status.resolved'
   | 'status.queued'
@@ -560,6 +561,7 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'status.success',
   'status.failed',
   'status.skipped',
+  'status.outcomeUnknown',
   'status.running',
   'status.resolved',
   'status.queued',
@@ -881,6 +883,7 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'status.success': { en: 'success', zh: '成功' },
   'status.failed': { en: 'failed', zh: '失败' },
   'status.skipped': { en: 'skipped', zh: '跳过' },
+  'status.outcomeUnknown': { en: 'outcome unknown', zh: '结果未知' },
   'status.running': { en: 'running', zh: '运行中' },
   'status.resolved': { en: 'resolved', zh: '已完成' },
   'status.queued': { en: 'queued', zh: '排队中' },
@@ -936,6 +939,7 @@ export function automationStatusLabel(status: AutomationStatus | UnknownAutomati
   if (status === 'success') return automationLabel('status.success', isZh)
   if (status === 'failed') return automationLabel('status.failed', isZh)
   if (status === 'skipped') return automationLabel('status.skipped', isZh)
+  if (status === 'outcome_unknown') return automationLabel('status.outcomeUnknown', isZh)
   if (status === 'running') return automationLabel('status.running', isZh)
   if (status === 'resolved') return automationLabel('status.resolved', isZh)
   if (status === 'queued') return automationLabel('status.queued', isZh)

--- a/apps/web/src/views/approval/ApprovalCardDecisionView.vue
+++ b/apps/web/src/views/approval/ApprovalCardDecisionView.vue
@@ -136,7 +136,11 @@ const staleTitle = computed(() => {
     return `该待办已处理（${s.actedAction === 'approve' ? '同意' : s.actedAction === 'reject' ? '驳回' : s.actedAction ?? ''}）。`
   }
   if (s.approval.status !== 'pending') return '该审批已办结，无需处理。'
-  if (s.sendStatus !== 'sent') return '该卡片未成功投递，无法在此处理。'
+  // outcome_unknown deliberately NOT here (PR #4046 Phase B): such a card MAY have been
+  // delivered, so while its instance is pending the server marks it actionable and this stale
+  // branch never renders; if it is non-actionable for another reason the generic 已流转 message
+  // below is the accurate one — not "未成功投递".
+  if (s.sendStatus === 'pending' || s.sendStatus === 'failed') return '该卡片未成功投递，无法在此处理。'
   return '该待办已流转（转办/新一轮），此卡片不再有效。'
 })
 

--- a/apps/web/tests/approvalCardDecisionView.spec.ts
+++ b/apps/web/tests/approvalCardDecisionView.spec.ts
@@ -132,6 +132,25 @@ describe('ApprovalCardDecisionView (A-3)', () => {
     expect((container!.querySelector('[data-testid="card-decision-reject"]') as HTMLButtonElement).disabled).toBe(false)
   })
 
+  it('PR #4046 Phase B: an actionable outcome_unknown card renders live buttons; a non-actionable one gets 已流转 — never 未成功投递', async () => {
+    // The valid deep-link token only ever existed inside the delivered card, so an
+    // outcome_unknown delivery whose instance is pending stays actionable server-side.
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, data: summaryFixture({ sendStatus: 'outcome_unknown' }) }))
+    await mountView()
+    expect(container!.querySelector('[data-testid="card-decision-approve"]')).toBeTruthy()
+    expect(container!.querySelector('[data-testid="card-decision-stale"]')).toBeNull()
+    app!.unmount(); container!.remove()
+
+    // Non-actionable for ANOTHER reason (superseded): the accurate message is 已流转 —
+    // "未成功投递" is reserved for pending/failed sends, where non-delivery is KNOWN.
+    apiFetchMock.mockReset()
+    apiFetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, data: summaryFixture({ sendStatus: 'outcome_unknown', cardState: 'superseded', actionable: false }) }))
+    await mountView()
+    const stale = container!.querySelector('[data-testid="card-decision-stale"]')
+    expect(stale?.getAttribute('data-title')).toContain('已流转')
+    expect(stale?.getAttribute('data-title')).not.toContain('未成功投递')
+  })
+
   it('approve submits to the card-delivery endpoint and renders the terminal state', async () => {
     apiFetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, data: summaryFixture() }))
     await mountView()

--- a/apps/web/tests/meta-person-delivery-viewer-migration.spec.ts
+++ b/apps/web/tests/meta-person-delivery-viewer-migration.spec.ts
@@ -40,4 +40,30 @@ describe('MetaAutomationPersonDeliveryViewer — MtButton migration (UI-P2-1c)',
     expect(get).toHaveBeenCalledTimes(1)
     expect(get).toHaveBeenCalledWith('s1', 'r1', 50)
   })
+
+  it('PR #4046 Phase B: an outcome_unknown delivery renders its own badge + reason (not folded into failed) and the filter offers the state', async () => {
+    const delivery = {
+      id: 'd1',
+      localUserId: 'u1',
+      dingtalkUserId: 'dd1',
+      sourceType: 'automation',
+      subject: 'S',
+      content: 'C',
+      success: false,
+      status: 'outcome_unknown',
+      errorMessage: 'dingtalk_send_outcome_unknown: fetch failed',
+      createdAt: new Date().toISOString(),
+      localUserIsActive: true,
+    }
+    mount({ getAutomationDingTalkPersonDeliveries: vi.fn().mockResolvedValue([delivery]) })
+    await flush()
+    const badge = container!.querySelector('.meta-person-delivery__badge') as HTMLElement
+    expect(badge.getAttribute('data-status')).toBe('outcome_unknown')
+    expect(badge.textContent?.trim()).toBe('outcome unknown') // en locale label, NOT 'failed'
+    // the send-uncertainty reason stays visible (status !== success renders the error line)
+    expect(container!.querySelector('.meta-person-delivery__error')?.textContent).toContain('outcome_unknown')
+    // admin-side list filter: the new state is selectable, not silently excluded by the IN-list
+    const options = Array.from(container!.querySelectorAll('[data-field="statusFilter"] option')).map((o) => (o as HTMLOptionElement).value)
+    expect(options).toContain('outcome_unknown')
+  })
 })

--- a/packages/core-backend/src/db/migrations/zzzz20260710150000_add_outcome_unknown_delivery_status.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260710150000_add_outcome_unknown_delivery_status.ts
@@ -1,0 +1,133 @@
+/**
+ * Migration: `outcome_unknown` status for the three DingTalk send ledgers (PR #4046 Phase B,
+ * roadmap §7.2 send-tier semantics).
+ *
+ * Owner-ratified doctrine: a side-effect send whose outcome is unknowable (network error /
+ * timeout / 5xx / malformed 2xx — the client saw no usable response, DingTalk may well have
+ * delivered) is recorded as `outcome_unknown` and NEVER auto-resent. It is a DISTINCT terminal
+ * state, not a plain failure: reconciliation is manual/ops (DingTalk's async-send result query
+ * by task_id only helps when a task_id exists — a lost response has none, so it cannot be an
+ * idempotency key).
+ *
+ * Three persistence surfaces get the widened vocabulary:
+ *  - dingtalk_approval_card_deliveries.send_status  (approval-card ledger, one-tap lock #3594)
+ *  - dingtalk_person_deliveries.status              (automation person-message + rule-creator telemetry)
+ *  - attendance_notification_deliveries.status      (C5 outbox — worker terminal state, not re-claimed)
+ *
+ * Each table is guarded by checkTableExists so partial-schema test harnesses (isolated-schema
+ * suites that run only the migrations they need) can apply this migration too. down() maps
+ * existing outcome_unknown rows to 'failed' BEFORE re-tightening each constraint — a down()
+ * that fails on live rows is broken.
+ */
+import { sql, type Kysely } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  if (await checkTableExists(db, 'dingtalk_approval_card_deliveries')) {
+    // The original send_status CHECK was added inline by
+    // zzzz20260705150100_add_send_columns_to_dingtalk_approval_card_deliveries (auto-named by
+    // Postgres). Drop whatever CHECK constrains send_status, then add a named, widened one.
+    await sql`
+      DO $$
+      DECLARE con RECORD;
+      BEGIN
+        FOR con IN
+          SELECT conname
+            FROM pg_constraint
+           WHERE conrelid = 'dingtalk_approval_card_deliveries'::regclass
+             AND contype = 'c'
+             AND pg_get_constraintdef(oid) LIKE '%send_status%'
+        LOOP
+          EXECUTE format('ALTER TABLE dingtalk_approval_card_deliveries DROP CONSTRAINT %I', con.conname);
+        END LOOP;
+      END $$;
+    `.execute(db)
+    await sql`
+      ALTER TABLE dingtalk_approval_card_deliveries
+      ADD CONSTRAINT chk_dingtalk_approval_card_deliveries_send_status
+      CHECK (send_status IN ('pending', 'sent', 'failed', 'outcome_unknown'))
+    `.execute(db)
+  }
+
+  if (await checkTableExists(db, 'dingtalk_person_deliveries')) {
+    await sql`
+      ALTER TABLE dingtalk_person_deliveries
+      DROP CONSTRAINT IF EXISTS chk_dingtalk_person_deliveries_status
+    `.execute(db)
+    await sql`
+      ALTER TABLE dingtalk_person_deliveries
+      ADD CONSTRAINT chk_dingtalk_person_deliveries_status
+      CHECK (status IN ('success', 'failed', 'skipped', 'outcome_unknown'))
+    `.execute(db)
+  }
+
+  if (await checkTableExists(db, 'attendance_notification_deliveries')) {
+    await sql`
+      ALTER TABLE attendance_notification_deliveries
+      DROP CONSTRAINT IF EXISTS chk_attendance_notification_deliveries_status
+    `.execute(db)
+    // NOTE: chk_attendance_notification_deliveries_delivered_status (delivered_at only when
+    // status='sent') is untouched — outcome_unknown rows never carry delivered_at.
+    await sql`
+      ALTER TABLE attendance_notification_deliveries
+      ADD CONSTRAINT chk_attendance_notification_deliveries_status
+      CHECK (status IN ('pending', 'sending', 'sent', 'retrying', 'failed', 'skipped', 'outcome_unknown'))
+    `.execute(db)
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  if (await checkTableExists(db, 'dingtalk_approval_card_deliveries')) {
+    // Map live outcome_unknown rows to 'failed' BEFORE tightening the constraint back. This is
+    // lossy by design (the down path has no outcome_unknown vocabulary to keep); send_error
+    // retains the original failure text.
+    await sql`
+      UPDATE dingtalk_approval_card_deliveries
+         SET send_status = 'failed'
+       WHERE send_status = 'outcome_unknown'
+    `.execute(db)
+    await sql`
+      ALTER TABLE dingtalk_approval_card_deliveries
+      DROP CONSTRAINT IF EXISTS chk_dingtalk_approval_card_deliveries_send_status
+    `.execute(db)
+    await sql`
+      ALTER TABLE dingtalk_approval_card_deliveries
+      ADD CONSTRAINT chk_dingtalk_approval_card_deliveries_send_status
+      CHECK (send_status IN ('pending', 'sent', 'failed'))
+    `.execute(db)
+  }
+
+  if (await checkTableExists(db, 'dingtalk_person_deliveries')) {
+    await sql`
+      UPDATE dingtalk_person_deliveries
+         SET status = 'failed'
+       WHERE status = 'outcome_unknown'
+    `.execute(db)
+    await sql`
+      ALTER TABLE dingtalk_person_deliveries
+      DROP CONSTRAINT IF EXISTS chk_dingtalk_person_deliveries_status
+    `.execute(db)
+    await sql`
+      ALTER TABLE dingtalk_person_deliveries
+      ADD CONSTRAINT chk_dingtalk_person_deliveries_status
+      CHECK (status IN ('success', 'failed', 'skipped'))
+    `.execute(db)
+  }
+
+  if (await checkTableExists(db, 'attendance_notification_deliveries')) {
+    await sql`
+      UPDATE attendance_notification_deliveries
+         SET status = 'failed'
+       WHERE status = 'outcome_unknown'
+    `.execute(db)
+    await sql`
+      ALTER TABLE attendance_notification_deliveries
+      DROP CONSTRAINT IF EXISTS chk_attendance_notification_deliveries_status
+    `.execute(db)
+    await sql`
+      ALTER TABLE attendance_notification_deliveries
+      ADD CONSTRAINT chk_attendance_notification_deliveries_status
+      CHECK (status IN ('pending', 'sending', 'sent', 'retrying', 'failed', 'skipped'))
+    `.execute(db)
+  }
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1553,7 +1553,7 @@ export interface DingTalkApprovalCardDeliveriesTable {
   acted_action: string | null
   acted_by: string | null
   acted_at: NullableTimestamp
-  send_status: 'pending' | 'sent' | 'failed'
+  send_status: 'pending' | 'sent' | 'failed' | 'outcome_unknown'
   send_error: string | null
   created_at: CreatedAt
   updated_at: CreatedAt
@@ -1567,7 +1567,7 @@ export interface DingTalkPersonDeliveriesTable {
   subject: string
   content: string
   success: boolean
-  status: 'success' | 'failed' | 'skipped'
+  status: 'success' | 'failed' | 'skipped' | 'outcome_unknown'
   http_status: number | null
   response_body: string | null
   error_message: string | null

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -41,7 +41,14 @@ export interface DingTalkApprovalCardDeliveryRow {
   acted_action: string | null
   acted_by: string | null
   acted_at: Date | string | null
-  send_status: 'pending' | 'sent' | 'failed'
+  /**
+   * `outcome_unknown` (PR #4046 Phase B): the send threw with the transport's
+   * isDingTalkOutcomeUnknown marker — DingTalk may well have delivered the card even though the
+   * client saw no usable response. NEVER auto-resent (owner doctrine); reconciliation is
+   * manual/ops, and a valid HMAC callback (the token only exists inside the delivered card's
+   * deep link) is itself proof of delivery, so outcome_unknown rows stay claimable.
+   */
+  send_status: 'pending' | 'sent' | 'failed' | 'outcome_unknown'
   send_error: string | null
   created_at: Date | string
   updated_at: Date | string
@@ -107,10 +114,13 @@ export async function findDingTalkApprovalCardDeliveryById(
 
 /**
  * Atomic acted-claim: succeeds for exactly one caller while the card is still `sent` AND was
- * actually delivered (`send_status='sent'` — review P2: a pending/failed send never produced a
- * live button, so nothing may claim it). Returns the updated row for the winner, `null` for
- * everyone else (duplicate callback, double tap, undelivered card, or a card already
- * superseded/expired) — losers re-read via `find…ById` to render the real terminal state.
+ * possibly delivered (`send_status IN ('sent','outcome_unknown')` — review P2: a pending/failed
+ * send never produced a live button, so nothing may claim it; PR #4046 Phase B widened the set by
+ * exactly `outcome_unknown`, whose card MAY in fact have been delivered — a valid HMAC callback
+ * proves it was, so the ledger's send-time uncertainty must not make a delivered card inoperable).
+ * Returns the updated row for the winner, `null` for everyone else (duplicate callback, double
+ * tap, undelivered card, or a card already superseded/expired) — losers re-read via `find…ById`
+ * to render the real terminal state.
  */
 export async function claimDingTalkApprovalCardDeliveryActed(
   query: QueryFn,
@@ -120,7 +130,7 @@ export async function claimDingTalkApprovalCardDeliveryActed(
   const result = await query(
     `UPDATE dingtalk_approval_card_deliveries
      SET card_state = 'acted', acted_action = $2, acted_by = $3, acted_at = NOW(), updated_at = NOW()
-     WHERE id = $1 AND card_state = 'sent' AND send_status = 'sent'
+     WHERE id = $1 AND card_state = 'sent' AND send_status IN ('sent', 'outcome_unknown')
      RETURNING ${RETURNING_COLUMNS}`,
     [id, input.action, input.actedBy],
   )
@@ -152,6 +162,28 @@ export async function markDingTalkApprovalCardDeliverySendFailed(
   const result = await query(
     `UPDATE dingtalk_approval_card_deliveries
      SET send_status = 'failed', send_error = $2, updated_at = NOW()
+     WHERE id = $1 AND send_status = 'pending'
+     RETURNING ${RETURNING_COLUMNS}`,
+    [id, error],
+  )
+  return (result.rows[0] as DingTalkApprovalCardDeliveryRow | undefined) ?? null
+}
+
+/**
+ * PR #4046 Phase B: records a send whose outcome is UNKNOWN (network error / timeout / 5xx /
+ * malformed 2xx — the transport's isDingTalkOutcomeUnknown marker). Distinct from `failed`
+ * (definite rejection): the card may well have reached the recipient, so this state is never
+ * auto-resent AND stays claimable by a valid HMAC callback. Same pending-only guard as the
+ * other A-2b transitions.
+ */
+export async function markDingTalkApprovalCardDeliverySendOutcomeUnknown(
+  query: QueryFn,
+  id: string,
+  error: string,
+): Promise<DingTalkApprovalCardDeliveryRow | null> {
+  const result = await query(
+    `UPDATE dingtalk_approval_card_deliveries
+     SET send_status = 'outcome_unknown', send_error = $2, updated_at = NOW()
      WHERE id = $1 AND send_status = 'pending'
      RETURNING ${RETURNING_COLUMNS}`,
     [id, error],

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -1,7 +1,19 @@
-import { Logger } from '../../core/logger'
 import { assertDingTalkCorpAllowed } from './runtime-policy'
+import {
+  normalizeErrorMessage,
+  readNumericField,
+  requestDingTalkTransportJson,
+  type DingTalkCallSafety,
+} from './transport'
 
-const logger = new Logger('DingTalkClient')
+// Error shapes and the H06 timeout knob moved to the unified transport (roadmap
+// §7.2) — re-exported so existing callers keep importing them from this module.
+export {
+  DINGTALK_REQUEST_TIMEOUT_MS,
+  DingTalkBusinessError,
+  DingTalkRequestError,
+  DingTalkTimeoutError,
+} from './transport'
 
 export interface DingTalkOauthConfig {
   clientId: string
@@ -73,8 +85,10 @@ export interface DingTalkWorkNotificationResult {
 
 interface DingTalkRequestOptions {
   fetchFn?: typeof fetch
-  /** Override the default per-request timeout (DT-HARDEN-06). */
+  /** Override the default per-request timeout (DT-HARDEN-06); applies PER ATTEMPT. */
   timeoutMs?: number
+  /** Overall abort signal: cancels the in-flight attempt AND any retry backoff immediately. */
+  signal?: AbortSignal
 }
 
 export interface DingTalkDepartment {
@@ -117,28 +131,6 @@ export interface DingTalkDirectoryUser {
   source: Record<string, unknown>
 }
 
-export class DingTalkRequestError extends Error {
-  statusCode: number
-  responseBody: Record<string, unknown> | null
-
-  constructor(message: string, statusCode: number, responseBody: Record<string, unknown> | null) {
-    super(message)
-    this.name = 'DingTalkRequestError'
-    this.statusCode = statusCode
-    this.responseBody = responseBody
-  }
-}
-
-export class DingTalkBusinessError extends Error {
-  responseBody: Record<string, unknown> | null
-
-  constructor(message: string, responseBody: Record<string, unknown> | null) {
-    super(message)
-    this.name = 'DingTalkBusinessError'
-    this.responseBody = responseBody
-  }
-}
-
 function readStringEnv(...keys: string[]): string {
   for (const key of keys) {
     const value = process.env[key]
@@ -167,114 +159,9 @@ function readEnvStatus<const T extends readonly string[]>(
   }
 }
 
-function normalizeErrorMessage(payload: Record<string, unknown> | null, fallback: string): string {
-  if (!payload) return fallback
-  const candidates = [
-    payload.message,
-    payload.msg,
-    payload.error_description,
-    payload.errorDescription,
-    payload.error,
-  ]
-  for (const candidate of candidates) {
-    if (typeof candidate === 'string' && candidate.trim().length > 0) {
-      return candidate.trim()
-    }
-  }
-  return fallback
-}
-
-async function readJson(response: Response): Promise<Record<string, unknown> | null> {
-  try {
-    const payload = await response.json()
-    return payload && typeof payload === 'object' ? payload as Record<string, unknown> : null
-  } catch {
-    return null
-  }
-}
-
-/**
- * DT-HARDEN-06: every DingTalk call that is not the group-robot webhook goes through
- * here — gettoken, directory sync, work notifications, approval cards, container
- * login. They used a naked `fetch` with no timeout, so a hung connection blocked an
- * inline automation execution or a whole directory sync for as long as undici's
- * default (~300s). Bound them, and surface the timeout as a typed operational error
- * so callers record a failed run/delivery instead of hanging.
- */
-export const DINGTALK_REQUEST_TIMEOUT_MS = (() => {
-  const raw = Number(process.env.DINGTALK_REQUEST_TIMEOUT_MS)
-  return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 10_000
-})()
-
-export class DingTalkTimeoutError extends Error {
-  readonly timeoutMs: number
-
-  constructor(timeoutMs: number) {
-    super(`DingTalk request timed out after ${timeoutMs}ms`)
-    this.name = 'DingTalkTimeoutError'
-    this.timeoutMs = timeoutMs
-  }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')
-}
-
-async function requestDingTalkJson(
-  input: string,
-  init: RequestInit,
-  fallbackError: string,
-  options?: DingTalkRequestOptions,
-): Promise<Record<string, unknown>> {
-  const timeoutMs = options?.timeoutMs ?? DINGTALK_REQUEST_TIMEOUT_MS
-  let response: Response
-  try {
-    response = await (options?.fetchFn ?? fetch)(input, {
-      ...init,
-      // Spread first: an explicit `signal: undefined` in `init` would otherwise
-      // clobber the timeout. A caller-supplied signal still wins.
-      signal: init.signal ?? AbortSignal.timeout(timeoutMs),
-    })
-  } catch (error) {
-    if (isAbortError(error)) {
-      logger.warn(`DingTalk request timed out after ${timeoutMs}ms`)
-      throw new DingTalkTimeoutError(timeoutMs)
-    }
-    throw error
-  }
-  const payload = await readJson(response)
-
-  if (!response.ok) {
-    const message = normalizeErrorMessage(payload, fallbackError)
-    logger.warn(`DingTalk request failed (${response.status}): ${message}`)
-    throw new DingTalkRequestError(message, response.status, payload)
-  }
-
-  return payload ?? {}
-}
-
-function readNumericField(payload: Record<string, unknown>, ...keys: string[]): number | null {
-  for (const key of keys) {
-    const value = payload[key]
-    if (typeof value === 'number') return value
-    if (typeof value === 'string' && value.trim().length > 0 && !Number.isNaN(Number(value))) {
-      return Number(value)
-    }
-  }
-  return null
-}
-
 function readNestedPayload(payload: Record<string, unknown>, key = 'result'): Record<string, unknown> {
   const nested = payload[key]
   return nested && typeof nested === 'object' ? nested as Record<string, unknown> : {}
-}
-
-function normalizeDingTalkApiPayload(payload: Record<string, unknown>, fallbackError: string): Record<string, unknown> {
-  const errcode = readNumericField(payload, 'errcode', 'code')
-  if (errcode !== null && errcode !== 0) {
-    throw new DingTalkBusinessError(normalizeErrorMessage(payload, fallbackError), payload)
-  }
-  return payload
 }
 
 function normalizeDirectoryBaseUrl(baseUrl?: string): string {
@@ -284,20 +171,54 @@ function normalizeDirectoryBaseUrl(baseUrl?: string): string {
   return normalized.replace(/\/+$/, '')
 }
 
+/**
+ * v1.0 api.dingtalk.com endpoints (HTTP-status based, no errcode envelope). All
+ * timeout/retry/backoff/flow-control handling lives in the shared transport seam
+ * (roadmap §7.2); `safety` is the explicit idempotency classification every call
+ * site must declare — see DingTalkCallSafety in ./transport.
+ */
+async function requestDingTalkJson(
+  input: string,
+  init: RequestInit,
+  fallbackError: string,
+  safety: DingTalkCallSafety,
+  options?: DingTalkRequestOptions,
+): Promise<Record<string, unknown>> {
+  return requestDingTalkTransportJson({
+    input,
+    init,
+    fallbackError,
+    safety,
+    envelope: 'none',
+    fetchFn: options?.fetchFn,
+    timeoutMs: options?.timeoutMs,
+    signal: options?.signal,
+  })
+}
+
+/**
+ * Legacy oapi.dingtalk.com envelope endpoints: an `errcode !== 0` inside an HTTP-200
+ * body surfaces as DingTalkBusinessError. The envelope is checked INSIDE the
+ * transport's retry loop so flow-control errcodes back off on idempotent reads.
+ */
 async function requestDingTalkDirectoryJson(
   path: string,
   init: RequestInit,
   fallbackError: string,
+  safety: DingTalkCallSafety,
   baseUrl?: string,
   options?: DingTalkRequestOptions,
 ): Promise<Record<string, unknown>> {
-  const payload = await requestDingTalkJson(
-    `${normalizeDirectoryBaseUrl(baseUrl)}${path}`,
+  return requestDingTalkTransportJson({
+    input: `${normalizeDirectoryBaseUrl(baseUrl)}${path}`,
     init,
     fallbackError,
-    options,
-  )
-  return normalizeDingTalkApiPayload(payload, fallbackError)
+    safety,
+    envelope: 'oapi',
+    fetchFn: options?.fetchFn,
+    timeoutMs: options?.timeoutMs,
+    signal: options?.signal,
+  })
 }
 
 export function readDingTalkOauthConfig(): DingTalkOauthConfig {
@@ -397,6 +318,9 @@ export async function exchangeCodeForUserAccessToken(
       }),
     },
     'Failed to obtain access token from DingTalk',
+    // One-shot authorization-code exchange: a retry after an ambiguous failure
+    // replays a possibly-consumed code — never retried beyond network-error/429.
+    'non-idempotent-write',
   )
 
   const accessToken = typeof payload.accessToken === 'string'
@@ -436,6 +360,7 @@ export async function fetchDingTalkCurrentUser(accessToken: string): Promise<Din
       },
     },
     'Failed to get current user info from DingTalk',
+    'idempotent-read',
   )
 
   const openId = typeof payload.openId === 'string'
@@ -514,6 +439,7 @@ async function fetchDingTalkAppAccessTokenUncached(
       },
     },
     'Failed to obtain DingTalk app access token',
+    'idempotent-read',
     baseUrl,
     options,
   )
@@ -577,6 +503,8 @@ export async function listDingTalkDepartments(
       }),
     },
     'Failed to list DingTalk departments',
+    // POST-verb but a pure list read — idempotent.
+    'idempotent-read',
     config?.baseUrl,
   )
 
@@ -617,6 +545,7 @@ export async function getDingTalkDepartmentDetail(
       }),
     },
     'Failed to read DingTalk department detail',
+    'idempotent-read',
     config?.baseUrl,
   )
 
@@ -653,6 +582,7 @@ export async function listDingTalkDepartmentUsers(
       }),
     },
     'Failed to list DingTalk department users',
+    'idempotent-read',
     config?.baseUrl,
   )
 
@@ -708,6 +638,7 @@ export async function getDingTalkUserDetail(
       }),
     },
     'Failed to read DingTalk user detail',
+    'idempotent-read',
     config?.baseUrl,
   )
 
@@ -769,6 +700,9 @@ export async function getDingTalkUserInfoByAuthCode(
       body: JSON.stringify({ code: authCode }),
     },
     'Failed to exchange DingTalk container auth code',
+    // One-shot container authCode: replaying a possibly-consumed code after an
+    // ambiguous failure would fail differently — never retried beyond network/429.
+    'non-idempotent-write',
     config?.baseUrl,
   )
 
@@ -1014,6 +948,9 @@ export async function sendDingTalkWorkNotificationActionCard(
       }),
     },
     'Failed to send DingTalk action-card work notification',
+    // Send: a duplicate action card is worse than a missed retry — only
+    // network-error-before-response and HTTP 429 are retried.
+    'non-idempotent-write',
     config.baseUrl,
     options,
   )
@@ -1073,6 +1010,9 @@ export async function sendDingTalkWorkNotification(
       }),
     },
     'Failed to send DingTalk work notification',
+    // Send: a duplicate work notification is worse than a missed retry — only
+    // network-error-before-response and HTTP 429 are retried.
+    'non-idempotent-write',
     config.baseUrl,
     options,
   )

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -13,6 +13,7 @@ import {
 export {
   DINGTALK_REQUEST_TIMEOUT_MS,
   DingTalkBusinessError,
+  DingTalkMalformedResponseError,
   DingTalkRequestError,
   DingTalkTimeoutError,
   isDingTalkOutcomeUnknown,

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -3,16 +3,19 @@ import {
   normalizeErrorMessage,
   readNumericField,
   requestDingTalkTransportJson,
-  type DingTalkCallSafety,
+  type DingTalkCallKind,
 } from './transport'
 
 // Error shapes and the H06 timeout knob moved to the unified transport (roadmap
 // §7.2) — re-exported so existing callers keep importing them from this module.
+// isDingTalkOutcomeUnknown lets ledger writers distinguish "maybe delivered"
+// send failures (network/timeout/5xx) from definite rejections.
 export {
   DINGTALK_REQUEST_TIMEOUT_MS,
   DingTalkBusinessError,
   DingTalkRequestError,
   DingTalkTimeoutError,
+  isDingTalkOutcomeUnknown,
 } from './transport'
 
 export interface DingTalkOauthConfig {
@@ -174,21 +177,21 @@ function normalizeDirectoryBaseUrl(baseUrl?: string): string {
 /**
  * v1.0 api.dingtalk.com endpoints (HTTP-status based, no errcode envelope). All
  * timeout/retry/backoff/flow-control handling lives in the shared transport seam
- * (roadmap §7.2); `safety` is the explicit idempotency classification every call
- * site must declare — see DingTalkCallSafety in ./transport.
+ * (roadmap §7.2); `kind` is the explicit business-semantics tier every call site
+ * must declare (read / exchange / send) — see DingTalkCallKind in ./transport.
  */
 async function requestDingTalkJson(
   input: string,
   init: RequestInit,
   fallbackError: string,
-  safety: DingTalkCallSafety,
+  kind: DingTalkCallKind,
   options?: DingTalkRequestOptions,
 ): Promise<Record<string, unknown>> {
   return requestDingTalkTransportJson({
     input,
     init,
     fallbackError,
-    safety,
+    kind,
     envelope: 'none',
     fetchFn: options?.fetchFn,
     timeoutMs: options?.timeoutMs,
@@ -205,7 +208,7 @@ async function requestDingTalkDirectoryJson(
   path: string,
   init: RequestInit,
   fallbackError: string,
-  safety: DingTalkCallSafety,
+  kind: DingTalkCallKind,
   baseUrl?: string,
   options?: DingTalkRequestOptions,
 ): Promise<Record<string, unknown>> {
@@ -213,7 +216,7 @@ async function requestDingTalkDirectoryJson(
     input: `${normalizeDirectoryBaseUrl(baseUrl)}${path}`,
     init,
     fallbackError,
-    safety,
+    kind,
     envelope: 'oapi',
     fetchFn: options?.fetchFn,
     timeoutMs: options?.timeoutMs,
@@ -318,9 +321,9 @@ export async function exchangeCodeForUserAccessToken(
       }),
     },
     'Failed to obtain access token from DingTalk',
-    // One-shot authorization-code exchange: a retry after an ambiguous failure
-    // replays a possibly-consumed code — never retried beyond network-error/429.
-    'non-idempotent-write',
+    // One-shot authorization-code exchange: a retry after ANY ambiguous failure
+    // burns or double-redeems the single-use code — never retried.
+    'exchange',
   )
 
   const accessToken = typeof payload.accessToken === 'string'
@@ -360,7 +363,7 @@ export async function fetchDingTalkCurrentUser(accessToken: string): Promise<Din
       },
     },
     'Failed to get current user info from DingTalk',
-    'idempotent-read',
+    'read',
   )
 
   const openId = typeof payload.openId === 'string'
@@ -439,7 +442,7 @@ async function fetchDingTalkAppAccessTokenUncached(
       },
     },
     'Failed to obtain DingTalk app access token',
-    'idempotent-read',
+    'read',
     baseUrl,
     options,
   )
@@ -503,8 +506,8 @@ export async function listDingTalkDepartments(
       }),
     },
     'Failed to list DingTalk departments',
-    // POST-verb but a pure list read — idempotent.
-    'idempotent-read',
+    // POST-verb but a query-shaped read — safe to retry.
+    'read',
     config?.baseUrl,
   )
 
@@ -545,7 +548,7 @@ export async function getDingTalkDepartmentDetail(
       }),
     },
     'Failed to read DingTalk department detail',
-    'idempotent-read',
+    'read',
     config?.baseUrl,
   )
 
@@ -582,7 +585,7 @@ export async function listDingTalkDepartmentUsers(
       }),
     },
     'Failed to list DingTalk department users',
-    'idempotent-read',
+    'read',
     config?.baseUrl,
   )
 
@@ -638,7 +641,7 @@ export async function getDingTalkUserDetail(
       }),
     },
     'Failed to read DingTalk user detail',
-    'idempotent-read',
+    'read',
     config?.baseUrl,
   )
 
@@ -700,9 +703,9 @@ export async function getDingTalkUserInfoByAuthCode(
       body: JSON.stringify({ code: authCode }),
     },
     'Failed to exchange DingTalk container auth code',
-    // One-shot container authCode: replaying a possibly-consumed code after an
-    // ambiguous failure would fail differently — never retried beyond network/429.
-    'non-idempotent-write',
+    // One-shot container authCode: a retry after ANY ambiguous failure burns or
+    // double-redeems the single-use code — never retried.
+    'exchange',
     config?.baseUrl,
   )
 
@@ -948,9 +951,10 @@ export async function sendDingTalkWorkNotificationActionCard(
       }),
     },
     'Failed to send DingTalk action-card work notification',
-    // Send: a duplicate action card is worse than a missed retry — only
-    // network-error-before-response and HTTP 429 are retried.
-    'non-idempotent-write',
+    // Side-effect send: never auto-retried. A lost response has no task_id, so
+    // DingTalk's async-send result query cannot serve as an idempotency key —
+    // uncertain outcomes surface via isDingTalkOutcomeUnknown instead.
+    'send',
     config.baseUrl,
     options,
   )
@@ -1010,9 +1014,10 @@ export async function sendDingTalkWorkNotification(
       }),
     },
     'Failed to send DingTalk work notification',
-    // Send: a duplicate work notification is worse than a missed retry — only
-    // network-error-before-response and HTTP 429 are retried.
-    'non-idempotent-write',
+    // Side-effect send: never auto-retried. A lost response has no task_id, so
+    // DingTalk's async-send result query cannot serve as an idempotency key —
+    // uncertain outcomes surface via isDingTalkOutcomeUnknown instead.
+    'send',
     config.baseUrl,
     options,
   )

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -1,5 +1,6 @@
 import { assertDingTalkCorpAllowed } from './runtime-policy'
 import {
+  DingTalkBusinessError,
   normalizeErrorMessage,
   readNumericField,
   requestDingTalkTransportJson,
@@ -898,6 +899,9 @@ export async function sendDingTalkInteractiveApprovalCard(
       }),
     },
     'Failed to send DingTalk interactive approval card',
+    // B-2 interactive card is a SIDE-EFFECT SEND: never resent on ambiguity; a lost
+    // response surfaces as outcome-unknown for the card ledger (same tier as asyncsend_v2).
+    'send',
     options,
   )
 

--- a/packages/core-backend/src/integrations/dingtalk/transport.ts
+++ b/packages/core-backend/src/integrations/dingtalk/transport.ts
@@ -9,7 +9,9 @@ const logger = new Logger('DingTalkTransport')
  *
  *  - the DT-HARDEN-06 per-request timeout — preserved, now composed PER ATTEMPT
  *    (each retry attempt gets its own fresh `AbortSignal.timeout`; a caller-supplied
- *    overall signal aborts the in-flight attempt AND any backoff wait immediately);
+ *    overall signal aborts the in-flight attempt AND any backoff wait immediately).
+ *    The budget covers the whole attempt: a response BODY that stalls after headers
+ *    arrived surfaces as the same DingTalkTimeoutError as a request-phase timeout;
  *  - bounded retry with exponential backoff + full jitter, honoring `Retry-After`;
  *  - explicit BUSINESS-SEMANTICS classification per call site (see
  *    {@link DingTalkCallKind}) — never inferred from the HTTP verb;
@@ -157,7 +159,10 @@ export function resolveDingTalkTransportConfig(): DingTalkTransportConfig {
  *    envelope `code` field), so the transport never retries a class the delivery
  *    layer considers permanent, and vice versa.
  *
- * Only consulted for `'read'` calls — see {@link DingTalkCallKind}.
+ * The failure classifier consults this set for EVERY tier, but only `'read'` calls
+ * retry on a match; for `'send'`/`'exchange'` it only shapes the failure reason (a
+ * flow-control envelope is a definite rejection, so it is never outcome-unknown).
+ * See {@link DingTalkCallKind}.
  */
 export function isDingTalkFlowControlErrcode(code: number): boolean {
   return code === 90018
@@ -285,17 +290,55 @@ export function readNumericField(payload: Record<string, unknown>, ...keys: stri
   return null
 }
 
-async function readJson(response: Response): Promise<Record<string, unknown> | null> {
+/**
+ * Structural (name-based) check rather than `instanceof Error`: abort reasons are
+ * `DOMException`s, and DOMException only inherits from Error in recent Node versions
+ * (late 18.x onward) — the supported floor is Node >=18.0.0.
+ */
+function isAbortError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const name = (error as { name?: unknown }).name
+  return name === 'AbortError' || name === 'TimeoutError'
+}
+
+/**
+ * Body-phase abort detection. Current undici rejects an aborted body read with the
+ * abort reason itself (AbortError / TimeoutError DOMException); Node 18's undici
+ * wraps it as `TypeError: terminated` with the reason as `cause`. A `terminated`
+ * whose cause is a socket error is NOT an abort — it falls through to network-error
+ * classification.
+ */
+function isBodyAbortError(error: unknown): boolean {
+  if (isAbortError(error)) return true
+  if (typeof error !== 'object' || error === null) return false
+  return isAbortError((error as { cause?: unknown }).cause)
+}
+
+/**
+ * Read the response body as JSON under the SAME per-attempt budget as the request
+ * itself: undici ties the body stream to the request signal, so a body that stalls
+ * past the per-attempt timeout rejects here with the abort reason AFTER headers
+ * already arrived. That MUST surface as DingTalkTimeoutError — identical
+ * classification to a request-phase timeout (never retried; outcome-unknown on the
+ * send tier) — and must never be swallowed into a `null` payload: on the ok-path a
+ * swallowed body abort would normalize to `{}` and report SUCCESS for a call whose
+ * outcome is unknown; on the non-ok path it would masquerade as a retryable
+ * `http_<status>`. Only a genuinely non-JSON body (SyntaxError from JSON.parse)
+ * keeps the tolerant `null`; any other mid-body stream failure (connection reset)
+ * rethrows raw and classifies as a network error.
+ */
+async function readJson(response: Response, timeoutMs: number): Promise<Record<string, unknown> | null> {
   try {
     const payload = await response.json()
     return payload && typeof payload === 'object' ? payload as Record<string, unknown> : null
-  } catch {
-    return null
+  } catch (error) {
+    if (error instanceof SyntaxError) return null
+    if (isBodyAbortError(error)) {
+      logger.warn(`DingTalk response body read aborted after ${timeoutMs}ms (headers received, body stalled)`)
+      throw new DingTalkTimeoutError(timeoutMs)
+    }
+    throw error
   }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')
 }
 
 function normalizeDingTalkApiPayload(payload: Record<string, unknown>, fallbackError: string): Record<string, unknown> {
@@ -323,17 +366,55 @@ function readResponseHeader(response: Response, name: string): string | null {
  */
 const retryAfterHints = new WeakMap<object, number>()
 
+interface PerAttemptSignal {
+  signal: AbortSignal
+  /**
+   * Fallback-composition cleanup: detach the abort listeners once the attempt
+   * settles, so a long-lived caller signal does not accumulate one listener per
+   * attempt (`AbortSignal.any` manages its own internal registrations; the manual
+   * fallback must clean up explicitly). No-op on the native / no-caller-signal paths.
+   */
+  dispose: () => void
+}
+
+const noopDispose = () => {}
+
 /**
  * DT-HARDEN-06 composed per attempt: each attempt gets its OWN fresh timeout signal
  * (a retry must not start with an already-spent timeout budget); the caller's
- * overall signal aborts every attempt as well as the backoff sleeps.
+ * overall signal aborts every attempt as well as the backoff sleeps. The composed
+ * signal also governs the response BODY read (undici ties body streams to the
+ * request signal), so the per-attempt budget covers headers AND body.
  */
-function composePerAttemptSignal(callerSignal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+function composePerAttemptSignal(callerSignal: AbortSignal | undefined, timeoutMs: number): PerAttemptSignal {
   const timeoutSignal = AbortSignal.timeout(timeoutMs)
-  if (!callerSignal) return timeoutSignal
-  if (typeof AbortSignal.any === 'function') return AbortSignal.any([callerSignal, timeoutSignal])
-  // Pre-Node-20.3 fallback: preserve the pre-retry precedence (caller signal wins).
-  return callerSignal
+  if (!callerSignal) return { signal: timeoutSignal, dispose: noopDispose }
+  if (typeof AbortSignal.any === 'function') {
+    return { signal: AbortSignal.any([callerSignal, timeoutSignal]), dispose: noopDispose }
+  }
+  // Pre-Node-20.3 fallback: manual AbortSignal.any — whichever of (caller signal,
+  // per-attempt timeout) fires first aborts the attempt, with the same abort-reason
+  // surface as the native path. NOTE an earlier revision returned the caller signal
+  // alone here, silently dropping the per-attempt timeout whenever a caller passed
+  // a signal on Node <20.3.
+  const controller = new AbortController()
+  const onCallerAbort = () => controller.abort(callerSignal.reason)
+  const onTimeoutAbort = () => controller.abort(timeoutSignal.reason)
+  if (callerSignal.aborted) {
+    controller.abort(callerSignal.reason)
+  } else if (timeoutSignal.aborted) {
+    controller.abort(timeoutSignal.reason)
+  } else {
+    callerSignal.addEventListener('abort', onCallerAbort, { once: true })
+    timeoutSignal.addEventListener('abort', onTimeoutAbort, { once: true })
+  }
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      callerSignal.removeEventListener('abort', onCallerAbort)
+      timeoutSignal.removeEventListener('abort', onTimeoutAbort)
+    },
+  }
 }
 
 async function performDingTalkAttempt(
@@ -342,35 +423,40 @@ async function performDingTalkAttempt(
   timeoutMs: number,
   callerSignal: AbortSignal | undefined,
 ): Promise<Record<string, unknown>> {
-  let response: Response
+  const { signal, dispose } = composePerAttemptSignal(callerSignal, timeoutMs)
   try {
-    response = await fetchFn(request.input, {
-      ...request.init,
-      signal: composePerAttemptSignal(callerSignal, timeoutMs),
-    })
-  } catch (error) {
-    if (isAbortError(error)) {
-      logger.warn(`DingTalk request timed out after ${timeoutMs}ms`)
-      throw new DingTalkTimeoutError(timeoutMs)
+    let response: Response
+    try {
+      response = await fetchFn(request.input, {
+        ...request.init,
+        signal,
+      })
+    } catch (error) {
+      if (isAbortError(error)) {
+        logger.warn(`DingTalk request timed out after ${timeoutMs}ms`)
+        throw new DingTalkTimeoutError(timeoutMs)
+      }
+      throw error
     }
-    throw error
-  }
 
-  const payload = await readJson(response)
+    const payload = await readJson(response, timeoutMs)
 
-  if (!response.ok) {
-    const message = normalizeErrorMessage(payload, request.fallbackError)
-    logger.warn(`DingTalk request failed (${response.status}): ${message}`)
-    const requestError = new DingTalkRequestError(message, response.status, payload)
-    const retryAfterMs = parseRetryAfterMs(readResponseHeader(response, 'retry-after'))
-    if (retryAfterMs !== null) retryAfterHints.set(requestError, retryAfterMs)
-    throw requestError
-  }
+    if (!response.ok) {
+      const message = normalizeErrorMessage(payload, request.fallbackError)
+      logger.warn(`DingTalk request failed (${response.status}): ${message}`)
+      const requestError = new DingTalkRequestError(message, response.status, payload)
+      const retryAfterMs = parseRetryAfterMs(readResponseHeader(response, 'retry-after'))
+      if (retryAfterMs !== null) retryAfterHints.set(requestError, retryAfterMs)
+      throw requestError
+    }
 
-  if (request.envelope === 'oapi') {
-    return normalizeDingTalkApiPayload(payload ?? {}, request.fallbackError)
+    if (request.envelope === 'oapi') {
+      return normalizeDingTalkApiPayload(payload ?? {}, request.fallbackError)
+    }
+    return payload ?? {}
+  } finally {
+    dispose()
   }
-  return payload ?? {}
 }
 
 interface DingTalkFailureClassification {

--- a/packages/core-backend/src/integrations/dingtalk/transport.ts
+++ b/packages/core-backend/src/integrations/dingtalk/transport.ts
@@ -23,7 +23,11 @@ const logger = new Logger('DingTalkTransport')
  *    network error). Callers pattern-match on these shapes (routes/auth.ts,
  *    multitable/automation-executor.ts, AttendanceNotificationDeliveryWorker) —
  *    do not wrap or re-type them here. Send-tier uncertain outcomes additionally
- *    carry an {@link isDingTalkOutcomeUnknown} marker for ledger writers.
+ *    carry an {@link isDingTalkOutcomeUnknown} marker for ledger writers;
+ *  - malformed-2xx guard: an HTTP-2xx response with an unusable body never
+ *    normalizes to success — it throws {@link DingTalkMalformedResponseError}
+ *    (a NEW shape; pre-fix such responses silently became `{}`/success, so no
+ *    existing caller pattern-matched a shape for them).
  *
  * Rate-limit handling here (backoff on 429/flow-control) is BEST-EFFORT and
  * in-process only: replicas do not share a quota. Multi-replica shared throttling
@@ -49,6 +53,36 @@ export class DingTalkBusinessError extends Error {
     super(message)
     this.name = 'DingTalkBusinessError'
     this.responseBody = responseBody
+  }
+}
+
+/**
+ * An HTTP-2xx response whose body is UNUSABLE: not JSON (HTML error page, empty
+ * body, truncated stream, bare primitive/array) or — for `envelope: 'oapi'`
+ * endpoints — a JSON object MISSING the `errcode`/`code` discriminator the OAPI
+ * envelope contract guarantees. Such a response must NEVER normalize to success
+ * (the pre-fix behavior turned it into `{}` and reported success for a call whose
+ * outcome is unusable). Classification is per tier: reads may retry it within the
+ * attempt budget (transient proxy/CDN garbage), exchanges never retry, sends never
+ * resend and carry the {@link isDingTalkOutcomeUnknown} marker — the request very
+ * likely DID execute; only the response is unusable.
+ *
+ * `reason` is intentionally coarse ('unparseable_body' | 'missing_errcode') and the
+ * message carries NO body content — a garbled body could contain anything.
+ */
+export class DingTalkMalformedResponseError extends Error {
+  readonly httpStatus: number
+  readonly reason: 'unparseable_body' | 'missing_errcode'
+
+  constructor(reason: 'unparseable_body' | 'missing_errcode', httpStatus: number, fallbackError: string) {
+    super(
+      reason === 'missing_errcode'
+        ? `${fallbackError}: DingTalk returned HTTP ${httpStatus} with a JSON body missing the errcode/code envelope discriminator`
+        : `${fallbackError}: DingTalk returned HTTP ${httpStatus} with an unusable (non-JSON or non-object) body`,
+    )
+    this.name = 'DingTalkMalformedResponseError'
+    this.httpStatus = httpStatus
+    this.reason = reason
   }
 }
 
@@ -323,14 +357,17 @@ function isBodyAbortError(error: unknown): boolean {
  * send tier) — and must never be swallowed into a `null` payload: on the ok-path a
  * swallowed body abort would normalize to `{}` and report SUCCESS for a call whose
  * outcome is unknown; on the non-ok path it would masquerade as a retryable
- * `http_<status>`. Only a genuinely non-JSON body (SyntaxError from JSON.parse)
- * keeps the tolerant `null`; any other mid-body stream failure (connection reset)
- * rethrows raw and classifies as a network error.
+ * `http_<status>`. A genuinely non-JSON/non-object body (SyntaxError from
+ * JSON.parse, bare primitive, top-level array) returns the tolerant `null` — the
+ * OK-PATH then throws {@link DingTalkMalformedResponseError} instead of
+ * normalizing it to `{}`/success, while the non-ok path keeps `responseBody: null`
+ * on the DingTalkRequestError as before. Any other mid-body stream failure
+ * (connection reset) rethrows raw and classifies as a network error.
  */
 async function readJson(response: Response, timeoutMs: number): Promise<Record<string, unknown> | null> {
   try {
     const payload = await response.json()
-    return payload && typeof payload === 'object' ? payload as Record<string, unknown> : null
+    return payload && typeof payload === 'object' && !Array.isArray(payload) ? payload as Record<string, unknown> : null
   } catch (error) {
     if (error instanceof SyntaxError) return null
     if (isBodyAbortError(error)) {
@@ -341,10 +378,31 @@ async function readJson(response: Response, timeoutMs: number): Promise<Record<s
   }
 }
 
-function normalizeDingTalkApiPayload(payload: Record<string, unknown>, fallbackError: string): Record<string, unknown> {
-  const errcode = readNumericField(payload, 'errcode', 'code')
-  if (errcode !== null && errcode !== 0) {
-    throw new DingTalkBusinessError(normalizeErrorMessage(payload, fallbackError), payload)
+/**
+ * OK-path (HTTP 2xx) envelope normalization. A `null` payload (unparseable body) is
+ * a malformed response for EVERY envelope — never `{}`/success. For `'oapi'`
+ * envelopes the errcode/code discriminator is REQUIRED (the OAPI contract always
+ * carries `errcode: 0` on success; a 2xx JSON object without it is not a success
+ * envelope — e.g. a proxy error page in JSON clothing); `'none'` (v1.0
+ * api.dingtalk.com) endpoints have no discriminator, so any JSON object passes.
+ */
+function normalizeDingTalkApiPayload(
+  payload: Record<string, unknown> | null,
+  envelope: 'oapi' | 'none',
+  httpStatus: number,
+  fallbackError: string,
+): Record<string, unknown> {
+  if (payload === null) {
+    throw new DingTalkMalformedResponseError('unparseable_body', httpStatus, fallbackError)
+  }
+  if (envelope === 'oapi') {
+    const errcode = readNumericField(payload, 'errcode', 'code')
+    if (errcode === null) {
+      throw new DingTalkMalformedResponseError('missing_errcode', httpStatus, fallbackError)
+    }
+    if (errcode !== 0) {
+      throw new DingTalkBusinessError(normalizeErrorMessage(payload, fallbackError), payload)
+    }
   }
   return payload
 }
@@ -450,10 +508,7 @@ async function performDingTalkAttempt(
       throw requestError
     }
 
-    if (request.envelope === 'oapi') {
-      return normalizeDingTalkApiPayload(payload ?? {}, request.fallbackError)
-    }
-    return payload ?? {}
+    return normalizeDingTalkApiPayload(payload, request.envelope, response.status, request.fallbackError)
   } finally {
     dispose()
   }
@@ -509,6 +564,15 @@ function classifyDingTalkFailure(error: unknown, kind: DingTalkCallKind): DingTa
       return { error, reason: `flow_control_errcode_${errcode}`, retryable: isRead, retryAfterMs: null, outcomeUnknown: false }
     }
     return { error, reason: 'business_error', retryable: false, retryAfterMs: null, outcomeUnknown: false }
+  }
+  if (error instanceof DingTalkMalformedResponseError) {
+    // HTTP-2xx with an unusable body (or a 2xx oapi envelope missing its errcode
+    // discriminator): the server very likely EXECUTED the request — only the
+    // response is unusable. Per tier (owner-ratified, kept separate): reads may
+    // retry within the existing attempt budget (transient proxy/CDN garbage, same
+    // class as a 5xx-on-read); exchanges never retry (the single-use code may
+    // already be redeemed); sends never resend and record outcome_unknown.
+    return { error, reason: `malformed_response_${error.reason}`, retryable: isRead, retryAfterMs: null, outcomeUnknown: unknownIfSend }
   }
   // fetch rejected without producing a response (DNS/conn-refused/reset). Reads may
   // retry; exchanges never (single-use code may have been redeemed server-side);

--- a/packages/core-backend/src/integrations/dingtalk/transport.ts
+++ b/packages/core-backend/src/integrations/dingtalk/transport.ts
@@ -11,7 +11,8 @@ const logger = new Logger('DingTalkTransport')
  *    (each retry attempt gets its own fresh `AbortSignal.timeout`; a caller-supplied
  *    overall signal aborts the in-flight attempt AND any backoff wait immediately);
  *  - bounded retry with exponential backoff + full jitter, honoring `Retry-After`;
- *  - explicit idempotency-safety classification (see {@link DingTalkCallSafety});
+ *  - explicit BUSINESS-SEMANTICS classification per call site (see
+ *    {@link DingTalkCallKind}) — never inferred from the HTTP verb;
  *  - DingTalk flow-control recognition: HTTP 429 as well as HTTP-200 envelopes
  *    carrying flow-control errcodes (see {@link isDingTalkFlowControlErrcode});
  *  - error-shape preservation: when retries are exhausted or a failure is
@@ -19,7 +20,12 @@ const logger = new Logger('DingTalkTransport')
  *    (DingTalkRequestError / DingTalkBusinessError / DingTalkTimeoutError / the raw
  *    network error). Callers pattern-match on these shapes (routes/auth.ts,
  *    multitable/automation-executor.ts, AttendanceNotificationDeliveryWorker) —
- *    do not wrap or re-type them here.
+ *    do not wrap or re-type them here. Send-tier uncertain outcomes additionally
+ *    carry an {@link isDingTalkOutcomeUnknown} marker for ledger writers.
+ *
+ * Rate-limit handling here (backoff on 429/flow-control) is BEST-EFFORT and
+ * in-process only: replicas do not share a quota. Multi-replica shared throttling
+ * (per app/corp, Redis or equivalent) is explicitly out of scope — follow-up work.
  */
 
 export class DingTalkRequestError extends Error {
@@ -68,27 +74,42 @@ export class DingTalkTimeoutError extends Error {
 }
 
 /**
- * Idempotency-safety classification — REQUIRED at every call site so review can see
- * the retry class of every outbound call (roadmap §7.2: "Retry only safe/idempotent
- * API classes", "Keep work-notification sends bounded and classified"):
+ * Business-semantics classification — chosen EXPLICITLY at every call site, never
+ * inferred from the HTTP verb (roadmap §7.2: "Retry only safe/idempotent API
+ * classes", "Keep work-notification sends bounded and classified"):
  *
- *  - `'idempotent-read'`: GET-shaped reads. DingTalk's legacy topapi reads are
- *    POST-verb but semantically idempotent list/get calls (listsub, user/list,
- *    user/get, department/get) — repeating them cannot double-apply anything.
- *    Retried on: network error, HTTP 429, HTTP 5xx, and flow-control errcodes
- *    inside HTTP-200 envelopes.
+ *  - `'read'` — SAFE READS: token GET, user/department gets, and directory
+ *    query-shaped POSTs that only read (listsub, user/list, user/get,
+ *    department/get). Repeating them cannot double-apply anything. Retried on:
+ *    network error, HTTP 429, selected transient 5xx (500/502/503/504), and
+ *    flow-control errcodes inside HTTP-200 envelopes.
  *
- *  - `'non-idempotent-write'`: sends/notifications and one-shot code exchanges.
- *    Retried ONLY on network-error-before-response and HTTP 429 (both mean the
- *    request was rejected/never answered before processing). NEVER retried on an
- *    ambiguous 5xx or flow-control errcode observed AFTER DingTalk may have started
- *    processing — a duplicate work notification is worse than a missed retry.
+ *  - `'exchange'` — ONE-SHOT EXCHANGES: OAuth authorization-code exchange, E1
+ *    container-login authCode. The code is single-use; a retry after an ambiguous
+ *    failure burns it or double-redeems. NO retry on ANY failure — a fetch
+ *    timeout/disconnect only proves the CLIENT saw no response, not that DingTalk
+ *    didn't receive and execute the request.
  *
- * Per-attempt timeouts (DingTalkTimeoutError) are NOT retried for either class: an
+ *  - `'send'` — SIDE-EFFECT SENDS: asyncsend_v2 work notifications / action cards.
+ *    On network error, timeout, or 5xx the outcome is UNKNOWN — DingTalk may have
+ *    delivered the message even though we saw no response — so the transport does
+ *    NOT resend; it rethrows the original error marked via
+ *    {@link isDingTalkOutcomeUnknown} (and `outcomeUnknown: true` on the error)
+ *    so ledger writers can record `outcome_unknown` instead of a plain failure.
+ *    Note DingTalk's async-send result query (by task_id) can reconcile a KNOWN
+ *    send, but when the response was lost there IS no task_id — it cannot serve
+ *    as an idempotency key for auto-retry. HTTP 429 on sends is a definite
+ *    pre-processing rejection, but auto-retry is deliberately NOT enabled in this
+ *    slice pending endpoint-contract confirmation; it fails through unchanged.
+ *
+ * Unclassified call sites default to `'exchange'` — the most conservative tier
+ * (no retry at all).
+ *
+ * Per-attempt timeouts (DingTalkTimeoutError) are NOT retried for any tier: an
  * abort cannot distinguish "server still processing" from "request never arrived",
  * and retrying would multiply DT-HARDEN-06's bounded wall-time by the attempt count.
  */
-export type DingTalkCallSafety = 'idempotent-read' | 'non-idempotent-write'
+export type DingTalkCallKind = 'read' | 'exchange' | 'send'
 
 export interface DingTalkTransportConfig {
   /** Total attempts including the first one (1 = no retries). */
@@ -136,7 +157,7 @@ export function resolveDingTalkTransportConfig(): DingTalkTransportConfig {
  *    envelope `code` field), so the transport never retries a class the delivery
  *    layer considers permanent, and vice versa.
  *
- * Only consulted for `'idempotent-read'` calls — see {@link DingTalkCallSafety}.
+ * Only consulted for `'read'` calls — see {@link DingTalkCallKind}.
  */
 export function isDingTalkFlowControlErrcode(code: number): boolean {
   return code === 90018
@@ -145,6 +166,38 @@ export function isDingTalkFlowControlErrcode(code: number): boolean {
     || code === 429
     || (code >= 500 && code < 600)
     || code === 50001
+}
+
+/**
+ * Selected transient 5xx statuses retried for `'read'` calls. 501/505/… are
+ * permanent contract errors, not blips — retrying them only burns quota.
+ */
+const RETRYABLE_READ_5XX: ReadonlySet<number> = new Set([500, 502, 503, 504])
+
+/**
+ * Send-tier uncertain-outcome marker: the request MAY have been executed by
+ * DingTalk although the client saw no (usable) response. Ledger writers should
+ * record such failures as `outcome_unknown` rather than a plain failure. The
+ * original error object is thrown UNCHANGED apart from an added
+ * `outcomeUnknown: true` property; this guard also works for frozen/exotic
+ * errors via a WeakSet.
+ */
+const outcomeUnknownErrors = new WeakSet<object>()
+
+export function isDingTalkOutcomeUnknown(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  if (outcomeUnknownErrors.has(error)) return true
+  return (error as { outcomeUnknown?: unknown }).outcomeUnknown === true
+}
+
+function markOutcomeUnknown(error: unknown): void {
+  if (typeof error !== 'object' || error === null) return
+  outcomeUnknownErrors.add(error)
+  try {
+    Object.defineProperty(error, 'outcomeUnknown', { value: true, enumerable: true, configurable: true })
+  } catch {
+    // frozen error object — the WeakSet still answers isDingTalkOutcomeUnknown
+  }
 }
 
 /**
@@ -185,7 +238,11 @@ export interface DingTalkTransportRequest {
   input: string
   init: RequestInit
   fallbackError: string
-  safety: DingTalkCallSafety
+  /**
+   * Business-semantics tier chosen at the call site (see {@link DingTalkCallKind}).
+   * Omitted/unknown defaults to `'exchange'` — the most conservative tier (no retry).
+   */
+  kind?: DingTalkCallKind
   /**
    * `'oapi'`: legacy oapi.dingtalk.com envelope endpoints — an `errcode !== 0` in an
    * HTTP-200 body throws DingTalkBusinessError INSIDE the retry loop, so flow-control
@@ -321,41 +378,56 @@ interface DingTalkFailureClassification {
   reason: string
   retryable: boolean
   retryAfterMs: number | null
+  /** Send-tier only: the request may have been executed although we saw no response. */
+  outcomeUnknown: boolean
 }
 
-/** The explicit retry-safety matrix — see {@link DingTalkCallSafety} for the rationale. */
-function classifyDingTalkFailure(error: unknown, safety: DingTalkCallSafety): DingTalkFailureClassification {
-  const readsOnly = safety === 'idempotent-read'
+/** The explicit retry matrix — see {@link DingTalkCallKind} for the tier rationale. */
+function classifyDingTalkFailure(error: unknown, kind: DingTalkCallKind): DingTalkFailureClassification {
+  const isRead = kind === 'read'
+  // Uncertain outcomes (no usable response: timeout / network error / 5xx) get the
+  // outcome-unknown marker on the send tier so ledger writers can distinguish
+  // "maybe delivered" from "definitely rejected".
+  const unknownIfSend = kind === 'send'
 
   if (error instanceof DingTalkTimeoutError) {
-    // Timeout/abort: the request MAY be processing server-side. Not retried for
-    // either class — see DingTalkCallSafety.
-    return { error, reason: 'timeout', retryable: false, retryAfterMs: null }
+    // Timeout/abort: the request MAY be processing server-side. Never retried.
+    return { error, reason: 'timeout', retryable: false, retryAfterMs: null, outcomeUnknown: unknownIfSend }
   }
   if (error instanceof DingTalkRequestError) {
     const retryAfterMs = retryAfterHints.get(error) ?? null
     if (error.statusCode === 429) {
-      // Rejected by rate limiting before processing — safe for reads AND writes.
-      return { error, reason: 'http_429', retryable: true, retryAfterMs }
+      // Definite pre-processing rejection. Retried on reads only: send-tier 429
+      // auto-retry is deliberately NOT enabled in this slice (endpoint-contract
+      // confirmation pending); exchanges never retry.
+      return { error, reason: 'http_429', retryable: isRead, retryAfterMs, outcomeUnknown: false }
     }
     if (error.statusCode >= 500 && error.statusCode < 600) {
-      // Ambiguous server failure — a write may already have been applied; reads only.
-      return { error, reason: `http_${error.statusCode}`, retryable: readsOnly, retryAfterMs }
+      // Server-side failure AFTER the request arrived — a send may already have
+      // been executed. Only selected transient 5xx are retried, reads only.
+      return {
+        error,
+        reason: `http_${error.statusCode}`,
+        retryable: isRead && RETRYABLE_READ_5XX.has(error.statusCode),
+        retryAfterMs,
+        outcomeUnknown: unknownIfSend,
+      }
     }
-    return { error, reason: `http_${error.statusCode}`, retryable: false, retryAfterMs: null }
+    return { error, reason: `http_${error.statusCode}`, retryable: false, retryAfterMs: null, outcomeUnknown: false }
   }
   if (error instanceof DingTalkBusinessError) {
     const errcode = readNumericField(error.responseBody ?? {}, 'errcode', 'code')
     if (errcode !== null && isDingTalkFlowControlErrcode(errcode)) {
-      // HTTP-200 flow-control envelope. Reads only: unlike a transport-level 429 we
-      // cannot be certain the app layer did no work before answering.
-      return { error, reason: `flow_control_errcode_${errcode}`, retryable: readsOnly, retryAfterMs: null }
+      // HTTP-200 flow-control envelope: a definite app-layer rejection (we DID get
+      // a response), so it is not outcome-unknown — but only reads retry it.
+      return { error, reason: `flow_control_errcode_${errcode}`, retryable: isRead, retryAfterMs: null, outcomeUnknown: false }
     }
-    return { error, reason: 'business_error', retryable: false, retryAfterMs: null }
+    return { error, reason: 'business_error', retryable: false, retryAfterMs: null, outcomeUnknown: false }
   }
-  // fetch rejected without producing a response (DNS/conn-refused/reset): the one
-  // non-429 class the §7.2 design allows writes to retry (network-error-before-response).
-  return { error, reason: 'network_error', retryable: true, retryAfterMs: null }
+  // fetch rejected without producing a response (DNS/conn-refused/reset). Reads may
+  // retry; exchanges never (single-use code may have been redeemed server-side);
+  // sends never (the notification may have gone out) — outcome unknown.
+  return { error, reason: 'network_error', retryable: isRead, retryAfterMs: null, outcomeUnknown: unknownIfSend }
 }
 
 /** Resolves `true` when the signal aborted before the delay elapsed. */
@@ -384,6 +456,8 @@ export async function requestDingTalkTransportJson(request: DingTalkTransportReq
   const timeoutMs = request.timeoutMs ?? DINGTALK_REQUEST_TIMEOUT_MS
   const callerSignal = request.signal ?? request.init.signal ?? undefined
   const fetchFn = request.fetchFn ?? fetch
+  // Unclassified defaults to the most conservative tier: no retry at all.
+  const kind: DingTalkCallKind = request.kind ?? 'exchange'
 
   for (let attempt = 1; ; attempt++) {
     if (callerSignal?.aborted) {
@@ -395,18 +469,20 @@ export async function requestDingTalkTransportJson(request: DingTalkTransportReq
     try {
       return await performDingTalkAttempt(request, fetchFn, timeoutMs, callerSignal)
     } catch (error) {
-      failure = classifyDingTalkFailure(error, request.safety)
+      failure = classifyDingTalkFailure(error, kind)
     }
 
     if (!failure.retryable || attempt >= config.maxAttempts || callerSignal?.aborted) {
       // Exhausted or non-retryable: rethrow the ORIGINAL error unchanged — callers
-      // pattern-match on the pre-retry shapes.
+      // pattern-match on the pre-retry shapes. Send-tier uncertain outcomes get the
+      // outcome-unknown marker (additive property; shape otherwise identical).
+      if (failure.outcomeUnknown) markOutcomeUnknown(failure.error)
       throw failure.error
     }
 
     const delayMs = computeDingTalkRetryDelayMs(attempt, config, failure.retryAfterMs)
     logger.warn(
-      `DingTalk transport retry ${attempt + 1}/${config.maxAttempts} after ${failure.reason} (${request.safety}): backing off ${delayMs}ms`,
+      `DingTalk transport retry ${attempt + 1}/${config.maxAttempts} after ${failure.reason} (${kind}): backing off ${delayMs}ms`,
     )
     const aborted = await sleepUnlessAborted(delayMs, callerSignal)
     if (aborted) {

--- a/packages/core-backend/src/integrations/dingtalk/transport.ts
+++ b/packages/core-backend/src/integrations/dingtalk/transport.ts
@@ -1,0 +1,416 @@
+import { Logger } from '../../core/logger'
+
+const logger = new Logger('DingTalkTransport')
+
+/**
+ * Unified DingTalk transport (roadmap §7.2, docs/development/dingtalk-sync-integrated-roadmap-20260708.md).
+ *
+ * ONE seam that every DingTalk HTTP call in `client.ts` goes through. It centralizes:
+ *
+ *  - the DT-HARDEN-06 per-request timeout — preserved, now composed PER ATTEMPT
+ *    (each retry attempt gets its own fresh `AbortSignal.timeout`; a caller-supplied
+ *    overall signal aborts the in-flight attempt AND any backoff wait immediately);
+ *  - bounded retry with exponential backoff + full jitter, honoring `Retry-After`;
+ *  - explicit idempotency-safety classification (see {@link DingTalkCallSafety});
+ *  - DingTalk flow-control recognition: HTTP 429 as well as HTTP-200 envelopes
+ *    carrying flow-control errcodes (see {@link isDingTalkFlowControlErrcode});
+ *  - error-shape preservation: when retries are exhausted or a failure is
+ *    non-retryable, the SAME error is thrown that the pre-retry client threw
+ *    (DingTalkRequestError / DingTalkBusinessError / DingTalkTimeoutError / the raw
+ *    network error). Callers pattern-match on these shapes (routes/auth.ts,
+ *    multitable/automation-executor.ts, AttendanceNotificationDeliveryWorker) —
+ *    do not wrap or re-type them here.
+ */
+
+export class DingTalkRequestError extends Error {
+  statusCode: number
+  responseBody: Record<string, unknown> | null
+
+  constructor(message: string, statusCode: number, responseBody: Record<string, unknown> | null) {
+    super(message)
+    this.name = 'DingTalkRequestError'
+    this.statusCode = statusCode
+    this.responseBody = responseBody
+  }
+}
+
+export class DingTalkBusinessError extends Error {
+  responseBody: Record<string, unknown> | null
+
+  constructor(message: string, responseBody: Record<string, unknown> | null) {
+    super(message)
+    this.name = 'DingTalkBusinessError'
+    this.responseBody = responseBody
+  }
+}
+
+/**
+ * DT-HARDEN-06: every DingTalk call that is not the group-robot webhook goes through
+ * here — gettoken, directory sync, work notifications, approval cards, container
+ * login. They used a naked `fetch` with no timeout, so a hung connection blocked an
+ * inline automation execution or a whole directory sync for as long as undici's
+ * default (~300s). Bound them, and surface the timeout as a typed operational error
+ * so callers record a failed run/delivery instead of hanging.
+ */
+export const DINGTALK_REQUEST_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.DINGTALK_REQUEST_TIMEOUT_MS)
+  return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 10_000
+})()
+
+export class DingTalkTimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super(`DingTalk request timed out after ${timeoutMs}ms`)
+    this.name = 'DingTalkTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}
+
+/**
+ * Idempotency-safety classification — REQUIRED at every call site so review can see
+ * the retry class of every outbound call (roadmap §7.2: "Retry only safe/idempotent
+ * API classes", "Keep work-notification sends bounded and classified"):
+ *
+ *  - `'idempotent-read'`: GET-shaped reads. DingTalk's legacy topapi reads are
+ *    POST-verb but semantically idempotent list/get calls (listsub, user/list,
+ *    user/get, department/get) — repeating them cannot double-apply anything.
+ *    Retried on: network error, HTTP 429, HTTP 5xx, and flow-control errcodes
+ *    inside HTTP-200 envelopes.
+ *
+ *  - `'non-idempotent-write'`: sends/notifications and one-shot code exchanges.
+ *    Retried ONLY on network-error-before-response and HTTP 429 (both mean the
+ *    request was rejected/never answered before processing). NEVER retried on an
+ *    ambiguous 5xx or flow-control errcode observed AFTER DingTalk may have started
+ *    processing — a duplicate work notification is worse than a missed retry.
+ *
+ * Per-attempt timeouts (DingTalkTimeoutError) are NOT retried for either class: an
+ * abort cannot distinguish "server still processing" from "request never arrived",
+ * and retrying would multiply DT-HARDEN-06's bounded wall-time by the attempt count.
+ */
+export type DingTalkCallSafety = 'idempotent-read' | 'non-idempotent-write'
+
+export interface DingTalkTransportConfig {
+  /** Total attempts including the first one (1 = no retries). */
+  maxAttempts: number
+  backoffBaseMs: number
+  backoffCapMs: number
+}
+
+export const DINGTALK_TRANSPORT_DEFAULTS: Readonly<DingTalkTransportConfig> = Object.freeze({
+  maxAttempts: 3,
+  backoffBaseMs: 300,
+  backoffCapMs: 5_000,
+})
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (typeof raw !== 'string' || raw.trim().length === 0) return fallback
+  const value = Number(raw)
+  if (!Number.isFinite(value) || value < 1) return fallback
+  return Math.trunc(value)
+}
+
+/**
+ * Env-tunable retry knobs. Read at call time (not module load) so tests and ops
+ * overrides apply without a module reload; invalid or absent values fall back to
+ * {@link DINGTALK_TRANSPORT_DEFAULTS}.
+ */
+export function resolveDingTalkTransportConfig(): DingTalkTransportConfig {
+  return {
+    maxAttempts: readPositiveIntEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', DINGTALK_TRANSPORT_DEFAULTS.maxAttempts),
+    backoffBaseMs: readPositiveIntEnv('DINGTALK_TRANSPORT_BACKOFF_BASE_MS', DINGTALK_TRANSPORT_DEFAULTS.backoffBaseMs),
+    backoffCapMs: readPositiveIntEnv('DINGTALK_TRANSPORT_BACKOFF_CAP_MS', DINGTALK_TRANSPORT_DEFAULTS.backoffCapMs),
+  }
+}
+
+/**
+ * Flow-control / transient errcodes DingTalk returns inside HTTP-200 envelopes
+ * ("the call was rejected for quota/availability, back off and retry"):
+ *
+ *  - `90018` — DingTalk's documented flow-control (频率超限) errcode family;
+ *  - `-1`    — DingTalk "system busy" (系统繁忙, 稍后重试);
+ *  - `408 / 429 / 5xx / 50001` — kept in parity with what the repo's delivery layer
+ *    already treats as retryable (`AttendanceNotificationDeliveryWorker`'s
+ *    `isRetryableDingTalkErrorCode`: HTTP-ish echoes some endpoints place in the
+ *    envelope `code` field), so the transport never retries a class the delivery
+ *    layer considers permanent, and vice versa.
+ *
+ * Only consulted for `'idempotent-read'` calls — see {@link DingTalkCallSafety}.
+ */
+export function isDingTalkFlowControlErrcode(code: number): boolean {
+  return code === 90018
+    || code === -1
+    || code === 408
+    || code === 429
+    || (code >= 500 && code < 600)
+    || code === 50001
+}
+
+/**
+ * Parse a `Retry-After` header value: delay-seconds (RFC 9110 §10.2.3) or an
+ * HTTP-date. Returns milliseconds, or null when absent/unparseable.
+ */
+export function parseRetryAfterMs(raw: string | null | undefined): number | null {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return null
+  const seconds = Number(raw)
+  if (Number.isFinite(seconds)) {
+    return seconds >= 0 ? Math.trunc(seconds * 1000) : null
+  }
+  const dateMs = Date.parse(raw)
+  if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now())
+  return null
+}
+
+/**
+ * Exponential backoff with FULL jitter: `random() * min(cap, base * 2^(attempt-1))`.
+ * A server-provided `Retry-After` overrides the jittered delay (it is the server's
+ * explicit floor), clamped to the cap so a huge/hostile header cannot stall a sync
+ * worker beyond the configured bound.
+ *
+ * @param attempt 1-based index of the attempt that just FAILED.
+ */
+export function computeDingTalkRetryDelayMs(
+  attempt: number,
+  config: DingTalkTransportConfig,
+  retryAfterMs: number | null,
+  randomFn: () => number = Math.random,
+): number {
+  if (retryAfterMs !== null) return Math.min(config.backoffCapMs, retryAfterMs)
+  const ceiling = Math.min(config.backoffCapMs, config.backoffBaseMs * 2 ** (attempt - 1))
+  return Math.trunc(randomFn() * ceiling)
+}
+
+export interface DingTalkTransportRequest {
+  input: string
+  init: RequestInit
+  fallbackError: string
+  safety: DingTalkCallSafety
+  /**
+   * `'oapi'`: legacy oapi.dingtalk.com envelope endpoints — an `errcode !== 0` in an
+   * HTTP-200 body throws DingTalkBusinessError INSIDE the retry loop, so flow-control
+   * errcodes can back off on reads. `'none'`: v1.0 api.dingtalk.com endpoints
+   * (HTTP-status based, no envelope).
+   */
+  envelope: 'oapi' | 'none'
+  fetchFn?: typeof fetch
+  /** Override the default per-attempt timeout (DT-HARDEN-06). */
+  timeoutMs?: number
+  /** Caller's OVERALL signal: aborts the whole retry loop (incl. mid-backoff) immediately. */
+  signal?: AbortSignal
+}
+
+export function normalizeErrorMessage(payload: Record<string, unknown> | null, fallback: string): string {
+  if (!payload) return fallback
+  const candidates = [
+    payload.message,
+    payload.msg,
+    payload.error_description,
+    payload.errorDescription,
+    payload.error,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+  }
+  return fallback
+}
+
+export function readNumericField(payload: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = payload[key]
+    if (typeof value === 'number') return value
+    if (typeof value === 'string' && value.trim().length > 0 && !Number.isNaN(Number(value))) {
+      return Number(value)
+    }
+  }
+  return null
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    const payload = await response.json()
+    return payload && typeof payload === 'object' ? payload as Record<string, unknown> : null
+  } catch {
+    return null
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')
+}
+
+function normalizeDingTalkApiPayload(payload: Record<string, unknown>, fallbackError: string): Record<string, unknown> {
+  const errcode = readNumericField(payload, 'errcode', 'code')
+  if (errcode !== null && errcode !== 0) {
+    throw new DingTalkBusinessError(normalizeErrorMessage(payload, fallbackError), payload)
+  }
+  return payload
+}
+
+/** Unit-test fakes may hand us a headerless `Response`-shaped object — stay defensive. */
+function readResponseHeader(response: Response, name: string): string | null {
+  const headers = (response as Partial<Response>).headers
+  if (!headers || typeof headers.get !== 'function') return null
+  try {
+    return headers.get(name)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * `Retry-After` hints ride next to the thrown DingTalkRequestError without changing
+ * its shape (callers pattern-match on `statusCode`/`responseBody`).
+ */
+const retryAfterHints = new WeakMap<object, number>()
+
+/**
+ * DT-HARDEN-06 composed per attempt: each attempt gets its OWN fresh timeout signal
+ * (a retry must not start with an already-spent timeout budget); the caller's
+ * overall signal aborts every attempt as well as the backoff sleeps.
+ */
+function composePerAttemptSignal(callerSignal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs)
+  if (!callerSignal) return timeoutSignal
+  if (typeof AbortSignal.any === 'function') return AbortSignal.any([callerSignal, timeoutSignal])
+  // Pre-Node-20.3 fallback: preserve the pre-retry precedence (caller signal wins).
+  return callerSignal
+}
+
+async function performDingTalkAttempt(
+  request: DingTalkTransportRequest,
+  fetchFn: typeof fetch,
+  timeoutMs: number,
+  callerSignal: AbortSignal | undefined,
+): Promise<Record<string, unknown>> {
+  let response: Response
+  try {
+    response = await fetchFn(request.input, {
+      ...request.init,
+      signal: composePerAttemptSignal(callerSignal, timeoutMs),
+    })
+  } catch (error) {
+    if (isAbortError(error)) {
+      logger.warn(`DingTalk request timed out after ${timeoutMs}ms`)
+      throw new DingTalkTimeoutError(timeoutMs)
+    }
+    throw error
+  }
+
+  const payload = await readJson(response)
+
+  if (!response.ok) {
+    const message = normalizeErrorMessage(payload, request.fallbackError)
+    logger.warn(`DingTalk request failed (${response.status}): ${message}`)
+    const requestError = new DingTalkRequestError(message, response.status, payload)
+    const retryAfterMs = parseRetryAfterMs(readResponseHeader(response, 'retry-after'))
+    if (retryAfterMs !== null) retryAfterHints.set(requestError, retryAfterMs)
+    throw requestError
+  }
+
+  if (request.envelope === 'oapi') {
+    return normalizeDingTalkApiPayload(payload ?? {}, request.fallbackError)
+  }
+  return payload ?? {}
+}
+
+interface DingTalkFailureClassification {
+  error: unknown
+  reason: string
+  retryable: boolean
+  retryAfterMs: number | null
+}
+
+/** The explicit retry-safety matrix — see {@link DingTalkCallSafety} for the rationale. */
+function classifyDingTalkFailure(error: unknown, safety: DingTalkCallSafety): DingTalkFailureClassification {
+  const readsOnly = safety === 'idempotent-read'
+
+  if (error instanceof DingTalkTimeoutError) {
+    // Timeout/abort: the request MAY be processing server-side. Not retried for
+    // either class — see DingTalkCallSafety.
+    return { error, reason: 'timeout', retryable: false, retryAfterMs: null }
+  }
+  if (error instanceof DingTalkRequestError) {
+    const retryAfterMs = retryAfterHints.get(error) ?? null
+    if (error.statusCode === 429) {
+      // Rejected by rate limiting before processing — safe for reads AND writes.
+      return { error, reason: 'http_429', retryable: true, retryAfterMs }
+    }
+    if (error.statusCode >= 500 && error.statusCode < 600) {
+      // Ambiguous server failure — a write may already have been applied; reads only.
+      return { error, reason: `http_${error.statusCode}`, retryable: readsOnly, retryAfterMs }
+    }
+    return { error, reason: `http_${error.statusCode}`, retryable: false, retryAfterMs: null }
+  }
+  if (error instanceof DingTalkBusinessError) {
+    const errcode = readNumericField(error.responseBody ?? {}, 'errcode', 'code')
+    if (errcode !== null && isDingTalkFlowControlErrcode(errcode)) {
+      // HTTP-200 flow-control envelope. Reads only: unlike a transport-level 429 we
+      // cannot be certain the app layer did no work before answering.
+      return { error, reason: `flow_control_errcode_${errcode}`, retryable: readsOnly, retryAfterMs: null }
+    }
+    return { error, reason: 'business_error', retryable: false, retryAfterMs: null }
+  }
+  // fetch rejected without producing a response (DNS/conn-refused/reset): the one
+  // non-429 class the §7.2 design allows writes to retry (network-error-before-response).
+  return { error, reason: 'network_error', retryable: true, retryAfterMs: null }
+}
+
+/** Resolves `true` when the signal aborted before the delay elapsed. */
+function sleepUnlessAborted(delayMs: number, signal: AbortSignal | undefined): Promise<boolean> {
+  if (signal?.aborted) return Promise.resolve(true)
+  if (delayMs <= 0) return Promise.resolve(false)
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve(true)
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve(false)
+    }, delayMs)
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * The transport seam. Every DingTalk outbound call in `client.ts` funnels through
+ * this function — do NOT add per-call-site retry loops on top of it.
+ */
+export async function requestDingTalkTransportJson(request: DingTalkTransportRequest): Promise<Record<string, unknown>> {
+  const config = resolveDingTalkTransportConfig()
+  const timeoutMs = request.timeoutMs ?? DINGTALK_REQUEST_TIMEOUT_MS
+  const callerSignal = request.signal ?? request.init.signal ?? undefined
+  const fetchFn = request.fetchFn ?? fetch
+
+  for (let attempt = 1; ; attempt++) {
+    if (callerSignal?.aborted) {
+      // Preserve the pre-retry abort surface: aborts appear as DingTalkTimeoutError.
+      throw new DingTalkTimeoutError(timeoutMs)
+    }
+
+    let failure: DingTalkFailureClassification
+    try {
+      return await performDingTalkAttempt(request, fetchFn, timeoutMs, callerSignal)
+    } catch (error) {
+      failure = classifyDingTalkFailure(error, request.safety)
+    }
+
+    if (!failure.retryable || attempt >= config.maxAttempts || callerSignal?.aborted) {
+      // Exhausted or non-retryable: rethrow the ORIGINAL error unchanged — callers
+      // pattern-match on the pre-retry shapes.
+      throw failure.error
+    }
+
+    const delayMs = computeDingTalkRetryDelayMs(attempt, config, failure.retryAfterMs)
+    logger.warn(
+      `DingTalk transport retry ${attempt + 1}/${config.maxAttempts} after ${failure.reason} (${request.safety}): backing off ${delayMs}ms`,
+    )
+    const aborted = await sleepUnlessAborted(delayMs, callerSignal)
+    if (aborted) {
+      throw new DingTalkTimeoutError(timeoutMs)
+    }
+  }
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -20,6 +20,7 @@ import {
   DingTalkRequestError,
   fetchDingTalkAppAccessToken,
   sendDingTalkInteractiveApprovalCard,
+  isDingTalkOutcomeUnknown,
   sendDingTalkWorkNotification,
   sendDingTalkWorkNotificationActionCard,
 } from '../integrations/dingtalk/client'
@@ -33,6 +34,7 @@ import {
 import {
   insertDingTalkApprovalCardDelivery,
   markDingTalkApprovalCardDeliverySendFailed,
+  markDingTalkApprovalCardDeliverySendOutcomeUnknown,
   markDingTalkApprovalCardDeliverySent,
 } from '../integrations/dingtalk/approval-card-deliveries'
 import { createHmac } from 'crypto'
@@ -559,7 +561,8 @@ async function recordDingTalkPersonDelivery(
     subject: string
     content: string
     success: boolean
-    status?: 'success' | 'failed' | 'skipped'
+    /** `outcome_unknown` (PR #4046 Phase B): send threw with the transport's outcome-unknown marker — maybe delivered, never auto-resent. */
+    status?: 'success' | 'failed' | 'skipped' | 'outcome_unknown'
     httpStatus?: number | null
     responseBody?: string | null
     errorMessage?: string | null
@@ -1861,6 +1864,9 @@ export class AutomationExecutor {
           ? stringifyResponseBody(error.responseBody)
           : null
       const errorMessage = redactDingTalkFailureAlertText(error instanceof Error ? error.message : String(error))
+      // PR #4046 Phase B: an outcome-unknown send (transport marker) is recorded as the DISTINCT
+      // `outcome_unknown` telemetry state — the alert may well have reached the rule creator; it
+      // is never auto-resent and must not read as a definite failure.
       await recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
         localUserId: ruleCreatorId,
         dingtalkUserId,
@@ -1868,7 +1874,7 @@ export class AutomationExecutor {
         subject,
         content,
         success: false,
-        status: 'failed',
+        status: isDingTalkOutcomeUnknown(error) ? 'outcome_unknown' : 'failed',
         httpStatus,
         responseBody,
         errorMessage,
@@ -2802,17 +2808,27 @@ export class AutomationExecutor {
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
+      // PR #4046 Phase B (owner doctrine): a send whose outcome is unknowable (transport marker —
+      // network error/timeout/5xx/malformed 2xx) records the DISTINCT `outcome_unknown` ledger
+      // state, never plain `failed`, and is NEVER auto-resent — the card may well have reached
+      // the recipient. There is no task_id for a lost response, so DingTalk's async-send result
+      // query cannot reconcile it automatically; reconciliation is manual/ops via this state.
+      const outcomeUnknown = isDingTalkOutcomeUnknown(error)
       // DT-HARDEN-06: if the ledger row cannot be flipped out of `pending`, the card is
       // fail-closed but invisible — no sweeper, no admin listing. Swallowing that
       // silently (`.catch(() => null)`) hid the only signal an operator would ever get.
       // The send failure is still what we report; the bookkeeping failure is surfaced.
       let ledgerError: string | null = null
       try {
-        await markDingTalkApprovalCardDeliverySendFailed(this.deps.queryFn, delivery.id, errorMessage)
+        if (outcomeUnknown) {
+          await markDingTalkApprovalCardDeliverySendOutcomeUnknown(this.deps.queryFn, delivery.id, errorMessage)
+        } else {
+          await markDingTalkApprovalCardDeliverySendFailed(this.deps.queryFn, delivery.id, errorMessage)
+        }
       } catch (markError) {
         ledgerError = markError instanceof Error ? markError.message : String(markError)
         logger.error(
-          `DingTalk approval-card delivery ${delivery.id} is stuck pending: failed to record the send failure`,
+          `DingTalk approval-card delivery ${delivery.id} is stuck pending: failed to record the send ${outcomeUnknown ? 'outcome-unknown state' : 'failure'}`,
           markError instanceof Error ? markError : new Error(ledgerError),
         )
       }
@@ -2822,6 +2838,7 @@ export class AutomationExecutor {
         error: errorMessage,
         output: {
           deliveryId: delivery.id,
+          ...(outcomeUnknown ? { deliveryOutcomeUnknown: true } : {}),
           ...(ledgerError ? { deliveryLedgerError: ledgerError, deliveryStuckPending: true } : {}),
         },
       }
@@ -3103,6 +3120,12 @@ export class AutomationExecutor {
     // throwing must not re-mark them failed — that used to write BOTH a success and a
     // failed delivery row for the same recipient in the same send attempt.
     const sentRecipients = new Set<(typeof resolvedRecipients)[number]>()
+    // PR #4046 Phase B: the batch whose send call is IN FLIGHT when an error is thrown. Only
+    // these recipients can have an UNKNOWN outcome (the send was attempted and the response was
+    // lost); recipients of batches never reached have a KNOWN outcome (not sent) and stay
+    // `failed`. Cleared after each successful batch; null while no send is in flight (so a
+    // token-fetch/config failure — no send attempted — marks nobody outcome_unknown).
+    let inFlightSendBatch: (typeof resolvedRecipients) | null = null
 
     try {
       let responseCount = 0
@@ -3122,6 +3145,7 @@ export class AutomationExecutor {
           configCache.set(integrationId, credentials)
         }
 
+        inFlightSendBatch = batch
         const result = await sendDingTalkWorkNotification(
           credentials.accessToken,
           {
@@ -3132,6 +3156,7 @@ export class AutomationExecutor {
           credentials.messageConfig,
           { fetchFn: this.deps.fetchFn },
         )
+        inFlightSendBatch = null
         const responseBody = stringifyResponseBody(result.raw)
         responseCount += 1
 
@@ -3188,6 +3213,16 @@ export class AutomationExecutor {
       // did happen for them, and a partial failure is a partial result, not a total one.
       const unsentRecipients = resolvedRecipients.filter((recipient) => !sentRecipients.has(recipient))
 
+      // PR #4046 Phase B: when the thrown error carries the transport's outcome-unknown marker,
+      // the recipients of the batch that was IN FLIGHT get the DISTINCT `outcome_unknown` state
+      // (the message may well have reached them — never auto-resent, reconciliation is
+      // manual/ops). Recipients of batches never attempted have a KNOWN outcome and stay
+      // `failed`, exactly as before.
+      const outcomeUnknown = isDingTalkOutcomeUnknown(error)
+      const outcomeUnknownRecipients = outcomeUnknown && inFlightSendBatch
+        ? new Set<(typeof resolvedRecipients)[number]>(inFlightSendBatch)
+        : new Set<(typeof resolvedRecipients)[number]>()
+
       await Promise.all(unsentRecipients.map((recipient) => recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
         localUserId: recipient.localUserId,
         dingtalkUserId: recipient.dingtalkUserId,
@@ -3195,7 +3230,7 @@ export class AutomationExecutor {
         subject: renderedTitle,
         content: bodyWithLinks,
         success: false,
-        status: 'failed',
+        status: outcomeUnknownRecipients.has(recipient) ? 'outcome_unknown' : 'failed',
         httpStatus,
         responseBody,
         errorMessage,
@@ -3210,8 +3245,11 @@ export class AutomationExecutor {
         error: errorMessage,
         output: {
           notifiedUsers: sentRecipients.size,
-          failedRecipientCount: unsentRecipients.length,
+          failedRecipientCount: unsentRecipients.length - outcomeUnknownRecipients.size,
           batchCount: batches.length,
+          ...(outcomeUnknownRecipients.size > 0
+            ? { deliveryOutcomeUnknown: true, outcomeUnknownRecipientCount: outcomeUnknownRecipients.size }
+            : {}),
         },
       }
     }

--- a/packages/core-backend/src/multitable/dingtalk-person-delivery-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-person-delivery-service.ts
@@ -6,7 +6,8 @@ export interface DingTalkPersonDelivery {
   subject: string
   content: string
   success: boolean
-  status: 'success' | 'failed' | 'skipped'
+  /** `outcome_unknown` (PR #4046 Phase B): send attempted, response lost — maybe delivered, never auto-resent. */
+  status: 'success' | 'failed' | 'skipped' | 'outcome_unknown'
   httpStatus?: number
   responseBody?: string
   errorMessage?: string
@@ -45,7 +46,9 @@ type DeliveryRow = {
 }
 
 function normalizeDeliveryStatus(status: string | null, success: boolean): DingTalkPersonDelivery['status'] {
-  if (status === 'success' || status === 'failed' || status === 'skipped') return status
+  // outcome_unknown passes through unfolded (PR #4046 Phase B) — folding it into 'failed' would
+  // erase the reconciliation signal the distinct state exists for.
+  if (status === 'success' || status === 'failed' || status === 'skipped' || status === 'outcome_unknown') return status
   return success ? 'success' : 'failed'
 }
 

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -10,7 +10,11 @@
  *   reject-comment-required, nodeEntryEpoch round-scoping and version conflicts apply untouched.
  * - Channel attribution is injected SERVER-SIDE (`channelOrigin` → approval_records.metadata);
  *   HTTP bodies never carry it.
- * - A card is actionable only while card_state='sent' AND send_status='sent' (review P2).
+ * - A card is actionable only while card_state='sent' AND the send possibly delivered:
+ *   send_status IN ('sent','outcome_unknown') (review P2; PR #4046 Phase B widened the set by
+ *   exactly outcome_unknown — a send whose outcome the client could not observe MAY have been
+ *   delivered, and a valid HMAC deep-link token is itself proof of delivery, so the ledger's
+ *   send-time uncertainty must not make a delivered card inoperable. pending/failed stay stale.)
  */
 import { createHmac, timingSafeEqual } from 'crypto'
 
@@ -36,7 +40,7 @@ export interface ApprovalCardDeliverySummary {
   nodeKey: string
   recipientUserId: string
   viewerIsRecipient: boolean
-  /** card live + send delivered + instance still pending — the page may offer 同意/拒绝. */
+  /** card live + send possibly delivered ('sent'/'outcome_unknown') + instance still pending — the page may offer 同意/拒绝. */
   actionable: boolean
   approval: {
     instanceId: string
@@ -125,7 +129,7 @@ async function buildSummary(
     viewerIsRecipient: delivery.recipient_user_id === viewerUserId,
     actionable:
       delivery.card_state === 'sent'
-      && delivery.send_status === 'sent'
+      && (delivery.send_status === 'sent' || delivery.send_status === 'outcome_unknown')
       && instance.status === 'pending',
     approval: {
       instanceId: instance.id,

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -5,6 +5,7 @@ import {
   DingTalkBusinessError,
   DingTalkRequestError,
   fetchDingTalkAppAccessToken,
+  isDingTalkOutcomeUnknown,
   sendDingTalkWorkNotification,
   sendDingTalkWorkNotificationActionCard,
   type DingTalkMessageConfig,
@@ -74,10 +75,19 @@ export interface AttendanceDeliveryMessage {
  * "this user has no channel identity yet" case does not pollute the dead-letter/failed counter that
  * exists to surface real delivery faults (API errors, timeouts, quota). Channels MUST NOT set `skip`
  * on a retryable result; the worker only consults it once `retryable` is already false.
+ *
+ * `outcomeUnknown` (PR #4046 Phase B) likewise only has meaning alongside `retryable: false`: the
+ * send was ATTEMPTED and the outcome is unknowable (network error/timeout/5xx/malformed 2xx — the
+ * recipient may well have received the message). The worker terminates it as the DISTINCT
+ * `outcome_unknown` status: it must NOT burn retries and must NOT be resent (owner doctrine — a
+ * resend on ambiguity is a duplicate-notification hazard; DingTalk's async-send result query only
+ * reconciles when a task_id exists, and a lost response has none). Only the DingTalk channel's
+ * classifier produces it today; WeCom/email transports do not emit the marker and are untouched.
+ * `skip` and `outcomeUnknown` are mutually exclusive; the worker checks `outcomeUnknown` first.
  */
 export type AttendanceDeliveryChannelResult =
   | { ok: true }
-  | { ok: false; retryable: boolean; error: string; skip?: boolean }
+  | { ok: false; retryable: boolean; error: string; skip?: boolean; outcomeUnknown?: boolean }
 
 export interface AttendanceDeliveryChannel {
   readonly name: string
@@ -148,6 +158,8 @@ export interface AttendanceNotificationDeliveryResult {
   failed: number
   skipped: number
   lostLease?: number
+  /** PR #4046 Phase B: rows terminated `outcome_unknown` this batch (present only when > 0, like lostLease). */
+  outcomeUnknown?: number
 }
 
 interface DeliveryRow {
@@ -883,19 +895,24 @@ export class AttendanceNotificationDeliveryWorker {
       const rows = await this.claimDueDeliveries()
       result.claimed = rows.length
       let lostLease = 0
+      let outcomeUnknown = 0
       for (const row of rows) {
         const outcome = await this.deliver(row)
         if (outcome === 'sent') result.sent += 1
         else if (outcome === 'retrying') result.retrying += 1
         else if (outcome === 'failed') result.failed += 1
         else if (outcome === 'skipped') result.skipped += 1
+        else if (outcome === 'outcome_unknown') outcomeUnknown += 1
         else lostLease += 1
       }
       if (lostLease > 0) {
         result.lostLease = lostLease
       }
+      if (outcomeUnknown > 0) {
+        result.outcomeUnknown = outcomeUnknown
+      }
       if (result.claimed > 0) {
-        this.logger.info(`Attendance deliveries claimed=${result.claimed} sent=${result.sent} retrying=${result.retrying} failed=${result.failed} skipped=${result.skipped} lostLease=${lostLease}`)
+        this.logger.info(`Attendance deliveries claimed=${result.claimed} sent=${result.sent} retrying=${result.retrying} failed=${result.failed} skipped=${result.skipped} outcomeUnknown=${outcomeUnknown} lostLease=${lostLease}`)
       }
       return result
     } finally {
@@ -903,7 +920,7 @@ export class AttendanceNotificationDeliveryWorker {
     }
   }
 
-  private async deliver(row: DeliveryRow): Promise<'sent' | 'retrying' | 'failed' | 'skipped' | 'lost-lease'> {
+  private async deliver(row: DeliveryRow): Promise<'sent' | 'retrying' | 'failed' | 'skipped' | 'outcome_unknown' | 'lost-lease'> {
     const channel = this.channelsByName.get(row.channel)
     const attemptCount = Number(row.attempt_count)
     if (!channel) {
@@ -937,6 +954,14 @@ export class AttendanceNotificationDeliveryWorker {
 
     const failure = channelResult as Extract<AttendanceDeliveryChannelResult, { ok: false }>
     if (!failure.retryable || attemptCount >= this.maxAttempts) {
+      // PR #4046 Phase B: an outcome-unknown send (attempted, response lost — maybe delivered)
+      // terminates as the DISTINCT `outcome_unknown` state on the FIRST such classification: it
+      // never burns further attempts and is never resent (a resend on ambiguity is a duplicate
+      // hazard). Sits strictly in this per-row post-send classification — the quiet-hours gate
+      // and the claim/lease CAS semantics above are untouched.
+      if (!failure.retryable && failure.outcomeUnknown) {
+        return await this.markOutcomeUnknown(row.id, failure.error, attemptCount) ? 'outcome_unknown' : 'lost-lease'
+      }
       // Only a genuinely non-retryable, channel-flagged-structural result skips the dead-letter bucket.
       // A retryable failure that merely ran out of attempts (attemptCount >= maxAttempts) always still
       // lands in `failed` — it was a real, repeated send failure, not something we should have skipped.
@@ -993,6 +1018,28 @@ export class AttendanceNotificationDeliveryWorker {
     const result = await this.query(
       `UPDATE attendance_notification_deliveries
           SET status = 'failed',
+              last_error = $2,
+              claim_expires_at = NULL,
+              claim_worker_id = NULL,
+              updated_at = $3::timestamptz
+        WHERE id = $1::uuid
+          AND status = 'sending'
+          AND claim_worker_id = $4
+          AND attempt_count = $5::int`,
+      [id, error.slice(0, 1000), now, this.workerId, attemptCount],
+    )
+    return Number(result.rowCount ?? 0) === 1
+  }
+
+  // Same terminal-state CAS guard as markFailed (only the lease holder, matching attempt_count, may
+  // write) — the only difference is the target status. See the AttendanceDeliveryChannelResult
+  // `outcomeUnknown` doc comment: the send may well have been delivered, so this row must never be
+  // re-claimed or resent; reconciliation is manual/ops via the distinct status + last_error.
+  private async markOutcomeUnknown(id: string, error: string, attemptCount: number): Promise<boolean> {
+    const now = this.now().toISOString()
+    const result = await this.query(
+      `UPDATE attendance_notification_deliveries
+          SET status = 'outcome_unknown',
               last_error = $2,
               claim_expires_at = NULL,
               claim_worker_id = NULL,
@@ -1100,6 +1147,23 @@ function isRetryableDingTalkErrorCode(code: number): boolean {
 }
 
 function classifyDingTalkSendError(error: unknown): AttendanceDeliveryChannelResult {
+  // PR #4046 Phase B — checked FIRST, before any shape-based bucket: the transport marks
+  // send-tier failures whose outcome is unknowable (network error/timeout/5xx/malformed 2xx)
+  // with isDingTalkOutcomeUnknown. Pre-fix these fell into the retryable buckets below and the
+  // outbox RESENT them — the duplicate-notification hazard the owner's doctrine forbids. They
+  // are terminal (`outcome_unknown`), never retried: a resend cannot be reconciled (a lost
+  // response carries no task_id for DingTalk's async-send result query). Definite rejections
+  // (429 pre-processing, flow-control errcodes, business errors) are NOT marked by the
+  // transport and keep their classification below. WeCom/email classifiers are untouched —
+  // their transports do not emit the marker.
+  if (isDingTalkOutcomeUnknown(error)) {
+    return {
+      ok: false,
+      retryable: false,
+      outcomeUnknown: true,
+      error: `dingtalk_send_outcome_unknown: ${normalizeErrorText(error, 'DingTalk send outcome unknown')}`,
+    }
+  }
   if (error instanceof DingTalkRequestError) {
     return {
       ok: false,

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -20,6 +20,8 @@ import {
 } from '../../src/services/ApprovalCardDeliveryAction'
 import {
   insertDingTalkApprovalCardDelivery,
+  markDingTalkApprovalCardDeliverySendFailed,
+  markDingTalkApprovalCardDeliverySendOutcomeUnknown,
   markDingTalkApprovalCardDeliverySent,
 } from '../../src/integrations/dingtalk/approval-card-deliveries'
 import { normalizeStoredSecretValue } from '../../src/security/encrypted-secrets'
@@ -294,6 +296,72 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
       { deliveryId: row.id, token: tokenFor(row.id), decision: 'approve', actor: approverActor },
     )
     expect(outcome.status).toBe('stale')
+  })
+
+  test('PR #4046 Phase B: send_status=failed stays stale — the possibly-delivered widening is EXACTLY (sent, outcome_unknown), nothing else', async () => {
+    const instanceId = await newInstance()
+    const row = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: `dd_${APPROVER}`, deliveryKind: 'work_notice_action_card',
+    })
+    await markDingTalkApprovalCardDeliverySendFailed(q, row.id, 'ding: definite rejection')
+    const summary = await getApprovalCardDeliverySummary({ query: q }, { deliveryId: row.id, token: tokenFor(row.id), viewerUserId: APPROVER })
+    expect(summary.status).toBe('ok')
+    if (summary.status === 'ok') expect(summary.summary.actionable).toBe(false)
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId: row.id, token: tokenFor(row.id), decision: 'approve', actor: approverActor },
+    )
+    expect(outcome.status).toBe('stale')
+    // and the claim SQL is equally closed: the card was never claimed
+    const card = await q(`SELECT card_state, send_status FROM dingtalk_approval_card_deliveries WHERE id = $1`, [row.id])
+    expect(card.rows[0]).toMatchObject({ card_state: 'sent', send_status: 'failed' })
+  })
+
+  test('PR #4046 Phase B: outcome_unknown + valid HMAC token IS actionable — the token proves delivery; approve proceeds and claims the card', async () => {
+    // A card whose send outcome the client could not observe MAY have been delivered — and a
+    // valid deep-link token only ever existed inside the delivered card, so the callback is the
+    // delivery proof. The ledger's send-time uncertainty must not make the card inoperable.
+    const instanceId = await newInstance()
+    const row = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: `dd_${APPROVER}`, deliveryKind: 'work_notice_action_card',
+    })
+    await markDingTalkApprovalCardDeliverySendOutcomeUnknown(q, row.id, 'fetch failed (response lost)')
+
+    const summary = await getApprovalCardDeliverySummary({ query: q }, { deliveryId: row.id, token: tokenFor(row.id), viewerUserId: APPROVER })
+    expect(summary.status).toBe('ok')
+    if (summary.status === 'ok') {
+      expect(summary.summary.sendStatus).toBe('outcome_unknown')
+      expect(summary.summary.actionable).toBe(true)
+    }
+
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId: row.id, token: tokenFor(row.id), decision: 'approve', comment: '同意', actor: approverActor },
+    )
+    expect(outcome.status).toBe('ok')
+    if (outcome.status === 'ok') {
+      expect(outcome.summary.cardState).toBe('acted')
+      expect(outcome.summary.actedAction).toBe('approve')
+      expect(outcome.summary.approval.status).toBe('approved')
+      // the send-time record keeps its truth: uncertainty at send time is history, acted is the proof of delivery
+      expect(outcome.summary.sendStatus).toBe('outcome_unknown')
+    }
+
+    // engine untouched beyond the one approve; channel attribution intact (guards NOT restructured)
+    const record = await q(
+      `SELECT metadata FROM approval_records WHERE instance_id = $1 AND action = 'approve' ORDER BY created_at DESC LIMIT 1`,
+      [instanceId],
+    )
+    const metadata = (record.rows[0] as { metadata: Record<string, unknown> }).metadata
+    expect(metadata.channel).toBe('dingtalk_card')
+    expect(metadata.cardDeliveryId).toBe(row.id)
+
+    // an INVALID token against the same outcome_unknown delivery is still not_found — HMAC stays the authority
+    const forged = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId: row.id, token: 'f'.repeat(32), decision: 'approve', actor: approverActor },
+    )
+    expect(forged.status).toBe('not_found')
   })
 
   test('approve: engine gates apply, channel attribution lands on approval_records, card claims acted', async () => {

--- a/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto'
 import { Kysely, PostgresDialect } from 'kysely'
 import { Pool } from 'pg'
 import { up as createAttendanceNotificationDeliveries } from '../../src/db/migrations/zzzz20260611120000_create_attendance_notification_deliveries'
+import { up as addOutcomeUnknownDeliveryStatus } from '../../src/db/migrations/zzzz20260710150000_add_outcome_unknown_delivery_status'
 import {
   AttendanceNotificationDeliveryWorker,
   buildAttendanceNotificationDeepLink,
@@ -12,7 +13,7 @@ import {
   WeComAttendanceDeliveryChannel,
   type AttendanceNotificationDeliveryQuery,
 } from '../../src/services/AttendanceNotificationDeliveryWorker'
-import type { DingTalkMessageConfig } from '../../src/integrations/dingtalk/client'
+import { sendDingTalkWorkNotification, type DingTalkMessageConfig } from '../../src/integrations/dingtalk/client'
 import type { WeComMessageConfig } from '../../src/integrations/wecom/client'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
@@ -433,6 +434,119 @@ describeIfDatabase('Attendance C5 notification delivery outbox', () => {
         claim_worker_id: null,
         claim_expires_at: null,
       })
+    } finally {
+      await workerPool.end().catch(() => undefined)
+      await workerDb.destroy().catch(() => undefined)
+      await dropSchema(dbUrl, workerSchemaName).catch(() => undefined)
+    }
+  })
+
+  it('PR #4046 Phase B: an outcome-unknown DingTalk send terminates as outcome_unknown — zero retries, never re-claimed, never resent; an ordinary network error still retries', async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL is required for this integration test')
+    const workerSchemaName = createIsolatedSchemaName()
+    await createSchema(dbUrl, workerSchemaName)
+    const workerDbUrl = withSearchPath(dbUrl, workerSchemaName)
+    const workerDb = createTestDb(workerDbUrl)
+    const workerPool = new Pool({ connectionString: workerDbUrl })
+    const runSuffix = Date.now().toString(36)
+    const orgId = `c5-outcome-unknown-${runSuffix}`
+    const sourceId = randomUUID()
+    const firstNow = new Date('2026-08-01T00:00:00.000Z')
+    // beyond computeDeliveryBackoffMs(1)=60s, so the retrying row is due again on batch 2
+    const secondNow = new Date('2026-08-01T00:05:00.000Z')
+    let now = firstNow
+    const query: AttendanceNotificationDeliveryQuery = async (sqlText, params) => {
+      const r = await workerPool.query(sqlText, params as unknown[])
+      return { rows: r.rows, rowCount: r.rowCount }
+    }
+    // Per-recipient send attempts — the resend-hazard counter.
+    const sendAttemptsByUser = new Map<string, number>()
+    try {
+      await createAttendanceNotificationDeliveries(workerDb)
+      // the migration under test: widens the status CHECK by 'outcome_unknown'
+      await addOutcomeUnknownDeliveryStatus(workerDb)
+      await requireTable(workerPool, 'attendance_notification_deliveries')
+
+      const insert = async (label: string) => (await workerPool.query<{ id: string }>(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, payload)
+         VALUES ($1,'unscheduled_reminder',$2,$3,$4,'subject','dingtalk_work_notification','{}'::jsonb)
+         RETURNING id::text AS id`,
+        [orgId, sourceId, `outcome-unknown:${runSuffix}:${label}`, `u-${label}`],
+      )).rows[0].id
+      const unknownId = await insert('unknown')
+      const transientId = await insert('transient')
+
+      // Real DingTalkAttendanceDeliveryChannel; recipient resolution stubbed (unit-style DI — the
+      // directory JOIN is pinned elsewhere/C5-3), but the SEND for the outcome-unknown recipient
+      // goes through the REAL client + transport with a fetch that rejects at network level, so
+      // the outcome-unknown MARKING itself is the real transport behavior, not a hand-rolled flag.
+      const channel = new DingTalkAttendanceDeliveryChannel({
+        query: (async (sqlText: string, params?: unknown[]) => {
+          if (sqlText.includes('directory_account_links')) {
+            return { rows: [{ integration_id: 'integ-1', external_user_id: `dd_${String(params?.[0])}` }] }
+          }
+          return { rows: [{ org_has_active_integration: true }] }
+        }) as never,
+        readConfig: async () => ({ appKey: 'k', appSecret: 's', agentId: '42' }),
+        fetchAccessToken: async () => 'tok',
+        sendWorkNotification: async (accessToken, input, config) => {
+          const target = input.userIds[0]
+          sendAttemptsByUser.set(target, (sendAttemptsByUser.get(target) ?? 0) + 1)
+          if (target === 'dd_u-unknown') {
+            // network-level rejection → the real transport marks the rethrown error outcome-unknown
+            return sendDingTalkWorkNotification(accessToken, input, config, {
+              fetchFn: (async () => { throw new TypeError('fetch failed') }) as unknown as typeof fetch,
+            })
+          }
+          // ordinary transient failure WITHOUT the marker — must keep retrying (pinned unchanged)
+          throw new Error('ECONNRESET: transient blip')
+        },
+      })
+
+      const worker = new AttendanceNotificationDeliveryWorker({
+        query,
+        channels: [channel],
+        now: () => now,
+        leaseMs: 60_000,
+        maxAttempts: 5,
+        workerId: 'worker-outcome-unknown',
+      })
+
+      await expect(worker.runBatch()).resolves.toEqual({
+        claimed: 2, sent: 0, retrying: 1, failed: 0, skipped: 0, outcomeUnknown: 1,
+      })
+
+      const row = async (id: string) => (await workerPool.query(
+        `SELECT status, attempt_count, delivered_at, last_error, claim_expires_at, claim_worker_id
+           FROM attendance_notification_deliveries
+          WHERE id = $1`,
+        [id],
+      )).rows[0]
+
+      // Terminal distinct state against the REAL widened CHECK — not 'failed', lease released,
+      // attempt budget NOT burned beyond the single attempt.
+      expect(await row(unknownId)).toMatchObject({
+        status: 'outcome_unknown',
+        attempt_count: 1,
+        delivered_at: null,
+        claim_expires_at: null,
+        claim_worker_id: null,
+      })
+      expect(String((await row(unknownId)).last_error)).toMatch(/^dingtalk_send_outcome_unknown: /)
+      expect(await row(transientId)).toMatchObject({ status: 'retrying', attempt_count: 1 })
+
+      // Next batch (past the retry backoff): the outcome_unknown row is NOT re-claimed and NOT
+      // resent; the ordinary transient row IS retried (behavior pinned unchanged).
+      now = secondNow
+      await expect(worker.runBatch()).resolves.toEqual({
+        claimed: 1, sent: 0, retrying: 1, failed: 0, skipped: 0,
+      })
+      expect(await row(unknownId)).toMatchObject({ status: 'outcome_unknown', attempt_count: 1 })
+      expect(await row(transientId)).toMatchObject({ status: 'retrying', attempt_count: 2 })
+      // The resend-hazard assertion: exactly ONE send ever reached the outcome-unknown recipient.
+      expect(sendAttemptsByUser.get('dd_u-unknown')).toBe(1)
+      expect(sendAttemptsByUser.get('dd_u-transient')).toBe(2)
     } finally {
       await workerPool.end().catch(() => undefined)
       await workerDb.destroy().catch(() => undefined)

--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -67,7 +67,12 @@ const ruleIds: string[] = []
 const sentBodies: Array<Record<string, unknown>> = []
 const interactiveBodies: Array<Record<string, unknown>> = []
 let failNextSend = false
+// PR #4046 Phase B: one-shot TRANSPORT-LEVEL failure — the asyncsend fetch REJECTS at network
+// level, so the real client + transport seam (send tier: no resend) rethrows the error marked
+// isDingTalkOutcomeUnknown. asyncsendCallCount proves the no-second-send-attempt property.
+let failNextSendNetwork = false
 let fetchCallCount = 0
+let asyncsendCallCount = 0
 
 const fakeFetch: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   fetchCallCount += 1
@@ -76,6 +81,11 @@ const fakeFetch: typeof fetch = (async (input: RequestInfo | URL, init?: Request
     return new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'tok_test' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
   }
   if (url.includes('/topapi/message/corpconversation/asyncsend_v2')) {
+    asyncsendCallCount += 1
+    if (failNextSendNetwork) {
+      failNextSendNetwork = false
+      throw new TypeError('fetch failed')
+    }
     if (failNextSend) {
       failNextSend = false
       return new Response(JSON.stringify({ errcode: 88, errmsg: 'ding: simulated send failure' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
@@ -463,6 +473,85 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     expect(cardStep!.output?.deliveryLedgerError).toBeUndefined()
 
     await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('PR #4046 Phase B: a transport-level outcome-unknown send failure records send_status=outcome_unknown (NOT failed), the execution output carries deliveryOutcomeUnknown, and there is NO second send attempt', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'card outcome-unknown', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+
+    failNextSendNetwork = true
+    const asyncsendBefore = asyncsendCallCount
+    const dto = await approvals.createApproval({ templateId, formData: { summary: 'outcome-unknown run' } }, { userId: REQUESTER, userName: REQUESTER })
+    const instanceId = (dto as { id: string }).id
+
+    // The ledger consumes the marker: the DISTINCT outcome_unknown state, never plain 'failed' —
+    // the card may well have been delivered (owner doctrine: no auto-resend on ambiguity; a lost
+    // response has no task_id, so DingTalk's result query cannot reconcile it automatically).
+    const rows = await waitFor(async () => (await cardRows(instanceId)).filter((r) => r.send_status !== 'pending'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].send_status).toBe('outcome_unknown')
+    expect(rows[0].task_id).toBeNull()
+    expect(String(rows[0].send_error)).toContain('fetch failed')
+
+    // NO second send attempt: exactly one asyncsend fetch for this run (transport send tier
+    // never resends; the executor makes exactly one send call).
+    expect(asyncsendCallCount).toBe(asyncsendBefore + 1)
+
+    // The persisted execution record carries the flag for the execution ledger/readers.
+    const executionRows = await waitFor(async () => {
+      const r = await q(
+        `SELECT steps FROM multitable_automation_executions WHERE rule_id = $1 ORDER BY created_at DESC`,
+        [rule.id],
+      )
+      return r.rows
+    })
+    expect(executionRows.length).toBeGreaterThan(0)
+    const rawSteps = (executionRows[0] as { steps: unknown }).steps
+    const steps = (typeof rawSteps === 'string' ? JSON.parse(rawSteps) : rawSteps) as Array<Record<string, unknown>>
+    const cardStep = steps.find((s) => s.actionType === 'send_dingtalk_approval_card') as
+      | { status: string; output?: { deliveryId?: string; deliveryOutcomeUnknown?: boolean; deliveryStuckPending?: boolean } }
+      | undefined
+    expect(cardStep).toBeDefined()
+    expect(cardStep!.status).toBe('failed')
+    expect(cardStep!.output?.deliveryId).toBe(rows[0].id)
+    expect(cardStep!.output?.deliveryOutcomeUnknown).toBe(true)
+    expect(cardStep!.output?.deliveryStuckPending).toBeUndefined()
+
+    // Contrast pin (mutation guard both directions): the DEFINITE-rejection path in the previous
+    // test stays 'failed' WITHOUT the flag — mapping outcome-unknown back to plain 'failed' turns
+    // the assertions above red; mapping all failures to outcome_unknown turns that test red.
+
+    await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('PR #4046 Phase B: dingtalk_person_deliveries accepts the outcome_unknown status (widened CHECK) and still rejects unknown values', async () => {
+    // The executor's person-delivery writes go through recordDingTalkPersonDeliverySafely, which
+    // swallows insert errors by design — a unit test cannot prove the DB accepts the new status.
+    // Prove the widened CHECK against real Postgres here (both directions).
+    const inserted = await q(
+      `INSERT INTO dingtalk_person_deliveries
+         (id, local_user_id, dingtalk_user_id, source_type, subject, content, success, status, error_message)
+       VALUES ($1, $2, $3, 'automation', 's', 'c', FALSE, 'outcome_unknown', 'fetch failed')
+       RETURNING id, status`,
+      [randomUUID(), APPROVER, DD_USER_ID],
+    )
+    expect((inserted.rows[0] as { status: string }).status).toBe('outcome_unknown')
+
+    let code: string | undefined
+    try {
+      await q(
+        `INSERT INTO dingtalk_person_deliveries
+           (id, local_user_id, source_type, subject, content, success, status)
+         VALUES ($1, $2, 'automation', 's', 'c', FALSE, 'bogus_status')`,
+        [randomUUID(), APPROVER],
+      )
+    } catch (e) {
+      code = (e as { code?: string }).code
+    }
+    expect(code).toBe('23514')
   })
 
   test('DT-HARDEN-06: send fails AND the ledger mark-failed write ALSO fails — deliveryStuckPending/deliveryLedgerError surface in the persisted execution record, not swallowed', async () => {

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
@@ -16,6 +16,7 @@ import {
   findDingTalkApprovalCardDeliveryById,
   insertDingTalkApprovalCardDelivery,
   markDingTalkApprovalCardDeliverySendFailed,
+  markDingTalkApprovalCardDeliverySendOutcomeUnknown,
   markDingTalkApprovalCardDeliverySent,
   supersedeDingTalkApprovalCardDeliveriesForInstance,
 } from '../../src/integrations/dingtalk/approval-card-deliveries'
@@ -160,6 +161,34 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
     })
     await markDingTalkApprovalCardDeliverySent(q, delivered.id, null)
     expect((await claimDingTalkApprovalCardDeliveryActed(q, delivered.id, { action: 'reject', actedBy: 'user_p2c' }))?.card_state).toBe('acted')
+  })
+
+  it('PR #4046 Phase B: outcome_unknown persists via the new helper (pending-only guard), IS claimable, and the CHECK still rejects unknown send_status values', async () => {
+    const row = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_ou',
+      recipientDingTalkUserId: 'dd_user_ou',
+      deliveryKind: 'work_notice_action_card',
+    })
+    const marked = await markDingTalkApprovalCardDeliverySendOutcomeUnknown(q, row.id, 'fetch failed (response lost)')
+    expect(marked?.send_status).toBe('outcome_unknown')
+    expect(marked?.send_error).toBe('fetch failed (response lost)')
+
+    // pending-only guard: a second transition attempt is a no-op (same discipline as markSent/markSendFailed)
+    expect(await markDingTalkApprovalCardDeliverySendOutcomeUnknown(q, row.id, 'again')).toBeNull()
+    expect(await markDingTalkApprovalCardDeliverySent(q, row.id, 'task_late')).toBeNull()
+
+    // possibly-delivered ⇒ claimable: a valid callback proves the card WAS delivered
+    const claimed = await claimDingTalkApprovalCardDeliveryActed(q, row.id, { action: 'approve', actedBy: 'user_ou' })
+    expect(claimed?.card_state).toBe('acted')
+    expect(claimed?.send_status).toBe('outcome_unknown') // send-time truth is preserved on the audit row
+
+    // widened CHECK stays closed to anything else
+    await expect(
+      q(`INSERT INTO dingtalk_approval_card_deliveries (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, send_status)
+         VALUES ('bad_send_status', $1, 'n1', 'u', 'dd', 'interactive_card', 'maybe_sent')`, [INSTANCE]),
+    ).rejects.toThrow()
   })
 
     it('DB CHECKs reject invalid delivery_kind / card_state / acted-audit inconsistency; FK rejects unknown instances', async () => {

--- a/packages/core-backend/tests/unit/attendance-dingtalk-outcome-unknown.test.ts
+++ b/packages/core-backend/tests/unit/attendance-dingtalk-outcome-unknown.test.ts
@@ -1,0 +1,104 @@
+/**
+ * PR #4046 Phase B — the attendance DingTalk channel CONSUMES the transport's outcome-unknown
+ * marker (isDingTalkOutcomeUnknown): a send whose outcome is unknowable becomes a NON-retryable
+ * result carrying `outcomeUnknown: true`, so the outbox worker terminates it as the distinct
+ * `outcome_unknown` status instead of RESENDING it (the pre-existing duplicate hazard: these
+ * errors used to classify retryable). Definite rejections and read-tier failures keep their
+ * pre-Phase-B classification — pinned here so the widening is provably surgical.
+ *
+ * Unit-level DI (query/config/token/send injected) mirrors the WeCom channel suite; the real
+ * transport's marking behavior is pinned in dingtalk-transport-resilience.test.ts, and the
+ * worker's terminal-state/no-reclaim behavior against real Postgres lives in
+ * tests/integration/attendance-notification-deliveries.test.ts.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DingTalkAttendanceDeliveryChannel,
+  DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME,
+  type AttendanceDeliveryMessage,
+} from '../../src/services/AttendanceNotificationDeliveryWorker'
+import {
+  DingTalkBusinessError,
+  DingTalkRequestError,
+  type DingTalkMessageConfig,
+} from '../../src/integrations/dingtalk/client'
+
+const CONFIG: DingTalkMessageConfig = { appKey: 'k', appSecret: 's', agentId: '42' }
+
+const MESSAGE: AttendanceDeliveryMessage = {
+  id: 'dlv1',
+  orgId: 'org1',
+  sourceType: 'unscheduled_reminder',
+  sourceId: 'src1',
+  sourceKey: 'key1',
+  recipientUserId: 'u1',
+  recipientRole: 'subject',
+  channel: DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME,
+  payload: { title: 'Punch reminder', body: 'You have an unscheduled shift today.' },
+}
+
+function makeChannel(sendError: unknown) {
+  const query = vi.fn(async (sql: string) => {
+    if (sql.includes('directory_account_links')) {
+      return { rows: [{ integration_id: 'integ-1', external_user_id: 'dd-user-1' }] }
+    }
+    return { rows: [{ org_has_active_integration: true }] }
+  })
+  const sendWorkNotification = vi.fn(async () => { throw sendError })
+  const channel = new DingTalkAttendanceDeliveryChannel({
+    query: query as never,
+    readConfig: async () => CONFIG,
+    fetchAccessToken: async () => 'access-token',
+    sendWorkNotification,
+  })
+  return { channel, sendWorkNotification }
+}
+
+/** The transport marks outcome-unknown sends with an enumerable `outcomeUnknown: true` property. */
+function markedError(base: Error): Error {
+  return Object.assign(base, { outcomeUnknown: true })
+}
+
+describe('DingTalk attendance channel — outcome-unknown consumption (PR #4046 Phase B)', () => {
+  it('a marked network error → NON-retryable + outcomeUnknown:true (terminal, never resent), send attempted exactly once', async () => {
+    const { channel, sendWorkNotification } = makeChannel(markedError(new TypeError('fetch failed')))
+    const result = await channel.send(MESSAGE)
+    expect(result).toEqual({
+      ok: false,
+      retryable: false,
+      outcomeUnknown: true,
+      error: expect.stringMatching(/^dingtalk_send_outcome_unknown: /),
+    })
+    expect(sendWorkNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('a marked DingTalkRequestError 502 (send-tier 5xx) → outcome_unknown, NOT the retryable dingtalk_request_502 bucket', async () => {
+    const { channel } = makeChannel(markedError(new DingTalkRequestError('bad gateway', 502, null)))
+    const result = await channel.send(MESSAGE)
+    expect(result).toMatchObject({ ok: false, retryable: false, outcomeUnknown: true })
+    expect((result as { error: string }).error).toMatch(/^dingtalk_send_outcome_unknown: /)
+  })
+
+  it('PINNED unchanged: an UNMARKED network error stays retryable (ordinary transient failure keeps its backoff path)', async () => {
+    const { channel } = makeChannel(new TypeError('socket hang up'))
+    const result = await channel.send(MESSAGE)
+    expect(result).toMatchObject({ ok: false, retryable: true })
+    expect((result as { outcomeUnknown?: boolean }).outcomeUnknown).toBeUndefined()
+    expect((result as { error: string }).error).toMatch(/^dingtalk_send_failed: /)
+  })
+
+  it('PINNED unchanged: an UNMARKED DingTalkRequestError 500 stays retryable (read-tier/legacy paths do not carry the marker)', async () => {
+    const { channel } = makeChannel(new DingTalkRequestError('server error', 500, null))
+    const result = await channel.send(MESSAGE)
+    expect(result).toMatchObject({ ok: false, retryable: true })
+    expect((result as { outcomeUnknown?: boolean }).outcomeUnknown).toBeUndefined()
+  })
+
+  it('PINNED unchanged: a definite business rejection (errcode 88, unmarked — the transport never marks HTTP-200 envelopes) stays non-retryable WITHOUT outcomeUnknown', async () => {
+    const { channel } = makeChannel(new DingTalkBusinessError('ding: not allowed', { errcode: 88, errmsg: 'not allowed' }))
+    const result = await channel.send(MESSAGE)
+    expect(result).toMatchObject({ ok: false, retryable: false })
+    expect((result as { outcomeUnknown?: boolean }).outcomeUnknown).toBeUndefined()
+    expect((result as { error: string }).error).toMatch(/^dingtalk_business_error: /)
+  })
+})

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -1584,8 +1584,11 @@ describe('AutomationExecutor', () => {
         ],
       })
       .mockResolvedValue({ rows: [] })
-    const fetchFn = vi.fn()
-      .mockResolvedValue(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'tok', expires_in: 7200 }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as unknown as typeof fetch
+    // Fresh Response per call — a real fetch never resolves an already-consumed body;
+    // this test spans 4 fetches (2 tokens + 2 sends) and the transport no longer
+    // swallows the double-read TypeError a single shared mockResolvedValue Response
+    // produces (body-phase timeout fix, PR #4046).
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'tok', expires_in: 7200 }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as unknown as typeof fetch
 
     deps = createMockDeps({ queryFn, fetchFn })
     executor = new AutomationExecutor(deps)

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -991,7 +991,7 @@ describe('AutomationExecutor', () => {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
@@ -1039,6 +1039,68 @@ describe('AutomationExecutor', () => {
     expect(insertArgs?.[2]).toBe('dt-user-1')
     expect(insertArgs?.[6]).toBe(true)
     expect(insertArgs?.[7]).toBe('success')
+  })
+
+  // PR #4046 Phase B: when the rule-creator ALERT send itself has an unknowable outcome (network
+  // error — real transport marks it), the person-delivery telemetry records the DISTINCT
+  // 'outcome_unknown' state instead of 'failed', and the alert is not resent.
+  it('records outcome_unknown telemetry when the rule-creator alert send outcome is unknowable (no resend)', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ local_user_id: 'user_1', dingtalk_user_id: 'dt-user-1' }] })
+      .mockResolvedValue({ rows: [], rowCount: 1 })
+    const fetchFn = vi.fn()
+      // group robot send rejected by DingTalk → triggers the rule-creator alert path
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 310000, errmsg: 'signature mismatch' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      // the alert asyncsend REJECTS at network level → transport (send tier) marks outcome-unknown
+      .mockRejectedValueOnce(new TypeError('fetch failed')) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_2',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].output).toEqual(expect.objectContaining({
+      failureAlert: expect.objectContaining({ status: 'failed' }),
+    }))
+    // robot send + gettoken + ONE alert asyncsend attempt — never resent on ambiguity.
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+    const personInsertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
+    expect(personInsertCalls).toHaveLength(1)
+    const insertArgs = personInsertCalls[0]?.[1] as unknown[] | undefined
+    expect(insertArgs?.[1]).toBe('user_1')
+    expect(insertArgs?.[6]).toBe(false)
+    expect(insertArgs?.[7]).toBe('outcome_unknown')
   })
 
   it('audits a skipped rule-creator alert when the creator is not linked to DingTalk', async () => {
@@ -1349,7 +1411,7 @@ describe('AutomationExecutor', () => {
       })
       .mockResolvedValue({ rows: [] })
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
@@ -1417,7 +1479,7 @@ describe('AutomationExecutor', () => {
       .mockResolvedValue({ rows: [] })
 
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
@@ -1475,6 +1537,97 @@ describe('AutomationExecutor', () => {
 
     // Partial success is reported as a partial result.
     expect(result.steps[0]?.output).toMatchObject({ notifiedUsers: 100, failedRecipientCount: 50 })
+    // Definite rejection (errcode 88 envelope — the transport never marks HTTP-200 envelopes):
+    // NOTHING is outcome_unknown. Mutation guard for Phase B: classifying definite rejections as
+    // outcome_unknown would flip the 50 'failed' assertions above red.
+    expect((result.steps[0]?.output as { deliveryOutcomeUnknown?: boolean }).deliveryOutcomeUnknown).toBeUndefined()
+  })
+
+  // PR #4046 Phase B: a send whose outcome is UNKNOWABLE (network error — the real transport
+  // marks it isDingTalkOutcomeUnknown) records the DISTINCT `outcome_unknown` state for exactly
+  // the recipients of the batch that was IN FLIGHT. Batches never attempted have a KNOWN
+  // outcome (not sent) and stay `failed`; earlier successful batches keep success. Nobody is
+  // resent — the executor makes exactly one send attempt per batch, and the step output carries
+  // deliveryOutcomeUnknown for the execution record.
+  it('records ONLY the in-flight batch as outcome_unknown when the send outcome is unknowable (marker consumed; no resend)', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const recipientCount = 250 // → three batches: 100 + 100 + 50
+    const recipientRows = Array.from({ length: recipientCount }, (_, i) => ({
+      local_user_id: `user_${i}`,
+      local_user_active: true,
+      dingtalk_user_id: `dt-user-${i}`,
+    }))
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({ rows: recipientRows })
+      .mockResolvedValue({ rows: [] })
+
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      // batch 1 (100 recipients) succeeds
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      // batch 2 (100 recipients): the fetch REJECTS at network level — the real client/transport
+      // (send tier) rethrows it marked outcome-unknown, with NO transport-level resend.
+      .mockRejectedValueOnce(new TypeError('fetch failed')) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_person_message',
+        config: {
+          userIds: recipientRows.map((row) => row.local_user_id),
+          titleTemplate: 'T',
+          bodyTemplate: 'B',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    // token + batch1 + batch2 only — batch 2's failure is NOT resent and batch 3 is never sent.
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+
+    const deliveryInserts = queryFn.mock.calls
+      .filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
+      .map((call) => {
+        const params = call[1] as unknown[]
+        return { localUserId: String(params[1]), status: String(params[7]) }
+      })
+
+    const succeeded = deliveryInserts.filter((row) => row.status === 'success').map((row) => row.localUserId)
+    const outcomeUnknown = deliveryInserts.filter((row) => row.status === 'outcome_unknown').map((row) => row.localUserId)
+    const failed = deliveryInserts.filter((row) => row.status === 'failed').map((row) => row.localUserId)
+
+    expect(deliveryInserts).toHaveLength(recipientCount)
+    expect(succeeded).toHaveLength(100) // batch 1: sent, response seen
+    expect(outcomeUnknown).toHaveLength(100) // batch 2: attempted, outcome unknowable
+    expect(failed).toHaveLength(50) // batch 3: never attempted — KNOWN not sent
+    // the in-flight batch is exactly batch 2 (userIds preserve recipient order)
+    expect(outcomeUnknown).toEqual(recipientRows.slice(100, 200).map((row) => row.local_user_id))
+    expect(failed).toEqual(recipientRows.slice(200).map((row) => row.local_user_id))
+
+    expect(result.steps[0]?.output).toMatchObject({
+      notifiedUsers: 100,
+      failedRecipientCount: 50,
+      deliveryOutcomeUnknown: true,
+      outcomeUnknownRecipientCount: 100,
+    })
   })
 
   it('truncates an oversized title/body before sending a person message instead of failing delivery', async () => {
@@ -1489,7 +1642,7 @@ describe('AutomationExecutor', () => {
       })
       .mockResolvedValue({ rows: [] })
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
@@ -1550,7 +1703,7 @@ describe('AutomationExecutor', () => {
       })
       .mockResolvedValue({ rows: [] })
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'tok' }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'tok' }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok' }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as unknown as typeof fetch
 
     deps = createMockDeps({ queryFn, fetchFn })
@@ -1710,7 +1863,7 @@ describe('AutomationExecutor', () => {
       })
       .mockResolvedValue({ rows: [] })
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
@@ -1776,7 +1929,7 @@ describe('AutomationExecutor', () => {
       })
       .mockResolvedValue({ rows: [] })
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
@@ -1838,7 +1991,7 @@ describe('AutomationExecutor', () => {
       })
       .mockResolvedValue({ rows: [] })
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
@@ -1929,7 +2082,7 @@ describe('AutomationExecutor', () => {
       })
       .mockResolvedValue({ rows: [] })
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))
@@ -2039,7 +2192,7 @@ describe('AutomationExecutor', () => {
       })
       .mockResolvedValue({ rows: [] })
     const fetchFn = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }))

--- a/packages/core-backend/tests/unit/dingtalk-person-delivery-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-person-delivery-service.test.ts
@@ -98,4 +98,39 @@ describe('dingtalk person delivery service', () => {
       },
     ])
   })
+
+  it("passes 'outcome_unknown' through UNFOLDED (PR #4046 Phase B) while unknown junk still folds by success", async () => {
+    const base = {
+      local_user_id: 'user_1',
+      dingtalk_user_id: 'dt_1',
+      source_type: 'automation',
+      subject: 'S',
+      content: 'C',
+      http_status: null,
+      response_body: null,
+      error_message: 'dingtalk_send_outcome_unknown: fetch failed',
+      automation_rule_id: 'rule_1',
+      record_id: 'rec_1',
+      initiated_by: 'user_2',
+      created_at: '2026-07-10T12:00:00.000Z',
+      delivered_at: null,
+      local_user_name: 'Lin Lan',
+      local_user_email: null,
+      local_user_is_active: true,
+    }
+    const queryFn = vi.fn(async () => ({
+      rows: [
+        { ...base, id: 'dpd_ou', success: false, status: 'outcome_unknown' },
+        // legacy/garbage status still folds by the success boolean (unchanged behavior)
+        { ...base, id: 'dpd_junk', success: false, status: 'totally_bogus', error_message: 'x' },
+      ],
+    }))
+    const deliveries = await listAutomationDingTalkPersonDeliveries(queryFn, 'rule_1')
+    // Folding outcome_unknown into 'failed' would erase the reconciliation signal the
+    // distinct state exists for — the API surface must carry it verbatim.
+    expect(deliveries.map((d) => ({ id: d.id, status: d.status }))).toEqual([
+      { id: 'dpd_ou', status: 'outcome_unknown' },
+      { id: 'dpd_junk', status: 'failed' },
+    ])
+  })
 })

--- a/packages/core-backend/tests/unit/dingtalk-request-timeout.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-request-timeout.test.ts
@@ -83,9 +83,11 @@ describe('DT-HARDEN-06 DingTalk request timeout', () => {
     expect(seenInit?.signal?.aborted).toBe(false)
   })
 
-  // NOTE on the spread-order precedence (`{ ...init, signal: init.signal ?? … }` vs
-  // `{ signal: …, ...init }`): it cannot be exercised through the public surface because no
-  // in-repo caller passes an `init.signal`, and `requestDingTalkJson` is not exported. The order
-  // in client.ts is correct (spread-first, caller-signal-wins); it is left structurally correct
-  // rather than tested through a re-implemented merge, which proves nothing.
+  // NOTE: since the §7.2 unified transport, the signal handed to fetch is composed in
+  // transport.ts (`composePerAttemptSignal`): a fresh AbortSignal.timeout PER ATTEMPT,
+  // AbortSignal.any-composed with the caller's overall signal when one is provided.
+  // Per-attempt freshness and caller-abort behavior are covered in
+  // dingtalk-transport-resilience.test.ts; this suite keeps pinning the H06 surface
+  // (a live signal reaches fetch; aborts surface as DingTalkTimeoutError; failures
+  // are never cached).
 })

--- a/packages/core-backend/tests/unit/dingtalk-transport-resilience.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-transport-resilience.test.ts
@@ -5,7 +5,10 @@ import {
   DingTalkRequestError,
   DingTalkTimeoutError,
   __resetDingTalkAppAccessTokenCacheForTests,
+  exchangeCodeForUserAccessToken,
   fetchDingTalkAppAccessToken,
+  getDingTalkUserInfoByAuthCode,
+  isDingTalkOutcomeUnknown,
   listDingTalkDepartments,
   sendDingTalkWorkNotification,
 } from '../../src/integrations/dingtalk/client'
@@ -20,19 +23,24 @@ import {
 
 /**
  * Roadmap §7.2 unified DingTalk transport: retry / backoff / rate-limit handling at
- * the ONE seam every client.ts call goes through. The safety matrix under test:
+ * the ONE seam every client.ts call goes through. The tier matrix under test
+ * (business semantics, never inferred from the HTTP verb):
  *
- *   idempotent-read       → retried on network error, HTTP 429, HTTP 5xx, and
- *                           flow-control errcodes in HTTP-200 envelopes
- *   non-idempotent-write  → retried ONLY on network-error-before-response and 429
- *   per-attempt timeout   → never retried (either class)
+ *   read      → retried on network error, HTTP 429, selected 5xx (500/502/503/504),
+ *               and flow-control errcodes in HTTP-200 envelopes
+ *   exchange  → never retried (single-use codes; ambiguous retry burns them)
+ *   send      → never retried; uncertain outcomes (network/timeout/5xx) are marked
+ *               isDingTalkOutcomeUnknown for ledger writers
+ *   (omitted) → defaults to 'exchange', the most conservative tier
  *
  * Error shapes after exhaustion/non-retryable failures must be IDENTICAL to the
- * pre-retry client (callers pattern-match DingTalkRequestError/BusinessError).
+ * pre-retry client (callers pattern-match DingTalkRequestError/BusinessError);
+ * the send-tier marker is additive only.
  */
 
 const MESSAGE_CONFIG = { appKey: 'k', appSecret: 's', agentId: '42' }
 const NOTIFICATION = { userIds: ['u1'], title: 'T', content: 'C' }
+const OAUTH_CONFIG = { clientId: 'cid', clientSecret: 'sec', redirectUri: 'https://app.example.com/cb', corpId: null }
 
 const jsonResponse = (body: unknown, status = 200, headers?: Record<string, string>) =>
   new Response(JSON.stringify(body), {
@@ -45,8 +53,6 @@ const okDeptEnvelope = () => jsonResponse({
   errmsg: 'ok',
   result: [{ dept_id: 1, parent_id: null, name: '技术部' }],
 })
-
-const okSendEnvelope = () => jsonResponse({ errcode: 0, errmsg: 'ok', task_id: 7 })
 
 describe('DingTalk transport resilience (roadmap §7.2)', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
@@ -66,7 +72,7 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
     .map((call) => String(call[0]))
     .filter((message) => message.includes('DingTalk transport retry'))
 
-  describe('idempotent reads', () => {
+  describe("'read' tier (safe reads)", () => {
     it('retries HTTP 429 with a real backoff delay and succeeds on attempt 2', async () => {
       vi.spyOn(Math, 'random').mockReturnValue(1) // full jitter at its ceiling: base=300ms
       const fetchMock = vi.fn()
@@ -81,7 +87,7 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
       expect(departments).toEqual([expect.objectContaining({ id: '1', name: '技术部' })])
       expect(fetchMock).toHaveBeenCalledTimes(2)
       expect(elapsedMs).toBeGreaterThanOrEqual(280) // the backoff actually waited
-      expect(retryLogs()).toEqual([expect.stringMatching(/retry 2\/3 after http_429 \(idempotent-read\)/)])
+      expect(retryLogs()).toEqual([expect.stringMatching(/retry 2\/3 after http_429 \(read\)/)])
     })
 
     it('honors Retry-After (server floor wins over a zero-jitter delay)', async () => {
@@ -113,6 +119,19 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
       expect(retryLogs()).toEqual([expect.stringMatching(/flow_control_errcode_90018/)])
     })
 
+    it('retries a network error', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const fetchMock = vi.fn()
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce(okDeptEnvelope())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await listDingTalkDepartments('tok', '1')
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(retryLogs()).toEqual([expect.stringMatching(/network_error \(read\)/)])
+    })
+
     it('does NOT retry a non-flow-control business errcode (same DingTalkBusinessError shape)', async () => {
       const fetchMock = vi.fn()
         .mockResolvedValue(jsonResponse({ errcode: 40035, errmsg: 'invalid param' }))
@@ -127,7 +146,15 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1)
     })
 
-    it('exhausted retries rethrow the ORIGINAL error shape (statusCode + responseBody intact), one warn per retry', async () => {
+    it('does NOT retry a non-transient 5xx (501 is a contract error, not a blip)', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ message: 'not implemented' }, 501))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(listDingTalkDepartments('tok', '1')).rejects.toMatchObject({ statusCode: 501 })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('exhausted retries rethrow the ORIGINAL error shape (statusCode + responseBody intact), one warn per retry, not outcome-unknown', async () => {
       vi.spyOn(Math, 'random').mockReturnValue(0)
       const fetchFn = vi.fn(async () => jsonResponse({ message: 'unavailable' }, 503)) as unknown as typeof fetch
 
@@ -142,6 +169,7 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
       expect(requestError.statusCode).toBe(503)
       expect(requestError.message).toBe('unavailable')
       expect(requestError.responseBody).toEqual({ message: 'unavailable' })
+      expect(isDingTalkOutcomeUnknown(requestError)).toBe(false) // marker is send-tier only
       expect(fetchFn).toHaveBeenCalledTimes(3) // default maxAttempts
       expect(retryLogs()).toHaveLength(2) // one warn per retry: attempts 2 and 3
     })
@@ -157,47 +185,129 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
     })
   })
 
-  describe('non-idempotent writes (sends)', () => {
-    it('does NOT retry HTTP 5xx (duplicate notification risk) and throws today\'s error shape', async () => {
-      const fetchFn = vi.fn(async () => jsonResponse({ message: 'boom' }, 500)) as unknown as typeof fetch
+  describe("'send' tier (side-effect sends, asyncsend_v2)", () => {
+    it('does NOT resend on network error; the failure is marked outcome-unknown', async () => {
+      const networkError = new TypeError('fetch failed')
+      const fetchFn = vi.fn().mockRejectedValue(networkError) as unknown as typeof fetch
 
-      await expect(sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn }))
-        .rejects.toMatchObject({ name: 'DingTalkRequestError', statusCode: 500, message: 'boom' })
+      let caught: unknown
+      try {
+        await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBe(networkError) // original error object, unwrapped
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(true)
+      expect((caught as { outcomeUnknown?: unknown }).outcomeUnknown).toBe(true)
       expect(fetchFn).toHaveBeenCalledTimes(1)
       expect(retryLogs()).toEqual([])
     })
 
-    it('does NOT retry a flow-control errcode on a send (app layer may have processed it)', async () => {
-      const fetchFn = vi.fn(async () => jsonResponse({ errcode: 90018, errmsg: '流控' })) as unknown as typeof fetch
+    it('does NOT resend on HTTP 5xx; same DingTalkRequestError shape + outcome-unknown marker', async () => {
+      const fetchFn = vi.fn(async () => jsonResponse({ message: 'boom' }, 500)) as unknown as typeof fetch
 
-      await expect(sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn }))
-        .rejects.toBeInstanceOf(DingTalkBusinessError)
+      let caught: unknown
+      try {
+        await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeInstanceOf(DingTalkRequestError)
+      expect(caught).toMatchObject({ statusCode: 500, message: 'boom' })
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(true)
       expect(fetchFn).toHaveBeenCalledTimes(1)
     })
 
-    it('DOES retry a network error before any response was received', async () => {
-      vi.spyOn(Math, 'random').mockReturnValue(0)
-      const fetchFn = vi.fn()
-        .mockRejectedValueOnce(new TypeError('fetch failed'))
-        .mockResolvedValueOnce(okSendEnvelope()) as unknown as typeof fetch
+    it('does NOT resend on a timeout; DingTalkTimeoutError is marked outcome-unknown', async () => {
+      const abortError = new Error('aborted')
+      abortError.name = 'TimeoutError'
+      const fetchFn = vi.fn(async () => { throw abortError }) as unknown as typeof fetch
 
-      const result = await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
-
-      expect(result.taskId).toBe('7')
-      expect(fetchFn).toHaveBeenCalledTimes(2)
-      expect(retryLogs()).toEqual([expect.stringMatching(/network_error \(non-idempotent-write\)/)])
+      let caught: unknown
+      try {
+        await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeInstanceOf(DingTalkTimeoutError)
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(true)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
     })
 
-    it('DOES retry HTTP 429 (rejected before processing)', async () => {
-      vi.spyOn(Math, 'random').mockReturnValue(0)
-      const fetchFn = vi.fn()
-        .mockResolvedValueOnce(jsonResponse({ message: 'limited' }, 429))
-        .mockResolvedValueOnce(okSendEnvelope()) as unknown as typeof fetch
+    it('does NOT retry HTTP 429 in this slice (definite rejection → NOT outcome-unknown)', async () => {
+      const fetchFn = vi.fn(async () => jsonResponse({ message: 'limited' }, 429)) as unknown as typeof fetch
 
-      const result = await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+      let caught: unknown
+      try {
+        await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toMatchObject({ name: 'DingTalkRequestError', statusCode: 429 })
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(false)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
 
-      expect(result.taskId).toBe('7')
-      expect(fetchFn).toHaveBeenCalledTimes(2)
+    it('does NOT retry a flow-control errcode (definite app-layer rejection → NOT outcome-unknown)', async () => {
+      const fetchFn = vi.fn(async () => jsonResponse({ errcode: 90018, errmsg: '流控' })) as unknown as typeof fetch
+
+      let caught: unknown
+      try {
+        await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeInstanceOf(DingTalkBusinessError)
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(false)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("'exchange' tier (one-shot code exchanges)", () => {
+    it('OAuth code exchange is NOT retried on a network error (single-use code)', async () => {
+      const networkError = new TypeError('fetch failed')
+      const fetchMock = vi.fn().mockRejectedValue(networkError)
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(exchangeCodeForUserAccessToken('code-1', OAUTH_CONFIG)).rejects.toBe(networkError)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(retryLogs()).toEqual([])
+    })
+
+    it('OAuth code exchange is NOT retried on HTTP 429/5xx', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ message: 'limited' }, 429))
+      vi.stubGlobal('fetch', fetchMock)
+      await expect(exchangeCodeForUserAccessToken('code-2', OAUTH_CONFIG)).rejects.toMatchObject({ statusCode: 429 })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      const fetchMock5xx = vi.fn().mockResolvedValue(jsonResponse({ message: 'down' }, 503))
+      vi.stubGlobal('fetch', fetchMock5xx)
+      await expect(exchangeCodeForUserAccessToken('code-3', OAUTH_CONFIG)).rejects.toMatchObject({ statusCode: 503 })
+      expect(fetchMock5xx).toHaveBeenCalledTimes(1)
+    })
+
+    it('container authCode exchange is NOT retried on a network error', async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new TypeError('socket hang up'))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(getDingTalkUserInfoByAuthCode('tok', 'auth-code')).rejects.toBeInstanceOf(TypeError)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('default tier is conservative', () => {
+    it("an unclassified transport call defaults to 'exchange' — no retry even on 429", async () => {
+      const fetchFn = vi.fn(async () => jsonResponse({ message: 'limited' }, 429)) as unknown as typeof fetch
+
+      await expect(requestDingTalkTransportJson({
+        input: 'https://oapi.dingtalk.com/topapi/v2/department/listsub?access_token=x',
+        init: { method: 'POST' },
+        fallbackError: 'failed',
+        // kind deliberately omitted
+        envelope: 'oapi',
+        fetchFn,
+      })).rejects.toMatchObject({ statusCode: 429 })
+      expect(fetchFn).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -215,7 +325,7 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
         input: 'https://oapi.dingtalk.com/topapi/v2/department/listsub?access_token=x',
         init: { method: 'POST' },
         fallbackError: 'failed',
-        safety: 'idempotent-read',
+        kind: 'read',
         envelope: 'oapi',
         fetchFn,
         signal: controller.signal,
@@ -235,7 +345,7 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
         input: 'https://oapi.dingtalk.com/gettoken?appkey=x&appsecret=y',
         init: { method: 'GET' },
         fallbackError: 'failed',
-        safety: 'idempotent-read',
+        kind: 'read',
         envelope: 'oapi',
         fetchFn,
         signal: controller.signal,
@@ -258,7 +368,7 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
         input: 'https://oapi.dingtalk.com/topapi/v2/department/listsub?access_token=x',
         init: { method: 'POST' },
         fallbackError: 'failed',
-        safety: 'idempotent-read',
+        kind: 'read',
         envelope: 'oapi',
         fetchFn,
         timeoutMs: 120,
@@ -289,7 +399,7 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
       expect(resolveDingTalkTransportConfig()).toEqual({ maxAttempts: 5, backoffBaseMs: 100, backoffCapMs: 2000 })
     })
 
-    it('DINGTALK_TRANSPORT_MAX_ATTEMPTS=1 disables retries end-to-end', async () => {
+    it('DINGTALK_TRANSPORT_MAX_ATTEMPTS=1 disables read retries end-to-end', async () => {
       vi.stubEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', '1')
       const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ message: 'limited' }, 429))
       vi.stubGlobal('fetch', fetchMock)
@@ -341,6 +451,14 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
       for (const code of [0, 88, 400, 404, 40001, 40035, 60020, 600, 49999]) {
         expect(isDingTalkFlowControlErrcode(code), String(code)).toBe(false)
       }
+    })
+
+    it('isDingTalkOutcomeUnknown is false for unmarked/foreign values', () => {
+      expect(isDingTalkOutcomeUnknown(new Error('plain'))).toBe(false)
+      expect(isDingTalkOutcomeUnknown(null)).toBe(false)
+      expect(isDingTalkOutcomeUnknown(undefined)).toBe(false)
+      expect(isDingTalkOutcomeUnknown('string')).toBe(false)
+      expect(isDingTalkOutcomeUnknown({ outcomeUnknown: true })).toBe(true) // property form
     })
   })
 })

--- a/packages/core-backend/tests/unit/dingtalk-transport-resilience.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-transport-resilience.test.ts
@@ -1,3 +1,6 @@
+import http from 'node:http'
+import { getEventListeners } from 'node:events'
+import type { AddressInfo } from 'node:net'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Logger } from '../../src/core/logger'
 import {
@@ -379,6 +382,205 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
     })
   })
 
+  describe('body-phase timeout — headers arrive, then the BODY stalls (real undici fetch, real server)', () => {
+    // The per-attempt budget must cover the response BODY read, not just the wait
+    // for headers: undici ties the body stream to the request signal, so a stalled
+    // body rejects res.json() with the abort reason once the per-attempt timeout
+    // fires. That rejection must surface as DingTalkTimeoutError with the SAME
+    // per-tier classification as a request-phase timeout — never be swallowed into
+    // a `null` payload (which the oapi envelope would normalize to `{}` and report
+    // as a SUCCESS for a call whose outcome is unknown).
+    let stall: { url: string; requests: { count: number }; close: () => Promise<void> } | null = null
+
+    beforeEach(() => {
+      // tests/setup.ts protectively stubs global fetch with a bare vi.fn(); these
+      // tests exist precisely to exercise the REAL undici fetch body-stream/abort
+      // integration against a real socket — restore it explicitly.
+      vi.unstubAllGlobals()
+    })
+
+    const startStallServer = async (status = 200) => {
+      const requests = { count: 0 }
+      const server = http.createServer((_req, res) => {
+        requests.count += 1
+        res.writeHead(status, { 'Content-Type': 'application/json' })
+        res.write('{"errcode":') // headers + partial body, then stall forever
+      })
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+      const { port } = server.address() as AddressInfo
+      const handle = {
+        url: `http://127.0.0.1:${port}/stall`,
+        requests,
+        close: async () => {
+          server.closeAllConnections()
+          await new Promise<void>((resolve) => server.close(() => resolve()))
+        },
+      }
+      stall = handle
+      return handle
+    }
+
+    afterEach(async () => {
+      if (stall) {
+        await stall.close()
+        stall = null
+      }
+    })
+
+    const transportCall = (url: string, kind: 'read' | 'exchange' | 'send') => requestDingTalkTransportJson({
+      input: url,
+      init: { method: 'POST' },
+      fallbackError: 'failed',
+      kind,
+      envelope: 'oapi',
+      timeoutMs: 200,
+    })
+
+    it("read tier: a body stall past the per-attempt timeout fails as DingTalkTimeoutError — bounded, NOT retried, NOT a silent {} success", async () => {
+      const { url, requests } = await startStallServer()
+
+      const startedAt = Date.now()
+      let caught: unknown
+      try {
+        await transportCall(url, 'read')
+      } catch (error) {
+        caught = error
+      }
+      const elapsedMs = Date.now() - startedAt
+
+      expect(caught).toBeInstanceOf(DingTalkTimeoutError)
+      expect(caught).toMatchObject({ timeoutMs: 200 })
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(false) // marker is send-tier only
+      expect(requests.count).toBe(1) // timeouts are never retried, body-phase included
+      expect(elapsedMs).toBeLessThan(3000) // budget actually bounds the body read
+    })
+
+    it('exchange tier: body stall fails as DingTalkTimeoutError, single attempt', async () => {
+      const { url, requests } = await startStallServer()
+
+      await expect(transportCall(url, 'exchange')).rejects.toBeInstanceOf(DingTalkTimeoutError)
+      expect(requests.count).toBe(1)
+    })
+
+    it('send tier: body stall fails as DingTalkTimeoutError, marked outcome-unknown (the send may have executed)', async () => {
+      const { url, requests } = await startStallServer()
+
+      let caught: unknown
+      try {
+        await transportCall(url, 'send')
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(DingTalkTimeoutError)
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(true)
+      expect(requests.count).toBe(1) // never resent
+    })
+
+    it('a body stall on a NON-ok response is still a timeout (read tier: not misclassified as retryable http_500)', async () => {
+      const { url, requests } = await startStallServer(500)
+
+      await expect(transportCall(url, 'read')).rejects.toBeInstanceOf(DingTalkTimeoutError)
+      expect(requests.count).toBe(1) // http_500 would have retried; timeout must not
+    })
+  })
+
+  describe('pre-Node-20.3 AbortSignal.any fallback (composition + cleanup)', () => {
+    // CI's test(18.x) lane exercises this path only incidentally; force it here so
+    // the composition itself is pinned: with AbortSignal.any absent, the per-attempt
+    // timeout must STILL fire when a caller signal is present (the naive fallback of
+    // "just use the caller signal" silently drops the timeout), the caller signal
+    // must still abort the in-flight attempt, and the manual composition must not
+    // leak abort listeners on the long-lived caller signal across attempts.
+    const abortSignalStatics = AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }
+    const originalAny = abortSignalStatics.any
+
+    beforeEach(() => {
+      abortSignalStatics.any = undefined
+    })
+
+    afterEach(() => {
+      abortSignalStatics.any = originalAny
+    })
+
+    /** Resolves nothing: hangs until the composed signal aborts, then rejects with its reason. */
+    const hangingFetch = (guardMs: number) => vi.fn((_input: unknown, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return reject(new Error('no signal reached fetch'))
+      if (signal.aborted) return reject(signal.reason)
+      const guard = setTimeout(() => reject(new Error('composed signal never fired under the fallback')), guardMs)
+      signal.addEventListener('abort', () => {
+        clearTimeout(guard)
+        reject(signal.reason)
+      }, { once: true })
+    })) as unknown as typeof fetch
+
+    it('per-attempt timeout still fires when a caller signal is present (naive caller-signal-only fallback drops it)', async () => {
+      const controller = new AbortController() // live, never aborted
+      const fetchFn = hangingFetch(1500)
+
+      const startedAt = Date.now()
+      await expect(requestDingTalkTransportJson({
+        input: 'https://oapi.dingtalk.com/gettoken?appkey=x&appsecret=y',
+        init: { method: 'GET' },
+        fallbackError: 'failed',
+        kind: 'exchange',
+        envelope: 'oapi',
+        fetchFn,
+        timeoutMs: 120,
+        signal: controller.signal,
+      })).rejects.toBeInstanceOf(DingTalkTimeoutError)
+
+      expect(Date.now() - startedAt).toBeLessThan(1200) // timeout fired, not the guard
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('caller abort still cancels the in-flight attempt under the fallback', async () => {
+      const controller = new AbortController()
+      const fetchFn = hangingFetch(3000)
+      setTimeout(() => controller.abort(), 60)
+
+      const startedAt = Date.now()
+      await expect(requestDingTalkTransportJson({
+        input: 'https://oapi.dingtalk.com/gettoken?appkey=x&appsecret=y',
+        init: { method: 'GET' },
+        fallbackError: 'failed',
+        kind: 'read',
+        envelope: 'oapi',
+        fetchFn,
+        timeoutMs: 5000, // far beyond the caller abort — the caller must win
+        signal: controller.signal,
+      })).rejects.toBeInstanceOf(DingTalkTimeoutError)
+
+      expect(Date.now() - startedAt).toBeLessThan(2000)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('detaches its abort listeners from the long-lived caller signal once each attempt settles (no leak)', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0) // zero backoff between attempts
+      const controller = new AbortController() // long-lived, never aborted
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ message: 'limited' }, 429))
+        .mockResolvedValueOnce(okDeptEnvelope()) as unknown as typeof fetch
+
+      const payload = await requestDingTalkTransportJson({
+        input: 'https://oapi.dingtalk.com/topapi/v2/department/listsub?access_token=x',
+        init: { method: 'POST' },
+        fallbackError: 'failed',
+        kind: 'read',
+        envelope: 'oapi',
+        fetchFn: fetchMock,
+        signal: controller.signal,
+      })
+
+      expect(payload.errcode).toBe(0)
+      expect(fetchMock).toHaveBeenCalledTimes(2) // two attempts BOTH composed against the caller signal
+      // once-listeners that never fired are NOT auto-removed — without explicit
+      // dispose-on-settle each attempt would leave one behind on the caller signal.
+      expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
+    })
+  })
+
   describe('env knobs (DINGTALK_TRANSPORT_*)', () => {
     it('falls back to defaults on invalid values', () => {
       vi.stubEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', 'abc')
@@ -411,7 +613,10 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
     it('a raised DINGTALK_TRANSPORT_MAX_ATTEMPTS bounds the loop exactly', async () => {
       vi.stubEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', '2')
       vi.spyOn(Math, 'random').mockReturnValue(0)
-      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ message: 'down' }, 503))
+      // Fresh Response per attempt — a real fetch never resolves an already-consumed
+      // body, and since the body-timeout fix the transport no longer swallows the
+      // double-read TypeError a shared mockResolvedValue Response would produce.
+      const fetchMock = vi.fn(async () => jsonResponse({ message: 'down' }, 503))
       vi.stubGlobal('fetch', fetchMock)
 
       await expect(listDingTalkDepartments('tok', '1')).rejects.toMatchObject({ statusCode: 503 })

--- a/packages/core-backend/tests/unit/dingtalk-transport-resilience.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-transport-resilience.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Logger } from '../../src/core/logger'
 import {
   DingTalkBusinessError,
+  DingTalkMalformedResponseError,
   DingTalkRequestError,
   DingTalkTimeoutError,
   __resetDingTalkAppAccessTokenCacheForTests,
@@ -311,6 +312,153 @@ describe('DingTalk transport resilience (roadmap §7.2)', () => {
         fetchFn,
       })).rejects.toMatchObject({ statusCode: 429 })
       expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('malformed 2xx responses — NEVER success (PR #4046 Phase B P1)', () => {
+    // Pre-fix: readJson swallowed a SyntaxError into `null` and the ok-path normalized
+    // `null` → `{}` → SUCCESS. An HTTP 200 whose body is HTML, empty, truncated JSON, a bare
+    // primitive, or (for oapi envelopes) a JSON object MISSING the errcode/code discriminator
+    // must never report success. Tier behaviors are pinned SEPARATELY (owner guardrail):
+    // read = retryable within the existing budget; exchange = never retried; send = never
+    // resent + outcome-unknown marker.
+    const MALFORMED_200_BODIES: Array<[label: string, body: string, contentType: string]> = [
+      ['HTML error page', '<html><body>Bad Gateway</body></html>', 'text/html'],
+      ['empty body', '', 'application/json'],
+      ['truncated JSON', '{"errcode": 0, "task_id"', 'application/json'],
+      ['bare primitive', '42', 'application/json'],
+      ['JSON without errcode/code discriminator', '{"task_id": 424242}', 'application/json'],
+    ]
+    const malformedResponse = (body: string, contentType: string) =>
+      new Response(body, { status: 200, headers: { 'Content-Type': contentType } })
+
+    it("send tier: every malformed-200 shape throws DingTalkMalformedResponseError, marked outcome-unknown, exactly ONE fetch (no resend)", async () => {
+      for (const [label, body, contentType] of MALFORMED_200_BODIES) {
+        const fetchFn = vi.fn(async () => malformedResponse(body, contentType)) as unknown as typeof fetch
+        let caught: unknown
+        try {
+          await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+        } catch (error) {
+          caught = error
+        }
+        expect({ label, name: (caught as Error | undefined)?.name }).toEqual({ label, name: 'DingTalkMalformedResponseError' })
+        expect({ label, outcomeUnknown: isDingTalkOutcomeUnknown(caught) }).toEqual({ label, outcomeUnknown: true })
+        expect({ label, calls: (fetchFn as ReturnType<typeof vi.fn>).mock.calls.length }).toEqual({ label, calls: 1 })
+      }
+      expect(retryLogs()).toEqual([])
+    })
+
+    it('read tier: every malformed-200 shape retries within the EXISTING attempt budget, then throws (never success, never outcome-unknown)', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0) // zero jitter — no real sleeping
+      for (const [label, body, contentType] of MALFORMED_200_BODIES) {
+        warnSpy.mockClear()
+        const fetchMock = vi.fn(async () => malformedResponse(body, contentType))
+        vi.stubGlobal('fetch', fetchMock)
+        let caught: unknown
+        try {
+          await listDingTalkDepartments('tok', '1')
+        } catch (error) {
+          caught = error
+        }
+        expect({ label, name: (caught as Error | undefined)?.name }).toEqual({ label, name: 'DingTalkMalformedResponseError' })
+        expect({ label, outcomeUnknown: isDingTalkOutcomeUnknown(caught) }).toEqual({ label, outcomeUnknown: false })
+        // default budget: 3 attempts (2 retries) — malformed responses are retryable-on-read
+        expect({ label, calls: fetchMock.mock.calls.length }).toEqual({ label, calls: DINGTALK_TRANSPORT_DEFAULTS.maxAttempts })
+        expect({ label, retries: retryLogs().length }).toEqual({ label, retries: DINGTALK_TRANSPORT_DEFAULTS.maxAttempts - 1 })
+      }
+    })
+
+    it('read tier: a malformed body on attempt 1 recovers when attempt 2 returns a valid envelope (retry is real, not a rethrow loop)', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(malformedResponse('<html>oops</html>', 'text/html'))
+        .mockResolvedValueOnce(okDeptEnvelope())
+      vi.stubGlobal('fetch', fetchMock)
+      const departments = await listDingTalkDepartments('tok', '1')
+      expect(departments).toEqual([expect.objectContaining({ id: '1', name: '技术部' })])
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('exchange tier: every malformed-200 shape throws after exactly ONE fetch (never retried, never outcome-unknown)', async () => {
+      for (const [label, body, contentType] of MALFORMED_200_BODIES) {
+        const fetchMock = vi.fn(async () => malformedResponse(body, contentType))
+        vi.stubGlobal('fetch', fetchMock)
+        let caught: unknown
+        try {
+          await getDingTalkUserInfoByAuthCode('tok', 'auth-code')
+        } catch (error) {
+          caught = error
+        }
+        expect({ label, name: (caught as Error | undefined)?.name }).toEqual({ label, name: 'DingTalkMalformedResponseError' })
+        expect({ label, outcomeUnknown: isDingTalkOutcomeUnknown(caught) }).toEqual({ label, outcomeUnknown: false })
+        expect({ label, calls: fetchMock.mock.calls.length }).toEqual({ label, calls: 1 })
+      }
+      expect(retryLogs()).toEqual([])
+    })
+
+    it("envelope 'none' (v1.0, no errcode contract): unparseable body is malformed, but a JSON object WITHOUT errcode is still SUCCESS", async () => {
+      // The discriminator requirement is oapi-only — v1.0 endpoints (oauth2/userAccessToken,
+      // contact/users/me) have no errcode field on success, so requiring one there would break
+      // every healthy call. Unparseable bodies are still malformed for BOTH envelope kinds.
+      const malformedFetch = vi.fn(async () => malformedResponse('', 'application/json')) as unknown as typeof fetch
+      await expect(requestDingTalkTransportJson({
+        input: 'https://api.dingtalk.com/v1.0/contact/users/me',
+        init: { method: 'GET' },
+        fallbackError: 'failed',
+        kind: 'exchange',
+        envelope: 'none',
+        fetchFn: malformedFetch,
+      })).rejects.toMatchObject({ name: 'DingTalkMalformedResponseError' })
+      expect(malformedFetch).toHaveBeenCalledTimes(1)
+
+      const okFetch = vi.fn(async () => jsonResponse({ accessToken: 'v1-token', expireIn: 7200 })) as unknown as typeof fetch
+      await expect(requestDingTalkTransportJson({
+        input: 'https://api.dingtalk.com/v1.0/oauth2/userAccessToken',
+        init: { method: 'POST' },
+        fallbackError: 'failed',
+        kind: 'exchange',
+        envelope: 'none',
+        fetchFn: okFetch,
+      })).resolves.toMatchObject({ accessToken: 'v1-token' })
+      expect(okFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('a top-level JSON array on an oapi 200 is malformed (arrays are not envelopes)', async () => {
+      const fetchFn = vi.fn(async () => jsonResponse([{ task_id: 1 }])) as unknown as typeof fetch
+      let caught: unknown
+      try {
+        await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+      } catch (error) {
+        caught = error
+      }
+      expect((caught as Error | undefined)?.name).toBe('DingTalkMalformedResponseError')
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(true)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('malformed-200 on a NON-ok status is untouched: a 500 with an HTML body still throws DingTalkRequestError(500)', async () => {
+      // Guard the guard: the malformed classification applies to the OK path only; error
+      // statuses keep their original shape (responseBody: null) and tiering.
+      const fetchFn = vi.fn(async () => new Response('<html>boom</html>', { status: 500, headers: { 'Content-Type': 'text/html' } })) as unknown as typeof fetch
+      let caught: unknown
+      try {
+        await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeInstanceOf(DingTalkRequestError)
+      expect(caught).toMatchObject({ statusCode: 500, responseBody: null })
+      expect(isDingTalkOutcomeUnknown(caught)).toBe(true) // send-tier 5xx stays outcome-unknown
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('DingTalkMalformedResponseError message carries NO body content (a garbled body could contain anything)', () => {
+      const err = new DingTalkMalformedResponseError('unparseable_body', 200, 'Failed to send')
+      expect(err.message).not.toContain('<html>')
+      expect(err.message).toContain('unusable')
+      expect(err.httpStatus).toBe(200)
+      const missing = new DingTalkMalformedResponseError('missing_errcode', 200, 'Failed to send')
+      expect(missing.message).toContain('errcode')
     })
   })
 

--- a/packages/core-backend/tests/unit/dingtalk-transport-resilience.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-transport-resilience.test.ts
@@ -1,0 +1,346 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Logger } from '../../src/core/logger'
+import {
+  DingTalkBusinessError,
+  DingTalkRequestError,
+  DingTalkTimeoutError,
+  __resetDingTalkAppAccessTokenCacheForTests,
+  fetchDingTalkAppAccessToken,
+  listDingTalkDepartments,
+  sendDingTalkWorkNotification,
+} from '../../src/integrations/dingtalk/client'
+import {
+  DINGTALK_TRANSPORT_DEFAULTS,
+  computeDingTalkRetryDelayMs,
+  isDingTalkFlowControlErrcode,
+  parseRetryAfterMs,
+  requestDingTalkTransportJson,
+  resolveDingTalkTransportConfig,
+} from '../../src/integrations/dingtalk/transport'
+
+/**
+ * Roadmap §7.2 unified DingTalk transport: retry / backoff / rate-limit handling at
+ * the ONE seam every client.ts call goes through. The safety matrix under test:
+ *
+ *   idempotent-read       → retried on network error, HTTP 429, HTTP 5xx, and
+ *                           flow-control errcodes in HTTP-200 envelopes
+ *   non-idempotent-write  → retried ONLY on network-error-before-response and 429
+ *   per-attempt timeout   → never retried (either class)
+ *
+ * Error shapes after exhaustion/non-retryable failures must be IDENTICAL to the
+ * pre-retry client (callers pattern-match DingTalkRequestError/BusinessError).
+ */
+
+const MESSAGE_CONFIG = { appKey: 'k', appSecret: 's', agentId: '42' }
+const NOTIFICATION = { userIds: ['u1'], title: 'T', content: 'C' }
+
+const jsonResponse = (body: unknown, status = 200, headers?: Record<string, string>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+
+const okDeptEnvelope = () => jsonResponse({
+  errcode: 0,
+  errmsg: 'ok',
+  result: [{ dept_id: 1, parent_id: null, name: '技术部' }],
+})
+
+const okSendEnvelope = () => jsonResponse({ errcode: 0, errmsg: 'ok', task_id: 7 })
+
+describe('DingTalk transport resilience (roadmap §7.2)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined) as ReturnType<typeof vi.spyOn>
+  })
+
+  afterEach(() => {
+    __resetDingTalkAppAccessTokenCacheForTests()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  const retryLogs = () => warnSpy.mock.calls
+    .map((call) => String(call[0]))
+    .filter((message) => message.includes('DingTalk transport retry'))
+
+  describe('idempotent reads', () => {
+    it('retries HTTP 429 with a real backoff delay and succeeds on attempt 2', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(1) // full jitter at its ceiling: base=300ms
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ message: 'too many requests' }, 429))
+        .mockResolvedValueOnce(okDeptEnvelope())
+      vi.stubGlobal('fetch', fetchMock)
+
+      const startedAt = Date.now()
+      const departments = await listDingTalkDepartments('tok', '1')
+      const elapsedMs = Date.now() - startedAt
+
+      expect(departments).toEqual([expect.objectContaining({ id: '1', name: '技术部' })])
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(elapsedMs).toBeGreaterThanOrEqual(280) // the backoff actually waited
+      expect(retryLogs()).toEqual([expect.stringMatching(/retry 2\/3 after http_429 \(idempotent-read\)/)])
+    })
+
+    it('honors Retry-After (server floor wins over a zero-jitter delay)', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0) // jitter alone would back off 0ms
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ message: 'limited' }, 429, { 'Retry-After': '1' }))
+        .mockResolvedValueOnce(okDeptEnvelope())
+      vi.stubGlobal('fetch', fetchMock)
+
+      const startedAt = Date.now()
+      await listDingTalkDepartments('tok', '1')
+      const elapsedMs = Date.now() - startedAt
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(elapsedMs).toBeGreaterThanOrEqual(950)
+    })
+
+    it('retries a flow-control errcode inside an HTTP-200 envelope', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ errcode: 90018, errmsg: '触发流控' }))
+        .mockResolvedValueOnce(okDeptEnvelope())
+      vi.stubGlobal('fetch', fetchMock)
+
+      const departments = await listDingTalkDepartments('tok', '1')
+
+      expect(departments).toHaveLength(1)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(retryLogs()).toEqual([expect.stringMatching(/flow_control_errcode_90018/)])
+    })
+
+    it('does NOT retry a non-flow-control business errcode (same DingTalkBusinessError shape)', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValue(jsonResponse({ errcode: 40035, errmsg: 'invalid param' }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(listDingTalkDepartments('tok', '1')).rejects.toMatchObject({
+        name: 'DingTalkBusinessError',
+        // errmsg is not a normalizeErrorMessage candidate → fallback text (pre-retry behavior)
+        message: 'Failed to list DingTalk departments',
+        responseBody: expect.objectContaining({ errcode: 40035 }),
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('exhausted retries rethrow the ORIGINAL error shape (statusCode + responseBody intact), one warn per retry', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const fetchFn = vi.fn(async () => jsonResponse({ message: 'unavailable' }, 503)) as unknown as typeof fetch
+
+      let caught: unknown
+      try {
+        await fetchDingTalkAppAccessToken({ appKey: 'k', appSecret: 's' }, { fetchFn })
+      } catch (error) {
+        caught = error
+      }
+      const requestError = caught as DingTalkRequestError
+      expect(requestError).toBeInstanceOf(DingTalkRequestError)
+      expect(requestError.statusCode).toBe(503)
+      expect(requestError.message).toBe('unavailable')
+      expect(requestError.responseBody).toEqual({ message: 'unavailable' })
+      expect(fetchFn).toHaveBeenCalledTimes(3) // default maxAttempts
+      expect(retryLogs()).toHaveLength(2) // one warn per retry: attempts 2 and 3
+    })
+
+    it('does NOT retry a per-attempt timeout (H06 wall-time bound is preserved)', async () => {
+      const abortError = new Error('aborted')
+      abortError.name = 'TimeoutError'
+      const fetchFn = vi.fn(async () => { throw abortError }) as unknown as typeof fetch
+
+      await expect(fetchDingTalkAppAccessToken({ appKey: 'k', appSecret: 's' }, { fetchFn }))
+        .rejects.toBeInstanceOf(DingTalkTimeoutError)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('non-idempotent writes (sends)', () => {
+    it('does NOT retry HTTP 5xx (duplicate notification risk) and throws today\'s error shape', async () => {
+      const fetchFn = vi.fn(async () => jsonResponse({ message: 'boom' }, 500)) as unknown as typeof fetch
+
+      await expect(sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn }))
+        .rejects.toMatchObject({ name: 'DingTalkRequestError', statusCode: 500, message: 'boom' })
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+      expect(retryLogs()).toEqual([])
+    })
+
+    it('does NOT retry a flow-control errcode on a send (app layer may have processed it)', async () => {
+      const fetchFn = vi.fn(async () => jsonResponse({ errcode: 90018, errmsg: '流控' })) as unknown as typeof fetch
+
+      await expect(sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn }))
+        .rejects.toBeInstanceOf(DingTalkBusinessError)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('DOES retry a network error before any response was received', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const fetchFn = vi.fn()
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce(okSendEnvelope()) as unknown as typeof fetch
+
+      const result = await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+
+      expect(result.taskId).toBe('7')
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+      expect(retryLogs()).toEqual([expect.stringMatching(/network_error \(non-idempotent-write\)/)])
+    })
+
+    it('DOES retry HTTP 429 (rejected before processing)', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const fetchFn = vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ message: 'limited' }, 429))
+        .mockResolvedValueOnce(okSendEnvelope()) as unknown as typeof fetch
+
+      const result = await sendDingTalkWorkNotification('tok', NOTIFICATION, MESSAGE_CONFIG, { fetchFn })
+
+      expect(result.taskId).toBe('7')
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('abort composition (H06 per-attempt timeout + overall signal)', () => {
+    it('caller abort mid-backoff exits immediately (no residual sleep, no further attempts)', async () => {
+      vi.stubEnv('DINGTALK_TRANSPORT_BACKOFF_BASE_MS', '3000')
+      vi.stubEnv('DINGTALK_TRANSPORT_BACKOFF_CAP_MS', '3000')
+      vi.spyOn(Math, 'random').mockReturnValue(1) // deterministic 3000ms backoff
+      const controller = new AbortController()
+      const fetchFn = vi.fn(async () => jsonResponse({ message: 'limited' }, 429)) as unknown as typeof fetch
+
+      const startedAt = Date.now()
+      setTimeout(() => controller.abort(), 50)
+      await expect(requestDingTalkTransportJson({
+        input: 'https://oapi.dingtalk.com/topapi/v2/department/listsub?access_token=x',
+        init: { method: 'POST' },
+        fallbackError: 'failed',
+        safety: 'idempotent-read',
+        envelope: 'oapi',
+        fetchFn,
+        signal: controller.signal,
+      })).rejects.toBeInstanceOf(DingTalkTimeoutError)
+      const elapsedMs = Date.now() - startedAt
+
+      expect(elapsedMs).toBeLessThan(1500) // exited the 3000ms backoff early
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('an already-aborted caller signal short-circuits before any fetch', async () => {
+      const controller = new AbortController()
+      controller.abort()
+      const fetchFn = vi.fn() as unknown as typeof fetch
+
+      await expect(requestDingTalkTransportJson({
+        input: 'https://oapi.dingtalk.com/gettoken?appkey=x&appsecret=y',
+        init: { method: 'GET' },
+        fallbackError: 'failed',
+        safety: 'idempotent-read',
+        envelope: 'oapi',
+        fetchFn,
+        signal: controller.signal,
+      })).rejects.toBeInstanceOf(DingTalkTimeoutError)
+      expect(fetchFn).not.toHaveBeenCalled()
+    })
+
+    it('every attempt gets its own FRESH timeout signal (a retry must not start with a spent budget)', async () => {
+      // timeout (120ms) shorter than the backoff (300ms): a signal created once and
+      // reused across attempts would already be aborted when attempt 2 fires.
+      vi.spyOn(Math, 'random').mockReturnValue(1)
+      const seenAborted: boolean[] = []
+      const fetchFn = vi.fn(async (_input: unknown, init?: RequestInit) => {
+        seenAborted.push(init?.signal?.aborted ?? true)
+        if (seenAborted.length === 1) return jsonResponse({ message: 'limited' }, 429)
+        return okDeptEnvelope()
+      }) as unknown as typeof fetch
+
+      const payload = await requestDingTalkTransportJson({
+        input: 'https://oapi.dingtalk.com/topapi/v2/department/listsub?access_token=x',
+        init: { method: 'POST' },
+        fallbackError: 'failed',
+        safety: 'idempotent-read',
+        envelope: 'oapi',
+        fetchFn,
+        timeoutMs: 120,
+      })
+
+      expect(payload.errcode).toBe(0)
+      expect(seenAborted).toEqual([false, false])
+    })
+  })
+
+  describe('env knobs (DINGTALK_TRANSPORT_*)', () => {
+    it('falls back to defaults on invalid values', () => {
+      vi.stubEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', 'abc')
+      vi.stubEnv('DINGTALK_TRANSPORT_BACKOFF_BASE_MS', '-5')
+      vi.stubEnv('DINGTALK_TRANSPORT_BACKOFF_CAP_MS', '0')
+      expect(resolveDingTalkTransportConfig()).toEqual(DINGTALK_TRANSPORT_DEFAULTS)
+
+      vi.stubEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', '')
+      vi.stubEnv('DINGTALK_TRANSPORT_BACKOFF_BASE_MS', '   ')
+      vi.stubEnv('DINGTALK_TRANSPORT_BACKOFF_CAP_MS', 'Infinity')
+      expect(resolveDingTalkTransportConfig()).toEqual(DINGTALK_TRANSPORT_DEFAULTS)
+    })
+
+    it('applies valid overrides (fractions truncated)', () => {
+      vi.stubEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', '5')
+      vi.stubEnv('DINGTALK_TRANSPORT_BACKOFF_BASE_MS', '100.9')
+      vi.stubEnv('DINGTALK_TRANSPORT_BACKOFF_CAP_MS', '2000')
+      expect(resolveDingTalkTransportConfig()).toEqual({ maxAttempts: 5, backoffBaseMs: 100, backoffCapMs: 2000 })
+    })
+
+    it('DINGTALK_TRANSPORT_MAX_ATTEMPTS=1 disables retries end-to-end', async () => {
+      vi.stubEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', '1')
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ message: 'limited' }, 429))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(listDingTalkDepartments('tok', '1')).rejects.toMatchObject({ statusCode: 429 })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('a raised DINGTALK_TRANSPORT_MAX_ATTEMPTS bounds the loop exactly', async () => {
+      vi.stubEnv('DINGTALK_TRANSPORT_MAX_ATTEMPTS', '2')
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ message: 'down' }, 503))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(listDingTalkDepartments('tok', '1')).rejects.toMatchObject({ statusCode: 503 })
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('pure helpers', () => {
+    it('computeDingTalkRetryDelayMs: Retry-After overrides jitter and is clamped to the cap', () => {
+      const config = { maxAttempts: 3, backoffBaseMs: 300, backoffCapMs: 5000 }
+      expect(computeDingTalkRetryDelayMs(1, config, 2000, () => 0)).toBe(2000)
+      expect(computeDingTalkRetryDelayMs(1, config, 60_000, () => 0)).toBe(5000)
+      expect(computeDingTalkRetryDelayMs(1, config, null, () => 1)).toBe(300)
+      expect(computeDingTalkRetryDelayMs(2, config, null, () => 1)).toBe(600)
+      expect(computeDingTalkRetryDelayMs(6, config, null, () => 1)).toBe(5000) // cap
+      expect(computeDingTalkRetryDelayMs(1, config, null, () => 0)).toBe(0) // full jitter floor
+    })
+
+    it('parseRetryAfterMs: seconds, HTTP-date, and garbage', () => {
+      expect(parseRetryAfterMs('2')).toBe(2000)
+      expect(parseRetryAfterMs('0')).toBe(0)
+      expect(parseRetryAfterMs('-1')).toBeNull()
+      expect(parseRetryAfterMs('garbage')).toBeNull()
+      expect(parseRetryAfterMs(null)).toBeNull()
+      expect(parseRetryAfterMs(undefined)).toBeNull()
+      const inThreeSeconds = new Date(Date.now() + 3000).toUTCString()
+      const parsed = parseRetryAfterMs(inThreeSeconds)
+      expect(parsed).not.toBeNull()
+      expect(parsed as number).toBeGreaterThanOrEqual(1500)
+      expect(parsed as number).toBeLessThanOrEqual(3100)
+    })
+
+    it('isDingTalkFlowControlErrcode matches the documented + delivery-layer-parity set only', () => {
+      for (const code of [90018, -1, 408, 429, 500, 503, 599, 50001]) {
+        expect(isDingTalkFlowControlErrcode(code), String(code)).toBe(true)
+      }
+      for (const code of [0, 88, 400, 404, 40001, 40035, 60020, 600, 49999]) {
+        expect(isDingTalkFlowControlErrcode(code), String(code)).toBe(false)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Phase A — What / why

Roadmap §7.2 (docs/development/dingtalk-sync-integrated-roadmap-20260708.md, never ticketed — section text is the spec): `packages/core-backend/src/integrations/dingtalk/client.ts` had ZERO retry/backoff/rate-limit handling. This adds ONE shared transport seam — `packages/core-backend/src/integrations/dingtalk/transport.ts` — that every DingTalk outbound call in client.ts funnels through. No per-call-site retry sprinkling.

**Mid-lane design revision (owner, supersedes the brief's constraint #2):** classification is by BUSINESS SEMANTICS (`kind: 'read' | 'exchange' | 'send'`), never by HTTP verb, because a fetch timeout/disconnect only proves the client saw no response — not that DingTalk didn't execute the request. The first commit (0bf550944) implemented the original two-class matrix; the second (906e88a9a) reworks it to the ratified tiering.

### The tier matrix (explicit at all 10 call sites in client.ts)

| Tier | Call sites | Retries |
|---|---|---|
| `'read'` | gettoken, contact/users/me, department listsub/get, user list/get | network error, HTTP 429, selected transient 5xx (500/502/503/504), flow-control errcodes in HTTP-200 envelopes |
| `'exchange'` | OAuth code exchange, E1 container authCode | **never** — single-use codes; ambiguous retry burns/double-redeems them |
| `'send'` | asyncsend_v2 markdown + action_card | **never auto-resent**; network/timeout/5xx failures rethrown marked `outcomeUnknown: true` (+ exported `isDingTalkOutcomeUnknown` guard) so ledger writers can record `outcome_unknown`. A lost response has no `task_id`, so DingTalk's async-send result query cannot serve as an idempotency key (stated in the code comment at the classification). 429-on-send auto-retry deliberately NOT enabled in this slice — needs endpoint-contract confirmation first |
| (omitted) | — | defaults to `'exchange'`, the most conservative tier |

### Mechanics

- Exponential backoff + **full jitter** (`random() * min(cap, base * 2^(attempt-1))`); `Retry-After` honored (seconds or HTTP-date), clamped to the cap so a huge header can't stall a sync worker.
- Env knobs `DINGTALK_TRANSPORT_MAX_ATTEMPTS` / `_BACKOFF_BASE_MS` / `_BACKOFF_CAP_MS` (defaults 3 / 300ms / 5000ms); invalid values fall back to defaults (negative tests included). Documented in `.env.example`.
- **DT-HARDEN-06 preserved and composed per attempt**: each attempt gets its OWN fresh `AbortSignal.timeout`; a caller-supplied overall signal (`options.signal` / `init.signal`, composed via `AbortSignal.any`) aborts the in-flight attempt AND any backoff sleep immediately. Per-attempt timeouts are never retried (wall-time bound preserved).
- Flow-control errcode set anchored on DingTalk's documented `90018` family / `-1` system-busy PLUS parity with what the repo already treats as retryable (`AttendanceNotificationDeliveryWorker.isRetryableDingTalkErrorCode`: 408/429/5xx-echo/50001) — not invented.
- **Zero error-shape change**: exhausted/non-retryable failures rethrow the ORIGINAL `DingTalkRequestError` / `DingTalkBusinessError` / `DingTalkTimeoutError` / raw network error. Callers pattern-match these (routes/auth.ts:1295ff, automation-executor.ts:1850/3125, AttendanceNotificationDeliveryWorker classifiers) — verified by reading them; error classes physically moved to transport.ts and re-exported from client.ts (single class definition, `instanceof` identity preserved).
- Observability: exactly one `warn` per retry (attempt count + reason + tier + delay); **no URLs logged** (gettoken query carries the app secret). No new tables.
- **In-process rate limiting is BEST-EFFORT only** — replicas do not share a quota; multi-replica shared throttling (per app/corp, Redis or equivalent) is out of scope, listed as follow-up.

## Test evidence

- New `tests/unit/dingtalk-transport-resilience.test.ts`: 28 tests (read retry/backoff/Retry-After/flow-control/501-boundary/exhaustion shape; send no-resend + outcome-unknown markers; exchange no-retry; conservative default; abort composition ×3; env knobs ×4; pure helpers ×4). Mock fetch at the seam; real timing asserted with stubbed `Math.random` (backoff ≥280ms, Retry-After ≥950ms, abort exits <1500ms of a 3000ms backoff).
- H06 suite `tests/unit/dingtalk-request-timeout.test.ts`: 5/5 green unchanged (one stale implementation comment updated to point at the transport seam).
- Full core-backend unit suite: **346 files / 4670 tests, all green** (`CI=true npx vitest run tests/unit`).
- `npx tsc --noEmit -p tsconfig.json`: clean.

## Mutation table (protocol: real impl committed first; each mutation applied → run → recorded → restored via git checkout)

| # | Mutation | Result |
|---|---|---|
| M1 | Retry loop removed (always throw on first failure) | **RED ×8**: 429-retry, Retry-After, flow-control-retry, network-retry, exhausted-attempts(3), abort-mid-backoff, per-attempt freshness, maxAttempts=2 bound |
| M2 | Sends classified like reads (auto-resend flip) | **RED ×4**: send network-error / 5xx / 429 / flow-control all detect extra fetch calls |
| M3 | Retry-After ignored | **RED ×2**: end-to-end honor test (elapsed <950ms) + pure-helper test |
| M4 | Per-attempt signal hoisted out of the loop (composed once, reused) | **RED ×1**: freshness test (`seenAborted` `[false,true]`); **H06 suite stayed GREEN 5/5** — proves the pre-existing tests alone would NOT catch this and the new test is load-bearing |
| M5 | Backoff sleep ignores the abort signal | **RED ×1**: abort-mid-backoff (elapsed ~3000ms > 1500ms bound) |
| M6 | Flow-control errcode not retried on reads | **RED ×1** |
| M7 | Exchange tier retries like reads | **RED ×4**: 3 exchange tests + conservative-default test |
| M8 | Unclassified default flips `'exchange'` → `'read'` | **RED ×1**: conservative-default test |
| M9 | Outcome-unknown marking dropped | **RED ×3**: send network / 5xx / timeout marker assertions |

## Honest gaps (not proven / deliberately out of scope)

1. ~~**Ledger writers are not wired to `isDingTalkOutcomeUnknown` in this PR**~~ — **CLOSED by Phase B below**: all three send ledgers (approval-card, person-delivery telemetry, attendance outbox) now consume the marker and record `outcome_unknown` without resending.
2. §7.2 acceptance "repeated flow-control failures produce clear run stats and alerts" is only partially served here (warn logs + preserved error shapes feeding existing run stats); run-stat/alert enrichment belongs to §7.4 / the directory-sync lane.
3. 429-on-send auto-retry NOT enabled — pending endpoint-contract confirmation (owner instruction).
4. Retry-After beyond the backoff cap is clamped (bounded stall) — a deviation from a strict "honor" reading, documented in code.
5. The 408/429/5xx/50001 errcode-echo portion of the flow-control set is codebase-parity-anchored (delivery worker), not DingTalk-doc-anchored; only 90018/-1 are the documented codes.
6. `AbortSignal.any` pre-Node-20.3 fallback (caller signal wins, no per-attempt timeout) is structurally present but untested — CI runs Node 20.x where `any` exists.
7. Timeouts are never retried on ANY tier (including idempotent reads) — conservative reading of the spec; preserves the H06 wall-time bound. A read-tier timeout retry would be safe but multiplies hung-endpoint wall time 3×.
8. Unit tests mock fetch at the seam; no real DingTalk endpoint or end-to-end flaky-sync exercise. Directory sync gets read-tier retries transparently via `fetchDingTalkAppAccessToken`/list/get calls (directory-sync.ts untouched per lane boundary).

## Behavior changes flagged for ops

- Reads now retried up to 3× with jittered backoff (env-tunable): a persistently failing endpoint costs up to ~2 extra attempts + ≤10s backoff per call in sync paths.
- Send failures on network/timeout/5xx now carry an enumerable `outcomeUnknown: true` property on the (otherwise unchanged) error — visible in serialized error dumps.
- A caller-supplied signal now COMPOSES with the per-attempt timeout via `AbortSignal.any` (previously a caller signal replaced the timeout). No in-repo caller passes one (verified; noted in the H06 test).

## Follow-up candidates: raw `fetch` to DingTalk OUTSIDE client.ts (NOT converted here, per lane boundary)

- `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts` (~L321) — group-robot webhook send, own AbortController/timeout.
- `packages/core-backend/src/directory/directory-sync-alert-delivery.ts` (~L128) — sync-alert robot webhook delivery.
- `packages/core-backend/src/services/NotificationService.ts` (~L135) — robot webhook recipients path.
- (Generic, not DingTalk-specific: automation-executor `send_webhook` has its own retry loop.)


---

## Phase B — the outcome-unknown marker is CONSUMED by the ledgers (owner blockers closed)

Phase A defined the send-tier semantics (uncertain outcomes throw marked `isDingTalkOutcomeUnknown`, never resent at the transport). **Phase B closes the owner's blocker: the marker is now consumed by every send ledger, so the system stops auto-resending on ambiguity — and a malformed HTTP-2xx response can no longer masquerade as success.** Together, Phase A + Phase B close both owner blockers on this PR.

**What reconciliation IS (stated plainly):** a delivery recorded `outcome_unknown` is resolved **manually / by ops** via the distinct state + persisted error text. DingTalk's async-send result query (by `task_id`) can confirm a send **only when a task_id exists** — a lost response carries none, so the result query can never serve as an idempotency key for automatic retry. Everything in-process (retry budgets, backoff, rate limiting) remains **best-effort**; replicas do not share state.

### B1. Malformed-2xx guard (P1, same seam)

Pre-fix, `readJson` swallowed a body `SyntaxError` into `null` and the ok-path normalized `null → {} → SUCCESS`. Now an HTTP-2xx whose body is HTML / empty / truncated JSON / a bare primitive / a top-level array — or, for `envelope: 'oapi'`, a JSON object **missing the `errcode`/`code` envelope discriminator** — throws the new typed `DingTalkMalformedResponseError` (message carries **no body content**). Tier behaviors kept separate (owner guardrail), each pinned by its own test:

| Tier | Malformed 2xx |
|---|---|
| `read` | retryable **within the existing attempt budget** (like 5xx-on-read); recovery on a later good attempt pinned |
| `exchange` | **never** retried — exactly one fetch |
| `send` | **never** resent — exactly one fetch, error marked `isDingTalkOutcomeUnknown` |

`envelope: 'none'` (v1.0) endpoints have no discriminator requirement — object-without-errcode is still success there (pinned; the real v1.0 success shapes carry no errcode). Non-ok statuses keep their original `DingTalkRequestError` shape (`responseBody: null`) — pinned.

### B2. Three persistence surfaces (status-vocabulary decision: `outcome_unknown` in all three)

New migration `zzzz20260710150000_add_outcome_unknown_delivery_status.ts` widens all three CHECK constraints (each guarded by `checkTableExists` for partial-schema test harnesses). **down() maps live `outcome_unknown` rows → `'failed'` BEFORE re-tightening** — verified end-to-end against real Postgres (seed rows on all 3 tables → down() → all `'failed'`, constraint rejects `outcome_unknown` again (23514) → up() re-accepts).

1. **`dingtalk_approval_card_deliveries.send_status`** (was CHECK `pending|sent|failed`, merged on main via #3647 → new migration required): the card action's catch consumes the marker → new helper `markDingTalkApprovalCardDeliverySendOutcomeUnknown` (same pending-only guard) records the DISTINCT state + `send_error`; execution-record output carries `deliveryOutcomeUnknown: true`. Definite rejections (errcode envelopes, 4xx) still record `failed` — pinned.
2. **`dingtalk_person_deliveries.status`** (was CHECK `success|failed|skipped`): BOTH writers consume the marker — the batch person-message action records `outcome_unknown` for **exactly the in-flight batch** (batches never attempted have a KNOWN outcome → stay `failed`; earlier successful batches keep `success`), and the rule-creator failure-alert path records it for the alert send. Step output carries `deliveryOutcomeUnknown: true` + `outcomeUnknownRecipientCount`.
3. **`attendance_notification_deliveries.status`** (was CHECK `pending|sending|sent|retrying|failed|skipped`; `'skipped'` precedent from #3920): `classifyDingTalkSendError` checks the marker FIRST → `{ retryable: false, outcomeUnknown: true }` → the worker terminates the row as `outcome_unknown` on the first such attempt. **No retry burn, never re-claimed (claim predicate only takes `pending`/`retrying`/expired `sending`), never resent.** Quiet-hours gate and lease/CAS semantics untouched (the change sits strictly in the per-row post-send classification; `markOutcomeUnknown` uses the identical CAS guard as `markFailed`). Ordinary transient errors still retry — pinned. **WeCom/email classifiers untouched** (their transports never emit the marker).

### B3. Card `outcome_unknown` × HMAC callback (fail-open for valid tokens — surgically)

An `outcome_unknown` card MAY in fact have been delivered — and the deep-link HMAC token only ever existed inside the delivered card, so a valid callback is itself proof of delivery. The possibly-delivered set is widened by **exactly** `('sent', 'outcome_unknown')` in two places: `buildSummary().actionable` and the atomic acted-claim SQL. Nothing else changed — HMAC verify, instance-state checks, supersede handling, one-shot claim semantics all untouched. Pinned both directions: `outcome_unknown` + valid token + pending instance → approve proceeds and claims (send-time truth preserved on the audit row); `pending`/`failed` stay stale; forged token still `not_found`.

### Reader-compatibility audit (three consumer classes, file:line in the PR comment)

- **#4013 retention sweep** (landed mid-lane; rebased onto it): targets `dingtalk_group_deliveries` ONLY, deletes purely by `created_at < cutoff` — no status filter, touches none of the three Phase B tables.
- **Stats/aggregations**: no SQL aggregation on any of the three status columns exists in `src/` (worker `runBatch` counters extended with an optional `outcomeUnknown` count, present only when > 0 — same pattern as `lostLease`, so existing `toEqual` result assertions stay exact).
- **List/UI readers**: person-delivery endpoint passes the state through verbatim (folding it to `failed` is now a RED test); viewer gets a distinct badge + filter option + typed i18n label (`结果未知`/`outcome unknown`); the mobile decision page keys on server `actionable` (buttons render for actionable outcome_unknown; the "未成功投递" stale message is now reserved for pending/failed, where non-delivery is KNOWN).

### Phase B test evidence (fresh DB `lane_dtphaseb_*`, full migration stack)

- core-backend unit: **358 files / 4866 tests green** (`CI=true npx vitest run tests/unit`), incl. 8 new malformed-2xx transport tests, 5 channel-classification tests, 3 executor tests, reader pass-through pin.
- Real-DB (6 suites, 52 tests green): attendance-notification-deliveries (+outcome_unknown terminal/no-reclaim/no-resend), automation-dingtalk-approval-card-action (+transport-level marker → ledger + output flag + single asyncsend; person-deliveries CHECK both directions), approval-card-delivery-wrapper.db (+actionable/claim widening both directions), dingtalk-approval-card-deliveries.db (+helper guard + claimability + CHECK), dingtalk-person-message-integration-scoping.db, automation-approval-task-created-trigger.
- Web: 232 tests green across the 6 touched-surface spec files; `tsc` + `vue-tsc` clean.
- gettoken unit fixtures aligned to the real oapi wire contract (`errcode: 0`) — wire-vs-fixture drift surfaced by the new missing-errcode guard.

### Phase B mutation table (protocol: impl committed first; each mutation applied → run → restored)

| # | Mutation | Result |
|---|---|---|
| B-M1 | Restore `null → {}` ok-path normalization | **RED ×6** (send/read/exchange malformed suites + array + recovery) |
| B-M2 | Drop ONLY the oapi missing-errcode requirement | **RED ×3** (the JSON-without-errcode case per tier) |
| B-M3 | Exchange tier retries malformed responses | **RED ×2** (exchange single-fetch + 'none'-envelope test) |
| B-M4 | Read tier gives up immediately on malformed | **RED ×2** (budget-retry + recovery tests) |
| B-M5 | Executor maps outcome-unknown → plain `failed` (no flag) | **RED ×4** (card real-DB) |
| B-M6 | Send-tier network error retryable ("make it retry") | **RED ×4** card real-DB (single-asyncsend pin) **+ RED ×1** transport unit |
| B-M7 | Worker classifier treats outcome-unknown as retryable (the resend hazard) | **RED ×1** worker real-DB **+ RED ×2** channel unit |
| B-M8 | Worker maps outcome_unknown terminal → `failed` | **RED ×1** worker real-DB (distinct-state + counter pins) |
| B-M9 | Claim SQL back to `send_status = 'sent'` | **RED ×2** (wrapper + ledger claimability) |
| B-M10 | `actionable` back to `send_status === 'sent'` | **RED ×1** (wrapper actionable test) |
| B-M11 | Person-message marks ALL unsent recipients outcome_unknown (in-flight scoping dropped) | **RED ×1** (3-batch test: batch-3 must stay `failed`) |
| B-M12 | Endpoint reader folds outcome_unknown → `failed` | **RED ×1** (pass-through pin) |

### Behavior changes flagged for ops (Phase B)

- A 200-with-garbage-body DingTalk response now FAILS (typed `DingTalkMalformedResponseError`) instead of silently succeeding — directory-sync reads retry it up to the budget then surface a failed run (previously: silent `{}` success with confusing downstream field errors); asyncsend "successes" without a parseable envelope no longer record `sent` with no task_id.
- New terminal state `outcome_unknown` appears in the three delivery tables + the person-delivery viewer/endpoint + worker log line (`outcomeUnknown=N`). These rows are NOT retried; resolution is manual (resend by hand only after checking with the recipient / the DingTalk backend, or via the task_id result query when a task_id exists).
- Approval cards recorded `outcome_unknown` remain operable via their deep link (valid HMAC = delivery proof).

### Honest gaps (Phase B)

1. No automated reconciliation job (deliberate — owner doctrine): `outcome_unknown` rows stay until ops resolves them; no retention/aging policy for them yet (the #4013 sweep covers group deliveries only).
2. The worker terminates outcome-unknown on the FIRST such attempt even if earlier attempts were ordinary retryable failures — attempt history is preserved in `attempt_count`/`last_error`, but there is no per-attempt error trail.
3. `getDingTalkUserInfoByAuthCode` (oapi exchange) malformed-2xx is covered; the v1.0 `exchangeCodeForUserAccessToken` unparseable-body path is covered via the raw-transport 'none'-envelope test, not through that specific client function.
4. The decision page's outcome_unknown behavior is pinned at component level (server `actionable` drives it); no e2e over a real DingTalk callback.
5. Migration down() is verified by a scripted real-DB run (documented in the PR comment), not a committed test — the repo has no migration-down test convention to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
