### PR TITLE
docs(files): record owner CHANGES-REQUESTED review + F9 fixes (file-security line)

### DIFF
--- a/docs/development/file-evidence-security-line-verification-20260710.md
+++ b/docs/development/file-evidence-security-line-verification-20260710.md
@@ -67,6 +67,31 @@ GF6-3 修迁移注释第三处 stale `'abort' (DEFAULT)`→poison；GF6-4 注释
 
 ---
 
+## §owner 复审 + F9 修复 — owner CHANGES-REQUESTED（2026-07-10）
+
+前批（F1–F6）各过独立 opus 对抗审 0 P1/P2 后，**owner 亲自复审又挖出 3 个 P2**——opus 两轮都漏。
+如实记录（不留「全 opus-clean」的假象）：
+
+| owner 挖出（P2） | 本质 | F9 修法 |
+|---|---|---|
+| **P2-1** multitable 正常删除仍走漂移内存索引 + cleanup 不回收正常软删行 | 我在 F5 把 multitable delete 显式 OUT = **sibling 半修** | `deleteAttachmentBinary` 改 `deleteByKey(storage_path)`（消漂移）+ Option A 补偿（新 `blob_purged_at` 列 + 补偿 sweep，草稿 sweep 连带 stamp） |
+| **P2-2** files delete 的 URL fallback key 未回写 → 失败后 `storage_key=NULL` 被 F5 sweep 排除永不重试 | F5 delete↔sweep 交互洞 | resolve 上移 + 原子 `UPDATE … deleted_at=now(), storage_key=COALESCE(…) WHERE deleted_at IS NULL`（避开「tombstone 后独立 UPDATE→no-op」坑） |
+| **P2-3** F5 sweep poison/shared-key 只 skip 不写终态 → head-of-line 饿死后面可清理 blob | F5 sweep 批次逻辑洞 | SQL 候选阶段 `NOT starts_with(storage_key, FILES_POISON_KEY_PREFIX)` 排除 poison；owner 点名 `batchSize=1 + oldest-poison + newer-valid` 测已加 |
+
+外加 P3（test NUL 字节转义 + F5 四 env 进 .env.example）。
+
+**F9 = PR #4094 → main `66f9edae5`**（Sonnet impl）：opus **深审 APPROVE 0 P1 / 0 新 P2**，4/4 mutation 红→还原；
+且专门做了 **Part-2「同类再猎」——无第四类**（无别的 sibling 漂移删路径、无新 sweep 饿死、回收洞 airtight）。
+审 MD `/tmp/pr4094-f9-review-claude-20260710.md`。
+
+**教训（进本线永久记录）**：
+1. **opus「0 P1/P2」在本线不足以预测 owner 验收**——owner 更深复审三次挖出 opus 漏的问题（F1/F2→F3、F5→3 P2）。
+2. **「已在别处修」≠「这条平行路径也修了」**——sibling delete 路径必须一起修，否则半修 = P2（P2-1 即此）。
+3. 补偿 sweep 默认 OFF 是**故意**（复用默认-ON 的 cleanup flag 会在下次 deploy 静默删每条历史软删 blob）；主修（deleteByKey +
+   交互同步 stamp）是 always-on，与 gate 无关；仅残留真失败尾的补偿受 env 门。
+
+---
+
 ## 落地清单
 | 刀 | PR | main sha | 模型 | opus 审 |
 |---|---|---|---|---|
@@ -74,16 +99,22 @@ GF6-3 修迁移注释第三处 stale `'abort' (DEFAULT)`→poison；GF6-4 注释
 | F3 | #4063 | `7d4cb8027` | opus impl | APPROVE 0 P1/P2·M1-M6 红 |
 | F5 | #4072 | `0012422fe` | sonnet impl | APPROVE 0 P1/P2·7/7 mutation 红 |
 | F6 | #4076 | `a9ceef97e` | sonnet impl | APPROVE 0 P1/P2 |
+| **F9**（owner-P2 修复） | #4094 | `66f9edae5` | sonnet impl | APPROVE 0 P1/**0 新** P2·4/4 mutation 红·Part-2 再猎无第四类 |
 
