### PR TITLE
docs(multitable): R10 gate-front — 4 owner-menu decision one-pagers (PROPOSED)

### DIFF
--- a/docs/development/multitable-global-history-alltables-field-metadata-decision-20260710.md
+++ b/docs/development/multitable-global-history-alltables-field-metadata-decision-20260710.md
@@ -1,0 +1,22 @@
+# Global History — all-tables 模式跨表字段元数据 — 决策 one-pager (PROPOSED)
+
+- **Status**: PROPOSED 决策文档；owner ratify 前零实现授权。R10 gate-front 工件（R9 UX 审计携带项）。
+- **现状**：History Center 的 `fields` prop 只承载**活动表**（workbench 的 `historyVisibleFields`，layer-2∩layer-3 已修）；all-tables 模式下其它表的批次 diff 标签/筛选回退为原始 field id。R9 已如实保留该回退。
+
+## 约束（不可绕）
+
+R9 #4007 的教训直接适用：**字段名本身是两层可掩码信息**（layer-2 property-hidden + layer-3 per-subject RBAC，均按「该字段所在表」评估）。任何跨表字段名供给必须对**每张表**做两层过滤——否则 all-tables 模式变成字段名侧信道。
+
+## 选项
+
+| 选项 | 内容 | 代价/问题 |
+|---|---|---|
+| A 客户端逐表拉取 | FE 对批次涉及的每张表调 fields+field-permissions 再本地求交集 | N 张表 N×2 请求;两层推导逻辑（permission-derivation.ts）在服务端,客户端复刻=两处真源漂移风险——正是 R9 P1 的病根 |
+| **B（推荐）** 服务端掩码字段名随批次详情下发 | 批次详情投影已按表计算 per-sheet allow-set（值掩码用的同一套）;顺路输出 `fieldNames: {sheetId: {fieldId: name}}`,只含**该 actor 在该表两层可见**的字段 | response-shape 增量=两侧 shape-lock 全扫+LOCK-3 goldens;单一真源,零新端点 |
+| C 维持 id 回退 | 现状 | 跨表可读性欠账永挂 |
+
+## 建议
+
+**B**。值掩码与名字掩码同源同 allow-set（`filterDataByAllowedFields` 的集合就是名字白名单），不引入第二套推导。实现要点（ratify 后才排）：投影层输出仅覆盖 payload 实际涉及的表；**隐藏字段名绝不出现**（golden：property-hidden 与 RBAC-denied 各一，跨表各一）；FE `diffFieldName` 优先 `fieldNames` 映射、活动表仍走 props（不回归 #4007）；两侧 wire shape 测试同步。
+
+- **解锁词**：owner 点头选项（A/B/C）。

--- a/docs/development/multitable-global-history-fieldvalue-tombstone-floor-decision-20260710.md
+++ b/docs/development/multitable-global-history-fieldvalue-tombstone-floor-decision-20260710.md
@@ -1,0 +1,20 @@
+# Global History — field-value tombstone 留存地板 — 决策 one-pager (PROPOSED)
+
+- **Status**: PROPOSED 决策文档；任何构建选项都需 owner 单项签核。R10 gate-front 工件（R9 审计残差 L2）。
+- **现状（真库核验）**：`meta-revision-retention.ts` 的 `floorPredicate` 仅对 link-tombstone 表生效（引用 `meta_records_trash.delete_revision_id` 锚——trash 行不灭则组不灭）；`meta_field_value_tombstones` 的 keep-days 清扫**无地板**。O-2 阶梯文档已如实记为边界（footgun 注记在案）。
+- **何时会咬人**：仅当 4c-1/4c-2 flag 在生产开启 **且** retention 同时开启——field-delete/lossy-retype 的值恢复窗口=keep-days，过期即 4d 化（字节消失）。
+
+## 选项
+
+| 选项 | 内容 | 代价/问题 |
+|---|---|---|
+| **A（推荐）** 接受边界 | 维持现状；O-2 阶梯文档已注明「先开 capture 类 flag 时保持 retention 关闭,或接受 keep-days=恢复窗口」 | 零代码;边界已如实文档化 |
+| B 锚定 config-revision 地板 | floor 引用产生该 tombstone 的 `meta_config_revisions` 行(field-delete/retype revision) | config revision 自身也被 retention 老化——链到另一张会老化的表=弱地板,给运维假安全感 |
+| C 独立不灭锚 | 为 field-value tombstone 组新增专用 never-delete 标记/存储 | 新存储+新治理面,重;当前无任何 pending-revert 概念可挂 |
+| D 差异 keep-days | field-value tombstone 单独更长的 keep-days 旋钮 | 又一个旋钮;不解决「地板」语义,只推迟 |
+
+## 建议
+
+**A**。理由：该边界只在「capture flag 开 + retention 开」的组合世界存在,而 O-2 阶梯本就把这一组合列为联动注意事项;B 是伪地板,C 的成本与当前零生产启用不成比例。**复议触发条件（写入 O-2 阶梯）**：任一 4c 系 capture/revert flag 在生产开启且 retention 计划开启时,本决策自动回到 owner 桌面。
+
+- **解锁词**：owner 选 B/C/D 之一并点头;选 A 仅需在本文所附 PR 上确认（或沉默视为维持现状——A 即现状,无代码）。

