### PR TITLE
feat(plm): Discussion Phase-3 WRITE consumer (Lane C) — session exchange + 6 write routes [HELD — owner-word merge]

### DIFF
--- a/docs/development/plm-discussion-consumer-taskbook-20260709.md
+++ b/docs/development/plm-discussion-consumer-taskbook-20260709.md
@@ -95,6 +95,22 @@ interface PlmDiscussionProvider {
    mentionable-users` (tenant-safe, id+username only) — no client-side
    identity caching or scraping.
 
+> **Gate-2 REWORKED contract (owner-ratified, Yuantus provider #1188, live).**
+> Supersedes the "dedicated `aud`, target-scoped, refreshable" sketch in point
+> 1 above with the shipped shape: the session credential is **type-restricted**
+> (`typ=discussion_session`, `aud=discussion`) and **scope-bound** to
+> `part_id`/`feature_key`/`embed_origin` (baked into the token, re-checked
+> **route-scoped** on each of the 6 write routes individually — never accepted
+> on the shared session-JWT funnel/middleware). The mint is
+> `POST /api/v1/auth/embed/discussion-session`, dark-flag gated
+> (`DISCUSSION_SESSION_ENABLED`, default **OFF**); while off, every exchange —
+> valid or invalid embed token alike — returns the same uniform 401. **There is
+> NO refresh in v1**: a caller whose credential expires re-exchanges from a
+> fresh embed token. Write-time entitlement is a dedicated own-SKU,
+> **`metasheet_review_writeback`** (freshly checked per write) — **not** the
+> read-side `metasheet_review` gate in §6. Consumer implementation: Lane C
+> (`PLMAdapter.exchangeDiscussionSession` + the 6 write methods).
+
 ## 5. Notifications
 
 - Cross-system dedup key = the Yuantus outbox occurrence nonce
@@ -114,6 +130,12 @@ interface PlmDiscussionProvider {
   absent, zero broken UI; discussion data remains in Yuantus and stays
   readable on PLM surfaces ("data outlives the add-on") — assert both in the
   downgrade tests.
+- **Gate-2 REWORKED contract note:** the `metasheet_review` gate above is
+  READ-ONLY. Write-time (C2/Lane C) gates on the **separate, own-SKU**
+  `metasheet_review_writeback` entitlement, freshly checked by the provider on
+  every write call — a caller entitled to read discussions is not
+  automatically entitled to write them. See §4's Gate-2 callout for the full
+  session-credential shape this gate sits behind.
 
 ## 7. Pact sequencing
 

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -933,6 +933,54 @@ export interface DiscussionThreadDetail extends DiscussionThreadSummary {
   history?: Array<Record<string, unknown>>;
 }
 
+/**
+ * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE) consumer types: the discussion-session
+ * credential exchange plus the six write routes it authorizes. Gate-2 REWORKED contract
+ * (owner-ratified rework of Yuantus provider #1188): the credential is minted from the SAME
+ * BOM-review embed token (feature_key="bom_multitable") via a dedicated pre-auth exchange
+ * (`POST /api/v1/auth/embed/discussion-session`, no Authorization header, JSON body). The
+ * minted access_token is type-restricted (`typ=discussion_session`) and scope-bound
+ * (part_id/feature_key/embed_origin), checked ROUTE-SCOPED on each of the 6 write routes only
+ * -- never accepted on the shared session-JWT funnel/middleware. There is NO refresh in v1: a
+ * caller whose credential expires must re-exchange from a fresh embed token. Write-time
+ * entitlement is the credential's OWN SKU `metasheet_review_writeback` (freshly checked per
+ * write; distinct from the read-side `metasheet_review`). The whole exchange is dark-flag gated
+ * server-side (`DISCUSSION_SESSION_ENABLED`, default OFF); while off, EVERY exchange attempt
+ * (valid or invalid embed token alike) returns the SAME uniform 401 -- this consumer must never
+ * try to distinguish "flag off" from "bad token".
+ */
+export interface DiscussionSessionCredential {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  aud: string;
+}
+
+export interface CreateThreadRequest {
+  target_type: DiscussionTargetType;
+  target_id: string;
+  title?: string;
+  body: string;
+  mentioned_user_ids?: number[];
+  anchor?: Record<string, unknown> | null;
+}
+
+export interface AddCommentRequest {
+  body: string;
+  parent_comment_id?: string;
+  mentioned_user_ids?: number[];
+  anchor?: Record<string, unknown> | null;
+}
+
+export interface EditCommentRequest {
+  body: string;
+}
+
+export interface ThreadTransitionRequest {
+  comment?: string;
+  mentioned_user_ids?: number[];
+}
+
 export class PLMAdapter extends HTTPAdapter {
   private mockMode = false;
   private apiMode: PLMApiMode = 'legacy';
@@ -2499,6 +2547,363 @@ export class PLMAdapter extends HTTPAdapter {
     if (options?.includeHistory) params.include_history = options.includeHistory
 
     return this.query<DiscussionThreadDetail>(`/api/v1/discussions/${threadId}`, [params])
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): shared raw-fetch transport for the
+   * discussion-session exchange and the six write routes. Deliberately bypasses
+   * `this.select`/`this.query` -- HTTPAdapter's request interceptor (see `connect()` above)
+   * unconditionally overwrites `Authorization` with the adapter's own service token, which
+   * would silently replace the caller-supplied discussion-session bearer token with the wrong
+   * credential. `headers.Authorization`, when present, is therefore set by the CALLER on each
+   * invocation -- never cached on `this`. Never throws: network failures and non-2xx responses
+   * alike come back as `QueryResult.error`, mirroring the envelope the read methods return.
+   */
+  private async yuantusDiscussionFetch<T>(
+    path: string,
+    init: { method: string; headers?: Record<string, string>; body?: unknown },
+  ): Promise<QueryResult<T>> {
+    const baseUrl = this.config.connection.baseURL || this.config.connection.url
+    if (!baseUrl) {
+      return { data: [], error: new Error('PLM base URL is not configured') }
+    }
+
+    let response: Awaited<ReturnType<typeof fetch>>
+    try {
+      response = await fetch(`${baseUrl}${path}`, {
+        method: init.method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(init.headers || {}),
+        },
+        body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+      })
+    } catch (err) {
+      return { data: [], error: err instanceof Error ? err : new Error(String(err)) }
+    }
+
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch {
+      payload = undefined
+    }
+
+    if (!response.ok) {
+      const detail = payload && typeof payload === 'object' && 'detail' in (payload as Record<string, unknown>)
+        ? (payload as Record<string, unknown>).detail
+        : undefined
+      const message = typeof detail === 'string'
+        ? detail
+        : `PLM discussion request failed with status ${response.status}`
+      return {
+        data: [],
+        error: Object.assign(new Error(message), { response: { status: response.status, data: payload } }),
+      }
+    }
+
+    return { data: [payload as T], metadata: { totalCount: 1 } }
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): exchange the BOM-review embed token
+   * (feature_key="bom_multitable") for a discussion-session credential
+   * (`POST /api/v1/auth/embed/discussion-session`). Pre-auth -- sends NO Authorization header.
+   * Fail-closed and uniform: dark-flag-off and an invalid/expired embed token both come back as
+   * the SAME 401, surfaced as `QueryResult.error`, never thrown. The returned `access_token`
+   * MUST be passed explicitly to every write method below; this adapter never stores it.
+   */
+  async exchangeDiscussionSession(embedToken: string): Promise<QueryResult<DiscussionSessionCredential>> {
+    if (this.mockMode) {
+      return {
+        data: [{ access_token: 'mock-discussion-session-token', token_type: 'bearer', expires_in: 300, aud: 'discussion' }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussion writes are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionSessionCredential>('/api/v1/auth/embed/discussion-session', {
+      method: 'POST',
+      body: { embed_token: embedToken },
+    })
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): open a new discussion thread
+   * (`POST /api/v1/discussions`). `sessionToken` is the `access_token` from
+   * `exchangeDiscussionSession`, passed explicitly on every call -- see the type-block docstring
+   * above for why it is never cached on the adapter instance.
+   */
+  async createDiscussionThread(
+    sessionToken: string,
+    req: CreateThreadRequest,
+  ): Promise<QueryResult<DiscussionThreadDetail>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: 'mock-thread-1',
+          target_type: req.target_type,
+          target_id: req.target_id,
+          title: req.title ?? null,
+          status: 'open',
+          created_by_id: 1,
+          created_at: new Date().toISOString(),
+          resolved_by_id: null,
+          resolved_at: null,
+          last_comment_at: new Date().toISOString(),
+          comment_count: 1,
+          anchor: req.anchor ?? null,
+          comments: [],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussion writes are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionThreadDetail>('/api/v1/discussions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${sessionToken}` },
+      body: req,
+    })
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): reply on an existing thread
+   * (`POST /api/v1/discussions/{threadId}/comments`).
+   */
+  async addDiscussionComment(
+    sessionToken: string,
+    threadId: string,
+    req: AddCommentRequest,
+  ): Promise<QueryResult<DiscussionThreadDetail>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: threadId,
+          target_type: 'item',
+          target_id: 'mock-item-1',
+          title: 'Mock discussion thread',
+          status: 'open',
+          created_by_id: 1,
+          created_at: new Date().toISOString(),
+          resolved_by_id: null,
+          resolved_at: null,
+          last_comment_at: new Date().toISOString(),
+          comment_count: 1,
+          anchor: null,
+          comments: [{
+            id: 'mock-comment-1',
+            parent_comment_id: req.parent_comment_id ?? null,
+            body: req.body,
+            body_format: 'text',
+            author_user_id: 1,
+            mentioned_user_ids: req.mentioned_user_ids ?? [],
+            created_at: new Date().toISOString(),
+            edited_at: null,
+            deleted_at: null,
+            anchor: req.anchor ?? null,
+          }],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussion writes are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionThreadDetail>(`/api/v1/discussions/${threadId}/comments`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${sessionToken}` },
+      body: req,
+    })
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): edit a comment's body
+   * (`PATCH /api/v1/discussions/{threadId}/comments/{commentId}`).
+   */
+  async editDiscussionComment(
+    sessionToken: string,
+    threadId: string,
+    commentId: string,
+    req: EditCommentRequest,
+  ): Promise<QueryResult<DiscussionThreadDetail>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: threadId,
+          target_type: 'item',
+          target_id: 'mock-item-1',
+          title: 'Mock discussion thread',
+          status: 'open',
+          created_by_id: 1,
+          created_at: new Date().toISOString(),
+          resolved_by_id: null,
+          resolved_at: null,
+          last_comment_at: new Date().toISOString(),
+          comment_count: 1,
+          anchor: null,
+          comments: [{
+            id: commentId,
+            parent_comment_id: null,
+            body: req.body,
+            body_format: 'text',
+            author_user_id: 1,
+            mentioned_user_ids: [],
+            created_at: new Date().toISOString(),
+            edited_at: new Date().toISOString(),
+            deleted_at: null,
+            anchor: null,
+          }],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussion writes are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionThreadDetail>(`/api/v1/discussions/${threadId}/comments/${commentId}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${sessionToken}` },
+      body: req,
+    })
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): soft-delete a comment (body/anchor redacted
+   * to null server-side, row kept for audit) -- `DELETE
+   * /api/v1/discussions/{threadId}/comments/{commentId}`. No request body.
+   */
+  async deleteDiscussionComment(
+    sessionToken: string,
+    threadId: string,
+    commentId: string,
+  ): Promise<QueryResult<DiscussionThreadDetail>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: threadId,
+          target_type: 'item',
+          target_id: 'mock-item-1',
+          title: 'Mock discussion thread',
+          status: 'open',
+          created_by_id: 1,
+          created_at: new Date().toISOString(),
+          resolved_by_id: null,
+          resolved_at: null,
+          last_comment_at: new Date().toISOString(),
+          comment_count: 1,
+          anchor: null,
+          comments: [{
+            id: commentId,
+            parent_comment_id: null,
+            body: null,
+            body_format: 'text',
+            author_user_id: 1,
+            mentioned_user_ids: [],
+            created_at: new Date().toISOString(),
+            edited_at: null,
+            deleted_at: new Date().toISOString(),
+            anchor: null,
+          }],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussion writes are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionThreadDetail>(`/api/v1/discussions/${threadId}/comments/${commentId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${sessionToken}` },
+    })
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): transition a thread to resolved
+   * (`POST /api/v1/discussions/{threadId}/resolve`). `req` is optional -- an empty object is
+   * sent when the caller resolves without a closing comment/mentions.
+   */
+  async resolveDiscussionThread(
+    sessionToken: string,
+    threadId: string,
+    req?: ThreadTransitionRequest,
+  ): Promise<QueryResult<DiscussionThreadDetail>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: threadId,
+          target_type: 'item',
+          target_id: 'mock-item-1',
+          title: 'Mock discussion thread',
+          status: 'resolved',
+          created_by_id: 1,
+          created_at: new Date().toISOString(),
+          resolved_by_id: 1,
+          resolved_at: new Date().toISOString(),
+          last_comment_at: new Date().toISOString(),
+          comment_count: 1,
+          anchor: null,
+          comments: [],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussion writes are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionThreadDetail>(`/api/v1/discussions/${threadId}/resolve`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${sessionToken}` },
+      body: req ?? {},
+    })
+  }
+
+  /**
+   * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): transition a resolved thread back to open
+   * (`POST /api/v1/discussions/{threadId}/reopen`). `req` is optional, same shape as resolve.
+   */
+  async reopenDiscussionThread(
+    sessionToken: string,
+    threadId: string,
+    req?: ThreadTransitionRequest,
+  ): Promise<QueryResult<DiscussionThreadDetail>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: threadId,
+          target_type: 'item',
+          target_id: 'mock-item-1',
+          title: 'Mock discussion thread',
+          status: 'open',
+          created_by_id: 1,
+          created_at: new Date().toISOString(),
+          resolved_by_id: null,
+          resolved_at: null,
+          last_comment_at: new Date().toISOString(),
+          comment_count: 1,
+          anchor: null,
+          comments: [],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussion writes are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionThreadDetail>(`/api/v1/discussions/${threadId}/reopen`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${sessionToken}` },
+      body: req ?? {},
+    })
   }
 
   async getApprovals(options?: ApprovalQueryOptions): Promise<QueryResult<ApprovalRequest>> {

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -4462,6 +4462,283 @@
       }
     },
     {
+      "description": "exchange a valid BOM-review embed token for a discussion-session credential",
+      "providerStates": [
+        {
+          "name": "a valid embed token exchanges for a discussion-session credential"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/auth/embed/discussion-session",
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "embed_token": "eyJhbGciOiJFZERTQSJ9.example-bom-multitable-embed-token"
+        },
+        "matchingRules": {
+          "body": {
+            "$.embed_token": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "access_token": "eyJhbGciOiJIUzI1NiJ9.discussion-session-example",
+          "token_type": "bearer",
+          "expires_in": 300,
+          "aud": "discussion"
+        },
+        "matchingRules": {
+          "body": {
+            "$.access_token": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.token_type": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.expires_in": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.aud": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "add a comment on a discussion thread using a discussion-session credential authorized to comment",
+      "providerStates": [
+        {
+          "name": "the discussion-session credential authorizes a comment write (can_comment true)"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/discussions/01H000000000000000000000T2/comments",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.discussion-session-example",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "body": "Confirmed with vendor -- tolerance is fine"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.body": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": "01H000000000000000000000T2",
+          "target_type": "item",
+          "target_id": "01H000000000000000000000T1",
+          "title": "Check tolerance on mounting hole",
+          "status": "open",
+          "created_by_id": 1,
+          "created_at": "2026-07-09T00:00:00.000Z",
+          "resolved_by_id": null,
+          "resolved_at": null,
+          "last_comment_at": "2026-07-09T00:10:00.000Z",
+          "comment_count": 2,
+          "anchor": null,
+          "comments": [
+            {
+              "id": "01H000000000000000000000T3",
+              "parent_comment_id": null,
+              "body": "Tolerance looks tight -- can we confirm with the vendor?",
+              "body_format": "text",
+              "author_user_id": 1,
+              "mentioned_user_ids": [],
+              "created_at": "2026-07-09T00:05:00.000Z",
+              "edited_at": null,
+              "deleted_at": null,
+              "anchor": null
+            },
+            {
+              "id": "01H000000000000000000000T4",
+              "parent_comment_id": null,
+              "body": "Confirmed with vendor -- tolerance is fine",
+              "body_format": "text",
+              "author_user_id": 2,
+              "mentioned_user_ids": [],
+              "created_at": "2026-07-09T00:10:00.000Z",
+              "edited_at": null,
+              "deleted_at": null,
+              "anchor": null
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.comment_count": {
+              "matchers": [
+                {
+                  "match": "integer",
+                  "min": 1
+                }
+              ]
+            },
+            "$.comments": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.comments[*].id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.comments[*].author_user_id": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.comments[*].created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.created_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.last_comment_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "reject a comment write from a discussion-session credential without comment permission",
+      "providerStates": [
+        {
+          "name": "the discussion-session credential is forbidden from writing (can_comment false)"
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/discussions/01H000000000000000000000T2/comments",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.discussion-session-example",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "body": "trying to comment without permission"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.body": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 403,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "detail": "not permitted for this discussion target"
+        }
+      }
+    },
+    {
       "description": "mint a MetaSheet BOM review embed token for the Yuantus parent host",
       "providerStates": [
         {

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -137,6 +137,17 @@ const PLM_ADAPTER_PACT_PATHS = [
   { method: 'GET', path: '/api/v1/discussions' },
   { method: 'GET', path: '/api/v1/discussions/01H000000000000000000000T2' },
   { method: 'GET', path: '/api/v1/discussions' },
+  // PLM-COLLAB Discussion Phase 3 slice-2 (WRITE, Gate-2 REWORKED contract): the
+  // discussion-session credential exchange plus a representative write success/forbidden pair.
+  // Only interactions backed by a provider PRE-REGISTERED state (named verbatim in the
+  // taskbook) are pact-frozen here -- the contract-first principle above forbids inventing a
+  // state name the provider does not actually expose. The adapter itself implements all 6
+  // write routes (see `endpointsToFind` below, which checks source presence, not pact
+  // interactions); the other 5 write routes share this same exchange + entitlement shape and
+  // are exercised at the unit-test layer (plm-adapter-yuantus.test.ts) instead of here.
+  { method: 'POST', path: '/api/v1/auth/embed/discussion-session' },
+  { method: 'POST', path: '/api/v1/discussions/01H000000000000000000000T2/comments' },
+  { method: 'POST', path: '/api/v1/discussions/01H000000000000000000000T2/comments' },
 ] as const
 
 const PARENT_HOST_PACT_PATHS = [
@@ -245,6 +256,15 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       // PLM-COLLAB Discussion Phase 3 slice-1 (READ-ONLY)
       '/api/v1/discussions',
       '/api/v1/discussions/${threadId}',
+      // PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): the exchange path + the write route
+      // templates. '/api/v1/discussions' (createDiscussionThread's POST target) is already
+      // covered by the read-slice entry above -- these are the remaining 6 write path
+      // templates (5 distinct templates: edit/delete share one) + the exchange path = 7.
+      '/api/v1/auth/embed/discussion-session',
+      '/api/v1/discussions/${threadId}/comments',
+      '/api/v1/discussions/${threadId}/comments/${commentId}',
+      '/api/v1/discussions/${threadId}/resolve',
+      '/api/v1/discussions/${threadId}/reopen',
     ]
     for (const ep of endpointsToFind) {
       expect(
@@ -466,6 +486,60 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       const headers = (interaction.request.headers ?? {}) as Record<string, string>
       expect(headers.Authorization).toBeDefined()
     }
+  })
+
+  // PLM-COLLAB Discussion Phase 3 slice-2 (WRITE, Gate-2 REWORKED contract): the
+  // discussion-session credential exchange (pre-auth, NO Authorization header) plus a
+  // representative write success/forbidden pair on the same comments route -- mirrors the
+  // read-slice's own shape (one distinct exchange path, one write path exercised twice).
+  it('Discussion Phase 3 slice-2: the session exchange and a write success/forbidden pair are locked', () => {
+    const pact = loadPact()
+    const exchange = pact.interactions.find(
+      i => i.request.path === '/api/v1/auth/embed/discussion-session',
+    )
+    const writeInteractions = pact.interactions.filter(
+      i => i.request.path === '/api/v1/discussions/01H000000000000000000000T2/comments',
+    )
+    expect(exchange).toBeDefined()
+    expect(writeInteractions).toHaveLength(2)
+
+    // exchange: pre-auth, NO Authorization header, body is {embed_token}
+    expect(exchange!.request.method).toBe('POST')
+    expect(exchange!.request.headers?.Authorization).toBeUndefined()
+    expect(exchange!.request.body).toEqual({ embed_token: expect.any(String) })
+    expect(exchange!.response.status).toBe(200)
+    const credential = exchange!.response.body as Record<string, unknown>
+    expect(credential).toMatchObject({
+      access_token: expect.any(String),
+      token_type: expect.any(String),
+      expires_in: expect.any(Number),
+      aud: 'discussion',
+    })
+    expect(exchange!.providerStates![0].name).toBe(
+      'a valid embed token exchanges for a discussion-session credential',
+    )
+
+    // write success: Bearer-authorized with the exchanged credential, response is a thread detail
+    const writeSuccess = writeInteractions.find(i => i.response.status === 200)
+    expect(writeSuccess).toBeDefined()
+    expect(writeSuccess!.request.method).toBe('POST')
+    const successHeaders = (writeSuccess!.request.headers ?? {}) as Record<string, string>
+    expect(successHeaders.Authorization).toBeDefined()
+    const successRules = (writeSuccess!.request as unknown as { matchingRules?: { header?: Record<string, unknown> } })
+      .matchingRules
+    expect(successRules?.header).toHaveProperty('$.Authorization')
+    expect((writeSuccess!.response.body as Record<string, unknown>).comments).toBeDefined()
+    expect(writeSuccess!.providerStates![0].name).toBe(
+      'the discussion-session credential authorizes a comment write (can_comment true)',
+    )
+
+    // forbidden write: same route, same credential shape, provider denies (can_comment false)
+    const writeForbidden = writeInteractions.find(i => i.response.status === 403)
+    expect(writeForbidden).toBeDefined()
+    expect(writeForbidden!.providerStates![0].name).toBe(
+      'the discussion-session credential is forbidden from writing (can_comment false)',
+    )
+    expect(writeForbidden!.response.body).toEqual({ detail: expect.any(String) })
   })
 
   // ECO Phase 0: the discriminated-409 error contract (Yuantus provider #968 taskbook + #969 impl).

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
 
 const createAdapter = () => {
@@ -1290,5 +1290,308 @@ describe('PLMAdapter Yuantus discussion reads', () => {
     const detailResult = await adapter.getDiscussionThread('thread-1')
     expect(detailResult.data).toHaveLength(0)
     expect(detailResult.error).toBeDefined()
+  })
+})
+
+// PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): exchangeDiscussionSession + the six write
+// methods. AUTH IS DIFFERENT FROM THE READS ABOVE -- these bypass this.select/this.query (the
+// HTTPAdapter request interceptor unconditionally overwrites Authorization with the adapter's
+// own service token) and issue a raw fetch() instead, carrying the discussion-session bearer
+// token as an EXPLICIT per-call parameter that is never cached on the adapter instance.
+describe('PLMAdapter Yuantus discussion writes', () => {
+  const jsonResponse = (status: number, body: unknown) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  })
+
+  const threadDetail = (overrides: Record<string, unknown> = {}) => ({
+    id: 'thread-1',
+    target_type: 'item',
+    target_id: 'item-1',
+    title: 'Check tolerance',
+    status: 'open',
+    created_by_id: 1,
+    created_at: '2026-07-09T00:00:00.000Z',
+    resolved_by_id: null,
+    resolved_at: null,
+    last_comment_at: '2026-07-09T00:05:00.000Z',
+    comment_count: 1,
+    anchor: null,
+    comments: [],
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    ;(fetch as Mock).mockClear()
+  })
+
+  it('exchanges a valid embed token for a discussion-session credential, sending NO Authorization header', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+      access_token: 'session-token-abc',
+      token_type: 'bearer',
+      expires_in: 300,
+      aud: 'discussion',
+    }))
+
+    const result = await adapter.exchangeDiscussionSession('embed-token-1')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/auth/embed/discussion-session')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ embed_token: 'embed-token-1' })
+    expect(init.headers).not.toHaveProperty('Authorization')
+
+    expect(result.error).toBeUndefined()
+    expect(result.data[0]).toMatchObject({ access_token: 'session-token-abc', aud: 'discussion' })
+  })
+
+  it('fails closed and uniform on a 401 exchange (dark-flag-off and an invalid token are indistinguishable)', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: 'invalid or expired embed token' }))
+
+    const result = await adapter.exchangeDiscussionSession('bad-embed-token')
+
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+    expect((result.error as any)?.response?.status).toBe(401)
+  })
+
+  it('creates a discussion thread, carrying the caller-supplied bearer token', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({ id: 'thread-new' })))
+
+    const result = await adapter.createDiscussionThread('session-token-1', {
+      target_type: 'item',
+      target_id: 'item-1',
+      title: 'New thread',
+      body: 'first comment',
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions')
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe('Bearer session-token-1')
+    expect(JSON.parse(init.body)).toEqual({
+      target_type: 'item',
+      target_id: 'item-1',
+      title: 'New thread',
+      body: 'first comment',
+    })
+    expect(result.error).toBeUndefined()
+    expect(result.data[0]).toMatchObject({ id: 'thread-new', status: 'open' })
+  })
+
+  it('rejects an invalid create-thread payload (422) as a QueryResult error, never throwing', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(422, { detail: 'unknown target_type' }))
+
+    const result = await adapter.createDiscussionThread('session-token-1', {
+      target_type: 'item',
+      target_id: 'item-1',
+      body: '',
+    })
+
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+    expect((result.error as any)?.response?.status).toBe(422)
+  })
+
+  it('adds a comment to an existing thread', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({
+      comment_count: 2,
+      comments: [{
+        id: 'comment-new',
+        parent_comment_id: null,
+        body: 'Confirmed with vendor',
+        body_format: 'text',
+        author_user_id: 1,
+        mentioned_user_ids: [],
+        created_at: '2026-07-09T00:06:00.000Z',
+        edited_at: null,
+        deleted_at: null,
+        anchor: null,
+      }],
+    })))
+
+    const result = await adapter.addDiscussionComment('session-token-1', 'thread-1', {
+      body: 'Confirmed with vendor',
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions/thread-1/comments')
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe('Bearer session-token-1')
+    expect(JSON.parse(init.body)).toEqual({ body: 'Confirmed with vendor' })
+    expect(result.error).toBeUndefined()
+    expect(result.data[0].comments[0]).toMatchObject({ id: 'comment-new', body: 'Confirmed with vendor' })
+  })
+
+  it('surfaces a forbidden comment write (out-of-scope / no can_comment) as a QueryResult error, never throwing', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(403, { detail: 'not permitted to comment on this discussion' }))
+
+    const result = await adapter.addDiscussionComment('session-token-1', 'thread-1', { body: 'hi' })
+
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+    expect((result.error as any)?.response?.status).toBe(403)
+  })
+
+  it('edits a comment', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({
+      comments: [{
+        id: 'comment-1',
+        parent_comment_id: null,
+        body: 'Updated body',
+        body_format: 'text',
+        author_user_id: 1,
+        mentioned_user_ids: [],
+        created_at: '2026-07-09T00:05:00.000Z',
+        edited_at: '2026-07-09T00:07:00.000Z',
+        deleted_at: null,
+        anchor: null,
+      }],
+    })))
+
+    const result = await adapter.editDiscussionComment('session-token-1', 'thread-1', 'comment-1', {
+      body: 'Updated body',
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions/thread-1/comments/comment-1')
+    expect(init.method).toBe('PATCH')
+    expect(init.headers.Authorization).toBe('Bearer session-token-1')
+    expect(JSON.parse(init.body)).toEqual({ body: 'Updated body' })
+    expect(result.error).toBeUndefined()
+    expect(result.data[0].comments[0]).toMatchObject({ id: 'comment-1', body: 'Updated body' })
+  })
+
+  it('deletes (soft) a comment, sending DELETE with no request body', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({
+      comments: [{
+        id: 'comment-1',
+        parent_comment_id: null,
+        body: null,
+        body_format: 'text',
+        author_user_id: 1,
+        mentioned_user_ids: [],
+        created_at: '2026-07-09T00:05:00.000Z',
+        edited_at: null,
+        deleted_at: '2026-07-09T00:08:00.000Z',
+        anchor: null,
+      }],
+    })))
+
+    const result = await adapter.deleteDiscussionComment('session-token-1', 'thread-1', 'comment-1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions/thread-1/comments/comment-1')
+    expect(init.method).toBe('DELETE')
+    expect(init.headers.Authorization).toBe('Bearer session-token-1')
+    expect(init.body).toBeUndefined()
+    expect(result.error).toBeUndefined()
+    expect(result.data[0].comments[0]).toMatchObject({ id: 'comment-1', body: null, deleted_at: expect.any(String) })
+  })
+
+  it('surfaces a missing/unreadable thread as a no-leak 404 QueryResult error on delete, never throwing', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(404, { detail: 'discussion target not found' }))
+
+    const result = await adapter.deleteDiscussionComment('session-token-1', 'thread-missing', 'comment-1')
+
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+    expect((result.error as any)?.response?.status).toBe(404)
+  })
+
+  it('resolves a thread', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({
+      status: 'resolved',
+      resolved_by_id: 1,
+      resolved_at: '2026-07-09T00:09:00.000Z',
+    })))
+
+    const result = await adapter.resolveDiscussionThread('session-token-1', 'thread-1', { comment: 'Done' })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions/thread-1/resolve')
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe('Bearer session-token-1')
+    expect(JSON.parse(init.body)).toEqual({ comment: 'Done' })
+    expect(result.error).toBeUndefined()
+    expect(result.data[0]).toMatchObject({ status: 'resolved' })
+  })
+
+  it('resolves a thread with no closing comment, sending an empty JSON body', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({ status: 'resolved' })))
+
+    await adapter.resolveDiscussionThread('session-token-1', 'thread-1')
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(JSON.parse(init.body)).toEqual({})
+  })
+
+  it('reopens a thread', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({ status: 'open' })))
+
+    const result = await adapter.reopenDiscussionThread('session-token-1', 'thread-1', { comment: 'Reopening' })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions/thread-1/reopen')
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe('Bearer session-token-1')
+    expect(JSON.parse(init.body)).toEqual({ comment: 'Reopening' })
+    expect(result.error).toBeUndefined()
+    expect(result.data[0]).toMatchObject({ status: 'open' })
+  })
+
+  it('never caches a session token between calls -- concurrent embed sessions each carry their own bearer token', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({ id: 'thread-a' })))
+    await adapter.addDiscussionComment('token-A', 'thread-a', { body: 'from A' })
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, threadDetail({ id: 'thread-b' })))
+    await adapter.addDiscussionComment('token-B', 'thread-b', { body: 'from B' })
+
+    expect(fetchMock.mock.calls).toHaveLength(2)
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer token-A')
+    expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe('Bearer token-B')
+  })
+
+  it('is not gated by apiMode !== yuantus (legacy PLM has no discussion write surface)', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).apiMode = 'legacy'
+    const fetchMock = fetch as Mock
+
+    const exchangeResult = await adapter.exchangeDiscussionSession('embed-token-1')
+    expect(exchangeResult.error).toBeDefined()
+
+    const writeResult = await adapter.addDiscussionComment('session-token-1', 'thread-1', { body: 'hi' })
+    expect(writeResult.error).toBeDefined()
+
+    // never reaches the network in legacy mode
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Lane C consumer for the Yuantus Discussion Phase-3 write channel (provider shipped in yuantus-plm#1188). Adds PLMAdapter write methods: `exchangeDiscussionSession` + create/add/edit/delete/resolve/reopen, using raw `fetch()` with the discussion-session token as an **explicit per-call parameter, never cached** (the axios interceptor would otherwise clobber Authorization with the adapter's own service token — and a shared adapter serves concurrent embed sessions). 64 tests (unit + pact) pass; type-check clean; no lockfile mutation. Write pact interactions verified provider-first against yuantus-plm (provider PR merges first). Held for owner-word merge (merging publishes the consumer pact on push:main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)