### PR TITLE
fix(onprem): make staging node_modules cleanup deep-path safe

### DIFF
--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -739,6 +739,40 @@ function Get-WorkspaceProjectRelativeRoots {
   return @($roots | Select-Object -Unique)
 }
 
+function Remove-DirectoryTree {
+  param(
+    [string]$Path,
+    [string]$Label = 'Directory tree'
+  )
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return
+  }
+
+  # PowerShell's FileSystem provider can fail while traversing deep pnpm trees
+  # on Windows. Node is already a required runtime and removes those trees
+  # without asking the provider to enumerate every nested path.
+  $removeScript = @'
+const fs = require('node:fs')
+const target = process.argv[1]
+if (!target) throw new Error('cleanup target is required')
+fs.rmSync(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 250 })
+'@
+  $output = & node -e $removeScript $Path 2>&1
+  $exitCode = $LASTEXITCODE
+  foreach ($line in @($output)) {
+    if (-not [string]::IsNullOrWhiteSpace([string]$line)) {
+      Write-Host "[node-rm] $line"
+    }
+  }
+  if ($exitCode -ne 0) {
+    throw "$Label cleanup failed for $Path (node exit=$exitCode)"
+  }
+  if (Test-Path -LiteralPath $Path) {
+    throw "$Label cleanup did not remove $Path"
+  }
+}
+
 function Remove-WorkspaceNodeModules {
   param([string]$Root)
 
@@ -748,7 +782,7 @@ function Remove-WorkspaceNodeModules {
     $projectRoot = if ([string]::IsNullOrWhiteSpace($relativeRoot)) { $Root } else { Join-Path $Root $relativeRoot }
     $modulesPath = Join-Path $projectRoot 'node_modules'
     if (Test-Path -LiteralPath $modulesPath) {
-      Remove-Item -LiteralPath $modulesPath -Recurse -Force
+      Remove-DirectoryTree -Path $modulesPath -Label 'Staging dependency tree'
     }
   }
 }
