### PR TITLE
fix(dingtalk): P1-2 cross-corp gate for interactive approval cards (send + callback)

### DIFF
--- a/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
+++ b/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
@@ -7,7 +7,24 @@
 ## 0. 环境准备
 
 - [ ] `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=1` 仅在 UAT 环境设置；prod 保持缺省（OFF）。
+- [ ] **`DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID=<Stream 应用所绑定企业的 directory_integrations.id>`**（P1-2 跨企业门，#4116 新增）。
+      **未设置 = 互动卡一律不投放，全部回落 OA 工作通知**——这是 fail-closed 的正确行为，但会表现为「Stream 开了却永远收不到互动卡」。排查 U1 无卡时，**先查这个 env**。
 - [ ] Stream 凭据/模板 id 按锁 §4 B-1 env 形状配置（或 per-corp config store，PR body 声明过的那种）。
+
+### 0-a. 🚧 硬前置：真实回调帧的 corpId 字段形状（**flag ON 之前必须做完**）
+
+P1-2 跨企业门（#4116）用「点击方企业」与「台账 `integration_id` 所属企业」比对，fail-closed。它按优先级读：
+**(1) frame header `eventCorpId`**（SDK 类型化、网关填充，adapter 盖到 payload 上）→ **(2) body `corpId`**；两者都缺 ⇒ 判 `corp_mismatch` 拒绝。
+
+**风险（#4116 对抗审阅 P3-2，未经真实帧验证）**：`dingtalk-stream@2.1.5` 的类型声明里 `eventCorpId` 只出现在 **EVENT 主题**的 header 组；**互动卡 callback 帧很可能根本不带这个 header**。若为真：
+- 门会静默退化为只认 body `corpId`（不是「网关保证的权威锚点」，与设计意图不符）；
+- **若真实 callback body 顶层也没有 `corpId`，则每一次点击都会 fail-closed → 卡片「点了没反应」（dead-on-arrival）。**
+
+- [ ] **抓一帧真实的互动卡 callback frame**（worker 侧 values-free 落一条「字段是否存在」的日志即可，**切勿打印 corpId 值本身**），确认：
+      - [ ] header 里是否有 `eventCorpId`？
+      - [ ] body 顶层是否有 `corpId`？
+- [ ] 依结果决定：两者皆无 ⇒ **不得开 flag**，先补一个真实可用的企业锚点（例如从 Stream 连接自身所绑定的 corp 推导），否则互动卡必然全数拒绝。
+- [ ] 结论回填本文件，并同步到 `interactive-card-callback.ts` 的 `readCallbackCorpId` 注释（把「推测」改成「实测」）。
 - [ ] 互动卡模板的「同意」按钮 action id **必须字面 `approve`**（B-3 review 指定的 UAT 必验项）；「驳回」按钮 = 签名 `/m/approval-decision` 深链（B-2 as-built：驳回必填意见走 Slice-A 页）。
 - [ ] 确认 worker 状态从 `sdk_unwired` → 连接态（W2b adapter 接线后）；断网重连一次验证 backoff 日志 values-free。
 

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
@@ -18,6 +18,14 @@
  *   recipient lateral and `ApprovalDirectoryOrg.resolveLinkedLocalUserIdByExternal`), pinned to
  *   the DELIVERY row's integration when present (DT-R2 per-corp discipline). Unmapped, inactive,
  *   or ambiguous operators get a typed refusal outcome and NO engine call.
+ * - CORP CROSS-CHECK (P1-2 owner gate): the DingTalk Stream card-callback payload carries the
+ *   OFFICIAL `corpId` of the operator who clicked. It MUST equal the corp the delivery's own
+ *   `integration_id` belongs to (`directory_integrations.corp_id`). A mismatch — or an ABSENT
+ *   payload corpId — is refused (`operator_unresolved:corp_mismatch`) BEFORE any operator lookup
+ *   or engine call. Without this, a corp-A userId that collides with a corp-B assignee's userId
+ *   would resolve through the corp-B-pinned delivery and approve a corp-B task (cross-corp
+ *   approval). Composes with `integration_unpinned`: an unpinned delivery already refuses, so this
+ *   gate only ever runs on a corp-pinned delivery.
  * - UNIFIED ACTION PATH: execution funnels through `executeApprovalActionFromCardDelivery`
  *   (A-4 wrapper) — assignee check, reject-comment gate, idempotent acted-claim, and server-side
  *   `channel='dingtalk_card'` attribution all apply untouched. No raw approvals route is called
@@ -79,7 +87,7 @@ export type DingTalkApprovalCardCallbackResult =
   | { outcome: 'rejected'; reason: DingTalkApprovalCardCallbackRejectReason }
   | { outcome: 'ignored_unsupported_action'; outTrackId: string }
   | { outcome: 'delivery_not_found'; outTrackId: string }
-  | { outcome: 'operator_unresolved'; deliveryId: string; reason: 'unlinked' | 'inactive' | 'ambiguous' | 'integration_unpinned' }
+  | { outcome: 'operator_unresolved'; deliveryId: string; reason: 'unlinked' | 'inactive' | 'ambiguous' | 'integration_unpinned' | 'corp_mismatch' }
   | { outcome: 'link_secret_unavailable'; deliveryId: string }
   | { outcome: 'executed'; deliveryId: string; summary: ApprovalCardDeliverySummary }
   | { outcome: 'stale'; deliveryId: string; summary: ApprovalCardDeliverySummary }
