### PR TITLE
feat(dingtalk): official Stream SDK adapter — card-topic-only, shutdown-race fix, credential-blanking close

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -41,6 +41,7 @@
     "axios": "^1.8.0",
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
+    "dingtalk-stream": "^2.1.5",
     "eventemitter3": "^5.0.1",
     "express": "^4.18.2",
     "geoip-lite": "^1.4.10",

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
@@ -1,0 +1,184 @@
+/**
+ * Slice-B SDK adapter: wires the official DingTalk Stream SDK (`dingtalk-stream`,
+ * github.com/open-dingtalk/dingtalk-stream-sdk-nodejs) as the production
+ * `DingTalkInteractiveCardStreamClient` behind the B-1 factory seam.
+ *
+ * Import discipline (B-1 gate invariant): this module is loaded ONLY via dynamic import from the
+ * worker's default client factory, which runs strictly after the env gate resolved enabled — with
+ * the flag off (the default) neither this module nor `dingtalk-stream` (ws/axios transport) is
+ * ever imported. The `dingtalk-stream` import below is itself dynamic so merely loading this
+ * module stays side-effect-free as well.
+ *
+ * Topic discipline: subscribes ONLY to the card-callback topic (the SDK's `TOPIC_CARD`,
+ * `/v1.0/card/instances/callback`). The SDK's default wildcard EVENT subscription is dropped
+ * before connecting so the gateway registration carries exactly that one CALLBACK subscription.
+ * Frames are threaded into the worker's existing `handlers.onEvent` seam unchanged — semantic
+ * parsing of the payload stays owned by the B-3 callback adapter.
+ *
+ * Reconnect: the SDK's built-in reconnect (`autoReconnect`, default on) owns retry after
+ * transport drops and CONNECT failures; `close()` disables it BEFORE disconnecting so an
+ * already-scheduled reconnect timer can never resurrect the connection after shutdown (the SDK
+ * clears its own user-disconnect latch on every connection attempt).
+ *
+ * Values-free logging: this adapter logs reason categories only — never frame data, card
+ * payloads, operator ids, or credentials. The SDK's `debug` mode is NEVER enabled: it dumps the
+ * full client config — including the client secret — to the console.
+ */
+import { Logger } from '../../core/logger'
+import {
+  DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED_ERROR,
+  type DingTalkInteractiveCardStreamClient,
+  type DingTalkInteractiveCardStreamConfig,
+  type DingTalkInteractiveCardStreamHandlers,
+} from './interactive-card-stream'
+
+type EnabledStreamConfig = Extract<DingTalkInteractiveCardStreamConfig, { enabled: true }>
+
+/**
+ * Shape of a downstream frame as delivered by the SDK's callback listener (`DWClientDownStream`),
+ * kept structurally loose: every field is re-validated here before use.
+ */
+export type DingTalkStreamDownStreamFrame = {
+  type?: string
+  headers?: {
+    messageId?: string
+    topic?: string
+  }
+  /** JSON-encoded card-callback payload (a string on the wire). */
+  data?: unknown
+}
+
+/**
+ * The narrow slice of the SDK's `DWClient` this adapter relies on (structurally satisfied by the
+ * real class). Keeping the surface minimal pins exactly what an SDK upgrade must preserve.
+ */
+export type DingTalkStreamClientLike = {
+  config: {
+    subscriptions: Array<{ type: string; topic: string }>
+    autoReconnect?: boolean
+  }
+  registerCallbackListener(topic: string, listener: (frame: DingTalkStreamDownStreamFrame) => void): unknown
+  connect(): Promise<void>
+  disconnect(): void
+  /** Acks a pushed frame so the gateway stops re-delivering it (~60s retry window otherwise). */
+  socketCallBackResponse(messageId: string, response: unknown): void
+}
+
+export type DingTalkStreamSdkModule = {
+  DWClient: new (opts: {
+    clientId: string
+    clientSecret: string
+    keepAlive?: boolean
+    debug?: boolean
+  }) => DingTalkStreamClientLike
+  /** Card-callback topic constant (`/v1.0/card/instances/callback`). */
+  TOPIC_CARD: string
+}
+
+async function importDingTalkStreamSdk(): Promise<DingTalkStreamSdkModule> {
+  return import('dingtalk-stream')
+}
+
+/**
+ * Transport-frame handling: validate framing, ack, JSON-decode, and thread the decoded payload
+ * into the worker's `handleEvent` seam. Malformed frames are rejected values-free (reason
+ * category only — the raw wire bytes are never logged and never forwarded).
+ */
+async function handleCardCallbackFrame(
+  client: DingTalkStreamClientLike,
+  frame: DingTalkStreamDownStreamFrame,
+  handlers: DingTalkInteractiveCardStreamHandlers,
+  logger: Pick<Logger, 'info' | 'warn'>,
+): Promise<void> {
+  const messageId = typeof frame?.headers?.messageId === 'string' ? frame.headers.messageId : ''
+
+  // Ack first (empty card response — no card update, no frame data echoed back): the gateway
+  // re-pushes unacked callbacks for ~60s, and the B-3 executor behind onEvent may legitimately be
+  // slow (engine execution). B-3's ledger/stale handling keeps redelivery harmless, but acking up
+  // front avoids systematic duplicate deliveries. Malformed frames are acked too — they will
+  // never become well-formed on retry.
+  if (messageId) {
+    try {
+      client.socketCallBackResponse(messageId, {})
+    } catch {
+      logger.warn('DingTalk interactive-card Stream frame ack failed (ack_failed)')
+    }
+  }
+
+  if (typeof frame?.data !== 'string') {
+    logger.warn('DingTalk interactive-card Stream frame rejected (malformed_frame:data_not_string)')
+    return
+  }
+  let payload: unknown
+  try {
+    payload = JSON.parse(frame.data)
+  } catch {
+    // Values-free reject: never log (or forward) unparseable wire bytes.
+    logger.warn('DingTalk interactive-card Stream frame rejected (malformed_frame:data_not_json)')
+    return
+  }
+
+  try {
+    await handlers.onEvent({
+      eventType: typeof frame.type === 'string' ? frame.type : undefined,
+      eventId: messageId || undefined,
+      payload,
+    })
+  } catch {
+    // The worker's handleEvent is designed to never throw; belt-and-braces so a rejection can
+    // never surface as an unhandled rejection inside the SDK's EventEmitter dispatch.
+    logger.warn('DingTalk interactive-card Stream event dispatch failed (event_dispatch_failed)')
+  }
+}
+
+export async function createDingTalkInteractiveCardStreamSdkClient(
+  config: EnabledStreamConfig,
+  handlers: DingTalkInteractiveCardStreamHandlers,
+  seams: {
+    logger?: Pick<Logger, 'info' | 'warn'>
+    /** Test seam: SDK module override. Production loads the real `dingtalk-stream` package. */
+    loadSdk?: () => Promise<DingTalkStreamSdkModule>
+  } = {},
+): Promise<DingTalkInteractiveCardStreamClient> {
+  const logger = seams.logger ?? new Logger('DingTalkInteractiveCardStreamSdk')
+
+  let sdk: DingTalkStreamSdkModule
+  try {
+    sdk = await (seams.loadSdk ?? importDingTalkStreamSdk)()
+  } catch {
+    // SDK module genuinely unavailable: surface the honest unwired sentinel (the worker maps it
+    // to `{ state: 'failed', reason: 'sdk_unwired' }`) instead of a generic start failure.
+    throw new Error(DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED_ERROR)
+  }
+
+  const client = new sdk.DWClient({
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    // Client-side ping/pong heartbeat so half-dead connections are terminated and reconnected.
+    keepAlive: true,
+    // NEVER enable: SDK debug mode dumps the full config — including the client secret.
+    debug: false,
+  })
+
+  // Subscribe ONLY to the card-callback topic: drop the SDK's default wildcard EVENT
+  // subscription so the gateway registration carries exactly the CALLBACK topic added below.
+  client.config.subscriptions.length = 0
+  client.registerCallbackListener(sdk.TOPIC_CARD, (frame) => {
+    void handleCardCallbackFrame(client, frame, handlers, logger)
+  })
+
+  return {
+    async start() {
+      // The SDK owns retry from here: CONNECT/registration failures and later transport drops are
+      // re-attempted by its built-in reconnect loop (autoReconnect, default on).
+      await client.connect()
+    },
+    async close() {
+      // Disable the built-in reconnect FIRST — the SDK resets its own user-disconnect latch on
+      // every connection attempt, so a pending reconnect timer could otherwise reconnect after
+      // shutdown — then close the socket (a no-op if the client never connected).
+      client.config.autoReconnect = false
+      client.disconnect()
+    },
+  }
+}

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
@@ -56,6 +56,9 @@ export type DingTalkStreamClientLike = {
   config: {
     subscriptions: Array<{ type: string; topic: string }>
     autoReconnect?: boolean
+    // P2-1: close() blanks these to kill an already-scheduled SDK reconnect (see close()).
+    clientId?: string
+    clientSecret?: string
   }
   registerCallbackListener(topic: string, listener: (frame: DingTalkStreamDownStreamFrame) => void): unknown
   connect(): Promise<void>
@@ -174,10 +177,17 @@ export async function createDingTalkInteractiveCardStreamSdkClient(
       await client.connect()
     },
     async close() {
-      // Disable the built-in reconnect FIRST — the SDK resets its own user-disconnect latch on
-      // every connection attempt, so a pending reconnect timer could otherwise reconnect after
-      // shutdown — then close the socket (a no-op if the client never connected).
+      // Review P2-1 (proved against the real SDK dist): disabling autoReconnect does NOT stop an
+      // ALREADY-SCHEDULED reconnect timer — the SDK checks its reconnect gate only at SCHEDULE
+      // time, connect() never re-checks it, and _connect() resets the user-disconnect latch. A
+      // retry timer pending at shutdown (guaranteed during any outage — 1s chain) would resurrect
+      // the connection after close(). Defense: ALSO blank the credentials so a resurrected
+      // connect() dies at endpoint resolution — and with autoReconnect false at that point, no
+      // further retry is scheduled from that failure. Then close the socket (no-op if never
+      // connected).
       client.config.autoReconnect = false
+      client.config.clientId = ''
+      client.config.clientSecret = ''
       client.disconnect()
     },
   }

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts
@@ -6,7 +6,10 @@
  * is ever created, so no callback can execute.
  *
  * This module stays import-side-effect-free: the production callback executor (db pool +
- * ApprovalProductService) is materialized lazily via dynamic import on the first callback event.
+ * ApprovalProductService) is materialized lazily via dynamic import on the first callback event,
+ * and the production client factory (official `dingtalk-stream` SDK adapter,
+ * `interactive-card-stream-sdk.ts`) is materialized lazily via dynamic import only after the env
+ * gate resolved enabled.
  */
 import { Logger } from '../../core/logger'
 import type { DingTalkApprovalCardCallbackResult } from './interactive-card-callback'
