### PR TITLE
fix(onprem): remove unused native bcrypt dependency

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -39,7 +39,6 @@
     "@wendellhu/redi": "^1.1.0",
     "ajv": "^8.12.0",
     "axios": "^1.8.0",
-    "bcrypt": "^5.1.1",
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "eventemitter3": "^5.0.1",
@@ -73,7 +72,6 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.25",
     "@types/jsonwebtoken": "^9.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,9 +163,6 @@ importers:
       axios:
         specifier: ^1.8.0
         version: 1.13.2
-      bcrypt:
-        specifier: ^5.1.1
-        version: 5.1.1(encoding@0.1.13)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -260,9 +257,6 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
-      '@types/bcrypt':
-        specifier: ^5.0.2
-        version: 5.0.2
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.19
@@ -1513,9 +1507,6 @@ packages:
   '@tediousjs/connection-string@0.5.0':
     resolution: {integrity: sha512-7qSgZbincDDDFyRweCIEvZULFAw5iz/DeunhvuxpL31nfntX3P4Yd4HkHBRg9H8CdqY1e5WFN1PZIz/REL9MVQ==}
 
-  '@types/bcrypt@5.0.2':
-    resolution: {integrity: sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==}
-
   '@types/bcryptjs@3.0.0':
     resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
     deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
@@ -1971,10 +1962,6 @@ packages:
   base64id@2.0.0:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
-
-  bcrypt@5.1.1:
-    resolution: {integrity: sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==}
-    engines: {node: '>= 10.0.0'}
 
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
@@ -5641,10 +5628,6 @@ snapshots:
 
   '@tediousjs/connection-string@0.5.0': {}
 
-  '@types/bcrypt@5.0.2':
-    dependencies:
-      '@types/node': 20.19.25
-
   '@types/bcryptjs@3.0.0':
     dependencies:
       bcryptjs: 3.0.3
@@ -6190,14 +6173,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
-
-  bcrypt@5.1.1(encoding@0.1.13):
-    dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
-      node-addon-api: 5.1.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   bcryptjs@3.0.3: {}
 

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -60,6 +60,29 @@ function runStockPreparationVerifier(root) {
   )
 }
 
