### PR TITLE
fix(attendance): expand import options in strict gates

### DIFF
--- a/scripts/ops/attendance-run-gate-contract-case.sh
+++ b/scripts/ops/attendance-run-gate-contract-case.sh
@@ -89,6 +89,9 @@ function expect_fail() {
 }
 
 if [[ "$CASE_ID" == "strict" ]]; then
+  info "running strict import advanced-panel contract"
+  node --test ./scripts/ops/attendance-strict-import-advanced-contract.test.mjs
+
   cp "$valid_summary" "${strict_dir}/gate-summary.json"
   ./scripts/ops/attendance-validate-gate-summary.sh "$strict_dir" 1
   node ./scripts/ops/attendance-validate-gate-summary-schema.mjs \

--- a/scripts/ops/attendance-strict-import-advanced-contract.test.mjs
+++ b/scripts/ops/attendance-strict-import-advanced-contract.test.mjs
@@ -9,6 +9,7 @@ const read = (file) => readFileSync(path.join(repoRoot, file), 'utf8')
 const productionFlow = read('scripts/verify-attendance-production-flow.mjs')
 const fullFlow = read('scripts/verify-attendance-full-flow.mjs')
 const attendanceView = read('apps/web/src/views/AttendanceView.vue')
+const gateContractRunner = read('scripts/ops/attendance-run-gate-contract-case.sh')
 
 function functionSlice(raw, name, nextDeclaration) {
   const start = raw.indexOf(`async function ${name}`)
@@ -69,4 +70,13 @@ test('full flow opens advanced options in retry and recovery entry points', () =
 
   assert.match(retry, /const payloadInput = await ensureImportAdvancedOptionsVisible\(importSection\)/)
   assert.match(recovery, /const payloadInput = await ensureImportAdvancedOptionsVisible\(importSection\)/)
+})
+
+test('required strict contract case executes this verifier contract', () => {
+  const strictCase = gateContractRunner.slice(
+    gateContractRunner.indexOf('if [[ "$CASE_ID" == "strict" ]]'),
+    gateContractRunner.indexOf('if [[ "$CASE_ID" == "openapi" ]]'),
+  )
+
+  assert.match(strictCase, /node --test \.\/scripts\/ops\/attendance-strict-import-advanced-contract\.test\.mjs/)
 })

--- a/scripts/ops/attendance-strict-import-advanced-contract.test.mjs
+++ b/scripts/ops/attendance-strict-import-advanced-contract.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const read = (file) => readFileSync(path.join(repoRoot, file), 'utf8')
+
+const productionFlow = read('scripts/verify-attendance-production-flow.mjs')
+const fullFlow = read('scripts/verify-attendance-full-flow.mjs')
+const attendanceView = read('apps/web/src/views/AttendanceView.vue')
+
+function functionSlice(raw, name, nextDeclaration) {
+  const start = raw.indexOf(`async function ${name}`)
+  const end = raw.indexOf(`\n${nextDeclaration}`, start + 1)
+  assert.notEqual(start, -1, `${name} must exist`)
+  assert.ok(end > start, `${name} must have a bounded function body`)
+  return raw.slice(start, end)
+}
+
+test('attendance import payload remains inside the collapsed advanced panel contract', () => {
+  const toggle = attendanceView.indexOf('data-testid="attendance-import-advanced-toggle"')
+  const advanced = attendanceView.indexOf('data-testid="attendance-import-advanced"', toggle + 1)
+  const payload = attendanceView.indexOf('id="attendance-import-payload"', advanced + 1)
+
+  assert.notEqual(toggle, -1)
+  assert.notEqual(advanced, -1)
+  assert.notEqual(payload, -1)
+  assert.ok(toggle < advanced)
+  assert.ok(advanced < payload)
+  assert.match(attendanceView.slice(advanced - 120, advanced + 120), /v-show="importAdvancedOpen"/)
+})
+
+for (const [name, raw] of [
+  ['production flow', productionFlow],
+  ['full flow', fullFlow],
+]) {
+  test(`${name} expands advanced import options before using the payload`, () => {
+    const helper = functionSlice(raw, 'ensureImportAdvancedOptionsVisible', name === 'production flow'
+      ? 'async function waitForJsonResponse'
+      : 'function squashWhitespace')
+
+    assert.match(helper, /payloadInput\.isVisible\(\)\.catch/)
+    assert.match(helper, /attendance-import-advanced-toggle/)
+    assert.match(helper, /const expanded = await toggle\.getAttribute\('aria-expanded'\)/)
+    assert.match(helper, /if \(expanded !== 'true'\)/)
+    assert.match(helper, /await toggle\.click\(\)/)
+    assert.match(helper, /attendance-import-advanced/)
+    assert.match(helper, /payloadInput\.waitFor\(\{ state: 'visible', timeout: waitMs \}\)/)
+    assert.match(helper, /return payloadInput/)
+  })
+}
+
+test('production flow opens advanced options after loading the import template', () => {
+  const loadTemplate = productionFlow.indexOf("uiText.loadTemplate) }).click()")
+  const expand = productionFlow.indexOf('await ensureImportAdvancedOptionsVisible(importSection)', loadTemplate)
+  const buildCsv = productionFlow.indexOf('// Prepare a tiny CSV', loadTemplate)
+
+  assert.notEqual(loadTemplate, -1)
+  assert.notEqual(expand, -1)
+  assert.notEqual(buildCsv, -1)
+  assert.ok(loadTemplate < expand)
+  assert.ok(expand < buildCsv)
+})
+
+test('full flow opens advanced options in retry and recovery entry points', () => {
+  const retry = functionSlice(fullFlow, 'assertAdminRetryState', 'async function assertAdminSettingsSaveCycle')
+  const recovery = functionSlice(fullFlow, 'assertImportJobRecoveryFlow', 'async function run')
+
+  assert.match(retry, /const payloadInput = await ensureImportAdvancedOptionsVisible\(importSection\)/)
+  assert.match(recovery, /const payloadInput = await ensureImportAdvancedOptionsVisible\(importSection\)/)
+})

