### PR TITLE
feat(dingtalk): safe operator redelivery + task_id trace foundation

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -428,6 +428,7 @@ jobs:
             tests/integration/directory-sync-orchestration.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \
+            tests/integration/attendance-notification-redelivery-route.db.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -427,6 +427,7 @@ jobs:
             tests/integration/directory-sync-run-lease.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
+            tests/integration/attendance-notification-redelivery.db.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/src/db/migrations/zzzz20260710160000_add_task_id_index_to_dingtalk_approval_card_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260710160000_add_task_id_index_to_dingtalk_approval_card_deliveries.ts
@@ -1,0 +1,32 @@
+/**
+ * Migration: task_id trace index on the approval-card ledger (roadmap §7.6 "Delivery Closure" —
+ * "Promote DingTalk task_id into queryable columns / operators can trace accepted async messages").
+ *
+ * `dingtalk_approval_card_deliveries.task_id` already EXISTS (created inline by
+ * zzzz20260705120000_create_dingtalk_approval_card_deliveries and populated on a successful
+ * asyncsend_v2 by markDingTalkApprovalCardDeliverySent). It was never queryable: no index, and no
+ * lookup accessor. This migration adds ONLY the missing index — NOT a redundant column — so an
+ * operator holding a DingTalk task_id can look up "was this async approval-card message accepted,
+ * and under what instance/recipient" through findDingTalkApprovalCardDeliveriesByTaskId without a
+ * sequential scan.
+ *
+ * Partial index (WHERE task_id IS NOT NULL): task_id is NULL for pending/failed rows that never
+ * produced an accepted async send; those are never a trace target, and excluding them keeps the
+ * index small. checkTableExists guards partial-schema test harnesses that apply only a subset of
+ * migrations.
+ */
+import { sql, type Kysely } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  if (!(await checkTableExists(db, 'dingtalk_approval_card_deliveries'))) return
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dacd_task_id
+    ON dingtalk_approval_card_deliveries(task_id)
+    WHERE task_id IS NOT NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_dacd_task_id`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260711120000_add_redelivery_safe_to_attendance_notification_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260711120000_add_redelivery_safe_to_attendance_notification_deliveries.ts
@@ -1,0 +1,50 @@
+/**
+ * Migration: `redelivery_safe` flag on attendance_notification_deliveries (PR #4102 owner
+ * CHANGES-REQUESTED, §7.6 delivery closure).
+ *
+ * Why this column exists — the owner-caught bug: `status='failed'` alone does NOT prove a row is
+ * safe for OPERATOR-initiated redelivery. attendance_notification_deliveries is a MULTI-CHANNEL
+ * shared outbox (dingtalk_work_notification / wecom_work_notification / email_smtp). Two classes of
+ * `failed` row are duplicate-notification hazards if resent:
+ *   - Pre-#4046 DingTalk timeouts/5xx (ambiguous sends recorded as `failed` before the
+ *     `outcome_unknown` vocabulary existed) — may already have been delivered.
+ *   - WeCom / Email failures — those channels never emit the `outcome_unknown` marker, so a `failed`
+ *     row there can also be an ambiguous send.
+ * A boolean the worker sets ONLY on a definite, non-ambiguous DingTalk non-delivery (markFailed,
+ * which per the deliver() invariant is only ever reached by a definite failure — ambiguous results
+ * go to markOutcomeUnknown) is the load-bearing signal the redelivery gate keys on.
+ *
+ * up(): ADD COLUMN redelivery_safe boolean NOT NULL DEFAULT false. All pre-existing rows become
+ * `false`, which is correct by design — every historical `failed` row (multi-channel, pre-flag) is
+ * NOT eligible for redelivery. On PostgreSQL 11+ `ADD COLUMN ... NOT NULL DEFAULT <constant>` is a
+ * metadata-only change (catalog default, no table rewrite / full-table lock), so this is cheap even
+ * on a large outbox.
+ *
+ * Guarded by checkTableExists so partial-schema test harnesses (isolated-schema suites that run only
+ * the migrations they need) can apply this migration too, mirroring the sibling
+ * zzzz20260710150000_add_outcome_unknown_delivery_status. down(): DROP COLUMN.
+ */
+import { sql, type Kysely } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+const TABLE = 'attendance_notification_deliveries'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  if (await checkTableExists(db, TABLE)) {
+    // IF NOT EXISTS keeps the migration idempotent under allowUnorderedMigrations replay. NOT NULL
+    // DEFAULT false is metadata-only on PG 11+ (no rewrite): existing rows read the catalog default.
+    await sql`
+      ALTER TABLE attendance_notification_deliveries
+      ADD COLUMN IF NOT EXISTS redelivery_safe boolean NOT NULL DEFAULT false
+    `.execute(db)
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  if (await checkTableExists(db, TABLE)) {
+    await sql`
+      ALTER TABLE attendance_notification_deliveries
+      DROP COLUMN IF EXISTS redelivery_safe
+    `.execute(db)
+  }
+}

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -113,6 +113,33 @@ export async function findDingTalkApprovalCardDeliveryById(
 }
 
 /**
+ * §7.6 Delivery Closure — task_id trace accessor. An operator holding a DingTalk asyncsend_v2
+ * `task_id` (the receipt of an accepted async message) resolves it back to the delivery row(s) —
+ * instance, recipient, send_status — so "was this async approval-card message accepted, and under
+ * what task_id" is answerable without reading logs. Backed by the partial index idx_dacd_task_id.
+ *
+ * Returns an array (newest first): task_id is NOT enforced UNIQUE — each send records its own, so
+ * in practice one row per task_id, but a lost-then-reconciled or re-sent card could share one, and
+ * the trace surface must surface all matches rather than silently pick one. A blank task_id never
+ * matches (the partial index excludes NULLs; an empty string is short-circuited here).
+ */
+export async function findDingTalkApprovalCardDeliveriesByTaskId(
+  query: QueryFn,
+  taskId: string,
+): Promise<DingTalkApprovalCardDeliveryRow[]> {
+  const trimmed = taskId.trim()
+  if (trimmed.length === 0) return []
+  const result = await query(
+    `SELECT ${RETURNING_COLUMNS}
+       FROM dingtalk_approval_card_deliveries
+      WHERE task_id = $1
+      ORDER BY created_at DESC`,
+    [trimmed],
+  )
+  return result.rows as DingTalkApprovalCardDeliveryRow[]
+}
+
+/**
  * Atomic acted-claim: succeeds for exactly one caller while the card is still `sent` AND was
  * possibly delivered (`send_status IN ('sent','outcome_unknown')` — review P2: a pending/failed
  * send never produced a live button, so nothing may claim it; PR #4046 Phase B widened the set by

--- a/packages/core-backend/src/middleware/attendance-production.ts
+++ b/packages/core-backend/src/middleware/attendance-production.ts
@@ -135,6 +135,10 @@ function resolveAttendanceOperation(req: Request, normalizedRoute: string): stri
   if (method === 'POST' && normalizedRoute === '/api/attendance/punch') return 'punch'
   if (method === 'POST' && normalizedRoute === '/api/attendance-admin/users/batch/roles/assign') return 'admin_batch_assign'
   if (method === 'POST' && normalizedRoute === '/api/attendance-admin/users/batch/roles/unassign') return 'admin_batch_unassign'
+  // §7.6 operator-initiated redelivery of a single failed attendance-notification delivery. This is
+  // a send-triggering, platform-admin-only mutation — give it a first-class operation label instead
+  // of the `other` bucket so the audit trail (and metrics) name the action.
+  if (method === 'POST' && normalizedRoute === '/api/attendance-admin/notification-deliveries/:id/redeliver') return 'notification_redeliver'
   return 'other'
 }
 
@@ -196,6 +200,10 @@ function extractResourceId(req: Request, captured: { batchId?: string; requestId
   // /api/attendance-admin/users/:userId/...
   const usersIdx = parts.indexOf('users')
   if (usersIdx >= 0 && parts[usersIdx + 1]) return parts[usersIdx + 1]
+  // /api/attendance-admin/notification-deliveries/:deliveryId/redeliver — extract the delivery id so
+  // the §7.6 redelivery audit row is keyed to the exact row acted on, not NULL.
+  const ndIdx = parts.indexOf('notification-deliveries')
+  if (ndIdx >= 0 && parts[ndIdx + 1]) return parts[ndIdx + 1]
   return null
 }
 
@@ -343,8 +351,15 @@ export function attendanceAuditMiddleware(): RequestHandler {
         const action = `attendance_http:${method}:${normalizedRoute}`
         const resourceType = 'attendance'
         const resourceId = extractResourceId(req, captured)
+        // Values-free per-operation audit extras a handler may attach via res.locals (e.g. the §7.6
+        // redelivery route records org_id / channel / old_status / result). Never PII by contract —
+        // the handler is responsible for putting only enums/ids-of-scope here, no recipient/body.
+        const auditExtra = (res.locals && typeof res.locals.attendanceAuditExtra === 'object' && res.locals.attendanceAuditExtra !== null)
+          ? res.locals.attendanceAuditExtra as Record<string, unknown>
+          : null
         const meta = {
           ok: responseOk,
+          operation: op,
           error: errorCode ? { code: errorCode, message: errorMessage } : null,
           request: {
             method,
@@ -353,6 +368,7 @@ export function attendanceAuditMiddleware(): RequestHandler {
             queryKeys: Object.keys(req.query || {}).slice(0, 50),
             bodyKeys: redactBodyKeys(req.body),
           },
+          ...(auditExtra ? { redelivery: auditExtra } : {}),
         }
 
         // Best effort insert; do not block the request lifecycle on audit issues.

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -335,7 +335,13 @@ function hasLegacyAdminClaim(req: Request): boolean {
   return false
 }
 
-async function ensurePlatformAdmin(req: Request, res: Response): Promise<string | null> {
+// Exported IN PLACE (not extracted to a shared guard module — there is no such module today;
+// the sibling `requireOrgMemberAccess` is itself a local function in routes/api-tokens.ts) so the
+// attendance-admin redelivery route can reuse the SAME platform-admin check rather than
+// reimplementing it. Two drifting admin checks would be an auth bug. Behavior and the ~20 existing
+// in-file call sites are unchanged. Contract: returns the userId on success, or null AFTER already
+// writing the 401/403 response — callers MUST return early on null.
+export async function ensurePlatformAdmin(req: Request, res: Response): Promise<string | null> {
   const userId = getRequestUserId(req)
   if (!userId) {
     jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -5,6 +5,7 @@ import { isAdmin as isRbacAdmin, listUserPermissions } from '../rbac/service'
 import { query } from '../db/pg'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 import { redeliverFailedAttendanceNotification } from '../services/AttendanceNotificationRedelivery'
+import { ensurePlatformAdmin } from './admin-users'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -821,15 +822,43 @@ export function attendanceAdminRouter(): Router {
   //   requeued            → 200 (failed → pending; worker sends exactly once)
   //   already_delivered   → 200 (sent row → no-op; destination already received it, nothing sent)
   //   refused_outcome_unknown → 409 (may already have been delivered; never resent — manual review)
-  //   not_eligible        → 409 (pending/sending/retrying/skipped — not a redelivery target)
+  //   not_eligible        → 409 (failed-but-not-safe / non-dingtalk / pending / sending / retrying /
+  //                              skipped — not a redelivery target)
   //   not_found           → 404
   r.post('/api/attendance-admin/notification-deliveries/:deliveryId/redeliver', async (req: Request, res: Response) => {
+    // AUTH DIVERGENCE — READ BEFORE "FIXING" THIS BACK TO attendance:admin.
+    // Every OTHER route on this router is deliberately guarded by attendance:admin (see the
+    // r.use(rbacGuard('attendance','admin')) note above): an attendance-scoped admin surface tenants
+    // can delegate. This ONE route is different because it TRIGGERS AN EXTERNAL SEND (the worker
+    // re-sends a DingTalk work notification to a real recipient). `attendance:admin` cannot currently
+    // prove org-boundedness — user_roles carries no org_id — so an attendance admin of org A could
+    // otherwise redeliver a row belonging to org B. Owner transitional ruling (2026-07-11): until the
+    // org-scoped-RBAC governance line lands, ONLY a platform admin may invoke this send-triggering
+    // route. requireOrgMemberAccess was explicitly REJECTED by the owner for this seam. Reuse the
+    // single-source platform-admin check (exported in place from admin-users.ts) so there is no second
+    // drifting auth check. It writes the 401/403 response itself and returns null — RETURN EARLY.
+    const platformAdminId = await ensurePlatformAdmin(req, res)
+    if (!platformAdminId) return
+
     try {
       const deliveryId = String(req.params.deliveryId || '').trim()
       if (!UUID_RE.test(deliveryId)) {
         return jsonError(res, 400, 'DELIVERY_ID_INVALID', 'deliveryId must be a UUID')
       }
       const result = await redeliverFailedAttendanceNotification(query, deliveryId)
+
+      // VALUES-FREE audit metadata for the attendance audit middleware (which writes ONE audit row on
+      // res 'finish'). Passed via res.locals so it never leaks into the client-facing response body
+      // and is guaranteed PII-free: org_id, channel, and the prior/result status enums only — NEVER
+      // recipient id / phone / source_key / message body. The middleware records it under
+      // meta.redelivery + keys resource_id off the :deliveryId param.
+      res.locals.attendanceAuditExtra = {
+        org_id: result.orgId,
+        channel: result.channel,
+        old_status: result.previousStatus,
+        result: result.outcome,
+      }
+
       switch (result.outcome) {
         case 'requeued':
           return jsonOk(res, { outcome: result.outcome, deliveryId, status: result.status })
@@ -839,7 +868,7 @@ export function attendanceAdminRouter(): Router {
         case 'refused_outcome_unknown':
           return jsonError(res, 409, 'DELIVERY_OUTCOME_UNKNOWN', 'Delivery outcome is unknown (possibly already delivered); not resent. Reconcile manually.', { deliveryId, status: result.status })
         case 'not_eligible':
-          return jsonError(res, 409, 'DELIVERY_NOT_ELIGIBLE', `Delivery is not a failed row (status=${result.status}); only failed deliveries can be redelivered.`, { deliveryId, status: result.status })
+          return jsonError(res, 409, 'DELIVERY_NOT_ELIGIBLE', `Delivery is not a redelivery-safe DingTalk failure (status=${result.status}); only definite DingTalk failures can be redelivered.`, { deliveryId, status: result.status })
         case 'not_found':
         default:
           return jsonError(res, 404, 'DELIVERY_NOT_FOUND', 'No such notification delivery')

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -4,6 +4,9 @@ import { rbacGuard } from '../rbac/rbac'
 import { isAdmin as isRbacAdmin, listUserPermissions } from '../rbac/service'
 import { query } from '../db/pg'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
+import { redeliverFailedAttendanceNotification } from '../services/AttendanceNotificationRedelivery'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 type AttendanceRoleTemplateId = 'employee' | 'approver' | 'importer' | 'admin'
 
@@ -809,6 +812,40 @@ export function attendanceAdminRouter(): Router {
       })
     } catch (error) {
       return jsonError(res, 500, 'AUDIT_LOGS_SUMMARY_FAILED', (error as Error)?.message || 'Failed to load audit summary')
+    }
+  })
+
+  // §7.6 Delivery Closure — OPERATOR-INITIATED redelivery of a single FAILED attendance-notification
+  // delivery. Explicit operator request only (there is no background/auto path — see
+  // AttendanceNotificationRedelivery doctrine header). Doctrine outcomes map to HTTP:
+  //   requeued            → 200 (failed → pending; worker sends exactly once)
+  //   already_delivered   → 200 (sent row → no-op; destination already received it, nothing sent)
+  //   refused_outcome_unknown → 409 (may already have been delivered; never resent — manual review)
+  //   not_eligible        → 409 (pending/sending/retrying/skipped — not a redelivery target)
+  //   not_found           → 404
+  r.post('/api/attendance-admin/notification-deliveries/:deliveryId/redeliver', async (req: Request, res: Response) => {
+    try {
+      const deliveryId = String(req.params.deliveryId || '').trim()
+      if (!UUID_RE.test(deliveryId)) {
+        return jsonError(res, 400, 'DELIVERY_ID_INVALID', 'deliveryId must be a UUID')
+      }
+      const result = await redeliverFailedAttendanceNotification(query, deliveryId)
+      switch (result.outcome) {
+        case 'requeued':
+          return jsonOk(res, { outcome: result.outcome, deliveryId, status: result.status })
+        case 'already_delivered':
+          // Idempotent no-op: the destination already succeeded; nothing was sent. 200, not an error.
+          return jsonOk(res, { outcome: result.outcome, deliveryId, status: result.status })
+        case 'refused_outcome_unknown':
+          return jsonError(res, 409, 'DELIVERY_OUTCOME_UNKNOWN', 'Delivery outcome is unknown (possibly already delivered); not resent. Reconcile manually.', { deliveryId, status: result.status })
+        case 'not_eligible':
+          return jsonError(res, 409, 'DELIVERY_NOT_ELIGIBLE', `Delivery is not a failed row (status=${result.status}); only failed deliveries can be redelivered.`, { deliveryId, status: result.status })
+        case 'not_found':
+        default:
+          return jsonError(res, 404, 'DELIVERY_NOT_FOUND', 'No such notification delivery')
+      }
+    } catch (error) {
+      return jsonError(res, 500, 'DELIVERY_REDELIVER_FAILED', (error as Error)?.message || 'Failed to redeliver notification')
     }
   })
 

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -1015,10 +1015,20 @@ export class AttendanceNotificationDeliveryWorker {
 
   private async markFailed(id: string, error: string, attemptCount: number): Promise<boolean> {
     const now = this.now().toISOString()
+    // redelivery_safe = (this row's own channel is dingtalk_work_notification). markFailed is only
+    // ever reached by a DEFINITE non-delivery: the deliver() invariant routes an ambiguous DingTalk
+    // result (retryable:false + outcomeUnknown) to markOutcomeUnknown BEFORE this fallthrough, and
+    // the classifier contract guarantees outcomeUnknown ⟹ !retryable. So a row that lands here is a
+    // definite failure, and it is redelivery-safe IFF it is a DingTalk failure — WeCom/Email have no
+    // outcome_unknown vocabulary yet, so their `failed` rows may still be ambiguous sends and must
+    // stay redelivery_safe=false. Ambiguous DingTalk rows never reach here; they go to
+    // markOutcomeUnknown (which leaves redelivery_safe at its default false). No new parameter: the
+    // row's persisted `channel` column drives the flag. See the redelivery-service doctrine header.
     const result = await this.query(
       `UPDATE attendance_notification_deliveries
           SET status = 'failed',
               last_error = $2,