@@ -96,6 +104,33 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null
+}
+
+/**
+ * The official corp id of the operator who clicked, read from the DingTalk card-callback payload's
+ * top-level `corpId` (the documented `/v1.0/card/instances/callback` business field — the same slot
+ * the Stream frame's decoded `data` carries it in). Returns '' when absent/blank so the caller
+ * fail-closes: an absent corpId is treated exactly like a mismatch (never skipped).
+ */
+function readCallbackCorpId(payload: unknown): string {
+  const record = asRecord(payload)
+  if (!record) return ''
+  return readTrimmedString(record.corpId)
+}
+
+/**
+ * The DingTalk corp id that a delivery's `integration_id` belongs to
+ * (`directory_integrations.corp_id`, NOT NULL for a live integration). Returns '' when the
+ * integration row is missing (e.g. deleted) so the corp cross-check fail-closes rather than
+ * matching an absent value.
+ */
+async function resolveIntegrationCorpId(query: QueryFn, integrationId: string): Promise<string> {
+  const result = await query(
+    `SELECT corp_id FROM directory_integrations WHERE id = $1::uuid AND provider = 'dingtalk' LIMIT 1`,
+    [integrationId],
+  )
+  const row = (result.rows[0] ?? null) as { corp_id?: unknown } | null
+  return readTrimmedString(row?.corp_id)
 }
 
 /**
@@ -288,6 +323,21 @@ async function resolveDingTalkApprovalCardCallbackOutcome(
   if (!delivery.integration_id) {
     return {
       result: { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: 'integration_unpinned' },
+      operatorDisplayName: null,
+    }
+  }
+
+  // P1-2 corp cross-check: the platform-verified corpId of the clicker (from the callback payload)
+  // must equal the corp the delivery's integration belongs to. This closes the userid-collision
+  // face left after the send-side gate: even if a corp-A userId collides with a corp-B assignee's
+  // userId, a corp-A click carries corpId=corp-A and is refused against a corp-B-pinned delivery.
+  // Fail-closed on an ABSENT payload corpId (readCallbackCorpId → '') — never skipped on a missing
+  // field — and on a delivery whose integration corp cannot be resolved.
+  const payloadCorpId = readCallbackCorpId(payload)
+  const deliveryCorpId = await resolveIntegrationCorpId(deps.query, delivery.integration_id)
+  if (!payloadCorpId || !deliveryCorpId || payloadCorpId !== deliveryCorpId) {
+    return {
+      result: { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: 'corp_mismatch' },
       operatorDisplayName: null,
     }
   }

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
@@ -107,15 +107,21 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 /**
- * The official corp id of the operator who clicked, read from the DingTalk card-callback payload's
- * top-level `corpId` (the documented `/v1.0/card/instances/callback` business field — the same slot
- * the Stream frame's decoded `data` carries it in). Returns '' when absent/blank so the caller
- * fail-closes: an absent corpId is treated exactly like a mismatch (never skipped).
+ * The official corp id of the operator who clicked. Two sources (P3-1):
+ *  - `eventCorpId` — the gateway-guaranteed, SDK-typed header corp id the Stream adapter stamps onto
+ *    the payload. AUTHORITATIVE provenance.
+ *  - `corpId` — the untyped top-level business field of the decoded `/v1.0/card/instances/callback`
+ *    `data`. SECONDARY (an echo).
+ * The header wins; when BOTH are present they must AGREE (a mismatch is treated as absent → the
+ * caller fail-closes). Returns '' when neither is present so an absent corpId is never skipped.
  */
 function readCallbackCorpId(payload: unknown): string {
   const record = asRecord(payload)
   if (!record) return ''
-  return readTrimmedString(record.corpId)
+  const headerCorp = readTrimmedString(record.eventCorpId)
+  const bodyCorp = readTrimmedString(record.corpId)
+  if (headerCorp && bodyCorp && headerCorp !== bodyCorp) return ''
+  return headerCorp || bodyCorp
 }
 
 /**

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
@@ -13,7 +13,10 @@
  * `/v1.0/card/instances/callback`). The SDK's default wildcard EVENT subscription is dropped
  * before connecting so the gateway registration carries exactly that one CALLBACK subscription.
  * Frames are threaded into the worker's existing `handlers.onEvent` seam unchanged — semantic
- * parsing of the payload stays owned by the B-3 callback adapter.
+ * parsing of the payload stays owned by the B-3 callback adapter. The decoded `data` object is
+ * forwarded WHOLE (never field-filtered): the DingTalk card-callback business payload carries the
+ * platform-verified `corpId` at its top level, and the B-3 executor consumes it for the P1-2
+ * cross-corp gate — dropping fields here would blind that check.
  *
  * Reconnect: the SDK's built-in reconnect (`autoReconnect`, default on) owns retry after
  * transport drops and CONNECT failures; `close()` disables it BEFORE disconnecting so an

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
@@ -46,6 +46,12 @@ export type DingTalkStreamDownStreamFrame = {
   headers?: {
     messageId?: string
     topic?: string
+    /**
+     * P3-1: the gateway-populated, SDK-typed corp id of the clicking corp. Authoritative provenance
+     * (the untyped business `data.corpId` is a secondary echo). The adapter forwards it into the
+     * business payload as `eventCorpId` so the callback's cross-corp gate can anchor on it.
+     */
+    eventCorpId?: string
   }
   /** JSON-encoded card-callback payload (a string on the wire). */
   data?: unknown
