### PR TITLE
fix(multitable): PIT-resurrect anchor derived from asOf T (R11 A′)

### DIFF
--- a/docs/development/multitable-global-history-resurrect-anchor-exactness-decision-20260710.md
+++ b/docs/development/multitable-global-history-resurrect-anchor-exactness-decision-20260710.md
@@ -1,6 +1,6 @@
 # Global History — PIT-resurrect 锚精确化 + response-shape — 决策 one-pager (RATIFIED — A′ · AS-BUILT R11)
 
-- **Status**: **RATIFIED 2026-07-11（owner R11 directive: 「ratify 锚 A′ 并优先实现」）→ 选项 A′（服务端按 `asOf` T 推导锚）。AS-BUILT**：impl 落在本轮 anchor 分支——`univer-meta.ts` resurrect 锚查询由 `created_at DESC` latest-delete 启发式改为 `WHERE action='delete' AND created_at > $asOfIso ORDER BY created_at ASC, version ASC, id ASC LIMIT 1`；R8 goldens 翻断言为 vintage-exact + 新增同毫秒 tiebreak(D) + 边界(E) goldens（`multitable-undelete-inbound-resurrect-realdb.test.ts`）。零 wire、零 schema。**边界正确性核验（ratify 前）**：`reconstructRecordsAtT` 用 `created_at <= T`（record-reconstructor.ts:53），故 record 在 resurrect 集 ⟺ 其移除性 delete 严格 `> T`——锁定的 `> T` 是该边界的精确补集；`created_at == T` 的 delete ⇒ 该记录在 T 已不存在 ⇒ 本就不在 resurrect 集（golden E 钉住）。
+- **Status**: **RATIFIED 2026-07-11（owner R11 directive: 「ratify 锚 A′ 并优先实现」）→ 选项 A′（服务端按 `asOf` T 推导锚）。AS-BUILT**：impl 落在本轮 anchor 分支——`univer-meta.ts` resurrect 锚查询由 `created_at DESC` latest-delete 启发式改为 `WHERE action='delete' AND created_at > $asOfIso ORDER BY created_at ASC, version ASC, id ASC LIMIT 1`；R8 goldens 翻断言为 vintage-exact + 新增同毫秒 tiebreak(D) + 缺席边界(E) + 严格 `>T` 载荷(F) goldens（`multitable-undelete-inbound-resurrect-realdb.test.ts`）。零 wire、零 schema。**边界正确性核验（ratify 前）**：`reconstructRecordsAtT` 用 `created_at <= T`（record-reconstructor.ts:53），故 record 在 resurrect 集 ⟺ 其移除性 delete 严格 `> T`——锁定的 `> T` 是该边界的精确补集。两种边界分别钉：`created_at == T` 的 delete 若是最新 `<=T` revision ⇒ 该记录在 T 不存在 ⇒ 本就不在 resurrect 集（golden **E** 钉「缺席」，记录根本不到锚查询）；但若 T 时刻有更高版本 re-create（记录在 T **存在**），其移除性 delete 严格晚于 T，`>=T` 会误锚到上一 vintage 的同刻 delete ⇒ golden **F** 钉「`>T` 严格性」（唯一在 `>T→>=T` 突变下变红的 golden；审阅 P2 补入）。
 - ~~PROPOSED~~ 原始状态（保留供审计）：R10 gate-front 工件（4c-3 wave 验证 §4 项 (1)(2)）。
 - **历史现状（R8，已被本轮 A′ AS-BUILT 取代——保留供审计）**：PIT-undelete 的 resurrect 侧无 trash 行可携锚，R8 采用「该记录最新 `action='delete'` revision」`created_at DESC` 启发式选锚（univer-meta.ts ~:10183）；多 vintage 场景**只会 under-replay 不会 over-replay**（R8 多 vintage/未捕获 vintage goldens + 注释诚实化已落 main）。restore 侧（trash 路径）锚精确，无此问题。**R11 后**：resurrect 侧改为 asOf-derived vintage-exact 锚，under-replay 边界消除；restore 侧不变。
 