--- a/docs/development/multitable-global-history-restore-backreference-design-lock-20260710.md
+++ b/docs/development/multitable-global-history-restore-backreference-design-lock-20260710.md
@@ -17,12 +17,12 @@
 2. **写路径穿线**：仅上述两个 restore-execute 路径在生成新 revision 时携带 targetVersion；其它 revision 写入点不触碰（列缺省 NULL）。字段级子集恢复（fieldIds）同样携带——回链语义 = 「本次 restore 以版本 N 为源」。
 3. **投影面**：`HistoryChange` / `HistoryBatchDetail` 增加可选 `restoredFromVersion`；LOCK-3 口径：版本号与 `changedFieldIds` 同级=元数据，不含字段值，无掩码增量，但仍走既有投影管道（不得旁路）。
 4. **FE**：`HistoryBatchChangesList` 对 `source='restore'` 的变更行渲染「从版本 N 恢复」（typed label，i18n strict-zero 走 meta-record-labels 既有模式）；无版本可回链（NULL）时不渲染该徽标。
-5. **不做**（明确出界）：跨批次深链跳转到源批次页（源版本≠源批次 id，本锁只回链版本号）；PIT 族回链（revert/reset 已有各自的 preview-identity 语义）。
+5. **不做**（明确出界）：跨批次深链跳转到源批次页（源版本≠源批次 id，本锁只回链版本号）；PIT 族回链（revert/reset 已有各自的 preview-identity 语义）；**legacy `POST …/records/:recordId/restore`（univer-meta.ts ~:9362，:9369 有 targetVersion、:9561 写 `source='restore'`）——该路由的 FE client 方法 `restoreRecordVersion` 现无活跃调用方（History Center 恢复全走 preview→execute 链），本锁不穿线、其新 revision 恒 NULL，由 G2 显式钉住这一意图**（审阅 P3-1）。
 
 ## §3 Goldens（实现 PR 必带，mutation-verified）
 
 - G1 execute 写入：record-restore-execute 后新 revision 行携带 `restored_from_version = targetVersion`（真库）；restore-batch 同。
-- G2 非 restore 写路径恒 NULL（create/update/delete/automation/plugin 各一抽查）。
+- G2 非穿线写路径恒 NULL（create/update/delete/automation/plugin 各一抽查，**外加 legacy `/restore` 路由一例——钉住 §2.5 的 NULL 意图**）。
 - G3 投影携带：批次详情 payload 含 `restoredFromVersion`，且掩码路径不变（LOCK-3 邻测不红）。
 - G4 FE 渲染 + NULL 不渲染；两侧 shape-lock wire 测试同步（wire 形状变更=两侧全扫，家规）。
 - G5 突变：去掉穿线 ⇒ G1 红；投影漏字段 ⇒ G3 红。

