### PR TITLE
feat(directory): §7.1 inactive-linked-for-N-days metric + post-run alert

### DIFF
--- a/packages/core-backend/src/directory/directory-sync-alert-delivery.ts
+++ b/packages/core-backend/src/directory/directory-sync-alert-delivery.ts
@@ -367,12 +367,16 @@ export function buildDirectoryInactiveLinkedAlertMessage(options: {
     `- 阈值：${metric.thresholdDays} 天`,
     `- 数量：${metric.count}`,
   ]
-  for (const item of metric.sample.slice(0, 5)) {
+  const shown = Math.min(metric.sample.length, 5)
+  for (const item of metric.sample.slice(0, shown)) {
     const label = item.localUserName || item.localUserEmail || item.localUserId
     lines.push(`  - ${item.accountName || item.externalUserId} → ${label}（已停用 ${item.inactiveDays} 天）`)
   }
-  if (metric.count > metric.sample.length) {
-    lines.push(`  - ……以及其他 ${metric.count - Math.min(metric.sample.length, 5)} 个账号`)
+  // `metric.sample` is already capped (INACTIVE_LINKED_SAMPLE_LIMIT) upstream, so
+  // `count` can exceed `sample.length` even before this message's own 5-item cap —
+  // compare against what was actually SHOWN here, not the upstream sample size.
+  if (metric.count > shown) {
+    lines.push(`  - ……以及其他 ${metric.count - shown} 个账号`)
   }
   return { subject, content: lines.join('\n') }
 }

--- a/packages/core-backend/src/directory/directory-sync-alert-delivery.ts
+++ b/packages/core-backend/src/directory/directory-sync-alert-delivery.ts
@@ -220,3 +220,228 @@ export async function getDirectoryManagerBindingCoverage(
     coverage: managerCount === 0 ? 1 : linkedManagerCount / managerCount,
   }
 }
+
+export type DirectoryInactiveLinkedSample = {
+  directoryAccountId: string
+  externalUserId: string
+  accountName: string | null
+  localUserId: string
+  localUserEmail: string | null
+  localUserName: string | null
+  inactiveSinceAt: string
+  inactiveDays: number
+}
+
+export type DirectoryInactiveLinkedMetric = {
+  thresholdDays: number
+  count: number
+  sample: DirectoryInactiveLinkedSample[]
+}
+
+const INACTIVE_LINKED_SAMPLE_LIMIT = 20
+
+/**
+ * roadmap §7.1 — the offboarding blind spot. `DIRECTORY_DEPROVISION_ENABLED` (DT-OPS-01) is
+ * default-OFF by owner decision, so a directory account going `is_active = false` (DingTalk
+ * removal / the deactivation sweep) does NOT touch the linked local user at all: password
+ * login keeps working indefinitely. The `inactive_linked` review-item filter
+ * (`directory-sync.ts` `buildReviewFilterSql`) surfaces these as a REVIEW QUEUE, but has no
+ * notion of how long an account has sat that way — this is the missing age dimension.
+ *
+ * "Linked" here matches the `inactive_linked` review-item's own definition exactly:
+ * `directory_account_links.local_user_id IS NOT NULL` (link_status is NOT required to be
+ * `'linked'` — a recorded candidate match is enough to mean "this local user inherits
+ * whatever the directory account grants"). We ALSO require the local user to still be
+ * `is_active = true`: a local user already deactivated by some other path is not part of
+ * this specific blind spot (there is nothing left to revoke).
+ *
+ * Anchor for "since when": `directory_accounts.updated_at`. There is no dedicated
+ * deactivation-transition column in this schema. Verified by grepping every write site
+ * that can touch `directory_accounts` in this codebase — there are exactly two, both in
+ * `directory-sync.ts`:
+ *   1. The re-sync upsert (`INSERT ... ON CONFLICT DO UPDATE SET is_active = true, ...,
+ *      updated_at = NOW()`) — only fires for accounts CURRENTLY present in the DingTalk
+ *      pull, and always sets is_active back to true (which takes the row OUT of this
+ *      metric's target set).
+ *   2. The deactivation sweep (`UPDATE directory_accounts SET is_active = false,
+ *      updated_at = NOW() WHERE ... AND is_active = true`) — guarded by `AND is_active =
+ *      true`, i.e. a genuine one-way transition, not a re-stamp. Once a row is inactive,
+ *      this statement's WHERE clause no longer matches it, so it cannot bump `updated_at`
+ *      again while the row stays inactive.
+ * No other module in `packages/core-backend/src` issues an UPDATE or INSERT against
+ * `directory_accounts` (every other reference is a read-only JOIN). So for a row that is
+ * CURRENTLY `is_active = false`, `updated_at` is exactly the timestamp of the transition
+ * into inactivity — an honest anchor, not an approximation, given the current schema.
+ */
+export async function getDirectoryInactiveLinkedMetric(
+  integrationId: string,
+  thresholdDays: number,
+  queryFn: typeof query = query,
+  sampleLimit: number = INACTIVE_LINKED_SAMPLE_LIMIT,
+): Promise<DirectoryInactiveLinkedMetric> {
+  const normalizedThresholdDays = Math.floor(thresholdDays)
+
+  const [countResult, sampleResult] = await Promise.all([
+    queryFn<{ total: number }>(
+      `SELECT COUNT(*)::int AS total
+         FROM directory_accounts a
+         JOIN directory_account_links l ON l.directory_account_id = a.id
+         JOIN users u ON u.id = l.local_user_id
+        WHERE a.integration_id = $1
+          AND a.is_active = FALSE
+          AND u.is_active = TRUE
+          AND a.updated_at <= NOW() - ($2 || ' days')::interval`,
+      [integrationId, normalizedThresholdDays],
+    ),
+    queryFn<{
+      directory_account_id: string
+      external_user_id: string
+      account_name: string | null
+      local_user_id: string
+      local_user_email: string | null
+      local_user_name: string | null
+      inactive_since_at: string
+      inactive_days: number
+    }>(
+      `SELECT a.id AS directory_account_id,
+              a.external_user_id,
+              a.name AS account_name,
+              u.id AS local_user_id,
+              u.email AS local_user_email,
+              u.name AS local_user_name,
+              a.updated_at AS inactive_since_at,
+              FLOOR(EXTRACT(EPOCH FROM (NOW() - a.updated_at)) / 86400)::int AS inactive_days
+         FROM directory_accounts a
+         JOIN directory_account_links l ON l.directory_account_id = a.id
+         JOIN users u ON u.id = l.local_user_id
+        WHERE a.integration_id = $1
+          AND a.is_active = FALSE
+          AND u.is_active = TRUE
+          AND a.updated_at <= NOW() - ($2 || ' days')::interval
+        ORDER BY a.updated_at ASC
+        LIMIT $3`,
+      [integrationId, normalizedThresholdDays, sampleLimit],
+    ),
+  ])
+
+  return {
+    thresholdDays: normalizedThresholdDays,
+    count: Number(countResult.rows[0]?.total ?? 0),
+    sample: sampleResult.rows.map((row) => ({
+      directoryAccountId: row.directory_account_id,
+      externalUserId: row.external_user_id,
+      accountName: row.account_name,
+      localUserId: row.local_user_id,
+      localUserEmail: row.local_user_email,
+      localUserName: row.local_user_name,
+      inactiveSinceAt: row.inactive_since_at,
+      inactiveDays: Number(row.inactive_days),
+    })),
+  }
+}
+
+/**
+ * `unset = off`, matching `DIRECTORY_SYNC_ALERT_WEBHOOK`'s own channel-gating discipline. A
+ * non-positive or non-integer value is treated as unset (logged once) rather than silently
+ * clamped, so a typo in ops config fails closed instead of alerting on a bogus threshold.
+ */
+export function readDirectoryInactiveLinkedAlertThresholdDays(): number | null {
+  const raw = String(process.env.DIRECTORY_INACTIVE_LINKED_ALERT_DAYS ?? '').trim()
+  if (!raw) return null
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    logger.warn(`DIRECTORY_INACTIVE_LINKED_ALERT_DAYS is set but not a positive integer: ${raw}`)
+    return null
+  }
+  return parsed
+}
+
+export function buildDirectoryInactiveLinkedAlertMessage(options: {
+  integrationName: string
+  metric: DirectoryInactiveLinkedMetric
+}): { subject: string; content: string } {
+  const { integrationName, metric } = options
+  const subject = `钉钉目录存在停用超 ${metric.thresholdDays} 天但本地账号仍激活的绑定`
+  const lines = [
+    `- 集成：${integrationName}`,
+    `- 阈值：${metric.thresholdDays} 天`,
+    `- 数量：${metric.count}`,
+  ]
+  for (const item of metric.sample.slice(0, 5)) {
+    const label = item.localUserName || item.localUserEmail || item.localUserId
+    lines.push(`  - ${item.accountName || item.externalUserId} → ${label}（已停用 ${item.inactiveDays} 天）`)
+  }
+  if (metric.count > metric.sample.length) {
+    lines.push(`  - ……以及其他 ${metric.count - Math.min(metric.sample.length, 5)} 个账号`)
+  }
+  return { subject, content: lines.join('\n') }
+}
+
+/**
+ * §7.1 post-run informational alert. Best-effort and NEVER throws — this is a backlog
+ * digest, not a failure signal, and must not make a healthy sync look broken.
+ *
+ * Two independent env gates, both required, matching the `breach-channels` /
+ * `DIRECTORY_SYNC_ALERT_WEBHOOK` convention that a side channel exists only when configured:
+ *   - `DIRECTORY_INACTIVE_LINKED_ALERT_DAYS` turns THIS alert on and sets its threshold.
+ *   - `DIRECTORY_SYNC_ALERT_WEBHOOK` (+ optional secret) is the delivery channel, shared
+ *     with the sync-failure alert.
+ * The threshold-days check is the SOLE gate on computing/sending this alert (no second,
+ * redundant guard inside the metric query) — a query gate here as well would make the env
+ * guard unfalsifiable by mutation (removing it would still silently no-op downstream).
+ */
+export async function deliverDirectoryInactiveLinkedAlert(
+  options: {
+    integrationId: string
+    integrationName: string
+  },
+  deps: {
+    thresholdDays?: number | null
+    config?: DirectorySyncAlertDeliveryConfig | null
+    fetchFn?: typeof fetch
+    queryFn?: typeof query
+  } = {},
+): Promise<boolean> {
+  const thresholdDays = deps.thresholdDays !== undefined ? deps.thresholdDays : readDirectoryInactiveLinkedAlertThresholdDays()
+  if (!thresholdDays) return false
+
+  const config = deps.config !== undefined ? deps.config : readDirectorySyncAlertWebhookConfig()
+  if (!config) return false
+
+  const queryFn = deps.queryFn ?? query
+  const fetchFn = deps.fetchFn ?? fetch
+
+  try {
+    const metric = await getDirectoryInactiveLinkedMetric(options.integrationId, thresholdDays, queryFn)
+    if (metric.count === 0) return false
+
+    const { subject, content } = buildDirectoryInactiveLinkedAlertMessage({
+      integrationName: options.integrationName,
+      metric,
+    })
+
+    const signedUrl = buildSignedDingTalkWebhookUrl(config.webhookUrl, config.secret)
+    const response = await fetchFn(signedUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildDingTalkMarkdown(subject, content)),
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!response.ok) {
+      logger.warn(`Directory inactive-linked alert webhook returned HTTP ${response.status} (${maskDingTalkWebhookUrl(config.webhookUrl)})`)
+      return false
+    }
+    validateDingTalkRobotResponse(await response.json().catch(() => null))
+
+    logger.info(`Directory inactive-linked backlog alert delivered for integration ${options.integrationId} (${metric.count} accounts >= ${thresholdDays}d)`)
+    return true
+  } catch (error) {
+    // A backlog digest must never be made worse by a failed webhook — same discipline as
+    // deliverDirectorySyncFailureAlert.
+    logger.warn(
+      `Failed to deliver directory inactive-linked alert for integration ${options.integrationId}: ${error instanceof Error ? error.message : String(error)}`,
+    )
+    return false
+  }
+}