@@ -18,6 +18,10 @@
 **A′**（原推荐 A 经审阅修正后降为次选）：T 已在 wire 上、语义即「恢复到 T 时刻」，vintage-正确锚由 T 唯一决定——服务端推导比把选择权推给调用方更便宜也更不易错。实现要点（ratify 后才排）：
 - **锚选择的确定性排序契约（owner P2，锁定为规范文本，与既有 LOCK-11 确定性约束一致）**：筛 `action='delete'` 且 `created_at > T`，排序 **`ORDER BY created_at ASC, version ASC, id ASC LIMIT 1`**——同毫秒多条 delete revision 时由 version、再由 id 决出唯一且稳定的锚；任何实现不得省略三级 tiebreak。
 - 找不到时的语义：找不到 = 该记录 T 时刻未删，resurrect 集合本就不含它；以 goldens 钉边界（不回退启发式）。
-- Goldens：R8 的多 vintage/未捕获 vintage goldens 翻断言为精确重放；**新增同毫秒 golden**（两条 delete revision `created_at` 相同 → version/id tiebreak 选定且跨运行稳定）；锚选择突变（改回 latest-delete 启发式，或去掉任一 tiebreak 键）⇒ 对应 golden 红。
+- Goldens（AS-BUILT，突变逐一在真库核验）：R8 的多 vintage/未捕获 vintage goldens 翻断言为精确重放。突变精确命中：
+  - 改回 `created_at DESC` latest-delete 启发式 ⇒ (A) + (D) 红（vintage 与同毫秒各一）；
+  - 锚查询 `version DESC`（翻 version tiebreak）⇒ 仅 (D) 红——UUID 无关，稳定；
+  - `created_at > T` 改 `>= T`（去严格性）⇒ 仅 (F) 红；
+  - **id tiebreak 键**：属 belt-and-suspenders（`(sheet_id, record_id, version)` 索引非 UNIQUE），当前无单独行使它的 golden（去掉不改任何断言）——如实记，不夸大为「去掉任一 tiebreak 键必红」。
 
 - **解锁词**：~~owner 点头选项（A′/A/B/C）~~ **已解锁 → A′（owner R11 directive 2026-07-11）**。本项从 owner 菜单出列（AS-BUILT）。

--- a/docs/development/multitable-global-history-resurrect-anchor-exactness-decision-20260710.md
+++ b/docs/development/multitable-global-history-resurrect-anchor-exactness-decision-20260710.md
@@ -1,7 +1,8 @@
-# Global History — PIT-resurrect 锚精确化 + response-shape — 决策 one-pager (PROPOSED)
+# Global History — PIT-resurrect 锚精确化 + response-shape — 决策 one-pager (RATIFIED — A′ · AS-BUILT R11)
 
-- **Status**: PROPOSED 决策文档；owner ratify 前零实现授权。R10 gate-front 工件（4c-3 wave 验证 §4 项 (1)(2)）。
-- **现状（R8 已诚实钉住）**：PIT-undelete 的 resurrect 侧无 trash 行可携锚，采用「该记录最新 `action='delete'` revision」启发式选锚（univer-meta.ts ~:10183）；多 vintage 场景**只会 under-replay 不会 over-replay**（R8 多 vintage/未捕获 vintage goldens + 注释诚实化已落 main）。restore 侧（trash 路径）锚精确，无此问题。
+- **Status**: **RATIFIED 2026-07-11（owner R11 directive: 「ratify 锚 A′ 并优先实现」）→ 选项 A′（服务端按 `asOf` T 推导锚）。AS-BUILT**：impl 落在本轮 anchor 分支——`univer-meta.ts` resurrect 锚查询由 `created_at DESC` latest-delete 启发式改为 `WHERE action='delete' AND created_at > $asOfIso ORDER BY created_at ASC, version ASC, id ASC LIMIT 1`；R8 goldens 翻断言为 vintage-exact + 新增同毫秒 tiebreak(D) + 边界(E) goldens（`multitable-undelete-inbound-resurrect-realdb.test.ts`）。零 wire、零 schema。**边界正确性核验（ratify 前）**：`reconstructRecordsAtT` 用 `created_at <= T`（record-reconstructor.ts:53），故 record 在 resurrect 集 ⟺ 其移除性 delete 严格 `> T`——锁定的 `> T` 是该边界的精确补集；`created_at == T` 的 delete ⇒ 该记录在 T 已不存在 ⇒ 本就不在 resurrect 集（golden E 钉住）。
+- ~~PROPOSED~~ 原始状态（保留供审计）：R10 gate-front 工件（4c-3 wave 验证 §4 项 (1)(2)）。
+- **历史现状（R8，已被本轮 A′ AS-BUILT 取代——保留供审计）**：PIT-undelete 的 resurrect 侧无 trash 行可携锚，R8 采用「该记录最新 `action='delete'` revision」`created_at DESC` 启发式选锚（univer-meta.ts ~:10183）；多 vintage 场景**只会 under-replay 不会 over-replay**（R8 多 vintage/未捕获 vintage goldens + 注释诚实化已落 main）。restore 侧（trash 路径）锚精确，无此问题。**R11 后**：resurrect 侧改为 asOf-derived vintage-exact 锚，under-replay 边界消除；restore 侧不变。
 
 ## 选项
 