--- a/scripts/verify-attendance-full-flow.mjs
+++ b/scripts/verify-attendance-full-flow.mjs
@@ -420,6 +420,27 @@ async function selectAdminSection(page, sectionId, headingName = null) {
   return section
 }
 
+async function ensureImportAdvancedOptionsVisible(importSection, waitMs = adminReadyTimeoutMs) {
+  // #3708 moved payload JSON behind a collapsed advanced panel. Older deployments have no toggle.
+  const payloadInput = importSection.locator('#attendance-import-payload').first()
+  if (await payloadInput.isVisible().catch(() => false)) return payloadInput
+
+  const toggle = importSection.locator('[data-testid="attendance-import-advanced-toggle"]').first()
+  if (await toggle.count()) {
+    const expanded = await toggle.getAttribute('aria-expanded')
+    if (expanded !== 'true') {
+      await toggle.click()
+    }
+    const advanced = importSection.locator('[data-testid="attendance-import-advanced"]').first()
+    if (await advanced.count()) {
+      await advanced.waitFor({ state: 'visible', timeout: waitMs })
+    }
+  }
+
+  await payloadInput.waitFor({ state: 'visible', timeout: waitMs })
+  return payloadInput
+}
+
 function squashWhitespace(value) {
   return String(value || '').replace(/\s+/g, ' ').trim()
 }
