### PR TITLE
fix(dingtalk): preview integrity — same-batch overcount + lease-aware refusal

### DIFF
--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3476,12 +3476,31 @@ export async function syncDirectoryIntegration(
  * eligibility check alone, so preview no longer counts accounts that are already linked or
  * would merely be linked (not created).
  *
- * Residual known gap (fail-safe, over-counts only): apply mutates its match maps as it
- * auto-admits users within a single run, so two brand-new in-scope pulled users who share an
- * email/mobile count as 1 apply-created account but 2 preview candidates. Preview does not
- * simulate creation order. This does not affect the already-linked / matched / out-of-scope
- * cases this function was built to fix.
+ * Same-batch duplicates: apply mutates its match maps as it auto-admits users within a
+ * single run, so a second brand-new in-scope pulled account that shares an email/mobile/
+ * external-identity with one already counted resolves matched:'email'/'mobile'/
+ * 'external_identity' against the FIRST account's freshly-created user, not matched:'none'
+ * again. Preview mirrors that below with a sentinel userId (`'preview-would-admit'`)
+ * written into `identityMatchMaps` right after counting an in-scope candidate, using the
+ * same normalizeText/normalizeMobileIdentifier keying `resolveDirectoryIdentityMatch`
+ * itself uses — so the next iteration's cascade call sees exactly what apply's would see.
+ *
+ * Residual known gap (fail-safe, over-counts only): this cannot foresee an apply-side
+ * creation FAILURE (e.g. `createDirectoryAdmittedUserInTransaction` throwing mid-run) —
+ * apply's catch block skips its map mutation for a failed account, so a later same-batch
+ * duplicate would still resolve against it as a candidate on the apply side too, while
+ * preview (which cannot know a future apply run will fail) always mutates the maps. Preview
+ * and apply only diverge here when apply itself fails partway through a run.
  */
+
+/**
+ * Placeholder written into `identityMatchMaps` in place of a real `created.userId` (preview
+ * never creates anything). Only ever compared as a map VALUE by `matched-kind` branching —
+ * never read back as a real user id or returned in any preview response field. Distinctive on
+ * purpose so it is unmistakable in a debugger or log if that invariant is ever violated.
+ */
+const PREVIEW_ADMIT_SENTINEL_USER_ID = 'preview-would-admit'
+
 export type DirectorySyncPreview = {
   integrationId: string
   integrationName: string
@@ -3509,6 +3528,15 @@ type ExistingAccountPreviewRow = {
 export async function previewDirectorySyncIntegration(integrationId: string): Promise<DirectorySyncPreview> {
   const integration = await getIntegrationRow(integrationId)
   if (!integration) throw new Error('Directory integration not found')
+
+  // DT-OPS-02 / R3: refuse a preview while a real sync holds the lease for this
+  // integration. Preview pulls the FULL DingTalk directory (same API quota `syncDirectoryIntegration`
+  // consumes — see the doc-comment above) with no lease check at all; running one during an
+  // in-flight sync doubles the shared quota consumption the lease exists to bound. This is a
+  // READ-ONLY refusal: unlike apply, preview never calls `claimDirectorySyncRun` — it only asks
+  // whether a run is currently `running` and, if so, declines before making any outbound call.
+  const activeRunId = await findActiveDirectorySyncRunId(integrationId)
+  if (activeRunId) throw new DirectorySyncInProgressError(activeRunId)
 
   const config = parseIntegrationConfig(integration)
   const departments = await fetchAllDepartments(config, integration.name)
@@ -3592,6 +3620,33 @@ export async function previewDirectorySyncIntegration(integrationId: string): Pr
     // is true (independent of inScope) would over-count vs. apply here too.
     if (eligibility.inScope) {
       autoAdmissionCandidateCount += 1
+      // Same-batch duplicate fix: mirror apply's post-admit map mutations (see the
+      // `emailMap.set` / `mobileMap.set` / ambiguous-key deletes / identity-map sets right
+      // after `createDirectoryAdmittedUserInTransaction` succeeds, above) onto
+      // `identityMatchMaps` with a sentinel userId instead of a real one — preview writes
+      // nothing, so there is no real created.userId to use, only a placeholder that proves
+      // "an account was admitted here" to the next iteration's `resolveDirectoryIdentityMatch`
+      // call. Keyed with the SAME normalizeText/normalizeMobileIdentifier helpers
+      // `resolveDirectoryIdentityMatch` uses internally (lines ~1129-1130 above), so a later
+      // pulled account in this same pull that shares this one's email/mobile/external-identity
+      // resolves matched:'email'/'mobile'/'external_identity' against it — exactly as it would
+      // resolve against the real user apply creates for this account — instead of independently
+      // resolving matched:'none' and being double-counted.
+      const emailKey = normalizeText(account.email).toLowerCase()
+      const mobileKey = normalizeMobileIdentifier(account.mobile)
+      if (emailKey) {
+        identityMatchMaps.emailMap.set(emailKey, PREVIEW_ADMIT_SENTINEL_USER_ID)
+        identityMatchMaps.ambiguousEmailKeys.delete(emailKey)
+      }
+      if (mobileKey) {
+        identityMatchMaps.mobileMap.set(mobileKey, PREVIEW_ADMIT_SENTINEL_USER_ID)
+        identityMatchMaps.ambiguousMobileKeys.delete(mobileKey)
+      }
+      identityMatchMaps.externalIdentityMap.set(account.external_key, PREVIEW_ADMIT_SENTINEL_USER_ID)
+      const scopedOpenIdentityKey = buildScopedIdentityKey(account.corp_id, account.open_id)
+      if (scopedOpenIdentityKey) identityMatchMaps.scopedOpenIdentityMap.set(scopedOpenIdentityKey, PREVIEW_ADMIT_SENTINEL_USER_ID)
+      const scopedUnionIdentityKey = buildScopedIdentityKey(account.corp_id, account.union_id)
+      if (scopedUnionIdentityKey) identityMatchMaps.scopedUnionIdentityMap.set(scopedUnionIdentityKey, PREVIEW_ADMIT_SENTINEL_USER_ID)
     } else if (eligibility.missingEmail) {
       autoAdmissionSkippedMissingEmailCount += 1
     }

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -359,6 +359,13 @@ export function adminDirectoryRouter(): Router {
       const preview = await previewDirectorySyncIntegration(req.params.integrationId)
       jsonOk(res, { preview })
     } catch (error) {
+      // DT-HARDEN-05 / R3: a real sync holds the lease — same benign "already running" state
+      // as the two sync-trigger branches above, mapped identically (409 + the active runId,
+      // never a 500 that monitoring pages on).
+      if (error instanceof DirectorySyncInProgressError) {
+        jsonError(res, error.statusCode, error.code, error.message, { activeRunId: error.activeRunId })
+        return
+      }
       const message = readErrorMessage(error, 'Failed to preview directory sync')
       jsonError(res, /not found/i.test(message) ? 404 : 500, 'DIRECTORY_SYNC_PREVIEW_FAILED', message)
     }

--- a/packages/core-backend/tests/integration/directory-sync-preview-apply-parity.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-preview-apply-parity.db.test.ts
@@ -316,3 +316,193 @@ describeIfDatabase('DT-OPS-02 preview/apply auto-admission parity (real DB)', ()
     expect(newUserCount.rows[0].n).toBe('1')
   })
 })
+
+/**
+ * Residual fix — same-batch preview overcount (dt-preview-integrity FIX 1).
+ *
+ * The suite above proves preview↔apply parity for accounts matched against PRE-EXISTING
+ * local users. It does not cover two BRAND-NEW pulled accounts that share an identity key
+ * with EACH OTHER (not with anything already in the DB): both independently resolve
+ * `matched:'none'` against the match maps `loadMatchMaps` builds once up front, so both
+ * counted as auto-admission candidates — but apply mutates its maps as it admits users
+ * within the run, so the second duplicate resolves `matched:'email'`/`'mobile'` against the
+ * user apply just created for the first and is LINKED, not created. Preview reported 2
+ * candidates for what apply turns into 1 new user.
+ *
+ * This drives a separate integration (own corp/department/users — no overlap with the
+ * scenario above) with two duplicate pairs (shared email, shared mobile) plus one solo new
+ * user, and asserts preview's count already accounts for both pairs collapsing to 1 each,
+ * matching apply's actual `users` insert count exactly.
+ */
+describeIfDatabase('DT-OPS-02 preview/apply parity — intra-batch identity duplicates (residual fix)', () => {
+  let integrationId = ''
+
+  const DUP_CORP = `dt3915dupcorp${TS}`
+  const DUP_DEPT_IN = `dt3915dupdin${TS}`
+
+  const DUP_SHARED_EMAIL = `dt3915dup-shared-${TS}@example.com`
+  const DUP_SHARED_MOBILE = `132${String(TS).slice(-8)}`
+
+  const DT_DUP_EMAIL_A = `dt3915dupemailA${TS}`
+  const DT_DUP_EMAIL_B = `dt3915dupemailB${TS}`
+  const DT_DUP_MOBILE_A = `dt3915dupmobileA${TS}`
+  const DT_DUP_MOBILE_B = `dt3915dupmobileB${TS}`
+  const DT_DUP_SOLO = `dt3915dupsolo${TS}`
+
+  const UNION_DUP_EMAIL_A = `dt3915dupunionemailA${TS}`
+  const UNION_DUP_EMAIL_B = `dt3915dupunionemailB${TS}`
+  const UNION_DUP_MOBILE_A = `dt3915dupunionmobileA${TS}`
+  const UNION_DUP_MOBILE_B = `dt3915dupunionmobileB${TS}`
+  const UNION_DUP_SOLO = `dt3915dupunionsolo${TS}`
+
+  beforeAll(async () => {
+    const integration = await createDirectoryIntegration({
+      name: `dt3915dup-${TS}`,
+      corpId: DUP_CORP,
+      appKey: `appkey-dup-${TS}`,
+      appSecret: 'appsecret-value',
+      admissionMode: 'auto_for_scoped_departments',
+      admissionDepartmentIds: [DUP_DEPT_IN],
+      excludeDepartmentIds: [],
+    })
+    integrationId = integration.id
+
+    // DingTalk pull: a single in-scope department carrying five brand-new users — two
+    // sharing an email, two sharing a mobile, and one solo (no existing directory_accounts
+    // row and no existing local user for ANY of them — this integration is otherwise empty).
+    clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('app-token')
+    clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+    clientMocks.listDingTalkDepartments.mockImplementation(async (_token: string, parentId: string) => {
+      if (parentId === '1') {
+        return [{ id: DUP_DEPT_IN, parentId: '1', name: 'Dup In-Scope', order: 0, source: {} }]
+      }
+      return []
+    })
+    clientMocks.listDingTalkDepartmentUsers.mockImplementation(async (_token: string, deptId: string) => {
+      if (deptId === DUP_DEPT_IN) {
+        return {
+          users: [
+            deptUserSummary(DT_DUP_EMAIL_A, 'Dup Email A', DUP_DEPT_IN),
+            deptUserSummary(DT_DUP_EMAIL_B, 'Dup Email B', DUP_DEPT_IN),
+            deptUserSummary(DT_DUP_MOBILE_A, 'Dup Mobile A', DUP_DEPT_IN),
+            deptUserSummary(DT_DUP_MOBILE_B, 'Dup Mobile B', DUP_DEPT_IN),
+            deptUserSummary(DT_DUP_SOLO, 'Dup Solo', DUP_DEPT_IN),
+          ],
+          nextCursor: null,
+          hasMore: false,
+        }
+      }
+      return { users: [], nextCursor: null, hasMore: false }
+    })
+    clientMocks.getDingTalkUserDetail.mockImplementation(async (_token: string, userId: string) => {
+      switch (userId) {
+        case DT_DUP_EMAIL_A:
+          return userDetail(DT_DUP_EMAIL_A, 'Dup Email A', UNION_DUP_EMAIL_A, { email: DUP_SHARED_EMAIL })
+        case DT_DUP_EMAIL_B:
+          return userDetail(DT_DUP_EMAIL_B, 'Dup Email B', UNION_DUP_EMAIL_B, { email: DUP_SHARED_EMAIL })
+        case DT_DUP_MOBILE_A:
+          return userDetail(DT_DUP_MOBILE_A, 'Dup Mobile A', UNION_DUP_MOBILE_A, { mobile: DUP_SHARED_MOBILE })
+        case DT_DUP_MOBILE_B:
+          return userDetail(DT_DUP_MOBILE_B, 'Dup Mobile B', UNION_DUP_MOBILE_B, { mobile: DUP_SHARED_MOBILE })
+        case DT_DUP_SOLO:
+          return userDetail(DT_DUP_SOLO, 'Dup Solo', UNION_DUP_SOLO)
+        default:
+          throw new Error(`unexpected userId ${userId}`)
+      }
+    })
+  })
+
+  afterAll(async () => {
+    if (integrationId) {
+      await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_account_links WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`, [integrationId])
+      await query(`DELETE FROM directory_account_departments WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`, [integrationId])
+      await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+    }
+    // Auto-admitted users created by the apply-path test below carry these DT names.
+    await query(
+      `DELETE FROM users WHERE name = ANY($1::text[])`,
+      [['Dup Email A', 'Dup Email B', 'Dup Mobile A', 'Dup Mobile B', 'Dup Solo']],
+    )
+  })
+
+  it('preview counts exactly 3 candidates — one per duplicate pair plus the solo user, not 5', async () => {
+    const preview = await previewDirectorySyncIntegration(integrationId)
+
+    expect(preview.wouldCreateAccounts).toBe(5)
+    expect(preview.accountsSeen).toBe(5)
+    // Without the fix this is 5 (every matched:'none' account counted independently); with
+    // it, the second half of each duplicate pair resolves matched:'email'/'mobile' against
+    // the sentinel the first half wrote, so only 3 are genuinely new candidates.
+    expect(preview.autoAdmissionCandidateCount).toBe(3)
+  })
+
+  it('apply creates exactly 3 users for the batch — preview/apply parity holds for intra-batch duplicates', async () => {
+    const preview = await previewDirectorySyncIntegration(integrationId)
+
+    const result = await syncDirectoryIntegration(integrationId, 'system:dt3915-dup-parity-test')
+    const stats = result.run.stats as Record<string, unknown>
+
+    // The headline parity assertion for this fix: preview and apply must agree, including
+    // for intra-batch duplicates apply resolves as it goes.
+    expect(stats.autoAdmissionCandidateCount).toBe(preview.autoAdmissionCandidateCount)
+    expect(stats.autoAdmissionCandidateCount).toBe(3)
+    expect(stats.autoAdmittedCount).toBe(3)
+
+    const links = await query<{ external_user_id: string; link_status: string; match_strategy: string | null; local_user_id: string | null }>(
+      `SELECT a.external_user_id, l.link_status, l.match_strategy, l.local_user_id
+         FROM directory_accounts a
+         JOIN directory_account_links l ON l.directory_account_id = a.id
+        WHERE a.integration_id = $1
+        ORDER BY a.external_user_id`,
+      [integrationId],
+    )
+    const byExternalId = new Map(links.rows.map((row) => [row.external_user_id, row]))
+
+    // Email pair: exactly one of {A, B} was auto_admit-created; the other resolved as an
+    // 'email' match against the SAME newly created user — apply does not care which pulled
+    // account "wins", only that exactly one new user results per pair.
+    const emailRows = [byExternalId.get(DT_DUP_EMAIL_A), byExternalId.get(DT_DUP_EMAIL_B)]
+    const emailCreated = emailRows.filter((row) => row?.match_strategy === 'auto_admit')
+    const emailMatched = emailRows.filter((row) => row?.match_strategy === 'email')
+    expect(emailCreated).toHaveLength(1)
+    expect(emailMatched).toHaveLength(1)
+    expect(emailCreated[0]?.link_status).toBe('linked')
+    expect(emailMatched[0]?.link_status).toBe('pending')
+    expect(emailMatched[0]?.local_user_id).toBe(emailCreated[0]?.local_user_id)
+
+    // Mobile pair: same shape, via the mobile match strategy.
+    const mobileRows = [byExternalId.get(DT_DUP_MOBILE_A), byExternalId.get(DT_DUP_MOBILE_B)]
+    const mobileCreated = mobileRows.filter((row) => row?.match_strategy === 'auto_admit')
+    const mobileMatched = mobileRows.filter((row) => row?.match_strategy === 'mobile')
+    expect(mobileCreated).toHaveLength(1)
+    expect(mobileMatched).toHaveLength(1)
+    expect(mobileCreated[0]?.link_status).toBe('linked')
+    expect(mobileMatched[0]?.link_status).toBe('pending')
+    expect(mobileMatched[0]?.local_user_id).toBe(mobileCreated[0]?.local_user_id)
+
+    // Solo new user: its own independent auto-admit, never merged with either pair (proves
+    // the fix cannot over-dedupe — a genuinely distinct account still counts and gets created).
+    const solo = byExternalId.get(DT_DUP_SOLO)
+    expect(solo?.match_strategy).toBe('auto_admit')
+    expect(solo?.link_status).toBe('linked')
+    expect(solo?.local_user_id).not.toBe(emailCreated[0]?.local_user_id)
+    expect(solo?.local_user_id).not.toBe(mobileCreated[0]?.local_user_id)
+
+    // Exactly 3 distinct new local users total across the whole batch.
+    const distinctNewUserIds = new Set([
+      emailCreated[0]?.local_user_id,
+      mobileCreated[0]?.local_user_id,
+      solo?.local_user_id,
+    ])
+    expect(distinctNewUserIds.size).toBe(3)
+
+    const newUserCount = await query<{ n: string }>(
+      `SELECT COUNT(*)::text AS n FROM users WHERE id = ANY($1::text[])`,
+      [Array.from(distinctNewUserIds) as string[]],
+    )
+    expect(newUserCount.rows[0].n).toBe('3')
+  })
+})

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -627,6 +627,26 @@ describe('adminDirectoryRouter', () => {
     expect(directoryMocks.previewDirectorySyncIntegration).not.toHaveBeenCalled()
   })
 
+  // R3: previewing while a real sync holds the lease doubles the shared DingTalk API quota
+  // the lease exists to bound. Same benign "already running" state as the sync-trigger
+  // branches above — mapped identically (409 + activeRunId, never a 500 that pages on-call).
+  it('maps a lease conflict to 409 with the active runId on the preview path', async () => {
+    directoryMocks.previewDirectorySyncIntegration.mockRejectedValue(new DirectorySyncInProgressError('run-live-3'))
+
+    const response = await invokeRoute('post', '/integrations/:integrationId/sync/preview', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'DIRECTORY_SYNC_IN_PROGRESS', details: { activeRunId: 'run-live-3' } },
+    })
+    // The load-bearing property: a refused preview never falls through to the sync path.
+    expect(directoryMocks.syncDirectoryIntegration).not.toHaveBeenCalled()
+  })
+
   it('tests a saved integration by forwarding the integrationId and payload to the directory service', async () => {
     directoryMocks.testDirectoryIntegration.mockResolvedValue({
       corpId: 'dingcorp',

--- a/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
@@ -31,6 +31,7 @@ import {
   DIRECTORY_SYNC_LEASE_STALE_MINUTES,
   DirectorySyncInProgressError,
   DirectorySyncLeaseLostError,
+  previewDirectorySyncIntegration,
   reclaimStaleDirectorySyncRuns,
   syncDirectoryIntegration,
 } from '../../src/directory/directory-sync'
@@ -356,6 +357,66 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
       expect(failureWrite).toBeDefined()
       expect(failureWrite?.params?.[0]).toBe(RUN_ID)
       expect(String(failureWrite?.params?.[1])).toContain('lost its lease while still alive')
+    })
+  })
+
+  /**
+   * R3 — preview must not double the shared DingTalk API quota the lease exists to bound.
+   * `previewDirectorySyncIntegration` pulls the FULL directory just like apply does, so
+   * running it while a real sync holds the lease consumes the same quota twice. Unlike
+   * apply, preview never claims the lease (`claimDirectorySyncRun`/`INSERT INTO
+   * directory_sync_runs` must never appear here) — it only asks `findActiveDirectorySyncRunId`
+   * whether a run is currently `running` and refuses, read-only, before any outbound call.
+   */
+  describe('previewDirectorySyncIntegration refuses while a run holds the lease (R3)', () => {
+    it('refuses a preview while a sync is running and never touches the DingTalk API', async () => {
+      pgMocks.query
+        // getIntegrationRow
+        .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+        // findActiveDirectorySyncRunId
+        .mockResolvedValueOnce({ rows: [{ id: 'run-active' }] })
+
+      await expect(previewDirectorySyncIntegration('dir-1'))
+        .rejects.toBeInstanceOf(DirectorySyncInProgressError)
+
+      // The load-bearing assertion: the expensive, quota-consuming pull never started.
+      expect(dingtalkMocks.fetchDingTalkAppAccessToken).not.toHaveBeenCalled()
+      expect(dingtalkMocks.listDingTalkDepartments).not.toHaveBeenCalled()
+    })
+
+    it('carries the active run id, and never claims a lease of its own', async () => {
+      pgMocks.query
+        .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+        .mockResolvedValueOnce({ rows: [{ id: 'run-active' }] })
+
+      const error = await previewDirectorySyncIntegration('dir-1').catch((err) => err)
+      expect(error).toBeInstanceOf(DirectorySyncInProgressError)
+      expect((error as DirectorySyncInProgressError).activeRunId).toBe('run-active')
+      expect((error as DirectorySyncInProgressError).statusCode).toBe(409)
+
+      // Preview is read-only: it must never attempt to claim the lease it is checking.
+      const insertedRunRow = pgMocks.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO directory_sync_runs'))
+      expect(insertedRunRow).toBe(false)
+    })
+
+    it('proceeds with the pull when no run is active', async () => {
+      pgMocks.query.mockImplementation(async (sql: unknown) => {
+        const text = String(sql)
+        if (text.includes('FROM directory_integrations')) return { rows: [INTEGRATION_ROW] }
+        if (text.includes('FROM directory_sync_runs') && text.includes("status = 'running'")) return { rows: [] }
+        if (text.includes('FROM directory_accounts')) return { rows: [] }
+        return { rows: [] }
+      })
+      dingtalkMocks.fetchDingTalkAppAccessToken.mockResolvedValue('token')
+      dingtalkMocks.listDingTalkDepartments.mockResolvedValue([])
+      dingtalkMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+      dingtalkMocks.listDingTalkDepartmentUsers.mockResolvedValue({ users: [], hasMore: false, nextCursor: null })
+
+      const preview = await previewDirectorySyncIntegration('dir-1')
+
+      expect(preview.integrationId).toBe('dir-1')
+      // No active run this time — the pull proceeds.
+      expect(dingtalkMocks.fetchDingTalkAppAccessToken).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## What / why

Two scoped correctness fixes to `previewDirectorySyncIntegration` (DT-OPS-02), from the design-verif MD residual tracker.

**FIX 1 — same-batch preview overcount.** Preview counted two brand-new pulled users who share an email/mobile as 2 separate `autoAdmissionCandidateCount` entries, because it walks `resolveDirectoryIdentityMatch` against `identityMatchMaps` built once up front. Apply, however, mutates those same maps as it admits users *within a single run* — so the second duplicate resolves `matched:'email'`/`'mobile'` against the user apply just created for the first, and only 1 user is actually created. Preview now mirrors apply's post-admit map mutations (`emailMap.set` / `mobileMap.set` / ambiguous-key deletes / identity-map sets) with a sentinel userId (`'preview-would-admit'`) right after counting an in-scope candidate, keyed with the exact same `normalizeText`/`normalizeMobileIdentifier` helpers `resolveDirectoryIdentityMatch` uses internally — so a later duplicate in the same pull resolves against it exactly as it would resolve against the real created user.

**FIX 2 (R3) — preview ignored the sync lease.** `previewDirectorySyncIntegration` pulls the FULL DingTalk directory (same API quota as a real sync) with no lease check at all. Running a preview while a real sync is in flight for the same integration doubles the shared API quota consumption the DT-HARDEN-05 lease exists to bound. Preview now calls the existing `findActiveDirectorySyncRunId` **read-only** (it never claims a lease of its own — unlike apply, no `claimDirectorySyncRun`/`INSERT INTO directory_sync_runs`) before the pull, and throws `DirectorySyncInProgressError` when a run is active. The preview route (`POST /integrations/:id/sync/preview`) now maps that error to 409 + `activeRunId`, exactly like the two sync-trigger branches already do.

## Honest gaps (not proven / by design)

- **FIX 1 residual** (documented in the doc-comment): preview cannot foresee an apply-side creation **failure**. If `createDirectoryAdmittedUserInTransaction` throws mid-run for the first half of a duplicate pair, apply's catch block skips its own map mutation, so apply's own second-duplicate resolution differs from a clean run too — this is an apply-side divergence unrelated to preview, and preview (which cannot know a future apply run will fail) always mutates the maps. Preview and apply only diverge here when apply itself fails partway through a run — not a preview bug.
- FIX 1's new test only proves the same-email and same-mobile duplicate shapes; it does not add a case for two new users sharing only an `external_key`/`union_id`/`open_id` (the sentinel mutation covers that map too, per the brief's `proposedFix`, but it isn't independently exercised by a new fixture — a real DingTalk pull cannot produce two accounts with the same union/open id in practice, so this is lower-risk than the email/mobile paths).
- FIX 2's real-DB coverage is the existing `directory-sync-run-lease.db.test.ts` (untouched, still green) proving the underlying lease/reclaim mechanics against real Postgres; the NEW preview-refusal assertions are unit-level (mocked pg), following the same precedent the existing `syncDirectoryIntegration` lease tests already use in that file. I did not add a dedicated real-DB preview-refusal test — the lease semantics themselves are already real-DB-proven, and mocked-pg is the "cheaper honest seam" the brief pointed at.

## Tests

All run against a fresh `lane_dtpreview_*` Postgres DB (dropped after) + `tsc --noEmit` (clean) + full `tests/unit` (**4667/4667 passed, 347 files**).

- `tests/integration/directory-sync-preview-apply-parity.db.test.ts` (already whitelisted in `plugin-tests.yml` — no new wiring): extended with a new `describe` block — a separate integration fixture with two users sharing an email, two sharing a mobile, and one solo new user. **6/6 passed** (4 pre-existing + 2 new):
  - `preview counts exactly 3 candidates — one per duplicate pair plus the solo user, not 5`
  - `apply creates exactly 3 users for the batch — preview/apply parity holds for intra-batch duplicates`
- `tests/unit/directory-sync-run-lease.test.ts` (mocked-pg precedent, matches the existing `syncDirectoryIntegration` lease pins in the same file): new `describe` block, **3 new tests, 16/16 passed** in the file:
  - refuses a preview while a sync is running and never touches the DingTalk API
  - carries the active run id, and never claims a lease of its own (asserts no `INSERT INTO directory_sync_runs`)
  - proceeds with the pull when no run is active (happy-path smoke)
- `tests/unit/admin-directory-routes.test.ts`: **1 new test, all 60 tests in the file passed**:
  - `maps a lease conflict to 409 with the active runId on the preview path`

## Mutation table

| Mutation | Test that goes RED | Confirmed |
|---|---|---|
| Remove the sentinel map-mutation block in the preview loop (FIX 1) | Both new cases in `directory-sync-preview-apply-parity.db.test.ts` (`preview counts exactly 3...` expected 5 got 3→**5**; `apply creates exactly 3...` expected 5 got **3**) | ✅ RED, confirmed |
| Remove the `findActiveDirectorySyncRunId` lease check from `previewDirectorySyncIntegration` (FIX 2) | Both new `directory-sync-run-lease.test.ts` R3 tests (`TypeError: children is not iterable` instead of `DirectorySyncInProgressError` — the pull proceeded and hit the mocked DingTalk client with a stale mock queue) | ✅ RED, confirmed |
| Remove the `instanceof DirectorySyncInProgressError` branch from the preview route's catch (FIX 2, route side) | `maps a lease conflict to 409 with the active runId on the preview path` (500 instead of 409) | ✅ RED, confirmed |

Each mutation was applied on top of the committed implementation, run to confirm RED, then restored via `git checkout --` per the mutation-testing protocol (working tree is clean — `git diff --stat 685643cfc..HEAD` shows exactly the 5 intended files, 338 insertions / 5 deletions).

## Base / scope

Base is `origin/main` at merge `685643cfc` (DT-HARDEN-05, #3903) — confirmed an ancestor of current `origin/main`, and no intervening main commit touches any of the 5 files this PR changes, so no conflict risk.

Scope: `packages/core-backend/src/directory/directory-sync.ts`, `packages/core-backend/src/routes/admin-directory.ts`, and their test files only. Per lane discipline, **not merging/arming this PR** — landing is gated and serialized by the main loop (Wave 2, lands after the Wave 1 queue drains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)