@@ -19,4 +20,4 @@
 - 找不到时的语义：找不到 = 该记录 T 时刻未删，resurrect 集合本就不含它；以 goldens 钉边界（不回退启发式）。
 - Goldens：R8 的多 vintage/未捕获 vintage goldens 翻断言为精确重放；**新增同毫秒 golden**（两条 delete revision `created_at` 相同 → version/id tiebreak 选定且跨运行稳定）；锚选择突变（改回 latest-delete 启发式，或去掉任一 tiebreak 键）⇒ 对应 golden 红。
 
-- **解锁词**：owner 点头选项（A′/A/B/C）。选 C=关闭本项,从 owner 菜单划除。
+- **解锁词**：~~owner 点头选项（A′/A/B/C）~~ **已解锁 → A′（owner R11 directive 2026-07-11）**。本项从 owner 菜单出列（AS-BUILT）。

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -10163,29 +10163,35 @@ export function univerMetaRouter(): Router {
               }
               await recordRecordRevision(query, { sheetId, recordId: r.recordId, version: 1, action: 'create', source: 'restore', changedFieldIds: Object.keys(r.snapshot), patch: r.snapshot, snapshot: r.snapshot, actorId: undeleteActorId })
               // 4c-3 §7: the SECOND resurrection surface reuses the SAME replay helper — never a
