### PR TITLE
refactor(core-backend): remove vestigial listFiles + plugin-context setStorage/getStorage (F8)

### DIFF
--- a/packages/core-backend/src/core/enhanced-plugin-context.ts
+++ b/packages/core-backend/src/core/enhanced-plugin-context.ts
@@ -26,8 +26,6 @@ export interface EnhancedPluginContext {
   // Storage helpers
   getConfig<T = unknown>(key: string): T | undefined
   setConfig<T = unknown>(key: string, value: T): Promise<void>
-  getStorage<T = unknown>(key: string): Promise<T | undefined>
-  setStorage<T = unknown>(key: string, value: T): Promise<void>
 
   // Event helpers
   emit(event: string, data: unknown): Promise<void>
@@ -39,7 +37,6 @@ export function createEnhancedPluginContext(config: EnhancedPluginContextConfig)
   const pluginId = config.manifest.name // use name as id
   const logger = new Logger(`Plugin:${pluginId}`)
   const configStore = new Map<string, unknown>()
-  const storageCache = new Map<string, unknown>()
   const eventHandlers = new Map<string, Set<(data: unknown) => void>>()
 
   const capabilities: PluginCapabilities = {
@@ -69,45 +66,6 @@ export function createEnhancedPluginContext(config: EnhancedPluginContextConfig)
 
     async setConfig<T = unknown>(key: string, value: T): Promise<void> {
       configStore.set(key, value)
-    },
-
-    async getStorage<T = unknown>(key: string): Promise<T | undefined> {
-      // Check cache first
-      if (storageCache.has(key)) {
-        return storageCache.get(key) as T | undefined
-      }
-
-      // Load from storage service if available
-      if (config.services.storage) {
-        try {
-          const file = await config.services.storage.getFileInfo(`plugin:${pluginId}:${key}`)
-          if (file) {
-            const data = await config.services.storage.download(file.id)
-            const value = JSON.parse(data.toString())
-            storageCache.set(key, value)
-            return value as T | undefined
-          }
-        } catch (error) {
-          logger.error(`Failed to get storage key '${key}':`, error instanceof Error ? error : undefined)
-        }
-      }
-      return undefined
-    },
-
-    async setStorage<T = unknown>(key: string, value: T): Promise<void> {
-      storageCache.set(key, value)
-
-      if (config.services.storage) {
-        try {
-          const data = Buffer.from(JSON.stringify(value))
-          await config.services.storage.upload(data, {
-            filename: `plugin:${pluginId}:${key}`,
-            overwrite: true
-          })
-        } catch (error) {
-          logger.error(`Failed to set storage key '${key}':`, error instanceof Error ? error : undefined)
-        }
-      }
     },
 
     async emit(event: string, data: unknown): Promise<void> {

--- a/packages/core-backend/src/services/StorageService.ts
+++ b/packages/core-backend/src/services/StorageService.ts
@@ -15,7 +15,6 @@ import type {
   GetUrlOptions,
   PresignedUploadOptions,
   PresignedUpload,
-  ListOptions,
   StorageUsage
 } from '../types/plugin'
 import { Logger } from '../core/logger'
@@ -73,7 +72,6 @@ interface StorageProvider {
   getFileInfo(fileId: string): Promise<StorageFile | null>
   getFileUrl(fileId: string, options?: GetUrlOptions): Promise<string>
   getPresignedUploadUrl(options: PresignedUploadOptions): Promise<PresignedUpload>
-  listFiles(prefix?: string, options?: ListOptions): Promise<StorageFile[]>
   createFolder(path: string): Promise<void>
   deleteFolder(path: string, recursive?: boolean): Promise<void>
   getStorageUsage(): Promise<StorageUsage>
@@ -348,54 +346,6 @@ class LocalStorageProvider implements StorageProvider {
     }
   }
 
-  async listFiles(prefix?: string, options?: ListOptions): Promise<StorageFile[]> {
-    let files = Array.from(this.fileIndex.values())
-
-    // 应用前缀过滤
-    if (prefix) {
-      files = files.filter(file => file.path.startsWith(prefix))
-    }
-
-    // 应用过滤器
-    if (options?.filter) {
-      const filter = options.filter
-      files = files.filter(file => {
-        if (filter.contentType && file.contentType !== filter.contentType) return false
-        if (filter.sizeMin && file.size < filter.sizeMin) return false
-        if (filter.sizeMax && file.size > filter.sizeMax) return false
-        if (filter.createdAfter && file.createdAt < filter.createdAfter) return false
-        if (filter.createdBefore && file.createdAt > filter.createdBefore) return false
-        return true
-      })
-    }
-
-    // 排序
-    if (options?.sortBy) {
-      const sortBy = options.sortBy
-      const sortOrder = options.sortOrder || 'asc'
-      files.sort((a, b) => {
-        const aRaw = a[sortBy]
-        const bRaw = b[sortBy]
-        let aValue: string | number | Date = aRaw ?? ''
-        let bValue: string | number | Date = bRaw ?? ''
-
-        // Convert Date objects to timestamps for comparison
-        if (sortBy === 'createdAt' || sortBy === 'updatedAt') {
-          aValue = (aValue as Date).getTime()
-          bValue = (bValue as Date).getTime()
-        }
-
-        const comparison = aValue < bValue ? -1 : aValue > bValue ? 1 : 0
-        return sortOrder === 'asc' ? comparison : -comparison
-      })
-    }
-
-    // 分页
-    const offset = options?.offset || 0
-    const limit = options?.limit || files.length
-    return files.slice(offset, offset + limit)
-  }
-
   async createFolder(dirPath: string): Promise<void> {
     const fullPath = path.join(this.basePath, dirPath)
     try {
@@ -630,10 +580,6 @@ export class StorageServiceImpl extends EventEmitter implements StorageService {
       this.logger.error('Failed to delete multiple files', error as Error)
       throw error
     }
-  }
-
-  async listFiles(prefix?: string, options?: ListOptions): Promise<StorageFile[]> {
-    return this.provider.listFiles(prefix, options)
   }
 
   async createFolder(path: string): Promise<void> {

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -1676,7 +1676,6 @@ export interface StorageService {
   getFileInfo(fileId: string): Promise<StorageFile | null>
   getFileUrl(fileId: string, options?: GetUrlOptions): Promise<string>
   getPresignedUploadUrl(options: PresignedUploadOptions): Promise<PresignedUpload>
-  listFiles(prefix?: string, options?: ListOptions): Promise<StorageFile[]>
   createFolder(path: string): Promise<void>
   deleteFolder(path: string, recursive?: boolean): Promise<void>
   getStorageUsage(): Promise<StorageUsage>
@@ -1732,21 +1731,6 @@ export interface PresignedUpload {
   fileId?: string
   fields?: Record<string, string>
   expiresAt?: Date
-}
-
-export interface ListOptions {
-  limit?: number
-  offset?: number
-  recursive?: boolean
-  sortBy?: 'name' | 'size' | 'createdAt' | 'updatedAt'
-  sortOrder?: 'asc' | 'desc'
-  filter?: {
-    contentType?: string
-    sizeMin?: number
-    sizeMax?: number
-    createdAfter?: Date
-    createdBefore?: Date
-  }
 }
 
 export interface StorageUsage {


### PR DESCRIPTION
## F8 — vestigial interface/contract cleanup (ratified design-lock GF8-1 + GF8-2)

refs #3925. Pure deletion, zero logic change. Base: `main`. **Not merging** — hold for opus adversarial review (safety gate for the GF8-2 plugin-context question).

### GF8-1: remove `listFiles` (landed)

Confirmed via `git grep -n '\.listFiles\|listFiles(' -- 'packages/**' 'plugins/**'` before deletion: the only hits outside declarations/impls were two **comments** in `routes/files.ts:488/490` explaining that the `GET /api/files` list route was already migrated off `storage.listFiles` onto a DB query (F1, prior to this PR) — zero real callers. Also grepped broader (`listFiles` with no path filter): the only other hits are an unrelated local helper function of the same name in `packages/mssql-readonly-utils/__tests__/helper-contract.test.cjs` — not this interface.

Deleted:
- `packages/core-backend/src/services/StorageService.ts` — `StorageProvider` interface `listFiles(...)` declaration (was line 76)
- `packages/core-backend/src/services/StorageService.ts` — `LocalStorageProvider.listFiles(...)` implementation (was lines 351–397, the filter/sort/paginate body reading `fileIndex`)
- `packages/core-backend/src/services/StorageService.ts` — `StorageServiceImpl.listFiles(...)` implementation + delegate to `this.provider.listFiles(...)` (was lines 635–637)
- `packages/core-backend/src/services/StorageService.ts` — `ListOptions` removed from the `import type { ... } from '../types/plugin'` block (now unused in this file)
- `packages/core-backend/src/types/plugin.ts` — **public plugin type**: `StorageService` interface `listFiles(...)` declaration (was line 1679)
- `packages/core-backend/src/types/plugin.ts` — **public plugin type**: `ListOptions` interface definition (was lines 1737–1750), deleted because after removing `listFiles` it had zero remaining references anywhere in the repo (re-grepped post-delete: `git grep -n 'ListOptions'` only matches unrelated distinct identifiers `DiscussionListOptions`, `DLQListOptions`, `resolvePlmListOptions`)

**Flag for owner/opus**: `listFiles` and `ListOptions` are both `export`ed from `types/plugin.ts`, i.e. this is a **public plugin-type surface removal**, not a purely internal/private cleanup. Zero in-repo importers confirmed; no evidence either way of external plugin consumers (per f6-recon.md's prior analysis, same as F6's S3StorageProvider precedent).

Untouched (per design-lock, same-family methods explicitly out of scope): `getStorageUsage`, `deleteFolder`, `createFolder`, `uploadMultiple`, `deleteMultiple`, `setUploadLimit`.

### GF8-2: remove `setStorage`/`getStorage` (landed — see decision rationale below)

Confirmed via `git grep -n 'setStorage\|getStorage' -- 'packages/**' 'plugins/**'` (and re-run with no path filter) before deletion: the **only** hits were the interface declaration and implementation in `enhanced-plugin-context.ts` itself, plus two doc-only mentions in already-committed design-lock docs (`docs/development/file-evidence-security-line-verification-20260710.md:115`, `docs/development/files-storage-integrity-f3-design-lock-20260710.md:45`) that pre-date this PR and are not code references. Zero plugin/core/test callers.

Deleted:
- `packages/core-backend/src/core/enhanced-plugin-context.ts` — `EnhancedPluginContext` interface: `getStorage<T>(...)` / `setStorage<T>(...)` declarations (were lines 29–30)
- `packages/core-backend/src/core/enhanced-plugin-context.ts` — implementation of both methods in the object returned by `createEnhancedPluginContext` (were lines 72–109: `getStorage` reading `storageCache`/calling `config.services.storage.getFileInfo`+`download`, `setStorage` writing `storageCache`/calling `config.services.storage.upload`)
- `packages/core-backend/src/core/enhanced-plugin-context.ts` — the `storageCache` Map (was line 40): grepped post-removal-of-methods, it had zero remaining readers/writers (only `getStorage`/`setStorage` touched it), so it would otherwise be dead weight / an eslint `no-unused-vars` trip. Removing it changes no *remaining* logic.

**Per task instruction**, since grep found **zero in-repo callers**, GF8-2 is implemented (not held) — the design-lock's hold condition ("if grep finds an in-repo caller, don't delete GF8-2") did not trigger. This does **not** pre-empt the opus safety-gate judgment on whether removing a public plugin-context contract method is acceptable given unknown external plugin consumers — that call is explicitly deferred to the adversarial review per the design-lock ("若审阅判定 plugin-context 契约不宜自动移除，则 hold 该部分只落安全部分").

**Flag for owner/opus**: `setStorage`/`getStorage` are **plugin-context contract methods** (part of the dynamically-loaded external-plugin API surface, `EnhancedPluginContext`), a different risk category from GF8-1's public *type* removal — this is a public *method* removal from an interface plugins are handed at runtime. `context.services.storage` (the underlying `StorageService`, with `upload`/`getFileInfo`/`download`/etc.) is untouched — only the two convenience wrapper methods on the enhanced context are removed. `config` (getConfig/setConfig) is untouched.

### Hard-preserved boundary (untouched, confirmed by inspection)

Not touched: in-memory `fileIndex`/`buildFileIndex`/`scanDirectory`/`deriveIdFromRelativePath`/`generateFileId`, and the full by-`fileId` method family (`download`/`delete`/`exists`/`getFileInfo`/`getFileUrl`), `downloadByKey`/`deleteByKey`, any auth/ACL logic, `files.ts` read/delete/info routes, multitable attachment code, `attachment-orphan-retention.ts`, F4.

### Verification

- `pnpm -C packages/core-backend exec tsc --noEmit` → **0 errors** (confirms no dangling references to any deleted symbol).
- Scoped eslint (`npx eslint -c .eslintrc.json` on the 3 changed files) → **0 errors**, 1 pre-existing unrelated warning (`MultitableProvisioningFieldDescriptor` unused import in `types/plugin.ts`, present on `main` before this change).
- Full no-DB vitest suite (`npx vitest run`, no `DATABASE_URL`): **447 test files / 6166 tests passed**, 182 files / 1566 tests skipped (DB-gated, expected without a live Postgres — not new skips introduced by this change).
- Targeted real-suite re-run (no regressions, all green): `tests/unit/storageServiceLocalProvider.test.ts`, `tests/unit/multitable-attachment-service.test.ts`, `tests/unit/multitable-attachment-cleanup.test.ts`, `tests/integration/attendance-files-acl.test.ts`, `tests/integration/multitable-attachment-readgate.security.test.ts`, `tests/integration/multitable-attachments.api.test.ts` — 53 passed, 16 skipped (DB-gated).
- No mutation testing (pure deletion, per design-lock).

### Diff stat

```
 packages/core-backend/src/core/enhanced-plugin-context.ts | 42 -----------------
 packages/core-backend/src/services/StorageService.ts      | 54 ----------------------
 packages/core-backend/src/types/plugin.ts                 | 16 -------
 3 files changed, 112 deletions(-)
```