@@ -448,13 +469,12 @@ async function collectAdminImportDebugState(page) {
 }
 
 async function assertAdminRetryState(page, importSection) {
-  const payloadInput = importSection.locator('#attendance-import-payload').first()
+  const payloadInput = await ensureImportAdvancedOptionsVisible(importSection)
   const previewButton = importSection.getByRole('button', { name: labels.preview }).first()
   const adminStatusBlock = page.locator('div.attendance__status-block--admin').first()
   const invalidJsonMessage = adminStatusBlock.getByText(labels.invalidImportJson).first()
   const retryPreviewButton = adminStatusBlock.getByRole('button', { name: labels.retryPreview }).first()
 
-  await payloadInput.waitFor({ timeout: adminReadyTimeoutMs })
   await previewButton.waitFor({ timeout: adminReadyTimeoutMs })
 
   if (await invalidJsonMessage.isVisible().catch(() => false) || await retryPreviewButton.isVisible().catch(() => false)) {
@@ -754,9 +774,8 @@ async function resolveRecoveryUserId(apiBase) {
 
 async function assertImportJobRecoveryFlow(page, importSection, apiBase) {
   logInfo('Admin import recovery assertion started')
-  const payloadInput = importSection.locator('#attendance-import-payload').first()
+  const payloadInput = await ensureImportAdvancedOptionsVisible(importSection)
   const importButton = importSection.getByRole('button', { name: labels.import }).first()
-  await payloadInput.waitFor({ timeout: adminReadyTimeoutMs })
   await importButton.waitFor({ timeout: adminReadyTimeoutMs })
 
   const profileSelect = importSection.locator('#attendance-import-profile').first()

--- a/scripts/verify-attendance-production-flow.mjs
+++ b/scripts/verify-attendance-production-flow.mjs
@@ -277,6 +277,27 @@ async function selectAdminSection(page, sectionId, headingName, waitMs = timeout
   return section
 }
 
+async function ensureImportAdvancedOptionsVisible(importSection, waitMs = timeoutMs) {
+  // #3708 moved payload JSON behind a collapsed advanced panel. Older deployments have no toggle.
+  const payloadInput = importSection.locator('#attendance-import-payload').first()
+  if (await payloadInput.isVisible().catch(() => false)) return payloadInput
+
+  const toggle = importSection.locator('[data-testid="attendance-import-advanced-toggle"]').first()
+  if (await toggle.count()) {
+    const expanded = await toggle.getAttribute('aria-expanded')
+    if (expanded !== 'true') {
+      await toggle.click()
+    }
+    const advanced = importSection.locator('[data-testid="attendance-import-advanced"]').first()
+    if (await advanced.count()) {
+      await advanced.waitFor({ state: 'visible', timeout: waitMs })
+    }
+  }
+
+  await payloadInput.waitFor({ state: 'visible', timeout: waitMs })
+  return payloadInput
+}
+
 async function waitForJsonResponse(page, predicate, { label }) {
   const response = await page.waitForResponse(predicate, { timeout: timeoutMs })
   const raw = await response.text()
@@ -527,7 +548,7 @@ async function run() {
 
   logInfo('Loading import template')
   await importSection.getByRole('button', { name: exactNamePattern(uiText.loadTemplate) }).click()
-  await page.locator('#attendance-import-payload').waitFor({ timeout: timeoutMs })
+  await ensureImportAdvancedOptionsVisible(importSection)
 
   // Prepare a tiny CSV with explicit UserId so we don't need user-map.
   const groupName = `E2E Group ${Date.now().toString(36)}`


### PR DESCRIPTION
## What

- Expand the attendance import advanced panel before the production-flow verifier reads payload JSON.
- Apply the same behavior to full-flow retry and import-recovery assertions.
- Preserve compatibility with older deployments where the advanced toggle does not exist.
- Add a contract test binding both verifiers to the current collapsed-panel UI structure.
- Execute that contract from the required `contracts (strict)` matrix case.

## Why

Attendance Strict Gates runs reach API smoke, provisioning, and mobile flow, while production and desktop time out on hidden `#attendance-import-payload`. PR #3708 intentionally moved payload JSON into a collapsed advanced panel, but the strict verifiers did not open it.

Refs #189. Keep #189 open until a deployed SHA receives a fresh strict-gate PASS.

## Verification at exact head `ffcbfdd509ed6f1622857f2e86d381b3cd818b19`

- GitHub checks: 11/11 SUCCESS, including required `contracts (strict)`, Node 18/20, web-tests, and coverage
- Focused verifier/workflow contracts: 11/11 PASS
- Required strict contract case, including expected-negative schema checks: PASS
- All other attendance-prefixed ops tests: 200/200 PASS
- `node --check` on both verifier scripts: PASS
- `bash -n` on the strict contract runner: PASS
- `git diff --check`: PASS

The excluded `attendance-fast-parallel-regression.test.mjs` has a separate macOS Bash 3.2 empty-worker regression addressed by #4135; it is not caused by this patch.

## Remaining runtime gate

No production workflow was dispatched by this PR. After owner merge and a successful application deploy containing this fix, rerun Attendance Strict Gates and require both `playwrightProd` and `playwrightDesktop` to pass. Production deployment is currently blocked by #159 host filesystem pressure.