### PR TITLE
fix(approval): bind DingTalk card-delivery actionability to a live active assignment (node+epoch) [P1-1]

### DIFF
--- a/docs/development/approval-dingtalk-slice-b-p1-rereview-round3-verification-20260711.md
+++ b/docs/development/approval-dingtalk-slice-b-p1-rereview-round3-verification-20260711.md
@@ -1,0 +1,152 @@
+# DingTalk Approval Card (Slice-B) — P1-1 re-review **round 3** design + verification
+
+**PR:** #4112 · branch `claude/dt-card-p1-node-epoch-binding` · flag `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` **default OFF**
+**Status:** fixes applied + mutation-verified on a real DB; **not merged** (owner landing decision) · **Stream flag stays OFF · U1–U13 UAT held**
+**Trigger:** owner REQUEST-CHANGES (real-DB probe), round 3.
+
+This round closes the four findings the owner reproduced against the round-2 code. Each fix is
+pinned by a **RED-before** real-DB golden, and the two load-bearing goldens are **mutation-verified**
+(reintroduce the vulnerability → the golden goes RED).
+
+---
+
+## Findings & fixes
+
+### P1 — migration backfill re-authorized a legacy card into a fresh round *(the critical one)*
+
+**Owner repro:** a pre-column card (`sent`, `entry_epoch=NULL`) for `(instance, node, recipient)`;
+then a **fresh** same-node/same-recipient active seat at a new epoch (9). The round-2 backfill step-1
+("infer the epoch from the unique live seat that exists now") adopted epoch 9 → the legacy card became
+`sent` + `entry_epoch=9` → **actionable in a round it never belonged to** (same-node re-entry reopened).
+
+**Root cause:** a pre-column card has **no provable original-round anchor**. Inferring the epoch from
+the *current* unique seat is unsound — a legitimate fresh round presents exactly one live non-null-epoch
+seat, indistinguishable from the card's real (lost) round.
+
+**Fix:** `backfillDingTalkApprovalCardDeliveryEpochs` → **`supersedeLegacyDingTalkApprovalCardDeliveries`**
+(supersede-only). Every legacy `sent` + NULL-epoch card is **superseded** at migrate time — no epoch
+recovery, ever. Fail-closed: the card stops working and the recipient re-approves via web. This retires
+**all** in-flight legacy cards (near-zero impact: pre-GA, flag OFF) but **never** re-authorizes one.
+Migration import + doc + `db/types.ts` comment updated.
+
+- File: `packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts`
+- File: `packages/core-backend/src/db/migrations/zzzz20260711120000_add_entry_epoch_to_dingtalk_approval_card_deliveries.ts`
+- Golden (replaced the *vulnerable* one that encoded "infer from unique seat" as correct):
+  `tests/integration/dingtalk-approval-card-deliveries.db.test.ts` — owner's exact repro → legacy card
+  `superseded`, `entry_epoch` stays NULL (not 9), unclaimable; orphan superseded; idempotent.
+- **Mutation-verified:** restore the seat-inference step-1 → golden RED
+  (`expected [Array(1)] to deeply equal [Array(2)]` — legacy backfilled to 9, not superseded).
+
+### P2 — required `test (20.x)` was RED (5/11 callback db cases)
+
+**Cause:** the callback db fixture helper never stamped the live seat epoch, so the strict binding staled
+**every deliverable card** — 5 cases that should execute/engine-reject turned `stale`.
+
+**Fix:** `liveSeatEpoch(instance, node, recipient)` helper reads the active seat's `entry_epoch` and
+stamps it on every **deliverable** card (`newSentDelivery` + the 3 inline `markSent` cards in the DT-R2
+and corp-B cases). Pending/failed negatives keep NULL (unactionable by `send_status` alone — correct).
+
+- File: `packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts`
+- Result: **callback db 11/11** (was 6/11).
+
+### P2 — the committed "TOCTOU headline" was sequential, not a two-transaction interleaving
+
+**Cause:** the round-2 headline advanced N1→N2 *first*, then called `dispatchAction` — it proves the
+guard **exists** but not that it lives **inside** the lock (a guard moved outside would still observe the
+already-committed advance). It could not defend against a future refactor that validates the binding
+outside the `FOR UPDATE`.
+
+**Fix:** added a **real two-transaction interleaving** golden. A dedicated connection **holds** the
+`approval_instances` row `FOR UPDATE` and advances N1→N2 **in-txn** while a concurrent node1-card
+`dispatchAction` is **parked behind that lock** — proven genuinely blocked via
+`pg_stat_activity.wait_event_type='Lock'` (not a timer; throws if it never blocks, so it can't silently
+degrade to the sequential case). On commit, the parked dispatch re-reads under its own lock → **409
+STALE**, **0 node2 approve records**.
+
+- File: `packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts`
+- **Mutation-verified (the decisive one):** move the guard to evaluate a **pre-lock snapshot** of
+  `current_node_key` + active assignments (models "guard outside the lock") →
+  **interleaving RED while the sequential HEADLINE stays GREEN** — proving the interleaving golden
+  catches a regression the sequential test cannot.
+
+### P3 — stale comments
+
+Row-type + input-type doc comments in `approval-card-deliveries.ts` and `db/types.ts` still described the
+deleted permissive NULL dual-read ("NULL skips the epoch clause / binds on node+assignee alone"). Updated
+to strict fail-closed.
+
+---
+
+## Verification (real Postgres)
+
+Method: `DATABASE_URL=postgresql://localhost:5432/<db>` · `pnpm --filter @metasheet/core-backend db:migrate`
+· `vitest --config vitest.integration.config.ts run`. Unit suite: `pnpm --filter @metasheet/core-backend test`.
+
+| Check | Result |
+|---|---|
+| `tsc --noEmit` (core-backend) | clean |
+| callback db (`dingtalk-approval-card-callback.db.test.ts`) | **11/11** (was 6/11) |
+| deliveries db (`dingtalk-approval-card-deliveries.db.test.ts`) incl. P1 repro golden | pass |
+| wrapper db (`approval-card-delivery-wrapper.db.test.ts`) incl. interleaving golden | **21/21** |
+| P1 golden mutation (restore seat-inference) | **RED** → confirms teeth; restored GREEN |
+| interleaving mutation (guard outside lock) | interleaving **RED** / headline **GREEN**; restored GREEN |
+| full backend unit suite | **6177 passed / 0 failed** (1575 skipped, 633 files) |
+| migration `up()` on a **fresh** DB (new code) | reaches `zzzz20260711120000` clean via `sql.raw`; unscoped supersede retired a seeded legacy card → `superseded / epoch=NULL` (NOT adopting the epoch-9 seat); idempotent |
+| **CI on pushed head `5f49558b4`** | **all green** — `test (20.x)` **pass** (the check the owner saw fail on 5/11), `migration-replay` **pass**, `web-tests`/`test (18.x)`/`coverage`/`contracts×3`/`e2e` pass; only always-skipped Strict-E2E is skipping |
+| independent Opus adversarial re-review (real-DB, refute-first) | **APPROVE — no P1/P2** (details below) |
+
+_Counts are read from the actual run and from CI on the pushed head — no "pending == pass" (the round-2 mistake)._
+
+### Independent Opus adversarial re-review — APPROVE (no P1/P2)
+
+A separate Opus reviewer attacked head `5f49558b4` as a **real-DB refutation** (own worktree, real
+Postgres 15.17, migrations applied), not a diff read. It could not break the strict node+epoch binding
+on any path. What it actually executed:
+
+- **43/43** author goldens + **7/7** independent adversarial repros + **5/5** parallel cross-branch
+  repros — all PASS.
+- **Independently reproduced the mutation teeth-proof**: guard→pre-lock snapshot → the interleaving
+  goldens went **RED** (parked card approved the wrong round) while sequential/strict-epoch/NULL-epoch
+  stayed GREEN; restored from backup (no `git checkout`), post-restore diff empty.
+- **Migration `up()` end-to-end**: `db:rollback` → seed a legacy `sent`/NULL-epoch card → `db:migrate`
+  → card `superseded`, epoch stayed NULL (the real unscoped `sql.raw` path, fail-closed). Also verified
+  `outcome_unknown` NULL-epoch cards are swept.
+- Drove a **post-migration** NULL-epoch card DIRECTLY into `dispatchAction` → STALE 409, 0 approves (a
+  path the author goldens didn't cover). Callback delegates to the same wrapper → same fail-closed.
+- **Parallel `joinMode:all` (the resolved advisor gap #3):** the cross-branch attack is foreclosed at
+  **two independent live layers** — template validation rejects the same user on two branches
+  (`VALIDATION_ERROR`), and the active-seat unique index `idx_approval_assignments_active_unique`
+  (per-instance) blocks a second live seat (`23505`) — so a recipient is live on at most one branch, and
+  the round-3 `actorBranchNodeKey` guard approves only the actor's own branch (0 cross-branch approves).
+- Cross-corp P1-2 not regressed (callback refuses NULL `integration_id` outright).
+
+Deliverable: `/tmp/pr4112-rev3-adversarial-20260711.md`.
+
+### P3 (non-blocking) — the reviewer's two findings
+
+- **P3-2 (doc drift) — FIXED this round.** `ApprovalCardDeliveryAction.ts` and `ApprovalProductService.ts`
+  comments still said legacy cards are "backfilled … else superseded" / "the migration failed to
+  backfill"; round-3 is supersede-only. Comments corrected (code was already correct). (My round-3 grep
+  missed these because an over-clever `grep -iv "supersede"` filter excluded lines containing both words.)
+- **P3-1 (defense-in-depth, offered as a follow-up).** The in-txn guard does not additionally assert
+  `card_state='sent'`. The reviewer proved this **not exploitable** three ways: the wrapper is the sole
+  producer of a `dingtalk_card` channelOrigin and does the `card_state` pre-read; the HTTP route builds
+  `ApprovalActionRequest` from an explicit field list that excludes `channelOrigin`; and seat
+  deactivation independently blocks replay double-approve. Recommended as a small standalone hardening
+  PR (add `AND card_state='sent'` to the guard's delivery read + a golden) rather than widening this
+  security chokepoint under the landing wire — owner's call.
+
+## Holds (owner constraints, unchanged)
+
+- **`DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` stays OFF; U1–U13 UAT and production enablement held.**
+- **#4112 not merged** — awaiting explicit owner landing go.
+- On go: merge #4112 → rebase+merge #4116 (P1-2 corp-scoping) → rebase #4118 last (resolve the
+  `interactive-card-callback.ts` conflict against #4116 + combined regression) → merge; then fix the
+  Slice-B UAT doc (`im_robot`→`IM_ROBOT`, add `DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID`,
+  add the corp-provenance U-case) — still before any UAT execution.
+
+## Deferred (documented, non-blocking)
+
+- **P3-2** — a recipient active on two parallel branches could bind the wrong branch and *false-stale* a
+  legitimate card until the sibling resolves. Strictly safer than main (fail-closed vs wrong-branch
+  approval) and an unusual topology.

--- a/packages/core-backend/src/db/migrations/zzzz20260711120000_add_entry_epoch_to_dingtalk_approval_card_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260711120000_add_entry_epoch_to_dingtalk_approval_card_deliveries.ts
@@ -1,28 +1,38 @@
 import type { Kysely } from 'kysely'
 import { sql } from 'kysely'
 import { checkTableExists } from './_patterns'
+import { backfillDingTalkApprovalCardDeliveryEpochs } from '../../integrations/dingtalk/approval-card-deliveries'
 
 /**
  * P1-1 (stale-card node/epoch binding): record the node-entry epoch a card was sent for.
  *
- * The card-delivery action wrapper gates actionability on a LIVE active `approval_assignments`
- * row matching the delivery's node + recipient. That live-state match already closes FORWARD
- * advance (node-1's assignment flips is_active=FALSE once the node is approved), but SAME-NODE
- * re-entry (a loop-back to the same node_key mints a FRESH entry_epoch on a NEW active assignment)
- * would still match on node_key + recipient alone. Persisting the epoch the card was sent for lets
- * the wrapper additionally require the delivery's epoch to equal the active assignment's epoch, so
- * a stale card from a prior round of the SAME node is no longer actionable.
+ * The card-delivery action wrapper AND the engine's in-txn dispatch guard gate actionability on a
+ * LIVE active `approval_assignments` row matching the delivery's node + recipient. That live-state
+ * match closes FORWARD advance (node-1's assignment flips is_active=FALSE once the node is approved),
+ * but SAME-NODE re-entry (a loop-back to the same node_key mints a FRESH entry_epoch on a NEW active
+ * assignment) would still match on node_key + recipient alone. Persisting the epoch the card was sent
+ * for lets both guards additionally require the delivery's epoch to equal the active assignment's
+ * epoch, so a stale card from a prior round of the SAME node is no longer actionable.
  *
- * Nullable + additive: legacy rows predate the column and carry NULL. A NULL delivery epoch skips
- * the epoch clause entirely (dual-read, mirroring approval_assignments.entry_epoch §6) — forward
- * advance stays closed via the node/assignee match, so in-flight legacy cards are never broken. A
- * non-null delivery epoch enforces the exact-round match. No backfill (the dual-read removes the
- * risk).
+ * STRICT binding (P1-1 re-review): the epoch match carries NO null-pass arm — an actionable card MUST
+ * carry a NON-NULL epoch equal to a NON-NULL live-seat epoch. The column is still nullable+additive so
+ * the ADD COLUMN is safe, but legacy `sent` rows that predate the column (entry_epoch NULL) can no
+ * longer act permissively, so `up()` reconciles them ONCE at migrate time:
+ * `backfillDingTalkApprovalCardDeliveryEpochs` backfills a card's epoch from its UNIQUE live active
+ * seat, and supersedes (fail-closed) any card with no unique live seat. Idempotent (only `sent` +
+ * NULL-epoch rows are touched) and reversible-safe (`down()` drops the column; superseded stays
+ * superseded — fail-closed remains closed).
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   const hasTable = await checkTableExists(db, 'dingtalk_approval_card_deliveries')
   if (hasTable) {
     await sql`ALTER TABLE dingtalk_approval_card_deliveries ADD COLUMN IF NOT EXISTS entry_epoch INTEGER`.execute(db)
+    // One-time legacy reconciliation (UNSCOPED → no bound params, so sql.raw is safe): backfill each
+    // pre-column `sent` card's epoch from its unique live seat, else supersede it fail-closed.
+    await backfillDingTalkApprovalCardDeliveryEpochs(async (text) => {
+      const res = await sql.raw(text).execute(db)
+      return { rows: (res.rows ?? []) as unknown[] }
+    })
   }
 }
 

--- a/packages/core-backend/src/db/migrations/zzzz20260711120000_add_entry_epoch_to_dingtalk_approval_card_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260711120000_add_entry_epoch_to_dingtalk_approval_card_deliveries.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from 'kysely'
 import { sql } from 'kysely'
 import { checkTableExists } from './_patterns'
-import { backfillDingTalkApprovalCardDeliveryEpochs } from '../../integrations/dingtalk/approval-card-deliveries'
+import { supersedeLegacyDingTalkApprovalCardDeliveries } from '../../integrations/dingtalk/approval-card-deliveries'
 
 /**
  * P1-1 (stale-card node/epoch binding): record the node-entry epoch a card was sent for.
@@ -18,18 +18,20 @@ import { backfillDingTalkApprovalCardDeliveryEpochs } from '../../integrations/d
  * carry a NON-NULL epoch equal to a NON-NULL live-seat epoch. The column is still nullable+additive so
  * the ADD COLUMN is safe, but legacy `sent` rows that predate the column (entry_epoch NULL) can no
  * longer act permissively, so `up()` reconciles them ONCE at migrate time:
- * `backfillDingTalkApprovalCardDeliveryEpochs` backfills a card's epoch from its UNIQUE live active
- * seat, and supersedes (fail-closed) any card with no unique live seat. Idempotent (only `sent` +
- * NULL-epoch rows are touched) and reversible-safe (`down()` drops the column; superseded stays
- * superseded — fail-closed remains closed).
+ * `supersedeLegacyDingTalkApprovalCardDeliveries` SUPERSEDES every pre-column `sent`/NULL-epoch card
+ * fail-closed. It does NOT recover an epoch — a pre-column card has no provable original-round anchor,
+ * and inferring one from a currently-unique live seat would re-authorize an old card into a fresh
+ * same-node round (re-review P1). Idempotent (only `sent` + NULL-epoch rows are touched) and
+ * reversible-safe (`down()` drops the column; superseded stays superseded — fail-closed remains
+ * closed). Retires all in-flight legacy cards; recipients re-approve via web (near-zero pre-GA).
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   const hasTable = await checkTableExists(db, 'dingtalk_approval_card_deliveries')
   if (hasTable) {
     await sql`ALTER TABLE dingtalk_approval_card_deliveries ADD COLUMN IF NOT EXISTS entry_epoch INTEGER`.execute(db)
-    // One-time legacy reconciliation (UNSCOPED → no bound params, so sql.raw is safe): backfill each
-    // pre-column `sent` card's epoch from its unique live seat, else supersede it fail-closed.
-    await backfillDingTalkApprovalCardDeliveryEpochs(async (text) => {
+    // One-time legacy reconciliation (UNSCOPED → no bound params, so sql.raw is safe): supersede every
+    // pre-column `sent`/NULL-epoch card fail-closed (no epoch inference — see the fn doc for why).
+    await supersedeLegacyDingTalkApprovalCardDeliveries(async (text) => {
       const res = await sql.raw(text).execute(db)
       return { rows: (res.rows ?? []) as unknown[] }
     })

--- a/packages/core-backend/src/db/migrations/zzzz20260711120000_add_entry_epoch_to_dingtalk_approval_card_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260711120000_add_entry_epoch_to_dingtalk_approval_card_deliveries.ts
@@ -1,0 +1,34 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+/**
+ * P1-1 (stale-card node/epoch binding): record the node-entry epoch a card was sent for.
+ *
+ * The card-delivery action wrapper gates actionability on a LIVE active `approval_assignments`
+ * row matching the delivery's node + recipient. That live-state match already closes FORWARD
+ * advance (node-1's assignment flips is_active=FALSE once the node is approved), but SAME-NODE
+ * re-entry (a loop-back to the same node_key mints a FRESH entry_epoch on a NEW active assignment)
+ * would still match on node_key + recipient alone. Persisting the epoch the card was sent for lets
+ * the wrapper additionally require the delivery's epoch to equal the active assignment's epoch, so
+ * a stale card from a prior round of the SAME node is no longer actionable.
+ *
+ * Nullable + additive: legacy rows predate the column and carry NULL. A NULL delivery epoch skips
+ * the epoch clause entirely (dual-read, mirroring approval_assignments.entry_epoch §6) — forward
+ * advance stays closed via the node/assignee match, so in-flight legacy cards are never broken. A
+ * non-null delivery epoch enforces the exact-round match. No backfill (the dual-read removes the
+ * risk).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const hasTable = await checkTableExists(db, 'dingtalk_approval_card_deliveries')
+  if (hasTable) {
+    await sql`ALTER TABLE dingtalk_approval_card_deliveries ADD COLUMN IF NOT EXISTS entry_epoch INTEGER`.execute(db)
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const hasTable = await checkTableExists(db, 'dingtalk_approval_card_deliveries')
+  if (hasTable) {
+    await sql`ALTER TABLE dingtalk_approval_card_deliveries DROP COLUMN IF EXISTS entry_epoch`.execute(db)
+  }
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1549,7 +1549,7 @@ export interface DingTalkApprovalCardDeliveriesTable {
   task_id: string | null
   /** DT-R2: directory integration (corp) the card was sent through; NULL on legacy/env-only rows. */
   integration_id: string | null
-  /** P1-1: node-entry epoch (approval_assignments.entry_epoch) the card was sent for; NULL on legacy/backfill-skipped rows. */
+  /** P1-1: node-entry epoch (approval_assignments.entry_epoch) the card was sent for; NULL only on rows that can never be actionable (strict fail-closed — legacy pre-column rows are superseded at migrate time). */
   entry_epoch: number | null
   card_state: 'sent' | 'acted' | 'superseded' | 'expired' | 'revoked'
   acted_action: string | null

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1549,6 +1549,8 @@ export interface DingTalkApprovalCardDeliveriesTable {
   task_id: string | null
   /** DT-R2: directory integration (corp) the card was sent through; NULL on legacy/env-only rows. */
   integration_id: string | null
+  /** P1-1: node-entry epoch (approval_assignments.entry_epoch) the card was sent for; NULL on legacy/backfill-skipped rows. */
+  entry_epoch: number | null
   card_state: 'sent' | 'acted' | 'superseded' | 'expired' | 'revoked'
   acted_action: string | null
   acted_by: string | null

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -235,9 +235,15 @@ export async function markDingTalkApprovalCardDeliverySendOutcomeUnknown(
 }
 
 /**
- * Marks every still-`sent` card of an instance `superseded` (node advanced past them, or the
- * instance reached a terminal state). `excludeId` spares the delivery that triggered the
- * transition (it is claimed `acted` separately). Returns the swept ids.
+ * Marks still-`sent` cards of an instance `superseded` when their node/seat is no longer live
+ * (node advanced past them, or the instance reached a terminal state). `excludeId` spares the
+ * delivery that triggered the transition (it is claimed `acted` separately). Returns the swept ids.
+ *
+ * Review P2-1: a card whose (node_key, recipient) STILL has an active `approval_assignments` seat
+ * MUST NOT be superseded — otherwise approving branch A of a `joinMode:'all'` parallel fork would
+ * false-stale branch B's legitimately-live card. The `NOT EXISTS` clause keeps this sweep in exact
+ * agreement with the wrapper's read-time active-assignment binding: a card is superseded iff no
+ * live seat matches it.
  */
 export async function supersedeDingTalkApprovalCardDeliveriesForInstance(
   query: QueryFn,
@@ -254,6 +260,13 @@ export async function supersedeDingTalkApprovalCardDeliveriesForInstance(
     `UPDATE dingtalk_approval_card_deliveries
      SET card_state = 'superseded', updated_at = NOW()
      WHERE instance_id = $1 AND card_state = 'sent'${excludeClause}
+       AND NOT EXISTS (
+         SELECT 1 FROM approval_assignments aa
+          WHERE aa.instance_id = dingtalk_approval_card_deliveries.instance_id
+            AND aa.node_key = dingtalk_approval_card_deliveries.node_key
+            AND aa.assignee_id = dingtalk_approval_card_deliveries.recipient_user_id
+            AND aa.is_active = TRUE
+       )
      RETURNING id`,
     params,
   )

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -39,10 +39,12 @@ export interface DingTalkApprovalCardDeliveryRow {
   integration_id: string | null
   /**
    * P1-1: the node-entry epoch (approval_assignments.entry_epoch) this card was sent for. NULL on
-   * legacy rows and env-only/epoch-less sends. The action wrapper's live-assignment binding uses it
-   * to close SAME-NODE re-entry (a loop-back mints a fresh epoch on a new active assignment, so an
-   * old-epoch card no longer matches); a NULL delivery epoch skips the epoch clause (dual-read) and
-   * relies on the node/assignee match alone, which still closes forward advance.
+   * legacy rows and env-only/epoch-less sends. The action wrapper AND the engine's in-txn dispatch
+   * guard use it to close SAME-NODE re-entry (a loop-back mints a fresh epoch on a new active
+   * assignment, so an old-epoch card no longer matches). STRICT fail-closed (P1-1 re-review): the
+   * binding requires a NON-NULL delivery epoch that equals a live seat's NON-NULL epoch — a NULL
+   * delivery epoch is NEVER actionable (no permissive null-pass), and the legacy migration
+   * supersedes any pre-column NULL-epoch card rather than binding it on node/assignee alone.
    */
   entry_epoch: number | null
   card_state: DingTalkApprovalCardState
@@ -81,8 +83,10 @@ export interface InsertDingTalkApprovalCardDeliveryInput {
   integrationId?: string | null
   /**
    * P1-1: the node-entry epoch (from the task_created event's `task.entryEpoch`) this card is sent
-   * for. Omit/null for legacy or epoch-less sends — the wrapper then skips the epoch clause and
-   * binds on node/assignee alone.
+   * for. Omit/null ONLY for sends that can never be actionable — STRICT fail-closed (P1-1
+   * re-review): a NULL-epoch card is never claimable (both the wrapper pre-read and the engine's
+   * in-txn guard require a NON-NULL epoch equal to a live seat's epoch), and the legacy migration
+   * supersedes any pre-column NULL-epoch card. So a real, claimable card MUST carry the seat epoch.
    */
   entryEpoch?: number | null
 }
@@ -274,56 +278,36 @@ export async function supersedeDingTalkApprovalCardDeliveriesForInstance(
 }
 
 /**
- * P1-1 legacy backfill (migrate-time, one-time, idempotent). The strict epoch binding — the wrapper
- * pre-read AND the engine's in-txn card→round guard — now requires every actionable `sent` card to
- * carry a NON-NULL entry_epoch equal to a live seat's epoch (the permissive null-pass dual-read was
- * dropped in the P1-1 re-review). Cards sent BEFORE the entry_epoch column existed carry NULL and
- * would be permanently un-actionable with no ledger expiry to retire them, so this reconciles them
- * ONCE at migrate time:
- *   - if the card's (instance_id, node_key, recipient_user_id) maps to EXACTLY ONE live active
- *     `approval_assignments` seat carrying a NON-NULL entry_epoch → backfill the delivery's epoch from
- *     that seat (the card stays actionable for its real round);
- *   - otherwise (no live seat, an ambiguous >1 non-null-epoch match, or only null-epoch seats) → mark
- *     the card `superseded` — FAIL-CLOSED: the card stops working and the recipient re-approves via web.
+ * P1-1 legacy reconcile (migrate-time, one-time, idempotent). The strict epoch binding — the wrapper
+ * pre-read AND the engine's in-txn card→round guard — requires every actionable `sent` card to carry
+ * a NON-NULL entry_epoch equal to a live seat's epoch (the permissive null-pass dual-read was dropped
+ * in the P1-1 re-review). Cards sent BEFORE the entry_epoch column existed carry NULL and would be
+ * permanently un-actionable with no ledger expiry to retire them, so this reconciles them ONCE.
+ *
+ * We SUPERSEDE every legacy `sent` + NULL-epoch card outright — we do NOT try to recover an epoch.
+ * A pre-column card has no PROVABLE original-round anchor: inferring the epoch from "the unique live
+ * seat that exists now" is unsound — a fresh SAME-NODE, SAME-RECIPIENT round (a loop-back, or a new
+ * assignment after the old round closed) presents exactly one live non-null-epoch seat, and adopting
+ * its epoch would RE-AUTHORIZE the old card into the new round (the re-review P1: same-node re-entry
+ * reopened). With no way to prove provenance, the only safe move is fail-closed: the card stops
+ * working and the recipient re-approves via web. This retires ALL in-flight legacy cards (near-zero
+ * impact pre-GA / flag OFF) but never re-authorizes one.
  *
  * Only `sent` + NULL-epoch rows are touched, so a re-run is a no-op (idempotent); `down()` dropping
- * the column leaves superseded cards superseded (fail-closed stays closed — reversible-safe). The two
- * statements carry NO bound parameters in the UNSCOPED (migration) path — `options.instanceIds` scopes
- * BOTH (used only by the deterministic golden to avoid touching sibling fixtures in the shared test DB).
+ * the column leaves superseded cards superseded (fail-closed stays closed — reversible-safe). The
+ * statement carries NO bound parameters in the UNSCOPED (migration) path — `options.instanceIds`
+ * scopes it (used only by the deterministic golden to avoid touching sibling fixtures in the shared
+ * test DB).
  */
-export async function backfillDingTalkApprovalCardDeliveryEpochs(
+export async function supersedeLegacyDingTalkApprovalCardDeliveries(
   query: QueryFn,
   options: { instanceIds?: string[] } = {},
-): Promise<{ backfilledIds: string[]; supersededIds: string[] }> {
+): Promise<{ supersededIds: string[] }> {
   const scope = options.instanceIds
   const scopeClause = scope ? ' AND d.instance_id = ANY($1::text[])' : ''
   const scopeParams: unknown[] = scope ? [scope] : []
 
-  // Step 1 — backfill from the UNIQUE live non-null-epoch seat. The grouped subquery yields a seat
-  // ONLY when EXACTLY ONE non-null-epoch active seat exists for the card's (instance, node, recipient)
-  // — HAVING COUNT(*) = 1 over `entry_epoch IS NOT NULL` rows; a zero/ambiguous match produces no row,
-  // leaving the delivery's entry_epoch NULL for step 2.
-  const backfilled = await query(
-    `UPDATE dingtalk_approval_card_deliveries d
-        SET entry_epoch = seat.epoch, updated_at = NOW()
-       FROM (
-         SELECT aa.instance_id, aa.node_key, aa.assignee_id, MIN(aa.entry_epoch) AS epoch
-           FROM approval_assignments aa
-          WHERE aa.is_active = TRUE AND aa.entry_epoch IS NOT NULL
-          GROUP BY aa.instance_id, aa.node_key, aa.assignee_id
-         HAVING COUNT(*) = 1
-       ) seat
-      WHERE d.card_state = 'sent'
-        AND d.entry_epoch IS NULL
-        AND seat.instance_id = d.instance_id
-        AND seat.node_key = d.node_key
-        AND seat.assignee_id = d.recipient_user_id${scopeClause}
-      RETURNING d.id`,
-    scopeParams,
-  )
-
-  // Step 2 — any still-`sent` NULL-epoch card step 1 did NOT backfill (no unique live seat) is
-  // superseded (fail-closed).
+  // Supersede every still-`sent` NULL-epoch (pre-column) card — fail-closed, no epoch inference.
   const superseded = await query(
     `UPDATE dingtalk_approval_card_deliveries d
         SET card_state = 'superseded', updated_at = NOW()
@@ -334,7 +318,6 @@ export async function backfillDingTalkApprovalCardDeliveryEpochs(
   )
 
   return {
-    backfilledIds: (backfilled.rows as Array<{ id: string }>).map((row) => row.id),
     supersededIds: (superseded.rows as Array<{ id: string }>).map((row) => row.id),
   }
 }

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -37,6 +37,14 @@ export interface DingTalkApprovalCardDeliveryRow {
    * legacy single-integration resolver for those).
    */
   integration_id: string | null
+  /**
+   * P1-1: the node-entry epoch (approval_assignments.entry_epoch) this card was sent for. NULL on
+   * legacy rows and env-only/epoch-less sends. The action wrapper's live-assignment binding uses it
+   * to close SAME-NODE re-entry (a loop-back mints a fresh epoch on a new active assignment, so an
+   * old-epoch card no longer matches); a NULL delivery epoch skips the epoch clause (dual-read) and
+   * relies on the node/assignee match alone, which still closes forward advance.
+   */
+  entry_epoch: number | null
   card_state: DingTalkApprovalCardState
   acted_action: string | null
   acted_by: string | null
@@ -57,7 +65,7 @@ export interface DingTalkApprovalCardDeliveryRow {
 type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
 
 const RETURNING_COLUMNS =
-  'id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, integration_id, card_state, acted_action, acted_by, acted_at, send_status, send_error, created_at, updated_at'
+  'id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, integration_id, entry_epoch, card_state, acted_action, acted_by, acted_at, send_status, send_error, created_at, updated_at'
 
 export interface InsertDingTalkApprovalCardDeliveryInput {
   /** Optional caller-supplied id; defaults to a fresh UUID. Doubles as the interactive-card outTrackId (Slice B). */
@@ -71,6 +79,12 @@ export interface InsertDingTalkApprovalCardDeliveryInput {
   taskId?: string | null
   /** DT-R2: the assignee's directory integration id (uuid) — null/omitted for env-only sends. */
   integrationId?: string | null
+  /**
+   * P1-1: the node-entry epoch (from the task_created event's `task.entryEpoch`) this card is sent
+   * for. Omit/null for legacy or epoch-less sends — the wrapper then skips the epoch clause and
+   * binds on node/assignee alone.
+   */
+  entryEpoch?: number | null
 }
 
 export async function insertDingTalkApprovalCardDelivery(
@@ -82,10 +96,11 @@ export async function insertDingTalkApprovalCardDelivery(
     typeof input.integrationId === 'string' && input.integrationId.trim().length > 0
       ? input.integrationId.trim()
       : null
+  const entryEpoch = typeof input.entryEpoch === 'number' && Number.isInteger(input.entryEpoch) ? input.entryEpoch : null
   const result = await query(
     `INSERT INTO dingtalk_approval_card_deliveries
-       (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, integration_id)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       (id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind, task_id, integration_id, entry_epoch)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
      RETURNING ${RETURNING_COLUMNS}`,
     [
       id,
@@ -96,6 +111,7 @@ export async function insertDingTalkApprovalCardDelivery(
       input.deliveryKind,
       input.taskId ?? null,
       integrationId,
+      entryEpoch,
     ],
   )
   return result.rows[0] as DingTalkApprovalCardDeliveryRow

--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -272,3 +272,69 @@ export async function supersedeDingTalkApprovalCardDeliveriesForInstance(
   )
   return (result.rows as Array<{ id: string }>).map((row) => row.id)
 }
+
+/**
+ * P1-1 legacy backfill (migrate-time, one-time, idempotent). The strict epoch binding — the wrapper
+ * pre-read AND the engine's in-txn card→round guard — now requires every actionable `sent` card to
+ * carry a NON-NULL entry_epoch equal to a live seat's epoch (the permissive null-pass dual-read was
+ * dropped in the P1-1 re-review). Cards sent BEFORE the entry_epoch column existed carry NULL and
+ * would be permanently un-actionable with no ledger expiry to retire them, so this reconciles them
+ * ONCE at migrate time:
+ *   - if the card's (instance_id, node_key, recipient_user_id) maps to EXACTLY ONE live active
+ *     `approval_assignments` seat carrying a NON-NULL entry_epoch → backfill the delivery's epoch from
+ *     that seat (the card stays actionable for its real round);
+ *   - otherwise (no live seat, an ambiguous >1 non-null-epoch match, or only null-epoch seats) → mark
+ *     the card `superseded` — FAIL-CLOSED: the card stops working and the recipient re-approves via web.
+ *
+ * Only `sent` + NULL-epoch rows are touched, so a re-run is a no-op (idempotent); `down()` dropping
+ * the column leaves superseded cards superseded (fail-closed stays closed — reversible-safe). The two
+ * statements carry NO bound parameters in the UNSCOPED (migration) path — `options.instanceIds` scopes
+ * BOTH (used only by the deterministic golden to avoid touching sibling fixtures in the shared test DB).
+ */
+export async function backfillDingTalkApprovalCardDeliveryEpochs(
+  query: QueryFn,
+  options: { instanceIds?: string[] } = {},
+): Promise<{ backfilledIds: string[]; supersededIds: string[] }> {
+  const scope = options.instanceIds
+  const scopeClause = scope ? ' AND d.instance_id = ANY($1::text[])' : ''
+  const scopeParams: unknown[] = scope ? [scope] : []
+
+  // Step 1 — backfill from the UNIQUE live non-null-epoch seat. The grouped subquery yields a seat
+  // ONLY when EXACTLY ONE non-null-epoch active seat exists for the card's (instance, node, recipient)
+  // — HAVING COUNT(*) = 1 over `entry_epoch IS NOT NULL` rows; a zero/ambiguous match produces no row,
+  // leaving the delivery's entry_epoch NULL for step 2.
+  const backfilled = await query(
+    `UPDATE dingtalk_approval_card_deliveries d
+        SET entry_epoch = seat.epoch, updated_at = NOW()
+       FROM (
+         SELECT aa.instance_id, aa.node_key, aa.assignee_id, MIN(aa.entry_epoch) AS epoch
+           FROM approval_assignments aa
+          WHERE aa.is_active = TRUE AND aa.entry_epoch IS NOT NULL
+          GROUP BY aa.instance_id, aa.node_key, aa.assignee_id
+         HAVING COUNT(*) = 1
+       ) seat
+      WHERE d.card_state = 'sent'
+        AND d.entry_epoch IS NULL
+        AND seat.instance_id = d.instance_id
+        AND seat.node_key = d.node_key
+        AND seat.assignee_id = d.recipient_user_id${scopeClause}
+      RETURNING d.id`,
+    scopeParams,
+  )
+
+  // Step 2 — any still-`sent` NULL-epoch card step 1 did NOT backfill (no unique live seat) is
+  // superseded (fail-closed).
+  const superseded = await query(
+    `UPDATE dingtalk_approval_card_deliveries d
+        SET card_state = 'superseded', updated_at = NOW()
+      WHERE d.card_state = 'sent'
+        AND d.entry_epoch IS NULL${scopeClause}
+      RETURNING d.id`,
+    scopeParams,
+  )
+
+  return {
+    backfilledIds: (backfilled.rows as Array<{ id: string }>).map((row) => row.id),
+    supersededIds: (superseded.rows as Array<{ id: string }>).map((row) => row.id),
+  }
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2730,6 +2730,15 @@ export class AutomationExecutor {
     // Ledger FIRST — the row is the only legitimate delivery → instance anchor.
     const entryEpochRaw = event.task?.entryEpoch
     const sourceStepRaw = event.task?.sourceStep
+    if (typeof entryEpochRaw !== 'number') {
+      // Review P3-1: a card with no node-entry epoch is dead-on-arrival under the strict binding
+      // (never actionable). Surface it (values-free: ids + node only) instead of shipping silently.
+      logger.warn('DingTalk approval card sent with no node-entry epoch — will not be actionable (fail-closed)', {
+        instanceId,
+        nodeKey,
+        ruleId: context.ruleId,
+      })
+    }
     const delivery = await insertDingTalkApprovalCardDelivery(this.deps.queryFn, {
       instanceId,
       nodeKey,
@@ -2737,9 +2746,11 @@ export class AutomationExecutor {
       recipientDingTalkUserId: dingtalkUserId,
       deliveryKind: useInteractiveCard ? 'interactive_card' : 'work_notice_action_card',
       integrationId: assigneeIntegrationId || null,
-      // P1-1: persist the node-entry epoch this card is sent for so the action wrapper can bind the
-      // card to the SAME round's active assignment (closes same-node re-entry). Legacy/epoch-less
-      // events pass null → the wrapper skips the epoch clause (dual-read).
+      // P1-1: persist the node-entry epoch this card is sent for so the action wrapper + the engine's
+      // in-txn binding can bind the card to the SAME round's active assignment (closes same-node
+      // re-entry). Review P3-1: under the STRICT binding a NULL epoch is NOT actionable (fail-closed
+      // dead-on-arrival), so a null here means this card will never be clickable — warn (values-free)
+      // rather than silently ship a dead card. Expected only for pre-epoch/legacy task events.
       entryEpoch: typeof entryEpochRaw === 'number' ? entryEpochRaw : null,
     })
 

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2737,6 +2737,10 @@ export class AutomationExecutor {
       recipientDingTalkUserId: dingtalkUserId,
       deliveryKind: useInteractiveCard ? 'interactive_card' : 'work_notice_action_card',
       integrationId: assigneeIntegrationId || null,
+      // P1-1: persist the node-entry epoch this card is sent for so the action wrapper can bind the
+      // card to the SAME round's active assignment (closes same-node re-entry). Legacy/epoch-less
+      // events pass null → the wrapper skips the epoch clause (dual-read).
+      entryEpoch: typeof entryEpochRaw === 'number' ? entryEpochRaw : null,
     })
 
     const token = createHmac('sha256', linkSecret).update(delivery.id).digest('hex').slice(0, 32)

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -131,15 +131,18 @@ async function buildSummary(
   delivery: DingTalkApprovalCardDeliveryRow,
   viewerUserId: string,
 ): Promise<ApprovalCardDeliverySummary | null> {
-  // P1-1: bind actionability to a LIVE active assignment matching the delivery's node + recipient
-  // (+ epoch when the delivery carries one) — computed in the SAME round-trip as the instance read.
+  // P1-1: bind actionability to a LIVE active assignment matching the delivery's node + recipient +
+  // STRICT epoch — computed in the SAME round-trip as the instance read.
   //   - The node/assignee match closes FORWARD advance using live state: once node-1 is approved and
   //     the instance advances to node-2 (where the recipient is ALSO an assignee), node-1's assignment
-  //     row is is_active=FALSE, so a stale node-1 card no longer matches → NOT actionable. It never
-  //     stored an epoch, so it does not break legacy cards.
-  //   - The epoch clause closes SAME-NODE re-entry: a loop-back to the same node_key mints a FRESH
-  //     entry_epoch on a new active assignment, so the old-epoch card fails the equality. Dual-read: a
-  //     NULL delivery epoch (legacy card) SKIPS the epoch clause and relies on the node/assignee match.
+  //     row is is_active=FALSE, so a stale node-1 card no longer matches → NOT actionable.
+  //   - The STRICT epoch clause closes SAME-NODE re-entry: a loop-back to the same node_key mints a
+  //     FRESH entry_epoch on a new active assignment, so the old-epoch card fails the equality. There
+  //     is NO null-pass arm (the P1-1 re-review dropped the `$4 IS NULL` / `aa.entry_epoch IS NULL`
+  //     dual-read that let a legacy card re-enter the same node): the delivery MUST carry a NON-NULL
+  //     epoch equal to a NON-NULL live-seat epoch. A NULL delivery epoch (a card the migration failed
+  //     to backfill) → NOT actionable (fail-closed). Legacy in-flight cards are handled at migrate
+  //     time (backfilled from their unique live seat, else superseded), never by a permissive read.
   const result = await query(
     `SELECT i.id, i.title, i.request_no, i.status, i.current_node_key, i.policy_snapshot,
             EXISTS (
@@ -148,7 +151,8 @@ async function buildSummary(
                  AND aa.node_key = $2
                  AND aa.assignee_id = $3
                  AND aa.is_active = TRUE
-                 AND ($4::int IS NULL OR aa.entry_epoch IS NULL OR aa.entry_epoch = $4::int)
+                 AND aa.entry_epoch IS NOT NULL
+                 AND aa.entry_epoch = $4::int
             ) AS has_active_assignment
        FROM approval_instances i WHERE i.id = $1`,
     [delivery.instance_id, delivery.node_key, delivery.recipient_user_id, delivery.entry_epoch],
@@ -236,6 +240,13 @@ export async function executeApprovalActionFromCardDelivery(
       const fresh = await findDingTalkApprovalCardDeliveryById(deps.query, input.deliveryId)
       return fresh ? buildSummary(deps.query, fresh, input.actor.userId) : null
     })()) ?? preSummary
+    // P1-1 TOCTOU close: the engine's authoritative in-txn card→round binding threw because a
+    // concurrent advance (or same-node re-entry) raced the wrapper's pre-read — the card is stale,
+    // not "rejected". Report it as `stale` (matching the pre-read early-stale outcome) so a raced
+    // card renders the real terminal state, never a dead engine-error form.
+    if (err.code === 'APPROVAL_CARD_DELIVERY_STALE') {
+      return { status: 'stale', summary }
+    }
     return {
       status: 'engine_rejected',
       code: typeof err.code === 'string' ? err.code : 'APPROVAL_ACTION_FAILED',

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -15,6 +15,13 @@
  *   exactly outcome_unknown — a send whose outcome the client could not observe MAY have been
  *   delivered, and a valid HMAC deep-link token is itself proof of delivery, so the ledger's
  *   send-time uncertainty must not make a delivered card inoperable. pending/failed stay stale.)
+ * - P1-1 stale-card binding: actionability ADDITIONALLY requires a LIVE active `approval_assignments`
+ *   row still matching the delivery's node_key + recipient (+ entry_epoch when the delivery carries
+ *   one). A card issued for node-1 must NOT approve node-2 after the instance advances (node-1's
+ *   assignment is deactivated → no match), nor re-approve the SAME node after a loop-back (a fresh
+ *   epoch on the new active assignment fails the old card's epoch match). The read-time binding is the
+ *   authoritative guard and stands alone even if the supersede sweep never runs; a NULL delivery
+ *   epoch (legacy) skips only the epoch clause and stays closed on the node/assignee match.
  */
 import { createHmac, timingSafeEqual } from 'crypto'
 
@@ -40,7 +47,11 @@ export interface ApprovalCardDeliverySummary {
   nodeKey: string
   recipientUserId: string
   viewerIsRecipient: boolean
-  /** card live + send possibly delivered ('sent'/'outcome_unknown') + instance still pending — the page may offer 同意/拒绝. */
+  /**
+   * card live + send possibly delivered ('sent'/'outcome_unknown') + instance still pending + the
+   * delivery's node/recipient(/epoch) still matches a LIVE active assignment (P1-1 stale-card
+   * binding) — the page may offer 同意/拒绝.
+   */
   actionable: boolean
   approval: {
     instanceId: string
@@ -97,6 +108,13 @@ interface InstanceSummaryRow {
   status: string
   current_node_key: string | null
   policy_snapshot: unknown
+  /**
+   * P1-1: TRUE iff an ACTIVE `approval_assignments` row still matches the delivery's node +
+   * recipient (+ epoch when the delivery carries one). This is the authoritative stale-card guard —
+   * see `buildSummary`. Computed in the same round-trip as the instance read so `actionable`
+   * reflects live assignment state, never just the instance status.
+   */
+  has_active_assignment: boolean
 }
 
 function rejectCommentRequiredFromPolicy(policySnapshot: unknown): boolean {
@@ -113,10 +131,27 @@ async function buildSummary(
   delivery: DingTalkApprovalCardDeliveryRow,
   viewerUserId: string,
 ): Promise<ApprovalCardDeliverySummary | null> {
+  // P1-1: bind actionability to a LIVE active assignment matching the delivery's node + recipient
+  // (+ epoch when the delivery carries one) — computed in the SAME round-trip as the instance read.
+  //   - The node/assignee match closes FORWARD advance using live state: once node-1 is approved and
+  //     the instance advances to node-2 (where the recipient is ALSO an assignee), node-1's assignment
+  //     row is is_active=FALSE, so a stale node-1 card no longer matches → NOT actionable. It never
+  //     stored an epoch, so it does not break legacy cards.
+  //   - The epoch clause closes SAME-NODE re-entry: a loop-back to the same node_key mints a FRESH
+  //     entry_epoch on a new active assignment, so the old-epoch card fails the equality. Dual-read: a
+  //     NULL delivery epoch (legacy card) SKIPS the epoch clause and relies on the node/assignee match.
   const result = await query(
-    `SELECT id, title, request_no, status, current_node_key, policy_snapshot
-       FROM approval_instances WHERE id = $1`,
-    [delivery.instance_id],
+    `SELECT i.id, i.title, i.request_no, i.status, i.current_node_key, i.policy_snapshot,
+            EXISTS (
+              SELECT 1 FROM approval_assignments aa
+               WHERE aa.instance_id = $1
+                 AND aa.node_key = $2
+                 AND aa.assignee_id = $3
+                 AND aa.is_active = TRUE
+                 AND ($4::int IS NULL OR aa.entry_epoch IS NULL OR aa.entry_epoch = $4::int)
+            ) AS has_active_assignment
+       FROM approval_instances i WHERE i.id = $1`,
+    [delivery.instance_id, delivery.node_key, delivery.recipient_user_id, delivery.entry_epoch],
   )
   const instance = (result.rows[0] ?? null) as InstanceSummaryRow | null
   if (!instance) return null
@@ -130,7 +165,8 @@ async function buildSummary(
     actionable:
       delivery.card_state === 'sent'
       && (delivery.send_status === 'sent' || delivery.send_status === 'outcome_unknown')
-      && instance.status === 'pending',
+      && instance.status === 'pending'
+      && instance.has_active_assignment === true,
     approval: {
       instanceId: instance.id,
       title: instance.title,

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -140,9 +140,10 @@ async function buildSummary(
   //     FRESH entry_epoch on a new active assignment, so the old-epoch card fails the equality. There
   //     is NO null-pass arm (the P1-1 re-review dropped the `$4 IS NULL` / `aa.entry_epoch IS NULL`
   //     dual-read that let a legacy card re-enter the same node): the delivery MUST carry a NON-NULL
-  //     epoch equal to a NON-NULL live-seat epoch. A NULL delivery epoch (a card the migration failed
-  //     to backfill) → NOT actionable (fail-closed). Legacy in-flight cards are handled at migrate
-  //     time (backfilled from their unique live seat, else superseded), never by a permissive read.
+  //     epoch equal to a NON-NULL live-seat epoch. A NULL delivery epoch (a pre-column legacy card)
+  //     → NOT actionable (fail-closed). Legacy in-flight cards are retired at migrate time — SUPERSEDED
+  //     outright (no epoch inference: a pre-column card has no provable original-round anchor), never
+  //     re-authorized by a permissive read.
   const result = await query(
     `SELECT i.id, i.title, i.request_no, i.status, i.current_node_key, i.policy_snapshot,
             EXISTS (

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4884,8 +4884,21 @@ export class ApprovalProductService {
       //   STRICT epoch (no null-pass arm): the card must carry a NON-NULL entry_epoch equal to a
       //   NON-NULL epoch on a live seat the actor holds at that node. A NULL delivery epoch (a legacy
       //   card the migration failed to backfill) is NOT actionable — fail-closed.
-      if (request.channelOrigin?.channel === 'dingtalk_card' && request.channelOrigin.cardDeliveryId) {
+      if (request.channelOrigin?.channel === 'dingtalk_card') {
+        // Review NIT (defense-in-depth): a card-channel action MUST carry the delivery id — the
+        // whole point of the binding is that a card action is bound to its delivery. A dingtalk_card
+        // origin with no cardDeliveryId can never be validated, so treat it as STALE rather than
+        // silently skipping the guard. (Not reachable today — the wrapper is the sole producer and
+        // always sets it, and the HTTP route never forwards channelOrigin — but the guard must not
+        // depend on that invariant holding forever.)
         const cardDeliveryId = request.channelOrigin.cardDeliveryId
+        if (!cardDeliveryId) {
+          throw new ServiceError(
+            'Approval card is no longer valid for the current node',
+            409,
+            'APPROVAL_CARD_DELIVERY_STALE',
+          )
+        }
         const deliveryResult = await client.query<{
           instance_id: string
           node_key: string

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4882,8 +4882,8 @@ export class ApprovalProductService {
       //   `currentNodeKey` is the actor's EFFECTIVE node — `actorBranchNodeKey` in a parallel region,
       //   else `storedCurrentNodeKey` (both already resolved into `currentNodeKey` above).
       //   STRICT epoch (no null-pass arm): the card must carry a NON-NULL entry_epoch equal to a
-      //   NON-NULL epoch on a live seat the actor holds at that node. A NULL delivery epoch (a legacy
-      //   card the migration failed to backfill) is NOT actionable — fail-closed.
+      //   NON-NULL epoch on a live seat the actor holds at that node. A NULL delivery epoch (a
+      //   pre-column legacy card, which the migration supersedes outright) is NOT actionable — fail-closed.
       if (request.channelOrigin?.channel === 'dingtalk_card') {
         // Review NIT (defense-in-depth): a card-channel action MUST carry the delivery id — the
         // whole point of the binding is that a card action is bound to its delivery. A dingtalk_card

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4871,6 +4871,58 @@ export class ApprovalProductService {
         throw new ServiceError('Approval assignment not found for actor', 403, 'APPROVAL_ASSIGNMENT_REQUIRED')
       }
 
+      // P1-1 TOCTOU close (authoritative in-txn card→round binding): the wrapper's pre-read binding
+      // (ApprovalCardDeliveryAction.buildSummary) runs OUTSIDE this FOR UPDATE txn, so a concurrent
+      // advance can slip a card issued for a PRIOR node/round past it and into the engine — where
+      // `actorCanAct` only proves "actor is an assignee of the CURRENT node", never "this CARD was
+      // issued for the current node/round". Re-validate the binding HERE, under the same instance lock
+      // that serializes advances, BEFORE any record insert / node advance / side effect. A concurrent
+      // advance is now ordered by the lock: it either committed before we locked (delivery.node_key ≠
+      // currentNodeKey → stale) or waits behind us (we act on the round the card was issued for).
+      //   `currentNodeKey` is the actor's EFFECTIVE node — `actorBranchNodeKey` in a parallel region,
+      //   else `storedCurrentNodeKey` (both already resolved into `currentNodeKey` above).
+      //   STRICT epoch (no null-pass arm): the card must carry a NON-NULL entry_epoch equal to a
+      //   NON-NULL epoch on a live seat the actor holds at that node. A NULL delivery epoch (a legacy
+      //   card the migration failed to backfill) is NOT actionable — fail-closed.
+      if (request.channelOrigin?.channel === 'dingtalk_card' && request.channelOrigin.cardDeliveryId) {
+        const cardDeliveryId = request.channelOrigin.cardDeliveryId
+        const deliveryResult = await client.query<{
+          instance_id: string
+          node_key: string
+          recipient_user_id: string
+          entry_epoch: number | string | null
+        }>(
+          `SELECT instance_id, node_key, recipient_user_id, entry_epoch
+             FROM dingtalk_approval_card_deliveries WHERE id = $1`,
+          [cardDeliveryId],
+        )
+        const deliveryRow = deliveryResult.rows[0]
+        const deliveryEpoch =
+          deliveryRow && deliveryRow.entry_epoch !== null && deliveryRow.entry_epoch !== undefined
+            ? Number(deliveryRow.entry_epoch)
+            : null
+        const epochMatchesLiveSeat =
+          deliveryEpoch !== null
+          && Number.isInteger(deliveryEpoch)
+          && actorAssignments.some((assignment) => {
+            const seatEpoch = assignment.entry_epoch
+            return seatEpoch !== null && seatEpoch !== undefined && Number(seatEpoch) === deliveryEpoch
+          })
+        const cardBindingValid =
+          !!deliveryRow
+          && deliveryRow.instance_id === id
+          && deliveryRow.node_key === currentNodeKey
+          && deliveryRow.recipient_user_id === actor.userId
+          && epochMatchesLiveSeat
+        if (!cardBindingValid) {
+          throw new ServiceError(
+            'Approval card is no longer valid for the current node',
+            409,
+            'APPROVAL_CARD_DELIVERY_STALE',
+          )
+        }
+      }
+
       if (request.action === 'comment') {
         await this.insertApprovalRecord(client, id, {
           action: 'comment',

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -82,6 +82,7 @@ import {
   type ApprovalTaskCreatedTaskSnapshot,
 } from './ApprovalTaskCreatedEvent'
 import { getApprovalRecordProjectionService } from '../multitable/approval-record-projection-service'
+import { supersedeDingTalkApprovalCardDeliveriesForInstance } from '../integrations/dingtalk/approval-card-deliveries'
 import { Logger } from '../core/logger'
 import { eventBus } from '../integration/events/event-bus'
 
@@ -5703,6 +5704,12 @@ export class ApprovalProductService {
 
       await client.query('COMMIT')
       await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
+      // P1-1 defense-in-depth (NOT the safety mechanism — the wrapper's read-time active-assignment
+      // binding stands alone): the node just advanced past `currentNodeKey`, so sweep every still-`sent`
+      // card of this instance to `superseded`. The card that TRIGGERED this approve (card-originated
+      // path) is excluded — the wrapper claims it `acted` after dispatchAction returns. Best-effort:
+      // a card-ledger hiccup must never fail a committed approval.
+      await this.supersedeCardDeliveriesPostCommit(id, request.channelOrigin?.cardDeliveryId)
 
       // Wave 2 WP5 slice 1 — emit metrics after commit so rollback failures
       // never leave dangling breakdown entries. All hooks are guarded.
@@ -6049,6 +6056,27 @@ export class ApprovalProductService {
     } catch (error) {
       approvalProductLogger.warn(
         `approval.task_created post-commit emission failed for ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  /**
+   * P1-1 defense-in-depth: after a node advance commits, mark every still-`sent` DingTalk approval
+   * card of the instance `superseded` (its node is no longer active). `excludeId` spares the card
+   * that triggered the advance (card-originated path) so the wrapper can claim it `acted`. Best-effort
+   * by contract — the wrapper's read-time active-assignment binding is the authoritative stale-card
+   * guard, so a sweep failure here NEVER fails the approval.
+   */
+  private async supersedeCardDeliveriesPostCommit(instanceId: string, excludeId?: string): Promise<void> {
+    try {
+      await supersedeDingTalkApprovalCardDeliveriesForInstance(
+        (sql, params) => pool.query(sql, params),
+        instanceId,
+        excludeId ? { excludeId } : {},
+      )
+    } catch (error) {
+      approvalProductLogger.warn(
+        `approval card supersede sweep failed for ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
       )
     }
   }

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -748,4 +748,27 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     const approves = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve'`, [instanceId])
     expect((approves.rows[0] as { c: number }).c).toBe(0)
   })
+
+  test('P1-1 FIX 3 strict predicate: a NULL-epoch card is NOT actionable even with a live non-null seat (no null-pass arm)', async () => {
+    // Owner's 2nd P1: the wrapper pre-read dropped BOTH permissive arms ($delivery IS NULL /
+    // aa.entry_epoch IS NULL). A card that carries NO epoch (legacy, escaped the migration) must
+    // fail-closed — never re-enter the same node on the node/assignee match alone. Live seat has a
+    // NON-NULL epoch; the card's epoch is NULL. RED-before (restore either null-pass arm): actionable.
+    const instanceId = await newInstance()
+    const liveEpoch = await activeEpoch(instanceId, 'approval_1')
+    expect(typeof liveEpoch).toBe('number') // the seat IS non-null — only the card is null
+    const deliveryId = await newSentDelivery(instanceId, { nodeKey: 'approval_1', entryEpoch: null })
+
+    const summary = await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })
+    expect(summary.status).toBe('ok')
+    if (summary.status === 'ok') expect(summary.summary.actionable).toBe(false)
+
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '同意', actor: approverActor },
+    )
+    expect(outcome.status).toBe('stale')
+    const approves = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve'`, [instanceId])
+    expect((approves.rows[0] as { c: number }).c).toBe(0)
+  })
 })

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -43,30 +43,49 @@ const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlTe
 
 let approvals: ApprovalProductService
 let templateId = ''
+// P1-1: a linear TWO-approval-node template (node1 → node2, SAME assignee) — the shape the
+// stale-card node-binding fix is proven against (a card issued for node1 must not approve node2).
+let twoNodeTemplateId = ''
 const SECRET = 'cdw-test-secret'
 
 function tokenFor(deliveryId: string): string {
   return createHmac('sha256', SECRET).update(deliveryId).digest('hex').slice(0, 32)
 }
 
-async function newInstance(): Promise<string> {
+async function newInstance(tid: string = templateId): Promise<string> {
   const dto = await approvals.createApproval(
-    { templateId, formData: { summary: 'wrapper test' } },
+    { templateId: tid, formData: { summary: 'wrapper test' } },
     { userId: REQUESTER, userName: REQUESTER },
   )
   return (dto as { id: string }).id
 }
 
-async function newSentDelivery(instanceId: string): Promise<string> {
+async function newSentDelivery(
+  instanceId: string,
+  opts: { nodeKey?: string; entryEpoch?: number | null } = {},
+): Promise<string> {
   const row = await insertDingTalkApprovalCardDelivery(q, {
     instanceId,
-    nodeKey: 'approval_1',
+    nodeKey: opts.nodeKey ?? 'approval_1',
     recipientUserId: APPROVER,
     recipientDingTalkUserId: `dd_${APPROVER}`,
     deliveryKind: 'work_notice_action_card',
+    entryEpoch: opts.entryEpoch ?? null,
   })
   await markDingTalkApprovalCardDeliverySent(q, row.id, 'task_cdw')
   return row.id
+}
+
+/** The live entry_epoch of the node's still-active assignment for APPROVER (the round a card binds to). */
+async function activeEpoch(instanceId: string, nodeKey: string): Promise<number | null> {
+  const r = await q(
+    `SELECT entry_epoch FROM approval_assignments
+      WHERE instance_id = $1 AND node_key = $2 AND assignee_id = $3 AND is_active = TRUE
+      ORDER BY created_at DESC LIMIT 1`,
+    [instanceId, nodeKey, APPROVER],
+  )
+  const raw = (r.rows[0] as { entry_epoch: number | string | null } | undefined)?.entry_epoch
+  return raw === null || raw === undefined ? null : Number(raw)
 }
 
 const approverActor = { userId: '', userName: '' }
@@ -106,17 +125,39 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     } as never)
     templateId = (template as { id: string }).id
     await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+
+    // P1-1 two-node linear template: node1 → node2, SAME approver on both nodes.
+    const twoNode = await approvals.createTemplate({
+      key: `cdw2-${TS}`,
+      name: 'Card Wrapper Two-Node Template',
+      formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          { key: 'approval_1', type: 'approval', name: 'First', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] } },
+          { key: 'approval_2', type: 'approval', name: 'Second', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] } },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval_1-approval_2', source: 'approval_1', target: 'approval_2' },
+          { key: 'edge-approval_2-end', source: 'approval_2', target: 'end' },
+        ],
+      },
+    } as never)
+    twoNodeTemplateId = (twoNode as { id: string }).id
+    await approvals.publishTemplate(twoNodeTemplateId, { policy: { allowRevoke: true } } as never)
   })
 
   afterAll(async () => {
-    const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [templateId]).catch(() => ({ rows: [] as unknown[] }))
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = ANY($1::text[])', [[templateId, twoNodeTemplateId]]).catch(() => ({ rows: [] as unknown[] }))
     for (const row of instances.rows as Array<{ id: string }>) {
       await q('DELETE FROM dingtalk_approval_card_deliveries WHERE instance_id = $1', [row.id]).catch(() => {})
       await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
       await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
       await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
     }
-    await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
+    await q('DELETE FROM approval_templates WHERE id = ANY($1::text[])', [[templateId, twoNodeTemplateId]]).catch(() => {})
     await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER]]).catch(() => {})
     await q('DELETE FROM users WHERE id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER]]).catch(() => {})
     if (savedSecret === undefined) delete process.env.APPROVAL_CARD_LINK_SECRET
@@ -480,5 +521,119 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     )
     expect(outcome.status).toBe('engine_rejected')
     if (outcome.status === 'engine_rejected') expect(outcome.summary.cardState).toBe('sent')
+  })
+
+  // ─── P1-1 stale-card node/epoch binding — RED-before goldens (real two-node state) ────────────
+  //
+  // The class this closes was missed by mock-only review: on origin/main a card issued for NODE 1,
+  // after node 1 is approved and the instance advances to NODE 2 (where the recipient is ALSO the
+  // assignee), returns `ok` and silently approves node 2 — the approver never saw node 2's context.
+  // These construct REAL two-node / re-entry state and assert `stale` + zero cross-node writes.
+
+  test('P1-1 TWO-NODE web-first: a node1 card is STALE after the instance advances to node2 (same assignee) — never approves node2', async () => {
+    const instanceId = await newInstance(twoNodeTemplateId)
+    // The card is issued for node1's round (persist its live epoch, exactly as the send path does).
+    const node1Epoch = await activeEpoch(instanceId, 'approval_1')
+    const deliveryId = await newSentDelivery(instanceId, { nodeKey: 'approval_1', entryEpoch: node1Epoch })
+
+    // While node1 is still active the card IS actionable (baseline — the binding matches the live seat).
+    const before = await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })
+    expect(before.status).toBe('ok')
+    if (before.status === 'ok') expect(before.summary.actionable).toBe(true)
+
+    // Approve node1 through the ENGINE (web-first) → the instance advances to node2, where APPROVER is
+    // ALSO the active assignee. node1's assignment flips is_active=FALSE.
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: '同意' }, { userId: APPROVER, userName: APPROVER, roles: [] })
+    const advanced = await q('SELECT status, current_node_key FROM approval_instances WHERE id = $1', [instanceId])
+    expect(advanced.rows[0]).toMatchObject({ status: 'pending', current_node_key: 'approval_2' })
+
+    // Defense-in-depth: the post-commit supersede sweep flipped the still-sent node1 card to superseded.
+    const swept = await q('SELECT card_state FROM dingtalk_approval_card_deliveries WHERE id = $1', [deliveryId])
+    expect((swept.rows[0] as { card_state: string }).card_state).toBe('superseded')
+
+    // ISOLATE THE BINDING (must stand alone even if supersede never runs): force the card back to
+    // 'sent' so card_state cannot mask the read-time active-assignment binding. RED-before: with the
+    // binding reverted this card is actionable and dispatchAction approves node2.
+    await q(`UPDATE dingtalk_approval_card_deliveries SET card_state = 'sent' WHERE id = $1`, [deliveryId])
+    const summary = await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })
+    expect(summary.status).toBe('ok')
+    if (summary.status === 'ok') expect(summary.summary.actionable).toBe(false) // node1 seat is gone
+
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '同意', actor: approverActor },
+    )
+    expect(outcome.status).toBe('stale')
+
+    // node2 was NEVER approved by the stale node1 card: instance still pending at node2, and there is
+    // ZERO approve record carrying node2's key.
+    const post = await q('SELECT status, current_node_key FROM approval_instances WHERE id = $1', [instanceId])
+    expect(post.rows[0]).toMatchObject({ status: 'pending', current_node_key: 'approval_2' })
+    const node2Approves = await q(
+      `SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND metadata->>'nodeKey' = 'approval_2'`,
+      [instanceId],
+    )
+    expect((node2Approves.rows[0] as { c: number }).c).toBe(0)
+  })
+
+  test('P1-1 SAME-NODE re-entry: an old-epoch card is STALE after the same node re-activates with a fresh epoch (needs the persisted delivery epoch)', async () => {
+    const instanceId = await newInstance()
+    const e1 = await activeEpoch(instanceId, 'approval_1')
+    expect(typeof e1).toBe('number')
+    // Card carries the FIRST round's epoch.
+    const deliveryId = await newSentDelivery(instanceId, { nodeKey: 'approval_1', entryEpoch: e1 })
+
+    // Matching-epoch baseline: while round e1 is the live round, the card is actionable.
+    const before = await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })
+    expect(before.status).toBe('ok')
+    if (before.status === 'ok') expect(before.summary.actionable).toBe(true)
+
+    // Model a loop-back that RE-ENTERS the SAME node_key on a FRESH epoch: deactivate the current
+    // seat and mint a new active seat at approval_1 with epoch e1+1 (what a real return/jump does),
+    // and advance the instance's activation sequence to match. node_key is unchanged; only the epoch is.
+    const e2 = (e1 as number) + 1
+    await q(`UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND node_key = 'approval_1' AND is_active = TRUE`, [instanceId])
+    await q(
+      `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch, metadata, created_at, updated_at)
+       VALUES ($1, 'user', $2, 1, 'approval_1', TRUE, $3, '{}'::jsonb, now(), now())`,
+      [instanceId, APPROVER, e2],
+    )
+    await q(`UPDATE approval_instances SET node_activation_seq = $2, updated_at = now() WHERE id = $1`, [instanceId, e2])
+
+    // The old-epoch card (e1) no longer matches the live seat (e2) → stale. RED-before: with the
+    // epoch clause reverted the card is actionable and approves the NEW round it never belonged to.
+    const summary = await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })
+    expect(summary.status).toBe('ok')
+    if (summary.status === 'ok') expect(summary.summary.actionable).toBe(false)
+
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '同意', actor: approverActor },
+    )
+    expect(outcome.status).toBe('stale')
+    // No approve record was written for this instance (the stale card never reached the engine).
+    const approves = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve'`, [instanceId])
+    expect((approves.rows[0] as { c: number }).c).toBe(0)
+  })
+
+  test('P1-1 POSITIVE (happy path unchanged): a node1 card whose persisted epoch matches the live active seat still approves node1', async () => {
+    const instanceId = await newInstance()
+    const e1 = await activeEpoch(instanceId, 'approval_1')
+    const deliveryId = await newSentDelivery(instanceId, { nodeKey: 'approval_1', entryEpoch: e1 })
+
+    const summary = await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })
+    expect(summary.status).toBe('ok')
+    if (summary.status === 'ok') expect(summary.summary.actionable).toBe(true)
+
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '同意', actor: approverActor },
+    )
+    expect(outcome.status).toBe('ok')
+    if (outcome.status === 'ok') {
+      expect(outcome.summary.cardState).toBe('acted')
+      expect(outcome.summary.actedAction).toBe('approve')
+      expect(outcome.summary.approval.status).toBe('approved')
+    }
   })
 })

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -13,6 +13,7 @@ import { randomUUID } from 'crypto'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import { ServiceError } from '../../src/services/ApprovalBridgeService'
 import {
   executeApprovalActionFromCardDelivery,
   getApprovalCardDeliverySummary,
@@ -642,5 +643,109 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
       expect(outcome.summary.actedAction).toBe('approve')
       expect(outcome.summary.approval.status).toBe('approved')
     }
