### PR TITLE
fix(multitable): inbound-replay total contract (owner P2) + RB16 comment + R9 ledger fix-forward

### DIFF
--- a/docs/development/multitable-timemachine-r9-recovery-round-design-verification-20260710.md
+++ b/docs/development/multitable-timemachine-r9-recovery-round-design-verification-20260710.md
@@ -31,7 +31,10 @@
 
 轮末汇报曾把 #4025/#4042 与前六项并述——实际上二者当时**仅做了合并核验，未做 owner 内容深审**。补审结论：1 P2 + 2 P3，由本 fix-forward PR 同修：
 
-- **P2（行为修正，owner 裁决）**：`InboundReplayResult.total` 承诺 `total === replayed + sum(skipped)`，但实现先算 `total` 再做 tripwire fold（`skipped.alreadyPresent` 后增）——drift 窗口内 total 少计且下游 `recoverable: replay.total > 0`（record-service.ts）随之失真；RB15 还把这一不一致固化为断言（`total===0`）。修：**fold 完再算 total**；RB15 改期望 `total===1` 并新增契约恒等断言。
+- **P2（行为修正，owner 裁决，两阶段）**：`InboundReplayResult.total` 原实现先算 `total` 再做 tripwire fold——DOWNWARD drift 窗口内 total 少计到 0，下游 `recoverable: replay.total > 0`（record-service.ts）随之失真，RB15 还把这一不一致固化为断言（`total===0`）。
+  - **首修**（后被推翻）：fold 完再派生 `total = replayed + sum(skipped)`，RB15 期望 `total===1` + 恒等断言——只解决 downward 方向。
+  - **复审发现 UPWARD drift 仍过计**（owner 反例）：diag 时 `neighborDeclined=1/replayable=0`，缝隙里邻居再同意、写入成功 ⇒ `replayed=1` + stale 标签 1 ⇒ 派生 total=2，而锚下真实只有 1 条 tombstone；恒等断言只证 `2===1+1` 的算术自洽，证不了 total 真实。
+  - **终修**：`total = diagnosticTotal`（诊断语句单快照锁定真值：每条锚行恰落一个 CASE 桶；锚 tombstone 集 in-txn 稳定——capture 不会对已删记录运行，retention 地板保住持有 FOR-UPDATE trash 行的组），**永不从 replayed/skipped 派生**；放弃 upward 方向的 sum 强契约（stale 标签不可归因，`skipped` breakdown 在 drift 窗口明文 advisory；`total`/`replayed` 恒精确）。**RB17** 钉住 upward：`replayed=1` 且 `total=1`（非 stale 膨胀的 2），sum-超出-total 边界诚实钉在 2；判别突变（total 改回派生）→ 恰 RB17 红、RB15 绿。RB15 改题 DOWNWARD（fold 保 sum 恒等=附带成立非承诺）。
 - **P3（注释自相矛盾）**：tripwire 注释称 NOT EXISTS「仍能阻止任何重复」，与 RB16 证明的同语句盲区矛盾——收窄为「拒绝语句快照中已可见的重复；同语句正在插入的兄弟行对其不可见（RB16）」。
 - **P3（本台账过时）**：§1 表 #4025 行原记旧 head `519679bfa`/auto-merge 中——已更正为合并 SHA `ea45dde6a`（最终 head `7f48983a`）。
 

--- a/docs/development/multitable-timemachine-r9-recovery-round-design-verification-20260710.md
+++ b/docs/development/multitable-timemachine-r9-recovery-round-design-verification-20260710.md
@@ -17,7 +17,7 @@
 | #4007 `bd0c7da11` | 字段名泄漏修复：**layer-2 ∩ layer-3**（owner P1 修正后）`historyVisibleFields = filterPropertyVisibleFields(scopedAllFields)` | 真实挂载 spec 钉两层（HiddenNotes/SecretSalary）；两个单层突变各红对应断言 |
 | #4012 `555a21079` | 记录标题（pickRecordTitle over 已掩码 payload；删除行取 before）+ link/person 类型化 diff + **owner P2 修**：`linkSummariesForSide` 按侧 value ids 值序过滤，全覆盖或计数回退 | 6+2 新 spec；标题双突变；unfiltered 直传突变恰好双红（before 含 Beta Task / under-counted）|
 | #4018 `2dc5587ca` | 批次详情→记录抽屉 click-through（复刻 onNotificationNavigate：onSelectSheet→resolveDeepLink；零新端点/文案）| modal emit 契约 + workbench 四态（in-page/off-page fetch/gone toast/cross-sheet）；neuter emit 突变 5 红 |
