### PR TITLE
feat(dingtalk): B-4 interactive-card terminal update — outcome→copy mapping, no-rollback, no existence oracle

### DIFF
--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -914,6 +914,73 @@ export async function sendDingTalkInteractiveApprovalCard(
   }
 }
 
+/**
+ * B-4 (interactive approval cards): update a delivered interactive card in place.
+ *
+ * Official card-instances update endpoint (`PUT /v1.0/card/instances`), addressed by the SAME
+ * `outTrackId` the B-2 send used (= the ledger delivery id). The update is a PRESENTATION
+ * follow-up only: it carries exactly one param — the terminal `statusText` — with
+ * `updateCardDataByKey` so every other card param (title/requestNo/nodeName/buttons) stays as
+ * sent. Values-free by construction (B-2 §5 fence): no form data can ride this call.
+ *
+ * HTTP-200 business failures fail closed (`success !== true` throws), same discipline as
+ * create-and-deliver above — callers must never treat an unacknowledged update as applied.
+ */
+export interface DingTalkInteractiveApprovalCardUpdateInput {
+  /** Must equal dingtalk_approval_card_deliveries.id — the only card ↔ ledger anchor. */
+  outTrackId: string
+  /** Terminal status copy (values-free, built server-side by interactive-card-update.ts). */
+  statusText: string
+}
+
+export async function updateDingTalkInteractiveApprovalCard(
+  accessToken: string,
+  input: DingTalkInteractiveApprovalCardUpdateInput,
+  config: DingTalkInteractiveCardConfig = {},
+  options?: DingTalkRequestOptions,
+): Promise<{ requestId?: string; raw: Record<string, unknown> }> {
+  const outTrackId = input.outTrackId.trim()
+  const statusText = input.statusText.trim()
+
+  if (!accessToken.trim()) throw new Error('DingTalk access token is required')
+  if (!outTrackId) throw new Error('DingTalk interactive-card outTrackId is required')
+  if (!statusText) throw new Error('DingTalk interactive-card status text is required')
+
+  const payload = await requestDingTalkJson(
+    `${normalizeDingTalkOpenApiBaseUrl(config.openApiBaseUrl)}/v1.0/card/instances`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-acs-dingtalk-access-token': accessToken,
+      },
+      body: JSON.stringify({
+        outTrackId,
+        cardData: {
+          cardParamMap: {
+            statusText,
+          },
+        },
+        cardUpdateOptions: { updateCardDataByKey: true },
+      }),
+    },
+    'Failed to update DingTalk interactive approval card',
+    options,
+  )
+
+  if (payload.success !== true) {
+    throw new DingTalkBusinessError(
+      normalizeErrorMessage(payload, 'DingTalk interactive-card update failed'),
+      payload,
+    )
+  }
+
+  return {
+    requestId: readStringField(payload, 'requestId', 'request_id'),
+    raw: payload,
+  }
+}
+
 export async function sendDingTalkWorkNotificationActionCard(
   accessToken: string,
   input: DingTalkWorkNotificationActionCardInput,

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -965,6 +965,10 @@ export async function updateDingTalkInteractiveApprovalCard(
       }),
     },
     'Failed to update DingTalk interactive approval card',
+    // B-4 terminal update is a SIDE-EFFECT SEND tier (same as createAndDeliver above): although
+    // the PUT is an idempotent statusText overwrite, we never auto-resend on ambiguity — a lost
+    // update is non-critical by design (duplicate clicks converge via the stale summary).
+    'send',
     options,
   )
 

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
@@ -29,12 +29,19 @@
  *   the SAME secret source the sender used (`approval-card-config`, env-first, per-integration
  *   pinned). A missing secret fail-closes BEFORE any engine call.
  *
- * The result is a typed union B-4 will map to in-place card updates. B-3 performs NO card update.
+ * The result is a typed union mapped by B-4 (`interactive-card-update.ts`) to an in-place card
+ * update, hooked here at outcome production. The update is a PRESENTATION follow-up only: it never
+ * throws back into this path and owns no ledger/engine access, so a failed card update can never
+ * roll back a committed action (lock §B-4 row 6).
  */
 import { createHmac } from 'crypto'
 
 import { findDingTalkApprovalCardDeliveryById } from './approval-card-deliveries'
 import { resolveApprovalCardLinkSecretForIntegration } from './approval-card-config'