-              // parallel inbound semantic. HONEST NOTE (R8 absorption-audit P3-1, reworded from an
-              // earlier "deterministic" claim that overstated this): resurrect has no trash row to
-              // read an anchor off (unlike restoreRecord's `meta_records_trash.delete_revision_id`),
-              // so it falls back to a HEURISTIC — the record's MOST RECENT 'delete' revision, by
-              // `created_at DESC`. Under multi-vintage churn (delete → restore → delete → resurrect
-              // an OLDER vintage via PIT asOf) this anchors to the LATEST deletion even when the
-              // snapshot being resurrected is an older one — it replays that one vintage's captured
-              // edges only, never strings multiple anchors together. If the most recent deletion
-              // happened while capture was off (or its tombstones already aged out via retention),
-              // the anchor still resolves but carries zero tombstones ⇒ zero replay — silent and
-              // honest, never fabricated. Under-replay (missing a vintage's edges) is the only
-              // failure mode this heuristic can produce; OVER-replay stays impossible regardless of
-              // which delete revision is picked, because precondition 6 (neighbour consent — replay
-              // only what N's OWN live `data` still declares) gates every edge independently of the
-              // anchor. See `multitable-undelete-inbound-resurrect-realdb.test.ts` for the pinned
-              // multi-vintage + uncaptured-vintage goldens. Runs AFTER the outbound loop (NOT EXISTS
-              // must see those rows; self-link stays single).
+              // parallel inbound semantic. Anchor derivation (R11 A′, ratified 2026-07-11 — replaces the
+              // R8 `created_at DESC` latest-delete heuristic): resurrect has no trash row to read an
+              // anchor off (unlike restoreRecord's `meta_records_trash.delete_revision_id`), but the
+              // revert already carries `asOf` T on the wire and the semantics are "restore the record as
+              // it existed at T". A record is in the resurrect set precisely because its latest revision
+              // with `created_at <= T` is NOT a delete (reconstructRecordsAtT, delete-aware), so the
+              // deletion that removed that T-era record is the FIRST 'delete' revision strictly AFTER T.
+              // Deriving the anchor from T (below) is therefore vintage-EXACT: under multi-vintage churn
+              // (delete → restore → delete → resurrect an OLDER vintage via PIT asOf) it anchors to THAT
+              // vintage's deletion and replays exactly that vintage's captured edges — never a later
+              // vintage's, never a cross-vintage union. The deterministic tiebreak
+              // `created_at ASC, version ASC, id ASC` (LOCK-11 parity, complement of reconstruct's
+              // `created_at <= T ... DESC`) makes the choice unique and stable even when two delete
+              // revisions share a millisecond; no implementation may drop a tiebreak key. A delete at
+              // exactly `created_at == T` means the record is absent at T (reconstruct includes it) and
+              // is never in the resurrect set — the strict `> T` correctly excludes it. If the deletion
+              // happened while capture was off (or its tombstones aged out via retention) the anchor
+              // still resolves but carries zero tombstones ⇒ zero replay — silent and honest, never
+              // fabricated. OVER-replay stays impossible regardless, because precondition 6 (neighbour
+              // consent — replay only what N's OWN live `data` still declares) gates every edge
+              // independently of the anchor. See `multitable-undelete-inbound-resurrect-realdb.test.ts`
+              // for the vintage-exact + same-ms tiebreak + boundary goldens. Runs AFTER the outbound
+              // loop (NOT EXISTS must see those rows; self-link stays single).
               if (isRecordUndeleteInboundEnabled()) {
                 const anchorRes = await query(
                   `SELECT id FROM meta_record_revisions
-                    WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete'
-                    ORDER BY created_at DESC, version DESC, id DESC LIMIT 1`,
-                  [sheetId, r.recordId],
+                    WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete' AND created_at > $3
+                    ORDER BY created_at ASC, version ASC, id ASC LIMIT 1`,
+                  [sheetId, r.recordId, asOfIso],
                 )
                 const anchorId = ((anchorRes.rows as Array<{ id?: string }>)[0]?.id) ?? null
                 if (anchorId) {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -10176,9 +10176,13 @@ export function univerMetaRouter(): Router {
               // vintage's, never a cross-vintage union. The deterministic tiebreak
               // `created_at ASC, version ASC, id ASC` (LOCK-11 parity, complement of reconstruct's
               // `created_at <= T ... DESC`) makes the choice unique and stable even when two delete
-              // revisions share a millisecond; no implementation may drop a tiebreak key. A delete at
-              // exactly `created_at == T` means the record is absent at T (reconstruct includes it) and
-              // is never in the resurrect set — the strict `> T` correctly excludes it. If the deletion
+              // revisions share a millisecond (version is the exercised discriminator; id is
+              // belt-and-suspenders — the version index is not UNIQUE). A delete at exactly
+              // `created_at == T` that is the record's latest `<= T` revision ⇒ absent at T ⇒ not in the
+              // resurrect set (golden E). The STRICTNESS of `> T` (vs `>= T`) is load-bearing in the
+              // inverse case: a re-create at exactly T makes the record PRESENT at T, so its removing
+              // delete is a strictly-later one — `>= T` would mis-anchor to the prior vintage's
+              // same-instant delete (golden F). If the deletion
               // happened while capture was off (or its tombstones aged out via retention) the anchor
               // still resolves but carries zero tombstones ⇒ zero replay — silent and honest, never
               // fabricated. OVER-replay stays impossible regardless, because precondition 6 (neighbour

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
@@ -19,8 +19,12 @@
  *   (C) flag OFF: byte-identical to pre-4c-3 (no undeleteInbound field).
  *   (D) same-millisecond tiebreak: two delete revisions share `created_at`; `version ASC, id ASC`
  *       selects a unique, stable anchor (mutation: `version DESC` flips which neighbour replays).
- *   (E) boundary: a delete at exactly `created_at == T` ⇒ record absent at T ⇒ NOT resurrected
- *       (the strict `> T` complements reconstruct's `<= T`).
+ *   (E) boundary — absent-at-T: a delete at exactly `created_at == T` is the record's latest revision ⇒
+ *       absent at T ⇒ NOT resurrected. Pins reconstruct's `<= T` EXCLUSION (the record never reaches the
+ *       anchor query), NOT the anchor's `> T` strictness.
+ *   (F) boundary — strict `> T` is load-bearing: a re-create at exactly T makes the record PRESENT at T, so
+ *       its removing delete is a LATER one; `>= T` would mis-anchor to the prior vintage's same-instant
+ *       delete. This is the ONLY golden that reds under `> T` → `>= T`.
  * Over-replay stays impossible regardless of which delete revision anchors, because precondition 6
  * (neighbour consent — replay only what N's OWN live data still declares) gates every edge
  * independently of the anchor.
@@ -51,6 +55,7 @@ const T0_5 = '2026-01-01T12:00:00.000Z'
 const T1 = '2026-01-02T00:00:00.000Z'
 const T1_5 = '2026-01-02T12:00:00.000Z'
 const T2 = '2026-01-03T00:00:00.000Z'
+const T3 = '2026-01-04T00:00:00.000Z'
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 let app: Express
@@ -264,5 +269,44 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anc
     expect(pv.status).toBe(200)
     expect(pv.body?.data?.undeleteRecordIds ?? []).not.toContain(R)
     expect(await edgeCount(F, N, R)).toBe(0) // never resurrected, so no inbound edge replayed
+  })
+
+  test('(F) strict > T is load-bearing: a re-create at exactly T means the removing delete is a LATER one — >= T would mis-anchor to the prior vintage\'s delete', async () => {
+    // The one shape golden (E) does NOT cover: at exactly T the record EXISTS (a re-create landed at T with
+    // a higher version than the same-instant delete of the previous vintage), so it IS in the resurrect set.
+    // reconstruct (`created_at <= T`, DISTINCT ON ... version DESC) picks the v3 CREATE as the state at T.
+    // The deletion that removed THAT vintage is v4 (T3), strictly after T. Shipped `created_at > T` anchors to
+    // v4 (correct). Mutating the query to `created_at >= T` would anchor to v2 (the T2 delete of the OLD
+    // vintage) and replay the wrong neighbour — this golden is the ONLY one that reds under `>=`.
+    process.env[INBOUND_FLAG] = 'true'
+    const F = mkFieldId('f')
+    await insertField(SHEET_B, F)
+    const R = mkRecordId('f_r')
+    const Nv2 = mkRecordId('f_nv2') // edge captured under v2 (the T2 delete of the OLD, un-resurrected vintage)
+    const Nv4 = mkRecordId('f_nv4') // edge captured under v4 (the T3 delete of the RESURRECTED vintage)
+    await insertRecord(SHEET_B, Nv2, { [F]: [R] })
+    await insertRecord(SHEET_B, Nv4, { [F]: [R] })
+
+    const SNAP_V1 = { [NAME]: 'v1' }
+    const SNAP_V3 = { [NAME]: 'v3' }
+    await rev(SHEET_A, R, 1, 'create', SNAP_V1, T0)
+    const dv2 = await rev(SHEET_A, R, 2, 'delete', SNAP_V1, T2) // delete of vintage-1, exactly at T2
+    await insertTombstone(SHEET_A, F, Nv2, R, dv2)
+    await rev(SHEET_A, R, 3, 'create', SNAP_V3, T2) // re-create at exactly T2 (higher version ⇒ latest <= T2)
+    const dv4 = await rev(SHEET_A, R, 4, 'delete', SNAP_V3, T3) // delete of vintage-3, later
+    await insertTombstone(SHEET_A, F, Nv4, R, dv4)
+
+    const pv = await preview(T2)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.undeleteRecordIds).toEqual([R])
+    const ex = await execute(T2, pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200)
+    expect(ex.body?.data?.resurrectedCount).toBe(1)
+    const live = await liveRow(R)
+    expect(live?.data?.[NAME]).toBe('v3') // the AT-T (re-created) vintage was resurrected, not vintage-1
+    // strict `> T2` anchors to v4 (vintage-3's own delete) → Nv4 replays, Nv2 does not.
+    expect(await edgeCount(F, Nv4, R)).toBe(1)
+    expect(await edgeCount(F, Nv2, R)).toBe(0)
+    expect(ex.body?.data?.undeleteInbound).toMatchObject({ replayed: 1 })
   })
 })

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
@@ -1,25 +1,33 @@
 /**
  * 4c-3 §7 — PIT-resurrect (`POST /sheets/:id/revert-execute`, T8-1 undelete) inbound-edge replay (real
- * DB). R8 absorption-audit hardening (P3-1, post-hoc — no product behaviour changed). PR #3975 wired
- * resurrect to reuse the SAME `replayInboundLinks` helper restore uses (design-lock §7: "never a
- * parallel inbound semantic"), but shipped with no dedicated golden for its anchor derivation, which
- * — unlike restore's `meta_records_trash.delete_revision_id` column — is a HEURISTIC: resurrect has no
- * trash row, so it anchors to the record's MOST RECENT 'delete' revision (`ORDER BY created_at DESC`).
+ * DB). R11 A′ (ratified 2026-07-11) — the anchor is now DERIVED from the revert's `asOf` T, replacing
+ * the R8 `created_at DESC` latest-delete heuristic. Resurrect has no trash row (unlike restore's
+ * `meta_records_trash.delete_revision_id`), but the revert carries T on the wire and the semantics are
+ * "restore the record as it existed at T"; a record is in the resurrect set precisely because its
+ * latest revision with `created_at <= T` is NOT a delete (reconstructRecordsAtT), so the removing
+ * deletion is the FIRST 'delete' revision strictly AFTER T — a vintage-EXACT anchor:
+ * `SELECT ... WHERE action='delete' AND created_at > T ORDER BY created_at ASC, version ASC, id ASC LIMIT 1`.
  *
- * This file pins the two honest consequences of that heuristic (see the reworded comment at
- * `univer-meta.ts` ~10165, which used to overclaim "deterministic"):
- *   (A) multi-vintage: resurrecting an OLDER vintage's snapshot still anchors to the LATEST delete
- *       revision — replaying only that vintage's captured edges, never stringing multiple anchors'
- *       tombstones together (no cross-vintage double-replay).
- *   (B) the most recent deletion happened while capture was off (zero tombstones for that anchor) →
+ * Goldens:
+ *   (A) multi-vintage: resurrecting an OLDER vintage's snapshot anchors to THAT vintage's deletion
+ *       (first delete after T), replaying exactly that vintage's captured edges — never the LATEST
+ *       deletion's, never a cross-vintage union. This assertion is the INVERSE of the R8 heuristic
+ *       golden (which replayed the latest vintage's edges); reverting the query to `created_at DESC`
+ *       flips it red.
+ *   (B) the removing deletion happened while capture was off (zero tombstones for that anchor) →
  *       silent zero replay, honest, never an error and never fabricated.
- * Over-replay stays impossible in both cases regardless of which delete revision the heuristic picks,
- * because precondition 6 (neighbour consent — replay only what N's OWN live data still declares) gates
- * every edge independently of the anchor.
+ *   (C) flag OFF: byte-identical to pre-4c-3 (no undeleteInbound field).
+ *   (D) same-millisecond tiebreak: two delete revisions share `created_at`; `version ASC, id ASC`
+ *       selects a unique, stable anchor (mutation: `version DESC` flips which neighbour replays).
+ *   (E) boundary: a delete at exactly `created_at == T` ⇒ record absent at T ⇒ NOT resurrected
+ *       (the strict `> T` complements reconstruct's `<= T`).
+ * Over-replay stays impossible regardless of which delete revision anchors, because precondition 6
+ * (neighbour consent — replay only what N's OWN live data still declares) gates every edge
+ * independently of the anchor.
  *
  * Design-lock: `docs/development/multitable-global-history-4c3-record-undelete-2b-inbound-edge-replay-
- * design-lock-20260708.md` §7. Audit: `/tmp/pr3975-4c3-absorption-audit-claude-20260709.md` (P3-1).
- * Runs only with DATABASE_URL.
+ * design-lock-20260708.md` §7; A′ decision: `multitable-global-history-resurrect-anchor-exactness-
+ * decision-20260710.md`. Runs only with DATABASE_URL.
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
@@ -114,7 +122,7 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anc
 
   test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
 
-  test('(A) multi-vintage: resurrecting an OLDER vintage anchors to the LATEST delete revision — replays ONLY that vintage, never strings anchors together', async () => {
+  test('(A) multi-vintage: resurrecting an OLDER vintage anchors to THAT vintage\'s deletion (first delete after T) — replays vintage-1, NOT the latest vintage', async () => {
     process.env[INBOUND_FLAG] = 'true'
     const F = mkFieldId('a')
     await insertField(SHEET_B, F)
@@ -144,13 +152,14 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anc
     const live = await liveRow(R)
     expect(live?.data?.[NAME]).toBe('vintage-1') // the OLD vintage's snapshot was indeed resurrected
 
-    // Anchor = latest delete revision (del2, vintage-2) — so vintage-2's neighbour replays...
-    expect(await edgeCount(F, N2, R)).toBe(1)
+    // A′: anchor = FIRST delete after T0_5 = del1 (vintage-1's own deletion). So vintage-1's neighbour
+    // replays — the vintage-EXACT edge, matching the resurrected snapshot...
+    expect(await edgeCount(F, N1, R)).toBe(1)
     expect(ex.body?.data?.undeleteInbound).toMatchObject({ replayed: 1 })
-    // ...but vintage-1's neighbour does NOT — its tombstone lives under a DIFFERENT anchor (del1) that
-    // this resurrect never queries. This is the honest, pinned consequence of the heuristic: exactly
-    // one vintage's edges replay, never a cross-vintage union.
-    expect(await edgeCount(F, N1, R)).toBe(0)
+    // ...and vintage-2's neighbour does NOT — its tombstone lives under a LATER anchor (del2) that a
+    // T0_5 revert never reaches. Reverting the anchor query to `created_at DESC` (the R8 heuristic)
+    // inverts both assertions: N2 replays, N1 does not.
+    expect(await edgeCount(F, N2, R)).toBe(0)
   })
 
   test('(B) most recent deletion was uncaptured (zero tombstones for its anchor): silent zero replay, no error, resurrect still succeeds', async () => {
@@ -197,5 +206,63 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anc
     expect(ex.status).toBe(200)
     expect(ex.body?.data?.undeleteInbound).toBeUndefined()
     expect(await edgeCount(F, N, R)).toBe(0) // today's (pre-4c-3) behavior: inbound stays lost on resurrect
+  })
+
+  test('(D) same-millisecond tiebreak: two delete revisions share created_at — version ASC, id ASC picks a unique, stable anchor', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const F = mkFieldId('d')
+    await insertField(SHEET_B, F)
+    const R = mkRecordId('d_r')
+    const Na = mkRecordId('d_na') // edge captured under the LOWER-version delete (v2)
+    const Nb = mkRecordId('d_nb') // edge captured under the HIGHER-version delete (v4)
+    await insertRecord(SHEET_B, Na, { [F]: [R] })
+    await insertRecord(SHEET_B, Nb, { [F]: [R] })
+
+    const SNAP_V1 = { [NAME]: 'v1' }
+    const SNAP_V2 = { [NAME]: 'v2' }
+    await rev(SHEET_A, R, 1, 'create', SNAP_V1, T0)
+    // delete v2, restore v3, delete v4 — ALL sharing the same created_at (T1). Rapid same-ms churn.
+    const delLo = await rev(SHEET_A, R, 2, 'delete', SNAP_V1, T1)
+    await insertTombstone(SHEET_A, F, Na, R, delLo)
+    await rev(SHEET_A, R, 3, 'create', SNAP_V2, T1)
+    const delHi = await rev(SHEET_A, R, 4, 'delete', SNAP_V2, T1)
+    await insertTombstone(SHEET_A, F, Nb, R, delHi)
+
+    // Resurrect at T0_5 (< T1) → the v1 snapshot. Anchor = first delete after T0_5, and with delLo/delHi
+    // tied on created_at, `version ASC` picks delLo (v2). Na replays; Nb does not. Mutation: flipping the
+    // anchor query to `version DESC` (or dropping the version tiebreak so id decides differently) selects
+    // delHi and replays Nb instead ⇒ this golden goes red.
+    const pv = await preview(T0_5)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.undeleteRecordIds).toEqual([R])
+    const ex = await execute(T0_5, pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200)
+    expect(ex.body?.data?.resurrectedCount).toBe(1)
+    expect(ex.body?.data?.undeleteInbound).toMatchObject({ replayed: 1 })
+    expect(await edgeCount(F, Na, R)).toBe(1)
+    expect(await edgeCount(F, Nb, R)).toBe(0)
+  })
+
+  test('(E) boundary: a delete at exactly created_at == T ⇒ record absent at T ⇒ NOT in the resurrect set (strict > T complements reconstruct\'s <= T)', async () => {
+    process.env[INBOUND_FLAG] = 'true'
+    const F = mkFieldId('e')
+    await insertField(SHEET_B, F)
+    const R = mkRecordId('e_r')
+    const N = mkRecordId('e_n')
+    await insertRecord(SHEET_B, N, { [F]: [R] })
+
+    const SNAP = { [NAME]: 'boundary' }
+    await rev(SHEET_A, R, 1, 'create', SNAP, T0)
+    const delAtT = await rev(SHEET_A, R, 2, 'delete', SNAP, T2) // deleted at exactly T2
+    await insertTombstone(SHEET_A, F, N, R, delAtT)
+
+    // Revert to exactly T2: reconstructRecordsAtT applies `created_at <= T2`, so the delete@T2 is the
+    // latest revision ⇒ the record is ABSENT at T2 ⇒ it is never in the "existed at T but deleted now"
+    // resurrect set. The strict `created_at > T` anchor query would also skip that delete, but the record
+    // never reaches the anchor step because it is excluded upstream.
+    const pv = await preview(T2)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.undeleteRecordIds ?? []).not.toContain(R)
+    expect(await edgeCount(F, N, R)).toBe(0) // never resurrected, so no inbound edge replayed
   })
 })


