### PR TITLE
fix(dingtalk): distinct outcome-unknown response for work-notification test-send

### DIFF
--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -27,6 +27,7 @@ import {
   updateDirectoryIntegration,
 } from '../directory/directory-sync'
 import { getDirectoryInactiveLinkedMetric, getDirectoryManagerBindingCoverage } from '../directory/directory-sync-alert-delivery'
+import { isDingTalkOutcomeUnknown } from '../integrations/dingtalk/client'
 import {
   getDingTalkWorkNotificationRuntimeStatusFromStore,
   saveDingTalkWorkNotificationAgentId,
@@ -190,6 +191,22 @@ export function adminDirectoryRouter(): Router {
       const result = await testDingTalkWorkNotificationAgentId(req.body as never)
       jsonOk(res, { result })
     } catch (error) {
+      // #4046 send-tier: network error/timeout/5xx/malformed-2xx on the actual send carries the
+      // transport's isDingTalkOutcomeUnknown marker — DingTalk may well have delivered the test
+      // message even though this request saw no (usable) response. Folding that into the generic
+      // "failed" code below would tell an admin their Agent ID is broken when the message may in
+      // fact have arrived. This is the interactive test-send path — there is no ledger row to mark
+      // outcome_unknown on (by design), so the ambiguity is surfaced directly to the caller instead.
+      if (isDingTalkOutcomeUnknown(error)) {
+        const reason = readErrorMessage(error, 'DingTalk did not confirm the outcome')
+        jsonError(
+          res,
+          502,
+          'DINGTALK_TEST_SEND_OUTCOME_UNKNOWN',
+          `${reason}. The test message may still have been delivered — check the test message on the device before retrying.`,
+        )
+        return
+      }
       jsonError(res, 400, 'DINGTALK_WORK_NOTIFICATION_TEST_FAILED', readErrorMessage(error, 'Failed to test DingTalk work notification Agent ID'))
     }
   })

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -397,6 +397,57 @@ describe('adminDirectoryRouter', () => {
     })
   })
 