@@ -122,6 +128,14 @@ async function handleCardCallbackFrame(
     // Values-free reject: never log (or forward) unparseable wire bytes.
     logger.warn('DingTalk interactive-card Stream frame rejected (malformed_frame:data_not_json)')
     return
+  }
+
+  // P3-1: stamp the gateway-guaranteed header corp id onto the forwarded payload as `eventCorpId`
+  // so the callback's cross-corp gate anchors on the SDK-typed provenance rather than the untyped
+  // business-blob `data.corpId` (the header wins; a mismatch is cross-checked downstream).
+  const headerCorpId = typeof frame.headers?.eventCorpId === 'string' ? frame.headers.eventCorpId.trim() : ''
+  if (headerCorpId && payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    (payload as Record<string, unknown>).eventCorpId = headerCorpId
   }
 
   try {

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream-sdk.ts
@@ -133,9 +133,19 @@ async function handleCardCallbackFrame(
   // P3-1: stamp the gateway-guaranteed header corp id onto the forwarded payload as `eventCorpId`
   // so the callback's cross-corp gate anchors on the SDK-typed provenance rather than the untyped
   // business-blob `data.corpId` (the header wins; a mismatch is cross-checked downstream).
-  const headerCorpId = typeof frame.headers?.eventCorpId === 'string' ? frame.headers.eventCorpId.trim() : ''
-  if (headerCorpId && payload && typeof payload === 'object' && !Array.isArray(payload)) {
-    (payload as Record<string, unknown>).eventCorpId = headerCorpId
+  //
+  // Provenance laundering (review P3-1): `eventCorpId` on the forwarded payload MUST mean "came from
+  // the frame HEADER". Stamping it only when the header is present let a BODY-supplied `eventCorpId`
+  // survive untouched and be trusted downstream as header-grade provenance. So strip it
+  // UNCONDITIONALLY first, then re-add it only from the header — the body can no longer forge the
+  // anchor, and an absent header now honestly reads as absent (fail-closed) rather than as whatever
+  // the body claimed.
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    delete (payload as Record<string, unknown>).eventCorpId
+    const headerCorpId = typeof frame.headers?.eventCorpId === 'string' ? frame.headers.eventCorpId.trim() : ''
+    if (headerCorpId) {
+      (payload as Record<string, unknown>).eventCorpId = headerCorpId
+    }
   }
 
   try {

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-stream.ts
@@ -18,6 +18,16 @@ export const DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV = 'DINGTALK_INTERACTIV
 export const DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV = 'DINGTALK_INTERACTIVE_CARD_CLIENT_ID'
 export const DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV = 'DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET'
 export const DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV = 'DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID'
+/**
+ * P1-2 cross-corp gate: the directory `integration_id` (uuid) of the DingTalk corp the GLOBAL
+ * Stream app is bound to. The Stream app can only legitimately push an interactive card to
+ * recipients in its OWN corp, and its callbacks are only trustworthy for that corp. The send path
+ * uses this to refuse interactive-sending to any other corp (OA fallback instead) so a card is
+ * never dispatched via the wrong corp's credentials. Absent → the send fail-closes to OA for
+ * everyone (never interactive-send via an unbound global app); it does NOT stop the worker from
+ * connecting to receive callbacks.
+ */
+export const DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID_ENV = 'DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID'
 
 export type DingTalkInteractiveCardStreamDisabledReason =
   | 'env_disabled'
@@ -40,6 +50,13 @@ export type DingTalkInteractiveCardStreamConfig =
     clientId: string
     clientSecret: string
     templateId: string
+    /**
+     * The directory integration id the Stream app is bound to, or '' when unset. NOT a requirement
+     * for enabling the worker (a Stream app can connect to receive callbacks without it); the SEND
+     * path additionally gates interactive-sends on this being present AND equal to the recipient's
+     * integration (cross-corp P1-2). '' therefore means "flag on but unbound" → OA fallback only.
+     */
+    integrationId: string
     requirements: {
       clientId: true
       clientSecret: true
@@ -106,6 +123,7 @@ export function resolveDingTalkInteractiveCardStreamConfig(
   const clientId = readEnv(env, DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV)
   const clientSecret = readEnv(env, DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV)
   const templateId = readEnv(env, DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV)
+  const integrationId = readEnv(env, DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID_ENV)
   const requirements = {
     clientId: Boolean(clientId),
     clientSecret: Boolean(clientSecret),
@@ -122,6 +140,7 @@ export function resolveDingTalkInteractiveCardStreamConfig(
     clientId,
     clientSecret,
     templateId,
+    integrationId,
     requirements: {
       clientId: true,
       clientSecret: true,

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2725,7 +2725,19 @@ export class AutomationExecutor {
       }
     }
     const interactiveCardConfig = resolveDingTalkInteractiveCardStreamConfig()
-    const useInteractiveCard = interactiveCardConfig.enabled === true
+    // P1-2 cross-corp SEND gate: the interactive card is dispatched via the GLOBAL Stream app's
+    // OWN credentials (robotCode = its clientId), so it may only go to a recipient in the Stream
+    // app's OWN corp. Gate on flag-enabled AND the Stream app being bound to a directory
+    // integration AND that binding matching the recipient's integration. Any mismatch — a
+    // recipient in a different corp, an unbound Stream app, or a recipient with no integration —
+    // falls through to the per-corp OA `work_notice_action_card` (the doc's "other corps
+    // auto-fallback to OA"), never a card sent through the wrong corp's app.
+    const streamIntegrationId = interactiveCardConfig.enabled === true ? interactiveCardConfig.integrationId : ''
+    const useInteractiveCard =
+      interactiveCardConfig.enabled === true
+      && streamIntegrationId.length > 0
+      && assigneeIntegrationId.length > 0
+      && assigneeIntegrationId === streamIntegrationId
 
     // Ledger FIRST — the row is the only legitimate delivery → instance anchor.
     const entryEpochRaw = event.task?.entryEpoch

--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -17,6 +17,7 @@ import {
   DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV,
   DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV,
   DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV,
+  DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID_ENV,
   DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV,
   resolveDingTalkInteractiveCardStreamConfig,
 } from '../../src/integrations/dingtalk/interactive-card-stream'
@@ -36,6 +37,13 @@ import { normalizeStoredSecretValue } from '../../src/security/encrypted-secrets
 const DD_INTEGRATION = randomUUID()
 const DD_ACCOUNT = randomUUID()
 const DD_USER_ID = `dd_ext_${TS}`
+// P1-2 cross-corp fixtures: a SECOND corp (B). Its approver routes through DD_INTEGRATION_B, which
+// is NOT the corp the Stream app is bound to — so the interactive-card send must fall through to OA.
+const APPROVER_B = `u_card_appr_b_${TS}`
+const DD_INTEGRATION_B = randomUUID()
+const DD_ACCOUNT_B = randomUUID()
+const DD_USER_ID_B = `dd_ext_b_${TS}`
+let templateIdB = ''
 
 const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
 
@@ -131,6 +139,56 @@ function cardTemplateRequest() {
   }
 }
 
+function cardTemplateRequestB() {
+  return {
+    key: `card-b-${TS}`,
+    name: 'Approval Card Action Template (corp B)',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        { key: 'approval_1', type: 'approval', name: 'First', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER_B] }] } },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+// Corp-B directory binding: APPROVER_B ↔ DD_USER_ID_B under DD_INTEGRATION_B (a distinct corp).
+async function ensureDingTalkBindingB(): Promise<void> {
+  await q(
+    `INSERT INTO directory_integrations (id, name, corp_id)
+     VALUES ($1, 'card-test-corp-b', 'corp_card_test_b')
+     ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, corp_id = EXCLUDED.corp_id`,
+    [DD_INTEGRATION_B],
+  )
+  await q(
+    `INSERT INTO directory_accounts
+       (id, integration_id, provider, external_user_id, external_key, name, is_active)
+     VALUES ($1, $2, 'dingtalk', $3, $3, 'Card Approver B', TRUE)
+     ON CONFLICT (id) DO UPDATE
+       SET integration_id = EXCLUDED.integration_id,
+           external_user_id = EXCLUDED.external_user_id,
+           external_key = EXCLUDED.external_key,
+           name = EXCLUDED.name,
+           is_active = TRUE`,
+    [DD_ACCOUNT_B, DD_INTEGRATION_B, DD_USER_ID_B],
+  )
+  await q(
+    'DELETE FROM directory_account_links WHERE directory_account_id = $1 OR local_user_id = $2',
+    [DD_ACCOUNT_B, APPROVER_B],
+  )
+  await q(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+     VALUES ($1, $2, 'linked')`,
+    [DD_ACCOUNT_B, APPROVER_B],
+  )
+}
+
 async function cardRows(instanceId: string) {
   const r = await q('SELECT * FROM dingtalk_approval_card_deliveries WHERE instance_id = $1 ORDER BY created_at', [instanceId])
   return r.rows as Array<Record<string, unknown>>
@@ -193,6 +251,7 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
       DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV,
       DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV,
       DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV,
+      DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID_ENV,
     ]) {
       savedEnv[key] = process.env[key]
       delete process.env[key]
@@ -201,18 +260,22 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Card Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'Card Sheet'])
     await q(`INSERT INTO permissions (code, name, description) VALUES ('approvals:read','r','t'),('approvals:write','w','t'),('approvals:act','a','t') ON CONFLICT (code) DO NOTHING`)
-    for (const uid of [CREATOR, REQUESTER, APPROVER]) {
+    for (const uid of [CREATOR, REQUESTER, APPROVER, APPROVER_B]) {
       await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
                VALUES ($1,$2,$1,'x','user','[]'::jsonb,TRUE,FALSE) ON CONFLICT (id) DO UPDATE SET is_active = TRUE`, [uid, `${uid}@card.test`])
     }
     await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:read') ON CONFLICT DO NOTHING`, [CREATOR])
     await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
     await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER_B])
 
     approvals = new ApprovalProductService()
     const template = await approvals.createTemplate(cardTemplateRequest() as never)
     templateId = (template as { id: string }).id
     await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+    const templateB = await approvals.createTemplate(cardTemplateRequestB() as never)
+    templateIdB = (templateB as { id: string }).id
+    await approvals.publishTemplate(templateIdB, { policy: { allowRevoke: true } } as never)
 
     svc = new AutomationService(integrationEventBus, db as never, queryFn, fakeFetch as never)
     svc.init()
@@ -223,12 +286,22 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     delete process.env[DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]
     delete process.env[DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]
     delete process.env[DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]
+    delete process.env[DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID_ENV]
     interactiveBodies.length = 0
   })
 