### PR DESCRIPTION
## What / why

Ratifies + implements **anchor A′** (owner R11 directive: "ratify 锚 A′ 并优先实现") from `multitable-global-history-resurrect-anchor-exactness-decision-20260710.md`.

The record-undelete **resurrect** path (`revert-execute`, T8-1) has no `meta_records_trash.delete_revision_id` to anchor inbound-edge replay off. R8 fell back to the record's **most recent** delete revision (`created_at DESC`) — under multi-vintage churn (delete → restore → delete → resurrect an OLDER vintage via PIT `asOf`) this anchors to the **latest** deletion, silently **under-replaying** the vintage-correct edges.

A record is in the resurrect set precisely because its latest revision with `created_at <= T` is **not** a delete (`reconstructRecordsAtT`), so the deletion that removed the T-era record is the **first** delete revision strictly **after T**. The anchor is now derived from the `asOf` T the revert already carries:

```
WHERE action='delete' AND created_at > T ORDER BY created_at ASC, version ASC, id ASC LIMIT 1
```

**Zero wire, zero schema.** The deterministic tiebreak (LOCK-11 parity) is the exact complement of reconstruct's `created_at <= T ... DESC`.

## Boundary correctness (verified before ratify)

`reconstructRecordsAtT` uses `created_at <= T` (`record-reconstructor.ts:53`). So a record is in the resurrect set ⟺ its removing delete is strictly `> T` — the locked `> T` is the precise complement. A delete at exactly `created_at == T` ⇒ record absent at T ⇒ never in the resurrect set (golden E pins this).

