### PR TITLE
fix(dingtalk): P2 wire-contract — IM_ROBOT casing + callback reads official params.action

### DIFF
--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -861,7 +861,11 @@ export async function sendDingTalkInteractiveApprovalCard(
   if (!rejectUrl) throw new Error('DingTalk interactive-card reject url is required')
   if (!callbackRouteKey) throw new Error('DingTalk interactive-card callback route key is required')
 
-  const openSpaceId = `dtv1.card//im_robot.${userId}`
+  // openSpaceId spaceType segment casing per DingTalk's official card-callback contract: the
+  // documented value is UPPERCASE `IM_ROBOT` (the sample library + `imRobotOpenDeliverModel.spaceType`
+  // below both use `IM_ROBOT`; a lowercase segment here was internally inconsistent). UAT-confirmable
+  // against the real createAndDeliver API.
+  const openSpaceId = `dtv1.card//IM_ROBOT.${userId}`
   const payload = await requestDingTalkJson(
     `${normalizeDingTalkOpenApiBaseUrl(config.openApiBaseUrl)}/v1.0/card/instances/createAndDeliver`,
     {

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
@@ -140,35 +140,72 @@ async function resolveIntegrationCorpId(query: QueryFn, integrationId: string): 
 }
 
 /**
- * Action ids submitted by the card button, read from the documented DingTalk card-callback
- * `content.cardPrivateData.actionIds` shape (string or pre-parsed object).
+ * The action a card button submitted, read from the documented DingTalk card-callback `content`
+ * frame (string or pre-parsed object). Two channels are read from the SAME parse of `content`:
  *
- * Review P3-1: returns `null` when content was PROVIDED but is unreadable (bad JSON / not an
- * object) — the caller must fail-close on that even when an explicit `action` spelling is also
- * present (an unreadable wire frame is a wire frame whose opinion we could not check, not the
- * absence of one). `[]` = readable but carries no action ids (no wire opinion).
+ * - `cardPrivateData.params.action` — the OFFICIAL/PRIMARY channel DingTalk's approval-template
+ *   callback handler fills (P2-2). A single action string.
+ * - `cardPrivateData.actionIds` — the SECONDARY/backward-compat channel (depends on the operator
+ *   configuring the component's actionId literally, e.g. `approve`). A list; a single entry is the
+ *   clicked action, an empty/multi list carries no clean single opinion.
+ *
+ * The caller reconciles the two (they must AGREE when both are present) — see
+ * `parseDingTalkApprovalCardCallback`.
+ *
+ * Review P3-1: returns `{ readable: false }` when content was PROVIDED but is unreadable (bad JSON
+ * / not an object) — the caller must fail-close on that even when an explicit `action` spelling or
+ * a `params.action` would otherwise be present (an unreadable wire frame is a frame whose opinion
+ * we could not check, not the absence of one). `{ readable: true, ... }` with an empty
+ * `paramsAction` and `[]` actionIds = readable but carrying no wire opinion.
  */
-function readWireActionIds(content: unknown): string[] | null {
+type WireActionRead =
+  | { readable: false }
+  | { readable: true; paramsAction: string; actionIds: string[] }
+
+function readWireAction(content: unknown): WireActionRead {
   let record = asRecord(content)
   if (typeof content === 'string') {
     try {
       record = asRecord(JSON.parse(content))
     } catch {
-      return null
+      return { readable: false }
     }
   }
-  if (record === null) return null
+  if (record === null) return { readable: false }
   const cardPrivateData = asRecord(record.cardPrivateData)
-  const actionIds = cardPrivateData?.actionIds
-  if (!Array.isArray(actionIds)) return []
-  return actionIds.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+  const paramsAction = readTrimmedString(asRecord(cardPrivateData?.params)?.action)
+  const rawActionIds = cardPrivateData?.actionIds
+  const actionIds = Array.isArray(rawActionIds)
+    ? rawActionIds.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    : []
+  return { readable: true, paramsAction, actionIds }
+}
+
+/**
+ * Reduces the readable wire frame to a single action opinion by reconciling the PRIMARY
+ * (`params.action`) and SECONDARY (`actionIds`) channels:
+ * - a multi-entry `actionIds` list is an ambiguous multi-button signal → `conflict` (no clean pick);
+ * - otherwise both present channels must AGREE (disagreement → `conflict`, fail-closed no-op);
+ * - either one alone is used; neither present → empty opinion (`''`).
+ */
+function resolveWireAction(read: { paramsAction: string; actionIds: string[] }): { action: string } | { conflict: true } {
+  if (read.actionIds.length > 1) return { conflict: true }
+  const idAction = read.actionIds.length === 1 ? read.actionIds[0] : ''
+  if (read.paramsAction && idAction && read.paramsAction !== idAction) return { conflict: true }
+  return { action: read.paramsAction || idAction }
 }
 
 /**
  * Parses/normalizes an incoming callback payload into the ratified triple. Accepts either the
  * pre-normalized business shape (`action`/`operatorDingTalkUserId`) or the documented DingTalk
- * wire frame (`userId` + `content.cardPrivateData.actionIds`); when both spellings are present
- * they must agree — disagreement fail-closes instead of picking a side.
+ * wire frame (`userId` + `content.cardPrivateData.{params.action | actionIds}`).
+ *
+ * Action channels (P2-2): `content.cardPrivateData.params.action` is the OFFICIAL PRIMARY channel
+ * DingTalk's approval-template callback fills; `content.cardPrivateData.actionIds` is SECONDARY
+ * (backward-compat). Whenever more than one spelling is present — the two wire channels, or the
+ * wire opinion vs the pre-normalized `action` — they must AGREE; any disagreement fail-closes to a
+ * recorded no-op instead of picking a side. A template that fills only `params.action` (with or
+ * without `actionIds`) is accepted; a single `actionIds` entry with no `params.action` still works.
  *
  * Validation order per lock §B-3: outTrackId UUID gate → action approve-only → operator present.
  * The transport frame's remaining fields are NEVER read.
@@ -187,16 +224,26 @@ export function parseDingTalkApprovalCardCallback(payload: unknown): DingTalkApp
   const outTrackId = rawOutTrackId.toLowerCase()
 
   // 2. action — exactly 'approve'; anything else (including ambiguity or unreadable content) is a
-  //    recorded no-op, never mapped heuristically.
+  //    recorded no-op, never mapped heuristically. The action opinion is reconciled across three
+  //    possible spellings: the pre-normalized business `action`, the PRIMARY wire channel
+  //    `content.cardPrivateData.params.action`, and the SECONDARY `content.cardPrivateData.actionIds`.
   const explicitAction = readTrimmedString(record.action)
-  const wireActionIds = 'content' in record && record.content !== undefined ? readWireActionIds(record.content) : []
+  // No `content` key → a readable frame with no wire opinion (the pre-normalized business shape).
+  const wire: WireActionRead = 'content' in record && record.content !== undefined
+    ? readWireAction(record.content)
+    : { readable: true, paramsAction: '', actionIds: [] }
   let action = ''
-  // Review P3-1: `null` = content provided but unreadable → fail-close (action stays ''), even
-  // with an explicit approve spelling alongside — never accept what we could not cross-check.
-  if (wireActionIds !== null) {
-    if (explicitAction && wireActionIds.length === 0) action = explicitAction
-    else if (!explicitAction && wireActionIds.length === 1) action = wireActionIds[0]
-    else if (explicitAction && wireActionIds.length === 1 && wireActionIds[0] === explicitAction) action = explicitAction
+  // Review P3-1: content provided but unreadable (bad JSON / not an object) → fail-close (action
+  // stays ''), even with an explicit approve spelling alongside — never accept what we could not
+  // cross-check. A READABLE frame carrying a valid `params.action` is NOT rejected by this gate.
+  if (wire.readable) {
+    const resolved = resolveWireAction(wire)
+    if (!('conflict' in resolved)) {
+      const wireAction = resolved.action
+      // The pre-normalized `action` and the resolved wire opinion must agree when both present.
+      if (explicitAction && wireAction && explicitAction !== wireAction) action = ''
+      else action = explicitAction || wireAction
+    }
   }
   if (action !== 'approve') return { ok: false, outcome: 'ignored_unsupported_action', outTrackId }
 

--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -456,7 +456,7 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     expect(body.callbackType).toBe('STREAM')
     expect(body.callbackRouteKey).toBe('approval_card')
     expect(body.userId).toBe(DD_USER_ID)
-    expect(body.openSpaceId).toBe(`dtv1.card//im_robot.${DD_USER_ID}`)
+    expect(body.openSpaceId).toBe(`dtv1.card//IM_ROBOT.${DD_USER_ID}`)
     expect(body.imRobotOpenSpaceModel).toEqual({ supportForward: false })
     expect(body.imRobotOpenDeliverModel).toEqual({ robotCode: 'stream-app-key', spaceType: 'IM_ROBOT' })
     expect(body).not.toHaveProperty('openSpaceModel')

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
@@ -186,6 +186,83 @@ describe('parseDingTalkApprovalCardCallback (B-3 §B-3 shape gates)', () => {
   })
 })
 
+// ── P2-2: the OFFICIAL params.action wire channel (primary) + actionIds (secondary) ────────────
+
+describe('parseDingTalkApprovalCardCallback (P2-2 params.action official channel)', () => {
+  type Parsed = ReturnType<typeof parseDingTalkApprovalCardCallback>
+  const expectApprove = (parsed: Parsed) =>
+    expect(parsed).toEqual({
+      ok: true,
+      callback: { outTrackId: DELIVERY_ID, action: 'approve', operatorDingTalkUserId: OPERATOR },
+    })
+  const expectNoOp = (parsed: Parsed) =>
+    expect(parsed).toEqual({ ok: false, outcome: 'ignored_unsupported_action', outTrackId: DELIVERY_ID })
+
+  it('(a) PRIMARY channel: params.action=approve with NO actionIds → approve (string or object content)', () => {
+    expectApprove(parseDingTalkApprovalCardCallback(wirePayload({
+      content: JSON.stringify({ cardPrivateData: { params: { action: 'approve' } } }),
+    })))
+    expectApprove(parseDingTalkApprovalCardCallback(wirePayload({
+      content: { cardPrivateData: { params: { action: 'approve' } } },
+    })))
+  })
+
+  it('(b) params.action and actionIds AGREE → approve', () => {
+    expectApprove(parseDingTalkApprovalCardCallback(wirePayload({
+      content: JSON.stringify({ cardPrivateData: { params: { action: 'approve' }, actionIds: ['approve'] } }),
+    })))
+  })
+
+  it('(c) params.action vs actionIds DISAGREE → fail-closed no-op (symmetric)', () => {
+    expectNoOp(parseDingTalkApprovalCardCallback(wirePayload({
+      content: JSON.stringify({ cardPrivateData: { params: { action: 'approve' }, actionIds: ['reject'] } }),
+    })))
+    expectNoOp(parseDingTalkApprovalCardCallback(wirePayload({
+      content: JSON.stringify({ cardPrivateData: { params: { action: 'reject' }, actionIds: ['approve'] } }),
+    })))
+  })
+
+  it('(d) params.action=reject → approve-only no-op', () => {
+    expectNoOp(parseDingTalkApprovalCardCallback(wirePayload({
+      content: JSON.stringify({ cardPrivateData: { params: { action: 'reject' } } }),
+    })))
+  })
+
+  it('(e) backward-compat: a single actionIds entry with NO params.action → approve', () => {
+    expectApprove(parseDingTalkApprovalCardCallback(wirePayload({
+      content: JSON.stringify({ cardPrivateData: { actionIds: ['approve'] } }),
+    })))
+    expectApprove(parseDingTalkApprovalCardCallback(wirePayload({
+      content: JSON.stringify({ cardPrivateData: { actionIds: ['approve'], params: {} } }),
+    })))
+  })
+
+  it('(f) P3-1 preserved: genuinely unreadable content (no readable params) → no-op, even with explicit approve', () => {
+    expectNoOp(parseDingTalkApprovalCardCallback(wirePayload({ content: 'not-json{{' })))
+    expectNoOp(parseDingTalkApprovalCardCallback(wirePayload({ action: 'approve', content: 'not-json{{' })))
+    expectNoOp(parseDingTalkApprovalCardCallback(wirePayload({ action: 'approve', content: 42 })))
+  })
+
+  it('a READABLE frame carrying only params.action is NOT swallowed by the P3-1 unreadable gate', () => {
+    // Regression guard: the P3-1 "content present but unreadable → fail-close" must not reject a
+    // valid template callback that legitimately fills params.action and omits actionIds.
+    expect(parseDingTalkApprovalCardCallback(wirePayload({
+      content: JSON.stringify({ cardPrivateData: { params: { action: 'approve' } } }),
+    })).ok).toBe(true)
+  })
+
+  it('pre-normalized business action + params.action: agreement → approve, disagreement → no-op', () => {
+    expectApprove(parseDingTalkApprovalCardCallback(wirePayload({
+      action: 'approve',
+      content: JSON.stringify({ cardPrivateData: { params: { action: 'approve' } } }),
+    })))
+    expectNoOp(parseDingTalkApprovalCardCallback(wirePayload({
+      action: 'approve',
+      content: JSON.stringify({ cardPrivateData: { params: { action: 'reject' } } }),
+    })))
+  })
+})
+
 // ── executor: ledger-only resolution + fail-closed operator + wrapper funneling ────────────────
 
 type QueryCall = { sql: string; params: unknown[] }
@@ -289,6 +366,16 @@ describe('executeDingTalkApprovalCardCallback (B-3 §B-3 execution)', () => {
     expect(result).toEqual({ outcome: 'ignored_unsupported_action', outTrackId: DELIVERY_ID })
     expect(h.calls).toHaveLength(0)
     expect(h.dispatchAction).not.toHaveBeenCalled()
+  })
+
+  it('P2-2: a params.action=approve template callback (no actionIds) executes through the wrapper', async () => {
+    const h = makeHarness()
+    const result = await executeDingTalkApprovalCardCallback(
+      h.deps as never,
+      wirePayload({ content: JSON.stringify({ cardPrivateData: { params: { action: 'approve' } } }) }),
+    )
+    expect(result.outcome).toBe('executed')
+    expect(h.dispatchAction).toHaveBeenCalledTimes(1)
   })
 
   it('unknown delivery id → delivery_not_found (values-free, no engine call)', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
@@ -166,7 +166,7 @@ describe('dingtalk work notification client', () => {
           rejectUrl: 'https://ms.example.test/m/approval-decision?d=delivery-1&t=token',
         },
       },
-      openSpaceId: 'dtv1.card//im_robot.dt-user-1',
+      openSpaceId: 'dtv1.card//IM_ROBOT.dt-user-1',
       imRobotOpenSpaceModel: { supportForward: false },
       imRobotOpenDeliverModel: { robotCode: 'ding-app-key', spaceType: 'IM_ROBOT' },
     })


### PR DESCRIPTION
Two P2 wire-contract deviations from the owner REQUEST-CHANGES review. Interactive-card path stays flag-OFF.

**P2-1 openSpaceId casing (`im_robot` → `IM_ROBOT`)** — `client.ts` sent lowercase `dtv1.card//im_robot.<userId>` while the same createAndDeliver body already sends `imRobotOpenDeliverModel.spaceType: 'IM_ROBOT'`. DingTalk's official card-callback contract + sample library use UPPERCASE; lowercase was internally inconsistent and unverified. Flipped the two fixtures that pinned the lowercase guess (a guess, not evidence). UAT-confirmable.

**P2-2 callback parser reads the official `params.action`** — the parser read ONLY `cardPrivateData.actionIds`, which depends on the operator naming the component's actionId literally `approve` (fragile); DingTalk's official approval-template callback fills `cardPrivateData.params.action`. Now: `params.action` = PRIMARY (official), `actionIds` = SECONDARY (backward compat); both present must AGREE (disagreement → fail-closed no-op); either alone works; neither readable → existing no-op. approve-only invariant kept; P3-1 unreadable-content fail-closed preserved for genuinely-unreadable content, but a readable frame filling `params.action` is no longer rejected.

**Verify:** full backend unit 370 files / 5094 pass; tsc clean. New goldens cover params-only / agree / disagree / reject / backward-compat / unreadable, with RED-before (5 fail on the old parser) and a mutation check proving the `params.action` path is load-bearing (neuter → 5 fail). No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
