### PR TITLE
feat(plm): Discussion Phase-3 write-relay — embed HTTP surface (Option A, HELD)

### DIFF
--- a/docs/development/plm-discussion-consumer-taskbook-20260709.md
+++ b/docs/development/plm-discussion-consumer-taskbook-20260709.md
@@ -111,7 +111,7 @@ interface PlmDiscussionProvider {
 > read-side `metasheet_review` gate in §6. Consumer implementation: Lane C
 > (`PLMAdapter.exchangeDiscussionSession` + the 6 write methods).
 
-> **Write-relay (server-side): Option A shipped, Option B deferred.**
+> **Write-relay (server-side): Option A (PROPOSED — owner-recommended, pending ratification), Option B deferred.**
 > `routes/plm-embed-discussion.ts` wires Lane C's adapter methods into the
 > actual `/api/plm-embed/discussion/...` HTTP surface an embedded BOM-review
 > writes through. Two designs were considered for how the discussion-session

--- a/docs/development/plm-discussion-consumer-taskbook-20260709.md
+++ b/docs/development/plm-discussion-consumer-taskbook-20260709.md
@@ -111,6 +111,38 @@ interface PlmDiscussionProvider {
 > read-side `metasheet_review` gate in §6. Consumer implementation: Lane C
 > (`PLMAdapter.exchangeDiscussionSession` + the 6 write methods).
 
+> **Write-relay (server-side): Option A shipped, Option B deferred.**
+> `routes/plm-embed-discussion.ts` wires Lane C's adapter methods into the
+> actual `/api/plm-embed/discussion/...` HTTP surface an embedded BOM-review
+> writes through. Two designs were considered for how the discussion-session
+> credential (minted by `exchangeDiscussionSession`) is held between the
+> exchange and the write call:
+>
+> - **Option A — stateless, single-use per write (shipped, the owner-chosen
+>   conservative default).** Every write request carries its own
+>   freshly-minted `bom_multitable` embed token; the relay runs the read
+>   relay's guards (feature_key / embed_origin / tenant cross-check),
+>   consumes that token's jti via the SAME shared single-use store the read
+>   relay uses, exchanges it for a discussion-session credential, holds the
+>   `access_token` in a request-local variable for the lifetime of the
+>   handler only, and lets it fall out of scope on return. No new stateful
+>   surface: nothing is cached, and a compromised process has nothing at
+>   rest to steal. Cost: one exchange round-trip per write, and a transient
+>   write failure after the jti is consumed still burns the token (the
+>   embed frontend must re-mint and retry).
+> - **Option B — server-side credential cache (deferred).** Cache the
+>   exchanged credential (e.g. keyed by embed session / part_id) across
+>   several writes within its TTL, trading the per-write exchange round-trip
+>   for a new credential-storage security surface (cache invalidation,
+>   cross-tenant/cross-user key scoping, at-rest exposure). Not built; would
+>   need its own Gate-2-style review before landing.
+>
+> The 6 write routes (`POST .../threads`, `POST .../threads/:id/comments`,
+> `PATCH .../threads/:id/comments/:commentId`, `DELETE
+> .../threads/:id/comments/:commentId`, `POST .../threads/:id/resolve`,
+> `POST .../threads/:id/reopen`) return only the write result — the
+> credential itself never appears in a response body or header.
+
 ## 5. Notifications
 
 - Cross-system dedup key = the Yuantus outbox occurrence nonce

--- a/docs/development/plm-discussion-consumer-taskbook-20260709.md
+++ b/docs/development/plm-discussion-consumer-taskbook-20260709.md
@@ -111,15 +111,16 @@ interface PlmDiscussionProvider {
 > read-side `metasheet_review` gate in §6. Consumer implementation: Lane C
 > (`PLMAdapter.exchangeDiscussionSession` + the 6 write methods).
 
-> **Write-relay (server-side): Option A (PROPOSED — owner-recommended, pending ratification), Option B deferred.**
+> **Write-relay (server-side): Option A (RATIFIED by owner 2026-07-11), Option B deferred.**
 > `routes/plm-embed-discussion.ts` wires Lane C's adapter methods into the
 > actual `/api/plm-embed/discussion/...` HTTP surface an embedded BOM-review
 > writes through. Two designs were considered for how the discussion-session
 > credential (minted by `exchangeDiscussionSession`) is held between the
 > exchange and the write call:
 >
-> - **Option A — stateless, single-use per write (PROPOSED — owner-recommended
->   at Gate-2 2026-07-11, pending final ratification; NOT yet shipped).** Every
+> - **Option A — stateless, single-use per write (RATIFIED by the owner at
+>   Gate-2 2026-07-11; Option B deferred). Merge pending the provider-first
+>   sequence.** Every
 >   write request carries its own freshly-minted `bom_multitable` embed token;
 >   the relay runs the read relay's guards (feature_key / embed_origin / tenant
 >   cross-check), consumes that token's jti via the SAME shared single-use store

--- a/docs/development/plm-discussion-consumer-taskbook-20260709.md
+++ b/docs/development/plm-discussion-consumer-taskbook-20260709.md
@@ -118,18 +118,28 @@ interface PlmDiscussionProvider {
 > credential (minted by `exchangeDiscussionSession`) is held between the
 > exchange and the write call:
 >
-> - **Option A — stateless, single-use per write (shipped, the owner-chosen
->   conservative default).** Every write request carries its own
->   freshly-minted `bom_multitable` embed token; the relay runs the read
->   relay's guards (feature_key / embed_origin / tenant cross-check),
->   consumes that token's jti via the SAME shared single-use store the read
->   relay uses, exchanges it for a discussion-session credential, holds the
->   `access_token` in a request-local variable for the lifetime of the
+> - **Option A — stateless, single-use per write (PROPOSED — owner-recommended
+>   at Gate-2 2026-07-11, pending final ratification; NOT yet shipped).** Every
+>   write request carries its own freshly-minted `bom_multitable` embed token;
+>   the relay runs the read relay's guards (feature_key / embed_origin / tenant
+>   cross-check), consumes that token's jti via the SAME shared single-use store
+>   the read relay uses, exchanges it for a discussion-session credential, holds
+>   the `access_token` in a request-local variable for the lifetime of the
 >   handler only, and lets it fall out of scope on return. No new stateful
->   surface: nothing is cached, and a compromised process has nothing at
->   rest to steal. Cost: one exchange round-trip per write, and a transient
->   write failure after the jti is consumed still burns the token (the
+>   surface on the relay side: nothing is cached, and a compromised process has
+>   nothing at rest to steal. Cost: one exchange round-trip per write, and a
+>   transient write failure after the jti is consumed still burns the token (the
 >   embed frontend must re-mint and retry).
+>   - **HARD PRECONDITION (owner Gate-2 2026-07-11), blocking flag-on:** the
+>     relay's single-use store is **defense-in-depth only** — the Yuantus
+>     pre-auth exchange endpoint (`POST /api/v1/auth/embed/discussion-session`)
+>     is reachable DIRECTLY, bypassing the relay's Redis consumption, so a valid
+>     embed token could otherwise be replayed to mint discussion-session
+>     credentials repeatedly within its TTL. Option A is only sound once the
+>     **provider** atomically consumes the embed token's jti at exchange time
+>     (Yuantus-side single-use table). `DISCUSSION_SESSION_ENABLED=true` must NOT
+>     be set until that provider-side single-use lands. Until the owner ratifies
+>     Option A, this section is a proposal, not a decision.
 > - **Option B — server-side credential cache (deferred).** Cache the
 >   exchanged credential (e.g. keyed by embed session / part_id) across
 >   several writes within its TTL, trading the per-write exchange round-trip

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -171,6 +171,7 @@ import workflowRouter from './routes/workflow'
 import workflowDesignerRouter from './routes/workflow-designer'
 import plmWorkbenchRouter from './routes/plm-workbench'
 import plmEmbedRouter from './routes/plm-embed'
+import plmEmbedDiscussionWriteRouter from './routes/plm-embed-discussion'
 import { createHostPluginStorage } from './plugins/plugin-durable-storage'
 import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
@@ -1141,6 +1142,7 @@ export class MetaSheetServer {
     if (plmEnabled) {
       this.app.use(plmWorkbenchRouter)
       this.app.use(plmEmbedRouter())
+      this.app.use(plmEmbedDiscussionWriteRouter())
     } else {
       this.app.use('/api/plm-workbench', disabledFeatureHandler('PLM workbench is disabled in this deployment'))
       this.app.use('/api/plm-embed', disabledFeatureHandler('PLM embed is disabled in this deployment'))

--- a/packages/core-backend/src/middleware/embed-token-auth.ts
+++ b/packages/core-backend/src/middleware/embed-token-auth.ts
@@ -16,6 +16,13 @@ declare global {
   namespace Express {
     interface Request {
       embedToken?: EmbedTokenClaims
+      // PLM-COLLAB Discussion Phase-3 WRITE (Option A, stateless single-use-per-write): the raw
+      // embed JWT string, set ONLY here, ONLY for the lifetime of this request. It exists solely
+      // so a write-relay route can pass it, unmodified, to PLMAdapter.exchangeDiscussionSession
+      // for a Yuantus-side discussion-session credential exchange -- it MUST NEVER be persisted,
+      // cached on any shared object (adapter/module/store), logged, or returned to the client.
+      // The read relay (plm-embed.ts) has no use for this and continues to read only req.embedToken.
+      embedTokenRaw?: string
     }
   }
 }
@@ -34,6 +41,7 @@ export function embedTokenAuth(req: Request, res: Response, next: NextFunction):
   }
   try {
     req.embedToken = verifyEmbedToken(token, { publicKeysByKid: publicKeys, audience: embedAudience() })
+    req.embedTokenRaw = token
   } catch {
     res.status(401).json({ ok: false, error: { code: 'INVALID_EMBED_TOKEN', message: 'invalid embed token' } })
     return

--- a/packages/core-backend/src/routes/plm-embed-discussion.ts
+++ b/packages/core-backend/src/routes/plm-embed-discussion.ts
@@ -1,0 +1,380 @@
+/**
+ * PLM-COLLAB Discussion Phase-3 WRITE relay (Lane C write-relay; taskbook
+ * docs/development/plm-discussion-consumer-taskbook-20260709.md §4's Gate-2 REWORKED contract,
+ * Yuantus provider #1188 ratified/merged).
+ *
+ * Wires PLMAdapter's 6 discussion write methods (+ exchangeDiscussionSession) into a dedicated
+ * write surface under the SAME `/api/plm-embed/` prefix as the read relay (plm-embed.ts) --
+ * whitelisted from the global session-JWT gate (jwt-middleware.ts's AUTH_WHITELIST prefix match)
+ * and gated solely by `embedTokenAuth`.
+ *
+ * **Design: Option A (stateless, single-use per write) -- the owner-chosen conservative default.**
+ * Every write request carries its OWN freshly-minted BOM-review embed token
+ * (`X-PLM-Embed-Token`, feature_key="bom_multitable"). The route:
+ *   1. runs the SAME guards as the read relay (feature_key / embed_origin / data-source resolve
+ *      + connect / tenant cross-check) and consumes the token's jti via the SAME shared single-use
+ *      store the read relay uses -- one embed token authorizes exactly one relay call, read OR
+ *      write, ever.
+ *   2. exchanges the raw embed JWT (`req.embedTokenRaw`, set by embedTokenAuth -- see that file's
+ *      docstring) for a Yuantus discussion-session credential via
+ *      `PLMAdapter.exchangeDiscussionSession`.
+ *   3. holds the credential's `access_token` in a LOCAL const for the lifetime of this handler
+ *      only, passes it straight into the matching write method, and lets it fall out of scope
+ *      when the handler returns. It is NEVER assigned to `req`, the adapter instance, module
+ *      scope, or any cache -- so there is no new stateful credential-storage surface (that is
+ *      explicitly deferred as "Option B", see the taskbook note this PR adds).
+ *   4. returns ONLY the write result (`result.data[0]`) -- the credential itself never appears in
+ *      any response body or header.
+ *
+ * A transient failure AFTER the jti is consumed (e.g. the provider write itself 5xx's) still
+ * burns the embed token -- Option A's tradeoff is explicitly one-shot; the embed frontend must
+ * re-mint and retry, not assume a second attempt is free.
+ */
+import { Router, type Request, type Response } from 'express'
+import { getDataSourceManager } from './data-sources'
+import { embedTokenAuth } from '../middleware/embed-token-auth'
+import { embedAllowedOrigins, embedDataSourceId } from '../auth/embed-config'
+import { consumeEmbedJti, embedJtiKey } from '../auth/embed-jti-store'
+import type { QueryResult } from '../data-adapters/BaseAdapter'
+import type {
+  AddCommentRequest,
+  CreateThreadRequest,
+  DiscussionSessionCredential,
+  DiscussionTargetType,
+  DiscussionThreadDetail,
+  EditCommentRequest,
+  ThreadTransitionRequest,
+} from '../data-adapters/PLMAdapter'
+import type { EmbedTokenClaims } from '../auth/embed-token-verify'
+
+const BOM_FEATURE_KEY = 'bom_multitable'
+const TARGET_TYPES: ReadonlySet<DiscussionTargetType> = new Set([
+  'item',
+  'item_version',
+  'file',
+  'eco',
+  'pdm_relationship',
+])
+
+interface PlmDiscussionWriteAdapter {
+  exchangeDiscussionSession(embedToken: string): Promise<QueryResult<DiscussionSessionCredential>>
+  createDiscussionThread(sessionToken: string, req: CreateThreadRequest): Promise<QueryResult<DiscussionThreadDetail>>
+  addDiscussionComment(sessionToken: string, threadId: string, req: AddCommentRequest): Promise<QueryResult<DiscussionThreadDetail>>
+  editDiscussionComment(sessionToken: string, threadId: string, commentId: string, req: EditCommentRequest): Promise<QueryResult<DiscussionThreadDetail>>
+  deleteDiscussionComment(sessionToken: string, threadId: string, commentId: string): Promise<QueryResult<DiscussionThreadDetail>>
+  resolveDiscussionThread(sessionToken: string, threadId: string, req?: ThreadTransitionRequest): Promise<QueryResult<DiscussionThreadDetail>>
+  reopenDiscussionThread(sessionToken: string, threadId: string, req?: ThreadTransitionRequest): Promise<QueryResult<DiscussionThreadDetail>>
+  // tenant/connect surface, same duck-type contract the read relay enforces
+  getEffectiveTenantId(): string | undefined
+  isConnected(): boolean
+  connect(): Promise<void>
+}
+
+function isPlmDiscussionWriteAdapter(adapter: unknown): adapter is PlmDiscussionWriteAdapter {
+  const a = adapter as Partial<PlmDiscussionWriteAdapter> | null
+  return typeof a?.exchangeDiscussionSession === 'function'
+    && typeof a?.createDiscussionThread === 'function'
+    && typeof a?.addDiscussionComment === 'function'
+    && typeof a?.editDiscussionComment === 'function'
+    && typeof a?.deleteDiscussionComment === 'function'
+    && typeof a?.resolveDiscussionThread === 'function'
+    && typeof a?.reopenDiscussionThread === 'function'
+    && typeof a?.getEffectiveTenantId === 'function'
+    && typeof a?.isConnected === 'function'
+    && typeof a?.connect === 'function'
+}
+
+/**
+ * Runs the read relay's exact guard sequence (feature_key -> embed_origin -> data-source resolve
+ * -> connect -> tenant cross-check -> single-use jti consume) and, on success, returns the
+ * verified claims + a connected adapter. On failure it has already written the response and
+ * returns `null` -- callers must return immediately without touching the response again.
+ */
+async function runEmbedWriteGuards(req: Request, res: Response): Promise<{ claims: EmbedTokenClaims; adapter: PlmDiscussionWriteAdapter } | null> {
+  const claims = req.embedToken!
+
+  if (claims.feature_key !== BOM_FEATURE_KEY) {
+    res.status(403).json({ ok: false, error: { code: 'EMBED_FEATURE_MISMATCH', message: 'token not scoped to bom_multitable' } })
+    return null
+  }
+  const origin = typeof claims.embed_origin === 'string' ? claims.embed_origin : ''
+  if (!origin || !embedAllowedOrigins().includes(origin)) {
+    res.status(403).json({ ok: false, error: { code: 'EMBED_ORIGIN_NOT_ALLOWED', message: 'embed origin not allowed' } })
+    return null
+  }
+
+  const dataSourceId = embedDataSourceId()
+  if (!dataSourceId) {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source not configured' } })
+    return null
+  }
+
+  let adapter: unknown
+  try {
+    adapter = getDataSourceManager().getDataSource(dataSourceId)
+  } catch {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unavailable' } })
+    return null
+  }
+  if (!isPlmDiscussionWriteAdapter(adapter)) {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unsupported' } })
+    return null
+  }
+
+  try {
+    if (!adapter.isConnected()) await adapter.connect()
+  } catch {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unavailable' } })
+    return null
+  }
+
+  // Same fail-closed cross-check as the read relay: compare against the tenant ACTUALLY served,
+  // before consuming the jti or doing any write.
+  const servedTenantId = adapter.getEffectiveTenantId()
+  if (!servedTenantId || claims.tenant_id !== servedTenantId) {
+    res.status(403).json({ ok: false, error: { code: 'EMBED_TENANT_MISMATCH', message: 'token tenant does not match the embed data source tenant' } })
+    return null
+  }
+
+  // Single-use, Option A: one embed token authorizes exactly one relay call (read OR write).
+  // Consumed AFTER all other guards, BEFORE the session exchange / write -- mirrors the read
+  // relay's ordering so a 403 above never burns the token.
+  const jti = typeof claims.jti === 'string' ? claims.jti : ''
+  if (!jti) {
+    res.status(401).json({ ok: false, error: { code: 'INVALID_EMBED_TOKEN', message: 'missing jti' } })
+    return null
+  }
+  const now = Math.floor(Date.now() / 1000)
+  const ttl = Math.min(typeof claims.exp === 'number' ? claims.exp - now : 0, 600)
+  if (ttl < 1) {
+    res.status(401).json({ ok: false, error: { code: 'INVALID_EMBED_TOKEN', message: 'token expired' } })
+    return null
+  }
+  let firstUse: boolean
+  try {
+    firstUse = await consumeEmbedJti(
+      embedJtiKey({
+        aud: claims.aud ?? '',
+        feature_key: claims.feature_key ?? '',
+        tenant_id: claims.tenant_id ?? '',
+        part_id: claims.part_id,
+        jti,
+      }),
+      ttl,
+    )
+  } catch {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed replay store unavailable' } })
+    return null
+  }
+  if (!firstUse) {
+    res.status(401).json({ ok: false, error: { code: 'EMBED_TOKEN_REPLAYED', message: 'embed token already used' } })
+    return null
+  }
+
+  return { claims, adapter }
+}
+
+/**
+ * Exchanges the request's raw embed token for a discussion-session credential and returns ONLY
+ * its `access_token`, as a value the caller must keep local. Never logs, never returns the
+ * credential object itself. A failed/empty exchange is a uniform 401 -- the adapter already
+ * collapses "dark-flag off" and "bad token" into the same shape upstream, so this must not
+ * re-introduce a distinction (no oracle).
+ */
+async function exchangeForAccessToken(req: Request, res: Response, adapter: PlmDiscussionWriteAdapter): Promise<string | null> {
+  const rawToken = req.embedTokenRaw
+  if (!rawToken) {
+    // Should be unreachable (embedTokenAuth always sets it on success), but fail closed.
+    res.status(401).json({ ok: false, error: { code: 'EMBED_SESSION_EXCHANGE_FAILED', message: 'discussion session exchange failed' } })
+    return null
+  }
+  const cred = await adapter.exchangeDiscussionSession(rawToken)
+  const credential = cred.data[0]
+  if (cred.error || !credential || !credential.access_token) {
+    res.status(401).json({ ok: false, error: { code: 'EMBED_SESSION_EXCHANGE_FAILED', message: 'discussion session exchange failed' } })
+    return null
+  }
+  return credential.access_token
+}
+
+/** Reads a provider HTTP status off a QueryResult.error, mirroring routes/plm-workbench.ts's providerErrorStatus. */
+function providerErrorStatus(error: unknown): number | null {
+  const candidate = error as { response?: { status?: unknown } } | null
+  const status = candidate?.response?.status
+  return typeof status === 'number' ? status : null
+}
+
+const KNOWN_PROVIDER_STATUSES = new Set([400, 401, 403, 404, 409, 422])
+
+/**
+ * Maps a write method's QueryResult.error to a relay HTTP response. The provider's own status is
+ * authoritative (taskbook §2's "Yuantus 401/403/404/422 responses are authoritative" rule) for
+ * the small set of statuses this relay understands; anything else (network failure, unexpected
+ * status) degrades to a generic 502 -- a write must never silently succeed on failure, and the
+ * relay must never echo the raw upstream error body/message (no oracle on internals).
+ */
+function respondWriteError(res: Response, error: Error): void {
+  const status = providerErrorStatus(error)
+  if (status !== null && KNOWN_PROVIDER_STATUSES.has(status)) {
+    res.status(status).json({ ok: false, error: { code: 'EMBED_DISCUSSION_WRITE_REJECTED', message: 'the discussion write was rejected' } })
+    return
+  }
+  res.status(502).json({ ok: false, error: { code: 'EMBED_DISCUSSION_WRITE_UNAVAILABLE', message: 'the discussion write could not be completed' } })
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0
+}
+
+function optionalMentionedUserIds(body: Record<string, unknown>): number[] | undefined {
+  const v = body.mentioned_user_ids
+  if (v === undefined) return undefined
+  return Array.isArray(v) && v.every((x) => typeof x === 'number') ? v : undefined
+}
+
+function optionalAnchor(body: Record<string, unknown>): Record<string, unknown> | null | undefined {
+  const v = body.anchor
+  if (v === undefined) return undefined
+  if (v === null) return null
+  return typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined
+}
+
+function badBody(res: Response, message: string): void {
+  res.status(422).json({ ok: false, error: { code: 'EMBED_DISCUSSION_INVALID_BODY', message } })
+}
+
+export default function plmEmbedDiscussionWriteRouter(): Router {
+  const router = Router()
+
+  // POST /api/plm-embed/discussion/threads -- open a new thread.
+  router.post('/api/plm-embed/discussion/threads', embedTokenAuth, async (req: Request, res: Response) => {
+    const guarded = await runEmbedWriteGuards(req, res)
+    if (!guarded) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const targetType = body.target_type
+    if (typeof targetType !== 'string' || !TARGET_TYPES.has(targetType as DiscussionTargetType)) {
+      return badBody(res, 'target_type must be one of item, item_version, file, eco, pdm_relationship')
+    }
+    if (!isNonEmptyString(body.target_id)) return badBody(res, 'target_id is required')
+    if (!isNonEmptyString(body.body)) return badBody(res, 'body is required')
+    const title = typeof body.title === 'string' ? body.title : undefined
+    const mentioned_user_ids = optionalMentionedUserIds(body)
+    const anchor = optionalAnchor(body)
+    const createReq: CreateThreadRequest = {
+      target_type: targetType as DiscussionTargetType,
+      target_id: body.target_id as string,
+      body: body.body as string,
+      ...(title !== undefined ? { title } : {}),
+      ...(mentioned_user_ids !== undefined ? { mentioned_user_ids } : {}),
+      ...(anchor !== undefined ? { anchor } : {}),
+    }
+
+    const accessToken = await exchangeForAccessToken(req, res, guarded.adapter)
+    if (!accessToken) return
+    const result = await guarded.adapter.createDiscussionThread(accessToken, createReq)
+    if (result.error) return respondWriteError(res, result.error)
+    return res.json({ ok: true, data: result.data[0] ?? null })
+  })
+
+  // POST /api/plm-embed/discussion/threads/:threadId/comments -- reply on a thread.
+  router.post('/api/plm-embed/discussion/threads/:threadId/comments', embedTokenAuth, async (req: Request, res: Response) => {
+    const guarded = await runEmbedWriteGuards(req, res)
+    if (!guarded) return
+
+    const threadId = req.params.threadId
+    const body = (req.body ?? {}) as Record<string, unknown>
+    if (!isNonEmptyString(body.body)) return badBody(res, 'body is required')
+    const parent_comment_id = typeof body.parent_comment_id === 'string' ? body.parent_comment_id : undefined
+    const mentioned_user_ids = optionalMentionedUserIds(body)
+    const anchor = optionalAnchor(body)
+    const commentReq: AddCommentRequest = {
+      body: body.body as string,
+      ...(parent_comment_id !== undefined ? { parent_comment_id } : {}),
+      ...(mentioned_user_ids !== undefined ? { mentioned_user_ids } : {}),
+      ...(anchor !== undefined ? { anchor } : {}),
+    }
+
+    const accessToken = await exchangeForAccessToken(req, res, guarded.adapter)
+    if (!accessToken) return
+    const result = await guarded.adapter.addDiscussionComment(accessToken, threadId, commentReq)
+    if (result.error) return respondWriteError(res, result.error)
+    return res.json({ ok: true, data: result.data[0] ?? null })
+  })
+
+  // PATCH /api/plm-embed/discussion/threads/:threadId/comments/:commentId -- edit a comment body.
+  router.patch('/api/plm-embed/discussion/threads/:threadId/comments/:commentId', embedTokenAuth, async (req: Request, res: Response) => {
+    const guarded = await runEmbedWriteGuards(req, res)
+    if (!guarded) return
+
+    const { threadId, commentId } = req.params
+    const body = (req.body ?? {}) as Record<string, unknown>
+    if (!isNonEmptyString(body.body)) return badBody(res, 'body is required')
+    const editReq: EditCommentRequest = { body: body.body as string }
+
+    const accessToken = await exchangeForAccessToken(req, res, guarded.adapter)
+    if (!accessToken) return
+    const result = await guarded.adapter.editDiscussionComment(accessToken, threadId, commentId, editReq)
+    if (result.error) return respondWriteError(res, result.error)
+    return res.json({ ok: true, data: result.data[0] ?? null })
+  })
+
+  // DELETE /api/plm-embed/discussion/threads/:threadId/comments/:commentId -- soft-delete a comment.
+  router.delete('/api/plm-embed/discussion/threads/:threadId/comments/:commentId', embedTokenAuth, async (req: Request, res: Response) => {
+    const guarded = await runEmbedWriteGuards(req, res)
+    if (!guarded) return
+
+    const { threadId, commentId } = req.params
+    const accessToken = await exchangeForAccessToken(req, res, guarded.adapter)
+    if (!accessToken) return
+    const result = await guarded.adapter.deleteDiscussionComment(accessToken, threadId, commentId)
+    if (result.error) return respondWriteError(res, result.error)
+    return res.json({ ok: true, data: result.data[0] ?? null })
+  })
+
+  // POST /api/plm-embed/discussion/threads/:threadId/resolve -- transition a thread to resolved.
+  router.post('/api/plm-embed/discussion/threads/:threadId/resolve', embedTokenAuth, async (req: Request, res: Response) => {
+    const guarded = await runEmbedWriteGuards(req, res)
+    if (!guarded) return
+
+    const threadId = req.params.threadId
+    const transitionReq = parseTransitionRequest(req.body)
+    if (transitionReq === undefined) return badBody(res, 'comment must be a string and mentioned_user_ids must be number[] when present')
+
+    const accessToken = await exchangeForAccessToken(req, res, guarded.adapter)
+    if (!accessToken) return
+    const result = await guarded.adapter.resolveDiscussionThread(accessToken, threadId, transitionReq)
+    if (result.error) return respondWriteError(res, result.error)
+    return res.json({ ok: true, data: result.data[0] ?? null })
+  })
+
+  // POST /api/plm-embed/discussion/threads/:threadId/reopen -- transition a resolved thread back to open.
+  router.post('/api/plm-embed/discussion/threads/:threadId/reopen', embedTokenAuth, async (req: Request, res: Response) => {
+    const guarded = await runEmbedWriteGuards(req, res)
+    if (!guarded) return
+
+    const threadId = req.params.threadId
+    const transitionReq = parseTransitionRequest(req.body)
+    if (transitionReq === undefined) return badBody(res, 'comment must be a string and mentioned_user_ids must be number[] when present')
+
+    const accessToken = await exchangeForAccessToken(req, res, guarded.adapter)
+    if (!accessToken) return
+    const result = await guarded.adapter.reopenDiscussionThread(accessToken, threadId, transitionReq)
+    if (result.error) return respondWriteError(res, result.error)
+    return res.json({ ok: true, data: result.data[0] ?? null })
+  })
+
+  return router
+}
+
+/** `undefined` body -> {} (both resolve/reopen take an optional transition). `null` return = invalid shape. */
+function parseTransitionRequest(rawBody: unknown): ThreadTransitionRequest | null | undefined {
+  const body = (rawBody ?? {}) as Record<string, unknown>
+  if (body.comment !== undefined && typeof body.comment !== 'string') return undefined
+  const mentioned_user_ids = optionalMentionedUserIds(body)
+  if (body.mentioned_user_ids !== undefined && mentioned_user_ids === undefined) return undefined
+  const req: ThreadTransitionRequest = {}
+  if (typeof body.comment === 'string') req.comment = body.comment
+  if (mentioned_user_ids !== undefined) req.mentioned_user_ids = mentioned_user_ids
+  return req
+}

--- a/packages/core-backend/src/routes/plm-embed-discussion.ts
+++ b/packages/core-backend/src/routes/plm-embed-discussion.ts
@@ -258,9 +258,22 @@ export default function plmEmbedDiscussionWriteRouter(): Router {
     }
     if (!isNonEmptyString(body.target_id)) return badBody(res, 'target_id is required')
     if (!isNonEmptyString(body.body)) return badBody(res, 'body is required')
+    // Distinguish an ABSENT optional field (omit it) from a PRESENT-but-wrong-typed one
+    // (reject 422). Silently coercing a bad value to `undefined` and omitting it would let a
+    // malformed mention/anchor/title write succeed DEGRADED (no mention / no anchor / no title)
+    // when the caller should have gotten a 422 -- mirrors parseTransitionRequest's guard below.
+    if (body.title !== undefined && typeof body.title !== 'string') {
+      return badBody(res, 'title must be a string when present')
+    }
     const title = typeof body.title === 'string' ? body.title : undefined
     const mentioned_user_ids = optionalMentionedUserIds(body)
+    if (body.mentioned_user_ids !== undefined && mentioned_user_ids === undefined) {
+      return badBody(res, 'mentioned_user_ids must be number[] when present')
+    }
     const anchor = optionalAnchor(body)
+    if (body.anchor !== undefined && anchor === undefined) {
+      return badBody(res, 'anchor must be an object or null when present')
+    }
     const createReq: CreateThreadRequest = {
       target_type: targetType as DiscussionTargetType,
       target_id: body.target_id as string,
@@ -285,9 +298,20 @@ export default function plmEmbedDiscussionWriteRouter(): Router {
     const threadId = req.params.threadId
     const body = (req.body ?? {}) as Record<string, unknown>
     if (!isNonEmptyString(body.body)) return badBody(res, 'body is required')
+    // Present-but-wrong-typed optional fields reject 422 (never silently omit) -- see the
+    // create-thread route above for the rationale.
+    if (body.parent_comment_id !== undefined && typeof body.parent_comment_id !== 'string') {
+      return badBody(res, 'parent_comment_id must be a string when present')
+    }
     const parent_comment_id = typeof body.parent_comment_id === 'string' ? body.parent_comment_id : undefined
     const mentioned_user_ids = optionalMentionedUserIds(body)
+    if (body.mentioned_user_ids !== undefined && mentioned_user_ids === undefined) {
+      return badBody(res, 'mentioned_user_ids must be number[] when present')
+    }
     const anchor = optionalAnchor(body)
+    if (body.anchor !== undefined && anchor === undefined) {
+      return badBody(res, 'anchor must be an object or null when present')
+    }
     const commentReq: AddCommentRequest = {
       body: body.body as string,
       ...(parent_comment_id !== undefined ? { parent_comment_id } : {}),

--- a/packages/core-backend/src/routes/plm-embed-discussion.ts
+++ b/packages/core-backend/src/routes/plm-embed-discussion.ts
@@ -8,8 +8,8 @@
  * whitelisted from the global session-JWT gate (jwt-middleware.ts's AUTH_WHITELIST prefix match)
  * and gated solely by `embedTokenAuth`.
  *
- * **Design: Option A (stateless, single-use per write) -- PROPOSED, owner-recommended at Gate-2
- * 2026-07-11, pending final ratification (NOT yet the owner's ratified choice).**
+ * **Design: Option A (stateless, single-use per write) -- RATIFIED by the owner at Gate-2
+ * 2026-07-11 (Option B, a server-side credential cache, remains deferred).**
  * Every write request carries its OWN freshly-minted BOM-review embed token
  * (`X-PLM-Embed-Token`, feature_key="bom_multitable"). The route:
  *   1. runs the SAME guards as the read relay (feature_key / embed_origin / data-source resolve

--- a/packages/core-backend/src/routes/plm-embed-discussion.ts
+++ b/packages/core-backend/src/routes/plm-embed-discussion.ts
@@ -8,7 +8,8 @@
  * whitelisted from the global session-JWT gate (jwt-middleware.ts's AUTH_WHITELIST prefix match)
  * and gated solely by `embedTokenAuth`.
  *
- * **Design: Option A (stateless, single-use per write) -- the owner-chosen conservative default.**
+ * **Design: Option A (stateless, single-use per write) -- PROPOSED, owner-recommended at Gate-2
+ * 2026-07-11, pending final ratification (NOT yet the owner's ratified choice).**
  * Every write request carries its OWN freshly-minted BOM-review embed token
  * (`X-PLM-Embed-Token`, feature_key="bom_multitable"). The route:
  *   1. runs the SAME guards as the read relay (feature_key / embed_origin / data-source resolve

--- a/packages/core-backend/tests/unit/plm-embed-discussion-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-discussion-routes.test.ts
@@ -1,0 +1,384 @@
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Controllable DataSourceManager mock.
+const dsMocks = vi.hoisted(() => ({ getDataSource: vi.fn() }))
+
+// Controllable single-use jti store -- same shared store the read relay uses.
+const jtiMocks = vi.hoisted(() => ({ consume: vi.fn() }))
+vi.mock('../../src/auth/embed-jti-store', () => ({
+  consumeEmbedJti: (...args: unknown[]) => jtiMocks.consume(...args),
+  embedJtiKey: (scope: { jti?: unknown }) => `plm-embed:jti:${String(scope.jti)}`,
+}))
+
+vi.mock('../../src/db/sharding/tenant-context', () => ({ extractTenantFromHeaders: () => undefined }))
+vi.mock('../../src/metrics/metrics', () => ({ metrics: new Proxy({}, { get: () => ({ inc: () => {} }) }) }))
+vi.mock('../../src/auth/AuthService', () => ({ authService: {} }))
+vi.mock('../../src/routes/data-sources', () => ({
+  getDataSourceManager: () => ({ getDataSource: dsMocks.getDataSource }),
+}))
+
+import { isWhitelisted } from '../../src/auth/jwt-middleware'
+import plmEmbedDiscussionWriteRouter from '../../src/routes/plm-embed-discussion'
+
+const KID = 'embed-1'
+const AUD = 'metasheet2.embed'
+const ORIGIN = 'https://plm.example.com'
+const DS_ID = 'plm-ds'
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519')
+const PUB_B64 = Buffer.from((publicKey.export({ format: 'jwk' }) as { x: string }).x, 'base64url').toString('base64')
+
+let jtiCounter = 0
+function mint(overrides: Record<string, unknown> = {}, kid = KID): string {
+  const now = Math.floor(Date.now() / 1000)
+  jtiCounter += 1
+  const claims = {
+    sub: '7',
+    tenant_id: 'default',
+    part_id: 'P1',
+    feature_key: 'bom_multitable',
+    aud: AUD,
+    embed_origin: ORIGIN,
+    iat: now,
+    exp: now + 120,
+    jti: `j-${jtiCounter}`,
+    typ: 'embed',
+    ...overrides,
+  }
+  const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT', kid })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url')
+  const sig = crypto.sign(null, Buffer.from(`${header}.${payload}`, 'ascii'), privateKey).toString('base64url')
+  return `${header}.${payload}.${sig}`
+}
+
+const SESSION_TOKEN = 'discussion-session-secret-abc123'
+const THREAD_DETAIL = {
+  id: 't1',
+  target_type: 'item',
+  target_id: 'P1',
+  title: 'Discuss',
+  status: 'open',
+  created_by_id: 1,
+  created_at: '2026-07-11T00:00:00Z',
+  resolved_by_id: null,
+  resolved_at: null,
+  last_comment_at: '2026-07-11T00:00:00Z',
+  comment_count: 1,
+  anchor: null,
+  comments: [],
+}
+
+function credentialResult(overrides: Record<string, unknown> = {}) {
+  return {
+    data: [{ access_token: SESSION_TOKEN, token_type: 'bearer', expires_in: 300, aud: 'discussion', ...overrides }],
+    metadata: { totalCount: 1 },
+  }
+}
+
+// A COMPLETE PlmDiscussionWriteAdapter mock (exchange + all 6 write methods + tenant/connect
+// surface). Each write method defaults to returning THREAD_DETAIL wrapped success; override any
+// via `opts` to simulate a provider error / different payload.
+function fullAdapter(opts: {
+  exchangeDiscussionSession?: ReturnType<typeof vi.fn>
+  createDiscussionThread?: ReturnType<typeof vi.fn>
+  addDiscussionComment?: ReturnType<typeof vi.fn>
+  editDiscussionComment?: ReturnType<typeof vi.fn>
+  deleteDiscussionComment?: ReturnType<typeof vi.fn>
+  resolveDiscussionThread?: ReturnType<typeof vi.fn>
+  reopenDiscussionThread?: ReturnType<typeof vi.fn>
+  tenant?: string | undefined
+  connected?: boolean
+  connect?: ReturnType<typeof vi.fn>
+} = {}) {
+  const writeOk = () => vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } })
+  return {
+    exchangeDiscussionSession: opts.exchangeDiscussionSession ?? vi.fn().mockResolvedValue(credentialResult()),
+    createDiscussionThread: opts.createDiscussionThread ?? writeOk(),
+    addDiscussionComment: opts.addDiscussionComment ?? writeOk(),
+    editDiscussionComment: opts.editDiscussionComment ?? writeOk(),
+    deleteDiscussionComment: opts.deleteDiscussionComment ?? writeOk(),
+    resolveDiscussionThread: opts.resolveDiscussionThread ?? writeOk(),
+    reopenDiscussionThread: opts.reopenDiscussionThread ?? writeOk(),
+    getEffectiveTenantId: () => ('tenant' in opts ? opts.tenant : 'default'),
+    isConnected: () => opts.connected ?? true,
+    connect: opts.connect ?? vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function providerError(status: number, message = 'rejected') {
+  return Object.assign(new Error(message), { response: { status, data: { detail: message } } })
+}
+
+function buildApp() {
+  const app = express()
+  app.use(express.json())
+  // Reproduce the REAL global gate (index.ts): whitelisted -> through; else /api/* needs the
+  // session JWT (stood in here by a 401, exactly what jwtAuthMiddleware does on a missing token).
+  app.use((req, res, next) => {
+    if (isWhitelisted(req.path)) return next()
+    if (req.path.startsWith('/api/')) return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED' } })
+    return next()
+  })
+  app.use(plmEmbedDiscussionWriteRouter())
+  return app
+}
+
+const THREADS_URL = '/api/plm-embed/discussion/threads'
+const COMMENTS_URL = (threadId = 't1') => `/api/plm-embed/discussion/threads/${threadId}/comments`
+const COMMENT_URL = (threadId = 't1', commentId = 'c1') => `/api/plm-embed/discussion/threads/${threadId}/comments/${commentId}`
+const RESOLVE_URL = (threadId = 't1') => `/api/plm-embed/discussion/threads/${threadId}/resolve`
+const REOPEN_URL = (threadId = 't1') => `/api/plm-embed/discussion/threads/${threadId}/reopen`
+
+const CREATE_BODY = { target_type: 'item', target_id: 'P1', body: 'hello' }
+
+describe('PLM embed discussion WRITE relay (Discussion Phase-3 write-relay, Option A)', () => {
+  beforeEach(() => {
+    dsMocks.getDataSource.mockReset()
+    jtiMocks.consume.mockReset()
+    jtiMocks.consume.mockResolvedValue(true) // default: first use
+    process.env.YUANTUS_EMBED_PUBLIC_KEY = PUB_B64
+    process.env.YUANTUS_EMBED_KEY_ID = KID
+    process.env.PLM_EMBED_AUDIENCE = AUD
+    process.env.PLM_EMBED_ALLOWED_ORIGINS = ORIGIN
+    process.env.PLM_EMBED_DATA_SOURCE_ID = DS_ID
+  })
+  afterEach(() => {
+    for (const k of ['YUANTUS_EMBED_PUBLIC_KEYS', 'YUANTUS_EMBED_PUBLIC_KEY', 'YUANTUS_EMBED_KEY_ID', 'PLM_EMBED_AUDIENCE', 'PLM_EMBED_ALLOWED_ORIGINS', 'PLM_EMBED_DATA_SOURCE_ID']) delete process.env[k]
+  })
+
+  it('the write routes are whitelisted from the global session gate (same prefix as the read relay)', () => {
+    expect(isWhitelisted(THREADS_URL)).toBe(true)
+    expect(isWhitelisted(COMMENTS_URL())).toBe(true)
+    expect(isWhitelisted(RESOLVE_URL())).toBe(true)
+  })
+
+  // --- happy path + no-credential-leak (load-bearing security test) ---
+
+  it('happy write: create a thread -> 200, exchange used, credential NEVER in the response body or headers', async () => {
+    const createDiscussionThread = vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } })
+    const exchangeDiscussionSession = vi.fn().mockResolvedValue(credentialResult())
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ createDiscussionThread, exchangeDiscussionSession }))
+
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toEqual(THREAD_DETAIL)
+    expect(exchangeDiscussionSession).toHaveBeenCalledTimes(1)
+    expect(createDiscussionThread).toHaveBeenCalledWith(SESSION_TOKEN, expect.objectContaining({ target_type: 'item', target_id: 'P1', body: 'hello' }))
+
+    // The credential must not leak anywhere in the response.
+    const serializedBody = JSON.stringify(res.body)
+    expect(serializedBody).not.toContain(SESSION_TOKEN)
+    expect(serializedBody).not.toContain('access_token')
+    const serializedHeaders = JSON.stringify(res.headers)
+    expect(serializedHeaders).not.toContain(SESSION_TOKEN)
+  })
+
+  it('NO CACHING: two sequential requests (two fresh embed tokens) both call exchangeDiscussionSession -- no cred is reused/cached', async () => {
+    const exchangeDiscussionSession = vi.fn().mockResolvedValue(credentialResult())
+    const createDiscussionThread = vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionSession, createDiscussionThread }))
+
+    const app = buildApp()
+    const res1 = await request(app).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
+    const res2 = await request(app).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
+
+    expect(res1.status).toBe(200)
+    expect(res2.status).toBe(200)
+    expect(exchangeDiscussionSession).toHaveBeenCalledTimes(2) // fired on BOTH, not cached after the first
+    // each exchange used a DIFFERENT raw token (distinct jti-bearing mints), never a reused value
+    const [firstArg] = exchangeDiscussionSession.mock.calls[0]
+    const [secondArg] = exchangeDiscussionSession.mock.calls[1]
+    expect(firstArg).not.toEqual(secondArg)
+  })
+
+  // --- exchange failure -> uniform 401 ---
+
+  it('exchange failure (adapter returns error) -> 401, write method never called', async () => {
+    const exchangeDiscussionSession = vi.fn().mockResolvedValue({ data: [], error: new Error('exchange rejected') })
+    const createDiscussionThread = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionSession, createDiscussionThread }))
+
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('EMBED_SESSION_EXCHANGE_FAILED')
+    expect(createDiscussionThread).not.toHaveBeenCalled()
+  })
+
+  it('exchange returns no data (dark-flag-off shape) -> the SAME uniform 401 as a bad token (no oracle)', async () => {
+    const exchangeDiscussionSession = vi.fn().mockResolvedValue({ data: [] })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionSession }))
+
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('EMBED_SESSION_EXCHANGE_FAILED')
+  })
+
+  // --- provider write errors propagated ---
+
+  it('provider 403 (write-back entitlement denied) is propagated as 403', async () => {
+    const createDiscussionThread = vi.fn().mockResolvedValue({ data: [], error: providerError(403) })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ createDiscussionThread }))
+
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
+
+    expect(res.status).toBe(403)
+    expect(res.body.ok).toBe(false)
+  })
+
+  it('provider 404 (unknown thread) is propagated as 404 on the comment route', async () => {
+    const addDiscussionComment = vi.fn().mockResolvedValue({ data: [], error: providerError(404) })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ addDiscussionComment }))
+
+    const res = await request(buildApp()).post(COMMENTS_URL('missing-thread')).set('X-PLM-Embed-Token', mint()).send({ body: 'hi' })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('provider 422 (validation failure) is propagated as 422', async () => {
+    const editDiscussionComment = vi.fn().mockResolvedValue({ data: [], error: providerError(422) })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ editDiscussionComment }))
+
+    const res = await request(buildApp()).patch(COMMENT_URL()).set('X-PLM-Embed-Token', mint()).send({ body: 'edited' })
+
+    expect(res.status).toBe(422)
+  })
+
+  it('a network-level / unrecognized provider failure degrades to 502, never a silent 200', async () => {
+    const resolveDiscussionThread = vi.fn().mockResolvedValue({ data: [], error: new Error('fetch failed') })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ resolveDiscussionThread }))
+
+    const res = await request(buildApp()).post(RESOLVE_URL()).set('X-PLM-Embed-Token', mint()).send({})
+
+    expect(res.status).toBe(502)
+  })
+
+  // --- jti single-use / Option A ---
+
+  it('jti reuse (already consumed) -> 401 EMBED_TOKEN_REPLAYED, exchange never attempted', async () => {
+    jtiMocks.consume.mockResolvedValue(false)
+    const exchangeDiscussionSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionSession }))
+
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('EMBED_TOKEN_REPLAYED')
+    expect(exchangeDiscussionSession).not.toHaveBeenCalled()
+  })
+
+  it('a token with no jti -> 401, exchange never attempted', async () => {
+    const exchangeDiscussionSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionSession }))
+
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint({ jti: undefined })).send(CREATE_BODY)
+
+    expect(res.status).toBe(401)
+    expect(jtiMocks.consume).not.toHaveBeenCalled()
+    expect(exchangeDiscussionSession).not.toHaveBeenCalled()
+  })
+
+  // --- feature_key / origin / tenant guards (shared with the read relay) ---
+
+  it('a token scoped to a DIFFERENT feature -> 403, nothing downstream called', async () => {
+    const exchangeDiscussionSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionSession }))
+
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint({ feature_key: 'approval_automation' })).send(CREATE_BODY)
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_FEATURE_MISMATCH')
+    expect(exchangeDiscussionSession).not.toHaveBeenCalled()
+  })
+
+  it('embed_origin not in the allowlist -> 403', async () => {
+    dsMocks.getDataSource.mockReturnValue(fullAdapter())
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint({ embed_origin: 'https://evil.example.com' })).send(CREATE_BODY)
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_ORIGIN_NOT_ALLOWED')
+  })
+
+  it('token tenant does not match the served tenant -> 403, jti never consumed, exchange never attempted', async () => {
+    const exchangeDiscussionSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ tenant: 'tenant-b', exchangeDiscussionSession }))
+
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint({ tenant_id: 'tenant-a' })).send(CREATE_BODY)
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_TENANT_MISMATCH')
+    expect(jtiMocks.consume).not.toHaveBeenCalled()
+    expect(exchangeDiscussionSession).not.toHaveBeenCalled()
+  })
+
+  it('no embed token -> 401 (embedTokenAuth itself)', async () => {
+    const res = await request(buildApp()).post(THREADS_URL).send(CREATE_BODY)
+    expect(res.status).toBe(401)
+  })
+
+  // --- body validation / whitelisting ---
+
+  it('thread create missing target_type -> 422, nothing downstream called', async () => {
+    const exchangeDiscussionSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionSession }))
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send({ target_id: 'P1', body: 'hi' })
+    expect(res.status).toBe(422)
+    expect(res.body.error.code).toBe('EMBED_DISCUSSION_INVALID_BODY')
+    expect(exchangeDiscussionSession).not.toHaveBeenCalled()
+  })
+
+  it('thread create with an unknown target_type -> 422', async () => {
+    dsMocks.getDataSource.mockReturnValue(fullAdapter())
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send({ target_type: 'bogus', target_id: 'P1', body: 'hi' })
+    expect(res.status).toBe(422)
+  })
+
+  it('comment missing body -> 422', async () => {
+    dsMocks.getDataSource.mockReturnValue(fullAdapter())
+    const res = await request(buildApp()).post(COMMENTS_URL()).set('X-PLM-Embed-Token', mint()).send({})
+    expect(res.status).toBe(422)
+  })
+
+  it('edit comment missing body -> 422', async () => {
+    dsMocks.getDataSource.mockReturnValue(fullAdapter())
+    const res = await request(buildApp()).patch(COMMENT_URL()).set('X-PLM-Embed-Token', mint()).send({})
+    expect(res.status).toBe(422)
+  })
+
+  // --- per-route dispatch smoke tests (each route calls the RIGHT adapter method with the RIGHT args) ---
+
+  it('delete comment: DELETE dispatches to deleteDiscussionComment with (token, threadId, commentId)', async () => {
+    const deleteDiscussionComment = vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ deleteDiscussionComment }))
+
+    const res = await request(buildApp()).delete(COMMENT_URL('t9', 'c9')).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(200)
+    expect(deleteDiscussionComment).toHaveBeenCalledWith(SESSION_TOKEN, 't9', 'c9')
+  })
+
+  it('resolve: POST .../resolve dispatches to resolveDiscussionThread with an optional transition body', async () => {
+    const resolveDiscussionThread = vi.fn().mockResolvedValue({ data: [{ ...THREAD_DETAIL, status: 'resolved' }], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ resolveDiscussionThread }))
+
+    const res = await request(buildApp()).post(RESOLVE_URL('t9')).set('X-PLM-Embed-Token', mint()).send({ comment: 'done' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('resolved')
+    expect(resolveDiscussionThread).toHaveBeenCalledWith(SESSION_TOKEN, 't9', expect.objectContaining({ comment: 'done' }))
+  })
+
+  it('reopen: POST .../reopen dispatches to reopenDiscussionThread with an empty transition when body omitted', async () => {
+    const reopenDiscussionThread = vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ reopenDiscussionThread }))
+
+    const res = await request(buildApp()).post(REOPEN_URL('t9')).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(200)
+    expect(reopenDiscussionThread).toHaveBeenCalledWith(SESSION_TOKEN, 't9', {})
+  })
+})