## Goldens (`multitable-undelete-inbound-resurrect-realdb.test.ts`, in plugin-tests.yml whitelist)

- **(A)** flipped to **vintage-exact**: resurrecting the T0.5 vintage replays vintage-1's neighbour (N1), NOT the latest vintage's (N2) — the inverse of the R8 heuristic golden.
- **(B)/(C)** unchanged (uncaptured-anchor zero-replay; flag-off byte-identical).
- **(D)** new **same-millisecond tiebreak**: two deletes share `created_at`; `version ASC, id ASC` picks a unique, stable anchor.
- **(E)** new **boundary**: `created_at == T` ⇒ absent-at-T ⇒ not resurrected.

**Mutation-verified on a real DB (postgres:16-alpine + CI MIGRATION_EXCLUDE):**
- revert query → `created_at DESC` (R8 heuristic) ⇒ **(A) + (D) red**, B/C/E green
- flip only `version DESC` ⇒ **(D) red**, A/B/C/E green
- restored ⇒ 6/6 green; sibling `...inbound-replay-realdb` 17/17 unaffected

## Scope guards

- Only affects behaviour when `MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND` is on (default-off). No flag flip here.
- `restore` side (trash-anchored) unchanged. Over-replay stays impossible (precondition 6 neighbour-consent gates every edge independently of the anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)