--- a/docs/development/multitable-global-history-restore-backreference-design-lock-20260710.md
+++ b/docs/development/multitable-global-history-restore-backreference-design-lock-20260710.md
@@ -1,0 +1,33 @@
+# Global History — restore 批次回链（restored-from back-reference）— MINI DESIGN LOCK (PROPOSED)
+
+- **Status**: PROPOSED — docs-only；owner ratify 前零实现授权。R10 gate-front 工件（R9 UX-parity 审计 gated 项 (e)）。
+- **解锁词**：owner 对本文的明确点头（如「ratify 回链」）。
+- **难度/分派建议**：中（一列迁移 + 两处写路径穿线 + 投影面 + FE 渲染）→ Sonnet 5 建 + 对抗审。
+
+## §1 问题（R9 审计原始证据，已对 origin/main 核验）
+
+`source='restore'` 的批次在 History Center 里无法回答「它恢复了什么」：
+- `meta_record_revisions` 无承载列（创建迁移 + batch_id 迁移均无此概念）；
+- record-restore-execute（univer-meta.ts ~:9596）与 restore-batch-execute（~:9736）调用 `patchRecords({ source: 'restore' })` 时从不把 `targetVersion`（被恢复的源版本）写入新 revision；
+- 对照面：config 侧早有 `restoredFromId`（config-revision-recorder.ts ~:33）——记录数据侧缺同款。
+
+## §2 设计（锁定项）
+
+1. **新列** `meta_record_revisions.restored_from_version`（int，nullable，forward-only 迁移；legacy 行恒 NULL——不回填，不启发式）。
+2. **写路径穿线**：仅上述两个 restore-execute 路径在生成新 revision 时携带 targetVersion；其它 revision 写入点不触碰（列缺省 NULL）。字段级子集恢复（fieldIds）同样携带——回链语义 = 「本次 restore 以版本 N 为源」。
+3. **投影面**：`HistoryChange` / `HistoryBatchDetail` 增加可选 `restoredFromVersion`；LOCK-3 口径：版本号与 `changedFieldIds` 同级=元数据，不含字段值，无掩码增量，但仍走既有投影管道（不得旁路）。
+4. **FE**：`HistoryBatchChangesList` 对 `source='restore'` 的变更行渲染「从版本 N 恢复」（typed label，i18n strict-zero 走 meta-record-labels 既有模式）；无版本可回链（NULL）时不渲染该徽标。
+5. **不做**（明确出界）：跨批次深链跳转到源批次页（源版本≠源批次 id，本锁只回链版本号）；PIT 族回链（revert/reset 已有各自的 preview-identity 语义）。
+
+## §3 Goldens（实现 PR 必带，mutation-verified）
+
+- G1 execute 写入：record-restore-execute 后新 revision 行携带 `restored_from_version = targetVersion`（真库）；restore-batch 同。
+- G2 非 restore 写路径恒 NULL（create/update/delete/automation/plugin 各一抽查）。
+- G3 投影携带：批次详情 payload 含 `restoredFromVersion`，且掩码路径不变（LOCK-3 邻测不红）。
+- G4 FE 渲染 + NULL 不渲染；两侧 shape-lock wire 测试同步（wire 形状变更=两侧全扫，家规）。
+- G5 突变：去掉穿线 ⇒ G1 红；投影漏字段 ⇒ G3 红。
+
+## §4 Owner 决策点
+
+- OD-1：列名/语义确认（`restored_from_version` vs 记源 revision id——推荐版本号：与 restore 请求的 `targetVersion` 同物，无需反查 revision id）。
+- OD-2：FE 徽标是否上线即显（推荐：是——只读元数据，无 flag 必要）。

--- a/docs/development/multitable-global-history-resurrect-anchor-exactness-decision-20260710.md
+++ b/docs/development/multitable-global-history-resurrect-anchor-exactness-decision-20260710.md
@@ -7,12 +7,13 @@
 
 | 选项 | 内容 | 代价/问题 |
 |---|---|---|
-| **A（推荐）** 显式锚参数 opt-in | PIT-undelete 请求增加可选 `deleteRevisionId`；给出则精确用该锚（校验属于该记录且 action=delete），缺省保持现启发式 | response/request-shape 增量=两侧 shape-lock 全扫;向后兼容;零新存储 |
-| B 存储映射 | resurrect 时把所选锚写入新列(记录→源 delete revision) | 新列+写路径,为一个只读诊断性需求引入 schema;偏重 |
+| **A′（推荐，审阅 P3-2 补入）** 服务端按 `asOf` T 推导锚 | resurrect 的唯一现役入口是 PIT-revert（undelete 走 revert-preview 链），wire 上**已携带** `asOf` T——服务端按「该记录 T 之后的第一条 delete revision」推导 vintage-正确锚 | **零 wire 变更**、零新存储;恰好修掉多 vintage under-replay;只改锚选择查询+goldens |
+| A 显式锚参数 opt-in | 请求加可选 `deleteRevisionId`（校验属于该记录且 action=delete，非法 ⇒ 422），缺省保持现行为 | **注意（审阅修正）**：现 preview 响应只回 `{recordId, snapshot, snapshotHash}`（~:9943/:9960），候选 delete-revision id 并未下发——A 实际还需 preview **response**-shape 增量才能让调用方拿到候选锚;两侧 shape-lock 全扫;且显式锚必须纳入 preview-identity 绑定散列（`resurrectScopeHash` ~:10123），否则 preview/execute 锚可漂移=no-side-channel 破口 |
+| B 存储映射 | resurrect 时把所选锚写入新列 | 新列+写路径,为只读诊断性需求引入 schema;偏重 |
 | C 维持现状 | 启发式+goldens(已落) | 多 vintage 精确恢复不可达;边界已如实文档化 |
 
 ## 建议
 