+import {
+  applyDingTalkApprovalCardTerminalUpdate,
+  type DingTalkApprovalCardUpdateSender,
+} from './interactive-card-update'
 import {
   executeApprovalActionFromCardDelivery,
   type ApprovalCardDeliverySummary,
@@ -171,6 +178,12 @@ export function parseDingTalkApprovalCardCallback(payload: unknown): DingTalkApp
 export type DingTalkApprovalCardCallbackDeps = {
   query: QueryFn
   approvals: Pick<ApprovalProductService, 'dispatchAction'>
+  /**
+   * B-4 card-update sender override (tests / alternate transports). Omitted → the production
+   * sender behind the SAME env gate as the B-2 send (`resolveDingTalkInteractiveCardStreamConfig`);
+   * with the gate off the terminal update is a silent no-op.
+   */
+  cardUpdateSender?: DingTalkApprovalCardUpdateSender
 }
 
 type ResolvedOperator =
@@ -229,42 +242,71 @@ async function resolveOperatorLocalUser(
 
 /**
  * Full B-3 execution: parse → ledger-only delivery resolve → fail-closed operator mapping →
- * same-source token threading → A-4 wrapper. Returns the typed outcome for B-4; never updates
- * the card, never logs (callers own values-free logging).
+ * same-source token threading → A-4 wrapper — then the B-4 terminal card update at outcome
+ * production. Returns the typed outcome; never logs (callers own values-free logging).
+ *
+ * The B-4 follow-up is failure-isolated by construction: `applyDingTalkApprovalCardTerminalUpdate`
+ * never throws and holds no query/engine access, so the committed action and the returned outcome
+ * are identical whether the card update succeeds, fails, or is env-disabled (no-rollback, §B-4).
  */
 export async function executeDingTalkApprovalCardCallback(
   deps: DingTalkApprovalCardCallbackDeps,
   payload: unknown,
 ): Promise<DingTalkApprovalCardCallbackResult> {
+  const { result, operatorDisplayName } = await resolveDingTalkApprovalCardCallbackOutcome(deps, payload)
+  await applyDingTalkApprovalCardTerminalUpdate(result, { operatorDisplayName }, deps.cardUpdateSender)
+  return result
+}
+
+/**
+ * Outcome production (the B-3 pipeline), plus the server-side operator display name for B-4's
+ * success copy — resolved from LOCAL user data by `resolveOperatorLocalUser`, never from callback
+ * payload display text (lock §B-4).
+ */
+async function resolveDingTalkApprovalCardCallbackOutcome(
+  deps: DingTalkApprovalCardCallbackDeps,
+  payload: unknown,
+): Promise<{ result: DingTalkApprovalCardCallbackResult; operatorDisplayName: string | null }> {
   const parsed = parseDingTalkApprovalCardCallback(payload)
   if (parsed.ok === false) {
-    return parsed.outcome === 'rejected'
-      ? { outcome: 'rejected', reason: parsed.reason }
-      : { outcome: 'ignored_unsupported_action', outTrackId: parsed.outTrackId }
+    return {
+      result: parsed.outcome === 'rejected'
+        ? { outcome: 'rejected', reason: parsed.reason }
+        : { outcome: 'ignored_unsupported_action', outTrackId: parsed.outTrackId },
+      operatorDisplayName: null,
+    }
   }
   const { outTrackId, operatorDingTalkUserId } = parsed.callback
 
   // LEDGER-ONLY resolution (§2): the delivery row is the sole delivery → instance anchor.
   const delivery = await findDingTalkApprovalCardDeliveryById(deps.query, outTrackId)
-  if (!delivery) return { outcome: 'delivery_not_found', outTrackId }
+  if (!delivery) return { result: { outcome: 'delivery_not_found', outTrackId }, operatorDisplayName: null }
 
   // Owner hard gate (2026-07-10): operator identity may only resolve inside the delivery's own
   // DingTalk corp. An unpinned delivery (integration_id NULL) refuses OUTRIGHT — never a global
   // userId lookup (cross-corp identity-collision face).
   if (!delivery.integration_id) {
-    return { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: 'integration_unpinned' }
+    return {
+      result: { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: 'integration_unpinned' },
+      operatorDisplayName: null,
+    }
   }
 
   const operator = await resolveOperatorLocalUser(deps.query, operatorDingTalkUserId, delivery.integration_id)
   if (operator.ok === false) {
-    return { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: operator.reason }
+    return {
+      result: { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: operator.reason },
+      operatorDisplayName: null,
+    }
   }
 
   // Same-source signing (see module doc): resolve the secret exactly as the sender did — pinned
   // integration (env override wins inside the resolver). The legacy NULL-row resolver is
-  // unreachable here by the owner gate above.
+  // unreachable here by the owner gate above (P2 landing discipline: do NOT re-add it).
   const linkSecret = await resolveApprovalCardLinkSecretForIntegration(delivery.integration_id, deps.query)
-  if (!linkSecret) return { outcome: 'link_secret_unavailable', deliveryId: delivery.id }
+  if (!linkSecret) {
+    return { result: { outcome: 'link_secret_unavailable', deliveryId: delivery.id }, operatorDisplayName: operator.userName }
+  }
   const token = createHmac('sha256', linkSecret).update(delivery.id).digest('hex').slice(0, 32)
 
   const outcome = await executeApprovalActionFromCardDelivery(
@@ -285,23 +327,27 @@ export async function executeDingTalkApprovalCardCallback(
     },
   )
 
+  const operatorDisplayName = operator.userName
   switch (outcome.status) {
     case 'ok':
-      return { outcome: 'executed', deliveryId: delivery.id, summary: outcome.summary }
+      return { result: { outcome: 'executed', deliveryId: delivery.id, summary: outcome.summary }, operatorDisplayName }
     case 'stale':
-      return { outcome: 'stale', deliveryId: delivery.id, summary: outcome.summary }
+      return { result: { outcome: 'stale', deliveryId: delivery.id, summary: outcome.summary }, operatorDisplayName }
     case 'engine_rejected':
       // Values-free: the engine's human-readable message may carry titles/names — only the stable
       // code and HTTP class cross this boundary. B-4 maps codes to reason-coded card copy.
       return {
-        outcome: 'engine_rejected',
-        deliveryId: delivery.id,
-        code: outcome.code,
-        httpStatus: outcome.httpStatus,
-        summary: outcome.summary,
+        result: {
+          outcome: 'engine_rejected',
+          deliveryId: delivery.id,
+          code: outcome.code,
+          httpStatus: outcome.httpStatus,
+          summary: outcome.summary,
+        },
+        operatorDisplayName,
       }
     case 'not_found':
     default:
-      return { outcome: 'wrapper_not_found', deliveryId: delivery.id }
+      return { result: { outcome: 'wrapper_not_found', deliveryId: delivery.id }, operatorDisplayName }
   }
 }

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-update.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-update.ts
@@ -1,0 +1,206 @@
+/**
+ * B-4 (Slice B design lock §B-4): terminal card update — the presentation follow-up that maps the
+ * B-3 callback outcome union onto an in-place DingTalk card update.
+ *
+ * Non-negotiables encoded here:
+ * - PRESENTATION ONLY: the approval engine + delivery ledger stay the source of truth. This module
+ *   has NO database access at all — a failed card update can not roll anything back by
+ *   construction (lock §B-4: "do not roll back the approval"). Duplicate clicks converge through
+ *   the wrapper's stale summary on the next callback.
+ * - VALUES-FREE COPY (§2/§5, same fence as the B-2 card body): the terminal `statusText` is built
+ *   exclusively from status-level fields (card state, acted action/time, instance status, stable
+ *   engine reason codes) plus the server-side operator display name the callback adapter resolved
+ *   from LOCAL user data. Titles, request numbers, node names, form values, and payload-supplied
+ *   display text never enter the copy.
+ * - NO EXISTENCE ORACLE (§5.2, review P3-H): `delivery_not_found` and every `operator_unresolved`
+ *   reason render the BYTE-EQUAL neutral copy, so card copy never confirms whether a delivery id
+ *   exists. Do not split these strings.
+ * - FAILURE ISOLATION: `applyDingTalkApprovalCardTerminalUpdate` never throws. Update failures
+ *   are logged values-free (reason class + ledger delivery id only — never card payloads or API
+ *   error bodies) and surface as a typed outcome the caller may ignore.
+ */
+import { Logger } from '../../core/logger'
+import {
+  fetchDingTalkAppAccessToken,
+  updateDingTalkInteractiveApprovalCard,
+} from './client'
+import { resolveDingTalkInteractiveCardStreamConfig } from './interactive-card-stream'
+import type { DingTalkApprovalCardCallbackResult } from './interactive-card-callback'
+import type { ApprovalCardDeliverySummary } from '../../services/ApprovalCardDeliveryAction'
+
+const logger = new Logger('DingTalkInteractiveCardUpdate')
+
+/**
+ * Ratified §B-4 copy for an unmapped operator — and (review P3-H) the SHARED neutral copy for an
+ * unknown delivery id: both cases must stay byte-equal so the card never oracles ledger existence.
+ */
+export const DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT = '请先在网页端绑定钉钉后再处理'
+/** Ratified §B-4 copy for non-recipient / permission-denied outcomes. */
+export const DINGTALK_APPROVAL_CARD_NO_PERMISSION_TEXT = '当前账号无权处理该审批'
+/** Server-side inconsistency (missing link secret, wrapper row vanished): generic, values-free. */
+export const DINGTALK_APPROVAL_CARD_SYSTEM_UNAVAILABLE_TEXT = '暂时无法处理，请在网页端处理该审批'
+
+export type DingTalkApprovalCardTerminalUpdate = {
+  /** The ledger delivery id — identical to the card's outTrackId (B-2 anchor). */
+  outTrackId: string
+  /** Terminal status copy; the ONLY card param a B-4 update may change. */
+  statusText: string
+}
+
+export type DingTalkApprovalCardUpdateSender = (update: DingTalkApprovalCardTerminalUpdate) => Promise<void>
+
+export type DingTalkApprovalCardTerminalUpdateContext = {
+  /**
+   * Operator display name resolved by the callback adapter from LOCAL user data (users.name).
+   * Never sourced from callback payload display text (lock §B-4).
+   */
+  operatorDisplayName?: string | null
+  /** Clock override for tests; production uses the ledger acted_at first, then now. */
+  now?: Date
+}
+
+export type DingTalkApprovalCardTerminalUpdateOutcome =
+  | { status: 'updated'; outTrackId: string }
+  | { status: 'skipped'; reason: 'no_update_for_outcome' | 'stream_config_disabled' }
+  /** `reason` is the error class name only — values-free by construction. */
+  | { status: 'failed'; outTrackId: string; reason: string }
+
+// Card audience timezone: DingTalk corp deployments (Asia/Shanghai, same default as the
+// attendance delivery worker). The acted time is presentation-only; the ledger keeps the instant.
+const CARD_TIME_FORMATTER = new Intl.DateTimeFormat('zh-CN', {
+  timeZone: 'Asia/Shanghai',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+})
+
+function formatCardTime(value: Date | string | null | undefined): string | null {
+  if (value === null || value === undefined) return null
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return CARD_TIME_FORMATTER.format(date)
+}
+
+/**
+ * Stale/duplicate convergence: the current TRUE terminal state, derived ONLY from status-level
+ * summary fields. Precedence: this card's own acted claim → the instance's terminal status → the
+ * card's lifecycle state (expired/superseded/undelivered).
+ */
+function staleStatusText(summary: ApprovalCardDeliverySummary): string {
+  if (summary.cardState === 'acted') {
+    const time = formatCardTime(summary.actedAt)
+    const suffix = time ? ` · ${time}` : ''
+    if (summary.actedAction === 'approve') return `已同意${suffix}`
+    if (summary.actedAction === 'reject') return `已驳回${suffix}`
+    return `已处理${suffix}`
+  }
+  switch (summary.approval.status) {
+    case 'approved':
+      return '审批已通过'
+    case 'rejected':
+      return '审批已拒绝'
+    case 'revoked':
+      return '审批已撤销'
+    default:
+      break
+  }
+  if (summary.cardState === 'expired') return '卡片已过期，请在网页端处理'
+  if (summary.cardState === 'superseded') return '该任务已流转，请在网页端查看'
+  return '卡片已失效，请在网页端查看'
+}
+
+/**
+ * The §B-4 mapping table as a pure function: callback outcome → terminal card update, or `null`
+ * for the no-op rows (parse-level rejection has no card to address; unsupported actions are a
+ * recorded no-op per §B-3 step 2).
+ */
+export function buildDingTalkApprovalCardTerminalUpdate(
+  result: DingTalkApprovalCardCallbackResult,
+  context: DingTalkApprovalCardTerminalUpdateContext = {},
+): DingTalkApprovalCardTerminalUpdate | null {
+  switch (result.outcome) {
+    case 'rejected':
+    case 'ignored_unsupported_action':
+      return null
+    case 'delivery_not_found':
+      // P3-H: byte-equal with operator_unresolved below — never an existence oracle.
+      return { outTrackId: result.outTrackId, statusText: DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT }
+    case 'operator_unresolved':
+      return { outTrackId: result.deliveryId, statusText: DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT }
+    case 'link_secret_unavailable':
+    case 'wrapper_not_found':
+      return { outTrackId: result.deliveryId, statusText: DINGTALK_APPROVAL_CARD_SYSTEM_UNAVAILABLE_TEXT }
+    case 'executed': {
+      const name = typeof context.operatorDisplayName === 'string' ? context.operatorDisplayName.trim() : ''
+      const time = formatCardTime(result.summary.actedAt) ?? formatCardTime(context.now ?? new Date())!
+      return {
+        outTrackId: result.deliveryId,
+        statusText: name ? `已由 ${name} 同意 · ${time}` : `已同意 · ${time}`,
+      }
+    }
+    case 'stale':
+      return { outTrackId: result.deliveryId, statusText: staleStatusText(result.summary) }
+    case 'engine_rejected': {
+      const permissionDenied = result.httpStatus === 403 || result.code === 'APPROVAL_ASSIGNMENT_REQUIRED'
+      return {
+        outTrackId: result.deliveryId,
+        statusText: permissionDenied
+          ? DINGTALK_APPROVAL_CARD_NO_PERMISSION_TEXT
+          // Reason-coded failure copy: the STABLE engine code only, never the engine message
+          // (which may carry titles/names) and never form values (lock §B-4 row 5).
+          : `无法处理该审批（${result.code}）`,
+      }
+    }
+  }
+}
+
+/**
+ * Production sender: same env-gated Stream credentials the B-2 send used (`resolve…StreamConfig`),
+ * app-token via the shared cache, official update endpoint. Returns `null` when the stream gate is
+ * off — with the flag off no card was ever sent by this channel, so there is nothing to update.
+ */
+export function createDingTalkApprovalCardStreamUpdateSender(
+  env: NodeJS.ProcessEnv = process.env,
+): DingTalkApprovalCardUpdateSender | null {
+  const config = resolveDingTalkInteractiveCardStreamConfig(env)
+  if (config.enabled === false) return null
+  return async (update) => {
+    const accessToken = await fetchDingTalkAppAccessToken({
+      appKey: config.clientId,
+      appSecret: config.clientSecret,
+    })
+    await updateDingTalkInteractiveApprovalCard(accessToken, update)
+  }
+}
+
+/**
+ * The B-4 follow-up hook: build the terminal update for an outcome and send it. NEVER throws and
+ * touches no database — the committed approval action is out of reach from here (no-rollback
+ * invariant). Failures log values-free (error class + delivery id) and duplicate clicks converge
+ * later through the wrapper's stale summary.
+ */
+export async function applyDingTalkApprovalCardTerminalUpdate(
+  result: DingTalkApprovalCardCallbackResult,
+  context: DingTalkApprovalCardTerminalUpdateContext = {},
+  sender?: DingTalkApprovalCardUpdateSender,
+): Promise<DingTalkApprovalCardTerminalUpdateOutcome> {
+  const update = buildDingTalkApprovalCardTerminalUpdate(result, context)
+  if (!update) return { status: 'skipped', reason: 'no_update_for_outcome' }
+
+  const send = sender ?? createDingTalkApprovalCardStreamUpdateSender()
+  if (!send) return { status: 'skipped', reason: 'stream_config_disabled' }
+
+  try {
+    await send(update)
+    return { status: 'updated', outTrackId: update.outTrackId }
+  } catch (error) {
+    const reason = error instanceof Error ? error.name : 'UnknownError'
+    // Values-free (lock §5.3): reason class + ledger id only — API error bodies and card payloads
+    // never enter logs. The action itself is already committed and stays committed.
+    logger.warn(`DingTalk approval-card terminal update failed (card_update_failed:${reason}) delivery=${update.outTrackId}`)
+    return { status: 'failed', outTrackId: update.outTrackId, reason }
+  }
+}

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-update.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-update.ts
@@ -187,20 +187,24 @@ export async function applyDingTalkApprovalCardTerminalUpdate(
   context: DingTalkApprovalCardTerminalUpdateContext = {},
   sender?: DingTalkApprovalCardUpdateSender,
 ): Promise<DingTalkApprovalCardTerminalUpdateOutcome> {
-  const update = buildDingTalkApprovalCardTerminalUpdate(result, context)
-  if (!update) return { status: 'skipped', reason: 'no_update_for_outcome' }
-
-  const send = sender ?? createDingTalkApprovalCardStreamUpdateSender()
-  if (!send) return { status: 'skipped', reason: 'stream_config_disabled' }
-
+  // Review P3-1: the copy builder and sender resolution sit INSIDE the try so "never throws" is
+  // structural, not incidental — both are total functions today, but a future edit to either must
+  // not be able to break the no-rollback invariant.
   try {
+    const update = buildDingTalkApprovalCardTerminalUpdate(result, context)
+    if (!update) return { status: 'skipped', reason: 'no_update_for_outcome' }
+
+    const send = sender ?? createDingTalkApprovalCardStreamUpdateSender()
+    if (!send) return { status: 'skipped', reason: 'stream_config_disabled' }
+
     await send(update)
     return { status: 'updated', outTrackId: update.outTrackId }
   } catch (error) {
     const reason = error instanceof Error ? error.name : 'UnknownError'
     // Values-free (lock §5.3): reason class + ledger id only — API error bodies and card payloads
     // never enter logs. The action itself is already committed and stays committed.
-    logger.warn(`DingTalk approval-card terminal update failed (card_update_failed:${reason}) delivery=${update.outTrackId}`)
-    return { status: 'failed', outTrackId: update.outTrackId, reason }
+    const outTrackId = 'deliveryId' in result ? result.deliveryId : ('outTrackId' in result ? result.outTrackId : 'unknown')
+    logger.warn(`DingTalk approval-card terminal update failed (card_update_failed:${reason}) delivery=${outTrackId}`)
+    return { status: 'failed', outTrackId, reason }
   }
 }

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
@@ -24,6 +24,7 @@ import {
   parseDingTalkApprovalCardCallback,
   type DingTalkApprovalCardCallbackResult,
 } from '../../src/integrations/dingtalk/interactive-card-callback'
+import type { DingTalkApprovalCardTerminalUpdate } from '../../src/integrations/dingtalk/interactive-card-update'
 
 const DELIVERY_ID = '11111111-2222-4333-8444-555555555555'
 const OPERATOR = 'dd_operator_1'
@@ -410,11 +411,101 @@ describe('executeDingTalkApprovalCardCallback (B-3 §B-3 execution)', () => {
   })
 })
 