+function runNativeBcryptVerifier(packageJson, lockfile) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-package-native-bcrypt-'))
+  const backendRoot = path.join(root, 'packages/core-backend')
+  fs.mkdirSync(backendRoot, { recursive: true })
+  fs.writeFileSync(path.join(backendRoot, 'package.json'), JSON.stringify(packageJson, null, 2))
+  fs.writeFileSync(path.join(root, 'pnpm-lock.yaml'), lockfile)
+  const result = spawnSync(
+    'bash',
+    ['-lc', 'source "$VERIFY"; verify_no_native_bcrypt_dependency "$PACKAGE_ROOT"'],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        VERIFY: verifyScriptPath,
+        PACKAGE_ROOT: root,
+      },
+      encoding: 'utf8',
+    },
+  )
+  fs.rmSync(root, { recursive: true, force: true })
+  return result
+}
+
 test('on-prem package build prunes copied workspace node_modules before archiving', () => {
   assert.match(
     buildScript,
@@ -81,6 +104,57 @@ test('on-prem package build prunes copied workspace node_modules before archivin
     /prune_node_modules "\$PACKAGE_ROOT"/,
     'the final package root should be swept before archive creation',
   )
+})
+
+test('on-prem verifier rejects native bcrypt build dependencies', () => {
+  const clean = runNativeBcryptVerifier(
+    {
+      dependencies: { bcryptjs: '^3.0.3' },
+      devDependencies: {},
+    },
+    "lockfileVersion: '9.0'\n",
+  )
+  assert.equal(clean.status, 0, clean.stderr)
+
+  const nativeManifest = runNativeBcryptVerifier(
+    {
+      dependencies: { bcrypt: '^5.1.1', bcryptjs: '^3.0.3' },
+      devDependencies: { '@types/bcrypt': '^5.0.2' },
+    },
+    "lockfileVersion: '9.0'\n",
+  )
+  assert.notEqual(nativeManifest.status, 0, 'native bcrypt manifest entries must fail verification')
+  assert.match(nativeManifest.stderr, /must not depend on native bcrypt/)
+
+  const nativeTypeManifest = runNativeBcryptVerifier(
+    {
+      dependencies: { bcryptjs: '^3.0.3' },
+      devDependencies: { '@types/bcrypt': '^5.0.2' },
+    },
+    "lockfileVersion: '9.0'\n",
+  )
+  assert.notEqual(nativeTypeManifest.status, 0, 'unused native bcrypt type entries must fail verification')
+  assert.match(nativeTypeManifest.stderr, /must not depend on native bcrypt/)
+
+  const staleLock = runNativeBcryptVerifier(
+    {
+      dependencies: { bcryptjs: '^3.0.3' },
+      devDependencies: {},
+    },
+    "lockfileVersion: '9.0'\n\npackages:\n\n  bcrypt@5.1.1:\n    resolution: {}\n",
+  )
+  assert.notEqual(staleLock.status, 0, 'native bcrypt lockfile entries must fail verification')
+  assert.match(staleLock.stderr, /lockfile must not contain native bcrypt/)
+
+  const staleTypeLock = runNativeBcryptVerifier(
+    {
+      dependencies: { bcryptjs: '^3.0.3' },
+      devDependencies: {},
+    },
+    "lockfileVersion: '9.0'\n\npackages:\n\n  '@types/bcrypt@5.0.2':\n    resolution: {}\n",
+  )
+  assert.notEqual(staleTypeLock.status, 0, 'native bcrypt type lockfile entries must fail verification')
+  assert.match(staleTypeLock.stderr, /lockfile must not contain native bcrypt/)
 })
 
 test('on-prem verifier rejects archive lists that contain node_modules entries', () => {

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -199,6 +199,22 @@ function verify_root_runtime_dependencies() {
   search_fixed_string '"packageManager": "pnpm@9.15.9"' "$package_json" || die "packaged root package.json must pin pnpm@9.15.9"
 }
 
+function verify_no_native_bcrypt_dependency() {
+  local root="$1"
+  local core_backend_package_json="${root}/packages/core-backend/package.json"
+  local lockfile="${root}/pnpm-lock.yaml"
+
+  [[ -f "$core_backend_package_json" ]] || die "core-backend package.json must be present"
+  [[ -f "$lockfile" ]] || die "pnpm-lock.yaml must be present"
+  search_fixed_string '"bcryptjs":' "$core_backend_package_json" || die "core-backend package.json must keep the portable bcryptjs runtime"
+  if search_fixed_string '"bcrypt":' "$core_backend_package_json" || search_fixed_string '"@types/bcrypt":' "$core_backend_package_json"; then
+    die "core-backend package.json must not depend on native bcrypt or its unused type package"
+  fi
+  if grep -Eq "^[[:space:]]+(bcrypt@|'@types/bcrypt@)" "$lockfile"; then
+    die "pnpm lockfile must not contain native bcrypt build dependencies"
+  fi
+}
+
 function verify_integration_plugin_runtime_dependencies() {
   local root="$1"
   local workspace_yaml="${root}/pnpm-workspace.yaml"
@@ -968,6 +984,7 @@ bootstrap_run_wrapper="$(find "$pkg_root" -maxdepth 1 -type f -name 'bootstrap-a
 [[ -n "$bootstrap_run_wrapper" ]] || die "Required package content missing: bootstrap-admin-<run>.bat"
 verify_windows_entrypoints "$pkg_root"
 verify_root_runtime_dependencies "$pkg_root"
+verify_no_native_bcrypt_dependency "$pkg_root"
 verify_integration_plugin_runtime_dependencies "$pkg_root"
 verify_deployable_artifact_contract "$pkg_root"
 verify_build_provenance "$pkg_root"


### PR DESCRIPTION
## Summary

- remove the unused native `bcrypt@5.1.1` dependency and its unused `@types/bcrypt` package from core-backend;
- keep the existing `bcryptjs` runtime unchanged (all authentication/hash call sites already import it);
- remove the corresponding importer/package/snapshot lockfile nodes;
- make the on-prem package verifier fail closed if native bcrypt or its type package reappears in either the backend manifest or lockfile.

## Why

The latest #3751 entity-machine rerun proved the Corepack dispatcher fix works, then reached the next blocker: Node 24 attempted to install unused `bcrypt@5.1.1`, found no compatible prebuilt binary, and had no declared Visual Studio C++ toolchain. The failure remained in staging, but blocked migration/restart/smoke.

Requiring a production build toolchain or downgrading Node is unnecessary: source and test imports already use portable `bcryptjs`; native bcrypt was a stale direct dependency from the initial backend manifest.

## Verification

Fail-first:

```text
on-prem verifier rejects native bcrypt build dependencies = FAIL
reason=verify_no_native_bcrypt_dependency absent
```

After the change:

```text
Node=24.14.1
pnpm=9.15.9
full workspace frozen install=PASS (905/905, lifecycle scripts enabled)
pnpm why bcrypt=empty
package/windows/smoke contracts=39/39 PASS
authentication unit tests=127/127 PASS
core-backend type-check=PASS
bash/node syntax + git diff check=PASS
```

The Node 24 install logged `bcryptjs` and did not invoke bcrypt/node-pre-gyp compilation.

## Boundary

No authentication implementation, password-hash format, apply/overlay/rollback flow, migration, PM2 restart, smoke, external write, K3 Save/Submit/Audit, or production data behavior changes. Issue #3751 remains open until the entity-machine rerun reaches full PASS.
