### PR TITLE
feat(multitable): masked cross-table fieldNames in History batch detail (R11 all-tables-B)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -243,6 +243,7 @@ jobs:
             tests/integration/multitable-record-restore.test.ts \
             tests/integration/multitable-record-recycle-bin.test.ts \
             tests/integration/multitable-history-events-realdb.test.ts \
+            tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts \
             tests/integration/multitable-history-events-hasmore-realdb.test.ts \
             tests/integration/multitable-history-audit-grant-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-realdb.test.ts \

--- a/apps/web/src/multitable/components/HistoryBatchChangesList.vue
+++ b/apps/web/src/multitable/components/HistoryBatchChangesList.vue
@@ -24,7 +24,7 @@
       </div>
       <ul v-if="c.changedFieldIds.length" class="meta-hist__diff" data-test="hist-diff">
         <li v-for="d in changeFieldDiffs(c)" :key="d.fieldId" class="meta-hist__diff-row" data-test="hist-diff-row">
-          <span class="meta-hist__diff-label" :title="diffFieldName(d.fieldId)">{{ diffFieldName(d.fieldId) }}</span>
+          <span class="meta-hist__diff-label" :title="diffFieldName(d.fieldId, c.sheetId)">{{ diffFieldName(d.fieldId, c.sheetId) }}</span>
           <span class="meta-hist__diff-values">
             <template v-if="d.shape === 'masked'">
               <span class="meta-hist__diff-masked" data-test="hist-diff-masked">{{ diffMaskedLabel() }}</span>
@@ -67,6 +67,12 @@ const props = defineProps<{
    *  own count/id fallbacks — never a fetch, never un-masking. */
   linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
   personSummaries?: Record<string, Record<string, PersonSummary[]>>
+  /** all-tables-B (R11): server-masked field-id → display-name map, keyed by sheetId, from the batch-detail
+   *  payload (`HistoryBatchDetail.fieldNames`). Lets a change row on a NON-active sheet (all-tables mode)
+   *  show its field name instead of a raw id. Already two-layer-masked server-side (layer-2 property-hidden ∩
+   *  layer-3 field_permissions), so it carries only names the actor may see — the FE never re-derives the
+   *  mask (the #4007 footgun). Active-table rows still resolve via `fields`; both sources are masked. */
+  fieldNames?: Record<string, Record<string, string>>
   /** Reuses the caller's own action-label map (kept as a single source of truth in HistoryCenterModal.vue —
    *  this is prop-drilling, not a shared-module extraction, per the AI-fields S1 design-lock's constraint
    *  on `sourceLabel` NOT applying here since this is a distinct map (per-change action, not source)). */
@@ -172,8 +178,12 @@ function changeFieldDiffs(c: HistoryChange): FieldDiffRow[] {
     }
   })
 }
-function diffFieldName(fieldId: string): string {
-  return props.fields?.find((f) => f.id === fieldId)?.name ?? fieldId
+// all-tables-B: the active sheet still resolves via the `fields` prop (byte-identical to pre-R11, no #4007
+// regression — `fields` only ever carries the ACTIVE sheet's fields, and field ids are globally unique so it
+// can't match another sheet's id). A change row on a NON-active sheet falls through to the server-masked,
+// sheet-scoped `fieldNames` map, then to the raw id. Both name sources are already two-layer-masked server-side.
+function diffFieldName(fieldId: string, sheetId: string): string {
+  return props.fields?.find((f) => f.id === fieldId)?.name ?? props.fieldNames?.[sheetId]?.[fieldId] ?? fieldId
 }
 function diffOpLabel(shape: 'set' | 'cleared'): string {
   return recordLabel(shape === 'set' ? 'record.restorePreviewSet' : 'record.restorePreviewUnset', isZh.value)

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -26,7 +26,7 @@
             <span class="meta-hist__when">{{ formatTime(pinnedDetail.createdAt) }}</span>
             <span class="meta-hist__counts" data-test="hist-pinned-counts">{{ countLabel(pinnedDetail) }}</span>
           </div>
-          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
+          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :field-names="pinnedDetail.fieldNames" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
         </template>
       </div>
 
@@ -68,7 +68,7 @@
           <div v-if="expandedId === b.batchId" class="meta-hist__detail" data-test="hist-detail">
             <p v-if="detailLoading" class="meta-hist__hint">{{ t('加载中…', 'Loading…') }}</p>
             <p v-else-if="!detail" class="meta-hist__hint">{{ t('无法打开该批次', 'This batch is unavailable') }}</p>
-            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
+            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :field-names="detail.fieldNames" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
           </div>
         </li>
       </ul>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -400,6 +400,10 @@ export interface HistoryBatchDetail {
   visibleAffectedRecordCount: number
   visibleAffectedFieldCount: number
   changes: HistoryChange[]
+  /** all-tables-B (R11): server-masked field-id → display-name map, keyed by sheetId, for the fields that
+   *  appear in this batch's (post-mask) changes across ALL involved sheets. Optional so a pre-R11 backend
+   *  payload still typechecks; the FE degrades to raw ids / active-table names when absent. */
+  fieldNames?: Record<string, Record<string, string>>
 }
 
 export interface MetaRecordSubscription {

--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -486,3 +486,34 @@ describe('HistoryCenterModal — record click-through emit (PR-C)', () => {
     } finally { app.unmount(); container.remove() }
   })
 })
