### PR TITLE
fix(multitable): close P1 root-escape in attachment sweep default deleters (F10)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -507,6 +507,7 @@ jobs:
             tests/integration/files-storage-key-migration.db.test.ts \
             tests/integration/files-orphan-blob-retention.db.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
+            tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/attendance-import-template-prefs.test.ts \
             tests/integration/attendance-notification-deliveries.test.ts \
             tests/integration/attendance-comp-time-expiry-reminder.test.ts \

--- a/packages/core-backend/src/multitable/attachment-orphan-retention.ts
+++ b/packages/core-backend/src/multitable/attachment-orphan-retention.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import { Logger } from '../core/logger'
 import { query } from '../db/pg'
 import { isDatabaseSchemaError } from '../utils/database-errors'
+import { resolveWithinBase } from '../services/StorageService'
 
 export type MultitableAttachmentCleanupOptions = {
   retentionHours?: number
@@ -27,10 +28,23 @@ type AttachmentCleanupResult = {
   skipped: number
 }
 
-const DEFAULT_ATTACHMENT_PATH = process.env.ATTACHMENT_PATH || path.join(process.cwd(), 'data', 'attachments')
+// F10 design-lock (2026-07-11), GF10-1 — owner P1 finding: this base MUST be read lazily (call-time, not
+// module-load-time) so `resolveWithinBase` below is exercised against whatever `ATTACHMENT_PATH` is
+// active when the deleter actually runs (tests included) — a frozen module-load constant would silently
+// re-introduce an untestable default. No production behavior change: `ATTACHMENT_PATH` is set before the
+// process starts either way.
+function getDefaultAttachmentPath(): string {
+  return process.env.ATTACHMENT_PATH || path.join(process.cwd(), 'data', 'attachments')
+}
 
+// F10 design-lock (2026-07-11), GF10-1 — owner P1 root-escape fix: F9 introduced these default deleters
+// with a bare `path.join(base, storagePath)`, which lets a `storagePath` containing `../` (malformed,
+// corrupt, or legacy data) resolve OUTSIDE the attachment storage root before `fs.unlink` — deleting an
+// arbitrary file on the host. `resolveWithinBase` (the same containment floor F3 already enforces for
+// `files.ts`/`StorageService.ts`) throws instead of resolving once the escape is detected. Containment:
+// NEVER unlink a path outside the storage base — no exceptions, no join fallback.
 async function deleteLocalAttachment(_storageFileId: string, storagePath: string): Promise<void> {
-  const fullPath = path.join(DEFAULT_ATTACHMENT_PATH, storagePath)
+  const fullPath = resolveWithinBase(getDefaultAttachmentPath(), storagePath)
   await fs.unlink(fullPath)
 }
 
@@ -181,8 +195,10 @@ export type MultitableAttachmentBlobPurgeResult = {
   skipped: number
 }
 
+// F10 design-lock (2026-07-11), GF10-1 — owner P1 root-escape fix (same containment floor as
+// `deleteLocalAttachment` above): never unlink a path outside the storage base.
 async function deleteLocalAttachmentByKey(storagePath: string): Promise<void> {
-  const fullPath = path.join(DEFAULT_ATTACHMENT_PATH, storagePath)
+  const fullPath = resolveWithinBase(getDefaultAttachmentPath(), storagePath)
   await fs.unlink(fullPath)
 }
 

--- a/packages/core-backend/tests/integration/multitable-attachment-root-escape.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-attachment-root-escape.db.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { Pool, type QueryResultRow } from 'pg'
+import { randomUUID } from 'crypto'
+import * as fsp from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  up as migrateUp,
+} from '../../src/db/migrations/zzzz20260711090000_add_multitable_attachments_blob_purged_at'
+import {
+  sweepMultitableAttachmentBlobPurge,
+  cleanupOrphanMultitableAttachments,
+} from '../../src/multitable/attachment-orphan-retention'
+
+// F10 design-lock (2026-07-11), GF10-1/GF10-2 — owner P1 finding: the two *default* deleters
+// (`deleteLocalAttachment` / `deleteLocalAttachmentByKey`) in attachment-orphan-retention.ts used a bare
+// `path.join(base, storagePath)` before this fix, which let a `storage_path` containing `../` resolve
+// OUTSIDE the attachment storage root and `fs.unlink` an arbitrary file on the host — reproduced by the
+// owner with `storage_path='../victim.txt'` (sweep reported purged=1, victim deleted).
+//
+// CRITICAL for this test file: unlike multitable-attachment-blob-purge.db.test.ts (which always injects a
+// real `StorageServiceImpl` via the `storage` option), every test below calls
+// `sweepMultitableAttachmentBlobPurge` / `cleanupOrphanMultitableAttachments` WITHOUT a `storage` option —
+// exercising the module's own default deleters (gated only via `ATTACHMENT_PATH`). Injecting
+// `StorageServiceImpl` would only prove the already-safe `resolveWithinBase`-backed path is safe (it
+// always was) — a false green that does not touch the P1 finding at all.
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+describeDb('F10 multitable-attachments default-deleter root-escape containment (real DB + real fs, default storage — NOT injected)', () => {
+  let adminPool: Pool
+  let schema: string
+  let testPool: Pool
+  let testDb: Kysely<unknown>
+  let tmpRoot: string
+  let attachmentsDir: string
+  let originalAttachmentPath: string | undefined
+
+  function queryFn<T extends QueryResultRow = QueryResultRow>(text: string, params?: unknown[]) {
+    return testPool.query<T>(text, params)
+  }
+
+  const hoursAgo = (h: number) => new Date(Date.now() - h * 3600 * 1000)
+  const pathExists = async (p: string): Promise<boolean> => fsp.access(p).then(() => true).catch(() => false)
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: dbUrl })
+    schema = `f10escape_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+
+    testPool = new Pool({ connectionString: dbUrl, options: `-c search_path=${schema}` })
+    testDb = new Kysely<unknown>({ dialect: new PostgresDialect({ pool: testPool }) })
+
+    await sql`
+      CREATE TABLE multitable_attachments (
+        id TEXT PRIMARY KEY,
+        sheet_id TEXT NOT NULL,
+        record_id TEXT NULL,
+        field_id TEXT NULL,
+        storage_file_id TEXT NOT NULL,
+        filename TEXT NOT NULL,
+        original_name TEXT NULL,
+        mime_type TEXT NOT NULL,
+        size BIGINT NOT NULL DEFAULT 0,
+        storage_path TEXT NOT NULL,
+        storage_provider TEXT NOT NULL DEFAULT 'local',
+        metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_by TEXT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        deleted_at TIMESTAMPTZ NULL
+      )
+    `.execute(testDb)
+    await migrateUp(testDb)
+
+    // `<tmp>/attachments` is the containment base (`ATTACHMENT_PATH`); `<tmp>/victim*.txt` sits ONE level
+    // above it, so a `storage_path` of `../victim.txt` resolves to exactly that file — the owner's repro.
+    tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'f10-root-escape-'))
+    attachmentsDir = path.join(tmpRoot, 'attachments')
+    await fsp.mkdir(attachmentsDir, { recursive: true })
+
+    originalAttachmentPath = process.env.ATTACHMENT_PATH
+    process.env.ATTACHMENT_PATH = attachmentsDir
+  })
+
+  afterEach(async () => {
+    if (originalAttachmentPath === undefined) {
+      delete process.env.ATTACHMENT_PATH
+    } else {
+      process.env.ATTACHMENT_PATH = originalAttachmentPath
+    }
+
+    await testDb.destroy()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+    await fsp.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  async function insertBlobPurgeRow(row: { id: string; storagePath: string; deletedAt: Date }): Promise<void> {
+    await sql`
+      INSERT INTO multitable_attachments
+        (id, sheet_id, record_id, field_id, storage_file_id, filename, mime_type, storage_path, created_by, deleted_at)
+      VALUES
+        (${row.id}, 'sheet-1', 'rec-1', 'fld-1', ${row.id + '-file'}, 'a.txt', 'text/plain', ${row.storagePath}, 'user-1', ${row.deletedAt})
+    `.execute(testDb)
+  }
+
+  async function insertDraftRow(row: { id: string; storagePath: string; createdAt: Date }): Promise<void> {
+    await sql`
+      INSERT INTO multitable_attachments
+        (id, sheet_id, record_id, field_id, storage_file_id, filename, mime_type, storage_path, created_by, created_at, deleted_at)
+      VALUES
+        (${row.id}, 'sheet-1', NULL, NULL, ${row.id + '-file'}, 'a.txt', 'text/plain', ${row.storagePath}, 'user-1', ${row.createdAt}, NULL)
+    `.execute(testDb)
+  }
+
+  async function attachmentRowState(id: string): Promise<{ deletedAt: Date | null; blobPurgedAt: Date | null }> {
+    const r = await sql<{ deleted_at: Date | null; blob_purged_at: Date | null }>`
+      SELECT deleted_at, blob_purged_at FROM multitable_attachments WHERE id = ${id}
+    `.execute(testDb)
+    return { deletedAt: r.rows[0]?.deleted_at ?? null, blobPurgedAt: r.rows[0]?.blob_purged_at ?? null }
+  }
+
+  it('#1 compensating sweep — a root-escaping storage_path (../victim.txt) is NOT deleted and the row is NOT stamped (default storage, no injection)', async () => {
+    const victim = path.join(tmpRoot, 'victim.txt')
+    await fsp.writeFile(victim, 'do-not-delete-me')
+
+    await insertBlobPurgeRow({ id: 'esc-sweep-1', storagePath: '../victim.txt', deletedAt: hoursAgo(48) })
+
+    const result = await sweepMultitableAttachmentBlobPurge({ queryFn, graceHours: 24 })
+
+    expect(result).toEqual({ inspected: 1, purged: 0, skipped: 1 })
+    expect(await pathExists(victim)).toBe(true)
+    expect((await attachmentRowState('esc-sweep-1')).blobPurgedAt).toBeNull()
+  })
+
+  it('#2 draft-orphan cleanup — a root-escaping storage_path (../victim2.txt) is NOT deleted and the row is NOT tombstoned (default storage, no injection, default-ON production path)', async () => {
+    const victim2 = path.join(tmpRoot, 'victim2.txt')
+    await fsp.writeFile(victim2, 'do-not-delete-me-either')
+
+    await insertDraftRow({ id: 'esc-draft-1', storagePath: '../victim2.txt', createdAt: hoursAgo(48) })
+
+    const result = await cleanupOrphanMultitableAttachments({ queryFn, retentionHours: 24 })
+
+    expect(result).toEqual({ inspected: 1, deleted: 0, skipped: 1 })
+    expect(await pathExists(victim2)).toBe(true)
+    const state = await attachmentRowState('esc-draft-1')
+    expect(state.deletedAt).toBeNull()
+    expect(state.blobPurgedAt).toBeNull()
+  })
+
+  it('#3 positive path (compensating sweep) — a contained storage_path is still deleted and stamped by the default deleter (no regression)', async () => {
+    const key = 'sub/ok.txt'
+    const full = path.join(attachmentsDir, key)
+    await fsp.mkdir(path.dirname(full), { recursive: true })
+    await fsp.writeFile(full, 'ok-bytes')
+
+    await insertBlobPurgeRow({ id: 'ok-sweep-1', storagePath: key, deletedAt: hoursAgo(48) })
+
+    const result = await sweepMultitableAttachmentBlobPurge({ queryFn, graceHours: 24 })
+
+    expect(result).toEqual({ inspected: 1, purged: 1, skipped: 0 })
+    expect(await pathExists(full)).toBe(false)
+    expect((await attachmentRowState('ok-sweep-1')).blobPurgedAt).not.toBeNull()
+  })
+
+  it('#4 positive path (draft-orphan cleanup) — a contained storage_path is still deleted and the row is tombstoned by the default deleter (no regression)', async () => {
+    const key = 'sub/ok2.txt'
+    const full = path.join(attachmentsDir, key)
+    await fsp.mkdir(path.dirname(full), { recursive: true })
+    await fsp.writeFile(full, 'ok-bytes-2')
+
+    await insertDraftRow({ id: 'ok-draft-1', storagePath: key, createdAt: hoursAgo(48) })
+
+    const result = await cleanupOrphanMultitableAttachments({ queryFn, retentionHours: 24 })
+
+    expect(result).toEqual({ inspected: 1, deleted: 1, skipped: 0 })
+    expect(await pathExists(full)).toBe(false)
+    const state = await attachmentRowState('ok-draft-1')
+    expect(state.deletedAt).not.toBeNull()
+    expect(state.blobPurgedAt).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Root cause

`packages/core-backend/src/multitable/attachment-orphan-retention.ts`'s two default deleters resolved `storage_path` with a bare `path.join(DEFAULT_ATTACHMENT_PATH, storagePath)` before `fs.unlink`, entirely bypassing F3's `resolveWithinBase` containment floor:

- `deleteLocalAttachment` (was :32-35) — default `storage.delete` for the draft-orphan cleanup sweep (`cleanupOrphanMultitableAttachments`, default arg at :73). `isEnabled()` defaults to `NODE_ENV === 'production'`, so this path is **live by default in production**.
- `deleteLocalAttachmentByKey` (was :184-186) — default `storage.deleteByKey` for the compensating blob-purge sweep (`sweepMultitableAttachmentBlobPurge`, default arg at :202). Env-gated, default OFF, but exposed once `MULTITABLE_ATTACHMENT_BLOB_RETENTION_ENABLED=true`.

A `storage_path` of `../victim.txt` (malformed/corrupt/legacy row) resolves outside the attachment root and gets unlinked. Owner reproduced this directly: sweep reported `inspected=1, purged=1, skipped=0`, and the victim file outside the root was gone.

Both production starters (`startMultitableAttachmentBlobPurge`, `startMultitableAttachmentCleanup`) only pass `{ logger }`, so they always exercise these unguarded default deleters — the existing real-DB tests always inject a `StorageServiceImpl` (already safe via `resolveWithinBase`), so the vulnerable default path had zero coverage.

## Fix (GF10-1)

1. Import `resolveWithinBase` from `../services/StorageService` (the same containment floor F3 already enforces for `files.ts`).
2. `DEFAULT_ATTACHMENT_PATH` (module-load-time constant) → `getDefaultAttachmentPath()` (call-time function reading `process.env.ATTACHMENT_PATH`), so the containment check is exercised against whatever base is active when the deleter actually runs — no production behavior change, since `ATTACHMENT_PATH` is set before the process starts either way.
3. Both deleters now do `resolveWithinBase(getDefaultAttachmentPath(), storagePath)` before `fs.unlink` — an escaping key throws `Storage key resolves outside the storage base path` instead of resolving.
   - `attachment-orphan-retention.ts:47` (`deleteLocalAttachment`)
   - `attachment-orphan-retention.ts:201` (`deleteLocalAttachmentByKey`)
4. **No poison/terminal-state column added.** The existing `isMissingStorageFile` ENOENT check in both sweep call-sites already treats the containment throw as a genuine (non-ENOENT) failure → `skipped++`, row NOT stamped, file survives. This is the intended "file preserved, DB not stamped" outcome without over-engineering a new state.
5. Swept the whole module and the rest of `multitable/` for other `fs.unlink/rm/rmdir/writeFile` call sites — these two are the ONLY physical-delete calls in the module; no second root-outside surface found.

## Tests (GF10-2)

New `packages/core-backend/tests/integration/multitable-attachment-root-escape.db.test.ts` (real Postgres, isolated throwaway schema per test, real filesystem). Critical distinction from the existing `multitable-attachment-blob-purge.db.test.ts`: **no `storage` option is injected** — every test exercises the module's own default deleters (only `ATTACHMENT_PATH` is set), because injecting `StorageServiceImpl` would only prove the already-safe path is safe.

Wired into `.github/workflows/plugin-tests.yml`'s existing real-DB whitelist (next to `multitable-attachment-blob-purge.db.test.ts`) so it actually runs in CI, not just locally.

Real run against a fresh throwaway Postgres 16 container + real tmp filesystem — all 4 pass:
```
✓ #1 compensating sweep — ../victim.txt is NOT deleted, row NOT stamped
✓ #2 draft cleanup — ../victim2.txt is NOT deleted, row NOT tombstoned (default-ON prod path)
✓ #3 positive path (sweep) — contained key still deleted + stamped (no regression)
✓ #4 positive path (cleanup) — contained key still deleted + tombstoned (no regression)
```
Full existing `multitable-attachment-blob-purge.db.test.ts` suite (16 tests) re-run alongside — all pass, no regression.

## Mutation test (proves the guard is load-bearing)

Temporarily reverted `resolveWithinBase(getDefaultAttachmentPath(), storagePath)` back to `path.join(getDefaultAttachmentPath(), storagePath)` in both deleters and re-ran the new test file:

```
✗ #1 — expected {purged:0, skipped:1}, got {purged:1, skipped:0}  (victim.txt WAS deleted)
✗ #2 — expected {deleted:0, skipped:1}, got {deleted:1, skipped:0} (victim2.txt WAS deleted)
✓ #3, #4 — still pass (positive path unaffected by the mutation)
```
Confirms the guard is load-bearing: without it, both escapes silently succeed, reproducing the exact P1. Reverted back to the fix afterward (verified via git diff / re-run to green).

## Verification

- `pnpm -C packages/core-backend exec tsc --noEmit` → 0 errors.
- Scoped `eslint` on both changed source files → clean (test files are eslint-ignored repo-wide, same as the pre-existing blob-purge test — not a regression).
- Full no-DB unit suite: 370 test files / 5085 tests passed.
- Real-DB integration: new file (4/4) + existing `multitable-attachment-blob-purge.db.test.ts` (16/16), run together against a fresh isolated Postgres 16 container — no regression.

## Scope

Only touched `attachment-orphan-retention.ts`, the new db test, and wiring the new test into `plugin-tests.yml`'s existing real-DB whitelist. Did NOT touch auth/`files.ts`/`StorageService.ts`/F4/tracker/verification MD. No migration.

This fixes the P1 root-escape introduced by F9 (per the ratified F10 design lock). Not requesting merge — for owner review / opus adversarial gate per standing process.