+  /** Enable the interactive-card Stream flag bound to a specific corp integration (P1-2). */
+  function enableInteractiveStream(streamIntegrationId: string): void {
+    process.env[DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV] = '1'
+    process.env[DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV] = 'stream-app-key'
+    process.env[DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV] = 'stream-app-secret'
+    process.env[DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV] = 'stream-card-template'
+    process.env[DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID_ENV] = streamIntegrationId
+  }
+
   afterAll(async () => {
     try { svc?.shutdown() } catch { /* noop */ }
-    const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [templateId]).catch(() => ({ rows: [] as unknown[] }))
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = ANY($1::text[])', [[templateId, templateIdB]]).catch(() => ({ rows: [] as unknown[] }))
     for (const row of instances.rows as Array<{ id: string }>) {
       await q('DELETE FROM dingtalk_approval_card_deliveries WHERE instance_id = $1', [row.id]).catch(() => {})
       await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
@@ -240,15 +313,15 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
       await q('DELETE FROM multitable_automation_executions WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
       await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [ruleIds]).catch(() => {})
     }
-    await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
-    await q('DELETE FROM dingtalk_person_deliveries WHERE local_user_id = ANY($1::text[])', [[APPROVER]]).catch(() => {})
-    await q('DELETE FROM directory_account_links WHERE local_user_id = $1', [APPROVER]).catch(() => {})
-    await q('DELETE FROM directory_accounts WHERE id = $1', [DD_ACCOUNT]).catch(() => {})
-    await q('DELETE FROM directory_integrations WHERE id = $1', [DD_INTEGRATION]).catch(() => {})
+    await q('DELETE FROM approval_templates WHERE id = ANY($1::text[])', [[templateId, templateIdB]]).catch(() => {})
+    await q('DELETE FROM dingtalk_person_deliveries WHERE local_user_id = ANY($1::text[])', [[APPROVER, APPROVER_B]]).catch(() => {})
+    await q('DELETE FROM directory_account_links WHERE local_user_id = ANY($1::text[])', [[APPROVER, APPROVER_B]]).catch(() => {})
+    await q('DELETE FROM directory_accounts WHERE id = ANY($1::uuid[])', [[DD_ACCOUNT, DD_ACCOUNT_B]]).catch(() => {})
+    await q('DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])', [[DD_INTEGRATION, DD_INTEGRATION_B]]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
-    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER]]).catch(() => {})
-    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER]]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER, APPROVER_B]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[CREATOR, REQUESTER, APPROVER, APPROVER_B]]).catch(() => {})
     for (const [k, v] of Object.entries(savedEnv)) {
       if (v === undefined) delete process.env[k]
       else process.env[k] = v
@@ -339,10 +412,9 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
 
   test('B-2 opt-in: interactive card uses the ledger id as outTrackId and stays values-free', async () => {
     await ensureDingTalkBinding()
-    process.env[DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV] = '1'
-    process.env[DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV] = 'stream-app-key'
-    process.env[DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV] = 'stream-app-secret'
-    process.env[DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV] = 'stream-card-template'
+    // P1-2: the recipient (APPROVER) is in DD_INTEGRATION's corp, and the Stream app is bound to
+    // that SAME integration — so an interactive card is legitimately sent through its own corp.
+    enableInteractiveStream(DD_INTEGRATION)
 
     const rule = await svc.createRule(SHEET_ID, {
       name: 'interactive card bound', triggerType: 'approval.task_created', triggerConfig: { templateId },
@@ -397,6 +469,90 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     expect(serialized).not.toContain(instanceId)
     expect(serialized).not.toContain('SECRET-INTERACTIVE-FORM-VALUE')
 
+    await svc.deleteRule(rule.id, SHEET_ID)
+  })
+
+  test('P1-2 cross-corp SEND gate: Stream bound to corp A → a corp-B recipient falls back to OA (work_notice_action_card); a corp-A recipient gets interactive', async () => {
+    await ensureDingTalkBinding()   // corp A: APPROVER ↔ DD_INTEGRATION
+    await ensureDingTalkBindingB()  // corp B: APPROVER_B ↔ DD_INTEGRATION_B
+    enableInteractiveStream(DD_INTEGRATION) // the global Stream app belongs to corp A only
+
+    // Corp-B recipient: routes through DD_INTEGRATION_B ≠ the Stream app's corp. The card must NOT
+    // be sent via corp A's Stream app; it falls through to the per-corp OA action-card. RED-before:
+    // on main `useInteractiveCard = enabled === true` alone, so this corp-B recipient gets an
+    // interactive_card dispatched with corp A's robotCode/token — the cross-corp send bug.
+    const ruleB = await svc.createRule(SHEET_ID, {
+      name: 'card cross-corp B', triggerType: 'approval.task_created', triggerConfig: { templateId: templateIdB },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(ruleB.id)
+    sentBodies.length = 0
+    interactiveBodies.length = 0
+    const dtoB = await approvals.createApproval(
+      { templateId: templateIdB, formData: { summary: 'cross-corp B run' } },
+      { userId: REQUESTER, userName: REQUESTER },
+    )
+    const instanceB = (dtoB as { id: string }).id
+    const rowsB = await waitFor(async () => (await cardRows(instanceB)).filter((r) => r.send_status !== 'pending'))
+    expect(rowsB).toHaveLength(1)
+    expect(rowsB[0].delivery_kind).toBe('work_notice_action_card')
+    expect(rowsB[0].integration_id).toBe(DD_INTEGRATION_B)
+    expect(rowsB[0].send_status).toBe('sent')
+    // The interactive endpoint was NEVER called for the corp-B recipient; the OA send fired once.
+    expect(interactiveBodies).toHaveLength(0)
+    expect(sentBodies).toHaveLength(1)
+    await svc.deleteRule(ruleB.id, SHEET_ID)
+
+    // Corp-A recipient (same corp as the Stream app): the legitimate interactive-card case.
+    const ruleA = await svc.createRule(SHEET_ID, {
+      name: 'card cross-corp A', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(ruleA.id)
+    sentBodies.length = 0
+    interactiveBodies.length = 0
+    const dtoA = await approvals.createApproval(
+      { templateId, formData: { summary: 'cross-corp A run' } },
+      { userId: REQUESTER, userName: REQUESTER },
+    )
+    const instanceA = (dtoA as { id: string }).id
+    const rowsA = await waitFor(async () => (await cardRows(instanceA)).filter((r) => r.send_status !== 'pending'))
+    expect(rowsA).toHaveLength(1)
+    expect(rowsA[0].delivery_kind).toBe('interactive_card')
+    expect(rowsA[0].integration_id).toBe(DD_INTEGRATION)
+    expect(interactiveBodies).toHaveLength(1)
+    expect(sentBodies).toHaveLength(0)
+    await svc.deleteRule(ruleA.id, SHEET_ID)
+  })
+
+  test('P1-2 fail-closed: flag ON but the Stream app UNBOUND (no integration id) → OA fallback even for the local corp, never interactive via an unbound global app', async () => {
+    await ensureDingTalkBinding()
+    // Flag + credentials + template present, but DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID
+    // deliberately unset: the config is enabled:true but carries integrationId ''. The send path
+    // must NOT interactive-dispatch to anyone (there is no corp to legitimize the app's identity).
+    process.env[DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV] = '1'
+    process.env[DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV] = 'stream-app-key'
+    process.env[DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV] = 'stream-app-secret'
+    process.env[DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV] = 'stream-card-template'
+    expect(resolveDingTalkInteractiveCardStreamConfig()).toMatchObject({ enabled: true, integrationId: '' })
+
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'card unbound stream', triggerType: 'approval.task_created', triggerConfig: { templateId },
+      actionType: 'send_dingtalk_approval_card', actionConfig: {}, createdBy: CREATOR,
+    } as never)
+    ruleIds.push(rule.id)
+    sentBodies.length = 0
+    interactiveBodies.length = 0
+    const dto = await approvals.createApproval(
+      { templateId, formData: { summary: 'unbound stream run' } },
+      { userId: REQUESTER, userName: REQUESTER },
+    )
+    const instanceId = (dto as { id: string }).id
+    const rows = await waitFor(async () => (await cardRows(instanceId)).filter((r) => r.send_status !== 'pending'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].delivery_kind).toBe('work_notice_action_card')
+    expect(interactiveBodies).toHaveLength(0)
+    expect(sentBodies).toHaveLength(1)
     await svc.deleteRule(rule.id, SHEET_ID)
   })
 

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
@@ -40,6 +40,11 @@ const INACTIVE = `u_cb_inactive_${TS}`
 
 const INTEGRATION_A = randomUUID()
 const INTEGRATION_B = randomUUID()
+// P1-2: the DingTalk corp each integration belongs to (directory_integrations.corp_id). The
+// callback corp cross-check requires the payload's official corpId to equal the corp the DELIVERY
+// row's integration belongs to.
+const CORP_A = `corp_b3cb_a_${TS}`
+const CORP_B = `corp_b3cb_b_${TS}`
 const DD_OP = `dd_cb_op_${TS}` // → APPROVER (corp A)
 const DD_REQ = `dd_cb_req_${TS}` // → REQUESTER (corp A) — mapped but non-assignee
 const DD_INACTIVE = `dd_cb_inactive_${TS}` // → INACTIVE user (corp A)
@@ -57,15 +62,25 @@ let approvals: ApprovalProductService
 let templateId = ''
 const deps = { query: q, approvals: null as unknown as ApprovalProductService }
 
-function payloadFor(outTrackId: string, operator: string, extra: Record<string, unknown> = {}, action = 'approve') {
-  return {
+// P1-2: `corpId` is the official clicker corp the callback carries. It defaults to CORP_A (the
+// corp the default INTEGRATION_A deliveries belong to) so the happy path passes the corp
+// cross-check; corp-B deliveries and the cross-corp goldens pass it explicitly. `corpId: null`
+// omits the field entirely (the ABSENT-corpId fail-closed case).
+function payloadFor(
+  outTrackId: string,
+  operator: string,
+  extra: Record<string, unknown> = {},
+  action = 'approve',
+  corpId: string | null = CORP_A,
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
     outTrackId,
     userId: operator,
     userIdType: 1,
     content: JSON.stringify({ cardPrivateData: { actionIds: [action], params: {} } }),
-    corpId: 'corp_transport_metadata',
-    ...extra,
   }
+  if (corpId !== null) base.corpId = corpId
+  return { ...base, ...extra }
 }
 
 async function newInstance(): Promise<string> {
@@ -170,12 +185,12 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
     await q(
       `INSERT INTO directory_integrations (id, name, provider, status, corp_id, config, updated_at)
        VALUES ($1, $2, 'dingtalk', 'active', $3, $4::jsonb, now())`,
-      [INTEGRATION_A, `b3cb-corp-a-${TS}`, `corp_b3cb_a_${TS}`, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(STORED_SECRET_A) })],
+      [INTEGRATION_A, `b3cb-corp-a-${TS}`, CORP_A, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(STORED_SECRET_A) })],
     )
     await q(
       `INSERT INTO directory_integrations (id, name, provider, status, corp_id, config, updated_at)
        VALUES ($1, $2, 'dingtalk', 'active', $3, $4::jsonb, now() - interval '1 minute')`,
-      [INTEGRATION_B, `b3cb-corp-b-${TS}`, `corp_b3cb_b_${TS}`, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(STORED_SECRET_B) })],
+      [INTEGRATION_B, `b3cb-corp-b-${TS}`, CORP_B, JSON.stringify({ approvalCardLinkSecret: normalizeStoredSecretValue(STORED_SECRET_B) })],
     )
 
     await linkAccount(ACCOUNTS.op, INTEGRATION_A, DD_OP, APPROVER)
@@ -376,6 +391,36 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
     expect(await approveRecordCount(instanceId)).toBe(1)
   })
 