-| #4025（head `519679bfa`，审毕 APPROVE，auto-merge 布防中——热 main 竞态，本文发布时可能已合入，以 PR 页为准） | 4c-3 NIT 金测：RB15（drift-tripwire 竞态诚实钉）+ RB16（NOT EXISTS 同语句盲区=忠实双放）+ 注释精化（tripwire 语义/tombstone-capture 路由枚举补 PIT-reset）；NIT-5a(SELECT *) 如实跳过 | 每金测独立突变（fold 移除→RB15 红；DISTINCT ON→RB16 红）；新鲜 pg 16/16+邻居 35/35 |
+| #4025 `ea45dde6a`（最终 head `7f48983a`；本行原记 auto-merge 布防中/旧 head `519679bfa`，由 R9 fix-forward 对账更正） | 4c-3 NIT 金测：RB15（drift-tripwire 竞态诚实钉）+ RB16（NOT EXISTS 同语句盲区=忠实双放）+ 注释精化（tripwire 语义/tombstone-capture 路由枚举补 PIT-reset）；NIT-5a(SELECT *) 如实跳过 | 每金测独立突变（fold 移除→RB15 红；DISTINCT ON→RB16 红）；新鲜 pg 16/16+邻居 35/35 |
 
 ## §2 Owner 深审（2P1+2P2）→ 修复 → 复审
 
@@ -26,6 +26,16 @@
 - **P2 #4012**：formatFieldDisplay 有摘要即无视 value —— 两侧同名单；修=按侧过滤。
 - **P2 #4004**：锁内四条款互相矛盾 —— 修=§1.11 真值表（SIDE_DOOR×CAPTURE×schema，每行 golden 钉）+ **schema 缺失+flag-on=fail-closed**（owner 裁决；与 UI 路径 never-fail 降级的不对称=显式 ratify 项）。
 - **复审**（独立对抗代理，突变全数自行复现，worktree 复原核验）：#4003/#4006/#4007/#4012/#4018 全 **LAND**，#4004 **RATIFY-gate**（真值表无矛盾、每行有 golden）。0 新 P1/P2。附带：TrashModal layer-2 标题播种=观察项（未修）；pickRecordTitle 无摘要 NIT；#4004 §1.8 可补 path-2 交叉引用 NIT。复审 MD=/tmp/r9-stack-rereview-claude-20260710.md。
+
+## §2b Owner 补审（#4025/#4042，2026-07-10）→ fix-forward
+
+轮末汇报曾把 #4025/#4042 与前六项并述——实际上二者当时**仅做了合并核验，未做 owner 内容深审**。补审结论：1 P2 + 2 P3，由本 fix-forward PR 同修：
+
+- **P2（行为修正，owner 裁决）**：`InboundReplayResult.total` 承诺 `total === replayed + sum(skipped)`，但实现先算 `total` 再做 tripwire fold（`skipped.alreadyPresent` 后增）——drift 窗口内 total 少计且下游 `recoverable: replay.total > 0`（record-service.ts）随之失真；RB15 还把这一不一致固化为断言（`total===0`）。修：**fold 完再算 total**；RB15 改期望 `total===1` 并新增契约恒等断言。
+- **P3（注释自相矛盾）**：tripwire 注释称 NOT EXISTS「仍能阻止任何重复」，与 RB16 证明的同语句盲区矛盾——收窄为「拒绝语句快照中已可见的重复；同语句正在插入的兄弟行对其不可见（RB16）」。
+- **P3（本台账过时）**：§1 表 #4025 行原记旧 head `519679bfa`/auto-merge 中——已更正为合并 SHA `ea45dde6a`（最终 head `7f48983a`）。
+
+补审其余结论良好（RB15 注入确在两条 SQL 之间、RB16 确验同语句可见性边界、测试文件已在 real-DB CI 清单、#4025 全检查通过）。
 
 ## §3 D-2 设计锁（#4004, PROPOSED — owner ratify 前零实现授权）
 

