### PR TITLE
fix(ci): publish on-prem bootstrap sidecars

### DIFF
--- a/.github/workflows/multitable-onprem-package-build.yml
+++ b/.github/workflows/multitable-onprem-package-build.yml
@@ -70,6 +70,8 @@ jobs:
           pkg_tgz="$(ls -1 output/releases/multitable-onprem/*.tgz | sort | tail -n 1)"
           pkg_zip="$(ls -1 output/releases/multitable-onprem/*.zip | sort | tail -n 1)"
           pkg_meta="${pkg_tgz%.tgz}.json"
+          pkg_bootstrap_ps1="${pkg_tgz%.tgz}-deploy-bootstrap.ps1"
+          pkg_bootstrap_bat="${pkg_tgz%.tgz}-deploy-bootstrap.bat"
           pkg_name="$(basename "${pkg_tgz%.tgz}")"
           verify_dir="output/releases/multitable-onprem/verify"
           mkdir -p "$verify_dir"
@@ -97,6 +99,8 @@ jobs:
           echo "PACKAGE_FILE=$pkg_tgz" >> "$GITHUB_ENV"
           echo "PACKAGE_FILE_ZIP=$pkg_zip" >> "$GITHUB_ENV"
           echo "PACKAGE_META_FILE=$pkg_meta" >> "$GITHUB_ENV"
+          echo "PACKAGE_BOOTSTRAP_PS1=$pkg_bootstrap_ps1" >> "$GITHUB_ENV"
+          echo "PACKAGE_BOOTSTRAP_BAT=$pkg_bootstrap_bat" >> "$GITHUB_ENV"
           echo "PACKAGE_VERIFY_TGZ_JSON=$verify_tgz_json" >> "$GITHUB_ENV"
           echo "PACKAGE_VERIFY_TGZ_MD=$verify_tgz_md" >> "$GITHUB_ENV"
           echo "PACKAGE_VERIFY_ZIP_JSON=$verify_zip_json" >> "$GITHUB_ENV"
@@ -121,6 +125,10 @@ jobs:
             "$PACKAGE_FILE_ZIP"
             "${PACKAGE_FILE}.sha256"
             "${PACKAGE_FILE_ZIP}.sha256"
+            "$PACKAGE_BOOTSTRAP_PS1"
+            "$PACKAGE_BOOTSTRAP_BAT"
+            "${PACKAGE_BOOTSTRAP_PS1}.sha256"
+            "${PACKAGE_BOOTSTRAP_BAT}.sha256"
             "output/releases/multitable-onprem/SHA256SUMS"
             "$PACKAGE_META_FILE"
             "$PACKAGE_VERIFY_TGZ_JSON"