@@ -890,7 +924,7 @@ function Restore-WorkspaceNodeModules {
 
   foreach ($entry in @($Transaction.Entries) | Sort-Object { $_.ModulesPath.Length } -Descending) {
     if (Test-Path -LiteralPath $entry.ModulesPath) {
-      Remove-Item -LiteralPath $entry.ModulesPath -Recurse -Force
+      Remove-DirectoryTree -Path $entry.ModulesPath -Label 'Rollback dependency tree'
     }
     if ($entry.HadExisting -and (Test-Path -LiteralPath $entry.BackupPath)) {
       Move-Item -LiteralPath $entry.BackupPath -Destination $entry.ModulesPath
@@ -903,7 +937,7 @@ function Complete-WorkspaceNodeModulesTransaction {
 
   foreach ($entry in @($Transaction.Entries)) {
     if ($entry.HadExisting -and (Test-Path -LiteralPath $entry.BackupPath)) {
-      Remove-Item -LiteralPath $entry.BackupPath -Recurse -Force
+      Remove-DirectoryTree -Path $entry.BackupPath -Label 'Retired dependency backup'
     }
   }
 }

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -134,6 +134,74 @@ test('Windows apply preflights dependencies before live overlay and rolls activa
   assert.match(script, /Remove-WorkspaceNodeModules -Root \$packageRoot/)
 })
 
+test('staging dependency cleanup bypasses PowerShell deep-path traversal', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2 onprem deep cleanup-'))
+  const applyHelper = path.join(repoRoot, 'scripts/ops/multitable-onprem-apply-package.ps1')
+  const modulesPath = path.join(tempRoot, 'node_modules')
+  let deepPath = modulesPath
+  for (let index = 0; index < 18; index += 1) {
+    deepPath = path.join(deepPath, `pnpm-segment-${index}-${'x'.repeat(18)}`)
+  }
+  fs.mkdirSync(deepPath, { recursive: true })
+  fs.writeFileSync(path.join(deepPath, 'package.json'), '{}')
+  assert.ok(deepPath.length > 260, 'fixture must exceed the traditional Windows MAX_PATH boundary')
+
+  const harness = String.raw`
+$ErrorActionPreference = 'Stop'
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($env:APPLY_HELPER, [ref]$tokens, [ref]$errors)
+if ($errors.Count -gt 0) { throw ($errors | ForEach-Object { $_.Message } | Out-String) }
+$functionText = $ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true) |
+  ForEach-Object { $_.Extent.Text }
+Invoke-Expression ($functionText -join [Environment]::NewLine)
+
+Remove-WorkspaceNodeModules -Root $env:TARGET_ROOT
+if (Test-Path -LiteralPath $env:TARGET_PATH) { throw 'deep dependency tree survived cleanup' }
+`
+
+  try {
+    const result = spawnSync('pwsh', ['-NoProfile', '-NonInteractive', '-Command', harness], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        APPLY_HELPER: applyHelper,
+        TARGET_ROOT: tempRoot,
+        TARGET_PATH: modulesPath,
+      },
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+
+    const script = readScript('scripts/ops/multitable-onprem-apply-package.ps1')
+    assert.match(script, /fs\.rmSync\(target, \{ recursive: true, force: true, maxRetries: 5, retryDelay: 250 \}\)/)
+    assert.match(script, /if \(\$exitCode -ne 0\)/)
+    assert.match(script, /cleanup did not remove \$Path/)
+    const cleanupBlock = script.slice(
+      script.indexOf('function Remove-WorkspaceNodeModules'),
+      script.indexOf('function New-PackageOverlayTransaction'),
+    )
+    assert.match(cleanupBlock, /Remove-DirectoryTree -Path \$modulesPath/)
+    assert.doesNotMatch(cleanupBlock, /Remove-Item[\s\S]*-Recurse/)
+
+    const restoreBlock = script.slice(
+      script.indexOf('function Restore-WorkspaceNodeModules'),
+      script.indexOf('function Complete-WorkspaceNodeModulesTransaction'),
+    )
+    assert.match(restoreBlock, /Remove-DirectoryTree -Path \$entry\.ModulesPath/)
+    assert.doesNotMatch(restoreBlock, /Remove-Item[\s\S]*-Recurse/)
+
+    const completeBlock = script.slice(
+      script.indexOf('function Complete-WorkspaceNodeModulesTransaction'),
+      script.indexOf('function Invoke-HealthcheckOnce'),
+    )
+    assert.match(completeBlock, /Remove-DirectoryTree -Path \$entry\.BackupPath/)
+    assert.doesNotMatch(completeBlock, /Remove-Item[\s\S]*-Recurse/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('package overlay and workspace dependency rollback restore the previous live tree', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-onprem-rollback-'))
   const applyHelper = path.join(repoRoot, 'scripts/ops/multitable-onprem-apply-package.ps1')


### PR DESCRIPTION
## What changed

- replace PowerShell provider recursion for workspace `node_modules` cleanup with a single Node `fs.rmSync` helper
- use the helper for disposable staging cleanup, activation rollback cleanup, and retired dependency-backup cleanup
- fail closed on a non-zero Node exit or a surviving target directory
- add a >260-character nested pnpm-tree regression that executes the production staging cleanup path, including a path containing spaces

## Why

The latest #3751 corrective-3 entity run passed checksum, package inventory, pinned-pnpm, native dependency, and frozen-install preflight, then failed `2/2` while PowerShell `Remove-Item -Recurse` traversed the disposable staging `node_modules` tree. The failure occurred before live overlay, migrations, PM2 restart, or smoke execution.

This keeps the existing frozen-install and rollback transaction boundaries unchanged while avoiding PowerShell FileSystem-provider traversal of deep pnpm paths. #3751 remains open; a corrective package and entity rerun remain required.

## Verification

Fail-first before the helper:

- `staging dependency cleanup bypasses PowerShell deep-path traversal` failed because `Remove-DirectoryTree` did not exist

Green after the change:

- on-prem package / Windows hardening / release gate / postdeploy smoke: `40/40`
- existing package-overlay and workspace-dependency rollback harness: PASS
- PowerShell AST parser: PASS
- `node --check`: PASS
- `git diff --check`: PASS
- `pnpm run verify:integration-k3wise:poc`: PASS

## Boundaries

- no lockfile or dependency change
- no frozen-install relaxation
- no package overlay, migration, PM2, healthcheck, K3, or external-write behavior change
- entity rerun remains values-free and owner-operated