+  })
+
+  // ─── P1-1 re-review: authoritative IN-TXN card→round binding (the TOCTOU close) ───────────────
+  //
+  // The wrapper's pre-read binding runs OUTSIDE dispatchAction's FOR UPDATE txn. A concurrent advance
+  // can slip a stale card past it into the engine, where actorCanAct only proves "assignee of the
+  // CURRENT node", never "this CARD was issued for the current round". These goldens drive
+  // dispatchAction DIRECTLY (bypassing the pre-read) to prove the in-txn guard is the authoritative
+  // close — a mock/sequential review of the wrapper alone could not see this class.
+
+  test('P1-1 TOCTOU (in-txn guard, HEADLINE): a node1 card driven DIRECTLY into dispatchAction after the instance advanced to node2 → APPROVAL_CARD_DELIVERY_STALE, node2 NEVER approved', async () => {
+    const instanceId = await newInstance(twoNodeTemplateId)
+    const node1Epoch = await activeEpoch(instanceId, 'approval_1')
+    const deliveryId = await newSentDelivery(instanceId, { nodeKey: 'approval_1', entryEpoch: node1Epoch })
+
+    // Advance N1 → N2 via a REAL approve of node1 (the concurrent advance the stale card races). The
+    // N1 recipient is ALSO the active N2 assignee, so actorCanAct is TRUE at node2 — WITHOUT the
+    // in-txn card→round binding the engine would silently approve node2.
+    await approvals.dispatchAction(instanceId, { action: 'approve', comment: '同意' }, { userId: APPROVER, userName: APPROVER, roles: [] })
+    const advanced = await q('SELECT status, current_node_key FROM approval_instances WHERE id = $1', [instanceId])
+    expect(advanced.rows[0]).toMatchObject({ status: 'pending', current_node_key: 'approval_2' })
+    const beforeN2 = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND metadata->>'nodeKey' = 'approval_2'`, [instanceId])
+    expect((beforeN2.rows[0] as { c: number }).c).toBe(0)
+
+    // Drive the guard DIRECTLY: card.node_key ('approval_1') ≠ currentNodeKey ('approval_2') → the
+    // in-txn guard throws BEFORE any record insert. RED-before (revert FIX 1): this resolves and
+    // approves node2 (the owner's reproduced bug).
+    await expect(
+      approvals.dispatchAction(
+        instanceId,
+        { action: 'approve', comment: '同意', channelOrigin: { channel: 'dingtalk_card', cardDeliveryId: deliveryId } },
+        { userId: APPROVER, userName: APPROVER, roles: [] },
+      ),
+    ).rejects.toMatchObject({ code: 'APPROVAL_CARD_DELIVERY_STALE', statusCode: 409 })
+
+    // node2 was NEVER approved by the stale node1 card — zero new approve records for node2, instance
+    // still pending at node2.
+    const post = await q('SELECT status, current_node_key FROM approval_instances WHERE id = $1', [instanceId])
+    expect(post.rows[0]).toMatchObject({ status: 'pending', current_node_key: 'approval_2' })
+    const node2Approves = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND metadata->>'nodeKey' = 'approval_2'`, [instanceId])
+    expect((node2Approves.rows[0] as { c: number }).c).toBe(0)
+  })
+
+  test('P1-1 wrapper maps the engine STALE code to `stale` (not engine_rejected) — FIX 2', async () => {
+    // A deterministic non-concurrent DB state cannot make the wrapper pre-read PASS while the engine's
+    // in-txn guard throws (the active-assignment unique index limits an assignee to ONE active seat per
+    // instance, so the pre-read and the guard agree unless a real advance races between them — the very
+    // TOCTOU window). So this isolates FIX 2 faithfully: a REAL actionable card (pre-read passes → the
+    // wrapper proceeds to dispatch), with the engine standing in for the raced-advance outcome by
+    // throwing the exact ServiceError the in-txn guard raises. The wrapper MUST map it to `stale`, not
+    // engine_rejected. The real end-to-end throw is proven by the HEADLINE golden driving dispatchAction
+    // directly; here we pin the catch mapping. RED-before (revert FIX 2): status is engine_rejected.
+    const instanceId = await newInstance()
+    const e1 = await activeEpoch(instanceId, 'approval_1')
+    const deliveryId = await newSentDelivery(instanceId, { nodeKey: 'approval_1', entryEpoch: e1 })
+
+    const pre = await getApprovalCardDeliverySummary({ query: q }, { deliveryId, token: tokenFor(deliveryId), viewerUserId: APPROVER })
+    expect(pre.status).toBe('ok')
+    if (pre.status === 'ok') expect(pre.summary.actionable).toBe(true)
+
+    const stalingApprovals = {
+      dispatchAction: async () => {
+        throw new ServiceError('Approval card is no longer valid for the current node', 409, 'APPROVAL_CARD_DELIVERY_STALE')
+      },
+    }
+    const outcome = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals: stalingApprovals },
+      { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '同意', actor: approverActor },
+    )
+    expect(outcome.status).toBe('stale')
+    // No approve record was written (the guard threw before any insert; the stub performed no engine work).
+    const approves = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve'`, [instanceId])
+    expect((approves.rows[0] as { c: number }).c).toBe(0)
+  })
+
+  test('P1-1 STRICT epoch (in-txn guard): an old-epoch card driven DIRECTLY into dispatchAction after the SAME node re-activated with a fresh epoch → APPROVAL_CARD_DELIVERY_STALE', async () => {
+    const instanceId = await newInstance()
+    const e1 = await activeEpoch(instanceId, 'approval_1')
+    expect(typeof e1).toBe('number')
+    const deliveryId = await newSentDelivery(instanceId, { nodeKey: 'approval_1', entryEpoch: e1 })
+
+    // Re-enter the SAME node on a FRESH epoch: deactivate the current seat, mint a new active seat at
+    // approval_1 with epoch e1+1, advance the activation sequence. node_key is unchanged; only epoch is.
+    const e2 = (e1 as number) + 1
+    await q(`UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND node_key = 'approval_1' AND is_active = TRUE`, [instanceId])
+    await q(
+      `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch, metadata, created_at, updated_at)
+       VALUES ($1, 'user', $2, 1, 'approval_1', TRUE, $3, '{}'::jsonb, now(), now())`,
+      [instanceId, APPROVER, e2],
+    )
+    await q(`UPDATE approval_instances SET node_activation_seq = $2, updated_at = now() WHERE id = $1`, [instanceId, e2])
+
+    // Direct dispatch: node_key matches (approval_1 = current) and actorCanAct is TRUE (the fresh e2
+    // seat), but the card's epoch e1 ≠ the live seat epoch e2 → STALE. RED-before (remove the strict
+    // epoch from the in-txn guard): the card approves the new round it never belonged to.
+    await expect(
+      approvals.dispatchAction(
+        instanceId,
+        { action: 'approve', comment: '同意', channelOrigin: { channel: 'dingtalk_card', cardDeliveryId: deliveryId } },
+        { userId: APPROVER, userName: APPROVER, roles: [] },
+      ),
+    ).rejects.toMatchObject({ code: 'APPROVAL_CARD_DELIVERY_STALE' })
+    const approves = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve'`, [instanceId])
+    expect((approves.rows[0] as { c: number }).c).toBe(0)
   })
 })

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -42,6 +42,30 @@ const APPROVER = `u_cdw_appr_${TS}`
 
 const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
 
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Block until a backend is genuinely WAITING on the instance row lock (wait_event_type='Lock' on the
+ * `approval_instances … FOR UPDATE`) — the deterministic proof that the concurrent dispatchAction is
+ * parked behind the held lock, NOT a timer. Throws if it never blocks so the interleaving golden can
+ * never silently degrade into the sequential case (a vacuous green).
+ */
+async function waitUntilBlockedOnInstanceLock(timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const r = await q(
+      `SELECT COUNT(*)::int AS c FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND wait_event_type = 'Lock'
+          AND query ILIKE '%approval_instances%'
+          AND query ILIKE '%for update%'`,
+    )
+    if ((r.rows[0] as { c: number }).c >= 1) return
+    await sleep(25)
+  }
+  throw new Error('concurrent dispatchAction never blocked on the instance row lock — interleaving did not occur')
+}
+
 let approvals: ApprovalProductService
 let templateId = ''
 // P1-1: a linear TWO-approval-node template (node1 → node2, SAME assignee) — the shape the