-**A**。preview 阶段本就枚举 revision 列表——客户端已知候选锚；opt-in 参数把「选哪个 vintage」交给调用方而不动缺省行为。实现要点（ratify 后才排）：参数校验 fail-closed（非本记录/非 delete revision ⇒ 422）；preview-identity 需把显式锚纳入绑定散列（否则 preview/execute 锚可漂移=既有 no-side-channel 纪律的破口）；goldens=显式锚精确重放多 vintage + 非法锚 422 + identity 绑定突变。
+**A′**（原推荐 A 经审阅修正后降为次选）：T 已在 wire 上、语义即「恢复到 T 时刻」，vintage-正确锚由 T 唯一决定——服务端推导比把选择权推给调用方更便宜也更不易错。实现要点（ratify 后才排）：锚选择查询改为「首条 `action='delete'` 且 created_at > T」（找不到时 fail-closed 维持现启发式?否——找不到=该记录 T 时刻未删,resurrect 集合本就不含它;以 goldens 钉边界）；R8 的多 vintage/未捕获 vintage goldens 翻断言为精确重放；锚选择突变（改回 latest-delete 启发式）⇒ 多 vintage golden 红。
 
-- **解锁词**：owner 点头选项（A/B/C）。选 C=关闭本项,从 owner 菜单划除。
+- **解锁词**：owner 点头选项（A′/A/B/C）。选 C=关闭本项,从 owner 菜单划除。

--- a/docs/development/multitable-global-history-resurrect-anchor-exactness-decision-20260710.md
+++ b/docs/development/multitable-global-history-resurrect-anchor-exactness-decision-20260710.md
@@ -1,0 +1,18 @@
+# Global History — PIT-resurrect 锚精确化 + response-shape — 决策 one-pager (PROPOSED)
+
+- **Status**: PROPOSED 决策文档；owner ratify 前零实现授权。R10 gate-front 工件（4c-3 wave 验证 §4 项 (1)(2)）。
+- **现状（R8 已诚实钉住）**：PIT-undelete 的 resurrect 侧无 trash 行可携锚，采用「该记录最新 `action='delete'` revision」启发式选锚（univer-meta.ts ~:10183）；多 vintage 场景**只会 under-replay 不会 over-replay**（R8 多 vintage/未捕获 vintage goldens + 注释诚实化已落 main）。restore 侧（trash 路径）锚精确，无此问题。
+
+## 选项
+
+| 选项 | 内容 | 代价/问题 |
+|---|---|---|
+| **A（推荐）** 显式锚参数 opt-in | PIT-undelete 请求增加可选 `deleteRevisionId`；给出则精确用该锚（校验属于该记录且 action=delete），缺省保持现启发式 | response/request-shape 增量=两侧 shape-lock 全扫;向后兼容;零新存储 |
+| B 存储映射 | resurrect 时把所选锚写入新列(记录→源 delete revision) | 新列+写路径,为一个只读诊断性需求引入 schema;偏重 |
+| C 维持现状 | 启发式+goldens(已落) | 多 vintage 精确恢复不可达;边界已如实文档化 |
+
+## 建议
+
+**A**。preview 阶段本就枚举 revision 列表——客户端已知候选锚；opt-in 参数把「选哪个 vintage」交给调用方而不动缺省行为。实现要点（ratify 后才排）：参数校验 fail-closed（非本记录/非 delete revision ⇒ 422）；preview-identity 需把显式锚纳入绑定散列（否则 preview/execute 锚可漂移=既有 no-side-channel 纪律的破口）；goldens=显式锚精确重放多 vintage + 非法锚 422 + identity 绑定突变。
+
+- **解锁词**：owner 点头选项（A/B/C）。选 C=关闭本项,从 owner 菜单划除。


### PR DESCRIPTION
**Docs-only, zero runtime** — R10 round gate-front artifacts (owner /goal「这条线余下开发」, owner away ⇒ gated items pushed to decision-ready only, per the line's standing R4 discipline).

Four per-item decision units, each with options + recommendation + inline unlock word:

| # | Item | Recommendation |
|---|---|---|
| 1 | **restore 批次回链** mini-lock | `restored_from_version` col + 2 execute-path threading + projection/FE + G1-G5 |
| 2 | **field-value tombstone 留存地板** | **A: accept the documented boundary**(re-decision trigger tied to any 4c capture/revert flag going prod+retention-on); B=weak floor rejected reasoning included |
| 3 | **PIT-resurrect 锚精确化** | **A: opt-in explicit `deleteRevisionId`**(fail-closed validation + preview-identity hash binding), backward compatible, zero schema |
| 4 | **all-tables 字段元数据** | **B: server-side masked `fieldNames` map** reusing the projection's per-sheet allow-sets — field NAMES are two-layer-maskable (R9 #4007 lesson); client-side re-derivation = two-truth-sources hazard |

No implementation is authorized by this PR; each item unlocks independently on its own owner nod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)