@@ -121,8 +124,28 @@ export function resolveDingTalkInteractiveCardStreamConfig(
   }
 }
 
+/** Sentinel error message for a genuinely unavailable Stream SDK (worker maps it to `sdk_unwired`). */
+export const DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED_ERROR = 'DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED'
+
+/**
+ * Explicit unwired seam (tests / SDK-less builds): always fails with the `sdk_unwired` sentinel.
+ * Production defaults to `defaultDingTalkInteractiveCardStreamClientFactory` below instead.
+ */
 export const unwiredDingTalkInteractiveCardStreamClientFactory: DingTalkInteractiveCardStreamClientFactory = async () => {
-  throw new Error('DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED')
+  throw new Error(DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED_ERROR)
+}
+
+/**
+ * Production default: the official DingTalk Stream SDK adapter (`dingtalk-stream`), materialized
+ * via dynamic import ONLY when this factory runs — and the worker invokes its factory strictly
+ * after the env gate resolved enabled, so with the flag off (the default) neither the adapter
+ * module nor the SDK (ws/axios transport) is ever imported. If the SDK package is genuinely
+ * absent from the install, the adapter throws the `sdk_unwired` sentinel and the worker reports
+ * `{ state: 'failed', reason: 'sdk_unwired' }` instead of pretending to be active.
+ */
+export const defaultDingTalkInteractiveCardStreamClientFactory: DingTalkInteractiveCardStreamClientFactory = async (config, handlers) => {
+  const { createDingTalkInteractiveCardStreamSdkClient } = await import('./interactive-card-stream-sdk')
+  return createDingTalkInteractiveCardStreamSdkClient(config, handlers)
 }
 
 /**
@@ -160,6 +183,13 @@ export class DingTalkInteractiveCardStreamWorker {
   private client: DingTalkInteractiveCardStreamClient | null = null
   private initializing: Promise<DingTalkInteractiveCardStreamWorkerStatus> | null = null
   private status: DingTalkInteractiveCardStreamWorkerStatus = { state: 'disabled', reason: 'env_disabled' }
+  /**
+   * Shutdown latch (B-2 review P3-1, W1b-confirmed race): shutdown() sets this even when
+   * `this.client` is still null — exactly the state while initializeOnce() is awaiting the client
+   * factory / start(). The in-flight initialize re-checks the latch after every await and closes
+   * the client it just created instead of activating a worker that is supposed to be dead.
+   */
+  private shutdownRequested = false
 
   constructor(options: {
     logger?: Pick<Logger, 'info' | 'warn'>
@@ -168,7 +198,7 @@ export class DingTalkInteractiveCardStreamWorker {
     callbackExecutor?: DingTalkInteractiveCardCallbackExecutor
   } = {}) {
     this.logger = options.logger ?? new Logger('DingTalkInteractiveCardStreamWorker')
-    this.clientFactory = options.clientFactory ?? unwiredDingTalkInteractiveCardStreamClientFactory
+    this.clientFactory = options.clientFactory ?? defaultDingTalkInteractiveCardStreamClientFactory
     this.callbackExecutor = options.callbackExecutor ?? null
   }
 
@@ -180,6 +210,9 @@ export class DingTalkInteractiveCardStreamWorker {
     if (this.initializing) return this.initializing
     if (this.client && this.status.state === 'active') return this.status
 
+    // A fresh initialize (not piggybacking on an in-flight one) starts a new lifecycle: clear any
+    // latch left behind by an earlier shutdown so the worker can be deliberately restarted.
+    this.shutdownRequested = false
     this.initializing = this.initializeOnce(env).finally(() => {
       this.initializing = null
     })
@@ -201,7 +234,15 @@ export class DingTalkInteractiveCardStreamWorker {
           await this.handleEvent(event)
         },
       })
