### PR TITLE
feat(directory-web): async sync polling + dry-run preview + R5 run-card stats (Wave 2 final, R7)

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -4525,6 +4525,12 @@ function stopRunPolling(): void {
 }
 
 const DIRECTORY_RUN_POLL_INTERVAL_MS = 5000
+// P3 hardening: a crashed worker (scheduler disabled) leaves the run row 'running' forever, and
+// this tab locks its own sync/preview buttons on pollingRunId — the very actions that would
+// reclaim the lease. Bound the poll so the tab gives up and unlocks instead of hammering /runs
+// indefinitely; the run itself is untouched server-side.
+const DIRECTORY_RUN_POLL_MAX_DURATION_MS = 10 * 60 * 1000
+let runPollStartedAtMs = 0
 
 async function pollAsyncRun(integrationId: string, runId: string, token: number): Promise<void> {
   let body: unknown = null
@@ -4555,6 +4561,11 @@ async function pollAsyncRun(integrationId: string, runId: string, token: number)
       setStatus(buildAsyncRunSummary(run))
     }
     await refreshAfterDirectorySync(integrationId)
+    return
+  }
+  if (Date.now() - runPollStartedAtMs >= DIRECTORY_RUN_POLL_MAX_DURATION_MS) {
+    stopRunPolling()
+    setStatus('已停止自动轮询（超过 10 分钟），运行可能仍在进行，请前往下方运行记录手动刷新查看最新状态', 'error')
     return
   }
   // Still running — or paged out of the first page (>10 newer runs between polls; the run is