@@ -144,6 +152,8 @@ jobs:
           path: |
             output/releases/multitable-onprem/*.tgz
             output/releases/multitable-onprem/*.zip
+            output/releases/multitable-onprem/*-deploy-bootstrap.ps1
+            output/releases/multitable-onprem/*-deploy-bootstrap.bat
             output/releases/multitable-onprem/*.sha256
             output/releases/multitable-onprem/SHA256SUMS
             output/releases/multitable-onprem/*.json
@@ -158,6 +168,8 @@ jobs:
             echo ""
             echo "- Package (.tgz): \`${PACKAGE_FILE}\`"
             echo "- Package (.zip): \`${PACKAGE_FILE_ZIP}\`"
+            echo "- First-hop bootstrap (.ps1): \`${PACKAGE_BOOTSTRAP_PS1}\`"
+            echo "- First-hop bootstrap (.bat): \`${PACKAGE_BOOTSTRAP_BAT}\`"
             echo "- Verify (.tgz JSON): \`${PACKAGE_VERIFY_TGZ_JSON}\`"
             echo "- Verify (.zip JSON): \`${PACKAGE_VERIFY_ZIP_JSON}\`"
             echo "- Artifact: \`multitable-onprem-package-${{ github.run_id }}-${{ github.run_attempt }}\`"

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -9,8 +9,10 @@ import { fileURLToPath } from 'node:url'
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const buildScriptPath = path.join(repoRoot, 'scripts/ops/multitable-onprem-package-build.sh')
 const verifyScriptPath = path.join(repoRoot, 'scripts/ops/multitable-onprem-package-verify.sh')
+const packageWorkflowPath = path.join(repoRoot, '.github/workflows/multitable-onprem-package-build.yml')
 const buildScript = fs.readFileSync(buildScriptPath, 'utf8')
 const verifyScript = fs.readFileSync(verifyScriptPath, 'utf8')
+const packageWorkflow = fs.readFileSync(packageWorkflowPath, 'utf8')
 
 function runVerifierFunction(functionName, listEntries) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-package-list-'))
@@ -246,6 +248,43 @@ test('on-prem package build emits first-hop Windows bootstrap sidecar assets', (
     verifyScript,
     /first-hop bootstrap release sidecar/,
     'package verifier should require the package metadata to describe the bootstrap sidecar',
+  )
+})
+
+test('on-prem release and workflow artifacts publish both first-hop bootstrap sidecars', () => {
+  assert.match(
+    packageWorkflow,
+    /pkg_bootstrap_ps1="\$\{pkg_tgz%\.tgz\}-deploy-bootstrap\.ps1"/,
+    'the workflow should derive the PowerShell sidecar from the selected package name',
+  )
+  assert.match(
+    packageWorkflow,
+    /pkg_bootstrap_bat="\$\{pkg_tgz%\.tgz\}-deploy-bootstrap\.bat"/,
+    'the workflow should derive the batch sidecar from the selected package name',
+  )
+  const releaseAssetsMatch = packageWorkflow.match(/assets=\(\n([\s\S]*?)\n\s+\)/)
+  assert.ok(releaseAssetsMatch, 'the workflow should declare a GitHub Release asset list')
+  const releaseAssets = releaseAssetsMatch[1]
+  for (const asset of [
+    '"$PACKAGE_BOOTSTRAP_PS1"',
+    '"$PACKAGE_BOOTSTRAP_BAT"',
+    '"${PACKAGE_BOOTSTRAP_PS1}.sha256"',
+    '"${PACKAGE_BOOTSTRAP_BAT}.sha256"',
+  ]) {
+    assert.ok(
+      releaseAssets.includes(asset),
+      `the GitHub Release asset list should include ${asset}`,
+    )
+  }
+  assert.match(
+    packageWorkflow,
+    /output\/releases\/multitable-onprem\/\*-deploy-bootstrap\.ps1/,
+    'the workflow artifact should retain the PowerShell bootstrap sidecar',
+  )
+  assert.match(
+    packageWorkflow,
+    /output\/releases\/multitable-onprem\/\*-deploy-bootstrap\.bat/,
+    'the workflow artifact should retain the batch bootstrap sidecar',
   )
 })
 


### PR DESCRIPTION
## Summary

- publish the generated first-hop PowerShell and batch bootstrap sidecars in GitHub Releases;
- retain both sidecars in the Actions package artifact;
- include the sidecar paths in the workflow summary;
- lock the Release asset list and artifact globs with a focused contract test.

## Why

The corrective W3-W6 release generated the sidecars and listed them in `SHA256SUMS`, but the workflow's Release asset array omitted the raw sidecar files and their per-file checksums. The current release was remediated by uploading the four exact, hash-matching assets. This PR prevents future releases from repeating that incomplete download set.

## Verification

```text
node --test scripts/ops/onprem-windows-system-hardening.test.mjs scripts/ops/multitable-onprem-package-no-node-modules.test.mjs scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs
tests=35
pass=35
fail=0
git diff --check=PASS
```

Scope is CI/package publication only. No runtime, migration, adapter, external write, or entity-machine behavior changes.
