### PR TITLE
feat(directory): per-run sync change summary persisted into directory_sync_runs.stats (R5)

### DIFF
--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -31,7 +31,7 @@ import { invalidateUserPerms } from '../rbac/service'
 import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../security/encrypted-secrets'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 import { SimpleCronExpression } from '../services/SchedulerService'
-import { deliverDirectorySyncFailureAlert } from './directory-sync-alert-delivery'
+import { deliverDirectorySyncFailureAlert, getDirectoryManagerBindingCoverage } from './directory-sync-alert-delivery'
 
 const logger = new Logger('DirectorySync')
 const DEFAULT_ORG_ID = 'default'
@@ -2856,6 +2856,10 @@ export async function syncDirectoryIntegration(
   await reclaimStaleDirectorySyncRuns(integrationId)
   const runResult = await claimDirectorySyncRun(integrationId, triggeredBy, triggerSource)
   const runId = runResult.rows[0].id
+  // R5: wall-clock anchor for stats.durationMs. Measured app-side from the lease claim to
+  // just before the completion UPDATE (stats is serialized inside the transaction), so it
+  // is immune to app/DB clock skew that started_at/finished_at arithmetic would inherit.
+  const runStartedAtMs = Date.now()
   hooks.onRunStarted?.(runId)
 
   // DT-HARDEN-05 heartbeat: prove this run is alive for as long as it holds the lease.
@@ -2919,8 +2923,16 @@ export async function syncDirectoryIntegration(
     const autoAdmissionOnboardingPackets: DirectoryAutoAdmissionOnboardingPacket[] = []
 
     await transaction(async (client) => {
+      // R5: created-vs-updated split for the run summary. `departmentsSynced`/`accountsSynced`
+      // conflate "0 new" and "500 new"; the discriminator is `(xmax = 0)` on the upserted row —
+      // a freshly INSERTed tuple has xmax 0, an ON CONFLICT DO UPDATE tuple carries the updating
+      // transaction's xid (pg-only repo, standard PostgreSQL trick). Read defensively
+      // (`rows[0]?.created === true`) so a fake client answering empty rows in unit suites
+      // falls into the "updated" bucket instead of throwing.
+      let departmentsCreatedCount = 0
+      let departmentsUpdatedCount = 0
       for (const department of departments.values()) {
-        await client.query(
+        const departmentUpsert = await client.query(
           `INSERT INTO directory_departments (
              integration_id, provider, external_department_id, external_parent_department_id, name,
              full_path, order_index, is_active, raw, last_seen_at, created_at, updated_at
@@ -2935,7 +2947,8 @@ export async function syncDirectoryIntegration(
              is_active = true,
              raw = EXCLUDED.raw,
              last_seen_at = EXCLUDED.last_seen_at,
-             updated_at = NOW()`,
+             updated_at = NOW()
+           RETURNING (xmax = 0) AS created`,
           [
             integrationId,
             DEFAULT_PROVIDER,
@@ -2953,12 +2966,16 @@ export async function syncDirectoryIntegration(
             syncTimestamp,
           ],
         )
+        if (departmentUpsert.rows[0]?.created === true) departmentsCreatedCount += 1
+        else departmentsUpdatedCount += 1
       }
 
+      let accountsCreatedCount = 0
+      let accountsUpdatedCount = 0
       const userList = Array.from(users.values())
       for (const user of userList) {
         const externalKey = normalizeText(user.unionId || user.openId || user.userId)
-        await client.query(
+        const accountUpsert = await client.query(
           `INSERT INTO directory_accounts (
              integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key,
              name, nick, email, mobile, job_number, title, avatar_url, is_active, raw, last_seen_at, created_at, updated_at
@@ -2979,7 +2996,8 @@ export async function syncDirectoryIntegration(
              is_active = true,
              raw = EXCLUDED.raw,
              last_seen_at = EXCLUDED.last_seen_at,
-             updated_at = NOW()`,
+             updated_at = NOW()
+           RETURNING (xmax = 0) AS created`,
           [
             integrationId,
             DEFAULT_PROVIDER,
@@ -2999,14 +3017,24 @@ export async function syncDirectoryIntegration(
             syncTimestamp,
           ],
         )
+        if (accountUpsert.rows[0]?.created === true) accountsCreatedCount += 1
+        else accountsUpdatedCount += 1
       }
 
-      await client.query(
+      // R5, mirroring the DT-OPS-01 account sweep below: `AND is_active = true` makes this a
+      // TRANSITION (departments that departed in THIS run), not a re-stamp of every
+      // long-gone department on every sync — without it the per-run count would report the
+      // same departed department forever. The resulting state is identical for already-
+      // inactive rows (nothing reads directory_departments.updated_at); only the honest
+      // count is new.
+      const deactivatedDepartmentsResult = await client.query(
         `UPDATE directory_departments
          SET is_active = false, updated_at = NOW()
-         WHERE integration_id = $1 AND last_seen_at < $2`,
+         WHERE integration_id = $1 AND last_seen_at < $2 AND is_active = true
+         RETURNING id`,
         [integrationId, syncTimestamp],
       )
+      const departmentsDeactivatedCount = deactivatedDepartmentsResult.rows.length
       // DT-OPS-01: `AND is_active = true` makes this a TRANSITION, not a re-stamp of the
       // whole backlog. Without it the deprovision executor re-processed every account ever
       // deactivated on every sync — audit spam, and it would stomp a reactivation.
@@ -3314,9 +3342,32 @@ export async function syncDirectoryIntegration(
         enabled: isDirectoryDeprovisionEnabled(),
       })
 
+      // R5: per-run manager-binding snapshot. The live GET /manager-coverage endpoint
+      // (#3914) answers "what is coverage NOW"; persisting the same numbers here answers
+      // "what did THIS run leave it at", so admins can see the trend across runs. Runs
+      // through the transaction client on purpose: it must see this run's (uncommitted)
+      // final link state, and `getDirectoryManagerBindingCoverage`'s queryFn is injectable
+      // for exactly this. Placed after the link loop, member-group projection and
+      // deprovision so it is the end-of-run snapshot.
+      const managerBindingCoverage = await getDirectoryManagerBindingCoverage(
+        integrationId,
+        (sql, params) => client.query(sql, params),
+      )
+
       const stats = {
         departmentsSynced: departments.size,
         accountsSynced: users.size,
+        // R5 per-run change summary — all additive; every pre-existing key above/below is kept.
+        departmentsCreatedCount,
+        departmentsUpdatedCount,
+        departmentsDeactivatedCount,
+        accountsCreatedCount,
+        accountsUpdatedCount,
+        accountsDeactivatedCount: deactivatedAccountIds.length,
+        managerCount: managerBindingCoverage.managerCount,
+        linkedManagerCount: managerBindingCoverage.linkedManagerCount,
+        managerCoverage: managerBindingCoverage.coverage,
+        durationMs: Date.now() - runStartedAtMs,
         deprovisionApplied: deprovisionOutcome.applied,
         deprovisionCandidateCount: deprovisionOutcome.candidateCount,
         deprovisionManualReviewCount: deprovisionOutcome.manualReviewCount,

--- a/packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts
@@ -1,9 +1,34 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+// R5 (per-run summary block below): the DingTalk HTTP client is mocked so real
+// `syncDirectoryIntegration` runs can pull a synthetic directory against real Postgres.
+// The DT-OPS-03 blocks in this file never touch the client, so they are unaffected.
+const clientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: clientMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: clientMocks.listDingTalkDepartments,
+  getDingTalkDepartmentDetail: clientMocks.getDingTalkDepartmentDetail,
+  listDingTalkDepartmentUsers: clientMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
+}))
+
 import { query } from '../../src/db/pg'
 import {
   countConsecutiveFailedRuns,
   getDirectoryManagerBindingCoverage,
 } from '../../src/directory/directory-sync-alert-delivery'
+import {
+  createDirectoryIntegration,
+  listDirectorySyncRuns,
+  syncDirectoryIntegration,
+} from '../../src/directory/directory-sync'
 
 /**
  * DT-OPS-03 P2-2 — REAL DB coverage. The unit test (directory-sync-alert-delivery.test.ts)
@@ -214,5 +239,238 @@ describeIfDatabase('DT-OPS-03 manager binding coverage + failure streak (real DB
       const streak = await countConsecutiveFailedRuns(integrationId)
       expect(streak).toBe(0)
     })
+  })
+})
+
+/**
+ * R5 — per-run directory sync summary persisted into directory_sync_runs.stats.
+ *
+ * Drives the REAL `syncDirectoryIntegration` (mocked DingTalk pull, real Postgres apply)
+ * four times over an evolving synthetic directory and asserts the run rows carry an honest
+ * change summary: created-vs-updated split (the `(xmax = 0)` upsert discriminator — this is
+ * exactly what mocks cannot exercise), per-run deactivation TRANSITION counts, the
+ * manager-binding coverage snapshot, and durationMs. Real-DB on purpose: ON CONFLICT
+ * resolution and xmax semantics only exist in PostgreSQL.
+ *
+ * The `it` blocks are order-dependent (run 1 → run 4), matching this file's existing style.
+ */
+describeIfDatabase('R5 per-run sync summary stats (real DB)', () => {
+  const CORP = `dsrs-corp-${TS}`
+  const D1 = `dsrs-d1-${TS}`
+  const D2 = `dsrs-d2-${TS}`
+  const EXT_M1 = `dsrs-ext-m1-${TS}` // dept head of D1, pre-seeded + pre-linked
+  const EXT_M2 = `dsrs-ext-m2-${TS}` // leader_in_dept manager, never linked
+  const EXT_E3 = `dsrs-ext-e3-${TS}` // plain employee, departs before run 2
+  const U_MGR = `dsrs-umgr-${TS}` // local user M1 is linked to
+
+  let integrationId = ''
+  // Which directory the mocked DingTalk tenant currently answers with.
+  let pullScenario: 'full' | 'e3Departed' | 'd2Departed' = 'full'
+
+  function userDetail(userId: string, name: string, source: Record<string, unknown> = {}) {
+    return {
+      userId,
+      name,
+      unionId: `dsrs-un-${userId}`,
+      openId: `dsrs-op-${userId}`,
+      email: undefined,
+      mobile: undefined,
+      departmentIds: [] as string[],
+      source,
+    }
+  }
+
+  beforeAll(async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, role)
+       VALUES ($1, $2, 'DSRS Manager', 'x', 'user')
+       ON CONFLICT (id) DO NOTHING`,
+      [U_MGR, `${U_MGR}@example.test`],
+    )
+
+    const integration = await createDirectoryIntegration({
+      name: `dsrs-${TS}`,
+      corpId: CORP,
+      appKey: `dsrs-appkey-${TS}`,
+      appSecret: 'dsrs-appsecret',
+      admissionMode: 'manual_only',
+    })
+    integrationId = integration.id
+
+    // Pre-seed M1 as an existing, LINKED directory account: run 1 must count it as
+    // UPDATED (upsert hits ON CONFLICT), and coverage must count it as the one bound manager.
+    const m1Account = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (
+         integration_id, corp_id, external_user_id, union_id, external_key, name, is_active, last_seen_at, created_at, updated_at
+       ) VALUES ($1, $2, $3, $4, $4, 'Manager One', true, NOW(), NOW(), NOW())
+       RETURNING id`,
+      [integrationId, CORP, EXT_M1, `dsrs-un-${EXT_M1}`],
+    )).rows[0].id
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at)
+       VALUES ($1, $2, 'linked', 'manual', NOW(), NOW())`,
+      [m1Account, U_MGR],
+    )
+
+    clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('dsrs-token')
+    clientMocks.listDingTalkDepartments.mockImplementation(async (_token: string, parentId: string) => {
+      if (parentId !== '1') return []
+      const children = [{ id: D1, parentId: '1', name: 'Ops', order: 0, source: {} }]
+      if (pullScenario !== 'd2Departed') {
+        children.push({ id: D2, parentId: '1', name: 'Empty Wing', order: 1, source: {} })
+      }
+      return children
+    })
+    // D1 names M1 as its department head (dept_manager_userid_list manager path).
+    clientMocks.getDingTalkDepartmentDetail.mockImplementation(async (_token: string, deptId: string) => ({
+      deptManagerUserIdList: deptId === D1 ? [EXT_M1] : [],
+    }))
+    clientMocks.listDingTalkDepartmentUsers.mockImplementation(async (_token: string, deptId: string) => {
+      if (deptId === D1) {
+        const users = [
+          { userId: EXT_M1, name: 'Manager One', departmentIds: [D1], source: {} },
+          { userId: EXT_M2, name: 'Manager Two', departmentIds: [D1], source: {} },
+        ]
+        if (pullScenario === 'full') {
+          users.push({ userId: EXT_E3, name: 'Employee Three', departmentIds: [D1], source: {} })
+        }
+        return { users, nextCursor: null, hasMore: false }
+      }
+      return { users: [], nextCursor: null, hasMore: false }
+    })
+    clientMocks.getDingTalkUserDetail.mockImplementation(async (_token: string, userId: string) => {
+      switch (userId) {
+        case EXT_M1:
+          return userDetail(EXT_M1, 'Manager One')
+        case EXT_M2:
+          // leader_in_dept manager path (account raw), never linked to a local user.
+          return userDetail(EXT_M2, 'Manager Two', { leader_in_dept: [{ dept_id: 999, leader: true }] })
+        case EXT_E3:
+          return userDetail(EXT_E3, 'Employee Three')
+        default:
+          throw new Error(`unexpected userId ${userId}`)
+      }
+    })
+  })
+
+  afterAll(async () => {
+    if (integrationId) {
+      await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_account_links WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`, [integrationId])
+      await query(`DELETE FROM directory_account_departments WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`, [integrationId])
+      await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+    }
+    await query(`DELETE FROM users WHERE id = $1`, [U_MGR])
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('run 1: first sync splits created vs updated (xmax discriminator), snapshots manager coverage, keeps pre-existing stats keys, and flows through the runs list', async () => {
+    pullScenario = 'full'
+    const result = await syncDirectoryIntegration(integrationId, 'system:dsrs-test')
+    const stats = result.run.stats as Record<string, unknown>
+
+    // Departments: synthetic root + D1 + D2, all new to the DB.
+    expect(stats.departmentsSynced).toBe(3)
+    expect(stats.departmentsCreatedCount).toBe(3)
+    expect(stats.departmentsUpdatedCount).toBe(0)
+    expect(stats.departmentsDeactivatedCount).toBe(0)
+
+    // Accounts: M2 + E3 are genuinely new (INSERT, xmax=0); pre-seeded M1 hits
+    // ON CONFLICT DO UPDATE (xmax != 0). A mock could never prove this split.
+    expect(stats.accountsSynced).toBe(3)
+    expect(stats.accountsCreatedCount).toBe(2)
+    expect(stats.accountsUpdatedCount).toBe(1)
+    expect(stats.accountsDeactivatedCount).toBe(0)
+
+    // Manager coverage snapshot: M1 (dept head, linked) + M2 (leader_in_dept, unlinked).
+    expect(stats.managerCount).toBe(2)
+    expect(stats.linkedManagerCount).toBe(1)
+    expect(stats.managerCoverage).toBe(0.5)
+
+    expect(typeof stats.durationMs).toBe('number')
+    expect(stats.durationMs as number).toBeGreaterThanOrEqual(0)
+
+    // The summary is ADDITIVE: pre-existing completion keys must survive the merge.
+    expect(stats.linkedCount).toBe(1)
+    expect(stats.pendingCount).toBe(0)
+    expect(stats.unmatchedCount).toBe(2)
+    expect(stats.autoAdmittedCount).toBe(0)
+    expect(stats.deprovisionApplied).toBe(false)
+
+    // The persisted snapshot must agree with the live #3914 coverage function that
+    // GET /manager-coverage serves — same numbers, one from the run row, one live.
+    const live = await getDirectoryManagerBindingCoverage(integrationId)
+    expect(live).toEqual({ managerCount: 2, linkedManagerCount: 1, coverage: 0.5 })
+    expect(stats.managerCount).toBe(live.managerCount)
+    expect(stats.linkedManagerCount).toBe(live.linkedManagerCount)
+    expect(stats.managerCoverage).toBe(live.coverage)
+
+    // OPS-02 surface: GET /integrations/:id/runs serves listDirectorySyncRuns verbatim —
+    // the new keys must arrive there with no route change.
+    const runs = await listDirectorySyncRuns(integrationId, { limit: 5, offset: 0 })
+    const listed = runs.items.find((item) => item.id === result.run.id)
+    expect(listed).toBeTruthy()
+    const listedStats = listed?.stats as Record<string, unknown>
+    expect(listedStats.accountsCreatedCount).toBe(2)
+    expect(listedStats.accountsUpdatedCount).toBe(1)
+    expect(listedStats.managerCoverage).toBe(0.5)
+    expect(typeof listedStats.durationMs).toBe('number')
+  })
+
+  it('run 2: after one user departs — nothing created, survivors updated, departure counted as deactivated', async () => {
+    pullScenario = 'e3Departed'
+    const result = await syncDirectoryIntegration(integrationId, 'system:dsrs-test')
+    const stats = result.run.stats as Record<string, unknown>
+
+    expect(stats.accountsCreatedCount).toBe(0)
+    expect(stats.accountsUpdatedCount).toBe(2)
+    expect(stats.accountsDeactivatedCount).toBe(1)
+
+    expect(stats.departmentsCreatedCount).toBe(0)
+    expect(stats.departmentsUpdatedCount).toBe(3)
+    expect(stats.departmentsDeactivatedCount).toBe(0)
+
+    // Cross-check the count against the actual DB effect: E3 really is inactive now.
+    const e3 = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM directory_accounts WHERE integration_id = $1 AND external_user_id = $2`,
+      [integrationId, EXT_E3],
+    )
+    expect(e3.rows[0]?.is_active).toBe(false)
+  })
+
+  it('run 3: a department departs — counted once; the already-inactive account is NOT re-counted', async () => {
+    pullScenario = 'd2Departed'
+    const result = await syncDirectoryIntegration(integrationId, 'system:dsrs-test')
+    const stats = result.run.stats as Record<string, unknown>
+
+    expect(stats.departmentsSynced).toBe(2)
+    expect(stats.departmentsCreatedCount).toBe(0)
+    expect(stats.departmentsUpdatedCount).toBe(2)
+    expect(stats.departmentsDeactivatedCount).toBe(1)
+    // E3 went inactive in run 2; a TRANSITION count must not report it again.
+    expect(stats.accountsDeactivatedCount).toBe(0)
+  })
+
+  it('run 4: steady state — deactivation counts are transitions, not a re-stamp of the backlog', async () => {
+    pullScenario = 'd2Departed'
+    const result = await syncDirectoryIntegration(integrationId, 'system:dsrs-test')
+    const stats = result.run.stats as Record<string, unknown>
+
+    // D2 and E3 are long gone; without the `AND is_active = true` predicate both
+    // deactivation sweeps would report them on every run forever.
+    expect(stats.departmentsDeactivatedCount).toBe(0)
+    expect(stats.accountsDeactivatedCount).toBe(0)
+    expect(stats.accountsCreatedCount).toBe(0)
+    expect(stats.accountsUpdatedCount).toBe(2)
+
+    // Coverage snapshot is stable across runs when nothing about managers changed.
+    expect(stats.managerCount).toBe(2)
+    expect(stats.linkedManagerCount).toBe(1)
+    expect(stats.managerCoverage).toBe(0.5)
   })
 })


### PR DESCRIPTION
## What / why

R5 from the DingTalk backlog pool: a completed directory sync run's `stats` jsonb previously conflated "0 new" and "500 new" (`accountsSynced` is just the pull size), never recorded what THIS run deactivated, and manager-binding coverage (#3914) was live-only with no per-run trend. This persists a complete, honest per-run change summary — **all-additive, no schema change** (`directory_sync_runs.stats` is already jsonb), **no route change** (`GET /integrations/:id/runs` passes `stats` through `summarizeRun` verbatim — verified by test), **no FE change** (the run panel reads defensively via `readNumericStat`; rendering the new keys is a separate FE slice).

New stats keys written at the single completion write point, merged into the existing stats object with every pre-existing key kept:

- `accountsCreatedCount` / `accountsUpdatedCount`, `departmentsCreatedCount` / `departmentsUpdatedCount` — via `RETURNING (xmax = 0) AS created` on both upserts (freshly INSERTed tuple has xmax 0; ON CONFLICT DO UPDATE carries the updating xid — standard PostgreSQL discriminator, pg-only repo). Read defensively (`rows[0]?.created === true`) so unit-suite fake clients answering `{ rows: [] }` don't throw.
- `accountsDeactivatedCount` — from the DT-OPS-01 transition sweep's ids already in memory.
- `departmentsDeactivatedCount` — via `RETURNING id` on the departments sweep.
- `managerCount` / `linkedManagerCount` / `managerCoverage` — `getDirectoryManagerBindingCoverage` run through the **transaction client** (queryFn was already injectable), so the snapshot sees this run's final (uncommitted) link state; end-of-run placement after link loop + member groups + deprovision.
- `durationMs` — lease claim → completion write, app-side clock only (no app/DB clock-skew arithmetic).

## Behavior change flagged for ops (the one non-additive edit)

The departments deactivation sweep now carries `AND is_active = true`, mirroring the DT-OPS-01 account sweep: it is a TRANSITION (what departed this run), not a re-stamp of every long-departed department on every sync. End state is identical for already-inactive rows; the only observable difference is `directory_departments.updated_at` is no longer re-stamped on them — grepped the backend: nothing reads that column for logic. Without this the per-run count would report the same departed department forever (run-4 test pins this).

## Tests (real DB required — xmax + ON CONFLICT cannot be mocked honestly)

Extended the already-whitelisted `directory-sync-alert-coverage.db.test.ts` (both wiring points already exist: vitest.config.ts exclude + plugin-tests.yml whole-file entry — **zero new CI wiring**). Chose it over the parity suite deliberately: #4049 (Wave 2, lands before this) touches `directory-sync-preview-apply-parity.db.test.ts`, so extending the alert-coverage file keeps the eventual 3-way merge clean. All source edits sit in the `syncDirectoryIntegration` region (ends ~line 3400); #4049's hunks start at the preview doc-comment (~3476) — no overlap.

New block drives the REAL `syncDirectoryIntegration` 4 times (mocked DingTalk pull, real Postgres apply) over an evolving directory:

- run 1 (seeded: 1 pre-existing linked manager account + 2 new pulled users): `created=2, updated=1`, `managerCount=2 / linkedManagerCount=1 / managerCoverage=0.5` equal to the live #3914 function's own numbers, `durationMs >= 0`, pre-existing keys (`linkedCount`, `unmatchedCount`, `deprovisionApplied`, …) survive the merge, and the new keys arrive through `listDirectorySyncRuns` (the GET /runs surface) with no route change
- run 2 (one user departs): `created=0, updated=2, accountsDeactivatedCount=1` + DB cross-check that the account really is inactive
- run 3 (one department departs): `departmentsDeactivatedCount=1`, already-inactive account NOT re-counted
- run 4 (steady state): both deactivation counts 0 — transition semantics pinned

Local evidence on a fresh migrated DB (`lane_perrunsummary_*`): extended suite 11/11; all 8 whitelisted directory real-DB suites 64/64 (gate-corrected arithmetic across the same 8 whitelisted files); full `tests/unit` 4702/4702; `tsc --noEmit` clean.

## Mutation table (each applied to the committed impl, suite re-run, then restored)

| # | Mutation | Result |
|---|---|---|
| M1 | Drop xmax discriminator on account upsert (count every upsert as created) | RED — run 1 (`created 3≠2`), run 2 + run 4 (`created 2≠0`) |
| M2 | Skip the stats merge write (new keys never persisted) | RED — all 4 run tests |
| M3 | Swap coverage numerator/denominator in `getDirectoryManagerBindingCoverage` | RED — existing DT-OPS-03 test + run 1 + run 4 |
| M4 | Drop `AND is_active = true` from departments sweep | RED — run 4 (`departmentsDeactivatedCount 1≠0`) |
| M5 | Hardcode `accountsDeactivatedCount: 0` | RED — run 2 |
| M6 | Miswire coverage call to global pool `query` instead of the transaction client | RED — run 1 (`managerCount 0≠2`: snapshot must see uncommitted in-transaction state) |

## Not proven / honest gaps

- **Failed runs** still leave `stats = '{}'` (only `error_message`) — pre-existing `markSyncFailure` behavior, unchanged and untested here; accepted by the brief.
- `durationMs` excludes the completion UPDATE itself and all post-commit work (invite ledger, deprovision audit) — it measures claim → just-before-completion-write.
- FE rendering of the new keys is **not** in this PR; old run rows lack the keys and `readNumericStat` renders them as 0 — the future FE slice should gate on key presence to distinguish "absent (pre-R5 run)" from a true 0.
- The manager-coverage query adds one heavier CTE query per run inside the write transaction (marginal lengthening; it is the point of the snapshot).
- xmax discriminator is PostgreSQL-specific — fine for this pg-only repo, flagged for the record.
- The new tests' `it` blocks are order-dependent (run 1 → 4), matching the file's existing style.

## Sequencing

Wave 2 of the directory-sync serial queue: lands **after the Wave 1 queue and after #4049** in the Wave 2 serial order. Do not arm auto-merge; landing is gated and serialized by the main loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