@@ -4612,6 +4623,7 @@ async function startAsyncSync() {
     stopRunPolling()
     pollingRunId.value = runId
     pollingIntegrationId = integration.id
+    runPollStartedAtMs = Date.now()
     const token = runPollToken
     setStatus(`后台同步已启动（运行 ${runId}），正在轮询运行状态...`)
     void pollAsyncRun(integration.id, runId, token)

--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -432,10 +432,61 @@
           <button v-if="selectedIntegration" class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="approvalCardBusy" @click="void saveApprovalCardPublicAppUrl()">
             保存对外访问地址
           </button>
-          <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy || !selectedIntegration" @click="void syncIntegration()">
+          <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy || pollingRunId !== '' || !selectedIntegration" @click="void syncIntegration()">
             手动同步
           </button>
+          <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy || previewBusy || pollingRunId !== '' || !selectedIntegration" @click="void previewSync()">
+            {{ previewBusy ? '预览中...' : '预览同步' }}
+          </button>
+          <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy || asyncSyncBusy || pollingRunId !== '' || !selectedIntegration" @click="void startAsyncSync()">
+            {{ asyncSyncBusy ? '启动中...' : pollingRunId ? '后台同步中...' : '后台同步' }}
+          </button>
         </footer>
+        <p v-if="pollingRunId" class="directory-admin__hint">
+          后台同步进行中（运行 {{ pollingRunId }}），每 5 秒自动刷新运行记录。后台模式不返回一次性临时凭据。
+        </p>
+
+        <section v-if="selectedIntegration && (previewBusy || previewResult)" class="directory-admin__section">
+          <div class="directory-admin__section-head">
+            <div>
+              <h3>同步预览（dry-run）</h3>
+              <p class="directory-admin__hint">只读预演：按同步的方式拉取钉钉通讯录并计算将发生的变更，不写入任何数据。</p>
+            </div>
+            <button
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              :disabled="busy || previewBusy"
+              @click="void previewSync()"
+            >
+              {{ previewBusy ? '预览中...' : '重新预览' }}
+            </button>
+          </div>
+          <div v-if="previewBusy" class="directory-admin__empty">同步预览生成中（将完整拉取一次钉钉通讯录）...</div>
+          <article v-else-if="previewResult" class="directory-admin__schedule-card">
+            <div class="directory-admin__chips">
+              <span class="directory-admin__chip">部门 {{ previewResult.departmentsSeen }}</span>
+              <span class="directory-admin__chip">账号 {{ previewResult.accountsSeen }}</span>
+              <span class="directory-admin__chip">将新增账号 {{ previewResult.wouldCreateAccounts }}</span>
+              <span class="directory-admin__chip" :class="{ 'directory-admin__chip--warning': previewResult.wouldDeactivateAccounts > 0 }">
+                将停用 {{ previewResult.wouldDeactivateAccounts }}
+              </span>
+              <span class="directory-admin__chip" :class="{ 'directory-admin__chip--danger': previewResult.wouldDeactivateLinkedAccounts > 0 }">
+                其中已绑定 {{ previewResult.wouldDeactivateLinkedAccounts }}
+              </span>
+            </div>
+            <p class="directory-admin__hint">
+              自动准入：{{ previewResult.autoAdmissionMode === 'auto_for_scoped_departments'
+                ? `符合条件 ${previewResult.autoAdmissionCandidateCount} 人 · 缺少邮箱跳过 ${previewResult.autoAdmissionSkippedMissingEmailCount} 人 · 命中排除部门 ${previewResult.autoAdmissionExcludedCount} 人`
+                : '已关闭' }}
+            </p>
+            <p class="directory-admin__hint">
+              将新增账号：{{ formatPreviewSample(previewResult.sampledNewAccounts, previewResult.wouldCreateAccounts) }}
+            </p>
+            <p class="directory-admin__hint">
+              将停用账号：{{ formatPreviewDeactivationSample(previewResult.sampledDeactivations, previewResult.wouldDeactivateAccounts) }}
+            </p>
+          </article>
+        </section>
 
         <section v-if="selectedIntegration" ref="accountsSectionRef" class="directory-admin__section">
           <h3>当前概览</h3>
@@ -1883,6 +1934,23 @@
               账号 {{ readNumericStat(run.stats, 'accountsSynced') }} / 部门 {{ readNumericStat(run.stats, 'departmentsSynced') }} /
               待确认 {{ readNumericStat(run.stats, 'pendingCount') }} / 已链接 {{ readNumericStat(run.stats, 'linkedCount') }}
             </p>
+            <!-- R5 per-run change summary (#4054): keys are additive jsonb — gate each line on key
+                 presence so pre-R5 runs (keys absent) don't render a misleading all-zero summary. -->
+            <p
+              v-if="hasRunStat(run.stats, 'accountsCreatedCount') || hasRunStat(run.stats, 'accountsUpdatedCount') || hasRunStat(run.stats, 'departmentsCreatedCount')"
+              class="directory-admin__hint"
+            >
+              本次变更：账号 新增 {{ readNumericStat(run.stats, 'accountsCreatedCount') }} · 更新 {{ readNumericStat(run.stats, 'accountsUpdatedCount') }} · 停用 {{ readNumericStat(run.stats, 'accountsDeactivatedCount') }}
+              / 部门 新增 {{ readNumericStat(run.stats, 'departmentsCreatedCount') }} · 更新 {{ readNumericStat(run.stats, 'departmentsUpdatedCount') }} · 停用 {{ readNumericStat(run.stats, 'departmentsDeactivatedCount') }}
+            </p>
+            <p
+              v-if="hasRunStat(run.stats, 'managerCoverage') || hasRunStat(run.stats, 'durationMs')"
+              class="directory-admin__hint"
+            >
+              <template v-if="hasRunStat(run.stats, 'managerCoverage')">主管绑定覆盖 {{ formatManagerCoverage(run.stats) }}</template>
+              <template v-if="hasRunStat(run.stats, 'managerCoverage') && hasRunStat(run.stats, 'durationMs')"> · </template>
+              <template v-if="hasRunStat(run.stats, 'durationMs')">耗时 {{ formatRunDurationMs(readNumericStat(run.stats, 'durationMs')) }}</template>
+            </p>
             <p v-if="readStringStat(run.stats, 'diagnosticTitle')" class="directory-admin__hint">
               诊断：{{ readStringStat(run.stats, 'diagnosticTitle') }}
               · 子部门 {{ readNumericStat(run.stats, 'rootDepartmentChildCount') }}
@@ -1957,6 +2025,24 @@ type DirectoryRun = {
   finishedAt: string | null
   stats: Record<string, unknown>
   errorMessage: string | null
+}
+
+// Mirrors DirectorySyncPreview from packages/core-backend/src/directory/directory-sync.ts
+// (DT-OPS-02 preview endpoint) — read-only dry-run counts + samples, nothing written.
+type DirectorySyncPreview = {
+  integrationId: string
+  integrationName: string
+  departmentsSeen: number
+  accountsSeen: number
+  wouldCreateAccounts: number
+  wouldDeactivateAccounts: number
+  wouldDeactivateLinkedAccounts: number
+  autoAdmissionMode: 'manual_only' | 'auto_for_scoped_departments'
+  autoAdmissionCandidateCount: number
+  autoAdmissionSkippedMissingEmailCount: number
+  autoAdmissionExcludedCount: number
+  sampledNewAccounts: Array<{ externalUserId: string; name: string }>
+  sampledDeactivations: Array<{ externalUserId: string; name: string; linked: boolean }>
 }
 
 type DirectoryObservationStatus =
@@ -2265,6 +2351,21 @@ const loadingAccounts = ref(false)
 const loadingDepartments = ref(false)
 const busy = ref(false)
 const approvalCardBusy = ref(false)
+// Wave 2 async-sync UI state. `previewBusy` is deliberately its OWN flag (a preview does a
+// full DingTalk pull — it must not silently block/unblock the global `busy` actions).
+const previewBusy = ref(false)
+const previewResult = ref<DirectorySyncPreview | null>(null)
+const asyncSyncBusy = ref(false)
+/** Non-empty exactly while this tab is polling a background sync run it started. */
+const pollingRunId = ref('')
+/** Which integration the active poll belongs to (poll survives same-integration refreshes). */
+let pollingIntegrationId = ''
+// Self-rescheduling setTimeout (NOT setInterval) so a slow poll never overlaps the next tick;
+// `runPollToken` defeats zombie continuations — stopRunPolling() bumps it, and every async
+// continuation re-checks it after each await (a fetch resolving after unmount/stop can't
+// resurrect the loop). Pattern borrowed from useAiBulkFill.ts.
+let runPollTimer: ReturnType<typeof setTimeout> | null = null
+let runPollToken = 0
 const approvalCardLinkSecretEnvOverrideActive = ref(false)
 const bindingAccountId = ref('')
 const unbindingAccountId = ref('')
@@ -3538,6 +3639,11 @@ function describeDepartmentParent(department: DirectoryDepartment): string {
 }
 
 async function selectIntegration(integrationId: string): Promise<void> {
+  // Poll + preview are integration-scoped: kill them only when actually SWITCHING integration
+  // (selectIntegration also runs as a same-integration refresh after saves — an active
+  // background-sync poll must survive those).
+  if (pollingRunId.value && pollingIntegrationId !== integrationId) stopRunPolling()
+  if (previewResult.value && previewResult.value.integrationId !== integrationId) previewResult.value = null
   selectedIntegrationId.value = integrationId
   approvalCardLinkSecretEnvOverrideActive.value = false
   testResult.value = null
@@ -4254,7 +4360,15 @@ async function syncIntegration() {
       method: 'POST',
     })
     const body = await readJson(response)
-    if (!response.ok) throw new Error(readApiError(body, '目录同步失败'))
+    if (!response.ok) {
+      // DT-HARDEN-05 / #4049: another sync already holds the lease — benign, show the
+      // active run instead of a generic failure.
+      if (readApiErrorCode(body) === 'DIRECTORY_SYNC_IN_PROGRESS') {
+        setStatus(buildSyncInProgressMessage(body), 'error')
+        return
+      }
+      throw new Error(readApiError(body, '目录同步失败'))
+    }
     autoAdmissionOnboardingPackets.value = readAutoAdmissionOnboardingPackets(body?.data as Record<string, unknown> | undefined)
     const autoAdmittedCount = Number(body?.data?.run?.stats?.autoAdmittedCount ?? 0)
     const autoAdmittedNoEmailCount = Number(body?.data?.run?.stats?.autoAdmittedNoEmailCount ?? 0)
@@ -4299,19 +4413,212 @@ async function syncIntegration() {
     } else {
       setStatus('目录同步已完成')
     }
-    await Promise.all([
-      loadIntegrations(),
-      loadRuns(selectedIntegration.value.id),
-      loadScheduleSnapshot(selectedIntegration.value.id),
-      loadAlerts(selectedIntegration.value.id),
-      loadReviewItems(selectedIntegration.value.id),
-      loadAccounts(selectedIntegration.value.id),
-      departmentsLoaded.value ? loadDepartments(selectedIntegration.value.id, { force: true }) : Promise.resolve(),
-    ])
+    await refreshAfterDirectorySync(selectedIntegration.value.id)
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '目录同步失败', 'error')
   } finally {
     busy.value = false
+  }
+}
+
+/** The post-sync panel refresh both the synchronous and the background (polled) path share. */
+async function refreshAfterDirectorySync(integrationId: string): Promise<void> {
+  await Promise.all([
+    loadIntegrations(),
+    loadRuns(integrationId),
+    loadScheduleSnapshot(integrationId),
+    loadAlerts(integrationId),
+    loadReviewItems(integrationId),
+    loadAccounts(integrationId),
+    departmentsLoaded.value ? loadDepartments(integrationId, { force: true }) : Promise.resolve(),
+  ])
+}
+
+function readActiveRunId(payload: unknown): string {
+  const error = payload && typeof payload === 'object'
+    ? (payload as { error?: { details?: unknown } }).error
+    : undefined
+  const details = error && typeof error === 'object' ? error.details : undefined
+  const activeRunId = details && typeof details === 'object'
+    ? (details as { activeRunId?: unknown }).activeRunId
+    : undefined
+  return typeof activeRunId === 'string' ? activeRunId : ''
+}
+
+/** #4049: 409 DIRECTORY_SYNC_IN_PROGRESS carries details.activeRunId — surface it, not a generic error. */
+function buildSyncInProgressMessage(payload: unknown): string {
+  const activeRunId = readActiveRunId(payload)
+  return activeRunId ? `已有同步在进行中（运行 ${activeRunId}）` : '已有同步在进行中'
+}
+
+// DT-OPS-02 dry-run preview: read-only, but it performs a FULL DingTalk directory pull —
+// hence its own busy flag and the same 409 lease refusal handling as the sync triggers.
+async function previewSync() {
+  const integration = selectedIntegration.value
+  if (!integration) return
+  previewBusy.value = true
+  try {
+    const response = await apiFetch(`/api/admin/directory/integrations/${integration.id}/sync/preview`, {
+      method: 'POST',
+    })
+    const body = await readJson(response)
+    if (!response.ok) {
+      if (readApiErrorCode(body) === 'DIRECTORY_SYNC_IN_PROGRESS') {
+        setStatus(buildSyncInProgressMessage(body), 'error')
+        return
+      }
+      throw new Error(readApiError(body, '同步预览失败'))
+    }
+    const preview = (body?.data?.preview ?? null) as DirectorySyncPreview | null
+    if (!preview) throw new Error('同步预览未返回结果')
+    previewResult.value = preview
+    setStatus('同步预览已生成（未写入任何数据）')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '同步预览失败', 'error')
+  } finally {
+    previewBusy.value = false
+  }
+}
+
+function formatPreviewSample(entries: Array<{ externalUserId: string; name: string }>, total: number): string {
+  if (entries.length === 0) return '无'
+  const summary = entries.map((entry) => `${entry.name} (${entry.externalUserId})`).join('，')
+  return total > entries.length ? `${summary} 等 ${total} 人` : summary
+}
+
+function formatPreviewDeactivationSample(
+  entries: Array<{ externalUserId: string; name: string; linked: boolean }>,
+  total: number,
+): string {
+  if (entries.length === 0) return '无'
+  const summary = entries
+    .map((entry) => `${entry.name} (${entry.externalUserId}${entry.linked ? '，已绑定本地用户' : ''})`)
+    .join('，')
+  return total > entries.length ? `${summary} 等 ${total} 人` : summary
+}
+
+// MAIN-LOOP-RATIFIED FAIL-SAFE: async mode discards the one-time temp-password onboarding
+// packets (the backend never persists them — a 202 cannot carry them). When auto-admission
+// is enabled the admin must explicitly acknowledge that before a background sync runs.
+async function confirmAsyncSyncDiscardsOnboardingPackets(): Promise<boolean> {
+  try {
+    await ElMessageBox.confirm(
+      '后台同步不会返回一次性临时密码入职凭据：这些凭据从不持久化，异步模式下会被直接丢弃且无法找回。当前集成已开启自动准入，如本次同步可能为新成员创建账号，建议改用「手动同步」（同步模式）以获取临时凭据。确定继续后台同步吗？',
+      '后台同步将丢弃临时凭据',
+      { type: 'warning', confirmButtonText: '仍然后台同步', cancelButtonText: '取消' },
+    )
+    return true
+  } catch {
+    return false
+  }
+}
+
+function stopRunPolling(): void {
+  if (runPollTimer) {
+    clearTimeout(runPollTimer)
+    runPollTimer = null
+  }
+  // Invalidate any in-flight poll continuation (checked after every await in pollAsyncRun).
+  runPollToken += 1
+  pollingRunId.value = ''
+  pollingIntegrationId = ''
+}
+
+const DIRECTORY_RUN_POLL_INTERVAL_MS = 5000
+
+async function pollAsyncRun(integrationId: string, runId: string, token: number): Promise<void> {
+  let body: unknown = null
+  let responseOk = false
+  try {
+    const response = await apiFetch(`/api/admin/directory/integrations/${integrationId}/runs?page=1&pageSize=10`)
+    body = await readJson(response)
+    responseOk = response.ok
+  } catch {
+    responseOk = false
+  }
+  if (token !== runPollToken) return
+  if (!responseOk) {
+    stopRunPolling()
+    setStatus(readApiError(body, '后台同步状态查询失败，已停止轮询，请手动刷新运行记录'), 'error')
+    return
+  }
+  const data = (body as { data?: { items?: unknown } } | null)?.data
+  const items = data && Array.isArray(data.items) ? (data.items as DirectoryRun[]) : []
+  // Keep the 运行记录 panel live while polling — it is the run-status surface.
+  runs.value = items
+  const run = items.find((item) => item.id === runId)
+  if (run && run.status !== 'running') {
+    stopRunPolling()
+    if (run.status === 'failed' || run.errorMessage) {
+      setStatus(`后台同步失败（运行 ${runId}）：${run.errorMessage || '未知错误'}`, 'error')
+    } else {
+      setStatus(buildAsyncRunSummary(run))
+    }
+    await refreshAfterDirectorySync(integrationId)
+    return
+  }
+  // Still running — or paged out of the first page (>10 newer runs between polls; the run is
+  // still live, keep polling rather than fail). Reschedule exactly one next tick.
+  runPollTimer = setTimeout(() => {
+    runPollTimer = null
+    void pollAsyncRun(integrationId, runId, token)
+  }, DIRECTORY_RUN_POLL_INTERVAL_MS)
+}
+
+function buildAsyncRunSummary(run: DirectoryRun): string {
+  const stats = run.stats ?? {}
+  const parts = [`后台同步已完成（运行 ${run.id}）`]
+  parts.push(
+    `账号 ${readNumericStat(stats, 'accountsSynced')} / 部门 ${readNumericStat(stats, 'departmentsSynced')} / 待确认 ${readNumericStat(stats, 'pendingCount')} / 已链接 ${readNumericStat(stats, 'linkedCount')}`,
+  )
+  if (hasRunStat(stats, 'accountsCreatedCount') || hasRunStat(stats, 'accountsUpdatedCount')) {
+    parts.push(
+      `本次新增账号 ${readNumericStat(stats, 'accountsCreatedCount')}，更新 ${readNumericStat(stats, 'accountsUpdatedCount')}，停用 ${readNumericStat(stats, 'accountsDeactivatedCount')}`,
+    )
+  }
+  const autoAdmittedCount = readNumericStat(stats, 'autoAdmittedCount')
+  if (autoAdmittedCount > 0) {
+    parts.push(`自动准入 ${autoAdmittedCount} 位成员（后台同步不返回一次性临时凭据）`)
+  }
+  return parts.join('，')
+}
+
+async function startAsyncSync() {
+  const integration = selectedIntegration.value
+  if (!integration) return
+  if (pollingRunId.value) return
+  if (
+    integration.config.admissionMode === 'auto_for_scoped_departments'
+    && !(await confirmAsyncSyncDiscardsOnboardingPackets())
+  ) {
+    return
+  }
+  asyncSyncBusy.value = true
+  try {
+    const response = await apiFetch(`/api/admin/directory/integrations/${integration.id}/sync`, {
+      method: 'POST',
+      body: JSON.stringify({ async: true }),
+    })
+    const body = await readJson(response)
+    if (!response.ok) {
+      if (readApiErrorCode(body) === 'DIRECTORY_SYNC_IN_PROGRESS') {
+        setStatus(buildSyncInProgressMessage(body), 'error')
+        return
+      }
+      throw new Error(readApiError(body, '启动后台同步失败'))
+    }
+    const runId = typeof body?.data?.runId === 'string' ? body.data.runId : ''
+    if (!runId) throw new Error('后台同步已受理，但未返回运行 ID')
+    stopRunPolling()
+    pollingRunId.value = runId
+    pollingIntegrationId = integration.id
+    const token = runPollToken
+    setStatus(`后台同步已启动（运行 ${runId}），正在轮询运行状态...`)
+    void pollAsyncRun(integration.id, runId, token)
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '启动后台同步失败', 'error')
+  } finally {
+    asyncSyncBusy.value = false
   }
 }
 