--- a/packages/core-backend/src/directory/directory-sync-scheduler.ts
+++ b/packages/core-backend/src/directory/directory-sync-scheduler.ts
@@ -2,6 +2,7 @@ import { Logger } from '../core/logger'
 import { query } from '../db/pg'
 import { SchedulerServiceImpl } from '../services/SchedulerService'
 import { DirectorySyncInProgressError, reclaimStaleDirectorySyncRuns, syncDirectoryIntegration } from './directory-sync'
+import { deliverDirectoryInactiveLinkedAlert } from './directory-sync-alert-delivery'
 
 type DirectoryScheduleRow = {
   id: string
@@ -52,7 +53,7 @@ async function getScheduleRow(integrationId: string): Promise<DirectoryScheduleR
   return result.rows[0] ?? null
 }
 
-async function runScheduledSync(integrationId: string): Promise<void> {
+async function runScheduledSync(integrationId: string, integrationName: string): Promise<void> {
   try {
     await syncDirectoryIntegration(integrationId, SYSTEM_TRIGGERED_BY, 'scheduler')
   } catch (error) {
@@ -65,6 +66,13 @@ async function runScheduledSync(integrationId: string): Promise<void> {
     }
     throw error
   }
+
+  // §7.1 offboarding blind-spot digest. Deliberately scoped to scheduler-triggered (nightly)
+  // syncs only, not manual ones: the manual-sync route lives in directory-sync.ts's apply
+  // region, which is being touched by an unlanded PR in the same lane batch — this hook
+  // stays entirely in this file to avoid any collision there. `deliverDirectoryInactiveLinkedAlert`
+  // is best-effort and never throws, so no try/catch is needed here.
+  await deliverDirectoryInactiveLinkedAlert({ integrationId, integrationName })
 }
 
 async function applySchedule(row: DirectoryScheduleRow | null): Promise<void> {
@@ -88,7 +96,7 @@ async function applySchedule(row: DirectoryScheduleRow | null): Promise<void> {
       logger.info(`Rescheduled directory sync job: ${jobName} (${cronExpression})`)
     } else {
       await scheduler.schedule(jobName, cronExpression, async () => {
-        await runScheduledSync(row.id)
+        await runScheduledSync(row.id, row.name)
       }, {
         timezone: 'UTC',
       })

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -26,7 +26,7 @@ import {
   unbindDirectoryAccount,
   updateDirectoryIntegration,
 } from '../directory/directory-sync'
-import { getDirectoryManagerBindingCoverage } from '../directory/directory-sync-alert-delivery'
+import { getDirectoryInactiveLinkedMetric, getDirectoryManagerBindingCoverage } from '../directory/directory-sync-alert-delivery'
 import {
   getDingTalkWorkNotificationRuntimeStatusFromStore,
   saveDingTalkWorkNotificationAgentId,
@@ -67,6 +67,17 @@ function normalizeReviewFilter(value: unknown): 'all' | 'pending_binding' | 'ina
     default:
       return 'all'
   }
+}
+
+const DEFAULT_INACTIVE_LINKED_DAYS = 30
+const MAX_INACTIVE_LINKED_DAYS = 3650
+
+function normalizeInactiveLinkedDays(value: unknown): number {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  if (!raw) return DEFAULT_INACTIVE_LINKED_DAYS
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_INACTIVE_LINKED_DAYS
+  return Math.min(parsed, MAX_INACTIVE_LINKED_DAYS)
 }
 
 function readErrorMessage(error: unknown, fallback: string): string {
@@ -590,6 +601,24 @@ export function adminDirectoryRouter(): Router {
     } catch (error) {
       const message = readErrorMessage(error, 'Failed to load directory manager binding coverage')
       jsonError(res, /required|invalid/i.test(message) ? 400 : 500, 'DIRECTORY_MANAGER_COVERAGE_FAILED', message)
+    }
+  })
+
+  // §7.1 offboarding blind-spot metric: directory accounts that went inactive (DingTalk
+  // removal / deactivation sweep) at least `days` ago while still linked to a LOCAL user
+  // that is still active. Read-only derived metric — no write path, same admin gate and
+  // error-handling shape as the sibling GET routes (mirrors /manager-coverage above).
+  router.get('/integrations/:integrationId/inactive-linked', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const thresholdDays = normalizeInactiveLinkedDays(req.query.days)
+      const metric = await getDirectoryInactiveLinkedMetric(req.params.integrationId, thresholdDays)
+      jsonOk(res, { metric })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory inactive-linked metric')
+      jsonError(res, /required|invalid/i.test(message) ? 400 : 500, 'DIRECTORY_INACTIVE_LINKED_FAILED', message)
     }
   })
 

