### PR TITLE
fix(scheduler): far-future cron delay clamp + invalid-cron telemetry + stale-name closure (R1-L1)

### DIFF
--- a/packages/core-backend/src/directory/directory-sync-scheduler.ts
+++ b/packages/core-backend/src/directory/directory-sync-scheduler.ts
@@ -53,6 +53,23 @@ async function getScheduleRow(integrationId: string): Promise<DirectoryScheduleR
   return result.rows[0] ?? null
 }
 
+// P3-2 (#4057's gate): the schedule callback used to close over the mutable `row.name`
+// captured at job-CREATION time. reschedule() (the `existingJob` branch of applySchedule)
+// keeps the same job/handler and only swaps the cron expression, so a renamed integration
+// kept alerting/logging under its old display name until the job was unscheduled and
+// recreated (or the process restarted). Resolving the name at fire time — carrying only
+// the immutable `row.id` in the closure — fixes that without changing reschedule-in-place
+// semantics (job stats/runCount survive a rename, matching every other cron-only edit).
+// Mirrors the existing `readIntegrationNameForAlert` fallback convention in directory-sync.ts.
+async function resolveScheduledIntegrationName(integrationId: string): Promise<string> {
+  try {
+    const currentRow = await getScheduleRow(integrationId)
+    return currentRow?.name || integrationId
+  } catch {
+    return integrationId
+  }
+}
+
 async function runScheduledSync(integrationId: string, integrationName: string): Promise<void> {
   try {
     await syncDirectoryIntegration(integrationId, SYSTEM_TRIGGERED_BY, 'scheduler')
@@ -75,7 +92,18 @@ async function runScheduledSync(integrationId: string, integrationName: string):
   await deliverDirectoryInactiveLinkedAlert({ integrationId, integrationName })
 }
 
-async function applySchedule(row: DirectoryScheduleRow | null): Promise<void> {
+type InvalidCronReport = { id: string; name: string; cron: string; error: string }
+
+type ApplyScheduleOptions = {
+  // §7.8 follow-up (P3-1 from #4053's gate): rows saved before save-time cron validation
+  // landed may hold a schedule_cron the runtime can never fire. applySchedule already
+  // unschedules/skips them safely; this hook lets the boot sweep additionally collect
+  // them for one aggregate telemetry line so ops can find and fix the rows. Never used
+  // to mutate/auto-clear anything.
+  onInvalidCron?: (report: InvalidCronReport) => void
+}
+
+async function applySchedule(row: DirectoryScheduleRow | null, options: ApplyScheduleOptions = {}): Promise<void> {
   if (!scheduler) return
 
   const jobName = buildJobName(normalizeText(row?.id))
@@ -96,14 +124,20 @@ async function applySchedule(row: DirectoryScheduleRow | null): Promise<void> {
       logger.info(`Rescheduled directory sync job: ${jobName} (${cronExpression})`)
     } else {
       await scheduler.schedule(jobName, cronExpression, async () => {
-        await runScheduledSync(row.id, row.name)
+        await runScheduledSync(row.id, await resolveScheduledIntegrationName(row.id))
       }, {
         timezone: 'UTC',
       })
       logger.info(`Scheduled directory sync job: ${jobName} (${cronExpression})`)
     }
   } catch (error) {
-    logger.warn(`Failed to apply directory sync schedule for ${row.id}: ${error instanceof Error ? error.message : String(error)}`)
+    const message = error instanceof Error ? error.message : String(error)
+    logger.warn(`Failed to apply directory sync schedule for ${row.id}: ${message}`, {
+      integrationId: row.id,
+      integrationName: row.name,
+      scheduleCron: cronExpression,
+    })
+    options.onInvalidCron?.({ id: row.id, name: row.name, cron: cronExpression, error: message })
     if (existingJob) {
       await scheduler.unschedule(jobName)
     }
@@ -129,8 +163,21 @@ export async function startDirectorySyncScheduler(
 
   try {
     const rows = await listScheduleRows()
-    await Promise.all(rows.map((row) => applySchedule(row)))
+    const invalidCronRows: InvalidCronReport[] = []
+    await Promise.all(rows.map((row) => applySchedule(row, {
+      onInvalidCron: (report) => invalidCronRows.push(report),
+    })))
     logger.info(`Directory sync scheduler started with ${rows.length} integration(s) loaded`)
+
+    // §7.8 follow-up (P3-1): one structured summary per boot so ops can find legacy rows
+    // with a schedule_cron the runtime can never fire, without scanning per-row warnings.
+    // Read-only — this never clears or otherwise mutates the offending rows.
+    if (invalidCronRows.length > 0) {
+      logger.warn(
+        `Directory sync scheduler boot found ${invalidCronRows.length} integration(s) with a schedule_cron the runtime can never fire`,
+        { invalidCronIntegrations: invalidCronRows },
+      )
+    }
   } catch (error) {
     logger.warn(`Directory sync scheduler bootstrap failed: ${error instanceof Error ? error.message : String(error)}`)
   }

--- a/packages/core-backend/src/services/SchedulerService.ts
+++ b/packages/core-backend/src/services/SchedulerService.ts
@@ -139,6 +139,17 @@ class SimpleCronExpression implements CronExpression {
 }
 
 /**
+ * Node clamps setTimeout delays greater than 2^31-1 ms (~24.86 days) down to 1ms. Passed
+ * a raw far-future delay (e.g. a yearly cron saved mid-year, ~175 days out), that clamp
+ * would make the job fire immediately and hot-loop — re-scheduling itself right back into
+ * the same clamp — gated only by whatever the handler itself does (e.g. a sync lease).
+ * Arm delays above this safe ceiling in repeated max-size chunks: wait out one chunk,
+ * recompute the remaining delay against the fixed target time, and re-arm. Only once the
+ * remaining delay fits under the ceiling does the real fire-the-job timeout get set.
+ */
+const MAX_SAFE_TIMEOUT_MS = 2 ** 31 - 1 - 1_000_000 // headroom under Node's ~24.86-day clamp point
+
+/**
  * 调度作业管理器
  */
 class JobScheduler extends EventEmitter {
@@ -238,7 +249,6 @@ class JobScheduler extends EventEmitter {
       }
 
       job.nextRun = nextRun
-      const delayMs = nextRun.getTime() - Date.now()
       const jobName = job.name || job.id || ''
 
       // 清理旧的定时器
@@ -247,19 +257,41 @@ class JobScheduler extends EventEmitter {
         clearTimeout(oldCronJob.timeout)
       }
 
-      const timeout = setTimeout(async () => {
-        await this.executeJob(job)
-        // 执行完成后重新调度下一次
-        this.scheduleCronJob(job)
-      }, delayMs)
-
-      this.cronJobs.set(jobName, { expression, timeout })
+      this.armCronTimeout(job, jobName, expression, nextRun)
 
       this.logger.debug(`Cron job ${jobName} scheduled for ${nextRun.toISOString()}`)
     } catch (error) {
       this.logger.error(`Failed to schedule cron job ${job.name}`, error as Error)
       this.emit('job:error', job, error)
     }
+  }
+
+  /**
+   * Arms the timer for a job's next cron fire, chunking delays that exceed
+   * MAX_SAFE_TIMEOUT_MS so a single setTimeout call is never handed a value Node would
+   * silently clamp. `nextRun` is the fixed target time computed once by scheduleCronJob;
+   * each chunk re-derives the remaining delay from it rather than re-parsing the cron.
+   * Always writes the latest timeout handle into `cronJobs` so removeJob/destroy can
+   * cancel mid-chain — a job unscheduled between chunks must not fire.
+   */
+  private armCronTimeout(job: ScheduledJob, jobName: string, expression: CronExpression, nextRun: Date): void {
+    const remainingMs = nextRun.getTime() - Date.now()
+
+    if (remainingMs > MAX_SAFE_TIMEOUT_MS) {
+      const timeout = setTimeout(() => {
+        this.armCronTimeout(job, jobName, expression, nextRun)
+      }, MAX_SAFE_TIMEOUT_MS)
+      this.cronJobs.set(jobName, { expression, timeout })
+      return
+    }
+
+    const timeout = setTimeout(async () => {
+      await this.executeJob(job)
+      // 执行完成后重新调度下一次
+      this.scheduleCronJob(job)
+    }, Math.max(remainingMs, 0))
+
+    this.cronJobs.set(jobName, { expression, timeout })
   }
 
   private scheduleDelayedJob(job: ScheduledJob): void {

--- a/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Logger } from '../../src/core/logger'
 
 const pgMocks = vi.hoisted(() => ({
   query: vi.fn(),
@@ -69,38 +70,52 @@ describe('directory-sync-scheduler', () => {
     const scheduler = createSchedulerMock()
     scheduler.getJob.mockResolvedValue(null)
 
-    pgMocks.query.mockResolvedValueOnce({
-      rows: [
-        {
-          id: 'dir-1',
-          name: 'DingTalk CN',
-          status: 'active',
-          sync_enabled: true,
-          schedule_cron: '*/5 * * * *',
-        },
-        {
-          id: 'dir-2',
-          name: 'Inactive',
-          status: 'inactive',
-          sync_enabled: true,
-          schedule_cron: '*/5 * * * *',
-        },
-        {
-          id: 'dir-3',
-          name: 'Disabled',
-          status: 'active',
-          sync_enabled: false,
-          schedule_cron: '*/5 * * * *',
-        },
-        {
-          id: 'dir-4',
-          name: 'Blank cron',
-          status: 'active',
-          sync_enabled: true,
-          schedule_cron: '   ',
-        },
-      ],
-    })
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'dir-1',
+            name: 'DingTalk CN',
+            status: 'active',
+            sync_enabled: true,
+            schedule_cron: '*/5 * * * *',
+          },
+          {
+            id: 'dir-2',
+            name: 'Inactive',
+            status: 'inactive',
+            sync_enabled: true,
+            schedule_cron: '*/5 * * * *',
+          },
+          {
+            id: 'dir-3',
+            name: 'Disabled',
+            status: 'active',
+            sync_enabled: false,
+            schedule_cron: '*/5 * * * *',
+          },
+          {
+            id: 'dir-4',
+            name: 'Blank cron',
+            status: 'active',
+            sync_enabled: true,
+            schedule_cron: '   ',
+          },
+        ],
+      })
+      // Fire-time name resolution (P3-2 fix): the schedule callback now re-reads the row
+      // instead of closing over `row.name`, so firing it triggers one more `query()` call.
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'dir-1',
+            name: 'DingTalk CN',
+            status: 'active',
+            sync_enabled: true,
+            schedule_cron: '*/5 * * * *',
+          },
+        ],
+      })
 
     await startDirectorySyncScheduler({ scheduler: scheduler as never })
 