+      // Shutdown latch re-check after every await (B-2 review P3-1): a shutdown() that landed
+      // while this initialize was in flight must win — close what we created, never go active.
+      if (this.shutdownRequested) {
+        return this.abortInFlightInitialize(createdClient)
+      }
       await createdClient.start()
+      if (this.shutdownRequested) {
+        return this.abortInFlightInitialize(createdClient)
+      }
       this.client = createdClient
       this.status = { state: 'active' }
       this.logger.info('DingTalk interactive-card Stream worker started')
@@ -225,8 +266,35 @@ export class DingTalkInteractiveCardStreamWorker {
     }
   }
 
+  /**
+   * Closes the in-flight initialize's client after a raced shutdown() and finalizes status.
+   * Mirrors the normal shutdown() outcome shape so callers cannot tell the two paths apart.
+   */
+  private async abortInFlightInitialize(
+    createdClient: DingTalkInteractiveCardStreamClient,
+  ): Promise<DingTalkInteractiveCardStreamWorkerStatus> {
+    this.client = null
+    try {
+      await createdClient.close()
+      this.status = { state: 'disabled', reason: 'env_disabled' }
+      this.logger.info('DingTalk interactive-card Stream worker start aborted (shutdown_during_initialize)')
+    } catch {
+      this.status = { state: 'failed', reason: 'client_stop_failed' }
+      this.logger.warn('DingTalk interactive-card Stream worker failed to stop (client_stop_failed)')
+    }
+    return this.status
+  }
+
   async shutdown(): Promise<DingTalkInteractiveCardStreamWorkerStatus> {
-    if (!this.client) return this.status
+    this.shutdownRequested = true
+    if (!this.client) {
+      if (this.initializing) {
+        // In-flight initialize observes the latch after its awaited factory/start() and closes the
+        // client it created (abortInFlightInitialize); there is nothing to close from here yet.
+        this.logger.info('DingTalk interactive-card Stream worker shutdown latched during in-flight initialize')
+      }
+      return this.status
+    }
     try {
       await this.client.close()
       this.client = null

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts
@@ -81,6 +81,12 @@ export type DingTalkInteractiveCardStreamClientFactory = (
 
 export type DingTalkInteractiveCardStreamWorkerStatus =
   | { state: 'disabled'; reason: DingTalkInteractiveCardStreamDisabledReason }
+  // Review P2-2 (proved against the real SDK dist): the SDK's connect() RESOLVES even on total
+  // failure (bad credentials, unreachable endpoint) and retries internally forever — so 'active'
+  // means "worker running; connection lifecycle delegated to the SDK", NOT "connected". A
+  // misconfigured-but-enabled worker reports active while the SDK silently retries; real
+  // connectivity is a UAT checklist item (U12/U13), and 'client_start_failed' is reachable only
+  // through factory/setup throws, never through a connect() rejection.
   | { state: 'active' }
   | { state: 'failed'; reason: 'client_start_failed' | 'client_stop_failed' | 'sdk_unwired' }
 
@@ -244,6 +250,7 @@ export class DingTalkInteractiveCardStreamWorker {
         return this.abortInFlightInitialize(createdClient)
       }
       this.client = createdClient
+      // 'active' = running-with-SDK-owned-connection, not proven-connected (see status type doc).
       this.status = { state: 'active' }
       this.logger.info('DingTalk interactive-card Stream worker started')
       return this.status

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-default-factory.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-default-factory.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Import-discipline lock for the production default client factory (SDK-adapter slice).
+ *
+ * With the env flag OFF (the default), constructing + initializing the worker must have ZERO SDK
+ * side effects: neither the adapter module (`interactive-card-stream-sdk.ts`) nor the
+ * `dingtalk-stream` package may even be imported. With the flag ON, the default factory routes
+ * through the adapter module exactly once (dynamic import inside the gated path only).
+ *
+ * Both modules are vi.mocked with load-counting factories; the counters can only move if a
+ * dynamic import actually happens — this file itself never imports either statically.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV,
+  DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV,
+  DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV,
+  DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV,
+  DingTalkInteractiveCardStreamWorker,
+} from '../../src/integrations/dingtalk/interactive-card-stream'
+
+const loads = vi.hoisted(() => ({
+  sdkPackage: 0,
+  adapterModule: 0,
+  createClient: vi.fn(),
+}))
+
+vi.mock('dingtalk-stream', () => {
+  loads.sdkPackage += 1
+  return {}
+})
+
+vi.mock('../../src/integrations/dingtalk/interactive-card-stream-sdk', () => {
+  loads.adapterModule += 1
+  return {
+    createDingTalkInteractiveCardStreamSdkClient: (...args: unknown[]) => loads.createClient(...args),
+  }
+})
+
+function logger() {
+  return { info: vi.fn(), warn: vi.fn() }
+}
+
+describe('DingTalk interactive-card Stream default factory import discipline', () => {
+  it('flag OFF (default): initialize() has zero SDK side effects — adapter and SDK never imported', async () => {
+    const worker = new DingTalkInteractiveCardStreamWorker({ logger: logger() })
+
+    await expect(worker.initialize({} as NodeJS.ProcessEnv)).resolves.toEqual({
+      state: 'disabled',
+      reason: 'env_disabled',
+    })
+
+    expect(loads.adapterModule).toBe(0)
+    expect(loads.sdkPackage).toBe(0)
+    expect(loads.createClient).not.toHaveBeenCalled()
+  })
+
+  it('flag ON: the default factory dynamically imports the SDK adapter and starts its client', async () => {
+    const client = { start: vi.fn(async () => {}), close: vi.fn(async () => {}) }
+    loads.createClient.mockResolvedValue(client)
+    const worker = new DingTalkInteractiveCardStreamWorker({ logger: logger() })
+
+    await expect(worker.initialize({
+      [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+      [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+      [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: 'secret-1',
+      [DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]: 'template-1',
+    } as NodeJS.ProcessEnv)).resolves.toEqual({ state: 'active' })
+
+    expect(loads.adapterModule).toBe(1)
+    expect(loads.createClient).toHaveBeenCalledTimes(1)
+    expect(loads.createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true, clientId: 'client-1', templateId: 'template-1' }),
+      expect.objectContaining({ onEvent: expect.any(Function) }),
+    )
+    expect(client.start).toHaveBeenCalledTimes(1)
+    // The mocked adapter never touches the real package.
+    expect(loads.sdkPackage).toBe(0)
+
+    await expect(worker.shutdown()).resolves.toEqual({ state: 'disabled', reason: 'env_disabled' })
+    expect(client.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-lifecycle.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-lifecycle.test.ts
@@ -1,20 +1,19 @@
 /**
- * B-2 adversarial review P3-1 (shutdown × in-flight initialize race).
+ * B-2 adversarial review P3-1 (shutdown × in-flight initialize race) — now FIXED.
  *
  * B-1's single-flight guard (`if (this.initializing) return this.initializing`) only covers
  * initialize() called concurrently with itself — that lifecycle is already locked in
  * `dingtalk-interactive-card-stream.test.ts` ("does not start twice when initialize is called
- * concurrently or after active"). It does not cover shutdown() racing an in-flight initialize():
- * `shutdown()` early-returns whenever `this.client` is still null
- * (`packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts:181-182`), which is
- * exactly the state while `initializeOnce()` is still awaiting the client factory / `start()`. If
- * that in-flight initialize later resolves successfully, it unconditionally sets `this.client` and
- * flips status to `active` — with no knowledge that shutdown() was ever called in the meantime.
+ * concurrently or after active"). It did not cover shutdown() racing an in-flight initialize():
+ * `shutdown()` early-returned whenever `this.client` was still null — exactly the state while
+ * `initializeOnce()` was still awaiting the client factory / `start()` — and the late-resolving
+ * initialize then unconditionally activated a worker that was supposed to be dead.
  *
- * This file is intentionally NOT merged into `dingtalk-interactive-card-stream.test.ts` (a
- * different lane owns that file). It documents the desired lifecycle contract with a real,
- * runnable test and leaves it `.skip`ped rather than red, per this hardening pack's scope
- * (tests + docs only, zero runtime change).
+ * The fix (SDK-adapter slice): `shutdown()` latches `shutdownRequested`, and `initializeOnce()`
+ * re-checks the latch after every await — closing the client it just created instead of going
+ * active. The first test below was authored red against the pre-fix implementation on
+ * `claude/dt-card-b2-p3-hardening` (kept `.skip`ped there because that pack was tests+docs only)
+ * and is un-skipped here now that the runtime fix exists.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -48,15 +47,7 @@ describe('DingTalk interactive-card Stream worker lifecycle races (B-2 P3 harden
     vi.unstubAllEnvs()
   })
 
-  // KNOWN RACE — B-2 adversarial review finding P3-1 (/tmp/pr4058-review-claude-20260710.md).
-  // Mutation-verified this test is red against the CURRENT implementation (deferred-start client,
-  // shutdown() called while `initialize()` is still awaiting `start()`): shutdown() no-ops because
-  // `this.client` is still null, then the in-flight initialize resolves and unconditionally
-  // activates the client shutdown() never got a chance to close. Runtime fixes are out of scope
-  // for this hardening pack (tests + docs only) — leaving this SKIPPED rather than silently
-  // asserting the buggy behavior as if it were the contract. A real SDK adapter (B-3+) should make
-  // shutdown() await any in-flight `this.initializing` before deciding there is nothing to close.
-  it.skip('closes the client and does not end up active when shutdown() races an in-flight initialize()', async () => {
+  it('closes the client and does not end up active when shutdown() races an in-flight initialize()', async () => {
     const log = logger()
     let resolveStart!: () => void
     const client: DingTalkInteractiveCardStreamClient = {
@@ -77,11 +68,65 @@ describe('DingTalk interactive-card Stream worker lifecycle races (B-2 P3 harden
     resolveStart()
     const initializeResult = await initializePromise
 
-    // Desired lifecycle contract: a shutdown() that lands during an in-flight initialize() must
-    // not leave a connected client behind, and the worker must not report itself active afterward.
+    // Lifecycle contract: a shutdown() that lands during an in-flight initialize() must not leave
+    // a connected client behind, and the worker must not report itself active afterward.
     expect(client.close).toHaveBeenCalledTimes(1)
     expect(initializeResult.state).not.toBe('active')
     expect(worker.getStatus().state).not.toBe('active')
     expect(shutdownResult.state).not.toBe('active')
+  })
+
+  it('never even starts the client when shutdown() lands while the factory is still in flight', async () => {
+    const log = logger()
+    const client: DingTalkInteractiveCardStreamClient = {
+      start: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+    }
+    let resolveFactory!: (created: DingTalkInteractiveCardStreamClient) => void
+    const factory = vi.fn<DingTalkInteractiveCardStreamClientFactory>(
+      () => new Promise<DingTalkInteractiveCardStreamClient>((resolve) => { resolveFactory = resolve }),
+    )
+    const worker = new DingTalkInteractiveCardStreamWorker({ logger: log, clientFactory: factory })
+
+    const initializePromise = worker.initialize(activeEnv)
+    await vi.waitFor(() => expect(factory).toHaveBeenCalledTimes(1))
+
+    await worker.shutdown()
+    resolveFactory(client)
+    const initializeResult = await initializePromise
+
+    // The latch is observed before start(): the freshly created client is closed, never started.
+    expect(client.start).not.toHaveBeenCalled()
+    expect(client.close).toHaveBeenCalledTimes(1)
+    expect(initializeResult.state).not.toBe('active')
+    expect(worker.getStatus().state).not.toBe('active')
+  })
+
+  it('allows a deliberate fresh initialize() after a raced shutdown (latch is per-lifecycle)', async () => {
+    const log = logger()
+    let resolveStart!: () => void
+    const firstClient: DingTalkInteractiveCardStreamClient = {
+      start: vi.fn(() => new Promise<void>((resolve) => { resolveStart = resolve })),
+      close: vi.fn(async () => {}),
+    }
+    const secondClient: DingTalkInteractiveCardStreamClient = {
+      start: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+    }
+    const factory = vi.fn<DingTalkInteractiveCardStreamClientFactory>(async () => firstClient)
+    const worker = new DingTalkInteractiveCardStreamWorker({ logger: log, clientFactory: factory })
+
+    const initializePromise = worker.initialize(activeEnv)
+    await vi.waitFor(() => expect(firstClient.start).toHaveBeenCalledTimes(1))
+    await worker.shutdown()
+    resolveStart()
+    const racedResult = await initializePromise
+    expect(racedResult.state).not.toBe('active')
+
+    factory.mockImplementation(async () => secondClient)
+    await expect(worker.initialize(activeEnv)).resolves.toEqual({ state: 'active' })
+    expect(secondClient.start).toHaveBeenCalledTimes(1)
+    await expect(worker.shutdown()).resolves.toEqual({ state: 'disabled', reason: 'env_disabled' })
+    expect(secondClient.close).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-sdk.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-sdk.test.ts
@@ -47,10 +47,19 @@ function enabledConfig(): Extract<DingTalkInteractiveCardStreamConfig, { enabled
 
 /** Mirrors the real DWClient surface the adapter relies on, incl. subscription bookkeeping. */
 class FakeDWClient {
-  config: { subscriptions: Array<{ type: string; topic: string }>; autoReconnect?: boolean } = {
+  config: {
+    subscriptions: Array<{ type: string; topic: string }>
+    autoReconnect?: boolean
+    clientId?: string
+    clientSecret?: string
+  } = {
     // Real SDK default: a wildcard EVENT subscription the adapter must drop.
     subscriptions: [{ type: 'EVENT', topic: '*' }],
     autoReconnect: true,
+    // Real SDK behavior: the ctor copies credentials onto config, where a late reconnect reads
+    // them (P2-1 — close() must blank these to kill an already-scheduled reconnect timer).
+    clientId: 'client-1',
+    clientSecret: 'secret-1',
   }
 
   listeners = new Map<string, (frame: DingTalkStreamDownStreamFrame) => void>()
@@ -138,6 +147,11 @@ describe('DingTalk interactive-card Stream SDK adapter', () => {
     expect(dw.disconnect).toHaveBeenCalledTimes(1)
     expect(autoReconnectAtDisconnect).toBe(false)
     expect(dw.config.autoReconnect).toBe(false)
+    // Review P2-1: an ALREADY-SCHEDULED SDK reconnect timer survives the autoReconnect flip (the
+    // gate is checked at schedule time only) — close() must ALSO blank the credentials so a
+    // resurrected connect() dies at endpoint resolution and schedules nothing further.
+    expect(dw.config.clientId).toBe('')
+    expect(dw.config.clientSecret).toBe('')
   })
 
   it('threads a card-callback frame into handlers.onEvent with the JSON-decoded payload and acks it', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-sdk.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-sdk.test.ts
@@ -1,0 +1,269 @@
+/**
+ * SDK-adapter slice: `createDingTalkInteractiveCardStreamSdkClient` against a mocked
+ * `dingtalk-stream` module (injected through the `loadSdk` test seam — the real package is never
+ * touched here).
+ *
+ * Locks: card-callback-topic-only subscription, connection lifecycle (start/close incl.
+ * reconnect kill-switch ordering), frame → `handlers.onEvent` threading, malformed-frame
+ * values-free rejection, ack semantics, secrets-never-logged, and the honest `sdk_unwired`
+ * sentinel when the SDK module is genuinely unavailable.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV,
+  DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV,
+  DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV,
+  DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV,
+  DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED_ERROR,
+  DingTalkInteractiveCardStreamWorker,
+  resolveDingTalkInteractiveCardStreamConfig,
+  type DingTalkInteractiveCardStreamConfig,
+  type DingTalkInteractiveCardStreamEvent,
+  type DingTalkInteractiveCardStreamHandlers,
+} from '../../src/integrations/dingtalk/interactive-card-stream'
+import {
+  createDingTalkInteractiveCardStreamSdkClient,
+  type DingTalkStreamDownStreamFrame,
+  type DingTalkStreamSdkModule,
+} from '../../src/integrations/dingtalk/interactive-card-stream-sdk'
+
+const TOPIC_CARD = '/v1.0/card/instances/callback'
+
+function logger() {
+  return { info: vi.fn(), warn: vi.fn() }
+}
+
+function enabledConfig(): Extract<DingTalkInteractiveCardStreamConfig, { enabled: true }> {
+  const config = resolveDingTalkInteractiveCardStreamConfig({
+    [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+    [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+    [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: 'secret-1',
+    [DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]: 'template-1',
+  } as NodeJS.ProcessEnv)
+  if (config.enabled !== true) throw new Error('fixture config must be enabled')
+  return config
+}
+
+/** Mirrors the real DWClient surface the adapter relies on, incl. subscription bookkeeping. */
+class FakeDWClient {
+  config: { subscriptions: Array<{ type: string; topic: string }>; autoReconnect?: boolean } = {
+    // Real SDK default: a wildcard EVENT subscription the adapter must drop.
+    subscriptions: [{ type: 'EVENT', topic: '*' }],
+    autoReconnect: true,
+  }
+
+  listeners = new Map<string, (frame: DingTalkStreamDownStreamFrame) => void>()
+  connect = vi.fn(async () => {})
+  disconnect = vi.fn(() => {})
+  socketCallBackResponse = vi.fn((_messageId: string, _response: unknown) => {})
+  readonly constructorOpts: Record<string, unknown>
+
+  constructor(opts: Record<string, unknown>) {
+    this.constructorOpts = opts
+  }
+
+  registerCallbackListener(topic: string, listener: (frame: DingTalkStreamDownStreamFrame) => void) {
+    // Real SDK behavior: registering a callback listener records a CALLBACK subscription.
+    if (!this.config.subscriptions.find((s) => s.topic === topic && s.type === 'CALLBACK')) {
+      this.config.subscriptions.push({ type: 'CALLBACK', topic })
+    }
+    this.listeners.set(topic, listener)
+    return this
+  }
+}
+
+function fakeSdk() {
+  const instances: FakeDWClient[] = []
+  const sdk: DingTalkStreamSdkModule = {
+    DWClient: class extends FakeDWClient {
+      constructor(opts: Record<string, unknown>) {
+        super(opts)
+        instances.push(this)
+      }
+    },
+    TOPIC_CARD,
+  }
+  return { sdk, instances }
+}
+
+async function adapter(overrides: {
+  onEvent?: DingTalkInteractiveCardStreamHandlers['onEvent']
+} = {}) {
+  const log = logger()
+  const { sdk, instances } = fakeSdk()
+  const onEvent = overrides.onEvent ?? vi.fn(async () => {})
+  const client = await createDingTalkInteractiveCardStreamSdkClient(
+    enabledConfig(),
+    { onEvent },
+    { logger: log, loadSdk: async () => sdk },
+  )
+  expect(instances).toHaveLength(1)
+  return { log, client, dw: instances[0]!, onEvent }
+}
+
+function loggedText(log: ReturnType<typeof logger>): string {
+  return JSON.stringify([...log.info.mock.calls, ...log.warn.mock.calls])
+}
+
+describe('DingTalk interactive-card Stream SDK adapter', () => {
+  it('constructs the SDK client from the gated config with debug OFF and never logs the secret', async () => {
+    const { log, dw } = await adapter()
+    expect(dw.constructorOpts).toEqual({
+      clientId: 'client-1',
+      clientSecret: 'secret-1',
+      keepAlive: true,
+      debug: false,
+    })
+    expect(loggedText(log)).not.toContain('secret-1')
+  })
+
+  it('subscribes ONLY to the card-callback topic (drops the SDK default wildcard EVENT subscription)', async () => {
+    const { dw } = await adapter()
+    expect(dw.config.subscriptions).toEqual([{ type: 'CALLBACK', topic: TOPIC_CARD }])
+    expect(dw.listeners.size).toBe(1)
+    expect(dw.listeners.has(TOPIC_CARD)).toBe(true)
+  })
+
+  it('start() connects once; close() kills the SDK reconnect BEFORE disconnecting', async () => {
+    const { client, dw } = await adapter()
+    await client.start()
+    expect(dw.connect).toHaveBeenCalledTimes(1)
+
+    let autoReconnectAtDisconnect: boolean | undefined = true
+    dw.disconnect.mockImplementation(() => {
+      autoReconnectAtDisconnect = dw.config.autoReconnect
+    })
+    await client.close()
+    expect(dw.disconnect).toHaveBeenCalledTimes(1)
+    expect(autoReconnectAtDisconnect).toBe(false)
+    expect(dw.config.autoReconnect).toBe(false)
+  })
+
+  it('threads a card-callback frame into handlers.onEvent with the JSON-decoded payload and acks it', async () => {
+    const events: DingTalkInteractiveCardStreamEvent[] = []
+    const onEvent = vi.fn(async (event: DingTalkInteractiveCardStreamEvent) => { events.push(event) })
+    const { dw } = await adapter({ onEvent })
+
+    const wirePayload = { outTrackId: 'd-1', userId: 'dd_op', content: '{"cardPrivateData":{"actionIds":["approve"]}}' }
+    dw.listeners.get(TOPIC_CARD)!({
+      type: 'CALLBACK',
+      headers: { messageId: 'msg-1', topic: TOPIC_CARD },
+      data: JSON.stringify(wirePayload),
+    })
+
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledTimes(1))
+    expect(events[0]).toEqual({
+      eventType: 'CALLBACK',
+      eventId: 'msg-1',
+      payload: wirePayload,
+    })
+    expect(dw.socketCallBackResponse).toHaveBeenCalledTimes(1)
+    expect(dw.socketCallBackResponse).toHaveBeenCalledWith('msg-1', {})
+  })
+
+  it('rejects a frame whose data is not a string: values-free warn, no onEvent, still acked', async () => {
+    const onEvent = vi.fn(async () => {})
+    const { log, dw } = await adapter({ onEvent })
+
+    dw.listeners.get(TOPIC_CARD)!({
+      type: 'CALLBACK',
+      headers: { messageId: 'msg-2', topic: TOPIC_CARD },
+      data: { SECRET_FIELD: 'SECRET_FORM_VALUE' },
+    })
+
+    await vi.waitFor(() => expect(log.warn).toHaveBeenCalledWith(
+      'DingTalk interactive-card Stream frame rejected (malformed_frame:data_not_string)',
+    ))
+    expect(onEvent).not.toHaveBeenCalled()
+    expect(dw.socketCallBackResponse).toHaveBeenCalledWith('msg-2', {})
+    expect(loggedText(log)).not.toContain('SECRET_FORM_VALUE')
+  })
+
+  it('rejects a frame whose data is not JSON: values-free warn, wire bytes never logged or forwarded', async () => {
+    const onEvent = vi.fn(async () => {})
+    const { log, dw } = await adapter({ onEvent })
+
+    dw.listeners.get(TOPIC_CARD)!({
+      type: 'CALLBACK',
+      headers: { messageId: 'msg-3', topic: TOPIC_CARD },
+      data: 'SECRET_RAW_WIRE_BYTES{{{not-json',
+    })
+
+    await vi.waitFor(() => expect(log.warn).toHaveBeenCalledWith(
+      'DingTalk interactive-card Stream frame rejected (malformed_frame:data_not_json)',
+    ))
+    expect(onEvent).not.toHaveBeenCalled()
+    expect(loggedText(log)).not.toContain('SECRET_RAW_WIRE_BYTES')
+  })
+
+  it('skips the ack (send would throw) when the frame carries no messageId', async () => {
+    const onEvent = vi.fn(async () => {})
+    const { dw } = await adapter({ onEvent })
+
+    dw.listeners.get(TOPIC_CARD)!({ type: 'CALLBACK', headers: {}, data: JSON.stringify({ outTrackId: 'd-2' }) })
+
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledTimes(1))
+    expect(dw.socketCallBackResponse).not.toHaveBeenCalled()
+  })
+
+  it('an ack failure is warned values-free and does not block payload delivery', async () => {
+    const onEvent = vi.fn(async () => {})
+    const { log, dw } = await adapter({ onEvent })
+    dw.socketCallBackResponse.mockImplementation(() => {
+      throw new Error('socket closed with secret-1 in message')
+    })
+
+    dw.listeners.get(TOPIC_CARD)!({
+      type: 'CALLBACK',
+      headers: { messageId: 'msg-4', topic: TOPIC_CARD },
+      data: JSON.stringify({ outTrackId: 'd-3' }),
+    })
+
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledTimes(1))
+    expect(log.warn).toHaveBeenCalledWith('DingTalk interactive-card Stream frame ack failed (ack_failed)')
+    expect(loggedText(log)).not.toContain('secret-1')
+  })
+
+  it('an onEvent rejection is contained as a values-free warn (never an unhandled rejection)', async () => {
+    const onEvent = vi.fn(async () => {
+      throw new Error('executor exploded with SECRET_FORM_VALUE')
+    })
+    const { log, dw } = await adapter({ onEvent })
+
+    dw.listeners.get(TOPIC_CARD)!({
+      type: 'CALLBACK',
+      headers: { messageId: 'msg-5', topic: TOPIC_CARD },
+      data: JSON.stringify({ outTrackId: 'd-4' }),
+    })
+
+    await vi.waitFor(() => expect(log.warn).toHaveBeenCalledWith(
+      'DingTalk interactive-card Stream event dispatch failed (event_dispatch_failed)',
+    ))
+    expect(loggedText(log)).not.toContain('SECRET_FORM_VALUE')
+  })
+
+  it('an unavailable SDK module surfaces the honest sdk_unwired sentinel end-to-end', async () => {
+    await expect(createDingTalkInteractiveCardStreamSdkClient(
+      enabledConfig(),
+      { onEvent: async () => {} },
+      { logger: logger(), loadSdk: async () => { throw new Error('Cannot find module dingtalk-stream') } },
+    )).rejects.toThrow(DINGTALK_INTERACTIVE_CARD_STREAM_SDK_UNWIRED_ERROR)
+
+    const log = logger()
+    const worker = new DingTalkInteractiveCardStreamWorker({
+      logger: log,
+      clientFactory: (config, handlers) => createDingTalkInteractiveCardStreamSdkClient(config, handlers, {
+        logger: log,
+        loadSdk: async () => { throw new Error('Cannot find module dingtalk-stream') },
+      }),
+    })
+    await expect(worker.initialize({
+      [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+      [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+      [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: 'secret-1',
+      [DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]: 'template-1',
+    } as NodeJS.ProcessEnv)).resolves.toEqual({ state: 'failed', reason: 'sdk_unwired' })
+    expect(log.warn).toHaveBeenCalledWith('DingTalk interactive-card Stream worker failed to start (sdk_unwired)')
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-stream.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-stream.test.ts
@@ -7,6 +7,7 @@ import {
   DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV,
   DingTalkInteractiveCardStreamWorker,
   resolveDingTalkInteractiveCardStreamConfig,
+  unwiredDingTalkInteractiveCardStreamClientFactory,
   type DingTalkInteractiveCardCallbackExecutor,
   type DingTalkInteractiveCardStreamClient,
   type DingTalkInteractiveCardStreamClientFactory,
@@ -133,9 +134,15 @@ describe('DingTalk interactive-card Stream worker (B-1)', () => {
       expect(client.close).toHaveBeenCalledTimes(1)
     })
 
-    it('classifies the default unwired SDK seam separately from real client failures', async () => {
+    it('classifies the unwired SDK seam separately from real client failures', async () => {
+      // The default factory is now the real `dingtalk-stream` adapter (covered in
+      // dingtalk-interactive-card-stream-default-factory.test.ts); the explicit unwired seam
+      // keeps the honest `sdk_unwired` classification for SDK-less builds.
       const log = logger()
-      const worker = new DingTalkInteractiveCardStreamWorker({ logger: log })
+      const worker = new DingTalkInteractiveCardStreamWorker({
+        logger: log,
+        clientFactory: unwiredDingTalkInteractiveCardStreamClientFactory,
+      })
 
       await expect(worker.initialize(env({
         [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: link:../../packages/openapi/dist-sdk
       axios:
         specifier: ^1.8.0
-        version: 1.13.2
+        version: 1.13.2(debug@4.4.3)
       bpmn-js:
         specifier: ^18.10.1
         version: 18.10.1
@@ -162,13 +162,16 @@ importers:
         version: 8.17.1
       axios:
         specifier: ^1.8.0
-        version: 1.13.2
+        version: 1.13.2(debug@4.4.3)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      dingtalk-stream:
+        specifier: ^2.1.5
+        version: 2.1.5
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
@@ -1132,10 +1135,6 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@mapbox/node-pre-gyp@1.0.11':
-    resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
-    hasBin: true
-
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
@@ -1816,9 +1815,6 @@ packages:
       react:
         optional: true
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -1845,10 +1841,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1889,14 +1881,6 @@ packages:
 
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
-
-  aproba@2.1.0:
-    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
-
-  are-we-there-yet@2.0.0:
-    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
-    engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2072,10 +2056,6 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -2122,10 +2102,6 @@ packages:
     resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
     engines: {node: '>=18'}
 
-  color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
-
   color@5.0.3:
     resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
     engines: {node: '>=18'}
@@ -2156,9 +2132,6 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
-  console-control-strings@1.1.0:
-    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -2297,9 +2270,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  delegates@1.0.0:
-    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
-
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -2311,10 +2281,6 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -2334,6 +2300,9 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  dingtalk-stream@2.1.5:
+    resolution: {integrity: sha512-6H3tSc/mE6hMj4RBB5ntkI4ycC498RobmtMxfLS8eBTRPjBZlhUdDYEHA0asOoTLSzC2PHqupr4D4HVoaU7bRQ==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -2402,9 +2371,6 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
-
-  encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
   engine.io-client@6.6.4:
     resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
@@ -2662,10 +2628,6 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -2688,11 +2650,6 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-
-  gauge@3.0.2:
-    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
-    engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -2797,9 +2754,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  has-unicode@2.0.1:
-    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
-
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -2821,10 +2775,6 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -3264,10 +3214,6 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3347,26 +3293,9 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -3438,30 +3367,13 @@ packages:
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
-  node-addon-api@5.1.0:
-    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
-
   node-cron@4.2.1:
     resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
     engines: {node: '>=6.0.0'}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   nodemailer@6.10.1:
     resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
     engines: {node: '>=6.0.0'}
-
-  nopt@5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   normalize-wheel-es@1.2.0:
     resolution: {integrity: sha512-Wj7+EJQ8mSuXr2iWfnujrimU35R2W4FAErEyTmJoJ7ucwTn2hOUSsRehMb5RSYkxXGTM7Y9QpvPmp++w5ftoJw==}
@@ -3469,10 +3381,6 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  npmlog@5.0.1:
-    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
-    deprecated: This package is no longer supported.
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -3937,10 +3845,6 @@ packages:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
 
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -3953,9 +3857,6 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
-
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4151,11 +4052,6 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
     engines: {node: '>=8.0.0'}
@@ -4220,9 +4116,6 @@ packages:
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -4475,9 +4368,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@8.0.0:
     resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
     engines: {node: '>=20'}
@@ -4494,9 +4384,6 @@ packages:
   whatwg-url@15.1.0:
     resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
     engines: {node: '>=20'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4523,9 +4410,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wide-align@1.1.5:
-    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
   winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
@@ -5259,21 +5143,6 @@ snapshots:
   '@js-joda/core@5.7.0': {}
 
   '@js-sdsl/ordered-map@4.4.2': {}
-
-  '@mapbox/node-pre-gyp@1.0.11(encoding@0.1.13)':
-    dependencies:
-      detect-libc: 2.1.2
-      https-proxy-agent: 5.0.1
-      make-dir: 3.1.0
-      node-fetch: 2.7.0(encoding@0.1.13)
-      nopt: 5.0.0
-      npmlog: 5.0.1
-      rimraf: 3.0.2
-      semver: 7.7.3
-      tar: 6.2.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   '@noble/hashes@1.8.0': {}
 
@@ -6043,8 +5912,6 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  abbrev@1.1.1: {}
-
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -6067,12 +5934,6 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -6107,13 +5968,6 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   append-field@1.0.0: {}
-
-  aproba@2.1.0: {}
-
-  are-we-there-yet@2.0.0:
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
 
   argparse@2.0.1: {}
 
@@ -6160,9 +6014,9 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.13.2:
+  axios@1.13.2(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -6317,8 +6171,6 @@ snapshots:
 
   check-error@2.1.1: {}
 
-  chownr@2.0.0: {}
-
   cjs-module-lexer@1.4.3: {}
 
   cli-cursor@4.0.0:
@@ -6355,8 +6207,6 @@ snapshots:
     dependencies:
       color-name: 2.1.0
 
-  color-support@1.1.3: {}
-
   color@5.0.3:
     dependencies:
       color-convert: 3.1.3
@@ -6384,8 +6234,6 @@ snapshots:
       typedarray: 0.0.6
 
   confbox@0.1.8: {}
-
-  console-control-strings@1.1.0: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -6504,15 +6352,11 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  delegates@1.0.0: {}
-
   denque@2.1.0: {}
 
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
-
-  detect-libc@2.1.2: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -6540,6 +6384,16 @@ snapshots:
   didi@10.2.2: {}
 
   diff-sequences@29.6.3: {}
+
+  dingtalk-stream@2.1.5:
+    dependencies:
+      axios: 1.13.2(debug@4.4.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   dir-glob@3.0.1:
     dependencies:
@@ -6623,11 +6477,6 @@ snapshots:
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
-
-  encoding@0.1.13:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
 
   engine.io-client@6.6.4:
     dependencies:
@@ -7037,7 +6886,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.15.11(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@10.2.2)
 
   for-each@0.3.5:
     dependencies:
@@ -7080,10 +6931,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
-
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -7104,18 +6951,6 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
-
-  gauge@3.0.2:
-    dependencies:
-      aproba: 2.1.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      object-assign: 4.1.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
 
   generate-function@2.3.1:
     dependencies:
@@ -7237,8 +7072,6 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  has-unicode@2.0.1: {}
-
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -7267,13 +7100,6 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -7744,10 +7570,6 @@ snapshots:
       semver: 5.7.2
     optional: true
 
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.1
-
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.12.2: {}
@@ -7807,20 +7629,7 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  minipass@5.0.0: {}
-
   minipass@7.1.2: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-
-  mkdirp@1.0.4: {}
 
   mlly@1.8.0:
     dependencies:
@@ -7900,34 +7709,15 @@ snapshots:
 
   node-abort-controller@3.1.1: {}
 
-  node-addon-api@5.1.0: {}
-
   node-cron@4.2.1: {}
 
-  node-fetch@2.7.0(encoding@0.1.13):
-    dependencies:
-      whatwg-url: 5.0.0
-    optionalDependencies:
-      encoding: 0.1.13
-
   nodemailer@6.10.1: {}
-
-  nopt@5.0.0:
-    dependencies:
-      abbrev: 1.1.1
 
   normalize-wheel-es@1.2.0: {}
 
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
-
-  npmlog@5.0.1:
-    dependencies:
-      are-we-there-yet: 2.0.0
-      console-control-strings: 1.1.0
-      gauge: 3.0.2
-      set-blocking: 2.0.0
 
   nth-check@2.1.1:
     dependencies:
@@ -8431,8 +8221,6 @@ snapshots:
   semver@5.7.2:
     optional: true
 
-  semver@6.3.1: {}
-
   semver@7.7.3: {}
 
   send@0.19.0:
@@ -8461,8 +8249,6 @@ snapshots:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
-
-  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -8702,15 +8488,6 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-
   tarn@3.0.2: {}
 
   tdigest@0.1.2:
@@ -8769,8 +8546,6 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.17
-
-  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -9039,8 +8814,6 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@8.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -9053,11 +8826,6 @@ snapshots:
     dependencies:
       tr46: 6.0.0
       webidl-conversions: 8.0.0
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -9108,10 +8876,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wide-align@1.1.5:
-    dependencies:
-      string-width: 4.2.3
 
   winston-transport@4.9.0:
     dependencies:


### PR DESCRIPTION
Wires the official DingTalk Stream SDK as the interactive-card Stream client and fixes the W1b-confirmed lifecycle race.

## Summary
- NEW `interactive-card-stream-sdk.ts`: adapter over `dingtalk-stream@^2.1.5` (official `opendingtalk` package — supply-chain reviewed: repo/publisher/downloads verified, lockfile integrity matches registry, no install hooks). Card-callback topic ONLY (drops the SDK's default wildcard EVENT subscription); malformed frames → values-free reject (wire bytes never logged/forwarded); secrets never logged; `debug:false` pinned (SDK debug dumps the full config incl. secret).
- **Shutdown × in-flight initialize race FIXED** (W1b's red repro now un-skipped and green): `shutdownRequested` latch re-checked after every await; a raced shutdown closes the just-created client and reports the normal shutdown shape. Latch mutation → exactly 3 red.
- **Review P2-1**: `close()` also blanks `config.clientId/clientSecret` — proved against the real SDK dist that an ALREADY-SCHEDULED reconnect timer survives the `autoReconnect` flip and would resurrect the connection post-shutdown; blanked credentials make a resurrected connect() die at endpoint resolution with no further retry. Pinned by test.
- **Review P2-2**: `active` documented honestly as "running, connection delegated to the SDK" — the SDK's connect() resolves even on total failure and retries internally; real connectivity is a UAT item (U12/U13).
- Ack semantics: ack-before-dispatch (at-most-once) — deliberate (slow executor would cause systematic ~60s redelivery); a crashed click stays recoverable (ledger row actionable, card non-terminal, duplicates converge via B-3 idempotency). Ack-ordering mutation-pinned.
- Flag-OFF zero side effects: SDK module never imported when off (dynamic import inside the gated path only), pinned by test. `sdk_unwired` stays honest (package genuinely absent → typed failure).
- Dep discipline: `pnpm-lock.yaml` regenerated on main's tip (not hand-merged past the bcrypt removal); `--frozen-lockfile` proven.

## Verification
- Adversarial review APPROVE-with-fixes (both P2s fixed here; supply-chain PASS; ack judgment: acceptable) — MD `/tmp/w2b-sdk-review-claude-20260710.md`
- Suites 29/29 (lifecycle un-skipped green) + mutations M1-M6 red (reviewer re-ran independently); full unit 364 files / 4962 green on the rebased tip; tsc clean.

Flag stays OFF; live UAT is the remaining gate before any enablement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