--- a/packages/core-backend/tests/unit/plm-embed-discussion-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-discussion-routes.test.ts
@@ -177,22 +177,24 @@ describe('PLM embed discussion WRITE relay (Discussion Phase-3 write-relay, Opti
     expect(serializedHeaders).not.toContain(SESSION_TOKEN)
   })
 
-  it('NO CACHING: two sequential requests (two fresh embed tokens) both call exchangeDiscussionSession -- no cred is reused/cached', async () => {
+  it('NO CACHING: two sequential requests (two fresh embed tokens) both call exchangeDiscussionSession with THEIR OWN raw token -- no cred is reused/cached', async () => {
     const exchangeDiscussionSession = vi.fn().mockResolvedValue(credentialResult())
     const createDiscussionThread = vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } })
     dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionSession, createDiscussionThread }))
 
     const app = buildApp()
-    const res1 = await request(app).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
-    const res2 = await request(app).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send(CREATE_BODY)
+    const token1 = mint()
+    const token2 = mint()
+    const res1 = await request(app).post(THREADS_URL).set('X-PLM-Embed-Token', token1).send(CREATE_BODY)
+    const res2 = await request(app).post(THREADS_URL).set('X-PLM-Embed-Token', token2).send(CREATE_BODY)
 
     expect(res1.status).toBe(200)
     expect(res2.status).toBe(200)
     expect(exchangeDiscussionSession).toHaveBeenCalledTimes(2) // fired on BOTH, not cached after the first
