### PR TITLE
docs(multitable): ratify field-value tombstone floor decision (R11 floor-A)

### DIFF
--- a/docs/development/multitable-global-history-fieldvalue-tombstone-floor-decision-20260710.md
+++ b/docs/development/multitable-global-history-fieldvalue-tombstone-floor-decision-20260710.md
@@ -1,6 +1,7 @@
-# Global History — field-value tombstone 留存地板 — 决策 one-pager (PROPOSED)
+# Global History — field-value tombstone 留存地板 — 决策 one-pager (RATIFIED — A · 决策定案)
 
-- **Status**: PROPOSED 决策文档；任何构建选项都需 owner 单项签核。R10 gate-front 工件（R9 审计残差 L2）。
+- **Status**: **RATIFIED 2026-07-11（owner R11 directive: 「ratify 地板-A」）→ 选项 A（接受边界，维持现状，零代码）。** field-value tombstone 的 keep-days 清扫无地板这一边界被正式接受为文档化边界，而非缺陷；仅在「4c-1/4c-2 capture flag 生产开启 **且** retention 生产开启」的组合世界才有实际影响，O-2 阶梯已把该组合列为联动注意事项（本轮把复议触发条件显式写入 O-2 阶梯 L4/L5 与 §5）。**复议触发**：任一 4c 系 capture/revert flag 在生产开启且 retention 计划在生产开启时，本决策自动回到 owner 桌面（O-2 阶梯 §5 交叉引用本文）。
+- ~~PROPOSED~~ 原始状态（保留供审计）：任何构建选项都需 owner 单项签核。R10 gate-front 工件（R9 审计残差 L2）。
 - **现状（真库核验）**：`meta-revision-retention.ts` 的 `floorPredicate` 仅对 link-tombstone 表生效（引用 `meta_records_trash.delete_revision_id` 锚——trash 行不灭则组不灭）；`meta_field_value_tombstones` 的 keep-days 清扫**无地板**。O-2 阶梯文档已如实记为边界（footgun 注记在案）。
 - **何时会咬人**：仅当 4c-1/4c-2 flag 在生产开启 **且** retention 同时开启——field-delete/lossy-retype 的值恢复窗口=keep-days，过期即 4d 化（字节消失）。
 
@@ -17,4 +18,4 @@
 
 **A**。理由：该边界只在「capture flag 开 + retention 开」的组合世界存在,而 O-2 阶梯本就把这一组合列为联动注意事项;B 是伪地板,C 的成本与当前零生产启用不成比例。**复议触发条件（写入 O-2 阶梯）**：任一 4c 系 capture/revert flag 在生产开启且 retention 计划开启时,本决策自动回到 owner 桌面。
 
-- **解锁词**：owner 选 B/C/D 之一并点头;选 A 仅需在本文所附 PR 上确认（或沉默视为维持现状——A 即现状,无代码）。
+- **解锁词**：~~owner 选 B/C/D 之一并点头;选 A 仅需在本文所附 PR 上确认~~ **已定案 → A（owner R11 directive 2026-07-11）。** 复议仅由上述「capture+retention 双开于生产」触发条件重新打开。

--- a/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
+++ b/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
@@ -62,6 +62,11 @@ tombstone 数据是惰性的——关 flag 不删数据，重开后继续可用�
 ## 5. 未做/边界（如实）
 
 - field-value tombstones（4c-1 恢复力）**无 retention 地板**（link 侧才有）——若 retention 上线且
-  4c-1 恢复窗口重要，需单独补地板（新 rung，不在本文）。
+  4c-1 恢复窗口重要，需单独补地板（新 rung，不在本文）。**此边界已经 owner RATIFIED 为地板-A（接受边界，
+  维持现状，零代码）**，见 `multitable-global-history-fieldvalue-tombstone-floor-decision-20260710.md`。
+  **⚠ 复议触发（O-2 联动）**：一旦在 **生产** 走到 L4（retention，值 `'1'`）**且** 任一 4c 系
+  capture/revert flag（`TOMBSTONE_CAPTURE_ENABLED` / `ENABLE_RECORD_UNDELETE_INBOUND` /
+  `ENABLE_FIELD_RETYPE_REVERT`）已在生产开启，地板-A 决策自动回到 owner 桌面——此时 field-value 值恢复窗口
+  = keep-days，过期即 4d 化。operator 在 L4/L5 勾选前必须显式确认这一联动（或保持 retention 关闭）。
 - automation / plugin-SDK 删除仍**无捕获**（不可恢复=D-2，owner-gated）；4c-3 可达边界不含它们。
 - 4d 红线不变：已删字段列值的值级恢复永不承诺。


### PR DESCRIPTION
## What

Owner R11 directive: **ratify floor-A** (decision-only, zero code).

Flips `multitable-global-history-fieldvalue-tombstone-floor-decision-20260710.md` **PROPOSED → RATIFIED (A: accept boundary)**. The field-value tombstone keep-days sweep has no retention floor (only the link-tombstone side does, anchored to surviving `meta_records_trash` rows). This is formally **accepted as a documented boundary, not a defect** — it only has effect in the "4c capture flag on prod AND retention on prod" combination world.

Makes the **re-decision trigger explicit** in the O-2 operator flag ladder (`...o2-operator-flag-ladder-20260709.md` §5, cross-linking the floor decision doc): if prod reaches **L4** (retention `'1'`) **and** any 4c capture/revert flag is on prod, floor-A automatically returns to the owner's desk (recovery window becomes keep-days). Operators must confirm this coupling before ticking L4/L5, or keep retention off.

Docs-only. No runtime, no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)