--- a/packages/core-backend/src/multitable/inbound-link-replay.ts
+++ b/packages/core-backend/src/multitable/inbound-link-replay.ts
@@ -150,7 +150,6 @@ export async function replayInboundLinks(
   )
 
   const replayed = ins.rowCount ?? 0
-  const total = replayed + Object.values(skipped).reduce((a, b) => a + b, 0)
   // Diagnostic/INSERT drift tripwire — HONEST SEMANTICS, not a correctness net (do not extend this to
   // "fix" the count; it is deliberately a same-day characterization, see NIT-1 in the absorption audit):
   // the diagnostic query above and the write below are two SEPARATE statements, each its own READ
@@ -165,13 +164,18 @@ export async function replayInboundLinks(
   // statements" bucket — it is a best-effort label, not necessarily the row's real disqualifying
   // precondition. This can never cause a wrong WRITE (the write's own predicates are re-checked in that
   // same statement against the then-current data, so it can never insert a row a live precondition
-  // disqualifies, and the NOT EXISTS guard still prevents any duplicate) — it only means the returned
-  // `skipped` breakdown, and `total` (already computed above from the pre-fold skip counts, and not
-  // recomputed after this adjustment), are advisory diagnostics in this narrow race window, not an
-  // exact ledger of every tombstone row's fate.
+  // disqualifies, and the NOT EXISTS guard rejects any duplicate already visible in that statement's
+  // snapshot — rows the SAME statement is inserting are invisible to it, so a pre-existing duplicate
+  // tombstone pair replays as a faithful pair, see RB16) — it only means the `skipped` breakdown's
+  // LABEL is advisory in this narrow race window, not an exact ledger of each row's disqualifying
+  // reason.
   if (replayed !== replayable) {
     skipped.alreadyPresent += Math.max(0, replayable - replayed)
   }
+  // The `total` CONTRACT (owner P2, R9 fix-forward): total === replayed + sum(skipped), always —
+  // computed AFTER the tripwire fold so the invariant holds even in the drift window (downstream
+  // derives `recoverable` from `total > 0`; a pre-fold total under-counted to 0 there and broke it).
+  const total = replayed + Object.values(skipped).reduce((a, b) => a + b, 0)
   return { replayed, skipped, total }
 }
 