+
+// all-tables-B (R11): a batch can span multiple sheets, but the `fields` prop only carries the ACTIVE
+// sheet's fields. diffFieldName resolves the active sheet via `fields` (byte-identical to pre-R11), a
+// non-active sheet via the server-masked `fieldNames` map, and neither → the raw id.
+describe('HistoryCenterModal — all-tables-B cross-table field-name resolution', () => {
+  it('active sheet uses `fields` prop; non-active sheet uses the masked fieldNames map; neither → raw id', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    const detail: HistoryBatchDetail = {
+      batchId: 'batch_1', actorId: 'user_1', source: 'rest', createdAt: new Date().toISOString(),
+      visibleAffectedRecordCount: 2, visibleAffectedFieldCount: 3,
+      changes: [
+        { sheetId: 'sheet_active', recordId: 'rec_a', action: 'update', version: 2,
+          changedFieldIds: ['fld_active'], before: { fld_active: 'x' }, after: { fld_active: 'y' } },
+        { sheetId: 'sheet_other', recordId: 'rec_o', action: 'update', version: 2,
+          changedFieldIds: ['fld_other', 'fld_orphan'],
+          before: { fld_other: 'p', fld_orphan: 'm' }, after: { fld_other: 'q', fld_orphan: 'n' } },
+      ],
+      // active field's map name is DIFFERENT from its prop name, to prove props win for the active sheet.
+      fieldNames: { sheet_active: { fld_active: 'ActiveMap' }, sheet_other: { fld_other: 'OtherName' } },
+    }
+    mockGetHistoryBatch.mockResolvedValue(detail)
+    const { app, container } = mountModal([{ id: 'fld_active', name: 'ActiveProp' }])
+    try {
+      await flushPromises()
+      container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+      await flushPromises()
+      const labels = Array.from(container.querySelectorAll<HTMLElement>('.meta-hist__diff-label')).map((n) => n.textContent?.trim())
+      expect(labels).toEqual(['ActiveProp', 'OtherName', 'fld_orphan'])
+    } finally { app.unmount(); container.remove() }
+  })
+})

