### PR TITLE
fix(multitable): wire TrashModal to the two-layer-visible field list (R10)

### DIFF
--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -61,7 +61,7 @@
       <button class="mt-workbench__mgr-btn" :class="{ 'mt-workbench__mgr-btn--active': showDashboardView }" @click="showDashboardView = !showDashboardView" data-action="toggle-dashboard"><el-icon class="mt-workbench__mgr-btn-icon"><component :is="ICON.dashboard" /></el-icon> {{ wb('toolbar.dashboard', isZh) }}</button>
       <button v-if="activeViewType === 'form'" class="mt-workbench__mgr-btn" @click="showFormShareManager = true"><el-icon class="mt-workbench__mgr-btn-icon"><component :is="ICON.shareForm" /></el-icon> {{ wb('toolbar.shareForm', isZh) }}</button>
       <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true"><el-icon class="mt-workbench__mgr-btn-icon"><component :is="ICON.apiWebhooks" /></el-icon> {{ wb('toolbar.apiWebhooks', isZh) }}</button>
-      <button v-if="caps.canDeleteRecord.value" class="mt-workbench__mgr-btn" @click="showTrash = true"><el-icon class="mt-workbench__mgr-btn-icon"><component :is="ICON.trash" /></el-icon> {{ wb('toolbar.trash', isZh) }}</button>
+      <button v-if="caps.canDeleteRecord.value" class="mt-workbench__mgr-btn" data-action="open-trash" @click="showTrash = true"><el-icon class="mt-workbench__mgr-btn-icon"><component :is="ICON.trash" /></el-icon> {{ wb('toolbar.trash', isZh) }}</button>
       <button v-if="activeBaseId" class="mt-workbench__mgr-btn" data-action="open-history" @click="historyDeepLinkBatchId = null; showHistory = true"><el-icon class="mt-workbench__mgr-btn-icon"><component :is="ICON.history" /></el-icon> {{ isZh ? '历史' : 'History' }}</button>
       <button v-if="workbench.activeSheetId.value" class="mt-workbench__mgr-btn" data-action="open-config-history" @click="openConfigHistory"><el-icon class="mt-workbench__mgr-btn-icon"><component :is="ICON.configHistory" /></el-icon> {{ isZh ? '配置历史' : 'Config history' }}</button>
     </div>
@@ -525,7 +525,7 @@
     <TrashModal
       :open="showTrash"
       :sheet-id="workbench.activeSheetId.value"
-      :fields="scopedAllFields"
+      :fields="twoLayerVisibleFields"
       @close="showTrash = false"
       @restored="onTrashRestored"
     />
@@ -534,7 +534,7 @@
       :open="showHistory"
       :base-id="activeBaseId || ''"
       :sheet-id="workbench.activeSheetId.value"
-      :fields="historyVisibleFields"
+      :fields="twoLayerVisibleFields"
       :link-summaries="grid.linkSummaries.value"
       :person-summaries="grid.personSummaries.value"
       :initial-batch-id="historyDeepLinkBatchId"