+              redelivery_safe = (channel = $6),
               claim_expires_at = NULL,
               claim_worker_id = NULL,
               updated_at = $3::timestamptz
@@ -1026,7 +1036,7 @@ export class AttendanceNotificationDeliveryWorker {
           AND status = 'sending'
           AND claim_worker_id = $4
           AND attempt_count = $5::int`,
-      [id, error.slice(0, 1000), now, this.workerId, attemptCount],
+      [id, error.slice(0, 1000), now, this.workerId, attemptCount, DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME],
     )
     return Number(result.rowCount ?? 0) === 1
   }

--- a/packages/core-backend/src/services/AttendanceNotificationRedelivery.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationRedelivery.ts
@@ -2,8 +2,9 @@
  * §7.6 Delivery Closure — OPERATOR-INITIATED redelivery of a single failed attendance-notification
  * outbox row (`attendance_notification_deliveries`).
  *
- * Doctrine (owner-ratified, roadmap §7.2/§7.6 — every guardrail below is load-bearing and covered
- * by a mutation-replay test in attendance-notification-redelivery.db.test.ts):
+ * Doctrine (owner-ratified, roadmap §7.2/§7.6; PR #4102 owner CHANGES-REQUESTED — every guardrail
+ * below is load-bearing and covered by a mutation-replay test in
+ * attendance-notification-redelivery.db.test.ts):
  *
  *  - Redelivery is OPERATOR-INITIATED ONLY. This function is invoked from the admin route
  *    (POST /api/attendance-admin/notification-deliveries/:id/redeliver) and NOWHERE else. There is
@@ -12,26 +13,49 @@
  *    lease-expired `sending`) — it NEVER moves a terminal `failed` row back to `pending`. The only
  *    failed→pending transition in the system is this explicit request.
  *
- *  - Eligibility is STRICTLY `status = 'failed'`. That is the single load-bearing gate: the
- *    UPDATE's `AND status = 'failed'` predicate. Requeuing flips the SAME row `failed → pending`
- *    (attempt_count reset to 0 for a fresh operator-requested cycle, next_attempt_at = now); the
- *    worker's deliver() calls channel.send() before any attempt-count classification, so exactly
- *    ONE genuine new send follows.
+ *  - Eligibility is a THREE-predicate gate:
+ *        status = 'failed'
+ *          AND channel = 'dingtalk_work_notification'
+ *          AND redelivery_safe = true
+ *    RETRACTION (this replaces the earlier, WRONG doctrine that the single `AND status='failed'`
+ *    predicate was the sole load-bearing gate): `status='failed'` alone is CONTAMINATED and cannot
+ *    prove a row is safe to resend, because attendance_notification_deliveries is a MULTI-CHANNEL
+ *    shared outbox:
+ *      1. Pre-#4046 DingTalk timeouts/5xx were recorded as `failed` before the `outcome_unknown`
+ *         vocabulary existed — those sends may already have been delivered (ambiguous).
+ *      2. WeCom / Email transports never emit the `outcome_unknown` marker, so a `failed` row on
+ *         those channels can equally be an ambiguous (already-delivered) send.
+ *    Redelivering either class risks a DUPLICATE notification — even within a single org. So we
+ *    additionally require the row to be a DingTalk row AND carry the worker-set `redelivery_safe`
+ *    flag, which markFailed sets true IFF the row is a DEFINITE (non-ambiguous) DingTalk
+ *    non-delivery. An ambiguous DingTalk result never reaches markFailed — deliver() routes it to
+ *    markOutcomeUnknown, which leaves redelivery_safe=false — so this gate can never resend an
+ *    ambiguous row. Requeuing flips the SAME row `failed → pending` (attempt_count reset to 0 for a
+ *    fresh operator-requested cycle, next_attempt_at = now); the worker's deliver() calls
+ *    channel.send() before any attempt-count classification, so exactly ONE genuine new send follows.
  *
  *  - source_key dedup is honored BY CONSTRUCTION: (org_id, source_key) is UNIQUE, so there is at
  *    most one row per logical destination. We flip that existing row's status — we NEVER insert a
- *    new row — so redelivery can never create a duplicate send to a destination. An
- *    already-succeeded destination is a `sent` row; the `status='failed'` gate skips it, nothing is
- *    sent, and the caller gets `already_delivered` (the existing success), not a resend.
+ *    new row — so redelivery can never create a duplicate row for a destination. An
+ *    already-succeeded destination is a `sent` row; the gate skips it, nothing is sent, and the
+ *    caller gets `already_delivered` (the existing success), not a resend.
  *
  *  - `outcome_unknown` is NEVER resent. Its send was attempted and the response was lost — it may
- *    well have been delivered, and a resend on ambiguity is a duplicate-notification hazard. It is
- *    a DISTINCT operator-review category (`refused_outcome_unknown`), not a redelivery target; the
- *    `status='failed'` gate excludes it and we surface it as its own outcome, never as a failure to
- *    resend.
+ *    well have been delivered, and a resend on ambiguity is a duplicate-notification hazard. It is a
+ *    DISTINCT operator-review category (`refused_outcome_unknown`), not a redelivery target; the gate
+ *    excludes it and we surface it as its own outcome, never as a failure to resend.
+ *
+ *  - A `failed` row that is NOT redelivery-safe (historical/pre-flag DingTalk failure, or any
+ *    WeCom/Email failure) classifies as `not_eligible` — the same operator-review outcome as
+ *    pending/sending/retrying/skipped. We deliberately do NOT invent a new outcome variant per
+ *    contamination reason: the operator's action is identical (do not auto-resend; reconcile
+ *    manually), so one `not_eligible` bucket keeps the surface small.
  *
  * Import-side-effect-free (no pool/scheduler): the caller injects the query function, same
- * discipline as the DingTalk approval-card accessor.
+ * discipline as the DingTalk approval-card accessor. The DingTalk channel name is inlined as a
+ * literal (= DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME in AttendanceNotificationDeliveryWorker) to
+ * keep this module free of the heavy worker import graph; the exact predicate text is pinned by a
+ * mutation-replay test.
  */
 
 type QueryFn = (
@@ -40,13 +64,13 @@ type QueryFn = (
 ) => Promise<{ rows: unknown[]; rowCount?: number | null }>
 
 export type AttendanceRedeliveryOutcome =
-  /** failed → pending: requeued for exactly one operator-requested worker send. */
+  /** failed + dingtalk + redelivery_safe → pending: requeued for exactly one operator-requested send. */
   | 'requeued'
   /** already `sent`: no-op, nothing sent — the destination already received it (dedup no-op). */
   | 'already_delivered'
   /** `outcome_unknown`: refused — may already have been delivered; never resent (manual review). */
   | 'refused_outcome_unknown'
-  /** pending / sending / retrying / skipped: not a redelivery target. */
+  /** failed-but-not-safe / non-dingtalk / pending / sending / retrying / skipped: not a redelivery target. */
   | 'not_eligible'
   /** no such delivery row. */
   | 'not_found'
@@ -56,25 +80,38 @@ export interface AttendanceRedeliveryResult {
   id: string
   /** The current (post-op) status of the row, or null when not found. */
   status: string | null
+  /** The row's status BEFORE this operation (for the values-free audit trail). Null when not found. */
+  previousStatus: string | null
+  /** The row's org_id (values-free audit metadata). Null when not found. */
+  orgId: string | null
+  /** The row's channel (values-free audit metadata). Null when not found. */
+  channel: string | null
 }
 
 /**
- * Requeue a single FAILED attendance-notification delivery for exactly one operator-requested
- * resend. See the file header for the full doctrine. Pure state-machine transition on the outbox
- * row; the actual send is performed by AttendanceNotificationDeliveryWorker when it next claims the
- * now-`pending` row.
+ * Requeue a single FAILED, redelivery-safe DingTalk attendance-notification delivery for exactly one
+ * operator-requested resend. See the file header for the full doctrine. Pure state-machine
+ * transition on the outbox row; the actual send is performed by AttendanceNotificationDeliveryWorker
+ * when it next claims the now-`pending` row.
  */
 export async function redeliverFailedAttendanceNotification(
   query: QueryFn,
   id: string,
 ): Promise<AttendanceRedeliveryResult> {
   const trimmed = id.trim()
-  if (trimmed.length === 0) return { outcome: 'not_found', id, status: null }
+  if (trimmed.length === 0) {
+    return { outcome: 'not_found', id, status: null, previousStatus: null, orgId: null, channel: null }
+  }
 
-  // Single load-bearing eligibility gate: `AND status = 'failed'`. A `sent` (already-delivered),
-  // `outcome_unknown` (never-resend), `skipped`, `pending`, `sending`, or `retrying` row does not
-  // match, so this writes NOTHING for them — no resend, no duplicate row. attempt_count resets to 0
-  // so the operator's explicit redelivery gets a fresh retry budget rather than an instant re-fail.
+  // THREE load-bearing eligibility predicates (each pinned by a mutation-replay test):
+  //   status = 'failed'                          — only a terminal failure is a redelivery candidate.
+  //   channel = 'dingtalk_work_notification'     — WeCom/Email `failed` rows may be ambiguous sends.
+  //   redelivery_safe = true                     — set by markFailed ONLY for a DEFINITE (non-
+  //                                                ambiguous) DingTalk non-delivery; historical/
+  //                                                pre-#4046 rows are false and stay ineligible.
+  // A row failing ANY predicate matches nothing here, so this writes NOTHING for it — no resend, no
+  // duplicate row. attempt_count resets to 0 so the operator's explicit redelivery gets a fresh
+  // retry budget rather than an instant re-fail.
   const updated = await query(
     `UPDATE attendance_notification_deliveries
         SET status = 'pending',
@@ -87,21 +124,45 @@ export async function redeliverFailedAttendanceNotification(
             updated_at = NOW()
       WHERE id = $1::uuid
         AND status = 'failed'
-      RETURNING status`,
+        AND channel = 'dingtalk_work_notification'
+        AND redelivery_safe = true
+      RETURNING org_id, channel`,
     [trimmed],
   )
   if (Number(updated.rowCount ?? 0) === 1) {
-    return { outcome: 'requeued', id: trimmed, status: 'pending' }
+    const row = updated.rows[0] as { org_id: string; channel: string }
+    return {
+      outcome: 'requeued',
+      id: trimmed,
+      status: 'pending',
+      previousStatus: 'failed',
+      orgId: row.org_id ?? null,
+      channel: row.channel ?? null,
+    }
   }
 
-  // Not requeued — read the row to classify the outcome for the operator (why it was ineligible).
+  // Not requeued — read the row to classify the outcome for the operator (why it was ineligible) and
+  // to carry values-free audit metadata (org_id, channel, prior status).
   const read = await query(
-    `SELECT status FROM attendance_notification_deliveries WHERE id = $1::uuid`,
+    `SELECT status, org_id, channel, redelivery_safe
+       FROM attendance_notification_deliveries WHERE id = $1::uuid`,
     [trimmed],
   )
-  if (read.rows.length === 0) return { outcome: 'not_found', id: trimmed, status: null }
-  const status = String((read.rows[0] as { status: string }).status)
-  if (status === 'sent') return { outcome: 'already_delivered', id: trimmed, status }
-  if (status === 'outcome_unknown') return { outcome: 'refused_outcome_unknown', id: trimmed, status }
-  return { outcome: 'not_eligible', id: trimmed, status }
+  if (read.rows.length === 0) {
+    return { outcome: 'not_found', id: trimmed, status: null, previousStatus: null, orgId: null, channel: null }
+  }
+  const row = read.rows[0] as { status: string; org_id: string; channel: string; redelivery_safe: boolean }
+  const status = String(row.status)
+  const base = {
+    id: trimmed,
+    status,
+    previousStatus: status,
+    orgId: row.org_id ?? null,
+    channel: row.channel ?? null,
+  }
+  if (status === 'sent') return { outcome: 'already_delivered', ...base }
+  if (status === 'outcome_unknown') return { outcome: 'refused_outcome_unknown', ...base }
+  // Everything else — including a `failed` row that is not redelivery-safe or on a non-DingTalk
+  // channel — is a single `not_eligible` operator-review bucket (see header).
+  return { outcome: 'not_eligible', ...base }
 }