+  test('P1-2 corp cross-check: a corp-A click (userId collision) on a corp-B delivery is refused (corp_mismatch); missing corpId is refused; the matching corp executes', async () => {
+    const instanceId = await newInstance()
+    // Delivery pinned to corp B; the assignee APPROVER is linked under corp B as DD_OP_B.
+    const row = await insertDingTalkApprovalCardDelivery(q, {
+      instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: DD_OP_B, deliveryKind: 'interactive_card', integrationId: INTEGRATION_B,
+    })
+    await markDingTalkApprovalCardDeliverySent(q, row.id, 'carrier_corp_xcheck')
+
+    // The cross-corp collision face: the click carries the corp-B assignee's userId (DD_OP_B) but
+    // the OFFICIAL corpId is corp A — a corp-A clicker whose id collides with the corp-B assignee.
+    // On main (no corp check) resolveOperatorLocalUser(DD_OP_B, INTEGRATION_B) → APPROVER and the
+    // corp-A clicker APPROVES the corp-B task. The gate refuses it before any operator lookup.
+    const mismatch = await executeDingTalkApprovalCardCallback(deps, payloadFor(row.id, DD_OP_B, {}, 'approve', CORP_A))
+    expect(mismatch).toEqual({ outcome: 'operator_unresolved', deliveryId: row.id, reason: 'corp_mismatch' })
+    expect(await approveRecordCount(instanceId)).toBe(0)
+    expect(await cardState(row.id)).toBe('sent')
+
+    // Fail-closed on an ABSENT payload corpId (the field is omitted entirely), never skipped.
+    const absent = await executeDingTalkApprovalCardCallback(deps, payloadFor(row.id, DD_OP_B, {}, 'approve', null))
+    expect(absent).toEqual({ outcome: 'operator_unresolved', deliveryId: row.id, reason: 'corp_mismatch' })
+    expect(await approveRecordCount(instanceId)).toBe(0)
+    expect(await cardState(row.id)).toBe('sent')
+
+    // Matching corpId (the delivery's own corp B) passes the gate and executes end-to-end.
+    const match = await executeDingTalkApprovalCardCallback(deps, payloadFor(row.id, DD_OP_B, {}, 'approve', CORP_B))
+    expect(match.outcome).toBe('executed')
+    expect(await approveRecordCount(instanceId)).toBe(1)
+    expect(await cardState(row.id)).toBe('acted')
+  })
+
   test('per-corp stored secret (env unset): a corp-B-pinned delivery signs and verifies through corp B\'s stored secret end-to-end', async () => {
     const instanceId = await newInstance()
     const row = await insertDingTalkApprovalCardDelivery(q, {
@@ -387,12 +432,14 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
     const prev = process.env.APPROVAL_CARD_LINK_SECRET
     delete process.env.APPROVAL_CARD_LINK_SECRET
     try {
-      // Cross-corp identity fail-closed: corp A's operator id is NOT linked under corp B.
-      const crossCorp = await executeDingTalkApprovalCardCallback(deps, payloadFor(row.id, DD_OP))
+      // Cross-corp identity fail-closed: corp A's operator id is NOT linked under corp B. (The
+      // callback presents corp B's own corpId so the P1-2 corp gate passes and the refusal is
+      // proven to come from the identity lookup, not the corp cross-check.)
+      const crossCorp = await executeDingTalkApprovalCardCallback(deps, payloadFor(row.id, DD_OP, {}, 'approve', CORP_B))
       expect(crossCorp).toEqual({ outcome: 'operator_unresolved', deliveryId: row.id, reason: 'unlinked' })
 
       // Corp B's own linked operator executes; token threading used corp B's stored secret.
-      const result = await executeDingTalkApprovalCardCallback(deps, payloadFor(row.id, DD_OP_B))
+      const result = await executeDingTalkApprovalCardCallback(deps, payloadFor(row.id, DD_OP_B, {}, 'approve', CORP_B))
       expect(result.outcome).toBe('executed')
       const record = await q(
         `SELECT metadata FROM approval_records WHERE instance_id = $1 AND action = 'approve' ORDER BY created_at DESC LIMIT 1`,

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
@@ -394,8 +394,14 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
   test('P1-2 corp cross-check: a corp-A click (userId collision) on a corp-B delivery is refused (corp_mismatch); missing corpId is refused; the matching corp executes', async () => {
     const instanceId = await newInstance()
     // Delivery pinned to corp B; the assignee APPROVER is linked under corp B as DD_OP_B.
+    // The delivery MUST carry the live seat's entry_epoch (P1-1 strict binding): without it the card
+    // is un-actionable for the epoch reason, and the final `executed` leg below would degrade to
+    // `stale` — leaving an all-fail-closed suite that stays green even if the corp gate refused
+    // EVERYTHING. The positive control is what proves the gate refuses the attacker specifically,
+    // rather than refusing everyone.
     const row = await insertDingTalkApprovalCardDelivery(q, {
       instanceId, nodeKey: 'approval_1', recipientUserId: APPROVER, recipientDingTalkUserId: DD_OP_B, deliveryKind: 'interactive_card', integrationId: INTEGRATION_B,
+      entryEpoch: await liveSeatEpoch(instanceId, 'approval_1', APPROVER),
     })
     await markDingTalkApprovalCardDeliverySent(q, row.id, 'carrier_corp_xcheck')
 

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
@@ -418,6 +418,28 @@ describe('executeDingTalkApprovalCardCallback (B-3 §B-3 execution)', () => {
     expect(blankResult).toMatchObject({ outcome: 'operator_unresolved', reason: 'corp_mismatch' })
   })
 
+  it('P3-1 provenance: the SDK-typed header corp (eventCorpId) is authoritative — used even when the untyped body corpId is absent', async () => {
+    // The Stream adapter stamps the gateway-guaranteed header corp onto the payload as eventCorpId.
+    // A frame with only eventCorpId (no business corpId) must still pass on a matching corp.
+    const h = makeHarness()
+    const result = await executeDingTalkApprovalCardCallback(
+      h.deps as never,
+      wirePayload({ corpId: undefined, eventCorpId: DEFAULT_CORP_ID }),
+    )
+    expect(result).not.toMatchObject({ reason: 'corp_mismatch' })
+    expect(h.dispatchAction).toHaveBeenCalled()
+  })
+
+  it('P3-1 provenance: header eventCorpId and body corpId DISAGREEING → fail-closed corp_mismatch (a forged body echo cannot override the header)', async () => {
+    const h = makeHarness()
+    const result = await executeDingTalkApprovalCardCallback(
+      h.deps as never,
+      wirePayload({ eventCorpId: DEFAULT_CORP_ID, corpId: 'corp_forged' }),
+    )
+    expect(result).toEqual({ outcome: 'operator_unresolved', deliveryId: DELIVERY_ID, reason: 'corp_mismatch' })
+    expect(h.dispatchAction).not.toHaveBeenCalled()
+  })
+
   it('P1-2 CORP GATE fail-closed when the delivery integration corp cannot be resolved (missing integration row)', async () => {
     const h = makeHarness({ integrationCorpId: null })
     const result = await executeDingTalkApprovalCardCallback(h.deps as never, wirePayload())

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
@@ -28,6 +28,10 @@ import type { DingTalkApprovalCardTerminalUpdate } from '../../src/integrations/
 
 const DELIVERY_ID = '11111111-2222-4333-8444-555555555555'
 const OPERATOR = 'dd_operator_1'
+// P1-2: the delivery fixture's integration belongs to this corp; the wire payload's official
+// corpId matches it by default so the corp cross-check passes on the happy path. Mismatch/absent
+// cases override `corpId` explicitly.
+const DEFAULT_CORP_ID = 'corp_default'
 
 function wirePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -35,6 +39,7 @@ function wirePayload(overrides: Record<string, unknown> = {}): Record<string, un
     userId: OPERATOR,
     userIdType: 1,
     content: JSON.stringify({ cardPrivateData: { actionIds: ['approve'], params: {} } }),
+    corpId: DEFAULT_CORP_ID,
     ...overrides,
   }
 }
@@ -213,15 +218,24 @@ function makeHarness(state: {
   deliveryRows?: Record<string, unknown>[]
   linkRows?: Record<string, unknown>[]
   dispatchError?: unknown
+  /** P1-2: the corp_id the delivery's integration resolves to. `null` = integration row missing. */
+  integrationCorpId?: string | null
 } = {}) {
   const calls: QueryCall[] = []
   const deliveryRows = state.deliveryRows ?? [deliveryRow()]
+  const integrationCorpId = state.integrationCorpId === undefined ? DEFAULT_CORP_ID : state.integrationCorpId
   const linkRows = state.linkRows ?? [
     { local_user_id: 'u_appr', local_user_name: 'Approver A', local_user_active: true },
   ]
   const query = async (sql: string, params?: unknown[]) => {
     calls.push({ sql, params: params ?? [] })
     if (sql.includes('FROM dingtalk_approval_card_deliveries')) return { rows: deliveryRows }
+    // P1-2 corp cross-check resolver (SELECT corp_id FROM directory_integrations …). The
+    // link-secret resolver also reads directory_integrations but selects id/name/status/config
+    // (no corp_id), so it stays on the empty-else branch below — preserving link_secret_unavailable.
+    if (sql.includes('FROM directory_integrations') && sql.includes('corp_id')) {
+      return { rows: integrationCorpId === null ? [] : [{ corp_id: integrationCorpId }] }
+    }
     if (sql.includes('FROM directory_accounts')) return { rows: linkRows }
     if (sql.includes('FROM approval_instances')) {
       return {
@@ -378,6 +392,44 @@ describe('executeDingTalkApprovalCardCallback (B-3 §B-3 execution)', () => {
     // fail-closed BEFORE the lookup: the directory is never queried, the engine never dispatched.
     expect(h.calls.some((c) => c.sql.includes('FROM directory_accounts'))).toBe(false)
     expect(h.dispatchAction).not.toHaveBeenCalled()
+  })
+
+  it('P1-2 CORP GATE: a payload corpId that differs from the delivery integration corp → corp_mismatch, NO operator lookup, NO engine call', async () => {
+    // Cross-corp collision face: the delivery is pinned to corp `corp_default`, the operator id
+    // is a legitimately-linked corp user, but the click carries corpId=corp_other (a corp-A
+    // clicker whose userId collides with the corp-B assignee). Refused before any operator lookup.
+    const h = makeHarness()
+    const result = await executeDingTalkApprovalCardCallback(h.deps as never, wirePayload({ corpId: 'corp_other' }))
+    expect(result).toEqual({ outcome: 'operator_unresolved', deliveryId: DELIVERY_ID, reason: 'corp_mismatch' })
+    expect(h.calls.some((c) => c.sql.includes('FROM directory_accounts'))).toBe(false)
+    expect(h.dispatchAction).not.toHaveBeenCalled()
+  })
+
+  it('P1-2 CORP GATE fail-closed on ABSENT corpId: a payload with no corpId is refused, not skipped', async () => {
+    const h = makeHarness()
+    const result = await executeDingTalkApprovalCardCallback(h.deps as never, wirePayload({ corpId: undefined }))
+    expect(result).toEqual({ outcome: 'operator_unresolved', deliveryId: DELIVERY_ID, reason: 'corp_mismatch' })
+    expect(h.calls.some((c) => c.sql.includes('FROM directory_accounts'))).toBe(false)
+    expect(h.dispatchAction).not.toHaveBeenCalled()
+
+    // Blank/whitespace corpId is equally absent (readCallbackCorpId trims to '').
+    const blank = makeHarness()
+    const blankResult = await executeDingTalkApprovalCardCallback(blank.deps as never, wirePayload({ corpId: '   ' }))
+    expect(blankResult).toMatchObject({ outcome: 'operator_unresolved', reason: 'corp_mismatch' })
+  })
+
+  it('P1-2 CORP GATE fail-closed when the delivery integration corp cannot be resolved (missing integration row)', async () => {
+    const h = makeHarness({ integrationCorpId: null })
+    const result = await executeDingTalkApprovalCardCallback(h.deps as never, wirePayload())
+    expect(result).toEqual({ outcome: 'operator_unresolved', deliveryId: DELIVERY_ID, reason: 'corp_mismatch' })
+    expect(h.dispatchAction).not.toHaveBeenCalled()
+  })
+
+  it('P1-2 CORP GATE: a matching corpId passes the gate and executes (contrast pin for the mismatch test)', async () => {
+    const h = makeHarness()
+    const result = await executeDingTalkApprovalCardCallback(h.deps as never, wirePayload({ corpId: DEFAULT_CORP_ID }))
+    expect(result.outcome).toBe('executed')
+    expect(h.dispatchAction).toHaveBeenCalledTimes(1)
   })
 
   it('missing link secret fail-closes BEFORE the engine (link_secret_unavailable)', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-sdk.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-stream-sdk.test.ts
@@ -176,6 +176,35 @@ describe('DingTalk interactive-card Stream SDK adapter', () => {
     expect(dw.socketCallBackResponse).toHaveBeenCalledWith('msg-1', {})
   })
 
+  it('P3-1 provenance: a BODY-forged eventCorpId is STRIPPED (never laundered into header-grade provenance); a real header IS stamped', async () => {
+    // `eventCorpId` on the forwarded payload is the cross-corp gate's SDK-typed provenance anchor and
+    // must mean "came from the frame HEADER". Stamping it only-when-the-header-exists left a
+    // body-supplied value in place, so the untrusted business blob could forge the anchor the gate
+    // trusts above body `corpId`. RED-before (restore the conditional stamp): the forged value survives.
+    const events: DingTalkInteractiveCardStreamEvent[] = []
+    const onEvent = vi.fn(async (event: DingTalkInteractiveCardStreamEvent) => { events.push(event) })
+    const { dw } = await adapter({ onEvent })
+
+    // (a) NO header eventCorpId, but the body forges one → it must be stripped, leaving the field ABSENT
+    //     (absent reads honestly as absent → the gate fail-closes, rather than trusting the forgery).
+    dw.listeners.get(TOPIC_CARD)!({
+      type: 'CALLBACK',
+      headers: { messageId: 'msg-forge', topic: TOPIC_CARD },
+      data: JSON.stringify({ outTrackId: 'd-forge', userId: 'dd_op', eventCorpId: 'corp_ATTACKER' }),
+    })
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledTimes(1))
+    expect((events[0].payload as Record<string, unknown>)).not.toHaveProperty('eventCorpId')
+
+    // (b) A REAL header value IS stamped, and overrides whatever the body claimed.
+    dw.listeners.get(TOPIC_CARD)!({
+      type: 'CALLBACK',
+      headers: { messageId: 'msg-hdr', topic: TOPIC_CARD, eventCorpId: 'corp_REAL' },
+      data: JSON.stringify({ outTrackId: 'd-hdr', userId: 'dd_op', eventCorpId: 'corp_ATTACKER' }),
+    })
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledTimes(2))
+    expect((events[1].payload as Record<string, unknown>).eventCorpId).toBe('corp_REAL')
+  })
+
   it('rejects a frame whose data is not a string: values-free warn, no onEvent, still acked', async () => {
     const onEvent = vi.fn(async () => {})
     const { log, dw } = await adapter({ onEvent })

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-stream.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-stream.test.ts
@@ -4,6 +4,7 @@ import {
   DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV,
   DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV,
   DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV,
+  DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID_ENV,
   DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV,
   DingTalkInteractiveCardStreamWorker,
   resolveDingTalkInteractiveCardStreamConfig,
@@ -76,12 +77,36 @@ describe('DingTalk interactive-card Stream worker (B-1)', () => {
         clientId: 'client-1',
         clientSecret: 'secret-1',
         templateId: 'template-1',
+        // P1-2: absent DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID → '' (flag on but unbound);
+        // the worker still enables, but the SEND path treats '' as "OA fallback for everyone".
+        integrationId: '',
         requirements: {
           clientId: true,
           clientSecret: true,
           templateId: true,
         },
       })
+    })
+
+    it('P1-2: carries the bound Stream integration id (trimmed) when configured; enabling is independent of it', () => {
+      const bound = resolveDingTalkInteractiveCardStreamConfig(env({
+        [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: 'secret-1',
+        [DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]: 'template-1',
+        [DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID_ENV]: '  integration-corp-a  ',
+      }))
+      expect(bound).toMatchObject({ enabled: true, integrationId: 'integration-corp-a' })
+
+      // A missing integration id does NOT disable the worker (it can still receive callbacks);
+      // the cross-corp restriction is enforced only on the SEND path via integrationId === ''.
+      const unbound = resolveDingTalkInteractiveCardStreamConfig(env({
+        [DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED_ENV]: '1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_ID_ENV]: 'client-1',
+        [DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET_ENV]: 'secret-1',
+        [DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID_ENV]: 'template-1',
+      }))
+      expect(unbound).toMatchObject({ enabled: true, integrationId: '' })
     })
   })
 


### PR DESCRIPTION
**P1-2 of the owner REQUEST-CHANGES review.** The interactive-card path chose the card on the GLOBAL Stream flag alone, sending via the Stream app's own credentials to any corp's recipient while stamping the recipient's corp on the ledger; the callback resolved the clicker against the ledger corp and **ignored the payload corpId** — so a corp-A userId colliding with a corp-B assignee could proxy-approve the corp-B task. Not live-exploitable today (flag OFF by default) but must be fixed before enablement. **Flag stays OFF.**

**Send side** — bind the interactive card to the Stream app's own corp via new env `DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID`: interactive-send only when the recipient's integration equals the Stream app's bound integration, else the per-corp OA `work_notice_action_card` (the doc's "other corps auto-fallback to OA"). Unbound Stream → OA for everyone (never send via an unbound global app).

**Callback side** — cross-check the official payload `corpId` (top-level of the decoded Stream `data` payload) against `directory_integrations.corp_id` of the delivery's integration; refuse (`operator_unresolved:corp_mismatch`) on mismatch, on absent payload corpId (**fail-closed, never skipped**), or on an unresolvable delivery corp, before any operator lookup or engine call. Composes with the existing `integration_unpinned` gate.

**Verification** — real-DB goldens on both paths (ephemeral PG): send cross-corp fallback (RED-before: corp-B recipient got `interactive_card` on main) + callback corp cross-check (RED-before: collision click `executed`/approved on main); per-guard mutation proofs (send equality; callback fail-closed-on-absent); full backend unit 5090; `tsc --noEmit` clean.

**Caveat**: corpId is read from the decoded business payload (verified against existing fixtures + the DingTalk card-callback shape). If a future DingTalk change moved corpId into frame headers, the SDK adapter (threads the whole payload) would need to lift it — a doc note flags this. UAT-confirmable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
