### PR TITLE
docs(dingtalk): #4102 P3 comment fixes — migration lock semantics + redelivery cycle framing

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260711120000_add_redelivery_safe_to_attendance_notification_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260711120000_add_redelivery_safe_to_attendance_notification_deliveries.ts
@@ -17,8 +17,10 @@
  * up(): ADD COLUMN redelivery_safe boolean NOT NULL DEFAULT false. All pre-existing rows become
  * `false`, which is correct by design — every historical `failed` row (multi-channel, pre-flag) is
  * NOT eligible for redelivery. On PostgreSQL 11+ `ADD COLUMN ... NOT NULL DEFAULT <constant>` is a
- * metadata-only change (catalog default, no table rewrite / full-table lock), so this is cheap even
- * on a large outbox.
+ * metadata-only change (the constant is stored as a catalog default, so no full-table REWRITE and no
+ * per-row scan). ALTER TABLE still briefly takes an ACCESS EXCLUSIVE lock to update the catalog, but
+ * because it neither rewrites nor scans the table that lock is held only momentarily — cheap even on
+ * a large outbox.
  *
  * Guarded by checkTableExists so partial-schema test harnesses (isolated-schema suites that run only
  * the migrations they need) can apply this migration too, mirroring the sibling

--- a/packages/core-backend/src/services/AttendanceNotificationRedelivery.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationRedelivery.ts
@@ -31,8 +31,11 @@
  *    non-delivery. An ambiguous DingTalk result never reaches markFailed — deliver() routes it to
  *    markOutcomeUnknown, which leaves redelivery_safe=false — so this gate can never resend an
  *    ambiguous row. Requeuing flips the SAME row `failed → pending` (attempt_count reset to 0 for a
- *    fresh operator-requested cycle, next_attempt_at = now); the worker's deliver() calls
- *    channel.send() before any attempt-count classification, so exactly ONE genuine new send follows.
+ *    fresh operator-requested cycle, next_attempt_at = now). The invariant is per-CYCLE, not
+ *    per-send: each operator action creates exactly ONE redelivery cycle; the worker's deliver()
+ *    calls channel.send() once per attempt, and the fresh retry budget means a *retryable* failure
+ *    may span several worker attempts within that one cycle. An ambiguous result is NEVER retried —
+ *    it routes to markOutcomeUnknown (not markFailed), so no ambiguous send can be resent.
  *
  *  - source_key dedup is honored BY CONSTRUCTION: (org_id, source_key) is UNIQUE, so there is at
  *    most one row per logical destination. We flip that existing row's status — we NEVER insert a


### PR DESCRIPTION
Owner-requested P3 wording fixes from the #4102 review (both **comment-only**, no logic change):

1. **Migration `zzzz20260711120000`** — "no full-table lock" was inaccurate. PG11+ fast default avoids the table **rewrite** and per-row scan, but `ALTER TABLE ADD COLUMN` still briefly takes an **ACCESS EXCLUSIVE** lock to update the catalog; reworded to say the lock is held only momentarily (no rewrite/scan).
2. **`AttendanceNotificationRedelivery` doctrine** — "exactly ONE genuine new send follows" was inaccurate; the fresh retry budget allows multiple worker attempts after a *retryable* failure. Reworded to the **per-CYCLE** invariant: each operator action creates ONE redelivery cycle; `deliver()` sends once per attempt; an ambiguous result is **never** retried (routes to `markOutcomeUnknown`).

Verified every changed line is a doc comment — behavior-neutral. Follows the merged #4102 (`7839b73a8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)