--- a/packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../src/integrations/dingtalk/client', () => ({
 import { query } from '../../src/db/pg'
 import {
   countConsecutiveFailedRuns,
+  getDirectoryInactiveLinkedMetric,
   getDirectoryManagerBindingCoverage,
 } from '../../src/directory/directory-sync-alert-delivery'
 import {
@@ -472,5 +473,173 @@ describeIfDatabase('R5 per-run sync summary stats (real DB)', () => {
     expect(stats.managerCount).toBe(2)
     expect(stats.linkedManagerCount).toBe(1)
     expect(stats.managerCoverage).toBe(0.5)
+  })
+})
+
+
+/**
+ * roadmap §7.1 — offboarding blind spot. Self-contained describe block, appended at the end
+ * of the file on purpose (see the lane brief this was written under): this file is also
+ * being extended by another unlanded PR touching the deprovision-selection area, and a
+ * trailing, independent describe block keeps that a trivial 3-way merge.
+ *
+ * "Linked" mirrors the `inactive_linked` review-item filter in directory-sync.ts exactly:
+ * `directory_account_links.local_user_id IS NOT NULL`, independent of `link_status`. Anchor
+ * for "how long inactive": `directory_accounts.updated_at`, set directly by these fixtures
+ * (see the module doc-comment on `getDirectoryInactiveLinkedMetric` for why that column is
+ * the correct anchor given the current schema).
+ */
+describeIfDatabase('§7.1 directory inactive-linked backlog metric (real DB)', () => {
+  const TS2 = Date.now()
+  const THRESHOLD_DAYS = 10
+  let integrationId = ''
+  let otherIntegrationIdRef = ''
+  const userIds: string[] = []
+  const accountIds: string[] = []
+
+  const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString()
+
+  beforeAll(async () => {
+    integrationId = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`dil-int-${TS2}`, `dil-corp-${TS2}`],
+    )).rows[0].id
+
+    // A second, wholly separate integration — proves the metric is scoped per-integration
+    // and does not leak another tenant's backlog into this one's count.
+    const otherIntegrationId = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`dil-other-int-${TS2}`, `dil-other-corp-${TS2}`],
+    )).rows[0].id
+
+    const insertUser = async (id: string, isActive: boolean) => {
+      await query(
+        `INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'x', $3)`,
+        [id, `${id}@example.test`, isActive],
+      )
+      userIds.push(id)
+    }
+    const insertAccount = async (opts: {
+      externalUserId: string
+      isActive: boolean
+      updatedAt: string
+      integration?: string
+    }) => {
+      const result = await query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active, raw, updated_at)
+         VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, $6) RETURNING id`,
+        [opts.integration ?? integrationId, opts.externalUserId, `key-${opts.externalUserId}`, opts.externalUserId, opts.isActive, opts.updatedAt],
+      )
+      accountIds.push(result.rows[0].id)
+      return result.rows[0].id
+    }
+    const link = async (accountId: string, userId: string) => {
+      await query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+         VALUES ($1, $2, 'linked', 'manual')`,
+        [accountId, userId],
+      )
+    }
+
+    const uOldActive = `dil-u-old-active-${TS2}`
+    const uBoundaryActive = `dil-u-boundary-active-${TS2}`
+    const uRecentActive5 = `dil-u-recent5-${TS2}`
+    const uRecentActive1 = `dil-u-recent1-${TS2}`
+    const uLocalInactive = `dil-u-local-inactive-${TS2}`
+    const uStillActiveAccount = `dil-u-still-active-account-${TS2}`
+    const uOtherTenant = `dil-u-other-tenant-${TS2}`
+    await Promise.all([
+      insertUser(uOldActive, true),
+      insertUser(uBoundaryActive, true),
+      insertUser(uRecentActive5, true),
+      insertUser(uRecentActive1, true),
+      insertUser(uLocalInactive, false),
+      insertUser(uStillActiveAccount, true),
+      insertUser(uOtherTenant, true),
+    ])
+
+    // 1. QUALIFIES — 20 days inactive (past threshold), linked, local user still active.
+    const accOld = await insertAccount({ externalUserId: `dil-old-${TS2}`, isActive: false, updatedAt: daysAgo(20) })
+    await link(accOld, uOldActive)
+
+    // 2. QUALIFIES — exactly AT the 10-day threshold (the predicate is `<=`, inclusive).
+    const accBoundary = await insertAccount({ externalUserId: `dil-boundary-${TS2}`, isActive: false, updatedAt: daysAgo(THRESHOLD_DAYS) })
+    await link(accBoundary, uBoundaryActive)
+
+    // 3. EXCLUDED — only 5 days inactive, short of the 10-day threshold (crosses the
+    //    boundary the OTHER way from fixture 1/2).
+    const accRecent5 = await insertAccount({ externalUserId: `dil-recent5-${TS2}`, isActive: false, updatedAt: daysAgo(5) })
+    await link(accRecent5, uRecentActive5)
+
+    // 4. EXCLUDED — 1 day inactive, well short of the threshold.
+    const accRecent1 = await insertAccount({ externalUserId: `dil-recent1-${TS2}`, isActive: false, updatedAt: daysAgo(1) })
+    await link(accRecent1, uRecentActive1)
+
+    // 5. EXCLUDED — unlinked. 20 days inactive but no directory_account_links row at all;
+    //    this is the review-queue's OWN definition of "not linked" — must not leak in.
+    await insertAccount({ externalUserId: `dil-unlinked-${TS2}`, isActive: false, updatedAt: daysAgo(20) })
+
+    // 6. EXCLUDED — linked, 20 days inactive, but the LOCAL USER is already inactive. This
+    //    account is not part of the offboarding blind spot: there is nothing left to revoke.
+    const accLocalInactive = await insertAccount({ externalUserId: `dil-local-inactive-${TS2}`, isActive: false, updatedAt: daysAgo(20) })
+    await link(accLocalInactive, uLocalInactive)
+
+    // 7. EXCLUDED — linked, local user active, but the directory ACCOUNT itself is still
+    //    active (never went inactive) — sanity check on `a.is_active = FALSE`.
+    const accStillActive = await insertAccount({ externalUserId: `dil-still-active-${TS2}`, isActive: true, updatedAt: daysAgo(20) })
+    await link(accStillActive, uStillActiveAccount)
+
+    // 8. EXCLUDED — same shape as fixture 1, but under a DIFFERENT integration. Kept alive
+    //    through the assertions below (cleaned up in afterAll) — proves the metric is
+    //    scoped by integration_id rather than trivially absent.
+    const accOtherTenant = await insertAccount({ externalUserId: `dil-other-tenant-${TS2}`, isActive: false, updatedAt: daysAgo(20), integration: otherIntegrationId })
+    await link(accOtherTenant, uOtherTenant)
+
+    otherIntegrationIdRef = otherIntegrationId
+  })
+
+  afterAll(async () => {
+    if (integrationId) {
+      await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+    }
+    if (otherIntegrationIdRef) {
+      await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [otherIntegrationIdRef])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [otherIntegrationIdRef])
+    }
+    if (userIds.length) {
+      await query(`DELETE FROM users WHERE id = ANY($1)`, [userIds])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('counts only linked, still-locally-active accounts inactive at least the threshold, crossing the boundary both ways (real SQL)', async () => {
+    const metric = await getDirectoryInactiveLinkedMetric(integrationId, THRESHOLD_DAYS)
+    expect(metric.thresholdDays).toBe(THRESHOLD_DAYS)
+    expect(metric.count).toBe(2)
+
+    const externalIds = metric.sample.map((s) => s.externalUserId)
+    expect(externalIds).toContain(`dil-old-${TS2}`)
+    expect(externalIds).toContain(`dil-boundary-${TS2}`)
+    expect(externalIds).not.toContain(`dil-recent5-${TS2}`)
+    expect(externalIds).not.toContain(`dil-recent1-${TS2}`)
+    expect(externalIds).not.toContain(`dil-unlinked-${TS2}`)
+    expect(externalIds).not.toContain(`dil-local-inactive-${TS2}`)
+    expect(externalIds).not.toContain(`dil-still-active-${TS2}`)
+    expect(externalIds).not.toContain(`dil-other-tenant-${TS2}`)
+
+    // ORDER BY updated_at ASC — the most-overdue account (20 days) sorts before the
+    // boundary account (10 days).
+    expect(metric.sample[0].externalUserId).toBe(`dil-old-${TS2}`)
+    expect(metric.sample[0].inactiveDays).toBeGreaterThanOrEqual(20)
+    expect(metric.sample[1].externalUserId).toBe(`dil-boundary-${TS2}`)
+  })
+
+  it('returns zero for a threshold high enough that nothing qualifies', async () => {
+    const metric = await getDirectoryInactiveLinkedMetric(integrationId, 3650)
+    expect(metric).toMatchObject({ count: 0, sample: [] })
   })
 })

