### PR TITLE
fix(onprem): pin Corepack pnpm dispatcher

### DIFF
--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -254,6 +254,34 @@ function Resolve-CorepackCommand {
   return $null
 }
 
+function New-CorepackPnpmCommandWrapper {
+  param(
+    [string]$WrapperPath,
+    [string]$CorepackPath,
+    [string]$RequiredVersion
+  )
+
+  $resolvedCorepackPath = Resolve-NormalizedPath -Candidate $CorepackPath -Label 'Corepack command'
+  $quotedCorepackPath = ConvertTo-CmdQuoted -Value $resolvedCorepackPath
+  $corepackPrefix = if ($resolvedCorepackPath.ToLowerInvariant().EndsWith('.ps1')) {
+    "powershell.exe -NoProfile -ExecutionPolicy Bypass -File $quotedCorepackPath"
+  } elseif ($resolvedCorepackPath.ToLowerInvariant().EndsWith('.cmd') -or $resolvedCorepackPath.ToLowerInvariant().EndsWith('.bat')) {
+    "call $quotedCorepackPath"
+  } else {
+    $quotedCorepackPath
+  }
+
+  $lines = @(
+    '@echo off',
+    'setlocal EnableExtensions DisableDelayedExpansion',
+    "$corepackPrefix `"pnpm@$RequiredVersion`" %*",
+    'set "COREPACK_PNPM_EXIT=%ERRORLEVEL%"',
+    'exit /b %COREPACK_PNPM_EXIT%'
+  )
+  Set-Content -LiteralPath $WrapperPath -Value $lines -Encoding ASCII
+  return (Resolve-Path -LiteralPath $WrapperPath).Path
+}
+
 function Resolve-PackagePnpmVersion {
   param([string]$PackageRoot)
 
@@ -272,9 +300,13 @@ function Resolve-PackagePnpmVersion {
 }
 
 function Initialize-PinnedPnpm {
-  param([string]$RequiredVersion)
+  param(
+    [string]$RequiredVersion,
+    [string]$WrapperRoot
+  )
 
   $corepackPath = Resolve-CorepackCommand
+  $pnpmPath = $null
   if (-not [string]::IsNullOrWhiteSpace($corepackPath)) {
     Write-Info "Activate pinned pnpm via corepack prepare pnpm@$RequiredVersion --activate"
     $prepareOutput = & $corepackPath prepare "pnpm@$RequiredVersion" --activate 2>&1
@@ -283,11 +315,19 @@ function Initialize-PinnedPnpm {
     if ($prepareExit -ne 0) {
       throw "corepack failed to activate pnpm $RequiredVersion (exit=$prepareExit)"
     }
+    # Dispatch through this exact Corepack binary with an explicit pnpm
+    # version. A generic PATH/profile search here can select an unrelated
+    # pnpm.cmd and defeat the activation that just succeeded.
+    $corepackWrapperPath = Join-Path $WrapperRoot "pnpm-corepack-$RequiredVersion.cmd"
+    $pnpmPath = New-CorepackPnpmCommandWrapper `
+      -WrapperPath $corepackWrapperPath `
+      -CorepackPath $corepackPath `
+      -RequiredVersion $RequiredVersion
   } else {
     Write-Info 'corepack is unavailable; an already-installed exact pnpm version is required'
+    $pnpmPath = Resolve-PnpmInstallCommand
   }
 
-  $pnpmPath = Resolve-PnpmInstallCommand
   $actualVersion = Invoke-PnpmSingleLine -PnpmPath $pnpmPath -Arguments @('--version')
   if ([string]::IsNullOrWhiteSpace($actualVersion) -or $actualVersion.Trim() -ne $RequiredVersion) {
     throw "PNPM_VERSION_MISMATCH: package requires $RequiredVersion but resolved '$actualVersion' at $pnpmPath"
@@ -958,7 +998,9 @@ try {
 
   if ($InstallDeps -ne '0') {
     $requiredPnpmVersion = Resolve-PackagePnpmVersion -PackageRoot $packageRoot
-    $pnpmInstallPath = Initialize-PinnedPnpm -RequiredVersion $requiredPnpmVersion
+    $pnpmInstallPath = Initialize-PinnedPnpm `
+      -RequiredVersion $requiredPnpmVersion `
+      -WrapperRoot $extractRoot
     $dependencyTimeoutSec = Convert-PositiveInt -Value $DependencyRefreshTimeoutSec -Label 'DependencyRefreshTimeoutSec'
     $dependencyHeartbeatSec = Convert-PositiveInt -Value $DependencyRefreshHeartbeatSec -Label 'DependencyRefreshHeartbeatSec'
     # The deploy-local content-addressable store is cache-only state. Reusing it

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -20,8 +20,75 @@ test('Windows apply helper bootstraps SYSTEM-safe tool PATH and resolves pnpm fr
   assert.match(script, /Join-Path \$base 'nodejs'/)
   assert.match(script, /foreach \(\$leaf in @\('pnpm\.exe', 'pnpm\.cmd', 'pnpm\.ps1'\)\)/)
   assert.match(script, /Initialize-WindowsSystemToolPath/)
-  assert.match(script, /\$pnpmInstallPath = Initialize-PinnedPnpm -RequiredVersion \$requiredPnpmVersion/)
+  assert.match(script, /\$pnpmInstallPath = Initialize-PinnedPnpm/)
+  assert.match(script, /-RequiredVersion \$requiredPnpmVersion/)
+  assert.match(script, /-WrapperRoot \$extractRoot/)
   assert.match(script, /\$pnpmPath = Resolve-PnpmInstallCommand/)
+})
+
+test('Corepack activation uses an exact-version dispatcher instead of a shadowing profile binary', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-corepack-pnpm-'))
+  const applyHelper = path.join(repoRoot, 'scripts/ops/multitable-onprem-apply-package.ps1')
+  const harness = String.raw`
+$ErrorActionPreference = 'Stop'
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($env:APPLY_HELPER, [ref]$tokens, [ref]$errors)
+if ($errors.Count -gt 0) { throw ($errors | ForEach-Object { $_.Message } | Out-String) }
+$functionText = $ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true) |
+  ForEach-Object { $_.Extent.Text }
+Invoke-Expression ($functionText -join [Environment]::NewLine)
+
+$corepackDir = Join-Path $env:TEST_ROOT 'corepack-bin'
+$profileDir = Join-Path $env:TEST_ROOT 'profile-bin'
+New-Item -ItemType Directory -Path $corepackDir, $profileDir -Force | Out-Null
+$corepackPath = Join-Path $corepackDir 'corepack.cmd'
+$shadowingPnpmPath = Join-Path $profileDir 'pnpm.cmd'
+$wrapperPath = Join-Path $env:TEST_ROOT 'pinned-pnpm.cmd'
+Set-Content -LiteralPath $corepackPath -Value '@echo off' -NoNewline
+Set-Content -LiteralPath $shadowingPnpmPath -Value '@echo 8.0.0' -NoNewline
+
+$resolved = New-CorepackPnpmCommandWrapper -WrapperPath $wrapperPath -CorepackPath $corepackPath -RequiredVersion '9.15.9'
+$wrapper = Get-Content -LiteralPath $resolved -Raw
+if (-not $wrapper.Contains([System.IO.Path]::GetFullPath($corepackPath))) { throw 'wrapper does not pin the Corepack path' }
+if (-not $wrapper.Contains('pnpm@9.15.9')) { throw 'wrapper does not pin the required pnpm version' }
+if (-not $wrapper.Contains('%*')) { throw 'wrapper does not forward pnpm arguments' }
+$expectedDispatch = 'call "' + [System.IO.Path]::GetFullPath($corepackPath) + '" "pnpm@9.15.9" %*'
+if (-not $wrapper.Contains($expectedDispatch)) { throw "wrapper command is not exact: $wrapper" }
+if (-not $wrapper.Contains('set "COREPACK_PNPM_EXIT=%ERRORLEVEL%"')) { throw 'wrapper does not capture the Corepack exit code' }
+if (-not $wrapper.Contains('exit /b %COREPACK_PNPM_EXIT%')) { throw 'wrapper does not propagate the Corepack exit code' }
+if ($wrapper.Contains([System.IO.Path]::GetFullPath($shadowingPnpmPath))) { throw 'wrapper captured the shadowing profile pnpm' }
+`
+
+  try {
+    const result = spawnSync('pwsh', ['-NoProfile', '-NonInteractive', '-Command', harness], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        APPLY_HELPER: applyHelper,
+        TEST_ROOT: tempRoot,
+      },
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+
+    const script = readScript('scripts/ops/multitable-onprem-apply-package.ps1')
+    const initializer = script.slice(
+      script.indexOf('function Initialize-PinnedPnpm'),
+      script.indexOf('function Convert-PositiveInt'),
+    )
+    assert.match(initializer, /New-CorepackPnpmCommandWrapper/)
+    assert.match(initializer, /-WrapperPath \$corepackWrapperPath/)
+    assert.match(initializer, /-CorepackPath \$corepackPath/)
+    assert.match(initializer, /-RequiredVersion \$RequiredVersion/)
+    assert.match(
+      initializer,
+      /else \{[\s\S]*\$pnpmPath = Resolve-PnpmInstallCommand/,
+      'generic pnpm discovery should remain only as the no-Corepack fallback',
+    )
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
 })
 
 test('on-prem package build and apply use the same exact pnpm version', () => {


### PR DESCRIPTION
## Summary

- keep `corepack prepare pnpm@9.15.9 --activate` as the cache/activation step;
- generate a short-lived dispatcher under the extraction root that invokes the resolved Corepack absolute path as `corepack pnpm@9.15.9 ...`;
- route version checks, config diagnostics, staging preflight, and rollback-protected live activation through that dispatcher;
- retain generic pnpm discovery only when Corepack is completely unavailable and the discovered pnpm already passes the exact-version check.

## Why

The #3751 entity-machine rerun proved that Corepack preparation can succeed while the subsequent generic pnpm search selects a shadowing system-profile `pnpm.cmd`. The helper correctly failed before dependency preflight or live overlay, but the release could not proceed.

The dispatcher binds both the Corepack executable and pnpm version. It does not modify PATH, write into the Node installation, or trust a profile pnpm shim.

## Verification

Fail-first on current main:

```text
Corepack activation uses an exact-version dispatcher ... FAIL
reason=dispatcher contract absent
```

After the change:

```text
package/windows/smoke contract tests=38/38 PASS on rebased main
PowerShell parser=PASS
node --check=PASS
verify:integration-k3wise:poc=PASS
git diff --check=PASS
```

The regression fixture creates a Corepack path and a separate shadowing profile pnpm, then proves the generated command pins:

```text
call "<resolved-corepack.cmd>" "pnpm@9.15.9" %*
```

It also locks argument forwarding and exit-code propagation.

## Boundary

No package overlay, migration, restart, external write, K3 Save/Submit/Audit, or smoke behavior changes. The entity-machine evidence confirms the failed attempt touched none of those surfaces.