@@ -206,5 +221,120 @@ describe('directory-sync-scheduler', () => {
     // §7.1 digest is a POST-run check: neither failure path (lease conflict skip, nor a
     // real sync error) should reach it.
     expect(alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert).not.toHaveBeenCalled()
+  })
+
+  // P3-1 (#4053's gate): legacy rows saved before save-time cron validation may hold a
+  // schedule_cron the runtime can never fire. applySchedule already unschedules/skips them
+  // safely; boot should additionally log ONE structured summary so ops can find them,
+  // without ever mutating the offending rows.
+  describe('boot-time invalid-cron telemetry (P3-1)', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(Logger.prototype, 'warn')
+    })
+
+    const summaryCalls = () => warnSpy.mock.calls.filter(([message]) =>
+      typeof message === 'string' && message.includes('schedule_cron the runtime can never fire'),
+    )
+
+    it('logs one structured summary of invalid-cron integrations found at boot; valid rows still schedule', async () => {
+      const scheduler = createSchedulerMock()
+      scheduler.getJob.mockResolvedValue(null)
+      scheduler.schedule.mockImplementation((jobName: string) => {
+        if (jobName === 'directory-sync:dir-bad') {
+          return Promise.reject(new Error('Invalid cron expression: no future execution times'))
+        }
+        return Promise.resolve({})
+      })
+
+      pgMocks.query.mockResolvedValueOnce({
+        rows: [
+          { id: 'dir-good', name: 'Good', status: 'active', sync_enabled: true, schedule_cron: '*/5 * * * *' },
+          { id: 'dir-bad', name: 'Bad Legacy', status: 'active', sync_enabled: true, schedule_cron: '0 0 30 2 *' },
+        ],
+      })
+
+      await startDirectorySyncScheduler({ scheduler: scheduler as never })
+
+      expect(summaryCalls()).toHaveLength(1)
+      expect(summaryCalls()[0][1]).toMatchObject({
+        invalidCronIntegrations: [
+          { id: 'dir-bad', name: 'Bad Legacy', cron: '0 0 30 2 *', error: 'Invalid cron expression: no future execution times' },
+        ],
+      })
+
+      // The valid row is unaffected: it schedules normally and is not part of the summary.
+      expect(scheduler.schedule).toHaveBeenCalledWith(
+        'directory-sync:dir-good',
+        '*/5 * * * *',
+        expect.any(Function),
+        { timezone: 'UTC' },
+      )
+      // Read-only: no row mutation of any kind — this scheduler module never issues an
+      // UPDATE/DELETE against directory_integrations.
+      expect(pgMocks.query).not.toHaveBeenCalledWith(expect.stringMatching(/UPDATE|DELETE/i), expect.anything())
+    })
+
+    it('does not log an invalid-cron summary when every integration schedules cleanly', async () => {
+      const scheduler = createSchedulerMock()
+      scheduler.getJob.mockResolvedValue(null)
+      scheduler.schedule.mockResolvedValue({})
+
+      pgMocks.query.mockResolvedValueOnce({
+        rows: [
+          { id: 'dir-good-1', name: 'Good 1', status: 'active', sync_enabled: true, schedule_cron: '*/5 * * * *' },
+          { id: 'dir-good-2', name: 'Good 2', status: 'active', sync_enabled: true, schedule_cron: '*/10 * * * *' },
+        ],
+      })
+
+      await startDirectorySyncScheduler({ scheduler: scheduler as never })
+
+      expect(summaryCalls()).toHaveLength(0)
+    })
+  })
+
+  // P3-2 (#4057's gate): the schedule callback used to close over the mutable `row.name`
+  // at job-creation time; reschedule() keeps the same job/handler, so a renamed
+  // integration alerted under its stale name until the job was recreated. The fix resolves
+  // the display name at fire time instead of carrying it in the closure.
+  it('resolves the CURRENT integration name at fire time, even for a handler captured before a rename', async () => {
+    const scheduler = createSchedulerMock()
+    scheduler.getJob.mockResolvedValue(null) // no existing job yet -> create path
+
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [
+        { id: 'dir-1', name: 'DingTalk CN', status: 'active', sync_enabled: true, schedule_cron: '*/5 * * * *' },
+      ],
+    })
+
+    await startDirectorySyncScheduler({ scheduler: scheduler as never })
+    // This is the SAME handler reference the reschedule-in-place path below will keep using.
+    const scheduleHandler = scheduler.schedule.mock.calls[0][2] as () => Promise<void>
+
+    // Admin renames the integration; the update route's refresh call finds an existing job
+    // and takes the reschedule-in-place branch (same handler, only the cron args differ).
+    scheduler.getJob.mockResolvedValue({ name: 'directory-sync:dir-1' })
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [
+        { id: 'dir-1', name: 'DingTalk CN Renamed', status: 'active', sync_enabled: true, schedule_cron: '*/5 * * * *' },
+      ],
+    })
+    await refreshDirectoryIntegrationSchedule('dir-1')
+    expect(scheduler.reschedule).toHaveBeenCalledWith('directory-sync:dir-1', '*/5 * * * *')
+    expect(scheduler.schedule).toHaveBeenCalledTimes(1) // reschedule-in-place: no second schedule() call
+
+    // Firing the ORIGINAL handler must reflect the rename, not the name captured at creation.
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [
+        { id: 'dir-1', name: 'DingTalk CN Renamed', status: 'active', sync_enabled: true, schedule_cron: '*/5 * * * *' },
+      ],
+    })
+    await scheduleHandler()
+
+    expect(alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert).toHaveBeenCalledWith({
+      integrationId: 'dir-1',
+      integrationName: 'DingTalk CN Renamed',
+    })
   })
 })