-迁移 on `main`：`zzzz20260710140000_add_files_storage_key.ts`（F3）+ `zzzz20260710150000_add_files_blob_purged_at.ts`（F5）。
+迁移 on `main`：`zzzz20260710140000_add_files_storage_key.ts`（F3）+ `zzzz20260710150000_add_files_blob_purged_at.ts`（F5）
++ `zzzz20260711090000_add_multitable_attachments_blob_purged_at.ts`（F9）。
 
-## 余下 owner 决策项（不阻塞已落地部分；本线自主层已尽）
-1. **硬化池关闭 / tracker 状态**：owner 复审后判定；本文与本次自主层**未触碰 tracker**、未宣布关池。
-2. **F4 审批人 approval-scoped read grant**：新授权路径（权限层，须 owner 逐刀显式授权）+ 当前无活需求方（审批 UI 未
-   渲染照片）→ 未自动开工。若授权：机制 A（plugin 端点 `/api/attendance/requests/:id/evidence`，复用批准门
-   `assertAttendanceRequestApprovalAllowed`，正向核对 + status 生命周期，与本线零碰撞）。
-3. **F7 深度图片校验**：owner 已接受 lazy-forgery 威胁为 P3 → 默认不做。
-4. **listFiles 接口移除 + setStorage/getStorage plugin 契约移除**：属公开接口/插件契约变更（非局部死码），留 owner 决策。
+## 余下 = owner 决策 / ops / 红线（**非自主开发项**；自主开发层已尽）
+> 说明：以下**不是**我在拖延的「开发」——是定义上非自主的项（红线只 owner 能解、tracker 是 owner 的账、env 是部署动作）。
+1. **硬化池关闭 / tracker 状态**：owner 复审后判定；本文与自主层**均未触碰 tracker**、未宣布关池（状态仍 OPEN）。
+2. **F4 审批人 read grant 实现**：新授权路径（权限层，须 owner 逐刀显式授权）+ 无活需求方（审批 UI 未渲染照片）→ 设计已定
+   （见 §owner 决策项引用的 f4-design-lock；机制 A，复用批准门 `assertAttendanceRequestApprovalAllowed`，与本线零碰撞），**实现 gated**。
+3. **retention env prod 启用**（ops）：`FILES_ORPHAN_BLOB_RETENTION_ENABLED` / `MULTITABLE_ATTACHMENT_BLOB_RETENTION_ENABLED`
+   默认 OFF；启用兜住残留真失败尾（**不影响主修生效**——主修 always-on）。
+4. **F7 深度图片校验**：owner 已接受 lazy-forgery 威胁为 P3 → 默认不做。
+5. **listFiles 接口移除 + setStorage/getStorage plugin 契约移除**（F8，cosmetic）：公开接口/插件契约收窄，非局部死码，留 owner 决策；暂停。
+6. **N1 NIT（后补）**：`isDatabaseSchemaError` 未认 42703（undefined_column）；F9 后 default-ON 草稿 sweep 耦合新列，
+   deploy-before-migrate 窗口优雅降级不崩、迁移后自愈，仅日志文案影响。
 
 ## 部署提示
 本线引入两个新迁移。按 deploy SOP：镜像拉取部署前 diff pending migrations、**先迁移后代码**、验证一次 auth round-trip。


### PR DESCRIPTION
Amends the file-evidence-security verification record (docs-only) to record your CHANGES-REQUESTED review + the F9 fixes.

- Adds the "owner 复审 + F9 修复" chapter: the 3 P2s you found (which two opus reviews missed), F9's per-P2 fixes, the deep-review APPROVE 0 P1/0-new-P2 + "hunt found no fourth class", and the lessons.
- Adds F9 (#4094, `66f9edae5`) to the landing table + its migration.
- Refreshes the residue as owner/ops/red-line items (F4 impl, tracker close, retention env), explicitly not withheld development.

Not a closeout: pool status OPEN, tracker untouched. refs #3925

🤖 Generated with [Claude Code](https://claude.com/claude-code)