--- a/packages/core-backend/src/services/AttendanceNotificationRedelivery.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationRedelivery.ts
@@ -1,0 +1,107 @@
+/**
+ * §7.6 Delivery Closure — OPERATOR-INITIATED redelivery of a single failed attendance-notification
+ * outbox row (`attendance_notification_deliveries`).
+ *
+ * Doctrine (owner-ratified, roadmap §7.2/§7.6 — every guardrail below is load-bearing and covered
+ * by a mutation-replay test in attendance-notification-redelivery.db.test.ts):
+ *
+ *  - Redelivery is OPERATOR-INITIATED ONLY. This function is invoked from the admin route
+ *    (POST /api/attendance-admin/notification-deliveries/:id/redeliver) and NOWHERE else. There is
+ *    NO background job, scheduler, or worker path that calls it. The delivery worker
+ *    (AttendanceNotificationDeliveryWorker) only ever claims `pending`/`retrying` (and re-claims a
+ *    lease-expired `sending`) — it NEVER moves a terminal `failed` row back to `pending`. The only
+ *    failed→pending transition in the system is this explicit request.
+ *
+ *  - Eligibility is STRICTLY `status = 'failed'`. That is the single load-bearing gate: the
+ *    UPDATE's `AND status = 'failed'` predicate. Requeuing flips the SAME row `failed → pending`
+ *    (attempt_count reset to 0 for a fresh operator-requested cycle, next_attempt_at = now); the
+ *    worker's deliver() calls channel.send() before any attempt-count classification, so exactly
+ *    ONE genuine new send follows.
+ *
+ *  - source_key dedup is honored BY CONSTRUCTION: (org_id, source_key) is UNIQUE, so there is at
+ *    most one row per logical destination. We flip that existing row's status — we NEVER insert a
+ *    new row — so redelivery can never create a duplicate send to a destination. An
+ *    already-succeeded destination is a `sent` row; the `status='failed'` gate skips it, nothing is
+ *    sent, and the caller gets `already_delivered` (the existing success), not a resend.
+ *
+ *  - `outcome_unknown` is NEVER resent. Its send was attempted and the response was lost — it may
+ *    well have been delivered, and a resend on ambiguity is a duplicate-notification hazard. It is
+ *    a DISTINCT operator-review category (`refused_outcome_unknown`), not a redelivery target; the
+ *    `status='failed'` gate excludes it and we surface it as its own outcome, never as a failure to
+ *    resend.
+ *
+ * Import-side-effect-free (no pool/scheduler): the caller injects the query function, same
+ * discipline as the DingTalk approval-card accessor.
+ */
+
+type QueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export type AttendanceRedeliveryOutcome =
+  /** failed → pending: requeued for exactly one operator-requested worker send. */
+  | 'requeued'
+  /** already `sent`: no-op, nothing sent — the destination already received it (dedup no-op). */
+  | 'already_delivered'
+  /** `outcome_unknown`: refused — may already have been delivered; never resent (manual review). */
+  | 'refused_outcome_unknown'
+  /** pending / sending / retrying / skipped: not a redelivery target. */
+  | 'not_eligible'
+  /** no such delivery row. */
+  | 'not_found'
+
+export interface AttendanceRedeliveryResult {
+  outcome: AttendanceRedeliveryOutcome
+  id: string
+  /** The current (post-op) status of the row, or null when not found. */
+  status: string | null
+}
+
+/**
+ * Requeue a single FAILED attendance-notification delivery for exactly one operator-requested
+ * resend. See the file header for the full doctrine. Pure state-machine transition on the outbox
+ * row; the actual send is performed by AttendanceNotificationDeliveryWorker when it next claims the
+ * now-`pending` row.
+ */
+export async function redeliverFailedAttendanceNotification(
+  query: QueryFn,
+  id: string,
+): Promise<AttendanceRedeliveryResult> {
+  const trimmed = id.trim()
+  if (trimmed.length === 0) return { outcome: 'not_found', id, status: null }
+
+  // Single load-bearing eligibility gate: `AND status = 'failed'`. A `sent` (already-delivered),
+  // `outcome_unknown` (never-resend), `skipped`, `pending`, `sending`, or `retrying` row does not
+  // match, so this writes NOTHING for them — no resend, no duplicate row. attempt_count resets to 0
+  // so the operator's explicit redelivery gets a fresh retry budget rather than an instant re-fail.
+  const updated = await query(
+    `UPDATE attendance_notification_deliveries
+        SET status = 'pending',
+            attempt_count = 0,
+            next_attempt_at = NOW(),
+            last_error = NULL,
+            claimed_at = NULL,
+            claim_expires_at = NULL,
+            claim_worker_id = NULL,
+            updated_at = NOW()
+      WHERE id = $1::uuid
+        AND status = 'failed'
+      RETURNING status`,
+    [trimmed],
+  )
+  if (Number(updated.rowCount ?? 0) === 1) {
+    return { outcome: 'requeued', id: trimmed, status: 'pending' }
+  }
+
+  // Not requeued — read the row to classify the outcome for the operator (why it was ineligible).
+  const read = await query(
+    `SELECT status FROM attendance_notification_deliveries WHERE id = $1::uuid`,
+    [trimmed],
+  )
+  if (read.rows.length === 0) return { outcome: 'not_found', id: trimmed, status: null }
+  const status = String((read.rows[0] as { status: string }).status)
+  if (status === 'sent') return { outcome: 'already_delivered', id: trimmed, status }
+  if (status === 'outcome_unknown') return { outcome: 'refused_outcome_unknown', id: trimmed, status }
+  return { outcome: 'not_eligible', id: trimmed, status }
+}