@@ -683,6 +707,72 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     const post = await q('SELECT status, current_node_key FROM approval_instances WHERE id = $1', [instanceId])
     expect(post.rows[0]).toMatchObject({ status: 'pending', current_node_key: 'approval_2' })
     const node2Approves = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND metadata->>'nodeKey' = 'approval_2'`, [instanceId])
+    expect((node2Approves.rows[0] as { c: number }).c).toBe(0)
+  })
+
+  test('P1-1 TOCTOU (REAL two-transaction interleaving): a node1 card ALREADY IN FLIGHT when the instance advances N1→N2 under a held lock resolves STALE — the guard reads post-advance state INSIDE the FOR UPDATE, never the pre-advance snapshot', async () => {
+    // The HEADLINE above advances FIRST, then dispatches — it proves the guard EXISTS but not that it
+    // lives INSIDE the lock (a guard moved outside would still see the already-committed advance). This
+    // golden constructs the real race the owner reproduced: a dedicated connection HOLDS the instance
+    // row lock and advances N1→N2 in-txn WHILE a node1 card dispatch is already parked behind that lock.
+    // Only a guard that re-reads under the FOR UPDATE observes node2 and refuses; a guard reading the
+    // pre-advance snapshot (outside the lock) sees node1 → passes → approves node2 (owner P1).
+    const instanceId = await newInstance(twoNodeTemplateId)
+    const node1Epoch = await activeEpoch(instanceId, 'approval_1')
+    const deliveryId = await newSentDelivery(instanceId, { nodeKey: 'approval_1', entryEpoch: node1Epoch })
+
+    const hold = await poolManager.get().getInternalPool().connect()
+    let bStarted = false
+    try {
+      // A: take and HOLD the instance row lock (same row dispatchAction locks FOR UPDATE).
+      await hold.query('BEGIN')
+      await hold.query(`SELECT id FROM approval_instances WHERE id = $1 AND COALESCE(source_system, 'platform') = 'platform' FOR UPDATE`, [instanceId])
+
+      // B: the stale node1 card driven directly into dispatchAction — it must block on B's own FOR UPDATE.
+      let bSettled = false
+      const bPromise = approvals
+        .dispatchAction(
+          instanceId,
+          { action: 'approve', comment: '同意', channelOrigin: { channel: 'dingtalk_card', cardDeliveryId: deliveryId } },
+          { userId: APPROVER, userName: APPROVER, roles: [] },
+        )
+        .then((v) => { bSettled = true; return v }, (e) => { bSettled = true; throw e })
+      bStarted = true
+
+      // Deterministic proof B is parked behind the lock (not a timer): wait for wait_event_type='Lock'.
+      await waitUntilBlockedOnInstanceLock()
+      expect(bSettled).toBe(false) // B cannot have resolved while A holds the lock
+
+      // A advances N1→N2 IN-TXN (deactivate node1 seat, mint the node2 seat at a fresh epoch, move the
+      // pointer) and COMMITs — B is still blocked, so this advance lands strictly before B re-reads.
+      const e2 = (node1Epoch as number) + 1
+      await hold.query(`UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE instance_id = $1 AND node_key = 'approval_1' AND is_active = TRUE`, [instanceId])
+      await hold.query(
+        `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch, metadata, created_at, updated_at)
+         VALUES ($1, 'user', $2, 1, 'approval_2', TRUE, $3, '{}'::jsonb, now(), now())`,
+        [instanceId, APPROVER, e2],
+      )
+      await hold.query(`UPDATE approval_instances SET current_node_key = 'approval_2', node_activation_seq = $2, version = version + 1, updated_at = now() WHERE id = $1`, [instanceId, e2])
+      await hold.query('COMMIT')
+
+      // B unblocks, acquires the lock, re-reads current_node_key='approval_2' INSIDE its txn: the node1
+      // card no longer binds the current round → 409 STALE. RED-before (validate the binding against a
+      // PRE-lock read of current_node_key instead of the locked row): B saw node1 → approves node2.
+      await expect(bPromise).rejects.toMatchObject({ code: 'APPROVAL_CARD_DELIVERY_STALE', statusCode: 409 })
+    } catch (err) {
+      await hold.query('ROLLBACK').catch(() => {})
+      throw err
+    } finally {
+      hold.release()
+    }
+
+    // node2 was NEVER approved by the in-flight stale card; the instance is untouched at node2.
+    const post = await q('SELECT status, current_node_key FROM approval_instances WHERE id = $1', [instanceId])
+    expect(post.rows[0]).toMatchObject({ status: 'pending', current_node_key: 'approval_2' })
+    const node2Approves = await q(
+      `SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND metadata->>'nodeKey' = 'approval_2'`,
+      [instanceId],
+    )
     expect((node2Approves.rows[0] as { c: number }).c).toBe(0)
   })
 

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -686,6 +686,22 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     expect((node2Approves.rows[0] as { c: number }).c).toBe(0)
   })
 
+  test('P1-1 NIT: a dingtalk_card channelOrigin with NO cardDeliveryId is treated as STALE, never silently skipped', async () => {
+    // Defense-in-depth: even for a legitimately-actionable node1 seat (actorCanAct TRUE), a card
+    // channel that carries no delivery id can never be bound — the guard must fail-close, not skip.
+    const instanceId = await newInstance(twoNodeTemplateId)
+    await expect(
+      approvals.dispatchAction(
+        instanceId,
+        { action: 'approve', comment: '同意', channelOrigin: { channel: 'dingtalk_card' } as never },
+        { userId: APPROVER, userName: APPROVER, roles: [] },
+      ),
+    ).rejects.toMatchObject({ code: 'APPROVAL_CARD_DELIVERY_STALE', statusCode: 409 })
+    // node1 was NOT approved by the malformed card channel.
+    const rec = await q(`SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action = 'approve'`, [instanceId])
+    expect((rec.rows[0] as { c: number }).c).toBe(0)
+  })
+
   test('P1-1 wrapper maps the engine STALE code to `stale` (not engine_rejected) — FIX 2', async () => {
     // A deterministic non-concurrent DB state cannot make the wrapper pre-read PASS while the engine's
     // in-txn guard throws (the active-assignment unique index limits an assignee to ONE active seat per

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -64,13 +64,18 @@ async function newSentDelivery(
   instanceId: string,
   opts: { nodeKey?: string; entryEpoch?: number | null } = {},
 ): Promise<string> {
+  const nodeKey = opts.nodeKey ?? 'approval_1'
+  // P1-1 STRICT epoch: an actionable card MUST carry the round's non-null epoch (the real send path
+  // now persists it). Default to the live seat's epoch so a plain newSentDelivery is actionable, and
+  // let callers pass an explicit epoch (or null) to exercise the stale/legacy paths.
+  const entryEpoch = opts.entryEpoch === undefined ? await activeEpoch(instanceId, nodeKey) : opts.entryEpoch
   const row = await insertDingTalkApprovalCardDelivery(q, {
     instanceId,
-    nodeKey: opts.nodeKey ?? 'approval_1',
+    nodeKey,
     recipientUserId: APPROVER,
     recipientDingTalkUserId: `dd_${APPROVER}`,
     deliveryKind: 'work_notice_action_card',
-    entryEpoch: opts.entryEpoch ?? null,
+    entryEpoch,
   })
   await markDingTalkApprovalCardDeliverySent(q, row.id, 'task_cdw')
   return row.id
@@ -364,7 +369,9 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
     // delivery proof. The ledger's send-time uncertainty must not make the card inoperable.
     const instanceId = await newInstance()
     const row = await insertDingTalkApprovalCardDelivery(q, {
+      // P1-1 STRICT epoch: bind to the live round so actionability turns on send_status, not a null epoch.
       instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: `dd_${APPROVER}`, deliveryKind: 'work_notice_action_card',
+      entryEpoch: await activeEpoch(instanceId, 'approval_1'),
     })
     await markDingTalkApprovalCardDeliverySendOutcomeUnknown(q, row.id, 'fetch failed (response lost)')
 

--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -365,6 +365,16 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     expect(row.card_state).toBe('sent')
     expect(row.send_status).toBe('sent')
     expect(row.task_id).toBe('interactive-task-4242')
+    // P2-2: the executor MUST persist the task's entry epoch onto the delivery row (this is what
+    // powers the wrapper's same-node re-entry binding). Pinned to the live seat's epoch so a
+    // regression that drops the capture (persists null) fails HERE, not silently.
+    const seatEpoch = await q(
+      `SELECT entry_epoch FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY created_at ASC LIMIT 1`,
+      [instanceId],
+    )
+    const expectedEpoch = (seatEpoch.rows[0] as { entry_epoch: number | null } | undefined)?.entry_epoch ?? null
+    expect(expectedEpoch).not.toBeNull()
+    expect(row.entry_epoch).toBe(expectedEpoch)
 
     expect(sentBodies).toHaveLength(0)
     expect(interactiveBodies).toHaveLength(1)

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
@@ -76,6 +76,25 @@ async function newInstance(): Promise<string> {
   return (dto as { id: string }).id
 }
 
+/**
+ * The live node-entry epoch of the active seat for (instance, node, recipient). A DELIVERABLE card
+ * MUST be stamped with this (strict P1-1 binding: a NULL-epoch card is never actionable) — the real
+ * send path reads `task.entryEpoch` from the task_created event; the fixtures read it from the seat
+ * the engine minted so the card binds to its real round. Undeliverable negatives (pending/failed)
+ * keep NULL — they are unactionable by send_status alone, and stamping them would mask nothing.
+ */
+async function liveSeatEpoch(instanceId: string, nodeKey: string, recipientUserId: string): Promise<number> {
+  const res = await q(
+    `SELECT entry_epoch FROM approval_assignments
+      WHERE instance_id = $1 AND node_key = $2 AND assignee_id = $3 AND is_active = TRUE AND entry_epoch IS NOT NULL
+      ORDER BY entry_epoch DESC LIMIT 1`,
+    [instanceId, nodeKey, recipientUserId],
+  )
+  const epoch = (res.rows[0] as { entry_epoch: number } | undefined)?.entry_epoch
+  if (typeof epoch !== 'number') throw new Error(`no live non-null-epoch seat for ${instanceId}/${nodeKey}/${recipientUserId}`)
+  return epoch
+}
+
 async function newSentDelivery(instanceId: string, integrationId: string | null = INTEGRATION_A): Promise<string> {
   const row = await insertDingTalkApprovalCardDelivery(q, {
     instanceId,
@@ -84,6 +103,7 @@ async function newSentDelivery(instanceId: string, integrationId: string | null 
     recipientDingTalkUserId: DD_OP,
     deliveryKind: 'interactive_card',
     integrationId,
+    entryEpoch: await liveSeatEpoch(instanceId, 'approval_1', APPROVER),
   })
   await markDingTalkApprovalCardDeliverySent(q, row.id, `carrier_${row.id.slice(0, 8)}`)
   return row.id
@@ -338,6 +358,7 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
     // so a globally-unique-but-wrong-corp id would have resolved (cross-corp collision face).
     const unpinned = await insertDingTalkApprovalCardDelivery(q, {
       instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: DD_DUP, deliveryKind: 'interactive_card', integrationId: null,
+      entryEpoch: await liveSeatEpoch(instanceId, 'approval_1', APPROVER),
     })
     await markDingTalkApprovalCardDeliverySent(q, unpinned.id, 'carrier_dup_unpinned')
     const refused = await executeDingTalkApprovalCardCallback(deps, payloadFor(unpinned.id, DD_DUP))
@@ -347,6 +368,7 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
     // Corp-A-pinned delivery: the SAME external id resolves to corp A's link (APPROVER) → executes.
     const pinned = await insertDingTalkApprovalCardDelivery(q, {
       instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: DD_DUP, deliveryKind: 'interactive_card', integrationId: INTEGRATION_A,
+      entryEpoch: await liveSeatEpoch(instanceId, 'approval_1', APPROVER),
     })
     await markDingTalkApprovalCardDeliverySent(q, pinned.id, 'carrier_dup_pinned')
     const executed = await executeDingTalkApprovalCardCallback(deps, payloadFor(pinned.id, DD_DUP))
@@ -358,6 +380,7 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
     const instanceId = await newInstance()
     const row = await insertDingTalkApprovalCardDelivery(q, {
       instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: DD_OP_B, deliveryKind: 'interactive_card', integrationId: INTEGRATION_B,
+      entryEpoch: await liveSeatEpoch(instanceId, 'approval_1', APPROVER),
     })
     await markDingTalkApprovalCardDeliverySent(q, row.id, 'carrier_corp_b')
 

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { pool } from '../../src/db/pg'
 import {
-  backfillDingTalkApprovalCardDeliveryEpochs,
+  supersedeLegacyDingTalkApprovalCardDeliveries,
   claimDingTalkApprovalCardDeliveryActed,
   findDingTalkApprovalCardDeliveriesByTaskId,
   findDingTalkApprovalCardDeliveryById,
@@ -169,56 +169,47 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
     await q(`DELETE FROM approval_assignments WHERE instance_id = $1`, [INSTANCE_CASCADE]).catch(() => {})
   })
 
-  it('P1-1 legacy backfill: a null-epoch sent card with a UNIQUE live non-null seat is backfilled; no-unique-seat and ambiguous cards are superseded (fail-closed); idempotent', async () => {
-    // Dedicated instance so the scoped backfill cannot touch sibling fixtures in this shared-DB file.
-    const INST = `apv_dacd_backfill_${Date.now()}`
+  it('P1-1 legacy reconcile (owner re-review repro): a null-epoch sent card is SUPERSEDED outright — NEVER re-authorized into a fresh same-node/same-recipient round via seat inference; idempotent', async () => {
+    // Dedicated instance so the scoped reconcile cannot touch sibling fixtures in this shared-DB file.
+    const INST = `apv_dacd_reentry_${Date.now()}`
     await q(`INSERT INTO approval_instances (id, status, current_node_key) VALUES ($1, 'pending', 'approval_1') ON CONFLICT (id) DO NOTHING`, [INST])
     try {
-      // (a) UNIQUE live non-null-epoch seat for (INST, approval_1, user_match) — epoch 7.
-      await q(`INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch) VALUES ($1,'user','user_match',0,'approval_1',TRUE,7)`, [INST])
-      // (c) AMBIGUOUS: two live non-null-epoch seats for (INST, approval_2, user_ambig). The active-seat
-      // unique index is (instance, assignment_type, assignee), so ambiguity needs DISTINCT types — the
-      // backfill groups by (instance, node, assignee), so COUNT(*)=2 here → HAVING fails → superseded.
-      await q(`INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch) VALUES ($1,'user','user_ambig',0,'approval_2',TRUE,3),($1,'role','user_ambig',0,'approval_2',TRUE,4)`, [INST])
-      // (d) NULL-EPOCH-ONLY seat for (INST, approval_3, user_nullseat): a live seat exists but its epoch
-      // is NULL, so the backfill (which counts only NON-NULL-epoch seats) finds no unique seat → superseded.
-      await q(`INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch) VALUES ($1,'user','user_nullseat',0,'approval_3',TRUE,NULL)`, [INST])
+      // (1) Legacy pre-column card — sent for round R0 of (INST, approval_1, user_reentry), entry_epoch NULL.
+      const legacy = await insertDingTalkApprovalCardDelivery(q, { instanceId: INST, nodeKey: 'approval_1', recipientUserId: 'user_reentry', recipientDingTalkUserId: 'dd_user_reentry', deliveryKind: 'work_notice_action_card' })
+      await markDingTalkApprovalCardDeliverySent(q, legacy.id, 'task_reentry')
 
-      const mkNullEpochSent = async (node: string, recipient: string): Promise<string> => {
-        const row = await insertDingTalkApprovalCardDelivery(q, { instanceId: INST, nodeKey: node, recipientUserId: recipient, recipientDingTalkUserId: `dd_${recipient}`, deliveryKind: 'work_notice_action_card' })
-        await markDingTalkApprovalCardDeliverySent(q, row.id, `task_${recipient}`)
-        return row.id
-      }
-      const matched = await mkNullEpochSent('approval_1', 'user_match')     // → backfilled to 7
-      const orphan = await mkNullEpochSent('approval_9', 'user_orphan')     // → superseded (no live seat)
-      const ambiguous = await mkNullEpochSent('approval_2', 'user_ambig')   // → superseded (>1 non-null seat)
-      const nullseat = await mkNullEpochSent('approval_3', 'user_nullseat') // → superseded (only null-epoch seat)
+      // (2) A FRESH round re-enters the SAME node for the SAME recipient — a NEW active seat at epoch 9.
+      //     This is the ONLY live non-null-epoch seat for (INST, approval_1, user_reentry). The DELETED
+      //     "infer epoch from the unique live seat" backfill would have adopted 9 and left the legacy card
+      //     sent + entry_epoch=9 → actionable in round-9 (owner re-review P1: same-node re-entry reopened).
+      await q(`INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch) VALUES ($1,'user','user_reentry',0,'approval_1',TRUE,9)`, [INST])
 
-      // All four start sent + null-epoch.
-      for (const id of [matched, orphan, ambiguous, nullseat]) {
+      // (3) An orphan legacy card with NO live seat at all — must also supersede.
+      const orphan = await insertDingTalkApprovalCardDelivery(q, { instanceId: INST, nodeKey: 'approval_9', recipientUserId: 'user_orphan', recipientDingTalkUserId: 'dd_user_orphan', deliveryKind: 'work_notice_action_card' })
+      await markDingTalkApprovalCardDeliverySent(q, orphan.id, 'task_orphan')
+
+      // Both start sent + null-epoch.
+      for (const id of [legacy.id, orphan.id]) {
         const row = await findDingTalkApprovalCardDeliveryById(q, id)
         expect(row?.card_state).toBe('sent')
         expect(row?.entry_epoch ?? null).toBeNull()
       }
 
-      const result = await backfillDingTalkApprovalCardDeliveryEpochs(q, { instanceIds: [INST] })
+      const result = await supersedeLegacyDingTalkApprovalCardDeliveries(q, { instanceIds: [INST] })
 
-      // matched → epoch backfilled from the unique seat (7), still sent (now strictly bindable).
-      // RED-before (remove the backfill step): entry_epoch stays null → card unrecoverable.
-      expect(result.backfilledIds).toEqual([matched])
-      const backfilledRow = await findDingTalkApprovalCardDeliveryById(q, matched)
-      expect(backfilledRow?.entry_epoch).toBe(7)
-      expect(backfilledRow?.card_state).toBe('sent')
+      // Both legacy cards are SUPERSEDED (fail-closed). RED-before (restore the seat-inference backfill):
+      // `legacy` becomes entry_epoch=9 + card_state='sent' → re-authorized into the wrong round.
+      expect(result.supersededIds.sort()).toEqual([legacy.id, orphan.id].sort())
+      const legacyRow = await findDingTalkApprovalCardDeliveryById(q, legacy.id)
+      expect(legacyRow?.card_state).toBe('superseded')
+      expect(legacyRow?.entry_epoch ?? null).toBeNull() // NOT adopted from the epoch-9 seat — provenance never inferred
+      expect((await findDingTalkApprovalCardDeliveryById(q, orphan.id))?.card_state).toBe('superseded')
 
-      // orphan + ambiguous + nullseat → superseded (fail-closed). RED-before (remove the supersede step): sent + null.
-      expect(result.supersededIds.sort()).toEqual([ambiguous, nullseat, orphan].sort())
-      for (const id of [orphan, ambiguous, nullseat]) {
-        expect((await findDingTalkApprovalCardDeliveryById(q, id))?.card_state).toBe('superseded')
-      }
+      // A superseded card is UNCLAIMABLE — the acted-claim requires card_state='sent'. Not actionable, full stop.
+      expect(await claimDingTalkApprovalCardDeliveryActed(q, legacy.id, { action: 'approve', actedBy: 'user_reentry' })).toBeNull()
 
-      // Idempotent: a second run touches neither (no sent + null-epoch rows remain).
-      const rerun = await backfillDingTalkApprovalCardDeliveryEpochs(q, { instanceIds: [INST] })
-      expect(rerun.backfilledIds).toEqual([])
+      // Idempotent: a second run touches nothing (no sent + null-epoch rows remain).
+      const rerun = await supersedeLegacyDingTalkApprovalCardDeliveries(q, { instanceIds: [INST] })
       expect(rerun.supersededIds).toEqual([])
     } finally {
       await q(`DELETE FROM dingtalk_approval_card_deliveries WHERE instance_id = $1`, [INST]).catch(() => {})

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
@@ -130,6 +130,44 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
     expect(sweptAll).toEqual([keep.id])
   })
 
+  it('P2-1: supersede NEVER sweeps a card whose (node,recipient) seat is still ACTIVE (parallel-fork sibling)', async () => {
+    // Model a joinMode:'all' parallel fork: two live seats on distinct branch nodes. Approving
+    // branch A advances past its own node but branch B's seat stays active — sweeping the instance
+    // must NOT false-stale branch B's live card.
+    const liveSeatCard = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE_CASCADE,
+      nodeKey: 'branch_b',
+      recipientUserId: 'user_live',
+      recipientDingTalkUserId: 'dd_user_live',
+      deliveryKind: 'work_notice_action_card',
+    })
+    await markDingTalkApprovalCardDeliverySent(q, liveSeatCard.id, 'task_live_seat')
+    const deadSeatCard = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId: INSTANCE_CASCADE,
+      nodeKey: 'branch_a',
+      recipientUserId: 'user_dead',
+      recipientDingTalkUserId: 'dd_user_dead',
+      deliveryKind: 'work_notice_action_card',
+    })
+    await markDingTalkApprovalCardDeliverySent(q, deadSeatCard.id, 'task_dead_seat')
+    // branch B's seat is ACTIVE; branch A's seat was consumed (is_active = FALSE).
+    await q(
+      `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active)
+       VALUES ($1, 'user', 'user_live', 0, 'branch_b', TRUE), ($1, 'user', 'user_dead', 0, 'branch_a', FALSE)`,
+      [INSTANCE_CASCADE],
+    )
+
+    const swept = await supersedeDingTalkApprovalCardDeliveriesForInstance(q, INSTANCE_CASCADE)
+
+    // Only the dead-seat card is superseded; the live parallel-sibling card is spared.
+    expect(swept).toContain(deadSeatCard.id)
+    expect(swept).not.toContain(liveSeatCard.id)
+    expect((await findDingTalkApprovalCardDeliveryById(q, liveSeatCard.id))?.card_state).toBe('sent')
+    expect((await findDingTalkApprovalCardDeliveryById(q, deadSeatCard.id))?.card_state).toBe('superseded')
+
+    await q(`DELETE FROM approval_assignments WHERE instance_id = $1`, [INSTANCE_CASCADE]).catch(() => {})
+  })
+
   it('P2: pending/failed sends are NEVER claimable — only a delivered card is actionable', async () => {
     const pending = await insertDingTalkApprovalCardDelivery(q, {
       instanceId: INSTANCE,

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-deliveries.db.test.ts
@@ -12,6 +12,7 @@ import { randomUUID } from 'crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { pool } from '../../src/db/pg'
 import {
+  backfillDingTalkApprovalCardDeliveryEpochs,
   claimDingTalkApprovalCardDeliveryActed,
   findDingTalkApprovalCardDeliveriesByTaskId,
   findDingTalkApprovalCardDeliveryById,
@@ -166,6 +167,64 @@ describeIfDb('A-1 — dingtalk approval card delivery ledger (real DB)', () => {
     expect((await findDingTalkApprovalCardDeliveryById(q, deadSeatCard.id))?.card_state).toBe('superseded')
 
     await q(`DELETE FROM approval_assignments WHERE instance_id = $1`, [INSTANCE_CASCADE]).catch(() => {})
+  })
+
+  it('P1-1 legacy backfill: a null-epoch sent card with a UNIQUE live non-null seat is backfilled; no-unique-seat and ambiguous cards are superseded (fail-closed); idempotent', async () => {
+    // Dedicated instance so the scoped backfill cannot touch sibling fixtures in this shared-DB file.
+    const INST = `apv_dacd_backfill_${Date.now()}`
+    await q(`INSERT INTO approval_instances (id, status, current_node_key) VALUES ($1, 'pending', 'approval_1') ON CONFLICT (id) DO NOTHING`, [INST])
+    try {
+      // (a) UNIQUE live non-null-epoch seat for (INST, approval_1, user_match) — epoch 7.
+      await q(`INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch) VALUES ($1,'user','user_match',0,'approval_1',TRUE,7)`, [INST])
+      // (c) AMBIGUOUS: two live non-null-epoch seats for (INST, approval_2, user_ambig). The active-seat
+      // unique index is (instance, assignment_type, assignee), so ambiguity needs DISTINCT types — the
+      // backfill groups by (instance, node, assignee), so COUNT(*)=2 here → HAVING fails → superseded.
+      await q(`INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch) VALUES ($1,'user','user_ambig',0,'approval_2',TRUE,3),($1,'role','user_ambig',0,'approval_2',TRUE,4)`, [INST])
+      // (d) NULL-EPOCH-ONLY seat for (INST, approval_3, user_nullseat): a live seat exists but its epoch
+      // is NULL, so the backfill (which counts only NON-NULL-epoch seats) finds no unique seat → superseded.
+      await q(`INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, entry_epoch) VALUES ($1,'user','user_nullseat',0,'approval_3',TRUE,NULL)`, [INST])
+
+      const mkNullEpochSent = async (node: string, recipient: string): Promise<string> => {
+        const row = await insertDingTalkApprovalCardDelivery(q, { instanceId: INST, nodeKey: node, recipientUserId: recipient, recipientDingTalkUserId: `dd_${recipient}`, deliveryKind: 'work_notice_action_card' })
+        await markDingTalkApprovalCardDeliverySent(q, row.id, `task_${recipient}`)
+        return row.id
+      }
+      const matched = await mkNullEpochSent('approval_1', 'user_match')     // → backfilled to 7
+      const orphan = await mkNullEpochSent('approval_9', 'user_orphan')     // → superseded (no live seat)
+      const ambiguous = await mkNullEpochSent('approval_2', 'user_ambig')   // → superseded (>1 non-null seat)
+      const nullseat = await mkNullEpochSent('approval_3', 'user_nullseat') // → superseded (only null-epoch seat)
+
+      // All four start sent + null-epoch.
+      for (const id of [matched, orphan, ambiguous, nullseat]) {
+        const row = await findDingTalkApprovalCardDeliveryById(q, id)
+        expect(row?.card_state).toBe('sent')
+        expect(row?.entry_epoch ?? null).toBeNull()
+      }
+
+      const result = await backfillDingTalkApprovalCardDeliveryEpochs(q, { instanceIds: [INST] })
+
+      // matched → epoch backfilled from the unique seat (7), still sent (now strictly bindable).
+      // RED-before (remove the backfill step): entry_epoch stays null → card unrecoverable.
+      expect(result.backfilledIds).toEqual([matched])
+      const backfilledRow = await findDingTalkApprovalCardDeliveryById(q, matched)
+      expect(backfilledRow?.entry_epoch).toBe(7)
+      expect(backfilledRow?.card_state).toBe('sent')
+
+      // orphan + ambiguous + nullseat → superseded (fail-closed). RED-before (remove the supersede step): sent + null.
+      expect(result.supersededIds.sort()).toEqual([ambiguous, nullseat, orphan].sort())
+      for (const id of [orphan, ambiguous, nullseat]) {
+        expect((await findDingTalkApprovalCardDeliveryById(q, id))?.card_state).toBe('superseded')
+      }
+
+      // Idempotent: a second run touches neither (no sent + null-epoch rows remain).
+      const rerun = await backfillDingTalkApprovalCardDeliveryEpochs(q, { instanceIds: [INST] })
+      expect(rerun.backfilledIds).toEqual([])
+      expect(rerun.supersededIds).toEqual([])
+    } finally {
+      await q(`DELETE FROM dingtalk_approval_card_deliveries WHERE instance_id = $1`, [INST]).catch(() => {})
+      await q(`DELETE FROM approval_assignments WHERE instance_id = $1`, [INST]).catch(() => {})
+      await q(`DELETE FROM approval_instances WHERE id = $1`, [INST]).catch(() => {})
+    }
   })
 
   it('P2: pending/failed sends are NEVER claimable — only a delivered card is actionable', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
@@ -232,6 +232,9 @@ function makeHarness(state: {
           status: 'pending',
           current_node_key: 'approval_1',
           policy_snapshot: {},
+          // P1-1: the card is for the STILL-active node/assignee, so the wrapper's live-assignment
+          // binding matches (buildSummary computes this EXISTS as has_active_assignment).
+          has_active_assignment: true,
         }],
       }
     }


### PR DESCRIPTION
**P1-1 of the owner REQUEST-CHANGES review (LIVE fix).** A stale approval card issued for NODE 1 stayed actionable after the instance advanced to NODE 2 (same assignee) and silently approved node 2 — the approver never saw node 2's context. LIVE on the shipped default (OA `work_notice_action_card`, Stream flag OFF); the action endpoint `POST /api/approval-card-deliveries/:deliveryId/actions` is guarded only by `authenticate + rbacGuard('approvals','act')`, no Stream-flag gate.

**Fix:** `buildSummary` additionally requires a LIVE active `approval_assignments` row matching the delivery's `node_key` + `recipient_user_id` (+ `entry_epoch` when the delivery carries one). Node/assignee match closes forward-advance via live state (node-1's seat flips `is_active=FALSE`); the epoch clause closes same-node re-entry (fresh epoch). Dual-read: NULL delivery epoch (legacy card) skips only the epoch clause and stays closed on node/assignee. This read-time binding is the authoritative guard.

**Schema:** additive nullable `entry_epoch` on `dingtalk_approval_card_deliveries`, persisted at send from the `approval.task_created` event's `task.entryEpoch`.

**Defense-in-depth:** wired the previously-dead `supersedeDingTalkApprovalCardDeliveriesForInstance` post-commit on node advance (best-effort; excludes the triggering card). The read-time binding stands alone even if the sweep never runs.

**Concurrency:** the engine already reduces concurrent duplicate approves to one (`dispatchAction`: instance `FOR UPDATE` + active-assignment check → 403 `APPROVAL_ASSIGNMENT_REQUIRED`); no claim-before-dispatch added.

**Verify:** 3 real-DB RED-before goldens (two-node web-first / same-node re-entry / positive) on ephemeral PG; two-node RED-before reproduced the live bug (binding reverted → node-1 card approves node-2); mutation-verified the node/assignee and epoch clauses are each load-bearing (Mutation B neutralizes only epoch → only the re-entry golden fails); full backend unit suite 5085 + sibling card-path real-DB 29 + `tsc --noEmit` all green.

**Caveat (intended dual-read trade):** a legacy card with NULL `entry_epoch` is protected against forward-advance but not same-node re-entry within its own node; new cards persist the epoch and are fully covered. Chosen to never break in-flight legacy cards.

Stream flag stays OFF; this fix is on the OA path too. Separate branches follow for P1-2 (cross-corp) and the P2 wire-contract fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