--- a/docs/development/multitable-global-history-alltables-field-metadata-decision-20260710.md
+++ b/docs/development/multitable-global-history-alltables-field-metadata-decision-20260710.md
@@ -2,7 +2,7 @@
 
 - **Status**: **RATIFIED 2026-07-11（owner R11 directive: 「并行实现 all-tables-B」）→ 选项 B（服务端掩码 `fieldNames` 随批次详情下发）。AS-BUILT**：`loadHistoryBatchDetail`（history-projection.ts）新增 `fieldNames: { [sheetId]: { [fieldId]: name } }`，仅覆盖批次 changes 实际涉及的表与**该表 post-mask（layer-2 property-hidden ∩ layer-3 field_permissions ∩ taint）已可见**的字段——复用值掩码同一 `allowedFieldsBySheet` allow-set + 防御性 `allowed.has` 二次校验；一次 unnest-join 查询（非 N+1）。FE `HistoryBatchChangesList.diffFieldName(fieldId, sheetId)`：活动表仍走 `fields` prop（字节等价 pre-R11，field id 全局唯一故不误配），非活动表走 `fieldNames` 映射，皆无 → 原始 id。零新端点、零 schema、无 flag（只读元数据）。
 - **验证**：realdb golden `multitable-history-alltables-fieldnames-realdb.test.ts`（plugin-tests.yml 白名单）——layer-2 隐藏名（表 A）+ layer-3 拒绝名（表 B）各一，跨表；whole-body 断言两个敏感名绝不出现。突变（用 pre-mask changed_field_ids 建 `fieldNames` 且去二次校验）⇒ 三断言全红。FE spec（inline-diff spec，web-guard 已覆盖）钉 props→map→id 优先序；突变（去 map 分支）⇒ 跨表断言红。
-- ~~PROPOSED~~ 原始现状（保留供审计）：History Center 的 `fields` prop 只承载**活动表**（workbench 的 `historyVisibleFields`，layer-2∩layer-3 已修）；all-tables 模式下其它表的批次 diff 标签回退为原始 field id。**R11 后**：非活动表由服务端掩码 `fieldNames` 提供名字，隐藏/拒绝字段名绝不出现。
+- ~~PROPOSED~~ 原始现状（保留供审计）：History Center 的 `fields` prop 只承载**活动表**（workbench 的 `twoLayerVisibleFields` — #4007 后的活动真源，layer-2∩layer-3 已修）；all-tables 模式下其它表的批次 diff 标签回退为原始 field id。**R11 后**：非活动表由服务端掩码 `fieldNames` 提供名字，隐藏/拒绝字段名绝不出现。
 
 ## 约束（不可绕）
 

--- a/docs/development/multitable-global-history-alltables-field-metadata-decision-20260710.md
+++ b/docs/development/multitable-global-history-alltables-field-metadata-decision-20260710.md
@@ -1,7 +1,8 @@
-# Global History — all-tables 模式跨表字段元数据 — 决策 one-pager (PROPOSED)
+# Global History — all-tables 模式跨表字段元数据 — 决策 one-pager (RATIFIED — B · AS-BUILT R11)
 
-- **Status**: PROPOSED 决策文档；owner ratify 前零实现授权。R10 gate-front 工件（R9 UX 审计携带项）。
-- **现状**：History Center 的 `fields` prop 只承载**活动表**（workbench 的 `historyVisibleFields`，layer-2∩layer-3 已修）；all-tables 模式下其它表的批次 diff 标签/筛选回退为原始 field id。R9 已如实保留该回退。
+- **Status**: **RATIFIED 2026-07-11（owner R11 directive: 「并行实现 all-tables-B」）→ 选项 B（服务端掩码 `fieldNames` 随批次详情下发）。AS-BUILT**：`loadHistoryBatchDetail`（history-projection.ts）新增 `fieldNames: { [sheetId]: { [fieldId]: name } }`，仅覆盖批次 changes 实际涉及的表与**该表 post-mask（layer-2 property-hidden ∩ layer-3 field_permissions ∩ taint）已可见**的字段——复用值掩码同一 `allowedFieldsBySheet` allow-set + 防御性 `allowed.has` 二次校验；一次 unnest-join 查询（非 N+1）。FE `HistoryBatchChangesList.diffFieldName(fieldId, sheetId)`：活动表仍走 `fields` prop（字节等价 pre-R11，field id 全局唯一故不误配），非活动表走 `fieldNames` 映射，皆无 → 原始 id。零新端点、零 schema、无 flag（只读元数据）。
+- **验证**：realdb golden `multitable-history-alltables-fieldnames-realdb.test.ts`（plugin-tests.yml 白名单）——layer-2 隐藏名（表 A）+ layer-3 拒绝名（表 B）各一，跨表；whole-body 断言两个敏感名绝不出现。突变（用 pre-mask changed_field_ids 建 `fieldNames` 且去二次校验）⇒ 三断言全红。FE spec（inline-diff spec，web-guard 已覆盖）钉 props→map→id 优先序；突变（去 map 分支）⇒ 跨表断言红。
+- ~~PROPOSED~~ 原始现状（保留供审计）：History Center 的 `fields` prop 只承载**活动表**（workbench 的 `historyVisibleFields`，layer-2∩layer-3 已修）；all-tables 模式下其它表的批次 diff 标签回退为原始 field id。**R11 后**：非活动表由服务端掩码 `fieldNames` 提供名字，隐藏/拒绝字段名绝不出现。
 
 ## 约束（不可绕）
 