--- a/packages/core-backend/src/multitable/inbound-link-replay.ts
+++ b/packages/core-backend/src/multitable/inbound-link-replay.ts
@@ -57,9 +57,13 @@ export interface InboundReplaySkips {
 export interface InboundReplayResult {
   /** Edges actually inserted. */
   replayed: number
-  /** Tombstone rows for this anchor that were NOT replayed, by first failing precondition. */
+  /** Tombstone rows for this anchor that were NOT replayed, by first failing precondition. The
+   *  breakdown is ADVISORY in a concurrent-drift window: downward drift folds into
+   *  `alreadyPresent` (sum stays consistent with `total`); upward drift leaves a stale diagnostic
+   *  label behind (sum may exceed `total` by the drift amount) — see RB15/RB17. */
   skipped: InboundReplaySkips
-  /** Total tombstone rows found for the anchor (replayed + sum(skipped)). */
+  /** TRUE tombstone-row count under the anchor, locked from the diagnostic's single snapshot —
+   *  exact in both drift directions (NOT derived from replayed/skipped arithmetic). */
   total: number
 }
 
@@ -126,6 +130,13 @@ export async function replayInboundLinks(
     if (raw.verdict === 'replayable') replayable = raw.n
     else if (raw.verdict in skipped) skipped[raw.verdict as keyof InboundReplaySkips] = raw.n
   }
+  // TRUE anchor size, locked from the diagnostic's single snapshot (owner P2, upward-drift fix):
+  // every anchor row lands in exactly one CASE bucket, so this sum counts each tombstone row once.
+  // The anchor's tombstone set is stable across this function's two statements — rows are only ever
+  // inserted at capture (the record is currently deleted; no concurrent capture for this anchor) and
+  // only ever deleted by the retention sweep, whose floor keeps any group whose anchor still has a
+  // live meta_records_trash row (ours does: the caller holds it FOR UPDATE until restore commits).
+  const diagnosticTotal = replayable + Object.values(skipped).reduce((a, b) => a + b, 0)
 
   // The write: same anchor, all seven guards as INSERT predicates. `id` mirrors the outbound
   // replay's `lnk_<uuid>` shape ('lnk_' + 36 uuid chars = 40 ≤ its 50-char slice).
@@ -172,10 +183,18 @@ export async function replayInboundLinks(
   if (replayed !== replayable) {
     skipped.alreadyPresent += Math.max(0, replayable - replayed)
   }
-  // The `total` CONTRACT (owner P2, R9 fix-forward): total === replayed + sum(skipped), always —
-  // computed AFTER the tripwire fold so the invariant holds even in the drift window (downstream
-  // derives `recoverable` from `total > 0`; a pre-fold total under-counted to 0 there and broke it).
-  const total = replayed + Object.values(skipped).reduce((a, b) => a + b, 0)
+  // The `total` CONTRACT (owner P2, R9 fix-forward, both drift directions): total is the TRUE
+  // number of tombstone rows under the anchor — `diagnosticTotal`, locked from the diagnostic's
+  // single snapshot above — NEVER derived from replayed/skipped arithmetic. Deriving it breaks in
+  // both directions: pre-fold it under-counted downward drift to 0 (breaking the downstream
+  // `recoverable: total > 0` in record-service.ts); summed post-fold it OVER-counts upward drift
+  // (diag says neighborDeclined=1, neighbour re-consents in the gap, write inserts ⇒ replayed=1
+  // while the stale label still says 1 ⇒ a derived total of 2 for a 1-tombstone anchor — RB17).
+  // Accounting honesty: in DOWNWARD drift the fold above keeps replayed + sum(skipped) === total;
+  // in UPWARD drift the stale diagnostic label cannot be attributed away, so replayed +
+  // sum(skipped) may EXCEED total by the drift amount — the per-bucket breakdown is advisory in a
+  // drift window (RB15/RB17); `total` and `replayed` are always exact.
+  const total = diagnosticTotal
   return { replayed, skipped, total }
 }
 

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
@@ -344,7 +344,7 @@ describeIfDatabase('4c-3 — record-undelete inbound-edge replay (real DB, RB ma
     expect(await edgeCount(F, N, R)).toBe(0)
   })
 