--- a/packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts
@@ -495,7 +495,6 @@ describeIfDatabase('§7.1 directory inactive-linked backlog metric (real DB)', (
   let integrationId = ''
   let otherIntegrationIdRef = ''
   const userIds: string[] = []
-  const accountIds: string[] = []
 
   const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString()
 
@@ -530,7 +529,6 @@ describeIfDatabase('§7.1 directory inactive-linked backlog metric (real DB)', (
          VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, $6) RETURNING id`,
         [opts.integration ?? integrationId, opts.externalUserId, `key-${opts.externalUserId}`, opts.externalUserId, opts.isActive, opts.updatedAt],
       )
-      accountIds.push(result.rows[0].id)
       return result.rows[0].id
     }
     const link = async (accountId: string, userId: string) => {

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -1118,6 +1118,16 @@ describe('adminDirectoryRouter', () => {
     expect(alertDeliveryMocks.getDirectoryInactiveLinkedMetric).toHaveBeenCalledWith('dir-1', 30)
   })
 
+  it('rejects an unauthenticated inactive-linked request (401)', async () => {
+    const response = await invokeRoute('get', '/integrations/:integrationId/inactive-linked', {
+      params: { integrationId: 'dir-1' },
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.body).toMatchObject({ ok: false, error: { code: 'UNAUTHENTICATED' } })
+    expect(alertDeliveryMocks.getDirectoryInactiveLinkedMetric).not.toHaveBeenCalled()
+  })
+
   it('admin-gates the inactive-linked route (403 for non-admin)', async () => {
     rbacMocks.isRbacAdmin.mockResolvedValue(false)
 

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -97,10 +97,12 @@ vi.mock('../../src/directory/directory-sync-scheduler', () => ({
 
 const alertDeliveryMocks = vi.hoisted(() => ({
   getDirectoryManagerBindingCoverage: vi.fn(),
+  getDirectoryInactiveLinkedMetric: vi.fn(),
 }))
 
 vi.mock('../../src/directory/directory-sync-alert-delivery', () => ({
   getDirectoryManagerBindingCoverage: alertDeliveryMocks.getDirectoryManagerBindingCoverage,
+  getDirectoryInactiveLinkedMetric: alertDeliveryMocks.getDirectoryInactiveLinkedMetric,
 }))
 
 const approvalCardConfigMocks = vi.hoisted(() => ({
@@ -217,6 +219,7 @@ describe('adminDirectoryRouter', () => {
     directoryMocks.updateDirectoryIntegration.mockReset()
     schedulerMocks.refreshDirectoryIntegrationSchedule.mockReset()
     alertDeliveryMocks.getDirectoryManagerBindingCoverage.mockReset()
+    alertDeliveryMocks.getDirectoryInactiveLinkedMetric.mockReset()
     workNotificationMocks.getDingTalkWorkNotificationRuntimeStatusFromStore.mockReset()
     workNotificationMocks.saveDingTalkWorkNotificationAgentId.mockReset()
     workNotificationMocks.testDingTalkWorkNotificationAgentId.mockReset()
@@ -1079,6 +1082,66 @@ describe('adminDirectoryRouter', () => {
     expect(response.body).toMatchObject({
       ok: false,
       error: { code: 'DIRECTORY_MANAGER_COVERAGE_FAILED', message: 'db unreachable' },
+    })
+  })
+
+  it('returns the directory inactive-linked backlog metric for an integration (§7.1)', async () => {
+    alertDeliveryMocks.getDirectoryInactiveLinkedMetric.mockResolvedValue({
+      thresholdDays: 30,
+      count: 2,
+      sample: [{ directoryAccountId: 'acc-1', externalUserId: 'ext-1', accountName: 'Alice', localUserId: 'u-1', localUserEmail: 'a@example.com', localUserName: 'Alice', inactiveSinceAt: '2026-06-01T00:00:00.000Z', inactiveDays: 40 }],
+    })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/inactive-linked', {
+      params: { integrationId: 'dir-1' },
+      query: { days: '30' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(alertDeliveryMocks.getDirectoryInactiveLinkedMetric).toHaveBeenCalledWith('dir-1', 30)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: { metric: { thresholdDays: 30, count: 2 } },
+    })
+  })
+
+  it('defaults the inactive-linked threshold to 30 days when the query param is missing or invalid', async () => {
+    alertDeliveryMocks.getDirectoryInactiveLinkedMetric.mockResolvedValue({ thresholdDays: 30, count: 0, sample: [] })
+
+    await invokeRoute('get', '/integrations/:integrationId/inactive-linked', {
+      params: { integrationId: 'dir-1' },
+      query: { days: 'not-a-number' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(alertDeliveryMocks.getDirectoryInactiveLinkedMetric).toHaveBeenCalledWith('dir-1', 30)
+  })
+
+  it('admin-gates the inactive-linked route (403 for non-admin)', async () => {
+    rbacMocks.isRbacAdmin.mockResolvedValue(false)
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/inactive-linked', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'user-1', role: 'user' },
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect(alertDeliveryMocks.getDirectoryInactiveLinkedMetric).not.toHaveBeenCalled()
+  })
+
+  it('surfaces inactive-linked metric failures as 500', async () => {
+    alertDeliveryMocks.getDirectoryInactiveLinkedMetric.mockRejectedValue(new Error('db unreachable'))
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/inactive-linked', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'DIRECTORY_INACTIVE_LINKED_FAILED', message: 'db unreachable' },
     })
   })
 

--- a/packages/core-backend/tests/unit/directory-sync-alert-delivery.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-alert-delivery.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  buildDirectoryInactiveLinkedAlertMessage,
   buildDirectorySyncAlertMessage,
   countConsecutiveFailedRuns,
+  deliverDirectoryInactiveLinkedAlert,
   deliverDirectorySyncFailureAlert,
   getDirectoryManagerBindingCoverage,
+  readDirectoryInactiveLinkedAlertThresholdDays,
   readDirectorySyncAlertWebhookConfig,
+  type DirectoryInactiveLinkedMetric,
 } from '../../src/directory/directory-sync-alert-delivery'
 
 /**
@@ -144,6 +148,146 @@ describe('DT-OPS-03 directory sync alert delivery', () => {
       const updates = (queryFn as unknown as { mock: { calls: Array<[string]> } }).mock.calls
         .filter(([sql]) => /UPDATE directory_sync_alerts/.test(sql))
       expect(updates).toHaveLength(0)
+    })
+  })
+})
+
+/**
+ * roadmap §7.1 — offboarding blind-spot digest. `getDirectoryInactiveLinkedMetric`'s real
+ * SQL (the age comparison, the linked-join, the local-user-active filter) is proven against
+ * real Postgres in `tests/integration/directory-sync-alert-coverage.db.test.ts`. This suite
+ * proves the WIRING around it: the two independent env gates and the message/delivery shape,
+ * using a fake queryFn that ignores the SQL text — exactly the same division of labor the
+ * manager-coverage tests above use.
+ */
+describe('§7.1 directory inactive-linked backlog digest', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('threshold env gate', () => {
+    it('is off when the threshold env is unset', () => {
+      expect(readDirectoryInactiveLinkedAlertThresholdDays()).toBeNull()
+    })
+
+    it('rejects a non-positive or non-integer threshold rather than silently clamping it', () => {
+      for (const bad of ['0', '-3', '2.5', 'abc']) {
+        vi.stubEnv('DIRECTORY_INACTIVE_LINKED_ALERT_DAYS', bad)
+        expect(readDirectoryInactiveLinkedAlertThresholdDays()).toBeNull()
+      }
+    })
+
+    it('accepts a positive integer threshold', () => {
+      vi.stubEnv('DIRECTORY_INACTIVE_LINKED_ALERT_DAYS', '45')
+      expect(readDirectoryInactiveLinkedAlertThresholdDays()).toBe(45)
+    })
+  })
+
+  describe('buildDirectoryInactiveLinkedAlertMessage', () => {
+    it('reports the threshold and count, caps the example list at 5, and notes the remainder', () => {
+      const metric: DirectoryInactiveLinkedMetric = {
+        thresholdDays: 30,
+        count: 7,
+        sample: Array.from({ length: 6 }, (_, i) => ({
+          directoryAccountId: `acc-${i}`,
+          externalUserId: `ext-${i}`,
+          accountName: `Account ${i}`,
+          localUserId: `user-${i}`,
+          localUserEmail: `user${i}@example.com`,
+          localUserName: `User ${i}`,
+          inactiveSinceAt: '2026-01-01T00:00:00.000Z',
+          inactiveDays: 40 + i,
+        })),
+      }
+      const { subject, content } = buildDirectoryInactiveLinkedAlertMessage({ integrationName: 'CN', metric })
+      expect(subject).toContain('30')
+      expect(content).toContain('数量：7')
+      expect((content.match(/Account \d/g) ?? []).length).toBe(5)
+      expect(content).toContain('以及其他 2 个账号')
+    })
+  })
+
+  describe('deliverDirectoryInactiveLinkedAlert', () => {
+    // Discriminates by SQL shape rather than args, mirroring the getDirectoryManagerBindingCoverage
+    // unit fakes above — it proves the WIRING (does a nonzero backlog reach the webhook), not the
+    // predicate; the predicate itself is proven against real Postgres in the .db.test.ts.
+    const metricQueryFn = (total: number) => (async (sql: string) => (
+      /COUNT\(\*\)/.test(sql) ? { rows: [{ total }] } : { rows: [] }
+    )) as unknown as typeof import('../../src/db/pg').query
+
+    it('sends nothing when the threshold env is unset — the SOLE gate on this alert', async () => {
+      // No `deps.thresholdDays` override: falls through to the REAL env reader, which is
+      // unset here. The fake queryFn would report a backlog of 3 if the guard let it
+      // through — proving the guard, not the query, is what stops delivery. Deleting the
+      // `if (!thresholdDays) return false` line in the source makes this test go RED.
+      const fetchFn = vi.fn() as unknown as typeof fetch
+      const queryFn = vi.fn(metricQueryFn(3))
+      const delivered = await deliverDirectoryInactiveLinkedAlert(
+        { integrationId: 'dir-1', integrationName: 'CN' },
+        { config: { webhookUrl: WEBHOOK }, fetchFn, queryFn: queryFn as never },
+      )
+      expect(delivered).toBe(false)
+      expect(fetchFn).not.toHaveBeenCalled()
+      expect(queryFn).not.toHaveBeenCalled()
+    })
+
+    it('sends nothing when the webhook channel is not configured, even with a threshold set', async () => {
+      const fetchFn = vi.fn() as unknown as typeof fetch
+      const queryFn = vi.fn(metricQueryFn(3))
+      const delivered = await deliverDirectoryInactiveLinkedAlert(
+        { integrationId: 'dir-1', integrationName: 'CN' },
+        { thresholdDays: 30, config: null, fetchFn, queryFn: queryFn as never },
+      )
+      expect(delivered).toBe(false)
+      expect(fetchFn).not.toHaveBeenCalled()
+      expect(queryFn).not.toHaveBeenCalled()
+    })
+
+    it('sends nothing when the backlog is empty — this is a digest, not per-tick noise', async () => {
+      const fetchFn = vi.fn(async () => okResponse()) as unknown as typeof fetch
+      const queryFn = metricQueryFn(0)
+      const delivered = await deliverDirectoryInactiveLinkedAlert(
+        { integrationId: 'dir-1', integrationName: 'CN' },
+        { thresholdDays: 30, config: { webhookUrl: WEBHOOK }, fetchFn, queryFn: queryFn as never },
+      )
+      expect(delivered).toBe(false)
+      expect(fetchFn).not.toHaveBeenCalled()
+    })
+
+    it('signs and posts a markdown digest when both gates are open and the backlog is nonzero', async () => {
+      const fetchFn = vi.fn(async () => okResponse()) as unknown as typeof fetch
+      const queryFn = metricQueryFn(4)
+      const delivered = await deliverDirectoryInactiveLinkedAlert(
+        { integrationId: 'dir-1', integrationName: 'CN' },
+        { thresholdDays: 30, config: { webhookUrl: WEBHOOK, secret: 'SECabc123' }, fetchFn, queryFn: queryFn as never },
+      )
+      expect(delivered).toBe(true)
+      const [url, init] = (fetchFn as unknown as { mock: { calls: Array<[string, RequestInit]> } }).mock.calls[0]
+      expect(url).toContain('sign=')
+      expect(url).toContain('timestamp=')
+      const payload = JSON.parse(init.body as string)
+      expect(payload.msgtype).toBe('markdown')
+      expect(payload.markdown.text).toContain('数量：4')
+    })
+
+    it('NEVER lets a webhook failure escape — a healthy sync must not look broken', async () => {
+      const fetchFn = vi.fn(async () => {
+        throw new Error('webhook unreachable')
+      }) as unknown as typeof fetch
+      const queryFn = metricQueryFn(1)
+      await expect(deliverDirectoryInactiveLinkedAlert(
+        { integrationId: 'dir-1', integrationName: 'CN' },
+        { thresholdDays: 30, config: { webhookUrl: WEBHOOK }, fetchFn, queryFn: queryFn as never },
+      )).resolves.toBe(false)
+    })
+
+    it('treats a DingTalk business error as undelivered', async () => {
+      const fetchFn = vi.fn(async () => okResponse({ errcode: 130101, errmsg: 'flow control' })) as unknown as typeof fetch
+      const queryFn = metricQueryFn(2)
+      await expect(deliverDirectoryInactiveLinkedAlert(
+        { integrationId: 'dir-1', integrationName: 'CN' },
+        { thresholdDays: 30, config: { webhookUrl: WEBHOOK }, fetchFn, queryFn: queryFn as never },
+      )).resolves.toBe(false)
     })
   })
 })

--- a/packages/core-backend/tests/unit/directory-sync-alert-delivery.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-alert-delivery.test.ts
@@ -185,10 +185,14 @@ describe('§7.1 directory inactive-linked backlog digest', () => {
 
   describe('buildDirectoryInactiveLinkedAlertMessage', () => {
     it('reports the threshold and count, caps the example list at 5, and notes the remainder', () => {
+      // count === sample.length here on purpose: getDirectoryInactiveLinkedMetric only ever
+      // returns a shorter sample than count once count exceeds its OWN 20-row cap, so a
+      // count/sample-length mismatch (e.g. count:7, sample:6) is not a state the real query
+      // can produce. This message-builder has its own, separate 5-item display cap.
       const metric: DirectoryInactiveLinkedMetric = {
         thresholdDays: 30,
-        count: 7,
-        sample: Array.from({ length: 6 }, (_, i) => ({
+        count: 8,
+        sample: Array.from({ length: 8 }, (_, i) => ({
           directoryAccountId: `acc-${i}`,
           externalUserId: `ext-${i}`,
           accountName: `Account ${i}`,
@@ -201,9 +205,29 @@ describe('§7.1 directory inactive-linked backlog digest', () => {
       }
       const { subject, content } = buildDirectoryInactiveLinkedAlertMessage({ integrationName: 'CN', metric })
       expect(subject).toContain('30')
-      expect(content).toContain('数量：7')
+      expect(content).toContain('数量：8')
       expect((content.match(/Account \d/g) ?? []).length).toBe(5)
-      expect(content).toContain('以及其他 2 个账号')
+      expect(content).toContain('以及其他 3 个账号')
+    })
+
+    it('shows every example without a remainder line when the backlog is small enough to fit', () => {
+      const metric: DirectoryInactiveLinkedMetric = {
+        thresholdDays: 30,
+        count: 2,
+        sample: Array.from({ length: 2 }, (_, i) => ({
+          directoryAccountId: `acc-${i}`,
+          externalUserId: `ext-${i}`,
+          accountName: `Account ${i}`,
+          localUserId: `user-${i}`,
+          localUserEmail: `user${i}@example.com`,
+          localUserName: `User ${i}`,
+          inactiveSinceAt: '2026-01-01T00:00:00.000Z',
+          inactiveDays: 40 + i,
+        })),
+      }
+      const { content } = buildDirectoryInactiveLinkedAlertMessage({ integrationName: 'CN', metric })
+      expect((content.match(/Account \d/g) ?? []).length).toBe(2)
+      expect(content).not.toContain('以及其他')
     })
   })
 

--- a/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
@@ -9,11 +9,19 @@ const directoryMocks = vi.hoisted(() => ({
   reclaimStaleDirectorySyncRuns: vi.fn(),
 }))
 
+const alertDeliveryMocks = vi.hoisted(() => ({
+  deliverDirectoryInactiveLinkedAlert: vi.fn(),
+}))
+
 vi.mock('../../src/db/pg', () => ({
   query: pgMocks.query,
   // The real directory-sync (loaded below via importOriginal for its error class)
   // imports { query, transaction }; a factory missing either export fails at load.
   transaction: vi.fn(),
+}))
+
+vi.mock('../../src/directory/directory-sync-alert-delivery', () => ({
+  deliverDirectoryInactiveLinkedAlert: alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert,
 }))
 
 vi.mock('../../src/directory/directory-sync', async (importOriginal) => ({
@@ -52,6 +60,8 @@ describe('directory-sync-scheduler', () => {
     directoryMocks.syncDirectoryIntegration.mockReset()
     directoryMocks.reclaimStaleDirectorySyncRuns.mockReset()
     directoryMocks.reclaimStaleDirectorySyncRuns.mockResolvedValue(0)
+    alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert.mockReset()
+    alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert.mockResolvedValue(false)
     resetDirectorySyncSchedulerForTests()
   })
 
@@ -117,6 +127,12 @@ describe('directory-sync-scheduler', () => {
       'system:directory-sync-scheduler',
       'scheduler',
     )
+    // §7.1 offboarding blind-spot digest: fires after a successful scheduled sync, carrying
+    // the integration's display name through for the alert message.
+    expect(alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert).toHaveBeenCalledWith({
+      integrationId: 'dir-1',
+      integrationName: 'DingTalk CN',
+    })
   })
 
   it.each([
@@ -183,8 +199,12 @@ describe('directory-sync-scheduler', () => {
 
     directoryMocks.syncDirectoryIntegration.mockRejectedValueOnce(new DirectorySyncInProgressError('run-held'))
     await expect(scheduleHandler()).resolves.toBeUndefined()
+    expect(alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert).not.toHaveBeenCalled()
 
     directoryMocks.syncDirectoryIntegration.mockRejectedValueOnce(new Error('DingTalk 500'))
     await expect(scheduleHandler()).rejects.toThrow('DingTalk 500')
+    // §7.1 digest is a POST-run check: neither failure path (lease conflict skip, nor a
+    // real sync error) should reach it.
+    expect(alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Roadmap §7.1 (Offboarding Policy Executor) target bullet 3: *"Add inactive linked for N days metric and alert."* Only the `inactive_linked` review-item **filter** existed (`directory-sync.ts` `buildReviewFilterSql` + the review-items admin endpoint/UI filter) — no age dimension and no alert. Because `DIRECTORY_DEPROVISION_ENABLED` (DT-OPS-01) is default-off by owner decision, a directory account going `is_active = false` never touches the linked local user, so this backlog was invisible. This PR adds the metric and a gated alert, read-only, no deprovision writes.

- **`getDirectoryInactiveLinkedMetric(integrationId, thresholdDays)`** (`packages/core-backend/src/directory/directory-sync-alert-delivery.ts`, module scope near `getDirectoryManagerBindingCoverage`): count + oldest-first sample (capped 20) of directory accounts that are `is_active = false`, linked (`directory_account_links.local_user_id IS NOT NULL` — matches the review-item's own definition, independent of `link_status`), local user still `is_active = true`, and inactive at least N days.
- **GET `/integrations/:integrationId/inactive-linked?days=N`** admin route in `admin-directory.ts` (default 30, clamped to [1, 3650]), mirroring the existing `/manager-coverage` route exactly (same admin gate, same error-mapping shape).
- **`deliverDirectoryInactiveLinkedAlert`**: best-effort DingTalk webhook digest, reusing the `DIRECTORY_SYNC_ALERT_WEBHOOK` channel and gated by a new **`DIRECTORY_INACTIVE_LINKED_ALERT_DAYS`** threshold env (unset = off, following the existing env-gate side-channel convention). Never throws; only sends when the backlog is nonzero.
- Wired as a **post-run hook in `directory-sync-scheduler.ts`'s `runScheduledSync`** (scheduler-triggered/nightly syncs only — see "Decisions" below).

## Deactivation-time anchor (read before reviewing the SQL)

There is no dedicated deactivation-transition column in this schema. I grepped every write site that can touch `directory_accounts` across `packages/core-backend/src` — there are exactly two, both in `directory-sync.ts`:

1. The re-sync upsert (`INSERT ... ON CONFLICT DO UPDATE SET is_active = true, ..., updated_at = NOW()`) — only fires for accounts currently present in the DingTalk pull, and always sets `is_active` back to `true` (which removes the row from this metric's target set).
2. The deactivation sweep (`UPDATE directory_accounts SET is_active = false, updated_at = NOW() WHERE ... AND is_active = true`) — guarded by `AND is_active = true`, i.e. a genuine one-way transition, not a re-stamp. Once inactive, this statement's WHERE clause no longer matches the row, so it can't bump `updated_at` again while the row stays inactive.

No other module issues an UPDATE/INSERT against `directory_accounts` (every other reference is a read-only JOIN). So for a row currently `is_active = false`, `directory_accounts.updated_at` is exactly the deactivation timestamp — an honest anchor given the current schema, not an approximation. **No migration added or needed.**

## Coordination / scope decisions

- `directory-sync.ts` is being touched by unlanded #4049 (preview region) and #4054 (apply region ~2860-3370). The new metric function lives entirely in `directory-sync-alert-delivery.ts`; `directory-sync.ts` itself is **untouched** by this PR.
- The post-run alert hook is wired in `directory-sync-scheduler.ts`'s `runScheduledSync`, **not** in the manual-sync route (`admin-directory.ts` `/integrations/:id/sync`) or inside `syncDirectoryIntegration`'s apply/preview bodies. This means the digest only fires after **scheduler-triggered (nightly) syncs**, not manual ones. Manual-sync visibility still exists via the new on-demand endpoint. Flagging this narrowing for reviewer scrutiny — it was a deliberate collision-avoidance choice given #4049/#4054 are in flight on the same file.
- `admin-directory.ts` is touched by unlanded #4053 on the create/update handlers; this PR only adds a new GET route and does not touch any existing handler.
- The alert is a pure outbound webhook POST — no new row written to `directory_sync_alerts` (no new persistence semantics/migration introduced).

## Tests

- `packages/core-backend/tests/unit/directory-sync-alert-delivery.test.ts` — new `§7.1 directory inactive-linked backlog digest` describe block: env-gate unit tests (unset/non-integer/negative/valid), message-builder cap-at-5 test, delivery wiring tests (both gates required, empty-backlog no-send, successful send, webhook-failure swallow, DingTalk business-error swallow) using a fake `queryFn` (SQL-shape discriminated, matching the existing `getDirectoryManagerBindingCoverage` unit-test style — real SQL is proven in the `.db.test.ts` below).
- `packages/core-backend/tests/integration/directory-sync-alert-coverage.db.test.ts` — new self-contained describe block **appended at the end of the file** (per lane brief, since #4054 also extends this file — keeps the 3-way merge trivial). Real-Postgres fixtures: past-threshold (20d), exact boundary (10d, inclusive `<=`), short-of-threshold (5d, 1d), unlinked, linked-but-locally-inactive-user, linked-but-account-still-active, and a second integration to prove scoping. Both new tests pass on a fresh migrated DB.
- `packages/core-backend/tests/unit/admin-directory-routes.test.ts` — new route tests (200 with metric shape, day-param default/invalid-fallback, 403 non-admin, 500 on failure), plus wired `getDirectoryInactiveLinkedMetric` into the existing whole-module mock factory (would otherwise return `undefined` at call time once the route imports it).
- `packages/core-backend/tests/unit/directory-sync-scheduler.test.ts` — new assertions: digest called with `{integrationId, integrationName}` after a successful scheduled sync; **not** called on lease-conflict skip or on a real sync failure.
- Full `tests/unit` suite: **353 files / 4767 tests passed**. `tsc --noEmit`: clean. Real-DB whitelisted file (`directory-sync-alert-coverage.db.test.ts`) + two sibling directory `.db.test.ts` files: all green on a fresh migrated database (dropped after each run).
- No new two-point wiring needed: `directory-sync-alert-coverage.db.test.ts` was already excluded in `vitest.config.ts` and whitelisted in `plugin-tests.yml`'s real-DB step; this PR only extends that file.

## Mutation table

| Mutation | Result |
|---|---|
| Invert age comparison (`<=` → `>=` in both count/sample queries) | RED — both new `.db.test.ts` assertions fail |
| Drop the linked-join (query `directory_accounts` alone, no join to links/users) | RED — count assertion fails (unlinked fixture leaks in) |
| Drop `AND u.is_active = TRUE` | RED — count assertion fails (locally-inactive-user fixture leaks in) |
| Remove the `if (!thresholdDays) return false` env-gate in `deliverDirectoryInactiveLinkedAlert` | RED — exactly the targeted unit test ("sends nothing when the threshold env is unset") fails; used a fake `queryFn` that reports a nonzero backlog regardless of args, so the guard removal is provably load-bearing (not masked by a redundant inner guard) |

All four mutations applied one at a time (real implementation committed first), confirmed RED, then reverted (`git checkout --`) before moving to the next.

## Honest gaps

- The digest only fires after scheduler-triggered syncs, not manual ones (see Coordination above) — a manual-sync operator only sees the backlog via the new GET endpoint, not a push notification.
- No persisted `directory_sync_alerts` row for this alert type — it's delivery-only, so there's nothing to acknowledge/list in the existing alerts admin UI (only the webhook digest and the on-demand metric endpoint exist).
- `getDirectoryInactiveLinkedMetric`'s sample is capped at 20 rows; the message builder further caps at 5 examples per digest. Not configurable in this PR.
- No frontend UI changes — brief scoped this to backend metric + endpoint + alert only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)