@@ -19,4 +20,4 @@ R9 #4007 的教训直接适用：**字段名本身是两层可掩码信息**（l
 
 **B**。值掩码与名字掩码同源同 allow-set（`filterDataByAllowedFields` 的集合就是名字白名单），不引入第二套推导。实现要点（ratify 后才排）：投影层输出仅覆盖 payload 实际涉及的表；**隐藏字段名绝不出现**（golden：property-hidden 与 RBAC-denied 各一，跨表各一）；FE `diffFieldName` 优先 `fieldNames` 映射、活动表仍走 props（不回归 #4007）；两侧 wire shape 测试同步。
 
-- **解锁词**：owner 点头选项（A/B/C）。
+- **解锁词**：~~owner 点头选项（A/B/C）~~ **已解锁 → B（owner R11 directive 2026-07-11）**。本项出列（AS-BUILT）。

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -517,6 +517,15 @@ export interface HistoryBatchDetail {
   visibleAffectedRecordCount: number
   visibleAffectedFieldCount: number
   changes: HistoryChange[]
+  /**
+   * all-tables-B (R11): masked field-id → display-name map, per sheet, for the fields that actually appear
+   * in this batch's (post-mask) changes. Reuses the SAME per-sheet allow-set (`allowedFieldsBySheet`) the
+   * value masking uses — layer-2 property-hidden ∩ layer-3 field_permissions ∩ taint-mask — so a field name
+   * here is, by construction, a field whose VALUE the projection already emits: no new information. Lets the
+   * History Center label cross-table (all-tables mode) diff rows by name instead of raw id without the FE
+   * re-deriving the two-layer mask client-side (the #4007 footgun). Hidden/denied field names NEVER appear.
+   */
+  fieldNames: Record<string, Record<string, string>>
 }
 
 /**
@@ -629,6 +638,9 @@ export async function loadHistoryBatchDetail(
   const changes: HistoryChange[] = []
   const visibleRecords = new Set<string>()
   const visibleFields = new Set<string>()
+  // all-tables-B: per-sheet set of the (already post-mask) field ids that appear in this batch's changes —
+  // exactly the ids we need display names for. Only these get named (minimal surface, "payload 实际涉及").
+  const involvedFieldsBySheet = new Map<string, Set<string>>()
   let head: Record<string, unknown> | null = null
   for (const { row: r, sheetId, recordId, action, version } of visible) {
     if (!head) head = r
@@ -638,6 +650,11 @@ export async function loadHistoryBatchDetail(
     const allowed = allowedFieldsFor(allowedFieldsBySheet, sheetId)
     const fields = (Array.isArray(r.changed_field_ids) ? r.changed_field_ids.map(String) : []).filter((f) => allowed.has(f))
     for (const f of fields) visibleFields.add(f)
+    if (fields.length > 0) {
+      let inv = involvedFieldsBySheet.get(sheetId)
+      if (!inv) { inv = new Set(); involvedFieldsBySheet.set(sheetId, inv) }
+      for (const f of fields) inv.add(f)
+    }
     // T1b before-image, sourced per action semantics (see loadPreviousSnapshots doc):
     //   create → null (no prior state); update → the immediately-previous revision's snapshot (looked up
     //   above); delete → this revision's OWN snapshot column (the pre-delete state it captured).
@@ -659,6 +676,30 @@ export async function loadHistoryBatchDetail(
     })
   }
   if (!head || visibleRecords.size === 0) return null // fully denied → same as missing (LOCK-3, no oracle)
+
+  // all-tables-B: resolve display names for the involved (already post-mask) fields, one query for the whole
+  // batch (unnest-join, never N+1 — same shape as loadPreviousSnapshots). Every (sheet, field) pair is a
+  // subset of the two-layer allow-set, so the query cannot return a hidden/denied field; the re-check below
+  // is defense-in-depth (LOCK-3: a field name is as sensitive as its value, evaluated PER the field's sheet).
+  const fieldNames: Record<string, Record<string, string>> = {}
+  const nameSheetIds: string[] = []
+  const nameFieldIds: string[] = []
+  for (const [sheetId, ids] of involvedFieldsBySheet) for (const fieldId of ids) { nameSheetIds.push(sheetId); nameFieldIds.push(fieldId) }
+  if (nameFieldIds.length > 0) {
+    const nameRes = await query(
+      `SELECT f.id, f.sheet_id, f.name FROM meta_fields f
+       JOIN unnest($1::text[], $2::text[]) AS t(sheet_id, field_id) ON f.sheet_id = t.sheet_id AND f.id = t.field_id`,
+      [nameSheetIds, nameFieldIds],
+    )
+    for (const row of nameRes.rows as Array<Record<string, unknown>>) {
+      const sheetId = String(row.sheet_id)
+      const fieldId = String(row.id)
+      if (!allowedFieldsFor(allowedFieldsBySheet, sheetId).has(fieldId)) continue // defense-in-depth LOCK-3
+      const name = typeof row.name === 'string' ? row.name : ''
+      ;(fieldNames[sheetId] ??= {})[fieldId] = name
+    }
+  }
+
   return {
     batchId,
     actorId: typeof head.actor_id === 'string' ? head.actor_id : null,
@@ -667,5 +708,6 @@ export async function loadHistoryBatchDetail(
     visibleAffectedRecordCount: visibleRecords.size,
     visibleAffectedFieldCount: visibleFields.size,
     changes,
+    fieldNames,
   }
 }

--- a/packages/core-backend/tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts
@@ -14,9 +14,11 @@
  * even though both fields ARE listed in the raw `changed_field_ids`. One golden per layer, on a DIFFERENT
  * sheet each, so a regression that masks one layer but not the other is caught.
  *
- * A mutation that builds `fieldNames` from the raw (pre-mask) changed_field_ids, or that queries meta_fields
- * without the `allowed`-set re-check, would surface `AlphaSecret` / `BetaSecret` — the whole-body assertion
- * at the end pins that neither string can appear anywhere in the response.
+ * The masking here is redundant defense-in-depth: (i) `involvedFieldsBySheet` accumulates from the POST-mask
+ * `fields`, and (ii) the name loop re-checks `allowed.has`. Breaking EITHER alone still blocks the leak (the
+ * other guard catches it); only breaking BOTH — raw pre-mask accumulation AND no re-check — surfaces
+ * `AlphaSecret` / `BetaSecret`. The whole-body assertion at the end pins that neither string can appear
+ * anywhere in the response (verified: only the both-broken mutation reds these three tests).
  *
  * Runs only with DATABASE_URL. (plugin-tests.yml whitelist.)
  */