+  // #4046 P3-2: send-tier failures (network error/timeout/5xx/malformed-2xx) on the actual test
+  // send carry the transport's REAL isDingTalkOutcomeUnknown marker (imported unmocked from
+  // dingtalk/client — this is the same discriminator production code runs, not a stand-in). Before
+  // this fix both branches below folded into the same 400 DINGTALK_WORK_NOTIFICATION_TEST_FAILED
+  // code, telling an admin their Agent ID is broken for a message that may have actually arrived.
+  it('reports a distinct outcome-unknown code+message when the test send outcome is ambiguous', async () => {
+    const sendError = Object.assign(new Error('DingTalk request timed out after 10000ms'), {
+      outcomeUnknown: true,
+    })
+    workNotificationMocks.testDingTalkWorkNotificationAgentId.mockRejectedValue(sendError)
+
+    const payload = { integrationId: 'dir-1', agentId: '123456789', recipientUserId: 'user-1' }
+    const response = await invokeRoute('post', '/dingtalk/work-notification/test', {
+      body: payload,
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(502)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'DINGTALK_TEST_SEND_OUTCOME_UNKNOWN',
+      },
+    })
+    const message = (response.body as { error: { message: string } }).error.message
+    expect(message).toContain('DingTalk request timed out after 10000ms')
+    expect(message.toLowerCase()).toContain('may still have been delivered')
+    expect(message.toLowerCase()).toContain('check the test message on the device')
+  })
+
+  it('keeps the generic failure shape for a plain (non-outcome-unknown) test-send error', async () => {
+    workNotificationMocks.testDingTalkWorkNotificationAgentId.mockRejectedValue(
+      new Error('DingTalk appSecret is required'),
+    )
+
+    const payload = { integrationId: 'dir-1', agentId: '123456789' }
+    const response = await invokeRoute('post', '/dingtalk/work-notification/test', {
+      body: payload,
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'DINGTALK_WORK_NOTIFICATION_TEST_FAILED',
+        message: 'DingTalk appSecret is required',
+      },
+    })
+  })
+
   it('saves DingTalk work notification Agent ID and writes a redacted audit entry', async () => {
     workNotificationMocks.saveDingTalkWorkNotificationAgentId.mockResolvedValue({
       integration: { id: 'dir-1', name: 'DingTalk CN', status: 'active' },


### PR DESCRIPTION
## What / why

Roadmap #4046 gave the DingTalk transport a `'send'` tier that marks network-error / timeout / 5xx / malformed-2xx outcomes with `isDingTalkOutcomeUnknown` — DingTalk may have actually delivered the message even though the client saw no usable response. Every other send path in the codebase (approval-card deliveries, attendance delivery worker, automation-executor alerts) already discriminates this marker into a distinct `outcome_unknown` state.

The interactive admin **test-send** endpoint (`POST /api/admin/directory/dingtalk/work-notification/test`, `packages/core-backend/src/routes/admin-directory.ts`) did not: it caught every failure — including outcome-unknown ones — into the same generic `DINGTALK_WORK_NOTIFICATION_TEST_FAILED` (400) response. An admin verifying their Agent ID could see a plain "failed" for a test message that DingTalk actually delivered.

## Fix

In the test-send route's catch block, discriminate `isDingTalkOutcomeUnknown(error)` (imported from `../integrations/dingtalk/client`, same real function every other send-tier caller uses — not re-implemented) before falling through to the generic branch:

- **Outcome-unknown**: `502 DINGTALK_TEST_SEND_OUTCOME_UNKNOWN`, message = the underlying reason + explicit guidance that the message may still have been delivered and to check the device before retrying.
- **Everything else**: unchanged — `400 DINGTALK_WORK_NOTIFICATION_TEST_FAILED` with the original error message.

No ledger involved — this is the interactive test-send path, which by design has no ledger row to reconcile (kept that way per the lane brief).

### FE consumer checked

`apps/web/src/views/DirectoryManagementView.vue`'s `testWorkNotificationAgentId()` calls `readApiError(body, fallback)` and renders `error.message` directly via `setStatus(...)`. It does **not** switch on `error.code` for this route (unlike the directory-sync routes, which do use `readApiErrorCode(...) === 'DIRECTORY_SYNC_IN_PROGRESS'` for special UI). So no FE change was needed — the new message text alone conveys the distinct outcome. Noted as a candidate follow-up if product wants a visually distinct (non-error-red) treatment for this ambiguous state.

## Tests

Extended `packages/core-backend/tests/unit/admin-directory-routes.test.ts` (existing whitelisted `tests/unit` auto-collected file, no new wiring needed):

- `reports a distinct outcome-unknown code+message when the test send outcome is ambiguous` — mocks `testDingTalkWorkNotificationAgentId` rejecting with `Object.assign(new Error(...), { outcomeUnknown: true })` (the real property `isDingTalkOutcomeUnknown` checks — not a stand-in), asserts `502` + `DINGTALK_TEST_SEND_OUTCOME_UNKNOWN` + message contains both the original reason and the "may still have been delivered" / "check the test message on the device" guidance.
- `keeps the generic failure shape for a plain (non-outcome-unknown) test-send error` — pins the unchanged direction: `400` + `DINGTALK_WORK_NOTIFICATION_TEST_FAILED` + original message, unmodified.

`isDingTalkOutcomeUnknown` itself is NOT mocked in this test file (`dingtalk/client` is unmocked), so the route runs against the real discriminator.

Run results:
- `npx tsc --noEmit -p tsconfig.json` (packages/core-backend): clean
- `CI=true npx vitest run tests/unit/admin-directory-routes.test.ts`: 85/85 passed
- `CI=true npx vitest run tests/unit` (full core-backend unit suite): 368 files / 5064 tests passed

## Mutation table

| # | Mutation | Result |
|---|----------|--------|
| 1 | Delete the `isDingTalkOutcomeUnknown` branch entirely (fold back into generic failure) | RED — `reports a distinct outcome-unknown code+message...` fails (`expected 400 to be 502`); generic test stays green |
| 2 | Keep the branch but make it call the exact same `jsonError(res, 400, 'DINGTALK_WORK_NOTIFICATION_TEST_FAILED', ...)` as the generic path | RED — same test fails (`expected 400 to be 502`) |
| 3 | Keep code/status distinct but drop the "may still have been delivered / check the test message on the device" guidance from the message | RED — same test fails on the message-content assertion |

After each mutation the implementation file was restored via `git checkout --` to the committed state (verified via `git diff HEAD` empty before/after).

## Honest gaps

- No FE visual differentiation (e.g. warning vs. error styling) for the outcome-unknown case — deliberately out of scope per "if it renders the message directly, no FE change needed", but flagged above as a candidate follow-up.
- HTTP status `502` was chosen by analogy to existing upstream-provider-error usage in this codebase (`multitable-ai.ts`, `plm-workbench.ts`); there's no prior DingTalk-route precedent for this exact status pinning outcome-unknown specifically, so a reviewer should sanity-check that choice.
- Did not add integration/e2e coverage exercising the real transport → real DingTalk send path; the test mocks `testDingTalkWorkNotificationAgentId` at the settings-module boundary (consistent with the rest of this test file) and exercises the real `isDingTalkOutcomeUnknown` predicate against a hand-built error, not a live retry-exhausted transport call.

Base: `origin/main` (includes #4046 `b94b46bf3` and #4082 `be6f3fde1`). Not armed for auto-merge — landing is gated per the lane brief.