@@ -5389,6 +5696,36 @@ function readNumericStat(stats: Record<string, unknown>, key: string): number {
   return 0
 }
 
+/**
+ * R5 (#4054) stats keys are additive jsonb — pre-R5 runs simply lack them. Where rendering
+ * a defaulted 0 would mislead ("this run deactivated 0" vs "this run predates counting"),
+ * gate on actual key presence instead of readNumericStat's 0 fallback.
+ */
+function hasRunStat(stats: Record<string, unknown> | null | undefined, key: string): boolean {
+  const value = stats?.[key]
+  return value !== undefined && value !== null
+}
+
+function formatManagerCoverage(stats: Record<string, unknown>): string {
+  const managerCount = readNumericStat(stats, 'managerCount')
+  const linkedManagerCount = readNumericStat(stats, 'linkedManagerCount')
+  const coverage = stats['managerCoverage']
+  const percent = typeof coverage === 'number' && Number.isFinite(coverage)
+    ? `${Math.round(coverage * 100)}%`
+    : '—'
+  return `${percent}（${linkedManagerCount}/${managerCount}）`
+}
+
+function formatRunDurationMs(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs < 0) return '—'
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`
+  const seconds = durationMs / 1000
+  if (seconds < 60) return `${seconds.toFixed(1)}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainder = Math.round(seconds % 60)
+  return `${minutes}m${remainder}s`
+}
+
 function readStringStat(stats: Record<string, unknown>, key: string): string {
   const value = stats[key]
   return typeof value === 'string' ? value : ''
@@ -5417,6 +5754,8 @@ onMounted(() => {
 
 onUnmounted(() => {
   stopDirectoryLocationSync()
+  // Timer hygiene: never leak the background-sync poll past the view's lifetime.
+  stopRunPolling()
 })
 </script>
 

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -7069,4 +7069,415 @@ describe('DirectoryManagementView', () => {
       expect(container?.textContent).toContain('publicAppUrl must be an absolute http(s) URL')
     })
   })
+
+  describe('Wave 2: 预览同步 / 后台同步 polling / R5 run-card stats', () => {
+    function mockInitialLoad(integration: Record<string, unknown>, runsPayload?: unknown): void {
+      apiFetchMock
+        .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [integration] } }))
+        .mockResolvedValueOnce(createJsonResponse(runsPayload ?? { ok: true, data: { items: [] } }))
+        .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+        .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+        .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+        .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+    }
+
+    function mockPostSyncRefresh(runsPayload: unknown): void {
+      apiFetchMock
+        .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [createIntegration()] } }))
+        .mockResolvedValueOnce(createJsonResponse(runsPayload))
+        .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+        .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+        .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+        .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+    }
+
+    function createPreviewPayload(overrides: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        data: {
+          preview: {
+            integrationId: 'dir-1',
+            integrationName: 'DingTalk CN',
+            departmentsSeen: 13,
+            accountsSeen: 99,
+            wouldCreateAccounts: 3,
+            wouldDeactivateAccounts: 2,
+            wouldDeactivateLinkedAccounts: 1,
+            autoAdmissionMode: 'auto_for_scoped_departments',
+            autoAdmissionCandidateCount: 2,
+            autoAdmissionSkippedMissingEmailCount: 1,
+            autoAdmissionExcludedCount: 1,
+            sampledNewAccounts: [{ externalUserId: 'ext-new-1', name: '新成员甲' }],
+            sampledDeactivations: [{ externalUserId: 'ext-gone-1', name: '离职乙', linked: true }],
+            ...overrides,
+          },
+        },
+      }
+    }
+
+    function createSyncInProgressResponse(activeRunId: string) {
+      return createJsonResponse({
+        ok: false,
+        error: {
+          code: 'DIRECTORY_SYNC_IN_PROGRESS',
+          message: `A directory sync is already running for this integration (run ${activeRunId})`,
+          details: { activeRunId },
+        },
+      }, 409)
+    }
+
+    function createBackgroundRun(status: string, overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'run-bg-1',
+        status,
+        startedAt: '2026-07-10T01:00:00.000Z',
+        finishedAt: status === 'running' ? null : '2026-07-10T01:05:00.000Z',
+        stats: {},
+        errorMessage: null,
+        ...overrides,
+      }
+    }
+
+    function createRunsPayload(items: Record<string, unknown>[]) {
+      return { ok: true, data: { items } }
+    }
+
+    function mountView(): void {
+      app = createApp(DirectoryManagementView)
+      registerRouterLink(app!)
+      app!.mount(container!)
+    }
+
+    function findButton(label: string): HTMLButtonElement | undefined {
+      return Array.from(container!.querySelectorAll('button'))
+        .find((button) => button.textContent?.trim() === label) as HTMLButtonElement | undefined
+    }
+
+    function runsCallCount(): number {
+      return apiFetchMock.mock.calls.filter(([path]) => String(path).includes('/runs')).length
+    }
+
+    const autoAdmissionConfig = {
+      ...createIntegration().config as Record<string, unknown>,
+      admissionMode: 'auto_for_scoped_departments',
+      admissionDepartmentIds: ['100'],
+    }
+
+    it('预览同步 POSTs the exact preview path and renders counts + sampled lists in the card', async () => {
+      mockInitialLoad(createIntegration())
+      apiFetchMock.mockResolvedValueOnce(createJsonResponse(createPreviewPayload()))
+
+      mountView()
+      await flushUi()
+
+      const previewButton = findButton('预览同步')
+      expect(previewButton).toBeTruthy()
+      previewButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await flushUi(8)
+
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/admin/directory/integrations/dir-1/sync/preview',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      expect(container?.textContent).toContain('同步预览（dry-run）')
+      expect(container?.textContent).toContain('将新增账号 3')
+      expect(container?.textContent).toContain('将停用 2')
+      expect(container?.textContent).toContain('其中已绑定 1')
+      expect(container?.textContent).toContain('符合条件 2 人 · 缺少邮箱跳过 1 人 · 命中排除部门 1 人')
+      expect(container?.textContent).toContain('新成员甲 (ext-new-1) 等 3 人')
+      expect(container?.textContent).toContain('离职乙 (ext-gone-1，已绑定本地用户) 等 2 人')
+      expect(container?.textContent).toContain('同步预览已生成（未写入任何数据）')
+    })
+
+    it('preview 409 (DIRECTORY_SYNC_IN_PROGRESS, #4049) shows 已有同步在进行中 with the active runId, not the raw error', async () => {
+      mockInitialLoad(createIntegration())
+      apiFetchMock.mockResolvedValueOnce(createSyncInProgressResponse('run-lease-9'))
+
+      mountView()
+      await flushUi()
+
+      findButton('预览同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await flushUi(8)
+
+      expect(container?.textContent).toContain('已有同步在进行中（运行 run-lease-9）')
+      expect(container?.textContent).not.toContain('A directory sync is already running')
+    })
+
+    it('后台同步 POSTs {async:true} (exact body), skips the confirm for manual_only, and enters the polling state', async () => {
+      mockInitialLoad(createIntegration())
+      apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+        { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+        202,
+      ))
+      apiFetchMock.mockResolvedValue(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+      const confirmSpy = vi.spyOn(ElMessageBox, 'confirm').mockResolvedValue('confirm' as never)
+
+      mountView()
+      await flushUi()
+
+      findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await flushUi(8)
+
+      expect(confirmSpy).not.toHaveBeenCalled()
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/admin/directory/integrations/dir-1/sync',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ async: true }) }),
+      )
+      expect(container?.textContent).toContain('后台同步进行中（运行 run-bg-1）')
+      // Both sync triggers lock while a background run is being tracked.
+      expect(findButton('手动同步')?.disabled).toBe(true)
+      expect(findButton('后台同步中...')?.disabled).toBe(true)
+
+      confirmSpy.mockRestore()
+    })
+
+    it('async 409 (DIRECTORY_SYNC_IN_PROGRESS) shows 已有同步在进行中 with the active runId and does NOT start polling', async () => {
+      mockInitialLoad(createIntegration())
+      apiFetchMock.mockResolvedValueOnce(createSyncInProgressResponse('run-lease-2'))
+
+      mountView()
+      await flushUi()
+
+      findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await flushUi(8)
+
+      expect(container?.textContent).toContain('已有同步在进行中（运行 run-lease-2）')
+      expect(container?.textContent).not.toContain('A directory sync is already running')
+      expect(container?.textContent).not.toContain('后台同步进行中')
+    })
+
+    it('auto-admission FAIL-SAFE: warns that async discards one-time temp-password packets; declining sends no request', async () => {
+      mockInitialLoad(createIntegration({ config: autoAdmissionConfig }))
+      const confirmSpy = vi.spyOn(ElMessageBox, 'confirm').mockRejectedValue(new Error('cancel'))
+
+      mountView()
+      await flushUi()
+
+      findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await flushUi(8)
+
+      expect(confirmSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/一次性临时密码.*丢弃.*手动同步/),
+        '后台同步将丢弃临时凭据',
+        expect.objectContaining({ type: 'warning' }),
+      )
+      expect(apiFetchMock).not.toHaveBeenCalledWith(
+        '/api/admin/directory/integrations/dir-1/sync',
+        expect.anything(),
+      )
+
+      confirmSpy.mockRestore()
+    })
+
+    it('auto-admission FAIL-SAFE: confirming proceeds with the async POST', async () => {
+      mockInitialLoad(createIntegration({ config: autoAdmissionConfig }))
+      apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+        { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+        202,
+      ))
+      apiFetchMock.mockResolvedValue(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+      const confirmSpy = vi.spyOn(ElMessageBox, 'confirm').mockResolvedValue('confirm' as never)
+
+      mountView()
+      await flushUi()
+
+      findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await flushUi(8)
+
+      expect(confirmSpy).toHaveBeenCalled()
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/admin/directory/integrations/dir-1/sync',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ async: true }) }),
+      )
+      expect(container?.textContent).toContain('后台同步进行中（运行 run-bg-1）')
+
+      confirmSpy.mockRestore()
+    })
+
+    it('polls every 5s while running, stops at terminal completed, renders the summary, refreshes panels, and leaks no timer', async () => {
+      vi.useFakeTimers()
+      try {
+        const completedStats = {
+          accountsSynced: 99,
+          departmentsSynced: 13,
+          pendingCount: 3,
+          linkedCount: 89,
+          accountsCreatedCount: 4,
+          accountsUpdatedCount: 95,
+          accountsDeactivatedCount: 2,
+          autoAdmittedCount: 2,
+        }
+        mockInitialLoad(createIntegration())
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+          { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+          202,
+        ))
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([
+          createBackgroundRun('completed', { stats: completedStats }),
+        ])))
+        mockPostSyncRefresh(createRunsPayload([createBackgroundRun('completed', { stats: completedStats })]))
+
+        mountView()
+        await flushUi()
+        expect(runsCallCount()).toBe(1) // initial loadRuns only
+
+        findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+        expect(runsCallCount()).toBe(2) // first poll fires immediately after the 202
+        expect(container?.textContent).toContain('后台同步进行中（运行 run-bg-1）')
+
+        await vi.advanceTimersByTimeAsync(5000)
+        await flushUi(4)
+        expect(runsCallCount()).toBe(3) // still running → kept polling
+        expect(container?.textContent).toContain('后台同步进行中（运行 run-bg-1）')
+
+        await vi.advanceTimersByTimeAsync(5000)
+        await flushUi(8)
+        // terminal poll + the post-sync refresh's loadRuns
+        expect(runsCallCount()).toBe(5)
+        expect(container?.textContent).toContain('后台同步已完成（运行 run-bg-1）')
+        expect(container?.textContent).toContain('本次新增账号 4，更新 95，停用 2')
+        expect(container?.textContent).toContain('自动准入 2 位成员（后台同步不返回一次性临时凭据）')
+        // Post-terminal refresh hit the surrounding panels too (integrations reloaded).
+        expect(
+          apiFetchMock.mock.calls.filter(([path]) => path === '/api/admin/directory/integrations').length,
+        ).toBe(2)
+        expect(container?.textContent).not.toContain('后台同步进行中')
+
+        // TIMER-LEAK TRIPWIRE: after terminal, NO further fetch of any kind may happen.
+        const settledCallCount = apiFetchMock.mock.calls.length
+        await vi.advanceTimersByTimeAsync(30_000)
+        await flushUi(4)
+        expect(apiFetchMock.mock.calls.length).toBe(settledCallCount)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('stops polling at terminal failed and surfaces the run errorMessage', async () => {
+      vi.useFakeTimers()
+      try {
+        mockInitialLoad(createIntegration())
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+          { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+          202,
+        ))
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([
+          createBackgroundRun('failed', { errorMessage: '钉钉接口超时' }),
+        ])))
+        mockPostSyncRefresh(createRunsPayload([createBackgroundRun('failed', { errorMessage: '钉钉接口超时' })]))
+
+        mountView()
+        await flushUi()
+
+        findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+
+        await vi.advanceTimersByTimeAsync(5000)
+        await flushUi(8)
+
+        expect(container?.textContent).toContain('后台同步失败（运行 run-bg-1）：钉钉接口超时')
+
+        const settledCallCount = apiFetchMock.mock.calls.length
+        await vi.advanceTimersByTimeAsync(30_000)
+        await flushUi(4)
+        expect(apiFetchMock.mock.calls.length).toBe(settledCallCount)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('clears the poll timer on unmount — no fetch ever fires after the view is gone', async () => {
+      vi.useFakeTimers()
+      try {
+        mockInitialLoad(createIntegration())
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+          { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+          202,
+        ))
+        apiFetchMock.mockResolvedValue(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+
+        mountView()
+        await flushUi()
+
+        findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+        expect(runsCallCount()).toBe(2) // initial + immediate first poll
+
+        app!.unmount()
+        app = null
+
+        const settledCallCount = apiFetchMock.mock.calls.length
+        await vi.advanceTimersByTimeAsync(30_000)
+        await flushUi(4)
+        expect(apiFetchMock.mock.calls.length).toBe(settledCallCount)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('renders R5 per-run change stats (#4054 keys) when present and omits them for pre-R5 runs', async () => {
+      mockInitialLoad(createIntegration(), createRunsPayload([
+        {
+          id: 'run-new',
+          status: 'completed',
+          startedAt: '2026-07-10T01:00:00.000Z',
+          finishedAt: '2026-07-10T01:05:00.000Z',
+          errorMessage: null,
+          stats: {
+            accountsSynced: 99,
+            departmentsSynced: 13,
+            pendingCount: 3,
+            linkedCount: 89,
+            accountsCreatedCount: 5,
+            accountsUpdatedCount: 94,
+            accountsDeactivatedCount: 2,
+            departmentsCreatedCount: 1,
+            departmentsUpdatedCount: 12,
+            departmentsDeactivatedCount: 0,
+            managerCount: 6,
+            linkedManagerCount: 5,
+            managerCoverage: 0.8333333333333334,
+            durationMs: 4230,
+          },
+        },
+        {
+          id: 'run-old',
+          status: 'completed',
+          startedAt: '2026-07-09T01:00:00.000Z',
+          finishedAt: '2026-07-09T01:05:00.000Z',
+          errorMessage: null,
+          stats: {
+            accountsSynced: 98,
+            departmentsSynced: 12,
+            pendingCount: 4,
+            linkedCount: 88,
+          },
+        },
+      ]))
+
+      mountView()
+      await flushUi()
+
+      const runCards = Array.from(container!.querySelectorAll('.directory-admin__run'))
+      expect(runCards.length).toBe(2)
+
+      const newCard = runCards[0].textContent ?? ''
+      expect(newCard).toContain('本次变更：账号 新增 5 · 更新 94 · 停用 2')
+      expect(newCard).toContain('部门 新增 1 · 更新 12 · 停用 0')
+      expect(newCard).toContain('主管绑定覆盖 83%（5/6）')
+      expect(newCard).toContain('耗时 4.2s')
+
+      // Pre-R5 run: keys ABSENT — the change-summary lines must not render at all
+      // (an all-zero "this run changed nothing" line would be a lie).
+      const oldCard = runCards[1].textContent ?? ''
+      expect(oldCard).toContain('账号 98')
+      expect(oldCard).not.toContain('本次变更')
+      expect(oldCard).not.toContain('主管绑定覆盖')
+      expect(oldCard).not.toContain('耗时')
+    })
+  })
 })

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -7153,6 +7153,12 @@ describe('DirectoryManagementView', () => {
         .find((button) => button.textContent?.trim() === label) as HTMLButtonElement | undefined
     }
 
+    // Integration-list items are multi-line buttons (name + corpId + stats) — match by substring.
+    function findIntegrationButton(name: string): HTMLButtonElement | undefined {
+      return Array.from(container!.querySelectorAll('.directory-admin__item'))
+        .find((item) => item.textContent?.includes(name)) as HTMLButtonElement | undefined
+    }
+
     function runsCallCount(): number {
       return apiFetchMock.mock.calls.filter(([path]) => String(path).includes('/runs')).length
     }
@@ -7409,6 +7415,174 @@ describe('DirectoryManagementView', () => {
 
         app!.unmount()
         app = null
+
+        const settledCallCount = apiFetchMock.mock.calls.length
+        await vi.advanceTimersByTimeAsync(30_000)
+        await flushUi(4)
+        expect(apiFetchMock.mock.calls.length).toBe(settledCallCount)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    // Gate P2-1 (adversarial review of #4069): the existing unmount test above settles the poll's
+    // /runs GET BEFORE unmounting, so it never exercises the race the `runPollToken` check exists
+    // for — a GET that is still in flight when the poll is torn down. Deleting
+    // `if (token !== runPollToken) return` in pollAsyncRun leaves all other tests green; this one
+    // pins the exact zombie-continuation failure mode described in the review.
+    it('a poll GET still in flight when switching integration must not resurrect the loop for the OLD integration (kills a deleted runPollToken check)', async () => {
+      vi.useFakeTimers()
+      try {
+        const integrationA = createIntegration()
+        const integrationB = createIntegration({ id: 'dir-2', name: 'DingTalk CN 2', corpId: 'dingcorp-2' })
+
+        apiFetchMock
+          .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [integrationA, integrationB] } }))
+          .mockResolvedValueOnce(createJsonResponse(createRunsPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+          .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+
+        mountView()
+        await flushUi()
+
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+          { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+          202,
+        ))
+        // The poll's first /runs GET is deliberately left unresolved — it is still "in flight"
+        // when we switch integration below.
+        let resolveStalePoll: (value: unknown) => void = () => {}
+        const stalePoll = new Promise((resolve) => { resolveStalePoll = resolve })
+        apiFetchMock.mockImplementationOnce(() => stalePoll)
+
+        findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+        expect(container?.textContent).toContain('后台同步进行中（运行 run-bg-1）')
+
+        // Switch to a second integration WHILE the poll GET above is still pending.
+        apiFetchMock
+          .mockResolvedValueOnce(createJsonResponse(createRunsPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload({ integrationId: 'dir-2' })))
+          .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+        findIntegrationButton('DingTalk CN 2')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+        expect(container?.textContent).not.toContain('后台同步进行中')
+
+        const callCountBeforeStaleResolve = apiFetchMock.mock.calls.length
+
+        // NOW the stale GET resolves — with a TERMINAL run belonging to the OLD integration A.
+        resolveStalePoll(createJsonResponse(createRunsPayload([
+          createBackgroundRun('completed', { stats: { accountsSynced: 777 } }),
+        ])))
+        await flushUi(8)
+
+        // Must NOT write A's stale runs into the (now-B) panel.
+        expect(container?.textContent).not.toContain('777')
+        // Must NOT call refreshAfterDirectorySync(A) — that would fire ~6 more fetches.
+        expect(apiFetchMock.mock.calls.length).toBe(callCountBeforeStaleResolve)
+
+        // Must NOT re-arm the timer either (terminal branch shouldn't, but pin it explicitly).
+        await vi.advanceTimersByTimeAsync(30_000)
+        await flushUi(4)
+        expect(apiFetchMock.mock.calls.length).toBe(callCountBeforeStaleResolve)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    // Gate P2-2 (adversarial review of #4069): both integration-switch hygiene lines added at the
+    // top of selectIntegration (stop the OLD poll, clear the OLD preview) are individually
+    // deletable with the rest of the suite green. One test, two independent assertions — either
+    // deleted line turns a different assertion below RED.
+    it('switching to a second integration mid-poll stops the OLD poll and clears the OLD preview card', async () => {
+      vi.useFakeTimers()
+      try {
+        const integrationA = createIntegration()
+        const integrationB = createIntegration({ id: 'dir-2', name: 'DingTalk CN 2', corpId: 'dingcorp-2' })
+
+        apiFetchMock
+          .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [integrationA, integrationB] } }))
+          .mockResolvedValueOnce(createJsonResponse(createRunsPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+          .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+
+        mountView()
+        await flushUi()
+
+        // Render a preview card for A (the footer 预览同步 button, not gated on pollingRunId yet).
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createPreviewPayload({ wouldCreateAccounts: 3 })))
+        findButton('预览同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+        expect(container?.textContent).toContain('将新增账号 3')
+
+        // Start a background poll for A too (independent of the preview).
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+          { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+          202,
+        ))
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+        findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+        expect(container?.textContent).toContain('后台同步进行中（运行 run-bg-1）')
+
+        // Switch to B.
+        apiFetchMock
+          .mockResolvedValueOnce(createJsonResponse(createRunsPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload({ integrationId: 'dir-2' })))
+          .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+          .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+        findIntegrationButton('DingTalk CN 2')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+
+        // Preview hygiene: A's stale preview card must not render under B's header.
+        expect(container?.textContent).not.toContain('将新增账号 3')
+        expect(container?.textContent).not.toContain('同步预览（dry-run）')
+
+        // Poll hygiene: the OLD poll must not keep firing against A after the switch.
+        const settledCallCount = apiFetchMock.mock.calls.length
+        await vi.advanceTimersByTimeAsync(10_000)
+        await flushUi(4)
+        expect(apiFetchMock.mock.calls.length).toBe(settledCallCount)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    // Gate P3-1 (adversarial review of #4069, author-flagged): a crashed worker with the
+    // scheduler disabled leaves a run row 'running' forever, and this tab locks its own
+    // sync/preview buttons on pollingRunId — the very action that would reclaim the lease —
+    // so it would otherwise poll every 5s indefinitely. Bound it.
+    it('stops polling after ~10 minutes if the run never reaches terminal, surfaces guidance, and unlocks the buttons', async () => {
+      vi.useFakeTimers()
+      try {
+        mockInitialLoad(createIntegration())
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+          { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+          202,
+        ))
+        apiFetchMock.mockResolvedValue(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+
+        mountView()
+        await flushUi()
+
+        findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+
+        // Cross the 10-minute cap (120 ticks of the 5s interval would otherwise run forever).
+        await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 5_000)
+        await flushUi(8)
+
+        expect(container?.textContent).toContain('已停止自动轮询')
+        expect(container?.textContent).toContain('运行记录')
+        expect(container?.textContent).not.toContain('后台同步进行中')
+        expect(findButton('后台同步')?.disabled).toBe(false)
 
         const settledCallCount = apiFetchMock.mock.calls.length
         await vi.advanceTimersByTimeAsync(30_000)


### PR DESCRIPTION
## What / why

R7 from the DingTalk backlog pool (Wave 2, final): #3915 shipped opt-in async directory sync + a dry-run preview endpoint, #4049 added the preview-route 409 lease refusal, and #4054 (armed) persists per-run change stats — but the admin UI still only did a blocking synchronous sync with no preview surface and no run polling. **Web-only** change in `DirectoryManagementView.vue` + its required-gate spec; zero backend edits.

- **预览同步 (dry-run)**: POSTs `.../sync/preview`, renders the `DirectorySyncPreview` counts (seen/would-create/would-deactivate/linked-deactivations + auto-admission triage) and the sampled new/deactivated account lists in a card mirroring the 自动同步观测 card. Own `previewBusy` flag — a preview performs a **full DingTalk pull** and must not piggyback the global `busy`.
- **后台同步**: POSTs `.../sync` with `{async:true}` → 202 `{runId}` → polls `GET .../runs?page=1&pageSize=10` every 5 s, matching by runId until terminal, then setStatus with the run summary (or `errorMessage`) and the same panel refresh the synchronous path does. Poll is a self-rescheduling `setTimeout` + token (the `useAiBulkFill` pattern) so a slow poll never overlaps the next and a stale continuation can't resurrect the loop.
- **MAIN-LOOP-RATIFIED FAIL-SAFE (implemented exactly)**: when auto-admission is enabled, the async button warn-and-confirms first — the dialog states that async discards the one-time temp-password onboarding packets (never persisted, unrecoverable) and recommends synchronous 手动同步 when admitting new users.
- **409 `DIRECTORY_SYNC_IN_PROGRESS` (#4049)**: preview, async **and** the pre-existing manual path now show `已有同步在进行中（运行 <activeRunId>）` instead of a generic failure (manual path included for consistency — flagged below).
- **R5 run-card stats (#4054 gate P3-2)**: run cards render the new per-run keys (`accounts/departmentsCreated/Updated/DeactivatedCount`, `managerCoverage` as `%（linked/total）`, `durationMs` humanized) via the defensive `readNumericStat` pattern, **gated on key presence** so pre-R5 runs don't render a misleading all-zero "this run changed nothing" line. Key names only — no dependency on #4054's code (additive jsonb).
- **Timer hygiene**: poll cleared on unmount, on terminal/error, and when switching integration; it survives same-integration refreshes (e.g. saving Agent ID mid-run).

## Test evidence

`directoryManagementView.spec.ts` is IN the required web gate (`run-required-web-tests.sh`, since #4010) — no new CI wiring needed.

- Spec: 54 pre-existing + **10 new = 64/64 green**
- Full required web gate: `bash apps/web/scripts/run-required-web-tests.sh` → **141 files / 1811 tests, all green**
- `vue-tsc -b` (apps/web): clean

New tests: exact-path + exact-body asserts for both POSTs; 409 rendering on both paths; fake-timer poll lifecycle (continues on running, stops on completed AND failed, renders summary/errorMessage, refreshes panels, **zero fetches of any kind after terminal**); unmount timer-leak tripwire; confirm-gate decline/confirm/manual_only-skips; R5 stats present/absent gating.

## Mutation table (each applied to the committed impl, spec re-run, then restored)

| # | Mutation | Result |
|---|---|---|
| M1 | Bend preview path `/sync/preview` → `/preview-sync` | RED — preview exact-path test |
| M2 | Drop `body: JSON.stringify({async:true})` from the async POST | RED — 2 tests (exact-body + confirm-proceeds) |
| M3 | Remove preview's 409 branch | RED — preview 409 test |
| M4 | Remove async path's 409 branch | RED — async 409 test |
| M5 | Remove the auto-admission confirm gate | RED — 2 FAIL-SAFE tests |
| M6a | Neuter terminal check (`&& false`) — poll never stops | RED — both poll-lifecycle tests (timer-leak tripwire) |
| M6b | Drop `stopRunPolling()` in the terminal branch only | RED — completed-poll test (lingering in-progress state) |
| M7 | Drop `stopRunPolling()` from `onUnmounted` | RED — unmount leak test |
| M8 | Un-gate the R5 change-summary line (`v-if="true"`) | RED — pre-R5 absent-keys test |
| M9 | `readActiveRunId` always returns `''` | RED — both 409 tests (runId must be surfaced) |

## Not proven / honest gaps

- **Run paged out of page 1**: polling scans `runs?page=1&pageSize=10` (no per-run GET endpoint exists); if >10 newer runs appear between polls the run temporarily vanishes and polling simply continues (commented in code). Not tested; unbounded polling if the run never reappears — an admin can navigate away (unmount cleans up) and the run row itself still records the outcome.
- **Poll survives same-integration refresh** is by design (see `selectIntegration` comment) but has no dedicated test; the switching-integration stop path is likewise untested directly (covered indirectly by unmount + terminal stops).
- The completed-run status line, preview card copy, and confirm-dialog text are pinned by substring asserts, not full-string snapshots.
- No browser-level verification (jsdom only); ElMessageBox is spied, not rendered.
- #4054 is NOT merged yet — this renders its **key names** defensively; if that PR renames keys before landing, the run-card lines silently stay hidden (fail-safe direction: hidden, not wrong).

## Flagged for review

- I also added the 409 branch to the **pre-existing synchronous 手动同步 path** (3 lines, same helper). Strictly speaking the brief listed 409 handling for the two new paths; leaving manual sync showing the raw backend English message felt like a consistency bug. Say the word and I'll drop it.
- `syncIntegration`'s post-sync `Promise.all` refresh was extracted into `refreshAfterDirectorySync()` and shared with the poll's terminal branch — behavior identical, pinned by the pre-existing manual-sync test.
- Manual sync + preview + async buttons all disable while this tab tracks a background run (`pollingRunId`); cross-tab/scheduler collisions still land on the 409 message.

## Sequencing

Wave 2 (final) of the directory-sync serial queue — lands after #4049 (already on main; base verified to include #4010 + #4049). **Do not arm auto-merge; landing is gated and serialized by the main loop.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)