--- a/packages/core-backend/tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts
@@ -1,0 +1,138 @@
+/**
+ * all-tables-B (R11) — batch-detail `fieldNames` masked cross-table field-name map (real DB).
+ *
+ * The History Center's all-tables mode shows changes from MANY sheets in one batch, but the FE `fields` prop
+ * only carries the ACTIVE sheet's fields, so a change row on a non-active sheet fell back to a raw field id.
+ * `loadHistoryBatchDetail` now emits `fieldNames: { [sheetId]: { [fieldId]: name } }` for the fields that
+ * appear in the batch's (post-mask) changes, reusing the SAME per-sheet allow-set the VALUE masking uses.
+ *
+ * The load-bearing security claim (this file's reason to exist): a field NAME is as sensitive as its value,
+ * evaluated PER the field's own sheet (the #4007 lesson — TWO independent layers: property-hidden AND
+ * per-subject RBAC field_permissions). So `fieldNames` must NEVER carry:
+ *   (1) a layer-2 property-hidden field's name (sheet A here), NOR
+ *   (2) a layer-3 field_permissions-denied field's name (sheet B here),
+ * even though both fields ARE listed in the raw `changed_field_ids`. One golden per layer, on a DIFFERENT
+ * sheet each, so a regression that masks one layer but not the other is caught.
+ *
+ * A mutation that builds `fieldNames` from the raw (pre-mask) changed_field_ids, or that queries meta_fields
+ * without the `allowed`-set re-check, would surface `AlphaSecret` / `BetaSecret` — the whole-body assertion
+ * at the end pins that neither string can appear anywhere in the response.
+ *
+ * Runs only with DATABASE_URL. (plugin-tests.yml whitelist.)
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_atb_${TS}`
+const SHEET_A = `sheet_atb_a_${TS}`
+const SHEET_B = `sheet_atb_b_${TS}`
+const OK_A = `fld_atb_oka_${TS}` // sheet A, readable
+const HIDDEN_A = `fld_atb_hida_${TS}` // sheet A, LAYER-2 property-hidden
+const OK_B = `fld_atb_okb_${TS}` // sheet B, readable
+const DENIED_B = `fld_atb_denb_${TS}` // sheet B, LAYER-3 field_permissions-denied
+const REC_A = `rec_atb_a_${TS}`
+const REC_B = `rec_atb_b_${TS}`
+const BATCH = `batch_atb_${TS}`
+const USER_ID = `user_atb_${TS}`
+const OK_A_NAME = 'Alpha'
+const HIDDEN_A_NAME = 'AlphaSecret'
+const OK_B_NAME = 'Beta'
+const DENIED_B_NAME = 'BetaSecret'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+
+const detail = (batchId: string) => request(app).get(`/api/multitable/bases/${BASE_ID}/history/events/${batchId}`)
+
+const insertRevision = (sheetId: string, recordId: string, changedFieldIds: string[], snapshot: Record<string, unknown>) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+     VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', $3, $4::text[], '{}'::jsonb, $5::jsonb, $6)`,
+    [sheetId, recordId, USER_ID, changedFieldIds, JSON.stringify(snapshot), BATCH],
+  )
+
+describeIfDatabase('all-tables-B — batch-detail fieldNames masked cross-table map (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: USER_ID, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [USER_ID])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'AllTablesB Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_A, BASE_ID, 'Sheet A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_B, BASE_ID, 'Sheet B'])
+    // Sheet A: OK_A readable, HIDDEN_A layer-2 property-hidden.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [OK_A, SHEET_A, OK_A_NAME, 'select', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [HIDDEN_A, SHEET_A, HIDDEN_A_NAME, 'select', '{"hidden":true}', 2])
+    // Sheet B: OK_B readable, DENIED_B layer-3 field_permissions-denied for USER_ID.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [OK_B, SHEET_B, OK_B_NAME, 'select', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [DENIED_B, SHEET_B, DENIED_B_NAME, 'select', '{}', 2])
+    await q(
+      `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`,
+      [SHEET_B, DENIED_B, USER_ID],
+    )
+    // ONE batch spanning both sheets; each change lists a readable AND an unreadable field in changed_field_ids.
+    await insertRevision(SHEET_A, REC_A, [OK_A, HIDDEN_A], { [OK_A]: 'a-visible', [HIDDEN_A]: 'a-secret-value' })
+    await insertRevision(SHEET_B, REC_B, [OK_B, DENIED_B], { [OK_B]: 'b-visible', [DENIED_B]: 'b-secret-value' })
+  })
+
+  afterAll(async () => {
+    for (const sheet of [SHEET_A, SHEET_B]) {
+      await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM field_permissions WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
+    }
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [USER_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('fieldNames is present, shaped {sheetId:{fieldId:name}}, and covers both involved sheets', async () => {
+    const res = await detail(BATCH)
+    expect(res.status).toBe(200)
+    const fieldNames = res.body?.data?.fieldNames
+    expect(fieldNames && typeof fieldNames === 'object').toBe(true)
+    // both involved sheets appear
+    expect(Object.keys(fieldNames).sort()).toEqual([SHEET_A, SHEET_B].sort())
+    // values are strings
+    for (const sheetId of Object.keys(fieldNames)) for (const name of Object.values(fieldNames[sheetId])) expect(typeof name).toBe('string')
+  })
+
+  test('(1) layer-2 property-hidden field NAME never appears (sheet A)', async () => {
+    const res = await detail(BATCH)
+    const a = res.body?.data?.fieldNames?.[SHEET_A]
+    expect(a[OK_A]).toBe(OK_A_NAME) // readable name present
+    expect(a).not.toHaveProperty(HIDDEN_A) // hidden field's id/name absent
+    // and the CHANGED-field-id set is masked to the readable field only (existing LOCK-3 behaviour)
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC_A)
+    expect(change?.changedFieldIds).toEqual([OK_A])
+  })
+
+  test('(2) layer-3 field_permissions-denied field NAME never appears (sheet B)', async () => {
+    const res = await detail(BATCH)
+    const b = res.body?.data?.fieldNames?.[SHEET_B]
+    expect(b[OK_B]).toBe(OK_B_NAME)
+    expect(b).not.toHaveProperty(DENIED_B)
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC_B)
+    expect(change?.changedFieldIds).toEqual([OK_B])
+  })
+
+  test('whole-body: neither hidden nor denied field name leaks anywhere in the response', async () => {
+    const res = await detail(BATCH)
+    const body = JSON.stringify(res.body)
+    expect(body).not.toContain(HIDDEN_A_NAME)
+    expect(body).not.toContain(DENIED_B_NAME)
+    // the readable names DO appear (proves the assertion above isn't vacuous)
+    expect(body).toContain(OK_A_NAME)
+    expect(body).toContain(OK_B_NAME)
+  })
+})


### PR DESCRIPTION
## What / why

Ratifies + implements **all-tables-B** (owner R11 directive: "并行实现 all-tables-B") from `multitable-global-history-alltables-field-metadata-decision-20260710.md`.

History Center's **all-tables** mode shows changes from many sheets in one batch, but the FE `fields` prop only carries the **active** sheet's fields — so a change row on a non-active sheet fell back to a raw field id.

`loadHistoryBatchDetail` now emits:
```ts
fieldNames: { [sheetId]: { [fieldId]: name } }
```
covering only the fields that appear in the batch's **post-mask** changes, reusing the **same** per-sheet allow-set the value masking already uses (`allowedFieldsBySheet` = layer-2 property-hidden ∩ layer-3 `field_permissions` ∩ taint) + a defense-in-depth `allowed.has` re-check. One `unnest`-join query for the whole batch (never N+1).

**Security invariant:** a field name here is, by construction, a field whose **value** the projection already emits — so no new information is disclosed, and the FE never re-derives the two-layer mask client-side (the #4007 footgun). Hidden/denied field names never appear.

FE `diffFieldName(fieldId, sheetId)`: active sheet via `fields` (byte-identical to pre-R11 — field ids are globally unique so `fields` can't match another sheet's id), non-active sheet via the masked map, neither → raw id. **No new endpoint, no schema, no flag** (read-only metadata).

## Goldens (mutation-verified on real DB)

- `multitable-history-alltables-fieldnames-realdb.test.ts` (added to plugin-tests.yml whitelist): a two-sheet batch with a **layer-2 property-hidden** field (sheet A) and a **layer-3 field_permissions-denied** field (sheet B); asserts `fieldNames` carries the readable names but neither sensitive one, per layer, cross-table, plus a whole-body leak assertion.
  - Mutation (build `fieldNames` from pre-mask `changed_field_ids` + drop the re-check) ⇒ all 3 leak goldens **red**.
- FE inline-diff spec (already in multitable-web-guard filter): pins the **props → map → raw-id** order.
  - Mutation (strip the map branch) ⇒ the cross-table test **red**.

Backend + web typecheck clean. Value rendering for non-active sheets is unchanged (still plain-text — this PR is about field **names**, not values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)