### PR TITLE
feat(directory): make directory-sync N+1 (user/get fan-out) ops-verifiable (§7.7)

### DIFF
--- a/packages/core-backend/src/directory/directory-sync-api-telemetry.ts
+++ b/packages/core-backend/src/directory/directory-sync-api-telemetry.ts
@@ -1,0 +1,73 @@
+/**
+ * DT-PERF (roadmap §7.7 "Sync Performance") — make the directory-sync external API call
+ * pattern OPS-VERIFIABLE.
+ *
+ * The pull walks the department tree and, for every UNIQUE user it sees, issues one
+ * `topapi/v2/user/get` detail call (directory-sync.ts `fetchAllUsers`). On a 2,000-employee
+ * tenant that is ~2,000 sequential HTTP round trips — the N+1 the roadmap targets. The fix
+ * itself (prefer `user/list` fields, detail only when missing) is STAGING-GATED: it cannot be
+ * proven here that `user/list` returns every field the sync reads, so this module does NOT
+ * change WHICH fields are read. It only instruments the call pattern so an operator can SEE
+ * the cost on the run record and later prove the staging fix helped (before/after
+ * `externalUserDetailCalls`).
+ *
+ * Counters are per DIRECTORY-PULL client invocation — one increment per real call at the
+ * `fetchAllDepartments` / `fetchAllUsers` call sites. They are folded into the sync run's
+ * `stats` JSONB (see `summarizeDirectorySyncApiCalls`), which `summarizeRun` already returns
+ * verbatim, so the counts reach the runs API/UI with no new surface.
+ */
+
+/** One counter per external directory-pull client call issued during a sync run. */
+export interface DirectorySyncApiCallCounters {
+  /** `department/listsub` pages (one per department visited in the BFS). */
+  departmentListCalls: number
+  /** `department/get` detail calls (dept-manager enrichment; one per department, best-effort). */
+  departmentDetailCalls: number
+  /** `user/listsub` pages (one per page per department; more pages = larger tenant). */
+  userListPageCalls: number
+  /**
+   * `user/get` detail calls — THE N+1. One per UNIQUE user (deduped: a user in two
+   * departments is fetched once). Compare against `accountsSynced`: when they are ~equal the
+   * per-user detail fan-out is fully in play.
+   */
+  userDetailCalls: number
+}
+
+/** A fresh zeroed counter set for one sync run. */
+export function createDirectorySyncApiCallCounters(): DirectorySyncApiCallCounters {
+  return {
+    departmentListCalls: 0,
+    departmentDetailCalls: 0,
+    userListPageCalls: 0,
+    userDetailCalls: 0,
+  }
+}
+
+/**
+ * The stats-JSONB projection of the counters. Keys are prefixed `external*` so ops can see at
+ * a glance these are network cost, not row counts.
+ *
+ * `externalDirectoryPullCalls` is the SUM OF THE FOUR PULL CATEGORIES above — deliberately NOT
+ * named "total": it excludes the (cached) app-access-token fetch and the manual-run diagnostic
+ * sample, which are not part of the per-user fan-out and whose logical-vs-HTTP count is
+ * ambiguous. It is the honest aggregate of what the directory pull itself costs.
+ */
+export function summarizeDirectorySyncApiCalls(counters: DirectorySyncApiCallCounters): {
+  externalDepartmentListCalls: number
+  externalDepartmentDetailCalls: number
+  externalUserListPageCalls: number
+  externalUserDetailCalls: number
+  externalDirectoryPullCalls: number
+} {
+  return {
+    externalDepartmentListCalls: counters.departmentListCalls,
+    externalDepartmentDetailCalls: counters.departmentDetailCalls,
+    externalUserListPageCalls: counters.userListPageCalls,
+    externalUserDetailCalls: counters.userDetailCalls,
+    externalDirectoryPullCalls:
+      counters.departmentListCalls +
+      counters.departmentDetailCalls +
+      counters.userListPageCalls +
+      counters.userDetailCalls,
+  }
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -21,6 +21,11 @@ import {
   mergeDeptManagerIntoRaw,
   resolveManagerListForDept,
 } from './department-manager-enrichment'
+import {
+  createDirectorySyncApiCallCounters,
+  summarizeDirectorySyncApiCalls,
+  type DirectorySyncApiCallCounters,
+} from './directory-sync-api-telemetry'
 import { assertDingTalkCorpAllowed } from '../integrations/dingtalk/runtime-policy'
 import {
   deriveDelegatedAdminNamespace,
@@ -2405,7 +2410,13 @@ export async function testDirectoryIntegration(input: DirectoryIntegrationTestIn
   }
 }
 
-async function fetchAllDepartments(config: DirectoryIntegrationConfig, integrationName: string): Promise<Map<string, DingTalkDepartment>> {
+export async function fetchAllDepartments(
+  config: DirectoryIntegrationConfig,
+  integrationName: string,
+  // §7.7 telemetry: increment per external directory-pull call so the N+1 is ops-visible on
+  // the run record. Optional — the preview path (no run row) omits it.
+  apiCalls?: DirectorySyncApiCallCounters,
+): Promise<Map<string, DingTalkDepartment>> {
   const accessToken = await fetchDingTalkAppAccessToken({
     appKey: config.appKey,
     appSecret: config.appSecret,
@@ -2424,6 +2435,7 @@ async function fetchAllDepartments(config: DirectoryIntegrationConfig, integrati
   while (queue.length > 0) {
     const current = queue.shift()
     if (!current) continue
+    if (apiCalls) apiCalls.departmentListCalls += 1
     const children = await listDingTalkDepartments(accessToken, current, { baseUrl: config.baseUrl })
     for (const child of children) {
       const existing = departments.get(child.id)
@@ -2439,7 +2451,10 @@ async function fetchAllDepartments(config: DirectoryIntegrationConfig, integrati
   // the prior dept_manager_userid_list forward instead of wiping it.
   await enrichDepartmentsWithManagers(
     departments.values(),
-    (deptId) => getDingTalkDepartmentDetail(accessToken, deptId, { baseUrl: config.baseUrl }),
+    (deptId) => {
+      if (apiCalls) apiCalls.departmentDetailCalls += 1
+      return getDingTalkDepartmentDetail(accessToken, deptId, { baseUrl: config.baseUrl })
+    },
     (deptId, error) =>
       logger.warn(
         `dept-head: department/get failed for dept ${deptId} (integration ${integrationName}); carrying prior forward: ${readErrorMessage(error, 'unknown error')}`,
@@ -2453,9 +2468,12 @@ function mergeDepartmentIds(primary: string[], secondary: string[]): string[] {
   return Array.from(new Set([...primary, ...secondary].filter(Boolean)))
 }
 
-async function fetchAllUsers(
+export async function fetchAllUsers(
   config: DirectoryIntegrationConfig,
   departmentMap: Map<string, DingTalkDepartment>,
+  // §7.7 telemetry: `userDetailCalls` is THE N+1 metric — one `user/get` per unique user.
+  // Optional — the preview path (no run row) omits it.
+  apiCalls?: DirectorySyncApiCallCounters,
 ): Promise<Map<string, DingTalkDirectoryUser>> {
   const accessToken = await fetchDingTalkAppAccessToken({
     appKey: config.appKey,
@@ -2469,6 +2487,7 @@ async function fetchAllUsers(
     let cursor = 0
     let hasMore = true
     while (hasMore) {
+      if (apiCalls) apiCalls.userListPageCalls += 1
       const response = await listDingTalkDepartmentUsers(
         accessToken,
         departmentId,
@@ -2479,6 +2498,9 @@ async function fetchAllUsers(
       for (const summary of response.users) {
         const existing = users.get(summary.userId)
         if (!existing) {
+          // The N+1: a per-user detail fetch, issued once per UNIQUE user (this branch only
+          // runs on first sight — a user in two departments is fetched once).
+          if (apiCalls) apiCalls.userDetailCalls += 1
           const detail = await getDingTalkUserDetail(accessToken, summary.userId, { baseUrl: config.baseUrl })
           users.set(summary.userId, {
             ...detail,
@@ -2883,14 +2905,18 @@ export async function syncDirectoryIntegration(
   }, DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS)
   heartbeat.unref?.()
 
+  // §7.7 telemetry: one counter set per run, incremented at each external directory-pull call
+  // site (departments + users) so the N+1 detail fan-out is measurable on the run record.
+  const apiCallCounters = createDirectorySyncApiCallCounters()
+
   try {
-    const departments = await fetchAllDepartments(config, integration.name)
+    const departments = await fetchAllDepartments(config, integration.name, apiCallCounters)
     const departmentPathMap = buildDepartmentPathMap(departments)
     // dept-head plumbing: capture last-known-good dept_manager_userid_list BEFORE the
     // whole-column upsert (raw = EXCLUDED.raw) overwrites raw, so a failed department/get
     // (managerUserIds left undefined) carries the prior value forward instead of wiping it.
     const priorDeptManagers = await capturePriorDeptManagers(integrationId, query)
-    const users = await fetchAllUsers(config, departments)
+    const users = await fetchAllUsers(config, departments, apiCallCounters)
 
     let directoryDiagnosticStats: JsonRecord = {}
     if (triggerSource === 'manual') {
@@ -3357,6 +3383,11 @@ export async function syncDirectoryIntegration(
       const stats = {
         departmentsSynced: departments.size,
         accountsSynced: users.size,
+        // §7.7 sync-performance telemetry — external directory-pull call counts for THIS run.
+        // `externalUserDetailCalls` is the N+1: compare it against `accountsSynced` (≈ equal
+        // means one `user/get` per account). Makes the eventual `user/list` staging fix
+        // provable via before/after on this number. Additive; all pre-existing keys kept.
+        ...summarizeDirectorySyncApiCalls(apiCallCounters),
         // R5 per-run change summary — all additive; every pre-existing key above/below is kept.
         departmentsCreatedCount,
         departmentsUpdatedCount,

--- a/packages/core-backend/tests/integration/directory-sync-preview-apply-parity.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-preview-apply-parity.db.test.ts
@@ -523,6 +523,11 @@ describeIfDatabase('DT-OPS-02 preview/apply parity — intra-batch identity dupl
     // that real count is what got written to the run record.
     expect(detailCallsThisRun).toBeGreaterThan(0)
     expect(stats.externalUserDetailCalls).toBe(detailCallsThisRun)
+    // CURRENT-N+1 CANARY (expected to break with the §7.7 staging fix): this equality holds
+    // only while EVERY user takes a `user/get`. When `user/list` becomes the primary field
+    // source (detail only when fields are missing), `externalUserDetailCalls` will drop BELOW
+    // `accountsSynced` — that is the fix working, not a regression. Relax this line to
+    // `toBeLessThanOrEqual` (and assert the drop) when that flip lands.
     expect(stats.externalUserDetailCalls).toBe(stats.accountsSynced)
 
     // The other pull categories are present and positive (departments are walked + detailed,

--- a/packages/core-backend/tests/integration/directory-sync-preview-apply-parity.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-preview-apply-parity.db.test.ts
@@ -505,4 +505,38 @@ describeIfDatabase('DT-OPS-02 preview/apply parity — intra-batch identity dupl
     )
     expect(newUserCount.rows[0].n).toBe('3')
   })
+
+  // §7.7 Sync Performance — the N+1 `user/get` fan-out must be OPS-VISIBLE: its count has to
+  // land in the persisted run `stats` (which `summarizeRun` returns verbatim to the runs API).
+  // Non-tautological anchor: the persisted `externalUserDetailCalls` is pinned to the ACTUAL
+  // per-run `getDingTalkUserDetail` mock invocation delta AND to `accountsSynced` — a stale or
+  // wrong counter can't satisfy all three at once.
+  it('persists external directory-pull call telemetry in run stats, with externalUserDetailCalls = one user/get per synced account (the N+1)', async () => {
+    const detailCallsBefore = clientMocks.getDingTalkUserDetail.mock.calls.length
+
+    const result = await syncDirectoryIntegration(integrationId, 'system:dt3915-telemetry-test')
+    const stats = result.run.stats as Record<string, number>
+
+    const detailCallsThisRun = clientMocks.getDingTalkUserDetail.mock.calls.length - detailCallsBefore
+
+    // The N+1, made measurable: this run issued exactly one user/get per unique account, and
+    // that real count is what got written to the run record.
+    expect(detailCallsThisRun).toBeGreaterThan(0)
+    expect(stats.externalUserDetailCalls).toBe(detailCallsThisRun)
+    expect(stats.externalUserDetailCalls).toBe(stats.accountsSynced)
+
+    // The other pull categories are present and positive (departments are walked + detailed,
+    // users are listed page-by-page).
+    expect(stats.externalDepartmentListCalls).toBeGreaterThan(0)
+    expect(stats.externalDepartmentDetailCalls).toBeGreaterThan(0)
+    expect(stats.externalUserListPageCalls).toBeGreaterThan(0)
+
+    // The aggregate is the honest sum of the four pull categories (not a mislabeled "total").
+    expect(stats.externalDirectoryPullCalls).toBe(
+      stats.externalDepartmentListCalls +
+        stats.externalDepartmentDetailCalls +
+        stats.externalUserListPageCalls +
+        stats.externalUserDetailCalls,
+    )
+  })
 })

--- a/packages/core-backend/tests/unit/directory-sync-api-telemetry.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-api-telemetry.test.ts
@@ -1,0 +1,163 @@
+/**
+ * §7.7 Sync Performance — the external directory-pull call counters must count what actually
+ * happens. This drives the REAL `fetchAllDepartments` / `fetchAllUsers` (the sync's pull code
+ * path) with only the DingTalk HTTP client mocked (the network boundary), so the increments
+ * under test run in real code. No DB — runs in the required test(20.x) job.
+ *
+ * The load-bearing property is the N+1 signature: exactly one `user/get` per UNIQUE user.
+ * The fixture puts one user in TWO departments; the assertions pin BOTH the counter AND the
+ * client mock's call count to the unique-user total, so the counter cannot be satisfied by a
+ * stale/tautological value — remove the `userDetailCalls += 1` increment and the counter goes
+ * to 0 while the mock call count stays 4 (they diverge → RED).
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+const clientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: clientMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: clientMocks.listDingTalkDepartments,
+  getDingTalkDepartmentDetail: clientMocks.getDingTalkDepartmentDetail,
+  listDingTalkDepartmentUsers: clientMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
+}))
+
+import { fetchAllDepartments, fetchAllUsers } from '../../src/directory/directory-sync'
+import {
+  createDirectorySyncApiCallCounters,
+  summarizeDirectorySyncApiCalls,
+} from '../../src/directory/directory-sync-api-telemetry'
+
+const ROOT = 'r'
+const DEPT_A = 'A'
+const DEPT_B = 'B'
+
+// minimal config — the pull helpers only read appKey/appSecret/baseUrl/rootDepartmentId/pageSize.
+const config = {
+  appKey: 'k',
+  appSecret: 's',
+  workNotificationAgentId: '',
+  rootDepartmentId: ROOT,
+  baseUrl: 'https://example.test',
+  pageSize: 100,
+  admissionMode: 'disabled',
+  admissionDepartmentIds: [],
+  excludeDepartmentIds: [],
+  memberGroupSyncMode: 'disabled',
+  memberGroupDepartmentIds: [],
+  memberGroupDefaultRoleIds: [],
+  memberGroupDefaultNamespaces: [],
+} as unknown as Parameters<typeof fetchAllDepartments>[0]
+
+function dept(id: string, parentId: string | null, name: string) {
+  return { id, parentId, name, order: 0, source: {} }
+}
+function summary(userId: string, deptId: string) {
+  return { userId, name: userId, departmentIds: [deptId], source: {} }
+}
+function detail(userId: string) {
+  return { userId, name: userId, departmentIds: [], source: {} }
+}
+
+function wireClient() {
+  clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('app-token')
+  // BFS: root -> [A, B]; A -> []; B -> []  => 3 listsub calls (r, A, B).
+  clientMocks.listDingTalkDepartments.mockImplementation(async (_t: string, parentId: string) => {
+    if (parentId === ROOT) return [dept(DEPT_A, ROOT, 'A'), dept(DEPT_B, ROOT, 'B')]
+    return []
+  })
+  // department/get is called once per department (root + A + B = 3).
+  clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+  // Users:
+  //   root -> 1 page, 0 users
+  //   A    -> 2 pages: [U1,U2] then [U3]  (pagination proves pages counted, not departments)
+  //   B    -> 1 page:  [U3,U4]            (U3 shared with A -> detail fetched ONCE)
+  clientMocks.listDingTalkDepartmentUsers.mockImplementation(
+    async (_t: string, deptId: string, cursor: number) => {
+      if (deptId === DEPT_A && cursor === 0) {
+        return { users: [summary('U1', DEPT_A), summary('U2', DEPT_A)], nextCursor: 100, hasMore: true }
+      }
+      if (deptId === DEPT_A && cursor === 100) {
+        return { users: [summary('U3', DEPT_A)], nextCursor: null, hasMore: false }
+      }
+      if (deptId === DEPT_B) {
+        return { users: [summary('U3', DEPT_B), summary('U4', DEPT_B)], nextCursor: null, hasMore: false }
+      }
+      return { users: [], nextCursor: null, hasMore: false }
+    },
+  )
+  clientMocks.getDingTalkUserDetail.mockImplementation(async (_t: string, userId: string) => detail(userId))
+}
+
+describe('§7.7 directory-sync external API call telemetry', () => {
+  it('fetchAllDepartments counts one listsub per department visited and one department/get per department', async () => {
+    vi.clearAllMocks()
+    wireClient()
+    const counters = createDirectorySyncApiCallCounters()
+
+    const departments = await fetchAllDepartments(config, 'Acme', counters)
+
+    // root + A + B
+    expect(departments.size).toBe(3)
+    expect(counters.departmentListCalls).toBe(3)
+    expect(counters.departmentDetailCalls).toBe(3)
+    // both-assertions: the counter equals the actual client invocation count, so it can't be
+    // a stale/tautological value.
+    expect(clientMocks.listDingTalkDepartments.mock.calls.length).toBe(3)
+    expect(clientMocks.getDingTalkDepartmentDetail.mock.calls.length).toBe(3)
+  })
+
+  it('fetchAllUsers issues exactly one user/get per UNIQUE user (the N+1 signature) and counts every list page', async () => {
+    vi.clearAllMocks()
+    wireClient()
+    const departmentMap = await fetchAllDepartments(config, 'Acme')
+    const counters = createDirectorySyncApiCallCounters()
+
+    const users = await fetchAllUsers(config, departmentMap, counters)
+
+    // U1, U2, U3, U4 — U3 appears in both A and B but is deduped.
+    expect([...users.keys()].sort()).toEqual(['U1', 'U2', 'U3', 'U4'])
+
+    // THE N+1: one user/get per unique user, NOT per (user × department) occurrence (which is 5).
+    expect(counters.userDetailCalls).toBe(4)
+    // both-assertions non-tautology: counter tracks the real client call count. Remove the
+    // increment and this stays 4 while the counter drops to 0 -> divergence -> RED.
+    expect(clientMocks.getDingTalkUserDetail.mock.calls.length).toBe(4)
+
+    // Pages: root(1) + A(2) + B(1) = 4 — proves pages are counted, not departments (3).
+    expect(counters.userListPageCalls).toBe(4)
+    expect(clientMocks.listDingTalkDepartmentUsers.mock.calls.length).toBe(4)
+  })
+
+  it('summarizeDirectorySyncApiCalls projects external* keys and an honest pull-only aggregate', () => {
+    const summarized = summarizeDirectorySyncApiCalls({
+      departmentListCalls: 3,
+      departmentDetailCalls: 3,
+      userListPageCalls: 4,
+      userDetailCalls: 4,
+    })
+    expect(summarized).toEqual({
+      externalDepartmentListCalls: 3,
+      externalDepartmentDetailCalls: 3,
+      externalUserListPageCalls: 4,
+      externalUserDetailCalls: 4,
+      externalDirectoryPullCalls: 14, // 3 + 3 + 4 + 4 — sum of the four pull categories
+    })
+  })
+
+  it('counters passed to neither helper stay pristine (optional param is truly optional)', async () => {
+    vi.clearAllMocks()
+    wireClient()
+    // no counter argument — must not throw and must still return the full pull.
+    const departmentMap = await fetchAllDepartments(config, 'Acme')
+    const users = await fetchAllUsers(config, departmentMap)
+    expect(departmentMap.size).toBe(3)
+    expect(users.size).toBe(4)
+  })
+})


### PR DESCRIPTION
## What / why

Roadmap **§7.7 Sync Performance** targets the directory-sync N+1: `fetchAllUsers` issues one `topapi/v2/user/get` **detail call per unique user**, so a 2,000-employee tenant does ~2,000 sequential HTTP round trips inside the pull.

The actual §7.7 fix ("prefer `user/list` as the primary field source") is **staging-gated** — it cannot be verified here that `user/list` returns every field the sync reads (no real DingTalk tenant). So this PR does **not** change WHICH fields are read. It makes the N+1 **ops-verifiable**: instrument the external call pattern and surface it on the run record, so operators can measure the cost and later **prove the staging fix helped** via before/after on `externalUserDetailCalls`.

## What this instruments

New pure module `directory-sync-api-telemetry.ts` (per-run counters + a `summarizeDirectorySyncApiCalls` fold), incremented at each external directory-pull call site in `fetchAllDepartments` / `fetchAllUsers`:

| stats key | meaning |
|---|---|
| `externalDepartmentListCalls` | `department/listsub` pages |
| `externalDepartmentDetailCalls` | `department/get` (dept-manager enrichment) |
| `externalUserListPageCalls` | `user/listsub` pages |
| **`externalUserDetailCalls`** | **`user/get` — THE N+1** (one per UNIQUE user; deduped) |
| `externalDirectoryPullCalls` | sum of the four above |

- `userDetailCalls` increments only on first sight of a userId, so a user in two departments is counted once — the counter equals the unique-user total, which is the N+1 signature.
- Folded into the run's `stats` JSONB next to `accountsSynced`. `summarizeRun` already returns the whole `stats` blob, so `GET /integrations/:id/runs` surfaces the new keys with **no route/UI change**. When `externalUserDetailCalls` ≈ `accountsSynced`, the per-user fan-out is fully in play — the exact number the staging fix should drive down.
- `externalDirectoryPullCalls` is deliberately **not** named "total": it excludes the (cached) app-access-token fetch and the manual-run diagnostic sample, whose logical-vs-HTTP counts are ambiguous. It is the honest sum of the four pull categories.
- Counters are threaded only through the sync (which persists a run row); the preview path (no run row) passes no counter — the param is optional.

## Test evidence

Both suites run locally against the repo toolchain (vitest 1.6.1); real-DB against a fresh migrated Postgres.

- **Unit** `tests/unit/directory-sync-api-telemetry.test.ts` (no DB, runs in required `test(20.x)`): drives the real `fetchAllDepartments`/`fetchAllUsers` with only the DingTalk client mocked. Fixture shares one user across two departments + paginates one department. **4 passed.**
- **Real-DB**: extends the already-whitelisted `directory-sync-preview-apply-parity.db.test.ts` (two-point-wired: vitest.config exclude + plugin-tests.yml whitelist — no new wiring) with one focused case that asserts the counts land in the persisted run `stats`, deriving expected from the run itself. **7 passed** (`... --config vitest.integration.config.ts`).
- Full unit suite: **369 files / 5078 tests passed**; `tsc --noEmit` clean.

### Mutation table (impl committed first, reverted, run, restored)

| mutation | test that went RED |
|---|---|
| remove `userDetailCalls += 1` | unit: `expected +0 to be 4` (counter 0 vs mock call count 4 — divergence proves non-tautology) |
| remove `userListPageCalls += 1` | unit: `expected +0 to be 4` |
| remove `...summarizeDirectorySyncApiCalls(...)` fold | real-DB: `expected undefined to be 5` (stat not persisted) |

## Not done here (design-only / out of scope)

- **`user/list` primary field-source flip** — the actual perf fix. Stays **design-only, staging-gated**. No scaffold or dead code added; it needs a real tenant to verify `user/list` field completeness before the flip is safe.
- **Batch upsert of account-department links** — already landed (DT-PERF-01, `unnest`).
- **Batch upsert of departments/accounts** — still per-row loops in the apply transaction. Batchable via `unnest`, but touches the hot transaction and the per-department `dept_manager_userid_list` carry-forward; left as a design note to keep this PR to the instrumentation.
- **bcrypt outside the transaction** — `bcrypt.hash` runs inside the apply transaction in the auto-admission loop. Moving it out entangles with the identity-match cascade that DECIDES who is admitted (that decision is inside the txn); left as a design note.

## Ops note

Additive-only: new keys appear in `directory_sync_runs.stats` and on the runs API. No behavior change to what the sync reads or writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Honest gaps / CI coverage

- The **increment logic** is covered by the unit test in the required `test(20.x)` job. The **fold-into-persisted-stats** is covered only by the `.db` case, which runs in **`plugin-tests.yml` (non-required)**, not required CI — consistent with this line's model (all directory-sync stats live in `.db` tests). Green required CI does not by itself mean that `.db` case passed.
- `externalUserDetailCalls === accountsSynced` is pinned as a **current-N+1 canary** and is **expected to go RED when the `user/list` field-source flip lands** (detail count drops below account count = the fix working). The assertion carries a comment saying to relax it to `<=` at that point. Flagged so a future failure reads as a signpost, not a regression.