-    // each exchange used a DIFFERENT raw token (distinct jti-bearing mints), never a reused value
-    const [firstArg] = exchangeDiscussionSession.mock.calls[0]
-    const [secondArg] = exchangeDiscussionSession.mock.calls[1]
-    expect(firstArg).not.toEqual(secondArg)
+    // each exchange was called with THIS REQUEST's actual raw embed JWT -- not a fixed/reused value
+    expect(exchangeDiscussionSession).toHaveBeenNthCalledWith(1, token1)
+    expect(exchangeDiscussionSession).toHaveBeenNthCalledWith(2, token2)
+    expect(token1).not.toEqual(token2)
   })
 
   // --- exchange failure -> uniform 401 ---

--- a/packages/core-backend/tests/unit/plm-embed-discussion-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-discussion-routes.test.ts
@@ -351,6 +351,76 @@ describe('PLM embed discussion WRITE relay (Discussion Phase-3 write-relay, Opti
     expect(res.status).toBe(422)
   })
 
+  // --- P2-a (Gate-2 2026-07-11): a PRESENT-but-wrong-typed optional field must 422, never be
+  // silently coerced to `undefined` and dropped -- otherwise a malformed mention/anchor/title/
+  // parent_comment_id would let the write SUCCEED DEGRADED (no mention / top-level / no anchor)
+  // when the caller should have gotten a 422. The write adapter must NEVER be called. ---
+
+  it('create with a non-string title -> 422, write never called (not silently dropped)', async () => {
+    const createDiscussionThread = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ createDiscussionThread }))
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send({ ...CREATE_BODY, title: 123 })
+    expect(res.status).toBe(422)
+    expect(res.body.error.code).toBe('EMBED_DISCUSSION_INVALID_BODY')
+    expect(createDiscussionThread).not.toHaveBeenCalled()
+  })
+
+  it('create with a non-array mentioned_user_ids -> 422, write never called', async () => {
+    const createDiscussionThread = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ createDiscussionThread }))
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send({ ...CREATE_BODY, mentioned_user_ids: 'not-an-array' })
+    expect(res.status).toBe(422)
+    expect(createDiscussionThread).not.toHaveBeenCalled()
+  })
+
+  it('create with mentioned_user_ids containing a non-number -> 422, write never called', async () => {
+    const createDiscussionThread = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ createDiscussionThread }))
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send({ ...CREATE_BODY, mentioned_user_ids: [1, 'two', 3] })
+    expect(res.status).toBe(422)
+    expect(createDiscussionThread).not.toHaveBeenCalled()
+  })
+
+  it('create with a non-object anchor -> 422, write never called', async () => {
+    const createDiscussionThread = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ createDiscussionThread }))
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send({ ...CREATE_BODY, anchor: 'not-an-object' })
+    expect(res.status).toBe(422)
+    expect(createDiscussionThread).not.toHaveBeenCalled()
+  })
+
+  it('create with anchor: null is VALID (explicit no-anchor) -> 200, NOT over-rejected', async () => {
+    const createDiscussionThread = vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ createDiscussionThread }))
+    const res = await request(buildApp()).post(THREADS_URL).set('X-PLM-Embed-Token', mint()).send({ ...CREATE_BODY, anchor: null })
+    expect(res.status).toBe(200)
+    expect(createDiscussionThread).toHaveBeenCalled()
+  })
+
+  it('add-comment with a non-string parent_comment_id -> 422, write never called', async () => {
+    const addDiscussionComment = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ addDiscussionComment }))
+    const res = await request(buildApp()).post(COMMENTS_URL()).set('X-PLM-Embed-Token', mint()).send({ body: 'hi', parent_comment_id: 42 })
+    expect(res.status).toBe(422)
+    expect(addDiscussionComment).not.toHaveBeenCalled()
+  })
+
+  it('add-comment with a bad mentioned_user_ids -> 422, write never called', async () => {
+    const addDiscussionComment = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ addDiscussionComment }))
+    const res = await request(buildApp()).post(COMMENTS_URL()).set('X-PLM-Embed-Token', mint()).send({ body: 'hi', mentioned_user_ids: [{}] })
+    expect(res.status).toBe(422)
+    expect(addDiscussionComment).not.toHaveBeenCalled()
+  })
+
+  it('add-comment with a non-object anchor -> 422, write never called', async () => {
+    const addDiscussionComment = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ addDiscussionComment }))
+    const res = await request(buildApp()).post(COMMENTS_URL()).set('X-PLM-Embed-Token', mint()).send({ body: 'hi', anchor: ['array-not-object'] })
+    expect(res.status).toBe(422)
+    expect(addDiscussionComment).not.toHaveBeenCalled()
+  })
+
   // --- per-route dispatch smoke tests (each route calls the RIGHT adapter method with the RIGHT args) ---
 
   it('delete comment: DELETE dispatches to deleteDiscussionComment with (token, threadId, commentId)', async () => {


### PR DESCRIPTION
## Discussion Phase-3 write-relay — the embed HTTP surface for Lane C writes (Option A, build-then-HOLD)

Stacked on #4110 (Lane C consumer). This is the deferred end-to-end wiring: the `/api/plm-embed/discussion/...` HTTP surface an embedded BOM-review writes through. Each write request carries its own freshly-minted `bom_multitable` embed token; the relay runs the read relay's guard chain (feature_key → embed_origin → data-source → tenant → single-use jti), exchanges the token for a discussion-session credential held in a **request-local** const (never cached, never in a response body/header), and dispatches to the Lane C adapter write methods. Provider 401/403/404/422 pass through; an unrecognized failure degrades to 502 (a write must never silently succeed).

### Gate-2 (2026-07-11) fixes in the latest commit
- **P2-a** — the create + add-comment routes silently coerced a **present-but-wrong-typed** optional field (`title` / `mentioned_user_ids` / `anchor` / `parent_comment_id`) to `undefined` and omitted it, so a malformed request **succeeded degraded** instead of getting a 422. Now each route distinguishes ABSENT (omit) from PRESENT-but-invalid (422), mirroring `parseTransitionRequest` (resolve/reopen already did this). `anchor: null` stays valid. 8 new tests assert the write adapter is **never called** on a bad field + a null-anchor positive control.
- **P2-b** — the consumer taskbook is corrected from "Option A shipped / owner-chosen" to **proposed/held, owner-recommended pending ratification**, and records the **hard precondition**: the relay's single-use store is defense-in-depth only (the pre-auth exchange endpoint is reachable directly), so Option A is sound only once the **Yuantus provider atomically consumes the embed jti**; `DISCUSSION_SESSION_ENABLED` stays OFF until that lands (separate Yuantus PR).

### Status
**HELD for owner ratification of Option A** (the credential-lifecycle fork) — this is an auth-adjacent surface; do not merge before the owner rules A vs B and the provider-side atomic-jti fix lands. 30 relay tests pass; type-check clean; no lockfile mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