--- a/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
@@ -4,6 +4,9 @@ import { Kysely, PostgresDialect } from 'kysely'
 import { Pool } from 'pg'
 import { up as createAttendanceNotificationDeliveries } from '../../src/db/migrations/zzzz20260611120000_create_attendance_notification_deliveries'
 import { up as addOutcomeUnknownDeliveryStatus } from '../../src/db/migrations/zzzz20260710150000_add_outcome_unknown_delivery_status'
+// markFailed always writes redelivery_safe (PR #4102), so every isolated-schema harness below that
+// runs the worker must chain this follow-up migration after the create — mirroring the full stack.
+import { up as addRedeliverySafe } from '../../src/db/migrations/zzzz20260711120000_add_redelivery_safe_to_attendance_notification_deliveries'
 import {
   AttendanceNotificationDeliveryWorker,
   buildAttendanceNotificationDeepLink,
@@ -97,6 +100,7 @@ describeIfDatabase('Attendance C5 notification delivery outbox', () => {
     testDb = createTestDb(isolatedDbUrl)
     pool = new Pool({ connectionString: isolatedDbUrl })
     await createAttendanceNotificationDeliveries(testDb)
+    await addRedeliverySafe(testDb)
   })
 
   afterAll(async () => {
@@ -251,6 +255,7 @@ describeIfDatabase('Attendance C5 notification delivery outbox', () => {
     }
     try {
       await createAttendanceNotificationDeliveries(workerDb)
+      await addRedeliverySafe(workerDb)
       await requireTable(workerPool, 'attendance_notification_deliveries')
 
       const okId = await insertDelivery('ok')
@@ -387,6 +392,7 @@ describeIfDatabase('Attendance C5 notification delivery outbox', () => {
     }
     try {
       await createAttendanceNotificationDeliveries(workerDb)
+      await addRedeliverySafe(workerDb)
       await requireTable(workerPool, 'attendance_notification_deliveries')
       const insert = await workerPool.query<{ id: string }>(
         `INSERT INTO attendance_notification_deliveries
@@ -465,6 +471,8 @@ describeIfDatabase('Attendance C5 notification delivery outbox', () => {
       await createAttendanceNotificationDeliveries(workerDb)
       // the migration under test: widens the status CHECK by 'outcome_unknown'
       await addOutcomeUnknownDeliveryStatus(workerDb)
+      // markFailed writes redelivery_safe on the definite-failure branch this test also exercises.
+      await addRedeliverySafe(workerDb)
       await requireTable(workerPool, 'attendance_notification_deliveries')
 
       const insert = async (label: string) => (await workerPool.query<{ id: string }>(

--- a/packages/core-backend/tests/integration/attendance-notification-redelivery-route.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-redelivery-route.db.test.ts
@@ -1,0 +1,209 @@
+/**
+ * §7.6 Delivery Closure — HTTP route-level tests for the OPERATOR-initiated redelivery endpoint
+ * POST /api/attendance-admin/notification-deliveries/:deliveryId/redeliver (real DB).
+ *
+ * Proves the PR #4102 owner CHANGES-REQUESTED wiring end-to-end through Express:
+ *   - FIX 2 platform-admin gate: an attendance:admin who is NOT a platform admin gets 403; a
+ *     platform admin proceeds. `ensurePlatformAdmin` decides access via isRbacAdmin against REAL
+ *     Postgres (no mock shadows the gate).
+ *   - handler status mapping: 400 bad id / 409 not_eligible / 409 outcome_unknown / 200
+ *     already_delivered / 200 requeued.
+ *   - FIX 3 audit: ONE values-free audit row (operation=notification_redeliver, resource_id=the
+ *     deliveryId, meta.redelivery = {org_id, channel, old_status, result}) with NO PII (recipient id
+ *     / source_key never appear anywhere in the row).
+ *
+ * rbacGuard is stubbed to a pass-through so the test ISOLATES the new platform-admin gate (the thing
+ * under review). The router-level attendance:admin guard is a separate, pre-existing control; it is
+ * not the subject here, and — because `attendance` is a namespace-admission-controlled resource — a
+ * token-only attendance:admin user would otherwise be rejected by rbacGuard's namespace check before
+ * ever reaching ensurePlatformAdmin, defeating the point of the test. Load-bearing mutation (record
+ * in PR body): removing the `if (!platformAdminId) return` early-return in the handler makes the 403
+ * test go RED.
+ *
+ * DATABASE_URL-gated (describeIfDb): excluded from the no-DB vitest job so it cannot skip-green, and
+ * wired as a WHOLE FILE into the `Run approval real-DB integration` step in plugin-tests.yml.
+ */
+import { randomUUID } from 'crypto'
+
+import express from 'express'
+import request from 'supertest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub rbacGuard to pass-through; keep every other rbac export intact (the router graph pulls
+// userHasPermission/isAdmin from this module).
+vi.mock('../../src/rbac/rbac', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
+  return {
+    ...actual,
+    rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  }
+})
+
+import { pool } from '../../src/db/pg'
+import { attendanceAdminRouter } from '../../src/routes/attendance-admin'
+import { attendanceAuditMiddleware } from '../../src/middleware/attendance-production'
+import { DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME } from '../../src/services/AttendanceNotificationDeliveryWorker'
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => pool!.query(sql, params)
+
+const ORG = `org_redeliver_route_${Date.now()}`
+const RECIPIENT = 'recipient_pii_should_never_be_audited'
+
+type SeedStatus = 'failed' | 'sent' | 'outcome_unknown'
+
+// Mutable authenticated user for the fake auth middleware.
+let currentUser: Record<string, unknown> | null = null
+
+const app = express()
+app.use(express.json())
+app.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = currentUser ?? undefined
+  next()
+})
+app.use(attendanceAuditMiddleware())
+app.use(attendanceAdminRouter())
+
+async function seed(status: SeedStatus, opts: { channel?: string; redeliverySafe?: boolean; sourceKey?: string } = {}): Promise<string> {
+  const sourceKey = opts.sourceKey ?? `sk_route_${randomUUID()}`
+  const channel = opts.channel ?? DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME
+  const redeliverySafe = opts.redeliverySafe ?? (status === 'failed' && channel === DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME)
+  const attemptCount = status === 'failed' ? 5 : status === 'outcome_unknown' ? 2 : 0
+  const deliveredAt = status === 'sent' ? 'NOW()' : 'NULL'
+  const res = await q(
+    `INSERT INTO attendance_notification_deliveries
+       (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel,
+        status, attempt_count, redelivery_safe, next_attempt_at, last_error, delivered_at, payload)
+     VALUES
+       ($1, 'test', NULL, $2, $3, 'employee', $4, $5, $6, $7,
+        NOW() - interval '1 hour',
+        ${status === 'failed' ? "'boom: previous send failed'" : 'NULL'},
+        ${deliveredAt}, '{}'::jsonb)
+     RETURNING id::text AS id`,
+    [ORG, sourceKey, RECIPIENT, channel, status, attemptCount, redeliverySafe],
+  )
+  return (res.rows[0] as { id: string }).id
+}
+
+async function pollAuditRow(deliveryId: string): Promise<{ resource_id: string; action: string; status_code: number; actor_id: string | null; meta: Record<string, unknown> } | null> {
+  // The audit insert runs on res 'finish' AFTER supertest resolves — poll briefly for it.
+  for (let i = 0; i < 40; i += 1) {
+    const res = await q(
+      `SELECT resource_id, action, status_code, actor_id, meta
+         FROM operation_audit_logs
+        WHERE resource_id = $1
+        ORDER BY created_at DESC
+        LIMIT 1`,
+      [deliveryId],
+    )
+    if (res.rows.length > 0) {
+      return res.rows[0] as { resource_id: string; action: string; status_code: number; actor_id: string | null; meta: Record<string, unknown> }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  return null
+}
+
+describeIfDb('§7.6 — attendance notification redelivery route (platform-admin gate, real DB)', () => {
+  beforeEach(() => {
+    currentUser = null
+  })
+
+  afterAll(async () => {
+    await q(`DELETE FROM operation_audit_logs WHERE resource_type = 'attendance' AND actor_id IN ('platform-admin-1','att-admin-not-platform')`).catch(() => {})
+    await q(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [ORG]).catch(() => {})
+  })
+
+  it('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('403: an attendance:admin who is NOT a platform admin is refused (platform-admin gate)', async () => {
+    // Passes the (stubbed) attendance:admin router guard, but is not a platform admin: isRbacAdmin is
+    // consulted against real Postgres and this id has no admin role → 403 FORBIDDEN.
+    currentUser = { id: 'att-admin-not-platform', permissions: ['attendance:admin'] }
+    const id = await seed('failed', { redeliverySafe: true })
+
+    const res = await request(app)
+      .post(`/api/attendance-admin/notification-deliveries/${id}/redeliver`)
+      .send({})
+
+    expect(res.status).toBe(403)
+    // The row was NOT requeued (gate blocked before the mutation).
+    const row = await q(`SELECT status FROM attendance_notification_deliveries WHERE id = $1::uuid`, [id])
+    expect((row.rows[0] as { status: string }).status).toBe('failed')
+  })
+
+  it('400: a bad (non-UUID) deliveryId is rejected', async () => {
+    currentUser = { id: 'platform-admin-1', role: 'admin' }
+    const res = await request(app)
+      .post('/api/attendance-admin/notification-deliveries/not-a-uuid/redeliver')
+      .send({})
+    expect(res.status).toBe(400)
+    expect(res.body?.error?.code).toBe('DELIVERY_ID_INVALID')
+  })
+
+  it('409: a historical DingTalk failure (redelivery_safe=false) is not_eligible', async () => {
+    currentUser = { id: 'platform-admin-1', role: 'admin' }
+    const id = await seed('failed', { redeliverySafe: false })
+    const res = await request(app)
+      .post(`/api/attendance-admin/notification-deliveries/${id}/redeliver`)
+      .send({})
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('DELIVERY_NOT_ELIGIBLE')
+  })
+
+  it('409: an outcome_unknown row is refused (never resent)', async () => {
+    currentUser = { id: 'platform-admin-1', role: 'admin' }
+    const id = await seed('outcome_unknown')
+    const res = await request(app)
+      .post(`/api/attendance-admin/notification-deliveries/${id}/redeliver`)
+      .send({})
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('DELIVERY_OUTCOME_UNKNOWN')
+  })
+
+  it('200: an already-sent row is an idempotent no-op (already_delivered)', async () => {
+    currentUser = { id: 'platform-admin-1', role: 'admin' }
+    const id = await seed('sent')
+    const res = await request(app)
+      .post(`/api/attendance-admin/notification-deliveries/${id}/redeliver`)
+      .send({})
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.outcome).toBe('already_delivered')
+  })
+
+  it('200: a definite DingTalk failure is requeued AND a values-free, PII-free audit row is written', async () => {
+    currentUser = { id: 'platform-admin-1', role: 'admin' }
+    const sourceKey = `sk_route_audit_${randomUUID()}`
+    const id = await seed('failed', { redeliverySafe: true, sourceKey })
+
+    const res = await request(app)
+      .post(`/api/attendance-admin/notification-deliveries/${id}/redeliver`)
+      .send({})
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.outcome).toBe('requeued')
+    expect(res.body?.data?.status).toBe('pending')
+
+    const audit = await pollAuditRow(id)
+    expect(audit).not.toBeNull()
+    // resource_id keyed to the exact row acted on.
+    expect(audit?.resource_id).toBe(id)
+    expect(audit?.status_code).toBe(200)
+    expect(audit?.actor_id).toBe('platform-admin-1')
+
+    const meta = audit?.meta ?? {}
+    expect(meta.operation).toBe('notification_redeliver')
+    const redelivery = (meta.redelivery ?? {}) as Record<string, unknown>
+    expect(redelivery.org_id).toBe(ORG)
+    expect(redelivery.channel).toBe(DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME)
+    expect(redelivery.old_status).toBe('failed')
+    expect(redelivery.result).toBe('requeued')
+
+    // NO PII: neither the recipient id nor the source_key may appear ANYWHERE in the audit row
+    // (columns or serialized meta).
+    const serialized = JSON.stringify(audit)
+    expect(serialized).not.toContain(RECIPIENT)
+    expect(serialized).not.toContain(sourceKey)
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-notification-redelivery.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-redelivery.db.test.ts
@@ -177,6 +177,9 @@ describeIfDb('§7.6 — attendance notification redelivery (operator-initiated, 
   })
 
   it('(6) no auto/background path: worker runBatch NEVER requeues or sends a failed row', async () => {
+    // The delivery worker's claim is DB-global (no org filter), so isolate: the ONLY row it could
+    // see is this one failed row. If the worker had any failed→pending path, it would claim+send it.
+    await q(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [ORG])
     const failedId = await seed('failed', { sourceKey: `sk_worker_failed_${randomUUID()}` })
     const channel = new RecordingChannel()
     const worker = new AttendanceNotificationDeliveryWorker({
@@ -196,6 +199,8 @@ describeIfDb('§7.6 — attendance notification redelivery (operator-initiated, 
   })
 
   it('(6-control) worker liveness: the SAME worker DOES claim+send a pending row (so (6) is not vacuous)', async () => {
+    // Same global-claim isolation: the only row the worker can see is this due pending row.
+    await q(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [ORG])
     const pendingId = await seed('pending', { sourceKey: `sk_worker_pending_${randomUUID()}` })
     const channel = new RecordingChannel()
     const worker = new AttendanceNotificationDeliveryWorker({

--- a/packages/core-backend/tests/integration/attendance-notification-redelivery.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-redelivery.db.test.ts
@@ -1,0 +1,225 @@
+/**
+ * §7.6 Delivery Closure — OPERATOR-INITIATED redelivery of a FAILED attendance-notification outbox
+ * row (real DB). Locks every owner-ratified doctrine guardrail as a falsifiable property:
+ *
+ *   1. Eligibility is STRICTLY `status='failed'` → requeued to `pending` (one operator-requested send).
+ *   2. `sent` → no-op `already_delivered`: nothing written, nothing sent (dedup no-op on success).
+ *   3. `outcome_unknown` → refused, row untouched: NEVER resent (may already have been delivered).
+ *   4. skipped/pending/retrying → `not_eligible`, untouched.
+ *   5. source_key dedup BY CONSTRUCTION: the row is flipped in place, a redelivery NEVER inserts a
+ *      second row for the same (org_id, source_key) destination.
+ *   6. No auto/background path: the delivery worker's claim NEVER moves a `failed` row to `pending`;
+ *      the only failed→pending transition is this explicit operator request.
+ *
+ * Mutation-replay (recorded in the PR body): weakening the `AND status='failed'` gate makes (2)/(3)
+ * RED; making the requeue SET a no-op makes (1) RED.
+ */
+import { randomUUID } from 'crypto'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { pool } from '../../src/db/pg'
+import {
+  redeliverFailedAttendanceNotification,
+} from '../../src/services/AttendanceNotificationRedelivery'
+import {
+  AttendanceNotificationDeliveryWorker,
+  DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME,
+  type AttendanceDeliveryChannel,
+  type AttendanceDeliveryChannelResult,
+  type AttendanceNotificationDeliveryQuery,
+} from '../../src/services/AttendanceNotificationDeliveryWorker'
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => pool!.query(sql, params)
+
+const ORG = `org_redeliver_${Date.now()}`
+
+type SeedStatus = 'failed' | 'sent' | 'outcome_unknown' | 'pending' | 'skipped' | 'retrying'
+
+async function seed(status: SeedStatus, opts: { attemptCount?: number; channel?: string; sourceKey?: string } = {}): Promise<string> {
+  const sourceKey = opts.sourceKey ?? `sk_${randomUUID()}`
+  const channel = opts.channel ?? DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME
+  const attemptCount = opts.attemptCount ?? (status === 'failed' ? 5 : 0)
+  // A failed row carries the residue of its exhausted attempts (claim fields + last_error + a past
+  // next_attempt_at) — exactly what a requeue must clear.
+  const deliveredAt = status === 'sent' ? 'NOW()' : 'NULL'
+  const res = await q(
+    `INSERT INTO attendance_notification_deliveries
+       (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel,
+        status, attempt_count, next_attempt_at, last_attempt_at, claimed_at, claim_expires_at,
+        claim_worker_id, last_error, delivered_at, payload)
+     VALUES
+       ($1, 'test', NULL, $2, 'user_x', 'employee', $3,
+        $4, $5, NOW() - interval '1 hour', NOW() - interval '1 hour',
+        ${status === 'failed' ? "NOW() - interval '1 hour'" : 'NULL'},
+        ${status === 'failed' ? "NOW() - interval '30 minutes'" : 'NULL'},
+        ${status === 'failed' ? "'stale-worker'" : 'NULL'},
+        ${status === 'failed' ? "'boom: previous send failed'" : 'NULL'},
+        ${deliveredAt}, '{}'::jsonb)
+     RETURNING id::text AS id`,
+    [ORG, sourceKey, channel, status, attemptCount],
+  )
+  return (res.rows[0] as { id: string }).id
+}
+
+async function readRow(id: string): Promise<{ status: string; attempt_count: number; last_error: string | null; claim_worker_id: string | null; updated_at: string } | null> {
+  const res = await q(
+    `SELECT status, attempt_count, last_error, claim_worker_id, updated_at::text AS updated_at
+       FROM attendance_notification_deliveries WHERE id = $1::uuid`,
+    [id],
+  )
+  return (res.rows[0] as { status: string; attempt_count: number; last_error: string | null; claim_worker_id: string | null; updated_at: string } | undefined) ?? null
+}
+
+describeIfDb('§7.6 — attendance notification redelivery (operator-initiated, real DB)', () => {
+  afterAll(async () => {
+    await q(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [ORG]).catch(() => {})
+  })
+
+  it('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('(1) failed → requeued: status flips to pending, attempt_count reset, claim/last_error cleared', async () => {
+    const id = await seed('failed', { attemptCount: 5 })
+    const before = await readRow(id)
+    expect(before?.status).toBe('failed')
+    expect(before?.attempt_count).toBe(5)
+    expect(before?.claim_worker_id).toBe('stale-worker')
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('requeued')
+    expect(result.status).toBe('pending')
+
+    const after = await readRow(id)
+    expect(after?.status).toBe('pending')
+    expect(after?.attempt_count).toBe(0)
+    expect(after?.last_error).toBeNull()
+    expect(after?.claim_worker_id).toBeNull()
+    // next_attempt_at is now-ish → the worker will claim it. Assert it is no longer in the far past.
+    const due = await q(
+      `SELECT (next_attempt_at <= NOW()) AS due, (next_attempt_at > NOW() - interval '5 minutes') AS fresh
+         FROM attendance_notification_deliveries WHERE id = $1::uuid`,
+      [id],
+    )
+    expect((due.rows[0] as { due: boolean }).due).toBe(true)
+    expect((due.rows[0] as { fresh: boolean }).fresh).toBe(true)
+  })
+
+  it('(2) sent → already_delivered: NO-OP, row untouched, nothing sent (dedup no-op on success)', async () => {
+    const id = await seed('sent')
+    const before = await readRow(id)
+    expect(before?.status).toBe('sent')
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('already_delivered')
+    expect(result.status).toBe('sent')
+
+    const after = await readRow(id)
+    expect(after?.status).toBe('sent')
+    // No write happened at all: updated_at is byte-for-byte identical.
+    expect(after?.updated_at).toBe(before?.updated_at)
+  })
+
+  it('(3) outcome_unknown → refused, NEVER resent, row untouched', async () => {
+    const id = await seed('outcome_unknown', { attemptCount: 2 })
+    const before = await readRow(id)
+    expect(before?.status).toBe('outcome_unknown')
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('refused_outcome_unknown')
+    expect(result.status).toBe('outcome_unknown')
+
+    const after = await readRow(id)
+    expect(after?.status).toBe('outcome_unknown')
+    expect(after?.attempt_count).toBe(2)
+    expect(after?.updated_at).toBe(before?.updated_at)
+  })
+
+  it('(4) skipped / pending / retrying → not_eligible, untouched', async () => {
+    for (const status of ['skipped', 'pending', 'retrying'] as const) {
+      const id = await seed(status)
+      const before = await readRow(id)
+      const result = await redeliverFailedAttendanceNotification(q, id)
+      expect(result.outcome).toBe('not_eligible')
+      expect(result.status).toBe(status)
+      const after = await readRow(id)
+      expect(after?.status).toBe(status)
+      expect(after?.updated_at).toBe(before?.updated_at)
+    }
+  })
+
+  it('not_found: unknown id → not_found (no write)', async () => {
+    const result = await redeliverFailedAttendanceNotification(q, randomUUID())
+    expect(result.outcome).toBe('not_found')
+    expect(result.status).toBeNull()
+  })
+
+  it('(5) source_key dedup BY CONSTRUCTION: redelivery flips the row in place, never inserts a second row', async () => {
+    const sourceKey = `sk_dedup_${randomUUID()}`
+    const id = await seed('failed', { sourceKey })
+    const countBefore = await q(
+      `SELECT COUNT(*)::int AS c FROM attendance_notification_deliveries WHERE org_id = $1 AND source_key = $2`,
+      [ORG, sourceKey],
+    )
+    expect((countBefore.rows[0] as { c: number }).c).toBe(1)
+
+    await redeliverFailedAttendanceNotification(q, id)
+
+    const countAfter = await q(
+      `SELECT COUNT(*)::int AS c FROM attendance_notification_deliveries WHERE org_id = $1 AND source_key = $2`,
+      [ORG, sourceKey],
+    )
+    // Still exactly one row for this (org_id, source_key) destination — no duplicate send row.
+    expect((countAfter.rows[0] as { c: number }).c).toBe(1)
+    const after = await readRow(id)
+    expect(after?.status).toBe('pending')
+  })
+
+  it('(6) no auto/background path: worker runBatch NEVER requeues or sends a failed row', async () => {
+    const failedId = await seed('failed', { sourceKey: `sk_worker_failed_${randomUUID()}` })
+    const channel = new RecordingChannel()
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: q as unknown as AttendanceNotificationDeliveryQuery,
+      channels: [channel],
+      quietHours: null,
+      workerId: `test-worker-${randomUUID()}`,
+    })
+
+    const outcome = await worker.runBatch()
+
+    // The failed row was never claimed, never sent, never moved off `failed`.
+    expect(channel.calls).toBe(0)
+    const after = await readRow(failedId)
+    expect(after?.status).toBe('failed')
+    expect(outcome.claimed).toBe(0)
+  })
+
+  it('(6-control) worker liveness: the SAME worker DOES claim+send a pending row (so (6) is not vacuous)', async () => {
+    const pendingId = await seed('pending', { sourceKey: `sk_worker_pending_${randomUUID()}` })
+    const channel = new RecordingChannel()
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: q as unknown as AttendanceNotificationDeliveryQuery,
+      channels: [channel],
+      quietHours: null,
+      workerId: `test-worker-${randomUUID()}`,
+    })
+
+    await worker.runBatch()
+
+    // The worker is live: a due `pending` row IS claimed and sent — proving (6)'s failed-skip is a
+    // real eligibility fence, not an inert worker.
+    expect(channel.calls).toBe(1)
+    const after = await readRow(pendingId)
+    expect(after?.status).toBe('sent')
+  })
+})
+
+class RecordingChannel implements AttendanceDeliveryChannel {
+  readonly name = DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME
+  calls = 0
+  async send(): Promise<AttendanceDeliveryChannelResult> {
+    this.calls += 1
+    return { ok: true }
+  }
+}

--- a/packages/core-backend/tests/integration/attendance-notification-redelivery.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-redelivery.db.test.ts
@@ -1,18 +1,34 @@
 /**
  * §7.6 Delivery Closure — OPERATOR-INITIATED redelivery of a FAILED attendance-notification outbox
- * row (real DB). Locks every owner-ratified doctrine guardrail as a falsifiable property:
+ * row (real DB). Locks every owner-ratified doctrine guardrail as a falsifiable property.
  *
- *   1. Eligibility is STRICTLY `status='failed'` → requeued to `pending` (one operator-requested send).
+ * DOCTRINE UPDATE (PR #4102 owner CHANGES-REQUESTED): eligibility is NO LONGER the single
+ * `status='failed'` predicate — that was CONTAMINATED (this is a MULTI-CHANNEL shared outbox; a
+ * `failed` row can be a pre-#4046 ambiguous DingTalk send, or a WeCom/Email failure with no
+ * outcome_unknown vocabulary — resending either risks a DUPLICATE notification). The gate is now
+ * THREE predicates: `status='failed' AND channel='dingtalk_work_notification' AND
+ * redelivery_safe=true`, where redelivery_safe is a boolean the worker's markFailed sets true IFF the
+ * row is a DEFINITE (non-ambiguous) DingTalk non-delivery.
+ *
+ *   1. A DEFINITE DingTalk failure (failed + dingtalk + redelivery_safe=true) → requeued to `pending`
+ *      (one operator-requested send).
  *   2. `sent` → no-op `already_delivered`: nothing written, nothing sent (dedup no-op on success).
  *   3. `outcome_unknown` → refused, row untouched: NEVER resent (may already have been delivered).
- *   4. skipped/pending/retrying → `not_eligible`, untouched.
+ *   4. skipped/pending/retrying, a historical DingTalk failure (redelivery_safe=false), and any
+ *      WeCom/Email failure → `not_eligible`, untouched.
  *   5. source_key dedup BY CONSTRUCTION: the row is flipped in place, a redelivery NEVER inserts a
  *      second row for the same (org_id, source_key) destination.
  *   6. No auto/background path: the delivery worker's claim NEVER moves a `failed` row to `pending`;
  *      the only failed→pending transition is this explicit operator request.
  *
- * Mutation-replay (recorded in the PR body): weakening the `AND status='failed'` gate makes (2)/(3)
- * RED; making the requeue SET a no-op makes (1) RED.
+ * Mutation-replay (recorded in the PR body): reverting EACH of the three UPDATE predicates
+ * individually turns a distinct test RED —
+ *   - dropping `status='failed'`  → the status-predicate pin (synthetic pending+safe row) requeues.
+ *   - dropping `channel='dingtalk_work_notification'` → the WeCom-safe pin requeues.
+ *   - dropping `redelivery_safe=true` → the historical-DingTalk-failure pin requeues.
+ * The DISCRIMINATOR test drives an ambiguous DingTalk send through the worker and proves it lands as
+ * `outcome_unknown` (redelivery_safe=false) and is then REFUSED by redelivery — never requeued.
+ * Making the requeue SET a no-op makes (1) RED.
  */
 import { randomUUID } from 'crypto'
 
@@ -24,8 +40,10 @@ import {
 import {
   AttendanceNotificationDeliveryWorker,
   DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME,
+  WECOM_WORK_NOTIFICATION_CHANNEL_NAME,
   type AttendanceDeliveryChannel,
   type AttendanceDeliveryChannelResult,
+  type AttendanceDeliveryMessage,
   type AttendanceNotificationDeliveryQuery,
 } from '../../src/services/AttendanceNotificationDeliveryWorker'
 
@@ -36,39 +54,48 @@ const ORG = `org_redeliver_${Date.now()}`
 
 type SeedStatus = 'failed' | 'sent' | 'outcome_unknown' | 'pending' | 'skipped' | 'retrying'
 
-async function seed(status: SeedStatus, opts: { attemptCount?: number; channel?: string; sourceKey?: string } = {}): Promise<string> {
+async function seed(
+  status: SeedStatus,
+  opts: { attemptCount?: number; channel?: string; sourceKey?: string; redeliverySafe?: boolean } = {},
+): Promise<string> {
   const sourceKey = opts.sourceKey ?? `sk_${randomUUID()}`
   const channel = opts.channel ?? DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME
   const attemptCount = opts.attemptCount ?? (status === 'failed' ? 5 : 0)
+  // redelivery_safe default mirrors what the worker's markFailed would persist: a DEFINITE DingTalk
+  // failure carries redelivery_safe=true; every other row (non-dingtalk failure, or a non-failed
+  // status that never went through the dingtalk-failed markFailed path) is false. Tests that need to
+  // isolate a single UPDATE predicate override this explicitly (synthetic rows).
+  const redeliverySafe = opts.redeliverySafe
+    ?? (status === 'failed' && channel === DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME)
   // A failed row carries the residue of its exhausted attempts (claim fields + last_error + a past
   // next_attempt_at) — exactly what a requeue must clear.
   const deliveredAt = status === 'sent' ? 'NOW()' : 'NULL'
   const res = await q(
     `INSERT INTO attendance_notification_deliveries
        (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel,
-        status, attempt_count, next_attempt_at, last_attempt_at, claimed_at, claim_expires_at,
+        status, attempt_count, redelivery_safe, next_attempt_at, last_attempt_at, claimed_at, claim_expires_at,
         claim_worker_id, last_error, delivered_at, payload)
      VALUES
        ($1, 'test', NULL, $2, 'user_x', 'employee', $3,
-        $4, $5, NOW() - interval '1 hour', NOW() - interval '1 hour',
+        $4, $5, $6, NOW() - interval '1 hour', NOW() - interval '1 hour',
         ${status === 'failed' ? "NOW() - interval '1 hour'" : 'NULL'},
         ${status === 'failed' ? "NOW() - interval '30 minutes'" : 'NULL'},
         ${status === 'failed' ? "'stale-worker'" : 'NULL'},
         ${status === 'failed' ? "'boom: previous send failed'" : 'NULL'},
         ${deliveredAt}, '{}'::jsonb)
      RETURNING id::text AS id`,
-    [ORG, sourceKey, channel, status, attemptCount],
+    [ORG, sourceKey, channel, status, attemptCount, redeliverySafe],
   )
   return (res.rows[0] as { id: string }).id
 }
 
-async function readRow(id: string): Promise<{ status: string; attempt_count: number; last_error: string | null; claim_worker_id: string | null; updated_at: string } | null> {
+async function readRow(id: string): Promise<{ status: string; attempt_count: number; redelivery_safe: boolean; last_error: string | null; claim_worker_id: string | null; updated_at: string } | null> {
   const res = await q(
-    `SELECT status, attempt_count, last_error, claim_worker_id, updated_at::text AS updated_at
+    `SELECT status, attempt_count, redelivery_safe, last_error, claim_worker_id, updated_at::text AS updated_at
        FROM attendance_notification_deliveries WHERE id = $1::uuid`,
     [id],
   )
-  return (res.rows[0] as { status: string; attempt_count: number; last_error: string | null; claim_worker_id: string | null; updated_at: string } | undefined) ?? null
+  return (res.rows[0] as { status: string; attempt_count: number; redelivery_safe: boolean; last_error: string | null; claim_worker_id: string | null; updated_at: string } | undefined) ?? null
 }
 
 describeIfDb('§7.6 — attendance notification redelivery (operator-initiated, real DB)', () => {
@@ -218,6 +245,182 @@ describeIfDb('§7.6 — attendance notification redelivery (operator-initiated, 
     const after = await readRow(pendingId)
     expect(after?.status).toBe('sent')
   })
+
+  // ── PR #4102 owner CHANGES-REQUESTED — three-predicate safe-redelivery gate ──────────────────────
+
+  it('positive: a DEFINITE DingTalk failure (failed + dingtalk + redelivery_safe=true) → requeued', async () => {
+    const id = await seed('failed', { redeliverySafe: true })
+    const before = await readRow(id)
+    expect(before?.status).toBe('failed')
+    expect(before?.redelivery_safe).toBe(true)
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('requeued')
+    expect(result.status).toBe('pending')
+    // Values-free audit metadata is carried out for the audit trail.
+    expect(result.previousStatus).toBe('failed')
+    expect(result.orgId).toBe(ORG)
+    expect(result.channel).toBe(DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME)
+
+    const after = await readRow(id)
+    expect(after?.status).toBe('pending')
+  })
+
+  it('predicate pin (status=\'failed\'): a synthetic pending+dingtalk+safe row → not_eligible, untouched', async () => {
+    // Only status differs from an eligible row (dingtalk + redelivery_safe=true). With the real gate
+    // it is not_eligible; DROP the `status='failed'` predicate and it would requeue → this test RED.
+    const id = await seed('pending', { redeliverySafe: true })
+    const before = await readRow(id)
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('not_eligible')
+    expect(result.status).toBe('pending')
+
+    const after = await readRow(id)
+    expect(after?.status).toBe('pending')
+    expect(after?.updated_at).toBe(before?.updated_at)
+  })
+
+  it('predicate pin (channel=dingtalk): a synthetic WeCom failed+safe row → not_eligible, untouched', async () => {
+    // Only channel differs from an eligible row (status=failed + redelivery_safe forced true — a
+    // WeCom row would never really carry safe=true, this isolates the channel predicate). Real gate:
+    // not_eligible; DROP the channel predicate and it would requeue → this test RED.
+    const id = await seed('failed', { channel: WECOM_WORK_NOTIFICATION_CHANNEL_NAME, redeliverySafe: true })
+    const before = await readRow(id)
+    expect(before?.status).toBe('failed')
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('not_eligible')
+    expect(result.channel).toBe(WECOM_WORK_NOTIFICATION_CHANNEL_NAME)
+
+    const after = await readRow(id)
+    expect(after?.status).toBe('failed')
+    expect(after?.updated_at).toBe(before?.updated_at)
+  })
+
+  it('predicate pin (redelivery_safe=true): a historical DingTalk failed row (safe=false) → not_eligible, untouched', async () => {
+    // A pre-#4046 / pre-flag DingTalk failure: failed + dingtalk, but redelivery_safe=false. It may
+    // already have been delivered (ambiguous) — resending is the duplicate hazard the owner caught.
+    // Real gate: not_eligible, NOTHING written; DROP the redelivery_safe predicate and it would
+    // requeue → this test RED.
+    const id = await seed('failed', { redeliverySafe: false })
+    const before = await readRow(id)
+    expect(before?.status).toBe('failed')
+    expect(before?.redelivery_safe).toBe(false)
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('not_eligible')
+
+    const after = await readRow(id)
+    expect(after?.status).toBe('failed')
+    expect(after?.redelivery_safe).toBe(false)
+    expect(after?.updated_at).toBe(before?.updated_at)
+  })
+
+  it('a natural WeCom failure (redelivery_safe=false by default) → not_eligible', async () => {
+    // WeCom/Email transports emit no outcome_unknown marker, so a WeCom `failed` row can be an
+    // ambiguous send — it is never redelivery-eligible.
+    const id = await seed('failed', { channel: WECOM_WORK_NOTIFICATION_CHANNEL_NAME })
+    const before = await readRow(id)
+    expect(before?.redelivery_safe).toBe(false)
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('not_eligible')
+
+    const after = await readRow(id)
+    expect(after?.status).toBe('failed')
+    expect(after?.updated_at).toBe(before?.updated_at)
+  })
+
+  it('DISCRIMINATOR: an ambiguous DingTalk send → worker marks outcome_unknown (safe=false) → redelivery REFUSES it', async () => {
+    // Drive a genuine ambiguous DingTalk result through the worker via a fake channel returning
+    // {ok:false, retryable:false, outcomeUnknown:true}. The deliver() invariant must route it to
+    // markOutcomeUnknown (NOT markFailed), so the row lands `outcome_unknown` with redelivery_safe
+    // still false — and redelivery then refuses it. This proves ambiguous results are never
+    // redelivery-eligible (the owner's crux).
+    await q(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [ORG])
+    const id = await seed('pending', { sourceKey: `sk_ambiguous_${randomUUID()}` })
+    const channel = new OutcomeUnknownChannel()
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: q as unknown as AttendanceNotificationDeliveryQuery,
+      channels: [channel],
+      quietHours: null,
+      maxAttempts: 1,
+      workerId: `test-worker-${randomUUID()}`,
+    })
+
+    const outcome = await worker.runBatch()
+    expect(channel.calls).toBe(1)
+    expect(outcome.outcomeUnknown).toBe(1)
+
+    // The worker classified the ambiguous send as outcome_unknown, NOT failed, and did NOT flip the
+    // redelivery-safe flag (only markFailed on a DingTalk row does).
+    const marked = await readRow(id)
+    expect(marked?.status).toBe('outcome_unknown')
+    expect(marked?.redelivery_safe).toBe(false)
+
+    // Redelivery refuses it — never requeued.
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('refused_outcome_unknown')
+    expect(result.status).toBe('outcome_unknown')
+    const after = await readRow(id)
+    expect(after?.status).toBe('outcome_unknown')
+  })
+
+  it('markFailed WRITE: a DEFINITE DingTalk failure → worker sets redelivery_safe=true → redelivery requeues it', async () => {
+    // End-to-end proof that markFailed's `redelivery_safe = (channel = dingtalk)` write is real: seed
+    // a due pending DingTalk row (redelivery_safe defaults false for a non-failed row), drive a
+    // DEFINITE non-retryable failure through the worker, and assert the resulting failed row carries
+    // redelivery_safe=true — then redelivery accepts it. Breaking the markFailed write turns this RED.
+    await q(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [ORG])
+    const id = await seed('pending', { redeliverySafe: false, sourceKey: `sk_markfailed_dt_${randomUUID()}` })
+    const channel = new DefiniteFailureChannel(DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME)
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: q as unknown as AttendanceNotificationDeliveryQuery,
+      channels: [channel],
+      quietHours: null,
+      maxAttempts: 1,
+      workerId: `test-worker-${randomUUID()}`,
+    })
+
+    const outcome = await worker.runBatch()
+    expect(channel.calls).toBe(1)
+    expect(outcome.failed).toBe(1)
+
+    const marked = await readRow(id)
+    expect(marked?.status).toBe('failed')
+    expect(marked?.redelivery_safe).toBe(true)
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('requeued')
+  })
+
+  it('markFailed WRITE: a DEFINITE WeCom failure → worker leaves redelivery_safe=false → redelivery refuses it', async () => {
+    // The channel-conditional write: a definite WeCom non-delivery is `failed` but NOT redelivery-safe
+    // (WeCom has no outcome_unknown vocabulary, so its failures may be ambiguous). Mutating the
+    // markFailed write to an unconditional `true` would turn this RED.
+    await q(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [ORG])
+    const id = await seed('pending', { channel: WECOM_WORK_NOTIFICATION_CHANNEL_NAME, sourceKey: `sk_markfailed_wecom_${randomUUID()}` })
+    const channel = new DefiniteFailureChannel(WECOM_WORK_NOTIFICATION_CHANNEL_NAME)
+    const worker = new AttendanceNotificationDeliveryWorker({
+      query: q as unknown as AttendanceNotificationDeliveryQuery,
+      channels: [channel],
+      quietHours: null,
+      maxAttempts: 1,
+      workerId: `test-worker-${randomUUID()}`,
+    })
+
+    const outcome = await worker.runBatch()
+    expect(channel.calls).toBe(1)
+    expect(outcome.failed).toBe(1)
+
+    const marked = await readRow(id)
+    expect(marked?.status).toBe('failed')
+    expect(marked?.redelivery_safe).toBe(false)
+
+    const result = await redeliverFailedAttendanceNotification(q, id)
+    expect(result.outcome).toBe('not_eligible')
+  })
 })
 
 class RecordingChannel implements AttendanceDeliveryChannel {
@@ -226,5 +429,30 @@ class RecordingChannel implements AttendanceDeliveryChannel {
   async send(): Promise<AttendanceDeliveryChannelResult> {
     this.calls += 1
     return { ok: true }
+  }
+}
+
+// A DingTalk channel whose send() is AMBIGUOUS: attempted, outcome unknowable (network/timeout/5xx/
+// malformed 2xx). retryable:false + outcomeUnknown:true is exactly what classifyDingTalkSendError
+// emits for an isDingTalkOutcomeUnknown error, and the deliver() invariant must route it to
+// markOutcomeUnknown — never markFailed — so redelivery_safe stays false.
+class OutcomeUnknownChannel implements AttendanceDeliveryChannel {
+  readonly name = DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME
+  calls = 0
+  async send(_message: AttendanceDeliveryMessage): Promise<AttendanceDeliveryChannelResult> {
+    this.calls += 1
+    return { ok: false, retryable: false, outcomeUnknown: true, error: 'dingtalk_send_outcome_unknown: fake ambiguous send' }
+  }
+}
+
+// A channel (name configurable) whose send() is a DEFINITE, non-retryable, non-ambiguous failure —
+// the classification that reaches markFailed. Used to prove markFailed's channel-conditional
+// redelivery_safe write end-to-end.
+class DefiniteFailureChannel implements AttendanceDeliveryChannel {
+  calls = 0
+  constructor(readonly name: string) {}
+  async send(_message: AttendanceDeliveryMessage): Promise<AttendanceDeliveryChannelResult> {
+    this.calls += 1
+    return { ok: false, retryable: false, error: 'definite_non_delivery' }
   }
 }

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { pool } from '../../src/db/pg'
 import {
   claimDingTalkApprovalCardDeliveryActed,
+  findDingTalkApprovalCardDeliveriesByTaskId,
   findDingTalkApprovalCardDeliveryById,
   insertDingTalkApprovalCardDelivery,
   markDingTalkApprovalCardDeliverySendFailed,
@@ -274,6 +275,50 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
     } finally {
       await q(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId]).catch(() => {})
     }
+  })
+
+  // §7.6 Delivery Closure — task_id is now queryable: the trace index + lookup-by-task_id accessor
+  // let an operator resolve a DingTalk asyncsend_v2 receipt back to the delivery (instance, recipient,
+  // send status). task_id was already persisted (insert + markSent); this locks it as queryable.
+  it('§7.6 trace: findByTaskId resolves an accepted async message; blank/unknown → []', async () => {
+    const taskId = `trace_task_${randomUUID()}`
+    const inserted = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_trace',
+      recipientDingTalkUserId: 'dd_user_trace',
+      deliveryKind: 'work_notice_action_card',
+      taskId,
+    })
+
+    const found = await findDingTalkApprovalCardDeliveriesByTaskId(q, taskId)
+    expect(found.map((r) => r.id)).toContain(inserted.id)
+    expect(found.every((r) => r.task_id === taskId)).toBe(true)
+
+    // A receipt recorded via markSent (the real asyncsend_v2 success path) is equally traceable.
+    const pending = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE,
+      nodeKey: 'approval_1',
+      recipientUserId: 'user_trace2',
+      recipientDingTalkUserId: 'dd_user_trace2',
+      deliveryKind: 'interactive_card',
+    })
+    const markTaskId = `trace_marked_${randomUUID()}`
+    await markDingTalkApprovalCardDeliverySent(q, pending.id, markTaskId)
+    const foundMarked = await findDingTalkApprovalCardDeliveriesByTaskId(q, markTaskId)
+    expect(foundMarked.map((r) => r.id)).toContain(pending.id)
+
+    // Unknown task_id and blank input never match (the partial index excludes NULL task_ids).
+    expect(await findDingTalkApprovalCardDeliveriesByTaskId(q, `nope_${randomUUID()}`)).toEqual([])
+    expect(await findDingTalkApprovalCardDeliveriesByTaskId(q, '   ')).toEqual([])
+  })
+
+  it('§7.6 trace: the partial task_id index exists (migration applied)', async () => {
+    const res = await q(
+      `SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_dacd_task_id' AND tablename = 'dingtalk_approval_card_deliveries'`,
+    )
+    expect(res.rows.length).toBe(1)
+    expect(String((res.rows[0] as { indexdef: string }).indexdef)).toMatch(/task_id/)
   })
 
   it('ON DELETE CASCADE removes ledger rows with their instance', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -86,6 +86,11 @@ export default defineConfig({
       // a WHOLE FILE into the `Run approval real-DB integration` step in plugin-tests.yml where it
       // runs against real Postgres every PR.
       'tests/integration/dingtalk-approval-card-deliveries.db.test.ts',
+      // §7.6 Delivery Closure — operator-initiated redelivery of a FAILED attendance-notification
+      // outbox row: DATABASE_URL-gated (describeIfDb). Excluded from the no-DB default job so it
+      // cannot skip-green, and wired as a WHOLE FILE into the `Run approval real-DB integration`
+      // step in plugin-tests.yml where it runs against real Postgres every PR.
+      'tests/integration/attendance-notification-redelivery.db.test.ts',
       // DT-OPS-02 P2 follow-up: preview/apply auto-admission-candidate-count parity.
       // DATABASE_URL-gated (describeIfDatabase). Excluded from the no-DB default job so it
       // doesn't skip-green, and wired as a WHOLE FILE into the `Run approval real-DB

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -91,6 +91,11 @@ export default defineConfig({
       // cannot skip-green, and wired as a WHOLE FILE into the `Run approval real-DB integration`
       // step in plugin-tests.yml where it runs against real Postgres every PR.
       'tests/integration/attendance-notification-redelivery.db.test.ts',
+      // §7.6 Delivery Closure — HTTP route-level tests for the platform-admin-gated redelivery
+      // endpoint (403/400/409/200 + values-free PII-free audit row). DATABASE_URL-gated
+      // (describeIfDb). Excluded from the no-DB default job so it cannot skip-green, and wired as a
+      // WHOLE FILE into the `Run approval real-DB integration` step in plugin-tests.yml.
+      'tests/integration/attendance-notification-redelivery-route.db.test.ts',
       // DT-OPS-02 P2 follow-up: preview/apply auto-admission-candidate-count parity.
       // DATABASE_URL-gated (describeIfDatabase). Excluded from the no-DB default job so it
       // doesn't skip-green, and wired as a WHOLE FILE into the `Run approval real-DB


### PR DESCRIPTION
## What / why

Roadmap §7.6 **Delivery Closure**: give operators a **redelivery tool for failed DingTalk deliveries**, and lay **trace foundation** for accepted async messages — without violating the owner-ratified send-once / operator-initiated-only doctrine.

**This revision reworks the PR per the owner's CHANGES-REQUESTED review** (security-sensitive: an authorization gate + a send-triggering mutation + a schema change). Five fixes below.

---

## FIX 1 (P1) — safe-redelivery criterion

The owner caught that **`status='failed'` alone does NOT prove a row is safe to redeliver.** `attendance_notification_deliveries` is a **multi-channel shared outbox**: pre-#4046 DingTalk timeouts/5xx (ambiguous — may already have delivered) and **all** WeCom/Email failures (those channels have no `outcome_unknown` vocabulary) land as `failed`. Redelivering any of them risks a **duplicate notification, even within one org**.

- **New migration** `zzzz20260711120000_add_redelivery_safe_…`: `ADD COLUMN redelivery_safe boolean NOT NULL DEFAULT false` (all pre-existing rows → `false`, correctly not-eligible by design; metadata-only on PG 11+, no table rewrite). `down()` drops it.
- **Worker `markFailed`** now sets `redelivery_safe = (channel = 'dingtalk_work_notification')`. This is sound because `markFailed` is reached **only by a definite non-delivery**: `deliver()` routes an ambiguous DingTalk result (`!retryable && outcomeUnknown`) to `markOutcomeUnknown` **before** the `markFailed` fallthrough, and the classifier contract guarantees `outcomeUnknown ⟹ !retryable`. Ambiguous rows go to `markOutcomeUnknown`, which leaves `redelivery_safe=false`.
- **Redelivery gate** is now a **three-predicate** `UPDATE`:

  ```sql
  WHERE id = $1::uuid
    AND status = 'failed'
    AND channel = 'dingtalk_work_notification'
    AND redelivery_safe = true
  ```

  A `failed`-but-not-safe row, or any non-DingTalk row, classifies as **`not_eligible`** (one operator-review bucket — the action is identical: don't auto-resend, reconcile manually). The service doctrine header **retracts** the earlier "single load-bearing gate = `AND status='failed'`" claim and documents why `status='failed'` is contaminated.

| Guardrail | Behavior | Outcome / HTTP |
|---|---|---|
| Definite DingTalk failure (`failed` + dingtalk + `redelivery_safe`) | requeue → one operator-requested send | `requeued` / 200 |
| Already-succeeded destination | `sent` skipped, **nothing sent** (dedup no-op) | `already_delivered` / 200 |
| `outcome_unknown` never resent | refused, untouched (may already be delivered) | `refused_outcome_unknown` / 409 |
| Historical/pre-flag DingTalk failure, any WeCom/Email failure, pending/sending/retrying/skipped | not a target | `not_eligible` / 409 |
| source_key dedup by construction | `(org_id, source_key)` UNIQUE → row flipped in place, never inserted | — |
| operator-initiated only | worker claim only ever selects `pending`/`retrying` (+ lease-expired `sending`), never `failed` | — |

## FIX 2 (auth — owner-authorized, single-source) — platform-admin gate

`attendance:admin` cannot prove org-boundedness (`user_roles` has no `org_id`), and this route **triggers an external send**. Per the owner's **transitional ruling (2026-07-11)**, only a **platform admin** may call it (org-scoped RBAC is a separate governance line; `requireOrgMemberAccess` was explicitly **rejected** by the owner for this seam). The handler calls the **existing** `ensurePlatformAdmin` (exported **in place** from `admin-users.ts` — no second drifting auth check; the other ~20 call sites are unchanged) **first**, and returns early on `null` (it writes the 401/403 itself). A load-bearing in-code comment explains why this route diverges from the router's `attendance:admin` convention.

## FIX 3 (P2) — semantic audit (extends existing middleware, values-free)

Previously this route logged `operation=other`, `resource_id=NULL`, no context. The existing `attendanceAuditMiddleware` is **extended** (no duplicate audit log): a `notification_redeliver` operation, `deliveryId → resource_id`, and **values-free** metadata — **`org_id`, `channel`, `old_status`, `result`** — carried from the handler via `res.locals` (kept out of the client response body, guaranteeing no PII: **no recipient id / phone / source_key / message body**). Audit-write failure stays best-effort (does not fail the request).

## FIX 4 — task_id trace kept as **foundation**, not claimed complete

The partial index `idx_dacd_task_id` + accessor `findDingTalkApprovalCardDeliveriesByTaskId` are **kept as trace foundation infrastructure**. No new operator trace API/CLI is built (that would add another send-adjacent auth surface). **This PR does not claim §7.6 operator-trace acceptance is complete** — an operator trace API/CLI is **follow-up**.

## FIX 5 — supertest route-level tests

`403` (an `attendance:admin` who is **not** a platform admin) / `400` (bad deliveryId) / `409` (`not_eligible`, `outcome_unknown`) / `200` (`already_delivered`, `requeued`) + an assertion that the **audit row** carries `operation=notification_redeliver`, `resource_id=deliveryId`, the values-free `org/channel/old-status/result`, and **no PII** (seeded recipient id / source_key appear nowhere in the row).

---

## Test evidence (real Postgres)

`vitest --config vitest.integration.config.ts run` against a fresh migrated PG DB:

```
Test Files  2 passed (2)
     Tests  24 passed (24)
```

Files: `tests/integration/attendance-notification-redelivery.db.test.ts` (service + worker, already two-point-wired) and **new** `tests/integration/attendance-notification-redelivery-route.db.test.ts` (route, two-point-wired: `vitest.config.ts` exclude + `plugin-tests.yml` approval real-DB whitelist). `tsc --noEmit` clean. 174 affected unit tests green (worker/channels/outcome-unknown/admin-users routes).

### Mutation-replay (each guard is falsifiable)

| # | Mutation | Test that went RED |
|---|---|---|
| M1 | drop `AND status='failed'` from the redelivery UPDATE | predicate pin (status): synthetic pending+dingtalk+safe requeues |
| M2 | drop `AND channel='dingtalk_work_notification'` | predicate pin (channel): synthetic WeCom+safe requeues |
| M3 | drop `AND redelivery_safe=true` | predicate pin (redelivery_safe): historical DingTalk failure requeues |
| M4 | `markFailed` write `(channel=…)` → unconditional `false` | markFailed WRITE: definite DingTalk failure no longer redelivery-safe |
| M5 | remove the route's `if (!platformAdminId) return` early-return | 403 route test: forbidden caller's row gets requeued despite 403 |

Each mutation was applied, the suite run, RED confirmed, then restored to the committed state.

## Explicitly out of scope / not proven
- **`dingtalk_person_deliveries` retry** — no `source_key`/dedup substrate; not doctrine-safe. Future work.
- **`getsendresult` reconciliation** — roadmap "later opt-in".
- **Operator trace API/CLI** — follow-up (FIX 4); this PR ships trace foundation only.
- **Org-scoped RBAC** for this route — deferred to the governance line; guarded transitionally by the platform-admin gate per the owner's ruling.

## Reviewer scrutiny
- Redelivery resets `attempt_count` to 0 on requeue (fresh operator-requested cycle), not the exhausted count — so the explicit redelivery gets a real retry budget; still exactly one send per worker attempt.
- The `not_eligible` bucket deliberately covers both "failed-but-not-safe" and non-DingTalk rows (identical operator action) rather than proliferating outcome variants.
- Migration is timestamp-named after the current tip; auto-discovered by the file provider (no manifest). down/up round-trip + idempotent re-up verified.

Do NOT auto-merge — landing is gated/serialized by the main loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