+// ── B-4 hook: terminal card update at outcome production (lock §B-4) ───────────────────────────
+
+describe('B-4 hook: terminal card update at outcome production', () => {
+  beforeEach(() => {
+    vi.stubEnv('APPROVAL_CARD_LINK_SECRET', 'b3-unit-secret')
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  function recordingSender() {
+    const sends: DingTalkApprovalCardTerminalUpdate[] = []
+    const sender = async (update: DingTalkApprovalCardTerminalUpdate) => { sends.push(update) }
+    return { sends, sender }
+  }
+
+  it('executed → sender gets 已由 <server-side local name> 同意 · <time>; hostile payload display text never enters the copy', async () => {
+    const h = makeHarness()
+    const { sends, sender } = recordingSender()
+    const result = await executeDingTalkApprovalCardCallback(
+      { ...h.deps, cardUpdateSender: sender } as never,
+      wirePayload({ nick: '大黑客', operatorName: 'Payload Hacker', senderNick: 'EvilNick' }),
+    )
+    expect(result.outcome).toBe('executed')
+    expect(sends).toHaveLength(1)
+    expect(sends[0].outTrackId).toBe(DELIVERY_ID)
+    // Display name is the LOCAL users.name resolved fail-closed by the adapter (lock §B-4).
+    expect(sends[0].statusText).toMatch(/^已由 Approver A 同意 · \d{4}\/\d{2}\/\d{2} \d{2}:\d{2}$/)
+    expect(sends[0].statusText).not.toContain('大黑客')
+    expect(sends[0].statusText).not.toContain('Payload Hacker')
+    expect(sends[0].statusText).not.toContain('EvilNick')
+  })
+
+  it('NO ROLLBACK: a failing card update leaves the committed action untouched — result stays executed, ZERO DB traffic after the update attempt', async () => {
+    const h = makeHarness()
+    let callsAtUpdate = -1
+    const sender = async () => {
+      callsAtUpdate = h.calls.length
+      throw new Error('card update API 500')
+    }
+    const result = await executeDingTalkApprovalCardCallback(
+      { ...h.deps, cardUpdateSender: sender } as never,
+      wirePayload(),
+    )
+    expect(result.outcome).toBe('executed')
+    expect(h.dispatchAction).toHaveBeenCalledTimes(1)
+    // The update ran AFTER the acted claim, and NOTHING ran after it failed: no ledger revert,
+    // no re-claim, no compensating engine call (lock §B-4 row 6).
+    expect(callsAtUpdate).toBeGreaterThan(0)
+    expect(h.calls.length).toBe(callsAtUpdate)
+    expect(h.calls.some((c) => c.sql.includes("SET card_state = 'sent'"))).toBe(false)
+  })
+
+  it('P3-H at the hook: delivery_not_found and operator_unresolved send BYTE-EQUAL neutral copy', async () => {
+    const notFoundH = makeHarness({ deliveryRows: [] })
+    const a = recordingSender()
+    await executeDingTalkApprovalCardCallback({ ...notFoundH.deps, cardUpdateSender: a.sender } as never, wirePayload())
+
+    const unmappedH = makeHarness({ linkRows: [] })
+    const b = recordingSender()
+    await executeDingTalkApprovalCardCallback({ ...unmappedH.deps, cardUpdateSender: b.sender } as never, wirePayload())
+
+    expect(a.sends).toHaveLength(1)
+    expect(b.sends).toHaveLength(1)
+    expect(a.sends[0].statusText).toBe(b.sends[0].statusText)
+    expect(a.sends[0].outTrackId).toBe(DELIVERY_ID)
+  })
+
+  it('stale duplicate → sender receives the TRUE terminal state from the summary', async () => {
+    const h = makeHarness({
+      deliveryRows: [deliveryRow({ card_state: 'acted', acted_action: 'approve', acted_by: 'u_appr', acted_at: '2026-07-10T06:30:00.000Z' })],
+    })
+    const { sends, sender } = recordingSender()
+    const result = await executeDingTalkApprovalCardCallback({ ...h.deps, cardUpdateSender: sender } as never, wirePayload())
+    expect(result.outcome).toBe('stale')
+    expect(sends).toEqual([{ outTrackId: DELIVERY_ID, statusText: '已同意 · 2026/07/10 14:30' }])
+  })
+
+  it('parse-level rejection and unsupported actions never touch the card updater (no-op rows)', async () => {
+    const h = makeHarness()
+    const { sends, sender } = recordingSender()
+    await executeDingTalkApprovalCardCallback({ ...h.deps, cardUpdateSender: sender } as never, wirePayload({ outTrackId: 'not-a-uuid' }))
+    await executeDingTalkApprovalCardCallback(
+      { ...h.deps, cardUpdateSender: sender } as never,
+      wirePayload({ content: JSON.stringify({ cardPrivateData: { actionIds: ['reject'] } }) }),
+    )
+    expect(sends).toHaveLength(0)
+  })
+})
+
 // ── Slice-A-style static tripwire (lock §6): no raw approvals-actions route on this chain ──────
 
 describe('B-3 static tripwire: callback chain never touches the raw approvals actions route', () => {
   const SRC = join(__dirname, '../../src/integrations/dingtalk')
-  const files = ['interactive-card-callback.ts', 'interactive-card-stream.ts']
+  const files = ['interactive-card-callback.ts', 'interactive-card-stream.ts', 'interactive-card-update.ts']
 
   it('modules do not contain or compose the raw route path', () => {
     for (const file of files) {

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-update.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-update.test.ts
@@ -157,7 +157,7 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
     })
     expect(notFound).toEqual({ outTrackId: DELIVERY_ID, statusText: DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT })
 
-    for (const reason of ['unlinked', 'inactive', 'ambiguous'] as const) {
+    for (const reason of ['unlinked', 'inactive', 'ambiguous', 'integration_unpinned'] as const) {
       const unresolved = buildDingTalkApprovalCardTerminalUpdate({
         outcome: 'operator_unresolved', deliveryId: DELIVERY_ID, reason,
       })

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-update.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-update.test.ts
@@ -1,0 +1,301 @@
+/**
+ * B-4 terminal card update (Slice B design lock §B-4) — unit matrix for the copy builder and the
+ * presentation-follow-up orchestration.
+ *
+ * Pins, per the ratified §B-4 table:
+ *  - success approve → `已由 <display name> 同意 · <time>` — the display name comes from the
+ *    CONTEXT (server-side local user data threaded by the callback adapter), never from summary
+ *    or payload fields;
+ *  - stale/duplicate → the current TRUE terminal state derived ONLY from status-level summary
+ *    fields (cardState/actedAction/actedAt/approval.status);
+ *  - unmapped operator → the bind-first copy — and (review P3-H) `delivery_not_found` renders the
+ *    BYTE-EQUAL same copy so card copy never becomes a delivery-existence oracle;
+ *  - non-recipient / permission denied → `当前账号无权处理该审批`;
+ *  - engine validation error → reason-coded copy (stable code only, NO values);
+ *  - update failure after a committed action → the orchestrator resolves (never throws) and owns
+ *    no DB access at all, so a rollback is structurally impossible from here.
+ *
+ * VALUES-FREE FENCE (mutation-verified): every expected statusText is asserted byte-exact over a
+ * summary poisoned with canary values in ALL non-status fields — any leak of title/requestNo/
+ * nodeKey/recipient/instance data into the copy turns a test red.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT,
+  DINGTALK_APPROVAL_CARD_NO_PERMISSION_TEXT,
+  DINGTALK_APPROVAL_CARD_SYSTEM_UNAVAILABLE_TEXT,
+  applyDingTalkApprovalCardTerminalUpdate,
+  buildDingTalkApprovalCardTerminalUpdate,
+  createDingTalkApprovalCardStreamUpdateSender,
+} from '../../src/integrations/dingtalk/interactive-card-update'
+import type { DingTalkApprovalCardCallbackResult } from '../../src/integrations/dingtalk/interactive-card-callback'
+import { __resetDingTalkAppAccessTokenCacheForTests } from '../../src/integrations/dingtalk/client'
+import type { ApprovalCardDeliverySummary } from '../../src/services/ApprovalCardDeliveryAction'
+
+const DELIVERY_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+// 2026-07-10T06:30Z = 2026/07/10 14:30 Asia/Shanghai — the card audience timezone.
+const ACTED_AT = '2026-07-10T06:30:00.000Z'
+const ACTED_AT_TEXT = '2026/07/10 14:30'
+
+/** Summary poisoned with canaries in every NON-status field (values-free fence probes). */
+function canarySummary(overrides: Partial<ApprovalCardDeliverySummary> = {}, approvalOverrides: Partial<ApprovalCardDeliverySummary['approval']> = {}): ApprovalCardDeliverySummary {
+  return {
+    deliveryId: DELIVERY_ID,
+    cardState: 'acted',
+    sendStatus: 'sent',
+    nodeKey: 'NODE_KEY_CANARY',
+    recipientUserId: 'RECIPIENT_CANARY',
+    viewerIsRecipient: true,
+    actionable: false,
+    approval: {
+      instanceId: 'INSTANCE_CANARY',
+      title: 'TITLE_CANARY_机密采购单',
+      requestNo: 'REQNO_CANARY',
+      status: 'approved',
+      currentNodeKey: 'CURRENT_NODE_CANARY',
+      rejectCommentRequired: true,
+      ...approvalOverrides,
+    },
+    actedAction: 'approve',
+    actedAt: ACTED_AT,
+    ...overrides,
+  }
+}
+
+const CANARIES = [
+  'NODE_KEY_CANARY',
+  'RECIPIENT_CANARY',
+  'INSTANCE_CANARY',
+  'TITLE_CANARY',
+  '机密采购单',
+  'REQNO_CANARY',
+  'CURRENT_NODE_CANARY',
+]
+
+function executed(summary = canarySummary()): DingTalkApprovalCardCallbackResult {
+  return { outcome: 'executed', deliveryId: DELIVERY_ID, summary }
+}
+
+describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => {
+  it('success approve → 已由 <display name> 同意 · <time> (name from server-side context, time from the ledger acted_at)', () => {
+    const update = buildDingTalkApprovalCardTerminalUpdate(executed(), { operatorDisplayName: '张审批' })
+    expect(update).toEqual({
+      outTrackId: DELIVERY_ID,
+      statusText: `已由 张审批 同意 · ${ACTED_AT_TEXT}`,
+    })
+  })
+
+  it('success approve without a resolvable display name still renders a terminal state (name omitted, never guessed)', () => {
+    const update = buildDingTalkApprovalCardTerminalUpdate(executed(), {})
+    expect(update?.statusText).toBe(`已同意 · ${ACTED_AT_TEXT}`)
+  })
+
+  it('success approve with a missing acted_at falls back to the injected now', () => {
+    const update = buildDingTalkApprovalCardTerminalUpdate(
+      executed(canarySummary({ actedAt: null })),
+      { operatorDisplayName: '张审批', now: new Date(ACTED_AT) },
+    )
+    expect(update?.statusText).toBe(`已由 张审批 同意 · ${ACTED_AT_TEXT}`)
+  })
+
+  it('stale on an acted card → the ledger terminal action (approve/reject), status-level only', () => {
+    const approved = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'stale', deliveryId: DELIVERY_ID, summary: canarySummary(),
+    })
+    expect(approved).toEqual({ outTrackId: DELIVERY_ID, statusText: `已同意 · ${ACTED_AT_TEXT}` })
+
+    const rejected = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'stale',
+      deliveryId: DELIVERY_ID,
+      summary: canarySummary({ actedAction: 'reject' }, { status: 'rejected' }),
+    })
+    expect(rejected?.statusText).toBe(`已驳回 · ${ACTED_AT_TEXT}`)
+  })
+
+  it('stale on a non-acted card falls through to the instance terminal status', () => {
+    for (const [status, text] of [
+      ['approved', '审批已通过'],
+      ['rejected', '审批已拒绝'],
+      ['revoked', '审批已撤销'],
+    ] as const) {
+      const update = buildDingTalkApprovalCardTerminalUpdate({
+        outcome: 'stale',
+        deliveryId: DELIVERY_ID,
+        summary: canarySummary({ cardState: 'superseded', actedAction: null, actedAt: null }, { status }),
+      })
+      expect(update?.statusText).toBe(text)
+    }
+  })
+
+  it('stale on a still-pending instance renders card-level convergence copy (expired/superseded/undelivered)', () => {
+    const expired = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'stale',
+      deliveryId: DELIVERY_ID,
+      summary: canarySummary({ cardState: 'expired', actedAction: null, actedAt: null }, { status: 'pending' }),
+    })
+    expect(expired?.statusText).toBe('卡片已过期，请在网页端处理')
+
+    const superseded = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'stale',
+      deliveryId: DELIVERY_ID,
+      summary: canarySummary({ cardState: 'superseded', actedAction: null, actedAt: null }, { status: 'pending' }),
+    })
+    expect(superseded?.statusText).toBe('该任务已流转，请在网页端查看')
+
+    const undelivered = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'stale',
+      deliveryId: DELIVERY_ID,
+      summary: canarySummary({ cardState: 'sent', sendStatus: 'pending', actedAction: null, actedAt: null }, { status: 'pending' }),
+    })
+    expect(undelivered?.statusText).toBe('卡片已失效，请在网页端查看')
+  })
+
+  it('P3-H: delivery_not_found and EVERY operator_unresolved reason render BYTE-EQUAL neutral copy (no existence oracle)', () => {
+    const notFound = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'delivery_not_found', outTrackId: DELIVERY_ID,
+    })
+    expect(notFound).toEqual({ outTrackId: DELIVERY_ID, statusText: DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT })
+
+    for (const reason of ['unlinked', 'inactive', 'ambiguous'] as const) {
+      const unresolved = buildDingTalkApprovalCardTerminalUpdate({
+        outcome: 'operator_unresolved', deliveryId: DELIVERY_ID, reason,
+      })
+      // toBe on the exact same string: byte-equal, not merely similar.
+      expect(unresolved?.statusText).toBe(notFound?.statusText)
+    }
+    // …and the shared copy is the ratified unmapped-user row (lock §B-4).
+    expect(DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT).toBe('请先在网页端绑定钉钉后再处理')
+  })
+
+  it('link_secret_unavailable / wrapper_not_found → generic values-free system copy', () => {
+    const secret = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'link_secret_unavailable', deliveryId: DELIVERY_ID,
+    })
+    const wrapper = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'wrapper_not_found', deliveryId: DELIVERY_ID,
+    })
+    expect(secret?.statusText).toBe(DINGTALK_APPROVAL_CARD_SYSTEM_UNAVAILABLE_TEXT)
+    expect(wrapper?.statusText).toBe(secret?.statusText)
+  })
+
+  it('non-recipient / permission denied → 当前账号无权处理该审批', () => {
+    const forbidden = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'engine_rejected', deliveryId: DELIVERY_ID, code: 'APPROVAL_ASSIGNMENT_REQUIRED', httpStatus: 403, summary: canarySummary({}, { status: 'pending' }),
+    })
+    expect(forbidden?.statusText).toBe(DINGTALK_APPROVAL_CARD_NO_PERMISSION_TEXT)
+
+    // The engine's assignee gate code maps to the same copy even if the HTTP class drifts.
+    const codeOnly = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'engine_rejected', deliveryId: DELIVERY_ID, code: 'APPROVAL_ASSIGNMENT_REQUIRED', httpStatus: 422, summary: canarySummary({}, { status: 'pending' }),
+    })
+    expect(codeOnly?.statusText).toBe(DINGTALK_APPROVAL_CARD_NO_PERMISSION_TEXT)
+  })
+
+  it('engine validation error → reason-coded copy, stable code only, NO values', () => {
+    const update = buildDingTalkApprovalCardTerminalUpdate({
+      outcome: 'engine_rejected', deliveryId: DELIVERY_ID, code: 'VALIDATION_ERROR', httpStatus: 400, summary: canarySummary({}, { status: 'pending' }),
+    })
+    expect(update?.statusText).toBe('无法处理该审批（VALIDATION_ERROR）')
+  })
+
+  it('parse-level rejections and unsupported actions are a NO-OP (no card update built)', () => {
+    expect(buildDingTalkApprovalCardTerminalUpdate({ outcome: 'rejected', reason: 'payload_not_object' })).toBeNull()
+    expect(buildDingTalkApprovalCardTerminalUpdate({ outcome: 'ignored_unsupported_action', outTrackId: DELIVERY_ID })).toBeNull()
+  })
+
+  it('VALUES-FREE fence: no summary identifier/title/request field ever reaches the terminal copy', () => {
+    const results: DingTalkApprovalCardCallbackResult[] = [
+      executed(),
+      { outcome: 'stale', deliveryId: DELIVERY_ID, summary: canarySummary() },
+      { outcome: 'stale', deliveryId: DELIVERY_ID, summary: canarySummary({ cardState: 'superseded', actedAction: null, actedAt: null }, { status: 'pending' }) },
+      { outcome: 'engine_rejected', deliveryId: DELIVERY_ID, code: 'VALIDATION_ERROR', httpStatus: 400, summary: canarySummary({}, { status: 'pending' }) },
+    ]
+    for (const result of results) {
+      const update = buildDingTalkApprovalCardTerminalUpdate(result, { operatorDisplayName: '张审批' })
+      expect(update).not.toBeNull()
+      for (const canary of CANARIES) {
+        expect(update!.statusText).not.toContain(canary)
+      }
+    }
+  })
+})
+
+describe('applyDingTalkApprovalCardTerminalUpdate (presentation follow-up, never the source of truth)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('sends the built update through the injected sender', async () => {
+    const sends: unknown[] = []
+    const outcome = await applyDingTalkApprovalCardTerminalUpdate(
+      executed(),
+      { operatorDisplayName: '张审批' },
+      async (update) => { sends.push(update) },
+    )
+    expect(outcome).toEqual({ status: 'updated', outTrackId: DELIVERY_ID })
+    expect(sends).toEqual([{ outTrackId: DELIVERY_ID, statusText: `已由 张审批 同意 · ${ACTED_AT_TEXT}` }])
+  })
+
+  it('NO ROLLBACK: a failing card update resolves to a typed failure — it never throws back into the action path', async () => {
+    const outcome = await applyDingTalkApprovalCardTerminalUpdate(
+      executed(),
+      { operatorDisplayName: '张审批' },
+      async () => { throw new Error('DingTalk 5xx with card payload details') },
+    )
+    expect(outcome).toEqual({ status: 'failed', outTrackId: DELIVERY_ID, reason: 'Error' })
+  })
+
+  it('no-op outcomes skip without touching the sender', async () => {
+    const sender = vi.fn()
+    const outcome = await applyDingTalkApprovalCardTerminalUpdate(
+      { outcome: 'rejected', reason: 'payload_not_object' },
+      {},
+      sender,
+    )
+    expect(outcome).toEqual({ status: 'skipped', reason: 'no_update_for_outcome' })
+    expect(sender).not.toHaveBeenCalled()
+  })
+
+  it('without an injected sender the production sender is env-gated: stream config off → skipped, zero network', async () => {
+    vi.stubEnv('DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED', '')
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const outcome = await applyDingTalkApprovalCardTerminalUpdate(executed(), { operatorDisplayName: '张审批' })
+    expect(outcome).toEqual({ status: 'skipped', reason: 'stream_config_disabled' })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(createDingTalkApprovalCardStreamUpdateSender()).toBeNull()
+  })
+
+  it('production sender: stream credentials → app token → PUT /v1.0/card/instances with the terminal statusText', async () => {
+    __resetDingTalkAppAccessTokenCacheForTests()
+    vi.stubEnv('DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED', '1')
+    vi.stubEnv('DINGTALK_INTERACTIVE_CARD_CLIENT_ID', 'stream-client-id')
+    vi.stubEnv('DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET', 'stream-client-secret')
+    vi.stubEnv('DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID', 'tmpl-1')
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, access_token: 'app-tok', expires_in: 7200 }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const outcome = await applyDingTalkApprovalCardTerminalUpdate(executed(), { operatorDisplayName: '张审批' })
+    expect(outcome).toEqual({ status: 'updated', outTrackId: DELIVERY_ID })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const [tokenUrl] = fetchMock.mock.calls[0] as [string]
+    expect(tokenUrl).toContain('/gettoken?appkey=stream-client-id&appsecret=stream-client-secret')
+    const [updateUrl, updateInit] = fetchMock.mock.calls[1] as [string, RequestInit]
+    expect(updateUrl).toBe('https://api.dingtalk.com/v1.0/card/instances')
+    expect(updateInit.method).toBe('PUT')
+    expect((updateInit.headers as Record<string, string>)['x-acs-dingtalk-access-token']).toBe('app-tok')
+    expect(JSON.parse(String(updateInit.body))).toMatchObject({
+      outTrackId: DELIVERY_ID,
+      cardData: { cardParamMap: { statusText: `已由 张审批 同意 · ${ACTED_AT_TEXT}` } },
+    })
+    __resetDingTalkAppAccessTokenCacheForTests()
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
@@ -4,6 +4,7 @@ import {
   readDingTalkMessageConfig,
   sendDingTalkInteractiveApprovalCard,
   sendDingTalkWorkNotification,
+  updateDingTalkInteractiveApprovalCard,
 } from '../../src/integrations/dingtalk/client'
 
 describe('dingtalk work notification client', () => {
@@ -220,6 +221,94 @@ describe('dingtalk work notification client', () => {
         rejectUrl: 'https://ms.example.test/m/approval-decision?d=delivery-1&t=token',
       },
     )).rejects.toThrow('create-and-deliver rejected')
+  })
+
+  it('B-4 sends the official card-instances update shape (statusText only, update-by-key)', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      result: true,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await updateDingTalkInteractiveApprovalCard(
+      'app-access-token',
+      {
+        outTrackId: 'delivery-1',
+        statusText: '已由 张审批 同意 · 2026/07/10 14:30',
+      },
+      { openApiBaseUrl: 'https://api.dingtalk.test/' },
+    )
+
+    expect(result.raw).toEqual({ success: true, result: true })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://api.dingtalk.test/v1.0/card/instances')
+    expect(init.method).toBe('PUT')
+    expect(init.headers).toEqual({
+      'Content-Type': 'application/json',
+      'x-acs-dingtalk-access-token': 'app-access-token',
+    })
+    // Values-free fence (B-2 §5 / B-4): the update carries statusText ONLY — no form values, no
+    // extra params can ride the terminal update.
+    expect(JSON.parse(String(init.body))).toEqual({
+      outTrackId: 'delivery-1',
+      cardData: {
+        cardParamMap: {
+          statusText: '已由 张审批 同意 · 2026/07/10 14:30',
+        },
+      },
+      cardUpdateOptions: { updateCardDataByKey: true },
+    })
+  })
+
+  it('B-4 update fails closed when the API returns HTTP 200 with success=false', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      success: false,
+      message: 'card instance not found',
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(updateDingTalkInteractiveApprovalCard(
+      'app-access-token',
+      { outTrackId: 'delivery-1', statusText: '已同意' },
+    )).rejects.toThrow('card instance not found')
+  })
+
+  it('B-4 update fails closed on HTTP-200 with a missing success flag (never assume success)', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      result: true,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(updateDingTalkInteractiveApprovalCard(
+      'app-access-token',
+      { outTrackId: 'delivery-1', statusText: '已同意' },
+    )).rejects.toThrow(/update failed/)
+  })
+
+  it('B-4 update surfaces HTTP errors as typed request failures', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      message: 'invalid token',
+    }), { status: 401, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(updateDingTalkInteractiveApprovalCard(
+      'app-access-token',
+      { outTrackId: 'delivery-1', statusText: '已同意' },
+    )).rejects.toThrow('invalid token')
+  })
+
+  it('B-4 update refuses empty token / outTrackId / statusText without calling the API', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(updateDingTalkInteractiveApprovalCard('', { outTrackId: 'delivery-1', statusText: '已同意' }))
+      .rejects.toThrow('access token is required')
+    await expect(updateDingTalkInteractiveApprovalCard('token', { outTrackId: '  ', statusText: '已同意' }))
+      .rejects.toThrow('outTrackId is required')
+    await expect(updateDingTalkInteractiveApprovalCard('token', { outTrackId: 'delivery-1', statusText: ' ' }))
+      .rejects.toThrow('status text is required')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('B-2 fails closed when create-and-deliver omits delivery results', async () => {


### PR DESCRIPTION
Implements design-lock §B-4 (`approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md`).

## Summary
- `interactive-card-update.ts`: outcome→card-copy mapping per the lock table — success approve → `已由 <服务端本地显示名> 同意 · <时间>`; stale/duplicate → true terminal state from summary; unmapped operator → `请先在网页端绑定钉钉后再处理`; permission denied → `当前账号无权处理该审批`; engine validation → reason-coded values-free copy; **update failure after a committed action → never rolls back** (orchestrator resolves, values-free log, duplicates converge via stale summary; builder+sender-resolve inside try so never-throws is structural — review P3-1).
- **No existence oracle (B-3 review P3-H)**: `delivery_not_found` and EVERY `operator_unresolved` reason (incl. the owner-gate's `integration_unpinned`) render BYTE-EQUAL copy — which IS the lock's bind-first text, so both contracts hold simultaneously (review arbitration 1).
- Silent skip for parse-level `ignored_unsupported_action` — lock-compliant "no-op" branch and defensively correct: that outTrackId is ledger-unverified (review arbitration 2, mutation-pinned).
- `client.ts`: interactive-card update API (PUT /v1.0/card/instances), statusText-only, same auth/error idioms as createAndDeliver, fail-closed on unacknowledged success.
- Hook in the B-3 callback executor at outcome production; display names from server-side local user data only.

## Verification
- Adversarial review APPROVE (MD `/tmp/w2a-b4-review-claude-20260710.md`): 5 mutations red (P3-H byte-equality ×2, no-rollback rethrow ×2, delivery-id leak ×6 asserts, client fail-closed weaken, skip neuter ×2); review's P2 landing discipline followed — the rebase conflict resolved WITHOUT resurrecting the retired legacy secret resolver (0 references; owner cross-corp gate intact).
- Suites 76/76 + update 17/17; full unit 362 files / 4974 green; tsc clean.

Not shipped: live UAT; flag stays OFF (`DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` default off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