--- a/packages/core-backend/tests/unit/scheduler-service.test.ts
+++ b/packages/core-backend/tests/unit/scheduler-service.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SchedulerServiceImpl } from '../../src/services/SchedulerService'
+
+// Node clamps setTimeout delays above 2^31-1 ms (~24.86 days) to 1ms. A validated
+// far-future cron (e.g. a yearly schedule saved mid-year) must not be handed a raw delay
+// that crosses that ceiling, or it fires immediately and hot-loops. These tests pin the
+// chunked delay-arming mechanics in SchedulerService's JobScheduler.scheduleCronJob.
+const NODE_MAX_TIMEOUT_MS = 2 ** 31 - 1
+
+describe('SchedulerService cron delay arming (far-future crons)', () => {
+  const originalTz = process.env.TZ
+
+  beforeEach(() => {
+    // SimpleCronExpression matches against local-time Date getters, not UTC — pin TZ so
+    // the test is deterministic regardless of the machine/CI runner's default zone.
+    process.env.TZ = 'UTC'
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-10T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalTz === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = originalTz
+    }
+  })
+
+  function totalDelayToNextJan1(): number {
+    // Mirrors what SimpleCronExpression.next() resolves '0 0 1 1 *' to from the fixed
+    // system time above: the next Jan 1 00:00 (2026-01-01 has already passed).
+    return Date.parse('2027-01-01T00:00:00.000Z') - Date.parse('2026-07-10T00:00:00.000Z')
+  }
+
+  it('does not fire a far-future cron early, and fires once the full delay elapses', async () => {
+    const service = new SchedulerServiceImpl()
+    const handler = vi.fn().mockResolvedValue(undefined)
+
+    await service.schedule('yearly-job', '0 0 1 1 *', handler, { timezone: 'UTC' })
+
+    const totalDelayMs = totalDelayToNextJan1()
+    expect(totalDelayMs).toBeGreaterThan(NODE_MAX_TIMEOUT_MS) // sanity: this case actually crosses the clamp
+
+    // Advance through several chunk boundaries but stop short of the real target time.
+    await vi.advanceTimersByTimeAsync(totalDelayMs - 1_000)
+    expect(handler).not.toHaveBeenCalled()
+
+    // Cross the remaining delay: now it must fire, exactly once.
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    service.destroy()
+  })
+
+  it('kills a far-future cron unscheduled mid-chain — it must never fire', async () => {
+    const service = new SchedulerServiceImpl()
+    const handler = vi.fn().mockResolvedValue(undefined)
+
+    await service.schedule('yearly-job-cancel', '0 0 1 1 *', handler, { timezone: 'UTC' })
+
+    // Advance partway through the chain — past at least two chunk boundaries (~24.86 days
+    // each) — while still well short of the total delay.
+    await vi.advanceTimersByTimeAsync(60 * 24 * 60 * 60 * 1000)
+    expect(handler).not.toHaveBeenCalled()
+
+    await service.unschedule('yearly-job-cancel')
+
+    // Advance well past what would have been the remaining delay.
+    await vi.advanceTimersByTimeAsync(200 * 24 * 60 * 60 * 1000)
+    expect(handler).not.toHaveBeenCalled()
+
+    service.destroy()
+  })
+
+  it('never arms a raw setTimeout delay beyond Node\'s clamp ceiling for a far-future cron', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const service = new SchedulerServiceImpl()
+    const handler = vi.fn().mockResolvedValue(undefined)
+
+    await service.schedule('yearly-job-armed-delay', '0 0 1 1 *', handler, { timezone: 'UTC' })
+
+    // At least one chunk timer must have been armed already (the total delay for this
+    // case exceeds the ceiling), and every delay ever passed to setTimeout for this run
+    // must stay under Node's clamp point — including delays armed later as the chain
+    // advances.
+    expect(setTimeoutSpy.mock.calls.length).toBeGreaterThan(0)
+    for (const call of setTimeoutSpy.mock.calls) {
+      const delay = call[1]
+      if (typeof delay === 'number') {
+        expect(delay).toBeLessThanOrEqual(NODE_MAX_TIMEOUT_MS)
+      }
+    }
+
+    await vi.advanceTimersByTimeAsync(totalDelayToNextJan1() + 2_000)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    for (const call of setTimeoutSpy.mock.calls) {
+      const delay = call[1]
+      if (typeof delay === 'number') {
+        expect(delay).toBeLessThanOrEqual(NODE_MAX_TIMEOUT_MS)
+      }
+    }
+
+    service.destroy()
+    setTimeoutSpy.mockRestore()
+  })
+
+  it('does not chunk a near-term cron — delay under the ceiling arms unchanged', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const service = new SchedulerServiceImpl()
+    const handler = vi.fn().mockResolvedValue(undefined)
+
+    // Next run is at most a few minutes out — nowhere near the ~24.86-day ceiling.
+    await service.schedule('near-term-job', '*/5 * * * *', handler, { timezone: 'UTC' })
+
+    const cronTimeoutCalls = setTimeoutSpy.mock.calls.filter((call) => {
+      const delay = call[1]
+      return typeof delay === 'number' && delay > 0
+    })
+    expect(cronTimeoutCalls.length).toBe(1) // single arm, no chunking
+    const armedDelay = cronTimeoutCalls[0][1] as number
+    expect(armedDelay).toBeLessThanOrEqual(5 * 60 * 1000)
+
+    await vi.advanceTimersByTimeAsync(armedDelay + 1_000)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    service.destroy()
+    setTimeoutSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## What / why

Three scheduler-hygiene fixes in the directory sync scheduler family, all catalogued as P3 findings by adversarial gates during the just-closed pool round:

- **FIX 1** (P3-3 from #4053's adversarial-gate comment) — `JobScheduler.scheduleCronJob` (`packages/core-backend/src/services/SchedulerService.ts`) passed the raw `delayMs` to `setTimeout`. Node silently clamps delays above `2^31-1` ms (~24.86 days) to 1ms, so a validated far-future cron (e.g. a yearly schedule saved mid-year, ~175 days out) would fire immediately and hot-loop, gated only by whatever the handler itself does (for directory sync, the sync lease).
- **FIX 2** (P3-1 from #4053's adversarial-gate comment) — Directory integrations saved before #4053's save-time cron validation landed may hold a `schedule_cron` the runtime can never fire. `applySchedule` already unschedules/skips these safely, but the failure was only a per-row `logger.warn`. Boot now also logs ONE structured summary of every such row so ops can find and fix them.
- **FIX 3** (P3-2 from #4057's adversarial-gate comment) — The schedule callback in `directory-sync-scheduler.ts` closed over the mutable `row.name` captured at job-creation time. `reschedule()` (the `existingJob` branch of `applySchedule`) keeps the same job/handler and only swaps the cron expression, so a renamed integration alerted/logged under its stale name until the job was unscheduled and recreated (or the process restarted).

(#4053 = "validate schedule_cron at save time"; #4057 = "§7.1 inactive-linked-for-N-days metric + post-run alert" — both merged into main earlier in this pool round.)

## Changes

- `packages/core-backend/src/services/SchedulerService.ts` — new `armCronTimeout` helper chunks any delay above a safe ceiling (`2^31-1-1_000_000` ms, headroom under Node's clamp point) into repeated max-size waits, recomputing the remaining delay against the fixed target time at each re-arm. Only once the remaining delay fits under the ceiling does the real fire-the-job timeout get set. `removeJob`/`destroy` always cancel whatever timeout is currently in `cronJobs` — since every re-arm updates that map entry, unscheduling mid-chain still kills the job before it fires. Zero behavior change for delays under the ceiling (still a single `setTimeout` call, same computed delay).
- `packages/core-backend/src/directory/directory-sync-scheduler.ts` —
  - `applySchedule` now accepts an optional `onInvalidCron` hook, invoked from its existing catch block (unchanged failure semantics — still unschedules/skips). `startDirectorySyncScheduler` collects every invalid-cron row hit during the boot sweep and, if any, logs one structured `logger.warn` with `{ invalidCronIntegrations: [{id, name, cron, error}, ...] }`. Never mutates/clears the offending rows.
  - New `resolveScheduledIntegrationName(integrationId)` re-reads the row via the existing `getScheduleRow` helper at fire time and falls back to the id on lookup failure — mirroring the existing `readIntegrationNameForAlert` convention in `directory-sync.ts`. The schedule-creation callback now carries only `row.id` and resolves the display name at fire time instead of closing over `row.name`.
- Tests: new `packages/core-backend/tests/unit/scheduler-service.test.ts` (FIX 1); extended `packages/core-backend/tests/unit/directory-sync-scheduler.test.ts` (FIX 2, FIX 3, plus one extra mocked `query()` response in the pre-existing "registers a job..." test to account for FIX 3's new fire-time lookup).

## Design decision flagged for review (FIX 3)

Brief asked to pick the smaller diff between (a) resolving the name at fire time vs (b) recreating the job on every reschedule, and justify. Chose (a): it doesn't touch `reschedule()`'s in-place semantics, so job `runCount`/`lastRun` survive a rename exactly like they survive any other cron-only edit. (b) would reset those stats on every rename since `schedule()` always constructs a fresh `ScheduledJob`. Cost of (a): one extra `SELECT` on `directory_integrations` per triggered sync (not per scheduler tick) — negligible relative to the DingTalk API sync work that follows, but flagging as a genuine behavior change for ops. On DB failure at fire time, the alert degrades to showing the integration id instead of the (possibly now-stale) name — strictly safer than the prior "always stale, never expires" behavior, but different from status quo.

## Test evidence

- `packages/core-backend/tests/unit/scheduler-service.test.ts` (new, 4 tests) — pass
- `packages/core-backend/tests/unit/directory-sync-scheduler.test.ts` (extended, 8 tests, was 5) — pass
- Scheduler-family suites run explicitly by name (`scheduler-service`, `directory-sync-scheduler`, `attendance-scheduler`, `ledger-retention-scheduler`, `webhook-retry-scheduler`, `approval-sla-scheduler`, `automation-scheduler-date-reminder`, `automation-scheduler-leader`, `automation-scheduler-metrics`): **9 files / 84 tests pass**
- Full `tests/unit`: **369 files / 5069 tests pass**
- `tsc --noEmit -p tsconfig.json` (core-backend): clean

## Mutation table

| # | Fix | Mutation | Result |
|---|---|---|---|
| M1 | FIX 1 | Remove the `armCronTimeout` chunking guard (`if (remainingMs > MAX_SAFE_TIMEOUT_MS)` branch) — always pass the raw remaining delay to `setTimeout` | **RED** — the armed-delay invariant test fails cleanly (`expected 15120000000 to be less than or equal to 2147483647`). This is the load-bearing detector for the clamp property: per the brief's own note, fake timers don't apply Node's real clamp, so a delay-based advance-and-assert test can't distinguish chunked-vs-raw by itself — only inspecting the actual armed `setTimeout` delay can. The other 3 tests in the file also failed under this mutation (via 30s timeouts from fake-timer/setTimeout interaction instability with an unchunked ~1.5e10ms delay) — treat those as corroborating noise, not as clean falsification; the invariant test is the one to trust here. |
| M2 | FIX 1 | Drop `this.cronJobs.set(jobName, { expression, timeout })` from the chunk-wait branch (leaves `removeJob` unable to find/cancel the pending chunk timer) | **RED**, cleanly — exactly the "kills a far-future cron unscheduled mid-chain" test fails (`expected "spy" to not be called at all, but actually been called 1 times`) |
| M3 | FIX 2 | Delete the `if (invalidCronRows.length > 0) { logger.warn(...) }` boot summary block entirely | **RED**, cleanly — exactly the "logs one structured summary..." test fails (`expected [] to have a length of 1 but got +0`); the "does not log a summary when all rows are valid" test still passes (as expected — nothing to falsify there) |
| M4 | FIX 3 | Revert the schedule callback to `runScheduledSync(row.id, row.name)` (the pre-fix stale closure) | **RED**, cleanly — exactly the "resolves the CURRENT integration name at fire time..." test fails (expected `'DingTalk CN Renamed'`, got `'DingTalk CN'`) |

All four mutations applied to a committed real implementation, one at a time, then reverted via `git checkout --` after recording red/green; working tree confirmed clean (`git status --short` / `git diff --stat` empty) and full suite re-verified green before opening this PR.

## Honest gaps / not proven

- FIX 1's early-fire sanity test ("does not fire a far-future cron early, and fires once the full delay elapses") is a behavior pin, not a mutation-falsifiable guard under fake timers (per the brief's own caveat — Node's real `setTimeout` clamp isn't simulated by `vi.useFakeTimers()`). It documents intended behavior and catches gross regressions in the re-arm loop, but the armed-delay invariant test (M1's detector) is the actual falsifiable proof for the clamp property.
- FIX 2's test triggers the catch path via a **mocked scheduler rejection** (`scheduler.schedule` rejects with the real `SimpleCronExpression` error string), not by driving a genuinely-invalid cron string through the real `SchedulerServiceImpl` — consistent with how this test file already mocks the injected scheduler throughout (`createSchedulerMock()`), but noting it as a boundary: this proves the collect-and-summarize wiring, not that `SimpleCronExpression` itself classifies any particular cron as invalid (that's covered elsewhere, in #4053's route-validation tests).
- Not verified against a live DingTalk sync run or production log volume — this is a logging/timer-mechanics change with no route/UI surface, verified at the unit level only, consistent with the rest of this scheduler family's test coverage.
- Landing-coordination check: `git log origin/main --oneline` shows no drift on the three touched files since branch point; searched all currently-open PRs' diffs for `SchedulerService.ts` / `directory-sync-scheduler.ts` — none touch either file. No known collision, but flagging per house convention since this file family has had cross-PR collisions before (#4057 vs #4054).

## Behavior changes for ops

- Boot now emits one additional structured `warn` log line when any directory integration has an unschedulable `schedule_cron` (read-only; no row mutation).
- Every scheduler-triggered sync now issues one extra `SELECT` against `directory_integrations` (to resolve the current display name) before the §7.1 offboarding-digest alert fires — negligible relative to the sync itself.
