### PR TITLE
fix(db): supersede the legacy audit-tables SQL migration with its idempotent twin (entity-machine 42P07)

### DIFF
--- a/packages/core-backend/src/db/migration-provider.ts
+++ b/packages/core-backend/src/db/migration-provider.ts
@@ -48,6 +48,12 @@ const SUPERSEDED_LEGACY_SQL_MIGRATIONS = [
   '053_create_protection_rules',
   '054_create_users_table',
   '055_create_attendance_import_tokens',
+  // #3751 entity-machine baseline conflict (42P07 duplicate_table on audit_logs): this legacy raw
+  // SQL migration is fully superseded by the idempotent zz20251231_create_audit_tables.ts twin
+  // (same 10 tables + 3 views + partitioned audit_logs with guarded dynamic monthly partitions).
+  // Machines that executed the zz twin first (allowUnorderedMigrations histories) must never
+  // replay this earlier-named file; fresh installs get every object from the twin.
+  '20250926_create_audit_tables',
 ]
 
 function dedupe(values: string[]): string[] {

--- a/packages/core-backend/tests/unit/migration-provider.test.ts
+++ b/packages/core-backend/tests/unit/migration-provider.test.ts
@@ -122,6 +122,13 @@ describe('createCoreBackendMigrationProvider', () => {
       path.join(legacySqlDir, '057_create_integration_core_tables.sql'),
       'create table if not exists integration_external_systems (id uuid primary key);'
     )
+    // #3751: superseded name substitution must apply by NAME across ALL source folders — this one
+    // lives in src/db/migrations (kysely dir), not the legacy dir, and its raw body is a
+    // NON-idempotent CREATE TABLE that must never execute.
+    await writeFile(
+      path.join(sourceMigrationsDir, '20250926_create_audit_tables.sql'),
+      'create table audit_logs (id bigserial primary key);'
+    )
 
     const provider = createCoreBackendMigrationProvider({ runtimeDir })
     const migrations = await provider.getMigrations()
@@ -133,6 +140,7 @@ describe('createCoreBackendMigrationProvider', () => {
       '055_create_attendance_import_tokens',
       '056_add_users_must_change_password',
       '057_create_integration_core_tables',
+      '20250926_create_audit_tables',
       'zzzz20260119100000_create_users_table',
     ])
     await expect(
@@ -143,6 +151,11 @@ describe('createCoreBackendMigrationProvider', () => {
     ).resolves.toBeUndefined()
     await expect(
       migrations['038_config_and_secrets']?.up({} as never)
+    ).resolves.toBeUndefined()
+    // The audit .sql is a no-op marker: up() with a null db must resolve without touching anything —
+    // if the raw CREATE TABLE body ever executed it would throw on the {} fake immediately.
+    await expect(
+      migrations['20250926_create_audit_tables']?.up({} as never)
     ).resolves.toBeUndefined()
   })
 


### PR DESCRIPTION
## What

Corrective-5 source fix for the #3751 entity-machine rerun blocker:

```text
failedMigrationName=20250926_create_audit_tables
sqlStateClass=42P07 (duplicate_table)
schemaObjectKind=table
```

**Root cause**: the machine executed the idempotent `zz20251231_create_audit_tables.ts` twin first (`allowUnorderedMigrations` history); the earlier-named raw SQL file merged later and replays its bare `CREATE TABLE audit_logs` against existing objects.

**Fix**: one entry in the purpose-built `SUPERSEDED_LEGACY_SQL_MIGRATIONS` no-op list — the name stays visible (Kysely history validation intact for machines that DID execute it), the DDL never replays (entity machine gets a ledger stamp with zero DDL; fresh installs get every object from the twin). **No error class is swallowed anywhere** — 42P07 stays fatal for any other migration.

**Supersession verified object-by-object**: 10 tables ✓ · 3 views (CREATE OR REPLACE) ✓ · partitioned `audit_logs` + guarded dynamic monthly partitions (superset of the SQL's hardcoded 2025_01-03) ✓ · indexes/trigger ✓ · views have no code consumers.

Test: cross-folder no-op case (this file lives in `src/db/migrations`, not the legacy dir) + proof the non-idempotent body never executes.

## Verification

`npx vitest run tests/unit/migration-provider.test.ts` → 6/6.

After merge: cut `corrective-5` on-prem package → post pointer to #3751. Interim unblock for the operator (documented escape hatch): `MIGRATION_EXCLUDE=20250926_create_audit_tables`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)