@@ -1336,10 +1336,13 @@ const effectiveRowActions = computed<MetaRowActions>(() => {
 const scopedAllFields = computed(() =>
   grid.fields.value.filter((field) => effectiveFieldPermissions.value[field.id]?.visible !== false),
 )
-// History Center field list: BOTH visibility layers must filter — layer-2 property-hidden
-// (property.hidden / property.visible=false) ∩ layer-3 per-subject field_permissions (RBAC).
-// Either alone leaks the other layer's hidden field NAMES into the filter options / diff labels.
-const historyVisibleFields = computed(() => filterPropertyVisibleFields(scopedAllFields.value))
+// Two-layer-visible field list (History Center + TrashModal): BOTH visibility layers must filter —
+// layer-2 property-hidden (property.hidden / property.visible=false) ∩ layer-3 per-subject
+// field_permissions (RBAC, already applied by scopedAllFields). Either alone leaks the other layer:
+// History Center would leak hidden field NAMES into the filter options / diff labels; TrashModal's
+// pickRecordTitle would leak a hidden field's VALUE into a trash-row title (R10 fix — was wired to
+// scopedAllFields alone, layer-3-only).
+const twoLayerVisibleFields = computed(() => filterPropertyVisibleFields(scopedAllFields.value))
 const scopedGridFields = computed(() =>
   grid.visibleFields.value.filter((field) => effectiveFieldPermissions.value[field.id]?.visible !== false),
 )

--- a/apps/web/tests/multitable-workbench-history-field-scope-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-history-field-scope-wiring.spec.ts
@@ -8,17 +8,21 @@
  *    scopedAllFields covers ONLY this.
  * The original wiring used propertyVisibleGridFields (leaked RBAC-denied names); the first fix swapped to
  * scopedAllFields (owner P1: re-leaked property-hidden names). The correct wiring is the INTERSECTION —
- * `historyVisibleFields = filterPropertyVisibleFields(scopedAllFields)` — and this spec pins BOTH layers:
+ * `twoLayerVisibleFields = filterPropertyVisibleFields(scopedAllFields)` — and this spec pins BOTH layers:
  * either single-layer wiring turns exactly one assertion red. Backend already withholds VALUES (LOCK-3);
  * the label itself was the FE-side leak.
  *
- * This test does NOT mock HistoryCenterModal or HistoryBatchChangesList — it mounts the real
+ * R10: `twoLayerVisibleFields` (renamed from `historyVisibleFields`, #4007) now also feeds TrashModal's
+ * `:fields`, which was wired to `scopedAllFields` alone (layer-3-only) — a property-hidden field's VALUE
+ * could seed a trash-row TITLE via `pickRecordTitle`. The 'recycle bin' describe block below pins that.
+ *
+ * This test does NOT mock HistoryCenterModal, HistoryBatchChangesList, or TrashModal — it mounts the real
  * MultitableWorkbench (heavy siblings stubbed, same pattern as
  * multitable-workbench-permission-wiring.spec.ts).
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, computed, type App as VueApp, type Component } from 'vue'
-import type { HistoryBatchDetail, HistoryBatchSummary } from '../src/multitable/types'
+import type { HistoryBatchDetail, HistoryBatchSummary, MetaDeletedRecord } from '../src/multitable/types'
 
 function stubComponent(name: string) {
   return defineComponent({ name, render() { return h('div', { [`data-stub-${name}`]: 'true' }) } })
@@ -28,9 +32,10 @@ let workbenchMock: any
 let gridMock: any
 let capsMock: any
 
-const { mockListHistoryEvents, mockGetHistoryBatch } = vi.hoisted(() => ({
+const { mockListHistoryEvents, mockGetHistoryBatch, mockListDeletedRecords } = vi.hoisted(() => ({
   mockListHistoryEvents: vi.fn(),
   mockGetHistoryBatch: vi.fn(),
+  mockListDeletedRecords: vi.fn(),
 }))
 
 vi.mock('../src/multitable/api/client', async () => {
@@ -41,6 +46,7 @@ vi.mock('../src/multitable/api/client', async () => {
       ...actual.multitableClient,
       listHistoryEvents: mockListHistoryEvents,
       getHistoryBatch: mockGetHistoryBatch,
+      listDeletedRecords: mockListDeletedRecords,
     },
   }
 })
@@ -251,6 +257,8 @@ describe('MultitableWorkbench -> HistoryCenterModal field-scope wiring', () => {
   beforeEach(() => {
     mockListHistoryEvents.mockReset()
     mockGetHistoryBatch.mockReset()
+    mockListDeletedRecords.mockReset()
+    mockListDeletedRecords.mockResolvedValue({ records: [], total: 0 })
     mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
     const detail: HistoryBatchDetail = {
       batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
@@ -397,5 +405,86 @@ describe('MultitableWorkbench -> HistoryCenterModal field-scope wiring', () => {
     await flushUi()
     expect(workbenchMock.selectSheet).toHaveBeenCalledWith('sheet_2')
     expect(mockShowError).not.toHaveBeenCalled()
+  })
+})
+
+// R10: TrashModal shares the SAME `twoLayerVisibleFields` wiring as History Center (was `scopedAllFields`
+// alone, layer-3-only). TrashModal derives a trash-row TITLE from field VALUES via `pickRecordTitle` —
+// a property-hidden (layer-2) field leaking its NAME is bad enough; leaking its VALUE into a visible
+// title is worse. This pins both layers on the trash-row title, reusing the same `fields` fixture
+// (fld_1 visible-both-layers, fld_2 RBAC-denied/layer-3, fld_3 property-hidden/layer-2).
+describe('MultitableWorkbench -> TrashModal field-scope wiring', () => {
+  let app: VueApp | null = null
+  let container: HTMLDivElement | null = null
+
+  async function flushUi() {
+    await nextTick(); await nextTick()
+    await new Promise((r) => setTimeout(r, 20))
+    await nextTick()
+  }
+
+  function deletedRecord(): MetaDeletedRecord {
+    return {
+      recordId: 'rec_del_1',
+      sheetId: 'sheet_1',
+      // fld_1 (visible on both layers) is intentionally ABSENT/empty so title-resolution falls through
+      // to the next field by column order — exercising exactly the leak path: does it stop at the
+      // record-id fallback (correct) or fall through into fld_3's HIDDEN value (leak)?
+      data: { fld_2: 'Secret42000', fld_3: 'Hidden Value' },
+      originalVersion: 1,
+      createdBy: null,
+      deletedBy: 'user_1',
+      deletedAt: new Date().toISOString(),
+    }
+  }
+
+  beforeEach(() => {
+    mockListDeletedRecords.mockReset()
+    mockListDeletedRecords.mockResolvedValue({ records: [deletedRecord()], total: 1 })
+    workbenchMock = createWorkbenchMock()
+    gridMock = createGridMock()
+    capsMock = {
+      canRead: ref(true), canCreateRecord: ref(true), canEditRecord: ref(true),
+      canDeleteRecord: ref(true), canManageFields: ref(true), canManageSheetAccess: ref(true),
+      canManageViews: ref(true), canComment: ref(true), canManageAutomation: ref(false),
+      canExport: ref(true),
+    }
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    window.history.replaceState(null, '', window.location.pathname)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null; container = null
+    vi.clearAllMocks()
+  })
+
+  it('the trash-row title falls through a property-hidden field (layer-2) to the record-id fallback, and never shows the RBAC-denied field (layer-3) either', async () => {
+    const MultitableWorkbench = (await import('../src/multitable/views/MultitableWorkbench.vue')).default
+
+    app = createApp(defineComponent({
+      setup() { return () => h(MultitableWorkbench as Component) },
+    }))
+    app.mount(container!)
+    await flushUi()
+
+    const trashBtn = container!.querySelector<HTMLButtonElement>('[data-action="open-trash"]')
+    expect(trashBtn).toBeTruthy()
+    trashBtn!.click()
+    await flushUi()
+
+    expect(mockListDeletedRecords).toHaveBeenCalledWith('sheet_1', undefined)
+
+    const titleEl = container!.querySelector('[data-test="trash-record-title"]')
+    expect(titleEl).toBeTruthy()
+    // fld_1 is empty → skipped; fld_3 (layer-2 property-hidden) MUST NOT seed the title even though its
+    // value is present on the row — falls all the way through to the record-id fallback.
+    expect(titleEl!.textContent).toBe('#del_1')
+    expect(titleEl!.textContent).not.toContain('Hidden Value')
+    // fld_2 (layer-3 RBAC-denied) is excluded too — already covered by scopedAllFields itself, pinned
+    // here alongside the layer-2 case so a future regression on either layer fails in ONE place.
+    expect(titleEl!.textContent).not.toContain('Secret42000')
   })
 })


### PR DESCRIPTION
## What

Field VISIBILITY has two independent display layers:
- **layer-2 property-hidden** (`field.property.hidden === true || property.visible === false`) — `filterPropertyVisibleFields`
- **layer-3 per-subject RBAC** (`effectiveFieldPermissions[f.id]?.visible !== false`) — `scopedAllFields`

`TrashModal` was wired `:fields="scopedAllFields"` — layer-3 only. It uses `fields` (via `pickRecordTitle`) to derive a trash-row **title** from field **values**, so a property-hidden (but RBAC-readable) field's value could seed a visible title. This is a display-consistency gap, not a permission bypass: the acting user already has read access to that field's value (RBAC layer-3 is unaffected and untouched by this PR) — the fix only stops a display-hidden field from surfacing in a derived title where the plain field itself wouldn't be shown.

Fix: reuse the existing `filterPropertyVisibleFields(scopedAllFields)` computed added by #4007 for History Center (`historyVisibleFields`), and wire it into `TrashModal` too. Since it now serves two consumers, renamed to `twoLayerVisibleFields` (both usages + the one spec comment reference updated — grepped the whole repo, no other reference exists). No RBAC/permission logic changed.

Also tagged the trash-open toolbar button with `data-action="open-trash"`, matching the existing `open-history` / `open-config-history` / `open-template-library` convention, so it's clickable from a wiring spec without a text-content query.

## Verification

Extended the existing `multitable-workbench-history-field-scope-wiring.spec.ts` (neither `multitable-trash-fe.spec.ts` nor `multitable-workbench-restore-wiring.spec.ts` mounts `TrashModal` through the real workbench with it open — this file already mounts the real workbench + real `TrashModal`/`HistoryCenterModal`) with a new `describe` block that opens the real Trash modal and asserts the derived row title.

```
pnpm --filter @metasheet/web exec vitest run \
  tests/multitable-trash-fe.spec.ts \
  tests/multitable-history-fe.spec.ts \
  tests/multitable-history-center-ai-shortcut-label.spec.ts \
  tests/multitable-history-center-inline-diff.spec.ts \
  tests/multitable-history-center-pinned-batch-deeplink.spec.ts \
  tests/multitable-workbench-history-field-scope-wiring.spec.ts \
  tests/multitable-workbench-restore-wiring.spec.ts \
  --watch=false
# Test Files  7 passed (7)
#      Tests  56 passed (56)
```

`multitable-workbench-history-field-scope-wiring.spec.ts` alone: 6/6 passed (5 pre-existing History Center cases + 1 new TrashModal case).

`pnpm --filter @metasheet/web exec vue-tsc -b` — clean, exit 0, no output.

Required CI (`test 20.x`) only builds `apps/web`; it does not execute this vitest suite. The commands above are the reproducible evidence.

## Mutation evidence

Checkpoint-committed the fix first, then used the Edit tool to swap `TrashModal`'s `:fields` back to `scopedAllFields` (the pre-fix wiring), re-ran the same spec file, and reverted with the Edit tool back to the exact committed diff (`git diff --stat` empty after revert):

```
❯ tests/multitable-workbench-history-field-scope-wiring.spec.ts (6 tests | 1 failed)
  ❯ MultitableWorkbench -> TrashModal field-scope wiring > the trash-row title falls through
    a property-hidden field (layer-2) to the record-id fallback, and never shows the
    RBAC-denied field (layer-3) either
    → expected 'Hidden Value' to be '#del_1'

Test Files  1 failed (1)
     Tests  1 failed | 5 passed (6)
```

Exactly the property-hidden (layer-2) assertion reds — the fld_3 value leaks into the title instead of falling through to the record-id fallback (`#del_1`). The RBAC-denied (layer-3, fld_2) assertion and all 5 pre-existing History Center cases stay green, confirming layer-3 already held via `scopedAllFields` and this fix is precisely load-bearing for layer-2.

## Not covered

- No RBAC/permission-layer logic was touched — `scopedAllFields` (the RBAC filter) is reused as-is; this PR only layers the existing property-hidden filter on top for `TrashModal`, same as #4007 did for History Center.
- The property-hidden field's value still legitimately lives in the record's `data` payload and in any other surface that renders it directly (e.g. the record drawer, when the field itself isn't display-hidden there) — this change only touches trash-row *title derivation* via `pickRecordTitle`.
- Did not rename the spec file itself (still named `...history-field-scope-wiring.spec.ts` though it now also covers TrashModal) — kept the diff minimal per the task's neighbor-sweep list, which names this file explicitly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>