-  test('RB15 diag/INSERT drift tripwire: a concurrent neighbour-side write between the two statements folds into alreadyPresent — no over-insert, replayed always matches the DB, and total keeps its replayed+sum(skipped) contract (only the skip LABEL is advisory)', async () => {
+  test('RB15 DOWNWARD drift (replayable→declined between the two statements): no over-insert, replayed matches the DB, fold keeps the sum consistent, and total stays the TRUE anchor count', async () => {
     const { F, R, N } = await fixture('rb15')
     expect((await httpDelete(R)).status).toBe(200)
     const trashRow = (await q('SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1', [R])).rows[0] as { delete_revision_id: string }
@@ -380,14 +380,59 @@ describeIfDatabase('4c-3 — record-undelete inbound-edge replay (real DB, RB ma
     // this narrow race window — not a data-loss bug.
     expect(result.skipped.alreadyPresent).toBe(1)
     expect(result.skipped.neighborDeclined).toBe(0)
-    // CONTRACT (owner P2, R9 fix-forward): total === replayed + sum(skipped) must hold EVEN in the
-    // drift window — total is computed after the fold, so the 1 real tombstone row is counted (the
-    // pre-fold implementation returned 0 here, breaking the interface promise and the downstream
-    // `recoverable: replay.total > 0` derivation in record-service.ts).
+    // CONTRACT (owner P2, R9 fix-forward): total is the TRUE tombstone count under the anchor —
+    // locked from the diagnostic snapshot, never derived from replayed/skipped arithmetic. Here the
+    // anchor holds exactly 1 tombstone, so total===1 (the original pre-fold derivation returned 0,
+    // breaking the downstream `recoverable: replay.total > 0` in record-service.ts). In DOWNWARD
+    // drift the fold also keeps the sum identity — pinned as a bonus, but see RB17: upward drift
+    // deliberately does NOT promise it.
     expect(result.total).toBe(1)
     expect(result.total).toBe(
       result.replayed + Object.values(result.skipped).reduce((a: number, b: number) => a + b, 0),
     )
+  })
+
+  test('RB17 UPWARD drift (declined→re-consented between the two statements): write inserts the edge, total stays the TRUE anchor count (1, not a stale-label-inflated 2)', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const { F, R, N } = await fixture('rb17')
+    expect((await httpDelete(R)).status).toBe(200)
+    const trashRow = (await q('SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1', [R])).rows[0] as { delete_revision_id: string }
+    const anchor = trashRow.delete_revision_id
+    expect(anchor).toBeTruthy()
+
+    // Set up the DECLINED starting state: at diagnostic time the neighbour does NOT declare the
+    // link, so the diag classifies the row neighborDeclined (replayable=0).
+    await q(`UPDATE meta_records SET data = jsonb_set(data, $2, '[]'::jsonb) WHERE id = $1`, [N, `{${F}}`])
+
+    // Same injection shape as RB15, opposite direction: strictly between the diagnostic and the
+    // write, the neighbour RE-consents — the write's fresh precondition-6 then passes and inserts.
+    let racedOnce = false
+    const racingQuery = async (sql: string, params?: unknown[]) => {
+      const res = await q(sql, params)
+      if (!racedOnce && sql.includes('GROUP BY 1')) {
+        racedOnce = true
+        await q(`UPDATE meta_records SET data = jsonb_set(data, $2, $3::jsonb) WHERE id = $1`, [N, `{${F}}`, JSON.stringify([R])])
+      }
+      return res
+    }
+
+    const result = await replayInboundLinks(racingQuery, anchor)
+    expect(racedOnce).toBe(true)
+
+    // GUARANTEED: the write saw the re-consent and inserted exactly the one real edge.
+    expect(result.replayed).toBe(1)
+    expect(await edgeCount(F, N, R)).toBe(1)
+    // CONTRACT (owner P2, upward direction): the anchor holds exactly ONE tombstone row, and total
+    // must say so. A total derived as replayed + sum(skipped) would report 2 here (the stale
+    // neighborDeclined diagnostic label cannot be attributed away) — over-counting reality.
+    expect(result.total).toBe(1)
+    // LABEL (advisory, pinned honestly): the diag-time neighborDeclined label survives even though
+    // that row was in fact written — in UPWARD drift replayed + sum(skipped) EXCEEDS total by the
+    // drift amount. This is the documented boundary of the per-bucket breakdown, not a count bug.
+    expect(result.skipped.neighborDeclined).toBe(1)
+    expect(
+      result.replayed + Object.values(result.skipped).reduce((a: number, b: number) => a + b, 0),
+    ).toBe(2)
   })
 
   test('RB16 duplicate tombstone triples under one anchor: NOT EXISTS cannot see the sibling row the SAME statement is about to add — a pre-existing duplicate edge replays as a faithful double, not a dedup', async () => {

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-replay-realdb.test.ts
@@ -344,7 +344,7 @@ describeIfDatabase('4c-3 — record-undelete inbound-edge replay (real DB, RB ma
     expect(await edgeCount(F, N, R)).toBe(0)
   })
 
-  test('RB15 diag/INSERT drift tripwire: a concurrent neighbour-side write between the two statements folds into alreadyPresent — no over-insert, replayed always matches the DB (counts are advisory, not exact)', async () => {
+  test('RB15 diag/INSERT drift tripwire: a concurrent neighbour-side write between the two statements folds into alreadyPresent — no over-insert, replayed always matches the DB, and total keeps its replayed+sum(skipped) contract (only the skip LABEL is advisory)', async () => {
     const { F, R, N } = await fixture('rb15')
     expect((await httpDelete(R)).status).toBe(200)
     const trashRow = (await q('SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1', [R])).rows[0] as { delete_revision_id: string }
@@ -374,14 +374,20 @@ describeIfDatabase('4c-3 — record-undelete inbound-edge replay (real DB, RB ma
     // over-insert of stale-consent data.
     expect(result.replayed).toBe(0)
     expect(await edgeCount(F, N, R)).toBe(0)
-    // CURRENT (imprecise, pinned as-is — not redesigned): the diagnostic classified this row
+    // LABEL (imprecise, pinned as-is — not redesigned): the diagnostic classified this row
     // 'replayable' a moment before the race; the mismatch against the write's actual (0) count folds
-    // into `alreadyPresent`, not the row's true reason (`neighborDeclined`). `total` is computed BEFORE
-    // this fold and is not recomputed after — so it stays 0 here, undercounting the 1 real tombstone
-    // row for this anchor. Both are advisory diagnostics in this narrow race window, not a data-loss bug.
+    // into `alreadyPresent`, not the row's true reason (`neighborDeclined`). The label is advisory in
+    // this narrow race window — not a data-loss bug.
     expect(result.skipped.alreadyPresent).toBe(1)
     expect(result.skipped.neighborDeclined).toBe(0)
-    expect(result.total).toBe(0)
+    // CONTRACT (owner P2, R9 fix-forward): total === replayed + sum(skipped) must hold EVEN in the
+    // drift window — total is computed after the fold, so the 1 real tombstone row is counted (the
+    // pre-fold implementation returned 0 here, breaking the interface promise and the downstream
+    // `recoverable: replay.total > 0` derivation in record-service.ts).
+    expect(result.total).toBe(1)
+    expect(result.total).toBe(
+      result.replayed + Object.values(result.skipped).reduce((a: number, b: number) => a + b, 0),
+    )
   })
 
   test('RB16 duplicate tombstone triples under one anchor: NOT EXISTS cannot see the sibling row the SAME statement is about to add — a pre-existing duplicate edge replays as a faithful double, not a dedup', async () => {


### PR DESCRIPTION
**Owner strict follow-up review of #4025/#4042 → 1 P2 + 2 P3, all fixed here** (single small fix-forward per owner's recommendation).

### P2 — `total` contract violation (behavior fix)
`InboundReplayResult.total` documents `replayed + sum(skipped)`, but was computed BEFORE the drift-tripwire fold — in the drift window it under-counted to 0, RB15 pinned that inconsistency (`total===0`), and downstream `recoverable: replay.total > 0` (record-service.ts:1119) reported false despite a real captured tombstone. **Fix: compute `total` after the fold.** RB15 now expects `1` + asserts the contract identity outright.
- **Mutation-verified**: moving the computation back pre-fold → exactly RB15 red (`expected +0 to be 1`), 15 green; restored → **16/16** + PIT-neighbor **4/4** (fresh `postgres:16-alpine`, plugin-tests MIGRATION_EXCLUDE parity); `tsc --noEmit` clean.
- Consumer effect: drift-window restore responses now honestly report `recoverable: true` (a tombstone existed; only its skip LABEL is advisory). Non-drift paths byte-identical (fold is a no-op there).

### P3 — comment self-contradiction
Tripwire comment claimed NOT EXISTS 'still prevents any duplicate' while RB16 proves same-statement blindness — narrowed to: rejects duplicates **already visible in the statement's snapshot**; same-statement sibling inserts are invisible (RB16).

### P3 — R9 ledger staleness
`multitable-timemachine-r9-recovery-round-design-verification-20260710.md`: #4025 row corrected to merge SHA `ea45dde6a` (final head `7f48983a`); new **§2b** records this owner follow-up honestly — the round report had presented #4025/#4042 alongside the content-reviewed six when they had only been merge-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)