### PR TITLE
docs(multitable): R10 台账残迹清理 — 初审处置标注被推翻 + 两处措辞 (owner 复审)

### DIFF
--- a/docs/development/assets/multitable-history-center-t2-evidence-20260710/EVIDENCE.md
+++ b/docs/development/assets/multitable-history-center-t2-evidence-20260710/EVIDENCE.md
@@ -4,7 +4,11 @@ Date: 2026-07-10 · Lane: evidence (no lane PR — final archival landed via **#
 Debt item: `docs/development/multitable-time-machine-plus-todo-20260619.md:102` — T2 tests: "browser Path A screenshot for dense timeline layout" (never captured), plus §3 rule (line 314): "Browser evidence is required for the global history center timeline before calling the UI slice complete."
 Captured after R9 landed record titles + typed link/person diffs + click-through, so the evidence also covers those.
 
-## Files (all in /tmp/lane-evidence-out/)
+## Files
+
+> **仓库归档内容 = 本目录的 5 张 PNG + 本 MD**（经 #4064 落库）。下表描述的即这 5 张归档图。
+> `/tmp/lane-evidence-out/` 是当时的**捕获源目录**（会话临时,日滚清理）,其中的种子/捕获脚本与 `.token`
+> **未提交也不应提交**——脚本内容已在下方「Steps to reproduce」全文重述,`.token` 为已过期 dev JWT。
 
 | File | What it proves (vs T2/T3 checklist) |
 |---|---|
@@ -14,7 +18,7 @@ Captured after R9 landed record titles + typed link/person diffs + click-through
 | `03-record-chip-clickthrough-drawer.png` | **Click-through.** Clicking the `Write launch spec` chip (`[data-test="hist-rec-label"]`) closed the modal and opened the Record Detail drawer for that record (URL gains `#recordId=rec_655e505a-…`), showing Task Name / Owner / Related Feature "Realtime Sync, Audit Log" / Status Done. |
 | `04-history-batch-expanded-person-diff.png` | Bonus: typed PERSON diff. Field filter = "Owner"; expanded batch `Update — Update user docs`, diff `Owner: ~~e0546c94-…~~ → Carol Li`. After-side renders the person NAME. **Observed nuance (honest):** the before-side fell back to the raw user id even though Bob Wu is still assigned elsewhere in the loaded grid — person-summary cache hit resolves names per side only on full coverage; a miss shows the id. Same family of fallback exists for links (an unlinked before-side rendered as "1 linked record" count in another batch). Not a blocker for T2 (the link diff in `02` renders names on both sides); worth a look if per-side person hydration should widen. |
 
-Also in this dir: `seed.mjs` + `seed-continue.mjs` (API seeding), `capture.mjs`/`capture2.mjs`/`capture3.mjs` (Playwright), `seed-output.txt` (ids), `.token` (expired dev JWT).
+捕获源目录（`/tmp/lane-evidence-out/`,未归档）另含当时的工作文件：`seed.mjs`/`seed-continue.mjs`（API 种子）、`capture*.mjs`（Playwright 捕获）、`seed-output.txt`（ids）、`.token`（已过期 dev JWT,**未提交**）——复现请直接按下节步骤,不依赖这些临时文件。
 
 ## Steps to reproduce
 

--- a/docs/development/multitable-global-history-restore-backreference-design-lock-20260710.md
+++ b/docs/development/multitable-global-history-restore-backreference-design-lock-20260710.md
@@ -2,7 +2,7 @@
 
 - **Status**: PROPOSED — docs-only；owner ratify 前零实现授权。R10 gate-front 工件（R9 UX-parity 审计 gated 项 (e)）。
 - **解锁词**：owner 对本文的明确点头（如「ratify 回链」）。
-- **难度/分派建议**：中（一列迁移 + 两处写路径穿线 + 投影面 + FE 渲染）→ Sonnet 5 建 + 对抗审。
+- **难度/分派建议**：中（一列迁移 + **按 OD-0 结果三路全穿线、或废弃 legacy 后两路穿线** + 投影面 + FE 渲染）→ Sonnet 5 建 + 对抗审。
 
 ## §1 问题（R9 审计原始证据，已对 origin/main 核验）
 

--- a/docs/development/multitable-timemachine-r10-round-design-verification-20260710.md
+++ b/docs/development/multitable-timemachine-r10-round-design-verification-20260710.md
@@ -14,13 +14,13 @@
 | 项 | 载体 | 关键验证 |
 |---|---|---|
 | **TrashModal 双层过滤 hygiene**（R9 观察项收尾） | #4060 `bc97802a2` | `historyVisibleFields`→`twoLayerVisibleFields` 更名服务双消费者；真实挂载 spec 经新 `open-trash` 锚点；突变恰红 `'Hidden Value' to be '#del_1'`；对抗审 **APPROVE 0P1/0P2/0P3**（含反证：fields 仅 title 一处消费、无恢复列选择器回归；全仓 sibling 扫描=最后一个单层喂给面） |
-| **四份 gate-front 决策 one-pager** | #4059 `63944c461` | ①restore 回链 mini-lock ②field-value tombstone 地板（推荐 A=接受边界+复议触发器） ③resurrect 锚精确化（**审阅贡献 A′=服务端按 asOf T 推导锚,零 wire 变更,成为新推荐**） ④all-tables 字段元数据（推荐 B=服务端掩码 fieldNames 复用投影 allow-set）。对抗审 APPROVE-with-hardening 0P1/0P2,2P3 全折入（legacy /restore NULL 意图钉进 G2;A 选项成本修正=preview response 并不下发候选锚） |
+| **四份 gate-front 决策 one-pager** | #4059 `63944c461` | ①restore 回链 mini-lock ②field-value tombstone 地板（推荐 A=接受边界+复议触发器） ③resurrect 锚精确化（**审阅贡献 A′=服务端按 asOf T 推导锚,零 wire 变更,成为新推荐**） ④all-tables 字段元数据（推荐 B=服务端掩码 fieldNames 复用投影 allow-set）。对抗审 APPROVE-with-hardening 0P1/0P2,2P3 全折入（legacy /restore 处置=**初审时钉为 NULL golden,后被 owner 深审推翻,最终以 OD-0 为准**;A 选项成本修正=preview response 并不下发候选锚） |
 | **T2 浏览器证据（历史欠账清偿）** | `docs/development/assets/multitable-history-center-t2-evidence-20260710/`（5 PNG + EVIDENCE.md） | 真实全栈（新鲜 pg + migrate + backend + vite + 无头 Chromium）：①密集时间线（~22 可见批次行,actor 显示名非 id,筛选栏全量）②展开批次含**记录标题** + **link diff 显示名称非 JSON** ③record chip click-through 关模态开抽屉 ④workbench 基线 ⑤person diff（含诚实发现,见 §3） |
 
 ## §2 复审贡献（值得留档的设计输入）
 
 - **A′ 锚推导方案**（#4059 复审 P3-2）：resurrect 的唯一现役入口 PIT-revert wire 上已携带 `asOf` T，vintage-正确锚可由「该记录 T 之后首条 delete revision」服务端推导——比显式参数便宜（零 wire 变更）且恰好修掉多 vintage under-replay；原推荐 A 的「客户端已知候选锚」经核为不实（preview response 只回 recordId/snapshot/snapshotHash）。
-- **legacy `/restore` 第三路**（P3-1）：`POST …/records/:recordId/restore` 也产 `source='restore'` revision 但无活跃 FE 调用方——回链锁 §5 显式出界 + G2 钉 NULL 意图。
+- **legacy `/restore` 第三路**（P3-1，**初审处置已被推翻**）：`POST …/records/:recordId/restore` 也产 `source='restore'` revision——初审曾以「无活跃 FE 调用方」为由出界+G2 钉 NULL;**owner 深审推翻该处置**（活路由永久 NULL=双轨语义），最终以回链锁 **OD-0**（三路全穿线 或 正式废弃）为准,NULL golden 已删除。
 
 ## §3 诚实发现与携带项
 


### PR DESCRIPTION
**Docs-only** — owner 复审 #4067 后的残迹清理(1P2+2P3)。

| 发现 | 修正 |
|---|---|
| **P2 台账自相矛盾**: R10 MD 头部已写 OD-0 必选,但 §1 表格与 §2 仍称「NULL 意图钉进 G2」 | 两处均改为「**初审方案,后被深审推翻,最终以 OD-0 为准**」 |
| P3 回链锁工作量摘要仍写「两处写路径穿线」 | → 「按 OD-0 结果**三路全穿线、或废弃 legacy 后两路穿线**」 |
| P3 EVIDENCE.md 归档路径漂移 | 明确区分**仓库归档内容**(5 PNG+MD,经 #4064)与 **/tmp 捕获源目录**(临时脚本+`.token` 未提交且不应提交;复现依文内步骤) |

实质设计内容(OD-0/排序契约)不变——本 PR 纯措辞对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)